### PR TITLE
Minor improvement for duplicate key resolving dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - [#1485](https://github.com/JabRef/jabref/issues/1485): Biblatex field shorttitle is now exported/imported as standard field ShortTitle to Word bibliography
 - [#1431](https://github.com/JabRef/jabref/issues/1431): Import dialog shows file extensions and filters the view
 - Updated German translation
+- When resolving duplicate BibTeX-keys there is now an "Ignore" button. "Cancel" and close key now quits the resolving.
 
 ### Fixed
 - Fixed [#405](https://github.com/JabRef/jabref/issues/405): Added more {} around capital letters in Unicode/HTML to LaTeX conversion to preserve them

--- a/src/main/java/net/sf/jabref/gui/labelpattern/ResolveDuplicateLabelDialog.java
+++ b/src/main/java/net/sf/jabref/gui/labelpattern/ResolveDuplicateLabelDialog.java
@@ -51,6 +51,7 @@ class ResolveDuplicateLabelDialog {
     private final JDialog diag;
     private final List<JCheckBox> cbs = new ArrayList<>();
     private boolean okPressed;
+    private boolean cancelPressed;
 
     private static final String LAYOUT = "<font face=\"arial\"><b><i>\\bibtextype</i><a name=\"\\bibtexkey\">\\begin{bibtexkey} (\\bibtexkey)</a>\\end{bibtexkey}</b><br>\n" +
             "\\begin{author} \\format[HTMLChars,AuthorAbbreviator,AuthorAndsReplacer]{\\author}<BR>\\end{author}\n" +
@@ -78,15 +79,10 @@ class ResolveDuplicateLabelDialog {
         int row = 3;
         for (BibEntry entry : entries) {
             JCheckBox cb = new JCheckBox(Localization.lang("Generate BibTeX key"), !first);
-            //JPanel pan = new JPanel();
-            //pan.setLayout(new BorderLayout());
-            //pan.add(cb, BorderLayout.NORTH);
-            //cb.add(new JPanel(), BorderLayout.CENTER);
             b.appendRows("1dlu, p");
             b.add(cb).xy(1, row);
             PreviewPanel pp = new PreviewPanel(null, entry, null, ResolveDuplicateLabelDialog.LAYOUT);
             pp.setPreferredSize(new Dimension(800, 90));
-            //pp.setBorder(BorderFactory.createEtchedBorder());
             b.add(new JScrollPane(pp)).xy(3, row);
             row += 2;
             cbs.add(cb);
@@ -97,6 +93,8 @@ class ResolveDuplicateLabelDialog {
         bb.addGlue();
         JButton ok = new JButton(Localization.lang("OK"));
         bb.addButton(ok);
+        JButton ignore = new JButton(Localization.lang("Ignore"));
+        bb.addButton(ignore);
         JButton cancel = new JButton(Localization.lang("Cancel"));
         bb.addButton(cancel);
         bb.addGlue();
@@ -112,11 +110,13 @@ class ResolveDuplicateLabelDialog {
                 diag.dispose();
         });
 
+        ignore.addActionListener(e -> diag.dispose());
 
         AbstractAction closeAction = new AbstractAction() {
 
             @Override
             public void actionPerformed(ActionEvent e) {
+                cancelPressed = true;
                 diag.dispose();
             }
         };
@@ -151,5 +151,9 @@ class ResolveDuplicateLabelDialog {
         okPressed = false;
         diag.setLocationRelativeTo(diag.getParent());
         diag.setVisible(true);
+    }
+
+    public boolean isCancelPressed() {
+        return cancelPressed;
     }
 }

--- a/src/main/java/net/sf/jabref/gui/labelpattern/SearchFixDuplicateLabels.java
+++ b/src/main/java/net/sf/jabref/gui/labelpattern/SearchFixDuplicateLabels.java
@@ -47,7 +47,7 @@ public class SearchFixDuplicateLabels extends AbstractWorker {
 
     @Override
     public void run() {
-        // Find all multiple occurences of BibTeX keys.
+        // Find all multiple occurrences of BibTeX keys.
         dupes = new HashMap<>();
 
         Map<String, BibEntry> foundKeys = new HashMap<>();
@@ -99,6 +99,8 @@ public class SearchFixDuplicateLabels extends AbstractWorker {
                         toGenerateFor.add(dupeEntry.getValue().get(i));
                     }
                 }
+            } else if (rdld.isCancelPressed()) {
+                break;
             }
         }
 


### PR DESCRIPTION
Added an "Ignore" button to the duplicate key resolving dialog and changed the behavior of cancel and close key such that the complete key resolving process is cancelled.

Not sure how to refer to the discourse topic.

- [x] Change in CHANGELOG.md described
