### PR TITLE
PDF-file metadata: Privacy Filtering all metadata

### DIFF
--- a/src/main/java/net/sf/jabref/util/XMPUtil.java
+++ b/src/main/java/net/sf/jabref/util/XMPUtil.java
@@ -996,7 +996,20 @@ public class XMPUtil {
 		for (String field : fields){
 
 			if (useXmpPrivacyFilter && filters.contains(field)) {
-				continue;
+                            // erase field instead of adding it
+                            if (field.equals("author")) {
+				di.setAuthor(null);
+                            } else if (field.equals("title")) {
+				di.setTitle(null);
+                            } else if (field.equals("keywords")) {
+				di.setKeywords(null);
+                            } else if (field.equals("abstract")) {
+				di.setSubject(null);
+                            } else {
+				di.setCustomMetadataValue("bibtex/" + field,
+                                                          null);
+                            }
+                            continue;
 			}
 
 			if (field.equals("author")) {


### PR DESCRIPTION
This pull-request pertains to the addition of metadata to PDF files associated with entries, as triggered by the menu entry "Write XMP metadata to PDFs" in the "Tools" menu. XMP is an extremely interesting feature that allows tagging PDF files (amongst others) with automatically retrievable metadata in much the same way mp3-tags allow adding title/author/... information to mp3 music files. Actually JabRef exports the metadata not only to two XMP namespaces (Dublin Core and a custom JabRef namespace), but also to the PDF DocumentInformation Object.

Practically from the beginning of the XMP-writing capabilities of JabRef, Christopher Oezbek had added _privacy filtering_ for the XMP-tagging of PDF-files with data from the bibtex-record, meaning that the user could define a list of fields (in Preferences->XMP metadata) which should _not_ be exported to the PDF file.  Unfortunately, the filtering was incomplete: jabref exports the metadata in three different forms, only one of which was originally filtered. In 2013 filtering was extended to both XMP namespaces, but JabRef still exported _all_ fields into the PDF DocumentInfo object. The two present commits correct this problem. The first (b45316f) prevents private fields from being exported to the PDF DocumentInfo. The second one more agressively erases these fields even if they already exist in the PDF document. 

The deletion of existing fields might be debateable. It seems the right thing to do for fields clearly generated by JabRef (viz. those prefixed by "jabref/"), but there are four fields which might be of other origin (Author,Title,Subject and Keywords). Making a systematic exception for these four fields, i.e. not erasing them even if they are privacy filtered, is a bad idea and violates the principle of least surprise. This is why the second commit makes no exception. Deactivating the erasure for the four generic fields could however easily be added as an option in the XMP export preferences if it is judged important. The current behaviour has the advantage of reliably correcting PDF files previously tagged with a buggy privacy filtering.

If these commits are pulled into the master branch and confirmed to work, the bug #869 on the sourceforge tracker: 
https://sourceforge.net/p/jabref/bugs/869/
can be closed.
