### PR TITLE
Scrollingthroughentrylisttest

### DIFF
--- a/src/integrationTest/java/net/sf/jabref/gui/AbstractUITest.java
+++ b/src/integrationTest/java/net/sf/jabref/gui/AbstractUITest.java
@@ -1,31 +1,91 @@
 package net.sf.jabref.gui;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
+import net.sf.jabref.JabRefMain;
+
+import org.assertj.swing.fixture.AbstractWindowFixture;
 import org.assertj.swing.fixture.FrameFixture;
 import org.assertj.swing.fixture.JFileChooserFixture;
+import org.assertj.swing.image.ScreenshotTaker;
 import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
+import org.assertj.swing.timing.Pause;
 
+import static org.assertj.swing.finder.WindowFinder.findFrame;
+import static org.assertj.swing.launcher.ApplicationLauncher.application;
 
 public abstract class AbstractUITest extends AssertJSwingJUnitTestCase {
 
+    protected final static int SPEED_NORMAL = 50;
 
+    protected AWTExceptionHandler awtExceptionHandler;
+    protected FrameFixture mainFrame;
 
-    public String getTestFilePath(String fileName) {
-        return new File(this.getClass().getClassLoader().getResource(fileName).getFile()).getAbsolutePath();
+    @Override
+    protected void onSetUp() {
+        awtExceptionHandler = new AWTExceptionHandler();
+        awtExceptionHandler.installExceptionDetectionInEDT();
+        application(JabRefMain.class).start();
+
+        robot().waitForIdle();
+
+        robot().settings().timeoutToFindSubMenu(1_000);
+        robot().settings().delayBetweenEvents(SPEED_NORMAL);
+
+        mainFrame = findFrame(JabRefFrame.class).withTimeout(10_000).using(robot());
+        robot().waitForIdle();
     }
 
-    public void importBibIntoNewDatabase(FrameFixture mainFrame, String path) {
-        // have to replace backslashes with normal slashes b/c assertJ can't type the former one on windows
-        path = path.replace("\\", "/");
+    /**
+     * Returns the absolute Path of the given relative Path
+     * The backlashes are replaced with forwardslashes b/c assertJ can't type the former one on windows
+     */
+    protected String getAbsolutePath(String relativePath) {
+        return new File(this.getClass().getClassLoader().getResource(relativePath).getFile()).getAbsolutePath().replace("\\", "/");
+    }
 
+    /**
+     * opens a database and gives JabRef a second to open it before proceeding
+     */
+    protected void importBibIntoNewDatabase(String path) {
         mainFrame.menuItemWithPath("File", "Import into new database").click();
         JFileChooserFixture openFileDialog = mainFrame.fileChooser();
         robot().settings().delayBetweenEvents(1);
         openFileDialog.fileNameTextBox().enterText(path);
-        robot().settings().delayBetweenEvents(1_000);
         openFileDialog.approve();
-        robot().settings().delayBetweenEvents(50);
+        Pause.pause(1_000);
+    }
+
+    protected void exitJabRef() {
+        mainFrame.menuItemWithPath("File", "Quit").click();
+        awtExceptionHandler.assertNoExceptions();
+    }
+
+    protected void newDatabase() {
+        mainFrame.menuItemWithPath("File", "New BibTeX database").click();
+    }
+
+    protected void closeDatabase() {
+        mainFrame.menuItemWithPath("File", "Close database").click();
+    }
+
+    protected void takeScreenshot(AbstractWindowFixture<?, ?, ?> dialog, String filename) throws IOException {
+        ScreenshotTaker screenshotTaker = new ScreenshotTaker();
+        Path folder = Paths.get("build", "screenshots");
+        // Create build/srceenshots folder if not present
+        if (!Files.exists(folder)) {
+            Files.createDirectory(folder);
+        }
+        Path file = folder.resolve(filename + ".png").toAbsolutePath();
+        // Delete already present file
+        if (Files.exists(file)) {
+            Files.delete(file);
+        }
+        screenshotTaker.saveComponentAsPng(dialog.target(), file.toString());
     }
 
 }

--- a/src/integrationTest/java/net/sf/jabref/gui/AbstractUITest.java
+++ b/src/integrationTest/java/net/sf/jabref/gui/AbstractUITest.java
@@ -1,7 +1,8 @@
 package net.sf.jabref.gui;
 
-import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -11,9 +12,11 @@ import net.sf.jabref.JabRefMain;
 import org.assertj.swing.fixture.AbstractWindowFixture;
 import org.assertj.swing.fixture.FrameFixture;
 import org.assertj.swing.fixture.JFileChooserFixture;
+import org.assertj.swing.fixture.JTableFixture;
 import org.assertj.swing.image.ScreenshotTaker;
 import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
 import org.assertj.swing.timing.Pause;
+import org.junit.Assert;
 
 import static org.assertj.swing.finder.WindowFinder.findFrame;
 import static org.assertj.swing.launcher.ApplicationLauncher.application;
@@ -43,9 +46,16 @@ public abstract class AbstractUITest extends AssertJSwingJUnitTestCase {
     /**
      * Returns the absolute Path of the given relative Path
      * The backlashes are replaced with forwardslashes b/c assertJ can't type the former one on windows
+     * @param relativePath the relative path to the resource database
      */
     protected String getAbsolutePath(String relativePath) {
-        return new File(this.getClass().getClassLoader().getResource(relativePath).getFile()).getAbsolutePath().replace("\\", "/");
+        final URL resource = this.getClass().getClassLoader().getResource(relativePath);
+        try {
+            return Paths.get(resource.toURI()).toAbsolutePath().toString().replace("\\", "/");
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     /**
@@ -88,4 +98,11 @@ public abstract class AbstractUITest extends AssertJSwingJUnitTestCase {
         screenshotTaker.saveComponentAsPng(dialog.target(), file.toString());
     }
 
+    protected void assertColumnValue(JTableFixture table, int rowIndex, int columnIndex, String selectionValue){
+        String[][] tableContent;
+        tableContent = table.contents();
+
+        String value = tableContent[rowIndex][columnIndex];
+        Assert.assertEquals(value, selectionValue);
+    }
 }

--- a/src/integrationTest/java/net/sf/jabref/gui/AbstractUITest.java
+++ b/src/integrationTest/java/net/sf/jabref/gui/AbstractUITest.java
@@ -1,0 +1,31 @@
+package net.sf.jabref.gui;
+
+import java.io.File;
+
+import org.assertj.swing.fixture.FrameFixture;
+import org.assertj.swing.fixture.JFileChooserFixture;
+import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
+
+
+public abstract class AbstractUITest extends AssertJSwingJUnitTestCase {
+
+
+
+    public String getTestFilePath(String fileName) {
+        return new File(this.getClass().getClassLoader().getResource(fileName).getFile()).getAbsolutePath();
+    }
+
+    public void importBibIntoNewDatabase(FrameFixture mainFrame, String path) {
+        // have to replace backslashes with normal slashes b/c assertJ can't type the former one on windows
+        path = path.replace("\\", "/");
+
+        mainFrame.menuItemWithPath("File", "Import into new database").click();
+        JFileChooserFixture openFileDialog = mainFrame.fileChooser();
+        robot().settings().delayBetweenEvents(1);
+        openFileDialog.fileNameTextBox().enterText(path);
+        robot().settings().delayBetweenEvents(1_000);
+        openFileDialog.approve();
+        robot().settings().delayBetweenEvents(50);
+    }
+
+}

--- a/src/integrationTest/java/net/sf/jabref/gui/EntryTableTest.java
+++ b/src/integrationTest/java/net/sf/jabref/gui/EntryTableTest.java
@@ -1,0 +1,74 @@
+package net.sf.jabref.gui;
+
+import java.awt.event.KeyEvent;
+import java.util.regex.Pattern;
+
+import net.sf.jabref.JabRefMain;
+
+import org.assertj.swing.fixture.FrameFixture;
+import org.assertj.swing.fixture.JTableCellFixture;
+import org.assertj.swing.fixture.JTableFixture;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.assertj.swing.finder.WindowFinder.findFrame;
+import static org.assertj.swing.launcher.ApplicationLauncher.application;
+
+/**
+ * Specific Use-Case:
+ * I import a database. Then I doubleclick on the first entry in the table to open the entry editor.
+ * Then I click on the first entry again, and scroll through all of the lists entries, without having to click
+ * on the table again.
+ */
+public class EntryTableTest extends AbstractUITest{
+
+    private final static int SCROLL_ACTION_EXECUTION = 5;
+    private final static String TEST_FILE_NAME = "testbib/testjabref.bib";
+    private final static int DOWN = KeyEvent.VK_DOWN;
+    private final static int UP = KeyEvent.VK_UP;
+
+    @Override
+    protected void onSetUp() {
+        AWTExceptionHandler awtExceptionHandler = new AWTExceptionHandler();
+        awtExceptionHandler.installExceptionDetectionInEDT();
+        application(JabRefMain.class).start();
+
+        robot().settings().timeoutToFindSubMenu(1_000);
+        robot().settings().delayBetweenEvents(50);
+    }
+
+    @Test
+    public void scrollThroughEntryList() {
+        FrameFixture mainFrame = findFrame(JabRefFrame.class).withTimeout(10_000).using(robot());
+        robot().waitForIdle();
+
+        String path = getTestFilePath(TEST_FILE_NAME);
+
+        importBibIntoNewDatabase(mainFrame, path);
+
+        JTableFixture entryTable = mainFrame.table();
+
+        //use a pattern from the first row to select it since it seems to be the best way to get the cell object
+        Pattern pattern = Pattern.compile("256.*");
+        JTableCellFixture firstCell = entryTable.cell(pattern);
+
+        entryTable.selectRows(0).doubleClick();
+        //delay has to be shortened so that double click is recognized
+        robot().settings().delayBetweenEvents(0);
+        firstCell.doubleClick();
+        robot().settings().delayBetweenEvents(50);
+
+        firstCell.click();
+
+        for (int i=0; i < SCROLL_ACTION_EXECUTION; i++) {
+            robot().pressAndReleaseKey(DOWN);
+            Assert.assertTrue(entryTable.selectionValue() != null);
+        }
+
+        for (int i = 0; i < SCROLL_ACTION_EXECUTION; i++) {
+            robot().pressAndReleaseKey(UP);
+            Assert.assertTrue(entryTable.selectionValue() != null);
+        }
+    }
+
+}

--- a/src/integrationTest/java/net/sf/jabref/gui/EntryTableTest.java
+++ b/src/integrationTest/java/net/sf/jabref/gui/EntryTableTest.java
@@ -3,16 +3,10 @@ package net.sf.jabref.gui;
 import java.awt.event.KeyEvent;
 import java.util.regex.Pattern;
 
-import net.sf.jabref.JabRefMain;
-
-import org.assertj.swing.fixture.FrameFixture;
 import org.assertj.swing.fixture.JTableCellFixture;
 import org.assertj.swing.fixture.JTableFixture;
 import org.junit.Assert;
 import org.junit.Test;
-
-import static org.assertj.swing.finder.WindowFinder.findFrame;
-import static org.assertj.swing.launcher.ApplicationLauncher.application;
 
 /**
  * Specific Use-Case:
@@ -27,24 +21,11 @@ public class EntryTableTest extends AbstractUITest{
     private final static int DOWN = KeyEvent.VK_DOWN;
     private final static int UP = KeyEvent.VK_UP;
 
-    @Override
-    protected void onSetUp() {
-        AWTExceptionHandler awtExceptionHandler = new AWTExceptionHandler();
-        awtExceptionHandler.installExceptionDetectionInEDT();
-        application(JabRefMain.class).start();
-
-        robot().settings().timeoutToFindSubMenu(1_000);
-        robot().settings().delayBetweenEvents(50);
-    }
-
     @Test
     public void scrollThroughEntryList() {
-        FrameFixture mainFrame = findFrame(JabRefFrame.class).withTimeout(10_000).using(robot());
-        robot().waitForIdle();
+        String path = getAbsolutePath(TEST_FILE_NAME);
 
-        String path = getTestFilePath(TEST_FILE_NAME);
-
-        importBibIntoNewDatabase(mainFrame, path);
+        importBibIntoNewDatabase(path);
 
         JTableFixture entryTable = mainFrame.table();
 
@@ -56,7 +37,7 @@ public class EntryTableTest extends AbstractUITest{
         //delay has to be shortened so that double click is recognized
         robot().settings().delayBetweenEvents(0);
         firstCell.doubleClick();
-        robot().settings().delayBetweenEvents(50);
+        robot().settings().delayBetweenEvents(SPEED_NORMAL);
 
         firstCell.click();
 
@@ -69,6 +50,9 @@ public class EntryTableTest extends AbstractUITest{
             robot().pressAndReleaseKey(UP);
             Assert.assertTrue(entryTable.selectionValue() != null);
         }
+
+        closeDatabase();
+        exitJabRef();
     }
 
 }

--- a/src/integrationTest/java/net/sf/jabref/gui/EntryTableTest.java
+++ b/src/integrationTest/java/net/sf/jabref/gui/EntryTableTest.java
@@ -20,6 +20,7 @@ public class EntryTableTest extends AbstractUITest{
     private final static String TEST_FILE_NAME = "testbib/testjabref.bib";
     private final static int DOWN = KeyEvent.VK_DOWN;
     private final static int UP = KeyEvent.VK_UP;
+    private final static int TITLE_COLUMN_INDEX = 5;
 
     @Test
     public void scrollThroughEntryList() {
@@ -40,15 +41,20 @@ public class EntryTableTest extends AbstractUITest{
         robot().settings().delayBetweenEvents(SPEED_NORMAL);
 
         firstCell.click();
+        //is the first table entry selected?
+        assertColumnValue(entryTable, 0, TITLE_COLUMN_INDEX, entryTable.selectionValue());
 
+        //go throught the table and check if the entry with the correct index is selected
         for (int i=0; i < SCROLL_ACTION_EXECUTION; i++) {
             robot().pressAndReleaseKey(DOWN);
             Assert.assertTrue(entryTable.selectionValue() != null);
+            assertColumnValue(entryTable, i+1, TITLE_COLUMN_INDEX, entryTable.selectionValue());
         }
-
-        for (int i = 0; i < SCROLL_ACTION_EXECUTION; i++) {
+        //do the same going up again
+        for (int i = SCROLL_ACTION_EXECUTION; i > 0; i--) {
             robot().pressAndReleaseKey(UP);
             Assert.assertTrue(entryTable.selectionValue() != null);
+            assertColumnValue(entryTable, i-1, TITLE_COLUMN_INDEX, entryTable.selectionValue());
         }
 
         closeDatabase();

--- a/src/integrationTest/java/net/sf/jabref/gui/GUITest.java
+++ b/src/integrationTest/java/net/sf/jabref/gui/GUITest.java
@@ -1,94 +1,52 @@
 package net.sf.jabref.gui;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import javax.swing.JButton;
 
-import net.sf.jabref.JabRefMain;
 import net.sf.jabref.gui.dbproperties.DatabasePropertiesDialog;
 import net.sf.jabref.gui.preftabs.PreferencesDialog;
 
 import org.assertj.swing.core.GenericTypeMatcher;
 import org.assertj.swing.dependency.jsr305.Nonnull;
-import org.assertj.swing.fixture.AbstractWindowFixture;
 import org.assertj.swing.fixture.DialogFixture;
-import org.assertj.swing.fixture.FrameFixture;
-import org.assertj.swing.image.ScreenshotTaker;
-import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
-import org.assertj.swing.timing.Pause;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.swing.finder.WindowFinder.findDialog;
-import static org.assertj.swing.finder.WindowFinder.findFrame;
-import static org.assertj.swing.launcher.ApplicationLauncher.application;
 
-public class GUITest extends AssertJSwingJUnitTestCase {
-    private AWTExceptionHandler awtExceptionHandler;
-
-    @Override
-    protected void onSetUp() {
-        awtExceptionHandler = new AWTExceptionHandler();
-        awtExceptionHandler.installExceptionDetectionInEDT();
-        application(JabRefMain.class).start();
-
-        robot().waitForIdle();
-
-        robot().settings().timeoutToFindSubMenu(1_000);
-        robot().settings().delayBetweenEvents(50);
-    }
+public class GUITest extends AbstractUITest {
 
     @Test
     public void testExit() {
-        FrameFixture mainFrame = findFrame(JabRefFrame.class).withTimeout(10_000).using(robot());
-        Pause.pause(1_000);
-        exitJabRef(mainFrame);
-    }
-
-    private void exitJabRef(FrameFixture mainFrame) {
-        mainFrame.menuItemWithPath("File", "Quit").click();
-        awtExceptionHandler.assertNoExceptions();
+        exitJabRef();
     }
 
     @Test
     public void testNewFile() {
-        FrameFixture mainFrame = findFrame(JabRefFrame.class).withTimeout(10_000).using(robot());
-        newDatabase(mainFrame);
-
-        mainFrame.menuItemWithPath("File", "Close database").click();
-        exitJabRef(mainFrame);
-    }
-
-    private void newDatabase(FrameFixture mainFrame) {
-        mainFrame.menuItemWithPath("File", "New BibTeX database").click();
+        newDatabase();
+        closeDatabase();
+        exitJabRef();
     }
 
     @Test
     public void testCreateBibtexEntry() throws IOException {
-        FrameFixture mainFrame = findFrame(JabRefFrame.class).withTimeout(10_000).using(robot());
-
-        newDatabase(mainFrame);
+        newDatabase();
 
         mainFrame.menuItemWithPath("BibTeX", "New entry...").click();
         findDialog(EntryTypeDialog.class).withTimeout(10_000).using(robot())
                 .button(new GenericTypeMatcher<JButton>(JButton.class) {
-
                     @Override
                     protected boolean isMatching(@Nonnull JButton jButton) {
                         return "Book".equals(jButton.getText());
                     }
                 }).click();
         takeScreenshot(mainFrame, "MainWindowWithOneDatabase");
-        exitJabRef(mainFrame);
     }
 
     @Ignore
     @Test
     public void testOpenAndSavePreferences() throws IOException {
-        FrameFixture mainFrame = findFrame(JabRefFrame.class).withTimeout(10_000).using(robot());
         mainFrame.menuItemWithPath("Options", "Preferences").click();
 
         robot().waitForIdle();
@@ -96,41 +54,50 @@ public class GUITest extends AssertJSwingJUnitTestCase {
         DialogFixture preferencesDialog = findDialog(PreferencesDialog.class).withTimeout(10_000).using(robot());
         takeScreenshot(preferencesDialog, "PreferencesDialog");
         preferencesDialog.button(new GenericTypeMatcher<JButton>(JButton.class) {
-
                     @Override
                     protected boolean isMatching(@Nonnull JButton jButton) {
                         return "OK".equals(jButton.getText());
                     }
                 }).click();
 
-        exitJabRef(mainFrame);
+        exitJabRef();
     }
 
+    /**
+     * tests different buttons
+     * sometimes this test clicks some buttons twice to reverse their effect and leaves JabRef as it was before
+     */
     @Test
     public void testViewChanges() {
-        FrameFixture mainFrame = findFrame(JabRefFrame.class).withTimeout(10_000).using(robot());
-
-        newDatabase(mainFrame);
+        newDatabase();
 
         mainFrame.menuItemWithPath("View", "Increase table font size").click();
         mainFrame.menuItemWithPath("View", "Decrease table font size").click();
+
         mainFrame.menuItemWithPath("View", "Web search").click();
+        mainFrame.menuItemWithPath("View", "Web search").click();
+
         mainFrame.menuItemWithPath("View", "Toggle groups interface").click();
+        mainFrame.menuItemWithPath("View", "Toggle groups interface").click();
+
         mainFrame.menuItemWithPath("View", "Toggle entry preview").click();
+        mainFrame.menuItemWithPath("View", "Toggle entry preview").click();
+
         mainFrame.menuItemWithPath("View", "Switch preview layout").click();
+        mainFrame.menuItemWithPath("View", "Switch preview layout").click();
+
         mainFrame.menuItemWithPath("View", "Hide/show toolbar").click();
+        mainFrame.menuItemWithPath("View", "Hide/show toolbar").click();
+
         mainFrame.menuItemWithPath("View", "Focus entry table").click();
 
-        newDatabase(mainFrame);
-        mainFrame.menuItemWithPath("File", "Close database").click();
-        exitJabRef(mainFrame);
+        closeDatabase();
+        exitJabRef();
     }
 
     @Test
     public void testDatabasePropertiesDialog() throws IOException {
-
-        FrameFixture mainFrame = findFrame(JabRefFrame.class).withTimeout(10_000).using(robot());
-        newDatabase(mainFrame);
+        newDatabase();
 
         mainFrame.menuItemWithPath("File", "Database properties").click();
 
@@ -139,28 +106,13 @@ public class GUITest extends AssertJSwingJUnitTestCase {
         DialogFixture databasePropertiesDialog = findDialog(DatabasePropertiesDialog.class).withTimeout(10_000).using(robot());
         takeScreenshot(databasePropertiesDialog, "DatabasePropertiesDialog");
         databasePropertiesDialog.button(new GenericTypeMatcher<JButton>(JButton.class) {
-
                     @Override
                     protected boolean isMatching(@Nonnull JButton jButton) {
                         return "OK".equals(jButton.getText());
                     }
                 }).click();
 
-        exitJabRef(mainFrame);
-    }
-
-    private void takeScreenshot(AbstractWindowFixture<?, ?, ?> dialog, String filename) throws IOException {
-        ScreenshotTaker screenshotTaker = new ScreenshotTaker();
-        Path folder = Paths.get("build", "screenshots");
-        // Create build/srceenshots folder if not present
-        if (!Files.exists(folder)) {
-            Files.createDirectory(folder);
-        }
-        Path file = folder.resolve(filename + ".png").toAbsolutePath();
-        // Delete already present file
-        if (Files.exists(file)) {
-            Files.delete(file);
-        }
-        screenshotTaker.saveComponentAsPng(dialog.target(), file.toString());
+        closeDatabase();
+        exitJabRef();
     }
 }

--- a/src/integrationTest/java/net/sf/jabref/gui/UndoTest.java
+++ b/src/integrationTest/java/net/sf/jabref/gui/UndoTest.java
@@ -1,20 +1,16 @@
 package net.sf.jabref.gui;
 
-import java.io.File;
-
 import net.sf.jabref.JabRefMain;
 
 import org.assertj.swing.fixture.FrameFixture;
-import org.assertj.swing.fixture.JFileChooserFixture;
 import org.assertj.swing.fixture.JTableFixture;
-import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
 import org.junit.Test;
 
 import static org.assertj.swing.finder.WindowFinder.findFrame;
 import static org.assertj.swing.launcher.ApplicationLauncher.application;
 import static org.junit.Assert.assertTrue;
 
-public class UndoTest extends AssertJSwingJUnitTestCase {
+public class UndoTest extends AbstractUITest {
 
     private AWTExceptionHandler awtExceptionHandler;
 
@@ -33,23 +29,6 @@ public class UndoTest extends AssertJSwingJUnitTestCase {
     private void exitJabRef(FrameFixture mainFrame) {
         mainFrame.menuItemWithPath("File", "Quit").click();
         awtExceptionHandler.assertNoExceptions();
-    }
-
-    private String getTestFilePath(String fileName) {
-        return new File(this.getClass().getClassLoader().getResource(fileName).getFile()).getAbsolutePath();
-    }
-
-    private void importBibIntoNewDatabase(FrameFixture mainFrame, String path) {
-        // have to replace backslashes with normal slashes b/c assertJ can't type the former one on windows
-        path = path.replace("\\", "/");
-
-        mainFrame.menuItemWithPath("File", "Import into new database").click();
-        JFileChooserFixture openFileDialog = mainFrame.fileChooser();
-        robot().settings().delayBetweenEvents(1);
-        openFileDialog.fileNameTextBox().enterText(path);
-        robot().settings().delayBetweenEvents(1_000);
-        openFileDialog.approve();
-        robot().settings().delayBetweenEvents(50);
     }
 
     @Test

--- a/src/integrationTest/java/net/sf/jabref/gui/UndoTest.java
+++ b/src/integrationTest/java/net/sf/jabref/gui/UndoTest.java
@@ -1,40 +1,15 @@
 package net.sf.jabref.gui;
 
-import net.sf.jabref.JabRefMain;
-
-import org.assertj.swing.fixture.FrameFixture;
 import org.assertj.swing.fixture.JTableFixture;
 import org.junit.Test;
 
-import static org.assertj.swing.finder.WindowFinder.findFrame;
-import static org.assertj.swing.launcher.ApplicationLauncher.application;
 import static org.junit.Assert.assertTrue;
 
 public class UndoTest extends AbstractUITest {
 
-    private AWTExceptionHandler awtExceptionHandler;
-
-    @Override
-    protected void onSetUp() {
-        awtExceptionHandler = new AWTExceptionHandler();
-        awtExceptionHandler.installExceptionDetectionInEDT();
-        application(JabRefMain.class).start();
-
-        robot().waitForIdle();
-
-        robot().settings().timeoutToFindSubMenu(1_000);
-        robot().settings().delayBetweenEvents(50);
-    }
-
-    private void exitJabRef(FrameFixture mainFrame) {
-        mainFrame.menuItemWithPath("File", "Quit").click();
-        awtExceptionHandler.assertNoExceptions();
-    }
-
     @Test
     public void undoCutOfMultipleEntries() {
-        FrameFixture mainFrame = findFrame(JabRefFrame.class).withTimeout(10_000).using(robot());
-        importBibIntoNewDatabase(mainFrame, getTestFilePath("testbib/testjabref.bib"));
+        importBibIntoNewDatabase(getAbsolutePath("testbib/testjabref.bib"));
 
         JTableFixture entryTable = mainFrame.table();
 
@@ -47,9 +22,8 @@ public class UndoTest extends AbstractUITest {
         mainFrame.menuItemWithPath("Edit", "Undo").click();
         entryTable.requireRowCount(oldRowCount);
 
-        mainFrame.menuItemWithPath("File", "Close database").click();
-        mainFrame.menuItemWithPath("File", "Close database").click();
-        exitJabRef(mainFrame);
+        closeDatabase();
+        exitJabRef();
     }
 
 }


### PR DESCRIPTION
I wrote a ui-test for the following use case:
I import a bib-file into a new database.
Then I double-click on the first entry in the database to open up the entry editor.
Then I click back into the table and start scrolling through the entries.
When I do that, the table should always keep the focus.

This test case tests the following pull-requests enhancement: #988
It also referes to the discussion about ui-testing: #507 
 
- [x] Tests created