### PR TITLE
Update supported lookAndFeels

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -50,6 +50,7 @@
     - Removes support for key bindings per external application by allowing only the key binding "push to application" for the currently selected external application.
     - Removes "edit preamble" from toolbar
     - Fix #250: No hard line breaks after 70 chars in serialized JabRef meta data
+    - Update supported LookAndFeels
 [dev_2.11]
     - Backports from 2.80: Fix bug #194: JabRef starts again on Win XP and Win Vista
     - Backports from 2.80: Fixes #103: JDialog for auto set links is openend and closed correctly

--- a/src/main/java/net/sf/jabref/gui/preftabs/AdvancedTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/AdvancedTab.java
@@ -87,9 +87,8 @@ class AdvancedTab extends JPanel implements PrefsTab {
         String[] possibleLookAndFeels = {
                 UIManager.getSystemLookAndFeelClassName(),
                 UIManager.getCrossPlatformLookAndFeelClassName(),
-                "com.jgoodies.plaf.plastic.Plastic3DLookAndFeel",
-                "com.sun.java.swing.plaf.motif.MotifLookAndFeel",
-                "javax.swing.plaf.mac.MacLookAndFeel",
+                "com.jgoodies.looks.plastic.Plastic3DLookAndFeel",
+                "com.jgoodies.looks.windows.WindowsLookAndFeel"
         };
         // Only list L&F which are available
         List<String> lookAndFeels = new ArrayList<String>();


### PR DESCRIPTION
I propose to update the list of supported lookAndFeels:

- The FQCN for the `jgoodies` LaFs were wrong
- the "`javax.swing.plaf.mac.MacLookAndFeel`" is not available on Windows and not chosable on Macs either (as the whole input field is hidden on a Mac (see https://github.com/JabRef/jabref/blob/1a0d23b64efa72f5184ad7f4100a428b7cc06040/src/main/java/net/sf/jabref/gui/preftabs/AdvancedTab.java#L123-L148)
- `com.sun.java.swing.plaf.motif.MotifLookAndFeel` looks like this: 
![jabref_metal](https://cloud.githubusercontent.com/assets/676652/10665721/8a474c96-78cd-11e5-8f3a-f46afba25229.png)
