### PR TITLE
Add "open folder" icon

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 [master]
+    - Fixed bug SF #1149: Missing icon for "Open folder"
     - Feature: Search DOAJ, Directory of Open Access Journals
     - The key bindings for searching specific databases are removed
     - Removes option to toggle native file dialog on mac by making JabRef always use native file dialogs on mac

--- a/src/main/java/net/sf/jabref/gui/IconTheme.java
+++ b/src/main/java/net/sf/jabref/gui/IconTheme.java
@@ -54,7 +54,7 @@ public class IconTheme {
         ADD_ENTRY("\uF571") /*css: tooltip-outline-plus */,
         EDIT_ENTRY("\uf56e") /*css: tooltip-edit */,
         EDIT_STRINGS("\uf572") /*css: tooltip-text */,
-        FOLDER("\uf07b"),
+        FOLDER("\uF300") /*css: folder */,
         REMOVE("\uf406"),
         REMOVE_NOBOX("\uF405") /*css: minus */,
         FILE("\uf2cf"),

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -401,8 +401,10 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             prefs.getKey(KeyBinds.WRITE_XMP));
 
     private final AbstractAction openFolder = new GeneralAction(Actions.OPEN_FOLDER,
-            Localization.menuTitle("Open folder"), Localization.lang("Open folder"),
-            prefs.getKey(KeyBinds.OPEN_FOLDER));
+            Localization.menuTitle("Open folder"),
+            Localization.lang("Open folder"),
+ prefs.getKey(KeyBinds.OPEN_FOLDER),
+            IconTheme.JabRefIcon.FOLDER.getIcon());
     private final AbstractAction openFile = new GeneralAction(Actions.OPEN_EXTERNAL_FILE,
             Localization.menuTitle("Open file"),
             Localization.lang("Open file"),

--- a/src/main/java/net/sf/jabref/gui/RightClickMenu.java
+++ b/src/main/java/net/sf/jabref/gui/RightClickMenu.java
@@ -147,7 +147,8 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
             addSeparator();
         }
 
-        add(new GeneralAction(Actions.OPEN_FOLDER, Localization.lang("Open folder")) {
+        add(new GeneralAction(Actions.OPEN_FOLDER, Localization.lang("Open folder"),
+                IconTheme.JabRefIcon.FOLDER.getSmallIcon()) {
             {
                 if (!isFieldSetForSelectedEntry("file")) {
                     this.setEnabled(false);


### PR DESCRIPTION
Adds a icon to the "open folder" command (under the tools menu as well
as for the menu appearing on right-click). This fixes [SF bug #1149 Missing icon for "Open folder"](https://sourceforge.net/p/jabref/bugs/1149/).

(Before you ask: the line `prefs.getKey(KeyBinds.OPEN_FOLDER)` is formatted in this way by eclipse on save...)