### PR TITLE
Add tests for the Bibtex parser

### DIFF
--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexImporter.java
@@ -31,11 +31,12 @@ import net.sf.jabref.model.entry.BibEntry;
 public class BibtexImporter extends ImportFormat {
 
     /**
-     * @return false as that does not cause any harm in the current implementation of JabRef
+     * @return true as we have no effective way to decide whether a file is in bibtex format or not. See
+     *         https://github.com/JabRef/jabref/pull/379#issuecomment-158685726 for more details.
      */
     @Override
     public boolean isRecognizedFormat(InputStream in) throws IOException {
-        return BibtexParser.isRecognizedFormat(new InputStreamReader(in));
+        return true;
     }
 
     /**

--- a/src/main/java/net/sf/jabref/model/database/BibDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabase.java
@@ -240,7 +240,7 @@ public class BibDatabase {
     }
 
     /**
-     * Inserts a Bibtex String at the given index.
+     * Inserts a Bibtex String.
      */
     public synchronized void addString(BibtexString string)
             throws KeyCollisionException {
@@ -256,7 +256,7 @@ public class BibDatabase {
     }
 
     /**
-     * Removes the string at the given index.
+     * Removes the string with the given id.
      */
     public void removeString(String id) {
         bibtexStrings.remove(id);
@@ -279,10 +279,10 @@ public class BibDatabase {
     }
 
     /**
-     * Returns the string at the given index.
+     * Returns the string with the given id.
      */
-    public BibtexString getString(String o) {
-        return bibtexStrings.get(o);
+    public BibtexString getString(String id) {
+        return bibtexStrings.get(id);
     }
 
     /**

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -5,6 +5,8 @@ import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
+import net.sf.jabref.model.entry.BibtexString;
+import net.sf.jabref.model.entry.UnknownEntryType;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -15,7 +17,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.Set;
 
 /**
  * Test the BibtexParser
@@ -25,15 +26,84 @@ import java.util.Set;
  */
 public class BibtexParserTest {
 
-
     @BeforeClass
     public static void setUp() {
         Globals.prefs = JabRefPreferences.getInstance();
     }
 
+    @Test(expected = NullPointerException.class)
+    public void initalizationWithNullThrowsNullPointerException() {
+        new BibtexParser(null);
+    }
 
     @Test
-    public void testParseReader() throws IOException {
+    public void fromStringRecognizesEntry() throws Exception {
+        Collection<BibEntry> c = BibtexParser.fromString("@article{test,author={Ed von Test}}");
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test", e.getField("author"));
+    }
+
+    @Test
+    public void fromStringReturnsEmptyListFromEmptyString() {
+        Collection<BibEntry> c = BibtexParser.fromString("");
+        Assert.assertNotNull(c);
+        Assert.assertEquals(0, c.size());
+    }
+
+    @Test
+    public void fromStringReturnsEmptyListIfNoEntryRecognized() {
+        Collection<BibEntry> c = BibtexParser.fromString("@@article@@{{{{{{}");
+        Assert.assertNotNull(c);
+        Assert.assertEquals(0, c.size());
+    }
+
+    @Test
+    public void singleFromStringRecognizesEntry() {
+        BibEntry e = BibtexParser.singleFromString(
+                "@article{canh05," + "  author = {Crowston, K. and Annabi, H.},\n" + "  title = {Title A}}\n");
+
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("canh05", e.getCiteKey());
+        Assert.assertEquals("Crowston, K. and Annabi, H.", e.getField("author"));
+        Assert.assertEquals("Title A", e.getField("title"));
+    }
+
+    @Test
+    public void singleFromStringRecognizesEntryInMultiple() {
+        BibEntry e = BibtexParser.singleFromString("@article{canh05," + "  author = {Crowston, K. and Annabi, H.},\n"
+                + "  title = {Title A}}\n" + "@inProceedings{foo," + "  author={Norton Bar}}");
+
+        Assert.assertTrue(e.getCiteKey().equals("canh05") || e.getCiteKey().equals("foo"));
+    }
+
+    @Test
+    public void singleFromStringReturnsNullFromEmptyString() {
+        BibEntry e = BibtexParser.singleFromString("");
+        Assert.assertNull(e);
+    }
+
+    @Test
+    public void singleFromStringReturnsNullIfNoEntryRecognized() {
+        BibEntry e = BibtexParser.singleFromString("@@article@@{{{{{{}");
+        Assert.assertNull(e);
+    }
+
+    @Test
+    public void parseTwoTimesReturnsSameResult() throws IOException {
+
+        BibtexParser parser = new BibtexParser(new StringReader("@article{test,author={Ed von Test}}"));
+        ParserResult result = parser.parse();
+
+        Assert.assertEquals(result, parser.parse());
+    }
+
+    @Test
+    public void parseRecognizesEntry() throws IOException {
 
         ParserResult result = BibtexParser.parse(new StringReader(
                 "@article{test,author={Ed von Test}}"));
@@ -42,219 +112,677 @@ public class BibtexParserTest {
         Assert.assertEquals(1, c.size());
 
         BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
         Assert.assertEquals("test", e.getCiteKey());
         Assert.assertEquals(2, e.getFieldNames().size());
-        Set<String> o = e.getFieldNames();
-        Assert.assertTrue(o.contains("author"));
         Assert.assertEquals("Ed von Test", e.getField("author"));
     }
 
     @Test
-    public void testBibtexParser() {
-        try {
-            new BibtexParser(null);
-            Assert.fail("Should not accept null.");
-        } catch (NullPointerException ignored) {
-            // Ignored
-        }
-    }
+    public void parseRecognizesEntryWithWhitespaceAtBegining() throws IOException {
 
-    @Test
-    public void testIsRecognizedFormat() throws IOException {
-        Assert.assertTrue(BibtexParser
-                .isRecognizedFormat(new StringReader(
-                        "This file was created with JabRef 2.1 beta 2."
-                                + "\n"
-                                + "Encoding: Cp1252"
-                                + "\n"
-                                + ""
-                                + "\n"
-                                + "@INPROCEEDINGS{CroAnnHow05,"
-                                + "\n"
-                                + "  author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.},"
-                                + "\n"
-                                + "  title = {Effective work practices for floss development: A model and propositions},"
-                                + "\n"
-                                + "  booktitle = {Hawaii International Conference On System Sciences (HICSS)},"
-                                + "\n" + "  year = {2005}," + "\n" + "  owner = {oezbek}," + "\n"
-                                + "  timestamp = {2006.05.29}," + "\n"
-                                + "  url = {http://james.howison.name/publications.html}" + "\n" + "}))"
-                )));
-
-        Assert.assertTrue(BibtexParser
-                .isRecognizedFormat(new StringReader(
-                        "@INPROCEEDINGS{CroAnnHow05,"
-                                + "\n"
-                                + "  author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.},"
-                                + "\n"
-                                + "  title = {Effective work practices for floss development: A model and propositions},"
-                                + "\n"
-                                + "  booktitle = {Hawaii International Conference On System Sciences (HICSS)},"
-                                + "\n" + "  year = {2005}," + "\n" + "  owner = {oezbek}," + "\n"
-                                + "  timestamp = {2006.05.29}," + "\n"
-                                + "  url = {http://james.howison.name/publications.html}" + "\n" + "}))"
-                )));
-
-        Assert.assertFalse(BibtexParser
-                .isRecognizedFormat(new StringReader(
-                        "  author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.},"
-                                + "\n"
-                                + "  title = {Effective work practices for floss development: A model and propositions},"
-                                + "\n"
-                                + "  booktitle = {Hawaii International Conference On System Sciences (HICSS)},"
-                                + "\n" + "  year = {2005}," + "\n" + "  owner = {oezbek}," + "\n"
-                                + "  timestamp = {2006.05.29}," + "\n"
-                                + "  url = {http://james.howison.name/publications.html}" + "\n" + "}))"
-                )));
-
-        Assert.assertFalse(BibtexParser.isRecognizedFormat(new StringReader(
-                "This was created with JabRef 2.1 beta 2." + "\n" + "Encoding: Cp1252" + "\n")));
-    }
-
-    @Test
-    public void testFromString() throws Exception {
-
-        { // Simple case
-            Collection<BibEntry> c = BibtexParser.fromString("@article{test,author={Ed von Test}}");
-            Assert.assertEquals(1, c.size());
-
-            BibEntry e = c.iterator().next();
-            Assert.assertEquals("test", e.getCiteKey());
-            Assert.assertEquals(2, e.getFieldNames().size());
-            Assert.assertTrue(e.getFieldNames().contains("author"));
-            Assert.assertEquals("Ed von Test", e.getField("author"));
-        }
-        { // Empty String
-            Collection<BibEntry> c = BibtexParser.fromString("");
-            Assert.assertEquals(0, c.size());
-
-        }
-        // Error
-        Collection<BibEntry> c = BibtexParser.fromString("@@article@@{{{{{{}");
-        Assert.assertEquals(null, c);
-
-    }
-
-    @Test
-    public void testFromSingle2() {
-        /**
-         * More
-         */
-        Collection<BibEntry> c = BibtexParser.fromString("@article{canh05,"
-                + "  author = {Crowston, K. and Annabi, H.},\n" + "  title = {Title A}}\n"
-                + "@inProceedings{foo," + "  author={Norton Bar}}");
-
-        Assert.assertEquals(2, c.size());
-
-        Iterator<BibEntry> i = c.iterator();
-        BibEntry a = i.next();
-        BibEntry b = i.next();
-
-        if (a.getCiteKey().equals("foo")) {
-            BibEntry tmp = a;
-            a = b;
-            b = tmp;
-        }
-
-        Assert.assertEquals("canh05", a.getCiteKey());
-        Assert.assertEquals("Crowston, K. and Annabi, H.", a.getField("author"));
-        Assert.assertEquals("Title A", a.getField("title"));
-        Assert.assertEquals(BibtexEntryTypes.ARTICLE, a.getType());
-
-        Assert.assertEquals("foo", b.getCiteKey());
-        Assert.assertEquals("Norton Bar", b.getField("author"));
-        Assert.assertEquals(BibtexEntryTypes.INPROCEEDINGS, b.getType());
-    }
-
-    @Test
-    public void testFromStringSingle() {
-        BibEntry a = BibtexParser.singleFromString("@article{canh05,"
-                + "  author = {Crowston, K. and Annabi, H.},\n" + "  title = {Title A}}\n");
-
-        Assert.assertEquals("canh05", a.getCiteKey());
-        Assert.assertEquals("Crowston, K. and Annabi, H.", a.getField("author"));
-        Assert.assertEquals("Title A", a.getField("title"));
-        Assert.assertEquals(BibtexEntryTypes.ARTICLE, a.getType());
-
-        BibEntry b = BibtexParser.singleFromString("@article{canh05,"
-                + "  author = {Crowston, K. and Annabi, H.},\n" + "  title = {Title A}}\n"
-                + "@inProceedings{foo," + "  author={Norton Bar}}");
-
-        if (!(b.getCiteKey().equals("canh05") || b.getCiteKey().equals("foo"))) {
-            Assert.fail();
-        }
-    }
-
-    @Test
-    public void testParse() throws IOException {
-
-        // Test Standard parsing
-        BibtexParser parser = new BibtexParser(new StringReader(
-                "@article{test,author={Ed von Test}}"));
-        ParserResult result = parser.parse();
+        ParserResult result = BibtexParser.parse(new StringReader(" @article{test,author={Ed von Test}}"));
 
         Collection<BibEntry> c = result.getDatabase().getEntries();
         Assert.assertEquals(1, c.size());
 
         BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
         Assert.assertEquals("test", e.getCiteKey());
         Assert.assertEquals(2, e.getFieldNames().size());
-        Assert.assertTrue(e.getFieldNames().contains("author"));
         Assert.assertEquals("Ed von Test", e.getField("author"));
-
-        // Calling parse again will return the same result
-        Assert.assertEquals(result, parser.parse());
     }
 
     @Test
-    public void testParse2() throws IOException {
+    public void parseRecognizesEntryWithWhitespace() throws IOException {
 
-        BibtexParser parser = new BibtexParser(new StringReader(
-                "@article{test,author={Ed von Test}}"));
-        ParserResult result = parser.parse();
-
-        BibEntry e = new BibEntry("", BibtexEntryTypes.ARTICLE);
-        e.setField("author", "Ed von Test");
-        e.setField("bibtexkey", "test");
+        ParserResult result = BibtexParser.parse(new StringReader("@article { test,author={Ed von Test}}"));
 
         Collection<BibEntry> c = result.getDatabase().getEntries();
         Assert.assertEquals(1, c.size());
 
-        BibEntry e2 = c.iterator().next();
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test", e.getField("author"));
+    }
 
-        Assert.assertNotSame(e.getId(), e2.getId());
+    @Test
+    public void parseRecognizesEntryWithNewlines() throws IOException {
 
-        for (String field : e.getFieldNames()) {
-            if (!e.getField(field).equals(e2.getField(field))) {
-                Assert.fail("e and e2 differ in field " + field);
-            }
-        }
+        ParserResult result = BibtexParser.parse(new StringReader("@article\n{\ntest,author={Ed von Test}}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test", e.getField("author"));
+    }
+
+    @Test
+    public void parseRecognizesEntryWithUnknownType() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@unknown{test,author={Ed von Test}}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(new UnknownEntryType("Unknown"), e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test", e.getField("author"));
+    }
+
+    @Test
+    public void parseRecognizesEntryWithVeryLongType() throws IOException {
+
+        ParserResult result = BibtexParser.parse(
+                new StringReader("@thisIsALongStringToTestMaybeItIsToLongWhoKnowsNOTme{test,author={Ed von Test}}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(new UnknownEntryType("Thisisalongstringtotestmaybeitistolongwhoknowsnotme"), e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test", e.getField("author"));
+    }
+
+    @Test
+    public void parseRecognizesEntryInParenthesis() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article(test,author={Ed von Test})"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test", e.getField("author"));
     }
 
     /**
-     * Test for [ 1594123 ] Failure to import big numbers
-     * <p/>
-     * Issue Reported by Ulf Martin.
-     *
-     * @throws IOException
+     * Test for [ 1594123 ] Failure to import big numbers Issue Reported by Ulf Martin. SF Bugs #503, #495 are also
+     * related
      */
     @Test
-    public void testBigNumbers() throws IOException {
+    public void parseRecognizesEntryWithBigNumbers() throws IOException {
 
-        ParserResult result = BibtexParser.parse(new StringReader("@article{canh05,"
-                + "isbn = 1234567890123456789,\n" + "isbn2 = {1234567890123456789},\n"
-                + "small = 1234,\n" + "}"));
+        ParserResult result = BibtexParser.parse(new StringReader("@article{canh05," + "isbn = 1234567890123456789,\n"
+                + "isbn2 = {1234567890123456789},\n" + "small = 1234,\n" + "}"));
 
         Collection<BibEntry> c = result.getDatabase().getEntries();
         BibEntry e = c.iterator().next();
 
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("canh05", e.getCiteKey());
         Assert.assertEquals("1234567890123456789", e.getField("isbn"));
         Assert.assertEquals("1234567890123456789", e.getField("isbn2"));
         Assert.assertEquals("1234", e.getField("small"));
     }
 
     @Test
-    public void testBigNumbers2() throws IOException {
+    public void parseRecognizesBibtexKeyWithSpecialCharacters() throws IOException {
+
+        ParserResult result = BibtexParser
+                .parse(new StringReader("@article{te_st:with-special(characters),author={Ed von Test}}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        BibEntry e = c.iterator().next();
+
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("te_st:with-special(characters)", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test", e.getField("author"));
+    }
+
+    @Test
+    public void parseRecognizesEntryWhereLastFieldIsFinishedWithComma() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,author={Ed von Test},}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test", e.getField("author"));
+    }
+
+    @Test
+    public void parseRecognizesMultipleEntries() throws IOException {
+
+        ParserResult result = BibtexParser
+                .parse(new StringReader("@article{canh05," + "  author = {Crowston, K. and Annabi, H.},\n"
+                        + "  title = {Title A}}\n" + "@inProceedings{foo," + "  author={Norton Bar}}"));
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(2, c.size());
+
+        Iterator<BibEntry> i = c.iterator();
+        BibEntry a = i.next();
+        BibEntry b = i.next();
+
+        // Sort them because we can't be sure about the order
+        if (a.getCiteKey().equals("foo")) {
+            BibEntry tmp = a;
+            a = b;
+            b = tmp;
+        }
+
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, a.getType());
+        Assert.assertEquals("canh05", a.getCiteKey());
+        Assert.assertEquals("Crowston, K. and Annabi, H.", a.getField("author"));
+        Assert.assertEquals("Title A", a.getField("title"));
+
+        Assert.assertEquals(BibtexEntryTypes.INPROCEEDINGS, b.getType());
+        Assert.assertEquals("foo", b.getCiteKey());
+        Assert.assertEquals("Norton Bar", b.getField("author"));
+    }
+
+    @Test
+    public void parseCombinesMultipleAuthorFields() throws IOException {
+
+        ParserResult result = BibtexParser.parse(
+                new StringReader("@article{test,author={Ed von Test},author={Second Author},author={Third Author}}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test and Second Author and Third Author", e.getField("author"));
+    }
+
+    @Test
+    public void parseCombinesMultipleEditorFields() throws IOException {
+
+        ParserResult result = BibtexParser.parse(
+                new StringReader("@article{test,editor={Ed von Test},editor={Second Author},editor={Third Author}}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test and Second Author and Third Author", e.getField("editor"));
+    }
+
+    /**
+     * Test for SF Bug #1269
+     */
+    @Test
+    @Ignore
+    public void parseCombinesMultipleKeywordsFields() throws IOException {
+
+        ParserResult result = BibtexParser.parse(
+                new StringReader("@article{test,Keywords={Test},Keywords={Second Keyword},Keywords={Third Keyword}}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Test, Second Keyword, Third Keyword", e.getField("keywords"));
+    }
+
+    @Test
+    public void parseRecognizesHeaderButIgnoresEncoding() throws IOException {
+        ParserResult result = BibtexParser.parse(new StringReader(
+                    "This file was created with JabRef 2.1 beta 2."
+                            + "\n"
+                            + "Encoding: Cp1252"
+                            + "\n"
+                            + ""
+                            + "\n"
+                            + "@INPROCEEDINGS{CroAnnHow05,"
+                            + "\n"
+                            + "  author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.},"
+                            + "\n"
+                            + "  title = {Effective work practices for floss development: A model and propositions},"
+                            + "\n"
+                            + "  booktitle = {Hawaii International Conference On System Sciences (HICSS)},"
+                            + "\n" + "  year = {2005}," + "\n" + "  owner = {oezbek}," + "\n"
+                            + "  timestamp = {2006.05.29}," + "\n"
+                            + "  url = {http://james.howison.name/publications.html}" + "\n" + "}))"
+                ));
+        Assert.assertNull(result.getEncoding());
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.INPROCEEDINGS, e.getType());
+        Assert.assertEquals(8, e.getFieldNames().size());
+        Assert.assertEquals("CroAnnHow05", e.getCiteKey());
+        Assert.assertEquals("Crowston, K. and Annabi, H. and Howison, J. and Masango, C.", e.getField("author"));
+        Assert.assertEquals("Effective work practices for floss development: A model and propositions",
+                e.getField("title"));
+        Assert.assertEquals("Hawaii International Conference On System Sciences (HICSS)", e.getField("booktitle"));
+        Assert.assertEquals("2005", e.getField("year"));
+        Assert.assertEquals("oezbek", e.getField("owner"));
+        Assert.assertEquals("2006.05.29", e.getField("timestamp"));
+        Assert.assertEquals("http://james.howison.name/publications.html", e.getField("url"));
+    }
+
+    @Test
+    public void parseRecognizesFormatedEntry() throws IOException {
+        ParserResult result = BibtexParser.parse(new StringReader(
+                    "@INPROCEEDINGS{CroAnnHow05,"
+                            + "\n"
+                            + "  author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.},"
+                            + "\n"
+                            + "  title = {Effective work practices for floss development: A model and propositions},"
+                            + "\n"
+                            + "  booktitle = {Hawaii International Conference On System Sciences (HICSS)},"
+                            + "\n" + "  year = {2005}," + "\n" + "  owner = {oezbek}," + "\n"
+                            + "  timestamp = {2006.05.29}," + "\n"
+                            + "  url = {http://james.howison.name/publications.html}" + "\n" + "}))"
+                ));
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.INPROCEEDINGS, e.getType());
+        Assert.assertEquals(8, e.getFieldNames().size());
+        Assert.assertEquals("CroAnnHow05", e.getCiteKey());
+        Assert.assertEquals("Crowston, K. and Annabi, H. and Howison, J. and Masango, C.", e.getField("author"));
+        Assert.assertEquals("Effective work practices for floss development: A model and propositions",
+                e.getField("title"));
+        Assert.assertEquals("Hawaii International Conference On System Sciences (HICSS)", e.getField("booktitle"));
+        Assert.assertEquals("2005", e.getField("year"));
+        Assert.assertEquals("oezbek", e.getField("owner"));
+        Assert.assertEquals("2006.05.29", e.getField("timestamp"));
+        Assert.assertEquals("http://james.howison.name/publications.html", e.getField("url"));
+     }
+
+    @Test
+    public void parseRecognizesFieldValuesInQuotationMarks() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,author=\"Ed von Test\"}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test", e.getField("author"));
+    }
+
+    @Test
+    public void parseRecognizesNumbersWithoutBracketsOrQuotationMarks() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,year = 2005}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("2005", e.getField("year"));
+    }
+
+    @Test
+    public void parseRecognizesUppercaseFields() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,AUTHOR={Ed von Test}}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test", e.getField("author"));
+    }
+
+    /**
+     * Test for SF Bug #806
+     */
+    @Test
+    public void parseRecognizesAbsoluteFile() throws IOException {
+
+        ParserResult result = BibtexParser
+                .parse(new StringReader("@article{test,file = {D:\\Documents\\literature\\Tansel-PRL2006.pdf}}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("D:\\Documents\\literature\\Tansel-PRL2006.pdf", e.getField("file"));
+    }
+
+    /**
+     * Test for SF Bug #48
+     */
+    @Test
+    public void parseRecognizesDateFieldWithConcatenation() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,date = {1-4~} # nov}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("1-4~#nov#", e.getField("date"));
+    }
+
+    @Test
+    public void parseReturnsEmptyListIfNoEntryRecognized() throws IOException {
+        ParserResult result = BibtexParser.parse(new StringReader(
+                    "  author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.},"
+                            + "\n"
+                            + "  title = {Effective work practices for floss development: A model and propositions},"
+                            + "\n"
+                            + "  booktitle = {Hawaii International Conference On System Sciences (HICSS)},"
+                            + "\n" + "  year = {2005}," + "\n" + "  owner = {oezbek}," + "\n"
+                            + "  timestamp = {2006.05.29}," + "\n"
+                            + "  url = {http://james.howison.name/publications.html}" + "\n" + "}))"
+                ));
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(0, c.size());
+    }
+
+    @Test
+    public void parseReturnsEmptyListIfNoEntryExistent() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader(
+                "This was created with JabRef 2.1 beta 2." + "\n" + "Encoding: Cp1252" + "\n"));
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(0, c.size());
+    }
+
+    @Test
+    public void parseRecognizesDuplicateBibtexKeys() throws IOException {
+
+        ParserResult result = BibtexParser
+                .parse(new StringReader("@article{canh05," + "  author = {Crowston, K. and Annabi, H.},\n"
+                        + "  title = {Title A}}\n" + "@inProceedings{canh05," + "  author={Norton Bar}}"));
+
+        String[] duplicateKeys = result.getDuplicateKeys();
+        Assert.assertEquals(1, duplicateKeys.length);
+        Assert.assertEquals("canh05", duplicateKeys[0]);
+    }
+
+    @Test
+    public void parseWarnsAboutEntryWithoutBibtexKey() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{,author={Ed von Test}}"));
+
+        Assert.assertTrue(result.hasWarnings());
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test", e.getField("author"));
+    }
+
+    @Test
+    public void parseIgnoresAndWarnsAboutEntryWithUnmatchedOpenBracket() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,author={author missing bracket}"));
+
+        Assert.assertTrue(result.hasWarnings());
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(0, c.size());
+    }
+
+    @Test
+    public void parseIgnoresAndWarnsAboutEntryWithUnmatchedOpenBracketInQuotationMarks() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,author=\"author {missing bracket\"}"));
+
+        Assert.assertTrue(result.hasWarnings());
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(0, c.size());
+    }
+
+    @Test
+    @Ignore
+    public void parseIgnoresAndWarnsAboutEntryWithUnmatchedClosingBracket() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,author={author bracket } to much}}"));
+
+        Assert.assertTrue(result.hasWarnings());
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(0, c.size());
+    }
+
+    @Test
+    @Ignore
+    public void parseIgnoresAndWarnsAboutEntryWithAtSymbolInBrackets() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,author={author @ not good}}"));
+
+        Assert.assertTrue(result.hasWarnings());
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(0, c.size());
+    }
+
+    @Test
+    public void parseRecognizesEntryWithAtSymbolInQuotationMarks() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,author=\"author @ good\"}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("author @ good", e.getField("author"));
+    }
+
+    @Test
+    public void parseRecognizesFieldsWithBracketsEnclosedInQuotationMarks() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,author=\"Test {Ed {von} Test}\"}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Test {Ed {von} Test}", e.getField("author"));
+    }
+
+    @Test
+    public void parseRecognizesFieldsWithEscapedQuotationMarks() throws IOException {
+
+        // Quotes in fields of the form key = "value" have to be escaped by putting them into braces
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,author=\"Test {\" Test}\"}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Test {\" Test}", e.getField("author"));
+    }
+
+    @Test
+    public void parseIgnoresAndWarnsAboutEntryWithFieldsThatAreNotSeperatedByComma() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,author={Ed von Test} year=2005}"));
+
+        Assert.assertTrue(result.hasWarnings());
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(0, c.size());
+    }
+
+    @Test
+    public void parseIgnoresAndWarnsAboutCorruptedEntryButRecognizeOthers() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,author={author missing bracket}" + "@article{test,author={Ed von Test}}"));
+
+        Assert.assertTrue(result.hasWarnings());
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test", e.getField("author"));
+    }
+
+    /**
+     * Test for SF Bug #1283
+     */
+    @Test
+    @Ignore
+    public void parseRecognizesMonthFieldsWithFollowingComma() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,author={Ed von Test}},month={8,},"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(3, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test", e.getField("author"));
+        Assert.assertEquals("8,", e.getField("month"));
+    }
+
+    @Test
+    public void parseRecognizesPreamble() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@preamble{some text and \\latex}"));
+        Assert.assertEquals("some text and \\latex", result.getDatabase().getPreamble());
+    }
+
+    @Test
+    public void parseRecognizesUppercasePreamble() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@PREAMBLE{some text and \\latex}"));
+        Assert.assertEquals("some text and \\latex", result.getDatabase().getPreamble());
+    }
+
+    @Test
+    @Ignore
+    public void parseRecognizesPreambleWithWhitespace() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@preamble {some text and \\latex}"));
+        Assert.assertEquals("some text and \\latex", result.getDatabase().getPreamble());
+    }
+
+    @Test
+    @Ignore
+    public void parseRecognizesPreambleInParenthesis() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@preamble(some text and \\latex)"));
+        Assert.assertEquals("some text and \\latex", result.getDatabase().getPreamble());
+    }
+
+    @Test
+    public void parseRecognizesPreambleWithConcatenation() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@preamble{\"some text\" # \"and \\latex\"}"));
+        Assert.assertEquals("\"some text\" # \"and \\latex\"", result.getDatabase().getPreamble());
+    }
+
+    @Test
+    public void parseRecognizesString() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@string{bourdieu = {Bourdieu, Pierre}}"));
+        Assert.assertEquals(1, result.getDatabase().getStringCount());
+
+        BibtexString s = result.getDatabase().getStringValues().iterator().next();
+        Assert.assertEquals("bourdieu", s.getName());
+        Assert.assertEquals("Bourdieu, Pierre", s.getContent());
+    }
+
+    @Test
+    public void parseRecognizesStringWithWhitespace() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@string {bourdieu = {Bourdieu, Pierre}}"));
+        Assert.assertEquals(1, result.getDatabase().getStringCount());
+
+        BibtexString s = result.getDatabase().getStringValues().iterator().next();
+        Assert.assertEquals("bourdieu", s.getName());
+        Assert.assertEquals("Bourdieu, Pierre", s.getContent());
+    }
+
+    @Test
+    public void parseRecognizesStringInParenthesis() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@string(bourdieu = {Bourdieu, Pierre})"));
+        Assert.assertEquals(1, result.getDatabase().getStringCount());
+
+        BibtexString s = result.getDatabase().getStringValues().iterator().next();
+        Assert.assertEquals("bourdieu", s.getName());
+        Assert.assertEquals("Bourdieu, Pierre", s.getContent());
+    }
+
+    @Test
+    public void parseRecognizesMultipleStrings() throws IOException {
+
+        ParserResult result = BibtexParser
+                .parse(new StringReader("@string{bourdieu = {Bourdieu, Pierre}}" + "@string{adieu = {Adieu, Pierre}}"));
+
+        Assert.assertEquals(2, result.getDatabase().getStringCount());
+        Iterator<BibtexString> iterator = result.getDatabase().getStringValues().iterator();
+        BibtexString s = iterator.next();
+        BibtexString t = iterator.next();
+
+        // Sort them because we can't be sure about the order
+        if (s.getName().equals("adieu")) {
+            BibtexString tmp = s;
+            s = t;
+            t = tmp;
+        }
+
+        Assert.assertEquals("bourdieu", s.getName());
+        Assert.assertEquals("Bourdieu, Pierre", s.getContent());
+        Assert.assertEquals("adieu", t.getName());
+        Assert.assertEquals("Adieu, Pierre", t.getContent());
+    }
+
+    @Test
+    public void parseRecognizesStringAndEntry() throws IOException {
 
         ParserResult result = BibtexParser.parse(new StringReader(""
                 + "@string{bourdieu = {Bourdieu, Pierre}}"
@@ -262,46 +790,160 @@ public class BibtexParserTest {
                 + "	Author = bourdieu," + "	Isbn = 2707318256," + "	Publisher = {Minuit},"
                 + "	Title = {Questions de sociologie}," + "	Year = 2002" + "}"));
 
+        Assert.assertEquals(1, result.getDatabase().getStringCount());
+        BibtexString s = result.getDatabase().getStringValues().iterator().next();
+        Assert.assertEquals("bourdieu", s.getName());
+        Assert.assertEquals("Bourdieu, Pierre", s.getContent());
+
         Collection<BibEntry> c = result.getDatabase().getEntries();
         Assert.assertEquals(1, c.size());
 
         BibEntry e = c.iterator().next();
 
-        Assert.assertEquals("bourdieu-2002-questions-sociologie", e.getCiteKey());
         Assert.assertEquals(BibtexEntryTypes.BOOK, e.getType());
-        Assert.assertEquals("2707318256", e.getField("isbn"));
+        Assert.assertEquals("bourdieu-2002-questions-sociologie", e.getCiteKey());
         Assert.assertEquals("Paris", e.getField("address"));
+        Assert.assertEquals("#bourdieu#", e.getField("author"));
+        Assert.assertEquals("2707318256", e.getField("isbn"));
         Assert.assertEquals("Minuit", e.getField("publisher"));
         Assert.assertEquals("Questions de sociologie", e.getField("title"));
-        Assert.assertEquals("#bourdieu#", e.getField("author"));
         Assert.assertEquals("2002", e.getField("year"));
     }
 
     @Test
-    @Ignore
-    public void testNewlineHandling() {
+    public void parseWarnsAboutStringsWithSameNameAndOnlyKeepsOne() throws IOException {
 
-        BibEntry e = BibtexParser.singleFromString("@article{canh05," +
-                "a = {a\nb}," +
-                "b = {a\n\nb}," +
-                "c = {a\n \nb}," +
-                "d = {a \n \n b},"
-                + "title = {\nHallo \nWorld \nthis \n is\n\nnot \n\nan \n\n exercise \n \n.\n \n\n},\n"
-                + "tabs = {\nHallo \tWorld \tthis \t is\t\tnot \t\tan \t\n exercise \t \n.\t \n\t},\n"
-                + "file = {Bemerkung:H:\\bla\\ups  sala.pdf:PDF}, \n"
-                + "}");
+        ParserResult result = BibtexParser
+                .parse(new StringReader("@string{bourdieu = {Bourdieu, Pierre}}" + "@string{bourdieu = {Other}}"));
+        Assert.assertTrue(result.hasWarnings());
+        Assert.assertEquals(1, result.getDatabase().getStringCount());
+    }
 
-        Assert.assertEquals("canh05", e.getCiteKey());
+    @Test
+    public void parseIgnoresComments() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@comment{some text and \\latex}"));
+        Assert.assertEquals(0, result.getDatabase().getEntries().size());
+    }
+
+    @Test
+    public void parseIgnoresUpercaseComments() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@COMMENT{some text and \\latex}"));
+        Assert.assertEquals(0, result.getDatabase().getEntries().size());
+    }
+
+    @Test
+    public void parseIgnoresCommentsBeforeEntry() throws IOException {
+
+        ParserResult result = BibtexParser
+                .parse(new StringReader("@comment{some text and \\latex}" + "@article{test,author={Ed von Test}}"));
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
         Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test", e.getField("author"));
+    }
 
