### PR TITLE
Restructure Help Pages 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,13 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Implemented [feature request 384](https://sourceforge.net/p/jabref/features/384): The merge entries dialog now show all text and colored differences between the fields
 - Implemented [#1233](https://github.com/JabRef/jabref/issues/1233): Group side pane now takes up all the remaining space
 - Added integrity check detecting HTML-encoded characters
+- Added missing help files
 
 ### Fixed
 - Fixed [#473](https://github.com/JabRef/jabref/issues/473): Values in an entry containing symbols like ' are now properly escaped for exporting to the database
 - Fixed [#1270](https://github.com/JabRef/jabref/issues/1270): Auto save is now working again as expected (without leaving a bunch of temporary files behind)
 - Fixed [#1234](https://github.com/JabRef/jabref/issues/1234): NPE when getting information from retrieved DOI
-- Fixed [1245](https://github.com/JabRef/jabref/issues/1245): Empty jstyle properties can now be specified as "" 
+- Fixed [1245](https://github.com/JabRef/jabref/issues/1245): Empty jstyle properties can now be specified as ""
 
 ### Removed
 - Removed possibility to export entries/databases to an `.sql` file, as the logic cannot easily use the correct escape logic

--- a/src/main/java/net/sf/jabref/exporter/ExportCustomizationDialog.java
+++ b/src/main/java/net/sf/jabref/exporter/ExportCustomizationDialog.java
@@ -137,7 +137,7 @@ public class ExportCustomizationDialog extends JDialog {
         JButton close = new JButton(Localization.lang("Close"));
         close.addActionListener(closeAction);
 
-        JButton help = new HelpAction(HelpFiles.exportCustomizationHelp).getHelpButton();
+        JButton help = new HelpAction(HelpFiles.CUSTOM_EXPORTS).getHelpButton();
 
         // Key bindings:
         JPanel main = new JPanel();

--- a/src/main/java/net/sf/jabref/gui/ContentSelectorDialog2.java
+++ b/src/main/java/net/sf/jabref/gui/ContentSelectorDialog2.java
@@ -443,7 +443,7 @@ class ContentSelectorDialog2 extends JDialog {
         bsb.addButton(apply);
         bsb.addButton(cancel);
         bsb.addRelatedGap();
-        bsb.addButton(new HelpAction(HelpFiles.contentSelectorHelp).getHelpButton());
+        bsb.addButton(new HelpAction(HelpFiles.CONTENT_SELECTOR).getHelpButton());
         bsb.addGlue();
 
         // Add panels to dialog:

--- a/src/main/java/net/sf/jabref/gui/GenFieldsCustomizer.java
+++ b/src/main/java/net/sf/jabref/gui/GenFieldsCustomizer.java
@@ -67,7 +67,7 @@ public class GenFieldsCustomizer extends JDialog {
     public GenFieldsCustomizer(JabRefFrame frame) {
         super(frame, Localization.lang("Set general fields"), false);
         parentFrame = frame;
-        helpBut = new HelpAction(HelpFiles.generalFieldsHelp).getHelpButton();
+        helpBut = new HelpAction(HelpFiles.GENERAL_FIELDS).getHelpButton();
         jbInit();
         setSize(new Dimension(650, 300));
     }

--- a/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
@@ -288,7 +288,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
                 Localization.lang("Cancel"));
         bb.addButton(cancel);
         bb.addRelatedGap();
-        JButton help = new HelpAction(HelpFiles.importInspectionHelp).getHelpButton();
+        JButton help = new HelpAction(HelpFiles.IMPORT_INSPECTION).getHelpButton();
         bb.addButton(help);
         bb.addGlue();
         bb.getPanel().setBorder(BorderFactory.createEmptyBorder(2, 2, 2, 2));
@@ -1269,6 +1269,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
 
     private void setupComparatorChooser() {
         // First column:
+
         List<Comparator> comparators = comparatorChooser.getComparatorsForColumn(0);
         comparators.clear();
 

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -269,7 +269,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     private final AbstractAction forkMeOnGitHubAction = new ForkMeOnGitHubAction();
     private final AbstractAction donationAction = new DonateAction();
     private final AbstractAction help = new HelpAction(Localization.menuTitle("JabRef help"), Localization.lang("JabRef help"),
-            HelpFiles.helpContents, Globals.getKeyPrefs().getKey(KeyBinding.HELP));
+            HelpFiles.CONTENTS, Globals.getKeyPrefs().getKey(KeyBinding.HELP));
     private final AbstractAction about = new AboutAction(Localization.menuTitle("About JabRef"), aboutDiag,
             Localization.lang("About JabRef"), IconTheme.getImage("about"));
     private final AbstractAction editEntry = new GeneralAction(Actions.EDIT, Localization.menuTitle("Edit entry"),

--- a/src/main/java/net/sf/jabref/gui/StringDialog.java
+++ b/src/main/java/net/sf/jabref/gui/StringDialog.java
@@ -88,7 +88,7 @@ class StringDialog extends JDialog {
 
         sortStrings();
 
-        helpAction = new HelpAction(Localization.lang("Help"), HelpFiles.stringEditorHelp);
+        helpAction = new HelpAction(Localization.lang("Help"), HelpFiles.STRING_EDITOR);
 
         addWindowListener(new WindowAdapter() {
 

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -213,7 +213,7 @@ public class EntryEditor extends JPanel implements VetoableChangeListener, Entry
         this.entry.addPropertyChangeListener(SpecialFieldUpdateListener.getInstance());
         displayedBibEntryType = entry.getType();
 
-        helpAction = new HelpAction(HelpFiles.entryEditorHelp, IconTheme.JabRefIcon.HELP.getIcon());
+        helpAction = new HelpAction(HelpFiles.ENTRY_EDITOR, IconTheme.JabRefIcon.HELP.getIcon());
         closeAction = new CloseAction();
         generateKeyAction = new GenerateKeyAction();
         storeFieldAction = new StoreFieldAction();

--- a/src/main/java/net/sf/jabref/gui/groups/GroupSelector.java
+++ b/src/main/java/net/sf/jabref/gui/groups/GroupSelector.java
@@ -293,7 +293,7 @@ public class GroupSelector extends SidePaneComponent implements TreeSelectionLis
         newButton.setMinimumSize(butDim);
         refresh.setPreferredSize(butDim);
         refresh.setMinimumSize(butDim);
-        JButton helpButton = new HelpAction(Localization.lang("Help on groups"), HelpFiles.groupsHelp)
+        JButton helpButton = new HelpAction(Localization.lang("Help on groups"), HelpFiles.GROUP)
                 .getHelpButton();
         helpButton.setPreferredSize(butDim);
         helpButton.setMinimumSize(butDim);

--- a/src/main/java/net/sf/jabref/gui/help/HelpAction.java
+++ b/src/main/java/net/sf/jabref/gui/help/HelpAction.java
@@ -40,32 +40,33 @@ import org.apache.commons.logging.LogFactory;
  * Dialog unless it is already visible, and shows the URL in it.
  */
 public class HelpAction extends MnemonicAwareAction {
+
     private static final Log LOGGER = LogFactory.getLog(HelpAction.class);
+    private HelpFiles helpPage;
 
-    private String urlPart;
 
-    public HelpAction(String title, String tooltip, String urlPart, KeyStroke key) {
-        this(title, tooltip, urlPart, IconTheme.JabRefIcon.HELP.getSmallIcon());
+    public HelpAction(String title, String tooltip, HelpFiles helpPage, KeyStroke key) {
+        this(title, tooltip, helpPage, IconTheme.JabRefIcon.HELP.getSmallIcon());
         putValue(Action.ACCELERATOR_KEY, key);
     }
 
-    private HelpAction(String title, String tooltip, String urlPart, Icon icon) {
+    private HelpAction(String title, String tooltip, HelpFiles helpPage, Icon icon) {
         super(icon);
-        this.urlPart = urlPart;
+        this.helpPage = helpPage;
         putValue(Action.NAME, title);
         putValue(Action.SHORT_DESCRIPTION, tooltip);
     }
 
-    public HelpAction(String tooltip, String urlPart) {
-        this(Localization.lang("Help"), tooltip, urlPart, IconTheme.JabRefIcon.HELP.getSmallIcon());
+    public HelpAction(String tooltip, HelpFiles helpPage) {
+        this(Localization.lang("Help"), tooltip, helpPage, IconTheme.JabRefIcon.HELP.getSmallIcon());
     }
 
-    public HelpAction(String urlPart, Icon icon) {
-        this(Localization.lang("Help"), Localization.lang("Help"), urlPart, icon);
+    public HelpAction(HelpFiles helpPage, Icon icon) {
+        this(Localization.lang("Help"), Localization.lang("Help"), helpPage, icon);
     }
 
-    public HelpAction(String urlPart) {
-        this(Localization.lang("Help"), Localization.lang("Help"), urlPart, IconTheme.JabRefIcon.HELP.getSmallIcon());
+    public HelpAction(HelpFiles helpPage) {
+        this(Localization.lang("Help"), Localization.lang("Help"), helpPage, IconTheme.JabRefIcon.HELP.getSmallIcon());
     }
 
     public JButton getHelpButton() {
@@ -76,14 +77,15 @@ public class HelpAction extends MnemonicAwareAction {
         return button;
     }
 
-    public void setHelpFile(String urlPart) {
-        this.urlPart = urlPart;
+    public void setHelpFile(HelpFiles urlPart) {
+        this.helpPage = urlPart;
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
         try {
-            JabRefDesktop.openBrowser("http://help.jabref.org/" + Globals.prefs.get(JabRefPreferences.LANGUAGE) + "/" + urlPart);
+            JabRefDesktop.openBrowser("http://help.jabref.org/" + Globals.prefs.get(JabRefPreferences.LANGUAGE) + "/"
+                    + helpPage.getPageName());
         } catch (IOException ex) {
             LOGGER.warn("Could not open browser", ex);
             JabRefGUI.getMainFrame().getCurrentBasePanel().output(Localization.lang("Could not open browser."));

--- a/src/main/java/net/sf/jabref/gui/help/HelpFiles.java
+++ b/src/main/java/net/sf/jabref/gui/help/HelpFiles.java
@@ -1,25 +1,144 @@
+/*  Copyright (C) 2003-2016 JabRef contributors.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
 package net.sf.jabref.gui.help;
 
-public class HelpFiles {
-    public static final String helpContents = "";
-    public static final String entryEditorHelp = "EntryEditorHelp";
-    public static final String stringEditorHelp = "StringEditorHelp";
-    public static final String searchHelp = "SearchHelp";
-    public static final String groupsHelp = "GroupsHelp";
-    public static final String contentSelectorHelp = "ContentSelectorHelp";
-    public static final String specialFieldsHelp = "SpecialFieldsHelp";
-    public static final String labelPatternHelp = "LabelPatterns";
-    public static final String ownerHelp = "OwnerHelp";
-    public static final String timeStampHelp = "TimeStampHelp";
-    public static final String exportCustomizationHelp = "CustomExports";
-    public static final String importCustomizationHelp = "CustomImports";
-    public static final String medlineHelp = "MedlineHelp";
-    public static final String generalFieldsHelp = "GeneralFields";
-    public static final String importInspectionHelp = "ImportInspectionDialog";
-    public static final String remoteHelp = "RemoteHelp";
-    public static final String journalAbbrHelp = "JournalAbbreviations";
-    public static final String regularExpressionSearchHelp = "ExternalFiles#RegularExpressionSearch";
-    public static final String nameFormatterHelp = "CustomExports#NameFormatter";
-    public static final String previewHelp = "PreviewHelp";
-    public static final String autosaveHelp = "Autosave";
+/**
+ * This enum globally defines all help pages with the name of the markdown file in the help repository at github
+ * @see <a href=https://github.com/JabRef/help.jabref.org>help.jabref.org@github</a>
+ *
+ *
+ */
+public enum HelpFiles {
+    COMMAND_LINE(
+            ""),
+
+    //Empty because it refers to the TOC/index
+    CONTENTS(
+            ""),
+    ENTRY_EDITOR(
+            "EntryEditorHelp"),
+    STRING_EDITOR(
+            "StringEditorHelp"),
+    SEARCH(
+            "SearchHelp"),
+    GROUP(
+            "GroupsHelp"),
+    CONTENT_SELECTOR(
+            "ContentSelectorHelp"),
+    SPECIAL_FIELDS(
+            "specialFieldsHelp"),
+    LABEL_PATTERN(
+            "labelPatternHelp"),
+    OWNER(
+            "OwnerHelp"),
+    TIMESTAMP(
+            "TimeStampHelp"),
+    CUSTOM_EXPORTS(
+            "CustomExports"),
+    CUSTOM_EXPORTS_NAME_FORMATTER(
+            "CustomExports#NameFormatter"),
+    CUSTOM_IMPORTS(
+            "CustomImports"),
+    GENERAL_FIELDS(
+            "GeneralFields"),
+    IMPORT_INSPECTION(
+            "ImportInspectionDialog"),
+    REMOTE(
+            "RemoteHelp"),
+    JOURNAL_ABBREV(
+            "JournalAbbreviations"),
+    REGEX_SEARCH(
+            "ExternalFiles#RegularExpressionSearch"),
+    PREVIEW(
+            "PreviewHelp"),
+    AUTOSAVE(
+            "Autosave"),
+
+    //The help page covers both OO and LO.
+    OPENOFFICE_LIBREOFFICE(
+            "OpenOfficeIntegration"),
+
+    FETCHER_ACM(
+            "ACMPortalHelp"),
+
+    FETCHER_ADS(
+            "ADSHelp"),
+
+    FETCHER_CITESEERX(
+            "CiteSeerHelp"),
+
+    FETCHER_DBLP(
+            "DBLPHelp"),
+
+    FETCHER_DIVA_TO_BIBTEX(
+            "DiVAtoBibTeXHelp"),
+
+    FETCHER_DOAJ(
+            "DOAJHelp"),
+
+    FETCHER_DOI_TO_BIBTEX(
+            "DOItoBibTeXHelp"),
+
+    FETCHER_GOOGLE_SCHOLAR(
+            "GoogleScholarHelp"),
+
+    FETCHER_GVK(
+            "GVKHelp"),
+
+    FETCHER_IEEEXPLORE(
+            "IEEEXploreHelp"),
+
+    FETCHER_INSPIRE(
+            "INSPIRE"),
+
+    FETCHER_ISBN_TO_BIBTEX(
+            "ISBNtoBibTeXHelp"),
+    FETCHER_MEDLINE(
+            "MedlineHelp"),
+
+    FETCHER_OAI2_ARXIV(
+            "arXivHelp"),
+
+    FETCHER_SPRINGER(
+            "SpringerHelp"),
+
+    FETCHER_SCIENCEDIRECT(
+            ""),
+
+    FETCHER_BIBSONOMY_SCRAPER(
+            "");
+
+    /**
+     *
+     * @param pageName The filename of the help page
+     */
+    HelpFiles(String pageName) {
+        this.pageName = pageName;
+    }
+
+
+    private final String pageName;
+
+
+    /**
+     * Get the filename of a help page
+     * @return The filename of the associated help page
+     */
+    public String getPageName() {
+        return pageName;
+    }
+
 }

--- a/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
+++ b/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
@@ -163,7 +163,7 @@ class ManageJournalsPanel extends JPanel {
         bb.addButton(cancel);
         bb.addUnrelatedGap();
 
-        JButton help = new HelpAction(HelpFiles.journalAbbrHelp).getHelpButton();
+        JButton help = new HelpAction(HelpFiles.JOURNAL_ABBREV).getHelpButton();
         bb.addButton(help);
         bb.addGlue();
         bb.getPanel().setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));

--- a/src/main/java/net/sf/jabref/gui/labelpattern/LabelPatternPanel.java
+++ b/src/main/java/net/sf/jabref/gui/labelpattern/LabelPatternPanel.java
@@ -63,7 +63,7 @@ public class LabelPatternPanel extends JPanel {
 
     public LabelPatternPanel(BasePanel panel) {
         this.panel = panel;
-        help = new HelpAction(Localization.lang("Help on key patterns"), HelpFiles.labelPatternHelp);
+        help = new HelpAction(Localization.lang("Help on key patterns"), HelpFiles.LABEL_PATTERN);
         buildGUI();
     }
 

--- a/src/main/java/net/sf/jabref/gui/openoffice/OpenOfficePanel.java
+++ b/src/main/java/net/sf/jabref/gui/openoffice/OpenOfficePanel.java
@@ -53,6 +53,7 @@ import net.sf.jabref.gui.SidePaneComponent;
 import net.sf.jabref.gui.SidePaneManager;
 import net.sf.jabref.gui.actions.BrowseAction;
 import net.sf.jabref.gui.help.HelpAction;
+import net.sf.jabref.gui.help.HelpFiles;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.gui.worker.AbstractWorker;
 import net.sf.jabref.logic.l10n.Localization;
@@ -96,7 +97,8 @@ public class OpenOfficePanel extends AbstractWorker {
     private final JButton merge = new JButton(Localization.lang("Merge citations"));
     private final JButton manageCitations = new JButton(Localization.lang("Manage citations"));
     private final JButton settingsB = new JButton(Localization.lang("Settings"));
-    private final JButton help = new HelpAction("OpenOfficeIntegration").getHelpButton();
+    private final JButton help = new HelpAction(Localization.lang("OpenOffice/LibreOffice integration"),
+            HelpFiles.OPENOFFICE_LIBREOFFICE).getHelpButton();
     private OOBibBase ooBase;
     private JabRefFrame frame;
     private SidePaneManager manager;
@@ -461,7 +463,7 @@ public class OpenOfficePanel extends AbstractWorker {
         } catch (SecurityException | NoSuchMethodException | IllegalAccessException | IllegalArgumentException |
                 InvocationTargetException e) {
             LOGGER.error("Could not add URL to system classloader", e);
-            throw new IOException("Error, could not add URL to system classloader");
+            throw new IOException("Error, could not add URL to system classloader", e);
 
         }
     }

--- a/src/main/java/net/sf/jabref/gui/preftabs/AdvancedTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/AdvancedTab.java
@@ -82,7 +82,7 @@ class AdvancedTab extends JPanel implements PrefsTab {
         JPanel p = new JPanel();
         p.add(useRemoteServer);
         p.add(remoteServerPort);
-        p.add(new HelpAction(HelpFiles.remoteHelp).getHelpButton());
+        p.add(new HelpAction(HelpFiles.REMOTE).getHelpButton());
         builder.append(p);
 
         // IEEE

--- a/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
@@ -177,7 +177,9 @@ class FileTab extends JPanel implements PrefsTab {
         builder.append(useRegExpComboBox);
         builder.append(regExpTextField);
 
-        builder.append(new HelpAction(Localization.lang("Help on Regular Expression Search"), HelpFiles.regularExpressionSearchHelp).getHelpButton());
+        builder.append(new HelpAction(Localization.lang("Help on Regular Expression Search"),
+                HelpFiles.REGEX_SEARCH)
+                .getHelpButton());
         builder.nextLine();
         builder.append(runAutoFileSearch, 3);
         builder.nextLine();
@@ -186,7 +188,7 @@ class FileTab extends JPanel implements PrefsTab {
 
         builder.appendSeparator(Localization.lang("Autosave"));
         builder.append(autoSave, 1);
-        JButton help = new HelpAction(HelpFiles.autosaveHelp).getHelpButton();
+        JButton help = new HelpAction(HelpFiles.AUTOSAVE).getHelpButton();
         help.setPreferredSize(new Dimension(24, 24));
         JPanel hPan = new JPanel();
         hPan.setLayout(new BorderLayout());

--- a/src/main/java/net/sf/jabref/gui/preftabs/GeneralTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/GeneralTab.java
@@ -144,7 +144,7 @@ class GeneralTab extends JPanel implements PrefsTab {
         builder.append(overwriteOwner);
         builder.append(new JPanel(), 3);
 
-        JButton help = new HelpAction(HelpFiles.ownerHelp).getHelpButton();
+        JButton help = new HelpAction(HelpFiles.OWNER).getHelpButton();
         builder.append(help);
         builder.nextLine();
 
@@ -154,7 +154,7 @@ class GeneralTab extends JPanel implements PrefsTab {
         builder.append(Localization.lang("Field name") + ':');
         builder.append(timeStampField);
 
-        help = new HelpAction(HelpFiles.timeStampHelp).getHelpButton();
+        help = new HelpAction(HelpFiles.TIMESTAMP).getHelpButton();
         builder.append(help);
         builder.nextLine();
 

--- a/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
@@ -193,7 +193,8 @@ public class NameFormatterTab extends JPanel implements PrefsTab {
         toolBar.setBorder(null);
         toolBar.add(new AddRowAction());
         toolBar.add(new DeleteRowAction());
-        toolBar.add(new HelpAction(Localization.lang("Help on Name Formatting"), HelpFiles.nameFormatterHelp));
+        toolBar.add(new HelpAction(Localization.lang("Help on Name Formatting"),
+                HelpFiles.CUSTOM_EXPORTS_NAME_FORMATTER).getHelpButton());
 
         tabPanel.add(toolBar, BorderLayout.EAST);
 

--- a/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
@@ -304,7 +304,8 @@ class TableColumnsTab extends JPanel implements PrefsTab {
 
         /*** begin: special table columns and special fields ***/
 
-        JButton helpButton = new HelpAction(Localization.lang("Help on special fields"), HelpFiles.specialFieldsHelp).getHelpButton();
+        JButton helpButton = new HelpAction(Localization.lang("Help on special fields"),
+                HelpFiles.SPECIAL_FIELDS).getHelpButton();
 
         rankingColumn = new JCheckBox(Localization.lang("Show rank"));
         qualityColumn = new JCheckBox(Localization.lang("Show quality"));

--- a/src/main/java/net/sf/jabref/importer/ImportCustomizationDialog.java
+++ b/src/main/java/net/sf/jabref/importer/ImportCustomizationDialog.java
@@ -189,7 +189,7 @@ public class ImportCustomizationDialog extends JDialog {
         JButton closeButton = new JButton(Localization.lang("Close"));
         closeButton.addActionListener(closeAction);
 
-        JButton helpButton = new HelpAction(HelpFiles.importCustomizationHelp).getHelpButton();
+        JButton helpButton = new HelpAction(HelpFiles.CUSTOM_IMPORTS).getHelpButton();
 
 
         // Key bindings:

--- a/src/main/java/net/sf/jabref/importer/fetcher/ACMPortalFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/ACMPortalFetcher.java
@@ -44,6 +44,7 @@ import javax.swing.JRadioButton;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.FetcherPreviewDialog;
+import net.sf.jabref.gui.help.HelpFiles;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OutputPrinter;
 import net.sf.jabref.importer.fileformat.BibtexParser;
@@ -417,8 +418,8 @@ public class ACMPortalFetcher implements PreviewEntryFetcher {
     }
 
     @Override
-    public String getHelpPage() {
-        return "ACMPortalHelp";
+    public HelpFiles getHelpPage() {
+        return HelpFiles.FETCHER_ACM;
     }
 
 

--- a/src/main/java/net/sf/jabref/importer/fetcher/ADSFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/ADSFetcher.java
@@ -39,6 +39,7 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
+import net.sf.jabref.gui.help.HelpFiles;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OutputPrinter;
 import net.sf.jabref.importer.ParserResult;
@@ -69,8 +70,8 @@ public class ADSFetcher implements EntryFetcher {
     }
 
     @Override
-    public String getHelpPage() {
-        return null;
+    public HelpFiles getHelpPage() {
+        return HelpFiles.FETCHER_ADS;
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/importer/fetcher/CiteSeerXFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/CiteSeerXFetcher.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 
 import javax.swing.JPanel;
 
+import net.sf.jabref.gui.help.HelpFiles;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OutputPrinter;
 import net.sf.jabref.logic.formatter.bibtexfields.NormalizeNamesFormatter;
@@ -87,8 +88,8 @@ public class CiteSeerXFetcher implements EntryFetcher {
     }
 
     @Override
-    public String getHelpPage() {
-        return "CiteSeerHelp";
+    public HelpFiles getHelpPage() {
+        return HelpFiles.FETCHER_CITESEERX;
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/importer/fetcher/DBLPFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/DBLPFetcher.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import javax.swing.JPanel;
 
+import net.sf.jabref.gui.help.HelpFiles;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OutputPrinter;
 import net.sf.jabref.importer.fileformat.BibtexParser;
@@ -166,8 +167,8 @@ public class DBLPFetcher implements EntryFetcher {
     }
 
     @Override
-    public String getHelpPage() {
-        return null;
+    public HelpFiles getHelpPage() {
+        return HelpFiles.FETCHER_DBLP;
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/importer/fetcher/DOAJFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/DOAJFetcher.java
@@ -18,6 +18,7 @@ package net.sf.jabref.importer.fetcher;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 
+import net.sf.jabref.gui.help.HelpFiles;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OutputPrinter;
 import net.sf.jabref.importer.fileformat.JSONEntryParser;
@@ -124,8 +125,8 @@ public class DOAJFetcher implements EntryFetcher {
     }
 
     @Override
-    public String getHelpPage() {
-        return "DOAJHelp";
+    public HelpFiles getHelpPage() {
+        return HelpFiles.FETCHER_DOAJ;
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/importer/fetcher/DOItoBibTeXFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/DOItoBibTeXFetcher.java
@@ -29,6 +29,7 @@ import javax.swing.JPanel;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.gui.help.HelpFiles;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OutputPrinter;
 import net.sf.jabref.importer.fileformat.BibtexParser;
@@ -70,8 +71,8 @@ public class DOItoBibTeXFetcher implements EntryFetcher {
     }
 
     @Override
-    public String getHelpPage() {
-        return "DOItoBibTeXHelp";
+    public HelpFiles getHelpPage() {
+        return HelpFiles.FETCHER_DOI_TO_BIBTEX;
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/importer/fetcher/DiVAtoBibTeXFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/DiVAtoBibTeXFetcher.java
@@ -27,6 +27,7 @@ import javax.swing.JPanel;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.gui.help.HelpFiles;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OutputPrinter;
 import net.sf.jabref.importer.fileformat.BibtexParser;
@@ -124,8 +125,8 @@ public class DiVAtoBibTeXFetcher implements EntryFetcher {
     }
 
     @Override
-    public String getHelpPage() {
-        return "DiVAtoBibTeXHelp";
+    public HelpFiles getHelpPage() {
+        return HelpFiles.FETCHER_DIVA_TO_BIBTEX;
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/importer/fetcher/EntryFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/EntryFetcher.java
@@ -18,6 +18,7 @@ package net.sf.jabref.importer.fetcher;
 import javax.swing.JPanel;
 
 import net.sf.jabref.gui.ImportInspectionDialog;
+import net.sf.jabref.gui.help.HelpFiles;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OutputPrinter;
 
@@ -67,10 +68,9 @@ public interface EntryFetcher extends ImportInspectionDialog.CallBack {
      * If given, a question mark is displayed in the side pane which leads to
      * the help page.
      *
-     * @return The name of the help file or null if this activeFetcher does not have
-     *         any help.
+     * @return The {@link HelpFiles} enum constant for the help page
      */
-    String getHelpPage();
+    HelpFiles getHelpPage();
 
     /**
      * If this activeFetcher requires additional options, a panel for setting up these

--- a/src/main/java/net/sf/jabref/importer/fetcher/GVKFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/GVKFetcher.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import javax.swing.JPanel;
 import javax.xml.parsers.ParserConfigurationException;
 
+import net.sf.jabref.gui.help.HelpFiles;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OutputPrinter;
 import net.sf.jabref.logic.l10n.Localization;
@@ -61,8 +62,8 @@ public class GVKFetcher implements EntryFetcher {
     }
 
     @Override
-    public String getHelpPage() {
-        return "GVKHelp";
+    public HelpFiles getHelpPage() {
+        return HelpFiles.FETCHER_GVK;
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/importer/fetcher/GoogleScholarFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/GoogleScholarFetcher.java
@@ -34,6 +34,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 import net.sf.jabref.gui.FetcherPreviewDialog;
+import net.sf.jabref.gui.help.HelpFiles;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OutputPrinter;
 import net.sf.jabref.importer.ParserResult;
@@ -149,8 +150,8 @@ public class GoogleScholarFetcher implements PreviewEntryFetcher {
     }
 
     @Override
-    public String getHelpPage() {
-        return "GoogleScholarHelp";
+    public HelpFiles getHelpPage() {
+        return HelpFiles.FETCHER_GOOGLE_SCHOLAR;
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/importer/fetcher/IEEEXploreFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/IEEEXploreFetcher.java
@@ -38,6 +38,7 @@ import javax.swing.JPanel;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.gui.help.HelpFiles;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OutputPrinter;
 import net.sf.jabref.importer.fileformat.BibtexParser;
@@ -201,8 +202,8 @@ public class IEEEXploreFetcher implements EntryFetcher {
     }
 
     @Override
-    public String getHelpPage() {
-        return "IEEEXploreHelp";
+    public HelpFiles getHelpPage() {
+        return HelpFiles.FETCHER_IEEEXPLORE;
     }
 
     /**

--- a/src/main/java/net/sf/jabref/importer/fetcher/INSPIREFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/INSPIREFetcher.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 
+import net.sf.jabref.gui.help.HelpFiles;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OutputPrinter;
 import net.sf.jabref.importer.ParserResult;
@@ -138,8 +139,8 @@ public class INSPIREFetcher implements EntryFetcher {
      * @see net.sf.jabref.imports.fetcher.EntryFetcher
      */
     @Override
-    public String getHelpPage() {
-        return "INSPIRE";
+    public HelpFiles getHelpPage() {
+        return HelpFiles.FETCHER_INSPIRE;
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/importer/fetcher/ISBNtoBibTeXFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/ISBNtoBibTeXFetcher.java
@@ -28,6 +28,7 @@ import javax.swing.JPanel;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.gui.help.HelpFiles;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OutputPrinter;
 import net.sf.jabref.importer.fileformat.BibtexParser;
@@ -133,8 +134,8 @@ public class ISBNtoBibTeXFetcher implements EntryFetcher {
     }
 
     @Override
-    public String getHelpPage() {
-        return "ISBNtoBibTeXHelp";
+    public HelpFiles getHelpPage() {
+        return HelpFiles.FETCHER_ISBN_TO_BIBTEX;
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/importer/fetcher/MedlineFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/MedlineFetcher.java
@@ -125,8 +125,8 @@ public class MedlineFetcher implements EntryFetcher {
     }
 
     @Override
-    public String getHelpPage() {
-        return HelpFiles.medlineHelp;
+    public HelpFiles getHelpPage() {
+        return HelpFiles.FETCHER_MEDLINE;
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/importer/fetcher/OAI2Fetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/OAI2Fetcher.java
@@ -31,6 +31,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
+import net.sf.jabref.gui.help.HelpFiles;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OAI2Handler;
 import net.sf.jabref.importer.OutputPrinter;
@@ -232,9 +233,8 @@ public class OAI2Fetcher implements EntryFetcher {
     }
 
     @Override
-    public String getHelpPage() {
-        // there is no helppage
-        return null;
+    public HelpFiles getHelpPage() {
+        return HelpFiles.FETCHER_OAI2_ARXIV;
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/importer/fetcher/ScienceDirectFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/ScienceDirectFetcher.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 
+import net.sf.jabref.gui.help.HelpFiles;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OutputPrinter;
 import net.sf.jabref.logic.l10n.Localization;
@@ -35,6 +36,12 @@ import net.sf.jabref.logic.net.URLDownload;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+/**
+ *
+ * The current ScienceDirect fetcher implementation does no longer work
+ *
+ */
+@Deprecated
 public class ScienceDirectFetcher implements EntryFetcher {
 
     private static final String SCIENCE_DIRECT = "ScienceDirect";
@@ -53,8 +60,8 @@ public class ScienceDirectFetcher implements EntryFetcher {
 
 
     @Override
-    public String getHelpPage() {
-        return SCIENCE_DIRECT;
+    public HelpFiles getHelpPage() {
+        return HelpFiles.FETCHER_SCIENCEDIRECT;
     }
 
     @Override
@@ -65,7 +72,7 @@ public class ScienceDirectFetcher implements EntryFetcher {
 
     @Override
     public String getTitle() {
-        return SCIENCE_DIRECT;
+        return "ScienceDirect";
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/importer/fetcher/SpringerFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/SpringerFetcher.java
@@ -19,7 +19,8 @@ package net.sf.jabref.importer.fetcher;
     import javax.swing.JOptionPane;
     import javax.swing.JPanel;
 
-    import net.sf.jabref.importer.ImportInspector;
+import net.sf.jabref.gui.help.HelpFiles;
+import net.sf.jabref.importer.ImportInspector;
     import net.sf.jabref.importer.OutputPrinter;
     import net.sf.jabref.importer.fileformat.JSONEntryParser;
     import net.sf.jabref.logic.l10n.Localization;
@@ -129,8 +130,8 @@ public class SpringerFetcher implements EntryFetcher {
     }
 
     @Override
-    public String getHelpPage() {
-        return "SpringerHelp";
+    public HelpFiles getHelpPage() {
+        return HelpFiles.FETCHER_SPRINGER;
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/logic/groups/AbstractGroup.java
+++ b/src/main/java/net/sf/jabref/logic/groups/AbstractGroup.java
@@ -131,6 +131,7 @@ public abstract class AbstractGroup implements SearchMatcher {
      */
     public abstract boolean contains(BibEntry entry);
 
+    @Override
     public boolean isMatch(BibEntry entry) {
         return contains(entry);
     }

--- a/src/main/java/net/sf/jabref/sql/database/MySQL.java
+++ b/src/main/java/net/sf/jabref/sql/database/MySQL.java
@@ -14,7 +14,8 @@ public class MySQL implements Database {
 
     public static final String DRIVER = "com.mysql.jdbc.Driver";
 
-    private void loadDriver() throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+
+    private void loadDriver() throws InstantiationException, IllegalAccessException, ClassNotFoundException {
         Class.forName(DRIVER).newInstance();
     }
 

--- a/src/main/java/net/sf/jabref/sql/importer/DatabaseImporter.java
+++ b/src/main/java/net/sf/jabref/sql/importer/DatabaseImporter.java
@@ -89,7 +89,7 @@ public class DatabaseImporter {
      */
     private List<String> readColumnNames(Connection conn) throws SQLException {
         String query = database.getReadColumnNamesQuery();
-        try (Statement statement = (Statement) conn.createStatement();
+        try (Statement statement = conn.createStatement();
              ResultSet rsColumns = statement.executeQuery(query)) {
             List<String> colNames = new ArrayList<>();
             while (rsColumns.next()) {
@@ -106,10 +106,15 @@ public class DatabaseImporter {
      * @param mode
      * @return An ArrayList containing pairs of Objects. Each position of the ArrayList stores three Objects: a
      * BibDatabase, a MetaData and a String with the bib database name stored in the DBMS
+     * @throws SQLException
+     * @throws ClassNotFoundException
+     * @throws InstantiationException
+     * @throws IllegalAccessException
      * @throws Exception
      */
     public List<DBImporterResult> performImport(DBStrings dbs, List<String> listOfDBs, BibDatabaseMode mode)
-            throws Exception {
+            throws IllegalAccessException, InstantiationException, ClassNotFoundException, SQLException
+    {
         List<DBImporterResult> result = new ArrayList<>();
         try (Connection conn = this.connectToDB(dbs)) {
 
@@ -281,9 +286,13 @@ public class DatabaseImporter {
      *
      * @param dbstrings The DBStrings to use to make the connection
      * @return java.sql.Connection to the DB chosen
-     * @throws Exception
+     * @throws SQLException
+     * @throws ClassNotFoundException
+     * @throws InstantiationException
+     * @throws IllegalAccessException
      */
-    public Connection connectToDB(DBStrings dbstrings) throws Exception {
+    public Connection connectToDB(DBStrings dbstrings)
+            throws IllegalAccessException, InstantiationException, ClassNotFoundException, SQLException {
         String url = SQLUtil.createJDBCurl(dbstrings, true);
         return database.connect(url, dbstrings.getDbPreferences().getUsername(), dbstrings.getPassword());
     }

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -1674,3 +1674,5 @@ Show_symmetric_diff=
 HTML_encoded_character_found=
 
 All_external_files=
+
+OpenOffice/LibreOffice_integration=

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2392,3 +2392,5 @@ Show_symmetric_diff=
 HTML_encoded_character_found=
 
 All_external_files=
+
+OpenOffice/LibreOffice_integration=

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2255,3 +2255,5 @@ Show_symmetric_diff=Show_symmetric_diff
 HTML_encoded_character_found=HTML_encoded_character_found
 
 All_external_files=All_external_files
+
+OpenOffice/LibreOffice_integration=OpenOffice/LibreOffice_integration

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -1575,3 +1575,5 @@ Show_symmetric_diff=
 HTML_encoded_character_found=
 
 All_external_files=
+
+OpenOffice/LibreOffice_integration=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -2362,3 +2362,5 @@ Show_symmetric_diff=
 HTML_encoded_character_found=
 
 All_external_files=
+
+OpenOffice/LibreOffice_integration=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -1618,3 +1618,5 @@ Show_symmetric_diff=
 HTML_encoded_character_found=
 
 All_external_files=
+
+OpenOffice/LibreOffice_integration=

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -1594,3 +1594,5 @@ Show_symmetric_diff=
 HTML_encoded_character_found=
 
 All_external_files=
+
+OpenOffice/LibreOffice_integration=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -1694,3 +1694,5 @@ Show_symmetric_diff=
 HTML_encoded_character_found=
 
 All_external_files=
+
+OpenOffice/LibreOffice_integration=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2338,3 +2338,5 @@ Show_symmetric_diff=
 HTML_encoded_character_found=
 
 All_external_files=
+
+OpenOffice/LibreOffice_integration=

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -2372,3 +2372,5 @@ Show_symmetric_diff=
 HTML_encoded_character_found=
 
 All_external_files=
+
+OpenOffice/LibreOffice_integration=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -2768,3 +2768,5 @@ Show_symmetric_diff=
 HTML_encoded_character_found=
 
 All_external_files=
+
+OpenOffice/LibreOffice_integration=

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -1588,3 +1588,5 @@ Show_symmetric_diff=
 HTML_encoded_character_found=
 
 All_external_files=
+
+OpenOffice/LibreOffice_integration=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2339,3 +2339,5 @@ Show_symmetric_diff=
 HTML_encoded_character_found=
 
 All_external_files=
+
+OpenOffice/LibreOffice_integration=

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -1532,3 +1532,5 @@ Show_symmetric_diff=Visa_skillnad_symmetriskt
 HTML_encoded_character_found=HTML-kodade_tecken_hittades
 
 All_external_files=
+
+OpenOffice/LibreOffice_integration=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -1606,3 +1606,5 @@ Show_symmetric_diff=Simetrik_diff_göster
 HTML_encoded_character_found=HTML_kodlu_karakter_bulundu
 
 All_external_files=
+
+OpenOffice/LibreOffice_integration=

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -2363,3 +2363,5 @@ Show_symmetric_diff=
 HTML_encoded_character_found=
 
 All_external_files=
+
+OpenOffice/LibreOffice_integration=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -1600,3 +1600,5 @@ Show_symmetric_diff=
 HTML_encoded_character_found=
 
 All_external_files=
+
+OpenOffice/LibreOffice_integration=

--- a/src/test/java/net/sf/jabref/logic/l10n/LocalizationConsistencyTest.java
+++ b/src/test/java/net/sf/jabref/logic/l10n/LocalizationConsistencyTest.java
@@ -51,13 +51,6 @@ public class LocalizationConsistencyTest {
         }
 
         /**
-         * @param defaults
-         */
-        public DuplicationDetectionProperties(Properties defaults) {
-            super(defaults);
-        }
-
-        /**
          * Overriding the HashTable put() so we can check for duplicates
          */
         @Override
@@ -166,7 +159,7 @@ public class LocalizationConsistencyTest {
             System.out.println();
             System.out.println("1. REMOVE THESE FROM THE ENGLISH LANGUAGE FILE");
             System.out.println(
-                    "2. EXECUTE gradlew -b localization.gradle compareAndUpdateTranslationsWithEnglishTranslation TO");
+                    "2. EXECUTE gradlew -b localization.gradle generateMissingTranslationKeys\r\n" + " TO");
             System.out.println("REMOVE THESE FROM THE NON-ENGLISH LANGUAGE FILES");
             fail("Obsolete keys " + obsoleteKeys + " found in menu properties file which should be removed");
         }
@@ -192,7 +185,7 @@ public class LocalizationConsistencyTest {
 
     private String convertPropertiesFile(List<LocalizationEntry> missingKeys) {
         System.out.println(
-                "EXECUTE gradlew -b localization.gradle compareAndUpdateTranslationsWithEnglishTranslation TO");
+                "EXECUTE gradlew -b localization.gradle generateMissingTranslationKeys TO");
         System.out.println("PASTE THIS INTO THE NON-ENGLISH LANGUAGE FILES");
         StringJoiner result = new StringJoiner("\n");
         for (LocalizationEntry key : missingKeys) {


### PR DESCRIPTION
Help Pages are now all listed in one file. 
See: https://github.com/JabRef/help.jabref.org/issues/11 (I cant' get the crosslinking right)
~~Use given encoding when writing SQL-Files~~ (no longer relevant)
Refactored some DB Exceptions

-  [X] Change in CHANGELOG.md described

@mlep  Have a look at the HelpFiles,java file There are all help pages listed which are atm used. The one with the empty Strings ("") atm don't have a help page associated, but should (at least the fetchers) (except for CONTENTS, as it links to the toc of the help pages.


@oscargus  As you worked on the CLI classes recently, is there a way to link to the help page like in the gui dialogs?
https://github.com/JabRef/help.jabref.org/blob/gh-pages/en/CommandLine.md


