### PR TITLE
Fixed null issue in GoogleScholarFetcher

### DIFF
--- a/src/main/java/net/sf/jabref/importer/fetcher/GoogleScholarFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/GoogleScholarFetcher.java
@@ -270,10 +270,6 @@ public class GoogleScholarFetcher implements PreviewEntryFetcher {
                 Collection<BibEntry> entries = pr.getDatabase().getEntries();
                 if (entries.size() == 1) {
                     BibEntry entry = entries.iterator().next();
-                    boolean clearKeys = true;
-                    if (clearKeys) {
-                        entry.setField(BibEntry.KEY_FIELD, null);
-                    }
                     // If the entry's url field is not set, and we have stored an url for this
                     // entry, set it:
                     if (entry.getField("url") == null) {


### PR DESCRIPTION
Fix so that the Google Scholar fetcher is working again after the new BibtexEntry class require nun-null values.