### PR TITLE
Make BibTex parser more robust against missing newlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 ### Changed
 
 ### Fixed
+- Make BibTex parser more robust against missing newlines
+- Fix bug that prevented the import of BibTex entries having only a key as content
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
@@ -62,7 +62,6 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
     // upgrade actions etc. that may depend on the JabRef version that wrote the file:
     private static final List<PostOpenAction> POST_OPEN_ACTIONS = new ArrayList<>();
 
-
     static {
         // Add the action for checking for new custom entry types loaded from
         // the bib file:
@@ -104,13 +103,11 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
         openFiles(filesToOpen, true);
     }
 
-
     class OpenItSwingHelper implements Runnable {
 
         private final BasePanel basePanel;
         private final boolean raisePanel;
         private final File file;
-
 
         OpenItSwingHelper(BasePanel basePanel, File file, boolean raisePanel) {
             this.basePanel = basePanel;
@@ -124,7 +121,6 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
 
         }
     }
-
 
     /**
      * Opens the given file. If null or 404, nothing happens
@@ -450,10 +446,11 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
                     // Except if there is already a @ symbol signalising the starting of a BibEntry
                     Integer atSymbolIndex = line.indexOf("@");
                     String encoding;
-                    if(atSymbolIndex > 0)
+                    if (atSymbolIndex > 0) {
                         encoding = line.substring(Globals.encPrefix.length(), atSymbolIndex);
-                    else
+                    } else {
                         encoding = line.substring(Globals.encPrefix.length());
+                    }
 
                     return Optional.of(Charset.forName(encoding));
                 } else {

--- a/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
@@ -447,7 +447,14 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
                     // Signature line, so keep reading and skip to next line
                 } else if (line.startsWith(Globals.encPrefix)) {
                     // Line starts with "Encoding: ", so the rest of the line should contain the name of the encoding
-                    String encoding = line.substring(Globals.encPrefix.length());
+                    // Except if there is already a @ symbol signalising the starting of a BibEntry
+                    Integer atSymbolIndex = line.indexOf("@");
+                    String encoding;
+                    if(atSymbolIndex > 0)
+                        encoding = line.substring(Globals.encPrefix.length(), atSymbolIndex);
+                    else
+                        encoding = line.substring(Globals.encPrefix.length());
+
                     return Optional.of(Charset.forName(encoding));
                 } else {
                     // Line not recognized so stop parsing

--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
@@ -795,7 +795,7 @@ public class BibtexParser {
                     // return what we
                     // have found, as the key and try to restore the rest in fixKey().
                     return token + fixKey();
-                } else if (character == ',') {
+                } else if (character == ',' || character == '}') {
                     unread(character);
                     return token.toString();
                 } else if (character == '=') {

--- a/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
+++ b/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
@@ -3,6 +3,7 @@ package net.sf.jabref.importer;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.database.BibDatabase;
+import net.sf.jabref.model.entry.BibEntry;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -11,6 +12,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 
 public class OpenDatabaseActionTest {
 
@@ -21,6 +23,8 @@ public class OpenDatabaseActionTest {
     private final File bibHeader = new File(OpenDatabaseActionTest.class.getResource("encoding-header.bib").getFile());
     private final File bibHeaderAndSignature = new File(
             OpenDatabaseActionTest.class.getResource("jabref-header.bib").getFile());
+    private final File bibEncodingWithoutNewline = new File(
+            OpenDatabaseActionTest.class.getResource("encodingWithoutNewline.bib").getFile());
 
     @BeforeClass
     public static void setUpGlobalsPrefs() {
@@ -82,4 +86,21 @@ public class OpenDatabaseActionTest {
         Assert.assertEquals("2014", db.getEntryByKey("1").getField("year"));
     }
 
+    /**
+     * Test for #669
+     */
+    @Test
+    public void correctlyParseEncodingWithoutNewline() throws IOException {
+        ParserResult result = OpenDatabaseAction.loadDatabase(bibEncodingWithoutNewline, defaultEncoding);
+        Assert.assertEquals(StandardCharsets.US_ASCII, result.getEncoding());
+
+        BibDatabase db = result.getDatabase();
+        Assert.assertEquals("testPreamble", db.getPreamble());
+
+        Collection<BibEntry> entries = db.getEntries();
+        Assert.assertEquals(1, entries.size());
+
+        BibEntry entry = entries.iterator().next();
+        Assert.assertEquals("testArticle", entry.getCiteKey());
+    }
 }

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -119,6 +119,20 @@ public class BibtexParserTest {
     }
 
     @Test
