### PR TITLE
Modify canonical representation to normalize authors

### DIFF
--- a/src/main/java/net/sf/jabref/model/entry/CanonicalBibtexEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/CanonicalBibtexEntry.java
@@ -15,6 +15,8 @@ public class CanonicalBibtexEntry {
      * This returns a canonical BibTeX serialization. Special characters such as "{" or "&" are NOT escaped, but written
      * as is
      *
+     * authors and editors are normalized
+     *
      * Serializes all fields, even the JabRef internal ones. Does NOT serialize "KEY_FIELD" as field, but as key
      */
     public static String getCanonicalRepresentation(BibEntry e) {
@@ -34,7 +36,12 @@ public class CanonicalBibtexEntry {
             if (!fieldName.equals(BibEntry.KEY_FIELD)) {
                 String lowerCaseFieldName = fieldName.toLowerCase(Locale.US);
                 sortedFields.add(lowerCaseFieldName);
-                mapFieldToValue.put(lowerCaseFieldName, e.getField(fieldName));
+                String value = e.getField(fieldName);
+                if ("author".equals(lowerCaseFieldName) || "editor".equals(lowerCaseFieldName)) {
+                    // normalize field contents
+                    value = AuthorList.getAuthorList(value).toString();
+                }
+                mapFieldToValue.put(lowerCaseFieldName, value);
             }
         }
 

--- a/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
@@ -8,6 +8,7 @@ import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.AuthorList;
 import net.sf.jabref.bibtex.BibEntryWriter;
+import net.sf.jabref.bibtex.BibtexEntryAssert;
 import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
@@ -456,7 +457,7 @@ public class XMPUtilTest {
         Assert.assertEquals(1, l.size());
         BibEntry x = l.get(0);
 
-        assertEqualsBibtexEntry(e, x);
+        BibtexEntryAssert.assertEquals(e, x);
     }
 
     /**
@@ -500,7 +501,7 @@ public class XMPUtilTest {
         Assert.assertEquals(1, l.size());
         BibEntry e = l.get(0);
 
-        assertEqualsBibtexEntry(t2BibtexEntry(), e);
+        BibtexEntryAssert.assertEquals(t2BibtexEntry(), e);
     }
 
     @Test
@@ -564,7 +565,7 @@ public class XMPUtilTest {
             Assert.assertEquals(1, l.size());
             BibEntry e = l.get(0);
 
-            assertEqualsBibtexEntry(t1BibtexEntry(), e);
+            BibtexEntryAssert.assertEquals(t1BibtexEntry(), e);
 
             // This is what we really want to test: Is the rest of the
             // descriptions still there?
@@ -640,7 +641,7 @@ public class XMPUtilTest {
         Assert.assertEquals(1, l.size());
         BibEntry e = l.get(0);
 
-        assertEqualsBibtexEntry(toSet, e);
+        BibtexEntryAssert.assertEquals(toSet, e);
 
         // This is what we really want to test: Is the rest of the
         // descriptions still there?
@@ -731,28 +732,7 @@ public class XMPUtilTest {
         Assert.assertEquals(1, l.size());
         BibEntry x = l.get(0);
 
-        assertEqualsBibtexEntry(e, x);
-    }
-
-    public void assertEqualsBibtexEntry(BibEntry expected, BibEntry actual) {
-        Assert.assertNotNull(expected);
-        Assert.assertNotNull(actual);
-        Assert.assertEquals(expected.getCiteKey(), actual.getCiteKey());
-        Assert.assertEquals(expected.getType(), actual.getType());
-
-        for (String field : expected.getFieldNames()) {
-
-            if ("author".equalsIgnoreCase(field) || "editor".equalsIgnoreCase(field)) {
-
-                AuthorList expectedAuthors = AuthorList.getAuthorList(expected.getField(field));
-                AuthorList actualAuthors = AuthorList.getAuthorList(actual.getField(field));
-                Assert.assertEquals(expectedAuthors, actualAuthors);
-            } else {
-                Assert.assertEquals("comparing " + field, expected.getField(field), actual.getField(field));
-            }
-        }
-
-        Assert.assertEquals(expected.getFieldNames().size(), actual.getFieldNames().size());
+        BibtexEntryAssert.assertEquals(e, x);
     }
 
     /**
@@ -834,8 +814,8 @@ public class XMPUtilTest {
             b = tmp;
         }
 
-        assertEqualsBibtexEntry(t2BibtexEntry(), a);
-        assertEqualsBibtexEntry(t3BibtexEntry(), b);
+        BibtexEntryAssert.assertEquals(t2BibtexEntry(), a);
+        BibtexEntryAssert.assertEquals(t3BibtexEntry(), b);
     }
 
     /**
@@ -865,8 +845,8 @@ public class XMPUtilTest {
             b = tmp;
         }
 
-        assertEqualsBibtexEntry(t2BibtexEntry(), a);
-        assertEqualsBibtexEntry(t3BibtexEntry(), b);
+        BibtexEntryAssert.assertEquals(t2BibtexEntry(), a);
+        BibtexEntryAssert.assertEquals(t3BibtexEntry(), b);
     }
 
     @Test
@@ -890,7 +870,7 @@ public class XMPUtilTest {
                     document.getDocumentInformation().getCustomMetadataValue("bibtex/bibtexkey"));
             Assert.assertEquals("peanut, butter, jelly", document.getDocumentInformation().getKeywords());
 
-            assertEqualsBibtexEntry(t3BibtexEntry(),
+            BibtexEntryAssert.assertEquals(t3BibtexEntry(),
                     XMPUtil.getBibtexEntryFromDocumentInformation(document.getDocumentInformation()).get());
 
             PDDocumentCatalog catalog = document.getDocumentCatalog();
@@ -929,7 +909,7 @@ public class XMPUtilTest {
              */
             Assert.assertEquals(4, dcSchema.getRelationships().size());
 
-            assertEqualsBibtexEntry(t3BibtexEntry(), XMPUtil.getBibtexEntryFromDublinCore(dcSchema).get());
+            BibtexEntryAssert.assertEquals(t3BibtexEntry(), XMPUtil.getBibtexEntryFromDublinCore(dcSchema).get());
 
         }
 
@@ -956,7 +936,7 @@ public class XMPUtilTest {
                     document.getDocumentInformation().getCustomMetadataValue("bibtex/bibtexkey"));
             Assert.assertEquals("peanut, butter, jelly", document.getDocumentInformation().getKeywords());
 
-            assertEqualsBibtexEntry(t3BibtexEntry(),
+            BibtexEntryAssert.assertEquals(t3BibtexEntry(),
                     XMPUtil.getBibtexEntryFromDocumentInformation(document.getDocumentInformation()).get());
 
             PDDocumentCatalog catalog = document.getDocumentCatalog();
@@ -995,7 +975,7 @@ public class XMPUtilTest {
              */
             Assert.assertEquals(4, dcSchema.getRelationships().size());
 
-            assertEqualsBibtexEntry(t3BibtexEntry(), XMPUtil.getBibtexEntryFromDublinCore(dcSchema).get());
+            BibtexEntryAssert.assertEquals(t3BibtexEntry(), XMPUtil.getBibtexEntryFromDublinCore(dcSchema).get());
 
         }
     }
@@ -1070,7 +1050,7 @@ public class XMPUtilTest {
             }
             List<BibEntry> l = XMPUtil.readXMP(pdfFile);
             Assert.assertEquals(1, l.size());
-            assertEqualsBibtexEntry(t1BibtexEntry(), l.get(0));
+            BibtexEntryAssert.assertEquals(t1BibtexEntry(), l.get(0));
 
         } finally {
             if (!tempBib.delete()) {
@@ -1103,7 +1083,7 @@ public class XMPUtilTest {
                 Assert.assertEquals(1, c.size());
                 BibEntry x = c.iterator().next();
 
-                assertEqualsBibtexEntry(e, x);
+                BibtexEntryAssert.assertEquals(e, x);
             }
         }
         // Write XMP to file
@@ -1137,7 +1117,7 @@ public class XMPUtilTest {
             List<BibEntry> l = XMPUtil.readXMP(pdfFile);
             Assert.assertEquals(1, l.size());
 
-            assertEqualsBibtexEntry(t1BibtexEntry(), l.get(0));
+            BibtexEntryAssert.assertEquals(t1BibtexEntry(), l.get(0));
         }
     }
 
