### PR TITLE
[WIP] Fix for undoing deletion/cutting multiple entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Fixed [#1245](https://github.com/JabRef/jabref/issues/1245): Empty jstyle properties can now be specified as ""
 - Fixed [#1364](https://github.com/JabRef/jabref/issues/1364): Windows: install to LOCALAPPDATA directory for non-admin users
 - Fixed [#1365](https://github.com/JabRef/jabref/issues/1365): Default label pattern back to "[auth][year]"
+- Fixed [#796](https://github.com/JabRef/jabref/issues/796): Undoing more than one entry at the same time is now working
 
 ### Removed
 - Removed possibility to export entries/databases to an `.sql` file, as the logic cannot easily use the correct escape logic

--- a/src/integrationTest/java/net/sf/jabref/gui/UndoTest.java
+++ b/src/integrationTest/java/net/sf/jabref/gui/UndoTest.java
@@ -1,0 +1,72 @@
+package net.sf.jabref.gui;
+
+import java.io.File;
+
+import net.sf.jabref.JabRefMain;
+
+import org.assertj.swing.finder.JFileChooserFinder;
+import org.assertj.swing.fixture.FrameFixture;
+import org.assertj.swing.fixture.JFileChooserFixture;
+import org.assertj.swing.fixture.JTableFixture;
+import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
+import org.junit.Test;
+
+import static org.assertj.swing.finder.WindowFinder.findFrame;
+import static org.assertj.swing.launcher.ApplicationLauncher.application;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class UndoTest extends AssertJSwingJUnitTestCase {
+
+    private AWTExceptionHandler awtExceptionHandler;
+
+    @Override
+    protected void onSetUp() {
+        awtExceptionHandler = new AWTExceptionHandler();
+        awtExceptionHandler.installExceptionDetectionInEDT();
+        application(JabRefMain.class).start();
+
+        robot().waitForIdle();
+
+        robot().settings().timeoutToFindSubMenu(1_000);
+        robot().settings().delayBetweenEvents(50);
+    }
+
+    private void exitJabRef(FrameFixture mainFrame) {
+        mainFrame.menuItemWithPath("File", "Quit").click();
+        awtExceptionHandler.assertNoExceptions();
+    }
+
+    private String getTestFilePath(String fileName) {
+        return new File(this.getClass().getClassLoader().getResource(fileName).getFile()).getAbsolutePath();
+    }
+
+    private void importBibIntoNewDatabase(FrameFixture mainFrame, String path) {
+        mainFrame.menuItemWithPath("File", "Import into new database").click();
+
+        JFileChooserFixture openFileDialog = JFileChooserFinder.findFileChooser().withTimeout(10_000).using(robot());
+        robot().settings().delayBetweenEvents(1);
+        openFileDialog.fileNameTextBox().enterText(path);
+        robot().settings().delayBetweenEvents(50);
+        openFileDialog.approve();
+    }
+
+    @Test
+    public void undoCutOfMultipleEntries() {
+        FrameFixture mainFrame = findFrame(JabRefFrame.class).withTimeout(10_000).using(robot());
+        importBibIntoNewDatabase(mainFrame, getTestFilePath("testbib/testjabref.bib"));
+
+        JTableFixture entryTable = mainFrame.table();
+        assertTrue("The database must have at least 2 entries for the test to begin!", entryTable.rowCount() >= 2);
+        entryTable.selectRows(0, 1);
+
+        int rowCount = entryTable.rowCount();
+        mainFrame.menuItemWithPath("Edit", "Cut").click();
+        mainFrame.menuItemWithPath("Edit", "Undo").click();
+        assertEquals(rowCount, entryTable.rowCount());
+
+        mainFrame.menuItemWithPath("File", "Close database").click();
+        exitJabRef(mainFrame);
+    }
+
+}

--- a/src/main/java/net/sf/jabref/specialfields/SpecialFieldDatabaseChangeListener.java
+++ b/src/main/java/net/sf/jabref/specialfields/SpecialFieldDatabaseChangeListener.java
@@ -1,6 +1,20 @@
+/*  Copyright (C) 2003-2016 JabRef contributors.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
 package net.sf.jabref.specialfields;
 
-import net.sf.jabref.JabRefGUI;
 import net.sf.jabref.event.EntryAddedEvent;
 import net.sf.jabref.gui.undo.NamedCompound;
 import net.sf.jabref.logic.l10n.Localization;
@@ -21,14 +35,15 @@ public class SpecialFieldDatabaseChangeListener {
     }
 
     @Subscribe
-    public void listen(EntryAddedEvent EntryAddedEvent) {
+    public void listen(EntryAddedEvent event) {
         if (SpecialFieldsUtils.keywordSyncEnabled()) {
-            final BibEntry entry = EntryAddedEvent.getBibEntry();
+            final BibEntry entry = event.getBibEntry();
             // NamedCompount code similar to SpecialFieldUpdateListener
             NamedCompound nc = new NamedCompound(Localization.lang("Synchronized special fields based on keywords"));
             SpecialFieldsUtils.syncSpecialFieldsFromKeywords(entry, nc);
-            nc.end();
-            JabRefGUI.getMainFrame().getCurrentBasePanel().undoManager.addEdit(nc);
+            // Don't insert the compound into the undoManager,
+            // it would be added before the component which undoes the insertion of the entry and creates heavy problems
+            // (which prohibits the undo the deleting multiple entries)
         }
     }
 


### PR DESCRIPTION
Workaround for #796.
When an undo with multiple entries is undone, each entry is undone one at a time. The Problem herein lies, that when the first entry is undone, the insertion in the database triggers the creation and insertion of an NamedCompund into the UndoManager which kills the main Undo (the one with the multiple entries), which result in just one entry being undone.

With this Workaround each entry has its own NamedCompund which solves the Problem but the user has to call the UndoAction several times (Ctrl-Z for each entry).

- [x] Change in CHANGELOG.md described?
- [x] Changes in pull request outlined? (What, why, ...)
- [ ] Tests created for changes?
- [x] Tests green?