### PR TITLE
Replace NormalizeNamesFormatter by AuthorList and so fix #318

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Move PDF file directory configuration from external tab to file tab in preferences
 
 ### Fixed
+- Fixed [#318](https://github.com/JabRef/jabref/issues/318): Improve normalization of author names
 - Fixed [#598](https://github.com/JabRef/jabref/issues/598) and [#402](https://github.com/JabRef/jabref/issues/402): No more issues with invalid icons for ExternalFileTypes in global search or after editing the settings
 - Fixed [#883](https://github.com/JabRef/jabref/issues/883): No NPE during cleanup
 - Fixed [#845](https://github.com/JabRef/jabref/issues/845): Add checkboxes for highlighting in groups menu, fixes other toggle highlighting as well for all toggle buttons

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatter.java
@@ -17,19 +17,12 @@ package net.sf.jabref.logic.formatter.bibtexfields;
 
 import net.sf.jabref.logic.formatter.Formatter;
 import net.sf.jabref.logic.l10n.Localization;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import net.sf.jabref.model.entry.AuthorList;
 
 /**
  * Formatter normalizing a list of person names to the BibTeX format.
  */
 public class NormalizeNamesFormatter implements Formatter {
-    private static final Pattern LAST_F_F = Pattern.compile("(\\p{javaUpperCase}[\\p{javaLowerCase}]+) (\\p{javaUpperCase}+)");
-    private static final Pattern LAST_FDOT_F = Pattern.compile("(\\p{javaUpperCase}[\\p{javaLowerCase}]+) ([\\. \\p{javaUpperCase}]+)");
-    private static final Pattern F_F_LAST = Pattern.compile("(\\p{javaUpperCase}+) (\\p{javaUpperCase}[\\p{javaLowerCase}]+)");
-    private static final Pattern FDOT_F_LAST = Pattern.compile("([\\. \\p{javaUpperCase}]+) (\\p{javaUpperCase}[\\p{javaLowerCase}]+)");
-    private static final Pattern SINGLE_NAME = Pattern.compile("(\\p{javaUpperCase}[\\p{javaLowerCase}]*)");
 
     @Override
     public String getName() {
@@ -43,91 +36,8 @@ public class NormalizeNamesFormatter implements Formatter {
 
     @Override
     public String format(String value) {
-        boolean andSep = false;
-        // String can contain newlines. Convert each to a space
-        String noNewlineValue = value.replace("\n", " ");
-        String[] authors = noNewlineValue.split("( |,)and ", -1);
-        if (authors.length > 1) {
-            andSep = true;
-        } else {
-            /*
-            If there are no "and" separators in the original string, we assume it either means that
-            the author list is comma or semicolon separated or that it contains only a single name.
-            If there is a semicolon, we go by that. If not, we assume commas, and count the parts
-            separated by commas to determine which it is.
-            */
-            String[] authors2 = noNewlineValue.split("; ");
-            if (authors2.length > 1) {
-                authors = authors2;
-            } else {
-                authors2 = noNewlineValue.split(", ");
-                if (authors2.length > 3) { // Probably more than a single author, so we split by commas.
-                    authors = authors2;
-                } else {
-                    if (authors2.length == 3) {
-                        // This could be a BibTeX formatted name containing a Jr particle,
-                        // e.g. Smith, Jr., Peter
-                        // We check if the middle part is <= 3 characters. If not, we assume we are
-                        // dealing with three authors.
-                        if (authors2[1].length() > 3) {
-                            authors = authors2;
-                        }
-                    }
-                }
-            }
-        }
-
-        // Remove leading and trailing whitespaces from each name:
-        for (int i = 0; i < authors.length; i++) {
-            authors[i] = authors[i].trim();
-        }
-
-        // If we found an and separator, there could possibly be semicolon or
-        // comma separation before the last separator. If there are two or more
-        // and separators, we can dismiss this possibility.
-        // If there is only a single and separator, check closer:
-        if (andSep && (authors.length == 2)) {
-            // Check if the first part is semicolon separated:
-            String[] semiSep = authors[0].split("; ");
-            if (semiSep.length > 1) {
-                // Ok, it looks like this is the case. Use separation by semicolons:
-                String[] newAuthors = new String[1 + semiSep.length];
-                for (int i = 0; i < semiSep.length; i++) {
-                    newAuthors[i] = semiSep[i].trim();
-                }
-                newAuthors[semiSep.length] = authors[1];
-                authors = newAuthors;
-            } else {
-                // Check if there is a comma in the last name. If so, we can assume that comma
-                // is not used to separate the names:
-                boolean lnfn = authors[1].indexOf(',') >= 1;
-                if (!lnfn) {
-                    String[] cmSep = authors[0].split(", ");
-                    if (cmSep.length > 1) {
-                        // This means that the last name doesn't contain a comma, but the first
-                        // one contains one or more. This indicates that the names leading up to
-                        // the single "and" are comma separated:
-                        String[] newAuthors = new String[1 + cmSep.length];
-                        for (int i = 0; i < cmSep.length; i++) {
-                            newAuthors[i] = cmSep[i].trim();
-                        }
-                        newAuthors[cmSep.length] = authors[1];
-                        authors = newAuthors;
-                    }
-
-                }
-            }
-        }
-
-        StringBuilder stringBuilder = new StringBuilder();
-        for (int i = 0; i < authors.length; i++) {
-            String norm = NormalizeNamesFormatter.normalizeName(authors[i]);
-            stringBuilder.append(norm);
-            if (i < (authors.length - 1)) {
-                stringBuilder.append(" and ");
-            }
-        }
-        return stringBuilder.toString();
+        AuthorList authorList = AuthorList.parse(value);
+        return authorList.getAsLastFirstNamesWithAnd(false);
     }
 
     @Override
@@ -135,118 +45,4 @@ public class NormalizeNamesFormatter implements Formatter {
         return Localization.lang("Normalizes lists of persons to the BibTeX standard.");
     }
 
-    private static String normalizeName(String oldName) {
-        String name = oldName;
-        Matcher matcher = NormalizeNamesFormatter.LAST_F_F.matcher(name);
-        if (matcher.matches()) {
-            String initials = matcher.group(2);
-            StringBuilder stringBuilder = new StringBuilder(matcher.group(1));
-            stringBuilder.append(", ");
-            fixInitials(initials, stringBuilder);
-            return stringBuilder.toString();
-        }
-        matcher = NormalizeNamesFormatter.LAST_FDOT_F.matcher(name);
-        if (matcher.matches()) {
-            String initials = matcher.group(2).replaceAll("[\\. ]+", "");
-            StringBuilder stringBuilder = new StringBuilder(matcher.group(1));
-            stringBuilder.append(", ");
-            fixInitials(initials, stringBuilder);
-            return stringBuilder.toString();
-        }
-
-        matcher = NormalizeNamesFormatter.F_F_LAST.matcher(name);
-        if (matcher.matches()) {
-            String initials = matcher.group(1);
-            StringBuilder stringBuilder = new StringBuilder(matcher.group(2));
-            stringBuilder.append(", ");
-            fixInitials(initials, stringBuilder);
-            return stringBuilder.toString();
-        }
-        matcher = NormalizeNamesFormatter.FDOT_F_LAST.matcher(name);
-        if (matcher.matches()) {
-            String initials = matcher.group(1).replaceAll("[\\. ]+", "");
-            StringBuilder stringBuilder = new StringBuilder(matcher.group(2));
-            stringBuilder.append(", ");
-            fixInitials(initials, stringBuilder);
-            return stringBuilder.toString();
-        }
-
-        if (name.indexOf(',') >= 0) {
-            // Name contains comma
-            int index = name.lastIndexOf(',');
-            // If the comma is at the end of the name, just remove it to prevent index error:
-            if (index == (name.length() - 1)) {
-                name = name.substring(0, name.length() - 1);
-            }
-
-            StringBuilder stringBuilder = new StringBuilder(name.substring(0, index));
-            stringBuilder.append(", ");
-            // Check if the remainder is a single name:
-            String firstName = name.substring(index + 1).trim();
-            String[] firstNameParts = firstName.split(" ");
-            if (firstNameParts.length > 1) {
-                // Multiple parts. Add all of them, and add a dot if they are single letter parts:
-                for (int i = 0; i < firstNameParts.length; i++) {
-                    if (firstNameParts[i].length() == 1) {
-                        stringBuilder.append(firstNameParts[i]).append('.');
-                    } else {
-                        stringBuilder.append(firstNameParts[i]);
-                    }
-                    if (i < (firstNameParts.length - 1)) {
-                        stringBuilder.append(' ');
-                    }
-                }
-            } else {
-                // Only a single part. Check if it looks like a name or initials:
-                Matcher nameMatcher = NormalizeNamesFormatter.SINGLE_NAME.matcher(firstNameParts[0]);
-                if (nameMatcher.matches()) {
-                    stringBuilder.append(firstNameParts[0]);
-                } else {
-                    // It looks like initials.
-                    String initials = firstNameParts[0].replaceAll("[\\.]+", "");
-                    fixInitials(initials, stringBuilder);
-                }
-
-            }
-            return stringBuilder.toString();
-        } else {
-            // Name doesn't contain comma
-            String[] parts = name.split(" +");
-            boolean allNames = true;
-            for (String part : parts) {
-                matcher = NormalizeNamesFormatter.SINGLE_NAME.matcher(part);
-                if (!matcher.matches()) {
-                    allNames = false;
-                    break;
-                }
-            }
-            if (allNames) {
-                // Looks like a name written in full with first name first.
-                // Change into last name first format:
-                StringBuilder stringBuilder = new StringBuilder(parts[parts.length - 1]);
-                if (parts.length > 1) {
-                    stringBuilder.append(',');
-                    for (int i = 0; i < (parts.length - 1); i++) {
-                        stringBuilder.append(' ').append(parts[i]);
-                        if (parts[i].length() == 1) {
-                            stringBuilder.append('.');
-                        }
-                    }
-                }
-                return stringBuilder.toString();
-            }
-        }
-
-        return name;
-    }
-
-    private static void fixInitials(final String initials, final StringBuilder stringBuilder) {
-        for (int i = 0; i < initials.length(); i++) {
-            stringBuilder.append(initials.charAt(i));
-            stringBuilder.append('.');
-            if (i < (initials.length() - 1)) {
-                stringBuilder.append(' ');
-            }
-        }
-    }
 }

--- a/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 
 import com.google.common.base.CharMatcher;
 import net.sf.jabref.Globals;
+import net.sf.jabref.model.entry.Author;
 
 public class StringUtil {
 
@@ -641,7 +642,7 @@ public class StringUtil {
                 }
                 for (int j = 1; j < names.length; j++) {
                     if (j == 1) {
-                        sb.append(StringUtil.expandAll(names[j]));
+                        sb.append(Author.addDotIfAbbreviation(names[j]));
                     } else {
                         sb.append(names[j]);
                     }
@@ -653,7 +654,7 @@ public class StringUtil {
             } else {
                 String[] names = authors[i].split(" ");
                 if (names.length > 0) {
-                    sb.append(StringUtil.expandAll(names[0]));
+                    sb.append(Author.addDotIfAbbreviation(names[0]));
                 }
                 for (int j = 1; j < names.length; j++) {
                     sb.append(' ');
@@ -665,50 +666,6 @@ public class StringUtil {
             }
         }
 
-        return sb.toString().trim();
-    }
-
-    private static String expandAll(String s) {
-        // Avoid arrayindexoutof.... :
-        if (s.isEmpty()) {
-            return s;
-        }
-        // If only one character (uppercase letter), add a dot and return immediately:
-        if ((s.length() == 1) && Character.isLetter(s.charAt(0)) &&
-                Character.isUpperCase(s.charAt(0))) {
-            return s + ".";
-        }
-        StringBuilder sb = new StringBuilder();
-        char c = s.charAt(0);
-        char d = 0;
-        for (int i = 1; i < s.length(); i++) {
-            d = s.charAt(i);
-            if (Character.isLetter(c) && Character.isUpperCase(c) &&
-                    Character.isLetter(d) && Character.isUpperCase(d)) {
-                // AA -> A. A.
-                sb.append(c);
-                sb.append(". ");
-            } else if (Character.isLetter(c) && Character.isUpperCase(c) &&
-                    ('-' == d)) {
-                // A-A -> A.-A.
-                sb.append(c);
-                sb.append(".");
-            } else if ((c == '.') && Character.isLetter(d)
-                    && Character.isUpperCase(d)) {
-                // A.A. -> A. A.
-                sb.append(". ");
-            } else {
-                sb.append(c);
-            }
-            c = d;
-        }
-        if (Character.isLetter(c) && Character.isUpperCase(c) &&
-                Character.isLetter(d) && Character.isUpperCase(d)) {
-            sb.append(c);
-            sb.append(". ");
-        } else {
-            sb.append(c);
-        }
         return sb.toString().trim();
     }
 

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatterTest.java
@@ -27,23 +27,81 @@ public class NormalizeNamesFormatterTest {
     @Test
     public void testNormalizeAuthorList() {
         expectCorrect("Staci D Bilbo", "Bilbo, Staci D.");
-        expectCorrect("Staci D. Bilbo", "Staci D. Bilbo"); // TODO strange behaviour
+        expectCorrect("Staci D. Bilbo", "Bilbo, Staci D.");
 
         expectCorrect("Staci D Bilbo and Smith SH and Jaclyn M Schwarz", "Bilbo, Staci D. and Smith, S. H. and Schwarz, Jaclyn M.");
 
         expectCorrect("Ølver MA", "Ølver, M. A.");
 
-        expectCorrect("Ølver MA, GG Øie, Øie GG, Alfredsen JÅÅ, Jo Alfredsen, Olsen Y.Y. and Olsen Y. Y.",
+        expectCorrect("Ølver MA; GG Øie; Øie GG; Alfredsen JÅÅ; Jo Alfredsen; Olsen Y.Y. and Olsen YY.",
                 "Ølver, M. A. and Øie, G. G. and Øie, G. G. and Alfredsen, J. Å. Å. and Alfredsen, Jo and Olsen, Y. Y. and Olsen, Y. Y.");
 
-        expectCorrect("Ølver MA, GG Øie, Øie GG, Alfredsen JÅÅ, Jo Alfredsen, Olsen Y.Y., Olsen Y. Y.",
+        expectCorrect("Ølver MA; GG Øie; Øie GG; Alfredsen JÅÅ; Jo Alfredsen; Olsen Y.Y.; Olsen YY.",
                 "Ølver, M. A. and Øie, G. G. and Øie, G. G. and Alfredsen, J. Å. Å. and Alfredsen, Jo and Olsen, Y. Y. and Olsen, Y. Y.");
 
         expectCorrect("Alver, Morten and Alver, Morten O and Alfredsen, JA and Olsen, Y.Y.", "Alver, Morten and Alver, Morten O. and Alfredsen, J. A. and Olsen, Y. Y.");
 
         expectCorrect("Alver, MA; Alfredsen, JA; Olsen Y.Y.", "Alver, M. A. and Alfredsen, J. A. and Olsen, Y. Y.");
 
-        // TODO: expectCorrect("Kolb, Stefan and J{\\\"o}rg Lenhard and Wirtz, Guido", "Kolb, Stefan and Lenhard, J{\\\"o}rg and Wirtz, Guido");
+        expectCorrect("Kolb, Stefan and J{\\\"o}rg Lenhard and Wirtz, Guido", "Kolb, Stefan and Lenhard, J{\\\"o}rg and Wirtz, Guido");
+    }
+
+    @Test
+    public void twoAuthorsSeperatedByColon() {
+        expectCorrect("Staci Bilbo; Morten Alver", "Bilbo, Staci and Alver, Morten");
+    }
+
+    @Test
+    public void threeAuthorsSeperatedByColon() {
+        expectCorrect("Staci Bilbo; Morten Alver; Test Name", "Bilbo, Staci and Alver, Morten and Name, Test");
+    }
+
+    // Test for https://github.com/JabRef/jabref/issues/318
+    @Test
+    public void threeAuthorsSeperatedByAnd() {
+        expectCorrect("Stefan Kolb and J{\\\"o}rg Lenhard and Guido Wirtz", "Kolb, Stefan and Lenhard, J{\\\"o}rg and Wirtz, Guido");
+    }
+
+    // Test for https://github.com/JabRef/jabref/issues/318
+    @Test
+    public void threeAuthorsSeperatedByAndWithDash() {
+        expectCorrect("Heng-Yu Jian and Xu, Z. and Chang, M.-C.F.", "Jian, Heng-Yu and Xu, Z. and Chang, M.-C. F.");
+    }
+
+    // Test for https://github.com/JabRef/jabref/issues/318
+    @Test
+    public void threeAuthorsSeperatedByAndWithLatex() {
+        expectCorrect("Oscar Gustafsson and Linda S. DeBrunner and Victor DeBrunner and H{\\aa}kan Johansson", "Gustafsson, Oscar and DeBrunner, Linda S. and DeBrunner, Victor and Johansson, H{\\aa}kan");
+    }
+
+    @Test
+    public void lastThenInitial() {
+        expectCorrect("Smith S", "Smith, S.");
+    }
+
+    @Test
+    public void lastThenInitials() {
+        expectCorrect("Smith SH", "Smith, S. H.");
+    }
+
+    @Test
+    public void initialThenLast() {
+        expectCorrect("S Smith", "Smith, S.");
+    }
+
+    @Test
+    public void initialDotThenLast() {
+        expectCorrect("S. Smith", "Smith, S.");
+    }
+
+    @Test
+    public void initialsThenLast() {
+        expectCorrect("SH Smith", "Smith, S. H.");
+    }
+
+    @Test
+    public void lastThenJuniorThenFirst() {
+        expectCorrect("Name, della, first", "Name, della, first");
     }
 
     private void expectCorrect(String input, String expected) {

--- a/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
@@ -1,13 +1,11 @@
 package net.sf.jabref.logic.util.strings;
 
-import static org.junit.Assert.*;
-
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.entry.FileField;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
 
 public class StringUtilTest {
 
@@ -290,6 +288,7 @@ public class StringUtilTest {
     public void testExpandAuthorInitialsAddDot() {
         assertEquals("O.", StringUtil.expandAuthorInitials("O"));
         assertEquals("A. O.", StringUtil.expandAuthorInitials("AO"));
+        assertEquals("A. O.", StringUtil.expandAuthorInitials("AO."));
         assertEquals("A. O.", StringUtil.expandAuthorInitials("A.O."));
         assertEquals("A.-O.", StringUtil.expandAuthorInitials("A-O"));
         assertEquals("O. Moore", StringUtil.expandAuthorInitials("O Moore"));
@@ -313,6 +312,9 @@ public class StringUtilTest {
         assertEquals("Moore, O.", StringUtil.expandAuthorInitials("Moore, O."));
         assertEquals("Moore, A. O.", StringUtil.expandAuthorInitials("Moore, A. O."));
         assertEquals("Moore, A.-O.", StringUtil.expandAuthorInitials("Moore, A.-O."));
+        assertEquals("MEmre", StringUtil.expandAuthorInitials("MEmre"));
+        assertEquals("{\\'{E}}douard", StringUtil.expandAuthorInitials("{\\'{E}}douard"));
+        assertEquals("J{\\\"o}rg", StringUtil.expandAuthorInitials("J{\\\"o}rg"));
     }
 
 }

--- a/src/test/resources/net/sf/jabref/importer/fileformat/OvidImporterTestBib5.bib
+++ b/src/test/resources/net/sf/jabref/importer/fileformat/OvidImporterTestBib5.bib
@@ -1,6 +1,6 @@
 @Misc{,
   Title                    = {Listening: Important to the Stuff of a Life},
-  Author                   = {Bunkers, Sandra Schmidt RN and PhD and FAAN},
+  Author                   = {Bunkers, Sandra Schmidt R. N. and PhD and FAAN},
   Abstract                 = {Lorem ipsum abstract},
   DOI                      = {10.1177/0894318415571606}
 }

--- a/src/test/resources/net/sf/jabref/importer/fileformat/OvidImporterTestBib6.bib
+++ b/src/test/resources/net/sf/jabref/importer/fileformat/OvidImporterTestBib6.bib
@@ -1,6 +1,6 @@
 @Misc{,
   Title                    = {Correct positioning of percutaneous iliosacral screws with computer-navigated versus fluoroscopically guided surgery in traumatic pelvic ring fractures},
-  Author                   = {Verbeek, Jan MD and Hermans, Erik MD and van Vugt, Arie MD, PhD and Frolke, Jan Paul MD, PhD},
+  Author                   = {Verbeek, Jan M. D. and Hermans, Erik M. D. and van Vugt, Arie MD, PhD and Frolke, Jan Paul MD, PhD},
   Abstract                 = {Lorem ipsum abstract},
   ISSN                     = {0890-5339},
   DOI                      = {10.1097/BOT.0000000000000502},

--- a/src/test/resources/net/sf/jabref/importer/fileformat/RisImporterTest6.bib
+++ b/src/test/resources/net/sf/jabref/importer/fileformat/RisImporterTest6.bib
@@ -1,6 +1,6 @@
 @article{,
   abstract = {Toxic metals such as arsenic, cadmium, lead, and mercury are ubiquitous, have no beneficial role in human homeostasis, and contribute to noncommunicable chronic diseases. While novel drug targets for chronic disease are eagerly sought, potentially helpful agents that aid in detoxification of toxic elements, chelators, have largely been restricted to overt acute poisoning. Chelation, that is multiple coordination bonds between organic molecules and metals, is very common in the body and at the heart of enzymes with a metal cofactor such as copper or zinc. Peptides glutathione and metallothionein chelate both essential and toxic elements as they are sequestered, transported, and excreted. Enhancing natural chelation detoxification pathways, as well as use of pharmaceutical chelators against heavy metals are reviewed. Historical adverse outcomes with chelators, lessons learned in the art of using them, and successes using chelation to ameliorate renal, cardiovascular, and neurological conditions highlight the need for renewed attention to simple, safe, inexpensive interventions that offer potential to stem the tide of debilitating, expensive chronic disease.},
-  author = {Sears, Margaret E},
+  author = {Sears, Margaret E.},
   comment = {23690738[pmid]},
   issn = {1537-744X},
   journal = {The Scientific World Journal},


### PR DESCRIPTION
- Fixes #318 (and refs #950)
- Removes comma as delimiter of author names (in NormalizenamesFormatter).
 The problem is that comma separated authors cannot be distingued from one author in BibTeX format.
 For example `Name, della, first` could be three names separated by commas or if interpreted as valid BibTeX string it is one author with lastname=name, jrpart=della, firstname=first.
- Add colon as delimiter of author names (in AuthorListParser).

Thanks at all, but especially @oscargus, for creating many tests. Made implementing this PR way easier! 

--

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)