### PR TITLE
Fix open folder action in Windows not working correctly...

### DIFF
--- a/src/main/java/net/sf/jabref/gui/desktop/JabRefDesktop.java
+++ b/src/main/java/net/sf/jabref/gui/desktop/JabRefDesktop.java
@@ -33,21 +33,17 @@ import java.util.regex.Pattern;
  * http://stackoverflow.com/questions/18004150/desktop-api-is-not-supported-on-the-current-platform
  */
 public class JabRefDesktop {
-    private static final NativeDesktop ND_LINUX = new Linux();
-    private static final NativeDesktop ND_WINDOWS = new Windows();
-    private static final NativeDesktop ND_MAC = new OSX();
-    private static final NativeDesktop ND_DEFAULT = new DefaultDesktop();
+
     private static final NativeDesktop NATIVE_DESKTOP = getNativeDesktop();
-
     private static final Log LOGGER = LogFactory.getLog(JabRefDesktop.class);
-
     private static final Pattern REMOTE_LINK_PATTERN = Pattern.compile("[a-z]+://.*");
+
 
     /**
      * Open a http/pdf/ps viewer for the given link string.
      */
-    public static void openExternalViewer(BibDatabaseContext databaseContext, String initialLink, String initialFieldName)
-            throws IOException {
+    public static void openExternalViewer(BibDatabaseContext databaseContext, String initialLink,
+            String initialFieldName) throws IOException {
         String link = initialLink;
         String fieldName = initialFieldName;
         if ("ps".equals(fieldName) || "pdf".equals(fieldName)) {
@@ -74,7 +70,7 @@ public class JabRefDesktop {
             }
         } else if ("doi".equals(fieldName)) {
             Optional<DOI> doiUrl = DOI.build(link);
-            if(doiUrl.isPresent()) {
+            if (doiUrl.isPresent()) {
                 link = doiUrl.get().getURLAsASCIIString();
             }
             // should be opened in browser
@@ -171,20 +167,20 @@ public class JabRefDesktop {
 
         String cancelMessage = Localization.lang("Unable to open file.");
         String[] options = new String[] {Localization.lang("Define '%0'", fileType.getName()),
-                Localization.lang("Change file type"),
-                Localization.lang("Cancel")};
+                Localization.lang("Change file type"), Localization.lang("Cancel")};
         String defOption = options[0];
-        int answer = JOptionPane.showOptionDialog(frame, Localization.lang("This external link is of the type '%0', which is undefined. What do you want to do?",
+        int answer = JOptionPane.showOptionDialog(frame,
+                Localization.lang("This external link is of the type '%0', which is undefined. What do you want to do?",
                         fileType.getName()),
                 Localization.lang("Undefined file type"), JOptionPane.YES_NO_CANCEL_OPTION,
                 JOptionPane.QUESTION_MESSAGE, null, options, defOption);
         if (answer == JOptionPane.CANCEL_OPTION) {
             frame.output(cancelMessage);
             return false;
-        }
-        else if (answer == JOptionPane.YES_OPTION) {
+        } else if (answer == JOptionPane.YES_OPTION) {
             // User wants to define the new file type. Show the dialog:
-            ExternalFileType newType = new ExternalFileType(fileType.getName(), "", "", "", "new", IconTheme.JabRefIcon.FILE.getSmallIcon());
+            ExternalFileType newType = new ExternalFileType(fileType.getName(), "", "", "", "new",
+                    IconTheme.JabRefIcon.FILE.getSmallIcon());
             ExternalFileTypeEntryEditor editor = new ExternalFileTypeEntryEditor(frame, newType);
             editor.setVisible(true);
             if (editor.okPressed()) {
@@ -226,8 +222,7 @@ public class JabRefDesktop {
             if (editor.okPressed()) {
                 // Store the changes and add an undo edit:
                 String newValue = tModel.getStringRepresentation();
-                UndoableFieldChange ce = new UndoableFieldChange(entry, Globals.FILE_FIELD,
-                        oldValue, newValue);
+                UndoableFieldChange ce = new UndoableFieldChange(entry, Globals.FILE_FIELD, oldValue, newValue);
                 entry.setField(Globals.FILE_FIELD, newValue);
                 frame.getCurrentBasePanel().undoManager.addEdit(ce);
                 frame.getCurrentBasePanel().markBaseChanged();
@@ -266,20 +261,19 @@ public class JabRefDesktop {
             return;
         }
 
-        String absolutePath = file.getAbsolutePath();
-        absolutePath = absolutePath.substring(0, absolutePath.lastIndexOf(File.separator) + 1);
+        String absolutePath = file.toPath().toAbsolutePath().getParent().toString();
         NATIVE_DESKTOP.openConsole(absolutePath);
     }
 
     // TODO: Move to OS.java
     public static NativeDesktop getNativeDesktop() {
-        if(OS.WINDOWS) {
-            return ND_WINDOWS;
-        } else if(OS.OS_X) {
-            return ND_MAC;
-        } else if(OS.LINUX) {
-            return ND_LINUX;
+        if (OS.WINDOWS) {
+            return new Windows();
+        } else if (OS.OS_X) {
+            return new OSX();
+        } else if (OS.LINUX) {
+            return new Linux();
         }
-        return ND_DEFAULT;
+        return new DefaultDesktop();
     }
 }

--- a/src/main/java/net/sf/jabref/gui/desktop/os/DefaultDesktop.java
+++ b/src/main/java/net/sf/jabref/gui/desktop/os/DefaultDesktop.java
@@ -6,6 +6,7 @@ import org.apache.commons.logging.LogFactory;
 import java.awt.*;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 
 public class DefaultDesktop implements NativeDesktop {
     private static final Log LOGGER = LogFactory.getLog(NativeDesktop.class);
@@ -22,8 +23,8 @@ public class DefaultDesktop implements NativeDesktop {
 
     @Override
     public void openFolderAndSelectFile(String filePath) throws IOException {
-        File file = new File(filePath);
-        Desktop.getDesktop().open(file.getParentFile());
+        File file = Paths.get(filePath).toAbsolutePath().getParent().toFile();
+        Desktop.getDesktop().open(file);
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/gui/desktop/os/Linux.java
+++ b/src/main/java/net/sf/jabref/gui/desktop/os/Linux.java
@@ -7,6 +7,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.file.Paths;
 import java.util.Optional;
 
 public class Linux implements NativeDesktop {
@@ -51,7 +52,7 @@ public class Linux implements NativeDesktop {
         } else if (desktopSession.contains("kde")) {
             cmd = "dolphin --select " + filePath;
         } else {
-            cmd = "xdg-open " + filePath.substring(0, filePath.lastIndexOf(File.separator));
+            cmd = "xdg-open " + Paths.get(filePath).toAbsolutePath().getParent().toString();
         }
 
         Runtime.getRuntime().exec(cmd);

--- a/src/main/java/net/sf/jabref/gui/desktop/os/OSX.java
+++ b/src/main/java/net/sf/jabref/gui/desktop/os/OSX.java
@@ -9,13 +9,14 @@ import java.io.IOException;
 import java.util.Optional;
 
 public class OSX implements NativeDesktop {
+
     @Override
     public void openFile(String filePath, String fileType) throws IOException {
         Optional<ExternalFileType> type = ExternalFileTypes.getInstance().getExternalFileTypeByExt(fileType);
         if (type.isPresent() && !type.get().getOpenWithApplication().isEmpty()) {
             openFileWithApplication(filePath, type.get().getOpenWithApplication());
         } else {
-            String[] cmd = { "/usr/bin/open", filePath };
+            String[] cmd = {"/usr/bin/open", filePath};
             Runtime.getRuntime().exec(cmd);
         }
     }
@@ -23,9 +24,8 @@ public class OSX implements NativeDesktop {
     @Override
     public void openFileWithApplication(String filePath, String application) throws IOException {
         // Use "-a <application>" if the app is specified, and just "open <filename>" otherwise:
-        String[] cmd = (application != null) && !application.isEmpty() ?
-                new String[] {"/usr/bin/open", "-a", application, filePath} :
-                new String[] {"/usr/bin/open", filePath};
+        String[] cmd = (application != null) && !application.isEmpty() ? new String[] {"/usr/bin/open", "-a",
+                application, filePath} : new String[] {"/usr/bin/open", filePath};
         Runtime.getRuntime().exec(cmd);
     }
 
@@ -37,8 +37,7 @@ public class OSX implements NativeDesktop {
 
     @Override
     public void openConsole(String absolutePath) throws IOException {
-        Runtime runtime = Runtime.getRuntime();
-        runtime.exec("open -a Terminal " + absolutePath, null, new File(absolutePath));
+        Runtime.getRuntime().exec("open -a Terminal " + absolutePath, null, new File(absolutePath));
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/gui/desktop/os/Windows.java
+++ b/src/main/java/net/sf/jabref/gui/desktop/os/Windows.java
@@ -3,24 +3,39 @@ package net.sf.jabref.gui.desktop.os;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.Optional;
+
+import net.sf.jabref.external.ExternalFileType;
+import net.sf.jabref.external.ExternalFileTypes;
 
 public class Windows implements NativeDesktop {
+
+    private static String DEFAULT_EXECUTABLE_EXTENSION = ".exe";
+
+
+    @Override
+    public void openFile(String filePath, String fileType) throws IOException {
+        Optional<ExternalFileType> type = ExternalFileTypes.getInstance().getExternalFileTypeByExt(fileType);
+        if (type.isPresent() && !type.get().getOpenWithApplication().isEmpty()) {
+            openFileWithApplication(filePath, type.get().getOpenWithApplication());
+        } else {
+            //filePath as string, because it could be an URL
+            Runtime.getRuntime().exec(new String[] {"explorer.exe", filePath});
+        }
+
+    }
+
     @Override
     public String detectProgramPath(String programName, String directoryName) {
+
         String progFiles = System.getenv("ProgramFiles(x86)");
         if (progFiles == null) {
             progFiles = System.getenv("ProgramFiles");
         }
         if ((directoryName != null) && !directoryName.isEmpty()) {
-            return progFiles + "\\" + directoryName + "\\" + programName + ".exe";
+            return Paths.get(progFiles, directoryName, programName, DEFAULT_EXECUTABLE_EXTENSION).toString();
         }
-        return progFiles + "\\" + programName + ".exe";
-    }
-
-    @Override
-    public void openFile(String filePath, String fileType) throws IOException {
-        // escape & and spaces
-        Runtime.getRuntime().exec("cmd.exe /c start " + filePath.replace("&", "\"&\"").replace(" ", "\" \""));
+        return Paths.get(progFiles, programName, DEFAULT_EXECUTABLE_EXTENSION).toString();
     }
 
     @Override
@@ -30,16 +45,16 @@ public class Windows implements NativeDesktop {
 
     @Override
     public void openFolderAndSelectFile(String filePath) throws IOException {
-        String escapedLink = filePath.replace("&", "\"&\"");
-
-        String cmd = "explorer.exe /select,\"" + escapedLink + "\"";
-
-        Runtime.getRuntime().exec(cmd);
+        String cmd = "explorer.exe";
+        String arg = "/select,";
+        String[] commandWithArgs = {cmd, arg, filePath};
+        //Array variant, because otherwise the Tokenizer, which is internally run, kills the whitespaces in the path
+        Runtime.getRuntime().exec(commandWithArgs);
     }
 
     @Override
     public void openConsole(String absolutePath) throws IOException {
-        Runtime runtime = Runtime.getRuntime();
-        runtime.exec("cmd.exe /c start", null, new File(absolutePath));
+
+        Runtime.getRuntime().exec("cmd.exe /c start", null, new File(absolutePath));
     }
 }


### PR DESCRIPTION
when direcory path contained whitespaces
Use Path-class and methods
"& Symbol" does not cause problems on Windows
Use Path.getParent instead of ugly substring-hack

- [X] Change in CHANGELOG.md described

