### PR TITLE
Key bindings are now working in preview panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Fixed [#685](https://github.com/JabRef/jabref/issues/685): Fixed MySQL exporting for more than one entry
 - Fixed [#815](https://github.com/JabRef/jabref/issues/815): Curly Braces no longer ignored in OpenOffice/LibreOffice citation
 - Fixed [#855](https://github.com/JabRef/jabref/issues/856): Fixed OpenOffice Manual connect - Clicking on browse does now work correctly
+- Fixed [#649](https://github.com/JabRef/jabref/issues/649): Key bindings are now working in the preview panel
 
 ### Removed
 - Fixed [#627](https://github.com/JabRef/jabref/issues/627): The pdf field is removed from the export formats, use the file field

--- a/src/main/java/net/sf/jabref/gui/PreviewPanel.java
+++ b/src/main/java/net/sf/jabref/gui/PreviewPanel.java
@@ -163,6 +163,25 @@ public class PreviewPanel extends JPanel implements VetoableChangeListener, Sear
         }
 
         add(scrollPane, BorderLayout.CENTER);
+
+        this.createKeyBindings();
+    }
+
+    private void createKeyBindings(){
+        ActionMap actionMap = this.getActionMap();
+        InputMap inputMap = this.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
+
+        final String close = "close";
+        inputMap.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), close);
+        actionMap.put(close, this.closeAction);
+
+        final String copy = "copy";
+        inputMap.put(Globals.getKeyPrefs().getKey(KeyBinding.COPY_PREVIEW), copy);
+        actionMap.put(copy, this.copyPreviewAction);
+
+        final String print = "print";
+        inputMap.put(Globals.getKeyPrefs().getKey(KeyBinding.PRINT_ENTRY_PREVIEW), print);
+        actionMap.put(print, this.printAction);
     }
 
     private JPopupMenu createPopupMenu() {
@@ -175,23 +194,7 @@ public class PreviewPanel extends JPanel implements VetoableChangeListener, Sear
 
     private JToolBar createToolBar() {
         JToolBar toolBar = new OSXCompatibleToolbar(SwingConstants.VERTICAL);
-
         toolBar.setMargin(new Insets(0, 0, 0, 2));
-
-        // The toolbar carries all the key bindings that are valid for the whole
-        // window.
-        ActionMap actionMap = toolBar.getActionMap();
-        InputMap inputMap = toolBar.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-
-        inputMap.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
-        actionMap.put("close", this.closeAction);
-
-        inputMap.put(Globals.getKeyPrefs().getKey(KeyBinding.COPY_PREVIEW), "copy");
-        actionMap.put("copy", this.copyPreviewAction);
-
-        inputMap.put(Globals.getKeyPrefs().getKey(KeyBinding.PRINT_ENTRY_PREVIEW), "print");
-        actionMap.put("print", this.printAction);
-
         toolBar.setFloatable(false);
 
         // Add actions (and thus buttons)


### PR DESCRIPTION
Fixes #649.
Until now the toolbar within the Preview panel held the key bindings which weren't active when the toolbar wasn't created. Now the Preview panel itself carries the key bindings.

- [x] Change in CHANGELOG.md described?
- [X] Changes in pull request outlined? (What, why, ...)
- [ ] Tests created for changes?
- [x] Tests green?

