### PR TITLE
add gradle test encoding 'utf-8'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -240,6 +240,10 @@ compileTestJava {
     options.encoding = 'UTF-8'
 }
 
+test {
+    systemProperty "file.encoding", "UTF-8"
+}
+
 javadoc {
     options {
         encoding = 'UTF-8'


### PR DESCRIPTION
Added important missing Encoding information for testing with Gradle.