### PR TITLE
Fix a small bug in citekey generator

### DIFF
--- a/src/main/java/net/sf/jabref/logic/labelPattern/LabelPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/labelPattern/LabelPatternUtil.java
@@ -422,7 +422,6 @@ public class LabelPatternUtil {
      */
     public static void makeLabel(MetaData metaData, BibDatabase dBase, BibEntry entry) {
         LabelPatternUtil.database = dBase;
-        List<String> typeList;
         String key;
         StringBuilder stringBuilder = new StringBuilder();
         boolean forceUpper = false;
@@ -432,7 +431,10 @@ public class LabelPatternUtil {
             // get the type of entry
             String entryType = entry.getType();
             // Get the arrayList corresponding to the type
-            typeList = metaData.getLabelPattern().getValue(entryType);
+            List<String> typeList = new ArrayList<>(metaData.getLabelPattern().getValue(entryType));
+            if(! typeList.isEmpty()) {
+                typeList.remove(0);
+            }
             boolean field = false;
             for (String typeListEntry : typeList) {
                 if ("[".equals(typeListEntry)) {


### PR DESCRIPTION
Generating a new key would prepend the pattern which resulted for example in `[author]Weinstein` instead of the expected `Weinstein`. The reason for the bug was that the list returned by
`getLabelPattern().getValue(entryType)` contains as the first item the complete pattern.

This bug was introduced in https://github.com/oscargus/jabref/commit/81f2a687010c4da31f1808133ae03fb3ef8cd0b9.