### PR TITLE
Removes option to toggle native file dialog on mac by making JabRef a…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 [master]
     - Feature: Search DOAJ, Directory of Open Access Journals
+    - Removes option to toggle native file dialog on mac by making JabRef always use native file dialogs on mac
     - Removes options to set PDF and PS directories per .bib database as the general options have also been deleted.
     - Removes option to disable renaming in FileChooser dialogs.
     - Removes option to hide the BibTeX Code tab in the entry editor.

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -282,7 +282,6 @@ public class JabRefPreferences {
     public static final String IMPORT_INSPECTION_DIALOG_WIDTH = "importInspectionDialogWidth";
     public static final String SIDE_PANE_WIDTH = "sidePaneWidth";
     public static final String LAST_USED_EXPORT = "lastUsedExport";
-    public static final String USE_NATIVE_FILE_DIALOG_ON_MAC = "useNativeFileDialogOnMac";
     public static final String FLOAT_MARKED_ENTRIES = "floatMarkedEntries";
     public static final String CITE_COMMAND = "citeCommand";
     public static final String EXTERNAL_JOURNAL_LISTS = "externalJournalLists";
@@ -738,8 +737,6 @@ public class JabRefPreferences {
         defaults.put(EXTERNAL_JOURNAL_LISTS, null);
         defaults.put(CITE_COMMAND, "\\cite"); // obsoleted by the app-specific ones (not any more?)
         defaults.put(FLOAT_MARKED_ENTRIES, Boolean.TRUE);
-
-        defaults.put(USE_NATIVE_FILE_DIALOG_ON_MAC, Boolean.FALSE);
 
         defaults.put(LAST_USED_EXPORT, null);
         defaults.put(SIDE_PANE_WIDTH, -1);

--- a/src/main/java/net/sf/jabref/gui/FileDialogs.java
+++ b/src/main/java/net/sf/jabref/gui/FileDialogs.java
@@ -24,6 +24,7 @@ import javax.swing.JFrame;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.logic.util.OS;
 
 /**
  * Created by IntelliJ IDEA.
@@ -105,8 +106,7 @@ public class FileDialogs {
 
         // Added the !dirOnly condition below as a workaround to the native file dialog
         // not supporting directory selection:
-        if (!dirOnly && Globals.prefs.getBoolean(JabRefPreferences.USE_NATIVE_FILE_DIALOG_ON_MAC)) {
-
+        if (!dirOnly && OS.OS_X) {
             return FileDialogs.getNewFileForMac(owner, directory, extension, dialogType, updateWorkingDirectory, dirOnly, off);
         }
 
@@ -127,7 +127,6 @@ public class FileDialogs {
 
         if (dirOnly) {
             fc.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-
         }
 
         fc.setMultiSelectionEnabled(multipleSelection);

--- a/src/main/java/net/sf/jabref/gui/preftabs/AdvancedTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/AdvancedTab.java
@@ -49,7 +49,6 @@ class AdvancedTab extends JPanel implements PrefsTab {
     private final JabRefPreferences preferences;
     private final JCheckBox useDefault;
     private final JCheckBox useRemoteServer;
-    private final JCheckBox useNativeFileDialogOnMac;
     private final JCheckBox useIEEEAbrv;
     private final JCheckBox biblatexMode;
     private final JComboBox<String> className;
@@ -73,7 +72,6 @@ class AdvancedTab extends JPanel implements PrefsTab {
 
         useDefault = new JCheckBox(Localization.lang("Use other look and feel"));
         useRemoteServer = new JCheckBox(Localization.lang("Listen for remote operation on port") + ':');
-        useNativeFileDialogOnMac = new JCheckBox(Localization.lang("Use native file dialog"));
         useIEEEAbrv = new JCheckBox(Localization.lang("Use IEEE LaTeX abbreviations"));
         biblatexMode = new JCheckBox(Localization.lang("BibLaTeX mode"));
         remoteServerPort = new JTextField();
@@ -97,13 +95,7 @@ class AdvancedTab extends JPanel implements PrefsTab {
         className = new JComboBox<>(lookAndFeels.toArray(new String[lookAndFeels.size()]));
         className.setEditable(true);
         final JComboBox<String> clName = className;
-        useDefault.addChangeListener(new ChangeListener() {
-
-            @Override
-            public void stateChanged(ChangeEvent e) {
-                clName.setEnabled(((JCheckBox) e.getSource()).isSelected());
-            }
-        });
+        useDefault.addChangeListener(e -> clName.setEnabled(((JCheckBox) e.getSource()).isSelected()));
         useConvertToEquation = new JCheckBox(Localization.lang("Prefer converting subscripts and superscripts to equations rather than text"));
         useCaseKeeperOnSearch = new JCheckBox(Localization.lang("Add {} to specified title words on search to keep the correct case"));
         useUnitFormatterOnSearch = new JCheckBox(Localization.lang("Format units by adding non-breaking separators and keeping the correct case on search"));
@@ -156,13 +148,6 @@ class AdvancedTab extends JPanel implements PrefsTab {
         p.add(new HelpAction(diag, GUIGlobals.remoteHelp).getIconButton());
         builder.append(p);
 
-        //if (Globals.OS_X) {
-        builder.nextLine();
-        builder.appendSeparator(Localization.lang("File dialog"));
-        builder.nextLine();
-        builder.append(new JPanel());
-        builder.append(useNativeFileDialogOnMac);
-        //}
         // IEEE
         builder.nextLine();
         builder.appendSeparator(Localization.lang("Search IEEEXplore"));
@@ -204,7 +189,6 @@ class AdvancedTab extends JPanel implements PrefsTab {
         useRemoteServer.setSelected(remotePreferences.useRemoteServer());
         oldPort = remotePreferences.getPort();
         remoteServerPort.setText(String.valueOf(oldPort));
-        useNativeFileDialogOnMac.setSelected(Globals.prefs.getBoolean(JabRefPreferences.USE_NATIVE_FILE_DIALOG_ON_MAC));
         useIEEEAbrv.setSelected(Globals.prefs.getBoolean(JabRefPreferences.USE_IEEE_ABRV));
         oldBiblMode = Globals.prefs.getBoolean(JabRefPreferences.BIBLATEX_MODE);
         biblatexMode.setSelected(oldBiblMode);
@@ -217,7 +201,6 @@ class AdvancedTab extends JPanel implements PrefsTab {
     public void storeSettings() {
         preferences.putBoolean(JabRefPreferences.USE_DEFAULT_LOOK_AND_FEEL, !useDefault.isSelected());
         preferences.put(JabRefPreferences.WIN_LOOK_AND_FEEL, className.getSelectedItem().toString());
-        preferences.putBoolean(JabRefPreferences.USE_NATIVE_FILE_DIALOG_ON_MAC, useNativeFileDialogOnMac.isSelected());
 
         if(preferences.getBoolean(JabRefPreferences.USE_IEEE_ABRV) != useIEEEAbrv.isSelected()) {
             preferences.putBoolean(JabRefPreferences.USE_IEEE_ABRV, useIEEEAbrv.isSelected());


### PR DESCRIPTION
…lways use native file dialogs on mac

As discussed in the dev meeting. But the option is only for mac users. To make this available for all other operating system, more has to be investigated. But this is not necessary for now. 