+    @Test
+    public void parseIgnoresCommentsAfterEntry() throws IOException {
+
+        ParserResult result = BibtexParser
+                .parse(new StringReader("@article{test,author={Ed von Test}}" + "@comment{some text and \\latex}"));
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test", e.getField("author"));
+    }
+
+    @Test
+    public void parseIgnoresText() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("comment{some text and \\latex"));
+        Assert.assertEquals(0, result.getDatabase().getEntries().size());
+    }
+
+    @Test
+    public void parseIgnoresTextBeforeEntry() throws IOException {
+
+        ParserResult result = BibtexParser
+                .parse(new StringReader("comment{some text and \\latex" + "@article{test,author={Ed von Test}}"));
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test", e.getField("author"));
+    }
+
+    @Test
+    public void parseIgnoresTextAfterEntry() throws IOException {
+
+        ParserResult result = BibtexParser
+                .parse(new StringReader("@article{test,author={Ed von Test}}" + "comment{some text and \\latex"));
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals(2, e.getFieldNames().size());
+        Assert.assertEquals("Ed von Test", e.getField("author"));
+    }
+
+    @Test
+    public void parseConvertsNewlineToSpace() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,a = {a\nb}}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        BibEntry e = c.iterator().next();
         Assert.assertEquals("a b", e.getField("a"));
