### PR TITLE
Add method getExampleInput() to Format class

### DIFF
--- a/src/main/java/net/sf/jabref/logic/formatter/Formatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/Formatter.java
@@ -42,6 +42,14 @@ public interface Formatter {
     String getDescription();
 
     /**
+     * Returns an example input string of the formatter.
+     * This example is used as input to the formatter to demonstrate its functionality
+     *
+     * @return the example input string, always non empty
+     */
+    String getExampleInput();
+
+    /**
      * Returns a default hashcode of the formatter based on its key.
      *
      * @return the hash of the key of the formatter

--- a/src/main/java/net/sf/jabref/logic/formatter/IdentityFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/IdentityFormatter.java
@@ -31,6 +31,11 @@ public class IdentityFormatter implements Formatter {
     }
 
     @Override
+    public String getExampleInput() {
+        return "JabRef";
+    }
+
+    @Override
     public int hashCode() {
         return defaultHashCode();
     }

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/ClearFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/ClearFormatter.java
@@ -27,4 +27,10 @@ public class ClearFormatter implements Formatter {
     public String getDescription() {
         return Localization.lang("Clears the field completely.");
     }
+
+    @Override
+    public String getExampleInput() {
+        return "Obsolete text";
+    }
+
 }

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatter.java
@@ -136,6 +136,11 @@ public class HtmlToLatexFormatter implements LayoutFormatter, Formatter {
         return Localization.lang("Converts HTML code to LaTeX code.");
     }
 
+    @Override
+    public String getExampleInput() {
+        return "<strong>JabRef</strong>";
+    }
+
     private int readTag(String text, int position) {
         // Have just read the < character that starts the tag.
         int index = text.indexOf('>', position);

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/LatexCleanupFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/LatexCleanupFormatter.java
@@ -40,4 +40,9 @@ public class LatexCleanupFormatter implements Formatter {
         return Localization.lang("Cleans up LaTeX code.");
     }
 
+    @Override
+    public String getExampleInput() {
+        return "{VLSI} {DSP}";
+    }
+
 }

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizeDateFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizeDateFormatter.java
@@ -46,6 +46,11 @@ public class NormalizeDateFormatter implements Formatter {
         return Localization.lang("Normalizes the date to ISO date format.");
     }
 
+    @Override
+    public String getExampleInput() {
+        return "29.11.2003";
+    }
+
     /*
      * Try to parse the following formats
      *  "M/y" (covers 9/15, 9/2015, and 09/2015)

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizeMonthFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizeMonthFormatter.java
@@ -33,4 +33,10 @@ public class NormalizeMonthFormatter implements Formatter {
     public String getDescription() {
         return Localization.lang("Normalize month to BibTeX standard abbreviation.");
     }
+
+    @Override
+    public String getExampleInput() {
+        return "December";
+    }
+
 }

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatter.java
@@ -45,4 +45,9 @@ public class NormalizeNamesFormatter implements Formatter {
         return Localization.lang("Normalizes lists of persons to the BibTeX standard.");
     }
 
+    @Override
+    public String getExampleInput() {
+        return "Albert Einstein and Alan Turing";
+    }
+
 }

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatter.java
@@ -77,6 +77,11 @@ public class NormalizePagesFormatter implements Formatter {
     }
 
     @Override
+    public String getExampleInput() {
+        return "1 - 2";
+    }
+
+    @Override
     public int hashCode() {
         return defaultHashCode();
     }

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/OrdinalsToSuperscriptFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/OrdinalsToSuperscriptFormatter.java
@@ -71,4 +71,10 @@ public class OrdinalsToSuperscriptFormatter implements Formatter {
     public String getDescription() {
         return Localization.lang("Converts ordinals to LaTeX superscripts.");
     }
+
+    @Override
+    public String getExampleInput() {
+        return "11th";
+    }
+
 }

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/RemoveBracesFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/RemoveBracesFormatter.java
@@ -25,8 +25,8 @@ public class RemoveBracesFormatter implements Formatter {
         Objects.requireNonNull(value);
 
         String formatted = value;
-        while (formatted.length() >= 2 && formatted.charAt(0) == '{' && formatted.charAt(formatted.length() - 1)
-                == '}') {
+        while ((formatted.length() >= 2) && (formatted.charAt(0) == '{') && (formatted.charAt(formatted.length() - 1)
+                == '}')) {
             String trimmed = formatted.substring(1, formatted.length() - 1);
 
             // It could be that the removed braces were not matching
@@ -44,6 +44,11 @@ public class RemoveBracesFormatter implements Formatter {
     @Override
     public String getDescription() {
         return Localization.lang("Removes braces encapsulating the complete field content.");
+    }
+
+    @Override
+    public String getExampleInput() {
+        return "{In CDMA}";
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatter.java
@@ -84,6 +84,11 @@ public class UnicodeToLatexFormatter implements LayoutFormatter, Formatter {
     }
 
     @Override
+    public String getExampleInput() {
+        return "Mönch";
+    }
+
+    @Override
     public String getName() {
         return Localization.lang("Unicode to LaTeX");
     }

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/UnitsToLatexFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/UnitsToLatexFormatter.java
@@ -143,6 +143,11 @@ public class UnitsToLatexFormatter implements Formatter {
     }
 
     @Override
+    public String getExampleInput() {
+        return "1 Hz";
+    }
+
+    @Override
     public String getName() {
         return Localization.lang("Units to LaTeX");
     }

--- a/src/main/java/net/sf/jabref/logic/formatter/casechanger/CapitalizeFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/casechanger/CapitalizeFormatter.java
@@ -32,4 +32,10 @@ public class CapitalizeFormatter implements Formatter {
         return Localization.lang(
                 "Changes the first letter of all words to capital case and the remaining letters to lower case.");
     }
+
+    @Override
+    public String getExampleInput() {
+        return "I have {a} DREAM";
+    }
+
 }

--- a/src/main/java/net/sf/jabref/logic/formatter/casechanger/LowerCaseFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/casechanger/LowerCaseFormatter.java
@@ -41,4 +41,10 @@ public class LowerCaseFormatter implements Formatter {
     public String getDescription() {
         return Localization.lang("Changes all letters to lower case.");
     }
+
+    @Override
+    public String getExampleInput() {
+        return "KDE {Amarok}";
+    }
+
 }

--- a/src/main/java/net/sf/jabref/logic/formatter/casechanger/ProtectTermsFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/casechanger/ProtectTermsFormatter.java
@@ -52,6 +52,11 @@ public class ProtectTermsFormatter implements Formatter {
     }
 
     @Override
+    public String getExampleInput() {
+        return "In CDMA";
+    }
+
+    @Override
     public String getName() {
         return Localization.lang("Protect terms");
     }

--- a/src/main/java/net/sf/jabref/logic/formatter/casechanger/SentenceCaseFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/casechanger/SentenceCaseFormatter.java
@@ -33,4 +33,10 @@ public class SentenceCaseFormatter implements Formatter {
         return Localization.lang(
                 "Capitalize the first word, changes other words to lower case.");
     }
+
+    @Override
+    public String getExampleInput() {
+        return "i have {Aa} DREAM";
+    }
+
 }

--- a/src/main/java/net/sf/jabref/logic/formatter/casechanger/TitleCaseFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/casechanger/TitleCaseFormatter.java
@@ -44,4 +44,10 @@ public class TitleCaseFormatter implements Formatter {
         return Localization.lang(
                 "Capitalize all words, but converts articles, prepositions, and conjunctions to lower case.");
     }
+
+    @Override
+    public String getExampleInput() {
+        return "{BPMN} conformance In open source Engines";
+    }
+
 }

--- a/src/main/java/net/sf/jabref/logic/formatter/casechanger/UpperCaseFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/casechanger/UpperCaseFormatter.java
@@ -32,4 +32,10 @@ public class UpperCaseFormatter implements Formatter {
         return Localization.lang(
                 "Changes all letters to upper case.");
     }
+
+    @Override
+    public String getExampleInput() {
+        return "Kde {Amarok}";
+    }
+
 }

--- a/src/main/java/net/sf/jabref/logic/formatter/minifier/MinifyNameListFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/minifier/MinifyNameListFormatter.java
@@ -45,6 +45,11 @@ public class MinifyNameListFormatter implements Formatter {
         return Localization.lang("Shortens lists of persons if there are more than 2 persons to \"et al.\".");
     }
 
+    @Override
+    public String getExampleInput() {
+        return "Stefan Kolb and Simon Harrer and Oliver Kopp";
+    }
+
     private String abbreviateAuthor(String authorField) {
         // single author
         String authorSeparator = " and ";

--- a/src/main/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatter.java
@@ -210,4 +210,9 @@ public class LatexToUnicodeFormatter implements LayoutFormatter, Formatter {
         return Localization.lang("Converts LaTeX encoding to Unicode characters.");
     }
 
+    @Override
+    public String getExampleInput() {
+        return "M{\\\"{o}}nch";
+    }
+
 }

--- a/src/test/java/net/sf/jabref/logic/formatter/FormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/FormatterTest.java
@@ -71,6 +71,11 @@ public class FormatterTest {
         assertFalse(formatter.getDescription().isEmpty());
     }
 
+    @Test
+    public void getExampleInputAlwaysNonEmpty() {
+        assertFalse(formatter.getExampleInput().isEmpty());
+    }
+
     @Parameterized.Parameters(name = "{index}: {0}")
     public static Collection<Object[]> instancesToTest() {
         // all classes implementing {@link net.sf.jabref.logic.formatter.Formatter}

--- a/src/test/java/net/sf/jabref/logic/formatter/IdentityFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/IdentityFormatterTest.java
@@ -1,0 +1,19 @@
+package net.sf.jabref.logic.formatter;
+
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Tests in addition to the general tests from {@link net.sf.jabref.logic.formatter.FormatterTest}
+ */
+public class IdentityFormatterTest {
+
+    private final IdentityFormatter formatter = new IdentityFormatter();
+
+    @Test
+    public void formatExample() {
+        assertEquals("JabRef", formatter.format(formatter.getExampleInput()));
+    }
+}

--- a/src/test/java/net/sf/jabref/logic/formatter/OrdinalsToSuperscriptFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/OrdinalsToSuperscriptFormatterTest.java
@@ -2,6 +2,9 @@ package net.sf.jabref.logic.formatter;
 
 
 import net.sf.jabref.logic.formatter.bibtexfields.OrdinalsToSuperscriptFormatter;
+
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -47,6 +50,11 @@ public class OrdinalsToSuperscriptFormatterTest {
     @Test
     public void ignoreSuperscriptsInsideWords() {
         expectCorrect("1st 1stword words1st inside1stwords", "1\\textsuperscript{st} 1stword words1st inside1stwords");
+    }
+
+    @Test
+    public void formatExample() {
+        assertEquals("11\\textsuperscript{th}", formatter.format(formatter.getExampleInput()));
     }
 
     private void expectCorrect(String input, String expected) {

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/ClearFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/ClearFormatterTest.java
@@ -9,12 +9,15 @@ import static org.junit.Assert.*;
 
 public class ClearFormatterTest {
 
+    private final ClearFormatter formatter = new ClearFormatter();
+
+
     /**
      * Check whether the clear formatter really returns the empty string for the empty string
      */
     @Test
     public void formatReturnsEmptyForEmptyString() throws Exception {
-        assertEquals("", new ClearFormatter().format(""));
+        assertEquals("", formatter.format(""));
     }
 
     /**
@@ -22,6 +25,11 @@ public class ClearFormatterTest {
      */
     @Test
     public void formatReturnsEmptyForSomeString() throws Exception {
-        assertEquals("", new ClearFormatter().format("test"));
+        assertEquals("", formatter.format("test"));
+    }
+
+    @Test
+    public void formatExample() {
+        assertEquals("", formatter.format(formatter.getExampleInput()));
     }
 }

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatterTest.java
@@ -59,4 +59,9 @@ public class HtmlToLatexFormatterTest {
         assertEquals("{\\\"{a}}b", formatter.format("a&#776;b"));
         assertEquals("{\\\"{a}}b", formatter.format("a&#x308;b"));
     }
+
+    @Test
+    public void formatExample() {
+        assertEquals("JabRef", formatter.format(formatter.getExampleInput()));
+    }
 }

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/LatexCleanupFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/LatexCleanupFormatterTest.java
@@ -13,13 +13,16 @@ public class LatexCleanupFormatterTest {
 
     @Test
     public void test() {
-
         assertEquals("$\\alpha\\beta$", formatter.format("$\\alpha$$\\beta$"));
         assertEquals("{VLSI DSP}", formatter.format("{VLSI} {DSP}"));
         assertEquals("\\textbf{VLSI} {DSP}", formatter.format("\\textbf{VLSI} {DSP}"));
-
         assertEquals("A ${\\Delta\\Sigma}$ modulator for {FPGA DSP}",
                 formatter.format("A ${\\Delta}$${\\Sigma}$ modulator for {FPGA} {DSP}"));
+    }
+
+    @Test
+    public void formatExample() {
+        assertEquals("{VLSI DSP}", formatter.format(formatter.getExampleInput()));
     }
 
 

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizeDateFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizeDateFormatterTest.java
@@ -124,4 +124,9 @@ public class NormalizeDateFormatterTest {
     public void formatDateDDdotMdotYYYY() {
         Assert.assertEquals("2015-01-15", formatter.format("15.1.2015"));
     }
+
+    @Test
+    public void formatExample() {
+        Assert.assertEquals("2003-11-29", formatter.format(formatter.getExampleInput()));
+    }
 }

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizeMonthFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizeMonthFormatterTest.java
@@ -1,0 +1,18 @@
+package net.sf.jabref.logic.formatter.bibtexfields;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests in addition to the general tests from {@link net.sf.jabref.logic.formatter.FormatterTest}
+ */
+public class NormalizeMonthFormatterTest {
+
+    private final NormalizeMonthFormatter formatter = new NormalizeMonthFormatter();
+
+    @Test
+    public void formatExample() {
+        Assert.assertEquals("#dec#", formatter.format(formatter.getExampleInput()));
+    }
+
+}

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatterTest.java
@@ -1,5 +1,7 @@
 package net.sf.jabref.logic.formatter.bibtexfields;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -93,4 +95,10 @@ public class NormalizeNamesFormatterTest {
     private void expectCorrect(String input, String expected) {
         Assert.assertEquals(expected, formatter.format(input));
     }
+
+    @Test
+    public void formatExample() {
+        assertEquals("Einstein, Albert and Turing, Alan", formatter.format(formatter.getExampleInput()));
+    }
+
 }

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatterTest.java
@@ -51,6 +51,11 @@ public class NormalizePagesFormatterTest {
         expectCorrect("12", "12");
     }
 
+    @Test
+    public void formatExample() {
+        expectCorrect(formatter.getExampleInput(), "1--2");
+    }
+
     private void expectCorrect(String input, String expected) {
         Assert.assertEquals(expected, formatter.format(input));
     }

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/RemoveBracesFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/RemoveBracesFormatterTest.java
@@ -63,4 +63,10 @@ public class RemoveBracesFormatterTest {
         // We opt here for a conservative approach although one could argue that "A} and {B}" is also a valid return
         assertEquals("{A} and {B}}", formatter.format("{A} and {B}}"));
     }
+
+    @Test
+    public void formatExample() {
+        assertEquals("In CDMA", formatter.format(formatter.getExampleInput()));
+    }
+
 }

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/UnicodeConverterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/UnicodeConverterTest.java
@@ -27,12 +27,6 @@ public class UnicodeConverterTest {
     }
 
     @Test
-    public void testEmpty() {
-        assertEquals("", formatter.format(""));
-    }
-
-
-    @Test
     public void testUnicodeCombiningAccents() {
         assertEquals("{\\\"{a}}", formatter.format("a\u0308"));
         assertEquals("{\\\"{a}}b", formatter.format("a\u0308b"));

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/UnicodeConverterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/UnicodeConverterTest.java
@@ -27,6 +27,12 @@ public class UnicodeConverterTest {
     }
 
     @Test
+    public void testEmpty() {
+        assertEquals("", formatter.format(""));
+    }
+
+
+    @Test
     public void testUnicodeCombiningAccents() {
         assertEquals("{\\\"{a}}", formatter.format("a\u0308"));
         assertEquals("{\\\"{a}}b", formatter.format("a\u0308b"));

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/UnicodeToLatexFormatterTest.java
@@ -20,4 +20,9 @@ public class UnicodeToLatexFormatterTest {
     public void formatMultipleUnicodeCharacters() {
         assertEquals("{{\\aa}}{\\\"{a}}{\\\"{o}}", formatter.format("\u00E5\u00E4\u00F6"));
     }
+
+    @Test
+    public void formatExample() {
+        assertEquals("M{\\\"{o}}nch", formatter.format(formatter.getExampleInput()));
+    }
 }

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/UnitsToLatexFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/UnitsToLatexFormatterTest.java
@@ -19,4 +19,9 @@ public class UnitsToLatexFormatterTest {
         assertEquals("1\\mbox{-}{mA}", formatter.format("1-mA"));
     }
 
+    @Test
+    public void formatExample() {
+        assertEquals("1~{Hz}", formatter.format(formatter.getExampleInput()));
+    }
+
 }

--- a/src/test/java/net/sf/jabref/logic/formatter/casechanger/CapitalizeFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/casechanger/CapitalizeFormatterTest.java
@@ -17,4 +17,9 @@ public class CapitalizeFormatterTest {
         Assert.assertEquals("Upper Each First {N}ot {t}his", formatter.format("upper each first {N}OT {t}his"));
     }
 
+    @Test
+    public void formatExample() {
+        Assert.assertEquals("I Have {a} Dream", formatter.format(formatter.getExampleInput()));
+    }
+
 }

--- a/src/test/java/net/sf/jabref/logic/formatter/casechanger/LowerCaseFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/casechanger/LowerCaseFormatterTest.java
@@ -17,4 +17,9 @@ public class LowerCaseFormatterTest {
         Assert.assertEquals("lower {U}pper", formatter.format("LOWER {U}PPER"));
     }
 
+    @Test
+    public void formatExample() {
+        Assert.assertEquals("kde {Amarok}", formatter.format(formatter.getExampleInput()));
+    }
+
 }

--- a/src/test/java/net/sf/jabref/logic/formatter/casechanger/ProtectTermsFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/casechanger/ProtectTermsFormatterTest.java
@@ -20,4 +20,9 @@ public class ProtectTermsFormatterTest {
         assertEquals("{VLSI} {VLSI}", formatter.format("VLSI {VLSI}"));
     }
 
+    @Test
+    public void formatExample() {
+        assertEquals("In {CDMA}", formatter.format(formatter.getExampleInput()));
+    }
+
 }

