### PR TITLE
Refer to new issue tracker

### DIFF
--- a/src/main/resources/help/About.html
+++ b/src/main/resources/help/About.html
@@ -16,10 +16,9 @@
     version 2 of the License, or (at your option) any later version.</p>
 
     <p>The source code and documentation can be found at the homepage of JabRef <a href="http://jabref.sourceforge.net/">http://jabref.sourceforge.net/</a>.
-        Please submit bugs to
-        <a href="https://sourceforge.net/p/jabref/bugs/">https://sourceforge.net/p/jabref/bugs/</a>
-        and feature requests to
-        <a href="https://sourceforge.net/p/jabref/feature-requests/">https://sourceforge.net/p/jabref/feature-requests/</a>.</p>
+        Please submit bugs and feature requests to
+        <a href="https://github.com/JabRef/jabref/issues">https://github.com/JabRef/jabref/issues</a>.
+    </p>
 
         <h2>Current developers:</h2>
         <p>Simon Harrer,

--- a/src/main/resources/help/About.html
+++ b/src/main/resources/help/About.html
@@ -15,7 +15,7 @@
     License</a> as published by the Free Software Foundation, either
     version 2 of the License, or (at your option) any later version.</p>
 
-    <p>The source code and documentation can be found at the homepage of JabRef <a href="http://jabref.sourceforge.net/">http://jabref.sourceforge.net/</a>.
+    <p>The source code and documentation can be found at <a href="https://github.com/JabRef/jabref/">https://github.com/JabRef/jabref/</a>.
         Please submit bugs and feature requests to
         <a href="https://github.com/JabRef/jabref/issues">https://github.com/JabRef/jabref/issues</a>.
     </p>


### PR DESCRIPTION
I replaced the information for the old SF bug tracker inside the GUI application.
Am I missing any locations? 
At the moment it is only replaced inside `About.html`.