### PR TITLE
Readd FormatChars support

### DIFF
--- a/src/main/java/net/sf/jabref/Globals.java
+++ b/src/main/java/net/sf/jabref/Globals.java
@@ -46,7 +46,6 @@ public class Globals {
 
     public static final ImportFormatReader IMPORT_FORMAT_READER = new ImportFormatReader();
 
-    public static final String FILETYPE_PREFS_EXT = "_dir";
     public static final String SELECTOR_META_PREFIX = "selector_";
     public static final String PROTECTED_FLAG_META = "protectedFlag";
     public static final String NONE = "_non__";

--- a/src/main/java/net/sf/jabref/gui/GUIGlobals.java
+++ b/src/main/java/net/sf/jabref/gui/GUIGlobals.java
@@ -79,8 +79,6 @@ public class GUIGlobals {
 
     public static final int MAX_BACK_HISTORY_SIZE = 10; // The maximum number of "Back" operations stored.
 
-    public static final double PE_HEIGHT = 2;
-
     //	Constants controlling formatted bibtex output.
     public static final int INDENT = 4;
     public static final int LINE_LENGTH = 65; // Maximum

--- a/src/main/java/net/sf/jabref/logic/layout/LayoutEntry.java
+++ b/src/main/java/net/sf/jabref/logic/layout/LayoutEntry.java
@@ -78,9 +78,7 @@ class LayoutEntry {
 
     public LayoutEntry(List<StringInt> parsedEntries, int layoutType, JournalAbbreviationRepository repository) {
         this.repository = repository;
-        List<StringInt> blockEntries = null;
         List<LayoutEntry> tmpEntries = new ArrayList<>();
-        LayoutEntry le;
         String blockStart = parsedEntries.get(0).s;
         String blockEnd = parsedEntries.get(parsedEntries.size() - 1).s;
 
@@ -90,6 +88,7 @@ class LayoutEntry {
 
         type = layoutType;
         text = blockEnd;
+        List<StringInt> blockEntries = null;
         for (StringInt parsedEntry : parsedEntries.subList(1, parsedEntries.size() - 1)) {
             switch (parsedEntry.i) {
             case LayoutHelper.IS_FIELD_START:
@@ -101,9 +100,9 @@ class LayoutEntry {
             case LayoutHelper.IS_GROUP_END:
                 if (blockStart.equals(parsedEntry.s)) {
                     blockEntries.add(parsedEntry);
-                    le = new LayoutEntry(blockEntries,
-                            parsedEntry.i == LayoutHelper.IS_GROUP_END ? LayoutHelper.IS_GROUP_START : LayoutHelper.IS_FIELD_START,
-                            repository);
+                    int groupType = parsedEntry.i == LayoutHelper.IS_GROUP_END ? LayoutHelper.IS_GROUP_START :
+                            LayoutHelper.IS_FIELD_START;
+                    LayoutEntry le = new LayoutEntry(blockEntries, groupType, repository);
                     tmpEntries.add(le);
                     blockEntries = null;
                 } else {
@@ -346,7 +345,7 @@ class LayoutEntry {
         } else {
             text = v.get(0).trim();
 
-            option = LayoutEntry.getOptionalLayout(v.get(1), repository);
+            option = getOptionalLayout(v.get(1));
             // See if there was an undefined formatter:
             for (LayoutFormatter anOption : option) {
                 if (anOption instanceof NotFoundFormatter) {
@@ -360,13 +359,8 @@ class LayoutEntry {
 
     }
 
-    private static LayoutFormatter getLayoutFormatterByName(String name, JournalAbbreviationRepository repository)
-            throws Exception {
-
-        if (name.isEmpty()) {
-            return null;
-        }
-
+    private LayoutFormatter getLayoutFormatterByName(String name) throws Exception {
+        
         switch (name) {
         case "HTMLToLatexFormatter": // For backward compatibility
         case "HtmlToLatex":
@@ -503,11 +497,9 @@ class LayoutEntry {
     /**
      * Return an array of LayoutFormatters found in the given formatterName
      * string (in order of appearance).
-     * @param repository
      *
      */
-    private static List<LayoutFormatter> getOptionalLayout(String formatterName,
-            JournalAbbreviationRepository repository) {
+    private List<LayoutFormatter> getOptionalLayout(String formatterName) {
 
         List<List<String>> formatterStrings = parseMethodsCalls(formatterName);
 
@@ -532,7 +524,7 @@ class LayoutEntry {
 
             // Try to load from formatters in formatter folder
             try {
-                LayoutFormatter f = LayoutEntry.getLayoutFormatterByName(className, repository);
+                LayoutFormatter f = getLayoutFormatterByName(className);
                 // If this formatter accepts an argument, check if we have one, and
                 // set it if so:
                 if ((f instanceof ParamLayoutFormatter) && (strings.size() >= 2)) {

--- a/src/main/java/net/sf/jabref/logic/layout/LayoutEntry.java
+++ b/src/main/java/net/sf/jabref/logic/layout/LayoutEntry.java
@@ -21,10 +21,12 @@ import java.util.*;
 import java.util.regex.Pattern;
 
 import net.sf.jabref.BibDatabaseContext;
+import net.sf.jabref.logic.formatter.bibtexfields.HtmlToLatexFormatter;
+import net.sf.jabref.logic.formatter.bibtexfields.UnicodeToLatexFormatter;
 import net.sf.jabref.logic.journals.JournalAbbreviationRepository;
-import net.sf.jabref.logic.layout.format.JournalAbbreviator;
-import net.sf.jabref.logic.layout.format.NameFormatter;
-import net.sf.jabref.logic.layout.format.NotFoundFormatter;
+import net.sf.jabref.logic.layout.format.*;
+import net.sf.jabref.logic.layout.format.Number;
+import net.sf.jabref.logic.openoffice.OOPreFormatter;
 import net.sf.jabref.logic.search.MatchesHighlighter;
 import net.sf.jabref.logic.util.strings.StringUtil;
 
@@ -282,7 +284,6 @@ class LayoutEntry {
         }
     }
 
-    // added section - begin (arudert)
     /**
      * Do layout for general formatters (no bibtex-entry fields).
      *
@@ -358,29 +359,144 @@ class LayoutEntry {
         }
 
     }
-    // added section - end (arudert)
 
-    private static LayoutFormatter getLayoutFormatterByClassName(String className,
-            JournalAbbreviationRepository repostiory)
+    private static LayoutFormatter getLayoutFormatterByName(String name, JournalAbbreviationRepository repository)
             throws Exception {
 
-        if (className.isEmpty()) {
+        if (name.isEmpty()) {
             return null;
         }
 
-        if ("JournalAbbreviator".equals(className)) {
-            return new JournalAbbreviator(repostiory);
-        }
-
-        try {
-            String prefix = "net.sf.jabref.logic.layout.format.";
-            return (LayoutFormatter) Class.forName(prefix + className).newInstance();
-        } catch (ClassNotFoundException ex) {
-            throw new Exception("Formatter not found: " + className);
-        } catch (InstantiationException ex) {
-            throw new Exception(className + " cannot be instantiated.");
-        } catch (IllegalAccessException ex) {
-            throw new Exception(className + " cannot be accessed.");
+        switch (name) {
+        case "HTMLToLatexFormatter": // For backward compatibility
+        case "HtmlToLatex":
+            return new HtmlToLatexFormatter();
+        case "UnicodeToLatexFormatter": // For backward compatibility
+        case "UnicodeToLatex":
+            return new UnicodeToLatexFormatter();
+        case "OOPreFormatter":
+            return new OOPreFormatter();
+        case "AuthorAbbreviator":
+            return new AuthorAbbreviator();
+        case "AuthorAndsCommaReplacer":
+            return new AuthorAndsCommaReplacer();
+        case "AuthorAndsReplacer":
+            return new AuthorAndsReplacer();
+        case "AuthorFirstAbbrLastCommas":
+            return new AuthorFirstAbbrLastCommas();
+        case "AuthorFirstAbbrLastOxfordCommas":
+            return new AuthorFirstAbbrLastOxfordCommas();
+        case "AuthorFirstFirst":
+            return new AuthorFirstFirst();
+        case "AuthorFirstFirstCommas":
+            return new AuthorFirstFirstCommas();
+        case "AuthorFirstLastCommas":
+            return new AuthorFirstLastCommas();
+        case "AuthorFirstLastOxfordCommas":
+            return new AuthorFirstLastOxfordCommas();
+        case "AuthorLastFirst":
+            return new AuthorLastFirst();
+        case "AuthorLastFirstAbbrCommas":
+            return new AuthorLastFirstAbbrCommas();
+        case "AuthorLastFirstAbbreviator":
+            return new AuthorLastFirstAbbreviator();
+        case "AuthorLastFirstAbbrOxfordCommas":
+            return new AuthorLastFirstAbbrOxfordCommas();
+        case "AuthorLastFirstCommas":
+            return new AuthorLastFirstCommas();
+        case "AuthorLastFirstOxfordCommas":
+            return new AuthorLastFirstOxfordCommas();
+        case "AuthorLF_FF":
+            return new AuthorLF_FF();
+        case "AuthorLF_FFAbbr":
+            return new AuthorLF_FFAbbr();
+        case "AuthorNatBib":
+            return new AuthorNatBib();
+        case "AuthorOrgSci":
+            return new AuthorOrgSci();
+        case "CompositeFormat":
+            return new CompositeFormat();
+        case "CreateBibORDFAuthors":
+            return new CreateBibORDFAuthors();
+        case "CreateDocBookAuthors":
+            return new CreateDocBookAuthors();
+        case "CurrentDate":
+            return new CurrentDate();
+        case "DOICheck":
+            return new DOICheck();
+        case "DOIStrip":
+            return new DOIStrip();
+        case "FirstPage":
+            return new FirstPage();
+        case "FormatPagesForHTML":
+            return new FormatPagesForHTML();
+        case "FormatPagesForXML":
+            return new FormatPagesForXML();
+        case "GetOpenOfficeType":
+            return new GetOpenOfficeType();
+        case "HTMLChars":
+            return new HTMLChars();
+        case "HTMLParagraphs":
+            return new HTMLParagraphs();
+        case "Iso690FormatDate":
+            return new Iso690FormatDate();
+        case "Iso690NamesAuthors":
+            return new Iso690NamesAuthors();
+        case "JournalAbbreviator":
+            return new JournalAbbreviator(repository);
+        case "LastPage":
+            return new LastPage();
+        case "FormatChars": // For backward compatibility
+        case "LatexToUnicode":
+            return new LatexToUnicodeFormatter();
+        case "NameFormatter":
+            return new NameFormatter();
+        case "NoSpaceBetweenAbbreviations":
+            return new NoSpaceBetweenAbbreviations();
+        case "Ordinal":
+            return new Ordinal();
+        case "RemoveBrackets":
+            return new RemoveBrackets();
+        case "RemoveBracketsAddComma":
+            return new RemoveBracketsAddComma();
+        case "RemoveLatexCommands":
+            return new RemoveLatexCommands();
+        case "RemoveTilde":
+            return new RemoveTilde();
+        case "RemoveWhitespace":
+            return new RemoveWhitespace();
+        case "RisKeywords":
+            return new RisKeywords();
+        case "RisMonth":
+            return new RisMonth();
+        case "RTFChars":
+            return new RTFChars();
+        case "ToLowerCase":
+            return new ToLowerCase();
+        case "ToUpperCase":
+            return new ToUpperCase();
+        case "XMLChars":
+            return new XMLChars();
+        case "Default":
+            return new Default();
+        case "FileLink":
+            return new FileLink();
+        case "Number":
+            return new Number();
+        case "RisAuthors":
+            return new RisAuthors();
+        case "Authors":
+            return new Authors();
+        case "IfPlural":
+            return new IfPlural();
+        case "Replace":
+            return new Replace();
+        case "WrapContent":
+            return new WrapContent();
+        case "WrapFileLinks":
+            return new WrapFileLinks();
+        default:
+            return new NotFoundFormatter(name);
         }
     }
 
@@ -416,7 +532,7 @@ class LayoutEntry {
 
             // Try to load from formatters in formatter folder
             try {
-                LayoutFormatter f = LayoutEntry.getLayoutFormatterByClassName(className, repository);
+                LayoutFormatter f = LayoutEntry.getLayoutFormatterByName(className, repository);
                 // If this formatter accepts an argument, check if we have one, and
                 // set it if so:
                 if ((f instanceof ParamLayoutFormatter) && (strings.size() >= 2)) {


### PR DESCRIPTION
Alternative to  #1114 to add backwards compatibility for FormatChars (and a few other renamed LayoutFormatters). The idea was to replace the reflection code by an (admittedly big) switch statement. In this way we gain some flexibility about the location and naming of LayoutFormatter classes.

By the way,  according to http://jabref.sourceforge.net/help/CustomExports.php all LayoutFormatters starting with "Author" are deprecated and are replaced by "Authors" since 2.7. Should we just delete them now?

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