--- a/src/test/java/net/sf/jabref/logic/formatter/casechanger/SentenceCaseFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/casechanger/SentenceCaseFormatterTest.java
@@ -19,4 +19,9 @@ public class SentenceCaseFormatterTest {
         Assert.assertEquals("Upper {N}ot first", formatter.format("upper {N}OT FIRST"));
     }
 
+    @Test
+    public void formatExample() {
+        Assert.assertEquals("I have {Aa} dream", formatter.format(formatter.getExampleInput()));
+    }
+
 }

--- a/src/test/java/net/sf/jabref/logic/formatter/casechanger/TitleCaseFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/casechanger/TitleCaseFormatterTest.java
@@ -24,4 +24,8 @@ public class TitleCaseFormatterTest {
                 formatter.format("AN UPPER FIRST WITH {A}ND WITHOUT {C}URLY {b}rackets"));
     }
 
+    @Test
+    public void formatExample() {
+        Assert.assertEquals("{BPMN} Conformance in Open Source Engines", formatter.format(formatter.getExampleInput()));
+    }
 }

--- a/src/test/java/net/sf/jabref/logic/formatter/casechanger/UpperCaseFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/casechanger/UpperCaseFormatterTest.java
@@ -20,4 +20,8 @@ public class UpperCaseFormatterTest {
         Assert.assertEquals("UPPER {l}OWER", formatter.format("upper {l}ower"));
     }
 
