### PR TITLE
Refactor Gradle script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ because <additional rationale>.
 Add new Localization.lang("KEY") to Java file.
 Tests fail. In the test output a snippet is generated which must be added to the English translation file. There is also a snippet generated for the non-English files, but this is irrelevant.
 Add snippet to English translation file located at `src/main/resources/l10n/JabRef_en.properties`
-With `gradlew -b localization.gradle generateMissingTranslationKeys` the "KEY" is added to the other translation files as well.
+With `gradlew generateMissingTranslationKeys` the "KEY" is added to the other translation files as well.
 Tests are green again.
 
 You can also directly run the specific test in your IDE. The test "LocalizationConsistencyTest" is placed under `src/test/java/net.sf.jabref.logic.l10n/LocalizationConsistencyTest.java`

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ apply plugin: 'me.champeau.gradle.jmh'
 apply plugin: 'checkstyle'
 
 apply from: 'eclipse.gradle'
+apply from: 'localization.gradle'
 
 group = "net.sf.jabref"
 version = "3.4dev"

--- a/localization.gradle
+++ b/localization.gradle
@@ -12,6 +12,7 @@ dependencies {
 
 task checkTranslations(type: JavaExec) {
     description "Print empty and duplicate translations."
+    group = 'Localization'
     main 'org.python.util.jython'
     classpath project.configurations.jython.asPath
     args file("scripts/syncLang.py")
@@ -20,6 +21,7 @@ task checkTranslations(type: JavaExec) {
 
 task checkTranslationsSummary(type: JavaExec) {
     description "Print summary of empty and duplicate translations."
+    group = 'Localization'
     main 'org.python.util.jython'
     classpath project.configurations.jython.asPath
     args file("scripts/syncLang.py")
@@ -28,6 +30,7 @@ task checkTranslationsSummary(type: JavaExec) {
 
 task showMissingTranslationKeys(type: JavaExec) {
     description "Prints differences between the English translation and translations in other languages."
+    group = 'Localization'
     main 'org.python.util.jython'
     classpath project.configurations.jython.asPath
     args file("scripts/syncLang.py")
@@ -36,6 +39,7 @@ task showMissingTranslationKeys(type: JavaExec) {
 
 task generateMissingTranslationKeys(type: JavaExec) {
     description "Prints differences between the English translation and translations in other languages, and updates translations if possible."
+    group = 'Localization'
     main 'org.python.util.jython'
     classpath project.configurations.jython.asPath
     args file("scripts/syncLang.py")


### PR DESCRIPTION
We can now
- [ ] split the script into smaller files
- [ ] group similar tasks into self-describing groups so they can be easily found.

I started this attempt with:
- Include localization tasks and package into a group

![image](https://cloud.githubusercontent.com/assets/2141507/15398081/952f141c-1de2-11e6-9002-783bf8843bd2.png)


