### PR TITLE
Fix bug in parsing custom entry types

### DIFF
--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
@@ -22,6 +22,7 @@ import java.io.StringReader;
 import java.util.*;
 
 import net.sf.jabref.*;
+import net.sf.jabref.logic.CustomEntryTypesManager;
 import net.sf.jabref.model.database.KeyCollisionException;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.logic.l10n.Localization;
@@ -262,8 +263,13 @@ public class BibtexParser {
                 .equals(CustomEntryType.ENTRYTYPE_FLAG)) {
             // A custom entry type can also be stored in a
             // "@comment"
-            CustomEntryType typ = parseEntryType(comment);
-            entryTypes.put(typ.getName(), typ);
+            CustomEntryType typ = CustomEntryTypesManager.parseEntryType(comment);
+            if(typ == null) {
+                parserResult.addWarning(Localization.lang("Ill-formed entrytype comment in bib file") + ": " +
+                        comment);
+            } else {
+                entryTypes.put(typ.getName(), typ);
+            }
 
             // custom entry types are always re-written by JabRef and not stored in the file
             dumpTextReadSoFarToString();
@@ -925,28 +931,6 @@ public class BibtexParser {
         if ((character != firstOption) && (character != secondOption)) {
             throw new IOException("Error in line " + line + ": Expected " + firstOption + " or "
                     + secondOption + " but received " + (char) character);
-        }
-    }
-
-    private CustomEntryType parseEntryType(String comment) {
-        try {
-            String rest = comment.substring(CustomEntryType.ENTRYTYPE_FLAG.length());
-            int indexEndOfName = rest.indexOf(':');
-            String fieldsDescription = rest.substring(indexEndOfName + 2);
-
-            int indexEndOfRequiredFields = fieldsDescription.indexOf(']');
-            int indexEndOfOptionalFields = fieldsDescription.indexOf(']', indexEndOfRequiredFields + 1);
-            if (indexEndOfRequiredFields < 4 || indexEndOfOptionalFields < indexEndOfRequiredFields + 6) {
-                throw new IndexOutOfBoundsException();
-            }
-            String name = rest.substring(0, indexEndOfName);
-            String reqFields = fieldsDescription.substring(4, indexEndOfRequiredFields);
-            String optFields = fieldsDescription.substring(indexEndOfRequiredFields + 6, indexEndOfOptionalFields);
-            return new CustomEntryType(name, reqFields, optFields);
-        } catch (IndexOutOfBoundsException ex) {
-            parserResult.addWarning(Localization.lang("Ill-formed entrytype comment in bib file") + ": " +
-                    comment);
-            return null;
         }
     }
 }

