### PR TITLE
fixed incompatibility with INSPIRE output page

### DIFF
--- a/src/main/java/net/sf/jabref/imports/INSPIREBibtexFilterReader.java
+++ b/src/main/java/net/sf/jabref/imports/INSPIREBibtexFilterReader.java
@@ -57,11 +57,11 @@ class INSPIREBibtexFilterReader extends FilterReader {
             if (l == null) {
                 return null;
             }
-            if (l.indexOf("<pre>") != -1) {
+            if (l.contains("<pre>")) {
                 pre = true;
                 l = in.readLine();
             }
-            if (l.indexOf("</pre>") != -1) {
+            if (l.contains("</pre>")) {
                 pre = false;
             }
         } while (!pre);

--- a/src/main/java/net/sf/jabref/imports/INSPIREBibtexFilterReader.java
+++ b/src/main/java/net/sf/jabref/imports/INSPIREBibtexFilterReader.java
@@ -57,11 +57,11 @@ class INSPIREBibtexFilterReader extends FilterReader {
             if (l == null) {
                 return null;
             }
-            if (l.equals("<pre>")) {
+            if (l.indexOf("<pre>") != -1) {
                 pre = true;
                 l = in.readLine();
             }
-            if (l.equals("</pre>")) {
+            if (l.indexOf("</pre>") != -1) {
                 pre = false;
             }
         } while (!pre);


### PR DESCRIPTION
Due to a change in the html output of the INSPIRE search, JabRef was no more able to distinguish the interesting output from the rest of the page. It was due to a missing newline character.