### PR TITLE
Added FormatChars LayoutFormatter back again (to be merged before 3.3 unless someone else solves it in a proper way)

### DIFF
--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableColumn.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableColumn.java
@@ -2,8 +2,7 @@ package net.sf.jabref.gui.maintable;
 
 import net.sf.jabref.bibtex.BibtexSingleFieldProperties;
 import net.sf.jabref.bibtex.InternalBibtexFields;
-import net.sf.jabref.logic.layout.LayoutFormatter;
-import net.sf.jabref.logic.layout.format.LatexToUnicodeFormatter;
+import net.sf.jabref.logic.formatter.bibtexfields.LatexToUnicodeFormatter;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.EntryUtil;
@@ -22,7 +21,7 @@ public class MainTableColumn {
 
     private final Optional<BibDatabase> database;
 
-    private final LayoutFormatter toUnicode = new LatexToUnicodeFormatter();
+    private final LatexToUnicodeFormatter toUnicode = new LatexToUnicodeFormatter();
 
     public MainTableColumn(String columnName) {
         this.columnName = columnName;

--- a/src/main/java/net/sf/jabref/logic/formatter/BibtexFieldFormatters.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/BibtexFieldFormatters.java
@@ -1,7 +1,6 @@
 package net.sf.jabref.logic.formatter;
 
 import net.sf.jabref.logic.formatter.bibtexfields.*;
-import net.sf.jabref.logic.layout.format.LatexToUnicodeFormatter;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/LatexToUnicodeFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/LatexToUnicodeFormatter.java
@@ -13,13 +13,12 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-package net.sf.jabref.logic.layout.format;
+package net.sf.jabref.logic.formatter.bibtexfields;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.logic.formatter.Formatter;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.strings.StringUtil;
-import net.sf.jabref.logic.layout.LayoutFormatter;
 import net.sf.jabref.logic.util.strings.HTMLUnicodeConversionMaps;
 
 import java.util.Map;
@@ -28,7 +27,7 @@ import java.util.Map;
  * This formatter converts LaTeX character sequences their equivalent unicode characters,
  * and removes other LaTeX commands without handling them.
  */
-public class LatexToUnicodeFormatter implements LayoutFormatter, Formatter {
+public class LatexToUnicodeFormatter implements Formatter {
 
     private static final Map<String, String> CHARS = HTMLUnicodeConversionMaps.LATEX_UNICODE_CONVERSION_MAP;
 

--- a/src/main/java/net/sf/jabref/logic/layout/format/FormatChars.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/FormatChars.java
@@ -1,0 +1,34 @@
+/*  Copyright (C) 2003-2016 JabRef contributors.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+package net.sf.jabref.logic.layout.format;
+
+import net.sf.jabref.logic.formatter.Formatter;
+import net.sf.jabref.logic.formatter.bibtexfields.LatexToUnicodeFormatter;
+import net.sf.jabref.logic.layout.LayoutFormatter;
+
+/**
+ * Formatter that outputs a sequence number for the current entry. The sequence number is
+ * tied to the entry's position in the order, not to the number of calls to this formatter.
+ */
+public class FormatChars implements LayoutFormatter {
+
+    private static final Formatter formatter = new LatexToUnicodeFormatter();
+
+    @Override
+    public String format(String fieldText) {
+        return formatter.format(fieldText);
+    }
+}

--- a/src/test/java/net/sf/jabref/logic/formatter/FormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/FormatterTest.java
@@ -5,7 +5,7 @@ import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.formatter.bibtexfields.*;
 import net.sf.jabref.logic.formatter.casechanger.*;
 import net.sf.jabref.logic.formatter.minifier.MinifyNameListFormatter;
-import net.sf.jabref.logic.layout.format.LatexToUnicodeFormatter;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/net/sf/jabref/logic/layout/format/FormatCharsTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/format/FormatCharsTest.java
@@ -29,10 +29,11 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 
+import net.sf.jabref.logic.formatter.bibtexfields.LatexToUnicodeFormatter;
 import net.sf.jabref.logic.layout.LayoutFormatter;
 
 
-public class LatexToUnicodeFormatterTest {
+public class FormatCharsTest {
 
     @Test
     public void testPlainFormat() {
@@ -52,7 +53,7 @@ public class LatexToUnicodeFormatterTest {
 
     @Test
     public void testEquations() {
-        LayoutFormatter layout = new LatexToUnicodeFormatter();
+        LayoutFormatter layout = new FormatChars();
 
         assertEquals("$", layout.format("\\$"));
         assertEquals("σ", layout.format("$\\sigma$"));


### PR DESCRIPTION
Just to make sure that we do not release 3.3 with non-working export formats...

Also moves LatexToUnicodeFormatter to its proper place.