### PR TITLE
Add MathSciNet tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Add LaTeX to Unicode converter as cleanup operation
 - Added an option in the about dialog to easily copy the version information of JabRef
 - Integrity check table can be sorted by clicking on column headings
+- Add tab which shows the MathSciNet review website if the `MRNumber` field is present.
 
 ### Fixed
 - Fixed [#473](https://github.com/JabRef/jabref/issues/473): Values in an entry containing symbols like ' are now properly escaped for exporting to the database

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -38,7 +38,7 @@
         <module name="IllegalImport"/>
 
         <module name="ImportOrder">
-            <property name="groups" value="java,javax,net.sf.jabref,*"/>
+            <property name="groups" value="java,javax,javafx,net.sf.jabref,*"/>
             <property name="ordered" value="true"/>
             <property name="separated" value="true"/>
             <property name="option" value="bottom"/>

--- a/src/main/java/net/sf/jabref/JabRefMain.java
+++ b/src/main/java/net/sf/jabref/JabRefMain.java
@@ -20,6 +20,10 @@ import java.net.Authenticator;
 
 import javax.swing.SwingUtilities;
 
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.stage.Stage;
+
 import net.sf.jabref.bibtex.InternalBibtexFields;
 import net.sf.jabref.cli.ArgumentProcessor;
 import net.sf.jabref.exporter.ExportFormats;
@@ -32,10 +36,6 @@ import net.sf.jabref.logic.net.ProxyPreferences;
 import net.sf.jabref.logic.net.ProxyRegisterer;
 import net.sf.jabref.logic.remote.RemotePreferences;
 import net.sf.jabref.logic.remote.client.RemoteListenerClient;
-
-import javafx.application.Application;
-import javafx.application.Platform;
-import javafx.stage.Stage;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/gui/FXAlert.java
+++ b/src/main/java/net/sf/jabref/gui/FXAlert.java
@@ -15,14 +15,14 @@
 */
 package net.sf.jabref.gui;
 
+import java.awt.Window;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
 import javafx.application.Platform;
 import javafx.scene.control.Alert;
 import javafx.scene.image.Image;
 import javafx.stage.Stage;
-
-import java.awt.Window;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
 
 import net.sf.jabref.JabRefGUI;
 

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -70,6 +70,8 @@ import javax.swing.TransferHandler;
 import javax.swing.UIManager;
 import javax.swing.WindowConstants;
 
+import javafx.application.Platform;
+
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
 import net.sf.jabref.HighlightMatchingGroupPreferences;
@@ -141,7 +143,6 @@ import net.sf.jabref.sql.importer.DbImportAction;
 
 import com.jgoodies.looks.HeaderStyle;
 import com.jgoodies.looks.Options;
-import javafx.application.Platform;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import osx.macadapter.MacAdapter;

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -64,6 +64,13 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.text.JTextComponent;
 
+import javafx.application.Platform;
+import javafx.embed.swing.JFXPanel;
+import javafx.scene.Scene;
+import javafx.scene.control.ProgressIndicator;
+import javafx.scene.layout.StackPane;
+import javafx.scene.web.WebView;
+
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.bibtex.BibEntryWriter;
@@ -115,12 +122,6 @@ import net.sf.jabref.model.entry.EntryType;
 import net.sf.jabref.specialfields.SpecialFieldUpdateListener;
 
 import com.google.common.eventbus.Subscribe;
-import javafx.application.Platform;
-import javafx.embed.swing.JFXPanel;
-import javafx.scene.Scene;
-import javafx.scene.control.ProgressIndicator;
-import javafx.scene.layout.StackPane;
-import javafx.scene.web.WebView;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/src/main/java/net/sf/jabref/gui/help/AboutAction.java
+++ b/src/main/java/net/sf/jabref/gui/help/AboutAction.java
@@ -20,8 +20,9 @@ import java.awt.event.ActionEvent;
 import javax.swing.Action;
 import javax.swing.Icon;
 
-import net.sf.jabref.gui.actions.MnemonicAwareAction;
 import javafx.application.Platform;
+
+import net.sf.jabref.gui.actions.MnemonicAwareAction;
 
 public class AboutAction extends MnemonicAwareAction {
 

--- a/src/main/java/net/sf/jabref/gui/help/AboutDialogView.java
+++ b/src/main/java/net/sf/jabref/gui/help/AboutDialogView.java
@@ -15,12 +15,13 @@
 */
 package net.sf.jabref.gui.help;
 
+import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.DialogPane;
+
 import net.sf.jabref.gui.FXAlert;
 import net.sf.jabref.logic.l10n.Localization;
 
 import com.airhacks.afterburner.views.FXMLView;
-import javafx.scene.control.DialogPane;
-import javafx.scene.control.Alert.AlertType;
 
 public class AboutDialogView extends FXMLView {
 

--- a/src/main/java/net/sf/jabref/gui/help/AboutDialogViewModel.java
+++ b/src/main/java/net/sf/jabref/gui/help/AboutDialogViewModel.java
@@ -17,18 +17,20 @@ package net.sf.jabref.gui.help;
 
 import java.io.IOException;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.stage.Stage;
+
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefGUI;
 import net.sf.jabref.gui.ClipBoardManager;
 import net.sf.jabref.gui.desktop.JabRefDesktop;
 import net.sf.jabref.logic.l10n.Localization;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 public class AboutDialogViewModel {
 

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -1693,3 +1693,5 @@ Copy_version_to_clipboard=
 Copied_version_to_clipboard=
 BibTeX_key=
 Message=
+
+MathSciNet_Review=

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2408,3 +2408,5 @@ Copy_version_to_clipboard=Kopiere_Version_in_die_Zwischenablage
 Copied_version_to_clipboard=Version_in_die_Zwischenablage_kopiert
 BibTeX_key=
 Message=
+
+MathSciNet_Review=

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2272,4 +2272,4 @@ Copied_version_to_clipboard=Copied_version_to_clipboard
 BibTeX_key=BibTeX_key
 Message=Message
 
-MathSciNet_Review=
+MathSciNet_Review=MathSciNet_Review

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2271,3 +2271,5 @@ Copied_version_to_clipboard=Copied_version_to_clipboard
 
 BibTeX_key=BibTeX_key
 Message=Message
+
+MathSciNet_Review=

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -1593,3 +1593,5 @@ Copy_version_to_clipboard=
 Copied_version_to_clipboard=
 BibTeX_key=
 Message=
+
+MathSciNet_Review=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -2379,3 +2379,5 @@ Copy_version_to_clipboard=
 Copied_version_to_clipboard=
 BibTeX_key=
 Message=
+
+MathSciNet_Review=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -1637,3 +1637,4 @@ booktitle_ends_with_'conference_on'=
 
 BibTeX_key=
 Message=
+MathSciNet_Review=

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -1612,3 +1612,5 @@ Copy_version_to_clipboard=
 Copied_version_to_clipboard=
 BibTeX_key=
 Message=
+
+MathSciNet_Review=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -1713,3 +1713,5 @@ Copy_version_to_clipboard=
 Copied_version_to_clipboard=
 BibTeX_key=
 Message=
+
+MathSciNet_Review=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2358,3 +2358,5 @@ Copied_version_to_clipboard=クリップボードにコピーされたバージ�
 booktitle_ends_with_'conference_on'=
 BibTeX_key=
 Message=
+
+MathSciNet_Review=

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -2388,3 +2388,5 @@ Copy_version_to_clipboard=
 Copied_version_to_clipboard=
 BibTeX_key=
 Message=
+
+MathSciNet_Review=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -2785,3 +2785,5 @@ Copy_version_to_clipboard=
 Copied_version_to_clipboard=
 BibTeX_key=
 Message=
+
+MathSciNet_Review=

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -1607,3 +1607,5 @@ Copy_version_to_clipboard=
 Copied_version_to_clipboard=
 BibTeX_key=
 Message=
+
+MathSciNet_Review=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2356,3 +2356,5 @@ Copy_version_to_clipboard=
 Copied_version_to_clipboard=
 BibTeX_key=
 Message=
+
+MathSciNet_Review=

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -1552,3 +1552,5 @@ Copied_version_to_clipboard=
 
 BibTeX_key=
 Message=
+
+MathSciNet_Review=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -1626,3 +1626,5 @@ Copied_version_to_clipboard=Sürüm_panoya_kopyalandı
 
 BibTeX_key=
 Message=
+
+MathSciNet_Review=

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -2380,3 +2380,5 @@ Copy_version_to_clipboard=
 Copied_version_to_clipboard=
 BibTeX_key=
 Message=
+
+MathSciNet_Review=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -1619,3 +1619,5 @@ Copy_version_to_clipboard=
 Copied_version_to_clipboard=
 BibTeX_key=
 Message=
+
+MathSciNet_Review=


### PR DESCRIPTION
If the `MRNumber` field is present in the entry, then a new tab is added which shows the associated MathSciNet review. (Note that MathSciNet is probably _the_ reference for all mathematicians).

This PR is against the javafx branch since the javafx control WebView is used to show the webpage.
@JabRef/stupro also have a look at this PR, since you are the ones with JavaFX experience.

![untitled](https://cloud.githubusercontent.com/assets/5037600/15164150/3fe3990a-170d-11e6-9e6b-ae173470c8cc.png)

<describe the changes you have made here: what, why, ...>

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Screenshots added (for bigger UI changes)

