### PR TITLE
Fix error when setting unset field in source panel

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,4 @@
 [master]
-    - Make (un)abbreviating journal titles also work on the journaltitle field
     - Change default behaviour to be more non-invasive: timestamps and owners are NOT set by default per entry.
     - "Open Folder" works again
     - newline separator can now be configured globally
@@ -13,6 +12,8 @@
     - Fixes bug 880 "PubMed Import broken" (pull request #11 by vegeziel)
     - Fixes bug #959 "StringIndexOutOfBoundsException with invalid Preview text" (pull request #13 by IngvarJackal)
     - Fixes bug #960 "FileNotFoundException in Journal abbreviations window" (pull request #13 by IngvarJackal)
+    - Make (un)abbreviating journal titles also work on the journaltitle field
+    - Fix error when setting a previously unset field via the source panel of the entry editor
 2.10
     - Made IEEEXploreFetcher author parsing work again.
     - Added a few more characters in the HTML/Unicode to LaTeX conversion.

--- a/src/main/java/net/sf/jabref/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/EntryEditor.java
@@ -840,15 +840,14 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
 
             // Then set all fields that have been set by the user.
             for (String field : nu.getAllFields()){
-                if (!entry.getField(field).equals(nu.getField(field))) {
-                    String toSet = nu.getField(field);
-
+                String oldValue = entry.getField(field);
+                String newValue = nu.getField(field);
+                if (oldValue == null || !oldValue.equals(newValue)) {
                     // Test if the field is legally set.
-                    (new LatexFieldFormatter()).format(toSet, field);
+                    (new LatexFieldFormatter()).format(newValue, field);
 
-                    compound.addEdit(new UndoableFieldChange(entry, field, entry
-                        .getField(field), toSet));
-                    entry.setField(field, toSet);
+                    compound.addEdit(new UndoableFieldChange(entry, field, oldValue, newValue));
+                    entry.setField(field, newValue);
                     anyChanged = true;
                 }
             }


### PR DESCRIPTION
When the user tries to set a previously unset field of an entry via the
source panel of the entry editor, the program complains with an error
message and refuses to store the field values.
This change fixes that behaviour.
