### PR TITLE
Fix encoding for DOI import

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 [master]
+    - Fix for bug 1213 (sourceforge): Fix encoding for DOI import
     - Feature #809: import pubmed central id (pmc) field from medline
     - Fix undoing Cleanup/Convert to Biblatex
     - Adapted pattern to parse DBLP entries

--- a/src/main/java/net/sf/jabref/imports/DOItoBibTeXFetcher.java
+++ b/src/main/java/net/sf/jabref/imports/DOItoBibTeXFetcher.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2012 JabRef contributors.
+/*  Copyright (C) 2014 JabRef contributors.
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or

--- a/src/main/resources/help/About.html
+++ b/src/main/resources/help/About.html
@@ -83,6 +83,7 @@
         Alex Montgomery,
         Saverio Mori,
         Ambrogio Oliva,
+        Brian Quistorff,
         Stephan Rave,
         John Relph,
         Hannes Restel,


### PR DESCRIPTION
Get the right encoding for the data from DOI import. Then, for
convenience, also replace the en-dash so that most entries can compile
under latex without modification.
Fixes: http://sourceforge.net/p/jabref/bugs/1213/
