### PR TITLE
Replaced String.replaceAll with String.replace when no regexp is used

### DIFF
--- a/src/main/java/net/sf/jabref/exporter/LatexFieldFormatter.java
+++ b/src/main/java/net/sf/jabref/exporter/LatexFieldFormatter.java
@@ -94,7 +94,7 @@ public class LatexFieldFormatter {
         if (shouldNormalizeNewlines) {
             // if we don't have real new lines, but pseudo newlines, we replace them
             // On Win 8.1, this is always true for multiline fields
-            content = content.replaceAll("\n", Globals.NEWLINE);
+            content = content.replace("\n", Globals.NEWLINE);
         }
 
         // If the field is non-standard, we will just append braces,

--- a/src/main/java/net/sf/jabref/exporter/layout/format/Authors.java
+++ b/src/main/java/net/sf/jabref/exporter/layout/format/Authors.java
@@ -299,10 +299,10 @@ public class Authors extends AbstractParamLayoutFormatter {
                 }
             }
             if (!abbrDots) {
-                firstNamePart = firstNamePart.replaceAll("\\.", "");
+                firstNamePart = firstNamePart.replace(".", "");
             }
             if (!abbrSpaces) {
-                firstNamePart = firstNamePart.replaceAll(" ", "");
+                firstNamePart = firstNamePart.replace(" ", "");
             }
         }
 

--- a/src/main/java/net/sf/jabref/exporter/layout/format/FormatPagesForHTML.java
+++ b/src/main/java/net/sf/jabref/exporter/layout/format/FormatPagesForHTML.java
@@ -21,6 +21,6 @@ public class FormatPagesForHTML implements LayoutFormatter {
 
     @Override
     public String format(String field) {
-        return field.replaceAll("--", "-");
+        return field.replace("--", "-");
     }
 }

--- a/src/main/java/net/sf/jabref/exporter/layout/format/FormatPagesForXML.java
+++ b/src/main/java/net/sf/jabref/exporter/layout/format/FormatPagesForXML.java
@@ -21,6 +21,6 @@ public class FormatPagesForXML implements LayoutFormatter {
 
     @Override
     public String format(String field) {
-        return field.replaceAll("--", "&#x2013;");
+        return field.replace("--", "&#x2013;");
     }
 }

