### PR TITLE
Fix package declaration in LabelPatternUtilTest

### DIFF
--- a/src/test/java/net/sf/jabref/logic/labelPattern/LabelPatternUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/labelPattern/LabelPatternUtilTest.java
@@ -1,4 +1,4 @@
-package net.sf.jabref.gui.labelPattern;
+package net.sf.jabref.logic.labelPattern;
 
 import net.sf.jabref.BibtexDatabase;
 import net.sf.jabref.BibtexEntry;


### PR DESCRIPTION
The package declaration in this class is syntactically wrong. For some reason, this does not bother gradle, which still runs the test (Eclipse, however, doesn't). This is kind of alarming, since this code should not compile.