### PR TITLE
Add test to metadata serialization

### DIFF
--- a/src/main/java/net/sf/jabref/BibDatabaseContext.java
+++ b/src/main/java/net/sf/jabref/BibDatabaseContext.java
@@ -58,7 +58,7 @@ public class BibDatabaseContext {
     }
 
     public void setMode(BibDatabaseMode bibDatabaseMode) {
-        metaData.putData(MetaData.DATABASE_TYPE, Collections.singletonList(bibDatabaseMode.getFormattedName()));
+        metaData.setMode(bibDatabaseMode);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -23,6 +23,7 @@ import net.sf.jabref.groups.GroupTreeNode;
 import net.sf.jabref.logic.config.SaveOrderConfig;
 import net.sf.jabref.logic.labelpattern.AbstractLabelPattern;
 import net.sf.jabref.logic.labelpattern.DatabaseLabelPattern;
+import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.migrations.VersionHandling;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
@@ -352,7 +353,7 @@ public class MetaData implements Iterable<String> {
      * @param labelPattern the key patterns to update to. <br />
      *                     A reference to this object is stored internally and is returned at getLabelPattern();
      */
-    public void setLabelPattern(DatabaseLabelPattern labelPattern) {
+    public void setLabelPattern(AbstractLabelPattern labelPattern) {
         // remove all keypatterns from metadata
         Iterator<String> iterator = this.iterator();
         while (iterator.hasNext()) {
@@ -432,5 +433,91 @@ public class MetaData implements Iterable<String> {
         } else {
             return Optional.of(fileDirectory.get(0).trim());
         }
+    }
+
+    /**
+     * Writes all data in the format <key, serialized data>.
+     */
+    public Map<String, String> serialize() throws IOException {
+
+        Map<String, String> serializedMetaData = new TreeMap<>();
+
+        // first write all meta data except groups
+        for (Map.Entry<String, List<String>> metaItem : metaData.entrySet()) {
+
+            StringBuilder stringBuilder = new StringBuilder();
+            for (String dataItem : metaItem.getValue()) {
+                stringBuilder.append(StringUtil.quote(dataItem, ";", '\\')).append(";");
+
+                //in case of save actions, add an additional newline after the enabled flag
+                if (metaItem.getKey().equals(SaveActions.META_KEY) && "enabled".equals(dataItem)) {
+                    stringBuilder.append(Globals.NEWLINE);
+                }
+            }
+
+            serializedMetaData.put(metaItem.getKey(), stringBuilder.toString());
+        }
+
+        // write groups if present. skip this if only the root node exists
+        // (which is always the AllEntriesGroup).
+        if ((groupsRoot != null) && (groupsRoot.getChildCount() > 0)) {
+
+            // write version first
+            serializedMetaData.put(MetaData.GROUPSVERSION, Integer.toString(VersionHandling.CURRENT_VERSION));
+
+            // now write actual groups
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.append(Globals.NEWLINE);
+            // GroupsTreeNode.toString() uses "\n" for separation
+            StringTokenizer tok = new StringTokenizer(groupsRoot.getTreeAsString(), Globals.NEWLINE);
+            while (tok.hasMoreTokens()) {
+                stringBuilder.append(StringUtil.quote(tok.nextToken(), ";", '\\'));
+                stringBuilder.append(";");
+                stringBuilder.append(Globals.NEWLINE);
+            }
+            serializedMetaData.put(MetaData.GROUPSTREE, stringBuilder.toString());
+        }
+
+        return serializedMetaData;
+    }
+
+    public void setSaveActions(SaveActions saveActions) {
+        List<String> actionsSerialized = new ArrayList<>();
+
+        if (saveActions.isEnabled()) {
+            actionsSerialized.add("enabled");
+        } else {
+            actionsSerialized.add("disabled");
+        }
+
+        String formatterString = SaveActions.getMetaDataString(saveActions.getConfiguredActions());
+        actionsSerialized.add(formatterString);
+
+        putData(SaveActions.META_KEY, actionsSerialized);
+    }
+
+    public void setSaveOrderConfig(SaveOrderConfig saveOrderConfig) {
+        List<String> serialized = saveOrderConfig.getConfigurationList();
+        putData(MetaData.SAVE_ORDER_CONFIG, serialized);
+    }
+
+    public void setMode(BibDatabaseMode mode) {
+        putData(MetaData.DATABASE_TYPE, Collections.singletonList(mode.getFormattedName()));
+    }
+
+    public void markAsProtected() {
+        putData(Globals.PROTECTED_FLAG_META, Collections.singletonList("true"));
+    }
+
+    public void setContentSelectors(String fieldName, List<String> contentSelectors) {
+        putData(Globals.SELECTOR_META_PREFIX + fieldName, contentSelectors);
+    }
+
+    public void setDefaultFileDirectory(String path) {
+        putData(FILE_DIRECTORY, Collections.singletonList(path));
+    }
+
+    public void setUserFileDirectory(String user, String path) {
+        putData(FILE_DIRECTORY + '-' + user, Collections.singletonList(path));
     }
 }

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -463,7 +463,7 @@ public class MetaData implements Iterable<String> {
         if ((groupsRoot != null) && (groupsRoot.getChildCount() > 0)) {
 
             // write version first
-            serializedMetaData.put(MetaData.GROUPSVERSION, Integer.toString(VersionHandling.CURRENT_VERSION));
+            serializedMetaData.put(MetaData.GROUPSVERSION, Integer.toString(VersionHandling.CURRENT_VERSION) + ";");
 
             // now write actual groups
             StringBuilder stringBuilder = new StringBuilder();

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -455,7 +455,11 @@ public class MetaData implements Iterable<String> {
                 }
             }
 
-            serializedMetaData.put(metaItem.getKey(), stringBuilder.toString());
+            String serializedItem = stringBuilder.toString();
+            // Only add non-empty values
+            if (!serializedItem.isEmpty() && !serializedItem.equals(";")) {
+                serializedMetaData.put(metaItem.getKey(), serializedItem);
+            }
         }
 
         // write groups if present. skip this if only the root node exists

--- a/src/main/java/net/sf/jabref/exporter/BibDatabaseWriter.java
+++ b/src/main/java/net/sf/jabref/exporter/BibDatabaseWriter.java
@@ -271,52 +271,18 @@ public class BibDatabaseWriter {
             return;
         }
 
-        // first write all meta data except groups
-        for (String key : metaData) {
+        Map<String, String> serializedMetaData = metaData.serialize();
+
+        for(Map.Entry<String, String> metaItem : serializedMetaData.entrySet()) {
 
             StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.append(Globals.NEWLINE);
-            stringBuilder.append(COMMENT_PREFIX + "{").append(MetaData.META_FLAG).append(key).append(":");
-
-            for (String metaItem : metaData.getData(key)) {
-                stringBuilder.append(StringUtil.quote(metaItem, ";", '\\')).append(";");
-
-                //in case of save actions, add an additional newline after the enabled flag
-                if (key.equals(SaveActions.META_KEY) && "enabled".equals(metaItem)) {
-                    stringBuilder.append(Globals.NEWLINE);
-                }
-            }
+            stringBuilder.append(COMMENT_PREFIX + "{").append(MetaData.META_FLAG).append(metaItem.getKey()).append(":");
+            stringBuilder.append(metaItem.getValue());
             stringBuilder.append("}");
             stringBuilder.append(Globals.NEWLINE);
 
             out.write(stringBuilder.toString());
-        }
-        // write groups if present. skip this if only the root node exists
-        // (which is always the AllEntriesGroup).
-        GroupTreeNode groupsRoot = metaData.getGroups();
-        if ((groupsRoot != null) && (groupsRoot.getChildCount() > 0)) {
-            StringBuilder sb = new StringBuilder();
-            // write version first
-            sb.append(Globals.NEWLINE);
-            sb.append(COMMENT_PREFIX).append("{").append(MetaData.META_FLAG).append(MetaData.GROUPSVERSION).append(":");
-            sb.append(VersionHandling.CURRENT_VERSION).append(";");
-            sb.append("}");
-            sb.append(Globals.NEWLINE);
-
-            // now write actual groups
-            sb.append(Globals.NEWLINE);
-            sb.append(COMMENT_PREFIX).append("{").append(MetaData.META_FLAG).append(MetaData.GROUPSTREE).append(":");
-            sb.append(Globals.NEWLINE);
-            // GroupsTreeNode.toString() uses "\n" for separation
-            StringTokenizer tok = new StringTokenizer(groupsRoot.getTreeAsString(), Globals.NEWLINE);
-            while (tok.hasMoreTokens()) {
-                sb.append(StringUtil.quote(tok.nextToken(), ";", '\\'));
-                sb.append(";");
-                sb.append(Globals.NEWLINE);
-            }
-            sb.append("}");
-            sb.append(Globals.NEWLINE);
-            out.write(sb.toString());
         }
     }
 

--- a/src/test/java/net/sf/jabref/MetaDataTest.java
+++ b/src/test/java/net/sf/jabref/MetaDataTest.java
@@ -1,0 +1,38 @@
+package net.sf.jabref;
+
+import net.sf.jabref.exporter.SaveActions;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.junit.Assert.*;
+
+public class MetaDataTest {
+
+    private MetaData metaData;
+
+    @Before
+    public void setUp() {
+        metaData = new MetaData();
+    }
+
+    @Test
+    public void serializeNewMetadataReturnsEmptyMap() throws Exception {
+        assertEquals(Collections.emptyMap(), metaData.serialize());
+    }
+
+    @Test
+    public void serializeSingleSaveAction() throws Exception {
+        SaveActions saveActions = new SaveActions(true, "title[LowerCaseChanger]");
+        metaData.setSaveActions(saveActions);
+
+        Map<String, String> expectedSerialization = new TreeMap<>();
+        expectedSerialization.put("saveActions",
+                "enabled;" + Globals.NEWLINE + "title[LowerCaseChanger]" + Globals.NEWLINE + ";");
+        assertEquals(expectedSerialization, metaData.serialize());
+    }
+}

--- a/src/test/java/net/sf/jabref/exporter/BibDatabaseWriterTest.java
+++ b/src/test/java/net/sf/jabref/exporter/BibDatabaseWriterTest.java
@@ -400,4 +400,22 @@ public class BibDatabaseWriterTest {
                 Globals.NEWLINE + "@Comment{jabref-meta: fileDirectory-defaultOwner-user:D:\\\\Documents;}"
                 + Globals.NEWLINE, stringWriter.toString());
     }
+
+    @Test
+    public void writeNotEmptyContentSelectors() throws Exception {
+        metaData.setContentSelectors("title", Arrays.asList(""));
+
+        databaseWriter.writePartOfDatabase(stringWriter, bibtexContext, Collections.emptyList(), new SavePreferences());
+
+        assertEquals("", stringWriter.toString());
+    }
+
+    @Test
+    public void writeNotCompletelyEmptyContentSelectors() throws Exception {
+        metaData.setContentSelectors("title", Collections.emptyList());
+
+        databaseWriter.writePartOfDatabase(stringWriter, bibtexContext, Collections.emptyList(), new SavePreferences());
+
+        assertEquals("", stringWriter.toString());
+    }
 }

--- a/src/test/java/net/sf/jabref/exporter/BibDatabaseWriterTest.java
+++ b/src/test/java/net/sf/jabref/exporter/BibDatabaseWriterTest.java
@@ -179,13 +179,13 @@ public class BibDatabaseWriterTest {
         databaseWriter.writePartOfDatabase(stringWriter, bibtexContext, Collections.emptyList(), new SavePreferences());
 
         // @formatter:off
-        Assert.assertEquals(Globals.NEWLINE +
-                "@Comment{jabref-meta: groupsversion:3;}" + Globals.NEWLINE
-                + Globals.NEWLINE
+        Assert.assertEquals(Globals.NEWLINE
                 + "@Comment{jabref-meta: groupstree:" + Globals.NEWLINE
                 + "0 AllEntriesGroup:;" + Globals.NEWLINE
                 + "1 ExplicitGroup:test\\;2\\;;" + Globals.NEWLINE
-                + "}" + Globals.NEWLINE, stringWriter.toString());
+                + "}" + Globals.NEWLINE
+                + Globals.NEWLINE
+                + "@Comment{jabref-meta: groupsversion:3;}" + Globals.NEWLINE, stringWriter.toString());
         // @formatter:on
     }
 
@@ -202,13 +202,13 @@ public class BibDatabaseWriterTest {
         // @formatter:off
         Assert.assertEquals(
                 "% Encoding: US-ASCII" + Globals.NEWLINE +
-                Globals.NEWLINE +
-                "@Comment{jabref-meta: groupsversion:3;}" + Globals.NEWLINE
-                + Globals.NEWLINE
+                Globals.NEWLINE
                 + "@Comment{jabref-meta: groupstree:" + Globals.NEWLINE
                 + "0 AllEntriesGroup:;" + Globals.NEWLINE
                 + "1 ExplicitGroup:test\\;2\\;;" + Globals.NEWLINE
-                + "}" + Globals.NEWLINE, stringWriter.toString());
+                + "}" + Globals.NEWLINE
+                + Globals.NEWLINE
+                + "@Comment{jabref-meta: groupsversion:3;}" + Globals.NEWLINE, stringWriter.toString());
         // @formatter:on
     }
 

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -1428,7 +1428,7 @@ public class BibtexParserTest {
     }
 
     @Test
