### PR TITLE
Make (un)abbreviating journal titles also work on the journaltitle field

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 [master]
+    - Make (un)abbreviating journal titles also work on the journaltitle field
     - Change default behaviour to be more non-invasive: timestamps and owners are NOT set by default per entry.
     - "Open Folder" works again
     - newline separator can now be configured globally

--- a/src/main/java/net/sf/jabref/BibtexFields.java
+++ b/src/main/java/net/sf/jabref/BibtexFields.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 Raik Nagel and JabRef contributors
+/*  Copyright (C) 2003-2014 Raik Nagel and JabRef contributors
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -96,6 +96,10 @@ public class BibtexFields
     dummy = new BibtexSingleField( "journal", true, GUIGlobals.SMALL_W ) ;
     dummy.setExtras("journalNames");
     add(dummy) ;
+    dummy = new BibtexSingleField( "journaltitle", true, GUIGlobals.SMALL_W ) ;
+    dummy.setExtras("journalNames");
+    add(dummy) ;
+
     add( new BibtexSingleField( "key", true ) ) ;
     add( new BibtexSingleField( "month", true, GUIGlobals.SMALL_W ) ) ;
     add( new BibtexSingleField( "note", true, GUIGlobals.MEDIUM_W  ) ) ;

--- a/src/main/java/net/sf/jabref/journals/AbbreviateAction.java
+++ b/src/main/java/net/sf/jabref/journals/AbbreviateAction.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2014 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -55,6 +55,8 @@ public class AbbreviateAction extends AbstractWorker {
         int count = 0;
         for (BibtexEntry entry : entries) {
             if (Globals.journalAbbrev.abbreviate(panel.database(), entry, "journal", ce, iso))
+                count++;
+            if (Globals.journalAbbrev.abbreviate(panel.database(), entry, "journaltitle", ce, iso))
                 count++;
         }
         if (count > 0) {

--- a/src/main/java/net/sf/jabref/journals/UnabbreviateAction.java
+++ b/src/main/java/net/sf/jabref/journals/UnabbreviateAction.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2014 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -53,6 +53,8 @@ public class UnabbreviateAction extends AbstractWorker {
         int count = 0;
         for (BibtexEntry entry : entries) {
             if (Globals.journalAbbrev.unabbreviate(panel.database(), entry, "journal", ce))
+                count++;
+            if (Globals.journalAbbrev.unabbreviate(panel.database(), entry, "journaltitle", ce))
                 count++;
         }
         if (count > 0) {

--- a/src/main/resources/help/About.html
+++ b/src/main/resources/help/About.html
@@ -53,6 +53,7 @@
         Fedor Bezrukov,
         Fabian Bieker,
         Aaron Chen,
+        Thorsten Dahlheimer,
         Fabrice Dessaint,
         Nathan Dunn,
         E. Hakan Duran,


### PR DESCRIPTION
I've (i) added the toggle button to the "journaltitle" field editor
and (ii) made the abbreviate/unabbreviate actions change both the "journal" and "journaltitle" fields.
The latter might be a bit simple-minded --  should the field to consider depend on whether Biblatex mode is actually turned on?
