### PR TITLE
Coverity and Codacy cleanups

### DIFF
--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -440,7 +440,7 @@ public class MetaData implements Iterable<String> {
     /**
      * Writes all data in the format <key, serialized data>.
      */
-    public Map<String, String> serialize() throws IOException {
+    public Map<String, String> serialize() {
 
         Map<String, String> serializedMetaData = new TreeMap<>();
 

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -18,6 +18,9 @@ package net.sf.jabref;
 import java.io.*;
 import java.util.*;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import net.sf.jabref.exporter.FieldFormatterCleanups;
 import net.sf.jabref.groups.GroupTreeNode;
 import net.sf.jabref.logic.config.SaveOrderConfig;
@@ -30,6 +33,8 @@ import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.sql.DBStrings;
 
 public class MetaData implements Iterable<String> {
+
+    private static final Log LOGGER = LogFactory.getLog(MetaData.class);
 
     public static final String META_FLAG = "jabref-meta: ";
     public static final String SAVE_ORDER_CONFIG = "saveOrderConfig";
@@ -77,7 +82,7 @@ public class MetaData implements Iterable<String> {
                         orderedData.add(unit);
                     }
                 } catch (IOException ex) {
-                    System.err.println("Weird error while parsing meta data.");
+                    LOGGER.error("Weird error while parsing meta data.", ex);
                 }
                 if (GROUPSVERSION.equals(entry.getKey())) {
                     if (!orderedData.isEmpty()) {
@@ -260,7 +265,7 @@ public class MetaData implements Iterable<String> {
             groupTreeValid = true;
         } catch (Exception e) {
             // we cannot really do anything about this here
-            System.err.println(e);
+            LOGGER.error("Problem parsing groups from MetaData", e);
             groupTreeValid = false;
         }
     }

--- a/src/main/java/net/sf/jabref/collab/ChangeScanner.java
+++ b/src/main/java/net/sf/jabref/collab/ChangeScanner.java
@@ -84,7 +84,6 @@ public class ChangeScanner implements Runnable {
     @Override
     public void run() {
         try {
-            //long startTime = System.currentTimeMillis();
 
             // Parse the temporary file.
             File tempFile = Globals.fileUpdateMonitor.getTempFile(panel.fileMonitorHandle());
@@ -286,25 +285,9 @@ public class ChangeScanner implements Runnable {
                     EntryChange ec = new EntryChange(bestFit(tmp, mem, piv1), tmp.getEntryAt(piv1),
                             disk.getEntryAt(bestMatchI));
                     changes.add(ec);
-
-                    // Create an undo edit to represent this change:
-                    //NamedCompound ce = new NamedCompound("Modified entry");
-                    //ce.addEdit(new UndoableRemoveEntry(inMem, disk.getEntryAt(bestMatchI), panel));
-                    //ce.addEdit(new UndoableInsertEntry(inMem, tmp.getEntryAt(piv1), panel));
-                    //ce.end();
-                    //changes.add(ce);
-
-                    //System.out.println("Possible match for entry:");
-                    //System.out.println("----------------------------------------------");
-
                 } else {
                     EntryDeleteChange ec = new EntryDeleteChange(bestFit(tmp, mem, piv1), tmp.getEntryAt(piv1));
                     changes.add(ec);
-                    /*NamedCompound ce = new NamedCompound("Removed entry");
-                    ce.addEdit(new UndoableInsertEntry(inMem, tmp.getEntryAt(piv1), panel));
-                    ce.end();
-                    changes.add(ce);*/
-
                 }
 
             }
@@ -329,13 +312,8 @@ public class ChangeScanner implements Runnable {
                         EntryAddChange ec = new EntryAddChange(disk.getEntryAt(i));
                         changes.add(ec);
                     }
-                    /*NamedCompound ce = new NamedCompound("Added entry");
-                    ce.addEdit(new UndoableRemoveEntry(inMem, disk.getEntryAt(i), panel));
-                    ce.end();
-                    changes.add(ce);*/
                 }
             }
-            //System.out.println("Suspected new entries in file: "+(disk.getEntryCount()-used.size()));
         }
     }
 

--- a/src/main/java/net/sf/jabref/collab/EntryChange.java
+++ b/src/main/java/net/sf/jabref/collab/EntryChange.java
@@ -150,9 +150,17 @@ class EntryChange extends Change {
 
         @Override
         public boolean makeChange(BasePanel panel, BibDatabase secondary, NamedCompound undoEdit) {
-            entry.setField(field, onDisk);
+            if (onDisk == null) {
+                entry.clearField(field);
+            } else {
+                entry.setField(field, onDisk);
+            }
             undoEdit.addEdit(new UndoableFieldChange(entry, field, inMem, onDisk));
-            tmpEntry.setField(field, onDisk);
+            if (onDisk == null) {
+                tmpEntry.clearField(field);
+            } else {
+                tmpEntry.setField(field, onDisk);
+            }
             return true;
         }
 

--- a/src/main/java/net/sf/jabref/exporter/IExportFormat.java
+++ b/src/main/java/net/sf/jabref/exporter/IExportFormat.java
@@ -22,7 +22,6 @@ import net.sf.jabref.model.entry.BibEntry;
 import javax.swing.filechooser.FileFilter;
 import java.nio.charset.Charset;
 import java.util.List;
-import java.util.Set;
 
 public interface IExportFormat {
 

--- a/src/main/java/net/sf/jabref/exporter/MSBibExportFormat.java
+++ b/src/main/java/net/sf/jabref/exporter/MSBibExportFormat.java
@@ -21,6 +21,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
+
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;

--- a/src/main/java/net/sf/jabref/exporter/ModsExportFormat.java
+++ b/src/main/java/net/sf/jabref/exporter/ModsExportFormat.java
@@ -30,6 +30,7 @@ import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.OutputKeys;
 import java.util.List;
 import java.util.Objects;
+
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/net/sf/jabref/exporter/MySQLExport.java
+++ b/src/main/java/net/sf/jabref/exporter/MySQLExport.java
@@ -18,6 +18,7 @@ package net.sf.jabref.exporter;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Objects;
+
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.l10n.Localization;

--- a/src/main/java/net/sf/jabref/exporter/OOCalcDatabase.java
+++ b/src/main/java/net/sf/jabref/exporter/OOCalcDatabase.java
@@ -16,11 +16,8 @@
 package net.sf.jabref.exporter;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 

--- a/src/main/java/net/sf/jabref/exporter/OpenDocumentRepresentation.java
+++ b/src/main/java/net/sf/jabref/exporter/OpenDocumentRepresentation.java
@@ -16,11 +16,8 @@
 package net.sf.jabref.exporter;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 

--- a/src/main/java/net/sf/jabref/exporter/PostgreSQLExport.java
+++ b/src/main/java/net/sf/jabref/exporter/PostgreSQLExport.java
@@ -18,6 +18,7 @@ package net.sf.jabref.exporter;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Objects;
+
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.l10n.Localization;

--- a/src/main/java/net/sf/jabref/exporter/SaveDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/exporter/SaveDatabaseAction.java
@@ -23,7 +23,6 @@ import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.worker.AbstractWorker;
 import net.sf.jabref.gui.FileDialogs;
 import net.sf.jabref.collab.ChangeScanner;
-import net.sf.jabref.collab.ChangeScanner.DisplayResultCallback;
 import net.sf.jabref.gui.worker.CallBack;
 import net.sf.jabref.gui.worker.Worker;
 import net.sf.jabref.logic.l10n.Encodings;
@@ -100,7 +99,7 @@ public class SaveDatabaseAction extends AbstractWorker {
                                 panel.getBibDatabaseContext().getDatabaseFile());
                         JabRefExecutorService.INSTANCE.executeWithLowPriorityInOwnThreadAndWait(scanner);
                         if (scanner.changesFound()) {
-                            scanner.displayResult((DisplayResultCallback) resolved -> {
+                            scanner.displayResult((ChangeScanner.DisplayResultCallback) resolved -> {
                                 if (resolved) {
                                     panel.setUpdatedExternally(false);
                                     SwingUtilities.invokeLater(

--- a/src/main/java/net/sf/jabref/gui/FieldWeightDialog.java
+++ b/src/main/java/net/sf/jabref/gui/FieldWeightDialog.java
@@ -117,12 +117,11 @@ public class FieldWeightDialog extends JDialog {
     }
 
     private void storeSettings() {
-        for (JSlider slider : sliders.keySet()) {
-            SliderInfo sInfo = sliders.get(slider);
+        for (Map.Entry<JSlider, SliderInfo> sliderEntry : sliders.entrySet()) {
             // Only list the value if it has changed:
-            if (sInfo.originalValue != slider.getValue()) {
-                double weight = (BibtexSingleField.MAX_FIELD_WEIGHT * slider.getValue()) / 100d;
-                InternalBibtexFields.setFieldWeight(sInfo.fieldName, weight);
+            if (sliderEntry.getValue().originalValue != sliderEntry.getKey().getValue()) {
+                double weight = (BibtexSingleField.MAX_FIELD_WEIGHT * sliderEntry.getKey().getValue()) / 100d;
+                InternalBibtexFields.setFieldWeight(sliderEntry.getValue().fieldName, weight);
             }
         }
         frame.removeCachedEntryEditors();

--- a/src/main/java/net/sf/jabref/gui/GlazedEntrySorter.java
+++ b/src/main/java/net/sf/jabref/gui/GlazedEntrySorter.java
@@ -17,7 +17,6 @@ package net.sf.jabref.gui;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.database.DatabaseChangeEvent;
 import net.sf.jabref.model.database.DatabaseChangeListener;

--- a/src/main/java/net/sf/jabref/gui/labelpattern/SearchFixDuplicateLabels.java
+++ b/src/main/java/net/sf/jabref/gui/labelpattern/SearchFixDuplicateLabels.java
@@ -87,15 +87,15 @@ public class SearchFixDuplicateLabels extends AbstractWorker {
     @Override
     public void update() {
         List<BibEntry> toGenerateFor = new ArrayList<>();
-        for (String key : dupes.keySet()) {
-            ResolveDuplicateLabelDialog rdld = new ResolveDuplicateLabelDialog(panel, key, dupes.get(key));
+        for (Map.Entry<String, List<BibEntry>> dupeEntry : dupes.entrySet()) {
+            ResolveDuplicateLabelDialog rdld = new ResolveDuplicateLabelDialog(panel, dupeEntry.getKey(), dupeEntry.getValue());
             rdld.show();
             if (rdld.isOkPressed()) {
                 List<JCheckBox> cbs = rdld.getCheckBoxes();
                 for (int i = 0; i < cbs.size(); i++) {
                     if (cbs.get(i).isSelected()) {
                         // The checkbox for entry i has been selected, so we should generate a new key for it:
-                        toGenerateFor.add(dupes.get(key).get(i));
+                        toGenerateFor.add(dupeEntry.getValue().get(i));
                     }
                 }
             }

--- a/src/main/java/net/sf/jabref/importer/fetcher/GVKFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/GVKFetcher.java
@@ -146,7 +146,7 @@ public class GVKFetcher implements EntryFetcher {
                 lastWasKey = false;
             }
         }
-        return (result);
+        return result;
     }
 
     private List<BibEntry> fetchGVK(String query) {
@@ -155,25 +155,24 @@ public class GVKFetcher implements EntryFetcher {
         String urlPrefix = "http://sru.gbv.de/gvk?version=1.1&operation=searchRetrieve&query=";
         String urlSuffix = "&maximumRecords=50&recordSchema=picaxml&sortKeys=Year%2C%2C1";
 
-        String searchstring = (urlPrefix + query + urlSuffix);
+        String searchstring = urlPrefix + query + urlSuffix;
         LOGGER.debug(searchstring);
         try {
-            URI uri;
-            try {
-                uri = new URI(searchstring);
-            } catch (URISyntaxException e) {
-                LOGGER.error("URI malformed error", e);
-                return Collections.emptyList();
-            }
+            URI uri = new URI(searchstring);
             URL url = uri.toURL();
             try (InputStream is = url.openStream()) {
                 result = (new GVKParser()).parseEntries(is);
             }
+        } catch (
+
+        URISyntaxException e) {
+            LOGGER.error("URI malformed error", e);
+            return Collections.emptyList();
         } catch (IOException e) {
-            LOGGER.error("GVK plugin: An I/O exception occurred", e);
+            LOGGER.error("GVK: An I/O exception occurred", e);
             return Collections.emptyList();
         } catch (ParserConfigurationException e) {
-            LOGGER.error("GVK plugin: An internal parser error occurred", e);
+            LOGGER.error("GVK: An internal parser error occurred", e);
             return Collections.emptyList();
         } catch (SAXException e) {
             LOGGER.error("An internal parser error occurred", e);

--- a/src/main/java/net/sf/jabref/importer/fetcher/GVKFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/GVKFetcher.java
@@ -163,9 +163,7 @@ public class GVKFetcher implements EntryFetcher {
             try (InputStream is = url.openStream()) {
                 result = (new GVKParser()).parseEntries(is);
             }
-        } catch (
-
-        URISyntaxException e) {
+        } catch (URISyntaxException e) {
             LOGGER.error("URI malformed error", e);
             return Collections.emptyList();
         } catch (IOException e) {

--- a/src/main/java/net/sf/jabref/model/database/EntrySorter.java
+++ b/src/main/java/net/sf/jabref/model/database/EntrySorter.java
@@ -90,8 +90,10 @@ public class EntrySorter implements DatabaseChangeListener {
             int pos;
             switch (e.getType()) {
             case ADDED_ENTRY:
-                pos = -Collections.binarySearch(set, e.getEntry(), comp) - 1;
-                set.add(pos, e.getEntry());
+                pos = Collections.binarySearch(set, e.getEntry(), comp);
+                if (pos < 0) {
+                    set.add(0, e.getEntry());
+                }
                 break;
             case REMOVED_ENTRY:
                 set.remove(e.getEntry());
@@ -101,8 +103,7 @@ public class EntrySorter implements DatabaseChangeListener {
                 pos = Collections.binarySearch(set, e.getEntry(), comp);
                 int posOld = set.indexOf(e.getEntry());
                 if (pos < 0) {
-                    set.remove(posOld);
-                    set.add(-pos - 1, e.getEntry());
+                    set.add(0, e.getEntry());
                 }
                 break;
             }

--- a/src/main/java/net/sf/jabref/model/database/EntrySorter.java
+++ b/src/main/java/net/sf/jabref/model/database/EntrySorter.java
@@ -101,7 +101,6 @@ public class EntrySorter implements DatabaseChangeListener {
                 break;
             case CHANGED_ENTRY:
                 pos = Collections.binarySearch(set, e.getEntry(), comp);
-                int posOld = set.indexOf(e.getEntry());
                 if (pos < 0) {
                     set.add(0, e.getEntry());
                 }

--- a/src/main/java/net/sf/jabref/model/database/EntrySorter.java
+++ b/src/main/java/net/sf/jabref/model/database/EntrySorter.java
@@ -19,7 +19,12 @@ import net.sf.jabref.model.entry.BibEntry;
 
 import java.util.*;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 public class EntrySorter implements DatabaseChangeListener {
+
+    private static final Log LOGGER = LogFactory.getLog(EntrySorter.class);
 
     private final List<BibEntry> set;
     private final Comparator<BibEntry> comp;
@@ -90,8 +95,11 @@ public class EntrySorter implements DatabaseChangeListener {
             int pos;
             switch (e.getType()) {
             case ADDED_ENTRY:
-                pos = Collections.binarySearch(set, e.getEntry(), comp);
-                if (pos < 0) {
+                pos = -Collections.binarySearch(set, e.getEntry(), comp) - 1;
+                LOGGER.debug("Insert position = " + pos);
+                if (pos >= 0) {
+                    set.add(pos, e.getEntry());
+                } else {
                     set.add(0, e.getEntry());
                 }
                 break;
@@ -101,9 +109,13 @@ public class EntrySorter implements DatabaseChangeListener {
                 break;
             case CHANGED_ENTRY:
                 pos = Collections.binarySearch(set, e.getEntry(), comp);
+                int posOld = set.indexOf(e.getEntry());
                 if (pos < 0) {
-                    set.add(0, e.getEntry());
+                    set.remove(posOld);
+                    set.add(-posOld - 1, e.getEntry());
                 }
+                break;
+            default:
                 break;
             }
         }

--- a/src/test/java/net/sf/jabref/bst/TestVM.java
+++ b/src/test/java/net/sf/jabref/bst/TestVM.java
@@ -511,7 +511,7 @@ public class TestVM {
     }
 
     @Test
-    public void testFormatName() throws RecognitionException, IOException {
+    public void testFormatName() throws RecognitionException {
         VM vm = new VM(
                 "FUNCTION {format}{ \"Charles Louis Xavier Joseph de la Vall{\\'e}e Poussin\" #1 \"{vv~}{ll}{, jj}{, f}?\" format.name$ }"
                         + "EXECUTE {format}");


### PR DESCRIPTION
Actually found a bug in the ChangeScanner leading to NPEs while trying to remove a Codacy warning (not sure if that part succeeded though).

Got rid of unused imports (don't you have your editors configured to do that automatically :question: ).

Got rid of maybe the last unwanted println.