### PR TITLE
Fix #1381 File links containing blanks are broken if non-default viewer is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ to [sourceforge feature requests](https://sourceforge.net/p/jabref/features/) by
 - Fixed [#1365](https://github.com/JabRef/jabref/issues/1365): Default label pattern back to "[auth][year]"
 - Fixed [#796](https://github.com/JabRef/jabref/issues/796): Undoing more than one entry at the same time is now working
 - Fixed [#1353](https://github.com/JabRef/jabref/issues/1353): Fetch-Preview did not display updated BibTeX-Key after clicking on `Generate Now`
+- Fixed [#1381](https://github.com/JabRef/jabref/issues/1381): File links containing blanks are broken if non-default viewer is set
 
 ### Removed
 - Removed possibility to export entries/databases to an `.sql` file, as the logic cannot easily use the correct escape logic

--- a/src/main/java/net/sf/jabref/gui/desktop/os/Windows.java
+++ b/src/main/java/net/sf/jabref/gui/desktop/os/Windows.java
@@ -9,9 +9,7 @@ import net.sf.jabref.external.ExternalFileType;
 import net.sf.jabref.external.ExternalFileTypes;
 
 public class Windows implements NativeDesktop {
-
     private static String DEFAULT_EXECUTABLE_EXTENSION = ".exe";
-
 
     @Override
     public void openFile(String filePath, String fileType) throws IOException {
@@ -23,12 +21,10 @@ public class Windows implements NativeDesktop {
             String quotePath = "\"" + filePath +"\"";
             Runtime.getRuntime().exec(new String[] {"explorer.exe", quotePath});
         }
-
     }
 
     @Override
     public String detectProgramPath(String programName, String directoryName) {
-
         String progFiles = System.getenv("ProgramFiles(x86)");
         if (progFiles == null) {
             progFiles = System.getenv("ProgramFiles");
@@ -41,7 +37,7 @@ public class Windows implements NativeDesktop {
 
     @Override
     public void openFileWithApplication(String filePath, String application) throws IOException {
-        Runtime.getRuntime().exec(Paths.get(application) + " " + Paths.get(filePath));
+        new ProcessBuilder(Paths.get(application).toString(), Paths.get(filePath).toString()).start();
     }
 
     @Override
@@ -49,13 +45,12 @@ public class Windows implements NativeDesktop {
         String cmd = "explorer.exe";
         String arg = "/select,";
         String[] commandWithArgs = {cmd, arg, filePath};
-        //Array variant, because otherwise the Tokenizer, which is internally run, kills the whitespaces in the path
+        // Array variant, because otherwise the Tokenizer, which is internally run, kills the whitespaces in the path
         Runtime.getRuntime().exec(commandWithArgs);
     }
 
     @Override
     public void openConsole(String absolutePath) throws IOException {
-
         Runtime.getRuntime().exec("cmd.exe /c start", null, new File(absolutePath));
     }
 }

--- a/src/main/java/net/sf/jabref/gui/desktop/os/Windows.java
+++ b/src/main/java/net/sf/jabref/gui/desktop/os/Windows.java
@@ -14,12 +14,13 @@ public class Windows implements NativeDesktop {
     @Override
     public void openFile(String filePath, String fileType) throws IOException {
         Optional<ExternalFileType> type = ExternalFileTypes.getInstance().getExternalFileTypeByExt(fileType);
+
         if (type.isPresent() && !type.get().getOpenWithApplication().isEmpty()) {
             openFileWithApplication(filePath, type.get().getOpenWithApplication());
         } else {
             // quote String so explorer handles URL query strings correctly
             String quotePath = "\"" + filePath +"\"";
-            Runtime.getRuntime().exec(new String[] {"explorer.exe", quotePath});
+            new ProcessBuilder("explorer.exe", quotePath).start();
         }
     }
 
@@ -42,15 +43,13 @@ public class Windows implements NativeDesktop {
 
     @Override
     public void openFolderAndSelectFile(String filePath) throws IOException {
-        String cmd = "explorer.exe";
-        String arg = "/select,";
-        String[] commandWithArgs = {cmd, arg, filePath};
-        // Array variant, because otherwise the Tokenizer, which is internally run, kills the whitespaces in the path
-        Runtime.getRuntime().exec(commandWithArgs);
+        new ProcessBuilder("explorer.exe", "/select,", filePath).start();
     }
 
     @Override
     public void openConsole(String absolutePath) throws IOException {
-        Runtime.getRuntime().exec("cmd.exe /c start", null, new File(absolutePath));
+        ProcessBuilder process = new ProcessBuilder("cmd.exe", "/c", "start");
+        process.directory(new File(absolutePath));
+        process.start();
     }
 }


### PR DESCRIPTION
Runtime.exec with a String splits on white spaces...