### PR TITLE
More memorizable task names

### DIFF
--- a/localization.gradle
+++ b/localization.gradle
@@ -26,7 +26,7 @@ task checkTranslationsSummary(type: JavaExec) {
     args "-c"
 }
 
-task compareTranslationsWithEnglishTranslation(type: JavaExec) {
+task showMissingTranslationKeys(type: JavaExec) {
     description "Prints differences between the English translation and translations in other languages."
     main 'org.python.util.jython'
     classpath project.configurations.jython.asPath
@@ -34,7 +34,7 @@ task compareTranslationsWithEnglishTranslation(type: JavaExec) {
     args "-t"
 }
 
-task compareAndUpdateTranslationsWithEnglishTranslation(type: JavaExec) {
+task generateMissingTranslationKeys(type: JavaExec) {
     description "Prints differences between the English translation and translations in other languages, and updates translations if possible."
     main 'org.python.util.jython'
     classpath project.configurations.jython.asPath


### PR DESCRIPTION
I always have to look up the Gradle task name to generate missing translation keys.
Therefore, I suggest to change to a more memorizable name.

- [ ] Must be changed in Code Howtos: https://github.com/JabRef/jabref/wiki/Code-Howtos#using-localization-correctly
