### PR TITLE
Fix for bug #1253: Cleanup entries error 2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 [master]
+	- Fix for bug #1253: Cleanup entries error 2 (by ruy.takata)
     - Fix for bug 1213 (sourceforge): Fix encoding for DOI import
     - Feature #809: import pubmed central id (pmc) field from medline
     - Fix undoing Cleanup/Convert to Biblatex

--- a/src/main/java/net/sf/jabref/imports/HTMLConverter.java
+++ b/src/main/java/net/sf/jabref/imports/HTMLConverter.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2012 JabRef contributors.
+/*  Copyright (C) 2003-2015 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -107,7 +107,7 @@ public class HTMLConverter implements LayoutFormatter {
         //                                 U+00C3 ISOlat1 
         {"196", "Auml", "\\{\\\\\"\\{A\\}\\}"}, // latin capital letter A with diaeresis, 
         //                                 U+00C4 ISOlat1 
-        {"197", "Aring", "\\{\\\\AA\\}"}, // latin capital letter A with ring above 
+        {"197", "Aring", "\\{\\{\\\\AA\\}\\}"}, // latin capital letter A with ring above 
         //                                 = latin capital letter A ring,
         //                                 U+00C5 ISOlat1 
         {"198", "AElig", "\\{\\\\AE\\}"}, // latin capital letter AE 
@@ -173,7 +173,7 @@ public class HTMLConverter implements LayoutFormatter {
         //                                 U+00E3 ISOlat1 
         {"228", "auml", "\\{\\\\\"\\{a\\}\\}"}, // latin small letter a with diaeresis, 
         //                                 U+00E4 ISOlat1 
-        {"229", "aring", "\\{\\\\aa\\}"}, // latin small letter a with ring above 
+        {"229", "aring", "\\{\\{\\\\aa\\}\\}"}, // latin small letter a with ring above 
         //                                 = latin small letter a ring,
         //                                 U+00E5 ISOlat1 
         {"230", "aelig", "\\{\\\\ae\\}"}, // latin small letter ae 

--- a/src/main/resources/help/About.html
+++ b/src/main/resources/help/About.html
@@ -101,7 +101,8 @@
         Mattias Ulbrich,
         David Weitzman,
         Seb Wills,
-        John Zedlewski</p>
+        John Zedlewski,
+        Ruy Minoru Ito Takata</p>
 
         <h2>Thanks to:</h2>
 


### PR DESCRIPTION
Committer: Ruy Minoru Ito Takata <ruy.takata@gmail.com>

When using the "Cleanup entries" function, the special character Å should be converted to {{\AA}} to preserve the capital when generating the PDF.