### PR TITLE
Replace BibtexEntryAssert by overwriting BibEntry.equals method

### DIFF
--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -664,7 +664,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     for (BibEntry entry : entries) {
                         bes = entry;
                         // Store the old value:
-                        oldvals.put(bes, bes.getField(BibEntry.KEY_FIELD));
+                        oldvals.put(bes, bes.getCiteKey());
                         database.setCiteKeyForEntry(bes, null);
                     }
                 }
@@ -676,7 +676,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     bes = entry;
                     LabelPatternUtil.makeLabel(bibDatabaseContext.getMetaData(), database, bes);
                     ce.addEdit(new UndoableKeyChange(database, bes, (String) oldvals.get(bes),
-                            bes.getField(BibEntry.KEY_FIELD)));
+                            bes.getCiteKey()));
                 }
                 ce.end();
                 undoManager.addEdit(ce);

--- a/src/main/java/net/sf/jabref/gui/preftabs/PreviewPrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/PreviewPrefsTab.java
@@ -189,7 +189,7 @@ class PreviewPrefsTab extends JPanel implements PrefsTab {
             return PreviewPrefsTab.entry;
         }
         PreviewPrefsTab.entry = new BibEntry(IdGenerator.next(), "article");
-        PreviewPrefsTab.entry.setField(BibEntry.KEY_FIELD, "conceicao1997");
+        PreviewPrefsTab.entry.setCiteKey("conceicao1997");
         PreviewPrefsTab.entry.setField("author",
                 "Luis E. C. Conceic{\\~a}o and Terje van der Meeren and Johan A. J. Verreth and M S. Evjen and D. F. Houlihan and H. J. Fyhn");
         PreviewPrefsTab.entry.setField("title",

--- a/src/main/java/net/sf/jabref/importer/fileformat/BibTeXMLHandler.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibTeXMLHandler.java
@@ -77,7 +77,7 @@ class BibTeXMLHandler extends DefaultHandler {
                     }
                 }
                 if (bibtexKey != null) {
-                    b.setField(BibEntry.KEY_FIELD, bibtexKey);
+                    b.setCiteKey(bibtexKey);
                 }
             } else if ("article".equals(local) || "inbook".equals(local) || "book".equals(local)
                     || "booklet".equals(local) || "incollection".equals(local) || "inproceedings".equals(local)

--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
@@ -513,7 +513,7 @@ public class BibtexParser {
             skipWhitespace();
         }
         String key = parseKey();
-        result.setField(BibEntry.KEY_FIELD, key);
+        result.setCiteKey(key);
         skipWhitespace();
 
         while (true) {

--- a/src/main/java/net/sf/jabref/importer/fileformat/MedlinePlainImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/MedlinePlainImporter.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.importer.ImportFormatReader;
 import net.sf.jabref.importer.OutputPrinter;
 import net.sf.jabref.model.entry.AuthorList;
@@ -213,7 +214,7 @@ public class MedlinePlainImporter extends ImportFormat {
                     if (oldAb == null) {
                         hm.put("abstract", val);
                     } else {
-                        hm.put("abstract", oldAb + "\n" + val);
+                        hm.put("abstract", oldAb + Globals.NEWLINE + val);
                     }
                 } else if ("DP".equals(lab)) {
                     String[] parts = val.split(" ");

--- a/src/main/java/net/sf/jabref/importer/fileformat/RisImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/RisImporter.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.importer.ImportFormatReader;
 import net.sf.jabref.importer.OutputPrinter;
 import net.sf.jabref.model.entry.AuthorList;
@@ -207,7 +208,7 @@ public class RisImporter extends ImportFormat {
                         if (oldAb == null) {
                             hm.put("abstract", val);
                         } else {
-                            hm.put("abstract", oldAb + "\n" + val);
+                            hm.put("abstract", oldAb + Globals.NEWLINE + val);
                         }
                     } else if ("UR".equals(lab)) {
                         hm.put("url", val);

--- a/src/main/java/net/sf/jabref/logic/labelpattern/LabelPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/labelpattern/LabelPatternUtil.java
@@ -500,7 +500,7 @@ public class LabelPatternUtil {
             if (!key.equals(oldKey)) {
                 if (!database.containsEntryWithId(entry.getId())) {
                     // entry does not (yet) exist in the database, just update the entry
-                    entry.setField(BibEntry.KEY_FIELD, key);
+                    entry.setCiteKey(key);
                 } else {
                     database.setCiteKeyForEntry(entry, key);
                 }
@@ -533,7 +533,7 @@ public class LabelPatternUtil {
             if (!moddedKey.equals(oldKey)) {
                 if (!database.containsEntryWithId(entry.getId())) {
                     // entry does not (yet) exist in the database, just update the entry
-                    entry.setField(BibEntry.KEY_FIELD, moddedKey);
+                    entry.setCiteKey(moddedKey);
                 } else {
                     database.setCiteKeyForEntry(entry, moddedKey);
                 }

--- a/src/main/java/net/sf/jabref/logic/mods/MODSEntry.java
+++ b/src/main/java/net/sf/jabref/logic/mods/MODSEntry.java
@@ -112,7 +112,7 @@ class MODSEntry {
         }
 
         if (bibtex.hasField(BibEntry.KEY_FIELD)) {
-            id = bibtex.getField(BibEntry.KEY_FIELD);
+            id = bibtex.getCiteKey();
         }
         if (bibtex.hasField("place")) {
             if (CHARFORMAT) {

--- a/src/main/java/net/sf/jabref/logic/msbib/MSBibEntry.java
+++ b/src/main/java/net/sf/jabref/logic/msbib/MSBibEntry.java
@@ -323,7 +323,7 @@ class MSBibEntry {
         sourceType = getMSBibSourceType(bibtex);
 
         if (bibtex.hasField(BibEntry.KEY_FIELD)) {
-            tag = bibtex.getField(BibEntry.KEY_FIELD);
+            tag = bibtex.getCiteKey();
         }
 
         if (bibtex.hasField("language")) {

--- a/src/main/java/net/sf/jabref/model/database/BibDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabase.java
@@ -212,7 +212,7 @@ public class BibDatabase {
         if (key == null) {
             entry.clearField(BibEntry.KEY_FIELD);
         } else {
-            entry.setField(BibEntry.KEY_FIELD, key);
+            entry.setCiteKey(key);
         }
         return duplicationChecker.checkForDuplicateKeyAndAdd(oldKey, entry.getCiteKey());
     }

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -611,4 +611,21 @@ public class BibEntry {
         // TODO Auto-generated method stub
         return fields;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BibEntry entry = (BibEntry) o;
+        return Objects.equals(type, entry.type) && Objects.equals(fields, entry.fields);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, fields);
+    }
 }

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -309,15 +309,11 @@ public class BibEntry {
     /**
      * Sets a number of fields simultaneously. The given HashMap contains field
      * names as keys, each mapped to the value to set.
-     * WARNING: this method does not notify change listeners, so it should *NOT*
-     * be used for entries that are being displayed in the GUI. Furthermore, it
-     * does not check values for content, so e.g. empty strings will be set as such.
      */
     public void setField(Map<String, String> fields) {
         Objects.requireNonNull(fields, "fields must not be null");
 
-        changed = true;
-        this.fields.putAll(fields);
+        fields.forEach((field, value) -> setField(field, value));
     }
 
     /**
@@ -329,6 +325,11 @@ public class BibEntry {
     public void setField(String name, String value) {
         Objects.requireNonNull(name, "field name must not be null");
         Objects.requireNonNull(value, "field value must not be null");
+
+        if(value.isEmpty()) {
+            clearField(name);
+            return;
+        }
 
         String fieldName = toLowerCase(name);
 

--- a/src/main/java/net/sf/jabref/sql/importer/DatabaseImporter.java
+++ b/src/main/java/net/sf/jabref/sql/importer/DatabaseImporter.java
@@ -149,7 +149,7 @@ public class DatabaseImporter {
                         while (rsEntries.next()) {
                             String id = rsEntries.getString("entries_id");
                             BibEntry entry = new BibEntry(IdGenerator.next(), types.get(rsEntries.getString("entry_types_id")).getName());
-                            entry.setField(BibEntry.KEY_FIELD, rsEntries.getString("cite_key"));
+                            entry.setCiteKey(rsEntries.getString("cite_key"));
                             for (String col : colNames) {
                                 String value = rsEntries.getString(col);
                                 if (value != null) {

--- a/src/test/java/net/sf/jabref/bibtex/BibtexEntryAssert.java
+++ b/src/test/java/net/sf/jabref/bibtex/BibtexEntryAssert.java
@@ -14,7 +14,6 @@ import net.sf.jabref.importer.fileformat.BibtexImporter;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.importer.fileformat.ImportFormat;
 import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.model.entry.CanonicalBibtexEntry;
 
 import org.junit.Assert;
 
@@ -133,21 +132,13 @@ public class BibtexEntryAssert {
      * @param actualEntries the list with the actual entries
      */
     public static void assertEquals(List<BibEntry> shouldBeIs, List<BibEntry> actualEntries) {
-        Assert.assertNotNull(shouldBeIs);
-        Assert.assertNotNull(actualEntries);
-        Assert.assertEquals(shouldBeIs.size(), actualEntries.size());
-        for (int i = 0; i < actualEntries.size(); i++) {
-            assertEquals(shouldBeIs.get(i), actualEntries.get(i));
-        }
+        Assert.assertEquals(shouldBeIs, actualEntries);
     }
 
     /**
-     * Compares to BibTeX entries using their canonical representation
+     * Compares to BibTeX entries
      */
     public static void assertEquals(BibEntry shouldBeEntry, BibEntry entry) {
-        // use the canonical string representation to compare the entries
-        String shouldBeEntryRepresentation = CanonicalBibtexEntry.getCanonicalRepresentation(shouldBeEntry);
-        String entryRepresentation = CanonicalBibtexEntry.getCanonicalRepresentation(entry);
-        Assert.assertEquals(shouldBeEntryRepresentation, entryRepresentation);
+        Assert.assertEquals(shouldBeEntry, entry);
     }
 }

--- a/src/test/java/net/sf/jabref/exporter/FieldFormatterCleanupsTest.java
+++ b/src/test/java/net/sf/jabref/exporter/FieldFormatterCleanupsTest.java
@@ -37,7 +37,7 @@ public class FieldFormatterCleanupsTest {
     public void setUp() {
         entry = new BibEntry();
         entry.setType(BibtexEntryTypes.INPROCEEDINGS);
-        entry.setField(BibEntry.KEY_FIELD, "6055279");
+        entry.setCiteKey("6055279");
         entry.setField("title", "Educational session 1");
         entry.setField("booktitle", "Custom Integrated Circuits Conference (CICC), 2011 IEEE");
         entry.setField("year", "2011");

--- a/src/test/java/net/sf/jabref/external/RegExpFileSearchTests.java
+++ b/src/test/java/net/sf/jabref/external/RegExpFileSearchTests.java
@@ -77,7 +77,7 @@ public class RegExpFileSearchTests {
         //given
         List<BibEntry> entries = new ArrayList<>();
         BibEntry localEntry = new BibEntry("123", BibtexEntryTypes.ARTICLE.getName());
-        localEntry.setField(BibEntry.KEY_FIELD, "pdfInDatabase");
+        localEntry.setCiteKey("pdfInDatabase");
         localEntry.setField("year", "2001");
         entries.add(localEntry);
 

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -640,13 +640,12 @@ public class BibtexParserTest {
         assertTrue(result.hasWarnings());
 
         Collection<BibEntry> c = result.getDatabase().getEntries();
-        assertEquals(1, c.size());
 
-        BibEntry e = c.iterator().next();
-        assertEquals("article", e.getType());
-        assertEquals("", e.getCiteKey());
-        assertEquals(2, e.getFieldNames().size());
-        assertEquals("Ed von Test", e.getField("author"));
+        BibEntry e = new BibEntry();
+        e.setField("author", "Ed von Test");
+        e.setType("article");
+
+        assertEquals(Collections.singletonList(e), c);
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/autocompleter/BibtexKeyAutoCompleterTest.java
+++ b/src/test/java/net/sf/jabref/logic/autocompleter/BibtexKeyAutoCompleterTest.java
@@ -58,7 +58,7 @@ public class BibtexKeyAutoCompleterTest {
         BibtexKeyAutoCompleter autoCompleter = new BibtexKeyAutoCompleter(preferences);
 
         BibEntry entry = new BibEntry();
-        entry.setField(BibEntry.KEY_FIELD, "testKey");
+        entry.setCiteKey("testKey");
         autoCompleter.addBibtexEntry(entry);
 
         List<String> result = autoCompleter.complete("testKey");
@@ -71,7 +71,7 @@ public class BibtexKeyAutoCompleterTest {
         BibtexKeyAutoCompleter autoCompleter = new BibtexKeyAutoCompleter(preferences);
 
         BibEntry entry = new BibEntry();
-        entry.setField(BibEntry.KEY_FIELD, "testKey");
+        entry.setCiteKey("testKey");
         autoCompleter.addBibtexEntry(entry);
 
         List<String> result = autoCompleter.complete("test");
@@ -84,7 +84,7 @@ public class BibtexKeyAutoCompleterTest {
         BibtexKeyAutoCompleter autoCompleter = new BibtexKeyAutoCompleter(preferences);
 
         BibEntry entry = new BibEntry();
-        entry.setField(BibEntry.KEY_FIELD, "testKey");
+        entry.setCiteKey("testKey");
         autoCompleter.addBibtexEntry(entry);
 
         List<String> result = autoCompleter.complete("testkey");
@@ -97,7 +97,7 @@ public class BibtexKeyAutoCompleterTest {
         BibtexKeyAutoCompleter autoCompleter = new BibtexKeyAutoCompleter(preferences);
 
         BibEntry entry = new BibEntry();
-        entry.setField(BibEntry.KEY_FIELD, "testKey");
+        entry.setCiteKey("testKey");
         autoCompleter.addBibtexEntry(entry);
 
         List<String> result = autoCompleter.complete(null);
@@ -110,7 +110,7 @@ public class BibtexKeyAutoCompleterTest {
         BibtexKeyAutoCompleter autoCompleter = new BibtexKeyAutoCompleter(preferences);
 
         BibEntry entry = new BibEntry();
-        entry.setField(BibEntry.KEY_FIELD, "testKey");
+        entry.setCiteKey("testKey");
         autoCompleter.addBibtexEntry(entry);
 
         List<String> result = autoCompleter.complete("");
@@ -123,10 +123,10 @@ public class BibtexKeyAutoCompleterTest {
         BibtexKeyAutoCompleter autoCompleter = new BibtexKeyAutoCompleter(preferences);
 
         BibEntry entryOne = new BibEntry();
-        entryOne.setField(BibEntry.KEY_FIELD, "testKeyOne");
+        entryOne.setCiteKey("testKeyOne");
         autoCompleter.addBibtexEntry(entryOne);
         BibEntry entryTwo = new BibEntry();
-        entryTwo.setField(BibEntry.KEY_FIELD, "testKeyTwo");
+        entryTwo.setCiteKey("testKeyTwo");
         autoCompleter.addBibtexEntry(entryTwo);
 
         List<String> result = autoCompleter.complete("testKey");
@@ -139,7 +139,7 @@ public class BibtexKeyAutoCompleterTest {
         BibtexKeyAutoCompleter autoCompleter = new BibtexKeyAutoCompleter(preferences);
 
         BibEntry entry = new BibEntry();
-        entry.setField(BibEntry.KEY_FIELD, "key");
+        entry.setCiteKey("key");
         autoCompleter.addBibtexEntry(entry);
 
         List<String> result = autoCompleter.complete("k");
@@ -153,7 +153,7 @@ public class BibtexKeyAutoCompleterTest {
         BibtexKeyAutoCompleter autoCompleter = new BibtexKeyAutoCompleter(preferences);
 
         BibEntry entry = new BibEntry();
-        entry.setField(BibEntry.KEY_FIELD, "testKey");
+        entry.setCiteKey("testKey");
         autoCompleter.addBibtexEntry(entry);
 
         List<String> result = autoCompleter.complete("test");

--- a/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
@@ -76,7 +76,7 @@ public class CleanupWorkerTest {
     @Test
     public void cleanupDoesNothingByDefault() throws IOException {
         BibEntry entry = new BibEntry();
-        entry.setField(BibEntry.KEY_FIELD, "Toot");
+        entry.setCiteKey("Toot");
         entry.setField("pdf", "aPdfFile");
         entry.setField("some", "1st");
         entry.setField("doi", "http://dx.doi.org/10.1016/0001-8708(80)90035-3");
@@ -231,7 +231,7 @@ public class CleanupWorkerTest {
 
         File tempFile = bibFolder.newFile();
         BibEntry entry = new BibEntry();
-        entry.setField(BibEntry.KEY_FIELD, "Toot");
+        entry.setCiteKey("Toot");
         ParsedFileField fileField = new ParsedFileField("", tempFile.getAbsolutePath(), "");
         entry.setField("file", FileField.getStringRepresentation(fileField));
 

--- a/src/test/java/net/sf/jabref/model/entry/BibtexEntryTests.java
+++ b/src/test/java/net/sf/jabref/model/entry/BibtexEntryTests.java
@@ -80,7 +80,7 @@ public class BibtexEntryTests {
     public void isNullCiteKeyThrowsNPE() {
         BibEntry e = new BibEntry("id", BibtexEntryTypes.ARTICLE.getName());
 
-        e.setField(BibEntry.KEY_FIELD, null);
+        e.setCiteKey(null);
         Assert.fail();
     }
 
@@ -89,10 +89,10 @@ public class BibtexEntryTests {
         BibEntry e = new BibEntry("id", BibtexEntryTypes.ARTICLE.getName());
         Assert.assertFalse(e.hasCiteKey());
 
-        e.setField(BibEntry.KEY_FIELD, "");
+        e.setCiteKey("");
         Assert.assertFalse(e.hasCiteKey());
 
-        e.setField(BibEntry.KEY_FIELD, "key");
+        e.setCiteKey("key");
         Assert.assertTrue(e.hasCiteKey());
 
         e.clearField(BibEntry.KEY_FIELD);
@@ -352,7 +352,7 @@ public class BibtexEntryTests {
         BibEntry be = new BibEntry();
         Assert.assertFalse(be.hasCiteKey());
         be.setField("author", "Albert Einstein");
-        be.setField(BibEntry.KEY_FIELD, "Einstein1931");
+        be.setCiteKey("Einstein1931");
         Assert.assertTrue(be.hasCiteKey());
         Assert.assertEquals("Einstein1931", be.getCiteKey());
         Assert.assertEquals("Albert Einstein", be.getField("author"));

--- a/src/test/java/net/sf/jabref/model/entry/CanonicalBibEntryTest.java
+++ b/src/test/java/net/sf/jabref/model/entry/CanonicalBibEntryTest.java
@@ -8,7 +8,7 @@ public class CanonicalBibEntryTest {
     @Test
     public void simpleCanonicalRepresentation() {
         BibEntry e = new BibEntry("id", BibtexEntryTypes.ARTICLE.getName());
-        e.setField(BibEntry.KEY_FIELD, "key");
+        e.setCiteKey("key");
         e.setField("author", "abc");
         e.setField("title", "def");
         e.setField("journal", "hij");
@@ -20,7 +20,7 @@ public class CanonicalBibEntryTest {
     @Test
     public void canonicalRepresentationWithNewlines() {
         BibEntry e = new BibEntry("id", BibtexEntryTypes.ARTICLE.getName());
-        e.setField(BibEntry.KEY_FIELD, "key");
+        e.setCiteKey("key");
         e.setField("abstract", "line 1\nline 2");
         String canonicalRepresentation = CanonicalBibtexEntry.getCanonicalRepresentation(e);
         Assert.assertEquals("@article{key,\n  abstract = {line 1\nline 2}\n}", canonicalRepresentation);


### PR DESCRIPTION
As proposed in #625 a proper BibEntry.equals is provided in this PR and used for the tests. 

This as a few advantages:
- detect differences which are not visible in the canonical string representation (so far this hit empty fields and different line breaks)
- get more meaningful test-failure messages for lists (instead of "expected 2 got 3" the added entry is displayed)
- Assert.assertEquals just works and no custom written assertEquals method has to be used

I clicked around a bit, but couldn't find any unexpected side effects due to the overwritten equals method. 

If this PR is accepted, then I would inline the BibtexEntryAssert.assertEquals methods.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
