### PR TITLE
Fixed #492: All text is copied if nothing is marked and preview of pa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Moved default bibliography mode to general preferences tab
 - Added Ordinal formatter (1 -> 1st etc)
 
+- [#492](https://github.com/JabRef/jabref/issues/492): If no text is marked, the whole field is copied. Preview of pasted text in tool tip
 
 ### Fixed
 - Fixed [#621](https://github.com/JabRef/jabref/issues/621) and [#669](https://github.com/JabRef/jabref/issues/669): Encoding and preamble now end with newline.

--- a/src/main/java/net/sf/jabref/groups/GroupTreeCellRenderer.java
+++ b/src/main/java/net/sf/jabref/groups/GroupTreeCellRenderer.java
@@ -94,10 +94,7 @@ public class GroupTreeCellRenderer extends DefaultTreeCellRenderer {
                 }
             }
         }
-        String name = group.getName();
-        if (name.length() > GroupTreeCellRenderer.MAX_DISPLAYED_LETTERS) {
-            name = name.substring(0, GroupTreeCellRenderer.MAX_DISPLAYED_LETTERS - 2) + "...";
-        }
+        String name = StringUtil.limitStringLength(group.getName(), GroupTreeCellRenderer.MAX_DISPLAYED_LETTERS);
         StringBuilder sb = new StringBuilder(60);
         sb.append("<html>");
         if (red) {

--- a/src/main/java/net/sf/jabref/gui/actions/CopyAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/CopyAction.java
@@ -23,9 +23,12 @@ public class CopyAction extends AbstractAction {
     @Override
     public void actionPerformed(ActionEvent e) {
         if (field != null) {
-            String data = field.getSelectedText();
-            if ((data != null) && !data.isEmpty()) {
-                    ClipBoardManager.CLIPBOARD.setClipboardContents(data);
+            String selectedText = field.getSelectedText();
+            String allText = field.getText();
+            if ((selectedText != null) && !selectedText.isEmpty()) {
+                ClipBoardManager.CLIPBOARD.setClipboardContents(selectedText);
+            } else if ((allText != null) && !allText.isEmpty()) {
+                ClipBoardManager.CLIPBOARD.setClipboardContents(allText);
             }
         }
     }

--- a/src/main/java/net/sf/jabref/gui/fieldeditors/contextmenu/FieldTextMenu.java
+++ b/src/main/java/net/sf/jabref/gui/fieldeditors/contextmenu/FieldTextMenu.java
@@ -18,16 +18,16 @@ import net.sf.jabref.logic.formatter.bibtexfields.AuthorsFormatter;
 public class FieldTextMenu implements MouseListener {
     private final FieldEditor field;
     private final JPopupMenu inputMenu = new JPopupMenu();
-    private final CopyAction copyAct;
-    private final PasteAction pasteAct;
+    private final CopyAction copyAction;
+    private final PasteAction pasteAction;
 
     private static final int MAX_PASTE_PREVIEW_LENGTH = 20;
 
 
     public FieldTextMenu(FieldEditor fieldComponent) {
         field = fieldComponent;
-        copyAct = new CopyAction((JTextComponent) field);
-        pasteAct = new PasteAction((JTextComponent) field);
+        copyAction = new CopyAction((JTextComponent) field);
+        pasteAction = new PasteAction((JTextComponent) field);
         initMenu();
     }
 
@@ -61,31 +61,31 @@ public class FieldTextMenu implements MouseListener {
                 // enable/disable copy to clipboard if selected text available
                 String txt = field.getSelectedText();
                 String allTxt = field.getText();
-                boolean cStat = false;
+                boolean copyStatus = false;
                 if (((txt != null) && (!txt.isEmpty())) || ((allTxt != null) && !allTxt.isEmpty())) {
-                    cStat = true;
+                    copyStatus = true;
                 }
 
-                copyAct.setEnabled(cStat);
+                copyAction.setEnabled(copyStatus);
 
                 String data = ClipBoardManager.CLIPBOARD.getClipboardContents();
-                boolean pStat = false;
+                boolean pasteStatus = false;
                 if (!data.isEmpty()) {
-                    pStat = true;
-                    pasteAct.putValue(Action.SHORT_DESCRIPTION, Localization.lang("Paste from clipboard") + ": "
+                    pasteStatus = true;
+                    pasteAction.putValue(Action.SHORT_DESCRIPTION, Localization.lang("Paste from clipboard") + ": "
                             + StringUtil.limitStringLength(data, MAX_PASTE_PREVIEW_LENGTH));
                 } else {
-                    pasteAct.putValue(Action.SHORT_DESCRIPTION, Localization.lang("Paste from clipboard"));
+                    pasteAction.putValue(Action.SHORT_DESCRIPTION, Localization.lang("Paste from clipboard"));
                 }
-                pasteAct.setEnabled(pStat);
+                pasteAction.setEnabled(pasteStatus);
                 inputMenu.show(e.getComponent(), e.getX(), e.getY());
             }
         }
     }
 
     private void initMenu() {
-        inputMenu.add(pasteAct);
-        inputMenu.add(copyAct);
+        inputMenu.add(pasteAction);
+        inputMenu.add(copyAction);
         inputMenu.addSeparator();
         inputMenu.add(new ReplaceAction());
 

--- a/src/main/java/net/sf/jabref/gui/fieldeditors/contextmenu/FieldTextMenu.java
+++ b/src/main/java/net/sf/jabref/gui/fieldeditors/contextmenu/FieldTextMenu.java
@@ -1,6 +1,5 @@
 package net.sf.jabref.gui.fieldeditors.contextmenu;
 
-import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
@@ -8,20 +7,27 @@ import java.awt.event.MouseListener;
 import javax.swing.*;
 import javax.swing.text.JTextComponent;
 
+import net.sf.jabref.gui.ClipBoardManager;
 import net.sf.jabref.gui.actions.CopyAction;
 import net.sf.jabref.gui.actions.PasteAction;
 import net.sf.jabref.gui.fieldeditors.FieldEditor;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.logic.formatter.bibtexfields.AuthorsFormatter;
 
 public class FieldTextMenu implements MouseListener {
     private final FieldEditor field;
     private final JPopupMenu inputMenu = new JPopupMenu();
     private final CopyAction copyAct;
+    private final PasteAction pasteAct;
+
+    private static final int MAX_PASTE_PREVIEW_LENGTH = 20;
+
 
     public FieldTextMenu(FieldEditor fieldComponent) {
         field = fieldComponent;
         copyAct = new CopyAction((JTextComponent) field);
+        pasteAct = new PasteAction((JTextComponent) field);
         initMenu();
     }
 
@@ -54,18 +60,31 @@ public class FieldTextMenu implements MouseListener {
 
                 // enable/disable copy to clipboard if selected text available
                 String txt = field.getSelectedText();
+                String allTxt = field.getText();
                 boolean cStat = false;
-                if ((txt != null) && !txt.isEmpty()) {
+                if (((txt != null) && (!txt.isEmpty())) || ((allTxt != null) && !allTxt.isEmpty())) {
                     cStat = true;
                 }
+
                 copyAct.setEnabled(cStat);
+
+                String data = ClipBoardManager.CLIPBOARD.getClipboardContents();
+                boolean pStat = false;
+                if (!data.isEmpty()) {
+                    pStat = true;
+                    pasteAct.putValue(Action.SHORT_DESCRIPTION, Localization.lang("Paste from clipboard") + ": "
+                            + StringUtil.limitStringLength(data, MAX_PASTE_PREVIEW_LENGTH));
+                } else {
+                    pasteAct.putValue(Action.SHORT_DESCRIPTION, Localization.lang("Paste from clipboard"));
+                }
+                pasteAct.setEnabled(pStat);
                 inputMenu.show(e.getComponent(), e.getX(), e.getY());
             }
         }
     }
 
     private void initMenu() {
-        inputMenu.add(new PasteAction((Component) field));
+        inputMenu.add(pasteAct);
         inputMenu.add(copyAct);
         inputMenu.addSeparator();
         inputMenu.add(new ReplaceAction());

--- a/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
@@ -553,4 +553,16 @@ public class StringUtil {
         }
         return result.toString();
     }
+
+    public static String limitStringLength(String s, int maxLength) {
+        if (s == null) {
+            return null;
+        }
+    
+        if (s.length() <= maxLength) {
+            return s;
+        }
+    
+        return s.substring(0, maxLength - 3) + "...";
+    }
 }

--- a/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
@@ -533,19 +533,19 @@ public class StringUtil {
      */
     public static String quote(String toQuote, String specials, char quoteChar) {
         if (toQuote == null) {
-            return null;
+            return "";
         }
-    
+
         StringBuilder result = new StringBuilder();
         char c;
         boolean isSpecial;
         for (int i = 0; i < toQuote.length(); ++i) {
             c = toQuote.charAt(i);
-    
+
             isSpecial = (c == quoteChar);
             // If non-null specials performs logic-or with specials.indexOf(c) >= 0
             isSpecial |= ((specials != null) && (specials.indexOf(c) >= 0));
-    
+
             if (isSpecial) {
                 result.append(quoteChar);
             }
@@ -556,13 +556,13 @@ public class StringUtil {
 
     public static String limitStringLength(String s, int maxLength) {
         if (s == null) {
-            return null;
+            return "";
         }
-    
+
         if (s.length() <= maxLength) {
             return s;
         }
-    
+
         return s.substring(0, maxLength - 3) + "...";
     }
 }

--- a/src/main/java/net/sf/jabref/pdfimport/ImportDialog.java
+++ b/src/main/java/net/sf/jabref/pdfimport/ImportDialog.java
@@ -22,6 +22,7 @@ import com.jgoodies.forms.layout.FormLayout;
 import net.sf.jabref.Globals;
 import net.sf.jabref.gui.preftabs.ImportSettingsTab;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.strings.StringUtil;
 
 import javax.swing.*;
 
@@ -104,11 +105,7 @@ public class ImportDialog extends JDialog {
             this.radioButtononlyAttachPDF.setEnabled(false);
         }
         String name = new File(fileName).getName();
-        if (name.length() < 34) {
-            labelFileName.setText(name);
-        } else {
-            labelFileName.setText(new File(fileName).getName().substring(0, 33) + "...");
-        }
+        labelFileName.setText(StringUtil.limitStringLength(name, 34));
         this.setTitle(Localization.lang("Import_Metadata_From_PDF"));
 
         setModal(true);

--- a/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
@@ -245,7 +245,7 @@ public class StringUtilTest {
 
     @Test
     public void testQuoteNullString() {
-        assertNull(StringUtil.quote(null, ";", ':'));
+        assertEquals("", StringUtil.quote(null, ";", ':'));
     }
 
     @Test
@@ -271,7 +271,7 @@ public class StringUtilTest {
 
     @Test
     public void testLimitStringLengthNullInput() {
-        assertNull(StringUtil.limitStringLength(null, 10));
+        assertEquals("", StringUtil.limitStringLength(null, 10));
     }
 
 }

--- a/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
@@ -258,4 +258,20 @@ public class StringUtilTest {
         assertEquals("a::b:%c:;", StringUtil.quote("a:b%c;", "%;", ':'));
     }
 
+    @Test
+    public void testLimitStringLengthShort() {
+        assertEquals("Test", StringUtil.limitStringLength("Test", 20));
+    }
+
+    @Test
+    public void testLimitStringLengthLimiting() {
+        assertEquals("TestTes...", StringUtil.limitStringLength("TestTestTestTestTest", 10));
+        assertEquals(10, StringUtil.limitStringLength("TestTestTestTestTest", 10).length());
+    }
+
+    @Test
+    public void testLimitStringLengthNullInput() {
+        assertNull(StringUtil.limitStringLength(null, 10));
+    }
+
 }


### PR DESCRIPTION
Fixed #492

When nothing is selected the whole field is copied. If the field is empty, the right click copy item is disabled.

Preview of text to be pasted in tool tip. Now maximum 20 characters. Should it be longer?