### PR TITLE
Preview panel is now updated when an entry is cut/deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Fixed [#855](https://github.com/JabRef/jabref/issues/856): Fixed OpenOffice Manual connect - Clicking on browse does now work correctly
 - Fixed [#649](https://github.com/JabRef/jabref/issues/649): Key bindings are now working in the preview panel
 - Fixed [#410](https://github.com/JabRef/jabref/issues/410): Find unlinked files no longer freezes when extracting entry from PDF content
+- Fixed [#936](https://github.com/JabRef/jabref/issues/936): Preview panel is now updated when an entry is cut/deleted
 
 ### Removed
 - Fixed [#627](https://github.com/JabRef/jabref/issues/627): The pdf field is removed from the export formats, use the file field

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -346,6 +346,9 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 ce.end();
                 undoManager.addEdit(ce);
                 markBaseChanged();
+
+                //no entry is selected anymore, thus hide the preview panel
+                hideBottomComponent();
             }
         });
 
@@ -371,6 +374,9 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     ce.end();
                     undoManager.addEdit(ce);
                 }
+
+                //no entry is selected anymore, thus hide the preview panel
+                hideBottomComponent();
             }
         });
 


### PR DESCRIPTION
Fixes #936.
When an entry is cut/deleted the preview panel will be hidden due to the fact that no entry is selected anymore.

- [x] Change in CHANGELOG.md described?
- [x] Changes in pull request outlined? (What, why, ...)
- [ ] Tests created for changes?
- [x] Tests green?

