### PR TITLE
[WIP] Replaced deprecated Glazedlists-API with current

### DIFF
--- a/src/main/java/net/sf/jabref/exporter/ExportCustomizationDialog.java
+++ b/src/main/java/net/sf/jabref/exporter/ExportCustomizationDialog.java
@@ -34,7 +34,7 @@ import net.sf.jabref.gui.util.PositionWindow;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import ca.odell.glazedlists.gui.TableFormat;
-import ca.odell.glazedlists.swing.EventTableModel;
+import ca.odell.glazedlists.swing.DefaultEventTableModel;
 import net.sf.jabref.logic.l10n.Localization;
 
 /**
@@ -128,7 +128,8 @@ public class ExportCustomizationDialog extends JDialog {
 
         JButton help = new HelpAction(frame.helpDiag, GUIGlobals.exportCustomizationHelp).getIconButton();
 
-        EventTableModel<String[]> tableModel = new EventTableModel<>(Globals.prefs.customExports.getSortedList(),
+        DefaultEventTableModel<String[]> tableModel = new DefaultEventTableModel<>(
+                Globals.prefs.customExports.getSortedList(),
                 new ExportTableFormat());
         table = new JTable(tableModel);
         TableColumnModel cm = table.getColumnModel();

--- a/src/main/java/net/sf/jabref/groups/structure/SearchGroup.java
+++ b/src/main/java/net/sf/jabref/groups/structure/SearchGroup.java
@@ -244,4 +244,10 @@ public class SearchGroup extends AbstractGroup {
         return sb.toString();
     }
 
+    @Override
+    public int hashCode() {
+        // TODO Auto-generated method stub
+        return super.hashCode();
+    }
+
 }

--- a/src/main/java/net/sf/jabref/gui/FetcherPreviewDialog.java
+++ b/src/main/java/net/sf/jabref/gui/FetcherPreviewDialog.java
@@ -15,26 +15,42 @@
  */
 package net.sf.jabref.gui;
 
