### PR TITLE
Fixed problem with whitespaces in file paths for tests

### DIFF
--- a/src/test/java/net/sf/jabref/cli/AuxCommandLineTest.java
+++ b/src/test/java/net/sf/jabref/cli/AuxCommandLineTest.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -23,9 +25,10 @@ public class AuxCommandLineTest {
     }
 
     @Test
-    public void test() {
+    public void test() throws URISyntaxException {
         InputStream originalStream = AuxCommandLineTest.class.getResourceAsStream("origin.bib");
-        File auxFile = new File(AuxCommandLineTest.class.getResource("paper.aux").getFile());
+
+        File auxFile = Paths.get(AuxCommandLineTest.class.getResource("paper.aux").toURI()).toFile();
         try (InputStreamReader originalReader = new InputStreamReader(originalStream)) {
             ParserResult result = BibtexParser.parse(originalReader);
 

--- a/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
+++ b/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
@@ -10,21 +10,31 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.Collection;
 
 public class OpenDatabaseActionTest {
 
     private final Charset defaultEncoding = StandardCharsets.UTF_8;
-    private final File bibNoHeader = new File(OpenDatabaseActionTest.class.getResource("headerless.bib").getFile());
-    private final File bibWrongHeader = new File(
-            OpenDatabaseActionTest.class.getResource("wrong-header.bib").getFile());
-    private final File bibHeader = new File(OpenDatabaseActionTest.class.getResource("encoding-header.bib").getFile());
-    private final File bibHeaderAndSignature = new File(
-            OpenDatabaseActionTest.class.getResource("jabref-header.bib").getFile());
-    private final File bibEncodingWithoutNewline = new File(
-            OpenDatabaseActionTest.class.getResource("encodingWithoutNewline.bib").getFile());
+    private final File bibNoHeader;
+    private final File bibWrongHeader;
+    private final File bibHeader;
+    private final File bibHeaderAndSignature;
+    private final File bibEncodingWithoutNewline;
+
+
+    public OpenDatabaseActionTest() throws URISyntaxException {
+        bibNoHeader = Paths.get(OpenDatabaseActionTest.class.getResource("headerless.bib").toURI()).toFile();
+        bibWrongHeader = Paths.get(OpenDatabaseActionTest.class.getResource("wrong-header.bib").toURI()).toFile();
+        bibHeader = Paths.get(OpenDatabaseActionTest.class.getResource("encoding-header.bib").toURI()).toFile();
+        bibHeaderAndSignature = Paths.get(OpenDatabaseActionTest.class.getResource("jabref-header.bib").toURI())
+                .toFile();
+        bibEncodingWithoutNewline = Paths
+                .get(OpenDatabaseActionTest.class.getResource("encodingWithoutNewline.bib").toURI()).toFile();
+    }
 
     @BeforeClass
     public static void setUpGlobalsPrefs() {

--- a/src/test/java/net/sf/jabref/logic/auxparser/AuxParserTest.java
+++ b/src/test/java/net/sf/jabref/logic/auxparser/AuxParserTest.java
@@ -6,6 +6,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -24,9 +26,9 @@ public class AuxParserTest {
     }
 
     @Test
-    public void testNormal() {
+    public void testNormal() throws URISyntaxException {
         InputStream originalStream = AuxParserTest.class.getResourceAsStream("origin.bib");
-        File auxFile = new File(AuxParserTest.class.getResource("paper.aux").getFile());
+        File auxFile = Paths.get(AuxParserTest.class.getResource("paper.aux").toURI()).toFile();
         try (InputStreamReader originalReader = new InputStreamReader(originalStream)) {
             ParserResult result = BibtexParser.parse(originalReader);
 
@@ -48,9 +50,10 @@ public class AuxParserTest {
     }
 
     @Test
-    public void testNotAllFound() {
+    public void testNotAllFound() throws URISyntaxException {
         InputStream originalStream = AuxParserTest.class.getResourceAsStream("origin.bib");
-        File auxFile = new File(AuxParserTest.class.getResource("badpaper.aux").getFile());
+        File auxFile = Paths.get(AuxParserTest.class.getResource("badpaper.aux").toURI()).toFile();
+
         try (InputStreamReader originalReader = new InputStreamReader(originalStream)) {
             ParserResult result = BibtexParser.parse(originalReader);
 
@@ -72,9 +75,9 @@ public class AuxParserTest {
     }
 
     @Test
-    public void duplicateBibDatabaseConfiguration() {
+    public void duplicateBibDatabaseConfiguration() throws URISyntaxException {
         InputStream originalStream = AuxParserTest.class.getResourceAsStream("config.bib");
-        File auxFile = new File(AuxParserTest.class.getResource("paper.aux").getFile());
+        File auxFile = Paths.get(AuxParserTest.class.getResource("paper.aux").toURI()).toFile();
         try (InputStreamReader originalReader = new InputStreamReader(originalStream)) {
             ParserResult result = BibtexParser.parse(originalReader);
 
@@ -90,9 +93,9 @@ public class AuxParserTest {
     }
 
     @Test
-    public void testNestedAux() {
+    public void testNestedAux() throws URISyntaxException {
         InputStream originalStream = AuxParserTest.class.getResourceAsStream("origin.bib");
-        File auxFile = new File(AuxParserTest.class.getResource("nested.aux").getFile());
+        File auxFile = Paths.get(AuxParserTest.class.getResource("nested.aux").toURI()).toFile();
         try (InputStreamReader originalReader = new InputStreamReader(originalStream)) {
             ParserResult result = BibtexParser.parse(originalReader);
 

--- a/src/test/java/net/sf/jabref/openoffice/OOBibStyleTest.java
+++ b/src/test/java/net/sf/jabref/openoffice/OOBibStyleTest.java
@@ -5,9 +5,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -61,10 +63,12 @@ public class OOBibStyleTest {
     }
 
     @Test
-    public void testAuthorYearAsFile() {
+    public void testAuthorYearAsFile() throws URISyntaxException {
         try {
-            URL defPath = JabRef.class.getResource(OpenOfficePanel.DEFAULT_AUTHORYEAR_STYLE_PATH);
-            OOBibStyle style = new OOBibStyle(new File(defPath.getFile()), mock(JournalAbbreviationRepository.class),
+            File defFile = Paths.get(JabRef.class.getResource(OpenOfficePanel.DEFAULT_AUTHORYEAR_STYLE_PATH).toURI())
+                    .toFile();
+
+            OOBibStyle style = new OOBibStyle(defFile, mock(JournalAbbreviationRepository.class),
                     Globals.prefs.getDefaultEncoding());
             assertTrue(style.isValid());
             assertFalse(style.isBibtexKeyCiteMarkers());


### PR DESCRIPTION
After I relocated my workspace, I notice some problems with white spaces in file paths. The whitespaces got encoded as %20 and failed on Windows.
Problem was Url.toFile()
`Paths.get(url.toUri()).toFile()` is now the correct way to handle Files from URLs.
See  http://stackoverflow.com/questions/6164448/convert-url-to-normal-windows-filename-java

- [x] Changes in pull request outlined? (What, why, ...)
- [x] Tests created for changes?
- [x] Tests green?