+    public void parseRecognizesEntryOnlyWithKey() throws IOException {
+
+        ParserResult result = BibtexParser.parse(new StringReader(
+                "@article{test}"));
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+    }
+
+    @Test
     public void parseRecognizesEntryWithWhitespaceAtBegining() throws IOException {
 
         ParserResult result = BibtexParser.parse(new StringReader(" @article{test,author={Ed von Test}}"));
@@ -344,23 +358,23 @@ public class BibtexParserTest {
     @Test
     public void parseRecognizesHeaderButIgnoresEncoding() throws IOException {
         ParserResult result = BibtexParser.parse(new StringReader(
-                    "This file was created with JabRef 2.1 beta 2."
-                            + "\n"
-                            + "Encoding: Cp1252"
-                            + "\n"
-                            + ""
-                            + "\n"
-                            + "@INPROCEEDINGS{CroAnnHow05,"
-                            + "\n"
-                            + "  author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.},"
-                            + "\n"
-                            + "  title = {Effective work practices for floss development: A model and propositions},"
-                            + "\n"
-                            + "  booktitle = {Hawaii International Conference On System Sciences (HICSS)},"
-                            + "\n" + "  year = {2005}," + "\n" + "  owner = {oezbek}," + "\n"
-                            + "  timestamp = {2006.05.29}," + "\n"
-                            + "  url = {http://james.howison.name/publications.html}" + "\n" + "}))"
-                ));
+                "This file was created with JabRef 2.1 beta 2."
+                        + "\n"
+                        + "Encoding: Cp1252"
+                        + "\n"
+                        + ""
+                        + "\n"
+                        + "@INPROCEEDINGS{CroAnnHow05,"
+                        + "\n"
+                        + "  author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.},"
+                        + "\n"
+                        + "  title = {Effective work practices for floss development: A model and propositions},"
+                        + "\n"
+                        + "  booktitle = {Hawaii International Conference On System Sciences (HICSS)},"
+                        + "\n" + "  year = {2005}," + "\n" + "  owner = {oezbek}," + "\n"
+                        + "  timestamp = {2006.05.29}," + "\n"
+                        + "  url = {http://james.howison.name/publications.html}" + "\n" + "}))"
+        ));
         Assert.assertNull(result.getEncoding());
 
         Collection<BibEntry> c = result.getDatabase().getEntries();
@@ -383,17 +397,17 @@ public class BibtexParserTest {
     @Test
     public void parseRecognizesFormatedEntry() throws IOException {
         ParserResult result = BibtexParser.parse(new StringReader(
-                    "@INPROCEEDINGS{CroAnnHow05,"
-                            + "\n"
-                            + "  author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.},"
-                            + "\n"
-                            + "  title = {Effective work practices for floss development: A model and propositions},"
-                            + "\n"
-                            + "  booktitle = {Hawaii International Conference On System Sciences (HICSS)},"
-                            + "\n" + "  year = {2005}," + "\n" + "  owner = {oezbek}," + "\n"
-                            + "  timestamp = {2006.05.29}," + "\n"
-                            + "  url = {http://james.howison.name/publications.html}" + "\n" + "}))"
-                ));
+                "@INPROCEEDINGS{CroAnnHow05,"
+                        + "\n"
+                        + "  author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.},"
+                        + "\n"
+                        + "  title = {Effective work practices for floss development: A model and propositions},"
+                        + "\n"
+                        + "  booktitle = {Hawaii International Conference On System Sciences (HICSS)},"
+                        + "\n" + "  year = {2005}," + "\n" + "  owner = {oezbek}," + "\n"
+                        + "  timestamp = {2006.05.29}," + "\n"
+                        + "  url = {http://james.howison.name/publications.html}" + "\n" + "}))"
+        ));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         Assert.assertEquals(1, c.size());
 
@@ -409,7 +423,7 @@ public class BibtexParserTest {
         Assert.assertEquals("oezbek", e.getField("owner"));
         Assert.assertEquals("2006.05.29", e.getField("timestamp"));
         Assert.assertEquals("http://james.howison.name/publications.html", e.getField("url"));
-     }
+    }
 
     @Test
     public void parseRecognizesFieldValuesInQuotationMarks() throws IOException {
@@ -496,15 +510,15 @@ public class BibtexParserTest {
     @Test
     public void parseReturnsEmptyListIfNoEntryRecognized() throws IOException {
         ParserResult result = BibtexParser.parse(new StringReader(
-                    "  author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.},"
-                            + "\n"
-                            + "  title = {Effective work practices for floss development: A model and propositions},"
-                            + "\n"
-                            + "  booktitle = {Hawaii International Conference On System Sciences (HICSS)},"
-                            + "\n" + "  year = {2005}," + "\n" + "  owner = {oezbek}," + "\n"
-                            + "  timestamp = {2006.05.29}," + "\n"
-                            + "  url = {http://james.howison.name/publications.html}" + "\n" + "}))"
-                ));
+                "  author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.},"
+                        + "\n"
+                        + "  title = {Effective work practices for floss development: A model and propositions},"
+                        + "\n"
+                        + "  booktitle = {Hawaii International Conference On System Sciences (HICSS)},"
+                        + "\n" + "  year = {2005}," + "\n" + "  owner = {oezbek}," + "\n"
+                        + "  timestamp = {2006.05.29}," + "\n"
+                        + "  url = {http://james.howison.name/publications.html}" + "\n" + "}))"
+        ));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         Assert.assertEquals(0, c.size());
     }
