### PR TITLE
Used PositionWindow for PreambleEditor dialog size

### DIFF
--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -150,6 +150,10 @@ public class JabRefPreferences {
     public static final String MERGEENTRIES_SIZE_X = "mergeEntriesSizeX";
     public static final String MERGEENTRIES_POS_Y = "mergeEntriesPosY";
     public static final String MERGEENTRIES_POS_X = "mergeEntriesPosX";
+    public static final String PREAMBLE_SIZE_Y = "preambleSizeY";
+    public static final String PREAMBLE_SIZE_X = "preambleSizeX";
+    public static final String PREAMBLE_POS_Y = "preamblePosY";
+    public static final String PREAMBLE_POS_X = "preamblePosX";
     public static final String LAST_EDITED = "lastEdited";
     public static final String OPEN_LAST_EDITED = "openLastEdited";
     public static final String LAST_FOCUSED = "lastFocused";
@@ -552,8 +556,6 @@ public class JabRefPreferences {
         defaults.put(IMPORT_WORKING_DIRECTORY, USER_HOME);
         defaults.put(FILE_WORKING_DIRECTORY, USER_HOME);
         defaults.put(AUTO_OPEN_FORM, Boolean.TRUE);
-        defaults.put(ENTRY_TYPE_FORM_HEIGHT_FACTOR, 1);
-        defaults.put(ENTRY_TYPE_FORM_WIDTH, 1);
         defaults.put(BACKUP, Boolean.TRUE);
         defaults.put(OPEN_LAST_EDITED, Boolean.TRUE);
         defaults.put(LAST_EDITED, "");
@@ -570,6 +572,10 @@ public class JabRefPreferences {
         defaults.put(MERGEENTRIES_POS_Y, 0);
         defaults.put(MERGEENTRIES_SIZE_X, 800);
         defaults.put(MERGEENTRIES_SIZE_Y, 600);
+        defaults.put(PREAMBLE_POS_X, 0);
+        defaults.put(PREAMBLE_POS_Y, 0);
+        defaults.put(PREAMBLE_SIZE_X, 600);
+        defaults.put(PREAMBLE_SIZE_Y, 400);
         defaults.put(DEFAULT_SHOW_SOURCE, Boolean.FALSE);
         defaults.put(DEFAULT_AUTO_SORT, Boolean.FALSE);
         defaults.put(SEARCH_CASE_SENSITIVE, Boolean.FALSE);

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -475,7 +475,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         // The action for opening the preamble editor
         actions.put(Actions.EDIT_PREAMBLE, (BaseAction) () -> {
             if (preambleEditor == null) {
-                PreambleEditor form = new PreambleEditor(frame, BasePanel.this, database, Globals.prefs);
+                PreambleEditor form = new PreambleEditor(frame, BasePanel.this, database);
                 PositionWindow.placeDialog(form, frame);
                 form.setVisible(true);
                 preambleEditor = form;

--- a/src/main/java/net/sf/jabref/gui/GUIGlobals.java
+++ b/src/main/java/net/sf/jabref/gui/GUIGlobals.java
@@ -86,10 +86,6 @@ public class GUIGlobals {
 
     public static final double PE_HEIGHT = 2;
 
-    //	Size constants for PreambleEditor; small, medium and large.
-    public static final int[] FORM_WIDTH = new int[]{500, 650, 820};
-    public static final int[] FORM_HEIGHT = new int[]{90, 110, 130};
-
     //	Constants controlling formatted bibtex output.
     public static final int INDENT = 4;
     public static final int LINE_LENGTH = 65; // Maximum

--- a/src/main/java/net/sf/jabref/gui/PreambleEditor.java
+++ b/src/main/java/net/sf/jabref/gui/PreambleEditor.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2015 JabRef contributors.
+/*  Copyright (C) 2003-2016 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -19,6 +19,7 @@ import java.awt.event.*;
 import java.awt.*;
 
 import javax.swing.*;
+import javax.swing.text.JTextComponent;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.gui.actions.Actions;
@@ -28,6 +29,7 @@ import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.fieldeditors.FieldEditor;
 import net.sf.jabref.gui.fieldeditors.TextArea;
 import net.sf.jabref.gui.undo.UndoablePreambleChange;
+import net.sf.jabref.gui.util.PositionWindow;
 import net.sf.jabref.logic.l10n.Localization;
 
 class PreambleEditor extends JDialog {
@@ -43,8 +45,10 @@ class PreambleEditor extends JDialog {
     // The action concerned with closing the window.
     private final CloseAction closeAction = new CloseAction();
 
+    private final PositionWindow pw;
 
-    public PreambleEditor(JabRefFrame baseFrame, BasePanel panel, BibDatabase base, JabRefPreferences prefs) {
+
+    public PreambleEditor(JabRefFrame baseFrame, BasePanel panel, BibDatabase base) {
         super(baseFrame);
         this.panel = panel;
         this.base = base;
@@ -69,9 +73,6 @@ class PreambleEditor extends JDialog {
             }
         });
 
-        int prefHeight = (int) (GUIGlobals.PE_HEIGHT * GUIGlobals.FORM_HEIGHT[prefs.getInt(JabRefPreferences.ENTRY_TYPE_FORM_HEIGHT_FACTOR)]);
-        setSize(GUIGlobals.FORM_WIDTH[prefs.getInt(JabRefPreferences.ENTRY_TYPE_FORM_WIDTH)], prefHeight);
-
         JPanel pan = new JPanel();
         GridBagLayout gbl = new GridBagLayout();
         pan.setLayout(gbl);
@@ -83,7 +84,7 @@ class PreambleEditor extends JDialog {
         String content = base.getPreamble();
 
         ed = new TextArea(Localization.lang("Preamble"), content == null ? "" : content);
-        //ed.addUndoableEditListener(panel.undoListener);
+
         setupJTextComponent((TextArea) ed);
 
         gbl.setConstraints(ed.getLabel(), con);
@@ -94,14 +95,32 @@ class PreambleEditor extends JDialog {
         gbl.setConstraints(ed.getPane(), con);
         pan.add(ed.getPane());
 
-        //tlb.add(closeAction);
-        //conPane.add(tlb, BorderLayout.NORTH);
         Container conPane = getContentPane();
         conPane.add(pan, BorderLayout.CENTER);
         setTitle(Localization.lang("Edit preamble"));
+
+        pw = new PositionWindow(this, JabRefPreferences.PREAMBLE_POS_X, JabRefPreferences.PREAMBLE_POS_Y,
+                JabRefPreferences.PREAMBLE_SIZE_X, JabRefPreferences.PREAMBLE_SIZE_Y);
+        pw.setWindowPosition();
+        // Set up a ComponentListener that saves the last size and position of the dialog
+        addComponentListener(new ComponentAdapter() {
+
+            @Override
+            public void componentResized(ComponentEvent e) {
+                // Save dialog position
+                pw.storeWindowPosition();
+            }
+
+            @Override
+            public void componentMoved(ComponentEvent e) {
+                // Save dialog position
+                pw.storeWindowPosition();
+            }
+        });
+
     }
 
-    private void setupJTextComponent(javax.swing.text.JTextComponent ta) {
+    private void setupJTextComponent(JTextComponent ta) {
         // Set up key bindings and focus listener for the FieldEditor.
         ta.getInputMap().put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
         ta.getActionMap().put("close", closeAction);
@@ -224,8 +243,6 @@ class PreambleEditor extends JDialog {
 
         public CloseAction() {
             super(Localization.lang("Close window"));
-            //, new ImageIcon(GUIGlobals.closeIconFile));
-            //putValue(SHORT_DESCRIPTION, "Close window (Ctrl-Q)");
         }
 
         @Override


### PR DESCRIPTION
Now the preamble editor opens with the same size and position as last time. (Plus that some unused preferences and GUIGlobals variables were removed.)