### PR TITLE
Increase saving speed

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 [master]
+    - Breaking API change: String[] is replaced by List<String> in BibtexEntryType
     - Use correct encoding names (#155) and replace old encoding names in bibtex files. This changes the file header.
     - Feature: When pasting a Google search URL, meta data will be automatically stripped before insertion.
     - No longer write JabRef version to BibTex file header.

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -1319,8 +1319,8 @@ public class JabRefPreferences {
         String nr = "" + number;
         put(JabRefPreferences.CUSTOM_TYPE_NAME + nr, tp.getName());
         put(JabRefPreferences.CUSTOM_TYPE_REQ + nr, tp.getRequiredFieldsString());
-        putStringArray(JabRefPreferences.CUSTOM_TYPE_OPT + nr, tp.getOptionalFields());
-        putStringArray(JabRefPreferences.CUSTOM_TYPE_PRIOPT + nr, tp.getPrimaryOptionalFields());
+        putStringArray(JabRefPreferences.CUSTOM_TYPE_OPT + nr, tp.getOptionalFields().toArray(new String[0]));
+        putStringArray(JabRefPreferences.CUSTOM_TYPE_PRIOPT + nr, tp.getPrimaryOptionalFields().toArray(new String[0]));
     }
 
     /**

--- a/src/main/java/net/sf/jabref/gui/EntryCustomizationDialog2.java
+++ b/src/main/java/net/sf/jabref/gui/EntryCustomizationDialog2.java
@@ -62,7 +62,9 @@ public class EntryCustomizationDialog2 extends JDialog implements ListSelectionL
     private boolean biblatexMode;
 
 
-    /** Creates a new instance of EntryCustomizationDialog2 */
+    /**
+     * Creates a new instance of EntryCustomizationDialog2
+     */
     public EntryCustomizationDialog2(JabRefFrame frame) {
         super(frame, Localization.lang("Customize entry types"), false);
 
@@ -83,9 +85,9 @@ public class EntryCustomizationDialog2 extends JDialog implements ListSelectionL
         right.setLayout(new GridLayout(biblatexMode ? 2 : 1, 2));
 
         java.util.List<String> entryTypes = new ArrayList<String>();
-		for (String s : BibtexEntryType.getAllTypes()) {
-			entryTypes.add(s);
-		}
+        for (String s : BibtexEntryType.getAllTypes()) {
+            entryTypes.add(s);
+        }
 
         typeComp = new EntryTypeList(entryTypes);
         typeComp.addListSelectionListener(this);
@@ -114,7 +116,7 @@ public class EntryCustomizationDialog2 extends JDialog implements ListSelectionL
             right.add(new JPanel());
             right.add(optComp2);
         }
-        
+
         //right.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), Globals.lang("Fields")));
         right.setBorder(BorderFactory.createEtchedBorder());
         ok = new JButton("Ok");
@@ -177,38 +179,18 @@ public class EntryCustomizationDialog2 extends JDialog implements ListSelectionL
         }
         List<String> rl = reqLists.get(s);
         if (rl == null) {
-        	BibtexEntryType type = BibtexEntryType.getType(s);
+            BibtexEntryType type = BibtexEntryType.getType(s);
             if (type != null) {
-                String[] rf = type.getRequiredFieldsForCustomization();
-                List<String> req;
-                if (rf != null) {
-                    req = java.util.Arrays.asList(rf);
-                } else {
-                    req = new ArrayList<String>();
-                }
+                List<String> req = type.getRequiredFieldsForCustomization();
 
                 List<String> opt;
                 if (!biblatexMode) {
-                    String[] of = type.getOptionalFields();
-                    if (of != null) {
-                        opt = java.util.Arrays.asList(of);
-                    } else {
-                        opt = new ArrayList<String>();
-                    }
+                    opt = type.getOptionalFields();
                 } else {
-                    String[] priOf = type.getPrimaryOptionalFields();
-                    if (priOf != null) {
-                        opt = java.util.Arrays.asList(priOf);
-                    } else {
-                        opt = new ArrayList<String>();
-                    }
-                    String[] secOpt = type.getSecondaryOptionalFields();
-                    List<String> opt2;
-                    if (secOpt != null) {
-                    	opt2 = java.util.Arrays.asList(secOpt);
-                    } else {
-                    	opt2 = new ArrayList<String>();
-                    }
+                    opt = type.getPrimaryOptionalFields();
+
+                    List<String> opt2 = type.getSecondaryOptionalFields();
+
                     optComp2.setFields(opt2);
                     optComp2.setEnabled(true);
                 }
@@ -222,8 +204,7 @@ public class EntryCustomizationDialog2 extends JDialog implements ListSelectionL
                 reqComp.setEnabled(true);
                 optComp.setFields(new ArrayList<String>());
                 optComp.setEnabled(true);
-                if (biblatexMode)
-                {
+                if (biblatexMode) {
                     optComp2.setFields(new ArrayList<String>());
                     optComp2.setEnabled(true);
                 }
@@ -281,11 +262,11 @@ public class EntryCustomizationDialog2 extends JDialog implements ListSelectionL
 
             BibtexEntryType oldType = BibtexEntryType.getType(stringListEntry.getKey());
             if (oldType != null) {
-                String[] oldReq = oldType.getRequiredFields();
-                String[] oldOpt = oldType.getOptionalFields();
+                String[] oldReq = oldType.getRequiredFields().toArray(new String[0]);
+                String[] oldOpt = oldType.getOptionalFields().toArray(new String[0]);
                 if (biblatexMode) {
-                    String[] oldPriOpt = oldType.getPrimaryOptionalFields();
-                    String[] oldSecOpt = oldType.getSecondaryOptionalFields(); 
+                    String[] oldPriOpt = oldType.getPrimaryOptionalFields().toArray(new String[0]);
+                    String[] oldSecOpt = oldType.getSecondaryOptionalFields().toArray(new String[0]);
                     if (equalArrays(oldReq, reqStr) && equalArrays(oldPriOpt, optStr) &&
                             equalArrays(oldSecOpt, opt2Str)) {
                         changesMade = false;
@@ -354,16 +335,13 @@ public class EntryCustomizationDialog2 extends JDialog implements ListSelectionL
     }
 
     private boolean equalArrays(String[] one, String[] two) {
-        if ((one == null) && (two == null))
-         {
+        if ((one == null) && (two == null)) {
             return true; // Both null.
         }
-        if ((one == null) || (two == null))
-         {
+        if ((one == null) || (two == null)) {
             return false; // One of them null, the other not.
         }
-        if (one.length != two.length)
-         {
+        if (one.length != two.length) {
             return false; // Different length.
         }
         // If we get here, we know that both are non-null, and that they have the same length.
@@ -438,36 +416,19 @@ public class EntryCustomizationDialog2 extends JDialog implements ListSelectionL
 
             BibtexEntryType type = BibtexEntryType.getStandardType(lastSelected);
             if (type != null) {
-                String[] rf = type.getRequiredFieldsForCustomization();
-                String[] of = type.getOptionalFields();
-                List<String> req;
-                List<String> opt1;
-                List<String> opt2;
-                if (rf != null) {
-                    req = java.util.Arrays.asList(rf);
-                } else {
-                    req = new ArrayList<String>();
-                }
+                List<String> of = type.getOptionalFields();
+                List<String> req = type.getRequiredFieldsForCustomization();;
+                List<String> opt1 = new ArrayList<>();
+                List<String> opt2 = new ArrayList<>();;
 
-                opt1 = new ArrayList<String>();
-                opt2 = new ArrayList<String>();
                 if (biblatexMode) {
-                    if (of != null)
-                    {
-                        String[] priOptArray = type.getPrimaryOptionalFields();
-                        String[] secOptArray = type.getSecondaryOptionalFields();
-                        if (priOptArray != null) {
-                            opt1 = java.util.Arrays.asList(priOptArray);
-                        }
-                        if (secOptArray != null) {
-                            opt2 = java.util.Arrays.asList(secOptArray);
-                        }
+                    if (of.size() != 0) {
+                        opt1 = type.getPrimaryOptionalFields();
+                        opt2 = type.getSecondaryOptionalFields();
                     }
-                }
-                else
-                {
-                    if (of != null) {
-                        opt1 = java.util.Arrays.asList(of);
+                } else {
+                    if (of.size() != 0) {
+                        opt1 = of;
                     }
                 }
 

--- a/src/main/java/net/sf/jabref/gui/EntryCustomizationDialog2.java
+++ b/src/main/java/net/sf/jabref/gui/EntryCustomizationDialog2.java
@@ -232,18 +232,12 @@ public class EntryCustomizationDialog2 extends JDialog implements ListSelectionL
                 continue;
             }
 
-            List<String> reqFields = stringListEntry.getValue();
-            List<String> optFields = optLists.get(stringListEntry.getKey());
-            List<String> opt2Fields = opt2Lists.get(stringListEntry.getKey());
-            String[] reqStr = new String[reqFields.size()];
-            reqStr = reqFields.toArray(reqStr);
-            String[] optStr = new String[optFields.size()];
-            optStr = optFields.toArray(optStr);
-            String[] opt2Str;
-            if (opt2Fields != null) {
-                opt2Str = opt2Fields.toArray(new String[opt2Fields.size()]);
-            } else {
-                opt2Str = new String[0];
+            List<String> reqStr = stringListEntry.getValue();
+            List<String> optStr = optLists.get(stringListEntry.getKey());
+            List<String> opt2Str = opt2Lists.get(stringListEntry.getKey());
+
+            if (opt2Str != null) {
+                opt2Str = new ArrayList<>(0);
             }
 
             // If this type is already existing, check if any changes have
@@ -262,16 +256,16 @@ public class EntryCustomizationDialog2 extends JDialog implements ListSelectionL
 
             BibtexEntryType oldType = BibtexEntryType.getType(stringListEntry.getKey());
             if (oldType != null) {
-                String[] oldReq = oldType.getRequiredFields().toArray(new String[0]);
-                String[] oldOpt = oldType.getOptionalFields().toArray(new String[0]);
+                List<String> oldReq = oldType.getRequiredFields();
+                List<String> oldOpt = oldType.getOptionalFields();
                 if (biblatexMode) {
-                    String[] oldPriOpt = oldType.getPrimaryOptionalFields().toArray(new String[0]);
-                    String[] oldSecOpt = oldType.getSecondaryOptionalFields().toArray(new String[0]);
-                    if (equalArrays(oldReq, reqStr) && equalArrays(oldPriOpt, optStr) &&
-                            equalArrays(oldSecOpt, opt2Str)) {
+                    List<String> oldPriOpt = oldType.getPrimaryOptionalFields();
+                    List<String> oldSecOpt = oldType.getSecondaryOptionalFields();
+                    if (equalLists(oldReq, reqStr) && equalLists(oldPriOpt, optStr) &&
+                            equalLists(oldSecOpt, opt2Str)) {
                         changesMade = false;
                     }
-                } else if (equalArrays(oldReq, reqStr) && equalArrays(oldOpt, optStr)) {
+                } else if (equalLists(oldReq, reqStr) && equalLists(oldOpt, optStr)) {
                     changesMade = false;
                 }
             }
@@ -334,19 +328,19 @@ public class EntryCustomizationDialog2 extends JDialog implements ListSelectionL
 
     }
 
-    private boolean equalArrays(String[] one, String[] two) {
+    private boolean equalLists(List<String> one, List<String> two) {
         if ((one == null) && (two == null)) {
             return true; // Both null.
         }
         if ((one == null) || (two == null)) {
             return false; // One of them null, the other not.
         }
-        if (one.length != two.length) {
+        if (one.size() != two.size()) {
             return false; // Different length.
         }
         // If we get here, we know that both are non-null, and that they have the same length.
-        for (int i = 0; i < one.length; i++) {
-            if (!one[i].equals(two[i])) {
+        for (int i = 0; i < one.size(); i++) {
+            if (!one.get(i).equals(two.get(i))) {
                 return false;
             }
         }

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -208,12 +208,8 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
     private void setupFieldPanels() {
         tabbed.removeAll();
         tabs.clear();
-        String[] fields = entry.getRequiredFields();
+        List<String> fieldList = entry.getRequiredFields();
 
-        List<String> fieldList = null;
-        if (fields != null) {
-            fieldList = java.util.Arrays.asList(fields);
-        }
         EntryEditorTab reqPan = new EntryEditorTab(frame, panel, fieldList, this, true, false, Localization.lang("Required fields"));
         if (reqPan.fileListEditor != null) {
             fileListEditor = reqPan.fileListEditor;
@@ -222,10 +218,10 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                 .getPane(), Localization.lang("Show required fields"));
         tabs.add(reqPan);
 
-        if (entry.getOptionalFields() != null && entry.getOptionalFields().length >= 1) {
+        if (entry.getOptionalFields() != null && entry.getOptionalFields().size() >= 1) {
             EntryEditorTab optPan;
             if (!prefs.getBoolean(JabRefPreferences.BIBLATEX_MODE)) {
-                optPan = new EntryEditorTab(frame, panel, java.util.Arrays.asList(entry.getOptionalFields()), this,
+                optPan = new EntryEditorTab(frame, panel, entry.getOptionalFields(), this,
                         false, false, Localization.lang("Optional fields"));
                 if (optPan.fileListEditor != null) {
                     fileListEditor = optPan.fileListEditor;
@@ -235,7 +231,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                 tabs.add(optPan);
             } else {
                 optPan = new EntryEditorTab(frame, panel,
-                        java.util.Arrays.asList(entry.getType().getPrimaryOptionalFields()), this,
+                        entry.getType().getPrimaryOptionalFields(), this,
                         false, true, Localization.lang("Optional fields"));
                 if (optPan.fileListEditor != null) {
                     fileListEditor = optPan.fileListEditor;
@@ -247,8 +243,8 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                 Set<String> deprecatedFields = new HashSet<>(BibtexEntry.FIELD_ALIASES_OLD_TO_NEW.keySet());
                 deprecatedFields.add("year");
                 deprecatedFields.add("month");
-                String[] secondaryOptionalFields = entry.getType().getSecondaryOptionalFields();
-                String[] optionalFieldsNotPrimaryOrDeprecated = StringUtil.getRemainder(secondaryOptionalFields,
+                List<String> secondaryOptionalFields = entry.getType().getSecondaryOptionalFields();
+                String[] optionalFieldsNotPrimaryOrDeprecated = StringUtil.getRemainder((secondaryOptionalFields.toArray(new String[0])),
                         deprecatedFields.toArray(new String[deprecatedFields.size()]));
 
                 // Get list of all optional fields of this entry and their aliases

--- a/src/main/java/net/sf/jabref/logic/bibtex/BibtexEntryWriter.java
+++ b/src/main/java/net/sf/jabref/logic/bibtex/BibtexEntryWriter.java
@@ -156,7 +156,7 @@ public class BibtexEntryWriter {
 
         // put into chache if necessary
         if (sortedFields == null) {
-            sortedFields = entry.getRequiredFields().clone();
+            sortedFields = entry.getRequiredFields().stream().toArray(size -> new String[size]);
             Arrays.sort(sortedFields);
             requiredFieldsSorted.put(entryTypeName, sortedFields);
         }
@@ -170,7 +170,7 @@ public class BibtexEntryWriter {
 
         // put into chache if necessary
         if (sortedFields == null) {
-            sortedFields = entry.getOptionalFields().clone();
+            sortedFields = entry.getOptionalFields().stream().toArray(size -> new String[size]);
             Arrays.sort(sortedFields);
             optionalFieldsSorted.put(entryTypeName, sortedFields);
         }
@@ -195,7 +195,7 @@ public class BibtexEntryWriter {
         written.add(BibtexEntry.KEY_FIELD);
         boolean hasWritten = false;
         // Write required fields first.
-        String[] fields = entry.getRequiredFields();
+        List<String> fields = entry.getRequiredFields();
         if (fields != null) {
             for (String value : fields) {
                 hasWritten = hasWritten | writeField(entry, out, value, hasWritten);

--- a/src/main/java/net/sf/jabref/logic/bibtex/BibtexEntryWriter.java
+++ b/src/main/java/net/sf/jabref/logic/bibtex/BibtexEntryWriter.java
@@ -32,9 +32,9 @@ public class BibtexEntryWriter {
         BibtexEntryWriter.tagDisplayNameMap.put("UNKNOWN", "UNKNOWN");
     }
 
-    private static final Map<String, String[]> requiredFieldsSorted = new HashMap<>();
+    private static final Map<String, List<String>> requiredFieldsSorted = new HashMap<>();
 
-    private static final Map<String, String[]> optionalFieldsSorted = new HashMap<>();
+    private static final Map<String, List<String>> optionalFieldsSorted = new HashMap<>();
 
 
     /**
@@ -112,7 +112,7 @@ public class BibtexEntryWriter {
         writtenFields.add("title");
 
         if (entry.getRequiredFields() != null) {
-            String[] requiredFields = getRequiredFieldsSorted(entry);
+            List<String> requiredFields = getRequiredFieldsSorted(entry);
             for (String value : requiredFields) {
                 if (!writtenFields.contains(value)) { // If field appears both in req. and opt. don't repeat.
                     hasWritten = hasWritten | writeField(entry, out, value, hasWritten);
@@ -123,7 +123,7 @@ public class BibtexEntryWriter {
 
         // Then optional fields
         if (entry.getOptionalFields() != null) {
-            String[] optionalFields = getOptionalFieldsSorted(entry);
+            List<String> optionalFields = getOptionalFieldsSorted(entry);
             for (String value : optionalFields) {
                 if (!writtenFields.contains(value)) { // If field appears both in req. and opt. don't repeat.
                     hasWritten = hasWritten | writeField(entry, out, value, hasWritten);
@@ -150,28 +150,28 @@ public class BibtexEntryWriter {
         out.write((hasWritten ? Globals.NEWLINE : "") + '}' + Globals.NEWLINE);
     }
 
-    private String[] getRequiredFieldsSorted(BibtexEntry entry) {
+    private List<String> getRequiredFieldsSorted(BibtexEntry entry) {
         String entryTypeName = entry.getType().getName();
-        String[] sortedFields = requiredFieldsSorted.get(entryTypeName);
+        List<String> sortedFields = requiredFieldsSorted.get(entryTypeName);
 
         // put into chache if necessary
         if (sortedFields == null) {
-            sortedFields = entry.getRequiredFields().stream().toArray(size -> new String[size]);
-            Arrays.sort(sortedFields);
+            sortedFields = new ArrayList(entry.getRequiredFields());
+            Collections.sort(sortedFields);
             requiredFieldsSorted.put(entryTypeName, sortedFields);
         }
 
         return sortedFields;
     }
 
-    private String[] getOptionalFieldsSorted(BibtexEntry entry) {
+    private List<String> getOptionalFieldsSorted(BibtexEntry entry) {
         String entryTypeName = entry.getType().getName();
-        String[] sortedFields = optionalFieldsSorted.get(entryTypeName);
+        List<String> sortedFields = optionalFieldsSorted.get(entryTypeName);
 
         // put into chache if necessary
         if (sortedFields == null) {
-            sortedFields = entry.getOptionalFields().stream().toArray(size -> new String[size]);
-            Arrays.sort(sortedFields);
+            sortedFields = new ArrayList(entry.getOptionalFields());
+            Collections.sort(sortedFields);
             optionalFieldsSorted.put(entryTypeName, sortedFields);
         }
 

--- a/src/main/java/net/sf/jabref/logic/bibtex/BibtexEntryWriter.java
+++ b/src/main/java/net/sf/jabref/logic/bibtex/BibtexEntryWriter.java
@@ -155,7 +155,7 @@ public class BibtexEntryWriter {
         String[] sortedFields = requiredFieldsSorted.get(entryTypeName);
 
         // put into chache if necessary
-        if(sortedFields == null){
+        if (sortedFields == null) {
             sortedFields = entry.getRequiredFields().clone();
             Arrays.sort(sortedFields);
             requiredFieldsSorted.put(entryTypeName, sortedFields);
@@ -169,7 +169,7 @@ public class BibtexEntryWriter {
         String[] sortedFields = optionalFieldsSorted.get(entryTypeName);
 
         // put into chache if necessary
-        if(sortedFields == null){
+        if (sortedFields == null) {
             sortedFields = entry.getOptionalFields().clone();
             Arrays.sort(sortedFields);
             optionalFieldsSorted.put(entryTypeName, sortedFields);

--- a/src/main/java/net/sf/jabref/logic/bibtex/DuplicateCheck.java
+++ b/src/main/java/net/sf/jabref/logic/bibtex/DuplicateCheck.java
@@ -70,7 +70,7 @@ public class DuplicateCheck {
         }
 
         // The check if they have the same required fields:
-        String[] fields = one.getType().getRequiredFields();
+        String[] fields = one.getType().getRequiredFields().toArray(new String[0]);
         double[] req;
         if (fields == null) {
             req = new double[]{0., 0.};
@@ -83,7 +83,7 @@ public class DuplicateCheck {
             return req[0] >= DuplicateCheck.duplicateThreshold;
         } else {
             // Close to the threshold value, so we take a look at the optional fields, if any:
-            fields = one.getType().getOptionalFields();
+            fields = one.getType().getOptionalFields().toArray(new String[0]);
             if (fields != null) {
                 double[] opt = DuplicateCheck.compareFieldSet(fields, one, two);
                 double totValue = (DuplicateCheck.reqWeight * req[0] * req[1] + opt[0] * opt[1]) / (req[1] * DuplicateCheck.reqWeight + opt[1]);

--- a/src/main/java/net/sf/jabref/model/entry/BibLatexEntryTypes.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibLatexEntryTypes.java
@@ -17,6 +17,10 @@ package net.sf.jabref.model.entry;
 
 import net.sf.jabref.model.database.BibtexDatabase;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * This class defines entry types for BibLatex support.
  */
@@ -29,35 +33,32 @@ class BibLatexEntryTypes {
             "issuetitle", "issuesubtitle", "origlanguage", "version", "addendum"
 
      */
-	
+
     public static final BibtexEntryType ARTICLE = new BibtexEntryType() {
+
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{"subtitle",
+                "editor", "series", "volume", "number", "eid", "issue", "pages", "note", "issn",
+                "doi", "eprint", "eprintclass", "eprinttype", "url", "urldate"}));
+
+        {
+            addAllOptional("translator", "annotator", "commentator", "subtitle", "titleaddon",
+                    "editor", "editora", "editorb", "editorc", "journalsubtitle", "issuetitle",
+                    "issuesubtitle", "language", "origlanguage", "series", "volume", "number",
+                    "eid", "issue", "month", "year", "pages", "version", "note", "issn",
+                    "addendum", "pubstate", "doi", "eprint", "eprintclass", "eprinttype", "url",
+                    "urldate");
+            addAllRequired("author", "title", "journaltitle", "date");
+        }
 
         @Override
         public String getName() {
             return "Article";
         }
 
-        @Override
-        public String[] getRequiredFields() {
-            return new String[] {"author", "title", "journaltitle", "date"};
-        }
-
-        @Override
-        public String[] getOptionalFields() {
-            return new String[] {"translator", "annotator", "commentator", "subtitle", "titleaddon",
-                    "editor", "editora", "editorb", "editorc", "journalsubtitle", "issuetitle",
-                    "issuesubtitle", "language", "origlanguage", "series", "volume", "number",
-                    "eid", "issue", "month", "year", "pages", "version", "note", "issn",
-                    "addendum", "pubstate", "doi", "eprint", "eprintclass", "eprinttype", "url",
-                    "urldate"};
-        }
-
         // TODO: number vs issue?
         @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"subtitle", "editor", "series", "volume", "number",
-                    "eid", "issue", "pages", "note", "issn",
-                    "doi", "eprint", "eprintclass", "eprinttype", "url", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -68,32 +69,30 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType BOOK = new BibtexEntryType() {
 
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{"editor",
+                "subtitle", "titleaddon", "maintitle", "mainsubtitle", "maintitleaddon", "volume", "edition",
+                "publisher", "isbn", "chapter", "pages", "pagetotal", "doi", "eprint", "eprintclass", "eprinttype",
+                "url", "urldate"}));
+
+        {
+            addAllOptional("editor", "editora", "editorb", "editorc", "translator",
+                    "annotator", "commentator", "introduction",
+                    "foreword", "afterword", "subtitle", "titleaddon", "maintitle", "mainsubtitle",
+                    "maintitleaddon", "language", "origlanguage", "volume", "part",
+                    "edition", "volumes", "series", "number", "month", "year", "note", "publisher",
+                    "location", "isbn", "chapter", "pages", "pagetotal", "addendum", "pubstate",
+                    "doi", "eprint", "eprintclass", "eprinttype", "url", "urldate");
+            addAllRequired("author", "title", "date");
+        }
+
         @Override
         public String getName() {
             return "Book";
         }
 
         @Override
-        public String[] getRequiredFields() {
-            return new String[] {"author", "title", "date"};
-        }
-
-        @Override
-        public String[] getOptionalFields() {
-            return new String[] {"editor", "editora", "editorb", "editorc", "translator",
-                    "annotator", "commentator", "introduction",
-                    "foreword", "afterword", "subtitle", "titleaddon", "maintitle", "mainsubtitle",
-                    "maintitleaddon", "language", "origlanguage", "volume", "part",
-                    "edition", "volumes", "series", "number", "month", "year", "note", "publisher",
-                    "location", "isbn", "chapter", "pages", "pagetotal", "addendum", "pubstate",
-                    "doi", "eprint", "eprintclass", "eprinttype", "url", "urldate"};
-        }
-
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"editor", "subtitle", "titleaddon", "maintitle", "mainsubtitle",
-                    "maintitleaddon", "volume", "edition", "publisher", "isbn", "chapter", "pages",
-                    "pagetotal", "doi", "eprint", "eprintclass", "eprinttype", "url", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -104,33 +103,31 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType INBOOK = new BibtexEntryType() {
 
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{
+                "bookauthor", "editor", "subtitle", "titleaddon", "maintitle",
+                "mainsubtitle", "maintitleaddon", "booksubtitle", "booktitleaddon", "volume",
+                "edition", "publisher", "isbn", "chapter", "pages", "doi", "eprint", "eprintclass",
+                "eprinttype", "url", "urldate"}));
+
+        {
+            addAllOptional("bookauthor", "editor", "editora", "editorb", "editorc",
+                    "translator", "annotator", "commentator", "introduction", "foreword", "afterword",
+                    "subtitle", "titleaddon", "maintitle", "mainsubtitle", "maintitleaddon",
+                    "booksubtitle", "booktitleaddon", "language", "origlanguage", "volume", "part",
+                    "edition", "volumes", "series", "number", "note", "publisher", "location", "isbn",
+                    "chapter", "pages", "addendum", "pubstate", "doi", "eprint", "eprintclass",
+                    "eprinttype", "url", "urldate", "year");
+            addAllRequired("author", "title", "booktitle", "date");
+        }
+
         @Override
         public String getName() {
             return "InBook";
         }
 
         @Override
-        public String[] getRequiredFields() {
-            return new String[] {"author", "title", "booktitle", "date"};
-        }
-
-        @Override
-        public String[] getOptionalFields() {
-            return new String[] {"bookauthor", "editor", "editora", "editorb", "editorc",
-                    "translator", "annotator", "commentator", "introduction", "foreword", "afterword",
-                    "subtitle", "titleaddon", "maintitle", "mainsubtitle", "maintitleaddon",
-                    "booksubtitle", "booktitleaddon", "language", "origlanguage", "volume", "part",
-                    "edition", "volumes", "series", "number", "note", "publisher", "location", "isbn",
-                    "chapter", "pages", "addendum", "pubstate", "doi", "eprint", "eprintclass",
-                    "eprinttype", "url", "urldate", "year"};
-        }
-
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"bookauthor", "editor", "subtitle", "titleaddon", "maintitle",
-                    "mainsubtitle", "maintitleaddon", "booksubtitle", "booktitleaddon", "volume",
-                    "edition", "publisher", "isbn", "chapter", "pages", "doi", "eprint", "eprintclass",
-                    "eprinttype", "url", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -148,17 +145,17 @@ class BibLatexEntryTypes {
 
         // Same fields as "INBOOK" according to Biblatex 1.0: 
         @Override
-        public String[] getRequiredFields() {
+        public List<String> getRequiredFields() {
             return BibLatexEntryTypes.INBOOK.getRequiredFields();
         }
 
         @Override
-        public String[] getOptionalFields() {
+        public List<String> getOptionalFields() {
             return BibLatexEntryTypes.INBOOK.getOptionalFields();
         }
 
         @Override
-        public String[] getPrimaryOptionalFields() {
+        public List<String> getPrimaryOptionalFields() {
             return BibLatexEntryTypes.INBOOK.getPrimaryOptionalFields();
         }
 
@@ -177,17 +174,17 @@ class BibLatexEntryTypes {
 
         // Same fields as "INBOOK" according to Biblatex 1.0: 
         @Override
-        public String[] getRequiredFields() {
+        public List<String> getRequiredFields() {
             return BibLatexEntryTypes.INBOOK.getRequiredFields();
         }
 
         @Override
-        public String[] getOptionalFields() {
+        public List<String> getOptionalFields() {
             return BibLatexEntryTypes.INBOOK.getOptionalFields();
         }
 
         @Override
-        public String[] getPrimaryOptionalFields() {
+        public List<String> getPrimaryOptionalFields() {
             return BibLatexEntryTypes.INBOOK.getPrimaryOptionalFields();
         }
 
@@ -199,27 +196,25 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType BOOKLET = new BibtexEntryType() {
 
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{"subtitle",
+                "titleaddon", "howpublished", "chapter", "pages", "doi", "eprint",
+                "eprintclass", "eprinttype", "url", "urldate"}));
+
+        {
+            addAllRequired("author", "editor", "title", "date");
+            addAllOptional("subtitle", "titleaddon", "language", "howpublished", "type", "note",
+                    "location", "chapter", "year", "pages", "pagetotal", "addendum", "pubstate", "doi", "eprint",
+                    "eprintclass", "eprinttype", "url", "urldate");
+        }
+
         @Override
         public String getName() {
             return "Booklet";
         }
 
         @Override
-        public String[] getRequiredFields() {
-            return new String[] {"author", "editor", "title", "date"};
-        }
-
-        @Override
-        public String[] getOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "language", "howpublished", "type", "note",
-                    "location", "chapter", "year", "pages", "pagetotal", "addendum", "pubstate", "doi", "eprint",
-                    "eprintclass", "eprinttype", "url", "urldate"};
-        }
-
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "howpublished", "chapter", "pages", "doi", "eprint",
-                    "eprintclass", "eprinttype", "url", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -230,32 +225,30 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType COLLECTION = new BibtexEntryType() {
 
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{
+                "translator", "subtitle", "titleaddon", "maintitle",
+                "mainsubtitle", "maintitleaddon", "volume",
+                "edition", "publisher", "isbn", "chapter", "pages", "doi", "eprint", "eprintclass",
+                "eprinttype", "url", "urldate"}));
+
+        {
+            addAllRequired("editor", "title", "date");
+            addAllOptional("editora", "editorb", "editorc", "translator", "annotator",
+                    "commentator", "introduction", "foreword", "afterword", "subtitle", "titleaddon",
+                    "maintitle", "mainsubtitle", "maintitleaddon", "language", "origlanguage", "volume",
+                    "part", "edition", "volumes", "series", "number", "note", "publisher", "location", "isbn",
+                    "chapter", "pages", "pagetotal", "addendum", "pubstate", "doi", "eprint", "eprintclass",
+                    "eprinttype", "url", "urldate", "year");
+        }
+
         @Override
         public String getName() {
             return "Collection";
         }
 
         @Override
-        public String[] getRequiredFields() {
-            return new String[] {"editor", "title", "date"};
-        }
-
-        @Override
-        public String[] getOptionalFields() {
-            return new String[] {"editora", "editorb", "editorc", "translator", "annotator",
-                    "commentator", "introduction", "foreword", "afterword", "subtitle", "titleaddon",
-                    "maintitle", "mainsubtitle", "maintitleaddon", "language", "origlanguage", "volume",
-                    "part", "edition", "volumes", "series", "number", "note", "publisher", "location", "isbn",
-                    "chapter", "pages", "pagetotal", "addendum", "pubstate", "doi", "eprint", "eprintclass",
-                    "eprinttype", "url", "urldate", "year"};
-        }
-
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"translator", "subtitle", "titleaddon", "maintitle",
-                    "mainsubtitle", "maintitleaddon", "volume",
-                    "edition", "publisher", "isbn", "chapter", "pages", "doi", "eprint", "eprintclass",
-                    "eprinttype", "url", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -266,32 +259,30 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType INCOLLECTION = new BibtexEntryType() {
 
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{
+                "translator", "subtitle", "titleaddon", "maintitle",
+                "mainsubtitle", "maintitleaddon", "booksubtitle", "booktitleaddon", "volume",
+                "edition", "publisher", "isbn", "chapter", "pages", "doi", "eprint", "eprintclass",
+                "eprinttype", "url", "urldate"}));
+
+        {
+            addAllRequired("author", "editor", "title", "booktitle", "date");
+            addAllOptional("editora", "editorb", "editorc", "translator", "annotator",
+                    "commentator", "introduction", "foreword", "afterword", "subtitle", "titleaddon",
+                    "maintitle", "mainsubtitle", "maintitleaddon", "booksubtitle", "booktitleaddon",
+                    "language", "origlanguage", "volume", "part", "edition", "volumes", "series", "number",
+                    "note", "publisher", "location", "isbn", "chapter", "pages", "addendum", "pubstate", "doi",
+                    "eprint", "eprintclass", "eprinttype", "url", "urldate", "year");
+        }
+
         @Override
         public String getName() {
             return "InCollection";
         }
 
         @Override
-        public String[] getRequiredFields() {
-            return new String[] {"author", "editor", "title", "booktitle", "date"};
-        }
-
-        @Override
-        public String[] getOptionalFields() {
-            return new String[] {"editora", "editorb", "editorc", "translator", "annotator",
-                    "commentator", "introduction", "foreword", "afterword", "subtitle", "titleaddon",
-                    "maintitle", "mainsubtitle", "maintitleaddon", "booksubtitle", "booktitleaddon",
-                    "language", "origlanguage", "volume", "part", "edition", "volumes", "series", "number",
-                    "note", "publisher", "location", "isbn", "chapter", "pages", "addendum", "pubstate", "doi",
-                    "eprint", "eprintclass", "eprinttype", "url", "urldate", "year"};
-        }
-
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"translator", "subtitle", "titleaddon", "maintitle",
-                    "mainsubtitle", "maintitleaddon", "booksubtitle", "booktitleaddon", "volume",
-                    "edition", "publisher", "isbn", "chapter", "pages", "doi", "eprint", "eprintclass",
-                    "eprinttype", "url", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -309,17 +300,17 @@ class BibLatexEntryTypes {
 
         // Treated as alias of "INCOLLECTION" according to Biblatex 1.0: 
         @Override
-        public String[] getRequiredFields() {
+        public List<String> getRequiredFields() {
             return BibLatexEntryTypes.INCOLLECTION.getRequiredFields();
         }
 
         @Override
-        public String[] getOptionalFields() {
+        public List<String> getOptionalFields() {
             return BibLatexEntryTypes.INCOLLECTION.getOptionalFields();
         }
 
         @Override
-        public String[] getPrimaryOptionalFields() {
+        public List<String> getPrimaryOptionalFields() {
             return BibLatexEntryTypes.INCOLLECTION.getPrimaryOptionalFields();
         }
 
@@ -331,29 +322,27 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType MANUAL = new BibtexEntryType() {
 
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{"subtitle",
+                "titleaddon", "edition", "publisher", "isbn", "chapter",
+                "pages", "doi", "eprint", "eprintclass",
+                "eprinttype", "url", "urldate"}));
+
+        {
+            addAllRequired("author", "editor", "title", "date");
+            addAllOptional("subtitle", "titleaddon", "language", "edition", "type", "series",
+                    "number", "version", "note", "organization", "publisher", "location", "isbn", "chapter",
+                    "pages", "pagetotal", "addendum", "pubstate", "doi", "eprint", "eprintclass",
+                    "eprinttype", "url", "urldate", "year");
+        }
+
         @Override
         public String getName() {
             return "Manual";
         }
 
         @Override
-        public String[] getRequiredFields() {
-            return new String[] {"author", "editor", "title", "date"};
-        }
-
-        @Override
-        public String[] getOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "language", "edition", "type", "series",
-                    "number", "version", "note", "organization", "publisher", "location", "isbn", "chapter",
-                    "pages", "pagetotal", "addendum", "pubstate", "doi", "eprint", "eprintclass",
-                    "eprinttype", "url", "urldate", "year"};
-        }
-
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "edition", "publisher", "isbn", "chapter",
-                    "pages", "doi", "eprint", "eprintclass",
-                    "eprinttype", "url", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -364,27 +353,25 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType MISC = new BibtexEntryType() {
 
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{"subtitle",
+                "titleaddon", "howpublished", "location", "doi", "eprint", "eprintclass",
+                "eprinttype", "url", "urldate"}));
+
+        {
+            addAllRequired("author", "editor", "title", "date");
+            addAllOptional("subtitle", "titleaddon", "language", "howpublished", "type",
+                    "version", "note", "organization", "location", "month", "year", "addendum",
+                    "pubstate", "doi", "eprint", "eprintclass", "eprinttype", "url", "urldate");
+        }
+
         @Override
         public String getName() {
             return "Misc";
         }
 
         @Override
-        public String[] getRequiredFields() {
-            return new String[] {"author", "editor", "title", "date"};
-        }
-
-        @Override
-        public String[] getOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "language", "howpublished", "type",
-                    "version", "note", "organization", "location", "month", "year", "addendum",
-                    "pubstate", "doi", "eprint", "eprintclass", "eprinttype", "url", "urldate"};
-        }
-
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "howpublished", "location", "doi", "eprint", "eprintclass",
-                    "eprinttype", "url", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -395,25 +382,24 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType ONLINE = new BibtexEntryType() {
 
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{"subtitle",
+                "titleaddon", "note", "organization", "urldate"}));
+
+        {
+            addAllRequired("author", "editor", "title", "date", "url");
+            addAllOptional("subtitle", "titleaddon", "language", "version", "note",
+                    "organization", "month", "year", "addendum", "pubstate", "urldate");
+        }
+
+
         @Override
         public String getName() {
             return "Online";
         }
 
         @Override
-        public String[] getRequiredFields() {
-            return new String[] {"author", "editor", "title", "date", "url"};
-        }
-
-        @Override
-        public String[] getOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "language", "version", "note",
-                    "organization", "month", "year", "addendum", "pubstate", "urldate"};
-        }
-
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "note", "organization", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -424,27 +410,24 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType PATENT = new BibtexEntryType() {
 
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{"holder",
+                "subtitle", "titleaddon", "doi", "eprint", "eprintclass", "eprinttype", "url", "urldate"}));
+
+        {
+            addAllRequired("author", "title", "number", "date");
+            addAllOptional("holder", "subtitle", "titleaddon", "type", "version", "location", "note",
+                    "month", "year", "addendum", "pubstate", "doi", "eprint", "eprintclass",
+                    "eprinttype", "url", "urldate");
+        }
+
         @Override
         public String getName() {
             return "Patent";
         }
 
         @Override
-        public String[] getRequiredFields() {
-            return new String[] {"author", "title", "number", "date"};
-        }
-
-        @Override
-        public String[] getOptionalFields() {
-            return new String[] {"holder", "subtitle", "titleaddon", "type", "version", "location", "note",
-                    "month", "year", "addendum", "pubstate", "doi", "eprint", "eprintclass",
-                    "eprinttype", "url", "urldate"};
-        }
-
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"holder", "subtitle", "titleaddon", "doi", "eprint", "eprintclass",
-                    "eprinttype", "url", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -455,28 +438,26 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType PERIODICAL = new BibtexEntryType() {
 
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{"subtitle",
+                "issuetitle", "issuesubtitle", "issn", "doi", "eprint", "eprintclass",
+                "eprinttype", "url", "urldate"}));
+
+        {
+            addAllRequired("editor", "title", "date");
+            addAllOptional("editora", "editorb", "editorc", "subtitle", "issuetitle",
+                    "issuesubtitle", "language", "series", "volume", "number", "issue", "month", "year",
+                    "note", "issn", "addendum", "pubstate", "doi", "eprint", "eprintclass", "eprinttype", "url",
+                    "urldate");
+        }
+
         @Override
         public String getName() {
             return "Periodical";
         }
 
         @Override
-        public String[] getRequiredFields() {
-            return new String[] {"editor", "title", "date"};
-        }
-
-        @Override
-        public String[] getOptionalFields() {
-            return new String[] {"editora", "editorb", "editorc", "subtitle", "issuetitle",
-                    "issuesubtitle", "language", "series", "volume", "number", "issue", "month", "year",
-                    "note", "issn", "addendum", "pubstate", "doi", "eprint", "eprintclass", "eprinttype", "url",
-                    "urldate"};
-        }
-
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"subtitle", "issuetitle", "issuesubtitle", "issn", "doi", "eprint", "eprintclass",
-                    "eprinttype", "url", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -494,17 +475,17 @@ class BibLatexEntryTypes {
 
         // Treated as alias of "ARTICLE" according to Biblatex 1.0: 
         @Override
-        public String[] getRequiredFields() {
+        public List<String> getRequiredFields() {
             return BibLatexEntryTypes.ARTICLE.getRequiredFields();
         }
 
         @Override
-        public String[] getOptionalFields() {
+        public List<String> getOptionalFields() {
             return BibLatexEntryTypes.ARTICLE.getOptionalFields();
         }
 
         @Override
-        public String[] getPrimaryOptionalFields() {
+        public List<String> getPrimaryOptionalFields() {
             return BibLatexEntryTypes.ARTICLE.getPrimaryOptionalFields();
         }
 
@@ -516,30 +497,28 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType PROCEEDINGS = new BibtexEntryType() {
 
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{"subtitle",
+                "titleaddon", "maintitle", "mainsubtitle",
+                "maintitleaddon", "eventtitle", "volume", "publisher", "isbn", "chapter", "pages",
+                "pagetotal", "doi", "eprint", "eprintclass", "eprinttype", "url", "urldate"}));
+
+        {
+            addAllRequired("editor", "title", "date");
+            addAllOptional("subtitle", "titleaddon", "maintitle", "mainsubtitle",
+                    "maintitleaddon", "eventtitle", "eventdate", "venue", "language", "volume", "part",
+                    "volumes", "series", "number", "note", "organization", "publisher", "location", "month",
+                    "year", "isbn", "chapter", "pages", "pagetotal", "addendum", "pubstate", "doi", "eprint",
+                    "eprintclass", "eprinttype", "url", "urldate");
+        }
+
         @Override
         public String getName() {
             return "Proceedings";
         }
 
         @Override
-        public String[] getRequiredFields() {
-            return new String[] {"editor", "title", "date"};
-        }
-
-        @Override
-        public String[] getOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "maintitle", "mainsubtitle",
-                    "maintitleaddon", "eventtitle", "eventdate", "venue", "language", "volume", "part",
-                    "volumes", "series", "number", "note", "organization", "publisher", "location", "month",
-                    "year", "isbn", "chapter", "pages", "pagetotal", "addendum", "pubstate", "doi", "eprint",
-                    "eprintclass", "eprinttype", "url", "urldate"};
-        }
-
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "maintitle", "mainsubtitle",
-                    "maintitleaddon", "eventtitle", "volume", "publisher", "isbn", "chapter", "pages",
-                    "pagetotal", "doi", "eprint", "eprintclass", "eprinttype", "url", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -550,31 +529,29 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType INPROCEEDINGS = new BibtexEntryType() {
 
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{"subtitle",
+                "titleaddon", "maintitle", "mainsubtitle",
+                "maintitleaddon", "booksubtitle", "booktitleaddon", "eventtitle", "volume",
+                "publisher", "isbn", "chapter", "pages",
+                "doi", "eprint", "eprintclass", "eprinttype", "url", "urldate"}));
+
+        {
+            addAllRequired("author", "editor", "title", "booktitle", "date");
+            addAllOptional("subtitle", "titleaddon", "maintitle", "mainsubtitle",
+                    "maintitleaddon", "booksubtitle", "booktitleaddon", "eventtitle", "eventdate", "venue",
+                    "language", "volume", "part", "volumes", "series", "number", "note", "organization",
+                    "publisher", "location", "month", "year", "isbn", "chapter", "pages", "addendum",
+                    "pubstate", "doi", "eprint", "eprintclass", "eprinttype", "url", "urldate");
+        }
+
         @Override
         public String getName() {
             return "InProceedings";
         }
 
         @Override
-        public String[] getRequiredFields() {
-            return new String[] {"author", "editor", "title", "booktitle", "date"};
-        }
-
-        @Override
-        public String[] getOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "maintitle", "mainsubtitle",
-                    "maintitleaddon", "booksubtitle", "booktitleaddon", "eventtitle", "eventdate", "venue",
-                    "language", "volume", "part", "volumes", "series", "number", "note", "organization",
-                    "publisher", "location", "month", "year", "isbn", "chapter", "pages", "addendum",
-                    "pubstate", "doi", "eprint", "eprintclass", "eprinttype", "url", "urldate"};
-        }
-
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "maintitle", "mainsubtitle",
-                    "maintitleaddon", "booksubtitle", "booktitleaddon", "eventtitle", "volume",
-                    "publisher", "isbn", "chapter", "pages",
-                    "doi", "eprint", "eprintclass", "eprinttype", "url", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -592,17 +569,17 @@ class BibLatexEntryTypes {
 
         // Treated as alias of "COLLECTION" according to Biblatex 1.0: 
         @Override
-        public String[] getRequiredFields() {
+        public List<String> getRequiredFields() {
             return BibLatexEntryTypes.COLLECTION.getRequiredFields();
         }
 
         @Override
-        public String[] getOptionalFields() {
+        public List<String> getOptionalFields() {
             return BibLatexEntryTypes.COLLECTION.getOptionalFields();
         }
 
         @Override
-        public String[] getPrimaryOptionalFields() {
+        public List<String> getPrimaryOptionalFields() {
             return BibLatexEntryTypes.COLLECTION.getPrimaryOptionalFields();
         }
 
@@ -621,17 +598,17 @@ class BibLatexEntryTypes {
 
         // Treated as alias of "INCOLLECTION" according to Biblatex 1.0: 
         @Override
-        public String[] getRequiredFields() {
+        public List<String> getRequiredFields() {
             return BibLatexEntryTypes.INCOLLECTION.getRequiredFields();
         }
 
         @Override
-        public String[] getOptionalFields() {
+        public List<String> getOptionalFields() {
             return BibLatexEntryTypes.INCOLLECTION.getOptionalFields();
         }
 
         @Override
-        public String[] getPrimaryOptionalFields() {
+        public List<String> getPrimaryOptionalFields() {
             return BibLatexEntryTypes.INCOLLECTION.getPrimaryOptionalFields();
         }
 
@@ -643,27 +620,25 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType REPORT = new BibtexEntryType() {
 
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{"subtitle",
+                "titleaddon", "number", "isrn", "chapter", "pages", "pagetotal", "doi",
+                "eprint", "eprintclass", "eprinttype", "url", "urldate"}));
+
+        {
+            addAllRequired("author", "title", "type", "institution", "date");
+            addAllOptional("subtitle", "titleaddon", "language", "number", "version", "note",
+                    "location", "month", "year", "isrn", "chapter", "pages", "pagetotal", "addendum", "pubstate", "doi",
+                    "eprint", "eprintclass", "eprinttype", "url", "urldate");
+        }
+
         @Override
         public String getName() {
             return "Report";
         }
 
         @Override
-        public String[] getRequiredFields() {
-            return new String[] {"author", "title", "type", "institution", "date"};
-        }
-
-        @Override
-        public String[] getOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "language", "number", "version", "note",
-                    "location", "month", "year", "isrn", "chapter", "pages", "pagetotal", "addendum", "pubstate", "doi",
-                    "eprint", "eprintclass", "eprinttype", "url", "urldate"};
-        }
-
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "number", "isrn", "chapter", "pages", "pagetotal", "doi",
-                    "eprint", "eprintclass", "eprinttype", "url", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -674,54 +649,13 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType SET = new BibtexEntryType() {
 
+        {
+            addAllRequired("entryset", "crossref");
+        }
+
         @Override
         public String getName() {
             return "Set";
-        }
-
-        @Override
-        public String[] getRequiredFields() {
-            return new String[] {"entryset", "crossref"};
-        }
-
-        // These are all the standard entry fields, custom fields and field aliases not included:
-        /* Optional fields left out since they take up too much space - I think the set type is mainly supposed
-           to fall back on content from the entries contained in the set, so only the required fields are included.*/
-        @Override
-        public String[] getOptionalFields() {
-            return null;
-            /*return new String[] {"abstract", "addendum", "afterword", "annotation", "annotator", "author", "authortype",
-            	 "bookauthor", "bookpagination", "booksubtitle", "booktitle", "booktitleaddon",
-            	 "chapter", "commentator", "date", "doi", "edition", "editor", "editora", "editorb",
-            	 "editorc", "editortype", "editoratype", "editorbtype", "editorctype", "eid", "eprint",
-            	 "eprintclass", "eprinttype", "eventdate", "eventtitle", "file", "foreword", "holder",
-            	 "howpublished", "indextitle", "insitution", "introduction", "isan", "isbn", "ismn",
-            	 "isrn", "issn", "issue", "issuesubtitle", "issuetitle", "iswc", "journalsubtitle",
-            	 "journaltitle", "label", "language", "library", "location", "mainsubtitle",
-            	 "maintitle", "maintitleaddon", "month", "nameaddon", "note", "number", "organization",
-            	 "origdate", "origlanguage", "origlocation", "origpublisher", "origtitle", "pages",
-            	 "pagetotal", "pagination", "part", "publisher", "pubstate", "reprinttitle", "series",
-            	 "shortauthor", "shorteditor", "shorthand", "shorthandintro", "shortjournal",
-            	 "shortseries", "shorttitle", "subtitle", "title", "titleaddon", "translator", "type",
-            	 "url", "urldate", "venue", "version", "volume", "volumes", "year", "crossref",
-            	 "entryset", "entrysubtype", "execute", "gender", "hyphenation", "indexsorttitle",
-            	 "keywords", "options", "presort", "sortkey", "sortname", "sorttitle", "sortyear",
-            	 "xref"};*/
-        }
-
-        // These are just appr. the first half of the above fields:
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return null;
-            /*return new String[] {"abstract", "addendum", "afterword", "annotation", "annotator", "author", "authortype",
-            	 "bookauthor", "bookpagination", "booksubtitle", "booktitle", "booktitleaddon",
-            	 "chapter", "commentator", "date", "doi", "edition", "editor", "editora", "editorb",
-            	 "editorc", "editortype", "editoratype", "editorbtype", "editorctype", "eid", "eprint",
-            	 "eprintclass", "eprinttype", "eventdate", "eventtitle", "file", "foreword", "holder",
-            	 "howpublished", "indextitle", "insitution", "introduction", "isan", "isbn", "ismn",
-            	 "isrn", "issn", "issue", "issuesubtitle", "issuetitle", "iswc", "journalsubtitle",
-            	 "journaltitle", "label", "language", "library", "location", "mainsubtitle",
-            	 "maintitle", "maintitleaddon", "month", "nameaddon"};*/
         }
 
         @Override
@@ -732,27 +666,25 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType THESIS = new BibtexEntryType() {
 
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{"subtitle",
+                "titleaddon", "chapter", "pages", "pagetotal", "doi", "eprint",
+                "eprintclass", "eprinttype", "url", "urldate"}));
+
+        {
+            addAllRequired("author", "title", "type", "institution", "date");
+            addAllOptional("subtitle", "titleaddon", "language", "note", "location", "month", "year",
+                    "chapter", "pages", "pagetotal", "addendum", "pubstate", "doi", "eprint", "eprintclass",
+                    "eprinttype", "url", "urldate");
+        }
+
         @Override
         public String getName() {
             return "Thesis";
         }
 
         @Override
-        public String[] getRequiredFields() {
-            return new String[] {"author", "title", "type", "institution", "date"};
-        }
-
-        @Override
-        public String[] getOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "language", "note", "location", "month", "year",
-                    "chapter", "pages", "pagetotal", "addendum", "pubstate", "doi", "eprint", "eprintclass",
-                    "eprinttype", "url", "urldate"};
-        }
-
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "chapter", "pages", "pagetotal", "doi", "eprint",
-                    "eprintclass", "eprinttype", "url", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -763,25 +695,23 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType UNPUBLISHED = new BibtexEntryType() {
 
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{"subtitle",
+                "titleaddon", "howpublished", "pubstate", "url", "urldate"}));
+
+        {
+            addAllRequired("author", "title", "date");
+            addAllOptional("subtitle", "titleaddon", "language", "howpublished", "note",
+                    "location", "month", "year", "addendum", "pubstate", "url", "urldate");
+        }
+
         @Override
         public String getName() {
             return "Unpublished";
         }
 
         @Override
-        public String[] getRequiredFields() {
-            return new String[] {"author", "title", "date"};
-        }
-
-        @Override
-        public String[] getOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "language", "howpublished", "note",
-                    "location", "month", "year", "addendum", "pubstate", "url", "urldate"};
-        }
-
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "howpublished", "pubstate", "url", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -801,17 +731,17 @@ class BibLatexEntryTypes {
 
         // Treated as alias of "INPROCEEDINGS" according to Biblatex 1.0: 
         @Override
-        public String[] getRequiredFields() {
+        public List<String> getRequiredFields() {
             return BibLatexEntryTypes.INPROCEEDINGS.getRequiredFields();
         }
 
         @Override
-        public String[] getOptionalFields() {
+        public List<String> getOptionalFields() {
             return BibLatexEntryTypes.INPROCEEDINGS.getOptionalFields();
         }
 
         @Override
-        public String[] getPrimaryOptionalFields() {
+        public List<String> getPrimaryOptionalFields() {
             return BibLatexEntryTypes.INPROCEEDINGS.getPrimaryOptionalFields();
         }
 
@@ -830,17 +760,17 @@ class BibLatexEntryTypes {
 
         // Treated as alias of "ONLINE" according to Biblatex 1.0: 
         @Override
-        public String[] getRequiredFields() {
+        public List<String> getRequiredFields() {
             return BibLatexEntryTypes.ONLINE.getRequiredFields();
         }
 
         @Override
-        public String[] getOptionalFields() {
+        public List<String> getOptionalFields() {
             return BibLatexEntryTypes.ONLINE.getOptionalFields();
         }
 
         @Override
-        public String[] getPrimaryOptionalFields() {
+        public List<String> getPrimaryOptionalFields() {
             return BibLatexEntryTypes.ONLINE.getPrimaryOptionalFields();
         }
 
@@ -852,28 +782,27 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType MASTERSTHESIS = new BibtexEntryType() {
 
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{"subtitle",
+                "titleaddon", "type", "chapter", "pages", "pagetotal", "doi", "eprint",
+                "eprintclass", "eprinttype", "url", "urldate"}));
+
+        {
+            // Treated as alias of "THESIS", except "type" field is optional
+            addAllRequired("author", "title", "institution", "date");
+            addAllOptional("subtitle", "titleaddon", "type", "language", "note", "location", "month", "year",
+                    "chapter", "pages", "pagetotal", "addendum", "pubstate", "doi", "eprint", "eprintclass",
+                    "eprinttype", "url", "urldate");
+        }
+
         @Override
         public String getName() {
             return "MastersThesis";
         }
 
-        // Treated as alias of "THESIS", except "type" field is optional
-        @Override
-        public String[] getRequiredFields() {
-            return new String[] {"author", "title", "institution", "date"};
-        }
 
         @Override
-        public String[] getOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "type", "language", "note", "location", "month", "year",
-                    "chapter", "pages", "pagetotal", "addendum", "pubstate", "doi", "eprint", "eprintclass",
-                    "eprinttype", "url", "urldate"};
-        }
-
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "type", "chapter", "pages", "pagetotal", "doi", "eprint",
-                    "eprintclass", "eprinttype", "url", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -884,28 +813,26 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType PHDTHESIS = new BibtexEntryType() {
 
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{"subtitle",
+                "titleaddon", "type", "chapter", "pages", "pagetotal", "doi", "eprint",
+                "eprintclass", "eprinttype", "url", "urldate"}));
+
+        {
+            // Treated as alias of "THESIS", except "type" field is optional
+            addAllRequired("author", "title", "institution", "date");
+            addAllOptional("subtitle", "titleaddon", "type", "language", "note", "location", "month", "year",
+                    "chapter", "pages", "pagetotal", "addendum", "pubstate", "doi", "eprint", "eprintclass",
+                    "eprinttype", "url", "urldate");
+        }
+
         @Override
         public String getName() {
             return "PhdThesis";
         }
 
-        // Treated as alias of "THESIS", except "type" field is optional
         @Override
-        public String[] getRequiredFields() {
-            return new String[] {"author", "title", "institution", "date"};
-        }
-
-        @Override
-        public String[] getOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "type", "language", "note", "location", "month", "year",
-                    "chapter", "pages", "pagetotal", "addendum", "pubstate", "doi", "eprint", "eprintclass",
-                    "eprinttype", "url", "urldate"};
-        }
-
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "type", "chapter", "pages", "pagetotal", "doi", "eprint",
-                    "eprintclass", "eprinttype", "url", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -916,28 +843,26 @@ class BibLatexEntryTypes {
 
     public static final BibtexEntryType TECHREPORT = new BibtexEntryType() {
 
+        private List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(new String[]{"subtitle",
+                "titleaddon", "type", "number", "isrn", "chapter", "pages", "pagetotal",
+                "doi", "eprint", "eprintclass", "eprinttype", "url", "urldate"}));
+
+        {
+            // Treated as alias of "REPORT", except "type" field is optional
+            addAllRequired("author", "title", "institution", "date");
+            addAllOptional("subtitle", "titleaddon", "type", "language", "number", "version", "note",
+                    "location", "month", "year", "isrn", "chapter", "pages", "pagetotal", "addendum", "pubstate",
+                    "doi", "eprint", "eprintclass", "eprinttype", "url", "urldate");
+        }
+
         @Override
         public String getName() {
             return "TechReport";
         }
 
-        // Treated as alias of "REPORT", except "type" field is optional
         @Override
-        public String[] getRequiredFields() {
-            return new String[] {"author", "title", "institution", "date"};
-        }
-
-        @Override
-        public String[] getOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "type", "language", "number", "version", "note",
-                    "location", "month", "year", "isrn", "chapter", "pages", "pagetotal", "addendum", "pubstate",
-                    "doi", "eprint", "eprintclass", "eprinttype", "url", "urldate"};
-        }
-
-        @Override
-        public String[] getPrimaryOptionalFields() {
-            return new String[] {"subtitle", "titleaddon", "type", "number", "isrn", "chapter", "pages", "pagetotal",
-                    "doi", "eprint", "eprintclass", "eprinttype", "url", "urldate"};
+        public List<String> getPrimaryOptionalFields() {
+            return primaryOptionalFields;
         }
 
         @Override
@@ -955,17 +880,17 @@ class BibLatexEntryTypes {
 
         // Treated as alias of "ONLINE" according to Biblatex 1.0: 
         @Override
-        public String[] getRequiredFields() {
+        public List<String> getRequiredFields() {
             return BibLatexEntryTypes.ONLINE.getRequiredFields();
         }
 
         @Override
-        public String[] getOptionalFields() {
+        public List<String> getOptionalFields() {
             return BibLatexEntryTypes.ONLINE.getOptionalFields();
         }
 
         @Override
-        public String[] getPrimaryOptionalFields() {
+        public List<String> getPrimaryOptionalFields() {
             return BibLatexEntryTypes.ONLINE.getPrimaryOptionalFields();
         }
 
@@ -976,37 +901,25 @@ class BibLatexEntryTypes {
     };
 
     /**
-     * This type is used for IEEEtran.bst to control various 
+     * This type is used for IEEEtran.bst to control various
      * be repeated or not. Not a very elegant solution, but it works...
      */
     public static final BibtexEntryType IEEETRANBSTCTL = new BibtexEntryType() {
 
-        @Override
-        public String getName()
         {
+            addAllOptional("ctluse_article_number", "ctluse_paper", "ctluse_forced_etal",
+                    "ctlmax_names_forced_etal", "ctlnames_show_etal", "ctluse_alt_spacing",
+                    "ctlalt_stretch_factor", "ctldash_repeated_names", "ctlname_format_string",
+                    "ctlname_latex_cmd", "ctlname_url_prefix");
+        }
+
+        @Override
+        public String getName() {
             return "IEEEtranBSTCTL";
         }
 
         @Override
-        public String[] getOptionalFields()
-        {
-            return new String[] {
-                    "ctluse_article_number", "ctluse_paper", "ctluse_forced_etal",
-                    "ctlmax_names_forced_etal", "ctlnames_show_etal", "ctluse_alt_spacing",
-                    "ctlalt_stretch_factor", "ctldash_repeated_names", "ctlname_format_string",
-                    "ctlname_latex_cmd", "ctlname_url_prefix"
-            };
-        }
-
-        @Override
-        public String[] getRequiredFields()
-        {
-            return null;
-        }
-
-        @Override
-        public boolean hasAllRequiredFields(BibtexEntry entry, BibtexDatabase database)
-        {
+        public boolean hasAllRequiredFields(BibtexEntry entry, BibtexDatabase database) {
             return true;
         }
     };

--- a/src/main/java/net/sf/jabref/model/entry/BibtexEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibtexEntry.java
@@ -118,14 +118,14 @@ public class BibtexEntry {
     /**
      * @return An array describing the optional fields for this entry. "null" if no fields are required
      */
-    public String[] getOptionalFields() {
+    public List<String> getOptionalFields() {
         return type.getOptionalFields();
     }
 
     /**
      * @return an array describing the required fields for this entry. "null" if no fields are required
      */
-    public String[] getRequiredFields() {
+    public List<String> getRequiredFields() {
         return type.getRequiredFields();
     }
 
@@ -434,6 +434,10 @@ public class BibtexEntry {
         }
 
         return true;
+    }
+
+    boolean allFieldsPresent(List<String> fields, BibtexDatabase database) {
+        return allFieldsPresent((String[]) fields.toArray(), database);
     }
 
     boolean atLeastOnePresent(String[] fields, BibtexDatabase database) {

--- a/src/main/java/net/sf/jabref/model/entry/BibtexEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibtexEntry.java
@@ -119,28 +119,14 @@ public class BibtexEntry {
      * @return An array describing the optional fields for this entry. "null" if no fields are required
      */
     public String[] getOptionalFields() {
-        String[] res = type.getOptionalFields();
-        if (res == null) {
-            return res;
-        } else {
-            // Fix for https://sourceforge.net/p/jabref/bugs/1221/ - see https://github.com/fc7/jabref/commit/e92238a37cc780eb7fccc0684fa62d2437ddd825
-            return res.clone();
-        }
+        return type.getOptionalFields();
     }
 
     /**
      * @return an array describing the required fields for this entry. "null" if no fields are required
      */
     public String[] getRequiredFields() {
-        String[] res = type.getRequiredFields();
-        if (res == null) {
-            return res;
-        } else {
-            // FIXME: This fix slows down saving very much. The issue should be investigated further and the one working on the result should do the clone
-            //        Removing the "clone()" here is against a rule in "Effective Java". However, the speed improvement weights more 
-            // Fix for https://sourceforge.net/p/jabref/bugs/1221/ - see https://github.com/fc7/jabref/commit/e92238a37cc780eb7fccc0684fa62d2437ddd825
-            return res.clone();
-        }
+        return type.getRequiredFields();
     }
 
     public String[] getUserDefinedFields() {

--- a/src/main/java/net/sf/jabref/model/entry/BibtexEntryType.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibtexEntryType.java
@@ -30,6 +30,7 @@ Modified for use in JabRef.
 package net.sf.jabref.model.entry;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
@@ -108,28 +109,43 @@ public abstract class BibtexEntryType implements Comparable<BibtexEntryType> {
         STANDARD_TYPES = new TreeMap<>(ALL_TYPES);
     }
 
+    private List<String> requiredFields = new ArrayList<>();
+
+    private List<String> optionalFields = new ArrayList<>();
 
     @Override
     public int compareTo(BibtexEntryType o) {
         return getName().compareTo(o.getName());
     }
 
-    public abstract String[] getOptionalFields();
+    public List<String> getOptionalFields() {
+        return Collections.unmodifiableList(optionalFields);
+    }
 
-    public abstract String[] getRequiredFields();
+    public List<String> getRequiredFields() {
+        return Collections.unmodifiableList(requiredFields);
+    }
 
-    public String[] getPrimaryOptionalFields() {
+    void addAllOptional(String... fieldNames) {
+        optionalFields.addAll(Arrays.asList(fieldNames));
+    }
+
+    void addAllRequired(String... fieldNames) {
+        requiredFields.addAll(Arrays.asList(fieldNames));
+    }
+
+    public List<String> getPrimaryOptionalFields() {
         return getOptionalFields();
     }
 
-    public String[] getSecondaryOptionalFields() {
-        String[] optionalFields = getOptionalFields();
+    public List<String> getSecondaryOptionalFields() {
+        List<String> optionalFields = getOptionalFields();
 
         if (optionalFields == null) {
-            return new String[0];
+            return new ArrayList<>(0);
         }
 
-        return Arrays.stream(optionalFields).filter(field -> !isPrimary(field)).toArray(String[]::new);
+        return optionalFields.stream().filter(field -> !isPrimary(field)).collect(Collectors.toList());
     }
 
     public abstract boolean hasAllRequiredFields(BibtexEntry entry, BibtexDatabase database);
@@ -139,7 +155,7 @@ public abstract class BibtexEntryType implements Comparable<BibtexEntryType> {
     }
 
     public boolean isRequired(String field) {
-        String[] requiredFields = getRequiredFields();
+        List<String> requiredFields = getRequiredFields();
         if (requiredFields == null) {
             return false;
         }
@@ -152,7 +168,7 @@ public abstract class BibtexEntryType implements Comparable<BibtexEntryType> {
     }
 
     public boolean isOptional(String field) {
-        String[] optionalFields = getOptionalFields();
+        List<String> optionalFields = getOptionalFields();
 
         if (optionalFields == null) {
             return false;
@@ -162,7 +178,7 @@ public abstract class BibtexEntryType implements Comparable<BibtexEntryType> {
     }
 
     private boolean isPrimary(String field) {
-        String[] primaryFields = getPrimaryOptionalFields();
+        List<String> primaryFields = getPrimaryOptionalFields();
 
         if (primaryFields == null) {
             return false;
@@ -277,7 +293,7 @@ public abstract class BibtexEntryType implements Comparable<BibtexEntryType> {
      *
      * @return Array of the required fields in a form appropriate for the entry customization dialog.
      */
-    public String[] getRequiredFieldsForCustomization() {
+    public List<String> getRequiredFieldsForCustomization() {
         return getRequiredFields();
     }
 }

--- a/src/main/java/net/sf/jabref/model/entry/BibtexEntryTypes.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibtexEntryTypes.java
@@ -2,6 +2,10 @@ package net.sf.jabref.model.entry;
 
 import net.sf.jabref.model.database.BibtexDatabase;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 public class BibtexEntryTypes {
     // Get an entry type defined in BibtexEntryType
     public static BibtexEntryType getEntryType(String type) {
@@ -23,16 +27,6 @@ public class BibtexEntryTypes {
                 }
 
                 @Override
-                public String[] getOptionalFields() {
-                    return new String[0];
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[0];
-                }
-
-                @Override
                 public boolean hasAllRequiredFields(BibtexEntry entry, BibtexDatabase database) {
                     return true;
                 }
@@ -41,23 +35,14 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType ARTICLE =
             new BibtexEntryType() {
 
+                {
+                    addAllOptional("volume", "pages", "number", "month", "note"); //- "volume", "pages", "part", "eid"
+                    addAllRequired("author", "title", "journal", "year");  //+ "volume", "pages"
+                }
+
                 @Override
                 public String getName() {
                     return "Article";
-                }
-
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]{
-                            "volume", "pages", "number", "month", "note", //- "volume", "pages", "part", "eid"
-                    };
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[]{
-                            "author", "title", "journal", "year" //+ "volume", "pages"
-                    };
                 }
 
                 @Override
@@ -71,21 +56,13 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType BOOKLET =
             new BibtexEntryType() {
 
+                {
+                    addAllOptional("author", "howpublished", "address", "month", "year", "note");  //+ "lastchecked"
+                }
+
                 @Override
                 public String getName() {
                     return "Booklet";
-                }
-
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]{
-                            "author", "howpublished", "address", "month", "year", "note" //+ "lastchecked"
-                    };
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[]{"title"};
                 }
 
                 @Override
@@ -97,32 +74,23 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType INBOOK =
             new BibtexEntryType() {
 
+                private List<String> requiredFieldsForCustomization = Collections.unmodifiableList(Arrays.asList(new String[]{"author/editor", "title", "chapter/pages", "year", "publisher"}));
+
+                {
+                    addAllOptional("volume", "number", "series", "type", "address", "edition",
+                            "month", "note"); //+ "pages"
+                    addAllRequired("chapter", "pages", "title", "publisher", "year", "editor",
+                            "author");
+                }
+
                 @Override
                 public String getName() {
                     return "InBook";
                 }
 
                 @Override
-                public String[] getOptionalFields() {
-                    return new String[]
-                            {
-                                    "volume", "number", "series", "type", "address", "edition",
-                                    "month", "note" //+ "pages"
-                            };
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[]
-                            {
-                                    "chapter", "pages", "title", "publisher", "year", "editor",
-                                    "author"
-                            };
-                }
-
-                @Override
-                public String[] getRequiredFieldsForCustomization() {
-                    return new String[]{"author/editor", "title", "chapter/pages", "year", "publisher"};
+                public List<String> getRequiredFieldsForCustomization() {
+                    return requiredFieldsForCustomization;
                 }
 
                 @Override
@@ -139,34 +107,24 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType BOOK =
             new BibtexEntryType() {
 
+                private List<String> requiredFieldsForCustomization = Collections.unmodifiableList(Arrays.asList(new String[]
+                        {"title", "publisher", "year", "author/editor"}));
+
+                {
+                    addAllRequired("title", "publisher", "year", "editor", "author");
+                    addAllOptional("volume", "number", "series", "address", "edition", "month",
+                            "note");     //+ pages
+                }
+
                 @Override
                 public String getName() {
                     return "Book";
                 }
 
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]
-                            {
-                                    "volume", "number", "series", "address", "edition", "month",
-                                    "note" //+ pages
-                            };
-                }
 
                 @Override
-                public String[] getRequiredFields() {
-                    return new String[]
-                            {
-                                    "title", "publisher", "year", "editor", "author"
-                            };
-                }
-
-                @Override
-                public String[] getRequiredFieldsForCustomization() {
-                    return new String[]
-                            {
-                                    "title", "publisher", "year", "author/editor"
-                            };
+                public List<String> getRequiredFieldsForCustomization() {
+                    return requiredFieldsForCustomization;
                 }
 
                 @Override
@@ -183,26 +141,15 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType INCOLLECTION =
             new BibtexEntryType() {
 
+                {
+                    addAllRequired("author", "title", "booktitle", "publisher", "year");
+                    addAllOptional("editor", "volume", "number", "series", "type", "chapter",
+                            "pages", "address", "edition", "month", "note");
+                }
+
                 @Override
                 public String getName() {
                     return "InCollection";
-                }
-
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]
-                            {
-                                    "editor", "volume", "number", "series", "type", "chapter",
-                                    "pages", "address", "edition", "month", "note"
-                            };
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[]
-                            {
-                                    "author", "title", "booktitle", "publisher", "year"
-                            };
                 }
 
                 @Override
@@ -219,26 +166,15 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType CONFERENCE =
             new BibtexEntryType() {
 
+                {
+                    addAllOptional("editor", "volume", "number", "series", "pages",
+                            "address", "month", "organization", "publisher", "note");
+                    addAllRequired("author", "title", "booktitle", "year");
+                }
+
                 @Override
                 public String getName() {
                     return "Conference";
-                }
-
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]
-                            {
-                                    "editor", "volume", "number", "series", "pages",
-                                    "address", "month", "organization", "publisher", "note"
-                            };
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[]
-                            {
-                                    "author", "title", "booktitle", "year"
-                            };
                 }
 
                 @Override
@@ -253,26 +189,15 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType INPROCEEDINGS =
             new BibtexEntryType() {
 
+                {
+                    addAllOptional("editor", "volume", "number", "series", "pages",
+                            "address", "month", "organization", "publisher", "note");
+                    addAllRequired("author", "title", "booktitle", "year");
+                }
+
                 @Override
                 public String getName() {
                     return "InProceedings";
-                }
-
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]
-                            {
-                                    "editor", "volume", "number", "series", "pages",
-                                    "address", "month", "organization", "publisher", "note"
-                            };
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[]
-                            {
-                                    "author", "title", "booktitle", "year"
-                            };
                 }
 
                 @Override
@@ -287,26 +212,15 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType PROCEEDINGS =
             new BibtexEntryType() {
 
+                {
+                    addAllOptional("editor", "volume", "number", "series", "address",
+                            "publisher", "note", "month", "organization");
+                    addAllRequired("title", "year");
+                }
+
                 @Override
                 public String getName() {
                     return "Proceedings";
-                }
-
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]
-                            {
-                                    "editor", "volume", "number", "series", "address",
-                                    "publisher", "note", "month", "organization"
-                            };
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[]
-                            {
-                                    "title", "year"
-                            };
                 }
 
                 @Override
@@ -321,26 +235,15 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType MANUAL =
             new BibtexEntryType() {
 
+                {
+                    addAllOptional("author", "organization", "address", "edition",
+                            "month", "year", "note");
+                    addAllRequired("title");
+                }
+
                 @Override
                 public String getName() {
                     return "Manual";
-                }
-
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]
-                            {
-                                    "author", "organization", "address", "edition",
-                                    "month", "year", "note"
-                            };
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[]
-                            {
-                                    "title"
-                            };
                 }
 
                 @Override
@@ -355,25 +258,14 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType TECHREPORT =
             new BibtexEntryType() {
 
+                {
+                    addAllOptional("type", "number", "address", "month", "note");
+                    addAllRequired("author", "title", "institution", "year");
+                }
+
                 @Override
                 public String getName() {
                     return "TechReport";
-                }
-
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]
-                            {
-                                    "type", "number", "address", "month", "note"
-                            };
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[]
-                            {
-                                    "author", "title", "institution", "year"
-                            };
                 }
 
                 @Override
@@ -389,25 +281,14 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType MASTERSTHESIS =
             new BibtexEntryType() {
 
+                {
+                    addAllOptional("type", "address", "month", "note");
+                    addAllRequired("author", "title", "school", "year");
+                }
+
                 @Override
                 public String getName() {
                     return "MastersThesis";
-                }
-
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]
-                            {
-                                    "type", "address", "month", "note"
-                            };
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[]
-                            {
-                                    "author", "title", "school", "year"
-                            };
                 }
 
                 @Override
@@ -422,25 +303,14 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType PHDTHESIS =
             new BibtexEntryType() {
 
+                {
+                    addAllOptional("type", "address", "month", "note");
+                    addAllRequired("author", "title", "school", "year");
+                }
+
                 @Override
                 public String getName() {
                     return "PhdThesis";
-                }
-
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]
-                            {
-                                    "type", "address", "month", "note"
-                            };
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[]
-                            {
-                                    "author", "title", "school", "year"
-                            };
                 }
 
                 @Override
@@ -455,25 +325,14 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType UNPUBLISHED =
             new BibtexEntryType() {
 
+                {
+                    addAllOptional("month", "year");
+                    addAllRequired("author", "title", "note");
+                }
+
                 @Override
                 public String getName() {
                     return "Unpublished";
-                }
-
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]
-                            {
-                                    "month", "year"
-                            };
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[]
-                            {
-                                    "author", "title", "note"
-                            };
                 }
 
                 @Override
@@ -488,25 +347,14 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType PERIODICAL =
             new BibtexEntryType() {
 
+                {
+                    addAllOptional("editor", "language", "series", "volume", "number", "organization", "month", "note", "url");
+                    addAllRequired("title", "year");
+                }
+
                 @Override
                 public String getName() {
                     return "Periodical";
-                }
-
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]
-                            {
-                                    "editor", "language", "series", "volume", "number", "organization", "month", "note", "url"
-                            };
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[]
-                            {
-                                    "title", "year"
-                            };
                 }
 
                 @Override
@@ -521,25 +369,14 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType PATENT =
             new BibtexEntryType() {
 
+                {
+                    addAllOptional("author", "title", "language", "assignee", "address", "type", "number", "day", "dayfiled", "month", "monthfiled", "note", "url");
+                    addAllRequired("nationality", "number", "year", "yearfiled");
+                }
+
                 @Override
                 public String getName() {
                     return "Patent";
-                }
-
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]
-                            {
-                                    "author", "title", "language", "assignee", "address", "type", "number", "day", "dayfiled", "month", "monthfiled", "note", "url"
-                            };
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[]
-                            {
-                                    "nationality", "number", "year", "yearfiled"
-                            };
                 }
 
                 @Override
@@ -556,30 +393,22 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType STANDARD =
             new BibtexEntryType() {
 
+                private List<String> requiredFieldsForCustomization = Collections.unmodifiableList(Arrays.asList(new String[]{"title", "organization/institution"}));
+
+                {
+                    addAllOptional("author", "language", "howpublished", "type", "number", "revision", "address", "month", "year", "note", "url");
+                    addAllRequired("title", "organization", "institution");
+                }
+
                 @Override
                 public String getName() {
                     return "Standard";
                 }
 
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]
-                            {
-                                    "author", "language", "howpublished", "type", "number", "revision", "address", "month", "year", "note", "url"
-                            };
-                }
 
                 @Override
-                public String[] getRequiredFields() {
-                    return new String[]
-                            {
-                                    "title", "organization", "institution"
-                            };
-                }
-
-                @Override
-                public String[] getRequiredFieldsForCustomization() {
-                    return new String[]{"title", "organization/institution"};
+                public List<String> getRequiredFieldsForCustomization() {
+                    return requiredFieldsForCustomization;
                 }
 
                 @Override
@@ -596,22 +425,14 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType ELECTRONIC =
             new BibtexEntryType() {
 
+                {
+                    addAllOptional("author", "month", "year", "title", "language", "howpublished", "organization", "address", "note", "url");
+
+                }
+
                 @Override
                 public String getName() {
                     return "Electronic";
-                }
-
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]
-                            {
-                                    "author", "month", "year", "title", "language", "howpublished", "organization", "address", "note", "url"
-                            };
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[]{};
                 }
 
                 @Override
@@ -626,22 +447,13 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType MISC =
             new BibtexEntryType() {
 
+                {
+                    addAllOptional("author", "title", "howpublished", "month", "year", "note");
+                }
+
                 @Override
                 public String getName() {
                     return "Misc";
-                }
-
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]
-                            {
-                                    "author", "title", "howpublished", "month", "year", "note"
-                            };
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[]{};
                 }
 
                 @Override
@@ -660,24 +472,16 @@ public class BibtexEntryTypes {
     public static final BibtexEntryType IEEETRANBSTCTL =
             new BibtexEntryType() {
 
+                {
+                    addAllOptional("ctluse_article_number", "ctluse_paper", "ctluse_forced_etal",
+                            "ctlmax_names_forced_etal", "ctlnames_show_etal", "ctluse_alt_spacing",
+                            "ctlalt_stretch_factor", "ctldash_repeated_names", "ctlname_format_string",
+                            "ctlname_latex_cmd", "ctlname_url_prefix");
+                }
+
                 @Override
                 public String getName() {
                     return "IEEEtranBSTCTL";
-                }
-
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]{
-                            "ctluse_article_number", "ctluse_paper", "ctluse_forced_etal",
-                            "ctlmax_names_forced_etal", "ctlnames_show_etal", "ctluse_alt_spacing",
-                            "ctlalt_stretch_factor", "ctldash_repeated_names", "ctlname_format_string",
-                            "ctlname_latex_cmd", "ctlname_url_prefix"
-                    };
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[]{};
                 }
 
                 @Override
@@ -701,16 +505,6 @@ public class BibtexEntryTypes {
                 @Override
                 public String getName() {
                     return "Typeless";
-                }
-
-                @Override
-                public String[] getOptionalFields() {
-                    return new String[]{};
-                }
-
-                @Override
-                public String[] getRequiredFields() {
-                    return new String[]{};
                 }
 
                 @Override

--- a/src/main/java/net/sf/jabref/model/entry/CustomEntryType.java
+++ b/src/main/java/net/sf/jabref/model/entry/CustomEntryType.java
@@ -18,7 +18,9 @@ package net.sf.jabref.model.entry;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.logic.util.strings.StringUtil;
@@ -96,28 +98,28 @@ public class CustomEntryType extends BibtexEntryType {
     }
 
     @Override
-    public String[] getOptionalFields() {
-        return optional;
+    public List<String> getOptionalFields() {
+        return Arrays.asList(optional);
     }
 
     @Override
-    public String[] getRequiredFields() {
-        return required;
+    public List<String> getRequiredFields() {
+        return Arrays.asList(required);
     }
 
     @Override
-    public String[] getPrimaryOptionalFields() {
-        return priOpt;
+    public List<String> getPrimaryOptionalFields() {
+        return Arrays.asList(priOpt);
     }
 
     @Override
-    public String[] getSecondaryOptionalFields() {
-        return StringUtil.getRemainder(optional, priOpt);
+    public List<String> getSecondaryOptionalFields() {
+        return Arrays.asList(StringUtil.getRemainder(optional, priOpt));
     }
 
     @Override
-    public String[] getRequiredFieldsForCustomization() {
-        return getRequiredFieldsString().split(";");
+    public List<String> getRequiredFieldsForCustomization() {
+        return Arrays.asList(getRequiredFieldsString().split(";"));
     }
 
     /**

--- a/src/main/java/net/sf/jabref/model/entry/CustomEntryType.java
+++ b/src/main/java/net/sf/jabref/model/entry/CustomEntryType.java
@@ -43,12 +43,20 @@ public class CustomEntryType extends BibtexEntryType {
 
     private static final Log LOGGER = LogFactory.getLog(CustomEntryType.class);
 
+    public CustomEntryType(String name, List<String> required, List<String> priOpt, List<String> secOpt) {
+        this(name, required.toArray(new String[required.size()]), priOpt.toArray(new String[priOpt.size()]),
+                secOpt.toArray(new String[secOpt.size()]));
+    }
 
     public CustomEntryType(String name, String[] required, String[] priOpt, String[] secOpt) {
         this.name = StringUtil.capitalizeFirst(name);
         parseRequiredFields(required);
         this.priOpt = priOpt;
         optional = StringUtil.arrayConcat(priOpt, secOpt);
+    }
+
+    public CustomEntryType(String name, List<String> required, List<String> optional) {
+        this(name, required.toArray(new String[required.size()]), optional.toArray(new String[optional.size()]));
     }
 
     public CustomEntryType(String name, String[] required, String[] optional) {

--- a/src/main/java/net/sf/jabref/model/entry/UnknownEntryType.java
+++ b/src/main/java/net/sf/jabref/model/entry/UnknownEntryType.java
@@ -22,17 +22,15 @@ import net.sf.jabref.model.database.BibtexDatabase;
  * during bibtex parsing. The only known information is the type name.
  * This is useful if the bibtex file contains type definitions that are used
  * in the file - because the entries will be parsed before the type definitions
- * are found. In the meantime, the entries will be assigned an 
+ * are found. In the meantime, the entries will be assigned an
  * UnknownEntryType giving the name.
  */
 public class UnknownEntryType extends BibtexEntryType {
 
     private final String name;
-    private final String[] fields = new String[0];
 
-
-    public UnknownEntryType(String name_) {
-        name = name_;
+    public UnknownEntryType(String name) {
+        this.name = name;
     }
 
     @Override
@@ -40,15 +38,6 @@ public class UnknownEntryType extends BibtexEntryType {
         return name;
     }
 
-    @Override
-    public String[] getOptionalFields() {
-        return fields;
-    }
-
-    @Override
-    public String[] getRequiredFields() {
-        return fields;
-    }
 
     @Override
     public boolean hasAllRequiredFields(BibtexEntry entry, BibtexDatabase database) {

--- a/src/main/java/net/sf/jabref/sql/exporter/DBExporter.java
+++ b/src/main/java/net/sf/jabref/sql/exporter/DBExporter.java
@@ -231,12 +231,8 @@ public abstract class DBExporter extends DBImporterExporter {
             for (int i = 0; i < SQLUtil.getAllFields().size(); i++) {
                 fieldRequirement.add(i, "gen");
             }
-            List<String> reqFields = Arrays
-                    .asList(val.getRequiredFields() != null ? val
-                            .getRequiredFields() : new String[0]);
-            List<String> optFields = Arrays
-                    .asList(val.getOptionalFields() != null ? val
-                            .getOptionalFields() : new String[0]);
+            List<String> reqFields = val.getRequiredFields();
+            List<String> optFields = val.getOptionalFields();
             List<String> utiFields = Arrays
                     .asList(val.getUtilityFields() != null ? val
                             .getUtilityFields() : new String[0]);

--- a/src/main/java/net/sf/jabref/wizard/text/gui/TextInputDialog.java
+++ b/src/main/java/net/sf/jabref/wizard/text/gui/TextInputDialog.java
@@ -554,12 +554,12 @@ public class TextInputDialog extends JDialog implements ActionListener {
     }
 
     private String[] getAllFields() {
-        ArrayList<String> f = new ArrayList<String>();
-        String[] req = entry.getRequiredFields();
-        String[] opt = entry.getOptionalFields();
+        ArrayList<String> f = new ArrayList<>();
+        List<String> req = entry.getRequiredFields();
+        List<String> opt = entry.getOptionalFields();
         String[] allFields = BibtexFields.getAllFieldNames();
-        Collections.addAll(f, req);
-        Collections.addAll(f, opt);
+        f.addAll(req);
+        f.addAll(opt);
         for (String allField : allFields) {
             if (!f.contains(allField)) {
                 f.add(allField);


### PR DESCRIPTION
Intended to fix #122, this PR turned into a major API change. It replaces `String[]` in the return types of `BibtexEntryType` with `List<String>`. This allows to return immutable lists instead of mutable arrays and improves the stability of the program. Additionally, the rewrite allowed to replace a lot of duplicate object creation with instance variables.

With respect to #122, the immutability of the new lists removes the necessity to create defensive copies and therefore avoids a lot of cloning.