### PR TITLE
Refactor BibTex model (a bit)

### DIFF
--- a/src/main/java/net/sf/jabref/bibtex/BibtexEntryWriter.java
+++ b/src/main/java/net/sf/jabref/bibtex/BibtexEntryWriter.java
@@ -153,7 +153,7 @@ public class BibtexEntryWriter {
 
         // Then write remaining fields in alphabetic order.
         TreeSet<String> remainingFields = new TreeSet<>();
-        for (String key : entry.getAllFields()) {
+        for (String key : entry.getFieldNames()) {
             boolean writeIt = write ? BibtexFields.isWriteableField(key) :
                     BibtexFields.isDisplayableField(key);
             if (!writtenFields.contains(key) && writeIt) {
@@ -233,7 +233,7 @@ public class BibtexEntryWriter {
         }
         // Then write remaining fields in alphabetic order.
         TreeSet<String> remainingFields = new TreeSet<>();
-        for (String key : entry.getAllFields()) {
+        for (String key : entry.getFieldNames()) {
             boolean writeIt = write ? BibtexFields.isWriteableField(key) :
                     BibtexFields.isDisplayableField(key);
             if (!written.contains(key) && writeIt) {
@@ -273,7 +273,7 @@ public class BibtexEntryWriter {
 
         //STA get remaining fields
         TreeSet<String> remainingFields = new TreeSet<>();
-        for (String key : entry.getAllFields()) {
+        for (String key : entry.getFieldNames()) {
             //iterate through all fields
             boolean writeIt = write ? BibtexFields.isWriteableField(key) :
                     BibtexFields.isDisplayableField(key);

--- a/src/main/java/net/sf/jabref/bibtex/DuplicateCheck.java
+++ b/src/main/java/net/sf/jabref/bibtex/DuplicateCheck.java
@@ -183,8 +183,8 @@ public class DuplicateCheck {
 
     public static double compareEntriesStrictly(BibtexEntry one, BibtexEntry two) {
         HashSet<String> allFields = new HashSet<>();// one.getAllFields());
-        allFields.addAll(one.getAllFields());
-        allFields.addAll(two.getAllFields());
+        allFields.addAll(one.getFieldNames());
+        allFields.addAll(two.getFieldNames());
 
         int score = 0;
         for (String field : allFields) {

--- a/src/main/java/net/sf/jabref/collab/EntryChange.java
+++ b/src/main/java/net/sf/jabref/collab/EntryChange.java
@@ -54,9 +54,9 @@ class EntryChange extends Change {
         //        +" Modifications agree: "+modificationsAgree);
 
         TreeSet<String> allFields = new TreeSet<String>();
-        allFields.addAll(memEntry.getAllFields());
-        allFields.addAll(tmpEntry.getAllFields());
-        allFields.addAll(diskEntry.getAllFields());
+        allFields.addAll(memEntry.getFieldNames());
+        allFields.addAll(tmpEntry.getFieldNames());
+        allFields.addAll(diskEntry.getFieldNames());
 
         for (String field : allFields) {
             String mem = memEntry.getField(field);

--- a/src/main/java/net/sf/jabref/gui/IncrementalSearcher.java
+++ b/src/main/java/net/sf/jabref/gui/IncrementalSearcher.java
@@ -36,7 +36,7 @@ class IncrementalSearcher {
 
     public boolean search(String pattern, BibtexEntry bibtexEntry) {
         hitInField = null;
-        return searchFields(bibtexEntry.getAllFields(), bibtexEntry, pattern);
+        return searchFields(bibtexEntry.getFieldNames(), bibtexEntry, pattern);
     }
 
     private boolean searchFields(Set<String> fields, BibtexEntry bibtexEntry,

--- a/src/main/java/net/sf/jabref/gui/ReplaceStringDialog.java
+++ b/src/main/java/net/sf/jabref/gui/ReplaceStringDialog.java
@@ -212,7 +212,7 @@ class ReplaceStringDialog extends JDialog {
         int counter = 0;
         if (allFields()) {
 
-            for (String s : be.getAllFields()) {
+            for (String s : be.getFieldNames()) {
                 if (!s.equals(BibtexEntry.KEY_FIELD)) {
                     counter += replaceField(be, s, ce);
                 }

--- a/src/main/java/net/sf/jabref/gui/RightClickMenu.java
+++ b/src/main/java/net/sf/jabref/gui/RightClickMenu.java
@@ -372,7 +372,7 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
     private boolean isFieldSetForSelectedEntry(String fieldname) {
         if (panel.mainTable.getSelectedRowCount() == 1) {
             BibtexEntry entry = panel.mainTable.getSelected().get(0);
-            if (entry.getAllFields().contains(fieldname)) {
+            if (entry.getFieldNames().contains(fieldname)) {
                 return true;
             } else {
                 return false;

--- a/src/main/java/net/sf/jabref/gui/actions/CleanUpAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/CleanUpAction.java
@@ -18,7 +18,6 @@ package net.sf.jabref.gui.actions;
 import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 import javax.swing.JCheckBox;
@@ -46,6 +45,7 @@ import net.sf.jabref.model.entry.BibtexEntry;
 import net.sf.jabref.logic.util.DOI;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.logic.util.date.MonthUtil;
+import net.sf.jabref.model.entry.EntryConverter;
 import net.sf.jabref.util.Util;
 
 public class CleanUpAction extends AbstractWorker {
@@ -319,7 +319,7 @@ public class CleanUpAction extends AbstractWorker {
                 doConvertUnicode(entry, ce);
             }
             if (choiceConvertToBiblatex) {
-                doConvertToBiblatex(entry, ce);
+                EntryConverter.convertToBiblatex(entry, ce);
             }
 
             ce.end();
@@ -669,19 +669,12 @@ public class CleanUpAction extends AbstractWorker {
         // Remove redundant $, {, and }, but not if the } is part of a command argument: \mbox{-}{GPS} should not be adjusted
         newValue = newValue.replace("$$", "").replaceAll("(?<!\\\\[\\p{Alpha}]{0,100}\\{[^\\}]{0,100})\\}([-/ ]?)\\{", "$1");
         // Move numbers, +, -, /, and brackets into equations
-        // System.err.println(newValue);
         newValue = newValue.replaceAll("(([^$]|\\\\\\$)*)\\$", "$1@@"); // Replace $, but not \$ with @@
-        // System.err.println(newValue);
         newValue = newValue.replaceAll("([^@]*)@@([^@]*)@@", "$1\\$$2@@"); // Replace every other @@ with $
-        // System.err.println(newValue);
         //newValue = newValue.replaceAll("([0-9\\(\\.]+) \\$","\\$$1\\\\ "); // Move numbers followed by a space left of $ inside the equation, e.g., 0.35 $\mu$m
-        // System.err.println(newValue);
         newValue = newValue.replaceAll("([0-9\\(\\.]+[ ]?[-+/]?[ ]?)\\$", "\\$$1"); // Move numbers, possibly with operators +, -, or /,  left of $ into the equation
-        // System.err.println(newValue);
         newValue = newValue.replaceAll("@@([ ]?[-+/]?[ ]?[0-9\\)\\.]+)", " $1@@"); // Move numbers right of @@ into the equation
-        // System.err.println(newValue);
         newValue = newValue.replace("@@", "$"); // Replace all @@ with $
-        // System.err.println(newValue);
         newValue = newValue.replace("  ", " "); // Clean up
         newValue = newValue.replace("$$", "");
         newValue = newValue.replace(" )$", ")$");
@@ -692,40 +685,4 @@ public class CleanUpAction extends AbstractWorker {
         }
     }
 
-    /**
-     * Converts to BibLatex format
-     */
-    private static void doConvertToBiblatex(BibtexEntry entry, NamedCompound ce) {
-
-        for (Map.Entry<String, String> alias : BibtexEntry.FIELD_ALIASES_OLD_TO_NEW.entrySet()) {
-            String oldFieldName = alias.getKey();
-            String newFieldName = alias.getValue();
-            String oldValue = entry.getField(oldFieldName);
-            String newValue = entry.getField(newFieldName);
-            if ((oldValue != null) && (!oldValue.isEmpty()) && (newValue == null))
-            {
-                // There is content in the old field and no value in the new, so just copy
-                entry.setField(newFieldName, oldValue);
-                ce.addEdit(new UndoableFieldChange(entry, newFieldName, null, oldValue));
-
-                entry.setField(oldFieldName, null);
-                ce.addEdit(new UndoableFieldChange(entry, oldFieldName, oldValue, null));
-            }
-        }
-
-        // Dates: create date out of year and month, save it and delete old fields
-        if ((entry.getField("date") == null) || (entry.getField("date").isEmpty()))
-        {
-            String newDate = entry.getFieldOrAlias("date");
-            String oldYear = entry.getField("year");
-            String oldMonth = entry.getField("month");
-            entry.setField("date", newDate);
-            entry.setField("year", null);
-            entry.setField("month", null);
-
-            ce.addEdit(new UndoableFieldChange(entry, "date", null, newDate));
-            ce.addEdit(new UndoableFieldChange(entry, "year", oldYear, null));
-            ce.addEdit(new UndoableFieldChange(entry, "month", oldMonth, null));
-        }
-    }
 }

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -843,7 +843,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                 // First, remove fields that the user have removed.
             }
 
-            for (String field : entry.getAllFields()) {
+            for (String field : entry.getFieldNames()) {
                 if (BibtexFields.isDisplayableField(field)) {
                     if (newEntry.getField(field) == null) {
                         compound.addEdit(new UndoableFieldChange(entry, field, entry
@@ -855,7 +855,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
             }
 
             // Then set all fields that have been set by the user.
-            for (String field : newEntry.getAllFields()) {
+            for (String field : newEntry.getFieldNames()) {
                 String oldValue = entry.getField(field);
                 String newValue = newEntry.getField(field);
                 if (oldValue == null || !oldValue.equals(newValue)) {

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -69,6 +69,7 @@ import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.database.BibtexDatabase;
 import net.sf.jabref.model.entry.BibtexEntry;
 import net.sf.jabref.model.entry.BibtexEntryType;
+import net.sf.jabref.model.entry.EntryConverter;
 import net.sf.jabref.specialfields.SpecialFieldUpdateListener;
 import net.sf.jabref.gui.undo.NamedCompound;
 import net.sf.jabref.gui.undo.UndoableChangeType;
@@ -241,7 +242,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                         .getPane(), Localization.lang("Show optional fields"));
                 tabs.add(optPan);
 
-                Set<String> deprecatedFields = new HashSet<>(BibtexEntry.FIELD_ALIASES_OLD_TO_NEW.keySet());
+                Set<String> deprecatedFields = new HashSet<>(EntryConverter.FIELD_ALIASES_TEX_TO_LTX.keySet());
                 deprecatedFields.add("year");
                 deprecatedFields.add("month");
                 List<String> secondaryOptionalFields = entry.getType().getSecondaryOptionalFields();
@@ -252,8 +253,8 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                 Set<String> optionalFieldsAndAliases = new HashSet<>();
                 for (String field : entry.getOptionalFields()) {
                     optionalFieldsAndAliases.add(field);
-                    if (BibtexEntry.FIELD_ALIASES_NEW_TO_OLD.containsKey(field)) {
-                        optionalFieldsAndAliases.add(BibtexEntry.FIELD_ALIASES_NEW_TO_OLD.get(field));
+                    if (EntryConverter.FIELD_ALIASES_LTX_TO_TEX.containsKey(field)) {
+                        optionalFieldsAndAliases.add(EntryConverter.FIELD_ALIASES_LTX_TO_TEX.get(field));
                     }
                 }
 

--- a/src/main/java/net/sf/jabref/gui/mergeentries/MergeEntries.java
+++ b/src/main/java/net/sf/jabref/gui/mergeentries/MergeEntries.java
@@ -107,8 +107,8 @@ public class MergeEntries {
      */
     private void initialize() {
 
-        joint = new TreeSet<>(one.getAllFields());
-        joint.addAll(two.getAllFields());
+        joint = new TreeSet<>(one.getFieldNames());
+        joint.addAll(two.getFieldNames());
 
         // Remove field starting with __
         TreeSet<String> toberemoved = new TreeSet<>();

--- a/src/main/java/net/sf/jabref/gui/mergeentries/MergeEntryDOIDialog.java
+++ b/src/main/java/net/sf/jabref/gui/mergeentries/MergeEntryDOIDialog.java
@@ -175,7 +175,7 @@ public class MergeEntryDOIDialog extends JDialog {
         } else if (button.equals("done")) {
             // Create a new entry and add it to the undo stack
             // Remove the old entry and add it to the undo stack (which is not working...)
-            Set<String> joint = new TreeSet<>(mergedEntry.getAllFields());
+            Set<String> joint = new TreeSet<>(mergedEntry.getFieldNames());
             Boolean edited = false;
 
             for (String field : joint) {

--- a/src/main/java/net/sf/jabref/gui/undo/UndoableFieldChange.java
+++ b/src/main/java/net/sf/jabref/gui/undo/UndoableFieldChange.java
@@ -29,15 +29,12 @@ import net.sf.jabref.model.entry.BibtexEntry;
  * new value. Old/new values can be null.
  */
 public class UndoableFieldChange extends AbstractUndoableEdit {
-
-    private static final long serialVersionUID = 1L;
+    private static final Log LOGGER = LogFactory.getLog(UndoableFieldChange.class);
     
     private final BibtexEntry entry;
     private final String field;
     private final String oldValue;
     private final String newValue;
-    
-    private static final Log LOGGER = LogFactory.getLog(UndoableFieldChange.class);
 
 
     public UndoableFieldChange(BibtexEntry entry, String field,

--- a/src/main/java/net/sf/jabref/importer/EntryFromFileCreator.java
+++ b/src/main/java/net/sf/jabref/importer/EntryFromFileCreator.java
@@ -188,7 +188,7 @@ public abstract class EntryFromFileCreator implements java.io.FileFilter {
     }
 
     void addEntryDataToEntry(BibtexEntry entry, BibtexEntry e) {
-        for (String field : e.getAllFields()) {
+        for (String field : e.getFieldNames()) {
             appendToField(entry, field, e.getField(field));
         }
     }

--- a/src/main/java/net/sf/jabref/importer/ImportFormatReader.java
+++ b/src/main/java/net/sf/jabref/importer/ImportFormatReader.java
@@ -378,7 +378,7 @@ public class ImportFormatReader {
             BibtexEntry entry = i.next();
 
             // If there are no fields, remove the entry:
-            if (entry.getAllFields().isEmpty()) {
+            if (entry.getFieldNames().isEmpty()) {
                 i.remove();
             }
         }

--- a/src/main/java/net/sf/jabref/importer/fetcher/OAI2Fetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/OAI2Fetcher.java
@@ -210,7 +210,7 @@ public class OAI2Fetcher implements EntryFetcher {
             saxParser.parse(inputStream, handlerBase);
 
             /* Correct line breaks and spacing */
-            for (String name : be.getAllFields()) {
+            for (String name : be.getFieldNames()) {
                 be.setField(name, OAI2Fetcher.correctLineBreaks(be.getField(name)));
             }
 

--- a/src/main/java/net/sf/jabref/importer/fileformat/EndnoteImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/EndnoteImporter.java
@@ -278,7 +278,7 @@ public class EndnoteImporter extends ImportFormat {
             // create one here
             b.setField(hm);
             //if (hm.isEmpty())
-            if (!b.getAllFields().isEmpty()) {
+            if (!b.getFieldNames().isEmpty()) {
                 bibitems.add(b);
             }
 

--- a/src/main/java/net/sf/jabref/logic/mods/MODSEntry.java
+++ b/src/main/java/net/sf/jabref/logic/mods/MODSEntry.java
@@ -138,7 +138,7 @@ class MODSEntry {
 
     private void populateExtensionFields(BibtexEntry e) {
 
-        for (String field : e.getAllFields()) {
+        for (String field : e.getFieldNames()) {
             String value = e.getField(field);
             field = MODSEntry.BIBTEX + field;
             extensionFields.put(field, value);

--- a/src/main/java/net/sf/jabref/logic/search/rules/ContainBasedSearchRule.java
+++ b/src/main/java/net/sf/jabref/logic/search/rules/ContainBasedSearchRule.java
@@ -57,7 +57,7 @@ public class ContainBasedSearchRule implements SearchRule {
         // We need match for all words:
         boolean[] matchFound = new boolean[words.size()];
 
-        for (String field : bibtexEntry.getAllFields()) {
+        for (String field : bibtexEntry.getFieldNames()) {
             Object fieldContentAsObject = bibtexEntry.getField(field);
             if (fieldContentAsObject != null) {
                 String fieldContent = ContainBasedSearchRule.REMOVE_LATEX_COMMANDS.format(fieldContentAsObject.toString());

--- a/src/main/java/net/sf/jabref/logic/search/rules/GrammarBasedSearchRule.java
+++ b/src/main/java/net/sf/jabref/logic/search/rules/GrammarBasedSearchRule.java
@@ -135,7 +135,7 @@ public class GrammarBasedSearchRule implements SearchRule {
 
         public boolean compare(BibtexEntry entry) {
             // specification of fields to search is done in the search expression itself
-            String[] searchKeys = entry.getAllFields().toArray(new String[entry.getAllFields().size()]);
+            String[] searchKeys = entry.getFieldNames().toArray(new String[entry.getFieldNames().size()]);
 
             boolean noSuchField = true;
             // this loop iterates over all regular keys, then over pseudo keys like "type"

--- a/src/main/java/net/sf/jabref/logic/search/rules/RegexBasedSearchRule.java
+++ b/src/main/java/net/sf/jabref/logic/search/rules/RegexBasedSearchRule.java
@@ -83,7 +83,7 @@ public class RegexBasedSearchRule implements SearchRule {
         // We need match for all words:
         boolean[] matchFound = new boolean[words.size()];
 
-        for (String field : bibtexEntry.getAllFields()) {
+        for (String field : bibtexEntry.getFieldNames()) {
             Object fieldContentAsObject = bibtexEntry.getField(field);
             if (fieldContentAsObject != null) {
                 String fieldContent = RegexBasedSearchRule.REMOVE_LATEX_COMMANDS.format(fieldContentAsObject.toString());

--- a/src/main/java/net/sf/jabref/logic/xmp/XMPSchemaBibtex.java
+++ b/src/main/java/net/sf/jabref/logic/xmp/XMPSchemaBibtex.java
@@ -283,7 +283,7 @@ public class XMPSchemaBibtex extends XMPSchema {
      */
     public void setBibtexEntry(BibtexEntry entry, BibtexDatabase database) {
         // Set all the values including key and entryType
-        Set<String> fields = entry.getAllFields();
+        Set<String> fields = entry.getFieldNames();
 
         JabRefPreferences prefs = JabRefPreferences.getInstance();
         if (prefs.getBoolean(JabRefPreferences.USE_XMP_PRIVACY_FILTER)) {

--- a/src/main/java/net/sf/jabref/logic/xmp/XMPUtil.java
+++ b/src/main/java/net/sf/jabref/logic/xmp/XMPUtil.java
@@ -252,7 +252,7 @@ public class XMPUtil {
         }
 
         // Return null if no values were found
-        return !entry.getAllFields().isEmpty() ? entry : null;
+        return !entry.getFieldNames().isEmpty() ? entry : null;
     }
 
     /**
@@ -449,7 +449,7 @@ public class XMPUtil {
             }
         }
 
-        return !entry.getAllFields().isEmpty() ? entry : null;
+        return !entry.getFieldNames().isEmpty() ? entry : null;
     }
 
     /**
@@ -628,7 +628,7 @@ public class XMPUtil {
 
         // Set all the values including key and entryType
 
-        for (String field : entry.getAllFields()) {
+        for (String field : entry.getFieldNames()) {
 
             if (useXmpPrivacyFilter && filters.contains(field)) {
                 continue;
@@ -1018,7 +1018,7 @@ public class XMPUtil {
                 Arrays.asList(prefs.getStringArray(JabRefPreferences.XMP_PRIVACY_FILTERS)));
 
         // Set all the values including key and entryType
-        Set<String> fields = entry.getAllFields();
+        Set<String> fields = entry.getFieldNames();
 
         for (String field : fields) {
 

--- a/src/main/java/net/sf/jabref/model/database/BibtexDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibtexDatabase.java
@@ -120,7 +120,7 @@ public class BibtexDatabase {
     public TreeSet<String> getAllVisibleFields() {
         TreeSet<String> allFields = new TreeSet<>();
         for (BibtexEntry e : getEntries()) {
-            allFields.addAll(e.getAllFields());
+            allFields.addAll(e.getFieldNames());
         }
         TreeSet<String> toberemoved = new TreeSet<>();
         for (String field : allFields) {
@@ -358,7 +358,7 @@ public class BibtexDatabase {
             entry = (BibtexEntry) entry.clone();
         }
 
-        for (Object field : entry.getAllFields()) {
+        for (Object field : entry.getFieldNames()) {
             entry.setField(field.toString(), this.resolveForStrings(entry.getField(field.toString())));
         }
 

--- a/src/main/java/net/sf/jabref/model/entry/BibtexEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibtexEntry.java
@@ -306,7 +306,7 @@ public class BibtexEntry {
      * does not check values for content, so e.g. empty strings will be set as such.
      */
     public void setField(Map<String, String> fields) {
-        fields.putAll(fields);
+        this.fields.putAll(fields);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/model/entry/BibtexEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibtexEntry.java
@@ -49,12 +49,11 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 public class BibtexEntry {
+    private static final Log LOGGER = LogFactory.getLog(BibtexEntry.class);
 
     public static final String TYPE_HEADER = "entrytype";
     public static final String KEY_FIELD = "bibtexkey";
     private static final String ID_FIELD = "id";
-
-    private static final Log LOGGER = LogFactory.getLog(BibtexEntry.class);
 
     public static final Map<String, String> FIELD_ALIASES_OLD_TO_NEW = new HashMap<>(); // Bibtex to BibLatex
     public static final Map<String, String> FIELD_ALIASES_NEW_TO_OLD = new HashMap<>(); // BibLatex to Bibtex
@@ -137,9 +136,20 @@ public class BibtexEntry {
     /**
      * Returns an set containing the names of all fields that are
      * set for this particular entry.
+     *
+     * @return a set of existing field names
      */
-    public Set<String> getAllFields() {
+    public Set<String> getFieldNames() {
         return new TreeSet<>(fields.keySet());
+    }
+
+    /**
+     * Returns all fields of the BibTex entry
+     *
+     * @return a map of key, value pairs
+     */
+    public Map<String, String> getFields() {
+        return fields;
     }
 
     /**

--- a/src/main/java/net/sf/jabref/model/entry/BibtexEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibtexEntry.java
@@ -98,15 +98,6 @@ public class BibtexEntry {
     }
 
     /**
-     * Returns all fields of the BibTex entry
-     *
-     * @return a map of key, value pairs
-     */
-    public Map<String, String> getFields() {
-        return fields;
-    }
-
-    /**
      * Returns true if this entry contains the fields it needs to be
      * complete.
      */

--- a/src/main/java/net/sf/jabref/model/entry/EntryConverter.java
+++ b/src/main/java/net/sf/jabref/model/entry/EntryConverter.java
@@ -1,0 +1,79 @@
+package net.sf.jabref.model.entry;
+
+import net.sf.jabref.gui.undo.NamedCompound;
+import net.sf.jabref.gui.undo.UndoableFieldChange;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Converts Enntry models from BibTex to BibLaTex and back.
+ */
+public class EntryConverter {
+    // BibTex to BibLatex
+    public static Map<String, String> FIELD_ALIASES_TEX_TO_LTX;
+    // BibLatex to BibTex
+    public static Map<String, String> FIELD_ALIASES_LTX_TO_TEX;
+    // All aliases
+    public static Map<String, String> FIELD_ALIASES;
+
+    static {
+        EntryConverter.FIELD_ALIASES_TEX_TO_LTX = new HashMap<>();
+        EntryConverter.FIELD_ALIASES_TEX_TO_LTX.put("address", "location");
+        EntryConverter.FIELD_ALIASES_TEX_TO_LTX.put("annote", "annotation");
+        EntryConverter.FIELD_ALIASES_TEX_TO_LTX.put("archiveprefix", "eprinttype");
+        EntryConverter.FIELD_ALIASES_TEX_TO_LTX.put("journal", "journaltitle");
+        EntryConverter.FIELD_ALIASES_TEX_TO_LTX.put("key", "sortkey");
+        EntryConverter.FIELD_ALIASES_TEX_TO_LTX.put("pdf", "file");
+        EntryConverter.FIELD_ALIASES_TEX_TO_LTX.put("primaryclass", "eprintclass");
+        EntryConverter.FIELD_ALIASES_TEX_TO_LTX.put("school", "institution");
+
+        // inverse map
+        EntryConverter.FIELD_ALIASES_LTX_TO_TEX = EntryConverter.FIELD_ALIASES_TEX_TO_LTX.entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+
+        // all aliases
+        FIELD_ALIASES = new HashMap<>();
+        FIELD_ALIASES.putAll(EntryConverter.FIELD_ALIASES_TEX_TO_LTX);
+        FIELD_ALIASES.putAll(EntryConverter.FIELD_ALIASES_LTX_TO_TEX);
+    }
+
+    /**
+     * Converts to BibLatex format
+     */
+    public static void convertToBiblatex(BibtexEntry entry, NamedCompound ce) {
+
+        for (Map.Entry<String, String> alias : FIELD_ALIASES_TEX_TO_LTX.entrySet()) {
+            String oldFieldName = alias.getKey();
+            String newFieldName = alias.getValue();
+            String oldValue = entry.getField(oldFieldName);
+            String newValue = entry.getField(newFieldName);
+            if ((oldValue != null) && (!oldValue.isEmpty()) && (newValue == null))
+            {
+                // There is content in the old field and no value in the new, so just copy
+                entry.setField(newFieldName, oldValue);
+                ce.addEdit(new UndoableFieldChange(entry, newFieldName, null, oldValue));
+
+                entry.setField(oldFieldName, null);
+                ce.addEdit(new UndoableFieldChange(entry, oldFieldName, oldValue, null));
+            }
+        }
+
+        // Dates: create date out of year and month, save it and delete old fields
+        if ((entry.getField("date") == null) || (entry.getField("date").isEmpty()))
+        {
+            String newDate = entry.getFieldOrAlias("date");
+            String oldYear = entry.getField("year");
+            String oldMonth = entry.getField("month");
+            entry.setField("date", newDate);
+            entry.setField("year", null);
+            entry.setField("month", null);
+
+            ce.addEdit(new UndoableFieldChange(entry, "date", null, newDate));
+            ce.addEdit(new UndoableFieldChange(entry, "year", oldYear, null));
+            ce.addEdit(new UndoableFieldChange(entry, "month", oldMonth, null));
+        }
+    }
+}

--- a/src/main/java/net/sf/jabref/model/entry/EntryConverter.java
+++ b/src/main/java/net/sf/jabref/model/entry/EntryConverter.java
@@ -1,8 +1,5 @@
 package net.sf.jabref.model.entry;
 
-import net.sf.jabref.gui.undo.NamedCompound;
-import net.sf.jabref.gui.undo.UndoableFieldChange;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -38,42 +35,5 @@ public class EntryConverter {
         FIELD_ALIASES = new HashMap<>();
         FIELD_ALIASES.putAll(EntryConverter.FIELD_ALIASES_TEX_TO_LTX);
         FIELD_ALIASES.putAll(EntryConverter.FIELD_ALIASES_LTX_TO_TEX);
-    }
-
-    /**
-     * Converts to BibLatex format
-     */
-    public static void convertToBiblatex(BibtexEntry entry, NamedCompound ce) {
-
-        for (Map.Entry<String, String> alias : FIELD_ALIASES_TEX_TO_LTX.entrySet()) {
-            String oldFieldName = alias.getKey();
-            String newFieldName = alias.getValue();
-            String oldValue = entry.getField(oldFieldName);
-            String newValue = entry.getField(newFieldName);
-            if ((oldValue != null) && (!oldValue.isEmpty()) && (newValue == null))
-            {
-                // There is content in the old field and no value in the new, so just copy
-                entry.setField(newFieldName, oldValue);
-                ce.addEdit(new UndoableFieldChange(entry, newFieldName, null, oldValue));
-
-                entry.setField(oldFieldName, null);
-                ce.addEdit(new UndoableFieldChange(entry, oldFieldName, oldValue, null));
-            }
-        }
-
-        // Dates: create date out of year and month, save it and delete old fields
-        if ((entry.getField("date") == null) || (entry.getField("date").isEmpty()))
-        {
-            String newDate = entry.getFieldOrAlias("date");
-            String oldYear = entry.getField("year");
-            String oldMonth = entry.getField("month");
-            entry.setField("date", newDate);
-            entry.setField("year", null);
-            entry.setField("month", null);
-
-            ce.addEdit(new UndoableFieldChange(entry, "date", null, newDate));
-            ce.addEdit(new UndoableFieldChange(entry, "year", oldYear, null));
-            ce.addEdit(new UndoableFieldChange(entry, "month", oldMonth, null));
-        }
     }
 }

--- a/src/main/java/net/sf/jabref/openoffice/OOUtil.java
+++ b/src/main/java/net/sf/jabref/openoffice/OOUtil.java
@@ -300,7 +300,7 @@ class OOUtil {
             return null;
         }
         BibtexEntry e = (BibtexEntry) entry.clone();
-        for (String field : e.getAllFields()) {
+        for (String field : e.getFieldNames()) {
             if (field.equals(BibtexEntry.KEY_FIELD)) {
                 continue;
             }

--- a/src/test/java/net/sf/jabref/bibtex/BibtexEntryWriterTest.java
+++ b/src/test/java/net/sf/jabref/bibtex/BibtexEntryWriterTest.java
@@ -80,8 +80,8 @@ public class BibtexEntryWriterTest {
 
         BibtexEntry entry = entries.iterator().next();
         Assert.assertEquals("test", entry.getCiteKey());
-        Assert.assertEquals(5, entry.getAllFields().size());
-        Set<String> fields = entry.getAllFields();
+        Assert.assertEquals(5, entry.getFieldNames().size());
+        Set<String> fields = entry.getFieldNames();
         Assert.assertTrue(fields.contains("author"));
         Assert.assertEquals("Foo Bar", entry.getField("author"));
 
@@ -109,8 +109,8 @@ public class BibtexEntryWriterTest {
 
         BibtexEntry entry = entries.iterator().next();
         Assert.assertEquals("test", entry.getCiteKey());
-        Assert.assertEquals(4, entry.getAllFields().size());
-        Set<String> fields = entry.getAllFields();
+        Assert.assertEquals(4, entry.getFieldNames().size());
+        Set<String> fields = entry.getFieldNames();
         Assert.assertTrue(fields.contains("month"));
         Assert.assertEquals("#mar#", entry.getField("month"));
 

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -1,7 +1,6 @@
 package net.sf.jabref.importer.fileformat;
 
 import net.sf.jabref.importer.ParserResult;
-import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.model.entry.BibtexEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
 
@@ -34,8 +33,8 @@ public class BibtexParserTest {
 
         BibtexEntry e = c.iterator().next();
         Assert.assertEquals("test", e.getCiteKey());
-        Assert.assertEquals(2, e.getAllFields().size());
-        Set<String> o = e.getAllFields();
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Set<String> o = e.getFieldNames();
         Assert.assertTrue(o.contains("author"));
         Assert.assertEquals("Ed von Test", e.getField("author"));
     }
@@ -111,8 +110,8 @@ public class BibtexParserTest {
 
             BibtexEntry e = c.iterator().next();
             Assert.assertEquals("test", e.getCiteKey());
-            Assert.assertEquals(2, e.getAllFields().size());
-            Assert.assertTrue(e.getAllFields().contains("author"));
+            Assert.assertEquals(2, e.getFieldNames().size());
+            Assert.assertTrue(e.getFieldNames().contains("author"));
             Assert.assertEquals("Ed von Test", e.getField("author"));
         }
         { // Empty String
@@ -189,8 +188,8 @@ public class BibtexParserTest {
 
         BibtexEntry e = c.iterator().next();
         Assert.assertEquals("test", e.getCiteKey());
-        Assert.assertEquals(2, e.getAllFields().size());
-        Assert.assertTrue(e.getAllFields().contains("author"));
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertTrue(e.getFieldNames().contains("author"));
         Assert.assertEquals("Ed von Test", e.getField("author"));
 
         // Calling parse again will return the same result
@@ -215,7 +214,7 @@ public class BibtexParserTest {
 
         Assert.assertNotSame(e.getId(), e2.getId());
 
-        for (String field : e.getAllFields()) {
+        for (String field : e.getFieldNames()) {
             if (!e.getField(field).equals(e2.getField(field))) {
                 Assert.fail("e and e2 differ in field " + field);
             }

--- a/src/test/java/net/sf/jabref/util/XMPSchemaBibtexTest.java
+++ b/src/test/java/net/sf/jabref/util/XMPSchemaBibtexTest.java
@@ -27,9 +27,9 @@ public class XMPSchemaBibtexTest {
         Assert.assertEquals(e.getCiteKey(), x.getCiteKey());
         Assert.assertEquals(e.getType(), x.getType());
 
-        Assert.assertEquals(e.getAllFields().size(), x.getAllFields().size());
+        Assert.assertEquals(e.getFieldNames().size(), x.getFieldNames().size());
 
-        for (String name : e.getAllFields()) {
+        for (String name : e.getFieldNames()) {
             Assert.assertEquals(e.getField(name), x.getField(name));
         }
     }

--- a/src/test/java/net/sf/jabref/util/XMPUtilTest.java
+++ b/src/test/java/net/sf/jabref/util/XMPUtilTest.java
@@ -358,7 +358,7 @@ public class XMPUtilTest {
             Set<String> expectedFields = new HashSet<String>(Arrays.asList("bibtexkey", "booktitle",
                     "owner", "timestamp", "url", "year"));
 
-            Assert.assertEquals(expectedFields, x.getAllFields());
+            Assert.assertEquals(expectedFields, x.getFieldNames());
         }
         // First set:
         prefs.putBoolean("useXmpPrivacyFilter", true);
@@ -374,7 +374,7 @@ public class XMPUtilTest {
         List<BibtexEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile());
         Assert.assertEquals(1, l.size());
         BibtexEntry x = l.get(0);
-        Set<String> ts = x.getAllFields();
+        Set<String> ts = x.getFieldNames();
         Assert.assertEquals(8, ts.size());
 
         ts.contains("bibtextype");
@@ -874,7 +874,7 @@ public class XMPUtilTest {
         Assert.assertEquals(expected.getCiteKey(), actual.getCiteKey());
         Assert.assertEquals(expected.getType(), actual.getType());
 
-        for (String field : expected.getAllFields()) {
+        for (String field : expected.getFieldNames()) {
 
             if (field.toLowerCase().equals("author")
                     || field.toLowerCase().equals("editor")) {
@@ -889,8 +889,8 @@ public class XMPUtilTest {
             }
         }
 
-        Assert.assertEquals(expected.getAllFields().size(),
-                actual.getAllFields().size());
+        Assert.assertEquals(expected.getFieldNames().size(),
+                actual.getFieldNames().size());
     }
 
     /**


### PR DESCRIPTION
- Renames getAllFields() to getFieldNames() 
- add getFields() method

Often the workflow in our code is:
```java 
for(String name: entry.getFieldnames()) {
  entry.getField(name);
  // do something
}
```

We can directly use `entry.getFields()` for this now.
Are there any concurrency Problems behind the old rationale or was it just dumb?