### PR TITLE
Clean registry on uninstall

### DIFF
--- a/jabref.install4j
+++ b/jabref.install4j
@@ -117,14 +117,10 @@
             <preActivation />
             <postActivation />
             <actions>
-              <action name="" id="311" customizedId="" beanClass="com.install4j.runtime.beans.actions.misc.RequestPrivilegesAction" enabled="true" commentSet="false" comment="" actionElevationType="none" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
+              <action name="" id="13" customizedId="" beanClass="com.install4j.runtime.beans.actions.misc.RequestPrivilegesAction" enabled="true" commentSet="false" comment="" actionElevationType="none" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
                 <serializedBean>
                   <java class="java.beans.XMLDecoder">
-                    <object class="com.install4j.runtime.beans.actions.misc.RequestPrivilegesAction">
-                      <void property="failIfNotObtainedWin">
-                        <boolean>false</boolean>
-                      </void>
-                    </object>
+                    <object class="com.install4j.runtime.beans.actions.misc.RequestPrivilegesAction" />
                   </java>
                 </serializedBean>
                 <condition />
@@ -161,14 +157,14 @@
                 </serializedBean>
                 <condition>context.getBooleanVariable("sys.confirmedUpdateInstallation")</condition>
               </action>
-              <action name="InstallationDirectory" id="184" customizedId="" beanClass="com.install4j.runtime.beans.actions.control.RunScriptAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="true" failureStrategy="1" errorMessage="">
+              <action name="" id="184" customizedId="" beanClass="com.install4j.runtime.beans.actions.control.RunScriptAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="true" failureStrategy="1" errorMessage="">
                 <serializedBean>
                   <java class="java.beans.XMLDecoder">
                     <object class="com.install4j.runtime.beans.actions.control.RunScriptAction">
                       <void property="script">
                         <object class="com.install4j.api.beans.ScriptProperty">
                           <void property="value">
