### PR TITLE
Preserve bibtex import order

### DIFF
--- a/src/main/java/net/sf/jabref/exporter/BibDatabaseWriter.java
+++ b/src/main/java/net/sf/jabref/exporter/BibDatabaseWriter.java
@@ -82,7 +82,7 @@ public class BibDatabaseWriter {
      * (such as the exportDatabase call), we do not wish to use the
      * global preference of saving in standard order.
      */
-    public static List<BibEntry> getSortedEntries(BibDatabaseContext bibDatabaseContext, Set<String> keySet,
+    public static List<BibEntry> getSortedEntries(BibDatabaseContext bibDatabaseContext, List<BibEntry> entriesToSort,
             SavePreferences preferences) {
 
         //if no meta data are present, simply return in original order
@@ -97,12 +97,8 @@ public class BibDatabaseWriter {
         FieldComparatorStack<BibEntry> comparatorStack = new FieldComparatorStack<>(comparators);
 
         List<BibEntry> sorted = new ArrayList<>();
-        if (keySet == null) {
-            keySet = bibDatabaseContext.getDatabase().getKeySet();
-        }
-        for (String id : keySet) {
-            sorted.add(bibDatabaseContext.getDatabase().getEntryById(id));
-        }
+        sorted.addAll(entriesToSort);
+
         Collections.sort(sorted, comparatorStack);
 
         return sorted;
@@ -132,11 +128,12 @@ public class BibDatabaseWriter {
      * let the user save only the results of a search. False and false means all
      * entries are saved.
      */
-    public SaveSession saveDatabase(BibDatabaseContext bibDatabaseContext, SavePreferences preferences) throws SaveException {
+    public SaveSession saveDatabase(BibDatabaseContext bibDatabaseContext, SavePreferences preferences)
+            throws SaveException {
         return savePartOfDatabase(bibDatabaseContext, bibDatabaseContext.getDatabase().getEntries(), preferences);
     }
 
-    public SaveSession savePartOfDatabase(BibDatabaseContext bibDatabaseContext, Collection<BibEntry> entries,
+    public SaveSession savePartOfDatabase(BibDatabaseContext bibDatabaseContext, List<BibEntry> entries,
             SavePreferences preferences) throws SaveException {
 
         SaveSession session;
@@ -161,8 +158,8 @@ public class BibDatabaseWriter {
 
     }
 
-    public List<FieldChange> writePartOfDatabase(Writer writer, BibDatabaseContext bibDatabaseContext, Collection<BibEntry> entries,
-            SavePreferences preferences) throws IOException {
+    public List<FieldChange> writePartOfDatabase(Writer writer, BibDatabaseContext bibDatabaseContext,
+            List<BibEntry> entries, SavePreferences preferences) throws IOException {
         Objects.requireNonNull(writer);
 
         // Map to collect entry type definitions that we must save along with entries using them.
@@ -180,8 +177,7 @@ public class BibDatabaseWriter {
         writeStrings(writer, bibDatabaseContext.getDatabase(), preferences.isReformatFile());
 
         // Write database entries.
-        List<BibEntry> sortedEntries = BibDatabaseWriter.getSortedEntries(bibDatabaseContext,
-                entries.stream().map(BibEntry::getId).collect(Collectors.toSet()), preferences);
+        List<BibEntry> sortedEntries = BibDatabaseWriter.getSortedEntries(bibDatabaseContext, entries, preferences);
         List<FieldChange> saveActionChanges = BibDatabaseWriter.applySaveActions(sortedEntries, bibDatabaseContext.getMetaData());
         BibEntryWriter bibtexEntryWriter = new BibEntryWriter(new LatexFieldFormatter(), true);
         for (BibEntry entry : sortedEntries) {
@@ -220,7 +216,7 @@ public class BibDatabaseWriter {
      * supplied input array bes.
      */
     public SaveSession savePartOfDatabase(BibDatabaseContext bibDatabaseContext, SavePreferences preferences,
-            Collection<BibEntry> entries) throws SaveException {
+            List<BibEntry> entries) throws SaveException {
 
         return savePartOfDatabase(bibDatabaseContext, entries, preferences);
     }

--- a/src/main/java/net/sf/jabref/exporter/ExportFormat.java
+++ b/src/main/java/net/sf/jabref/exporter/ExportFormat.java
@@ -167,16 +167,16 @@ public class ExportFormat implements IExportFormat {
      * @param metaData   The database's meta data.
      * @param file       the file to write the resulting export to
      * @param encoding   The encoding of the database
-     * @param entryIds   Contains the IDs of all entries that should be exported. If
+     * @param entries    Contains all entries that should be exported. If
      *                   <code>null</code>, all entries will be exported.
      * @throws IOException if a problem occurred while trying to write to {@code writer}
      *                     or read from required resources.
      * @throws Exception   if any other error occurred during export.
-     * @see net.sf.jabref.exporter.IExportFormat#performExport(BibDatabase, MetaData, String, Charset, Set)
+     * @see net.sf.jabref.exporter.IExportFormat#performExport(BibDatabase, MetaData, String, Charset, List)
      */
     @Override
     public void performExport(final BibDatabase database, final MetaData metaData, final String file,
-            final Charset encoding, Set<String> entryIds) throws Exception {
+            final Charset encoding, List<BibEntry> entries) throws Exception {
 
         File outFile = new File(file);
         SaveSession ss = null;
@@ -228,7 +228,7 @@ public class ExportFormat implements IExportFormat {
                     BibDatabaseMode.fromPreference(Globals.prefs.getBoolean(JabRefPreferences.BIBLATEX_DEFAULT_MODE)));
             SavePreferences savePrefs = SavePreferences.loadForExportFromPreferences(Globals.prefs);
             List<BibEntry> sorted = BibDatabaseWriter.getSortedEntries(
-                    new BibDatabaseContext(database, metaData, defaults), entryIds, savePrefs);
+                    new BibDatabaseContext(database, metaData, defaults), entries, savePrefs);
 
             // Load default layout
             Layout defLayout;

--- a/src/main/java/net/sf/jabref/exporter/ExportFormats.java
+++ b/src/main/java/net/sf/jabref/exporter/ExportFormats.java
@@ -200,13 +200,9 @@ public class ExportFormats {
                         }
                     }
                     final IExportFormat format = eff.getExportFormat();
-                    Set<String> entryIds = null;
+                    List<BibEntry> entries = null;
                     if (selectedOnly) {
-                        List<BibEntry> selected = frame.getCurrentBasePanel().getSelectedEntries();
-                        entryIds = new HashSet<>();
-                        for (BibEntry bibtexEntry : selected) {
-                            entryIds.add(bibtexEntry.getId());
-                        }
+                        entries = frame.getCurrentBasePanel().getSelectedEntries();
                     }
 
                     // Set the global variable for this database's file directory before exporting,
@@ -223,7 +219,7 @@ public class ExportFormats {
                     Globals.prefs.put(JabRefPreferences.EXPORT_WORKING_DIRECTORY, file.getParent());
 
                     final File finFile = file;
-                    final Set<String> finEntryIDs = entryIds;
+                    final List<BibEntry> finEntries = entries;
                     AbstractWorker exportWorker = new AbstractWorker() {
 
                         String errorMessage;
@@ -235,7 +231,7 @@ public class ExportFormats {
                                 format.performExport(frame.getCurrentBasePanel().database(),
                                         frame.getCurrentBasePanel().getBibDatabaseContext().getMetaData(),
                                         finFile.getPath(), frame
-                                                .getCurrentBasePanel().getEncoding(), finEntryIDs);
+                                                .getCurrentBasePanel().getEncoding(), finEntries);
                             } catch (Exception ex) {
                                 LOGGER.warn("Problem exporting", ex);
                                 if (ex.getMessage() == null) {

--- a/src/main/java/net/sf/jabref/exporter/ExportToClipboardAction.java
+++ b/src/main/java/net/sf/jabref/exporter/ExportToClipboardAction.java
@@ -111,11 +111,7 @@ public class ExportToClipboardAction extends AbstractWorker {
             // file, and read the contents afterwards:
             tmp = File.createTempFile("jabrefCb", ".tmp");
             tmp.deleteOnExit();
-            List<BibEntry> bes = panel.getSelectedEntries();
-            Set<String> entries = new HashSet<>(bes.size());
-            for (BibEntry be : bes) {
-                entries.add(be.getId());
-            }
+            List<BibEntry> entries = panel.getSelectedEntries();
 
             // Write to file:
             format.performExport(database, panel.getBibDatabaseContext().getMetaData(),
@@ -134,7 +130,7 @@ public class ExportToClipboardAction extends AbstractWorker {
             RtfSelection rs = new RtfSelection(sb.toString());
             Toolkit.getDefaultToolkit().getSystemClipboard()
                     .setContents(rs, owner);
-            message = Localization.lang("Entries exported to clipboard") + ": " + bes.size();
+            message = Localization.lang("Entries exported to clipboard") + ": " + entries.size();
 
         } catch (Exception e) {
             LOGGER.error("Error exporting to clipboard", e); //To change body of catch statement use File | Settings | File Templates.

--- a/src/main/java/net/sf/jabref/exporter/IExportFormat.java
+++ b/src/main/java/net/sf/jabref/exporter/IExportFormat.java
@@ -17,9 +17,11 @@ package net.sf.jabref.exporter;
 
 import net.sf.jabref.MetaData;
 import net.sf.jabref.model.database.BibDatabase;
+import net.sf.jabref.model.entry.BibEntry;
 
 import javax.swing.filechooser.FileFilter;
 import java.nio.charset.Charset;
+import java.util.List;
 import java.util.Set;
 
 public interface IExportFormat {
@@ -51,12 +53,12 @@ public interface IExportFormat {
      *            The filename to write to.
      * @param encoding
      *            The encoding to use.
-     * @param entryIds
-     *            (may be null) A Set containing the IDs of all entries that
+     * @param entries
+     *            (may be null) A list containing all entries that
      *            should be exported. If null, all entries will be exported.
      * @throws Exception
      */
-    void performExport(BibDatabase database, MetaData metaData, String file, Charset encoding, Set<String> entryIds)
+    void performExport(BibDatabase database, MetaData metaData, String file, Charset encoding, List<BibEntry> entries)
             throws Exception;
 
 }

--- a/src/main/java/net/sf/jabref/exporter/MSBibExportFormat.java
+++ b/src/main/java/net/sf/jabref/exporter/MSBibExportFormat.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Set;
 
 import javax.xml.transform.OutputKeys;
@@ -33,6 +34,7 @@ import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.msbib.MSBibDatabase;
+import net.sf.jabref.model.entry.BibEntry;
 
 /**
  * ExportFormat for exporting in MSBIB XML format.
@@ -45,11 +47,11 @@ class MSBibExportFormat extends ExportFormat {
 
     @Override
     public void performExport(final BibDatabase database, final MetaData metaData, final String file,
-            final Charset encoding, Set<String> keySet) throws IOException {
+            final Charset encoding, List<BibEntry> entries) throws IOException {
         // forcing to use UTF8 output format for some problems with
         // xml export in other encodings
         SaveSession ss = new SaveSession(StandardCharsets.UTF_8, false);
-        MSBibDatabase md = new MSBibDatabase(database, keySet);
+        MSBibDatabase md = new MSBibDatabase(database, entries);
         try (VerifyingWriter ps = ss.getWriter()) {
 
         // PS: DOES NOT SUPPORT EXPORTING ONLY A SET OF ENTRIES

--- a/src/main/java/net/sf/jabref/exporter/ModsExportFormat.java
+++ b/src/main/java/net/sf/jabref/exporter/ModsExportFormat.java
@@ -19,6 +19,7 @@ import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.mods.MODSDatabase;
+import net.sf.jabref.model.entry.BibEntry;
 
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
@@ -27,6 +28,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.OutputKeys;
+import java.util.List;
 import java.util.Set;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -44,10 +46,10 @@ class ModsExportFormat extends ExportFormat {
 
     @Override
     public void performExport(final BibDatabase database, final MetaData metaData, final String file,
-            final Charset encoding, Set<String> keySet) throws IOException {
+            final Charset encoding, List<BibEntry> entries) throws IOException {
         SaveSession ss = new SaveSession(StandardCharsets.UTF_8, false);
         try (VerifyingWriter ps = ss.getWriter()) {
-            MODSDatabase md = new MODSDatabase(database, keySet);
+            MODSDatabase md = new MODSDatabase(database, entries);
 
             try {
                 DOMSource source = new DOMSource(md.getDOMrepresentation());

--- a/src/main/java/net/sf/jabref/exporter/MySQLExport.java
+++ b/src/main/java/net/sf/jabref/exporter/MySQLExport.java
@@ -16,11 +16,13 @@
 package net.sf.jabref.exporter;
 
 import java.nio.charset.Charset;
+import java.util.List;
 import java.util.Set;
 
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.sql.DBExporterAndImporterFactory;
 
 /**
@@ -38,16 +40,16 @@ public class MySQLExport extends ExportFormat {
      * @param database The bibtex database from which to export.
      * @param file The filename to which the export should be writtten.
      * @param encodingToUse The encoding to use.
-     * @param keySet The set of IDs of the entries to export.
+     * @param entries The entries to export.
      * @throws java.lang.Exception If something goes wrong, feel free to throw an exception. The error message is shown
      *             to the user.
      */
     @Override
     public void performExport(final BibDatabase database, final MetaData metaData, final String file,
-            final Charset encodingToUse, Set<String> keySet)
+            final Charset encodingToUse, List<BibEntry> entries)
                     throws Exception {
 
-        new DBExporterAndImporterFactory().getExporter("MYSQL").exportDatabaseAsFile(database, metaData, keySet, file,
+        new DBExporterAndImporterFactory().getExporter("MYSQL").exportDatabaseAsFile(database, metaData, entries, file,
                 encodingToUse);
 
     }

--- a/src/main/java/net/sf/jabref/exporter/OOCalcDatabase.java
+++ b/src/main/java/net/sf/jabref/exporter/OOCalcDatabase.java
@@ -45,12 +45,12 @@ import org.w3c.dom.Text;
  */
 class OOCalcDatabase {
 
-    private final Collection<BibEntry> entries;
+    private final List<BibEntry> entries;
 
     private static final Log LOGGER = LogFactory.getLog(OOCalcDatabase.class);
 
 
-    public OOCalcDatabase(BibDatabase bibtex, Set<String> keySet) {
+    public OOCalcDatabase(BibDatabase bibtex, List<BibEntry> entries) {
         // Make a list of comparators for sorting the entries:
         List<FieldComparator> comparators = new ArrayList<>();
         comparators.add(new FieldComparator("author"));
@@ -60,15 +60,13 @@ class OOCalcDatabase {
         List<BibEntry> entryList = new ArrayList<>();
         // Set up a list of all entries, if keySet==null, or the entries whose
         // ids are in keySet, otherwise:
-        if (keySet == null) {
+        if (entries == null) {
             entryList.addAll(bibtex.getEntries());
         } else {
-            for (String key : keySet) {
-                entryList.add(bibtex.getEntryById(key));
-            }
+            entryList.addAll(entries);
         }
         Collections.sort(entryList, new FieldComparatorStack<>(comparators));
-        entries = entryList;
+        this.entries = entryList;
     }
 
     public Document getDOMrepresentation() {

--- a/src/main/java/net/sf/jabref/exporter/OpenDocumentRepresentation.java
+++ b/src/main/java/net/sf/jabref/exporter/OpenDocumentRepresentation.java
@@ -45,13 +45,13 @@ import org.w3c.dom.Text;
  */
 class OpenDocumentRepresentation {
 
-    private final Collection<BibEntry> entries;
+    private final List<BibEntry> entries;
     private final BibDatabase database;
 
     private static final Log LOGGER = LogFactory.getLog(OpenDocumentRepresentation.class);
 
 
-    public OpenDocumentRepresentation(BibDatabase database, Set<String> keySet) {
+    public OpenDocumentRepresentation(BibDatabase database, List<BibEntry> entries) {
         this.database = database;
         // Make a list of comparators for sorting the entries:
         List<FieldComparator> comparators = new ArrayList<>();
@@ -61,17 +61,15 @@ class OpenDocumentRepresentation {
         // Use glazed lists to get a sorted view of the entries:
         List<BibEntry> entryList = new ArrayList<>();
 
-        // Set up a list of all entries, if keySet==null, or the entries whose
-        // ids are in keySet, otherwise:
-        if (keySet == null) {
+        // Set up a list of all entries, if entries==null, or the entries in the given list
+        if (entries == null) {
             entryList.addAll(database.getEntries());
         } else {
-            for (String key : keySet) {
-                entryList.add(database.getEntryById(key));
-            }
+            entryList.addAll(entries);
         }
+
         Collections.sort(entryList, new FieldComparatorStack<>(comparators));
-        entries = entryList;
+        this.entries = entryList;
     }
 
     public Document getDOMrepresentation() {

--- a/src/main/java/net/sf/jabref/exporter/OpenDocumentSpreadsheetCreator.java
+++ b/src/main/java/net/sf/jabref/exporter/OpenDocumentSpreadsheetCreator.java
@@ -25,6 +25,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import net.sf.jabref.model.entry.BibEntry;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -32,6 +33,7 @@ import java.io.*;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Set;
 import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
@@ -54,8 +56,8 @@ public class OpenDocumentSpreadsheetCreator extends ExportFormat {
 
     @Override
     public void performExport(final BibDatabase database, final MetaData metaData, final String file,
-            final Charset encoding, Set<String> keySet) throws Exception {
-        OpenDocumentSpreadsheetCreator.exportOpenDocumentSpreadsheet(new File(file), database, keySet);
+            final Charset encoding, List<BibEntry> entries) throws Exception {
+        OpenDocumentSpreadsheetCreator.exportOpenDocumentSpreadsheet(new File(file), database, entries);
     }
 
     private static void storeOpenDocumentSpreadsheetFile(File file, InputStream source) throws Exception {
@@ -93,12 +95,12 @@ public class OpenDocumentSpreadsheetCreator extends ExportFormat {
         }
     }
 
-    private static void exportOpenDocumentSpreadsheet(File file, BibDatabase database, Set<String> keySet)
+    private static void exportOpenDocumentSpreadsheet(File file, BibDatabase database, List<BibEntry> entries)
             throws Exception {
 
         // First store the xml formatted content to a temporary file.
         File tmpFile = File.createTempFile("opendocument", null);
-        OpenDocumentSpreadsheetCreator.exportOpenDocumentSpreadsheetXML(tmpFile, database, keySet);
+        OpenDocumentSpreadsheetCreator.exportOpenDocumentSpreadsheetXML(tmpFile, database, entries);
 
         // Then add the content to the zip file:
         try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(tmpFile))) {
@@ -110,8 +112,8 @@ public class OpenDocumentSpreadsheetCreator extends ExportFormat {
         }
     }
 
-    private static void exportOpenDocumentSpreadsheetXML(File tmpFile, BibDatabase database, Set<String> keySet) {
-        OpenDocumentRepresentation od = new OpenDocumentRepresentation(database, keySet);
+    private static void exportOpenDocumentSpreadsheetXML(File tmpFile, BibDatabase database, List<BibEntry> entries) {
+        OpenDocumentRepresentation od = new OpenDocumentRepresentation(database, entries);
 
         try (Writer ps = new OutputStreamWriter(new FileOutputStream(tmpFile), StandardCharsets.UTF_8)) {
 

--- a/src/main/java/net/sf/jabref/exporter/OpenOfficeDocumentCreator.java
+++ b/src/main/java/net/sf/jabref/exporter/OpenOfficeDocumentCreator.java
@@ -25,6 +25,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import net.sf.jabref.model.entry.BibEntry;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -32,6 +33,7 @@ import java.io.*;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -53,8 +55,8 @@ public class OpenOfficeDocumentCreator extends ExportFormat {
 
     @Override
     public void performExport(final BibDatabase database, final MetaData metaData, final String file,
-            final Charset encoding, Set<String> keySet) throws Exception {
-        OpenOfficeDocumentCreator.exportOpenOfficeCalc(new File(file), database, keySet);
+            final Charset encoding, List<BibEntry> entries) throws Exception {
+        OpenOfficeDocumentCreator.exportOpenOfficeCalc(new File(file), database, entries);
     }
 
     private static void storeOpenOfficeFile(File file, InputStream source) throws Exception {
@@ -77,10 +79,10 @@ public class OpenOfficeDocumentCreator extends ExportFormat {
         }
     }
 
-    private static void exportOpenOfficeCalc(File file, BibDatabase database, Set<String> keySet) throws Exception {
+    private static void exportOpenOfficeCalc(File file, BibDatabase database, List<BibEntry> entries) throws Exception {
         // First store the xml formatted content to a temporary file.
         File tmpFile = File.createTempFile("oocalc", null);
-        OpenOfficeDocumentCreator.exportOpenOfficeCalcXML(tmpFile, database, keySet);
+        OpenOfficeDocumentCreator.exportOpenOfficeCalcXML(tmpFile, database, entries);
 
         // Then add the content to the zip file:
         try (BufferedInputStream in = new BufferedInputStream(new FileInputStream(tmpFile))) {
@@ -93,8 +95,8 @@ public class OpenOfficeDocumentCreator extends ExportFormat {
         }
     }
 
-    private static void exportOpenOfficeCalcXML(File tmpFile, BibDatabase database, Set<String> keySet) {
-        OOCalcDatabase od = new OOCalcDatabase(database, keySet);
+    private static void exportOpenOfficeCalcXML(File tmpFile, BibDatabase database, List<BibEntry> entries) {
+        OOCalcDatabase od = new OOCalcDatabase(database, entries);
 
         try (Writer ps = new OutputStreamWriter(new FileOutputStream(tmpFile), StandardCharsets.UTF_8)) {
             DOMSource source = new DOMSource(od.getDOMrepresentation());

--- a/src/main/java/net/sf/jabref/exporter/PostgreSQLExport.java
+++ b/src/main/java/net/sf/jabref/exporter/PostgreSQLExport.java
@@ -16,11 +16,13 @@
 package net.sf.jabref.exporter;
 
 import java.nio.charset.Charset;
+import java.util.List;
 import java.util.Set;
 
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.sql.DBExporterAndImporterFactory;
 
 /**
@@ -42,17 +44,17 @@ public class PostgreSQLExport extends ExportFormat {
      *            The filename to which the export should be writtten.
      * @param encoding
      *            The encoding to use.
-     * @param keySet
-     *            The set of IDs of the entries to export.
+     * @param entries
+     *            The entries to export.
      * @throws java.lang.Exception
      *             If something goes wrong, feel free to throw an exception. The
      *             error message is shown to the user.
      */
     @Override
     public void performExport(final BibDatabase database, final MetaData metaData, final String file,
-            final Charset encoding, Set<String> keySet) throws Exception {
+            final Charset encoding, List<BibEntry> entries) throws Exception {
 
-        new DBExporterAndImporterFactory().getExporter("POSTGRESQL").exportDatabaseAsFile(database, metaData, keySet,
+        new DBExporterAndImporterFactory().getExporter("POSTGRESQL").exportDatabaseAsFile(database, metaData, entries,
                 file, encoding);
 
     }

--- a/src/main/java/net/sf/jabref/groups/structure/ExplicitGroup.java
+++ b/src/main/java/net/sf/jabref/groups/structure/ExplicitGroup.java
@@ -79,10 +79,9 @@ public class ExplicitGroup extends AbstractGroup {
      * Called only when created fromString
      */
     private void addEntries(QuotedStringTokenizer tok, BibDatabase db) {
-        BibEntry[] entries;
         while (tok.hasMoreTokens()) {
-            entries = db.getEntriesByKey(StringUtil.unquote(tok.nextToken(), AbstractGroup.QUOTE_CHAR));
-            Collections.addAll(this.entries, entries);
+            List<BibEntry> entries = db.getEntriesByKey(StringUtil.unquote(tok.nextToken(), AbstractGroup.QUOTE_CHAR));
+            this.entries.addAll(entries);
         }
     }
 

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -671,7 +671,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                         bes = entry;
                         // Store the old value:
                         oldvals.put(bes, bes.getField(BibEntry.KEY_FIELD));
-                        database.setCiteKeyForEntry(bes.getId(), null);
+                        database.setCiteKeyForEntry(bes, null);
                     }
                 }
 
@@ -681,7 +681,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 for (BibEntry entry : entries) {
                     bes = entry;
                     LabelPatternUtil.makeLabel(bibDatabaseContext.getMetaData(), database, bes);
-                    ce.addEdit(new UndoableKeyChange(database, bes.getId(), (String) oldvals.get(bes),
+                    ce.addEdit(new UndoableKeyChange(database, bes, (String) oldvals.get(bes),
                             bes.getField(BibEntry.KEY_FIELD)));
                 }
                 ce.end();
@@ -1396,11 +1396,11 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
     }
 
     public void editEntryByKeyAndFocusField(final String bibtexKey, final String fieldName) {
-        final BibEntry[] entries = database.getEntriesByKey(bibtexKey);
-        if (entries.length == 1) {
-            mainTable.setSelected(mainTable.findEntry(entries[0]));
+        final List<BibEntry> entries = database.getEntriesByKey(bibtexKey);
+        if (entries.size() == 1) {
+            mainTable.setSelected(mainTable.findEntry(entries.get(0)));
             selectionListener.editSignalled();
-            final EntryEditor editor = getEntryEditor(entries[0]);
+            final EntryEditor editor = getEntryEditor(entries.get(0));
             editor.setFocusToField(fieldName);
             new FocusRequester(editor);
         }
@@ -1413,7 +1413,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
     private void createMainTable() {
         //Comparator comp = new FieldComparator("author");
 
-        final GlazedEntrySorter eventList = new GlazedEntrySorter(database.getEntryMap());
+        final GlazedEntrySorter eventList = new GlazedEntrySorter(database.getEntries());
         // Must initialize sort columns somehow:
 
         database.addDatabaseChangeListener(eventList);
@@ -2104,7 +2104,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 String oldKey = bes.getCiteKey();
                 if ((oldKey == null) || oldKey.isEmpty()) {
                     LabelPatternUtil.makeLabel(bibDatabaseContext.getMetaData(), database, bes);
-                    ce.addEdit(new UndoableKeyChange(database, bes.getId(), null, bes.getCiteKey()));
+                    ce.addEdit(new UndoableKeyChange(database, bes, null, bes.getCiteKey()));
                     any = true;
                 }
             }

--- a/src/main/java/net/sf/jabref/gui/DuplicateSearch.java
+++ b/src/main/java/net/sf/jabref/gui/DuplicateSearch.java
@@ -38,7 +38,7 @@ import spin.Spin;
 public class DuplicateSearch implements Runnable {
 
     private final BasePanel panel;
-    private BibEntry[] bes;
+    private List<BibEntry> bes;
     private final List<BibEntry[]> duplicates = new ArrayList<>();
 
 
@@ -50,13 +50,10 @@ public class DuplicateSearch implements Runnable {
     public void run() {
 
         panel.output(Localization.lang("Searching for duplicates..."));
-        Object[] keys = panel.getDatabase().getKeySet().toArray();
-        if (keys.length < 2) {
+
+        bes = panel.getDatabase().getEntries();
+        if (bes.size() < 2) {
             return;
-        }
-        bes = new BibEntry[keys.length];
-        for (int i = 0; i < keys.length; i++) {
-            bes[i] = panel.getDatabase().getEntryById((String) keys[i]);
         }
 
         SearcherRunnable st = new SearcherRunnable();
@@ -170,14 +167,16 @@ public class DuplicateSearch implements Runnable {
 
         @Override
         public void run() {
-            for (int i = 0; (i < (bes.length - 1)) && !finished; i++) {
-                for (int j = i + 1; (j < bes.length) && !finished; j++) {
-                    boolean eq = DuplicateCheck.isDuplicate(bes[i], bes[j], panel.getBibDatabaseContext().getMode());
+            for (int i = 0; (i < (bes.size() - 1)) && !finished; i++) {
+                for (int j = i + 1; (j < bes.size()) && !finished; j++) {
+                    BibEntry first = bes.get(i);
+                    BibEntry second = bes.get(j);
+                    boolean eq = DuplicateCheck.isDuplicate(first, second, panel.getBibDatabaseContext().getMode());
 
                     // If (suspected) duplicates, add them to the duplicates vector.
                     if (eq) {
                         synchronized (duplicates) {
-                            duplicates.add(new BibEntry[]{bes[i], bes[j]});
+                            duplicates.add(new BibEntry[]{first, second});
                             duplicates.notifyAll(); // send wake up all
                         }
                     }

--- a/src/main/java/net/sf/jabref/gui/GlazedEntrySorter.java
+++ b/src/main/java/net/sf/jabref/gui/GlazedEntrySorter.java
@@ -16,6 +16,7 @@
 package net.sf.jabref.gui;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.database.DatabaseChangeEvent;
@@ -28,12 +29,10 @@ public class GlazedEntrySorter implements DatabaseChangeListener {
 
     private final EventList<BibEntry> list;
 
-    public GlazedEntrySorter(Map<String, BibEntry> entries) {
+    public GlazedEntrySorter(List<BibEntry> entries) {
         list = new BasicEventList<>();
         list.getReadWriteLock().writeLock().lock();
-        for (Map.Entry<String, BibEntry> entry : entries.entrySet()) {
-            list.add(entry.getValue());
-        }
+        list.addAll(entries);
 
         // Sort the list so it is ordered according to creation (or read) order
         // when the table is unsorted.

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -749,15 +749,14 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
             }
 
             NamedCompound compound = new NamedCompound(Localization.lang("source edit"));
-            BibEntry newEntry = database.getEntryById(database.getKeySet().iterator().next());
-            String id = entry.getId();
+            BibEntry newEntry = database.getEntries().iterator().next();
             String newKey = newEntry.getCiteKey();
             boolean anyChanged = false;
             boolean changedType = false;
             boolean duplicateWarning = false;
             boolean emptyWarning = (newKey == null) || newKey.isEmpty();
 
-            if (panel.getDatabase().setCiteKeyForEntry(id, newKey)) {
+            if (panel.getDatabase().setCiteKeyForEntry(entry, newKey)) {
                 duplicateWarning = true;
 
                 // First, remove fields that the user have removed.
@@ -1078,7 +1077,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                     return;
                 }
 
-                boolean isDuplicate = panel.getDatabase().setCiteKeyForEntry(entry.getId(), newValue);
+                boolean isDuplicate = panel.getDatabase().setCiteKeyForEntry(entry, newValue);
 
                 if (newValue == null) {
                     warnEmptyBibtexkey();
@@ -1091,7 +1090,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                 }
 
                 // Add an UndoableKeyChange to the baseframe's undoManager.
-                UndoableKeyChange undoableKeyChange = new UndoableKeyChange(panel.getDatabase(), entry.getId(), oldValue, newValue);
+                UndoableKeyChange undoableKeyChange = new UndoableKeyChange(panel.getDatabase(), entry, oldValue, newValue);
                 if (net.sf.jabref.util.Util.updateTimeStampIsSet()) {
                     NamedCompound ce = net.sf.jabref.util.Util.doUpdateTimeStamp(entry, undoableKeyChange);
                     panel.undoManager.addEdit(ce);
@@ -1325,7 +1324,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
             LabelPatternUtil.makeLabel(panel.getBibDatabaseContext().getMetaData(), panel.getDatabase(), entry);
 
             // Store undo information:
-            panel.undoManager.addEdit(new UndoableKeyChange(panel.getDatabase(), entry.getId(), (String) oldValue, entry.getCiteKey()));
+            panel.undoManager.addEdit(new UndoableKeyChange(panel.getDatabase(), entry, (String) oldValue, entry.getCiteKey()));
 
             // here we update the field
             String bibtexKeyData = entry.getCiteKey();

--- a/src/main/java/net/sf/jabref/gui/labelpattern/SearchFixDuplicateLabels.java
+++ b/src/main/java/net/sf/jabref/gui/labelpattern/SearchFixDuplicateLabels.java
@@ -107,8 +107,7 @@ public class SearchFixDuplicateLabels extends AbstractWorker {
             for (BibEntry entry : toGenerateFor) {
                 String oldKey = entry.getCiteKey();
                 LabelPatternUtil.makeLabel(panel.getBibDatabaseContext().getMetaData(), panel.database(), entry);
-                ce.addEdit(new UndoableKeyChange(panel.database(), entry.getId(), oldKey,
- entry.getCiteKey()));
+                ce.addEdit(new UndoableKeyChange(panel.database(), entry, oldKey, entry.getCiteKey()));
             }
             ce.end();
             panel.undoManager.addEdit(ce);

--- a/src/main/java/net/sf/jabref/gui/undo/UndoableKeyChange.java
+++ b/src/main/java/net/sf/jabref/gui/undo/UndoableKeyChange.java
@@ -19,6 +19,7 @@ import javax.swing.undo.AbstractUndoableEdit;
 
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.model.entry.BibEntry;
 
 /**
  * This class represents a change in any field value. The relevant
@@ -27,16 +28,16 @@ import net.sf.jabref.logic.l10n.Localization;
  */
 public class UndoableKeyChange extends AbstractUndoableEdit {
 
-    private final String entryId;
+    private final BibEntry entry;
     private final BibDatabase base;
     private final String oldValue;
     private final String newValue;
 
 
-    public UndoableKeyChange(BibDatabase base, String entryId,
+    public UndoableKeyChange(BibDatabase base, BibEntry entry,
             String oldValue, String newValue) {
         this.base = base;
-        this.entryId = entryId;
+        this.entry = entry;
         this.oldValue = oldValue;
         this.newValue = newValue;
     }
@@ -75,7 +76,7 @@ public class UndoableKeyChange extends AbstractUndoableEdit {
     }
 
     private void set(String to) {
-        base.setCiteKeyForEntry(entryId, to);
+        base.setCiteKeyForEntry(entry, to);
     }
 
 }

--- a/src/main/java/net/sf/jabref/importer/AppendDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/AppendDatabaseAction.java
@@ -134,7 +134,7 @@ public class AppendDatabaseAction implements BaseAction {
         ArrayList<BibEntry> appendedEntries = new ArrayList<>();
         ArrayList<BibEntry> originalEntries = new ArrayList<>();
         BibDatabase database = panel.database();
-        BibEntry originalEntry;
+
         NamedCompound ce = new NamedCompound(Localization.lang("Append database"));
         MetaData meta = pr.getMetaData();
 
@@ -142,8 +142,7 @@ public class AppendDatabaseAction implements BaseAction {
             boolean overwriteOwner = Globals.prefs.getBoolean(JabRefPreferences.OVERWRITE_OWNER);
             boolean overwriteTimeStamp = Globals.prefs.getBoolean(JabRefPreferences.OVERWRITE_TIME_STAMP);
 
-            for (String key : fromDatabase.getKeySet()) {
-                originalEntry = fromDatabase.getEntryById(key);
+            for (BibEntry originalEntry : fromDatabase.getEntries()) {
                 BibEntry be = (BibEntry) originalEntry.clone();
                 be.setId(IdGenerator.next());
                 Util.setAutomaticFields(be, overwriteOwner, overwriteTimeStamp);

--- a/src/main/java/net/sf/jabref/importer/EntryFromFileCreatorManager.java
+++ b/src/main/java/net/sf/jabref/importer/EntryFromFileCreatorManager.java
@@ -158,7 +158,7 @@ public final class EntryFromFileCreatorManager {
                  * does 'true' mean "There were duplicates", while 'false' means
                  * "Everything alright"?
                  */
-                if (database.getEntryById(entry.getId()) == null) {
+                if (!database.containsEntryWithId(entry.getId())) {
                     // Work around SIDE EFFECT of creator.createEntry. The EntryFromPDFCreator also creates the entry in the table
                     // Therefore, we only insert the entry if it is not already present
                     if (database.insertEntry(entry)) {

--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
@@ -85,7 +85,7 @@ public class BibtexParser {
      * @param bibtexString
      * @return Returns returns an empty collection if no entries where found or if an error occurred.
      */
-    public static Collection<BibEntry> fromString(String bibtexString) {
+    public static List<BibEntry> fromString(String bibtexString) {
         StringReader reader = new StringReader(bibtexString);
         BibtexParser parser = new BibtexParser(reader);
 

--- a/src/main/java/net/sf/jabref/logic/groups/GroupsUtil.java
+++ b/src/main/java/net/sf/jabref/logic/groups/GroupsUtil.java
@@ -15,8 +15,7 @@ public class GroupsUtil {
     public static Set<String> findDeliminatedWordsInField(BibDatabase db, String field, String deliminator) {
         Set<String> res = new TreeSet<>();
 
-        for (String s : db.getKeySet()) {
-            BibEntry be = db.getEntryById(s);
+        for (BibEntry be : db.getEntries()) {
             if (be.hasField(field)) {
                 String fieldValue = be.getField(field).trim();
                 StringTokenizer tok = new StringTokenizer(fieldValue, deliminator);
@@ -39,8 +38,7 @@ public class GroupsUtil {
      */
     public static Set<String> findAllWordsInField(BibDatabase db, String field, String remove) {
         Set<String> res = new TreeSet<>();
-        for (String s : db.getKeySet()) {
-            BibEntry be = db.getEntryById(s);
+        for (BibEntry be : db.getEntries()) {
             be.getFieldOptional(field).ifPresent(o -> {
                 StringTokenizer tok = new StringTokenizer(o.toString(), remove, false);
                 while (tok.hasMoreTokens()) {
@@ -60,8 +58,7 @@ public class GroupsUtil {
      */
     public static Set<String> findAuthorLastNames(BibDatabase db, List<String> fields) {
         Set<String> res = new TreeSet<>();
-        for (String s : db.getKeySet()) {
-            BibEntry be = db.getEntryById(s);
+        for (BibEntry be : db.getEntries()) {
             for (String field : fields) {
                 String val = be.getField(field);
                 if ((val != null) && !val.isEmpty()) {

--- a/src/main/java/net/sf/jabref/logic/labelpattern/LabelPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/labelpattern/LabelPatternUtil.java
@@ -499,7 +499,7 @@ public class LabelPatternUtil {
         if (!alwaysAddLetter && (occurrences == 0)) {
             // No dupes found, so we can just go ahead.
             if (!key.equals(oldKey)) {
-                if (! database.containsEntryWithId(entry.getId())) {
+                if (!database.containsEntryWithId(entry.getId())) {
                     // entry does not (yet) exist in the database, just update the entry
                     entry.setField(BibEntry.KEY_FIELD, key);
                 } else {

--- a/src/main/java/net/sf/jabref/logic/labelpattern/LabelPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/labelpattern/LabelPatternUtil.java
@@ -250,7 +250,7 @@ public class LabelPatternUtil {
      * Rest part is only the first part which do not match any other type. All
      * other parts (address, ...) are ignored.
      *
-     * @param result the institution to generate a Bibtex key for
+     * @param content the institution to generate a Bibtex key for
      * @return <ul>
      *         <li>the institution key</li>
      *         <li>"" in the case of a failure</li>
@@ -499,11 +499,11 @@ public class LabelPatternUtil {
         if (!alwaysAddLetter && (occurrences == 0)) {
             // No dupes found, so we can just go ahead.
             if (!key.equals(oldKey)) {
-                if (database.getEntryById(entry.getId()) == null) {
+                if (! database.containsEntryWithId(entry.getId())) {
                     // entry does not (yet) exist in the database, just update the entry
                     entry.setField(BibEntry.KEY_FIELD, key);
                 } else {
-                    database.setCiteKeyForEntry(entry.getId(), key);
+                    database.setCiteKeyForEntry(entry, key);
                 }
             }
 
@@ -532,11 +532,11 @@ public class LabelPatternUtil {
             }
 
             if (!moddedKey.equals(oldKey)) {
-                if (database.getEntryById(entry.getId()) == null) {
+                if (!database.containsEntryWithId(entry.getId())) {
                     // entry does not (yet) exist in the database, just update the entry
                     entry.setField(BibEntry.KEY_FIELD, moddedKey);
                 } else {
-                    database.setCiteKeyForEntry(entry.getId(), moddedKey);
+                    database.setCiteKeyForEntry(entry, moddedKey);
                 }
             }
         }
@@ -544,7 +544,7 @@ public class LabelPatternUtil {
 
     /**
      * Applies modifiers to a label generated based on a field marker.
-     * @param resultingLabel The generated label.
+     * @param label The generated label.
      * @param parts String array containing the modifiers.
      * @param offset The number of initial items in the modifiers array to skip.
      * @return The modified label.

--- a/src/main/java/net/sf/jabref/logic/mods/MODSDatabase.java
+++ b/src/main/java/net/sf/jabref/logic/mods/MODSDatabase.java
@@ -16,6 +16,7 @@
 package net.sf.jabref.logic.mods;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -45,21 +46,17 @@ public class MODSDatabase {
         entries = new HashSet<>();
     }
 
-    public MODSDatabase(BibDatabase bibtex) {
-        addEntries(bibtex, bibtex.getKeySet());
-    }
-
-    public MODSDatabase(BibDatabase bibtex, Set<String> keySet) {
-        if (keySet == null) {
-            keySet = bibtex.getKeySet();
+    public MODSDatabase(BibDatabase database, List<BibEntry> entries) {
+        if (entries == null) {
+            addEntries(database.getEntries());
+        } else {
+            addEntries(entries);
         }
-        addEntries(bibtex, keySet);
     }
 
-    private void addEntries(BibDatabase database, Set<String> keySet) {
+    private void addEntries(List<BibEntry> entriesToAdd) {
         entries = new HashSet<>();
-        for (String aKeySet : keySet) {
-            BibEntry entry = database.getEntryById(aKeySet);
+        for (BibEntry entry : entriesToAdd) {
             MODSEntry newMods = new MODSEntry(entry);
             entries.add(newMods);
         }

--- a/src/main/java/net/sf/jabref/logic/msbib/MSBibDatabase.java
+++ b/src/main/java/net/sf/jabref/logic/msbib/MSBibDatabase.java
@@ -49,20 +49,12 @@ public class MSBibDatabase {
         entries = new HashSet<>();
     }
 
-    public MSBibDatabase(InputStream stream) {
-        importEntries(stream);
-    }
-
-    public MSBibDatabase(BibDatabase bibtex) {
-        Set<String> keySet = bibtex.getKeySet();
-        addEntries(bibtex, keySet);
-    }
-
-    public MSBibDatabase(BibDatabase bibtex, Set<String> keySet) {
-        if (keySet == null) {
-            keySet = bibtex.getKeySet();
+    public MSBibDatabase(BibDatabase database, List<BibEntry> entries) {
+        if (entries == null) {
+            addEntries(database.getEntries());
+        } else {
+            addEntries(entries);
         }
-        addEntries(bibtex, keySet);
     }
 
     public List<BibEntry> importEntries(InputStream stream) {
@@ -98,10 +90,9 @@ public class MSBibDatabase {
         return bibitems;
     }
 
-    private void addEntries(BibDatabase database, Set<String> keySet) {
+    private void addEntries(List<BibEntry> entriesToAdd) {
         entries = new HashSet<>();
-        for (String key : keySet) {
-            BibEntry entry = database.getEntryById(key);
+        for (BibEntry entry : entriesToAdd) {
             MSBibEntry newMods = new MSBibEntry(entry);
             entries.add(newMods);
         }

--- a/src/main/java/net/sf/jabref/migrations/FileLinksUpgradeWarning.java
+++ b/src/main/java/net/sf/jabref/migrations/FileLinksUpgradeWarning.java
@@ -244,7 +244,7 @@ public class FileLinksUpgradeWarning implements PostOpenAction {
         NamedCompound ce = new NamedCompound(Localization.lang("Move external links to 'file' field"));
 
         UpgradePdfPsToFileCleanup cleanupJob = new UpgradePdfPsToFileCleanup(Arrays.asList(fields));
-        for (BibEntry entry : database.getEntryMap().values()) {
+        for (BibEntry entry : database.getEntries()) {
             List<FieldChange> changes = cleanupJob.cleanup(entry);
 
             for (FieldChange change : changes) {

--- a/src/main/java/net/sf/jabref/model/database/BibDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabase.java
@@ -51,7 +51,7 @@ public class BibDatabase {
     /**
      * State attributes
      */
-    private final Map<String, BibEntry> entries = new ConcurrentHashMap<>();
+    private final List<BibEntry> entries = Collections.synchronizedList(new ArrayList<>());
     // use a map instead of a set since i need to know how many of each key is in there
     private final Map<String, Integer> allKeys = new HashMap<>();
     private String preamble;
@@ -88,14 +88,6 @@ public class BibDatabase {
     }
 
     /**
-     * Returns a Set containing the keys to all entries.
-     * Use getKeySet().iterator() to iterate over all entries.
-     */
-    public Set<String> getKeySet() {
-        return entries.keySet();
-    }
-
-    /**
      * Returns an EntrySorter with the sorted entries from this base,
      * sorted by the given Comparator.
      */
@@ -105,19 +97,15 @@ public class BibDatabase {
         return sorter;
     }
 
-    public Map<String, BibEntry> getEntryMap() {
-        return entries;
-    }
-
     /**
-     * Returns the entry with the given ID (-> entry_type + hashcode).
+     * Returns whether an entry with the given ID exists (-> entry_type + hashcode).
      */
-    public BibEntry getEntryById(String id) {
-        return entries.get(id);
+    public boolean containsEntryWithId(String id) {
+        return entries.stream().anyMatch(entry -> entry.getId() == id);
     }
 
-    public Collection<BibEntry> getEntries() {
-        return entries.values();
+    public List<BibEntry> getEntries() {
+        return Collections.unmodifiableList(entries);
     }
 
     public Set<String> getAllVisibleFields() {
@@ -146,9 +134,7 @@ public class BibDatabase {
 
         int keyHash = key.hashCode(); // key hash for better performance
 
-        Set<String> keySet = entries.keySet();
-        for (String entryID : keySet) {
-            BibEntry entry = getEntryById(entryID);
+        for (BibEntry entry : entries) {
             if ((entry != null) && (entry.getCiteKey() != null) && (keyHash == entry.getCiteKey().hashCode())) {
                 back = entry;
             }
@@ -156,15 +142,15 @@ public class BibDatabase {
         return back;
     }
 
-    public synchronized BibEntry[] getEntriesByKey(String key) {
+    public synchronized List<BibEntry> getEntriesByKey(String key) {
         ArrayList<BibEntry> result = new ArrayList<>();
 
-        for (BibEntry entry : entries.values()) {
+        for (BibEntry entry : entries) {
             if (key.equals(entry.getCiteKey())) {
                 result.add(entry);
             }
         }
-        return result.toArray(new BibEntry[result.size()]);
+        return result;
     }
 
     /**
@@ -173,14 +159,11 @@ public class BibDatabase {
      */
     public synchronized boolean insertEntry(BibEntry entry) throws KeyCollisionException {
         String id = entry.getId();
-        if (getEntryById(id) != null) {
-            throw new KeyCollisionException(
-                    "ID is already in use, please choose another");
+        if (containsEntryWithId(id)) {
+            throw new KeyCollisionException("ID is already in use, please choose another");
         }
 
-        entry.addPropertyChangeListener(listener);
-
-        entries.put(id, entry);
+        entries.add(entry);
 
         fireDatabaseChanged(new DatabaseChangeEvent(this, DatabaseChangeEvent.ChangeType.ADDED_ENTRY, entry));
 
@@ -198,15 +181,10 @@ public class BibDatabase {
         entries.remove(oldValue.getId());
 
         removeKeyFromSet(oldValue.getCiteKey());
-        oldValue.removePropertyChangeListener(listener);
         fireDatabaseChanged(new DatabaseChangeEvent(this, DatabaseChangeEvent.ChangeType.REMOVED_ENTRY, oldValue));
     }
 
-    public synchronized boolean setCiteKeyForEntry(String id, String key) {
-        if (!entries.containsKey(id)) {
-            return false; // Entry doesn't exist!
-        }
-        BibEntry entry = getEntryById(id);
+    public synchronized boolean setCiteKeyForEntry(BibEntry entry, String key) {
         String oldKey = entry.getCiteKey();
         if (key == null) {
             entry.clearField(BibEntry.KEY_FIELD);
@@ -621,43 +599,6 @@ public class BibDatabase {
     public void setFollowCrossrefs(boolean followCrossrefs) {
         this.followCrossrefs = followCrossrefs;
     }
-
-    /*
-     * Entries are stored in a HashMap with the ID as key. What happens if
-     * someone changes a BibEntry's ID after it has been added to this
-     * BibDatabase? The key of that entry would be the old ID, not the new
-     * one. Use a PropertyChangeListener to identify an ID change and update the
-     * Map.
-     */
-    private final VetoableChangeListener listener = propertyChangeEvent -> {
-        if (propertyChangeEvent.getPropertyName() == null) {
-            fireDatabaseChanged(new DatabaseChangeEvent(BibDatabase.this,
-                    DatabaseChangeEvent.ChangeType.CHANGING_ENTRY, (BibEntry) propertyChangeEvent.getSource()));
-        } else if ("id".equals(propertyChangeEvent.getPropertyName())) {
-            // locate the entry under its old key
-            BibEntry oldEntry = entries.remove(propertyChangeEvent.getOldValue());
-
-            if (oldEntry != propertyChangeEvent.getSource()) {
-                // Something is very wrong!
-                // The entry under the old key isn't
-                // the one that sent this event.
-                // Restore the old state.
-                entries.put((String) propertyChangeEvent.getOldValue(), oldEntry);
-                throw new PropertyVetoException("Wrong old ID", propertyChangeEvent);
-            }
-
-            if (entries.get(propertyChangeEvent.getNewValue()) != null) {
-                entries.put((String) propertyChangeEvent.getOldValue(), oldEntry);
-                throw new PropertyVetoException("New ID already in use, please choose another", propertyChangeEvent);
-            }
-
-            // and re-file this entry
-            entries.put((String) propertyChangeEvent.getNewValue(), (BibEntry) propertyChangeEvent.getSource());
-        } else {
-            fireDatabaseChanged(new DatabaseChangeEvent(BibDatabase.this,
-                    DatabaseChangeEvent.ChangeType.CHANGED_ENTRY, (BibEntry) propertyChangeEvent.getSource()));
-        }
-    };
 
     public void setEpilog(String epilog) {
         this.epilog = epilog;

--- a/src/main/java/net/sf/jabref/model/database/EntrySorter.java
+++ b/src/main/java/net/sf/jabref/model/database/EntrySorter.java
@@ -23,17 +23,13 @@ public class EntrySorter implements DatabaseChangeListener {
 
     private final List<BibEntry> set;
     private final Comparator<BibEntry> comp;
-    private String[] idArray;
     private BibEntry[] entryArray;
     private boolean changed;
 
 
-    public EntrySorter(Map<String, BibEntry> entries, Comparator<BibEntry> comp) {
-        set = new ArrayList<>();
+    public EntrySorter(List<BibEntry> entries, Comparator<BibEntry> comp) {
+        set = entries;
         this.comp = comp;
-        for (Map.Entry<String, BibEntry> stringBibtexEntryEntry : entries.entrySet()) {
-            set.add(stringBibtexEntryEntry.getValue());
-        }
         changed = true;
         index();
     }
@@ -63,24 +59,12 @@ public class EntrySorter implements DatabaseChangeListener {
             // getValueAt() in EntryTableModel, which *has* to be efficient.
 
             int count = set.size();
-            idArray = new String[count];
             entryArray = new BibEntry[count];
             int piv = 0;
             for (BibEntry entry : set) {
-                idArray[piv] = entry.getId();
                 entryArray[piv] = entry;
                 piv++;
             }
-        }
-    }
-
-    public boolean isOutdated() {
-        return false;
-    }
-
-    public String getIdAt(int pos) {
-        synchronized (set) {
-            return idArray[pos];
         }
     }
 

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -46,7 +46,7 @@ public class BibEntry {
 
     public static final String TYPE_HEADER = "entrytype";
     public static final String KEY_FIELD = "bibtexkey";
-    public static final String ID_FIELD = "id";
+    protected static final String ID_FIELD = "id";
     public static final String DEFAULT_TYPE = "misc";
 
     private String id;
@@ -292,6 +292,10 @@ public class BibEntry {
      */
     public String getCiteKey() {
         return fields.get(KEY_FIELD);
+    }
+
+    public void setCiteKey(String newCiteKey) {
+        setField(KEY_FIELD, newCiteKey);
     }
 
     public boolean hasCiteKey() {

--- a/src/test/java/net/sf/jabref/BibtexTestData.java
+++ b/src/test/java/net/sf/jabref/BibtexTestData.java
@@ -12,7 +12,7 @@ public class BibtexTestData {
 
     public static BibEntry getBibtexEntry() {
         BibDatabase database = getBibtexDatabase();
-        return database.getEntriesByKey("HipKro03")[0];
+        return database.getEntryByKey("HipKro03");
     }
 
     public static BibDatabase getBibtexDatabase() {

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -3,6 +3,7 @@ package net.sf.jabref.importer.fileformat;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
+import net.sf.jabref.bibtex.BibtexEntryAssert;
 import net.sf.jabref.exporter.FieldFormatterCleanups;
 import net.sf.jabref.groups.GroupTreeNode;
 import net.sf.jabref.groups.structure.AllEntriesGroup;
@@ -1435,5 +1436,32 @@ public class BibtexParserTest {
 
         assertEquals("\\Literature\\", result.getMetaData().getDefaultFileDirectory().get());
         assertEquals("D:\\Documents", result.getMetaData().getUserFileDirectory("defaultOwner-user").get());
+    }
+
+    @Test
+    public void parseReturnsEntriesInSameOrder() throws IOException {
+        ParserResult result = BibtexParser.parse(new StringReader(
+                "@article{a}" + Globals.NEWLINE +
+                "@article{b}" + Globals.NEWLINE +
+                "@inProceedings{c}"));
+
+        List<BibEntry> expected = new ArrayList<>();
+        BibEntry a = new BibEntry();
+        a.setType("article");
+        a.setCiteKey("a");
+        expected.add(a);
+
+        BibEntry b = new BibEntry();
+        b.setType("article");
+        b.setCiteKey("b");
+        expected.add(b);
+
+        BibEntry c = new BibEntry();
+        c.setType("inproceedings");
+        c.setCiteKey("c");
+        expected.add(c);
+
+        BibtexEntryAssert.assertEquals(expected, result.getDatabase().getEntries());
+
     }
 }

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -49,64 +49,64 @@ public class BibtexParserTest {
 
     @Test
     public void fromStringRecognizesEntry() throws Exception {
-        Collection<BibEntry> c = BibtexParser.fromString("@article{test,author={Ed von Test}}");
-        assertEquals(1, c.size());
+        List<BibEntry> parsed = BibtexParser.fromString("@article{test,author={Ed von Test}}");
 
-        BibEntry e = c.iterator().next();
-        assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
-        assertEquals(2, e.getFieldNames().size());
-        assertEquals("Ed von Test", e.getField("author"));
+        BibEntry expected = new BibEntry();
+        expected.setType("article");
+        expected.setCiteKey("test");
+        expected.setField("author", "Ed von Test");
+        BibtexEntryAssert.assertEquals(Arrays.asList(expected), parsed);
     }
 
     @Test
     public void fromStringReturnsEmptyListFromEmptyString() {
-        Collection<BibEntry> c = BibtexParser.fromString("");
-        Assert.assertNotNull(c);
-        assertEquals(0, c.size());
+        Collection<BibEntry> parsed = BibtexParser.fromString("");
+        Assert.assertNotNull(parsed);
+        assertEquals(Collections.emptyList(), parsed);
     }
 
     @Test
     public void fromStringReturnsEmptyListIfNoEntryRecognized() {
-        Collection<BibEntry> c = BibtexParser.fromString("@@article@@{{{{{{}");
-        Assert.assertNotNull(c);
-        assertEquals(0, c.size());
+        Collection<BibEntry> parsed = BibtexParser.fromString("@@article@@{{{{{{}");
+        Assert.assertNotNull(parsed);
+        assertEquals(Collections.emptyList(), parsed);
     }
 
     @Test
     public void singleFromStringRecognizesEntry() {
-        BibEntry e = BibtexParser.singleFromString(
+        BibEntry parsed = BibtexParser.singleFromString(
                 "@article{canh05," + "  author = {Crowston, K. and Annabi, H.},\n" + "  title = {Title A}}\n");
 
-        assertEquals("article", e.getType());
-        assertEquals("canh05", e.getCiteKey());
-        assertEquals("Crowston, K. and Annabi, H.", e.getField("author"));
-        assertEquals("Title A", e.getField("title"));
+        BibEntry expected = new BibEntry();
+        expected.setType("article");
+        expected.setCiteKey("canh05");
+        expected.setField("author", "Crowston, K. and Annabi, H.");
+        expected.setField("title", "Title A");
+        BibtexEntryAssert.assertEquals(expected, parsed);
     }
 
     @Test
     public void singleFromStringRecognizesEntryInMultiple() {
-        BibEntry e = BibtexParser.singleFromString("@article{canh05," + "  author = {Crowston, K. and Annabi, H.},\n"
+        BibEntry parsed = BibtexParser.singleFromString("@article{canh05," + "  author = {Crowston, K. and Annabi, H.},\n"
                 + "  title = {Title A}}\n" + "@inProceedings{foo," + "  author={Norton Bar}}");
 
-        Assert.assertTrue(e.getCiteKey().equals("canh05") || e.getCiteKey().equals("foo"));
+        Assert.assertTrue(parsed.getCiteKey().equals("canh05") || parsed.getCiteKey().equals("foo"));
     }
 
     @Test
     public void singleFromStringReturnsNullFromEmptyString() {
-        BibEntry e = BibtexParser.singleFromString("");
-        Assert.assertNull(e);
+        BibEntry parsed = BibtexParser.singleFromString("");
+        Assert.assertNull(parsed);
     }
 
     @Test
     public void singleFromStringReturnsNullIfNoEntryRecognized() {
-        BibEntry e = BibtexParser.singleFromString("@@article@@{{{{{{}");
-        Assert.assertNull(e);
+        BibEntry parsed = BibtexParser.singleFromString("@@article@@{{{{{{}");
+        Assert.assertNull(parsed);
     }
 
     @Test
     public void parseTwoTimesReturnsSameResult() throws IOException {
-
         BibtexParser parser = new BibtexParser(new StringReader("@article{test,author={Ed von Test}}"));
         ParserResult result = parser.parse();
 
@@ -115,14 +115,13 @@ public class BibtexParserTest {
 
     @Test
     public void parseRecognizesEntry() throws IOException {
-
         ParserResult result = BibtexParser.parse(new StringReader(
                 "@article{test,author={Ed von Test}}"));
 
-        Collection<BibEntry> c = result.getDatabase().getEntries();
-        assertEquals(1, c.size());
+        List<BibEntry> parsed = result.getDatabase().getEntries();
+        assertEquals(1, parsed.size());
 
-        BibEntry e = c.iterator().next();
+        BibEntry e = parsed.iterator().next();
         assertEquals("article", e.getType());
         assertEquals("test", e.getCiteKey());
         assertEquals(2, e.getFieldNames().size());
@@ -135,10 +134,10 @@ public class BibtexParserTest {
         ParserResult result = BibtexParser.parse(new StringReader(
                 "@article{test,author=\"Ed von Test\"}"));
 
-        Collection<BibEntry> c = result.getDatabase().getEntries();
-        assertEquals(1, c.size());
+        List<BibEntry> parsed = result.getDatabase().getEntries();
+        assertEquals(1, parsed.size());
 
-        BibEntry e = c.iterator().next();
+        BibEntry e = parsed.iterator().next();
         assertEquals("article", e.getType());
         assertEquals("test", e.getCiteKey());
         assertEquals(2, e.getFieldNames().size());
@@ -152,10 +151,10 @@ public class BibtexParserTest {
         ParserResult result = BibtexParser.parse(new StringReader(
                 "@article{test}"));
 
-        Collection<BibEntry> c = result.getDatabase().getEntries();
-        assertEquals(1, c.size());
+        List<BibEntry> parsed = result.getDatabase().getEntries();
+        assertEquals(1, parsed.size());
 
-        BibEntry e = c.iterator().next();
+        BibEntry e = parsed.iterator().next();
         assertEquals("article", e.getType());
         assertEquals("test", e.getCiteKey());
     }
@@ -165,10 +164,10 @@ public class BibtexParserTest {
 
         ParserResult result = BibtexParser.parse(new StringReader(" @article{test,author={Ed von Test}}"));
 
-        Collection<BibEntry> c = result.getDatabase().getEntries();
-        assertEquals(1, c.size());
+        List<BibEntry> parsed = result.getDatabase().getEntries();
+        assertEquals(1, parsed.size());
 
-        BibEntry e = c.iterator().next();
+        BibEntry e = parsed.iterator().next();
         assertEquals("article", e.getType());
         assertEquals("test", e.getCiteKey());
         assertEquals(2, e.getFieldNames().size());
@@ -180,10 +179,10 @@ public class BibtexParserTest {
 
         ParserResult result = BibtexParser.parse(new StringReader("@article { test,author={Ed von Test}}"));
 
-        Collection<BibEntry> c = result.getDatabase().getEntries();
-        assertEquals(1, c.size());
+        List<BibEntry> parsed = result.getDatabase().getEntries();
+        assertEquals(1, parsed.size());
 
-        BibEntry e = c.iterator().next();
+        BibEntry e = parsed.iterator().next();
         assertEquals("article", e.getType());
         assertEquals("test", e.getCiteKey());
         assertEquals(2, e.getFieldNames().size());
@@ -307,28 +306,23 @@ public class BibtexParserTest {
         ParserResult result = BibtexParser
                 .parse(new StringReader("@article{canh05," + "  author = {Crowston, K. and Annabi, H.},\n"
                         + "  title = {Title A}}\n" + "@inProceedings{foo," + "  author={Norton Bar}}"));
-        Collection<BibEntry> c = result.getDatabase().getEntries();
-        assertEquals(2, c.size());
+        List<BibEntry> parsed = result.getDatabase().getEntries();
 
-        Iterator<BibEntry> i = c.iterator();
-        BibEntry a = i.next();
-        BibEntry b = i.next();
+        List<BibEntry> expected = new ArrayList<>();
+        BibEntry firstEntry = new BibEntry();
+        firstEntry.setType("article");
+        firstEntry.setCiteKey("canh05");
+        firstEntry.setField("author", "Crowston, K. and Annabi, H.");
+        firstEntry.setField("title", "Title A");
+        expected.add(firstEntry);
 
-        // Sort them because we can't be sure about the order
-        if (a.getCiteKey().equals("foo")) {
-            BibEntry tmp = a;
-            a = b;
-            b = tmp;
-        }
+        BibEntry secondEntry = new BibEntry();
+        secondEntry.setType("inproceedings");
+        secondEntry.setCiteKey("foo");
+        secondEntry.setField("author", "Norton Bar");
+        expected.add(secondEntry);
 
-        assertEquals("article", a.getType());
-        assertEquals("canh05", a.getCiteKey());
-        assertEquals("Crowston, K. and Annabi, H.", a.getField("author"));
-        assertEquals("Title A", a.getField("title"));
-
-        assertEquals("inproceedings", b.getType());
-        assertEquals("foo", b.getCiteKey());
-        assertEquals("Norton Bar", b.getField("author"));
+        BibtexEntryAssert.assertEquals(expected, parsed);
     }
 
     @Test
@@ -352,25 +346,20 @@ public class BibtexParserTest {
     public void parseRecognizesMultipleEntriesOnSameLine() throws IOException {
 
         ParserResult result = BibtexParser.parse(new StringReader("@article{canh05}" + "@inProceedings{foo}"));
-        Collection<BibEntry> c = result.getDatabase().getEntries();
-        assertEquals(2, c.size());
+        List<BibEntry> parsed = result.getDatabase().getEntries();
 
-        Iterator<BibEntry> i = c.iterator();
-        BibEntry a = i.next();
-        BibEntry b = i.next();
+        List<BibEntry> expected = new ArrayList<>();
+        BibEntry firstEntry = new BibEntry();
+        firstEntry.setType("article");
+        firstEntry.setCiteKey("canh05");
+        expected.add(firstEntry);
 
-        // Sort them because we can't be sure about the order
-        if (a.getCiteKey().equals("foo")) {
-            BibEntry tmp = a;
-            a = b;
-            b = tmp;
-        }
+        BibEntry secondEntry = new BibEntry();
+        secondEntry.setType("inproceedings");
+        secondEntry.setCiteKey("foo");
+        expected.add(secondEntry);
 
-        assertEquals("article", a.getType());
-        assertEquals("canh05", a.getCiteKey());
-
-        assertEquals("inproceedings", b.getType());
-        assertEquals("foo", b.getCiteKey());
+        BibtexEntryAssert.assertEquals(expected, parsed);
     }
 
     @Test
@@ -1462,6 +1451,5 @@ public class BibtexParserTest {
         expected.add(c);
 
         BibtexEntryAssert.assertEquals(expected, result.getDatabase().getEntries());
-
     }
 }

--- a/src/test/java/net/sf/jabref/util/UtilTest.java
+++ b/src/test/java/net/sf/jabref/util/UtilTest.java
@@ -52,7 +52,7 @@ public class UtilTest {
             Assert.fail();
         }
         database = result.getDatabase();
-        entry = database.getEntriesByKey("HipKro03")[0];
+        entry = database.getEntryByKey("HipKro03");
 
         Assert.assertNotNull(database);
         Assert.assertNotNull(entry);


### PR DESCRIPTION
@obraliar https://github.com/JabRef/jabref/pull/504#discussion_r56398599 noted that the order of the bibentries in `parserResult.getDatabase().getEntries` is not the same as in the bib file.
As it turned out, fixing the order required to store the bibentries not as `Map<id, BibEntry>` but simply as a list. So I removed almost everything which is connected to ID's. Now they are only used for writing bibentries (to determine the original order) and for the sql export. 

- [x] Change in CHANGELOG.md described? Not relevant
- [x] Changes in pull request outlined? (What, why, ...)
- [x] Tests created for changes?
- [x] Tests green?
