### PR TITLE
Partial fix for bug #913

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 [master]
+	- Partial fix for bug 913: fixed export for .ods and .sxc (by yaragg)
 	- Fix for bug 949: Exception properly logged
 	- Fix for bug 950: NullPointerException on "Manage custom imports"
 	- Feature 850: Keyboard shortcut for 'Cleanup entries' (by eduardogreco)

--- a/src/main/java/net/sf/jabref/export/OOCalcDatabase.java
+++ b/src/main/java/net/sf/jabref/export/OOCalcDatabase.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2014 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or

--- a/src/main/java/net/sf/jabref/export/OpenDocumentRepresentation.java
+++ b/src/main/java/net/sf/jabref/export/OpenDocumentRepresentation.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2014 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or

--- a/src/main/resources/help/About.html
+++ b/src/main/resources/help/About.html
@@ -92,7 +92,8 @@
         Waluyo Adi Siswanto,
 		Eduardo Roberto Greco,
 		Thiago Gomes Toledo,
-		Renato Massao Maeda da Silva</p>
+		Renato Massao Maeda da Silva,
+		Yara Grassi Gouffon</p>
 
         <h2>Thanks to:</h2>
 


### PR DESCRIPTION
Realized many fields were not being exported, not only in .csv and .ods formats as stated in the bug report, but in .sxc as well. I fixed the export for both .ods and .sxc, but couldn't figure out how to fix it for .csv.