--- a/src/main/java/net/sf/jabref/logic/CustomEntryTypesManager.java
+++ b/src/main/java/net/sf/jabref/logic/CustomEntryTypesManager.java
@@ -5,15 +5,12 @@ import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.CustomEntryType;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.entry.EntryType;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
 public class CustomEntryTypesManager {
-    private static final Log LOGGER = LogFactory.getLog(CustomEntryTypesManager.class);
 
     public static final List<EntryType> ALL = new ArrayList<>();
     /**
@@ -51,27 +48,5 @@ public class CustomEntryTypesManager {
         // from preferences. This is necessary if the number of custom types
         // has decreased.
         prefs.purgeCustomEntryTypes(number);
-    }
-
-    public static CustomEntryType parseEntryType(String comment) {
-        try {
-            String rest;
-            rest = comment.substring(CustomEntryType.ENTRYTYPE_FLAG.length());
-            int nPos = rest.indexOf(':');
-            rest = rest.substring(nPos + 2);
-
-            int rPos = rest.indexOf(']');
-            if (rPos < 4) {
-                throw new IndexOutOfBoundsException();
-            }
-            String name = rest.substring(0, nPos);
-            String reqFields = rest.substring(4, rPos);
-            int oPos = rest.indexOf(']', rPos + 1);
-            String optFields = rest.substring(rPos + 6, oPos);
-            return new CustomEntryType(name, reqFields, optFields);
-        } catch (IndexOutOfBoundsException ex) {
-            LOGGER.info("Ill-formed entrytype comment in BibTeX file.", ex);
-            return null;
-        }
     }
 }

--- a/src/main/java/net/sf/jabref/logic/CustomEntryTypesManager.java
+++ b/src/main/java/net/sf/jabref/logic/CustomEntryTypesManager.java
@@ -49,4 +49,23 @@ public class CustomEntryTypesManager {
         // has decreased.
         prefs.purgeCustomEntryTypes(number);
     }
+
+    public static CustomEntryType parseEntryType(String comment) {
+        String rest = comment.substring(CustomEntryType.ENTRYTYPE_FLAG.length());
+        int indexEndOfName = rest.indexOf(':');
+        if(indexEndOfName < 0) {
+            return null;
+        }
+        String fieldsDescription = rest.substring(indexEndOfName + 2);
+
+        int indexEndOfRequiredFields = fieldsDescription.indexOf(']');
+        int indexEndOfOptionalFields = fieldsDescription.indexOf(']', indexEndOfRequiredFields + 1);
+        if (indexEndOfRequiredFields < 4 || indexEndOfOptionalFields < indexEndOfRequiredFields + 6) {
+            return null;
+        }
+        String name = rest.substring(0, indexEndOfName);
+        String reqFields = fieldsDescription.substring(4, indexEndOfRequiredFields);
+        String optFields = fieldsDescription.substring(indexEndOfRequiredFields + 6, indexEndOfOptionalFields);
+        return new CustomEntryType(name, reqFields, optFields);
+    }
 }

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -1788,3 +1788,5 @@ Usage=
 
 Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
 Reset_preferences=
+
+Ill-formed_entrytype_comment_in_bib_file=

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2499,3 +2499,5 @@ Usage=
 
 Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
 Reset_preferences=
+
+Ill-formed_entrytype_comment_in_bib_file=

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2471,4 +2471,4 @@ Unabbreviating...=Unabbreviating...
 Usage=Usage
 
 Are_you_sure_you_want_to_reset_all_settings_to_default_values?=Are_you_sure_you_want_to_reset_all_settings_to_default_values?
-Reset_preferences=Reset_preferences
+Reset_preferences=Reset_preferencesIll-formed_entrytype_comment_in_bib_file=Ill-formed_entrytype_comment_in_bib_file

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2471,4 +2471,5 @@ Unabbreviating...=Unabbreviating...
 Usage=Usage
 
 Are_you_sure_you_want_to_reset_all_settings_to_default_values?=Are_you_sure_you_want_to_reset_all_settings_to_default_values?
-Reset_preferences=Reset_preferencesIll-formed_entrytype_comment_in_bib_file=Ill-formed_entrytype_comment_in_bib_file
+Reset_preferences=Reset_preferences
+Ill-formed_entrytype_comment_in_bib_file=Ill-formed_entrytype_comment_in_bib_file

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -1689,3 +1689,5 @@ Usage=
 
 Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
 Reset_preferences=
+
+Ill-formed_entrytype_comment_in_bib_file=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -2476,3 +2476,5 @@ Usage=
 
 Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
 Reset_preferences=
+
+Ill-formed_entrytype_comment_in_bib_file=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -1728,3 +1728,5 @@ Usage=
 
 Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
 Reset_preferences=
+
+Ill-formed_entrytype_comment_in_bib_file=

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -1711,3 +1711,5 @@ Usage=
 
 Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
 Reset_preferences=
+
+Ill-formed_entrytype_comment_in_bib_file=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -1808,3 +1808,5 @@ Usage=
 
 Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
 Reset_preferences=
+
+Ill-formed_entrytype_comment_in_bib_file=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2483,3 +2483,5 @@ Usage=
 
 Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
 Reset_preferences=
+
+Ill-formed_entrytype_comment_in_bib_file=

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -2483,3 +2483,5 @@ Usage=
 
 Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
 Reset_preferences=
+
+Ill-formed_entrytype_comment_in_bib_file=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -2882,3 +2882,5 @@ Usage=
 
 Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
 Reset_preferences=
+
+Ill-formed_entrytype_comment_in_bib_file=

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -1702,3 +1702,5 @@ Usage=
 
 Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
 Reset_preferences=
+
+Ill-formed_entrytype_comment_in_bib_file=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2483,3 +2483,5 @@ Usage=
 
 Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
 Reset_preferences=
+
+Ill-formed_entrytype_comment_in_bib_file=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -1723,3 +1723,5 @@ Usage=
 
 Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
 Reset_preferences=
+
+Ill-formed_entrytype_comment_in_bib_file=

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -2479,3 +2479,5 @@ Usage=
 
 Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
 Reset_preferences=
+
+Ill-formed_entrytype_comment_in_bib_file=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -2476,3 +2476,5 @@ Usage=
 
 Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
 Reset_preferences=
+
+Ill-formed_entrytype_comment_in_bib_file=

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -6,6 +6,7 @@ import net.sf.jabref.exporter.SaveActions;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexString;
+import net.sf.jabref.model.entry.EntryType;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -13,10 +14,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 
@@ -1311,5 +1309,20 @@ public class BibtexParserTest {
 
         assertEquals("enabled", saveActions.get(0));
         assertEquals("title[LowerCaseChanger]", saveActions.get(1));
+    }
+
+    @Test
+    public void parseRecognizesCustomEntryType() throws IOException {
+        ParserResult result = BibtexParser.parse(
+                new StringReader("@comment{jabref-entrytype: Lecturenotes: req[author;title] opt[language;url]}"));
+
+        Map<String, EntryType> customEntryTypes = result.getEntryTypes();
+
+        assertEquals(1, customEntryTypes.size());
+        assertEquals("Lecturenotes", customEntryTypes.keySet().toArray()[0]);
+        EntryType entryType = customEntryTypes.get("Lecturenotes");
+        assertEquals("Lecturenotes", entryType.getName());
+        assertEquals(Arrays.asList("author", "title"), entryType.getRequiredFields());
+        assertEquals(Arrays.asList("language", "url"), entryType.getOptionalFields());
     }
 }


### PR DESCRIPTION
Fix unreported bug which prevented the parsing of custom entry types.
Also move the custom entry type parsing logic to the parser.

- [ ] Change in CHANGELOG.md described? - No, the bug was not present in 3.2.
- [x] Changes in pull request outlined? (What, why, ...)
- [x] Tests created for changes?
- [x] Tests green?