### PR TITLE
Minor UI Fix: Add "Save selected as plain BibTeX..." to the list of open database-only actions.

### DIFF
--- a/src/main/java/net/sf/jabref/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/JabRefFrame.java
@@ -1686,7 +1686,7 @@ public JabRefPreferences prefs() {
     protected void initActions() {
         openDatabaseOnlyActions = new LinkedList<Object>();
         openDatabaseOnlyActions.addAll(Arrays.asList(manageSelectors,
-                mergeDatabaseAction, newSubDatabaseAction, close, save, saveAs, saveSelectedAs, undo,
+                mergeDatabaseAction, newSubDatabaseAction, close, save, saveAs, saveSelectedAs, saveSelectedAsPlain, undo,
                 redo, cut, delete, copy, paste, mark, unmark, unmarkAll, editEntry,
                 selectAll, copyKey, copyCiteKey, copyKeyAndTitle, editPreamble, editStrings, toggleGroups, toggleSearch,
                 makeKeyAction, normalSearch,


### PR DESCRIPTION
The "Save selected as plain BibTeX..." menu option is now correctly enabled and disabled based on whether or not a database is currently open.

I haven't included a CHANGELOG entry, since this commit effectively just corrects a minor oversight on my behalf when adding this menu entry in [a previous pull request](https://github.com/JabRef/jabref/pull/48), but I'm happy to add one if deemed necessary.