### PR TITLE
FileList field size now dependent on its content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,8 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Moved "Get BibTeX data from DOI" from main table context menu to DOI field in entry editor
 - Added open buttons to DOI and URL field
 - Move Look & Feel settings from advanced to appearance tab in preferences
-
 - Move PDF file directory configuration from external tab to file tab in preferences
+- Implemented [#672](https://github.com/JabRef/jabref/issues/672): FileList now distributes its space dependent on the width of its columns
 
 ### Fixed
 - Fixed [#318](https://github.com/JabRef/jabref/issues/318): Improve normalization of author names

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -34,40 +34,61 @@ import java.beans.VetoableChangeListener;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.swing.*;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.ActionMap;
+import javax.swing.InputMap;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
+import javax.swing.JTabbedPane;
+import javax.swing.JTextArea;
+import javax.swing.JToolBar;
+import javax.swing.KeyStroke;
+import javax.swing.ScrollPaneConstants;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.text.JTextComponent;
-import net.sf.jabref.*;
+
+import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.bibtex.BibEntryWriter;
 import net.sf.jabref.bibtex.FieldProperties;
 import net.sf.jabref.bibtex.InternalBibtexFields;
-import net.sf.jabref.logic.TypedBibEntry;
-import net.sf.jabref.model.EntryTypes;
-import net.sf.jabref.gui.actions.Actions;
-import net.sf.jabref.gui.fieldeditors.*;
-import net.sf.jabref.gui.help.HelpFiles;
-import net.sf.jabref.gui.help.HelpAction;
-import net.sf.jabref.gui.keyboard.KeyBinding;
-import net.sf.jabref.gui.menus.ChangeEntryTypeMenu;
-import net.sf.jabref.logic.autocompleter.AutoCompleter;
 import net.sf.jabref.exporter.LatexFieldFormatter;
 import net.sf.jabref.external.WriteXMPEntryEditorAction;
-import net.sf.jabref.gui.*;
-import net.sf.jabref.importer.fileformat.BibtexParser;
-import net.sf.jabref.importer.ParserResult;
-import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.logic.labelpattern.LabelPatternUtil;
-import net.sf.jabref.logic.search.SearchQueryHighlightListener;
-import net.sf.jabref.logic.util.date.TimeStamp;
-import net.sf.jabref.model.database.BibDatabase;
-import net.sf.jabref.model.database.BibDatabaseMode;
-import net.sf.jabref.model.entry.*;
-import net.sf.jabref.specialfields.SpecialFieldUpdateListener;
+import net.sf.jabref.gui.BasePanel;
+import net.sf.jabref.gui.EntryContainer;
+import net.sf.jabref.gui.FieldContentSelector;
+import net.sf.jabref.gui.GUIGlobals;
+import net.sf.jabref.gui.IconTheme;
+import net.sf.jabref.gui.JabRefFrame;
+import net.sf.jabref.gui.OSXCompatibleToolbar;
+import net.sf.jabref.gui.actions.Actions;
+import net.sf.jabref.gui.fieldeditors.FieldEditor;
+import net.sf.jabref.gui.fieldeditors.FieldEditorFocusListener;
+import net.sf.jabref.gui.fieldeditors.FileListEditor;
+import net.sf.jabref.gui.fieldeditors.JTextAreaWithHighlighting;
+import net.sf.jabref.gui.fieldeditors.TextField;
+import net.sf.jabref.gui.help.HelpAction;
+import net.sf.jabref.gui.help.HelpFiles;
+import net.sf.jabref.gui.keyboard.KeyBinding;
+import net.sf.jabref.gui.menus.ChangeEntryTypeMenu;
 import net.sf.jabref.gui.undo.NamedCompound;
 import net.sf.jabref.gui.undo.UndoableChangeType;
 import net.sf.jabref.gui.undo.UndoableFieldChange;
@@ -76,6 +97,22 @@ import net.sf.jabref.gui.undo.UndoableRemoveEntry;
 import net.sf.jabref.gui.util.FocusRequester;
 import net.sf.jabref.gui.util.component.CheckBoxMessage;
 import net.sf.jabref.gui.util.component.VerticalLabelUI;
+import net.sf.jabref.importer.ParserResult;
+import net.sf.jabref.importer.fileformat.BibtexParser;
+import net.sf.jabref.logic.TypedBibEntry;
+import net.sf.jabref.logic.autocompleter.AutoCompleter;
+import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.labelpattern.LabelPatternUtil;
+import net.sf.jabref.logic.search.SearchQueryHighlightListener;
+import net.sf.jabref.logic.util.date.TimeStamp;
+import net.sf.jabref.model.EntryTypes;
+import net.sf.jabref.model.database.BibDatabase;
+import net.sf.jabref.model.database.BibDatabaseMode;
+import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.model.entry.EntryConverter;
+import net.sf.jabref.model.entry.EntryType;
+import net.sf.jabref.specialfields.SpecialFieldUpdateListener;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -193,6 +230,9 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
         }
 
         updateAllFields();
+        if (this.fileListEditor != null){
+            this.fileListEditor.adjustColumnWidth();
+        }
     }
 
     private void setupFieldPanels() {

--- a/src/main/java/net/sf/jabref/gui/fieldeditors/FileListEditor.java
+++ b/src/main/java/net/sf/jabref/gui/fieldeditors/FileListEditor.java
@@ -17,6 +17,7 @@ package net.sf.jabref.gui.fieldeditors;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -43,22 +44,32 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.KeyStroke;
 import javax.swing.TransferHandler;
+import javax.swing.table.TableCellRenderer;
 
-import net.sf.jabref.*;
-import net.sf.jabref.external.*;
-
-import com.jgoodies.forms.builder.FormBuilder;
-import com.jgoodies.forms.layout.FormLayout;
-import net.sf.jabref.gui.*;
-import net.sf.jabref.gui.autocompleter.AutoCompleteListener;
+import net.sf.jabref.BibDatabaseContext;
+import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefExecutorService;
+import net.sf.jabref.external.DownloadExternalFile;
+import net.sf.jabref.external.ExternalFileType;
+import net.sf.jabref.external.ExternalFileTypes;
+import net.sf.jabref.external.MoveFileAction;
+import net.sf.jabref.gui.FileListEntry;
+import net.sf.jabref.gui.FileListEntryEditor;
+import net.sf.jabref.gui.FileListTableModel;
+import net.sf.jabref.gui.IconTheme;
+import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.actions.Actions;
+import net.sf.jabref.gui.autocompleter.AutoCompleteListener;
+import net.sf.jabref.gui.desktop.JabRefDesktop;
 import net.sf.jabref.gui.entryeditor.EntryEditor;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.gui.desktop.JabRefDesktop;
 import net.sf.jabref.model.entry.EntryUtil;
+
+import com.jgoodies.forms.builder.FormBuilder;
+import com.jgoodies.forms.layout.FormLayout;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -227,6 +238,19 @@ public class FileListEditor extends JTable implements FieldEditor, DownloadExter
                 }
             }
         });
