### PR TITLE
Replaced some Guava usage with standard java.*

### DIFF
--- a/src/main/java/net/sf/jabref/logic/fulltext/IEEE.java
+++ b/src/main/java/net/sf/jabref/logic/fulltext/IEEE.java
@@ -2,6 +2,7 @@ package net.sf.jabref.logic.fulltext;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -9,8 +10,6 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
-import com.google.common.base.Charsets;
 
 import net.sf.jabref.logic.net.URLDownload;
 import net.sf.jabref.logic.util.DOI;
@@ -52,7 +51,7 @@ public class IEEE implements FullTextFinder {
             if (doi.isPresent() && doi.get().getDOI().startsWith(IEEE_DOI) && doi.get().getURI().isPresent()) {
                 // Download the HTML page from IEEE
                 String resolvedDOIPage = new URLDownload(doi.get().getURI().get().toURL())
-                        .downloadToString(Charsets.UTF_8);
+                        .downloadToString(StandardCharsets.UTF_8);
                 // Try to find the link
                 Matcher matcher = STAMP_PATTERN.matcher(resolvedDOIPage);
                 if (matcher.find()) {
@@ -68,7 +67,7 @@ public class IEEE implements FullTextFinder {
         }
 
         // Download the HTML page containing a frame with the PDF
-        String framePage = new URLDownload(new URL(BASE_URL + stampString)).downloadToString(Charsets.UTF_8);
+        String framePage = new URLDownload(new URL(BASE_URL + stampString)).downloadToString(StandardCharsets.UTF_8);
         // Try to find the direct PDF link
         Matcher matcher = PDF_PATTERN.matcher(framePage);
         if (matcher.find()) {

--- a/src/main/java/net/sf/jabref/logic/journals/Abbreviation.java
+++ b/src/main/java/net/sf/jabref/logic/journals/Abbreviation.java
@@ -1,6 +1,6 @@
 package net.sf.jabref.logic.journals;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 public class Abbreviation implements Comparable<Abbreviation> {
 
@@ -59,7 +59,7 @@ public class Abbreviation implements Comparable<Abbreviation> {
         }
         if (o instanceof Abbreviation) {
             Abbreviation that = (Abbreviation) o;
-            return Objects.equal(name, that.name);
+            return Objects.equals(name, that.name);
         }
         return false;
     }


### PR DESCRIPTION
While looking for the use of Guava I found these calls which can be replaced with standard java-classes.

Regarding the original quest:
* Most uses are for checking null or empty Strings or similarly return an empty String if the input String is null, it may not be worth importing the library just for these two and better to create these two trivial methods in StringUtil (and use them to a larger extent)
* There is also `CharMatcher.WHITESPACE` which may be slightly less trivial to replace

