### PR TITLE
Add missing status translations for various specialfields

### DIFF
--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -963,15 +963,14 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         actions.put(Relevance.getInstance().getValues().get(0).getActionName(),
                 new SpecialFieldAction(frame, Relevance.getInstance(),
                         Relevance.getInstance().getValues().get(0).getFieldValue().get(), true,
-                        Localization.lang("Toggle relevance"), Localization.lang("Toggled relevance for %0 entries")));
+                        Localization.lang("Toggle relevance")));
         actions.put(Quality.getInstance().getValues().get(0).getActionName(),
                 new SpecialFieldAction(frame, Quality.getInstance(),
                         Quality.getInstance().getValues().get(0).getFieldValue().get(), true,
-                        Localization.lang("Toggle quality assured"),
-                        Localization.lang("Toggled quality for %0 entries")));
+                        Localization.lang("Toggle quality assured")));
         actions.put(Printed.getInstance().getValues().get(0).getActionName(), new SpecialFieldAction(frame,
                 Printed.getInstance(), Printed.getInstance().getValues().get(0).getFieldValue().get(), true,
-                Localization.lang("Toggle print status"), Localization.lang("Toggled print status for %0 entries")));
+                Localization.lang("Toggle print status")));
 
         for (SpecialFieldValue prio : Priority.getInstance().getValues()) {
             actions.put(prio.getActionName(), prio.getAction(this.frame));

--- a/src/main/java/net/sf/jabref/specialfields/Printed.java
+++ b/src/main/java/net/sf/jabref/specialfields/Printed.java
@@ -41,6 +41,11 @@ public class Printed extends SpecialField {
         return SpecialFieldsUtils.FIELDNAME_PRINTED;
     }
 
+    @Override
+    public String getLocalizedFieldName() {
+        return Localization.lang("Printed");
+    }
+
     public static Printed getInstance() {
         if (Printed.INSTANCE == null) {
             Printed.INSTANCE = new Printed();
@@ -51,21 +56,6 @@ public class Printed extends SpecialField {
     @Override
     public Icon getRepresentingIcon() {
         return this.getValues().get(0).getIcon();
-    }
-
-    @Override
-    public String getToolTip() {
-        return this.getValues().get(0).getToolTipText();
-    }
-
-    @Override
-    public String getMenuString() {
-        return Localization.lang("Printed");
-    }
-
-    @Override
-    public String getTextDone(String... params) {
-        return Localization.lang("Toggled print status for %0 entries", params);
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/specialfields/Printed.java
+++ b/src/main/java/net/sf/jabref/specialfields/Printed.java
@@ -34,7 +34,6 @@ public class Printed extends SpecialField {
         values.add(new SpecialFieldValue(this, "printed", "togglePrinted", Localization.lang("Toggle print status"), IconTheme.JabRefIcon.PRINTED.getSmallIcon(),
                 Localization.lang("Toggle print status")));
         this.setValues(values);
-        TEXT_DONE_PATTERN = "Toggled print status for %0 entries";
     }
 
     @Override
@@ -62,6 +61,11 @@ public class Printed extends SpecialField {
     @Override
     public String getMenuString() {
         return Localization.lang("Printed");
+    }
+
+    @Override
+    public String getTextDone(String... params) {
+        return Localization.lang("Toggled print status for %0 entries", params);
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/specialfields/Priority.java
+++ b/src/main/java/net/sf/jabref/specialfields/Priority.java
@@ -60,23 +60,12 @@ public class Priority extends SpecialField {
         return SpecialFieldsUtils.FIELDNAME_PRIORITY;
     }
 
+    @Override public String getLocalizedFieldName() {
+        return Localization.lang("Priority");
+    }
+
     @Override
     public Icon getRepresentingIcon() {
         return this.icon;
-    }
-
-    @Override
-    public String getToolTip() {
-        return Localization.lang("Priority");
-    }
-
-    @Override
-    public String getTextDone(String... params) {
-        return Localization.lang("Set priority to '%0' for %1 entries", params);
-    }
-
-    @Override
-    public String getMenuString() {
-        return Localization.lang("Priority");
     }
 }

--- a/src/main/java/net/sf/jabref/specialfields/Priority.java
+++ b/src/main/java/net/sf/jabref/specialfields/Priority.java
@@ -46,7 +46,6 @@ public class Priority extends SpecialField {
         values.add(new SpecialFieldValue(this, "prio3", "setPriority3", Localization.lang("Set priority to low"),
                 tmpicon, Localization.lang("Priority low")));
         this.setValues(values);
-        TEXT_DONE_PATTERN = "Set priority to '%0' for %1 entries";
     }
 
     public static Priority getInstance() {
@@ -69,6 +68,11 @@ public class Priority extends SpecialField {
     @Override
     public String getToolTip() {
         return Localization.lang("Priority");
+    }
+
+    @Override
+    public String getTextDone(String... params) {
+        return Localization.lang("Set priority to '%0' for %1 entries", params);
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/specialfields/Quality.java
+++ b/src/main/java/net/sf/jabref/specialfields/Quality.java
@@ -35,7 +35,6 @@ public class Quality extends SpecialField {
                 Localization.lang("Toggle quality assured"), IconTheme.JabRefIcon.QUALITY_ASSURED.getSmallIcon(),
                 Localization.lang("Toggle quality assured")));
         this.setValues(values);
-        TEXT_DONE_PATTERN = "Toggled quality for %0 entries";
     }
 
     @Override
@@ -58,6 +57,10 @@ public class Quality extends SpecialField {
     @Override
     public String getToolTip() {
         return this.getValues().get(0).getToolTipText();
+    }
+
+    @Override public String getTextDone(String... params) {
+        return Localization.lang("Toggled quality for %0 entries", params);
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/specialfields/Quality.java
+++ b/src/main/java/net/sf/jabref/specialfields/Quality.java
@@ -42,6 +42,11 @@ public class Quality extends SpecialField {
         return SpecialFieldsUtils.FIELDNAME_QUALITY;
     }
 
+    @Override
+    public String getLocalizedFieldName() {
+        return Localization.lang("Quality");
+    }
+
     public static Quality getInstance() {
         if (Quality.INSTANCE == null) {
             Quality.INSTANCE = new Quality();
@@ -52,20 +57,6 @@ public class Quality extends SpecialField {
     @Override
     public Icon getRepresentingIcon() {
         return IconTheme.JabRefIcon.QUALITY.getSmallIcon();
-    }
-
-    @Override
-    public String getToolTip() {
-        return this.getValues().get(0).getToolTipText();
-    }
-
-    @Override public String getTextDone(String... params) {
-        return Localization.lang("Toggled quality for %0 entries", params);
-    }
-
-    @Override
-    public String getMenuString() {
-        return Localization.lang("Quality");
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/specialfields/Rank.java
+++ b/src/main/java/net/sf/jabref/specialfields/Rank.java
@@ -58,18 +58,7 @@ public class Rank extends SpecialField {
         return SpecialFieldsUtils.FIELDNAME_RANKING;
     }
 
-    @Override
-    public String getToolTip() {
+    @Override public String getLocalizedFieldName() {
         return Localization.lang("Rank");
     }
-
-    @Override public String getTextDone(String... params) {
-        return Localization.lang("Set rank to '%0' for %1 entries", params);
-    }
-
-    @Override
-    public String getMenuString() {
-        return Localization.lang("Rank");
-    }
-
 }

--- a/src/main/java/net/sf/jabref/specialfields/Rank.java
+++ b/src/main/java/net/sf/jabref/specialfields/Rank.java
@@ -28,8 +28,6 @@ public class Rank extends SpecialField {
     private static Rank INSTANCE;
 
     private Rank() {
-        TEXT_DONE_PATTERN = "Set rank to '%0' for %1 entries";
-
         List<SpecialFieldValue> values = new ArrayList<>();
         // lab.setName("i");
         values.add(new SpecialFieldValue(this, null, "clearRank", Localization.lang("Clear rank"), null,
@@ -63,6 +61,10 @@ public class Rank extends SpecialField {
     @Override
     public String getToolTip() {
         return Localization.lang("Rank");
+    }
+
+    @Override public String getTextDone(String... params) {
+        return Localization.lang("Set rank to '%0' for %1 entries", params);
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/specialfields/ReadStatus.java
+++ b/src/main/java/net/sf/jabref/specialfields/ReadStatus.java
@@ -60,22 +60,12 @@ public class ReadStatus extends SpecialField {
     }
 
     @Override
+    public String getLocalizedFieldName() {
+        return Localization.lang("Read status");
+    }
+
+    @Override
     public Icon getRepresentingIcon() {
         return this.icon;
-    }
-
-    @Override
-    public String getToolTip() {
-        return Localization.lang("Read status");
-    }
-
-    @Override
-    public String getTextDone(String... params) {
-        return Localization.lang("Set read status to '%0' for %1 entries", params);
-    }
-
-    @Override
-    public String getMenuString() {
-        return Localization.lang("Read status");
     }
 }

--- a/src/main/java/net/sf/jabref/specialfields/ReadStatus.java
+++ b/src/main/java/net/sf/jabref/specialfields/ReadStatus.java
@@ -45,7 +45,6 @@ public class ReadStatus extends SpecialField {
                 Localization.lang("Set read status to skimmed"), tmpicon,
                 Localization.lang("Read status skimmed")));
         this.setValues(values);
-        TEXT_DONE_PATTERN = "Set read status to '%0' for %1 entries";
     }
 
     public static ReadStatus getInstance() {
@@ -68,6 +67,11 @@ public class ReadStatus extends SpecialField {
     @Override
     public String getToolTip() {
         return Localization.lang("Read status");
+    }
+
+    @Override
+    public String getTextDone(String... params) {
+        return Localization.lang("Set read status to '%0' for %1 entries", params);
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/specialfields/Relevance.java
+++ b/src/main/java/net/sf/jabref/specialfields/Relevance.java
@@ -42,6 +42,11 @@ public class Relevance extends SpecialField {
         return SpecialFieldsUtils.FIELDNAME_RELEVANCE;
     }
 
+    @Override
+    public String getLocalizedFieldName() {
+        return Localization.lang("Relevance");
+    }
+
     public static Relevance getInstance() {
         if (Relevance.INSTANCE == null) {
             Relevance.INSTANCE = new Relevance();
@@ -52,21 +57,6 @@ public class Relevance extends SpecialField {
     @Override
     public Icon getRepresentingIcon() {
         return this.getValues().get(0).getIcon();
-    }
-
-    @Override
-    public String getToolTip() {
-        return this.getValues().get(0).getToolTipText();
-    }
-
-    @Override
-    public String getTextDone(String... params) {
-        return Localization.lang("Toggled relevance for %0 entries", params);
-    }
-
-    @Override
-    public String getMenuString() {
-        return Localization.lang("Relevance");
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/specialfields/Relevance.java
+++ b/src/main/java/net/sf/jabref/specialfields/Relevance.java
@@ -35,7 +35,6 @@ public class Relevance extends SpecialField {
         values.add(new SpecialFieldValue(this, "relevant", "toggleRelevance", Localization.lang("Toggle relevance"), IconTheme.JabRefIcon.RELEVANCE.getSmallIcon(),
                 Localization.lang("Toggle relevance")));
         this.setValues(values);
-        TEXT_DONE_PATTERN = "Toggled relevance for %0 entries";
     }
 
     @Override
@@ -58,6 +57,11 @@ public class Relevance extends SpecialField {
     @Override
     public String getToolTip() {
         return this.getValues().get(0).getToolTipText();
+    }
+
+    @Override
+    public String getTextDone(String... params) {
+        return Localization.lang("Toggled relevance for %0 entries", params);
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/specialfields/SpecialField.java
+++ b/src/main/java/net/sf/jabref/specialfields/SpecialField.java
@@ -18,12 +18,18 @@ package net.sf.jabref.specialfields;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 
 import javax.swing.Icon;
 
 import net.sf.jabref.logic.l10n.Localization;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 public abstract class SpecialField {
+
+    private static final Log LOGGER = LogFactory.getLog(SpecialField.class);
 
     // currently, menuString is used for undo string
     // public static String TEXT_UNDO;
@@ -70,21 +76,23 @@ public abstract class SpecialField {
     }
 
     public String getTextDone(String... params) {
-        if(isSingleValueField()) {
-            if(params.length == 1 && params[0] != null) {
-                return Localization.lang("Toggled '%0' for %1 entries", getLocalizedFieldName(), params[0]);
-            }
+        Objects.requireNonNull(params);
+
+        if (isSingleValueField() && (params.length == 1) && (params[0] != null)) {
+            // Single value fields can be toggled only
+            return Localization.lang("Toggled '%0' for %1 entries", getLocalizedFieldName(), params[0]);
+        } else if (!isSingleValueField() && (params.length == 2) && (params[0] != null) && (params[1] != null)) {
+            // setting a multi value special field - the setted value is displayed, too
+            String[] allParams = {getLocalizedFieldName(), params[0], params[1]};
+            return Localization.lang("Set '%0' to '%1' for %2 entries", allParams);
+        } else if (!isSingleValueField() && (params.length == 1) && (params[0] != null)) {
+            // clearing a multi value specialfield
+            return Localization.lang("Cleared '%0' for %1 entries", getLocalizedFieldName(), params[0]);
         } else {
-            if (params.length == 2 && params[0] != null) {
-                String[] allParams = {getLocalizedFieldName(), params[0], params[1]};
-                return Localization.lang("Set '%0' to '%1' for %2 entries", allParams);
-            } else if (params.length == 1) {
-                return Localization.lang("Cleared '%0' for %1 entries", getLocalizedFieldName(), params[0]);
-            }
+            // invalid usage
+            LOGGER.info("Creation of special field status change message failed: illegal argument combination.");
+            return "";
         }
-
-         return "";
-
     }
 
     public boolean isSingleValueField() {

--- a/src/main/java/net/sf/jabref/specialfields/SpecialField.java
+++ b/src/main/java/net/sf/jabref/specialfields/SpecialField.java
@@ -15,6 +15,8 @@
  */
 package net.sf.jabref.specialfields;
 
+import net.sf.jabref.logic.l10n.Localization;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -55,13 +57,35 @@ public abstract class SpecialField {
 
     public abstract String getFieldName();
 
+    public abstract String getLocalizedFieldName();
+
     public abstract Icon getRepresentingIcon();
 
-    public abstract String getMenuString();
+    public String getMenuString() {
+        return getLocalizedFieldName();
+    }
 
-    public abstract String getToolTip();
+    public String getToolTip() {
+        return getLocalizedFieldName();
+    }
 
-    public abstract String getTextDone(String... params);
+    public String getTextDone(String... params) {
+        if(isSingleValueField()) {
+            if(params.length == 1 && params[0] != null) {
+                return Localization.lang("Toggled '%0' for %1 entries", getLocalizedFieldName(), params[0]);
+            }
+        } else {
+            if (params.length == 2 && params[0] != null) {
+                String[] allParams = {getLocalizedFieldName(), params[0], params[1]};
+                return Localization.lang("Set '%0' to '%1' for %2 entries", allParams);
+            } else if (params.length == 1) {
+                return Localization.lang("Cleared '%0' for %1 entries", getLocalizedFieldName(), params[0]);
+            }
+        }
+
+         return "";
+
+    }
 
     public boolean isSingleValueField() {
         return false;

--- a/src/main/java/net/sf/jabref/specialfields/SpecialField.java
+++ b/src/main/java/net/sf/jabref/specialfields/SpecialField.java
@@ -26,9 +26,6 @@ public abstract class SpecialField {
     // currently, menuString is used for undo string
     // public static String TEXT_UNDO;
 
-    // Plain string; NOT treated by Globals.lang
-    public String TEXT_DONE_PATTERN;
-
     private List<SpecialFieldValue> values;
     private List<String> keywords;
     private HashMap<String, SpecialFieldValue> map;
@@ -63,6 +60,8 @@ public abstract class SpecialField {
     public abstract String getMenuString();
 
     public abstract String getToolTip();
+
+    public abstract String getTextDone(String... params);
 
     public boolean isSingleValueField() {
         return false;

--- a/src/main/java/net/sf/jabref/specialfields/SpecialField.java
+++ b/src/main/java/net/sf/jabref/specialfields/SpecialField.java
@@ -15,13 +15,13 @@
  */
 package net.sf.jabref.specialfields;
 
-import net.sf.jabref.logic.l10n.Localization;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
 import javax.swing.Icon;
+
+import net.sf.jabref.logic.l10n.Localization;
 
 public abstract class SpecialField {
 

--- a/src/main/java/net/sf/jabref/specialfields/SpecialFieldAction.java
+++ b/src/main/java/net/sf/jabref/specialfields/SpecialFieldAction.java
@@ -71,7 +71,7 @@ public class SpecialFieldAction implements BaseAction {
                 frame.getCurrentBasePanel().markBaseChanged();
                 frame.getCurrentBasePanel().updateEntryEditorIfShowing();
                 String outText;
-                if (nullFieldIfValueIsTheSame) {
+                if (nullFieldIfValueIsTheSame || value==null) {
                     outText = specialField.getTextDone(Integer.toString(bes.size()));
                 } else {
                     outText = specialField.getTextDone(value, Integer.toString(bes.size()));

--- a/src/main/java/net/sf/jabref/specialfields/SpecialFieldAction.java
+++ b/src/main/java/net/sf/jabref/specialfields/SpecialFieldAction.java
@@ -29,8 +29,7 @@ import org.apache.commons.logging.LogFactory;
 public class SpecialFieldAction implements BaseAction {
 
     private final JabRefFrame frame;
-    private final String doneTextPattern;
-    private final SpecialField c;
+    private final SpecialField specialField;
     private final String value;
     private final boolean nullFieldIfValueIsTheSame;
     private final String undoText;
@@ -41,21 +40,18 @@ public class SpecialFieldAction implements BaseAction {
     /**
      *
      * @param nullFieldIfValueIsTheSame - false also causes that doneTextPattern has two place holders %0 for the value and %1 for the sum of entries
-     * @param doneTextPattern - the pattern to use to update status information shown in MainFrame
      */
     public SpecialFieldAction(
             JabRefFrame frame,
-            SpecialField c,
+            SpecialField specialField,
             String value,
             boolean nullFieldIfValueIsTheSame,
-            String undoText,
-            String doneTextPattern) {
+            String undoText) {
         this.frame = frame;
-        this.c = c;
+        this.specialField = specialField;
         this.value = value;
         this.nullFieldIfValueIsTheSame = nullFieldIfValueIsTheSame;
         this.undoText = undoText;
-        this.doneTextPattern = doneTextPattern;
     }
 
     @Override
@@ -68,7 +64,7 @@ public class SpecialFieldAction implements BaseAction {
             NamedCompound ce = new NamedCompound(undoText);
             for (BibEntry be : bes) {
                 // if (value==null) and then call nullField has been omitted as updatefield also handles value==null
-                SpecialFieldsUtils.updateField(c, value, be, ce, nullFieldIfValueIsTheSame);
+                SpecialFieldsUtils.updateField(specialField, value, be, ce, nullFieldIfValueIsTheSame);
             }
             ce.end();
             if (ce.hasEdits()) {
@@ -77,9 +73,9 @@ public class SpecialFieldAction implements BaseAction {
                 frame.getCurrentBasePanel().updateEntryEditorIfShowing();
                 String outText;
                 if (nullFieldIfValueIsTheSame) {
-                    outText = Localization.lang(doneTextPattern, Integer.toString(bes.size()));
+                    outText = specialField.getTextDone(Integer.toString(bes.size()));
                 } else {
-                    outText = Localization.lang(doneTextPattern, value, Integer.toString(bes.size()));
+                    outText = specialField.getTextDone(value, Integer.toString(bes.size()));
                 }
                 frame.output(outText);
             } else {

--- a/src/main/java/net/sf/jabref/specialfields/SpecialFieldAction.java
+++ b/src/main/java/net/sf/jabref/specialfields/SpecialFieldAction.java
@@ -20,7 +20,6 @@ import java.util.List;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.actions.BaseAction;
 import net.sf.jabref.gui.undo.NamedCompound;
-import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
 
 import org.apache.commons.logging.Log;

--- a/src/main/java/net/sf/jabref/specialfields/SpecialFieldValue.java
+++ b/src/main/java/net/sf/jabref/specialfields/SpecialFieldValue.java
@@ -107,8 +107,7 @@ public class SpecialFieldValue {
                     // if field contains only one value, it has to be nulled
                     // otherwise, another setting does not empty the field
                     this.field.getValues().size() == 1,
-                    this.getMenuString(),
-                    this.field.TEXT_DONE_PATTERN);
+                    this.getMenuString());
         }
         return action;
     }

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -1307,9 +1307,6 @@ Show_gridlines=
 Show_printed_status=
 Show_read_status=
 Table_row_height_padding=
-Toggled_quality_for_%0_entries=
-Toggled_print_status_for_%0_entries=
-Toggled_relevance_for_%0_entries=
 
 Marked_all_%0_selected_entries=
 Marked_selected_entry=
@@ -1688,6 +1685,6 @@ Download_from_URL=
 
 Decryption_not_supported.=
 
-Set_priority_to_'%0'_for_%1_entries=
-Set_rank_to_'%0'_for_%1_entries=
-Set_read_status_to_'%0'_for_%1_entries=
+Cleared_'%0'_for_%1_entries=
+Set_'%0'_to_'%1'_for_%2_entries=
+Toggled_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -1687,3 +1687,7 @@ Get_fulltext=
 Download_from_URL=
 
 Decryption_not_supported.=
+
+Set_priority_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=
+Set_read_status_to_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2403,3 +2403,7 @@ Get_fulltext=Hole_Volltext
 Download_from_URL=Download_von_URL
 
 Decryption_not_supported.=Entschlüsselung_wird_nicht_unterstützt.
+
+Set_priority_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=
+Set_read_status_to_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2015,9 +2015,6 @@ Show_gridlines=Gitternetzlinien_anzeigen
 Show_printed_status=Druckstatus_anzeigen
 Show_read_status=Lesestatus_anzeigen
 Table_row_height_padding=Zeilenabstand
-Toggled_quality_for_%0_entries=Qualität_für_%0_Einträge_umschalten
-Toggled_print_status_for_%0_entries=Druckstatus_für_%0_Einträge_umschalten
-Toggled_relevance_for_%0_entries=Relevanz_für_%0_Einträge_schalten
 Marked_all_%0_selected_entries=Alle_%0_Einträge_markiert
 
 Marked_selected_entry=Ausgewählten_Eintrag_markiert
@@ -2404,6 +2401,6 @@ Download_from_URL=Download_von_URL
 
 Decryption_not_supported.=Entschlüsselung_wird_nicht_unterstützt.
 
-Set_rank_to_'%0'_for_%1_entries=Rang_für_%1_Einträge_auf_'0%'_setzen
-Set_priority_to_'%0'_for_%1_entries=Priorität_für_%1_Einträge_auf_'%0'_setzen
-Set_read_status_to_'%0'_for_%1_entries=Lesestatus_für_%1_Einträge_auf_'%0'_setzen
+Cleared_'%0'_for_%1_entries='%0'_für_%1_Einträge_entfernt
+Set_'%0'_to_'%1'_for_%2_entries='%0'_für_%2_Einträge_auf_'%1'_gesetzt
+Toggled_'%0'_for_%1_entries='%0'_für_%1_Einträge_geändert

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2404,6 +2404,6 @@ Download_from_URL=Download_von_URL
 
 Decryption_not_supported.=Entschlüsselung_wird_nicht_unterstützt.
 
-Set_priority_to_'%0'_for_%1_entries=
-Set_rank_to_'%0'_for_%1_entries=
-Set_read_status_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=Rang_für_%1_Einträge_auf_'0%'_setzen
+Set_priority_to_'%0'_for_%1_entries=Priorität_für_%1_Einträge_auf_'%0'_setzen
+Set_read_status_to_'%0'_for_%1_entries=Lesestatus_für_%1_Einträge_auf_'%0'_setzen

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2259,3 +2259,7 @@ BibTeX_key=BibTeX_key
 Message=Message
 
 Decryption_not_supported.=Decryption_not_supported.
+
+Set_priority_to_'%0'_for_%1_entries=Set_priority_to_'%0'_for_%1_entries
+Set_rank_to_'%0'_for_%1_entries=Set_rank_to_'%0'_for_%1_entries
+Set_read_status_to_'%0'_for_%1_entries=Set_read_status_to_'%0'_for_%1_entries

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1921,9 +1921,6 @@ Show_gridlines=Show_gridlines
 Show_printed_status=Show_printed_status
 Show_read_status=Show_read_status
 Table_row_height_padding=Table_row_height_padding
-Toggled_quality_for_%0_entries=Toggled_quality_for_%0_entries
-Toggled_print_status_for_%0_entries=Toggled_print_status_for_%0_entries
-Toggled_relevance_for_%0_entries=Toggled_relevance_for_%0_entries
 
 Marked_selected_entry=Marked_selected_entry
 Marked_all_%0_selected_entries=Marked_all_%0_selected_entries
@@ -2260,6 +2257,6 @@ Message=Message
 
 Decryption_not_supported.=Decryption_not_supported.
 
-Set_priority_to_'%0'_for_%1_entries=Set_priority_to_'%0'_for_%1_entries
-Set_rank_to_'%0'_for_%1_entries=Set_rank_to_'%0'_for_%1_entries
-Set_read_status_to_'%0'_for_%1_entries=Set_read_status_to_'%0'_for_%1_entries
+Cleared_'%0'_for_%1_entries=Cleared_'%0'_for_%1_entries
+Set_'%0'_to_'%1'_for_%2_entries=Set_'%0'_to_'%1'_for_%2_entries
+Toggled_'%0'_for_%1_entries=Toggled_'%0'_for_%1_entries

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -1208,9 +1208,6 @@ Show_gridlines=Mostrar_líneas_de_rejilla
 Show_printed_status=Mostrar_estatus_de_impresion
 Show_read_status=Mostrar_estatus_de_lectura
 Table_row_height_padding=Relleno_de_altura_de_fila
-Toggled_quality_for_%0_entries=Cambiada_calidad_para_%0_entradas
-Toggled_print_status_for_%0_entries=Cambiado_estatus_de_impresion
-Toggled_relevance_for_%0_entries=Cambiada_relevancia_para_%0_entradas
 
 Marked_all_%0_selected_entries=Marcadas_todas_las_%0_entradas_seleccionadas
 Marked_selected_entry=Entrada_marcada_seleccionadas
@@ -1589,6 +1586,6 @@ Download_from_URL=
 
 Decryption_not_supported.=
 
-Set_rank_to_'%0'_for_%1_entries=Establecer_rango_a_'%0'_para_%1_entradas
-Set_priority_to_'%0'_for_%1_entries=Establecer_prioridad_a_'%0'_para_%1_entradas
-Set_read_status_to_'%0'_for_%1_entries=Establecer_estatus_de_lectura_a_'%0'_para_%1_entradas
+Cleared_'%0'_for_%1_entries=Ajustes_de_'%0'_para_%1_entradas
+Set_'%0'_to_'%1'_for_%2_entries=Establecer_'%0'_a_'%1'_para_%2_entradas
+Toggled_'%0'_for_%1_entries=Cambiada_'%0'_para_%1_entradas

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -1588,3 +1588,7 @@ Get_fulltext=
 Download_from_URL=
 
 Decryption_not_supported.=
+
+Set_priority_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=
+Set_read_status_to_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -1589,6 +1589,6 @@ Download_from_URL=
 
 Decryption_not_supported.=
 
-Set_priority_to_'%0'_for_%1_entries=
-Set_rank_to_'%0'_for_%1_entries=
-Set_read_status_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=Establecer_rango_a_'%0'_para_%1_entradas
+Set_priority_to_'%0'_for_%1_entries=Establecer_prioridad_a_'%0'_para_%1_entradas
+Set_read_status_to_'%0'_for_%1_entries=Establecer_estatus_de_lectura_a_'%0'_para_%1_entradas

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -1970,9 +1970,6 @@ Show_gridlines=
 Show_printed_status=
 Show_read_status=
 Table_row_height_padding=
-Toggled_quality_for_%0_entries=
-Toggled_print_status_for_%0_entries=
-Toggled_relevance_for_%0_entries=
 
 Marked_selected_entry=
 Marked_all_%0_selected_entries=
@@ -2375,6 +2372,6 @@ Download_from_URL=
 
 Decryption_not_supported.=
 
-Set_priority_to_'%0'_for_%1_entries=
-Set_rank_to_'%0'_for_%1_entries=
-Set_read_status_to_'%0'_for_%1_entries=
+Cleared_'%0'_for_%1_entries=
+Set_'%0'_to_'%1'_for_%2_entries=
+Toggled_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -2374,3 +2374,7 @@ Get_fulltext=
 Download_from_URL=
 
 Decryption_not_supported.=
+
+Set_priority_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=
+Set_read_status_to_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -1632,3 +1632,7 @@ Get_fulltext=Obtenir_le_document
 Download_from_URL=Télécharger_depuis_l'URL
 
 Decryption_not_supported.=Déchiffrement_non_supporté.
+
+Set_priority_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=
+Set_read_status_to_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -1247,9 +1247,6 @@ Show_gridlines=Afficher_la_grille
 Show_printed_status=Afficher_le_statut_d'impression
 Show_read_status=Afficher_le_statut_de_lecture
 Table_row_height_padding=Espacement_en_hauteur_des_rangées_de_tableau
-Toggled_quality_for_%0_entries=Vérification_de_qualité_modifiée_pour_%0_entrées
-Toggled_print_status_for_%0_entries=Statut_d'impression_modifié_pour_%0_entrées
-Toggled_relevance_for_%0_entries=Pertinence_modifiée_pour_%0_entrées
 
 Marked_all_%0_selected_entries=%0_entrées_sélectionnées_étiquetées
 Marked_selected_entry=Entrées_sélectionnées_étiquetées
@@ -1633,6 +1630,6 @@ Download_from_URL=Télécharger_depuis_l'URL
 
 Decryption_not_supported.=Déchiffrement_non_supporté.
 
-Set_rank_to_'%0'_for_%1_entries=Rang_mis_à_'%0'_pour_%1_entrées
-Set_priority_to_'%0'_for_%1_entries=Priorité_mise_à_'%0'_pour_%1_entrées
-Set_read_status_to_'%0'_for_%1_entries=Statut_de_lecture_mis_à_'%0'_pour_%1_entrées
+Cleared_'%0'_for_%1_entries=Réinitialisés_'%0'_pour_%1_entrées
+Set_'%0'_to_'%1'_for_%2_entries='%0'_mis_à_'%1'_pour_%2_entrées
+Toggled_'%0'_for_%1_entries='%0'_modifiée_pour_%1_entrées

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -1633,6 +1633,6 @@ Download_from_URL=Télécharger_depuis_l'URL
 
 Decryption_not_supported.=Déchiffrement_non_supporté.
 
-Set_priority_to_'%0'_for_%1_entries=
-Set_rank_to_'%0'_for_%1_entries=
-Set_read_status_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=Rang_mis_à_'%0'_pour_%1_entrées
+Set_priority_to_'%0'_for_%1_entries=Priorité_mise_à_'%0'_pour_%1_entrées
+Set_read_status_to_'%0'_for_%1_entries=Statut_de_lecture_mis_à_'%0'_pour_%1_entrées

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -1607,3 +1607,7 @@ Get_fulltext=
 Download_from_URL=
 
 Decryption_not_supported.=
+
+Set_priority_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=
+Set_read_status_to_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -1225,9 +1225,6 @@ Show_gridlines=Tampilkan_garis_kisi
 Show_printed_status=Tampilkan_status_pencetakan
 Show_read_status=Tampilkan_status_pembacaan
 Table_row_height_padding=Lapisan_tinggi_baris_tabel
-Toggled_quality_for_%0_entries=
-Toggled_print_status_for_%0_entries=
-Toggled_relevance_for_%0_entries=
 
 Marked_all_%0_selected_entries=Semua_%0_entri_pilihan_ditandai
 Marked_selected_entry=Entri_pilihan_ditandai
@@ -1608,6 +1605,6 @@ Download_from_URL=
 
 Decryption_not_supported.=
 
-Set_priority_to_'%0'_for_%1_entries=
-Set_rank_to_'%0'_for_%1_entries=
-Set_read_status_to_'%0'_for_%1_entries=
+Cleared_'%0'_for_%1_entries=
+Set_'%0'_to_'%1'_for_%2_entries=
+Toggled_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -1707,3 +1707,7 @@ Get_fulltext=
 Download_from_URL=
 
 Decryption_not_supported.=
+
+Set_priority_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=
+Set_read_status_to_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -1325,9 +1325,6 @@ Show_gridlines=Mostra_la_griglia
 Show_printed_status=Mostra_lo_stato_di_stampa
 Show_read_status=Mostra_lo_stato_di_lettura
 Table_row_height_padding=Altezza_delle_righe
-Toggled_quality_for_%0_entries=Modificata_la_valutazione_di_qualit\u00e0_per_'%0'_voce/i
-Toggled_print_status_for_%0_entries=Invertito_lo_stato_di_stampa_per_'%0'_voce/i
-Toggled_relevance_for_%0_entries=Modificata_la_valutazione_di_rilevanza_per_'%0'_voce/i
 
 Marked_all_%0_selected_entries=Contrassegnate_tutte_le_'%0'_voci_selezionate
 Marked_selected_entry=Contrassegnate_le_voci_selezionate
@@ -1708,6 +1705,6 @@ Download_from_URL=
 
 Decryption_not_supported.=
 
-Set_rank_to_'%0'_for_%1_entries=Valutazione_impostata_a_'%0'_per_'%1'_voce/i
-Set_priority_to_'%0'_for_%1_entries=Priorit\u00e0_impostata_a_'%0'_per_'%1'_voce/i
-Set_read_status_to_'%0'_for_%1_entries=Stato_di_lettura_impostato_a_'%0'_per_'%1'_voce/i
+Cleared_'%0'_for_%1_entries=Reinizializzati_'%0'_per_%1_voce/i
+Set_'%0'_to_'%1'_for_%2_entries='%0'_impostata_a_'%1'_per_%2_voce/i
+Toggled_'%0'_for_%1_entries=Modificata_la_valutazione_di_'%0'_per_%1_voce/i

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -1708,6 +1708,6 @@ Download_from_URL=
 
 Decryption_not_supported.=
 
-Set_priority_to_'%0'_for_%1_entries=
-Set_rank_to_'%0'_for_%1_entries=
-Set_read_status_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=Valutazione_impostata_a_'%0'_per_'%1'_voce/i
+Set_priority_to_'%0'_for_%1_entries=Priorit\u00e0_impostata_a_'%0'_per_'%1'_voce/i
+Set_read_status_to_'%0'_for_%1_entries=Stato_di_lettura_impostato_a_'%0'_per_'%1'_voce/i

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -1996,9 +1996,6 @@ Show_gridlines=グリッド線を表示
 Show_printed_status=印刷済情報を表示
 Show_read_status=既読情報を表示
 Table_row_height_padding=表の行高パディング
-Toggled_quality_for_%0_entries=%0個の項目の品質を変更しました
-Toggled_print_status_for_%0_entries=%0個の項目の印刷済情報を変更しました
-Toggled_relevance_for_%0_entries=%0個の項目の関連性を変更しました
 
 Marked_all_%0_selected_entries=%0個の選択項目全てに標識を付けました
 Marked_selected_entry=選択した項目に標識を付けました
@@ -2353,6 +2350,6 @@ Download_from_URL=URLからダウンロード
 
 Decryption_not_supported.=
 
-Set_rank_to_'%0'_for_%1_entries=%1個の項目の評価を「%0」に設定しました
-Set_priority_to_'%0'_for_%1_entries=%1個の項目の優先度を「%0」に設定しました
-Set_read_status_to_'%0'_for_%1_entries=%1個の項目の既読情報を「%0」に設定しました
+Cleared_'%0'_for_%1_entries=
+Set_'%0'_to_'%1'_for_%2_entries=
+Toggled_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2352,3 +2352,7 @@ Get_fulltext=フルテキストを得る
 Download_from_URL=URLからダウンロード
 
 Decryption_not_supported.=
+
+Set_priority_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=
+Set_read_status_to_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2353,6 +2353,6 @@ Download_from_URL=URLからダウンロード
 
 Decryption_not_supported.=
 
-Set_priority_to_'%0'_for_%1_entries=
-Set_rank_to_'%0'_for_%1_entries=
-Set_read_status_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=%1個の項目の評価を「%0」に設定しました
+Set_priority_to_'%0'_for_%1_entries=%1個の項目の優先度を「%0」に設定しました
+Set_read_status_to_'%0'_for_%1_entries=%1個の項目の既読情報を「%0」に設定しました

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -2383,3 +2383,7 @@ Get_fulltext=
 Download_from_URL=
 
 Decryption_not_supported.=
+
+Set_priority_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=
+Set_read_status_to_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -1998,9 +1998,6 @@ Show_gridlines=
 Show_printed_status=
 Show_read_status=
 Table_row_height_padding=
-Toggled_quality_for_%0_entries=
-Toggled_print_status_for_%0_entries=
-Toggled_relevance_for_%0_entries=
 
 Marked_all_%0_selected_entries=
 Marked_selected_entry=
@@ -2384,6 +2381,6 @@ Download_from_URL=
 
 Decryption_not_supported.=
 
-Set_priority_to_'%0'_for_%1_entries=
-Set_rank_to_'%0'_for_%1_entries=
-Set_read_status_to_'%0'_for_%1_entries=
+Cleared_'%0'_for_%1_entries=
+Set_'%0'_to_'%1'_for_%2_entries=
+Toggled_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -2393,9 +2393,6 @@ Show_gridlines=
 Show_printed_status=
 Show_read_status=
 Table_row_height_padding=
-Toggled_quality_for_%0_entries=
-Toggled_print_status_for_%0_entries=
-Toggled_relevance_for_%0_entries=
 
 Marked_all_%0_selected_entries=
 Marked_selected_entry=
@@ -2780,6 +2777,6 @@ Download_from_URL=
 
 Decryption_not_supported.=
 
-Set_priority_to_'%0'_for_%1_entries=
-Set_rank_to_'%0'_for_%1_entries=
-Set_read_status_to_'%0'_for_%1_entries=
+Cleared_'%0'_for_%1_entries=
+Set_'%0'_to_'%1'_for_%2_entries=
+Toggled_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -2779,3 +2779,7 @@ Get_fulltext=
 Download_from_URL=
 
 Decryption_not_supported.=
+
+Set_priority_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=
+Set_read_status_to_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -1602,6 +1602,6 @@ Download_from_URL=
 
 Decryption_not_supported.=
 
-Set_priority_to_'%0'_for_%1_entries=
-Set_rank_to_'%0'_for_%1_entries=
-Set_read_status_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=Definir_ranking_%0_para_%_registros
+Set_priority_to_'%0'_for_%1_entries=Definir_prioridade_%0_para_%1_registros
+Set_read_status_to_'%0'_for_%1_entries=Definir_status_de_leitura_%0_para_%1_registros

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -1601,3 +1601,7 @@ Get_fulltext=
 Download_from_URL=
 
 Decryption_not_supported.=
+
+Set_priority_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=
+Set_read_status_to_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -1222,9 +1222,6 @@ Show_gridlines=Mostrar_linhas_de_grade
 Show_printed_status=Mostrar_status_de_impressão
 Show_read_status=Mostrar_status_da_leitura
 Table_row_height_padding=Preenchimento_(padding)_da_altura_das_linhas_da_tabela
-Toggled_quality_for_%0_entries=Qualidade_de_%0_registros_foi_alternada
-Toggled_print_status_for_%0_entries=%0_registros_tiveram_seus_status_de_impressão_de_alternados
-Toggled_relevance_for_%0_entries=%0_registros_tiveram_sua_relevância_alternada
 
 Marked_all_%0_selected_entries=Marcadas_todos_os_%0_registros
 Marked_selected_entry=Registro_selecionado_marcado
@@ -1602,6 +1599,6 @@ Download_from_URL=
 
 Decryption_not_supported.=
 
-Set_rank_to_'%0'_for_%1_entries=Definir_ranking_%0_para_%_registros
-Set_priority_to_'%0'_for_%1_entries=Definir_prioridade_%0_para_%1_registros
-Set_read_status_to_'%0'_for_%1_entries=Definir_status_de_leitura_%0_para_%1_registros
+Cleared_'%0'_for_%1_entries=
+Set_'%0'_to_'%1'_for_%2_entries=Definir_'%0'_'%1'_para_%2_registros
+Toggled_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -1969,9 +1969,6 @@ Show_gridlines=Показать_сетку
 Show_printed_status=Показать_статус_'печать'
 Show_read_status=Показать_статус_'чтение'
 Table_row_height_padding=Отступ_по_высоте_для_строки_таблицы
-Toggled_quality_for_%0_entries=Изменение_качества_для_%0_записей
-Toggled_print_status_for_%0_entries=Статус_'печать'_изменен_для_%0_записей
-Toggled_relevance_for_%0_entries=Изменение_соответствия_для_%0_записей
 
 Marked_selected_entry=Отмечены_выбранные_записи
 Marked_all_%0_selected_entries=Отмечены_все_%0_выбранные_записи
@@ -2352,6 +2349,6 @@ Download_from_URL=
 
 Decryption_not_supported.=
 
-Set_rank_to_'%0'_for_%1_entries=Установить_ранг_'%0'_для_%1_записей
-Set_priority_to_'%0'_for_%1_entries=Установить_приоритет_'%0'_для_%1_записей
-Set_read_status_to_'%0'_for_%1_entries=Установить_статус_"чтение"_'%0'_для_%1_записей
+Cleared_'%0'_for_%1_entries=
+Set_'%0'_to_'%1'_for_%2_entries=Установить_'%0'_'%1'_для_%2_записей
+Toggled_'%0'_for_%1_entries=Изменение_'%0'_для_%1_записей

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2351,3 +2351,7 @@ Get_fulltext=
 Download_from_URL=
 
 Decryption_not_supported.=
+
+Set_priority_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=
+Set_read_status_to_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2352,6 +2352,6 @@ Download_from_URL=
 
 Decryption_not_supported.=
 
-Set_priority_to_'%0'_for_%1_entries=
-Set_rank_to_'%0'_for_%1_entries=
-Set_read_status_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=Установить_ранг_'%0'_для_%1_записей
+Set_priority_to_'%0'_for_%1_entries=Установить_приоритет_'%0'_для_%1_записей
+Set_read_status_to_'%0'_for_%1_entries=Установить_статус_"чтение"_'%0'_для_%1_записей

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -1204,9 +1204,6 @@ Toggle_entry_preview=Växla_postvisning
 Toggle_groups_interface=Växla_grupphantering
 Toggle_print_status=Växla_utskriftsstatus
 Toggle_relevance=Växla_relevans
-Toggled_print_status_for_%0_entries=Växlade_utskriftsstatus_för_%0_poster
-Toggled_quality_for_%0_entries=Växlade_kvalitet_för_%0_poster
-Toggled_relevance_for_%0_entries=Växlade_relevans_för_%0_poster
 Toggle_quality_assured=Växla_kvalitetssäkring
 Treatment_of_first_names=Hantering_av_förnamn
 Try_different_encoding=Prova_en_annan_teckenkodning
@@ -1547,6 +1544,6 @@ Decryption_not_supported.=Avkryptering_stöds_ej.
 
 
 
-Set_priority_to_'%0'_for_%1_entries=
-Set_rank_to_'%0'_for_%1_entries=
-Set_read_status_to_'%0'_for_%1_entries=
+Cleared_'%0'_for_%1_entries=Rensade_'%0'_för_%1_poster
+Set_'%0'_to_'%1'_for_%2_entries=
+Toggled_'%0'_for_%1_entries=Växlade_'%0'_för_%1_poster

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -1546,3 +1546,7 @@ Download_from_URL=Ladda_ned_från_URL
 Decryption_not_supported.=Avkryptering_stöds_ej.
 
 
+
+Set_priority_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=
+Set_read_status_to_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -1620,3 +1620,7 @@ Get_fulltext=Tammetni_getir
 Download_from_URL=URL'den_indir
 
 Decryption_not_supported.=Şifre_çözme_desteklenmiyor.
+
+Set_priority_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=
+Set_read_status_to_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -1621,6 +1621,6 @@ Download_from_URL=URL'den_indir
 
 Decryption_not_supported.=Şifre_çözme_desteklenmiyor.
 
-Set_priority_to_'%0'_for_%1_entries=
-Set_rank_to_'%0'_for_%1_entries=
-Set_read_status_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=%1_girdiler_için_rütbeyi_'%0'a_ata
+Set_priority_to_'%0'_for_%1_entries=%1_girdiler_için_önceliği_'%0'a_ata
+Set_read_status_to_'%0'_for_%1_entries=%1_girdiler_için_okunma_statüsü_'%0'_olarak_ayarlandı

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -1242,9 +1242,6 @@ Show_gridlines=Izgarayı_göster
 Show_printed_status=Yazdırma_statüsünü_göster
 Show_read_status=Okunma_statüsünü_göster
 Table_row_height_padding=Tablo_satır_yüksekliği_dolgusu
-Toggled_quality_for_%0_entries=%0_girdiler_için_kalite_değiştirildi
-Toggled_print_status_for_%0_entries=%0_girdiler_için_yazdırma_statüsü_değiştirildi
-Toggled_relevance_for_%0_entries=%0_girdiler_için_uygunluk_değiştirildi
 
 Marked_all_%0_selected_entries=Tüm_%0_seçilmiş_girdi_işaretlendi
 Marked_selected_entry=Seçilmiş_girdi_işaretlendi
@@ -1621,6 +1618,6 @@ Download_from_URL=URL'den_indir
 
 Decryption_not_supported.=Şifre_çözme_desteklenmiyor.
 
-Set_rank_to_'%0'_for_%1_entries=%1_girdiler_için_rütbeyi_'%0'a_ata
-Set_priority_to_'%0'_for_%1_entries=%1_girdiler_için_önceliği_'%0'a_ata
-Set_read_status_to_'%0'_for_%1_entries=%1_girdiler_için_okunma_statüsü_'%0'_olarak_ayarlandı
+Cleared_'%0'_for_%1_entries=
+Set_'%0'_to_'%1'_for_%2_entries=%2_girdiler_için_'%0'_'%1'a_ata
+Toggled_'%0'_for_%1_entries=%1_girdiler_için_'%0'_değiştirildi

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -2375,3 +2375,7 @@ Get_fulltext=
 Download_from_URL=
 
 Decryption_not_supported.=
+
+Set_priority_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=
+Set_read_status_to_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -1992,9 +1992,6 @@ Show_gridlines=
 Show_printed_status=
 Show_read_status=
 Table_row_height_padding=
-Toggled_quality_for_%0_entries=
-Toggled_print_status_for_%0_entries=
-Toggled_relevance_for_%0_entries=
 
 Marked_all_%0_selected_entries=
 Marked_selected_entry=
@@ -2376,6 +2373,6 @@ Download_from_URL=
 
 Decryption_not_supported.=
 
-Set_priority_to_'%0'_for_%1_entries=
-Set_rank_to_'%0'_for_%1_entries=
-Set_read_status_to_'%0'_for_%1_entries=
+Cleared_'%0'_for_%1_entries=
+Set_'%0'_to_'%1'_for_%2_entries=
+Toggled_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -1614,3 +1614,7 @@ Get_fulltext=
 Download_from_URL=
 
 Decryption_not_supported.=
+
+Set_priority_to_'%0'_for_%1_entries=
+Set_rank_to_'%0'_for_%1_entries=
+Set_read_status_to_'%0'_for_%1_entries=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -1299,9 +1299,6 @@ Show_gridlines=显示边框
 Show_printed_status=显示打印状态
 Show_read_status=显示已读状态
 Table_row_height_padding=表格行高
-Toggled_quality_for_%0_entries=
-Toggled_print_status_for_%0_entries=
-Toggled_relevance_for_%0_entries=
 
 Marked_all_%0_selected_entries=标记共_%0_条选中的记录
 Marked_selected_entry=标记选中的记录
@@ -1615,6 +1612,6 @@ Download_from_URL=
 
 Decryption_not_supported.=
 
-Set_priority_to_'%0'_for_%1_entries=
-Set_rank_to_'%0'_for_%1_entries=
-Set_read_status_to_'%0'_for_%1_entries=
+Cleared_'%0'_for_%1_entries=
+Set_'%0'_to_'%1'_for_%2_entries=
+Toggled_'%0'_for_%1_entries=


### PR DESCRIPTION
The status messages for some specialfields have not been translated correctly (missing localization has not been detected automatically as a variable has been used.)

- [x] Refactor Java code to directly use `Localization.lang` consistently for all SpecialFields
- [x] Lookup missing translations in previous releases 
- [x] fix NPE when clearing multivalue fields (Ranking, Priority, Read Status)