### PR TITLE
Fix bug in "Find broken file links" integrity check: files relative to the bibfile are now found

### DIFF
--- a/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
@@ -1,7 +1,6 @@
 package net.sf.jabref.logic.integrity;
 
 import net.sf.jabref.BibDatabaseContext;
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.entry.BibEntry;
@@ -123,16 +122,12 @@ public class IntegrityCheck {
                     .collect(Collectors.toList());
 
             for (FileField.ParsedFileField p : parsedFileFields) {
-
-                List<String> fileDirectories = context.getMetaData().getFileDirectory(Globals.FILE_FIELD);
-
-                for (String fileDirectory : fileDirectories) {
-                    Optional<File> file = FileUtil.expandFilename(p.link, fileDirectory);
-                    if ((!file.isPresent()) || !file.get().exists()) {
-                        return Collections.singletonList(new IntegrityMessage(Localization.lang("link should refer to a correct file path"), entry, "file"));
-                    }
+                Optional<File> file = FileUtil.expandFilename(context.getMetaData(), p.link);
+                if ((!file.isPresent()) || !file.get().exists()) {
+                    return Collections.singletonList(
+                            new IntegrityMessage(Localization.lang("link should refer to a correct file path"), entry,
+                                    "file"));
                 }
-
             }
 
             return Collections.emptyList();

--- a/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
@@ -208,7 +208,7 @@ public class FileUtil {
      * Converts a relative filename to an absolute one, if necessary. Returns
      * null if the file does not exist.
      */
-    public static Optional<File> expandFilename(String filename, String dir) {
+    private static Optional<File> expandFilename(String filename, String dir) {
 
         if ((filename == null) || filename.isEmpty()) {
             return Optional.empty();

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -1,14 +1,17 @@
 package net.sf.jabref.logic.integrity;
 
-import net.sf.jabref.BibDatabaseContext;
-import net.sf.jabref.Defaults;
-import net.sf.jabref.MetaData;
+import net.sf.jabref.*;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
+import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -17,6 +20,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 public class IntegrityCheckTest {
+
+    @BeforeClass
+    public static void setUp() {
+        Globals.prefs = JabRefPreferences.getInstance();
+    }
 
     @Test
     public void testUrlChecks() {
@@ -95,7 +103,22 @@ public class IntegrityCheckTest {
         Mockito.when(metaData.getFileDirectory("file")).thenReturn(Collections.singletonList("."));
 
         assertCorrect(createContext("file", ":build.gradle:gradle", metaData));
+        assertCorrect(createContext("file", "description:build.gradle:gradle", metaData));
         assertWrong(createContext("file", ":asflakjfwofja:PDF", metaData));
+    }
+
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+    @Test
+    public void fileCheckFindsFilesRelativeToBibFile() throws IOException {
+        File bibFile = testFolder.newFile("lit.bib");
+        testFolder.newFile("file.pdf");
+
+        MetaData metaData = new MetaData();
+        metaData.setFile(bibFile);
+
+        assertCorrect(createContext("file", ":file.pdf:PDF", metaData));
     }
 
     @Test


### PR DESCRIPTION
Suppose you have a linked file test.pdf in the same folder as the bib file. Then "Open linked file" finds the file. However the integrity check complained. This is fixed now.

Solution was to replace FileUtil.expandFilename(p.link, fileDirectory) with FileUtil.expandFilename(context.getMetaData(), p.link), which is a bit smarter.

- [x] Change in CHANGELOG.md described? (no, since the feature was not yet released)
- [x] Changes in pull request outlined? (What, why, ...)
- [x] Tests created for changes?
- [x] Tests green?