### PR TITLE
Removes option to hide the BibTeX Code tab in the entry editor.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 [master]
+    - Removes option to hide the BibTeX Code tab in the entry editor.
     - Removes option to set a custom icon for the external file types. This is not possible anymore with the new icon font.
     - Added combo box in MassSetFieldAction to simplify selecting the correct field name
     - Fixes bug when having added and then removed a personal journal list, an exception is always shown on startup

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -137,7 +137,6 @@ public class JabRefPreferences {
     public static final String SEARCH_REQ = "searchReq";
     public static final String CASE_SENSITIVE_SEARCH = "caseSensitiveSearch";
     public static final String DEFAULT_AUTO_SORT = "defaultAutoSort";
-    public static final String SHOW_SOURCE = "showSource";
     public static final String DEFAULT_SHOW_SOURCE = "defaultShowSource";
     public static final String STRINGS_SIZE_Y = "stringsSizeY";
     public static final String STRINGS_SIZE_X = "stringsSizeX";
@@ -542,7 +541,6 @@ public class JabRefPreferences {
         defaults.put(DUPLICATES_SIZE_X, 800);
         defaults.put(DUPLICATES_SIZE_Y, 600);
         defaults.put(DEFAULT_SHOW_SOURCE, Boolean.FALSE);
-        defaults.put(SHOW_SOURCE, Boolean.TRUE);
         defaults.put(DEFAULT_AUTO_SORT, Boolean.FALSE);
         defaults.put(CASE_SENSITIVE_SEARCH, Boolean.FALSE);
         defaults.put(SEARCH_REQ, Boolean.TRUE);

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -199,7 +199,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
         setupSourcePanel();
         add(tabbed, BorderLayout.CENTER);
         tabbed.addChangeListener(tabListener);
-        if (prefs.getBoolean(JabRefPreferences.SHOW_SOURCE) && prefs.getBoolean(JabRefPreferences.DEFAULT_SHOW_SOURCE)) {
+        if (prefs.getBoolean(JabRefPreferences.DEFAULT_SHOW_SOURCE)) {
             tabbed.setSelectedIndex(sourceIndex);
         }
 
@@ -299,11 +299,9 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
         }
 
         srcPanel.setName(Localization.lang("BibTeX source"));
-        if (Globals.prefs.getBoolean(JabRefPreferences.SHOW_SOURCE)) {
-            tabbed.addTab(Localization.lang("BibTeX source"), IconTheme.JabRefIcon.SOURCE.getSmallIcon(), srcPanel,
-                    Localization.lang("Show/edit BibTeX source"));
-            tabs.add(srcPanel);
-        }
+        tabbed.addTab(Localization.lang("BibTeX source"), IconTheme.JabRefIcon.SOURCE.getSmallIcon(), srcPanel,
+                Localization.lang("Show/edit BibTeX source"));
+        tabs.add(srcPanel);
         sourceIndex = tabs.size() - 1; // Set the sourceIndex variable.
         srcPanel.setFocusCycleRoot(true);
     }

--- a/src/main/java/net/sf/jabref/gui/preftabs/EntryEditorPrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/EntryEditorPrefsTab.java
@@ -36,7 +36,6 @@ import com.jgoodies.forms.layout.FormLayout;
 class EntryEditorPrefsTab extends JPanel implements PrefsTab {
 
     private final JCheckBox autoOpenForm;
-    private final JCheckBox showSource;
     private final JCheckBox defSource;
     private final JCheckBox emacsMode;
     private final JCheckBox emacsRebindCtrlA;
@@ -78,7 +77,6 @@ class EntryEditorPrefsTab extends JPanel implements PrefsTab {
 
         autoOpenForm = new JCheckBox(Localization.lang("Open editor when a new entry is created"));
         defSource = new JCheckBox(Localization.lang("Show BibTeX source by default"));
-        showSource = new JCheckBox(Localization.lang("Show BibTeX source panel"));
         emacsMode = new JCheckBox(Localization.lang("Use Emacs key bindings"));
         emacsRebindCtrlA = new JCheckBox(Localization.lang("Rebind C-a, too"));
         emacsRebindCtrlF = new JCheckBox(Localization.lang("Rebind C-f, too"));
@@ -106,49 +104,20 @@ class EntryEditorPrefsTab extends JPanel implements PrefsTab {
         firstNameModeButtonGroup.add(firstNameModeBoth);
 
         Insets marg = new Insets(0, 20, 3, 0);
-        defSource.setMargin(marg);
-        // We need a listener on showSource to enable and disable the source panel-related choices:
-        showSource.addChangeListener(new ChangeListener() {
-
-            @Override
-            public void stateChanged(ChangeEvent event) {
-                defSource.setEnabled(showSource.isSelected());
-            }
-        }
-                );
 
         emacsRebindCtrlA.setMargin(marg);
         // We need a listener on showSource to enable and disable the source panel-related choices:
-        emacsMode.addChangeListener(new ChangeListener() {
-
-            @Override
-            public void stateChanged(ChangeEvent event) {
-                emacsRebindCtrlA.setEnabled(emacsMode.isSelected());
-            }
-        }
-                );
+        emacsMode.addChangeListener(event -> emacsRebindCtrlA.setEnabled(emacsMode.isSelected()));
 
         emacsRebindCtrlF.setMargin(marg);
         // We need a listener on showSource to enable and disable the source panel-related choices:
-        emacsMode.addChangeListener(new ChangeListener() {
-            public void stateChanged(ChangeEvent event) {
-                emacsRebindCtrlF.setEnabled(emacsMode.isSelected());
-            }
-        }
-        );
+        emacsMode.addChangeListener(event -> emacsRebindCtrlF.setEnabled(emacsMode.isSelected()));
 
         
         autoCompFields = new JTextField(40);
         // We need a listener on autoComplete to enable and disable the
         // autoCompFields text field:
-        autoComplete.addChangeListener(new ChangeListener() {
-
-            @Override
-            public void stateChanged(ChangeEvent event) {
-                setAutoCompleteElementsEnabled(autoComplete.isSelected());
-            }
-        }
-                );
+        autoComplete.addChangeListener(event -> setAutoCompleteElementsEnabled(autoComplete.isSelected()));
 
         FormLayout layout = new FormLayout
                 (// columns
@@ -164,13 +133,12 @@ class EntryEditorPrefsTab extends JPanel implements PrefsTab {
         builder.addSeparator(Localization.lang("Editor options"), cc.xyw(1, 1, 5));
         builder.add(autoOpenForm, cc.xy(2, 3));
         builder.add(disableOnMultiple, cc.xy(2, 5));
-        builder.add(showSource, cc.xy(2, 7));
-        builder.add(defSource, cc.xy(2, 9));
-        builder.add(emacsMode, cc.xy(2, 11));
-        builder.add(emacsRebindCtrlA, cc.xy(2, 13));
-        builder.add(emacsRebindCtrlF, cc.xy(2, 15));
+        builder.add(defSource, cc.xy(2, 7));
+        builder.add(emacsMode, cc.xy(2, 9));
+        builder.add(emacsRebindCtrlA, cc.xy(2, 11));
+        builder.add(emacsRebindCtrlF, cc.xy(2, 13));
         
-        builder.addSeparator(Localization.lang("Autocompletion options"), cc.xyw(1, 17, 5));
+        builder.addSeparator(Localization.lang("Autocompletion options"), cc.xyw(1, 15, 5));
         builder.add(autoComplete, cc.xy(2, 19));
         
         DefaultFormBuilder builder3 = new DefaultFormBuilder(new FormLayout("left:pref, 4dlu, fill:150dlu",""));
@@ -202,7 +170,6 @@ class EntryEditorPrefsTab extends JPanel implements PrefsTab {
     public void setValues() {
         autoOpenForm.setSelected(prefs.getBoolean(JabRefPreferences.AUTO_OPEN_FORM));
         defSource.setSelected(prefs.getBoolean(JabRefPreferences.DEFAULT_SHOW_SOURCE));
-        showSource.setSelected(prefs.getBoolean(JabRefPreferences.SHOW_SOURCE));
         emacsMode.setSelected(prefs.getBoolean(JabRefPreferences.EDITOR_EMACS_KEYBINDINGS));
         emacsRebindCtrlA.setSelected(prefs.getBoolean(JabRefPreferences.EDITOR_EMACS_KEYBINDINGS_REBIND_CA));
         emacsRebindCtrlF.setSelected(prefs.getBoolean(JabRefPreferences.EDITOR_EMACS_KEYBINDINGS_REBIND_CF));
@@ -232,8 +199,6 @@ class EntryEditorPrefsTab extends JPanel implements PrefsTab {
         oldAutoCompFModeAbbr = firstNameModeAbbr.isSelected();
         oldAutoCompFModeFull = firstNameModeFull.isSelected();
 
-        // This choice only makes sense when the source panel is visible:
-        defSource.setEnabled(showSource.isSelected());
         // similar for emacs CTRL-a and emacs mode
         emacsRebindCtrlA.setEnabled(emacsMode.isSelected());
         // Autocomplete fields is only enabled when autocompletion is selected
@@ -269,12 +234,10 @@ class EntryEditorPrefsTab extends JPanel implements PrefsTab {
         prefs.putBoolean(JabRefPreferences.DISABLE_ON_MULTIPLE_SELECTION, disableOnMultiple.isSelected());
         // We want to know if the following settings have been modified:
         boolean oldAutoComplete = prefs.getBoolean(JabRefPreferences.AUTO_COMPLETE);
-        boolean oldShowSource = prefs.getBoolean(JabRefPreferences.SHOW_SOURCE);
         String oldAutoCompFields = prefs.get(JabRefPreferences.AUTO_COMPLETE_FIELDS);
         prefs.putInt(JabRefPreferences.SHORTEST_TO_COMPLETE, (Integer) shortestToComplete.getValue());
         prefs.putBoolean(JabRefPreferences.AUTO_COMPLETE, autoComplete.isSelected());
         prefs.put(JabRefPreferences.AUTO_COMPLETE_FIELDS, autoCompFields.getText());
-        prefs.putBoolean(JabRefPreferences.SHOW_SOURCE, showSource.isSelected());
         if (autoCompBoth.isSelected()) {
             prefs.putBoolean(JabRefPreferences.AUTO_COMP_FIRST_LAST, false);
             prefs.putBoolean(JabRefPreferences.AUTO_COMP_LAST_FIRST, false);
@@ -297,7 +260,7 @@ class EntryEditorPrefsTab extends JPanel implements PrefsTab {
 
         // We need to remove all entry editors from cache if the source panel setting
         // or the autocompletion settings have been changed:
-        if (oldShowSource != showSource.isSelected() || oldAutoComplete != autoComplete.isSelected()
+        if (oldAutoComplete != autoComplete.isSelected()
                 || !oldAutoCompFields.equals(autoCompFields.getText()) ||
                 oldAutoCompFF != autoCompFF.isSelected() || oldAutoCompLF != autoCompLF.isSelected() ||
                 oldAutoCompFModeAbbr != firstNameModeAbbr.isSelected() ||


### PR DESCRIPTION
Why?

- I do not see the point of hiding the BibTeX Code tab in the entry editor. Hence, I removed the option. 