### PR TITLE
Import Format Reader Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Default order in entry table:  # | all file based icons (file, URL/DOI, ...) | all bibtex field based icons (bibtexkey, entrytype, author, title, ...) | all activated special field icons (ranking, quality, ...)
 
 ### Fixed
+- Fixed #479: Import works again
 - Fixed #434: Revert to old 'JabRef' installation folder name instead of 'jabref'
 - Fixed #435: Retrieve non open access ScienceDirect PDFs via HTTP DOM
 - Fixed: Cleanup process aborts if linked file does not exists

--- a/src/main/java/net/sf/jabref/importer/ImportFormatReader.java
+++ b/src/main/java/net/sf/jabref/importer/ImportFormatReader.java
@@ -128,13 +128,18 @@ public class ImportFormatReader {
     public List<BibEntry> importFromFile(ImportFormat importer, String filename, OutputPrinter status) throws IOException {
         File file = new File(filename);
 
-        try (InputStream stream = new FileInputStream(file)) {
+        try (InputStream stream = new FileInputStream(file);
+                BufferedInputStream bis = new BufferedInputStream(stream)) {
 
-            if (!importer.isRecognizedFormat(stream)) {
+            bis.mark(Integer.MAX_VALUE);
+
+            if (!importer.isRecognizedFormat(bis)) {
                 throw new IOException("Wrong file format");
             }
 
-            return importer.importEntries(stream, status);
+            bis.reset();
+
+            return importer.importEntries(bis, status);
         }
     }
 


### PR DESCRIPTION
The Problem is, that the stream can not be resetted without a BufferedInputStream. 
However this is necessary since we check if a import file is in the right format with
looking into the stream and searching for specific patterns.

Result of the above mentioned issue is that I always got an error message saying
"No entries found" when trying to import a file with a valid format and entries. 

This fixes the issue without changing any method interfaces.