### PR TITLE
create update checker for the enduser

### DIFF
--- a/src/main/java/net/sf/jabref/JabRefGUI.java
+++ b/src/main/java/net/sf/jabref/JabRefGUI.java
@@ -36,12 +36,15 @@ import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.ParserResultWarningDialog;
 import net.sf.jabref.gui.util.FocusRequester;
+import net.sf.jabref.gui.worker.VersionWorker;
 import net.sf.jabref.importer.AutosaveStartupPrompter;
 import net.sf.jabref.importer.OpenDatabaseAction;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.preferences.LastFocusedTabPreferences;
 import net.sf.jabref.logic.util.OS;
+import net.sf.jabref.logic.util.Version;
+import net.sf.jabref.logic.util.VersionPreferences;
 import net.sf.jabref.migrations.PreferencesMigrations;
 
 import com.jgoodies.looks.plastic.Plastic3DLookAndFeel;
@@ -65,6 +68,13 @@ public class JabRefGUI {
         this.loaded = loaded;
         this.isBlank = isBlank;
         openWindow();
+        JabRefGUI.checkForNewVersion(false);
+    }
+
+    public static void checkForNewVersion(boolean manualExecution) {
+        Version toBeIgnored = new VersionPreferences(Globals.prefs).getIgnoredVersion();
+        Version currentVersion = Globals.BUILD_INFO.getVersion();
+        new VersionWorker(JabRefGUI.getMainFrame(), manualExecution, currentVersion, toBeIgnored).execute();
     }
 
     private void openWindow() {

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2015 JabRef contributors.
+/*  Copyright (C) 2003-2016 JabRef contributors.
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 2 of the License, or
@@ -70,6 +70,7 @@ import net.sf.jabref.logic.openoffice.OpenOfficePreferences;
 import net.sf.jabref.logic.openoffice.StyleLoader;
 import net.sf.jabref.logic.remote.RemotePreferences;
 import net.sf.jabref.logic.util.OS;
+import net.sf.jabref.logic.util.VersionPreferences;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.CustomEntryType;
@@ -419,7 +420,7 @@ public class JabRefPreferences {
     private static final String USER_HOME = System.getProperty("user.home");
 
     /**
-     * Set with all custom {@link ImportFormat}s
+     * Set with all custom {@link net.sf.jabref.importer.fileformat.ImportFormat}s
      */
     public final CustomImportList customImports;
 
@@ -861,6 +862,9 @@ public class JabRefPreferences {
         defaults.put(MAX_BACK_HISTORY_SIZE, 10);
         defaults.put(LINE_LENGTH, 65);
         defaults.put(INDENT, 4);
+
+        //versioncheck defaults
+        defaults.put(VersionPreferences.VERSION_IGNORED_UPDATE, "");
     }
 
     public String getUser() {

--- a/src/main/java/net/sf/jabref/cli/JabRefCLI.java
+++ b/src/main/java/net/sf/jabref/cli/JabRefCLI.java
@@ -1,3 +1,18 @@
+/*  Copyright (C) 2003-2016 JabRef contributors.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
 package net.sf.jabref.cli;
 
 import net.sf.jabref.Globals;

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -92,6 +92,7 @@ import net.sf.jabref.gui.actions.MnemonicAwareAction;
 import net.sf.jabref.gui.actions.NewDatabaseAction;
 import net.sf.jabref.gui.actions.NewEntryAction;
 import net.sf.jabref.gui.actions.NewSubDatabaseAction;
+import net.sf.jabref.gui.actions.SearchForUpdateAction;
 import net.sf.jabref.gui.actions.SortTabsAction;
 import net.sf.jabref.gui.dbproperties.DatabasePropertiesDialog;
 import net.sf.jabref.gui.groups.EntryTableTransferHandler;
@@ -715,7 +716,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
     // General preferences dialog.  The MacAdapter calls this method when "Preferences..."
     // is selected from the application menu.
-    public void preferences() {
+    public void showPreferencesDialog() {
         output(Localization.lang("Opening preferences..."));
         if (prefsDialog == null) {
             prefsDialog = new PreferencesDialog(JabRefFrame.this);
@@ -1354,6 +1355,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         helpMenu.add(forkMeOnGitHubAction);
         helpMenu.add(donationAction);
         helpMenu.addSeparator();
+        helpMenu.add(new SearchForUpdateAction());
         helpMenu.add(about);
         mb.add(helpMenu);
 
@@ -1476,6 +1478,9 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         tlb.add(donationAction);
     }
 
+    /**
+     * displays the String on the Status Line visible on the bottom of the JabRef mainframe
+     */
     public void output(final String s) {
         SwingUtilities.invokeLater(() -> {
             statusLine.setText(s);
@@ -1703,7 +1708,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            preferences();
+            showPreferencesDialog();
         }
     }
 

--- a/src/main/java/net/sf/jabref/gui/actions/SearchForUpdateAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/SearchForUpdateAction.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2015 Oliver Kopp
+/*  Copyright (C) 2016 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -13,30 +13,23 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-package net.sf.jabref.gui.menus.help;
+package net.sf.jabref.gui.actions;
 
 import java.awt.event.ActionEvent;
 
 import javax.swing.AbstractAction;
-import javax.swing.Action;
 
-import net.sf.jabref.gui.IconTheme;
-import net.sf.jabref.gui.desktop.JabRefDesktop;
+import net.sf.jabref.JabRefGUI;
 import net.sf.jabref.logic.l10n.Localization;
 
-public class DonateAction extends AbstractAction {
+public class SearchForUpdateAction extends AbstractAction {
 
-    private static final String DONATION_LINK = "https://github.com/JabRef/jabref/wiki/Donations";
-
-    public DonateAction() {
-        super(Localization.menuTitle("Donate to JabRef"));
-        putValue(Action.SHORT_DESCRIPTION, Localization.lang("Donate to JabRef"));
-        putValue(Action.SMALL_ICON, IconTheme.JabRefIcon.DONATE.getSmallIcon());
-        putValue(Action.LARGE_ICON_KEY, IconTheme.JabRefIcon.DONATE.getIcon());
+    public SearchForUpdateAction(){
+        super(Localization.lang("Check for updates"));
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        JabRefDesktop.openBrowserShowPopup(DONATION_LINK);
+        JabRefGUI.checkForNewVersion(true);
     }
 }

--- a/src/main/java/net/sf/jabref/gui/desktop/JabRefDesktop.java
+++ b/src/main/java/net/sf/jabref/gui/desktop/JabRefDesktop.java
@@ -1,3 +1,18 @@
+/*  Copyright (C) 2003-2016 JabRef contributors.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
 package net.sf.jabref.gui.desktop;
 
 import java.io.File;
@@ -12,10 +27,12 @@ import javax.swing.JOptionPane;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefGUI;
 import net.sf.jabref.external.ExternalFileType;
 import net.sf.jabref.external.ExternalFileTypeEntryEditor;
 import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.external.UnknownExternalFileType;
+import net.sf.jabref.gui.ClipBoardManager;
 import net.sf.jabref.gui.FileListEntry;
 import net.sf.jabref.gui.FileListEntryEditor;
 import net.sf.jabref.gui.FileListTableModel;
@@ -263,6 +280,27 @@ public class JabRefDesktop {
     public static void openBrowser(String url) throws IOException {
         Optional<ExternalFileType> fileType = ExternalFileTypes.getInstance().getExternalFileTypeByExt("html");
         openExternalFilePlatformIndependent(fileType, url);
+    }
+
+    /**
+     * Opens the url with the users standard Browser.
+     * If that fails a popup will be shown to instruct the user to open the link manually
+     * and the link gets copied to the clipboard
+     * @param url
+     */
+    public static void openBrowserShowPopup(String url) {
+        try {
+            openBrowser(url);
+        } catch (IOException exception) {
+            new ClipBoardManager().setClipboardContents(url);
+            LOGGER.error("Could not open browser", exception);
+            String couldNotOpenBrowser = Localization.lang("Could not open browser.");
+            String openManually = Localization.lang("Please open %0 manually.", url);
+            String copiedToClipboard = Localization.lang("The_link_has_been_copied_to_the_clipboard.");
+            JabRefGUI.getMainFrame().output(couldNotOpenBrowser);
+            JOptionPane.showMessageDialog(JabRefGUI.getMainFrame(), couldNotOpenBrowser + "\n" + openManually +"\n"+
+                    copiedToClipboard, couldNotOpenBrowser, JOptionPane.ERROR_MESSAGE);
+        }
     }
 
     public static void openConsole(File file) throws IOException {

--- a/src/main/java/net/sf/jabref/gui/help/HelpAction.java
+++ b/src/main/java/net/sf/jabref/gui/help/HelpAction.java
@@ -17,7 +17,6 @@ package net.sf.jabref.gui.help;
 
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
-import java.io.IOException;
 
 import javax.swing.Action;
 import javax.swing.Icon;
@@ -25,7 +24,6 @@ import javax.swing.JButton;
 import javax.swing.KeyStroke;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefGUI;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.actions.MnemonicAwareAction;
@@ -83,12 +81,7 @@ public class HelpAction extends MnemonicAwareAction {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        try {
-            JabRefDesktop.openBrowser("http://help.jabref.org/" + Globals.prefs.get(JabRefPreferences.LANGUAGE) + "/"
-                    + helpPage.getPageName());
-        } catch (IOException ex) {
-            LOGGER.warn("Could not open browser", ex);
-            JabRefGUI.getMainFrame().getCurrentBasePanel().output(Localization.lang("Could not open browser."));
-        }
+        String url = "http://help.jabref.org/" + Globals.prefs.get(JabRefPreferences.LANGUAGE) + "/" + helpPage.getPageName();
+        JabRefDesktop.openBrowserShowPopup(url);
     }
 }

--- a/src/main/java/net/sf/jabref/gui/help/NewVersionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/help/NewVersionDialog.java
@@ -1,0 +1,110 @@
+/*  Copyright (C) 2016 JabRef contributors.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+package net.sf.jabref.gui.help;
+
+import java.awt.Cursor;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.MouseEvent;
+
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.event.MouseInputAdapter;
+
+import net.sf.jabref.Globals;
+import net.sf.jabref.gui.desktop.JabRefDesktop;
+import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.Version;
+import net.sf.jabref.logic.util.VersionPreferences;
+
+public class NewVersionDialog extends JDialog {
+
+    public NewVersionDialog(JFrame frame, Version currentVersion, Version latestVersion, Version toBeIgnored) {
+        super(frame);
+        setTitle(Localization.lang("New version available"));
+
+        JLabel lblTitle = new JLabel(Localization.lang("A new version of JabRef has been released."));
+        JLabel lblCurrentVersion = new JLabel(Localization.lang("Installed version") + ": " + currentVersion.getFullVersion());
+        JLabel lblLatestVersion = new JLabel(Localization.lang("Latest version") + ": " + latestVersion.getFullVersion());
+
+        String localization = Localization.lang("To see what's new view the changelog.");
+        JLabel lblMoreInformation = new JLabel("<HTML><a href=" + latestVersion.getChangelogUrl() + "'>" + localization + "</a></HTML>");
+        lblMoreInformation.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
+        lblMoreInformation.addMouseListener(new MouseInputAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                JabRefDesktop.openBrowserShowPopup(latestVersion.getChangelogUrl());
+            }
+        });
+
+        JButton btnIgnoreUpdate = new JButton(Localization.lang("Ignore this update"));
+        btnIgnoreUpdate.addActionListener(e -> {
+            new VersionPreferences(Globals.prefs).setAsIgnoredVersion(toBeIgnored);
+            dispose();
+        });
+
+        JButton btnDownloadUpdate = new JButton(Localization.lang("Download update"));
+        btnDownloadUpdate.addActionListener(e -> {
+            JabRefDesktop.openBrowserShowPopup(Version.JABREF_DOWNLOAD_URL);
+            dispose();
+        });
+
+        JButton btnRemindMeLater = new JButton(Localization.lang("Remind me later"));
+        btnRemindMeLater.addActionListener(e -> dispose());
+
+        JPanel panel = new JPanel();
+        panel.setLayout(new GridBagLayout());
+        GridBagConstraints c = new GridBagConstraints();
+        c.gridheight = 1;
+        c.fill = GridBagConstraints.BOTH;
+        c.insets = new Insets(2, 5, 5, 2);
+
+        c.gridx = c.gridy = 0;
+        c.gridwidth = 3;
+        panel.add(lblTitle, c);
+
+        c.gridy = 1;
+        panel.add(lblCurrentVersion, c);
+
+        c.gridy = 2;
+        panel.add(lblLatestVersion, c);
+
+        c.gridy = 3;
+        panel.add(lblMoreInformation, c);
+
+        c.gridy = 4;
+        c.gridx = 0;
+        c.gridwidth = 1;
+        panel.add(btnDownloadUpdate, c);
+
+        c.gridx = 1;
+        panel.add(btnIgnoreUpdate, c);
+
+        c.gridx = 2;
+        panel.add(btnRemindMeLater, c);
+
+        add(panel);
+        pack();
+        setLocationRelativeTo(frame);
+        setModalityType(ModalityType.APPLICATION_MODAL);
+        setVisible(true);
+    }
+
+}

--- a/src/main/java/net/sf/jabref/gui/menus/help/ForkMeOnGitHubAction.java
+++ b/src/main/java/net/sf/jabref/gui/menus/help/ForkMeOnGitHubAction.java
@@ -16,24 +16,16 @@
 package net.sf.jabref.gui.menus.help;
 
 import java.awt.event.ActionEvent;
-import java.io.IOException;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 
-import net.sf.jabref.JabRefGUI;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.desktop.JabRefDesktop;
 import net.sf.jabref.logic.l10n.Localization;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 @SuppressWarnings("serial")
 public class ForkMeOnGitHubAction extends AbstractAction {
-
-    private static final Log LOGGER = LogFactory.getLog(ForkMeOnGitHubAction.class);
-
 
     public ForkMeOnGitHubAction() {
         super(Localization.menuTitle("Fork me on GitHub"), IconTheme.JabRefIcon.GITHUB.getSmallIcon());
@@ -43,12 +35,6 @@ public class ForkMeOnGitHubAction extends AbstractAction {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        try {
-            JabRefDesktop.openBrowser("https://github.com/JabRef/jabref");
-        } catch (IOException ex) {
-            LOGGER.warn("Could not open browser", ex);
-            JabRefGUI.getMainFrame().getCurrentBasePanel().output(Localization.lang("Could not open browser.") + " "
-                    + Localization.lang("Please open http://github.com/JabRef/jabref manually."));
-        }
+        JabRefDesktop.openBrowserShowPopup("https://github.com/JabRef/jabref");
     }
 }

--- a/src/main/java/net/sf/jabref/gui/worker/VersionWorker.java
+++ b/src/main/java/net/sf/jabref/gui/worker/VersionWorker.java
@@ -1,0 +1,101 @@
+/*  Copyright (C) 2003-2016 JabRef contributors.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+package net.sf.jabref.gui.worker;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+
+import javax.swing.JOptionPane;
+import javax.swing.SwingWorker;
+
+import net.sf.jabref.gui.JabRefFrame;
+import net.sf.jabref.gui.help.NewVersionDialog;
+import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.Version;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class VersionWorker extends SwingWorker<Version, Void> {
+
+    private static final Log LOGGER = LogFactory.getLog(VersionWorker.class);
+
+    private final JabRefFrame mainFrame;
+    private final boolean manualExecution;
+    private final Version installedVersion;
+    private final Version toBeIgnored;
+
+    public VersionWorker(JabRefFrame mainFrame, boolean manualExecution, Version installedVersion, Version toBeIgnored) {
+        this.mainFrame = Objects.requireNonNull(mainFrame);
+        this.manualExecution = manualExecution;
+        this.installedVersion = Objects.requireNonNull(installedVersion);
+        this.toBeIgnored = Objects.requireNonNull(toBeIgnored);
+    }
+
+    @Override
+    protected Version doInBackground() throws Exception {
+        try {
+            return Version.getLatestVersion();
+        } catch (IOException ioException) {
+            LOGGER.warn("Couldn't connect to the updateserver.", ioException);
+            return null;
+        }
+    }
+
+    @Override
+    public void done(){
+        if (this.isCancelled()){
+            return;
+        }
+
+        try {
+            Version latestVersion = this.get();
+
+            if (latestVersion == null){
+                String couldNotConnect = Localization.lang("Couldn't connect to the update server.");
+                String tryLater = Localization.lang("Please try again later and/or check your network connection.");
+                if (manualExecution) {
+                    JOptionPane.showMessageDialog(this.mainFrame, couldNotConnect + "\n" + tryLater,
+                            couldNotConnect, JOptionPane.ERROR_MESSAGE);
+                }
+                this.mainFrame.output(couldNotConnect + " " + tryLater);
+                return;
+            }
+
+            // only respect the ignored version on automated version checks
+            if (latestVersion.equals(toBeIgnored) && !manualExecution) {
+                return;
+            }
+
+            boolean newer = latestVersion.isNewerThan(installedVersion);
+            if (newer){
+                new NewVersionDialog(this.mainFrame, installedVersion, latestVersion, toBeIgnored);
+                return;
+            }
+
+            String upToDate = Localization.lang("JabRef is up-to-date.");
+            if (manualExecution) {
+                JOptionPane.showMessageDialog(this.mainFrame, upToDate, upToDate, JOptionPane.INFORMATION_MESSAGE);
+            }
+            this.mainFrame.output(upToDate);
+
+        } catch (InterruptedException | ExecutionException e) {
+            LOGGER.error("Error while checking for updates", e);
+        }
+    }
+
+}

--- a/src/main/java/net/sf/jabref/logic/util/BuildInfo.java
+++ b/src/main/java/net/sf/jabref/logic/util/BuildInfo.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2015 JabRef contributors.
+/*  Copyright (C) 2003-2016 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -21,14 +21,14 @@ import java.util.Properties;
 
 public class BuildInfo {
 
-    private static final String UNKOWN_VERSION = "*unknown*";
+    public static final String UNKNOWN_VERSION = "*unknown*";
 
-    public final static String OS = System.getProperty("os.name", UNKOWN_VERSION).toLowerCase();
-    public final static String OS_VERSION = System.getProperty("os.version", UNKOWN_VERSION).toLowerCase();
-    public final static String OS_ARCH = System.getProperty("os.arch", UNKOWN_VERSION).toLowerCase();
-    public final static String JAVA_VERSION = System.getProperty("java.version", UNKOWN_VERSION).toLowerCase();
+    public final static String OS = System.getProperty("os.name", UNKNOWN_VERSION).toLowerCase();
+    public final static String OS_VERSION = System.getProperty("os.version", UNKNOWN_VERSION).toLowerCase();
+    public final static String OS_ARCH = System.getProperty("os.arch", UNKNOWN_VERSION).toLowerCase();
+    public final static String JAVA_VERSION = System.getProperty("java.version", UNKNOWN_VERSION).toLowerCase();
 
-    private final String version;
+    private final Version version;
     private final String authors;
     private final String developers;
     private final String year;
@@ -48,14 +48,14 @@ public class BuildInfo {
             // nothing to do -> default already set
         }
 
-        version = properties.getProperty("version", UNKOWN_VERSION);
+        version = new Version(properties.getProperty("version", UNKNOWN_VERSION));
         authors = properties.getProperty("authors", "");
         year = properties.getProperty("year", "");
         developers = properties.getProperty("developers", "");
 
     }
 
-    public String getVersion() {
+    public Version getVersion() {
         return version;
     }
 

--- a/src/main/java/net/sf/jabref/logic/util/Version.java
+++ b/src/main/java/net/sf/jabref/logic/util/Version.java
@@ -1,0 +1,154 @@
+/*  Copyright (C) 2016 JabRef contributors.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+package net.sf.jabref.logic.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import org.json.JSONObject;
+
+/**
+ * Represents the Application Version with the major and minor number, the full Version String and if it's a developer version
+ */
+public class Version {
+
+    public final static String JABREF_DOWNLOAD_URL = "http://www.fosshub.com/JabRef.html";
+    private final static String JABREF_GITHUB_URL = "https://api.github.com/repos/JabRef/jabref/releases/latest";
+
+    private final String fullVersion;
+    private final int major;
+    private final int minor;
+    private final int patch;
+    private final boolean isDevelopmentVersion;
+
+
+    /**
+     * @param version must be in form of X.X (eg 3.3; 3.4dev)
+     */
+    public Version(String version) {
+        if (version == null || "".equals(version) || version.equals(BuildInfo.UNKNOWN_VERSION)) {
+            this.fullVersion = BuildInfo.UNKNOWN_VERSION;
+            this.major = this.minor = this.patch = 0;
+            this.isDevelopmentVersion = false;
+            return;
+        }
+
+        this.fullVersion = version;
+        isDevelopmentVersion = version.contains("dev");
+        String[] versionParts = version.split("dev");
+        String[] versionNumbers = versionParts[0].split(Pattern.quote("."));
+        this.major = Integer.parseInt(versionNumbers[0]);
+        this.minor = versionNumbers.length >= 2 ? Integer.parseInt(versionNumbers[1]) : 0;
+        this.patch = versionNumbers.length >= 3 ? Integer.parseInt(versionNumbers[2]) : 0;
+    }
+
+    /**
+     * Grabs the latest release version from the JabRef GitHub repository
+     *
+     * @return
+     * @throws IOException
+     */
+    public static Version getLatestVersion() throws IOException {
+        URLConnection connection = new URL(JABREF_GITHUB_URL).openConnection();
+        connection.setRequestProperty("Accept-Charset", "UTF-8");
+        BufferedReader rd = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+        JSONObject obj = new JSONObject(rd.readLine());
+        return new Version(obj.getString("tag_name").replaceFirst("v", ""));
+    }
+
+    /**
+     * @return true if this version is newer than the passed one
+     */
+    public boolean isNewerThan(Version otherVersion) {
+        Objects.requireNonNull(otherVersion);
+        if (Objects.equals(this, otherVersion)) {
+            return false;
+        }
+        if (this.getFullVersion().equals(BuildInfo.UNKNOWN_VERSION)) {
+            return false;
+        }
+        if (otherVersion.getFullVersion().equals(BuildInfo.UNKNOWN_VERSION)) {
+            return true;
+        }
+
+        if (this.getMajor() > otherVersion.getMajor()) {
+            return true;
+        }
+        if (this.getMajor() == otherVersion.getMajor()) {
+            if (this.getMinor() > otherVersion.getMinor()) {
+                return true;
+            }
+            if (this.getMinor() == otherVersion.getMinor() && this.getPatch() > otherVersion.getPatch()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public String getFullVersion() {
+        return fullVersion;
+    }
+
+    public int getMajor() {
+        return major;
+    }
+
+    public int getMinor() {
+        return minor;
+    }
+
+    public int getPatch() {
+        return patch;
+    }
+
+    public boolean isDevelopmentVersion() {
+        return isDevelopmentVersion;
+    }
+
+    /**
+     * @return The link to the changelog on github to this specific version
+     * (https://github.com/JabRef/jabref/blob/vX.X/CHANGELOG.md)
+     */
+    public String getChangelogUrl() {
+        String version = this.getMajor() + "." + this.getMinor() + (this.getPatch() != 0 ? "." + this.getPatch() : "");
+        return "https://github.com/JabRef/jabref/blob/v" + version + "/CHANGELOG.md";
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof Version)) {
+            return false;
+        }
+
+        Version otherVersion = (Version) other;
+        // till all the information are stripped from the fullverison this should suffice
+        return this.getFullVersion().equals(otherVersion.getFullVersion());
+    }
+
+    @Override
+    public String toString() {
+        return this.getFullVersion();
+    }
+}

--- a/src/main/java/net/sf/jabref/logic/util/VersionPreferences.java
+++ b/src/main/java/net/sf/jabref/logic/util/VersionPreferences.java
@@ -1,0 +1,40 @@
+/*  Copyright (C) 2016 JabRef contributors.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+package net.sf.jabref.logic.util;
+
+import net.sf.jabref.JabRefPreferences;
+
+
+public class VersionPreferences {
+
+    public static final String VERSION_IGNORED_UPDATE = "versionIgnoreUpdate";
+
+    private final JabRefPreferences preferences;
+
+
+    public VersionPreferences(JabRefPreferences preferences) {
+        this.preferences = preferences;
+    }
+
+    public void setAsIgnoredVersion(Version version) {
+        preferences.put(VERSION_IGNORED_UPDATE, version.toString());
+    }
+
+    public Version getIgnoredVersion() {
+        return new Version(preferences.get(VERSION_IGNORED_UPDATE));
+    }
+
+}

--- a/src/main/java/osx/macadapter/MacAdapter.java
+++ b/src/main/java/osx/macadapter/MacAdapter.java
@@ -89,7 +89,7 @@ public class MacAdapter implements PreferencesHandler, AboutHandler, QuitHandler
             return;
         }
 
-        parentFrame.preferences();
+        parentFrame.showPreferencesDialog();
     }
 
     @Override

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -1320,8 +1320,6 @@ Unable_to_find_the_requested_Look_&_Feel_and_thus_the_default_one_is_used.=
 
 Could_not_open_browser.=
 Opens_JabRef's_GitHub_page=
-Please_open_http\://github.com/JabRef/jabref_manually.=
-
 Rebind_C-f,_too=
 This_group_contains_all_entries._It_cannot_be_edited_or_removed.=
 
@@ -1688,3 +1686,20 @@ Decryption_not_supported.=
 Cleared_'%0'_for_%1_entries=
 Set_'%0'_to_'%1'_for_%2_entries=
 Toggled_'%0'_for_%1_entries=
+
+Check_for_updates=
+Download_update=
+New_version_available=
+Installed_version=
+Remind_me_later=
+Ignore_this_update=
+Couldn't_connect_to_the_update_server.=
+Please_try_again_later_and/or_check_your_network_connection.=
+To_see_what's_new_view_the_changelog.=
+A_new_version_of_JabRef_has_been_released.=
+JabRef_is_up-to-date.=
+Latest_version=
+
+Please_open_%0_manually.=
+
+The_link_has_been_copied_to_the_clipboard.=

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2028,7 +2028,6 @@ Unable_to_find_the_requested_Look_&_Feel_and_thus_the_default_one_is_used.=Look_
 
 Could_not_open_browser.=Konnte_Browser_nicht_öffnen.
 Opens_JabRef's_GitHub_page=Öffnet_JabRefs_GitHub-Seite
-Please_open_http\://github.com/JabRef/jabref_manually.=Bitte_öffnen_Sie_http\://github.com/JabRef/jabref_von_Hand.
 Rebind_C-f,_too=C-f_ebenfalls_neu_zuweisen
 
 This_group_contains_all_entries._It_cannot_be_edited_or_removed.=Diese_Gruppe_enthält_alle_Einträge._Sie_kann_nicht_gelöscht_werden.
@@ -2404,3 +2403,20 @@ Decryption_not_supported.=Entschlüsselung_wird_nicht_unterstützt.
 Cleared_'%0'_for_%1_entries='%0'_für_%1_Einträge_entfernt
 Set_'%0'_to_'%1'_for_%2_entries='%0'_für_%2_Einträge_auf_'%1'_gesetzt
 Toggled_'%0'_for_%1_entries='%0'_für_%1_Einträge_geändert
+
+Check_for_updates=
+Download_update=
+New_version_available=
+Installed_version=
+Remind_me_later=
+Ignore_this_update=
+Couldn't_connect_to_the_update_server.=
+Please_try_again_later_and/or_check_your_network_connection.=
+To_see_what's_new_view_the_changelog.=
+A_new_version_of_JabRef_has_been_released.=
+JabRef_is_up-to-date.=
+Latest_version=
+
+Please_open_%0_manually.=
+
+The_link_has_been_copied_to_the_clipboard.=

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1935,7 +1935,8 @@ Unable_to_find_the_requested_Look_&_Feel_and_thus_the_default_one_is_used.=Unabl
 
 Opens_JabRef's_GitHub_page=Opens_JabRef's_GitHub_page
 Could_not_open_browser.=Could_not_open_browser.
-Please_open_http\://github.com/JabRef/jabref_manually.=Please_open_http\://github.com/JabRef/jabref_manually.
+Please_open_%0_manually.=Please_open_%0_manually.
+The_link_has_been_copied_to_the_clipboard.=The_link_has_been_copied_to_the_clipboard.
 
 This_group_contains_all_entries._It_cannot_be_edited_or_removed.=This_group_contains_all_entries._It_cannot_be_edited_or_removed.
 
@@ -2260,3 +2261,16 @@ Decryption_not_supported.=Decryption_not_supported.
 Cleared_'%0'_for_%1_entries=Cleared_'%0'_for_%1_entries
 Set_'%0'_to_'%1'_for_%2_entries=Set_'%0'_to_'%1'_for_%2_entries
 Toggled_'%0'_for_%1_entries=Toggled_'%0'_for_%1_entries
+
+Check_for_updates=Check_for_updates
+Download_update=Download_update
+New_version_available=New_version_available
+Installed_version=Installed_version
+Remind_me_later=Remind_me_later
+Ignore_this_update=Ignore_this_update
+Couldn't_connect_to_the_update_server.=Couldn't_connect_to_the_update_server.
+Please_try_again_later_and/or_check_your_network_connection.=Please_try_again_later_and/or_check_your_network_connection.
+To_see_what's_new_view_the_changelog.=To_see_what's_new_view_the_changelog.
+A_new_version_of_JabRef_has_been_released.=A_new_version_of_JabRef_has_been_released.
+JabRef_is_up-to-date.=JabRef_is_up-to-date.
+Latest_version=Latest_version

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -1221,7 +1221,6 @@ Unable_to_find_the_requested_Look_&_Feel_and_thus_the_default_one_is_used.=No_se
 
 Could_not_open_browser.=No_se_puede_abrir_el_explorador.
 Opens_JabRef's_GitHub_page=Abrir_la_página_de_JabRef_en_GitHub
-Please_open_http\://github.com/JabRef/jabref_manually.=Por_favor,_abra_http\://github.com/JabRef/jabref_manualmente
 
 Rebind_C-f,_too=Recombinar_C-f,_también
 This_group_contains_all_entries._It_cannot_be_edited_or_removed.=Este_grupo_contiene_todas_las_entradas._No_puede_ser_eliminado_o_editado.
@@ -1589,3 +1588,20 @@ Decryption_not_supported.=
 Cleared_'%0'_for_%1_entries=Ajustes_de_'%0'_para_%1_entradas
 Set_'%0'_to_'%1'_for_%2_entries=Establecer_'%0'_a_'%1'_para_%2_entradas
 Toggled_'%0'_for_%1_entries=Cambiada_'%0'_para_%1_entradas
+
+Check_for_updates=
+Download_update=
+New_version_available=
+Installed_version=
+Remind_me_later=
+Ignore_this_update=
+Couldn't_connect_to_the_update_server.=
+Please_try_again_later_and/or_check_your_network_connection.=
+To_see_what's_new_view_the_changelog.=
+A_new_version_of_JabRef_has_been_released.=
+JabRef_is_up-to-date.=
+Latest_version=
+
+Please_open_%0_manually.=
+
+The_link_has_been_copied_to_the_clipboard.=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -1984,7 +1984,6 @@ Unable_to_find_the_requested_Look_&_Feel_and_thus_the_default_one_is_used.=
 
 Opens_JabRef's_GitHub_page=
 Could_not_open_browser.=
-Please_open_http\://github.com/JabRef/jabref_manually.=
 
 This_group_contains_all_entries._It_cannot_be_edited_or_removed.=
 
@@ -2375,3 +2374,20 @@ Decryption_not_supported.=
 Cleared_'%0'_for_%1_entries=
 Set_'%0'_to_'%1'_for_%2_entries=
 Toggled_'%0'_for_%1_entries=
+
+Check_for_updates=
+Download_update=
+New_version_available=
+Installed_version=
+Remind_me_later=
+Ignore_this_update=
+Couldn't_connect_to_the_update_server.=
+Please_try_again_later_and/or_check_your_network_connection.=
+To_see_what's_new_view_the_changelog.=
+A_new_version_of_JabRef_has_been_released.=
+JabRef_is_up-to-date.=
+Latest_version=
+
+Please_open_%0_manually.=
+
+The_link_has_been_copied_to_the_clipboard.=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -1261,7 +1261,6 @@ Unable_to_find_the_requested_Look_&_Feel_and_thus_the_default_one_is_used.=Impos
 
 Could_not_open_browser.=Le_navigateur_n'a_pas_pu_être_lancé.
 Opens_JabRef's_GitHub_page=Ouvre_la_page_GitHub_de_JabRef
-Please_open_http\://github.com/JabRef/jabref_manually.=Ouvrez_http\://github.com/JabRef/jabref_manuellement,_SVP.
 
 Rebind_C-f,_too=Ré-associer_aussi_C-f
 This_group_contains_all_entries._It_cannot_be_edited_or_removed.=Ce_groupe_contient_toutes_les_entrées._Il_ne_peut_pas_être_modifié_ou_supprimé.
@@ -1633,3 +1632,20 @@ Decryption_not_supported.=Déchiffrement_non_supporté.
 Cleared_'%0'_for_%1_entries=Réinitialisés_'%0'_pour_%1_entrées
 Set_'%0'_to_'%1'_for_%2_entries='%0'_mis_à_'%1'_pour_%2_entrées
 Toggled_'%0'_for_%1_entries='%0'_modifiée_pour_%1_entrées
+
+Check_for_updates=
+Download_update=
+New_version_available=
+Installed_version=
+Remind_me_later=
+Ignore_this_update=
+Couldn't_connect_to_the_update_server.=
+Please_try_again_later_and/or_check_your_network_connection.=
+To_see_what's_new_view_the_changelog.=
+A_new_version_of_JabRef_has_been_released.=
+JabRef_is_up-to-date.=
+Latest_version=
+
+Please_open_%0_manually.=
+
+The_link_has_been_copied_to_the_clipboard.=

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -1238,7 +1238,6 @@ Unable_to_find_the_requested_Look_&_Feel_and_thus_the_default_one_is_used.=Penam
 
 Could_not_open_browser.=Penjelajah_tidak_bisa_dibuka.
 Opens_JabRef's_GitHub_page=Buka_halaman_JabRef_di_GitHub
-Please_open_http\://github.com/JabRef/jabref_manually.=Buka_http\://github.com/JabRef/jabref_secara_manual.
 
 Rebind_C-f,_too=
 This_group_contains_all_entries._It_cannot_be_edited_or_removed.=Grup_ini_mengandung_semua_entri._Tidak_bisa_disunting_atau_dihapus.
@@ -1608,3 +1607,20 @@ Decryption_not_supported.=
 Cleared_'%0'_for_%1_entries=
 Set_'%0'_to_'%1'_for_%2_entries=
 Toggled_'%0'_for_%1_entries=
+
+Check_for_updates=
+Download_update=
+New_version_available=
+Installed_version=
+Remind_me_later=
+Ignore_this_update=
+Couldn't_connect_to_the_update_server.=
+Please_try_again_later_and/or_check_your_network_connection.=
+To_see_what's_new_view_the_changelog.=
+A_new_version_of_JabRef_has_been_released.=
+JabRef_is_up-to-date.=
+Latest_version=
+
+Please_open_%0_manually.=
+
+The_link_has_been_copied_to_the_clipboard.=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -1338,7 +1338,6 @@ Unable_to_find_the_requested_Look_&_Feel_and_thus_the_default_one_is_used.=Impos
 
 Could_not_open_browser.=Impossibile_avviare_il_browser
 Opens_JabRef's_GitHub_page=Apri_la_pagina_di_JabRef_su_GitHub
-Please_open_http\://github.com/JabRef/jabref_manually.=Aprire_manualmente_la_pagina_http\://github.com/JabRef/jabref
 
 Rebind_C-f,_too=Riassociare_anche_C-f
 This_group_contains_all_entries._It_cannot_be_edited_or_removed.=Questo_gruppo_contiene_tutte_le_voci._Non_pu\u00f2_essere_modificato_o_rimosso.
@@ -1708,3 +1707,20 @@ Decryption_not_supported.=
 Cleared_'%0'_for_%1_entries=Reinizializzati_'%0'_per_%1_voce/i
 Set_'%0'_to_'%1'_for_%2_entries='%0'_impostata_a_'%1'_per_%2_voce/i
 Toggled_'%0'_for_%1_entries=Modificata_la_valutazione_di_'%0'_per_%1_voce/i
+
+Check_for_updates=
+Download_update=
+New_version_available=
+Installed_version=
+Remind_me_later=
+Ignore_this_update=
+Couldn't_connect_to_the_update_server.=
+Please_try_again_later_and/or_check_your_network_connection.=
+To_see_what's_new_view_the_changelog.=
+A_new_version_of_JabRef_has_been_released.=
+JabRef_is_up-to-date.=
+Latest_version=
+
+Please_open_%0_manually.=
+
+The_link_has_been_copied_to_the_clipboard.=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2009,7 +2009,6 @@ Unable_to_find_the_requested_Look_&_Feel_and_thus_the_default_one_is_used.=要�
 
 Could_not_open_browser.=ブラウザを開くことができませんでした。
 Opens_JabRef's_GitHub_page=JabRefのGitHubページを開きます
-Please_open_http\://github.com/JabRef/jabref_manually.=手動でhttp\://github.com/JabRef/jabrefを開いてください。
 
 Rebind_C-f,_too=C-fもバインドし直します
 This_group_contains_all_entries._It_cannot_be_edited_or_removed.=このグループは全項目を含んでいます。編集したり削除したりすることはできません。
@@ -2353,3 +2352,20 @@ Decryption_not_supported.=
 Cleared_'%0'_for_%1_entries=
 Set_'%0'_to_'%1'_for_%2_entries=
 Toggled_'%0'_for_%1_entries=
+
+Check_for_updates=
+Download_update=
+New_version_available=
+Installed_version=
+Remind_me_later=
+Ignore_this_update=
+Couldn't_connect_to_the_update_server.=
+Please_try_again_later_and/or_check_your_network_connection.=
+To_see_what's_new_view_the_changelog.=
+A_new_version_of_JabRef_has_been_released.=
+JabRef_is_up-to-date.=
+Latest_version=
+
+Please_open_%0_manually.=
+
+The_link_has_been_copied_to_the_clipboard.=

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -2011,7 +2011,6 @@ Unable_to_find_the_requested_Look_&_Feel_and_thus_the_default_one_is_used.=
 
 Could_not_open_browser.=
 Opens_JabRef's_GitHub_page=
-Please_open_http\://github.com/JabRef/jabref_manually.=
 
 Rebind_C-f,_too=
 This_group_contains_all_entries._It_cannot_be_edited_or_removed.=
@@ -2384,3 +2383,20 @@ Decryption_not_supported.=
 Cleared_'%0'_for_%1_entries=
 Set_'%0'_to_'%1'_for_%2_entries=
 Toggled_'%0'_for_%1_entries=
+
+Check_for_updates=
+Download_update=
+New_version_available=
+Installed_version=
+Remind_me_later=
+Ignore_this_update=
+Couldn't_connect_to_the_update_server.=
+Please_try_again_later_and/or_check_your_network_connection.=
+To_see_what's_new_view_the_changelog.=
+A_new_version_of_JabRef_has_been_released.=
+JabRef_is_up-to-date.=
+Latest_version=
+
+Please_open_%0_manually.=
+
+The_link_has_been_copied_to_the_clipboard.=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -2406,7 +2406,6 @@ Unable_to_find_the_requested_Look_&_Feel_and_thus_the_default_one_is_used.=
 
 Could_not_open_browser.=
 Opens_JabRef's_GitHub_page=
-Please_open_http\://github.com/JabRef/jabref_manually.=
 
 Rebind_C-f,_too=
 This_group_contains_all_entries._It_cannot_be_edited_or_removed.=
@@ -2780,3 +2779,20 @@ Decryption_not_supported.=
 Cleared_'%0'_for_%1_entries=
 Set_'%0'_to_'%1'_for_%2_entries=
 Toggled_'%0'_for_%1_entries=
+
+Check_for_updates=
+Download_update=
+New_version_available=
+Installed_version=
+Remind_me_later=
+Ignore_this_update=
+Couldn't_connect_to_the_update_server.=
+Please_try_again_later_and/or_check_your_network_connection.=
+To_see_what's_new_view_the_changelog.=
+A_new_version_of_JabRef_has_been_released.=
+JabRef_is_up-to-date.=
+Latest_version=
+
+Please_open_%0_manually.=
+
+The_link_has_been_copied_to_the_clipboard.=

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -1235,7 +1235,6 @@ Unable_to_find_the_requested_Look_&_Feel_and_thus_the_default_one_is_used.=Não_
 
 Could_not_open_browser.=Não_foi_possível_abrir_o_navegador.
 Opens_JabRef's_GitHub_page=Abrir_a_página_do_JabRef_no_GitHub
-Please_open_http\://github.com/JabRef/jabref_manually.=
 
 Rebind_C-f,_too=Recombinar_C-f_também
 This_group_contains_all_entries._It_cannot_be_edited_or_removed.=Este_grupo_tem_todas_as_entradas._Ele_não_pode_ser_editado_ou_removido.
@@ -1602,3 +1601,20 @@ Decryption_not_supported.=
 Cleared_'%0'_for_%1_entries=
 Set_'%0'_to_'%1'_for_%2_entries=Definir_'%0'_'%1'_para_%2_registros
 Toggled_'%0'_for_%1_entries=
+
+Check_for_updates=
+Download_update=
+New_version_available=
+Installed_version=
+Remind_me_later=
+Ignore_this_update=
+Couldn't_connect_to_the_update_server.=
+Please_try_again_later_and/or_check_your_network_connection.=
+To_see_what's_new_view_the_changelog.=
+A_new_version_of_JabRef_has_been_released.=
+JabRef_is_up-to-date.=
+Latest_version=
+
+Please_open_%0_manually.=
+
+The_link_has_been_copied_to_the_clipboard.=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -1983,7 +1983,6 @@ Unable_to_find_the_requested_Look_&_Feel_and_thus_the_default_one_is_used.=Не_
 
 Opens_JabRef's_GitHub_page=Открывает_страницу_JabRef_на_GitHub
 Could_not_open_browser.=Не_удалось_открыть_браузер.
-Please_open_http\://github.com/JabRef/jabref_manually.=Откройте_ссылку_http\://github.com/JabRef/jabref_вручную.
 
 This_group_contains_all_entries._It_cannot_be_edited_or_removed.=Эта_группа_содержит_все_записи._Ее_удаление_или_изменение_невозможно.
 
@@ -2352,3 +2351,20 @@ Decryption_not_supported.=
 Cleared_'%0'_for_%1_entries=
 Set_'%0'_to_'%1'_for_%2_entries=Установить_'%0'_'%1'_для_%2_записей
 Toggled_'%0'_for_%1_entries=Изменение_'%0'_для_%1_записей
+
+Check_for_updates=
+Download_update=
+New_version_available=
+Installed_version=
+Remind_me_later=
+Ignore_this_update=
+Couldn't_connect_to_the_update_server.=
+Please_try_again_later_and/or_check_your_network_connection.=
+To_see_what's_new_view_the_changelog.=
+A_new_version_of_JabRef_has_been_released.=
+JabRef_is_up-to-date.=
+Latest_version=
+
+Please_open_%0_manually.=
+
+The_link_has_been_copied_to_the_clipboard.=

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -854,7 +854,6 @@ Please_enter_the_desired_name\:=Ange_det_önskade_namnet\:
 Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=
 Please_enter_the_string's_label=Ange_namnet_på_strängen
 Please_move_the_file_manually_and_link_in_place.=
-Please_open_http\://github.com/JabRef/jabref_manually.=
 Please_open_or_start_a_new_database_before_searching=
 Please_select_an_importer.=
 Please_select_exactly_one_group_to_move.=Välj_exakt_en_grupp_att_flytta.
@@ -1542,8 +1541,23 @@ Get_fulltext=
 Download_from_URL=Ladda_ned_från_URL
 Decryption_not_supported.=Avkryptering_stöds_ej.
 
-
-
 Cleared_'%0'_for_%1_entries=Rensade_'%0'_för_%1_poster
 Set_'%0'_to_'%1'_for_%2_entries=
 Toggled_'%0'_for_%1_entries=Växlade_'%0'_för_%1_poster
+
+Check_for_updates=
+Download_update=
+New_version_available=
+Installed_version=
+Remind_me_later=
+Ignore_this_update=
+Couldn't_connect_to_the_update_server.=
+Please_try_again_later_and/or_check_your_network_connection.=
+To_see_what's_new_view_the_changelog.=
+A_new_version_of_JabRef_has_been_released.=
+JabRef_is_up-to-date.=
+Latest_version=
+
+Please_open_%0_manually.=
+
+The_link_has_been_copied_to_the_clipboard.=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -1255,7 +1255,6 @@ Unable_to_find_the_requested_Look_&_Feel_and_thus_the_default_one_is_used.=Arzu_
 
 Could_not_open_browser.=Tarayıcı_açılamadı.
 Opens_JabRef's_GitHub_page=JabRef'in_GitHub_sayfasını_açar
-Please_open_http\://github.com/JabRef/jabref_manually.=Lütfen_http\://github.com/JabRef/jabref'i_manüel_olarak_açın.
 
 Rebind_C-f,_too=C-f'yi_de_tekrar_bağla
 This_group_contains_all_entries._It_cannot_be_edited_or_removed.=Bu_grup_tüm_girdileri_içeriyor._Düzenlenemez_ya_da_silinemez.
@@ -1621,3 +1620,20 @@ Decryption_not_supported.=Şifre_çözme_desteklenmiyor.
 Cleared_'%0'_for_%1_entries=
 Set_'%0'_to_'%1'_for_%2_entries=%2_girdiler_için_'%0'_'%1'a_ata
 Toggled_'%0'_for_%1_entries=%1_girdiler_için_'%0'_değiştirildi
+
+Check_for_updates=
+Download_update=
+New_version_available=
+Installed_version=
+Remind_me_later=
+Ignore_this_update=
+Couldn't_connect_to_the_update_server.=
+Please_try_again_later_and/or_check_your_network_connection.=
+To_see_what's_new_view_the_changelog.=
+A_new_version_of_JabRef_has_been_released.=
+JabRef_is_up-to-date.=
+Latest_version=
+
+Please_open_%0_manually.=
+
+The_link_has_been_copied_to_the_clipboard.=

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -2005,7 +2005,6 @@ Unable_to_find_the_requested_Look_&_Feel_and_thus_the_default_one_is_used.=
 
 Could_not_open_browser.=
 Opens_JabRef's_GitHub_page=
-Please_open_http\://github.com/JabRef/jabref_manually.=
 
 Rebind_C-f,_too=
 This_group_contains_all_entries._It_cannot_be_edited_or_removed.=
@@ -2376,3 +2375,20 @@ Decryption_not_supported.=
 Cleared_'%0'_for_%1_entries=
 Set_'%0'_to_'%1'_for_%2_entries=
 Toggled_'%0'_for_%1_entries=
+
+Check_for_updates=
+Download_update=
+New_version_available=
+Installed_version=
+Remind_me_later=
+Ignore_this_update=
+Couldn't_connect_to_the_update_server.=
+Please_try_again_later_and/or_check_your_network_connection.=
+To_see_what's_new_view_the_changelog.=
+A_new_version_of_JabRef_has_been_released.=
+JabRef_is_up-to-date.=
+Latest_version=
+
+Please_open_%0_manually.=
+
+The_link_has_been_copied_to_the_clipboard.=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -1312,7 +1312,6 @@ Unable_to_find_the_requested_Look_&_Feel_and_thus_the_default_one_is_used.=无�
 
 Could_not_open_browser.=无法打开浏览器。
 Opens_JabRef's_GitHub_page=打开_JabRef_在_GitHub_上的页面
-Please_open_http\://github.com/JabRef/jabref_manually.=请手动打开_http\://github.com/JabRef/jabref
 
 Rebind_C-f,_too=
 This_group_contains_all_entries._It_cannot_be_edited_or_removed.=这个组包含所有记录，不可以被编辑或移除。
@@ -1615,3 +1614,20 @@ Decryption_not_supported.=
 Cleared_'%0'_for_%1_entries=
 Set_'%0'_to_'%1'_for_%2_entries=
 Toggled_'%0'_for_%1_entries=
+
+Check_for_updates=
+Download_update=
+New_version_available=
+Installed_version=
+Remind_me_later=
+Ignore_this_update=
+Couldn't_connect_to_the_update_server.=
+Please_try_again_later_and/or_check_your_network_connection.=
+To_see_what's_new_view_the_changelog.=
+A_new_version_of_JabRef_has_been_released.=
+JabRef_is_up-to-date.=
+Latest_version=
+
+Please_open_%0_manually.=
+
+The_link_has_been_copied_to_the_clipboard.=

--- a/src/test/java/net/sf/jabref/logic/util/BuildInfoTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/BuildInfoTest.java
@@ -9,13 +9,13 @@ public class BuildInfoTest {
     @Test
     public void testDefaults() {
         BuildInfo buildInfo = new BuildInfo("asdf");
-        assertEquals("*unknown*", buildInfo.getVersion());
+        assertEquals("*unknown*", buildInfo.getVersion().getFullVersion());
     }
 
     @Test
     public void testFileImport() {
         BuildInfo buildInfo = new BuildInfo("/net/sf/jabref/util/build.properties");
-        assertEquals("42", buildInfo.getVersion());
+        assertEquals("42", buildInfo.getVersion().getFullVersion());
     }
 
 }

--- a/src/test/java/net/sf/jabref/logic/util/version/VersionTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/version/VersionTest.java
@@ -1,0 +1,127 @@
+package net.sf.jabref.logic.util.version;
+
+
+import net.sf.jabref.logic.util.BuildInfo;
+import net.sf.jabref.logic.util.Version;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class VersionTest {
+
+    @Test
+    public void unknownVersion() {
+        Version version = new Version(BuildInfo.UNKNOWN_VERSION);
+        assertEquals(BuildInfo.UNKNOWN_VERSION, version.getFullVersion());
+    }
+
+    @Test
+    public void versionOneDigit() {
+        String versionText = "1";
+        Version version = new Version(versionText);
+        assertEquals(versionText, version.getFullVersion());
+        assertEquals(1, version.getMajor());
+        assertEquals(0, version.getMinor());
+        assertEquals(0, version.getPatch());
+        assertFalse(version.isDevelopmentVersion());
+    }
+
+    @Test
+    public void versionTwoDigits() {
+        String versionText = "1.2";
+        Version version = new Version(versionText);
+        assertEquals(versionText, version.getFullVersion());
+        assertEquals(1, version.getMajor());
+        assertEquals(2, version.getMinor());
+        assertEquals(0, version.getPatch());
+        assertFalse(version.isDevelopmentVersion());
+    }
+
+    @Test
+    public void versionThreeDigits() {
+        String versionText = "1.2.3";
+        Version version = new Version(versionText);
+        assertEquals(versionText, version.getFullVersion());
+        assertEquals(1, version.getMajor());
+        assertEquals(2, version.getMinor());
+        assertEquals(3, version.getPatch());
+        assertFalse(version.isDevelopmentVersion());
+    }
+
+    @Test
+    public void versionOneDigitDevVersion() {
+        String versionText = "1dev";
+        Version version = new Version(versionText);
+        assertEquals(versionText, version.getFullVersion());
+        assertEquals(1, version.getMajor());
+        assertEquals(0, version.getMinor());
+        assertEquals(0, version.getPatch());
+        assertTrue(version.isDevelopmentVersion());
+    }
+
+    @Test
+    public void versionTwoDigitDevVersion() {
+        String versionText = "1.2dev";
+        Version version = new Version(versionText);
+        assertEquals(versionText, version.getFullVersion());
+        assertEquals(1, version.getMajor());
+        assertEquals(2, version.getMinor());
+        assertEquals(0, version.getPatch());
+        assertTrue(version.isDevelopmentVersion());
+    }
+
+    @Test
+    public void versionThreeDigitDevVersion() {
+        String versionText = "1.2.3dev";
+        Version version = new Version(versionText);
+        assertEquals(versionText, version.getFullVersion());
+        assertEquals(1, version.getMajor());
+        assertEquals(2, version.getMinor());
+        assertEquals(3, version.getPatch());
+        assertTrue(version.isDevelopmentVersion());
+    }
+
+    @Test
+    public void versionNewerThan() {
+        Version olderVersion = new Version("2.4");
+        Version newerVersion = new Version("4.2");
+        assertTrue(newerVersion.isNewerThan(olderVersion));
+    }
+
+    @Test
+    public void versionNewerThanDevTwoDigits() {
+        Version older = new Version("4.2");
+        Version newer = new Version("4.3dev");
+        assertTrue(newer.isNewerThan(older));
+    }
+
+    @Test
+    public void versionNewerThanDevThreeDigits() {
+        Version older = new Version("4.2.1");
+        Version newer = new Version("4.3dev");
+        assertTrue(newer.isNewerThan(older));
+    }
+
+    @Test
+    public void versionNewerPatch() {
+        Version older = new Version("4.2.1");
+        Version newer = new Version("4.2.2");
+        assertTrue(newer.isNewerThan(older));
+    }
+
+    @Test
+    public void changelogWithTwoDigits(){
+        Version version = new Version("3.4");
+        assertEquals("https://github.com/JabRef/jabref/blob/v3.4/CHANGELOG.md", version.getChangelogUrl());
+    }
+
+    @Test
+    public void changelogWithThreeDigits(){
+        Version version = new Version("3.4.1");
+        assertEquals("https://github.com/JabRef/jabref/blob/v3.4.1/CHANGELOG.md", version.getChangelogUrl());
+    }
+
+}


### PR DESCRIPTION
Implements #661.

The updater regularly checks if there is a new stable version of JabRef available [via github API](https://api.github.com/repos/JabRef/jabref/releases/latest).
If there is, a dialog will popup:

![newversion](https://cloud.githubusercontent.com/assets/15333371/15649011/86b17b5c-266e-11e6-97c4-e47cda603fa7.PNG)
- `Download update` points directly to [fosshub](http://www.fosshub.com/JabRef.html)
- `Ignore this update` will ignore this specific version on automatic version checks
- `Remind me later` will inform the user on the next version check (automatic or manual) of this version
- `View changelog` points directly to the changelog specific to this version (eg. v3.3 would point to https://github.com/JabRef/jabref/blob/v3.3/CHANGELOG.md)

Under `Help` there is another button to check for updates.

![updatetab](https://cloud.githubusercontent.com/assets/15333371/15649013/8e438c2a-266e-11e6-8cc6-07461176e8d1.png)
under preferences you can see:
- the current version
- when the version was last checked and a button to check it now
- if there's a new version available and a download button
- if a version was ignored and a button to unignore it
- you can also define how often the automatic check should occur
