### PR TITLE
Fixed all fields set to null

### DIFF
--- a/src/main/java/net/sf/jabref/groups/structure/KeywordGroup.java
+++ b/src/main/java/net/sf/jabref/groups/structure/KeywordGroup.java
@@ -330,7 +330,11 @@ public class KeywordGroup extends AbstractGroup {
         }
 
         String result = sbOrig.toString().trim();
-        entry.setField(searchField, !result.isEmpty() ? result : null);
+        if (result.isEmpty()) {
+            entry.clearField(searchField);
+        } else {
+            entry.setField(searchField, result);
+        }
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/gui/actions/BiblatexCleanup.java
+++ b/src/main/java/net/sf/jabref/gui/actions/BiblatexCleanup.java
@@ -27,7 +27,7 @@ public class BiblatexCleanup implements Cleaner {
                 entry.setField(newFieldName, oldValue);
                 changes.add(new FieldChange(entry, newFieldName, null, oldValue));
 
-                entry.setField(oldFieldName, null);
+                entry.clearField(oldFieldName);
                 changes.add(new FieldChange(entry, oldFieldName, oldValue, null));
             }
         }
@@ -38,8 +38,8 @@ public class BiblatexCleanup implements Cleaner {
             String oldYear = entry.getField("year");
             String oldMonth = entry.getField("month");
             entry.setField("date", newDate);
-            entry.setField("year", null);
-            entry.setField("month", null);
+            entry.clearField("year");
+            entry.clearField("month");
 
             changes.add(new FieldChange(entry, "date", null, newDate));
             changes.add(new FieldChange(entry, "year", oldYear, null));

--- a/src/main/java/net/sf/jabref/gui/mergeentries/MergeEntries.java
+++ b/src/main/java/net/sf/jabref/gui/mergeentries/MergeEntries.java
@@ -410,7 +410,7 @@ public class MergeEntries {
                 } else if (rb[2][i + 1].isSelected()) {
                     mergedEntry.setField(jointStrings[i], two.getField(jointStrings[i]));
                 } else {
-                    mergedEntry.setField(jointStrings[i], null);
+                    mergedEntry.clearField(jointStrings[i]);
                 }
             }
         }

--- a/src/main/java/net/sf/jabref/importer/fetcher/DiVAtoBibTeXFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/DiVAtoBibTeXFetcher.java
@@ -107,7 +107,7 @@ public class DiVAtoBibTeXFetcher implements EntryFetcher {
                 entry.setField("institution", institution);
             }
             // Do not use the provided key
-            // entry.setField(BibtexFields.KEY_FIELD,null);
+            // entry.clearField(BibtexFields.KEY_FIELD);
             inspector.addEntry(entry);
 
             return true;

--- a/src/main/java/net/sf/jabref/importer/fetcher/GoogleScholarFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/GoogleScholarFetcher.java
@@ -270,6 +270,7 @@ public class GoogleScholarFetcher implements PreviewEntryFetcher {
                 Collection<BibEntry> entries = pr.getDatabase().getEntries();
                 if (entries.size() == 1) {
                     BibEntry entry = entries.iterator().next();
+                    entry.clearField(BibEntry.KEY_FIELD);
                     // If the entry's url field is not set, and we have stored an url for this
                     // entry, set it:
                     if (entry.getField("url") == null) {

--- a/src/main/java/net/sf/jabref/logic/cleanup/RemoveFieldCleanup.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/RemoveFieldCleanup.java
@@ -27,7 +27,7 @@ public class RemoveFieldCleanup implements Cleaner {
             return new ArrayList<>();
         }
 
-        entry.setField(field, null);
+        entry.clearField(field);
         FieldChange change = new FieldChange(entry, field, oldValue, null);
         return Arrays.asList(new FieldChange[] {change});
     }


### PR DESCRIPTION
As entry.setField() does not accept a null argument anymore, the method entry.clearField() is used instead.
