### PR TITLE
Add missing german Translation

### DIFF
--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2336,10 +2336,10 @@ Identity=Identität
 Clears_the_field_completely.=Löscht_das_Feld_komplett
 
 
-Main_file_directory_not_set\!=
+Main_file_directory_not_set\!=Hauptverzeichnis_nicht_gesetzt\!
 
-This_operation_requires_exactly_one_item_to_be_selected.=
+This_operation_requires_exactly_one_item_to_be_selected.=Für_diesen_Vorgang_muss_genau_ein_Eintrag_ausgewählt_sein
 
-Directory_not_found=
+Directory_not_found=Verzeichnis_nicht_gefunden
 
-wrong_entry_type_as_proceedings_has_page_numbers=
+wrong_entry_type_as_proceedings_has_page_numbers=falscher_Eintragstyp,_weil_'Konferenzbericht'_Feld_mit_Seitenzahlen_hat


### PR DESCRIPTION
The only one I am not really sure about is the last one. It is from the integrity checker, if you have an "proceedings" entry with "pages" field instead of page-number 