### PR TITLE
Normalize pages formatter does not remove letters in page numbers

### DIFF
--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatter.java
@@ -20,7 +20,7 @@ public class NormalizePagesFormatter implements Formatter {
 
     private static final Pattern PAGES_DETECT_PATTERN = Pattern.compile("\\A(\\d+)-{1,2}(\\d+)\\Z");
 
-    private static final String REJECT_LITERALS = "[^0-9,\\-\\+]";
+    private static final String REJECT_LITERALS = "[^a-zA-Z0-9,\\-\\+,]";
     private static final String PAGES_REPLACE_PATTERN = "$1--$2";
 
 
@@ -37,7 +37,7 @@ public class NormalizePagesFormatter implements Formatter {
     /**
      * Format page numbers, separated either by commas or double-hyphens.
      * Converts the range number format of the <code>pages</code> field to page_number--page_number.
-     * Removes all literals except [0-9,-+].
+     * Removes unwanted literals except letters, numbers and -+ signs.
      * Keeps the existing String if the resulting field does not match the expected Regex.
      *
      * <example>

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatter.java
@@ -64,7 +64,7 @@ public class NormalizePagesFormatter implements Formatter {
         // replace
         String newValue = matcher.replaceFirst(PAGES_REPLACE_PATTERN);
         // replacement?
-        if(!newValue.equals(cleanValue)) {
+        if(matcher.matches()) {
             // write field
             return newValue;
         }

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatterTest.java
@@ -36,6 +36,11 @@ public class NormalizePagesFormatterTest {
     }
 
     @Test
+    public void ignoreWhitespaceInPageNumbersWithDoubleDash() {
+        expectCorrect("43 -- 103", "43--103");
+    }
+
+    @Test
     public void keepCorrectlyFormattedPageNumbers() {
         expectCorrect("1--2", "1--2");
     }

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatterTest.java
@@ -51,6 +51,11 @@ public class NormalizePagesFormatterTest {
     }
 
     @Test
+    public void doesNotRemoveLetters() {
+        expectCorrect("R1-R50", "R1-R50");
+    }
+
+    @Test
     public void formatExample() {
         expectCorrect(formatter.getExampleInput(), "1--2");
     }


### PR DESCRIPTION
Formatting the page range `R1--R50` resulted in `1--50`. Now nothing is changed.
Moreover, "43 -- 103" is now correctly converted to "43--103".

- [ ] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)

