### PR TITLE
Hide helpful comments in issue reports

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 JabRef version <version as shown in the about box> on <Windows 10|Ubuntu 14.04|Mac OS X 10.8|...>
-Hint: If you use a [development version](http://builds.jabref.org/master/), ensure that you use the latest one.
+<Hint: If you use a [development version](http://builds.jabref.org/master/), ensure that you use the latest one.>
 
 Steps to reproduce:
 
@@ -7,4 +7,4 @@ Steps to reproduce:
 2. ...
 3. ...
 
-If applicable, excerpt of the bibliography file, screenshot, and excerpt of log (available in the error console)
+<If applicable, excerpt of the bibliography file, screenshot, and excerpt of log (available in the error console)>


### PR DESCRIPTION
Hide the comment
`Hint: If you use a [development version](http://builds.jabref.org/master/), ensure that you use the latest one.`
for new issues. (i.e. it is still displayed in the edit dialog but not in the posted issue)

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)

