### PR TITLE
 I have implemented 2 features requested in Ticket #841.

### DIFF
--- a/src/main/java/net/sf/jabref/GUIGlobals.java
+++ b/src/main/java/net/sf/jabref/GUIGlobals.java
@@ -28,6 +28,8 @@ import java.util.*;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 
+import javax.swing.SwingConstants;
+import net.sf.jabref.external.ExternalFileType;
 import org.xnap.commons.gui.shortcut.EmacsKeyBindings;
 
 import net.sf.jabref.specialfields.Priority;
@@ -411,6 +413,12 @@ public class GUIGlobals {
         lab = new JLabel(getImage("psSmall"));
         lab.setToolTipText(Globals.lang("Open file"));
         tableIcons.put(GUIGlobals.FILE_FIELD, lab);
+
+        for(ExternalFileType fileType : Globals.prefs.getExternalFileTypeSelection()) {
+            lab = new JLabel(fileType.getIcon());
+            lab.setToolTipText(Globals.lang("Open "+fileType.getName()+" file"));
+            tableIcons.put(fileType.getName(), lab);
+        }
         
         lab = new JLabel(Relevance.getInstance().getRepresentingIcon());
         lab.setToolTipText(Relevance.getInstance().getToolTip());

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -424,6 +424,9 @@ public class JabRefPreferences {
         defaults.put("fileColumn", Boolean.TRUE);
         defaults.put("arxivColumn", Boolean.FALSE);
 
+        defaults.put("extraFileColumns", Boolean.FALSE);
+        defaults.put("listOfFileColumns","");
+
         defaults.put(SpecialFieldsUtils.PREF_SPECIALFIELDSENABLED, SpecialFieldsUtils.PREF_SPECIALFIELDSENABLED_DEFAULT);
         defaults.put(SpecialFieldsUtils.PREF_SHOWCOLUMN_PRIORITY, SpecialFieldsUtils.PREF_SHOWCOLUMN_PRIORITY_DEFAULT);
         defaults.put(SpecialFieldsUtils.PREF_SHOWCOLUMN_QUALITY, SpecialFieldsUtils.PREF_SHOWCOLUMN_QUALITY_DEFAULT);

--- a/src/main/java/net/sf/jabref/gui/PreventDraggingJTableHeader.java
+++ b/src/main/java/net/sf/jabref/gui/PreventDraggingJTableHeader.java
@@ -21,6 +21,7 @@ import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 
 import net.sf.jabref.Globals;
+import net.sf.jabref.Util;
 import net.sf.jabref.specialfields.SpecialFieldsUtils;
 
 /**
@@ -118,6 +119,10 @@ public class PreventDraggingJTableHeader extends JTableHeader {
         }
         if (Globals.prefs.getBoolean("arxivColumn")) {
             count++;
+        }
+
+        if (Globals.prefs.getBoolean("extraFileColumns")) {
+            count+=Globals.prefs.getStringArray("listOfFileColumns").length;
         }
         
         // special field columns may also not be dragged


### PR DESCRIPTION
```
The user can now specify an arbitrary number of file-link columns in te "Entry table columns" preferences tab, to be added to the main table. The user can any file types specified in the list of External File Types. The extra columns work exactly like the original file-link column.

For each file-link column whenever there are multiple files, the letter "m" is displayed at the bottom right corner of the icon.
```

 Committer: noravanq

 On branch master
 Changes to be committed:
   (use "git reset HEAD <file>..." to unstage)

```
modified:   src/main/java/net/sf/jabref/GUIGlobals.java
modified:   src/main/java/net/sf/jabref/JabRefPreferences.java
modified:   src/main/java/net/sf/jabref/TableColumnsTab.java
modified:   src/main/java/net/sf/jabref/gui/MainTableFormat.java
modified:   src/main/java/net/sf/jabref/gui/MainTableSelectionListener.java
modified:   src/main/java/net/sf/jabref/gui/PreventDraggingJTableHeader.java
```
