### PR TITLE
Added the ability to reorder the panels in the side pane.

### DIFF
--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2012 JabRef contributors.
+/*  Copyright (C) 2003-2015 JabRef contributors.
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 2 of the License, or
@@ -310,6 +310,9 @@ public class JabRefPreferences {
 
         defaults.put(NEWLINE, System.getProperty("line.separator"));
         
+        defaults.put("sidePaneComponentNames", "");
+        defaults.put("sidePaneComponentPreferredPositions", "");
+
         defaults.put("columnNames", "entrytype;author;title;year;journal;owner;timestamp;bibtexkey");
         defaults.put("columnWidths", "75;280;400;60;100;100;100;100");
         defaults.put(PersistenceTableColumnListener.ACTIVATE_PREF_KEY,

--- a/src/main/java/net/sf/jabref/SidePaneComponent.java
+++ b/src/main/java/net/sf/jabref/SidePaneComponent.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2015 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -31,6 +31,8 @@ import com.jgoodies.uif_lite.panel.SimpleInternalFrame;
 public abstract class SidePaneComponent extends SimpleInternalFrame {
 
 	protected JButton close = new JButton(GUIGlobals.getImage("close"));
+	protected JButton up = new JButton(GUIGlobals.getImage("up"));
+	protected JButton down = new JButton(GUIGlobals.getImage("down"));
 
 	protected boolean visible = false;
 
@@ -46,7 +48,15 @@ public abstract class SidePaneComponent extends SimpleInternalFrame {
 		close.setMargin(new Insets(0, 0, 0, 0));
 		// tlb.setOpaque(false);
 		close.setBorder(null);
+		up.setMargin(new Insets(0, 0, 0, 0));
+		down.setMargin(new Insets(0, 0, 0, 0));
+		up.setBorder(null);
+		down.setBorder(null);
+		up.addActionListener(new UpButtonListener());
+		down.addActionListener(new DownButtonListener());
         tlb.setFloatable(false);
+		tlb.add(up);
+		tlb.add(down);
 		tlb.add(close);
 		close.addActionListener(new CloseButtonListener());
 		setToolBar(tlb);
@@ -60,6 +70,14 @@ public abstract class SidePaneComponent extends SimpleInternalFrame {
 
 	public void hideAway() {
 		manager.hideComponent(this);
+	}
+	
+	public void moveUp() {
+		manager.moveUp(this);
+	}
+	
+	public void moveDown() {
+		manager.moveDown(this);
 	}
 
 	/**
@@ -109,6 +127,18 @@ public abstract class SidePaneComponent extends SimpleInternalFrame {
 	class CloseButtonListener implements ActionListener {
 		public void actionPerformed(ActionEvent e) {
 			hideAway();
+		}
+	}
+	
+	class UpButtonListener implements ActionListener {
+		public void actionPerformed(ActionEvent e) {
+			moveUp();
+		}
+	}
+	
+	class DownButtonListener implements ActionListener {
+		public void actionPerformed(ActionEvent e) {
+			moveDown();
 		}
 	}
 }

--- a/src/main/java/net/sf/jabref/SidePaneManager.java
+++ b/src/main/java/net/sf/jabref/SidePaneManager.java
@@ -205,10 +205,12 @@ public class SidePaneManager {
 		public int compare(SidePaneComponent comp1, SidePaneComponent comp2) {
 			String comp1Name = getComponentName(comp1);
 			String comp2Name = getComponentName(comp2);
-			return Integer.compare(
-					preferredPositions.getOrDefault(comp1Name, 0),
-					preferredPositions.getOrDefault(comp2Name, 0)
-			);
+			
+			// Manually provide default values, since getOrDefault() doesn't exist prior to Java 8
+			int pos1 = (preferredPositions.containsKey(comp1Name) ? preferredPositions.get(comp1Name) : 0);
+			int pos2 = (preferredPositions.containsKey(comp2Name) ? preferredPositions.get(comp2Name) : 0);
+			
+			return Integer.compare(pos1, pos2);
 		}
 	}
 	

--- a/src/main/java/net/sf/jabref/SidePaneManager.java
+++ b/src/main/java/net/sf/jabref/SidePaneManager.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2015 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -37,6 +37,7 @@ public class SidePaneManager {
 	SidePane sidep;
 
 	Map<String, SidePaneComponent> components = new LinkedHashMap<String, SidePaneComponent>();
+	Map<SidePaneComponent, String> componentNames = new HashMap<SidePaneComponent, String>();
 
 	List<SidePaneComponent> visible = new LinkedList<SidePaneComponent>();
 
@@ -104,6 +105,7 @@ public class SidePaneManager {
 
 	public synchronized void register(String name, SidePaneComponent comp) {
         components.put(name, comp);
+        componentNames.put(comp, name);
 	}
 
 	public synchronized void registerAndShow(String name, SidePaneComponent comp) {
@@ -115,6 +117,10 @@ public class SidePaneManager {
 		if (!visible.contains(component)) {
 			// Put the new component at the top of the group
 			visible.add(0, component);
+			
+			// Sort the visible components by their preferred position
+			Collections.sort(visible, new PreferredIndexSort());
+			
 			updateView();
 			component.componentOpening();
 		}
@@ -123,6 +129,10 @@ public class SidePaneManager {
     public SidePaneComponent getComponent(String name) {
         return components.get(name);
     }
+	
+	public String getComponentName(SidePaneComponent comp) {
+		return componentNames.get(comp);
+	}
 
     public synchronized void hideComponent(SidePaneComponent comp) {
 		if (visible.contains(comp)) {
@@ -143,7 +153,95 @@ public class SidePaneManager {
 	}
     }
 
+	private Map<String, Integer> getPreferredPositions() {
+		Map<String, Integer> preferredPositions = new HashMap<String, Integer>();
+		
+		String[] componentNames = Globals.prefs.getStringArray("sidePaneComponentNames");
+		String[] componentPositions = Globals.prefs.getStringArray("sidePaneComponentPreferredPositions");
+		
+		for (int i = 0; i < componentNames.length; ++i) {
+			try {
+				preferredPositions.put(componentNames[i], Integer.parseInt(componentPositions[i]));
+			}
+			catch (NumberFormatException e) {
+				// Invalid integer format, ignore
+			}
+		}
+		
+		return preferredPositions;
+	}
+	
+	private void updatePreferredPositions() {
+		Map<String, Integer> preferredPositions = getPreferredPositions();
+		
+		// Update the preferred positions of all visible components
+		int index = 0;
+		for (SidePaneComponent comp : visible) {
+			String componentName = getComponentName(comp);
+			preferredPositions.put(componentName, index++);
+		}
+		
+		// Split the map into a pair of parallel String arrays suitable for storage
+		String[] componentNames = preferredPositions.keySet().toArray(new String[0]);
+		String[] componentPositions = new String[preferredPositions.size()];
+		
+		for (int i = 0; i < componentNames.length; ++i) {
+			componentPositions[i] = preferredPositions.get(componentNames[i]).toString();
+		}
+		
+		Globals.prefs.putStringArray("sidePaneComponentNames", componentNames);
+		Globals.prefs.putStringArray("sidePaneComponentPreferredPositions", componentPositions);
+	}
+	
+	// Helper class for sorting visible componenys based on their preferred position
+	private class PreferredIndexSort implements Comparator<SidePaneComponent> {
+		private Map<String, Integer> preferredPositions;
+		
+		public PreferredIndexSort() {
+			preferredPositions = getPreferredPositions();
+		}
+		
+		@Override
+		public int compare(SidePaneComponent comp1, SidePaneComponent comp2) {
+			String comp1Name = getComponentName(comp1);
+			String comp2Name = getComponentName(comp2);
+			return Integer.compare(
+					preferredPositions.getOrDefault(comp1Name, 0),
+					preferredPositions.getOrDefault(comp2Name, 0)
+			);
+		}
+	}
+	
+	public synchronized void moveUp(SidePaneComponent comp) {
+		if (visible.contains(comp)) {
+			int currIndex = visible.indexOf(comp);
+			if (currIndex > 0) {
+				int newIndex = currIndex - 1; 
+				visible.remove(currIndex);
+				visible.add(newIndex, comp);
+				
+				updatePreferredPositions();
+				updateView();
+			}
+		}
+	}
+	
+	public synchronized void moveDown(SidePaneComponent comp) {
+		if (visible.contains(comp)) {
+			int currIndex = visible.indexOf(comp);
+			if (currIndex < (visible.size() - 1)) {
+				int newIndex = currIndex + 1;
+				visible.remove(currIndex);
+				visible.add(newIndex, comp);
+				
+				updatePreferredPositions();
+				updateView();
+			}
+		}
+	}
+	
 	public synchronized void unregisterComponent(String name) {
+		componentNames.remove(components.get(name));
 	    components.remove(name);
 	}
 


### PR DESCRIPTION
Side pane panels now feature an up arrow button and a down arrow button immediately to the left of the close button. These buttons allow panes to be swapped with the pane above or below them, respectively.

Whenever the panes are reordered, the current position of each visible pane is recorded in the application preferences, so the user's custom ordering can be preserved when JabRef is next run.