### PR TITLE
Web Search: display only the name of the database

### DIFF
--- a/src/main/resources/l10n/Menu_en.properties
+++ b/src/main/resources/l10n/Menu_en.properties
@@ -108,7 +108,7 @@ Write_XMP-metadata_to_PDFs=Write_XMP-metadata_to_PDFs
 Set/clear_fields=Set/clear_fields
 
 Export_selected_entries=Export_selected_entries
-Fetch_ArXiv.org=Fetch_ArXiv.org
+Fetch_ArXiv.org=ArXiv.org
 Sessions=Sessions
 
 Save_all=Save_all
@@ -123,7 +123,7 @@ Connect_to_external_SQL_database=Connect_to_external_SQL_database
 Export_to_external_SQL_database=Export_to_external_SQL_database
 Search_JSTOR=Search_JSTOR
 Fetch_SPIRES=Fetch_SPIRES
-Fetch_INSPIRE=Fetch_INSPIRE
+Fetch_INSPIRE=INSPIRE
 Search_Medline=Search_Medline
 Import_from_external_SQL_database=Import_from_external_SQL_database
 Focus_entry_table=Focus_entry_table


### PR DESCRIPTION
Currently, in the Web Search, "Fetch Arxiv.org" and "Fetch INSPIRE" were displayed. For the other databases, only the name is displayed, which is sufficient