### PR TITLE
Simplify key bindings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,6 +46,7 @@
     - Feature: all new lines when writing an entry are obeying the globally configured new line (File -> newline separator). Affects fields: abstract and review
     - Feature: [veryShortTitle] and [shortTitle] also skip words like "in", "among", "before", ...
     - Feature: New LabelPattern [keywordsN], where N is optional. Returns the first N keywords. If no N is specified ("[keywords]"), all keywords are returned. Spaces are removed.
+    - Removes support for key bindings per external application by allowing only the key binding "push to application" for the currently selected external application.
 [dev_2.11]
     - Backports from 2.80: Fix bug #194: JabRef starts again on Win XP and Win Vista
     - Backports from 2.80: Fixes #103: JDialog for auto set links is openend and closed correctly

--- a/src/main/java/net/sf/jabref/external/push/AbstractPushToApplication.java
+++ b/src/main/java/net/sf/jabref/external/push/AbstractPushToApplication.java
@@ -90,7 +90,9 @@ public abstract class AbstractPushToApplication implements PushToApplication {
         // In case it didn't work
         catch (IOException excep) {
             couldNotCall = true;
-            LOGGER.warn(getCouldNotCall());
+
+            LOGGER.warn(Localization.lang("Error") + ": "
+                    + Localization.lang("Could not call executable") + " '" + commandPath + "'.");
         }
     }
 
@@ -102,9 +104,11 @@ public abstract class AbstractPushToApplication implements PushToApplication {
                     + Localization.lang("Path to %0 not defined", getApplicationName()) + ".");
             // @formatter:on
         } else if (couldNotCall) {
-            panel.output(getCouldNotCall());
+            panel.output(Localization.lang("Error") + ": "
+                    + Localization.lang("Could not call executable") + " '" + commandPath + "'.");
         } else if (couldNotConnect) {
-            panel.output(getCouldNotConnect());
+            panel.output(Localization.lang("Error") + ": "
+                    + Localization.lang("Could not connect to ") + getApplicationName() + ".");
         } else {
             panel.output(Localization.lang("Pushed citations to %0", getApplicationName()) + ".");
         }
@@ -176,26 +180,6 @@ public abstract class AbstractPushToApplication implements PushToApplication {
     @Override
     public void storeSettings() {
         Globals.prefs.put(commandPathPreferenceKey, Path.getText());
-    }
-
-    /**
-     * @return Error message in case couldNotCall is set
-     */
-    protected String getCouldNotCall() {
-        // @formatter:off
-        return Localization.lang("Error") + ": "
-                + Localization.lang("Could not call executable") + " '" + commandPath + "'.";
-        // @formatter:on
-    }
-
-    /**
-     * @return Error message in case couldNotConnect is set
-     */
-    protected String getCouldNotConnect() {
-        // @formatter:off
-        return Localization.lang("Error") + ": "
-                + Localization.lang("Could not connect to ") + getApplicationName() + ".";
-        // @formatter:on
     }
 
 }

--- a/src/main/java/net/sf/jabref/external/push/AbstractPushToApplication.java
+++ b/src/main/java/net/sf/jabref/external/push/AbstractPushToApplication.java
@@ -62,11 +62,6 @@ public abstract class AbstractPushToApplication implements PushToApplication {
     }
 
     @Override
-    public String getKeyStrokeName() {
-        return "Push to " + getApplicationName();
-    }
-
-    @Override
     public void pushEntries(BibtexDatabase database, BibtexEntry[] entries, String keyString, MetaData metaData) {
 
         couldNotConnect = false;

--- a/src/main/java/net/sf/jabref/external/push/PushToApplication.java
+++ b/src/main/java/net/sf/jabref/external/push/PushToApplication.java
@@ -35,8 +35,6 @@ public interface PushToApplication {
 
     Icon getIcon();
 
-    String getKeyStrokeName();
-
     /**
      * This method asks the implementing class to return a JPanel populated with the imlementation's options panel, if
      * necessary. If the JPanel is shown to the user, and the user indicates that settings should be stored, the

--- a/src/main/java/net/sf/jabref/external/push/PushToApplicationAction.java
+++ b/src/main/java/net/sf/jabref/external/push/PushToApplicationAction.java
@@ -45,9 +45,6 @@ class PushToApplicationAction extends AbstractAction implements Runnable {
         putValue(Action.SMALL_ICON, operation.getIcon());
         putValue(Action.NAME, operation.getName());
         putValue(Action.SHORT_DESCRIPTION, operation.getTooltip());
-        if (operation.getKeyStrokeName() != null) {
-            putValue(Action.ACCELERATOR_KEY, Globals.prefs.getKey(operation.getKeyStrokeName()));
-        }
         this.operation = operation;
     }
 

--- a/src/main/java/net/sf/jabref/external/push/PushToApplications.java
+++ b/src/main/java/net/sf/jabref/external/push/PushToApplications.java
@@ -28,7 +28,7 @@ public class PushToApplications {
      * Set up the current available choices:
      */
     static {
-        applications = new ArrayList<PushToApplication>();
+        applications = new ArrayList<>();
 
         PushToApplications.applications.add(new PushToLyx());
         PushToApplications.applications.add(new PushToEmacs());

--- a/src/main/java/net/sf/jabref/external/push/PushToEmacs.java
+++ b/src/main/java/net/sf/jabref/external/push/PushToEmacs.java
@@ -171,8 +171,9 @@ public class PushToEmacs extends AbstractPushToApplication implements PushToAppl
                     + "the emacsclient/gnuclient program installed and available in the PATH."),
                     Localization.lang("Error"), JOptionPane.ERROR_MESSAGE);
             // @formatter:on
+        } else {
+            super.operationCompleted(panel);
         }
