### PR TITLE
Add the option to save selected entries as plain BibTeX.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 [master]
     - Feature: Ability to reorder the panels in the side pane
+	- Feature: Option to save selected entries as plain BibTex without JabRef metadata
 2.11 beta
     - Some UI updates (mainly removing unnecessary boundaries)
     - Feature: Gridlines are now optional (and disabled by default)

--- a/src/main/java/net/sf/jabref/BasePanel.java
+++ b/src/main/java/net/sf/jabref/BasePanel.java
@@ -70,6 +70,7 @@ import net.sf.jabref.export.FileActions;
 import net.sf.jabref.export.SaveDatabaseAction;
 import net.sf.jabref.export.SaveException;
 import net.sf.jabref.export.SaveSession;
+import net.sf.jabref.export.FileActions.DatabaseSaveType;
 import net.sf.jabref.export.layout.Layout;
 import net.sf.jabref.export.layout.LayoutHelper;
 import net.sf.jabref.external.AttachFileAction;
@@ -411,9 +412,9 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             }
         });
 
-        actions.put("saveSelectedAs", new SaveSelectedAction(false));
+        actions.put("saveSelectedAs", new SaveSelectedAction(FileActions.DatabaseSaveType.DEFAULT));
         
-        actions.put("saveSelectedAsPlain", new SaveSelectedAction(true));
+        actions.put("saveSelectedAsPlain", new SaveSelectedAction(FileActions.DatabaseSaveType.PLAIN_BIBTEX));
         
         // The action for copying selected entries.
         actions.put("copy", new BaseAction() {
@@ -1696,7 +1697,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
       //}).start();
     }
 
-    private boolean saveDatabase(File file, boolean selectedOnly, String encoding, boolean savePlainBibtex) throws SaveException {
+    private boolean saveDatabase(File file, boolean selectedOnly, String encoding, FileActions.DatabaseSaveType saveType) throws SaveException {
         SaveSession session;
         frame.block();
         try {
@@ -1705,7 +1706,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                                            Globals.prefs, false, false, encoding, false);
             else
                 session = FileActions.savePartOfDatabase(database, metaData, file,
-                                               Globals.prefs, mainTable.getSelectedEntries(), encoding, savePlainBibtex);
+                                               Globals.prefs, mainTable.getSelectedEntries(), encoding, saveType);
 
         } catch (UnsupportedCharsetException ex2) {
             JOptionPane.showMessageDialog(frame, Globals.lang("Could not save file. "
@@ -1755,7 +1756,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                         JOptionPane.QUESTION_MESSAGE, null, Globals.ENCODINGS, encoding);
                 if (choice != null) {
                     String newEncoding = (String)choice;
-                    return saveDatabase(file, selectedOnly, newEncoding, savePlainBibtex);
+                    return saveDatabase(file, selectedOnly, newEncoding, saveType);
                 } else
                     commit = false;
             } else if (answer == JOptionPane.CANCEL_OPTION)
@@ -3078,10 +3079,10 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
     private class SaveSelectedAction extends BaseAction {
     	
-    	private boolean savePlainBibtex;
+    	private DatabaseSaveType saveType;
     	
-    	public SaveSelectedAction(boolean savePlainBibtex) {
-    		this.savePlainBibtex = savePlainBibtex;
+    	public SaveSelectedAction(DatabaseSaveType saveType) {
+    		this.saveType = saveType;
     	}
     	
         public void action() throws Throwable {
@@ -3097,7 +3098,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     Globals.lang("Save database"), JOptionPane.OK_CANCEL_OPTION)
                    == JOptionPane.OK_OPTION)) {
 
-                saveDatabase(expFile, true, Globals.prefs.get("defaultEncoding"), savePlainBibtex);
+                saveDatabase(expFile, true, Globals.prefs.get("defaultEncoding"), saveType);
                 //runCommand("save");
                 frame.getFileHistory().newFile(expFile.getPath());
                 frame.output(Globals.lang("Saved selected to")+" '"

--- a/src/main/java/net/sf/jabref/BasePanel.java
+++ b/src/main/java/net/sf/jabref/BasePanel.java
@@ -411,30 +411,10 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             }
         });
 
-        actions.put("saveSelectedAs", new BaseAction () {
-                public void action() throws Throwable {
-
-                  String chosenFile = FileDialogs.getNewFile(frame, new File(Globals.prefs.get("workingDirectory")), ".bib",
-                                                         JFileChooser.SAVE_DIALOG, false);
-                  if (chosenFile != null) {
-                    File expFile = new File(chosenFile);
-                    if (!expFile.exists() ||
-                        (JOptionPane.showConfirmDialog
-                         (frame, "'"+expFile.getName()+"' "+
-                          Globals.lang("exists. Overwrite file?"),
-                          Globals.lang("Save database"), JOptionPane.OK_CANCEL_OPTION)
-                         == JOptionPane.OK_OPTION)) {
-
-                      saveDatabase(expFile, true, Globals.prefs.get("defaultEncoding"));
-                      //runCommand("save");
-                      frame.getFileHistory().newFile(expFile.getPath());
-                      frame.output(Globals.lang("Saved selected to")+" '"
-                                   +expFile.getPath()+"'.");
-                        }
-                    }
-                }
-            });
-    
+        actions.put("saveSelectedAs", new SaveSelectedAction(false));
+        
+        actions.put("saveSelectedAsPlain", new SaveSelectedAction(true));
+        
         // The action for copying selected entries.
         actions.put("copy", new BaseAction() {
                 public void action() {
@@ -1716,7 +1696,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
       //}).start();
     }
 
-    private boolean saveDatabase(File file, boolean selectedOnly, String encoding) throws SaveException {
+    private boolean saveDatabase(File file, boolean selectedOnly, String encoding, boolean savePlainBibtex) throws SaveException {
         SaveSession session;
         frame.block();
         try {
@@ -1725,7 +1705,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                                            Globals.prefs, false, false, encoding, false);
             else
                 session = FileActions.savePartOfDatabase(database, metaData, file,
-                                               Globals.prefs, mainTable.getSelectedEntries(), encoding);
+                                               Globals.prefs, mainTable.getSelectedEntries(), encoding, savePlainBibtex);
 
         } catch (UnsupportedCharsetException ex2) {
             JOptionPane.showMessageDialog(frame, Globals.lang("Could not save file. "
@@ -1775,7 +1755,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                         JOptionPane.QUESTION_MESSAGE, null, Globals.ENCODINGS, encoding);
                 if (choice != null) {
                     String newEncoding = (String)choice;
-                    return saveDatabase(file, selectedOnly, newEncoding);
+                    return saveDatabase(file, selectedOnly, newEncoding, savePlainBibtex);
                 } else
                     commit = false;
             } else if (answer == JOptionPane.CANCEL_OPTION)
@@ -3096,5 +3076,34 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         frame.forward.setEnabled(nextEntries.size() > 0);
     }
 
+    private class SaveSelectedAction extends BaseAction {
+    	
+    	private boolean savePlainBibtex;
+    	
+    	public SaveSelectedAction(boolean savePlainBibtex) {
+    		this.savePlainBibtex = savePlainBibtex;
+    	}
+    	
+        public void action() throws Throwable {
 
+            String chosenFile = FileDialogs.getNewFile(frame, new File(Globals.prefs.get("workingDirectory")), ".bib",
+                                                   JFileChooser.SAVE_DIALOG, false);
+            if (chosenFile != null) {
+              File expFile = new File(chosenFile);
+              if (!expFile.exists() ||
+                  (JOptionPane.showConfirmDialog
+                   (frame, "'"+expFile.getName()+"' "+
+                    Globals.lang("exists. Overwrite file?"),
+                    Globals.lang("Save database"), JOptionPane.OK_CANCEL_OPTION)
+                   == JOptionPane.OK_OPTION)) {
+
+                saveDatabase(expFile, true, Globals.prefs.get("defaultEncoding"), savePlainBibtex);
+                //runCommand("save");
+                frame.getFileHistory().newFile(expFile.getPath());
+                frame.output(Globals.lang("Saved selected to")+" '"
+                             +expFile.getPath()+"'.");
+                  }
+              }
+          }
+      }
 }

--- a/src/main/java/net/sf/jabref/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/JabRefFrame.java
@@ -186,6 +186,10 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
                                          "Save selected as ...",
                                          Globals.lang("Save selected as ..."),
                                          GUIGlobals.getIconUrl("saveAs")),
+      saveSelectedAsPlain = new GeneralAction("saveSelectedAsPlain",
+                                                 "Save selected as plain BibTeX ...",
+                                                 Globals.lang("Save selected as plain BibTeX ..."),
+                                                 GUIGlobals.getIconUrl("saveAs")),
       exportAll = ExportFormats.getExportAction(this, false),
       exportSelected = ExportFormats.getExportAction(this, true),
       importCurrent = ImportFormats.getImportAction(this, false),
@@ -1291,6 +1295,7 @@ public JabRefPreferences prefs() {
       file.add(saveAs);
       file.add(saveAll);
       file.add(saveSelectedAs);
+      file.add(saveSelectedAsPlain);
       file.addSeparator();
       //file.add(importMenu);
       //file.add(importNewMenu);

--- a/src/main/java/net/sf/jabref/export/FileActions.java
+++ b/src/main/java/net/sf/jabref/export/FileActions.java
@@ -357,7 +357,7 @@ public class FileActions {
      * @return A List containing warnings, if any.
      */
     public static SaveSession savePartOfDatabase(BibtexDatabase database, MetaData metaData,
-            File file, JabRefPreferences prefs, BibtexEntry[] bes, String encoding) throws SaveException {
+            File file, JabRefPreferences prefs, BibtexEntry[] bes, String encoding, boolean writePlainBibtex) throws SaveException {
 
         TreeMap<String, BibtexEntryType> types = new TreeMap<String, BibtexEntryType>(); // Map
         // to
@@ -382,9 +382,11 @@ public class FileActions {
             // Define our data stream.
             VerifyingWriter fw = session.getWriter();
 
-            // Write signature.
-            writeBibFileHeader(fw, encoding);
-
+            if (!writePlainBibtex) {
+            	// Write signature.
+            	writeBibFileHeader(fw, encoding);
+            }
+            
             // Write preamble if there is one.
             writePreamble(fw, database.getPreamble());
 
@@ -423,7 +425,7 @@ public class FileActions {
             }
 
             // Write meta data.
-            if (metaData != null) {
+            if (!writePlainBibtex && metaData != null) {
                 metaData.writeMetaData(fw);
             }
 

--- a/src/main/java/net/sf/jabref/export/FileActions.java
+++ b/src/main/java/net/sf/jabref/export/FileActions.java
@@ -55,7 +55,11 @@ import ca.odell.glazedlists.BasicEventList;
 import ca.odell.glazedlists.SortedList;
 
 public class FileActions {
-
+	
+	public enum DatabaseSaveType {
+		DEFAULT, PLAIN_BIBTEX
+	}
+	
     private static Pattern refPat = Pattern.compile("(#[A-Za-z]+#)"); // Used to detect string references in strings
     private static BibtexString.Type previousStringType;
 
@@ -357,7 +361,7 @@ public class FileActions {
      * @return A List containing warnings, if any.
      */
     public static SaveSession savePartOfDatabase(BibtexDatabase database, MetaData metaData,
-            File file, JabRefPreferences prefs, BibtexEntry[] bes, String encoding, boolean writePlainBibtex) throws SaveException {
+            File file, JabRefPreferences prefs, BibtexEntry[] bes, String encoding, DatabaseSaveType saveType) throws SaveException {
 
         TreeMap<String, BibtexEntryType> types = new TreeMap<String, BibtexEntryType>(); // Map
         // to
@@ -382,7 +386,7 @@ public class FileActions {
             // Define our data stream.
             VerifyingWriter fw = session.getWriter();
 
-            if (!writePlainBibtex) {
+            if (saveType != DatabaseSaveType.PLAIN_BIBTEX) {
             	// Write signature.
             	writeBibFileHeader(fw, encoding);
             }
@@ -425,7 +429,7 @@ public class FileActions {
             }
 
             // Write meta data.
-            if (!writePlainBibtex && metaData != null) {
+            if (saveType != DatabaseSaveType.PLAIN_BIBTEX && metaData != null) {
                 metaData.writeMetaData(fw);
             }
 

--- a/src/main/java/net/sf/jabref/export/SaveDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/export/SaveDatabaseAction.java
@@ -218,7 +218,7 @@ public class SaveDatabaseAction extends AbstractWorker {
                         Globals.prefs, false, false, encoding, false);
             else
                 session = FileActions.savePartOfDatabase(panel.database(), panel.metaData(), file,
-                        Globals.prefs, panel.getSelectedEntries(), encoding, false);
+                        Globals.prefs, panel.getSelectedEntries(), encoding, FileActions.DatabaseSaveType.DEFAULT);
 
         } catch (UnsupportedCharsetException ex2) {
             JOptionPane.showMessageDialog(frame, Globals.lang("Could not save file. "

--- a/src/main/java/net/sf/jabref/export/SaveDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/export/SaveDatabaseAction.java
@@ -218,7 +218,7 @@ public class SaveDatabaseAction extends AbstractWorker {
                         Globals.prefs, false, false, encoding, false);
             else
                 session = FileActions.savePartOfDatabase(panel.database(), panel.metaData(), file,
-                        Globals.prefs, panel.getSelectedEntries(), encoding);
+                        Globals.prefs, panel.getSelectedEntries(), encoding, false);
 
         } catch (UnsupportedCharsetException ex2) {
             JOptionPane.showMessageDialog(frame, Globals.lang("Could not save file. "


### PR DESCRIPTION
Adds a new menu option called "Save selected as plain BibTeX ...".

This option behaves the same way as the existing "Save selected as ..." option, except that the JabRef metadata and signature comment are not written to the resulting output file.