### PR TITLE
Removed file history size from preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Biblatex preserves capital letters, checking whether letters may be converted to lowercase within the Integrity Check action is obsolete. Fixes #412 
 
 ### Removed
-
+- Removed file history size preference (never available from the UI)
 
 
 

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -221,7 +221,6 @@ public class JabRefPreferences {
     public static final String OVERRIDE_DEFAULT_FONTS = "overrideDefaultFonts";
     public static final String FONT_SIZE = "fontSize";
     public static final String FONT_STYLE = "fontStyle";
-    public static final String HISTORY_SIZE = "historySize";
     public static final String RECENT_FILES = "recentFiles";
     public static final String GENERAL_FIELDS = "generalFields";
     public static final String RENAME_ON_MOVE_FILE_TO_FILE_DIR = "renameOnMoveFileToFileDir";
@@ -589,7 +588,6 @@ public class JabRefPreferences {
         defaults.put(GENERAL_FIELDS, "crossref;keywords;file;doi;url;urldate;"
                 + "pdf;comment;owner");
 
-        defaults.put(HISTORY_SIZE, 8);
         defaults.put(FONT_STYLE, java.awt.Font.PLAIN);
         defaults.put(FONT_SIZE, 12);
         defaults.put(OVERRIDE_DEFAULT_FONTS, Boolean.FALSE);

--- a/src/main/java/net/sf/jabref/logic/util/io/FileHistory.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileHistory.java
@@ -26,6 +26,8 @@ public class FileHistory {
     private final JabRefPreferences prefs;
     private final LinkedList<String> history = new LinkedList<>();
 
+    private final int HISTORY_SIZE = 8;
+
 
     public FileHistory(JabRefPreferences prefs) {
         this.prefs = prefs;
@@ -48,7 +50,7 @@ public class FileHistory {
     public void newFile(String filename) {
         history.remove(filename);
         history.addFirst(filename);
-        while (history.size() > prefs.getInt(JabRefPreferences.HISTORY_SIZE)) {
+        while (history.size() > HISTORY_SIZE) {
             history.removeLast();
         }
     }

--- a/src/test/java/net/sf/jabref/logic/util/io/FileHistoryTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/io/FileHistoryTest.java
@@ -2,6 +2,7 @@ package net.sf.jabref.logic.util.io;
 
 import static org.junit.Assert.*;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -10,13 +11,18 @@ import net.sf.jabref.JabRefPreferences;
 public class FileHistoryTest {
 
     JabRefPreferences prefs;
-
+    String[] oldFileNames;
 
     @Before
     public void setUp() throws Exception {
         prefs = JabRefPreferences.getInstance();
+        oldFileNames = prefs.getStringArray(JabRefPreferences.RECENT_FILES);
     }
 
+    @After
+    public void restore() {
+        prefs.putStringArray(JabRefPreferences.RECENT_FILES, oldFileNames);
+    }
     @Test
     public void testConstructor() {
         FileHistory fh = new FileHistory(prefs);
@@ -26,46 +32,41 @@ public class FileHistoryTest {
     @Test
     public void testFileHistory() {
         FileHistory fh = new FileHistory(prefs);
-        String[] oldFileNames = prefs.getStringArray(JabRefPreferences.RECENT_FILES);
-        Integer oldHistorySize = prefs.getInt(JabRefPreferences.HISTORY_SIZE);
 
-        prefs.putInt(JabRefPreferences.HISTORY_SIZE, 1);
         fh.newFile("aa");
         assertEquals("aa", fh.getFileName(0));
-        assertEquals(1, fh.size());
-
-        prefs.putInt(JabRefPreferences.HISTORY_SIZE, 3);
         fh.newFile("bb");
         assertEquals("bb", fh.getFileName(0));
-        assertEquals(2, fh.size());
 
         fh.newFile("aa");
         assertEquals("aa", fh.getFileName(0));
-        assertEquals(2, fh.size());
 
         fh.newFile("cc");
         assertEquals("cc", fh.getFileName(0));
         assertEquals("aa", fh.getFileName(1));
         assertEquals("bb", fh.getFileName(2));
-        assertEquals(3, fh.size());
 
         fh.newFile("dd");
         assertEquals("dd", fh.getFileName(0));
         assertEquals("cc", fh.getFileName(1));
         assertEquals("aa", fh.getFileName(2));
-        assertEquals(3, fh.size());
-
+        fh.newFile("ee");
+        fh.newFile("ff");
+        fh.newFile("gg");
+        fh.newFile("hh");
+        assertEquals("bb", fh.getFileName(7));
+        assertEquals(8, fh.size());
+        fh.newFile("ii");
+        assertEquals("aa", fh.getFileName(7));
+        fh.removeItem("ff");
+        assertEquals(7, fh.size());
+        fh.removeItem("ee");
+        fh.removeItem("dd");
         fh.removeItem("cc");
-        assertEquals("dd", fh.getFileName(0));
-        assertEquals("aa", fh.getFileName(1));
-        assertEquals(2, fh.size());
-
+        fh.removeItem("cc");
+        fh.removeItem("aa");
         fh.storeHistory();
-        String[] newFileNames = prefs.getStringArray(JabRefPreferences.RECENT_FILES);
-
-        assertArrayEquals(newFileNames, new String[] {"dd", "aa"});
-        prefs.putInt(JabRefPreferences.HISTORY_SIZE, oldHistorySize);
-        prefs.putStringArray(JabRefPreferences.RECENT_FILES, oldFileNames);
+        assertArrayEquals(new String[] {"ii", "hh", "gg"}, prefs.getStringArray(JabRefPreferences.RECENT_FILES));
     }
 
 }


### PR DESCRIPTION
Removed file history size as a preference variable, since it could not be set anyway and replaced it with a constant. See discussion in koppor/Jabref#43.