### PR TITLE
Fix that FieldFormatters run although they are disabled

### DIFF
--- a/src/main/java/net/sf/jabref/logic/cleanup/CleanupWorker.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/CleanupWorker.java
@@ -14,16 +14,16 @@
 
 package net.sf.jabref.logic.cleanup;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.logic.FieldChange;
 import net.sf.jabref.logic.formatter.BibtexFieldFormatters;
 import net.sf.jabref.logic.journals.JournalAbbreviationRepository;
 import net.sf.jabref.model.entry.BibEntry;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
 
 public class CleanupWorker {
 
@@ -88,7 +88,9 @@ public class CleanupWorker {
             jobs.add(new BiblatexCleanup());
         }
 
-        jobs.addAll(preset.getFormatterCleanups().getConfiguredActions());
+        if(preset.getFormatterCleanups().isEnabled()) {
+            jobs.addAll(preset.getFormatterCleanups().getConfiguredActions());
+        }
 
         return jobs;
     }

--- a/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
@@ -291,4 +291,15 @@ public class CleanupWorkerTest {
         Assert.assertEquals(null, entry.getField("journal"));
         Assert.assertEquals("test", entry.getField("journaltitle"));
     }
+
+    @Test
+    public void cleanupWithDisabledFieldFormatterChangesNothing() {
+        CleanupPreset preset = new CleanupPreset(new FieldFormatterCleanups(false,
+                Collections.singletonList(new FieldFormatterCleanup("month", new NormalizeMonthFormatter()))));
+        BibEntry entry = new BibEntry();
+        entry.setField("month", "01");
+
+        worker.cleanup(preset, entry);
+        Assert.assertEquals("01", entry.getField("month"));
+    }
 }


### PR DESCRIPTION
As reported by @stefan-kolb, the field formatters run although they were disabled. This is fixed with this PR.

- [ ] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)