@@ -1167,7 +1147,7 @@ public class XMPUtilTest {
                 // PDF should be annotated:
                 List<BibEntry> l = XMPUtil.readXMP(pdfFile);
                 Assert.assertEquals(1, l.size());
-                assertEqualsBibtexEntry(t1BibtexEntry(), l.get(0));
+                BibtexEntryAssert.assertEquals(t1BibtexEntry(), l.get(0));
             }
             // Now try OezbekC06
             try (ByteArrayOutputStream s = new ByteArrayOutputStream()) {
@@ -1183,7 +1163,7 @@ public class XMPUtilTest {
             // PDF should be annotated:
             List<BibEntry> l = XMPUtil.readXMP(pdfFile);
             Assert.assertEquals(1, l.size());
-            assertEqualsBibtexEntry(t2BibtexEntry(), l.get(0));
+            BibtexEntryAssert.assertEquals(t2BibtexEntry(), l.get(0));
         } finally {
             if (!tempBib.delete()) {
                 System.err.println("Cannot delete temporary file");
@@ -1231,8 +1211,8 @@ public class XMPUtilTest {
             // Writing and reading will resolve strings!
             t3.setField("month", "July");
 
-            assertEqualsBibtexEntry(t1, a);
-            assertEqualsBibtexEntry(t3, b);
+            BibtexEntryAssert.assertEquals(t1, a);
+            BibtexEntryAssert.assertEquals(t3, b);
 
         } finally {
             if (!tempBib.delete()) {

--- a/src/test/java/net/sf/jabref/model/entry/CanonicalBibEntryTest.java
+++ b/src/test/java/net/sf/jabref/model/entry/CanonicalBibEntryTest.java
@@ -26,4 +26,14 @@ public class CanonicalBibEntryTest {
         Assert.assertEquals("@article{key,\n  abstract = {line 1\nline 2}\n}", canonicalRepresentation);
     }
 
+    @Test
+    public void canonicalRepresentationOfAnAuthor() {
+        BibEntry e = new BibEntry("id", BibtexEntryTypes.ARTICLE.getName());
+        e.setField(BibEntry.KEY_FIELD, "key");
+        e.setField("author", "K. Crowston and H. Annabi and J. Howison and C. Masango");
+        String canonicalRepresentation = CanonicalBibtexEntry.getCanonicalRepresentation(e);
+        Assert.assertEquals(
+                "@article{key,\n  author = {Crowston, K. and Annabi, H. and Howison, J. and Masango, C.}\n}",
+                canonicalRepresentation);
+    }
 }


### PR DESCRIPTION
This is a PR to start discussions on our canonical representation.

When are two entries are equal. Is "Firstname Lastname" equal to "Lastname, Firstname"? Is "Cool and the Gang" equal to "Cool And The Gang"? How strict should we be?

At first, I thought, we have to be very strict. Then, I saw that our XMP utilities normalize the content of the author field for writing into the PDF.

Maybe we need a "normalized format" and a "canonical representation". The canonical representation is kept as is and the "normalized format" normalizes as much as possible?

This PR currently just normalizes the entry in the canonical representation, which feels wrong, doesn't it?