### PR TITLE
Change DOI importer to use application/x-bibtex

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 [master]
-    - Change the CrossRef content negotiation for bibtex DOI import
+    - Change the CrossRef content negotiation for bibtex DOI import (by sheffien)
     - Fix for bug #1253: Cleanup entries error 2 (by ruy.takata)
     - Fix for bug 1213 (sourceforge): Fix encoding for DOI import
     - Feature #809: import pubmed central id (pmc) field from medline

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 [master]
-	- Fix for bug #1253: Cleanup entries error 2 (by ruy.takata)
+    - Change the CrossRef content negotiation for bibtex DOI import
+    - Fix for bug #1253: Cleanup entries error 2 (by ruy.takata)
     - Fix for bug 1213 (sourceforge): Fix encoding for DOI import
     - Feature #809: import pubmed central id (pmc) field from medline
     - Fix undoing Cleanup/Convert to Biblatex

--- a/src/main/java/net/sf/jabref/imports/DOItoBibTeXFetcher.java
+++ b/src/main/java/net/sf/jabref/imports/DOItoBibTeXFetcher.java
@@ -114,7 +114,7 @@ public class DOItoBibTeXFetcher implements EntryFetcher {
             return null;
         }
 
-        conn.setRequestProperty("Accept", "text/bibliography; style=bibtex");
+        conn.setRequestProperty("Accept", "application/x-bibtex");
 
 
         String bibtexString;

--- a/src/main/resources/help/About.html
+++ b/src/main/resources/help/About.html
@@ -90,6 +90,7 @@
         Moritz Ringler,
         Andreas Rudert,
         Mark Schenk,
+        Nathan Sheffield,
         Rudolf Seemann,
         Toralf Senger,
         Manuel Siebeneicher,


### PR DESCRIPTION
Changes the CrossRef content negotiation method to yield more complete bibtex entries. This fixes an issue with DOI import from papers with many authors, which previously yielded truncated results.