### PR TITLE
Demo of AuthorList instead of AuthorsFormatter

### DIFF
--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/AuthorsFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/AuthorsFormatter.java
@@ -16,19 +16,12 @@
 package net.sf.jabref.logic.formatter.bibtexfields;
 
 import net.sf.jabref.logic.formatter.Formatter;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import net.sf.jabref.model.entry.AuthorList;
 
 /**
  * Class for normalizing author lists to BibTeX format.
  */
 public class AuthorsFormatter implements Formatter {
-    private static final Pattern LAST_F_F = Pattern.compile("(\\p{javaUpperCase}[\\p{javaLowerCase}]+) (\\p{javaUpperCase}+)");
-    private static final Pattern LAST_FDOT_F = Pattern.compile("(\\p{javaUpperCase}[\\p{javaLowerCase}]+) ([\\. \\p{javaUpperCase}]+)");
-    private static final Pattern F_F_LAST = Pattern.compile("(\\p{javaUpperCase}+) (\\p{javaUpperCase}[\\p{javaLowerCase}]+)");
-    private static final Pattern FDOT_F_LAST = Pattern.compile("([\\. \\p{javaUpperCase}]+) (\\p{javaUpperCase}[\\p{javaLowerCase}]+)");
-    private static final Pattern SINGLE_NAME = Pattern.compile("(\\p{javaUpperCase}[\\p{javaLowerCase}]*)");
 
     @Override
     public String getName() {
@@ -45,205 +38,12 @@ public class AuthorsFormatter implements Formatter {
      */
     @Override
     public String format(String value) {
-        boolean andSep = false;
-        // String can contain newlines. Convert each to a space
-        String noNewlineValue = value.replace("\n", " ");
-        String[] authors = noNewlineValue.split("( |,)and ", -1);
-        if (authors.length > 1) {
-            andSep = true;
-        } else {
-            /*
-            If there are no "and" separators in the original string, we assume it either means that
-            the author list is comma or semicolon separated or that it contains only a single name.
-            If there is a semicolon, we go by that. If not, we assume commas, and count the parts
-            separated by commas to determine which it is.
-            */
-            String[] authors2 = noNewlineValue.split("; ");
-            if (authors2.length > 1) {
-                authors = authors2;
-            } else {
-                authors2 = noNewlineValue.split(", ");
-                if (authors2.length > 3) { // Probably more than a single author, so we split by commas.
-                    authors = authors2;
-                } else {
-                    if (authors2.length == 3) {
-                        // This could be a BibTeX formatted name containing a Jr particle,
-                        // e.g. Smith, Jr., Peter
-                        // We check if the middle part is <= 3 characters. If not, we assume we are
-                        // dealing with three authors.
-                        if (authors2[1].length() > 3) {
-                            authors = authors2;
-                        }
-                    }
-                }
-            }
-        }
+        // try to convert to BibTeX format, where multiple names are separated by " and " instead of ";" or other characters
+        String inputForAuthorList = value.replaceAll(";", " and ");
 
-        // Remove leading and trailing whitespaces from each name:
-        for (int i = 0; i < authors.length; i++) {
-            authors[i] = authors[i].trim();
-        }
-
-        // If we found an and separator, there could possibly be semicolon or
-        // comma separation before the last separator. If there are two or more
-        // and separators, we can dismiss this possibility.
-        // If there is only a single and separator, check closer:
-        if (andSep && (authors.length == 2)) {
-            // Check if the first part is semicolon separated:
-            String[] semiSep = authors[0].split("; ");
-            if (semiSep.length > 1) {
-                // Ok, it looks like this is the case. Use separation by semicolons:
-                String[] newAuthors = new String[1 + semiSep.length];
-                for (int i = 0; i < semiSep.length; i++) {
-                    newAuthors[i] = semiSep[i].trim();
-                }
-                newAuthors[semiSep.length] = authors[1];
-                authors = newAuthors;
-            } else {
-                // Check if there is a comma in the last name. If so, we can assume that comma
-                // is not used to separate the names:
-                boolean lnfn = authors[1].indexOf(',') >= 1;
-                if (!lnfn) {
-                    String[] cmSep = authors[0].split(", ");
-                    if (cmSep.length > 1) {
-                        // This means that the last name doesn't contain a comma, but the first
-                        // one contains one or more. This indicates that the names leading up to
-                        // the single "and" are comma separated:
-                        String[] newAuthors = new String[1 + cmSep.length];
-                        for (int i = 0; i < cmSep.length; i++) {
-                            newAuthors[i] = cmSep[i].trim();
-                        }
-                        newAuthors[cmSep.length] = authors[1];
-                        authors = newAuthors;
-                    }
-
-                }
-            }
-        }
-
-        StringBuilder stringBuilder = new StringBuilder();
-        for (int i = 0; i < authors.length; i++) {
-            String norm = AuthorsFormatter.normalizeName(authors[i]);
-            stringBuilder.append(norm);
-            if (i < (authors.length - 1)) {
-                stringBuilder.append(" and ");
-            }
-        }
-        return stringBuilder.toString();
+        // AuthorList does the whole magic when the string is a well-formed BibTeX author string
+        AuthorList list = AuthorList.getAuthorList(inputForAuthorList);
+        return list.getAuthorsLastFirstAnds(false);
     }
 
-    private static String normalizeName(String oldName) {
-        String name = oldName;
-        Matcher matcher = AuthorsFormatter.LAST_F_F.matcher(name);
-        if (matcher.matches()) {
-            String initials = matcher.group(2);
-            StringBuilder stringBuilder = new StringBuilder(matcher.group(1));
-            stringBuilder.append(", ");
-            fixInitials(initials, stringBuilder);
-            return stringBuilder.toString();
-        }
-        matcher = AuthorsFormatter.LAST_FDOT_F.matcher(name);
-        if (matcher.matches()) {
-            String initials = matcher.group(2).replaceAll("[\\. ]+", "");
-            StringBuilder stringBuilder = new StringBuilder(matcher.group(1));
-            stringBuilder.append(", ");
-            fixInitials(initials, stringBuilder);
-            return stringBuilder.toString();
-        }
-
-        matcher = AuthorsFormatter.F_F_LAST.matcher(name);
-        if (matcher.matches()) {
-            String initials = matcher.group(1);
-            StringBuilder stringBuilder = new StringBuilder(matcher.group(2));
-            stringBuilder.append(", ");
-            fixInitials(initials, stringBuilder);
-            return stringBuilder.toString();
-        }
-        matcher = AuthorsFormatter.FDOT_F_LAST.matcher(name);
-        if (matcher.matches()) {
-            String initials = matcher.group(1).replaceAll("[\\. ]+", "");
-            StringBuilder stringBuilder = new StringBuilder(matcher.group(2));
-            stringBuilder.append(", ");
-            fixInitials(initials, stringBuilder);
-            return stringBuilder.toString();
-        }
-
-        if (name.indexOf(',') >= 0) {
-            // Name contains comma
-            int index = name.lastIndexOf(',');
-            // If the comma is at the end of the name, just remove it to prevent index error:
-            if (index == (name.length() - 1)) {
-                name = name.substring(0, name.length() - 1);
-            }
-
-            StringBuilder stringBuilder = new StringBuilder(name.substring(0, index));
-            stringBuilder.append(", ");
-            // Check if the remainder is a single name:
-            String firstName = name.substring(index + 1).trim();
-            String[] firstNameParts = firstName.split(" ");
-            if (firstNameParts.length > 1) {
-                // Multiple parts. Add all of them, and add a dot if they are single letter parts:
-                for (int i = 0; i < firstNameParts.length; i++) {
-                    if (firstNameParts[i].length() == 1) {
-                        stringBuilder.append(firstNameParts[i]).append('.');
-                    } else {
-                        stringBuilder.append(firstNameParts[i]);
-                    }
-                    if (i < (firstNameParts.length - 1)) {
-                        stringBuilder.append(' ');
-                    }
-                }
-            } else {
-                // Only a single part. Check if it looks like a name or initials:
-                Matcher nameMatcher = AuthorsFormatter.SINGLE_NAME.matcher(firstNameParts[0]);
-                if (nameMatcher.matches()) {
-                    stringBuilder.append(firstNameParts[0]);
-                } else {
-                    // It looks like initials.
-                    String initials = firstNameParts[0].replaceAll("[\\.]+", "");
-                    fixInitials(initials, stringBuilder);
-                }
-
-            }
-            return stringBuilder.toString();
-        } else {
-            // Name doesn't contain comma
-            String[] parts = name.split(" +");
-            boolean allNames = true;
-            for (String part : parts) {
-                matcher = AuthorsFormatter.SINGLE_NAME.matcher(part);
-                if (!matcher.matches()) {
-                    allNames = false;
-                    break;
-                }
-            }
-            if (allNames) {
-                // Looks like a name written in full with first name first.
-                // Change into last name first format:
-                StringBuilder stringBuilder = new StringBuilder(parts[parts.length - 1]);
-                if (parts.length > 1) {
-                    stringBuilder.append(',');
-                    for (int i = 0; i < (parts.length - 1); i++) {
-                        stringBuilder.append(' ').append(parts[i]);
-                        if (parts[i].length() == 1) {
-                            stringBuilder.append('.');
-                        }
-                    }
-                }
-                return stringBuilder.toString();
-            }
-        }
-
-        return name;
-    }
-
-    private static void fixInitials(final String initials, final StringBuilder stringBuilder) {
-        for (int i = 0; i < initials.length(); i++) {
-            stringBuilder.append(initials.charAt(i));
-            stringBuilder.append('.');
-            if (i < (initials.length() - 1)) {
-                stringBuilder.append(' ');
-            }
-        }
-    }
 }

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/AuthorsFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/AuthorsFormatterTest.java
@@ -1,10 +1,16 @@
 package net.sf.jabref.logic.formatter.bibtexfields;
 
-import org.junit.After;
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
 
+@RunWith(Parameterized.class)
 public class AuthorsFormatterTest {
     private AuthorsFormatter formatter;
 
@@ -13,40 +19,50 @@ public class AuthorsFormatterTest {
         formatter = new AuthorsFormatter();
     }
 
-    @After
-    public void tearDown() {
-        formatter = null;
+    @Parameterized.Parameters(name = "{index}: {1} -> {0}")
+    public static Collection<Object[]> authorList() {
+        return Arrays.asList(
+
+                new Object[] {"Bilbo, Staci D.", "Staci D Bilbo"},
+
+                // First case, where AuthorList is better than the original AuthorsFormatter
+                new Object[] {"Bilbo, Staci D.", "Staci D. Bilbo"},
+
+                new Object[] {"Bilbo, Staci D. and Smith, S. H. and Schwarz, Jaclyn M.",
+                        "Staci D Bilbo and Smith SH and Jaclyn M Schwarz"},
+
+                new Object[] {"Ølver, M. A.", "Ølver MA"},
+
+                new Object[] {
+                        "Ølver, M. A. and Øie, G. G. and Øie, G. G. and Alfredsen, J. Å. Å. and Alfredsen, Jo and Olsen, Y. Y. and Olsen, Y. Y.",
+                        "Ølver MA, GG Øie, Øie GG, Alfredsen JÅÅ, Jo Alfredsen, Olsen Y.Y. and Olsen Y. Y."},
+
+                new Object[] {
+                        "Ølver, M. A. and Øie, G. G. and Øie, G. G. and Alfredsen, J. Å. Å. and Alfredsen, Jo and Olsen, Y. Y. and Olsen, Y. Y.",
+                        "Ølver MA, GG Øie, Øie GG, Alfredsen JÅÅ, Jo Alfredsen, Olsen Y.Y., Olsen Y. Y."},
+
+                new Object[] {"Alver, Morten and Alver, Morten O. and Alfredsen, J. A. and Olsen, Y. Y.",
+                        "Alver, Morten and Alver, Morten O and Alfredsen, JA and Olsen, Y.Y."},
+
+                new Object[] {"Alver, M. A. and Alfredsen, J. A. and Olsen, Y. Y.",
+                        "Alver, MA; Alfredsen, JA; Olsen Y.Y."},
+
+                // Second case, where AuthorList is better than the original AuthorsFormatter
+                new Object[] {"Kolb, Stefan and Lenhard, J{\\\"o}rg and Wirtz, Guido",
+                        "Kolb, Stefan and J{\\\"o}rg Lenhard and Wirtz, Guido"});
     }
 
-    @Test
-    public void returnsFormatterName() {
-        Assert.assertNotNull(formatter.getName());
-        Assert.assertNotEquals("", formatter.getName());
-    }
+
+    @Parameter(value = 0)
+    public String expectedNames;
+
+    @Parameter(value = 1)
+    public String namesToNormalize;
+
 
     @Test
     public void testNormalizeAuthorList() {
-        expectCorrect("Staci D Bilbo", "Bilbo, Staci D.");
-        expectCorrect("Staci D. Bilbo", "Staci D. Bilbo"); // TODO strange behaviour
-
-        expectCorrect("Staci D Bilbo and Smith SH and Jaclyn M Schwarz", "Bilbo, Staci D. and Smith, S. H. and Schwarz, Jaclyn M.");
-
-        expectCorrect("Ølver MA", "Ølver, M. A.");
-
-        expectCorrect("Ølver MA, GG Øie, Øie GG, Alfredsen JÅÅ, Jo Alfredsen, Olsen Y.Y. and Olsen Y. Y.",
-                "Ølver, M. A. and Øie, G. G. and Øie, G. G. and Alfredsen, J. Å. Å. and Alfredsen, Jo and Olsen, Y. Y. and Olsen, Y. Y.");
-
-        expectCorrect("Ølver MA, GG Øie, Øie GG, Alfredsen JÅÅ, Jo Alfredsen, Olsen Y.Y., Olsen Y. Y.",
-                "Ølver, M. A. and Øie, G. G. and Øie, G. G. and Alfredsen, J. Å. Å. and Alfredsen, Jo and Olsen, Y. Y. and Olsen, Y. Y.");
-
-        expectCorrect("Alver, Morten and Alver, Morten O and Alfredsen, JA and Olsen, Y.Y.", "Alver, Morten and Alver, Morten O. and Alfredsen, J. A. and Olsen, Y. Y.");
-
-        expectCorrect("Alver, MA; Alfredsen, JA; Olsen Y.Y.", "Alver, M. A. and Alfredsen, J. A. and Olsen, Y. Y.");
-
-        // TODO: expectCorrect("Kolb, Stefan and J{\\\"o}rg Lenhard and Wirtz, Guido", "Kolb, Stefan and Lenhard, J{\\\"o}rg and Wirtz, Guido");
+        Assert.assertEquals(expectedNames, formatter.format(namesToNormalize));
     }
 
-    private void expectCorrect(String input, String expected) {
-        Assert.assertEquals(expected, formatter.format(input));
-    }
 }

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/AuthorsFormatterTestNonParamterized.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/AuthorsFormatterTestNonParamterized.java
@@ -1,0 +1,22 @@
+package net.sf.jabref.logic.formatter.bibtexfields;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AuthorsFormatterTestNonParamterized {
+
+    private AuthorsFormatter formatter;
+
+    @Before
+    public void setUp() {
+        formatter = new AuthorsFormatter();
+    }
+
+    @Test
+    public void returnsFormatterName() {
+        Assert.assertNotNull(formatter.getName());
+        Assert.assertNotEquals("", formatter.getName());
+    }
+
+}


### PR DESCRIPTION
This PR demonstrates a straight-forward replacement of AuthorsFormatter by AuthorList. It shows that *none* of the cases treated by the current AuthorsFormatterTest can be treated by AuthorList. Only two cases not being handled by AuthorsFormatter can be handled by AuthorList.

I identified three things what the AuthorsFormatter does:

1. It adds dots after Initials. Meaning: A L Some gets Some, A. L.
2. It separates initials: Meaning: AL Some gets Some, A. L.
3. It knows what initials are: Olsen Y.Y. gets Olsen, Y.Y. (and not Y.Y. Olsen)

![grabbed_20160313-123654](https://cloud.githubusercontent.com/assets/1366654/13728422/4fa5b0a8-e918-11e5-8c76-0f4767e19bb3.png)
