### PR TITLE
Removed unused group submenu from RIghtClickMenu

### DIFF
--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableSelectionListener.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableSelectionListener.java
@@ -377,7 +377,7 @@ public class MainTableSelectionListener implements ListEventListener<BibEntry>, 
             table.setRowSelectionInterval(row, row);
             //panel.updateViewToSelected();
         }
-        RightClickMenu rightClickMenu = new RightClickMenu(panel, panel.getBibDatabaseContext().getMetaData());
+        RightClickMenu rightClickMenu = new RightClickMenu(panel);
         rightClickMenu.show(table, e.getX(), e.getY());
     }
 


### PR DESCRIPTION
All code is now gone (and the Move to group menu item follows the same logic as the add to and remove from group).