### PR TITLE
Make tabbedPane in mainframe private

### DIFF
--- a/src/main/java/net/sf/jabref/exporter/SaveAllAction.java
+++ b/src/main/java/net/sf/jabref/exporter/SaveAllAction.java
@@ -36,7 +36,6 @@ public class SaveAllAction extends MnemonicAwareAction implements Worker {
 
     private final JabRefFrame frame;
     private int databases;
-    private int saved;
 
 
     /** Creates a new instance of SaveAllAction */
@@ -50,8 +49,7 @@ public class SaveAllAction extends MnemonicAwareAction implements Worker {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        databases = frame.getTabbedPane().getTabCount();
-        saved = 0;
+        databases = frame.getBasePanelCount();
         frame.output(Localization.lang("Saving all databases..."));
         Spin.off(this);
         run();
@@ -61,14 +59,13 @@ public class SaveAllAction extends MnemonicAwareAction implements Worker {
     @Override
     public void run() {
         for (int i = 0; i < databases; i++) {
-            if (i < frame.getTabbedPane().getTabCount()) {
+            if (i < frame.getBasePanelCount()) {
                 BasePanel panel = frame.getBasePanelAt(i);
                 if (panel.getBibDatabaseContext().getDatabaseFile() == null) {
                     frame.showBasePanelAt(i);
                 }
                 panel.runCommand(Actions.SAVE);
                 // TODO: can we find out whether the save was actually done or not?
-                saved++;
             }
         }
     }

--- a/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
@@ -756,7 +756,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
             dispose();
             SwingUtilities.invokeLater(() -> {
                 if (newDatabase) {
-                    frame.addTab(panel, null, true);
+                    frame.addTab(panel, true);
                 }
                 panel.markBaseChanged();
 

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -98,7 +98,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     // The sidepane manager takes care of populating the sidepane.
     public SidePaneManager sidePaneManager;
 
-    public JTabbedPane tabbedPane; // initialized at constructor
+    private JTabbedPane tabbedPane; // initialized at constructor
 
     private final Insets marg = new Insets(1, 0, 2, 0);
     private final JabRef jabRef;
@@ -994,7 +994,6 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     /**
      * Returns a list of BasePanel.
      *
-     * @param i Index of base
      */
     public List<BasePanel> getBasePanelList() {
         List<BasePanel> returnList = new ArrayList<>(getBasePanelCount());
@@ -1609,7 +1608,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
         Defaults defaults = new Defaults(BibDatabaseMode.fromPreference(Globals.prefs.getBoolean(JabRefPreferences.BIBLATEX_DEFAULT_MODE)));
         BasePanel bp = new BasePanel(JabRefFrame.this, new BibDatabaseContext(db, metaData, file, defaults), encoding);
-        addTab(bp, file, raisePanel);
+        addTab(bp, raisePanel);
         return bp;
     }
 
@@ -1651,13 +1650,14 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
                 // set original filename (again)
                 tabbedPane.setTitleAt(i, getBasePanelAt(i).getTabTitle());
             }
+            tabbedPane.setToolTipTextAt(i, file == null ? null : file.getAbsolutePath());
         }
     }
 
-    public void addTab(BasePanel bp, File file, boolean raisePanel) {
+    public void addTab(BasePanel bp, boolean raisePanel) {
         // add tab
         tabbedPane.add(bp.getTabTitle(), bp);
-        tabbedPane.setToolTipTextAt(tabbedPane.getTabCount() - 1, file == null ? null : file.getAbsolutePath());
+
         // update all tab titles
         updateAllTabTitles();
 

--- a/src/main/java/net/sf/jabref/gui/SidePaneManager.java
+++ b/src/main/java/net/sf/jabref/gui/SidePaneManager.java
@@ -57,8 +57,8 @@ public class SidePaneManager {
          * side pane components, we get rid of the annoying latency when
          * switching tabs:
          */
-        frame.tabbedPane.addChangeListener(event -> SwingUtilities.invokeLater(
-                () -> setActiveBasePanel((BasePanel) SidePaneManager.this.frame.tabbedPane.getSelectedComponent())));
+        frame.getTabbedPane().addChangeListener(event -> SwingUtilities.invokeLater(
+                () -> setActiveBasePanel(SidePaneManager.this.frame.getCurrentBasePanel())));
         sidep = new SidePane();
         sidep.setVisible(false);
     }

--- a/src/main/java/net/sf/jabref/gui/actions/NewEntryAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/NewEntryAction.java
@@ -57,9 +57,10 @@ public class NewEntryAction extends MnemonicAwareAction {
             thisType = tp.getName();
         }
 
-        if (jabRefFrame.tabbedPane.getTabCount() > 0) {
-            ((BasePanel) jabRefFrame.tabbedPane.getSelectedComponent())
-                    .newEntry(EntryTypes.getType(thisType, jabRefFrame.getCurrentBasePanel().getBibDatabaseContext().getMode()).get());
+        if (jabRefFrame.getBasePanelCount() > 0) {
+            jabRefFrame.getCurrentBasePanel().newEntry(
+                    EntryTypes.getType(thisType, jabRefFrame.getCurrentBasePanel().getBibDatabaseContext().getMode())
+                            .get());
         } else {
             LOGGER.info("Action 'New entry' must be disabled when no database is open.");
         }

--- a/src/main/java/net/sf/jabref/gui/actions/NewSubDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/NewSubDatabaseAction.java
@@ -31,17 +31,17 @@ public class NewSubDatabaseAction extends MnemonicAwareAction {
     public void actionPerformed(ActionEvent e) {
         // Create a new, empty, database.
 
-        FromAuxDialog dialog = new FromAuxDialog(jabRefFrame, "", true, jabRefFrame.tabbedPane);
+        FromAuxDialog dialog = new FromAuxDialog(jabRefFrame, "", true, jabRefFrame.getTabbedPane());
 
         PositionWindow.placeDialog(dialog, jabRefFrame);
         dialog.setVisible(true);
 
         if (dialog.generatePressed()) {
-            Defaults defaults = new Defaults(BibDatabaseMode.fromPreference(Globals.prefs.getBoolean(JabRefPreferences.BIBLATEX_DEFAULT_MODE)));
-            BasePanel bp = new BasePanel(jabRefFrame,
-                    new BibDatabaseContext(dialog.getGenerateDB(), defaults), Globals.prefs.getDefaultEncoding()); // meta data
-            jabRefFrame.tabbedPane.add(GUIGlobals.untitledTitle, bp);
-            jabRefFrame.tabbedPane.setSelectedComponent(bp);
+            Defaults defaults = new Defaults(
+                    BibDatabaseMode.fromPreference(Globals.prefs.getBoolean(JabRefPreferences.BIBLATEX_DEFAULT_MODE)));
+            BasePanel bp = new BasePanel(jabRefFrame, new BibDatabaseContext(dialog.getGenerateDB(), defaults),
+                    Globals.prefs.getDefaultEncoding()); // meta data
+            jabRefFrame.addTab(bp, true);
             jabRefFrame.output(Localization.lang("New database created."));
         }
     }

--- a/src/main/java/net/sf/jabref/gui/actions/SortTabsAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/SortTabsAction.java
@@ -44,17 +44,16 @@ public class SortTabsAction extends MnemonicAwareAction implements Comparator<St
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        JTabbedPane tabbedPane = frame.getTabbedPane();
         // Make a sorted Map that compares case-insensitively:
         TreeMap<String, BasePanel> map = new TreeMap<>(this);
 
-        for (int i = 0; i < tabbedPane.getTabCount(); i++) {
-            BasePanel panel = (BasePanel) tabbedPane.getComponent(i);
-            map.put(tabbedPane.getTitleAt(i), panel);
+        for (BasePanel panel : frame.getBasePanelList()) {
+            map.put(panel.getTabTitle(), panel);
         }
-        tabbedPane.removeAll();
+
+        frame.getTabbedPane().removeAll();
         for (Map.Entry<String, BasePanel> entry : map.entrySet()) {
-            tabbedPane.addTab(entry.getKey(), entry.getValue());
+            frame.addTab(entry.getValue(), false);
         }
     }
 

--- a/src/main/java/net/sf/jabref/gui/preftabs/EntryEditorPrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/EntryEditorPrefsTab.java
@@ -279,9 +279,8 @@ class EntryEditorPrefsTab extends JPanel implements PrefsTab {
                 (oldAutoCompFF != autoCompFF.isSelected()) || (oldAutoCompLF != autoCompLF.isSelected()) ||
                 (oldAutoCompFModeAbbr != firstNameModeAbbr.isSelected()) ||
                 (oldAutoCompFModeFull != firstNameModeFull.isSelected())) {
-            for (int j = 0; j < frame.getTabbedPane().getTabCount(); j++) {
-                BasePanel bp = (BasePanel) frame.getTabbedPane().getComponentAt(j);
-                bp.entryEditors.clear();
+            for (BasePanel panel : frame.getBasePanelList()) {
+                panel.entryEditors.clear();
             }
         }
     }

--- a/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
@@ -106,17 +106,15 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
 
         private final BasePanel basePanel;
         private final boolean raisePanel;
-        private final File file;
 
-        OpenItSwingHelper(BasePanel basePanel, File file, boolean raisePanel) {
+        OpenItSwingHelper(BasePanel basePanel, boolean raisePanel) {
             this.basePanel = basePanel;
             this.raisePanel = raisePanel;
-            this.file = file;
         }
 
         @Override
         public void run() {
-            frame.addTab(basePanel, file, raisePanel);
+            frame.addTab(basePanel, raisePanel);
 
         }
     }
@@ -342,7 +340,7 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
         BasePanel basePanel = new BasePanel(frame, new BibDatabaseContext(database, meta, file, defaults), result.getEncoding());
 
         // file is set to null inside the EventDispatcherThread
-        SwingUtilities.invokeLater(new OpenItSwingHelper(basePanel, file, raisePanel));
+        SwingUtilities.invokeLater(new OpenItSwingHelper(basePanel, raisePanel));
 
         frame.output(Localization.lang("Opened database") + " '" + fileName + "' " + Localization.lang("with") + " "
                 + database.getEntryCount() + " " + Localization.lang("entries") + ".");


### PR DESCRIPTION
Triggered by #931. 
- Makes tabbedPane in mainframe private
- Set tab tooltips in consistent way (for example they should now also show up after the tab list is sorted)

-
- [x] Change in CHANGELOG.md described? not worth it
- [x] Changes in pull request outlined? (What, why, ...)
- [x] Tests created for changes? well....
- [x] Tests green?
