### PR TITLE
Fixes and cleanup for OpenOffice

### DIFF
--- a/src/main/java/net/sf/jabref/openoffice/CitationManager.java
+++ b/src/main/java/net/sf/jabref/openoffice/CitationManager.java
@@ -29,6 +29,10 @@ import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.logic.l10n.Localization;
 
 import javax.swing.*;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseAdapter;
@@ -45,6 +49,8 @@ class CitationManager {
     private final EventList<CitEntry> list;
     private final JTable table;
     private final DefaultEventTableModel<CitEntry> tableModel;
+
+    private static final Log LOGGER = LogFactory.getLog(CitationManager.class);
 
 
     public CitationManager(final JabRefFrame frame, OOBibBase ooBase) throws Exception {
@@ -84,7 +90,7 @@ class CitationManager {
                 try {
                     storeSettings();
                 } catch (Exception ex) {
-                    ex.printStackTrace();
+                    LOGGER.warn("Problem modifying citation", ex);
                     JOptionPane.showMessageDialog(frame, Localization.lang("Problem modifying citation"));
                 }
                 diag.dispose();
@@ -132,12 +138,10 @@ class CitationManager {
         private final String keyString;
         final String context;
         private final String origPageInfo;
-        private final List<String> keys;
 
 
         public CitEntry(String refMarkName, List<String> keys, String context, String pageInfo) {
             this.refMarkName = refMarkName;
-            this.keys = keys;
             this.context = context;
             this.pageInfo = pageInfo;
             this.origPageInfo = pageInfo;

--- a/src/main/java/net/sf/jabref/openoffice/OOBibBase.java
+++ b/src/main/java/net/sf/jabref/openoffice/OOBibBase.java
@@ -943,7 +943,7 @@ class OOBibBase {
      * @return The list of bibtex keys encoded in the name.
      */
     public List<String> parseRefMarkName(String name) {
-        ArrayList<String> keys = new ArrayList<>();
+        List<String> keys = new ArrayList<>();
         Matcher m = citePattern.matcher(name);
         if (m.find()) {
             String[] keystring = m.group(2).split(",");
@@ -1030,14 +1030,12 @@ class OOBibBase {
         // If we don't have numbered entries, we need to sort the entries before adding them:
         if (!style.isSortByPosition()) {
             Map<BibEntry, BibDatabase> newMap = new TreeMap<>(entryComparator);
-            for (BibEntry entry : entries.keySet()) {
-                newMap.put(entry, entries.get(entry));
-            }
+            newMap.putAll(entries);
             entries = newMap;
         }
         int number = 1;
-        for (BibEntry entry : entries.keySet()) {
-            if (entry instanceof UndefinedBibtexEntry) {
+        for (Map.Entry<BibEntry, BibDatabase> entry : entries.entrySet()) {
+            if (entry.getKey() instanceof UndefinedBibtexEntry) {
                 continue;
             }
             OOUtil.insertParagraphBreak(text, cursor);
@@ -1047,14 +1045,14 @@ class OOBibBase {
                         style.getNumCitationMarker(new int[] {number++}, minGroupingCount, true),
                         false, false, false, false, false, false);
             }
-            Layout layout = style.getReferenceFormat(entry.getType().getName());
+            Layout layout = style.getReferenceFormat(entry.getKey().getType().getName());
             try {
                 layout.setPostFormatter(OOUtil.POSTFORMATTER);
             } catch (NoSuchMethodError ignore) {
                 // Ignored
             }
-            OOUtil.insertFullReferenceAtCurrentLocation(text, cursor, layout, parFormat, entry,
-                    entries.get(entry), uniquefiers.get(entry.getCiteKey()));
+            OOUtil.insertFullReferenceAtCurrentLocation(text, cursor, layout, parFormat, entry.getKey(),
+                    entry.getValue(), uniquefiers.get(entry.getKey().getCiteKey()));
         }
 
     }


### PR DESCRIPTION
Revert a minor error introduced in earlier fix.

Further cleanup, primarily getting rid of duplicated code and some Coverity warnings.