### PR TITLE
Fix for Bug #1278 Crash after changing LookAndFeel

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 [master]
-    - Add some predefined look and feels in preference window
+    - Fix for bug #1278 Crash after changing LookAndFeel (showing a proper error message if L&F is not available)
+    - Adds some predefined look and feels in preference window (lists only available L&Fs)
     - Fixes #1131: MacOSX: JabRef minimizes when clicking on x
     - Dropped jayatana version 1.2.4 as version 2.x superseeds it
     - Feature: Trim journal names before looking up the abbreviation

--- a/src/main/java/net/sf/jabref/AdvancedTab.java
+++ b/src/main/java/net/sf/jabref/AdvancedTab.java
@@ -16,6 +16,8 @@
 package net.sf.jabref;
 
 import java.awt.BorderLayout;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
@@ -70,7 +72,7 @@ public class AdvancedTab extends JPanel implements PrefsTab {
     useIEEEAbrv = new JCheckBox(Globals.lang("Use IEEE LaTeX abbreviations"));
     biblatexMode = new JCheckBox(Globals.lang("BibLaTeX mode"));
     remoteServerPort = new JTextField();
-    String[] lookAndFeels = {
+    String[] possibleLookAndFeels = {
     	"com.jgoodies.plaf.plastic.Plastic3DLookAndFeel",
     	"com.sun.java.swing.plaf.windows.WindowsLookAndFeel",
     	"com.sun.java.swing.plaf.motif.MotifLookAndFeel",
@@ -78,7 +80,16 @@ public class AdvancedTab extends JPanel implements PrefsTab {
     	"com.sun.java.swing.plaf.gtk.GTKLookAndFeel",
     	"javax.swing.plaf.metal.MetalLookAndFeel"
     };
-    className = new JComboBox<String>(lookAndFeels);
+    // Only list L&F which are available
+    List<String> lookAndFeels = new ArrayList<String>();
+    for (String lf : possibleLookAndFeels) {
+    	try {
+    		// Try to find L&F, throws exception if not successful
+    		Class.forName(lf);
+    		lookAndFeels.add(lf);
+    	} catch(ClassNotFoundException e) {}
+    }
+    className = new JComboBox<String>(lookAndFeels.toArray(new String[lookAndFeels.size()]));
     className.setEditable(true);
     final JComboBox<String> clName = className;
     useDefault.addChangeListener(new ChangeListener() {

--- a/src/main/java/net/sf/jabref/JabRef.java
+++ b/src/main/java/net/sf/jabref/JabRef.java
@@ -614,24 +614,36 @@ public class JabRef {
     
     private void setLookAndFeel() {
         try {
-            String systemLnF;
-            // * Look first into the Preferences
-            // * Fallback to the System Look & Fell
+            String lookFeel;
+        	String systemLnF = UIManager.getSystemLookAndFeelClassName();
+            
             if (Globals.prefs.getBoolean("useDefaultLookAndFeel")) {
-                systemLnF = UIManager.getSystemLookAndFeelClassName();
+            	// Use system Look & Feel by default
+            	lookFeel = systemLnF;
             } else {
-                systemLnF = Globals.prefs.get("lookAndFeel");
+            	lookFeel = Globals.prefs.get("lookAndFeel");
             }
 
             // At all cost, avoid ending up with the Metal look and feel:
-            if (systemLnF.equals("javax.swing.plaf.metal.MetalLookAndFeel")) {
+            if (lookFeel.equals("javax.swing.plaf.metal.MetalLookAndFeel")) {
                 Plastic3DLookAndFeel lnf = new Plastic3DLookAndFeel();
                 Plastic3DLookAndFeel.setCurrentTheme(new SkyBluer());
                 com.jgoodies.looks.Options.setPopupDropShadowEnabled(true);
                 UIManager.setLookAndFeel(lnf);
             }
             else {
-                UIManager.setLookAndFeel(systemLnF);
+            	try {
+            		UIManager.setLookAndFeel(lookFeel);
+            	} catch(ClassNotFoundException e) {
+            		// specified look and feel does not exist on the classpath, so use system l&f
+            		UIManager.setLookAndFeel(systemLnF);
+            		// also set system l&f as default
+            		Globals.prefs.put("lookAndFeel", systemLnF);
+            		// notify the user
+            		JOptionPane.showMessageDialog(jrf, Globals.lang("Unable to find the requested Look & Feel and thus the default one is used."),
+                            Globals.lang("Warning"),
+                            JOptionPane.WARNING_MESSAGE);
+            	}
             }
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
Now a proper error message is shown at start if the L&F is not available.
Moreover, only available L&Fs are listed in the preference window.