### PR TITLE
Fix for #1450

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed [#1421](https://github.com/JabRef/jabref/issues/1421): Auto downloader should try to retrieve DOI if not present and fetch afterwards
 - Fixed [#1457](https://github.com/JabRef/jabref/issues/1457): Support multiple words inside LaTeX commands to RTF export
 - Entries retain their groupmembership when undoing their cut/deletion
+- Fixed [#1450](https://github.com/JabRef/jabref/issues/1450): EntryEditor is restored in the correct size after preference changes
 
 ### Removed
 - Removed possibility to export entries/databases to an `.sql` file, as the logic cannot easily use the correct escape logic

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -1518,6 +1518,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
     public void setupMainPanel() {
         splitPane = new JSplitPane(JSplitPane.VERTICAL_SPLIT);
         splitPane.setDividerSize(SPLIT_PANE_DIVIDER_SIZE);
+        adjustSplitter(); // restore last splitting state (before mainTable is created as creation affects the stored size of the entryEditors)
 
         // check whether a mainTable already existed and a floatSearch was active
         boolean floatSearchActive = (mainTable != null) && (this.tableModel.getSearchState() == MainTableDataModel.DisplayOption.FLOAT);


### PR DESCRIPTION
This fixes #1450 

After changing the preferences the mainTable is using a new `SplitPane` object to divide table and `EntryEditor` - in the course of creating the actual table existing entryEditors are closed which causes a saving of the current `EntryEditor` height in the prefs. As this is calculated based on the (already new) `SplitPane` a wrong value "1" is stored.

To prevent this the previous state of the divider for the SplitPane is restored based on the prefs before the mainTable is recreated.

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)

