### PR TITLE
Fixes #1340

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Fixed [#1271](https://github.com/JabRef/jabref/issues/1271): Authors with compound first names are displayed properly 
 - Fixed: Selecting invalid jstyle causes NPE and prevents opening of style selection dialog
 - Fixed: Move linked files to default directory works again
+- Fixed [#1340]https://github.com/JabRef/jabref/issues/1340: Edit -> Mark Specific Color Dysfunctional on OSX
+
+
 
 ### Removed
 - Removed possibility to export entries/databases to an `.sql` file, as the logic cannot easily use the correct escape logic

--- a/src/main/java/net/sf/jabref/gui/worker/MarkEntriesAction.java
+++ b/src/main/java/net/sf/jabref/gui/worker/MarkEntriesAction.java
@@ -50,7 +50,7 @@ public class MarkEntriesAction extends AbstractWorker implements ActionListener 
         this.level = level;
 
         //menuItem = new JMenuItem(Globals.menuTitle("Mark entries").replace("&",""));
-        menuItem = new JMenuItem("               ");
+        menuItem = new JMenuItem(Localization.lang("Level") + " " + level + "   ");
         menuItem.setMnemonic(String.valueOf(level + 1).charAt(0));
         menuItem.setBackground(Globals.prefs.getColor(JabRefPreferences.MARKED_ENTRY_BACKGROUND + this.level));
         menuItem.setOpaque(true);

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -439,6 +439,7 @@ LaTeX_AUX_file=LaTeX_AUX-fil
 Leave_file_in_its_current_directory=Lad_filen_ligge_i_biblioteket,_den_ligger_i_nu
 
 Left=Venstre
+Level=
 Limit_to_fields=Begræns_til_følgende_felter
 Limit_to_selected_entries=Begræns_til_valgte_poster
 

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -805,6 +805,7 @@ LaTeX_AUX_file=LaTeX_AUX-Datei
 Leave_file_in_its_current_directory=Datei_im_aktuellen_Verzeichnis_lassen
 
 Left=Links
+Level=Ebene
 
 
 Limit_to_fields=Auf_folgende_Felder_begrenzen

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -768,6 +768,7 @@ LaTeX_AUX_file=LaTeX_AUX_file
 Leave_file_in_its_current_directory=Leave_file_in_its_current_directory
 
 Left=Left
+Level=Level
 
 Limit_to_fields=Limit_to_fields
 

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -410,6 +410,7 @@ Last_modified=Modificado_por_última_vez
 LaTeX_AUX_file=Archivo_LaTeX_AUX
 Leave_file_in_its_current_directory=Dejar_el_archivo_en_su_directorio_actual
 Left=Dejar
+Level=
 Limit_to_fields=Limitar_a_los_campos
 Limit_to_selected_entries=Limitar_a_las_entradas_seleccionadas
 Link=Enlace

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -777,6 +777,7 @@ LaTeX_AUX_file=
 Leave_file_in_its_current_directory=
 
 Left=
+Level=
 
 Limit_to_fields=
 

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -410,6 +410,7 @@ Last_modified=Dernier_modifié
 LaTeX_AUX_file=Fichier_LaTeX_AUX
 Leave_file_in_its_current_directory=Laisser_le_fichier_dans_son_répertoire_courant
 Left=Gauche
+Level=
 Limit_to_fields=Restreindre_aux_champs
 Limit_to_selected_entries=Restreindre_aux_seules_entrées_sélectionnées
 Link=Lien

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -409,6 +409,7 @@ Last_modified=Terakhir_diubah
 LaTeX_AUX_file=berkas_LaTeX_AUX
 Leave_file_in_its_current_directory=Tinggalkan_berkas_di_direktori_yg_sekarang
 Left=Kiri
+Level=
 Limit_to_fields=Batasi_ke_bidang
 Limit_to_selected_entries=Batasi_ke_entri_pilihan
 Link=Tautan

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -444,6 +444,7 @@ LaTeX_AUX_file=File_AUX_LaTeX
 Leave_file_in_its_current_directory=Lascia_il_file_nella_cartella_corrente
 
 Left=Sinistra
+Level=
 Limit_to_fields=Restrizioni_ai_campi
 Limit_to_selected_entries=Restrizioni_alle_voci_selezionate
 

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -788,6 +788,7 @@ LaTeX_AUX_file=LaTeX_AUXファイル
 Leave_file_in_its_current_directory=ファイルを現在のディレクトリに置いておく。
 
 Left=左
+Level=
 
 
 Limit_to_fields=以下のフィールドに制限

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -805,7 +805,7 @@ LaTeX_AUX_file=LaTeX_AUX-bestand
 Leave_file_in_its_current_directory=
 
 Left=Links
-
+Level=
 
 Limit_to_fields=De_volgende_velden_begrenzen
 

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -859,6 +859,7 @@ Leave_file_in_its_current_directory=La_filen_ligge_i_katalogen_den_ligger_i_n\u0
 
 
 Left=Venstre
+Level=
 
 
 Limit_to_fields=Begrens_til_f\u00f8lgende_felter

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -410,6 +410,7 @@ Last_modified=Última_modificação
 LaTeX_AUX_file=Arquivo_LaTeX_AUX
 Leave_file_in_its_current_directory=Manter_arquivos_em_seu_diretório_atual
 Left=Esquerdo(a)
+Level=
 Limit_to_fields=Limitar_aos_campos
 Limit_to_selected_entries=Limitar_às_referência_selecionadas
 Link=Linkar

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -773,6 +773,7 @@ LaTeX_AUX_file=Файл_AUX_для_LaTeX
 Leave_file_in_its_current_directory=Сохранить_файл_в_текущем_каталоге
 
 Left=Левый
+Level=
 
 
 Limit_to_fields=Ограничение_для_полей

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -645,6 +645,7 @@ Last_modified=Senast_ändrad
 Leave_file_in_its_current_directory=Lämna_filen_i_nuvarande_mapp
 Leave_this_dialog.=Lämna_denna_dialog.
 Left=Vänster
+Level=
 Left_entry=Vänster_post
 Limit_to_fields=Begränsa_till_fält
 Limit_to_selected_entries=Begränsa_till_valda_poster

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -410,6 +410,7 @@ Last_modified=Son_değiştirme
 LaTeX_AUX_file=LaTex_AUX_dosyası
 Leave_file_in_its_current_directory=Dosyayı_şimdiki_dizininde_bırak
 Left=Sol
+Level=
 Limit_to_fields=Alanlara_kısıtla
 Limit_to_selected_entries=Seçili_girdilere_kısıtla
 Link=Link

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -790,6 +790,7 @@ LaTeX_AUX_file=Tập_tin_LaTeX_AUX
 Leave_file_in_its_current_directory=Giữ_tập_tin_trong_thư_mục_hiện_tại_của_nó
 
 Left=Trái
+Level=
 
 
 Limit_to_fields=Giới_hạn_theo_các_trường

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -406,6 +406,7 @@ Language=语言
 Last_modified=上次修改的
 Leave_file_in_its_current_directory=保留文件的当前位置不改变。
 Left=Left
+Level=
 Limit_to_fields=限制范围到域
 Limit_to_selected_entries=限制范围为选中的记录
 Link=链接


### PR DESCRIPTION
Added a textual description for the functionality "Mark Specific Color" since some Look and Feels (including the OSX one) do not consider the Background and Foreground color (at least for) JMenuItem

the current fix at least provides some kind of indicator of the level instead of a blank field as before
