### PR TITLE
Some performance improvements

### DIFF
--- a/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
+++ b/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
@@ -34,7 +34,7 @@ public class Benchmarks {
         Globals.prefs = JabRefPreferences.getInstance();
 
         Random randomizer = new Random();
-        for (int i = 0; i < 100000; i++) {
+        for (int i = 0; i < 1000; i++) {
             BibEntry entry = new BibEntry();
             entry.setCiteKey("id" + i);
             entry.setField("title", "This is my title " + i);

--- a/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
+++ b/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
@@ -26,7 +26,7 @@ import org.openjdk.jmh.runner.RunnerException;
 @State(Scope.Thread)
 public class Benchmarks {
 
-    StringReader bibtexStringReader;
+    String bibtexString;
     BibDatabase database = new BibDatabase();
 
     @Setup
@@ -34,7 +34,7 @@ public class Benchmarks {
         Globals.prefs = JabRefPreferences.getInstance();
 
         Random randomizer = new Random();
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 100000; i++) {
             BibEntry entry = new BibEntry();
             entry.setCiteKey("id" + i);
             entry.setField("title", "This is my title " + i);
@@ -50,12 +50,13 @@ public class Benchmarks {
         databaseWriter.writePartOfDatabase(stringWriter,
                 new BibDatabaseContext(database, new MetaData(), new Defaults()), database.getEntries(),
                 new SavePreferences());
-        String bibtexString = stringWriter.toString();
-        bibtexStringReader = new StringReader(bibtexString);
+        bibtexString = stringWriter.toString();
+
     }
 
     @Benchmark
     public ParserResult parse() throws IOException {
+        StringReader bibtexStringReader = new StringReader(bibtexString);
         BibtexParser parser = new BibtexParser(bibtexStringReader);
         return parser.parse();
     }

--- a/src/main/java/net/sf/jabref/exporter/LatexFieldFormatter.java
+++ b/src/main/java/net/sf/jabref/exporter/LatexFieldFormatter.java
@@ -15,14 +15,15 @@
 */
 package net.sf.jabref.exporter;
 
-import net.sf.jabref.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.bibtex.InternalBibtexFields;
 import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.importer.fileformat.FieldContentParser;
 import net.sf.jabref.logic.util.strings.StringUtil;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Currently the only implementation of net.sf.jabref.exporter.FieldFormatter
@@ -171,7 +172,7 @@ public class LatexFieldFormatter {
             }
         }
 
-        return parser.format(stringBuilder.toString(), fieldName);
+        return parser.format(stringBuilder, fieldName);
     }
 
     private boolean shouldResolveStrings(String fieldName) {

--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
@@ -299,17 +299,12 @@ public class BibtexParser {
      * @return the text read so far
      */
     private String dumpTextReadSoFarToString() {
-        StringBuilder entry = new StringBuilder();
-        while (!pureTextFromFile.isEmpty()) {
-            entry.append(pureTextFromFile.pollFirst());
-        }
-
-        String result = entry.toString();
-        int indexOfAt = entry.indexOf("@");
+        String result = getPureTextFromFile();
+        int indexOfAt = result.indexOf("@");
 
         // if there is no entry found, simply return the content (necessary to parse text remaining after the last entry)
         if (indexOfAt == -1) {
-            return purgeEOFCharacters(entry);
+            return purgeEOFCharacters(result);
         } else {
 
             //skip all text except newlines and whitespaces before first @. This is necessary to remove the file header
@@ -332,10 +327,17 @@ public class BibtexParser {
                 }
             }
 
-            result = result.substring(runningIndex + 1);
-
-            return result;
+            return result.substring(runningIndex + 1);
         }
+    }
+
+    private String getPureTextFromFile() {
+        StringBuilder entry = new StringBuilder();
+        while (!pureTextFromFile.isEmpty()) {
+            entry.append(pureTextFromFile.pollFirst());
+        }
+
+        return entry.toString();
     }
 
     /**
@@ -343,10 +345,10 @@ public class BibtexParser {
      *
      * @return a String without eof characters
      */
-    private String purgeEOFCharacters(StringBuilder input) {
+    private String purgeEOFCharacters(String input) {
 
         StringBuilder remainingText = new StringBuilder();
-        for (Character character : input.toString().toCharArray()) {
+        for (Character character : input.toCharArray()) {
             if (!(isEOFCharacter(character))) {
                 remainingText.append(character);
             }
@@ -441,7 +443,7 @@ public class BibtexParser {
         int character = pushbackReader.read();
 
         if(! isEOFCharacter(character)) {
-            pureTextFromFile.offerLast(Character.valueOf((char) character));
+            pureTextFromFile.offerLast((char) character);
         }
         if (character == '\n') {
             line++;
@@ -454,7 +456,7 @@ public class BibtexParser {
             line--;
         }
         pushbackReader.unread(character);
-        if(pureTextFromFile.getLast().charValue() == character) {
+        if(pureTextFromFile.getLast() == character) {
             pureTextFromFile.pollLast();
         }
     }

--- a/src/main/java/net/sf/jabref/importer/fileformat/FieldContentParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/FieldContentParser.java
@@ -15,12 +15,13 @@
 */
 package net.sf.jabref.importer.fileformat;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.regex.Pattern;
+
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.util.strings.StringUtil;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * This class provides the reformatting needed when reading BibTeX fields formatted
@@ -28,10 +29,13 @@ import java.util.List;
  * writing the same fields.
  */
 public class FieldContentParser {
-    private final List<String> multiLineFields;
+    private final HashSet<String> multiLineFields;
+
+    // 's' matches a space, tab, new line, carriage return.
+    private static final Pattern WHITESPACE = Pattern.compile("\\s+");
 
     public FieldContentParser() {
-        multiLineFields = new ArrayList<>();
+        multiLineFields = new HashSet<>();
         // the following two are also coded in net.sf.jabref.exporter.LatexFieldFormatter.format(String, String)
         multiLineFields.add("abstract");
         multiLineFields.add("review");
@@ -43,27 +47,21 @@ public class FieldContentParser {
     /**
      * Performs the reformatting
      *
-     * @param text2     StringBuffer containing the field to format. bibtexField contains field name according to field
-     * @param bibtexField
-     * @return The formatted field content. The StringBuffer returned may or may not be the same as the argument given.
+     * @param fieldContent the content to format
+     * @param bibtexField the name of the bibtex field
+     * @return the formatted field content.
      */
-    public StringBuilder format(StringBuilder text2, String bibtexField) {
+    public String format(String fieldContent, String bibtexField) {
 
-        // Unify line breaks
-        String text = StringUtil.unifyLineBreaksToConfiguredLineBreaks(text2.toString());
-
-        // Do not format multiline fields
         if (multiLineFields.contains(bibtexField)) {
-            return new StringBuilder(text);
+            // Unify line breaks
+            return StringUtil.unifyLineBreaksToConfiguredLineBreaks(fieldContent);
         }
 
-        // 's' matches a space, tab, new line, carriage return.
-        text = text.replaceAll("\\s+", " ");
-
-        return new StringBuilder(text);
+        return WHITESPACE.matcher(fieldContent).replaceAll(" ");
     }
 
-    public String format(String content, String bibtexField) {
-        return format(new StringBuilder(content), bibtexField).toString();
+    public String format(StringBuilder fieldContent, String bibtexField) {
+        return format(fieldContent.toString(), bibtexField);
     }
 }

--- a/src/main/java/net/sf/jabref/logic/search/rules/ContainBasedSearchRule.java
+++ b/src/main/java/net/sf/jabref/logic/search/rules/ContainBasedSearchRule.java
@@ -15,6 +15,7 @@
 */
 package net.sf.jabref.logic.search.rules;
 
+import java.util.Iterator;
 import java.util.List;
 
 import net.sf.jabref.logic.layout.format.RemoveLatexCommands;
@@ -50,35 +51,28 @@ public class ContainBasedSearchRule implements SearchRule {
             searchString = searchString.toLowerCase();
         }
 
-        List<String> words = new SentenceAnalyzer(searchString).getWords();
+        List<String> unmatchedWords = new SentenceAnalyzer(searchString).getWords();
 
-        // We need match for all words:
-        boolean[] matchFound = new boolean[words.size()];
+        for (String fieldContent : bibEntry.getFieldValues()) {
+            String formattedFieldContent = ContainBasedSearchRule.REMOVE_LATEX_COMMANDS.format(fieldContent);
+            if (!caseSensitive) {
+                formattedFieldContent = formattedFieldContent.toLowerCase();
+            }
 
-        for (String field : bibEntry.getFieldNames()) {
-            if (bibEntry.hasField(field)) {
-                String fieldContent = ContainBasedSearchRule.REMOVE_LATEX_COMMANDS.format(bibEntry.getField(field));
-                if (!caseSensitive) {
-                    fieldContent = fieldContent.toLowerCase();
-                }
-
-                int index = 0;
-                // Check if we have a match for each of the query words, ignoring
-                // those words for which we already have a match:
-                for (String word : words) {
-                    matchFound[index] = matchFound[index] || fieldContent.contains(word);
-
-                    index++;
+            Iterator<String> unmatchedWordsIterator = unmatchedWords.iterator();
+            while (unmatchedWordsIterator.hasNext()) {
+                String word = unmatchedWordsIterator.next();
+                if(formattedFieldContent.contains(word)) {
+                    unmatchedWordsIterator.remove();
                 }
             }
 
-        }
-        for (boolean aMatchFound : matchFound) {
-            if (!aMatchFound) {
-                return false; // Didn't match all words.
+            if(unmatchedWords.isEmpty()) {
+                return true;
             }
         }
-        return true; // Matched all words.
+
+        return false; // Didn't match all words.
     }
 
 }

--- a/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
@@ -15,15 +15,12 @@
  */
 package net.sf.jabref.logic.util.strings;
 
-import net.sf.jabref.Globals;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.StringTokenizer;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.common.base.CharMatcher;
+import net.sf.jabref.Globals;
 
 public class StringUtil {
 

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -24,16 +24,7 @@ import java.text.FieldPosition;
 import java.text.ParseException;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -601,5 +592,9 @@ public class BibEntry {
 
     public List<String> getSeparatedKeywords() {
         return net.sf.jabref.model.entry.EntryUtil.getSeparatedKeywords(this.getField("keywords"));
+    }
+
+    public Collection<String> getFieldValues() {
+        return fields.values();
     }
 }


### PR DESCRIPTION
Motivated by the nice blog post from @mlep, I tried to further improve the performance.

Starting point

Benchmark                         Score      Error  Units
Benchmarks.parse                 30        ± 2.7  ops/s
Benchmarks.search                230.359 ±   27.399  ops/s
Benchmarks.write                 53.323 ±    5.528  ops/s

Now with this PR
Benchmark                         Score     Error  Units
Benchmarks.parse                 46.965 ±   0.608  ops/s
Benchmarks.search                304.795 ±   5.905  ops/s
Benchmarks.write                 85.171 ±   1.301  ops/s

For further improvements on should have a closer look at the formatter:
- RemoveLatexCommands for search (70% of time is spent there)
- FieldContentParser and LatexFieldFormatter for write (also >50%)

(also fixed a bug in the parse benchmark...this is why the numbers are so different than in my previous post)

--

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
