### PR TITLE
Change default preferences: Remote server is started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
  - Update supported LookAndFeels
  - Show replaced journal abbreviations on console
  - The three options to manage file references are moved to their own separated group in the Tools menu. 
+ - Default preferences: Remote server (port 6050) always started on first JabRef instance. This prevents JabRef loaded twice when opening a bib file.
 
 ### Fixed
  - Fixed the bug that the file encoding was not correctly determined from the first (or second) line

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -740,7 +740,7 @@ public class JabRefPreferences {
         defaults.put(WRITEFIELD_USERDEFINEDORDER, "author;title;journal;year;volume;number;pages;month;note;volume;pages;part;eid");
         defaults.put(WRITEFIELD_WRAPFIELD, Boolean.FALSE);
 
-        defaults.put(RemotePreferences.USE_REMOTE_SERVER, Boolean.FALSE);
+        defaults.put(RemotePreferences.USE_REMOTE_SERVER, Boolean.TRUE);
         defaults.put(RemotePreferences.REMOTE_SERVER_PORT, 6050);
 
         defaults.put(PERSONAL_JOURNAL_LIST, null);


### PR DESCRIPTION
I think, the new default makes sense as JabRef sometimes opens twice which is a bit annoying for me.

Before resetting the preference every now and then, I had the remote server activated for a few months and it worked fine.