-    public void integrationTestFileDirectory() throws IOException {
+    public void integrationTestFileDirectories() throws IOException {
         ParserResult result = BibtexParser.parse(new StringReader(
                 "@comment{jabref-meta: fileDirectory:\\\\Literature\\\\;}" +
                 "@comment{jabref-meta: fileDirectory-defaultOwner-user:D:\\\\Documents;}"));

--- a/src/test/resources/testbib/complex.bib
+++ b/src/test/resources/testbib/complex.bib
@@ -283,16 +283,26 @@
 
 @Comment{jabref-meta: DATABASE_TYPE:BibLaTeX;}
 
-@Comment{jabref-meta: keypatterndefault:[authors3][year];}
+@Comment{jabref-meta: fileDirectory:\\Literature\\;}
 
-@Comment{jabref-meta: saveOrderConfig:specified;author;false;address;false;bibtexkey;false;}
-
-@Comment{jabref-meta: groupsversion:3;}
+@Comment{jabref-meta: fileDirectory-defaultOwner-user:D:\\Documents;}
 
 @Comment{jabref-meta: groupstree:
 0 AllEntriesGroup:;
 1 ExplicitGroup:StaticGroup\;0\;1137631\;1233448\;1314293\;;
 1 KeywordGroup:DynamicGroup\;0\;author\;Churchill\;0\;0\;;
 }
+
+@Comment{jabref-meta: groupsversion:3;}
+
+@Comment{jabref-meta: keypattern_article:articleTest;}
+
+@Comment{jabref-meta: keypatterndefault:[authors3][year];}
+
+@Comment{jabref-meta: protectedFlag:true;}
+
+@Comment{jabref-meta: saveOrderConfig:specified;author;false;address;false;bibtexkey;false;}
+
+@Comment{jabref-meta: selector_title:testWord;word2;}
 
 Some trailing text


### PR DESCRIPTION
Changes:
- `@comment{groups...}` is now in the right position (based on alphabetical order of metadata keys)
- Empty content selectors are no longer written

Code changes:
-  Add tests for metadata serialization
- Move  the biggest part of metadataserialization to metadata class (probably not the final solution, just eased writing tests)
- Add a few methods which allow to change the metadata in a typed fashion
- Cleanup BibDataBasewriter tests
 
-
- [x] Change in CHANGELOG.md described? (not big enough for changelog entry)
- [x] Changes in pull request outlined? (What, why, ...)
- [x] Tests created for changes? 
- [x] Tests green?