-                            <string>if (Util.hasFullAdminRights()) {
+                            <string>if (Util.hasFullAdminRights() || Util.isAdminGroup()) {
   context.setInstallationDirectory(context.getInstallationDirectory());
 } else {
   if (Util.isAtLeastWindowsVista()) {
@@ -403,7 +399,7 @@ return true;</string>
                         </object>
                       </java>
                     </serializedBean>
-                    <condition>Util.hasFullAdminRights()</condition>
+                    <condition>Util.hasFullAdminRights() || Util.isAdminGroup()</condition>
                   </action>
                   <action name="PathUnprivileged" id="240" customizedId="" beanClass="com.install4j.runtime.beans.actions.registry.SetRegistryValueAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
                     <serializedBean>
@@ -427,7 +423,7 @@ return true;</string>
                         </object>
                       </java>
                     </serializedBean>
-                    <condition>!Util.hasFullAdminRights()</condition>
+                    <condition>!(Util.hasFullAdminRights() || Util.isAdminGroup())</condition>
                   </action>
                 </beans>
               </group>
@@ -617,14 +613,14 @@ return true;</string>
                 </serializedBean>
                 <condition />
               </action>
-              <group name="Registry" id="312" customizedId="" beanClass="com.install4j.runtime.beans.groups.ActionGroup" enabled="true" commentSet="false" comment="" actionElevationType="elevated">
+              <group name="Registry" id="284" customizedId="" beanClass="com.install4j.runtime.beans.groups.ActionGroup" enabled="true" commentSet="false" comment="" actionElevationType="elevated">
                 <serializedBean>
                   <java class="java.beans.XMLDecoder">
                     <object class="com.install4j.runtime.beans.groups.ActionGroup" />
                   </java>
                 </serializedBean>
                 <beans>
-                  <action name="PathAdmin" id="280" customizedId="" beanClass="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
+                  <action name="PathAdmin" id="282" customizedId="" beanClass="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
                     <serializedBean>
                       <java class="java.beans.XMLDecoder">
                         <object class="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction">
@@ -643,9 +639,9 @@ return true;</string>
                         </object>
                       </java>
                     </serializedBean>
-                    <condition>Util.hasFullAdminRights()</condition>
+                    <condition>Util.hasFullAdminRights() || Util.isAdminGroup()</condition>
                   </action>
-                  <action name="PathUnprivileged" id="281" customizedId="" beanClass="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
+                  <action name="PathUnprivileged" id="283" customizedId="" beanClass="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
                     <serializedBean>
                       <java class="java.beans.XMLDecoder">
                         <object class="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction">
@@ -664,7 +660,7 @@ return true;</string>
                         </object>
                       </java>
                     </serializedBean>
-                    <condition>!Util.hasFullAdminRights()</condition>
+                    <condition>!(Util.hasFullAdminRights() || Util.isAdminGroup())</condition>
                   </action>
                 </beans>
               </group>

--- a/jabref.install4j
+++ b/jabref.install4j
@@ -612,6 +612,48 @@ return true;</string>
                 </serializedBean>
                 <condition />
               </action>
+              <action name="PathAdmin" id="280" customizedId="" beanClass="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
+                <serializedBean>
+                  <java class="java.beans.XMLDecoder">
+                    <object class="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction">
+                      <void property="keyName">
+                        <string>SOFTWARE\JabRef</string>
+                      </void>
+                      <void property="onlyIfEmpty">
+                        <boolean>false</boolean>
+                      </void>
+                      <void property="registryRoot">
+                        <object class="java.lang.Enum" method="valueOf">
+                          <class>com.install4j.api.windows.RegistryRoot</class>
+                          <string>HKEY_LOCAL_MACHINE</string>
+                        </object>
+                      </void>
+                    </object>
+                  </java>
+                </serializedBean>
+                <condition>Util.hasFullAdminRights()</condition>
+              </action>
+              <action name="PathUnprivileged" id="281" customizedId="" beanClass="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
+                <serializedBean>
+                  <java class="java.beans.XMLDecoder">
+                    <object class="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction">
+                      <void property="keyName">
+                        <string>SOFTWARE\JabRef</string>
+                      </void>
+                      <void property="onlyIfEmpty">
+                        <boolean>false</boolean>
+                      </void>
+                      <void property="registryRoot">
+                        <object class="java.lang.Enum" method="valueOf">
+                          <class>com.install4j.api.windows.RegistryRoot</class>
+                          <string>HKEY_CURRENT_USER</string>
+                        </object>
+                      </void>
+                    </object>
+                  </java>
+                </serializedBean>
+                <condition>!Util.hasFullAdminRights()</condition>
+              </action>
             </actions>
             <formComponents />
           </screen>

--- a/jabref.install4j
+++ b/jabref.install4j
@@ -116,7 +116,16 @@
             <validation />
             <preActivation />
             <postActivation />
-            <actions />
+            <actions>
+              <action name="" id="311" customizedId="" beanClass="com.install4j.runtime.beans.actions.misc.RequestPrivilegesAction" enabled="true" commentSet="false" comment="" actionElevationType="none" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
+                <serializedBean>
+                  <java class="java.beans.XMLDecoder">
+                    <object class="com.install4j.runtime.beans.actions.misc.RequestPrivilegesAction" />
+                  </java>
+                </serializedBean>
+                <condition />
+              </action>
+            </actions>
             <formComponents />
           </screen>
         </startup>
@@ -148,15 +157,7 @@
                 </serializedBean>
                 <condition>context.getBooleanVariable("sys.confirmedUpdateInstallation")</condition>
               </action>
-              <action name="" id="13" customizedId="" beanClass="com.install4j.runtime.beans.actions.misc.RequestPrivilegesAction" enabled="true" commentSet="false" comment="" actionElevationType="none" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
-                <serializedBean>
-                  <java class="java.beans.XMLDecoder">
-                    <object class="com.install4j.runtime.beans.actions.misc.RequestPrivilegesAction" />
-                  </java>
-                </serializedBean>
-                <condition />
-              </action>
-              <action name="" id="184" customizedId="" beanClass="com.install4j.runtime.beans.actions.control.RunScriptAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="true" failureStrategy="1" errorMessage="">
+              <action name="InstallationDirectory" id="184" customizedId="" beanClass="com.install4j.runtime.beans.actions.control.RunScriptAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="true" failureStrategy="1" errorMessage="">
                 <serializedBean>
                   <java class="java.beans.XMLDecoder">
                     <object class="com.install4j.runtime.beans.actions.control.RunScriptAction">

--- a/jabref.install4j
+++ b/jabref.install4j
@@ -120,7 +120,11 @@
               <action name="" id="311" customizedId="" beanClass="com.install4j.runtime.beans.actions.misc.RequestPrivilegesAction" enabled="true" commentSet="false" comment="" actionElevationType="none" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
                 <serializedBean>
                   <java class="java.beans.XMLDecoder">
-                    <object class="com.install4j.runtime.beans.actions.misc.RequestPrivilegesAction" />
+                    <object class="com.install4j.runtime.beans.actions.misc.RequestPrivilegesAction">
+                      <void property="failIfNotObtainedWin">
+                        <boolean>false</boolean>
+                      </void>
+                    </object>
                   </java>
                 </serializedBean>
                 <condition />

--- a/jabref.install4j
+++ b/jabref.install4j
@@ -434,26 +434,6 @@ return true;</string>
             </actions>
             <formComponents />
           </screen>
-          <screen name="" id="314" customizedId="" beanClass="com.install4j.runtime.beans.screens.CustomizableInfoScreen" enabled="true" commentSet="false" comment="" actionElevationType="inherit" rollbackBarrier="false" backButton="2" finishScreen="false" wizardIndexChangeType="unchanged" wizardIndexKey="">
-            <serializedBean>
-              <java class="java.beans.XMLDecoder">
-                <object class="com.install4j.runtime.beans.screens.CustomizableInfoScreen">
-                  <void property="infoText">
-                    <string>Util.hasFullAdminRights()</string>
-                  </void>
-                  <void property="title">
-                    <string>Full Admin?</string>
-                  </void>
-                </object>
-              </java>
-            </serializedBean>
-            <condition />
-            <validation />
-            <preActivation />
-            <postActivation />
-            <actions />
-            <formComponents />
-          </screen>
           <screen name="" id="27" customizedId="" beanClass="com.install4j.runtime.beans.screens.FileAssociationsScreen" enabled="true" commentSet="false" comment="" actionElevationType="inherit" rollbackBarrier="false" backButton="2" finishScreen="false" wizardIndexChangeType="unchanged" wizardIndexKey="">
             <serializedBean>
               <java class="java.beans.XMLDecoder">

--- a/jabref.install4j
+++ b/jabref.install4j
@@ -434,6 +434,26 @@ return true;</string>
             </actions>
             <formComponents />
           </screen>
+          <screen name="" id="314" customizedId="" beanClass="com.install4j.runtime.beans.screens.CustomizableInfoScreen" enabled="true" commentSet="false" comment="" actionElevationType="inherit" rollbackBarrier="false" backButton="2" finishScreen="false" wizardIndexChangeType="unchanged" wizardIndexKey="">
+            <serializedBean>
+              <java class="java.beans.XMLDecoder">
+                <object class="com.install4j.runtime.beans.screens.CustomizableInfoScreen">
+                  <void property="infoText">
+                    <string>Util.hasFullAdminRights()</string>
+                  </void>
+                  <void property="title">
+                    <string>Full Admin?</string>
+                  </void>
+                </object>
+              </java>
+            </serializedBean>
+            <condition />
+            <validation />
+            <preActivation />
+            <postActivation />
+            <actions />
+            <formComponents />
+          </screen>
           <screen name="" id="27" customizedId="" beanClass="com.install4j.runtime.beans.screens.FileAssociationsScreen" enabled="true" commentSet="false" comment="" actionElevationType="inherit" rollbackBarrier="false" backButton="2" finishScreen="false" wizardIndexChangeType="unchanged" wizardIndexKey="">
             <serializedBean>
               <java class="java.beans.XMLDecoder">

--- a/jabref.install4j
+++ b/jabref.install4j
@@ -374,7 +374,7 @@ return true;</string>
                 </serializedBean>
                 <condition>context.getBooleanVariable("addToDockAction")</condition>
               </action>
-              <group name="Registry" id="239" customizedId="" beanClass="com.install4j.runtime.beans.groups.ActionGroup" enabled="true" commentSet="false" comment="" actionElevationType="inherit">
+              <group name="Registry" id="239" customizedId="" beanClass="com.install4j.runtime.beans.groups.ActionGroup" enabled="true" commentSet="false" comment="" actionElevationType="elevated">
                 <serializedBean>
                   <java class="java.beans.XMLDecoder">
                     <object class="com.install4j.runtime.beans.groups.ActionGroup" />
@@ -617,48 +617,57 @@ return true;</string>
                 </serializedBean>
                 <condition />
               </action>
-              <action name="PathAdmin" id="280" customizedId="" beanClass="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
+              <group name="Registry" id="312" customizedId="" beanClass="com.install4j.runtime.beans.groups.ActionGroup" enabled="true" commentSet="false" comment="" actionElevationType="elevated">
                 <serializedBean>
                   <java class="java.beans.XMLDecoder">
-                    <object class="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction">
-                      <void property="keyName">
-                        <string>SOFTWARE\JabRef</string>
-                      </void>
-                      <void property="onlyIfEmpty">
-                        <boolean>false</boolean>
-                      </void>
-                      <void property="registryRoot">
-                        <object class="java.lang.Enum" method="valueOf">
-                          <class>com.install4j.api.windows.RegistryRoot</class>
-                          <string>HKEY_LOCAL_MACHINE</string>
-                        </object>
-                      </void>
-                    </object>
+                    <object class="com.install4j.runtime.beans.groups.ActionGroup" />
                   </java>
                 </serializedBean>
-                <condition>Util.hasFullAdminRights()</condition>
-              </action>
-              <action name="PathUnprivileged" id="281" customizedId="" beanClass="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
-                <serializedBean>
-                  <java class="java.beans.XMLDecoder">
-                    <object class="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction">
-                      <void property="keyName">
-                        <string>SOFTWARE\JabRef</string>
-                      </void>
-                      <void property="onlyIfEmpty">
-                        <boolean>false</boolean>
-                      </void>
-                      <void property="registryRoot">
-                        <object class="java.lang.Enum" method="valueOf">
-                          <class>com.install4j.api.windows.RegistryRoot</class>
-                          <string>HKEY_CURRENT_USER</string>
+                <beans>
+                  <action name="PathAdmin" id="280" customizedId="" beanClass="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
+                    <serializedBean>
+                      <java class="java.beans.XMLDecoder">
+                        <object class="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction">
+                          <void property="keyName">
+                            <string>SOFTWARE\JabRef</string>
+                          </void>
+                          <void property="onlyIfEmpty">
+                            <boolean>false</boolean>
+                          </void>
+                          <void property="registryRoot">
+                            <object class="java.lang.Enum" method="valueOf">
+                              <class>com.install4j.api.windows.RegistryRoot</class>
+                              <string>HKEY_LOCAL_MACHINE</string>
+                            </object>
+                          </void>
                         </object>
-                      </void>
-                    </object>
-                  </java>
-                </serializedBean>
-                <condition>!Util.hasFullAdminRights()</condition>
-              </action>
+                      </java>
+                    </serializedBean>
+                    <condition>Util.hasFullAdminRights()</condition>
+                  </action>
+                  <action name="PathUnprivileged" id="281" customizedId="" beanClass="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction" enabled="true" commentSet="false" comment="" actionElevationType="elevated" rollbackBarrier="false" multiExec="false" failureStrategy="1" errorMessage="">
+                    <serializedBean>
+                      <java class="java.beans.XMLDecoder">
+                        <object class="com.install4j.runtime.beans.actions.registry.DeleteRegistryItemAction">
+                          <void property="keyName">
+                            <string>SOFTWARE\JabRef</string>
+                          </void>
+                          <void property="onlyIfEmpty">
+                            <boolean>false</boolean>
+                          </void>
+                          <void property="registryRoot">
+                            <object class="java.lang.Enum" method="valueOf">
+                              <class>com.install4j.api.windows.RegistryRoot</class>
+                              <string>HKEY_CURRENT_USER</string>
+                            </object>
+                          </void>
+                        </object>
+                      </java>
+                    </serializedBean>
+                    <condition>!Util.hasFullAdminRights()</condition>
+                  </action>
+                </beans>
+              </group>
             </actions>
             <formComponents />
           </screen>


### PR DESCRIPTION
Will delete the registry keys of JabRef on uninstall.
I'm not sure if we save anything that should permanently stay in the registry, custom entry types etc? Currently this reg key only hosts the Path word for me, which displays the installation location of JabRef.
