### PR TITLE
Fix bug: encoding was not read from comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
  - Show replaced journal abbreviations on console
 
 ### Fixed
+ - Fixed the bug that the file encoding was not correctly determined from the first (or second) line
  - Fixed #325: Deactivating AutoCompletion crashes EntryEditor
  - Fixed bug when having added and then removed a personal journal list, an exception is always shown on startup
  - Fixed a bug in the IEEEXploreFetcher

--- a/src/main/java/net/sf/jabref/importer/ImportFormatReader.java
+++ b/src/main/java/net/sf/jabref/importer/ImportFormatReader.java
@@ -333,20 +333,17 @@ public class ImportFormatReader {
         }
     }
 
-    public static Reader getUTF8Reader(File f) throws IOException {
+    public static InputStreamReader getUTF8Reader(File f) throws IOException {
         return getReader(f, "UTF-8");
     }
 
-    public static Reader getUTF16Reader(File f) throws IOException {
+    public static InputStreamReader getUTF16Reader(File f) throws IOException {
         return getReader(f, "UTF-16");
     }
 
-    public static Reader getReader(File f, String encoding)
+    public static InputStreamReader getReader(File f, String encoding)
             throws IOException {
-        InputStreamReader reader;
-        reader = new InputStreamReader(new FileInputStream(f), encoding);
-
-        return reader;
+        return new InputStreamReader(new FileInputStream(f), encoding);
     }
 
     public static Reader getReaderDefaultEncoding(InputStream in)

--- a/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
+++ b/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
@@ -11,7 +11,8 @@ import java.io.File;
 import java.io.IOException;
 
 public class OpenDatabaseActionTest {
-    private final String defaultEncoding = "UTF-8";
+
+    private final String defaultEncoding = "CP1252";
 
     @BeforeClass
     public static void setUpGlobalsPrefs() {
@@ -52,6 +53,9 @@ public class OpenDatabaseActionTest {
         // Version
         Assert.assertEquals(0, result.getJabrefMajorVersion());
         Assert.assertEquals(0, result.getJabrefMinorVersion());
+
+        // Encoding
+        Assert.assertEquals("UTF-8", result.getEncoding());
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
+++ b/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
@@ -12,7 +12,13 @@ import java.io.IOException;
 
 public class OpenDatabaseActionTest {
 
-    private final String defaultEncoding = "CP1252";
+    private final String defaultEncoding = "UTF8";
+    private final File bibNoHeader = new File(OpenDatabaseActionTest.class.getResource("headerless.bib").getFile());
+    private final File bibWrongHeader = new File(
+            OpenDatabaseActionTest.class.getResource("wrong-header.bib").getFile());
+    private final File bibHeader = new File(OpenDatabaseActionTest.class.getResource("encoding-header.bib").getFile());
+    private final File bibHeaderAndSignature = new File(
+            OpenDatabaseActionTest.class.getResource("jabref-header.bib").getFile());
 
     @BeforeClass
     public static void setUpGlobalsPrefs() {
@@ -21,8 +27,32 @@ public class OpenDatabaseActionTest {
     }
 
     @Test
-    public void headerless() throws IOException {
-        ParserResult result = OpenDatabaseAction.loadDatabase(new File(OpenDatabaseActionTest.class.getResource("headerless.bib").getFile()), defaultEncoding);
+    public void useFallbackEncodingIfNoHeader() throws IOException {
+        ParserResult result = OpenDatabaseAction.loadDatabase(bibNoHeader, defaultEncoding);
+        Assert.assertEquals(defaultEncoding, result.getEncoding());
+    }
+
+    @Test
+    public void useFallbackEncodingIfUnknownHeader() throws IOException {
+        ParserResult result = OpenDatabaseAction.loadDatabase(bibWrongHeader, defaultEncoding);
+        Assert.assertEquals(defaultEncoding, result.getEncoding());
+    }
+
+    @Test
+    public void useSpecifiedEncoding() throws IOException {
+        ParserResult result = OpenDatabaseAction.loadDatabase(bibHeader, "noEncoding");
+        Assert.assertEquals("UTF8", result.getEncoding());
+    }
+
+    @Test
+    public void useSpecifiedEncodingWithSignature() throws IOException {
+        ParserResult result = OpenDatabaseAction.loadDatabase(bibHeaderAndSignature, "noEncoding");
+        Assert.assertEquals("UTF8", result.getEncoding());
+    }
+
+    @Test
+    public void entriesAreParsedNoHeader() throws IOException {
+        ParserResult result = OpenDatabaseAction.loadDatabase(bibNoHeader, defaultEncoding);
         BibtexDatabase db = result.getDatabase();
 
         // Entry
@@ -31,42 +61,59 @@ public class OpenDatabaseActionTest {
     }
 
     @Test
-    public void jabrefHeader() throws IOException {
-        ParserResult result = OpenDatabaseAction.loadDatabase(new File(OpenDatabaseActionTest.class.getResource("jabref-header.bib").getFile()), defaultEncoding);
+    public void entriesAreParsedHeader() throws IOException {
+        ParserResult result = OpenDatabaseAction.loadDatabase(bibHeader, defaultEncoding);
         BibtexDatabase db = result.getDatabase();
 
         // Entry
         Assert.assertEquals(1, db.getEntryCount());
         Assert.assertEquals("2014", db.getEntryByKey("1").getField("year"));
-        // Version
-        Assert.assertEquals(2, result.getJabrefMajorVersion());
-        Assert.assertEquals(9, result.getJabrefMinorVersion());
-        // Encoding
-        Assert.assertEquals("UTF-8", result.getEncoding());
     }
 
     @Test
-    public void testAbsentVersionHeader() throws IOException {
-        // newer JabRef versions do not put a header
-        ParserResult result = OpenDatabaseAction.loadDatabase(new File(OpenDatabaseActionTest.class.getResource("encoding-header.bib").getFile()), defaultEncoding);
+    public void entriesAreParsedHeaderAndSignature() throws IOException {
+        ParserResult result = OpenDatabaseAction.loadDatabase(bibHeaderAndSignature, defaultEncoding);
+        BibtexDatabase db = result.getDatabase();
+
+        // Entry
+        Assert.assertEquals(1, db.getEntryCount());
+        Assert.assertEquals("2014", db.getEntryByKey("1").getField("year"));
+    }
+
+    @Test
+    public void noVersionForNoHeader() throws IOException {
+        ParserResult result = OpenDatabaseAction.loadDatabase(bibNoHeader, defaultEncoding);
 
         // Version
         Assert.assertEquals(0, result.getJabrefMajorVersion());
         Assert.assertEquals(0, result.getJabrefMinorVersion());
-
-        // Encoding
-        Assert.assertEquals("UTF-8", result.getEncoding());
     }
 
     @Test
-    public void encodingHeader() throws IOException {
-        ParserResult result = OpenDatabaseAction.loadDatabase(new File(OpenDatabaseActionTest.class.getResource("encoding-header.bib").getFile()), defaultEncoding);
-        BibtexDatabase db = result.getDatabase();
+    public void noVersionForWrongHeader() throws IOException {
+        ParserResult result = OpenDatabaseAction.loadDatabase(bibWrongHeader, defaultEncoding);
 
-        // Entry
-        Assert.assertEquals(1, db.getEntryCount());
-        Assert.assertEquals("2014", db.getEntryByKey("1").getField("year"));
-        // Encoding
-        Assert.assertEquals("UTF-8", result.getEncoding());
+        // Version
+        Assert.assertEquals(0, result.getJabrefMajorVersion());
+        Assert.assertEquals(0, result.getJabrefMinorVersion());
+    }
+
+    @Test
+    public void noVersionForHeaderWithoutSignature() throws IOException {
+        // newer JabRef versions do not put a header
+        ParserResult result = OpenDatabaseAction.loadDatabase(bibHeader, defaultEncoding);
+
+        // Version
+        Assert.assertEquals(0, result.getJabrefMajorVersion());
+        Assert.assertEquals(0, result.getJabrefMinorVersion());
+    }
+
+    @Test
+    public void versionFromSignature() throws IOException {
+        ParserResult result = OpenDatabaseAction.loadDatabase(bibHeaderAndSignature, defaultEncoding);
+
+        // Version
+        Assert.assertEquals(2, result.getJabrefMajorVersion());
+        Assert.assertEquals(9, result.getJabrefMinorVersion());
     }
 }

--- a/src/test/resources/net/sf/jabref/importer/wrong-header.bib
+++ b/src/test/resources/net/sf/jabref/importer/wrong-header.bib
@@ -1,0 +1,7 @@
+% Something which is not recognized by JabRef
+@INPROCEEDINGS{1,
+  author = {Stefan Kolb and Guido Wirtz},
+  title = {{Towards Application Portability in Platform as a Service}},
+  booktitle = {Proc. 8th Symp. Service-Oriented System Engineering},
+  year = {2014}
+}


### PR DESCRIPTION
The encoding was not correctly inferred from the first/second line of the file, i.e. from
````
% Encoding: encoding
```
This bug is covered in the tests by changing the default encoding to something different from the encoding in the test files. Fixed this bug by completely rewriting `checkForEncoding`.