--- a/src/main/java/net/sf/jabref/exporter/layout/format/HTMLChars.java
+++ b/src/main/java/net/sf/jabref/exporter/layout/format/HTMLChars.java
@@ -29,8 +29,7 @@ public class HTMLChars implements LayoutFormatter {
     @Override
     public String format(String field) {
         int i;
-        field = field.replaceAll("&|\\\\&", "&amp;").replaceAll("[\\n]{2,}", "<p>")
-                .replaceAll("\\n", "<br>");
+        field = field.replaceAll("&|\\\\&", "&amp;").replaceAll("[\\n]{2,}", "<p>").replace("\n", "<br>");
 
         StringBuilder sb = new StringBuilder();
         StringBuffer currentCommand = null;

--- a/src/main/java/net/sf/jabref/exporter/layout/format/RTFChars.java
+++ b/src/main/java/net/sf/jabref/exporter/layout/format/RTFChars.java
@@ -176,7 +176,8 @@ public class RTFChars implements LayoutFormatter {
             }
         }
 
-        return sb.toString().replaceAll("---", "{\\\\emdash}").replaceAll("--", "{\\\\endash}").replaceAll("``", "{\\\\ldblquote}").replaceAll("''", "{\\\\rdblquote}");
+        return sb.toString().replace("---", "{\\emdash}").replace("--", "{\\endash}").replace("``", "{\\ldblquote}")
+                .replace("''", "{\\rdblquote}");
     }
 
     /**

--- a/src/main/java/net/sf/jabref/exporter/layout/format/XMLChars.java
+++ b/src/main/java/net/sf/jabref/exporter/layout/format/XMLChars.java
@@ -83,7 +83,7 @@ public class XMLChars implements LayoutFormatter {
 
     private String restFormat(String toFormat) {
 
-        String fieldText = toFormat.replaceAll("\\}", "").replaceAll("\\{", "");
+        String fieldText = toFormat.replace("}", "").replace("{", "");
 
         // now some copy-paste problems most often occuring in abstracts when
         // copied from PDF

--- a/src/main/java/net/sf/jabref/external/DownloadExternalFile.java
+++ b/src/main/java/net/sf/jabref/external/DownloadExternalFile.java
@@ -284,7 +284,7 @@ public class DownloadExternalFile {
         if (OS.WINDOWS) {
             plannedName = plannedName.replaceAll("\\?|\\*|\\<|\\>|\\||\\\"|\\:|\\.$|\\[|\\]", "");
         } else if (OS.OS_X) {
-            plannedName = plannedName.replaceAll(":", "");
+            plannedName = plannedName.replace(":", "");
         }
 
         return plannedName;

--- a/src/main/java/net/sf/jabref/external/ExternalFilePanel.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFilePanel.java
@@ -25,8 +25,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 
 import javax.swing.JButton;
@@ -317,7 +315,7 @@ public class ExternalFilePanel extends JPanel {
                     plannedName = plannedName.replaceAll(
                             "\\?|\\*|\\<|\\>|\\||\\\"|\\:|\\.$|\\[|\\]", "");
                 } else if (OS.OS_X) {
-                    plannedName = plannedName.replaceAll(":", "");
+                    plannedName = plannedName.replace(":", "");
                 }
 
                 return plannedName;

--- a/src/main/java/net/sf/jabref/external/push/PushToWinEdt.java
+++ b/src/main/java/net/sf/jabref/external/push/PushToWinEdt.java
@@ -34,7 +34,8 @@ public class PushToWinEdt extends AbstractPushToApplication implements PushToApp
 
     @Override
     protected String[] getCommandLine(String keyString) {
-        return new String[] {commandPath, "\"[InsText('" + getCiteCommand() + "{" + keyString.replaceAll("'", "''") + "}');]\""};
+        return new String[] {commandPath,
+                "\"[InsText('" + getCiteCommand() + "{" + keyString.replace("'", "''") + "}');]\""};
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/groups/GroupDialog.java
+++ b/src/main/java/net/sf/jabref/groups/GroupDialog.java
@@ -525,8 +525,7 @@ class GroupDialog extends JDialog {
         int lastNewline = s.lastIndexOf("<br>");
         int hat = s.lastIndexOf('^');
         if ((lastNewline >= 0) && (hat >= 0) && (hat > lastNewline)) {
-            return s.substring(0, lastNewline + 4)
-                    + s.substring(lastNewline + 4).replaceAll(" ", "&nbsp;");
+            return s.substring(0, lastNewline + 4) + s.substring(lastNewline + 4).replace(" ", "&nbsp;");
         }
         return s;
     }

--- a/src/main/java/net/sf/jabref/gui/PreviewPanel.java
+++ b/src/main/java/net/sf/jabref/gui/PreviewPanel.java
@@ -309,7 +309,7 @@ public class PreviewPanel extends JPanel implements VetoableChangeListener, Sear
     }
 
     private void updateLayout() {
-        StringReader sr = new StringReader(layoutFile.replaceAll("__NEWLINE__", "\n"));
+        StringReader sr = new StringReader(layoutFile.replace("__NEWLINE__", "\n"));
         try {
             layout = Optional.of(new LayoutHelper(sr).getLayoutFromText(Globals.FORMATTER_PACKAGE));
         } catch (IOException e) {

--- a/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingsListener.java
+++ b/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingsListener.java
@@ -54,7 +54,7 @@ public class KeyBindingsListener extends KeyAdapter {
         if ("".equals(modifier)) {
             newKey = code;
         } else {
-            newKey = modifier.toLowerCase().replaceAll("\\+", " ") + " " + code;
+            newKey = modifier.toLowerCase().replace("+", " ") + " " + code;
         }
 
         // SHOW new key binding

--- a/src/main/java/net/sf/jabref/gui/preftabs/PreviewPrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/PreviewPrefsTab.java
@@ -155,10 +155,10 @@ class PreviewPrefsTab extends JPanel implements PrefsTab {
 
             @Override
             public void actionPerformed(ActionEvent e) {
-                String tmp = layout1.getText().replaceAll("\n", "__NEWLINE__");
+                String tmp = layout1.getText().replace("\n", "__NEWLINE__");
                 PreviewPrefsTab.this.prefs.remove(JabRefPreferences.PREVIEW_0);
                 layout1.setText(
-                        PreviewPrefsTab.this.prefs.get(JabRefPreferences.PREVIEW_0).replaceAll("__NEWLINE__", "\n"));
+                        PreviewPrefsTab.this.prefs.get(JabRefPreferences.PREVIEW_0).replace("__NEWLINE__", "\n"));
                 PreviewPrefsTab.this.prefs.put(JabRefPreferences.PREVIEW_0, tmp);
             }
         });
@@ -166,10 +166,10 @@ class PreviewPrefsTab extends JPanel implements PrefsTab {
 
             @Override
             public void actionPerformed(ActionEvent e) {
-                String tmp = layout2.getText().replaceAll("\n", "__NEWLINE__");
+                String tmp = layout2.getText().replace("\n", "__NEWLINE__");
                 PreviewPrefsTab.this.prefs.remove(JabRefPreferences.PREVIEW_1);
                 layout2.setText(
-                        PreviewPrefsTab.this.prefs.get(JabRefPreferences.PREVIEW_1).replaceAll("__NEWLINE__", "\n"));
+                        PreviewPrefsTab.this.prefs.get(JabRefPreferences.PREVIEW_1).replace("__NEWLINE__", "\n"));
                 PreviewPrefsTab.this.prefs.put(JabRefPreferences.PREVIEW_1, tmp);
             }
         });
@@ -262,15 +262,15 @@ class PreviewPrefsTab extends JPanel implements PrefsTab {
 
     @Override
     public void setValues() {
-        layout1.setText(prefs.get(JabRefPreferences.PREVIEW_0).replaceAll("__NEWLINE__", "\n"));
-        layout2.setText(prefs.get(JabRefPreferences.PREVIEW_1).replaceAll("__NEWLINE__", "\n"));
+        layout1.setText(prefs.get(JabRefPreferences.PREVIEW_0).replace("__NEWLINE__", "\n"));
+        layout2.setText(prefs.get(JabRefPreferences.PREVIEW_1).replace("__NEWLINE__", "\n"));
         pdfPreview.setSelected(prefs.getBoolean(JabRefPreferences.PDF_PREVIEW));
     }
 
     @Override
     public void storeSettings() {
-        prefs.put(JabRefPreferences.PREVIEW_0, layout1.getText().replaceAll("\n", "__NEWLINE__"));
-        prefs.put(JabRefPreferences.PREVIEW_1, layout2.getText().replaceAll("\n", "__NEWLINE__"));
+        prefs.put(JabRefPreferences.PREVIEW_0, layout1.getText().replace("\n", "__NEWLINE__"));
+        prefs.put(JabRefPreferences.PREVIEW_1, layout2.getText().replace("\n", "__NEWLINE__"));
         prefs.putBoolean(JabRefPreferences.PDF_PREVIEW, pdfPreview.isSelected());
     }
 

--- a/src/main/java/net/sf/jabref/importer/OAI2Handler.java
+++ b/src/main/java/net/sf/jabref/importer/OAI2Handler.java
@@ -87,7 +87,7 @@ public class OAI2Handler extends DefaultHandler {
             String pages = content.replaceFirst(journal, "");
             pages = pages.replaceFirst(volume, "");
             pages = pages.replaceFirst("\\(" + year + "\\)", "");
-            pages = pages.replaceAll(" ", "");
+            pages = pages.replace(" ", "");
             entry.setField("pages", pages);
         } else if ("datestamp".equals(qualifiedName)) {
             String year = entry.getField("year");

--- a/src/main/java/net/sf/jabref/importer/ZipFileChooser.java
+++ b/src/main/java/net/sf/jabref/importer/ZipFileChooser.java
@@ -139,7 +139,8 @@ class ZipFileChooser extends JDialog {
                     ZipEntry tempZipEntry = model.getZipEntry(row);
                     CustomImporter importer = new CustomImporter();
                     importer.setBasePath(model.getZipFile().getName());
-                    String className = tempZipEntry.getName().substring(0, tempZipEntry.getName().lastIndexOf('.')).replaceAll("/", ".");
+                    String className = tempZipEntry.getName().substring(0, tempZipEntry.getName().lastIndexOf('.'))
+                            .replace("/", ".");
                     importer.setClassName(className);
                     try {
                         ImportFormat importFormat = importer.getInstance();

--- a/src/main/java/net/sf/jabref/importer/fetcher/ACMPortalFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/ACMPortalFetcher.java
@@ -227,7 +227,7 @@ public class ACMPortalFetcher implements PreviewEntryFetcher {
 
     private String makeUrl() {
         StringBuilder sb = new StringBuilder(ACMPortalFetcher.START_URL).append(ACMPortalFetcher.SEARCH_URL_PART)
-                .append(terms.replaceAll(" ", "%20")).append(ACMPortalFetcher.SEARCH_URL_PART_II);
+                .append(terms.replace(" ", "%20")).append(ACMPortalFetcher.SEARCH_URL_PART_II);
 
         if (acmOrGuide) {
             sb.append("ACM");
@@ -389,7 +389,7 @@ public class ACMPortalFetcher implements PreviewEntryFetcher {
             if (m.find()) {
                 try {
                     String number = m.group(1);
-                    number = number.replaceAll(",", ""); // Remove , as in 1,234
+                    number = number.replace(",", ""); // Remove , as in 1,234
                     return Integer.parseInt(number);
                 } catch (IllegalStateException | NumberFormatException ex) {
                     throw new IOException("Cannot parse number of hits");

--- a/src/main/java/net/sf/jabref/importer/fetcher/BibsonomyScraper.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/BibsonomyScraper.java
@@ -48,7 +48,8 @@ class BibsonomyScraper {
     public static Optional<BibEntry> getEntry(String entryUrl) {
         try {
             // Replace special characters by corresponding sequences:
-            entryUrl = entryUrl.replaceAll("%", "%25").replaceAll(":", "%3A").replaceAll("/", "%2F").replaceAll("\\?", "%3F").replaceAll("&", "%26").replaceAll("=", "%3D");
+            entryUrl = entryUrl.replace("%", "%25").replace(":", "%3A").replace("/", "%2F").replace("?", "%3F")
+                    .replace("&", "%26").replace("=", "%3D");
 
             URL url = new URL(BibsonomyScraper.BIBSONOMY_SCRAPER + entryUrl + BibsonomyScraper.BIBSONOMY_SCRAPER_POST);
             String bibtex = new URLDownload(url).downloadToString(StandardCharsets.UTF_8);

--- a/src/main/java/net/sf/jabref/importer/fetcher/DBLPHelper.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/DBLPHelper.java
@@ -41,10 +41,7 @@ class DBLPHelper {
         public String cleanQuery(final String query) {
             String cleaned = query;
 
-            cleaned = cleaned.replaceAll("-", " ");
-            cleaned = cleaned.replaceAll(" ", "%20");
-            cleaned = cleaned.replaceAll(":", "");
-            cleaned = cleaned.toLowerCase();
+            cleaned = cleaned.replace("-", " ").replace(" ", "%20").replace(":", "").toLowerCase();
 
             return cleaned;
         }

--- a/src/main/java/net/sf/jabref/importer/fetcher/GVKFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/GVKFetcher.java
@@ -140,8 +140,7 @@ public class GVKFetcher implements EntryFetcher {
                     result = result.concat("%20");
                 }
                 String encoded = s[x];
-                encoded = encoded.replaceAll(",", "%2C");
-                encoded = encoded.replaceAll("\\?", "%3F");
+                encoded = encoded.replace(",", "%2C").replace("?", "%3F");
 
                 result = result.concat(encoded);
                 lastWasKey = false;

--- a/src/main/java/net/sf/jabref/importer/fetcher/GoogleScholarFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/GoogleScholarFetcher.java
@@ -220,7 +220,7 @@ public class GoogleScholarFetcher implements PreviewEntryFetcher {
         Matcher m = GoogleScholarFetcher.BIBTEX_LINK_PATTERN.matcher(cont);
         int lastRegionStart = 0;
         while (m.find()) {
-            String link = m.group(1).replaceAll("&amp;", "&");
+            String link = m.group(1).replace("&amp;", "&");
             String pText;
             //System.out.println("regionStart: "+m.start());
             String part = cont.substring(lastRegionStart, m.start());
@@ -240,7 +240,7 @@ public class GoogleScholarFetcher implements PreviewEntryFetcher {
                 pText = link;
             }
 
-            pText = pText.replaceAll("\\[PDF\\]", "");
+            pText = pText.replace("[PDF]", "");
             JLabel preview = new JLabel("<html>" + pText + "</html>");
             ids.put(link, preview);
 

--- a/src/main/java/net/sf/jabref/importer/fetcher/IEEEXploreFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/IEEEXploreFetcher.java
@@ -307,12 +307,8 @@ public class IEEEXploreFetcher implements EntryFetcher {
             }
             author = String.join(" and ", authorSplit);
 
-            author = author.replaceAll("\\.", ". ");
-            author = author.replaceAll("  ", " ");
-            author = author.replaceAll("\\. -", ".-");
-            author = author.replaceAll("; ", " and ");
-            author = author.replaceAll(" ,", ",");
-            author = author.replaceAll("  ", " ");
+            author = author.replace(".", ". ").replace("  ", " ").replace(". -", ".-").replace("; ", " and ")
+                    .replace(" ,", ",").replace("  ", " ");
             author = author.replaceAll("[ ,;]+$", "");
             //TODO: remove trailing commas
             entry.setField("author", author);
@@ -321,7 +317,7 @@ public class IEEEXploreFetcher implements EntryFetcher {
         // clean up month
         String month = entry.getField("month");
         if ((month != null) && !month.isEmpty()) {
-            month = month.replaceAll("\\.", "");
+            month = month.replace(".", "");
             month = month.toLowerCase();
 
             Pattern monthPattern = Pattern.compile("(\\d*+)\\s*([a-z]*+)-*(\\d*+)\\s*([a-z]*+)");
@@ -402,10 +398,10 @@ public class IEEEXploreFetcher implements EntryFetcher {
             } else {
                 fullName = fullName.replace("Conference Proceedings", "Proceedings")
                         .replace("Proceedings of", "Proceedings").replace("Proceedings.", "Proceedings");
-                fullName = fullName.replaceAll("International", "Int.");
-                fullName = fullName.replaceAll("Symposium", "Symp.");
-                fullName = fullName.replaceAll("Conference", "Conf.");
-                fullName = fullName.replaceAll(" on", " ").replace("  ", " ");
+                fullName = fullName.replace("International", "Int.");
+                fullName = fullName.replace("Symposium", "Symp.");
+                fullName = fullName.replace("Conference", "Conf.");
+                fullName = fullName.replace(" on", " ").replace("  ", " ");
             }
 
             Matcher m1 = PUBLICATION_PATTERN.matcher(fullName);
@@ -503,8 +499,7 @@ public class IEEEXploreFetcher implements EntryFetcher {
                 abstr = abstr.replaceAll("\\(sub\\)([^(]+)\\(/sub\\)", "\\\\textsubscript\\{$1\\}");
             }
             // Replace \infin with \infty
-            abstr = abstr.replaceAll("\\\\infin", "\\\\infty");
-
+            abstr = abstr.replace("\\infin", "\\infty");
             // Write back
             entry.setField("abstract", abstr);
         }

--- a/src/main/java/net/sf/jabref/importer/fetcher/OAI2Fetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/OAI2Fetcher.java
@@ -272,7 +272,7 @@ public class OAI2Fetcher implements EntryFetcher {
             shouldContinue = true;
 
             /* multiple keys can be delimited by ; or space */
