### PR TITLE
Fixes #962 Do not split Regexes and only match on entire fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - [#454](https://github.com/JabRef/jabref/issues/454) Add a tab that shows all remaining entry fields that are not displayed in any other tab
 - The LaTeX to Unicode/HTML functionality is much improved by covering many more cases
 - Ability to convert from LaTeX to Unicode in right-click field menu
-
+- Regex-based search is know only applied entirely and not split up to different Regexes on whitespaces
 - [#492](https://github.com/JabRef/jabref/issues/492): If no text is marked, the whole field is copied. Preview of pasted text in tool tip
 - Integrity check now also checks broken file links, abbreviations in journal and booktitle, and incorrect use of proceedings with page numbers
 - PdfContentImporter does not write the content of the first page into the review field any more

--- a/src/main/java/net/sf/jabref/logic/search/SearchQueryHighlightObservable.java
+++ b/src/main/java/net/sf/jabref/logic/search/SearchQueryHighlightObservable.java
@@ -67,6 +67,8 @@ public class SearchQueryHighlightObservable {
         // Parse the search string to words
         if (searchQuery.isGrammarBasedSearch()) {
             pattern = Optional.empty();
+        } else if (searchQuery.isRegularExpression()) {
+            pattern = getPatternForWords(Arrays.asList(searchQuery.getQuery()), true, searchQuery.isCaseSensitive());
         } else {
             pattern = getPatternForWords(getSearchwords(searchQuery.getQuery()), searchQuery.isRegularExpression(), searchQuery.isCaseSensitive());
         }

--- a/src/test/java/net/sf/jabref/logic/search/rules/ContainBasedSearchRuleTest.java
+++ b/src/test/java/net/sf/jabref/logic/search/rules/ContainBasedSearchRuleTest.java
@@ -28,7 +28,7 @@ public class ContainBasedSearchRuleTest {
         Assert.assertEquals(false, bsCaseSensitive.applyRule(query, be));
         Assert.assertEquals(true, bsCaseInsensitive.applyRule(query, be));
         Assert.assertEquals(false, bsCaseSensitiveRegexp.applyRule(query, be));
-        Assert.assertEquals(true, bsCaseInsensitiveRegexp.applyRule(query, be));
+        Assert.assertEquals(false, bsCaseInsensitiveRegexp.applyRule(query, be));
 
         query = "\"marine larviculture\"";
 
@@ -37,7 +37,7 @@ public class ContainBasedSearchRuleTest {
         Assert.assertEquals(false, bsCaseSensitiveRegexp.applyRule(query, be));
         Assert.assertEquals(false, bsCaseInsensitiveRegexp.applyRule(query, be));
 
-        query = "\"marine [A-Za-z]* larviculture\"";
+        query = "marine [A-Za-z]* larviculture";
 
         Assert.assertEquals(false, bsCaseSensitive.applyRule(query, be));
         Assert.assertEquals(false, bsCaseInsensitive.applyRule(query, be));


### PR DESCRIPTION
Attempts to fix the issue with whitespaces in #962.
Currently, all search queries are split on whitespaces and then matched separately on all fields.
This would change with this PR as Regex based search queries are only matched entirely on every field.
- [x] Matching looks fine, 
- [x] the higlighting is still based on splitting the string as far as I can see.

This PR must be assessed carefully to avoid unwanted effects.

