### PR TITLE
[WIP] Prototype for new EntryType interface

### DIFF
--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
@@ -28,7 +28,6 @@ import net.sf.jabref.bibtex.EntryTypes;
 import net.sf.jabref.logic.CustomEntryTypesManager;
 import net.sf.jabref.model.database.KeyCollisionException;
 import net.sf.jabref.importer.ParserResult;
-import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.database.BibtexDatabase;
@@ -188,6 +187,7 @@ public class BibtexParser {
             // try to read the entry type
             String entryType = parseTextToken();
             EntryType type = EntryTypes.getType(entryType);
+            MyEntryClass myClass = MyEntryClasses.getClassFor(entryType);
             boolean isEntry = type != null;
 
             // The entry type name was not recognized. This can mean

--- a/src/main/java/net/sf/jabref/model/entry/BibtexEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibtexEntry.java
@@ -585,4 +585,8 @@ public class BibtexEntry {
     public List<String> getSeparatedKeywords() {
         return net.sf.jabref.model.entry.EntryUtil.getSeparatedKeywords(this.getField("keywords"));
     }
+
+    public MyEntryClass getMyEntryClass() {
+        return MyStandardEntryClass.ARTICLE;
+    }
 }

--- a/src/main/java/net/sf/jabref/model/entry/MyEntryClass.java
+++ b/src/main/java/net/sf/jabref/model/entry/MyEntryClass.java
@@ -1,0 +1,7 @@
+package net.sf.jabref.model.entry;
+
+
+public interface MyEntryClass {
+
+    String getName();
+}

--- a/src/main/java/net/sf/jabref/model/entry/MyEntryClasses.java
+++ b/src/main/java/net/sf/jabref/model/entry/MyEntryClasses.java
@@ -1,0 +1,25 @@
+package net.sf.jabref.model.entry;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+public class MyEntryClasses {
+
+    private static Map<String, MyEntryClass> map = new TreeMap<String, MyEntryClass>();
+
+
+    static {
+        for (MyEntryClass myClass : MyStandardEntryClass.values()) {
+            map.put(myClass.getName(), myClass);
+        }
+    }
+
+    public static MyEntryClass getClassFor(String name) {
+        MyEntryClass type = map.get(name);
+        if (type == null) {
+            return new MyNonStandardEntryClass(name);
+        } else {
+            return type;
+        }
+    }
+}

--- a/src/main/java/net/sf/jabref/model/entry/MyEntryTypeFactory.java
+++ b/src/main/java/net/sf/jabref/model/entry/MyEntryTypeFactory.java
@@ -1,0 +1,20 @@
+package net.sf.jabref.model.entry;
+
+import net.sf.jabref.JabRefPreferences;
+
+public class MyEntryTypeFactory {
+
+    public MyEntryTypeFactory(JabRefPreferences preferences) {
+
+    }
+
+    public EntryType getTypeFor(MyEntryClass myClass) {
+        // if biblatex mode
+        if (myClass == MyStandardEntryClass.ARTICLE) {
+            return BibLatexEntryTypes.ARTICLE;
+        }
+
+        // be more intelligent than that...
+        return null;
+    }
+}

--- a/src/main/java/net/sf/jabref/model/entry/MyNonStandardEntryClass.java
+++ b/src/main/java/net/sf/jabref/model/entry/MyNonStandardEntryClass.java
@@ -1,0 +1,16 @@
+package net.sf.jabref.model.entry;
+
+public class MyNonStandardEntryClass implements MyEntryClass {
+    private final String name;
+
+
+    MyNonStandardEntryClass(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+}

--- a/src/main/java/net/sf/jabref/model/entry/MyStandardEntryClass.java
+++ b/src/main/java/net/sf/jabref/model/entry/MyStandardEntryClass.java
@@ -1,0 +1,20 @@
+package net.sf.jabref.model.entry;
+
+//@formatter:off
+public enum MyStandardEntryClass implements MyEntryClass {
+    ARTICLE("article"),
+    BOOK("book");
+
+    private final String name;
+
+
+    private MyStandardEntryClass(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+}


### PR DESCRIPTION
This is a prototype for an idea to resolve the issues discussed in #337 and #495.

Right now the entry type is converted from a string representation (in the bibtex file) to an EntryType by the parser. The problem with this approach is that the parser has to know about the bibtex vs biblatex mode. The idea was to add an intermediate step:
String (in Bibtex file) -> EntryClass (by parser) -> EntryType (by some factory using information from the preferences)
 
- There is an enum `StandardEntryClass` holding all the standard types regardless of bibtex or biblatex (so article, mvbook, etc, all are there). To support also unknown entry types we have the class `NonStandardEntryClass`. So for example, parsing `@article{}` results in `class = StandardEntryClass.ARTICLE` while `@gibberish{}` yields `class = NonStandardEntryClass` with name `gibberish`. In this way the type information is stored in a relative convenient form (better then a string).

The idea of an enum implementing an interface was taken from the way java handles standard file locations. See [the oracle blog ](https://blogs.oracle.com/darcy/entry/enums_and_mixins) (or [another blog](http://blog.pengyifan.com/how-to-extend-enum-in-java/)).
- The `EntryClass` does not know about required and optional fields. These information are provided by the `EntryTypeFactory`. For example, `entryTypeFactory(prefs).getTypeFor(StandardEntryClass.ARTICLE).getRequiredFields()` gives the required fields. 

Please ignore all the "my" prefixes in the class names.