### PR TITLE
Fix double-click opening of files on Mac

### DIFF
--- a/src/main/java/net/sf/jabref/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/JabRefFrame.java
@@ -449,8 +449,6 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
   private void init() {
 	    tabbedPane = new DragDropPopupPane(manageSelectors, databaseProperties, bibtexKeyPattern);
 
-        macOSXRegistration();
-
         UIManager.put("FileChooser.readOnly", Globals.prefs.getBoolean("filechooserDisableRename"));
 
         MyGlassPane glassPane = new MyGlassPane();
@@ -580,6 +578,11 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
                 }
             }
         });
+        
+        //Note: The registration of Apple event is at the end of initialization, because
+        //if the events happen too early (ie when the window is not initialized yet), the
+        //opened (double-clicked) documents are not displayed.
+        macOSXRegistration();
     }
 
     public void setWindowTitle() {


### PR DESCRIPTION
Moving the registration of Apple events ensures that double-clicking on a file to open it works even if JabRef is not yet running.