### PR TITLE
Fix #1476 NPE when importing from SQL DB because of missing DatabaseMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Fixed
 - Fixed [#405](https://github.com/JabRef/jabref/issues/405): Added more {} around capital letters in Unicode/HTML to LaTeX conversion to preserve them
 - Alleviate multiuser concurrency issue when near simultaneous saves occur to a shared database file
-
+- Fixed [#1476](https://github.com/JabRef/jabref/issues/1476): NPE when importing from SQL DB because of missing DatabaseMode
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/JabRefPreferences.java
@@ -71,6 +71,7 @@ import net.sf.jabref.logic.openoffice.StyleLoader;
 import net.sf.jabref.logic.remote.RemotePreferences;
 import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.CustomEntryType;
 import net.sf.jabref.model.entry.EntryUtil;
 import net.sf.jabref.model.entry.InternalBibtexFields;
@@ -1035,6 +1036,19 @@ public class JabRefPreferences {
         String value = (String) defaults.get(key);
         int[] rgb = getRgb(value);
         return new Color(rgb[0], rgb[1], rgb[2]);
+    }
+
+    /**
+     * Returns the default BibDatabase mode, which can be either BIBTEX or BIBLATEX.
+     *
+     * @return the default BibDatabaseMode
+     */
+    public BibDatabaseMode getDefaultBibDatabaseMode() {
+        if (getBoolean(BIBLATEX_DEFAULT_MODE)) {
+            return BibDatabaseMode.BIBLATEX;
+        } else {
+            return BibDatabaseMode.BIBTEX;
+        }
     }
 
     /**

--- a/src/main/java/net/sf/jabref/gui/labelpattern/LabelPatternPanel.java
+++ b/src/main/java/net/sf/jabref/gui/labelpattern/LabelPatternPanel.java
@@ -120,13 +120,11 @@ public class LabelPatternPanel extends JPanel {
         // check mode of currently used DB
         if (panel != null) {
             mode = panel.getBibDatabaseContext().getMode();
-        } else { // use preferences value if no DB is open
-            if (Globals.prefs.getBoolean(JabRefPreferences.BIBLATEX_DEFAULT_MODE)) {
-                mode = BibDatabaseMode.BIBLATEX;
-            } else {
-                mode = BibDatabaseMode.BIBTEX;
-            }
+        } else {
+            // use preferences value if no DB is open
+            mode = Globals.prefs.getDefaultBibDatabaseMode();
         }
+
         for (EntryType type : EntryTypes.getAllValues(mode)) {
             textFields.put(type.getName().toLowerCase(), addEntryType(pan, type, y));
             y++;

--- a/src/main/java/net/sf/jabref/sql/importer/DbImportAction.java
+++ b/src/main/java/net/sf/jabref/sql/importer/DbImportAction.java
@@ -27,6 +27,7 @@ import javax.swing.Action;
 import javax.swing.JOptionPane;
 
 import net.sf.jabref.BibDatabaseContext;
+import net.sf.jabref.Globals;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.actions.MnemonicAwareAction;
@@ -69,11 +70,8 @@ public class DbImportAction extends AbstractWorker {
     }
 
     class DbImpAction extends MnemonicAwareAction {
-
         public DbImpAction() {
-            super();
             putValue(Action.NAME, Localization.menuTitle("Import from external SQL database"));
-
         }
 
         @Override
@@ -151,14 +149,14 @@ public class DbImportAction extends AbstractWorker {
                             Localization.lang("There are no available databases to be imported"),
                             Localization.lang("Import from SQL database"), JOptionPane.INFORMATION_MESSAGE);
                 } else {
-                    DBImportExportDialog dialogo = new DBImportExportDialog(frame, matrix,
-                            DBImportExportDialog.DialogType.IMPORTER);
+                    DBImportExportDialog dialogo = new DBImportExportDialog(frame, matrix, DBImportExportDialog.DialogType.IMPORTER);
                     if (dialogo.removeAction) {
                         String dbName = dialogo.selectedDB;
                         DatabaseUtil.removeDB(dialogo, dbName, conn, databaseContext);
                         performImport();
                     } else if (dialogo.moreThanOne) {
-                        databases = importer.performImport(dbs, dialogo.listOfDBs, frame.getCurrentBasePanel().getBibDatabaseContext().getMode());
+                        // use default DB mode for import
+                        databases = importer.performImport(dbs, dialogo.listOfDBs, Globals.prefs.getDefaultBibDatabaseMode());
                         for (DBImporterResult res : databases) {
                             databaseContext = res.getDatabaseContext();
                             dbs.isConfigValid(true);


### PR DESCRIPTION
- Use the default mode set inside the Preferences for each import from an external SQL database
- Add new method for getting the default DB mode from the preferences
- Use the preferences method where necessary

