### PR TITLE
Using short circuit logic in boolean context

### DIFF
--- a/src/main/java/net/sf/jabref/bibtex/BibEntryWriter.java
+++ b/src/main/java/net/sf/jabref/bibtex/BibEntryWriter.java
@@ -72,7 +72,7 @@ public class BibEntryWriter {
         List<String> fields = type.getRequiredFieldsFlat();
         if (fields != null) {
             for (String value : fields) {
-                hasWritten = hasWritten | writeField(entry, out, value, hasWritten, indentation);
+                hasWritten = hasWritten || writeField(entry, out, value, hasWritten, indentation);
                 written.add(value);
             }
         }
@@ -81,7 +81,7 @@ public class BibEntryWriter {
         if (fields != null) {
             for (String value : fields) {
                 if (!written.contains(value)) { // If field appears both in req. and opt. don't repeat.
-                    hasWritten = hasWritten | writeField(entry, out, value, hasWritten, indentation);
+                    hasWritten = hasWritten || writeField(entry, out, value, hasWritten, indentation);
                     written.add(value);
                 }
             }
@@ -96,7 +96,7 @@ public class BibEntryWriter {
             }
         }
         for (String field : remainingFields) {
-            hasWritten = hasWritten | writeField(entry, out, field, hasWritten, indentation);
+            hasWritten = hasWritten || writeField(entry, out, field, hasWritten, indentation);
         }
 
         // Finally, end the entry.

--- a/src/main/java/net/sf/jabref/groups/GroupDialog.java
+++ b/src/main/java/net/sf/jabref/groups/GroupDialog.java
@@ -431,7 +431,7 @@ class GroupDialog extends JDialog {
             setNameFontItalic(true);
         } else if (m_searchRadioButton.isSelected()) {
             s1 = m_sgSearchExpression.getText().trim();
-            okEnabled = okEnabled & !s1.isEmpty();
+            okEnabled = okEnabled && !s1.isEmpty();
             if (okEnabled) {
                 setDescription(SearchDescribers.getSearchDescriberFor(SearchRules.getSearchRuleByQuery(s1, isCaseSensitive(), isRegex()), s1).getDescription());
 

--- a/src/main/java/net/sf/jabref/importer/ImportMenuItem.java
+++ b/src/main/java/net/sf/jabref/importer/ImportMenuItem.java
@@ -241,7 +241,7 @@ public class ImportMenuItem extends JMenuItem implements ActionListener {
                 ParserResult pr = importResult.parserResult;
                 Collection<BibEntry> entries = pr.getDatabase().getEntries();
 
-                anythingUseful = anythingUseful | !entries.isEmpty();
+                anythingUseful = anythingUseful || !entries.isEmpty();
 
                 // set timestamp and owner
                 Util.setAutomaticFields(entries, Globals.prefs.getBoolean(JabRefPreferences.OVERWRITE_OWNER),


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2178 - “ Short-circuit logic should be used in boolean contexts”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2178
Please let me know if you have any questions.
Ayman Abdelghany.