### PR TITLE
Change representation of encodings to Charset

### DIFF
--- a/src/main/java/net/sf/jabref/JabRef.java
+++ b/src/main/java/net/sf/jabref/JabRef.java
@@ -21,6 +21,7 @@ import com.jgoodies.looks.plastic.theme.SkyBluer;
 import java.awt.Font;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -341,13 +342,13 @@ public class JabRef {
                                 System.out.println(Localization.lang("Saving") + ": " + data[0]);
                                 SaveSession session = FileActions.saveDatabase(pr.getDatabase(), pr.getMetaData(),
                                         new File(data[0]), Globals.prefs, false, false,
-                                        Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING), false);
+                                        Charset.forName(Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING)), false);
                                 // Show just a warning message if encoding didn't work for all characters:
                                 if (!session.getWriter().couldEncodeAll()) {
                                     System.err.println(Localization.lang("Warning") + ": "
                                             + Localization.lang(
                                                     "The chosen encoding '%0' could not encode the following characters: ",
-                                                    session.getEncoding())
+                                                    session.getEncoding().displayName())
                                             + session.getWriter().getProblemCharacters());
                                 }
                                 session.commit();
@@ -428,13 +429,13 @@ public class JabRef {
                                 System.out.println(Localization.lang("Saving") + ": " + subName);
                                 SaveSession session = FileActions.saveDatabase(newBase, new MetaData(), // no Metadata
                                         new File(subName), Globals.prefs, false, false,
-                                        Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING), false);
+                                        Charset.forName(Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING)), false);
                                 // Show just a warning message if encoding didn't work for all characters:
                                 if (!session.getWriter().couldEncodeAll()) {
                                     System.err.println(Localization.lang("Warning") + ": "
                                             + Localization.lang(
                                                     "The chosen encoding '%0' could not encode the following characters: ",
-                                                    session.getEncoding())
+                                                    session.getEncoding().displayName())
                                             + session.getWriter().getProblemCharacters());
                                 }
                                 session.commit();
@@ -799,7 +800,7 @@ public class JabRef {
                 return ParserResult.FILE_LOCKED;
             }
 
-            String encoding = Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING);
+            Charset encoding = Charset.forName(Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING));
             ParserResult pr = OpenDatabaseAction.loadDatabase(file, encoding);
             if (pr == null) {
                 pr = new ParserResult(null, null, null);

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -32,6 +32,7 @@ import java.util.prefs.InvalidPreferencesFormatException;
 import java.util.prefs.Preferences;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 
 import javax.swing.*;
 
@@ -578,7 +579,7 @@ public class JabRefPreferences {
         defaults.put(HIGHLIGHT_GROUPS_MATCHING_ANY, Boolean.FALSE);
         defaults.put(HIGHLIGHT_GROUPS_MATCHING_ALL, Boolean.FALSE);
         defaults.put(TOOLBAR_VISIBLE, Boolean.TRUE);
-        defaults.put(DEFAULT_ENCODING, "UTF-8");
+        defaults.put(DEFAULT_ENCODING, StandardCharsets.UTF_8.name());
         defaults.put(GROUPS_VISIBLE_ROWS, 8);
         defaults.put(DEFAULT_OWNER, System.getProperty("user.name"));
         defaults.put(MEMORY_STICK_MODE, Boolean.FALSE);

--- a/src/main/java/net/sf/jabref/collab/ChangeScanner.java
+++ b/src/main/java/net/sf/jabref/collab/ChangeScanner.java
@@ -17,6 +17,7 @@ package net.sf.jabref.collab;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Vector;
@@ -91,11 +92,12 @@ public class ChangeScanner implements Runnable {
             // Parse the temporary file.
             File tempFile = Globals.fileUpdateMonitor.getTempFile(panel.fileMonitorHandle());
             ParserResult pr = OpenDatabaseAction.loadDatabase(tempFile,
-                    Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING));
+                    Charset.forName(Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING)));
             inTemp = pr.getDatabase();
             mdInTemp = pr.getMetaData();
             // Parse the modified file.
-            pr = OpenDatabaseAction.loadDatabase(f, Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING));
+            pr = OpenDatabaseAction.loadDatabase(f,
+                    Charset.forName(Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING)));
             BibtexDatabase onDisk = pr.getDatabase();
             MetaData mdOnDisk = pr.getMetaData();
 

--- a/src/main/java/net/sf/jabref/exporter/ExportFormat.java
+++ b/src/main/java/net/sf/jabref/exporter/ExportFormat.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.charset.Charset;
 import java.util.*;
 
 /**
@@ -43,7 +44,7 @@ public class ExportFormat implements IExportFormat {
     private String lfFileName;
     private String directory;
     private String extension;
-    String encoding; // If this value is set, it will be used to override
+    Charset encoding; // If this value is set, it will be used to override
     // the default encoding for the getCurrentBasePanel.
 
     private FileFilter fileFilter;
@@ -115,7 +116,7 @@ public class ExportFormat implements IExportFormat {
      * obtained from the basepanel.
      * @param encoding The name of the encoding to use.
      */
