### PR TITLE
Fix SF Bug #1285

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@
     - Streamline logging API: Replace usages of java.util.logging with commons.logging
     - BREAKING: Remove plugin functionality.
     - Fixes Bug#1297: No console message on closing.
+    - Fix bug #1285: Editing position is not lost on saving
 [dev_2.11]
     - Add of Persian localization (by Behrouz Javanmardi)
     - Backport from 2.80: Fixes #115: Remove whitespaces in serialization

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -1190,6 +1190,8 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
             if (event.getSource() instanceof TextField) {
                 // Storage from bibtex key field.
                 TextField textField = (TextField) event.getSource();
+                // get current caret position to restore current editing position after saving
+                int initialCaretPosition = textField.getCaretPosition();
                 String oldValue = entry.getCiteKey();
                 String newValue = textField.getText();
 
@@ -1241,9 +1243,17 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                 }
                 updateSource();
                 panel.markBaseChanged();
+                // set cursor back to the initial position
+                textField.setCaretPosition(initialCaretPosition);
             } else if (event.getSource() instanceof FieldEditor) {
                 String toSet = null;
                 FieldEditor fieldEditor = (FieldEditor) event.getSource();
+                // get current caret position to restore current editing position after saving
+                // (is only possible if fieldEditor is an instance of JTextComponent)
+                int initialCaretPosition = 0;
+                if(fieldEditor instanceof JTextComponent) {
+                    initialCaretPosition = ((JTextComponent) fieldEditor).getCaretPosition();
+                }
                 boolean set;
                 // Trim the whitespace off this value
                 String currentText = fieldEditor.getText();
@@ -1298,6 +1308,10 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                         }
                         updateSource();
                         panel.markBaseChanged();
+                        // set caret back to initial edit position
+                        if(fieldEditor instanceof JTextComponent) {
+                            ((JTextComponent) fieldEditor).setCaretPosition(initialCaretPosition);
+                        }
                     } catch (IllegalArgumentException ex) {
                         JOptionPane.showMessageDialog(frame, Localization.lang("Error") + ": " + ex.getMessage(),
                                 Localization.lang("Error setting field"), JOptionPane.ERROR_MESSAGE);

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -1190,8 +1190,6 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
             if (event.getSource() instanceof TextField) {
                 // Storage from bibtex key field.
                 TextField textField = (TextField) event.getSource();
-                // get current caret position to restore current editing position after saving
-                int initialCaretPosition = textField.getCaretPosition();
                 String oldValue = entry.getCiteKey();
                 String newValue = textField.getText();
 
@@ -1243,17 +1241,9 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                 }
                 updateSource();
                 panel.markBaseChanged();
-                // set cursor back to the initial position
-                textField.setCaretPosition(initialCaretPosition);
             } else if (event.getSource() instanceof FieldEditor) {
                 String toSet = null;
                 FieldEditor fieldEditor = (FieldEditor) event.getSource();
-                // get current caret position to restore current editing position after saving
-                // (is only possible if fieldEditor is an instance of JTextComponent)
-                int initialCaretPosition = 0;
-                if(fieldEditor instanceof JTextComponent) {
-                    initialCaretPosition = ((JTextComponent) fieldEditor).getCaretPosition();
-                }
                 boolean set;
                 // Trim the whitespace off this value
                 String currentText = fieldEditor.getText();
@@ -1308,10 +1298,6 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                         }
                         updateSource();
                         panel.markBaseChanged();
-                        // set caret back to initial edit position
-                        if(fieldEditor instanceof JTextComponent) {
-                            ((JTextComponent) fieldEditor).setCaretPosition(initialCaretPosition);
-                        }
                     } catch (IllegalArgumentException ex) {
                         JOptionPane.showMessageDialog(frame, Localization.lang("Error") + ": " + ex.getMessage(),
                                 Localization.lang("Error setting field"), JOptionPane.ERROR_MESSAGE);

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditorTab.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditorTab.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.swing.*;
+import javax.swing.text.JTextComponent;
 
 import net.sf.jabref.*;
 import net.sf.jabref.gui.*;
@@ -295,7 +296,14 @@ class EntryEditorTab {
             return false;
         }
         FieldEditor fieldEditor = editors.get(field);
-        fieldEditor.setText(content);
+        // trying to preserve current edit position (fixes SF bug #1285)
+        if(fieldEditor.getTextComponent() instanceof JTextComponent) {
+            int initialCaretPosition = ((JTextComponent) fieldEditor).getCaretPosition();
+            fieldEditor.setText(content);
+            ((JTextComponent) fieldEditor).setCaretPosition(initialCaretPosition);
+        } else {
+            fieldEditor.setText(content);
+        }
         return true;
     }
 


### PR DESCRIPTION
Restores the cursor resp. "caret" position when a field is store during editing.
This fixes [SF.net bug #1285](http://sourceforge.net/p/jabref/bugs/1285/).

To be done: 
- Backport to dev_2.11
- Ask for confirmation on SF.net and close the issue there.