### PR TITLE
Fix #1334: Display correct number of entries in static groups

### DIFF
--- a/src/main/java/net/sf/jabref/gui/groups/GroupTreeNodeViewModel.java
+++ b/src/main/java/net/sf/jabref/gui/groups/GroupTreeNodeViewModel.java
@@ -41,11 +41,8 @@ import net.sf.jabref.gui.undo.CountingUndoManager;
 import net.sf.jabref.logic.groups.AbstractGroup;
 import net.sf.jabref.logic.groups.AllEntriesGroup;
 import net.sf.jabref.logic.groups.EntriesGroupChange;
-import net.sf.jabref.logic.groups.ExplicitGroup;
 import net.sf.jabref.logic.groups.GroupTreeNode;
-import net.sf.jabref.logic.groups.KeywordGroup;
 import net.sf.jabref.logic.groups.MoveGroupChange;
-import net.sf.jabref.logic.groups.SearchGroup;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.BibEntry;
 
@@ -196,20 +193,11 @@ public class GroupTreeNodeViewModel implements Transferable, TreeNode {
         StringBuilder sb = new StringBuilder(60);
         sb.append(name);
 
-        if (Globals.prefs.getBoolean(JabRefPreferences.GROUP_SHOW_NUMBER_OF_ELEMENTS)) {
-            if (group instanceof ExplicitGroup) {
-                sb.append(" [").append(((ExplicitGroup) group).getNumEntries()).append(']');
-            } else if ((group instanceof KeywordGroup) || (group instanceof SearchGroup)) {
-                int hits = 0;
-                BasePanel currentBasePanel = JabRefGUI.getMainFrame().getCurrentBasePanel();
-                if(currentBasePanel != null) {
-                    for (BibEntry entry : currentBasePanel.getDatabase().getEntries()) {
-                        if (group.contains(entry)) {
-                            hits++;
-                        }
-                    }
-                }
-                sb.append(" [").append(hits).append(']');
+        if (Globals.prefs.getBoolean(JabRefPreferences.GROUP_SHOW_NUMBER_OF_ELEMENTS)
+                && JabRefGUI.getMainFrame() != null) {
+            BasePanel currentBasePanel = JabRefGUI.getMainFrame().getCurrentBasePanel();
+            if (currentBasePanel != null) {
+                sb.append(" [").append(group.numberOfHits(currentBasePanel.getDatabase().getEntries())).append(']');
             }
         }
 

--- a/src/main/java/net/sf/jabref/logic/groups/AbstractGroup.java
+++ b/src/main/java/net/sf/jabref/logic/groups/AbstractGroup.java
@@ -169,6 +169,21 @@ public abstract class AbstractGroup implements SearchMatcher {
     }
 
     /**
+     * Determines the number of entries in the specified list which are matched by this group.
+     * @param entries list of entries to be searched
+     * @return number of hits
+     */
+    public int numberOfHits(List<BibEntry> entries) {
+        int hits = 0;
+        for (BibEntry entry : entries) {
+            if (this.contains(entry)) {
+                hits++;
+            }
+        }
+        return hits;
+    }
+
+    /**
      * Returns true if this group is dynamic, i.e. uses a search definition or
      * equiv. that might match new entries, or false if this group contains a
      * fixed set of entries and thus will never match a new entry that was not

--- a/src/main/java/net/sf/jabref/logic/groups/ExplicitGroup.java
+++ b/src/main/java/net/sf/jabref/logic/groups/ExplicitGroup.java
@@ -168,10 +168,6 @@ public class ExplicitGroup extends KeywordGroup {
         return ExplicitGroup.ID;
     }
 
-    public int getNumEntries() {
-        return legacyEntryKeys.size();
-    }
-
     @Override
     public int hashCode() {
         return super.hashCode();

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -611,4 +611,8 @@ public class BibEntry implements Cloneable {
         this.eventBus.unregister(object);
     }
 
+    public BibEntry withField(String field, String value) {
+        setField(field, value);
+        return this;
+    }
 }

--- a/src/test/java/net/sf/jabref/logic/groups/AbstractGroupTest.java
+++ b/src/test/java/net/sf/jabref/logic/groups/AbstractGroupTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2003-2016 JabRef contributors.
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package net.sf.jabref.logic.groups;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import net.sf.jabref.model.entry.BibEntry;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AbstractGroupTest {
+
+    private AbstractGroup group;
+    private List<BibEntry> entries = new ArrayList<>();
+
+    @Before
+    public void setUp() throws Exception {
+        group = mock(AbstractGroup.class, Mockito.CALLS_REAL_METHODS);
+
+        entries.add(new BibEntry().withField("author", "author1 and author2"));
+        entries.add(new BibEntry().withField("author", "author1"));
+    }
+
+    @Test
+    public void numberOfHitsReturnsZeroForEmptyList() throws Exception {
+        assertEquals(0, group.numberOfHits(Collections.emptyList()));
+    }
+
+    @Test
+    public void numberOfHitsCallsContainsToDetermineSingleHit() throws Exception {
+        when(group.contains(any())).then(invocation ->
+                invocation.getArgumentAt(0, BibEntry.class).getField("author").contains("author2"));
+        assertEquals(1, group.numberOfHits(entries));
+    }
+
+    @Test
+    public void numberOfHitsCallsContainsToDetermineMultipleHits() throws Exception {
+        when(group.contains(any())).then(invocation ->
+                invocation.getArgumentAt(0, BibEntry.class).getField("author").contains("author1"));
+        assertEquals(2, group.numberOfHits(entries));
+    }
+
+
+}


### PR DESCRIPTION
<describe the changes you have made here: what, why, ...>
Fix of #1334. Nice bonus: total number of entries is displayed after "All Entries" group.

- [ ] Change in CHANGELOG.md described (bug not present in 3.3)
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)

