### PR TITLE
Encoding fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 ## [Unreleased]
 
 ### Changed
+- The user journal abbreviation list is now always read and written with the same default encoding as for the database (found in the preferences)
 - Implemented [#455](https://github.com/JabRef/jabref/issues/455): Add button in preference dialog to reset preferences
 - Add ability to run arbitrary formatters as cleanup actions (some old cleanup jobs are replaced by this functionality)
 - Implemented [#756](https://github.com/JabRef/jabref/issues/756): Add possibility to reformat all entries on save (under Preferences, File)

--- a/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
+++ b/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
@@ -20,8 +20,9 @@ import java.awt.Dimension;
 import java.awt.event.*;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.net.URL;
 import java.util.*;
 
@@ -299,7 +300,8 @@ class ManageJournalsPanel extends JPanel {
         String filename = personalFile.getText();
         if ((!filename.isEmpty()) && new File(filename).exists()) {
             try {
-                userAbbreviations = JournalAbbreviationLoader.readJournalListFromFile(new File(filename));
+                userAbbreviations = JournalAbbreviationLoader.readJournalListFromFile(new File(filename),
+                        Globals.prefs.getDefaultEncoding());
             } catch (FileNotFoundException e) {
                 LOGGER.warn("Problem reading abbreviation file", e);
             }
@@ -348,12 +350,13 @@ class ManageJournalsPanel extends JPanel {
             if (!f.exists()) {
                 throw new FileNotFoundException(f.getAbsolutePath());
             }
-            try (FileWriter fw = new FileWriter(f, false)) {
+            try (FileOutputStream stream = new FileOutputStream(f, false);
+                    OutputStreamWriter writer = new OutputStreamWriter(stream, Globals.prefs.getDefaultEncoding())) {
                 for (JournalEntry entry : tableModel.getJournals()) {
-                    fw.write(entry.getName());
-                    fw.write(" = ");
-                    fw.write(entry.getAbbreviation());
-                    fw.write(Globals.NEWLINE);
+                    writer.write(entry.getName());
+                    writer.write(" = ");
+                    writer.write(entry.getAbbreviation());
+                    writer.write(Globals.NEWLINE);
                 }
             } catch (IOException e) {
                 LOGGER.warn("Problem writing abbreviation file", e);

--- a/src/main/java/net/sf/jabref/logic/journals/AbbreviationParser.java
+++ b/src/main/java/net/sf/jabref/logic/journals/AbbreviationParser.java
@@ -22,6 +22,8 @@ import org.apache.commons.logging.LogFactory;
 
 import java.io.*;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -38,7 +40,7 @@ public class AbbreviationParser {
     public void readJournalListFromResource(String resourceFileName) {
         URL url = Objects.requireNonNull(JournalAbbreviationRepository.class.getResource(Objects.requireNonNull(resourceFileName)));
         try {
-            readJournalList(new InputStreamReader(url.openStream()));
+            readJournalList(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8));
         } catch (IOException e) {
             LOGGER.info("Could not read journal list from file " + resourceFileName, e);
         }
@@ -53,6 +55,18 @@ public class AbbreviationParser {
             LOGGER.warn("Could not read journal list from file " + file.getAbsolutePath(), e);
         }
     }
+
+    public void readJournalListFromFile(File file, Charset encoding) throws FileNotFoundException {
+        try (FileInputStream stream = new FileInputStream(Objects.requireNonNull(file));
+                InputStreamReader reader = new InputStreamReader(stream, Objects.requireNonNull(encoding))) {
+            readJournalList(reader);
+        } catch (FileNotFoundException e) {
+            throw e;
+        } catch (IOException e) {
+            LOGGER.warn("Could not read journal list from file " + file.getAbsolutePath(), e);
+        }
+    }
+
     /**
      * Read the given file, which should contain a list of journal names and their
      * abbreviations. Each line should be formatted as: "Full Journal Name=Abbr. Journal Name"

--- a/src/main/java/net/sf/jabref/logic/journals/JournalAbbreviationLoader.java
+++ b/src/main/java/net/sf/jabref/logic/journals/JournalAbbreviationLoader.java
@@ -15,12 +15,14 @@
 */
 package net.sf.jabref.logic.journals;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -75,7 +77,8 @@ public class JournalAbbreviationLoader {
         String personalJournalList = jabRefPreferences.get(JabRefPreferences.PERSONAL_JOURNAL_LIST);
         if ((personalJournalList != null) && !personalJournalList.trim().isEmpty()) {
             try {
-                journalAbbrev.addEntries(readJournalListFromFile(new File(personalJournalList)));
+                journalAbbrev.addEntries(
+                        readJournalListFromFile(new File(personalJournalList), Globals.prefs.getDefaultEncoding()));
             } catch (FileNotFoundException e) {
                 LOGGER.info("Personal journal list file '" + personalJournalList + "' not found.", e);
             }
@@ -109,6 +112,13 @@ public class JournalAbbreviationLoader {
         LOGGER.debug("Reading journal list from file " + file);
         AbbreviationParser parser = new AbbreviationParser();
         parser.readJournalListFromFile(Objects.requireNonNull(file));
+        return parser.getAbbreviations();
+    }
+
+    public static List<Abbreviation> readJournalListFromFile(File file, Charset encoding) throws FileNotFoundException {
+        LOGGER.debug("Reading journal list from file " + file);
+        AbbreviationParser parser = new AbbreviationParser();
+        parser.readJournalListFromFile(Objects.requireNonNull(file), Objects.requireNonNull(encoding));
         return parser.getAbbreviations();
     }
 }

--- a/src/main/java/net/sf/jabref/openoffice/OpenOfficePanel.java
+++ b/src/main/java/net/sf/jabref/openoffice/OpenOfficePanel.java
@@ -46,7 +46,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -459,13 +458,9 @@ public class OpenOfficePanel extends AbstractWorker {
      */
     private void readStyleFile() throws IOException {
         if (useDefaultAuthoryearStyle) {
-            URL defPath = JabRef.class.getResource(DEFAULT_AUTHORYEAR_STYLE_PATH);
-            Reader r = new InputStreamReader(defPath.openStream(), StandardCharsets.UTF_8);
-            style = new OOBibStyle(r, Globals.journalAbbreviationLoader.getRepository());
+            style = new OOBibStyle(DEFAULT_AUTHORYEAR_STYLE_PATH, Globals.journalAbbreviationLoader.getRepository());
         } else if (useDefaultNumericalStyle) {
-            URL defPath = JabRef.class.getResource(DEFAULT_NUMERICAL_STYLE_PATH);
-            Reader r = new InputStreamReader(defPath.openStream(), StandardCharsets.UTF_8);
-            style = new OOBibStyle(r, Globals.journalAbbreviationLoader.getRepository());
+            style = new OOBibStyle(DEFAULT_NUMERICAL_STYLE_PATH, Globals.journalAbbreviationLoader.getRepository());
         } else {
             style = new OOBibStyle(new File(styleFile), Globals.journalAbbreviationLoader.getRepository(),
                     Globals.prefs.getDefaultEncoding());

--- a/src/main/java/net/sf/jabref/openoffice/StyleSelectDialog.java
+++ b/src/main/java/net/sf/jabref/openoffice/StyleSelectDialog.java
@@ -397,7 +397,7 @@ class StyleSelectDialog {
         styles.getReadWriteLock().writeLock().lock();
         styles.clear();
         if (!styleDir.getText().isEmpty()) {
-            addStyles(styleDir.getText(), true);
+            addStyles(styleDir.getText(), true, Globals.prefs.getDefaultEncoding());
         }
         styles.getReadWriteLock().writeLock().unlock();
 
@@ -438,8 +438,9 @@ class StyleSelectDialog {
      * recurse into subdirectories.
      * @param dir the directory or file to handle.
      * @param recurse true indicates that we should recurse into subdirectories.
+     * @param encoding
      */
-    private void addStyles(String dir, boolean recurse) {
+    private void addStyles(String dir, boolean recurse, Charset encoding) {
         File dirF = new File(dir);
         if (dirF.isDirectory()) {
             File[] fileArray = dirF.listFiles();
@@ -452,15 +453,15 @@ class StyleSelectDialog {
             for (File file : files) {
                 // If the file looks like a style file, parse it:
                 if (!file.isDirectory() && (file.getName().endsWith(StyleSelectDialog.STYLE_FILE_EXTENSION))) {
-                    addSingleFile(file, Globals.prefs.getDefaultEncoding());
+                    addSingleFile(file, encoding);
                 } else if (file.isDirectory() && recurse) {
                     // If the file is a directory, and we should recurse, do:
-                    addStyles(file.getPath(), recurse);
+                    addStyles(file.getPath(), recurse, encoding);
                 }
             }
         } else {
             // The file wasn't a directory, so we simply parse it:
-            addSingleFile(dirF, Globals.prefs.getDefaultEncoding());
+            addSingleFile(dirF, encoding);
         }
     }
 

--- a/src/test/java/net/sf/jabref/exporter/ExportFormatTest.java
+++ b/src/test/java/net/sf/jabref/exporter/ExportFormatTest.java
@@ -3,7 +3,8 @@ package net.sf.jabref.exporter;
 import static org.junit.Assert.*;
 
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -58,9 +59,10 @@ public class ExportFormatTest {
         File tmpFile = testFolder.newFile();
         String filename = tmpFile.getCanonicalPath();
         exportFormat.performExport(database, metaData, filename, charset, entries);
-        try (FileReader fileReader = new FileReader(tmpFile)) {
+        try (FileInputStream stream = new FileInputStream(tmpFile);
+                InputStreamReader reader = new InputStreamReader(stream, charset)) {
             char[] buffer = new char[512];
-            assertEquals(-1, fileReader.read(buffer)); // Empty file
+            assertEquals(-1, reader.read(buffer)); // Empty file
         }
     }
 

--- a/src/test/java/net/sf/jabref/external/RegExpFileSearchTests.java
+++ b/src/test/java/net/sf/jabref/external/RegExpFileSearchTests.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 
 public class RegExpFileSearchTests {
 
-    private static final String filesDirectory = "/src/test/resources/net/sf/jabref/imports/unlinkedFilesTestFolder";
+    private static final String filesDirectory = "src/test/resources/net/sf/jabref/imports/unlinkedFilesTestFolder";
 
 
     @Before

--- a/src/test/java/net/sf/jabref/importer/DatabaseFileLookupTest.java
+++ b/src/test/java/net/sf/jabref/importer/DatabaseFileLookupTest.java
@@ -9,9 +9,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 /**
@@ -31,8 +33,9 @@ public class DatabaseFileLookupTest {
     public void setUp() throws FileNotFoundException, IOException {
         Globals.prefs = JabRefPreferences.getInstance();
 
-        try (FileReader fr = new FileReader(ImportDataTest.UNLINKED_FILES_TEST_BIB)) {
-            ParserResult result = BibtexParser.parse(fr);
+        try (FileInputStream stream = new FileInputStream(ImportDataTest.UNLINKED_FILES_TEST_BIB);
+                InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
+            ParserResult result = BibtexParser.parse(reader);
             database = result.getDatabase();
             entries = database.getEntries();
 

--- a/src/test/java/net/sf/jabref/importer/EntryFromFileCreatorManagerTest.java
+++ b/src/test/java/net/sf/jabref/importer/EntryFromFileCreatorManagerTest.java
@@ -27,9 +27,11 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -58,8 +60,9 @@ public class EntryFromFileCreatorManagerTest {
     @Test
     @Ignore
     public void testAddEntrysFromFiles() throws FileNotFoundException, IOException {
-        try (FileReader fr = new FileReader(ImportDataTest.UNLINKED_FILES_TEST_BIB)) {
-            ParserResult result = BibtexParser.parse(fr);
+        try (FileInputStream stream = new FileInputStream(ImportDataTest.UNLINKED_FILES_TEST_BIB);
+                InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
+            ParserResult result = BibtexParser.parse(reader);
             BibDatabase database = result.getDatabase();
 
             List<File> files = new ArrayList<>();

--- a/src/test/java/net/sf/jabref/openoffice/OOBibStyleTest.java
+++ b/src/test/java/net/sf/jabref/openoffice/OOBibStyleTest.java
@@ -3,10 +3,7 @@ package net.sf.jabref.openoffice;
 import static org.junit.Assert.*;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -48,18 +45,15 @@ public class OOBibStyleTest {
 
     @Test
     public void testAuthorYear() throws IOException {
-        URL defPath = JabRef.class.getResource(OpenOfficePanel.DEFAULT_AUTHORYEAR_STYLE_PATH);
-
-        try (Reader r = new InputStreamReader(defPath.openStream(), StandardCharsets.UTF_8)) {
-            OOBibStyle style = new OOBibStyle(r, mock(JournalAbbreviationRepository.class));
-            assertTrue(style.isValid());
-            assertFalse(style.isBibtexKeyCiteMarkers());
-            assertFalse(style.isBoldCitations());
-            assertFalse(style.isFormatCitations());
-            assertFalse(style.isItalicCitations());
-            assertFalse(style.isNumberEntries());
-            assertFalse(style.isSortByPosition());
-        }
+        OOBibStyle style = new OOBibStyle(OpenOfficePanel.DEFAULT_AUTHORYEAR_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
+        assertTrue(style.isValid());
+        assertFalse(style.isBibtexKeyCiteMarkers());
+        assertFalse(style.isBoldCitations());
+        assertFalse(style.isFormatCitations());
+        assertFalse(style.isItalicCitations());
+        assertFalse(style.isNumberEntries());
+        assertFalse(style.isSortByPosition());
     }
 
     @Test
@@ -83,25 +77,22 @@ public class OOBibStyleTest {
     @Test
     public void testNumerical() throws IOException {
 
-        URL defPath = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        try (Reader r = new InputStreamReader(defPath.openStream(), StandardCharsets.UTF_8)) {
-            OOBibStyle style = new OOBibStyle(r, mock(JournalAbbreviationRepository.class));
-            assertTrue(style.isValid());
-            assertFalse(style.isBibtexKeyCiteMarkers());
-            assertFalse(style.isBoldCitations());
-            assertFalse(style.isFormatCitations());
-            assertFalse(style.isItalicCitations());
-            assertTrue(style.isNumberEntries());
-            assertTrue(style.isSortByPosition());
-        }
+        OOBibStyle style = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
+        assertTrue(style.isValid());
+        assertFalse(style.isBibtexKeyCiteMarkers());
+        assertFalse(style.isBoldCitations());
+        assertFalse(style.isFormatCitations());
+        assertFalse(style.isItalicCitations());
+        assertTrue(style.isNumberEntries());
+        assertTrue(style.isSortByPosition());
 
     }
 
     @Test
     public void testGetNumCitationMarker() throws IOException {
-        URL defPath = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        Reader r = new InputStreamReader(defPath.openStream(), StandardCharsets.UTF_8);
-        OOBibStyle style = new OOBibStyle(r, mock(JournalAbbreviationRepository.class));
+        OOBibStyle style = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
         assertEquals("[1] ", style.getNumCitationMarker(Arrays.asList(1), -1, true));
         assertEquals("[1]", style.getNumCitationMarker(Arrays.asList(1), -1, false));
         assertEquals("[1] ", style.getNumCitationMarker(Arrays.asList(1), 0, true));
@@ -117,9 +108,8 @@ public class OOBibStyleTest {
 
     @Test
     public void testGetNumCitationMarkerUndefined() throws IOException {
-        URL defPath = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        Reader r = new InputStreamReader(defPath.openStream(), StandardCharsets.UTF_8);
-        OOBibStyle style = new OOBibStyle(r, mock(JournalAbbreviationRepository.class));
+        OOBibStyle style = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
         assertEquals("[" + OOBibStyle.UNDEFINED_CITATION_MARKER + "; 2-4] ",
                 style.getNumCitationMarker(Arrays.asList(4, 2, 3, 0), 1, true));
 
@@ -136,9 +126,8 @@ public class OOBibStyleTest {
 
     @Test
     public void testGetCitProperty() throws IOException {
-        URL defPath = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        Reader r = new InputStreamReader(defPath.openStream(), StandardCharsets.UTF_8);
-        OOBibStyle style = new OOBibStyle(r, mock(JournalAbbreviationRepository.class));
+        OOBibStyle style = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
         assertEquals(", ", style.getStringCitProperty("AuthorSeparator"));
         assertEquals(3, style.getIntCitProperty("MaxAuthors"));
         assertTrue(style.getBooleanCitProperty(OOBibStyle.MULTI_CITE_CHRONOLOGICAL));
@@ -152,9 +141,8 @@ public class OOBibStyleTest {
     public void testGetCitationMarker() throws IOException {
         File testBibtexFile = new File("src/test/resources/testbib/complex.bib");
         ParserResult result = BibtexParser.parse(ImportFormatReader.getReader(testBibtexFile, StandardCharsets.UTF_8));
-        URL defPath = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        Reader r = new InputStreamReader(defPath.openStream());
-        OOBibStyle style = new OOBibStyle(r, mock(JournalAbbreviationRepository.class));
+        OOBibStyle style = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         BibDatabase db = result.getDatabase();
         for (BibEntry entry : db.getEntries()) {
@@ -174,9 +162,8 @@ public class OOBibStyleTest {
     public void testLayout() throws IOException {
         File testBibtexFile = new File("src/test/resources/testbib/complex.bib");
         ParserResult result = BibtexParser.parse(ImportFormatReader.getReader(testBibtexFile, StandardCharsets.UTF_8));
-        URL defPath = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        Reader r = new InputStreamReader(defPath.openStream());
-        OOBibStyle style = new OOBibStyle(r, mock(JournalAbbreviationRepository.class));
+        OOBibStyle style = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
         BibDatabase db = result.getDatabase();
 
         Layout l = style.getReferenceFormat("default");
@@ -195,9 +182,8 @@ public class OOBibStyleTest {
 
     @Test
     public void testInstitutionAuthor() throws IOException {
-        URL defPath = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        Reader r = new InputStreamReader(defPath.openStream());
-        OOBibStyle style = new OOBibStyle(r, mock(JournalAbbreviationRepository.class));
+        OOBibStyle style = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
         BibDatabase database = new BibDatabase();
 
         Layout l = style.getReferenceFormat("article");
@@ -209,16 +195,14 @@ public class OOBibStyleTest {
         entry.setField("title", "JabRef Manual");
         entry.setField("year", "2016");
         database.insertEntry(entry);
-        assertEquals(
-                "<b>JabRef Development Team</b> (<b>2016</b>). <i>JabRef Manual</i>,  .",
+        assertEquals("<b>JabRef Development Team</b> (<b>2016</b>). <i>JabRef Manual</i>,  .",
                 l.doLayout(entry, database));
     }
 
     @Test
     public void testInstitutionAuthorMarker() throws IOException {
-        URL defPath = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        Reader r = new InputStreamReader(defPath.openStream());
-        OOBibStyle style = new OOBibStyle(r, mock(JournalAbbreviationRepository.class));
+        OOBibStyle style = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -237,9 +221,8 @@ public class OOBibStyleTest {
 
     @Test
     public void testEmptyEntryMarker() throws IOException {
-        URL defPath = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        Reader r = new InputStreamReader(defPath.openStream());
-        OOBibStyle style = new OOBibStyle(r, mock(JournalAbbreviationRepository.class));
+        OOBibStyle style = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -255,9 +238,8 @@ public class OOBibStyleTest {
 
     @Test
     public void testGetCitationMarkerInParenthesisUniquefiers() throws IOException {
-        URL defPath = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        Reader r = new InputStreamReader(defPath.openStream());
-        OOBibStyle style = new OOBibStyle(r, mock(JournalAbbreviationRepository.class));
+        OOBibStyle style = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -292,9 +274,8 @@ public class OOBibStyleTest {
 
     @Test
     public void testGetCitationMarkerInTextUniquefiers() throws IOException {
-        URL defPath = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        Reader r = new InputStreamReader(defPath.openStream());
-        OOBibStyle style = new OOBibStyle(r, mock(JournalAbbreviationRepository.class));
+        OOBibStyle style = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -329,9 +310,8 @@ public class OOBibStyleTest {
 
     @Test
     public void testGetCitationMarkerInParenthesisUniquefiersThreeSameAuthor() throws IOException {
-        URL defPath = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        Reader r = new InputStreamReader(defPath.openStream());
-        OOBibStyle style = new OOBibStyle(r, mock(JournalAbbreviationRepository.class));
+        OOBibStyle style = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -365,9 +345,8 @@ public class OOBibStyleTest {
 
     @Test
     public void testGetCitationMarkerInTextUniquefiersThreeSameAuthor() throws IOException {
-        URL defPath = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        Reader r = new InputStreamReader(defPath.openStream());
-        OOBibStyle style = new OOBibStyle(r, mock(JournalAbbreviationRepository.class));
+        OOBibStyle style = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -403,12 +382,10 @@ public class OOBibStyleTest {
     @Ignore
     // TODO: equals only work when initialized from file, not from reader
     public void testEquals() throws IOException {
-        URL defPath1 = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        Reader r1 = new InputStreamReader(defPath1.openStream());
-        OOBibStyle style1 = new OOBibStyle(r1, mock(JournalAbbreviationRepository.class));
-        URL defPath2 = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        Reader r2 = new InputStreamReader(defPath2.openStream());
-        OOBibStyle style2 = new OOBibStyle(r2, mock(JournalAbbreviationRepository.class));
+        OOBibStyle style1 = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
+        OOBibStyle style2 = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
         assertEquals(style1, style2);
     }
 
@@ -416,34 +393,28 @@ public class OOBibStyleTest {
     @Ignore
     // TODO: equals only work when initialized from file, not from reader
     public void testNotEquals() throws IOException {
-        URL defPath1 = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        Reader r1 = new InputStreamReader(defPath1.openStream());
-        OOBibStyle style1 = new OOBibStyle(r1, mock(JournalAbbreviationRepository.class));
-        URL defPath2 = JabRef.class.getResource(OpenOfficePanel.DEFAULT_AUTHORYEAR_STYLE_PATH);
-        Reader r2 = new InputStreamReader(defPath2.openStream());
-        OOBibStyle style2 = new OOBibStyle(r2, mock(JournalAbbreviationRepository.class));
+        OOBibStyle style1 = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
+        OOBibStyle style2 = new OOBibStyle(OpenOfficePanel.DEFAULT_AUTHORYEAR_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
         assertNotEquals(style1, style2);
     }
 
     @Test
     public void testCompareToEqual() throws IOException {
-        URL defPath1 = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        Reader r1 = new InputStreamReader(defPath1.openStream());
-        OOBibStyle style1 = new OOBibStyle(r1, mock(JournalAbbreviationRepository.class));
-        URL defPath2 = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        Reader r2 = new InputStreamReader(defPath2.openStream());
-        OOBibStyle style2 = new OOBibStyle(r2, mock(JournalAbbreviationRepository.class));
+        OOBibStyle style1 = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
+        OOBibStyle style2 = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
         assertEquals(0, style1.compareTo(style2));
     }
 
     @Test
     public void testCompareToNotEqual() throws IOException {
-        URL defPath1 = JabRef.class.getResource(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH);
-        Reader r1 = new InputStreamReader(defPath1.openStream());
-        OOBibStyle style1 = new OOBibStyle(r1, mock(JournalAbbreviationRepository.class));
-        URL defPath2 = JabRef.class.getResource(OpenOfficePanel.DEFAULT_AUTHORYEAR_STYLE_PATH);
-        Reader r2 = new InputStreamReader(defPath2.openStream());
-        OOBibStyle style2 = new OOBibStyle(r2, mock(JournalAbbreviationRepository.class));
+        OOBibStyle style1 = new OOBibStyle(OpenOfficePanel.DEFAULT_NUMERICAL_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
+        OOBibStyle style2 = new OOBibStyle(OpenOfficePanel.DEFAULT_AUTHORYEAR_STYLE_PATH,
+                mock(JournalAbbreviationRepository.class));
         assertTrue(style1.compareTo(style2) > 0);
         assertFalse(style2.compareTo(style1) > 0);
     }


### PR DESCRIPTION
Fixed some issues with the encoding for files and resources. Now the user defined journal abbreviation lists are always saved and loaded using the current default encoding from the preferences. Ideally, it should be possible to specify the encoding (or maybe not needed?). Similarly, OO style files are loaded with the default encoding.