### PR TITLE
Preview panel is now updated when an entry is cut/deleted (again)

### DIFF
--- a/src/main/java/net/sf/jabref/gui/undo/UndoableInsertEntry.java
+++ b/src/main/java/net/sf/jabref/gui/undo/UndoableInsertEntry.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2016 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -17,13 +17,12 @@ package net.sf.jabref.gui.undo;
 
 import javax.swing.undo.AbstractUndoableEdit;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import net.sf.jabref.gui.BasePanel;
-import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * This class represents the removal of an entry. The constructor needs
@@ -64,7 +63,7 @@ public class UndoableInsertEntry extends AbstractUndoableEdit {
         try {
             base.removeEntry(entry);
             // If the entry has an editor currently open, we must close it.
-            panel.ensureNotShowing(entry);
+            panel.ensureNotShowingBottomPanel(entry);
         } catch (Throwable ex) {
             LOGGER.warn("Problem to undo `insert entry`", ex);
         }
@@ -73,10 +72,6 @@ public class UndoableInsertEntry extends AbstractUndoableEdit {
     @Override
     public void redo() {
         super.redo();
-
-        // Redo the change
-        String id = IdGenerator.next();
-        entry.setId(id);
         base.insertEntry(entry);
     }
 

--- a/src/main/java/net/sf/jabref/gui/undo/UndoableRemoveEntry.java
+++ b/src/main/java/net/sf/jabref/gui/undo/UndoableRemoveEntry.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2011 JabRef contributors.
+/*  Copyright (C) 2003-2016 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -17,13 +17,12 @@ package net.sf.jabref.gui.undo;
 
 import javax.swing.undo.AbstractUndoableEdit;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import net.sf.jabref.gui.BasePanel;
-import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * This class represents the removal of an entry. The constructor needs
@@ -59,10 +58,6 @@ public class UndoableRemoveEntry extends AbstractUndoableEdit {
     @Override
     public void undo() {
         super.undo();
-
-        // Revert the change.
-        String id = IdGenerator.next();
-        entry.setId(id);
         base.insertEntry(entry);
     }
 
@@ -74,7 +69,7 @@ public class UndoableRemoveEntry extends AbstractUndoableEdit {
         try {
             base.removeEntry(entry);
             // If the entry has an editor currently open, we must close it.
-            panel.ensureNotShowing(entry);
+            panel.ensureNotShowingBottomPanel(entry);
         } catch (Throwable ex) {
             LOGGER.warn("Problem to redo `remove entry`", ex);
         }


### PR DESCRIPTION
When I fixed #936 some time ago (PR: #937) I made a tiny error.

The Issue was to hide the Preview Panel when deleting/cutting an entry, but it also hid it when aborting the Delete-Confirmation-Dialog.
I too refactored both actions a little to make it easier for future changes.

I also removed in `UndoableRemoveEntry` and `UndoableInsertEntry` the ID generation.
