### PR TITLE
LateXToUnicode Formatter does not handle commands correctly

### DIFF
--- a/src/test/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -46,8 +46,15 @@ public class LatexToUnicodeFormatterTest {
     }
 
     @Test
+    public void handleLaTeXCommandsWhichAreSubstrings() {
+        assertEquals("ç", formatter.format("$\\c{c}$"));
+        assertEquals("χ", formatter.format("$\\chi$"));
+    }
+
+    @Test
     public void testFormatStripLatexCommands() {
         assertEquals("-", formatter.format("\\mbox{-}"));
+        assertEquals("text", formatter.format("\\textit{text}"));
     }
 
     @Test


### PR DESCRIPTION
that are a substring of a special LaTex command like \c \~ \'...

A big problem is to support all kinds of special circumstances in LaTeX code.
The only chance to get the real output is to use the value of a real LaTeX run for stripping LaTeX commands and stuff. Can we somehow write a wrapper for this? Then we could transfer all the hard work to the LaTeX interpreter.

```tex  
\documentclass{article}
\begin{document}
$\chi$ some other italic \textit{text}
\end{document}
```

https://github.com/mcmtroffaes/latexcodec/