### PR TITLE
GVKParser handle publication year correctly

### DIFF
--- a/src/main/java/net/sf/jabref/importer/fetcher/GVKParser.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/GVKParser.java
@@ -388,7 +388,7 @@ public class GVKParser {
             result.setField("publisher", publisher);
         }
         if (date != null) {
-            result.setField("date", date);
+            result.setField("year", date);
         }
         if (address != null) {
             result.setField("address", address);


### PR DESCRIPTION
exchanged the field "date" with "year" to import GVK entries correctly.

Publication year was previously put to date when fetching entry-> now to year

* Sorry if I broke any conventions of changing code/testing...