### PR TITLE
Reverted a fix that lead to new Coverity warnings and more PMD cleanups

### DIFF
--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -123,7 +123,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
     private JSplitPane splitPane;
 
-    JabRefFrame frame;
+    private final JabRefFrame frame;
 
     private String fileMonitorHandle;
     private boolean saving;
@@ -515,7 +515,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         // action for exporting database to external SQL database
         actions.put(Actions.DB_EXPORT, new AbstractWorker() {
 
-            String errorMessage;
+            String errorMessage = "";
             boolean connectToDB;
 
             // run first, in EDT:
@@ -582,7 +582,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             public void update() {
 
                 // if no error, report success
-                if (errorMessage == null) {
+                if (errorMessage.isEmpty()) {
                     if (connectToDB) {
                         frame.output(Localization.lang("%0 export successful"));
                     }
@@ -594,7 +594,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     JOptionPane.showMessageDialog(frame, preamble + '\n' + errorMessage,
                             Localization.lang("Export to SQL database"), JOptionPane.ERROR_MESSAGE);
 
-                    errorMessage = null;
+                    errorMessage = "";
                 }
             }
 
@@ -2471,7 +2471,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             return;
         }
         nextEntries.clear();
-        if (!(entry.equals(showing))) {
+        if (entry != showing) {
             // Add the entry we are leaving to the history:
             if (showing != null) {
                 previousEntries.add(showing);

--- a/src/main/java/net/sf/jabref/gui/BibtexFields.java
+++ b/src/main/java/net/sf/jabref/gui/BibtexFields.java
@@ -34,9 +34,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Vector;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
@@ -68,10 +68,10 @@ public class BibtexFields {
             {"author", "title", "year", BibEntry.KEY_FIELD};
 
     // singleton instance
-    private static final BibtexFields runtime = new BibtexFields();
+    private static final BibtexFields RUNTIME = new BibtexFields();
 
     // contains all bibtex-field objects (BibtexSingleField)
-    private final HashMap<String, BibtexSingleField> fieldSet;
+    private final Map<String, BibtexSingleField> fieldSet;
 
     // contains all known (and public) bibtex fieldnames
     private final String[] PUBLIC_FIELDS;
@@ -258,7 +258,7 @@ public class BibtexFields {
         }
 
         // collect all public fields for the PUBLIC_FIELDS array
-        Vector<String> pFields = new Vector<>(fieldSet.size());
+        List<String> pFields = new ArrayList<>(fieldSet.size());
         for (BibtexSingleField sField : fieldSet.values()) {
             if (!sField.isPrivate()) {
                 pFields.add(sField.getFieldName());
@@ -269,7 +269,7 @@ public class BibtexFields {
 
         PUBLIC_FIELDS = pFields.toArray(new String[pFields.size()]);
         // sort the entries
-        java.util.Arrays.sort(PUBLIC_FIELDS);
+        Arrays.sort(PUBLIC_FIELDS);
 
     }
 
@@ -287,8 +287,8 @@ public class BibtexFields {
         HashSet<String> nF = new HashSet<>();
         Collections.addAll(nF, numFields);
         // Look through all registered fields, and activate numeric sorting if necessary:
-        for (String fieldName : BibtexFields.runtime.fieldSet.keySet()) {
-            BibtexSingleField field = BibtexFields.runtime.fieldSet.get(fieldName);
+        for (String fieldName : BibtexFields.RUNTIME.fieldSet.keySet()) {
+            BibtexSingleField field = BibtexFields.RUNTIME.fieldSet.get(fieldName);
             if (!field.isNumeric() && nF.contains(fieldName)) {
                 field.setNumeric(nF.contains(fieldName));
             }
@@ -298,7 +298,7 @@ public class BibtexFields {
         for (String fieldName : nF) {
             BibtexSingleField field = new BibtexSingleField(fieldName, false);
             field.setNumeric(true);
-            BibtexFields.runtime.fieldSet.put(fieldName, field);
+            BibtexFields.RUNTIME.fieldSet.put(fieldName, field);
         }
 
     }
@@ -317,7 +317,7 @@ public class BibtexFields {
     // --------------------------------------------------------------------------
     private static BibtexSingleField getField(String name) {
         if (name != null) {
-            return BibtexFields.runtime.fieldSet.get(name.toLowerCase());
+            return BibtexFields.RUNTIME.fieldSet.get(name.toLowerCase());
         }
 
         return null;
@@ -392,7 +392,7 @@ public class BibtexFields {
      * returns a List with all fieldnames
      */
     public static List<String> getAllFieldNames() {
-        return Arrays.asList(BibtexFields.runtime.PUBLIC_FIELDS);
+        return Arrays.asList(BibtexFields.RUNTIME.PUBLIC_FIELDS);
     }
 
     /**
@@ -400,7 +400,7 @@ public class BibtexFields {
      */
     public static List<String> getAllPrivateFieldNames() {
         List<String> pFields = new ArrayList<>();
-        for (BibtexSingleField sField : BibtexFields.runtime.fieldSet.values()) {
+        for (BibtexSingleField sField : BibtexFields.RUNTIME.fieldSet.values()) {
             if (sField.isPrivate()) {
                 pFields.add(sField.getFieldName());
             }
@@ -413,14 +413,14 @@ public class BibtexFields {
      * returns the fieldname of the entry at index t
      */
     public static String getFieldName(int t) {
-        return BibtexFields.runtime.PUBLIC_FIELDS[t];
+        return BibtexFields.RUNTIME.PUBLIC_FIELDS[t];
     }
 
     /**
      * returns the number of available fields
      */
     public static int numberOfPublicFields() {
-        return BibtexFields.runtime.PUBLIC_FIELDS.length;
+        return BibtexFields.RUNTIME.PUBLIC_FIELDS.length;
     }
 
 

--- a/src/main/java/net/sf/jabref/gui/CheckBoxMessage.java
+++ b/src/main/java/net/sf/jabref/gui/CheckBoxMessage.java
@@ -16,14 +16,12 @@
 package net.sf.jabref.gui;
 
 import javax.swing.*;
-import java.awt.BorderLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 
 public class CheckBoxMessage extends JPanel {
 
-    BorderLayout borderLayout1 = new BorderLayout();
     private final JCheckBox cb;
 
 

--- a/src/main/java/net/sf/jabref/gui/ClipBoardManager.java
+++ b/src/main/java/net/sf/jabref/gui/ClipBoardManager.java
@@ -37,7 +37,7 @@ public class ClipBoardManager implements ClipboardOwner {
 
     private static final Log LOGGER = LogFactory.getLog(ClipBoardManager.class);
 
-    public static final ClipBoardManager clipBoard = new ClipBoardManager();
+    public static final ClipBoardManager CLIPBOARD = new ClipBoardManager();
 
     /**
      * Empty implementation of the ClipboardOwner interface.

--- a/src/main/java/net/sf/jabref/gui/ColorSetupPanel.java
+++ b/src/main/java/net/sf/jabref/gui/ColorSetupPanel.java
@@ -23,6 +23,7 @@ import java.awt.*;
 import java.awt.event.ActionListener;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
+import java.util.List;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
@@ -39,8 +40,7 @@ public class ColorSetupPanel extends JPanel {
 
     private static final int ICON_WIDTH = 30;
     private static final int ICON_HEIGHT = 20;
-    private final ArrayList<ColorButton> buttons = new ArrayList<>();
-
+    private final List<ColorButton> buttons = new ArrayList<>();
 
     public ColorSetupPanel() {
 

--- a/src/main/java/net/sf/jabref/gui/ContentSelectorDialog2.java
+++ b/src/main/java/net/sf/jabref/gui/ContentSelectorDialog2.java
@@ -25,6 +25,8 @@ import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.Vector;
@@ -66,13 +68,10 @@ class ContentSelectorDialog2 extends JDialog {
     private final JPanel fieldNamePan = new JPanel();
     private final JPanel wordEditPan = new JPanel();
 
-    final String
-            WORD_EMPTY_TEXT = Localization.lang("<no field>");
     private final String WORD_FIRSTLINE_TEXT = Localization.lang("<select word>");
     private final String FIELD_FIRST_LINE = Localization.lang("<field name>");
     private final MetaData metaData;
     private String currentField;
-    TreeSet<String> fieldSet;
     private final JabRefFrame frame;
     private final BasePanel panel;
     private final JButton newField = new JButton(Localization.lang("New"));
@@ -91,8 +90,8 @@ class ContentSelectorDialog2 extends JDialog {
     private final JScrollPane fPane = new JScrollPane(fieldList);
     private final JScrollPane wPane = new JScrollPane(wordList);
 
-    private final HashMap<String, DefaultListModel<String>> wordListModels = new HashMap<>();
-    private final ArrayList<String> removedFields = new ArrayList<>();
+    private final Map<String, DefaultListModel<String>> wordListModels = new HashMap<>();
+    private final List<String> removedFields = new ArrayList<>();
 
     private static final Log LOGGER = LogFactory.getLog(ContentSelectorDialog2.class);
 
@@ -146,12 +145,12 @@ class ContentSelectorDialog2 extends JDialog {
 
             @Override
             public void actionPerformed(ActionEvent e) {
-                int index = wordList.getSelectedIndex();
                 String old = wordList.getSelectedValue();
                 String newVal = wordEditField.getText();
                 if ("".equals(newVal) || newVal.equals(old)) {
                     return; // Empty string or no change.
                 }
+                int index = wordList.getSelectedIndex();
                 if (wordListModel.contains(newVal)) {
                     // ensure that word already in list is visible
                     index = wordListModel.indexOf(newVal);
@@ -300,8 +299,7 @@ class ContentSelectorDialog2 extends JDialog {
                 }
                 try {
                     applyChanges();
-                }
-                catch (Exception ex) {
+                } catch (Exception ex) {
                     LOGGER.info("Could not apply changes in \"Setup selectors\"", ex);
                     JOptionPane.showMessageDialog(frame, Localization.lang("Could not apply changes."));
                 }
@@ -434,7 +432,6 @@ class ContentSelectorDialog2 extends JDialog {
             wordListModel = new DefaultListModel<>();
             wordList.setModel(wordListModel);
             wordListModels.put(currentField, wordListModel);
-            // wordListModel.addElement(WORD_FIRSTLINE_TEXT);
             Vector<String> items = metaData.getData(Globals.SELECTOR_META_PREFIX + currentField);
             if (items != null) {
                 TreeSet<String> wordSet = new TreeSet<>(items);

--- a/src/main/java/net/sf/jabref/gui/DatabasePropertiesDialog.java
+++ b/src/main/java/net/sf/jabref/gui/DatabasePropertiesDialog.java
@@ -19,7 +19,9 @@ import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Vector;
 
 import javax.swing.AbstractAction;
@@ -229,7 +231,7 @@ public class DatabasePropertiesDialog extends JDialog {
         saveInOriginalOrder.addActionListener(listener);
         saveInSpecifiedOrder.addActionListener(listener);
 
-        Vector<String> v = new Vector<>(BibtexFields.getAllFieldNames());
+        List<String> v = new ArrayList<>(BibtexFields.getAllFieldNames());
         v.add(BibEntry.KEY_FIELD);
         Collections.sort(v);
         String[] allPlusKey = v.toArray(new String[v.size()]);
@@ -333,13 +335,13 @@ public class DatabasePropertiesDialog extends JDialog {
             fileDir.setText("");
         } else {
             // Better be a little careful about how many entries the Vector has:
-            if (fileD.size() >= 1) {
+            if (!(fileD.isEmpty())) {
                 fileDir.setText((fileD.get(0)).trim());
             }
         }
 
-        Vector<String> fileDI = metaData.getData(Globals.prefs.get(JabRefPreferences.USER_FILE_DIR_INDIVIDUAL)); // File dir setting
-        Vector<String> fileDIL = metaData.getData(Globals.prefs.get(JabRefPreferences.USER_FILE_DIR_IND_LEGACY)); // Legacy file dir setting for backward comp.
+        List<String> fileDI = metaData.getData(Globals.prefs.get(JabRefPreferences.USER_FILE_DIR_INDIVIDUAL)); // File dir setting
+        List<String> fileDIL = metaData.getData(Globals.prefs.get(JabRefPreferences.USER_FILE_DIR_IND_LEGACY)); // Legacy file dir setting for backward comp.
         if (fileDI == null) {
             oldFileIndvVal = fileDirIndv.getText(); // Record individual file dir setting as originally empty if reading from legacy setting
             if (fileDIL == null) {
@@ -347,23 +349,23 @@ public class DatabasePropertiesDialog extends JDialog {
             } else {
                 // Insert path from legacy setting if possible
                 // Better be a little careful about how many entries the Vector has:
-                if (fileDIL.size() >= 1) {
+                if (!(fileDIL.isEmpty())) {
                     fileDirIndv.setText((fileDIL.get(0)).trim());
                 }
             }
         } else {
             // Better be a little careful about how many entries the Vector has:
-            if (fileDI.size() >= 1) {
+            if (!(fileDI.isEmpty())) {
                 fileDirIndv.setText((fileDI.get(0)).trim());
             }
             oldFileIndvVal = fileDirIndv.getText(); // Record individual file dir setting normally if reading from ordinary setting
         }
 
-        Vector<String> prot = metaData.getData(Globals.PROTECTED_FLAG_META);
+        List<String> prot = metaData.getData(Globals.PROTECTED_FLAG_META);
         if (prot == null) {
             protect.setSelected(false);
         } else {
-            if (prot.size() >= 1) {
+            if (!(prot.isEmpty())) {
                 protect.setSelected(Boolean.parseBoolean(prot.get(0)));
             }
         }
@@ -401,28 +403,28 @@ public class DatabasePropertiesDialog extends JDialog {
         Charset newEncoding = (Charset) encoding.getSelectedItem();
         panel.setEncoding(newEncoding);
 
-        Vector<String> dir = new Vector<>(1);
+        List<String> dir = new ArrayList<>(1);
         String text = fileDir.getText().trim();
-        if (!text.isEmpty()) {
-            dir.add(text);
-            metaData.putData(Globals.prefs.get(JabRefPreferences.USER_FILE_DIR), dir);
-        } else {
+        if (text.isEmpty()) {
             metaData.remove(Globals.prefs.get(JabRefPreferences.USER_FILE_DIR));
+        } else {
+            dir.add(text);
+            metaData.putData(Globals.prefs.get(JabRefPreferences.USER_FILE_DIR), new Vector<>(dir));
         }
         // Repeat for individual file dir - reuse 'text' and 'dir' vars
-        dir = new Vector<>(1);
+        dir = new ArrayList<>(1);
         text = fileDirIndv.getText().trim();
-        if (!text.isEmpty()) {
-            dir.add(text);
-            metaData.putData(Globals.prefs.get(JabRefPreferences.USER_FILE_DIR_INDIVIDUAL), dir);
-        } else {
+        if (text.isEmpty()) {
             metaData.remove(Globals.prefs.get(JabRefPreferences.USER_FILE_DIR_INDIVIDUAL));
+        } else {
+            dir.add(text);
+            metaData.putData(Globals.prefs.get(JabRefPreferences.USER_FILE_DIR_INDIVIDUAL), new Vector<>(dir));
         }
 
         if (protect.isSelected()) {
-            dir = new Vector<>(1);
+            dir = new ArrayList<>(1);
             dir.add("true");
-            metaData.putData(Globals.PROTECTED_FLAG_META, dir);
+            metaData.putData(Globals.PROTECTED_FLAG_META, new Vector<>(dir));
         } else {
             metaData.remove(Globals.PROTECTED_FLAG_META);
         }

--- a/src/main/java/net/sf/jabref/gui/DragDropPopupPane.java
+++ b/src/main/java/net/sf/jabref/gui/DragDropPopupPane.java
@@ -23,7 +23,8 @@ import javax.swing.JPopupMenu;
  * Adds popup functionality to DragDropPane
  */
 public class DragDropPopupPane extends DragDropPane {
-    private JPopupMenu popupMenu;
+
+    private final JPopupMenu popupMenu;
 
     public DragDropPopupPane(JPopupMenu menu) {
         this.popupMenu = menu;

--- a/src/main/java/net/sf/jabref/gui/DuplicateSearch.java
+++ b/src/main/java/net/sf/jabref/gui/DuplicateSearch.java
@@ -22,8 +22,7 @@
 package net.sf.jabref.gui;
 
 import java.util.ArrayList;
-import java.util.Vector;
-
+import java.util.List;
 import javax.swing.SwingUtilities;
 
 import net.sf.jabref.*;
@@ -40,7 +39,7 @@ public class DuplicateSearch implements Runnable {
 
     private final BasePanel panel;
     private BibEntry[] bes;
-    private final Vector<BibEntry[]> duplicates = new Vector<>();
+    private final List<BibEntry[]> duplicates = new ArrayList<>();
 
 
     public DuplicateSearch(BasePanel bp) {
@@ -49,10 +48,7 @@ public class DuplicateSearch implements Runnable {
 
     @Override
     public void run() {
-        final NamedCompound ce = new NamedCompound(Localization.lang("duplicate removal"));
-        int duplicateCounter = 0;
 
-        boolean autoRemoveExactDuplicates = false;
         panel.output(Localization.lang("Searching for duplicates..."));
         Object[] keys = panel.getDatabase().getKeySet().toArray();
         if (keys.length < 2) {
@@ -67,8 +63,11 @@ public class DuplicateSearch implements Runnable {
         JabRefExecutorService.INSTANCE.executeWithLowPriorityInOwnThread(st, "Searcher");
         int current = 0;
 
-        final ArrayList<BibEntry> toRemove = new ArrayList<>();
-        final ArrayList<BibEntry> toAdd = new ArrayList<>();
+        final List<BibEntry> toRemove = new ArrayList<>();
+        final List<BibEntry> toAdd = new ArrayList<>();
+
+        int duplicateCounter = 0;
+        boolean autoRemoveExactDuplicates = false;
 
         synchronized (duplicates) {
             while (!st.finished() || (current < duplicates.size())) {
@@ -83,9 +82,7 @@ public class DuplicateSearch implements Runnable {
                         // Ignore
                     }
 
-                } else // duplicates found
-                {
-
+                } else { // duplicates found
                     BibEntry[] be = duplicates.get(current);
                     current++;
                     if (!toRemove.contains(be[0]) && !toRemove.contains(be[1])) {
@@ -100,7 +97,7 @@ public class DuplicateSearch implements Runnable {
                             askAboutExact = true;
                         }
 
-                        DuplicateCallBack cb = new DuplicateCallBack(panel.frame, be[0], be[1],
+                        DuplicateCallBack cb = new DuplicateCallBack(JabRef.jrf, be[0], be[1],
                                 askAboutExact ? DuplicateResolverDialog.DUPLICATE_SEARCH_WITH_EXACT :
                                         DuplicateResolverDialog.DUPLICATE_SEARCH);
                         ((CallBack) Spin.over(cb)).update();
@@ -128,6 +125,8 @@ public class DuplicateSearch implements Runnable {
                 }
             }
         }
+
+        final NamedCompound ce = new NamedCompound(Localization.lang("duplicate removal"));
 
         final int dupliC = duplicateCounter;
         SwingUtilities.invokeLater(new Runnable() {
@@ -195,7 +194,7 @@ public class DuplicateSearch implements Runnable {
         }
 
         // Thread cancel option
-        // no synchronized used because no "realy" critical situations expected
+        // no synchronized used because no "really" critical situations expected
         public void setFinished() {
             finished = true;
         }
@@ -204,7 +203,6 @@ public class DuplicateSearch implements Runnable {
     static class DuplicateCallBack implements CallBack {
 
         private int reply = -1;
-        DuplicateResolverDialog diag;
         private final JabRefFrame frame;
         private final BibEntry one;
         private final BibEntry two;
@@ -231,7 +229,7 @@ public class DuplicateSearch implements Runnable {
 
         @Override
         public void update() {
-            diag = new DuplicateResolverDialog(frame, one, two, dialogType);
+            DuplicateResolverDialog diag = new DuplicateResolverDialog(frame, one, two, dialogType);
             diag.setVisible(true);
             diag.dispose();
             reply = diag.getSelected();

--- a/src/main/java/net/sf/jabref/gui/EntryMarker.java
+++ b/src/main/java/net/sf/jabref/gui/EntryMarker.java
@@ -86,10 +86,10 @@ public class EntryMarker {
             int index = s.indexOf(Globals.prefs.WRAPPED_USERNAME);
             if (index >= 0) {
                 // Marked 1 for this user.
-                if (!onlyMaxLevel) {
-                    newValue = s.substring(0, index) + s.substring(index + Globals.prefs.WRAPPED_USERNAME.length());
-                } else {
+                if (onlyMaxLevel) {
                     return;
+                } else {
+                    newValue = s.substring(0, index) + s.substring(index + Globals.prefs.WRAPPED_USERNAME.length());
                 }
             } else {
                 Matcher m = MARK_NUMBER_PATTERN.matcher(s);

--- a/src/main/java/net/sf/jabref/gui/EntryTypeList.java
+++ b/src/main/java/net/sf/jabref/gui/EntryTypeList.java
@@ -116,7 +116,10 @@ public class EntryTypeList extends FieldSetComponent implements ListSelectionLis
     public void enable(String typeName, boolean isChanged) {
         //String s = (String)list.getSelectedValue();
 
-        if (EntryTypes.getStandardType(typeName) != null) {
+        if (EntryTypes.getStandardType(typeName) == null) {
+            def.setEnabled(false);
+            remove.setEnabled(true);
+        } else {
 
             if (isChanged || (EntryTypes.getType(typeName) instanceof CustomEntryType)) {
                 def.setEnabled(true);
@@ -125,9 +128,6 @@ public class EntryTypeList extends FieldSetComponent implements ListSelectionLis
             }
 
             remove.setEnabled(false);
-        } else {
-            def.setEnabled(false);
-            remove.setEnabled(true);
         }
     }
 

--- a/src/main/java/net/sf/jabref/gui/FetcherPreviewDialog.java
+++ b/src/main/java/net/sf/jabref/gui/FetcherPreviewDialog.java
@@ -232,7 +232,7 @@ public class FetcherPreviewDialog extends JDialog implements OutputPrinter {
 
     static class PreviewRenderer implements TableCellRenderer {
 
-        final JLabel label = new JLabel();
+        private final JLabel label = new JLabel();
 
 
         @Override
@@ -247,7 +247,7 @@ public class FetcherPreviewDialog extends JDialog implements OutputPrinter {
 
     class EntryTable extends JTable {
 
-        final PreviewRenderer renderer = new PreviewRenderer();
+        private final PreviewRenderer renderer = new PreviewRenderer();
 
 
         public EntryTable(TableModel model) {

--- a/src/main/java/net/sf/jabref/gui/FieldWeightDialog.java
+++ b/src/main/java/net/sf/jabref/gui/FieldWeightDialog.java
@@ -19,6 +19,7 @@ import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.TreeSet;
 
 import javax.swing.*;
@@ -39,7 +40,7 @@ import net.sf.jabref.logic.l10n.Localization;
 public class FieldWeightDialog extends JDialog {
 
     private final JabRefFrame frame;
-    private final HashMap<JSlider, SliderInfo> sliders = new HashMap<>();
+    private final Map<JSlider, SliderInfo> sliders = new HashMap<>();
     private final JButton ok = new JButton(Localization.lang("OK"));
     private final JButton cancel = new JButton(Localization.lang("Cancel"));
 

--- a/src/main/java/net/sf/jabref/gui/FileHistoryMenu.java
+++ b/src/main/java/net/sf/jabref/gui/FileHistoryMenu.java
@@ -92,7 +92,7 @@ public class FileHistoryMenu extends JMenu implements ActionListener {
     @Override
     public void actionPerformed(ActionEvent e) {
         String name = ((JMenuItem) e.getSource()).getText();
-        int pos = name.indexOf(" ");
+        int pos = name.indexOf(' ');
         name = name.substring(pos + 1);
         final File fileToOpen = new File(name);
 

--- a/src/main/java/net/sf/jabref/gui/IconTheme.java
+++ b/src/main/java/net/sf/jabref/gui/IconTheme.java
@@ -42,6 +42,11 @@ public class IconTheme {
     public static final int DEFAULT_SIZE = 24;
     public static final int SMALL_SIZE = 16;
 
+    private static final Map<String, String> KEY_TO_ICON = readIconThemeFile(
+            IconTheme.class.getResource("/images/Icons.properties"), "/images/external/");
+    private static final String DEFAULT_ICON_PATH = "/images/external/red.png";
+
+
     private static final Log LOGGER = LogFactory.getLog(IconTheme.class);
 
     static {
@@ -237,9 +242,6 @@ public class IconTheme {
     }
 
 
-    private static final Map<String, String> KEY_TO_ICON = readIconThemeFile(IconTheme.class.getResource("/images/Icons.properties"), "/images/external/");
-    private static final String DEFAULT_ICON_PATH = "/images/external/red.png";
-
     /**
      * Constructs an ImageIcon for the image representing the given function, in the resource
      * file listing images.
@@ -292,7 +294,7 @@ public class IconTheme {
                     continue;
                 }
 
-                int index = line.indexOf("=");
+                int index = line.indexOf('=');
                 String key = line.substring(0, index).trim();
                 String value = prefix + line.substring(index + 1).trim();
                 result.put(key, value);

--- a/src/main/java/net/sf/jabref/gui/RightClickMenu.java
+++ b/src/main/java/net/sf/jabref/gui/RightClickMenu.java
@@ -87,7 +87,7 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
         addSeparator();
 
         JMenu markSpecific = JabRefFrame.subMenu("Mark specific color");
-        JabRefFrame frame = panel.frame;
+        JabRefFrame frame = JabRef.jrf;
         for (int i = 0; i < EntryMarker.MAX_MARKING_LEVEL; i++) {
             markSpecific.add(new MarkEntriesAction(frame, i).getMenuItem());
         }
@@ -113,7 +113,7 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
         if (Globals.prefs.getBoolean(SpecialFieldsUtils.PREF_SPECIALFIELDSENABLED)) {
             if (Globals.prefs.getBoolean(SpecialFieldsUtils.PREF_SHOWCOLUMN_RANKING)) {
                 JMenu rankingMenu = new JMenu();
-                RightClickMenu.populateSpecialFieldMenu(rankingMenu, Rank.getInstance(), panel.frame);
+                RightClickMenu.populateSpecialFieldMenu(rankingMenu, Rank.getInstance(), JabRef.jrf);
                 add(rankingMenu);
             }
 
@@ -121,24 +121,24 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
             // if multiple values are selected ("if (multiple)"), two options (set / clear) should be offered
             // if one value is selected either set or clear should be offered
             if (Globals.prefs.getBoolean(SpecialFieldsUtils.PREF_SHOWCOLUMN_RELEVANCE)) {
-                add(Relevance.getInstance().getValues().get(0).getMenuAction(panel.frame));
+                add(Relevance.getInstance().getValues().get(0).getMenuAction(JabRef.jrf));
             }
             if (Globals.prefs.getBoolean(SpecialFieldsUtils.PREF_SHOWCOLUMN_QUALITY)) {
-                add(Quality.getInstance().getValues().get(0).getMenuAction(panel.frame));
+                add(Quality.getInstance().getValues().get(0).getMenuAction(JabRef.jrf));
             }
             if (Globals.prefs.getBoolean(SpecialFieldsUtils.PREF_SHOWCOLUMN_PRINTED)) {
-                add(Printed.getInstance().getValues().get(0).getMenuAction(panel.frame));
+                add(Printed.getInstance().getValues().get(0).getMenuAction(JabRef.jrf));
             }
 
             if (Globals.prefs.getBoolean(SpecialFieldsUtils.PREF_SHOWCOLUMN_PRIORITY)) {
                 JMenu priorityMenu = new JMenu();
-                RightClickMenu.populateSpecialFieldMenu(priorityMenu, Priority.getInstance(), panel.frame);
+                RightClickMenu.populateSpecialFieldMenu(priorityMenu, Priority.getInstance(), JabRef.jrf);
                 add(priorityMenu);
             }
 
             if (Globals.prefs.getBoolean(SpecialFieldsUtils.PREF_SHOWCOLUMN_READ)) {
                 JMenu readStatusMenu = new JMenu();
-                RightClickMenu.populateSpecialFieldMenu(readStatusMenu, ReadStatus.getInstance(), panel.frame);
+                RightClickMenu.populateSpecialFieldMenu(readStatusMenu, ReadStatus.getInstance(), JabRef.jrf);
                 add(readStatusMenu);
             }
 

--- a/src/main/java/net/sf/jabref/gui/SidePaneComponent.java
+++ b/src/main/java/net/sf/jabref/gui/SidePaneComponent.java
@@ -57,7 +57,7 @@ public abstract class SidePaneComponent extends JXTitledPanel {
         setBorder(BorderFactory.createEmptyBorder());
     }
 
-    void hideAway() {
+    private void hideAway() {
         manager.hideComponent(this);
     }
 

--- a/src/main/java/net/sf/jabref/gui/StringDialog.java
+++ b/src/main/java/net/sf/jabref/gui/StringDialog.java
@@ -71,7 +71,7 @@ class StringDialog extends JDialog {
     private final StringTable table;
     private final HelpAction helpAction;
 
-    private PositionWindow pw;
+    private final PositionWindow pw;
 
 
     public StringDialog(JabRefFrame frame, BasePanel panel, BibDatabase base) {
@@ -148,10 +148,10 @@ class StringDialog extends JDialog {
         conPane.add(tlb, BorderLayout.NORTH);
         conPane.add(pan, BorderLayout.CENTER);
 
-        if (panel.getDatabaseFile() != null) {
-            setTitle(GUIGlobals.stringsTitle + ": " + panel.getDatabaseFile().getName());
-        } else {
+        if (panel.getDatabaseFile() == null) {
             setTitle(GUIGlobals.stringsTitle + ": " + GUIGlobals.untitledTitle);
+        } else {
+            setTitle(GUIGlobals.stringsTitle + ": " + panel.getDatabaseFile().getName());
         }
         pw = new PositionWindow(this, JabRefPreferences.STRINGS_POS_X, JabRefPreferences.STRINGS_POS_Y,
                 JabRefPreferences.STRINGS_SIZE_X, JabRefPreferences.STRINGS_SIZE_Y);
@@ -177,7 +177,7 @@ class StringDialog extends JDialog {
 
     class StringTable extends JTable {
 
-        final JScrollPane sp = new JScrollPane(this);
+        private final JScrollPane sp = new JScrollPane(this);
 
 
         public StringTable(StringTableModel stm) {
@@ -228,8 +228,8 @@ class StringDialog extends JDialog {
 
     class StringTableModel extends AbstractTableModel {
 
-        final BibDatabase tbase;
-        final StringDialog parent;
+        private final BibDatabase tbase;
+        private final StringDialog parent;
 
 
         public StringTableModel(StringDialog parent, BibDatabase base) {
@@ -334,18 +334,14 @@ class StringDialog extends JDialog {
 
 
     // The action concerned with closing the window.
-    private final CloseAction closeAction = new CloseAction(this);
+    private final CloseAction closeAction = new CloseAction();
 
 
     class CloseAction extends AbstractAction {
 
-        final StringDialog parent;
-
-
-        public CloseAction(StringDialog parent) {
+        public CloseAction() {
             super("Close window");
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Close dialog"));
-            this.parent = parent;
         }
 
         @Override
@@ -357,7 +353,7 @@ class StringDialog extends JDialog {
 
     class NewStringAction extends AbstractAction {
 
-        final StringDialog parent;
+        private final StringDialog parent;
 
 
         public NewStringAction(StringDialog parent) {
@@ -407,12 +403,12 @@ class StringDialog extends JDialog {
     }
 
 
-    SaveDatabaseAction saveAction = new SaveDatabaseAction(this);
+    private final SaveDatabaseAction saveAction = new SaveDatabaseAction(this);
 
 
     static class SaveDatabaseAction extends AbstractAction {
 
-        final StringDialog parent;
+        private final StringDialog parent;
 
 
         public SaveDatabaseAction(StringDialog parent) {
@@ -429,7 +425,7 @@ class StringDialog extends JDialog {
 
     class RemoveStringAction extends AbstractAction {
 
-        final StringDialog parent;
+        private final StringDialog parent;
 
 
         public RemoveStringAction(StringDialog parent) {

--- a/src/main/java/net/sf/jabref/gui/UrlDragDrop.java
+++ b/src/main/java/net/sf/jabref/gui/UrlDragDrop.java
@@ -64,8 +64,7 @@ public class UrlDragDrop implements DropTargetListener {
     private final JabRefFrame frame;
 
 
-    public UrlDragDrop(EntryEditor _editor, JabRefFrame _frame,
-            FieldEditor _feditor) {
+    public UrlDragDrop(final EntryEditor _editor, final JabRefFrame _frame, final FieldEditor _feditor) {
         editor = _editor;
         feditor = _feditor;
         frame = _frame;
@@ -115,7 +114,7 @@ public class UrlDragDrop implements DropTargetListener {
         private final int id;
 
 
-        public JOptionChoice(String _label, int _id) {
+        public JOptionChoice(final String _label, final int _id) {
             label = _label;
             id = _id;
         }
@@ -171,9 +170,8 @@ public class UrlDragDrop implements DropTargetListener {
             case 1:
                 try {
                     //auto filename:
-                    File file = new File(new File(Globals.prefs
-                            .get("pdfDirectory")), editor.getEntry()
-.getCiteKey()
+                    File file = new File(new File(Globals.prefs.get("pdfDirectory")),
+                            editor.getEntry().getCiteKey()
                             + ".pdf");
                     frame.output(Localization.lang("Downloading..."));
                     MonitoredURLDownload.buildMonitoredDownload(editor, url).downloadToFile(file);

--- a/src/main/java/net/sf/jabref/gui/VerticalLabelUI.java
+++ b/src/main/java/net/sf/jabref/gui/VerticalLabelUI.java
@@ -48,10 +48,8 @@ public class VerticalLabelUI extends BasicLabelUI {
     private Rectangle verticalViewR = new Rectangle();
     private Rectangle verticalIconR = new Rectangle();
     private Rectangle verticalTextR = new Rectangle();
-    private static final VerticalLabelUI verticalLabelUI =
-            new VerticalLabelUI();
-    private static final VerticalLabelUI SAFE_VERTICAL_LABEL_UI =
-            new VerticalLabelUI();
+    private static final VerticalLabelUI VERTICAL_LABEL_UI = new VerticalLabelUI();
+    private static final VerticalLabelUI SAFE_VERTICAL_LABEL_UI = new VerticalLabelUI();
 
 
     /**
@@ -74,10 +72,10 @@ public class VerticalLabelUI extends BasicLabelUI {
      * @see ComponentUI#createUI(javax.swing.JComponent)
      */
     public static ComponentUI createUI(JComponent c) {
-        if (System.getSecurityManager() != null) {
-            return VerticalLabelUI.SAFE_VERTICAL_LABEL_UI;
+        if (System.getSecurityManager() == null) {
+            return VerticalLabelUI.VERTICAL_LABEL_UI;
         } else {
-            return VerticalLabelUI.verticalLabelUI;
+            return VerticalLabelUI.SAFE_VERTICAL_LABEL_UI;
         }
     }
 

--- a/src/main/java/net/sf/jabref/gui/WrapLayout.java
+++ b/src/main/java/net/sf/jabref/gui/WrapLayout.java
@@ -92,8 +92,9 @@ public class WrapLayout extends FlowLayout {
 
             int targetWidth = target.getSize().width;
 
-            if (targetWidth == 0)
+            if (targetWidth == 0) {
                 targetWidth = Integer.MAX_VALUE;
+            }
 
             int hgap = getHgap();
             int vgap = getVgap();
@@ -119,7 +120,7 @@ public class WrapLayout extends FlowLayout {
 
                     //  Can't add the component to current row. Start a new row.
 
-                    if (rowWidth + d.width > maxWidth)
+                    if ((rowWidth + d.width) > maxWidth)
                     {
                         addRow(dim, rowWidth, rowHeight);
                         rowWidth = 0;
@@ -141,7 +142,7 @@ public class WrapLayout extends FlowLayout {
             addRow(dim, rowWidth, rowHeight);
 
             dim.width += horizontalInsetsAndGap;
-            dim.height += insets.top + insets.bottom + vgap * 2;
+            dim.height += insets.top + insets.bottom + (vgap * 2);
 
             //	When using a scroll pane or the DecoratedLookAndFeel we need to
             //  make sure the preferred size is less than the size of the

--- a/src/main/java/net/sf/jabref/gui/actions/CopyAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/CopyAction.java
@@ -26,7 +26,7 @@ public class CopyAction extends AbstractAction {
             String data = field.getSelectedText();
             if (data != null) {
                 if (!data.isEmpty()) {
-                    ClipBoardManager.clipBoard.setClipboardContents(data);
+                    ClipBoardManager.CLIPBOARD.setClipboardContents(data);
                 }
             }
         }

--- a/src/main/java/net/sf/jabref/gui/actions/PasteAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/PasteAction.java
@@ -24,7 +24,7 @@ public class PasteAction extends AbstractAction {
 
     @Override
     public void actionPerformed(ActionEvent evt) {
-        String data = ClipBoardManager.clipBoard.getClipboardContents();
+        String data = ClipBoardManager.CLIPBOARD.getClipboardContents();
 
         if (data.isEmpty()) {
             return;

--- a/src/main/java/net/sf/jabref/wizard/text/gui/TextInputDialog.java
+++ b/src/main/java/net/sf/jabref/wizard/text/gui/TextInputDialog.java
@@ -534,7 +534,7 @@ public class TextInputDialog extends JDialog implements ActionListener {
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            String data = ClipBoardManager.clipBoard.getClipboardContents();
+            String data = ClipBoardManager.CLIPBOARD.getClipboardContents();
             if (data != null) {
                 int selStart = textPane.getSelectionStart();
                 int selEnd = textPane.getSelectionEnd();


### PR DESCRIPTION
Sometimes comparing objects with `==` and `!=` is better than `equals`...