### PR TITLE
[WIP] Enable merge entries at context menu

### DIFF
--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -394,7 +394,8 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             prefs.getKey(KeyBinds.CLEANUP),
             IconTheme.JabRefIcon.CLEANUP_ENTRIES.getIcon());
 
-    private final AbstractAction mergeEntries = new GeneralAction(Actions.MERGE_ENTRIES,
+    // used by RightClickMenu
+    final AbstractAction mergeEntries = new GeneralAction(Actions.MERGE_ENTRIES,
             Localization.menuTitle("Merge entries"),
             Localization.lang("Merge entries"),
             IconTheme.JabRefIcon.MERGE_ENTRIES.getIcon());

--- a/src/main/java/net/sf/jabref/gui/RightClickMenu.java
+++ b/src/main/java/net/sf/jabref/gui/RightClickMenu.java
@@ -189,6 +189,9 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
 
         add(JabRef.jrf.massSetField);
         add(JabRef.jrf.manageKeywords);
+        // TODO: QUICK HACK. This should be done using panel.runCommand(...);
+        // TODO: This should be disabled if (!multiple)
+        add(JabRef.jrf.mergeEntries);
 
         addSeparator(); // for "add/move/remove to/from group" entries (appended here)
 


### PR DESCRIPTION
When selecting two entries, the context menu should offer merging of them, too.

- [ ] When only one entry is selected, the "Merge entries" entry should be disabled.