+        adjustColumnWidth();
+    }
+
+    public void adjustColumnWidth() {
+        for (int column = 0; column < this.getColumnCount(); column++) {
+            int width = 0;
+            for (int row = 0; row < this.getRowCount(); row++) {
+                TableCellRenderer renderer = this.getCellRenderer(row, column);
+                Component comp = this.prepareRenderer(renderer, row, column);
+                width = Math.max(comp.getPreferredSize().width, width);
+            }
+            this.columnModel.getColumn(column).setPreferredWidth(width);
+        }
     }
 
     private void openSelectedFile() {
@@ -319,6 +343,7 @@ public class FileListEditor extends JTable implements FieldEditor, DownloadExter
             tableModel.addEntry(row, entry);
         }
         entryEditor.updateField(this);
+        adjustColumnWidth();
     }
 
     private void addEntry() {
@@ -338,6 +363,7 @@ public class FileListEditor extends JTable implements FieldEditor, DownloadExter
             }
         }
         entryEditor.updateField(this);
+        adjustColumnWidth();
     }
 
     private void moveEntry(int i) {
@@ -357,6 +383,7 @@ public class FileListEditor extends JTable implements FieldEditor, DownloadExter
         tableModel.addEntry(toIdx, entry);
         entryEditor.updateField(this);
         setRowSelectionInterval(toIdx, toIdx);
+        adjustColumnWidth();
     }
 
     /**
@@ -377,6 +404,7 @@ public class FileListEditor extends JTable implements FieldEditor, DownloadExter
             tableModel.fireTableDataChanged();
         }
         entryEditor.updateField(this);
+        adjustColumnWidth();
         return editor.okPressed();
     }
 
@@ -395,6 +423,7 @@ public class FileListEditor extends JTable implements FieldEditor, DownloadExter
 
                 if (e.getID() > 0) {
                     entryEditor.updateField(FileListEditor.this);
+                    adjustColumnWidth();
                     frame.output(Localization.lang("Finished automatically setting external links."));
                 } else {
                     frame.output(Localization.lang("Finished automatically setting external links.")
@@ -445,6 +474,7 @@ public class FileListEditor extends JTable implements FieldEditor, DownloadExter
     public void downloadComplete(FileListEntry file) {
         tableModel.addEntry(tableModel.getRowCount(), file);
         entryEditor.updateField(this);
+        adjustColumnWidth();
     }
 
 


### PR DESCRIPTION
Fixes #672.
The FileList (within the EntryEditor) now automatically resizes its Columns dependent on the length of its content.

![java 2016-04-03 12-13-50-65](https://cloud.githubusercontent.com/assets/15333371/14231930/de478ace-f995-11e5-8ef7-3efff0f97eb4.jpg)


- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [X] Screenshots added (for bigger UI changes)

