### PR TITLE
"Find unlinked files" freezes when using for PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Fixed [#815](https://github.com/JabRef/jabref/issues/815): Curly Braces no longer ignored in OpenOffice/LibreOffice citation
 - Fixed [#855](https://github.com/JabRef/jabref/issues/856): Fixed OpenOffice Manual connect - Clicking on browse does now work correctly
 - Fixed [#649](https://github.com/JabRef/jabref/issues/649): Key bindings are now working in the preview panel
+- Fixed [#410](https://github.com/JabRef/jabref/issues/410): Find unlinked files no longer freezes when extracting entry from PDF content
 
 ### Removed
 - Fixed [#627](https://github.com/JabRef/jabref/issues/627): The pdf field is removed from the export formats, use the file field

--- a/src/main/java/net/sf/jabref/importer/fileformat/PdfContentImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/PdfContentImporter.java
@@ -191,33 +191,6 @@ public class PdfContentImporter extends ImportFormat {
 
             String firstPageContents = getFirstPageContents(document);
 
-            Optional<DOI> doi = DOI.build(firstPageContents);
-            if (doi.isPresent()) {
-                ImportInspector inspector = new ImportInspector() {
-
-                    @Override
-                    public void toFront() {
-                        // Do nothing
-                    }
-
-                    @Override
-                    public void setProgress(int current, int max) {
-                        // Do nothing
-                    }
-
-                    @Override
-                    public void addEntry(BibEntry entry) {
-                        // add the entry to the result object
-                        result.add(entry);
-                    }
-                };
-
-                doiToBibTeXFetcher.processQuery(doi.get().getDOI(), inspector, status);
-                if (!result.isEmpty()) {
-                    return result;
-                }
-            }
-
             split = firstPageContents.split(System.lineSeparator());
 
             // idea: split[] contains the different lines

--- a/src/main/java/net/sf/jabref/importer/fileformat/PdfContentImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/PdfContentImporter.java
@@ -35,14 +35,14 @@ public class PdfContentImporter extends ImportFormat {
 
     private static final DOItoBibTeXFetcher doiToBibTeXFetcher = new DOItoBibTeXFetcher();
 
-    // input paragraphs into several lines
-    private String[] paragraphs;
+    // input lines into several lines
+    private String[] lines;
 
-    // current index in paragraphs
+    // current index in lines
     private int i;
 
-    // curent "line" in paragraphs.
-    // sometimes, a "line" is several lines in paragraphs
+    // curent "line" in lines.
+    // sometimes, a "line" is several lines in lines
     private String curString;
 
     private String year;
@@ -225,16 +225,16 @@ public class PdfContentImporter extends ImportFormat {
             // i points to the current line
             // curString (mostly) contains the current block
             //   the different lines are joined into one and thereby separated by " "
-            paragraphs = firstPageContents.split(System.lineSeparator());
+            lines = firstPageContents.split(System.lineSeparator());
 
             proceedToNextNonEmptyLine();
-            if (i >= paragraphs.length) {
+            if (i >= lines.length) {
                 // PDF could not be parsed or is empty
                 // return empty list
                 return result;
             }
 
-            curString = paragraphs[i];
+            curString = lines[i];
             i = i + 1;
 
             String author;
@@ -279,15 +279,15 @@ public class PdfContentImporter extends ImportFormat {
 
             // after title: authors
             author = null;
-            while ((i < paragraphs.length) && !"".equals(paragraphs[i])) {
-                // author names are unlikely to be paragraphs among different lines
+            while ((i < lines.length) && !"".equals(lines[i])) {
+                // author names are unlikely to be lines among different lines
                 // treat them line by line
-                curString = streamlineNames(paragraphs[i]);
+                curString = streamlineNames(lines[i]);
                 if (author == null) {
                     author = curString;
                 } else {
                     if ("".equals(curString)) {
-                        // if paragraphs[i] is "and" then "" is returned by streamlineNames -> do nothing
+                        // if lines[i] is "and" then "" is returned by streamlineNames -> do nothing
                     } else {
                         author = author.concat(" and ").concat(curString);
                     }
@@ -298,8 +298,8 @@ public class PdfContentImporter extends ImportFormat {
             i++;
 
             // then, abstract and keywords follow
-            while (i < paragraphs.length) {
-                curString = paragraphs[i];
+            while (i < lines.length) {
+                curString = lines[i];
                 if ((curString.length() >= "Abstract".length()) && "Abstract".equalsIgnoreCase(curString.substring(0, "Abstract".length()))) {
                     if (curString.length() == "Abstract".length()) {
                         // only word "abstract" found -- skip line
@@ -310,8 +310,8 @@ public class PdfContentImporter extends ImportFormat {
                     i++;
                     // fillCurStringWithNonEmptyLines() cannot be used as that uses " " as line separator
                     // whereas we need linebreak as separator
-                    while ((i < paragraphs.length) && !"".equals(paragraphs[i])) {
-                        curString = curString.concat(paragraphs[i]).concat(System.lineSeparator());
+                    while ((i < lines.length) && !"".equals(lines[i])) {
+                        curString = curString.concat(lines[i]).concat(System.lineSeparator());
                         i++;
                     }
                     abstractT = curString;
@@ -345,7 +345,7 @@ public class PdfContentImporter extends ImportFormat {
                 }
             }
 
-            i = paragraphs.length - 1;
+            i = lines.length - 1;
 
             // last block: DOI, detailed information
             // sometimes, this information is in the third last block etc...
@@ -517,7 +517,7 @@ public class PdfContentImporter extends ImportFormat {
      * proceed to next non-empty line
      */
     private void proceedToNextNonEmptyLine() {
-        while ((i < paragraphs.length) && "".equals(paragraphs[i].trim())) {
+        while ((i < lines.length) && "".equals(lines[i].trim())) {
             i++;
         }
     }
@@ -530,19 +530,19 @@ public class PdfContentImporter extends ImportFormat {
      * Lines containing only white spaces are ignored,
      * but NOT considered as ""
      * <p>
-     * Uses GLOBAL variables paragraphs, curLine, i
+     * Uses GLOBAL variables lines, curLine, i
      */
     private void fillCurStringWithNonEmptyLines() {
         // ensure that curString does not end with " "
         curString = curString.trim();
-        while ((i < paragraphs.length) && !"".equals(paragraphs[i])) {
-            String curLine = paragraphs[i].trim();
+        while ((i < lines.length) && !"".equals(lines[i])) {
+            String curLine = lines[i].trim();
             if (!"".equals(curLine)) {
                 if (!curString.isEmpty()) {
                     // insert separating space if necessary
                     curString = curString.concat(" ");
                 }
-                curString = curString.concat(paragraphs[i]);
+                curString = curString.concat(lines[i]);
             }
             i++;
         }
@@ -558,7 +558,7 @@ public class PdfContentImporter extends ImportFormat {
      * invariant before/after: i points to line before the last handled block
      */
     private void readLastBlock() {
-        while ((i >= 0) && "".equals(paragraphs[i].trim())) {
+        while ((i >= 0) && "".equals(lines[i].trim())) {
             i--;
         }
         // i is now at the end of a block
@@ -566,7 +566,7 @@ public class PdfContentImporter extends ImportFormat {
         int end = i;
 
         // find beginning
-        while ((i >= 0) && !"".equals(paragraphs[i])) {
+        while ((i >= 0) && !"".equals(lines[i])) {
             i--;
         }
         // i is now the line before the beginning of the block
@@ -574,7 +574,7 @@ public class PdfContentImporter extends ImportFormat {
 
         curString = "";
         for (int j = i + 1; j <= end; j++) {
-            curString = curString.concat(paragraphs[j].trim());
+            curString = curString.concat(lines[j].trim());
             if (j != end) {
                 curString = curString.concat(" ");
             }

--- a/src/main/java/net/sf/jabref/logic/util/DOI.java
+++ b/src/main/java/net/sf/jabref/logic/util/DOI.java
@@ -36,9 +36,20 @@ public class DOI {
             + "(?:.+)"                          // suffix alphanumeric string
             + ")";                              // end group \1
 
+    private static final String FIND_DOI_EXP = ""
+            + "(?:urn:)?"                       // optional urn
+            + "(?:doi:)?"                       // optional doi
+            + "("                               // begin group \1
+            + "10"                              // directory indicator
+            + "(?:\\.[0-9]+)+"                  // registrant codes
+            + "[/:]"                            // divider
+            + "(?:[^\\s]+)"                     // suffix alphanumeric without space
+            + ")";                              // end group \1
+
     private static final String HTTP_EXP = "https?://[^\\s]+?" + DOI_EXP;
     // Pattern
-    private static final Pattern DOI_PATT = Pattern.compile("^(?:https?://[^\\s]+?)?" + DOI_EXP + "$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern EXACT_DOI_PATT = Pattern.compile("^(?:https?://[^\\s]+?)?" + DOI_EXP + "$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern DOI_PATT = Pattern.compile("(?:https?://[^\\s]+?)?" + FIND_DOI_EXP, Pattern.CASE_INSENSITIVE);
 
     /**
      * Creates a DOI from various schemes including URL, URN, and plain DOIs.
@@ -66,7 +77,7 @@ public class DOI {
         }
 
         // Extract DOI
-        Matcher matcher = DOI_PATT.matcher(trimmedDoi);
+        Matcher matcher = EXACT_DOI_PATT.matcher(trimmedDoi);
         if (matcher.find()) {
             // match only group \1
             this.doi = matcher.group(1);
@@ -90,6 +101,23 @@ public class DOI {
         } catch (IllegalArgumentException | NullPointerException e) {
             return Optional.empty();
         }
+    }
+
+    /**
+     * Tries to find a DOI inside the given text.
+     *
+     * @param text the Text which might contain a DOI
+     * @return an Optional containing the DOI or an empty Optional
+     */
+    public static Optional<DOI> findInText(String text) {
+        Optional<DOI> result = Optional.empty();
+
+        Matcher matcher = DOI_PATT.matcher(text);
+        if (matcher.find()) {
+            // match only group \1
+            result = Optional.of(new DOI(matcher.group(1)));
+        }
+        return result;
     }
 
     /**

--- a/src/test/java/net/sf/jabref/logic/util/DOITest.java
+++ b/src/test/java/net/sf/jabref/logic/util/DOITest.java
@@ -3,6 +3,8 @@ package net.sf.jabref.logic.util;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Optional;
+
 
 public class DOITest {
     @Test
@@ -110,5 +112,15 @@ public class DOITest {
         Assert.assertEquals("http://doi.org/10.1006/jmbi.1998.2354", new DOI("10.1006/jmbi.1998.2354").getURLAsASCIIString());
         Assert.assertEquals("http://doi.org/10.1006/jmbi.1998.2354", new DOI("http://doi.org/10.1006/jmbi.1998.2354").getURLAsASCIIString());
         Assert.assertEquals("http://doi.org/10.1109/VLHCC.2004.20", new DOI("doi:10.1109/VLHCC.2004.20").getURLAsASCIIString());
+    }
+
+    @Test
+    public void findDoiInsideArbitraryText() {
+        Assert.assertEquals("10.1006/jmbi.1998.2354", DOI.findInText("other stuff 10.1006/jmbi.1998.2354 end").get().getDOI());
+    }
+
+    @Test
+    public void noDOIFoundInsideArbitraryText() {
+        Assert.assertEquals(Optional.empty(), DOI.findInText("text without 28282 a doi"));
     }
 }


### PR DESCRIPTION
1. Fixed #410 Reason was an IllegalArgumentException thrown by DOI class when pasting the contents of the whole first PDF page to the constructor.
2. The DOI class can only handle real DOIs and does not extract Strings that might look like a DOI from the text, therefore the whole DOI scraper was removed in https://github.com/JabRef/jabref/commit/acdcd829c304e03b9bfd92d6eba383b5a1d52108
3. The whole PDFImporter class is screwed and a monkeypatch. It should be reimplemented from scratch.