-import ca.odell.glazedlists.BasicEventList;
-import ca.odell.glazedlists.EventList;
-import ca.odell.glazedlists.gui.TableFormat;
-import ca.odell.glazedlists.swing.EventSelectionModel;
-import ca.odell.glazedlists.swing.EventTableModel;
-import com.jgoodies.forms.builder.ButtonBarBuilder;
-import com.jgoodies.forms.builder.ButtonStackBuilder;
-import net.sf.jabref.*;
-import net.sf.jabref.gui.keyboard.KeyBinds;
-import net.sf.jabref.importer.OutputPrinter;
-import net.sf.jabref.logic.l10n.Localization;
-
-import javax.swing.*;
-import javax.swing.table.TableCellRenderer;
-import javax.swing.table.TableModel;
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import javax.swing.AbstractAction;
+import javax.swing.ActionMap;
+import javax.swing.BorderFactory;
+import javax.swing.InputMap;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableModel;
+
+import com.jgoodies.forms.builder.ButtonBarBuilder;
+import com.jgoodies.forms.builder.ButtonStackBuilder;
+
+import ca.odell.glazedlists.BasicEventList;
+import ca.odell.glazedlists.EventList;
+import ca.odell.glazedlists.gui.TableFormat;
+import ca.odell.glazedlists.swing.DefaultEventSelectionModel;
+import ca.odell.glazedlists.swing.DefaultEventTableModel;
+import ca.odell.glazedlists.swing.GlazedListsSwing;
+import net.sf.jabref.Globals;
+import net.sf.jabref.gui.keyboard.KeyBinds;
+import net.sf.jabref.importer.OutputPrinter;
+import net.sf.jabref.logic.l10n.Localization;
 
 /**
  *
@@ -91,13 +107,14 @@ public class FetcherPreviewDialog extends JDialog implements OutputPrinter {
             }
         });
 
-        EventTableModel<TableEntry> tableModelGl = new EventTableModel<>(entries,
-                new EntryTableFormat());
+        DefaultEventTableModel<TableEntry> tableModelGl = (DefaultEventTableModel<TableEntry>) GlazedListsSwing
+                .eventTableModelWithThreadProxyList(entries, new EntryTableFormat());
         glTable = new EntryTable(tableModelGl);
         glTable.setRowHeight(tableRowHeight);
         glTable.getColumnModel().getColumn(0).setMaxWidth(45);
         glTable.setPreferredScrollableViewportSize(new Dimension(1100, 600));
-        EventSelectionModel<TableEntry> selectionModel = new EventSelectionModel<>(entries);
+        DefaultEventSelectionModel<TableEntry> selectionModel = (DefaultEventSelectionModel<TableEntry>) GlazedListsSwing
+                .eventSelectionModelWithThreadProxyList(entries);
         glTable.setSelectionModel(selectionModel);
         ButtonStackBuilder builder = new ButtonStackBuilder();
         builder.addButton(selectAll);

--- a/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
@@ -97,8 +97,9 @@ import ca.odell.glazedlists.event.ListEvent;
 import ca.odell.glazedlists.event.ListEventListener;
 import ca.odell.glazedlists.gui.AbstractTableComparatorChooser;
 import ca.odell.glazedlists.gui.TableFormat;
-import ca.odell.glazedlists.swing.EventSelectionModel;
-import ca.odell.glazedlists.swing.EventTableModel;
+import ca.odell.glazedlists.swing.DefaultEventSelectionModel;
+import ca.odell.glazedlists.swing.DefaultEventTableModel;
+import ca.odell.glazedlists.swing.GlazedListsSwing;
 import ca.odell.glazedlists.swing.TableComparatorChooser;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
@@ -154,7 +155,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
 
     private final TableComparatorChooser<BibtexEntry> comparatorChooser;
 
-    private final EventSelectionModel<BibtexEntry> selectionModel;
+    private final DefaultEventSelectionModel<BibtexEntry> selectionModel;
 
     private final String[] fields;
 
@@ -246,8 +247,8 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
         duplLabel.setToolTipText(Localization.lang("Possible duplicate of existing entry. Click to resolve."));
 
         sortedList = new SortedList<>(entries);
-        EventTableModel<BibtexEntry> tableModelGl = new EventTableModel<>(sortedList,
-                new EntryTableFormat());
+        DefaultEventTableModel<BibtexEntry> tableModelGl = (DefaultEventTableModel<BibtexEntry>) GlazedListsSwing
+                .eventTableModelWithThreadProxyList(sortedList, new EntryTableFormat());
         glTable = new EntryTable(tableModelGl);
         GeneralRenderer renderer = new GeneralRenderer(Color.white);
         glTable.setDefaultRenderer(JLabel.class, renderer);
@@ -256,7 +257,8 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
         DeleteListener deleteListener = new DeleteListener();
         glTable.getActionMap().put("delete", deleteListener);
 
-        selectionModel = new EventSelectionModel<>(sortedList);
+        selectionModel = (DefaultEventSelectionModel<BibtexEntry>) GlazedListsSwing
+                .eventSelectionModelWithThreadProxyList(sortedList);
         glTable.setSelectionModel(selectionModel);
         selectionModel.getSelected().addListEventListener(new EntrySelectionListener());
         comparatorChooser = TableComparatorChooser.install(glTable, sortedList,

--- a/src/main/java/net/sf/jabref/gui/MainTable.java
+++ b/src/main/java/net/sf/jabref/gui/MainTable.java
@@ -59,8 +59,9 @@ import ca.odell.glazedlists.EventList;
 import ca.odell.glazedlists.SortedList;
 import ca.odell.glazedlists.event.ListEventListener;
 import ca.odell.glazedlists.matchers.Matcher;
-import ca.odell.glazedlists.swing.EventSelectionModel;
-import ca.odell.glazedlists.swing.EventTableModel;
+import ca.odell.glazedlists.swing.DefaultEventSelectionModel;
+import ca.odell.glazedlists.swing.DefaultEventTableModel;
+import ca.odell.glazedlists.swing.GlazedListsSwing;
 import ca.odell.glazedlists.swing.TableComparatorChooser;
 
 /**
@@ -83,7 +84,7 @@ public class MainTable extends JTable {
     private final boolean tableColorCodes;
     private boolean isFloatSearchActive;
     private boolean isFloatGroupingActive;
-    private final EventSelectionModel<BibtexEntry> localSelectionModel;
+    private final DefaultEventSelectionModel<BibtexEntry> localSelectionModel;
     private final TableComparatorChooser<BibtexEntry> comparatorChooser;
     private final JScrollPane pane;
     private Comparator<BibtexEntry> searchComparator;
@@ -120,7 +121,7 @@ public class MainTable extends JTable {
         this.tableFormat = tableFormat;
         this.panel = panel;
         // This SortedList has a Comparator controlled by the TableComparatorChooser
-        // we are going to install, which responds to user sorting selctions:
+        // we are going to install, which responds to user sorting selections:
         sortedForTable = new SortedList<>(list, null);
         // This SortedList applies afterwards, and floats marked entries:
         sortedForMarking = new SortedList<>(sortedForTable, null);
@@ -134,11 +135,13 @@ public class MainTable extends JTable {
         searchComparator = null;
         groupComparator = null;
 
-        EventTableModel<BibtexEntry> tableModel = new EventTableModel<>(sortedForGrouping, tableFormat);
+        DefaultEventTableModel<BibtexEntry> tableModel = (DefaultEventTableModel<BibtexEntry>) GlazedListsSwing
+                .eventTableModelWithThreadProxyList(sortedForGrouping, tableFormat);
         setModel(tableModel);
 
         tableColorCodes = Globals.prefs.getBoolean(JabRefPreferences.TABLE_COLOR_CODES_ON);
-        localSelectionModel = new EventSelectionModel<>(sortedForGrouping);
+        localSelectionModel = (DefaultEventSelectionModel<BibtexEntry>) GlazedListsSwing
+                .eventSelectionModelWithThreadProxyList(sortedForGrouping);
         setSelectionModel(localSelectionModel);
         pane = new JScrollPane(this);
         pane.setBorder(BorderFactory.createEmptyBorder());

--- a/src/main/java/net/sf/jabref/gui/search/SearchResultsDialog.java
+++ b/src/main/java/net/sf/jabref/gui/search/SearchResultsDialog.java
@@ -70,8 +70,9 @@ import ca.odell.glazedlists.event.ListEvent;
 import ca.odell.glazedlists.event.ListEventListener;
 import ca.odell.glazedlists.gui.AbstractTableComparatorChooser;
 import ca.odell.glazedlists.gui.AdvancedTableFormat;
-import ca.odell.glazedlists.swing.EventSelectionModel;
-import ca.odell.glazedlists.swing.EventTableModel;
+import ca.odell.glazedlists.swing.DefaultEventSelectionModel;
+import ca.odell.glazedlists.swing.DefaultEventTableModel;
+import ca.odell.glazedlists.swing.GlazedListsSwing;
 import ca.odell.glazedlists.swing.TableComparatorChooser;
 import net.sf.jabref.model.entry.EntryUtil;
 
@@ -97,7 +98,7 @@ public class SearchResultsDialog {
 
     private final Rectangle toRect = new Rectangle(0, 0, 1, 1);
 
-    private EventTableModel<BibtexEntry> model;
+    private DefaultEventTableModel<BibtexEntry> model;
     private final EventList<BibtexEntry> entries = new BasicEventList<>();
     private SortedList<BibtexEntry> sortedEntries;
     private final HashMap<BibtexEntry, BasePanel> entryHome = new HashMap<>();
@@ -122,7 +123,8 @@ public class SearchResultsDialog {
                 activePreview == 0 ? Globals.prefs.get(JabRefPreferences.PREVIEW_0) : Globals.prefs.get(JabRefPreferences.PREVIEW_1));
 
         sortedEntries = new SortedList<>(entries, new EntryComparator(false, true, "author"));
-        model = new EventTableModel<>(sortedEntries, new EntryTableFormat());
+        model = (DefaultEventTableModel<BibtexEntry>) GlazedListsSwing.eventTableModelWithThreadProxyList(sortedEntries,
+                new EntryTableFormat());
         entryTable = new JTable(model);
         GeneralRenderer renderer = new GeneralRenderer(Color.white);
         entryTable.setDefaultRenderer(JLabel.class, renderer);
@@ -134,7 +136,8 @@ public class SearchResultsDialog {
         setupComparatorChooser(tableSorter);
         JScrollPane sp = new JScrollPane(entryTable);
 
-        final EventSelectionModel<BibtexEntry> selectionModel = new EventSelectionModel<>(sortedEntries);
+        final DefaultEventSelectionModel<BibtexEntry> selectionModel = (DefaultEventSelectionModel<BibtexEntry>) GlazedListsSwing
+                .eventSelectionModelWithThreadProxyList(sortedEntries);
         entryTable.setSelectionModel(selectionModel);
         selectionModel.getSelected().addListEventListener(new EntrySelectionListener());
         entryTable.addMouseListener(new TableClickListener());

--- a/src/main/java/net/sf/jabref/openoffice/CitationManager.java
+++ b/src/main/java/net/sf/jabref/openoffice/CitationManager.java
@@ -18,7 +18,7 @@ package net.sf.jabref.openoffice;
 import ca.odell.glazedlists.BasicEventList;
 import ca.odell.glazedlists.EventList;
 import ca.odell.glazedlists.gui.TableFormat;
-import ca.odell.glazedlists.swing.EventTableModel;
+import ca.odell.glazedlists.swing.DefaultEventTableModel;
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;
@@ -44,7 +44,7 @@ class CitationManager {
     private final JDialog diag;
     private final EventList<CitEntry> list;
     private final JTable table;
-    private final EventTableModel<CitEntry> tableModel;
+    private final DefaultEventTableModel<CitEntry> tableModel;
     private final JButton ok = new JButton(Localization.lang("Ok"));
     private final JButton cancel = new JButton(Localization.lang("Cancel"));
 
@@ -62,7 +62,7 @@ class CitationManager {
                     "<html>..." + ooBase.getCitationContext(nameAccess, name, 30, 30, true) + "...</html>",
                     ooBase.getCustomProperty(name)));
         }
-        tableModel = new EventTableModel<>(list, new CitEntryFormat());
+        tableModel = new DefaultEventTableModel<>(list, new CitEntryFormat());
         table = new JTable(tableModel);
         diag.add(new JScrollPane(table), BorderLayout.CENTER);
 

--- a/src/main/java/net/sf/jabref/openoffice/StyleSelectDialog.java
+++ b/src/main/java/net/sf/jabref/openoffice/StyleSelectDialog.java
@@ -75,8 +75,9 @@ import ca.odell.glazedlists.SortedList;
 import ca.odell.glazedlists.event.ListEvent;
 import ca.odell.glazedlists.event.ListEventListener;
 import ca.odell.glazedlists.gui.TableFormat;
-import ca.odell.glazedlists.swing.EventSelectionModel;
-import ca.odell.glazedlists.swing.EventTableModel;
+import ca.odell.glazedlists.swing.DefaultEventSelectionModel;
+import ca.odell.glazedlists.swing.DefaultEventTableModel;
+import ca.odell.glazedlists.swing.GlazedListsSwing;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import com.jgoodies.forms.builder.DefaultFormBuilder;
@@ -93,8 +94,8 @@ class StyleSelectDialog {
     private JDialog diag;
     private JTable table;
     private final JSplitPane contentPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT);
-    private EventTableModel<OOBibStyle> tableModel;
-    private EventSelectionModel<OOBibStyle> selectionModel;
+    private DefaultEventTableModel<OOBibStyle> tableModel;
+    private DefaultEventSelectionModel<OOBibStyle> selectionModel;
     private final JPopupMenu popup = new JPopupMenu();
     private final JMenuItem edit = new JMenuItem(Localization.lang("Edit"));
     private final JRadioButton useDefaultAuthoryear = new JRadioButton(Localization.lang("Default style (author-year citations)"));
@@ -208,13 +209,15 @@ class StyleSelectDialog {
         // Use the test entry from the Preview settings tab in Preferences:
         preview.setEntry(prevEntry);//PreviewPrefsTab.getTestEntry());
 
-        tableModel = new EventTableModel<>(sortedStyles, new StyleTableFormat());
+        tableModel = (DefaultEventTableModel<OOBibStyle>) GlazedListsSwing
+                .eventTableModelWithThreadProxyList(sortedStyles, new StyleTableFormat());
         table = new JTable(tableModel);
         TableColumnModel cm = table.getColumnModel();
         cm.getColumn(0).setPreferredWidth(100);
         cm.getColumn(1).setPreferredWidth(200);
         cm.getColumn(2).setPreferredWidth(80);
-        selectionModel = new EventSelectionModel<>(sortedStyles);
+        selectionModel = (DefaultEventSelectionModel<OOBibStyle>) GlazedListsSwing
+                .eventSelectionModelWithThreadProxyList(sortedStyles);
         table.setSelectionModel(selectionModel);
         table.getSelectionModel().setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         table.addMouseListener(new MouseAdapter() {


### PR DESCRIPTION
I replaced the deprecated calls to the glazedlists-API with the current versions. The major difference is that the new ones are not thread-safe and as such in most placed I've used the suggested factory method to obtained a wrapped list/model.

This seems to work, but may require a bit more testing/thinking. Especially to figure out if the wrapping may not be needed in all places and if there actually should be wrapping where there currently isn't.

A better option would be to explicitly lock and unlock the tables, but that require much more work.