### PR TITLE
Fixed bug #1240. 1-char strings working correctly.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 [master]
+	- Fix for bug 1240: Accepting string with length of one character (by lhaddad).
 	- Fix for bug 949: Exception properly logged
 	- Fix for bug 950: NullPointerException on "Manage custom imports"
 	- Feature 850: Keyboard shortcut for 'Cleanup entries' (by eduardogreco)

--- a/src/main/java/net/sf/jabref/BibtexString.java
+++ b/src/main/java/net/sf/jabref/BibtexString.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2014 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -67,7 +67,7 @@ public class BibtexString {
         }
 
         public static final Type get(String name) {
-        	if (name.length() == 0) {
+        	if (name.length() <= 1) {
         		return OTHER;
         	}
             if (!(name.charAt(1) + "").toUpperCase().equals(

--- a/src/main/resources/help/About.html
+++ b/src/main/resources/help/About.html
@@ -92,7 +92,8 @@
         Waluyo Adi Siswanto,
 		Eduardo Roberto Greco,
 		Thiago Gomes Toledo,
-		Renato Massao Maeda da Silva</p>
+		Renato Massao Maeda da Silva
+		Leonardo Haddad Carlos</p>
 
         <h2>Thanks to:</h2>
 


### PR DESCRIPTION
Fixed bug #1240, about an error thrown when trying to add a string with length of one character.
