### PR TITLE
Fixes the export of more than one entry through the connection option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Fixed [#743](https://github.com/JabRef/jabref/issues/743): Logger not configured when JAR is started
 - Fixed [#822](https://github.com/JabRef/jabref/issues/822):OSX - Exception when adding the icon to the dock
 
+- Fixed [#685](https://github.com/JabRef/jabref/issues/685): Fixed MySQL exporting for more than one entry
 
 ### Removed
 - Fixed [#627](https://github.com/JabRef/jabref/issues/627): The pdf field is removed from the export formats, use the file field

--- a/src/main/java/net/sf/jabref/sql/DBStrings.java
+++ b/src/main/java/net/sf/jabref/sql/DBStrings.java
@@ -33,6 +33,7 @@ public class DBStrings {
     private String database;
     private String username;
     private String password;
+    private String dbParameters = "";
 
     private List<String> serverTypes;
     private boolean isInitialized;
@@ -124,6 +125,25 @@ public class DBStrings {
     }
 
     /**
+     * Returns the database parameters set
+     * @return dbParameters: The concatenated parameters
+     */
+    public String getDbParameters() {
+        return dbParameters;
+    }
+
+    /**
+     * Add server specific database parameter(s) <br>
+     * Multiple parameters must be concatenated in the format <br>
+     * {@code ?Parameter1=value&parameter2=value2}
+     * @param dbParameter The concatendated parameter
+     */
+    public void setDbParameters(String dbParameters) {
+        this.dbParameters = dbParameters;
+    }
+
+
+    /**
      * Store these db strings into JabRef preferences.
      */
     public void storeToPreferences() {
@@ -132,4 +152,6 @@ public class DBStrings {
         Globals.prefs.put(JabRefPreferences.DB_CONNECT_DATABASE, getDatabase());
         Globals.prefs.put(JabRefPreferences.DB_CONNECT_USERNAME, getUsername());
     }
+
+
 }

--- a/src/main/java/net/sf/jabref/sql/SQLUtil.java
+++ b/src/main/java/net/sf/jabref/sql/SQLUtil.java
@@ -228,7 +228,7 @@ final public class SQLUtil {
     public static String createJDBCurl(DBStrings dbStrings, boolean withDBName) {
         String url;
         url = "jdbc:" + dbStrings.getServerType().toLowerCase() + "://" + dbStrings.getServerHostname()
-                + (withDBName ? '/' + dbStrings.getDatabase() : "");
+                + (withDBName ? '/' + dbStrings.getDatabase() : "") + dbStrings.getDbParameters();
         return url;
     }
 

--- a/src/main/java/net/sf/jabref/sql/exporter/MySQLExporter.java
+++ b/src/main/java/net/sf/jabref/sql/exporter/MySQLExporter.java
@@ -36,6 +36,7 @@ import net.sf.jabref.sql.SQLUtil;
 final public class MySQLExporter extends DBExporter {
 
     private static MySQLExporter instance;
+    private static final String OPT_ALLOW_MULTI_QUERIES = "?allowMultiQueries=true";
 
 
     private MySQLExporter() {
@@ -55,15 +56,19 @@ final public class MySQLExporter extends DBExporter {
     @Override
     public Connection connectToDB(DBStrings dbstrings) throws Exception {
         this.dbStrings = dbstrings;
+
+        dbStrings.setDbParameters(OPT_ALLOW_MULTI_QUERIES);
         String url = SQLUtil.createJDBCurl(dbstrings, false);
         String drv = "com.mysql.jdbc.Driver";
+
 
         Class.forName(drv).newInstance();
         Connection conn = DriverManager.getConnection(url,
                 dbstrings.getUsername(), dbstrings.getPassword());
         SQLUtil.processQuery(conn, "CREATE DATABASE IF NOT EXISTS `"
                 + dbStrings.getDatabase() + '`');
-        SQLUtil.processQuery(conn, "USE `" + dbStrings.getDatabase() + '`');
+
+        conn.setCatalog(dbStrings.getDatabase());
         return conn;
     }
 


### PR DESCRIPTION
Added ability to add server specific connection parameters
Using setCatalog instead of use database (recommended in mysql doc)
For #685 