-            query = query.replaceAll(" ", ";");
+            query = query.replace(" ", ";");
             String[] keys = query.split(";");
             for (int i = 0; i < keys.length; i++) {
                 String key = keys[i];

--- a/src/main/java/net/sf/jabref/importer/fileformat/EndnoteImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/EndnoteImporter.java
@@ -306,7 +306,7 @@ public class EndnoteImporter extends ImportFormat {
         // Look for the comma at the end:
         index = s.lastIndexOf(',');
         if (index == (s.length() - 1)) {
-            String mod = s.substring(0, s.length() - 1).replaceAll(", ", " and ");
+            String mod = s.substring(0, s.length() - 1).replace(", ", " and ");
             return AuthorList.fixAuthor_lastNameFirst(mod);
         } else {
             return AuthorList.fixAuthor_lastNameFirst(s);

--- a/src/main/java/net/sf/jabref/importer/fileformat/InspecImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/InspecImporter.java
@@ -119,7 +119,7 @@ public class InspecImporter extends ImportFormat {
                     h.put("year", frest);
                 } else if ("AU".equals(f3)) {
                     h.put("author",
-                            AuthorList.fixAuthor_lastNameFirst(frest.replaceAll(",-", ", ").replaceAll(";", " and ")));
+                            AuthorList.fixAuthor_lastNameFirst(frest.replace(",-", ", ").replace(";", " and ")));
                 } else if ("AB".equals(f3)) {
                     h.put("abstract", frest);
                 } else if ("ID".equals(f3)) {
@@ -128,7 +128,7 @@ public class InspecImporter extends ImportFormat {
                     int m = frest.indexOf('.');
                     if (m >= 0) {
                         String jr = frest.substring(0, m);
-                        h.put("journal", jr.replaceAll("-", " "));
+                        h.put("journal", jr.replace("-", " "));
                         frest = frest.substring(m);
                         m = frest.indexOf(';');
                         if (m >= 5) {
@@ -151,7 +151,7 @@ public class InspecImporter extends ImportFormat {
                     } else if ("Conference-Paper".equals(frest) || "Conference-Paper; Journal-Paper".equals(frest)) {
                         type = "inproceedings";
                     } else {
-                        type = frest.replaceAll(" ", "");
+                        type = frest.replace(" ", "");
                     }
                 }
             }

--- a/src/main/java/net/sf/jabref/importer/fileformat/IsiImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/IsiImporter.java
@@ -247,7 +247,7 @@ public class IsiImporter extends ImportFormat {
                 } else if ("JO".equals(beg)) {
                     hm.put("booktitle", value);
                 } else if ("AU".equals(beg)) {
-                    String author = IsiImporter.isiAuthorsConvert(value.replaceAll("EOLEOL", " and "));
+                    String author = IsiImporter.isiAuthorsConvert(value.replace("EOLEOL", " and "));
 
                     // if there is already someone there then append with "and"
                     if (hm.get("author") != null) {
@@ -256,12 +256,12 @@ public class IsiImporter extends ImportFormat {
 
                     hm.put("author", author);
                 } else if ("TI".equals(beg)) {
-                    hm.put("title", value.replaceAll("EOLEOL", " "));
+                    hm.put("title", value.replace("EOLEOL", " "));
                 } else if ("SO".equals(beg) || "JA".equals(beg)) {
                     hm.put("journal", value.replaceAll("EOLEOL", " "));
                 } else if ("ID".equals(beg) || "KW".equals(beg)) {
 
-                    value = value.replaceAll("EOLEOL", " ");
+                    value = value.replace("EOLEOL", " ");
                     String existingKeywords = hm.get("keywords");
                     if ((existingKeywords == null) || existingKeywords.contains(value)) {
                         existingKeywords = value;
@@ -271,7 +271,7 @@ public class IsiImporter extends ImportFormat {
                     hm.put("keywords", existingKeywords);
 
                 } else if ("AB".equals(beg)) {
-                    hm.put("abstract", value.replaceAll("EOLEOL", " "));
+                    hm.put("abstract", value.replace("EOLEOL", " "));
                 } else if ("BP".equals(beg) || "BR".equals(beg) || "SP".equals(beg)) {
                     pages = value;
                 } else if ("EP".equals(beg)) {
@@ -315,7 +315,7 @@ public class IsiImporter extends ImportFormat {
                         Type = "misc";
                     }
                 } else if ("CR".equals(beg)) {
-                    hm.put("CitedReferences", value.replaceAll("EOLEOL", " ; ").trim());
+                    hm.put("CitedReferences", value.replace("EOLEOL", " ; ").trim());
                 } else {
                     // Preserve all other entries except
                     if ("ER".equals(beg) || "EF".equals(beg) || "VR".equals(beg)
@@ -422,7 +422,7 @@ public class IsiImporter extends ImportFormat {
 
             // Do we have only uppercase chars?
             if (first.toUpperCase().equals(first)) {
-                first = first.replaceAll("\\.", "");
+                first = first.replace(".", "");
                 for (int j = 0; j < first.length(); j++) {
                     sb.append(first.charAt(j)).append('.');
 

--- a/src/main/java/net/sf/jabref/importer/fileformat/MedlineHandler.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/MedlineHandler.java
@@ -265,7 +265,7 @@ class MedlineHandler extends DefaultHandler
                 b.setField("medline-pst", pst);
             }
             if (!"".equals(abstractText)) {
-                b.setField("abstract", abstractText.replaceAll("%", "\\\\%"));
+                b.setField("abstract", abstractText.replace("%", "\\%"));
             }
             if (!"".equals(keywords)) {
                 b.setField("keywords", keywords);
@@ -289,7 +289,7 @@ class MedlineHandler extends DefaultHandler
                 b.setField("pmc", pmc);
             }
             if (!"".equals(affiliation)) {
-                b.setField("institution", affiliation.replaceAll("#", "\\\\#"));
+                b.setField("institution", affiliation.replace("#", "\\#"));
             }
 
             // PENDING jeffrey.kuhn@yale.edu 2005-05-27 : added "pmid" bibtex field

--- a/src/main/java/net/sf/jabref/importer/fileformat/MedlinePlainImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/MedlinePlainImporter.java
@@ -96,7 +96,8 @@ public class MedlinePlainImporter extends ImportFormat {
             sb.append(str);
             sb.append('\n');
         }
-        String[] entries = sb.toString().replaceAll("\u2013", "-").replaceAll("\u2014", "--").replaceAll("\u2015", "--").split("\\n\\n");
+        String[] entries = sb.toString().replace("\u2013", "-").replace("\u2014", "--").replace("\u2015", "--")
+                .split("\\n\\n");
 
         for (String entry1 : entries) {
 

--- a/src/main/java/net/sf/jabref/importer/fileformat/OvidImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/OvidImporter.java
@@ -170,7 +170,7 @@ public class OvidImporter extends ImportFormat {
                         h.put("pages", matcher.group(6));
 
                     } else if ((matcher = OvidImporter.incollection_pat.matcher(content)).find()) {
-                        h.put("editor", matcher.group(1).replaceAll(" \\(Ed\\)", ""));
+                        h.put("editor", matcher.group(1).replace(" (Ed)", ""));
                         h.put("year", matcher.group(2));
                         h.put("booktitle", matcher.group(3));
                         h.put("pages", matcher.group(4));
@@ -185,7 +185,7 @@ public class OvidImporter extends ImportFormat {
                     }
                     // Add double hyphens to page ranges:
                     if (h.get("pages") != null) {
-                        h.put("pages", h.get("pages").replaceAll("-", "--"));
+                        h.put("pages", h.get("pages").replace("-", "--"));
                     }
 
                 } else if ("Abstract".equals(fieldName)) {
@@ -202,7 +202,7 @@ public class OvidImporter extends ImportFormat {
                 } else if (fieldName.startsWith("Language")) {
                     h.put("language", content);
                 } else if (fieldName.startsWith("Author Keywords")) {
-                    content = content.replaceAll(";", ",").replaceAll("  ", " ");
+                    content = content.replace(";", ",").replace("  ", " ");
                     h.put("keywords", content);
                 } else if (fieldName.startsWith("ISSN")) {
                     h.put("issn", content);
@@ -216,7 +216,7 @@ public class OvidImporter extends ImportFormat {
             String auth = h.get("author");
             if ((auth != null) && auth.contains(" [Ed]")) {
                 h.remove("author");
-                h.put("editor", auth.replaceAll(" \\[Ed\\]", ""));
+                h.put("editor", auth.replace(" [Ed]", ""));
             }
 
             // Rearrange names properly:
@@ -256,7 +256,7 @@ public class OvidImporter extends ImportFormat {
     private static String fixNames(String content) {
         String names;
         if (content.indexOf(';') > 0) { //LN FN; [LN FN;]*
-            names = content.replaceAll("[^\\.A-Za-z,;\\- ]", "").replaceAll(";", " and");
+            names = content.replaceAll("[^\\.A-Za-z,;\\- ]", "").replace(";", " and");
         } else if (content.indexOf("  ") > 0) {
             String[] sNames = content.split("  ");
             StringBuilder sb = new StringBuilder();

--- a/src/main/java/net/sf/jabref/importer/fileformat/RisImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/RisImporter.java
@@ -87,7 +87,8 @@ public class RisImporter extends ImportFormat {
             sb.append(str);
             sb.append('\n');
         }
-        String[] entries = sb.toString().replaceAll("\u2013", "-").replaceAll("\u2014", "--").replaceAll("\u2015", "--").split("ER  -.*\\n");
+        String[] entries = sb.toString().replace("\u2013", "-").replace("\u2014", "--").replace("\u2015", "--")
+                .split("ER  -.*\\n");
 
         for (String entry1 : entries) {
 

--- a/src/main/java/net/sf/jabref/importer/fileformat/SilverPlatterImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/SilverPlatterImporter.java
@@ -122,22 +122,22 @@ public class SilverPlatterImporter extends ImportFormat {
                         if (frest.trim().endsWith("(ed)")) {
                             String ed = frest.trim();
                             ed = ed.substring(0, ed.length() - 4);
-                            h.put("editor", AuthorList.fixAuthor_lastNameFirst(ed.replaceAll(",-", ", ")
-                                    .replaceAll(";", " and ")));
+                            h.put("editor",
+                                    AuthorList.fixAuthor_lastNameFirst(ed.replace(",-", ", ").replace(";", " and ")));
                         } else {
-                            h.put("author", AuthorList.fixAuthor_lastNameFirst(frest.replaceAll(
-                                    ",-", ", ").replaceAll(";", " and ")));
+                            h.put("author", AuthorList
+                                    .fixAuthor_lastNameFirst(frest.replace(",-", ", ").replace(";", " and ")));
                         }
                     } else if ("AB".equals(f3)) {
                         h.put("abstract", frest);
                     } else if ("DE".equals(f3)) {
-                        String kw = frest.replaceAll("-;", ",").toLowerCase();
+                        String kw = frest.replace("-;", ",").toLowerCase();
                         h.put("keywords", kw.substring(0, kw.length() - 1));
                     } else if ("SO".equals(f3)) {
                         int m = frest.indexOf('.');
                         if (m >= 0) {
                             String jr = frest.substring(0, m);
-                            h.put("journal", jr.replaceAll("-", " "));
+                            h.put("journal", jr.replace("-", " "));
                             frest = frest.substring(m);
                             m = frest.indexOf(';');
                             if (m >= 5) {
@@ -156,7 +156,7 @@ public class SilverPlatterImporter extends ImportFormat {
                         int m = frest.indexOf(':');
                         if (m >= 0) {
                             String jr = frest.substring(0, m);
-                            h.put("publisher", jr.replaceAll("-", " ").trim());
+                            h.put("publisher", jr.replace("-", " ").trim());
                             frest = frest.substring(m);
                             m = frest.indexOf(", ");
                             if ((m + 2) < frest.length()) {
@@ -189,7 +189,7 @@ public class SilverPlatterImporter extends ImportFormat {
                             // title field.
                             isChapter = true;
                         } else {
-                            type = frest.replaceAll(" ", "");
+                            type = frest.replace(" ", "");
                         }
                     }
                 }
@@ -205,7 +205,7 @@ public class SilverPlatterImporter extends ImportFormat {
                         }
                         if (pgPos > inPos) {
                             h.put("pages", title.substring(pgPos)
-                                    .replaceAll("-", "--"));
+.replace("-", "--"));
                         }
 
                     }

--- a/src/main/java/net/sf/jabref/importer/fileformat/SixpackImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/SixpackImporter.java
@@ -131,7 +131,7 @@ public class SixpackImporter extends ImportFormat {
         BibEntry entry;
         while ((s = in.readLine()) != null) {
             try {
-                s = s.replaceAll("<par>", ""); // What is <par> ????
+                s = s.replace("<par>", ""); // What is <par> ????
                 String[] fields = s.split(SEPARATOR);
                 // Check type and create entry:
                 if (fields.length < 2)
@@ -161,12 +161,10 @@ public class SixpackImporter extends ImportFormat {
                     fld = fI.get(fieldDef[i]);
                     if (fld != null) {
                         if ("author".equals(fld) || "editor".equals(fld)) {
-                            ImportFormatReader.setIfNecessary(entry,
-                                    fld, fields[i].replaceAll(" and ", ", ").replaceAll(", ",
-                                            " and "));
+                            ImportFormatReader.setIfNecessary(entry, fld,
+                                    fields[i].replace(" and ", ", ").replace(", ", " and "));
                         } else if ("pages".equals(fld)) {
-                            ImportFormatReader.setIfNecessary(entry, fld, fields[i]
-                                    .replaceAll("-", "--"));
+                            ImportFormatReader.setIfNecessary(entry, fld, fields[i].replace("-", "--"));
                         } else if ("file".equals(fld)) {
                             String fieldName = "pdf"; // We set pdf as default.
                             if (fields[i].endsWith("ps") || fields[i].endsWith("ps.gz")) {

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/AuthorsFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/AuthorsFormatter.java
@@ -42,7 +42,7 @@ public class AuthorsFormatter implements Formatter {
     public String format(String value) {
         boolean andSep = false;
         // String can contain newlines. Convert each to a space
-        value = value.replaceAll("\n", " ");
+        value = value.replace("\n", " ");
         String[] authors = value.split("( |,)and ", -1);
         if (authors.length > 1) {
             andSep = true;

--- a/src/main/java/net/sf/jabref/logic/journals/Abbreviation.java
+++ b/src/main/java/net/sf/jabref/logic/journals/Abbreviation.java
@@ -27,7 +27,7 @@ public class Abbreviation implements Comparable<Abbreviation> {
     }
 
     public String getMedlineAbbreviation() {
-        return getIsoAbbreviation().replaceAll("\\.", " ").replaceAll("  ", " ").trim();
+        return getIsoAbbreviation().replace(".", " ").replace("  ", " ").trim();
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/logic/l10n/LocalizationKey.java
+++ b/src/main/java/net/sf/jabref/logic/l10n/LocalizationKey.java
@@ -12,15 +12,15 @@ public class LocalizationKey {
 
     public String getPropertiesKeyUnescaped() {
         // space, = and : are not allowed in properties file keys
-        return this.key.replaceAll(" ", "_");
+        return this.key.replace(" ", "_");
     }
 
     public String getPropertiesKey() {
         // space, = and : are not allowed in properties file keys
-        return this.key.replaceAll(" ", "_").replace("=", "\\=").replace(":", "\\:").replace("\\\\", "\\");
+        return this.key.replace(" ", "_").replace("=", "\\=").replace(":", "\\:").replace("\\\\", "\\");
     }
 
     public String getTranslationValue() {
-        return this.key.replaceAll("_", " ").replaceAll("\\\\=", "=").replaceAll("\\\\:", ":");
+        return this.key.replace("_", " ").replaceAll("\\\\=", "=").replaceAll("\\\\:", ":");
     }
 }

--- a/src/main/java/net/sf/jabref/migrations/PreferencesMigrations.java
+++ b/src/main/java/net/sf/jabref/migrations/PreferencesMigrations.java
@@ -23,11 +23,11 @@ public class PreferencesMigrations {
             if ("abstract".equals(genFields)) {
                 newGen = "";
             } else if (genFields.contains(";abstract;")) {
-                newGen = genFields.replaceAll(";abstract;", ";");
+                newGen = genFields.replace(";abstract;", ";");
             } else if (genFields.indexOf("abstract;") == 0) {
-                newGen = genFields.replaceAll("abstract;", "");
+                newGen = genFields.replace("abstract;", "");
             } else if (genFields.indexOf(";abstract") == (genFields.length() - 9)) {
-                newGen = genFields.replaceAll(";abstract", "");
+                newGen = genFields.replace(";abstract", "");
             } else {
                 newGen = genFields;
             }

--- a/src/main/java/net/sf/jabref/model/DuplicateCheck.java
+++ b/src/main/java/net/sf/jabref/model/DuplicateCheck.java
@@ -144,8 +144,8 @@ public class DuplicateCheck {
         if ("author".equals(field) || "editor".equals(field)) {
             // Specific for name fields.
             // Harmonise case:
-            String auth1 = AuthorList.fixAuthor_lastNameOnlyCommas(s1, false).replaceAll(" and ", " ").toLowerCase();
-            String auth2 = AuthorList.fixAuthor_lastNameOnlyCommas(s2, false).replaceAll(" and ", " ").toLowerCase();
+            String auth1 = AuthorList.fixAuthor_lastNameOnlyCommas(s1, false).replace(" and ", " ").toLowerCase();
+            String auth2 = AuthorList.fixAuthor_lastNameOnlyCommas(s2, false).replace(" and ", " ").toLowerCase();
             double similarity = DuplicateCheck.correlateByWords(auth1, auth2);
             if (similarity > 0.8) {
                 return EQUAL;
@@ -165,8 +165,8 @@ public class DuplicateCheck {
             // We do not attempt to harmonize abbreviation state of the journal names,
             // but we remove periods from the names in case they are abbreviated with
             // and without dots:
-            s1 = s1.replaceAll("\\.", "").toLowerCase();
-            s2 = s2.replaceAll("\\.", "").toLowerCase();
+            s1 = s1.replace(".", "").toLowerCase();
+            s2 = s2.replace(".", "").toLowerCase();
             double similarity = DuplicateCheck.correlateByWords(s1, s2);
             if (similarity > 0.8) {
                 return EQUAL;


### PR DESCRIPTION
Better to use `replace`than `replaceAll` as the latter compiles a regular expression.