### PR TITLE
Take srceenshots in GUI tests

### DIFF
--- a/src/integrationTest/java/net/sf/jabref/gui/GUITest.java
+++ b/src/integrationTest/java/net/sf/jabref/gui/GUITest.java
@@ -1,5 +1,10 @@
 package net.sf.jabref.gui;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import javax.swing.JButton;
 
 import net.sf.jabref.JabRefMain;
@@ -8,7 +13,10 @@ import net.sf.jabref.gui.preftabs.PreferencesDialog;
 
 import org.assertj.swing.core.GenericTypeMatcher;
 import org.assertj.swing.dependency.jsr305.Nonnull;
+import org.assertj.swing.fixture.AbstractWindowFixture;
+import org.assertj.swing.fixture.DialogFixture;
 import org.assertj.swing.fixture.FrameFixture;
+import org.assertj.swing.image.ScreenshotTaker;
 import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
 import org.assertj.swing.timing.Pause;
 import org.junit.Ignore;
@@ -59,7 +67,7 @@ public class GUITest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    public void testCreateBibtexEntry() {
+    public void testCreateBibtexEntry() throws IOException {
         FrameFixture mainFrame = findFrame(JabRefFrame.class).withTimeout(10_000).using(robot());
 
         newDatabase(mainFrame);
@@ -73,20 +81,21 @@ public class GUITest extends AssertJSwingJUnitTestCase {
                         return "Book".equals(jButton.getText());
                     }
                 }).click();
-
+        takeScreenshot(mainFrame, "MainWindowWithOneDatabase");
         exitJabRef(mainFrame);
     }
 
     @Ignore
     @Test
-    public void testOpenAndSavePreferences() {
+    public void testOpenAndSavePreferences() throws IOException {
         FrameFixture mainFrame = findFrame(JabRefFrame.class).withTimeout(10_000).using(robot());
         mainFrame.menuItemWithPath("Options", "Preferences").click();
 
         robot().waitForIdle();
 
-        findDialog(PreferencesDialog.class).withTimeout(10_000).using(robot())
-                .button(new GenericTypeMatcher<JButton>(JButton.class) {
+        DialogFixture preferencesDialog = findDialog(PreferencesDialog.class).withTimeout(10_000).using(robot());
+        takeScreenshot(preferencesDialog, "PreferencesDialog");
+        preferencesDialog.button(new GenericTypeMatcher<JButton>(JButton.class) {
 
                     @Override
                     protected boolean isMatching(@Nonnull JButton jButton) {
@@ -118,7 +127,7 @@ public class GUITest extends AssertJSwingJUnitTestCase {
     }
 
     @Test
-    public void testDatabasePropertiesDialog() {
+    public void testDatabasePropertiesDialog() throws IOException {
 
         FrameFixture mainFrame = findFrame(JabRefFrame.class).withTimeout(10_000).using(robot());
         newDatabase(mainFrame);
@@ -127,8 +136,9 @@ public class GUITest extends AssertJSwingJUnitTestCase {
 
         robot().waitForIdle();
 
-        findDialog(DatabasePropertiesDialog.class).withTimeout(10_000).using(robot())
-                .button(new GenericTypeMatcher<JButton>(JButton.class) {
+        DialogFixture databasePropertiesDialog = findDialog(DatabasePropertiesDialog.class).withTimeout(10_000).using(robot());
+        takeScreenshot(databasePropertiesDialog, "DatabasePropertiesDialog");
+        databasePropertiesDialog.button(new GenericTypeMatcher<JButton>(JButton.class) {
 
                     @Override
                     protected boolean isMatching(@Nonnull JButton jButton) {
@@ -137,5 +147,20 @@ public class GUITest extends AssertJSwingJUnitTestCase {
                 }).click();
 
         exitJabRef(mainFrame);
+    }
+
+    private void takeScreenshot(AbstractWindowFixture<?, ?, ?> dialog, String filename) throws IOException {
+        ScreenshotTaker screenshotTaker = new ScreenshotTaker();
+        Path folder = Paths.get("build", "screenshots");
+        // Create build/srceenshots folder if not present
+        if (!Files.exists(folder)) {
+            Files.createDirectory(folder);
+        }
+        Path file = folder.resolve(filename + ".png").toAbsolutePath();
+        // Delete already present file
+        if (Files.exists(file)) {
+            Files.delete(file);
+        }
+        screenshotTaker.saveComponentAsPng(dialog.target(), file.toString());
     }
 }


### PR DESCRIPTION
This PR adds the possibility to take srceenshots in GUI tests. The idea is that srceenshots for the website can easily be updated for a new version by just running the GUI tests.

The images are stored in `builds/srceenshots/`.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)

