### PR TITLE
When changing the type of an entry, the editor does not update

### DIFF
--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -1859,7 +1859,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
     public void updateEntryEditorIfShowing() {
         if (mode == BasePanel.SHOWING_EDITOR) {
-            if (currentEditor.getType().equals(currentEditor.getEntry().getType())) {
+            if (currentEditor.getDisplayedBibEntryType().equals(currentEditor.getEntry().getType())) {
                 currentEditor.updateAllFields();
                 currentEditor.updateSource();
             } else {
@@ -2025,36 +2025,36 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         stringDialog = null;
     }
 
-    public void changeType(String type) {
+    public void changeTypeOfSelectedEntries(String newType) {
         List<BibEntry> bes = mainTable.getSelectedEntries();
-        changeType(bes, type);
+        changeTypeOfSelectedEntries(bes, newType);
     }
 
-    private void changeType(List<BibEntry> bes, String type) {
-
-        if ((bes == null) || (bes.isEmpty())) {
+    private void changeTypeOfSelectedEntries(List<BibEntry> entries, String newType) {
+        if ((entries == null) || (entries.isEmpty())) {
             LOGGER.error("At least one entry must be selected to be able to change the type.");
             return;
         }
-        if (bes.size() > 1) {
+
+        if (entries.size() > 1) {
             int choice = JOptionPane.showConfirmDialog(this,
                     Localization.lang("Multiple entries selected. Do you want to change the type of all these to '%0'?",
-                            type),
+                            newType),
                     Localization.lang("Change entry type"), JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
             if (choice == JOptionPane.NO_OPTION) {
                 return;
             }
         }
 
-        NamedCompound ce = new NamedCompound(Localization.lang("Change entry type"));
-        for (BibEntry be : bes) {
-            ce.addEdit(new UndoableChangeType(be, be.getType(), type));
-            be.setType(type);
+        NamedCompound compound = new NamedCompound(Localization.lang("Change entry type"));
+        for (BibEntry entry : entries) {
+            compound.addEdit(new UndoableChangeType(entry, entry.getType(), newType));
+            entry.setType(newType);
         }
 
-        output(formatOutputMessage(Localization.lang("Changed type to '%0' for", type), bes.size()));
-        ce.end();
-        undoManager.addEdit(ce);
+        output(formatOutputMessage(Localization.lang("Changed type to '%0' for", newType), entries.size()));
+        compound.end();
+        undoManager.addEdit(compound);
         markBaseChanged();
         updateEntryEditorIfShowing();
     }

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -2027,10 +2027,10 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
     public void changeTypeOfSelectedEntries(String newType) {
         List<BibEntry> bes = mainTable.getSelectedEntries();
-        changeTypeOfSelectedEntries(bes, newType);
+        changeType(bes, newType);
     }
 
-    private void changeTypeOfSelectedEntries(List<BibEntry> entries, String newType) {
+    private void changeType(List<BibEntry> entries, String newType) {
         if ((entries == null) || (entries.isEmpty())) {
             LOGGER.error("At least one entry must be selected to be able to change the type.");
             return;

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -2025,10 +2025,6 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         stringDialog = null;
     }
 
-    public void changeType(BibEntry bes, String type) {
-        changeType(Arrays.asList(bes), type);
-    }
-
     public void changeType(String type) {
         List<BibEntry> bes = mainTable.getSelectedEntries();
         changeType(bes, type);

--- a/src/main/java/net/sf/jabref/gui/actions/ChangeTypeAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/ChangeTypeAction.java
@@ -19,6 +19,6 @@ public class ChangeTypeAction extends AbstractAction {
 
     @Override
     public void actionPerformed(ActionEvent evt) {
-        panel.changeType(type);
+        panel.changeTypeOfSelectedEntries(type);
     }
 }

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -90,6 +90,8 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
 
     // A reference to the entry this object works on.
     private BibEntry entry;
+    // The currently displayed type
+    private final String displayedBibEntryType;
 
     // The action concerned with closing the window.
     private final CloseAction closeAction;
@@ -168,6 +170,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
 
         this.entry.addPropertyChangeListener(this);
         this.entry.addPropertyChangeListener(SpecialFieldUpdateListener.getInstance());
+        displayedBibEntryType = entry.getType();
 
         helpAction = new HelpAction(HelpFiles.entryEditorHelp, IconTheme.JabRefIcon.HELP.getIcon());
         closeAction = new CloseAction();
@@ -305,8 +308,8 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
         srcPanel.setFocusCycleRoot(true);
     }
 
-    public String getType() {
-        return entry.getType();
+    public String getDisplayedBibEntryType() {
+        return displayedBibEntryType;
     }
 
     /**

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -1387,26 +1387,6 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
         }
     }
 
-    class ChangeTypeAction extends AbstractAction {
-
-        private final String changeType;
-
-        private final BasePanel changeTypePanel;
-
-
-        public ChangeTypeAction(EntryType type, BasePanel bp) {
-            super(type.getName());
-            this.changeType = type.getName();
-            changeTypePanel = bp;
-        }
-
-        @Override
-        public void actionPerformed(ActionEvent evt) {
-            changeTypePanel.changeType(entry, changeType);
-        }
-    }
-
-
     private void warnDuplicateBibtexkey() {
         panel.output(Localization.lang("Duplicate BibTeX key.")+" "+Localization.lang("Grouping may not work for this entry."));
     }

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -109,13 +109,12 @@ public class BibEntry {
         }
 
         String oldType = this.type;
-        type = type.toLowerCase();
 
         try {
             // We set the type before throwing the changeEvent, to enable
             // the change listener to access the new value if the change
             // sets off a change in database sorting etc.
-            this.type = type;
+            this.type = type.toLowerCase();
             changed = true;
             firePropertyChangedEvent(TYPE_HEADER, oldType == null ? null : oldType, type);
         } catch (PropertyVetoException pve) {


### PR DESCRIPTION
Regression bug introduced by https://github.com/JabRef/jabref/commit/51685e85a39cb6dd998e6f4fb994ff2dd15b8fb8.
JabRef v3.2 is fine, so no changelog entry.

EntryEditor must keep a field for the currentlyDisplayed BibEntry type in order to update the editor correctly onChange to the entry type.