### PR TITLE
Show developers

### DIFF
--- a/DEVELOPERS
+++ b/DEVELOPERS
@@ -1,0 +1,7 @@
+# This file lists all individuals being part of JabRef's developers team
+# For how it is generated, see `scripts/generate-developers.sh`.
+Jörg Lenhard
+Matthias Geiger
+Oliver Kopp
+Simon Harrer
+Stefan Kolb

--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,8 @@ processResources {
     filesMatching("help/**/About.html") {
         expand ("version": project.version,
                 "year": String.valueOf(Calendar.getInstance().get(Calendar.YEAR)),
-                "authors": new File('AUTHORS').readLines().findAll {!it.startsWith("#")}.join(", "))
+                "authors": new File('AUTHORS').readLines().findAll {!it.startsWith("#")}.join(", "),
+                "developers": new File('DEVELOPERS').readLines().findAll {!it.startsWith("#")}.join(", "))
     }
 
     filesMatching("build.properties") {

--- a/scripts/generate-developers.sh
+++ b/scripts/generate-developers.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+#Check environment variables
+if [ -z $GITHUB_OAUTH_TOKEN ]; then
+    echo "GITHUB_OAUTH_TOKEN not set";
+    exit 1;
+fi;
+
+
+cd "$(dirname "$(readlink -f "$BASH_SOURCE")")/.."
+
+#github requires authorization on JabRef's developers team (id 727640) even if the team is public
+#github returns a formatted json. Therefore, we use plain sed to get the field content instead of using jq
+userURLs=`curl --silent -H "Authorization: token $GITHUB_OAUTH_TOKEN" https://api.github.com/teams/727640/members | grep \"url\" | sed 's|.*: "\(.*\)".*|\1|'`
+#now we have a list of URLs each pointing to a team member
+
+{
+    #generate header
+    cat <<-'EOF'
+	# This file lists all individuals being part of JabRef's developers team
+	# For how it is generated, see `scripts/generate-developers.sh`.
+	EOF
+
+    #list all developer names alphabetically (sorted by first name)
+    {
+        #iterate through all URLss and fetch name info
+        for userURL in $userURLs; do
+            name=`curl --silent $userURL | grep "name" | sed 's|.*: "\(.*\)".*|\1|'`
+            echo $name
+        done
+    } | LC_ALL=C.UTF-8 sort
+
+} > DEVELOPERS

--- a/src/main/resources/help/da/About.html
+++ b/src/main/resources/help/da/About.html
@@ -19,11 +19,6 @@
 
         <p>${authors}</p>
 
-        <h2>Tak til:</h2>
-
-        <p>Samin Muhammad Ridwanul Karim,
-        Stefan Robert</p>
-
         <h2>Tredjepartssoftware anvendt:</h2>
 
         <p>JabRef bruger JGoodies Looks og JGoodies Forms,

--- a/src/main/resources/help/da/About.html
+++ b/src/main/resources/help/da/About.html
@@ -15,6 +15,12 @@
         GNU <a href="License.html">General Public License</a>,
         version 2.</p>
 
+        <h2>Current developers:</h2>
+
+        <p>The following persons belong to the <a href="https://github.com/orgs/JabRef/teams/developers">JabRef developers team</a> and take care about the overall development of JabRef.</p>
+
+        <p>${developers}</p>
+
         <h2>Bidrag fra:</h2>
 
         <p>${authors}</p>

--- a/src/main/resources/help/de/About.html
+++ b/src/main/resources/help/de/About.html
@@ -18,11 +18,6 @@
 
         <p>${authors}</p>
 
-        <h2>Dank an:</h2>
-
-        <p>Samin Muhammad Ridwanul Karim,
-        Stefan Robert</p>
-
         <h2>Benutzte Fremdsoftware:</h2>
 
         <p>JabRef benutzt JGoodies

--- a/src/main/resources/help/de/About.html
+++ b/src/main/resources/help/de/About.html
@@ -14,6 +14,12 @@
         <p>JabRef ist frei verf&uuml;gbar unter den Bedingungen der
         GNU <a href="License.html">General Public License</a>.</p>
 
+        <h2>Derzeite Entwickler:</h2>
+
+        <p>Die folgenden Personen gehören zu dem <a href="https://github.com/orgs/JabRef/teams/developers">JabRef-Entwickler-Team</a> und kümmern sich um die Entwicklung von JabRef.</p>
+
+        <p>${developers}</p>
+
         <h2>Beitr&auml;ge von:</h2>
 
         <p>${authors}</p>

--- a/src/main/resources/help/en/About.html
+++ b/src/main/resources/help/en/About.html
@@ -26,10 +26,7 @@
 
         <p>${authors}</p>
 
-        <h2>Thanks to:</h2>
 
-        <p>Samin Muhammad Ridwanul Karim,
-        Stefan Robert</p>
 
         <h2>Third-party software used:</h2>
 

--- a/src/main/resources/help/en/About.html
+++ b/src/main/resources/help/en/About.html
@@ -22,11 +22,15 @@
         and feature requests to
         <a href="https://sourceforge.net/p/jabref/feature-requests/">https://sourceforge.net/p/jabref/feature-requests/</a>.</p>
 
+        <h2>Current developers:</h2>
+
+        <p>The following persons belong to the <a href="https://github.com/orgs/JabRef/teams/developers">JabRef developers team</a> and take care about the overall development of JabRef.</p>
+
+        <p>${developers}</p>
+
         <h2>Contributions from:</h2>
 
         <p>${authors}</p>
-
-
 
         <h2>Third-party software used:</h2>
 

--- a/src/main/resources/help/fr/About.html
+++ b/src/main/resources/help/fr/About.html
@@ -23,6 +23,12 @@
         soit en version 2 de cette License, soit (&agrave; votre choix)
         dans n'importe quelle version ult&eacute;rieure.</p>
 
+        <h2>Current developers:</h2>
+
+        <p>The following persons belong to the <a href="https://github.com/orgs/JabRef/teams/developers">JabRef developers team</a> and take care about the overall development of JabRef.</p>
+
+        <p>${developers}</p>
+
         <h2>Contributions de&nbsp;:</h2>
 
         <p>${authors}</p>

--- a/src/main/resources/help/fr/About.html
+++ b/src/main/resources/help/fr/About.html
@@ -27,11 +27,6 @@
 
         <p>${authors}</p>
 
-        <h2>Remerciements &agrave;&nbsp;:</h2>
-
-        <p>Samin Muhammad Ridwanul Karim,
-        Stefan Robert</p>
-
         <h2>Logiciels tiers utilis&eacute;s&nbsp;:</h2>
 
         <p>JabRef

--- a/src/main/resources/help/in/About.html
+++ b/src/main/resources/help/in/About.html
@@ -15,6 +15,12 @@
         GNU <a href="License.html">General Public License</a>,
         versi 2.</p>
 
+        <h2>Current developers:</h2>
+
+        <p>The following persons belong to the <a href="https://github.com/orgs/JabRef/teams/developers">JabRef developers team</a> and take care about the overall development of JabRef.</p>
+
+        <p>${developers}</p>
+
         <h2>Pendukung lain:</h2>
 
         <p>${authors}</p>

--- a/src/main/resources/help/in/About.html
+++ b/src/main/resources/help/in/About.html
@@ -19,11 +19,6 @@
 
         <p>${authors}</p>
 
-        <h2>Terima kasih kepada:</h2>
-
-        <p>Samin Muhammad Ridwanul Karim,
-        Stefan Robert</p>
-
         <h2>Program tambahan yang digunakan:</h2>
 
         <p>JabRef menggunakan JGoodies

--- a/src/main/resources/help/ja/About.html
+++ b/src/main/resources/help/ja/About.html
@@ -13,6 +13,12 @@
 
         <p>JabRefはフリーソフトウェアです。JabRefは、Free Software Foundationが公開しているGNU <a href="License.html">General Public License</a>のversion 2か、(お望みであれば)それよりも新しい版の下で自由に配布し修正することが可能です。</p>
 
+        <h2>Current developers:</h2>
+
+        <p>The following persons belong to the <a href="https://github.com/orgs/JabRef/teams/developers">JabRef developers team</a> and take care about the overall development of JabRef.</p>
+
+        <p>${developers}</p>
+
         <h2>貢献者:</h2>
 
         <p>${authors}</p>

--- a/src/main/resources/help/ja/About.html
+++ b/src/main/resources/help/ja/About.html
@@ -17,11 +17,6 @@
 
         <p>${authors}</p>
 
-        <h2>以下の方々に感謝します:</h2>
-
-        <p>Samin Muhammad Ridwanul Karim,
-        Stefan Robert</p>
-
         <h2>使用しているサードパーティ・ソフトウェア:</h2>
 
         <p>JabRefは、JGoodies (<code>http://www.jgoodies.com</code>) がBSDライセンス (詳細については<code>http://www.opensource.org/licenses/bsd-license.html</code>を参照) の下で配布しているJGoodies Looks およびJGoodies Forms を使用しています。</p>


### PR DESCRIPTION
As discussed in #244, especially at https://github.com/JabRef/jabref/pull/224#issuecomment-147650492, it would be good to show the currently active developers.

JabRef offers the team "developers", which are the currently developers of JabRef. There is also the organization, but these guys are more involved in the overall steering of JabRef and related projects (homepage, journal lists, ...) and not the concrete development and reviews of PRs in the JabRef code.

Similar to the AUTHORs list, I keep the alphabetical order. This is untypical, but more easy to create.

Side note: You have to have `GRADLE_OPTS` to be set to `-Dfile.encoding=UTF-8` on Windows to have the gradle build working correctly. See [README.md](https://github.com/JabRef/jabref/blob/master/README.md#building-jabref-from-source).