### PR TITLE
Removed leftovers from option to edit in table cells

### DIFF
--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -285,7 +285,6 @@ public class JabRefPreferences {
     public static final String DISPLAY_KEY_WARNING_DIALOG_AT_STARTUP = "displayKeyWarningDialogAtStartup";
     public static final String DIALOG_WARNING_FOR_EMPTY_KEY = "dialogWarningForEmptyKey";
     public static final String DIALOG_WARNING_FOR_DUPLICATE_KEY = "dialogWarningForDuplicateKey";
-    public static final String ALLOW_TABLE_EDITING = "allowTableEditing";
     public static final String OVERWRITE_OWNER = "overwriteOwner";
     public static final String USE_OWNER = "useOwner";
     public static final String AUTOLINK_EXACT_KEY_ONLY = "autolinkExactKeyOnly";
@@ -715,7 +714,6 @@ public class JabRefPreferences {
 
         defaults.put(USE_OWNER, Boolean.FALSE);
         defaults.put(OVERWRITE_OWNER, Boolean.FALSE);
-        defaults.put(ALLOW_TABLE_EDITING, Boolean.FALSE);
         defaults.put(DIALOG_WARNING_FOR_DUPLICATE_KEY, Boolean.TRUE);
         defaults.put(DIALOG_WARNING_FOR_EMPTY_KEY, Boolean.TRUE);
         defaults.put(DISPLAY_KEY_WARNING_DIALOG_AT_STARTUP, Boolean.TRUE);

--- a/src/main/java/net/sf/jabref/gui/preftabs/GeneralTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/GeneralTab.java
@@ -55,7 +55,6 @@ class GeneralTab extends JPanel implements PrefsTab {
     private final JCheckBox keyEmptyWarningDialog;
     private final JCheckBox enforceLegalKeys;
     private final JCheckBox confirmDelete;
-    private final JCheckBox allowEditing;
     private final JCheckBox memoryStick;
     private final JCheckBox inspectionWarnDupli;
     private final JCheckBox useTimeStamp;
@@ -89,7 +88,6 @@ class GeneralTab extends JPanel implements PrefsTab {
 
         biblatexMode = new JComboBox<>(BibDatabaseMode.values());
         biblatexMode.setRenderer(new DefaultBibModeRenderer());
-        allowEditing = new JCheckBox(Localization.lang("Allow editing in table cells"));
 
         memoryStick = new JCheckBox(Localization.lang("Load and Save preferences from/to jabref.xml on start-up (memory stick mode)"));
         defSort = new JCheckBox(Localization.lang("Sort automatically"));
@@ -190,7 +188,6 @@ class GeneralTab extends JPanel implements PrefsTab {
 
     @Override
     public void setValues() {
-        allowEditing.setSelected(prefs.getBoolean(JabRefPreferences.ALLOW_TABLE_EDITING));
         defSort.setSelected(prefs.getBoolean(JabRefPreferences.DEFAULT_AUTO_SORT));
         ctrlClick.setSelected(prefs.getBoolean(JabRefPreferences.CTRL_CLICK));
         useOwner.setSelected(prefs.getBoolean(JabRefPreferences.USE_OWNER));
@@ -250,7 +247,6 @@ class GeneralTab extends JPanel implements PrefsTab {
         }
         prefs.putBoolean(JabRefPreferences.MEMORY_STICK_MODE, memoryStick.isSelected());
         prefs.putBoolean(JabRefPreferences.CONFIRM_DELETE, confirmDelete.isSelected());
-        prefs.putBoolean(JabRefPreferences.ALLOW_TABLE_EDITING, allowEditing.isSelected());
         prefs.putBoolean(JabRefPreferences.CTRL_CLICK, ctrlClick.isSelected());
         prefs.putBoolean(JabRefPreferences.WARN_ABOUT_DUPLICATES_IN_INSPECTION, inspectionWarnDupli.isSelected());
         String owner = defOwnerField.getText().trim();

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -45,7 +45,6 @@ All_entries=Alle_poster
 All_entries_of_this_type_will_be_declared_typeless._Continue?=Alle_posterne_af_denne_type_vil_blive_klassificeret_som_typeløse._Fortsæt?
 All_fields=Alle_felter
 All_subgroups_(recursively)=Alle_undergrupper_(rekursivt)
-Allow_editing_in_table_cells=Tillad_redigering_af_celler_i_tabellen
 An_Exception_occurred_while_accessing_'%0'=En_fejl_opstod_ved_læsning_af_'%0'
 An_SAXException_occurred_while_parsing_'%0'\:=En_SAXException_forekom_ved_læsning_af_'%0'\:
 and=og

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -85,7 +85,6 @@ All_fields=Alle_Felder
 
 All_subgroups_(recursively)=Alle_Untergruppen_(rekursiv)
 
-Allow_editing_in_table_cells=Bearbeiten_in_der_Tabelle_zulassen
 An_Exception_occurred_while_accessing_'%0'=Fehler_beim_Zugriff_auf_'%0'
 An_SAXException_occurred_while_parsing_'%0'\:=Beim_Parsen_von_'%0'_ist_eine_SAX-Exception_aufgetreten\:
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -80,8 +80,6 @@ All_fields=All_fields
 
 All_subgroups_(recursively)=All_subgroups_(recursively)
 
-Allow_editing_in_table_cells=Allow_editing_in_table_cells
-
 Always_reformat_.bib_file_on_save_and_export=Always_reformat_.bib_file_on_save_and_export
 
 An_Exception_occurred_while_accessing_'%0'=An_Exception_occurred_while_accessing_'%0'

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -44,7 +44,6 @@ All_entries=Todas_las_entradas
 All_entries_of_this_type_will_be_declared_typeless._Continue?=Todas_las_entradas_de_este_tipo_serán_declaradas_Sin_Tipo._¿Continuar?
 All_fields=Todos_los_campos
 All_subgroups_(recursively)=Todos_los_subgrupos(Recursivamente)
-Allow_editing_in_table_cells=Permitir_la_edición_en_celdas_de_tabla
 An_Exception_occurred_while_accessing_'%0'=Ocurrió_una_Excepción_mientras_se_accedía_a_'%0'
 An_SAXException_occurred_while_parsing_'%0'\:=Ocurrió_una_Excepción_SAX_mientras_se_analizaba_la_sintaxis_de_'%0'\:
 and=y

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -85,7 +85,6 @@ All_fields=
 
 All_subgroups_(recursively)=
 
-Allow_editing_in_table_cells=
 An_Exception_occurred_while_accessing_'%0'=
 An_SAXException_occurred_while_parsing_'%0'\:=
 

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -44,7 +44,6 @@ All_entries=Toutes_les_entrées
 All_entries_of_this_type_will_be_declared_typeless._Continue?=Toutes_les_entrées_de_ce_type_seront_déclarées_'sans_type'._Continuer_?
 All_fields=Tous_les_champs
 All_subgroups_(recursively)=Tous_les_sous-groupes_(récursivement)
-Allow_editing_in_table_cells=Autoriser_l'édition_dans_les_cellules_de_la_table
 An_Exception_occurred_while_accessing_'%0'=Une_Exception_est_survenue_lors_de_l'accès_à_'%0'
 An_SAXException_occurred_while_parsing_'%0'\:=Une_Exception_SAX_est_survenue_pendant_le_traitement_de_'%0'_\:
 and=et

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -44,7 +44,6 @@ All_entries=Semua_entri
 All_entries_of_this_type_will_be_declared_typeless._Continue?=Semua_entri_tipe_ini_akan_dinyatakan_sebagai_tanpa_tipe._Teruskan?
 All_fields=Semua_bidang
 All_subgroups_(recursively)=Semua_anak_grup_(rekursif)
-Allow_editing_in_table_cells=Ijinkan_menyunting_dalam_sel_tabel
 An_Exception_occurred_while_accessing_'%0'=Kesalahan_terjadi_ketika_mengakses_'%0'
 An_SAXException_occurred_while_parsing_'%0'\:=SAXException_terjadi_ketika_mengurai_'%0'\:
 and=dan

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -44,7 +44,6 @@ All_entries=Tutte_le_voci
 All_entries_of_this_type_will_be_declared_typeless._Continue?=Tutte_le_voci_di_questo_tipo_saranno_definite_'senza_tipo'._Continuare?
 All_fields=Tutti_i_campi
 All_subgroups_(recursively)=Tutti_i_sottogruppi_(ricorsivamente)
-Allow_editing_in_table_cells=Consenti_la_modifica_nelle_celle_della_tabella
 An_Exception_occurred_while_accessing_'%0'=Eccezione_durante_l'accesso_a_'%0'
 An_SAXException_occurred_while_parsing_'%0'\:=Eccezione_SAX_durante_l'elaborazione_di_'%0'\:
 and=e

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -85,7 +85,6 @@ All_fields=全フィールド
 
 All_subgroups_(recursively)=全下層グループ（再帰的に）
 
-Allow_editing_in_table_cells=表セル中での編集を許可する
 An_Exception_occurred_while_accessing_'%0'=「%0」にアクセス中に例外エラーが発生しました\:
 An_SAXException_occurred_while_parsing_'%0'\:=「%0」を解析中にSAX例外エラーが発生しました\:
 

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -85,7 +85,6 @@ All_fields=Alle_velden
 
 All_subgroups_(recursively)=Alle_subgroepen_(recursief)
 
-Allow_editing_in_table_cells=Sta_aanpassingen_in_tabel_cellen_toe
 An_Exception_occurred_while_accessing_'%0'=
 An_SAXException_occurred_while_parsing_'%0'\:=
 

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -90,7 +90,6 @@ All_fields=Alle_felter
 
 All_subgroups_(recursively)=Alle_undergrupper_(rekursivt)
 
-Allow_editing_in_table_cells=Tillat_redigering_av_celler_i_tabellen
 
 An_Exception_occurred_while_accessing_'%0'=En_feil_oppsto_ved_lesing_av_'%0'
 

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -44,7 +44,6 @@ All_entries=Todas_as_referências
 All_entries_of_this_type_will_be_declared_typeless._Continue?=Todas_as_referências_serão_consideradas_sem_tipo._Continuar?
 All_fields=Todos_os_campos
 All_subgroups_(recursively)=Todos_os_subgrupos_(recursivamente)
-Allow_editing_in_table_cells=Permitir_a_edição_em_campos_da_tabela
 An_Exception_occurred_while_accessing_'%0'=Uma_exceção_ocorreu_durante_ao_acesso_a_'%0'
 An_SAXException_occurred_while_parsing_'%0'\:=Uma_exceção_ocorreu_durante_a_análise_de_'%0'
 and=e

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -71,7 +71,6 @@ All_fields=Все_поля
 
 All_subgroups_(recursively)=Все_подгруппы_(рекурсивно)
 
-Allow_editing_in_table_cells=Разрешить_изменение_ячеек_таблицы
 An_Exception_occurred_while_accessing_'%0'=Исключение_при_доступе_к_'%0'
 An_SAXException_occurred_while_parsing_'%0'\:=Исключение_SAX_при_анализе_'%0'\:
 

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -64,7 +64,6 @@ All_entries_of_this_type_will_be_declared_typeless._Continue?=
 All_fields=Alla_fält
 All_key_bindings_will_be_reset_to_their_defaults.=Alla_tangentbordsbindingar_kommer_att_återställas_till_standardvärden.
 All_subgroups_(recursively)=Alla_undergrupper_(rekursivt)
-Allow_editing_in_table_cells=
 Allow_file_links_relative_to_each_bib_file's_location=
 Allow_overwriting_existing_links.=Tillåt_att_befintliga_länkar_skrivs_över.
 Always_add_letter_(a,_b,_...)_to_generated_keys=Lägg_alltid_till_en_bokstav_(a,_b_...)_på_genererade_nycklar

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -44,7 +44,6 @@ All_entries=Tüm_girdiler
 All_entries_of_this_type_will_be_declared_typeless._Continue?=Bu_türeden_tüm_girdiler_türsüz_olarak_bildirilecek._Devam_edilsin_mi?
 All_fields=Tüm_alanlar
 All_subgroups_(recursively)=Tüm_alt-gruplar_(özyinelemeli)
-Allow_editing_in_table_cells=Tablo_hücrelerinde_düzenlemeye_izin_ver
 An_Exception_occurred_while_accessing_'%0'='%0''e_erişilirken_bir_istisna_oluştu
 An_SAXException_occurred_while_parsing_'%0'\:='%0'_ayrıştırılırken_bir_SAXİstisnası_oluştu\:
 and=ve

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -85,7 +85,6 @@ All_fields=Tất_cả_các_trường
 
 All_subgroups_(recursively)=Tất_cả_các_nhóm_con_(đệ_quy)
 
-Allow_editing_in_table_cells=Cho_phép_chỉnh_sửa_trong_ô_của_bảng
 An_Exception_occurred_while_accessing_'%0'=Một_lỗi_xảy_ra_khi_đang_truy_cập_'%0'
 An_SAXException_occurred_while_parsing_'%0'\:=Một_lỗi_SAXException_xảy_ra_khi_đang_phân_tách_'%0'\:
 

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -46,7 +46,6 @@ All_entries=所有记录
 All_entries_of_this_type_will_be_declared_typeless._Continue?=所有此类型记录将被标记为无类型记录，是否继续？
 All_fields=所有域
 All_subgroups_(recursively)=所有子分组(递归地)
-Allow_editing_in_table_cells=Allow_editing_in_table_cells
 Always_reformat_.bib_file_on_save_and_export=当保存和导出时重新格式化_.bib_文件
 An_Exception_occurred_while_accessing_'%0'=当访问_'%0'_时发生了一个异常
 An_SAXException_occurred_while_parsing_'%0'\:=当解析'%0'时发生了一个_SAXException\:


### PR DESCRIPTION
Found some unused code when doing translations. This is a left over from when it was possible to edit in the table directly.

I've earlier seen some code which checks if a single cell is selected. That should also be safe to remove I assume (I was a bit confused why it was ever there, but now I think I know the reason...).