-        super.operationCompleted(panel);
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/external/push/PushToLyx.java
+++ b/src/main/java/net/sf/jabref/external/push/PushToLyx.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import javax.swing.*;
 
 import net.sf.jabref.*;
+import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibtexDatabase;
@@ -46,22 +47,18 @@ public class PushToLyx extends AbstractPushToApplication implements PushToApplic
     }
 
     @Override
-    protected String getCouldNotCall() {
-        // @formatter:off
-        return Localization.lang("Error") + ": " +
-                Localization.lang("unable to write to") + " " + commandPath +
-                ".in";
-        // @formatter:on
-    }
-
-    @Override
-    protected String getCouldNotConnect() {
-        // @formatter:off
-        return Localization.lang("Error") + ": " +
-                Localization.lang("verify that LyX is running and that the lyxpipe is valid")
-                + ". [" + commandPath + "]";
-        // @formatter:on
-
+    public void operationCompleted(BasePanel panel) {
+        if(couldNotConnect) {
+            panel.output(Localization.lang("Error") + ": " +
+                    Localization.lang("verify that LyX is running and that the lyxpipe is valid")
+                    + ". [" + commandPath + "]");
+        } else if(couldNotCall) {
+            panel.output(Localization.lang("Error") + ": " +
+                    Localization.lang("unable to write to") + " " + commandPath +
+                    ".in");
+        } else {
+            super.operationCompleted(panel);
+        }
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/external/push/PushToVim.java
+++ b/src/main/java/net/sf/jabref/external/push/PushToVim.java
@@ -142,8 +142,9 @@ public class PushToVim extends AbstractPushToApplication implements PushToApplic
                     Localization.lang("Could not run the 'vim' program."),
                     Localization.lang("Error"), JOptionPane.ERROR_MESSAGE);
             // formatter:on
+        } else {
+            super.operationCompleted(panel);
         }
-        super.operationCompleted(panel);
     }
     
     @Override

--- a/src/main/java/net/sf/jabref/gui/keyboard/KeyBinds.java
+++ b/src/main/java/net/sf/jabref/gui/keyboard/KeyBinds.java
@@ -74,8 +74,6 @@ public class KeyBinds {
     public static final String PREAMBLE_EDITOR_STORE_CHANGES = "Preamble editor, store changes";
     public static final String PREVIOUS_TAB = "Previous tab";
     public static final String PUSH_TO_APPLICATION = "Push to application";
-    public static final String PUSH_TO_LY_X = "Push to LyX";
-    public static final String PUSH_TO_WIN_EDT = "Push to WinEdt";
     public static final String QUIT_JAB_REF = "Quit JabRef";
     public static final String REDO = "Redo";
     public static final String REFRESH_OO = "Refresh OO";
@@ -113,8 +111,6 @@ public class KeyBinds {
 
     public KeyBinds() {
         keyBindMap.put(PUSH_TO_APPLICATION, "ctrl L");
-        keyBindMap.put(PUSH_TO_LY_X, "ctrl L");
-        keyBindMap.put(PUSH_TO_WIN_EDT, "ctrl shift W");
         keyBindMap.put(QUIT_JAB_REF, "ctrl Q");
         keyBindMap.put(OPEN_DATABASE, "ctrl O");
         keyBindMap.put(SAVE_DATABASE, "ctrl S");

--- a/src/main/java/net/sf/jabref/openoffice/OpenOfficePanel.java
+++ b/src/main/java/net/sf/jabref/openoffice/OpenOfficePanel.java
@@ -1007,11 +1007,6 @@ public class OpenOfficePanel extends AbstractWorker implements PushToApplication
     }
 
     @Override
-    public String getKeyStrokeName() {
-        return null;
-    }
-
-    @Override
     public JPanel getSettingsPanel() {
         return null;
         /*if (settings == null)


### PR DESCRIPTION
Currently, there is a key binding for "push to application" but there can be key bindings for each specific application, e.g., LyX, Vim, etc.

To simplify, there should only be a key binding for the currently selected application, hence, only the "push to application" key binding. 