### PR TITLE
Used a scrollable text area for parser warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 ## [Unreleased]
 
 ### Changed
+- All import/open database warnings are now shown in a scrolling text area
 
 ### Fixed
 

--- a/src/main/java/net/sf/jabref/JabRef.java
+++ b/src/main/java/net/sf/jabref/JabRef.java
@@ -78,8 +78,6 @@ public class JabRef {
 
     public static JabRefFrame jrf;
 
-    private static final int MAX_DIALOG_WARNINGS = 10;
-
     private JabRefCLI cli;
 
 
@@ -726,8 +724,7 @@ public class JabRef {
 
         for (int i = 0; i < loaded.size(); i++) {
             if (Globals.prefs.getBoolean(JabRefPreferences.DISPLAY_KEY_WARNING_DIALOG_AT_STARTUP)) {
-                ParserResultWarningDialog.showParserResultWarningDialog(loaded.elementAt(i), JabRef.jrf,
-                        JabRef.MAX_DIALOG_WARNINGS, i);
+                ParserResultWarningDialog.showParserResultWarningDialog(loaded.elementAt(i), JabRef.jrf, i);
             }
         }
 


### PR DESCRIPTION
Now, all warnings when opening a file is shown in a scrollable text area instead of as plain warning text (with all the consequences, try opening a file with ~1000 items without keys...).