### PR TITLE
Fix SF bug 482 partly: escaped brackets are now properly parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Christmas color theme (red and green)
 
 ### Fixed
+- Fixed [bug 482](https://sourceforge.net/p/jabref/bugs/482/) partly: escaped brackets are now parsed properly when opening a bib file
 - Fixed #479: Import works again
 - Fixed #434: Revert to old 'JabRef' installation folder name instead of 'jabref'
 - Fixed #435: Retrieve non open access ScienceDirect PDFs via HTTP DOM

--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
@@ -861,23 +861,27 @@ public class BibtexParser {
         consume('{');
 
         int brackets = 0;
+        char character;
+        char lastCharacter = '\0';
 
-        while (!((peek() == '}') && (brackets == 0))) {
+        while (true) {
+            character = (char) read();
 
-            int character = read();
-            if (isEOFCharacter(character)) {
+            boolean isClosingBracket = (character == '}') && (lastCharacter != '\\');
+            if (isClosingBracket && (brackets == 0)) {
+                return value;
+            } else if (isEOFCharacter(character)) {
                 throw new IOException("Error in line " + line + ": EOF in mid-string");
-            } else if (character == '{') {
+            } else if ((character == '{') && (lastCharacter != '\\')) {
                 brackets++;
-            } else if (character == '}') {
+            } else if (isClosingBracket) {
                 brackets--;
             }
 
-            value.append((char) character);
-        }
-        consume('}');
+            value.append(character);
 
-        return value;
+            lastCharacter = character;
+        }
     }
 
     private StringBuffer parseQuotedFieldExactly() throws IOException {

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -558,6 +558,41 @@ public class BibtexParserTest {
         Assert.assertEquals(0, c.size());
     }
 
+    /**
+     * Test for SF bug 482
+     */
+    @Test
+    public void parseAddsEscapedOpenBracketToFieldValue() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,review={escaped \\{ bracket}}"));
+
+        Assert.assertFalse(result.hasWarnings());
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals("escaped \\{ bracket", e.getField("review"));
+    }
+
+    @Test
+    public void parseAddsEscapedClosingBracketToFieldValue() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,review={escaped \\} bracket}}"));
+
+        Assert.assertFalse(result.hasWarnings());
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals("escaped \\} bracket", e.getField("review"));
+    }
+
     @Test
     public void parseIgnoresAndWarnsAboutEntryWithUnmatchedOpenBracketInQuotationMarks() throws IOException {
 


### PR DESCRIPTION
Field values as `escaped \{ bracket` are now parsed properly by the BibtexParser. However, there is still a warning about non-matching brackets if the same string is entered directly in the review panel.