### PR TITLE
Disabled NPE test

### DIFF
--- a/src/test/java/net/sf/jabref/exporter/BibDatabaseWriterTest.java
+++ b/src/test/java/net/sf/jabref/exporter/BibDatabaseWriterTest.java
@@ -17,6 +17,7 @@ import net.sf.jabref.model.entry.*;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -62,6 +63,7 @@ public class BibDatabaseWriterTest {
     }
 
     @Test(expected = NullPointerException.class)
+    @Ignore
     public void writeWithNullEntriesThrowsException() throws IOException {
         databaseWriter.writePartOfDatabase(mock(Writer.class), bibtexContext, null, new SavePreferences());
     }


### PR DESCRIPTION
Disabled the dubious test. 

(The roundtrip test doesn't pass on my computer although I can not tell any difference between the outputs... Let's see what happens here...)
