### PR TITLE
Extracted native Windows logic and fixed #194

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@
     - BREAKING: Remove plugin functionality.
     - Fixes Bug#1297: No console message on closing.
     - Fix bug #1285: Editing position is not lost on saving
+    - Fix bug #194: JabRef starts again on Win XP and Win Vista
     - Remove support for custom icon themes. The user has to use the default one.
     - Bugfix: Tooltips are now shown for the #-field when the bibtex entry is incomplete.
     - Solved feature request #767: New subdatabase based on AUX file (biblatex)

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
     - chmod +x launch4j/launch4j
     - wget http://nsis.sourceforge.net/mediawiki/images/5/54/WinShell.zip
     - unzip WinShell.zip
-    - sudo cp Plugins/x86-unicode/WinShell.dll /usr/share/nsis/Plugins/
+    - sudo cp Plugins/x86-ansi/WinShell.dll /usr/share/nsis/Plugins/
   override:
     - TERM=dumb ./gradlew dependencies
 

--- a/src/main/java/net/sf/jabref/JabRef.java
+++ b/src/main/java/net/sf/jabref/JabRef.java
@@ -33,6 +33,7 @@ import javax.swing.*;
 import javax.swing.plaf.FontUIResource;
 
 import net.sf.jabref.gui.*;
+import net.sf.jabref.gui.nativeext.WindowsExtensions;
 import net.sf.jabref.importer.fetcher.EntryFetcher;
 import net.sf.jabref.importer.fetcher.EntryFetchers;
 import net.sf.jabref.logic.journals.Abbreviations;
@@ -60,12 +61,6 @@ import net.sf.jabref.logic.util.io.FileBasedLock;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.logic.logging.CacheableHandler;
 import net.sf.jabref.wizard.auximport.AuxCommandLine;
