### PR TITLE
Fix update notification for developer builds

### DIFF
--- a/src/main/java/net/sf/jabref/logic/util/Version.java
+++ b/src/main/java/net/sf/jabref/logic/util/Version.java
@@ -90,10 +90,8 @@ public class Version {
         } else if (this.getMajor() == otherVersion.getMajor()) {
             if (this.getMinor() > otherVersion.getMinor()) {
                 return true;
-            } else if ((this.getMinor() == otherVersion.getMinor()) && (this.getPatch() > otherVersion.getPatch())) {
-                return true;
             } else {
-                return false;
+                return (this.getMinor() == otherVersion.getMinor()) && (this.getPatch() > otherVersion.getPatch());
             }
         } else {
             return false;

--- a/src/main/java/net/sf/jabref/logic/util/Version.java
+++ b/src/main/java/net/sf/jabref/logic/util/Version.java
@@ -23,6 +23,8 @@ import java.net.URLConnection;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.json.JSONObject;
 
 /**
@@ -31,33 +33,34 @@ import org.json.JSONObject;
 public class Version {
 
     public final static String JABREF_DOWNLOAD_URL = "http://www.fosshub.com/JabRef.html";
+    private static final Log LOGGER = LogFactory.getLog(Version.class);
     private final static String JABREF_GITHUB_URL = "https://api.github.com/repos/JabRef/jabref/releases/latest";
 
-    private final String fullVersion;
-    private final int major;
-    private final int minor;
-    private final int patch;
-    private final boolean isDevelopmentVersion;
-
+    private String fullVersion = BuildInfo.UNKNOWN_VERSION;
+    private int major = 0;
+    private int minor = 0;
+    private int patch = 0;
+    private boolean isDevelopmentVersion = false;
 
     /**
      * @param version must be in form of X.X (eg 3.3; 3.4dev)
      */
     public Version(String version) {
         if (version == null || "".equals(version) || version.equals(BuildInfo.UNKNOWN_VERSION)) {
-            this.fullVersion = BuildInfo.UNKNOWN_VERSION;
-            this.major = this.minor = this.patch = 0;
-            this.isDevelopmentVersion = false;
             return;
         }
 
-        this.fullVersion = version;
-        isDevelopmentVersion = version.contains("dev");
         String[] versionParts = version.split("dev");
         String[] versionNumbers = versionParts[0].split(Pattern.quote("."));
-        this.major = Integer.parseInt(versionNumbers[0]);
-        this.minor = versionNumbers.length >= 2 ? Integer.parseInt(versionNumbers[1]) : 0;
-        this.patch = versionNumbers.length >= 3 ? Integer.parseInt(versionNumbers[2]) : 0;
+        try {
+            this.major = Integer.parseInt(versionNumbers[0]);
+            this.minor = versionNumbers.length >= 2 ? Integer.parseInt(versionNumbers[1]) : 0;
+            this.patch = versionNumbers.length >= 3 ? Integer.parseInt(versionNumbers[2]) : 0;
+            this.fullVersion = version;
+            this.isDevelopmentVersion = version.contains("dev");
+        } catch (NumberFormatException exception) {
+            LOGGER.warn("Invalid version string used: " + version, exception);
+        }
     }
 
     /**
@@ -86,7 +89,7 @@ public class Version {
             return false;
         }
         if (otherVersion.getFullVersion().equals(BuildInfo.UNKNOWN_VERSION)) {
-            return true;
+            return false;
         }
 
         if (this.getMajor() > otherVersion.getMajor()) {

--- a/src/main/java/net/sf/jabref/logic/util/Version.java
+++ b/src/main/java/net/sf/jabref/logic/util/Version.java
@@ -37,10 +37,10 @@ public class Version {
     private final static String JABREF_GITHUB_URL = "https://api.github.com/repos/JabRef/jabref/releases/latest";
 
     private String fullVersion = BuildInfo.UNKNOWN_VERSION;
-    private int major = 0;
-    private int minor = 0;
-    private int patch = 0;
-    private boolean isDevelopmentVersion = false;
+    private int major;
+    private int minor;
+    private int patch;
+    private boolean isDevelopmentVersion;
 
     /**
      * @param version must be in form of X.X (e.g., 3.3; 3.4dev)

--- a/src/test/java/net/sf/jabref/logic/util/version/VersionTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/version/VersionTest.java
@@ -14,22 +14,19 @@ public class VersionTest {
 
     @Test
     public void unknownVersionAsString() {
-        String versionText = BuildInfo.UNKNOWN_VERSION;
-        Version version = new Version(versionText);
+        Version version = new Version(BuildInfo.UNKNOWN_VERSION);
         assertEquals(BuildInfo.UNKNOWN_VERSION, version.getFullVersion());
     }
 
     @Test
     public void unknownVersionAsNull() {
-        String versionText = null;
-        Version version = new Version(versionText);
+        Version version = new Version(null);
         assertEquals(BuildInfo.UNKNOWN_VERSION, version.getFullVersion());
     }
 
     @Test
     public void unknownVersionAsEmptyString() {
-        String versionText = "";
-        Version version = new Version(versionText);
+        Version version = new Version("");
         assertEquals(BuildInfo.UNKNOWN_VERSION, version.getFullVersion());
     }
 
@@ -114,6 +111,13 @@ public class VersionTest {
     }
 
     @Test
+    public void unknownVersionIsNotNewerThanvalidVersion() {
+        Version unknownVersion = new Version(BuildInfo.UNKNOWN_VERSION);
+        Version validVersion = new Version("4.2");
+        assertFalse(unknownVersion.isNewerThan(validVersion));
+    }
+
+    @Test
     public void versionNewerThan() {
         Version olderVersion = new Version("2.4");
         Version newerVersion = new Version("4.2");
@@ -125,20 +129,6 @@ public class VersionTest {
         Version version1 = new Version("4.2");
         Version version2 = new Version("4.2");
         assertFalse(version1.isNewerThan(version2));
-    }
-
-    @Test
-    public void concreteVersionNewerThanUnknownVersion() {
-        Version concreteVersion = new Version("4.2");
-        Version unknownVersion = new Version(BuildInfo.UNKNOWN_VERSION);
-        assertTrue(concreteVersion.isNewerThan(unknownVersion));
-    }
-
-    @Test
-    public void unknownVersionNotNewerThanConceteVersion() {
-        Version concreteVersion = new Version("4.2");
-        Version unknownVersion = new Version(BuildInfo.UNKNOWN_VERSION);
-        assertTrue(unknownVersion.isNewerThan(concreteVersion));
     }
 
     @Test
@@ -173,7 +163,7 @@ public class VersionTest {
     public void equalVersionsNotNewer() {
         Version version1 = new Version("4.2.2");
         Version version2 = new Version("4.2.2");
-        assertTrue(version1.isNewerThan(version2));
+        assertFalse(version1.isNewerThan(version2));
     }
 
     @Test
@@ -186,13 +176,6 @@ public class VersionTest {
     public void changelogWithThreeDigits(){
         Version version = new Version("3.4.1");
         assertEquals("https://github.com/JabRef/jabref/blob/v3.4.1/CHANGELOG.md", version.getChangelogUrl());
-    }
-
-    @Test
-    public void versionNotReplaced() {
-        String versionText = "${version}";
-        Version version = new Version(versionText);
-        assertEquals(BuildInfo.UNKNOWN_VERSION, version.getFullVersion());
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/util/version/VersionTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/version/VersionTest.java
@@ -125,6 +125,13 @@ public class VersionTest {
     }
 
     @Test
+    public void versionNotNewerThan() {
+        Version olderVersion = new Version("2.4");
+        Version newerVersion = new Version("4.2");
+        assertFalse(olderVersion.isNewerThan(newerVersion));
+    }
+
+    @Test
     public void versionNotNewerThanSameVersion() {
         Version version1 = new Version("4.2");
         Version version2 = new Version("4.2");

--- a/src/test/java/net/sf/jabref/logic/util/version/VersionTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/version/VersionTest.java
@@ -153,6 +153,20 @@ public class VersionTest {
     }
 
     @Test
+    public void versionNewerMinor() {
+        Version older = new Version("4.1");
+        Version newer = new Version("4.2.1");
+        assertTrue(newer.isNewerThan(older));
+    }
+
+    @Test
+    public void versionNotNewerMinor() {
+        Version older = new Version("4.1");
+        Version newer = new Version("4.2.1");
+        assertFalse(older.isNewerThan(newer));
+    }
+
+    @Test
     public void versionNewerPatch() {
         Version older = new Version("4.2.1");
         Version newer = new Version("4.2.2");

--- a/src/test/java/net/sf/jabref/logic/util/version/VersionTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/version/VersionTest.java
@@ -19,6 +19,12 @@ public class VersionTest {
     }
 
     @Test
+    public void initVersionFromWrongStringResultsInUnknownVersion() {
+        Version version = new Version("${version}");
+        assertEquals(BuildInfo.UNKNOWN_VERSION, version.getFullVersion());
+    }
+
+    @Test
     public void versionOneDigit() {
         String versionText = "1";
         Version version = new Version(versionText);
@@ -82,6 +88,14 @@ public class VersionTest {
         assertEquals(2, version.getMinor());
         assertEquals(3, version.getPatch());
         assertTrue(version.isDevelopmentVersion());
+    }
+
+    @Test
+    public void validVersionIsNotNewerThanUnknownVersion() {
+        // Reason: unknown version should only happen for developer builds where we don't want an update notification
+        Version unknownVersion = new Version(BuildInfo.UNKNOWN_VERSION);
+        Version validVersion = new Version("4.2");
+        assertFalse(validVersion.isNewerThan(unknownVersion));
     }
 
     @Test


### PR DESCRIPTION
Just running the compiled version without using gradle resulted in a NumberFormatException since the version update was based on the wrong version string `${version}`. This is fixed with this PR (also in this case no update notification is shown).

- [ ] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)

