### PR TITLE
Added month selection to EntryEditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 
 ### Changed
  - Better support for IEEEtranBSTCTL entries
+ - Quick selection of month in entry editor
  - Unknown entry types will be converted to 'Misc' (was 'Other' before).
  - EntryTypes are now clustered per group on the 'new entry' GUI screen.
  - Tab shows the minimal unique folder name substring if multiple database files share the same name

--- a/src/main/java/net/sf/jabref/gui/BibtexFields.java
+++ b/src/main/java/net/sf/jabref/gui/BibtexFields.java
@@ -62,6 +62,7 @@ public class BibtexFields {
     public static final String EXTRA_BROWSE_DOC = "browseDoc"; // Browse button, file dialog with extension .fieldname
     public static final String EXTRA_BROWSE_DOC_ZIP = "browseDocZip"; // Browse button, file dialog with extension .fieldname, .fieldname.bz2, .filedname.gz
     public static final String EXTRA_SET_OWNER = "setOwner"; // Button to set owner to current used
+    public static final String EXTRA_MONTH = "month"; // Button to show the months and set abbreviation
 
     public static final String[] DEFAULT_INSPECTION_FIELDS = new String[]
             {"author", "title", "year", BibtexEntry.KEY_FIELD};
@@ -105,7 +106,9 @@ public class BibtexFields {
         add(dummy);
 
         add(new BibtexSingleField("key", true));
-        add(new BibtexSingleField("month", true, GUIGlobals.SMALL_W));
+        dummy = new BibtexSingleField("month", true, GUIGlobals.SMALL_W);
+        dummy.setExtras(EXTRA_MONTH);
+        add(dummy);
         add(new BibtexSingleField("note", true, GUIGlobals.MEDIUM_W));
         add(new BibtexSingleField("number", true, GUIGlobals.SMALL_W, 60).setNumeric(true));
         add(new BibtexSingleField("organization", true, GUIGlobals.MEDIUM_W));
@@ -453,7 +456,7 @@ public class BibtexFields {
         // the fieldname
         private String name;
 
-        // contains the standard, privat, displayable, writable infos
+        // contains the standard, private, displayable, writable infos
         // default is: not standard, public, displayable and writable
         private int flag = BibtexSingleField.DISPLAYABLE | BibtexSingleField.WRITEABLE;
 

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -65,7 +65,6 @@ import net.sf.jabref.logic.labelPattern.LabelPatternUtil;
 import net.sf.jabref.logic.util.date.EasyDateFormat;
 import net.sf.jabref.model.database.BibtexDatabase;
 import net.sf.jabref.model.entry.*;
-import net.sf.jabref.bibtex.EntryTypes;
 import net.sf.jabref.specialfields.SpecialFieldUpdateListener;
 import net.sf.jabref.gui.undo.NamedCompound;
 import net.sf.jabref.gui.undo.UndoableChangeType;
@@ -542,9 +541,28 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                         public void actionPerformed(ActionEvent actionEvent) {
 
                             editor.setText(((String) yesno.getSelectedItem()).toLowerCase());
+                            updateField(editor);
                         }
                     });
                     return yesno;
+                } else if (BibtexFields.EXTRA_MONTH.equals(fieldExtras)) {
+                    final String[] options = new String[13];
+                    options[0] = Localization.lang("Select");
+                    for (int i = 1; i <= 12; i++) {
+                        options[i] = MonthUtil.getMonthByNumber(i).fullName;
+                    }
+                    JComboBox<String> month = new JComboBox<>(options);
+                    month.addActionListener(new ActionListener() {
+
+                        @Override
+                        public void actionPerformed(ActionEvent actionEvent) {
+
+                            editor.setText((MonthUtil.getMonthByNumber(month.getSelectedIndex()).bibtexFormat));
+                            updateField(editor);
+                            month.setSelectedIndex(0);
+                        }
+                    });
+                    return month;
                 } else {
                     return null;
                 }

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -556,8 +556,16 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
 
                         @Override
                         public void actionPerformed(ActionEvent actionEvent) {
-
-                            editor.setText((MonthUtil.getMonthByNumber(month.getSelectedIndex()).bibtexFormat));
+                            int monthnumber = month.getSelectedIndex();
+                            if (monthnumber >= 1) {
+                                if (prefs.getBoolean(JabRefPreferences.BIBLATEX_MODE)) {
+                                    editor.setText(String.valueOf(monthnumber));
+                                } else {
+                                    editor.setText((MonthUtil.getMonthByNumber(monthnumber).bibtexFormat));
+                                }
+                            } else {
+                                editor.setText("");
+                            }
                             updateField(editor);
                             month.setSelectedIndex(0);
                         }


### PR DESCRIPTION
Added a button for the month field such that one can select a month and get the correct bibtex string for that month.

Ideally there should probably be localized month names in the list, but I didn't manage to find a way to do that which still keeps the entry model independent, avoids hard coding the month names again and make sure that syncLang can find the strings.