### PR TITLE
Save shortcut and cleanups in Stringdialog

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,4 @@
 [master]
-    - Added save button to string edit dialog
     - Removes non-compact rank symbols in favor of compact rank
     - All duplicate whitespaces / tabs / newlines are now removed from non-multiline fields
     - Fixed a bug in the IEEEXploreFetcher

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 [master]
+    - Added save button to string edit dialog
     - Removes non-compact rank symbols in favor of compact rank
     - All duplicate whitespaces / tabs / newlines are now removed from non-multiline fields
     - Fixed a bug in the IEEEXploreFetcher

--- a/src/main/java/net/sf/jabref/gui/StringDialog.java
+++ b/src/main/java/net/sf/jabref/gui/StringDialog.java
@@ -61,8 +61,6 @@ import net.sf.jabref.model.entry.BibtexString;
 
 class StringDialog extends JDialog {
 
-    private static final long serialVersionUID = 3649022684378600168L;
-
     // A reference to the entry this object works on.
     private final BibtexDatabase base;
     private final JabRefFrame frame;
@@ -75,8 +73,7 @@ class StringDialog extends JDialog {
     private final HelpAction helpAction;
 
 
-    public StringDialog(JabRefFrame frame, BasePanel panel,
-            BibtexDatabase base, JabRefPreferences prefs) {
+    public StringDialog(JabRefFrame frame, BasePanel panel, BibtexDatabase base, JabRefPreferences prefs) {
         super(frame);
         this.frame = frame;
         this.panel = panel;
@@ -85,8 +82,7 @@ class StringDialog extends JDialog {
 
         sortStrings();
 
-        helpAction = new HelpAction
-                (frame.helpDiag, GUIGlobals.stringEditorHelp, Localization.lang("Help"));
+        helpAction = new HelpAction(frame.helpDiag, GUIGlobals.stringEditorHelp, Localization.lang("Help"));
 
         addWindowListener(new WindowAdapter() {
 
@@ -99,8 +95,6 @@ class StringDialog extends JDialog {
         // We replace the default FocusTraversalPolicy with a subclass
         // that only allows the StringTable to gain keyboard focus.
         setFocusTraversalPolicy(new LayoutFocusTraversalPolicy() {
-
-            private static final long serialVersionUID = 601883449812894601L;
 
             @Override
             protected boolean accept(Component c) {
@@ -139,7 +133,7 @@ class StringDialog extends JDialog {
         am.put("remove", removeStringAction);
         im.put(prefs.getKey("Save database"), "save");
         am.put("save", saveAction);
-       im.put(prefs.getKey("Close dialog"), "close");
+        im.put(prefs.getKey("Close dialog"), "close");
         am.put("close", closeAction);
         im.put(prefs.getKey("Help"), "help");
         am.put("help", helpAction);
@@ -161,15 +155,15 @@ class StringDialog extends JDialog {
         if (panel.getFile() != null) {
             setTitle(Localization.lang(GUIGlobals.stringsTitle) + ": " + panel.getFile().getName());
         } else {
-            setTitle(Localization.lang(GUIGlobals.stringsTitle) + ": " + Localization.lang(GUIGlobals.untitledTitle));
+            // @formatter:off
+            setTitle(Localization.lang(GUIGlobals.stringsTitle) + ": " 
+                    + Localization.lang(GUIGlobals.untitledTitle));
+            // @formatter:on
         }
-
     }
 
 
     class StringTable extends JTable {
-
-        private static final long serialVersionUID = -2772213505406760942L;
 
         final JScrollPane sp = new JScrollPane(this);
 
@@ -186,12 +180,10 @@ class StringDialog extends JDialog {
             cm.getColumn(0).setPreferredWidth(800);
             cm.getColumn(1).setPreferredWidth(2000);
             sp.getViewport().setBackground(Globals.prefs.getColor(JabRefPreferences.TABLE_BACKGROUND));
-            // getInputMap().remove(GUIGlobals.exitDialog);
             getInputMap().put(frame.prefs.getKey("Close dialog"), "close");
             getActionMap().put("close", closeAction);
             getInputMap().put(frame.prefs.getKey("Help"), "help");
             getActionMap().put("help", helpAction);
-
         }
 
         public JComponent getPane() {
@@ -221,9 +213,8 @@ class StringDialog extends JDialog {
         panel.runCommand("save");
     }
 
-    class StringTableModel extends AbstractTableModel {
 
-        private static final long serialVersionUID = -3696860403245796557L;
+    class StringTableModel extends AbstractTableModel {
 
         final BibtexDatabase tbase;
         final StringDialog parent;
@@ -236,9 +227,7 @@ class StringDialog extends JDialog {
 
         @Override
         public Object getValueAt(int row, int col) {
-            return col == 0 ?
-                    ((BibtexString) strings[row]).getName() :
-                    ((BibtexString) strings[row]).getContent();
+            return col == 0 ? ((BibtexString) strings[row]).getName() : ((BibtexString) strings[row]).getContent();
         }
 
         @Override
@@ -247,39 +236,24 @@ class StringDialog extends JDialog {
                 // Change name of string.
                 if (!value.equals(((BibtexString) strings[row]).getName())) {
                     if (tbase.hasStringLabel((String) value)) {
-                        JOptionPane.showMessageDialog(parent,
-                                Localization.lang("A string with that label "
-                                        + "already exists"),
-                                Localization.lang("Label"),
-                                JOptionPane.ERROR_MESSAGE);
+                        // @formatter:off
+                        JOptionPane.showMessageDialog(parent, Localization.lang("A string with that label " 
+                                + "already exists"),
+                                Localization.lang("Label"), JOptionPane.ERROR_MESSAGE);
                     } else if (((String) value).contains(" ")) {
-                        JOptionPane.showMessageDialog
-                                (parent,
-                                        Localization.lang("The label of the string cannot contain spaces."),
-                                        Localization.lang("Label"),
-                                        JOptionPane.ERROR_MESSAGE);
-                    }
-                    else if (((String) value).contains("#")) {
-                        JOptionPane.showMessageDialog
-                                (parent,
-                                        Localization.lang("The label of the string cannot contain the '#' character."),
-                                        Localization.lang("Label"),
-                                        JOptionPane.ERROR_MESSAGE);
-                    }
-                    else if (isNumber((String) value)) {
-                        JOptionPane.showMessageDialog
-                                (parent,
-                                        Localization.lang("The label of the string cannot be a number."),
-                                        Localization.lang("Label"),
-                                        JOptionPane.ERROR_MESSAGE);
-                    }
-                    else {
+                        JOptionPane.showMessageDialog(parent, Localization.lang("The label of the string cannot contain spaces."),
+                                Localization.lang("Label"), JOptionPane.ERROR_MESSAGE);
+                    } else if (((String) value).contains("#")) {
+                        JOptionPane.showMessageDialog(parent, Localization.lang("The label of the string cannot contain the '#' character."),
+                                Localization.lang("Label"), JOptionPane.ERROR_MESSAGE);
+                    } else if (isNumber((String) value)) {
+                        JOptionPane.showMessageDialog(parent, Localization.lang("The label of the string cannot be a number."),
+                                Localization.lang("Label"), JOptionPane.ERROR_MESSAGE);
+                        // @formatter:on
+                    } else {
                         // Store undo information.
                         BibtexString subject = (BibtexString) strings[row];
-                        panel.undoManager.addEdit
-                                (new UndoableStringChange
-                                (panel, subject, true,
-                                        subject.getName(), (String) value));
+                        panel.undoManager.addEdit(new UndoableStringChange(panel, subject, true, subject.getName(), (String) value));
                         subject.setName((String) value);
                         panel.markBaseChanged();
                         refreshTable();
@@ -296,10 +270,7 @@ class StringDialog extends JDialog {
                         return;
                     }
                     // Store undo information.
-                    panel.undoManager.addEdit
-                            (new UndoableStringChange
-                            (panel, subject, false,
-                                    subject.getContent(), (String) value));
+                    panel.undoManager.addEdit(new UndoableStringChange(panel, subject, false, subject.getContent(), (String) value));
 
                     subject.setContent((String) value);
                     panel.markBaseChanged();
@@ -314,13 +285,15 @@ class StringDialog extends JDialog {
 
         @Override
         public int getRowCount() {
-            return strings.length; //base.getStringCount();
+            return strings.length;
         }
 
         @Override
         public String getColumnName(int col) {
-            return col == 0 ?
-                    Localization.lang("Name") : Localization.lang("Content");
+            // @formatter:off
+            return col == 0 ? Localization.lang("Name") : 
+                Localization.lang("Content");
+            // @formatter:on
         }
 
         @Override
@@ -357,14 +330,11 @@ class StringDialog extends JDialog {
 
     class CloseAction extends AbstractAction {
 
-        private static final long serialVersionUID = 5530138721879378049L;
-
         final StringDialog parent;
 
 
         public CloseAction(StringDialog parent) {
             super("Close window");
-            //, new ImageIcon(GUIGlobals.closeIconFile));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Close dialog"));
             this.parent = parent;
         }
@@ -382,51 +352,42 @@ class StringDialog extends JDialog {
         }
     }
 
-
     class NewStringAction extends AbstractAction {
-
-        private static final long serialVersionUID = -950091418779927997L;
 
         final StringDialog parent;
 
 
         public NewStringAction(StringDialog parent) {
-            super("New string",
-                    IconTheme.getImage("add"));
+            super("New string", IconTheme.getImage("add"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("New string"));
             this.parent = parent;
         }
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            String name =
-                    JOptionPane.showInputDialog(parent,
-                            Localization.lang("Please enter the string's label"));
+            String name = JOptionPane.showInputDialog(parent, Localization.lang("Please enter the string's label"));
             if (name == null) {
                 return;
             }
             if (isNumber(name)) {
-                JOptionPane.showMessageDialog
-                        (parent,
-                                Localization.lang("The label of the string cannot be a number."),
-                                Localization.lang("Label"),
-                                JOptionPane.ERROR_MESSAGE);
+                // @formatter:off
+                JOptionPane.showMessageDialog(parent, Localization.lang("The label of the string cannot be a number."),
+                        Localization.lang("Label"), JOptionPane.ERROR_MESSAGE);
+                // @formatter:on
                 return;
             }
             if (name.contains("#")) {
-                JOptionPane.showMessageDialog
-                        (parent,
-                                Localization.lang("The label of the string cannot contain the '#' character."),
-                                Localization.lang("Label"),
-                                JOptionPane.ERROR_MESSAGE);
+                // @formatter:off
+                JOptionPane.showMessageDialog(parent, Localization.lang("The label of the string cannot contain the '#' character."),
+                        Localization.lang("Label"), JOptionPane.ERROR_MESSAGE);
+                // @formatter:on
                 return;
             }
             if (name.contains(" ")) {
-                JOptionPane.showMessageDialog
-                        (parent,
-                                Localization.lang("The label of the string cannot contain spaces."),
-                                Localization.lang("Label"),
-                                JOptionPane.ERROR_MESSAGE);
+                // @formatter:off
+                JOptionPane.showMessageDialog(parent, Localization.lang("The label of the string cannot contain spaces."),
+                        Localization.lang("Label"), JOptionPane.ERROR_MESSAGE);
+                // @formatter:on
                 return;
             }
             try {
@@ -434,20 +395,18 @@ class StringDialog extends JDialog {
                 BibtexString bs = new BibtexString(newId, name, "");
 
                 // Store undo information:
-                panel.undoManager.addEdit
-                        (new UndoableInsertString
-                        (panel, panel.database, bs));
+                panel.undoManager.addEdit(new UndoableInsertString(panel, panel.database, bs));
 
                 base.addString(bs);
                 refreshTable();
                 //		table.revalidate();
                 panel.markBaseChanged();
             } catch (KeyCollisionException ex) {
-                JOptionPane.showMessageDialog(parent,
-                        Localization.lang("A string with that label "
-                                + "already exists"),
-                        Localization.lang("Label"),
-                        JOptionPane.ERROR_MESSAGE);
+                // @formatter:off
+                JOptionPane.showMessageDialog(parent, Localization.lang("A string with that label " 
+                        + "already exists"),
+                        Localization.lang("Label"), JOptionPane.ERROR_MESSAGE);
+                // @formatter:on
             }
         }
     }
@@ -455,16 +414,14 @@ class StringDialog extends JDialog {
 
     SaveDatabaseAction saveAction = new SaveDatabaseAction(this);
 
-    static class SaveDatabaseAction extends AbstractAction {
 
-        private static final long serialVersionUID = 2780778445054043703L;
+    static class SaveDatabaseAction extends AbstractAction {
 
         final StringDialog parent;
 
 
         public SaveDatabaseAction(StringDialog parent) {
-            super("Save database",
-                    IconTheme.getImage("save"));
+            super("Save database", IconTheme.getImage("save"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Save database"));
             this.parent = parent;
         }
@@ -475,17 +432,13 @@ class StringDialog extends JDialog {
         }
     }
 
-
     class RemoveStringAction extends AbstractAction {
-
-        private static final long serialVersionUID = -1134835504587601867L;
 
         final StringDialog parent;
 
 
         public RemoveStringAction(StringDialog parent) {
-            super("Remove selected strings",
-                    IconTheme.getImage("remove"));
+            super("Remove selected strings", IconTheme.getImage("remove"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Remove selected strings"));
             this.parent = parent;
         }
@@ -499,12 +452,13 @@ class StringDialog extends JDialog {
                 // keystroke. This makes the content hang on the screen.
                 assureNotEditing();
 
-                String msg = Localization.lang("Really delete the selected") + ' ' +
-                        (sel.length > 1 ? sel.length + " " + Localization.lang("entries")
-                                : Localization.lang("entry")) + '?';
+                // @formatter:off
+                String msg = Localization.lang("Really delete the selected") + ' ' 
+                        + (sel.length > 1 ? sel.length + " " + Localization.lang("entries") 
+                        : Localization.lang("entry")) + '?';
                 int answer = JOptionPane.showConfirmDialog(parent, msg, Localization.lang("Delete strings"),
-                        JOptionPane.YES_NO_OPTION,
-                        JOptionPane.QUESTION_MESSAGE);
+                        JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
+                // @formatter:on
                 if (answer == JOptionPane.YES_OPTION) {
                     CompoundEdit ce = new CompoundEdit();
                     for (int i = sel.length - 1; i >= 0; i--) {
@@ -513,9 +467,7 @@ class StringDialog extends JDialog {
                         BibtexString subject = (BibtexString) strings[sel[i]];
 
                         // Store undo information:
-                        ce.addEdit(new UndoableRemoveString
-                                (panel, base,
-                                        subject));
+                        ce.addEdit(new UndoableRemoveString(panel, base, subject));
 
                         base.removeString(subject.getId());
                     }
@@ -524,8 +476,7 @@ class StringDialog extends JDialog {
 
                     //table.revalidate();
                     refreshTable();
-                    if (base.getStringCount() > 0)
-                     {
+                    if (base.getStringCount() > 0) {
                         table.setRowSelectionInterval(0, 0);
                     }
                 }
@@ -534,8 +485,6 @@ class StringDialog extends JDialog {
     }
 
     class UndoAction extends AbstractAction {
-
-        private static final long serialVersionUID = -599852779966425698L;
 
         public UndoAction() {
             super("Undo", IconTheme.getImage("undo"));
@@ -551,10 +500,7 @@ class StringDialog extends JDialog {
         }
     }
 
-
     class RedoAction extends AbstractAction {
-
-        private static final long serialVersionUID = -4404964237851372948L;
 
         public RedoAction() {
             super("Undo", IconTheme.getImage("redo"));

--- a/src/main/java/net/sf/jabref/gui/StringDialog.java
+++ b/src/main/java/net/sf/jabref/gui/StringDialog.java
@@ -153,8 +153,6 @@ class StringDialog extends JDialog {
         tlb.add(newStringAction);
         tlb.add(removeStringAction);
         tlb.addSeparator();
-        tlb.add(saveAction);
-        tlb.addSeparator();
         tlb.add(helpAction);
         Container conPane = getContentPane();
         conPane.add(tlb, BorderLayout.NORTH);

--- a/src/main/java/net/sf/jabref/gui/StringDialog.java
+++ b/src/main/java/net/sf/jabref/gui/StringDialog.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2015 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -61,6 +61,8 @@ import net.sf.jabref.model.entry.BibtexString;
 
 class StringDialog extends JDialog {
 
+    private static final long serialVersionUID = 3649022684378600168L;
+
     // A reference to the entry this object works on.
     private final BibtexDatabase base;
     private final JabRefFrame frame;
@@ -98,9 +100,11 @@ class StringDialog extends JDialog {
         // that only allows the StringTable to gain keyboard focus.
         setFocusTraversalPolicy(new LayoutFocusTraversalPolicy() {
 
+            private static final long serialVersionUID = 601883449812894601L;
+
             @Override
             protected boolean accept(Component c) {
-                return super.accept(c) && c instanceof StringTable;
+                return super.accept(c) && (c instanceof StringTable);
             }
         });
 
@@ -133,10 +137,6 @@ class StringDialog extends JDialog {
         im.put(prefs.getKey("String dialog, remove string"), "remove");
         RemoveStringAction removeStringAction = new RemoveStringAction(this);
         am.put("remove", removeStringAction);
-        //im.put(prefs.getKey("String dialog, move string up"), "up");
-        //am.put("up", stringUpAction);
-        //im.put(prefs.getKey("String dialog, move string down"), "down");
-        //am.put("down", stringDownAction);
         im.put(prefs.getKey("Save database"), "save");
         am.put("save", saveAction);
        im.put(prefs.getKey("Close dialog"), "close");
@@ -150,14 +150,10 @@ class StringDialog extends JDialog {
         RedoAction redoAction = new RedoAction();
         am.put("redo", redoAction);
 
-        //tlb.add(closeAction);
-        //tlb.addSeparator();
         tlb.add(newStringAction);
         tlb.add(removeStringAction);
         tlb.addSeparator();
         tlb.add(saveAction);
-        //tlb.add(stringUpAction);
-        //tlb.add(stringDownAction);
         tlb.addSeparator();
         tlb.add(helpAction);
         Container conPane = getContentPane();
@@ -174,6 +170,8 @@ class StringDialog extends JDialog {
 
 
     class StringTable extends JTable {
+
+        private static final long serialVersionUID = -2772213505406760942L;
 
         final JScrollPane sp = new JScrollPane(this);
 
@@ -227,13 +225,15 @@ class StringDialog extends JDialog {
 
     class StringTableModel extends AbstractTableModel {
 
-        final BibtexDatabase base;
+        private static final long serialVersionUID = -3696860403245796557L;
+
+        final BibtexDatabase tbase;
         final StringDialog parent;
 
 
         public StringTableModel(StringDialog parent, BibtexDatabase base) {
             this.parent = parent;
-            this.base = base;
+            this.tbase = base;
         }
 
         @Override
@@ -245,14 +245,10 @@ class StringDialog extends JDialog {
 
         @Override
         public void setValueAt(Object value, int row, int col) {
-            //	    if (row >= base.getStringCount())
-            //	return; // After a Remove operation the program somehow
-            // thinks the user is still editing an entry,
-            // which might now be outside
             if (col == 0) {
                 // Change name of string.
                 if (!value.equals(((BibtexString) strings[row]).getName())) {
-                    if (base.hasStringLabel((String) value)) {
+                    if (tbase.hasStringLabel((String) value)) {
                         JOptionPane.showMessageDialog(parent,
                                 Localization.lang("A string with that label "
                                         + "already exists"),
@@ -363,6 +359,8 @@ class StringDialog extends JDialog {
 
     class CloseAction extends AbstractAction {
 
+        private static final long serialVersionUID = 5530138721879378049L;
+
         final StringDialog parent;
 
 
@@ -388,6 +386,8 @@ class StringDialog extends JDialog {
 
 
     class NewStringAction extends AbstractAction {
+
+        private static final long serialVersionUID = -950091418779927997L;
 
         final StringDialog parent;
 
@@ -455,31 +455,11 @@ class StringDialog extends JDialog {
     }
 
 
-    StoreContentAction storeContentAction = new StoreContentAction(this);
-
-
-    static class StoreContentAction extends AbstractAction {
-
-        final StringDialog parent;
-
-
-        public StoreContentAction(StringDialog parent) {
-            super("Store string",
-                    IconTheme.getImage("add"));
-            putValue(Action.SHORT_DESCRIPTION, Localization.lang("Store string"));
-            this.parent = parent;
-        }
-
-        @Override
-        public void actionPerformed(ActionEvent e) {
-        }
-    }
-
-
     SaveDatabaseAction saveAction = new SaveDatabaseAction(this);
 
-
     static class SaveDatabaseAction extends AbstractAction {
+
+        private static final long serialVersionUID = 2780778445054043703L;
 
         final StringDialog parent;
 
@@ -499,6 +479,8 @@ class StringDialog extends JDialog {
 
 
     class RemoveStringAction extends AbstractAction {
+
+        private static final long serialVersionUID = -1134835504587601867L;
 
         final StringDialog parent;
 
@@ -547,83 +529,15 @@ class StringDialog extends JDialog {
                     if (base.getStringCount() > 0)
                      {
                         table.setRowSelectionInterval(0, 0);
-                    //table.repaint();
-                    //panel.markBaseChanged();
                     }
                 }
             }
         }
     }
 
-
-    /*    StringUpAction stringUpAction = new StringUpAction();
-    class StringUpAction extends AbstractAction {
-    public StringUpAction() {
-        super("Move string up",
-    	  new ImageIcon(GUIGlobals.upIconFile));
-        putValue(SHORT_DESCRIPTION, Globals.lang("Move string up"));
-    }
-    public void actionPerformed(ActionEvent e) {
-        int[] sel = table.getSelectedRows();
-        if ((sel.length == 1) && (sel[0] > 0)) {
-
-    	// Make sure no cell is being edited, as caused by the
-    	// keystroke. This makes the content hang on the screen.
-    	assureNotEditing();
-    	// Store undo information:
-    	panel.undoManager.addEdit(new UndoableMoveString
-    				      (panel, base, sel[0], true));
-
-    	BibtexString bs = base.getString(sel[0]);
-    	base.removeString(sel[0]);
-    	try {
-    	    base.addString(bs, sel[0]-1);
-    	} catch (KeyCollisionException ex) {}
-    	table.revalidate();
-    	table.setRowSelectionInterval(sel[0]-1, sel[0]-1);
-    	table.repaint();
-    	panel.markBaseChanged();
-        }
-    }
-    }
-
-    StringDownAction stringDownAction = new StringDownAction();
-    class StringDownAction extends AbstractAction {
-    public StringDownAction() {
-        super("Move string down",
-    	  new ImageIcon(GUIGlobals.downIconFile));
-        putValue(SHORT_DESCRIPTION, Globals.lang("Move string down"));
-    }
-    public void actionPerformed(ActionEvent e) {
-        int[] sel = table.getSelectedRows();
-        if ((sel.length == 1) && (sel[0]+1 < base.getStringCount())) {
-
-    	// Make sure no cell is being edited, as caused by the
-    	// keystroke. This makes the content hang on the screen.
-    	assureNotEditing();
-
-
-    	// Store undo information:
-    	panel.undoManager.addEdit(new UndoableMoveString
-    				      (panel, base, sel[0], false));
-
-
-    	BibtexString bs = base.getString(sel[0]);
-    	base.removeString(sel[0]);
-    	try {
-    	    base.addString(bs, sel[0]+1);
-    	} catch (KeyCollisionException ex) {}
-    	table.revalidate();
-    	table.setRowSelectionInterval(sel[0]+1, sel[0]+1);
-    	table.repaint();
-    	panel.markBaseChanged();
-        }
-
-    }
-    }*/
-
-
     class UndoAction extends AbstractAction {
+
+        private static final long serialVersionUID = -599852779966425698L;
 
         public UndoAction() {
             super("Undo", IconTheme.getImage("undo"));
@@ -642,6 +556,8 @@ class StringDialog extends JDialog {
 
     class RedoAction extends AbstractAction {
 
+        private static final long serialVersionUID = -4404964237851372948L;
+
         public RedoAction() {
             super("Undo", IconTheme.getImage("redo"));
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Redo"));
@@ -655,5 +571,4 @@ class StringDialog extends JDialog {
             }
         }
     }
-
 }

--- a/src/main/java/net/sf/jabref/gui/StringDialog.java
+++ b/src/main/java/net/sf/jabref/gui/StringDialog.java
@@ -137,7 +137,9 @@ class StringDialog extends JDialog {
         //am.put("up", stringUpAction);
         //im.put(prefs.getKey("String dialog, move string down"), "down");
         //am.put("down", stringDownAction);
-        im.put(prefs.getKey("Close dialog"), "close");
+        im.put(prefs.getKey("Save database"), "save");
+        am.put("save", saveAction);
+       im.put(prefs.getKey("Close dialog"), "close");
         am.put("close", closeAction);
         im.put(prefs.getKey("Help"), "help");
         am.put("help", helpAction);
@@ -153,6 +155,7 @@ class StringDialog extends JDialog {
         tlb.add(newStringAction);
         tlb.add(removeStringAction);
         tlb.addSeparator();
+        tlb.add(saveAction);
         //tlb.add(stringUpAction);
         //tlb.add(stringDownAction);
         tlb.addSeparator();
@@ -218,6 +221,9 @@ class StringDialog extends JDialog {
         table.repaint();
     }
 
+    public void saveDatabase() {
+        panel.runCommand("save");
+    }
 
     class StringTableModel extends AbstractTableModel {
 
@@ -466,6 +472,28 @@ class StringDialog extends JDialog {
 
         @Override
         public void actionPerformed(ActionEvent e) {
+        }
+    }
+
+
+    SaveDatabaseAction saveAction = new SaveDatabaseAction(this);
+
+
+    static class SaveDatabaseAction extends AbstractAction {
+
+        final StringDialog parent;
+
+
+        public SaveDatabaseAction(StringDialog parent) {
+            super("Save database",
+                    IconTheme.getImage("save"));
+            putValue(Action.SHORT_DESCRIPTION, Localization.lang("Save database"));
+            this.parent = parent;
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            parent.saveDatabase();
         }
     }
 


### PR DESCRIPTION
Removed the button, but kept the shortcut plus all the cleanups from the previous PR.