### PR TITLE
Add tests for metadata parsing

### DIFF
--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -20,10 +20,12 @@ import java.util.*;
 
 import net.sf.jabref.exporter.SaveActions;
 import net.sf.jabref.groups.GroupTreeNode;
+import net.sf.jabref.logic.config.SaveOrderConfig;
 import net.sf.jabref.logic.labelpattern.AbstractLabelPattern;
 import net.sf.jabref.logic.labelpattern.DatabaseLabelPattern;
 import net.sf.jabref.migrations.VersionHandling;
 import net.sf.jabref.model.database.BibDatabase;
+import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.sql.DBStrings;
 
 public class MetaData implements Iterable<String> {
@@ -36,6 +38,7 @@ public class MetaData implements Iterable<String> {
     public static final String GROUPSVERSION = "groupsversion";
     public static final String GROUPSTREE = "groupstree";
     public static final String GROUPS = "groups";
+    private static final String FILE_DIRECTORY = Globals.FILE_FIELD + Globals.DIR_SUFFIX;
 
     private final Map<String, List<String>> metaData = new HashMap<>();
     private GroupTreeNode groupsRoot;
@@ -110,6 +113,14 @@ public class MetaData implements Iterable<String> {
      * The MetaData object can be constructed with no data in it.
      */
     public MetaData() {
+    }
+
+    public Optional<SaveOrderConfig> getSaveOrderConfig() {
+        List<String> storedSaveOrderConfig = getData(SAVE_ORDER_CONFIG);
+        if(storedSaveOrderConfig != null) {
+            return Optional.of(new SaveOrderConfig(storedSaveOrderConfig));
+        }
+        return Optional.empty();
     }
 
     /**
@@ -384,4 +395,42 @@ public class MetaData implements Iterable<String> {
         }
     }
 
+    public Optional<BibDatabaseMode> getMode() {
+        List<String> data = getData(MetaData.DATABASE_TYPE);
+        if (data == null || data.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(BibDatabaseMode.valueOf(data.get(0).toUpperCase()));
+    }
+
+    public boolean isProtected() {
+        List<String> data = getData(Globals.PROTECTED_FLAG_META);
+        if (data == null || data.isEmpty()) {
+            return false;
+        } else {
+            return Boolean.parseBoolean(data.get(0));
+        }
+    }
+
+    public List<String> getContentSelectors(String fieldName) {
+        return getData(Globals.SELECTOR_META_PREFIX + fieldName);
+    }
+
+    public Optional<String> getDefaultFileDirectory() {
+        List<String> fileDirectory = getData(FILE_DIRECTORY);
+        if (fileDirectory == null || fileDirectory.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(fileDirectory.get(0).trim());
+        }
+    }
+
+    public Optional<String> getUserFileDirectory(String user) {
+        List<String> fileDirectory = getData(FILE_DIRECTORY + '-' + user);
+        if (fileDirectory == null || fileDirectory.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(fileDirectory.get(0).trim());
+        }
+    }
 }

--- a/src/main/java/net/sf/jabref/exporter/BibDatabaseWriter.java
+++ b/src/main/java/net/sf/jabref/exporter/BibDatabaseWriter.java
@@ -120,10 +120,7 @@ public class BibDatabaseWriter {
         }
 
         if(preferences.getTakeMetadataSaveOrderInAccount()) {
-            List<String> storedSaveOrderConfig = metaData.getData(MetaData.SAVE_ORDER_CONFIG);
-            if(storedSaveOrderConfig != null) {
-                return Optional.of(new SaveOrderConfig(storedSaveOrderConfig));
-            }
+            return metaData.getSaveOrderConfig();
         }
 
         return Optional.ofNullable(preferences.getSaveOrder());

--- a/src/main/java/net/sf/jabref/logic/config/SaveOrderConfig.java
+++ b/src/main/java/net/sf/jabref/logic/config/SaveOrderConfig.java
@@ -31,6 +31,20 @@ public class SaveOrderConfig {
             this.descending = Boolean.parseBoolean(descending);
         }
 
+        public SortCriterion(String field, boolean descending) {
+            this.field = field;
+            this.descending = descending;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder("SortCriterion{");
+            sb.append("field='").append(field).append('\'');
+            sb.append(", descending=").append(descending);
+            sb.append('}');
+            return sb.toString();
+        }
+
         @Override
         public boolean equals(Object o) {
             if (this == o) {
@@ -50,6 +64,13 @@ public class SaveOrderConfig {
         }
     }
 
+    public SaveOrderConfig(boolean saveInOriginalOrder, SortCriterion first, SortCriterion second,
+            SortCriterion third) {
+        this.saveInOriginalOrder = saveInOriginalOrder;
+        sortCriteria[0] = first;
+        sortCriteria[1] = second;
+        sortCriteria[2] = third;
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -77,6 +98,15 @@ public class SaveOrderConfig {
         sortCriteria[0] = new SortCriterion();
         sortCriteria[1] = new SortCriterion();
         sortCriteria[2] = new SortCriterion();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("SaveOrderConfig{");
+        sb.append("saveInOriginalOrder=").append(saveInOriginalOrder);
+        sb.append(", sortCriteria=").append(Arrays.toString(sortCriteria));
+        sb.append('}');
+        return sb.toString();
     }
 
     public SaveOrderConfig(List<String> data) {

--- a/src/main/java/net/sf/jabref/logic/formatter/casechanger/LowerCaseChanger.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/casechanger/LowerCaseChanger.java
@@ -26,4 +26,18 @@ public class LowerCaseChanger implements Formatter {
 
         return title.toString();
     }
+
+    @Override
+    public int hashCode() {
+        return getKey().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(obj instanceof Formatter) {
+            return getKey().equals(((Formatter)obj).getKey());
+        } else {
+            return false;
+        }
+    }
 }

--- a/src/main/java/net/sf/jabref/logic/labelpattern/AbstractLabelPattern.java
+++ b/src/main/java/net/sf/jabref/logic/labelpattern/AbstractLabelPattern.java
@@ -17,10 +17,7 @@
 */
 package net.sf.jabref.logic.labelpattern;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * A small table, where an entry type is associated with a label pattern (an
@@ -34,6 +31,32 @@ public abstract class AbstractLabelPattern {
 
     public void addLabelPattern(String type, String pattern) {
         data.put(type, LabelPatternUtil.split(pattern));
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("AbstractLabelPattern{");
+        sb.append("defaultPattern=").append(defaultPattern);
+        sb.append(", data=").append(data);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AbstractLabelPattern that = (AbstractLabelPattern) o;
+        return Objects.equals(defaultPattern, that.defaultPattern) && Objects.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(defaultPattern, data);
     }
 
     /**


### PR DESCRIPTION
This solves #707 and prepares the way to refactor the metadata class.

I added a few methods to the MetaData class to make testing more convenient. Many calls to getData() in fact can be replaced by these new methods. I think this is something for a new PR.

One question: to write the tests in a nice way I had to overwrite a few equals methods. In particular for the LowerCaseChanger. Should I also override equals for all other formatters?