### PR TITLE
Trim journal names before looking up the Abbreviation

### DIFF
--- a/src/main/java/net/sf/jabref/journals/JournalAbbreviations.java
+++ b/src/main/java/net/sf/jabref/journals/JournalAbbreviations.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2015 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -91,7 +91,7 @@ public class JournalAbbreviations {
      * @return The abbreviated name, or null if it couldn't be found.
      */
     public String getAbbreviatedName(String journalName, boolean withDots) {
-        String s = journalName.toLowerCase();
+        String s = journalName.toLowerCase().trim();
         String abbr;
         if (fullNameKeyed.containsKey(s)) {
             abbr = fullNameKeyed.get(s);


### PR DESCRIPTION
Some journals put trailing space in the journal names when
exporting a bibtex citation. This causes the abbreviation
to fail. This should fix that.