### PR TITLE
Inlined Abbreviation button from JournalAbbreviationButton to EntryEd…

### DIFF
--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -481,7 +481,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                 public void actionPerformed(ActionEvent actionEvent) {
                     String text = editor.getText();
                     if (Abbreviations.journalAbbrev.isKnownName(text)) {
-                        String s = Abbreviations.journalAbbrev.getNextAbbreviation(text).orElse(text);
+                        String s = Abbreviations.toggleAbbreviation(text);
 
                         if (s != null) {
                             editor.setText(s);

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -43,7 +43,6 @@ import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.text.JTextComponent;
-
 import net.sf.jabref.*;
 import net.sf.jabref.gui.actions.Actions;
 import net.sf.jabref.gui.fieldeditors.*;
@@ -51,6 +50,7 @@ import net.sf.jabref.gui.keyboard.KeyBinds;
 import net.sf.jabref.bibtex.BibtexEntryWriter;
 import net.sf.jabref.gui.menus.ChangeEntryTypeMenu;
 import net.sf.jabref.logic.autocompleter.AutoCompleter;
+import net.sf.jabref.logic.journals.Abbreviations;
 import net.sf.jabref.exporter.LatexFieldFormatter;
 import net.sf.jabref.external.ExternalFilePanel;
 import net.sf.jabref.external.WriteXMPEntryEditorAction;
@@ -59,7 +59,6 @@ import net.sf.jabref.gui.date.DatePickerButton;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.importer.ParserResult;
-import net.sf.jabref.gui.journals.JournalAbbreviationsUtil;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.labelPattern.LabelPatternUtil;
 import net.sf.jabref.logic.util.date.EasyDateFormat;
@@ -169,6 +168,14 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
     private final RedoAction redoAction = new RedoAction();
 
     private final TabListener tabListener = new TabListener();
+
+    // @formatter:off
+    private final String ABBREVIATION_TOOLTIP_TEXT = "<HTML>"
+            + Localization.lang("Switches between full and abbreviated journal name if the journal name is known.")
+            + "<BR>" + Localization.lang("To set up, go to") + " <B>"
+            + Localization.lang("Options") + " -> "
+            + Localization.lang("Manage journal abbreviations") + "</B></HTML>";
+    // @formatter:on
 
 
     public EntryEditor(JabRefFrame frame, BasePanel panel, BibtexEntry entry) {
@@ -464,8 +471,33 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                 contentSelectors.add(ws);
                 controls.add(ws, BorderLayout.NORTH);
             }
-            controls.add(JournalAbbreviationsUtil.getNameSwitcher(this, editor, panel.undoManager),
-                    BorderLayout.SOUTH);
+
+            // Button to toggle abbreviated/full journal names
+            JButton button = new JButton(Localization.lang("Toggle abbreviation"));
+            button.setToolTipText(ABBREVIATION_TOOLTIP_TEXT);
+            button.addActionListener(new ActionListener() {
+
+                @Override
+                public void actionPerformed(ActionEvent actionEvent) {
+                    String text = editor.getText();
+                    if (Abbreviations.journalAbbrev.isKnownName(text)) {
+                        String s = toggleAbbreviation(text);
+
+                        if (s != null) {
+                            editor.setText(s);
+                            storeFieldAction.actionPerformed(new ActionEvent(editor, 0, ""));
+                            panel.undoManager
+                                    .addEdit(new UndoableFieldChange(getEntry(), editor.getFieldName(), text, s));
+                        }
+                    }
+                }
+
+                public String toggleAbbreviation(String currentText) {
+                    return Abbreviations.journalAbbrev.getNextAbbreviation(currentText).orElse(currentText);
+                }
+            });
+
+            controls.add(button, BorderLayout.SOUTH);
             return controls;
         } else {
             if (panel.metaData.getData(Globals.SELECTOR_META_PREFIX + editor.getFieldName()) != null) {

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -481,7 +481,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                 public void actionPerformed(ActionEvent actionEvent) {
                     String text = editor.getText();
                     if (Abbreviations.journalAbbrev.isKnownName(text)) {
-                        String s = toggleAbbreviation(text);
+                        String s = Abbreviations.journalAbbrev.getNextAbbreviation(text).orElse(text);
 
                         if (s != null) {
                             editor.setText(s);
@@ -490,10 +490,6 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                                     .addEdit(new UndoableFieldChange(getEntry(), editor.getFieldName(), text, s));
                         }
                     }
-                }
-
-                public String toggleAbbreviation(String currentText) {
-                    return Abbreviations.journalAbbrev.getNextAbbreviation(currentText).orElse(currentText);
                 }
             });
 

--- a/src/main/java/net/sf/jabref/gui/journals/JournalAbbreviationsUtil.java
+++ b/src/main/java/net/sf/jabref/gui/journals/JournalAbbreviationsUtil.java
@@ -15,64 +15,14 @@
 */
 package net.sf.jabref.gui.journals;
 
-import net.sf.jabref.gui.entryeditor.EntryEditor;
-import net.sf.jabref.gui.fieldeditors.FieldEditor;
 import net.sf.jabref.logic.journals.Abbreviation;
-import net.sf.jabref.logic.journals.Abbreviations;
 import net.sf.jabref.logic.journals.JournalAbbreviationRepository;
-import net.sf.jabref.gui.undo.UndoableFieldChange;
 import net.sf.jabref.logic.l10n.Localization;
 
-import javax.swing.JButton;
-import javax.swing.JComponent;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableModel;
-import javax.swing.undo.UndoManager;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
 public class JournalAbbreviationsUtil {
-
-    // @formatter:off
-    private static final String TOOLTIP_TEXT = "<HTML>" + Localization.lang("Switches between full and abbreviated journal name "
-            + "if the journal name is known.")
-            + "<BR>" + Localization.lang("To set up, go to <B>Tools -> Manage journal abbreviations</B>") + ".</HTML>";
-    // @formatter:on
-
-    /**
-     * Create a control panel for the entry editor's journal field, to toggle
-     * abbreviated/full journal name
-     * @param editor The FieldEditor for the journal field.
-     * @return The control panel for the entry editor.
-     */
-    public static JComponent getNameSwitcher(final EntryEditor entryEditor, final FieldEditor editor,
-            final UndoManager undoManager) {
-        JButton button = new JButton(Localization.lang("Toggle abbreviation"));
-        button.setToolTipText(TOOLTIP_TEXT);
-        button.addActionListener(new ActionListener() {
-
-            @Override
-            public void actionPerformed(ActionEvent actionEvent) {
-                String text = editor.getText();
-                if (Abbreviations.journalAbbrev.isKnownName(text)) {
-                    String s = toggleAbbreviation(text);
-
-                    if (s != null) {
-                        editor.setText(s);
-                        entryEditor.storeFieldAction.actionPerformed(new ActionEvent(editor, 0, ""));
-                        undoManager.addEdit(new UndoableFieldChange(entryEditor.getEntry(), editor.getFieldName(),
-                                text, s));
-                    }
-                }
-            }
-
-            public String toggleAbbreviation(String currentText) {
-                return Abbreviations.journalAbbrev.getNextAbbreviation(currentText).orElse(currentText);
-            }
-        });
-
-        return button;
-    }
 
     public static TableModel getTableModel(JournalAbbreviationRepository journalAbbreviationRepository) {
         Object[][] cells = new Object[journalAbbreviationRepository.size()][2];

--- a/src/main/java/net/sf/jabref/logic/journals/Abbreviation.java
+++ b/src/main/java/net/sf/jabref/logic/journals/Abbreviation.java
@@ -29,10 +29,6 @@ public class Abbreviation implements Comparable<Abbreviation> {
         return getIsoAbbreviation().replaceAll("\\.", " ").replaceAll("  ", " ").trim();
     }
 
-    public boolean hasIsoAndMedlineAbbreviationsAreSame() {
-        return getIsoAbbreviation().equals(getMedlineAbbreviation());
-    }
-
     @Override
     public int compareTo(Abbreviation toCompare) {
         return name.compareTo(toCompare.name);
@@ -53,14 +49,6 @@ public class Abbreviation implements Comparable<Abbreviation> {
     @Override
     public String toString() {
         return String.format("Abbreviation{name=%s, iso=%s, medline=%s}", name, getIsoAbbreviation(), getMedlineAbbreviation());
-    }
-
-    public String toPropertiesLine() {
-        return String.format("%s = %s", name, getAbbreviation());
-    }
-
-    public String getAbbreviation() {
-        return abbreviation;
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/logic/journals/Abbreviations.java
+++ b/src/main/java/net/sf/jabref/logic/journals/Abbreviations.java
@@ -74,4 +74,8 @@ public class Abbreviations {
         }
 
     }
+
+    public static String toggleAbbreviation(String text) {
+        return journalAbbrev.getNextAbbreviation(text).orElse(text);
+    }
 }

--- a/src/main/java/net/sf/jabref/logic/journals/Abbreviations.java
+++ b/src/main/java/net/sf/jabref/logic/journals/Abbreviations.java
@@ -1,3 +1,18 @@
+/*  Copyright (C) 2003-2015 JabRef contributors.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
 package net.sf.jabref.logic.journals;
 
 import net.sf.jabref.JabRefPreferences;
@@ -36,7 +51,7 @@ public class Abbreviations {
 
         // Read external lists
         String[] lists = jabRefPreferences.getStringArray(JabRefPreferences.EXTERNAL_JOURNAL_LISTS);
-        if (lists != null && lists.length > 0) {
+        if ((lists != null) && (lists.length > 0)) {
             for (int i = lists.length - 1; i >= 0; i--) {
                 String filename = lists[i];
                 try {
@@ -50,7 +65,7 @@ public class Abbreviations {
 
         // Read personal list
         String personalJournalList = jabRefPreferences.get(JabRefPreferences.PERSONAL_JOURNAL_LIST);
-        if (personalJournalList != null && !personalJournalList.trim().isEmpty()) {
+        if ((personalJournalList != null) && !personalJournalList.trim().isEmpty()) {
             try {
                 journalAbbrev.readJournalListFromFile(new File(personalJournalList));
             } catch (FileNotFoundException e) {

--- a/src/main/java/net/sf/jabref/logic/journals/JournalAbbreviationRepository.java
+++ b/src/main/java/net/sf/jabref/logic/journals/JournalAbbreviationRepository.java
@@ -142,12 +142,4 @@ public class JournalAbbreviationRepository {
         Abbreviation abbr = abbreviation.get();
         return Optional.of(abbr.getIsoAbbreviation());
     }
-
-    public String toPropertiesString() {
-        StringBuilder sb = new StringBuilder();
-        for (Abbreviation abbreviation : getAbbreviations()) {
-            sb.append(String.format("%s%n", abbreviation.toPropertiesLine()));
-        }
-        return sb.toString();
-    }
 }

--- a/src/test/java/net/sf/jabref/logic/journals/AbbreviationTest.java
+++ b/src/test/java/net/sf/jabref/logic/journals/AbbreviationTest.java
@@ -45,7 +45,7 @@ public class AbbreviationTest {
     public void testIsoAndMedlineAbbreviationsAreSame() {
         Abbreviation abbreviation = new Abbreviation(" Long Name ", " L N ");
 
-        assertTrue(abbreviation.hasIsoAndMedlineAbbreviationsAreSame());
+        assertTrue(abbreviation.getIsoAbbreviation().equals(abbreviation.getMedlineAbbreviation()));
     }
 
 }

--- a/src/test/java/net/sf/jabref/logic/journals/AbbreviationsTest.java
+++ b/src/test/java/net/sf/jabref/logic/journals/AbbreviationsTest.java
@@ -1,0 +1,44 @@
+package net.sf.jabref.logic.journals;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefPreferences;
+
+public class AbbreviationsTest {
+
+    @Before
+    public void setUp() throws Exception {
+        Globals.prefs = JabRefPreferences.getInstance();
+    }
+
+    @Test
+    public void testInitializeJournalNames() {
+        Abbreviations.initializeJournalNames(Globals.prefs);
+    }
+
+    @Test
+    public void testIEEEabrv() {
+        Boolean oldIEEEsetting = Globals.prefs.getBoolean(JabRefPreferences.USE_IEEE_ABRV);
+        Globals.prefs.putBoolean(JabRefPreferences.USE_IEEE_ABRV, true);
+        Abbreviations.initializeJournalNames(Globals.prefs);
+        String textAbrv = "#IEEE_J_PROC#";
+        String textFull = "Proceedings of the IEEE";
+        assertEquals(textAbrv, Abbreviations.journalAbbrev.getNextAbbreviation(textFull).orElse(textFull));
+        assertEquals(textFull, Abbreviations.journalAbbrev.getNextAbbreviation(textAbrv).orElse(textAbrv));
+
+        Globals.prefs.putBoolean(JabRefPreferences.USE_IEEE_ABRV, false);
+        Abbreviations.initializeJournalNames(Globals.prefs);
+        textAbrv = "Proc. IEEE";
+        String textAbrv2 = "Proc IEEE";
+        assertEquals(textAbrv, Abbreviations.journalAbbrev.getNextAbbreviation(textFull).orElse(textFull));
+        assertEquals(textAbrv2, Abbreviations.journalAbbrev.getNextAbbreviation(textAbrv).orElse(textAbrv));
+        assertEquals(textFull, Abbreviations.journalAbbrev.getNextAbbreviation(textAbrv2).orElse(textAbrv2));
+
+        Globals.prefs.putBoolean(JabRefPreferences.USE_IEEE_ABRV, oldIEEEsetting);
+    }
+
+}

--- a/src/test/java/net/sf/jabref/logic/journals/AbbreviationsTest.java
+++ b/src/test/java/net/sf/jabref/logic/journals/AbbreviationsTest.java
@@ -27,16 +27,16 @@ public class AbbreviationsTest {
         Abbreviations.initializeJournalNames(Globals.prefs);
         String textAbrv = "#IEEE_J_PROC#";
         String textFull = "Proceedings of the IEEE";
-        assertEquals(textAbrv, Abbreviations.journalAbbrev.getNextAbbreviation(textFull).orElse(textFull));
-        assertEquals(textFull, Abbreviations.journalAbbrev.getNextAbbreviation(textAbrv).orElse(textAbrv));
+        assertEquals(textAbrv, Abbreviations.toggleAbbreviation(textFull));
+        assertEquals(textFull, Abbreviations.toggleAbbreviation(textAbrv));
 
         Globals.prefs.putBoolean(JabRefPreferences.USE_IEEE_ABRV, false);
         Abbreviations.initializeJournalNames(Globals.prefs);
         textAbrv = "Proc. IEEE";
         String textAbrv2 = "Proc IEEE";
-        assertEquals(textAbrv, Abbreviations.journalAbbrev.getNextAbbreviation(textFull).orElse(textFull));
-        assertEquals(textAbrv2, Abbreviations.journalAbbrev.getNextAbbreviation(textAbrv).orElse(textAbrv));
-        assertEquals(textFull, Abbreviations.journalAbbrev.getNextAbbreviation(textAbrv2).orElse(textAbrv2));
+        assertEquals(textAbrv, Abbreviations.toggleAbbreviation(textFull));
+        assertEquals(textAbrv2, Abbreviations.toggleAbbreviation(textAbrv));
+        assertEquals(textFull, Abbreviations.toggleAbbreviation(textAbrv2));
 
         Globals.prefs.putBoolean(JabRefPreferences.USE_IEEE_ABRV, oldIEEEsetting);
     }

--- a/src/test/java/net/sf/jabref/logic/journals/JournalAbbreviationRepositoryTest.java
+++ b/src/test/java/net/sf/jabref/logic/journals/JournalAbbreviationRepositoryTest.java
@@ -36,7 +36,6 @@ public class JournalAbbreviationRepositoryTest {
         assertTrue(repository.isKnownName("L N"));
         assertFalse(repository.isKnownName("?"));
 
-        assertEquals(String.format("Long Name = L. N.%n"), repository.toPropertiesString());
     }
 
     @Test
@@ -78,7 +77,6 @@ public class JournalAbbreviationRepositoryTest {
         assertEquals(1, repository.size());
         assertEquals("LA. N.", repository.getIsoAbbreviation("Long Name").orElse("WRONG"));
 
-        assertEquals("Long Name = LA. N.", repository.getAbbreviations().first().toPropertiesLine());
     }
 
 }


### PR DESCRIPTION
Moved the method generating the journal abbreviation button and inlined it in EntryEditor.

I changed (and corrected) the translations strings and while I agree that the append-approach is not preferred there was a reason: If any of the menu items, "Options" and "Manage journal abbreviations", are translated, but the tool tip is not, it will still give the correct information. The reason for not using %0 etc is that anything after the first string to be inserted is not translatable.