### PR TITLE
Added content-type heading for HTML export fixing #1484

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed [#1482](https://github.com/JabRef/jabref/issues/1482): Correct number of matched entries is displayed for refining subgroups
 - Fixed [#1444](https://github.com/JabRef/jabref/issues/1444): Implement getExtension and getDescription for importers.
 - Fixed [#1507](https://github.com/JabRef/jabref/issues/1507): Keywords are now separated by the delimiter specified in the preferences
+- Fixed [#1484](https://github.com/JabRef/jabref/issues/1484): HTML export handles some UTF characters wrong
 
 ### Removed
 

--- a/src/main/resources/resource/layout/html.begin.layout
+++ b/src/main/resources/resource/layout/html.begin.layout
@@ -1,8 +1,9 @@
 <!-- jabref.sf.net generated HTML layout  -->
 <!-- 2006-01-17 wegner added PMID linkout -->
 <html>
-<header>
+<head>
 	<title>JabRef Output</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 	<style type="text/css">
 body {
     font-family:Georgia, Garamond, Serif;
@@ -57,7 +58,7 @@ body {
     display:inline;
 }
 	</style>
-</header>
+</head>
 <body>
 
 


### PR DESCRIPTION
Added a content type tag (and fixed tag name, head instead of header) to fix #1484.

- [X] Change in CHANGELOG.md described
