### PR TITLE
Refactor placement of parsing and writing logic

### DIFF
--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -1373,7 +1373,7 @@ public class JabRefPreferences {
         storage.put(CLEANUP_UPGRADE_EXTERNAL_LINKS, preset.isCleanUpUpgradeExternalLinks());
         storage.put(CLEANUP_CONVERT_TO_BIBLATEX, preset.isConvertToBiblatex());
         storage.put(CLEANUP_FIX_FILE_LINKS, preset.isFixFileLinks());
-        storage.put(CLEANUP_FORMATTERS, convertListToString(preset.getFormatterCleanups().convertToString()));
+        storage.put(CLEANUP_FORMATTERS, convertListToString(preset.getFormatterCleanups().getAsString()));
     }
 
 }

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -1373,7 +1373,7 @@ public class JabRefPreferences {
         storage.put(CLEANUP_UPGRADE_EXTERNAL_LINKS, preset.isCleanUpUpgradeExternalLinks());
         storage.put(CLEANUP_CONVERT_TO_BIBLATEX, preset.isConvertToBiblatex());
         storage.put(CLEANUP_FIX_FILE_LINKS, preset.isFixFileLinks());
-        storage.put(CLEANUP_FORMATTERS, convertListToString(preset.getFormatterCleanups().getAsString()));
+        storage.put(CLEANUP_FORMATTERS, convertListToString(preset.getFormatterCleanups().getAsStringList()));
     }
 
 }

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -393,17 +392,17 @@ public class MetaData implements Iterable<String> {
     }
 
     public void setSaveActions(FieldFormatterCleanups saveActions) {
-        List<String> actionsSerialized = saveActions.convertToString();
+        List<String> actionsSerialized = saveActions.getAsString();
         putData(SAVE_ACTIONS, actionsSerialized);
     }
 
     public void setSaveOrderConfig(SaveOrderConfig saveOrderConfig) {
-        List<String> serialized = saveOrderConfig.getConfigurationList();
+        List<String> serialized = saveOrderConfig.getAsString();
         putData(SAVE_ORDER_CONFIG, serialized);
     }
 
     public void setMode(BibDatabaseMode mode) {
-        putData(DATABASE_TYPE, Collections.singletonList(mode.getFormattedName().toLowerCase(Locale.ENGLISH)));
+        putData(DATABASE_TYPE, Collections.singletonList(mode.getAsString()));
     }
 
     public void markAsProtected() {

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -79,7 +79,7 @@ public class MetaData implements Iterable<String> {
      * must simply make sure the appropriate changes are reflected in the Vector
      * it has been passed.
      */
-    public MetaData(Map<String, String> inData) throws ParseException {
+    private MetaData(Map<String, String> inData) throws ParseException {
         Objects.requireNonNull(inData);
 
         for (Map.Entry<String, String> entry : inData.entrySet()) {
@@ -112,6 +112,10 @@ public class MetaData implements Iterable<String> {
      */
     public MetaData() {
         // No data
+    }
+
+    public static MetaData parse(Map<String, String> data) throws ParseException {
+        return new MetaData(data);
     }
 
     public Optional<SaveOrderConfig> getSaveOrderConfig() {

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -118,7 +118,7 @@ public class MetaData implements Iterable<String> {
     public Optional<SaveOrderConfig> getSaveOrderConfig() {
         List<String> storedSaveOrderConfig = getData(SAVE_ORDER_CONFIG);
         if (storedSaveOrderConfig != null) {
-            return Optional.of(new SaveOrderConfig(storedSaveOrderConfig));
+            return Optional.of(SaveOrderConfig.parse(storedSaveOrderConfig));
         }
         return Optional.empty();
     }
@@ -300,9 +300,7 @@ public class MetaData implements Iterable<String> {
         if (this.getData(SAVE_ACTIONS) == null) {
             return Optional.empty();
         } else {
-            boolean enablementStatus = "enabled".equals(this.getData(SAVE_ACTIONS).get(0));
-            String formatterString = this.getData(SAVE_ACTIONS).get(1);
-            return Optional.of(new FieldFormatterCleanups(enablementStatus, formatterString));
+            return Optional.of(FieldFormatterCleanups.parse(getData(SAVE_ACTIONS)));
         }
     }
 
@@ -311,7 +309,7 @@ public class MetaData implements Iterable<String> {
         if ((data == null) || data.isEmpty()) {
             return Optional.empty();
         }
-        return Optional.of(BibDatabaseMode.valueOf(data.get(0).toUpperCase(Locale.ENGLISH)));
+        return Optional.of(BibDatabaseMode.parse(data.get(0)));
     }
 
     public boolean isProtected() {

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -95,11 +95,9 @@ public class MetaData implements Iterable<String> {
             }
             if (GROUPSTREE.equals(entry.getKey())) {
                 putGroups(orderedData);
-                // the keys "groupsversion" and "groups" were used in JabRef versions around 1.3, we will not use them here
+                // the keys "groupsversion" and "groups" were used in JabRef versions around 1.3, we will not support them anymore
             } else if (SAVE_ACTIONS.equals(entry.getKey())) {
-                boolean enablementStatus = "enabled".equals(orderedData.get(0));
-                String formatterString = orderedData.get(1);
-                setSaveActions(new FieldFormatterCleanups(enablementStatus, formatterString));
+                setSaveActions(FieldFormatterCleanups.parse(orderedData));
             } else {
                 putData(entry.getKey(), orderedData);
             }

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -36,7 +36,6 @@ import net.sf.jabref.exporter.FieldFormatterCleanups;
 import net.sf.jabref.importer.fileformat.ParseException;
 import net.sf.jabref.logic.config.SaveOrderConfig;
 import net.sf.jabref.logic.groups.GroupTreeNode;
-import net.sf.jabref.logic.groups.GroupsParser;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.labelpattern.AbstractLabelPattern;
 import net.sf.jabref.logic.labelpattern.DatabaseLabelPattern;
@@ -182,7 +181,7 @@ public class MetaData implements Iterable<String> {
      */
     private void putGroups(List<String> orderedData) throws ParseException {
         try {
-            groupsRoot = GroupsParser.importGroups(orderedData);
+            groupsRoot = GroupTreeNode.parse(orderedData);
         } catch (ParseException e) {
             throw new ParseException(Localization.lang(
                     "Group tree could not be parsed. If you save the BibTeX database, all groups will be lost."), e);

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -350,7 +350,7 @@ public class MetaData implements Iterable<String> {
     /**
      * Writes all data in the format <key, serialized data>.
      */
-    public Map<String, String> getAsString() {
+    public Map<String, String> getAsStringMap() {
 
         Map<String, String> serializedMetaData = new TreeMap<>();
 
@@ -392,12 +392,12 @@ public class MetaData implements Iterable<String> {
     }
 
     public void setSaveActions(FieldFormatterCleanups saveActions) {
-        List<String> actionsSerialized = saveActions.getAsString();
+        List<String> actionsSerialized = saveActions.getAsStringList();
         putData(SAVE_ACTIONS, actionsSerialized);
     }
 
     public void setSaveOrderConfig(SaveOrderConfig saveOrderConfig) {
-        List<String> serialized = saveOrderConfig.getAsString();
+        List<String> serialized = saveOrderConfig.getAsStringList();
         putData(SAVE_ORDER_CONFIG, serialized);
     }
 

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -350,7 +350,7 @@ public class MetaData implements Iterable<String> {
     /**
      * Writes all data in the format <key, serialized data>.
      */
-    public Map<String, String> serialize() {
+    public Map<String, String> getAsString() {
 
         Map<String, String> serializedMetaData = new TreeMap<>();
 

--- a/src/main/java/net/sf/jabref/exporter/BibDatabaseWriter.java
+++ b/src/main/java/net/sf/jabref/exporter/BibDatabaseWriter.java
@@ -281,7 +281,7 @@ public class BibDatabaseWriter {
             return;
         }
 
-        Map<String, String> serializedMetaData = metaData.getAsString();
+        Map<String, String> serializedMetaData = metaData.getAsStringMap();
 
         for(Map.Entry<String, String> metaItem : serializedMetaData.entrySet()) {
 

--- a/src/main/java/net/sf/jabref/exporter/BibDatabaseWriter.java
+++ b/src/main/java/net/sf/jabref/exporter/BibDatabaseWriter.java
@@ -281,7 +281,7 @@ public class BibDatabaseWriter {
             return;
         }
 
-        Map<String, String> serializedMetaData = metaData.serialize();
+        Map<String, String> serializedMetaData = metaData.getAsString();
 
         for(Map.Entry<String, String> metaItem : serializedMetaData.entrySet()) {
 

--- a/src/main/java/net/sf/jabref/exporter/BibDatabaseWriter.java
+++ b/src/main/java/net/sf/jabref/exporter/BibDatabaseWriter.java
@@ -392,13 +392,8 @@ public class BibDatabaseWriter {
                 CustomEntryType customType = (CustomEntryType) type;
                 writer.write(Globals.NEWLINE);
                 writer.write(COMMENT_PREFIX + "{");
-                writer.write(CustomEntryType.ENTRYTYPE_FLAG);
-                writer.write(customType.getName());
-                writer.write(": req[");
-                writer.write(customType.getRequiredFieldsString());
-                writer.write("] opt[");
-                writer.write(String.join(";", customType.getOptionalFields()));
-                writer.write("]}");
+                writer.write(customType.getAsString());
+                writer.write("}");
                 writer.write(Globals.NEWLINE);
             }
         }

--- a/src/main/java/net/sf/jabref/exporter/FieldFormatterCleanups.java
+++ b/src/main/java/net/sf/jabref/exporter/FieldFormatterCleanups.java
@@ -198,7 +198,7 @@ public class FieldFormatterCleanups {
         return result.toString();
     }
 
-    public List<String> convertToString() {
+    public List<String> getAsString() {
         List<String> stringRepresentation = new ArrayList<>();
 
         if (enabled) {

--- a/src/main/java/net/sf/jabref/exporter/FieldFormatterCleanups.java
+++ b/src/main/java/net/sf/jabref/exporter/FieldFormatterCleanups.java
@@ -212,7 +212,7 @@ public class FieldFormatterCleanups {
         return stringRepresentation;
     }
 
-    public static FieldFormatterCleanups parseFromString(List<String> formatterMetaList) {
+    public static FieldFormatterCleanups parse(List<String> formatterMetaList) {
 
         if (formatterMetaList != null && formatterMetaList.size() >= 2) {
             boolean enablementStatus = "enabled".equals(formatterMetaList.get(0));

--- a/src/main/java/net/sf/jabref/exporter/FieldFormatterCleanups.java
+++ b/src/main/java/net/sf/jabref/exporter/FieldFormatterCleanups.java
@@ -198,7 +198,7 @@ public class FieldFormatterCleanups {
         return result.toString();
     }
 
-    public List<String> getAsString() {
+    public List<String> getAsStringList() {
         List<String> stringRepresentation = new ArrayList<>();
 
         if (enabled) {

--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
@@ -195,7 +195,7 @@ public class BibtexParser {
 
         // Instantiate meta data:
         try {
-            parserResult.setMetaData(new MetaData(meta));
+            parserResult.setMetaData(MetaData.parse(meta));
         } catch (ParseException exception) {
             parserResult.addWarning(exception.getLocalizedMessage());
         }

--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
@@ -30,7 +30,6 @@ import java.util.Objects;
 
 import net.sf.jabref.MetaData;
 import net.sf.jabref.importer.ParserResult;
-import net.sf.jabref.logic.CustomEntryTypesManager;
 import net.sf.jabref.logic.bibtex.FieldContentParser;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibDatabase;
@@ -281,7 +280,7 @@ public class BibtexParser {
                 .equals(CustomEntryType.ENTRYTYPE_FLAG)) {
             // A custom entry type can also be stored in a
             // "@comment"
-            CustomEntryType typ = CustomEntryTypesManager.parseEntryType(comment);
+            CustomEntryType typ = CustomEntryType.parse(comment);
             if(typ == null) {
                 parserResult.addWarning(Localization.lang("Ill-formed entrytype comment in bib file") + ": " +
                         comment);

--- a/src/main/java/net/sf/jabref/logic/CustomEntryTypesManager.java
+++ b/src/main/java/net/sf/jabref/logic/CustomEntryTypesManager.java
@@ -50,22 +50,4 @@ public class CustomEntryTypesManager {
         prefs.purgeCustomEntryTypes(number);
     }
 
-    public static CustomEntryType parseEntryType(String comment) {
-        String rest = comment.substring(CustomEntryType.ENTRYTYPE_FLAG.length());
-        int indexEndOfName = rest.indexOf(':');
-        if(indexEndOfName < 0) {
-            return null;
-        }
-        String fieldsDescription = rest.substring(indexEndOfName + 2);
-
-        int indexEndOfRequiredFields = fieldsDescription.indexOf(']');
-        int indexEndOfOptionalFields = fieldsDescription.indexOf(']', indexEndOfRequiredFields + 1);
-        if (indexEndOfRequiredFields < 4 || indexEndOfOptionalFields < indexEndOfRequiredFields + 6) {
-            return null;
-        }
-        String name = rest.substring(0, indexEndOfName);
-        String reqFields = fieldsDescription.substring(4, indexEndOfRequiredFields);
-        String optFields = fieldsDescription.substring(indexEndOfRequiredFields + 6, indexEndOfOptionalFields);
-        return new CustomEntryType(name, reqFields, optFields);
-    }
 }

--- a/src/main/java/net/sf/jabref/logic/cleanup/CleanupPreset.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/CleanupPreset.java
@@ -124,7 +124,7 @@ public class CleanupPreset {
         preferences.putBoolean(JabRefPreferences.CLEANUP_CONVERT_TO_BIBLATEX, isActive(CleanupStep.CONVERT_TO_BIBLATEX));
         preferences.putBoolean(JabRefPreferences.CLEANUP_FIX_FILE_LINKS, isActive(CleanupStep.FIX_FILE_LINKS));
 
-        preferences.putStringList(JabRefPreferences.CLEANUP_FORMATTERS, formatterCleanups.convertToString());
+        preferences.putStringList(JabRefPreferences.CLEANUP_FORMATTERS, formatterCleanups.getAsString());
     }
 
     private Boolean isActive(CleanupStep step) {

--- a/src/main/java/net/sf/jabref/logic/cleanup/CleanupPreset.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/CleanupPreset.java
@@ -124,7 +124,7 @@ public class CleanupPreset {
         preferences.putBoolean(JabRefPreferences.CLEANUP_CONVERT_TO_BIBLATEX, isActive(CleanupStep.CONVERT_TO_BIBLATEX));
         preferences.putBoolean(JabRefPreferences.CLEANUP_FIX_FILE_LINKS, isActive(CleanupStep.FIX_FILE_LINKS));
 
-        preferences.putStringList(JabRefPreferences.CLEANUP_FORMATTERS, formatterCleanups.getAsString());
+        preferences.putStringList(JabRefPreferences.CLEANUP_FORMATTERS, formatterCleanups.getAsStringList());
     }
 
     private Boolean isActive(CleanupStep step) {

--- a/src/main/java/net/sf/jabref/logic/cleanup/CleanupPreset.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/CleanupPreset.java
@@ -74,7 +74,7 @@ public class CleanupPreset {
             activeJobs.add(CleanupStep.FIX_FILE_LINKS);
         }
 
-        FieldFormatterCleanups formatterCleanups = FieldFormatterCleanups.parseFromString(
+        FieldFormatterCleanups formatterCleanups = FieldFormatterCleanups.parse(
                 preferences.getStringList(JabRefPreferences.CLEANUP_FORMATTERS));
 
         return new CleanupPreset(activeJobs, formatterCleanups);

--- a/src/main/java/net/sf/jabref/logic/config/SaveOrderConfig.java
+++ b/src/main/java/net/sf/jabref/logic/config/SaveOrderConfig.java
@@ -192,7 +192,7 @@ public class SaveOrderConfig {
     /**
      * Outputs the current configuration to be consumed later by the constructor
      */
-    public List<String> getConfigurationList() {
+    public List<String> getAsString() {
         List<String> res = new ArrayList<>(7);
         if (saveInOriginalOrder) {
             res.add("original");

--- a/src/main/java/net/sf/jabref/logic/config/SaveOrderConfig.java
+++ b/src/main/java/net/sf/jabref/logic/config/SaveOrderConfig.java
@@ -192,7 +192,7 @@ public class SaveOrderConfig {
     /**
      * Outputs the current configuration to be consumed later by the constructor
      */
-    public List<String> getAsString() {
+    public List<String> getAsStringList() {
         List<String> res = new ArrayList<>(7);
         if (saveInOriginalOrder) {
             res.add("original");

--- a/src/main/java/net/sf/jabref/logic/config/SaveOrderConfig.java
+++ b/src/main/java/net/sf/jabref/logic/config/SaveOrderConfig.java
@@ -19,6 +19,10 @@ public class SaveOrderConfig {
     // quick hack for outside modifications
     public final SortCriterion[] sortCriteria = new SortCriterion[3];
 
+    public static SaveOrderConfig parse(List<String> orderedData) {
+        return new SaveOrderConfig(orderedData);
+    }
+
     public static class SortCriterion {
 
         public String field;
@@ -112,7 +116,7 @@ public class SaveOrderConfig {
         return sb.toString();
     }
 
-    public SaveOrderConfig(List<String> data) {
+    private SaveOrderConfig(List<String> data) {
         Objects.requireNonNull(data);
 
         if (data.isEmpty()) {

--- a/src/main/java/net/sf/jabref/logic/groups/GroupTreeNode.java
+++ b/src/main/java/net/sf/jabref/logic/groups/GroupTreeNode.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import net.sf.jabref.importer.fileformat.ParseException;
 import net.sf.jabref.logic.search.SearchMatcher;
 import net.sf.jabref.logic.search.matchers.MatcherSet;
 import net.sf.jabref.logic.search.matchers.MatcherSets;
@@ -212,5 +213,9 @@ public class GroupTreeNode extends TreeNode<GroupTreeNode> {
     @Override
     public GroupTreeNode copyNode() {
         return new GroupTreeNode(group);
+    }
+
+    public static GroupTreeNode parse(List<String> orderedData) throws ParseException {
+        return GroupsParser.importGroups(orderedData);
     }
 }

--- a/src/main/java/net/sf/jabref/logic/groups/GroupsParser.java
+++ b/src/main/java/net/sf/jabref/logic/groups/GroupsParser.java
@@ -25,7 +25,7 @@ import net.sf.jabref.logic.l10n.Localization;
 /**
  * Converts string representation of groups to a parsed {@link GroupTreeNode}.
  */
-public class GroupsParser {
+class GroupsParser {
 
     public static GroupTreeNode importGroups(List<String> orderedData) throws ParseException {
         GroupTreeNode cursor = null;

--- a/src/main/java/net/sf/jabref/model/database/BibDatabaseMode.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabaseMode.java
@@ -29,4 +29,8 @@ public enum BibDatabaseMode {
     public static BibDatabaseMode parse(String data) {
         return BibDatabaseMode.valueOf(data.toUpperCase(Locale.ENGLISH));
     }
+
+    public String getAsString() {
+        return getFormattedName().toLowerCase(Locale.ENGLISH);
+    }
 }

--- a/src/main/java/net/sf/jabref/model/database/BibDatabaseMode.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabaseMode.java
@@ -1,5 +1,7 @@
 package net.sf.jabref.model.database;
 
+import java.util.Locale;
+
 public enum BibDatabaseMode {
     BIBTEX,
     BIBLATEX;
@@ -22,5 +24,9 @@ public enum BibDatabaseMode {
 
     public static BibDatabaseMode fromPreference(boolean isBibLatex) {
         return isBibLatex ? BIBLATEX : BIBTEX;
+    }
+
+    public static BibDatabaseMode parse(String data) {
+        return BibDatabaseMode.valueOf(data.toUpperCase(Locale.ENGLISH));
     }
 }

--- a/src/main/java/net/sf/jabref/model/entry/CustomEntryType.java
+++ b/src/main/java/net/sf/jabref/model/entry/CustomEntryType.java
@@ -51,6 +51,25 @@ public class CustomEntryType implements EntryType {
         this(name, Arrays.asList(required.split(";")), Arrays.asList(optional.split(";")));
     }
 
+    public static CustomEntryType parse(String comment) {
+        String rest = comment.substring(ENTRYTYPE_FLAG.length());
+        int indexEndOfName = rest.indexOf(':');
+        if(indexEndOfName < 0) {
+            return null;
+        }
+        String fieldsDescription = rest.substring(indexEndOfName + 2);
+
+        int indexEndOfRequiredFields = fieldsDescription.indexOf(']');
+        int indexEndOfOptionalFields = fieldsDescription.indexOf(']', indexEndOfRequiredFields + 1);
+        if (indexEndOfRequiredFields < 4 || indexEndOfOptionalFields < indexEndOfRequiredFields + 6) {
+            return null;
+        }
+        String name = rest.substring(0, indexEndOfName);
+        String reqFields = fieldsDescription.substring(4, indexEndOfRequiredFields);
+        String optFields = fieldsDescription.substring(indexEndOfRequiredFields + 6, indexEndOfOptionalFields);
+        return new CustomEntryType(name, reqFields, optFields);
+    }
+
     @Override
     public int compareTo(EntryType o) {
         return getName().compareTo(o.getName());

--- a/src/main/java/net/sf/jabref/model/entry/CustomEntryType.java
+++ b/src/main/java/net/sf/jabref/model/entry/CustomEntryType.java
@@ -124,4 +124,16 @@ public class CustomEntryType implements EntryType {
     public int hashCode() {
         return super.hashCode();
     }
+
+    public String getAsString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append(ENTRYTYPE_FLAG);
+        builder.append(getName());
+        builder.append(": req[");
+        builder.append(getRequiredFieldsString());
+        builder.append("] opt[");
+        builder.append(String.join(";", getOptionalFields()));
+        builder.append("]");
+        return builder.toString();
+    }
 }

--- a/src/test/java/net/sf/jabref/MetaDataTest.java
+++ b/src/test/java/net/sf/jabref/MetaDataTest.java
@@ -26,7 +26,7 @@ public class MetaDataTest {
 
     @Test
     public void serializeNewMetadataReturnsEmptyMap() throws Exception {
-        assertEquals(Collections.emptyMap(), metaData.getAsString());
+        assertEquals(Collections.emptyMap(), metaData.getAsStringMap());
     }
 
     @Test
@@ -38,6 +38,6 @@ public class MetaDataTest {
         Map<String, String> expectedSerialization = new TreeMap<>();
         expectedSerialization.put("saveActions",
                 "enabled;" + Globals.NEWLINE + "title[lower_case]" + Globals.NEWLINE + ";");
-        assertEquals(expectedSerialization, metaData.getAsString());
+        assertEquals(expectedSerialization, metaData.getAsStringMap());
     }
 }

--- a/src/test/java/net/sf/jabref/MetaDataTest.java
+++ b/src/test/java/net/sf/jabref/MetaDataTest.java
@@ -26,7 +26,7 @@ public class MetaDataTest {
 
     @Test
     public void serializeNewMetadataReturnsEmptyMap() throws Exception {
-        assertEquals(Collections.emptyMap(), metaData.serialize());
+        assertEquals(Collections.emptyMap(), metaData.getAsString());
     }
 
     @Test
@@ -38,6 +38,6 @@ public class MetaDataTest {
         Map<String, String> expectedSerialization = new TreeMap<>();
         expectedSerialization.put("saveActions",
                 "enabled;" + Globals.NEWLINE + "title[lower_case]" + Globals.NEWLINE + ";");
-        assertEquals(expectedSerialization, metaData.serialize());
+        assertEquals(expectedSerialization, metaData.getAsString());
     }
 }


### PR DESCRIPTION
According to the following conventions:
- All objects which can be read from a string have `public static Type parse(Stringy input)` method.
- All objects which can be written to a string have a `public Stringy getAsString()` method.

Should fix #888.

--

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
