### PR TITLE
Cleanup now uses active preferences

### DIFF
--- a/src/main/java/net/sf/jabref/gui/actions/CleanupAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/CleanupAction.java
@@ -49,15 +49,12 @@ public class CleanupAction extends AbstractWorker {
     private boolean canceled;
     private int modifiedEntriesCount;
     private final JabRefPreferences preferences;
-    private final CleanupPresetPanel presetPanel;
 
 
     public CleanupAction(BasePanel panel, JabRefPreferences preferences) {
         this.panel = panel;
         this.frame = panel.frame();
         this.preferences = Objects.requireNonNull(preferences);
-        this.presetPanel = new CleanupPresetPanel(panel.getBibDatabaseContext(),
-                CleanupPreset.loadFromPreferences(preferences));
     }
 
     @Override
@@ -80,7 +77,9 @@ public class CleanupAction extends AbstractWorker {
         if (canceled) {
             return;
         }
-        int choice = showDialog();
+        CleanupPresetPanel presetPanel = new CleanupPresetPanel(panel.getBibDatabaseContext(),
+                CleanupPreset.loadFromPreferences(preferences));
+        int choice = showDialog(presetPanel);
         if (choice != JOptionPane.OK_OPTION) {
             canceled = true;
             return;
@@ -148,7 +147,7 @@ public class CleanupAction extends AbstractWorker {
         frame.unblock();
     }
 
-    private int showDialog() {
+    private int showDialog(CleanupPresetPanel presetPanel) {
         String dialogTitle = Localization.lang("Cleanup entries");
 
         Object[] messages = {Localization.lang("What would you like to clean up?"), presetPanel.getPanel()};

--- a/src/main/java/net/sf/jabref/gui/preftabs/ImportSettingsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/ImportSettingsTab.java
@@ -16,6 +16,7 @@
 package net.sf.jabref.gui.preftabs;
 
 import java.awt.BorderLayout;
+import java.util.Objects;
 
 import javax.swing.BorderFactory;
 import javax.swing.ButtonGroup;
@@ -28,7 +29,6 @@ import javax.swing.JPopupMenu;
 import javax.swing.JRadioButton;
 import javax.swing.JTextField;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.pdfimport.ImportDialog;
@@ -49,6 +49,7 @@ public class ImportSettingsTab extends JPanel implements PrefsTab {
             "\\bibtexkey\\begin{title} - \\format[RemoveBrackets]{\\title}\\end{title}"
     };
 
+    private final JabRefPreferences prefs;
     private final JRadioButton radioButtonXmp;
     private final JRadioButton radioButtonPDFcontent;
     private final JRadioButton radioButtonNoMeta;
@@ -59,7 +60,9 @@ public class ImportSettingsTab extends JPanel implements PrefsTab {
     private final JButton selectFileNamePattern;
 
 
-    public ImportSettingsTab() {
+    public ImportSettingsTab(JabRefPreferences prefs) {
+        this.prefs = Objects.requireNonNull(prefs);
+
         setLayout(new BorderLayout());
         FormLayout layout = new FormLayout("1dlu, 8dlu, left:pref, 4dlu, fill:3dlu");
         radioButtonNoMeta = new JRadioButton(Localization.lang("Create_blank_entry_linking_the_PDF"));
@@ -116,8 +119,8 @@ public class ImportSettingsTab extends JPanel implements PrefsTab {
 
     @Override
     public void setValues() {
-        useDefaultPDFImportStyle.setSelected(Globals.prefs.getBoolean(JabRefPreferences.PREF_IMPORT_ALWAYSUSE));
-        int style = Globals.prefs.getInt(JabRefPreferences.PREF_IMPORT_DEFAULT_PDF_IMPORT_STYLE);
+        useDefaultPDFImportStyle.setSelected(prefs.getBoolean(JabRefPreferences.PREF_IMPORT_ALWAYSUSE));
+        int style = prefs.getInt(JabRefPreferences.PREF_IMPORT_DEFAULT_PDF_IMPORT_STYLE);
         switch (style) {
         case ImportDialog.NOMETA:
             radioButtonNoMeta.setSelected(true);
@@ -136,12 +139,12 @@ public class ImportSettingsTab extends JPanel implements PrefsTab {
             radioButtonPDFcontent.setSelected(true);
             break;
         }
-        fileNamePattern.setText(Globals.prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN));
+        fileNamePattern.setText(prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN));
     }
 
     @Override
     public void storeSettings() {
-        Globals.prefs.putBoolean(JabRefPreferences.PREF_IMPORT_ALWAYSUSE, useDefaultPDFImportStyle.isSelected());
+        prefs.putBoolean(JabRefPreferences.PREF_IMPORT_ALWAYSUSE, useDefaultPDFImportStyle.isSelected());
         int style = ImportSettingsTab.DEFAULT_STYLE;
         if (radioButtonNoMeta.isSelected()) {
             style = ImportDialog.NOMETA;
@@ -152,8 +155,8 @@ public class ImportSettingsTab extends JPanel implements PrefsTab {
         } else if (radioButtononlyAttachPDF.isSelected()) {
             style = ImportDialog.ONLYATTACH;
         }
-        Globals.prefs.putInt(JabRefPreferences.PREF_IMPORT_DEFAULT_PDF_IMPORT_STYLE, style);
-        Globals.prefs.put(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN, fileNamePattern.getText());
+        prefs.putInt(JabRefPreferences.PREF_IMPORT_DEFAULT_PDF_IMPORT_STYLE, style);
+        prefs.put(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN, fileNamePattern.getText());
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
@@ -20,6 +20,7 @@ import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -34,7 +35,7 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 
-import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.OSXCompatibleToolbar;
 import net.sf.jabref.gui.help.HelpAction;
@@ -47,6 +48,7 @@ import com.jgoodies.forms.layout.FormLayout;
 
 public class NameFormatterTab extends JPanel implements PrefsTab {
 
+    private final JabRefPreferences prefs;
     private boolean tableChanged;
 
     private final JTable table;
@@ -98,7 +100,8 @@ public class NameFormatterTab extends JPanel implements PrefsTab {
      * Tab to create custom Name Formatters
      *
      */
-    public NameFormatterTab() {
+    public NameFormatterTab(JabRefPreferences prefs) {
+        this.prefs = Objects.requireNonNull(prefs);
         setLayout(new BorderLayout());
 
         TableModel tableModel = new AbstractTableModel() {
@@ -208,8 +211,8 @@ public class NameFormatterTab extends JPanel implements PrefsTab {
     @Override
     public void setValues() {
         tableRows.clear();
-        List<String> names = Globals.prefs.getStringList(NameFormatter.NAME_FORMATER_KEY);
-        List<String> formats = Globals.prefs.getStringList(NameFormatter.NAME_FORMATTER_VALUE);
+        List<String> names = prefs.getStringList(NameFormatter.NAME_FORMATER_KEY);
+        List<String> formats = prefs.getStringList(NameFormatter.NAME_FORMATTER_VALUE);
 
         for (int i = 0; i < names.size(); i++) {
             if (i < formats.size()) {
@@ -325,8 +328,8 @@ public class NameFormatterTab extends JPanel implements PrefsTab {
             }
 
             // Finally, we store the new preferences.
-            Globals.prefs.putStringList(NameFormatter.NAME_FORMATER_KEY, names);
-            Globals.prefs.putStringList(NameFormatter.NAME_FORMATTER_VALUE, formats);
+            prefs.putStringList(NameFormatter.NAME_FORMATER_KEY, names);
+            prefs.putStringList(NameFormatter.NAME_FORMATTER_VALUE, formats);
         }
     }
 

--- a/src/main/java/net/sf/jabref/gui/preftabs/PreferencesDialog.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/PreferencesDialog.java
@@ -104,9 +104,9 @@ public class PreferencesDialog extends JDialog {
         tabs.add(new TableColumnsTab(prefs, parent));
         tabs.add(new LabelPatternPrefTab(prefs, parent.getCurrentBasePanel()));
         tabs.add(new PreviewPrefsTab(prefs));
-        tabs.add(new NameFormatterTab());
-        tabs.add(new ImportSettingsTab());
-        tabs.add(new XmpPrefsTab());
+        tabs.add(new NameFormatterTab(prefs));
+        tabs.add(new ImportSettingsTab(prefs));
+        tabs.add(new XmpPrefsTab(prefs));
         tabs.add(new AdvancedTab(prefs));
 
         // add all tabs

--- a/src/main/java/net/sf/jabref/gui/preftabs/XmpPrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/XmpPrefsTab.java
@@ -20,6 +20,7 @@ import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import javax.swing.AbstractAction;
@@ -36,7 +37,6 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.OSXCompatibleToolbar;
@@ -52,6 +52,7 @@ import com.jgoodies.forms.layout.FormLayout;
  */
 class XmpPrefsTab extends JPanel implements PrefsTab {
 
+    private final JabRefPreferences prefs;
     private boolean tableChanged;
 
     private int rowCount;
@@ -67,7 +68,8 @@ class XmpPrefsTab extends JPanel implements PrefsTab {
     /**
      * Customization of external program paths.
      */
-    public XmpPrefsTab() {
+    public XmpPrefsTab(JabRefPreferences prefs) {
+        this.prefs = Objects.requireNonNull(prefs);
         setLayout(new BorderLayout());
 
         TableModel tableModel = new AbstractTableModel() {
@@ -258,7 +260,7 @@ class XmpPrefsTab extends JPanel implements PrefsTab {
         // table setup table. This needs to be done either if changes were made, or
         // if the checkbox is checked and no field values have been stored previously:
         if (tableChanged ||
-                (privacyFilterCheckBox.isSelected() && !Globals.prefs.hasKey(JabRefPreferences.XMP_PRIVACY_FILTERS))) {
+                (privacyFilterCheckBox.isSelected() && !prefs.hasKey(JabRefPreferences.XMP_PRIVACY_FILTERS))) {
 
             // First we remove all rows with empty names.
             for (int i = tableRows.size() - 1; i >= 0; i--) {


### PR DESCRIPTION
Previously, the cleanup used the preference state from the program start and not the most recent preferences. This is fixed with this PR.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
