### PR TITLE
Replaced Map.get()  with containsKey() where appropriate

### DIFF
--- a/src/main/java/net/sf/jabref/external/RegExpFileSearch.java
+++ b/src/main/java/net/sf/jabref/external/RegExpFileSearch.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2016 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -54,10 +54,10 @@ public class RegExpFileSearch {
      * @param regExp The expression deciding which names are acceptable.
      * @return A map linking each given entry to a list of files matching the given criteria.
      */
-    public static Map<BibEntry, java.util.List<File>> findFilesForSet(Collection<BibEntry> entries,
+    public static Map<BibEntry, List<File>> findFilesForSet(Collection<BibEntry> entries,
             Collection<String> extensions, List<File> directories, String regExp) {
 
-        Map<BibEntry, java.util.List<File>> res = new HashMap<>();
+        Map<BibEntry, List<File>> res = new HashMap<>();
         for (BibEntry entry : entries) {
             res.put(entry, RegExpFileSearch.findFiles(entry, extensions, directories, regExp));
         }
@@ -83,7 +83,7 @@ public class RegExpFileSearch {
 
     /**
      * Searches the given directory and filename pattern for a file for the
-     * bibtex entry.
+     * BibTeX entry.
      *
      * Used to fix:
      *
@@ -99,7 +99,7 @@ public class RegExpFileSearch {
      * <ul>
      * <li>* Any subDir</li>
      * <li>** Any subDir (recursive)</li>
-     * <li>[key] Key from bibtex file and database</li>
+     * <li>[key] Key from BibTeX file and database</li>
      * <li>.* Anything else is taken to be a Regular expression.</li>
      * </ul>
      *
@@ -121,7 +121,7 @@ public class RegExpFileSearch {
      */
     private static List<File> findFile(BibEntry entry, Collection<File> dirs, String file,
             String extensionRegExp) {
-        ArrayList<File> res = new ArrayList<>();
+        List<File> res = new ArrayList<>();
         for (File directory : dirs) {
             res.addAll(RegExpFileSearch.findFile(entry, directory.getPath(), file, extensionRegExp));
         }

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2015 JabRef contributors.
+/*  Copyright (C) 2003-2016 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -1026,7 +1026,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
      * @param _command The name of the command to run.
      */
     public void runCommand(final String _command) {
-        if (actions.get(_command) == null) {
+        if (!actions.containsKey(_command)) {
             LOGGER.info("No action defined for '" + _command + '\'');
             return;
         }
@@ -1448,7 +1448,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         splitPane.setDividerSize(GUIGlobals.SPLIT_PANE_DIVIDER_SIZE);
 
         // check whether a mainTable already existed and a floatSearch was active
-        boolean floatSearchActive = (mainTable != null) && this.tableModel.getSearchState() == MainTableDataModel.DisplayOption.FLOAT;
+        boolean floatSearchActive = (mainTable != null) && (this.tableModel.getSearchState() == MainTableDataModel.DisplayOption.FLOAT);
 
         createMainTable();
 
@@ -2346,7 +2346,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             } else {
                 result = FileUtil.findAssociatedFiles(entries, extensions, dirs);
             }
-            if (result.get(entry) != null) {
+            if (result.containsKey(entry)) {
                 final List<File> res = result.get(entry);
                 if (!res.isEmpty()) {
                     final String filepath = res.get(0).getPath();

--- a/src/main/java/net/sf/jabref/gui/SidePaneManager.java
+++ b/src/main/java/net/sf/jabref/gui/SidePaneManager.java
@@ -68,7 +68,7 @@ public class SidePaneManager {
     }
 
     public synchronized boolean hasComponent(String name) {
-        return components.get(name) != null;
+        return components.containsKey(name);
     }
 
     public synchronized boolean isComponentVisible(String name) {

--- a/src/main/java/net/sf/jabref/logic/journals/JournalAbbreviationRepository.java
+++ b/src/main/java/net/sf/jabref/logic/journals/JournalAbbreviationRepository.java
@@ -38,16 +38,14 @@ public class JournalAbbreviationRepository {
     }
 
     public boolean isKnownName(String journalName) {
-        String nameKey = Objects.requireNonNull(journalName).trim().toLowerCase();
-        return (fullNameLowerCase2Abbreviation.get(nameKey) != null)
-                || (isoLowerCase2Abbreviation.get(nameKey) != null)
-                || (medlineLowerCase2Abbreviation.get(nameKey) != null);
+        String nameKey = Objects.requireNonNull(journalName).trim().toLowerCase(Locale.ENGLISH);
+        return (fullNameLowerCase2Abbreviation.containsKey(nameKey)) || (isoLowerCase2Abbreviation.containsKey(nameKey))
+                || (medlineLowerCase2Abbreviation.containsKey(nameKey));
     }
 
     public boolean isAbbreviatedName(String journalName) {
-        String nameKey = Objects.requireNonNull(journalName).trim().toLowerCase();
-        return (isoLowerCase2Abbreviation.get(nameKey) != null)
-                || (medlineLowerCase2Abbreviation.get(nameKey) != null);
+        String nameKey = Objects.requireNonNull(journalName).trim().toLowerCase(Locale.ENGLISH);
+        return (isoLowerCase2Abbreviation.containsKey(nameKey)) || (medlineLowerCase2Abbreviation.containsKey(nameKey));
     }
 
     /**
@@ -57,7 +55,7 @@ public class JournalAbbreviationRepository {
      * @return The abbreviated name
      */
     public Optional<Abbreviation> getAbbreviation(String journalName) {
-        String nameKey = Objects.requireNonNull(journalName).toLowerCase().trim();
+        String nameKey = Objects.requireNonNull(journalName).toLowerCase(Locale.ENGLISH).trim();
 
         if (fullNameLowerCase2Abbreviation.containsKey(nameKey)) {
             return Optional.of(fullNameLowerCase2Abbreviation.get(nameKey));
@@ -82,9 +80,10 @@ public class JournalAbbreviationRepository {
 
         abbreviations.add(abbreviation);
 
-        fullNameLowerCase2Abbreviation.put(abbreviation.getName().toLowerCase(), abbreviation);
-        isoLowerCase2Abbreviation.put(abbreviation.getIsoAbbreviation().toLowerCase(), abbreviation);
-        medlineLowerCase2Abbreviation.put(abbreviation.getMedlineAbbreviation().toLowerCase(), abbreviation);
+        fullNameLowerCase2Abbreviation.put(abbreviation.getName().toLowerCase(Locale.ENGLISH), abbreviation);
+        isoLowerCase2Abbreviation.put(abbreviation.getIsoAbbreviation().toLowerCase(Locale.ENGLISH), abbreviation);
+        medlineLowerCase2Abbreviation.put(abbreviation.getMedlineAbbreviation().toLowerCase(Locale.ENGLISH),
+                abbreviation);
     }
 
     public void addEntries(List<Abbreviation> abbreviationsToAdd) {

--- a/src/main/java/net/sf/jabref/logic/openoffice/OOBibStyle.java
+++ b/src/main/java/net/sf/jabref/logic/openoffice/OOBibStyle.java
@@ -431,11 +431,11 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
      */
     public String getNumCitationMarker(List<Integer> number, int minGroupingCount, boolean inList) {
         String bracketBefore = getStringCitProperty(BRACKET_BEFORE);
-        if (inList && (citProperties.get(BRACKET_BEFORE_IN_LIST) != null)) {
+        if (inList && (citProperties.containsKey(BRACKET_BEFORE_IN_LIST))) {
             bracketBefore = getStringCitProperty(BRACKET_BEFORE_IN_LIST);
         }
         String bracketAfter = getStringCitProperty(BRACKET_AFTER);
-        if (inList && (citProperties.get(BRACKET_AFTER_IN_LIST) != null)) {
+        if (inList && (citProperties.containsKey(BRACKET_AFTER_IN_LIST))) {
             bracketAfter = getStringCitProperty(BRACKET_AFTER_IN_LIST);
         }
         // Sort the numbers:

--- a/src/main/java/net/sf/jabref/migrations/PreferencesMigrations.java
+++ b/src/main/java/net/sf/jabref/migrations/PreferencesMigrations.java
@@ -69,7 +69,7 @@ public class PreferencesMigrations {
         encodingMap.put("Big5_HKSCS", "Big5-HKSCS");
         encodingMap.put("EUC_JP", "EUC-JP");
 
-        if (encodingMap.get(defaultEncoding) != null) {
+        if (encodingMap.containsKey(defaultEncoding)) {
             prefs.put(JabRefPreferences.DEFAULT_ENCODING, encodingMap.get(defaultEncoding));
         }
     }

--- a/src/main/java/net/sf/jabref/model/EntryTypes.java
+++ b/src/main/java/net/sf/jabref/model/EntryTypes.java
@@ -75,7 +75,7 @@ public class EntryTypes {
             if (!ALL_TYPES.get(toLowerCase).equals(STANDARD_TYPES.get(toLowerCase))) {
                 ALL_TYPES.remove(toLowerCase);
 
-                if (STANDARD_TYPES.get(toLowerCase) != null) {
+                if (STANDARD_TYPES.containsKey(toLowerCase)) {
                     // In this case the user has removed a customized version
                     // of a standard type. We reinstate the standard type.
                     addOrModifyEntryType(STANDARD_TYPES.get(toLowerCase));


### PR DESCRIPTION
Based on a disussion in #1142, pointed out by @Siedlerchr , checking if a `Map` containts a key is better done using `Map.containsKey()` than checking if `Map.get()` returns null. (I have checked that null is not stored in the `Map` as well.)

