### PR TITLE
Fix #1399 export to html: html code is not well-formed

### DIFF
--- a/src/main/java/net/sf/jabref/exporter/ExportFormat.java
+++ b/src/main/java/net/sf/jabref/exporter/ExportFormat.java
@@ -293,7 +293,7 @@ public class ExportFormat implements IExportFormat {
             }
 
             // Write footer
-            if ((endLayout != null) && (this.encoding != null)) {
+            if (endLayout != null) {
                 ps.write(endLayout.doLayout(databaseContext, this.encoding));
                 missingFormatters.addAll(endLayout.getMissingFormatters());
             }

--- a/src/main/java/net/sf/jabref/exporter/ExportFormats.java
+++ b/src/main/java/net/sf/jabref/exporter/ExportFormats.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2015 JabRef contributors.
+/*  Copyright (C) 2003-2016 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -42,13 +42,6 @@ import net.sf.jabref.model.entry.BibEntry;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-/**
- * User: alver
- *
- * Date: Oct 18, 2006
- *
- * Time: 9:35:08 PM
- */
 public class ExportFormats {
 
     private static final Log LOGGER = LogFactory.getLog(ExportFormats.class);

--- a/src/test/java/net/sf/jabref/exporter/HtmlExportFormatTest.java
+++ b/src/test/java/net/sf/jabref/exporter/HtmlExportFormatTest.java
@@ -29,6 +29,9 @@ public class HtmlExportFormatTest {
     public Charset charset;
     public List<BibEntry> entries;
 
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
     @Before
     public void setUp() {
         Globals.prefs = JabRefPreferences.getInstance();
@@ -49,9 +52,6 @@ public class HtmlExportFormatTest {
     public void tearDown() {
         exportFormat = null;
     }
-
-    @Rule
-    public TemporaryFolder testFolder = new TemporaryFolder();
 
     @Test
     public void emitWellFormedHtml() throws Exception {

--- a/src/test/java/net/sf/jabref/exporter/HtmlExportFormatTest.java
+++ b/src/test/java/net/sf/jabref/exporter/HtmlExportFormatTest.java
@@ -1,0 +1,64 @@
+package net.sf.jabref.exporter;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+
+import net.sf.jabref.BibDatabaseContext;
+import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.MetaData;
+import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
+import net.sf.jabref.model.database.BibDatabase;
+import net.sf.jabref.model.entry.BibEntry;
+
+import com.google.common.base.Charsets;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertEquals;
+
+public class HtmlExportFormatTest {
+    private IExportFormat exportFormat;
+    public BibDatabaseContext databaseContext;
+    public Charset charset;
+    public List<BibEntry> entries;
+
+    @Before
+    public void setUp() {
+        Globals.prefs = JabRefPreferences.getInstance();
+        ExportFormats.initAllExports();
+        exportFormat = ExportFormats.getExportFormat("html");
+
+        Globals.journalAbbreviationLoader = new JournalAbbreviationLoader(Globals.prefs);
+        databaseContext = new BibDatabaseContext(new BibDatabase(), new MetaData());
+        charset = Charsets.UTF_8;
+        BibEntry entry = new BibEntry();
+        entry.setField("title", "my paper title");
+        entry.setField("author", "Stefan Kolb");
+        entry.setCiteKey("mykey");
+        entries = Arrays.asList(entry);
+    }
+
+    @After
+    public void tearDown() {
+        exportFormat = null;
+    }
+
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+    @Test
+    public void emitWellFormedHtml() throws Exception {
+        File tmpFile = testFolder.newFile();
+        String filename = tmpFile.getCanonicalPath();
+        exportFormat.performExport(databaseContext, filename, charset, entries);
+        List<String> lines = Files.readAllLines(tmpFile.toPath());
+        assertEquals("</html>", lines.get(lines.size() - 1));
+    }
+}


### PR DESCRIPTION
Always write the footer, no matter if encoding is given or not.
