### PR TITLE
Remove field saving options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Tooltips are shown for header columns and contents which are too wide to be displayed in the entry table (#384)
 - Default order in entry table:  # | all file based icons (file, URL/DOI, ...) | all bibtex field based icons (bibtexkey, entrytype, author, title, ...) | all activated special field icons (ranking, quality, ...)
 - Write all field keys in lower case. No more camel casing of field names. E.g., `title` is written instead of `Title`, `howpublished` instead of `HowPublished`, and `doi` instead of `DOI`. The configuration option `Use camel case for field names (e.g., "HowPublished" instead of "howpublished")` is gone.
-- All field saving options are removed. There is no more customization of field sorting. '=' is now appended to the field key instead of its value. Entry names are written in title case format.
+- All field saving options are removed. There is no more customization of field sorting. '=' is now appended to the field key instead of its value. The intendation is aligned for an entry and not for the entire database. Entry names are written in title case format.
 - Entries are only reformatted if they were changed during a session. There is no more mandatory reformatting of the entire database on save.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Tooltips are shown for header columns and contents which are too wide to be displayed in the entry table (#384)
 - Default order in entry table:  # | all file based icons (file, URL/DOI, ...) | all bibtex field based icons (bibtexkey, entrytype, author, title, ...) | all activated special field icons (ranking, quality, ...)
 - Write all field keys in lower case. No more camel casing of field names. E.g., `title` is written instead of `Title`, `howpublished` instead of `HowPublished`, and `doi` instead of `DOI`. The configuration option `Use camel case for field names (e.g., "HowPublished" instead of "howpublished")` is gone.
+- All field saving options are removed. There is no more customization of field sorting. '=' is now appended to the field key instead of its value. Entry names are written in title case format.
+- Entries are only reformatted if they were changed during a session. There is no more mandatory reformatting of the entire database on save.
 
 ### Fixed
 - Fixed #479: Import works again

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -263,10 +263,6 @@ public class JabRefPreferences {
     public static final String ALLOW_TABLE_EDITING = "allowTableEditing";
     public static final String OVERWRITE_OWNER = "overwriteOwner";
     public static final String USE_OWNER = "useOwner";
-    public static final String WRITEFIELD_ADDSPACES = "writeFieldAddSpaces";
-    public static final String WRITEFIELD_SORTSTYLE = "writefieldSortStyle";
-    public static final String WRITEFIELD_USERDEFINEDORDER = "writefieldUserdefinedOrder";
-    public static final String WRITEFIELD_WRAPFIELD = "wrapFieldLine";
     public static final String AUTOLINK_EXACT_KEY_ONLY = "autolinkExactKeyOnly";
     public static final String SHOW_FILE_LINKS_UPGRADE_WARNING = "showFileLinksUpgradeWarning";
     public static final String SEARCH_DIALOG_HEIGHT = "searchDialogHeight";
@@ -284,7 +280,6 @@ public class JabRefPreferences {
     public static final String OPEN_FOLDERS_OF_ATTACHED_FILES = "openFoldersOfAttachedFiles";
     public static final String KEY_GEN_ALWAYS_ADD_LETTER = "keyGenAlwaysAddLetter";
     public static final String KEY_GEN_FIRST_LETTER_A = "keyGenFirstLetterA";
-    public static final String INCLUDE_EMPTY_FIELDS = "includeEmptyFields";
     public static final String VALUE_DELIMITERS2 = "valueDelimiters";
     public static final String BIBLATEX_MODE = "biblatexMode";
     public static final String ENFORCE_LEGAL_BIBTEX_KEY = "enforceLegalBibtexKey";
@@ -693,15 +688,6 @@ public class JabRefPreferences {
 
         defaults.put(GENERATE_KEYS_BEFORE_SAVING, Boolean.FALSE);
 
-        // behavior of JabRef before 2.10: false
-        defaults.put(WRITEFIELD_ADDSPACES, Boolean.TRUE);
-
-        //behavior of JabRef before LWang_AdjustableFieldOrder 1
-        //0 sorted order (2.10 default), 1 unsorted order (2.9.2 default), 2 user defined
-        defaults.put(WRITEFIELD_SORTSTYLE, 0);
-        defaults.put(WRITEFIELD_USERDEFINEDORDER, "author;title;journal;year;volume;number;pages;month;note;volume;pages;part;eid");
-        defaults.put(WRITEFIELD_WRAPFIELD, Boolean.FALSE);
-
         defaults.put(RemotePreferences.USE_REMOTE_SERVER, Boolean.TRUE);
         defaults.put(RemotePreferences.REMOTE_SERVER_PORT, 6050);
 
@@ -730,7 +716,6 @@ public class JabRefPreferences {
         // Curly brackets ({}) are the default delimiters, not quotes (") as these cause trouble when they appear within the field value:
         // Currently, JabRef does not escape them
         defaults.put(VALUE_DELIMITERS2, 1);
-        defaults.put(INCLUDE_EMPTY_FIELDS, Boolean.FALSE);
         defaults.put(KEY_GEN_FIRST_LETTER_A, Boolean.TRUE);
         defaults.put(KEY_GEN_ALWAYS_ADD_LETTER, Boolean.FALSE);
         // TODO l10n issue

--- a/src/main/java/net/sf/jabref/bibtex/BibEntryWriter.java
+++ b/src/main/java/net/sf/jabref/bibtex/BibEntryWriter.java
@@ -75,7 +75,7 @@ public class BibEntryWriter {
      */
     private void writeRequiredFieldsFirstRemainingFieldsSecond(BibEntry entry, Writer out) throws IOException {
         // Write header with type and bibtex-key.
-        out.write('@' + entry.getType().getName().toUpperCase(Locale.US) + '{');
+        out.write('@' + entry.getType().getName() + '{');
 
         writeKeyField(entry, out);
 

--- a/src/main/java/net/sf/jabref/bibtex/BibEntryWriter.java
+++ b/src/main/java/net/sf/jabref/bibtex/BibEntryWriter.java
@@ -48,9 +48,6 @@ public class BibEntryWriter {
 
     private final LatexFieldFormatter fieldFormatter;
     private final boolean write;
-    private final boolean writeFieldAddSpaces = Globals.prefs.getBoolean(JabRefPreferences.WRITEFIELD_ADDSPACES);
-    private final boolean includeEmptyFields = Globals.prefs.getBoolean(JabRefPreferences.INCLUDE_EMPTY_FIELDS);
-    private final int writeFieldSortStyle = Globals.prefs.getInt(JabRefPreferences.WRITEFIELD_SORTSTYLE);
 
 
     public BibEntryWriter(LatexFieldFormatter fieldFormatter, boolean write) {
@@ -60,115 +57,17 @@ public class BibEntryWriter {
 
     public void write(BibEntry entry, Writer out) throws IOException {
         // if the entry has not been modified, write it as it was
-        if(!entry.hasChanged()){
+        if (!entry.hasChanged()) {
             out.write(entry.getParsedSerialization());
             return;
         }
         out.write(Globals.NEWLINE + Globals.NEWLINE);
 
-        switch (writeFieldSortStyle) {
-            case 0:
-                writeRequiredFieldsFirstOptionalFieldsSecondRemainingFieldsThird(entry, out);
-                break;
-            case 1:
-                writeRequiredFieldsFirstRemainingFieldsSecond(entry, out);
-                break;
-            case 2:
-                writeUserDefinedOrder(entry, out);
-                break;
-        }
+        writeRequiredFieldsFirstRemainingFieldsSecond(entry, out);
     }
 
     /**
-     * new style ver>=2.10, sort the field for requiredFields, optionalFields and other fields separately
-     *
-     * @param entry
-     * @param out
-     * @throws IOException
-     */
-    private void writeRequiredFieldsFirstOptionalFieldsSecondRemainingFieldsThird(BibEntry entry, Writer out) throws IOException {
-        // Write header with type and bibtex-key.
-        out.write('@' + entry.getType().getName() + '{');
-
-        HashSet<String> writtenFields = new HashSet<>();
-
-        writeKeyField(entry, out);
-        writtenFields.add(BibEntry.KEY_FIELD);
-
-        // Write required fields first.
-        // Thereby, write the title field first.
-        boolean hasWritten = writeField(entry, out, "title", false);
-        writtenFields.add("title");
-
-        if (entry.getRequiredFieldsFlat() != null) {
-            List<String> requiredFields = getRequiredFieldsSorted(entry);
-            for (String value : requiredFields) {
-                if (!writtenFields.contains(value)) { // If field appears both in req. and opt. don't repeat.
-                    hasWritten = hasWritten | writeField(entry, out, value, hasWritten);
-                    writtenFields.add(value);
-                }
-            }
-        }
-
-        // Then optional fields
-        if (entry.getOptionalFields() != null) {
-            List<String> optionalFields = getOptionalFieldsSorted(entry);
-            for (String value : optionalFields) {
-                if (!writtenFields.contains(value)) { // If field appears both in req. and opt. don't repeat.
-                    hasWritten = hasWritten | writeField(entry, out, value, hasWritten);
-                    writtenFields.add(value);
-                }
-            }
-        }
-
-        // Then write remaining fields in alphabetic order.
-        TreeSet<String> remainingFields = new TreeSet<>();
-        for (String key : entry.getFieldNames()) {
-            boolean writeIt = write ? BibtexFields.isWriteableField(key) :
-                    BibtexFields.isDisplayableField(key);
-            if (!writtenFields.contains(key) && writeIt) {
-                remainingFields.add(key);
-            }
-        }
-
-        for (String field : remainingFields) {
-            hasWritten = hasWritten | writeField(entry, out, field, hasWritten);
-        }
-
-        // Finally, end the entry.
-        out.write((hasWritten ? Globals.NEWLINE : "") + '}');
-    }
-
-    private List<String> getRequiredFieldsSorted(BibEntry entry) {
-        String entryTypeName = entry.getType().getName();
-        List<String> sortedFields = requiredFieldsSorted.get(entryTypeName);
-
-        // put into cache if necessary
-        if (sortedFields == null) {
-            sortedFields = new ArrayList<>(entry.getRequiredFieldsFlat());
-            Collections.sort(sortedFields);
-            requiredFieldsSorted.put(entryTypeName, sortedFields);
-        }
-
-        return sortedFields;
-    }
-
-    private List<String> getOptionalFieldsSorted(BibEntry entry) {
-        String entryTypeName = entry.getType().getName();
-        List<String> sortedFields = optionalFieldsSorted.get(entryTypeName);
-
-        // put into chache if necessary
-        if (sortedFields == null) {
-            sortedFields = new ArrayList<>(entry.getOptionalFields());
-            Collections.sort(sortedFields);
-            optionalFieldsSorted.put(entryTypeName, sortedFields);
-        }
-
-        return sortedFields;
-    }
-
-    /**
-     * old style ver<=2.9.2, write fields in the order of requiredFields, optionalFields and other fields, but does not sort the fields.
+     * Write fields in the order of requiredFields, optionalFields and other fields, but does not sort the fields.
      *
      * @param entry
      * @param out
@@ -218,52 +117,6 @@ public class BibEntryWriter {
         out.write((hasWritten ? Globals.NEWLINE : "") + '}');
     }
 
-    private void writeUserDefinedOrder(BibEntry entry, Writer out) throws IOException {
-        // Write header with type and bibtex-key.
-        out.write('@' + entry.getType().getName() + '{');
-
-        writeKeyField(entry, out);
-        HashMap<String, String> written = new HashMap<>();
-        written.put(BibEntry.KEY_FIELD, null);
-        boolean hasWritten = false;
-
-        // Write user defined fields first.
-        String[] fields = Globals.prefs.getStringArray(JabRefPreferences.WRITEFIELD_USERDEFINEDORDER);
-        if (fields != null) {
-            //do not sort, write as it is.
-            for (String value : fields) {
-                if (!written.containsKey(value)) { // If field appears both in req. and opt. don't repeat.
-                    hasWritten = hasWritten | writeField(entry, out, value, hasWritten);
-                    written.put(value, null);
-                }
-            }
-        }
-
-        // Then write remaining fields in alphabetic order.
-
-        //STA get remaining fields
-        TreeSet<String> remainingFields = new TreeSet<>();
-        for (String key : entry.getFieldNames()) {
-            //iterate through all fields
-            boolean writeIt = write ? BibtexFields.isWriteableField(key) :
-                    BibtexFields.isDisplayableField(key);
-            //find the ones has not been written.
-            if (!written.containsKey(key) && writeIt) {
-                remainingFields.add(key);
-            }
-        }
-        //END get remaining fields
-
-
-        for (String field : remainingFields) {
-            hasWritten = hasWritten | writeField(entry, out, field, hasWritten);
-        }
-
-        // Finally, end the entry.
-        out.write((hasWritten ? Globals.NEWLINE : "") + '}');
-
-    }
-
     private void writeKeyField(BibEntry entry, Writer out) throws IOException {
         String keyField = StringUtil.shaveString(entry.getCiteKey());
         out.write((keyField == null ? "" : keyField) + ',' + Globals.NEWLINE);
@@ -284,7 +137,7 @@ public class BibEntryWriter {
         String field = entry.getField(name);
         // only write field if is is not empty or if empty fields should be included
         // the first condition mirrors mirror behavior of com.jgoodies.common.base.Strings.isNotBlank(str)
-        if (!Strings.nullToEmpty(field).trim().isEmpty() || includeEmptyFields) {
+        if (!Strings.nullToEmpty(field).trim().isEmpty()) {
             if (prependWhiteSpace) {
                 out.write(',' + Globals.NEWLINE);
             }
@@ -307,10 +160,10 @@ public class BibEntryWriter {
      * <p>
      * BibTeX is case-insensitive therefore there is no difference between:
      * howpublished, HOWPUBLISHED, HowPublished, etc.
-     *
+     * <p>
      * The was a long discussion about how JabRef should write the fields.
      * See https://github.com/JabRef/jabref/issues/116
-     *
+     * <p>
      * The team decided to do the biber way and use lower case for the field names.
      *
      * @param field The name of the field.
@@ -323,11 +176,11 @@ public class BibEntryWriter {
         }
 
         StringBuilder suffixSB = new StringBuilder();
-        if (writeFieldAddSpaces) {
-            for (int i = BibEntryWriter.maxFieldLength - field.length(); i > 0; i--) {
-                suffixSB.append(" ");
-            }
+
+        for (int i = BibEntryWriter.maxFieldLength - field.length(); i > 0; i--) {
+            suffixSB.append(" ");
         }
+
         String suffix = suffixSB.toString();
 
         String result;

--- a/src/main/java/net/sf/jabref/bibtex/BibEntryWriter.java
+++ b/src/main/java/net/sf/jabref/bibtex/BibEntryWriter.java
@@ -142,7 +142,7 @@ public class BibEntryWriter {
                 out.write(',' + Globals.NEWLINE);
             }
 
-            out.write("  " + getFieldDisplayName(name) + " = ");
+            out.write("  " + getFieldDisplayName(name));
 
             try {
                 out.write(fieldFormatter.format(field, name));
@@ -184,7 +184,7 @@ public class BibEntryWriter {
         String suffix = suffixSB.toString();
 
         String result;
-        result = field.toLowerCase() + suffix;
+        result = field.toLowerCase() + " = " + suffix;
 
         return result;
     }

--- a/src/main/java/net/sf/jabref/exporter/LatexFieldFormatter.java
+++ b/src/main/java/net/sf/jabref/exporter/LatexFieldFormatter.java
@@ -48,7 +48,6 @@ public class LatexFieldFormatter {
     private final boolean resolveStringsAllFields;
     private final char valueDelimiterStartOfValue;
     private final char valueDelimiterEndOfValue;
-    private final boolean writefieldWrapfield;
     private final String[] doNotResolveStringsFors;
 
     private final FieldContentParser parser;
@@ -65,7 +64,6 @@ public class LatexFieldFormatter {
         valueDelimiterStartOfValue = Globals.prefs.getValueDelimiters(0);
         valueDelimiterEndOfValue = Globals.prefs.getValueDelimiters(1);
         doNotResolveStringsFors = Globals.prefs.getStringArray(JabRefPreferences.DO_NOT_RESOLVE_STRINGS_FOR);
-        writefieldWrapfield = Globals.prefs.getBoolean(JabRefPreferences.WRITEFIELD_WRAPFIELD);
 
         parser = new FieldContentParser();
     }
@@ -170,7 +168,7 @@ public class LatexFieldFormatter {
         }
 
         // currently, we do not add newlines and new formatting
-        if (writefieldWrapfield && !Globals.prefs.isNonWrappableField(fieldName)) {
+        if (!Globals.prefs.isNonWrappableField(fieldName)) {
             //             introduce a line break to be read at the parser
             return parser.format(StringUtil.wrap(stringBuilder.toString(), GUIGlobals.LINE_LENGTH), fieldName);//, but that lead to ugly .tex
 
@@ -209,9 +207,8 @@ public class LatexFieldFormatter {
         boolean isAbstract = "abstract".equals(fieldName);
         boolean isReview = "review".equals(fieldName);
         boolean doWrap = !isAbstract || !isReview;
-        boolean strangePrefSettings = writefieldWrapfield && !Globals.prefs.isNonWrappableField(fieldName);
 
-        if (strangePrefSettings && doWrap) {
+        if (!Globals.prefs.isNonWrappableField(fieldName) && doWrap) {
             stringBuilder.append(parser.format(StringUtil.wrap(content, GUIGlobals.LINE_LENGTH), fieldName));
         } else {
             stringBuilder.append(parser.format(content, fieldName));

--- a/src/main/java/net/sf/jabref/exporter/LatexFieldFormatter.java
+++ b/src/main/java/net/sf/jabref/exporter/LatexFieldFormatter.java
@@ -71,7 +71,7 @@ public class LatexFieldFormatter {
     /**
      * Formats the content of a field.
      *
-     * @param content the content of the field
+     * @param content   the content of the field
      * @param fieldName the name of the field - used to trigger different serializations, e.g., turning off resolution for some strings
      * @return a formatted string suitable for output
      * @throws IllegalArgumentException if s is not a correct bibtex string, e.g., because of improperly balanced braces or using # not paired
@@ -167,14 +167,7 @@ public class LatexFieldFormatter {
             }
         }
 
-        // currently, we do not add newlines and new formatting
-        if (!Globals.prefs.isNonWrappableField(fieldName)) {
-            //             introduce a line break to be read at the parser
-            return parser.format(StringUtil.wrap(stringBuilder.toString(), GUIGlobals.LINE_LENGTH), fieldName);//, but that lead to ugly .tex
-
-        } else {
-            return parser.format(stringBuilder.toString(), fieldName);
-        }
+        return parser.format(stringBuilder.toString(), fieldName);
     }
 
     private boolean shouldResolveStrings(String fieldName) {
@@ -202,17 +195,8 @@ public class LatexFieldFormatter {
 
         stringBuilder = new StringBuilder(
                 String.valueOf(valueDelimiterStartOfValue));
-        // these two are also hard coded in net.sf.jabref.importer.fileformat.FieldContentParser.multiLineFields
-        // there, JabRefPreferences.NON_WRAPPABLE_FIELDS are also included
-        boolean isAbstract = "abstract".equals(fieldName);
-        boolean isReview = "review".equals(fieldName);
-        boolean doWrap = !isAbstract || !isReview;
 
-        if (!Globals.prefs.isNonWrappableField(fieldName) && doWrap) {
-            stringBuilder.append(parser.format(StringUtil.wrap(content, GUIGlobals.LINE_LENGTH), fieldName));
-        } else {
-            stringBuilder.append(parser.format(content, fieldName));
-        }
+        stringBuilder.append(parser.format(content, fieldName));
 
         stringBuilder.append(valueDelimiterEndOfValue);
 
@@ -221,9 +205,7 @@ public class LatexFieldFormatter {
 
     private void writeText(String text, int start_pos,
                            int end_pos) {
-        /*sb.append("{");
-        sb.append(text.substring(start_pos, end_pos));
-        sb.append("}");*/
+
         stringBuilder.append(valueDelimiterStartOfValue);
         boolean escape = false;
         boolean inCommandName = false;

--- a/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
@@ -60,8 +60,6 @@ class FileTab extends JPanel implements PrefsTab {
     private final JCheckBox autoDoubleBraces;
     private final JCheckBox autoSave;
     private final JCheckBox promptBeforeUsingAutoSave;
-    private final JCheckBox includeEmptyFields;
-    private final JCheckBox sameColumn;
     private final JComboBox<String> valueDelimiter;
     private final JComboBox<String> newlineSeparator;
     private final JRadioButton resolveStringsStandard;
@@ -71,11 +69,6 @@ class FileTab extends JPanel implements PrefsTab {
     private final JTextField doNotResolveStringsFor;
     private final JSpinner autoSaveInterval;
     private boolean origAutoSaveSetting;
-
-    private final ButtonGroup bgFieldOrderStyle;
-    private JTextField userDefinedFieldOrder;
-
-    private final JCheckBox wrapFieldLine;
 
 
     public FileTab(JabRefFrame frame, JabRefPreferences prefs) {
@@ -90,15 +83,11 @@ class FileTab extends JPanel implements PrefsTab {
         valueDelimiter = new JComboBox<>(new String[] {
                 Localization.lang("Quotes") + ": \", \"",
                 Localization.lang("Curly Brackets") + ": {, }"});
-        includeEmptyFields = new JCheckBox(Localization.lang("Include empty fields"));
-        sameColumn = new JCheckBox(Localization.lang("Start field contents in same column"));
         resolveStringsAll = new JRadioButton(Localization.lang("Resolve strings for all fields except") + ":");
         resolveStringsStandard = new JRadioButton(Localization.lang("Resolve strings for standard BibTeX fields only"));
         ButtonGroup bg = new ButtonGroup();
         bg.add(resolveStringsAll);
         bg.add(resolveStringsStandard);
-
-        userDefinedFieldOrder = new JTextField(this.prefs.get(JabRefPreferences.WRITEFIELD_USERDEFINEDORDER)); //need to use JcomboBox in the future
 
         // This is sort of a quick hack
         newlineSeparator = new JComboBox<>(new String[] {"CR", "CR/LF", "LF"});
@@ -162,42 +151,11 @@ class FileTab extends JPanel implements PrefsTab {
         builder.nextLine();
         builder.append(promptBeforeUsingAutoSave);
         builder.nextLine();
-        builder.appendSeparator(Localization.lang("Field saving options"));
-        builder.nextLine();
-        builder.append(sameColumn);
-        builder.append(new JPanel());
-        builder.nextLine();
-        builder.append(includeEmptyFields);
-        builder.append(new JPanel());
-        builder.nextLine();
-
-        wrapFieldLine = new JCheckBox(Localization.lang("Wrap fields as ver 2.9.2"));
-        builder.append(wrapFieldLine);
-        builder.nextLine();
-        //for LWang_AdjustableFieldOrder
-        String[] _rbs0 = {Localization.lang("Save fields sorted in alphabetic order (as in versions 2.10+)"),
-                Localization.lang("Save fields in unsorted order (as until version 2.9.2)"),
-                Localization.lang("Save fields in user-defined order")};
-        ArrayList<String> _rbs = new ArrayList<>();
-        Collections.addAll(_rbs, _rbs0);
-        bgFieldOrderStyle = createRadioBg(_rbs);
-        userDefinedFieldOrder = new JTextField(this.prefs.get(JabRefPreferences.WRITEFIELD_USERDEFINEDORDER)); //need to use JcomboBox in the future
-        createAdFieldOrderBg(builder, bgFieldOrderStyle, userDefinedFieldOrder);
 
         JPanel pan = builder.getPanel();
         pan.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
         setLayout(new BorderLayout());
         add(pan, BorderLayout.CENTER);
-    }
-
-    private ButtonGroup createRadioBg(Iterable<String> radioButtonLabels) {
-        ButtonGroup buttonGroup = new ButtonGroup();
-        for (String _s : radioButtonLabels) {
-            JRadioButton _rb = new JRadioButton(_s);
-            buttonGroup.add(_rb);
-
-        }
-        return buttonGroup;
     }
 
     private int getBgValue(ButtonGroup buttonGroup) {
@@ -261,7 +219,6 @@ class FileTab extends JPanel implements PrefsTab {
             newlineSeparator.setSelectedIndex(1);
         }
 
-        wrapFieldLine.setSelected(prefs.getBoolean(JabRefPreferences.WRITEFIELD_WRAPFIELD));
         autoDoubleBraces.setSelected(prefs.getBoolean(JabRefPreferences.AUTO_DOUBLE_BRACES));
         resolveStringsAll.setSelected(prefs.getBoolean(JabRefPreferences.RESOLVE_STRINGS_ALL_FIELDS));
         resolveStringsStandard.setSelected(!resolveStringsAll.isSelected());
@@ -274,13 +231,6 @@ class FileTab extends JPanel implements PrefsTab {
         autoSaveInterval.setValue(prefs.getInt(JabRefPreferences.AUTO_SAVE_INTERVAL));
         origAutoSaveSetting = autoSave.isSelected();
         valueDelimiter.setSelectedIndex(prefs.getInt(JabRefPreferences.VALUE_DELIMITERS2));
-        includeEmptyFields.setSelected(prefs.getBoolean(JabRefPreferences.INCLUDE_EMPTY_FIELDS));
-        sameColumn.setSelected(prefs.getBoolean(JabRefPreferences.WRITEFIELD_ADDSPACES));
-
-        //for LWang_AdjustableFieldOrder
-        setBgSelected(bgFieldOrderStyle, prefs.getInt(JabRefPreferences.WRITEFIELD_SORTSTYLE));
-        userDefinedFieldOrder.setText(prefs.get(JabRefPreferences.WRITEFIELD_USERDEFINEDORDER));
-
     }
 
     @Override
@@ -309,14 +259,7 @@ class FileTab extends JPanel implements PrefsTab {
         prefs.putBoolean(JabRefPreferences.PROMPT_BEFORE_USING_AUTOSAVE, promptBeforeUsingAutoSave.isSelected());
         prefs.putInt(JabRefPreferences.AUTO_SAVE_INTERVAL, (Integer) autoSaveInterval.getValue());
         prefs.putInt(JabRefPreferences.VALUE_DELIMITERS2, valueDelimiter.getSelectedIndex());
-        prefs.putBoolean(JabRefPreferences.INCLUDE_EMPTY_FIELDS, includeEmptyFields.isSelected());
-        prefs.putBoolean(JabRefPreferences.WRITEFIELD_ADDSPACES, sameColumn.isSelected());
         doNotResolveStringsFor.setText(prefs.get(JabRefPreferences.DO_NOT_RESOLVE_STRINGS_FOR));
-
-        //for LWang_AdjustableFieldOrder
-        prefs.putInt(JabRefPreferences.WRITEFIELD_SORTSTYLE, getBgValue(bgFieldOrderStyle));
-        prefs.put(JabRefPreferences.WRITEFIELD_USERDEFINEDORDER, userDefinedFieldOrder.getText().trim());
-        prefs.putBoolean(JabRefPreferences.WRITEFIELD_WRAPFIELD, wrapFieldLine.isSelected());
 
         boolean updateSpecialFields = false;
         if (!bracesAroundCapitalsFields.getText().trim().equals(prefs.get(JabRefPreferences.PUT_BRACES_AROUND_CAPITALS))) {

--- a/src/test/java/net/sf/jabref/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/net/sf/jabref/bibtex/BibEntryWriterTest.java
@@ -60,10 +60,10 @@ public class BibEntryWriterTest {
 
         // @formatter:off
         String expected = Globals.NEWLINE + Globals.NEWLINE + "@Article{," + Globals.NEWLINE +
-                "  author                   = {Foo Bar}," + Globals.NEWLINE +
-                "  journal                  = {International Journal of Something}," + Globals.NEWLINE +
-                "  number                   = {1}," + Globals.NEWLINE +
-                "  note                     = {some note}" + Globals.NEWLINE +
+                "  author =                   {Foo Bar}," + Globals.NEWLINE +
+                "  journal =                  {International Journal of Something}," + Globals.NEWLINE +
+                "  number =                   {1}," + Globals.NEWLINE +
+                "  note =                     {some note}" + Globals.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -169,10 +169,10 @@ public class BibEntryWriterTest {
 
         // @formatter:off
         String expected = Globals.NEWLINE + Globals.NEWLINE + "@Article{test," + Globals.NEWLINE +
-                "  author                   = {BlaBla}," + Globals.NEWLINE +
-                "  journal                  = {International Journal of Something}," + Globals.NEWLINE +
-                "  number                   = {1}," + Globals.NEWLINE +
-                "  note                     = {some note}" + Globals.NEWLINE +
+                "  author =                   {BlaBla}," + Globals.NEWLINE +
+                "  journal =                  {International Journal of Something}," + Globals.NEWLINE +
+                "  number =                   {1}," + Globals.NEWLINE +
+                "  note =                     {some note}" + Globals.NEWLINE +
                 "}";
         // @formatter:on
         assertEquals(expected, actual);
@@ -215,11 +215,11 @@ public class BibEntryWriterTest {
 
         // @formatter:off
         String expected = Globals.NEWLINE + Globals.NEWLINE + "@Article{test," + Globals.NEWLINE +
-                "  author                   = {BlaBla}," + Globals.NEWLINE +
-                "  journal                  = {International Journal of Something}," + Globals.NEWLINE +
-                "  number                   = {1}," + Globals.NEWLINE +
-                "  note                     = {some note}," + Globals.NEWLINE +
-                "  howpublished             = {asdf}" + Globals.NEWLINE +
+                "  author =                   {BlaBla}," + Globals.NEWLINE +
+                "  journal =                  {International Journal of Something}," + Globals.NEWLINE +
+                "  number =                   {1}," + Globals.NEWLINE +
+                "  note =                     {some note}," + Globals.NEWLINE +
+                "  howpublished =             {asdf}" + Globals.NEWLINE +
                 "}";
         // @formatter:on
         assertEquals(expected, actual);

--- a/src/test/java/net/sf/jabref/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/net/sf/jabref/bibtex/BibEntryWriterTest.java
@@ -30,8 +30,6 @@ public class BibEntryWriterTest {
     public static void setUp() {
         Globals.prefs = JabRefPreferences.getInstance();
         backup = Globals.prefs;
-        // make sure that we use the "new style" serialization
-        Globals.prefs.putInt(JabRefPreferences.WRITEFIELD_SORTSTYLE, 0);
     }
 
     @AfterClass

--- a/src/test/java/net/sf/jabref/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/net/sf/jabref/bibtex/BibEntryWriterTest.java
@@ -30,6 +30,8 @@ public class BibEntryWriterTest {
     public static void setUp() {
         Globals.prefs = JabRefPreferences.getInstance();
         backup = Globals.prefs;
+        // ensure BibTeX mode
+        Globals.prefs.putBoolean(JabRefPreferences.BIBLATEX_MODE, false);
     }
 
     @AfterClass
@@ -328,5 +330,42 @@ public class BibEntryWriterTest {
         String actual = stringWriter.toString();
 
         assertEquals(bibtexEntry, actual);
+    }
+
+    @Test
+    public void addFieldWithLongerLength() throws IOException {
+        // @formatter:off
+        String bibtexEntry = Globals.NEWLINE + Globals.NEWLINE + "@Article{test," + Globals.NEWLINE +
+                "  author =  {BlaBla}," + Globals.NEWLINE +
+                "  journal = {International Journal of Something}," + Globals.NEWLINE +
+                "  number =  {1}," + Globals.NEWLINE +
+                "  note =    {some note}" + Globals.NEWLINE +
+                "}";
+        // @formatter:on
+
+        // read in bibtex string
+        ParserResult result = BibtexParser.parse(new StringReader(bibtexEntry));
+        Collection<BibEntry> entries = result.getDatabase().getEntries();
+        BibEntry entry = entries.iterator().next();
+
+        // modify entry
+        entry.setField("howpublished", "asdf");
+
+        //write out bibtex string
+        StringWriter stringWriter = new StringWriter();
+
+        writer.write(entry, stringWriter);
+        String actual = stringWriter.toString();
+
+        // @formatter:off
+        String expected = Globals.NEWLINE + Globals.NEWLINE + "@Article{test," + Globals.NEWLINE +
+                "  author =       {BlaBla}," + Globals.NEWLINE +
+                "  journal =      {International Journal of Something}," + Globals.NEWLINE +
+                "  number =       {1}," + Globals.NEWLINE +
+                "  note =         {some note}," + Globals.NEWLINE +
+                "  howpublished = {asdf}" + Globals.NEWLINE +
+                "}";
+        // @formatter:on
+        assertEquals(expected, actual);
     }
 }

--- a/src/test/java/net/sf/jabref/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/net/sf/jabref/bibtex/BibEntryWriterTest.java
@@ -60,10 +60,10 @@ public class BibEntryWriterTest {
 
         // @formatter:off
         String expected = Globals.NEWLINE + Globals.NEWLINE + "@Article{," + Globals.NEWLINE +
-                "  author =                   {Foo Bar}," + Globals.NEWLINE +
-                "  journal =                  {International Journal of Something}," + Globals.NEWLINE +
-                "  number =                   {1}," + Globals.NEWLINE +
-                "  note =                     {some note}" + Globals.NEWLINE +
+                "  author =  {Foo Bar}," + Globals.NEWLINE +
+                "  journal = {International Journal of Something}," + Globals.NEWLINE +
+                "  number =  {1}," + Globals.NEWLINE +
+                "  note =    {some note}" + Globals.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -169,10 +169,10 @@ public class BibEntryWriterTest {
 
         // @formatter:off
         String expected = Globals.NEWLINE + Globals.NEWLINE + "@Article{test," + Globals.NEWLINE +
-                "  author =                   {BlaBla}," + Globals.NEWLINE +
-                "  journal =                  {International Journal of Something}," + Globals.NEWLINE +
-                "  number =                   {1}," + Globals.NEWLINE +
-                "  note =                     {some note}" + Globals.NEWLINE +
+                "  author =  {BlaBla}," + Globals.NEWLINE +
+                "  journal = {International Journal of Something}," + Globals.NEWLINE +
+                "  number =  {1}," + Globals.NEWLINE +
+                "  note =    {some note}" + Globals.NEWLINE +
                 "}";
         // @formatter:on
         assertEquals(expected, actual);
@@ -215,11 +215,11 @@ public class BibEntryWriterTest {
 
         // @formatter:off
         String expected = Globals.NEWLINE + Globals.NEWLINE + "@Article{test," + Globals.NEWLINE +
-                "  author =                   {BlaBla}," + Globals.NEWLINE +
-                "  journal =                  {International Journal of Something}," + Globals.NEWLINE +
-                "  number =                   {1}," + Globals.NEWLINE +
-                "  note =                     {some note}," + Globals.NEWLINE +
-                "  howpublished =             {asdf}" + Globals.NEWLINE +
+                "  author =       {BlaBla}," + Globals.NEWLINE +
+                "  journal =      {International Journal of Something}," + Globals.NEWLINE +
+                "  number =       {1}," + Globals.NEWLINE +
+                "  note =         {some note}," + Globals.NEWLINE +
+                "  howpublished = {asdf}" + Globals.NEWLINE +
                 "}";
         // @formatter:on
         assertEquals(expected, actual);

--- a/src/test/java/net/sf/jabref/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/net/sf/jabref/bibtex/BibEntryWriterTest.java
@@ -62,8 +62,8 @@ public class BibEntryWriterTest {
         String expected = Globals.NEWLINE + Globals.NEWLINE + "@Article{," + Globals.NEWLINE +
                 "  author                   = {Foo Bar}," + Globals.NEWLINE +
                 "  journal                  = {International Journal of Something}," + Globals.NEWLINE +
-                "  note                     = {some note}," + Globals.NEWLINE +
-                "  number                   = {1}" + Globals.NEWLINE +
+                "  number                   = {1}," + Globals.NEWLINE +
+                "  note                     = {some note}" + Globals.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -171,8 +171,8 @@ public class BibEntryWriterTest {
         String expected = Globals.NEWLINE + Globals.NEWLINE + "@Article{test," + Globals.NEWLINE +
                 "  author                   = {BlaBla}," + Globals.NEWLINE +
                 "  journal                  = {International Journal of Something}," + Globals.NEWLINE +
-                "  note                     = {some note}," + Globals.NEWLINE +
-                "  number                   = {1}" + Globals.NEWLINE +
+                "  number                   = {1}," + Globals.NEWLINE +
+                "  note                     = {some note}" + Globals.NEWLINE +
                 "}";
         // @formatter:on
         assertEquals(expected, actual);
@@ -217,8 +217,8 @@ public class BibEntryWriterTest {
         String expected = Globals.NEWLINE + Globals.NEWLINE + "@Article{test," + Globals.NEWLINE +
                 "  author                   = {BlaBla}," + Globals.NEWLINE +
                 "  journal                  = {International Journal of Something}," + Globals.NEWLINE +
-                "  note                     = {some note}," + Globals.NEWLINE +
                 "  number                   = {1}," + Globals.NEWLINE +
+                "  note                     = {some note}," + Globals.NEWLINE +
                 "  howpublished             = {asdf}" + Globals.NEWLINE +
                 "}";
         // @formatter:on


### PR DESCRIPTION
As decided in #116 all field saving options should be removed.

This PR purges the options from the GUI and cleans up related reader and formatter classes. This simplification greatly reduces the complexity of `BibEntryWriter`.