### PR TITLE
Cleanup preferences

### DIFF
--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -191,7 +191,6 @@ public class JabRefPreferences {
     public static final String PDF_COLUMN = "pdfColumn";
     public static final String DISABLE_ON_MULTIPLE_SELECTION = "disableOnMultipleSelection";
     public static final String CTRL_CLICK = "ctrlClick";
-    public static final String ANTIALIAS = "antialias";
     public static final String INCOMPLETE_ENTRY_BACKGROUND = "incompleteEntryBackground";
     public static final String FIELD_EDITOR_TEXT_COLOR = "fieldEditorTextColor";
     public static final String ACTIVE_FIELD_EDITOR_BACKGROUND_COLOR = "activeFieldEditorBackgroundColor";
@@ -624,7 +623,6 @@ public class JabRefPreferences {
 
         defaults.put(INCOMPLETE_ENTRY_BACKGROUND, "250:175:175");
 
-        defaults.put(ANTIALIAS, Boolean.FALSE);
         defaults.put(CTRL_CLICK, Boolean.FALSE);
         defaults.put(DISABLE_ON_MULTIPLE_SELECTION, Boolean.FALSE);
         defaults.put(PDF_COLUMN, Boolean.FALSE);

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -82,7 +82,6 @@ public class JabRefPreferences {
     public static final String NAMES_LAST_ONLY = "namesLastOnly";
     public static final String ABBR_AUTHOR_NAMES = "abbrAuthorNames";
     public static final String NAMES_NATBIB = "namesNatbib";
-    public static final String NAMES_LAST_FIRST = "namesLf";
     public static final String NAMES_FIRST_LAST = "namesFf";
     public static final String NAMES_AS_IS = "namesAsIs";
     public static final String TABLE_COLOR_CODES_ON = "tableColorCodesOn";
@@ -479,7 +478,6 @@ public class JabRefPreferences {
         defaults.put(TABLE_COLOR_CODES_ON, Boolean.FALSE);
         defaults.put(NAMES_AS_IS, Boolean.FALSE); // "Show names unchanged"
         defaults.put(NAMES_FIRST_LAST, Boolean.FALSE); // "Show 'Firstname Lastname'"
-        defaults.put(NAMES_LAST_FIRST, Boolean.FALSE); // "Show 'Lastname, Firstname'"
         defaults.put(NAMES_NATBIB, Boolean.TRUE); // "Natbib style"
         defaults.put(ABBR_AUTHOR_NAMES, Boolean.TRUE); // "Abbreviate names"
         defaults.put(NAMES_LAST_ONLY, Boolean.TRUE); // "Show last names only"

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -161,7 +161,6 @@ public class JabRefPreferences {
     public static final String AUTO_COMP_FIRST_LAST = "autoCompFF";
     public static final String AUTO_COMPLETE_FIELDS = "autoCompleteFields";
     public static final String AUTO_COMPLETE = "autoComplete";
-    public static final String SEARCH_PANE_POS_X = "searchPanePosX";
     public static final String HIGH_LIGHT_WORDS = "highLightWords";
     public static final String REG_EXP_SEARCH = "regExpSearch";
     public static final String SELECT_S = "selectS";
@@ -555,7 +554,6 @@ public class JabRefPreferences {
         defaults.put(SELECT_S, Boolean.FALSE);
         defaults.put(REG_EXP_SEARCH, Boolean.TRUE);
         defaults.put(HIGH_LIGHT_WORDS, Boolean.TRUE);
-        defaults.put(SEARCH_PANE_POS_X, 0);
         defaults.put(EDITOR_EMACS_KEYBINDINGS, Boolean.FALSE);
         defaults.put(EDITOR_EMACS_KEYBINDINGS_REBIND_CA, Boolean.TRUE);
         defaults.put(EDITOR_EMACS_KEYBINDINGS_REBIND_CF, Boolean.TRUE);

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -78,7 +78,6 @@ public class JabRefPreferences {
     public static final String TEXSTUDIO_PATH = "TeXstudioPath";
     public static final String WIN_EDT_PATH = "winEdtPath";
     public static final String TEXMAKER_PATH = "texmakerPath";
-    public static final String SHOW_SHORT = "showShort";
     public static final String LANGUAGE = "language";
     public static final String NAMES_LAST_ONLY = "namesLastOnly";
     public static final String ABBR_AUTHOR_NAMES = "abbrAuthorNames";
@@ -486,7 +485,6 @@ public class JabRefPreferences {
         defaults.put(NAMES_LAST_ONLY, Boolean.TRUE); // "Show last names only"
         // system locale as default
         defaults.put(LANGUAGE, Locale.getDefault().getLanguage());
-        defaults.put(SHOW_SHORT, Boolean.TRUE);
 
         // Sorting preferences
         defaults.put(TABLE_PRIMARY_SORT_FIELD, "author");

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -214,8 +214,6 @@ public class JabRefPreferences {
     public static final String TABLE_SHOW_GRID = "tableShowGrid";
     public static final String TABLE_ROW_PADDING = "tableRowPadding";
     public static final String MENU_FONT_SIZE = "menuFontSize";
-    public static final String MENU_FONT_STYLE = "menuFontStyle";
-    public static final String MENU_FONT_FAMILY = "menuFontFamily";
     public static final String OVERRIDE_DEFAULT_FONTS = "overrideDefaultFonts";
     public static final String FONT_SIZE = "fontSize";
     public static final String FONT_STYLE = "fontStyle";
@@ -595,8 +593,6 @@ public class JabRefPreferences {
         defaults.put(FONT_STYLE, java.awt.Font.PLAIN);
         defaults.put(FONT_SIZE, 12);
         defaults.put(OVERRIDE_DEFAULT_FONTS, Boolean.FALSE);
-        defaults.put(MENU_FONT_FAMILY, "Times");
-        defaults.put(MENU_FONT_STYLE, java.awt.Font.PLAIN);
         defaults.put(MENU_FONT_SIZE, 11);
         defaults.put(TABLE_ROW_PADDING, GUIGlobals.TABLE_ROW_PADDING);
         defaults.put(TABLE_SHOW_GRID, Boolean.FALSE);

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -221,7 +221,6 @@ public class JabRefPreferences {
     public static final String GENERAL_FIELDS = "generalFields";
     public static final String RENAME_ON_MOVE_FILE_TO_FILE_DIR = "renameOnMoveFileToFileDir";
     public static final String MEMORY_STICK_MODE = "memoryStickMode";
-    public static final String PRESERVE_FIELD_FORMATTING = "preserveFieldFormatting";
     public static final String DEFAULT_OWNER = "defaultOwner";
     public static final String GROUPS_VISIBLE_ROWS = "groupsVisibleRows";
     public static final String DEFAULT_ENCODING = "defaultEncoding";
@@ -581,7 +580,6 @@ public class JabRefPreferences {
         defaults.put(DEFAULT_ENCODING, "UTF-8");
         defaults.put(GROUPS_VISIBLE_ROWS, 8);
         defaults.put(DEFAULT_OWNER, System.getProperty("user.name"));
-        defaults.put(PRESERVE_FIELD_FORMATTING, Boolean.FALSE);
         defaults.put(MEMORY_STICK_MODE, Boolean.FALSE);
         defaults.put(RENAME_ON_MOVE_FILE_TO_FILE_DIR, Boolean.TRUE);
 

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -179,7 +179,6 @@ public class JabRefPreferences {
     public static final String GROUP_INVERT_SELECTIONS = "groupInvertSelections";
     public static final String GROUP_INTERSECT_SELECTIONS = "groupIntersectSelections";
     public static final String GROUP_FLOAT_SELECTIONS = "groupFloatSelections";
-    public static final String GROUP_SELECTOR_VISIBLE = "groupSelectorVisible";
     public static final String EDIT_GROUP_MEMBERSHIP_MODE = "groupEditGroupMembershipMode";
     public static final String GROUP_KEYWORD_SEPARATOR = "groupKeywordSeparator";
     public static final String AUTO_ASSIGN_GROUP = "autoAssignGroup";
@@ -563,7 +562,6 @@ public class JabRefPreferences {
         defaults.put(AUTO_COMP_LAST_FIRST, Boolean.FALSE); // "Autocomplete names in 'Lastname, Firstname' format only"
         defaults.put(SHORTEST_TO_COMPLETE, 2);
         defaults.put(AUTOCOMPLETE_FIRSTNAME_MODE, JabRefPreferences.AUTOCOMPLETE_FIRSTNAME_MODE_BOTH);
-        defaults.put(GROUP_SELECTOR_VISIBLE, Boolean.TRUE);
         defaults.put(GROUP_FLOAT_SELECTIONS, Boolean.TRUE);
         defaults.put(GROUP_INTERSECT_SELECTIONS, Boolean.TRUE);
         defaults.put(GROUP_INVERT_SELECTIONS, Boolean.FALSE);

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -161,7 +161,6 @@ public class JabRefPreferences {
     public static final String AUTO_COMP_FIRST_LAST = "autoCompFF";
     public static final String AUTO_COMPLETE_FIELDS = "autoCompleteFields";
     public static final String AUTO_COMPLETE = "autoComplete";
-    public static final String SEARCH_PANE_POS_Y = "searchPanePosY";
     public static final String SEARCH_PANE_POS_X = "searchPanePosX";
     public static final String HIGH_LIGHT_WORDS = "highLightWords";
     public static final String REG_EXP_SEARCH = "regExpSearch";
@@ -557,7 +556,6 @@ public class JabRefPreferences {
         defaults.put(REG_EXP_SEARCH, Boolean.TRUE);
         defaults.put(HIGH_LIGHT_WORDS, Boolean.TRUE);
         defaults.put(SEARCH_PANE_POS_X, 0);
-        defaults.put(SEARCH_PANE_POS_Y, 0);
         defaults.put(EDITOR_EMACS_KEYBINDINGS, Boolean.FALSE);
         defaults.put(EDITOR_EMACS_KEYBINDINGS_REBIND_CA, Boolean.TRUE);
         defaults.put(EDITOR_EMACS_KEYBINDINGS_REBIND_CF, Boolean.TRUE);

--- a/src/main/java/net/sf/jabref/exporter/LatexFieldFormatter.java
+++ b/src/main/java/net/sf/jabref/exporter/LatexFieldFormatter.java
@@ -141,11 +141,6 @@ public class LatexFieldFormatter {
 
             stringBuilder = new StringBuilder(
                     valueDelimiterStartOfValue + "");
-            // No formatting at all for these fields, to allow custom formatting?
-            //            if (Globals.prefs.getBoolean("preserveFieldFormatting"))
-            //              sb.append(text);
-            //            else
-            //             currently, we do not do any more wrapping
             // these two are also hard coded in net.sf.jabref.importer.fileformat.FieldContentParser.multiLineFields
             // there, JabRefPreferences.NON_WRAPPABLE_FIELDS are also included
             boolean isAbstract = "abstract".equals(fieldName);

--- a/src/main/java/net/sf/jabref/gui/ColorSetupPanel.java
+++ b/src/main/java/net/sf/jabref/gui/ColorSetupPanel.java
@@ -25,6 +25,7 @@ import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 
 import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.l10n.Localization;
 
 /**
@@ -49,23 +50,23 @@ public class ColorSetupPanel extends JPanel {
                         "pref, 2dlu, pref, 2dlu, pref, 2dlu, pref, 2dlu, pref, 2dlu, pref, 2dlu, pref, 2dlu, pref");
         FormBuilder builder = FormBuilder.create().layout(layout);
 
-        buttons.add(new ColorButton("tableText", Localization.lang("Table text color")));
-        buttons.add(new ColorButton("markedEntryBackground0", Localization.lang("Marking color %0", "1")));
-        buttons.add(new ColorButton("tableBackground", Localization.lang("Table background color")));
-        buttons.add(new ColorButton("markedEntryBackground1", Localization.lang("Marking color %0", "2")));
-        buttons.add(new ColorButton("tableReqFieldBackground", Localization.lang("Background color for required fields")));
-        buttons.add(new ColorButton("markedEntryBackground2", Localization.lang("Marking color %0", "3")));
-        buttons.add(new ColorButton("tableOptFieldBackground", Localization.lang("Background color for optional fields")));
-        buttons.add(new ColorButton("markedEntryBackground3", Localization.lang("Marking color %0", "4")));
-        buttons.add(new ColorButton("incompleteEntryBackground", Localization.lang("Color for marking incomplete entries")));
-        buttons.add(new ColorButton("markedEntryBackground4", Localization.lang("Marking color %0", "5")));
-        buttons.add(new ColorButton("gridColor", Localization.lang("Table grid color")));
-        buttons.add(new ColorButton("markedEntryBackground5", Localization.lang("Import marking color")));
+        buttons.add(new ColorButton(Globals.prefs.get(JabRefPreferences.TABLE_TEXT), Localization.lang("Table text color")));
+        buttons.add(new ColorButton(Globals.prefs.get(JabRefPreferences.MARKED_ENTRY_BACKGROUND0), Localization.lang("Marking color %0", "1")));
+        buttons.add(new ColorButton(Globals.prefs.get(JabRefPreferences.TABLE_BACKGROUND), Localization.lang("Table background color")));
+        buttons.add(new ColorButton(Globals.prefs.get(JabRefPreferences.MARKED_ENTRY_BACKGROUND1), Localization.lang("Marking color %0", "2")));
+        buttons.add(new ColorButton(Globals.prefs.get(JabRefPreferences.TABLE_REQ_FIELD_BACKGROUND), Localization.lang("Background color for required fields")));
+        buttons.add(new ColorButton(Globals.prefs.get(JabRefPreferences.MARKED_ENTRY_BACKGROUND2), Localization.lang("Marking color %0", "3")));
+        buttons.add(new ColorButton(Globals.prefs.get(JabRefPreferences.TABLE_OPT_FIELD_BACKGROUND), Localization.lang("Background color for optional fields")));
+        buttons.add(new ColorButton(Globals.prefs.get(JabRefPreferences.MARKED_ENTRY_BACKGROUND3), Localization.lang("Marking color %0", "4")));
+        buttons.add(new ColorButton(Globals.prefs.get(JabRefPreferences.INCOMPLETE_ENTRY_BACKGROUND), Localization.lang("Color for marking incomplete entries")));
+        buttons.add(new ColorButton(Globals.prefs.get(JabRefPreferences.MARKED_ENTRY_BACKGROUND4), Localization.lang("Marking color %0", "5")));
+        buttons.add(new ColorButton(Globals.prefs.get(JabRefPreferences.GRID_COLOR), Localization.lang("Table grid color")));
+        buttons.add(new ColorButton(Globals.prefs.get(JabRefPreferences.MARKED_ENTRY_BACKGROUND5), Localization.lang("Import marking color")));
 
-        buttons.add(new ColorButton("fieldEditorTextColor", Localization.lang("Entry editor font color")));
-        buttons.add(new ColorButton("validFieldBackgroundColor", Localization.lang("Entry editor background color")));
-        buttons.add(new ColorButton("activeFieldEditorBackgroundColor", Localization.lang("Entry editor active background color")));
-        buttons.add(new ColorButton("invalidFieldBackgroundColor", Localization.lang("Entry editor invalid field color")));
+        buttons.add(new ColorButton(Globals.prefs.get(JabRefPreferences.FIELD_EDITOR_TEXT_COLOR), Localization.lang("Entry editor font color")));
+        buttons.add(new ColorButton(Globals.prefs.get(JabRefPreferences.VALID_FIELD_BACKGROUND_COLOR), Localization.lang("Entry editor background color")));
+        buttons.add(new ColorButton(Globals.prefs.get(JabRefPreferences.ACTIVE_FIELD_EDITOR_BACKGROUND_COLOR), Localization.lang("Entry editor active background color")));
+        buttons.add(new ColorButton(Globals.prefs.get(JabRefPreferences.INVALID_FIELD_BACKGROUND_COLOR), Localization.lang("Entry editor invalid field color")));
 
         int rowcnt = 0;
         int col = 0;

--- a/src/main/java/net/sf/jabref/gui/MainTableFormat.java
+++ b/src/main/java/net/sf/jabref/gui/MainTableFormat.java
@@ -380,7 +380,6 @@ public class MainTableFormat implements TableFormat<BibtexEntry> {
         }
 
         // Read name format options:
-        boolean showShort = Globals.prefs.getBoolean(JabRefPreferences.SHOW_SHORT);
         namesNatbib = Globals.prefs.getBoolean(JabRefPreferences.NAMES_NATBIB); //MK:
         namesLastOnly = Globals.prefs.getBoolean(JabRefPreferences.NAMES_LAST_ONLY);
         namesAsIs = Globals.prefs.getBoolean(JabRefPreferences.NAMES_AS_IS);


### PR DESCRIPTION
This PR remove preferences that are no longer used in JabRef.

I checked the usage each public field of `JabRefPreferences` and, if there was no such usage, searched for String occurrences of the preference value in the complete project. If such usage was found, I replaced it with a usage of the respective field. Otherwise, I deleted the preference.

All in all, only a surprisingly small amount of preferences is not used.