### PR TITLE
Enable coverity

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Dependency Status](https://www.versioneye.com/user/projects/557f2723386664002000009c/badge.svg?style=flat)](https://www.versioneye.com/user/projects/557f2723386664002000009c)
 [![codecov.io](https://codecov.io/github/JabRef/jabref/coverage.svg?branch=master)](https://codecov.io/github/JabRef/jabref?branch=master)
 [![Coverity Status](https://badges.ondemand.coverity.com/streams/unhetcisrp7nna3b5cilqev4bk)](https://ondemand.coverity.com/streams/unhetcisrp7nna3b5cilqev4bk)
-[![Coverage Status](https://coveralls.io/repos/JabRef/jabref/badge.svg)](https://coveralls.io/r/JabRef/jabref)
 [![License](https://img.shields.io/badge/license-GPLv2-blue.svg)](http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt)
 [![Join the chat at https://gitter.im/JabRef/jabref](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/JabRef/jabref?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Donation](https://img.shields.io/badge/donate-paypal-orange.svg)](https://www.paypal.com/cgi-bin/webscr?item_name=JabRef+Bibliography+Manager&cmd=_donations&lc=US&currency_code=EUR&business=jabrefmail%40gmail.com)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![CircleCI](https://img.shields.io/circleci/project/JabRef/jabref.svg)](https://circleci.com/gh/JabRef/jabref)
 [![Dependency Status](https://www.versioneye.com/user/projects/557f2723386664002000009c/badge.svg?style=flat)](https://www.versioneye.com/user/projects/557f2723386664002000009c)
 [![codecov.io](https://codecov.io/github/JabRef/jabref/coverage.svg?branch=master)](https://codecov.io/github/JabRef/jabref?branch=master)
+[![Coverity Status](https://badges.ondemand.coverity.com/streams/unhetcisrp7nna3b5cilqev4bk)](https://ondemand.coverity.com/streams/unhetcisrp7nna3b5cilqev4bk)
+[![Coverage Status](https://coveralls.io/repos/JabRef/jabref/badge.svg)](https://coveralls.io/r/JabRef/jabref)
 [![License](https://img.shields.io/badge/license-GPLv2-blue.svg)](http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt)
 [![Join the chat at https://gitter.im/JabRef/jabref](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/JabRef/jabref?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Donation](https://img.shields.io/badge/donate-paypal-orange.svg)](https://www.paypal.com/cgi-bin/webscr?item_name=JabRef+Bibliography+Manager&cmd=_donations&lc=US&currency_code=EUR&business=jabrefmail%40gmail.com)

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.gradle.internal.os.OperatingSystem
 plugins {
     id 'com.github.johnrengelman.shadow' version '1.2.2'
     id "edu.sc.seis.launch4j" version "1.1.4"
-    id "com.github.kt3k.coveralls" version "2.4.0"
+    id "com.github.kt3k.coveralls" version "2.4.0x"
     id "edu.sc.seis.macAppBundle" version "2.1.1"
     id "com.github.youribonnaffe.gradle.format" version "1.2"
     id "com.coverity.ondemand" version "1.3.708"

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id "com.github.kt3k.coveralls" version "2.4.0"
     id "edu.sc.seis.macAppBundle" version "2.1.1"
     id "com.github.youribonnaffe.gradle.format" version "1.2"
+    id "com.coverity.ondemand" version "1.3.708"
 }
 
 apply plugin: "java"
@@ -26,6 +27,7 @@ mainClassName = "net.sf.jabref.JabRefMain"
 task wrapper(type: Wrapper) {
     gradleVersion = '2.8'
 }
+
 
 repositories {
     jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,17 @@ apply plugin: 'jacoco'
 apply plugin: 'com.github.kt3k.coveralls'
 apply from: 'eclipse.gradle'
 
+// HACK to disable coverityCheck task when not on CI server
+// necessary as coverity automatically adds check.dependsOn coverityCheck
+gradle.taskGraph.whenReady { taskGraph ->
+    def tasks = taskGraph.getAllTasks()
+    if (System.env.CI == null) {
+        tasks.findAll {it.name.startsWith('coverityCheck')}.each { task ->
+                task.enabled = false
+        }
+    }
+}
+
 group = "net.sf.jabref"
 version = "2.80dev"
 project.ext.threeDotVersion = "2.80.0.0"

--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,7 @@ test:
   override:
     - TERM=dumb ./gradlew test
   post:
+    - TERM=dumb ./gradlew coverityCheck
     - mkdir -p $CIRCLE_TEST_REPORTS/junit/
     - find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
     - TERM=dumb ./gradlew jacocoTestReport coveralls


### PR DESCRIPTION
Why?

- coverity does static analysis of the source code and makes the found warnings available via reports. In addition to its own checks it also performs findbugs evaluations.

To fix still

- [x] coveralls gradle plugin and coverity gradle plugin do not get along. Coverity causes coveralls to fail by using/loading the wrong class. :(