### PR TITLE
Write database type in lower case into the bib file

### DIFF
--- a/src/main/java/net/sf/jabref/BibDatabaseContext.java
+++ b/src/main/java/net/sf/jabref/BibDatabaseContext.java
@@ -7,6 +7,7 @@ import net.sf.jabref.model.database.BibDatabaseModeDetection;
 import java.io.File;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Represents everything related to a .bib file.
@@ -44,8 +45,9 @@ public class BibDatabaseContext {
     }
 
     public BibDatabaseMode getMode() {
-        List<String> data = metaData.getData(MetaData.DATABASE_TYPE);
-        if ((data == null) || data.isEmpty()) {
+        Optional<BibDatabaseMode> mode = metaData.getMode();
+
+        if (!mode.isPresent()) {
             BibDatabaseMode inferredMode = BibDatabaseModeDetection.inferMode(database);
             if ((defaults.mode == BibDatabaseMode.BIBLATEX) || (inferredMode == BibDatabaseMode.BIBLATEX)) {
                 return BibDatabaseMode.BIBLATEX;
@@ -53,7 +55,7 @@ public class BibDatabaseContext {
                 return BibDatabaseMode.BIBTEX;
             }
         }
-        return BibDatabaseMode.valueOf(data.get(0).toUpperCase());
+        return mode.get();
     }
 
     public void setMode(BibDatabaseMode bibDatabaseMode) {

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -33,7 +33,6 @@ import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.sql.DBStrings;
 
 public class MetaData implements Iterable<String> {
-
     private static final Log LOGGER = LogFactory.getLog(MetaData.class);
 
     public static final String META_FLAG = "jabref-meta: ";

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -503,7 +503,7 @@ public class MetaData implements Iterable<String> {
     }
 
     public void setMode(BibDatabaseMode mode) {
-        putData(MetaData.DATABASE_TYPE, Collections.singletonList(mode.getFormattedName()));
+        putData(MetaData.DATABASE_TYPE, Collections.singletonList(mode.getFormattedName().toLowerCase()));
     }
 
     public void markAsProtected() {

--- a/src/test/java/net/sf/jabref/exporter/BibDatabaseWriterTest.java
+++ b/src/test/java/net/sf/jabref/exporter/BibDatabaseWriterTest.java
@@ -367,7 +367,7 @@ public class BibDatabaseWriterTest {
 
         databaseWriter.writePartOfDatabase(stringWriter, bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(Globals.NEWLINE + "@Comment{jabref-meta: databaseType:BibLaTeX;}" + Globals.NEWLINE,
+        assertEquals(Globals.NEWLINE + "@Comment{jabref-meta: databaseType:biblatex;}" + Globals.NEWLINE,
                 stringWriter.toString());
     }
 

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -1334,7 +1334,7 @@ public class BibtexParserTest {
 
     @Test
     public void integrationTestBiblatexMode() throws IOException {
-        ParserResult result = BibtexParser.parse(new StringReader("@comment{jabref-meta: databaseType:BibLaTeX;}"));
+        ParserResult result = BibtexParser.parse(new StringReader("@comment{jabref-meta: databaseType:biblatex;}"));
 
         Optional<BibDatabaseMode> mode = result.getMetaData().getMode();
 

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -49,7 +50,7 @@ public class IntegrityCheckTest {
     }
 
     @Test
-    public void testBraketChecks() {
+    public void testBracketChecks() {
         assertCorrect(createContext("title", "x"));
         assertCorrect(createContext("title", "{x}"));
         assertCorrect(createContext("title", "{x}x{}x{{}}"));
@@ -104,6 +105,8 @@ public class IntegrityCheckTest {
     public void testFileChecks() {
         MetaData metaData = Mockito.mock(MetaData.class);
         Mockito.when(metaData.getFileDirectory("file")).thenReturn(Collections.singletonList("."));
+        // FIXME: must be set as checkBibtexDatabase only activates title checker based on database mode
+        Mockito.when(metaData.getMode()).thenReturn(Optional.of(BibDatabaseMode.BIBTEX));
 
         assertCorrect(createContext("file", ":build.gradle:gradle", metaData));
         assertCorrect(createContext("file", "description:build.gradle:gradle", metaData));

--- a/src/test/resources/net/sf/jabref/cli/origin.bib
+++ b/src/test/resources/net/sf/jabref/cli/origin.bib
@@ -21,4 +21,4 @@
   author =    {Einstein, Albert}
 }
 
-@Comment{jabref-meta: databaseType:BibTeX;}
+@Comment{jabref-meta: databaseType:bibtex;}

--- a/src/test/resources/net/sf/jabref/logic/auxparser/config.bib
+++ b/src/test/resources/net/sf/jabref/logic/auxparser/config.bib
@@ -22,4 +22,4 @@
   author =    {Einstein, Albert}
 }
 
-@Comment{jabref-meta: databaseType:BibTeX;}
+@Comment{jabref-meta: databaseType:bibtex;}

--- a/src/test/resources/net/sf/jabref/logic/auxparser/origin.bib
+++ b/src/test/resources/net/sf/jabref/logic/auxparser/origin.bib
@@ -21,4 +21,4 @@
   author =    {Einstein, Albert}
 }
 
-@Comment{jabref-meta: databaseType:BibTeX;}
+@Comment{jabref-meta: databaseType:bibtex;}

--- a/src/test/resources/testbib/complex.bib
+++ b/src/test/resources/testbib/complex.bib
@@ -281,7 +281,7 @@
   publisher = {IEEE Educational Activities Department}
 }
 
-@Comment{jabref-meta: databaseType:BibLaTeX;}
+@Comment{jabref-meta: databaseType:biblatex;}
 
 @Comment{jabref-meta: fileDirectory:\\Literature\\;}
 

--- a/src/test/resources/testbib/save-actions.bib
+++ b/src/test/resources/testbib/save-actions.bib
@@ -6,7 +6,7 @@
   year =   {2012}
 }
 
-@Comment{jabref-meta: databaseType:BibTeX;}
+@Comment{jabref-meta: databaseType:bibtex;}
 
 @Comment{jabref-meta: saveActions:enabled;
 pages[PageNumbersFormatter,DateFormatter]


### PR DESCRIPTION
This finally fixes #963. A quick fix has been introduced in 661eea007e555, but that does not cover the lower case writing of the type.

    @Comment{jabref-meta: DATABASE_TYPE:BibTeX;}

finally gets

    @Comment{jabref-meta: databaseType:bibtex;}

- [ ] Change in CHANGELOG.md described -> This has been introduced in the development versions after the last release, thus no entry required
- [x] Tests created for changes -> tests have been adapted to match this new implementation