### PR TITLE
Fixed a number of false positive translation strings

### DIFF
--- a/src/main/java/net/sf/jabref/JabRef.java
+++ b/src/main/java/net/sf/jabref/JabRef.java
@@ -359,7 +359,7 @@ public class JabRef {
                                 session.commit();
                             } catch (SaveException ex) {
                                 System.err.println(Localization.lang("Could not save file") + " '" + data[0] + "': "
-                                        + ex.getMessage());
+                                        + ex.getLocalizedMessage());
                             }
                         }
                     } else {
@@ -446,7 +446,7 @@ public class JabRef {
                                 session.commit();
                             } catch (SaveException ex) {
                                 System.err.println(Localization.lang("Could not save file") + " '" + subName + "': "
-                                        + ex.getMessage());
+                                        + ex.getLocalizedMessage());
                             }
 
                             notSavedMsg = true;

--- a/src/main/java/net/sf/jabref/JabRefCLI.java
+++ b/src/main/java/net/sf/jabref/JabRefCLI.java
@@ -130,13 +130,15 @@ public class JabRefCLI {
         // @formatter:off
         options.addOption(Option.builder("i").
                 longOpt("import").
-                desc(String.format("%s: %s[,import format]", Localization.lang("Import file"), Localization.lang("filename"))).
+                desc(String.format("%s: %s[,import format]", Localization.lang("Import file"),
+                        Localization.lang("filename"))).
                 hasArg().
                 argName("FILE").build());
 
         options.addOption(Option.builder("o").
                 longOpt("output").
-                desc(String.format("%s: %s[,export format]", Localization.lang("Output or export file"), Localization.lang("filename"))).
+                desc(String.format("%s: %s[,export format]", Localization.lang("Output or export file"),
+                        Localization.lang("filename"))).
                 hasArg().
                 argName("FILE").
                 build());
@@ -163,7 +165,9 @@ public class JabRefCLI {
 
         options.addOption(Option.builder("a").
                 longOpt("aux").
-                desc(String.format("%s: %s[.aux],%s[.bib]", Localization.lang("Subdatabase from aux"), Localization.lang("file"), Localization.lang("new"))).
+                desc(String.format("%s: %s[.aux],%s[.bib]", Localization.lang("Subdatabase from aux"),
+                        Localization.lang("file"),
+                        Localization.lang("new"))).
                 hasArg().
                 argName("FILE").
                 build());
@@ -221,6 +225,11 @@ public class JabRefCLI {
     }
 
     public static String getExportMatchesSyntax() {
-        return String.format("[%s]searchTerm,outputFile: %s[,%s]", Localization.lang("field"), Localization.lang("file"), Localization.lang("exportFormat"));
+        // @formatter:off
+        return String.format("[%s]searchTerm,outputFile: %s[,%s]",
+                Localization.lang("field"),
+                Localization.lang("file"),
+                Localization.lang("exportFormat"));
+        // @formatter:on
     }
 }

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -1357,13 +1357,18 @@ public class JabRefPreferences {
         list.add(new ExternalFileType("PostScript", "ps", "application/postscript", "evince", "psSmall", IconTheme.JabRefIcon.FILE.getSmallIcon()));
         list.add(new ExternalFileType("Word", "doc", "application/msword", "oowriter", "openoffice", IconTheme.JabRefIcon.FILE_WORD.getSmallIcon()));
         list.add(new ExternalFileType("Word 2007+", "docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "oowriter", "openoffice", IconTheme.JabRefIcon.FILE_WORD.getSmallIcon()));
-        list.add(new ExternalFileType("OpenDocument text", "odt", "application/vnd.oasis.opendocument.text", "oowriter", "openoffice", IconTheme.getImage("openoffice")));
+        list.add(new ExternalFileType(Localization.lang("OpenDocument text"), "odt",
+                "application/vnd.oasis.opendocument.text", "oowriter", "openoffice", IconTheme.getImage("openoffice")));
         list.add(new ExternalFileType("Excel", "xls", "application/excel", "oocalc", "openoffice", IconTheme.JabRefIcon.FILE_EXCEL.getSmallIcon()));
         list.add(new ExternalFileType("Excel 2007+", "xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "oocalc", "openoffice", IconTheme.JabRefIcon.FILE_EXCEL.getSmallIcon()));
-        list.add(new ExternalFileType("OpenDocument spreadsheet", "ods", "application/vnd.oasis.opendocument.spreadsheet", "oocalc", "openoffice", IconTheme.getImage("openoffice")));
+        list.add(new ExternalFileType(Localization.lang("OpenDocument spreadsheet"), "ods",
+                "application/vnd.oasis.opendocument.spreadsheet", "oocalc", "openoffice",
+                IconTheme.getImage("openoffice")));
         list.add(new ExternalFileType("PowerPoint", "ppt", "application/vnd.ms-powerpoint", "ooimpress", "openoffice", IconTheme.JabRefIcon.FILE_POWERPOINT.getSmallIcon()));
         list.add(new ExternalFileType("PowerPoint 2007+", "pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation", "ooimpress", "openoffice", IconTheme.JabRefIcon.FILE_POWERPOINT.getSmallIcon()));
-        list.add(new ExternalFileType("OpenDocument presentation", "odp", "application/vnd.oasis.opendocument.presentation", "ooimpress", "openoffice", IconTheme.getImage("openoffice")));
+        list.add(new ExternalFileType(Localization.lang("OpenDocument presentation"), "odp",
+                "application/vnd.oasis.opendocument.presentation", "ooimpress", "openoffice",
+                IconTheme.getImage("openoffice")));
         list.add(new ExternalFileType("Rich Text Format", "rtf", "application/rtf", "oowriter", "openoffice", IconTheme.JabRefIcon.FILE_TEXT.getSmallIcon()));
         list.add(new ExternalFileType("PNG image", "png", "image/png", "gimp", "picture", IconTheme.JabRefIcon.PICTURE.getSmallIcon()));
         list.add(new ExternalFileType("GIF image", "gif", "image/gif", "gimp", "picture", IconTheme.JabRefIcon.PICTURE.getSmallIcon()));
@@ -1372,7 +1377,8 @@ public class JabRefPreferences {
         list.add(new ExternalFileType("Text", "txt", "text/plain", "emacs", "emacs", IconTheme.JabRefIcon.FILE_TEXT.getSmallIcon()));
         list.add(new ExternalFileType("LaTeX", "tex", "application/x-latex", "emacs", "emacs", IconTheme.JabRefIcon.FILE_TEXT.getSmallIcon()));
         list.add(new ExternalFileType("CHM", "chm", "application/mshelp", "gnochm", "www", IconTheme.JabRefIcon.WWW.getSmallIcon()));
-        list.add(new ExternalFileType("TIFF image", "tiff", "image/tiff", "gimp", "picture", IconTheme.JabRefIcon.PICTURE.getSmallIcon()));
+        list.add(new ExternalFileType(Localization.lang("TIFF image"), "tiff", "image/tiff", "gimp", "picture",
+                IconTheme.JabRefIcon.PICTURE.getSmallIcon()));
         list.add(new ExternalFileType("URL", "html", "text/html", "firefox", "www", IconTheme.JabRefIcon.WWW.getSmallIcon()));
         list.add(new ExternalFileType("MHT", "mht", "multipart/related", "firefox", "www", IconTheme.JabRefIcon.WWW.getSmallIcon()));
         list.add(new ExternalFileType("ePUB", "epub", "application/epub+zip", "firefox", "www", IconTheme.JabRefIcon.WWW.getSmallIcon()));

--- a/src/main/java/net/sf/jabref/bibtex/BibtexEntryWriter.java
+++ b/src/main/java/net/sf/jabref/bibtex/BibtexEntryWriter.java
@@ -21,7 +21,6 @@ import net.sf.jabref.gui.BibtexFields;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.exporter.LatexFieldFormatter;
-import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.BibtexEntry;
 import net.sf.jabref.model.entry.BibtexEntryType;
@@ -326,7 +325,7 @@ public class BibtexEntryWriter {
             try {
                 out.write(fieldFormatter.format(field, name));
             } catch (IOException ex) {
-                throw new IOException(Localization.lang("Error in field") + " '" + name + "': " + ex.getMessage());
+                throw new IOException("Error in field '" + name + "': " + ex.getMessage());
             }
             return true;
         } else {

--- a/src/main/java/net/sf/jabref/collab/Change.java
+++ b/src/main/java/net/sf/jabref/collab/Change.java
@@ -32,17 +32,13 @@ abstract class Change extends DefaultMutableTreeNode {
         name = "";
     }
 
-    Change(String changeName) {
-        name = changeName;
-    }
-
-    private String getName() {
-        return name;
+    Change(String name) {
+        this.name = name;
     }
 
     @Override
     public String toString() {
-        return getName();
+        return name;
     }
 
     public boolean isAccepted() {

--- a/src/main/java/net/sf/jabref/collab/Change.java
+++ b/src/main/java/net/sf/jabref/collab/Change.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2015 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -21,7 +21,6 @@ import net.sf.jabref.model.database.BibtexDatabase;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.JComponent;
 import net.sf.jabref.gui.undo.NamedCompound;
-import net.sf.jabref.logic.l10n.Localization;
 
 abstract class Change extends DefaultMutableTreeNode {
 
@@ -33,8 +32,8 @@ abstract class Change extends DefaultMutableTreeNode {
         name = "";
     }
 
-    Change(String name) {
-        this.name = Localization.lang(name);
+    Change(String changeName) {
+        name = changeName;
     }
 
     private String getName() {
@@ -60,7 +59,7 @@ abstract class Change extends DefaultMutableTreeNode {
      * @return boolean false if the parent overrides by not being accepted.
      */
     public boolean isAcceptable() {
-        if (getParent() != null && getParent() instanceof Change) {
+        if ((getParent() != null) && (getParent() instanceof Change)) {
             return ((Change) getParent()).isAccepted();
         } else {
             return true;

--- a/src/main/java/net/sf/jabref/collab/EntryAddChange.java
+++ b/src/main/java/net/sf/jabref/collab/EntryAddChange.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2015 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -24,6 +24,7 @@ import net.sf.jabref.gui.PreviewPanel;
 import net.sf.jabref.gui.undo.NamedCompound;
 import net.sf.jabref.gui.undo.UndoableInsertEntry;
 import net.sf.jabref.logic.id.IdGenerator;
+import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibtexDatabase;
 import net.sf.jabref.model.entry.BibtexEntry;
 
@@ -34,7 +35,7 @@ class EntryAddChange extends Change {
 
 
     public EntryAddChange(BibtexEntry diskEntry) {
-        super("Added entry");
+        super(Localization.lang("Added entry"));
         this.diskEntry = diskEntry;
 
         PreviewPanel pp = new PreviewPanel(null, diskEntry, null, new MetaData(), Globals.prefs.get(JabRefPreferences.PREVIEW_0));

--- a/src/main/java/net/sf/jabref/collab/EntryChange.java
+++ b/src/main/java/net/sf/jabref/collab/EntryChange.java
@@ -41,9 +41,9 @@ class EntryChange extends Change {
         super();
         String key = tmpEntry.getCiteKey();
         if (key == null) {
-            name = "Modified entry";
+            name = Localization.lang("Modified entry");
         } else {
-            name = "Modified entry: '" + key + '\'';
+            name = Localization.lang("Modified entry") + ": '" + key + '\'';
         }
 
         // We know that tmpEntry is not equal to diskEntry. Check if it has been modified
@@ -122,9 +122,9 @@ class EntryChange extends Change {
 
 
         public FieldChange(String field, BibtexEntry memEntry, BibtexEntry tmpEntry, String inMem, String onTmp, String onDisk) {
+            super(field);
             entry = memEntry;
             this.tmpEntry = tmpEntry;
-            name = field;
             this.field = field;
             this.inMem = inMem;
             this.onTmp = onTmp;

--- a/src/main/java/net/sf/jabref/collab/EntryDeleteChange.java
+++ b/src/main/java/net/sf/jabref/collab/EntryDeleteChange.java
@@ -26,6 +26,7 @@ import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.PreviewPanel;
 import net.sf.jabref.gui.undo.NamedCompound;
 import net.sf.jabref.gui.undo.UndoableRemoveEntry;
+import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.bibtex.DuplicateCheck;
 import net.sf.jabref.model.database.BibtexDatabase;
 import net.sf.jabref.model.entry.BibtexEntry;
@@ -41,7 +42,7 @@ class EntryDeleteChange extends Change {
 
 
     public EntryDeleteChange(BibtexEntry memEntry, BibtexEntry tmpEntry) {
-        super("Deleted entry");
+        super(Localization.lang("Deleted entry"));
         this.memEntry = memEntry;
         this.tmpEntry = tmpEntry;
 

--- a/src/main/java/net/sf/jabref/collab/GroupChange.java
+++ b/src/main/java/net/sf/jabref/collab/GroupChange.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2015 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -31,10 +31,12 @@ class GroupChange extends Change {
     private final GroupTreeNode changedGroups;
     private final GroupTreeNode tmpGroupRoot;
 
+
     public GroupChange(GroupTreeNode changedGroups, GroupTreeNode tmpGroupRoot) {
-        super(changedGroups != null ?
-                "Modified groups tree"
-                : "Removed all groups"); // JZTODO lyrics
+        // @formatter:off
+        super(changedGroups != null ? Localization.lang("Modified groups tree") :
+            Localization.lang("Removed all groups")); // JZTODO lyrics
+        // @formatter:on
         this.changedGroups = changedGroups;
         this.tmpGroupRoot = tmpGroupRoot;
     }
@@ -79,9 +81,10 @@ class GroupChange extends Change {
 
     @Override
     JComponent description() {
-        return new JLabel("<html>" + name + '.' + (changedGroups != null ? ' '
-                + "Accepting the change replaces the complete " +
-                "groups tree with the externally modified groups tree." : "")
+        return new JLabel("<html>" + toString() + '.' + (changedGroups != null ? ' ' +
+                // @formatter:off
+                Localization.lang("Accepting the change replaces the complete groups tree with the externally modified groups tree.") : "")
+                // @formatter:on
                 + "</html>");
         // JZTODO lyrics
     }

--- a/src/main/java/net/sf/jabref/collab/PreambleChange.java
+++ b/src/main/java/net/sf/jabref/collab/PreambleChange.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2015 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -33,7 +33,7 @@ class PreambleChange extends Change {
 
 
     public PreambleChange(String tmp, String mem, String disk) {
-        super("Changed preamble");
+        super(Localization.lang("Changed preamble"));
         this.disk = disk;
         this.mem = mem;
 
@@ -41,13 +41,13 @@ class PreambleChange extends Change {
         text.append("<FONT SIZE=3>");
         text.append("<H2>").append(Localization.lang("Changed preamble")).append("</H2>");
 
-        if (disk != null && !disk.isEmpty()) {
+        if ((disk != null) && !disk.isEmpty()) {
             text.append("<H3>").append(Localization.lang("Value set externally")).append(":</H3>" + "<CODE>").append(disk).append("</CODE>");
         } else {
             text.append("<H3>").append(Localization.lang("Value cleared externally")).append("</H3>");
         }
 
-        if (mem != null && !mem.isEmpty()) {
+        if ((mem != null) && !mem.isEmpty()) {
             text.append("<H3>").append(Localization.lang("Current value")).append(":</H3>" + "<CODE>").append(mem).append("</CODE>");
         }
 

--- a/src/main/java/net/sf/jabref/collab/StringAddChange.java
+++ b/src/main/java/net/sf/jabref/collab/StringAddChange.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2015 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -32,22 +32,22 @@ import net.sf.jabref.gui.undo.UndoableInsertString;
 
 class StringAddChange extends Change {
 
-    private static final long serialVersionUID = 1L;
-
     private final BibtexString string;
 
     private final InfoPane tp = new InfoPane();
     private final JScrollPane sp = new JScrollPane(tp);
-    
+
     private static final Log LOGGER = LogFactory.getLog(StringAddChange.class);
 
 
     public StringAddChange(BibtexString string) {
-        name = Localization.lang("Added string") + ": '" + string.getName() + '\'';
+        super(Localization.lang("Added string") + ": '" + string.getName() + '\'');
         this.string = string;
-
-        tp.setText("<HTML><H2>" + Localization.lang("Added string") + "</H2><H3>" + Localization.lang("Label") + ":</H3>" + string.getName() + "<H3>" + Localization.lang("Content") + ":</H3>" + string.getContent() + "</HTML>");
-
+        // @formatter:off
+        tp.setText("<HTML><H2>" + Localization.lang("Added string") + "</H2><H3>" +
+                Localization.lang("Label") + ":</H3>" + string.getName() + "<H3>" +
+                Localization.lang("Content") + ":</H3>" + string.getContent() + "</HTML>");
+        // @formatter:on
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/collab/StringChange.java
+++ b/src/main/java/net/sf/jabref/collab/StringChange.java
@@ -33,7 +33,6 @@ import net.sf.jabref.gui.undo.UndoableStringChange;
 
 class StringChange extends Change {
 
-    private static final long serialVersionUID = 1L;
     private final BibtexString string;
     private final String mem;
     private final String disk;
@@ -47,8 +46,8 @@ class StringChange extends Change {
 
 
     public StringChange(BibtexString string, BibtexString tmpString, String label, String mem, String disk) {
+        super(Localization.lang("Modified string") + ": '" + label + '\'');
         this.tmpString = tmpString;
-        name = Localization.lang("Modified string") + ": '" + label + '\'';
         this.string = string;
         this.label = label;
         this.mem = mem;

--- a/src/main/java/net/sf/jabref/collab/StringNameChange.java
+++ b/src/main/java/net/sf/jabref/collab/StringNameChange.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2015 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -33,21 +33,19 @@ import net.sf.jabref.gui.undo.UndoableStringChange;
 
 class StringNameChange extends Change {
 
-    private static final long serialVersionUID = 1L;
-    
     private final BibtexString string;
     private final String mem;
     private final String disk;
     private final String content;
     private final BibtexString tmpString;
-    
+
     private static final Log LOGGER = LogFactory.getLog(StringNameChange.class);
 
 
     public StringNameChange(BibtexString string, BibtexString tmpString,
             String mem, String tmp, String disk, String content) {
+        super(Localization.lang("Renamed string") + ": '" + tmp + '\'');
         this.tmpString = tmpString;
-        name = Localization.lang("Renamed string") + ": '" + tmp + '\'';
         this.string = string;
         this.content = content;
         this.mem = mem;

--- a/src/main/java/net/sf/jabref/collab/StringRemoveChange.java
+++ b/src/main/java/net/sf/jabref/collab/StringRemoveChange.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2015 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -32,25 +32,28 @@ class StringRemoveChange extends Change {
 
 
     private static final long serialVersionUID = 1L;
-    
+
     private final BibtexString string;
     private final BibtexString inMem;
 
     private final InfoPane tp = new InfoPane();
     private final JScrollPane sp = new JScrollPane(tp);
     private final BibtexString tmpString;
-    
+
     private static final Log LOGGER = LogFactory.getLog(StringRemoveChange.class);
 
 
     public StringRemoveChange(BibtexString string, BibtexString tmpString, BibtexString inMem) {
+        super(Localization.lang("Removed string") + ": '" + string.getName() + '\'');
         this.tmpString = tmpString;
-        name = Localization.lang("Removed string") + ": '" + string.getName() + '\'';
         this.string = string;
         this.inMem = inMem; // Holds the version in memory. Check if it has been modified...?
 
-        tp.setText("<HTML><H2>" + Localization.lang("Removed string") + "</H2><H3>" + Localization.lang("Label") + ":</H3>" + string.getName() + "<H3>" + Localization.lang("Content") + ":</H3>" + string.getContent() + "</HTML>");
-
+        // @formatter:off
+        tp.setText("<HTML><H2>" + Localization.lang("Removed string") + "</H2><H3>" +
+                Localization.lang("Label") + ":</H3>" + string.getName() + "<H3>" +
+                Localization.lang("Content") + ":</H3>" + string.getContent() + "</HTML>");
+        // @formatter:on
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/exporter/ExpandEndnoteFilters.java
+++ b/src/main/java/net/sf/jabref/exporter/ExpandEndnoteFilters.java
@@ -62,8 +62,8 @@ public class ExpandEndnoteFilters extends MnemonicAwareAction implements Worker 
         //    filename += ".zip";
         file = new File(filename);
         if (file.exists()) {
-            int confirm = JOptionPane.showConfirmDialog(frame, '\'' + file.getName() + "' " +
-                    Localization.lang("exists. Overwrite file?"),
+            int confirm = JOptionPane.showConfirmDialog(frame,
+                    Localization.lang("'%0' exists. Overwrite file?", file.getName()),
                     Localization.lang("Unpack EndNote filter set"), JOptionPane.OK_CANCEL_OPTION);
             if (confirm != JOptionPane.OK_OPTION) {
                 return;

--- a/src/main/java/net/sf/jabref/exporter/ExportFormats.java
+++ b/src/main/java/net/sf/jabref/exporter/ExportFormats.java
@@ -190,7 +190,7 @@ public class ExportFormats {
                     if (file.exists()) {
                         // Warn that the file exists:
                         if (JOptionPane.showConfirmDialog(frame,
-                                '\'' + file.getName() + "' " + Localization.lang("exists. Overwrite file?"),
+                                Localization.lang("'%0' exists. Overwrite file?", file.getName()),
                                 Localization.lang("Export"), JOptionPane.OK_CANCEL_OPTION) != JOptionPane.OK_OPTION) {
                             return;
                         }

--- a/src/main/java/net/sf/jabref/exporter/ExportFormats.java
+++ b/src/main/java/net/sf/jabref/exporter/ExportFormats.java
@@ -162,7 +162,10 @@ public class ExportFormats {
             public ExportAction(JabRefFrame frame, boolean selectedOnly) {
                 this.frame = frame;
                 this.selectedOnly = selectedOnly;
-                putValue(Action.NAME, selectedOnly ? Localization.menuTitle("Export selected entries") : Localization.menuTitle("Export"));
+                // @formatter:off
+                putValue(Action.NAME, selectedOnly ? Localization.menuTitle("Export selected entries") :
+                    Localization.menuTitle("Export"));
+                // @formatter:on
             }
 
             @Override
@@ -186,9 +189,9 @@ public class ExportFormats {
                     file = new File(path);
                     if (file.exists()) {
                         // Warn that the file exists:
-                        if (JOptionPane.showConfirmDialog(frame, '\'' + file.getName() + "' "
-                                + Localization.lang("exists. Overwrite file?"), Localization.lang("Export"),
-                                JOptionPane.OK_CANCEL_OPTION) != JOptionPane.OK_OPTION) {
+                        if (JOptionPane.showConfirmDialog(frame,
+                                '\'' + file.getName() + "' " + Localization.lang("exists. Overwrite file?"),
+                                Localization.lang("Export"), JOptionPane.OK_CANCEL_OPTION) != JOptionPane.OK_OPTION) {
                             return;
                         }
                     }

--- a/src/main/java/net/sf/jabref/exporter/ExportToClipboardAction.java
+++ b/src/main/java/net/sf/jabref/exporter/ExportToClipboardAction.java
@@ -87,11 +87,12 @@ public class ExportToClipboardAction extends AbstractWorker {
         list.setSelectionInterval(0, 0);
         list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         int answer = JOptionPane.showOptionDialog(frame, list, Localization.lang("Select format"),
-                JOptionPane.YES_NO_OPTION,
-                JOptionPane.QUESTION_MESSAGE, null,
-                new String[] {Localization.lang("Ok"), Localization.lang("Cancel")},
+                JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null,
+                // @formatter:off
+                new String[] {Localization.lang("Ok"),
+                        Localization.lang("Cancel")},
                 Localization.lang("Ok"));
-
+                // @formatter:on
         if (answer == JOptionPane.NO_OPTION) {
             return;
         }

--- a/src/main/java/net/sf/jabref/exporter/FileActions.java
+++ b/src/main/java/net/sf/jabref/exporter/FileActions.java
@@ -39,7 +39,6 @@ import net.sf.jabref.bibtex.comparator.FieldComparator;
 import net.sf.jabref.bibtex.comparator.FieldComparatorStack;
 import net.sf.jabref.logic.config.SaveOrderConfig;
 import net.sf.jabref.logic.id.IdComparator;
-import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibtexDatabase;
 import net.sf.jabref.model.entry.BibtexEntry;
 import net.sf.jabref.model.entry.BibtexEntryType;
@@ -137,8 +136,8 @@ public class FileActions {
                 fw.write(formatted);
             } catch (IllegalArgumentException ex) {
                 throw new IllegalArgumentException(
-                        Localization.lang("The # character is not allowed in BibTeX strings unless escaped as in '\\#'.") + '\n'
-                        + Localization.lang("Before saving, please edit any strings containing the # character."));
+                        "The # character is not allowed in BibTeX strings unless escaped as in '\\#'.\n"
+                                + "Before saving, please edit any strings containing the # character.");
             }
 
         } else {
@@ -458,14 +457,14 @@ public class FileActions {
             try {
                 reader = new InputStreamReader(reso.openStream());
             } catch (FileNotFoundException ex) {
-                throw new IOException(Localization.lang("Could not find layout file") + ": '" + name + "'.");
+                throw new IOException("Cannot find layout file: '" + name + "'.");
             }
         } else {
             File f = new File(name);
             try {
                 reader = new FileReader(f);
             } catch (FileNotFoundException ex) {
-                throw new IOException(Localization.lang("Could not find layout file") + ": '" + name + "'.");
+                throw new IOException("Cannot find layout file: '" + name + "'.");
             }
         }
 

--- a/src/main/java/net/sf/jabref/exporter/FileActions.java
+++ b/src/main/java/net/sf/jabref/exporter/FileActions.java
@@ -188,7 +188,7 @@ public class FileActions {
             // saving failed, no matter what the reason was
             // (and they won't just quit JabRef thinking
             // everything worked and loosing data)
-            throw new SaveException(e.getMessage());
+            throw new SaveException(e.getMessage(), e.getLocalizedMessage());
         }
 
         // Get our data stream. This stream writes only to a temporary file,
@@ -262,7 +262,7 @@ public class FileActions {
             ex.printStackTrace();
             session.cancel();
             // repairAfterError(file, backup, INIT_OK);
-            throw new SaveException(ex.getMessage(), exceptionCause);
+            throw new SaveException(ex.getMessage(), ex.getLocalizedMessage(), exceptionCause);
         }
 
         return session;
@@ -373,7 +373,7 @@ public class FileActions {
         try {
             session = new SaveSession(file, encoding, backup);
         } catch (IOException e) {
-            throw new SaveException(e.getMessage());
+            throw new SaveException(e.getMessage(), e.getLocalizedMessage());
         }
 
         // Define our data stream.
@@ -435,7 +435,7 @@ public class FileActions {
         } catch (Throwable ex) {
             session.cancel();
             //repairAfterError(file, backup, status);
-            throw new SaveException(ex.getMessage(), be);
+            throw new SaveException(ex.getMessage(), ex.getLocalizedMessage(), be);
         }
 
         return session;

--- a/src/main/java/net/sf/jabref/exporter/LatexFieldFormatter.java
+++ b/src/main/java/net/sf/jabref/exporter/LatexFieldFormatter.java
@@ -19,7 +19,6 @@ import net.sf.jabref.*;
 import net.sf.jabref.gui.BibtexFields;
 import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.importer.fileformat.FieldContentParser;
-import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.strings.StringUtil;
 
 import java.util.Vector;
@@ -141,9 +140,10 @@ public class LatexFieldFormatter {
                 pos2 = content.indexOf('#', pos1 + 1);
                 if (pos2 == -1) {
                     if (!neverFailOnHashes) {
-                        throw new IllegalArgumentException(Localization.lang("The # character is not allowed in BibTeX strings unless escaped as in '\\#'.") + '\n' +
-                                Localization.lang("In JabRef, use pairs of # characters to indicate a string.") + '\n' +
-                                Localization.lang("Note that the entry causing the problem has been selected."));
+                        throw new IllegalArgumentException(
+                                "The # character is not allowed in BibTeX strings unless escaped as in '\\#'.\n"
+                                        + "In JabRef, use pairs of # characters to indicate a string.\n"
+                                        + "Note that the entry causing the problem has been selected.");
                     } else {
                         pos1 = content.length(); // just write out the rest of the text, and throw no exception
                     }

--- a/src/main/java/net/sf/jabref/exporter/SaveDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/exporter/SaveDatabaseAction.java
@@ -279,7 +279,10 @@ public class SaveDatabaseAction extends AbstractWorker {
             String tryDiff = Localization.lang("Try different encoding");
             int answer = JOptionPane.showOptionDialog(frame, builder.getPanel(), Localization.lang("Save database"),
                     JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
-                    new String[] {Localization.lang("Save"), tryDiff, Localization.lang("Cancel")}, tryDiff);
+                    // @formatter:off
+                    new String[] {Localization.lang("Save"), tryDiff,
+                            Localization.lang("Cancel")}, tryDiff);
+                    // @formatter:on
 
             if (answer == JOptionPane.NO_OPTION) {
                 // The user wants to use another encoding.

--- a/src/main/java/net/sf/jabref/exporter/SaveDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/exporter/SaveDatabaseAction.java
@@ -370,10 +370,9 @@ public class SaveDatabaseAction extends AbstractWorker {
             }
             f = new File(chosenFile);
             // Check if the file already exists:
-            if (f.exists() && (JOptionPane.showConfirmDialog
-                    (frame, '\'' + f.getName() + "' " + Localization.lang("exists. Overwrite file?"),
-                            Localization.lang("Save database"), JOptionPane.OK_CANCEL_OPTION)
-                        != JOptionPane.OK_OPTION)) {
+            if (f.exists() && (JOptionPane.showConfirmDialog(frame,
+                    Localization.lang("'%0' exists. Overwrite file?", f.getName()),
+                    Localization.lang("Save database"), JOptionPane.OK_CANCEL_OPTION) != JOptionPane.OK_OPTION)) {
                 f = null;
             }
         }

--- a/src/main/java/net/sf/jabref/exporter/SaveException.java
+++ b/src/main/java/net/sf/jabref/exporter/SaveException.java
@@ -16,7 +16,6 @@
 package net.sf.jabref.exporter;
 
 import net.sf.jabref.model.entry.BibtexEntry;
-import net.sf.jabref.logic.l10n.Localization;
 
 /**
  * Exception thrown if saving goes wrong. If caused by a specific
@@ -24,8 +23,9 @@ import net.sf.jabref.logic.l10n.Localization;
  */
 public class SaveException extends Exception {
 
-    public static final SaveException FILE_LOCKED = new SaveException(Localization.lang("Could not save, file locked by another JabRef instance."));
-    public static final SaveException BACKUP_CREATION = new SaveException(Localization.lang("Unable to create backup"));
+    public static final SaveException FILE_LOCKED = new SaveException(
+            "Could not save, file locked by another JabRef instance.");
+    public static final SaveException BACKUP_CREATION = new SaveException("Unable to create backup");
 
     private final BibtexEntry entry;
     private int status;

--- a/src/main/java/net/sf/jabref/exporter/SaveException.java
+++ b/src/main/java/net/sf/jabref/exporter/SaveException.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2015 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -15,6 +15,7 @@
 */
 package net.sf.jabref.exporter;
 
+import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibtexEntry;
 
 /**
@@ -24,15 +25,23 @@ import net.sf.jabref.model.entry.BibtexEntry;
 public class SaveException extends Exception {
 
     public static final SaveException FILE_LOCKED = new SaveException(
-            "Could not save, file locked by another JabRef instance.");
-    public static final SaveException BACKUP_CREATION = new SaveException("Unable to create backup");
+            "Could not save, file locked by another JabRef instance.",
+            Localization.lang("Could not save, file locked by another JabRef instance."));
+    public static final SaveException BACKUP_CREATION = new SaveException("Unable to create backup",
+            Localization.lang("Unable to create backup"));
 
     private final BibtexEntry entry;
     private int status;
-
+    private String localizedMessage;
 
     public SaveException(String message) {
         super(message);
+        entry = null;
+    }
+
+    public SaveException(String message, String localizedMessage) {
+        super(message);
+        this.localizedMessage = localizedMessage;
         entry = null;
     }
 
@@ -47,6 +56,12 @@ public class SaveException extends Exception {
         this.entry = entry;
     }
 
+    public SaveException(String message, String localizedMessage, BibtexEntry entry) {
+        super(message);
+        this.localizedMessage = localizedMessage;
+        this.entry = entry;
+    }
+
     public int getStatus() {
         return status;
     }
@@ -57,5 +72,14 @@ public class SaveException extends Exception {
 
     public boolean specificEntry() {
         return entry != null;
+    }
+
+    @Override
+    public String getLocalizedMessage() {
+        if (localizedMessage == null) {
+            return getMessage();
+        } else {
+            return localizedMessage;
+        }
     }
 }

--- a/src/main/java/net/sf/jabref/exporter/SaveSession.java
+++ b/src/main/java/net/sf/jabref/exporter/SaveSession.java
@@ -16,7 +16,6 @@
 package net.sf.jabref.exporter;
 
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.io.FileBasedLock;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.Globals;
@@ -128,8 +127,7 @@ public class SaveSession {
             // have a clean copy in tmp. However, we just failed to copy tmp to file, so it's not likely that
             // repeating the action will have a different result.
             // On the other hand, our temporary file should still be clean, and won't be deleted.
-            throw new SaveException(
-                    Localization.lang("Save failed while committing changes") + ": " + ex2.getMessage());
+            throw new SaveException("Save failed while committing changes: " + ex2.getMessage());
         } finally {
             if (useLockFile) {
                 deleteLockFile();

--- a/src/main/java/net/sf/jabref/exporter/SaveSession.java
+++ b/src/main/java/net/sf/jabref/exporter/SaveSession.java
@@ -16,6 +16,7 @@
 package net.sf.jabref.exporter;
 
 import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.io.FileBasedLock;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.Globals;
@@ -68,11 +69,11 @@ public class SaveSession {
         useLockFile = Globals.prefs.getBoolean(JabRefPreferences.USE_LOCK_FILES);
         this.backup = backup;
         this.encoding = encoding;
-	/* Using 
+	/* Using
 	   try (FileOutputStream fos = new FileOutputStream(tmp)) {
 	       writer = new VerifyingWriter(fos, encoding);
 	   }
-	   doesn't work since fos is closed after assigning write, 
+	   doesn't work since fos is closed after assigning write,
 	   leading to that fos may never be closed at all
 	 */
         writer = new VerifyingWriter(new FileOutputStream(tmp), encoding);
@@ -103,7 +104,6 @@ public class SaveSession {
             } catch (IOException ex) {
                 ex.printStackTrace();
                 throw SaveException.BACKUP_CREATION;
-                //throw new SaveException(Globals.lang("Save failed during backup creation")+": "+ex.getMessage());
             }
         }
         try {
@@ -127,7 +127,8 @@ public class SaveSession {
             // have a clean copy in tmp. However, we just failed to copy tmp to file, so it's not likely that
             // repeating the action will have a different result.
             // On the other hand, our temporary file should still be clean, and won't be deleted.
-            throw new SaveException("Save failed while committing changes: " + ex2.getMessage());
+            throw new SaveException("Save failed while committing changes: " + ex2.getMessage(),
+                    Localization.lang("Save failed while committing changes: %0", ex2.getMessage()));
         } finally {
             if (useLockFile) {
                 deleteLockFile();

--- a/src/main/java/net/sf/jabref/exporter/layout/LayoutEntry.java
+++ b/src/main/java/net/sf/jabref/exporter/layout/LayoutEntry.java
@@ -29,7 +29,6 @@ import net.sf.jabref.exporter.layout.format.NameFormatter;
 import net.sf.jabref.exporter.layout.format.NotFoundFormatter;
 import net.sf.jabref.gui.preftabs.NameFormatterTab;
 import net.sf.jabref.logic.l10n.Encodings;
-import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibtexDatabase;
 import net.sf.jabref.model.entry.BibtexEntry;
 import net.sf.jabref.util.Util;
@@ -392,7 +391,7 @@ class LayoutEntry {
                     return (LayoutFormatter) Class.forName(className).newInstance();
                 }
             } catch (ClassNotFoundException ex) {
-                throw new Exception(Localization.lang("Formatter not found") + ": " + className);
+                throw new Exception("Formatter not found: " + className);
             } catch (InstantiationException ex) {
                 throw new Exception(className + " cannot be instantiated.");
             } catch (IllegalAccessException ex) {

--- a/src/main/java/net/sf/jabref/exporter/layout/LayoutHelper.java
+++ b/src/main/java/net/sf/jabref/exporter/layout/LayoutHelper.java
@@ -20,8 +20,6 @@ import java.io.PushbackReader;
 import java.io.Reader;
 import java.util.Vector;
 
-import net.sf.jabref.logic.l10n.Localization;
-
 /**
  * Helper class to get a Layout object.
  *
@@ -309,7 +307,8 @@ public class LayoutHelper {
                             parsedEntries.size() - 1)) {
                         lastFive.append(entry.s);
                     }
-                    throw new StringIndexOutOfBoundsException(Localization.lang("Backslash parsing error near") + " \'"
+                    throw new StringIndexOutOfBoundsException(
+                            "Backslash parsing error near \'"
                             + lastFive.toString().replace("\n", " ") + '\'');
                 }
 

--- a/src/main/java/net/sf/jabref/external/DownloadExternalFile.java
+++ b/src/main/java/net/sf/jabref/external/DownloadExternalFile.java
@@ -188,10 +188,9 @@ public class DownloadExternalFile {
                     return false;
                 }
                 if (f.exists()) {
-                    return JOptionPane.showConfirmDialog
-                            (frame, "'" + f.getName() + "' " + Localization.lang("exists. Overwrite file?"),
-                                    Localization.lang("Download file"), JOptionPane.OK_CANCEL_OPTION)
-                    == JOptionPane.OK_OPTION;
+                    return JOptionPane.showConfirmDialog(frame,
+                            Localization.lang("'%0' exists. Overwrite file?", f.getName()),
+                            Localization.lang("Download file"), JOptionPane.OK_CANCEL_OPTION) == JOptionPane.OK_OPTION;
                 } else {
                     return true;
                 }

--- a/src/main/java/net/sf/jabref/external/DownloadExternalFile.java
+++ b/src/main/java/net/sf/jabref/external/DownloadExternalFile.java
@@ -81,7 +81,10 @@ public class DownloadExternalFile {
         try {
             url = new URL(res);
         } catch (MalformedURLException ex1) {
-            JOptionPane.showMessageDialog(frame, Localization.lang("Invalid URL"), Localization.lang("Download file"), JOptionPane.ERROR_MESSAGE);
+            // @formatter:off
+            JOptionPane.showMessageDialog(frame, Localization.lang("Invalid URL"),
+                    Localization.lang("Download file"), JOptionPane.ERROR_MESSAGE);
+            // @formatter:on
             return;
         }
 
@@ -180,9 +183,8 @@ public class DownloadExternalFile {
                 File f = directory != null ? expandFilename(directory, entry.getLink())
                         : new File(entry.getLink());
                 if (f.isDirectory()) {
-                    JOptionPane.showMessageDialog(frame,
-                            Localization.lang("Target file cannot be a directory."), Localization.lang("Download file"),
-                            JOptionPane.ERROR_MESSAGE);
+                    JOptionPane.showMessageDialog(frame, Localization.lang("Target file cannot be a directory."),
+                            Localization.lang("Download file"), JOptionPane.ERROR_MESSAGE);
                     return false;
                 }
                 if (f.exists()) {

--- a/src/main/java/net/sf/jabref/external/DroppedFileHandler.java
+++ b/src/main/java/net/sf/jabref/external/DroppedFileHandler.java
@@ -509,7 +509,8 @@ public class DroppedFileHandler {
         File toFile = new File(dirs[found] + System.getProperty("file.separator") + destFilename);
         if (toFile.exists()) {
             int answer = JOptionPane.showConfirmDialog(frame,
-                    toFile.getAbsolutePath() + " exists. Overwrite?", "Overwrite file?",
+                    Localization.lang("'%0' exists. Overwrite file?", toFile.getAbsolutePath()),
+                    Localization.lang("Overwrite file?"),
                     JOptionPane.YES_NO_OPTION);
             if (answer == JOptionPane.NO_OPTION) {
                 return false;
@@ -518,8 +519,10 @@ public class DroppedFileHandler {
 
         if (!fromFile.renameTo(toFile)) {
             JOptionPane.showMessageDialog(frame,
-                    "There was an error moving the file. Please move the file manually and link in place.",
-                    "Error moving file", JOptionPane.ERROR_MESSAGE);
+                    // @formatter:off
+                    Localization.lang("There was an error moving the file. Please move the file manually and link in place."),
+                    Localization.lang("Error moving file"), JOptionPane.ERROR_MESSAGE);
+                    // @formatter:on
             return false;
         } else {
             return true;
@@ -564,7 +567,7 @@ public class DroppedFileHandler {
 
         if (destFile.exists()) {
             int answer = JOptionPane.showConfirmDialog(frame,
-                    "'" + destFile.getPath() + "' " + Localization.lang("exists. Overwrite?"),
+                    Localization.lang("'%0' exists. Overwrite file?", destFile.getPath()),
                     Localization.lang("File exists"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
             if (answer == JOptionPane.NO_OPTION) {
                 return false;

--- a/src/main/java/net/sf/jabref/external/DroppedFileHandler.java
+++ b/src/main/java/net/sf/jabref/external/DroppedFileHandler.java
@@ -88,7 +88,7 @@ public class DroppedFileHandler {
         FormLayout layout = new FormLayout("left:15dlu,pref,pref,pref", "bottom:14pt,pref,pref,pref,pref");
         layout.setRowGroups(new int[][]{{1, 2, 3, 4, 5}});
         FormBuilder builder = FormBuilder.create().layout(layout);
-        
+
         builder.add(linkInPlace).xyw(1, 1, 4);
         builder.add(destDirLabel).xyw(1, 2, 4);
         builder.add(copyRadioButton).xyw(2, 3, 3);
@@ -270,15 +270,15 @@ public class DroppedFileHandler {
             return false;
         }
 
-        if (xmpEntriesInFile == null || xmpEntriesInFile.isEmpty()) {
+        if ((xmpEntriesInFile == null) || xmpEntriesInFile.isEmpty()) {
             return false;
         }
 
         JLabel confirmationMessage = new JLabel(
                 Localization.lang("The PDF contains one or several bibtex-records.\nDo you want to import these as new entries into the current database?"));
 
-        int reply = JOptionPane.showConfirmDialog(frame, confirmationMessage, Localization.lang(
-                        "XMP metadata found in PDF: %0", fileName), JOptionPane.YES_NO_CANCEL_OPTION,
+        int reply = JOptionPane.showConfirmDialog(frame, confirmationMessage,
+                Localization.lang("XMP metadata found in PDF: %0", fileName), JOptionPane.YES_NO_CANCEL_OPTION,
                 JOptionPane.QUESTION_MESSAGE);
 
         if (reply == JOptionPane.CANCEL_OPTION) {
@@ -293,10 +293,10 @@ public class DroppedFileHandler {
         /*
          * TODO Extract Import functionality from ImportMenuItem then we could
          * do:
-         * 
+         *
          * ImportMenuItem importer = new ImportMenuItem(frame, (mainTable ==
          * null), new PdfXmpImporter());
-         * 
+         *
          * importer.automatedImport(new String[] { fileName });
          */
 
@@ -343,7 +343,7 @@ public class DroppedFileHandler {
     //
     private boolean showLinkMoveCopyRenameDialog(String linkFileName, ExternalFileType fileType,
                                                  BibtexEntry entry, boolean newEntry, final boolean multipleEntries, BibtexDatabase database) {
-       
+
         String dialogTitle = Localization.lang("Link to file %0", linkFileName);
         String[] dirs = panel.metaData().getFileDirectory(Globals.FILE_FIELD);
         int found = -1;
@@ -450,13 +450,13 @@ public class DroppedFileHandler {
         if (avoidDuplicate) {
             // For comparison, find the absolute filename:
             String[] dirs = panel.metaData().getFileDirectory(Globals.FILE_FIELD);
-            String absFilename = !new File(filename).isAbsolute() && dirs.length > 0 ?
+            String absFilename = !new File(filename).isAbsolute() && (dirs.length > 0) ?
                     FileUtil.expandFilename(filename, dirs).getAbsolutePath() : filename;
 
             for (int i = 0; i < tm.getRowCount(); i++) {
                 FileListEntry flEntry = tm.getEntry(i);
                 // Find the absolute filename for this existing link:
-                String absName = !new File(flEntry.getLink()).isAbsolute() && dirs.length > 0 ?
+                String absName = !new File(flEntry.getLink()).isAbsolute() && (dirs.length > 0) ?
                         FileUtil.expandFilename(flEntry.getLink(), dirs).getAbsolutePath() : flEntry.getLink();
                 System.out.println("absName: " + absName);
                 // If the filenames are equal, we don't need to link, so we simply return:
@@ -563,9 +563,9 @@ public class DroppedFileHandler {
         }
 
         if (destFile.exists()) {
-            int answer = JOptionPane.showConfirmDialog(frame, "'" + destFile.getPath() + "' "
-                            + Localization.lang("exists. Overwrite?"), Localization.lang("File exists"),
-                    JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
+            int answer = JOptionPane.showConfirmDialog(frame,
+                    "'" + destFile.getPath() + "' " + Localization.lang("exists. Overwrite?"),
+                    Localization.lang("File exists"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
             if (answer == JOptionPane.NO_OPTION) {
                 return false;
             }

--- a/src/main/java/net/sf/jabref/external/MoveFileAction.java
+++ b/src/main/java/net/sf/jabref/external/MoveFileAction.java
@@ -80,7 +80,7 @@ public class MoveFileAction extends AbstractAction {
         if (!file.isAbsolute()) {
             file = FileUtil.expandFilename(ln, dirs);
         }
-        if (file != null && file.exists()) {
+        if ((file != null) && file.exists()) {
             // Ok, we found the file. Now get a new name:
             String extension = null;
             if (flEntry.getType() != null) {
@@ -133,10 +133,10 @@ public class MoveFileAction extends AbstractAction {
                 }
                 newFile = new File(chosenFile);
                 // Check if the file already exists:
-                if (newFile.exists() && JOptionPane.showConfirmDialog
-                        (frame, "'" + newFile.getName() + "' " + Localization.lang("exists. Overwrite file?"),
-                                Localization.lang("Move/Rename file"), JOptionPane.OK_CANCEL_OPTION)
-                            != JOptionPane.OK_OPTION) {
+                if (newFile.exists() && (JOptionPane.showConfirmDialog(frame,
+                        Localization.lang("'%0' exists. Overwrite file?", newFile.getName()),
+                        Localization.lang("Move/Rename file"),
+                        JOptionPane.OK_CANCEL_OPTION) != JOptionPane.OK_OPTION)) {
                     if (!toFileDir) {
                         repeat = true;
                     } else {
@@ -157,8 +157,8 @@ public class MoveFileAction extends AbstractAction {
                         // Relativise path, if possible.
                         String canPath = new File(dirs[found]).getCanonicalPath();
                         if (newFile.getCanonicalPath().startsWith(canPath)) {
-                            if (newFile.getCanonicalPath().length() > canPath.length() &&
-                                    newFile.getCanonicalPath().charAt(canPath.length()) == File.separatorChar) {
+                            if ((newFile.getCanonicalPath().length() > canPath.length()) &&
+                                    (newFile.getCanonicalPath().charAt(canPath.length()) == File.separatorChar)) {
                                 flEntry.setLink(newFile.getCanonicalPath().substring(1 + canPath.length()));
                             } else {
                                 flEntry.setLink(newFile.getCanonicalPath().substring(canPath.length()));

--- a/src/main/java/net/sf/jabref/external/SynchronizeFileField.java
+++ b/src/main/java/net/sf/jabref/external/SynchronizeFileField.java
@@ -220,9 +220,12 @@ public class SynchronizeFileField extends AbstractWorker {
 
                         // Unless we deleted this link, see if its file type is recognized:
                         if (!deleted && (flEntry.getType() instanceof UnknownExternalFileType)) {
-                            String[] options = new String[]
-                                    {Localization.lang("Define '%0'", flEntry.getType().getName()),
-                                            Localization.lang("Change file type"), Localization.lang("Cancel")};
+                            // @formatter:off
+                            String[] options = new String[] {
+                                    Localization.lang("Define '%0'", flEntry.getType().getName()),
+                                    Localization.lang("Change file type"),
+                                    Localization.lang("Cancel")};
+                            // @formatter:on
                             String defOption = options[0];
                             int answer = JOptionPane.showOptionDialog(panel.frame(), Localization.lang("One or more file links are of the type '%0', which is undefined. What do you want to do?",
                                     flEntry.getType().getName()),
@@ -349,11 +352,10 @@ public class SynchronizeFileField extends AbstractWorker {
 
             FormLayout layout = new FormLayout("fill:pref", "pref, 2dlu, pref, 2dlu, pref, pref, pref, 2dlu, pref, 2dlu, pref, 2dlu, pref");
             FormBuilder builder = FormBuilder.create().layout(layout);
-            description = new JLabel("<HTML>" +
-                    Localization.lang(//"This function helps you keep your external %0 links up-to-date." +
-                            "Attempt to autoset %0 links for your entries. Autoset works if "
-                            + "a %0 file in your %0 directory or a subdirectory<BR>is named identically to an entry's BibTeX key, plus extension.", fn)
-            + "</HTML>");
+            description = new JLabel("<HTML>" + Localization.lang(
+                    "Attempt to autoset %0 links for your entries. Autoset works if "
+                            + "a %0 file in your %0 directory or a subdirectory<BR>is named identically to an entry's BibTeX key, plus extension.",
+                    fn) + "</HTML>");
 
             builder.addSeparator(Localization.lang("Autoset")).xy(1, 1);
             builder.add(description).xy(1, 3);

--- a/src/main/java/net/sf/jabref/external/WriteXMPEntryEditorAction.java
+++ b/src/main/java/net/sf/jabref/external/WriteXMPEntryEditorAction.java
@@ -44,7 +44,8 @@ public class WriteXMPEntryEditorAction extends AbstractAction {
     public WriteXMPEntryEditorAction(BasePanel panel, EntryEditor editor) {
         this.panel = panel;
         this.editor = editor;
-        putValue(Action.NAME, Localization.lang("Write XMP")); // normally, this call should be without "Globals.lang". However, the string "Write XMP" is also used in non-menu places and therefore, the translation must be also available at Globals.lang()
+        // normally, the next call should be without "Localization.lang". However, the string "Write XMP" is also used in non-menu places and therefore, the translation must be also available at Localization.lang()
+        putValue(Action.NAME, Localization.lang("Write XMP"));
         putValue(Action.SMALL_ICON, IconTheme.JabRefIcon.WRITE_XMP.getIcon());
         putValue(Action.SHORT_DESCRIPTION, Localization.lang("Write BibtexEntry as XMP-metadata to PDF."));
     }

--- a/src/main/java/net/sf/jabref/groups/GroupSelector.java
+++ b/src/main/java/net/sf/jabref/groups/GroupSelector.java
@@ -350,7 +350,7 @@ public class GroupSelector extends SidePaneComponent implements TreeSelectionLis
         autoGroup.setToolTipText(Localization.lang("Automatically create groups for database."));
         invCb.setToolTipText(Localization.lang("Show entries *not* in group selection"));
         showOverlappingGroups.setToolTipText( // JZTODO lyrics
-                "Highlight groups that contain entries contained in any currently selected group");
+                Localization.lang("Highlight groups that contain entries contained in any currently selected group"));
         floatCb.setToolTipText(Localization.lang("Move entries in group selection to the top"));
         highlCb.setToolTipText(Localization.lang("Gray out entries not in group selection"));
         select.setToolTipText(Localization.lang("Select entries in group selection"));

--- a/src/main/java/net/sf/jabref/groups/GroupSelector.java
+++ b/src/main/java/net/sf/jabref/groups/GroupSelector.java
@@ -80,14 +80,12 @@ import org.apache.commons.logging.LogFactory;
 /**
  * The whole UI component holding the groups tree and the buttons
  */
-public class GroupSelector extends SidePaneComponent implements
-TreeSelectionListener, ActionListener {
+public class GroupSelector extends SidePaneComponent implements TreeSelectionListener, ActionListener {
 
     private static final Log LOGGER = LogFactory.getLog(GroupSelector.class);
 
     private final JButton newButton = new JButton(IconTheme.JabRefIcon.ADD_NOBOX.getSmallIcon());
-    private final JButton refresh = new JButton(
-            IconTheme.JabRefIcon.REFRESH.getSmallIcon());
+    private final JButton refresh = new JButton(IconTheme.JabRefIcon.REFRESH.getSmallIcon());
     private final JButton autoGroup = new JButton(IconTheme.JabRefIcon.AUTO_GROUP.getSmallIcon());
     private final JButton openset = new JButton(Localization.lang("Settings"));
     Color bgColor = Color.white;
@@ -101,8 +99,7 @@ TreeSelectionListener, ActionListener {
     private final JRadioButtonMenuItem grayOut;
     private final JRadioButtonMenuItem andCb = new JRadioButtonMenuItem(Localization.lang("Intersection"), true);
     private final JRadioButtonMenuItem floatCb = new JRadioButtonMenuItem(Localization.lang("Float"), true);
-    private final JCheckBoxMenuItem invCb = new JCheckBoxMenuItem(Localization.lang("Inverted"),
-            false);
+    private final JCheckBoxMenuItem invCb = new JCheckBoxMenuItem(Localization.lang("Inverted"), false);
     private final JCheckBoxMenuItem select = new JCheckBoxMenuItem(Localization.lang("Select matches"), false);
     private final JCheckBoxMenuItem showOverlappingGroups = new JCheckBoxMenuItem(
             Localization.lang("Highlight overlapping groups")); // JZTODO lyrics
@@ -110,15 +107,17 @@ TreeSelectionListener, ActionListener {
             Localization.lang("Show number of elements contained in each group"));
     private final JCheckBoxMenuItem autoAssignGroup = new JCheckBoxMenuItem(
             Localization.lang("Automatically assign new entry to selected groups"));
-    private final JCheckBoxMenuItem editModeCb = new JCheckBoxMenuItem(Localization.lang("Edit Group Membership"), false);
-    private final Border editModeBorder = BorderFactory.createTitledBorder(BorderFactory.createMatteBorder(2, 2, 2, 2, Color.RED),
-            "Edit mode", TitledBorder.RIGHT, TitledBorder.TOP, Font.getFont("Default"), Color.RED);
+    private final JCheckBoxMenuItem editModeCb = new JCheckBoxMenuItem(Localization.lang("Edit Group Membership"),
+            false);
+    private final Border editModeBorder = BorderFactory.createTitledBorder(
+            BorderFactory.createMatteBorder(2, 2, 2, 2, Color.RED), "Edit mode", TitledBorder.RIGHT, TitledBorder.TOP,
+            Font.getFont("Default"), Color.RED);
     private boolean editModeIndicator;
 
 
     /**
-     * The first element for each group defines which field to use for the
-     * quicksearch. The next two define the name and regexp for the group.
+     * The first element for each group defines which field to use for the quicksearch. The next two define the name and
+     * regexp for the group.
      */
     public GroupSelector(JabRefFrame frame, SidePaneManager manager) {
         super(manager, IconTheme.JabRefIcon.TOGGLE_GROUPS.getIcon(), Localization.lang("Groups"));
@@ -157,8 +156,7 @@ TreeSelectionListener, ActionListener {
 
             @Override
             public void stateChanged(ChangeEvent event) {
-                Globals.prefs.putBoolean(JabRefPreferences.GROUP_SHOW_OVERLAPPING,
-                        showOverlappingGroups.isSelected());
+                Globals.prefs.putBoolean(JabRefPreferences.GROUP_SHOW_OVERLAPPING, showOverlappingGroups.isSelected());
                 if (!showOverlappingGroups.isSelected()) {
                     groupsTree.setHighlight2Cells(null);
                 }
@@ -189,8 +187,7 @@ TreeSelectionListener, ActionListener {
             highlCb.setSelected(true);
             floatCb.setSelected(false);
         }
-        JRadioButtonMenuItem orCb = new JRadioButtonMenuItem(Localization.lang("Union"),
-                false);
+        JRadioButtonMenuItem orCb = new JRadioButtonMenuItem(Localization.lang("Union"), false);
         if (Globals.prefs.getBoolean(JabRefPreferences.GROUP_INTERSECT_SELECTIONS)) {
             andCb.setSelected(true);
             orCb.setSelected(false);
@@ -203,7 +200,8 @@ TreeSelectionListener, ActionListener {
 
             @Override
             public void stateChanged(ChangeEvent e) {
-                Globals.prefs.putBoolean(JabRefPreferences.GROUP_SHOW_NUMBER_OF_ELEMENTS, showNumberOfElements.isSelected());
+                Globals.prefs.putBoolean(JabRefPreferences.GROUP_SHOW_NUMBER_OF_ELEMENTS,
+                        showNumberOfElements.isSelected());
                 if (groupsTree != null) {
                     groupsTree.invalidate();
                     groupsTree.validate();
@@ -256,7 +254,8 @@ TreeSelectionListener, ActionListener {
                     // settings.setVisible(false);
                 } else {
                     JButton src = (JButton) e.getSource();
-                    showNumberOfElements.setSelected(Globals.prefs.getBoolean(JabRefPreferences.GROUP_SHOW_NUMBER_OF_ELEMENTS));
+                    showNumberOfElements
+                            .setSelected(Globals.prefs.getBoolean(JabRefPreferences.GROUP_SHOW_NUMBER_OF_ELEMENTS));
                     autoAssignGroup.setSelected(Globals.prefs.getBoolean(JabRefPreferences.AUTO_ASSIGN_GROUP));
                     settings.show(src, 0, openset.getHeight());
                 }
@@ -274,7 +273,8 @@ TreeSelectionListener, ActionListener {
                 GroupSelector.this.revalidate();
                 GroupSelector.this.repaint();
                 Globals.prefs.putInt(JabRefPreferences.GROUPS_VISIBLE_ROWS, i);
-                LOGGER.info("Height: " + GroupSelector.this.getHeight() + "; Preferred height: " + GroupSelector.this.getPreferredSize().getHeight());
+                LOGGER.info("Height: " + GroupSelector.this.getHeight() + "; Preferred height: "
+                        + GroupSelector.this.getPreferredSize().getHeight());
             }
         });
         JButton reduce = new JButton(IconTheme.JabRefIcon.REMOVE_ROW.getSmallIcon());
@@ -314,7 +314,8 @@ TreeSelectionListener, ActionListener {
         newButton.setMinimumSize(butDim);
         refresh.setPreferredSize(butDim);
         refresh.setMinimumSize(butDim);
-        JButton helpButton = new HelpAction(frame.helpDiag, GUIGlobals.groupsHelp, Localization.lang("Help on groups")).getIconButton();
+        JButton helpButton = new HelpAction(frame.helpDiag, GUIGlobals.groupsHelp, Localization.lang("Help on groups"))
+                .getIconButton();
         helpButton.setPreferredSize(butDim);
         helpButton.setMinimumSize(butDim);
         autoGroup.setPreferredSize(butDim);
@@ -344,10 +345,8 @@ TreeSelectionListener, ActionListener {
         grayOut.addActionListener(this);
         newButton.setToolTipText(Localization.lang("New group"));
         refresh.setToolTipText(Localization.lang("Refresh view"));
-        andCb.setToolTipText(Localization.lang("Display only entries belonging to all selected"
-                + " groups."));
-        orCb.setToolTipText(Localization.lang("Display all entries belonging to one or more "
-                + "of the selected groups."));
+        andCb.setToolTipText(Localization.lang("Display only entries belonging to all selected groups."));
+        orCb.setToolTipText(Localization.lang("Display all entries belonging to one or more of the selected groups."));
         autoGroup.setToolTipText(Localization.lang("Automatically create groups for database."));
         invCb.setToolTipText(Localization.lang("Show entries *not* in group selection"));
         showOverlappingGroups.setToolTipText( // JZTODO lyrics
@@ -396,8 +395,7 @@ TreeSelectionListener, ActionListener {
         groupsTree = new GroupsTree(this);
         groupsTree.addTreeSelectionListener(this);
         groupsTree.setModel(groupsTreeModel = new DefaultTreeModel(groupsRoot));
-        JScrollPane sp = new JScrollPane(groupsTree,
-                JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+        JScrollPane sp = new JScrollPane(groupsTree, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
                 JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
         revalidateGroups();
         con.gridwidth = GridBagConstraints.REMAINDER;
@@ -447,8 +445,7 @@ TreeSelectionListener, ActionListener {
         updateBorder(editModeIndicator);
         definePopup();
         NodeAction moveNodeUpAction = new MoveNodeUpAction();
-        moveNodeUpAction.putValue(Action.ACCELERATOR_KEY,
-                KeyStroke.getKeyStroke(KeyEvent.VK_UP, KeyEvent.CTRL_MASK));
+        moveNodeUpAction.putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_UP, KeyEvent.CTRL_MASK));
         NodeAction moveNodeDownAction = new MoveNodeDownAction();
         moveNodeDownAction.putValue(Action.ACCELERATOR_KEY,
                 KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, KeyEvent.CTRL_MASK));
@@ -514,11 +511,9 @@ TreeSelectionListener, ActionListener {
                 if (node.isRoot()) {
                     return;
                 }
-                if ((e.getClickCount() == 2)
-                        && (e.getButton() == MouseEvent.BUTTON1)) { // edit
+                if ((e.getClickCount() == 2) && (e.getButton() == MouseEvent.BUTTON1)) { // edit
                     editGroupAction.actionPerformed(null); // dummy event
-                } else if ((e.getClickCount() == 1)
-                        && (e.getButton() == MouseEvent.BUTTON1)) {
+                } else if ((e.getClickCount() == 1) && (e.getButton() == MouseEvent.BUTTON1)) {
                     annotationEvent(node);
                 }
             }
@@ -584,20 +579,18 @@ TreeSelectionListener, ActionListener {
                 removeGroupAndSubgroupsPopupAction.setEnabled(true);
                 removeGroupKeepSubgroupsPopupAction.setEnabled(true);
             }
-            expandSubtreePopupAction.setEnabled(groupsTree.isCollapsed(path)
-                    || groupsTree.hasCollapsedDescendant(path));
-            collapseSubtreePopupAction.setEnabled(groupsTree.isExpanded(path)
-                    || groupsTree.hasExpandedDescendant(path));
+            expandSubtreePopupAction
+                    .setEnabled(groupsTree.isCollapsed(path) || groupsTree.hasCollapsedDescendant(path));
+            collapseSubtreePopupAction
+                    .setEnabled(groupsTree.isExpanded(path) || groupsTree.hasExpandedDescendant(path));
             sortSubmenu.setEnabled(!node.isLeaf());
             removeSubgroupsPopupAction.setEnabled(!node.isLeaf());
             moveNodeUpPopupAction.setEnabled(node.canMoveUp());
             moveNodeDownPopupAction.setEnabled(node.canMoveDown());
             moveNodeLeftPopupAction.setEnabled(node.canMoveLeft());
             moveNodeRightPopupAction.setEnabled(node.canMoveRight());
-            moveSubmenu.setEnabled(moveNodeUpPopupAction.isEnabled()
-                    || moveNodeDownPopupAction.isEnabled()
-                    || moveNodeLeftPopupAction.isEnabled()
-                    || moveNodeRightPopupAction.isEnabled());
+            moveSubmenu.setEnabled(moveNodeUpPopupAction.isEnabled() || moveNodeDownPopupAction.isEnabled()
+                    || moveNodeLeftPopupAction.isEnabled() || moveNodeRightPopupAction.isEnabled());
             moveNodeUpPopupAction.setNode(node);
             moveNodeDownPopupAction.setNode(node);
             moveNodeLeftPopupAction.setNode(node);
@@ -605,8 +598,7 @@ TreeSelectionListener, ActionListener {
             // add/remove entries to/from group
             BibtexEntry[] selection = frame.basePanel().getSelectedEntries();
             if (selection.length > 0) {
-                if (node.getGroup().supportsAdd() && !node.getGroup().
-                        containsAll(selection)) {
+                if (node.getGroup().supportsAdd() && !node.getGroup().containsAll(selection)) {
                     addToGroup.setNode(node);
                     addToGroup.setBasePanel(panel);
                     addToGroup.setEnabled(true);
@@ -614,8 +606,7 @@ TreeSelectionListener, ActionListener {
                     moveToGroup.setBasePanel(panel);
                     moveToGroup.setEnabled(true);
                 }
-                if (node.getGroup().supportsRemove() && node.getGroup().
-                        containsAny(selection)) {
+                if (node.getGroup().supportsRemove() && node.getGroup().containsAny(selection)) {
                     removeFromGroup.setNode(node);
                     removeFromGroup.setBasePanel(panel);
                     removeFromGroup.setEnabled(true);
@@ -735,9 +726,8 @@ TreeSelectionListener, ActionListener {
             return; // ignore this event
         }
         final TreePath[] selection = groupsTree.getSelectionPaths();
-        if ((selection == null)
-                || (selection.length == 0)
-                || ((selection.length == 1) && (((GroupTreeNode) selection[0].getLastPathComponent()).getGroup() instanceof AllEntriesGroup))) {
+        if ((selection == null) || (selection.length == 0) || ((selection.length == 1)
+                && (((GroupTreeNode) selection[0].getLastPathComponent()).getGroup() instanceof AllEntriesGroup))) {
             panel.stopShowingGroup();
             panel.mainTable.stopShowingFloatGrouping();
             if (showOverlappingGroups.isSelected()) {
@@ -756,7 +746,8 @@ TreeSelectionListener, ActionListener {
     }
 
     private void updateSelections() {
-        final SearchRuleSet searchRules = SearchRuleSets.build(andCb.isSelected() ? SearchRuleSets.RuleSetType.AND : SearchRuleSets.RuleSetType.OR);
+        final SearchRuleSet searchRules = SearchRuleSets
+                .build(andCb.isSelected() ? SearchRuleSets.RuleSetType.AND : SearchRuleSets.RuleSetType.OR);
         TreePath[] selection = groupsTree.getSelectionPaths();
 
         for (TreePath aSelection : selection) {
@@ -775,6 +766,7 @@ TreeSelectionListener, ActionListener {
                 select.isSelected());
         search.start();*/
     }
+
 
     class GroupingWorker extends AbstractWorker {
 
@@ -826,22 +818,20 @@ TreeSelectionListener, ActionListener {
 
 
     /**
-     * Revalidate the groups tree (e.g. after the data stored in the model has
-     * been changed) and set the specified selection and expansion state.
+     * Revalidate the groups tree (e.g. after the data stored in the model has been changed) and set the specified
+     * selection and expansion state.
      */
-    public void revalidateGroups(TreePath[] selectionPaths,
-            Enumeration<TreePath> expandedNodes) {
+    public void revalidateGroups(TreePath[] selectionPaths, Enumeration<TreePath> expandedNodes) {
         revalidateGroups(selectionPaths, expandedNodes, null);
     }
 
     /**
-     * Revalidate the groups tree (e.g. after the data stored in the model has
-     * been changed) and set the specified selection and expansion state.
+     * Revalidate the groups tree (e.g. after the data stored in the model has been changed) and set the specified
+     * selection and expansion state.
      *
      * @param node If this is non-null, the view is scrolled to make it visible.
      */
-    private void revalidateGroups(TreePath[] selectionPaths,
-            Enumeration<TreePath> expandedNodes, GroupTreeNode node) {
+    private void revalidateGroups(TreePath[] selectionPaths, Enumeration<TreePath> expandedNodes, GroupTreeNode node) {
         groupsTreeModel.reload();
         groupsTree.clearSelection();
         if (selectionPaths != null) {
@@ -860,16 +850,16 @@ TreeSelectionListener, ActionListener {
     }
 
     /**
-     * Revalidate the groups tree (e.g. after the data stored in the model has
-     * been changed) and maintain the current selection and expansion state.
+     * Revalidate the groups tree (e.g. after the data stored in the model has been changed) and maintain the current
+     * selection and expansion state.
      */
     public void revalidateGroups() {
         revalidateGroups(null);
     }
 
     /**
-     * Revalidate the groups tree (e.g. after the data stored in the model has
-     * been changed) and maintain the current selection and expansion state.
+     * Revalidate the groups tree (e.g. after the data stored in the model has been changed) and maintain the current
+     * selection and expansion state.
      *
      * @param node If this is non-null, the view is scrolled to make it visible.
      */
@@ -889,17 +879,15 @@ TreeSelectionListener, ActionListener {
                 GroupTreeNode newNode = new GroupTreeNode(newGroup);
                 groupsRoot.add(newNode);
                 revalidateGroups();
-                UndoableAddOrRemoveGroup undo = new UndoableAddOrRemoveGroup(
-                        GroupSelector.this, groupsRoot, newNode,
+                UndoableAddOrRemoveGroup undo = new UndoableAddOrRemoveGroup(GroupSelector.this, groupsRoot, newNode,
                         UndoableAddOrRemoveGroup.ADD_NODE);
                 panel.undoManager.addEdit(undo);
                 panel.markBaseChanged();
-                frame.output(Localization.lang("Created_group_\"%0\".",
-                        newGroup.getName()));
+                frame.output(Localization.lang("Created_group_\"%0\".", newGroup.getName()));
             }
         } else if (e.getSource() == autoGroup) {
-            AutoGroupDialog gd = new AutoGroupDialog(frame, panel,
-                    GroupSelector.this, groupsRoot, Globals.prefs.get(JabRefPreferences.GROUPS_DEFAULT_FIELD), " .,", ",");
+            AutoGroupDialog gd = new AutoGroupDialog(frame, panel, GroupSelector.this, groupsRoot,
+                    Globals.prefs.get(JabRefPreferences.GROUPS_DEFAULT_FIELD), " .,", ",");
             gd.setVisible(true); // gd.show(); -> deprecated since 1.5
             // gd does the operation itself
         } else if (e.getSource() instanceof JCheckBox) {
@@ -934,10 +922,9 @@ TreeSelectionListener, ActionListener {
     }
 
     /**
-     * Adds the specified node as a child of the current root. The group
-     * contained in <b>newGroups </b> must not be of type AllEntriesGroup, since
-     * every tree has exactly one AllEntriesGroup (its root). The <b>newGroups
-     * </b> are inserted directly, i.e. they are not deepCopy()'d.
+     * Adds the specified node as a child of the current root. The group contained in <b>newGroups </b> must not be of
+     * type AllEntriesGroup, since every tree has exactly one AllEntriesGroup (its root). The <b>newGroups </b> are
+     * inserted directly, i.e. they are not deepCopy()'d.
      */
     public void addGroups(GroupTreeNode newGroups, CompoundEdit ce) {
         // paranoia: ensure that there are never two instances of AllEntriesGroup
@@ -945,8 +932,8 @@ TreeSelectionListener, ActionListener {
             return; // this should be impossible anyway
         }
         groupsRoot.add(newGroups);
-        UndoableAddOrRemoveGroup undo = new UndoableAddOrRemoveGroup(this,
-                groupsRoot, newGroups, UndoableAddOrRemoveGroup.ADD_NODE);
+        UndoableAddOrRemoveGroup undo = new UndoableAddOrRemoveGroup(this, groupsRoot, newGroups,
+                UndoableAddOrRemoveGroup.ADD_NODE);
         ce.addEdit(undo);
     }
 
@@ -969,10 +956,8 @@ TreeSelectionListener, ActionListener {
         }
 
         /**
-         * Returns the node to use in this action. If a node has been
-         * set explicitly (via setNode), it is returned. Otherwise, the first
-         * node in the current selection is returned. If all this fails, null
-         * is returned.
+         * Returns the node to use in this action. If a node has been set explicitly (via setNode), it is returned.
+         * Otherwise, the first node in the current selection is returned. If all this fails, null is returned.
          */
         public GroupTreeNode getNodeToUse() {
             if (m_node != null) {
@@ -1022,8 +1007,7 @@ TreeSelectionListener, ActionListener {
             if (gd.okPressed()) {
                 AbstractGroup newGroup = gd.getResultingGroup();
                 AbstractUndoableEdit undoAddPreviousEntries = gd.getUndoForAddPreviousEntries();
-                UndoableModifyGroup undo = new UndoableModifyGroup(
-                        GroupSelector.this, groupsRoot, node, newGroup);
+                UndoableModifyGroup undo = new UndoableModifyGroup(GroupSelector.this, groupsRoot, node, newGroup);
                 node.setGroup(newGroup);
                 revalidateGroups(node);
                 // Store undo information.
@@ -1037,8 +1021,7 @@ TreeSelectionListener, ActionListener {
                     panel.undoManager.addEdit(nc);
                 }
                 panel.markBaseChanged();
-                frame.output(Localization.lang("Modified group \"%0\".",
-                        newGroup.getName()));
+                frame.output(Localization.lang("Modified group \"%0\".", newGroup.getName()));
             }
         }
     }
@@ -1064,17 +1047,14 @@ TreeSelectionListener, ActionListener {
             } else {
                 ((GroupTreeNode) node.getParent()).insert(newNode, node.getParent().getIndex(node) + 1);
             }
-            UndoableAddOrRemoveGroup undo = new UndoableAddOrRemoveGroup(
-                    GroupSelector.this, groupsRoot, newNode,
+            UndoableAddOrRemoveGroup undo = new UndoableAddOrRemoveGroup(GroupSelector.this, groupsRoot, newNode,
                     UndoableAddOrRemoveGroup.ADD_NODE);
             revalidateGroups();
-            groupsTree.expandPath(new TreePath(
-                    (node != null ? node : groupsRoot).getPath()));
+            groupsTree.expandPath(new TreePath((node != null ? node : groupsRoot).getPath()));
             // Store undo information.
             panel.undoManager.addEdit(undo);
             panel.markBaseChanged();
-            frame.output(Localization.lang("Added group \"%0\".",
-                    newGroup.getName()));
+            frame.output(Localization.lang("Added group \"%0\".", newGroup.getName()));
         }
     }
 
@@ -1095,16 +1075,14 @@ TreeSelectionListener, ActionListener {
             final AbstractGroup newGroup = gd.getResultingGroup();
             final GroupTreeNode newNode = new GroupTreeNode(newGroup);
             node.add(newNode);
-            UndoableAddOrRemoveGroup undo = new UndoableAddOrRemoveGroup(
-                    GroupSelector.this, groupsRoot, newNode,
+            UndoableAddOrRemoveGroup undo = new UndoableAddOrRemoveGroup(GroupSelector.this, groupsRoot, newNode,
                     UndoableAddOrRemoveGroup.ADD_NODE);
             revalidateGroups();
             groupsTree.expandPath(new TreePath(node.getPath()));
             // Store undo information.
             panel.undoManager.addEdit(undo);
             panel.markBaseChanged();
-            frame.output(Localization.lang("Added group \"%0\".",
-                    newGroup.getName()));
+            frame.output(Localization.lang("Added group \"%0\".", newGroup.getName()));
         }
     }
 
@@ -1118,20 +1096,18 @@ TreeSelectionListener, ActionListener {
         public void actionPerformed(ActionEvent e) {
             final GroupTreeNode node = getNodeToUse();
             final AbstractGroup group = node.getGroup();
-            int conf = JOptionPane.showConfirmDialog(frame, Localization.lang("Remove group \"%0\" and its subgroups?", group.getName()),
-                    Localization.lang("Remove group and subgroups"),
-                    JOptionPane.YES_NO_OPTION);
+            int conf = JOptionPane.showConfirmDialog(frame,
+                    Localization.lang("Remove group \"%0\" and its subgroups?", group.getName()),
+                    Localization.lang("Remove group and subgroups"), JOptionPane.YES_NO_OPTION);
             if (conf == JOptionPane.YES_OPTION) {
-                final UndoableAddOrRemoveGroup undo = new UndoableAddOrRemoveGroup(
-                        GroupSelector.this, groupsRoot, node,
+                final UndoableAddOrRemoveGroup undo = new UndoableAddOrRemoveGroup(GroupSelector.this, groupsRoot, node,
                         UndoableAddOrRemoveGroup.REMOVE_NODE_AND_CHILDREN);
                 node.removeFromParent();
                 revalidateGroups();
                 // Store undo information.
                 panel.undoManager.addEdit(undo);
                 panel.markBaseChanged();
-                frame.output(Localization.lang("Removed group \"%0\" and its subgroups.",
-                        group.getName()));
+                frame.output(Localization.lang("Removed group \"%0\" and its subgroups.", group.getName()));
             }
         }
     }
@@ -1146,20 +1122,18 @@ TreeSelectionListener, ActionListener {
         public void actionPerformed(ActionEvent e) {
             final GroupTreeNode node = getNodeToUse();
             final AbstractGroup group = node.getGroup();
-            int conf = JOptionPane.showConfirmDialog(frame, Localization.lang("Remove all subgroups of \"%0\"?", group.getName()),
-                    Localization.lang("Remove all subgroups"),
-                    JOptionPane.YES_NO_OPTION);
+            int conf = JOptionPane.showConfirmDialog(frame,
+                    Localization.lang("Remove all subgroups of \"%0\"?", group.getName()),
+                    Localization.lang("Remove all subgroups"), JOptionPane.YES_NO_OPTION);
             if (conf == JOptionPane.YES_OPTION) {
-                final UndoableModifySubtree undo = new UndoableModifySubtree(
-                        GroupSelector.this, getGroupTreeRoot(), node,
-                        "Remove all subgroups");
+                final UndoableModifySubtree undo = new UndoableModifySubtree(GroupSelector.this, getGroupTreeRoot(),
+                        node, "Remove all subgroups");
                 node.removeAllChildren();
                 revalidateGroups();
                 // Store undo information.
                 panel.undoManager.addEdit(undo);
                 panel.markBaseChanged();
-                frame.output(Localization.lang("Removed all subgroups of group \"%0\".",
-                        group.getName()));
+                frame.output(Localization.lang("Removed all subgroups of group \"%0\".", group.getName()));
             }
         }
     }
@@ -1174,24 +1148,22 @@ TreeSelectionListener, ActionListener {
         public void actionPerformed(ActionEvent e) {
             final GroupTreeNode node = getNodeToUse();
             final AbstractGroup group = node.getGroup();
-            int conf = JOptionPane.showConfirmDialog(frame, Localization.lang("Remove group \"%0\"?", group.getName()), Localization.lang("Remove group"), JOptionPane.YES_NO_OPTION);
+            int conf = JOptionPane.showConfirmDialog(frame, Localization.lang("Remove group \"%0\"?", group.getName()),
+                    Localization.lang("Remove group"), JOptionPane.YES_NO_OPTION);
             if (conf == JOptionPane.YES_OPTION) {
-                final UndoableAddOrRemoveGroup undo = new UndoableAddOrRemoveGroup(
-                        GroupSelector.this, groupsRoot, node,
+                final UndoableAddOrRemoveGroup undo = new UndoableAddOrRemoveGroup(GroupSelector.this, groupsRoot, node,
                         UndoableAddOrRemoveGroup.REMOVE_NODE_KEEP_CHILDREN);
                 final GroupTreeNode parent = (GroupTreeNode) node.getParent();
                 final int childIndex = parent.getIndex(node);
                 node.removeFromParent();
                 while (node.getChildCount() > 0) {
-                    parent.insert((GroupTreeNode) node.getFirstChild(),
-                            childIndex);
+                    parent.insert((GroupTreeNode) node.getFirstChild(), childIndex);
                 }
                 revalidateGroups();
                 // Store undo information.
                 panel.undoManager.addEdit(undo);
                 panel.markBaseChanged();
-                frame.output(Localization.lang("Removed group \"%0\".",
-                        group.getName()));
+                frame.output(Localization.lang("Removed group \"%0\".", group.getName()));
             }
         }
     }
@@ -1211,8 +1183,8 @@ TreeSelectionListener, ActionListener {
         @Override
         public void actionPerformed(ActionEvent ae) {
             final GroupTreeNode node = getNodeToUse();
-            final UndoableModifySubtree undo = new UndoableModifySubtree(
-                    GroupSelector.this, getGroupTreeRoot(), node, Localization.lang("sort subgroups"));
+            final UndoableModifySubtree undo = new UndoableModifySubtree(GroupSelector.this, getGroupTreeRoot(), node,
+                    Localization.lang("sort subgroups"));
             groupsTree.sort(node, false);
             panel.undoManager.addEdit(undo);
             panel.markBaseChanged();
@@ -1229,8 +1201,8 @@ TreeSelectionListener, ActionListener {
         @Override
         public void actionPerformed(ActionEvent ae) {
             final GroupTreeNode node = getNodeToUse();
-            final UndoableModifySubtree undo = new UndoableModifySubtree(
-                    GroupSelector.this, getGroupTreeRoot(), node, Localization.lang("sort subgroups"));
+            final UndoableModifySubtree undo = new UndoableModifySubtree(GroupSelector.this, getGroupTreeRoot(), node,
+                    Localization.lang("sort subgroups"));
             groupsTree.sort(node, true);
             panel.undoManager.addEdit(undo);
             panel.markBaseChanged(); // JZTODO lyrics
@@ -1344,8 +1316,7 @@ TreeSelectionListener, ActionListener {
         }
         AbstractUndoableEdit undo;
         if (!node.canMoveUp() || ((undo = node.moveUp(GroupSelector.this)) == null)) {
-            frame.output(Localization.lang(
-                    "Cannot move group \"%0\" up.", node.getGroup().getName()));
+            frame.output(Localization.lang("Cannot move group \"%0\" up.", node.getGroup().getName()));
             return false; // not possible
         }
         // update selection/expansion state (not really needed when
@@ -1369,8 +1340,7 @@ TreeSelectionListener, ActionListener {
         }
         AbstractUndoableEdit undo;
         if (!node.canMoveDown() || ((undo = node.moveDown(GroupSelector.this)) == null)) {
-            frame.output(Localization.lang(
-                    "Cannot move group \"%0\" down.", node.getGroup().getName()));
+            frame.output(Localization.lang("Cannot move group \"%0\" down.", node.getGroup().getName()));
             return false; // not possible
         }
         // update selection/expansion state (not really needed when
@@ -1394,8 +1364,7 @@ TreeSelectionListener, ActionListener {
         }
         AbstractUndoableEdit undo;
         if (!node.canMoveLeft() || ((undo = node.moveLeft(GroupSelector.this)) == null)) {
-            frame.output(Localization.lang(
-                    "Cannot move group \"%0\" left.", node.getGroup().getName()));
+            frame.output(Localization.lang("Cannot move group \"%0\" left.", node.getGroup().getName()));
             return false; // not possible
         }
         // update selection/expansion state
@@ -1418,8 +1387,7 @@ TreeSelectionListener, ActionListener {
         }
         AbstractUndoableEdit undo;
         if (!node.canMoveRight() || ((undo = node.moveRight(GroupSelector.this)) == null)) {
-            frame.output(Localization.lang(
-                    "Cannot move group \"%0\" right.", node.getGroup().getName()));
+            frame.output(Localization.lang("Cannot move group \"%0\" right.", node.getGroup().getName()));
             return false; // not possible
         }
         // update selection/expansion state
@@ -1430,8 +1398,8 @@ TreeSelectionListener, ActionListener {
     }
 
     /**
-     * Concludes the moving of a group tree node by storing the specified
-     * undo information, marking the change, and setting the status line.
+     * Concludes the moving of a group tree node by storing the specified undo information, marking the change, and
+     * setting the status line.
      *
      * @param undo Undo information for the move operation.
      * @param node The node that has been moved.
@@ -1439,14 +1407,13 @@ TreeSelectionListener, ActionListener {
     public void concludeMoveGroup(AbstractUndoableEdit undo, GroupTreeNode node) {
         panel.undoManager.addEdit(undo);
         panel.markBaseChanged();
-        frame.output(Localization.lang("Moved group \"%0\".",
-                node.getGroup().getName()));
+        frame.output(Localization.lang("Moved group \"%0\".", node.getGroup().getName()));
     }
 
     public void concludeAssignment(AbstractUndoableEdit undo, GroupTreeNode node, int assignedEntries) {
         if (undo == null) {
             frame.output(Localization.lang("The group \"%0\" already contains the selection.",
-                    new String[]{node.getGroup().getName()}));
+                    new String[] {node.getGroup().getName()}));
             return;
         }
         panel.undoManager.addEdit(undo);
@@ -1456,8 +1423,8 @@ TreeSelectionListener, ActionListener {
         if (assignedEntries == 1) {
             frame.output(Localization.lang("Assigned 1 entry to group \"%0\".", groupName));
         } else {
-            frame.output(Localization.lang("Assigned %0 entries to group \"%1\".",
-                    String.valueOf(assignedEntries), groupName));
+            frame.output(Localization.lang("Assigned %0 entries to group \"%1\".", String.valueOf(assignedEntries),
+                    groupName));
         }
     }
 
@@ -1494,12 +1461,10 @@ TreeSelectionListener, ActionListener {
         }
 
         // auto show/hide groups interface
-        if (Globals.prefs.getBoolean(JabRefPreferences.GROUP_AUTO_SHOW)
-                && !groupsRoot.isLeaf()) { // groups were defined
+        if (Globals.prefs.getBoolean(JabRefPreferences.GROUP_AUTO_SHOW) && !groupsRoot.isLeaf()) { // groups were defined
             frame.sidePaneManager.show("groups");
             frame.groupToggle.setSelected(true);
-        } else if (Globals.prefs.getBoolean(JabRefPreferences.GROUP_AUTO_HIDE)
-                && groupsRoot.isLeaf()) { // groups were not defined
+        } else if (Globals.prefs.getBoolean(JabRefPreferences.GROUP_AUTO_HIDE) && groupsRoot.isLeaf()) { // groups were not defined
             frame.sidePaneManager.hide("groups");
             frame.groupToggle.setSelected(false);
         }
@@ -1511,8 +1476,8 @@ TreeSelectionListener, ActionListener {
     }
 
     /**
-     * Highlight all groups that contain any/all of the specified entries.
-     * If entries is null or has zero length, highlight is cleared.
+     * Highlight all groups that contain any/all of the specified entries. If entries is null or has zero length,
+     * highlight is cleared.
      */
     public void showMatchingGroups(BibtexEntry[] entries, boolean requireAll) {
         if ((entries == null) || (entries.length == 0)) { // nothing selected
@@ -1521,7 +1486,7 @@ TreeSelectionListener, ActionListener {
             return;
         }
         Vector<GroupTreeNode> vec = new Vector<>();
-        for (Enumeration<GroupTreeNode> e = groupsRoot.preorderEnumeration(); e.hasMoreElements(); ) {
+        for (Enumeration<GroupTreeNode> e = groupsRoot.preorderEnumeration(); e.hasMoreElements();) {
             GroupTreeNode node = e.nextElement();
             AbstractGroup group = node.getGroup();
             int i;
@@ -1553,12 +1518,11 @@ TreeSelectionListener, ActionListener {
     }
 
     /**
-     * Show groups that, if selected, would show at least one
-     * of the entries found in the specified search.
+     * Show groups that, if selected, would show at least one of the entries found in the specified search.
      */
     private void showOverlappingGroups(List<BibtexEntry> matches) { //DatabaseSearch search) {
         List<GroupTreeNode> nodes = new ArrayList<>();
-        for (Enumeration<GroupTreeNode> e = groupsRoot.depthFirstEnumeration(); e.hasMoreElements(); ) {
+        for (Enumeration<GroupTreeNode> e = groupsRoot.depthFirstEnumeration(); e.hasMoreElements();) {
             GroupTreeNode node = e.nextElement();
             SearchRule rule = node.getSearchRule();
             for (BibtexEntry match : matches) {

--- a/src/main/java/net/sf/jabref/groups/GroupSelector.java
+++ b/src/main/java/net/sf/jabref/groups/GroupSelector.java
@@ -883,7 +883,7 @@ public class GroupSelector extends SidePaneComponent implements TreeSelectionLis
                         UndoableAddOrRemoveGroup.ADD_NODE);
                 panel.undoManager.addEdit(undo);
                 panel.markBaseChanged();
-                frame.output(Localization.lang("Created_group_\"%0\".", newGroup.getName()));
+                frame.output(Localization.lang("Created group \"%0\".", newGroup.getName()));
             }
         } else if (e.getSource() == autoGroup) {
             AutoGroupDialog gd = new AutoGroupDialog(frame, panel, GroupSelector.this, groupsRoot,

--- a/src/main/java/net/sf/jabref/groups/UndoableAddOrRemoveGroup.java
+++ b/src/main/java/net/sf/jabref/groups/UndoableAddOrRemoveGroup.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2015 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -49,7 +49,7 @@ class UndoableAddOrRemoveGroup extends AbstractUndoableEdit {
 
     /**
      * Creates an object that can undo/redo an edit event.
-     * 
+     *
      * @param groupsRoot
      *            The global groups root.
      * @param editType
@@ -115,8 +115,8 @@ class UndoableAddOrRemoveGroup extends AbstractUndoableEdit {
     private void doOperation(boolean undo) {
         GroupTreeNode cursor = m_groupsRootHandle;
         final int childIndex = m_pathToNode[m_pathToNode.length - 1];
-        // traverse path up to butlast element
-        for (int i = 0; i < m_pathToNode.length - 1; ++i) {
+        // traverse path up to but last element
+        for (int i = 0; i < (m_pathToNode.length - 1); ++i) {
             cursor = (GroupTreeNode) cursor.getChildAt(m_pathToNode[i]);
         }
         if (undo) {
@@ -127,8 +127,8 @@ class UndoableAddOrRemoveGroup extends AbstractUndoableEdit {
             case REMOVE_NODE_KEEP_CHILDREN:
                 // move all children to newNode, then add newNode
                 GroupTreeNode newNode = m_subtreeBackup.deepCopy();
-                for (int i = childIndex; i < childIndex
-                        + m_subtreeRootChildCount; ++i) {
+                for (int i = childIndex; i < (childIndex
+                        + m_subtreeRootChildCount); ++i) {
                     newNode.add((GroupTreeNode) cursor.getChildAt(childIndex));
                 }
                 cursor.insert(newNode, childIndex);
@@ -165,7 +165,7 @@ class UndoableAddOrRemoveGroup extends AbstractUndoableEdit {
     /**
      * Call this method to decide if the group list should be immediately
      * revalidated by this operation. Default is true.
-     * 
+     *
      * @param val
      *            a <code>boolean</code> value
      */

--- a/src/main/java/net/sf/jabref/groups/structure/KeywordGroup.java
+++ b/src/main/java/net/sf/jabref/groups/structure/KeywordGroup.java
@@ -375,13 +375,13 @@ public class KeywordGroup extends AbstractGroup {
     }
 
     public static String getDescriptionForPreview(String field, String expr, boolean caseSensitive, boolean regExp) {
-        String header = regExp ? Localization.lang(
-                "This group contains entries whose <b>%0</b> field contains the regular expression <b>%1</b>",
+        // @formatter:off
+        String header = regExp ? Localization.lang("This group contains entries whose <b>%0</b> field contains the regular expression <b>%1</b>",
                 field, StringUtil.quoteForHTML(expr))
-                : Localization.lang(
-                "This group contains entries whose <b>%0</b> field contains the keyword <b>%1</b>",
+                : Localization.lang("This group contains entries whose <b>%0</b> field contains the keyword <b>%1</b>",
                 field, StringUtil.quoteForHTML(expr));
-        String caseSensitiveText = caseSensitive ? Localization.lang("case sensitive") : Localization.lang("case insensitive");
+        String caseSensitiveText = caseSensitive ? Localization.lang("case sensitive") :
+            Localization.lang("case insensitive");
         String footer = regExp ?
                 Localization.lang("Entries cannot be manually assigned to or removed from this group.")
                 : Localization.lang(
@@ -395,7 +395,7 @@ public class KeywordGroup extends AbstractGroup {
                         + "This process removes the term <b>%1</b> from "
                         + "each entry's <b>%0</b> field.",
                 field, StringUtil.quoteForHTML(expr));
-
+        // @formatter:on
         return String.format("%s (%s). %s", header, caseSensitiveText, footer);
     }
 

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -783,9 +783,8 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                         Localization.lang("Copied key")) + '.');
                     // @formatter:on
                 } else {
-                    output(Localization.lang("Warning") + ": " + (bes.length - keys.size()) + ' '
-                            + Localization.lang("out of") + ' ' + bes.length + ' '
-                            + Localization.lang("entries have undefined BibTeX key") + '.');
+                    output(Localization.lang("Warning: %0 out of %1 entries have undefined BibTeX key.",
+                            Integer.toString(bes.length - keys.size()), Integer.toString(bes.length)));
                 }
             }
         });
@@ -825,9 +824,8 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                             Localization.lang("Copied key") + '.');
                         // @formatter:on
                     } else {
-                        output(Localization.lang("Warning") + ": " + (bes.length - keys.size()) + ' '
-                                + Localization.lang("out of") + ' ' + bes.length + ' '
-                                + Localization.lang("entries have undefined BibTeX key") + '.');
+                        output(Localization.lang("Warning: %0 out of %1 entries have undefined BibTeX key.",
+                                Integer.toString(bes.length - keys.size()), Integer.toString(bes.length)));
                     }
                 }
             }
@@ -1423,8 +1421,8 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
         } catch (UnsupportedCharsetException ex2) {
             // @formatter:off
-            JOptionPane.showMessageDialog(frame, Localization.lang("Could not save file. "
-                            + "Character encoding '%0' is not supported.", enc),
+            JOptionPane.showMessageDialog(frame, Localization.lang("Could not save file.") + ' '
+                            + Localization.lang("Character encoding '%0' is not supported.", enc),
                     Localization.lang("Save database"), JOptionPane.ERROR_MESSAGE);
             // @formatter:on
             throw new SaveException("rt");
@@ -1441,7 +1439,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 ex.printStackTrace();
             }
 
-            JOptionPane.showMessageDialog(frame, Localization.lang("Could not save file") + ".\n" + ex.getMessage(),
+            JOptionPane.showMessageDialog(frame, Localization.lang("Could not save file.") + "\n" + ex.getMessage(),
                     Localization.lang("Save database"), JOptionPane.ERROR_MESSAGE);
             throw new SaveException("rt");
 
@@ -1522,8 +1520,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
                 // Create an UndoableInsertEntry object.
                 undoManager.addEdit(new UndoableInsertEntry(database, be, BasePanel.this));
-                output(Localization.lang("Added new") + " '" + type.getName().toLowerCase() + "' "
-                        + Localization.lang("entry") + '.');
+                output(Localization.lang("Added new '%0' entry.", type.getName().toLowerCase()));
 
                 // We are going to select the new entry. Before that, make sure that we are in
                 // show-entry mode. If we aren't already in that mode, enter the WILL_SHOW_EDITOR
@@ -1628,8 +1625,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 }
                 // Create an UndoableInsertEntry object.
                 undoManager.addEdit(new UndoableInsertEntry(database, bibEntry, BasePanel.this));
-                output(Localization.lang("Added new") + " '" + bibEntry.getType().getName().toLowerCase() + "' "
-                        + Localization.lang("entry") + '.');
+                output(Localization.lang("Added new '%0' entry.", bibEntry.getType().getName().toLowerCase()));
 
                 markBaseChanged(); // The database just changed.
                 if (Globals.prefs.getBoolean(JabRefPreferences.AUTO_OPEN_FORM)) {
@@ -2367,29 +2363,28 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
     private void changeType(BibtexEntry[] bes, BibtexEntryType type) {
 
         if ((bes == null) || (bes.length == 0)) {
-            output("First select the entries you wish to change type " + "for.");
+            output(Localization.lang("First select the entries you wish to change type for."));
             return;
         }
         if (bes.length > 1) {
-            int choice = JOptionPane.showConfirmDialog(
-                    this, "Multiple entries selected. Do you want to change" + "\nthe type of all these to '"
-                            + type.getName() + "'?",
-                    "Change type", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+            int choice = JOptionPane.showConfirmDialog(this,
+                    // @formatter:off
+                    Localization.lang("Multiple entries selected. Do you want to change\nthe type of all these to '%0'?", type.getName()),
+                    Localization.lang("Change type"), JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+                    // @formatter:on
             if (choice == JOptionPane.NO_OPTION) {
                 return;
             }
         }
 
-        NamedCompound ce = new NamedCompound(Localization.lang("change type"));
+        NamedCompound ce = new NamedCompound(Localization.lang("Change type"));
         for (BibtexEntry be : bes) {
             ce.addEdit(new UndoableChangeType(be, be.getType(), type));
             be.setType(type);
         }
 
         // @formatter:off
-        output(Localization.lang("Changed type to") + " '" + type.getName() + "' "
-                + Localization.lang("for") + ' '
-                + bes.length + ' ' + Localization.lang("entries") + '.');
+        output(formatOutputMessage(Localization.lang("Changed type to '%0' for", type.getName()), bes.length));
         // @formatter:on
         ce.end();
         undoManager.addEdit(ce);
@@ -2401,13 +2396,11 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         if (Globals.prefs.getBoolean(JabRefPreferences.CONFIRM_DELETE)) {
             String msg;
             // @formatter:off
-            msg = Localization.lang("Really delete the selected") + ' ' +
-                    Localization.lang("entry") + '?';
+            msg = Localization.lang("Really delete the selected entry?");
             // @formatter:on
             String title = Localization.lang("Delete entry");
             if (numberOfEntries > 1) {
-                msg = Localization.lang("Really delete the selected") + ' ' + numberOfEntries + ' '
-                        + Localization.lang("entries") + '?';
+                msg = Localization.lang("Really delete the selected %0 entries?", Integer.toString(numberOfEntries));
                 title = Localization.lang("Delete multiple entries");
             }
 
@@ -2788,8 +2781,8 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
     private String formatOutputMessage(String start, int count) {
         // @formatter:off
-        return start + ' ' + count + ' ' + (count > 1 ? Localization.lang("entries") :
-            Localization.lang("entry"))  + '.';
+        return String.format("%s %d %s.", start, count, (count > 1 ? Localization.lang("entries") :
+            Localization.lang("entry")));
         // @formatter:on
     }
 
@@ -2812,12 +2805,11 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             if (chosenFile != null) {
                 File expFile = new File(chosenFile);
                 if (!expFile.exists() || (JOptionPane.showConfirmDialog(frame,
-                        '\'' + expFile.getName() + "' " + Localization.lang("exists. Overwrite file?"),
+                        Localization.lang("'%0' exists. Overwrite file?", expFile.getName()),
                         Localization.lang("Save database"), JOptionPane.OK_CANCEL_OPTION) == JOptionPane.OK_OPTION)) {
-
                     saveDatabase(expFile, true, Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING), saveType);
                     frame.getFileHistory().newFile(expFile.getPath());
-                    frame.output(Localization.lang("Saved selected to") + " '" + expFile.getPath() + "'.");
+                    frame.output(Localization.lang("Saved selected to '%0'.", expFile.getPath()));
                 }
             }
         }

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -309,8 +309,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 TransferableBibtexEntry trbe = new TransferableBibtexEntry(bes);
                 // ! look at ClipBoardManager
                 Toolkit.getDefaultToolkit().getSystemClipboard().setContents(trbe, BasePanel.this);
-                output(Localization.lang("Copied") + ' ' + (bes.length > 1 ? bes.length + " "
-                        + Localization.lang("entries") : "1 " + Localization.lang("entry") + '.'));
+                output(formatOutputMessage(Localization.lang("Copied"), bes.length));
             } else {
                 // The user maybe selected a single cell.
                 int[] rows = mainTable.getSelectedRows();
@@ -334,7 +333,11 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             //int row0 = mainTable.getSelectedRow();
             if ((bes != null) && (bes.length > 0)) {
                 // Create a CompoundEdit to make the action undoable.
-                NamedCompound ce = new NamedCompound(Localization.lang(bes.length > 1 ? "cut entries" : "cut entry"));
+                NamedCompound ce = new NamedCompound((bes.length > 1 ?
+                // @formatter:off
+                    Localization.lang("cut entries") :
+                    Localization.lang("cut entry")));
+                // @formatter:on
                 // Loop through the array of entries, and delete them.
                 for (BibtexEntry be : bes) {
                     database.removeEntry(be.getId());
@@ -342,8 +345,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     ce.addEdit(new UndoableRemoveEntry(database, be, BasePanel.this));
                 }
                 //entryTable.clearSelection();
-                frame.output(Localization.lang("Cut_pr") + ' ' + (bes.length > 1 ? bes.length + " "
-                        + Localization.lang("entries") : Localization.lang("entry")) + '.');
+                frame.output(formatOutputMessage(Localization.lang("Cut_pr"), bes.length));
                 ce.end();
                 undoManager.addEdit(ce);
                 markBaseChanged();
@@ -357,8 +359,11 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 boolean goOn = showDeleteConfirmationDialog(bes.length);
                 if (goOn) {
                     // Create a CompoundEdit to make the action undoable.
-                    NamedCompound ce = new NamedCompound(
-                            Localization.lang(bes.length > 1 ? "delete entries" : "delete entry"));
+                    NamedCompound ce = new NamedCompound((bes.length > 1 ?
+                    // @formatter:off
+                        Localization.lang("delete entries") :
+                        Localization.lang("delete entry")));
+                    // @formatter:on
                     // Loop through the array of entries, and delete them.
                     for (BibtexEntry be : bes) {
                         database.removeEntry(be.getId());
@@ -366,8 +371,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                         ce.addEdit(new UndoableRemoveEntry(database, be, BasePanel.this));
                     }
                     markBaseChanged();
-                    frame.output(Localization.lang("Deleted") + ' ' + (bes.length > 1 ? bes.length + " "
-                            + Localization.lang("entries") : Localization.lang("entry")) + '.');
+                    frame.output(formatOutputMessage(Localization.lang("Deleted"), bes.length));
                     ce.end();
                     undoManager.addEdit(ce);
                 }
@@ -417,8 +421,11 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 // or were parsed from a string
                 if ((bes != null) && (bes.length > 0)) {
 
-                    NamedCompound ce = new NamedCompound(
-                            Localization.lang(bes.length > 1 ? "paste entries" : "paste entry"));
+                    NamedCompound ce = new NamedCompound((bes.length > 1 ?
+                    // @formatter:off
+                        Localization.lang("paste entries") :
+                        Localization.lang("paste entry")));
+                    // @formatter:on
 
                     // Store the first inserted bibtexentry.
                     // bes[0] does not work as bes[0] is first clonded,
@@ -451,8 +458,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     undoManager.addEdit(ce);
                     //entryTable.clearSelection();
                     //entryTable.revalidate();
-                    output(Localization.lang("Pasted") + ' ' + (bes.length > 1 ? bes.length + " "
-                            + Localization.lang("entries") : "1 " + Localization.lang("entry")) + '.');
+                    output(formatOutputMessage(Localization.lang("Pasted"), bes.length));
                     markBaseChanged();
 
                     if (Globals.prefs.getBoolean(JabRefPreferences.AUTO_OPEN_FORM)) {
@@ -557,11 +563,13 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                         exporter.exportDatabaseToDBMS(database, metaData, null, dbs, frame);
                         dbs.isConfigValid(true);
                     } catch (Exception ex) {
-                        String preamble = "Could not export to SQL database for the following reason:";
+                        // @formatter:off
+                        String preamble = Localization.lang("Could not export to SQL database for the following reason:");
+                        // @formatter:on
                         errorMessage = SQLUtil.getExceptionMessage(ex);
                         ex.printStackTrace();
                         dbs.isConfigValid(false);
-                        JOptionPane.showMessageDialog(frame, Localization.lang(preamble) + '\n' + errorMessage,
+                        JOptionPane.showMessageDialog(frame, preamble + '\n' + errorMessage,
                                 Localization.lang("Export to SQL database"), JOptionPane.ERROR_MESSAGE);
                     }
 
@@ -579,10 +587,12 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                         frame.output(Localization.lang("%0 export successful"));
                     }
                 } else { // show an error dialog if an error occurred
-                    String preamble = "Could not export to SQL database for the following reason:";
-                    frame.output(Localization.lang(preamble) + "  " + errorMessage);
+                    // @formatter:off
+                    String preamble = Localization.lang("Could not export to SQL database for the following reason:");
+                    // @formatter:on
+                    frame.output(preamble + "  " + errorMessage);
 
-                    JOptionPane.showMessageDialog(frame, Localization.lang(preamble) + '\n' + errorMessage,
+                    JOptionPane.showMessageDialog(frame, preamble + '\n' + errorMessage,
                             Localization.lang("Export to SQL database"), JOptionPane.ERROR_MESSAGE);
 
                     errorMessage = null;
@@ -619,8 +629,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     return;
                 }
                 frame.block();
-                output(Localization.lang("Generating BibTeX key for") + ' ' + numSelected + ' '
-                        + (numSelected > 1 ? Localization.lang("entries") : Localization.lang("entry")) + "...");
+                output(formatOutputMessage(Localization.lang("Generating BibTeX key for"), numSelected));
             }
 
             // Run second, on a different thread:
@@ -710,8 +719,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     });
                 }
                 ////////////////////////////////////////////////////////////////////////////////
-                output(Localization.lang("Generated BibTeX key for") + ' ' + numSelected + ' '
-                        + (numSelected != 1 ? Localization.lang("entries") : Localization.lang("entry")));
+                output(formatOutputMessage(Localization.lang("Generated BibTeX key for"), numSelected));
                 frame.unblock();
             }
         });
@@ -769,7 +777,11 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
                 if (keys.size() == bes.length) {
                     // All entries had keys.
-                    output(Localization.lang(bes.length > 1 ? "Copied keys" : "Copied key") + '.');
+                    output((bes.length > 1 ?
+                    // @formatter:off
+                        Localization.lang("Copied keys") :
+                        Localization.lang("Copied key")) + '.');
+                    // @formatter:on
                 } else {
                     output(Localization.lang("Warning") + ": " + (bes.length - keys.size()) + ' '
                             + Localization.lang("out of") + ' ' + bes.length + ' '
@@ -808,8 +820,10 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
                     if (keys.size() == bes.length) {
                         // All entries had keys.
-                        output(bes.length > 1 ? Localization.lang("Copied keys") : Localization.lang("Copied key")
-                                + '.');
+                        // @formatter:off
+                        output(bes.length > 1 ? Localization.lang("Copied keys") :
+                            Localization.lang("Copied key") + '.');
+                        // @formatter:on
                     } else {
                         output(Localization.lang("Warning") + ": " + (bes.length - keys.size()) + ' '
                                 + Localization.lang("out of") + ' ' + bes.length + ' '
@@ -860,10 +874,15 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
                     if (copied == bes.length) {
                         // All entries had keys.
-                        output(Localization.lang(bes.length > 1 ? "Copied keys" : "Copied key") + '.');
+                        output((bes.length > 1 ?
+                        // @formatter:off
+                            Localization.lang("Copied keys") :
+                            Localization.lang("Copied key")) + '.');
+                        // @formatter:on
                     } else {
-                        output(Localization.lang("Warning") + ": " + copied + ' ' + Localization.lang("out of") + ' '
-                                + bes.length + ' ' + Localization.lang("entries have undefined BibTeX key") + '.');
+                        // @formatter:off
+                        output(Localization.lang("Warning: %0 out of %1 entries have undefined BibTeX key.", Integer.toString(copied), Integer.toString(bes.length)));
+                        // @formatter:on
                     }
                 }
             }
@@ -1174,8 +1193,11 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     }
                 }
 
-                output(Localization.lang("Replaced") + ' ' + counter + ' '
-                        + Localization.lang(counter == 1 ? "occurence" : "occurences") + '.');
+                output(Localization.lang("Replaced") + ' ' + counter + ' ' + (counter == 1 ?
+                // @formatter:off
+                     Localization.lang("occurrence") :
+                     Localization.lang("occurrences")) + '.');
+                // @formatter:on
                 if (counter > 0) {
                     ce.end();
                     undoManager.addEdit(ce);
@@ -1258,17 +1280,22 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         });
 
         // Note that we can't put the number of entries that have been reverted into the undoText as the concrete number cannot be injected
+        // @formatter:off
         actions.put(Relevance.getInstance().getValues().get(0).getActionName(),
                 new SpecialFieldAction(frame, Relevance.getInstance(),
                         Relevance.getInstance().getValues().get(0).getFieldValue(), true,
-                        Localization.lang("Toggle relevance"), Localization.lang("Toggled relevance for %0 entries")));
+                        Localization.lang("Toggle relevance"),
+                        Localization.lang("Toggled relevance for %0 entries")));
         actions.put(Quality.getInstance().getValues().get(0).getActionName(),
                 new SpecialFieldAction(frame, Quality.getInstance(),
                         Quality.getInstance().getValues().get(0).getFieldValue(), true,
-                        Localization.lang("Toggle quality"), Localization.lang("Toggled quality for %0 entries")));
+                        Localization.lang("Toggle quality"),
+                        Localization.lang("Toggled quality for %0 entries")));
         actions.put(Printed.getInstance().getValues().get(0).getActionName(), new SpecialFieldAction(frame,
                 Printed.getInstance(), Printed.getInstance().getValues().get(0).getFieldValue(), true,
-                Localization.lang("Toggle print status"), Localization.lang("Toggled print status for %0 entries")));
+                Localization.lang("Toggle print status"),
+                Localization.lang("Toggled print status for %0 entries")));
+        // @formatter:on
 
         for (SpecialFieldValue prio : Priority.getInstance().getValues()) {
             actions.put(prio.getActionName(), prio.getAction(this.frame));
@@ -1435,7 +1462,10 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             String tryDiff = Localization.lang("Try different encoding");
             int answer = JOptionPane.showOptionDialog(frame, builder.getPanel(), Localization.lang("Save database"),
                     JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
-                    new String[] {Localization.lang("Save"), tryDiff, Localization.lang("Cancel")}, tryDiff);
+                    // @formatter:off
+                    new String[] {Localization.lang("Save"), tryDiff,
+                            Localization.lang("Cancel")}, tryDiff);
+                    // @formatter:on
 
             if (answer == JOptionPane.NO_OPTION) {
                 // The user wants to use another encoding.
@@ -2226,7 +2256,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             if (getFile() != null) {
                 frame.setTabTitle(BasePanel.this, getFile().getName(), getFile().getAbsolutePath());
             } else {
-                frame.setTabTitle(BasePanel.this, Localization.lang("untitled"), null);
+                frame.setTabTitle(BasePanel.this, GUIGlobals.untitledTitle, null);
             }
         }
         frame.setWindowTitle();
@@ -2356,8 +2386,11 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             be.setType(type);
         }
 
-        output(Localization.lang("Changed type to") + " '" + type.getName() + "' " + Localization.lang("for") + ' '
+        // @formatter:off
+        output(Localization.lang("Changed type to") + " '" + type.getName() + "' "
+                + Localization.lang("for") + ' '
                 + bes.length + ' ' + Localization.lang("entries") + '.');
+        // @formatter:on
         ce.end();
         undoManager.addEdit(ce);
         markBaseChanged();
@@ -2366,7 +2399,11 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
     public boolean showDeleteConfirmationDialog(int numberOfEntries) {
         if (Globals.prefs.getBoolean(JabRefPreferences.CONFIRM_DELETE)) {
-            String msg = Localization.lang("Really delete the selected") + ' ' + Localization.lang("entry") + '?';
+            String msg;
+            // @formatter:off
+            msg = Localization.lang("Really delete the selected") + ' ' +
+                    Localization.lang("entry") + '?';
+            // @formatter:on
             String title = Localization.lang("Delete entry");
             if (numberOfEntries > 1) {
                 msg = Localization.lang("Really delete the selected") + ' ' + numberOfEntries + ' '
@@ -2747,6 +2784,13 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
     public void setBackAndForwardEnabledState() {
         frame.back.setEnabled(!previousEntries.isEmpty());
         frame.forward.setEnabled(!nextEntries.isEmpty());
+    }
+
+    private String formatOutputMessage(String start, int count) {
+        // @formatter:off
+        return start + ' ' + count + ' ' + (count > 1 ? Localization.lang("entries") :
+            Localization.lang("entry"))  + '.';
+        // @formatter:on
     }
 
 

--- a/src/main/java/net/sf/jabref/gui/FieldSetComponent.java
+++ b/src/main/java/net/sf/jabref/gui/FieldSetComponent.java
@@ -73,7 +73,10 @@ class FieldSetComponent extends JPanel implements ActionListener {
      * values. These are put into a JComboBox.
      */
     public FieldSetComponent(String title, List<String> fields, List<String> preset, boolean arrows, boolean forceLowerCase) {
-        this(title, fields, preset, "Add", "Remove", arrows, forceLowerCase);
+        // @formatter:off
+        this(title, fields, preset, Localization.lang("Add"),
+                Localization.lang("Remove"), arrows, forceLowerCase);
+        // @formatter:on
     }
 
     /**
@@ -81,14 +84,17 @@ class FieldSetComponent extends JPanel implements ActionListener {
      * values. Replaces the JComboBox with a JTextField.
      */
     FieldSetComponent(String title, List<String> fields, boolean arrows, boolean forceLowerCase) {
-        this(title, fields, null, "Add", "Remove", arrows, forceLowerCase);
+        // @formatter:off
+        this(title, fields, null, Localization.lang("Add"),
+                Localization.lang("Remove"), arrows, forceLowerCase);
+        // @formatter:on
     }
 
     private FieldSetComponent(String title, List<String> fields, List<String> preset, String addText, String removeText,
                               boolean arrows, boolean forceLowerCase) {
         this.forceLowerCase = forceLowerCase;
-        add = new JButton(Localization.lang(addText));
-        remove = new JButton(Localization.lang(removeText));
+        add = new JButton(addText);
+        remove = new JButton(removeText);
         listModel = new DefaultListModel<>();
         JLabel title1 = null;
         if (title != null) {

--- a/src/main/java/net/sf/jabref/gui/FindUnlinkedFilesDialog.java
+++ b/src/main/java/net/sf/jabref/gui/FindUnlinkedFilesDialog.java
@@ -107,10 +107,12 @@ public class FindUnlinkedFilesDialog extends JDialog {
      * Keys to be used for referencing this Action.
      */
     public static final String ACTION_COMMAND = "findUnlinkedFiles";
-    public static final String ACTION_MENU_TITLE = "Find unlinked files...";
+    public static final String ACTION_MENU_TITLE = Localization.menuTitle("Find unlinked files...");
     public static final String ACTION_ICON = "toggleSearch";
     public static final String ACTION_KEYBINDING_ACTION = "Find unlinked files";
-    public static final String ACTION_SHORT_DESCRIPTION = "Searches for unlinked PDF files on the file system";
+    // @formatter:off
+    public static final String ACTION_SHORT_DESCRIPTION = Localization.lang("Searches for unlinked PDF files on the file system");
+    // @formatter:on
 
     private static final String GLOBAL_PREFS_WORKING_DIRECTORY_KEY = "findUnlinkedFilesWD";
     private static final String GLOBAL_PREFS_DIALOG_SIZE_KEY = "findUnlinkedFilesDialogSize";

--- a/src/main/java/net/sf/jabref/gui/GUIGlobals.java
+++ b/src/main/java/net/sf/jabref/gui/GUIGlobals.java
@@ -48,8 +48,8 @@ public class GUIGlobals {
 
     // Frame titles.
     public static final String frameTitle = "JabRef";
-    public static final String stringsTitle = "Strings for database";
-    public static final String untitledTitle = "untitled";
+    public static final String stringsTitle = Localization.lang("Strings for database");
+    public static final String untitledTitle = Localization.lang("untitled");
     public static final String NUMBER_COL = "#";
 
     public static Font CURRENTFONT;
@@ -227,7 +227,10 @@ public class GUIGlobals {
         GUIGlobals.tableIcons.put("eprint", label);
 
         label = new JLabel(IconTheme.JabRefIcon.WWW.getSmallIcon());
-        label.setToolTipText(Localization.lang("Open") + " DOI " + Localization.lang("web link"));
+        // @formatter:off
+        label.setToolTipText(Localization.lang("Open") + " DOI " +
+                Localization.lang("web link"));
+        // @formatter:on
         GUIGlobals.tableIcons.put("doi", label);
 
         label = new JLabel(IconTheme.JabRefIcon.FILE.getSmallIcon());

--- a/src/main/java/net/sf/jabref/gui/GroupAddRemoveDialog.java
+++ b/src/main/java/net/sf/jabref/gui/GroupAddRemoveDialog.java
@@ -54,8 +54,11 @@ public class GroupAddRemoveDialog implements BaseAction {
         selection = panel.getSelectedEntries();
 
         final JDialog diag = new JDialog(panel.frame(),
-                Localization.lang(add ? (move ? "Move to group" : "Add to group")
-                        : "Remove from group"), true);
+                // @formatter:off
+                (add ? (move ? Localization.lang("Move to group") :
+                    Localization.lang("Add to group")) :
+                    Localization.lang("Remove from group")), true);
+                // formatter:on
         ok = new JButton(Localization.lang("Ok"));
         JButton cancel = new JButton(Localization.lang("Cancel"));
         tree = new JTree(groups);

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -293,9 +293,12 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             Localization.lang("Back"), prefs.getKey(KeyBinds.BACK), IconTheme.JabRefIcon.LEFT.getIcon());
     private final AbstractAction delete = new GeneralAction(Actions.DELETE, Localization.menuTitle("Delete"),
             Localization.lang("Delete"), prefs.getKey(KeyBinds.DELETE), IconTheme.JabRefIcon.DELETE.getIcon());
-    private final AbstractAction copy = new EditAction(Actions.COPY, IconTheme.JabRefIcon.COPY.getIcon());
-    private final AbstractAction paste = new EditAction(Actions.PASTE, IconTheme.JabRefIcon.PASTE.getIcon());
-    private final AbstractAction cut = new EditAction(Actions.CUT, IconTheme.JabRefIcon.CUT.getIcon());
+    private final AbstractAction copy = new EditAction(Actions.COPY, Localization.lang("Copy"),
+            IconTheme.JabRefIcon.COPY.getIcon());
+    private final AbstractAction paste = new EditAction(Actions.PASTE, Localization.lang("Paste"),
+            IconTheme.JabRefIcon.PASTE.getIcon());
+    private final AbstractAction cut = new EditAction(Actions.CUT, Localization.lang("Cut"),
+            IconTheme.JabRefIcon.CUT.getIcon());
     private final AbstractAction mark = new GeneralAction(Actions.MARK_ENTRIES, Localization.menuTitle("Mark entries"),
             Localization.lang("Mark entries"), prefs.getKey(KeyBinds.MARK_ENTRIES), IconTheme.JabRefIcon.MARK_ENTRIES.getIcon());
     private final AbstractAction unmark = new GeneralAction(Actions.UNMARK_ENTRIES,
@@ -370,8 +373,8 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             prefs.getKey(KeyBinds.TOGGLE_GROUPS_INTERFACE),
             IconTheme.JabRefIcon.TOGGLE_GROUPS.getIcon());
     private final AbstractAction addToGroup = new GeneralAction(Actions.ADD_TO_GROUP, Localization.lang("Add to group"));
-    private final AbstractAction removeFromGroup = new GeneralAction(Actions.REMOVE_FROM_GROUP, Localization.lang(
-            "Remove from group"));
+    private final AbstractAction removeFromGroup = new GeneralAction(Actions.REMOVE_FROM_GROUP,
+            Localization.lang("Remove from group"));
     private final AbstractAction moveToGroup = new GeneralAction(Actions.MOVE_TO_GROUP, Localization.lang("Move to group"));
 
 
@@ -493,9 +496,8 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     final ManageKeywordsAction manageKeywords = new ManageKeywordsAction(this);
 
     private final GeneralAction findUnlinkedFiles = new GeneralAction(
-            FindUnlinkedFilesDialog.ACTION_COMMAND,
-            Localization.menuTitle(FindUnlinkedFilesDialog.ACTION_MENU_TITLE),
-            Localization.lang(FindUnlinkedFilesDialog.ACTION_SHORT_DESCRIPTION),
+FindUnlinkedFilesDialog.ACTION_COMMAND,
+            FindUnlinkedFilesDialog.ACTION_MENU_TITLE, FindUnlinkedFilesDialog.ACTION_SHORT_DESCRIPTION,
             prefs.getKey(FindUnlinkedFilesDialog.ACTION_KEYBINDING_ACTION)
     );
 
@@ -699,7 +701,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         if (bp.getFile() != null) {
             setTitle(GUIGlobals.frameTitle + " - " + bp.getFile().getPath() + star);
         } else {
-            setTitle(GUIGlobals.frameTitle + " - " + Localization.lang("untitled") + star);
+            setTitle(GUIGlobals.frameTitle + " - " + GUIGlobals.untitledTitle + star);
         }
     }
 
@@ -1176,17 +1178,17 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     private void fillMenu() {
         //mb.putClientProperty(Options.HEADER_STYLE_KEY, HeaderStyle.BOTH);
         mb.setBorder(null);
-        JMenu file = JabRefFrame.subMenu("File");
-        JMenu sessions = JabRefFrame.subMenu("Sessions");
-        JMenu edit = JabRefFrame.subMenu("Edit");
-        JMenu search = JabRefFrame.subMenu("Search");
-        JMenu groups = JabRefFrame.subMenu("Groups");
-        JMenu bibtex = JabRefFrame.subMenu("BibTeX");
-        JMenu view = JabRefFrame.subMenu("View");
-        JMenu tools = JabRefFrame.subMenu("Tools");
-        JMenu options = JabRefFrame.subMenu("Options");
-        JMenu newSpec = JabRefFrame.subMenu("New entry...");
-        JMenu helpMenu = JabRefFrame.subMenu("Help");
+        JMenu file = JabRefFrame.subMenu(Localization.lang("File"));
+        JMenu sessions = JabRefFrame.subMenu(Localization.lang("Sessions"));
+        JMenu edit = JabRefFrame.subMenu(Localization.lang("Edit"));
+        JMenu search = JabRefFrame.subMenu(Localization.lang("Search"));
+        JMenu groups = JabRefFrame.subMenu(Localization.lang("Groups"));
+        JMenu bibtex = JabRefFrame.subMenu(Localization.lang("BibTeX"));
+        JMenu view = JabRefFrame.subMenu(Localization.lang("View"));
+        JMenu tools = JabRefFrame.subMenu(Localization.lang("Tools"));
+        JMenu options = JabRefFrame.subMenu(Localization.lang("Options"));
+        JMenu newSpec = JabRefFrame.subMenu(Localization.lang("New entry..."));
+        JMenu helpMenu = JabRefFrame.subMenu(Localization.lang("Help"));
 
         file.add(newDatabaseAction);
         file.add(open); //opendatabaseaction
@@ -1394,7 +1396,6 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     }
 
     public static JMenu subMenu(String name) {
-        name = Localization.menuTitle(name);
         int i = name.indexOf('&');
         JMenu res;
         if (i >= 0) {
@@ -1658,7 +1659,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     public void addTab(BasePanel bp, File file, boolean raisePanel) {
         String title;
         if (file == null) {
-            title = Localization.lang(GUIGlobals.untitledTitle);
+            title = GUIGlobals.untitledTitle;
             if (!bp.database().getEntries().isEmpty()) {
                 // if the database is not empty and no file is assigned,
                 // the database came from an import and has to be treated somehow
@@ -2110,7 +2111,10 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
 
         public ChangeTabAction(boolean next) {
-            putValue(Action.NAME, next ? Localization.menuTitle("Next tab") : Localization.menuTitle("Previous tab"));
+            // @formatter:off
+            putValue(Action.NAME, next ? Localization.menuTitle("Next tab") :
+                Localization.menuTitle("Previous tab"));
+            // @formatter:on
             this.next = next;
             putValue(Action.ACCELERATOR_KEY,
                     next ? prefs.getKey(KeyBinds.NEXT_TAB) : prefs.getKey(KeyBinds.PREVIOUS_TAB));
@@ -2138,13 +2142,14 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     class EditAction extends MnemonicAwareAction {
         private final String command;
 
-        public EditAction(String command, Icon icon) {
+
+        public EditAction(String command, String name, Icon icon) {
             super(icon);
             this.command = command;
             String nName = StringUtil.capitalizeFirst(command);
             putValue(Action.NAME, nName);
             putValue(Action.ACCELERATOR_KEY, prefs.getKey(nName));
-            putValue(Action.SHORT_DESCRIPTION, Localization.lang(nName));
+            putValue(Action.SHORT_DESCRIPTION, name);
             //putValue(ACCELERATOR_KEY,
             //         (next?prefs.getKey(KeyBinds.NEXT_TAB):prefs.getKey(KeyBinds.PREVIOUS_TAB)));
         }

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -1178,17 +1178,17 @@ FindUnlinkedFilesDialog.ACTION_COMMAND,
     private void fillMenu() {
         //mb.putClientProperty(Options.HEADER_STYLE_KEY, HeaderStyle.BOTH);
         mb.setBorder(null);
-        JMenu file = JabRefFrame.subMenu(Localization.lang("File"));
-        JMenu sessions = JabRefFrame.subMenu(Localization.lang("Sessions"));
-        JMenu edit = JabRefFrame.subMenu(Localization.lang("Edit"));
-        JMenu search = JabRefFrame.subMenu(Localization.lang("Search"));
-        JMenu groups = JabRefFrame.subMenu(Localization.lang("Groups"));
-        JMenu bibtex = JabRefFrame.subMenu(Localization.lang("BibTeX"));
-        JMenu view = JabRefFrame.subMenu(Localization.lang("View"));
-        JMenu tools = JabRefFrame.subMenu(Localization.lang("Tools"));
-        JMenu options = JabRefFrame.subMenu(Localization.lang("Options"));
-        JMenu newSpec = JabRefFrame.subMenu(Localization.lang("New entry..."));
-        JMenu helpMenu = JabRefFrame.subMenu(Localization.lang("Help"));
+        JMenu file = JabRefFrame.subMenu(Localization.menuTitle("File"));
+        JMenu sessions = JabRefFrame.subMenu(Localization.menuTitle("Sessions"));
+        JMenu edit = JabRefFrame.subMenu(Localization.menuTitle("Edit"));
+        JMenu search = JabRefFrame.subMenu(Localization.menuTitle("Search"));
+        JMenu groups = JabRefFrame.subMenu(Localization.menuTitle("Groups"));
+        JMenu bibtex = JabRefFrame.subMenu(Localization.menuTitle("BibTeX"));
+        JMenu view = JabRefFrame.subMenu(Localization.menuTitle("View"));
+        JMenu tools = JabRefFrame.subMenu(Localization.menuTitle("Tools"));
+        JMenu options = JabRefFrame.subMenu(Localization.menuTitle("Options"));
+        JMenu newSpec = JabRefFrame.subMenu(Localization.menuTitle("New entry..."));
+        JMenu helpMenu = JabRefFrame.subMenu(Localization.menuTitle("Help"));
 
         file.add(newDatabaseAction);
         file.add(open); //opendatabaseaction
@@ -1240,7 +1240,7 @@ FindUnlinkedFilesDialog.ACTION_COMMAND,
 
         edit.addSeparator();
         edit.add(mark);
-        JMenu markSpecific = JabRefFrame.subMenu("Mark specific color");
+        JMenu markSpecific = JabRefFrame.subMenu(Localization.menuTitle("Mark specific color"));
         for (int i = 0; i < EntryMarker.MAX_MARKING_LEVEL; i++) {
             markSpecific.add(new MarkEntriesAction(this, i).getMenuItem());
         }

--- a/src/main/java/net/sf/jabref/gui/KeyBindingsDialog.java
+++ b/src/main/java/net/sf/jabref/gui/KeyBindingsDialog.java
@@ -269,7 +269,10 @@ class KeyBindingsDialog extends JDialog {
 
         @Override
         public String getColumnName(int col) {
-            return col == 0 ? Localization.lang("Action") : Localization.lang("Shortcut");
+            // @formatter:off
+            return col == 0 ? Localization.lang("Action") :
+                Localization.lang("Shortcut");
+            // @formatter:on
         }
 
         @Override
@@ -320,14 +323,18 @@ class KeyBindingsDialog extends JDialog {
             public void actionPerformed(ActionEvent e) {
                 int[] selected = table.getSelectedRows();
                 if (selected.length == 0) {
-                    int answer = JOptionPane.showOptionDialog(KeyBindingsDialog.this,
+                    int answer;
+                    // @formatter:off
+                    answer = JOptionPane.showOptionDialog(KeyBindingsDialog.this,
                             Localization.lang("All key bindings will be reset to their defaults.") + " " +
                             Localization.lang("Continue?"),
                             Localization.lang("Resetting all key bindings"),
                             JOptionPane.YES_NO_OPTION,
                             JOptionPane.QUESTION_MESSAGE, null,
-                            new String[] {Localization.lang("Ok"), Localization.lang("Cancel")},
+                            new String[] {Localization.lang("Ok"),
+                                    Localization.lang("Cancel")},
                             Localization.lang("Ok"));
+                    // @formatter:on
                     if (answer == JOptionPane.YES_OPTION) {
                         bindHM.clear();
                         Set<Entry<String, String>> entrySet = defBinds.entrySet();

--- a/src/main/java/net/sf/jabref/gui/MainTableSelectionListener.java
+++ b/src/main/java/net/sf/jabref/gui/MainTableSelectionListener.java
@@ -77,7 +77,7 @@ public class MainTableSelectionListener implements ListEventListener<BibtexEntry
     private long lastPressedTime;
 
     private static final Log LOGGER = LogFactory.getLog(MainTableSelectionListener.class);
-    
+
     //private int lastCharPressed = -1;
 
     public MainTableSelectionListener(BasePanel panel, MainTable table) {
@@ -409,7 +409,7 @@ public class MainTableSelectionListener implements ListEventListener<BibtexEntry
                                 panel.metaData(), type);
                         boolean success = item.openLink();
                         if (!success) {
-                            panel.output(Globals.lang("Unable to open link."));
+                            panel.output(Localization.lang("Unable to open link."));
                         } */
                         //Util.openExternalViewer(panel.metaData(), (String)link, fieldName);
                     }

--- a/src/main/java/net/sf/jabref/gui/MergeDialog.java
+++ b/src/main/java/net/sf/jabref/gui/MergeDialog.java
@@ -74,7 +74,6 @@ public class MergeDialog extends JDialog {
         Cancel.addActionListener(new MergeDialog_Cancel_actionAdapter(this));
         jPanel1.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
         jPanel1.setLayout(gridBagLayout1);
-        entries.setToolTipText("");
         entries.setSelected(true);
         entries.setText(Localization.lang("Import entries"));
         strings.setSelected(true);

--- a/src/main/java/net/sf/jabref/gui/PdfPreviewPanel.java
+++ b/src/main/java/net/sf/jabref/gui/PdfPreviewPanel.java
@@ -100,7 +100,7 @@ class PdfPreviewPanel extends JPanel {
     private BufferedImage resizeImage(BufferedImage originalImage, int width, int height, int type) {
         int h = originalImage.getHeight();
         int w = originalImage.getWidth();
-        if (height == 0 || width == 0) {
+        if ((height == 0) || (width == 0)) {
             height = h;
             width = w;
         } else {
@@ -153,7 +153,7 @@ class PdfPreviewPanel extends JPanel {
 
     private void clearPreview() {
         this.picLabel.setIcon(null);
-        this.picLabel.setText(Localization.lang("no preview available"));
+        this.picLabel.setText(Localization.lang("No preview available"));
     }
 
 }

--- a/src/main/java/net/sf/jabref/gui/SearchManager.java
+++ b/src/main/java/net/sf/jabref/gui/SearchManager.java
@@ -799,7 +799,10 @@ public class SearchManager extends SidePaneComponent
      * the type of search that will happen on click.
      */
     private void updateSearchButtonText() {
-        search.setText(isSpecificSearch() ? Localization.lang("Search specified field(s)") : Localization.lang("Search all fields"));
+        // @formatter:off
+        search.setText(isSpecificSearch() ? Localization.lang("Search specified field(s)") :
+            Localization.lang("Search all fields"));
+        // @formatter:on
     }
 
     private boolean isSpecificSearch() {

--- a/src/main/java/net/sf/jabref/gui/StringDialog.java
+++ b/src/main/java/net/sf/jabref/gui/StringDialog.java
@@ -155,12 +155,9 @@ class StringDialog extends JDialog {
         conPane.add(pan, BorderLayout.CENTER);
 
         if (panel.getFile() != null) {
-            setTitle(Localization.lang(GUIGlobals.stringsTitle) + ": " + panel.getFile().getName());
+            setTitle(GUIGlobals.stringsTitle + ": " + panel.getFile().getName());
         } else {
-            // @formatter:off
-            setTitle(Localization.lang(GUIGlobals.stringsTitle) + ": "
-                    + Localization.lang(GUIGlobals.untitledTitle));
-            // @formatter:on
+            setTitle(GUIGlobals.stringsTitle + ": " + GUIGlobals.untitledTitle);
         }
     }
 

--- a/src/main/java/net/sf/jabref/gui/actions/CleanUpAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/CleanUpAction.java
@@ -374,9 +374,8 @@ public class CleanUpAction extends AbstractWorker {
             return;
         }
         if (unsuccessfulRenames > 0) { //Rename failed for at least one entry
-            JOptionPane.showMessageDialog(frame, Localization.lang("File rename failed for") + " "
-                    + unsuccessfulRenames
-                    + " " + Localization.lang("entries") + ".",
+            JOptionPane.showMessageDialog(frame,
+                    Localization.lang("File rename failed for %0 entries.", Integer.toString(unsuccessfulRenames)),
                     Localization.lang("Autogenerate PDF Names"), JOptionPane.INFORMATION_MESSAGE);
         }
         if (modifiedEntriesCount > 0) {

--- a/src/main/java/net/sf/jabref/gui/actions/NewSubDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/NewSubDatabaseAction.java
@@ -16,7 +16,7 @@ import java.awt.event.ActionEvent;
  */
 public class NewSubDatabaseAction extends MnemonicAwareAction {
 
-    private JabRefFrame jabRefFrame;
+    private final JabRefFrame jabRefFrame;
 
     public NewSubDatabaseAction(JabRefFrame jabRefFrame) {
         super(IconTheme.JabRefIcon.NEW.getIcon());
@@ -39,7 +39,7 @@ public class NewSubDatabaseAction extends MnemonicAwareAction {
                     dialog.getGenerateDB(), // database
                     null, // file
                     new MetaData(), Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING)); // meta data
-            jabRefFrame.tabbedPane.add(Localization.lang(GUIGlobals.untitledTitle), bp);
+            jabRefFrame.tabbedPane.add(GUIGlobals.untitledTitle, bp);
             jabRefFrame.tabbedPane.setSelectedComponent(bp);
             jabRefFrame.output(Localization.lang("New database created."));
         }

--- a/src/main/java/net/sf/jabref/gui/desktop/JabRefDesktop.java
+++ b/src/main/java/net/sf/jabref/gui/desktop/JabRefDesktop.java
@@ -43,7 +43,7 @@ public class JabRefDesktop {
 
             // Check that the file exists:
             if ((file == null) || !file.exists()) {
-                throw new IOException(Localization.lang("File not found") + " (" + fieldName + "): '" + link + "'.");
+                throw new IOException("File not found (" + fieldName + "): '" + link + "'.");
             }
             link = file.getCanonicalPath();
 

--- a/src/main/java/net/sf/jabref/gui/desktop/JabRefDesktop.java
+++ b/src/main/java/net/sf/jabref/gui/desktop/JabRefDesktop.java
@@ -305,8 +305,11 @@ public class JabRefDesktop {
             String link, UnknownExternalFileType fileType) throws IOException {
 
         String cancelMessage = Localization.lang("Unable to open file.");
+        // @formatter:off
         String[] options = new String[] {Localization.lang("Define '%0'", fileType.getName()),
-                Localization.lang("Change file type"), Localization.lang("Cancel")};
+                Localization.lang("Change file type"),
+                Localization.lang("Cancel")};
+        // @formatter:on
         String defOption = options[0];
         int answer = JOptionPane.showOptionDialog(frame, Localization.lang("This external link is of the type '%0', which is undefined. What do you want to do?",
                         fileType.getName()),

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -1152,7 +1152,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
             panel.database.removeEntry(entry.getId());
             panel.markBaseChanged();
             panel.undoManager.addEdit(new UndoableRemoveEntry(panel.database, entry, panel));
-            panel.output(Localization.lang("Deleted") + ' ' + Localization.lang("entry"));
+            panel.output(Localization.lang("Deleted entry"));
         }
     }
 

--- a/src/main/java/net/sf/jabref/gui/fieldeditors/contextmenu/CaseChangeMenu.java
+++ b/src/main/java/net/sf/jabref/gui/fieldeditors/contextmenu/CaseChangeMenu.java
@@ -36,7 +36,7 @@ public class CaseChangeMenu extends JMenu {
 
         // create menu items, one for each case changer
         for (final Formatter caseChanger : CaseChangers.ALL) {
-            JMenuItem menuItem = new JMenuItem(Localization.lang(caseChanger.getName()));
+            JMenuItem menuItem = new JMenuItem(caseChanger.getName());
             menuItem.addActionListener(new ActionListener() {
 
                 @Override

--- a/src/main/java/net/sf/jabref/gui/fieldeditors/contextmenu/ConversionMenu.java
+++ b/src/main/java/net/sf/jabref/gui/fieldeditors/contextmenu/ConversionMenu.java
@@ -43,7 +43,7 @@ public class ConversionMenu extends JMenu {
 
         // create menu items, one for each case changer
         for (final Converters.Converter converter : Converters.ALL) {
-            JMenuItem menuItem = new JMenuItem(Localization.lang(converter.getName()));
+            JMenuItem menuItem = new JMenuItem(converter.getName());
             menuItem.addActionListener(new ActionListener() {
 
                 @Override

--- a/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
+++ b/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
@@ -347,7 +347,7 @@ class ManageJournalsPanel extends JPanel {
             if (!newNameTf.getText().isEmpty()) {
                 f = new File(newNameTf.getText());
                 return !f.exists() || (JOptionPane.showConfirmDialog(this,
-                        "'" + f.getName() + "' " + Localization.lang("exists. Overwrite file?"),
+                        Localization.lang("'%0' exists. Overwrite file?", f.getName()),
                         Localization.lang("Store journal abbreviations"),
                         JOptionPane.OK_CANCEL_OPTION) == JOptionPane.OK_OPTION);
             } else {

--- a/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
+++ b/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
@@ -48,11 +48,8 @@ import com.jgoodies.forms.layout.FormLayout;
 import net.sf.jabref.logic.l10n.Localization;
 
 /**
- * Created by IntelliJ IDEA.
- * User: alver
- * Date: Sep 19, 2005
- * Time: 7:57:29 PM
- * To browseOld this template use File | Settings | File Templates.
+ * Created by IntelliJ IDEA. User: alver Date: Sep 19, 2005 Time: 7:57:29 PM To browseOld this template use File |
+ * Settings | File Templates.
  */
 class ManageJournalsPanel extends JPanel {
 
@@ -89,18 +86,20 @@ class ManageJournalsPanel extends JPanel {
         addExtPan.add(addExt, BorderLayout.EAST);
         addExtPan.setToolTipText(Localization.lang("Add"));
         //addExtPan.setBorder(BorderFactory.createMatteBorder(1,1,1,1,Color.red));
-        FormLayout layout = new FormLayout
-                ("1dlu, 8dlu, left:pref, 4dlu, fill:200dlu:grow, 4dlu, fill:pref",// 4dlu, left:pref, 4dlu",
-                        "pref, pref, pref, 20dlu, 20dlu, fill:200dlu, 4dlu, pref");//150dlu");
+        FormLayout layout = new FormLayout("1dlu, 8dlu, left:pref, 4dlu, fill:200dlu:grow, 4dlu, fill:pref", // 4dlu, left:pref, 4dlu",
+                "pref, pref, pref, 20dlu, 20dlu, fill:200dlu, 4dlu, pref");//150dlu");
         FormBuilder builder = FormBuilder.create().layout(layout);
 
         /*JLabel description = new JLabel("<HTML>"+Glbals.lang("JabRef can switch journal names between "
             +"abbreviated and full form. Since it knows only a limited number of journal names, "
             +"you may need to add your own definitions.")+"</HTML>");*/
         builder.addSeparator(Localization.lang("Built-in journal list")).xyw(2, 1, 6);
-        JLabel description = new JLabel("<HTML>" + Localization.lang("JabRef includes a built-in list of journal abbreviations.")
-        + "<br>" + Localization.lang("You can add additional journal names by setting up a personal journal list,<br>as "
-                + "well as linking to external journal lists.") + "</HTML>");
+        JLabel description = new JLabel(
+                "<HTML>" + Localization.lang("JabRef includes a built-in list of journal abbreviations.") + "<br>"
+                        + Localization
+                                .lang("You can add additional journal names by setting up a personal journal list,<br>as "
+                                        + "well as linking to external journal lists.")
+                        + "</HTML>");
         description.setBorder(BorderFactory.createEmptyBorder(5, 0, 5, 0));
         builder.add(description).xyw(2, 2, 6);
         JButton viewBuiltin = new JButton(Localization.lang("View"));
@@ -146,7 +145,8 @@ class ManageJournalsPanel extends JPanel {
         bb.addButton(cancel);
         bb.addUnrelatedGap();
 
-        JButton help = new HelpAction(GUIGlobals.helpDiag, GUIGlobals.journalAbbrHelp, IconTheme.JabRefIcon.HELP.getSmallIcon()).getIconButton();
+        JButton help = new HelpAction(GUIGlobals.helpDiag, GUIGlobals.journalAbbrHelp,
+                IconTheme.JabRefIcon.HELP.getSmallIcon()).getIconButton();
         bb.addButton(help);
         bb.addGlue();
         bb.getPanel().setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
@@ -157,8 +157,7 @@ class ManageJournalsPanel extends JPanel {
         //add(new JScrollPane(builtInTable), BorderLayout.CENTER);
 
         // Set up panel for editing a single journal, to be used in a dialog box:
-        FormLayout layout2 = new FormLayout
-                ("right:pref, 4dlu, fill:180dlu", "p, 2dlu, p");
+        FormLayout layout2 = new FormLayout("right:pref, 4dlu, fill:180dlu", "p, 2dlu, p");
         FormBuilder builder2 = FormBuilder.create().layout(layout2);
         builder2.add(Localization.lang("Journal name")).xy(1, 1);
         builder2.add(nameTf).xy(3, 1);
@@ -174,7 +173,8 @@ class ManageJournalsPanel extends JPanel {
                 abbr.readJournalListFromResource(Abbreviations.JOURNALS_FILE_BUILTIN);
                 JTable table = new JTable(JournalAbbreviationsUtil.getTableModel(Abbreviations.journalAbbrev));
                 JScrollPane pane = new JScrollPane(table);
-                JOptionPane.showMessageDialog(null, pane, Localization.lang("Journal list preview"), JOptionPane.INFORMATION_MESSAGE);
+                JOptionPane.showMessageDialog(null, pane, Localization.lang("Journal list preview"),
+                        JOptionPane.INFORMATION_MESSAGE);
             }
         });
 
@@ -220,7 +220,9 @@ class ManageJournalsPanel extends JPanel {
                         storeSettings();
                         dialog.dispose();
                     } catch (FileNotFoundException ex) {
-                        JOptionPane.showMessageDialog(null, Localization.lang("Error opening file") + ": " + ex.getMessage(), Localization.lang("Error opening file"), JOptionPane.ERROR_MESSAGE);
+                        JOptionPane.showMessageDialog(null,
+                                Localization.lang("Error opening file") + ": " + ex.getMessage(),
+                                Localization.lang("Error opening file"), JOptionPane.ERROR_MESSAGE);
                     }
                 }
             }
@@ -285,10 +287,10 @@ class ManageJournalsPanel extends JPanel {
             builder.appendRows("2dlu, p");
             row += 2;
         }
-        builder.add(Box.createVerticalGlue()).xy(1,row);
+        builder.add(Box.createVerticalGlue()).xy(1, row);
         builder.appendRows("2dlu, p, 2dlu, p");
-        builder.add(addExtPan).xy(1, row+2);
-        builder.add(Box.createVerticalGlue()).xy(1, row+2);
+        builder.add(addExtPan).xy(1, row + 2);
+        builder.add(Box.createVerticalGlue()).xy(1, row + 2);
 
         //builder.getPanel().setBorder(BorderFactory.createMatteBorder(1,1,1,1,Color.green));
         //externalFilesPanel.setBorder(BorderFactory.createMatteBorder(1,1,1,1,Color.red));
@@ -344,13 +346,14 @@ class ManageJournalsPanel extends JPanel {
         if (newFile.isSelected()) {
             if (!newNameTf.getText().isEmpty()) {
                 f = new File(newNameTf.getText());
-                return !f.exists() || (JOptionPane.showConfirmDialog
-                        (this, "'" + f.getName() + "' " + Localization.lang("exists. Overwrite file?"),
-                                Localization.lang("Store journal abbreviations"), JOptionPane.OK_CANCEL_OPTION)
-                        == JOptionPane.OK_OPTION);
+                return !f.exists() || (JOptionPane.showConfirmDialog(this,
+                        "'" + f.getName() + "' " + Localization.lang("exists. Overwrite file?"),
+                        Localization.lang("Store journal abbreviations"),
+                        JOptionPane.OK_CANCEL_OPTION) == JOptionPane.OK_OPTION);
             } else {
                 if (tableModel.getRowCount() > 0) {
-                    JOptionPane.showMessageDialog(this, Localization.lang("You must choose a filename to store journal abbreviations"),
+                    JOptionPane.showMessageDialog(this,
+                            Localization.lang("You must choose a filename to store journal abbreviations"),
                             Localization.lang("Store journal abbreviations"), JOptionPane.ERROR_MESSAGE);
                     return false;
                 } else {
@@ -367,9 +370,9 @@ class ManageJournalsPanel extends JPanel {
         if (newFile.isSelected()) {
             if (!newNameTf.getText().isEmpty()) {
                 f = new File(newNameTf.getText());
-            }// else {
-            //    return; // Nothing to do.
-            //}
+            } // else {
+              //    return; // Nothing to do.
+              //}
         } else {
             f = new File(personalFile.getText());
         }
@@ -440,8 +443,8 @@ class ManageJournalsPanel extends JPanel {
             File toFile;
             try {
                 URL url = new URL(chosen);
-                String toName = FileDialogs.getNewFile(frame, new File(System.getProperty("user.home")),
-                        null, JFileChooser.SAVE_DIALOG, false);
+                String toName = FileDialogs.getNewFile(frame, new File(System.getProperty("user.home")), null,
+                        JFileChooser.SAVE_DIALOG, false);
                 if (toName == null) {
                     return;
                 } else {
@@ -472,11 +475,11 @@ class ManageJournalsPanel extends JPanel {
         public void actionPerformed(ActionEvent e) {
             String chosen;
             if (dir) {
-                chosen = FileDialogs.getNewDir(frame, new File(comp.getText()), Globals.NONE,
-                        JFileChooser.OPEN_DIALOG, false);
+                chosen = FileDialogs.getNewDir(frame, new File(comp.getText()), Globals.NONE, JFileChooser.OPEN_DIALOG,
+                        false);
             } else {
-                chosen = FileDialogs.getNewFile(frame, new File(comp.getText()), Globals.NONE,
-                        JFileChooser.OPEN_DIALOG, false);
+                chosen = FileDialogs.getNewFile(frame, new File(comp.getText()), Globals.NONE, JFileChooser.OPEN_DIALOG,
+                        false);
             }
             if (chosen != null) {
                 File nFile = new File(chosen);
@@ -487,7 +490,10 @@ class ManageJournalsPanel extends JPanel {
 
     class AbbreviationsTableModel extends AbstractTableModel implements ActionListener {
 
-        final String[] names = new String[] {Localization.lang("Journal name"), Localization.lang("Abbreviation")};
+        // @formatter:off
+        final String[] names = new String[] {Localization.lang("Journal name"),
+                Localization.lang("Abbreviation")};
+        //
         List<JournalEntry> journals;
 
 
@@ -587,8 +593,7 @@ class ManageJournalsPanel extends JPanel {
                     Collections.sort(journals);
                     fireTableDataChanged();
                 }
-            }
-            else if (e.getSource() == remove) {
+            } else if (e.getSource() == remove) {
                 int[] rows = userTable.getSelectedRows();
                 if (rows.length > 0) {
                     for (int i = rows.length - 1; i >= 0; i--) {
@@ -626,8 +631,8 @@ class ManageJournalsPanel extends JPanel {
             browse.addActionListener(browseA);
             DownloadAction da = new DownloadAction(tf);
             download.addActionListener(da);
-            FormBuilder builder = FormBuilder.create().
-                    layout(new FormLayout("fill:pref:grow, 4dlu, fill:pref, 4dlu, fill:pref, 4dlu, fill:pref, 4dlu, fill:pref", "p"));
+            FormBuilder builder = FormBuilder.create().layout(new FormLayout(
+                    "fill:pref:grow, 4dlu, fill:pref, 4dlu, fill:pref, 4dlu, fill:pref, 4dlu, fill:pref", "p"));
             builder.add(tf).xy(1, 1);
             builder.add(browse).xy(3, 1);
             builder.add(download).xy(5, 1);
@@ -646,7 +651,8 @@ class ManageJournalsPanel extends JPanel {
 
                         JTable table = new JTable(JournalAbbreviationsUtil.getTableModel(abbr));
                         JScrollPane pane = new JScrollPane(table);
-                        JOptionPane.showMessageDialog(null, pane, Localization.lang("Journal list preview"), JOptionPane.INFORMATION_MESSAGE);
+                        JOptionPane.showMessageDialog(null, pane, Localization.lang("Journal list preview"),
+                                JOptionPane.INFORMATION_MESSAGE);
                     } catch (FileNotFoundException ex) {
                         JOptionPane.showMessageDialog(null, Localization.lang("File '%0' not found", tf.getText()),
                                 Localization.lang("Error"), JOptionPane.ERROR_MESSAGE);
@@ -677,6 +683,7 @@ class ManageJournalsPanel extends JPanel {
 
         String name;
         String abbreviation;
+
 
         public JournalEntry(String name, String abbreviation) {
             this.name = name;

--- a/src/main/java/net/sf/jabref/gui/menus/help/ForkMeOnGitHubAction.java
+++ b/src/main/java/net/sf/jabref/gui/menus/help/ForkMeOnGitHubAction.java
@@ -41,7 +41,8 @@ public class ForkMeOnGitHubAction extends AbstractAction {
             JabRefDesktop.openBrowser("https://github.com/JabRef/jabref");
         } catch (IOException ex) {
             ex.printStackTrace();
-            JabRef.jrf.basePanel().output(Localization.lang("Could not open browser.") + " " + Localization.lang("Please open http://github.com/JabRef/jabref manually."));
+            JabRef.jrf.basePanel().output(Localization.lang("Could not open browser.") + " "
+                    + Localization.lang("Please open http://github.com/JabRef/jabref manually."));
         }
     }
 }

--- a/src/main/java/net/sf/jabref/gui/preftabs/AdvancedTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/AdvancedTab.java
@@ -28,9 +28,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.UIManager;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
-
 import net.sf.jabref.*;
 import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.gui.help.HelpAction;
@@ -75,12 +72,9 @@ class AdvancedTab extends JPanel implements PrefsTab {
         useIEEEAbrv = new JCheckBox(Localization.lang("Use IEEE LaTeX abbreviations"));
         biblatexMode = new JCheckBox(Localization.lang("BibLaTeX mode"));
         remoteServerPort = new JTextField();
-        String[] possibleLookAndFeels = {
-                UIManager.getSystemLookAndFeelClassName(),
-                UIManager.getCrossPlatformLookAndFeelClassName(),
-                "com.jgoodies.looks.plastic.Plastic3DLookAndFeel",
-                "com.jgoodies.looks.windows.WindowsLookAndFeel"
-        };
+        String[] possibleLookAndFeels = {UIManager.getSystemLookAndFeelClassName(),
+                UIManager.getCrossPlatformLookAndFeelClassName(), "com.jgoodies.looks.plastic.Plastic3DLookAndFeel",
+                "com.jgoodies.looks.windows.WindowsLookAndFeel"};
         // Only list L&F which are available
         List<String> lookAndFeels = new ArrayList<>();
         for (String lf : possibleLookAndFeels) {
@@ -108,7 +102,8 @@ class AdvancedTab extends JPanel implements PrefsTab {
 
         if (!OS.OS_X) {
             builder.appendSeparator(Localization.lang("Look and feel"));
-            JLabel lab = new JLabel(Localization.lang("Default look and feel") + ": " + UIManager.getSystemLookAndFeelClassName());
+            JLabel lab = new JLabel(
+                    Localization.lang("Default look and feel") + ": " + UIManager.getSystemLookAndFeelClassName());
             builder.nextLine();
             builder.append(pan);
             builder.append(lab);
@@ -124,21 +119,25 @@ class AdvancedTab extends JPanel implements PrefsTab {
             builder.append(pan2);
             builder.nextLine();
             builder.append(pan);
-            lab = new JLabel(Localization.lang("Note that you must specify the fully qualified class name for the look and feel,"));
+            lab = new JLabel(Localization
+                    .lang("Note that you must specify the fully qualified class name for the look and feel,"));
             builder.append(lab);
             builder.nextLine();
             builder.append(pan);
-            lab = new JLabel(Localization.lang("and the class must be available in your classpath next time you start JabRef."));
+            lab = new JLabel(
+                    Localization.lang("and the class must be available in your classpath next time you start JabRef."));
             builder.append(lab);
             builder.nextLine();
         }
         builder.appendSeparator(Localization.lang("Remote operation"));
         builder.nextLine();
         builder.append(new JPanel());
-        builder.append(new JLabel("<html>" + Localization.lang("This feature lets new files be opened or imported into an "
-                + "already running instance of JabRef<BR>instead of opening a new instance. For instance, this "
-                + "is useful when you open a file in JabRef<br>from your web browser."
-                + "<BR>Note that this will prevent you from running more than one instance of JabRef at a time.") + "</html>"));
+        builder.append(new JLabel("<html>"
+                + Localization.lang("This feature lets new files be opened or imported into an "
+                        + "already running instance of JabRef<BR>instead of opening a new instance. For instance, this "
+                        + "is useful when you open a file in JabRef<br>from your web browser."
+                        + "<BR>Note that this will prevent you from running more than one instance of JabRef at a time.")
+                + "</html>"));
         builder.nextLine();
         builder.append(new JPanel());
 
@@ -202,7 +201,7 @@ class AdvancedTab extends JPanel implements PrefsTab {
         preferences.putBoolean(JabRefPreferences.USE_DEFAULT_LOOK_AND_FEEL, !useDefault.isSelected());
         preferences.put(JabRefPreferences.WIN_LOOK_AND_FEEL, className.getSelectedItem().toString());
 
-        if(preferences.getBoolean(JabRefPreferences.USE_IEEE_ABRV) != useIEEEAbrv.isSelected()) {
+        if (preferences.getBoolean(JabRefPreferences.USE_IEEE_ABRV) != useIEEEAbrv.isSelected()) {
             preferences.putBoolean(JabRefPreferences.USE_IEEE_ABRV, useIEEEAbrv.isSelected());
             Abbreviations.initializeJournalNames(preferences);
         }
@@ -210,21 +209,17 @@ class AdvancedTab extends JPanel implements PrefsTab {
 
         preferences.putBoolean(JabRefPreferences.BIBLATEX_MODE, biblatexMode.isSelected());
 
-        if ((useDefault.isSelected() == oldUseDef) ||
-                !oldLnf.equals(className.getSelectedItem().toString())) {
+        if ((useDefault.isSelected() == oldUseDef) || !oldLnf.equals(className.getSelectedItem().toString())) {
             JOptionPane.showMessageDialog(null,
-                    Localization.lang("You have changed the look and feel setting.")
-                    .concat(" ")
-                    .concat(Localization.lang("You must restart JabRef for this to come into effect.")),
-                    Localization.lang("Changed look and feel settings"),
-                    JOptionPane.WARNING_MESSAGE);
+                    Localization.lang("You have changed the look and feel setting.").concat(" ")
+                            .concat(Localization.lang("You must restart JabRef for this to come into effect.")),
+                    Localization.lang("Changed look and feel settings"), JOptionPane.WARNING_MESSAGE);
         }
 
         if (biblatexMode.isSelected() != oldBiblMode) {
             JOptionPane.showMessageDialog(null,
-                    Localization.lang("You have toggled the BibLaTeX mode.")
-                    .concat(" ")
-                    .concat("You must restart JabRef for this change to come into effect."),
+                    Localization.lang("You have toggled the BibLaTeX mode.").concat(" ")
+                            .concat("You must restart JabRef for this change to come into effect."),
                     Localization.lang("BibLaTeX mode"), JOptionPane.WARNING_MESSAGE);
         }
 
@@ -235,15 +230,14 @@ class AdvancedTab extends JPanel implements PrefsTab {
 
     public void storeRemoteSettings() {
         Optional<Integer> newPort = getPortAsInt();
-        if(newPort.isPresent()) {
+        if (newPort.isPresent()) {
             if (remotePreferences.isDifferentPort(newPort.get())) {
                 remotePreferences.setPort(newPort.get());
 
-                if(remotePreferences.useRemoteServer()) {
+                if (remotePreferences.useRemoteServer()) {
                     JOptionPane.showMessageDialog(null,
-                            Localization.lang("Remote server port")
-                            .concat(" ")
-                            .concat("You must restart JabRef for this change to come into effect."),
+                            Localization.lang("Remote server port").concat(" ")
+                                    .concat("You must restart JabRef for this change to come into effect."),
                             Localization.lang("Remote server port"), JOptionPane.WARNING_MESSAGE);
                 }
             }
@@ -276,10 +270,12 @@ class AdvancedTab extends JPanel implements PrefsTab {
                 throw new NumberFormatException();
             }
         } catch (NumberFormatException ex) {
-            JOptionPane.showMessageDialog
-            (null, Localization.lang("You must enter an integer value in the interval 1025-65535 in the text field for") + " '" +
-                    Localization.lang("Remote server port") + '\'', Localization.lang("Remote server port"),
-                    JOptionPane.ERROR_MESSAGE);
+            // @formatter:off
+            JOptionPane.showMessageDialog(null,
+                    Localization.lang("You must enter an integer value in the interval 1025-65535 in the text field for")
+                            + " '" + Localization.lang("Remote server port") + '\'',
+                    Localization.lang("Remote server port"), JOptionPane.ERROR_MESSAGE);
+            // @formatter:on
             return false;
         }
 

--- a/src/main/java/net/sf/jabref/gui/preftabs/AppearancePrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/AppearancePrefsTab.java
@@ -164,8 +164,8 @@ class AppearancePrefsTab extends JPanel implements PrefsTab {
         prefs.putBoolean(JabRefPreferences.TABLE_SHOW_GRID, showGrid.isSelected());
         try {
             int size = Integer.parseInt(fontSize.getText());
-            if (overrideFonts.isSelected() != oldOverrideFontSize ||
-                    size != oldMenuFontSize) {
+            if ((overrideFonts.isSelected() != oldOverrideFontSize) ||
+                    (size != oldMenuFontSize)) {
                 prefs.putInt(JabRefPreferences.MENU_FONT_SIZE, size);
                 JOptionPane.showMessageDialog(null,
                         Localization.lang("You have changed the menu and label font size.")
@@ -191,10 +191,9 @@ class AppearancePrefsTab extends JPanel implements PrefsTab {
             // Test if the field value is a number:
             Integer.parseInt(fieldValue);
         } catch (NumberFormatException ex) {
-            JOptionPane.showMessageDialog
-                    (null, Localization.lang("You must enter an integer value in the text field for") + " '" +
-                            Localization.lang(fieldName) + "'", Localization.lang(errorTitle),
-                            JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(null,
+                    Localization.lang("You must enter an integer value in the text field for") + " '" + fieldName + "'",
+                    errorTitle, JOptionPane.ERROR_MESSAGE);
             return false;
         }
         return true;
@@ -203,12 +202,14 @@ class AppearancePrefsTab extends JPanel implements PrefsTab {
     @Override
     public boolean validateSettings() {
         // Test if font size is a number:
-        if (!validateIntegerField("Menu and label font size", fontSize.getText(), "Changed font settings")) {
+        if (!validateIntegerField(Localization.lang("Menu and label font size"), fontSize.getText(),
+                Localization.lang("Changed font settings"))) {
             return false;
         }
 
         // Test if row padding is a number:
-        if (!validateIntegerField("Table row height padding", rowPadding.getText(), "Changed table appearance settings")) {
+        if (!validateIntegerField(Localization.lang("Table row height padding"), rowPadding.getText(),
+                Localization.lang("Changed table appearance settings"))) {
             return false;
         }
 

--- a/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
@@ -178,10 +178,12 @@ class FileTab extends JPanel implements PrefsTab {
         builder.append(wrapFieldLine);
         builder.nextLine();
         //for LWang_AdjustableFieldOrder
-        String[] _rbs0 = {"Save fields sorted in alphabetic order (as in versions 2.10+)", "Save fields in unsorted order (as until version 2.9.2)", "Save fields in user-defined order"};
+        String[] _rbs0 = {Localization.lang("Save fields sorted in alphabetic order (as in versions 2.10+)"),
+                Localization.lang("Save fields in unsorted order (as until version 2.9.2)"),
+                Localization.lang("Save fields in user-defined order")};
         ArrayList<String> _rbs = new ArrayList<>();
         for (String _rb : _rbs0) {
-            _rbs.add(Localization.lang(_rb));
+            _rbs.add(_rb);
         }
         bgFieldOrderStyle = createRadioBg(_rbs);
         userDefinedFieldOrder = new JTextField(this.prefs.get(JabRefPreferences.WRITEFIELD_USERDEFINEDORDER)); //need to use JcomboBox in the future

--- a/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
@@ -141,7 +141,10 @@ public class NameFormatterTab extends JPanel implements PrefsTab {
 
             @Override
             public String getColumnName(int col) {
-                return col == 0 ? Localization.lang("Formatter Name") : Localization.lang("Format String");
+                // @formatter:off
+                return col == 0 ? Localization.lang("Formatter Name") :
+                    Localization.lang("Format String");
+                // @formatter:on
             }
 
             @Override

--- a/src/main/java/net/sf/jabref/gui/preftabs/PreferencesDialog.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/PreferencesDialog.java
@@ -182,10 +182,10 @@ public class PreferencesDialog extends JDialog {
                     return;
                 }
                 File file = new File(filename);
-                if (!file.exists()
-                        || (JOptionPane.showConfirmDialog(PreferencesDialog.this, '\'' + file.getName()
-                        + "' " + Localization.lang("exists. Overwrite file?"),
-                        Localization.lang("Export preferences"), JOptionPane.OK_CANCEL_OPTION) == JOptionPane.OK_OPTION)) {
+                if (!file.exists() || (JOptionPane.showConfirmDialog(PreferencesDialog.this,
+                        Localization.lang("'%0' exists. Overwrite file?", file.getName()),
+                        Localization.lang("Export preferences"),
+                        JOptionPane.OK_CANCEL_OPTION) == JOptionPane.OK_OPTION)) {
 
                     try {
                         prefs.exportPreferences(filename);

--- a/src/main/java/net/sf/jabref/gui/preftabs/PreviewPrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/PreviewPrefsTab.java
@@ -51,9 +51,7 @@ class PreviewPrefsTab extends JPanel implements PrefsTab {
     private final JButton testButton2 = new JButton(Localization.lang("Test"));
     private final JButton defaultButton2 = new JButton(Localization.lang("Default"));
 
-
     private final JPanel pdfPreviewPanel = new JPanel(new BorderLayout());
-
 
     private final JCheckBox pdfPreview = new JCheckBox(Localization.lang("Enable PDF preview"));
     private final JPanel firstPanel = new JPanel();
@@ -157,7 +155,8 @@ class PreviewPrefsTab extends JPanel implements PrefsTab {
             public void actionPerformed(ActionEvent e) {
                 String tmp = layout1.getText().replaceAll("\n", "__NEWLINE__");
                 PreviewPrefsTab.this.prefs.remove(JabRefPreferences.PREVIEW_0);
-                layout1.setText(PreviewPrefsTab.this.prefs.get(JabRefPreferences.PREVIEW_0).replaceAll("__NEWLINE__", "\n"));
+                layout1.setText(
+                        PreviewPrefsTab.this.prefs.get(JabRefPreferences.PREVIEW_0).replaceAll("__NEWLINE__", "\n"));
                 PreviewPrefsTab.this.prefs.put(JabRefPreferences.PREVIEW_0, tmp);
             }
         });
@@ -167,7 +166,8 @@ class PreviewPrefsTab extends JPanel implements PrefsTab {
             public void actionPerformed(ActionEvent e) {
                 String tmp = layout2.getText().replaceAll("\n", "__NEWLINE__");
                 PreviewPrefsTab.this.prefs.remove(JabRefPreferences.PREVIEW_1);
-                layout2.setText(PreviewPrefsTab.this.prefs.get(JabRefPreferences.PREVIEW_1).replaceAll("__NEWLINE__", "\n"));
+                layout2.setText(
+                        PreviewPrefsTab.this.prefs.get(JabRefPreferences.PREVIEW_1).replaceAll("__NEWLINE__", "\n"));
                 PreviewPrefsTab.this.prefs.put(JabRefPreferences.PREVIEW_1, tmp);
             }
         });
@@ -178,13 +178,18 @@ class PreviewPrefsTab extends JPanel implements PrefsTab {
             public void actionPerformed(ActionEvent e) {
                 PreviewPrefsTab.getTestEntry();
                 try {
-                    PreviewPanel testPanel = new PreviewPanel(null, PreviewPrefsTab.entry, null, new MetaData(), layout1.getText());
+                    PreviewPanel testPanel = new PreviewPanel(null, PreviewPrefsTab.entry, null, new MetaData(),
+                            layout1.getText());
                     testPanel.setPreferredSize(new Dimension(800, 350));
                     JOptionPane.showMessageDialog(null, testPanel, Localization.lang("Preview"),
                             JOptionPane.PLAIN_MESSAGE);
                 } catch (StringIndexOutOfBoundsException ex) {
                     ex.printStackTrace();
-                    JOptionPane.showMessageDialog(null, Localization.lang("Parsing error") + ": " + Localization.lang("illegal backslash expression") + ".\n" + ex.getMessage() + '\n' + Localization.lang("Look at stderr for details") + '.', Localization.lang("Parsing error"), JOptionPane.ERROR_MESSAGE);
+                    JOptionPane.showMessageDialog(null,
+                            Localization.lang("Parsing error") + ": "
+                                    + Localization.lang("illegal backslash expression") + ".\n" + ex.getMessage() + '\n'
+                                    + Localization.lang("Look at stderr for details") + '.',
+                            Localization.lang("Parsing error"), JOptionPane.ERROR_MESSAGE);
                 }
             }
         });
@@ -195,13 +200,18 @@ class PreviewPrefsTab extends JPanel implements PrefsTab {
             public void actionPerformed(ActionEvent e) {
                 PreviewPrefsTab.getTestEntry();
                 try {
-                    PreviewPanel testPanel = new PreviewPanel(null, PreviewPrefsTab.entry, null, new MetaData(), layout2.getText());
+                    PreviewPanel testPanel = new PreviewPanel(null, PreviewPrefsTab.entry, null, new MetaData(),
+                            layout2.getText());
                     testPanel.setPreferredSize(new Dimension(800, 350));
-                    JOptionPane.showMessageDialog(null, new JScrollPane(testPanel),
-                            Localization.lang("Preview"), JOptionPane.PLAIN_MESSAGE);
+                    JOptionPane.showMessageDialog(null, new JScrollPane(testPanel), Localization.lang("Preview"),
+                            JOptionPane.PLAIN_MESSAGE);
                 } catch (StringIndexOutOfBoundsException ex) {
                     ex.printStackTrace();
-                    JOptionPane.showMessageDialog(null, "Parsing error: illegal backslash expression.\n" + ex.getMessage() + "\nLook at stderr for details.", "Parsing error", JOptionPane.ERROR_MESSAGE);
+                    JOptionPane
+                            .showMessageDialog(null,
+                                    "Parsing error: illegal backslash expression.\n" + ex.getMessage()
+                                            + "\nLook at stderr for details.",
+                                    "Parsing error", JOptionPane.ERROR_MESSAGE);
                 }
             }
         });
@@ -213,14 +223,10 @@ class PreviewPrefsTab extends JPanel implements PrefsTab {
         }
         PreviewPrefsTab.entry = new BibtexEntry(IdGenerator.next(), BibtexEntryType.getType("article"));
         PreviewPrefsTab.entry.setField(BibtexEntry.KEY_FIELD, "conceicao1997");
-        PreviewPrefsTab.entry
-                .setField(
-                        "author",
-                        "Luis E. C. Conceic{\\~a}o and Terje van der Meeren and Johan A. J. Verreth and M S. Evjen and D. F. Houlihan and H. J. Fyhn");
-        PreviewPrefsTab.entry
-                .setField(
-                        "title",
-                        "Amino acid metabolism and protein turnover in larval turbot (Scophthalmus maximus) fed natural zooplankton or Artemia");
+        PreviewPrefsTab.entry.setField("author",
+                "Luis E. C. Conceic{\\~a}o and Terje van der Meeren and Johan A. J. Verreth and M S. Evjen and D. F. Houlihan and H. J. Fyhn");
+        PreviewPrefsTab.entry.setField("title",
+                "Amino acid metabolism and protein turnover in larval turbot (Scophthalmus maximus) fed natural zooplankton or Artemia");
         PreviewPrefsTab.entry.setField("year", "1997");
         PreviewPrefsTab.entry.setField("journal", "Marine Biology");
         PreviewPrefsTab.entry.setField("month", "January");
@@ -229,31 +235,28 @@ class PreviewPrefsTab extends JPanel implements PrefsTab {
         PreviewPrefsTab.entry.setField("pdf", "conceicao1997.pdf");
         PreviewPrefsTab.entry.setField("pages", "255--265");
         PreviewPrefsTab.entry.setField("keywords", "energetics, artemia, metabolism, amino acid, turbot");
-        PreviewPrefsTab.entry.setField("url",
-                "http://ejournals.ebsco.com/direct.asp?ArticleID=TYY4NT82XA9H7R8PFPPV");
-        PreviewPrefsTab.entry
-                .setField(
-                        "abstract",
-                        "Abstract The present paper studied the influence of different food regimes "
-                                + "on the free amino acid (FAA) pool, the rate of protein turnover, the flux of amino acids, and "
-                                + "their relation to growth of larval turbot (Scophthalmus maximus L.) from first feeding until "
-                                + "metamorphosis. The amino acid profile of protein was stable during the larval period although "
-                                + "some small, but significant, differences were found. Turbot larvae had proteins which were rich "
-                                + "in leucine and aspartate, and poor in glutamate, suggesting a high leucine requirement. The "
-                                + "profile of the FAA pool was highly variable and quite different from the amino acid profile in "
-                                + "protein. The proportion of essential FAA decreased with development. High contents of free tyrosine "
-                                + "and phenylalanine were found on Day 3, while free taurine was present at high levels throughout "
-                                + "the experimental period. Larval growth rates were positively correlated with taurine levels, "
-                                + "suggesting a dietary dependency for taurine and/or sulphur amino acids.\n\nReduced growth rates in "
-                                + "Artemia-fed larvae were associated with lower levels of free methionine, indicating that this diet "
-                                + "is deficient in methionine for turbot larvae. Leucine might also be limiting turbot growth as the "
-                                + "different diet organisms had lower levels of this amino acid in the free pool than was found in the "
-                                + "larval protein. A previously presented model was used to describe the flux of amino acids in growing "
-                                + "turbot larvae. The FAA pool was found to be small and variable. It was estimated that the daily dietary "
-                                + "amino acid intake might be up to ten times the larval FAA pool. In addition, protein synthesis and "
-                                + "protein degradation might daily remove and return, respectively, the equivalent of up to 20 and 10 "
-                                + "times the size of the FAA pool. In an early phase (Day 11) high growth rates were associated with a "
-                                + "relatively low protein turnover, while at a later stage (Day 17), a much higher turnover was observed.");
+        PreviewPrefsTab.entry.setField("url", "http://ejournals.ebsco.com/direct.asp?ArticleID=TYY4NT82XA9H7R8PFPPV");
+        PreviewPrefsTab.entry.setField("abstract",
+                "Abstract The present paper studied the influence of different food regimes "
+                        + "on the free amino acid (FAA) pool, the rate of protein turnover, the flux of amino acids, and "
+                        + "their relation to growth of larval turbot (Scophthalmus maximus L.) from first feeding until "
+                        + "metamorphosis. The amino acid profile of protein was stable during the larval period although "
+                        + "some small, but significant, differences were found. Turbot larvae had proteins which were rich "
+                        + "in leucine and aspartate, and poor in glutamate, suggesting a high leucine requirement. The "
+                        + "profile of the FAA pool was highly variable and quite different from the amino acid profile in "
+                        + "protein. The proportion of essential FAA decreased with development. High contents of free tyrosine "
+                        + "and phenylalanine were found on Day 3, while free taurine was present at high levels throughout "
+                        + "the experimental period. Larval growth rates were positively correlated with taurine levels, "
+                        + "suggesting a dietary dependency for taurine and/or sulphur amino acids.\n\nReduced growth rates in "
+                        + "Artemia-fed larvae were associated with lower levels of free methionine, indicating that this diet "
+                        + "is deficient in methionine for turbot larvae. Leucine might also be limiting turbot growth as the "
+                        + "different diet organisms had lower levels of this amino acid in the free pool than was found in the "
+                        + "larval protein. A previously presented model was used to describe the flux of amino acids in growing "
+                        + "turbot larvae. The FAA pool was found to be small and variable. It was estimated that the daily dietary "
+                        + "amino acid intake might be up to ten times the larval FAA pool. In addition, protein synthesis and "
+                        + "protein degradation might daily remove and return, respectively, the equivalent of up to 20 and 10 "
+                        + "times the size of the FAA pool. In an early phase (Day 11) high growth rates were associated with a "
+                        + "relatively low protein turnover, while at a later stage (Day 17), a much higher turnover was observed.");
         return PreviewPrefsTab.entry;
     }
 

--- a/src/main/java/net/sf/jabref/gui/preftabs/PreviewPrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/PreviewPrefsTab.java
@@ -188,7 +188,7 @@ class PreviewPrefsTab extends JPanel implements PrefsTab {
                     JOptionPane.showMessageDialog(null,
                             Localization.lang("Parsing error") + ": "
                                     + Localization.lang("illegal backslash expression") + ".\n" + ex.getMessage() + '\n'
-                                    + Localization.lang("Look at stderr for details") + '.',
+                                    + Localization.lang("Look at log for details") + '.',
                             Localization.lang("Parsing error"), JOptionPane.ERROR_MESSAGE);
                 }
             }

--- a/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
@@ -161,7 +161,10 @@ class TableColumnsTab extends JPanel implements PrefsTab {
 
             @Override
             public String getColumnName(int col) {
-                return col == 0 ? Localization.lang("Field name") : Localization.lang("Column width");
+                // @formatter:off
+                return col == 0 ? Localization.lang("Field name") :
+                    Localization.lang("Column width");
+                // @formatter:on
             }
 
             @Override

--- a/src/main/java/net/sf/jabref/gui/undo/UndoableFieldChange.java
+++ b/src/main/java/net/sf/jabref/gui/undo/UndoableFieldChange.java
@@ -30,7 +30,7 @@ import net.sf.jabref.model.entry.BibtexEntry;
  */
 public class UndoableFieldChange extends AbstractUndoableEdit {
     private static final Log LOGGER = LogFactory.getLog(UndoableFieldChange.class);
-    
+
     private final BibtexEntry entry;
     private final String field;
     private final String oldValue;
@@ -52,12 +52,18 @@ public class UndoableFieldChange extends AbstractUndoableEdit {
 
     @Override
     public String getUndoPresentationName() {
-        return Localization.lang("Undo") + ": " + Localization.lang("change field");
+        // @formatter:off
+        return Localization.lang("Undo") + ": " +
+                Localization.lang("change field");
+        // @formatter:on
     }
 
     @Override
     public String getRedoPresentationName() {
-        return Localization.lang("Redo") + ": " + Localization.lang("change field");
+        // @formatter:off
+        return Localization.lang("Redo") + ": " +
+                Localization.lang("change field");
+        // @formatter:on
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/gui/undo/UndoableInsertString.java
+++ b/src/main/java/net/sf/jabref/gui/undo/UndoableInsertString.java
@@ -39,12 +39,18 @@ public class UndoableInsertString extends AbstractUndoableEdit {
 
     @Override
     public String getUndoPresentationName() {
-        return Localization.lang("Undo") + ": " + Localization.lang("insert string ");
+        // @formatter:off
+        return Localization.lang("Undo") + ": " +
+                Localization.lang("insert string ");
+        // @formatter:on
     }
 
     @Override
     public String getRedoPresentationName() {
-        return Localization.lang("Redo") + ": " + Localization.lang("insert string ");
+        // @formatter:off
+        return Localization.lang("Redo") + ": " +
+                Localization.lang("insert string ");
+        // @formatter:on
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/gui/undo/UndoableKeyChange.java
+++ b/src/main/java/net/sf/jabref/gui/undo/UndoableKeyChange.java
@@ -48,12 +48,18 @@ public class UndoableKeyChange extends AbstractUndoableEdit {
 
     @Override
     public String getUndoPresentationName() {
-        return Localization.lang("Undo") + ": " + Localization.lang("change key");
+        // @formatter:off
+        return Localization.lang("Undo") + ": " +
+                Localization.lang("change key");
+        // @formatter:on
     }
 
     @Override
     public String getRedoPresentationName() {
-        return Localization.lang("Redo") + ": " + Localization.lang("change key");
+        // @formatter:off
+        return Localization.lang("Redo") + ": " +
+                Localization.lang("change key");
+        // @formatter:on
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/gui/undo/UndoablePreambleChange.java
+++ b/src/main/java/net/sf/jabref/gui/undo/UndoablePreambleChange.java
@@ -44,12 +44,18 @@ public class UndoablePreambleChange extends AbstractUndoableEdit {
 
     @Override
     public String getUndoPresentationName() {
-        return Localization.lang("Undo") + ": " + Localization.lang("change preamble");
+        // @formatter:off
+        return Localization.lang("Undo") + ": " +
+                Localization.lang("change preamble");
+        // @formatter:on
     }
 
     @Override
     public String getRedoPresentationName() {
-        return Localization.lang("Redo") + ": " + Localization.lang("change preamble");
+        // @formatter:off
+        return Localization.lang("Redo") + ": " +
+                Localization.lang("change preamble");
+        // @formatter:on
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/gui/undo/UndoableRemoveString.java
+++ b/src/main/java/net/sf/jabref/gui/undo/UndoableRemoveString.java
@@ -39,12 +39,18 @@ public class UndoableRemoveString extends AbstractUndoableEdit {
 
     @Override
     public String getUndoPresentationName() {
-        return Localization.lang("Undo") + ": " + Localization.lang("remove string ");
+        // @formatter:off
+        return Localization.lang("Undo") + ": " +
+                Localization.lang("remove string ");
+        // @formatter:on
     }
 
     @Override
     public String getRedoPresentationName() {
-        return Localization.lang("Redo") + ": " + Localization.lang("remove string ");
+        // @formatter:off
+        return Localization.lang("Redo") + ": " +
+                Localization.lang("remove string ");
+        // @formatter:on
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/gui/undo/UndoableStringChange.java
+++ b/src/main/java/net/sf/jabref/gui/undo/UndoableStringChange.java
@@ -42,14 +42,20 @@ public class UndoableStringChange extends AbstractUndoableEdit {
 
     @Override
     public String getUndoPresentationName() {
-        return Localization.lang("Undo") + ": "
-                + Localization.lang(nameChange ? "change string name" : "change string content");
+        // @formatter:off
+        return Localization.lang("Undo") + ": " + (nameChange ?
+           Localization.lang("change string name") :
+           Localization.lang("change string content"));
+        // @formatter:on
     }
 
     @Override
     public String getRedoPresentationName() {
-        return Localization.lang("Redo") + ": "
-                + Localization.lang(nameChange ? "change string name" : "change string content");
+        // @formatter:off
+        return Localization.lang("Redo") + ": " + (nameChange ?
+           Localization.lang("change string name") :
+           Localization.lang("change string content"));
+        // @formatter:on
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/importer/AppendDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/AppendDatabaseAction.java
@@ -112,7 +112,8 @@ public class AppendDatabaseAction implements BaseAction {
                 ex.printStackTrace();
                 JOptionPane.showMessageDialog
                 (panel, ex.getMessage(),
-                        "Open database", JOptionPane.ERROR_MESSAGE);
+ Localization.lang("Open database"),
+                        JOptionPane.ERROR_MESSAGE);
             }
         }
     }

--- a/src/main/java/net/sf/jabref/importer/ImportFormatReader.java
+++ b/src/main/java/net/sf/jabref/importer/ImportFormatReader.java
@@ -20,7 +20,6 @@ import java.util.*;
 
 import net.sf.jabref.importer.fileformat.*;
 import net.sf.jabref.logic.id.IdGenerator;
-import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibtexDatabase;
 import net.sf.jabref.model.entry.BibtexEntry;
 import org.apache.commons.logging.Log;
@@ -135,7 +134,7 @@ public class ImportFormatReader {
             stream = new FileInputStream(file);
 
             if (!importer.isRecognizedFormat(stream)) {
-                throw new IOException(Localization.lang("Wrong file format"));
+                throw new IOException("Wrong file format");
             }
 
             stream = new FileInputStream(file);

--- a/src/main/java/net/sf/jabref/importer/ImportMenuItem.java
+++ b/src/main/java/net/sf/jabref/importer/ImportMenuItem.java
@@ -203,7 +203,10 @@ public class ImportMenuItem extends JMenuItem implements ActionListener {
                     if (importError != null) {
                         JOptionPane.showMessageDialog(frame, importError.getMessage(), Localization.lang("Import failed"), JOptionPane.ERROR_MESSAGE);
                     } else {
-                        JOptionPane.showMessageDialog(frame, Localization.lang("No entries found. Please make sure you are " + "using the correct import filter."), Localization.lang("Import failed"), JOptionPane.ERROR_MESSAGE);
+                        // @formatter:off
+                        JOptionPane.showMessageDialog(frame, Localization.lang("No entries found. Please make sure you are using the correct import filter."),
+                                Localization.lang("Import failed"), JOptionPane.ERROR_MESSAGE);
+                        // @formatter:on
                     }
                 }
             }

--- a/src/main/java/net/sf/jabref/importer/fetcher/ACMPortalFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/ACMPortalFetcher.java
@@ -403,7 +403,7 @@ public class ACMPortalFetcher implements PreviewEntryFetcher {
     private static int getNumberOfHits(String page, String marker, Pattern pattern) throws IOException {
         int ind = page.indexOf(marker);
         if (ind < 0) {
-            throw new IOException(Localization.lang("Could not parse number of hits"));
+            throw new IOException("Cannot parse number of hits");
         }
         String substring = page.substring(ind, Math.min(ind + 42, page.length()));
         Matcher m = pattern.matcher(substring);
@@ -419,12 +419,12 @@ public class ACMPortalFetcher implements PreviewEntryFetcher {
                 //System.out.println(number);
                 return Integer.parseInt(number);
             } catch (NumberFormatException ex) {
-                throw new IOException(Localization.lang("Could not parse number of hits"));
+                throw new IOException("Cannot parse number of hits");
             } catch (IllegalStateException e) {
-                throw new IOException(Localization.lang("Could not parse number of hits"));
+                throw new IOException("Cannot parse number of hits");
             }
         }
-        throw new IOException(Localization.lang("Could not parse number of hits"));
+        throw new IOException("Cannot parse number of hits");
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/importer/fetcher/ACMPortalFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/ACMPortalFetcher.java
@@ -170,7 +170,7 @@ public class ACMPortalFetcher implements PreviewEntryFetcher {
             status.showMessage(Localization.lang("Connection to ACM Portal failed"),
                     Localization.lang("Search ACM Portal"), JOptionPane.ERROR_MESSAGE);
         } catch (IOException e) {
-            status.showMessage(Localization.lang(e.getMessage()),
+            status.showMessage(e.getMessage(),
                     Localization.lang("Search ACM Portal"), JOptionPane.ERROR_MESSAGE);
             e.printStackTrace();
         }

--- a/src/main/java/net/sf/jabref/importer/fetcher/IEEEXploreFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/IEEEXploreFetcher.java
@@ -635,14 +635,13 @@ public class IEEEXploreFetcher implements EntryFetcher {
         int ind = page.indexOf(marker);
         if (ind < 0) {
             LOGGER.debug(page);
-            throw new IOException(Localization.lang("Cannot parse number of hits"));
+            throw new IOException("Cannot parse number of hits");
         }
         String substring = page.substring(ind, page.length());
         Matcher m = pattern.matcher(substring);
         if (m.find()) {
             return Integer.parseInt(m.group(1));
         }
-        LOGGER.debug(page);
-        throw new IOException(Localization.lang("Cannot parse number of hits"));
+        throw new IOException("Cannot parse number of hits");
     }
 }

--- a/src/main/java/net/sf/jabref/importer/fetcher/IEEEXploreFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/IEEEXploreFetcher.java
@@ -133,22 +133,29 @@ public class IEEEXploreFetcher implements EntryFetcher {
             String page = Util.getResults(url);
 
             if (page.contains("You have entered an invalid search")) {
-                status.showMessage(Localization.lang("You have entered an invalid search '%0'.", terms), Localization.lang("Search IEEEXplore"), JOptionPane.INFORMATION_MESSAGE);
+                status.showMessage(Localization.lang("You have entered an invalid search '%0'.", terms),
+                        Localization.lang("Search IEEEXplore"), JOptionPane.INFORMATION_MESSAGE);
                 return false;
             }
 
             if (page.contains("Bad request")) {
-                status.showMessage(Localization.lang("Bad Request '%0'.", terms), Localization.lang("Search IEEEXplore"), JOptionPane.INFORMATION_MESSAGE);
+                status.showMessage(Localization.lang("Bad Request '%0'.", terms),
+                        Localization.lang("Search IEEEXplore"), JOptionPane.INFORMATION_MESSAGE);
                 return false;
             }
 
             if (page.contains("No results were found.")) {
-                status.showMessage(Localization.lang("No entries found for the search string '%0'", terms), Localization.lang("Search IEEEXplore"), JOptionPane.INFORMATION_MESSAGE);
+                status.showMessage(Localization.lang("No entries found for the search string '%0'", terms),
+                        Localization.lang("Search IEEEXplore"), JOptionPane.INFORMATION_MESSAGE);
                 return false;
             }
 
             if (page.contains("Error Page")) {
-                status.showMessage(Localization.lang("Intermittent errors on the IEEE Xplore server. Please try again in a while."), Localization.lang("Search IEEEXplore"), JOptionPane.INFORMATION_MESSAGE);
+                // @formatter:off
+                status.showMessage(
+                        Localization.lang("Intermittent errors on the IEEE Xplore server. Please try again in a while."),
+                        Localization.lang("Search IEEEXplore"), JOptionPane.INFORMATION_MESSAGE);
+                // @formatter:on
                 return false;
             }
 
@@ -168,9 +175,10 @@ public class IEEEXploreFetcher implements EntryFetcher {
         } catch (MalformedURLException e) {
             e.printStackTrace();
         } catch (ConnectException e) {
-            status.showMessage(Localization.lang("Connection to IEEEXplore failed"), Localization.lang("Search IEEEXplore"), JOptionPane.ERROR_MESSAGE);
+            status.showMessage(Localization.lang("Connection to IEEEXplore failed"),
+                    Localization.lang("Search IEEEXplore"), JOptionPane.ERROR_MESSAGE);
         } catch (IOException e) {
-            status.showMessage(Localization.lang(e.getMessage()), Localization.lang("Search IEEEXplore"), JOptionPane.ERROR_MESSAGE);
+            status.showMessage(e.getMessage(), Localization.lang("Search IEEEXplore"), JOptionPane.ERROR_MESSAGE);
             LOGGER.warn("Search IEEEXplore: " + e.getMessage(), e);
         }
         return false;
@@ -208,7 +216,6 @@ public class IEEEXploreFetcher implements EntryFetcher {
             }
         }
     }
-
 
     private BibtexEntry cleanup(BibtexEntry entry) {
         if (entry == null) {
@@ -299,7 +306,8 @@ public class IEEEXploreFetcher implements EntryFetcher {
                         date += ",";
                     }
                 } else {
-                    date = "#" + mm.group(2).substring(0, 3) + "# " + mm.group(1) + "--#" + mm.group(4).substring(0, 3) + "# " + mm.group(3) + ",";
+                    date = "#" + mm.group(2).substring(0, 3) + "# " + mm.group(1) + "--#" + mm.group(4).substring(0, 3)
+                            + "# " + mm.group(3) + ",";
                 }
             }
             //date = date.trim();
@@ -355,7 +363,8 @@ public class IEEEXploreFetcher implements EntryFetcher {
                     entry.clearField("number");
                 }
             } else {
-                fullName = fullName.replace("Conference Proceedings", "Proceedings").replace("Proceedings of", "Proceedings").replace("Proceedings.", "Proceedings");
+                fullName = fullName.replace("Conference Proceedings", "Proceedings")
+                        .replace("Proceedings of", "Proceedings").replace("Proceedings.", "Proceedings");
                 fullName = fullName.replaceAll("International", "Int.");
                 fullName = fullName.replaceAll("Symposium", "Symp.");
                 fullName = fullName.replaceAll("Conference", "Conf.");
@@ -427,7 +436,8 @@ public class IEEEXploreFetcher implements EntryFetcher {
                     fullName = fullName.replaceAll(", " + year + "\\.?", "");
                 }
 
-                if (!fullName.contains("Abstract") && !fullName.contains("Summaries") && !fullName.contains("Conference Record")) {
+                if (!fullName.contains("Abstract") && !fullName.contains("Summaries")
+                        && !fullName.contains("Conference Record")) {
                     fullName = "Proc. " + fullName;
                 }
             }
@@ -487,32 +497,38 @@ public class IEEEXploreFetcher implements EntryFetcher {
             Matcher typeMatcher = typePattern.matcher(text);
             if (typeMatcher.find()) {
                 typeName = typeMatcher.group(1);
-                if (typeName.equalsIgnoreCase("IEEE Journals &amp; Magazines") || typeName.equalsIgnoreCase("IEEE Early Access Articles") ||
-                        typeName.equalsIgnoreCase("IET Journals &amp; Magazines") || typeName.equalsIgnoreCase("AIP Journals &amp; Magazines") ||
-                        typeName.equalsIgnoreCase("AVS Journals &amp; Magazines") || typeName.equalsIgnoreCase("IBM Journals &amp; Magazines") ||
-                        typeName.equalsIgnoreCase("TUP Journals &amp; Magazines") || typeName.equalsIgnoreCase("BIAI Journals &amp; Magazines") ||
-                        typeName.equalsIgnoreCase("MIT Press Journals") || typeName.equalsIgnoreCase("Alcatel-Lucent Journal")) {
+                if (typeName.equalsIgnoreCase("IEEE Journals &amp; Magazines")
+                        || typeName.equalsIgnoreCase("IEEE Early Access Articles")
+                        || typeName.equalsIgnoreCase("IET Journals &amp; Magazines")
+                        || typeName.equalsIgnoreCase("AIP Journals &amp; Magazines")
+                        || typeName.equalsIgnoreCase("AVS Journals &amp; Magazines")
+                        || typeName.equalsIgnoreCase("IBM Journals &amp; Magazines")
+                        || typeName.equalsIgnoreCase("TUP Journals &amp; Magazines")
+                        || typeName.equalsIgnoreCase("BIAI Journals &amp; Magazines")
+                        || typeName.equalsIgnoreCase("MIT Press Journals")
+                        || typeName.equalsIgnoreCase("Alcatel-Lucent Journal")) {
                     type = BibtexEntryType.getType("article");
                     sourceField = "journal";
-                } else
-                    if (typeName.equalsIgnoreCase("IEEE Conference Publications") || typeName.equalsIgnoreCase("IET Conference Publications") || typeName.equalsIgnoreCase("VDE Conference Publications")) {
-                        type = BibtexEntryType.getType("inproceedings");
-                        sourceField = "booktitle";
-                    } else if (typeName.equalsIgnoreCase("IEEE Standards") || typeName.equalsIgnoreCase("Standards")) {
-                        type = BibtexEntryType.getType("standard");
-                        sourceField = "number";
-                    } else if (typeName.equalsIgnoreCase("IEEE eLearning Library Courses")) {
-                        type = BibtexEntryType.getType("electronic");
-                        sourceField = "note";
-                    } else if (typeName.equalsIgnoreCase("Wiley-IEEE Press eBook Chapters") ||
-                            typeName.equalsIgnoreCase("MIT Press eBook Chapters") ||
-                            typeName.equalsIgnoreCase("IEEE USA Books &amp; eBooks")) {
-                        type = BibtexEntryType.getType("incollection");
-                        sourceField = "booktitle";
-                    } else if (typeName.equalsIgnoreCase("Morgan and Claypool eBooks")) {
-                        type = BibtexEntryType.getType("book");
-                        sourceField = "note";
-                    }
+                } else if (typeName.equalsIgnoreCase("IEEE Conference Publications")
+                        || typeName.equalsIgnoreCase("IET Conference Publications")
+                        || typeName.equalsIgnoreCase("VDE Conference Publications")) {
+                    type = BibtexEntryType.getType("inproceedings");
+                    sourceField = "booktitle";
+                } else if (typeName.equalsIgnoreCase("IEEE Standards") || typeName.equalsIgnoreCase("Standards")) {
+                    type = BibtexEntryType.getType("standard");
+                    sourceField = "number";
+                } else if (typeName.equalsIgnoreCase("IEEE eLearning Library Courses")) {
+                    type = BibtexEntryType.getType("electronic");
+                    sourceField = "note";
+                } else if (typeName.equalsIgnoreCase("Wiley-IEEE Press eBook Chapters")
+                        || typeName.equalsIgnoreCase("MIT Press eBook Chapters")
+                        || typeName.equalsIgnoreCase("IEEE USA Books &amp; eBooks")) {
+                    type = BibtexEntryType.getType("incollection");
+                    sourceField = "booktitle";
+                } else if (typeName.equalsIgnoreCase("Morgan and Claypool eBooks")) {
+                    type = BibtexEntryType.getType("book");
+                    sourceField = "note";
+                }
             }
 
             if (type == null) {
@@ -581,7 +597,8 @@ public class IEEEXploreFetcher implements EntryFetcher {
                 entry.setField("author", authorString);
             }
 
-            if ((entry.getType() == BibtexEntryType.getStandardType("inproceedings")) && entry.getField("author").equals("")) {
+            if ((entry.getType() == BibtexEntryType.getStandardType("inproceedings"))
+                    && entry.getField("author").equals("")) {
                 entry.setType(BibtexEntryType.getStandardType("proceedings"));
             }
 

--- a/src/main/java/net/sf/jabref/importer/fetcher/INSPIREFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/INSPIREFetcher.java
@@ -125,7 +125,7 @@ public class INSPIREFetcher implements EntryFetcher {
             }
         } catch (RuntimeException | IOException e) {
             frame.showMessage(Localization.lang("An Exception ocurred while accessing '%0'", url) + "\n\n" + e,
-                    Localization.lang(getTitle()), JOptionPane.ERROR_MESSAGE);
+                    getTitle(), JOptionPane.ERROR_MESSAGE);
         }
         return null;
     }

--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
@@ -283,7 +283,7 @@ public class BibtexParser {
                         }
                     } catch (IOException ex) {
                         LOGGER.warn("Could not parse entry", ex);
-                        parserResult.addWarning(Localization.lang("Error occured when parsing entry") + ": '"
+                        parserResult.addWarning(Localization.lang("Error occurred when parsing entry") + ": '"
                                 + ex.getMessage() + "'. " + Localization.lang("Skipped entry."));
 
                     }

--- a/src/main/java/net/sf/jabref/logic/formatter/casechanger/LowerCaseChanger.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/casechanger/LowerCaseChanger.java
@@ -1,12 +1,13 @@
 package net.sf.jabref.logic.formatter.casechanger;
 
 import net.sf.jabref.logic.formatter.Formatter;
+import net.sf.jabref.logic.l10n.Localization;
 
 public class LowerCaseChanger implements Formatter {
 
     @Override
     public String getName() {
-        return "lower";
+        return Localization.lang("lower");
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/formatter/casechanger/TitleCaseChanger.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/casechanger/TitleCaseChanger.java
@@ -1,12 +1,13 @@
 package net.sf.jabref.logic.formatter.casechanger;
 
 import net.sf.jabref.logic.formatter.Formatter;
+import net.sf.jabref.logic.l10n.Localization;
 
 public class TitleCaseChanger implements Formatter {
 
     @Override
     public String getName() {
-        return "Title";
+        return Localization.lang("Title");
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/formatter/casechanger/UpperCaseChanger.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/casechanger/UpperCaseChanger.java
@@ -1,12 +1,13 @@
 package net.sf.jabref.logic.formatter.casechanger;
 
 import net.sf.jabref.logic.formatter.Formatter;
+import net.sf.jabref.logic.l10n.Localization;
 
 public class UpperCaseChanger implements Formatter {
 
     @Override
     public String getName() {
-        return "UPPER";
+        return Localization.lang("UPPER");
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/formatter/casechanger/UpperEachFirstCaseChanger.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/casechanger/UpperEachFirstCaseChanger.java
@@ -1,12 +1,13 @@
 package net.sf.jabref.logic.formatter.casechanger;
 
 import net.sf.jabref.logic.formatter.Formatter;
+import net.sf.jabref.logic.l10n.Localization;
 
 public class UpperEachFirstCaseChanger implements Formatter {
 
     @Override
     public String getName() {
-        return "Upper Each First";
+        return Localization.lang("Upper Each First");
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/formatter/casechanger/UpperFirstCaseChanger.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/casechanger/UpperFirstCaseChanger.java
@@ -2,12 +2,13 @@ package net.sf.jabref.logic.formatter.casechanger;
 
 import net.sf.jabref.logic.formatter.CaseChangers;
 import net.sf.jabref.logic.formatter.Formatter;
+import net.sf.jabref.logic.l10n.Localization;
 
 public class UpperFirstCaseChanger implements Formatter {
 
     @Override
     public String getName() {
-        return "Upper first";
+        return Localization.lang("Upper first");
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/search/describer/ContainsAndRegexBasedSearchRuleDescriber.java
+++ b/src/main/java/net/sf/jabref/logic/search/describer/ContainsAndRegexBasedSearchRuleDescriber.java
@@ -56,10 +56,14 @@ public class ContainsAndRegexBasedSearchRuleDescriber implements SearchDescriber
             searchDescription += StringUtil.join(unprocessedWordsInHtmlFormatArray, andSeparator);
         }
 
-        String caseSensitiveDescription = caseSensitive ? Localization.lang("case sensitive") : Localization.lang("case insensitive");
-        String genericDescription = Localization.lang(
-                "Entries cannot be manually assigned to or removed from this group.") + "<p><br>" + Localization.lang(
-                "Hint%c To search specific fields only, enter for example%c<p><tt>author%esmith and title%eelectrical</tt>");
+        // @formatter:off
+        String caseSensitiveDescription = caseSensitive ?
+            Localization.lang("case sensitive") :
+            Localization.lang("case insensitive");
+        String genericDescription =
+            Localization.lang("Entries cannot be manually assigned to or removed from this group.") + "<p><br>"
+            + Localization.lang("Hint%c To search specific fields only, enter for example%c<p><tt>author%esmith and title%eelectrical</tt>");
+        // @formatter:on
         return String.format("%s (%s). %s", searchDescription, caseSensitiveDescription, genericDescription);
     }
 }

--- a/src/main/java/net/sf/jabref/logic/search/describer/GrammarBasedSearchRuleDescriber.java
+++ b/src/main/java/net/sf/jabref/logic/search/describer/GrammarBasedSearchRuleDescriber.java
@@ -1,3 +1,18 @@
+/*  Copyright (C) 2003-2015 JabRef contributors.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
 package net.sf.jabref.logic.search.describer;
 
 import net.sf.jabref.logic.l10n.Localization;
@@ -69,8 +84,8 @@ public class GrammarBasedSearchRuleDescriber implements SearchDescriber {
 
                 if (operator == GrammarBasedSearchRule.ComparisonOperator.CONTAINS) {
                     if (regExp) {
-                        return Localization.lang(
-                                "%0 contains the Regular Expression <b>%1</b>", fieldSpecQuoted, termQuoted);
+                        return Localization.lang("%0 contains the Regular Expression <b>%1</b>", fieldSpecQuoted,
+                                termQuoted);
                     }
                     return Localization.lang("%0 contains the term <b>%1</b>", fieldSpecQuoted, termQuoted);
                 } else if (operator == GrammarBasedSearchRule.ComparisonOperator.EXACT) {
@@ -95,7 +110,10 @@ public class GrammarBasedSearchRuleDescriber implements SearchDescriber {
 
         }.visit(parseTree));
         stringBuilder.append(". ");
-        stringBuilder.append(caseSensitive ? Localization.lang("The search is case sensitive.") : Localization.lang("The search is case insensitive."));
+        // @formatter:off
+        stringBuilder.append(caseSensitive ? Localization.lang("The search is case sensitive.") :
+            Localization.lang("The search is case insensitive."));
+        // @formatter:on
         return stringBuilder.toString();
     }
 

--- a/src/main/java/net/sf/jabref/migrations/VersionHandling.java
+++ b/src/main/java/net/sf/jabref/migrations/VersionHandling.java
@@ -23,13 +23,12 @@ import net.sf.jabref.groups.structure.AbstractGroup;
 import net.sf.jabref.groups.structure.AllEntriesGroup;
 import net.sf.jabref.groups.structure.GroupHierarchyType;
 import net.sf.jabref.groups.structure.KeywordGroup;
-import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.strings.StringUtil;
 
 /**
  * Handles versioning of groups, e.g. automatic conversion from previous to
  * current versions, or import of flat groups (JabRef <= 1.6) to tree.
- * 
+ *
  * @author jzieren (10.04.2005)
  */
 public class VersionHandling {
@@ -40,7 +39,7 @@ public class VersionHandling {
     /**
      * Imports old (flat) groups data and converts it to a 2-level tree with an
      * AllEntriesGroup at the root.
-     * 
+     *
      * @return the root of the generated tree.
      */
     public static GroupTreeNode importFlatGroups(Vector<String> groups)
@@ -52,8 +51,8 @@ public class VersionHandling {
         String regexp;
         for (int i = 0; i < number; ++i) {
             field = groups.get(3 * i);
-            name = groups.get(3 * i + 1);
-            regexp = groups.get(3 * i + 2);
+            name = groups.get((3 * i) + 1);
+            regexp = groups.get((3 * i) + 2);
             root.add(new GroupTreeNode(new KeywordGroup(name, field, regexp,
                     false, true, GroupHierarchyType.INDEPENDENT)));
         }
@@ -71,7 +70,9 @@ public class VersionHandling {
         case 3:
             return Version2_3.fromString(orderedData, db, version);
         default:
-            throw new IllegalArgumentException(Localization.lang("Failed to read groups data (unsupported version: %0)", Integer.toString(version)));
+            throw new IllegalArgumentException(
+                    "Failed to read groups data (unsupported version: " +
+                    Integer.toString(version) + ")");
         }
     }
 
@@ -83,7 +84,7 @@ public class VersionHandling {
          * Parses the textual representation obtained from
          * GroupTreeNode.toString() and recreates that node and all of its
          * children from it.
-         * 
+         *
          * @throws Exception
          *             When a group could not be recreated
          */
@@ -126,7 +127,7 @@ public class VersionHandling {
         /**
          * Returns the substring delimited by a pair of matching braces, with
          * the first brace at index 0. Quoted characters are skipped.
-         * 
+         *
          * @return the matching substring, or "" if not found.
          */
         private static String getSubtree(String s) {
@@ -155,7 +156,7 @@ public class VersionHandling {
         /**
          * Returns the index of the first occurence of c, skipping quoted
          * special characters (escape character: '\\').
-         * 
+         *
          * @param s
          *            The String to search in.
          * @param c

--- a/src/main/java/net/sf/jabref/model/database/BibtexDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibtexDatabase.java
@@ -245,7 +245,7 @@ public class BibtexDatabase {
     public synchronized void addString(BibtexString string)
             throws KeyCollisionException {
         if (hasStringLabel(string.getName())) {
-            throw new KeyCollisionException(Localization.lang("A string with this label already exists"));
+            throw new KeyCollisionException("A string with this label already exists");
         }
 
         if (bibtexStrings.containsKey(string.getId())) {

--- a/src/main/java/net/sf/jabref/openoffice/OpenOfficePanel.java
+++ b/src/main/java/net/sf/jabref/openoffice/OpenOfficePanel.java
@@ -569,7 +569,7 @@ public class OpenOfficePanel extends AbstractWorker implements PushToApplication
             URL[] jarList = new URL[jarFiles.length];
             for (int i = 0; i < jarList.length; i++) {
                 if (!jarFiles[i].exists()) {
-                    throw new Exception(Localization.lang("File not found") + ": " + jarFiles[i].getPath());
+                    throw new Exception("File not found: " + jarFiles[i].getPath());
                 }
                 jarList[i] = jarFiles[i].toURI().toURL();
             }

--- a/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
+++ b/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
@@ -369,7 +369,7 @@ public class PdfImporter {
                 new FocusRequester(panel.getEntryEditor(be));
                 return be;
             } catch (KeyCollisionException ex) {
-                LOGGER.info("Key collision occured", ex);
+                LOGGER.info("Key collision occurred", ex);
             }
         }
         return null;

--- a/src/main/java/net/sf/jabref/specialfields/Printed.java
+++ b/src/main/java/net/sf/jabref/specialfields/Printed.java
@@ -29,8 +29,11 @@ public class Printed extends SpecialField {
 
     private Printed() {
         ArrayList<SpecialFieldValue> values = new ArrayList<>();
+        // @formatter:off
         // DO NOT TRANSLATE "printed" as this makes the produced .bib files non portable
-        values.add(new SpecialFieldValue(this, "printed", "togglePrinted", Localization.lang("Toogle print status"), IconTheme.JabRefIcon.PRINTED.getSmallIcon(), Localization.lang("Toogle print status")));
+        values.add(new SpecialFieldValue(this, "printed", "togglePrinted", Localization.lang("Toogle print status"), IconTheme.JabRefIcon.PRINTED.getSmallIcon(),
+                Localization.lang("Toogle print status")));
+        // @formatter:on
         this.setValues(values);
         TEXT_DONE_PATTERN = "Toggled print status for %0 entries";
     }

--- a/src/main/java/net/sf/jabref/specialfields/Priority.java
+++ b/src/main/java/net/sf/jabref/specialfields/Priority.java
@@ -31,7 +31,10 @@ public class Priority extends SpecialField {
 
     private Priority() {
         ArrayList<SpecialFieldValue> values = new ArrayList<>();
-        values.add(new SpecialFieldValue(this, null, "clearPriority", Localization.lang("Clear priority"), null, Localization.lang("No priority information")));
+        // @formatter:off
+        values.add(new SpecialFieldValue(this, null, "clearPriority", Localization.lang("Clear priority"), null,
+                Localization.lang("No priority information")));
+        // @formatter:on
         Icon tmpicon;
         tmpicon = IconTheme.JabRefIcon.PRIORITY_HIGH.getSmallIcon();
         // DO NOT TRANSLATE "prio1" etc. as this makes the .bib files non portable

--- a/src/main/java/net/sf/jabref/specialfields/Quality.java
+++ b/src/main/java/net/sf/jabref/specialfields/Quality.java
@@ -29,8 +29,11 @@ public class Quality extends SpecialField {
 
     private Quality() {
         ArrayList<SpecialFieldValue> values = new ArrayList<>();
+        // @formatter:off
         // DO NOT TRANSLATE "qualityAssured" as this makes the produced .bib files non portable
-        values.add(new SpecialFieldValue(this, "qualityAssured", "toggleQualityAssured", Localization.lang("Toogle quality assured"), IconTheme.JabRefIcon.QUALITY_ASSURED.getSmallIcon(), Localization.lang("Toogle quality assured")));
+        values.add(new SpecialFieldValue(this, "qualityAssured", "toggleQualityAssured", Localization.lang("Toogle quality assured"), IconTheme.JabRefIcon.QUALITY_ASSURED.getSmallIcon(),
+                Localization.lang("Toogle quality assured")));
+        // @formatter:on
         this.setValues(values);
         TEXT_DONE_PATTERN = "Toggled quality for %0 entries";
     }

--- a/src/main/java/net/sf/jabref/specialfields/Rank.java
+++ b/src/main/java/net/sf/jabref/specialfields/Rank.java
@@ -29,8 +29,11 @@ public class Rank extends SpecialField {
         TEXT_DONE_PATTERN = "Set rank to '%0' for %1 entries";
 
         ArrayList<SpecialFieldValue> values = new ArrayList<>();
-        //lab.setName("i");
-        values.add(new SpecialFieldValue(this, null, "clearRank", Localization.lang("Clear rank"), null, Localization.lang("No rank information")));
+        // lab.setName("i");
+        // @formatter:off
+        values.add(new SpecialFieldValue(this, null, "clearRank", Localization.lang("Clear rank"), null,
+                Localization.lang("No rank information")));
+        // @formatter:on
         // DO NOT TRANSLATE "rank1" etc. as this makes the .bib files non portable
         values.add(new SpecialFieldValue(this, "rank1", "setRank1", "", IconTheme.JabRefIcon.RANK1.getSmallIcon(), Localization.lang("One star")));
         values.add(new SpecialFieldValue(this, "rank2", "setRank2", "", IconTheme.JabRefIcon.RANK2.getSmallIcon(), Localization.lang("Two stars")));

--- a/src/main/java/net/sf/jabref/specialfields/ReadStatus.java
+++ b/src/main/java/net/sf/jabref/specialfields/ReadStatus.java
@@ -31,15 +31,20 @@ public class ReadStatus extends SpecialField {
 
     private ReadStatus() {
         ArrayList<SpecialFieldValue> values = new ArrayList<>();
-        values.add(new SpecialFieldValue(this, null, "clearReadStatus", Localization.lang("Clear read status"), null, Localization.lang("No read status information")));
+        // @formatter:off
+        values.add(new SpecialFieldValue(this, null, "clearReadStatus", Localization.lang("Clear read status"), null,
+                Localization.lang("No read status information")));
         Icon tmpicon;
         tmpicon = IconTheme.JabRefIcon.READ_STATUS_READ.getSmallIcon();
         // DO NOT TRANSLATE "read" as this makes the produced .bib files non portable
         values.add(new SpecialFieldValue(this, "read", "setReadStatusToRead",
-                Localization.lang("Set read status to read"), tmpicon, Localization.lang("Read status read")));
+                Localization.lang("Set read status to read"), tmpicon,
+                Localization.lang("Read status read")));
         tmpicon = IconTheme.JabRefIcon.READ_STATUS_SKIMMED.getSmallIcon();
         values.add(new SpecialFieldValue(this, "skimmed", "setReadStatusToSkimmed",
-                Localization.lang("Set read status to skimmed"), tmpicon, Localization.lang("Read status skimmed")));
+                Localization.lang("Set read status to skimmed"), tmpicon,
+                Localization.lang("Read status skimmed")));
+        // @formatter:on
         this.setValues(values);
         TEXT_DONE_PATTERN = "Set read status to '%0' for %1 entries";
     }

--- a/src/main/java/net/sf/jabref/specialfields/Relevance.java
+++ b/src/main/java/net/sf/jabref/specialfields/Relevance.java
@@ -29,9 +29,12 @@ public class Relevance extends SpecialField {
 
     private Relevance() {
         ArrayList<SpecialFieldValue> values = new ArrayList<>();
+        // @formatter:off
         // action directly set by JabRefFrame
         // DO NOT TRANSLATE "relevant" as this makes the produced .bib files non portable
-        values.add(new SpecialFieldValue(this, "relevant", "toggleRelevance", Localization.lang("Toggle relevance"), IconTheme.JabRefIcon.RELEVANCE.getSmallIcon(), Localization.lang("Toggle relevance")));
+        values.add(new SpecialFieldValue(this, "relevant", "toggleRelevance", Localization.lang("Toggle relevance"), IconTheme.JabRefIcon.RELEVANCE.getSmallIcon(),
+                Localization.lang("Toggle relevance")));
+        // @formatter:on
         this.setValues(values);
         TEXT_DONE_PATTERN = "Toggled relevance for %0 entries";
     }

--- a/src/main/java/net/sf/jabref/sql/DBStrings.java
+++ b/src/main/java/net/sf/jabref/sql/DBStrings.java
@@ -17,7 +17,6 @@ package net.sf.jabref.sql;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.logic.l10n.Localization;
 
 /**
  *
@@ -51,7 +50,7 @@ public class DBStrings {
      * Initializes the variables needed with defaults
      */
     public void initialize() {
-        String[] servers = {Localization.lang("MySQL"), Localization.lang("PostgreSQL")};
+        String[] servers = {"MySQL", "PostgreSQL"};
         setServerTypes(servers);
         setServerType(Globals.prefs.get(JabRefPreferences.DB_CONNECT_SERVER_TYPE));
         setServerHostname(Globals.prefs.get(JabRefPreferences.DB_CONNECT_HOSTNAME));

--- a/src/main/java/net/sf/jabref/sql/DbConnectAction.java
+++ b/src/main/java/net/sf/jabref/sql/DbConnectAction.java
@@ -28,9 +28,9 @@ import java.awt.event.ActionEvent;
 /**
  * Created by IntelliJ IDEA. User: alver Date: Mar 27, 2008 Time: 6:05:13 PM To
  * change this template use File | Settings | File Templates.
- * 
+ *
  * Jan 20th Adjusted to accomodate changes on SQL Exporter module by ifsteinm
- * 
+ *
  */
 public class DbConnectAction implements BaseAction {
 
@@ -91,12 +91,10 @@ public class DbConnectAction implements BaseAction {
                 String errorMessage = SQLUtil.getExceptionMessage(ex);
                 dbs.isConfigValid(false);
 
-                String preamble = "Could not connect to SQL database for the following reason:";
-                panel.frame().output(
-                        Localization.lang(preamble) + "  " + errorMessage);
+                String preamble = Localization.lang("Could not connect to SQL database for the following reason:");
+                panel.frame().output(preamble + "  " + errorMessage);
 
-                JOptionPane.showMessageDialog(panel.frame(),
-                        Localization.lang(preamble) + '\n' + errorMessage,
+                JOptionPane.showMessageDialog(panel.frame(), preamble + '\n' + errorMessage,
                         Localization.lang("Connect to SQL database"),
                         JOptionPane.ERROR_MESSAGE);
             } finally {

--- a/src/main/java/net/sf/jabref/sql/importer/DbImportAction.java
+++ b/src/main/java/net/sf/jabref/sql/importer/DbImportAction.java
@@ -170,11 +170,6 @@ public class DbImportAction extends AbstractWorker {
                                     frame.output(Localization.lang("Importing cancelled"));
                                 }
                             }
-<<<<<<< HEAD
-=======
-                            frame.output(Localization.lang("%0 databases will be imported",
-                                    Integer.toString(databases.size())));
->>>>>>> Fixed a number of false positive translation strings and cleaned up some parts related to translations
                         } else {
                             JOptionPane.showMessageDialog(frame,
                                     Localization.lang("There are no available databases to be imported"),

--- a/src/main/java/net/sf/jabref/sql/importer/DbImportAction.java
+++ b/src/main/java/net/sf/jabref/sql/importer/DbImportAction.java
@@ -170,6 +170,11 @@ public class DbImportAction extends AbstractWorker {
                                     frame.output(Localization.lang("Importing cancelled"));
                                 }
                             }
+<<<<<<< HEAD
+=======
+                            frame.output(Localization.lang("%0 databases will be imported",
+                                    Integer.toString(databases.size())));
+>>>>>>> Fixed a number of false positive translation strings and cleaned up some parts related to translations
                         } else {
                             JOptionPane.showMessageDialog(frame,
                                     Localization.lang("There are no available databases to be imported"),
@@ -178,7 +183,7 @@ public class DbImportAction extends AbstractWorker {
                     }
                 }
             } catch (Exception ex) {
-                String preamble = "Could not import from SQL database for the following reason:";
+                String preamble = Localization.lang("Could not import from SQL database for the following reason:");
                 String errorMessage = SQLUtil.getExceptionMessage(ex);
                 dbs.isConfigValid(false);
                 JOptionPane.showMessageDialog(frame, Localization.lang(preamble) + '\n' + errorMessage,

--- a/src/main/java/net/sf/jabref/wizard/text/gui/TextInputDialog.java
+++ b/src/main/java/net/sf/jabref/wizard/text/gui/TextInputDialog.java
@@ -273,12 +273,12 @@ public class TextInputDialog extends JDialog implements ActionListener {
 
         // Radio buttons
         JRadioButton appRadio = new JRadioButton(Localization.lang("Append"));
-        appRadio.setToolTipText(Localization.lang("append_the_selected_text_to_bibtex_key"));
+        appRadio.setToolTipText(Localization.lang("Append_the_selected_text_to_bibtex_key"));
         appRadio.setMnemonic(KeyEvent.VK_A);
         appRadio.setSelected(true);
 
         overRadio = new JRadioButton(Localization.lang("Override"));
-        overRadio.setToolTipText(Localization.lang("override_the_bibtex_key_by_the_selected_text"));
+        overRadio.setToolTipText(Localization.lang("Override_the_bibtex_key_by_the_selected_text"));
         overRadio.setMnemonic(KeyEvent.VK_O);
         overRadio.setSelected(false);
 
@@ -676,11 +676,11 @@ public class TextInputDialog extends JDialog implements ActionListener {
                 this.setForeground(Color.gray);
                 this.setFont(usedFont);
                 this.setIcon(okIcon);
-                this.setToolTipText("filled");
+                this.setToolTipText(Localization.lang("Filled"));
             }
             else {
                 this.setIcon(needIcon);
-                this.setToolTipText("field is missing");
+                this.setToolTipText(Localization.lang("Field is missing"));
             }
             return this;
         }
@@ -726,22 +726,9 @@ abstract class BasicAction extends AbstractAction {
         putValue(Action.SHORT_DESCRIPTION, description);
     }
 
-    /* TODO: Not used. Will comment out for a while for possible later removal
-    public BasicAction(String text, String description, URL icon, KeyStroke key) {
-        super(Localization.lang(text), new ImageIcon(icon));
-        putValue(Action.ACCELERATOR_KEY, key);
-        putValue(Action.SHORT_DESCRIPTION, Localization.lang(description));
-    } */
-
     public BasicAction(String text) {
         super(text);
     }
-    /* TODO: Not used. Will comment out for a while for possible later removal
-    public BasicAction(String text, KeyStroke key) {
-        super(Localization.lang(text));
-        putValue(Action.ACCELERATOR_KEY, key);
-    }
-    */
 
     @Override
     public abstract void actionPerformed(ActionEvent e);

--- a/src/main/java/net/sf/jabref/wizard/text/gui/TextInputDialog.java
+++ b/src/main/java/net/sf/jabref/wizard/text/gui/TextInputDialog.java
@@ -70,7 +70,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -528,7 +527,11 @@ public class TextInputDialog extends JDialog implements ActionListener {
 
     class PasteAction extends BasicAction {
         public PasteAction() {
-            super("Paste", "Paste from clipboard", IconTheme.JabRefIcon.PASTE.getIcon());
+            // @formatter:off
+            super(Localization.lang("Paste"),
+                    Localization.lang("Paste from clipboard"),
+                    IconTheme.JabRefIcon.PASTE.getIcon());
+            // @formatter:on
         }
 
         @Override
@@ -552,7 +555,11 @@ public class TextInputDialog extends JDialog implements ActionListener {
 
     class LoadAction extends BasicAction {
         public LoadAction() {
-            super("Open", "Open_file", IconTheme.JabRefIcon.OPEN.getIcon());
+            // @formatter:off
+            super(Localization.lang("Open"),
+                    Localization.lang("Open file"),
+                    IconTheme.JabRefIcon.OPEN.getIcon());
+            // @formatter:on
         }
 
         @Override
@@ -580,7 +587,11 @@ public class TextInputDialog extends JDialog implements ActionListener {
 
     class ClearAction extends BasicAction {
         public ClearAction() {
-            super("Clear", "Clear_inputarea", IconTheme.JabRefIcon.NEW.getIcon());
+            // @formatter:off
+            super(Localization.lang("Clear"),
+                    Localization.lang("Clear inputarea"),
+                    IconTheme.JabRefIcon.NEW.getIcon());
+            // @formatter:on
         }
 
         @Override
@@ -591,7 +602,7 @@ public class TextInputDialog extends JDialog implements ActionListener {
 
     class MenuHeaderAction extends BasicAction {
         public MenuHeaderAction() {
-            super("Edit");
+            super(Localization.lang("Edit"));
             this.setEnabled(false);
         }
 
@@ -711,24 +722,26 @@ class PopupListener extends MouseAdapter {
 
 abstract class BasicAction extends AbstractAction {
     public BasicAction(String text, String description, Icon icon) {
-        super(Localization.lang(text), icon);
-        putValue(Action.SHORT_DESCRIPTION, Localization.lang(description));
+        super(text, icon);
+        putValue(Action.SHORT_DESCRIPTION, description);
     }
 
+    /* TODO: Not used. Will comment out for a while for possible later removal
     public BasicAction(String text, String description, URL icon, KeyStroke key) {
         super(Localization.lang(text), new ImageIcon(icon));
         putValue(Action.ACCELERATOR_KEY, key);
         putValue(Action.SHORT_DESCRIPTION, Localization.lang(description));
-    }
+    } */
 
     public BasicAction(String text) {
-        super(Localization.lang(text));
+        super(text);
     }
-
+    /* TODO: Not used. Will comment out for a while for possible later removal
     public BasicAction(String text, KeyStroke key) {
         super(Localization.lang(text));
         putValue(Action.ACCELERATOR_KEY, key);
     }
+    */
 
     @Override
     public abstract void actionPerformed(ActionEvent e);

--- a/src/main/resources/help/en/SearchHelp.html
+++ b/src/main/resources/help/en/SearchHelp.html
@@ -12,12 +12,12 @@
     <p><em>CTRL-F</em> opens or focuses the search interface.
     Pressing <em>CTRL-F</em> several times toggles search mode.
     When searching incrementally, pressing <em>CTRL-F</em> makes
-    the program search for the next occurence of the search
+    the program search for the next occurrence of the search
     string.</p>
 
     <p><em>CTRL-SHIFT-F</em> opens or focuses the search interface,
     and selects incremental search. When searching incrementally,
-    <em>CTRL-SHIFT-F</em> also finds the next occurence of the
+    <em>CTRL-SHIFT-F</em> also finds the next occurrence of the
     search string.</p>
 
     <h2>Search modes</h2>
@@ -40,7 +40,7 @@
     <h3>Normal search</h3>
 
     <p>In a normal search, the program searches your
-    database for all occurences of the words in your search string,
+    database for all occurrences of the words in your search string,
     once you press ENTER. Only entries containing all words will be
     considered matches. To search for sequences of words, enclose
     the sequences in double quotes. For instance, the query


### PR DESCRIPTION
Cleaned up the code (basically move Localization.lang to the "correct" places) for a number of files to reduce the amount of false positives when it comes to possibly obsolete keys. This also resulted in some other related clean-ups, such as removing translation requests for database names (try to translate "INSPIRE"...).