### PR TITLE
[WIP] Fix latex field formatter

### DIFF
--- a/src/main/java/net/sf/jabref/exporter/LatexFieldFormatter.java
+++ b/src/main/java/net/sf/jabref/exporter/LatexFieldFormatter.java
@@ -41,7 +41,7 @@ public class LatexFieldFormatter implements FieldFormatter {
     }
 
 
-    private StringBuffer sb;
+    private StringBuffer stringBuffer;
 
     private final boolean neverFailOnHashes;
 
@@ -104,48 +104,53 @@ public class LatexFieldFormatter implements FieldFormatter {
                     || BIBTEX_STRING.equals(fieldName);
         }
         if (!resolveStrings) {
-            int brc = 0;
+            int numberOfBrackets = 0;
             boolean ok = true;
             for (int i = 0; i < text.length(); i++) {
                 char c = text.charAt(i);
                 //Util.pr(""+c);
                 if (c == '{') {
-                    brc++;
+                    numberOfBrackets++;
                 }
                 if (c == '}') {
-                    brc--;
+                    numberOfBrackets--;
                 }
-                if (brc < 0) {
+                if (numberOfBrackets < 0) {
                     ok = false;
                     break;
                 }
             }
-            if (brc > 0) {
+            if (numberOfBrackets > 0) {
                 ok = false;
             }
             if (!ok) {
                 throw new IllegalArgumentException("Curly braces { and } must be balanced.");
             }
 
-            sb = new StringBuffer(
+            stringBuffer = new StringBuffer(
                     valueDelimiterStartOfValue + "");
             // No formatting at all for these fields, to allow custom formatting?
             //            if (Globals.prefs.getBoolean("preserveFieldFormatting"))
             //              sb.append(text);
             //            else
             //             currently, we do not do any more wrapping
-            if (writefieldWrapfield && !Globals.prefs.isNonWrappableField(fieldName)) {
-                sb.append(StringUtil.wrap(text, GUIGlobals.LINE_LENGTH));
+            boolean isAbstract = "abstract".equals(fieldName);
+            boolean isReview = "review".equals(fieldName);
+            boolean doWrap = !isAbstract || !isReview;
+            boolean strangePrefSettings = writefieldWrapfield && !Globals.prefs.isNonWrappableField(fieldName);
+
+            if (strangePrefSettings && doWrap) {
+                stringBuffer.append(StringUtil.wrap(text, GUIGlobals.LINE_LENGTH));
             } else {
-                sb.append(text);
+                stringBuffer.append(text);
             }
 
-            sb.append(valueDelimiterEndOfValue);
+            stringBuffer.append(valueDelimiterEndOfValue);
 
-            return sb.toString();
+            return stringBuffer.toString();
         }
 
-        sb = new StringBuffer();
+        stringBuffer = new StringBuffer();
         int pivot = 0;
         int pos1;
         int pos2;
@@ -208,10 +213,10 @@ public class LatexFieldFormatter implements FieldFormatter {
         // currently, we do not add newlines and new formatting
         if (writefieldWrapfield && !Globals.prefs.isNonWrappableField(fieldName)) {
             //             introduce a line break to be read at the parser
-            return StringUtil.wrap(sb.toString(), GUIGlobals.LINE_LENGTH);//, but that lead to ugly .tex
+            return StringUtil.wrap(stringBuffer.toString(), GUIGlobals.LINE_LENGTH);//, but that lead to ugly .tex
 
         } else {
-            return sb.toString();
+            return stringBuffer.toString();
         }
 
     }
@@ -221,7 +226,7 @@ public class LatexFieldFormatter implements FieldFormatter {
         /*sb.append("{");
         sb.append(text.substring(start_pos, end_pos));
         sb.append("}");*/
-        sb.append(valueDelimiterStartOfValue);
+        stringBuffer.append(valueDelimiterStartOfValue);
         boolean escape = false;
         boolean inCommandName = false;
         boolean inCommand = false;
@@ -283,13 +288,13 @@ public class LatexFieldFormatter implements FieldFormatter {
 if (c == '&' && !escape &&
                     !(inCommand && commandName.toString().equals("url")) &&
         nestedEnvironments == 0) {
-                sb.append("\\&");
+                stringBuffer.append("\\&");
             } else {
-    sb.append(c);
+    stringBuffer.append(c);
 }
             escape = c == '\\';
         }
-        sb.append(valueDelimiterEndOfValue);
+        stringBuffer.append(valueDelimiterEndOfValue);
     }
 
     private void writeStringLabel(String text, int start_pos, int end_pos,
@@ -301,7 +306,7 @@ if (c == '&' && !escape &&
     }
 
     private void putIn(String s) {
-        sb.append(StringUtil.wrap(s, GUIGlobals.LINE_LENGTH));
+        stringBuffer.append(StringUtil.wrap(s, GUIGlobals.LINE_LENGTH));
     }
 
     private void checkBraces(String text) throws IllegalArgumentException {

--- a/src/main/java/net/sf/jabref/exporter/LatexFieldFormatter.java
+++ b/src/main/java/net/sf/jabref/exporter/LatexFieldFormatter.java
@@ -41,7 +41,7 @@ public class LatexFieldFormatter implements FieldFormatter {
     }
 
 
-    private StringBuffer stringBuffer;
+    private StringBuilder stringBuilder;
 
     private final boolean neverFailOnHashes;
 
@@ -127,7 +127,7 @@ public class LatexFieldFormatter implements FieldFormatter {
                 throw new IllegalArgumentException("Curly braces { and } must be balanced.");
             }
 
-            stringBuffer = new StringBuffer(
+            stringBuilder = new StringBuilder(
                     valueDelimiterStartOfValue + "");
             // No formatting at all for these fields, to allow custom formatting?
             //            if (Globals.prefs.getBoolean("preserveFieldFormatting"))
@@ -140,17 +140,17 @@ public class LatexFieldFormatter implements FieldFormatter {
             boolean strangePrefSettings = writefieldWrapfield && !Globals.prefs.isNonWrappableField(fieldName);
 
             if (strangePrefSettings && doWrap) {
-                stringBuffer.append(StringUtil.wrap(text, GUIGlobals.LINE_LENGTH));
+                stringBuilder.append(StringUtil.wrap(text, GUIGlobals.LINE_LENGTH));
             } else {
-                stringBuffer.append(text);
+                stringBuilder.append(text);
             }
 
-            stringBuffer.append(valueDelimiterEndOfValue);
+            stringBuilder.append(valueDelimiterEndOfValue);
 
-            return stringBuffer.toString();
+            return stringBuilder.toString();
         }
 
-        stringBuffer = new StringBuffer();
+        stringBuilder = new StringBuilder();
         int pivot = 0;
         int pos1;
         int pos2;
@@ -213,10 +213,10 @@ public class LatexFieldFormatter implements FieldFormatter {
         // currently, we do not add newlines and new formatting
         if (writefieldWrapfield && !Globals.prefs.isNonWrappableField(fieldName)) {
             //             introduce a line break to be read at the parser
-            return StringUtil.wrap(stringBuffer.toString(), GUIGlobals.LINE_LENGTH);//, but that lead to ugly .tex
+            return StringUtil.wrap(stringBuilder.toString(), GUIGlobals.LINE_LENGTH);//, but that lead to ugly .tex
 
         } else {
-            return stringBuffer.toString();
+            return stringBuilder.toString();
         }
 
     }
@@ -226,7 +226,7 @@ public class LatexFieldFormatter implements FieldFormatter {
         /*sb.append("{");
         sb.append(text.substring(start_pos, end_pos));
         sb.append("}");*/
-        stringBuffer.append(valueDelimiterStartOfValue);
+        stringBuilder.append(valueDelimiterStartOfValue);
         boolean escape = false;
         boolean inCommandName = false;
         boolean inCommand = false;
@@ -288,13 +288,13 @@ public class LatexFieldFormatter implements FieldFormatter {
 if (c == '&' && !escape &&
                     !(inCommand && commandName.toString().equals("url")) &&
         nestedEnvironments == 0) {
-                stringBuffer.append("\\&");
+                stringBuilder.append("\\&");
             } else {
-    stringBuffer.append(c);
+    stringBuilder.append(c);
 }
             escape = c == '\\';
         }
-        stringBuffer.append(valueDelimiterEndOfValue);
+        stringBuilder.append(valueDelimiterEndOfValue);
     }
 
     private void writeStringLabel(String text, int start_pos, int end_pos,
@@ -306,7 +306,7 @@ if (c == '&' && !escape &&
     }
 
     private void putIn(String s) {
-        stringBuffer.append(StringUtil.wrap(s, GUIGlobals.LINE_LENGTH));
+        stringBuilder.append(StringUtil.wrap(s, GUIGlobals.LINE_LENGTH));
     }
 
     private void checkBraces(String text) throws IllegalArgumentException {

--- a/src/test/java/net/sf/jabref/exporter/layout/LatexFieldFormatterTests.java
+++ b/src/test/java/net/sf/jabref/exporter/layout/LatexFieldFormatterTests.java
@@ -1,0 +1,50 @@
+package net.sf.jabref.exporter.layout;
+
+import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.exporter.LatexFieldFormatter;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by joerg on 05.10.2015.
+ */
+public class LatexFieldFormatterTests {
+
+    private LatexFieldFormatter formatter;
+
+    @BeforeClass
+    public static void setUpBeforeClass(){
+        Globals.prefs = JabRefPreferences.getInstance();
+    }
+
+    @Before
+    public void setUp() {
+        this.formatter = new LatexFieldFormatter();
+    }
+
+    @Test
+    public void preserveNewlineInAbstractField() {
+        String fieldName = "abstract";
+        String text = "lorem ipsum lorem ipsum" + Globals.NEWLINE + "lorem ipsum lorem ipsum" + Globals.NEWLINE;
+
+        String result = formatter.format(text, fieldName);
+        String expected = "{"+text+"}";
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void preserveNewlineInReviewField() {
+        String fieldName = "review";
+        String text = "lorem ipsum lorem ipsum" + Globals.NEWLINE + "lorem ipsum lorem ipsum" + Globals.NEWLINE;
+
+        String result = formatter.format(text, fieldName);
+        String expected = "{"+text+"}";
+
+        assertEquals(expected, result);
+    }
+}


### PR DESCRIPTION
Another attempt to fix the line wrapping. As far as I can see, some of the current behavior is due to the formatting implemented in `LatexFieldFormatter`. This PR tries to rectify some of this behavior by explicitly excluding the "review" and "abstract" fields from line wrapping.

Related: #114 #186 #185