### PR TITLE
Add test for bibtex key generation and refactoring

### DIFF
--- a/src/main/java/net/sf/jabref/bibtex/BibtexEntryWriter.java
+++ b/src/main/java/net/sf/jabref/bibtex/BibtexEntryWriter.java
@@ -296,7 +296,7 @@ public class BibtexEntryWriter {
     }
 
     private void writeKeyField(BibtexEntry entry, Writer out) throws IOException {
-        String keyField = StringUtil.shaveString(entry.getField(BibtexEntry.KEY_FIELD));
+        String keyField = StringUtil.shaveString(entry.getCiteKey());
         out.write((keyField == null ? "" : keyField) + ',' + Globals.NEWLINE);
     }
 

--- a/src/main/java/net/sf/jabref/external/ExternalFilePanel.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFilePanel.java
@@ -167,7 +167,7 @@ public class ExternalFilePanel extends JPanel {
     }
 
     private Object getKey() {
-        return getEntry().getField(BibtexEntry.KEY_FIELD);
+        return getEntry().getCiteKey();
     }
 
     private void output(String s) {

--- a/src/main/java/net/sf/jabref/external/push/PushToApplicationAction.java
+++ b/src/main/java/net/sf/jabref/external/push/PushToApplicationAction.java
@@ -98,7 +98,7 @@ class PushToApplicationAction extends AbstractAction implements Runnable {
         String citeKey;
         boolean first = true;
         for (BibtexEntry bes : bibentries) {
-            citeKey = bes.getField(BibtexEntry.KEY_FIELD);
+            citeKey = bes.getCiteKey();
             // if the key is empty we give a warning and ignore this entry
             if ((citeKey == null) || citeKey.equals("")) {
                 continue;

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -645,7 +645,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 // This is a partial clone of net.sf.jabref.gui.entryeditor.EntryEditor.GenerateKeyAction.actionPerformed(ActionEvent)
                 for (Iterator<BibtexEntry> i = entries.iterator(); i.hasNext();) {
                     bes = i.next();
-                    if (bes.getField(BibtexEntry.KEY_FIELD) != null) {
+                    if (bes.getCiteKey() != null) {
                         if (Globals.prefs.getBoolean(JabRefPreferences.AVOID_OVERWRITING_KEY)) {
                             // Remove the entry, because its key is already set:
                             i.remove();
@@ -686,7 +686,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 // Finally, set the new keys:
                 for (BibtexEntry entry : entries) {
                     bes = entry;
-                    bes = LabelPatternUtil.makeLabel(metaData, database, bes);
+                    LabelPatternUtil.makeLabel(metaData, database, bes);
                     ce.addEdit(new UndoableKeyChange(database, bes.getId(), (String) oldvals.get(bes),
                             bes.getField(BibtexEntry.KEY_FIELD)));
                 }
@@ -760,8 +760,8 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 List<String> keys = new ArrayList<>(bes.length);
                 // Collect all non-null keys.
                 for (BibtexEntry be : bes) {
-                    if (be.getField(BibtexEntry.KEY_FIELD) != null) {
-                        keys.add(be.getField(BibtexEntry.KEY_FIELD));
+                    if (be.getCiteKey() != null) {
+                        keys.add(be.getCiteKey());
                     }
                 }
                 if (keys.isEmpty()) {
@@ -802,8 +802,8 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     List<String> keys = new ArrayList<>(bes.length);
                     // Collect all non-null keys.
                     for (BibtexEntry be : bes) {
-                        if (be.getField(BibtexEntry.KEY_FIELD) != null) {
-                            keys.add(be.getField(BibtexEntry.KEY_FIELD));
+                        if (be.getCiteKey() != null) {
+                            keys.add(be.getCiteKey());
                         }
                     }
                     if (keys.isEmpty()) {
@@ -858,7 +858,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     int copied = 0;
                     // Collect all non-null keys.
                     for (BibtexEntry be : bes) {
-                        if (be.getField(BibtexEntry.KEY_FIELD) != null) {
+                        if (be.getCiteKey() != null) {
                             copied++;
                             sb.append(layout.doLayout(be, database));
                         }
@@ -2435,7 +2435,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 String oldKey = bes.getCiteKey();
                 if ((oldKey == null) || oldKey.isEmpty()) {
                     LabelPatternUtil.makeLabel(metaData, database, bes);
-                    ce.addEdit(new UndoableKeyChange(database, bes.getId(), null, bes.getField(BibtexEntry.KEY_FIELD)));
+                    ce.addEdit(new UndoableKeyChange(database, bes.getId(), null, bes.getCiteKey()));
                     any = true;
                 }
             }
@@ -2664,7 +2664,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         String citeKey;//, message = "";
         boolean first = true;
         for (BibtexEntry bes : mainTable.getSelected()) {
-            citeKey = bes.getField(BibtexEntry.KEY_FIELD);
+            citeKey = bes.getCiteKey();
             // if the key is empty we give a warning and ignore this entry
             if ((citeKey == null) || citeKey.isEmpty()) {
                 continue;

--- a/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
@@ -754,7 +754,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
                     // If this entry should be added to any groups, do it now:
                     Set<GroupTreeNode> groups = groupAdditions.get(entry);
                     if (!groupingCanceled && (groups != null)) {
-                        if (entry.getField(BibtexEntry.KEY_FIELD) == null) {
+                        if (entry.getCiteKey() == null) {
                             // The entry has no key, so it can't be added to the
                             // group.
                             // The best course of action is probably to ask the
@@ -773,7 +773,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
                         }
 
                         // If the key existed, or exists now, go ahead:
-                        if (entry.getField(BibtexEntry.KEY_FIELD) != null) {
+                        if (entry.getCiteKey() != null) {
                             for (GroupTreeNode node : groups) {
                                 if (node.getGroup().supportsAdd()) {
                                     // Add the entry:

--- a/src/main/java/net/sf/jabref/gui/UrlDragDrop.java
+++ b/src/main/java/net/sf/jabref/gui/UrlDragDrop.java
@@ -46,7 +46,6 @@ import net.sf.jabref.gui.entryeditor.EntryEditor;
 import net.sf.jabref.gui.fieldeditors.FieldEditor;
 import net.sf.jabref.gui.net.MonitoredURLDownload;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.model.entry.BibtexEntry;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -174,7 +173,7 @@ public class UrlDragDrop implements DropTargetListener {
                     //auto filename:
                     File file = new File(new File(Globals.prefs
                             .get("pdfDirectory")), editor.getEntry()
-                            .getField(BibtexEntry.KEY_FIELD)
+.getCiteKey()
                             + ".pdf");
                     frame.output(Localization.lang("Downloading..."));
                     MonitoredURLDownload.buildMonitoredDownload(editor, url).downloadToFile(file);

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -1468,7 +1468,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
 
             // this updates the table automatically, on close, but not
             // within the tab
-            Object oldValue = entry.getField(BibtexEntry.KEY_FIELD);
+            Object oldValue = entry.getCiteKey();
 
             if (oldValue != null) {
                 if (Globals.prefs.getBoolean(JabRefPreferences.AVOID_OVERWRITING_KEY)) {
@@ -1493,10 +1493,10 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
 
             // Store undo information:
             panel.undoManager.addEdit(new UndoableKeyChange(panel.database, entry.getId(),
-                    (String) oldValue, entry.getField(BibtexEntry.KEY_FIELD)));
+ (String) oldValue, entry.getCiteKey()));
 
             // here we update the field
-            String bibtexKeyData = entry.getField(BibtexEntry.KEY_FIELD);
+            String bibtexKeyData = entry.getCiteKey();
 
             // set the field named for "bibtexkey"
             setField(BibtexEntry.KEY_FIELD, bibtexKeyData);

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditorTab.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditorTab.java
@@ -199,7 +199,7 @@ class EntryEditorTab {
         // Add the edit field for Bibtex-key.
         if (addKeyField) {
             final TextField textField = new TextField(BibtexEntry.KEY_FIELD, parent
-                    .getEntry().getField(BibtexEntry.KEY_FIELD), true);
+.getEntry().getCiteKey(), true);
             setupJTextComponent(textField, null);
 
             editors.put("bibtexkey", textField);

--- a/src/main/java/net/sf/jabref/gui/labelPattern/SearchFixDuplicateLabels.java
+++ b/src/main/java/net/sf/jabref/gui/labelPattern/SearchFixDuplicateLabels.java
@@ -108,9 +108,9 @@ public class SearchFixDuplicateLabels extends AbstractWorker {
             NamedCompound ce = new NamedCompound("resolve duplicate keys");
             for (BibtexEntry entry : toGenerateFor) {
                 String oldKey = entry.getCiteKey();
-                entry = LabelPatternUtil.makeLabel(panel.metaData(), panel.database(), entry);
+                LabelPatternUtil.makeLabel(panel.metaData(), panel.database(), entry);
                 ce.addEdit(new UndoableKeyChange(panel.database(), entry.getId(), oldKey,
-                        entry.getField(BibtexEntry.KEY_FIELD)));
+ entry.getCiteKey()));
             }
             ce.end();
             panel.undoManager.addEdit(ce);

--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
@@ -894,7 +894,8 @@ public class BibtexParser {
                     be.setType(type);
                 } else {
                     _pr.addWarning(Localization.lang("unknown entry type") + ": "
-                                    + be.getType().getName() + ":" + be.getField(BibtexEntry.KEY_FIELD)
+ + be.getType().getName() + ":"
+                            + be.getCiteKey()
                                     + " . " + Localization.lang("Type set to 'other'")
                                     + ".");
                     be.setType(BibtexEntryTypes.OTHER);

--- a/src/main/java/net/sf/jabref/importer/fileformat/FreeCiteImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/FreeCiteImporter.java
@@ -207,7 +207,7 @@ public class FreeCiteImporter extends ImportFormat {
                     e.setType(type);
 
                     // autogenerate label (BibTeX key)
-                    e = LabelPatternUtil.makeLabel(JabRef.jrf.basePanel().metaData(), JabRef.jrf.basePanel().database(), e);
+                    LabelPatternUtil.makeLabel(JabRef.jrf.basePanel().metaData(), JabRef.jrf.basePanel().database(), e);
 
                     res.add(e);
                 }

--- a/src/main/java/net/sf/jabref/logic/labelPattern/LabelPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/labelPattern/LabelPatternUtil.java
@@ -408,8 +408,8 @@ public class LabelPatternUtil {
     }
 
     /**
-     * Generates a BibTeX label according to the pattern for a given entry type, and
-     * returns the <code>Bibtexentry</code> with the unique label.
+     * Generates a BibTeX label according to the pattern for a given entry type, and saves the unique label in the
+     * <code>Bibtexentry</code>.
      *
      * The given database is used to avoid duplicate keys.
      *
@@ -417,7 +417,7 @@ public class LabelPatternUtil {
      * @param entry a <code>BibtexEntry</code>
      * @return modified Bibtexentry
      */
-    public static BibtexEntry makeLabel(MetaData metaData, BibtexDatabase dBase, BibtexEntry entry) {
+    public static void makeLabel(MetaData metaData, BibtexDatabase dBase, BibtexEntry entry) {
         LabelPatternUtil.database = dBase;
         ArrayList<String> typeList;
         String key;
@@ -533,8 +533,6 @@ public class LabelPatternUtil {
                 }
             }
         }
-
-        return entry;
     }
 
     /**

--- a/src/main/java/net/sf/jabref/model/entry/BibtexEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibtexEntry.java
@@ -270,10 +270,10 @@ public class BibtexEntry {
         return null;
     }
 
+    /**
+     * Returns the bibtex key, or null if it is not set.
+     */
     public String getCiteKey() {
-        if(!fields.containsKey(KEY_FIELD)) {
-            return null;
-        }
         return fields.get(KEY_FIELD);
     }
 
@@ -403,7 +403,7 @@ public class BibtexEntry {
 
     @Override
     public String toString() {
-        return getType().getName() + ':' + getField(KEY_FIELD);
+        return getType().getName() + ':' + getCiteKey();
     }
 
     public boolean isSearchHit() {

--- a/src/main/java/net/sf/jabref/model/entry/CustomEntryType.java
+++ b/src/main/java/net/sf/jabref/model/entry/CustomEntryType.java
@@ -137,7 +137,7 @@ public class CustomEntryType extends BibtexEntryType {
     @Override
     public boolean hasAllRequiredFields(BibtexEntry entry, BibtexDatabase database) {
         // First check if the bibtex key is set:
-        if (entry.getField(BibtexEntry.KEY_FIELD) == null) {
+        if (entry.getCiteKey() == null) {
             return false;
         }
         // Then check other fields:

--- a/src/test/java/net/sf/jabref/logic/labelPattern/LabelPatternUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/labelPattern/LabelPatternUtilTest.java
@@ -61,6 +61,12 @@ public class LabelPatternUtilTest {
         Assert.assertEquals("HerlandHaugeHelgeland", Util.checkLegalKey(LabelPatternUtil.makeLabel(entry, "authors3")));
     }
 
+    @Test
+    public void testSpecialLatexCharacterInAuthorName() {
+        BibtexEntry entry = BibtexParser.singleFromString("@ARTICLE{kohn, author={Simon Popovi\\v{c}ov\\'{a}}}");
+        Assert.assertEquals("Popovicova", Util.checkLegalKey(LabelPatternUtil.makeLabel(entry, "auth")));
+    }
+
     /**
      * Test for https://sourceforge.net/forum/message.php?msg_id=4498555 Test the Labelmaker and all kind of accents Á á
      * Ć ć É é Í í Ĺ ĺ Ń ń Ó ó Ŕ ŕ Ś ś Ú ú Ý ý Ź ź


### PR DESCRIPTION
Verify that special latex characters in author names are handled correctly in bibtex key generation (from [SF bug 1186](http://sourceforge.net/p/jabref/bugs/1186/)).

Small code cleanup (`makeLabel` now returns voids since it updates the entry instead of returning a updated one)