### PR TITLE
Only show automated list of contributors

### DIFF
--- a/src/main/resources/help/About.html
+++ b/src/main/resources/help/About.html
@@ -21,32 +21,6 @@
         and feature requests to
         <a href="https://sourceforge.net/p/jabref/feature-requests/">https://sourceforge.net/p/jabref/feature-requests/</a>.</p>
 
-        <h2>Current developers:</h2>
-        <p>Simon Harrer,
-        Oliver Kopp,
-        Igor Steinmacher</p>
-
-        <h2>Former developers:</h2>
-        <p>Morten O. Alver,
-        Nizar N. Batada,
-        Michel Baylac,
-        Kolja Brix,
-        Guillaume Gardey,
-        Oscar Gustafsson,
-        Cyrille d'Haese,
-        S M Mahbub Murshed,
-        Raik Nagel,
-        Christopher Oezbek,
-        Ellen Reitmayr,
-        Gert Renckens,
-        Andreas Rudert,
-        Michael Spiegel,
-        Ulrik Stervbo,
-        Joerg K. Wegner,
-        Michael Wrighton,
-        Egon Willighagen,
-        J&ouml;rg Zieren</p>
-
         <h2>Contributions from:</h2>
 
         <p>${authors}</p>

--- a/src/main/resources/help/da/About.html
+++ b/src/main/resources/help/da/About.html
@@ -14,32 +14,6 @@
         GNU <a href="License.html">General Public License</a>,
         version 2.</p>
 
-        <h2>Current developers:</h2>
-        <p>Simon Harrer,
-        Oliver Kopp,
-        Igor Steinmacher</p>
-
-        <h2>Former developers:</h2>
-        <p>Morten O. Alver,
-        Nizar N. Batada,
-        Michel Baylac,
-        Kolja Brix,
-        Guillaume Gardey,
-        Oscar Gustafsson,
-        Cyrille d'Haese,
-        S M Mahbub Murshed,
-        Raik Nagel,
-        Christopher Oezbek,
-        Ellen Reitmayr,
-        Gert Renckens,
-        Andreas Rudert,
-        Michael Spiegel,
-        Ulrik Stervbo,
-        Joerg K. Wegner,
-        Michael Wrighton,
-        Egon Willighagen,
-        J&ouml;rg Zieren</p>
-
         <h2>Bidrag fra:</h2>
 
         <p>${authors}</p>

--- a/src/main/resources/help/de/About.html
+++ b/src/main/resources/help/de/About.html
@@ -13,32 +13,6 @@
         <p>JabRef ist frei verf&uuml;gbar unter den Bedingungen der
         GNU <a href="License.html">General Public License</a>.</p>
 
-        <h2>Akuelle Entwickler:</h2>
-        <p>Simon Harrer,
-        Oliver Kopp,
-        Igor Steinmacher</p>
-
-        <h2>Ehemalige Entwickler:</h2>
-        <p>Morten O. Alver,
-        Nizar N. Batada,
-        Michel Baylac,
-        Kolja Brix,
-        Guillaume Gardey,
-        Oscar Gustafsson,
-        Cyrille d'Haese,
-        S M Mahbub Murshed,
-        Raik Nagel,
-        Christopher Oezbek,
-        Ellen Reitmayr,
-        Gert Renckens,
-        Andreas Rudert,
-        Michael Spiegel,
-        Ulrik Stervbo,
-        Joerg K. Wegner,
-        Michael Wrighton,
-        Egon Willighagen,
-        J&ouml;rg Zieren</p>
-
         <h2>Beitr&auml;ge von:</h2>
 
         <p>${authors}</p>

--- a/src/main/resources/help/fr/About.html
+++ b/src/main/resources/help/fr/About.html
@@ -21,32 +21,6 @@
         tels que publi&eacute;s par la Free Software Foundation, 
         soit en version 2 de cette License, soit (&agrave; votre choix)
         dans n'importe quelle version ult&eacute;rieure.</p>
-        
-        <h2>Current developers:</h2>
-        <p>Simon Harrer,
-        Oliver Kopp,
-        Igor Steinmacher</p>
-
-        <h2>Former developers:</h2>
-        <p>Morten O. Alver,
-        Nizar N. Batada,
-        Michel Baylac,
-        Kolja Brix,
-        Guillaume Gardey,
-        Oscar Gustafsson,
-        Cyrille d'Haese,
-        S M Mahbub Murshed,
-        Raik Nagel,
-        Christopher Oezbek,
-        Ellen Reitmayr,
-        Gert Renckens,
-        Andreas Rudert,
-        Michael Spiegel,
-        Ulrik Stervbo,
-        Joerg K. Wegner,
-        Michael Wrighton,
-        Egon Willighagen,
-        J&ouml;rg Zieren</p>
 
         <h2>Contributions de&nbsp;:</h2>
 

--- a/src/main/resources/help/in/About.html
+++ b/src/main/resources/help/in/About.html
@@ -14,32 +14,6 @@
         GNU <a href="License.html">General Public License</a>,
         versi 2.</p>
 
-        <h2>Current developers:</h2>
-        <p>Simon Harrer,
-        Oliver Kopp,
-        Igor Steinmacher</p>
-
-        <h2>Former developers:</h2>
-        <p>Morten O. Alver,
-        Nizar N. Batada,
-        Michel Baylac,
-        Kolja Brix,
-        Guillaume Gardey,
-        Oscar Gustafsson,
-        Cyrille d'Haese,
-        S M Mahbub Murshed,
-        Raik Nagel,
-        Christopher Oezbek,
-        Ellen Reitmayr,
-        Gert Renckens,
-        Andreas Rudert,
-        Michael Spiegel,
-        Ulrik Stervbo,
-        Joerg K. Wegner,
-        Michael Wrighton,
-        Egon Willighagen,
-        J&ouml;rg Zieren</p>
-
         <h2>Pendukung lain:</h2>
 
         <p>${authors}</p>

--- a/src/main/resources/help/ja/About.html
+++ b/src/main/resources/help/ja/About.html
@@ -13,32 +13,6 @@
 
         <p>JabRefはフリーソフトウェアです。JabRefは、Free Software Foundationが公開しているGNU <a href="License.html">General Public License</a>のversion 2か、(お望みであれば)それよりも新しい版の下で自由に配布し修正することが可能です。</p>
 
-        <h2>Current developers:</h2>
-        <p>Simon Harrer,
-        Oliver Kopp,
-        Igor Steinmacher</p>
-
-        <h2>Former developers:</h2>
-        <p>Morten O. Alver,
-        Nizar N. Batada,
-        Michel Baylac,
-        Kolja Brix,
-        Guillaume Gardey,
-        Oscar Gustafsson,
-        Cyrille d'Haese,
-        S M Mahbub Murshed,
-        Raik Nagel,
-        Christopher Oezbek,
-        Ellen Reitmayr,
-        Gert Renckens,
-        Andreas Rudert,
-        Michael Spiegel,
-        Ulrik Stervbo,
-        Joerg K. Wegner,
-        Michael Wrighton,
-        Egon Willighagen,
-        J&ouml;rg Zieren</p>
-
         <h2>貢献者:</h2>
 
         <p>${authors}</p>


### PR DESCRIPTION
Maintaining a list of active developers is tedious and not necessarily fair.
All authors are automatically included in the contributors list (if we regenerate it often enough).
I know this is not an easy decision especially for those that contributed more than others and or are/were project leads. Maybe we can add these people exclusively again (as maintainers or the like).