### PR TITLE
[WIP] Refactor auto completion

### DIFF
--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -1281,7 +1281,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         @Override
         public void databaseChanged(DatabaseChangeEvent e) {
             if ((e.getType() == ChangeType.CHANGED_ENTRY) || (e.getType() == ChangeType.ADDED_ENTRY)) {
-                searchAutoCompleter.addBibtexEntry(e.getEntry());
+                searchAutoCompleter.addToIndex(e.getEntry());
             }
         }
     }
@@ -1574,7 +1574,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         AutoCompleterFactory autoCompleterFactory = new AutoCompleterFactory(autoCompletePreferences);
         searchAutoCompleter = autoCompleterFactory.getPersonAutoCompleter();
         for (BibEntry entry : database.getEntries()) {
-            searchAutoCompleter.addBibtexEntry(entry);
+            searchAutoCompleter.addToIndex(entry);
         }
     }
 

--- a/src/main/java/net/sf/jabref/gui/autocompleter/AutoCompleteListener.java
+++ b/src/main/java/net/sf/jabref/gui/autocompleter/AutoCompleteListener.java
@@ -25,12 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import java.awt.event.*;
 import java.util.List;
 
-/**
- * Created by Morten O. Alver, 16 Feb. 2007
- */
 public class AutoCompleteListener extends KeyAdapter implements FocusListener {
-
-    //TODO: The logging behavior in this class is probably too fine-grained and only understandable to its original author
     private static final Log LOGGER = LogFactory.getLog(AutoCompleteListener.class);
 
     private final AutoCompleter<String> completer;
@@ -41,20 +36,9 @@ public class AutoCompleteListener extends KeyAdapter implements FocusListener {
     private int lastCaretPosition = -1;
     private List<String> lastCompletions;
     private int lastShownCompletion;
-    private boolean consumeEnterKey = true;
-
-    // This field is set if the focus listener should call another focus listener
-    // after finishing. This is needed because the autocomplete listener must
-    // run before the focus listener responsible for storing the current edit.
     private FocusListener nextFocusListener;
 
     public AutoCompleteListener(AutoCompleter<String> completer) {
-        //    	if (logger.getHandlers().length == 0) {
-        //	    	logger.setLevel(Level.FINEST);
-        //	    	ConsoleHandler ch = new ConsoleHandler();
-        //	    	ch.setLevel(Level.FINEST);
-        //	    	logger.addHandler(ch);
-        //    	}
         this.completer = completer;
     }
 
@@ -65,18 +49,7 @@ public class AutoCompleteListener extends KeyAdapter implements FocusListener {
      * @param listener The listener to call.
      */
     public void setNextFocusListener(FocusListener listener) {
-        this.nextFocusListener = listener;
-    }
-
-    /**
-     * This setting determines whether the autocomplete listener should consume the Enter key stroke when it leads to
-     * accepting a completion. If set to false, the JTextComponent will receive the Enter key press after the completion
-     * is done. The default value if true.
-     *
-     * @param t true to indicate that the Enter key should be consumed, false that it should be forwarded
-     */
-    public void setConsumeEnterKey(boolean t) {
-        this.consumeEnterKey = t;
+        nextFocusListener = listener;
     }
 
     @Override
@@ -90,9 +63,7 @@ public class AutoCompleteListener extends KeyAdapter implements FocusListener {
             int end = comp.getSelectionEnd();
             comp.select(end, end);
             toSetIn = null;
-            if (consumeEnterKey) {
-                e.consume();
-            }
+            e.consume();
         }
         // Cycle through alternative completions when user presses PGUP/PGDN:
         else if ((e.getKeyCode() == KeyEvent.VK_PAGE_DOWN) && (toSetIn != null)) {
@@ -115,8 +86,6 @@ public class AutoCompleteListener extends KeyAdapter implements FocusListener {
             } else {
                 resetAutoCompletion();
             }
-        } else {
-            LOGGER.debug("Special case: defined character, but not caught above");
         }
     }
 
@@ -260,10 +229,10 @@ public class AutoCompleteListener extends KeyAdapter implements FocusListener {
 
     @Override
     public void keyTyped(KeyEvent e) {
-        LOGGER.debug("key typed event caught " + e.getKeyCode());
         char ch = e.getKeyChar();
-        if (ch == '\n') {
-            // this case is handled at keyPressed(e)
+
+        // this case is handled at keyPressed(e)
+        if (ch == KeyEvent.VK_ENTER) {
             return;
         }
 

--- a/src/main/java/net/sf/jabref/gui/autocompleter/AutoCompleteListener.java
+++ b/src/main/java/net/sf/jabref/gui/autocompleter/AutoCompleteListener.java
@@ -24,22 +24,18 @@ import org.apache.commons.logging.LogFactory;
 
 import java.awt.event.*;
 import java.util.List;
+import java.util.Optional;
 
 public class AutoCompleteListener extends KeyAdapter implements FocusListener {
     private static final Log LOGGER = LogFactory.getLog(AutoCompleteListener.class);
 
     private final AutoCompleter<String> completer;
-
-    // These variables keep track of the situation from time to time.
-    private String toSetIn; // null indicates that there are no completions available
-    private String lastBeginning; // the letters, the user has typed until know
-    private int lastCaretPosition = -1;
-    private List<String> lastCompletions;
-    private int lastShownCompletion;
+    private Optional<AutoCompleteState> currentCompletion;
     private FocusListener nextFocusListener;
 
     public AutoCompleteListener(AutoCompleter<String> completer) {
         this.completer = completer;
+        currentCompletion = Optional.empty();
     }
 
     /**
@@ -54,360 +50,180 @@ public class AutoCompleteListener extends KeyAdapter implements FocusListener {
 
     @Override
     public void keyPressed(KeyEvent e) {
-        if ((toSetIn != null) && (e.getKeyCode() == KeyEvent.VK_ENTER)) {
-            JTextComponent comp = (JTextComponent) e.getSource();
-
-            // replace typed characters by characters from completion
-            lastBeginning = lastCompletions.get(lastShownCompletion);
-
-            int end = comp.getSelectionEnd();
-            comp.select(end, end);
-            toSetIn = null;
-            e.consume();
-        }
-        // Cycle through alternative completions when user presses PGUP/PGDN:
-        else if ((e.getKeyCode() == KeyEvent.VK_PAGE_DOWN) && (toSetIn != null)) {
-            cycle((JTextComponent) e.getSource(), 1);
-            e.consume();
-        } else if ((e.getKeyCode() == KeyEvent.VK_PAGE_UP) && (toSetIn != null)) {
-            cycle((JTextComponent) e.getSource(), -1);
-            e.consume();
-        }
-        //        else if ((e.getKeyCode() == KeyEvent.VK_BACK_SPACE)) {
-        //        	StringBuffer currentword = getCurrentWord((JTextComponent) e.getSource());
-        //        	// delete last char to obey semantics of back space
-        //        	currentword.deleteCharAt(currentword.length()-1);
-        //        	doCompletion(currentword, e);
-        //        }
-        else if (e.getKeyChar() == KeyEvent.CHAR_UNDEFINED) {
-            if (e.getKeyCode() == KeyEvent.VK_SHIFT) {
-                // shift is OK, everything else leads to a reset
-                LOGGER.debug("Special case: shift pressed. No action.");
-            } else {
-                resetAutoCompletion();
-            }
-        }
-    }
-
-    private void cycle(JTextComponent comp, int increment) {
-        assert (lastCompletions != null);
-        assert (!lastCompletions.isEmpty());
-        lastShownCompletion += increment;
-        if (lastShownCompletion >= lastCompletions.size()) {
-            lastShownCompletion = 0;
-        } else if (lastShownCompletion < 0) {
-            lastShownCompletion = lastCompletions.size() - 1;
-        }
-        String sno = lastCompletions.get(lastShownCompletion);
-        toSetIn = sno.substring(lastBeginning.length() - 1);
-
-        StringBuilder alltext = new StringBuilder(comp.getText());
-
-        int oldSelectionStart = comp.getSelectionStart();
-        int oldSelectionEnd = comp.getSelectionEnd();
-
-        // replace prefix with new prefix
-        int startPos = comp.getSelectionStart() - lastBeginning.length();
-        alltext.delete(startPos, oldSelectionStart);
-        alltext.insert(startPos, sno.subSequence(0, lastBeginning.length()));
-
-        // replace suffix with new suffix
-        alltext.delete(oldSelectionStart, oldSelectionEnd);
-        //int cp = oldSelectionEnd - deletedChars;
-        alltext.insert(oldSelectionStart, toSetIn.substring(1));
-
-        LOGGER.debug(alltext.toString());
-        comp.setText(alltext.toString());
-        //comp.setCaretPosition(cp+toSetIn.length()-1);
-        comp.select(oldSelectionStart, (oldSelectionStart + toSetIn.length()) - 1);
-        lastCaretPosition = comp.getCaretPosition();
-        LOGGER.debug("ToSetIn: '" + toSetIn + "'");
-    }
-
-    /**
-     * If user cancels autocompletion by a) entering another letter than the completed word (and there is no other auto
-     * completion) b) space the casing of the letters has to be kept
-     *
-     * Global variable "lastBeginning" keeps track of typed letters. We rely on this variable to reconstruct the text
-     *
-     * @param wordSeperatorTyped indicates whether the user has typed a white space character or a
-     */
-    private void setUnmodifiedTypedLetters(JTextComponent comp, boolean lastBeginningContainsTypedCharacter,
-            boolean wordSeperatorTyped) {
-        if (lastBeginning == null) {
-            LOGGER.debug("No last beginning found");
-            // There was no previous input (if the user typed a word, where no autocompletion is available)
-            // Thus, there is nothing to replace
+        // no auto completions available
+        if (!currentCompletion.isPresent()) {
             return;
         }
-        LOGGER.debug("lastBeginning: >" + lastBeginning + '<');
-        if (comp.getSelectedText() == null) {
-            // if there is no selection
-            // the user has typed the complete word, but possibly with a different casing
-            // we need a replacement
-            if (wordSeperatorTyped) {
-                LOGGER.debug("Replacing complete word");
-            } else {
-                // if user did not press a white space character (space, ...),
-                // then we do not do anything
-                return;
-            }
-        } else {
-            LOGGER.debug("Selected text " + comp.getSelectedText() + " will be removed");
-            // remove completion suggestion
-            comp.replaceSelection("");
+
+        AutoCompleteState completion = currentCompletion.get();
+        int keyCode = e.getKeyCode();
+        JTextComponent textField = (JTextComponent) e.getSource();
+
+        if (keyCode == KeyEvent.VK_ENTER) {
+            // ENTER inserts auto-completion
+            insertSuggestion(textField, e);
+            // reset state
+            clearAutoCompletion(textField);
+        } else if (keyCode == KeyEvent.VK_PAGE_DOWN) {
+            // Cycle through alternative completions
+            completion.previousSuggestion();
+            insertSuggestion(textField, e);
+        } else if (keyCode == KeyEvent.VK_PAGE_UP) {
+            // Cycle through alternative completions
+            completion.nextSuggestion();
+            insertSuggestion(textField, e);
         }
-
-        lastCaretPosition = comp.getCaretPosition();
-
-        int endIndex = lastCaretPosition - lastBeginning.length();
-        if (lastBeginningContainsTypedCharacter) {
-            // the current letter is NOT contained in comp.getText(), but in lastBeginning
-            // thus lastBeginning.length() is one too large
-            endIndex++;
-        }
-        String text = comp.getText();
-        comp.setText(text.substring(0, endIndex).concat(lastBeginning).concat(text.substring(lastCaretPosition)));
-        if (lastBeginningContainsTypedCharacter) {
-            // the current letter is NOT contained in comp.getText()
-            // Thus, cursor position also did not get updated
-            lastCaretPosition++;
-        }
-        comp.setCaretPosition(lastCaretPosition);
-        lastBeginning = null;
-    }
-
-    /**
-     * Start a new completion attempt (instead of treating a continuation of an existing word or an interrupt of the
-     * current word)
-     */
-    private void startCompletion(StringBuffer currentword, KeyEvent e) {
-        JTextComponent comp = (JTextComponent) e.getSource();
-
-        List<String> completed = findCompletions(currentword.toString());
-        String prefix = completer.getPrefix();
-        String cWord = (prefix != null) && (!prefix.isEmpty()) ? currentword.toString()
-                .substring(prefix.length()) : currentword.toString();
-
-        LOGGER.debug("StartCompletion currentword: >" + currentword + "'<' prefix: >" + prefix + "'<' cword: >" + cWord
-                + '<');
-
-        int no = 0; // We use the first word in the array of completions.
-        if ((completed != null) && (!completed.isEmpty())) {
-            lastShownCompletion = 0;
-            lastCompletions = completed;
-            String sno = completed.get(no);
-
-            // these two lines obey the user's input
-            //toSetIn = Character.toString(ch);
-            //toSetIn = toSetIn.concat(sno.substring(cWord.length()));
-            // BUT we obey the completion
-            toSetIn = sno.substring(cWord.length() - 1);
-
-            LOGGER.debug("toSetIn: >" + toSetIn + '<');
-
-            StringBuilder alltext = new StringBuilder(comp.getText());
-            int cp = comp.getCaretPosition();
-            alltext.insert(cp, toSetIn);
-            comp.setText(alltext.toString());
-            comp.setCaretPosition(cp);
-            comp.select(cp + 1, (cp + 1 + sno.length()) - cWord.length());
-            e.consume();
-            lastCaretPosition = comp.getCaretPosition();
-            char ch = e.getKeyChar();
-
-            LOGGER.debug("Appending >" + ch + '<');
-
-            if (cWord.length() <= 1) {
-                lastBeginning = Character.toString(ch);
-            } else {
-                lastBeginning = cWord.substring(0, cWord.length() - 1).concat(Character.toString(ch));
-            }
-        }
-
     }
 
     @Override
     public void keyTyped(KeyEvent e) {
-        char ch = e.getKeyChar();
+        char newChar = e.getKeyChar();
+        JTextComponent textField = (JTextComponent) e.getSource();
 
         // this case is handled at keyPressed(e)
-        if (ch == KeyEvent.VK_ENTER) {
+        if (newChar == KeyEvent.VK_ENTER) {
             return;
         }
 
-        if ((e.getModifiers() | InputEvent.SHIFT_MASK) == InputEvent.SHIFT_MASK) {
-            // plain key or SHIFT + key is pressed, no handling of CTRL+key,  META+key, ...
-            if (Character.isLetter(ch) || Character.isDigit(ch)
-                    || (Character.isWhitespace(ch) && completer.isSingleUnitField())) {
-                JTextComponent comp = (JTextComponent) e.getSource();
+        if ((e.getModifiers() | InputEvent.SHIFT_MASK) != InputEvent.SHIFT_MASK) {
+            // TODO: plain key or SHIFT + key is pressed, no handling of CTRL+key,  META+key, ...
+            return;
+        }
 
-                if (toSetIn == null) {
-                    LOGGER.debug("toSetIn is null");
-                } else {
-                    LOGGER.debug("toSetIn: >" + toSetIn + '<');
-                }
+        // don't do auto completion inside words
+        if (!atEndOfWord(textField)) {
+            return;
+        }
 
-                // The case-insensitive system is a bit tricky here
-                // If keyword is "TODO" and user types "tO", then this is treated as "continue" as the "O" matches the "O"
-                // If keyword is "TODO" and user types "To", then this is treated as "discont" as the "o" does NOT match the "O".
-
-                if ((toSetIn != null) && (toSetIn.length() > 1) && (ch == toSetIn.charAt(1))) {
-                    // User continues on the word that was suggested.
-                    LOGGER.debug("cont");
-
-                    toSetIn = toSetIn.substring(1);
-                    if (!toSetIn.isEmpty()) {
-                        int cp = comp.getCaretPosition();
-                        //comp.setCaretPosition(cp+1-toSetIn.);
-                        comp.select((cp + 1) - toSetIn.length(), cp);
-                        lastBeginning = lastBeginning + ch;
-
-                        e.consume();
-                        lastCaretPosition = comp.getCaretPosition();
-
-                        lastCompletions = findCompletions(lastBeginning);
-                        lastShownCompletion = 0;
-                        for (int i = 0; i < lastCompletions.size(); i++) {
-                            String lastCompletion = lastCompletions.get(i);
-                            if (lastCompletion.endsWith(toSetIn)) {
-                                lastShownCompletion = i;
-                                break;
-                            }
-
-                        }
-                        if (toSetIn.length() < 2) {
-                            // User typed the last character of the autocompleted word
-                            // We have to replace the automcompletion word by the typed word.
-                            // This helps if the user presses "space" after the completion
-                            // "space" indicates that the user does NOT want the autocompletion,
-                            // but the typed word
-                            String text = comp.getText();
-                            comp.setText(text.substring(0, lastCaretPosition - lastBeginning.length()) + lastBeginning
-                                    + text.substring(lastCaretPosition));
-                            // there is no selected text, therefore we are not updating the selection
-                            toSetIn = null;
-                        }
-                        return;
-                    }
-                }
-
-                if ((toSetIn != null) && ((toSetIn.length() <= 1) || (ch != toSetIn.charAt(1)))) {
-                    // User discontinues the word that was suggested.
-                    lastBeginning = lastBeginning + ch;
-
-                    LOGGER.debug("discont toSetIn: >" + toSetIn + "'<' lastBeginning: >" + lastBeginning + '<');
-
-                    List<String> completed = findCompletions(lastBeginning);
-                    if ((completed != null) && (!completed.isEmpty())) {
-                        lastShownCompletion = 0;
-                        lastCompletions = completed;
-                        String sno = completed.get(0);
-                        // toSetIn = string used for autocompletion last time
-                        // this string has to be removed
-                        // lastCaretPosition is the position of the caret after toSetIn.
-                        int lastLen = toSetIn.length() - 1;
-                        toSetIn = sno.substring(lastBeginning.length() - 1);
-                        String text = comp.getText();
-                        //we do not use toSetIn as we want to obey the casing of "sno"
-                        comp.setText(text.substring(0, (lastCaretPosition - lastLen - lastBeginning.length()) + 1) + sno
-                                + text.substring(lastCaretPosition));
-                        int startSelect = (lastCaretPosition + 1) - lastLen;
-                        int endSelect = (lastCaretPosition + toSetIn.length()) - lastLen;
-                        comp.select(startSelect, endSelect);
-
-                        lastCaretPosition = comp.getCaretPosition();
-                        e.consume();
-                        return;
-                    } else {
-                        setUnmodifiedTypedLetters(comp, true, false);
-                        e.consume();
-                        toSetIn = null;
-                        return;
-                    }
-                }
-
-                LOGGER.debug("case else");
-
-                comp.replaceSelection("");
-
-                StringBuffer currentword = getCurrentWord(comp);
-
-                // only "real characters" end up here
-                assert (!Character.isISOControl(ch));
-                currentword.append(ch);
-                startCompletion(currentword, e);
-                return;
+        if (Character.isLetter(newChar) || Character.isDigit(newChar) || Character.isWhitespace(newChar)) {
+            // User continues on the word that was suggested.
+            if (currentCompletion.isPresent() && currentCompletion.get().continuesSuggestion(newChar)) {
+                // update currentWord inside auto-completion
+                currentCompletion.get().updateState(newChar);
+                // update highlighting
+                insertKeyAndSuggestion(textField, e);
             } else {
-                if (Character.isWhitespace(ch)) {
-                    assert (!completer.isSingleUnitField());
-                    LOGGER.debug("whitespace && !singleUnitField");
-                    // start a new search if end-of-field is reached
-
-                    // replace displayed letters with typed letters
-                    setUnmodifiedTypedLetters((JTextComponent) e.getSource(), false, true);
-                    resetAutoCompletion();
-                    return;
+                // start new completion attempt
+                // delete selection if auto-completion is active
+                if (currentCompletion.isPresent()) {
+                    textField.replaceSelection("");
                 }
+                String word = getCurrentWord(textField).toString() + newChar;
+                startCompletion(word, textField);
+                insertKeyAndSuggestion(textField, e);
+            }
+        } else {
+            // Some other key like backspace has been entered, state may have changed
+            clearAutoCompletion(textField);
+        }
+    }
 
-                LOGGER.debug("No letter/digit/whitespace or CHAR_UNDEFINED");
-                // replace displayed letters with typed letters
-                setUnmodifiedTypedLetters((JTextComponent) e.getSource(), false, !Character.isISOControl(ch));
-                resetAutoCompletion();
-                return;
+    private void startCompletion(String currentWord, JTextComponent textField) {
+        // reset state
+        clearAutoCompletion(textField);
+        // try to find suggestions for current word
+        List<String> suggestions = completer.complete(currentWord);
+
+        if (suggestions == null || suggestions.isEmpty()) {
+            return;
+        }
+        currentCompletion = Optional.of(new AutoCompleteState(currentWord, suggestions, textField.getCaretPosition()));
+    }
+
+    // DANGER: typed key will also be inserted here!
+    private void insertKeyAndSuggestion(JTextComponent textField, KeyEvent e) {
+        if (!currentCompletion.isPresent()) {
+            return;
+        }
+
+        AutoCompleteState completion = currentCompletion.get();
+
+        String suggestedWord = completion.getSuggestedWord();
+        // remove old suggestion
+        textField.replaceSelection("");
+        StringBuilder fieldText = new StringBuilder(textField.getText());
+        // insert suggested substring
+        int caretPosition = currentCompletion.get().getRealCaretPosition();
+        // DANGER: typed key will also be inserted here!
+        String keyAndWord = completion.getSuggestedWord().substring(completion.getCurrentWord().length() - 1);
+        fieldText.insert(caretPosition, keyAndWord);
+        textField.setText(fieldText.toString());
+        // highlight suggested substring
+        textField.select(caretPosition + 1, (caretPosition + 1 + suggestedWord.length()) - completion.getCurrentWord().length());
+        // prevent insertion of typed key
+        e.consume();
+    }
+
+    private void insertSuggestion(JTextComponent textField, KeyEvent e) {
+        if (!currentCompletion.isPresent()) {
+            return;
+        }
+
+        AutoCompleteState completion = currentCompletion.get();
+
+        String suggestedWord = completion.getSuggestedWord();
+        // remove old suggestion
+        textField.replaceSelection("");
+        StringBuilder fieldText = new StringBuilder(textField.getText());
+        // insert suggested substring
+        int caretPosition = currentCompletion.get().getRealCaretPosition();
+        String word = completion.getSuggestedWord().substring(completion.getCurrentWord().length());
+        fieldText.insert(caretPosition + 1, word);
+        textField.setText(fieldText.toString());
+        // highlight suggested substring
+        textField.select(caretPosition + 1, (caretPosition + 1 + suggestedWord.length()) - completion.getCurrentWord().length());
+        // prevent usual action of ENTER/PGUP/PGDN
+        e.consume();
+    }
+
+    private boolean atEndOfWord(JTextComponent textField) {
+        int nextCharPosition = textField.getCaretPosition();
+
+        // position not at the end of input
+        if(nextCharPosition < textField.getText().length()) {
+            char nextChar = textField.getText().charAt(nextCharPosition);
+            if (!Character.isWhitespace(nextChar)) {
+                return false;
             }
         }
-        resetAutoCompletion();
+        return true;
     }
 
-    /**
-     * Resets the auto completion data in a way that no leftovers are there
-     */
-    private void resetAutoCompletion() {
-        LOGGER.debug("Resetting autocompletion");
-        toSetIn = null;
-        lastBeginning = null;
-    }
+    private StringBuffer getCurrentWord(JTextComponent textField) {
+        final int caretPosition = textField.getCaretPosition();
 
-    private List<String> findCompletions(String beginning) {
-        return completer.complete(beginning);
-    }
-
-    private StringBuffer getCurrentWord(JTextComponent comp) {
-        StringBuffer res = new StringBuffer();
-        String upToCaret;
+        StringBuffer result = new StringBuffer();
 
         try {
-            upToCaret = comp.getText(0, comp.getCaretPosition());
-            // We now have the text from the start of the field up to the caret position.
+            // text from the start of the field up to the current caret/cursor position
+            String textBeforeCaret = textField.getText(0, caretPosition);
             // In most fields, we are only interested in the currently edited word, so we
-            // seek from the caret backward to the closest space:
+            // seek from the textBeforeCaret backward to the closest space:
             if (!completer.isSingleUnitField()) {
-                if ((comp.getCaretPosition() < comp.getText().length())
-                        && Character.isWhitespace(comp.getText().charAt(comp.getCaretPosition()))) {
-                    // caret is in the middle of the text AND current character is a whitespace
-                    // that means: a new word is started and there is no current word
-                    return new StringBuffer();
+                // textBeforeCaret is in the middle of the text AND last character is a whitespace
+                // that means: a new word is started and there is no current word
+                if (caretPosition < textField.getText().length() && Character.isWhitespace(textField.getText().charAt(caretPosition - 1))) {
+                    return new StringBuffer(0);
                 }
 
-                int piv = upToCaret.length() - 1;
-                while ((piv >= 0) && !Character.isWhitespace(upToCaret.charAt(piv))) {
+                // find word
+                int piv = textBeforeCaret.length() - 1;
+                while ((piv >= 0) && !Character.isWhitespace(textBeforeCaret.charAt(piv))) {
                     piv--;
                 }
                 // piv points to whitespace char or piv is -1
-                // copy everything from the next char up to the end of "upToCaret"
-                res.append(upToCaret.substring(piv + 1));
+                // copy everything from the next char up to the end of "caretPosition"
+                result.append(textBeforeCaret.substring(piv + 1));
             } else {
                 // For fields such as "journal" it is more reasonable to try to complete on the entire
-                // text field content, so we skip the searching and keep the entire part up to the caret:
-                res.append(upToCaret);
+                // text field content, so we skip the searching and keep the entire part up to the textBeforeCaret:
+                result.append(textBeforeCaret);
             }
-            LOGGER.debug("AutoCompListener: " + res);
         } catch (BadLocationException ignore) {
-            // Ignored
+            // potentially thrown by textField.getText()
         }
 
-        return res;
+        return result;
     }
 
     @Override
@@ -419,25 +235,20 @@ public class AutoCompleteListener extends KeyAdapter implements FocusListener {
 
     @Override
     public void focusLost(FocusEvent event) {
-        if (toSetIn != null) {
-            JTextComponent comp = (JTextComponent) event.getSource();
-            clearCurrentSuggestion(comp);
+        if (currentCompletion.isPresent()) {
+            // comment this when debugging!
+            clearAutoCompletion((JTextComponent) event.getSource());
         }
         if (nextFocusListener != null) {
             nextFocusListener.focusLost(event);
         }
     }
 
-    public void clearCurrentSuggestion(JTextComponent comp) {
-        if (toSetIn != null) {
-            int selStart = comp.getSelectionStart();
-            String text = comp.getText();
-            comp.setText(text.substring(0, selStart) + text.substring(comp.getSelectionEnd()));
-            comp.setCaretPosition(selStart);
-            lastCompletions = null;
-            lastShownCompletion = 0;
-            lastCaretPosition = -1;
-            toSetIn = null;
+    public void clearAutoCompletion(JTextComponent textField) {
+        if (currentCompletion.isPresent()) {
+            textField.replaceSelection("");
+            textField.setCaretPosition(textField.getSelectionStart());
+            currentCompletion = Optional.empty();
         }
     }
 }

--- a/src/main/java/net/sf/jabref/gui/autocompleter/AutoCompleteListener.java
+++ b/src/main/java/net/sf/jabref/gui/autocompleter/AutoCompleteListener.java
@@ -85,8 +85,8 @@ public class AutoCompleteListener extends KeyAdapter implements FocusListener {
             return;
         }
 
+        // only handle plain key or SHIFT+key
         if ((e.getModifiers() | InputEvent.SHIFT_MASK) != InputEvent.SHIFT_MASK) {
-            // TODO: plain key or SHIFT + key is pressed, no handling of CTRL+key,  META+key, ...
             return;
         }
 
@@ -221,6 +221,7 @@ public class AutoCompleteListener extends KeyAdapter implements FocusListener {
             }
         } catch (BadLocationException ignore) {
             // potentially thrown by textField.getText()
+            LOGGER.warn("Cannot extract text from field. Wrong caret position given.");
         }
 
         return result;

--- a/src/main/java/net/sf/jabref/gui/autocompleter/AutoCompleteState.java
+++ b/src/main/java/net/sf/jabref/gui/autocompleter/AutoCompleteState.java
@@ -1,0 +1,65 @@
+package net.sf.jabref.gui.autocompleter;
+
+import java.util.List;
+
+public class AutoCompleteState {
+    private List<String> suggestions;
+    private String currentWord;
+    private int currentCompletion;
+    private int realCaretPosition;
+
+    public AutoCompleteState(String currentWord, List<String> suggestions, int caretPosition) {
+        this.currentWord = currentWord;
+        this.suggestions = suggestions;
+        realCaretPosition = caretPosition;
+        currentCompletion = 0;
+    }
+
+    public String nextSuggestion() {
+        return cycleSuggestion(1);
+    }
+
+    public String previousSuggestion() {
+        return cycleSuggestion(-1);
+    }
+
+    public String getCurrentWord() {
+        return currentWord;
+    }
+
+    public boolean continuesSuggestion(char newChar) {
+        if (!getSuggestedWord().startsWith(currentWord + newChar)) {
+            return false;
+        }
+        return true;
+    }
+
+    public void updateState(char newChar) {
+        if (continuesSuggestion(newChar)) {
+            currentWord = currentWord + newChar;
+            realCaretPosition++;
+        } else {
+            throw new IllegalArgumentException("Make sure continuesSuggestion(newChar) is true before using this method!");
+        }
+    }
+
+    public int getRealCaretPosition() {
+        return realCaretPosition;
+    }
+
+    public String getSuggestedWord() {
+        return suggestions.get(currentCompletion);
+    }
+
+    private String cycleSuggestion(int increment) {
+        currentCompletion += increment;
+
+        if (currentCompletion >= suggestions.size()) {
+            currentCompletion = 0;
+        } else if (currentCompletion < 0) {
+            currentCompletion = suggestions.size() - 1;
+        }
+
+        return getSuggestedWord();
+    }
+}

--- a/src/main/java/net/sf/jabref/gui/autocompleter/AutoCompleteState.java
+++ b/src/main/java/net/sf/jabref/gui/autocompleter/AutoCompleteState.java
@@ -29,7 +29,7 @@ public class AutoCompleteState {
     }
 
     public boolean continuesSuggestion(char newChar) {
-        return !getSuggestedWord().startsWith(currentWord + newChar);
+        return getSuggestedWord().startsWith(currentWord + newChar);
     }
 
     public void updateState(char newChar) {

--- a/src/main/java/net/sf/jabref/gui/autocompleter/AutoCompleteState.java
+++ b/src/main/java/net/sf/jabref/gui/autocompleter/AutoCompleteState.java
@@ -29,10 +29,7 @@ public class AutoCompleteState {
     }
 
     public boolean continuesSuggestion(char newChar) {
-        if (!getSuggestedWord().startsWith(currentWord + newChar)) {
-            return false;
-        }
-        return true;
+        return !getSuggestedWord().startsWith(currentWord + newChar);
     }
 
     public void updateState(char newChar) {

--- a/src/main/java/net/sf/jabref/gui/autocompleter/AutoCompleteState.java
+++ b/src/main/java/net/sf/jabref/gui/autocompleter/AutoCompleteState.java
@@ -1,16 +1,17 @@
 package net.sf.jabref.gui.autocompleter;
 
 import java.util.List;
+import java.util.Objects;
 
 public class AutoCompleteState {
-    private List<String> suggestions;
+    private final List<String> suggestions;
     private String currentWord;
     private int currentCompletion;
     private int realCaretPosition;
 
     public AutoCompleteState(String currentWord, List<String> suggestions, int caretPosition) {
-        this.currentWord = currentWord;
-        this.suggestions = suggestions;
+        this.currentWord = Objects.requireNonNull(currentWord);
+        this.suggestions = Objects.requireNonNull(suggestions);
         realCaretPosition = caretPosition;
         currentCompletion = 0;
     }

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -1140,7 +1140,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
                         // See if we need to update an AutoCompleter instance:
                         AutoCompleter<String> aComp = panel.getAutoCompleters().get(fieldEditor.getFieldName());
                         if (aComp != null) {
-                            aComp.addBibtexEntry(entry);
+                            aComp.addToIndex(entry);
                         }
 
                         // Add an UndoableFieldChange to the baseframe's undoManager.

--- a/src/main/java/net/sf/jabref/gui/fieldeditors/TextArea.java
+++ b/src/main/java/net/sf/jabref/gui/fieldeditors/TextArea.java
@@ -150,7 +150,7 @@ public class TextArea extends JTextAreaWithHighlighting implements FieldEditor {
     @Override
     public void clearAutoCompleteSuggestion() {
         if (autoCompleteListener != null) {
-            autoCompleteListener.clearCurrentSuggestion(this);
+            autoCompleteListener.clearAutoCompletion(this);
         }
     }
 }

--- a/src/main/java/net/sf/jabref/gui/fieldeditors/TextField.java
+++ b/src/main/java/net/sf/jabref/gui/fieldeditors/TextField.java
@@ -158,7 +158,7 @@ public class TextField extends JTextField implements FieldEditor {
     @Override
     public void clearAutoCompleteSuggestion() {
         if (autoCompleteListener != null) {
-            autoCompleteListener.clearCurrentSuggestion(this);
+            autoCompleteListener.clearAutoCompletion(this);
         }
     }
 

--- a/src/main/java/net/sf/jabref/gui/preftabs/EntryEditorPrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/EntryEditorPrefsTab.java
@@ -81,7 +81,7 @@ class EntryEditorPrefsTab extends JPanel implements PrefsTab {
         autoComplete = new JCheckBox(Localization.lang("Enable word/name autocompletion"));
 
         shortestToComplete = new JSpinner(
-                new SpinnerNumberModel(autoCompletePreferences.getShortestLengthToComplete(), 1, 5, 1));
+                new SpinnerNumberModel(autoCompletePreferences.getMinLengthToComplete(), 1, 5, 1));
 
         // allowed name formats
         autoCompFF = new JRadioButton(Localization.lang("Autocomplete names in 'Firstname Lastname' format only"));
@@ -185,7 +185,7 @@ class EntryEditorPrefsTab extends JPanel implements PrefsTab {
         disableOnMultiple.setSelected(prefs.getBoolean(JabRefPreferences.DISABLE_ON_MULTIPLE_SELECTION));
         autoComplete.setSelected(prefs.getBoolean(JabRefPreferences.AUTO_COMPLETE));
         autoCompFields.setText(autoCompletePreferences.getCompleteNamesAsString());
-        shortestToComplete.setValue(autoCompletePreferences.getShortestLengthToComplete());
+        shortestToComplete.setValue(autoCompletePreferences.getMinLengthToComplete());
 
         if (autoCompletePreferences.getOnlyCompleteFirstLast()) {
             autoCompFF.setSelected(true);

--- a/src/main/java/net/sf/jabref/logic/autocompleter/AutoCompletePreferences.java
+++ b/src/main/java/net/sf/jabref/logic/autocompleter/AutoCompletePreferences.java
@@ -44,7 +44,7 @@ public class AutoCompletePreferences {
         this.preferences = Objects.requireNonNull(preferences);
     }
 
-    public int getShortestLengthToComplete() {
+    public int getMinLengthToComplete() {
         return preferences.getInt(PREF_SHORTEST_TO_COMPLETE);
     }
 

--- a/src/main/java/net/sf/jabref/logic/autocompleter/AutoCompleter.java
+++ b/src/main/java/net/sf/jabref/logic/autocompleter/AutoCompleter.java
@@ -22,7 +22,7 @@ public interface AutoCompleter<E> {
      * Add a BibEntry to this AutoCompleter.
      * @note The AutoCompleter itself decides which information should be stored for later completion.
      */
-    void addBibtexEntry(BibEntry entry);
+    void addToIndex(BibEntry entry);
 
     /**
      * States whether the field consists of multiple values (false) or of a single value (true)
@@ -33,25 +33,19 @@ public interface AutoCompleter<E> {
     boolean isSingleUnitField();
 
     /**
-     * Unclear what this method should do.
-     * TODO: Remove this method once the AutoCompleteListener is removed.
-     */
-    String getPrefix();
-
-    /**
      * Returns one or more possible completions for a given string. The returned
      * completion depends on which informations were stored while adding
      * BibtexEntries. If no suggestions for completions are found, then an empty list is returned.
      *
-     * @see AutoCompleter#addBibtexEntry(BibEntry)
+     * @see AutoCompleter#addToIndex(BibEntry)
      */
     List<E> complete(String toComplete);
 
     /**
      * Directly adds an item to the AutoCompleter.
      * This method should be called only if the information does not comes directly from a BibEntry.
-     * Otherwise the {@link #addBibtexEntry(BibEntry)} is preferred.
+     * Otherwise the {@link #addToIndex(BibEntry)} is preferred.
      * @param item item to add
      */
-    void addItemToIndex(E item);
+    void insertIntoIndex(E item);
 }

--- a/src/main/java/net/sf/jabref/logic/autocompleter/AutoCompleterFactory.java
+++ b/src/main/java/net/sf/jabref/logic/autocompleter/AutoCompleterFactory.java
@@ -19,20 +19,16 @@ import java.util.Arrays;
 import java.util.Objects;
 
 /**
- * Returns an autocompleter to a given fieldname.
- *
- * @author kahlert, cordes
+ * Returns an autocompleter for a given field name.
  */
 public class AutoCompleterFactory {
-
     private final AutoCompletePreferences preferences;
-
 
     public AutoCompleterFactory(AutoCompletePreferences preferences) {
         this.preferences = Objects.requireNonNull(preferences);
     }
 
-    public AutoCompleter<String> getFor(String fieldName) {
+    public AutoCompleter<String> forField(String fieldName) {
         Objects.requireNonNull(fieldName);
 
         if ("author".equals(fieldName) || "editor".equals(fieldName)) {
@@ -49,5 +45,4 @@ public class AutoCompleterFactory {
     public AutoCompleter<String> getPersonAutoCompleter() {
         return new NameFieldAutoCompleter(Arrays.asList("author", "editor"), true, preferences);
     }
-
 }

--- a/src/main/java/net/sf/jabref/logic/autocompleter/AutoCompleterFactory.java
+++ b/src/main/java/net/sf/jabref/logic/autocompleter/AutoCompleterFactory.java
@@ -15,6 +15,9 @@
 */
 package net.sf.jabref.logic.autocompleter;
 
+import net.sf.jabref.bibtex.BibtexSingleFieldProperties;
+import net.sf.jabref.bibtex.InternalBibtexFields;
+
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -31,7 +34,7 @@ public class AutoCompleterFactory {
     public AutoCompleter<String> forField(String fieldName) {
         Objects.requireNonNull(fieldName);
 
-        if ("author".equals(fieldName) || "editor".equals(fieldName)) {
+        if (InternalBibtexFields.getFieldExtras(fieldName).contains(BibtexSingleFieldProperties.PERSON_NAMES)) {
             return new NameFieldAutoCompleter(fieldName, preferences);
         } else if ("crossref".equals(fieldName)) {
             return new BibtexKeyAutoCompleter(preferences);

--- a/src/main/java/net/sf/jabref/logic/autocompleter/AutoCompleters.java
+++ b/src/main/java/net/sf/jabref/logic/autocompleter/AutoCompleters.java
@@ -28,7 +28,7 @@ class AutoCompleters {
      */
     public void addEntry(BibEntry bibEntry) {
         for (AutoCompleter<String> autoCompleter : autoCompleters.values()) {
-            autoCompleter.addBibtexEntry(bibEntry);
+            autoCompleter.addToIndex(bibEntry);
         }
     }
 

--- a/src/main/java/net/sf/jabref/logic/autocompleter/BibtexKeyAutoCompleter.java
+++ b/src/main/java/net/sf/jabref/logic/autocompleter/BibtexKeyAutoCompleter.java
@@ -18,11 +18,13 @@ package net.sf.jabref.logic.autocompleter;
 import net.sf.jabref.model.entry.BibEntry;
 
 /**
- * Delivers possible completions for a given string based on the key fields of the added items.
+ * Delivers auto-completions for BibTeX keys.
+ * Only applied for auto-completion inside crossref fields.
  *
  * @author kahlert, cordes
  */
 class BibtexKeyAutoCompleter extends AbstractAutoCompleter {
+    private static final int SHORTEST_WORD_TO_ADD = 1;
 
     public BibtexKeyAutoCompleter(AutoCompletePreferences preferences) {
         super(preferences);
@@ -30,6 +32,7 @@ class BibtexKeyAutoCompleter extends AbstractAutoCompleter {
 
     @Override
     public boolean isSingleUnitField() {
+        // TODO: Why is this not a single unit field?
         return false;
     }
 
@@ -38,19 +41,19 @@ class BibtexKeyAutoCompleter extends AbstractAutoCompleter {
      * The bibtex key of the entry will be added to the index.
      */
     @Override
-    public void addBibtexEntry(BibEntry entry) {
+    public void addToIndex(BibEntry entry) {
         if (entry == null) {
             return;
         }
 
         String key = entry.getCiteKey();
         if (key != null) {
-            addItemToIndex(key.trim());
+            insertIntoIndex(key.trim());
         }
     }
 
     @Override
     protected int getLengthOfShortestWordToAdd() {
-        return 1;
+        return SHORTEST_WORD_TO_ADD;
     }
 }

--- a/src/main/java/net/sf/jabref/logic/autocompleter/ContentAutoCompleters.java
+++ b/src/main/java/net/sf/jabref/logic/autocompleter/ContentAutoCompleters.java
@@ -27,7 +27,7 @@ public class ContentAutoCompleters extends AutoCompleters {
         AutoCompleterFactory autoCompleterFactory = new AutoCompleterFactory(preferences);
         List<String> completeFields = preferences.getCompleteNames();
         for (String field : completeFields) {
-            AutoCompleter<String> autoCompleter = autoCompleterFactory.getFor(field);
+            AutoCompleter<String> autoCompleter = autoCompleterFactory.forField(field);
             put(field, autoCompleter);
         }
 
@@ -47,7 +47,7 @@ public class ContentAutoCompleters extends AutoCompleters {
             if (metaData.getData(Globals.SELECTOR_META_PREFIX + entry.getKey()) != null) {
                 List<String> items = metaData.getData(Globals.SELECTOR_META_PREFIX + entry.getKey());
                 if (items != null) {
-                    items.forEach(ac::addItemToIndex);
+                    items.forEach(ac::insertIntoIndex);
                 }
             }
         }
@@ -61,7 +61,7 @@ public class ContentAutoCompleters extends AutoCompleters {
         AutoCompleter<String> autoCompleter = get("journal");
         if(autoCompleter != null) {
             for (Abbreviation abbreviation : abbreviationLoader.getRepository().getAbbreviations()) {
-                autoCompleter.addItemToIndex(abbreviation.getName());
+                autoCompleter.insertIntoIndex(abbreviation.getName());
             }
         }
     }

--- a/src/main/java/net/sf/jabref/logic/autocompleter/DefaultAutoCompleter.java
+++ b/src/main/java/net/sf/jabref/logic/autocompleter/DefaultAutoCompleter.java
@@ -18,26 +18,23 @@ package net.sf.jabref.logic.autocompleter;
 import net.sf.jabref.model.entry.BibEntry;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.StringTokenizer;
 
 /**
  * Delivers possible completions for a given string.
  * Stores all words in the given field which are separated by SEPARATING_CHARS.
- *
- * @author kahlert, cordes
  */
 class DefaultAutoCompleter extends AbstractAutoCompleter {
+    private static final String SEPARATING_CHARS = ";,\n ";
 
     private final String fieldName;
-
-    private static final String SEPARATING_CHARS = ";,\n ";
 
     /**
      * @see AutoCompleterFactory
      */
     DefaultAutoCompleter(String fieldName, AutoCompletePreferences preferences) {
         super(preferences);
-
         this.fieldName = Objects.requireNonNull(fieldName);
     }
 
@@ -51,16 +48,19 @@ class DefaultAutoCompleter extends AbstractAutoCompleter {
      * Stores all words in the given field which are separated by SEPARATING_CHARS.
      */
     @Override
-    public void addBibtexEntry(BibEntry entry) {
+    public void addToIndex(BibEntry entry) {
         if (entry == null) {
             return;
         }
 
-        entry.getFieldOptional(fieldName).ifPresent(fieldValue -> {
-            StringTokenizer tok = new StringTokenizer(fieldValue, SEPARATING_CHARS);
-            while (tok.hasMoreTokens()) {
-                addItemToIndex(tok.nextToken());
+        Optional<String> fieldValue = entry.getFieldOptional(fieldName);
+
+        if(fieldValue.isPresent()) {
+            StringTokenizer tokenizer = new StringTokenizer(fieldValue.get(), SEPARATING_CHARS);
+
+            while (tokenizer.hasMoreTokens()) {
+                insertIntoIndex(tokenizer.nextToken());
             }
-        });
+        }
     }
 }

--- a/src/main/java/net/sf/jabref/logic/autocompleter/EntireFieldAutoCompleter.java
+++ b/src/main/java/net/sf/jabref/logic/autocompleter/EntireFieldAutoCompleter.java
@@ -26,7 +26,6 @@ import net.sf.jabref.model.entry.BibEntry;
  * @author kahlert, cordes
  */
 class EntireFieldAutoCompleter extends AbstractAutoCompleter {
-
     private final String fieldName;
 
     /**
@@ -34,7 +33,6 @@ class EntireFieldAutoCompleter extends AbstractAutoCompleter {
      */
     EntireFieldAutoCompleter(String fieldName, AutoCompletePreferences preferences) {
         super(preferences);
-
         this.fieldName = Objects.requireNonNull(fieldName);
     }
 
@@ -48,11 +46,11 @@ class EntireFieldAutoCompleter extends AbstractAutoCompleter {
      * Stores the full original value of the given field.
      */
     @Override
-    public void addBibtexEntry(BibEntry entry) {
+    public void addToIndex(BibEntry entry) {
         if (entry == null) {
             return;
         }
 
-        entry.getFieldOptional(fieldName).ifPresent(fieldValue -> addItemToIndex(fieldValue.trim()));
+        entry.getFieldOptional(fieldName).ifPresent(fieldValue -> insertIntoIndex(fieldValue.trim()));
     }
 }

--- a/src/test/java/net/sf/jabref/logic/autocompleter/AutoCompleterFactoryTest.java
+++ b/src/test/java/net/sf/jabref/logic/autocompleter/AutoCompleterFactoryTest.java
@@ -2,10 +2,23 @@ package net.sf.jabref.logic.autocompleter;
 
 import static org.mockito.Mockito.*;
 
+import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefPreferences;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 public class AutoCompleterFactoryTest {
+    @Before
+    public void setup() {
+        Globals.prefs = mock(JabRefPreferences.class);
+    }
+
+    @After
+    public void teardown() {
+        Globals.prefs = null;
+    }
 
     @Test(expected = NullPointerException.class)
     public void initFactoryWithNullPreferenceThrowsException() {

--- a/src/test/java/net/sf/jabref/logic/autocompleter/AutoCompleterFactoryTest.java
+++ b/src/test/java/net/sf/jabref/logic/autocompleter/AutoCompleterFactoryTest.java
@@ -16,7 +16,7 @@ public class AutoCompleterFactoryTest {
     public void getForUnknownFieldReturnsDefaultAutoCompleter() {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
         AutoCompleterFactory autoCompleterFactory = new AutoCompleterFactory(preferences);
-        AutoCompleter<String> autoCompleter = autoCompleterFactory.getFor("unknownField");
+        AutoCompleter<String> autoCompleter = autoCompleterFactory.forField("unknownField");
         Assert.assertTrue(autoCompleter instanceof DefaultAutoCompleter);
     }
 
@@ -24,14 +24,14 @@ public class AutoCompleterFactoryTest {
     public void getForNullThrowsException() {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
         AutoCompleterFactory autoCompleterFactory = new AutoCompleterFactory(preferences);
-        autoCompleterFactory.getFor(null);
+        autoCompleterFactory.forField(null);
     }
 
     @Test
     public void getForAuthorReturnsNameFieldAutoCompleter() {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
         AutoCompleterFactory autoCompleterFactory = new AutoCompleterFactory(preferences);
-        AutoCompleter<String> autoCompleter = autoCompleterFactory.getFor("author");
+        AutoCompleter<String> autoCompleter = autoCompleterFactory.forField("author");
         Assert.assertTrue(autoCompleter instanceof NameFieldAutoCompleter);
     }
 
@@ -39,7 +39,7 @@ public class AutoCompleterFactoryTest {
     public void getForEditorReturnsNameFieldAutoCompleter() {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
         AutoCompleterFactory autoCompleterFactory = new AutoCompleterFactory(preferences);
-        AutoCompleter<String> autoCompleter = autoCompleterFactory.getFor("editor");
+        AutoCompleter<String> autoCompleter = autoCompleterFactory.forField("editor");
         Assert.assertTrue(autoCompleter instanceof NameFieldAutoCompleter);
     }
 
@@ -47,7 +47,7 @@ public class AutoCompleterFactoryTest {
     public void getForCrossrefReturnsBibtexKeyAutoCompleter() {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
         AutoCompleterFactory autoCompleterFactory = new AutoCompleterFactory(preferences);
-        AutoCompleter<String> autoCompleter = autoCompleterFactory.getFor("crossref");
+        AutoCompleter<String> autoCompleter = autoCompleterFactory.forField("crossref");
         Assert.assertTrue(autoCompleter instanceof BibtexKeyAutoCompleter);
     }
 
@@ -55,7 +55,7 @@ public class AutoCompleterFactoryTest {
     public void getForJournalReturnsEntireFieldAutoCompleter() {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
         AutoCompleterFactory autoCompleterFactory = new AutoCompleterFactory(preferences);
-        AutoCompleter<String> autoCompleter = autoCompleterFactory.getFor("journal");
+        AutoCompleter<String> autoCompleter = autoCompleterFactory.forField("journal");
         Assert.assertTrue(autoCompleter instanceof EntireFieldAutoCompleter);
     }
 
@@ -63,7 +63,7 @@ public class AutoCompleterFactoryTest {
     public void getForPublisherReturnsEntireFieldAutoCompleter() {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
         AutoCompleterFactory autoCompleterFactory = new AutoCompleterFactory(preferences);
-        AutoCompleter<String> autoCompleter = autoCompleterFactory.getFor("publisher");
+        AutoCompleter<String> autoCompleter = autoCompleterFactory.forField("publisher");
         Assert.assertTrue(autoCompleter instanceof EntireFieldAutoCompleter);
     }
 

--- a/src/test/java/net/sf/jabref/logic/autocompleter/AutoCompleterFactoryTest.java
+++ b/src/test/java/net/sf/jabref/logic/autocompleter/AutoCompleterFactoryTest.java
@@ -11,12 +11,12 @@ import org.junit.Test;
 
 public class AutoCompleterFactoryTest {
     @Before
-    public void setup() {
+    public void setUp() {
         Globals.prefs = mock(JabRefPreferences.class);
     }
 
     @After
-    public void teardown() {
+    public void tearDown() {
         Globals.prefs = null;
     }
 

--- a/src/test/java/net/sf/jabref/logic/autocompleter/BibtexKeyAutoCompleterTest.java
+++ b/src/test/java/net/sf/jabref/logic/autocompleter/BibtexKeyAutoCompleterTest.java
@@ -13,7 +13,6 @@ import net.sf.jabref.model.entry.BibEntry;
 
 public class BibtexKeyAutoCompleterTest {
 
-    @SuppressWarnings("unused")
     @Test(expected = NullPointerException.class)
     public void initAutoCompleterWithNullPreferenceThrowsException() {
         new BibtexKeyAutoCompleter(null);
@@ -148,7 +147,7 @@ public class BibtexKeyAutoCompleterTest {
     @Test
     public void completeTooShortInputReturnsNothing() {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
-        when(preferences.getShortestLengthToComplete()).thenReturn(100);
+        when(preferences.getMinLengthToComplete()).thenReturn(100);
         BibtexKeyAutoCompleter autoCompleter = new BibtexKeyAutoCompleter(preferences);
 
         BibEntry entry = new BibEntry();

--- a/src/test/java/net/sf/jabref/logic/autocompleter/BibtexKeyAutoCompleterTest.java
+++ b/src/test/java/net/sf/jabref/logic/autocompleter/BibtexKeyAutoCompleterTest.java
@@ -32,7 +32,7 @@ public class BibtexKeyAutoCompleterTest {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
         BibtexKeyAutoCompleter autoCompleter = new BibtexKeyAutoCompleter(preferences);
 
-        autoCompleter.addBibtexEntry(null);
+        autoCompleter.addToIndex(null);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -44,7 +44,7 @@ public class BibtexKeyAutoCompleterTest {
         BibtexKeyAutoCompleter autoCompleter = new BibtexKeyAutoCompleter(preferences);
 
         BibEntry entry = new BibEntry();
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -57,7 +57,7 @@ public class BibtexKeyAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField(BibEntry.KEY_FIELD, "testKey");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("testKey");
         Assert.assertEquals(Arrays.asList("testKey"), result);
@@ -70,7 +70,7 @@ public class BibtexKeyAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField(BibEntry.KEY_FIELD, "testKey");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Arrays.asList("testKey"), result);
@@ -83,7 +83,7 @@ public class BibtexKeyAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField(BibEntry.KEY_FIELD, "testKey");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("testkey");
         Assert.assertEquals(Arrays.asList("testKey"), result);
@@ -96,7 +96,7 @@ public class BibtexKeyAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField(BibEntry.KEY_FIELD, "testKey");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete(null);
         Assert.assertEquals(Collections.emptyList(), result);
@@ -109,7 +109,7 @@ public class BibtexKeyAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField(BibEntry.KEY_FIELD, "testKey");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -122,10 +122,10 @@ public class BibtexKeyAutoCompleterTest {
 
         BibEntry entryOne = new BibEntry();
         entryOne.setField(BibEntry.KEY_FIELD, "testKeyOne");
-        autoCompleter.addBibtexEntry(entryOne);
+        autoCompleter.addToIndex(entryOne);
         BibEntry entryTwo = new BibEntry();
         entryTwo.setField(BibEntry.KEY_FIELD, "testKeyTwo");
-        autoCompleter.addBibtexEntry(entryTwo);
+        autoCompleter.addToIndex(entryTwo);
 
         List<String> result = autoCompleter.complete("testKey");
         Assert.assertEquals(Arrays.asList("testKeyOne", "testKeyTwo"), result);
@@ -138,7 +138,7 @@ public class BibtexKeyAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField(BibEntry.KEY_FIELD, "key");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("k");
         Assert.assertEquals(Arrays.asList("key"), result);
@@ -152,7 +152,7 @@ public class BibtexKeyAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField(BibEntry.KEY_FIELD, "testKey");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Collections.emptyList(), result);

--- a/src/test/java/net/sf/jabref/logic/autocompleter/BibtexKeyAutoCompleterTest.java
+++ b/src/test/java/net/sf/jabref/logic/autocompleter/BibtexKeyAutoCompleterTest.java
@@ -77,19 +77,6 @@ public class BibtexKeyAutoCompleterTest {
     }
 
     @Test
-    public void completeLowercaseKeyReturnsKey() {
-        AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
-        BibtexKeyAutoCompleter autoCompleter = new BibtexKeyAutoCompleter(preferences);
-
-        BibEntry entry = new BibEntry();
-        entry.setField(BibEntry.KEY_FIELD, "testKey");
-        autoCompleter.addToIndex(entry);
-
-        List<String> result = autoCompleter.complete("testkey");
-        Assert.assertEquals(Arrays.asList("testKey"), result);
-    }
-
-    @Test
     public void completeNullReturnsNothing() {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
         BibtexKeyAutoCompleter autoCompleter = new BibtexKeyAutoCompleter(preferences);

--- a/src/test/java/net/sf/jabref/logic/autocompleter/DefaultAutoCompleterTest.java
+++ b/src/test/java/net/sf/jabref/logic/autocompleter/DefaultAutoCompleterTest.java
@@ -167,7 +167,7 @@ public class DefaultAutoCompleterTest {
     @Test
     public void completeTooShortInputReturnsNothing() {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
-        when(preferences.getShortestLengthToComplete()).thenReturn(100);
+        when(preferences.getMinLengthToComplete()).thenReturn(100);
         DefaultAutoCompleter autoCompleter = new DefaultAutoCompleter("field", preferences);
 
         BibEntry entry = new BibEntry();

--- a/src/test/java/net/sf/jabref/logic/autocompleter/DefaultAutoCompleterTest.java
+++ b/src/test/java/net/sf/jabref/logic/autocompleter/DefaultAutoCompleterTest.java
@@ -97,19 +97,6 @@ public class DefaultAutoCompleterTest {
     }
 
     @Test
-    public void completeLowercaseValueReturnsValue() {
-        AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
-        DefaultAutoCompleter autoCompleter = new DefaultAutoCompleter("field", preferences);
-
-        BibEntry entry = new BibEntry();
-        entry.setField("field", "testValue");
-        autoCompleter.addToIndex(entry);
-
-        List<String> result = autoCompleter.complete("testvalue");
-        Assert.assertEquals(Arrays.asList("testValue"), result);
-    }
-
-    @Test
     public void completeNullReturnsNothing() {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
         DefaultAutoCompleter autoCompleter = new DefaultAutoCompleter("field", preferences);

--- a/src/test/java/net/sf/jabref/logic/autocompleter/DefaultAutoCompleterTest.java
+++ b/src/test/java/net/sf/jabref/logic/autocompleter/DefaultAutoCompleterTest.java
@@ -39,7 +39,7 @@ public class DefaultAutoCompleterTest {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
         DefaultAutoCompleter autoCompleter = new DefaultAutoCompleter("field", preferences);
 
-        autoCompleter.addBibtexEntry(null);
+        autoCompleter.addToIndex(null);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -51,7 +51,7 @@ public class DefaultAutoCompleterTest {
         DefaultAutoCompleter autoCompleter = new DefaultAutoCompleter("field", preferences);
 
         BibEntry entry = new BibEntry();
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -64,7 +64,7 @@ public class DefaultAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("title", "testTitle");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -77,7 +77,7 @@ public class DefaultAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "testValue");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("testValue");
         Assert.assertEquals(Arrays.asList("testValue"), result);
@@ -90,7 +90,7 @@ public class DefaultAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "testValue");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Arrays.asList("testValue"), result);
@@ -103,7 +103,7 @@ public class DefaultAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "testValue");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("testvalue");
         Assert.assertEquals(Arrays.asList("testValue"), result);
@@ -116,7 +116,7 @@ public class DefaultAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "testKey");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete(null);
         Assert.assertEquals(Collections.emptyList(), result);
@@ -129,7 +129,7 @@ public class DefaultAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "testKey");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -142,10 +142,10 @@ public class DefaultAutoCompleterTest {
 
         BibEntry entryOne = new BibEntry();
         entryOne.setField("field", "testValueOne");
-        autoCompleter.addBibtexEntry(entryOne);
+        autoCompleter.addToIndex(entryOne);
         BibEntry entryTwo = new BibEntry();
         entryTwo.setField("field", "testValueTwo");
-        autoCompleter.addBibtexEntry(entryTwo);
+        autoCompleter.addToIndex(entryTwo);
 
         List<String> result = autoCompleter.complete("testValue");
         Assert.assertEquals(Arrays.asList("testValueOne", "testValueTwo"), result);
@@ -158,7 +158,7 @@ public class DefaultAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "val");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("va");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -172,7 +172,7 @@ public class DefaultAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "testValue");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -185,7 +185,7 @@ public class DefaultAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "test value");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("val");
         Assert.assertEquals(Arrays.asList("value"), result);
@@ -198,7 +198,7 @@ public class DefaultAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "test value");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("lue");
         Assert.assertEquals(Collections.emptyList(), result);

--- a/src/test/java/net/sf/jabref/logic/autocompleter/EntireFieldAutoCompleterTest.java
+++ b/src/test/java/net/sf/jabref/logic/autocompleter/EntireFieldAutoCompleterTest.java
@@ -39,7 +39,7 @@ public class EntireFieldAutoCompleterTest {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
         EntireFieldAutoCompleter autoCompleter = new EntireFieldAutoCompleter("field", preferences);
 
-        autoCompleter.addBibtexEntry(null);
+        autoCompleter.addToIndex(null);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -51,7 +51,7 @@ public class EntireFieldAutoCompleterTest {
         EntireFieldAutoCompleter autoCompleter = new EntireFieldAutoCompleter("field", preferences);
 
         BibEntry entry = new BibEntry();
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -64,7 +64,7 @@ public class EntireFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("title", "testTitle");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -77,7 +77,7 @@ public class EntireFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "testValue");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("testValue");
         Assert.assertEquals(Arrays.asList("testValue"), result);
@@ -90,7 +90,7 @@ public class EntireFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "testValue");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Arrays.asList("testValue"), result);
@@ -103,7 +103,7 @@ public class EntireFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "testValue");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("testvalue");
         Assert.assertEquals(Arrays.asList("testValue"), result);
@@ -116,7 +116,7 @@ public class EntireFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "testKey");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete(null);
         Assert.assertEquals(Collections.emptyList(), result);
@@ -129,7 +129,7 @@ public class EntireFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "testKey");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -142,10 +142,10 @@ public class EntireFieldAutoCompleterTest {
 
         BibEntry entryOne = new BibEntry();
         entryOne.setField("field", "testValueOne");
-        autoCompleter.addBibtexEntry(entryOne);
+        autoCompleter.addToIndex(entryOne);
         BibEntry entryTwo = new BibEntry();
         entryTwo.setField("field", "testValueTwo");
-        autoCompleter.addBibtexEntry(entryTwo);
+        autoCompleter.addToIndex(entryTwo);
 
         List<String> result = autoCompleter.complete("testValue");
         Assert.assertEquals(Arrays.asList("testValueOne", "testValueTwo"), result);
@@ -158,7 +158,7 @@ public class EntireFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "val");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("va");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -172,7 +172,7 @@ public class EntireFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "testValue");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -185,7 +185,7 @@ public class EntireFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "test value");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("val");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -198,7 +198,7 @@ public class EntireFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "test value");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("lue");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -211,7 +211,7 @@ public class EntireFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "test value");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("te");
         Assert.assertEquals(Arrays.asList("test value"), result);

--- a/src/test/java/net/sf/jabref/logic/autocompleter/EntireFieldAutoCompleterTest.java
+++ b/src/test/java/net/sf/jabref/logic/autocompleter/EntireFieldAutoCompleterTest.java
@@ -167,7 +167,7 @@ public class EntireFieldAutoCompleterTest {
     @Test
     public void completeTooShortInputReturnsNothing() {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
-        when(preferences.getShortestLengthToComplete()).thenReturn(100);
+        when(preferences.getMinLengthToComplete()).thenReturn(100);
         EntireFieldAutoCompleter autoCompleter = new EntireFieldAutoCompleter("field", preferences);
 
         BibEntry entry = new BibEntry();

--- a/src/test/java/net/sf/jabref/logic/autocompleter/EntireFieldAutoCompleterTest.java
+++ b/src/test/java/net/sf/jabref/logic/autocompleter/EntireFieldAutoCompleterTest.java
@@ -97,19 +97,6 @@ public class EntireFieldAutoCompleterTest {
     }
 
     @Test
-    public void completeLowercaseValueReturnsValue() {
-        AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
-        EntireFieldAutoCompleter autoCompleter = new EntireFieldAutoCompleter("field", preferences);
-
-        BibEntry entry = new BibEntry();
-        entry.setField("field", "testValue");
-        autoCompleter.addToIndex(entry);
-
-        List<String> result = autoCompleter.complete("testvalue");
-        Assert.assertEquals(Arrays.asList("testValue"), result);
-    }
-
-    @Test
     public void completeNullReturnsNothing() {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
         EntireFieldAutoCompleter autoCompleter = new EntireFieldAutoCompleter("field", preferences);

--- a/src/test/java/net/sf/jabref/logic/autocompleter/NameFieldAutoCompleterTest.java
+++ b/src/test/java/net/sf/jabref/logic/autocompleter/NameFieldAutoCompleterTest.java
@@ -97,19 +97,6 @@ public class NameFieldAutoCompleterTest {
     }
 
     @Test
-    public void completeLowercaseNameReturnsName() {
-        AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
-        NameFieldAutoCompleter autoCompleter = new NameFieldAutoCompleter("field", preferences);
-
-        BibEntry entry = new BibEntry();
-        entry.setField("field", "Testname");
-        autoCompleter.addToIndex(entry);
-
-        List<String> result = autoCompleter.complete("test");
-        Assert.assertEquals(Arrays.asList("Testname"), result);
-    }
-
-    @Test
     public void completeNullReturnsNothing() {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
         NameFieldAutoCompleter autoCompleter = new NameFieldAutoCompleter("field", preferences);

--- a/src/test/java/net/sf/jabref/logic/autocompleter/NameFieldAutoCompleterTest.java
+++ b/src/test/java/net/sf/jabref/logic/autocompleter/NameFieldAutoCompleterTest.java
@@ -39,7 +39,7 @@ public class NameFieldAutoCompleterTest {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
         NameFieldAutoCompleter autoCompleter = new NameFieldAutoCompleter("field", preferences);
 
-        autoCompleter.addBibtexEntry(null);
+        autoCompleter.addToIndex(null);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -51,7 +51,7 @@ public class NameFieldAutoCompleterTest {
         NameFieldAutoCompleter autoCompleter = new NameFieldAutoCompleter("field", preferences);
 
         BibEntry entry = new BibEntry();
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -64,7 +64,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("title", "testTitle");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -77,7 +77,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "Testname");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("Testname");
         Assert.assertEquals(Arrays.asList("Testname"), result);
@@ -90,7 +90,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "Testname");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("Test");
         Assert.assertEquals(Arrays.asList("Testname"), result);
@@ -103,7 +103,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "Testname");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Arrays.asList("Testname"), result);
@@ -116,7 +116,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "testKey");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete(null);
         Assert.assertEquals(Collections.emptyList(), result);
@@ -129,7 +129,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "testKey");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -142,10 +142,10 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entryOne = new BibEntry();
         entryOne.setField("field", "testNameOne");
-        autoCompleter.addBibtexEntry(entryOne);
+        autoCompleter.addToIndex(entryOne);
         BibEntry entryTwo = new BibEntry();
         entryTwo.setField("field", "testNameTwo");
-        autoCompleter.addBibtexEntry(entryTwo);
+        autoCompleter.addToIndex(entryTwo);
 
         List<String> result = autoCompleter.complete("testName");
         Assert.assertEquals(Arrays.asList("testNameOne", "testNameTwo"), result);
@@ -159,7 +159,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "Testname");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("test");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -172,7 +172,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "Vassilis Kostakos");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("osta");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -185,7 +185,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "Vassilis Kostakos");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("Vas");
         Assert.assertEquals(Arrays.asList("Vassilis Kostakos"), result);
@@ -198,7 +198,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "Reagle, Jr., Joseph M.");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("Jos");
         Assert.assertEquals(Arrays.asList("Joseph M. Reagle, Jr."), result);
@@ -211,7 +211,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "Eric von Hippel");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("Eric");
         Assert.assertEquals(Arrays.asList("Eric von Hippel"), result);
@@ -225,7 +225,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "Honig Bär");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("Bä");
         Assert.assertEquals(Arrays.asList("Bär, Honig"), result);
@@ -238,7 +238,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "Vassilis Kostakos");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("Kosta");
         Assert.assertEquals(Arrays.asList("Kostakos, V.", "Kostakos, Vassilis"), result);
@@ -252,7 +252,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "Vassilis Kostakos");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("Kosta");
         Assert.assertEquals(Arrays.asList("Kostakos, Vassilis"), result);
@@ -266,7 +266,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "Reagle, Jr., Joseph M.");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("Rea");
         Assert.assertEquals(Arrays.asList("Reagle, Jr., J. M."), result);
@@ -280,7 +280,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "Vassilis Kostakos");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("Kosta");
         Assert.assertEquals(Arrays.asList("Kostakos, V."), result);
@@ -294,7 +294,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "Eric von Hippel");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("von");
         Assert.assertEquals(Arrays.asList("von Hippel, E."), result);
@@ -307,7 +307,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "Vassilis Kostakos");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("Kostakos, Va");
         Assert.assertEquals(Arrays.asList("Kostakos, Vassilis"), result);
@@ -321,7 +321,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "Vassilis Kostakos");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("Kosta");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -335,7 +335,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "Vassilis Kostakos");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("Vas");
         Assert.assertEquals(Collections.emptyList(), result);
@@ -348,7 +348,7 @@ public class NameFieldAutoCompleterTest {
 
         BibEntry entry = new BibEntry();
         entry.setField("field", "nam");
-        autoCompleter.addBibtexEntry(entry);
+        autoCompleter.addToIndex(entry);
 
         List<String> result = autoCompleter.complete("n");
         Assert.assertEquals(Arrays.asList("nam"), result);

--- a/src/test/java/net/sf/jabref/logic/autocompleter/NameFieldAutoCompleterTest.java
+++ b/src/test/java/net/sf/jabref/logic/autocompleter/NameFieldAutoCompleterTest.java
@@ -154,7 +154,7 @@ public class NameFieldAutoCompleterTest {
     @Test
     public void completeTooShortInputReturnsNothing() {
         AutoCompletePreferences preferences = mock(AutoCompletePreferences.class);
-        when(preferences.getShortestLengthToComplete()).thenReturn(100);
+        when(preferences.getMinLengthToComplete()).thenReturn(100);
         NameFieldAutoCompleter autoCompleter = new NameFieldAutoCompleter("field", preferences);
 
         BibEntry entry = new BibEntry();


### PR DESCRIPTION
__Major changes in this PR:__
- [x] Only use auto-completion when at the end of a word (space after)
- [x] Detection modes: Only use case-sensitive detection for now (performance, logic, we can re-add functionality from here)
- [x] Remove method getPrefix() - Intention of this method was unknown
- [x] Use Nameautocompleter for every PERSONNAME BibTeX field, not only author & editor