### PR TITLE
Fix NPE on selecting invalid jstyle

### DIFF
--- a/src/main/java/net/sf/jabref/gui/openoffice/StyleSelectDialog.java
+++ b/src/main/java/net/sf/jabref/gui/openoffice/StyleSelectDialog.java
@@ -132,8 +132,9 @@ class StyleSelectDialog {
             addDialog.setDirectoryPath(preferences.getCurrentStyle());
             addDialog.setVisible(true);
             addDialog.getFileName().ifPresent(fileName -> {
-                loader.addStyle(fileName);
-                preferences.setCurrentStyle(fileName);
+                if (loader.addStyleIfValid(fileName)) {
+                    preferences.setCurrentStyle(fileName);
+                }
             });
             updateStyles();
 
@@ -310,6 +311,7 @@ class StyleSelectDialog {
      * settings, and add the styles to the list of styles.
      */
     private void updateStyles() {
+
         table.clearSelection();
         styles.getReadWriteLock().writeLock().lock();
         styles.clear();

--- a/src/main/java/net/sf/jabref/logic/openoffice/OOBibStyle.java
+++ b/src/main/java/net/sf/jabref/logic/openoffice/OOBibStyle.java
@@ -68,7 +68,7 @@ import org.apache.commons.logging.LogFactory;
 public class OOBibStyle implements Comparable<OOBibStyle> {
 
     public static final String UNDEFINED_CITATION_MARKER = "??";
-    private String name;
+    private String name = "";
     private final SortedSet<String> journals = new TreeSet<>();
 
     // Formatter to be run on fields before they are used as part of citation marker:
@@ -229,7 +229,7 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
     }
 
     private void initialize(InputStream stream) throws IOException {
-        name = null;
+
         try (Reader reader = new InputStreamReader(stream, encoding)) {
             readFormatFile(reader);
         }

--- a/src/main/java/net/sf/jabref/logic/openoffice/StyleLoader.java
+++ b/src/main/java/net/sf/jabref/logic/openoffice/StyleLoader.java
@@ -64,7 +64,12 @@ public class StyleLoader {
         return result;
     }
 
-    public void addStyle(String filename) {
+    /**
+     * Adds the given style to the list of styles
+     * @param filename The filename of the style
+     * @return True if the added style is valid, false otherwise
+     */
+    public boolean addStyleIfValid(String filename) {
         Objects.requireNonNull(filename);
         try {
             OOBibStyle newStyle = new OOBibStyle(new File(filename), repository, encoding);
@@ -73,6 +78,7 @@ public class StyleLoader {
             } else if (newStyle.isValid()) {
                 externalStyles.add(newStyle);
                 storeExternalStyles();
+                return true;
             } else {
                 LOGGER.error(String.format("Style with filename %s is invalid", filename));
             }
@@ -82,6 +88,7 @@ public class StyleLoader {
         } catch (IOException e) {
             LOGGER.info("Problem reading external style file " + filename, e);
         }
+        return false;
 
     }
 
@@ -92,7 +99,7 @@ public class StyleLoader {
         for (String filename : lists) {
             try {
                 OOBibStyle style = new OOBibStyle(new File(filename), repository, encoding);
-                if (style.isValid()) {
+                if (style.isValid()) { //Problem!
                     externalStyles.add(style);
                 } else {
                     LOGGER.error(String.format("Style with filename %s is invalid", filename));

--- a/src/test/java/net/sf/jabref/logic/openoffice/StyleLoaderTest.java
+++ b/src/test/java/net/sf/jabref/logic/openoffice/StyleLoaderTest.java
@@ -85,7 +85,7 @@ public class StyleLoaderTest {
 
         String filename = Paths.get(JabRefMain.class.getResource(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH).toURI())
                 .toFile().getPath();
-        loader.addStyle(filename);
+        loader.addStyleIfValid(filename);
         assertEquals(numberOfInternalStyles + 1, loader.getStyles().size());
     }
 
@@ -96,7 +96,7 @@ public class StyleLoaderTest {
         loader = new StyleLoader(preferences,
                 mock(JournalAbbreviationRepository.class), Globals.prefs.getDefaultEncoding());
         int beforeAdding = loader.getStyles().size();
-        loader.addStyle("DefinitelyNotAValidFileNameOrWeAreExtremelyUnlucky");
+        loader.addStyleIfValid("DefinitelyNotAValidFileNameOrWeAreExtremelyUnlucky");
         assertEquals(beforeAdding, loader.getStyles().size());
     }
 
@@ -170,8 +170,8 @@ public class StyleLoaderTest {
         int beforeAdding = loader.getStyles().size();
         String filename = Paths.get(JabRefMain.class.getResource(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH).toURI())
                 .toFile().getPath();
-        loader.addStyle(filename);
-        loader.addStyle(filename);
+        loader.addStyleIfValid(filename);
+        loader.addStyleIfValid(filename);
         assertEquals(beforeAdding + 1, loader.getStyles().size());
     }
 
@@ -179,7 +179,7 @@ public class StyleLoaderTest {
     public void testAddNullStyleThrowsNPE() {
         loader = new StyleLoader(new OpenOfficePreferences(Globals.prefs),
                 mock(JournalAbbreviationRepository.class), Globals.prefs.getDefaultEncoding());
-        loader.addStyle(null);
+        loader.addStyleIfValid(null);
         fail();
     }
 


### PR DESCRIPTION
Follow up from #1294 

NPE was raised in Comparator because name was initialized with null instead of Empty string
Only store preferences if style is valid

@oscargus  The fix has the side effect that a file where the name can not be parsed correctly is displayed as "Empty style". I attached the problematic style file which was provided in #1294 
However: Valid still returns true. 
As you have worked recently with the styles things, do you know what is required for a jstyle? @koppor  Maybe you know this?
Then we could improved the validity check 

[campus_format.english.txt](https://github.com/JabRef/jabref/files/247561/campus_format.english.txt)
![emptyjstyle](https://cloud.githubusercontent.com/assets/320228/14995084/4d8c3a3e-1173-11e6-8eb6-e8f5490ffa5e.png)
