### PR TITLE
Add test for parsing accents

### DIFF
--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -1027,4 +1027,23 @@ public class BibtexParserTest {
         BibEntry e = c.iterator().next();
         Assert.assertEquals("ups  sala", e.getField("file"));
     }
+
+    /**
+     * Test for #650
+     */
+    @Test
+    public void parseHandlesAccentsCorrectly() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,author = {H\'{e}lne Fiaux}}"));
+        Assert.assertFalse(result.hasWarnings());
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals("H\'{e}lne Fiaux", e.getField("author"));
+    }
+
 }


### PR DESCRIPTION
I tried to replicate the problems of #650 but in the progress realized that the problem lied in the bib file provided there and not in the parser. 
So the added test is rather useless but I figured it does not hurt to have more tests :)