### PR TITLE
The customize entry dialogs field list gets the focus as soon as it is focused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - [#1249](https://github.com/JabRef/jabref/issues/1249) Date layout formatter added
 - Added ISBN integrity checker
 - Added filter to not show selected integrity checks
+- Enhance the entry customization dialog to give better visual feedback
 
 ### Fixed
 - Fixed [#1264](https://github.com/JabRef/jabref/issues/1264): S with caron does not render correctly

--- a/src/main/java/net/sf/jabref/gui/FieldSetComponent.java
+++ b/src/main/java/net/sf/jabref/gui/FieldSetComponent.java
@@ -22,6 +22,8 @@ import java.awt.Insets;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -48,7 +50,6 @@ import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.labelpattern.LabelPatternUtil;
 
 /**
- *
  * @author alver
  */
 class FieldSetComponent extends JPanel implements ActionListener {
@@ -176,6 +177,8 @@ class FieldSetComponent extends JPanel implements ActionListener {
         gbl.setConstraints(add, con);
         add(add);
 
+        FieldListFocusListener fieldListFocusListener = new FieldListFocusListener(list);
+        list.addFocusListener(fieldListFocusListener);
     }
 
     public void setListSelectionMode(int mode) {
@@ -191,7 +194,7 @@ class FieldSetComponent extends JPanel implements ActionListener {
         // Make sure it is visible:
         JViewport viewport = sp.getViewport();
         Rectangle rectangle = list.getCellBounds(idx, idx);
-        if(rectangle != null) {
+        if (rectangle != null) {
             viewport.scrollRectToVisible(rectangle);
         }
 
@@ -363,5 +366,30 @@ class FieldSetComponent extends JPanel implements ActionListener {
             move(1);
         }
     }
+
+    /**
+     * FocusListener to select the first entry in the list of fields when they are focused
+     */
+    protected class FieldListFocusListener<T> implements FocusListener {
+
+        private JList<T> list;
+
+        public FieldListFocusListener(JList<T> list) {
+            this.list = list;
+        }
+
+        @Override
+        public void focusGained(FocusEvent e) {
+            if (list.getSelectedValue() == null) {
+                list.setSelectedIndex(0);
+            }
+        }
+
+        @Override
+        public void focusLost(FocusEvent e) {
+            //focus should remain at the same position so nothing to do here
+        }
+    }
+
 
 }


### PR DESCRIPTION
When using tab to navigate through the entry customization dialog, the lists now selects the first entry to give visual feedback when they are selected and to enable the up and down buttons functionality.

- [x] Change in CHANGELOG.md described

![image](https://cloud.githubusercontent.com/assets/15339195/16559795/b5d1f014-41ef-11e6-9332-f391eade89c1.png)

