### PR TITLE
Solve the bug '1248 Key bindings not modified'

### DIFF
--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -885,10 +885,9 @@ public class JabRefPreferences {
             // So, if this happens, we add the default value to the current
             // hashmap, so this doesn't happen again, and so this binding
             // will appear in the KeyBindingsDialog.
-            keyBinds.put(bindName, s);
-        }
-        if (s == null) {
             Globals.logger("Could not get key binding for \"" + bindName + "\"");
+            s = "Not associated"; // if the item of menu not in defKeyBind list
+            keyBinds.put(bindName, s);
         }
 
         if (Globals.ON_MAC) {

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -885,10 +885,9 @@ public class JabRefPreferences {
             // So, if this happens, we add the default value to the current
             // hashmap, so this doesn't happen again, and so this binding
             // will appear in the KeyBindingsDialog.
+            Globals.logger("Could not get key binding for \"" + bindName + "\"");            
+            s = "Not associated";
             keyBinds.put(bindName, s);
-        }
-        if (s == null) {
-            Globals.logger("Could not get key binding for \"" + bindName + "\"");
         }
 
         if (Globals.ON_MAC) {

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -885,9 +885,10 @@ public class JabRefPreferences {
             // So, if this happens, we add the default value to the current
             // hashmap, so this doesn't happen again, and so this binding
             // will appear in the KeyBindingsDialog.
-            Globals.logger("Could not get key binding for \"" + bindName + "\"");            
-            s = "Not associated";
             keyBinds.put(bindName, s);
+        }
+        if (s == null) {
+            Globals.logger("Could not get key binding for \"" + bindName + "\"");
         }
 
         if (Globals.ON_MAC) {


### PR DESCRIPTION
After checking the bug '1248 Key bindings not modified', it was Identified que the creation of the hashmap list 'defKeyBinds' that sets the standard keyboard shortcuts, the feature 'Open folder' was not included in the 'defineDefaultKeyBindings ( )' method in 'JabRefPreferences' class .
In the creation of the menu item in the 'JabRefFrame' class for the item 'Open folder', it was not possible to recover the value of the item in the list 'defKeyBinds', occurring error 'NullPointerException' in the 'String makeEscape (String s) 'method in 'JabRefPreferences' class, which shouldnt return the value of 'String' to fill out the menu item.
When the 'User' tried to change and save the list, the error 'NullPointerException' not allow the execution of the procedure.
To solve the bug , was included in the verification of the presence of null in 'keyBinds' list (copy of 'defKeyBinds'), the value 'Not associated' being passed to the 'String' return.
The warning that menu feature is created in the 'JabRefFrame' class without associated keyboard shortcut, was moved to the method mentioned before, as was duplicated.