### PR TITLE
Fix that the cleanup process aborts if linked file does not exists 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Implements #444: The search is cleared by either clicking the clear-button or by pressing ESC with having focus in the search field. 
 
 ### Fixed
+- Fixed: Cleanup process aborts if linked file does not exists
 - Fixed #420: Reenable preference changes
 - Fixed #414: Rework BibLatex entry types with correct required and optional fields
 - Fixed #413: Help links in released jar version are not working

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -1236,7 +1236,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             // The call to unblock will simply hide the glasspane, so there is no harm in calling
             // it even if the frame hasn't been blocked.
             frame.unblock();
-            LOGGER.error("runCommand error: " + ex.getMessage());
+            LOGGER.error("runCommand error: " + ex.getMessage(), ex);
         }
     }
 

--- a/src/main/java/net/sf/jabref/gui/actions/CleanUpAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/CleanUpAction.java
@@ -39,7 +39,6 @@ import net.sf.jabref.logic.cleanup.Cleaner;
 import net.sf.jabref.logic.cleanup.DoiCleanup;
 import net.sf.jabref.logic.cleanup.FieldFormatterCleanup;
 import net.sf.jabref.logic.cleanup.FormatterCleanup;
-import net.sf.jabref.logic.cleanup.RemoveFieldCleanup;
 import net.sf.jabref.logic.formatter.BibtexFieldFormatters;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibtexDatabase;
@@ -461,13 +460,5 @@ public class CleanUpAction extends AbstractWorker {
         for (FieldChange change : changes) {
             ce.addEdit(new UndoableFieldChange(change));
         }
-    }
-
-    /**
-     * Clears the given field of the entry and records the change.
-     */
-    private static void removeFieldValue(BibtexEntry entry, String fieldName, NamedCompound ce) {
-        RemoveFieldCleanup cleaner = new RemoveFieldCleanup(fieldName);
-        doCleanup(cleaner, entry, ce);
     }
 }

--- a/src/main/java/net/sf/jabref/gui/actions/RenamePdfCleanup.java
+++ b/src/main/java/net/sf/jabref/gui/actions/RenamePdfCleanup.java
@@ -60,7 +60,7 @@ public class RenamePdfCleanup implements Cleaner {
             //get new Filename with path
             //Create new Path based on old Path and new filename
             File expandedOldFile = FileUtil.expandFilename(realOldFilename, paths);
-            if (expandedOldFile.getParent() == null) {
+            if ((expandedOldFile == null) || (expandedOldFile.getParent() == null)) {
                 // something went wrong. Just skip this entry
                 continue;
             }


### PR DESCRIPTION
The cleanup process sometimes wasn't successful and reported a `null` reference. The reason was that a registered file wasn't available. This is fixed in this PR.

Moreover, if an exception is thrown in actions then a more detailed error message is displayed including the stack trace.