-        Assert.assertEquals("a\nb", e.getField("b"));
+    }
+
+    @Test
+    public void parseConvertsMultipleNewlinesToSpace() throws IOException {
+
+        ParserResult result = BibtexParser
+                .parse(new StringReader("@article{test,a = {a\n\nb}," + "b = {a\n \nb}," + "c = {a \n \n b}}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals("a b", e.getField("a"));
+        Assert.assertEquals("a b", e.getField("b"));
         Assert.assertEquals("a b", e.getField("c"));
-        Assert.assertEquals("a b", e.getField("d"));
+    }
 
-        // I think the last \n is a bug in the parser...
-        Assert.assertEquals("Hallo World this is\nnot \nan \n exercise . \n\n", e.getField("title"));
-        Assert.assertEquals("Hallo World this isnot an exercise . ", e.getField("tabs"));
+    @Test
+    public void parseConvertsTabToSpace() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,a = {a\tb}}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals("a b", e.getField("a"));
+    }
+
+    @Test
+    public void parseConvertsMultipleTabsToSpace() throws IOException {
+
+        ParserResult result = BibtexParser
+                .parse(new StringReader("@article{test,a = {a\t\tb}," + "b = {a\t \tb}," + "c = {a \t \t b}}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals("a b", e.getField("a"));
+        Assert.assertEquals("a b", e.getField("b"));
+        Assert.assertEquals("a b", e.getField("c"));
     }
 
     /**
@@ -311,31 +953,12 @@ public class BibtexParserTest {
      * @author Andrei Haralevich
      */
     @Test
-    public void testFileNaming() {
-        BibEntry e = BibtexParser.singleFromString("@article{canh05,"
-                + "title = {\nHallo \nWorld \nthis \n is\n\nnot \n\nan \n\n exercise \n \n.\n \n\n},\n"
-                + "tabs = {\nHallo \tWorld \tthis \t is\t\tnot \t\tan \t\n exercise \t \n.\t \n\t},\n"
-                + "file = {Bemerkung:H:\\bla\\ups  sala.pdf:PDF}, \n"
-                + "}");
+    public void parsePreservesMultipleSpacesInFileField() throws IOException {
+        ParserResult result = BibtexParser.parse(new StringReader("@article{canh05,file = {ups  sala}}"));
 
-        Assert.assertEquals("Bemerkung:H:\\bla\\ups  sala.pdf:PDF", e.getField("file"));
-    }
-
-    /**
-     * Test for [2022983]
-     *
-     * @author Uwe Kuehn
-     * @author Andrei Haralevich
-     */
-    @Test
-    public void testFileNaming1() {
-        BibEntry e = BibtexParser.singleFromString("@article{canh05,"
-                + "title = {\nHallo \nWorld \nthis \n is\n\nnot \n\nan \n\n exercise \n \n.\n \n\n},\n"
-                + "tabs = {\nHallo \tWorld \tthis \t is\t\tnot \t\tan \t\n exercise \t \n.\t \n\t},\n"
-                + "file = {Bemerkung:H:\\bla\\ups  \tsala.pdf:PDF}, \n"
-                + "}");
-
-        Assert.assertEquals("Bemerkung:H:\\bla\\ups  \tsala.pdf:PDF", e.getField("file"));
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals("ups  sala", e.getField("file"));
     }
 
     /**
@@ -346,13 +969,27 @@ public class BibtexParserTest {
      */
     @Test
     @Ignore
-    public void testFileNaming3() {
-        BibEntry e = BibtexParser.singleFromString("@article{canh05,"
-                + "title = {\nHallo \nWorld \nthis \n is\n\nnot \n\nan \n\n exercise \n \n.\n \n\n},\n"
-                + "tabs = {\nHallo \tWorld \tthis \t is\t\tnot \t\tan \t\n exercise \t \n.\t \n\t},\n"
-                + "file = {Bemerkung:H:\\bla\\ups \n\tsala.pdf:PDF}, \n"
-                + "}");
+    public void parseRemovesTabsInFileField() throws IOException {
+        ParserResult result = BibtexParser.parse(new StringReader("@article{canh05,file = {ups  \tsala}}"));
 
-        Assert.assertEquals("Bemerkung:H:\\bla\\ups  sala.pdf:PDF", e.getField("file"));
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals("ups  sala", e.getField("file"));
+    }
+
+    /**
+     * Test for [2022983]
+     *
+     * @author Uwe Kuehn
+     * @author Andrei Haralevich
+     */
+    @Test
+    @Ignore
+    public void parseRemovesNewlineInFileField() throws IOException {
+        ParserResult result = BibtexParser.parse(new StringReader("@article{canh05,file = {ups \n\tsala}}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals("ups  sala", e.getField("file"));
     }
 }


### PR DESCRIPTION
I added a few tests for the Bibtex parser. I appreciate your feedback about the following points.
- [x] Please have a look at the `TODO` comments. These concern string concatenation and `@String` fields. For example in `parseRecognizesDateFieldWithConcatenation` the field `date = {1-4~} # nov` is parsed as `1-4~#nov#`. I wouldn't have expect the last sharp symbol.
- [x] Tests about JabRef's metadata (groups etc.) are still missing. Mostly, because I don't know the specifications :). Maybe in a new PR.
- [x] Related to the previous point, the `GUIGlobals.META_FLAG` flags should be moved to another place (they are not GUI, but parser/writer logic). What would be an appropriate new home for them?
- [x] There are 4 tests at the end of the file starting with `test`. These tests fail (without the `@Ignore` tag) but I'm not sure what they test and what would be the expected behavior in these cases.
- [x] There are quite a few ignored tests. These are related to open bugs in SF or are new bugs which I found while writing the tests (nothing big). I will open a new issue for the new bugs after this PR is merged.

For the record: While going through the code, I also changed the following things:
- Remove `BibtexParser.isRecognizedFormat` since the code has quite a few shortcomings (whitespace before @ or closing brackets on new lines were a problem) and the execution was quite slow for big files
- Fixed a bug where loading a file with corrupted bibtex entries showed an exception, cf. `parseIgnoresAndWarnsAboutCorruptedEntry()`
- Made `EntryType` an abstract class which implements the `Comparable` interface and overwrites `equals(Object other)`. Thus new expressions like `entry.getType() == BibtexEntryTypes.ARTICLE` return the expected result.
