### PR TITLE
Fixed some warnings

### DIFF
--- a/src/main/java/net/sf/jabref/exporter/ExportFileFilter.java
+++ b/src/main/java/net/sf/jabref/exporter/ExportFileFilter.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2016 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -61,5 +61,13 @@ class ExportFileFilter extends FileFilter implements Comparable<ExportFileFilter
     @Override
     public int compareTo(ExportFileFilter o) {
         return name.compareTo(o.name);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if ((o != null) && (o instanceof ExportFileFilter)) {
+            return name.equals(((ExportFileFilter) o).name);
+        }
+        return false;
     }
 }

--- a/src/main/java/net/sf/jabref/exporter/OpenOfficeDocumentCreator.java
+++ b/src/main/java/net/sf/jabref/exporter/OpenOfficeDocumentCreator.java
@@ -88,7 +88,9 @@ public class OpenOfficeDocumentCreator extends ExportFormat {
         }
 
         // Delete the temporary file:
-        tmpFile.delete();
+        if (!tmpFile.delete()) {
+            LOGGER.info("Cannot delete temporary export file");
+        }
     }
 
     private static void exportOpenOfficeCalcXML(File tmpFile, BibDatabase database, Set<String> keySet) {

--- a/src/main/java/net/sf/jabref/external/SynchronizeFileField.java
+++ b/src/main/java/net/sf/jabref/external/SynchronizeFileField.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2015 JabRef contributors.
+/*  Copyright (C) 2003-2016 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -46,8 +46,10 @@ import java.util.List;
 public class SynchronizeFileField extends AbstractWorker {
 
     private final BasePanel panel;
-    private BibEntry[] sel;
+    private List<BibEntry> sel;
     private SynchronizeFileField.OptionsDialog optDiag;
+
+    private int entriesChangedCount = 0;
 
     private final Object[] brokenLinkOptions = {
             Localization.lang("Ignore"),
@@ -69,8 +71,7 @@ public class SynchronizeFileField extends AbstractWorker {
     public void init() {
         Collection<BibEntry> col = panel.database().getEntries();
         goOn = true;
-        sel = new BibEntry[col.size()];
-        sel = col.toArray(sel);
+        sel = new ArrayList<>(col);
 
         // Ask about rules for the operation:
         if (optDiag == null) {
@@ -94,11 +95,11 @@ public class SynchronizeFileField extends AbstractWorker {
             panel.output(Localization.lang("No entries selected."));
             return;
         }
+        entriesChangedCount = 0;
         panel.frame().setProgressBarValue(0);
         panel.frame().setProgressBarVisible(true);
         int weightAutoSet = 10; // autoSet takes 10 (?) times longer than checkExisting
-        int progressBarMax = (autoSet ? weightAutoSet * sel.length : 0)
-                + (checkExisting ? sel.length : 0);
+        int progressBarMax = (autoSet ? weightAutoSet * sel.size() : 0) + (checkExisting ? sel.size() : 0);
         panel.frame().setProgressBarMaximum(progressBarMax);
         int progress = 0;
         final NamedCompound ce = new NamedCompound(Localization.lang("Autoset %0 field", Globals.FILE_FIELD));
@@ -107,14 +108,13 @@ public class SynchronizeFileField extends AbstractWorker {
 
         // First we try to autoset fields
         if (autoSet) {
-            Collection<BibEntry> entries = new ArrayList<>();
-            Collections.addAll(entries, sel);
+            Collection<BibEntry> entries = new ArrayList<>(sel);
 
             // Start the autosetting process:
             Runnable r = Util.autoSetLinks(entries, ce, changedEntries, null, panel.getBibDatabaseContext().getMetaData(), null, null);
             JabRefExecutorService.INSTANCE.executeAndWait(r);
         }
-        progress += sel.length * weightAutoSet;
+        progress += sel.size() * weightAutoSet;
         panel.frame().setProgressBarValue(progress);
         // The following loop checks all external links that are already set.
         if (checkExisting) {
@@ -129,7 +129,7 @@ public class SynchronizeFileField extends AbstractWorker {
 
                     // We need to specify which directories to search in for Util.expandFilename:
                     List<String> dirsS = panel.getBibDatabaseContext().getMetaData().getFileDirectory(Globals.FILE_FIELD);
-                    ArrayList<File> dirs = new ArrayList<>();
+                    List<File> dirs = new ArrayList<>();
                     for (String dirs1 : dirsS) {
                         dirs.add(new File(dirs1));
                     }
@@ -250,6 +250,7 @@ public class SynchronizeFileField extends AbstractWorker {
             ce.end();
             panel.undoManager.addEdit(ce);
             panel.markBaseChanged();
+            entriesChangedCount = changedEntries.size();
         }
     }
 
@@ -259,7 +260,6 @@ public class SynchronizeFileField extends AbstractWorker {
             return;
         }
 
-        int entriesChangedCount = 0;
         panel.output(Localization.lang("Finished synchronizing %0 links. Entries changed: %1.",
                 Globals.FILE_FIELD.toUpperCase(), String.valueOf(entriesChangedCount)));
         panel.frame().setProgressBarVisible(false);
@@ -271,20 +271,23 @@ public class SynchronizeFileField extends AbstractWorker {
 
     static class OptionsDialog extends JDialog {
 
-        private final JRadioButton autoSetUnset;
-        private final JRadioButton autoSetAll;
-        private final JRadioButton autoSetNone;
-        private final JCheckBox checkLinks;
+
         private final JButton ok = new JButton(Localization.lang("OK"));
         private final JButton cancel = new JButton(Localization.lang("Cancel"));
         private boolean canceled = true;
         private final MetaData metaData;
+        private final String fn = Localization.lang("file");
+        private final JRadioButton autoSetUnset = new JRadioButton(
+                Localization.lang("Autoset %0 links. Do not overwrite existing links.", fn), true);
+        private final JRadioButton autoSetAll = new JRadioButton(
+                Localization.lang("Autoset %0 links. Allow overwriting existing links.", fn), false);
+        private final JRadioButton autoSetNone = new JRadioButton(Localization.lang("Do not autoset"), false);
+        private final JCheckBox checkLinks = new JCheckBox(Localization.lang("Check existing %0 links", fn), true);
 
 
         public OptionsDialog(JFrame parent, MetaData metaData) {
             super(parent, Localization.lang("Synchronize %0 links", Globals.FILE_FIELD.toUpperCase()), true);
             this.metaData = metaData;
-            final String fn = Localization.lang("file");
             ok.addActionListener(e -> {
                 canceled = false;
                 dispose();
@@ -305,10 +308,6 @@ public class SynchronizeFileField extends AbstractWorker {
             im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
             am.put("close", closeAction);
 
-            autoSetUnset = new JRadioButton(Localization.lang("Autoset %0 links. Do not overwrite existing links.", fn), true);
-            autoSetAll = new JRadioButton(Localization.lang("Autoset %0 links. Allow overwriting existing links.", fn), false);
-            autoSetNone = new JRadioButton(Localization.lang("Do not autoset"), false);
-            checkLinks = new JCheckBox(Localization.lang("Check existing %0 links", fn), true);
             ButtonGroup bg = new ButtonGroup();
             bg.add(autoSetUnset);
             bg.add(autoSetNone);

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -1914,10 +1914,9 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
             LOGGER.debug(Globals.focusListener.getFocused().toString());
             JComponent source = Globals.focusListener.getFocused();
-            try {
-                source.getActionMap().get(command).actionPerformed(new ActionEvent(source, 0, command));
-            } catch (NullPointerException ex) {
-                // No component is focused, so we do nothing.
+            Action action = source.getActionMap().get(command);
+            if (action != null) {
+                action.actionPerformed(new ActionEvent(source, 0, command));
             }
         }
     }

--- a/src/main/java/net/sf/jabref/importer/fetcher/ACMPortalFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/ACMPortalFetcher.java
@@ -41,6 +41,7 @@ import java.net.ConnectException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -326,7 +327,8 @@ public class ACMPortalFetcher implements PreviewEntryFetcher {
             // set user-agent to avoid being blocked as a crawler
             connection.addRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0");
             Collection<BibEntry> items = null;
-            try(BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+            try (BufferedReader in = new BufferedReader(
+                    new InputStreamReader(connection.getInputStream(), Charset.forName("UTF-8")))) {
                 items = BibtexParser.parse(in).getDatabase().getEntries();
             } catch (IOException e) {
                 LOGGER.info("Download of BibTeX information from ACM Portal failed.", e);

--- a/src/main/java/net/sf/jabref/importer/fetcher/ADSFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/ADSFetcher.java
@@ -39,6 +39,7 @@ import javax.xml.stream.XMLStreamReader;
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.Charset;
 
 /**
  *
@@ -104,7 +105,8 @@ public class ADSFetcher implements EntryFetcher {
             URL ADSUrl = new URL(url + "&data_type=BIBTEX");
             HttpURLConnection ADSConnection = (HttpURLConnection) ADSUrl.openConnection();
             ADSConnection.setRequestProperty("User-Agent", "JabRef");
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(ADSConnection.getInputStream()))) {
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(ADSConnection.getInputStream(), Charset.forName("ISO-8859-1")))) {
                 ParserResult pr = BibtexParser.parse(reader);
                 return pr.getDatabase();
             }

--- a/src/main/java/net/sf/jabref/importer/fetcher/INSPIREFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/INSPIREFetcher.java
@@ -33,6 +33,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -117,7 +118,8 @@ public class INSPIREFetcher implements EntryFetcher {
             conn.setRequestProperty("User-Agent", "JabRef");
             InputStream inputStream = conn.getInputStream();
 
-            try (INSPIREBibtexFilterReader reader = new INSPIREBibtexFilterReader(new InputStreamReader(inputStream))) {
+            try (INSPIREBibtexFilterReader reader = new INSPIREBibtexFilterReader(
+                    new InputStreamReader(inputStream, Charset.forName("UTF-8")))) {
 
                 ParserResult pr = BibtexParser.parse(reader);
 

--- a/src/test/java/net/sf/jabref/FileBasedTestCase.java
+++ b/src/test/java/net/sf/jabref/FileBasedTestCase.java
@@ -38,6 +38,8 @@ public class FileBasedTestCase {
         // Create file structure
         try {
             root = FileBasedTestHelper.createTempDir("UtilFindFileTest");
+            
+            Assert.assertNotNull(root);
 
             Globals.prefs.put("pdfDirectory", root.getPath());
 

--- a/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
@@ -242,7 +242,8 @@ public class XMPUtilTest {
     @After
     public void tearDown() {
         if (!pdfFile.delete()) {
-            System.err.println("Error: Cannot delete temporary file (already deleted).");
+            System.err
+                    .println("Note: Cannot delete temporary file (already deleted so the corresponding test passed).");
         }
 
         prefs.putBoolean("useXmpPrivacyFilter", use);
@@ -744,6 +745,8 @@ public class XMPUtilTest {
     }
 
     public void assertEqualsBibtexEntry(BibEntry expected, BibEntry actual) {
+        Assert.assertNotNull(expected);
+        Assert.assertNotNull(actual);
         Assert.assertEquals(expected.getCiteKey(), actual.getCiteKey());
         Assert.assertEquals(expected.getType(), actual.getType());
 


### PR DESCRIPTION
The most important consequences:

* The entry count when synchronizing file links is correct again (and the database is marked as modified).

* The correct (i.e. current) encoding is hard coded for ACM, ADS and Inspire fetchers.