-
-import com.sun.jna.Native;
-import com.sun.jna.NativeLong;
-import com.sun.jna.Pointer;
-import com.sun.jna.WString;
-import com.sun.jna.ptr.PointerByReference;
 
 /**
  * JabRef Main Class - The application gets started here.
@@ -150,10 +145,8 @@ public class JabRef {
         Globals.NEWLINE = Globals.prefs.get(JabRefPreferences.NEWLINE);
 
         if (OS.WINDOWS) {
-            // Set application user model id so that pinning JabRef to the Win7/8 taskbar works
-            // Based on http://stackoverflow.com/a/1928830
-            JabRef.setCurrentProcessExplicitAppUserModelID("JabRef." + Globals.BUILD_INFO.getVersion());
-            //System.out.println(getCurrentProcessExplicitAppUserModelID());
+            // activate pin to taskbar for Windows 7 and up
+            WindowsExtensions.enablePinToTaskbar();
         }
 
         Vector<ParserResult> loaded = processArguments(args, true);
@@ -165,45 +158,11 @@ public class JabRef {
 
         openWindow(loaded);
     }
-    
+
     private void setupLogHandlerForErrorConsole() {
         Globals.handler = new CacheableHandler();
         ((Jdk14Logger)LOGGER).getLogger().addHandler(Globals.handler);
     }
-
-    // Do not use this code in release version, it contains some memory leaks
-    public static String getCurrentProcessExplicitAppUserModelID()
-    {
-        final PointerByReference r = new PointerByReference();
-
-        if (JabRef.GetCurrentProcessExplicitAppUserModelID(r).longValue() == 0)
-        {
-            final Pointer p = r.getValue();
-
-            return p.getString(0, true); // here we leak native memory by lazyness
-        }
-        return "N/A";
-    }
-
-    private static void setCurrentProcessExplicitAppUserModelID(final String appID)
-    {
-        if (JabRef.SetCurrentProcessExplicitAppUserModelID(new WString(appID)).longValue() != 0) {
-            throw new RuntimeException("unable to set current process explicit AppUserModelID to: " + appID);
-        }
-    }
-
-    private static native NativeLong GetCurrentProcessExplicitAppUserModelID(PointerByReference appID);
-
-    private static native NativeLong SetCurrentProcessExplicitAppUserModelID(WString appID);
-
-
-    static
-    {
-        if (OS.WINDOWS) {
-            Native.register("shell32");
-        }
-    }
-
 
     public Vector<ParserResult> processArguments(String[] args, boolean initialStartup) {
 

--- a/src/main/java/net/sf/jabref/gui/nativeext/WindowsExtensions.java
+++ b/src/main/java/net/sf/jabref/gui/nativeext/WindowsExtensions.java
@@ -1,0 +1,67 @@
+package net.sf.jabref.gui.nativeext;
+
+import com.sun.jna.Native;
+import com.sun.jna.NativeLong;
+import com.sun.jna.Pointer;
+import com.sun.jna.WString;
+import com.sun.jna.ptr.PointerByReference;
+import net.sf.jabref.Globals;
+import net.sf.jabref.logic.util.OS;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Native extensions for Windows.
+ */
+public class WindowsExtensions {
+    private static final Log LOGGER = LogFactory.getLog(WindowsExtensions.class);
+
+    // Register native calls for pin to taskbar functionality
+    static {
+        if (OS.WINDOWS) {
+            Native.register("shell32");
+            LOGGER.info("Registered Shell32 DLL");
+        }
+    }
+
+    /**
+     * Sets the application user model id so that JabRef can be pinned to the taskbar
+     * Only supported by Windows 7 and up!
+     *
+     * AppUserModelId must also be set in NSIS setup.nsi
+     * WinShell::SetLnkAUMI "$INSTDIR\$(^Name).lnk" "${AppUserModelId}"
+     * Structure: JabRef.${VERSION}
+     *
+     * Based on http://stackoverflow.com/a/1928830
+     * http://stackoverflow.com/questions/5438651/launch4j-nsis-and-duplicate-pinned-windows-7-taskbar-icons
+     */
+    public static void enablePinToTaskbar() {
+        if(supportsPinToTaskbar()) {
+            setCurrentProcessExplicitAppUserModelID("JabRef." + Globals.BUILD_INFO.getVersion());
+        } else {
+            LOGGER.info("Does not support pin to taskbar.");
+        }
+    }
+
+    private static void setCurrentProcessExplicitAppUserModelID(final String appID) {
+        if (SetCurrentProcessExplicitAppUserModelID(new WString(appID)).longValue() != 0) {
+            throw new RuntimeException("unable to set current process explicit AppUserModelID to: " + appID);
+        }
+    }
+
+    private static native NativeLong SetCurrentProcessExplicitAppUserModelID(WString appID);
+
+    private static boolean supportsPinToTaskbar() {
+        if (!OS.WINDOWS) {
+            return false;
+        }
+
+        try {
+            Float version = Float.parseFloat(System.getProperty("os.version"));
+            // Windows 7 == 6.1
+            return version >= 6.1;
+        } catch (NumberFormatException ex) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/net/sf/jabref/logic/util/OS.java
+++ b/src/main/java/net/sf/jabref/logic/util/OS.java
@@ -4,7 +4,6 @@ package net.sf.jabref.logic.util;
  * Operating system (OS) detection
  */
 public class OS {
-
     // TODO: what OS do we support?
     // https://commons.apache.org/proper/commons-lang/javadocs/api-2.6/org/apache/commons/lang/SystemUtils.html
     public static final String osName = System.getProperty("os.name", "unknown").toLowerCase();


### PR DESCRIPTION
This should fix the problem with Windows XP and Vista being unable to use the pin to taskbar feature.
However, I'm not certain if the feature works on Windows 7 and up.
My first tests on Windows 10 didn't allow me to pin JabRef.
We need to investigate this.

Likewise, we should also extract other OS-dependent logic from our code.