### PR TITLE
Pass database to doCleanup to enable resolving of crossref fields at renaming of files

### DIFF
--- a/src/main/java/net/sf/jabref/gui/actions/CleanupAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/CleanupAction.java
@@ -15,6 +15,7 @@
  */
 package net.sf.jabref.gui.actions;
 
+import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
@@ -156,9 +157,10 @@ public class CleanupAction extends AbstractWorker {
      * Runs the cleanup on the entry and records the change.
      */
     private void doCleanup(CleanupPreset preset, BibEntry entry, NamedCompound ce) {
-        // Run cleaner
+        // Create and run cleaner
+        BibDatabaseContext bibDatabaseContext = panel.getBibDatabaseContext();
         CleanupWorker cleaner = new CleanupWorker(preset,
-                panel.getBibDatabaseContext().getMetaData().getFileDirectory(Globals.FILE_FIELD), null,
+                bibDatabaseContext.getMetaData().getFileDirectory(Globals.FILE_FIELD), bibDatabaseContext.getDatabase(),
                 Globals.journalAbbreviationLoader.getRepository());
         List<FieldChange> changes = cleaner.cleanup(entry);
 


### PR DESCRIPTION
This addresses https://github.com/JabRef/jabref/pull/884#issuecomment-189891290.

Replaces `null` by the concrete database at `CleanWorker`.

No tests as #507 is not yet finished.