### PR TITLE
now the preview panel will be shown with a single click after startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Fixed [#535](https://github.com/JabRef/jabref/issues/535): Add merge action to right click menu
 - Fixed [#1115](https://github.com/JabRef/jabref/issues/1115): Wrong warning message when importing duplicate entries
 - Fixed [#935](https://github.com/JabRef/jabref/issues/935): PDFs, which are readable, but carry a protection for editing, are treated by the XMP parser and the importer generating a BibTeX entry based on the content.
+- Fixed: Showing the preview panel with a single-click at Startup 
 
 ### Removed
 - Fixed [#627](https://github.com/JabRef/jabref/issues/627): The pdf field is removed from the export formats, use the file field

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -163,7 +163,8 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
     private final MainTableDataModel tableModel;
 
     // To contain instantiated entry editors. This is to save time
-    private BasePanelMode mode;
+    // As most enums, this must not be null
+    private BasePanelMode mode = BasePanelMode.SHOWING_NOTHING;
     private EntryEditor currentEditor;
 
     private PreviewPanel currentPreview;


### PR DESCRIPTION
When you click on an entry directly after startup the preview panel was not shown (of course this bug occurs only when it was activated in the preferences).
Now it does.

### Steps to Reproduce
- start JabRef
- open a database with entries
- click on one of the entries (single click)
- now the preview Panel should appear (if its activated in the settings), but it doesn't

When you de- and activate the Preview Panel (Ctrl+f9) or open and close the entry editor it works again.