### PR TITLE
Set default encoding to UTF-8

### DIFF
--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -591,7 +591,7 @@ public class JabRefPreferences {
         defaults.put(HIGHLIGHT_GROUPS_MATCHING_ALL, Boolean.FALSE);
         defaults.put(TOOLBAR_VISIBLE, Boolean.TRUE);
         defaults.put(SEARCH_PANEL_VISIBLE, Boolean.FALSE);
-        defaults.put(DEFAULT_ENCODING, System.getProperty("file.encoding"));
+        defaults.put(DEFAULT_ENCODING, "UTF-8");
         defaults.put(GROUPS_VISIBLE_ROWS, 8);
         defaults.put(DEFAULT_OWNER, System.getProperty("user.name"));
         defaults.put(PRESERVE_FIELD_FORMATTING, Boolean.FALSE);


### PR DESCRIPTION
The UTF-8 support of LaTeX, [biber](https://www.ctan.org/pkg/biber) and [LaTeX editors](http://tex.stackexchange.com/questions/339/latex-editors-ides) is really mature. To have interoperable `.bib` files, JabRef should set the default encoding (for new users) to `UTF-8`