### PR TITLE
Added some pre-requisites for testing custom imports

### DIFF
--- a/src/main/nonpackagejava/CustomImportExample.java
+++ b/src/main/nonpackagejava/CustomImportExample.java
@@ -1,0 +1,45 @@
+import java.io.*;
+import java.util.*;
+
+import net.sf.jabref.importer.ImportFormatReader;
+import net.sf.jabref.importer.OutputPrinter;
+import net.sf.jabref.importer.fileformat.ImportFormat;
+import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.model.entry.BibtexEntryTypes;
+
+// Make sure this is up to date with src/test/resources/net/sf/jabref/importer/fileformat/SimpleCSVImporter.java
+// Different names are needed to not cause any confusion(?)
+
+public class CustomImportExample extends ImportFormat {
+
+    @Override
+    public String getFormatName() {
+        return "Simple CSV Importer";
+    }
+
+    @Override
+    public boolean isRecognizedFormat(InputStream stream) throws IOException {
+        return true; // this is discouraged except for demonstration purposes
+    }
+
+    @Override
+    public List<BibEntry> importEntries(InputStream stream, OutputPrinter printer) throws IOException {
+        List<BibEntry> bibitems = new ArrayList<>();
+        BufferedReader in = new BufferedReader(ImportFormatReader.getReaderDefaultEncoding(stream));
+
+        String line = in.readLine();
+        while (line != null) {
+            if (!line.trim().isEmpty()) {
+                String[] fields = line.split(";");
+                BibEntry be = new BibEntry();
+                be.setType(BibtexEntryTypes.TECHREPORT);
+                be.setField("year", fields[0]);
+                be.setField("author", fields[1]);
+                be.setField("title", fields[2]);
+                bibitems.add(be);
+                line = in.readLine();
+            }
+        }
+        return bibitems;
+    }
+}

--- a/src/test/java/net/sf/jabref/importer/fileformat/SimpleCSVImporter.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/SimpleCSVImporter.java
@@ -1,0 +1,48 @@
+// This is the example used in the custom import format help page and should reside in test
+// Make sure this is up to date with the help page and /src/main/nonpackagejava (which is used for testing custom import)
+// Skip the package line when updating the help page
+
+package net.sf.jabref.importer.fileformat;
+
+import java.io.*;
+import java.util.*;
+
+import net.sf.jabref.importer.ImportFormatReader;
+import net.sf.jabref.importer.OutputPrinter;
+import net.sf.jabref.importer.fileformat.ImportFormat;
+import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.model.entry.BibtexEntryTypes;
+
+public class SimpleCSVImporter extends ImportFormat {
+
+    @Override
+    public String getFormatName() {
+        return "Simple CSV Importer";
+    }
+
+    @Override
+    public boolean isRecognizedFormat(InputStream stream) throws IOException {
+        return true; // this is discouraged except for demonstration purposes
+    }
+
+    @Override
+    public List<BibEntry> importEntries(InputStream stream, OutputPrinter printer) throws IOException {
+        List<BibEntry> bibitems = new ArrayList<>();
+        BufferedReader in = new BufferedReader(ImportFormatReader.getReaderDefaultEncoding(stream));
+
+        String line = in.readLine();
+        while (line != null) {
+            if (!line.trim().isEmpty()) {
+                String[] fields = line.split(";");
+                BibEntry be = new BibEntry();
+                be.setType(BibtexEntryTypes.TECHREPORT);
+                be.setField("year", fields[0]);
+                be.setField("author", fields[1]);
+                be.setField("title", fields[2]);
+                bibitems.add(be);
+                line = in.readLine();
+            }
+        }
+        return bibitems;
+    }
+}

--- a/src/test/java/net/sf/jabref/importer/fileformat/SimpleCSVImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/SimpleCSVImporterTest.java
@@ -1,0 +1,36 @@
+package net.sf.jabref.importer.fileformat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.importer.OutputPrinterToNull;
+import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.model.entry.BibtexEntryTypes;
+
+public class SimpleCSVImporterTest {
+
+    @BeforeClass
+    public static void setUp() {
+        Globals.prefs = JabRefPreferences.getInstance();
+    }
+
+    @Test
+    public void test() throws IOException {
+        try (InputStream is = SimpleCSVImporterTest.class.getResourceAsStream("SimpleCSVImporterExample.scsv")) {
+            List<BibEntry> entries = new SimpleCSVImporter().importEntries(is, new OutputPrinterToNull());
+            Assert.assertEquals(3, entries.size());
+            Assert.assertEquals("John Maynard Keynes", entries.get(0).getField("author"));
+            Assert.assertEquals("2003", entries.get(1).getField("year"));
+            Assert.assertEquals("The Software Patent Experiment", entries.get(2).getField("title"));
+            Assert.assertEquals(BibtexEntryTypes.TECHREPORT.getName().toLowerCase(), entries.get(0).getType());
+        }
+    }
+
+}

--- a/src/test/resources/net/sf/jabref/importer/fileformat/SimpleCSVImporterExample.scsv
+++ b/src/test/resources/net/sf/jabref/importer/fileformat/SimpleCSVImporterExample.scsv
@@ -1,0 +1,3 @@
+1936;John Maynard Keynes;The General Theory of Employment, Interest and Money
+2003;Boldrin and Levine;Case Against Intellectual Monopoly
+2004;ROBERT HUNT AND JAMES BESSEN;The Software Patent Experiment


### PR DESCRIPTION
Added the custom import example source code (http://help.jabref.org/en/CustomImports/) to the repository and added a test for it. Also created a new directory `src/main/nonpackagejava` to eventually enable testing of custom import and export and added the "same" file there.

Not sure what will happen if the same class name is used, so I avoided that.

See https://github.com/JabRef/help.jabref.org/issues/3 for a bit more background.