### PR TITLE
Update dependencies if possible

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 [master]
+    - Update dependencies: jersey, commons.logging, pdfbox, jgoodies, lazedlists, JDBC connectors
     - Refactored preferences
     - Remove local jgoodies dependency: replace SimpleInteralFrame with swingx JXTitledPanel and UIFSplitPane by JSplitPane
     - Fix several FindBugs warnings

--- a/build.gradle
+++ b/build.gradle
@@ -106,9 +106,9 @@ dependencies {
     // not available in maven repository
     compile fileTree(dir: 'lib/plugin', includes: ['jpf.jar', 'jpf-boot.jar', 'JPFCodeGenerator-rt.jar'])
 
-    compile 'com.sun.jersey:jersey-client:1.14'
-    compile 'com.sun.jersey:jersey-core:1.14'
-    compile 'com.sun.jersey.contribs:jersey-multipart:1.14'
+    compile 'com.sun.jersey:jersey-client:1.19'
+    compile 'com.sun.jersey:jersey-core:1.19'
+    compile 'com.sun.jersey.contribs:jersey-multipart:1.19'
 
     compile fileTree(dir: 'lib/spl/sciplore', includes: ['*.jar'])
 

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ dependencies {
     compile 'mysql:mysql-connector-java:5.0.7'
     compile 'org.postgresql:postgresql:9.2-1002-jdbc4'
 
-    compile 'net.java.dev.glazedlists:glazedlists_java15:1.8.0'
+    compile 'net.java.dev.glazedlists:glazedlists_java15:1.9.1'
     compile fileTree(dir: 'lib', includes: ['microba.jar', 'spin.jar'])
 
     compile 'net.java.dev.jna:jna:4.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -92,8 +92,8 @@ dependencies {
     antlr3 'org.antlr:antlr:3.4'
     compile 'org.antlr:antlr-runtime:3.4'
 
-    compile 'mysql:mysql-connector-java:5.0.7'
-    compile 'org.postgresql:postgresql:9.2-1002-jdbc4'
+    compile 'mysql:mysql-connector-java:5.1.36'
+    compile 'org.postgresql:postgresql:9.4-1201-jdbc41'
 
     compile 'net.java.dev.glazedlists:glazedlists_java15:1.9.1'
     compile fileTree(dir: 'lib', includes: ['microba.jar', 'spin.jar'])

--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ dependencies {
 
     compile 'com.google.guava:guava:18.0'
 
-    compile 'commons-logging:commons-logging:1.0.2'
+    compile 'commons-logging:commons-logging:1.2'
     // not available in maven repository
     compile fileTree(dir: 'lib/plugin', includes: ['jpf.jar', 'jpf-boot.jar', 'JPFCodeGenerator-rt.jar'])
 

--- a/build.gradle
+++ b/build.gradle
@@ -77,9 +77,9 @@ dependencies {
     
     compile 'org.swinglabs:swingx:1.6.1'
 
-    compile 'org.apache.pdfbox:pdfbox:1.7.1'
-    compile 'org.apache.pdfbox:fontbox:1.7.1'
-    compile 'org.apache.pdfbox:jempbox:1.7.1'
+    compile 'org.apache.pdfbox:pdfbox:1.8.9'
+    compile 'org.apache.pdfbox:fontbox:1.8.9'
+    compile 'org.apache.pdfbox:jempbox:1.8.9'
 
     compile 'commons-cli:commons-cli:1.3.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -71,9 +71,9 @@ configurations {
 dependencies {
 
     // jgoodies
-    compile 'com.jgoodies:jgoodies-common:1.4.0'
-    compile 'com.jgoodies:jgoodies-forms:1.6.0'
-    compile 'com.jgoodies:jgoodies-looks:2.5.2'
+    compile 'com.jgoodies:jgoodies-common:1.7.0'
+    compile 'com.jgoodies:jgoodies-forms:1.7.2'
+    compile 'com.jgoodies:jgoodies-looks:2.5.3'
     
     compile 'org.swinglabs:swingx:1.6.1'
 


### PR DESCRIPTION
This pull request updates all dependencies to their newest versions. 

The only dependency for which this is not possible is antlr3. Here the upgrade from 3.4 to 3.5.2 would introduce API-breaking changes.