+    @Test
+    public void formatExample() {
+        Assert.assertEquals("KDE {Amarok}", formatter.format(formatter.getExampleInput()));
+    }
 }

--- a/src/test/java/net/sf/jabref/logic/formatter/minifier/MinifyNameListFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/minifier/MinifyNameListFormatterTest.java
@@ -19,6 +19,11 @@ public class MinifyNameListFormatterTest {
         expectCorrect("Simon Harrer and Jörg Lenhard and Guido Wirtz and others", "Simon Harrer and others");
     }
 
+    @Test
+    public void formatExample() {
+        expectCorrect(formatter.getExampleInput(), "Stefan Kolb and others");
+    }
+
     private void expectCorrect(String input, String expected) {
         Assert.assertEquals(expected, formatter.format(input));
     }

--- a/src/test/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -57,4 +57,8 @@ public class LatexToUnicodeFormatterTest {
         assertEquals("A 32\u00A0mA ΣΔ-modulator", formatter.format("A 32~{mA} {$\\Sigma\\Delta$}-modulator"));
     }
 
+    @Test
+    public void formatExample() {
+        assertEquals("Mönch", formatter.format(formatter.getExampleInput()));
+    }
 }


### PR DESCRIPTION
I added `getExampleInput()` to the Formatter class to improve #1050.

