### PR TITLE
Remove unused menus for import/export

### DIFF
--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -454,13 +454,6 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
     public GroupSelector groupSelector;
 
-    // The menus for importing/appending other formats
-    private final JMenu importMenu = JabRefFrame.subMenu("Import into current database");
-    private final JMenu importNewMenu = JabRefFrame.subMenu("Import into new database");
-    private final JMenu exportMenu = JabRefFrame.subMenu("Export");
-    JMenu customExportMenu = JabRefFrame.subMenu("Custom export");
-    private final JMenu newDatabaseMenu = JabRefFrame.subMenu("New database");
-
     // Other submenus
     private final JMenu checkAndFix = JabRefFrame.subMenu("Legacy tools...");
 
@@ -1130,14 +1123,6 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         }
     }
 
-    /**
-     * Refresh import menus.
-     */
-    public void setUpImportMenus() {
-        setUpImportMenu(importMenu, false);
-        setUpImportMenu(importNewMenu, true);
-    }
-
     private void fillMenu() {
         //mb.putClientProperty(Options.HEADER_STYLE_KEY, HeaderStyle.BOTH);
         mb.setBorder(null);
@@ -1153,11 +1138,6 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         JMenu newSpec = JabRefFrame.subMenu("New entry...");
         JMenu helpMenu = JabRefFrame.subMenu("Help");
 
-        setUpImportMenus();
-
-        newDatabaseMenu.add(newDatabaseAction);
-        newDatabaseMenu.add(newSubDatabaseAction);
-
         file.add(newDatabaseAction);
         file.add(open); //opendatabaseaction
         file.add(mergeDatabaseAction);
@@ -1167,8 +1147,6 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         file.add(saveSelectedAs);
         file.add(saveSelectedAsPlain);
         file.addSeparator();
-        //file.add(importMenu);
-        //file.add(importNewMenu);
         file.add(importNew);
         file.add(importCurrent);
         file.add(exportAll);
@@ -1525,7 +1503,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
                 redo, cut, delete, copy, paste, mark, unmark, unmarkAll, editEntry,
                 selectAll, copyKey, copyCiteKey, copyKeyAndTitle, editPreamble, editStrings, toggleGroups, toggleSearch,
                 makeKeyAction, normalSearch, mergeEntries, cleanupEntries, exportToClipboard,
-                incrementalSearch, replaceAll, importMenu, exportMenu, sendAsEmail, downloadFullText, writeXmpAction,
+                incrementalSearch, replaceAll, sendAsEmail, downloadFullText, writeXmpAction,
                 findUnlinkedFiles, addToGroup, removeFromGroup, moveToGroup, autoLinkFile, resolveDuplicateKeys,
                 openPdf, openUrl, openFolder, openFile, openSpires, togglePreview, dupliCheck, autoSetFile,
                 newEntryAction, plainTextImport, massSetField, manageKeywords, pushExternalButton.getMenuAction(),

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -1823,39 +1823,6 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             });
     }
 
-    private void setUpImportMenu(JMenu importMenu, boolean intoNew_) {
-        importMenu.removeAll();
-
-        // Add a menu item for autodetecting import format:
-        importMenu.add(new ImportMenuItem(JabRefFrame.this, intoNew_));
-
-        // Add custom importers
-        importMenu.addSeparator();
-
-        SortedSet<ImportFormat> customImporters = Globals.importFormatReader.getCustomImportFormats();
-        JMenu submenu = new JMenu(Localization.lang("Custom importers"));
-        submenu.setMnemonic(KeyEvent.VK_S);
-
-        // Put in all formatters registered in ImportFormatReader:
-        for (ImportFormat imFo : customImporters) {
-            submenu.add(new ImportMenuItem(JabRefFrame.this, intoNew_, imFo));
-        }
-
-        if (!customImporters.isEmpty()) {
-            submenu.addSeparator();
-        }
-
-        submenu.add(customImpAction);
-
-        importMenu.add(submenu);
-        importMenu.addSeparator();
-
-        // Put in all formatters registered in ImportFormatReader:
-        for (ImportFormat imFo : Globals.importFormatReader.getBuiltInInputFormats()) {
-            importMenu.add(new ImportMenuItem(JabRefFrame.this, intoNew_, imFo));
-        }
-    }
-
     public FileHistory getFileHistory() {
         return fileHistory;
     }

--- a/src/main/java/net/sf/jabref/importer/ImportCustomizationDialog.java
+++ b/src/main/java/net/sf/jabref/importer/ImportCustomizationDialog.java
@@ -148,7 +148,6 @@ public class ImportCustomizationDialog extends JDialog {
                         addOrReplaceImporter(importer);
                         customImporterTable.revalidate();
                         customImporterTable.repaint();
-                        frame.setUpImportMenus();
                     } catch (Exception exc) {
                         JOptionPane.showMessageDialog(frame, Localization.lang("Could not instantiate %0", chosenFileStr));
                     } catch (NoClassDefFoundError exc) {
@@ -188,7 +187,6 @@ public class ImportCustomizationDialog extends JDialog {
                     zipFileChooser.setVisible(true);
                     customImporterTable.revalidate();
                     customImporterTable.repaint(10);
-                    frame.setUpImportMenus();
                 }
 
             }
@@ -228,7 +226,6 @@ public class ImportCustomizationDialog extends JDialog {
                     Globals.importFormatReader.resetImportFormats();
                     customImporterTable.revalidate();
                     customImporterTable.repaint();
-                    frame.setUpImportMenus();
                 } else {
                     JOptionPane.showMessageDialog(frame, Localization.lang("Please select an importer."));
                 }


### PR DESCRIPTION
Found some dead code in JabRefFrame which has been used to generate subMenus for custom imports/exports. 

Would be glad if someone checks whether this is okay.