@@ -1046,4 +1060,37 @@ public class BibtexParserTest {
         Assert.assertEquals("H\'{e}lne Fiaux", e.getField("author"));
     }
 
+    /**
+     * Test for #669
+     */
+    @Test
+    public void parsePreambleAndEntryWithoutNewLine() throws IOException {
+
+        ParserResult result = BibtexParser.parse(
+                new StringReader("@preamble{some text and \\latex}@article{test,author = {H\'{e}lne Fiaux}}"));
+        Assert.assertFalse(result.hasWarnings());
+
+        Assert.assertEquals("some text and \\latex", result.getDatabase().getPreamble());
+
+        Collection<BibEntry> c = result.getDatabase().getEntries();
+        Assert.assertEquals(1, c.size());
+
+        BibEntry e = c.iterator().next();
+        Assert.assertEquals(BibtexEntryTypes.ARTICLE, e.getType());
+        Assert.assertEquals("test", e.getCiteKey());
+        Assert.assertEquals("H\'{e}lne Fiaux", e.getField("author"));
+    }
+
+    /**
+     * Test for #669
+     */
+    @Test
+    public void parseFileHeaderAndPreambleWithoutNewLine() throws IOException {
+
+        ParserResult result = BibtexParser.parse(
+                new StringReader("% Encoding: US-ASCII@preamble{some text and \\latex}"));
+        Assert.assertFalse(result.hasWarnings());
+
+        Assert.assertEquals("some text and \\latex", result.getDatabase().getPreamble());
+    }
 }

--- a/src/test/resources/net/sf/jabref/importer/encodingWithoutNewline.bib
+++ b/src/test/resources/net/sf/jabref/importer/encodingWithoutNewline.bib
@@ -1,0 +1,1 @@
+% Encoding: US-ASCII@PREAMBLE{testPreamble}@article{testArticle}


### PR DESCRIPTION
As described in #669 and #621 the parser has some problems when an entry (or preamble) follows directly the file encoding header (on the same line), i.e. 
`% Encoding: myEncoding @article{...}`.
Actually, as the tests reveal it was not a problem with the actual parser but within the file opening logic. 
I don't view this PR as a complete fix for #669 and #621 since not just the parser but also the serialization should be improved.

Also fix a bug that prevented the import of BibTex entries having only a key as its content.