### PR TITLE
Remove StringUtil.expandAuthorInitials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Removed possibility to export entries/databases to an `.sql` file, as the logic cannot easily use the correct escape logic
 - Removed support of old groups format, which was used prior to JabRef version 1.6. If you happen to have a 10 years old .bib file, then JabRef 3.3 can be used to convert it to the current format.
 - Removed possibility to automatically add braces via Option - Preferences - File - Store the following fields with braces around capital letters. Please use save actions instead for adding braces automatically.
-
-
+- Medline and GVK importer no longer try to expand author initials (i.e.  `EH Wissler -> E. H. Wissler`).
 
 
 

--- a/src/main/java/net/sf/jabref/importer/fetcher/GVKParser.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/GVKParser.java
@@ -12,7 +12,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.IdGenerator;
 
@@ -365,10 +364,10 @@ public class GVKParser {
 
         // Zuordnung der Felder in Abhängigkeit vom Dokumenttyp
         if (author != null) {
-            result.setField("author", StringUtil.expandAuthorInitials(author));
+            result.setField("author", author);
         }
         if (editor != null) {
-            result.setField("editor", StringUtil.expandAuthorInitials(editor));
+            result.setField("editor", editor);
         }
         if (title != null) {
             result.setField("title", title);

--- a/src/main/java/net/sf/jabref/importer/fileformat/MedlineHandler.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/MedlineHandler.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import net.sf.jabref.logic.formatter.bibtexfields.UnicodeToLatexFormatter;
-import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.IdGenerator;
 
@@ -229,7 +228,7 @@ class MedlineHandler extends DefaultHandler {
             BibEntry b = new BibEntry(IdGenerator.next(), "article"); // id assumes an existing database so don't create one here
             if (!"".equals(author)) {
                 b.setField("author",
-                        MedlineHandler.UNICODE_CONVERTER.format(StringUtil.expandAuthorInitials(author)));
+                        MedlineHandler.UNICODE_CONVERTER.format(author));
                 // b.setField("author",Util.replaceSpecialCharacters(ImportFormatReader.expandAuthorInitials(author)));
                 author = "";
             }

--- a/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
@@ -23,7 +23,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.model.entry.Author;
 
 import com.google.common.base.CharMatcher;
 
@@ -624,53 +623,6 @@ public class StringUtil {
             result = result.replace(chrAndReplace.getKey(), chrAndReplace.getValue());
         }
         return result;
-    }
-
-    /**
-     * Expand initials, e.g. EH Wissler -> E. H. Wissler or Wissler, EH -> Wissler, E. H.
-     *
-     * @param name
-     * @return The name after expanding initials.
-     */
-    public static String expandAuthorInitials(String name) {
-        String[] authors = name.split(" and ");
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < authors.length; i++) {
-            if (authors[i].contains(", ")) {
-                String[] names = authors[i].split(", ");
-                if (names.length > 0) {
-                    sb.append(names[0]);
-                    if (names.length > 1) {
-                        sb.append(", ");
-                    }
-                }
-                for (int j = 1; j < names.length; j++) {
-                    if (j == 1) {
-                        sb.append(Author.addDotIfAbbreviation(names[j]));
-                    } else {
-                        sb.append(names[j]);
-                    }
-                    if (j < (names.length - 1)) {
-                        sb.append(", ");
-                    }
-                }
-
-            } else {
-                String[] names = authors[i].split(" ");
-                if (names.length > 0) {
-                    sb.append(Author.addDotIfAbbreviation(names[0]));
-                }
-                for (int j = 1; j < names.length; j++) {
-                    sb.append(' ');
-                    sb.append(names[j]);
-                }
-            }
-            if (i < (authors.length - 1)) {
-                sb.append(" and ");
-            }
-        }
-
-        return sb.toString().trim();
     }
 
     /**

--- a/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
@@ -290,47 +290,6 @@ public class StringUtilTest {
     }
 
     @Test
-    public void testExpandAuthorInitialsAddDot() {
-        assertEquals("O.", StringUtil.expandAuthorInitials("O"));
-        assertEquals("A. O.", StringUtil.expandAuthorInitials("AO"));
-        assertEquals("A. O.", StringUtil.expandAuthorInitials("AO."));
-        assertEquals("A. O.", StringUtil.expandAuthorInitials("A.O."));
-        assertEquals("A.-O.", StringUtil.expandAuthorInitials("A-O"));
-        assertEquals("O. Moore", StringUtil.expandAuthorInitials("O Moore"));
-        assertEquals("A. O. Moore", StringUtil.expandAuthorInitials("AO Moore"));
-        assertEquals("O. von Moore", StringUtil.expandAuthorInitials("O von Moore"));
-        assertEquals("A.-O. Moore", StringUtil.expandAuthorInitials("A-O Moore"));
-        assertEquals("Moore, O.", StringUtil.expandAuthorInitials("Moore, O"));
-        assertEquals("Moore, O., Jr.", StringUtil.expandAuthorInitials("Moore, O, Jr."));
-        assertEquals("Moore, A. O.", StringUtil.expandAuthorInitials("Moore, AO"));
-        assertEquals("Moore, A.-O.", StringUtil.expandAuthorInitials("Moore, A-O"));
-        assertEquals("Moore, O. and O. Moore", StringUtil.expandAuthorInitials("Moore, O and O Moore"));
-        assertEquals("Moore, O. and O. Moore and Moore, O. O.",
-                StringUtil.expandAuthorInitials("Moore, O and O Moore and Moore, OO"));
-    }
-
-    @Test
-    public void testExpandAuthorInitialsDoNotAddDot() {
-        assertEquals("O.", StringUtil.expandAuthorInitials("O."));
-        assertEquals("A. O.", StringUtil.expandAuthorInitials("A. O."));
-        assertEquals("A.-O.", StringUtil.expandAuthorInitials("A.-O."));
-        assertEquals("O. Moore", StringUtil.expandAuthorInitials("O. Moore"));
-        assertEquals("A. O. Moore", StringUtil.expandAuthorInitials("A. O. Moore"));
-        assertEquals("O. von Moore", StringUtil.expandAuthorInitials("O. von Moore"));
-        assertEquals("A.-O. Moore", StringUtil.expandAuthorInitials("A.-O. Moore"));
-        assertEquals("Moore, O.", StringUtil.expandAuthorInitials("Moore, O."));
-        assertEquals("Moore, O., Jr.", StringUtil.expandAuthorInitials("Moore, O., Jr."));
-        assertEquals("Moore, A. O.", StringUtil.expandAuthorInitials("Moore, A. O."));
-        assertEquals("Moore, A.-O.", StringUtil.expandAuthorInitials("Moore, A.-O."));
-        assertEquals("MEmre", StringUtil.expandAuthorInitials("MEmre"));
-        assertEquals("{\\'{E}}douard", StringUtil.expandAuthorInitials("{\\'{E}}douard"));
-        assertEquals("J{\\\"o}rg", StringUtil.expandAuthorInitials("J{\\\"o}rg"));
-        assertEquals("Moore, O. and O. Moore", StringUtil.expandAuthorInitials("Moore, O. and O. Moore"));
-        assertEquals("Moore, O. and O. Moore and Moore, O. O.",
-                StringUtil.expandAuthorInitials("Moore, O. and O. Moore and Moore, O. O."));
-    }
-
-    @Test
     public void testRepeatSpaces() {
         assertEquals("", StringUtil.repeatSpaces(0));
         assertEquals(" ", StringUtil.repeatSpaces(1));

--- a/src/test/java/net/sf/jabref/model/entry/AuthorTest.java
+++ b/src/test/java/net/sf/jabref/model/entry/AuthorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2003-2016 JabRef contributors.
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package net.sf.jabref.model.entry;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class AuthorTest {
+
+    @Test
+    public void addDotIfAbbreviationAddDot() {
+        assertEquals("O.", Author.addDotIfAbbreviation("O"));
+        assertEquals("A. O.", Author.addDotIfAbbreviation("AO"));
+        assertEquals("A. O.", Author.addDotIfAbbreviation("AO."));
+        assertEquals("A. O.", Author.addDotIfAbbreviation("A.O."));
+        assertEquals("A.-O.", Author.addDotIfAbbreviation("A-O"));
+    }
+
+    @Test
+    public void addDotIfAbbreviationDoNotAddDot() {
+        assertEquals("O.", Author.addDotIfAbbreviation("O."));
+        assertEquals("A. O.", Author.addDotIfAbbreviation("A. O."));
+        assertEquals("A.-O.", Author.addDotIfAbbreviation("A.-O."));
+        assertEquals("O. Moore", Author.addDotIfAbbreviation("O. Moore"));
+        assertEquals("A. O. Moore", Author.addDotIfAbbreviation("A. O. Moore"));
+        assertEquals("O. von Moore", Author.addDotIfAbbreviation("O. von Moore"));
+        assertEquals("A.-O. Moore", Author.addDotIfAbbreviation("A.-O. Moore"));
+        assertEquals("Moore, O.", Author.addDotIfAbbreviation("Moore, O."));
+        assertEquals("Moore, O., Jr.", Author.addDotIfAbbreviation("Moore, O., Jr."));
+        assertEquals("Moore, A. O.", Author.addDotIfAbbreviation("Moore, A. O."));
+        assertEquals("Moore, A.-O.", Author.addDotIfAbbreviation("Moore, A.-O."));
+        assertEquals("MEmre", Author.addDotIfAbbreviation("MEmre"));
+        assertEquals("{\\'{E}}douard", Author.addDotIfAbbreviation("{\\'{E}}douard"));
+        assertEquals("J{\\\"o}rg", Author.addDotIfAbbreviation("J{\\\"o}rg"));
+        assertEquals("Moore, O. and O. Moore", Author.addDotIfAbbreviation("Moore, O. and O. Moore"));
+        assertEquals("Moore, O. and O. Moore and Moore, O. O.",
+                Author.addDotIfAbbreviation("Moore, O. and O. Moore and Moore, O. O."));
+    }
+    
+}


### PR DESCRIPTION
Reasoning:
- only used by a few importers and not consistently so
- better handled by cleanup actions / converter
- duplicates logic to parse list of author names (while the AuthorList.parse method is far superior)
- results in discussion about string joiner and builder in #547 :smile_cat: 