### PR TITLE
Improve BibtexEntryAssert

### DIFF
--- a/src/test/java/net/sf/jabref/bibtex/BibEntryAssert.java
+++ b/src/test/java/net/sf/jabref/bibtex/BibEntryAssert.java
@@ -17,7 +17,7 @@ import net.sf.jabref.model.entry.BibEntry;
 
 import org.junit.Assert;
 
-public class BibtexEntryAssert {
+public class BibEntryAssert {
 
     /**
      * Reads a single entry from the resource using `getResourceAsStream` from the given class. The resource has to
@@ -33,7 +33,7 @@ public class BibtexEntryAssert {
         Assert.assertNotNull(resourceName);
         Assert.assertNotNull(entry);
         try (InputStream shouldBeIs = clazz.getResourceAsStream(resourceName)) {
-            BibtexEntryAssert.assertEquals(shouldBeIs, entry);
+            BibEntryAssert.assertEquals(shouldBeIs, entry);
         }
     }
 
@@ -51,7 +51,7 @@ public class BibtexEntryAssert {
         Assert.assertNotNull(resourceName);
         Assert.assertNotNull(asIsEntries);
         try (InputStream shouldBeIs = clazz.getResourceAsStream(resourceName)) {
-            BibtexEntryAssert.assertEquals(shouldBeIs, asIsEntries);
+            BibEntryAssert.assertEquals(shouldBeIs, asIsEntries);
         }
     }
 

--- a/src/test/java/net/sf/jabref/importer/fetcher/GVKParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fetcher/GVKParserTest.java
@@ -10,7 +10,7 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.bibtex.BibtexEntryAssert;
+import net.sf.jabref.bibtex.BibEntryAssert;
 import net.sf.jabref.model.entry.BibEntry;
 
 import org.junit.Assert;
@@ -34,7 +34,7 @@ public class GVKParserTest {
             Assert.assertEquals(expectedSize, entries.size());
             int i = 0;
             for (String resourceName : resourceNames) {
-                BibtexEntryAssert.assertEquals(GVKParser.class, resourceName, entries.get(i));
+                BibEntryAssert.assertEquals(GVKParser.class, resourceName, entries.get(i));
                 i++;
             }
         }

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibTeXMLImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibTeXMLImporterTestFiles.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.bibtex.BibtexEntryAssert;
+import net.sf.jabref.bibtex.BibEntryAssert;
 import net.sf.jabref.importer.OutputPrinterToNull;
 import net.sf.jabref.model.entry.BibEntry;
 
@@ -74,7 +74,7 @@ public class BibTeXMLImporterTestFiles {
             if (bibtexmlEntries.isEmpty()) {
                 Assert.assertEquals(Collections.emptyList(), bibtexmlEntries);
             } else {
-                BibtexEntryAssert.assertEquals(BibTeXMLImporterTest.class, bibFileName, bibtexmlEntries);
+                BibEntryAssert.assertEquals(BibTeXMLImporterTest.class, bibFileName, bibtexmlEntries);
             }
         }
     }

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibTeXMLImporterTestTypes.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibTeXMLImporterTestTypes.java
@@ -5,11 +5,11 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.bibtex.BibtexEntryAssert;
 import net.sf.jabref.importer.OutputPrinterToNull;
 import net.sf.jabref.model.entry.BibEntry;
 
@@ -64,7 +64,6 @@ public class BibTeXMLImporterTestTypes {
         entry.setField("year", "2016");
         entry.setType(expectedBibType);
 
-        Assert.assertEquals(1, bibEntries.size());
-        BibtexEntryAssert.assertEquals(entry, bibEntries.get(0));
+        Assert.assertEquals(Collections.singletonList(entry), bibEntries);
     }
 }

--- a/src/test/java/net/sf/jabref/importer/fileformat/BiblioscapeImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BiblioscapeImporterTestFiles.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.bibtex.BibtexEntryAssert;
+import net.sf.jabref.bibtex.BibEntryAssert;
 import net.sf.jabref.importer.OutputPrinterToNull;
 import net.sf.jabref.model.entry.BibEntry;
 
@@ -62,7 +62,7 @@ public class BiblioscapeImporterTestFiles {
 
             List<BibEntry> bsEntries = bsImporter.importEntries(bsStream, new OutputPrinterToNull());
             Assert.assertEquals(1, bsEntries.size());
-            BibtexEntryAssert.assertEquals(BiblioscapeImporterTest.class, fileName + ".bib", bsEntries);
+            BibEntryAssert.assertEquals(BiblioscapeImporterTest.class, fileName + ".bib", bsEntries);
 
 
         }

--- a/src/test/java/net/sf/jabref/importer/fileformat/BiblioscapeImporterTestTypes.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BiblioscapeImporterTestTypes.java
@@ -5,11 +5,11 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.bibtex.BibtexEntryAssert;
 import net.sf.jabref.importer.OutputPrinterToNull;
 import net.sf.jabref.model.entry.BibEntry;
 
@@ -61,7 +61,6 @@ public class BiblioscapeImporterTestTypes {
         entry.setField("year", "1999");
         entry.setType(expectedBibType);
 
-        Assert.assertEquals(1, bibEntries.size());
-        BibtexEntryAssert.assertEquals(entry, bibEntries.get(0));
+        Assert.assertEquals(Collections.singletonList(entry), bibEntries);
     }
 }

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.bibtex.BibtexEntryAssert;
 import net.sf.jabref.exporter.FieldFormatterCleanups;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.logic.cleanup.FieldFormatterCleanup;
@@ -64,7 +63,7 @@ public class BibtexParserTest {
         expected.setType("article");
         expected.setCiteKey("test");
         expected.setField("author", "Ed von Test");
-        BibtexEntryAssert.assertEquals(Arrays.asList(expected), parsed);
+        assertEquals(Collections.singletonList(expected), parsed);
     }
 
     @Test
@@ -91,7 +90,7 @@ public class BibtexParserTest {
         expected.setCiteKey("canh05");
         expected.setField("author", "Crowston, K. and Annabi, H.");
         expected.setField("title", "Title A");
-        BibtexEntryAssert.assertEquals(expected, parsed);
+        assertEquals(expected, parsed);
     }
 
     @Test
@@ -332,7 +331,7 @@ public class BibtexParserTest {
         secondEntry.setField("author", "Norton Bar");
         expected.add(secondEntry);
 
-        BibtexEntryAssert.assertEquals(expected, parsed);
+        assertEquals(expected, parsed);
     }
 
     @Test
@@ -372,7 +371,7 @@ public class BibtexParserTest {
         secondEntry.setCiteKey("foo");
         expected.add(secondEntry);
 
-        BibtexEntryAssert.assertEquals(expected, parsed);
+        assertEquals(expected, parsed);
     }
 
     @Test
@@ -1481,6 +1480,6 @@ public class BibtexParserTest {
         c.setCiteKey("c");
         expected.add(c);
 
-        BibtexEntryAssert.assertEquals(expected, result.getDatabase().getEntries());
+        assertEquals(expected, result.getDatabase().getEntries());
     }
 }

--- a/src/test/java/net/sf/jabref/importer/fileformat/CopacImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/CopacImporterTestFiles.java
@@ -62,7 +62,7 @@ public class CopacImporterTestFiles {
 
         try (InputStream copacStream = CopacImporterTest.class.getResourceAsStream(fileName);
                 InputStream bibStream = BibtexImporterTest.class.getResourceAsStream(bibFileName)) {
-            BibtexEntryAssert.assertEquals(copacImporter, bibStream, copacStream);
+            BibtexEntryAssert.assertEquals(bibStream, copacStream, copacImporter);
         }
 
     }

--- a/src/test/java/net/sf/jabref/importer/fileformat/CopacImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/CopacImporterTestFiles.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.bibtex.BibtexEntryAssert;
+import net.sf.jabref.bibtex.BibEntryAssert;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -62,7 +62,7 @@ public class CopacImporterTestFiles {
 
         try (InputStream copacStream = CopacImporterTest.class.getResourceAsStream(fileName);
                 InputStream bibStream = BibtexImporterTest.class.getResourceAsStream(bibFileName)) {
-            BibtexEntryAssert.assertEquals(bibStream, copacStream, copacImporter);
+            BibEntryAssert.assertEquals(bibStream, copacStream, copacImporter);
         }
 
     }

--- a/src/test/java/net/sf/jabref/importer/fileformat/InspecImportTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/InspecImportTest.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import net.sf.jabref.Globals;
@@ -54,24 +55,19 @@ public class InspecImportTest {
     @Test
     public void testCompleteBibtexEntryOnJournalPaperImport() throws IOException {
 
-        BibEntry shouldBeEntry = new BibEntry();
-        shouldBeEntry.setType("article");
-        shouldBeEntry.setField("title", "The SIS project : software reuse with a natural language approach");
-        shouldBeEntry.setField("author", "Prechelt, Lutz");
-        shouldBeEntry.setField("year", "1992");
-        shouldBeEntry.setField("abstract", "Abstrakt");
-        shouldBeEntry.setField("keywords", "key");
-        shouldBeEntry.setField("journal", "10000");
-        shouldBeEntry.setField("pages", "20");
-        shouldBeEntry.setField("volume", "19");
+        BibEntry expectedEntry = new BibEntry();
+        expectedEntry.setType("article");
+        expectedEntry.setField("title", "The SIS project : software reuse with a natural language approach");
+        expectedEntry.setField("author", "Prechelt, Lutz");
+        expectedEntry.setField("year", "1992");
+        expectedEntry.setField("abstract", "Abstrakt");
+        expectedEntry.setField("keywords", "key");
+        expectedEntry.setField("journal", "10000");
+        expectedEntry.setField("pages", "20");
+        expectedEntry.setField("volume", "19");
 
-        try (InputStream inStream = InspecImportTest.class.getResourceAsStream("InspecImportTest2.txt")) {
-            List<BibEntry> entries = inspecImp.importEntries(inStream, new OutputPrinterToNull());
-            assertEquals(1, entries.size());
-            BibEntry entry = entries.get(0);
-            BibtexEntryAssert.assertEquals(shouldBeEntry, entry);
-
-        }
+        BibtexEntryAssert.assertEquals(Collections.singletonList(expectedEntry),
+                InspecImportTest.class.getResourceAsStream("InspecImportTest2.txt"), inspecImp);
     }
 
     @Test
@@ -79,14 +75,12 @@ public class InspecImportTest {
         String testInput = "Record.*INSPEC.*\n" +
                 "\n" +
                 "RT ~ Conference-Paper";
-        BibEntry shouldBeEntry = new BibEntry();
-        shouldBeEntry.setType("Inproceedings");
+        BibEntry expectedEntry = new BibEntry();
+        expectedEntry.setType("Inproceedings");
 
         try (InputStream inStream = new ByteArrayInputStream(testInput.getBytes())) {
             List<BibEntry> entries = inspecImp.importEntries(inStream, new OutputPrinterToNull());
-            assertEquals(1, entries.size());
-            BibEntry entry = entries.get(0);
-            BibtexEntryAssert.assertEquals(shouldBeEntry, entry);
+            assertEquals(Collections.singletonList(expectedEntry), entries);
         }
     }
 
@@ -95,14 +89,14 @@ public class InspecImportTest {
         String testInput = "Record.*INSPEC.*\n" +
                 "\n" +
                 "RT ~ Misc";
-        BibEntry shouldBeEntry = new BibEntry();
-        shouldBeEntry.setType("Misc");
+        BibEntry expectedEntry = new BibEntry();
+        expectedEntry.setType("Misc");
 
         try (InputStream inStream = new ByteArrayInputStream(testInput.getBytes())) {
             List<BibEntry> entries = inspecImp.importEntries(inStream, new OutputPrinterToNull());
             assertEquals(1, entries.size());
             BibEntry entry = entries.get(0);
-            BibtexEntryAssert.assertEquals(shouldBeEntry, entry);
+            assertEquals(expectedEntry, entry);
         }
     }
 

--- a/src/test/java/net/sf/jabref/importer/fileformat/InspecImportTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/InspecImportTest.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.bibtex.BibtexEntryAssert;
+import net.sf.jabref.bibtex.BibEntryAssert;
 import net.sf.jabref.importer.OutputPrinterToNull;
 import net.sf.jabref.model.entry.BibEntry;
 
@@ -66,7 +66,7 @@ public class InspecImportTest {
         expectedEntry.setField("pages", "20");
         expectedEntry.setField("volume", "19");
 
-        BibtexEntryAssert.assertEquals(Collections.singletonList(expectedEntry),
+        BibEntryAssert.assertEquals(Collections.singletonList(expectedEntry),
                 InspecImportTest.class.getResourceAsStream("InspecImportTest2.txt"), inspecImp);
     }
 

--- a/src/test/java/net/sf/jabref/importer/fileformat/MedlinePlainImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/MedlinePlainImporterTest.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.bibtex.BibtexEntryAssert;
+import net.sf.jabref.bibtex.BibEntryAssert;
 import net.sf.jabref.importer.OutputPrinterToNull;
 import net.sf.jabref.model.entry.BibEntry;
 
@@ -132,7 +132,7 @@ public class MedlinePlainImporterTest {
             List<BibEntry> entries = importer.importEntries(is, new OutputPrinterToNull());
             Assert.assertNotNull(entries);
             Assert.assertEquals(1, entries.size());
-            BibtexEntryAssert.assertEquals(nis, entries.get(0));
+            BibEntryAssert.assertEquals(nis, entries.get(0));
         }
     }
 

--- a/src/test/java/net/sf/jabref/importer/fileformat/MedlinePlainImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/MedlinePlainImporterTest.java
@@ -151,7 +151,7 @@ public class MedlinePlainImporterTest {
                             + "Comment6" + "\n" + "Comment7" + "\n" + "Comment8" + "\n" + "Comment9" + "\n"
                             + "Comment10" + "\n" + "Comment11" + "\n" + "Comment12" + "\n" + "Comment13" + "\n"
                             + "Comment14" + "\n" + "Comment15" + "\n" + "Comment16");
-            BibtexEntryAssert.assertEquals(Arrays.asList(expectedEntry), actualEntries);
+            Assert.assertEquals(Collections.singletonList(expectedEntry), actualEntries);
         }
     }
 
@@ -162,7 +162,7 @@ public class MedlinePlainImporterTest {
 
             BibEntry expectedEntry = new BibEntry();
             expectedEntry.setField("keywords", "Female, Male");
-            BibtexEntryAssert.assertEquals(Arrays.asList(expectedEntry), actualEntries);
+            Assert.assertEquals(Collections.singletonList(expectedEntry), actualEntries);
         }
     }
 
@@ -175,7 +175,7 @@ public class MedlinePlainImporterTest {
 
             BibEntry expectedEntry = new BibEntry();
             expectedEntry.setType("article");
-            BibtexEntryAssert.assertEquals(Arrays.asList(expectedEntry), actualEntries);
+            Assert.assertEquals(Collections.singletonList(expectedEntry), actualEntries);
         }
     }
 

--- a/src/test/java/net/sf/jabref/importer/fileformat/MsBibImporterTestfiles.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/MsBibImporterTestfiles.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.bibtex.BibtexEntryAssert;
+import net.sf.jabref.bibtex.BibEntryAssert;
 import net.sf.jabref.importer.OutputPrinterToNull;
 import net.sf.jabref.model.entry.BibEntry;
 
@@ -57,7 +57,7 @@ public class MsBibImporterTestfiles {
         MsBibImporter testImporter = new MsBibImporter();
         try (InputStream is = MsBibImporter.class.getResourceAsStream(xmlFileName)) {
             List<BibEntry> result = testImporter.importEntries(is, new OutputPrinterToNull());
-            BibtexEntryAssert.assertEquals(MsBibImporterTest.class, bibFileName, result);
+            BibEntryAssert.assertEquals(MsBibImporterTest.class, bibFileName, result);
         }
     }
 

--- a/src/test/java/net/sf/jabref/importer/fileformat/OvidImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/OvidImporterTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.bibtex.BibtexEntryAssert;
+import net.sf.jabref.bibtex.BibEntryAssert;
 import net.sf.jabref.importer.OutputPrinterToNull;
 import net.sf.jabref.model.entry.BibEntry;
 
@@ -144,7 +144,7 @@ public class OvidImporterTest {
                 List<BibEntry> entries = importer.importEntries(is, new OutputPrinterToNull());
                 Assert.assertNotNull(entries);
                 Assert.assertEquals(1, entries.size());
-                BibtexEntryAssert.assertEquals(nis, entries.get(0));
+                BibEntryAssert.assertEquals(nis, entries.get(0));
             }
         }
     }

--- a/src/test/java/net/sf/jabref/importer/fileformat/PdfContentImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/PdfContentImporterTestFiles.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.bibtex.BibtexEntryAssert;
+import net.sf.jabref.bibtex.BibEntryAssert;
 import net.sf.jabref.model.entry.BibEntry;
 
 import org.junit.BeforeClass;
@@ -49,7 +49,7 @@ public class PdfContentImporterTestFiles {
         PdfContentImporter importer = new PdfContentImporter();
         try (InputStream is = PdfContentImporter.class.getResourceAsStream(pdfFileName)) {
             List<BibEntry> result = importer.importEntries(is, null);
-            BibtexEntryAssert.assertEquals(PdfContentImporterTest.class, bibFileName, result);
+            BibEntryAssert.assertEquals(PdfContentImporterTest.class, bibFileName, result);
         }
     }
 

--- a/src/test/java/net/sf/jabref/importer/fileformat/RISImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/RISImporterTestFiles.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.bibtex.BibtexEntryAssert;
+import net.sf.jabref.bibtex.BibEntryAssert;
 import net.sf.jabref.importer.OutputPrinterToNull;
 import net.sf.jabref.model.entry.BibEntry;
 
@@ -54,7 +54,7 @@ public class RISImporterTestFiles {
         try (InputStream risStream = RISImporterTest.class.getResourceAsStream(fileName + ".ris")) {
 
             List<BibEntry> risEntries = risImporter.importEntries(risStream, new OutputPrinterToNull());
-            BibtexEntryAssert.assertEquals(RISImporterTest.class, fileName + ".bib", risEntries);
+            BibEntryAssert.assertEquals(RISImporterTest.class, fileName + ".bib", risEntries);
 
         }
     }

--- a/src/test/java/net/sf/jabref/importer/fileformat/RepecNepImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/RepecNepImporterTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.bibtex.BibtexEntryAssert;
+import net.sf.jabref.bibtex.BibEntryAssert;
 import net.sf.jabref.importer.OutputPrinterToNull;
 import net.sf.jabref.model.entry.BibEntry;
 
@@ -59,7 +59,7 @@ public class RepecNepImporterTest {
                 InputStream bibIn = RepecNepImporter.class.getResourceAsStream("RepecNepImporterTest1.bib")) {
             List<BibEntry> entries = testImporter.importEntries(in, new OutputPrinterToNull());
             Assert.assertEquals(1, entries.size());
-            BibtexEntryAssert.assertEquals(bibIn, entries.get(0));
+            BibEntryAssert.assertEquals(bibIn, entries.get(0));
         }
     }
 
@@ -69,7 +69,7 @@ public class RepecNepImporterTest {
                 InputStream bibIn = RepecNepImporter.class.getResourceAsStream("RepecNepImporterTest2.bib")) {
             List<BibEntry> entries = testImporter.importEntries(in, new OutputPrinterToNull());
             Assert.assertEquals(1, entries.size());
-            BibtexEntryAssert.assertEquals(bibIn, entries.get(0));
+            BibEntryAssert.assertEquals(bibIn, entries.get(0));
         }
     }
 
@@ -79,7 +79,7 @@ public class RepecNepImporterTest {
                 InputStream bibIn = RepecNepImporter.class.getResourceAsStream("RepecNepImporterTest3.bib")) {
             List<BibEntry> entries = testImporter.importEntries(in, new OutputPrinterToNull());
             Assert.assertEquals(1, entries.size());
-            BibtexEntryAssert.assertEquals(bibIn, entries.get(0));
+            BibEntryAssert.assertEquals(bibIn, entries.get(0));
         }
     }
 

--- a/src/test/java/net/sf/jabref/importer/fileformat/SilverPlatterImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/SilverPlatterImporterTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.bibtex.BibtexEntryAssert;
+import net.sf.jabref.bibtex.BibEntryAssert;
 import net.sf.jabref.importer.OutputPrinterToNull;
 import net.sf.jabref.model.entry.BibEntry;
 
@@ -57,7 +57,7 @@ public class SilverPlatterImporterTest {
         try (InputStream in = SilverPlatterImporter.class.getResourceAsStream(txtName);
                 InputStream bibIn = SilverPlatterImporterTest.class.getResourceAsStream(bibName)) {
             List<BibEntry> entries = testImporter.importEntries(in, new OutputPrinterToNull());
-            BibtexEntryAssert.assertEquals(bibIn, entries);
+            BibEntryAssert.assertEquals(bibIn, entries);
         }
     }
 }

--- a/src/test/java/net/sf/jabref/logic/search/DatabaseSearcherTest.java
+++ b/src/test/java/net/sf/jabref/logic/search/DatabaseSearcherTest.java
@@ -2,7 +2,6 @@ package net.sf.jabref.logic.search;
 
 import java.util.Collections;
 
-import net.sf.jabref.bibtex.BibtexEntryAssert;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 
@@ -60,6 +59,6 @@ public class DatabaseSearcherTest {
         database.insertEntry(entry);
         BibDatabase newDatabase = new DatabaseSearcher(new SearchQuery("harrer", true, true), database)
                 .getDatabaseFromMatches();
-        BibtexEntryAssert.assertEquals(Collections.singletonList(entry), newDatabase.getEntries());
+        assertEquals(Collections.singletonList(entry), newDatabase.getEntries());
     }
 }

--- a/src/test/java/net/sf/jabref/logic/util/UpdateFieldTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/UpdateFieldTest.java
@@ -2,7 +2,6 @@ package net.sf.jabref.logic.util;
 
 import java.util.Optional;
 
-import net.sf.jabref.bibtex.BibtexEntryAssert;
 import net.sf.jabref.logic.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;
 
@@ -59,7 +58,7 @@ public class UpdateFieldTest {
         assertNull(change.get().getOldValue());
         assertEquals("year", change.get().getField());
         assertEquals("2016", change.get().getNewValue());
-        BibtexEntryAssert.assertEquals(entry, change.get().getEntry());
+        assertEquals(entry, change.get().getEntry());
     }
 
     @Test
@@ -69,7 +68,7 @@ public class UpdateFieldTest {
         assertEquals("2015", change.get().getOldValue());
         assertEquals("year", change.get().getField());
         assertEquals("2016", change.get().getNewValue());
-        BibtexEntryAssert.assertEquals(entry, change.get().getEntry());
+        assertEquals(entry, change.get().getEntry());
     }
 
     @Test
@@ -120,7 +119,7 @@ public class UpdateFieldTest {
         assertNull(change.get().getNewValue());
         assertEquals("year", change.get().getField());
         assertEquals("2016", change.get().getOldValue());
-        BibtexEntryAssert.assertEquals(entry, change.get().getEntry());
+        assertEquals(entry, change.get().getEntry());
     }
 
     @Test
@@ -152,7 +151,7 @@ public class UpdateFieldTest {
         assertNull(change.get().getNewValue());
         assertEquals("year", change.get().getField());
         assertEquals("2016", change.get().getOldValue());
-        BibtexEntryAssert.assertEquals(entry, change.get().getEntry());
+        assertEquals(entry, change.get().getEntry());
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
@@ -29,7 +29,6 @@ import javax.xml.transform.TransformerException;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.bibtex.BibEntryWriter;
-import net.sf.jabref.bibtex.BibtexEntryAssert;
 import net.sf.jabref.exporter.LatexFieldFormatter;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
@@ -907,7 +906,7 @@ public class XMPUtilTest {
             entry.setField("author", "Firstname Lastname");
             List<BibEntry> expected = Collections.singletonList(entry);
 
-            BibtexEntryAssert.assertEquals(expected, readEntries);
+            Assert.assertEquals(expected, readEntries);
         }
     }
 

--- a/src/test/java/net/sf/jabref/model/database/BibDatabaseTest.java
+++ b/src/test/java/net/sf/jabref/model/database/BibDatabaseTest.java
@@ -8,7 +8,6 @@ import java.util.Collections;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.bibtex.BibtexEntryAssert;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.model.entry.BibEntry;
@@ -75,7 +74,7 @@ public class BibDatabaseTest {
         database.insertEntry(entry);
         assertEquals(database.getEntries().size(), 1);
         assertEquals(database.getEntryCount(), 1);
-        BibtexEntryAssert.assertEquals(entry, database.getEntries().get(0));
+        assertEquals(entry, database.getEntries().get(0));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/sql/DatabaseImportExportTests.java
+++ b/src/test/java/net/sf/jabref/sql/DatabaseImportExportTests.java
@@ -7,7 +7,6 @@ import java.util.List;
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.bibtex.BibtexEntryAssert;
 import net.sf.jabref.logic.groups.AllEntriesGroup;
 import net.sf.jabref.logic.groups.GroupHierarchyType;
 import net.sf.jabref.logic.groups.GroupTreeNode;
@@ -144,7 +143,7 @@ public class DatabaseImportExportTests {
         try (Connection connection = importer.connectToDB(strings)) {
             List<DBImporterResult> results = importer.performImport(strings, Collections.singletonList(databaseName), databaseContext.getMode());
             assertEquals(1, results.size());
-            BibtexEntryAssert.assertEquals(databaseContext.getDatabase().getEntries(),
+            assertEquals(databaseContext.getDatabase().getEntries(),
                     results.get(0).getDatabaseContext().getDatabase().getEntries());
 
             assertEquals(databaseContext.getMetaData().getGroups(), results.get(0).getDatabaseContext().getMetaData().getGroups());


### PR DESCRIPTION
This is a follow up of  #1281 with removing obsolete BibtexEntry.assertEquals methods