### PR TITLE
Moved methods from Util

### DIFF
--- a/src/main/java/net/sf/jabref/JabRef.java
+++ b/src/main/java/net/sf/jabref/JabRef.java
@@ -590,9 +590,6 @@ public class JabRef {
         // Set up custom or default icon theme:
         // This is now done at processArguments
 
-        // TODO: remove temporary registering of external file types?
-        Globals.prefs.updateExternalFileTypes();
-
         // This property is set to make the Mac OSX Java VM move the menu bar to
         // the top of the screen, where Mac users expect it to be.
         System.setProperty("apple.laf.useScreenMenuBar", "true");

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -1283,6 +1283,21 @@ public final class JabRefPreferences {
     }
 
     /**
+     * Check if there is an external file type registered with this name.
+     *
+     * @param name The file type name.
+     * @return true if there is an ExternalFileType with this name, false if not.
+     */
+    public Boolean isExternalFileTypeName(String name) {
+        for (ExternalFileType type : externalFileTypes) {
+            if (type.getName().equals(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Look up the external file type registered for this extension, if any.
      *
      * @param extension The file extension.
@@ -1292,6 +1307,21 @@ public final class JabRefPreferences {
         for (ExternalFileType type : externalFileTypes) {
             if ((type.getExtension() != null) && type.getExtension().equalsIgnoreCase(extension)) {
                 return type;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Look up the external file type name registered for this extension, if any.
+     *
+     * @param extension The file extension.
+     * @return The name of the ExternalFileType registered, or null if none.
+     */
+    public String getExternalFileTypeNameByExt(String extension) {
+        for (ExternalFileType type : externalFileTypes) {
+            if ((type.getExtension() != null) && type.getExtension().equalsIgnoreCase(extension)) {
+                return type.getName();
             }
         }
         return null;
@@ -1331,6 +1361,26 @@ public final class JabRefPreferences {
         }
         if ("text/html".equals(mimeType)) {
             return HTML_FALLBACK_TYPE;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Look up the external file type name registered for this MIME type, if any.
+     *
+     * @param mimeType The MIME type.
+     * @return The name of the ExternalFileType registered, or null if none. For the mime type "text/html", a valid file type name is
+     *         guaranteed to be returned.
+     */
+    public String getExternalFileTypeNameByMimeType(String mimeType) {
+        for (ExternalFileType type : externalFileTypes) {
+            if ((type.getMimeType() != null) && type.getMimeType().equals(mimeType)) {
+                return type.getName();
+            }
+        }
+        if ("text/html".equals(mimeType)) {
+            return HTML_FALLBACK_TYPE.getName();
         } else {
             return null;
         }

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -53,16 +53,13 @@ import org.apache.commons.logging.LogFactory;
 import net.sf.jabref.exporter.CustomExportList;
 import net.sf.jabref.exporter.ExportComparator;
 import net.sf.jabref.external.DroppedFileHandler;
-import net.sf.jabref.external.ExternalFileType;
-import net.sf.jabref.external.UnknownExternalFileType;
 import net.sf.jabref.importer.CustomImportList;
 import net.sf.jabref.logic.remote.RemotePreferences;
 import net.sf.jabref.specialfields.SpecialFieldsUtils;
-import net.sf.jabref.logic.util.strings.StringUtil;
 
 public final class JabRefPreferences {
     private static final Log LOGGER = LogFactory.getLog(JabRefPreferences.class);
-    private static final String EXTERNAL_FILE_TYPES = "externalFileTypes";
+    public static final String EXTERNAL_FILE_TYPES = "externalFileTypes";
 
     /**
      * HashMap that contains all preferences which are set by default
@@ -348,9 +345,6 @@ public final class JabRefPreferences {
     private static final String CUSTOM_TYPE_PRIOPT = "customTypePriOpt_";
     public static final String PDF_PREVIEW = "pdfPreview";
 
-    // This String is used in the encoded list in prefs of external file type
-    // modifications, in order to indicate a removed default file type:
-    private static final String FILE_TYPE_REMOVED_FLAG = "REMOVED";
 
     private static final char[][] VALUE_DELIMITERS = new char[][] { {'"', '"'}, {'{', '}'}};
 
@@ -376,10 +370,6 @@ public final class JabRefPreferences {
 
     // Object containing info about customized entry editor tabs.
     private EntryEditorTabList tabList;
-    // Map containing all registered external file types:
-    private final Set<ExternalFileType> externalFileTypes = new TreeSet<>();
-
-    private final ExternalFileType HTML_FALLBACK_TYPE = new ExternalFileType("URL", "html", "text/html", "", "www", IconTheme.JabRefIcon.WWW.getSmallIcon());
 
     // The following field is used as a global variable during the export of a database.
     // By setting this field to the path of the database's default file directory, formatters
@@ -1221,286 +1211,6 @@ public final class JabRefPreferences {
 
     }
 
-    public List<ExternalFileType> getDefaultExternalFileTypes() {
-        List<ExternalFileType> list = new ArrayList<>();
-        list.add(new ExternalFileType("PDF", "pdf", "application/pdf", "evince", "pdfSmall", IconTheme.JabRefIcon.PDF_FILE.getSmallIcon()));
-        list.add(new ExternalFileType("PostScript", "ps", "application/postscript", "evince", "psSmall", IconTheme.JabRefIcon.FILE.getSmallIcon()));
-        list.add(new ExternalFileType("Word", "doc", "application/msword", "oowriter", "openoffice", IconTheme.JabRefIcon.FILE_WORD.getSmallIcon()));
-        list.add(new ExternalFileType("Word 2007+", "docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "oowriter", "openoffice", IconTheme.JabRefIcon.FILE_WORD.getSmallIcon()));
-        list.add(new ExternalFileType(Localization.lang("OpenDocument text"), "odt",
-                "application/vnd.oasis.opendocument.text", "oowriter", "openoffice", IconTheme.getImage("openoffice")));
-        list.add(new ExternalFileType("Excel", "xls", "application/excel", "oocalc", "openoffice", IconTheme.JabRefIcon.FILE_EXCEL.getSmallIcon()));
-        list.add(new ExternalFileType("Excel 2007+", "xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "oocalc", "openoffice", IconTheme.JabRefIcon.FILE_EXCEL.getSmallIcon()));
-        list.add(new ExternalFileType(Localization.lang("OpenDocument spreadsheet"), "ods",
-                "application/vnd.oasis.opendocument.spreadsheet", "oocalc", "openoffice",
-                IconTheme.getImage("openoffice")));
-        list.add(new ExternalFileType("PowerPoint", "ppt", "application/vnd.ms-powerpoint", "ooimpress", "openoffice", IconTheme.JabRefIcon.FILE_POWERPOINT.getSmallIcon()));
-        list.add(new ExternalFileType("PowerPoint 2007+", "pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation", "ooimpress", "openoffice", IconTheme.JabRefIcon.FILE_POWERPOINT.getSmallIcon()));
-        list.add(new ExternalFileType(Localization.lang("OpenDocument presentation"), "odp",
-                "application/vnd.oasis.opendocument.presentation", "ooimpress", "openoffice",
-                IconTheme.getImage("openoffice")));
-        list.add(new ExternalFileType("Rich Text Format", "rtf", "application/rtf", "oowriter", "openoffice", IconTheme.JabRefIcon.FILE_TEXT.getSmallIcon()));
-        list.add(new ExternalFileType(Localization.lang("%0 image", "PNG"), "png", "image/png", "gimp", "picture", IconTheme.JabRefIcon.PICTURE.getSmallIcon()));
-        list.add(new ExternalFileType(Localization.lang("%0 image", "GIF"), "gif", "image/gif", "gimp", "picture", IconTheme.JabRefIcon.PICTURE.getSmallIcon()));
-        list.add(new ExternalFileType(Localization.lang("%0 image", "JPG"), "jpg", "image/jpeg", "gimp", "picture", IconTheme.JabRefIcon.PICTURE.getSmallIcon()));
-        list.add(new ExternalFileType("Djvu", "djvu", "image/vnd.djvu", "evince", "psSmall",
-                IconTheme.JabRefIcon.FILE.getSmallIcon()));
-        list.add(new ExternalFileType("Text", "txt", "text/plain", "emacs", "emacs", IconTheme.JabRefIcon.FILE_TEXT.getSmallIcon()));
-        list.add(new ExternalFileType("LaTeX", "tex", "application/x-latex", "emacs", "emacs", IconTheme.JabRefIcon.FILE_TEXT.getSmallIcon()));
-        list.add(new ExternalFileType("CHM", "chm", "application/mshelp", "gnochm", "www", IconTheme.JabRefIcon.WWW.getSmallIcon()));
-        list.add(new ExternalFileType(Localization.lang("%0 image", "TIFF"), "tiff", "image/tiff", "gimp", "picture",
-                IconTheme.JabRefIcon.PICTURE.getSmallIcon()));
-        list.add(new ExternalFileType("URL", "html", "text/html", "firefox", "www", IconTheme.JabRefIcon.WWW.getSmallIcon()));
-        list.add(new ExternalFileType("MHT", "mht", "multipart/related", "firefox", "www", IconTheme.JabRefIcon.WWW.getSmallIcon()));
-        list.add(new ExternalFileType("ePUB", "epub", "application/epub+zip", "firefox", "www", IconTheme.JabRefIcon.WWW.getSmallIcon()));
-
-        // On all OSes there is a generic application available to handle file opening,
-        // so we don't need the default application settings anymore:
-        for (ExternalFileType type : list) {
-            type.setOpenWith("");
-        }
-
-        return list;
-    }
-
-    public ExternalFileType[] getExternalFileTypeSelection() {
-        return externalFileTypes.toArray(new ExternalFileType[externalFileTypes.size()]);
-    }
-
-    /**
-     * Look up the external file type registered with this name, if any.
-     *
-     * @param name The file type name.
-     * @return The ExternalFileType registered, or null if none.
-     */
-    public ExternalFileType getExternalFileTypeByName(String name) {
-        for (ExternalFileType type : externalFileTypes) {
-            if (type.getName().equals(name)) {
-                return type;
-            }
-        }
-        // Return an instance that signifies an unknown file type:
-        return new UnknownExternalFileType(name);
-    }
-
-    /**
-     * Check if there is an external file type registered with this name.
-     *
-     * @param name The file type name.
-     * @return true if there is an ExternalFileType with this name, false if not.
-     */
-    public Boolean isExternalFileTypeName(String name) {
-        for (ExternalFileType type : externalFileTypes) {
-            if (type.getName().equals(name)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Look up the external file type registered for this extension, if any.
-     *
-     * @param extension The file extension.
-     * @return The ExternalFileType registered, or null if none.
-     */
-    public ExternalFileType getExternalFileTypeByExt(String extension) {
-        for (ExternalFileType type : externalFileTypes) {
-            if ((type.getExtension() != null) && type.getExtension().equalsIgnoreCase(extension)) {
-                return type;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Look up the external file type name registered for this extension, if any.
-     *
-     * @param extension The file extension.
-     * @return The name of the ExternalFileType registered, or null if none.
-     */
-    public String getExternalFileTypeNameByExt(String extension) {
-        for (ExternalFileType type : externalFileTypes) {
-            if ((type.getExtension() != null) && type.getExtension().equalsIgnoreCase(extension)) {
-                return type.getName();
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Look up the external file type registered for this filename, if any.
-     *
-     * @param filename The name of the file whose type to look up.
-     * @return The ExternalFileType registered, or null if none.
-     */
-    public ExternalFileType getExternalFileTypeForName(String filename) {
-        int longestFound = -1;
-        ExternalFileType foundType = null;
-        for (ExternalFileType type : externalFileTypes) {
-            if ((type.getExtension() != null) && filename.toLowerCase().endsWith(type.getExtension().toLowerCase())
-                    && (type.getExtension().length() > longestFound)) {
-                longestFound = type.getExtension().length();
-                foundType = type;
-            }
-        }
-        return foundType;
-    }
-
-    /**
-     * Look up the external file type registered for this MIME type, if any.
-     *
-     * @param mimeType The MIME type.
-     * @return The ExternalFileType registered, or null if none. For the mime type "text/html", a valid file type is
-     *         guaranteed to be returned.
-     */
-    public ExternalFileType getExternalFileTypeByMimeType(String mimeType) {
-        for (ExternalFileType type : externalFileTypes) {
-            if ((type.getMimeType() != null) && type.getMimeType().equals(mimeType)) {
-                return type;
-            }
-        }
-        if ("text/html".equals(mimeType)) {
-            return HTML_FALLBACK_TYPE;
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * Look up the external file type name registered for this MIME type, if any.
-     *
-     * @param mimeType The MIME type.
-     * @return The name of the ExternalFileType registered, or null if none. For the mime type "text/html", a valid file type name is
-     *         guaranteed to be returned.
-     */
-    public String getExternalFileTypeNameByMimeType(String mimeType) {
-        for (ExternalFileType type : externalFileTypes) {
-            if ((type.getMimeType() != null) && type.getMimeType().equals(mimeType)) {
-                return type.getName();
-            }
-        }
-        if ("text/html".equals(mimeType)) {
-            return HTML_FALLBACK_TYPE.getName();
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * Reset the List of external file types after user customization.
-     *
-     * @param types The new List of external file types. This is the complete list, not just new entries.
-     */
-    public void setExternalFileTypes(List<ExternalFileType> types) {
-
-        // First find a list of the default types:
-        List<ExternalFileType> defTypes = getDefaultExternalFileTypes();
-        // Make a list of types that are unchanged:
-        List<ExternalFileType> unchanged = new ArrayList<>();
-
-        externalFileTypes.clear();
-        for (ExternalFileType type : types) {
-            externalFileTypes.add(type);
-
-            // See if we can find a type with matching name in the default type list:
-            ExternalFileType found = null;
-            for (ExternalFileType defType : defTypes) {
-                if (defType.getName().equals(type.getName())) {
-                    found = defType;
-                    break;
-                }
-            }
-            if (found != null) {
-                // Found it! Check if it is an exact match, or if it has been customized:
-                if (found.equals(type)) {
-                    unchanged.add(type);
-                } else {
-                    // It was modified. Remove its entry from the defaults list, since
-                    // the type hasn't been removed:
-                    defTypes.remove(found);
-                }
-            }
-        }
-
-        // Go through unchanged types. Remove them from the ones that should be stored,
-        // and from the list of defaults, since we don't need to mention these in prefs:
-        for (ExternalFileType type : unchanged) {
-            defTypes.remove(type);
-            types.remove(type);
-        }
-
-        // Now set up the array to write to prefs, containing all new types, all modified
-        // types, and a flag denoting each default type that has been removed:
-        String[][] array = new String[types.size() + defTypes.size()][];
-        int i = 0;
-        for (ExternalFileType type : types) {
-            array[i] = type.getStringArrayRepresentation();
-            i++;
-        }
-        for (ExternalFileType type : defTypes) {
-            array[i] = new String[] {type.getName(), JabRefPreferences.FILE_TYPE_REMOVED_FLAG};
-            i++;
-        }
-        //System.out.println("Encoded: '"+Util.encodeStringArray(array)+"'");
-        put("externalFileTypes", StringUtil.encodeStringArray(array));
-    }
-
-    /**
-     * Set up the list of external file types, either from default values, or from values recorded in Preferences.
-     */
-    public void updateExternalFileTypes() {
-        // First get a list of the default file types as a starting point:
-        List<ExternalFileType> types = getDefaultExternalFileTypes();
-        // If no changes have been stored, simply use the defaults:
-        if (prefs.get(EXTERNAL_FILE_TYPES, null) == null) {
-            externalFileTypes.clear();
-            externalFileTypes.addAll(types);
-            return;
-        }
-        // Read the prefs information for file types:
-        String[][] vals = StringUtil.decodeStringDoubleArray(prefs.get(EXTERNAL_FILE_TYPES, ""));
-        for (String[] val : vals) {
-            if ((val.length == 2) && val[1].equals(JabRefPreferences.FILE_TYPE_REMOVED_FLAG)) {
-                // This entry indicates that a default entry type should be removed:
-                ExternalFileType toRemove = null;
-                for (ExternalFileType type : types) {
-                    if (type.getName().equals(val[0])) {
-                        toRemove = type;
-                        break;
-                    }
-                }
-                // If we found it, remove it from the type list:
-                if (toRemove != null) {
-                    types.remove(toRemove);
-                }
-            } else {
-                // A new or modified entry type. Construct it from the string array:
-                ExternalFileType type = ExternalFileType.buildFromArgs(val);
-                // Check if there is a default type with the same name. If so, this is a
-                // modification of that type, so remove the default one:
-                ExternalFileType toRemove = null;
-                for (ExternalFileType defType : types) {
-                    if (type.getName().equals(defType.getName())) {
-                        toRemove = defType;
-                        break;
-                    }
-                }
-                // If we found it, remove it from the type list:
-                if (toRemove != null) {
-                    types.remove(toRemove);
-                }
-
-                // Then add the new one:
-                types.add(type);
-            }
-        }
-
-        // Finally, build the list of types based on the modified defaults list:
-        for (ExternalFileType type : types) {
-            externalFileTypes.add(type);
-        }
-    }
 
     /**
      * Removes all information about custom entry types with tags of

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -1243,7 +1243,8 @@ public final class JabRefPreferences {
         list.add(new ExternalFileType(Localization.lang("%0 image", "PNG"), "png", "image/png", "gimp", "picture", IconTheme.JabRefIcon.PICTURE.getSmallIcon()));
         list.add(new ExternalFileType(Localization.lang("%0 image", "GIF"), "gif", "image/gif", "gimp", "picture", IconTheme.JabRefIcon.PICTURE.getSmallIcon()));
         list.add(new ExternalFileType(Localization.lang("%0 image", "JPG"), "jpg", "image/jpeg", "gimp", "picture", IconTheme.JabRefIcon.PICTURE.getSmallIcon()));
-        list.add(new ExternalFileType("Djvu", "djvu", "", "evince", "psSmall", IconTheme.JabRefIcon.FILE.getSmallIcon()));
+        list.add(new ExternalFileType("Djvu", "djvu", "image/vnd.djvu", "evince", "psSmall",
+                IconTheme.JabRefIcon.FILE.getSmallIcon()));
         list.add(new ExternalFileType("Text", "txt", "text/plain", "emacs", "emacs", IconTheme.JabRefIcon.FILE_TEXT.getSmallIcon()));
         list.add(new ExternalFileType("LaTeX", "tex", "application/x-latex", "emacs", "emacs", IconTheme.JabRefIcon.FILE_TEXT.getSmallIcon()));
         list.add(new ExternalFileType("CHM", "chm", "application/mshelp", "gnochm", "www", IconTheme.JabRefIcon.WWW.getSmallIcon()));

--- a/src/main/java/net/sf/jabref/bibtex/comparator/FieldComparator.java
+++ b/src/main/java/net/sf/jabref/bibtex/comparator/FieldComparator.java
@@ -17,11 +17,11 @@ package net.sf.jabref.bibtex.comparator;
 
 import net.sf.jabref.gui.BibtexFields;
 import net.sf.jabref.gui.maintable.MainTableFormat;
+import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.AuthorList;
 import net.sf.jabref.model.entry.MonthUtil;
 import net.sf.jabref.model.entry.YearUtil;
 import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.util.Util;
 
 import java.text.Collator;
 import java.text.ParseException;
@@ -144,13 +144,13 @@ public class FieldComparator implements Comparator<BibEntry> {
             Integer i1 = null;
             Integer i2 = null;
             try {
-                i1 = Util.intValueOf((String) f1);
+                i1 = StringUtil.intValueOf((String) f1);
             } catch (NumberFormatException ex) {
                 // Parsing failed.
             }
 
             try {
-                i2 = Util.intValueOf((String) f2);
+                i2 = StringUtil.intValueOf((String) f2);
             } catch (NumberFormatException ex) {
                 // Parsing failed.
             }

--- a/src/main/java/net/sf/jabref/exporter/layout/format/FileLink.java
+++ b/src/main/java/net/sf/jabref/exporter/layout/format/FileLink.java
@@ -18,10 +18,10 @@ package net.sf.jabref.exporter.layout.format;
 import java.io.File;
 
 import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.io.SimpleFileList;
+import net.sf.jabref.logic.util.io.SimpleFileListEntry;
 import net.sf.jabref.Globals;
 import net.sf.jabref.exporter.layout.ParamLayoutFormatter;
-import net.sf.jabref.gui.FileListEntry;
-import net.sf.jabref.gui.FileListTableModel;
 import java.io.IOException;
 
 /**
@@ -35,24 +35,24 @@ public class FileLink implements ParamLayoutFormatter {
 
     @Override
     public String format(String field) {
-        FileListTableModel tableModel = new FileListTableModel();
         if (field == null) {
             return "";
         }
 
-        tableModel.setContent(field);
+        SimpleFileList fileList = new SimpleFileList();
+
+        fileList.setContent(field);
         String link = null;
         if (fileType == null) {
             // No file type specified. Simply take the first link.
-            if (tableModel.getRowCount() > 0) {
-                link = tableModel.getEntry(0).getLink();
+            if (!(fileList.isEmpty())) {
+                link = fileList.getEntry(0).getLink();
             }
         }
         else {
             // A file type is specified:
-            for (int i = 0; i < tableModel.getRowCount(); i++) {
-                FileListEntry flEntry = tableModel.getEntry(i);
-                if (flEntry.getType().getName().toLowerCase().equals(fileType)) {
+            for (SimpleFileListEntry flEntry : fileList.getEntryList()) {
+                if (flEntry.getTypeName().equalsIgnoreCase(fileType)) {
                     link = flEntry.getLink();
                     break;
                 }

--- a/src/main/java/net/sf/jabref/exporter/layout/format/FileLink.java
+++ b/src/main/java/net/sf/jabref/exporter/layout/format/FileLink.java
@@ -39,9 +39,8 @@ public class FileLink implements ParamLayoutFormatter {
             return "";
         }
 
-        SimpleFileList fileList = new SimpleFileList();
+        SimpleFileList fileList = new SimpleFileList(field);
 
-        fileList.setContent(field);
         String link = null;
         if (fileType == null) {
             // No file type specified. Simply take the first link.

--- a/src/main/java/net/sf/jabref/exporter/layout/format/WrapFileLinks.java
+++ b/src/main/java/net/sf/jabref/exporter/layout/format/WrapFileLinks.java
@@ -116,8 +116,7 @@ public class WrapFileLinks extends AbstractParamLayoutFormatter {
             return "";
         }
         // Build the list containing the links:
-        SimpleFileList fileList = new SimpleFileList();
-        fileList.setContent(field);
+        SimpleFileList fileList = new SimpleFileList(field);
 
         int piv = 1; // counter for relevant iterations
         for (SimpleFileListEntry flEntry : fileList.getEntryList()) {

--- a/src/main/java/net/sf/jabref/exporter/layout/format/WrapFileLinks.java
+++ b/src/main/java/net/sf/jabref/exporter/layout/format/WrapFileLinks.java
@@ -16,9 +16,9 @@
 package net.sf.jabref.exporter.layout.format;
 
 import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.io.SimpleFileList;
+import net.sf.jabref.logic.util.io.SimpleFileListEntry;
 import net.sf.jabref.exporter.layout.AbstractParamLayoutFormatter;
-import net.sf.jabref.gui.FileListTableModel;
-import net.sf.jabref.gui.FileListEntry;
 import net.sf.jabref.Globals;
 
 import java.util.*;
@@ -112,18 +112,17 @@ public class WrapFileLinks extends AbstractParamLayoutFormatter {
     public String format(String field) {
         StringBuilder sb = new StringBuilder();
 
-        // Build the table model containing the links:
-        FileListTableModel tableModel = new FileListTableModel();
         if (field == null) {
             return "";
         }
-        tableModel.setContent(field);
+        // Build the list containing the links:
+        SimpleFileList fileList = new SimpleFileList();
+        fileList.setContent(field);
 
         int piv = 1; // counter for relevant iterations
-        for (int i = 0; i < tableModel.getRowCount(); i++) {
-            FileListEntry flEntry = tableModel.getEntry(i);
+        for (SimpleFileListEntry flEntry : fileList.getEntryList()) {
             // Use this entry if we don't discriminate on types, or if the type fits:
-            if ((fileType == null) || flEntry.getType().getName().toLowerCase().equals(fileType)) {
+            if ((fileType == null) || flEntry.getTypeName().equalsIgnoreCase(fileType)) {
 
                 for (FormatEntry entry : format) {
                     switch (entry.getType()) {
@@ -134,10 +133,6 @@ public class WrapFileLinks extends AbstractParamLayoutFormatter {
                         sb.append(piv);
                         break;
                     case FILE_PATH:
-                        if (flEntry.getLink() == null) {
-                            break;
-                        }
-
                         String[] dirs;
                         // We need to resolve the file directory from the database's metadata,
                         // but that is not available from a formatter. Therefore, as an
@@ -169,9 +164,6 @@ public class WrapFileLinks extends AbstractParamLayoutFormatter {
 
                         break;
                     case RELATIVE_FILE_PATH:
-                        if (flEntry.getLink() == null) {
-                            break;
-                        }
 
                         /*
                          * Stumbled over this while investigating
@@ -182,16 +174,11 @@ public class WrapFileLinks extends AbstractParamLayoutFormatter {
 
                         break;
                     case FILE_EXTENSION:
-                        if (flEntry.getLink() == null) {
-                            break;
-                        }
-                        int index = flEntry.getLink().lastIndexOf('.');
-                        if ((index >= 0) && (index < (flEntry.getLink().length() - 1))) {
-                            sb.append(replaceStrings(flEntry.getLink().substring(index + 1)));
-                        }
+                        FileUtil.getFileExtension(flEntry.getLink())
+                                .ifPresent(extension -> sb.append(replaceStrings(extension)));
                         break;
                     case FILE_TYPE:
-                        sb.append(replaceStrings(flEntry.getType().getName()));
+                        sb.append(replaceStrings(flEntry.getTypeName()));
                         break;
                     case FILE_DESCRIPTION:
                         sb.append(replaceStrings(flEntry.getDescription()));

--- a/src/main/java/net/sf/jabref/external/DownloadExternalFile.java
+++ b/src/main/java/net/sf/jabref/external/DownloadExternalFile.java
@@ -143,7 +143,7 @@ public class DownloadExternalFile {
         ExternalFileType suggestedType = null;
         if (mimeType != null) {
             LOGGER.debug("MIME Type suggested: " + mimeType);
-            suggestedType = Globals.prefs.getExternalFileTypeByMimeType(mimeType);
+            suggestedType = ExternalFileTypes.getInstance().getExternalFileTypeByMimeType(mimeType);
         }
         // Then, while the download is proceeding, let the user choose the details of the file:
         String suffix;
@@ -152,7 +152,7 @@ public class DownloadExternalFile {
         } else {
             // If we didn't find a file type from the MIME type, try based on extension:
             suffix = getSuffix(res);
-            suggestedType = Globals.prefs.getExternalFileTypeByExt(suffix);
+            suggestedType = ExternalFileTypes.getInstance().getExternalFileTypeByExt(suffix);
         }
 
         String suggestedName = getSuggestedFileName(suffix);
@@ -318,7 +318,7 @@ public class DownloadExternalFile {
         } else {
             suffix = strippedLink.substring(strippedLinkIndex + 1);
         }
-        if (Globals.prefs.getExternalFileTypeByExt(suffix) != null) {
+        if (ExternalFileTypes.getInstance().getExternalFileTypeByExt(suffix) != null) {
             return suffix;
         } else {
             // If the suffix doesn't seem to give any reasonable file type, try

--- a/src/main/java/net/sf/jabref/external/DroppedFileHandler.java
+++ b/src/main/java/net/sf/jabref/external/DroppedFileHandler.java
@@ -176,7 +176,7 @@ public class DroppedFileHandler {
     }
 
     public void linkPdfToEntry(String fileName, MainTable entryTable, BibEntry entry) {
-        ExternalFileType fileType = Globals.prefs.getExternalFileTypeByExt("pdf");
+        ExternalFileType fileType = ExternalFileTypes.getInstance().getExternalFileTypeByExt("pdf");
         NamedCompound edits = new NamedCompound(Localization.lang("Drop %0", fileType.getExtension()));
 
         // Show dialog
@@ -213,7 +213,7 @@ public class DroppedFileHandler {
     }
 
     public void importXmp(List<BibEntry> xmpEntriesInFile, String fileName) {
-        ExternalFileType fileType = Globals.prefs.getExternalFileTypeByExt("pdf");
+        ExternalFileType fileType = ExternalFileTypes.getInstance().getExternalFileTypeByExt("pdf");
         NamedCompound edits = new NamedCompound(Localization.lang("Drop %0", fileType.getExtension()));
 
         boolean isSingle = xmpEntriesInFile.size() == 1;

--- a/src/main/java/net/sf/jabref/external/ExternalFileMenuItem.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFileMenuItem.java
@@ -85,10 +85,10 @@ public class ExternalFileMenuItem extends JMenuItem implements ActionListener {
                     // We try to check the extension for the file:
                     String name = file.getName();
                     int pos = name.indexOf('.');
-                    String extension = pos >= 0 && pos < name.length() - 1 ? name.substring(pos + 1)
+                    String extension = (pos >= 0) && (pos < (name.length() - 1)) ? name.substring(pos + 1)
                             .trim().toLowerCase() : null;
                     // Now we know the extension, check if it is one we know about:
-                    type = Globals.prefs.getExternalFileTypeByExt(extension);
+                    type = ExternalFileTypes.getInstance().getExternalFileTypeByExt(extension);
                     fileType = type;
                 }
             }
@@ -105,7 +105,7 @@ public class ExternalFileMenuItem extends JMenuItem implements ActionListener {
             // link with. We check if the file type is set, and if the file type has a non-empty
             // application link. If that link is referred by the error message, we can assume
             // that the problem is in the open-with-application setting:
-            if (fileType != null && fileType.getOpenWith() != null
+            if ((fileType != null) && (fileType.getOpenWith() != null)
                     && !fileType.getOpenWith().isEmpty() &&
                     e1.getMessage().contains(fileType.getOpenWith())) {
 

--- a/src/main/java/net/sf/jabref/external/ExternalFileTypeEditor.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFileTypeEditor.java
@@ -75,7 +75,7 @@ public class ExternalFileTypeEditor extends JDialog {
      */
     private void setValues() {
         fileTypes.clear();
-        ExternalFileType[] types = Globals.prefs.getExternalFileTypeSelection();
+        ExternalFileType[] types = ExternalFileTypes.getInstance().getExternalFileTypeSelection();
         for (ExternalFileType type : types) {
 
             fileTypes.add(type.copy());
@@ -87,7 +87,7 @@ public class ExternalFileTypeEditor extends JDialog {
      * Store the list of external entry types to Preferences.
      */
     private void storeSettings() {
-        Globals.prefs.setExternalFileTypes(fileTypes);
+        ExternalFileTypes.getInstance().setExternalFileTypes(fileTypes);
     }
 
     private void init() {
@@ -117,7 +117,7 @@ public class ExternalFileTypeEditor extends JDialog {
                         Globals.lang("Reset file type definitions"), JOptionPane.YES_NO_OPTION,
                         JOptionPane.QUESTION_MESSAGE);*/
                 //if (reply == JOptionPane.YES_OPTION) {
-                java.util.List<ExternalFileType> list = Globals.prefs.getDefaultExternalFileTypes();
+                java.util.List<ExternalFileType> list = ExternalFileTypes.getInstance().getDefaultExternalFileTypes();
                 fileTypes.clear();
                 fileTypes.addAll(list);
                 Collections.sort(fileTypes);

--- a/src/main/java/net/sf/jabref/external/ExternalFileTypes.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFileTypes.java
@@ -1,0 +1,344 @@
+package net.sf.jabref.external;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.gui.IconTheme;
+import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.strings.StringUtil;
+
+public class ExternalFileTypes {
+
+    // This String is used in the encoded list in prefs of external file type
+    // modifications, in order to indicate a removed default file type:
+    private static final String FILE_TYPE_REMOVED_FLAG = "REMOVED";
+
+    // Map containing all registered external file types:
+    private final Set<ExternalFileType> externalFileTypes = new TreeSet<>();
+
+    private final ExternalFileType HTML_FALLBACK_TYPE = new ExternalFileType("URL", "html", "text/html", "", "www",
+            IconTheme.JabRefIcon.WWW.getSmallIcon());
+
+    // The only instance of this class:
+    private static ExternalFileTypes singleton;
+
+
+    public static ExternalFileTypes getInstance() {
+        if (ExternalFileTypes.singleton == null) {
+            ExternalFileTypes.singleton = new ExternalFileTypes();
+        }
+        return ExternalFileTypes.singleton;
+    }
+
+    private ExternalFileTypes() {
+        updateExternalFileTypes();
+    }
+
+    public List<ExternalFileType> getDefaultExternalFileTypes() {
+        List<ExternalFileType> list = new ArrayList<>();
+        list.add(new ExternalFileType("PDF", "pdf", "application/pdf", "evince", "pdfSmall",
+                IconTheme.JabRefIcon.PDF_FILE.getSmallIcon()));
+        list.add(new ExternalFileType("PostScript", "ps", "application/postscript", "evince", "psSmall",
+                IconTheme.JabRefIcon.FILE.getSmallIcon()));
+        list.add(new ExternalFileType("Word", "doc", "application/msword", "oowriter", "openoffice",
+                IconTheme.JabRefIcon.FILE_WORD.getSmallIcon()));
+        list.add(new ExternalFileType("Word 2007+", "docx",
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "oowriter", "openoffice",
+                IconTheme.JabRefIcon.FILE_WORD.getSmallIcon()));
+        list.add(new ExternalFileType(Localization.lang("OpenDocument text"), "odt",
+                "application/vnd.oasis.opendocument.text", "oowriter", "openoffice", IconTheme.getImage("openoffice")));
+        list.add(new ExternalFileType("Excel", "xls", "application/excel", "oocalc", "openoffice",
+                IconTheme.JabRefIcon.FILE_EXCEL.getSmallIcon()));
+        list.add(new ExternalFileType("Excel 2007+", "xlsx",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "oocalc", "openoffice",
+                IconTheme.JabRefIcon.FILE_EXCEL.getSmallIcon()));
+        list.add(new ExternalFileType(Localization.lang("OpenDocument spreadsheet"), "ods",
+                "application/vnd.oasis.opendocument.spreadsheet", "oocalc", "openoffice",
+                IconTheme.getImage("openoffice")));
+        list.add(new ExternalFileType("PowerPoint", "ppt", "application/vnd.ms-powerpoint", "ooimpress", "openoffice",
+                IconTheme.JabRefIcon.FILE_POWERPOINT.getSmallIcon()));
+        list.add(new ExternalFileType("PowerPoint 2007+", "pptx",
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation", "ooimpress", "openoffice",
+                IconTheme.JabRefIcon.FILE_POWERPOINT.getSmallIcon()));
+        list.add(new ExternalFileType(Localization.lang("OpenDocument presentation"), "odp",
+                "application/vnd.oasis.opendocument.presentation", "ooimpress", "openoffice",
+                IconTheme.getImage("openoffice")));
+        list.add(new ExternalFileType("Rich Text Format", "rtf", "application/rtf", "oowriter", "openoffice",
+                IconTheme.JabRefIcon.FILE_TEXT.getSmallIcon()));
+        list.add(new ExternalFileType(Localization.lang("%0 image", "PNG"), "png", "image/png", "gimp", "picture",
+                IconTheme.JabRefIcon.PICTURE.getSmallIcon()));
+        list.add(new ExternalFileType(Localization.lang("%0 image", "GIF"), "gif", "image/gif", "gimp", "picture",
+                IconTheme.JabRefIcon.PICTURE.getSmallIcon()));
+        list.add(new ExternalFileType(Localization.lang("%0 image", "JPG"), "jpg", "image/jpeg", "gimp", "picture",
+                IconTheme.JabRefIcon.PICTURE.getSmallIcon()));
+        list.add(new ExternalFileType("Djvu", "djvu", "image/vnd.djvu", "evince", "psSmall",
+                IconTheme.JabRefIcon.FILE.getSmallIcon()));
+        list.add(new ExternalFileType("Text", "txt", "text/plain", "emacs", "emacs",
+                IconTheme.JabRefIcon.FILE_TEXT.getSmallIcon()));
+        list.add(new ExternalFileType("LaTeX", "tex", "application/x-latex", "emacs", "emacs",
+                IconTheme.JabRefIcon.FILE_TEXT.getSmallIcon()));
+        list.add(new ExternalFileType("CHM", "chm", "application/mshelp", "gnochm", "www",
+                IconTheme.JabRefIcon.WWW.getSmallIcon()));
+        list.add(new ExternalFileType(Localization.lang("%0 image", "TIFF"), "tiff", "image/tiff", "gimp", "picture",
+                IconTheme.JabRefIcon.PICTURE.getSmallIcon()));
+        list.add(new ExternalFileType("URL", "html", "text/html", "firefox", "www",
+                IconTheme.JabRefIcon.WWW.getSmallIcon()));
+        list.add(new ExternalFileType("MHT", "mht", "multipart/related", "firefox", "www",
+                IconTheme.JabRefIcon.WWW.getSmallIcon()));
+        list.add(new ExternalFileType("ePUB", "epub", "application/epub+zip", "firefox", "www",
+                IconTheme.JabRefIcon.WWW.getSmallIcon()));
+
+        // On all OSes there is a generic application available to handle file opening,
+        // so we don't need the default application settings anymore:
+        for (ExternalFileType type : list) {
+            type.setOpenWith("");
+        }
+
+        return list;
+    }
+
+    public ExternalFileType[] getExternalFileTypeSelection() {
+        return externalFileTypes.toArray(new ExternalFileType[externalFileTypes.size()]);
+    }
+
+    /**
+     * Look up the external file type registered with this name, if any.
+     *
+     * @param name The file type name.
+     * @return The ExternalFileType registered, or null if none.
+     */
+    public ExternalFileType getExternalFileTypeByName(String name) {
+        for (ExternalFileType type : externalFileTypes) {
+            if (type.getName().equals(name)) {
+                return type;
+            }
+        }
+        // Return an instance that signifies an unknown file type:
+        return new UnknownExternalFileType(name);
+    }
+
+    /**
+     * Check if there is an external file type registered with this name.
+     *
+     * @param name The file type name.
+     * @return true if there is an ExternalFileType with this name, false if not.
+     */
+    public Boolean isExternalFileTypeName(String name) {
+        for (ExternalFileType type : externalFileTypes) {
+            if (type.getName().equals(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Look up the external file type registered for this extension, if any.
+     *
+     * @param extension The file extension.
+     * @return The ExternalFileType registered, or null if none.
+     */
+    public ExternalFileType getExternalFileTypeByExt(String extension) {
+        for (ExternalFileType type : externalFileTypes) {
+            if ((type.getExtension() != null) && type.getExtension().equalsIgnoreCase(extension)) {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Look up the external file type name registered for this extension, if any.
+     *
+     * @param extension The file extension.
+     * @return The name of the ExternalFileType registered, or null if none.
+     */
+    public String getExternalFileTypeNameByExt(String extension) {
+        for (ExternalFileType type : externalFileTypes) {
+            if ((type.getExtension() != null) && type.getExtension().equalsIgnoreCase(extension)) {
+                return type.getName();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Look up the external file type registered for this filename, if any.
+     *
+     * @param filename The name of the file whose type to look up.
+     * @return The ExternalFileType registered, or null if none.
+     */
+    public ExternalFileType getExternalFileTypeForName(String filename) {
+        int longestFound = -1;
+        ExternalFileType foundType = null;
+        for (ExternalFileType type : externalFileTypes) {
+            if ((type.getExtension() != null) && filename.toLowerCase().endsWith(type.getExtension().toLowerCase())
+                    && (type.getExtension().length() > longestFound)) {
+                longestFound = type.getExtension().length();
+                foundType = type;
+            }
+        }
+        return foundType;
+    }
+
+    /**
+     * Look up the external file type registered for this MIME type, if any.
+     *
+     * @param mimeType The MIME type.
+     * @return The ExternalFileType registered, or null if none. For the mime type "text/html", a valid file type is
+     *         guaranteed to be returned.
+     */
+    public ExternalFileType getExternalFileTypeByMimeType(String mimeType) {
+        for (ExternalFileType type : externalFileTypes) {
+            if ((type.getMimeType() != null) && type.getMimeType().equals(mimeType)) {
+                return type;
+            }
+        }
+        if ("text/html".equals(mimeType)) {
+            return HTML_FALLBACK_TYPE;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Look up the external file type name registered for this MIME type, if any.
+     *
+     * @param mimeType The MIME type.
+     * @return The name of the ExternalFileType registered, or null if none. For the mime type "text/html", a valid file type name is
+     *         guaranteed to be returned.
+     */
+    public String getExternalFileTypeNameByMimeType(String mimeType) {
+        for (ExternalFileType type : externalFileTypes) {
+            if ((type.getMimeType() != null) && type.getMimeType().equals(mimeType)) {
+                return type.getName();
+            }
+        }
+        if ("text/html".equals(mimeType)) {
+            return HTML_FALLBACK_TYPE.getName();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Reset the List of external file types after user customization.
+     *
+     * @param types The new List of external file types. This is the complete list, not just new entries.
+     */
+    public void setExternalFileTypes(List<ExternalFileType> types) {
+
+        // First find a list of the default types:
+        List<ExternalFileType> defTypes = getDefaultExternalFileTypes();
+        // Make a list of types that are unchanged:
+        List<ExternalFileType> unchanged = new ArrayList<>();
+
+        externalFileTypes.clear();
+        for (ExternalFileType type : types) {
+            externalFileTypes.add(type);
+
+            // See if we can find a type with matching name in the default type list:
+            ExternalFileType found = null;
+            for (ExternalFileType defType : defTypes) {
+                if (defType.getName().equals(type.getName())) {
+                    found = defType;
+                    break;
+                }
+            }
+            if (found != null) {
+                // Found it! Check if it is an exact match, or if it has been customized:
+                if (found.equals(type)) {
+                    unchanged.add(type);
+                } else {
+                    // It was modified. Remove its entry from the defaults list, since
+                    // the type hasn't been removed:
+                    defTypes.remove(found);
+                }
+            }
+        }
+
+        // Go through unchanged types. Remove them from the ones that should be stored,
+        // and from the list of defaults, since we don't need to mention these in prefs:
+        for (ExternalFileType type : unchanged) {
+            defTypes.remove(type);
+            types.remove(type);
+        }
+
+        // Now set up the array to write to prefs, containing all new types, all modified
+        // types, and a flag denoting each default type that has been removed:
+        String[][] array = new String[types.size() + defTypes.size()][];
+        int i = 0;
+        for (ExternalFileType type : types) {
+            array[i] = type.getStringArrayRepresentation();
+            i++;
+        }
+        for (ExternalFileType type : defTypes) {
+            array[i] = new String[] {type.getName(), FILE_TYPE_REMOVED_FLAG};
+            i++;
+        }
+        //System.out.println("Encoded: '"+Util.encodeStringArray(array)+"'");
+        Globals.prefs.put("externalFileTypes", StringUtil.encodeStringArray(array));
+    }
+
+    /**
+     * Set up the list of external file types, either from default values, or from values recorded in Preferences.
+     */
+    private void updateExternalFileTypes() {
+        // First get a list of the default file types as a starting point:
+        List<ExternalFileType> types = getDefaultExternalFileTypes();
+        // If no changes have been stored, simply use the defaults:
+        if (Globals.prefs.get(JabRefPreferences.EXTERNAL_FILE_TYPES, null) == null) {
+            externalFileTypes.clear();
+            externalFileTypes.addAll(types);
+            return;
+        }
+        // Read the prefs information for file types:
+        String[][] vals = StringUtil
+                .decodeStringDoubleArray(Globals.prefs.get(JabRefPreferences.EXTERNAL_FILE_TYPES, ""));
+        for (String[] val : vals) {
+            if ((val.length == 2) && val[1].equals(FILE_TYPE_REMOVED_FLAG)) {
+                // This entry indicates that a default entry type should be removed:
+                ExternalFileType toRemove = null;
+                for (ExternalFileType type : types) {
+                    if (type.getName().equals(val[0])) {
+                        toRemove = type;
+                        break;
+                    }
+                }
+                // If we found it, remove it from the type list:
+                if (toRemove != null) {
+                    types.remove(toRemove);
+                }
+            } else {
+                // A new or modified entry type. Construct it from the string array:
+                ExternalFileType type = ExternalFileType.buildFromArgs(val);
+                // Check if there is a default type with the same name. If so, this is a
+                // modification of that type, so remove the default one:
+                ExternalFileType toRemove = null;
+                for (ExternalFileType defType : types) {
+                    if (type.getName().equals(defType.getName())) {
+                        toRemove = defType;
+                        break;
+                    }
+                }
+                // If we found it, remove it from the type list:
+                if (toRemove != null) {
+                    types.remove(toRemove);
+                }
+
+                // Then add the new one:
+                types.add(type);
+            }
+        }
+
+        // Finally, build the list of types based on the modified defaults list:
+        for (ExternalFileType type : types) {
+            externalFileTypes.add(type);
+        }
+    }
+
+}

--- a/src/main/java/net/sf/jabref/external/SynchronizeFileField.java
+++ b/src/main/java/net/sf/jabref/external/SynchronizeFileField.java
@@ -211,11 +211,12 @@ public class SynchronizeFileField extends AbstractWorker {
                                 if (editor.okPressed()) {
                                     // Get the old list of types, add this one, and update the list in prefs:
                                     List<ExternalFileType> fileTypes = new ArrayList<>();
-                                    ExternalFileType[] oldTypes = Globals.prefs.getExternalFileTypeSelection();
+                                    ExternalFileType[] oldTypes = ExternalFileTypes.getInstance()
+                                            .getExternalFileTypeSelection();
                                     Collections.addAll(fileTypes, oldTypes);
                                     fileTypes.add(newType);
                                     Collections.sort(fileTypes);
-                                    Globals.prefs.setExternalFileTypes(fileTypes);
+                                    ExternalFileTypes.getInstance().setExternalFileTypes(fileTypes);
                                     panel.mainTable.repaint();
                                 }
                             } else {

--- a/src/main/java/net/sf/jabref/groups/EntryTableTransferHandler.java
+++ b/src/main/java/net/sf/jabref/groups/EntryTableTransferHandler.java
@@ -38,11 +38,11 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import net.sf.jabref.gui.BasePanel;
-import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefExecutorService;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.external.DroppedFileHandler;
 import net.sf.jabref.external.ExternalFileType;
+import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.external.TransferableFileLinkSelection;
 import net.sf.jabref.gui.maintable.MainTable;
 import net.sf.jabref.importer.ImportMenuItem;
@@ -358,7 +358,7 @@ public class EntryTableTransferHandler extends TransferHandler {
                 continue;
             }
 
-            fileType = Globals.prefs.getExternalFileTypeByExt(extension.orElse(""));
+            fileType = ExternalFileTypes.getInstance().getExternalFileTypeByExt(extension.orElse(""));
             /*
              * This is a linkable file. If the user dropped it on an entry, we
              * should offer options for autolinking to this files:

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -910,7 +910,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     @Override
                     public void run() {
                         final BibEntry[] bes = mainTable.getSelectedEntries();
-                        final List<File> files = Util.getListOfLinkedFiles(bes,
+                        final List<File> files = FileUtil.getListOfLinkedFiles(bes,
                                 metaData().getFileDirectory(Globals.FILE_FIELD));
                         for (final File f : files) {
                             try {
@@ -944,7 +944,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                         // Look for web links in the "file" field as a fallback:
                         FileListEntry entry = null;
                         FileListTableModel tm = new FileListTableModel();
-                        tm.setContent(bes[0].getField("file"));
+                        tm.setContent(bes[0].getField(Globals.FILE_FIELD));
                         for (int i = 0; i < tm.getRowCount(); i++) {
                             FileListEntry flEntry = tm.getEntry(i);
                             if (URL_FIELD.equals(flEntry.getType().getName().toLowerCase())
@@ -2577,7 +2577,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 String regExp = Globals.prefs.get(JabRefPreferences.REG_EXP_SEARCH_EXPRESSION_KEY);
                 result = RegExpFileSearch.findFilesForSet(entries, extensions, dirs, regExp);
             } else {
-                result = Util.findAssociatedFiles(entries, extensions, dirs);
+                result = FileUtil.findAssociatedFiles(entries, extensions, dirs);
             }
             if (result.get(entry) != null) {
                 final List<File> res = result.get(entry);

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -2558,7 +2558,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             // see if we can fall back to a filename based on the bibtex key
             final Collection<BibEntry> entries = Collections.singleton(entry);
 
-            final ExternalFileType[] types = Globals.prefs.getExternalFileTypeSelection();
+            final ExternalFileType[] types = ExternalFileTypes.getInstance().getExternalFileTypeSelection();
             final List<File> dirs = new ArrayList<>();
             if (basePanel.metaData.getFileDirectory(Globals.FILE_FIELD).length > 0) {
                 final String[] mdDirs = basePanel.metaData.getFileDirectory(Globals.FILE_FIELD);
@@ -2585,7 +2585,8 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     final String filepath = res.get(0).getPath();
                     final Optional<String> extension = FileUtil.getFileExtension(filepath);
                     if (extension.isPresent()) {
-                        ExternalFileType type = Globals.prefs.getExternalFileTypeByExt(extension.get());
+                        ExternalFileType type = ExternalFileTypes.getInstance()
+                                .getExternalFileTypeByExt(extension.get());
                         if (type != null) {
                             try {
                                 JabRefDesktop.openExternalFileAnyFormat(basePanel.metaData, filepath, type);

--- a/src/main/java/net/sf/jabref/gui/FileListEntry.java
+++ b/src/main/java/net/sf/jabref/gui/FileListEntry.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2015 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -16,37 +16,24 @@
 package net.sf.jabref.gui;
 
 import net.sf.jabref.external.ExternalFileType;
+import net.sf.jabref.logic.util.io.SimpleFileListEntry;
 
 /**
  * This class represents a file link for a Bibtex entry.
  */
-public class FileListEntry {
+public class FileListEntry extends SimpleFileListEntry {
 
-    private String link;
-    private String description;
     private ExternalFileType type;
 
 
     public FileListEntry(String description, String link, ExternalFileType type) {
-        this.link = link;
-        this.description = description;
+        super(description, link);
         this.type = type;
     }
 
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public String getLink() {
-        return link;
-    }
-
-    public void setLink(String link) {
-        this.link = link;
+    public FileListEntry(SimpleFileListEntry simpleEntry, ExternalFileType type) {
+        super(simpleEntry.getDescription(), simpleEntry.getLink());
+        this.type = type;
     }
 
     public ExternalFileType getType() {
@@ -58,8 +45,8 @@ public class FileListEntry {
     }
 
     public String[] getStringArrayRepresentation() {
-        String type = getType() != null ? getType().getName() : "";
-        return new String[] {getDescription(), getLink(), type};
+        String typeString = getType() != null ? getType().getName() : "";
+        return new String[] {getDescription(), getLink(), typeString};
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/gui/FileListEntry.java
+++ b/src/main/java/net/sf/jabref/gui/FileListEntry.java
@@ -44,6 +44,7 @@ public class FileListEntry extends SimpleFileListEntry {
         this.type = type;
     }
 
+    @Override
     public String[] getStringArrayRepresentation() {
         String typeString = getType() != null ? getType().getName() : "";
         return new String[] {getDescription(), getLink(), typeString};

--- a/src/main/java/net/sf/jabref/gui/FileListEntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/FileListEntryEditor.java
@@ -40,6 +40,7 @@ import net.sf.jabref.gui.desktop.JabRefDesktop;
 import net.sf.jabref.gui.util.PositionWindow;
 import net.sf.jabref.external.ConfirmCloseFileListEntryEditor;
 import net.sf.jabref.external.ExternalFileType;
+import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.external.UnknownExternalFileType;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
@@ -227,7 +228,7 @@ public class FileListEntryEditor {
 
             // Check if this looks like a remote link:
             if (FileListEntryEditor.remoteLinkPattern.matcher(link.getText()).matches()) {
-                ExternalFileType type = Globals.prefs.getExternalFileTypeByExt("html");
+                ExternalFileType type = ExternalFileTypes.getInstance().getExternalFileTypeByExt("html");
                 if (type != null) {
                     types.setSelectedItem(type);
                     return;
@@ -236,7 +237,7 @@ public class FileListEntryEditor {
 
             // Try to guess the file type:
             String theLink = link.getText().trim();
-            ExternalFileType type = Globals.prefs.getExternalFileTypeForName(theLink);
+            ExternalFileType type = ExternalFileTypes.getInstance().getExternalFileTypeForName(theLink);
             if (type != null) {
                 types.setSelectedItem(type);
             }
@@ -293,7 +294,7 @@ public class FileListEntryEditor {
         link.setText(entry.getLink());
         //if (link.getText().length() > 0)
         //    checkExtension();
-        types.setModel(new DefaultComboBoxModel<>(Globals.prefs.getExternalFileTypeSelection()));
+        types.setModel(new DefaultComboBoxModel<>(ExternalFileTypes.getInstance().getExternalFileTypeSelection()));
         types.setSelectedIndex(-1);
         // See what is a reasonable selection for the type combobox:
         if ((entry.getType() != null) && !(entry.getType() instanceof UnknownExternalFileType)) {

--- a/src/main/java/net/sf/jabref/gui/FileListTableModel.java
+++ b/src/main/java/net/sf/jabref/gui/FileListTableModel.java
@@ -25,8 +25,8 @@ import javax.swing.SwingUtilities;
 import javax.swing.event.TableModelEvent;
 import javax.swing.table.AbstractTableModel;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.external.ExternalFileType;
+import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.external.UnknownExternalFileType;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.logic.util.io.SimpleFileListEntry;
@@ -172,19 +172,19 @@ public class FileListTableModel extends AbstractTableModel {
     }
 
     private FileListEntry decodeEntry(SimpleFileListEntry entry, boolean deduceUnknownType) {
-        ExternalFileType type = Globals.prefs.getExternalFileTypeByName(entry.getTypeName());
+        ExternalFileType type = ExternalFileTypes.getInstance().getExternalFileTypeByName(entry.getTypeName());
 
         if (deduceUnknownType && (type instanceof UnknownExternalFileType)) {
             // No file type was recognized. Try to find a usable file type based
             // on mime type:
-            type = Globals.prefs.getExternalFileTypeByMimeType(entry.getTypeName());
+            type = ExternalFileTypes.getInstance().getExternalFileTypeByMimeType(entry.getTypeName());
             if (type == null) {
                 // No type could be found from mime type on the extension:
                 //System.out.println("Not found by mime: '"+getElementIfAvailable(contents, 2));
                 ExternalFileType typeGuess = null;
                 Optional<String> extension = FileUtil.getFileExtension(entry.getLink());
                 if (extension.isPresent()) {
-                    typeGuess = Globals.prefs.getExternalFileTypeByExt(extension.get());
+                    typeGuess = ExternalFileTypes.getInstance().getExternalFileTypeByExt(extension.get());
                 }
                 if (typeGuess != null) {
                     type = typeGuess;

--- a/src/main/java/net/sf/jabref/gui/FileListTableModel.java
+++ b/src/main/java/net/sf/jabref/gui/FileListTableModel.java
@@ -17,6 +17,7 @@ package net.sf.jabref.gui;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Optional;
 
 import javax.swing.JLabel;
@@ -28,6 +29,7 @@ import net.sf.jabref.Globals;
 import net.sf.jabref.external.ExternalFileType;
 import net.sf.jabref.external.UnknownExternalFileType;
 import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.io.SimpleFileListEntry;
 import net.sf.jabref.logic.util.strings.StringUtil;
 
 /**
@@ -130,56 +132,15 @@ public class FileListTableModel extends AbstractTableModel {
         if (value == null) {
             value = "";
         }
+        List<SimpleFileListEntry> fileEntryList = FileUtil.decodeFileField(value);
         ArrayList<FileListEntry> newList = new ArrayList<>();
-        StringBuilder sb = new StringBuilder();
-        ArrayList<String> thisEntry = new ArrayList<>();
-        boolean inXmlChar = false;
-        boolean escaped = false;
-        for (int i = 0; i < value.length(); i++) {
-            char c = value.charAt(i);
-            if (!escaped && (c == '\\')) {
-                escaped = true;
-                continue;
-            }
-            // Check if we are entering an XML special character construct such
-            // as "&#44;", because we need to know in order to ignore the semicolon.
-            else if (!escaped && (c == '&') && !inXmlChar) {
-                sb.append(c);
-                if ((value.length() > (i + 1)) && (value.charAt(i + 1) == '#')) {
-                    inXmlChar = true;
-                }
-            }
-            // Check if we are exiting an XML special character construct:
-            else if (!escaped && inXmlChar && (c == ';')) {
-                sb.append(c);
-                inXmlChar = false;
-            }
-            else if (!escaped && (c == ':')) {
-                thisEntry.add(sb.toString());
-                sb = new StringBuilder();
-            }
-            else if (!escaped && (c == ';') && !inXmlChar) {
-                thisEntry.add(sb.toString());
-                sb = new StringBuilder();
-                if (firstOnly) {
-                    return decodeEntry(thisEntry, deduceUnknownTypes);
-                } else {
-                    newList.add(decodeEntry(thisEntry, deduceUnknownTypes));
-                    thisEntry.clear();
-                }
-            } else {
-                sb.append(c);
-            }
-            escaped = false;
-        }
-        if (sb.length() > 0) {
-            thisEntry.add(sb.toString());
-        }
-        if (!thisEntry.isEmpty()) {
+        if (!(fileEntryList.isEmpty())) {
             if (firstOnly) {
-                return decodeEntry(thisEntry, deduceUnknownTypes);
+                return decodeEntry(fileEntryList.get(0), deduceUnknownTypes);
             } else {
-                newList.add(decodeEntry(thisEntry, deduceUnknownTypes));
+                for (SimpleFileListEntry thisEntry : fileEntryList) {
+                    newList.add(decodeEntry(thisEntry, deduceUnknownTypes));
+                }
             }
         }
 
@@ -210,21 +171,18 @@ public class FileListTableModel extends AbstractTableModel {
         return entry.getType().getIconLabel();
     }
 
-    private FileListEntry decodeEntry(ArrayList<String> contents, boolean deduceUnknownType) {
-        ExternalFileType type = Globals.prefs.getExternalFileTypeByName
-                (getElementIfAvailable(contents, 2));
+    private FileListEntry decodeEntry(SimpleFileListEntry entry, boolean deduceUnknownType) {
+        ExternalFileType type = Globals.prefs.getExternalFileTypeByName(entry.getTypeName());
 
         if (deduceUnknownType && (type instanceof UnknownExternalFileType)) {
             // No file type was recognized. Try to find a usable file type based
             // on mime type:
-            type = Globals.prefs.getExternalFileTypeByMimeType
-                    (getElementIfAvailable(contents, 2));
+            type = Globals.prefs.getExternalFileTypeByMimeType(entry.getTypeName());
             if (type == null) {
                 // No type could be found from mime type on the extension:
                 //System.out.println("Not found by mime: '"+getElementIfAvailable(contents, 2));
                 ExternalFileType typeGuess = null;
-                String link = getElementIfAvailable(contents, 1);
-                Optional<String> extension = FileUtil.getFileExtension(link);
+                Optional<String> extension = FileUtil.getFileExtension(entry.getLink());
                 if (extension.isPresent()) {
                     typeGuess = Globals.prefs.getExternalFileTypeByExt(extension.get());
                 }
@@ -234,17 +192,7 @@ public class FileListTableModel extends AbstractTableModel {
             }
         }
 
-        return new FileListEntry(getElementIfAvailable(contents, 0),
-                getElementIfAvailable(contents, 1),
-                type);
-    }
-
-    private String getElementIfAvailable(ArrayList<String> contents, int index) {
-        if (index < contents.size()) {
-            return contents.get(index);
-        } else {
-            return "";
-        }
+        return new FileListEntry(entry, type);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/gui/GUIGlobals.java
+++ b/src/main/java/net/sf/jabref/gui/GUIGlobals.java
@@ -30,6 +30,7 @@ import org.xnap.commons.gui.shortcut.EmacsKeyBindings;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.external.ExternalFileType;
+import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.gui.help.HelpDialog;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.specialfields.Printed;
@@ -226,7 +227,7 @@ public class GUIGlobals {
         label.setToolTipText(Localization.lang("Open file"));
         GUIGlobals.tableIcons.put(Globals.FILE_FIELD, label);
 
-        for (ExternalFileType fileType : Globals.prefs.getExternalFileTypeSelection()) {
+        for (ExternalFileType fileType : ExternalFileTypes.getInstance().getExternalFileTypeSelection()) {
             label = new JLabel(fileType.getIcon());
             label.setToolTipText(Localization.lang("Open %0 file", fileType.getName()));
             GUIGlobals.tableIcons.put(fileType.getName(), label);

--- a/src/main/java/net/sf/jabref/gui/PdfPreviewPanel.java
+++ b/src/main/java/net/sf/jabref/gui/PdfPreviewPanel.java
@@ -33,6 +33,8 @@ import net.sf.jabref.MetaData;
 
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.io.SimpleFileList;
+import net.sf.jabref.logic.util.io.SimpleFileListEntry;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -115,12 +117,12 @@ class PdfPreviewPanel extends JPanel {
         }
         picLabel.setText("rendering preview...");
         picLabel.setIcon(null);
-        FileListTableModel tm = new FileListTableModel();
-        tm.setContent(entry.getField(Globals.FILE_FIELD));
-        FileListEntry flEntry = null;
-        for (int i = 0; i < tm.getRowCount(); i++) {
-            flEntry = tm.getEntry(i);
-            if ("pdf".equals(flEntry.getType().getName().toLowerCase())) {
+        SimpleFileList fileList = new SimpleFileList();
+        fileList.setContent(entry.getField(Globals.FILE_FIELD));
+        SimpleFileListEntry flEntry = null;
+        for (SimpleFileListEntry tmpFileListEntry : fileList.getEntryList()) {
+            if ("pdf".equals(tmpFileListEntry.getTypeName().toLowerCase())) {
+                flEntry = tmpFileListEntry;
                 break;
             }
         }

--- a/src/main/java/net/sf/jabref/gui/PdfPreviewPanel.java
+++ b/src/main/java/net/sf/jabref/gui/PdfPreviewPanel.java
@@ -28,6 +28,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.Globals;
 import net.sf.jabref.MetaData;
 
 import net.sf.jabref.logic.l10n.Localization;
@@ -115,7 +116,7 @@ class PdfPreviewPanel extends JPanel {
         picLabel.setText("rendering preview...");
         picLabel.setIcon(null);
         FileListTableModel tm = new FileListTableModel();
-        tm.setContent(entry.getField("file"));
+        tm.setContent(entry.getField(Globals.FILE_FIELD));
         FileListEntry flEntry = null;
         for (int i = 0; i < tm.getRowCount(); i++) {
             flEntry = tm.getEntry(i);

--- a/src/main/java/net/sf/jabref/gui/PdfPreviewPanel.java
+++ b/src/main/java/net/sf/jabref/gui/PdfPreviewPanel.java
@@ -117,8 +117,7 @@ class PdfPreviewPanel extends JPanel {
         }
         picLabel.setText("rendering preview...");
         picLabel.setIcon(null);
-        SimpleFileList fileList = new SimpleFileList();
-        fileList.setContent(entry.getField(Globals.FILE_FIELD));
+        SimpleFileList fileList = new SimpleFileList(entry.getField(Globals.FILE_FIELD));
         SimpleFileListEntry flEntry = null;
         for (SimpleFileListEntry tmpFileListEntry : fileList.getEntryList()) {
             if ("pdf".equals(tmpFileListEntry.getTypeName().toLowerCase())) {

--- a/src/main/java/net/sf/jabref/gui/RightClickMenu.java
+++ b/src/main/java/net/sf/jabref/gui/RightClickMenu.java
@@ -147,7 +147,7 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
 
         add(new GeneralAction(Actions.OPEN_FOLDER, Localization.lang("Open folder")) {
             {
-                if (!isFieldSetForSelectedEntry("file")) {
+                if (!isFieldSetForSelectedEntry(Globals.FILE_FIELD)) {
                     this.setEnabled(false);
                 }
             }
@@ -155,7 +155,7 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
 
         add(new GeneralAction(Actions.OPEN_EXTERNAL_FILE, Localization.lang("Open file"), getFileIconForSelectedEntry()) {
             {
-                if(!isFieldSetForSelectedEntry("file")) {
+                if (!isFieldSetForSelectedEntry(Globals.FILE_FIELD)) {
                     this.setEnabled(false);
                 }
             }

--- a/src/main/java/net/sf/jabref/gui/desktop/JabRefDesktop.java
+++ b/src/main/java/net/sf/jabref/gui/desktop/JabRefDesktop.java
@@ -3,6 +3,7 @@ package net.sf.jabref.gui.desktop;
 import net.sf.jabref.*;
 import net.sf.jabref.external.ExternalFileType;
 import net.sf.jabref.external.ExternalFileTypeEntryEditor;
+import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.external.UnknownExternalFileType;
 import net.sf.jabref.gui.*;
 import net.sf.jabref.gui.undo.UndoableFieldChange;
@@ -92,7 +93,7 @@ public class JabRefDesktop {
         } else if ("ps".equals(fieldName)) {
             try {
                 if (OS.OS_X) {
-                    ExternalFileType type = Globals.prefs.getExternalFileTypeByExt("ps");
+                    ExternalFileType type = ExternalFileTypes.getInstance().getExternalFileTypeByExt("ps");
                     String viewer = type != null ? type.getOpenWith() : Globals.prefs.get(JabRefPreferences.PSVIEWER);
                     String[] cmd = {"/usr/bin/open", "-a", viewer, link};
                     Runtime.getRuntime().exec(cmd);
@@ -104,7 +105,7 @@ public class JabRefDesktop {
                      * cmdArray[0] + " " + cmdArray[1]);
                      */
                 } else {
-                    ExternalFileType type = Globals.prefs.getExternalFileTypeByExt("ps");
+                    ExternalFileType type = ExternalFileTypes.getInstance().getExternalFileTypeByExt("ps");
                     String viewer = type != null ? type.getOpenWith() : "xdg-open";
                     String[] cmdArray = new String[2];
                     cmdArray[0] = viewer;
@@ -117,7 +118,7 @@ public class JabRefDesktop {
         } else if ("pdf".equals(fieldName)) {
             try {
                 if (OS.OS_X) {
-                    ExternalFileType type = Globals.prefs.getExternalFileTypeByExt("pdf");
+                    ExternalFileType type = ExternalFileTypes.getInstance().getExternalFileTypeByExt("pdf");
                     String viewer = type != null ? type.getOpenWith() : Globals.prefs.get(JabRefPreferences.PSVIEWER);
                     String[] cmd = {"/usr/bin/open", "-a", viewer, link};
                     Runtime.getRuntime().exec(cmd);
@@ -135,7 +136,7 @@ public class JabRefDesktop {
                      * Process child = Runtime.getRuntime().exec(cmd);
                      */
                 } else {
-                    ExternalFileType type = Globals.prefs.getExternalFileTypeByExt("pdf");
+                    ExternalFileType type = ExternalFileTypes.getInstance().getExternalFileTypeByExt("pdf");
                     String viewer = type != null ? type.getOpenWith() : Globals.prefs.get(JabRefPreferences.PSVIEWER);
                     String[] cmdArray = new String[2];
                     cmdArray[0] = viewer;
@@ -323,11 +324,11 @@ public class JabRefDesktop {
             if (editor.okPressed()) {
                 // Get the old list of types, add this one, and update the list in prefs:
                 List<ExternalFileType> fileTypes = new ArrayList<>();
-                ExternalFileType[] oldTypes = Globals.prefs.getExternalFileTypeSelection();
+                ExternalFileType[] oldTypes = ExternalFileTypes.getInstance().getExternalFileTypeSelection();
                 Collections.addAll(fileTypes, oldTypes);
                 fileTypes.add(newType);
                 Collections.sort(fileTypes);
-                Globals.prefs.setExternalFileTypes(fileTypes);
+                ExternalFileTypes.getInstance().setExternalFileTypes(fileTypes);
                 // Finally, open the file:
                 return openExternalFileAnyFormat(metaData, link, newType);
             } else {
@@ -428,7 +429,7 @@ public class JabRefDesktop {
      */
     public static void openBrowser(String url) throws IOException {
         url = URLUtil.sanitizeUrl(url);
-        ExternalFileType fileType = Globals.prefs.getExternalFileTypeByExt("html");
+        ExternalFileType fileType = ExternalFileTypes.getInstance().getExternalFileTypeByExt("html");
         openExternalFilePlatformIndependent(fileType, url);
     }
 }

--- a/src/main/java/net/sf/jabref/gui/fieldeditors/FileListEditor.java
+++ b/src/main/java/net/sf/jabref/gui/fieldeditors/FileListEditor.java
@@ -277,7 +277,8 @@ public class FileListEditor extends JTable implements FieldEditor, DownloadExter
         if (row >= 0) {
             FileListEntry entry = tableModel.getEntry(row);
             try {
-                ExternalFileType type = Globals.prefs.getExternalFileTypeByName(entry.getType().getName());
+                ExternalFileType type = ExternalFileTypes.getInstance()
+                        .getExternalFileTypeByName(entry.getType().getName());
                 JabRefDesktop.openExternalFileAnyFormat(metaData, entry.getLink(),
                         type != null ? type : entry.getType());
             } catch (IOException e) {

--- a/src/main/java/net/sf/jabref/gui/fieldeditors/FileListEditorTransferHandler.java
+++ b/src/main/java/net/sf/jabref/gui/fieldeditors/FileListEditorTransferHandler.java
@@ -35,11 +35,11 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import net.sf.jabref.gui.EntryContainer;
-import net.sf.jabref.Globals;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.external.DroppedFileHandler;
 import net.sf.jabref.external.ExternalFileType;
+import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.groups.EntryTableTransferHandler;
 
 class FileListEditorTransferHandler extends TransferHandler {
@@ -124,7 +124,7 @@ class FileListEditorTransferHandler extends TransferHandler {
                             Optional<String> extension = FileUtil.getFileExtension(name);
                             ExternalFileType fileType = null;
                             if (extension.isPresent()) {
-                                fileType = Globals.prefs.getExternalFileTypeByExt(extension.get());
+                                fileType = ExternalFileTypes.getInstance().getExternalFileTypeByExt(extension.get());
                             }
                             if (fileType != null) {
                                 if (droppedFileHandler == null) {

--- a/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
@@ -33,6 +33,7 @@ import javax.swing.table.TableModel;
 
 import net.sf.jabref.*;
 import net.sf.jabref.external.ExternalFileType;
+import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.gui.IconTheme;
@@ -279,7 +280,7 @@ class TableColumnsTab extends JPanel implements PrefsTab {
                 listOfFileColumns.setEnabled(extraFileColumns.isSelected());
             }
         });
-        ExternalFileType[] fileTypes = Globals.prefs.getExternalFileTypeSelection();
+        ExternalFileType[] fileTypes = ExternalFileTypes.getInstance().getExternalFileTypeSelection();
         String[] fileTypeNames = new String[fileTypes.length];
         for (int i = 0; i < fileTypes.length; i++) {
             fileTypeNames[i] = fileTypes[i].getName();

--- a/src/main/java/net/sf/jabref/gui/worker/SendAsEMailAction.java
+++ b/src/main/java/net/sf/jabref/gui/worker/SendAsEMailAction.java
@@ -30,9 +30,10 @@ import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.bibtex.BibEntryWriter;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.gui.desktop.JabRefDesktop;
-import net.sf.jabref.util.Util;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -94,7 +95,7 @@ public class SendAsEMailAction extends AbstractWorker {
         //   the unofficial "mailto:attachment" property
         boolean openFolders = JabRefPreferences.getInstance().getBoolean(JabRefPreferences.OPEN_FOLDERS_OF_ATTACHED_FILES);
 
-        List<File> fileList = Util.getListOfLinkedFiles(bes, frame.getCurrentBasePanel().metaData().getFileDirectory(Globals.FILE_FIELD));
+        List<File> fileList = FileUtil.getListOfLinkedFiles(bes, frame.getCurrentBasePanel().metaData().getFileDirectory(Globals.FILE_FIELD));
         for (File f : fileList) {
             attachments.add(f.getPath());
             if (openFolders) {

--- a/src/main/java/net/sf/jabref/importer/DatabaseFileLookup.java
+++ b/src/main/java/net/sf/jabref/importer/DatabaseFileLookup.java
@@ -26,6 +26,7 @@ import net.sf.jabref.Globals;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.io.SimpleFileListEntry;
 import net.sf.jabref.JabRef;
 
 /**
@@ -119,10 +120,10 @@ class DatabaseFileLookup {
         }
 
         String fileField = anEntry.getField(Globals.FILE_FIELD);
-        List<List<String>> fileList = FileUtil.decodeFileField(fileField);
+        List<SimpleFileListEntry> fileList = FileUtil.decodeFileField(fileField);
 
-        for (List<String> fileInfo : fileList) {
-            String link = fileInfo.get(1);
+        for (SimpleFileListEntry fileInfo : fileList) {
+            String link = fileInfo.getLink();
 
             if ((link == null)) {
                 break;

--- a/src/main/java/net/sf/jabref/importer/DatabaseFileLookup.java
+++ b/src/main/java/net/sf/jabref/importer/DatabaseFileLookup.java
@@ -121,10 +121,10 @@ class DatabaseFileLookup {
         String fileField = anEntry.getField(Globals.FILE_FIELD);
         List<List<String>> fileList = FileUtil.decodeFileField(fileField);
 
-        for (int i = 0; i < fileList.size(); i++) {
-            String link = fileList.get(i).get(1);
+        for (List<String> fileInfo : fileList) {
+            String link = fileInfo.get(1);
 
-            if (link == null) {
+            if ((link == null)) {
                 break;
             }
 

--- a/src/main/java/net/sf/jabref/importer/DatabaseFileLookup.java
+++ b/src/main/java/net/sf/jabref/importer/DatabaseFileLookup.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 import java.util.Objects;
 
 import net.sf.jabref.Globals;
@@ -26,8 +27,6 @@ import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.JabRef;
-import net.sf.jabref.gui.FileListEntry;
-import net.sf.jabref.gui.FileListTableModel;
 
 /**
  * Search class for files. <br>
@@ -119,14 +118,11 @@ class DatabaseFileLookup {
             return false;
         }
 
-        FileListTableModel model = new FileListTableModel();
+        String fileField = anEntry.getField(Globals.FILE_FIELD);
+        List<List<String>> fileList = FileUtil.decodeFileField(fileField);
 
-        String fileField = anEntry.getField(DatabaseFileLookup.KEY_FILE_FIELD);
-        model.setContent(fileField);
-
-        for (int i = 0; i < model.getRowCount(); i++) {
-            FileListEntry flEntry = model.getEntry(i);
-            String link = flEntry.getLink();
+        for (int i = 0; i < fileList.size(); i++) {
+            String link = fileList.get(i).get(1);
 
             if (link == null) {
                 break;

--- a/src/main/java/net/sf/jabref/importer/EntryFromFileCreator.java
+++ b/src/main/java/net/sf/jabref/importer/EntryFromFileCreator.java
@@ -161,7 +161,7 @@ public abstract class EntryFromFileCreator implements java.io.FileFilter {
         FileListTableModel model = new FileListTableModel();
         model.addEntry(0, fileListEntry);
 
-        entry.setField("file", model.getStringRepresentation());
+        entry.setField(Globals.FILE_FIELD, model.getStringRepresentation());
     }
 
     void appendToField(BibEntry entry, String field, String value) {

--- a/src/main/java/net/sf/jabref/importer/EntryFromFileCreator.java
+++ b/src/main/java/net/sf/jabref/importer/EntryFromFileCreator.java
@@ -24,8 +24,8 @@ import net.sf.jabref.Globals;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.JabRef;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.external.ExternalFileType;
+import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.gui.FileListEntry;
 import net.sf.jabref.gui.FileListTableModel;
 
@@ -151,8 +151,8 @@ public abstract class EntryFromFileCreator implements java.io.FileFilter {
     }
 
     private void addFileInfo(BibEntry entry, File file) {
-        JabRefPreferences jabRefPreferences = JabRefPreferences.getInstance();
-        ExternalFileType fileType = jabRefPreferences.getExternalFileTypeByExt(externalFileType.getFieldName());
+        ExternalFileType fileType = ExternalFileTypes.getInstance()
+                .getExternalFileTypeByExt(externalFileType.getFieldName());
 
         String[] possibleFilePaths = JabRef.jrf.getCurrentBasePanel().metaData().getFileDirectory(Globals.FILE_FIELD);
         File shortenedFileName = FileUtil.shortenFileName(file, possibleFilePaths);

--- a/src/main/java/net/sf/jabref/importer/EntryFromFileCreatorManager.java
+++ b/src/main/java/net/sf/jabref/importer/EntryFromFileCreatorManager.java
@@ -25,8 +25,8 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.undo.CompoundEdit;
 
-import net.sf.jabref.*;
 import net.sf.jabref.external.ExternalFileType;
+import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.undo.UndoableInsertEntry;
 import net.sf.jabref.model.entry.EntryType;
@@ -55,7 +55,7 @@ public final class EntryFromFileCreatorManager {
 
         // add a creator for each ExternalFileType if there is no specialised
         // creator existing.
-        ExternalFileType[] fileTypes = JabRefPreferences.getInstance().getExternalFileTypeSelection();
+        ExternalFileType[] fileTypes = ExternalFileTypes.getInstance().getExternalFileTypeSelection();
 
         for (ExternalFileType exFileType : fileTypes) {
             if (!hasSpecialisedCreatorForExternalFileType(exFileType)) {

--- a/src/main/java/net/sf/jabref/importer/EntryFromPDFCreator.java
+++ b/src/main/java/net/sf/jabref/importer/EntryFromPDFCreator.java
@@ -15,8 +15,8 @@ import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.pdfimport.PdfImporter;
 import net.sf.jabref.pdfimport.PdfImporter.ImportPdfFilesResult;
 import net.sf.jabref.JabRef;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.external.ExternalFileType;
+import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.logic.xmp.EncryptionNotSupportedException;
 import net.sf.jabref.logic.xmp.XMPUtil;
 
@@ -35,7 +35,7 @@ public class EntryFromPDFCreator extends EntryFromFileCreator {
     }
 
     private static ExternalFileType getPDFExternalFileType() {
-        ExternalFileType pdfFileType = JabRefPreferences.getInstance().getExternalFileTypeByExt("pdf");
+        ExternalFileType pdfFileType = ExternalFileTypes.getInstance().getExternalFileTypeByExt("pdf");
         if (pdfFileType == null) {
             return new ExternalFileType("PDF", "pdf", "application/pdf", "evince", "pdfSmall", IconTheme.JabRefIcon.PDF_FILE.getSmallIcon());
         }

--- a/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
@@ -441,8 +441,8 @@ public class FileUtil {
         ArrayList<File> result = new ArrayList<>();
         for (BibEntry entry : bes) {
             List<List<String>> fileList = decodeFileField(entry.getField(Globals.FILE_FIELD));
-            for (int i = 0; i < fileList.size(); i++) {
-                File f = expandFilename(fileList.get(i).get(1), fileDirs);
+            for (List<String> file : fileList) {
+                File f = expandFilename(file.get(1), fileDirs);
                 if (f != null) {
                     result.add(f);
                 }

--- a/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
@@ -411,8 +411,8 @@ public class FileUtil {
                 sb = new StringBuilder();
             } else if (!escaped && (c == ';') && !inXmlChar) {
                 thisEntry.add(sb.toString());
-                sb = new StringBuilder();
                 newList.add(new SimpleFileListEntry(thisEntry));
+                sb = new StringBuilder();
                 thisEntry = new ArrayList<>();
             } else {
                 sb.append(c);

--- a/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
@@ -423,6 +423,12 @@ public class FileUtil {
             thisEntry.add(sb.toString());
         }
         if (!thisEntry.isEmpty()) {
+            if (thisEntry.size() == 1) { // If a single string, probably the file name
+                String fileName = thisEntry.get(0);
+                thisEntry.clear();
+                thisEntry.add("");
+                thisEntry.add(fileName);
+            }
             newList.add(thisEntry);
         }
 

--- a/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
@@ -379,11 +379,11 @@ public class FileUtil {
         return result;
     }
 
-    public static List<List<String>> decodeFileField(String value) {
+    public static List<SimpleFileListEntry> decodeFileField(String value) {
         if (value == null) {
             value = "";
         }
-        List<List<String>> newList = new ArrayList<>();
+        List<SimpleFileListEntry> newList = new ArrayList<>();
         StringBuilder sb = new StringBuilder();
         List<String> thisEntry = new ArrayList<>();
         boolean inXmlChar = false;
@@ -412,7 +412,7 @@ public class FileUtil {
             } else if (!escaped && (c == ';') && !inXmlChar) {
                 thisEntry.add(sb.toString());
                 sb = new StringBuilder();
-                newList.add(thisEntry);
+                newList.add(new SimpleFileListEntry(thisEntry));
                 thisEntry = new ArrayList<>();
             } else {
                 sb.append(c);
@@ -423,13 +423,7 @@ public class FileUtil {
             thisEntry.add(sb.toString());
         }
         if (!thisEntry.isEmpty()) {
-            if (thisEntry.size() == 1) { // If a single string, probably the file name
-                String fileName = thisEntry.get(0);
-                thisEntry.clear();
-                thisEntry.add("");
-                thisEntry.add(fileName);
-            }
-            newList.add(thisEntry);
+            newList.add(new SimpleFileListEntry(thisEntry));
         }
 
         return newList;
@@ -446,9 +440,9 @@ public class FileUtil {
     public static List<File> getListOfLinkedFiles(BibEntry[] bes, String[] fileDirs) {
         ArrayList<File> result = new ArrayList<>();
         for (BibEntry entry : bes) {
-            List<List<String>> fileList = decodeFileField(entry.getField(Globals.FILE_FIELD));
-            for (List<String> file : fileList) {
-                File f = expandFilename(file.get(1), fileDirs);
+            List<SimpleFileListEntry> fileList = decodeFileField(entry.getField(Globals.FILE_FIELD));
+            for (SimpleFileListEntry file : fileList) {
+                File f = expandFilename(file.getLink(), fileDirs);
                 if (f != null) {
                     result.add(f);
                 }

--- a/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
@@ -16,8 +16,11 @@
 package net.sf.jabref.logic.util.io;
 
 import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.util.OS;
+import net.sf.jabref.model.entry.BibEntry;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -328,4 +331,125 @@ public class FileUtil {
             return fileName;
         }
     }
+
+    public static Map<BibEntry, List<File>> findAssociatedFiles(Collection<BibEntry> entries, Collection<String> extensions, Collection<File> directories) {
+        HashMap<BibEntry, List<File>> result = new HashMap<>();
+
+        // First scan directories
+        Set<File> filesWithExtension = FileFinder.findFiles(extensions, directories);
+
+        // Initialize Result-Set
+        for (BibEntry entry : entries) {
+            result.put(entry, new ArrayList<>());
+        }
+
+        boolean exactOnly = Globals.prefs.getBoolean(JabRefPreferences.AUTOLINK_EXACT_KEY_ONLY);
+        // Now look for keys
+        nextFile: for (File file : filesWithExtension) {
+
+            String name = file.getName();
+            int dot = name.lastIndexOf('.');
+            // First, look for exact matches:
+            for (BibEntry entry : entries) {
+                String citeKey = entry.getCiteKey();
+                if ((citeKey != null) && !citeKey.isEmpty()) {
+                    if (dot > 0) {
+                        if (name.substring(0, dot).equals(citeKey)) {
+                            result.get(entry).add(file);
+                            continue nextFile;
+                        }
+                    }
+                }
+            }
+            // If we get here, we didn't find any exact matches. If non-exact
+            // matches are allowed, try to find one:
+            if (!exactOnly) {
+                for (BibEntry entry : entries) {
+                    String citeKey = entry.getCiteKey();
+                    if ((citeKey != null) && !citeKey.isEmpty()) {
+                        if (name.startsWith(citeKey)) {
+                            result.get(entry).add(file);
+                            continue nextFile;
+                        }
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    public static List<List<String>> decodeFileField(String value) {
+        if (value == null) {
+            value = "";
+        }
+        List<List<String>> newList = new ArrayList<>();
+        StringBuilder sb = new StringBuilder();
+        List<String> thisEntry = new ArrayList<>();
+        boolean inXmlChar = false;
+        boolean escaped = false;
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (!escaped && (c == '\\')) {
+                escaped = true;
+                continue;
+            }
+            // Check if we are entering an XML special character construct such
+            // as "&#44;", because we need to know in order to ignore the semicolon.
+            else if (!escaped && (c == '&') && !inXmlChar) {
+                sb.append(c);
+                if ((value.length() > (i + 1)) && (value.charAt(i + 1) == '#')) {
+                    inXmlChar = true;
+                }
+            }
+            // Check if we are exiting an XML special character construct:
+            else if (!escaped && inXmlChar && (c == ';')) {
+                sb.append(c);
+                inXmlChar = false;
+            } else if (!escaped && (c == ':')) {
+                thisEntry.add(sb.toString());
+                sb = new StringBuilder();
+            } else if (!escaped && (c == ';') && !inXmlChar) {
+                thisEntry.add(sb.toString());
+                sb = new StringBuilder();
+                newList.add(thisEntry);
+                thisEntry = new ArrayList<>();
+            } else {
+                sb.append(c);
+            }
+            escaped = false;
+        }
+        if (sb.length() > 0) {
+            thisEntry.add(sb.toString());
+        }
+        if (!thisEntry.isEmpty()) {
+            newList.add(thisEntry);
+        }
+
+        return newList;
+    }
+
+    /**
+     * Returns the list of linked files. The files have the absolute filename
+     *
+     * @param bes list of BibTeX entries
+     * @param fileDirs list of directories to try for expansion
+     *
+     * @return list of files. May be empty
+     */
+    public static List<File> getListOfLinkedFiles(BibEntry[] bes, String[] fileDirs) {
+        ArrayList<File> result = new ArrayList<>();
+        for (BibEntry entry : bes) {
+            List<List<String>> fileList = decodeFileField(entry.getField(Globals.FILE_FIELD));
+            for (int i = 0; i < fileList.size(); i++) {
+                File f = expandFilename(fileList.get(i).get(1), fileDirs);
+                if (f != null) {
+                    result.add(f);
+                }
+            }
+        }
+
+        return result;
+    }
+
 }

--- a/src/main/java/net/sf/jabref/logic/util/io/SimpleFileList.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/SimpleFileList.java
@@ -32,7 +32,27 @@ public class SimpleFileList {
 
     private final List<SimpleFileListEntry> list = new ArrayList<>();
 
-    public SimpleFileListEntry getEntry(int index) {
+
+    public SimpleFileList() {
+        // Empty constructor
+    }
+
+    /**
+     * Set up the list contents based on the flat string representation of the file list
+     * @param fieldValue The string representation
+     */
+    public SimpleFileList(String fieldValue) {
+        if (fieldValue == null) {
+            fieldValue = "";
+        }
+        final List<SimpleFileListEntry> fileEntryList = FileUtil.decodeFileField(fieldValue);
+        for (final SimpleFileListEntry thisEntry : fileEntryList) {
+            list.add(decodeEntry(thisEntry));
+        }
+
+    }
+
+    public SimpleFileListEntry getEntry(final int index) {
             return list.get(index);
     }
 
@@ -44,7 +64,7 @@ public class SimpleFileList {
         return list.isEmpty();
     }
 
-    public void removeEntry(int index) {
+    public void removeEntry(final int index) {
             list.remove(index);
     }
 
@@ -55,27 +75,9 @@ public class SimpleFileList {
     public List<SimpleFileListEntry> getEntryList() {
         return new ArrayList<>(list);
     }
-    /**
-     * Set up the list contents based on the flat string representation of the file list
-     * @param value The string representation
-     */
-    public void setContent(String value) {
-        if (value == null) {
-            value = "";
-        }
-        List<SimpleFileListEntry> fileEntryList = FileUtil.decodeFileField(value);
-        List<SimpleFileListEntry> newList = new ArrayList<>();
-        for (SimpleFileListEntry thisEntry : fileEntryList) {
-            newList.add(decodeEntry(thisEntry));
-        }
 
-        list.clear();
-        list.addAll(newList);
-    }
-
-
-    private SimpleFileListEntry decodeEntry(SimpleFileListEntry entry) {
-        Boolean validName = Globals.prefs.isExternalFileTypeName(entry.getTypeName());
+    private SimpleFileListEntry decodeEntry(final SimpleFileListEntry entry) {
+        final Boolean validName = Globals.prefs.isExternalFileTypeName(entry.getTypeName());
         String typeName = entry.getTypeName();
 
         if (!validName) {
@@ -84,9 +86,8 @@ public class SimpleFileList {
             typeName = Globals.prefs.getExternalFileTypeNameByMimeType(entry.getTypeName());
             if (typeName == null) {
                 // No type could be found from mime type on the extension:
-                //System.out.println("Not found by mime: '"+getElementIfAvailable(contents, 2));
                 String typeGuess = null;
-                Optional<String> extension = FileUtil.getFileExtension(entry.getLink());
+                final Optional<String> extension = FileUtil.getFileExtension(entry.getLink());
                 if (extension.isPresent()) {
                     typeGuess = Globals.prefs.getExternalFileTypeNameByExt(extension.get());
                 }
@@ -106,10 +107,10 @@ public class SimpleFileList {
      */
     public String getStringRepresentation() {
         String[][] array = new String[list.size()][];
-        int i = 0;
-        for (SimpleFileListEntry entry : list) {
-            array[i] = entry.getStringArrayRepresentation();
-            i++;
+        int entryRowCount = 0;
+        for (final SimpleFileListEntry entry : list) {
+            array[entryRowCount] = entry.getStringArrayRepresentation();
+            entryRowCount++;
         }
         return StringUtil.encodeStringArray(array);
     }

--- a/src/main/java/net/sf/jabref/logic/util/io/SimpleFileList.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/SimpleFileList.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import net.sf.jabref.Globals;
+import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.logic.util.io.SimpleFileListEntry;
 import net.sf.jabref.logic.util.strings.StringUtil;
@@ -77,19 +77,19 @@ public class SimpleFileList {
     }
 
     private SimpleFileListEntry decodeEntry(final SimpleFileListEntry entry) {
-        final Boolean validName = Globals.prefs.isExternalFileTypeName(entry.getTypeName());
+        final Boolean validName = ExternalFileTypes.getInstance().isExternalFileTypeName(entry.getTypeName());
         String typeName = entry.getTypeName();
 
         if (!validName) {
             // No file type was recognized. Try to find a usable file type based
             // on mime type:
-            typeName = Globals.prefs.getExternalFileTypeNameByMimeType(entry.getTypeName());
+            typeName = ExternalFileTypes.getInstance().getExternalFileTypeNameByMimeType(entry.getTypeName());
             if (typeName == null) {
                 // No type could be found from mime type on the extension:
                 String typeGuess = null;
                 final Optional<String> extension = FileUtil.getFileExtension(entry.getLink());
                 if (extension.isPresent()) {
-                    typeGuess = Globals.prefs.getExternalFileTypeNameByExt(extension.get());
+                    typeGuess = ExternalFileTypes.getInstance().getExternalFileTypeNameByExt(extension.get());
                 }
                 if (typeGuess != null) {
                     typeName = typeGuess;

--- a/src/main/java/net/sf/jabref/logic/util/io/SimpleFileList.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/SimpleFileList.java
@@ -1,0 +1,123 @@
+/*  Copyright (C) 2015 JabRef contributors.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+package net.sf.jabref.logic.util.io;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import net.sf.jabref.Globals;
+import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.io.SimpleFileListEntry;
+import net.sf.jabref.logic.util.strings.StringUtil;
+
+/**
+ * Data structure to contain a list of file links, parseable from a coded string.
+ * To be used instead of FileListTableModel when no GUI parts are required.
+ */
+public class SimpleFileList {
+
+    private final List<SimpleFileListEntry> list = new ArrayList<>();
+
+
+    public SimpleFileListEntry getEntry(int index) {
+        synchronized (list) {
+            return list.get(index);
+        }
+    }
+
+    public void removeEntry(int index) {
+        synchronized (list) {
+            list.remove(index);
+        }
+
+    }
+
+    /**
+     * Add an entry to the table model, and fire a change event. The change event
+     * is fired on the event dispatch thread.
+     * @param index The row index to insert the entry at.
+     * @param entry The entry to insert.
+     */
+    public void addEntry(final int index, final SimpleFileListEntry entry) {
+        synchronized (list) {
+            list.add(index, entry);
+        }
+
+    }
+
+    /**
+     * Set up the table contents based on the flat string representation of the file list
+     * @param value The string representation
+     */
+    public void setContent(String value) {
+        if (value == null) {
+            value = "";
+        }
+        List<SimpleFileListEntry> fileEntryList = FileUtil.decodeFileField(value);
+        List<SimpleFileListEntry> newList = new ArrayList<>();
+        for (SimpleFileListEntry thisEntry : fileEntryList) {
+            newList.add(decodeEntry(thisEntry));
+        }
+
+        synchronized (list) {
+            list.clear();
+            list.addAll(newList);
+        }
+    }
+
+
+    private SimpleFileListEntry decodeEntry(SimpleFileListEntry entry) {
+        Boolean validName = Globals.prefs.isExternalFileTypeName(entry.getTypeName());
+        String typeName = entry.getTypeName();
+
+        if (!validName) {
+            // No file type was recognized. Try to find a usable file type based
+            // on mime type:
+            typeName = Globals.prefs.getExternalFileTypeNameByMimeType(entry.getTypeName());
+            if (typeName == null) {
+                // No type could be found from mime type on the extension:
+                //System.out.println("Not found by mime: '"+getElementIfAvailable(contents, 2));
+                String typeGuess = null;
+                Optional<String> extension = FileUtil.getFileExtension(entry.getLink());
+                if (extension.isPresent()) {
+                    typeGuess = Globals.prefs.getExternalFileTypeNameByExt(extension.get());
+                }
+                if (typeGuess != null) {
+                    typeName = typeGuess;
+                }
+            }
+        }
+
+        return new SimpleFileListEntry(entry.getDescription(), entry.getLink(), typeName);
+    }
+
+    /**
+     * Transform the file list shown in the table into a flat string representable
+     * as a BibTeX field:
+     * @return String representation.
+     */
+    public String getStringRepresentation() {
+        String[][] array = new String[list.size()][];
+        int i = 0;
+        for (SimpleFileListEntry entry : list) {
+            array[i] = entry.getStringArrayRepresentation();
+            i++;
+        }
+        return StringUtil.encodeStringArray(array);
+    }
+
+}

--- a/src/main/java/net/sf/jabref/logic/util/io/SimpleFileList.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/SimpleFileList.java
@@ -32,35 +32,28 @@ public class SimpleFileList {
 
     private final List<SimpleFileListEntry> list = new ArrayList<>();
 
-
     public SimpleFileListEntry getEntry(int index) {
-        synchronized (list) {
             return list.get(index);
-        }
+    }
+
+    public int size() {
+        return list.size();
+    }
+
+    public Boolean isEmpty() {
+        return list.isEmpty();
     }
 
     public void removeEntry(int index) {
-        synchronized (list) {
             list.remove(index);
-        }
+    }
 
+    public void addEntry(final SimpleFileListEntry entry) {
+            list.add(entry);
     }
 
     /**
-     * Add an entry to the table model, and fire a change event. The change event
-     * is fired on the event dispatch thread.
-     * @param index The row index to insert the entry at.
-     * @param entry The entry to insert.
-     */
-    public void addEntry(final int index, final SimpleFileListEntry entry) {
-        synchronized (list) {
-            list.add(index, entry);
-        }
-
-    }
-
-    /**
-     * Set up the table contents based on the flat string representation of the file list
+     * Set up the list contents based on the flat string representation of the file list
      * @param value The string representation
      */
     public void setContent(String value) {
@@ -73,10 +66,8 @@ public class SimpleFileList {
             newList.add(decodeEntry(thisEntry));
         }
 
-        synchronized (list) {
-            list.clear();
-            list.addAll(newList);
-        }
+        list.clear();
+        list.addAll(newList);
     }
 
 
@@ -106,7 +97,7 @@ public class SimpleFileList {
     }
 
     /**
-     * Transform the file list shown in the table into a flat string representable
+     * Transform the file list into a flat string representable
      * as a BibTeX field:
      * @return String representation.
      */

--- a/src/main/java/net/sf/jabref/logic/util/io/SimpleFileList.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/SimpleFileList.java
@@ -52,6 +52,9 @@ public class SimpleFileList {
             list.add(entry);
     }
 
+    public List<SimpleFileListEntry> getEntryList() {
+        return new ArrayList<>(list);
+    }
     /**
      * Set up the list contents based on the flat string representation of the file list
      * @param value The string representation

--- a/src/main/java/net/sf/jabref/logic/util/io/SimpleFileListEntry.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/SimpleFileListEntry.java
@@ -1,0 +1,73 @@
+/*  Copyright (C) 2015 JabRef contributors.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+package net.sf.jabref.logic.util.io;
+
+import java.util.List;
+
+/**
+ * This class represents a simplified version of the file link for a Bibtex entry.
+ */
+public class SimpleFileListEntry {
+
+    protected String description;
+    protected String link;
+
+
+    public SimpleFileListEntry(String description, String link) {
+        this.description = description;
+        this.link = link;
+    }
+
+    public SimpleFileListEntry(List<String> entry) {
+        if (entry.isEmpty()) {
+            this.description = "";
+            this.link = "";
+            return;
+        }
+
+        // A single string, probably the link
+        if (entry.size() == 1) {
+            this.description = "";
+            this.link = entry.get(0);
+            return;
+        }
+
+        this.description = entry.get(0);
+        this.link = entry.get(1);
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getLink() {
+        return link;
+    }
+
+    public void setLink(String link) {
+        this.link = link;
+    }
+
+    @Override
+    public String toString() {
+        return description + " : " + link;
+    }
+
+}

--- a/src/main/java/net/sf/jabref/logic/util/io/SimpleFileListEntry.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/SimpleFileListEntry.java
@@ -22,8 +22,9 @@ import java.util.List;
  */
 public class SimpleFileListEntry {
 
-    protected String description;
-    protected String link;
+    protected String description = "";
+    protected String link = "";
+    private String typeName = "";
 
 
     public SimpleFileListEntry(String description, String link) {
@@ -31,22 +32,28 @@ public class SimpleFileListEntry {
         this.link = link;
     }
 
+    public SimpleFileListEntry(String description, String link, String typeName) {
+        this.description = description;
+        this.link = link;
+        this.typeName = typeName;
+    }
+
     public SimpleFileListEntry(List<String> entry) {
         if (entry.isEmpty()) {
-            this.description = "";
-            this.link = "";
             return;
         }
 
         // A single string, probably the link
         if (entry.size() == 1) {
-            this.description = "";
             this.link = entry.get(0);
             return;
         }
 
         this.description = entry.get(0);
         this.link = entry.get(1);
+        if (entry.size() >= 3) {
+            this.typeName = entry.get(2);
+        }
     }
 
     public String getDescription() {
@@ -63,6 +70,10 @@ public class SimpleFileListEntry {
 
     public void setLink(String link) {
         this.link = link;
+    }
+
+    public String getTypeName() {
+        return typeName;
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/logic/util/io/SimpleFileListEntry.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/SimpleFileListEntry.java
@@ -35,7 +35,9 @@ public class SimpleFileListEntry {
     public SimpleFileListEntry(String description, String link, String typeName) {
         this.description = description;
         this.link = link;
-        this.typeName = typeName;
+        if (typeName != null) {
+            this.typeName = typeName;
+        }
     }
 
     public SimpleFileListEntry(List<String> entry) {
@@ -74,6 +76,14 @@ public class SimpleFileListEntry {
 
     public String getTypeName() {
         return typeName;
+    }
+
+    public void setTypeName(String typeName) {
+        this.typeName = typeName;
+    }
+
+    public String[] getStringArrayRepresentation() {
+        return new String[] {getDescription(), getLink(), getTypeName()};
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/logic/util/io/SimpleFileListEntry.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/SimpleFileListEntry.java
@@ -88,7 +88,7 @@ public class SimpleFileListEntry {
 
     @Override
     public String toString() {
-        return description + " : " + link;
+        return description + " : " + link + " : " + typeName;
     }
 
 }

--- a/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
@@ -526,4 +526,34 @@ public class StringUtil {
         }
     }
 
+    /**
+     * Optimized method for converting a String into an Integer
+     *
+     * From http://stackoverflow.com/questions/1030479/most-efficient-way-of-converting-string-to-integer-in-java
+     *
+     * @param str the String holding an Integer value
+     * @throws NumberFormatException if str cannot be parsed to an int
+     * @return the int value of str
+     */
+    public static int intValueOf(String str) {
+        int ival = 0;
+        int idx = 0;
+        int end;
+        boolean sign = false;
+        char ch;
+    
+        if ((str == null) || ((end = str.length()) == 0) || ((((ch = str.charAt(0)) < '0') || (ch > '9')) && (!(sign = ch == '-') || (++idx == end) || ((ch = str.charAt(idx)) < '0') || (ch > '9')))) {
+            throw new NumberFormatException(str);
+        }
+    
+        for (;; ival *= 10) {
+            ival += '0' - ch;
+            if (++idx == end) {
+                return sign ? ival : -ival;
+            }
+            if (((ch = str.charAt(idx)) < '0') || (ch > '9')) {
+                throw new NumberFormatException(str);
+            }
+        }
+    }
 }

--- a/src/main/java/net/sf/jabref/openoffice/StyleSelectDialog.java
+++ b/src/main/java/net/sf/jabref/openoffice/StyleSelectDialog.java
@@ -67,6 +67,7 @@ import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.gui.PreviewPanel;
 import net.sf.jabref.external.ExternalFileType;
+import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.external.UnknownExternalFileType;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.gui.desktop.JabRefDesktop;
@@ -184,7 +185,7 @@ class StyleSelectDialog {
                 if (i == -1) {
                     return;
                 }
-                ExternalFileType type = Globals.prefs.getExternalFileTypeByExt("jstyle");
+                ExternalFileType type = ExternalFileTypes.getInstance().getExternalFileTypeByExt("jstyle");
                 String link = tableModel.getElementAt(i).getFile().getPath();
                 try {
                     if (type == null) {

--- a/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
+++ b/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
@@ -35,6 +35,7 @@ import org.apache.commons.logging.LogFactory;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.external.DroppedFileHandler;
+import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.EntryTypeDialog;
 import net.sf.jabref.gui.FileListEntry;
@@ -228,7 +229,7 @@ public class PdfImporter {
                     File toLink = new File(fileName);
                     tm.addEntry(0, new FileListEntry(toLink.getName(),
                             FileUtil.shortenFileName(toLink, dirsS).getPath(),
-                            Globals.prefs.getExternalFileTypeByName("pdf")));
+                                    ExternalFileTypes.getInstance().getExternalFileTypeByName("pdf")));
                     entry.setField(Globals.FILE_FIELD, tm.getStringRepresentation());
                     res.add(entry);
                     break;

--- a/src/main/java/net/sf/jabref/util/Util.java
+++ b/src/main/java/net/sf/jabref/util/Util.java
@@ -363,12 +363,9 @@ public class Util {
      * @return A CompoundEdit specifying the undo operation for the whole operation.
      */
     public static void upgradePdfPsToFile(BibEntry entry, String[] fields, NamedCompound ce) {
-        SimpleFileList fileList = new SimpleFileList();
         // If there are already links in the file field, keep those on top:
         String oldFileContent = entry.getField(Globals.FILE_FIELD);
-        if (oldFileContent != null) {
-            fileList.setContent(oldFileContent);
-        }
+        SimpleFileList fileList = new SimpleFileList(oldFileContent);
         int oldItemCount = fileList.size();
         for (String field : fields) {
             String o = entry.getField(field);

--- a/src/main/java/net/sf/jabref/util/Util.java
+++ b/src/main/java/net/sf/jabref/util/Util.java
@@ -50,6 +50,8 @@ import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.io.FileNameCleaner;
 import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.io.SimpleFileList;
+import net.sf.jabref.logic.util.io.SimpleFileListEntry;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.logic.util.strings.UnicodeToReadableCharMap;
 import org.apache.commons.logging.Log;
@@ -361,29 +363,29 @@ public class Util {
      * @return A CompoundEdit specifying the undo operation for the whole operation.
      */
     public static void upgradePdfPsToFile(BibEntry entry, String[] fields, NamedCompound ce) {
-        FileListTableModel tableModel = new FileListTableModel();
+        SimpleFileList fileList = new SimpleFileList();
         // If there are already links in the file field, keep those on top:
         String oldFileContent = entry.getField(Globals.FILE_FIELD);
         if (oldFileContent != null) {
-            tableModel.setContent(oldFileContent);
+            fileList.setContent(oldFileContent);
         }
-        int oldRowCount = tableModel.getRowCount();
+        int oldItemCount = fileList.size();
         for (String field : fields) {
             String o = entry.getField(field);
             if (o != null) {
                 if (!o.trim().isEmpty()) {
                     File f = new File(o);
-                    FileListEntry flEntry = new FileListEntry(f.getName(), o,
-                            Globals.prefs.getExternalFileTypeByExt(field));
-                    tableModel.addEntry(tableModel.getRowCount(), flEntry);
+                    SimpleFileListEntry flEntry = new SimpleFileListEntry(f.getName(), o,
+                            Globals.prefs.getExternalFileTypeNameByExt(field));
+                    fileList.addEntry(flEntry);
 
                     entry.clearField(field);
                     ce.addEdit(new UndoableFieldChange(entry, field, o, null));
                 }
             }
         }
-        if (tableModel.getRowCount() != oldRowCount) {
-            String newValue = tableModel.getStringRepresentation();
+        if (fileList.size() != oldItemCount) {
+            String newValue = fileList.getStringRepresentation();
             entry.setField(Globals.FILE_FIELD, newValue);
             ce.addEdit(new UndoableFieldChange(entry, Globals.FILE_FIELD, oldFileContent, newValue));
         }

--- a/src/main/java/net/sf/jabref/util/Util.java
+++ b/src/main/java/net/sf/jabref/util/Util.java
@@ -73,6 +73,7 @@ import net.sf.jabref.gui.worker.Worker;
 import net.sf.jabref.exporter.layout.Layout;
 import net.sf.jabref.exporter.layout.LayoutHelper;
 import net.sf.jabref.external.ExternalFileType;
+import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.external.RegExpFileSearch;
 import net.sf.jabref.external.UnknownExternalFileType;
 import net.sf.jabref.groups.structure.AbstractGroup;
@@ -373,7 +374,7 @@ public class Util {
                 if (!o.trim().isEmpty()) {
                     File f = new File(o);
                     SimpleFileListEntry flEntry = new SimpleFileListEntry(f.getName(), o,
-                            Globals.prefs.getExternalFileTypeNameByExt(field));
+                            ExternalFileTypes.getInstance().getExternalFileTypeNameByExt(field));
                     fileList.addEntry(flEntry);
 
                     entry.clearField(field);
@@ -813,7 +814,7 @@ public class Util {
      * @return the thread performing the autosetting
      */
     public static Runnable autoSetLinks(final Collection<BibEntry> entries, final NamedCompound ce, final Set<BibEntry> changedEntries, final FileListTableModel singleTableModel, final MetaData metaData, final ActionListener callback, final JDialog diag) {
-        final ExternalFileType[] types = Globals.prefs.getExternalFileTypeSelection();
+        final ExternalFileType[] types = ExternalFileTypes.getInstance().getExternalFileTypeSelection();
         if (diag != null) {
             final JProgressBar prog = new JProgressBar(JProgressBar.HORIZONTAL, 0, types.length - 1);
             final JLabel label = new JLabel(Localization.lang("Searching for files"));
@@ -885,7 +886,7 @@ public class Util {
                             ExternalFileType type;
                             Optional<String> extension = FileUtil.getFileExtension(f);
                             if (extension.isPresent()) {
-                                type = Globals.prefs.getExternalFileTypeByExt(extension.get());
+                                type = ExternalFileTypes.getInstance().getExternalFileTypeByExt(extension.get());
                             } else {
                                 type = new UnknownExternalFileType("");
                             }

--- a/src/main/java/net/sf/jabref/util/Util.java
+++ b/src/main/java/net/sf/jabref/util/Util.java
@@ -475,37 +475,6 @@ public class Util {
     }
 
     /**
-     * Optimized method for converting a String into an Integer
-     *
-     * From http://stackoverflow.com/questions/1030479/most-efficient-way-of-converting-string-to-integer-in-java
-     *
-     * @param str the String holding an Integer value
-     * @throws NumberFormatException if str cannot be parsed to an int
-     * @return the int value of str
-     */
-    public static int intValueOf(String str) {
-        int ival = 0;
-        int idx = 0;
-        int end;
-        boolean sign = false;
-        char ch;
-
-        if ((str == null) || ((end = str.length()) == 0) || ((((ch = str.charAt(0)) < '0') || (ch > '9')) && (!(sign = ch == '-') || (++idx == end) || ((ch = str.charAt(idx)) < '0') || (ch > '9')))) {
-            throw new NumberFormatException(str);
-        }
-
-        for (;; ival *= 10) {
-            ival += '0' - ch;
-            if (++idx == end) {
-                return sign ? ival : -ival;
-            }
-            if (((ch = str.charAt(idx)) < '0') || (ch > '9')) {
-                throw new NumberFormatException(str);
-            }
-        }
-    }
-
-    /**
      * Run an AbstractWorker's methods using Spin features to put each method on the correct thread.
      *
      * @param worker The worker to run.

--- a/src/test/java/net/sf/jabref/importer/DatabaseFileLookupTest.java
+++ b/src/test/java/net/sf/jabref/importer/DatabaseFileLookupTest.java
@@ -5,8 +5,8 @@ import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.gui.FindUnlinkedFilesDialog;
 import net.sf.jabref.gui.FindUnlinkedFilesDialog.CheckableTreeNode;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.external.ExternalFileType;
+import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.gui.FileListEntry;
 import net.sf.jabref.gui.FileListTableModel;
 
@@ -61,8 +61,7 @@ public class DatabaseFileLookupTest {
     @Ignore
     public void testInsertTestData() throws Exception {
         entry1 = new BibEntry();
-        JabRefPreferences jabRefPreferences = JabRefPreferences.getInstance();
-        ExternalFileType fileType = jabRefPreferences.getExternalFileTypeByExt("PDF");
+        ExternalFileType fileType = ExternalFileTypes.getInstance().getExternalFileTypeByExt("PDF");
         FileListEntry fileListEntry = new FileListEntry("", ImportDataTest.FILE_IN_DATABASE.getAbsolutePath(), fileType);
 
         FileListTableModel model = new FileListTableModel();

--- a/src/test/java/net/sf/jabref/importer/EntryFromFileCreatorManagerTest.java
+++ b/src/test/java/net/sf/jabref/importer/EntryFromFileCreatorManagerTest.java
@@ -15,11 +15,14 @@
  */
 package net.sf.jabref.importer;
 
+import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -32,6 +35,12 @@ import java.util.List;
  * @version 11.11.2008 | 21:51:54
  */
 public class EntryFromFileCreatorManagerTest {
+
+    // Needed to initialize ExternalFileTypes
+    @Before
+    public void setUp() {
+        Globals.prefs = JabRefPreferences.getInstance();
+    }
 
     @Test
     public void testGetCreator() throws Exception {

--- a/src/test/java/net/sf/jabref/importer/EntryFromPDFCreatorTest.java
+++ b/src/test/java/net/sf/jabref/importer/EntryFromPDFCreatorTest.java
@@ -1,8 +1,8 @@
 package net.sf.jabref.importer;
 
-import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-
+import net.sf.jabref.model.entry.BibEntry;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -20,8 +20,7 @@ public class EntryFromPDFCreatorTest {
 
     @Before
     public void setUp() throws Exception {
-        // externalFileTypes are needed for the EntryFromPDFCreator
-        JabRefPreferences.getInstance().updateExternalFileTypes();
+        Globals.prefs = JabRefPreferences.getInstance();
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/util/io/FileUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/io/FileUtilTest.java
@@ -86,37 +86,37 @@ public class FileUtilTest {
 
     @Test
     public void testDecodeFileFieldSingleString() {
-        assertEquals("test.pdf", FileUtil.decodeFileField("test.pdf").get(0).get(1));
+        assertEquals("test.pdf", FileUtil.decodeFileField("test.pdf").get(0).getLink());
     }
 
     @Test
     public void testDecodeFileFieldSingleItem() {
-        List<List<String>> fileList = FileUtil.decodeFileField("paper:test.pdf:PDF");
-        assertEquals("paper", fileList.get(0).get(0));
-        assertEquals("test.pdf", fileList.get(0).get(1));
+        List<SimpleFileListEntry> fileList = FileUtil.decodeFileField("paper:test.pdf:PDF");
+        assertEquals("paper", fileList.get(0).getDescription());
+        assertEquals("test.pdf", fileList.get(0).getLink());
     }
 
     @Test
     public void testDecodeFileFieldMultipleItems() {
-        List<List<String>> fileList = FileUtil.decodeFileField("paper:test.pdf:PDF;presentation:test.ppt:PPT");
-        assertEquals("paper", fileList.get(0).get(0));
-        assertEquals("test.pdf", fileList.get(0).get(1));
-        assertEquals("presentation", fileList.get(1).get(0));
-        assertEquals("test.ppt", fileList.get(1).get(1));
+        List<SimpleFileListEntry> fileList = FileUtil.decodeFileField("paper:test.pdf:PDF;presentation:test.ppt:PPT");
+        assertEquals("paper", fileList.get(0).getDescription());
+        assertEquals("test.pdf", fileList.get(0).getLink());
+        assertEquals("presentation", fileList.get(1).getDescription());
+        assertEquals("test.ppt", fileList.get(1).getLink());
     }
 
     @Test
     public void testDecodeFileFieldEscaping() {
-        List<List<String>> fileList = FileUtil.decodeFileField("paper:c\\:\\\\test.pdf:PDF");
-        assertEquals("paper", fileList.get(0).get(0));
-        assertEquals("c:\\test.pdf", fileList.get(0).get(1));
+        List<SimpleFileListEntry> fileList = FileUtil.decodeFileField("paper:c\\:\\\\test.pdf:PDF");
+        assertEquals("paper", fileList.get(0).getDescription());
+        assertEquals("c:\\test.pdf", fileList.get(0).getLink());
     }
 
     @Test
     public void testDecodeFileFieldXMLCharacter() {
-        List<List<String>> fileList = FileUtil.decodeFileField("pap&#44;er:c\\:\\\\test.pdf:PDF");
-        assertEquals("pap&#44;er", fileList.get(0).get(0));
-        assertEquals("c:\\test.pdf", fileList.get(0).get(1));
+        List<SimpleFileListEntry> fileList = FileUtil.decodeFileField("pap&#44;er:c\\:\\\\test.pdf:PDF");
+        assertEquals("pap&#44;er", fileList.get(0).getDescription());
+        assertEquals("c:\\test.pdf", fileList.get(0).getLink());
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/util/io/FileUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/io/FileUtilTest.java
@@ -83,4 +83,50 @@ public class FileUtilTest {
         List<String> result = FileUtil.uniquePathSubstrings(paths);
         assertEquals(uniqPath, result);
     }
+
+    @Test
+    public void testDecodeFileFieldSingleString() {
+        assertEquals("test.pdf", FileUtil.decodeFileField("test.pdf").get(0).get(1));
+    }
+
+    @Test
+    public void testDecodeFileFieldSingleItem() {
+        List<List<String>> fileList = FileUtil.decodeFileField("paper:test.pdf:PDF");
+        assertEquals("paper", fileList.get(0).get(0));
+        assertEquals("test.pdf", fileList.get(0).get(1));
+    }
+
+    @Test
+    public void testDecodeFileFieldMultipleItems() {
+        List<List<String>> fileList = FileUtil.decodeFileField("paper:test.pdf:PDF;presentation:test.ppt:PPT");
+        assertEquals("paper", fileList.get(0).get(0));
+        assertEquals("test.pdf", fileList.get(0).get(1));
+        assertEquals("presentation", fileList.get(1).get(0));
+        assertEquals("test.ppt", fileList.get(1).get(1));
+    }
+
+    @Test
+    public void testDecodeFileFieldEscaping() {
+        List<List<String>> fileList = FileUtil.decodeFileField("paper:c\\:\\\\test.pdf:PDF");
+        assertEquals("paper", fileList.get(0).get(0));
+        assertEquals("c:\\test.pdf", fileList.get(0).get(1));
+    }
+
+    @Test
+    public void testDecodeFileFieldXMLCharacter() {
+        List<List<String>> fileList = FileUtil.decodeFileField("pap&#44;er:c\\:\\\\test.pdf:PDF");
+        assertEquals("pap&#44;er", fileList.get(0).get(0));
+        assertEquals("c:\\test.pdf", fileList.get(0).get(1));
+    }
+
+    @Test
+    public void testDecodeFileFieldEmptyString() {
+        assertTrue(FileUtil.decodeFileField("").isEmpty());
+    }
+
+    @Test
+    public void testDecodeFileFieldNullString() {
+        assertTrue(FileUtil.decodeFileField(null).isEmpty());
+    }
+
 }

--- a/src/test/java/net/sf/jabref/logic/util/io/FileUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/io/FileUtilTest.java
@@ -87,6 +87,8 @@ public class FileUtilTest {
     @Test
     public void testDecodeFileFieldSingleString() {
         assertEquals("test.pdf", FileUtil.decodeFileField("test.pdf").get(0).getLink());
+        assertEquals("", FileUtil.decodeFileField("test.pdf").get(0).getDescription());
+        assertEquals("", FileUtil.decodeFileField("test.pdf").get(0).getTypeName());
     }
 
     @Test
@@ -94,6 +96,15 @@ public class FileUtilTest {
         List<SimpleFileListEntry> fileList = FileUtil.decodeFileField("paper:test.pdf:PDF");
         assertEquals("paper", fileList.get(0).getDescription());
         assertEquals("test.pdf", fileList.get(0).getLink());
+        assertEquals("PDF", fileList.get(0).getTypeName());
+    }
+
+    @Test
+    public void testDecodeFileFieldSingleItemNoTypeName() {
+        List<SimpleFileListEntry> fileList = FileUtil.decodeFileField("paper:test.pdf");
+        assertEquals("paper", fileList.get(0).getDescription());
+        assertEquals("test.pdf", fileList.get(0).getLink());
+        assertEquals("", fileList.get(0).getTypeName());
     }
 
     @Test
@@ -101,8 +112,10 @@ public class FileUtilTest {
         List<SimpleFileListEntry> fileList = FileUtil.decodeFileField("paper:test.pdf:PDF;presentation:test.ppt:PPT");
         assertEquals("paper", fileList.get(0).getDescription());
         assertEquals("test.pdf", fileList.get(0).getLink());
+        assertEquals("PDF", fileList.get(0).getTypeName());
         assertEquals("presentation", fileList.get(1).getDescription());
         assertEquals("test.ppt", fileList.get(1).getLink());
+        assertEquals("PPT", fileList.get(1).getTypeName());
     }
 
     @Test
@@ -110,6 +123,7 @@ public class FileUtilTest {
         List<SimpleFileListEntry> fileList = FileUtil.decodeFileField("paper:c\\:\\\\test.pdf:PDF");
         assertEquals("paper", fileList.get(0).getDescription());
         assertEquals("c:\\test.pdf", fileList.get(0).getLink());
+        assertEquals("PDF", fileList.get(0).getTypeName());
     }
 
     @Test
@@ -117,6 +131,7 @@ public class FileUtilTest {
         List<SimpleFileListEntry> fileList = FileUtil.decodeFileField("pap&#44;er:c\\:\\\\test.pdf:PDF");
         assertEquals("pap&#44;er", fileList.get(0).getDescription());
         assertEquals("c:\\test.pdf", fileList.get(0).getLink());
+        assertEquals("PDF", fileList.get(0).getTypeName());
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/util/io/SimpleFileListEntryTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/io/SimpleFileListEntryTest.java
@@ -1,0 +1,102 @@
+package net.sf.jabref.logic.util.io;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+
+public class SimpleFileListEntryTest {
+
+    @Test
+    public void testTwoTermConstructor() {
+        SimpleFileListEntry entry = new SimpleFileListEntry("test", "test.pdf");
+        assertEquals("test", entry.getDescription());
+        assertEquals("test.pdf", entry.getLink());
+        assertEquals("", entry.getTypeName());
+    }
+
+    @Test
+    public void testThreeTermConstructor() {
+        SimpleFileListEntry entry = new SimpleFileListEntry("test", "test.pdf", "PDF");
+        assertEquals("test", entry.getDescription());
+        assertEquals("test.pdf", entry.getLink());
+        assertEquals("PDF", entry.getTypeName());
+    }
+
+    @Test
+    public void testEmptyListConstructor() {
+        List<String> list = new ArrayList<>();
+        SimpleFileListEntry entry = new SimpleFileListEntry(list);
+        assertEquals("", entry.getDescription());
+        assertEquals("", entry.getLink());
+        assertEquals("", entry.getTypeName());
+    }
+
+    @Test
+    public void testOneTermListConstructor() {
+        List<String> list = new ArrayList<>();
+        list.add("test.pdf");
+        SimpleFileListEntry entry = new SimpleFileListEntry(list);
+        assertEquals("", entry.getDescription());
+        assertEquals("test.pdf", entry.getLink());
+        assertEquals("", entry.getTypeName());
+    }
+
+    @Test
+    public void testTwoTermListConstructor() {
+        List<String> list = new ArrayList<>();
+        list.add("test");
+        list.add("test.pdf");
+        SimpleFileListEntry entry = new SimpleFileListEntry(list);
+        assertEquals("test", entry.getDescription());
+        assertEquals("test.pdf", entry.getLink());
+        assertEquals("", entry.getTypeName());
+    }
+
+    @Test
+    public void testThreeTermListConstructor() {
+        List<String> list = new ArrayList<>();
+        list.add("test");
+        list.add("test.pdf");
+        list.add("PDF");
+        SimpleFileListEntry entry = new SimpleFileListEntry(list);
+        assertEquals("test", entry.getDescription());
+        assertEquals("test.pdf", entry.getLink());
+        assertEquals("PDF", entry.getTypeName());
+    }
+
+    @Test
+    public void testGetStringArrayRepresentation() {
+        List<String> list = new ArrayList<>();
+        list.add("test");
+        list.add("test.pdf");
+        list.add("PDF");
+        SimpleFileListEntry entry = new SimpleFileListEntry(list);
+        assertArrayEquals(new String[] {"test", "test.pdf", "PDF"}, entry.getStringArrayRepresentation());
+    }
+
+    @Test
+    public void testSettersAndGetters() {
+        List<String> list = new ArrayList<>();
+        SimpleFileListEntry entry = new SimpleFileListEntry(list);
+        assertEquals("", entry.getDescription());
+        entry.setDescription("test");
+        assertEquals("test", entry.getDescription());
+        assertEquals("", entry.getLink());
+        entry.setLink("test.pdf");
+        assertEquals("test.pdf", entry.getLink());
+        assertEquals("", entry.getTypeName());
+        entry.setTypeName("PDF");
+        assertEquals("PDF", entry.getTypeName());
+    }
+
+    @Test
+    public void testToString() {
+        SimpleFileListEntry entry = new SimpleFileListEntry("test", "test.pdf", "PDF");
+        assertEquals("test : test.pdf : PDF", entry.toString());
+    }
+
+}

--- a/src/test/java/net/sf/jabref/logic/util/io/SimpleFileListTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/io/SimpleFileListTest.java
@@ -2,7 +2,7 @@ package net.sf.jabref.logic.util.io;
 
 import static org.junit.Assert.*;
 
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import net.sf.jabref.Globals;
@@ -10,10 +10,9 @@ import net.sf.jabref.JabRefPreferences;
 
 public class SimpleFileListTest {
 
-    @BeforeClass
-    public static void setUp() {
+    @Before
+    public void setUp() {
         Globals.prefs = JabRefPreferences.getInstance();
-        Globals.prefs.updateExternalFileTypes();
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/util/io/SimpleFileListTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/io/SimpleFileListTest.java
@@ -1,0 +1,106 @@
+package net.sf.jabref.logic.util.io;
+
+import static org.junit.Assert.*;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefPreferences;
+
+public class SimpleFileListTest {
+
+    @BeforeClass
+    public static void setUp() {
+        Globals.prefs = JabRefPreferences.getInstance();
+        Globals.prefs.updateExternalFileTypes();
+    }
+
+    @Test
+    public void testIncompleteSingleItemConstructor() {
+        SimpleFileList list = new SimpleFileList();
+        list.setContent("test.pdf");
+        assertEquals(1, list.size());
+        assertFalse(list.isEmpty());
+    }
+
+    @Test
+    public void testSingleItemConstructor() {
+        SimpleFileList list = new SimpleFileList();
+        list.setContent("test:test.pdf:PDF");
+        assertEquals(1, list.size());
+        assertFalse(list.isEmpty());
+    }
+
+    @Test
+    public void testNullConstructor() {
+        SimpleFileList list = new SimpleFileList();
+        list.setContent(null);
+        assertEquals(0, list.size());
+        assertTrue(list.isEmpty());
+    }
+
+    @Test
+    public void testMultiItemConstructors() {
+        SimpleFileList list = new SimpleFileList();
+        list.setContent("test:test.pdf:PDF;presentation:file.ppt:PPT");
+        assertEquals(2, list.size());
+        assertFalse(list.isEmpty());
+    }
+
+    @Test
+    public void testIncompleteMultiItemConstructors() {
+        SimpleFileList list = new SimpleFileList();
+        list.setContent("test.pdf;presentation:file.ppt:PPT");
+        assertEquals(2, list.size());
+        assertFalse(list.isEmpty());
+        assertEquals("pdf", list.getEntry(0).getTypeName().toLowerCase());
+    }
+
+    @Test
+    public void testStringArrayRepresentation() {
+        SimpleFileList list = new SimpleFileList();
+        list.setContent("test:test.pdf:pdf");
+        assertEquals("test:test.pdf:PDF", list.getStringRepresentation());
+    }
+
+    @Test
+    public void testIncompleteStringArrayRepresentation() {
+        SimpleFileList list = new SimpleFileList();
+        list.setContent("test.pdf;presentation:file.ppt");
+        assertEquals(2, list.size());
+        assertFalse(list.isEmpty());
+        assertEquals(":test.pdf:PDF;presentation:file.ppt:PowerPoint", list.getStringRepresentation());
+    }
+
+    @Test
+    public void testRemoveItem() {
+        SimpleFileList list = new SimpleFileList();
+        list.setContent("test:test.pdf:PDF;presentation:file.ppt:PPT");
+        assertEquals(2, list.size());
+        assertFalse(list.isEmpty());
+        assertEquals("test.pdf", list.getEntry(0).getLink());
+        list.removeEntry(0);
+        assertEquals(1, list.size());
+        assertFalse(list.isEmpty());
+        assertEquals("file.ppt", list.getEntry(0).getLink());
+        list.removeEntry(0);
+        assertEquals(0, list.size());
+        assertTrue(list.isEmpty());
+    }
+
+    @Test
+    public void testAddEntry() {
+        SimpleFileList list = new SimpleFileList();
+        list.setContent(null);
+        assertEquals(0, list.size());
+        assertTrue(list.isEmpty());
+        list.addEntry(new SimpleFileListEntry("test", "test.pdf", "PDF"));
+        assertEquals(1, list.size());
+        assertFalse(list.isEmpty());
+        assertEquals("test", list.getEntry(0).getDescription().toLowerCase());
+        assertEquals("test.pdf", list.getEntry(0).getLink().toLowerCase());
+        assertEquals("pdf", list.getEntry(0).getTypeName().toLowerCase());
+    }
+
+}

--- a/src/test/java/net/sf/jabref/logic/util/io/SimpleFileListTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/io/SimpleFileListTest.java
@@ -18,40 +18,35 @@ public class SimpleFileListTest {
 
     @Test
     public void testIncompleteSingleItemConstructor() {
-        SimpleFileList list = new SimpleFileList();
-        list.setContent("test.pdf");
+        SimpleFileList list = new SimpleFileList("test.pdf");
         assertEquals(1, list.size());
         assertFalse(list.isEmpty());
     }
 
     @Test
     public void testSingleItemConstructor() {
-        SimpleFileList list = new SimpleFileList();
-        list.setContent("test:test.pdf:PDF");
+        SimpleFileList list = new SimpleFileList("test:test.pdf:PDF");
         assertEquals(1, list.size());
         assertFalse(list.isEmpty());
     }
 
     @Test
     public void testNullConstructor() {
-        SimpleFileList list = new SimpleFileList();
-        list.setContent(null);
+        SimpleFileList list = new SimpleFileList(null);
         assertEquals(0, list.size());
         assertTrue(list.isEmpty());
     }
 
     @Test
     public void testMultiItemConstructors() {
-        SimpleFileList list = new SimpleFileList();
-        list.setContent("test:test.pdf:PDF;presentation:file.ppt:PPT");
+        SimpleFileList list = new SimpleFileList("test:test.pdf:PDF;presentation:file.ppt:PPT");
         assertEquals(2, list.size());
         assertFalse(list.isEmpty());
     }
 
     @Test
     public void testIncompleteMultiItemConstructors() {
-        SimpleFileList list = new SimpleFileList();
-        list.setContent("test.pdf;presentation:file.ppt:PPT");
+        SimpleFileList list = new SimpleFileList("test.pdf;presentation:file.ppt:PPT");
         assertEquals(2, list.size());
         assertFalse(list.isEmpty());
         assertEquals("pdf", list.getEntry(0).getTypeName().toLowerCase());
@@ -59,15 +54,13 @@ public class SimpleFileListTest {
 
     @Test
     public void testStringArrayRepresentation() {
-        SimpleFileList list = new SimpleFileList();
-        list.setContent("test:test.pdf:pdf");
+        SimpleFileList list = new SimpleFileList("test:test.pdf:pdf");
         assertEquals("test:test.pdf:PDF", list.getStringRepresentation());
     }
 
     @Test
     public void testIncompleteStringArrayRepresentation() {
-        SimpleFileList list = new SimpleFileList();
-        list.setContent("test.pdf;presentation:file.ppt");
+        SimpleFileList list = new SimpleFileList("test.pdf;presentation:file.ppt");
         assertEquals(2, list.size());
         assertFalse(list.isEmpty());
         assertEquals(":test.pdf:PDF;presentation:file.ppt:PowerPoint", list.getStringRepresentation());
@@ -75,8 +68,7 @@ public class SimpleFileListTest {
 
     @Test
     public void testRemoveItem() {
-        SimpleFileList list = new SimpleFileList();
-        list.setContent("test:test.pdf:PDF;presentation:file.ppt:PPT");
+        SimpleFileList list = new SimpleFileList("test:test.pdf:PDF;presentation:file.ppt:PPT");
         assertEquals(2, list.size());
         assertFalse(list.isEmpty());
         assertEquals("test.pdf", list.getEntry(0).getLink());
@@ -91,8 +83,7 @@ public class SimpleFileListTest {
 
     @Test
     public void testAddEntry() {
-        SimpleFileList list = new SimpleFileList();
-        list.setContent(null);
+        SimpleFileList list = new SimpleFileList(null);
         assertEquals(0, list.size());
         assertTrue(list.isEmpty());
         list.addEntry(new SimpleFileListEntry("test", "test.pdf", "PDF"));

--- a/src/test/java/net/sf/jabref/logic/util/io/UtilFindFileTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/io/UtilFindFileTest.java
@@ -2,7 +2,6 @@ package net.sf.jabref.logic.util.io;
 
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.testutils.AssertUtil;
-import net.sf.jabref.util.Util;
 import net.sf.jabref.FileBasedTestCase;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -85,7 +84,7 @@ public class UtilFindFileTest extends FileBasedTestCase {
         Collection<File> dirs = Arrays.asList(new File(root.getAbsoluteFile() + "/pdfs/"),
                 new File(root.getAbsoluteFile() + "/graphicsDir/"));
 
-        Map<BibEntry, List<File>> results = Util.findAssociatedFiles(entries, extensions, dirs);
+        Map<BibEntry, List<File>> results = FileUtil.findAssociatedFiles(entries, extensions, dirs);
 
         Assert.assertEquals(2, results.get(entry).size());
         Assert.assertTrue(

--- a/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
@@ -211,39 +211,34 @@ public class StringUtilTest {
     }
 
     @Test
-    public void testIntValueOf() {
+    public void testIntValueOfSingleDigit() {
         assertEquals(1, StringUtil.intValueOf("1"));
+        assertEquals(2, StringUtil.intValueOf("2"));
+        assertEquals(8, StringUtil.intValueOf("8"));
+    }
+
+    @Test
+    public void testIntValueOfLongString() {
         assertEquals(1234567890, StringUtil.intValueOf("1234567890"));
     }
 
     @Test
-    public void testIntValueOfExceptionLetter() {
-        try {
+    public void testIntValueOfStartWithZeros() {
+        assertEquals(1234, StringUtil.intValueOf("001234"));
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void testIntValueOfExceptionIfStringContainsLetter() {
             StringUtil.intValueOf("12A2");
-            fail();
-        } catch (NumberFormatException ignored) {
-            // Ignored
-        }
     }
 
-    @Test
-    public void testIntValueOfExceptionNull() {
-        try {
+    @Test(expected = NumberFormatException.class)
+    public void testIntValueOfExceptionIfStringNull() {
             StringUtil.intValueOf(null);
-            fail();
-        } catch (NumberFormatException ignored) {
-            // Ignored
-        }
-
     }
 
-    @Test
-    public void testIntValueOfExceptionEmpty() {
-        try {
+    @Test(expected = NumberFormatException.class)
+    public void testIntValueOfExceptionfIfStringEmpty() {
             StringUtil.intValueOf("");
-            fail();
-        } catch (NumberFormatException ignored) {
-            // Ignored
-        }
     }
 }

--- a/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
@@ -209,4 +209,41 @@ public class StringUtilTest {
         assertFalse(StringUtil.isInCitationMarks("\""));
         assertFalse(StringUtil.isInCitationMarks("a\"\"a"));
     }
+
+    @Test
+    public void testIntValueOf() {
+        assertEquals(1, StringUtil.intValueOf("1"));
+        assertEquals(1234567890, StringUtil.intValueOf("1234567890"));
+    }
+
+    @Test
+    public void testIntValueOfExceptionLetter() {
+        try {
+            StringUtil.intValueOf("12A2");
+            fail();
+        } catch (NumberFormatException ignored) {
+            // Ignored
+        }
+    }
+
+    @Test
+    public void testIntValueOfExceptionNull() {
+        try {
+            StringUtil.intValueOf(null);
+            fail();
+        } catch (NumberFormatException ignored) {
+            // Ignored
+        }
+
+    }
+
+    @Test
+    public void testIntValueOfExceptionEmpty() {
+        try {
+            StringUtil.intValueOf("");
+            fail();
+        } catch (NumberFormatException ignored) {
+            // Ignored
+        }
+    }
 }


### PR DESCRIPTION
* Moved `getListOfLinkedFiles` and `findAssociatedFiles` from Util to FileUtil
* Rewrote `getListOfLinkedFiles` to be independent of `FileListTableModel`, introducing a new method `decodeFileField` which does most of what  `FileListTableModel.setContent()` does (and later can be used there)
* Used the `decodeFileField` method in `DatabaseFileLookup`
* Replaced `"file"`with `Globals.FILE_FIELD` where appropriate
* Moved `intValueOf` from Util to StringUtil
* Added tests for `intValueOf`