### PR TITLE
[WIP] Rewrite and test layout formatter

### DIFF
--- a/src/main/java/net/sf/jabref/export/layout/format/RemoveBrackets.java
+++ b/src/main/java/net/sf/jabref/export/layout/format/RemoveBrackets.java
@@ -1,67 +1,25 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*/
-///////////////////////////////////////////////////////////////////////////////
-//  Filename: $RCSfile$
-//  Purpose:  Atom representation.
-//  Language: Java
-//  Compiler: JDK 1.4
-//  Authors:  Joerg K. Wegner
-//  Version:  $Revision$
-//            $Date$
-//            $Author$
-//
-//  Copyright (c) Dept. Computer Architecture, University of Tuebingen, Germany
-//
-//  This program is free software; you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation version 2 of the License.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-///////////////////////////////////////////////////////////////////////////////
-
 package net.sf.jabref.export.layout.format;
 
 import net.sf.jabref.export.layout.LayoutFormatter;
 
 /**
  * Remove brackets formatter.
+ *
+ * <example>
+ *     "{Stefan Kolb}" -> "Stefan Kolb"
+ * </example>
  */
 public class RemoveBrackets implements LayoutFormatter
 {
-
     @Override
-    public String format(String fieldText)
-    {
-        String fieldEntry = fieldText;
-        StringBuilder sb = new StringBuilder(fieldEntry.length());
+    public String format(String fieldText) {
+        StringBuilder builder = new StringBuilder(fieldText.length());
 
-        for (int i = 0; i < fieldEntry.length(); i++)
-        {
-            //System.out.print(fieldEntry.charAt(i));
-            if (fieldEntry.charAt(i) != '{' && fieldEntry.charAt(i) != '}')
-            {
-                //System.out.print(fieldEntry.charAt(i));
-                sb.append(fieldEntry.charAt(i));
+        for (char c: fieldText.toCharArray()) {
+            if (c != '{' && c != '}') {
+                builder.append(c);
             }
         }
-
-        fieldEntry = sb.toString();
-        return fieldEntry;
+        return builder.toString();
     }
 }

--- a/src/main/java/net/sf/jabref/export/layout/format/RemoveBracketsAddComma.java
+++ b/src/main/java/net/sf/jabref/export/layout/format/RemoveBracketsAddComma.java
@@ -1,40 +1,3 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*/
-///////////////////////////////////////////////////////////////////////////////
-//  Filename: $RCSfile$
-//  Purpose:  Atom representation.
-//  Language: Java
-//  Compiler: JDK 1.4
-//  Authors:  Joerg K. Wegner
-//  Version:  $Revision$
-//            $Date$
-//            $Author$
-//
-//  Copyright (c) Dept. Computer Architecture, University of Tuebingen, Germany
-//
-//  This program is free software; you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation version 2 of the License.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-///////////////////////////////////////////////////////////////////////////////
-
 package net.sf.jabref.export.layout.format;
 
 import net.sf.jabref.export.layout.LayoutFormatter;
@@ -42,30 +5,18 @@ import net.sf.jabref.export.layout.LayoutFormatter;
 /**
  * Remove brackets formatter.
  */
-public class RemoveBracketsAddComma implements LayoutFormatter
-{
-
+public class RemoveBracketsAddComma implements LayoutFormatter {
     @Override
-    public String format(String fieldText)
-    {
-        String fieldEntry = fieldText;
-        StringBuilder sb = new StringBuilder(fieldEntry.length());
+    public String format(String fieldText) {
+        StringBuilder builder = new StringBuilder(fieldText.length());
 
-        for (int i = 0; i < fieldEntry.length(); i++)
-        {
-            //System.out.print(fieldEntry.charAt(i));
-            if (fieldEntry.charAt(i) != '{' && fieldEntry.charAt(i) != '}')
-            {
-                //System.out.print(fieldEntry.charAt(i));
-                sb.append(fieldEntry.charAt(i));
-            }
-            if (fieldEntry.charAt(i) == '}')
-            {
-                sb.append(',');
+        for (char c: fieldText.toCharArray()) {
+            if (c != '{' && c != '}') {
+                builder.append(c);
+            } else if (c == '}') {
+                builder.append(',');
             }
         }
-
-        fieldEntry = sb.toString();
-        return fieldEntry;
+        return builder.toString();
     }
 }

--- a/src/main/java/net/sf/jabref/export/layout/format/RemoveTilde.java
+++ b/src/main/java/net/sf/jabref/export/layout/format/RemoveTilde.java
@@ -1,40 +1,3 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*/
-///////////////////////////////////////////////////////////////////////////////
-//  Filename: $RCSfile$
-//  Purpose:  Atom representation.
-//  Language: Java
-//  Compiler: JDK 1.4
-//  Authors:  Joerg K. Wegner
-//  Version:  $Revision$
-//            $Date$
-//            $Author$
-//
-//  Copyright (c) Dept. Computer Architecture, University of Tuebingen, Germany
-//
-//  This program is free software; you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation version 2 of the License.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-///////////////////////////////////////////////////////////////////////////////
-
 package net.sf.jabref.export.layout.format;
 
 import net.sf.jabref.export.layout.LayoutFormatter;
@@ -45,10 +8,8 @@ import net.sf.jabref.export.layout.LayoutFormatter;
  * Useful for formatting Latex code.
  */
 public class RemoveTilde implements LayoutFormatter {
-
     @Override
     public String format(String fieldText) {
-
         StringBuilder result = new StringBuilder(fieldText.length());
 
         char[] c = fieldText.toCharArray();
@@ -66,7 +27,6 @@ public class RemoveTilde implements LayoutFormatter {
                 result.append(' ');
             }
         }
-
         return result.toString();
     }
 }

--- a/src/main/resources/help/CustomExports.html
+++ b/src/main/resources/help/CustomExports.html
@@ -197,15 +197,6 @@
     distribute a collection of submitted layout files, or to add to
     the selection of standard export filters and formatters.</p>
 
-    <p>Starting with JabRef 2.4 you can also package your 
-	ExportFormat or LayoutFormatter as a plug-in. If you do so,
-	you can provide a single zip-file to other user to make use
-	of your ExportFormat. For an example download the JabRef
-	source release and have a look at the directory
-	<code>src/resources/plugins/</code>. Don't hesitate to stop by the
-	forums on Sourceforge, since we don't have extensive documentation, yet.</p>
-
-
     <h2>Built-in export formatters</h2>
 
     <p>JabRef provides the following set of formatters:</p>

--- a/src/test/java/net/sf/jabref/export/layout/format/RemoveBracketsAddCommaTest.java
+++ b/src/test/java/net/sf/jabref/export/layout/format/RemoveBracketsAddCommaTest.java
@@ -1,0 +1,24 @@
+package net.sf.jabref.export.layout.format;
+
+import junit.framework.Assert;
+import net.sf.jabref.export.layout.LayoutFormatter;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RemoveBracketsAddCommaTest {
+    private LayoutFormatter formatter;
+
+    @Before
+    public void setup() {
+        formatter = new RemoveBracketsAddComma();
+    }
+
+    @Test
+    public void testFormat() throws Exception {
+        Assert.assertEquals("some text,", formatter.format("{some text}"));
+        Assert.assertEquals("some text", formatter.format("{some text"));
+        Assert.assertEquals("some text,", formatter.format("some text}"));
+    }
+}

--- a/src/test/java/net/sf/jabref/export/layout/format/RemoveBracketsTest.java
+++ b/src/test/java/net/sf/jabref/export/layout/format/RemoveBracketsTest.java
@@ -1,0 +1,25 @@
+package net.sf.jabref.export.layout.format;
+
+import junit.framework.Assert;
+import net.sf.jabref.export.layout.LayoutFormatter;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RemoveBracketsTest {
+    private LayoutFormatter formatter;
+
+    @Before
+    public void setup() {
+        formatter = new RemoveBrackets();
+    }
+
+    @Test
+    public void testFormat() throws Exception {
+        Assert.assertEquals("some text", formatter.format("{some text}"));
+        Assert.assertEquals("some text", formatter.format("{some text"));
+        Assert.assertEquals("some text", formatter.format("some text}"));
+        Assert.assertEquals("\\some text\\", formatter.format("\\{some text\\}"));
+    }
+}


### PR DESCRIPTION
# Rationale
1. The layout formatter feature is a bit hidden and it is unclear how many people really use this feature.
2. The feature is complex to use
2. Some of the formatters should be a) integrated as default auto formatters b) removed because they really don't make a lot of sense.
3. Most license problems are caused by these classes.

# List
> - __Authors__ : this formatter provides formatting options for the author and editor fields; for detailed information, see below. It deprecates a range of dedicated formatters provided in versions of JabRef prior to 2.7.

> - __CreateBibORDFAuthors__ : formats authors for according to the requirements of the Bibliographic Ontology (bibo).

> - __CreateDocBookAuthors__ : formats the author field in DocBook style.

> - __CreateDocBookEditors__ : formats the editor field in DocBook style.

> - __CurrentDate__: outputs the current date. With no argument, this formatter outputs the current date and time in the format "yyyy.MM.dd hh:mm:ss z" (date, time and time zone). By giving a different format string as argument, the date format can be customized. E.g. \format[CurrentDate]{yyyy.MM.dd} will give the date only, e.g. 2005.11.30.

> - Default : takes a single argument, which serves as a default value. If the string to format is non-empty, it is output without changes. If it is empty, the default value is output. For instance, \format[Default(unknown)]{\year} will output the entry's year if set, and "unknown" if no year is set.

> __DOIStrip__: strips any prefixes from the DOI string.

Should be automatically integrated as sensible default!

> __DOICheck__ : provides the full url for a DOI link.

DOICheck as name makes no sense. Rename at least to DOILink.

> - FileLink(filetype) : if no argument is given, this formatter outputs the first external file link encoded in the field. To work, the formatter must be supplied with the contents of the "file" field.
This formatter takes the name of an external file type as an optional argument, specified in parentheses after the formatter name. For instance, \format[FileLink(pdf)]{\file} specifies pdf as an argument. When an argument is given, the formatter selects the first file link of the specified type. In the example, the path to the first PDF link will be output.

> - FirstPage : returns the first page from the "pages" field, if set. For instance, if the pages field is set to "345-360" or "345--360", this formatter will return "345".

> - FormatChars : This formatter converts LaTeX character sequences their equicalent unicode characters and removes other LaTeX commands without handling them.

> - FormatPagesForHTML : replaces "--" with "-".

> - FormatPagesForXML : replaces "--" with an XML en-dash.

> - GetOpenOfficeType : returns the number used by the OpenOffice.org bibliography system (versions 1.x and 2.x) to denote the type of this entry.

> - HTMLChars : replaces TeX-specific special characters (e.g. {\^a} or {\"{o}}) with their HTML representations, and translates LaTeX commands \emph, \textit, \textbf into HTML equivalents.

> - HTMLParagraphs : interprets two consecutive newlines (e.g. \n \n) as the beginning of a new paragraph and creates paragraph-html-tags accordingly.

> - IfPlural : outputs its first argument if the input field looks like an author list with two or more names, or its second argument otherwise. E.g. \format[IfPlural(Eds.,Ed.)]{\editor} will output "Eds." if there is more than one editor, and "Ed." if there is only one.

> - JournalAbbreviator : The given input text is abbreviated according to the journal abbreviation lists. If no abbreviation for input is found (e.g. not in list or already abbreviated), the input will be returned unmodified. For instance, when using \format[JournalAbbreviator]{\journal}, "Physical Review - Letters" gets "Phys. Rev. Lett."

> - LastPage : returns the last page from the "pages" field, if set. For instance, if the pages field is set to "345-360" or "345--360", this formatter will return "360".

> - NoSpaceBetweenAbbreviations : LayoutFormatter that removes the space between abbreviated First names. Example: J. R. R. Tolkien becomes J.R.R. Tolkien.

> - NotFoundFormatter : Formatter used to signal that a formatter hasn't been found. This can be used for graceful degradation if a layout uses an undefined format.

> - Number : outputs the 1-based sequence number of the current entry in the current export. This formatter can be used to make a numbered list of entries. The sequence number depends on the current entry's place in the current sort order, not on the number of calls to this formatter.

>__RemoveBrackets__ : removes all curly brackets "{" or "}".

This just removes __all__ brackets without checking for escape sequences or such, e.g. \{.

>__RemoveBracketsAddComma__: removes all curly brackets "{" or "}". The closing curly bracket is replaced by a comma.

I don't see any use case where I want to do this.

- RemoveLatexCommands : removes LaTeX commands like \em, \textbf, etc. If used together with HTMLChars or XMLChars, this formatter should be called last.

> __RemoveTilde__: replaces the tilde character used in LaTeX as a non-breakable space by a regular space. Useful in combination with the NameFormatter discussed in the next section.



>__RemoveWhitespace__: removes all whitespace characters.

Where would this make any sense?


> - Replace(regexp,replacewith) : does a regular expression replacement. To use this formatter, a two-part argument must be given. The parts are separated by a comma. To indicate the comma character, use an escape sequence: \,   The first part is the regular expression to search for. Remember that any commma character must be preceded by a backslash, and consequently a literal backslash must be written as a pair of backslashes. A description of Java regular expressions can be found at:  http://java.sun.com/j2se/1.4.2/docs/api/java/util/regex/Pattern.html   The second part is the text to replace all matches with.

>__RisAuthors__ : to be documented.
__RisKeywords__ : to be documented.
__RisMonth__ : to be documented.

[Biblioscape](http://www.biblioscape.com/) formatter?

> - RTFChars : replaces TeX-specific special characters (e.g. {\^a} or {\"{o}}) with their RTF representations, and translates LaTeX commands \emph, \textit, \textbf into RTF equivalents.

> - ToLowerCase : turns all characters into lower case.

> - ToUpperCase : turns all characters into upper case.

> - WrapContent : This formatter outputs the input value after adding a prefix and a postfix, as long as the input value is non-empty. If the input value is empty, an empty string is output (the prefix and postfix are not output in this case). The formatter requires an argument containing the prefix and postix separated by a comma. To include the comma character in either, use an escape sequence (\,).

> - WrapFileLinks : See below.

> - XMLChars : : replaces TeX-specific special
        characters (e.g. {\^a} or {\"{o}}) with their XML
        representations.

# Decisions
