### PR TITLE
Fix 1270: autosave is working again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 
 ### Fixed
 - Fixed [#473](https://github.com/JabRef/jabref/issues/473): Values in an entry containing symbols like ' are now properly escaped for exporting to the database
-
+- Fixed [#1270](https://github.com/JabRef/jabref/issues/1270): Auto save is now working again as expected (without leaving a bunch of temporary files behind)
 - Fixed [#1234](https://github.com/JabRef/jabref/issues/1234): NPE when getting information from retrieved DOI
 
 ### Removed

--- a/src/main/java/net/sf/jabref/exporter/AutoSaveManager.java
+++ b/src/main/java/net/sf/jabref/exporter/AutoSaveManager.java
@@ -98,7 +98,7 @@ public class AutoSaveManager {
 
             BibDatabaseWriter databaseWriter = new BibDatabaseWriter();
             SaveSession ss = databaseWriter.saveDatabase(panel.getBibDatabaseContext(), prefs);
-
+            ss.commit(backupFile);
         } catch (SaveException e) {
             LOGGER.error("Problem with automatic save", e);
             return false;


### PR DESCRIPTION
Fixed #1270. The auto save file was actually not saved at the desired place and thus the temp files were left over.

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)

