### PR TITLE
Refactor writing of bib files

### DIFF
--- a/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
+++ b/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
@@ -45,7 +45,7 @@ public class Benchmarks {
     private String htmlConversionString;
 
     @Setup
-    public void init() throws IOException {
+    public void init() throws Exception {
         Globals.prefs = JabRefPreferences.getInstance();
 
         Random randomizer = new Random();
@@ -79,7 +79,7 @@ public class Benchmarks {
     }
 
     @Benchmark
-    public String write() throws SaveException {
+    public String write() throws Exception {
         BibtexDatabaseWriter<StringSaveSession> databaseWriter = new BibtexDatabaseWriter<>(StringSaveSession::new);
         StringSaveSession saveSession = databaseWriter.savePartOfDatabase(
                 new BibDatabaseContext(database, new MetaData(), new Defaults()), database.getEntries(),

--- a/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
+++ b/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
@@ -2,7 +2,6 @@ package net.sf.jabref.benchmarks;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -13,8 +12,9 @@ import net.sf.jabref.Defaults;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
-import net.sf.jabref.exporter.BibDatabaseWriter;
+import net.sf.jabref.exporter.BibtexDatabaseWriter;
 import net.sf.jabref.exporter.SavePreferences;
+import net.sf.jabref.exporter.StringSaveSession;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.importer.fileformat.ParseException;
@@ -60,13 +60,11 @@ public class Benchmarks {
             entry.setField("rnd", "2" + randomizer.nextInt());
             database.insertEntry(entry);
         }
-        BibDatabaseWriter databaseWriter = new BibDatabaseWriter();
-        StringWriter stringWriter = new StringWriter();
-
-        databaseWriter.writePartOfDatabase(stringWriter,
+        BibtexDatabaseWriter<StringSaveSession> databaseWriter = new BibtexDatabaseWriter<>(StringSaveSession::new);
+        StringSaveSession saveSession = databaseWriter.savePartOfDatabase(
                 new BibDatabaseContext(database, new MetaData(), new Defaults()), database.getEntries(),
                 new SavePreferences());
-        bibtexString = stringWriter.toString();
+        bibtexString = saveSession.getStringValue();
 
         latexConversionString = "{A} \\textbf{bold} approach {\\it to} ${{\\Sigma}}{\\Delta}$ modulator \\textsuperscript{2} \\$";
 
@@ -81,14 +79,12 @@ public class Benchmarks {
     }
 
     @Benchmark
-    public String write() throws IOException {
-        StringWriter stringWriter = new StringWriter();
-
-        BibDatabaseWriter databaseWriter = new BibDatabaseWriter();
-        databaseWriter.writePartOfDatabase(stringWriter,
+    public String write() throws SaveException {
+        BibtexDatabaseWriter<StringSaveSession> databaseWriter = new BibtexDatabaseWriter<>(StringSaveSession::new);
+        StringSaveSession saveSession = databaseWriter.savePartOfDatabase(
                 new BibDatabaseContext(database, new MetaData(), new Defaults()), database.getEntries(),
                 new SavePreferences());
-        return stringWriter.toString();
+        return saveSession.getStringValue();
     }
 
     @Benchmark

--- a/src/main/java/net/sf/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/net/sf/jabref/cli/ArgumentProcessor.java
@@ -20,7 +20,9 @@ import net.sf.jabref.JabRefGUI;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.exporter.BibDatabaseWriter;
+import net.sf.jabref.exporter.BibtexDatabaseWriter;
 import net.sf.jabref.exporter.ExportFormats;
+import net.sf.jabref.exporter.FileSaveSession;
 import net.sf.jabref.exporter.IExportFormat;
 import net.sf.jabref.exporter.SaveException;
 import net.sf.jabref.exporter.SavePreferences;
@@ -286,7 +288,7 @@ public class ArgumentProcessor {
                 try {
                     System.out.println(Localization.lang("Saving") + ": " + subName);
                     SavePreferences prefs = SavePreferences.loadForSaveFromPreferences(Globals.prefs);
-                    BibDatabaseWriter databaseWriter = new BibDatabaseWriter();
+                    BibDatabaseWriter databaseWriter = new BibtexDatabaseWriter(FileSaveSession::new);
                     Defaults defaults = new Defaults(BibDatabaseMode
                             .fromPreference(Globals.prefs.getBoolean(JabRefPreferences.BIBLATEX_DEFAULT_MODE)));
                     SaveSession session = databaseWriter.saveDatabase(new BibDatabaseContext(newBase, defaults),
@@ -330,7 +332,7 @@ public class ArgumentProcessor {
                         SavePreferences prefs = SavePreferences.loadForSaveFromPreferences(Globals.prefs);
                         Defaults defaults = new Defaults(BibDatabaseMode.fromPreference(
                                 Globals.prefs.getBoolean(JabRefPreferences.BIBLATEX_DEFAULT_MODE)));
-                        BibDatabaseWriter databaseWriter = new BibDatabaseWriter();
+                        BibDatabaseWriter databaseWriter = new BibtexDatabaseWriter(FileSaveSession::new);
                         SaveSession session = databaseWriter.saveDatabase(
                                 new BibDatabaseContext(pr.getDatabase(), pr.getMetaData(), defaults), prefs);
 

--- a/src/main/java/net/sf/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/net/sf/jabref/cli/ArgumentProcessor.java
@@ -302,7 +302,7 @@ public class ArgumentProcessor {
                                         session.getEncoding().displayName())
                                 + " " + session.getWriter().getProblemCharacters());
                     }
-                    session.commit(new File(subName));
+                    session.commit(subName);
                 } catch (SaveException ex) {
                     System.err.println(
                             Localization.lang("Could not save file.") + "\n" + ex.getLocalizedMessage());
@@ -344,7 +344,7 @@ public class ArgumentProcessor {
                                             session.getEncoding().displayName())
                                     + " " + session.getWriter().getProblemCharacters());
                         }
-                        session.commit(new File(data[0]));
+                        session.commit(data[0]);
                     } catch (SaveException ex) {
                         System.err.println(
                                 Localization.lang("Could not save file.") + "\n" + ex.getLocalizedMessage());

--- a/src/main/java/net/sf/jabref/collab/ChangeScanner.java
+++ b/src/main/java/net/sf/jabref/collab/ChangeScanner.java
@@ -35,6 +35,8 @@ import net.sf.jabref.JabRefExecutorService;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.exporter.BibDatabaseWriter;
+import net.sf.jabref.exporter.BibtexDatabaseWriter;
+import net.sf.jabref.exporter.FileSaveSession;
 import net.sf.jabref.exporter.SaveException;
 import net.sf.jabref.exporter.SavePreferences;
 import net.sf.jabref.exporter.SaveSession;
@@ -164,7 +166,7 @@ public class ChangeScanner implements Runnable {
 
                 Defaults defaults = new Defaults(BibDatabaseMode
                         .fromPreference(Globals.prefs.getBoolean(JabRefPreferences.BIBLATEX_DEFAULT_MODE)));
-                BibDatabaseWriter databaseWriter = new BibDatabaseWriter();
+                BibDatabaseWriter databaseWriter = new BibtexDatabaseWriter(FileSaveSession::new);
                 SaveSession ss = databaseWriter.saveDatabase(new BibDatabaseContext(inTemp, mdInTemp, defaults), prefs);
                 ss.commit(Globals.getFileUpdateMonitor().getTempFile(panel.fileMonitorHandle()));
             } catch (SaveException ex) {

--- a/src/main/java/net/sf/jabref/collab/ChangeScanner.java
+++ b/src/main/java/net/sf/jabref/collab/ChangeScanner.java
@@ -17,6 +17,7 @@ package net.sf.jabref.collab;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -97,8 +98,8 @@ public class ChangeScanner implements Runnable {
         try {
 
             // Parse the temporary file.
-            File tempFile = Globals.getFileUpdateMonitor().getTempFile(panel.fileMonitorHandle());
-            ParserResult pr = OpenDatabaseAction.loadDatabase(tempFile, Globals.prefs.getDefaultEncoding());
+            Path tempFile = Globals.getFileUpdateMonitor().getTempFile(panel.fileMonitorHandle());
+            ParserResult pr = OpenDatabaseAction.loadDatabase(tempFile.toFile(), Globals.prefs.getDefaultEncoding());
             inTemp = pr.getDatabase();
             mdInTemp = pr.getMetaData();
             // Parse the modified file.

--- a/src/main/java/net/sf/jabref/collab/FileUpdateMonitor.java
+++ b/src/main/java/net/sf/jabref/collab/FileUpdateMonitor.java
@@ -17,6 +17,8 @@ package net.sf.jabref.collab;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -133,7 +135,7 @@ public class FileUpdateMonitor implements Runnable {
      * @throws IllegalArgumentException If the handle doesn't correspond to an entry.
      * @return File The temporary file.
      */
-    public File getTempFile(String key) throws IllegalArgumentException {
+    public Path getTempFile(String key) throws IllegalArgumentException {
         Object o = entries.get(key);
         if (o == null) {
             throw new IllegalArgumentException("Entry not found");
@@ -149,7 +151,7 @@ public class FileUpdateMonitor implements Runnable {
 
         private final FileUpdateListener listener;
         private final File file;
-        private final File tmpFile;
+        private final Path tmpFile;
         private long timeStamp;
         private long fileSize;
 
@@ -161,7 +163,7 @@ public class FileUpdateMonitor implements Runnable {
             fileSize = file.length();
             tmpFile = FileUpdateMonitor.getTempFile();
             if (tmpFile != null) {
-                tmpFile.deleteOnExit();
+                tmpFile.toFile().deleteOnExit();
                 copy();
             }
         }
@@ -194,9 +196,9 @@ public class FileUpdateMonitor implements Runnable {
 
             boolean res = false;
             try {
-                res = FileUtil.copyFile(file, tmpFile, true);
+                res = FileUtil.copyFile(file, tmpFile.toFile(), true);
             } catch (IOException ex) {
-                LOGGER.info("Cannot copy to temporary file '" + tmpFile.getPath() + '\'', ex);
+                LOGGER.info("Cannot copy to temporary file '" + tmpFile + '\'', ex);
             }
             return res;
         }
@@ -218,7 +220,7 @@ public class FileUpdateMonitor implements Runnable {
             listener.fileRemoved();
         }
 
-        public File getTmpFile() {
+        public Path getTmpFile() {
             return tmpFile;
         }
 
@@ -228,14 +230,14 @@ public class FileUpdateMonitor implements Runnable {
     }
 
 
-    private static synchronized File getTempFile() {
-        File f = null;
+    private static synchronized Path getTempFile() {
+        Path temporaryFile = null;
         try {
-            f = File.createTempFile("jabref", null);
-            f.deleteOnExit();
+            temporaryFile = Files.createTempFile("jabref", null);
+            temporaryFile.toFile().deleteOnExit();
         } catch (IOException ex) {
             LOGGER.warn("Could not create temporary file.", ex);
         }
-        return f;
+        return temporaryFile;
     }
 }

--- a/src/main/java/net/sf/jabref/exporter/AutoSaveManager.java
+++ b/src/main/java/net/sf/jabref/exporter/AutoSaveManager.java
@@ -96,7 +96,7 @@ public class AutoSaveManager {
                     .withMakeBackup(false)
                     .withEncoding(panel.getBibDatabaseContext().getMetaData().getEncoding());
 
-            BibDatabaseWriter databaseWriter = new BibDatabaseWriter();
+            BibDatabaseWriter databaseWriter = new BibtexDatabaseWriter(FileSaveSession::new);
             SaveSession ss = databaseWriter.saveDatabase(panel.getBibDatabaseContext(), prefs);
             ss.commit(backupFile);
         } catch (SaveException e) {

--- a/src/main/java/net/sf/jabref/exporter/AutoSaveManager.java
+++ b/src/main/java/net/sf/jabref/exporter/AutoSaveManager.java
@@ -98,7 +98,7 @@ public class AutoSaveManager {
 
             BibDatabaseWriter databaseWriter = new BibtexDatabaseWriter(FileSaveSession::new);
             SaveSession ss = databaseWriter.saveDatabase(panel.getBibDatabaseContext(), prefs);
-            ss.commit(backupFile);
+            ss.commit(backupFile.toPath());
         } catch (SaveException e) {
             LOGGER.error("Problem with automatic save", e);
             return false;

--- a/src/main/java/net/sf/jabref/exporter/BibDatabaseWriter.java
+++ b/src/main/java/net/sf/jabref/exporter/BibDatabaseWriter.java
@@ -69,12 +69,12 @@ public abstract class BibDatabaseWriter<E extends SaveSession> {
         List<FieldChange> changes = new ArrayList<>();
 
         Optional<FieldFormatterCleanups> saveActions = metaData.getSaveActions();
-        if (saveActions.isPresent()) {
+        saveActions.ifPresent(actions -> {
             // save actions defined -> apply for every entry
             for (BibEntry entry : toChange) {
-                changes.addAll(saveActions.get().applySaveActions(entry));
+                changes.addAll(actions.applySaveActions(entry));
             }
-        }
+        });
 
         return changes;
     }
@@ -104,11 +104,11 @@ public abstract class BibDatabaseWriter<E extends SaveSession> {
     }
 
     /*
-         * We have begun to use getSortedEntries() for both database save operations
-         * and non-database save operations.  In a non-database save operation
-         * (such as the exportDatabase call), we do not wish to use the
-         * global preference of saving in standard order.
-         */
+     * We have begun to use getSortedEntries() for both database save operations
+     * and non-database save operations.  In a non-database save operation
+     * (such as the exportDatabase call), we do not wish to use the
+     * global preference of saving in standard order.
+    */
     public static List<BibEntry> getSortedEntries(BibDatabaseContext bibDatabaseContext, List<BibEntry> entriesToSort,
             SavePreferences preferences) {
         Objects.requireNonNull(bibDatabaseContext);
@@ -241,14 +241,6 @@ public abstract class BibDatabaseWriter<E extends SaveSession> {
     protected abstract void writeMetaDataItem(Map.Entry<String, String> metaItem) throws SaveException;
 
     protected abstract void writePreamble(String preamble) throws SaveException;
-
-    private void writeUserCommentsForString(BibtexString string, Writer out) throws IOException {
-        String userComments = string.getUserComments();
-
-        if(!userComments.isEmpty()) {
-            out.write(userComments + Globals.NEWLINE);
-        }
-    }
 
     /**
      * Write all strings in alphabetical order, modified to produce a safe (for

--- a/src/main/java/net/sf/jabref/exporter/BibDatabaseWriter.java
+++ b/src/main/java/net/sf/jabref/exporter/BibDatabaseWriter.java
@@ -229,9 +229,7 @@ public abstract class BibDatabaseWriter<E extends SaveSession> {
      * Writes all data to the specified writer, using each object's toString() method.
      */
     protected void writeMetaData(MetaData metaData) throws SaveException {
-        if (metaData == null) {
-            return;
-        }
+        Objects.requireNonNull(metaData);
 
         Map<String, String> serializedMetaData = metaData.getAsStringMap();
 
@@ -296,10 +294,12 @@ public abstract class BibDatabaseWriter<E extends SaveSession> {
             String foundLabel = m.group(1);
             int restIndex = content.indexOf(foundLabel) + foundLabel.length();
             content = content.substring(restIndex);
-            Object referred = remaining.get(foundLabel.substring(1, foundLabel.length() - 1));
+            String label = foundLabel.substring(1, foundLabel.length() - 1);
+
             // If the label we found exists as a key in the "remaining" Map, we go on and write it now:
-            if (referred != null) {
-                writeString((BibtexString) referred, isFirstString, remaining, maxKeyLength, reformatFile);
+            if (remaining.containsKey(label)) {
+                BibtexString referred = remaining.get(label);
+                writeString(referred, isFirstString, remaining, maxKeyLength, reformatFile);
             }
         }
 

--- a/src/main/java/net/sf/jabref/exporter/BibtexDatabaseWriter.java
+++ b/src/main/java/net/sf/jabref/exporter/BibtexDatabaseWriter.java
@@ -87,10 +87,16 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
     @Override
     protected void writeString(BibtexString bibtexString, boolean isFirstString, int maxKeyLength, Boolean reformatFile) throws SaveException {
         try {
-            //if the string has not been modified, write it back as it was
+            // If the string has not been modified, write it back as it was
             if (!reformatFile && !bibtexString.hasChanged()) {
                 getWriter().write(bibtexString.getParsedSerialization());
                 return;
+            }
+
+            // Write user comments
+            String userComments = bibtexString.getUserComments();
+            if(!userComments.isEmpty()) {
+                getWriter().write(userComments + Globals.NEWLINE);
             }
 
             if (isFirstString) {

--- a/src/main/java/net/sf/jabref/exporter/BibtexDatabaseWriter.java
+++ b/src/main/java/net/sf/jabref/exporter/BibtexDatabaseWriter.java
@@ -1,0 +1,162 @@
+/*  Copyright (C) 2003-2016 JabRef contributors.
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along
+ with this program; if not, write to the Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+package net.sf.jabref.exporter;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+import net.sf.jabref.BibDatabaseContext;
+import net.sf.jabref.Globals;
+import net.sf.jabref.MetaData;
+import net.sf.jabref.logic.bibtex.BibEntryWriter;
+import net.sf.jabref.logic.bibtex.LatexFieldFormatter;
+import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.model.database.BibDatabaseMode;
+import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.model.entry.BibtexString;
+import net.sf.jabref.model.entry.CustomEntryType;
+
+public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWriter<E> {
+
+    private static final String STRING_PREFIX = "@String";
+    private static final String COMMENT_PREFIX = "@Comment";
+    private static final String PREAMBLE_PREFIX = "@Preamble";
+
+    public BibtexDatabaseWriter(SaveSessionFactory<E> saveSessionFactory) {
+        super(saveSessionFactory);
+    }
+
+    @Override
+    protected void writeEpilogue(String epilogue) throws SaveException {
+        if (!StringUtil.isNullOrEmpty(epilogue)) {
+            try {
+                getWriter().write(Globals.NEWLINE);
+                getWriter().write(epilogue);
+                getWriter().write(Globals.NEWLINE);
+            } catch (IOException e) {
+                throw new SaveException(e);
+            }
+        }
+    }
+
+    @Override
+    protected void writeMetaDataItem(Map.Entry<String, String> metaItem) throws SaveException {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append(Globals.NEWLINE);
+        stringBuilder.append(COMMENT_PREFIX + "{").append(MetaData.META_FLAG).append(metaItem.getKey()).append(":");
+        stringBuilder.append(metaItem.getValue());
+        stringBuilder.append("}");
+        stringBuilder.append(Globals.NEWLINE);
+
+        try {
+            getWriter().write(stringBuilder.toString());
+        } catch (IOException e) {
+            throw new SaveException(e);
+        }
+    }
+
+    @Override
+    protected void writePreamble(String preamble) throws SaveException {
+        if (!StringUtil.isNullOrEmpty(preamble)) {
+            try {
+                getWriter().write(Globals.NEWLINE);
+                getWriter().write(PREAMBLE_PREFIX + "{");
+                getWriter().write(preamble);
+                getWriter().write('}' + Globals.NEWLINE);
+            } catch (IOException e) {
+                throw new SaveException(e);
+            }
+        }
+    }
+
+    @Override
+    protected void writeString(BibtexString bibtexString, boolean isFirstString, int maxKeyLength, Boolean reformatFile) throws SaveException {
+        try {
+            //if the string has not been modified, write it back as it was
+            if (!reformatFile && !bibtexString.hasChanged()) {
+                getWriter().write(bibtexString.getParsedSerialization());
+                return;
+            }
+
+            if (isFirstString) {
+                getWriter().write(Globals.NEWLINE);
+            }
+
+            getWriter().write(STRING_PREFIX + "{" + bibtexString.getName() + StringUtil
+                    .repeatSpaces(maxKeyLength - bibtexString.getName().length()) + " = ");
+            if (bibtexString.getContent().isEmpty()) {
+                getWriter().write("{}");
+            } else {
+                try {
+                    String formatted = new LatexFieldFormatter().format(bibtexString.getContent(), LatexFieldFormatter.BIBTEX_STRING);
+                    getWriter().write(formatted);
+                } catch (IllegalArgumentException ex) {
+                    throw new IllegalArgumentException(
+                            "The # character is not allowed in BibTeX strings unless escaped as in '\\#'.\n" + "Before saving, please edit any strings containing the # character.");
+                }
+            }
+
+            getWriter().write("}" + Globals.NEWLINE);
+        } catch (IOException e) {
+            throw new SaveException(e);
+        }
+    }
+
+    @Override
+    protected void writeEntryTypeDefinition(CustomEntryType customType) throws SaveException {
+        try {
+            getWriter().write(Globals.NEWLINE);
+            getWriter().write(COMMENT_PREFIX + "{");
+            getWriter().write(customType.getAsString());
+            getWriter().write("}");
+            getWriter().write(Globals.NEWLINE);
+        } catch (IOException e) {
+            throw new SaveException(e);
+        }
+    }
+
+    @Override
+    protected void writePrelogue(BibDatabaseContext bibDatabaseContext, Charset encoding) throws SaveException {
+        if(encoding == null) {
+            return;
+        }
+
+        // Writes the file encoding information.
+        try {
+            getWriter().write("% ");
+            getWriter().write(Globals.ENCODING_PREFIX + encoding);
+            getWriter().write(Globals.NEWLINE);
+        } catch (IOException e) {
+            throw new SaveException(e);
+        }
+    }
+
+    @Override
+    protected void writeEntry(BibEntry entry, BibDatabaseMode mode, Boolean isReformatFile) throws SaveException {
+        BibEntryWriter bibtexEntryWriter = new BibEntryWriter(new LatexFieldFormatter(), true);
+        try {
+            bibtexEntryWriter.write(entry, getWriter(), mode, isReformatFile);
+        } catch (IOException e) {
+            throw new SaveException(e, entry);
+        }
+    }
+
+    private Writer getWriter() {
+        return getActiveSession().getWriter();
+    }
+}

--- a/src/main/java/net/sf/jabref/exporter/ExportFormat.java
+++ b/src/main/java/net/sf/jabref/exporter/ExportFormat.java
@@ -190,15 +190,15 @@ public class ExportFormat implements IExportFormat {
         SaveSession ss = null;
         if (this.encoding != null) {
             try {
-                ss = new SaveSession(this.encoding, false);
-            } catch (IOException ex) {
+                ss = new FileSaveSession(this.encoding, false);
+            } catch (SaveException ex) {
                 // Perhaps the overriding encoding doesn't work?
                 // We will fall back on the default encoding.
                 LOGGER.warn("Can not get save session.", ex);
             }
         }
         if (ss == null) {
-            ss = new SaveSession(encoding, false);
+            ss = new FileSaveSession(encoding, false);
         }
 
         try (VerifyingWriter ps = ss.getWriter()) {

--- a/src/main/java/net/sf/jabref/exporter/ExportFormat.java
+++ b/src/main/java/net/sf/jabref/exporter/ExportFormat.java
@@ -24,6 +24,7 @@ import java.io.Reader;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -186,7 +187,7 @@ public class ExportFormat implements IExportFormat {
         if (entries.isEmpty()) { // Do not export if no entries to export -- avoids exports with only template text
             return;
         }
-        File outFile = new File(file);
+        Path outFile = Paths.get(file);
         SaveSession ss = null;
         if (this.encoding != null) {
             try {
@@ -369,7 +370,7 @@ public class ExportFormat implements IExportFormat {
         return fileFilter;
     }
 
-    public void finalizeSaveSession(final SaveSession ss, File file) throws SaveException, IOException {
+    public void finalizeSaveSession(final SaveSession ss, Path file) throws SaveException, IOException {
         ss.getWriter().flush();
         ss.getWriter().close();
 

--- a/src/main/java/net/sf/jabref/exporter/FileSaveSession.java
+++ b/src/main/java/net/sf/jabref/exporter/FileSaveSession.java
@@ -1,0 +1,144 @@
+/*  Copyright (C) 2003-2015 JabRef contributors.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+package net.sf.jabref.exporter;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import net.sf.jabref.Globals;
+import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.io.FileBasedLock;
+import net.sf.jabref.logic.util.io.FileUtil;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Class used to handle safe storage to disk.
+ * <p>
+ * Usage: create a SaveSession giving the file to save to, the encoding, and whether to make a backup. The SaveSession
+ * will provide a Writer to store to, which actually goes to a temporary file. The Writer keeps track of whether all
+ * characters could be saved, and if not, which characters were not encodable.
+ * <p>
+ * After saving is finished, the client should close the Writer. If the save should be put into effect, call commit(),
+ * otherwise call cancel(). When canceling, the temporary file is simply deleted and the target file remains unchanged.
+ * When committing, the temporary file is copied to the target file after making a backup if requested and if the target
+ * file already existed, and finally the temporary file is deleted.
+ * <p>
+ * If committing fails, the temporary file will not be deleted.
+ */
+public class FileSaveSession extends SaveSession {
+
+    private static final Log LOGGER = LogFactory.getLog(FileSaveSession.class);
+
+    // Filenames.
+    private static final String BACKUP_EXTENSION = ".bak";
+    private static final String TEMP_PREFIX = "jabref";
+    private static final String TEMP_SUFFIX = "save.bib";
+    private final boolean useLockFile;
+    private Path temporaryFile;
+
+    public FileSaveSession(Charset encoding, boolean backup) throws SaveException {
+        this(encoding, backup, createTemporaryFile());
+    }
+
+    public FileSaveSession(Charset encoding, boolean backup, Path temporaryFile) throws SaveException {
+        super(encoding, backup, getWriterForFile(encoding, temporaryFile));
+        this.temporaryFile = temporaryFile;
+        this.useLockFile = Globals.prefs.getBoolean(JabRefPreferences.USE_LOCK_FILES);
+    }
+
+    private static VerifyingWriter getWriterForFile(Charset encoding, Path file) throws SaveException {
+        try {
+            return new VerifyingWriter(new FileOutputStream(file.toFile()), encoding);
+        } catch (FileNotFoundException e) {
+            throw new SaveException(e);
+        }
+    }
+
+    private static Path createTemporaryFile() throws SaveException {
+        try {
+            return Files.createTempFile(FileSaveSession.TEMP_PREFIX, FileSaveSession.TEMP_SUFFIX);
+        } catch (IOException e) {
+            throw new SaveException(e);
+        }
+    }
+
+    @Override
+    public void commit(File file) throws SaveException {
+        if (file == null) {
+            return;
+        }
+        if (file.exists() && backup) {
+            String name = file.getName();
+            String path = file.getParent();
+            File backupFile = new File(path, name + BACKUP_EXTENSION);
+            try {
+                FileUtil.copyFile(file, backupFile, true);
+            } catch (IOException ex) {
+                LOGGER.error("Problem copying file", ex);
+                throw SaveException.BACKUP_CREATION;
+            }
+        }
+        try {
+            if (useLockFile) {
+                try {
+                    if (FileBasedLock.createLockFile(file)) {
+                        // Oops, the lock file already existed. Try to wait it out:
+                        if (!FileBasedLock.waitForFileLock(file, 10)) {
+                            throw SaveException.FILE_LOCKED;
+                        }
+                    }
+                } catch (IOException ex) {
+                    LOGGER.error("Error when creating lock file.", ex);
+                }
+            }
+
+            FileUtil.copyFile(temporaryFile.toFile(), file, true);
+        } catch (IOException ex2) {
+            // If something happens here, what can we do to correct the problem? The file is corrupted, but we still
+            // have a clean copy in tmp. However, we just failed to copy tmp to file, so it's not likely that
+            // repeating the action will have a different result.
+            // On the other hand, our temporary file should still be clean, and won't be deleted.
+            throw new SaveException("Save failed while committing changes: " + ex2.getMessage(),
+                    Localization.lang("Save failed while committing changes: %0", ex2.getMessage()));
+        } finally {
+            if (useLockFile) {
+                FileBasedLock.deleteLockFile(file);
+            }
+        }
+        try {
+            Files.delete(temporaryFile);
+        } catch (IOException e) {
+            LOGGER.warn("Cannot delete temporary file", e);
+        }
+    }
+
+    @Override
+    public void cancel() {
+        try {
+            Files.delete(temporaryFile);
+        } catch (IOException e) {
+            LOGGER.warn("Cannot delete temporary file", e);
+        }
+    }
+}

--- a/src/main/java/net/sf/jabref/exporter/FileSaveSession.java
+++ b/src/main/java/net/sf/jabref/exporter/FileSaveSession.java
@@ -15,7 +15,6 @@
 */
 package net.sf.jabref.exporter;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -84,16 +83,15 @@ public class FileSaveSession extends SaveSession {
     }
 
     @Override
-    public void commit(File file) throws SaveException {
+    public void commit(Path file) throws SaveException {
         if (file == null) {
             return;
         }
-        if (file.exists() && backup) {
-            String name = file.getName();
-            String path = file.getParent();
-            File backupFile = new File(path, name + BACKUP_EXTENSION);
+        if (backup && Files.exists(file)) {
+            Path fileName = file.getFileName();
+            Path backupFile = file.resolveSibling(fileName + BACKUP_EXTENSION);
             try {
-                FileUtil.copyFile(file, backupFile, true);
+                FileUtil.copyFile(file.toFile(), backupFile.toFile(), true);
             } catch (IOException ex) {
                 LOGGER.error("Problem copying file", ex);
                 throw SaveException.BACKUP_CREATION;
@@ -113,7 +111,7 @@ public class FileSaveSession extends SaveSession {
                 }
             }
 
-            FileUtil.copyFile(temporaryFile.toFile(), file, true);
+            FileUtil.copyFile(temporaryFile.toFile(), file.toFile(), true);
         } catch (IOException ex2) {
             // If something happens here, what can we do to correct the problem? The file is corrupted, but we still
             // have a clean copy in tmp. However, we just failed to copy tmp to file, so it's not likely that

--- a/src/main/java/net/sf/jabref/exporter/MSBibExportFormat.java
+++ b/src/main/java/net/sf/jabref/exporter/MSBibExportFormat.java
@@ -15,10 +15,10 @@
 */
 package net.sf.jabref.exporter;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
 
@@ -66,7 +66,7 @@ class MSBibExportFormat extends ExportFormat {
             } catch (TransformerException | IllegalArgumentException | TransformerFactoryConfigurationError e) {
                 throw new Error(e);
             }
-            finalizeSaveSession(session, new File(file));
+            finalizeSaveSession(session, Paths.get(file));
         } catch (IOException ex) {
             throw new SaveException(ex);
         }

--- a/src/main/java/net/sf/jabref/exporter/MSBibExportFormat.java
+++ b/src/main/java/net/sf/jabref/exporter/MSBibExportFormat.java
@@ -45,7 +45,7 @@ class MSBibExportFormat extends ExportFormat {
 
     @Override
     public void performExport(final BibDatabaseContext databaseContext, final String file,
-            final Charset encoding, List<BibEntry> entries) throws IOException {
+            final Charset encoding, List<BibEntry> entries) throws SaveException {
         Objects.requireNonNull(databaseContext);
         Objects.requireNonNull(entries);
 
@@ -53,7 +53,7 @@ class MSBibExportFormat extends ExportFormat {
             return;
         }
         // forcing to use UTF8 output format for some problems with xml export in other encodings
-        SaveSession session = new SaveSession(StandardCharsets.UTF_8, false);
+        SaveSession session = new FileSaveSession(StandardCharsets.UTF_8, false);
         MSBibDatabase msBibDatabase = new MSBibDatabase(databaseContext.getDatabase(), entries);
 
         try (VerifyingWriter ps = session.getWriter()) {
@@ -67,8 +67,8 @@ class MSBibExportFormat extends ExportFormat {
                 throw new Error(e);
             }
             finalizeSaveSession(session, new File(file));
-        } catch (SaveException | IOException ex) {
-            throw new IOException(ex.getMessage());
+        } catch (IOException ex) {
+            throw new SaveException(ex);
         }
     }
 }

--- a/src/main/java/net/sf/jabref/exporter/ModsExportFormat.java
+++ b/src/main/java/net/sf/jabref/exporter/ModsExportFormat.java
@@ -15,10 +15,10 @@
 */
 package net.sf.jabref.exporter;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
 
@@ -65,7 +65,7 @@ class ModsExportFormat extends ExportFormat {
             } catch (TransformerException | IllegalArgumentException | TransformerFactoryConfigurationError e) {
                 throw new Error(e);
             }
-            finalizeSaveSession(ss, new File(file));
+            finalizeSaveSession(ss, Paths.get(file));
         } catch (IOException ex) {
             throw new SaveException(ex);
         }

--- a/src/main/java/net/sf/jabref/exporter/ModsExportFormat.java
+++ b/src/main/java/net/sf/jabref/exporter/ModsExportFormat.java
@@ -45,14 +45,14 @@ class ModsExportFormat extends ExportFormat {
 
     @Override
     public void performExport(final BibDatabaseContext databaseContext, final String file,
-            final Charset encoding, List<BibEntry> entries) throws IOException {
+            final Charset encoding, List<BibEntry> entries) throws SaveException {
         Objects.requireNonNull(databaseContext);
         Objects.requireNonNull(entries);
         if (entries.isEmpty()) { // Only export if entries exist
             return;
         }
 
-        SaveSession ss = new SaveSession(StandardCharsets.UTF_8, false);
+        SaveSession ss = new FileSaveSession(StandardCharsets.UTF_8, false);
         try (VerifyingWriter ps = ss.getWriter()) {
             MODSDatabase md = new MODSDatabase(databaseContext.getDatabase(), entries);
 
@@ -66,8 +66,8 @@ class ModsExportFormat extends ExportFormat {
                 throw new Error(e);
             }
             finalizeSaveSession(ss, new File(file));
-        } catch (SaveException | IOException ex) {
-            throw new IOException(ex.getMessage());
+        } catch (IOException ex) {
+            throw new SaveException(ex);
         }
     }
 }

--- a/src/main/java/net/sf/jabref/exporter/SaveDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/exporter/SaveDatabaseAction.java
@@ -168,11 +168,10 @@ public class SaveDatabaseAction extends AbstractWorker {
         frame.block();
         try {
             SavePreferences prefs = SavePreferences.loadForSaveFromPreferences(Globals.prefs).withEncoding(encoding);
-            BibDatabaseWriter databaseWriter = new BibDatabaseWriter();
+            BibtexDatabaseWriter databaseWriter = new BibtexDatabaseWriter(FileSaveSession::new);
             if (selectedOnly) {
-                session = databaseWriter.savePartOfDatabase(panel.getBibDatabaseContext(), prefs,
-                        panel.getSelectedEntries());
-
+                session = databaseWriter.savePartOfDatabase(panel.getBibDatabaseContext(), panel.getSelectedEntries(),
+                        prefs);
             } else {
                 session = databaseWriter.saveDatabase(panel.getBibDatabaseContext(), prefs);
 

--- a/src/main/java/net/sf/jabref/exporter/SaveDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/exporter/SaveDatabaseAction.java
@@ -120,7 +120,7 @@ public class SaveDatabaseAction extends AbstractWorker {
             // lacking keys, before saving:
             panel.autoGenerateKeysBeforeSaving();
 
-            if (FileBasedLock.waitForFileLock(panel.getBibDatabaseContext().getDatabaseFile(), 10)) {
+            if (FileBasedLock.waitForFileLock(panel.getBibDatabaseContext().getDatabaseFile().toPath(), 10)) {
                 // Check for external modifications to alleviate multiuser concurrency issue when near
                 // simultaneous saves occur to a shared database file: if true, do not perform the save
                 // rather return instead.
@@ -244,7 +244,7 @@ public class SaveDatabaseAction extends AbstractWorker {
 
         try {
             if (commit) {
-                session.commit(file);
+                session.commit(file.toPath());
                 panel.getBibDatabaseContext().getMetaData().setEncoding(encoding); // Make sure to remember which encoding we used.
             } else {
                 session.cancel();
@@ -256,7 +256,7 @@ public class SaveDatabaseAction extends AbstractWorker {
                     JOptionPane.YES_NO_OPTION);
             if (ans == JOptionPane.YES_OPTION) {
                 session.setUseBackup(false);
-                session.commit(file);
+                session.commit(file.toPath());
                 panel.getBibDatabaseContext().getMetaData().setEncoding(encoding);
             } else {
                 commit = false;
@@ -383,7 +383,7 @@ public class SaveDatabaseAction extends AbstractWorker {
 
                 JabRefExecutorService.INSTANCE.execute(() -> {
 
-                    if (!FileBasedLock.waitForFileLock(panel.getBibDatabaseContext().getDatabaseFile(), 10)) {
+                    if (!FileBasedLock.waitForFileLock(panel.getBibDatabaseContext().getDatabaseFile().toPath(), 10)) {
                         // TODO: GUI handling of the situation when the externally modified file keeps being locked.
                         LOGGER.error("File locked, this will be trouble.");
                     }

--- a/src/main/java/net/sf/jabref/exporter/SaveException.java
+++ b/src/main/java/net/sf/jabref/exporter/SaveException.java
@@ -62,6 +62,14 @@ public class SaveException extends Exception {
         this.entry = entry;
     }
 
+    public SaveException(Exception base) {
+        this(base.getMessage(), base.getLocalizedMessage());
+    }
+
+    public SaveException(Exception base, BibEntry entry) {
+        this(base.getMessage(), base.getLocalizedMessage(), entry);
+    }
+
     public int getStatus() {
         return status;
     }

--- a/src/main/java/net/sf/jabref/exporter/SavePreferences.java
+++ b/src/main/java/net/sf/jabref/exporter/SavePreferences.java
@@ -115,6 +115,10 @@ public class SavePreferences {
                 this.saveType, this.takeMetadataSaveOrderInAccount, reformatFile);
     }
 
+    public Charset getEncodingOrDefault() {
+        return encoding == null ? Charset.defaultCharset() : encoding;
+    }
+
     public enum DatabaseSaveType {
         ALL,
         PLAIN_BIBTEX

--- a/src/main/java/net/sf/jabref/exporter/SaveSession.java
+++ b/src/main/java/net/sf/jabref/exporter/SaveSession.java
@@ -17,8 +17,9 @@
 
 package net.sf.jabref.exporter;
 
-import java.io.File;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -50,7 +51,11 @@ public abstract class SaveSession {
         this.backup = useBackup;
     }
 
-    public abstract void commit(File file) throws SaveException;
+    public abstract void commit(Path file) throws SaveException;
+
+    public void commit(String path) throws SaveException {
+        commit(Paths.get(path));
+    }
 
     public abstract void cancel();
 

--- a/src/main/java/net/sf/jabref/exporter/SaveSession.java
+++ b/src/main/java/net/sf/jabref/exporter/SaveSession.java
@@ -1,87 +1,41 @@
-/*  Copyright (C) 2003-2015 JabRef contributors.
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
+/*
+ * Copyright (C) 2003-2016 JabRef contributors.
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*/
 package net.sf.jabref.exporter;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
-import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.logic.util.io.FileBasedLock;
-import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.FieldChange;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+public abstract class SaveSession {
 
-/**
- * Class used to handle safe storage to disk.
- * <p>
- * Usage: create a SaveSession giving the file to save to, the encoding, and whether to make a backup. The SaveSession
- * will provide a Writer to store to, which actually goes to a temporary file. The Writer keeps track of whether all
- * characters could be saved, and if not, which characters were not encodable.
- * <p>
- * After saving is finished, the client should close the Writer. If the save should be put into effect, call commit(),
- * otherwise call cancel(). When canceling, the temporary file is simply deleted and the target file remains unchanged.
- * When committing, the temporary file is copied to the target file after making a backup if requested and if the target
- * file already existed, and finally the temporary file is deleted.
- * <p>
- * If committing fails, the temporary file will not be deleted.
- */
-public class SaveSession {
-
-    private static final Log LOGGER = LogFactory.getLog(SaveSession.class);
-
-    // Filenames.
-    private static final String BACKUP_EXTENSION = ".bak";
-    public static final String LOCKFILE_SUFFIX = ".lock";
-
-    // The age in ms of a lockfile before JabRef will offer to "steal" the locked file:
-    public static final long LOCKFILE_CRITICAL_AGE = 60000;
-    private static final String TEMP_PREFIX = "jabref";
-
-    private static final String TEMP_SUFFIX = "save.bib";
-    private final File tmp;
-    private final Charset encoding;
-    private boolean backup;
-    private final boolean useLockFile;
-
-    private final VerifyingWriter writer;
-
+    protected final Charset encoding;
+    protected final VerifyingWriter writer;
     private final List<FieldChange> undoableFieldChanges = new ArrayList<>();
+    protected boolean backup;
 
-
-    public SaveSession(Charset encoding, boolean backup) throws IOException {
-        tmp = File.createTempFile(SaveSession.TEMP_PREFIX, SaveSession.TEMP_SUFFIX);
-        useLockFile = Globals.prefs.getBoolean(JabRefPreferences.USE_LOCK_FILES);
+    protected SaveSession(Charset encoding, boolean backup, VerifyingWriter writer) {
+        this.encoding = Objects.requireNonNull(encoding);
         this.backup = backup;
-        this.encoding = encoding;
-    /* Using
-	   try (FileOutputStream fos = new FileOutputStream(tmp)) {
-	       writer = new VerifyingWriter(fos, encoding);
-	   }
-	   doesn't work since fos is closed after assigning write,
-	   leading to that fos may never be closed at all
-	 */
-        writer = new VerifyingWriter(new FileOutputStream(tmp), encoding);
+        this.writer = Objects.requireNonNull(writer);
     }
 
     public VerifyingWriter getWriter() {
@@ -96,101 +50,9 @@ public class SaveSession {
         this.backup = useBackup;
     }
 
-    public void commit(File file) throws SaveException {
-        if (file == null) {
-            return;
-        }
-        if (file.exists() && backup) {
-            String name = file.getName();
-            String path = file.getParent();
-            File backupFile = new File(path, name + BACKUP_EXTENSION);
-            try {
-                FileUtil.copyFile(file, backupFile, true);
-            } catch (IOException ex) {
-                LOGGER.error("Problem copying file", ex);
-                throw SaveException.BACKUP_CREATION;
-            }
-        }
-        try {
-            if (useLockFile) {
-                try {
-                    if (createLockFile(file)) {
-                        // Oops, the lock file already existed. Try to wait it out:
-                        if (!FileBasedLock.waitForFileLock(file, 10)) {
-                            throw SaveException.FILE_LOCKED;
-                        }
+    public abstract void commit(File file) throws SaveException;
 
-                    }
-                } catch (IOException ex) {
-                    LOGGER.error("Error when creating lock file.", ex);
-                }
-            }
-
-            FileUtil.copyFile(tmp, file, true);
-        } catch (IOException ex2) {
-            // If something happens here, what can we do to correct the problem? The file is corrupted, but we still
-            // have a clean copy in tmp. However, we just failed to copy tmp to file, so it's not likely that
-            // repeating the action will have a different result.
-            // On the other hand, our temporary file should still be clean, and won't be deleted.
-            throw new SaveException("Save failed while committing changes: " + ex2.getMessage(),
-                    Localization.lang("Save failed while committing changes: %0", ex2.getMessage()));
-        } finally {
-            if (useLockFile) {
-                deleteLockFile(file);
-            }
-        }
-        if (!tmp.delete()) {
-            LOGGER.info("Cannot delete temporary file");
-        }
-    }
-
-    public void cancel() {
-        if (!tmp.delete()) {
-            LOGGER.info("Cannot delete temporary file");
-        }
-    }
-
-    /**
-     * Check if a lock file exists, and create it if it doesn't.
-     *
-     * @return true if the lock file already existed
-     * @throws IOException if something happens during creation.
-     */
-    private boolean createLockFile(File file) throws IOException {
-        File lock = new File(file.getPath() + SaveSession.LOCKFILE_SUFFIX);
-        if (lock.exists()) {
-            return true;
-        }
-        try (FileOutputStream out = new FileOutputStream(lock)) {
-            out.write(0);
-            out.close();
-        } catch (IOException ex) {
-            LOGGER.error("Error when creating lock file.", ex);
-        }
-        lock.deleteOnExit();
-        return false;
-    }
-
-    /**
-     * Check if a lock file exists, and delete it if it does.
-     *
-     * @return true if the lock file existed, false otherwise.
-     * @throws IOException if something goes wrong.
-     */
-    private boolean deleteLockFile(File file) {
-        File lock = new File(file.getPath() + SaveSession.LOCKFILE_SUFFIX);
-        if (!lock.exists()) {
-            return false;
-        }
-        if (!lock.delete()) {
-            LOGGER.info("Cannot delete lock file");
-        }
-        return true;
-    }
-
-    public File getTemporaryFile() {
-        return tmp;
-    }
+    public abstract void cancel();
 
     public List<FieldChange> getFieldChanges() {
         return undoableFieldChanges;

--- a/src/main/java/net/sf/jabref/exporter/StringSaveSession.java
+++ b/src/main/java/net/sf/jabref/exporter/StringSaveSession.java
@@ -18,11 +18,11 @@
 package net.sf.jabref.exporter;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -52,9 +52,9 @@ public class StringSaveSession extends SaveSession {
     }
 
     @Override
-    public void commit(File file) throws SaveException {
+    public void commit(Path file) throws SaveException {
         try {
-            Files.write(file.toPath(), outputStream.toByteArray());
+            Files.write(file, outputStream.toByteArray());
         } catch (IOException e) {
             throw new SaveException(e);
         }

--- a/src/main/java/net/sf/jabref/exporter/StringSaveSession.java
+++ b/src/main/java/net/sf/jabref/exporter/StringSaveSession.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2003-2016 JabRef contributors.
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package net.sf.jabref.exporter;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class StringSaveSession extends SaveSession {
+
+    private static final Log LOGGER = LogFactory.getLog(StringSaveSession.class);
+
+    private final ByteArrayOutputStream outputStream;
+
+    public StringSaveSession(Charset encoding, boolean backup) {
+        this(encoding, backup, new ByteArrayOutputStream());
+    }
+
+    private StringSaveSession(Charset encoding, boolean backup, ByteArrayOutputStream outputStream) {
+        super(encoding, backup, new VerifyingWriter(outputStream, encoding));
+        this.outputStream = outputStream;
+    }
+
+    public String getStringValue() {
+        try {
+            return outputStream.toString(encoding.name());
+        } catch (UnsupportedEncodingException e) {
+            LOGGER.warn(e);
+            return "";
+        }
+    }
+
+    @Override
+    public void commit(File file) throws SaveException {
+        try {
+            Files.write(file.toPath(), outputStream.toByteArray());
+        } catch (IOException e) {
+            throw new SaveException(e);
+        }
+    }
+
+    @Override
+    public void cancel() {
+        try {
+            outputStream.close();
+        } catch (IOException e) {
+            LOGGER.warn(e);
+        }
+    }
+}

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -63,8 +63,9 @@ import net.sf.jabref.collab.FileUpdateListener;
 import net.sf.jabref.collab.FileUpdatePanel;
 import net.sf.jabref.event.EntryAddedEvent;
 import net.sf.jabref.event.EntryChangedEvent;
-import net.sf.jabref.exporter.BibDatabaseWriter;
+import net.sf.jabref.exporter.BibtexDatabaseWriter;
 import net.sf.jabref.exporter.ExportToClipboardAction;
+import net.sf.jabref.exporter.FileSaveSession;
 import net.sf.jabref.exporter.SaveDatabaseAction;
 import net.sf.jabref.exporter.SaveException;
 import net.sf.jabref.exporter.SavePreferences;
@@ -1104,9 +1105,9 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         try {
             SavePreferences prefs = SavePreferences.loadForSaveFromPreferences(Globals.prefs).withEncoding(enc)
                     .withSaveType(saveType);
-            BibDatabaseWriter databaseWriter = new BibDatabaseWriter();
+            BibtexDatabaseWriter databaseWriter = new BibtexDatabaseWriter(FileSaveSession::new);
             if (selectedOnly) {
-                session = databaseWriter.savePartOfDatabase(bibDatabaseContext, prefs, mainTable.getSelectedEntries());
+                session = databaseWriter.savePartOfDatabase(bibDatabaseContext, mainTable.getSelectedEntries(), prefs);
             } else {
                 session = databaseWriter.saveDatabase(bibDatabaseContext, prefs);
             }

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -1174,7 +1174,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         }
 
         if (commit) {
-            session.commit(file);
+            session.commit(file.toPath());
             this.bibDatabaseContext.getMetaData().setEncoding(enc); // Make sure to remember which encoding we used.
         } else {
             session.cancel();
@@ -2171,7 +2171,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
         // Test: running scan automatically in background
         if ((getBibDatabaseContext().getDatabaseFile() != null)
-                && !FileBasedLock.waitForFileLock(getBibDatabaseContext().getDatabaseFile(), 10)) {
+                && !FileBasedLock.waitForFileLock(getBibDatabaseContext().getDatabaseFile().toPath(), 10)) {
             // The file is locked even after the maximum wait. Do nothing.
             LOGGER.error("File updated externally, but change scan failed because the file is locked.");
             // Perturb the stored timestamp so successive checks are made:

--- a/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
@@ -35,7 +35,6 @@ import net.sf.jabref.JabRefExecutorService;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.exporter.AutoSaveManager;
-import net.sf.jabref.exporter.SaveSession;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.FileDialogs;
 import net.sf.jabref.gui.IconTheme;
@@ -220,7 +219,7 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
                 if (FileBasedLock.hasLockFile(file)) {
                     long modificationTIme = FileBasedLock.getLockFileTimeStamp(file);
                     if ((modificationTIme != -1)
-                            && ((System.currentTimeMillis() - modificationTIme) > SaveSession.LOCKFILE_CRITICAL_AGE)) {
+                            && ((System.currentTimeMillis() - modificationTIme) > FileBasedLock.LOCKFILE_CRITICAL_AGE)) {
                         // The lock file is fairly old, so we can offer to "steal" the file:
                         int answer = JOptionPane.showConfirmDialog(null,
                                 "<html>" + Localization.lang("Error opening file") + " '" + fileName + "'. "

--- a/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
@@ -653,4 +653,7 @@ public class StringUtil {
 
     }
 
+    public static boolean isNullOrEmpty(String toTest) {
+        return (toTest == null || toTest.isEmpty());
+    }
 }

--- a/src/test/java/net/sf/jabref/exporter/MSBibExportFormatTestFiles.java
+++ b/src/test/java/net/sf/jabref/exporter/MSBibExportFormatTestFiles.java
@@ -70,7 +70,7 @@ public class MSBibExportFormatTestFiles {
     }
 
     @Test
-    public final void testPerformExport() throws IOException, URISyntaxException {
+    public final void testPerformExport() throws IOException, URISyntaxException, SaveException {
         String xmlFileName = filename.replace(".bib", ".xml");
         Path importFile = Paths.get(MSBibExportFormatTestFiles.class.getResource(filename).toURI());
         String tempFilename = tempFile.getCanonicalPath();

--- a/src/test/java/net/sf/jabref/exporter/MsBibExportFormatTest.java
+++ b/src/test/java/net/sf/jabref/exporter/MsBibExportFormatTest.java
@@ -44,7 +44,7 @@ public class MsBibExportFormatTest {
     }
 
     @Test
-    public final void testPerformExportWithNoEntry() throws IOException {
+    public final void testPerformExportWithNoEntry() throws IOException, SaveException {
         List<BibEntry> entries = Collections.emptyList();
         String tempFileName = tempFile.getCanonicalPath();
         msBibExportFormat.performExport(databaseContext, tempFileName, charset, entries);

--- a/src/test/resources/testbib/complex.bib
+++ b/src/test/resources/testbib/complex.bib
@@ -5,6 +5,7 @@
 This is some arbitrary user comment that should be preserved
 
 @String{firstString  = {my first string}}
+This is some user comment in front of a string, should also be preserved.
 @String{secondString = {}}
 
 @ARTICLE{1102917,


### PR DESCRIPTION
The main aim of this PR is to simplify the implementation of https://github.com/JabRef/jabref/pull/1451 (sql export) and other exporters.

- Abstract class BibDatabaseWriter, which controls the generic things of
writing a database (i.e. sorting entries, applying save actions, some
basic conversations, ...)
- Derived class BibtexDatabaseWriter, which only contains logic how to
actually write to in BibTeX format (should be simple to write similar
classes for other export formats like ris)
- Make SaveSession abstract and introduce two implementations which
write to a temporary file (FileSaveSession) or two a string/buffer
(StringSaveSession)
- Move code related to lock files to FileBasedLock

--

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)

