### PR TITLE
Import dialog shows file extensions and filters the view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 ### Changed
 - [#1485](https://github.com/JabRef/jabref/issues/1485) Biblatex field shorttitle is now exported/imported as standard field ShortTitle to Word bibliography
+- [#1431](https://github.com/JabRef/jabref/issues/1431): Import dialog shows file extensions and filters the view
 
 ### Fixed
 - Fixed [#405](https://github.com/JabRef/jabref/issues/405): Added more {} around capital letters in Unicode/HTML to LaTeX conversion to preserve them

--- a/src/main/java/net/sf/jabref/importer/ImportFileFilter.java
+++ b/src/main/java/net/sf/jabref/importer/ImportFileFilter.java
@@ -16,6 +16,7 @@
 package net.sf.jabref.importer;
 
 import java.io.File;
+import java.util.StringJoiner;
 
 import javax.swing.filechooser.FileFilter;
 
@@ -33,7 +34,12 @@ class ImportFileFilter extends FileFilter implements Comparable<ImportFileFilter
 
     public ImportFileFilter(ImportFormat format) {
         this.format = format;
-        this.name = format.getFormatName();
+
+        StringJoiner sj = new StringJoiner(", ", format.getFormatName() + " (", ")");
+        for (String ext : format.getExtensions()) {
+            sj.add("*" + ext);
+        }
+        this.name = sj.toString();
     }
 
     public ImportFormat getImportFormat() {
@@ -42,11 +48,17 @@ class ImportFileFilter extends FileFilter implements Comparable<ImportFileFilter
 
     @Override
     public boolean accept(File file) {
-        return true;
-        /*if (file.isDirectory())
+        if (format.getExtensions().isEmpty()) {
             return true;
-        else
-            return file.getPath().toLowerCase().endsWith(extension);*/
+        }
+
+        for (String extension : format.getExtensions()) {
+            if (file.getName().endsWith(extension)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     @Override

--- a/src/test/java/net/sf/jabref/importer/ImportFileFilterTest.java
+++ b/src/test/java/net/sf/jabref/importer/ImportFileFilterTest.java
@@ -1,0 +1,84 @@
+package net.sf.jabref.importer;
+
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import net.sf.jabref.importer.fileformat.ImportFormat;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ImportFileFilterTest {
+
+    @Test
+    public void nameWithSingleExtensions() {
+        ImportFormat importFormatSingleExtension = new ImportFormat() {
+            @Override
+            protected boolean isRecognizedFormat(BufferedReader input) throws IOException {
+                return false;
+            }
+
+            @Override
+            protected ParserResult importDatabase(BufferedReader input) throws IOException {
+                return null;
+            }
+
+            @Override
+            public String getFormatName() {
+                return "Single Extension";
+            }
+
+            @Override
+            public List<String> getExtensions() {
+                return Collections.singletonList(".abc");
+            }
+
+            @Override
+            public String getDescription() {
+                return null;
+            }
+        };
+
+        ImportFileFilter importFileFilter = new ImportFileFilter(importFormatSingleExtension);
+        assertEquals("Single Extension (*.abc)", importFileFilter.getDescription());
+    }
+
+    @Test
+    public void nameWithMultipleExtensions() {
+        ImportFormat importFormatMultipleExtensions = new ImportFormat() {
+            @Override
+            protected boolean isRecognizedFormat(BufferedReader input) throws IOException {
+                return false;
+            }
+
+            @Override
+            protected ParserResult importDatabase(BufferedReader input) throws IOException {
+                return null;
+            }
+
+            @Override
+            public String getFormatName() {
+                return "Multiple Extensions";
+            }
+
+            @Override
+            public List<String> getExtensions() {
+                return Arrays.asList(".abc", ".xyz");
+            }
+
+            @Override
+            public String getDescription() {
+                return null;
+            }
+        };
+
+        ImportFileFilter importFileFilter = new ImportFileFilter(importFormatMultipleExtensions);
+        assertEquals("Multiple Extensions (*.abc, *.xyz)", importFileFilter.getDescription());
+    }
+
+}


### PR DESCRIPTION
Fixes #1431. 

The open dialog of the `importer import into (new | current) database` now shows the filextensions behind the filetypename and filters the view based on it (if no extension is know it shows all files).

Right now almost no extensions are known, but this should change when #1487 is merged.

- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)

