### PR TITLE
Fix #466: Rename PDF cleanup now also changes case of file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - [#492](https://github.com/JabRef/jabref/issues/492): If no text is marked, the whole field is copied. Preview of pasted text in tool tip
 
 ### Fixed
+- Fixed [#466](https://github.com/JabRef/jabref/issues/466): Rename PDF cleanup now also changes case of file name
 - Fixed [#621](https://github.com/JabRef/jabref/issues/621) and [#669](https://github.com/JabRef/jabref/issues/669): Encoding and preamble now end with newline.
 - Make BibTex parser more robust against missing newlines
 - Fix bug that prevented the import of BibTex entries having only a key as content

--- a/src/main/java/net/sf/jabref/logic/cleanup/RenamePdfCleanup.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/RenamePdfCleanup.java
@@ -79,14 +79,19 @@ public class RenamePdfCleanup implements CleanupJob {
             String newPath = expandedOldFile.get().getParent().concat(System.getProperty("file.separator"))
                     .concat(newFilename.toString());
 
-            if (new File(newPath).exists()) {
+            String expandedOldFilePath = expandedOldFile.get().toString();
+            Boolean pathsDifferOnlyByCase = newPath.equalsIgnoreCase(expandedOldFilePath) && !newPath.equals(
+                    expandedOldFilePath);
+            if (new File(newPath).exists() && ! pathsDifferOnlyByCase) {
                 // we do not overwrite files
+                // Since File.exists is sometimes not case-sensitive, the check pathsDifferOnlyByCase ensures that we
+                // nonetheless rename files to a new name which just differs by case.
                 // TODO: we could check here if the newPath file is linked with the current entry. And if not, we could add a link
                 continue;
             }
 
             //do rename
-            boolean renameSuccessful = FileUtil.renameFile(expandedOldFile.get().toString(), newPath);
+            boolean renameSuccessful = FileUtil.renameFile(expandedOldFilePath, newPath);
 
             if (renameSuccessful) {
                 changed = true;

--- a/src/test/java/net/sf/jabref/logic/cleanup/RenamePdfCleanupTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/RenamePdfCleanupTest.java
@@ -1,0 +1,47 @@
+package net.sf.jabref.logic.cleanup;
+
+import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.logic.journals.JournalAbbreviationRepository;
+import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.model.entry.FileField;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RenamePdfCleanupTest {
+
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+    /**
+     * Test for #466
+     */
+    @Test
+    public void cleanupRenamePdfRenamesFileEvenIfOnlyDifferenceIsCase() throws IOException {
+        Globals.prefs = mock(JabRefPreferences.class);
+        when(Globals.prefs.get("importFileNamePattern")).thenReturn("\\bibtexkey");
+
+        RenamePdfCleanup cleanup = new RenamePdfCleanup(
+                Collections.singletonList(testFolder.getRoot().getAbsolutePath()), false,
+                null, mock(JournalAbbreviationRepository.class));
+
+        File tempFile = testFolder.newFile("toot.tmp");
+        BibEntry entry = new BibEntry();
+        entry.setField(BibEntry.KEY_FIELD, "Toot");
+        FileField.ParsedFileField fileField = new FileField.ParsedFileField("", tempFile.getAbsolutePath(), "");
+        entry.setField("file", FileField.getStringRepresentation(fileField));
+
+        cleanup.cleanup(entry);
+        FileField.ParsedFileField newFileField = new FileField.ParsedFileField("", "Toot.tmp", "");
+        assertEquals(FileField.getStringRepresentation(newFileField), entry.getField("file"));
+    }
+}


### PR DESCRIPTION
Fixes #466.

- [x] Change in CHANGELOG.md described?
- [x] Changes in pull request outlined? (What, why, ...)
- [x] Tests created for changes?
- [x] Tests green?

