### PR TITLE
Fix undoing Cleanup/Convert to Biblatex

### DIFF
--- a/src/main/java/net/sf/jabref/gui/CleanUpAction.java
+++ b/src/main/java/net/sf/jabref/gui/CleanUpAction.java
@@ -680,8 +680,8 @@ public class CleanUpAction extends AbstractWorker {
     		entry.setField("month", null);
     		
     		ce.addEdit(new UndoableFieldChange(entry, "date", null, newDate));
-    		ce.addEdit(new UndoableFieldChange(entry, "date", oldYear, null));
-    		ce.addEdit(new UndoableFieldChange(entry, "date", oldMonth, null));
+    		ce.addEdit(new UndoableFieldChange(entry, "year", oldYear, null));
+    		ce.addEdit(new UndoableFieldChange(entry, "month", oldMonth, null));
     	}
     }
 


### PR DESCRIPTION
When Cleanup/Convert to Biblatex converted year/month fields to a date
field, it used to store erroneous undo information. This change fixes
it.
