### PR TITLE
Fix #1347 Open URLs does not work with query strings

### DIFF
--- a/src/main/java/net/sf/jabref/gui/desktop/os/Windows.java
+++ b/src/main/java/net/sf/jabref/gui/desktop/os/Windows.java
@@ -19,8 +19,9 @@ public class Windows implements NativeDesktop {
         if (type.isPresent() && !type.get().getOpenWithApplication().isEmpty()) {
             openFileWithApplication(filePath, type.get().getOpenWithApplication());
         } else {
-            //filePath as string, because it could be an URL
-            Runtime.getRuntime().exec(new String[] {"explorer.exe", filePath});
+            // quote String so explorer handles URL query strings correctly
+            String quotePath = "\"" + filePath +"\"";
+            Runtime.getRuntime().exec(new String[] {"explorer.exe", quotePath});
         }
 
     }


### PR DESCRIPTION
This should work with query strings like
`http://books.google.de/books?id=0yaM63MuqckC&lpg=PA153&ots=0H7EqpbM79&lr&hl=de&pg=PA153#v=onepage&q&f=false`
and normal URLs.

However, the question is:
Does this impact the opening of any other file path or anything? We need to be careful as this is a generic open method. Maybe that's also the problem because it needs to handle any kind of URI.

@Siedlerchr @tobiasdiez Please take a look.

