### PR TITLE
Add a few cleanup formatters

### DIFF
--- a/src/main/java/net/sf/jabref/importer/HTMLConverter.java
+++ b/src/main/java/net/sf/jabref/importer/HTMLConverter.java
@@ -15,6 +15,7 @@
  */
 package net.sf.jabref.importer;
 
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -45,9 +46,7 @@ public class HTMLConverter implements LayoutFormatter, Formatter {
     }
 
     public String formatUnicode(String text) {
-        if (text == null) {
-            return null;
-        }
+        Objects.requireNonNull(text);
 
         if (text.isEmpty()) {
             return text;
@@ -94,9 +93,7 @@ public class HTMLConverter implements LayoutFormatter, Formatter {
 
     @Override
     public String format(String text) {
-        if (text == null) {
-            return null;
-        }
+        Objects.requireNonNull(text);
 
         if (text.isEmpty()) {
             return text;

--- a/src/main/java/net/sf/jabref/logic/formatter/Formatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/Formatter.java
@@ -13,22 +13,24 @@ public interface Formatter {
     /**
      * Returns a human readable name of the formatter usable for e.g. in the GUI
      *
-     * @return the name of the formatter
+     * @return the name of the formatter, always not null
      */
     String getName();
 
 
     /**
      * Returns a unique key for the formatter that can be used for its identification
-     * @return
+     * @return the key of the formatter, always not null
      */
     String getKey();
 
     /**
      * Formats a field value by with a particular formatter transformation.
      *
+     * Calling this method with a null argument results in a NullPointerException.
+     *
      * @param value the input String
-     * @return the formatted output String
+     * @return the formatted output String, always not null
      */
     String format(String value);
 }

--- a/src/main/java/net/sf/jabref/logic/formatter/IdentityFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/IdentityFormatter.java
@@ -1,5 +1,7 @@
 package net.sf.jabref.logic.formatter;
 
+import java.util.Objects;
+
 /**
  * It may seem useless, but is needed as a fallback option
  */
@@ -17,6 +19,7 @@ public class IdentityFormatter implements Formatter {
 
     @Override
     public String format(String value) {
+        Objects.requireNonNull(value);
         return value;
     }
 }

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/MonthFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/MonthFormatter.java
@@ -3,6 +3,8 @@ package net.sf.jabref.logic.formatter.bibtexfields;
 import net.sf.jabref.logic.formatter.Formatter;
 import net.sf.jabref.model.entry.MonthUtil;
 
+import java.util.Objects;
+
 public class MonthFormatter implements Formatter {
 
     @Override
@@ -17,6 +19,7 @@ public class MonthFormatter implements Formatter {
 
     @Override
     public String format(String value) {
+        Objects.requireNonNull(value);
         MonthUtil.Month month = MonthUtil.getMonth(value);
         if (month.isValid()) {
             return month.bibtexFormat;

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/PageNumbersFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/PageNumbersFormatter.java
@@ -2,6 +2,7 @@ package net.sf.jabref.logic.formatter.bibtexfields;
 
 import net.sf.jabref.logic.formatter.Formatter;
 
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -48,9 +49,10 @@ public class PageNumbersFormatter implements Formatter {
      */
     @Override
     public String format(String value) {
+        Objects.requireNonNull(value);
 
-        // nothing to do
-        if ((value == null) || value.isEmpty()) {
+        if (value.isEmpty()) {
+            // nothing to do
             return value;
         }
 

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/RemoveBracesFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/RemoveBracesFormatter.java
@@ -1,0 +1,62 @@
+package net.sf.jabref.logic.formatter.bibtexfields;
+
+import net.sf.jabref.logic.formatter.Formatter;
+
+import java.util.Objects;
+
+public class RemoveBracesFormatter implements Formatter {
+
+    @Override
+    public String getName() {
+        return "Remove enclosing double braces";
+    }
+
+    @Override
+    public String getKey() {
+        return "RemoveBracesFormatter";
+    }
+
+    @Override
+    public String format(String value) {
+        Objects.requireNonNull(value);
+
+        String formatted = value;
+        while (formatted.length() >= 2 && formatted.charAt(0) == '{' && formatted.charAt(formatted.length() - 1)
+                == '}') {
+            String trimmed = formatted.substring(1, formatted.length() - 1);
+
+            // It could be that the removed braces were not matching
+            // For example, "{A} test {B}" results in "A} test {B"
+            // In this case, trimmed has a closing } without an opening { before that
+            if(hasNegativeBraceCount(trimmed)) {
+                return formatted;
+            } else {
+                formatted = trimmed;
+            }
+        }
+        return formatted;
+    }
+
+    /**
+     * Check if a string at any point has had more ending } braces than opening { ones.
+     * Will e.g. return true for the string "DNA} blahblal {EPA"
+     *
+     * @param value The string to check.
+     * @return true if at any index the brace count is negative.
+     */
+    private boolean hasNegativeBraceCount(String value) {
+        int braceCount = 0;
+        for (int index = 0; index < value.length(); index++) {
+            char charAtIndex = value.charAt(index);
+            if (charAtIndex == '{') {
+                braceCount++;
+            } else if (charAtIndex == '}') {
+                braceCount--;
+            }
+            if (braceCount < 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/SuperscriptFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/SuperscriptFormatter.java
@@ -16,6 +16,8 @@
 package net.sf.jabref.logic.formatter.bibtexfields;
 
 import net.sf.jabref.logic.formatter.Formatter;
+
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -50,9 +52,10 @@ public class SuperscriptFormatter implements Formatter {
      */
     @Override
     public String format(String value) {
+        Objects.requireNonNull(value);
 
-        // nothing to do
-        if ((value == null) || value.isEmpty()) {
+        if (value.isEmpty()) {
+            // nothing to do
             return value;
         }
 

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/TrimFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/TrimFormatter.java
@@ -1,0 +1,25 @@
+package net.sf.jabref.logic.formatter.bibtexfields;
+
+import net.sf.jabref.logic.formatter.Formatter;
+import net.sf.jabref.model.entry.MonthUtil;
+
+import java.util.Objects;
+
+public class TrimFormatter implements Formatter {
+
+    @Override
+    public String getName() {
+        return "Trim whitespace";
+    }
+
+    @Override
+    public String getKey() {
+        return "TrimFormatter";
+    }
+
+    @Override
+    public String format(String value) {
+        Objects.requireNonNull(value);
+        return value.trim();
+    }
+}

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/UnitFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/UnitFormatter.java
@@ -16,6 +16,7 @@
 package net.sf.jabref.logic.formatter.bibtexfields;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import net.sf.jabref.logic.formatter.Formatter;
 import net.sf.jabref.logic.l10n.Localization;
@@ -129,7 +130,8 @@ public class UnitFormatter implements Formatter {
 
     @Override
     public String format(String text) {
-        if ((text == null) || text.isEmpty()) {
+        Objects.requireNonNull(text);
+        if (text.isEmpty()) {
             return text;
         }
         return format(text, UnitFormatter.UNIT_COMBINATIONS);

--- a/src/main/java/net/sf/jabref/logic/formatter/casechanger/CaseKeeper.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/casechanger/CaseKeeper.java
@@ -16,6 +16,7 @@
 package net.sf.jabref.logic.formatter.casechanger;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import net.sf.jabref.logic.formatter.Formatter;
 import net.sf.jabref.logic.l10n.Localization;
@@ -35,7 +36,9 @@ public class CaseKeeper implements Formatter {
 
     @Override
     public String format(String text) {
-        if ((text == null) || text.isEmpty()) {
+        Objects.requireNonNull(text);
+
+        if (text.isEmpty()) {
             return text;
         }
         final CaseKeeperList list = new CaseKeeperList();

--- a/src/main/java/net/sf/jabref/logic/formatter/minifier/AuthorsMinifier.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/minifier/AuthorsMinifier.java
@@ -2,6 +2,8 @@ package net.sf.jabref.logic.formatter.minifier;
 
 import net.sf.jabref.logic.formatter.Formatter;
 
+import java.util.Objects;
+
 /**
  * Replaces three or more authors with and others
  */
@@ -24,8 +26,10 @@ public class AuthorsMinifier implements Formatter {
      */
     @Override
     public String format(String value) {
-        // nothing to do
-        if ((value == null) || value.isEmpty()) {
+        Objects.requireNonNull(value);
+
+        if (value.isEmpty()) {
+            // nothing to do
             return value;
         }
 

--- a/src/test/java/net/sf/jabref/importer/HTMLConverterTest.java
+++ b/src/test/java/net/sf/jabref/importer/HTMLConverterTest.java
@@ -25,11 +25,6 @@ public class HTMLConverterTest {
     }
 
     @Test
-    public void testHTMLNull() {
-        assertEquals(null, conv.format(null));
-    }
-
-    @Test
     public void testHTMLEmpty() {
         assertEquals("", conv.format(""));
     }
@@ -72,9 +67,9 @@ public class HTMLConverterTest {
         assertEquals("a", conv.formatUnicode("a"));
     }
 
-    @Test
+    @Test(expected = NullPointerException.class)
     public void testUnicodeNull() {
-        assertEquals(null, conv.formatUnicode(null));
+        conv.formatUnicode(null);
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/formatter/FormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/FormatterTest.java
@@ -1,0 +1,90 @@
+package net.sf.jabref.logic.formatter;
+
+import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.importer.HTMLConverter;
+import net.sf.jabref.logic.formatter.bibtexfields.*;
+import net.sf.jabref.logic.formatter.casechanger.*;
+import net.sf.jabref.logic.formatter.minifier.AuthorsMinifier;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class FormatterTest {
+
+    @BeforeClass
+    public static void setUp() {
+        Globals.prefs = JabRefPreferences.getInstance();
+    }
+
+    @Test
+    public void getNameReturnsNotNull() {
+        assertNotNull(formatter.getName());
+    }
+
+    @Test
+    public void getNameReturnsNotEmpty() {
+        assertNotEquals("", formatter.getName());
+    }
+
+    @Test
+    public void getKeyReturnsNotNull() {
+        assertNotNull(formatter.getKey());
+    }
+
+    @Test
+    public void getKeyReturnsNotEmpty() {
+        assertNotEquals("", formatter.getKey());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void formatOfNullThrowsException() {
+        formatter.format(null);
+    }
+
+    @Test
+    public void formatOfEmptyStringReturnsEmpty() {
+        assertEquals("", formatter.format(""));
+    }
+
+    @Test
+    public void formatNotReturnsNull() {
+        assertNotNull(formatter.format("string"));
+    }
+
+    public Formatter formatter;
+
+    public FormatterTest(Formatter formatter) {
+        this.formatter = formatter;
+    }
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Collection<Object[]> instancesToTest() {
+        return Arrays.asList(
+                new Object[]{new AuthorsFormatter()},
+                new Object[]{new UpperEachFirstCaseChanger()},
+                new Object[]{new UpperCaseChanger()},
+                new Object[]{new MonthFormatter()},
+                new Object[]{new LatexFormatter()},
+                new Object[]{new IdentityFormatter()},
+                new Object[]{new UpperFirstCaseChanger()},
+                new Object[]{new AuthorsMinifier()},
+                new Object[]{new DateFormatter()},
+                new Object[]{new TitleCaseChanger()},
+                new Object[]{new CaseKeeper()},
+                new Object[]{new PageNumbersFormatter()},
+                new Object[]{new LowerCaseChanger()},
+                new Object[]{new TrimFormatter()},
+                new Object[]{new HTMLConverter()},
+                new Object[]{new SuperscriptFormatter()},
+                new Object[]{new UnitFormatter()}
+        );
+    }
+}

--- a/src/test/java/net/sf/jabref/logic/formatter/FormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/FormatterTest.java
@@ -84,7 +84,8 @@ public class FormatterTest {
                 new Object[]{new TrimFormatter()},
                 new Object[]{new HTMLConverter()},
                 new Object[]{new SuperscriptFormatter()},
-                new Object[]{new UnitFormatter()}
+                new Object[]{new UnitFormatter()},
+                new Object[]{new RemoveBracesFormatter()}
         );
     }
 }

--- a/src/test/java/net/sf/jabref/logic/formatter/PageNumbersFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/PageNumbersFormatterTest.java
@@ -53,7 +53,6 @@ public class PageNumbersFormatterTest {
     @Test
     public void formatPageNumbersEmptyFields() {
         expectCorrect("", "");
-        expectCorrect(null, null);
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/formatter/SuperscriptFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/SuperscriptFormatterTest.java
@@ -38,7 +38,6 @@ public class SuperscriptFormatterTest {
     @Test
     public void replaceSuperscriptsEmptyFields() {
         expectCorrect("", "");
-        expectCorrect(null, null);
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/RemoveBracesFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/RemoveBracesFormatterTest.java
@@ -1,0 +1,70 @@
+package net.sf.jabref.logic.formatter.bibtexfields;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class RemoveBracesFormatterTest {
+
+    @Test
+    public void formatRemovesSingleEnclosingBraces() {
+        RemoveBracesFormatter formatter = new RemoveBracesFormatter();
+        assertEquals("test", formatter.format("{test}"));
+    }
+
+    @Test
+    public void formatKeepsUnmatchedBracesAtBeginning() {
+        RemoveBracesFormatter formatter = new RemoveBracesFormatter();
+        assertEquals("{test", formatter.format("{test"));
+    }
+
+    @Test
+    public void formatKeepsUnmatchedBracesAtEnd() {
+        RemoveBracesFormatter formatter = new RemoveBracesFormatter();
+        assertEquals("test}", formatter.format("test}"));
+    }
+
+    @Test
+    public void formatKeepsShortString() {
+        RemoveBracesFormatter formatter = new RemoveBracesFormatter();
+        assertEquals("t", formatter.format("t"));
+    }
+
+    @Test
+    public void formatKeepsEmptyString() {
+        RemoveBracesFormatter formatter = new RemoveBracesFormatter();
+        assertEquals("", formatter.format(""));
+    }
+
+    @Test
+    public void formatRemovesDoubleEnclosingBraces() {
+        RemoveBracesFormatter formatter = new RemoveBracesFormatter();
+        assertEquals("test", formatter.format("{{test}}"));
+    }
+
+    @Test
+    public void formatRemovesTripleEnclosingBraces() {
+        RemoveBracesFormatter formatter = new RemoveBracesFormatter();
+        assertEquals("test", formatter.format("{{{test}}}"));
+    }
+
+    @Test
+    public void formatKeepsNonMatchingBraces() {
+        RemoveBracesFormatter formatter = new RemoveBracesFormatter();
+        assertEquals("{A} and {B}", formatter.format("{A} and {B}"));
+    }
+
+    @Test
+    public void formatRemovesOnlyMatchingBraces() {
+        RemoveBracesFormatter formatter = new RemoveBracesFormatter();
+        assertEquals("{A} and {B}", formatter.format("{{A} and {B}}"));
+    }
+
+    @Test
+    public void formatDoesNotRemoveBracesInBrokenString() {
+        RemoveBracesFormatter formatter = new RemoveBracesFormatter();
+        // We opt here for a conservative approach although one could argue that "A} and {B}" is also a valid return
+        assertEquals("{A} and {B}}", formatter.format("{A} and {B}}"));
+    }
+}

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/TrimFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/TrimFormatterTest.java
@@ -1,0 +1,26 @@
+package net.sf.jabref.logic.formatter.bibtexfields;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TrimFormatterTest {
+
+    @Test
+    public void formatTrimsWhitespaceBefore() throws Exception {
+        TrimFormatter formatter = new TrimFormatter();
+        assertEquals("nonspace", formatter.format("  nonspace"));
+    }
+
+    @Test
+    public void formatTrimsWhitespaceAfter() throws Exception {
+        TrimFormatter formatter = new TrimFormatter();
+        assertEquals("nonspace", formatter.format("nonspace   "));
+    }
+
+    @Test
+    public void formatTrimsWhitespaceBeforeAndAfter() throws Exception {
+        TrimFormatter formatter = new TrimFormatter();
+        assertEquals("nonspace", formatter.format("  nonspace   "));
+    }
+}

--- a/src/test/java/net/sf/jabref/logic/formatter/minifier/AuthorsMinifierTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/minifier/AuthorsMinifierTest.java
@@ -36,7 +36,6 @@ public class AuthorsMinifierTest {
     @Test
     public void formatEmptyFields() {
         expectCorrect("", "");
-        expectCorrect(null, null);
     }
 
     private void expectCorrect(String input, String expected) {


### PR DESCRIPTION
This PR adds the following formatters, which are suitable for the new save actions functionality #821:
- TrimFormatter: trims whitespace (as suggested in https://github.com/JabRef/jabref/pull/821#issuecomment-185801238)
- RemoveBracesFormatter: removes enclosing braces (i.e. "{{test}}" -> "test"). Partly implements [kooper #60](https://github.com/koppor/jabref/issues/60). This functionality was previously available under the option "Remove double braces around BibTeX fields when
loading" but was removed from the parser in c2928d2153301b3c5e90db468b53199bc8b1d521.

Also add some tests for all formatters.