### PR TITLE
Entries retain their groupmembership when undoing their cut/deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed [#651](https://github.com/JabRef/jabref/issues/651): Improve parsing of author names containing braces
 - Fixed [#1421](https://github.com/JabRef/jabref/issues/1421): Auto downloader should try to retrieve DOI if not present and fetch afterwards
 - Fixed [#1457](https://github.com/JabRef/jabref/issues/1457): Support multiple words inside LaTeX commands to RTF export
+- Entries retain their groupmembership when undoing their cut/deletion
 
 ### Removed
 - Removed possibility to export entries/databases to an `.sql` file, as the logic cannot easily use the correct escape logic

--- a/src/main/java/net/sf/jabref/event/EntryAddedEvent.java
+++ b/src/main/java/net/sf/jabref/event/EntryAddedEvent.java
@@ -1,19 +1,51 @@
+/*  Copyright (C) 2016 JabRef contributors.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
 package net.sf.jabref.event;
 
+import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 
 /**
- * <code>EntryAddedEvent</code> is fired when a new <code>BibEntry</code> was added
- * to the database.
+ * {@link EntryAddedEvent} is fired when a new {@link BibEntry} was added to the {@link BibDatabase}.
  */
-
 public class EntryAddedEvent extends EntryEvent {
 
     /**
-     * @param bibEntry <code>BibEntry</code> object which has been added.
+     * flag if the addition is the undo of a deletion/cut
+     */
+    private boolean isUndo;
+
+    /**
+     * @param bibEntry the entry which has been added
      */
     public EntryAddedEvent(BibEntry bibEntry) {
         super(bibEntry);
+        this.isUndo = false;
     }
 
+    /**
+     * @param bibEntry the entry which has been added
+     * @param isUndo   flag if the addition is the undo of a deletion/cut
+     */
+    public EntryAddedEvent(BibEntry bibEntry, boolean isUndo) {
+        super(bibEntry);
+        this.isUndo = isUndo;
+    }
+
+    public boolean isUndo() {
+        return isUndo;
+    }
 }

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -1269,6 +1269,12 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
         @Subscribe
         public void listen(EntryAddedEvent addedEntryEvent) {
+            // if the added entry is an undo don't add it to the current group
+            if (addedEntryEvent.isUndo()){
+                scheduleUpdate();
+                return;
+            }
+
             // Automatically add new entry to the selected group (or set of groups)
             if (Globals.prefs.getBoolean(JabRefPreferences.AUTO_ASSIGN_GROUP) && frame.groupToggle.isSelected()) {
                 final List<BibEntry> entries = Collections.singletonList(addedEntryEvent.getBibEntry());

--- a/src/main/java/net/sf/jabref/gui/undo/UndoableRemoveEntry.java
+++ b/src/main/java/net/sf/jabref/gui/undo/UndoableRemoveEntry.java
@@ -58,7 +58,7 @@ public class UndoableRemoveEntry extends AbstractUndoableEdit {
     @Override
     public void undo() {
         super.undo();
-        base.insertEntry(entry);
+        base.insertEntry(entry, true);
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/model/database/BibDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabase.java
@@ -175,9 +175,24 @@ public class BibDatabase {
      * Inserts the entry, given that its ID is not already in use.
      * use Util.createId(...) to make up a unique ID for an entry.
      *
+     * @param entry the entry to insert into the database
      * @return false if the insert was done without a duplicate warning
+     * @throws KeyCollisionException thrown if the entry id ({@link BibEntry#getId()}) is already  present in the database
      */
     public synchronized boolean insertEntry(BibEntry entry) throws KeyCollisionException {
+        return this.insertEntry(entry, false);
+    }
+
+    /**
+     * Inserts the entry, given that its ID is not already in use.
+     * use Util.createId(...) to make up a unique ID for an entry.
+     *
+     * @param entry  the entry to insert into the database
+     * @param isUndo set to true if the insertion is caused by an undo
+     * @return false if the insert was done without a duplicate warning
+     * @throws KeyCollisionException thrown if the entry id ({@link BibEntry#getId()}) is already  present in the database
+     */
+    public synchronized boolean insertEntry(BibEntry entry, boolean isUndo) throws KeyCollisionException {
         Objects.requireNonNull(entry);
 
         String id = entry.getId();
@@ -189,7 +204,7 @@ public class BibDatabase {
         entries.add(entry);
         entry.registerListener(this);
 
-        eventBus.post(new EntryAddedEvent(entry));
+        eventBus.post(new EntryAddedEvent(entry, isUndo));
         return duplicationChecker.checkForDuplicateKeyAndAdd(null, entry.getCiteKey());
     }
 


### PR DESCRIPTION
When undoing an entry which was deleted/cut while a group was selected of which the entry wasn't a member of it was after the undo.

I fixed that.

### Steps to reproduce
- delete an entry
- select a group of which the entry wasn't a member of
- undo the deletion
- now the entry is a member of the group