### PR TITLE
Remove option to set custom icon theme

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
     - BREAKING: Remove plugin functionality.
     - Fixes Bug#1297: No console message on closing.
     - Fix bug #1285: Editing position is not lost on saving
+    - Remove support for custom icon themes. The user has to use the default one.
 [dev_2.11]
     - Add of Persian localization (by Behrouz Javanmardi)
     - Backport from 2.80: Fixes #115: Remove whitespaces in serialization

--- a/src/main/java/net/sf/jabref/Globals.java
+++ b/src/main/java/net/sf/jabref/Globals.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 
 public class Globals {
+
     private static final Log LOGGER = LogFactory.getLog(Globals.class);
 
     // JabRef version info
@@ -51,6 +52,7 @@ public class Globals {
     public static final String JOURNALS_IEEE_INTERNAL_LIST = "/journals/IEEEJournalList.txt";
 
     public static JournalAbbreviationRepository journalAbbrev;
+
 
     public static void initializeJournalNames() {
         // Read internal lists:
@@ -79,12 +81,12 @@ public class Globals {
             try {
                 Globals.journalAbbrev.readJournalListFromFile(new File(Globals.prefs.get(JabRefPreferences.PERSONAL_JOURNAL_LIST)));
             } catch (FileNotFoundException e) {
-                LOGGER.info("Personal journal list file '" + Globals.prefs.get(JabRefPreferences.PERSONAL_JOURNAL_LIST)
-                        + "' not found.", e);
+                LOGGER.info("Personal journal list file '" + Globals.prefs.get(JabRefPreferences.PERSONAL_JOURNAL_LIST) + "' not found.", e);
             }
         }
 
     }
+
 
     public static final ImportFormatReader importFormatReader = new ImportFormatReader();
 
@@ -107,6 +109,7 @@ public class Globals {
     public static FileUpdateMonitor fileUpdateMonitor;
     public static StreamEavesdropper streamEavesdropper;
 
+
     public static void startBackgroundTasks() {
         Globals.focusListener = new GlobalFocusListener();
 
@@ -116,8 +119,10 @@ public class Globals {
         JabRefExecutorService.INSTANCE.executeWithLowPriorityInOwnThread(Globals.fileUpdateMonitor, "FileUpdateMonitor");
     }
 
+
     // Autosave manager
     public static AutoSaveManager autoSaveManager;
+
 
     public static void startAutoSaveManager(JabRefFrame frame) {
         Globals.autoSaveManager = new AutoSaveManager(frame);

--- a/src/main/java/net/sf/jabref/JabRef.java
+++ b/src/main/java/net/sf/jabref/JabRef.java
@@ -288,10 +288,6 @@ public class JabRef {
             }
         }
 
-        // Set up custom or default icon theme
-        // Has to be done here as openBibFile requires an initialized icon theme (due to the implementation of special fields)
-        GUIGlobals.setUpIconTheme();
-
         // Vector to put imported/loaded database(s) in.
         Vector<ParserResult> loaded = new Vector<ParserResult>();
         Vector<String> toImport = new Vector<String>();

--- a/src/main/java/net/sf/jabref/JabRefMain.java
+++ b/src/main/java/net/sf/jabref/JabRefMain.java
@@ -4,6 +4,7 @@ package net.sf.jabref;
  * JabRef MainClass
  */
 public class JabRefMain {
+
     public static void main(String[] args) {
         new JabRef().start(args);
     }

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -36,8 +36,7 @@ import java.net.UnknownHostException;
 import javax.swing.JTable;
 import javax.swing.KeyStroke;
 
-import net.sf.jabref.gui.BibtexFields;
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.*;
 import net.sf.jabref.gui.entryeditor.EntryEditorTabList;
 import net.sf.jabref.gui.keyboard.KeyBinds;
 import net.sf.jabref.gui.preftabs.ImportSettingsTab;
@@ -54,8 +53,6 @@ import net.sf.jabref.exporter.ExportComparator;
 import net.sf.jabref.external.DroppedFileHandler;
 import net.sf.jabref.external.ExternalFileType;
 import net.sf.jabref.external.UnknownExternalFileType;
-import net.sf.jabref.gui.CleanUpAction;
-import net.sf.jabref.gui.PersistenceTableColumnListener;
 import net.sf.jabref.importer.CustomImportList;
 import net.sf.jabref.logic.remote.RemotePreferences;
 import net.sf.jabref.specialfields.SpecialFieldsUtils;
@@ -376,7 +373,7 @@ public class JabRefPreferences {
     // Map containing all registered external file types:
     private final TreeSet<ExternalFileType> externalFileTypes = new TreeSet<ExternalFileType>();
 
-    private final ExternalFileType HTML_FALLBACK_TYPE = new ExternalFileType("URL", "html", "text/html", "", "www");
+    private final ExternalFileType HTML_FALLBACK_TYPE = new ExternalFileType("URL", "html", "text/html", "", "www", IconTheme.getImage("www"));
 
     // The following field is used as a global variable during the export of a database.
     // By setting this field to the path of the database's default file directory, formatters
@@ -1389,29 +1386,29 @@ public class JabRefPreferences {
 
     public List<ExternalFileType> getDefaultExternalFileTypes() {
         List<ExternalFileType> list = new ArrayList<ExternalFileType>();
-        list.add(new ExternalFileType("PDF", "pdf", "application/pdf", "evince", "pdfSmall"));
-        list.add(new ExternalFileType("PostScript", "ps", "application/postscript", "evince", "psSmall"));
-        list.add(new ExternalFileType("Word", "doc", "application/msword", "oowriter", "openoffice"));
-        list.add(new ExternalFileType("Word 2007+", "docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "oowriter", "openoffice"));
-        list.add(new ExternalFileType("OpenDocument text", "odt", "application/vnd.oasis.opendocument.text", "oowriter", "openoffice"));
-        list.add(new ExternalFileType("Excel", "xls", "application/excel", "oocalc", "openoffice"));
-        list.add(new ExternalFileType("Excel 2007+", "xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "oocalc", "openoffice"));
-        list.add(new ExternalFileType("OpenDocument spreadsheet", "ods", "application/vnd.oasis.opendocument.spreadsheet", "oocalc", "openoffice"));
-        list.add(new ExternalFileType("PowerPoint", "ppt", "application/vnd.ms-powerpoint", "ooimpress", "openoffice"));
-        list.add(new ExternalFileType("PowerPoint 2007+", "pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation", "ooimpress", "openoffice"));
-        list.add(new ExternalFileType("OpenDocument presentation", "odp", "application/vnd.oasis.opendocument.presentation", "ooimpress", "openoffice"));
-        list.add(new ExternalFileType("Rich Text Format", "rtf", "application/rtf", "oowriter", "openoffice"));
-        list.add(new ExternalFileType("PNG image", "png", "image/png", "gimp", "picture"));
-        list.add(new ExternalFileType("GIF image", "gif", "image/gif", "gimp", "picture"));
-        list.add(new ExternalFileType("JPG image", "jpg", "image/jpeg", "gimp", "picture"));
-        list.add(new ExternalFileType("Djvu", "djvu", "", "evince", "psSmall"));
-        list.add(new ExternalFileType("Text", "txt", "text/plain", "emacs", "emacs"));
-        list.add(new ExternalFileType("LaTeX", "tex", "application/x-latex", "emacs", "emacs"));
-        list.add(new ExternalFileType("CHM", "chm", "application/mshelp", "gnochm", "www"));
-        list.add(new ExternalFileType("TIFF image", "tiff", "image/tiff", "gimp", "picture"));
-        list.add(new ExternalFileType("URL", "html", "text/html", "firefox", "www"));
-        list.add(new ExternalFileType("MHT", "mht", "multipart/related", "firefox", "www"));
-        list.add(new ExternalFileType("ePUB", "epub", "application/epub+zip", "firefox", "www"));
+        list.add(new ExternalFileType("PDF", "pdf", "application/pdf", "evince", "pdfSmall", IconTheme.getImage("pdfSmall")));
+        list.add(new ExternalFileType("PostScript", "ps", "application/postscript", "evince", "psSmall", IconTheme.getImage("psSmall")));
+        list.add(new ExternalFileType("Word", "doc", "application/msword", "oowriter", "openoffice", IconTheme.getImage("openoffice")));
+        list.add(new ExternalFileType("Word 2007+", "docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "oowriter", "openoffice", IconTheme.getImage("openoffice")));
+        list.add(new ExternalFileType("OpenDocument text", "odt", "application/vnd.oasis.opendocument.text", "oowriter", "openoffice", IconTheme.getImage("openoffice")));
+        list.add(new ExternalFileType("Excel", "xls", "application/excel", "oocalc", "openoffice", IconTheme.getImage("openoffice")));
+        list.add(new ExternalFileType("Excel 2007+", "xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "oocalc", "openoffice", IconTheme.getImage("openoffice")));
+        list.add(new ExternalFileType("OpenDocument spreadsheet", "ods", "application/vnd.oasis.opendocument.spreadsheet", "oocalc", "openoffice", IconTheme.getImage("openoffice")));
+        list.add(new ExternalFileType("PowerPoint", "ppt", "application/vnd.ms-powerpoint", "ooimpress", "openoffice", IconTheme.getImage("openoffice")));
+        list.add(new ExternalFileType("PowerPoint 2007+", "pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation", "ooimpress", "openoffice", IconTheme.getImage("openoffice")));
+        list.add(new ExternalFileType("OpenDocument presentation", "odp", "application/vnd.oasis.opendocument.presentation", "ooimpress", "openoffice", IconTheme.getImage("openoffice")));
+        list.add(new ExternalFileType("Rich Text Format", "rtf", "application/rtf", "oowriter", "openoffice", IconTheme.getImage("openoffice")));
+        list.add(new ExternalFileType("PNG image", "png", "image/png", "gimp", "picture", IconTheme.getImage("picture")));
+        list.add(new ExternalFileType("GIF image", "gif", "image/gif", "gimp", "picture", IconTheme.getImage("picture")));
+        list.add(new ExternalFileType("JPG image", "jpg", "image/jpeg", "gimp", "picture", IconTheme.getImage("picture")));
+        list.add(new ExternalFileType("Djvu", "djvu", "", "evince", "psSmall", IconTheme.getImage("psSmall")));
+        list.add(new ExternalFileType("Text", "txt", "text/plain", "emacs", "emacs", IconTheme.getImage("emacs")));
+        list.add(new ExternalFileType("LaTeX", "tex", "application/x-latex", "emacs", "emacs", IconTheme.getImage("emacs")));
+        list.add(new ExternalFileType("CHM", "chm", "application/mshelp", "gnochm", "www", IconTheme.getImage("www")));
+        list.add(new ExternalFileType("TIFF image", "tiff", "image/tiff", "gimp", "picture", IconTheme.getImage("picture")));
+        list.add(new ExternalFileType("URL", "html", "text/html", "firefox", "www", IconTheme.getImage("www")));
+        list.add(new ExternalFileType("MHT", "mht", "multipart/related", "firefox", "www", IconTheme.getImage("www")));
+        list.add(new ExternalFileType("ePUB", "epub", "application/epub+zip", "firefox", "www", IconTheme.getImage("www")));
 
         // On all OSes there is a generic application available to handle file opening,
         // so we don't need the default application settings anymore:

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -227,8 +227,6 @@ public class JabRefPreferences {
     public static final String FONT_SIZE = "fontSize";
     public static final String FONT_STYLE = "fontStyle";
     public static final String HISTORY_SIZE = "historySize";
-    public static final String CUSTOM_ICON_THEME_FILE = "customIconThemeFile";
-    public static final String USE_CUSTOM_ICON_THEME = "useCustomIconTheme";
     public static final String GENERAL_FIELDS = "generalFields";
     public static final String RENAME_ON_MOVE_FILE_TO_FILE_DIR = "renameOnMoveFileToFileDir";
     public static final String MEMORY_STICK_MODE = "memoryStickMode";
@@ -635,9 +633,6 @@ public class JabRefPreferences {
         // The general fields stuff is made obsolete by the CUSTOM_TAB_... entries.
         defaults.put(GENERAL_FIELDS, "crossref;keywords;file;doi;url;urldate;"
                 + "pdf;comment;owner");
-
-        defaults.put(USE_CUSTOM_ICON_THEME, Boolean.FALSE);
-        defaults.put(CUSTOM_ICON_THEME_FILE, "/home/alver/div/crystaltheme_16/Icons.properties");
 
         defaults.put(HISTORY_SIZE, 8);
         defaults.put(FONT_STYLE, java.awt.Font.PLAIN);

--- a/src/main/java/net/sf/jabref/collab/FileUpdatePanel.java
+++ b/src/main/java/net/sf/jabref/collab/FileUpdatePanel.java
@@ -39,7 +39,7 @@ public class FileUpdatePanel extends SidePaneComponent implements ActionListener
 
     public FileUpdatePanel(JabRefFrame frame, BasePanel panel, SidePaneManager manager, File file,
             ChangeScanner scanner) {
-        super(manager, IconTheme.getIconUrl("save"), Localization.lang("File changed"));
+        super(manager, IconTheme.getImage("save"), Localization.lang("File changed"));
         close.setEnabled(false);
         this.panel = panel;
         this.manager = manager;

--- a/src/main/java/net/sf/jabref/collab/FileUpdatePanel.java
+++ b/src/main/java/net/sf/jabref/collab/FileUpdatePanel.java
@@ -39,7 +39,7 @@ public class FileUpdatePanel extends SidePaneComponent implements ActionListener
 
     public FileUpdatePanel(JabRefFrame frame, BasePanel panel, SidePaneManager manager, File file,
             ChangeScanner scanner) {
-        super(manager, GUIGlobals.getIconUrl("save"), Localization.lang("File changed"));
+        super(manager, IconTheme.getIconUrl("save"), Localization.lang("File changed"));
         close.setEnabled(false);
         this.panel = panel;
         this.manager = manager;

--- a/src/main/java/net/sf/jabref/exporter/SaveAllAction.java
+++ b/src/main/java/net/sf/jabref/exporter/SaveAllAction.java
@@ -20,10 +20,7 @@ import java.awt.event.ActionEvent;
 import javax.swing.Action;
 
 import net.sf.jabref.*;
-import net.sf.jabref.gui.BasePanel;
-import net.sf.jabref.gui.GUIGlobals;
-import net.sf.jabref.gui.JabRefFrame;
-import net.sf.jabref.gui.MnemonicAwareAction;
+import net.sf.jabref.gui.*;
 import net.sf.jabref.gui.worker.Worker;
 import net.sf.jabref.logic.l10n.Localization;
 import spin.Spin;
@@ -41,7 +38,7 @@ public class SaveAllAction extends MnemonicAwareAction implements Worker {
 
     /** Creates a new instance of SaveAllAction */
     public SaveAllAction(JabRefFrame frame) {
-        super(GUIGlobals.getImage("saveAll"));
+        super(IconTheme.getImage("saveAll"));
         this.frame = frame;
         putValue(Action.ACCELERATOR_KEY, Globals.prefs.getKey("Save all"));
         putValue(Action.SHORT_DESCRIPTION, Localization.lang("Save all open databases"));

--- a/src/main/java/net/sf/jabref/external/ExternalFileType.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFileType.java
@@ -34,16 +34,17 @@ public class ExternalFileType implements Comparable<ExternalFileType> {
     private ImageIcon icon;
     private final JLabel label = new JLabel();
 
-
     public ExternalFileType(String name, String extension, String mimeType,
-            String openWith, String iconName) {
+            String openWith, String iconName, ImageIcon icon) {
         label.setText(null);
         this.name = name;
         label.setToolTipText(this.name);
         this.extension = extension;
         this.mimeType = mimeType;
         this.openWith = openWith;
+
         setIconName(iconName);
+        setIcon(icon);
     }
 
     /**
@@ -61,7 +62,7 @@ public class ExternalFileType implements Comparable<ExternalFileType> {
      */
     public ExternalFileType(String[] val) {
         if (val == null || val.length < 4) {
-            throw new IllegalArgumentException("Cannot contruct ExternalFileType without four elements in String[] argument.");
+            throw new IllegalArgumentException("Cannot construct ExternalFileType without four elements in String[] argument.");
         }
         this.name = val[0];
         label.setToolTipText(this.name);
@@ -71,12 +72,14 @@ public class ExternalFileType implements Comparable<ExternalFileType> {
         if (val.length == 4) {
             this.openWith = val[2];
             setIconName(val[3]);
+            setIcon(IconTheme.getImage(getIconName()));
         }
         // When mime type is included, the array length should be 5:
         else if (val.length == 5) {
             this.mimeType = val[2];
             this.openWith = val[3];
             setIconName(val[4]);
+            setIcon(IconTheme.getImage(getIconName()));
         }
     }
 
@@ -134,15 +137,12 @@ public class ExternalFileType implements Comparable<ExternalFileType> {
     }
 
     /**
-     * Set the string associated with this file type's icon. The string is used
-     * to get the actual icon.
+     * Set the string associated with this file type's icon.
      *
      * @param name The icon name to use.
      */
     public void setIconName(String name) {
         this.iconName = name;
-        this.icon = IconTheme.getImage(iconName);
-        label.setIcon(this.icon);
     }
 
     /**
@@ -155,8 +155,8 @@ public class ExternalFileType implements Comparable<ExternalFileType> {
     }
 
     /**
-     * Get the string associated with this file type's icon. The string is used
-     * to get the actual icon by the method GUIGlobals.getIcon(String)
+     * Get the string associated with this file type's icon.
+     *
      * @return The icon name.
      */
     public String getIconName() {
@@ -169,6 +169,7 @@ public class ExternalFileType implements Comparable<ExternalFileType> {
 
     public void setIcon(ImageIcon icon) {
         this.icon = icon;
+        label.setIcon(this.icon);
     }
 
     @Override
@@ -182,7 +183,7 @@ public class ExternalFileType implements Comparable<ExternalFileType> {
     }
 
     public ExternalFileType copy() {
-        return new ExternalFileType(name, extension, mimeType, openWith, iconName);
+        return new ExternalFileType(name, extension, mimeType, openWith, iconName, icon);
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/external/ExternalFileType.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFileType.java
@@ -135,7 +135,8 @@ public class ExternalFileType implements Comparable<ExternalFileType> {
 
     /**
      * Set the string associated with this file type's icon. The string is used
-     * to get the actual icon by the method GUIGlobals.getIcon(String)
+     * to get the actual icon.
+     *
      * @param name The icon name to use.
      */
     public void setIconName(String name) {

--- a/src/main/java/net/sf/jabref/external/ExternalFileType.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFileType.java
@@ -17,7 +17,7 @@ package net.sf.jabref.external;
 
 import javax.swing.*;
 
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 
 /**
  * This class defines a type of external files that can be linked to from JabRef.
@@ -141,7 +141,7 @@ public class ExternalFileType implements Comparable<ExternalFileType> {
     public void setIconName(String name) {
         this.iconName = name;
         try {
-            this.icon = GUIGlobals.getImage(iconName);
+            this.icon = IconTheme.getImage(iconName);
         } catch (NullPointerException ex) {
             // Loading the icon failed. This could be because the icons have not been
             // initialized, which will be the case if we are operating from the command

--- a/src/main/java/net/sf/jabref/external/ExternalFileType.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFileType.java
@@ -140,15 +140,7 @@ public class ExternalFileType implements Comparable<ExternalFileType> {
      */
     public void setIconName(String name) {
         this.iconName = name;
-        try {
-            this.icon = IconTheme.getImage(iconName);
-        } catch (NullPointerException ex) {
-            // Loading the icon failed. This could be because the icons have not been
-            // initialized, which will be the case if we are operating from the command
-            // line and the graphical interface hasn't been initialized. In that case
-            // we will do without the icon:
-            this.icon = null;
-        }
+        this.icon = IconTheme.getImage(iconName);
         label.setIcon(this.icon);
     }
 

--- a/src/main/java/net/sf/jabref/external/ExternalFileTypeEditor.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFileTypeEditor.java
@@ -221,7 +221,7 @@ public class ExternalFileTypeEditor extends JDialog {
         @Override
         public void actionPerformed(ActionEvent e) {
             // Generate a new file type:
-            ExternalFileType type = new ExternalFileType("", "", "", "", "new");
+            ExternalFileType type = new ExternalFileType("", "", "", "", "new", IconTheme.getImage("new"));
             // Show the file type editor:
             getEditor(type).setVisible(true);
             if (entryEditor.okPressed()) {

--- a/src/main/java/net/sf/jabref/external/ExternalFileTypeEditor.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFileTypeEditor.java
@@ -28,8 +28,8 @@ import javax.swing.*;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableCellRenderer;
 
-import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.Globals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.MnemonicAwareAction;
 
@@ -50,9 +50,9 @@ public class ExternalFileTypeEditor extends JDialog {
     private FileTypeTableModel tableModel;
     private final JButton ok = new JButton(Localization.lang("Ok"));
     private final JButton cancel = new JButton(Localization.lang("Cancel"));
-    private final JButton add = new JButton(GUIGlobals.getImage("add"));
-    private final JButton remove = new JButton(GUIGlobals.getImage("remove"));
-    private final JButton edit = new JButton(GUIGlobals.getImage("edit"));
+    private final JButton add = new JButton(IconTheme.getImage("add"));
+    private final JButton remove = new JButton(IconTheme.getImage("remove"));
+    private final JButton edit = new JButton(IconTheme.getImage("edit"));
     private final JButton toDefaults = new JButton(Localization.lang("Default"));
     private final EditListener editListener = new EditListener();
 

--- a/src/main/java/net/sf/jabref/external/ExternalFileTypeEntryEditor.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFileTypeEntryEditor.java
@@ -25,7 +25,6 @@ import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
-import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.FileDialogs;
@@ -33,6 +32,7 @@ import net.sf.jabref.gui.FileDialogs;
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.OS;
 
@@ -49,7 +49,7 @@ public class ExternalFileTypeEntryEditor {
     private final JTextField mimeType = new JTextField();
     private final JTextField application = new JTextField();
     private String selectedIcon;
-    private final JButton icon = new JButton(GUIGlobals.getImage("picture"));
+    private final JButton icon = new JButton(IconTheme.getImage("picture"));
     private final JButton ok = new JButton(Localization.lang("Ok"));
     private final JButton cancel = new JButton(Localization.lang("Cancel"));
     private final JRadioButton useDefault = new JRadioButton(Localization.lang("Default"));
@@ -150,7 +150,7 @@ public class ExternalFileTypeEntryEditor {
                 ic.setVisible(true);
                 if (ic.isOkPressed()) {
                     selectedIcon = ic.getSelectedIconKey();
-                    icon.setIcon(GUIGlobals.getImage(selectedIcon));
+                    icon.setIcon(IconTheme.getImage(selectedIcon));
                 }
                 //JOptionPane.showMessageDialog(null, "Sorry, the icon can unfortunately not be changed in this version of JabRef");
             }

--- a/src/main/java/net/sf/jabref/external/ExternalFileTypeEntryEditor.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFileTypeEntryEditor.java
@@ -246,6 +246,7 @@ public class ExternalFileTypeEntryEditor {
 
         if (selectedIcon != null) {
             entry.setIconName(selectedIcon);
+            entry.setIcon(IconTheme.getImage(entry.getIconName()));
         }
         if (!OS.WINDOWS) {
             entry.setOpenWith(application.getText().trim());

--- a/src/main/java/net/sf/jabref/external/IconSelection.java
+++ b/src/main/java/net/sf/jabref/external/IconSelection.java
@@ -36,9 +36,8 @@ import javax.swing.JScrollPane;
 import javax.swing.ListCellRenderer;
 import javax.swing.ListSelectionModel;
 
-import net.sf.jabref.gui.GUIGlobals;
-
 import com.jgoodies.forms.builder.ButtonBarBuilder;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 
 /**
@@ -90,10 +89,10 @@ class IconSelection extends JDialog {
     private void init(String initialSelection) {
         int initSelIndex = -1;
         iconKeys = new ArrayList<String>();
-        Map<String, String> icns = GUIGlobals.getAllIcons();
+        Map<String, String> icns = IconTheme.getAllIcons();
         HashSet<ImageIcon> iconSet = new LinkedHashSet<ImageIcon>();
         for (String key : icns.keySet()) {
-            ImageIcon icon = GUIGlobals.getImage(key);
+            ImageIcon icon = IconTheme.getImage(key);
             if (!iconSet.contains(icon)) {
                 iconKeys.add(key);
                 if (key.equals(initialSelection)) {

--- a/src/main/java/net/sf/jabref/external/PushToApplicationButton.java
+++ b/src/main/java/net/sf/jabref/external/PushToApplicationButton.java
@@ -17,8 +17,8 @@ package net.sf.jabref.external;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 
-import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.Globals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.MnemonicAwareAction;
 import net.sf.jabref.logic.l10n.Localization;
@@ -57,7 +57,7 @@ public class PushToApplicationButton implements ActionListener {
     private JPopupMenu popup;
     private final HashMap<PushToApplication, PushToApplicationAction> actions = new HashMap<PushToApplication, PushToApplicationAction>();
     private final Dimension buttonDim = new Dimension(23, 23);
-    private static final URL ARROW_ICON = GUIGlobals.getIconUrl("secondary_sorted_reverse");
+    private static final URL ARROW_ICON = IconTheme.getIconUrl("secondary_sorted_reverse");
     private final MenuAction mAction = new MenuAction();
     private final JPopupMenu optPopup = new JPopupMenu();
     private final JMenuItem settings = new JMenuItem(Localization.lang("Settings"));

--- a/src/main/java/net/sf/jabref/external/PushToApplicationButton.java
+++ b/src/main/java/net/sf/jabref/external/PushToApplicationButton.java
@@ -57,7 +57,7 @@ public class PushToApplicationButton implements ActionListener {
     private JPopupMenu popup;
     private final HashMap<PushToApplication, PushToApplicationAction> actions = new HashMap<PushToApplication, PushToApplicationAction>();
     private final Dimension buttonDim = new Dimension(23, 23);
-    private static final URL ARROW_ICON = IconTheme.getIconUrl("secondary_sorted_reverse");
+    private static final ImageIcon ARROW_ICON = IconTheme.getImage("secondary_sorted_reverse");
     private final MenuAction mAction = new MenuAction();
     private final JPopupMenu optPopup = new JPopupMenu();
     private final JMenuItem settings = new JMenuItem(Localization.lang("Settings"));
@@ -92,7 +92,7 @@ public class PushToApplicationButton implements ActionListener {
         comp = new JPanel();
         comp.setLayout(new BorderLayout());
 
-        menuButton = new JButton(new ImageIcon(PushToApplicationButton.ARROW_ICON));
+        menuButton = new JButton(PushToApplicationButton.ARROW_ICON);
         menuButton.setMargin(new Insets(0, 0, 0, 0));
         menuButton.setPreferredSize(new Dimension(menuButton.getIcon().getIconWidth(),
                 menuButton.getIcon().getIconHeight()));

--- a/src/main/java/net/sf/jabref/external/PushToEmacs.java
+++ b/src/main/java/net/sf/jabref/external/PushToEmacs.java
@@ -25,7 +25,7 @@ import net.sf.jabref.*;
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;
 import net.sf.jabref.gui.BasePanel;
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.actions.BrowseAction;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.OS;
@@ -67,7 +67,7 @@ public class PushToEmacs implements PushToApplication {
 
     @Override
     public Icon getIcon() {
-        return GUIGlobals.getImage("emacs");
+        return IconTheme.getImage("emacs");
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/external/PushToLatexEditor.java
+++ b/src/main/java/net/sf/jabref/external/PushToLatexEditor.java
@@ -23,7 +23,7 @@ import net.sf.jabref.*;
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;
 import net.sf.jabref.gui.BasePanel;
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.actions.BrowseAction;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibtexDatabase;
@@ -58,7 +58,7 @@ public class PushToLatexEditor implements PushToApplication {
 
     @Override
     public Icon getIcon() {
-        return GUIGlobals.getImage("edit");
+        return IconTheme.getImage("edit");
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/external/PushToLyx.java
+++ b/src/main/java/net/sf/jabref/external/PushToLyx.java
@@ -24,7 +24,7 @@ import javax.swing.*;
 
 import net.sf.jabref.*;
 import net.sf.jabref.gui.BasePanel;
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibtexDatabase;
 import net.sf.jabref.model.entry.BibtexEntry;
@@ -98,7 +98,7 @@ public class PushToLyx implements PushToApplication {
 
     @Override
     public Icon getIcon() {
-        return GUIGlobals.getImage("lyx");
+        return IconTheme.getImage("lyx");
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/external/PushToTeXstudio.java
+++ b/src/main/java/net/sf/jabref/external/PushToTeXstudio.java
@@ -9,7 +9,7 @@ import net.sf.jabref.*;
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;
 import net.sf.jabref.gui.BasePanel;
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.database.BibtexDatabase;
@@ -50,7 +50,7 @@ public class PushToTeXstudio implements PushToApplication {
 
     @Override
     public Icon getIcon() {
-        return GUIGlobals.getImage("texstudio");
+        return IconTheme.getImage("texstudio");
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/external/PushToVim.java
+++ b/src/main/java/net/sf/jabref/external/PushToVim.java
@@ -19,7 +19,7 @@ import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;
 import net.sf.jabref.*;
 import net.sf.jabref.gui.BasePanel;
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.actions.BrowseAction;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibtexDatabase;
@@ -64,7 +64,7 @@ public class PushToVim implements PushToApplication {
 
     @Override
     public Icon getIcon() {
-        return GUIGlobals.getImage("vim");
+        return IconTheme.getImage("vim");
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/external/PushToWinEdt.java
+++ b/src/main/java/net/sf/jabref/external/PushToWinEdt.java
@@ -23,7 +23,7 @@ import net.sf.jabref.*;
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;
 import net.sf.jabref.gui.BasePanel;
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.actions.BrowseAction;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibtexDatabase;
@@ -55,7 +55,7 @@ public class PushToWinEdt implements PushToApplication {
 
     @Override
     public Icon getIcon() {
-        return GUIGlobals.getImage("winedt");
+        return IconTheme.getImage("winedt");
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/external/SynchronizeFileField.java
+++ b/src/main/java/net/sf/jabref/external/SynchronizeFileField.java
@@ -228,7 +228,7 @@ public class SynchronizeFileField extends AbstractWorker {
                                 // User doesn't want to handle this unknown link type.
                             } else if (answer == JOptionPane.YES_OPTION) {
                                 // User wants to define the new file type. Show the dialog:
-                                ExternalFileType newType = new ExternalFileType(flEntry.getType().getName(), "", "", "", "new");
+                                ExternalFileType newType = new ExternalFileType(flEntry.getType().getName(), "", "", "", "new", IconTheme.getImage("new"));
                                 ExternalFileTypeEntryEditor editor = new ExternalFileTypeEntryEditor(panel.frame(), newType);
                                 editor.setVisible(true);
                                 if (editor.okPressed()) {

--- a/src/main/java/net/sf/jabref/external/UnknownExternalFileType.java
+++ b/src/main/java/net/sf/jabref/external/UnknownExternalFileType.java
@@ -15,6 +15,8 @@
 */
 package net.sf.jabref.external;
 
+import net.sf.jabref.gui.IconTheme;
+
 /**
  * This subclass of ExternalFileType is used to mark types that are unknown.
  * This can be the case when a database is loaded which contains links to files
@@ -23,7 +25,7 @@ package net.sf.jabref.external;
 public class UnknownExternalFileType extends ExternalFileType {
 
     public UnknownExternalFileType(String name) {
-        super(name, "", "", "", "unknown");
+        super(name, "", "", "", "unknown", IconTheme.getImage("unknown"));
     }
 
 }

--- a/src/main/java/net/sf/jabref/external/WriteXMPEntryEditorAction.java
+++ b/src/main/java/net/sf/jabref/external/WriteXMPEntryEditorAction.java
@@ -15,16 +15,13 @@
 */
 package net.sf.jabref.external;
 
-import net.sf.jabref.gui.BasePanel;
+import net.sf.jabref.gui.*;
 import net.sf.jabref.gui.worker.AbstractWorker;
-import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.gui.entryeditor.EntryEditor;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibtexEntry;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.logic.xmp.XMPUtil;
-import net.sf.jabref.gui.FileListTableModel;
-import net.sf.jabref.gui.FileListEntry;
 
 import javax.swing.*;
 
@@ -47,7 +44,7 @@ public class WriteXMPEntryEditorAction extends AbstractAction {
         this.panel = panel;
         this.editor = editor;
         putValue(Action.NAME, Localization.lang("Write XMP")); // normally, this call should be without "Globals.lang". However, the string "Write XMP" is also used in non-menu places and therefore, the translation must be also available at Globals.lang()
-        putValue(Action.SMALL_ICON, GUIGlobals.getImage("pdfSmall"));
+        putValue(Action.SMALL_ICON, IconTheme.getImage("pdfSmall"));
         putValue(Action.SHORT_DESCRIPTION, Localization.lang("Write BibtexEntry as XMP-metadata to PDF."));
     }
 

--- a/src/main/java/net/sf/jabref/groups/GroupSelector.java
+++ b/src/main/java/net/sf/jabref/groups/GroupSelector.java
@@ -121,7 +121,7 @@ public class GroupSelector extends SidePaneComponent implements
      * quicksearch. The next two define the name and regexp for the group.
      */
     public GroupSelector(JabRefFrame frame, SidePaneManager manager) {
-        super(manager, IconTheme.getIconUrl("toggleGroups"), Localization.lang("Groups"));
+        super(manager, IconTheme.getImage("toggleGroups"), Localization.lang("Groups"));
         this.groupsRoot = new GroupTreeNode(new AllEntriesGroup());
 
         this.frame = frame;

--- a/src/main/java/net/sf/jabref/groups/GroupSelector.java
+++ b/src/main/java/net/sf/jabref/groups/GroupSelector.java
@@ -59,12 +59,10 @@ import javax.swing.tree.TreePath;
 import javax.swing.undo.AbstractUndoableEdit;
 import javax.swing.undo.CompoundEdit;
 
+import net.sf.jabref.gui.*;
 import net.sf.jabref.gui.worker.AbstractWorker;
-import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.model.entry.BibtexEntry;
-import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.Globals;
-import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.groups.structure.AbstractGroup;
@@ -72,8 +70,6 @@ import net.sf.jabref.groups.structure.AllEntriesGroup;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.search.rules.InvertSearchRule;
 import net.sf.jabref.logic.search.SearchRule;
-import net.sf.jabref.gui.SidePaneComponent;
-import net.sf.jabref.gui.SidePaneManager;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.logic.search.rules.sets.SearchRuleSets;
 import net.sf.jabref.logic.search.rules.sets.SearchRuleSet;
@@ -89,10 +85,10 @@ public class GroupSelector extends SidePaneComponent implements
 
     private static final Log LOGGER = LogFactory.getLog(GroupSelector.class);
 
-    private final JButton newButton = new JButton(GUIGlobals.getImage("new"));
+    private final JButton newButton = new JButton(IconTheme.getImage("new"));
     private final JButton refresh = new JButton(
-            GUIGlobals.getImage("refresh"));
-    private final JButton autoGroup = new JButton(GUIGlobals.getImage("autoGroup"));
+            IconTheme.getImage("refresh"));
+    private final JButton autoGroup = new JButton(IconTheme.getImage("autoGroup"));
     private final JButton openset = new JButton(Localization.lang("Settings"));
     Color bgColor = Color.white;
     private GroupsTree groupsTree;
@@ -125,7 +121,7 @@ public class GroupSelector extends SidePaneComponent implements
      * quicksearch. The next two define the name and regexp for the group.
      */
     public GroupSelector(JabRefFrame frame, SidePaneManager manager) {
-        super(manager, GUIGlobals.getIconUrl("toggleGroups"), Localization.lang("Groups"));
+        super(manager, IconTheme.getIconUrl("toggleGroups"), Localization.lang("Groups"));
         this.groupsRoot = new GroupTreeNode(new AllEntriesGroup());
 
         this.frame = frame;
@@ -266,7 +262,7 @@ public class GroupSelector extends SidePaneComponent implements
                 }
             }
         });
-        JButton expand = new JButton(GUIGlobals.getImage("down"));
+        JButton expand = new JButton(IconTheme.getImage("down"));
         expand.addActionListener(new ActionListener() {
 
             @Override
@@ -281,7 +277,7 @@ public class GroupSelector extends SidePaneComponent implements
                 LOGGER.info("Height: " + GroupSelector.this.getHeight() + "; Preferred height: " + GroupSelector.this.getPreferredSize().getHeight());
             }
         });
-        JButton reduce = new JButton(GUIGlobals.getImage("up"));
+        JButton reduce = new JButton(IconTheme.getImage("up"));
         reduce.addActionListener(new ActionListener() {
 
             @Override
@@ -319,7 +315,7 @@ public class GroupSelector extends SidePaneComponent implements
         refresh.setPreferredSize(butDim);
         refresh.setMinimumSize(butDim);
         JButton helpButton = new JButton(
-                GUIGlobals.getImage("help"));
+                IconTheme.getImage("help"));
         helpButton.setPreferredSize(butDim);
         helpButton.setMinimumSize(butDim);
         autoGroup.setPreferredSize(butDim);

--- a/src/main/java/net/sf/jabref/groups/GroupTreeCellRenderer.java
+++ b/src/main/java/net/sf/jabref/groups/GroupTreeCellRenderer.java
@@ -23,8 +23,8 @@ import javax.swing.JLabel;
 import javax.swing.JTree;
 import javax.swing.tree.DefaultTreeCellRenderer;
 
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.model.entry.BibtexEntry;
-import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRef;
 import net.sf.jabref.JabRefPreferences;
@@ -48,8 +48,8 @@ public class GroupTreeCellRenderer extends DefaultTreeCellRenderer {
     private Object highlightBorderCell;
 
     private static final ImageIcon
-            groupRefiningIcon = GUIGlobals.getImage("groupRefining");
-    private static final ImageIcon groupIncludingIcon = GUIGlobals.getImage("groupIncluding");
+            groupRefiningIcon = IconTheme.getImage("groupRefining");
+    private static final ImageIcon groupIncludingIcon = IconTheme.getImage("groupIncluding");
     private static final ImageIcon groupRegularIcon = null;
 
 

--- a/src/main/java/net/sf/jabref/gui/BaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/BaseAction.java
@@ -21,5 +21,6 @@ package net.sf.jabref.gui;
  * appropriate BaseAction object, and runs its action() method.
  */
 public interface BaseAction {
+
     void action() throws Throwable;
 }

--- a/src/main/java/net/sf/jabref/gui/DragDropPane.java
+++ b/src/main/java/net/sf/jabref/gui/DragDropPane.java
@@ -147,8 +147,9 @@ class DragDropPane extends JTabbedPane {
 
         public MarkerPane() {
             setOpaque(false);
-            markerImg = Toolkit.getDefaultToolkit().getImage(
-                    IconTheme.getIconUrl("dragNdropArrow")); // Sets the marker image
+
+            // Sets the marker image
+            markerImg = IconTheme.getImage("dragNdropArrow").getImage();
         }
 
         @Override

--- a/src/main/java/net/sf/jabref/gui/DragDropPane.java
+++ b/src/main/java/net/sf/jabref/gui/DragDropPane.java
@@ -148,7 +148,7 @@ class DragDropPane extends JTabbedPane {
         public MarkerPane() {
             setOpaque(false);
             markerImg = Toolkit.getDefaultToolkit().getImage(
-                    GUIGlobals.getIconUrl("dragNdropArrow")); // Sets the marker image
+                    IconTheme.getIconUrl("dragNdropArrow")); // Sets the marker image
         }
 
         @Override

--- a/src/main/java/net/sf/jabref/gui/DragDropPopupPane.java
+++ b/src/main/java/net/sf/jabref/gui/DragDropPopupPane.java
@@ -65,7 +65,7 @@ public class DragDropPopupPane extends DragDropPane {
         manageSelectorsBtn.addActionListener(manageSelectorsAction);
         popupMenu.add(manageSelectorsBtn);
 
-        JMenuItem closeBtn = new JMenuItem(Localization.lang("Close"), GUIGlobals.getImage("close"));
+        JMenuItem closeBtn = new JMenuItem(Localization.lang("Close"), IconTheme.getImage("close"));
         closeBtn.addActionListener(new ActionListener() {
 
             @Override

--- a/src/main/java/net/sf/jabref/gui/FieldSetComponent.java
+++ b/src/main/java/net/sf/jabref/gui/FieldSetComponent.java
@@ -122,8 +122,8 @@ class FieldSetComponent extends JPanel implements ActionListener {
         con.gridwidth = 1;
         if (arrows) {
             con.weightx = 0;
-            up = new JButton(GUIGlobals.getImage("up"));
-            down = new JButton(GUIGlobals.getImage("down"));
+            up = new JButton(IconTheme.getImage("up"));
+            down = new JButton(IconTheme.getImage("down"));
             up.addActionListener(this);
             down.addActionListener(this);
             up.setToolTipText(Localization.lang("Move up"));

--- a/src/main/java/net/sf/jabref/gui/GUIGlobals.java
+++ b/src/main/java/net/sf/jabref/gui/GUIGlobals.java
@@ -18,14 +18,8 @@ package net.sf.jabref.gui;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.*;
 
-import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 
 import net.sf.jabref.Globals;
@@ -85,13 +79,11 @@ public class GUIGlobals {
     public static String pre = "/images/";
     public static final String helpPre = "/help/";
 
-    private static final HashMap<String, JLabel> tableIcons = new HashMap<>(); // Contains table icon mappings. Set up
+    private static final Map<String, JLabel> tableIcons = new HashMap<>(); // Contains table icon mappings. Set up
     // further below.
     public static final Color activeEditor = new Color(230, 230, 255);
     public static SidePaneManager sidePaneManager;
     public static HelpDialog helpDiag;
-
-    private static HashMap<String, String> iconMap;
 
     //Help files (in HTML format):
     public static final String baseFrameHelp = "BaseFrameHelp.html";
@@ -223,131 +215,6 @@ public class GUIGlobals {
     }
 
     /**
-     * Read either the default icon theme, or a custom one. If loading of the custom theme
-     * fails, try to fall back on the default theme.
-     */
-    public static void setUpIconTheme() {
-        String defaultPrefix = "/images/crystal_16/";
-        String prefix = defaultPrefix;
-
-        URL defaultResource = GUIGlobals.class.getResource(prefix + "Icons.properties");
-        URL resource = defaultResource;
-
-        if (Globals.prefs.getBoolean(JabRefPreferences.USE_CUSTOM_ICON_THEME)) {
-            String filename = Globals.prefs.get(JabRefPreferences.CUSTOM_ICON_THEME_FILE);
-            if (filename != null) {
-                try {
-                    File file = new File(filename);
-                    String parent = file.getParentFile().getAbsolutePath();
-                    prefix = "file://" + parent + System.getProperty("file.separator");
-                    resource = new URL("file://" + file.getAbsolutePath());
-                } catch (MalformedURLException e) {
-                    LOGGER.warn("Could not read " + resource, e);
-                }
-            }
-        }
-        try {
-            GUIGlobals.iconMap = GUIGlobals.readIconThemeFile(resource, prefix);
-        } catch (IOException e) {
-            System.err.println(Localization.lang("Unable to read icon theme file") + " '" +
-                    resource + '\'');
-            // If we were trying to load a custom theme, try the default one as a fallback:
-            if (resource != defaultResource) {
-                try {
-                    GUIGlobals.iconMap = GUIGlobals.readIconThemeFile(defaultResource, defaultPrefix);
-                } catch (IOException e2) {
-                    LOGGER.warn(Localization.lang("Unable to read default icon theme."), e2);
-                }
-            }
-
-        }
-
-    }
-
-    /**
-     * Looks up the URL for the image representing the given function, in the resource
-     * file listing images.
-     *
-     * @param name The name of the icon, such as "open", "save", "saveAs" etc.
-     * @return The URL to the actual image to use.
-     */
-    public static URL getIconUrl(String name) {
-        if (GUIGlobals.iconMap.containsKey(name)) {
-            String path = GUIGlobals.iconMap.get(name);
-            URL url = GUIGlobals.class.getResource(path);
-            if (url == null) {
-                // This may be a resource outside of the jar file, so we try a general URL:
-                try {
-                    url = new URL(path);
-                } catch (MalformedURLException ignored) {
-                }
-            }
-            if (url == null) {
-                LOGGER.warn(Localization.lang("Could not find image file") + " '" + path + '\'');
-            }
-            return url;
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * Constructs an ImageIcon for the given function, using the image specified in
-     * the resource files resource/Icons_en.properties.
-     *
-     * @param name The name of the icon, such as "open", "save", "saveAs" etc.
-     * @return The ImageIcon for the function.
-     */
-    public static ImageIcon getImage(String name) {
-        URL imageUrl = GUIGlobals.getIconUrl(name);
-        return imageUrl != null ? new ImageIcon(GUIGlobals.getIconUrl(name)) : null;
-    }
-
-    /**
-     * Get a Map of all application icons mapped from their keys.
-     *
-     * @return A Map containing all icons used in the application.
-     */
-    public static Map<String, String> getAllIcons() {
-        return Collections.unmodifiableMap(GUIGlobals.iconMap);
-    }
-
-    /**
-     * Read a typical java property file into a HashMap. Currently doesn't support escaping
-     * of the '=' character - it simply looks for the first '=' to determine where the key ends.
-     * Both the key and the value is trimmed for whitespace at the ends.
-     *
-     * @param file   The URL to read information from.
-     * @param prefix A String to prefix to all values read. Can represent e.g. the directory
-     *               where icon files are to be found.
-     * @return A HashMap containing all key-value pairs found.
-     * @throws IOException
-     */
-    private static HashMap<String, String> readIconThemeFile(URL file, String prefix) throws IOException {
-        HashMap<String, String> map = new HashMap<>();
-
-        try (InputStream in = file.openStream()) {
-
-            StringBuilder buffer = new StringBuilder();
-            int c;
-            while ((c = in.read()) != -1) {
-                buffer.append((char) c);
-            }
-            String[] lines = buffer.toString().split("\n");
-            for (String line1 : lines) {
-                String line = line1.trim();
-                int index = line.indexOf("=");
-                if (index >= 0) {
-                    String key = line.substring(0, index).trim();
-                    String value = prefix + line.substring(index + 1).trim();
-                    map.put(key, value);
-                }
-            }
-        }
-        return map;
-    }
-
-    /**
      * returns the path to language independent help files
      */
     public static String getLocaleHelpPath() {
@@ -368,28 +235,28 @@ public class GUIGlobals {
     public static void init() {
         GUIGlobals.typeNameFont = new Font("dialog", Font.ITALIC + Font.BOLD, 18);
         JLabel label;
-        label = new JLabel(GUIGlobals.getImage("pdfSmall"));
+        label = new JLabel(IconTheme.getImage("pdfSmall"));
         label.setToolTipText(Localization.lang("Open") + " PDF");
         GUIGlobals.tableIcons.put("pdf", label);
-        label = new JLabel(GUIGlobals.getImage("wwwSmall"));
+        label = new JLabel(IconTheme.getImage("wwwSmall"));
         label.setToolTipText(Localization.lang("Open") + " URL");
         GUIGlobals.tableIcons.put("url", label);
-        label = new JLabel(GUIGlobals.getImage("citeseer"));
+        label = new JLabel(IconTheme.getImage("citeseer"));
         label.setToolTipText(Localization.lang("Open") + " CiteSeer URL");
         GUIGlobals.tableIcons.put("citeseerurl", label);
-        label = new JLabel(GUIGlobals.getImage("arxiv"));
+        label = new JLabel(IconTheme.getImage("arxiv"));
         label.setToolTipText(Localization.lang("Open") + " ArXiv URL");
         GUIGlobals.tableIcons.put("eprint", label);
-        label = new JLabel(GUIGlobals.getImage("doiSmall"));
+        label = new JLabel(IconTheme.getImage("doiSmall"));
         label.setToolTipText(Localization.lang("Open") + " DOI " + Localization.lang("web link"));
         GUIGlobals.tableIcons.put("doi", label);
-        label = new JLabel(GUIGlobals.getImage("psSmall"));
+        label = new JLabel(IconTheme.getImage("psSmall"));
         label.setToolTipText(Localization.lang("Open") + " PS");
         GUIGlobals.tableIcons.put("ps", label);
-        label = new JLabel(GUIGlobals.getImage("psSmall"));
+        label = new JLabel(IconTheme.getImage("psSmall"));
         label.setToolTipText(Localization.lang("Open folder"));
         GUIGlobals.tableIcons.put(GUIGlobals.FOLDER_FIELD, label);
-        label = new JLabel(GUIGlobals.getImage("psSmall"));
+        label = new JLabel(IconTheme.getImage("psSmall"));
         label.setToolTipText(Localization.lang("Open file"));
         GUIGlobals.tableIcons.put(GUIGlobals.FILE_FIELD, label);
 

--- a/src/main/java/net/sf/jabref/gui/GenFieldsCustomizer.java
+++ b/src/main/java/net/sf/jabref/gui/GenFieldsCustomizer.java
@@ -65,7 +65,7 @@ public class GenFieldsCustomizer extends JDialog {
         parent = frame;
         //this.diag = diag;
         HelpAction help = new HelpAction(parent.helpDiag, GUIGlobals.generalFieldsHelp,
-                "Help", GUIGlobals.getIconUrl("helpSmall"));
+                "Help", IconTheme.getIconUrl("helpSmall"));
         helpBut = new JButton(Localization.lang("Help"));
         helpBut.addActionListener(help);
         try {

--- a/src/main/java/net/sf/jabref/gui/GenFieldsCustomizer.java
+++ b/src/main/java/net/sf/jabref/gui/GenFieldsCustomizer.java
@@ -65,7 +65,7 @@ public class GenFieldsCustomizer extends JDialog {
         parent = frame;
         //this.diag = diag;
         HelpAction help = new HelpAction(parent.helpDiag, GUIGlobals.generalFieldsHelp,
-                "Help", IconTheme.getIconUrl("helpSmall"));
+                "Help", IconTheme.getImage("helpSmall"));
         helpBut = new JButton(Localization.lang("Help"));
         helpBut.addActionListener(help);
         try {

--- a/src/main/java/net/sf/jabref/gui/IconTheme.java
+++ b/src/main/java/net/sf/jabref/gui/IconTheme.java
@@ -24,19 +24,12 @@ public class IconTheme {
     private static final String DEFAULT_ICON_PATH = "/images/crystal_16/red.png";
 
     /**
-     * Looks up the URL for the image representing the given function, in the resource
-     * file listing images.
+     * Get a Map of all application icons mapped from their keys.
      *
-     * @param name The name of the icon, such as "open", "save", "saveAs" etc.
-     * @return The URL to the actual image to use.
+     * @return A Map containing all icons used in the application.
      */
-    public static URL getIconUrl(String name) {
-        String key = Objects.requireNonNull(name, "icon name");
-        if(!KEY_TO_ICON.containsKey(key)) {
-            LOGGER.warn("could not find icon url by name " + name + ", so falling back on default icon " + DEFAULT_ICON_PATH);
-        }
-        String path = KEY_TO_ICON.getOrDefault(key, DEFAULT_ICON_PATH);
-        return Objects.requireNonNull(IconTheme.class.getResource(path), "url");
+    public static Map<String, String> getAllIcons() {
+        return Collections.unmodifiableMap(KEY_TO_ICON);
     }
 
     /**
@@ -51,12 +44,19 @@ public class IconTheme {
     }
 
     /**
-     * Get a Map of all application icons mapped from their keys.
+     * Looks up the URL for the image representing the given function, in the resource
+     * file listing images.
      *
-     * @return A Map containing all icons used in the application.
+     * @param name The name of the icon, such as "open", "save", "saveAs" etc.
+     * @return The URL to the actual image to use.
      */
-    public static Map<String, String> getAllIcons() {
-        return Collections.unmodifiableMap(KEY_TO_ICON);
+    private static URL getIconUrl(String name) {
+        String key = Objects.requireNonNull(name, "icon name");
+        if(!KEY_TO_ICON.containsKey(key)) {
+            LOGGER.warn("could not find icon url by name " + name + ", so falling back on default icon " + DEFAULT_ICON_PATH);
+        }
+        String path = KEY_TO_ICON.getOrDefault(key, DEFAULT_ICON_PATH);
+        return Objects.requireNonNull(IconTheme.class.getResource(path), "url");
     }
 
     /**

--- a/src/main/java/net/sf/jabref/gui/IconTheme.java
+++ b/src/main/java/net/sf/jabref/gui/IconTheme.java
@@ -31,7 +31,11 @@ public class IconTheme {
      * @return The URL to the actual image to use.
      */
     public static URL getIconUrl(String name) {
-        String path = KEY_TO_ICON.getOrDefault(Objects.requireNonNull(name, "icon name"), DEFAULT_ICON_PATH);
+        String key = Objects.requireNonNull(name, "icon name");
+        if(!KEY_TO_ICON.containsKey(key)) {
+            LOGGER.warn("could not find icon url by name " + name + ", so falling back on default icon " + DEFAULT_ICON_PATH);
+        }
+        String path = KEY_TO_ICON.getOrDefault(key, DEFAULT_ICON_PATH);
         return Objects.requireNonNull(IconTheme.class.getResource(path), "url");
     }
 

--- a/src/main/java/net/sf/jabref/gui/IconTheme.java
+++ b/src/main/java/net/sf/jabref/gui/IconTheme.java
@@ -1,0 +1,103 @@
+package net.sf.jabref.gui;
+
+import net.sf.jabref.logic.l10n.Localization;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import javax.swing.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class IconTheme {
+
+    private static final Log LOGGER = LogFactory.getLog(IconTheme.class);
+
+    private static final Map<String, String> KEY_TO_ICON = readIconThemeFile(IconTheme.class.getResource("/images/crystal_16/Icons.properties"), "/images/crystal_16/");
+    private static final URL DEFAULT_ICON_URL = IconTheme.class.getResource("/images/crystal_16/red.png");
+
+
+    /**
+     * Looks up the URL for the image representing the given function, in the resource
+     * file listing images.
+     *
+     * @param name The name of the icon, such as "open", "save", "saveAs" etc.
+     * @return The URL to the actual image to use.
+     */
+    public static URL getIconUrl(String name) {
+        if (KEY_TO_ICON.containsKey(name)) {
+            String path = KEY_TO_ICON.get(name);
+            URL url = IconTheme.class.getResource(path);
+            if (url == null) {
+                LOGGER.warn(Localization.lang("Could not find image file") + " '" + path + '\'');
+                return DEFAULT_ICON_URL;
+            } else {
+                return url;
+            }
+        } else {
+            return DEFAULT_ICON_URL;
+        }
+    }
+
+    /**
+     * Constructs an ImageIcon for the image representing the given function, in the resource
+     * file listing images.
+     *
+     * @param name The name of the icon, such as "open", "save", "saveAs" etc.
+     * @return The ImageIcon for the function.
+     */
+    public static ImageIcon getImage(String name) {
+        return new ImageIcon(getIconUrl(name));
+    }
+
+    /**
+     * Get a Map of all application icons mapped from their keys.
+     *
+     * @return A Map containing all icons used in the application.
+     */
+    public static Map<String, String> getAllIcons() {
+        return Collections.unmodifiableMap(KEY_TO_ICON);
+    }
+
+    /**
+     * Read a typical java property file into a Map. Currently doesn't support escaping
+     * of the '=' character - it simply looks for the first '=' to determine where the key ends.
+     * Both the key and the value is trimmed for whitespace at the ends.
+     *
+     * @param file   The URL to read information from.
+     * @param prefix A String to prefix to all values read. Can represent e.g. the directory
+     *               where icon files are to be found.
+     * @return A Map containing all key-value pairs found.
+     */
+    private static Map<String, String> readIconThemeFile(URL file, String prefix) {
+        Objects.requireNonNull(file, "passed URL to file must be not null");
+
+        Map<String, String> result = new HashMap<>();
+
+        try (InputStream in = file.openStream()) {
+            StringBuilder buffer = new StringBuilder();
+            int c;
+            while ((c = in.read()) != -1) {
+                buffer.append((char) c);
+            }
+            String[] lines = buffer.toString().split("\n");
+            for (String line1 : lines) {
+                String line = line1.trim();
+                int index = line.indexOf("=");
+                if (index >= 0) {
+                    String key = line.substring(0, index).trim();
+                    String value = prefix + line.substring(index + 1).trim();
+                    result.put(key, value);
+                }
+            }
+        } catch (IOException e) {
+            LOGGER.warn(Localization.lang("Unable to read default icon theme."), e);
+        }
+        return result;
+    }
+}

--- a/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
@@ -183,12 +183,12 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
     private final JCheckBox autoGenerate = new JCheckBox(Localization.lang("Generate keys"), Globals.prefs
             .getBoolean(JabRefPreferences.GENERATE_KEYS_AFTER_INSPECTION));
 
-    private final JLabel duplLabel = new JLabel(GUIGlobals.getImage("duplicate"));
-    private final JLabel fileLabel = new JLabel(GUIGlobals.getImage("psSmall"));
-    private final JLabel pdfLabel = new JLabel(GUIGlobals
+    private final JLabel duplLabel = new JLabel(IconTheme.getImage("duplicate"));
+    private final JLabel fileLabel = new JLabel(IconTheme.getImage("psSmall"));
+    private final JLabel pdfLabel = new JLabel(IconTheme
             .getImage("pdfSmall"));
-    private final JLabel psLabel = new JLabel(GUIGlobals.getImage("psSmall"));
-    private final JLabel urlLabel = new JLabel(GUIGlobals.getImage("wwwSmall"));
+    private final JLabel psLabel = new JLabel(IconTheme.getImage("psSmall"));
+    private final JLabel urlLabel = new JLabel(IconTheme.getImage("wwwSmall"));
 
     private final int DUPL_COL = 1;
     private final int FILE_COL = 2;
@@ -876,7 +876,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
     class DeleteListener extends AbstractAction {
 
         public DeleteListener() {
-            super(Localization.lang("Delete"), GUIGlobals.getImage("delete"));
+            super(Localization.lang("Delete"), IconTheme.getImage("delete"));
         }
 
         @Override

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -450,7 +450,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             FindUnlinkedFilesDialog.ACTION_TITLE,
             FindUnlinkedFilesDialog.ACTION_SHORT_DESCRIPTION,
             prefs.getKey(FindUnlinkedFilesDialog.ACTION_KEYBINDING_ACTION),
-            IconTheme.getImage(FindUnlinkedFilesDialog.ACTION_ICON)
+            IconTheme.getImage("toggleSearch")
     );
 
     private final AutoLinkFilesAction autoLinkFile = new AutoLinkFilesAction();

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -214,10 +214,10 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             prefs.getKey("Help"));
     private final AbstractAction contents = new HelpAction("Help contents", helpDiag,
             GUIGlobals.helpContents, Localization.lang("Help contents"),
-            IconTheme.getIconUrl("helpContents"));
+            IconTheme.getImage("helpContents"));
     private final AbstractAction about = new HelpAction("About JabRef", helpDiag,
             GUIGlobals.aboutPage, Localization.lang("About JabRef"),
-            IconTheme.getIconUrl("about"));
+            IconTheme.getImage("about"));
     private final AbstractAction editEntry = new GeneralAction(Actions.EDIT, "Edit entry",
             Localization.lang("Edit entry"),
             prefs.getKey(KeyBinds.EDIT_ENTRY),
@@ -262,9 +262,9 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     private final AbstractAction delete = new GeneralAction(Actions.DELETE, "Delete", Localization.lang("Delete"),
             prefs.getKey(KeyBinds.DELETE),
             IconTheme.getImage("delete"));
-    private final AbstractAction copy = new EditAction(Actions.COPY, IconTheme.getIconUrl("copy"));
-    private final AbstractAction paste = new EditAction(Actions.PASTE, IconTheme.getIconUrl("paste"));
-    private final AbstractAction cut = new EditAction(Actions.CUT, IconTheme.getIconUrl("cut"));
+    private final AbstractAction copy = new EditAction(Actions.COPY, IconTheme.getImage("copy"));
+    private final AbstractAction paste = new EditAction(Actions.PASTE, IconTheme.getImage("paste"));
+    private final AbstractAction cut = new EditAction(Actions.CUT, IconTheme.getImage("cut"));
     private final AbstractAction mark = new GeneralAction(Actions.MARK_ENTRIES, "Mark entries",
             Localization.lang("Mark entries"),
             prefs.getKey(KeyBinds.MARK_ENTRIES),
@@ -2308,8 +2308,8 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     class EditAction extends MnemonicAwareAction {
         private final String command;
 
-        public EditAction(String command, URL icon) {
-            super(new ImageIcon(icon));
+        public EditAction(String command, ImageIcon icon) {
+            super(icon);
             this.command = command;
             String nName = StringUtil.capitalizeFirst(command);
             putValue(Action.NAME, nName);

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -220,16 +220,19 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             IconTheme.getIconUrl("about"));
     private final AbstractAction editEntry = new GeneralAction(Actions.EDIT, "Edit entry",
             Localization.lang("Edit entry"),
-            prefs.getKey(KeyBinds.EDIT_ENTRY));
+            prefs.getKey(KeyBinds.EDIT_ENTRY),
+            IconTheme.getImage("edit"));
     private final AbstractAction focusTable = new GeneralAction(Actions.FOCUS_TABLE, "Focus entry table",
             Localization.lang("Move the keyboard focus to the entry table"),
             prefs.getKey(KeyBinds.FOCUS_ENTRY_TABLE));
     private final AbstractAction save = new GeneralAction(Actions.SAVE, "Save database",
             Localization.lang("Save database"),
-            prefs.getKey(KeyBinds.SAVE_DATABASE));
+            prefs.getKey(KeyBinds.SAVE_DATABASE),
+            IconTheme.getImage("save"));
     private final AbstractAction saveAs = new GeneralAction(Actions.SAVE_AS, "Save database as ...",
             Localization.lang("Save database as ..."),
-            prefs.getKey(KeyBinds.SAVE_DATABASE_AS));
+            prefs.getKey(KeyBinds.SAVE_DATABASE_AS),
+            IconTheme.getImage("saveAs"));
     private final AbstractAction saveAll = new SaveAllAction(JabRefFrame.this);
     private final AbstractAction saveSelectedAs = new GeneralAction(Actions.SAVE_SELECTED_AS,
             "Save selected as ...",
@@ -247,47 +250,57 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     public final AbstractAction prevTab = new ChangeTabAction(false);
     private final AbstractAction sortTabs = new SortTabsAction(this);
     private final AbstractAction undo = new GeneralAction(Actions.UNDO, "Undo", Localization.lang("Undo"),
-            prefs.getKey(KeyBinds.UNDO));
+            prefs.getKey(KeyBinds.UNDO),
+            IconTheme.getImage("undo"));
     private final AbstractAction redo = new GeneralAction(Actions.REDO, "Redo", Localization.lang("Redo"),
-            prefs.getKey(KeyBinds.REDO));
+            prefs.getKey(KeyBinds.REDO),
+            IconTheme.getImage("redo"));
     final AbstractAction forward = new GeneralAction(Actions.FORWARD, "Forward", Localization.lang("Forward"),
-            IconTheme.getImage("right"), prefs.getKey(KeyBinds.FORWARD));
+            prefs.getKey(KeyBinds.FORWARD), IconTheme.getImage("right"));
     final AbstractAction back = new GeneralAction(Actions.BACK, "Back", Localization.lang("Back"),
-            IconTheme.getImage("left"), prefs.getKey(KeyBinds.BACK));
+            prefs.getKey(KeyBinds.BACK), IconTheme.getImage("left"));
     private final AbstractAction delete = new GeneralAction(Actions.DELETE, "Delete", Localization.lang("Delete"),
-            prefs.getKey(KeyBinds.DELETE));
+            prefs.getKey(KeyBinds.DELETE),
+            IconTheme.getImage("delete"));
     private final AbstractAction copy = new EditAction(Actions.COPY, IconTheme.getIconUrl("copy"));
     private final AbstractAction paste = new EditAction(Actions.PASTE, IconTheme.getIconUrl("paste"));
     private final AbstractAction cut = new EditAction(Actions.CUT, IconTheme.getIconUrl("cut"));
     private final AbstractAction mark = new GeneralAction(Actions.MARK_ENTRIES, "Mark entries",
             Localization.lang("Mark entries"),
-            prefs.getKey(KeyBinds.MARK_ENTRIES));
+            prefs.getKey(KeyBinds.MARK_ENTRIES),
+            IconTheme.getImage("markEntries"));
     private final AbstractAction unmark = new GeneralAction(Actions.UNMARK_ENTRIES, "Unmark entries",
             Localization.lang("Unmark entries"),
-            prefs.getKey(KeyBinds.UNMARK_ENTRIES));
+            prefs.getKey(KeyBinds.UNMARK_ENTRIES),
+            IconTheme.getImage("unmarkEntries"));
     private final AbstractAction unmarkAll = new GeneralAction(Actions.UNMARK_ALL, "Unmark all");
     private final AbstractAction toggleRelevance = new GeneralAction(
             Relevance.getInstance().getValues().get(0).getActionName(),
             Relevance.getInstance().getValues().get(0).getMenuString(),
-            Relevance.getInstance().getValues().get(0).getToolTipText());
+            Relevance.getInstance().getValues().get(0).getToolTipText(),
+            IconTheme.getImage(Relevance.getInstance().getValues().get(0).getActionName()));
     private final AbstractAction toggleQualityAssured = new GeneralAction(
             Quality.getInstance().getValues().get(0).getActionName(),
             Quality.getInstance().getValues().get(0).getMenuString(),
-            Quality.getInstance().getValues().get(0).getToolTipText());
+            Quality.getInstance().getValues().get(0).getToolTipText(),
+            IconTheme.getImage(Quality.getInstance().getValues().get(0).getActionName()));
     private final AbstractAction togglePrinted = new GeneralAction(
             Printed.getInstance().getValues().get(0).getActionName(),
             Printed.getInstance().getValues().get(0).getMenuString(),
-            Printed.getInstance().getValues().get(0).getToolTipText());
+            Printed.getInstance().getValues().get(0).getToolTipText(),
+            IconTheme.getImage(Printed.getInstance().getValues().get(0).getActionName()));
     private final AbstractAction manageSelectors = new GeneralAction(Actions.MANAGE_SELECTORS, "Manage content selectors");
     private final AbstractAction saveSessionAction = new SaveSessionAction();
     public final AbstractAction loadSessionAction = new LoadSessionAction();
     private final AbstractAction incrementalSearch = new GeneralAction(Actions.INC_SEARCH, "Incremental search",
             Localization.lang("Start incremental search"),
-            prefs.getKey(KeyBinds.INCREMENTAL_SEARCH));
+            prefs.getKey(KeyBinds.INCREMENTAL_SEARCH),
+            IconTheme.getImage("incSearch"));
     private final AbstractAction normalSearch = new GeneralAction(Actions.SEARCH, "Search", Localization.lang("Search"),
-            prefs.getKey(KeyBinds.SEARCH));
+            prefs.getKey(KeyBinds.SEARCH),
+            IconTheme.getImage("search"));
     private final AbstractAction toggleSearch = new GeneralAction(Actions.TOGGLE_SEARCH, "Search",
-            Localization.lang("Toggle search panel"));
+            Localization.lang("Toggle search panel"),IconTheme.getImage("toggleSearch"));
 
     private final AbstractAction copyKey = new GeneralAction(Actions.COPY_KEY, "Copy BibTeX key",
             prefs.getKey(KeyBinds.COPY_BIB_TE_X_KEY));
@@ -309,10 +322,12 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
     private final AbstractAction editPreamble = new GeneralAction(Actions.EDIT_PREAMBLE, "Edit preamble",
             Localization.lang("Edit preamble"),
-            prefs.getKey(KeyBinds.EDIT_PREAMBLE));
+            prefs.getKey(KeyBinds.EDIT_PREAMBLE),
+            IconTheme.getImage("editPreamble"));
     private final AbstractAction editStrings = new GeneralAction(Actions.EDIT_STRINGS, "Edit strings",
             Localization.lang("Edit strings"),
-            prefs.getKey(KeyBinds.EDIT_STRINGS));
+            prefs.getKey(KeyBinds.EDIT_STRINGS),
+            IconTheme.getImage("editStrings"));
     private final AbstractAction toggleToolbar = new AbstractAction("Hide/show toolbar") {
         {
             putValue(Action.ACCELERATOR_KEY, prefs.getKey(KeyBinds.HIDE_SHOW_TOOLBAR));
@@ -325,11 +340,13 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     private final AbstractAction toggleGroups = new GeneralAction(Actions.TOGGLE_GROUPS,
             "Toggle groups interface",
             Localization.lang("Toggle groups interface"),
-            prefs.getKey(KeyBinds.TOGGLE_GROUPS_INTERFACE));
+            prefs.getKey(KeyBinds.TOGGLE_GROUPS_INTERFACE),
+            IconTheme.getImage("toggleGroups"));
     private final AbstractAction togglePreview = new GeneralAction(Actions.TOGGLE_PREVIEW,
             "Toggle entry preview",
             Localization.lang("Toggle entry preview"),
-            prefs.getKey(KeyBinds.TOGGLE_ENTRY_PREVIEW));
+            prefs.getKey(KeyBinds.TOGGLE_ENTRY_PREVIEW),
+            IconTheme.getImage("togglePreview"));
     private final AbstractAction toggleHighlightAny = new GeneralAction(Actions.TOGGLE_HIGHLIGHTS_GROUPS_MATCHING_ANY,
             "Highlight groups matching any selected entry",
             Localization.lang("Highlight groups matching any selected entry"),
@@ -343,7 +360,8 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             prefs.getKey(KeyBinds.SWITCH_PREVIEW_LAYOUT));
     private final AbstractAction makeKeyAction = new GeneralAction(Actions.MAKE_KEY, "Autogenerate BibTeX keys",
             Localization.lang("Autogenerate BibTeX keys"),
-            prefs.getKey(KeyBinds.AUTOGENERATE_BIB_TE_X_KEYS));
+            prefs.getKey(KeyBinds.AUTOGENERATE_BIB_TE_X_KEYS),
+            IconTheme.getImage("makeKey"));
 
     private final AbstractAction writeXmpAction = new GeneralAction(Actions.WRITE_XMP, "Write XMP-metadata to PDFs",
             Localization.lang("Will write XMP-metadata to the PDFs linked from selected entries."),
@@ -354,13 +372,16 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             prefs.getKey(KeyBinds.OPEN_FOLDER));
     private final AbstractAction openFile = new GeneralAction(Actions.OPEN_EXTERNAL_FILE, "Open file",
             Localization.lang("Open file"),
-            prefs.getKey(KeyBinds.OPEN_FILE));
+            prefs.getKey(KeyBinds.OPEN_FILE),
+            IconTheme.getImage("openExternalFile"));
     private final AbstractAction openPdf = new GeneralAction(Actions.OPEN_FILE, "Open PDF or PS",
             Localization.lang("Open PDF or PS"),
-            prefs.getKey(KeyBinds.OPEN_PDF_OR_PS));
+            prefs.getKey(KeyBinds.OPEN_PDF_OR_PS),
+            IconTheme.getImage("openFile"));
     private final AbstractAction openUrl = new GeneralAction(Actions.OPEN_URL, "Open URL or DOI",
             Localization.lang("Open URL or DOI"),
-            prefs.getKey(KeyBinds.OPEN_URL_OR_DOI));
+            prefs.getKey(KeyBinds.OPEN_URL_OR_DOI),
+            IconTheme.getImage("openUrl"));
     private final AbstractAction openSpires = new GeneralAction(Actions.OPEN_SPIRES, "Open SPIRES entry",
             Localization.lang("Open SPIRES entry"),
             prefs.getKey(KeyBinds.OPEN_SPIRES_ENTRY));
@@ -428,8 +449,8 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             FindUnlinkedFilesDialog.ACTION_COMMAND,
             FindUnlinkedFilesDialog.ACTION_TITLE,
             FindUnlinkedFilesDialog.ACTION_SHORT_DESCRIPTION,
-            IconTheme.getImage(FindUnlinkedFilesDialog.ACTION_ICON),
-            prefs.getKey(FindUnlinkedFilesDialog.ACTION_KEYBINDING_ACTION)
+            prefs.getKey(FindUnlinkedFilesDialog.ACTION_KEYBINDING_ACTION),
+            IconTheme.getImage(FindUnlinkedFilesDialog.ACTION_ICON)
     );
 
     private final AutoLinkFilesAction autoLinkFile = new AutoLinkFilesAction();
@@ -1090,27 +1111,23 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
         private final String command;
 
-        public GeneralAction(String command, String text,
-                             String description, ImageIcon icon) {
-            super(icon);
-            this.command = command;
-            putValue(Action.NAME, text);
-            putValue(Action.SHORT_DESCRIPTION, Localization.lang(description));
-        }
-
-        public GeneralAction(String command, String text,
-                             String description, ImageIcon icon,
-                             KeyStroke key) {
-            super(icon);
-            this.command = command;
-            putValue(Action.NAME, text);
-            putValue(Action.ACCELERATOR_KEY, key);
-            putValue(Action.SHORT_DESCRIPTION, Localization.lang(description));
-        }
-
         public GeneralAction(String command, String text) {
-            putValue(Action.NAME, text);
             this.command = command;
+            putValue(Action.NAME, text);
+        }
+
+        public GeneralAction(String command, String text, String description) {
+            this.command = command;
+            putValue(Action.NAME, text);
+            putValue(Action.SHORT_DESCRIPTION, Localization.lang(description));
+        }
+
+        public GeneralAction(String command, String text, String description, ImageIcon icon) {
+            super(icon);
+
+            this.command = command;
+            putValue(Action.NAME, text);
+            putValue(Action.SHORT_DESCRIPTION, Localization.lang(description));
         }
 
         public GeneralAction(String command, String text, KeyStroke key) {
@@ -1119,15 +1136,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             putValue(Action.ACCELERATOR_KEY, key);
         }
 
-        public GeneralAction(String command, String text, String description) {
-            super(IconTheme.getImage(command));
-            this.command = command;
-            putValue(Action.NAME, text);
-            putValue(Action.SHORT_DESCRIPTION, Localization.lang(description));
-        }
-
         public GeneralAction(String command, String text, String description, KeyStroke key) {
-            super(IconTheme.getImage(command));
             this.command = command;
             putValue(Action.NAME, text);
             putValue(Action.SHORT_DESCRIPTION, Localization.lang(description));
@@ -1136,6 +1145,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
         public GeneralAction(String command, String text, String description, KeyStroke key, ImageIcon icon) {
             super(icon);
+
             this.command = command;
             putValue(Action.NAME, text);
             putValue(Action.SHORT_DESCRIPTION, Localization.lang(description));

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -214,10 +214,10 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             prefs.getKey("Help"));
     private final AbstractAction contents = new HelpAction("Help contents", helpDiag,
             GUIGlobals.helpContents, Localization.lang("Help contents"),
-            GUIGlobals.getIconUrl("helpContents"));
+            IconTheme.getIconUrl("helpContents"));
     private final AbstractAction about = new HelpAction("About JabRef", helpDiag,
             GUIGlobals.aboutPage, Localization.lang("About JabRef"),
-            GUIGlobals.getIconUrl("about"));
+            IconTheme.getIconUrl("about"));
     private final AbstractAction editEntry = new GeneralAction(Actions.EDIT, "Edit entry",
             Localization.lang("Edit entry"),
             prefs.getKey(KeyBinds.EDIT_ENTRY));
@@ -234,11 +234,11 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     private final AbstractAction saveSelectedAs = new GeneralAction(Actions.SAVE_SELECTED_AS,
             "Save selected as ...",
             Localization.lang("Save selected as ..."),
-            GUIGlobals.getIconUrl("saveAs"));
+            IconTheme.getIconUrl("saveAs"));
     private final AbstractAction saveSelectedAsPlain = new GeneralAction(Actions.SAVE_SELECTED_AS_PLAIN,
             "Save selected as plain BibTeX ...",
             Localization.lang("Save selected as plain BibTeX ..."),
-            GUIGlobals.getIconUrl("saveAs"));
+            IconTheme.getIconUrl("saveAs"));
     private final AbstractAction exportAll = ExportFormats.getExportAction(this, false);
     private final AbstractAction exportSelected = ExportFormats.getExportAction(this, true);
     private final AbstractAction importCurrent = ImportFormats.getImportAction(this, false);
@@ -256,9 +256,9 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             "left", prefs.getKey(KeyBinds.BACK));
     private final AbstractAction delete = new GeneralAction(Actions.DELETE, "Delete", Localization.lang("Delete"),
             prefs.getKey(KeyBinds.DELETE));
-    private final AbstractAction copy = new EditAction(Actions.COPY, GUIGlobals.getIconUrl("copy"));
-    private final AbstractAction paste = new EditAction(Actions.PASTE, GUIGlobals.getIconUrl("paste"));
-    private final AbstractAction cut = new EditAction(Actions.CUT, GUIGlobals.getIconUrl("cut"));
+    private final AbstractAction copy = new EditAction(Actions.COPY, IconTheme.getIconUrl("copy"));
+    private final AbstractAction paste = new EditAction(Actions.PASTE, IconTheme.getIconUrl("paste"));
+    private final AbstractAction cut = new EditAction(Actions.CUT, IconTheme.getIconUrl("cut"));
     private final AbstractAction mark = new GeneralAction(Actions.MARK_ENTRIES, "Mark entries",
             Localization.lang("Mark entries"),
             prefs.getKey(KeyBinds.MARK_ENTRIES));
@@ -301,7 +301,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     private final AbstractAction mergeDatabaseAction = new GeneralAction(Actions.MERGE_DATABASE,
             "Append database",
             Localization.lang("Append contents from a BibTeX database into the currently viewed database"),
-            GUIGlobals.getIconUrl("open"));
+            IconTheme.getIconUrl("open"));
     private final AbstractAction selectAll = new GeneralAction(Actions.SELECT_ALL, "Select all",
             prefs.getKey(KeyBinds.SELECT_ALL));
     private final AbstractAction replaceAll = new GeneralAction(Actions.REPLACE_ALL, "Replace string",
@@ -333,11 +333,11 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     private final AbstractAction toggleHighlightAny = new GeneralAction(Actions.TOGGLE_HIGHLIGHTS_GROUPS_MATCHING_ANY,
             "Highlight groups matching any selected entry",
             Localization.lang("Highlight groups matching any selected entry"),
-            GUIGlobals.getIconUrl("groupsHighlightAny"));
+            IconTheme.getIconUrl("groupsHighlightAny"));
     private final AbstractAction toggleHighlightAll = new GeneralAction(Actions.TOGGLE_HIGHLIGHTS_GROUPS_MATCHING_ALL,
             "Highlight groups matching all selected entries",
             Localization.lang("Highlight groups matching all selected entries"),
-            GUIGlobals.getIconUrl("groupsHighlightAll"));
+            IconTheme.getIconUrl("groupsHighlightAll"));
     final AbstractAction switchPreview = new GeneralAction(Actions.SWITCH_PREVIEW,
             "Switch preview layout",
             prefs.getKey(KeyBinds.SWITCH_PREVIEW_LAYOUT));
@@ -399,11 +399,11 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
     private final AbstractAction dbConnect = new GeneralAction(Actions.DB_CONNECT, "Connect to external SQL database",
             Localization.lang("Connect to external SQL database"),
-            GUIGlobals.getIconUrl("dbConnect"));
+            IconTheme.getIconUrl("dbConnect"));
 
     private final AbstractAction dbExport = new GeneralAction(Actions.DB_EXPORT, "Export to external SQL database",
             Localization.lang("Export to external SQL database"),
-            GUIGlobals.getIconUrl("dbExport"));
+            IconTheme.getIconUrl("dbExport"));
 
     private final AbstractAction Cleanup = new GeneralAction(Actions.CLEANUP, "Cleanup entries",
             Localization.lang("Cleanup entries"),
@@ -412,7 +412,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
     private final AbstractAction mergeEntries = new GeneralAction(Actions.MERGE_ENTRIES, "Merge entries",
             Localization.lang("Merge entries"),
-            GUIGlobals.getIconUrl("mergeentries"));
+            IconTheme.getIconUrl("mergeentries"));
 
     private final AbstractAction dbImport = new DbImportAction(this).getAction();
     private final AbstractAction increaseFontSize = new IncreaseTableFontSizeAction();
@@ -492,7 +492,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         // glassPane.setVisible(true);
 
         setTitle(GUIGlobals.frameTitle);
-        setIconImage(GUIGlobals.getImage("jabrefIcon48").getImage());
+        setIconImage(IconTheme.getImage("jabrefIcon48").getImage());
         setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
         addWindowListener(new WindowAdapter() {
 
@@ -1101,7 +1101,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         public GeneralAction(String command, String text,
                              String description, String imageName,
                              KeyStroke key) {
-            super(GUIGlobals.getImage(imageName));
+            super(IconTheme.getImage(imageName));
             this.command = command;
             putValue(Action.NAME, text);
             putValue(Action.ACCELERATOR_KEY, key);
@@ -1121,7 +1121,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
         public GeneralAction(String command, String text, String description) {
             this.command = command;
-            ImageIcon icon = GUIGlobals.getImage(command);
+            ImageIcon icon = IconTheme.getImage(command);
             if (icon != null) {
                 putValue(Action.SMALL_ICON, icon);
             }
@@ -1131,7 +1131,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
         public GeneralAction(String command, String text, String description, KeyStroke key) {
             this.command = command;
-            ImageIcon icon = GUIGlobals.getImage(command);
+            ImageIcon icon = IconTheme.getImage(command);
             if (icon != null) {
                 putValue(Action.SMALL_ICON, icon);
             }
@@ -1142,7 +1142,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
         public GeneralAction(String command, String text, String description, KeyStroke key, String imageUrl) {
             this.command = command;
-            ImageIcon icon = GUIGlobals.getImage(imageUrl);
+            ImageIcon icon = IconTheme.getImage(imageUrl);
             if (icon != null) {
                 putValue(Action.SMALL_ICON, icon);
             }
@@ -1760,7 +1760,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
     class CloseDatabaseAction extends MnemonicAwareAction {
         public CloseDatabaseAction() {
-            super(GUIGlobals.getImage("close"));
+            super(IconTheme.getImage("close"));
             putValue(Action.NAME, "Close database");
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Close the current database"));
             putValue(Action.ACCELERATOR_KEY, prefs.getKey("Close database"));
@@ -1830,7 +1830,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             extends MnemonicAwareAction {
 
         public ShowPrefsAction() {
-            super(GUIGlobals.getImage("preferences"));
+            super(IconTheme.getImage("preferences"));
             putValue(Action.NAME, "Preferences");
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Preferences"));
         }
@@ -2167,7 +2167,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             extends MnemonicAwareAction {
 
         public SaveSessionAction() {
-            super(GUIGlobals.getImage("save"));
+            super(IconTheme.getImage("save"));
             putValue(Action.NAME, "Save session");
             putValue(Action.ACCELERATOR_KEY, prefs.getKey("Save session"));
         }
@@ -2221,7 +2221,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         volatile boolean running;
 
         public LoadSessionAction() {
-            super(GUIGlobals.getImage("loadSession"));
+            super(IconTheme.getImage("loadSession"));
             putValue(Action.NAME, "Load session");
             putValue(Action.ACCELERATOR_KEY, prefs.getKey("Load session"));
         }

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -234,11 +234,11 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     private final AbstractAction saveSelectedAs = new GeneralAction(Actions.SAVE_SELECTED_AS,
             "Save selected as ...",
             Localization.lang("Save selected as ..."),
-            IconTheme.getIconUrl("saveAs"));
+            IconTheme.getImage("saveAs"));
     private final AbstractAction saveSelectedAsPlain = new GeneralAction(Actions.SAVE_SELECTED_AS_PLAIN,
             "Save selected as plain BibTeX ...",
             Localization.lang("Save selected as plain BibTeX ..."),
-            IconTheme.getIconUrl("saveAs"));
+            IconTheme.getImage("saveAs"));
     private final AbstractAction exportAll = ExportFormats.getExportAction(this, false);
     private final AbstractAction exportSelected = ExportFormats.getExportAction(this, true);
     private final AbstractAction importCurrent = ImportFormats.getImportAction(this, false);
@@ -251,9 +251,9 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     private final AbstractAction redo = new GeneralAction(Actions.REDO, "Redo", Localization.lang("Redo"),
             prefs.getKey(KeyBinds.REDO));
     final AbstractAction forward = new GeneralAction(Actions.FORWARD, "Forward", Localization.lang("Forward"),
-            "right", prefs.getKey(KeyBinds.FORWARD));
+            IconTheme.getImage("right"), prefs.getKey(KeyBinds.FORWARD));
     final AbstractAction back = new GeneralAction(Actions.BACK, "Back", Localization.lang("Back"),
-            "left", prefs.getKey(KeyBinds.BACK));
+            IconTheme.getImage("left"), prefs.getKey(KeyBinds.BACK));
     private final AbstractAction delete = new GeneralAction(Actions.DELETE, "Delete", Localization.lang("Delete"),
             prefs.getKey(KeyBinds.DELETE));
     private final AbstractAction copy = new EditAction(Actions.COPY, IconTheme.getIconUrl("copy"));
@@ -301,7 +301,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     private final AbstractAction mergeDatabaseAction = new GeneralAction(Actions.MERGE_DATABASE,
             "Append database",
             Localization.lang("Append contents from a BibTeX database into the currently viewed database"),
-            IconTheme.getIconUrl("open"));
+            IconTheme.getImage("open"));
     private final AbstractAction selectAll = new GeneralAction(Actions.SELECT_ALL, "Select all",
             prefs.getKey(KeyBinds.SELECT_ALL));
     private final AbstractAction replaceAll = new GeneralAction(Actions.REPLACE_ALL, "Replace string",
@@ -333,11 +333,11 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     private final AbstractAction toggleHighlightAny = new GeneralAction(Actions.TOGGLE_HIGHLIGHTS_GROUPS_MATCHING_ANY,
             "Highlight groups matching any selected entry",
             Localization.lang("Highlight groups matching any selected entry"),
-            IconTheme.getIconUrl("groupsHighlightAny"));
+            IconTheme.getImage("groupsHighlightAny"));
     private final AbstractAction toggleHighlightAll = new GeneralAction(Actions.TOGGLE_HIGHLIGHTS_GROUPS_MATCHING_ALL,
             "Highlight groups matching all selected entries",
             Localization.lang("Highlight groups matching all selected entries"),
-            IconTheme.getIconUrl("groupsHighlightAll"));
+            IconTheme.getImage("groupsHighlightAll"));
     final AbstractAction switchPreview = new GeneralAction(Actions.SWITCH_PREVIEW,
             "Switch preview layout",
             prefs.getKey(KeyBinds.SWITCH_PREVIEW_LAYOUT));
@@ -399,20 +399,20 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
     private final AbstractAction dbConnect = new GeneralAction(Actions.DB_CONNECT, "Connect to external SQL database",
             Localization.lang("Connect to external SQL database"),
-            IconTheme.getIconUrl("dbConnect"));
+            IconTheme.getImage("dbConnect"));
 
     private final AbstractAction dbExport = new GeneralAction(Actions.DB_EXPORT, "Export to external SQL database",
             Localization.lang("Export to external SQL database"),
-            IconTheme.getIconUrl("dbExport"));
+            IconTheme.getImage("dbExport"));
 
     private final AbstractAction Cleanup = new GeneralAction(Actions.CLEANUP, "Cleanup entries",
             Localization.lang("Cleanup entries"),
             prefs.getKey(KeyBinds.CLEANUP),
-            "cleanupentries");
+            IconTheme.getImage("cleanupentries"));
 
     private final AbstractAction mergeEntries = new GeneralAction(Actions.MERGE_ENTRIES, "Merge entries",
             Localization.lang("Merge entries"),
-            IconTheme.getIconUrl("mergeentries"));
+            IconTheme.getImage("mergeentries"));
 
     private final AbstractAction dbImport = new DbImportAction(this).getAction();
     private final AbstractAction increaseFontSize = new IncreaseTableFontSizeAction();
@@ -428,7 +428,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             FindUnlinkedFilesDialog.ACTION_COMMAND,
             FindUnlinkedFilesDialog.ACTION_TITLE,
             FindUnlinkedFilesDialog.ACTION_SHORT_DESCRIPTION,
-            FindUnlinkedFilesDialog.ACTION_ICON,
+            IconTheme.getImage(FindUnlinkedFilesDialog.ACTION_ICON),
             prefs.getKey(FindUnlinkedFilesDialog.ACTION_KEYBINDING_ACTION)
     );
 
@@ -1091,17 +1091,17 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         private final String command;
 
         public GeneralAction(String command, String text,
-                             String description, URL icon) {
-            super(new ImageIcon(icon));
+                             String description, ImageIcon icon) {
+            super(icon);
             this.command = command;
             putValue(Action.NAME, text);
             putValue(Action.SHORT_DESCRIPTION, Localization.lang(description));
         }
 
         public GeneralAction(String command, String text,
-                             String description, String imageName,
+                             String description, ImageIcon icon,
                              KeyStroke key) {
-            super(IconTheme.getImage(imageName));
+            super(icon);
             this.command = command;
             putValue(Action.NAME, text);
             putValue(Action.ACCELERATOR_KEY, key);
@@ -1120,32 +1120,23 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         }
 
         public GeneralAction(String command, String text, String description) {
+            super(IconTheme.getImage(command));
             this.command = command;
-            ImageIcon icon = IconTheme.getImage(command);
-            if (icon != null) {
-                putValue(Action.SMALL_ICON, icon);
-            }
             putValue(Action.NAME, text);
             putValue(Action.SHORT_DESCRIPTION, Localization.lang(description));
         }
 
         public GeneralAction(String command, String text, String description, KeyStroke key) {
+            super(IconTheme.getImage(command));
             this.command = command;
-            ImageIcon icon = IconTheme.getImage(command);
-            if (icon != null) {
-                putValue(Action.SMALL_ICON, icon);
-            }
             putValue(Action.NAME, text);
             putValue(Action.SHORT_DESCRIPTION, Localization.lang(description));
             putValue(Action.ACCELERATOR_KEY, key);
         }
 
-        public GeneralAction(String command, String text, String description, KeyStroke key, String imageUrl) {
+        public GeneralAction(String command, String text, String description, KeyStroke key, ImageIcon icon) {
+            super(icon);
             this.command = command;
-            ImageIcon icon = IconTheme.getImage(imageUrl);
-            if (icon != null) {
-                putValue(Action.SMALL_ICON, icon);
-            }
             putValue(Action.NAME, text);
             putValue(Action.SHORT_DESCRIPTION, Localization.lang(description));
             putValue(Action.ACCELERATOR_KEY, key);

--- a/src/main/java/net/sf/jabref/gui/PreambleEditor.java
+++ b/src/main/java/net/sf/jabref/gui/PreambleEditor.java
@@ -189,7 +189,7 @@ class PreambleEditor extends JDialog {
     class UndoAction extends AbstractAction {
 
         public UndoAction() {
-            super("Undo", GUIGlobals.getImage("undo"));
+            super("Undo", IconTheme.getImage("undo"));
             putValue(Action.SHORT_DESCRIPTION, "Undo");
         }
 
@@ -209,7 +209,7 @@ class PreambleEditor extends JDialog {
     class RedoAction extends AbstractAction {
 
         public RedoAction() {
-            super("Undo", GUIGlobals.getImage("redo"));
+            super("Undo", IconTheme.getImage("redo"));
             putValue(Action.SHORT_DESCRIPTION, "Redo");
         }
 

--- a/src/main/java/net/sf/jabref/gui/PreviewPanel.java
+++ b/src/main/java/net/sf/jabref/gui/PreviewPanel.java
@@ -204,7 +204,7 @@ public class PreviewPanel extends JPanel implements VetoableChangeListener, Sear
         private static final long serialVersionUID = 1L;
 
         public PrintAction() {
-            super(Localization.lang("Print Preview"), GUIGlobals.getImage("psSmall"));
+            super(Localization.lang("Print Preview"), IconTheme.getImage("psSmall"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Print Preview"));
         }
 
@@ -254,7 +254,7 @@ public class PreviewPanel extends JPanel implements VetoableChangeListener, Sear
         private static final long serialVersionUID = 1L;
 
         public CloseAction() {
-            super(Localization.lang("Close window"), GUIGlobals.getImage("close"));
+            super(Localization.lang("Close window"), IconTheme.getImage("close"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Close window"));
         }
 

--- a/src/main/java/net/sf/jabref/gui/RightClickMenu.java
+++ b/src/main/java/net/sf/jabref/gui/RightClickMenu.java
@@ -74,7 +74,7 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
 
         addPopupMenuListener(this);
 
-        add(new AbstractAction(Localization.lang("Copy"), GUIGlobals.getImage("copy")) {
+        add(new AbstractAction(Localization.lang("Copy"), IconTheme.getImage("copy")) {
 
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -85,7 +85,7 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
                 }
             }
         });
-        add(new AbstractAction(Localization.lang("Paste"), GUIGlobals.getImage("paste")) {
+        add(new AbstractAction(Localization.lang("Paste"), IconTheme.getImage("paste")) {
 
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -96,7 +96,7 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
                 }
             }
         });
-        add(new AbstractAction(Localization.lang("Cut"), GUIGlobals.getImage("cut")) {
+        add(new AbstractAction(Localization.lang("Cut"), IconTheme.getImage("cut")) {
 
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -108,7 +108,7 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
             }
         });
 
-        add(new AbstractAction(Localization.lang("Delete"), GUIGlobals.getImage("delete")) {
+        add(new AbstractAction(Localization.lang("Delete"), IconTheme.getImage("delete")) {
 
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -156,7 +156,7 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
         }
 
         if (multiple) {
-            add(new AbstractAction(Localization.lang("Mark entries"), GUIGlobals.getImage("markEntries")) {
+            add(new AbstractAction(Localization.lang("Mark entries"), IconTheme.getImage("markEntries")) {
 
                 @Override
                 public void actionPerformed(ActionEvent e) {
@@ -170,7 +170,7 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
 
             add(markSpecific);
 
-            add(new AbstractAction(Localization.lang("Unmark entries"), GUIGlobals.getImage("unmarkEntries")) {
+            add(new AbstractAction(Localization.lang("Unmark entries"), IconTheme.getImage("unmarkEntries")) {
 
                 @Override
                 public void actionPerformed(ActionEvent e) {
@@ -186,7 +186,7 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
             String marked = be.getField(BibtexFields.MARKED);
             // We have to check for "" too as the marked field may be empty
             if (marked == null || marked.isEmpty()) {
-                add(new AbstractAction(Localization.lang("Mark entry"), GUIGlobals.getImage("markEntries")) {
+                add(new AbstractAction(Localization.lang("Mark entry"), IconTheme.getImage("markEntries")) {
 
                     @Override
                     public void actionPerformed(ActionEvent e) {
@@ -201,7 +201,7 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
                 add(markSpecific);
             } else {
                 add(markSpecific);
-                add(new AbstractAction(Localization.lang("Unmark entry"), GUIGlobals.getImage("unmarkEntries")) {
+                add(new AbstractAction(Localization.lang("Unmark entry"), IconTheme.getImage("unmarkEntries")) {
 
                     @Override
                     public void actionPerformed(ActionEvent e) {
@@ -251,7 +251,7 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
             addSeparator();
         }
 
-        add(new AbstractAction(Localization.lang("Open folder"), GUIGlobals.getImage("openFolder")) {
+        add(new AbstractAction(Localization.lang("Open folder"), IconTheme.getImage("openFolder")) {
 
             {
                 if (!isFieldSetForSelectedEntry("file")) {
@@ -269,7 +269,7 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
             }
         });
 
-        add(new AbstractAction(Localization.lang("Open file"), GUIGlobals.getImage("openExternalFile")) {
+        add(new AbstractAction(Localization.lang("Open file"), IconTheme.getImage("openExternalFile")) {
 
             {
                 if(!isFieldSetForSelectedEntry("file")) {
@@ -287,7 +287,7 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
             }
         });
 
-        add(new AbstractAction(Localization.lang("Attach file"), GUIGlobals.getImage("open")) {
+        add(new AbstractAction(Localization.lang("Attach file"), IconTheme.getImage("open")) {
 
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -306,7 +306,7 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
             }
         });*/
 
-        add(new AbstractAction(Localization.lang("Open URL or DOI"), GUIGlobals.getImage("www")) {
+        add(new AbstractAction(Localization.lang("Open URL or DOI"), IconTheme.getImage("www")) {
 
             {
                 if(!(isFieldSetForSelectedEntry("url") || isFieldSetForSelectedEntry("doi"))) {
@@ -560,13 +560,13 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
         if (Globals.prefs.getBoolean(JabRefPreferences.GROUP_SHOW_ICONS)) {
             switch (group.getHierarchicalContext()) {
             case INCLUDING:
-                menuItem.setIcon(GUIGlobals.getImage("groupIncluding"));
+                menuItem.setIcon(IconTheme.getImage("groupIncluding"));
                 break;
             case REFINING:
-                menuItem.setIcon(GUIGlobals.getImage("groupRefining"));
+                menuItem.setIcon(IconTheme.getImage("groupRefining"));
                 break;
             default:
-                menuItem.setIcon(GUIGlobals.getImage("groupRegular"));
+                menuItem.setIcon(IconTheme.getImage("groupRegular"));
                 break;
             }
         }

--- a/src/main/java/net/sf/jabref/gui/SearchManager.java
+++ b/src/main/java/net/sf/jabref/gui/SearchManager.java
@@ -86,7 +86,7 @@ public class SearchManager extends SidePaneComponent
     // that the search is inactive.
 
     public SearchManager(JabRefFrame frame, SidePaneManager manager) {
-        super(manager, GUIGlobals.getIconUrl("search"), Localization.lang("Search"));
+        super(manager, IconTheme.getIconUrl("search"), Localization.lang("Search"));
 
         this.frame = frame;
         incSearcher = new IncrementalSearcher(Globals.prefs);
@@ -239,7 +239,7 @@ public class SearchManager extends SidePaneComponent
         //search.setMargin(margin);
         escape.setMargin(margin);
         openset.setMargin(margin);
-        JButton help = new JButton(GUIGlobals.getImage("help"));
+        JButton help = new JButton(IconTheme.getImage("help"));
         int butSize = help.getIcon().getIconHeight() + 5;
         Dimension butDim = new Dimension(butSize, butSize);
         help.setPreferredSize(butDim);

--- a/src/main/java/net/sf/jabref/gui/SearchManager.java
+++ b/src/main/java/net/sf/jabref/gui/SearchManager.java
@@ -86,7 +86,7 @@ public class SearchManager extends SidePaneComponent
     // that the search is inactive.
 
     public SearchManager(JabRefFrame frame, SidePaneManager manager) {
-        super(manager, IconTheme.getIconUrl("search"), Localization.lang("Search"));
+        super(manager, IconTheme.getImage("search"), Localization.lang("Search"));
 
         this.frame = frame;
         incSearcher = new IncrementalSearcher(Globals.prefs);

--- a/src/main/java/net/sf/jabref/gui/SearchResultsDialog.java
+++ b/src/main/java/net/sf/jabref/gui/SearchResultsDialog.java
@@ -80,8 +80,8 @@ public class SearchResultsDialog {
     private final int FILE_COL = 0;
     private final int URL_COL = 1;
     private final int PAD = 2;
-    private final JLabel fileLabel = new JLabel(GUIGlobals.getImage("psSmall"));
-    private final JLabel urlLabel = new JLabel(GUIGlobals.getImage("wwwSmall"));
+    private final JLabel fileLabel = new JLabel(IconTheme.getImage("psSmall"));
+    private final JLabel urlLabel = new JLabel(IconTheme.getImage("wwwSmall"));
 
     private final Rectangle toRect = new Rectangle(0, 0, 1, 1);
 

--- a/src/main/java/net/sf/jabref/gui/SidePaneComponent.java
+++ b/src/main/java/net/sf/jabref/gui/SidePaneComponent.java
@@ -42,9 +42,9 @@ public abstract class SidePaneComponent extends JXTitledPanel {
     protected BasePanel panel;
 
 
-    public SidePaneComponent(SidePaneManager manager, URL icon, String title) {
+    public SidePaneComponent(SidePaneManager manager, ImageIcon icon, String title) {
         super(title);
-        this.add(new JLabel(new ImageIcon(icon)));
+        this.add(new JLabel(icon));
         this.manager = manager;
         JToolBar tlb = new JToolBar();
         close.setMargin(new Insets(0, 0, 0, 0));

--- a/src/main/java/net/sf/jabref/gui/SidePaneComponent.java
+++ b/src/main/java/net/sf/jabref/gui/SidePaneComponent.java
@@ -33,7 +33,7 @@ public abstract class SidePaneComponent extends JXTitledPanel {
 
     private static final long serialVersionUID = 1L;
 
-    protected final JButton close = new JButton(GUIGlobals.getImage("close"));
+    protected final JButton close = new JButton(IconTheme.getImage("close"));
 
     private boolean visible;
 
@@ -49,9 +49,9 @@ public abstract class SidePaneComponent extends JXTitledPanel {
         JToolBar tlb = new JToolBar();
         close.setMargin(new Insets(0, 0, 0, 0));
         close.setBorder(null);
-        JButton up = new JButton(GUIGlobals.getImage("up"));
+        JButton up = new JButton(IconTheme.getImage("up"));
         up.setMargin(new Insets(0, 0, 0, 0));
-        JButton down = new JButton(GUIGlobals.getImage("down"));
+        JButton down = new JButton(IconTheme.getImage("down"));
         down.setMargin(new Insets(0, 0, 0, 0));
         up.setBorder(null);
         down.setBorder(null);

--- a/src/main/java/net/sf/jabref/gui/StringDialog.java
+++ b/src/main/java/net/sf/jabref/gui/StringDialog.java
@@ -388,7 +388,7 @@ class StringDialog extends JDialog {
 
         public NewStringAction(StringDialog parent) {
             super("New string",
-                    GUIGlobals.getImage("add"));
+                    IconTheme.getImage("add"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("New string"));
             this.parent = parent;
         }
@@ -459,7 +459,7 @@ class StringDialog extends JDialog {
 
         public StoreContentAction(StringDialog parent) {
             super("Store string",
-                    GUIGlobals.getImage("add"));
+                    IconTheme.getImage("add"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Store string"));
             this.parent = parent;
         }
@@ -477,7 +477,7 @@ class StringDialog extends JDialog {
 
         public RemoveStringAction(StringDialog parent) {
             super("Remove selected strings",
-                    GUIGlobals.getImage("remove"));
+                    IconTheme.getImage("remove"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Remove selected strings"));
             this.parent = parent;
         }
@@ -598,7 +598,7 @@ class StringDialog extends JDialog {
     class UndoAction extends AbstractAction {
 
         public UndoAction() {
-            super("Undo", GUIGlobals.getImage("undo"));
+            super("Undo", IconTheme.getImage("undo"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Undo"));
         }
 
@@ -615,7 +615,7 @@ class StringDialog extends JDialog {
     class RedoAction extends AbstractAction {
 
         public RedoAction() {
-            super("Undo", GUIGlobals.getImage("redo"));
+            super("Undo", IconTheme.getImage("redo"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Redo"));
         }
 

--- a/src/main/java/net/sf/jabref/gui/actions/Actions.java
+++ b/src/main/java/net/sf/jabref/gui/actions/Actions.java
@@ -4,6 +4,7 @@ package net.sf.jabref.gui.actions;
  * Global String constants for GUI actions
  */
 public class Actions {
+
     public static final String ABBREVIATE_ISO = "abbreviateIso";
     public static final String ABBREVIATE_MEDLINE = "abbreviateMedline";
     public static final String ADD_FILE_LINK = "addFileLink";
@@ -30,7 +31,7 @@ public class Actions {
     public static final String FORWARD = "forward";
     public static final String INC_SEARCH = "incSearch";
     public static final String MAKE_KEY = "makeKey";
-    public static final String MANAGE_SELECTORS= "manageSelectors";
+    public static final String MANAGE_SELECTORS = "manageSelectors";
     public static final String MARK_ENTRIES = "markEntries";
     public static final String MERGE_DATABASE = "mergeDatabase";
     public static final String MERGE_ENTRIES = "mergeEntries";

--- a/src/main/java/net/sf/jabref/gui/actions/AutoLinkFilesAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/AutoLinkFilesAction.java
@@ -9,11 +9,11 @@ import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JDialog;
 
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.model.entry.BibtexEntry;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRef;
 import net.sf.jabref.JabRefExecutorService;
-import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.gui.undo.NamedCompound;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.util.Util;
@@ -25,7 +25,7 @@ import net.sf.jabref.util.Util;
 public class AutoLinkFilesAction extends AbstractAction {
 
     public AutoLinkFilesAction() {
-        putValue(Action.SMALL_ICON, GUIGlobals.getImage("autoGroup"));
+        putValue(Action.SMALL_ICON, IconTheme.getImage("autoGroup"));
         putValue(Action.NAME, Localization.lang("Automatically set file links"));
         putValue(Action.ACCELERATOR_KEY, Globals.prefs.getKey("Automatically link files"));
     }

--- a/src/main/java/net/sf/jabref/gui/actions/CopyAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/CopyAction.java
@@ -1,7 +1,7 @@
 package net.sf.jabref.gui.actions;
 
 import net.sf.jabref.gui.ClipBoardManager;
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 
 import javax.swing.*;
@@ -16,7 +16,7 @@ public class CopyAction extends AbstractAction {
 
         putValue(Action.NAME, Localization.lang("Copy to clipboard"));
         putValue(Action.SHORT_DESCRIPTION, Localization.lang("Copy to clipboard"));
-        putValue(Action.SMALL_ICON, GUIGlobals.getImage("copy"));
+        putValue(Action.SMALL_ICON, IconTheme.getImage("copy"));
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
@@ -1,7 +1,7 @@
 package net.sf.jabref.gui.actions;
 
 import net.sf.jabref.gui.BasePanel;
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibtexDatabase;
@@ -20,7 +20,7 @@ public class IntegrityCheckAction extends AbstractAction {
 
     public IntegrityCheckAction(JabRefFrame jabRefFrame) {
         super(Localization.menuTitle("Integrity check"),
-                GUIGlobals.getImage("integrityCheck"));
+                IconTheme.getImage("integrityCheck"));
         this.jabRefFrame = jabRefFrame;
         //putValue( SHORT_DESCRIPTION, "integrity" ) ;  //Globals.lang( "integrity" ) ) ;
         //putValue(MNEMONIC_KEY, GUIGlobals.newKeyCode);

--- a/src/main/java/net/sf/jabref/gui/actions/NewDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/NewDatabaseAction.java
@@ -3,7 +3,7 @@ package net.sf.jabref.gui.actions;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.MnemonicAwareAction;
 import net.sf.jabref.logic.l10n.Localization;
@@ -19,7 +19,7 @@ public class NewDatabaseAction extends MnemonicAwareAction {
     private JabRefFrame jabRefFrame;
 
     public NewDatabaseAction(JabRefFrame jabRefFrame) {
-        super(GUIGlobals.getImage("new"));
+        super(IconTheme.getImage("new"));
         this.jabRefFrame = jabRefFrame;
         putValue(Action.NAME, "New database");
         putValue(Action.SHORT_DESCRIPTION, Localization.lang("New BibTeX database"));

--- a/src/main/java/net/sf/jabref/gui/actions/NewEntryAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/NewEntryAction.java
@@ -20,7 +20,7 @@ public class NewEntryAction extends MnemonicAwareAction {
 
     public NewEntryAction(JabRefFrame jabRefFrame, KeyStroke key) {
         // This action leads to a dialog asking for entry type.
-        super(GUIGlobals.getImage("add"));
+        super(IconTheme.getImage("add"));
         this.jabRefFrame = jabRefFrame;
         putValue(Action.NAME, "New entry");
         putValue(Action.ACCELERATOR_KEY, key);

--- a/src/main/java/net/sf/jabref/gui/actions/NewSubDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/NewSubDatabaseAction.java
@@ -3,10 +3,7 @@ package net.sf.jabref.gui.actions;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
-import net.sf.jabref.gui.BasePanel;
-import net.sf.jabref.gui.GUIGlobals;
-import net.sf.jabref.gui.JabRefFrame;
-import net.sf.jabref.gui.MnemonicAwareAction;
+import net.sf.jabref.gui.*;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.util.Util;
 import net.sf.jabref.wizard.auximport.gui.FromAuxDialog;
@@ -22,7 +19,7 @@ public class NewSubDatabaseAction extends MnemonicAwareAction {
     private JabRefFrame jabRefFrame;
 
     public NewSubDatabaseAction(JabRefFrame jabRefFrame) {
-        super(GUIGlobals.getImage("new"));
+        super(IconTheme.getImage("new"));
         this.jabRefFrame = jabRefFrame;
         putValue(Action.NAME, "New subdatabase based on AUX file");
         putValue(Action.SHORT_DESCRIPTION, Localization.lang("New BibTeX subdatabase"));

--- a/src/main/java/net/sf/jabref/gui/actions/PasteAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/PasteAction.java
@@ -1,7 +1,7 @@
 package net.sf.jabref.gui.actions;
 
 import net.sf.jabref.gui.ClipBoardManager;
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.io.URLUtil;
 
@@ -18,7 +18,7 @@ public class PasteAction extends AbstractAction {
 
         putValue(Action.NAME, Localization.lang("Paste from clipboard"));
         putValue(Action.SHORT_DESCRIPTION, Localization.lang("Paste from clipboard"));
-        putValue(Action.SMALL_ICON, GUIGlobals.getImage("paste"));
+        putValue(Action.SMALL_ICON, IconTheme.getImage("paste"));
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -218,7 +218,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
         if (reqPan.fileListEditor != null) {
             fileListEditor = reqPan.fileListEditor;
         }
-        tabbed.addTab(Localization.lang("Required fields"), GUIGlobals.getImage("required"), reqPan
+        tabbed.addTab(Localization.lang("Required fields"), IconTheme.getImage("required"), reqPan
                 .getPane(), Localization.lang("Show required fields"));
         tabs.add(reqPan);
 
@@ -230,7 +230,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                 if (optPan.fileListEditor != null) {
                     fileListEditor = optPan.fileListEditor;
                 }
-                tabbed.addTab(Localization.lang("Optional fields"), GUIGlobals.getImage("optional"), optPan
+                tabbed.addTab(Localization.lang("Optional fields"), IconTheme.getImage("optional"), optPan
                         .getPane(), Localization.lang("Show optional fields"));
                 tabs.add(optPan);
             } else {
@@ -240,7 +240,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                 if (optPan.fileListEditor != null) {
                     fileListEditor = optPan.fileListEditor;
                 }
-                tabbed.addTab(Localization.lang("Optional fields"), GUIGlobals.getImage("optional"), optPan
+                tabbed.addTab(Localization.lang("Optional fields"), IconTheme.getImage("optional"), optPan
                         .getPane(), Localization.lang("Show optional fields"));
                 tabs.add(optPan);
 
@@ -271,7 +271,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                 if (optPan2.fileListEditor != null) {
                     fileListEditor = optPan2.fileListEditor;
                 }
-                tabbed.addTab(Localization.lang("Optional fields 2"), GUIGlobals.getImage("optional"), optPan2
+                tabbed.addTab(Localization.lang("Optional fields 2"), IconTheme.getImage("optional"), optPan2
                         .getPane(), Localization.lang("Show optional fields"));
                 tabs.add(optPan2);
 
@@ -283,7 +283,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                     if (optPan3.fileListEditor != null) {
                         fileListEditor = optPan3.fileListEditor;
                     }
-                    tabbed.addTab(Localization.lang("Deprecated fields"), GUIGlobals.getImage("optional"), optPan3
+                    tabbed.addTab(Localization.lang("Deprecated fields"), IconTheme.getImage("optional"), optPan3
                             .getPane(), Localization.lang("Show deprecated bibtex fields"));
                     tabs.add(optPan3);
                 }
@@ -297,13 +297,13 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
             if (newTab.fileListEditor != null) {
                 fileListEditor = newTab.fileListEditor;
             }
-            tabbed.addTab(tabList.getTabName(i), GUIGlobals.getImage("general"), newTab.getPane());
+            tabbed.addTab(tabList.getTabName(i), IconTheme.getImage("general"), newTab.getPane());
             tabs.add(newTab);
         }
 
         srcPanel.setName(Localization.lang("BibTeX source"));
         if (Globals.prefs.getBoolean(JabRefPreferences.SHOW_SOURCE)) {
-            tabbed.addTab(Localization.lang("BibTeX source"), GUIGlobals.getImage("source"), srcPanel,
+            tabbed.addTab(Localization.lang("BibTeX source"), IconTheme.getImage("source"), srcPanel,
                     Localization.lang("Show/edit BibTeX source"));
             tabs.add(srcPanel);
         }
@@ -1011,7 +1011,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
         private static final long serialVersionUID = 1L;
 
         public TypeButton(String type) {
-            super(GUIGlobals.getImage("edit"));
+            super(IconTheme.getImage("edit"));
             setToolTipText(Localization.lang("Change entry type"));
             addActionListener(new ActionListener() {
 
@@ -1130,7 +1130,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
         private static final long serialVersionUID = 1L;
 
         public DeleteAction() {
-            super(Localization.lang("Delete"), GUIGlobals.getImage("delete"));
+            super(Localization.lang("Delete"), IconTheme.getImage("delete"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Delete entry"));
         }
 
@@ -1156,7 +1156,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
         private static final long serialVersionUID = 1L;
 
         public CloseAction() {
-            super(Localization.lang("Close window"), GUIGlobals.getImage("close"));
+            super(Localization.lang("Close window"), IconTheme.getImage("close"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Close window"));
         }
 
@@ -1377,7 +1377,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
         private static final long serialVersionUID = 1L;
 
         public NextEntryAction() {
-            super(Localization.lang("Next entry"), GUIGlobals.getImage("down"));
+            super(Localization.lang("Next entry"), IconTheme.getImage("down"));
 
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Next entry"));
         }
@@ -1408,7 +1408,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
         private static final long serialVersionUID = 1L;
 
         public PrevEntryAction() {
-            super(Localization.lang("Previous entry"), GUIGlobals.getImage("up"));
+            super(Localization.lang("Previous entry"), IconTheme.getImage("up"));
 
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Previous entry"));
         }
@@ -1442,7 +1442,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
 
 
         public GenerateKeyAction(JabRefFrame parentFrame) {
-            super(Localization.lang("Generate BibTeX key"), GUIGlobals.getImage("makeKey"));
+            super(Localization.lang("Generate BibTeX key"), IconTheme.getImage("makeKey"));
             parent = parentFrame;
 
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Generate BibTeX key"));
@@ -1503,7 +1503,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
         private static final long serialVersionUID = 1L;
 
         public UndoAction() {
-            super("Undo", GUIGlobals.getImage("undo"));
+            super("Undo", IconTheme.getImage("undo"));
             putValue(Action.SHORT_DESCRIPTION, "Undo");
         }
 
@@ -1518,7 +1518,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
         private static final long serialVersionUID = 1L;
 
         public RedoAction() {
-            super("Undo", GUIGlobals.getImage("redo"));
+            super("Undo", IconTheme.getImage("redo"));
             putValue(Action.SHORT_DESCRIPTION, "Redo");
         }
 
@@ -1616,7 +1616,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
         private static final long serialVersionUID = 1L;
 
         public AutoLinkAction() {
-            putValue(Action.SMALL_ICON, GUIGlobals.getImage("autoGroup"));
+            putValue(Action.SMALL_ICON, IconTheme.getImage("autoGroup"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Automatically set file links for this entry") + " (Alt-F)");
         }
 

--- a/src/main/java/net/sf/jabref/gui/fieldeditors/FileListEditor.java
+++ b/src/main/java/net/sf/jabref/gui/fieldeditors/FileListEditor.java
@@ -86,13 +86,13 @@ public class FileListEditor extends JTable implements FieldEditor,
         setTableHeader(null);
         addMouseListener(new TableClickListener());
 
-        JButton add = new JButton(GUIGlobals.getImage("add"));
+        JButton add = new JButton(IconTheme.getImage("add"));
         add.setToolTipText(Localization.lang("New file link (INSERT)"));
-        JButton remove = new JButton(GUIGlobals.getImage("remove"));
+        JButton remove = new JButton(IconTheme.getImage("remove"));
         remove.setToolTipText(Localization.lang("Remove file link (DELETE)"));
-        JButton up = new JButton(GUIGlobals.getImage("up"));
+        JButton up = new JButton(IconTheme.getImage("up"));
 
-        JButton down = new JButton(GUIGlobals.getImage("down"));
+        JButton down = new JButton(IconTheme.getImage("down"));
         auto = new JButton(Localization.lang("Auto"));
         JButton download = new JButton(Localization.lang("Download"));
         add.setMargin(new Insets(0, 0, 0, 0));

--- a/src/main/java/net/sf/jabref/gui/fieldeditors/contextmenu/CaseChangeMenu.java
+++ b/src/main/java/net/sf/jabref/gui/fieldeditors/contextmenu/CaseChangeMenu.java
@@ -25,7 +25,9 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
 public class CaseChangeMenu extends JMenu {
+
     private final JTextComponent parent;
+
 
     public CaseChangeMenu(JTextComponent opener) {
         super(Localization.lang("Change case"));

--- a/src/main/java/net/sf/jabref/gui/help/HelpAction.java
+++ b/src/main/java/net/sf/jabref/gui/help/HelpAction.java
@@ -56,8 +56,8 @@ public class HelpAction extends MnemonicAwareAction {
         this.helpFile = helpFile;
     }
 
-    public HelpAction(HelpDialog diag, String helpFile, String tooltip, URL iconFile) {
-        super(new ImageIcon(iconFile));
+    public HelpAction(HelpDialog diag, String helpFile, String tooltip, ImageIcon iconFile) {
+        super(iconFile);
         putValue(Action.NAME, "Help");
         putValue(Action.SHORT_DESCRIPTION, Localization.lang(tooltip));
         this.diag = diag;
@@ -81,8 +81,8 @@ public class HelpAction extends MnemonicAwareAction {
         this.helpFile = helpFile;
     }
 
-    public HelpAction(String title, HelpDialog diag, String helpFile, String tooltip, URL iconFile) {
-        super(new ImageIcon(iconFile));
+    public HelpAction(String title, HelpDialog diag, String helpFile, String tooltip, ImageIcon iconFile) {
+        super(iconFile);
         putValue(Action.NAME, title);
         putValue(Action.SHORT_DESCRIPTION, Localization.lang(tooltip));
         this.diag = diag;

--- a/src/main/java/net/sf/jabref/gui/help/HelpAction.java
+++ b/src/main/java/net/sf/jabref/gui/help/HelpAction.java
@@ -24,7 +24,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.KeyStroke;
 
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.MnemonicAwareAction;
 import net.sf.jabref.logic.l10n.Localization;
 
@@ -42,14 +42,14 @@ public class HelpAction extends MnemonicAwareAction {
 
 
     public HelpAction(HelpDialog diag, String helpFile) {
-        super(GUIGlobals.getImage("help"));
+        super(IconTheme.getImage("help"));
         putValue(Action.NAME, "Help");
         this.diag = diag;
         this.helpFile = helpFile;
     }
 
     public HelpAction(HelpDialog diag, String helpFile, String tooltip) {
-        super(GUIGlobals.getImage("help"));
+        super(IconTheme.getImage("help"));
         putValue(Action.NAME, "Help");
         putValue(Action.SHORT_DESCRIPTION, Localization.lang(tooltip));
         this.diag = diag;
@@ -65,7 +65,7 @@ public class HelpAction extends MnemonicAwareAction {
     }
 
     public HelpAction(String title, HelpDialog diag, String helpFile, String tooltip) {
-        super(GUIGlobals.getImage("help"));
+        super(IconTheme.getImage("help"));
         putValue(Action.NAME, title);
         putValue(Action.SHORT_DESCRIPTION, Localization.lang(tooltip));
         this.diag = diag;
@@ -73,7 +73,7 @@ public class HelpAction extends MnemonicAwareAction {
     }
 
     public HelpAction(String title, HelpDialog diag, String helpFile, String tooltip, KeyStroke key) {
-        super(GUIGlobals.getImage("help"));
+        super(IconTheme.getImage("help"));
         putValue(Action.NAME, title);
         putValue(Action.SHORT_DESCRIPTION, Localization.lang(tooltip));
         putValue(Action.ACCELERATOR_KEY, key);

--- a/src/main/java/net/sf/jabref/gui/help/HelpDialog.java
+++ b/src/main/java/net/sf/jabref/gui/help/HelpDialog.java
@@ -24,6 +24,7 @@ import javax.swing.event.HyperlinkListener;
 
 import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.JabRef;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.util.Util;
@@ -129,7 +130,7 @@ public class HelpDialog extends JDialog implements HyperlinkListener {
     class BackAction extends AbstractAction {
 
         public BackAction() {
-            super("Back", GUIGlobals.getImage("left"));
+            super("Back", IconTheme.getImage("left"));
             // putValue(SHORT_DESCRIPTION, "Show the previous page");
         }
 
@@ -143,7 +144,7 @@ public class HelpDialog extends JDialog implements HyperlinkListener {
     class ForwardAction extends AbstractAction {
 
         public ForwardAction() {
-            super("Forward", GUIGlobals.getImage("right"));
+            super("Forward", IconTheme.getImage("right"));
         }
 
         @Override
@@ -156,7 +157,7 @@ public class HelpDialog extends JDialog implements HyperlinkListener {
     class ContentsAction extends AbstractAction {
 
         public ContentsAction() {
-            super("Contents", GUIGlobals.getImage("helpContents"));
+            super("Contents", IconTheme.getImage("helpContents"));
         }
 
         @Override

--- a/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
+++ b/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
@@ -30,6 +30,7 @@ import javax.swing.table.AbstractTableModel;
 
 import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.Globals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.FileDialogs;
@@ -70,8 +71,8 @@ class ManageJournalsPanel extends JPanel {
     private final JRadioButton newFile = new JRadioButton(Localization.lang("New file"));
     private final JRadioButton oldFile = new JRadioButton(Localization.lang("Existing file"));
 
-    private final JButton add = new JButton(GUIGlobals.getImage("add"));
-    private final JButton remove = new JButton(GUIGlobals.getImage("remove"));
+    private final JButton add = new JButton(IconTheme.getImage("add"));
+    private final JButton remove = new JButton(IconTheme.getImage("remove"));
 
 
     public ManageJournalsPanel(final JabRefFrame frame) {
@@ -83,7 +84,7 @@ class ManageJournalsPanel extends JPanel {
         group.add(newFile);
         group.add(oldFile);
         addExtPan.setLayout(new BorderLayout());
-        JButton addExt = new JButton(GUIGlobals.getImage("add"));
+        JButton addExt = new JButton(IconTheme.getImage("add"));
         addExtPan.add(addExt, BorderLayout.EAST);
         addExtPan.setToolTipText(Localization.lang("Add"));
         //addExtPan.setBorder(BorderFactory.createMatteBorder(1,1,1,1,Color.red));
@@ -620,7 +621,7 @@ class ManageJournalsPanel extends JPanel {
         private final JTextField tf;
         private final JButton browse = new JButton(Localization.lang("Browse"));
         private final JButton view = new JButton(Localization.lang("Preview"));
-        private final JButton clear = new JButton(GUIGlobals.getImage("delete"));
+        private final JButton clear = new JButton(IconTheme.getImage("delete"));
         private final JButton download = new JButton(Localization.lang("Download"));
 
 

--- a/src/main/java/net/sf/jabref/gui/labelPattern/LabelPatternPanel.java
+++ b/src/main/java/net/sf/jabref/gui/labelPattern/LabelPatternPanel.java
@@ -32,6 +32,7 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.model.entry.BibtexEntryType;
 import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.Globals;
@@ -141,7 +142,7 @@ public class LabelPatternPanel extends JPanel {
         con.weighty = 0;
         con.anchor = GridBagConstraints.SOUTHEAST;
         con.insets = new Insets(0, 5, 0, 5);
-        JButton hlb = new JButton(GUIGlobals.getImage("helpSmall"));
+        JButton hlb = new JButton(IconTheme.getImage("helpSmall"));
         hlb.setToolTipText(Localization.lang("Help on key patterns"));
         gbl.setConstraints(hlb, con);
         add(hlb);

--- a/src/main/java/net/sf/jabref/gui/preftabs/AdvancedTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/AdvancedTab.java
@@ -33,6 +33,7 @@ import javax.swing.event.ChangeListener;
 
 import net.sf.jabref.*;
 import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.gui.help.HelpDialog;
 import net.sf.jabref.logic.journals.JournalAbbreviationRepository;
@@ -74,7 +75,7 @@ class AdvancedTab extends JPanel implements PrefsTab {
         this.remotePreferences = new RemotePreferences(preferences);
 
         HelpAction remoteHelp = new HelpAction(diag, GUIGlobals.remoteHelp, "Help",
-                GUIGlobals.getIconUrl("helpSmall"));
+                IconTheme.getIconUrl("helpSmall"));
         useDefault = new JCheckBox(Localization.lang("Use other look and feel"));
         useRemoteServer = new JCheckBox(Localization.lang("Listen for remote operation on port") + ':');
         useNativeFileDialogOnMac = new JCheckBox(Localization.lang("Use native file dialog"));

--- a/src/main/java/net/sf/jabref/gui/preftabs/AdvancedTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/AdvancedTab.java
@@ -75,7 +75,7 @@ class AdvancedTab extends JPanel implements PrefsTab {
         this.remotePreferences = new RemotePreferences(preferences);
 
         HelpAction remoteHelp = new HelpAction(diag, GUIGlobals.remoteHelp, "Help",
-                IconTheme.getIconUrl("helpSmall"));
+                IconTheme.getImage("helpSmall"));
         useDefault = new JCheckBox(Localization.lang("Use other look and feel"));
         useRemoteServer = new JCheckBox(Localization.lang("Listen for remote operation on port") + ':');
         useNativeFileDialogOnMac = new JCheckBox(Localization.lang("Use native file dialog"));

--- a/src/main/java/net/sf/jabref/gui/preftabs/ExternalTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/ExternalTab.java
@@ -142,7 +142,7 @@ class ExternalTab extends JPanel implements PrefsTab {
         builder.append(regExpTextField);
 
         HelpAction helpAction = new HelpAction(helpDialog, GUIGlobals.regularExpressionSearchHelp,
-                Localization.lang("Help on Regular Expression Search"), IconTheme.getIconUrl("helpSmall"));
+                Localization.lang("Help on Regular Expression Search"), IconTheme.getImage("helpSmall"));
         builder.append(helpAction.getIconButton());
         builder.nextLine();
         builder.append(new JPanel());

--- a/src/main/java/net/sf/jabref/gui/preftabs/ExternalTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/ExternalTab.java
@@ -28,6 +28,7 @@ import javax.swing.event.ChangeListener;
 import net.sf.jabref.*;
 import net.sf.jabref.external.*;
 import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.actions.BrowseAction;
 import net.sf.jabref.gui.help.HelpAction;
@@ -141,7 +142,7 @@ class ExternalTab extends JPanel implements PrefsTab {
         builder.append(regExpTextField);
 
         HelpAction helpAction = new HelpAction(helpDialog, GUIGlobals.regularExpressionSearchHelp,
-                Localization.lang("Help on Regular Expression Search"), GUIGlobals.getIconUrl("helpSmall"));
+                Localization.lang("Help on Regular Expression Search"), IconTheme.getIconUrl("helpSmall"));
         builder.append(helpAction.getIconButton());
         builder.nextLine();
         builder.append(new JPanel());

--- a/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
@@ -37,6 +37,7 @@ import javax.swing.event.ChangeListener;
 
 import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.Globals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.help.HelpAction;
@@ -83,7 +84,7 @@ class FileTab extends JPanel implements PrefsTab {
         this.frame = frame;
 
         HelpAction autosaveHelp = new HelpAction(frame.helpDiag, GUIGlobals.autosaveHelp, "Help",
-                GUIGlobals.getIconUrl("helpSmall"));
+                IconTheme.getIconUrl("helpSmall"));
         openLast = new JCheckBox(Localization.lang("Open last edited databases at startup"));
         backup = new JCheckBox(Localization.lang("Backup old file when saving"));
         autoSave = new JCheckBox(Localization.lang(JabRefPreferences.AUTO_SAVE));

--- a/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
@@ -84,7 +84,7 @@ class FileTab extends JPanel implements PrefsTab {
         this.frame = frame;
 
         HelpAction autosaveHelp = new HelpAction(frame.helpDiag, GUIGlobals.autosaveHelp, "Help",
-                IconTheme.getIconUrl("helpSmall"));
+                IconTheme.getImage("helpSmall"));
         openLast = new JCheckBox(Localization.lang("Open last edited databases at startup"));
         backup = new JCheckBox(Localization.lang("Backup old file when saving"));
         autoSave = new JCheckBox(Localization.lang(JabRefPreferences.AUTO_SAVE));

--- a/src/main/java/net/sf/jabref/gui/preftabs/GeneralTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/GeneralTab.java
@@ -110,9 +110,9 @@ class GeneralTab extends JPanel implements PrefsTab {
         timeStampFormat = new JTextField();
         timeStampField = new JTextField();
         HelpAction ownerHelp = new HelpAction(frame.helpDiag, GUIGlobals.ownerHelp,
-                "Help", IconTheme.getIconUrl("helpSmall"));
+                "Help", IconTheme.getImage("helpSmall"));
         HelpAction timeStampHelp = new HelpAction(frame.helpDiag, GUIGlobals.timeStampHelp, "Help",
-                IconTheme.getIconUrl("helpSmall"));
+                IconTheme.getImage("helpSmall"));
         inspectionWarnDupli = new JCheckBox(Localization.lang("Warn about unresolved duplicates when closing inspection window"));
 
         Insets marg = new Insets(0, 12, 3, 0);

--- a/src/main/java/net/sf/jabref/gui/preftabs/GeneralTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/GeneralTab.java
@@ -33,6 +33,7 @@ import javax.swing.event.ChangeListener;
 
 import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.Globals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.help.HelpAction;
@@ -109,9 +110,9 @@ class GeneralTab extends JPanel implements PrefsTab {
         timeStampFormat = new JTextField();
         timeStampField = new JTextField();
         HelpAction ownerHelp = new HelpAction(frame.helpDiag, GUIGlobals.ownerHelp,
-                "Help", GUIGlobals.getIconUrl("helpSmall"));
+                "Help", IconTheme.getIconUrl("helpSmall"));
         HelpAction timeStampHelp = new HelpAction(frame.helpDiag, GUIGlobals.timeStampHelp, "Help",
-                GUIGlobals.getIconUrl("helpSmall"));
+                IconTheme.getIconUrl("helpSmall"));
         inspectionWarnDupli = new JCheckBox(Localization.lang("Warn about unresolved duplicates when closing inspection window"));
 
         Insets marg = new Insets(0, 12, 3, 0);

--- a/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
@@ -199,7 +199,7 @@ public class NameFormatterTab extends JPanel implements PrefsTab {
         toolBar.add(new AddRowAction());
         toolBar.add(new DeleteRowAction());
         toolBar.add(new HelpAction(helpDialog, GUIGlobals.nameFormatterHelp,
-                "Help on Name Formatting", IconTheme.getIconUrl("helpSmall")));
+                "Help on Name Formatting", IconTheme.getImage("helpSmall")));
 
         tabPanel.add(toolBar, BorderLayout.EAST);
 

--- a/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
@@ -30,6 +30,7 @@ import javax.swing.table.TableModel;
 import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.Globals;
 import net.sf.jabref.exporter.layout.format.NameFormatter;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.gui.help.HelpDialog;
 
@@ -198,7 +199,7 @@ public class NameFormatterTab extends JPanel implements PrefsTab {
         toolBar.add(new AddRowAction());
         toolBar.add(new DeleteRowAction());
         toolBar.add(new HelpAction(helpDialog, GUIGlobals.nameFormatterHelp,
-                "Help on Name Formatting", GUIGlobals.getIconUrl("helpSmall")));
+                "Help on Name Formatting", IconTheme.getIconUrl("helpSmall")));
 
         tabPanel.add(toolBar, BorderLayout.EAST);
 
@@ -240,7 +241,7 @@ public class NameFormatterTab extends JPanel implements PrefsTab {
     class DeleteRowAction extends AbstractAction {
 
         public DeleteRowAction() {
-            super("Delete row", GUIGlobals.getImage("remove"));
+            super("Delete row", IconTheme.getImage("remove"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Delete rows"));
         }
 
@@ -273,7 +274,7 @@ public class NameFormatterTab extends JPanel implements PrefsTab {
     class AddRowAction extends AbstractAction {
 
         public AddRowAction() {
-            super("Add row", GUIGlobals.getImage("add"));
+            super("Add row", IconTheme.getImage("add"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Insert rows"));
         }
 

--- a/src/main/java/net/sf/jabref/gui/preftabs/PreviewPrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/PreviewPrefsTab.java
@@ -27,6 +27,7 @@ import javax.swing.*;
 
 import net.sf.jabref.*;
 import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.PreviewPanel;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.logic.id.IdGenerator;
@@ -141,7 +142,7 @@ class PreviewPrefsTab extends JPanel implements PrefsTab {
 
         { // Help Button
             HelpAction helpAction = new HelpAction(GUIGlobals.helpDiag, GUIGlobals.previewHelp,
-                    Localization.lang("Help on Preview Settings"), GUIGlobals.getIconUrl("helpSmall"));
+                    Localization.lang("Help on Preview Settings"), IconTheme.getIconUrl("helpSmall"));
             JButton help = helpAction.getIconButton();
             pdfPreviewPanel.add(help, BorderLayout.EAST);
         }

--- a/src/main/java/net/sf/jabref/gui/preftabs/PreviewPrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/PreviewPrefsTab.java
@@ -142,7 +142,7 @@ class PreviewPrefsTab extends JPanel implements PrefsTab {
 
         { // Help Button
             HelpAction helpAction = new HelpAction(GUIGlobals.helpDiag, GUIGlobals.previewHelp,
-                    Localization.lang("Help on Preview Settings"), IconTheme.getIconUrl("helpSmall"));
+                    Localization.lang("Help on Preview Settings"), IconTheme.getImage("helpSmall"));
             JButton help = helpAction.getIconButton();
             pdfPreviewPanel.add(help, BorderLayout.EAST);
         }

--- a/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
@@ -35,6 +35,7 @@ import net.sf.jabref.*;
 import net.sf.jabref.external.ExternalFileType;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.logic.l10n.Localization;
@@ -283,7 +284,7 @@ class TableColumnsTab extends JPanel implements PrefsTab {
         /*** begin: special table columns and special fields ***/
 
         HelpAction help = new HelpAction(frame.helpDiag, GUIGlobals.specialFieldsHelp);
-        JButton helpButton = new JButton(GUIGlobals.getImage("helpSmall"));
+        JButton helpButton = new JButton(IconTheme.getImage("helpSmall"));
         helpButton.setToolTipText(Localization.lang("Help on special fields"));
         helpButton.addActionListener(help);
 
@@ -472,7 +473,7 @@ class TableColumnsTab extends JPanel implements PrefsTab {
     class DeleteRowAction extends AbstractAction {
 
         public DeleteRowAction() {
-            super("Delete row", GUIGlobals.getImage("remove"));
+            super("Delete row", IconTheme.getImage("remove"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Delete rows"));
         }
 
@@ -502,7 +503,7 @@ class TableColumnsTab extends JPanel implements PrefsTab {
     class AddRowAction extends AbstractAction {
 
         public AddRowAction() {
-            super("Add row", GUIGlobals.getImage("add"));
+            super("Add row", IconTheme.getImage("add"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Insert rows"));
         }
 
@@ -553,7 +554,7 @@ class TableColumnsTab extends JPanel implements PrefsTab {
     class MoveRowUpAction extends AbstractMoveRowAction {
 
         public MoveRowUpAction() {
-            super("Up", GUIGlobals.getImage("up"));
+            super("Up", IconTheme.getImage("up"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Move up"));
         }
 
@@ -586,7 +587,7 @@ class TableColumnsTab extends JPanel implements PrefsTab {
     class MoveRowDownAction extends AbstractMoveRowAction {
 
         public MoveRowDownAction() {
-            super("Down", GUIGlobals.getImage("down"));
+            super("Down", IconTheme.getImage("down"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Down"));
         }
 

--- a/src/main/java/net/sf/jabref/gui/preftabs/XmpPrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/XmpPrefsTab.java
@@ -28,9 +28,9 @@ import javax.swing.table.TableModel;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;
-import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 
 /**
@@ -155,7 +155,7 @@ class XmpPrefsTab extends JPanel implements PrefsTab {
     class DeleteRowAction extends AbstractAction {
 
         public DeleteRowAction() {
-            super("Delete row", GUIGlobals.getImage("remove"));
+            super("Delete row", IconTheme.getImage("remove"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Delete rows"));
         }
 
@@ -184,7 +184,7 @@ class XmpPrefsTab extends JPanel implements PrefsTab {
     class AddRowAction extends AbstractAction {
 
         public AddRowAction() {
-            super("Add row", GUIGlobals.getImage("add"));
+            super("Add row", IconTheme.getImage("add"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Insert rows"));
         }
 

--- a/src/main/java/net/sf/jabref/importer/EntryFromPDFCreator.java
+++ b/src/main/java/net/sf/jabref/importer/EntryFromPDFCreator.java
@@ -6,6 +6,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.List;
 
+import net.sf.jabref.gui.IconTheme;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentInformation;
 
@@ -36,7 +37,7 @@ public class EntryFromPDFCreator extends EntryFromFileCreator {
     private static ExternalFileType getPDFExternalFileType() {
         ExternalFileType pdfFileType = JabRefPreferences.getInstance().getExternalFileTypeByExt("pdf");
         if (pdfFileType == null) {
-            return new ExternalFileType("PDF", "pdf", "application/pdf", "evince", "pdfSmall");
+            return new ExternalFileType("PDF", "pdf", "application/pdf", "evince", "pdfSmall", IconTheme.getImage("pdfSmall"));
         }
         return pdfFileType;
     }

--- a/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
@@ -71,7 +71,7 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
 
 
     public OpenDatabaseAction(JabRefFrame frame, boolean showDialog) {
-        super(GUIGlobals.getImage("open"));
+        super(IconTheme.getImage("open"));
         this.frame = frame;
         this.showDialog = showDialog;
         putValue(Action.NAME, "Open database");

--- a/src/main/java/net/sf/jabref/importer/fetcher/GeneralFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/GeneralFetcher.java
@@ -71,7 +71,7 @@ public class GeneralFetcher extends SidePaneComponent implements ActionListener 
 
 
     public GeneralFetcher(SidePaneManager p0, JabRefFrame frame) {
-        super(p0, IconTheme.getIconUrl("www"), Localization.lang("Web search"));
+        super(p0, IconTheme.getImage("www"), Localization.lang("Web search"));
         this.sidePaneManager = p0;
         this.frame = frame;
         List<EntryFetcher> fetchers = EntryFetchers.INSTANCE.getEntryFetchers();

--- a/src/main/java/net/sf/jabref/importer/fetcher/GeneralFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/GeneralFetcher.java
@@ -56,7 +56,7 @@ public class GeneralFetcher extends SidePaneComponent implements ActionListener 
 
     private final JTextField tf = new JTextField();
     private final JButton helpBut = new JButton(
-            GUIGlobals.getImage("helpSmall"));
+            IconTheme.getImage("helpSmall"));
     private final JComboBox fetcherChoice;
     private final CardLayout optionsCards = new CardLayout();
     private final JPanel optionsPanel = new JPanel(optionsCards);
@@ -71,7 +71,7 @@ public class GeneralFetcher extends SidePaneComponent implements ActionListener 
 
 
     public GeneralFetcher(SidePaneManager p0, JabRefFrame frame) {
-        super(p0, GUIGlobals.getIconUrl("www"), Localization.lang("Web search"));
+        super(p0, IconTheme.getIconUrl("www"), Localization.lang("Web search"));
         this.sidePaneManager = p0;
         this.frame = frame;
         List<EntryFetcher> fetchers = EntryFetchers.INSTANCE.getEntryFetchers();
@@ -305,7 +305,7 @@ public class GeneralFetcher extends SidePaneComponent implements ActionListener 
     class FetcherAction extends AbstractAction {
 
         public FetcherAction() {
-            super(Localization.lang("Web search"), GUIGlobals.getImage("www"));
+            super(Localization.lang("Web search"), IconTheme.getImage("www"));
             //if ((activeFetcher.getKeyName() != null) && (activeFetcher.getKeyName().length() > 0))
             putValue(Action.ACCELERATOR_KEY, Globals.prefs.getKey("Fetch Medline"));
         }

--- a/src/main/java/net/sf/jabref/importer/fileformat/FieldContentParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/FieldContentParser.java
@@ -24,6 +24,7 @@ import net.sf.jabref.logic.util.strings.StringUtil;
  * writing the same fields.
  */
 class FieldContentParser {
+
     /**
      * Performs the reformatting
      * @param content StringBuffer containing the field to format. key contains field name according to field

--- a/src/main/java/net/sf/jabref/logic/util/BuildInfo.java
+++ b/src/main/java/net/sf/jabref/logic/util/BuildInfo.java
@@ -19,7 +19,9 @@ import java.io.IOException;
 import java.util.Properties;
 
 public class BuildInfo {
+
     private final String version;
+
 
     public BuildInfo() {
         this("/resource/build.properties");

--- a/src/main/java/net/sf/jabref/logic/util/io/JabRefDesktop.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/JabRefDesktop.java
@@ -315,7 +315,7 @@ public class JabRefDesktop {
         }
         else if (answer == JOptionPane.YES_OPTION) {
             // User wants to define the new file type. Show the dialog:
-            ExternalFileType newType = new ExternalFileType(fileType.getName(), "", "", "", "new");
+            ExternalFileType newType = new ExternalFileType(fileType.getName(), "", "", "", "new", IconTheme.getImage("new"));
             ExternalFileTypeEntryEditor editor = new ExternalFileTypeEntryEditor(frame, newType);
             editor.setVisible(true);
             if (editor.okPressed()) {

--- a/src/main/java/net/sf/jabref/logic/util/io/URLUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/URLUtil.java
@@ -22,7 +22,9 @@ import java.net.URLDecoder;
 import java.util.Objects;
 
 public class URLUtil {
+
     private static final String URL_EXP = "^(https?|ftp)://.+";
+
 
     /**
      * Cleans URLs returned by Google search.

--- a/src/main/java/net/sf/jabref/logic/xmp/EncryptionNotSupportedException.java
+++ b/src/main/java/net/sf/jabref/logic/xmp/EncryptionNotSupportedException.java
@@ -18,6 +18,7 @@ package net.sf.jabref.logic.xmp;
 import java.io.IOException;
 
 public class EncryptionNotSupportedException extends IOException {
+
     private static final long serialVersionUID = 3280233692527372333L;
 
 

--- a/src/main/java/net/sf/jabref/migrations/PreferencesMigrations.java
+++ b/src/main/java/net/sf/jabref/migrations/PreferencesMigrations.java
@@ -4,6 +4,7 @@ import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 
 public class PreferencesMigrations {
+
     /**
      * This method is called at startup, and makes necessary adaptations to
      * preferences for users from an earlier version of Jabref.

--- a/src/main/java/net/sf/jabref/openoffice/OpenOfficePanel.java
+++ b/src/main/java/net/sf/jabref/openoffice/OpenOfficePanel.java
@@ -168,7 +168,7 @@ public class OpenOfficePanel extends AbstractWorker implements PushToApplication
     public void init(JabRefFrame frame, SidePaneManager manager) {
         OpenOfficePanel.frame = frame;
         this.manager = manager;
-        comp = new OOPanel(manager, IconTheme.getIconUrl("openoffice"), Localization.lang("OpenOffice"));
+        comp = new OOPanel(manager, IconTheme.getImage("openoffice"), Localization.lang("OpenOffice"));
         try {
             initPanel();
             manager.register(getName(), comp);
@@ -1069,7 +1069,7 @@ public class OpenOfficePanel extends AbstractWorker implements PushToApplication
 
     class OOPanel extends SidePaneComponent {
 
-        public OOPanel(SidePaneManager sidePaneManager, URL url, String s) {
+        public OOPanel(SidePaneManager sidePaneManager, ImageIcon url, String s) {
             super(sidePaneManager, url, s);
         }
 

--- a/src/main/java/net/sf/jabref/openoffice/OpenOfficePanel.java
+++ b/src/main/java/net/sf/jabref/openoffice/OpenOfficePanel.java
@@ -88,7 +88,7 @@ public class OpenOfficePanel extends AbstractWorker implements PushToApplication
     private static final JButton merge = new JButton(Localization.lang("Merge citations"));
     private static final JButton manageCitations = new JButton(Localization.lang("Manage citations"));
     private static final JButton settingsB = new JButton(Localization.lang("Settings"));
-    private static final JButton help = new JButton(GUIGlobals.getImage("help"));
+    private static final JButton help = new JButton(IconTheme.getImage("help"));
     private static final JButton test = new JButton("Test");
     private JRadioButton inPar;
     private JRadioButton inText;
@@ -117,15 +117,15 @@ public class OpenOfficePanel extends AbstractWorker implements PushToApplication
     }
 
     private OpenOfficePanel() {
-        ImageIcon connectImage = GUIGlobals.getImage("connect_no");
+        ImageIcon connectImage = IconTheme.getImage("connect_no");
 
         OpenOfficePanel.connect = new JButton(connectImage);
         OpenOfficePanel.manualConnect = new JButton(connectImage);
         OpenOfficePanel.connect.setToolTipText(Localization.lang("Connect"));
         OpenOfficePanel.manualConnect.setToolTipText(Localization.lang("Manual connect"));
-        OpenOfficePanel.selectDocument = new JButton(GUIGlobals.getImage("open"));
+        OpenOfficePanel.selectDocument = new JButton(IconTheme.getImage("open"));
         OpenOfficePanel.selectDocument.setToolTipText(Localization.lang("Select Writer document"));
-        OpenOfficePanel.update = new JButton(GUIGlobals.getImage("refresh"));
+        OpenOfficePanel.update = new JButton(IconTheme.getImage("refresh"));
         OpenOfficePanel.update.setToolTipText(Localization.lang("Sync OO bibliography"));
         String defExecutable;
         String defJarsDir;
@@ -168,7 +168,7 @@ public class OpenOfficePanel extends AbstractWorker implements PushToApplication
     public void init(JabRefFrame frame, SidePaneManager manager) {
         OpenOfficePanel.frame = frame;
         this.manager = manager;
-        comp = new OOPanel(manager, GUIGlobals.getIconUrl("openoffice"), Localization.lang("OpenOffice"));
+        comp = new OOPanel(manager, IconTheme.getIconUrl("openoffice"), Localization.lang("OpenOffice"));
         try {
             initPanel();
             manager.register(getName(), comp);
@@ -181,7 +181,7 @@ public class OpenOfficePanel extends AbstractWorker implements PushToApplication
         if (Globals.prefs.getBoolean("showOOPanel")) {
             manager.show(getName());
         }
-        JMenuItem item = new JMenuItem(Localization.lang("OpenOffice/LibreOffice connection"), GUIGlobals.getImage("openoffice"));
+        JMenuItem item = new JMenuItem(Localization.lang("OpenOffice/LibreOffice connection"), IconTheme.getImage("openoffice"));
         item.addActionListener(new ActionListener() {
 
             @Override
@@ -1003,7 +1003,7 @@ public class OpenOfficePanel extends AbstractWorker implements PushToApplication
 
     @Override
     public Icon getIcon() {
-        return GUIGlobals.getImage("openoffice");
+        return IconTheme.getImage("openoffice");
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/specialfields/Printed.java
+++ b/src/main/java/net/sf/jabref/specialfields/Printed.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 
 import javax.swing.ImageIcon;
 
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 
 public class Printed extends SpecialField {
@@ -30,7 +30,7 @@ public class Printed extends SpecialField {
     private Printed() {
         ArrayList<SpecialFieldValue> values = new ArrayList<SpecialFieldValue>();
         // DO NOT TRANSLATE "printed" as this makes the produced .bib files non portable
-        values.add(new SpecialFieldValue(this, "printed", "togglePrinted", Localization.lang("Toogle print status"), GUIGlobals.getImage("printed"), Localization.lang("Toogle print status")));
+        values.add(new SpecialFieldValue(this, "printed", "togglePrinted", Localization.lang("Toogle print status"), IconTheme.getImage("printed"), Localization.lang("Toogle print status")));
         this.setValues(values);
         TEXT_DONE_PATTERN = "Toggled print status for %0 entries";
     }

--- a/src/main/java/net/sf/jabref/specialfields/Priority.java
+++ b/src/main/java/net/sf/jabref/specialfields/Priority.java
@@ -19,26 +19,26 @@ import java.util.ArrayList;
 
 import javax.swing.ImageIcon;
 
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 
 public class Priority extends SpecialField {
 
     private static Priority INSTANCE;
 
-    private final ImageIcon icon = new ImageIcon(GUIGlobals.getIconUrl("priority"));
+    private final ImageIcon icon = new ImageIcon(IconTheme.getIconUrl("priority"));
 
 
     private Priority() {
         ArrayList<SpecialFieldValue> values = new ArrayList<SpecialFieldValue>();
         values.add(new SpecialFieldValue(this, null, "clearPriority", Localization.lang("Clear priority"), null, Localization.lang("No priority information")));
         ImageIcon icon;
-        icon = GUIGlobals.getImage("red");
+        icon = IconTheme.getImage("red");
         // DO NOT TRANSLATE "prio1" etc. as this makes the .bib files non portable
         values.add(new SpecialFieldValue(this, "prio1", "setPriority1", Localization.lang("Set priority to high"), icon, Localization.lang("Priority high")));
-        icon = GUIGlobals.getImage("orange");
+        icon = IconTheme.getImage("orange");
         values.add(new SpecialFieldValue(this, "prio2", "setPriority2", Localization.lang("Set priority to medium"), icon, Localization.lang("Priority medium")));
-        icon = GUIGlobals.getImage("green");
+        icon = IconTheme.getImage("green");
         values.add(new SpecialFieldValue(this, "prio3", "setPriority3", Localization.lang("Set priority to low"), icon, Localization.lang("Priority low")));
         this.setValues(values);
         TEXT_DONE_PATTERN = "Set priority to '%0' for %1 entries";

--- a/src/main/java/net/sf/jabref/specialfields/Priority.java
+++ b/src/main/java/net/sf/jabref/specialfields/Priority.java
@@ -26,7 +26,7 @@ public class Priority extends SpecialField {
 
     private static Priority INSTANCE;
 
-    private final ImageIcon icon = new ImageIcon(IconTheme.getIconUrl("priority"));
+    private final ImageIcon icon = IconTheme.getImage("priority");
 
 
     private Priority() {

--- a/src/main/java/net/sf/jabref/specialfields/Quality.java
+++ b/src/main/java/net/sf/jabref/specialfields/Quality.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 
 import javax.swing.ImageIcon;
 
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 
 public class Quality extends SpecialField {
@@ -30,7 +30,7 @@ public class Quality extends SpecialField {
     private Quality() {
         ArrayList<SpecialFieldValue> values = new ArrayList<SpecialFieldValue>();
         // DO NOT TRANSLATE "qualityAssured" as this makes the produced .bib files non portable
-        values.add(new SpecialFieldValue(this, "qualityAssured", "toggleQualityAssured", Localization.lang("Toogle quality assured"), GUIGlobals.getImage("qualityAssured"), Localization.lang("Toogle quality assured")));
+        values.add(new SpecialFieldValue(this, "qualityAssured", "toggleQualityAssured", Localization.lang("Toogle quality assured"), IconTheme.getImage("qualityAssured"), Localization.lang("Toogle quality assured")));
         this.setValues(values);
         TEXT_DONE_PATTERN = "Toggled quality for %0 entries";
     }

--- a/src/main/java/net/sf/jabref/specialfields/RankCompact.java
+++ b/src/main/java/net/sf/jabref/specialfields/RankCompact.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 
 import javax.swing.ImageIcon;
 
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 
 /**
@@ -20,11 +20,11 @@ public class RankCompact extends Rank {
         //lab.setName("i");
         values.add(new SpecialFieldValue(this, null, "clearRank", Localization.lang("Clear rank"), null, Localization.lang("No rank information")));
         // DO NOT TRANSLATE "rank1" etc. as this makes the .bib files non portable
-        values.add(new SpecialFieldValue(this, "rank1", "setRank1", Localization.lang("Set rank to one star"), GUIGlobals.getImage("rankc1"), Localization.lang("One star")));
-        values.add(new SpecialFieldValue(this, "rank2", "setRank2", Localization.lang("Set rank to two stars"), GUIGlobals.getImage("rankc2"), Localization.lang("Two stars")));
-        values.add(new SpecialFieldValue(this, "rank3", "setRank3", Localization.lang("Set rank to three stars"), GUIGlobals.getImage("rankc3"), Localization.lang("Three stars")));
-        values.add(new SpecialFieldValue(this, "rank4", "setRank4", Localization.lang("Set rank to four stars"), GUIGlobals.getImage("rankc4"), Localization.lang("Four stars")));
-        values.add(new SpecialFieldValue(this, "rank5", "setRank5", Localization.lang("Set rank to five stars"), GUIGlobals.getImage("rankc5"), Localization.lang("Five stars")));
+        values.add(new SpecialFieldValue(this, "rank1", "setRank1", Localization.lang("Set rank to one star"), IconTheme.getImage("rankc1"), Localization.lang("One star")));
+        values.add(new SpecialFieldValue(this, "rank2", "setRank2", Localization.lang("Set rank to two stars"), IconTheme.getImage("rankc2"), Localization.lang("Two stars")));
+        values.add(new SpecialFieldValue(this, "rank3", "setRank3", Localization.lang("Set rank to three stars"), IconTheme.getImage("rankc3"), Localization.lang("Three stars")));
+        values.add(new SpecialFieldValue(this, "rank4", "setRank4", Localization.lang("Set rank to four stars"), IconTheme.getImage("rankc4"), Localization.lang("Four stars")));
+        values.add(new SpecialFieldValue(this, "rank5", "setRank5", Localization.lang("Set rank to five stars"), IconTheme.getImage("rankc5"), Localization.lang("Five stars")));
         this.setValues(values);
     }
 
@@ -37,7 +37,7 @@ public class RankCompact extends Rank {
 
     @Override
     public ImageIcon getRepresentingIcon() {
-        return GUIGlobals.getImage("ranking");
+        return IconTheme.getImage("ranking");
     }
 
 }

--- a/src/main/java/net/sf/jabref/specialfields/RankExtended.java
+++ b/src/main/java/net/sf/jabref/specialfields/RankExtended.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 
 import javax.swing.ImageIcon;
 
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 
 /**
@@ -20,11 +20,11 @@ public class RankExtended extends Rank {
         ArrayList<SpecialFieldValue> values = new ArrayList<SpecialFieldValue>();
         values.add(new SpecialFieldValue(this, null, "clearRank", Localization.lang("Clear rank"), null, Localization.lang("No rank information")));
         // DO NOT TRANSLATE "rank1" etc. as this makes the .bib files non portable
-        values.add(new SpecialFieldValue(this, "rank1", "setRank1", Localization.lang("Set rank to one star"), GUIGlobals.getImage("rank1"), Localization.lang("One star")));
-        values.add(new SpecialFieldValue(this, "rank2", "setRank2", Localization.lang("Set rank to two stars"), GUIGlobals.getImage("rank2"), Localization.lang("Two stars")));
-        values.add(new SpecialFieldValue(this, "rank3", "setRank3", Localization.lang("Set rank to three stars"), GUIGlobals.getImage("rank3"), Localization.lang("Three stars")));
-        values.add(new SpecialFieldValue(this, "rank4", "setRank4", Localization.lang("Set rank to four stars"), GUIGlobals.getImage("rank4"), Localization.lang("Four stars")));
-        values.add(new SpecialFieldValue(this, "rank5", "setRank5", Localization.lang("Set rank to five stars"), GUIGlobals.getImage("rank5"), Localization.lang("Five stars")));
+        values.add(new SpecialFieldValue(this, "rank1", "setRank1", Localization.lang("Set rank to one star"), IconTheme.getImage("rank1"), Localization.lang("One star")));
+        values.add(new SpecialFieldValue(this, "rank2", "setRank2", Localization.lang("Set rank to two stars"), IconTheme.getImage("rank2"), Localization.lang("Two stars")));
+        values.add(new SpecialFieldValue(this, "rank3", "setRank3", Localization.lang("Set rank to three stars"), IconTheme.getImage("rank3"), Localization.lang("Three stars")));
+        values.add(new SpecialFieldValue(this, "rank4", "setRank4", Localization.lang("Set rank to four stars"), IconTheme.getImage("rank4"), Localization.lang("Four stars")));
+        values.add(new SpecialFieldValue(this, "rank5", "setRank5", Localization.lang("Set rank to five stars"), IconTheme.getImage("rank5"), Localization.lang("Five stars")));
         this.setValues(values);
     }
 

--- a/src/main/java/net/sf/jabref/specialfields/ReadStatus.java
+++ b/src/main/java/net/sf/jabref/specialfields/ReadStatus.java
@@ -26,7 +26,7 @@ public class ReadStatus extends SpecialField {
 
     private static ReadStatus INSTANCE;
 
-    private final ImageIcon icon = new ImageIcon(IconTheme.getIconUrl("readstatus"));
+    private final ImageIcon icon = IconTheme.getImage("readstatus");
 
 
     private ReadStatus() {

--- a/src/main/java/net/sf/jabref/specialfields/ReadStatus.java
+++ b/src/main/java/net/sf/jabref/specialfields/ReadStatus.java
@@ -19,24 +19,24 @@ import java.util.ArrayList;
 
 import javax.swing.ImageIcon;
 
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 
 public class ReadStatus extends SpecialField {
 
     private static ReadStatus INSTANCE;
 
-    private final ImageIcon icon = new ImageIcon(GUIGlobals.getIconUrl("readstatus"));
+    private final ImageIcon icon = new ImageIcon(IconTheme.getIconUrl("readstatus"));
 
 
     private ReadStatus() {
         ArrayList<SpecialFieldValue> values = new ArrayList<SpecialFieldValue>();
         values.add(new SpecialFieldValue(this, null, "clearReadStatus", Localization.lang("Clear read status"), null, Localization.lang("No read status information")));
         ImageIcon icon;
-        icon = GUIGlobals.getImage("readStatusRead");
+        icon = IconTheme.getImage("readStatusRead");
         // DO NOT TRANSLATE "read" as this makes the produced .bib files non portable
         values.add(new SpecialFieldValue(this, "read", "setReadStatusToRead", Localization.lang("Set read status to read"), icon, Localization.lang("Read status read")));
-        icon = GUIGlobals.getImage("readStatusSkimmed");
+        icon = IconTheme.getImage("readStatusSkimmed");
         values.add(new SpecialFieldValue(this, "skimmed", "setReadStatusToSkimmed", Localization.lang("Set read status to skimmed"), icon, Localization.lang("Read status skimmed")));
         this.setValues(values);
         TEXT_DONE_PATTERN = "Set read status to '%0' for %1 entries";

--- a/src/main/java/net/sf/jabref/specialfields/Relevance.java
+++ b/src/main/java/net/sf/jabref/specialfields/Relevance.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 
 import javax.swing.ImageIcon;
 
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 
 public class Relevance extends SpecialField {
@@ -31,7 +31,7 @@ public class Relevance extends SpecialField {
         ArrayList<SpecialFieldValue> values = new ArrayList<SpecialFieldValue>();
         // action directly set by JabRefFrame
         // DO NOT TRANSLATE "relevant" as this makes the produced .bib files non portable
-        values.add(new SpecialFieldValue(this, "relevant", "toggleRelevance", Localization.lang("Toggle relevance"), GUIGlobals.getImage("relevant"), Localization.lang("Toggle relevance")));
+        values.add(new SpecialFieldValue(this, "relevant", "toggleRelevance", Localization.lang("Toggle relevance"), IconTheme.getImage("relevant"), Localization.lang("Toggle relevance")));
         this.setValues(values);
         TEXT_DONE_PATTERN = "Toggled relevance for %0 entries";
     }

--- a/src/main/java/net/sf/jabref/sql/importer/DbImportAction.java
+++ b/src/main/java/net/sf/jabref/sql/importer/DbImportAction.java
@@ -25,15 +25,12 @@ import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JOptionPane;
 
+import net.sf.jabref.gui.*;
 import net.sf.jabref.gui.worker.AbstractWorker;
-import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.model.database.BibtexDatabase;
-import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.Globals;
-import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
-import net.sf.jabref.gui.MnemonicAwareAction;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.util.Util;
 import net.sf.jabref.sql.DBConnectDialog;
@@ -72,7 +69,7 @@ public class DbImportAction extends AbstractWorker {
     class DbImpAction extends MnemonicAwareAction {
 
         public DbImpAction() {
-            super(GUIGlobals.getImage("dbImport"));
+            super(IconTheme.getImage("dbImport"));
             putValue(Action.NAME, "Import from external SQL database");
 
         }

--- a/src/main/java/net/sf/jabref/wizard/integrity/gui/IntegrityMessagePanel.java
+++ b/src/main/java/net/sf/jabref/wizard/integrity/gui/IntegrityMessagePanel.java
@@ -55,9 +55,9 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 
 import net.sf.jabref.gui.BasePanel;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.model.database.BibtexDatabase;
 import net.sf.jabref.model.entry.BibtexEntry;
-import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.gui.undo.UndoableFieldChange;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.wizard.integrity.IntegrityCheck;
@@ -225,10 +225,10 @@ public class IntegrityMessagePanel
     class IntegrityListRenderer extends DefaultListCellRenderer
     {
 
-        final ImageIcon warnIcon = GUIGlobals.getImage("integrityWarn");
-        final ImageIcon infoIcon = GUIGlobals.getImage("integrityInfo");
-        final ImageIcon failIcon = GUIGlobals.getImage("integrityFail");
-        final ImageIcon fixedIcon = GUIGlobals.getImage("complete");
+        final ImageIcon warnIcon = IconTheme.getImage("integrityWarn");
+        final ImageIcon infoIcon = IconTheme.getImage("integrityInfo");
+        final ImageIcon failIcon = IconTheme.getImage("integrityFail");
+        final ImageIcon fixedIcon = IconTheme.getImage("complete");
 
 
         @Override

--- a/src/main/java/net/sf/jabref/wizard/text/gui/TextInputDialog.java
+++ b/src/main/java/net/sf/jabref/wizard/text/gui/TextInputDialog.java
@@ -570,7 +570,7 @@ public class TextInputDialog extends JDialog implements ActionListener {
 
     class PasteAction extends BasicAction {
         public PasteAction() {
-            super("Paste", "Paste from clipboard", IconTheme.getIconUrl("paste"));
+            super("Paste", "Paste from clipboard", IconTheme.getImage("paste"));
         }
 
         @Override
@@ -592,7 +592,7 @@ public class TextInputDialog extends JDialog implements ActionListener {
 
     class LoadAction extends BasicAction {
         public LoadAction() {
-            super("Open", "Open_file", IconTheme.getIconUrl("open"));
+            super("Open", "Open_file", IconTheme.getImage("open"));
         }
 
         @Override
@@ -616,7 +616,7 @@ public class TextInputDialog extends JDialog implements ActionListener {
 
     class ClearAction extends BasicAction {
         public ClearAction() {
-            super("Clear", "Clear_inputarea", IconTheme.getIconUrl("new"));
+            super("Clear", "Clear_inputarea", IconTheme.getImage("new"));
         }
 
         @Override
@@ -744,8 +744,8 @@ class PopupListener extends MouseAdapter {
 }
 
 abstract class BasicAction extends AbstractAction {
-    public BasicAction(String text, String description, URL icon) {
-        super(Localization.lang(text), new ImageIcon(icon));
+    public BasicAction(String text, String description, ImageIcon icon) {
+        super(Localization.lang(text), icon);
         putValue(Action.SHORT_DESCRIPTION, Localization.lang(description));
     }
 

--- a/src/main/java/net/sf/jabref/wizard/text/gui/TextInputDialog.java
+++ b/src/main/java/net/sf/jabref/wizard/text/gui/TextInputDialog.java
@@ -111,18 +111,13 @@ import javax.swing.text.StyleContext;
 import javax.swing.text.StyledDocument;
 
 import net.sf.jabref.exporter.LatexFieldFormatter;
-import net.sf.jabref.gui.BasePanel;
+import net.sf.jabref.gui.*;
 import net.sf.jabref.logic.bibtex.BibtexEntryWriter;
 import net.sf.jabref.model.entry.BibtexEntry;
-import net.sf.jabref.gui.BibtexFields;
-import net.sf.jabref.gui.ClipBoardManager;
-import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRef;
-import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.util.Util;
-import net.sf.jabref.gui.FileDialogs;
 import net.sf.jabref.importer.fileformat.FreeCiteImporter;
 import net.sf.jabref.wizard.integrity.gui.IntegrityMessagePanel;
 import net.sf.jabref.wizard.text.TagToMarkedTextStore;
@@ -575,7 +570,7 @@ public class TextInputDialog extends JDialog implements ActionListener {
 
     class PasteAction extends BasicAction {
         public PasteAction() {
-            super("Paste", "Paste from clipboard", GUIGlobals.getIconUrl("paste"));
+            super("Paste", "Paste from clipboard", IconTheme.getIconUrl("paste"));
         }
 
         @Override
@@ -597,7 +592,7 @@ public class TextInputDialog extends JDialog implements ActionListener {
 
     class LoadAction extends BasicAction {
         public LoadAction() {
-            super("Open", "Open_file", GUIGlobals.getIconUrl("open"));
+            super("Open", "Open_file", IconTheme.getIconUrl("open"));
         }
 
         @Override
@@ -621,7 +616,7 @@ public class TextInputDialog extends JDialog implements ActionListener {
 
     class ClearAction extends BasicAction {
         public ClearAction() {
-            super("Clear", "Clear_inputarea", GUIGlobals.getIconUrl("new"));
+            super("Clear", "Clear_inputarea", IconTheme.getIconUrl("new"));
         }
 
         @Override
@@ -671,8 +666,8 @@ public class TextInputDialog extends JDialog implements ActionListener {
     class SimpleCellRenderer extends DefaultListCellRenderer {
         private final Font baseFont;
         private final Font usedFont;
-        private final ImageIcon okIcon = GUIGlobals.getImage("complete");
-        private final ImageIcon needIcon = GUIGlobals.getImage("wrong");
+        private final ImageIcon okIcon = IconTheme.getImage("complete");
+        private final ImageIcon needIcon = IconTheme.getImage("wrong");
 
         public SimpleCellRenderer(Font normFont) {
             baseFont = normFont;

--- a/src/test/java/net/sf/jabref/SearchTextListenerTest.java
+++ b/src/test/java/net/sf/jabref/SearchTextListenerTest.java
@@ -1,6 +1,6 @@
 package net.sf.jabref;
 
-import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.fieldeditors.TextArea;
 import org.junit.Assert;
 import org.junit.Before;
@@ -15,9 +15,7 @@ public class SearchTextListenerTest {
 
     @Before
     public void setUp() throws Exception {
-
         Globals.prefs = JabRefPreferences.getInstance();
-        GUIGlobals.setUpIconTheme();
     }
 
     @Test


### PR DESCRIPTION
The setting of a custom icon theme is not available in the GUI. Because of this, I removed it. 

What is changed:
- no support for custom icon themes anymore
- a smaller GUIGlobals class
- more explicit referencing of icons
- less setup logic that is required to be called explicitly
- when no icon is available, the default one (red.png at the moment) will be used. This allows to detect icon errors -> see below
- less code

Uncovered issues through this change:
- the action openFolder is used in the icon bar, but as it had no icon, it was never displayed to the user. this is now marked explicitly in red, allowing us developers to fix this.

I am open for feedback.