### PR TITLE
Add compatibility check for UTF8

### DIFF
--- a/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
@@ -107,20 +107,20 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
 
     class OpenItSwingHelper implements Runnable {
 
-        final BasePanel bp;
+        final BasePanel basePanel;
         final boolean raisePanel;
         final File file;
 
 
-        OpenItSwingHelper(BasePanel bp, File file, boolean raisePanel) {
-            this.bp = bp;
+        OpenItSwingHelper(BasePanel basePanel, File file, boolean raisePanel) {
+            this.basePanel = basePanel;
             this.raisePanel = raisePanel;
             this.file = file;
         }
 
         @Override
         public void run() {
-            frame.addTab(bp, file, raisePanel);
+            frame.addTab(basePanel, file, raisePanel);
 
         }
     }
@@ -156,17 +156,17 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
         int removed = 0;
 
         // Check if any of the files are already open:
-        for (Iterator<File> iterator = filesToOpen.iterator(); iterator.hasNext();) {
+        for (Iterator<File> iterator = filesToOpen.iterator(); iterator.hasNext(); ) {
             File file = iterator.next();
             for (int i = 0; i < frame.getTabbedPane().getTabCount(); i++) {
-                BasePanel bp = frame.getBasePanelAt(i);
-                if ((bp.getDatabaseFile() != null) && bp.getDatabaseFile().equals(file)) {
+                BasePanel basePanel = frame.getBasePanelAt(i);
+                if ((basePanel.getDatabaseFile() != null) && basePanel.getDatabaseFile().equals(file)) {
                     iterator.remove();
                     removed++;
                     // See if we removed the final one. If so, we must perhaps
                     // raise the BasePanel in question:
                     if (removed == initialCount) {
-                        toRaise = bp;
+                        toRaise = basePanel;
                     }
                     // no more bps to check, we found a matching one
                     break;
@@ -221,9 +221,9 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
                 int answer = JOptionPane.showConfirmDialog(null,
                         "<html>" + Localization
                                 .lang("An autosave file was found for this database. This could indicate ")
-                        + Localization.lang("that JabRef didn't shut down cleanly last time the file was used.")
-                        + "<br>" + Localization.lang("Do you want to recover the database from the autosave file?")
-                        + "</html>", Localization.lang("Recover from autosave"), JOptionPane.YES_NO_OPTION);
+                                + Localization.lang("that JabRef didn't shut down cleanly last time the file was used.")
+                                + "<br>" + Localization.lang("Do you want to recover the database from the autosave file?")
+                                + "</html>", Localization.lang("Recover from autosave"), JOptionPane.YES_NO_OPTION);
                 if (answer == JOptionPane.YES_OPTION) {
                     fileToLoad = AutoSaveManager.getAutoSaveFile(file);
                     tryingAutosave = true;
@@ -238,9 +238,9 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
                 String encoding = Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING);
 
                 if (FileBasedLock.hasLockFile(file)) {
-                    long modTime = FileBasedLock.getLockFileTimeStamp(file);
-                    if ((modTime != -1)
-                            && ((System.currentTimeMillis() - modTime) > SaveSession.LOCKFILE_CRITICAL_AGE)) {
+                    long modificationTIme = FileBasedLock.getLockFileTimeStamp(file);
+                    if ((modificationTIme != -1)
+                            && ((System.currentTimeMillis() - modificationTIme) > SaveSession.LOCKFILE_CRITICAL_AGE)) {
                         // The lock file is fairly old, so we can offer to "steal" the file:
                         int answer = JOptionPane.showConfirmDialog(null,
                                 "<html>" + Localization.lang("Error opening file") + " '" + fileName + "'. "
@@ -261,23 +261,22 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
                     }
 
                 }
-                ParserResult pr;
+                ParserResult result;
                 String errorMessage = null;
                 try {
-                    pr = OpenDatabaseAction.loadDatabase(fileToLoad, encoding);
-                } catch (Exception ex) {
-                    //ex.printStackTrace();
-                    errorMessage = ex.getMessage();
-                    pr = null;
+                    result = OpenDatabaseAction.loadDatabase(fileToLoad, encoding);
+                } catch (IOException ex) {
+                    LOGGER.error("Error loading database " + fileToLoad, ex);
+                    result = null;
                 }
-                if ((pr == null) || (pr == ParserResult.INVALID_FORMAT)) {
+                if ((result == null) || (result == ParserResult.INVALID_FORMAT)) {
                     JOptionPane.showMessageDialog(null, Localization.lang("Error opening file") + " '" + fileName + "'",
                             Localization.lang("Error"), JOptionPane.ERROR_MESSAGE);
 
                     String message = "<html>" + errorMessage + "<p>"
                             + (tryingAutosave ? Localization.lang(
-                                    "Error opening autosave of '%0'. Trying to load '%0' instead.",
-                                    file.getName()) : ""/*Globals.lang("Error opening file '%0'.", file.getName())*/)
+                            "Error opening autosave of '%0'. Trying to load '%0' instead.",
+                            file.getName()) : ""/*Globals.lang("Error opening file '%0'.", file.getName())*/)
                             + "</html>";
                     JOptionPane.showMessageDialog(null, message, Localization.lang("Error opening file"),
                             JOptionPane.ERROR_MESSAGE);
@@ -293,7 +292,7 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
                     done = true;
                 }
 
-                final BasePanel panel = addNewDatabase(pr, file, raisePanel);
+                final BasePanel panel = addNewDatabase(result, file, raisePanel);
                 if (tryingAutosave) {
                     panel.markNonUndoableBaseChanged();
                 }
@@ -303,12 +302,12 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
                 // if we found new entry types that can be imported, or checking
                 // if the database contents should be modified due to new features
                 // in this version of JabRef:
-                final ParserResult prf = pr;
+                final ParserResult finalReferenceToResult = result;
                 SwingUtilities.invokeLater(new Runnable() {
 
                     @Override
                     public void run() {
-                        OpenDatabaseAction.performPostOpenActions(panel, prf, true);
+                        OpenDatabaseAction.performPostOpenActions(panel, finalReferenceToResult, true);
                     }
                 });
             }
@@ -319,59 +318,59 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
     /**
      * Go through the list of post open actions, and perform those that need to be performed.
      *
-     * @param panel The BasePanel where the database is shown.
-     * @param pr The result of the bib file parse operation.
+     * @param panel  The BasePanel where the database is shown.
+     * @param result The result of the bib file parse operation.
      */
-    public static void performPostOpenActions(BasePanel panel, ParserResult pr, boolean mustRaisePanel) {
+    public static void performPostOpenActions(BasePanel panel, ParserResult result, boolean mustRaisePanel) {
         for (PostOpenAction action : OpenDatabaseAction.postOpenActions) {
-            if (action.isActionNecessary(pr)) {
+            if (action.isActionNecessary(result)) {
                 if (mustRaisePanel) {
                     panel.frame().getTabbedPane().setSelectedComponent(panel);
                 }
-                action.performAction(panel, pr);
+                action.performAction(panel, result);
             }
         }
     }
 
-    public BasePanel addNewDatabase(ParserResult pr, final File file, boolean raisePanel) {
+    public BasePanel addNewDatabase(ParserResult result, final File file, boolean raisePanel) {
 
         String fileName = file.getPath();
-        BibtexDatabase db = pr.getDatabase();
-        MetaData meta = pr.getMetaData();
+        BibtexDatabase database = result.getDatabase();
+        MetaData meta = result.getMetaData();
 
-        if (pr.hasWarnings()) {
-            final String[] wrns = pr.warnings();
+        if (result.hasWarnings()) {
+            final String[] warnings = result.warnings();
             JabRefExecutorService.INSTANCE.execute(new Runnable() {
 
                 @Override
                 public void run() {
-                    StringBuilder wrn = new StringBuilder();
-                    for (int i = 0; i < wrns.length; i++) {
-                        wrn.append(i + 1).append(". ").append(wrns[i]).append("\n");
+                    StringBuilder warningStrin = new StringBuilder();
+                    for (int i = 0; i < warnings.length; i++) {
+                        warningStrin.append(i + 1).append(". ").append(warnings[i]).append("\n");
                     }
 
-                    if (wrn.length() > 0) {
-                        wrn.deleteCharAt(wrn.length() - 1);
+                    if (warningStrin.length() > 0) {
+                        warningStrin.deleteCharAt(warningStrin.length() - 1);
                     }
                     // Note to self or to someone else: The following line causes an
                     // ArrayIndexOutOfBoundsException in situations with a large number of
                     // warnings; approx. 5000 for the database I opened when I observed the problem
                     // (duplicate key warnings). I don't think this is a big problem for normal situations,
                     // and it may possibly be a bug in the Swing code.
-                    JOptionPane.showMessageDialog(frame, wrn.toString(),
+                    JOptionPane.showMessageDialog(frame, warningStrin.toString(),
                             Localization.lang("Warnings") + " (" + file.getName() + ")", JOptionPane.WARNING_MESSAGE);
                 }
             });
         }
-        BasePanel bp = new BasePanel(frame, db, file, meta, pr.getEncoding());
+        BasePanel basePanel = new BasePanel(frame, database, file, meta, result.getEncoding());
 
         // file is set to null inside the EventDispatcherThread
-        SwingUtilities.invokeLater(new OpenItSwingHelper(bp, file, raisePanel));
+        SwingUtilities.invokeLater(new OpenItSwingHelper(basePanel, file, raisePanel));
 
         frame.output(Localization.lang("Opened database") + " '" + fileName + "' " + Localization.lang("with") + " "
-                + db.getEntryCount() + " " + Localization.lang("entries") + ".");
+                + database.getEntryCount() + " " + Localization.lang("entries") + ".");
 
-        return bp;
+        return basePanel;
     }
 
     /**
@@ -397,25 +396,25 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
 
         // Open and parse file
         try (InputStreamReader reader = openFile(fileToOpen, suppliedEncoding, fallbackEncoding)) {
-            BibtexParser bp = new BibtexParser(reader);
+            BibtexParser parser = new BibtexParser(reader);
 
-            ParserResult pr = bp.parse();
-            pr.setEncoding(Charset.forName(reader.getEncoding()).name());
-            pr.setFile(fileToOpen);
+            ParserResult result = parser.parse();
+            result.setEncoding(Charset.forName(reader.getEncoding()).name());
+            result.setFile(fileToOpen);
 
             if (SpecialFieldsUtils.keywordSyncEnabled()) {
-                for (BibtexEntry entry : pr.getDatabase().getEntries()) {
+                for (BibtexEntry entry : result.getDatabase().getEntries()) {
                     SpecialFieldsUtils.syncSpecialFieldsFromKeywords(entry, null);
                 }
                 LOGGER.info("Synchronized special fields based on keywords");
             }
 
-            if (!pr.getMetaData().isGroupTreeValid()) {
-                pr.addWarning(Localization.lang(
+            if (!result.getMetaData().isGroupTreeValid()) {
+                result.addWarning(Localization.lang(
                         "Group tree could not be parsed. If you save the BibTeX database, all groups will be lost."));
             }
 
-            return pr;
+            return result;
         }
     }
 
@@ -445,9 +444,9 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
      */
     private static Optional<String> getSuppliedEncoding(Reader reader) {
         try {
-            BufferedReader br = new BufferedReader(reader);
+            BufferedReader bufferedReader = new BufferedReader(reader);
             String line;
-            while ((line = br.readLine()) != null) {
+            while ((line = bufferedReader.readLine()) != null) {
                 line = line.trim();
 
                 // Line does not start with %, so there are no comment lines for us and we can stop parsing

--- a/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
@@ -116,7 +116,7 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
         int removed = 0;
 
         // Check if any of the files are already open:
-        for (Iterator<File> iterator = filesToOpen.iterator(); iterator.hasNext();) {
+        for (Iterator<File> iterator = filesToOpen.iterator(); iterator.hasNext(); ) {
             File file = iterator.next();
             for (int i = 0; i < frame.getTabbedPane().getTabCount(); i++) {
                 BasePanel bp = frame.getBasePanelAt(i);
@@ -197,9 +197,9 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
                 int answer = JOptionPane.showConfirmDialog(null,
                         "<html>" + Localization
                                 .lang("An autosave file was found for this database. This could indicate ")
-                        + Localization.lang("that JabRef didn't shut down cleanly last time the file was used.")
-                        + "<br>" + Localization.lang("Do you want to recover the database from the autosave file?")
-                        + "</html>", Localization.lang("Recover from autosave"), JOptionPane.YES_NO_OPTION);
+                                + Localization.lang("that JabRef didn't shut down cleanly last time the file was used.")
+                                + "<br>" + Localization.lang("Do you want to recover the database from the autosave file?")
+                                + "</html>", Localization.lang("Recover from autosave"), JOptionPane.YES_NO_OPTION);
                 if (answer == JOptionPane.YES_OPTION) {
                     fileToLoad = AutoSaveManager.getAutoSaveFile(file);
                     tryingAutosave = true;
@@ -252,8 +252,8 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
 
                     String message = "<html>" + errorMessage + "<p>"
                             + (tryingAutosave ? Localization.lang(
-                                    "Error opening autosave of '%0'. Trying to load '%0' instead.",
-                                    file.getName()) : ""/*Globals.lang("Error opening file '%0'.", file.getName())*/)
+                            "Error opening autosave of '%0'. Trying to load '%0' instead.",
+                            file.getName()) : ""/*Globals.lang("Error opening file '%0'.", file.getName())*/)
                             + "</html>";
                     JOptionPane.showMessageDialog(null, message, Localization.lang("Error opening file"),
                             JOptionPane.ERROR_MESSAGE);
@@ -296,7 +296,7 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
      * Go through the list of post open actions, and perform those that need to be performed.
      *
      * @param panel The BasePanel where the database is shown.
-     * @param pr The result of the bib file parse operation.
+     * @param pr    The result of the bib file parse operation.
      */
     public static void performPostOpenActions(BasePanel panel, ParserResult pr, boolean mustRaisePanel) {
         for (PostOpenAction action : OpenDatabaseAction.postOpenActions) {
@@ -376,7 +376,7 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
             BibtexParser bp = new BibtexParser(reader);
 
             ParserResult pr = bp.parse();
-            pr.setEncoding(reader.getEncoding());
+            pr.setEncoding(getEncodingFromStream(reader));
             pr.setFile(fileToOpen);
 
             if (SpecialFieldsUtils.keywordSyncEnabled()) {
@@ -392,6 +392,17 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
             }
 
             return pr;
+        }
+    }
+
+
+    private static String getEncodingFromStream(InputStreamReader reader) {
+        String encoding = reader.getEncoding();
+        // compatibility hack to transfrom the UTF8 string to the version we expect
+        if (encoding == "UTF8") {
+            return "UTF-8";
+        } else {
+            return encoding;
         }
     }
 

--- a/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
@@ -344,20 +344,20 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
 
                 @Override
                 public void run() {
-                    StringBuilder warningStrin = new StringBuilder();
+                    StringBuilder warningString = new StringBuilder();
                     for (int i = 0; i < warnings.length; i++) {
-                        warningStrin.append(i + 1).append(". ").append(warnings[i]).append("\n");
+                        warningString.append(i + 1).append(". ").append(warnings[i]).append("\n");
                     }
 
-                    if (warningStrin.length() > 0) {
-                        warningStrin.deleteCharAt(warningStrin.length() - 1);
+                    if (warningString.length() > 0) {
+                        warningString.deleteCharAt(warningString.length() - 1);
                     }
                     // Note to self or to someone else: The following line causes an
                     // ArrayIndexOutOfBoundsException in situations with a large number of
                     // warnings; approx. 5000 for the database I opened when I observed the problem
                     // (duplicate key warnings). I don't think this is a big problem for normal situations,
                     // and it may possibly be a bug in the Swing code.
-                    JOptionPane.showMessageDialog(frame, warningStrin.toString(),
+                    JOptionPane.showMessageDialog(frame, warningString.toString(),
                             Localization.lang("Warnings") + " (" + file.getName() + ")", JOptionPane.WARNING_MESSAGE);
                 }
             });

--- a/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
@@ -374,25 +374,29 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
 
         // Open and parse file
         try (InputStreamReader reader = openFile(fileToOpen, suppliedEncoding, fallbackEncoding)) {
-            BibtexParser bp = new BibtexParser(reader);
+            BibtexParser parser = new BibtexParser(reader);
 
-            ParserResult pr = bp.parse();
-            pr.setEncoding(Charset.forName(reader.getEncoding()).name());
-            pr.setFile(fileToOpen);
+            ParserResult result = parser.parse();
+            /*
+            * The InputStreamReader might return 'UTF8', which is a wrong representation.
+            * Charset does the correct translation
+             */
+            result.setEncoding(Charset.forName(reader.getEncoding()).name());
+            result.setFile(fileToOpen);
 
             if (SpecialFieldsUtils.keywordSyncEnabled()) {
-                for (BibtexEntry entry : pr.getDatabase().getEntries()) {
+                for (BibtexEntry entry : result.getDatabase().getEntries()) {
                     SpecialFieldsUtils.syncSpecialFieldsFromKeywords(entry, null);
                 }
                 LOGGER.info("Synchronized special fields based on keywords");
             }
 
-            if (!pr.getMetaData().isGroupTreeValid()) {
-                pr.addWarning(Localization.lang(
+            if (!result.getMetaData().isGroupTreeValid()) {
+                result.addWarning(Localization.lang(
                         "Group tree could not be parsed. If you save the BibTeX database, all groups will be lost."));
             }
 
-            return pr;
+            return result;
         }
     }
 

--- a/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
@@ -99,14 +99,6 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
                 }
             }
 
-            /*
-            String chosenFile = Globals.getNewFile(frame,
-                    new File(Globals.prefs.get("workingDirectory")), ".bib",
-                    JFileChooser.OPEN_DIALOG, true);
-
-            if (chosenFile != null) {
-                fileToOpen = new File(chosenFile);
-            }*/
         } else {
             LOGGER.info(Action.NAME + " " + e.getActionCommand());
             filesToOpen.add(new File(StringUtil.getCorrectFileName(e.getActionCommand(), "bib")));
@@ -243,7 +235,6 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
                 try {
                     pr = OpenDatabaseAction.loadDatabase(fileToLoad, encoding);
                 } catch (Exception ex) {
-                    //ex.printStackTrace();
                     errorMessage = ex.getMessage();
                     pr = null;
                 }

--- a/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -376,7 +377,7 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
             BibtexParser bp = new BibtexParser(reader);
 
             ParserResult pr = bp.parse();
-            pr.setEncoding(getEncodingFromStream(reader));
+            pr.setEncoding(Charset.forName(reader.getEncoding()).name());
             pr.setFile(fileToOpen);
 
             if (SpecialFieldsUtils.keywordSyncEnabled()) {
@@ -392,17 +393,6 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
             }
 
             return pr;
-        }
-    }
-
-
-    private static String getEncodingFromStream(InputStreamReader reader) {
-        String encoding = reader.getEncoding();
-        // compatibility hack to transfrom the UTF8 string to the version we expect
-        if (encoding == "UTF8") {
-            return "UTF-8";
-        } else {
-            return encoding;
         }
     }
 

--- a/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
+++ b/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 
 public class OpenDatabaseActionTest {
 
-    private final String defaultEncoding = "UTF8";
+    private final String defaultEncoding = "UTF-8";
     private final File bibNoHeader = new File(OpenDatabaseActionTest.class.getResource("headerless.bib").getFile());
     private final File bibWrongHeader = new File(
             OpenDatabaseActionTest.class.getResource("wrong-header.bib").getFile());
@@ -41,13 +41,13 @@ public class OpenDatabaseActionTest {
     @Test
     public void useSpecifiedEncoding() throws IOException {
         ParserResult result = OpenDatabaseAction.loadDatabase(bibHeader, "noEncoding");
-        Assert.assertEquals("UTF8", result.getEncoding());
+        Assert.assertEquals("UTF-8", result.getEncoding());
     }
 
     @Test
     public void useSpecifiedEncodingWithSignature() throws IOException {
         ParserResult result = OpenDatabaseAction.loadDatabase(bibHeaderAndSignature, "noEncoding");
-        Assert.assertEquals("UTF8", result.getEncoding());
+        Assert.assertEquals("UTF-8", result.getEncoding());
     }
 
     @Test


### PR DESCRIPTION
This PR attempts to fix #367

We have a bit of a problem. `UTF8` came from these lines
```  java
        try (InputStreamReader reader = openFile(fileToOpen, suppliedEncoding, fallbackEncoding)) {
            BibtexParser bp = new BibtexParser(reader);

            ParserResult pr = bp.parse();
            pr.setEncoding(reader.getEncoding());
```
It is set in [this method call](https://docs.oracle.com/javase/8/docs/api/java/io/InputStreamReader.html#getEncoding--). That's the Java API. The `InputStreamReader` says that the proper name of the encoding is `UTF8`. 

My solution is an ugly compatibility hack in which we just insert the `-` manually. Ugly, but works... What do you think?