### PR TITLE
More use of Optional and some other fixes

### DIFF
--- a/src/main/java/net/sf/jabref/JabRef.java
+++ b/src/main/java/net/sf/jabref/JabRef.java
@@ -247,8 +247,7 @@ public class JabRef {
                     if (initialStartup) {
                         toImport.add(aLeftOver);
                     } else {
-                        Optional<ParserResult> res = JabRef.importToOpenBase(aLeftOver);
-                        loaded.add(res.orElse(ParserResult.INVALID_FORMAT));
+                        loaded.add(JabRef.importToOpenBase(aLeftOver).orElse(ParserResult.INVALID_FORMAT));
                     }
                 } else if (pr != ParserResult.FILE_LOCKED) {
                     loaded.add(pr);
@@ -262,18 +261,15 @@ public class JabRef {
         }
 
         for (String filenameString : toImport) {
-            Optional<ParserResult> pr = importFile(filenameString);
-            pr.ifPresent(loaded::add);
+            importFile(filenameString).ifPresent(loaded::add);
         }
 
         if (!cli.isBlank() && cli.isImportToOpenBase()) {
-            Optional<ParserResult> res = importToOpenBase(cli.getImportToOpenBase());
-            res.ifPresent(loaded::add);
+            importToOpenBase(cli.getImportToOpenBase()).ifPresent(loaded::add);
         }
 
         if (!cli.isBlank() && cli.isFetcherEngine()) {
-            Optional<ParserResult> res = fetch(cli.getFetcherEngine());
-            res.ifPresent(loaded::add);
+            fetch(cli.getFetcherEngine()).ifPresent(loaded::add);
         }
 
         if (cli.isExportMatches()) {
@@ -892,9 +888,7 @@ public class JabRef {
     private static Optional<ParserResult> importToOpenBase(String argument) {
         Optional<ParserResult> result = JabRef.importFile(argument);
 
-        if (result.isPresent()) {
-            result.get().setToOpenTab(true);
-        }
+        result.ifPresent(x -> x.setToOpenTab(true));
 
         return result;
     }

--- a/src/main/java/net/sf/jabref/bibtex/DuplicateCheck.java
+++ b/src/main/java/net/sf/jabref/bibtex/DuplicateCheck.java
@@ -21,6 +21,7 @@ import net.sf.jabref.model.entry.BibEntry;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Optional;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -207,13 +208,13 @@ public class DuplicateCheck {
      * @param entry    The entry of which we are looking for duplicates.
      * @return The first duplicate entry found. null if no duplicates are found.
      */
-    public static BibEntry containsDuplicate(BibDatabase database, BibEntry entry) {
+    public static Optional<BibEntry> containsDuplicate(BibDatabase database, BibEntry entry) {
         for (BibEntry other : database.getEntries()) {
             if (DuplicateCheck.isDuplicate(entry, other)) {
-                return other; // Duplicate found.
+                return Optional.of(other); // Duplicate found.
             }
         }
-        return null; // No duplicate found.
+        return Optional.empty(); // No duplicate found.
     }
 
     /**

--- a/src/main/java/net/sf/jabref/collab/ChangeScanner.java
+++ b/src/main/java/net/sf/jabref/collab/ChangeScanner.java
@@ -478,10 +478,9 @@ public class ChangeScanner implements Runnable {
             // Still one or more non-matched strings. So they must have been removed.
             for (String nmId : notMatched) {
                 BibtexString tmp = onTmp.getString(nmId);
-                Optional<BibtexString> mem = findString(inMem1, tmp.getName(), usedInMem);
-                if (mem.isPresent()) { // The removed string is not removed from the mem version.
-                    changes.add(new StringRemoveChange(tmp, tmp, mem.get()));
-                }
+                // The removed string is not removed from the mem version.
+                findString(inMem1, tmp.getName(), usedInMem)
+                        .ifPresent(x -> changes.add(new StringRemoveChange(tmp, tmp, x)));
             }
         }
 

--- a/src/main/java/net/sf/jabref/collab/ChangeScanner.java
+++ b/src/main/java/net/sf/jabref/collab/ChangeScanner.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.Vector;
 import java.util.ArrayList;
 
@@ -412,10 +413,10 @@ public class ChangeScanner implements Runnable {
                         // We have found a string with a matching name.
                         if ((tmp.getContent() != null) && !tmp.getContent().equals(disk.getContent())) {
                             // But they have nonmatching contents, so we've found a change.
-                            BibtexString mem = findString(inMem1, tmp.getName(), usedInMem);
-                            if (mem != null) {
-                                changes.add(
-                                        new StringChange(mem, tmp, tmp.getName(), mem.getContent(), disk.getContent()));
+                            Optional<BibtexString> mem = findString(inMem1, tmp.getName(), usedInMem);
+                            if (mem.isPresent()) {
+                                changes.add(new StringChange(mem.get(), tmp, tmp.getName(), mem.get().getContent(),
+                                        disk.getContent()));
                             } else {
                                 changes.add(new StringChange(null, tmp, tmp.getName(), null, disk.getContent()));
                             }
@@ -477,9 +478,9 @@ public class ChangeScanner implements Runnable {
             // Still one or more non-matched strings. So they must have been removed.
             for (String nmId : notMatched) {
                 BibtexString tmp = onTmp.getString(nmId);
-                BibtexString mem = findString(inMem1, tmp.getName(), usedInMem);
-                if (mem != null) { // The removed string is not removed from the mem version.
-                    changes.add(new StringRemoveChange(tmp, tmp, mem));
+                Optional<BibtexString> mem = findString(inMem1, tmp.getName(), usedInMem);
+                if (mem.isPresent()) { // The removed string is not removed from the mem version.
+                    changes.add(new StringRemoveChange(tmp, tmp, mem.get()));
                 }
             }
         }
@@ -496,18 +497,18 @@ public class ChangeScanner implements Runnable {
         }
     }
 
-    private static BibtexString findString(BibDatabase base, String name, HashSet<Object> used) {
+    private static Optional<BibtexString> findString(BibDatabase base, String name, HashSet<Object> used) {
         if (!base.hasStringLabel(name)) {
-            return null;
+            return Optional.empty();
         }
         for (String key : base.getStringKeySet()) {
             BibtexString bs = base.getString(key);
             if (bs.getName().equals(name) && !used.contains(key)) {
                 used.add(key);
-                return bs;
+                return Optional.of(bs);
             }
         }
-        return null;
+        return Optional.empty();
     }
 
     /**

--- a/src/main/java/net/sf/jabref/external/ExternalFileTypeEditor.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFileTypeEditor.java
@@ -301,10 +301,8 @@ public class ExternalFileTypeEditor extends JDialog {
                 return Localization.lang("Extension");
             case 3:
                 return Localization.lang("MIME type");
-            case 4:
+            default: // Five columns
                 return Localization.lang("Application");
-            default:
-                return null;
             }
         }
 
@@ -329,10 +327,8 @@ public class ExternalFileTypeEditor extends JDialog {
                 return type.getExtension();
             case 3:
                 return type.getMimeType();
-            case 4:
+            default: // Five columns
                 return type.getOpenWith();
-            default:
-                return null;
             }
         }
     }

--- a/src/main/java/net/sf/jabref/external/SynchronizeFileField.java
+++ b/src/main/java/net/sf/jabref/external/SynchronizeFileField.java
@@ -105,11 +105,6 @@ public class SynchronizeFileField extends AbstractWorker {
         int progress = 0;
         final NamedCompound ce = new NamedCompound(Localization.lang("Autoset %0 field", fieldName));
 
-        //final OpenFileFilter off = Util.getFileFilterForField(fieldName);
-
-        //ExternalFilePanel extPan = new ExternalFilePanel(fieldName, panel.metaData(), null, null, off);
-        //TextField editor = new TextField(fieldName, "", false);
-
         Set<BibEntry> changedEntries = new HashSet<>();
 
         // First we try to autoset fields
@@ -120,30 +115,9 @@ public class SynchronizeFileField extends AbstractWorker {
             // Start the autosetting process:
             Runnable r = Util.autoSetLinks(entries, ce, changedEntries, null, panel.metaData(), null, null);
             JabRefExecutorService.INSTANCE.executeAndWait(r);
-            /*
-                progress += weightAutoSet;
-                panel.frame().setProgressBarValue(progress);
-            
-                Object old = sel[i].getField(fieldName);
-                FileListTableModel tableModel = new FileListTableModel();
-                if (old != null)
-                    tableModel.setContent((String)old);
-                Thread t = FileListEditor.autoSetLinks(sel[i], tableModel, null, null);
-            
-                if (!tableModel.getStringRepresentation().equals(old)) {
-                    String toSet = tableModel.getStringRepresentation();
-                    if (toSet.isEmpty())
-                        toSet = null;
-                    ce.addEdit(new UndoableFieldChange(sel[i], fieldName, old, toSet));
-                    sel[i].setField(fieldName, toSet);
-                    entriesChanged++;
-                }
-            }    */
-
         }
         progress += sel.length * weightAutoSet;
         panel.frame().setProgressBarValue(progress);
-        //System.out.println("Done setting");
         // The following loop checks all external links that are already set.
         if (checkExisting) {
             boolean removeAllBroken = false;

--- a/src/main/java/net/sf/jabref/external/SynchronizeFileField.java
+++ b/src/main/java/net/sf/jabref/external/SynchronizeFileField.java
@@ -123,16 +123,16 @@ public class SynchronizeFileField extends AbstractWorker {
             /*
                 progress += weightAutoSet;
                 panel.frame().setProgressBarValue(progress);
-
+            
                 Object old = sel[i].getField(fieldName);
                 FileListTableModel tableModel = new FileListTableModel();
                 if (old != null)
                     tableModel.setContent((String)old);
                 Thread t = FileListEditor.autoSetLinks(sel[i], tableModel, null, null);
-
+            
                 if (!tableModel.getStringRepresentation().equals(old)) {
                     String toSet = tableModel.getStringRepresentation();
-                    if (toSet.length() == 0)
+                    if (toSet.isEmpty())
                         toSet = null;
                     ce.addEdit(new UndoableFieldChange(sel[i], fieldName, old, toSet));
                     sel[i].setField(fieldName, toSet);

--- a/src/main/java/net/sf/jabref/gui/preftabs/AppearancePrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/AppearancePrefsTab.java
@@ -122,9 +122,7 @@ class AppearancePrefsTab extends JPanel implements PrefsTab {
             @Override
             public void actionPerformed(ActionEvent e) {
                 Optional<Font> f = new FontSelectorDialog(null, GUIGlobals.CURRENTFONT).getSelectedFont();
-                if (f.isPresent()) {
-                    font = f.get();
-                }
+                f.ifPresent(x -> font = x);
             }
         });
 

--- a/src/main/java/net/sf/jabref/gui/preftabs/AppearancePrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/AppearancePrefsTab.java
@@ -20,6 +20,7 @@ import java.awt.Font;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.Optional;
 
 import javax.swing.*;
 
@@ -120,10 +121,9 @@ class AppearancePrefsTab extends JPanel implements PrefsTab {
 
             @Override
             public void actionPerformed(ActionEvent e) {
-                Font f = new FontSelectorDialog
-                        (null, GUIGlobals.CURRENTFONT).getSelectedFont();
-                if (f != null) {
-                    font = f;
+                Optional<Font> f = new FontSelectorDialog(null, GUIGlobals.CURRENTFONT).getSelectedFont();
+                if (f.isPresent()) {
+                    font = f.get();
                 }
             }
         });

--- a/src/main/java/net/sf/jabref/gui/preftabs/FontSelectorDialog.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/FontSelectorDialog.java
@@ -188,9 +188,7 @@ class FontSelector extends JButton {
         @Override
         public void actionPerformed(ActionEvent evt) {
             Optional<Font> font = new FontSelectorDialog(FontSelector.this, getFont()).getSelectedFont();
-            if (font.isPresent()) {
-                setFont(font.get());
-            }
+            font.ifPresent(f -> setFont(f));
         }
     }
 

--- a/src/main/java/net/sf/jabref/gui/preftabs/FontSelectorDialog.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/FontSelectorDialog.java
@@ -64,6 +64,7 @@ import java.awt.RenderingHints;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Optional;
 import java.util.Vector;
 
 import javax.swing.Box;
@@ -186,9 +187,9 @@ class FontSelector extends JButton {
 
         @Override
         public void actionPerformed(ActionEvent evt) {
-            Font font = new FontSelectorDialog(FontSelector.this, getFont()).getSelectedFont();
-            if (font != null) {
-                setFont(font);
+            Optional<Font> font = new FontSelectorDialog(FontSelector.this, getFont()).getSelectedFont();
+            if (font.isPresent()) {
+                setFont(font.get());
             }
         }
     }
@@ -314,9 +315,9 @@ public class FontSelectorDialog extends JDialog {
         dispose();
     }
 
-    public Font getSelectedFont() {
+    public Optional<Font> getSelectedFont() {
         if (!isOK) {
-            return null;
+            return Optional.empty();
         }
 
         int size;
@@ -326,7 +327,7 @@ public class FontSelectorDialog extends JDialog {
             size = 14;
         }
 
-        return new Font(familyField.getText(), styleList.getSelectedIndex(), size);
+        return Optional.of(new Font(familyField.getText(), styleList.getSelectedIndex(), size));
     }
 
 

--- a/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
@@ -133,10 +133,9 @@ public class NameFormatterTab extends JPanel implements PrefsTab {
                 switch (column) {
                 case 0:
                     return tr.name;
-                case 1:
+                default: // Only two columns
                     return tr.format;
                 }
-                return null; // Unreachable.
             }
 
             @Override

--- a/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
@@ -150,10 +150,9 @@ class TableColumnsTab extends JPanel implements PrefsTab {
                 switch (column) {
                 case 0:
                     return tr.name;
-                case 1:
+                default: // Only two columns
                     return tr.length > 0 ? Integer.toString(tr.length) : "";
                 }
-                return null; // Unreachable.
             }
 
             @Override

--- a/src/main/java/net/sf/jabref/gui/remote/JabRefMessageHandler.java
+++ b/src/main/java/net/sf/jabref/gui/remote/JabRefMessageHandler.java
@@ -19,6 +19,7 @@ import net.sf.jabref.JabRef;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.logic.remote.server.MessageHandler;
 
+import java.util.Optional;
 import java.util.Vector;
 
 public class JabRefMessageHandler implements MessageHandler {
@@ -31,13 +32,13 @@ public class JabRefMessageHandler implements MessageHandler {
 
     @Override
     public void handleMessage(String message) {
-        Vector<ParserResult> loaded = jabRef.processArguments(message.split("\n"), false);
-        if (loaded == null) {
+        Optional<Vector<ParserResult>> loaded = jabRef.processArguments(message.split("\n"), false);
+        if (!(loaded.isPresent())) {
             throw new IllegalStateException("Could not start JabRef with arguments " + message);
         }
 
-        for (int i = 0; i < loaded.size(); i++) {
-            ParserResult pr = loaded.elementAt(i);
+        for (int i = 0; i < loaded.get().size(); i++) {
+            ParserResult pr = loaded.get().elementAt(i);
             JabRef.jrf.addParserResult(pr, i == 0);
         }
     }

--- a/src/main/java/net/sf/jabref/importer/EntryFromExternalFileCreator.java
+++ b/src/main/java/net/sf/jabref/importer/EntryFromExternalFileCreator.java
@@ -1,6 +1,7 @@
 package net.sf.jabref.importer;
 
 import java.io.File;
+import java.util.Optional;
 
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.external.ExternalFileType;
@@ -20,12 +21,12 @@ public class EntryFromExternalFileCreator extends EntryFromFileCreator {
     }
 
     @Override
-    protected BibEntry createBibtexEntry(File file) {
+    protected Optional<BibEntry> createBibtexEntry(File file) {
         if (!accept(file)) {
-            return null;
+            return Optional.empty();
         }
 
-        return new BibEntry();
+        return Optional.of(new BibEntry());
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/importer/EntryFromFileCreator.java
+++ b/src/main/java/net/sf/jabref/importer/EntryFromFileCreator.java
@@ -17,6 +17,7 @@ package net.sf.jabref.importer;
 
 import java.io.File;
 import java.util.List;
+import java.util.Optional;
 import java.util.StringTokenizer;
 
 import net.sf.jabref.Globals;
@@ -55,7 +56,7 @@ public abstract class EntryFromFileCreator implements java.io.FileFilter {
         this.externalFileType = externalFileType;
     }
 
-    protected abstract BibEntry createBibtexEntry(File f);
+    protected abstract Optional<BibEntry> createBibtexEntry(File f);
 
     /**
      * <p>
@@ -98,22 +99,22 @@ public abstract class EntryFromFileCreator implements java.io.FileFilter {
         if ((f == null) || !f.exists()) {
             return null;
         }
-        BibEntry newEntry = createBibtexEntry(f);
+        Optional<BibEntry> newEntry = createBibtexEntry(f);
 
-        if (newEntry == null) {
+        if (!(newEntry.isPresent())) {
             return null;
         }
 
         if (addPathTokensAsKeywords) {
-            appendToField(newEntry, "keywords", extractPathesToKeyWordsfield(f.getAbsolutePath()));
+            appendToField(newEntry.get(), "keywords", extractPathesToKeyWordsfield(f.getAbsolutePath()));
         }
 
-        if (newEntry.getField("title") == null) {
-            newEntry.setField("title", f.getName());
+        if (newEntry.get().getField("title") == null) {
+            newEntry.get().setField("title", f.getName());
         }
 
-        addFileInfo(newEntry, f);
-        return newEntry;
+        addFileInfo(newEntry.get(), f);
+        return newEntry.get();
     }
 
     /** Returns the ExternalFileType that is imported here */

--- a/src/main/java/net/sf/jabref/importer/EntryFromPDFCreator.java
+++ b/src/main/java/net/sf/jabref/importer/EntryFromPDFCreator.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Optional;
 
 import net.sf.jabref.gui.IconTheme;
 import org.apache.pdfbox.pdmodel.PDDocument;
@@ -54,17 +55,17 @@ public class EntryFromPDFCreator extends EntryFromFileCreator {
     }
 
     @Override
-    protected BibEntry createBibtexEntry(File pdfFile) {
+    protected Optional<BibEntry> createBibtexEntry(File pdfFile) {
 
         if (!accept(pdfFile)) {
-            return null;
+            return Optional.empty();
         }
 
         PdfImporter pi = new PdfImporter(JabRef.jrf, JabRef.jrf.getCurrentBasePanel(), JabRef.jrf.getCurrentBasePanel().mainTable, -1);
         String[] fileNames = {pdfFile.toString()};
         ImportPdfFilesResult res = pi.importPdfFiles(fileNames, JabRef.jrf);
         assert res.entries.size() == 1;
-        return res.entries.get(0);
+        return Optional.of(res.entries.get(0));
 
         /*addEntryDataFromPDDocumentInformation(pdfFile, entry);
         addEntyDataFromXMP(pdfFile, entry);

--- a/src/main/java/net/sf/jabref/importer/HTMLConverter.java
+++ b/src/main/java/net/sf/jabref/importer/HTMLConverter.java
@@ -773,11 +773,11 @@ public class HTMLConverter implements LayoutFormatter, Formatter {
     public HTMLConverter() {
         super();
         for (String[] aConversionList : conversionList) {
-            if (aConversionList[2].length() >= 1) {
-                if (aConversionList[1].length() >= 1) {
+            if (!(aConversionList[2].isEmpty())) {
+                if (!(aConversionList[1].isEmpty())) {
                     escapedSymbols.put("&" + aConversionList[1] + ";", aConversionList[2]);
                 }
-                if (aConversionList[0].length() >= 1) {
+                if (!(aConversionList[0].isEmpty())) {
                     numSymbols.put(Integer.decode(aConversionList[0]), aConversionList[2]);
                     if (Integer.decode(aConversionList[0]) > 128) {
                         Character c = (char) Integer.decode(aConversionList[0]).intValue();

--- a/src/main/java/net/sf/jabref/importer/fileformat/JSONEntryParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/JSONEntryParser.java
@@ -206,8 +206,8 @@ public class JSONEntryParser {
         }
 
         // Page numbers
-        if (springerJsonEntry.has("startingPage") && (springerJsonEntry.getString("startingPage").length() > 0)) {
-            if (springerJsonEntry.has("endPage") && (springerJsonEntry.getString("endPage").length() > 0)) {
+        if (springerJsonEntry.has("startingPage") && !(springerJsonEntry.getString("startingPage").isEmpty())) {
+            if (springerJsonEntry.has("endPage") && !(springerJsonEntry.getString("endPage").isEmpty())) {
                 entry.setField("pages",
                         springerJsonEntry.getString("startingPage") + "--" + springerJsonEntry.getString("endPage"));
             } else {

--- a/src/main/java/net/sf/jabref/logic/labelPattern/LabelPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/labelPattern/LabelPatternUtil.java
@@ -175,8 +175,11 @@ public class LabelPatternUtil {
      * @return True if the author or editor is an institution.
      */
     private static boolean isInstitution(String author) {
-        return (author.charAt(0) == '{')
-                && (author.charAt(author.length() - 1) == '}');
+        if (!(author.isEmpty())) {
+            return (author.charAt(0) == '{') && (author.charAt(author.length() - 1) == '}');
+        } else {
+            return false; // In case of empty or null author
+        }
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/labelPattern/LabelPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/labelPattern/LabelPatternUtil.java
@@ -178,7 +178,7 @@ public class LabelPatternUtil {
         if (!(author.isEmpty())) {
             return (author.charAt(0) == '{') && (author.charAt(author.length() - 1) == '}');
         } else {
-            return false; // In case of empty or null author
+            return false; // In case of empty author
         }
     }
 

--- a/src/main/java/net/sf/jabref/logic/labelPattern/LabelPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/labelPattern/LabelPatternUtil.java
@@ -122,8 +122,8 @@ public class LabelPatternUtil {
      * @return The content without diacritics.
      */
     private static String removeDiacritics(String content) {
-        if (content == null) {
-            return null;
+        if (content.isEmpty()) {
+            return content;
         }
 
         // Replace umaut with '?e'
@@ -248,14 +248,14 @@ public class LabelPatternUtil {
      *
      * @param content the institution to generate a Bibtex key for
      * @return <ul>
-     *         <li>the institutation key</li>
+     *         <li>the institution key</li>
      *         <li>"" in the case of a failure</li>
      *         <li>null if content is null</li>
      *         </ul>
      */
     private static String generateInstitutionKey(String content) {
-        if (content == null) {
-            return null;
+        if (content.isEmpty()) {
+            return content;
         }
         content = LabelPatternUtil.unifyDiacritics(content);
         List<String> ignore = Arrays.asList("press", "the");

--- a/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
@@ -37,7 +37,7 @@ public class StringUtil {
      */
 
     public static String shaveString(String toShave) {
-        if ((toShave == null) || (toShave.length() == 0)) {
+        if ((toShave == null) || (toShave.isEmpty())) {
             return toShave;
         }
         toShave = toShave.trim();
@@ -436,7 +436,7 @@ public class StringUtil {
         return buf.toString();
 
         /*
-         * if (s.length() == 0) return s; // Protect against ArrayIndexOutOf....
+         * if (s.isEmpty()) return s; // Protect against ArrayIndexOutOf....
          * StringBuffer buf = new StringBuffer();
          *
          * Matcher mcr = titleCapitalPattern.matcher(s.substring(1)); while

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -569,7 +569,7 @@ public class BibEntry {
         List<String> keywords = this.getSeparatedKeywords();
         Boolean duplicate = false;
 
-        if ((keyword == null) || (keyword.length() == 0)) {
+        if ((keyword == null) || (keyword.isEmpty())) {
             return;
         }
 

--- a/src/main/java/net/sf/jabref/util/Util.java
+++ b/src/main/java/net/sf/jabref/util/Util.java
@@ -326,7 +326,7 @@ public class Util {
         if (setOwner) {
             // No or empty owner field?
             // if (entry.getField(Globals.OWNER) == null
-            // || ((String) entry.getField(Globals.OWNER)).length() == 0) {
+            // || ((String) entry.getField(Globals.OWNER)).isEmpty()) {
             // Set owner field to default value
             entry.setField(BibtexFields.OWNER, owner);
             // }
@@ -718,7 +718,7 @@ public class Util {
         if (affectedFields.isEmpty()) {
             return true; // no side effects
         }
-    
+
         // show a warning, then return
         StringBuffer message = new StringBuffer("This action will modify the following field(s)\n" + "in at least one entry each:\n");
         for (int i = 0; i < affectedFields.size(); ++i) {
@@ -727,7 +727,7 @@ public class Util {
         message.append("This could cause undesired changes to " + "your entries, so it is\nrecommended that you change the grouping field " + "in your group\ndefinition to \"keywords\" or a non-standard name." + "\n\nDo you still want to continue?");
         int choice = JOptionPane.showConfirmDialog(parent, message, Localization.lang("Warning"), JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
         return choice != JOptionPane.NO_OPTION;
-    
+
         // if (groups instanceof KeywordGroup) {
         // KeywordGroup kg = (KeywordGroup) groups;
         // String field = kg.getSearchField().toLowerCase();


### PR DESCRIPTION
* Used `Optional` instead of `return null`. Sometimes it makes much sense, sometimes less.
* Replaced checking zero or non-zero `String` lengths with `.isEmpty()`
* Changed the default case in some switch-statements to avoid `return null` (as that case should never happen anyway)
* Avoided an exception from happening when importing items without author and generating a BibTexKey which is based on the author name.