### PR TITLE
Added import order for javafx packages to the eclipse settings

### DIFF
--- a/eclipse.gradle
+++ b/eclipse.gradle
@@ -482,7 +482,7 @@ tasks.eclipse.doFirst {
             formatter_profile=_JabRef
             formatter_settings_version=12
             org.eclipse.jdt.ui.ignorelowercasenames=true
-            org.eclipse.jdt.ui.importorder=java;javax;net.sf.jabref;org.jabref;;\\#;
+            org.eclipse.jdt.ui.importorder=java;javax;javafx;net.sf.jabref;org.jabref;;\\#;
             org.eclipse.jdt.ui.ondemandthreshold=99
             org.eclipse.jdt.ui.staticondemandthreshold=99
             sp_cleanup.add_default_serial_version_id=true


### PR DESCRIPTION
The eclipse import order settings don't cover javafx packages but the file checkstyle.xml does. Therefore using "organize import" in eclipse gave wrong import order warnings at travis CI.