-    void setEncoding(String encoding) {
+    void setEncoding(Charset encoding) {
         this.encoding = encoding;
     }
 
@@ -175,7 +176,7 @@ public class ExportFormat implements IExportFormat {
     @Override
     public void performExport(final BibtexDatabase database,
             final MetaData metaData, final String file,
-            final String enc, Set<String> entryIds) throws Exception {
+            final Charset enc, Set<String> entryIds) throws Exception {
 
         File outFile = new File(file);
         SaveSession ss = null;
@@ -354,7 +355,7 @@ public class ExportFormat implements IExportFormat {
         return formatters;
     }
 
-    SaveSession getSaveSession(final String enc,
+    SaveSession getSaveSession(final Charset enc,
                                final File outFile) throws IOException {
         return new SaveSession(outFile, enc, false);
     }

--- a/src/main/java/net/sf/jabref/exporter/ExportFormats.java
+++ b/src/main/java/net/sf/jabref/exporter/ExportFormats.java
@@ -17,6 +17,7 @@ package net.sf.jabref.exporter;
 
 import java.awt.event.ActionEvent;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import javax.swing.AbstractAction;
@@ -72,7 +73,7 @@ public class ExportFormats {
         ExportFormats.putFormat(new ExportFormat(Localization.lang("OpenOffice CSV"), "oocsv", "openoffice-csv",
                 "openoffice", ".csv"));
         ExportFormat ef = new ExportFormat(Localization.lang("RIS"), "ris", "ris", "ris", ".ris");
-        ef.encoding = "UTF-8";
+        ef.encoding = StandardCharsets.UTF_8;
         ExportFormats.putFormat(ef);
         ExportFormats.putFormat(new ExportFormat(Localization.lang("MIS Quarterly"), "misq", "misq", "misq",".rtf"));
 

--- a/src/main/java/net/sf/jabref/exporter/FileActions.java
+++ b/src/main/java/net/sf/jabref/exporter/FileActions.java
@@ -23,6 +23,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.Writer;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -152,7 +153,7 @@ public class FileActions {
      *
      * @param encoding String the name of the encoding, which is part of the file header.
      */
-    private static void writeBibFileHeader(Writer out, String encoding) throws IOException {
+    private static void writeBibFileHeader(Writer out, Charset encoding) throws IOException {
         out.write("% ");
         out.write(Globals.encPrefix + encoding + Globals.NEWLINE + Globals.NEWLINE);
     }
@@ -166,7 +167,7 @@ public class FileActions {
      */
     public static SaveSession saveDatabase(BibtexDatabase database,
             MetaData metaData, File file, JabRefPreferences prefs,
-            boolean checkSearch, boolean checkGroup, String encoding, boolean suppressBackup)
+ boolean checkSearch, boolean checkGroup, Charset encoding, boolean suppressBackup)
                     throws SaveException {
 
         TreeMap<String, EntryType> types = new TreeMap<>();
@@ -182,7 +183,7 @@ public class FileActions {
             session = new SaveSession(file, encoding, backup);
         } catch (Throwable e) {
             if (encoding != null) {
-                LOGGER.error("Error from encoding: '" + encoding + "' Len: " + encoding.length(), e);
+                LOGGER.error("Error from encoding: '" + encoding.displayName(), e);
             }
             // we must catch all exceptions to be able notify users that
             // saving failed, no matter what the reason was
@@ -356,7 +357,9 @@ public class FileActions {
      * @return A List containing warnings, if any.
      */
     public static SaveSession savePartOfDatabase(BibtexDatabase database, MetaData metaData,
-            File file, JabRefPreferences prefs, BibtexEntry[] bes, String encoding, DatabaseSaveType saveType) throws SaveException {
+ File file,
+            JabRefPreferences prefs, BibtexEntry[] bes, Charset encoding, DatabaseSaveType saveType)
+                    throws SaveException {
 
         TreeMap<String, EntryType> types = new TreeMap<>(); // Map
         // to

--- a/src/main/java/net/sf/jabref/exporter/IExportFormat.java
+++ b/src/main/java/net/sf/jabref/exporter/IExportFormat.java
@@ -18,6 +18,7 @@ package net.sf.jabref.exporter;
 import net.sf.jabref.model.database.BibtexDatabase;
 import net.sf.jabref.MetaData;
 
+import java.nio.charset.Charset;
 import java.util.Set;
 
 import javax.swing.filechooser.FileFilter;
@@ -42,7 +43,7 @@ public interface IExportFormat {
 
     /**
      * Perform the export.
-     * 
+     *
      * @param database
      *            The database to export from.
      * @param metaData
@@ -57,7 +58,7 @@ public interface IExportFormat {
      * @throws Exception
      */
     void performExport(BibtexDatabase database, MetaData metaData,
-            String file, String encoding,
+ String file, Charset encoding,
             Set<String> entryIds) throws Exception;
 
 }

--- a/src/main/java/net/sf/jabref/exporter/MSBibExportFormat.java
+++ b/src/main/java/net/sf/jabref/exporter/MSBibExportFormat.java
@@ -17,6 +17,8 @@ package net.sf.jabref.exporter;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
 import javax.xml.transform.OutputKeys;
@@ -41,10 +43,11 @@ class MSBibExportFormat extends ExportFormat {
 
     @Override
     public void performExport(final BibtexDatabase database, final MetaData metaData,
-            final String file, final String encoding, Set<String> keySet) throws IOException {
+ final String file,
+            final Charset encoding, Set<String> keySet) throws IOException {
         // forcing to use UTF8 output format for some problems with
         // xml export in other encodings
-        SaveSession ss = getSaveSession("UTF8", new File(file));
+        SaveSession ss = getSaveSession(StandardCharsets.UTF_8, new File(file));
         VerifyingWriter ps = ss.getWriter();
         MSBibDatabase md = new MSBibDatabase(database, keySet);
 

--- a/src/main/java/net/sf/jabref/exporter/ModsExportFormat.java
+++ b/src/main/java/net/sf/jabref/exporter/ModsExportFormat.java
@@ -27,6 +27,8 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.OutputKeys;
 import java.util.Set;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.io.File;
 
 /**
@@ -40,8 +42,9 @@ class ModsExportFormat extends ExportFormat {
 
     @Override
     public void performExport(final BibtexDatabase database, final MetaData metaData,
-            final String file, final String encoding, Set<String> keySet) throws IOException {
-        SaveSession ss = getSaveSession("UTF8", new File(file));
+ final String file,
+            final Charset encoding, Set<String> keySet) throws IOException {
+        SaveSession ss = getSaveSession(StandardCharsets.UTF_8, new File(file));
         VerifyingWriter ps = ss.getWriter();
         MODSDatabase md = new MODSDatabase(database, keySet);
 

--- a/src/main/java/net/sf/jabref/exporter/MySQLExport.java
+++ b/src/main/java/net/sf/jabref/exporter/MySQLExport.java
@@ -15,6 +15,7 @@
 */
 package net.sf.jabref.exporter;
 
+import java.nio.charset.Charset;
 import java.util.Set;
 
 import net.sf.jabref.model.database.BibtexDatabase;
@@ -43,7 +44,7 @@ public class MySQLExport extends ExportFormat {
      */
     @Override
     public void performExport(final BibtexDatabase database, final MetaData metaData, final String file,
-            final String encodingToUse, Set<String> keySet) throws Exception {
+            final Charset encodingToUse, Set<String> keySet) throws Exception {
 
         new DBExporterAndImporterFactory().getExporter("MYSQL").exportDatabaseAsFile(database, metaData, keySet, file);
 

--- a/src/main/java/net/sf/jabref/exporter/OpenDocumentSpreadsheetCreator.java
+++ b/src/main/java/net/sf/jabref/exporter/OpenDocumentSpreadsheetCreator.java
@@ -26,6 +26,8 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.*;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
@@ -45,7 +47,7 @@ public class OpenDocumentSpreadsheetCreator extends ExportFormat {
 
     @Override
     public void performExport(final BibtexDatabase database, final MetaData metaData, final String file,
-            final String encoding, Set<String> keySet) throws Exception {
+            final Charset encoding, Set<String> keySet) throws Exception {
         OpenDocumentSpreadsheetCreator.exportOpenDocumentSpreadsheet(new File(file), database, keySet);
     }
 
@@ -103,7 +105,8 @@ public class OpenDocumentSpreadsheetCreator extends ExportFormat {
         OpenDocumentRepresentation od = new OpenDocumentRepresentation(database, keySet);
 
         try {
-            try (Writer ps = new OutputStreamWriter(new FileOutputStream(tmpFile), "UTF8")) {
+            try (Writer ps = new OutputStreamWriter(new FileOutputStream(tmpFile), StandardCharsets.UTF_8)) {
+
                 DOMSource source = new DOMSource(od.getDOMrepresentation());
                 StreamResult result = new StreamResult(ps);
                 Transformer trans = TransformerFactory.newInstance().newTransformer();

--- a/src/main/java/net/sf/jabref/exporter/OpenOfficeDocumentCreator.java
+++ b/src/main/java/net/sf/jabref/exporter/OpenOfficeDocumentCreator.java
@@ -26,6 +26,8 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.*;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -44,7 +46,8 @@ public class OpenOfficeDocumentCreator extends ExportFormat {
 
     @Override
     public void performExport(final BibtexDatabase database, final MetaData metaData,
-            final String file, final String encoding, Set<String> keySet) throws Exception {
+ final String file,
+            final Charset encoding, Set<String> keySet) throws Exception {
         OpenOfficeDocumentCreator.exportOpenOfficeCalc(new File(file), database, keySet);
     }
 
@@ -85,7 +88,7 @@ public class OpenOfficeDocumentCreator extends ExportFormat {
     private static void exportOpenOfficeCalcXML(File tmpFile, BibtexDatabase database, Set<String> keySet) {
         OOCalcDatabase od = new OOCalcDatabase(database, keySet);
 
-        try (Writer ps = new OutputStreamWriter(new FileOutputStream(tmpFile), "UTF8")) {
+        try (Writer ps = new OutputStreamWriter(new FileOutputStream(tmpFile), StandardCharsets.UTF_8)) {
             DOMSource source = new DOMSource(od.getDOMrepresentation());
             StreamResult result = new StreamResult(ps);
             Transformer trans = TransformerFactory.newInstance().newTransformer();

--- a/src/main/java/net/sf/jabref/exporter/PostgreSQLExport.java
+++ b/src/main/java/net/sf/jabref/exporter/PostgreSQLExport.java
@@ -15,6 +15,7 @@
 */
 package net.sf.jabref.exporter;
 
+import java.nio.charset.Charset;
 import java.util.Set;
 
 import net.sf.jabref.model.database.BibtexDatabase;
@@ -34,7 +35,7 @@ public class PostgreSQLExport extends ExportFormat {
 
     /**
      * First method called when user starts the export.
-     * 
+     *
      * @param database
      *            The bibtex database from which to export.
      * @param file
@@ -49,7 +50,8 @@ public class PostgreSQLExport extends ExportFormat {
      */
     @Override
     public void performExport(final BibtexDatabase database,
-            final MetaData metaData, final String file, final String encoding,
+ final MetaData metaData, final String file,
+            final Charset encoding,
             Set<String> keySet) throws Exception {
 
         new DBExporterAndImporterFactory().getExporter("POSTGRESQL").exportDatabaseAsFile(database, metaData, keySet, file);

--- a/src/main/java/net/sf/jabref/exporter/SaveDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/exporter/SaveDatabaseAction.java
@@ -35,6 +35,7 @@ import org.apache.commons.logging.LogFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Vector;
 
@@ -222,7 +223,7 @@ public class SaveDatabaseAction extends AbstractWorker {
         }
     }
 
-    private boolean saveDatabase(File file, boolean selectedOnly, String encoding) throws SaveException {
+    private boolean saveDatabase(File file, boolean selectedOnly, Charset encoding) throws SaveException {
         SaveSession session;
         frame.block();
         try {
@@ -236,7 +237,7 @@ public class SaveDatabaseAction extends AbstractWorker {
 
         } catch (UnsupportedCharsetException ex2) {
             JOptionPane.showMessageDialog(frame, Localization.lang("Could not save file.") +
-                            Localization.lang("Character encoding '%0' is not supported.", encoding),
+                            Localization.lang("Character encoding '%0' is not supported.", encoding.displayName()),
                     Localization.lang("Save database"), JOptionPane.ERROR_MESSAGE);
             throw new SaveException("rt");
         } catch (SaveException ex) {
@@ -272,7 +273,7 @@ public class SaveDatabaseAction extends AbstractWorker {
             JTextArea ta = new JTextArea(session.getWriter().getProblemCharacters());
             ta.setEditable(false);
             builder.add(Localization.lang("The chosen encoding '%0' could not encode the following characters: ",
-                    session.getEncoding())).xy(1, 1);
+                    session.getEncoding().displayName())).xy(1, 1);
             builder.add(ta).xy(3, 1);
             builder.add(Localization.lang("What do you want to do?")).xy(1, 3);
             String tryDiff = Localization.lang("Try different encoding");
@@ -287,9 +288,10 @@ public class SaveDatabaseAction extends AbstractWorker {
                 // The user wants to use another encoding.
                 Object choice = JOptionPane.showInputDialog(frame, Localization.lang("Select encoding"),
                         Localization.lang("Save database"),
-                        JOptionPane.QUESTION_MESSAGE, null, Encodings.ENCODINGS, encoding);
+ JOptionPane.QUESTION_MESSAGE, null,
+                        Encodings.ENCODINGS_DISPLAYNAMES, encoding);
                 if (choice != null) {
-                    String newEncoding = (String) choice;
+                    Charset newEncoding = Charset.forName((String) choice);
                     return saveDatabase(file, selectedOnly, newEncoding);
                 } else {
                     commit = false;

--- a/src/main/java/net/sf/jabref/exporter/SaveSession.java
+++ b/src/main/java/net/sf/jabref/exporter/SaveSession.java
@@ -25,6 +25,7 @@ import net.sf.jabref.Globals;
 import java.io.File;
 import java.io.IOException;
 import java.io.FileOutputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;
 
 import org.apache.commons.logging.Log;
@@ -55,7 +56,7 @@ public class SaveSession {
 
     private final File file;
     private final File tmp;
-    private final String encoding;
+    private final Charset encoding;
     private boolean backup;
     private final boolean useLockFile;
     private final VerifyingWriter writer;
@@ -63,7 +64,7 @@ public class SaveSession {
     private static final Log LOGGER = LogFactory.getLog(SaveSession.class);
 
 
-    public SaveSession(File file, String encoding, boolean backup) throws IOException, UnsupportedCharsetException {
+    public SaveSession(File file, Charset encoding, boolean backup) throws IOException, UnsupportedCharsetException {
         this.file = file;
         tmp = File.createTempFile(SaveSession.TEMP_PREFIX, SaveSession.TEMP_SUFFIX);
         useLockFile = Globals.prefs.getBoolean(JabRefPreferences.USE_LOCK_FILES);
@@ -83,7 +84,7 @@ public class SaveSession {
         return writer;
     }
 
-    public String getEncoding() {
+    public Charset getEncoding() {
         return encoding;
     }
 

--- a/src/main/java/net/sf/jabref/exporter/VerifyingWriter.java
+++ b/src/main/java/net/sf/jabref/exporter/VerifyingWriter.java
@@ -18,7 +18,6 @@ package net.sf.jabref.exporter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.util.TreeSet;
@@ -35,10 +34,9 @@ public class VerifyingWriter extends OutputStreamWriter {
     private final TreeSet<Character> problemCharacters = new TreeSet<>();
 
 
-    public VerifyingWriter(OutputStream out, String encoding)
-            throws UnsupportedEncodingException {
+    public VerifyingWriter(OutputStream out, Charset encoding) {
         super(out, encoding);
-        encoder = Charset.forName(encoding).newEncoder();
+        encoder = encoding.newEncoder();
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/exporter/layout/Layout.java
+++ b/src/main/java/net/sf/jabref/exporter/layout/Layout.java
@@ -20,6 +20,7 @@ import java.util.Vector;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -148,7 +149,7 @@ public class Layout {
      * string references will be replaced by the strings' contents. Even
      * recursive string references are resolved.
      */
-    public String doLayout(BibtexDatabase database, String encoding)
+    public String doLayout(BibtexDatabase database, Charset encoding)
     {
         //System.out.println("LAYOUT: " + bibtex.getId());
         StringBuilder sb = new StringBuilder(100);

--- a/src/main/java/net/sf/jabref/exporter/layout/LayoutEntry.java
+++ b/src/main/java/net/sf/jabref/exporter/layout/LayoutEntry.java
@@ -16,6 +16,7 @@
 package net.sf.jabref.exporter.layout;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -30,7 +31,6 @@ import net.sf.jabref.*;
 import net.sf.jabref.exporter.layout.format.NameFormatter;
 import net.sf.jabref.exporter.layout.format.NotFoundFormatter;
 import net.sf.jabref.gui.preftabs.NameFormatterTab;
-import net.sf.jabref.logic.l10n.Encodings;
 import net.sf.jabref.model.database.BibtexDatabase;
 import net.sf.jabref.model.entry.BibtexEntry;
 import net.sf.jabref.util.Util;
@@ -338,7 +338,7 @@ class LayoutEntry {
      *            Bibtex Database
      * @return
      */
-    public String doLayout(BibtexDatabase database, String encoding) {
+    public String doLayout(BibtexDatabase database, Charset encoding) {
         if (type == LayoutHelper.IS_LAYOUT_TEXT) {
             return text;
         } else if (type == LayoutHelper.IS_SIMPLE_FIELD) {
@@ -364,9 +364,7 @@ class LayoutEntry {
 
             return field;
         } else if (type == LayoutHelper.IS_ENCODING_NAME) {
-            // Try to translate from Java encoding name to common name:
-            String commonName = Encodings.ENCODING_NAMES_LOOKUP.get(encoding);
-            return commonName != null ? commonName : encoding;
+            return encoding.displayName();
         }
         else if (type == LayoutHelper.IS_FILENAME) {
             File f = Globals.prefs.databaseFile;

--- a/src/main/java/net/sf/jabref/gui/DatabasePropertiesDialog.java
+++ b/src/main/java/net/sf/jabref/gui/DatabasePropertiesDialog.java
@@ -18,6 +18,7 @@ package net.sf.jabref.gui;
 import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.Vector;
 
@@ -25,6 +26,7 @@ import javax.swing.AbstractAction;
 import javax.swing.ActionMap;
 import javax.swing.BorderFactory;
 import javax.swing.ButtonGroup;
+import javax.swing.DefaultComboBoxModel;
 import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -92,7 +94,8 @@ public class DatabasePropertiesDialog extends JDialog {
 
     public DatabasePropertiesDialog(JFrame parent) {
         super(parent, Localization.lang("Database properties"), true);
-        encoding = new JComboBox<>(Encodings.ENCODINGS);
+        encoding = new JComboBox<>();
+        encoding.setModel(new DefaultComboBoxModel(Encodings.ENCODINGS));
         ok = new JButton(Localization.lang("Ok"));
         cancel = new JButton(Localization.lang("Cancel"));
         init(parent);
@@ -394,8 +397,8 @@ public class DatabasePropertiesDialog extends JDialog {
             metaData.putData(DatabasePropertiesDialog.SAVE_ORDER_CONFIG, serialized);
         }
 
-        String oldEncoding = panel.getEncoding();
-        String newEncoding = (String) encoding.getSelectedItem();
+        Charset oldEncoding = panel.getEncoding();
+        Charset newEncoding = Charset.forName((String) encoding.getSelectedItem());
         panel.setEncoding(newEncoding);
 
         Vector<String> dir = new Vector<>(1);

--- a/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
@@ -26,6 +26,7 @@ import java.awt.event.MouseListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -726,7 +727,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
                     // Create a new BasePanel for the entries:
                     BibtexDatabase base = new BibtexDatabase();
                     panel = new BasePanel(frame, base, null, new MetaData(),
-                            Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING));
+                            Charset.forName(Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING)));
                 }
 
                 boolean groupingCanceled = false;

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -33,6 +33,7 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -1594,13 +1595,13 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         }
     }
 
-    public BasePanel addTab(BibtexDatabase db, File file, MetaData metaData, String encoding, boolean raisePanel) {
+    public BasePanel addTab(BibtexDatabase db, File file, MetaData metaData, Charset encoding, boolean raisePanel) {
         // ensure that non-null parameters are really non-null
         if (metaData == null) {
             metaData = new MetaData();
         }
         if (encoding == null) {
-            encoding = Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING);
+            encoding = Charset.forName(Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING));
         }
 
         BasePanel bp = new BasePanel(JabRefFrame.this, db, file, metaData, encoding);

--- a/src/main/java/net/sf/jabref/gui/actions/NewDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/NewDatabaseAction.java
@@ -10,12 +10,13 @@ import net.sf.jabref.model.database.BibtexDatabase;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;
+import java.nio.charset.Charset;
 
 /**
  * The action concerned with opening a new database.
  */
 public class NewDatabaseAction extends MnemonicAwareAction {
-    private JabRefFrame jabRefFrame;
+    private final JabRefFrame jabRefFrame;
 
     public NewDatabaseAction(JabRefFrame jabRefFrame) {
         super(IconTheme.JabRefIcon.NEW.getIcon());
@@ -29,7 +30,8 @@ public class NewDatabaseAction extends MnemonicAwareAction {
     public void actionPerformed(ActionEvent e) {
         // Create a new, empty, database.
         BibtexDatabase database = new BibtexDatabase();
-        jabRefFrame.addTab(database, null, new MetaData(), Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING), true);
+        jabRefFrame.addTab(database, null, new MetaData(),
+                Charset.forName(Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING)), true);
         jabRefFrame.output(Localization.lang("New database created."));
     }
 }

--- a/src/main/java/net/sf/jabref/gui/actions/NewSubDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/NewSubDatabaseAction.java
@@ -10,6 +10,7 @@ import net.sf.jabref.wizard.auximport.gui.FromAuxDialog;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;
+import java.nio.charset.Charset;
 
 /**
  * The action concerned with generate a new (sub-)database from latex aux file.
@@ -38,7 +39,7 @@ public class NewSubDatabaseAction extends MnemonicAwareAction {
             BasePanel bp = new BasePanel(jabRefFrame,
                     dialog.getGenerateDB(), // database
                     null, // file
-                    new MetaData(), Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING)); // meta data
+                    new MetaData(), Charset.forName(Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING))); // meta data
             jabRefFrame.tabbedPane.add(GUIGlobals.untitledTitle, bp);
             jabRefFrame.tabbedPane.setSelectedComponent(bp);
             jabRefFrame.output(Localization.lang("New database created."));

--- a/src/main/java/net/sf/jabref/gui/preftabs/GeneralTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/GeneralTab.java
@@ -16,9 +16,11 @@
 package net.sf.jabref.gui.preftabs;
 
 import java.awt.BorderLayout;
+import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
 
 import javax.swing.BorderFactory;
+import javax.swing.DefaultComboBoxModel;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
@@ -66,7 +68,8 @@ class GeneralTab extends JPanel implements PrefsTab {
     private final JTextField timeStampField;
     private final JabRefPreferences prefs;
     private final JComboBox<String> language = new JComboBox<>(LANGUAGES.keySet().toArray(new String[LANGUAGES.keySet().size()]));
-    private final JComboBox<String> encodings = new JComboBox<>(Encodings.ENCODINGS);
+    private final JComboBox<String> encodings;
+    private final DefaultComboBoxModel encodingsModel;
 
 
     public GeneralTab(JabRefFrame frame, JabRefPreferences prefs) {
@@ -107,6 +110,9 @@ class GeneralTab extends JPanel implements PrefsTab {
         timeStampField = new JTextField();
         inspectionWarnDupli = new JCheckBox(Localization.lang("Warn about unresolved duplicates when closing inspection window"));
 
+        encodings = new JComboBox<>();
+        encodingsModel = new DefaultComboBoxModel(Encodings.ENCODINGS);
+        encodings.setModel(encodingsModel);
 
         FormLayout layout = new FormLayout
                 ("8dlu, 1dlu, left:170dlu, 4dlu, fill:pref, 4dlu, fill:pref, 4dlu, left:pref, 4dlu, left:pref, 4dlu, left:pref", "");
@@ -194,13 +200,9 @@ class GeneralTab extends JPanel implements PrefsTab {
         markImportedEntries.setSelected(prefs.getBoolean(JabRefPreferences.MARK_IMPORTED_ENTRIES));
         unmarkAllEntriesBeforeImporting.setSelected(prefs.getBoolean(JabRefPreferences.UNMARK_ALL_ENTRIES_BEFORE_IMPORTING));
 
-        String enc = prefs.get(JabRefPreferences.DEFAULT_ENCODING);
-        for (int i = 0; i < Encodings.ENCODINGS.length; i++) {
-            if (Encodings.ENCODINGS[i].equalsIgnoreCase(enc)) {
-                encodings.setSelectedIndex(i);
-                break;
-            }
-        }
+        Charset enc = Charset.forName(prefs.get(JabRefPreferences.DEFAULT_ENCODING));
+        encodingsModel.setSelectedItem(enc);
+
         String oldLan = prefs.get(JabRefPreferences.LANGUAGE);
 
         // Language choice

--- a/src/main/java/net/sf/jabref/importer/AppendDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/AppendDatabaseAction.java
@@ -16,6 +16,7 @@
 package net.sf.jabref.importer;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -104,7 +105,7 @@ public class AppendDatabaseAction implements BaseAction {
             try {
                 Globals.prefs.put(JabRefPreferences.WORKING_DIRECTORY, file.getPath());
                 // Should this be done _after_ we know it was successfully opened?
-                String encoding = Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING);
+                Charset encoding = Charset.forName(Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING));
                 ParserResult pr = OpenDatabaseAction.loadDatabase(file, encoding);
                 AppendDatabaseAction.mergeFromBibtex(frame, panel, pr, importEntries, importStrings,
                         importGroups, importSelectorWords);

--- a/src/main/java/net/sf/jabref/importer/ImportFormatReader.java
+++ b/src/main/java/net/sf/jabref/importer/ImportFormatReader.java
@@ -16,6 +16,8 @@
 package net.sf.jabref.importer;
 
 import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import net.sf.jabref.importer.fileformat.*;
@@ -334,16 +336,16 @@ public class ImportFormatReader {
     }
 
     public static InputStreamReader getUTF8Reader(File f) throws IOException {
-        return getReader(f, "UTF-8");
+        return getReader(f, StandardCharsets.UTF_8);
     }
 
     public static InputStreamReader getUTF16Reader(File f) throws IOException {
-        return getReader(f, "UTF-16");
+        return getReader(f, StandardCharsets.UTF_16);
     }
 
-    public static InputStreamReader getReader(File f, String encoding)
+    public static InputStreamReader getReader(File f, Charset charset)
             throws IOException {
-        return new InputStreamReader(new FileInputStream(f), encoding);
+        return new InputStreamReader(new FileInputStream(f), charset);
     }
 
     public static Reader getReaderDefaultEncoding(InputStream in)
@@ -438,7 +440,7 @@ public class ImportFormatReader {
         // Finally, if all else fails, see if it is a BibTeX file:
         try {
             ParserResult pr = OpenDatabaseAction.loadDatabase(new File(filename),
-                    Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING));
+                    Charset.forName(Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING)));
             if ((pr.getDatabase().getEntryCount() > 0)
                     || (pr.getDatabase().getStringCount() > 0)) {
                 pr.setFile(new File(filename));

--- a/src/main/java/net/sf/jabref/importer/ImportMenuItem.java
+++ b/src/main/java/net/sf/jabref/importer/ImportMenuItem.java
@@ -19,6 +19,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -36,7 +37,6 @@ import net.sf.jabref.importer.fileformat.ImportFormat;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibtexDatabase;
 import net.sf.jabref.model.entry.BibtexEntry;
-import net.sf.jabref.model.entry.BibtexEntryType;
 import net.sf.jabref.model.entry.BibtexString;
 import net.sf.jabref.model.entry.EntryType;
 import net.sf.jabref.util.Util;
@@ -194,7 +194,8 @@ public class ImportMenuItem extends JMenuItem implements ActionListener {
                     diag.setVisible(true);
                     diag.toFront();
                 } else {
-                    frame.addTab(bibtexResult.getDatabase(), bibtexResult.getFile(), bibtexResult.getMetaData(), Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING), true);
+                    frame.addTab(bibtexResult.getDatabase(), bibtexResult.getFile(), bibtexResult.getMetaData(),
+                            Charset.forName(Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING)), true);
                     frame.output(Localization.lang("Imported entries") + ": " + bibtexResult.getDatabase().getEntryCount());
                 }
             } else {

--- a/src/main/java/net/sf/jabref/importer/ParserResult.java
+++ b/src/main/java/net/sf/jabref/importer/ParserResult.java
@@ -16,7 +16,8 @@
 package net.sf.jabref.importer;
 
 import java.io.File;
-import net.sf.jabref.model.entry.BibtexEntryType;
+import java.nio.charset.Charset;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -38,7 +39,7 @@ public class ParserResult {
 
     private String errorMessage;
     // Which encoding was used?
-    private String encoding;
+    private Charset encoding;
 
     private boolean postponedAutosaveFound;
     private boolean invalid;
@@ -136,17 +137,17 @@ public class ParserResult {
     /**
      * Sets the variable indicating which encoding was used during parsing.
      *
-     * @param enc String the name of the encoding.
+     * @param enc the encoding.
      */
-    public void setEncoding(String enc) {
+    public void setEncoding(Charset enc) {
         encoding = enc;
     }
 
     /**
-     * Returns the name of the encoding used during parsing, or null if not specified
-     * (indicates that prefs.get(JabRefPreferences.DEFAULT_ENCODING) was used).
+     * Returns the encoding used during parsing, or null if not specified (indicates that
+     * prefs.get(JabRefPreferences.DEFAULT_ENCODING) was used).
      */
-    public String getEncoding() {
+    public Charset getEncoding() {
         return encoding;
     }
 

--- a/src/main/java/net/sf/jabref/importer/fetcher/BibsonomyScraper.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/BibsonomyScraper.java
@@ -23,6 +23,7 @@ import net.sf.jabref.logic.net.URLDownload;
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Convenience class for getting BibTeX entries from the BibSonomy scraper,
@@ -45,10 +46,10 @@ class BibsonomyScraper {
             entryUrl = entryUrl.replaceAll("%", "%25").replaceAll(":", "%3A").replaceAll("/", "%2F").replaceAll("\\?", "%3F").replaceAll("&", "%26").replaceAll("=", "%3D");
 
             URL url = new URL(BibsonomyScraper.BIBSONOMY_SCRAPER + entryUrl + BibsonomyScraper.BIBSONOMY_SCRAPER_POST);
-            String bibtex = new URLDownload(url).downloadToString("UTF8");
+            String bibtex = new URLDownload(url).downloadToString(StandardCharsets.UTF_8);
             BibtexParser bp = new BibtexParser(new StringReader(bibtex));
             ParserResult pr = bp.parse();
-            if (pr != null && pr.getDatabase().getEntryCount() > 0) {
+            if ((pr != null) && (pr.getDatabase().getEntryCount() > 0)) {
                 return pr.getDatabase().getEntries().iterator().next();
             } else {
                 return null;

--- a/src/main/java/net/sf/jabref/importer/fetcher/CiteSeerXFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/CiteSeerXFetcher.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -100,7 +101,8 @@ public class CiteSeerXFetcher implements EntryFetcher {
         String urlQuery;
         ArrayList<String> ids = new ArrayList<>();
         try {
-            urlQuery = CiteSeerXFetcher.SEARCH_URL.replace(CiteSeerXFetcher.QUERY_MARKER, URLEncoder.encode(query, "UTF-8"));
+            urlQuery = CiteSeerXFetcher.SEARCH_URL.replace(CiteSeerXFetcher.QUERY_MARKER,
+                    URLEncoder.encode(query, StandardCharsets.UTF_8.name()));
             int count = 1;
             String nextPage;
             while (((nextPage = getCitationsFromUrl(urlQuery, ids)) != null)
@@ -140,7 +142,7 @@ public class CiteSeerXFetcher implements EntryFetcher {
     private static BibtexEntry getSingleCitation(String urlString) throws IOException {
 
         URL url = new URL(urlString);
-        String cont = new URLDownload(url).downloadToString("UTF8");
+        String cont = new URLDownload(url).downloadToString(StandardCharsets.UTF_8);
 
         // Find title, and create entry if we do. Otherwise assume we didn't get an entry:
         Matcher m = CiteSeerXFetcher.titlePattern.matcher(cont);

--- a/src/main/java/net/sf/jabref/importer/fetcher/DOItoBibTeXFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/DOItoBibTeXFetcher.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -105,7 +106,7 @@ public class DOItoBibTeXFetcher implements EntryFetcher {
 
         String bibtexString;
         try {
-            bibtexString = Util.getResultsWithEncoding(conn, "UTF8");
+            bibtexString = Util.getResultsWithEncoding(conn, StandardCharsets.UTF_8);
         } catch (FileNotFoundException e) {
 
             if (status != null) {

--- a/src/main/java/net/sf/jabref/importer/fetcher/DiVAtoBibTeXFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/DiVAtoBibTeXFetcher.java
@@ -20,6 +20,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -49,7 +50,7 @@ public class DiVAtoBibTeXFetcher implements EntryFetcher {
     public boolean processQuery(String query, ImportInspector inspector, OutputPrinter status) {
         String q;
         try {
-            q = URLEncoder.encode(query, "UTF-8");
+            q = URLEncoder.encode(query, StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             // this should never happen
             status.setStatus(Localization.lang("Error"));
@@ -70,7 +71,7 @@ public class DiVAtoBibTeXFetcher implements EntryFetcher {
 
         String bibtexString;
         try {
-            bibtexString = Util.getResultsWithEncoding(url, "UTF-8");
+            bibtexString = Util.getResultsWithEncoding(url, StandardCharsets.UTF_8);
         } catch (FileNotFoundException e) {
             status.showMessage(Localization.lang("Unknown DiVA entry: '%0'.",
                             query),

--- a/src/main/java/net/sf/jabref/importer/fetcher/GVKFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/GVKFetcher.java
@@ -26,6 +26,7 @@ import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibtexEntry;
 
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Fetch or search from GVK http://gso.gbv.de/sru/DB=2.1/
@@ -90,7 +91,7 @@ public class GVKFetcher implements EntryFetcher {
         // Jeden einzelnen Suchbegriff URL-Encodieren
         for (int x = 0; x < qterms.length; x++) {
             try {
-                qterms[x] = URLEncoder.encode(qterms[x], "UTF-8");
+                qterms[x] = URLEncoder.encode(qterms[x], StandardCharsets.UTF_8.name());
             } catch (UnsupportedEncodingException e) {
                 LOGGER.error("Unsupported encoding", e);
             }

--- a/src/main/java/net/sf/jabref/importer/fetcher/GoogleScholarFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/GoogleScholarFetcher.java
@@ -33,6 +33,7 @@ import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -197,7 +198,8 @@ public class GoogleScholarFetcher implements PreviewEntryFetcher {
         String urlQuery;
         LinkedHashMap<String, JLabel> res = new LinkedHashMap<>();
         try {
-            urlQuery = GoogleScholarFetcher.SEARCH_URL.replace(GoogleScholarFetcher.QUERY_MARKER, URLEncoder.encode(query, "UTF-8"));
+            urlQuery = GoogleScholarFetcher.SEARCH_URL.replace(GoogleScholarFetcher.QUERY_MARKER,
+                    URLEncoder.encode(query, StandardCharsets.UTF_8.name()));
             int count = 1;
             String nextPage;
             while (((nextPage = getCitationsFromUrl(urlQuery, res)) != null)

--- a/src/main/java/net/sf/jabref/importer/fetcher/INSPIREFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/INSPIREFetcher.java
@@ -22,6 +22,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -62,7 +63,7 @@ public class INSPIREFetcher implements EntryFetcher {
     private String constructUrl(String key) {
         String identifier;
         try {
-            identifier = URLEncoder.encode(key, "UTF-8");
+            identifier = URLEncoder.encode(key, StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             return "";
         }

--- a/src/main/java/net/sf/jabref/importer/fetcher/ISBNtoBibTeXFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/ISBNtoBibTeXFetcher.java
@@ -20,6 +20,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 
 import javax.swing.JPanel;
@@ -52,7 +53,7 @@ public class ISBNtoBibTeXFetcher implements EntryFetcher {
     public boolean processQuery(String query, ImportInspector inspector, OutputPrinter status) {
         String q;
         try {
-            q = URLEncoder.encode(query, "UTF-8");
+            q = URLEncoder.encode(query, StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             // this should never happen
             status.setStatus(Localization.lang("Error"));
@@ -76,7 +77,7 @@ public class ISBNtoBibTeXFetcher implements EntryFetcher {
             try(Scanner scan = new Scanner(source)) {
                 bibtexString = scan.useDelimiter("\\A").next();
             }
-            
+
             BibtexEntry entry = BibtexParser.singleFromString(bibtexString);
             if (entry != null) {
                 // Optionally add curly brackets around key words to keep the case

--- a/src/main/java/net/sf/jabref/importer/fetcher/JSTORFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/JSTORFetcher.java
@@ -23,6 +23,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.StringTokenizer;
 
@@ -186,7 +187,8 @@ public class JSTORFetcher implements EntryFetcher {
         String urlQuery;
         try {
             urlQuery = "http://www.jstor.org/search/BasicResults?hp=" + JSTORFetcher.MAX_CITATIONS +
-                    "&si=1&gw=jtx&jtxsi=1&jcpsi=1&artsi=1&Query=" + URLEncoder.encode(query, "UTF-8") +
+ "&si=1&gw=jtx&jtxsi=1&jcpsi=1&artsi=1&Query="
+                    + URLEncoder.encode(query, StandardCharsets.UTF_8.name()) +
                     "&wc=on&citationAction=saveAll";
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);

--- a/src/main/java/net/sf/jabref/importer/fetcher/JSTORFetcher2.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/JSTORFetcher2.java
@@ -25,6 +25,7 @@ import javax.swing.*;
 import java.io.*;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -135,7 +136,8 @@ public class JSTORFetcher2 implements EntryFetcher {
         String urlQuery;
         ArrayList<String> ids = new ArrayList<>();
         try {
-            urlQuery = JSTORFetcher2.SEARCH_URL + URLEncoder.encode(query, "UTF-8") + JSTORFetcher2.SEARCH_URL_END;
+            urlQuery = JSTORFetcher2.SEARCH_URL + URLEncoder.encode(query, StandardCharsets.UTF_8.name())
+                    + JSTORFetcher2.SEARCH_URL_END;
             int count = 1;
             String[] numberOfRefs = new String[2];
             int refsRequested;

--- a/src/main/java/net/sf/jabref/importer/fetcher/OAI2Fetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/OAI2Fetcher.java
@@ -21,6 +21,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 import javax.swing.JOptionPane;
@@ -147,7 +148,7 @@ public class OAI2Fetcher implements EntryFetcher {
     public String constructUrl(String key) {
         String identifier;
         try {
-            identifier = URLEncoder.encode(key, "UTF-8");
+            identifier = URLEncoder.encode(key, StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             return "";
         }

--- a/src/main/java/net/sf/jabref/importer/fetcher/ScienceDirectFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/ScienceDirectFetcher.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -117,7 +118,7 @@ public class ScienceDirectFetcher implements EntryFetcher {
         String urlQuery;
         ArrayList<String> ids = new ArrayList<>();
         try {
-            urlQuery = ScienceDirectFetcher.SEARCH_URL + URLEncoder.encode(query, "UTF-8");
+            urlQuery = ScienceDirectFetcher.SEARCH_URL + URLEncoder.encode(query, StandardCharsets.UTF_8.name());
             int count = 1;
             String nextPage;
             while (((nextPage = getCitationsFromUrl(urlQuery, ids)) != null)

--- a/src/main/java/net/sf/jabref/importer/fileformat/FreeCiteImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/FreeCiteImporter.java
@@ -23,6 +23,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
@@ -66,7 +67,7 @@ public class FreeCiteImporter extends ImportFormat {
         // URLencode the string for transmission
         String urlencodedCitation = null;
         try {
-            urlencodedCitation = URLEncoder.encode(text, "UTF-8");
+            urlencodedCitation = URLEncoder.encode(text, StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             // e.printStackTrace();
         }

--- a/src/main/java/net/sf/jabref/logic/fetcher/GoogleScholar.java
+++ b/src/main/java/net/sf/jabref/logic/fetcher/GoogleScholar.java
@@ -10,6 +10,7 @@ import org.jsoup.select.Elements;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -34,7 +35,7 @@ public class GoogleScholar implements FullTextFinder {
             return pdfLink;
         }
 
-        String url = String.format(SEARCH_URL, URLEncoder.encode(entryTitle, "UTF-8"));
+        String url = String.format(SEARCH_URL, URLEncoder.encode(entryTitle, StandardCharsets.UTF_8.name()));
 
         Document doc = Jsoup.connect(url)
                 .userAgent("Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0") // don't identify as a crawler

--- a/src/main/java/net/sf/jabref/logic/l10n/EncodingControl.java
+++ b/src/main/java/net/sf/jabref/logic/l10n/EncodingControl.java
@@ -9,6 +9,7 @@ import java.util.ResourceBundle;
 import java.util.ResourceBundle.Control;
 import java.util.Locale;
 import java.net.URLConnection;
+import java.nio.charset.Charset;
 
 /**
  * {@link Control} class allowing properties bundles to be in different encodings.
@@ -17,9 +18,11 @@ import java.net.URLConnection;
  *      and property files</a>
  */
 public class EncodingControl extends Control {
-    private final String encoding;
 
-    public EncodingControl(String encoding) {
+    private final Charset encoding;
+
+
+    public EncodingControl(Charset encoding) {
         this.encoding = encoding;
     }
 

--- a/src/main/java/net/sf/jabref/logic/l10n/Encodings.java
+++ b/src/main/java/net/sf/jabref/logic/l10n/Encodings.java
@@ -1,87 +1,20 @@
 package net.sf.jabref.logic.l10n;
 
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.stream.Collectors;
 
 public class Encodings {
 
-    public static final String[] ALL_ENCODINGS =
-            new String[] {"ISO8859-1", "UTF-8", "UTF-16", "ASCII", "CP1250", "CP1251", "CP1252",
-                    "CP1253", "CP1254", "CP1257", "SJIS",
-                    "KOI8-R", // Cyrillic
-                    "EUC-JP", // Added Japanese encodings
-                    "Big5", "Big5-HKSCS", "GBK", "ISO8859-2", "ISO8859-3", "ISO8859-4", "ISO8859-5",
-                    "ISO8859-6", "ISO8859-7", "ISO8859-8", "ISO8859-9", "ISO8859-13", "ISO8859-15"};
-
-    public static final String[] ENCODINGS;
-    public static final Map<String, String> ENCODING_NAMES_LOOKUP;
+    public static final Charset[] ENCODINGS;
+    public static final String[] ENCODINGS_DISPLAYNAMES;
 
     static {
-        // Build list of encodings, by filtering out all that are not supported
-        // on this system:
-        List<String> encodings = new ArrayList<>();
-        for (String ALL_ENCODING : ALL_ENCODINGS) {
-            if (Charset.isSupported(ALL_ENCODING)) {
-                encodings.add(ALL_ENCODING);
-            }
-        }
-        ENCODINGS = encodings.toArray(new String[encodings.size()]);
-        // Build a map for translating Java encoding names into common encoding names:
-        ENCODING_NAMES_LOOKUP = new HashMap<>();
-
-        // old mispelled encoding mappings, kept for compatibility with v2.10 downwards
-        ENCODING_NAMES_LOOKUP.put("Cp1250", "windows-1250");
-        ENCODING_NAMES_LOOKUP.put("Cp1251", "windows-1251");
-        ENCODING_NAMES_LOOKUP.put("Cp1252", "windows-1252");
-        ENCODING_NAMES_LOOKUP.put("Cp1253", "windows-1253");
-        ENCODING_NAMES_LOOKUP.put("Cp1254", "windows-1254");
-        ENCODING_NAMES_LOOKUP.put("Cp1257", "windows-1257");
-        ENCODING_NAMES_LOOKUP.put("ISO8859_1", "ISO-8859-1");
-        ENCODING_NAMES_LOOKUP.put("ISO8859_2", "ISO-8859-2");
-        ENCODING_NAMES_LOOKUP.put("ISO8859_3", "ISO-8859-3");
-        ENCODING_NAMES_LOOKUP.put("ISO8859_4", "ISO-8859-4");
-        ENCODING_NAMES_LOOKUP.put("ISO8859_5", "ISO-8859-5");
-        ENCODING_NAMES_LOOKUP.put("ISO8859_6", "ISO-8859-6");
-        ENCODING_NAMES_LOOKUP.put("ISO8859_7", "ISO-8859-7");
-        ENCODING_NAMES_LOOKUP.put("ISO8859_8", "ISO-8859-8");
-        ENCODING_NAMES_LOOKUP.put("ISO8859_9", "ISO-8859-9");
-        ENCODING_NAMES_LOOKUP.put("ISO8859_13", "ISO-8859-13");
-        ENCODING_NAMES_LOOKUP.put("ISO8859_15", "ISO-8859-15");
-        ENCODING_NAMES_LOOKUP.put("KOI8_R", "KOI8-R");
-        ENCODING_NAMES_LOOKUP.put("UTF8", "UTF-8");
-        ENCODING_NAMES_LOOKUP.put("Big5_HKSCS", "Big5-HKSCS");
-        ENCODING_NAMES_LOOKUP.put("EUC_JP", "EUC-JP");
-
-        // correct encoding name mappings
-        ENCODING_NAMES_LOOKUP.put("CP1250", "windows-1250");
-        ENCODING_NAMES_LOOKUP.put("CP1251", "windows-1251");
-        ENCODING_NAMES_LOOKUP.put("CP1252", "windows-1252");
-        ENCODING_NAMES_LOOKUP.put("CP1253", "windows-1253");
-        ENCODING_NAMES_LOOKUP.put("CP1254", "windows-1254");
-        ENCODING_NAMES_LOOKUP.put("CP1257", "windows-1257");
-        ENCODING_NAMES_LOOKUP.put("ISO8859-1", "ISO-8859-1");
-        ENCODING_NAMES_LOOKUP.put("ISO8859-2", "ISO-8859-2");
-        ENCODING_NAMES_LOOKUP.put("ISO8859-3", "ISO-8859-3");
-        ENCODING_NAMES_LOOKUP.put("ISO8859-4", "ISO-8859-4");
-        ENCODING_NAMES_LOOKUP.put("ISO8859-5", "ISO-8859-5");
-        ENCODING_NAMES_LOOKUP.put("ISO8859-6", "ISO-8859-6");
-        ENCODING_NAMES_LOOKUP.put("ISO8859-7", "ISO-8859-7");
-        ENCODING_NAMES_LOOKUP.put("ISO8859-8", "ISO-8859-8");
-        ENCODING_NAMES_LOOKUP.put("ISO8859-9", "ISO-8859-9");
-        ENCODING_NAMES_LOOKUP.put("ISO8859-13", "ISO-8859-13");
-        ENCODING_NAMES_LOOKUP.put("ISO8859-15", "ISO-8859-15");
-        ENCODING_NAMES_LOOKUP.put("KOI8-R", "KOI8-R");
-        ENCODING_NAMES_LOOKUP.put("UTF-8", "UTF-8");
-        ENCODING_NAMES_LOOKUP.put("Big5-HKSCS", "Big5-HKSCS");
-        ENCODING_NAMES_LOOKUP.put("EUC-JP", "EUC-JP");
-
-        ENCODING_NAMES_LOOKUP.put("UTF-16", "UTF-16");
-        ENCODING_NAMES_LOOKUP.put("SJIS", "Shift_JIS");
-        ENCODING_NAMES_LOOKUP.put("GBK", "GBK");
-        ENCODING_NAMES_LOOKUP.put("Big5", "Big5");
-        ENCODING_NAMES_LOOKUP.put("ASCII", "US-ASCII");
+        List<Charset> encodingsList = Charset.availableCharsets().values().stream().distinct()
+                .collect(Collectors.toList());
+        List<String> encodingsStringList = encodingsList.stream().map(c -> c.displayName()).distinct()
+                .collect(Collectors.toList());
+        ENCODINGS = encodingsList.toArray(new Charset[encodingsList.size()]);
+        ENCODINGS_DISPLAYNAMES = encodingsStringList.toArray(new String[encodingsStringList.size()]);
     }
 }

--- a/src/main/java/net/sf/jabref/logic/l10n/Localization.java
+++ b/src/main/java/net/sf/jabref/logic/l10n/Localization.java
@@ -3,6 +3,7 @@ package net.sf.jabref.logic.l10n;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 public class Localization {
@@ -20,8 +21,9 @@ public class Localization {
         Locale locale = new Locale(language);
 
         try {
-            messages = ResourceBundle.getBundle(RESOURCE_PREFIX, locale, new EncodingControl("UTF-8"));
-            menuTitles = ResourceBundle.getBundle(MENU_RESOURCE_PREFIX, locale, new EncodingControl("UTF-8"));
+            messages = ResourceBundle.getBundle(RESOURCE_PREFIX, locale, new EncodingControl(StandardCharsets.UTF_8));
+            menuTitles = ResourceBundle.getBundle(MENU_RESOURCE_PREFIX, locale,
+                    new EncodingControl(StandardCharsets.UTF_8));
 
             // silent fallback to system locale when bundle is not found
             if(!messages.getLocale().equals(locale)) {
@@ -32,8 +34,9 @@ public class Localization {
                     + "> failed, using locale <en> instead", e);
 
             locale = new Locale("en");
-            messages = ResourceBundle.getBundle(RESOURCE_PREFIX, locale, new EncodingControl("UTF-8"));
-            menuTitles = ResourceBundle.getBundle(MENU_RESOURCE_PREFIX, locale, new EncodingControl("UTF-8"));
+            messages = ResourceBundle.getBundle(RESOURCE_PREFIX, locale, new EncodingControl(StandardCharsets.UTF_8));
+            menuTitles = ResourceBundle.getBundle(MENU_RESOURCE_PREFIX, locale,
+                    new EncodingControl(StandardCharsets.UTF_8));
         } finally {
             // Set consistent VM locales
             Locale.setDefault(locale);

--- a/src/main/java/net/sf/jabref/logic/net/URLDownload.java
+++ b/src/main/java/net/sf/jabref/logic/net/URLDownload.java
@@ -24,6 +24,7 @@ import java.io.*;
 import java.net.CookieHandler;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.Charset;
 
 /**
  * Each call to a public method creates a new HTTP connection. Nothing is cached.
@@ -100,10 +101,10 @@ public class URLDownload {
      * @throws IOException
      */
     public String downloadToString() throws IOException {
-        return downloadToString(Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING));
+        return downloadToString(Charset.forName(Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING)));
     }
 
-    public String downloadToString(String encoding) throws IOException {
+    public String downloadToString(Charset encoding) throws IOException {
 
         try (InputStream input = new BufferedInputStream(openConnection().getInputStream());
              Writer output = new StringWriter()) {
@@ -115,7 +116,7 @@ public class URLDownload {
         }
     }
 
-    private void copy(InputStream in, Writer out, String encoding) throws IOException {
+    private void copy(InputStream in, Writer out, Charset encoding) throws IOException {
         InputStream monitoredInputStream = monitorInputStream(in);
         Reader r = new InputStreamReader(monitoredInputStream, encoding);
         try (BufferedReader read = new BufferedReader(r)) {

--- a/src/main/java/net/sf/jabref/logic/util/io/URLUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/URLUtil.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -68,7 +69,7 @@ public class URLUtil {
                 if (pair.startsWith("url=")) {
                     String value = pair.substring(pair.indexOf("=") + 1, pair.length());
 
-                    String decode = URLDecoder.decode(value, "UTF-8");
+                    String decode = URLDecoder.decode(value, StandardCharsets.UTF_8.name());
                     // url?
                     if(decode.matches(URL_EXP)) {
                         return decode;
@@ -93,12 +94,12 @@ public class URLUtil {
      */
     public static String sanitizeUrl(String link) {
         link = link.trim();
-    
+
         // First check if it is enclosed in \\url{}. If so, remove the wrapper.
         if (link.startsWith("\\url{") && link.endsWith("}")) {
             link = link.substring(5, link.length() - 1);
         }
-    
+
         // DOI cleanup
         // converts doi-only link to full http address
         // Morten Alver 6 Nov 2012: this extracts a nonfunctional Doi from some complete
@@ -112,21 +113,21 @@ public class URLUtil {
             link = link.replaceFirst("^doi:/*", "");
             link = new DOI(link).getURLAsASCIIString();
         }
-    
+
         Optional<DOI> doi = DOI.build(link);
         if (doi.isPresent() && !link.matches("^https?://.*")) {
             link = doi.get().getURLAsASCIIString();
         }
-    
+
         // FIXME: everything below is really flawed atm
         link = link.replaceAll("\\+", "%2B");
-    
+
         try {
-            link = URLDecoder.decode(link, "UTF-8");
+            link = URLDecoder.decode(link, StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException ignored) {
             // Ignored
         }
-    
+
         /**
          * Fix for: [ 1574773 ] sanitizeUrl() breaks ftp:// and file:///
          *

--- a/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
@@ -16,13 +16,8 @@
 package net.sf.jabref.logic.util.strings;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.logic.l10n.Encodings;
-
-import java.nio.charset.Charset;
-import java.nio.charset.CharsetEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -284,26 +279,6 @@ public class StringUtil {
 
     public static String booleanToBinaryString(boolean expression) {
         return expression ? "1" : "0";
-    }
-
-    /**
-     * Make a list of supported character encodings that can encode all
-     * characters in the given String.
-     *
-     * @param characters
-     *            A String of characters that should be supported by the
-     *            encodings.
-     * @return A List of character encodings
-     */
-    public static List<String> findEncodingsForString(String characters) {
-        List<String> encodings = new ArrayList<>();
-        for (int i = 0; i < Encodings.ENCODINGS.length; i++) {
-            CharsetEncoder encoder = Charset.forName(Encodings.ENCODINGS[i]).newEncoder();
-            if (encoder.canEncode(characters)) {
-                encodings.add(Encodings.ENCODINGS[i]);
-            }
-        }
-        return encodings;
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/xmp/XMPUtil.java
+++ b/src/main/java/net/sf/jabref/logic/xmp/XMPUtil.java
@@ -16,6 +16,7 @@
 package net.sf.jabref.logic.xmp;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import javax.xml.transform.TransformerException;
@@ -1222,7 +1223,7 @@ public class XMPUtil {
                     System.err
                     .println("The given pdf does not contain any XMP-metadata.");
                 } else {
-                    XMLUtil.save(meta.getXMPDocument(), System.out, "UTF-8");
+                    XMLUtil.save(meta.getXMPDocument(), System.out, StandardCharsets.UTF_8.name());
                 }
                 break;
             }

--- a/src/main/java/net/sf/jabref/migrations/PreferencesMigrations.java
+++ b/src/main/java/net/sf/jabref/migrations/PreferencesMigrations.java
@@ -26,7 +26,7 @@ public class PreferencesMigrations {
                 newGen = genFields.replaceAll(";abstract;", ";");
             } else if (genFields.indexOf("abstract;") == 0) {
                 newGen = genFields.replaceAll("abstract;", "");
-            } else if (genFields.indexOf(";abstract") == genFields.length() - 9) {
+            } else if (genFields.indexOf(";abstract") == (genFields.length() - 9)) {
                 newGen = genFields.replaceAll(";abstract", "");
             } else {
                 newGen = genFields;

--- a/src/main/java/net/sf/jabref/sql/importer/DbImportAction.java
+++ b/src/main/java/net/sf/jabref/sql/importer/DbImportAction.java
@@ -16,6 +16,7 @@
 package net.sf.jabref.sql.importer;
 
 import java.awt.event.ActionEvent;
+import java.nio.charset.Charset;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.util.ArrayList;
@@ -201,7 +202,7 @@ public class DbImportAction extends AbstractWorker {
             metaData = (MetaData) res[1];
             if (database != null) {
                 BasePanel pan = frame.addTab(database, null, metaData,
-                        Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING), true);
+                        Charset.forName(Globals.prefs.get(JabRefPreferences.DEFAULT_ENCODING)), true);
                 pan.metaData().setDBStrings(dbs);
                 frame.setTabTitle(pan, res[2] + "(Imported)", "Imported DB");
                 pan.markBaseChanged();

--- a/src/main/java/net/sf/jabref/util/Util.java
+++ b/src/main/java/net/sf/jabref/util/Util.java
@@ -26,6 +26,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.*;
 import java.net.*;
+import java.nio.charset.Charset;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -758,7 +759,7 @@ public class Util {
      * @return
      * @throws IOException
      */
-    public static String getResultsWithEncoding(URL source, String encoding) throws IOException {
+    public static String getResultsWithEncoding(URL source, Charset encoding) throws IOException {
         return net.sf.jabref.util.Util.getResultsWithEncoding(source.openConnection(), encoding);
     }
     /**
@@ -768,7 +769,7 @@ public class Util {
      * @return
      * @throws IOException
      */
-    public static String getResultsWithEncoding(URLConnection source, String encoding) throws IOException {
+    public static String getResultsWithEncoding(URLConnection source, Charset encoding) throws IOException {
 
         // set user-agent to avoid being blocked as a crawler
         source.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0");

--- a/src/test/java/net/sf/jabref/bibtex/BibtexEntryAssert.java
+++ b/src/test/java/net/sf/jabref/bibtex/BibtexEntryAssert.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Assert;
 
@@ -47,7 +48,7 @@ public class BibtexEntryAssert {
         Assert.assertNotNull(shouldBeIs);
         Assert.assertNotNull(entry);
         ParserResult result;
-        try (Reader reader = new InputStreamReader(shouldBeIs, "UTF-8")) {
+        try (Reader reader = new InputStreamReader(shouldBeIs, StandardCharsets.UTF_8)) {
             BibtexParser parser = new BibtexParser(reader);
             result = parser.parse();
         }

--- a/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
+++ b/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
@@ -9,10 +9,12 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 public class OpenDatabaseActionTest {
 
-    private final String defaultEncoding = "UTF-8";
+    private final Charset defaultEncoding = StandardCharsets.UTF_8;
     private final File bibNoHeader = new File(OpenDatabaseActionTest.class.getResource("headerless.bib").getFile());
     private final File bibWrongHeader = new File(
             OpenDatabaseActionTest.class.getResource("wrong-header.bib").getFile());
@@ -40,14 +42,14 @@ public class OpenDatabaseActionTest {
 
     @Test
     public void useSpecifiedEncoding() throws IOException {
-        ParserResult result = OpenDatabaseAction.loadDatabase(bibHeader, "noEncoding");
-        Assert.assertEquals("UTF-8", result.getEncoding());
+        ParserResult result = OpenDatabaseAction.loadDatabase(bibHeader, StandardCharsets.US_ASCII);
+        Assert.assertEquals(StandardCharsets.UTF_8, result.getEncoding());
     }
 
     @Test
     public void useSpecifiedEncodingWithSignature() throws IOException {
-        ParserResult result = OpenDatabaseAction.loadDatabase(bibHeaderAndSignature, "noEncoding");
-        Assert.assertEquals("UTF-8", result.getEncoding());
+        ParserResult result = OpenDatabaseAction.loadDatabase(bibHeaderAndSignature, StandardCharsets.US_ASCII);
+        Assert.assertEquals(StandardCharsets.UTF_8, result.getEncoding());
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/importer/fileformat/CopacImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/CopacImporterTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class CopacImporterTest {
@@ -50,7 +51,7 @@ public class CopacImporterTest {
 
     @Test
     public void testImportEntries() throws IOException {
-        Globals.prefs.put("defaultEncoding", "UTF8");
+        Globals.prefs.put("defaultEncoding", StandardCharsets.UTF_8.name());
 
         CopacImporter importer = new CopacImporter();
 
@@ -62,7 +63,7 @@ public class CopacImporterTest {
 
             Assert.assertEquals("The SIS project : software reuse with a natural language approach", entry.getField("title"));
             Assert.assertEquals(
-                    "Prechelt, Lutz and Universität Karlsruhe. Fakultät für Informatik",
+"Prechelt, Lutz and Universität Karlsruhe. Fakultät für Informatik",
                     entry.getField("author"));
             Assert.assertEquals("Interner Bericht ; Nr.2/92", entry.getField("series"));
             Assert.assertEquals("1992", entry.getField("year"));

--- a/src/test/java/net/sf/jabref/logic/l10n/TestL10nFiles.java
+++ b/src/test/java/net/sf/jabref/logic/l10n/TestL10nFiles.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -45,7 +46,7 @@ public class TestL10nFiles {
         try {
             Locale.setDefault(locale);
 
-            ResourceBundle.getBundle(prefix, locale, new EncodingControl("UTF-8"));
+            ResourceBundle.getBundle(prefix, locale, new EncodingControl(StandardCharsets.UTF_8));
         } finally {
             Locale.setDefault(oldLocale);
         }

--- a/src/test/java/net/sf/jabref/logic/net/URLDownloadTest.java
+++ b/src/test/java/net/sf/jabref/logic/net/URLDownloadTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 public class URLDownloadTest {
 
@@ -17,7 +18,8 @@ public class URLDownloadTest {
     public void testStringDownloadWithSetEncoding() throws IOException {
         URLDownload dl = new URLDownload(new URL("http://www.google.com"));
 
-        Assert.assertTrue("google.com should contain google", dl.downloadToString("UTF8").contains("Google"));
+        Assert.assertTrue("google.com should contain google",
+                dl.downloadToString(StandardCharsets.UTF_8).contains("Google"));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/util/XMPUtilTest.java
+++ b/src/test/java/net/sf/jabref/util/XMPUtilTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import javax.xml.transform.TransformerException;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 /**
@@ -93,7 +94,7 @@ public class XMPUtilTest {
 
             // Convert to UTF8 and make available for metadata.
             ByteArrayOutputStream bs = new ByteArrayOutputStream();
-            try (OutputStreamWriter os = new OutputStreamWriter(bs, "UTF8")) {
+            try (OutputStreamWriter os = new OutputStreamWriter(bs, StandardCharsets.UTF_8)) {
                 os.write(xmpString);
             }
             ByteArrayInputStream in = new ByteArrayInputStream(bs.toByteArray());
@@ -405,7 +406,7 @@ public class XMPUtilTest {
                 // PDMetadata.getInputStreamAsString() does not work
 
                 // Convert to UTF8 and make available for metadata.
-                try (InputStreamReader is = new InputStreamReader(meta.createInputStream(), "UTF8")) {
+                try (InputStreamReader is = new InputStreamReader(meta.createInputStream(), StandardCharsets.UTF_8)) {
                     return XMPUtilTest.slurp(is).trim(); // Trim to kill padding end-newline.
                 }
             }


### PR DESCRIPTION
Instead of representing an encoding as a string we now use a Charset.
This idea was already discussed in PR #370.