### PR TITLE
Add benchmarks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ plugins {
     id "com.github.youribonnaffe.gradle.format" version "1.3"
     id "com.coverity.ondemand" version "1.5.61"
     id "net.ltgt.errorprone" version "0.0.8"
+    id 'me.champeau.gradle.jmh' version '0.3.0'
 }
 
 apply plugin: "java"
@@ -27,6 +28,7 @@ apply plugin: "project-report"
 apply plugin: 'jacoco'
 apply plugin: 'com.github.kt3k.coveralls'
 apply plugin: 'install4j'
+apply plugin: 'me.champeau.gradle.jmh'
 
 apply from: 'eclipse.gradle'
 

--- a/build.gradle
+++ b/build.gradle
@@ -367,5 +367,4 @@ jmh {
     warmupIterations = 5
     iterations = 10
     fork = 2
-    benchmarkMode = 'avgt'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -363,3 +363,9 @@ task getdeps(type: Copy) {
     into 'build/tmp/alldeps/'
 }
 
+jmh {
+    warmupIterations = 5
+    iterations = 10
+    fork = 2
+    benchmarkMode = 'avgt'
+}

--- a/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
+++ b/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
@@ -16,6 +16,8 @@ import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.logic.search.SearchQuery;
 import net.sf.jabref.model.database.BibDatabase;
+import net.sf.jabref.model.database.BibDatabaseMode;
+import net.sf.jabref.model.database.BibDatabaseModeDetection;
 import net.sf.jabref.model.entry.BibEntry;
 import org.openjdk.jmh.Main;
 import org.openjdk.jmh.annotations.*;
@@ -23,6 +25,7 @@ import org.openjdk.jmh.runner.RunnerException;
 
 @State(Scope.Thread)
 public class Benchmarks {
+
     StringReader bibtexStringReader;
     BibDatabase database = new BibDatabase();
 
@@ -31,8 +34,7 @@ public class Benchmarks {
         Globals.prefs = JabRefPreferences.getInstance();
 
         Random randomizer = new Random();
-        for(int i = 0; i < 10000; i++)
-        {
+        for (int i = 0; i < 1000; i++) {
             BibEntry entry = new BibEntry();
             entry.setCiteKey("id" + i);
             entry.setField("title", "This is my title " + i);
@@ -45,9 +47,9 @@ public class Benchmarks {
         BibDatabaseWriter databaseWriter = new BibDatabaseWriter();
         StringWriter stringWriter = new StringWriter();
 
-        //databaseWriter.writePartOfDatabase(stringWriter,
-        //        new BibDatabaseContext(database, new MetaData(), new Defaults()), database.getEntries(),
-        //        new SavePreferences());
+        databaseWriter.writePartOfDatabase(stringWriter,
+                new BibDatabaseContext(database, new MetaData(), new Defaults()), database.getEntries(),
+                new SavePreferences());
         String bibtexString = stringWriter.toString();
         bibtexStringReader = new StringReader(bibtexString);
     }
@@ -76,6 +78,11 @@ public class Benchmarks {
         List<BibEntry> matchedEntries = new ArrayList<>();
         matchedEntries.addAll(database.getEntries().stream().filter(searchQuery::isMatch).collect(Collectors.toList()));
         return matchedEntries;
+    }
+
+    @Benchmark
+    public BibDatabaseMode inferBibDatabaseMode() {
+        return BibDatabaseModeDetection.inferMode(database);
     }
 
     public static void main(String[] args) throws IOException, RunnerException {

--- a/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
+++ b/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
@@ -1,0 +1,38 @@
+package net.sf.jabref.benchmarks;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Thread)
+public class Benchmarks {
+    int x = 1;
+    int y = 2;
+
+    @Benchmark
+    public int measureAdd() {
+        return (x + y);
+    }
+
+    @Benchmark
+    public int measureMul() {
+        return (x * y);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(".*" + Benchmarks.class.getSimpleName() + ".*")
+                .warmupIterations(5)
+                .measurementIterations(5)
+                .forks(1)
+                .build();
+
+        new Runner(opt).run();
+    }
+
+
+}

--- a/src/main/java/net/sf/jabref/BibDatabaseContext.java
+++ b/src/main/java/net/sf/jabref/BibDatabaseContext.java
@@ -1,13 +1,12 @@
 package net.sf.jabref;
 
+import java.io.File;
+import java.util.Objects;
+import java.util.Optional;
+
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.database.BibDatabaseModeDetection;
-
-import java.io.File;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 
 /**
  * Represents everything related to a .bib file.

--- a/src/main/java/net/sf/jabref/model/database/BibDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabase.java
@@ -29,15 +29,12 @@ Modified for use in JabRef
  */
 package net.sf.jabref.model.database;
 
-import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.model.entry.BibtexString;
-import net.sf.jabref.model.entry.EntryUtil;
-import net.sf.jabref.model.entry.MonthUtil;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+
+import net.sf.jabref.model.entry.*;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * A bibliography database.
@@ -66,10 +63,6 @@ public class BibDatabase {
      * Behavior
      */
     private final Set<DatabaseChangeListener> changeListeners = new HashSet<>();
-
-    public BibDatabaseMode getBibType() {
-        return BibDatabaseModeDetection.inferMode(this);
-    }
 
     /**
      * Returns the number of entries.


### PR DESCRIPTION
This PR adds some basic benchmarks for parsing and writing a bib file. The results are as following for a database consisting of 1000 entries.
Benchmark                         Score     Error  Units
Benchmarks.parse                 49736.582 ± 788.879  ops/s
Benchmarks.write                0.706 ±   0.012  ops/s
Benchmarks.search                258.838 ±   5.604  ops/s
Benchmarks.inferBibDatabaseMode  1297.622 ±  22.910  ops/s

As one can see the parse operation is by many orders of magnitudes quicker then writing. I had a closer look at the write operation and it turned out that 66% of the time is spent in Database.getMode(). Some small changes improved the situation by a factor of 10
Benchmark                         Score      Error  Units
Benchmarks.parse                42031.971 ± 8188.833  ops/s
Benchmarks.write                 8.299 ±    0.304  ops/s
Benchmarks.search               248.093 ±    7.573  ops/s
Benchmarks.inferBibDatabaseMode  20759.711 ±  397.031  ops/s

I suspect the changes in #1100 improve the situation even more (since there the database mode is cached).

(By the way, `gradle jmh` runs the benchmarks. So its pretty simple to use.)


- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)

