### PR TITLE
Simplify matching complexity of unlinked file finder

### DIFF
--- a/src/main/java/net/sf/jabref/gui/FileListTableModel.java
+++ b/src/main/java/net/sf/jabref/gui/FileListTableModel.java
@@ -184,7 +184,7 @@ public class FileListTableModel extends AbstractTableModel {
         return files;
     }
 
-    public FileListEntry setContent(String value, boolean firstOnly, boolean deduceUnknownTypes) {
+    private FileListEntry setContent(String value, boolean firstOnly, boolean deduceUnknownTypes) {
         if (value == null) {
             value = "";
         }

--- a/src/main/java/net/sf/jabref/importer/DatabaseFileLookup.java
+++ b/src/main/java/net/sf/jabref/importer/DatabaseFileLookup.java
@@ -54,7 +54,6 @@ class DatabaseFileLookup {
         for (BibEntry entry : database.getEntries()) {
             fileCache.addAll(parseFileField(entry));
         }
-
     }
 
     /**
@@ -88,9 +87,8 @@ class DatabaseFileLookup {
         model.setContent(fileField);
 
         List<File> fileLinks = new ArrayList<>();
-        for (int i = 0; i < model.getRowCount(); i++) {
-            FileListEntry flEntry = model.getEntry(i);
-            String link = flEntry.getLink();
+        for (FileListEntry e : model.parseFileField(fileField)) {
+            String link = e.getLink();
 
             if (link == null) {
                 break;

--- a/src/main/java/net/sf/jabref/importer/DatabaseFileLookup.java
+++ b/src/main/java/net/sf/jabref/importer/DatabaseFileLookup.java
@@ -40,10 +40,7 @@ class DatabaseFileLookup {
 
     private final Set<File> fileCache = new HashSet<>();
 
-    private final Collection<BibEntry> entries;
-
     private final String[] possibleFilePaths;
-
 
     /**
      * Creates an instance by passing a {@link BibDatabase} which will be used for the searches.
@@ -52,9 +49,12 @@ class DatabaseFileLookup {
      */
     public DatabaseFileLookup(BibDatabase database) {
         Objects.requireNonNull(database);
+        possibleFilePaths = Optional.ofNullable(JabRef.jrf.getCurrentBasePanel().metaData().getFileDirectory(Globals.FILE_FIELD)).orElse(new String[]{});
 
-        entries = database.getEntries();
-        possibleFilePaths = JabRef.jrf.getCurrentBasePanel().metaData().getFileDirectory(Globals.FILE_FIELD);
+        for (BibEntry entry : database.getEntries()) {
+            fileCache.addAll(parseFileField(entry));
+        }
+
     }
 
     /**
@@ -72,18 +72,10 @@ class DatabaseFileLookup {
      *         entry in the database, otherwise <code>false</code>.
      */
     public boolean lookupDatabase(File file) {
-        populateCache();
-
         if (fileCache.contains(file)) {
             return true;
         } else {
             return false;
-        }
-    }
-
-    private void populateCache() {
-        for (BibEntry entry : entries) {
-            fileCache.addAll(parseFileField(entry));
         }
     }
 

--- a/src/main/java/net/sf/jabref/importer/DatabaseFileLookup.java
+++ b/src/main/java/net/sf/jabref/importer/DatabaseFileLookup.java
@@ -25,6 +25,7 @@ import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.JabRef;
 import net.sf.jabref.gui.FileListEntry;
 import net.sf.jabref.gui.FileListTableModel;
+import net.sf.jabref.model.entry.FileField;
 
 /**
  * Search class for files. <br>
@@ -71,25 +72,21 @@ class DatabaseFileLookup {
      *         entry in the database, otherwise <code>false</code>.
      */
     public boolean lookupDatabase(File file) {
-        if (fileCache.contains(file)) {
-            return true;
-        } else {
-            return false;
-        }
+        return fileCache.contains(file);
     }
 
     private List<File> parseFileField(BibEntry entry) {
         Objects.requireNonNull(entry);
 
         String fileField = entry.getField(DatabaseFileLookup.KEY_FILE_FIELD);
-        List<FileListEntry> entries = new FileListTableModel().parseFileField(fileField);
+        List<FileField.ParsedFileField> entries = FileField.parse(fileField);
 
         List<File> fileLinks = new ArrayList<>();
-        for (FileListEntry e : entries) {
-            String link = e.getLink();
+        for (FileField.ParsedFileField field : entries) {
+            String link = field.link;
 
             // Do not query external file links (huge performance leak)
-            if(link == null || link.contains("//")) {
+            if(link.contains("//")) {
                 continue;
             }
 

--- a/src/main/java/net/sf/jabref/importer/DatabaseFileLookup.java
+++ b/src/main/java/net/sf/jabref/importer/DatabaseFileLookup.java
@@ -81,17 +81,16 @@ class DatabaseFileLookup {
     private List<File> parseFileField(BibEntry entry) {
         Objects.requireNonNull(entry);
 
-        FileListTableModel model = new FileListTableModel();
-
         String fileField = entry.getField(DatabaseFileLookup.KEY_FILE_FIELD);
-        model.setContent(fileField);
+        List<FileListEntry> entries = new FileListTableModel().parseFileField(fileField);
 
         List<File> fileLinks = new ArrayList<>();
-        for (FileListEntry e : model.parseFileField(fileField)) {
+        for (FileListEntry e : entries) {
             String link = e.getLink();
 
-            if (link == null) {
-                break;
+            // Do not query external file links (huge performance leak)
+            if(link == null || link.contains("//")) {
+                continue;
             }
 
             File expandedFilename = FileUtil.expandFilename(link, possibleFilePaths);

--- a/src/main/java/net/sf/jabref/importer/UnlinkedFilesCrawler.java
+++ b/src/main/java/net/sf/jabref/importer/UnlinkedFilesCrawler.java
@@ -12,15 +12,9 @@ import net.sf.jabref.gui.FindUnlinkedFilesDialog.CheckableTreeNode;
 import net.sf.jabref.gui.FindUnlinkedFilesDialog.FileNodeWrapper;
 
 /**
- * Util class for searching files on the file system which are not linked to a
- * provided {@link BibDatabase}.
- *
- * @author Nosh&Dan
- * @version 09.11.2008 | 19:55:20
- *
+ * Util class for searching files on the file system which are not linked to a provided {@link BibDatabase}.
  */
 public class UnlinkedFilesCrawler {
-
     /**
      * File filter, that accepts directories only.
      */
@@ -32,8 +26,8 @@ public class UnlinkedFilesCrawler {
         this.database = database;
     }
 
-    public CheckableTreeNode searchDirectory(File directory, FileFilter aFileFilter) {
-        UnlinkedPDFFileFilter ff = new UnlinkedPDFFileFilter(aFileFilter, database);
+    public CheckableTreeNode searchDirectory(File directory, FileFilter filter) {
+        UnlinkedPDFFileFilter ff = new UnlinkedPDFFileFilter(filter, database);
         return searchDirectory(directory, ff, new AtomicBoolean(true), null);
     }
 
@@ -59,7 +53,7 @@ public class UnlinkedFilesCrawler {
         if ((state == null) || !state.get()) {
             return null;
         }
-        /* Return null if the directory is not valid. */
+        // Return null if the directory is not valid.
         if ((directory == null) || !directory.exists() || !directory.isDirectory()) {
             return null;
         }

--- a/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
@@ -83,23 +83,23 @@ public class FileUtil {
         List<String> pathSubstrings = Arrays.asList(arr);
 
         // compute shortest folder substrings
-        while(!stackList.stream().allMatch(Vector::isEmpty)) {
-            for(int i = 0; i < stackList.size(); i++) {
+        while (!stackList.stream().allMatch(Vector::isEmpty)) {
+            for (int i = 0; i < stackList.size(); i++) {
                 String tempString = pathSubstrings.get(i);
 
-                if(tempString.isEmpty() && !stackList.get(i).isEmpty()) {
+                if (tempString.isEmpty() && !stackList.get(i).isEmpty()) {
                     pathSubstrings.set(i, stackList.get(i).pop());
                 } else {
-                    if(!stackList.get(i).isEmpty()) {
+                    if (!stackList.get(i).isEmpty()) {
                         pathSubstrings.set(i, stackList.get(i).pop() + File.separator + tempString);
                     }
                 }
             }
 
-            for(int i = 0; i < stackList.size(); i++) {
+            for (int i = 0; i < stackList.size(); i++) {
                 String tempString = pathSubstrings.get(i);
 
-                if(Collections.frequency(pathSubstrings, tempString) == 1) {
+                if (Collections.frequency(pathSubstrings, tempString) == 1) {
                     stackList.get(i).clear();
                 }
             }
@@ -232,28 +232,29 @@ public class FileUtil {
         }
 
         File file = new File(name);
-
-        if (!file.exists() && (dir != null)) {
-            if (dir.endsWith(FILE_SEPARATOR)) {
-                name = dir + name;
-            } else {
-                name = dir + FILE_SEPARATOR + name;
-            }
-
-            // fix / and \ problems:
-            if (OS.WINDOWS) {
-                name = SLASH.matcher(name).replaceAll("\\\\");
-            } else {
-                name = BACKSLASH.matcher(name).replaceAll("/");
-            }
-
-            file = new File(name);
-
-            if (!file.exists()) {
-                file = null;
-            }
+        if (file.exists() || dir == null) {
+            return file;
         }
-        return file;
+
+        if (dir.endsWith(FILE_SEPARATOR)) {
+            name = dir + name;
+        } else {
+            name = dir + FILE_SEPARATOR + name;
+        }
+
+        // fix / and \ problems:
+        if (OS.WINDOWS) {
+            name = SLASH.matcher(name).replaceAll("\\\\");
+        } else {
+            name = BACKSLASH.matcher(name).replaceAll("/");
+        }
+
+        File fileInDir = new File(name);
+        if (fileInDir.exists()) {
+            return fileInDir;
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/net/sf/jabref/model/entry/FileField.java
+++ b/src/main/java/net/sf/jabref/model/entry/FileField.java
@@ -1,0 +1,118 @@
+package net.sf.jabref.model.entry;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class FileField {
+    private static final FileField.ParsedFileField NULL_OBJECT = new FileField.ParsedFileField("", "", "");
+
+    public static class ParsedFileField {
+        public final String description;
+        public final String link;
+        public final String fileType;
+
+        public ParsedFileField(String description, String link, String fileType) {
+            this.description = Objects.requireNonNull(description);
+            this.link = Objects.requireNonNull(link);
+            this.fileType = Objects.requireNonNull(fileType);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || this.getClass() != o.getClass()) return false;
+
+            FileField.ParsedFileField that = (FileField.ParsedFileField) o;
+
+            if (this.description != null ? !this.description.equals(that.description) : that.description != null) return false;
+            if (this.link != null ? !this.link.equals(that.link) : that.link != null) return false;
+            return this.fileType != null ? this.fileType.equals(that.fileType) : that.fileType == null;
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = this.description != null ? this.description.hashCode() : 0;
+            result = 31 * result + (this.link != null ? this.link.hashCode() : 0);
+            result = 31 * result + (this.fileType != null ? this.fileType.hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "ParsedFileField{" +
+                    "description='" + description + '\'' +
+                    ", link='" + link + '\'' +
+                    ", fileType='" + fileType + '\'' +
+                    '}';
+        }
+
+        public boolean isEmpty() {
+            return NULL_OBJECT.equals(this);
+        }
+    }
+
+    public static List<FileField.ParsedFileField> parse(String value) {
+        if(value == null || value.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<FileField.ParsedFileField> files = new ArrayList<>();
+        List<String> entry = new ArrayList<>();
+        StringBuilder sb = new StringBuilder();
+        boolean inXmlChar = false;
+        boolean escaped = false;
+
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (!escaped && (c == '\\')) {
+                escaped = true;
+                continue;
+            }
+            // Check if we are entering an XML special character construct such
+            // as "&#44;", because we need to know in order to ignore the semicolon.
+            else if (!escaped && (c == '&') && !inXmlChar) {
+                sb.append(c);
+                if ((value.length() > (i + 1)) && (value.charAt(i + 1) == '#')) {
+                    inXmlChar = true;
+                }
+            } else if (!escaped && inXmlChar && (c == ';')) {
+                // Check if we are exiting an XML special character construct:
+                sb.append(c);
+                inXmlChar = false;
+            } else if (!escaped && (c == ':')) {
+                entry.add(sb.toString());
+                sb = new StringBuilder();
+            } else if (!escaped && (c == ';') && !inXmlChar) {
+                entry.add(sb.toString());
+                sb = new StringBuilder();
+
+                files.add(convert(entry));
+            } else {
+                sb.append(c);
+            }
+            escaped = false;
+        }
+        if (sb.length() > 0) {
+            entry.add(sb.toString());
+        }
+
+        if (!entry.isEmpty()) {
+            files.add(convert(entry));
+        }
+
+        return files;
+    }
+
+    private static FileField.ParsedFileField convert(List<String> entry) {
+        // ensure list has at least 3 fields
+        while(entry.size() < 3) {
+            entry.add("");
+        }
+        FileField.ParsedFileField field = new FileField.ParsedFileField(entry.get(0), entry.get(1), entry.get(2));
+        entry.clear();
+        return field;
+    }
+}

--- a/src/test/java/net/sf/jabref/model/entry/FileFieldTest.java
+++ b/src/test/java/net/sf/jabref/model/entry/FileFieldTest.java
@@ -1,0 +1,68 @@
+package net.sf.jabref.model.entry;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+
+public class FileFieldTest {
+
+    @Test
+    public void emptyListForEmptyInput() throws Exception {
+        String emptyInput = "";
+        String nullInput = null;
+
+        assertEquals(Collections.emptyList(), FileField.parse(emptyInput));
+        assertEquals(Collections.emptyList(), FileField.parse(nullInput));
+    }
+
+    @Test
+    public void parseCorrectInput() throws Exception {
+        String input = "Desc:File.PDF:PDF";
+
+        assertEquals(Collections.singletonList(new FileField.ParsedFileField("Desc", "File.PDF", "PDF")), FileField.parse(input));
+    }
+
+    @Test
+    public void ingoreMissingDescription() throws Exception {
+        String input = ":wei2005ahp.pdf:PDF";
+
+        assertEquals(Collections.singletonList(new FileField.ParsedFileField("", "wei2005ahp.pdf", "PDF")), FileField.parse(input));
+    }
+
+    @Test
+    public void escapedCharactersInDescription() throws Exception {
+        String input = "test\\:\\;:wei2005ahp.pdf:PDF";
+
+        assertEquals(Collections.singletonList(new FileField.ParsedFileField("test:;", "wei2005ahp.pdf", "PDF")), FileField.parse(input));
+    }
+
+    @Test
+    public void handleXmlCharacters() throws Exception {
+        String input = "test&#44\\;st\\:\\;:wei2005ahp.pdf:PDF";
+
+        assertEquals(Collections.singletonList(new FileField.ParsedFileField("test&#44;st:;", "wei2005ahp.pdf", "PDF")), FileField.parse(input));
+    }
+
+    @Test
+    public void handleEscapedFilePath() throws Exception {
+        String input = "desc:C\\:\\\\test.pdf:PDF";
+
+        assertEquals(Collections.singletonList(new FileField.ParsedFileField("desc", "C:\\test.pdf", "PDF")), FileField.parse(input));
+    }
+
+    @Test
+    public void tooLessSeparators() throws Exception {
+        String input = "desc:";
+
+        assertEquals(Collections.singletonList(new FileField.ParsedFileField("desc", "", "")), FileField.parse(input));
+    }
+
+    @Test
+    public void tooManySeparators() throws Exception {
+        String input = "desc:file.pdf:PDF:asdf";
+
+        assertEquals(Collections.singletonList(new FileField.ParsedFileField("desc", "file.pdf", "PDF")), FileField.parse(input));
+    }
+}


### PR DESCRIPTION
Reenables functionality #410 

Important point:
- Removed one file.exists check in FileUtil.java expandPath
I think one check after replacing / and \ is enough, without checking the expanded path with directory in front.
- Cache is filled at initial creation for bibdatabase, therefore no checks against the whole database are done for each file entry
- Parse logic for file field should moved from the FileListTableModel to FileField.java.

We could still improve quite a lot here but maybe its GOOD ENOUGH :tm: for now.