### PR TITLE
Fix #1434: Static groups are now longer displayed as dynamic ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Fixed
 - Fixed [#405](https://github.com/JabRef/jabref/issues/405): Added more {} around capital letters in Unicode/HTML to LaTeX conversion to preserve them
 - Alleviate multiuser concurrency issue when near simultaneous saves occur to a shared database file
-
+- Fixed [#1434](https://github.com/JabRef/jabref/issues/1434): Static groups are now longer displayed as dynamic ones
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/gui/groups/GroupDialog.java
+++ b/src/main/java/net/sf/jabref/gui/groups/GroupDialog.java
@@ -347,7 +347,7 @@ class GroupDialog extends JDialog {
         m_sgCaseSensitive.addItemListener(itemListener);
 
         // configure for current type
-        if (editedGroup instanceof KeywordGroup) {
+        if (editedGroup.getClass() == KeywordGroup.class) {
             KeywordGroup group = (KeywordGroup) editedGroup;
             m_name.setText(group.getName());
             m_kgSearchField.setText(group.getSearchField());
@@ -356,7 +356,7 @@ class GroupDialog extends JDialog {
             m_kgRegExp.setSelected(group.isRegExp());
             m_keywordsRadioButton.setSelected(true);
             setContext(editedGroup.getHierarchicalContext());
-        } else if (editedGroup instanceof SearchGroup) {
+        } else if (editedGroup.getClass() == SearchGroup.class) {
             SearchGroup group = (SearchGroup) editedGroup;
             m_name.setText(group.getName());
             m_sgSearchExpression.setText(group.getSearchExpression());
@@ -364,7 +364,7 @@ class GroupDialog extends JDialog {
             m_sgRegExp.setSelected(group.isRegExp());
             m_searchRadioButton.setSelected(true);
             setContext(editedGroup.getHierarchicalContext());
-        } else if (editedGroup instanceof ExplicitGroup) {
+        } else if (editedGroup.getClass() == ExplicitGroup.class) {
             m_name.setText(editedGroup.getName());
             m_explicitRadioButton.setSelected(true);
             setContext(editedGroup.getHierarchicalContext());

--- a/src/main/java/net/sf/jabref/logic/groups/ExplicitGroup.java
+++ b/src/main/java/net/sf/jabref/logic/groups/ExplicitGroup.java
@@ -172,4 +172,9 @@ public class ExplicitGroup extends KeywordGroup {
     public int hashCode() {
         return super.hashCode();
     }
+
+    @Override
+    public boolean isDynamic() {
+        return false;
+    }
 }

--- a/src/main/java/net/sf/jabref/util/Util.java
+++ b/src/main/java/net/sf/jabref/util/Util.java
@@ -74,8 +74,8 @@ public class Util {
     /**
      * Warns the user of undesired side effects of an explicit assignment/removal of entries to/from this group.
      * Currently there are four types of groups: AllEntriesGroup, SearchGroup - do not support explicit assignment.
-     * ExplicitGroup - never modifies entries. KeywordGroup - only this modifies entries upon assignment/removal.
-     * Modifications are acceptable unless they affect a standard field (such as "author") besides the "keywords" field.
+     * ExplicitGroup and KeywordGroup - this modifies entries upon assignment/removal.
+     * Modifications are acceptable unless they affect a standard field (such as "author") besides the "keywords" or "groups' field.
      *
      * @param parent The Component used as a parent when displaying a confirmation dialog.
      * @return true if the assignment has no undesired side effects, or the user chose to perform it anyway. false
@@ -87,7 +87,7 @@ public class Util {
             if (group instanceof KeywordGroup) {
                 KeywordGroup kg = (KeywordGroup) group;
                 String field = kg.getSearchField().toLowerCase();
-                if ("keywords".equals(field)) {
+                if ("keywords".equals(field) || "groups".equals(field)) {
                     continue; // this is not undesired
                 }
                 int len = InternalBibtexFields.numberOfPublicFields();


### PR DESCRIPTION
Reason for this bug: ExplicteGroup now derives from KeywordGroup and thus was sometimes displayed as a keyword group.

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)

