### PR TITLE
Fix #1271: Authors with compound first names are parsed properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Fixed [#1245](https://github.com/JabRef/jabref/issues/1245): Empty jstyle properties can now be specified as ""
 - Fixed [#1259](https://github.com/JabRef/jabref/issues/1259): NPE when sorting tabs
 - Fixed display bug in the cleanup dialog: field formatters are now correctly displayed using their name 
+- Fixed [#1245](https://github.com/JabRef/jabref/issues/1245): Empty jstyle properties can now be specified as "" 
+- Fixed [#1271](https://github.com/JabRef/jabref/issues/1271): Authors with compound first names are displayed properly 
 
 ### Removed
 - Removed possibility to export entries/databases to an `.sql` file, as the logic cannot easily use the correct escape logic

--- a/src/main/java/net/sf/jabref/model/entry/AuthorList.java
+++ b/src/main/java/net/sf/jabref/model/entry/AuthorList.java
@@ -15,6 +15,7 @@
 */
 package net.sf.jabref.model.entry;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.WeakHashMap;
@@ -154,6 +155,10 @@ public class AuthorList {
      */
     protected AuthorList(List<Author> authors) {
         this.authors = Objects.requireNonNull(authors);
+    }
+
+    protected AuthorList(Author author) {
+        this(Collections.singletonList(author));
     }
 
     /**
@@ -416,7 +421,7 @@ public class AuthorList {
 
     @Override
     public String toString() {
-        return getAsLastFirstNamesWithAnd(false);
+        return authors.toString();
     }
 
     /**

--- a/src/main/java/net/sf/jabref/model/entry/AuthorListParser.java
+++ b/src/main/java/net/sf/jabref/model/entry/AuthorListParser.java
@@ -47,9 +47,7 @@ public class AuthorListParser {
     }
 
 
-    private static final int TOKEN_GROUP_LENGTH = 4; // number of entries for
-
-    // a token
+    private static final int TOKEN_GROUP_LENGTH = 4; // number of entries for a token
 
     // the following are offsets of an entry in a group of entries for one token
     private static final int OFFSET_TOKEN = 0; // String -- token itself;
@@ -137,6 +135,11 @@ public class AuthorListParser {
                 }
                 if (vonStart < 0) {
                     if (!tokenCase) {
+                        int previousTermToken = tokens.size() - TOKEN_GROUP_LENGTH - TOKEN_GROUP_LENGTH + OFFSET_TOKEN_TERM;
+                        if(previousTermToken >= 0 && tokens.get(previousTermToken).equals('-')) {
+                            // We are in a first name which contained a hyphen
+                            break;
+                        }
                         vonStart = tokens.size() - TOKEN_GROUP_LENGTH;
                         break;
                     }
@@ -353,11 +356,11 @@ public class AuthorListParser {
             if (c == '{') {
                 bracesLevel++;
             }
-            if ((c == '}') && (bracesLevel > 0)) {
-                bracesLevel--;
-            }
             if (firstLetterIsFound && (tokenAbbr < 0) && (bracesLevel == 0)) {
                 tokenAbbr = tokenEnd;
+            }
+            if ((c == '}') && (bracesLevel > 0)) {
+                bracesLevel--;
             }
             if (!firstLetterIsFound && (currentBackslash < 0) && Character.isLetter(c)) {
                 if (bracesLevel == 0) {
@@ -386,11 +389,6 @@ public class AuthorListParser {
             if ((bracesLevel == 0) && ((",;~-".indexOf(c) != -1) || Character.isWhitespace(c))) {
                 break;
             }
-            // Morten Alver 18 Apr 2006: Removed check for hyphen '-' above to
-            // prevent
-            // problems with names like Bailey-Jones getting broken up and
-            // sorted wrong.
-            // Aaron Chen 14 Sep 2008: Enable hyphen check for first names like Chang-Chin
             tokenEnd++;
         }
         if (tokenAbbr < 0) {

--- a/src/test/java/net/sf/jabref/model/entry/AuthorListTest.java
+++ b/src/test/java/net/sf/jabref/model/entry/AuthorListTest.java
@@ -580,4 +580,29 @@ public class AuthorListTest {
     public void createCorrectInitials() {
         Assert.assertEquals("J. G.", AuthorList.parse("Hornberg, Johann Gottfried").getAuthor(0).getFirstAbbr());
     }
+
+    @Test
+    public void parseNameWithBracesAroundFirstName() throws Exception {
+        //TODO: Be more intelligent and abbreviate the first name correctly
+        Author expected = new Author("Tse-tung", "{Tse-tung}.", null, "Mao", null);
+        Assert.assertEquals(new AuthorList(expected), AuthorList.parse("{Tse-tung} Mao"));
+    }
+
+    @Test
+    public void parseNameWithBracesAroundLastName() throws Exception {
+        Author expected = new Author("Hans", "H.", null, "van den Bergen", null);
+        Assert.assertEquals(new AuthorList(expected), AuthorList.parse("{van den Bergen}, Hans"));
+    }
+
+    @Test
+    public void parseNameWithHyphenInFirstName() throws Exception {
+        Author expected = new Author("Tse-tung", "T.-t.", null, "Mao", null);
+        Assert.assertEquals(new AuthorList(expected), AuthorList.parse("Tse-tung Mao"));
+    }
+
+    @Test
+    public void parseNameWithHyphenInLastName() throws Exception {
+        Author expected = new Author("Firstname", "F.", null, "Bailey-Jones", null);
+        Assert.assertEquals(new AuthorList(expected), AuthorList.parse("Firstname Bailey-Jones"));
+    }
 }


### PR DESCRIPTION
- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)

