### PR TITLE
Extended the 'unknown entry type' error message 

### DIFF
--- a/src/main/java/net/sf/jabref/imports/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/imports/BibtexParser.java
@@ -979,7 +979,8 @@ public class BibtexParser {
 					// "+be.getType().getName());
 					_pr
 						.addWarning(Globals.lang("unknown entry type") + ": "
-							+ be.getType().getName() + ". " + Globals.lang("Type set to 'other'")
+							+ be.getType().getName() + ":" + be.getField(BibtexFields.KEY_FIELD)
+							+ " . " + Globals.lang("Type set to 'other'")
 							+ ".");
 					be.setType(BibtexEntryType.OTHER);
 				}


### PR DESCRIPTION
I had problems locating which entry had this unknown entry type and hence extended the error message to also include the bibtex key.
