### PR TITLE
Removes option to disable renaming in FileChooser dialogs.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 [master]
     - Removes options to set PDF and PS directories per .bib database as the general options have also been deleted.
+    - Removes option to disable renaming in FileChooser dialogs.
     - Removes option to hide the BibTeX Code tab in the entry editor.
     - Changes the old integrity check by improving the code base (+tests) and converting it to a simple issues table
     - Removes option to set a custom icon for the external file types. This is not possible anymore with the new icon font.

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -282,7 +282,6 @@ public class JabRefPreferences {
     public static final String IMPORT_INSPECTION_DIALOG_WIDTH = "importInspectionDialogWidth";
     public static final String SIDE_PANE_WIDTH = "sidePaneWidth";
     public static final String LAST_USED_EXPORT = "lastUsedExport";
-    public static final String FILECHOOSER_DISABLE_RENAME = "filechooserDisableRename";
     public static final String USE_NATIVE_FILE_DIALOG_ON_MAC = "useNativeFileDialogOnMac";
     public static final String FLOAT_MARKED_ENTRIES = "floatMarkedEntries";
     public static final String CITE_COMMAND = "citeCommand";
@@ -738,7 +737,6 @@ public class JabRefPreferences {
         defaults.put(FLOAT_MARKED_ENTRIES, Boolean.TRUE);
 
         defaults.put(USE_NATIVE_FILE_DIALOG_ON_MAC, Boolean.FALSE);
-        defaults.put(FILECHOOSER_DISABLE_RENAME, Boolean.TRUE);
 
         defaults.put(LAST_USED_EXPORT, null);
         defaults.put(SIDE_PANE_WIDTH, -1);

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -544,8 +544,6 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     private void init() {
         tabbedPane = new DragDropPopupPane(manageSelectors, databaseProperties, bibtexKeyPattern);
 
-        UIManager.put("FileChooser.readOnly", Globals.prefs.getBoolean(JabRefPreferences.FILECHOOSER_DISABLE_RENAME));
-
         MyGlassPane glassPane = new MyGlassPane();
         setGlassPane(glassPane);
         // glassPane.setVisible(true);

--- a/src/main/java/net/sf/jabref/gui/preftabs/AdvancedTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/AdvancedTab.java
@@ -50,7 +50,6 @@ class AdvancedTab extends JPanel implements PrefsTab {
     private final JCheckBox useDefault;
     private final JCheckBox useRemoteServer;
     private final JCheckBox useNativeFileDialogOnMac;
-    private final JCheckBox filechooserDisableRename;
     private final JCheckBox useIEEEAbrv;
     private final JCheckBox biblatexMode;
     private final JComboBox<String> className;
@@ -75,7 +74,6 @@ class AdvancedTab extends JPanel implements PrefsTab {
         useDefault = new JCheckBox(Localization.lang("Use other look and feel"));
         useRemoteServer = new JCheckBox(Localization.lang("Listen for remote operation on port") + ':');
         useNativeFileDialogOnMac = new JCheckBox(Localization.lang("Use native file dialog"));
-        filechooserDisableRename = new JCheckBox(Localization.lang("Disable file renaming in non-native file dialog"));
         useIEEEAbrv = new JCheckBox(Localization.lang("Use IEEE LaTeX abbreviations"));
         biblatexMode = new JCheckBox(Localization.lang("BibLaTeX mode"));
         remoteServerPort = new JTextField();
@@ -164,9 +162,6 @@ class AdvancedTab extends JPanel implements PrefsTab {
         builder.nextLine();
         builder.append(new JPanel());
         builder.append(useNativeFileDialogOnMac);
-        builder.nextLine();
-        builder.append(new JPanel());
-        builder.append(filechooserDisableRename);
         //}
         // IEEE
         builder.nextLine();
@@ -210,7 +205,6 @@ class AdvancedTab extends JPanel implements PrefsTab {
         oldPort = remotePreferences.getPort();
         remoteServerPort.setText(String.valueOf(oldPort));
         useNativeFileDialogOnMac.setSelected(Globals.prefs.getBoolean(JabRefPreferences.USE_NATIVE_FILE_DIALOG_ON_MAC));
-        filechooserDisableRename.setSelected(Globals.prefs.getBoolean(JabRefPreferences.FILECHOOSER_DISABLE_RENAME));
         useIEEEAbrv.setSelected(Globals.prefs.getBoolean(JabRefPreferences.USE_IEEE_ABRV));
         oldBiblMode = Globals.prefs.getBoolean(JabRefPreferences.BIBLATEX_MODE);
         biblatexMode.setSelected(oldBiblMode);
@@ -224,8 +218,6 @@ class AdvancedTab extends JPanel implements PrefsTab {
         preferences.putBoolean(JabRefPreferences.USE_DEFAULT_LOOK_AND_FEEL, !useDefault.isSelected());
         preferences.put(JabRefPreferences.WIN_LOOK_AND_FEEL, className.getSelectedItem().toString());
         preferences.putBoolean(JabRefPreferences.USE_NATIVE_FILE_DIALOG_ON_MAC, useNativeFileDialogOnMac.isSelected());
-        preferences.putBoolean(JabRefPreferences.FILECHOOSER_DISABLE_RENAME, filechooserDisableRename.isSelected());
-        UIManager.put("FileChooser.readOnly", filechooserDisableRename.isSelected());
 
         if(preferences.getBoolean(JabRefPreferences.USE_IEEE_ABRV) != useIEEEAbrv.isSelected()) {
             preferences.putBoolean(JabRefPreferences.USE_IEEE_ABRV, useIEEEAbrv.isSelected());


### PR DESCRIPTION
Why?

- I think this is annoying as one would expect this to work. 

I can also live with the option that this is ALWAYS active, but giving the user the option to choose is not good in my opinion. 