### PR TITLE
Default time stamps follows ISO-8601

### DIFF
--- a/src/main/java/net/sf/jabref/exporter/layout/format/CurrentDate.java
+++ b/src/main/java/net/sf/jabref/exporter/layout/format/CurrentDate.java
@@ -32,16 +32,18 @@ import net.sf.jabref.exporter.layout.LayoutFormatter;
 
 /**
  * Inserts the current date (the time a database is being exported).
- * 
+ *
  * <p>If a fieldText is given, it must be a valid {@link SimpleDateFormat} pattern.
- * If none is given, the format pattern will be <code>yyyy.MM.dd hh:mm:ss z</code></p>
+ * If none is given, the format pattern will be <code>yyyy-MM-dd hh:mm:ss z</code>.
+ * This follows ISO-8601. Reason: <a href="https://xkcd.com/1179/">https://xkcd.com/1179/</a>.</p>
  *
  * @author andreas_sf at rudert-home dot de
  */
 public class CurrentDate implements LayoutFormatter
 {
 
-    private static final String defaultFormat = "yyyy.MM.dd hh:mm:ss z";
+    // default time stamp follows ISO-8601. Reason: https://xkcd.com/1179/
+    private static final String defaultFormat = "yyyy-MM-dd hh:mm:ss z";
 
 
     /*
@@ -52,7 +54,7 @@ public class CurrentDate implements LayoutFormatter
     public String format(String fieldText)
     {
         String format = CurrentDate.defaultFormat;
-        if (fieldText != null && fieldText.trim() != null && !fieldText.trim().isEmpty()) {
+        if ((fieldText != null) && (fieldText.trim() != null) && !fieldText.trim().isEmpty()) {
             format = fieldText;
         }
         return new SimpleDateFormat(format).format(new Date());

--- a/src/main/java/net/sf/jabref/importer/EntryFromPDFCreator.java
+++ b/src/main/java/net/sf/jabref/importer/EntryFromPDFCreator.java
@@ -20,12 +20,12 @@ import net.sf.jabref.logic.xmp.EncryptionNotSupportedException;
 import net.sf.jabref.logic.xmp.XMPUtil;
 
 /**
- * Uses XMPUtils to get one BibtexEntry for a PDF-File. 
+ * Uses XMPUtils to get one BibtexEntry for a PDF-File.
  * Also imports the non-XMP Data (PDDocument-Information) using XMPUtil.getBibtexEntryFromDocumentInformation.
- * If data from more than one entry is read by XMPUtil then this entys are merged into one.  
+ * If data from more than one entry is read by XMPUtil then this entys are merged into one.
  * @author Dan
  * @version 12.11.2008 | 22:12:48
- * 
+ *
  */
 public class EntryFromPDFCreator extends EntryFromFileCreator {
 
@@ -43,14 +43,14 @@ public class EntryFromPDFCreator extends EntryFromFileCreator {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see net.sf.jabref.imports.EntryFromFileCreator#accept(java.io.File)
-     * 
+     *
      * Accepts all Files having as suffix ".PDF" (in ignore case mode).
      */
     @Override
     public boolean accept(File f) {
-        return f != null && f.getName().toUpperCase().endsWith(".PDF");
+        return (f != null) && f.getName().toUpperCase().endsWith(".PDF");
     }
 
     @Override
@@ -94,7 +94,8 @@ public class EntryFromPDFCreator extends EntryFromFileCreator {
                     addEntryDataToEntry(entry, entryDI);
                     Calendar creationDate = pdfDocInfo.getCreationDate();
                     if (creationDate != null) {
-                        String date = new SimpleDateFormat("yyyy.MM.dd")
+                        // default time stamp follows ISO-8601. Reason: https://xkcd.com/1179/
+                        String date = new SimpleDateFormat("yyyy-MM-dd")
                                 .format(creationDate.getTime());
                         appendToField(entry, "timestamp", date);
                     }
@@ -122,7 +123,7 @@ public class EntryFromPDFCreator extends EntryFromFileCreator {
      * Adds all data Found in all the entrys of this XMP file to the given
      * entry. This was implemented without having much knowledge of the XMP
      * format.
-     * 
+     *
      * @param aFile
      * @param entry
      */


### PR DESCRIPTION
Default time stamps follows ISO-8601. Reason: https://xkcd.com/1179/

I am not aware of side effects at the CurrentDate formatter.