### PR TITLE
Change output level from info to debug to remove clutter in the output

### DIFF
--- a/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
@@ -379,7 +379,7 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
                 for (BibEntry entry : result.getDatabase().getEntries()) {
                     SpecialFieldsUtils.syncSpecialFieldsFromKeywords(entry, compound);
                 }
-                LOGGER.info("Synchronized special fields based on keywords");
+                LOGGER.debug("Synchronized special fields based on keywords");
             }
 
             if (!result.getMetaData().isGroupTreeValid()) {


### PR DESCRIPTION
When openning a file and special fields are used, users currently **always** get the message `INFO net.sf.jabref.importer.OpenDatabaseAction - Synchronized special fields based on keywords` displayed. This is confusing. See for example https://github.com/JabRef/jabref/issues/742#issuecomment-209811934.

Currently, JabRef uses `info` for errors and warnings, too:

![grabbed_20160414-125653](https://cloud.githubusercontent.com/assets/1366654/14525943/6040e82e-0240-11e6-8916-1c1dda2da3d2.png)

The synchronized message is a debug message, which should not be shown in the general case.

To be consistent with the current logging approach, I changed the log level for a message from `info` to `debug`. This also reduces clutter in the log and on the console. 

The alternative is to rethink all log levels and the preferred default output.



