### PR TITLE
Add purple background in Windows 8.1+ start menu

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -333,6 +333,7 @@ task releaseWindows(dependsOn: "launch4j") {
     doLast {
         copy {
             from("$projectDir/LICENSE")
+            from("$projectDir/buildres/JabRef.VisualElementsManifest.xml")		
             from("$projectDir/README.md")
             from("$buildDir/launch4j/JabRef.exe")
             into("$buildDir/nsis")

--- a/buildres/JabRef.VisualElementsManifest.xml
+++ b/buildres/JabRef.VisualElementsManifest.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Application xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <VisualElements ForegroundText="light" BackgroundColor="#5C6FAD" ShowNameOnSquare150x150Logo="on"></VisualElements>
+</Application>

--- a/buildres/JabRef.VisualElementsManifest.xml
+++ b/buildres/JabRef.VisualElementsManifest.xml
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Application xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <VisualElements ForegroundText="light" BackgroundColor="#5C6FAD" ShowNameOnSquare150x150Logo="on"></VisualElements>
+  <VisualElements ForegroundText="light" BackgroundColor="#4F5F8F" ShowNameOnSquare150x150Logo="on"></VisualElements>
 </Application>


### PR DESCRIPTION
Add a gray background in JabRef's start menu tile (for Windows 8.1 and 10) by implementing the [VisualElementsManifest](https://msdn.microsoft.com/en-us/library/windows/apps/dn393983.aspx).
![screen](https://cloud.githubusercontent.com/assets/5037600/11211371/3dcb4676-8d2f-11e5-895c-6ac863676c6a.png)

Note: I couldn't test the install procedure since `gradlew releaseWindows` gives an error:
```
[ERROR] [org.gradle.BuildExceptionReporter] > A problem occurred starting process 'command 'launch4j''
```