### PR TITLE
IEEEXplore fetcher downloads the raw bibtex records from IEEEXplore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ out/
 .project
 bin/
 
+# For Mac OS
+.DS_Store
+
 # UNKNWON
 jabref.xml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Move Bibtex and Biblatex mode switcher to File menu
 - Display active edit mode (BibTeX or Biblatex) at window title
 - Implements #444: The search is cleared by either clicking the clear-button or by pressing ESC with having focus in the search field. 
+- IEEEXplore search now downloads the full Bibtex record instead of parsing the fields from the HTML webpage result (fixes #1146, #1267)
 
 ### Fixed
 - Fixed: Cleanup process aborts if linked file does not exists

--- a/src/main/java/net/sf/jabref/importer/fetcher/IEEEXploreFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/IEEEXploreFetcher.java
@@ -24,9 +24,10 @@ import java.net.CookieHandler;
 import java.net.CookieManager;
 import java.net.MalformedURLException;
 import java.net.URL;
-
-import java.util.HashMap;
-import java.util.Set;
+import java.net.UnknownHostException;
+import java.net.HttpURLConnection;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -34,14 +35,16 @@ import javax.swing.JCheckBox;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 
-import net.sf.jabref.bibtex.EntryTypes;
 import net.sf.jabref.model.entry.EntryType;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import net.sf.jabref.*;
 import net.sf.jabref.importer.*;
-import net.sf.jabref.model.entry.IdGenerator;
+import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.logic.formatter.bibtexfields.UnitFormatter;
 import net.sf.jabref.logic.formatter.casechanger.CaseKeeper;
 import net.sf.jabref.logic.formatter.casechanger.CaseKeeperList;
@@ -53,65 +56,32 @@ import net.sf.jabref.util.Util;
 public class IEEEXploreFetcher implements EntryFetcher {
 
     private static final Log LOGGER = LogFactory.getLog(IEEEXploreFetcher.class);
+    private static final String URL_SEARCH = "http://ieeexplore.ieee.org/rest/search?reload=true";
+    private static final String URL_BIBTEX_START = "http://ieeexplore.ieee.org/xpl/downloadCitations?reload=true&recordIds=";
+    private static final String URL_BIBTEX_END = "&download-format=download-bibtex&x=0&y=0";
+    private static final String DIALOG_TITLE = Localization.lang("Search %0", "IEEEXplore");
+    private static final int MAX_FETCH = 100;
 
     final CaseKeeperList caseKeeperList = new CaseKeeperList();
     private final CaseKeeper caseKeeper = new CaseKeeper();
     private final UnitFormatter unitFormatter = new UnitFormatter();
-
     private final HTMLConverter htmlConverter = new HTMLConverter();
-
     private final JCheckBox absCheckBox = new JCheckBox(Localization.lang("Include abstracts"), false);
 
-    private static final int MAX_FETCH = 100;
-    private final int perPage = IEEEXploreFetcher.MAX_FETCH;
     private int hits;
-    private int unparseable;
     private int parsed;
-    private int piv;
     private boolean shouldContinue;
     private boolean includeAbstract;
 
     private String terms;
-    private final String endUrl = "&rowsPerPage=" + Integer.toString(perPage) + "&pageNumber=";
-    private String searchUrl;
-
-    private final Pattern hitsPattern = Pattern.compile("([0-9,]+) Results");
-    private final Pattern typePattern = Pattern.compile("<span class=\"type\">\\s*(.+)");
-    private final HashMap<String, String> fieldPatterns = new HashMap<>();
-    private final Pattern absPattern = Pattern.compile("<p>\\s*(.+)");
-
-    Pattern stdEntryPattern = Pattern.compile(".*<strong>(.+)</strong><br>" + "\\s+(.+)");
+    private String postData;
 
     private final Pattern publicationPattern = Pattern.compile("(.*), \\d*\\.*\\s?(.*)");
     private final Pattern proceedingPattern = Pattern.compile("(.*?)\\.?\\s?Proceedings\\s?(.*)");
-    Pattern abstractLinkPattern = Pattern.compile("<a href=\'(.+)\'>\\s*<span class=\"more\">View full.*</span> </a>");
-
-    Pattern ieeeArticleNumberPattern = Pattern.compile("<a href=\".*arnumber=(\\d+).*\">");
-
-    private final Pattern authorPattern = Pattern.compile("<span id=\"preferredName\" class=\"(.*)\">");
-    private static final String START_URL = "http://ieeexplore.ieee.org/search/freesearchresult.jsp?queryText=";
-
-    private static final String DIALOG_TITLE = Localization.lang("Search %0", "IEEEXplore");
-
-
-    // Common words in IEEE Xplore that should always be
 
     public IEEEXploreFetcher() {
         super();
         CookieHandler.setDefault(new CookieManager());
-
-        fieldPatterns.put("title", "<a\\s*href=[^<]+>\\s*(.+)\\s*</a>");
-        //fieldPatterns.put("author", "</h3>\\s*(.+)");
-        //fieldPatterns.put("author", "(?s)</h3>\\s*(.+)</br>");
-        // fieldPatterns.put("author", "<span id=\"preferredName\" class=\"(.+)\">");
-        fieldPatterns.put("volume", "Volume:\\s*([A-Za-z-]*\\d+)");
-        fieldPatterns.put("number", "Issue:\\s*(\\d+)");
-        //fieldPatterns.put("part", "Part (\\d+),&nbsp;(.+)");
-        fieldPatterns.put("year", "(?:Copyright|Publication) Year:\\s*(\\d{4})");
-        fieldPatterns.put("pages", "Page\\(s\\):\\s*(\\d+)\\s*-\\s*(\\d*)");
-        //fieldPatterns.put("doi", "Digital Object Identifier:\\s*<a href=.*>(.+)</a>");
-        fieldPatterns.put("doi", "<a href=\"http://dx.doi.org/(.+)\" target");
-        fieldPatterns.put("url", "<a href=\"(/stamp/stamp[^\"]+)");
     }
 
     @Override
@@ -125,49 +95,47 @@ public class IEEEXploreFetcher implements EntryFetcher {
 
     @Override
     public boolean processQuery(String query, ImportInspector dialog, OutputPrinter status) {
-        terms = query;
+        //IEEE API seems to use .QT. as a marker for the quotes for exact phrase searching
+        terms = query.replaceAll("\"", "\\.QT\\.");
+
         shouldContinue = true;
         parsed = 0;
-        unparseable = 0;
-        piv = 0;
         int pageNumber = 1;
 
-        searchUrl = makeUrl(pageNumber);//start at page 1
+        postData = makeSearchPostRequestPayload(pageNumber);
 
         try {
-            URL url = new URL(searchUrl);
-            String page = Util.getResults(url);
+            URL url = new URL(IEEEXploreFetcher.URL_SEARCH);
 
-            if (page.contains("You have entered an invalid search")) {
-                status.showMessage(Localization.lang("You have entered an invalid search '%0'.", terms),
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+
+            //add request header
+            con.setRequestMethod("POST");
+            con.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0");
+            con.setRequestProperty("Accept", "application/json");
+            con.setRequestProperty("Content-type", "application/json");
+
+            String page = Util.getPostResultsWithEncoding(con, postData, null);
+            //the page can be blank if the search did not work (not sure the exact conditions that lead to this, but declaring it an invalid search for now)
+            if (page.isEmpty()) {
+                status.showMessage(Localization.lang("You have entered an invalid search '%0'.", query),
                         DIALOG_TITLE, JOptionPane.INFORMATION_MESSAGE);
                 return false;
             }
 
-            if (page.contains("Bad request")) {
-                status.showMessage(Localization.lang("Bad Request '%0'.", terms),
+            //parses the JSON data returned by the query
+            //todo: a faster way would be to parse the JSON tokens one at a time just to extract the article number, but this seems to be fast enough...
+            JSONObject jsonObj = new JSONObject(page);
+            hits = jsonObj.getInt("totalRecords");
+
+            //if no search results were found
+            if (hits == 0) {
+                status.showMessage(Localization.lang("No entries found for the search string '%0'", query),
                         DIALOG_TITLE, JOptionPane.INFORMATION_MESSAGE);
                 return false;
             }
 
-            if (page.contains("No results were found.")) {
-                status.showMessage(Localization.lang("No entries found for the search string '%0'", terms),
-                        DIALOG_TITLE, JOptionPane.INFORMATION_MESSAGE);
-                return false;
-            }
-
-            if (page.contains("Error Page")) {
-                // @formatter:off
-                status.showMessage(
-                        Localization.lang("Intermittent errors on the IEEE Xplore server. Please try again in a while."),
-                       DIALOG_TITLE, JOptionPane.INFORMATION_MESSAGE);
-                // @formatter:on
-                return false;
-            }
-
-            hits = getNumberOfHits(page, "display-status", hitsPattern);
-
-            includeAbstract = absCheckBox.isSelected();
+            //if max hits were exceeded, display the warning
             if (hits > IEEEXploreFetcher.MAX_FETCH) {
                 // @formatter:off
                 status.showMessage(Localization.lang("%0 entries found. To reduce server load, only %1 will be downloaded.",
@@ -176,19 +144,87 @@ public class IEEEXploreFetcher implements EntryFetcher {
                 // @formatter:on
             }
 
-            parse(dialog, page);
+            //buffer to use for building the URL for fetching the bibtex data from IEEEXplore
+            StringBuffer bibtexQueryURLStringBuf = new StringBuffer();
+            bibtexQueryURLStringBuf.append(URL_BIBTEX_START);
+
+            //loop over each record and create a comma-separate list of article numbers which will be used to download the raw Bibtex
+            JSONArray recordsJsonArray = jsonObj.getJSONArray("records");
+            for (int n = 0; n < recordsJsonArray.length(); n++) {
+                if (!recordsJsonArray.getJSONObject(n).isNull("articleNumber")) {
+                    bibtexQueryURLStringBuf.append(recordsJsonArray.getJSONObject(n).getString("articleNumber") + ",");
+                }
+            }
+            //delete the last comma
+            bibtexQueryURLStringBuf.deleteCharAt(bibtexQueryURLStringBuf.length() - 1);
+
+
+            //add the abstract setting
+            includeAbstract = absCheckBox.isSelected();
+            if (includeAbstract) {
+                bibtexQueryURLStringBuf.append("&citations-format=citation-abstract");
+            } else {
+                bibtexQueryURLStringBuf.append("&citations-format=citation-only");
+            }
+
+            //append the remaining URL
+            bibtexQueryURLStringBuf.append(URL_BIBTEX_END);
+
+            //fetch the raw Bibtex results from IEEEXplore and parse
+            URL bibtexURL = new URL(bibtexQueryURLStringBuf.toString());
+            String bibtexPage = Util.getResults(bibtexURL);
+
+            //for some reason, the escaped HTML characters in the titles are in the format "#xNNNN" (they are missing the ampersand)
+            //add the ampersands back in before passing to the HTML formatter so they can be properly converted
+            //TODO: Maybe edit the HTMLconverter to also recognize escaped characters even when the & is missing?
+            //Pattern escapedPattern = Pattern.compile("(?<!&)#([x]*)([0]*)(\\p{XDigit}+);");
+            bibtexPage = bibtexPage.replaceAll("(?<!&)(#[x]*[0]*\\p{XDigit}+;)", "&$1");
+
+            //Also, percent signs are not escaped by the IEEEXplore Bibtex output nor, it would appear, the subsequent processing in JabRef
+            //TODO: Maybe find a better spot for this if it applies more universally
+            bibtexPage = bibtexPage.replaceAll("(?<!\\\\)%", "\\\\%");
+
+            //Format the bibtexResults using the HTML formatter (clears up numerical and text escaped characters and remaining HTML tags)
+            bibtexPage = htmlConverter.format(bibtexPage);
+
+            Collection<BibtexEntry> parsedBibtexCollection = BibtexParser.fromString(bibtexPage);
+
+            if (parsedBibtexCollection == null) {
+                status.showMessage(Localization.lang("Error occured parsing Bibtex returned from IEEEXplore"),
+                        DIALOG_TITLE, JOptionPane.INFORMATION_MESSAGE);
+                return false;
+            }
+
+            int nEntries = parsedBibtexCollection.size();
+            Iterator<BibtexEntry> parsedBibtexCollectionIterator = parsedBibtexCollection.iterator();
+
+            while (parsedBibtexCollectionIterator.hasNext() && shouldContinue) {
+                dialog.addEntry(cleanup(parsedBibtexCollectionIterator.next()));
+                dialog.setProgress(parsed, nEntries);
+                parsed++;
+            }
+
             return true;
+
         } catch (MalformedURLException e) {
             e.printStackTrace();
         } catch (ConnectException e) {
-            status.showMessage(Localization.lang("Connection to IEEEXplore failed"),
-                    DIALOG_TITLE, JOptionPane.ERROR_MESSAGE);
+            status.showMessage(Localization.lang("Connection to IEEEXplore failed"), DIALOG_TITLE,
+                    JOptionPane.ERROR_MESSAGE);
+        } catch (UnknownHostException e) {
+            status.showMessage(Localization.lang("Connection to IEEEXplore failed"), DIALOG_TITLE,
+                    JOptionPane.ERROR_MESSAGE);
         } catch (IOException e) {
             status.showMessage(e.getMessage(), DIALOG_TITLE, JOptionPane.ERROR_MESSAGE);
             LOGGER.warn("Search IEEEXplore: " + e.getMessage(), e);
+        } catch (JSONException e) {
+            status.showMessage(e.getMessage(), DIALOG_TITLE, JOptionPane.ERROR_MESSAGE);
+            LOGGER.warn("Search IEEEXplore: " + e.getMessage(), e);
         }
+
         return false;
     }
+
 
     @Override
     public String getTitle() {
@@ -208,20 +244,11 @@ public class IEEEXploreFetcher implements EntryFetcher {
         shouldContinue = false;
     }
 
-    private String makeUrl(int startIndex) {
-        return IEEEXploreFetcher.START_URL + terms.replaceAll(" ", "+") + endUrl + startIndex;
+    private String makeSearchPostRequestPayload(int startIndex) {
+        return "{\"queryText\":" + JSONObject.quote(terms) + ",\"refinements\":[],\"pageNumber\":\"" + startIndex
+                + "\",\"searchWithin\":[],\"newsearch\":\"true\",\"searchField\":\"Search_All\",\"rowsPerPage\":\"100\"}";
     }
 
-    private void parse(ImportInspector dialog, String text) {
-        BibtexEntry entry;
-        while (((entry = parseNextEntry(text)) != null) && shouldContinue) {
-            if (entry.getField("title") != null) {
-                dialog.addEntry(entry);
-                dialog.setProgress(parsed + unparseable, hits);
-                parsed++;
-            }
-        }
-    }
 
     private BibtexEntry cleanup(BibtexEntry entry) {
         if (entry == null) {
@@ -269,23 +296,21 @@ public class IEEEXploreFetcher implements EntryFetcher {
         }
 
         // clean up author
-        /*   	String author = (String)entry.getField("author");
-           	if (author != null) {
-            if (author.indexOf("a href=") >= 0) {  // Author parsing failed because it was empty
-        	entry.setField("author","");  // Maybe not needed anymore due to another change
-            } else {
-            	author = author.replaceAll("\\s+", " ");
-            	author = author.replaceAll("\\.", ". ");
-            	author = author.replaceAll("([^;]+),([^;]+),([^;]+)","$1,$3,$2"); // Change order in case of Jr. etc
-            	author = author.replaceAll("  ", " ");
-            	author = author.replaceAll("\\. -", ".-");
-                       author = author.replaceAll("; ", " and ");
-            	author = author.replaceAll(" ,", ",");
-            	author = author.replaceAll("  ", " ");
-            	author = author.replaceAll("[ ,;]+$", "");
-            	entry.setField("author", author);
-            }
-        }*/
+        String author = entry.getField("author");
+        if (author != null) {
+            author = author.replaceAll("\\s+", " ");
+            author = author.replaceAll("\\.", ". ");
+            //author = author.replaceAll("([^;]+),([^;]+),([^;]+)", "$1,$3,$2"); // Change order in case of Jr. etc
+            author = author.replaceAll("  ", " ");
+            author = author.replaceAll("\\. -", ".-");
+            author = author.replaceAll("; ", " and ");
+            author = author.replaceAll(" ,", ",");
+            author = author.replaceAll("  ", " ");
+            author = author.replaceAll("[ ,;]+$", "");
+            //TODO: remove trailing commas
+            entry.setField("author", author);
+        }
+
         // clean up month
         String month = entry.getField("month");
         if ((month != null) && !month.isEmpty()) {
@@ -485,169 +510,5 @@ public class IEEEXploreFetcher implements EntryFetcher {
         return entry;
     }
 
-    private BibtexEntry parseNextEntry(String allText) {
-        BibtexEntry entry = null;
 
-        int index = allText.indexOf("<div class=\"detail", piv);
-        int endIndex = allText.indexOf("</div>", index);
-
-        if ((index >= 0) && (endIndex > 0)) {
-            endIndex += 6;
-            piv = endIndex;
-            String text = allText.substring(index, endIndex);
-
-            EntryType type = null;
-            String sourceField = null;
-
-            String typeName = "";
-            Matcher typeMatcher = typePattern.matcher(text);
-            if (typeMatcher.find()) {
-                typeName = typeMatcher.group(1);
-                if ("IEEE Journals &amp; Magazines".equalsIgnoreCase(typeName)
-                        || "IEEE Early Access Articles".equalsIgnoreCase(typeName)
-                        || "IET Journals &amp; Magazines".equalsIgnoreCase(typeName)
-                        || "AIP Journals &amp; Magazines".equalsIgnoreCase(typeName)
-                        || "AVS Journals &amp; Magazines".equalsIgnoreCase(typeName)
-                        || "IBM Journals &amp; Magazines".equalsIgnoreCase(typeName)
-                        || "TUP Journals &amp; Magazines".equalsIgnoreCase(typeName)
-                        || "BIAI Journals &amp; Magazines".equalsIgnoreCase(typeName)
-                        || "MIT Press Journals".equalsIgnoreCase(typeName)
-                        || "Alcatel-Lucent Journal".equalsIgnoreCase(typeName)) {
-                    type = EntryTypes.getType("article");
-                    sourceField = "journal";
-                } else if ("IEEE Conference Publications".equalsIgnoreCase(typeName)
-                        || "IET Conference Publications".equalsIgnoreCase(typeName)
-                        || "VDE Conference Publications".equalsIgnoreCase(typeName)) {
-                    type = EntryTypes.getType("inproceedings");
-                    sourceField = "booktitle";
-                } else if ("IEEE Standards".equalsIgnoreCase(typeName) || "Standards".equalsIgnoreCase(typeName)) {
-                    type = EntryTypes.getType("standard");
-                    sourceField = "number";
-                } else if ("IEEE eLearning Library Courses".equalsIgnoreCase(typeName)) {
-                    type = EntryTypes.getType("electronic");
-                    sourceField = "note";
-                } else if ("Wiley-IEEE Press eBook Chapters".equalsIgnoreCase(typeName)
-                        || "MIT Press eBook Chapters".equalsIgnoreCase(typeName)
-                        || "IEEE USA Books &amp; eBooks".equalsIgnoreCase(typeName)) {
-                    type = EntryTypes.getType("incollection");
-                    sourceField = "booktitle";
-                } else if ("Morgan and Claypool eBooks".equalsIgnoreCase(typeName)) {
-                    type = EntryTypes.getType("book");
-                    sourceField = "note";
-                }
-            }
-
-            if (type == null) {
-                type = EntryTypes.getType("misc");
-                sourceField = "note";
-                IEEEXploreFetcher.LOGGER.warn("Type detection failed. Use MISC instead. Type string: " + text);
-                unparseable++;
-            }
-
-            entry = new BibtexEntry(IdGenerator.next(), type);
-
-            if ("IEEE Standards".equalsIgnoreCase(typeName)) {
-                entry.setField("organization", "IEEE");
-            }
-
-            if ("Wiley-IEEE Press eBook Chapters".equalsIgnoreCase(typeName)) {
-                entry.setField("publisher", "Wiley-IEEE Press");
-            } else if ("MIT Press eBook Chapters".equalsIgnoreCase(typeName)) {
-                entry.setField("publisher", "MIT Press");
-            } else if ("IEEE USA Books &amp; eBooks".equalsIgnoreCase(typeName)) {
-                entry.setField("publisher", "IEEE USA");
-            } else if ("Morgan \\& Claypool eBooks".equalsIgnoreCase(typeName)) {
-                entry.setField("publisher", "Morgan and Claypool");
-            }
-
-            if ("IEEE Early Access Articles".equalsIgnoreCase(typeName)) {
-                entry.setField("note", "Early Access");
-            }
-
-            Set<String> fields = fieldPatterns.keySet();
-            for (String field : fields) {
-                Matcher fieldMatcher = Pattern.compile(fieldPatterns.get(field)).matcher(text);
-                if (fieldMatcher.find()) {
-                    entry.setField(field, htmlConverter.format(fieldMatcher.group(1)));
-                    if ("title".equals(field) && fieldMatcher.find()) {
-                        String sec_title = htmlConverter.format(fieldMatcher.group(1));
-                        if (entry.getType() == EntryTypes.getStandardType("standard")) {
-                            sec_title = sec_title.replaceAll("IEEE Std ", "");
-                        }
-                        entry.setField(sourceField, sec_title);
-
-                    }
-                    if ("pages".equals(field) && (fieldMatcher.groupCount() == 2)) {
-                        entry.setField(field, fieldMatcher.group(1) + "-" + fieldMatcher.group(2));
-                    }
-                }
-            }
-
-            Matcher authorMatcher = authorPattern.matcher(text);
-            // System.out.println(text);
-            StringBuilder authorNames = new StringBuilder("");
-            int authorCount = 0;
-            while (authorMatcher.find()) {
-                if (authorCount >= 1) {
-                    authorNames.append(" and ");
-                }
-                authorNames.append(htmlConverter.format(authorMatcher.group(1)));
-                //System.out.println(authorCount + ": " + authorMatcher.group(1));
-                authorCount++;
-            }
-
-            String authorString = authorNames.toString();
-            if ((authorString == null) || authorString.startsWith("a href") || authorString.startsWith("Topic(s)")) { // Fix for some documents without authors
-                entry.setField("author", "");
-            } else {
-                entry.setField("author", authorString);
-            }
-
-            if ((entry.getType() == EntryTypes.getStandardType("inproceedings"))
-                    && "".equals(entry.getField("author"))) {
-                entry.setType(EntryTypes.getStandardType("proceedings"));
-            }
-
-            if (includeAbstract) {
-                index = text.indexOf("id=\"abstract");
-                if (index >= 0) {
-                    endIndex = text.indexOf("</div>", index) + 6;
-
-                    text = text.substring(index, endIndex);
-                    Matcher absMatcher = absPattern.matcher(text);
-                    if (absMatcher.find()) {
-                        // Clean-up abstract
-                        String abstr = absMatcher.group(1);
-                        abstr = abstr.replaceAll("<span class='snippet'>([\\w]+)</span>", "$1");
-
-                        entry.setField("abstract", htmlConverter.format(abstr));
-                    }
-                }
-            }
-        }
-
-        if (entry == null) {
-            return null;
-        }
-        return cleanup(entry);
-    }
-
-    /**
-     * Find out how many hits were found.
-     *
-     * @param page
-     */
-    private static int getNumberOfHits(String page, String marker, Pattern pattern) throws IOException {
-        int ind = page.indexOf(marker);
-        if (ind < 0) {
-            LOGGER.debug(page);
-            throw new IOException("Cannot parse number of hits");
-        }
-        String substring = page.substring(ind, page.length());
-        Matcher m = pattern.matcher(substring);
-        if (m.find()) {
-            return Integer.parseInt(m.group(1));
-        }
-        throw new IOException("Cannot parse number of hits");
-    }
 }

--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
@@ -101,6 +101,7 @@ public class BibtexParser {
         try {
             return parser.parse().getDatabase().getEntries();
         } catch (Exception e) {
+            LOGGER.warn("BibtexParser.fromString(String): " + e.getMessage(), e);
             return null;
         }
     }

--- a/src/main/java/net/sf/jabref/util/Util.java
+++ b/src/main/java/net/sf/jabref/util/Util.java
@@ -620,7 +620,6 @@ public class Util {
      * @throws IOException
      */
     public static String getResults(URLConnection source) throws IOException {
-
         return net.sf.jabref.util.Util.getResultsWithEncoding(source, null);
     }
 
@@ -662,6 +661,66 @@ public class Util {
             sb.append((char) byteRead);
         }
         return sb.toString();
+    }
+
+    /**
+     * Get the results of HTTP post on a URL and return contents as a String.
+     *
+     * @param source postData encoding
+     * @return
+     * @throws IOException
+     */
+    public static String getPostResultsWithEncoding(URL source, String postData, Charset encoding) throws IOException {
+        HttpURLConnection con = (HttpURLConnection) source.openConnection();
+
+        //add a default request header
+        con.setRequestMethod("POST");
+        con.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0");
+        con.setRequestProperty("Accept-Language", "en-US,en;q=0.5");
+
+        return net.sf.jabref.util.Util.getPostResultsWithEncoding(con, postData, encoding);
+    }
+
+    /**
+     * Get the results of HTTP post on a URL and return contents as a String.
+     *
+     * @param source postData encoding
+     * @return
+     * @throws IOException
+     */
+    public static String getPostResultsWithEncoding(HttpURLConnection source, String postData, Charset encoding)
+            throws IOException {
+
+        // Send post request
+        source.setDoOutput(true);
+        try (DataOutputStream wr = new DataOutputStream(source.getOutputStream());) {
+            wr.writeBytes(postData);
+            wr.flush();
+            wr.close();
+        }
+
+        int responseCode = source.getResponseCode();
+
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+
+        if (encoding != null) {
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(source.getInputStream(), encoding));) {
+                while ((inputLine = in.readLine()) != null) {
+                    response.append(inputLine);
+                }
+                in.close();
+            }
+        } else {
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(source.getInputStream()));) {
+                while ((inputLine = in.readLine()) != null) {
+                    response.append(inputLine);
+                }
+                in.close();
+            }
+        }
+
+        return response.toString();
     }
 
     /**
@@ -718,7 +777,7 @@ public class Util {
         if (affectedFields.isEmpty()) {
             return true; // no side effects
         }
-    
+
         // show a warning, then return
         StringBuffer message = // JZTODO lyrics...
                 new StringBuffer("This action will modify the following field(s)\n" + "in at least one entry each:\n");
@@ -728,7 +787,7 @@ public class Util {
         message.append("This could cause undesired changes to " + "your entries, so it is\nrecommended that you change the grouping field " + "in your group\ndefinition to \"keywords\" or a non-standard name." + "\n\nDo you still want to continue?");
         int choice = JOptionPane.showConfirmDialog(parent, message, Localization.lang("Warning"), JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
         return choice != JOptionPane.NO_OPTION;
-    
+
         // if (groups instanceof KeywordGroup) {
         // KeywordGroup kg = (KeywordGroup) groups;
         // String field = kg.getSearchField().toLowerCase();

--- a/src/main/java/net/sf/jabref/util/Util.java
+++ b/src/main/java/net/sf/jabref/util/Util.java
@@ -694,8 +694,6 @@ public class Util {
         source.setDoOutput(true);
         try (DataOutputStream wr = new DataOutputStream(source.getOutputStream());) {
             wr.writeBytes(postData);
-            wr.flush();
-            wr.close();
         }
 
         int responseCode = source.getResponseCode();
@@ -703,19 +701,12 @@ public class Util {
         String inputLine;
         StringBuffer response = new StringBuffer();
 
-        if (encoding != null) {
-            try (BufferedReader in = new BufferedReader(new InputStreamReader(source.getInputStream(), encoding));) {
-                while ((inputLine = in.readLine()) != null) {
-                    response.append(inputLine);
-                }
-            }
-        } else {
-            try (BufferedReader in = new BufferedReader(new InputStreamReader(source.getInputStream()));) {
-                while ((inputLine = in.readLine()) != null) {
-                    response.append(inputLine);
-                }
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(source.getInputStream(), encoding));) {
+            while ((inputLine = in.readLine()) != null) {
+                response.append(inputLine);
             }
         }
+
 
         return response.toString();
     }

--- a/src/main/java/net/sf/jabref/util/Util.java
+++ b/src/main/java/net/sf/jabref/util/Util.java
@@ -670,15 +670,9 @@ public class Util {
      * @return
      * @throws IOException
      */
-    public static String getPostResultsWithEncoding(URL source, String postData, Charset encoding) throws IOException {
+    public static String getPostResults(URL source, String postData, Charset encoding) throws IOException {
         HttpURLConnection con = (HttpURLConnection) source.openConnection();
-
-        //add a default request header
-        con.setRequestMethod("POST");
-        con.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0");
-        con.setRequestProperty("Accept-Language", "en-US,en;q=0.5");
-
-        return net.sf.jabref.util.Util.getPostResultsWithEncoding(con, postData, encoding);
+        return getPostResults(con, postData, encoding);
     }
 
     /**
@@ -688,8 +682,13 @@ public class Util {
      * @return
      * @throws IOException
      */
-    public static String getPostResultsWithEncoding(HttpURLConnection source, String postData, Charset encoding)
+    public static String getPostResults(HttpURLConnection source, String postData, Charset encoding)
             throws IOException {
+
+        //add a default request header
+        source.setRequestMethod("POST");
+        source.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0");
+        source.setRequestProperty("Accept-Language", "en-US,en;q=0.5");
 
         // Send post request
         source.setDoOutput(true);
@@ -709,14 +708,12 @@ public class Util {
                 while ((inputLine = in.readLine()) != null) {
                     response.append(inputLine);
                 }
-                in.close();
             }
         } else {
             try (BufferedReader in = new BufferedReader(new InputStreamReader(source.getInputStream()));) {
                 while ((inputLine = in.readLine()) != null) {
                     response.append(inputLine);
                 }
-                in.close();
             }
         }
 


### PR DESCRIPTION
Summary of changes
- moved away from the freesearchresult.jsp script for older browsers (notice on the IEEE suggests support for this will be dropped in Jan 2016), instead use the 'search' script and POST method
- results are returned in JSON format and the article numbers are obtained directly; HTML parsing has been removed
- the article numbers are used to construct a second query for the raw Bibtex records, which now captures all fields available from the IEEE
- the Bibtex entries are still passed to the existing cleanup() routine to improve the formatting consistency
- cleaned up unsued code as a result of the changes (removed HTML parsing code)
- added a method to Util for performing HTTP POST