### PR TITLE
Updated some paths in Launch4j configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ To get a list of all targets, use `gradlew tasks`.
 To compile, use the command `gradlew generateSource antTargets.jars`.
 After the build is finished, you can find the executable jar file
 named `JabRef-$VERSION.jar` (where $VERSION is the current version of the
-source tree) in the `build/lib` directory. Enjoy!
+source tree) in the `buildant\lib` directory. Enjoy!
+The setup files are created by invoking the command `gradlew generateSource antTargets.release`.
 
 On Mac OS X you should include the targets osx and osxjar,
 making the correct command `gradlew generateSource antTargets.compile antTargets.unjarlib antTargets.osx antTargets.jars antTargets.osxjar`.

--- a/jabref-launch4j.xml
+++ b/jabref-launch4j.xml
@@ -2,7 +2,7 @@
   <dontWrapJar>true</dontWrapJar>
   <headerType>gui</headerType>
   <jar>JabRef-1.1.1.jar</jar>
-  <outfile>.\src\windows\nsis\dist\JabRef.exe</outfile>
+  <outfile>./src/main/resources/windows/nsis/dist/JabRef.exe</outfile>
   <errTitle></errTitle>
   <cmdLine></cmdLine>
   <chdir></chdir>
@@ -12,7 +12,7 @@
   <customProcName>false</customProcName>
   <stayAlive>false</stayAlive>
   <manifest></manifest>
-  <icon>./src/resources/images/JabRef.ico</icon>
+  <icon>./src/main/resources/images/JabRef.ico</icon>
   <jre>
     <path></path>
     <minVersion>1.6.0</minVersion>


### PR DESCRIPTION
In order that the Launch4j build task works, some paths in the configuration file have to be changed.