### PR TITLE
Fixes #1482: Correct number of matched entries is displayed for refining subgroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed [#405](https://github.com/JabRef/jabref/issues/405): Added more {} around capital letters in Unicode/HTML to LaTeX conversion to preserve them
 - Alleviate multiuser concurrency issue when near simultaneous saves occur to a shared database file
 - Fixed [#1476](https://github.com/JabRef/jabref/issues/1476): NPE when importing from SQL DB because of missing DatabaseMode
+- Fixed [#1482](https://github.com/JabRef/jabref/issues/1482): Correct number of matched entries is displayed for refining subgroups
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/gui/groups/GroupTreeNodeViewModel.java
+++ b/src/main/java/net/sf/jabref/gui/groups/GroupTreeNodeViewModel.java
@@ -197,7 +197,7 @@ public class GroupTreeNodeViewModel implements Transferable, TreeNode {
                 && JabRefGUI.getMainFrame() != null) {
             BasePanel currentBasePanel = JabRefGUI.getMainFrame().getCurrentBasePanel();
             if (currentBasePanel != null) {
-                sb.append(" [").append(group.numberOfHits(currentBasePanel.getDatabase().getEntries())).append(']');
+                sb.append(" [").append(node.numberOfHits(currentBasePanel.getDatabase().getEntries())).append(']');
             }
         }
 

--- a/src/main/java/net/sf/jabref/logic/groups/AbstractGroup.java
+++ b/src/main/java/net/sf/jabref/logic/groups/AbstractGroup.java
@@ -169,21 +169,6 @@ public abstract class AbstractGroup implements SearchMatcher {
     }
 
     /**
-     * Determines the number of entries in the specified list which are matched by this group.
-     * @param entries list of entries to be searched
-     * @return number of hits
-     */
-    public int numberOfHits(List<BibEntry> entries) {
-        int hits = 0;
-        for (BibEntry entry : entries) {
-            if (this.contains(entry)) {
-                hits++;
-            }
-        }
-        return hits;
-    }
-
-    /**
      * Returns true if this group is dynamic, i.e. uses a search definition or
      * equiv. that might match new entries, or false if this group contains a
      * fixed set of entries and thus will never match a new entry that was not

--- a/src/main/java/net/sf/jabref/logic/groups/GroupTreeNode.java
+++ b/src/main/java/net/sf/jabref/logic/groups/GroupTreeNode.java
@@ -213,4 +213,20 @@ public class GroupTreeNode extends TreeNode<GroupTreeNode> {
     public GroupTreeNode copyNode() {
         return new GroupTreeNode(group);
     }
+
+    /**
+     * Determines the number of entries in the specified list which are matched by this group.
+     * @param entries list of entries to be searched
+     * @return number of hits
+     */
+    public int numberOfHits(List<BibEntry> entries) {
+        int hits = 0;
+        SearchMatcher matcher = getSearchRule();
+        for (BibEntry entry : entries) {
+            if (matcher.isMatch(entry)) {
+                hits++;
+            }
+        }
+        return hits;
+    }
 }

--- a/src/test/java/net/sf/jabref/logic/groups/AbstractGroupTest.java
+++ b/src/test/java/net/sf/jabref/logic/groups/AbstractGroupTest.java
@@ -18,19 +18,14 @@
 package net.sf.jabref.logic.groups;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import net.sf.jabref.model.entry.BibEntry;
 
 import org.junit.Before;
-import org.junit.Test;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class AbstractGroupTest {
 
@@ -44,25 +39,4 @@ public class AbstractGroupTest {
         entries.add(new BibEntry().withField("author", "author1 and author2"));
         entries.add(new BibEntry().withField("author", "author1"));
     }
-
-    @Test
-    public void numberOfHitsReturnsZeroForEmptyList() throws Exception {
-        assertEquals(0, group.numberOfHits(Collections.emptyList()));
-    }
-
-    @Test
-    public void numberOfHitsCallsContainsToDetermineSingleHit() throws Exception {
-        when(group.contains(any())).then(invocation ->
-                invocation.getArgumentAt(0, BibEntry.class).getField("author").contains("author2"));
-        assertEquals(1, group.numberOfHits(entries));
-    }
-
-    @Test
-    public void numberOfHitsCallsContainsToDetermineMultipleHits() throws Exception {
-        when(group.contains(any())).then(invocation ->
-                invocation.getArgumentAt(0, BibEntry.class).getField("author").contains("author1"));
-        assertEquals(2, group.numberOfHits(entries));
-    }
-
-
 }

--- a/src/test/java/net/sf/jabref/logic/groups/GroupTreeNodeTest.java
+++ b/src/test/java/net/sf/jabref/logic/groups/GroupTreeNodeTest.java
@@ -1,17 +1,30 @@
 package net.sf.jabref.logic.groups;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import net.sf.jabref.importer.fileformat.ParseException;
 import net.sf.jabref.logic.search.matchers.AndMatcher;
 import net.sf.jabref.logic.search.matchers.OrMatcher;
+import net.sf.jabref.model.entry.BibEntry;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 public class GroupTreeNodeTest {
+
+    private List<BibEntry> entries = new ArrayList<>();
+
+    @Before
+    public void setUp() throws Exception {
+        entries.add(new BibEntry().withField("author", "author1 and author2"));
+        entries.add(new BibEntry().withField("author", "author1"));
+    }
+
 
     /**
      * Gets the marked node in the following tree of explicit groups:
@@ -173,5 +186,48 @@ public class GroupTreeNodeTest {
         matcher.addRule(node.getGroup());
         matcher.addRule(child.getGroup());
         assertEquals(matcher, node.getSearchRule());
+    }
+
+    @Test
+    public void numberOfHitsReturnsZeroForEmptyList() throws Exception {
+        assertEquals(0, getNodeInSimpleTree().numberOfHits(Collections.emptyList()));
+    }
+
+    @Test
+    public void numberOfHitsMatchesOneEntry() throws Exception {
+        GroupTreeNode parent = getNodeInSimpleTree();
+        GroupTreeNode node = parent.addSubgroup(
+                new KeywordGroup("node", "author", "author2", true, false, GroupHierarchyType.INDEPENDENT));
+        assertEquals(1, node.numberOfHits(entries));
+    }
+
+    @Test
+    public void numberOfHitsMatchesMultipleEntries() throws Exception {
+        GroupTreeNode parent = getNodeInSimpleTree();
+        GroupTreeNode node = parent.addSubgroup(
+                new KeywordGroup("node", "author", "author1", true, false, GroupHierarchyType.INDEPENDENT));
+        assertEquals(2, node.numberOfHits(entries));
+    }
+
+    // Test for #1482
+    @Test
+    public void numberOfHitsWorksForRefiningGroups() throws Exception {
+        GroupTreeNode grandParent = getNodeInSimpleTree();
+        GroupTreeNode parent = grandParent.addSubgroup(
+                new KeywordGroup("node", "author", "author2", true, false, GroupHierarchyType.INDEPENDENT));
+        GroupTreeNode node = parent.addSubgroup(
+                new KeywordGroup("node", "author", "author1", true, false, GroupHierarchyType.REFINING));
+        assertEquals(1, node.numberOfHits(entries));
+    }
+
+    // Test for #1482
+    @Test
+    public void numberOfHitsWorksForHierarchyOfIndependentGroups() throws Exception {
+        GroupTreeNode grandParent = getNodeInSimpleTree();
+        GroupTreeNode parent = grandParent.addSubgroup(
+                new KeywordGroup("node", "author", "author2", true, false, GroupHierarchyType.INDEPENDENT));
+        GroupTreeNode node = parent.addSubgroup(
+                new KeywordGroup("node", "author", "author1", true, false, GroupHierarchyType.INDEPENDENT));
+        assertEquals(2, node.numberOfHits(entries));
     }
 }


### PR DESCRIPTION
The issue was that, for the number of hits, JabRef only checked if the
group taken separately matched the entry. That is, it was completely
ignored that the group sits in a tree and might be set up to refine the
search of the parent. Taking the example given in #1482, 577 entries
satisfy the condition `articlé original` but only 38 are also matched by
`articlé`.

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)