### PR TITLE
Performance improvements for groups

### DIFF
--- a/src/main/java/net/sf/jabref/gui/groups/GroupSelector.java
+++ b/src/main/java/net/sf/jabref/gui/groups/GroupSelector.java
@@ -723,9 +723,8 @@ public class GroupSelector extends SidePaneComponent implements TreeSelectionLis
 
     private void setGroups(GroupTreeNode groupsRoot) {
         this.groupsRoot = new GroupTreeNodeViewModel(groupsRoot);
-        // refactor notice: groupsTreeModel::nodeStructureChanged cannot be used, because an NPE will be risen if no groupsTreeModel exists
-        this.groupsRoot.subscribeToDescendantChanged(source -> groupsTreeModel.nodeStructureChanged(source));
         groupsTreeModel = new DefaultTreeModel(this.groupsRoot);
+        this.groupsRoot.subscribeToDescendantChanged(groupsTreeModel::nodeStructureChanged);
         groupsTree.setModel(groupsTreeModel);
         if (Globals.prefs.getBoolean(JabRefPreferences.GROUP_EXPAND_TREE)) {
             this.groupsRoot.expandSubtree(groupsTree);

--- a/src/main/java/net/sf/jabref/logic/groups/KeywordGroup.java
+++ b/src/main/java/net/sf/jabref/logic/groups/KeywordGroup.java
@@ -201,11 +201,8 @@ public class KeywordGroup extends AbstractGroup {
     @Override
     public boolean contains(BibEntry entry) {
         if (regExp) {
-            String content = entry.getField(searchField);
-            if (content == null) {
-                return false;
-            }
-            return pattern.matcher(content).find();
+            Optional<String> content = entry.getFieldOptional(searchField);
+            return content.map(value -> pattern.matcher(value).find()).orElse(false);
         }
 
         Set<String> words = entry.getFieldAsWords(searchField);

--- a/src/main/java/net/sf/jabref/logic/groups/KeywordGroup.java
+++ b/src/main/java/net/sf/jabref/logic/groups/KeywordGroup.java
@@ -30,6 +30,7 @@ import net.sf.jabref.logic.util.strings.QuotedStringTokenizer;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.model.entry.EntryUtil;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -65,7 +66,7 @@ public class KeywordGroup extends AbstractGroup {
         if (this.regExp) {
             compilePattern();
         }
-        this.searchWords = StringUtil.getStringAsWords(searchExpression);
+        this.searchWords = EntryUtil.getStringAsWords(searchExpression);
     }
 
     private void compilePattern() throws ParseException {

--- a/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
@@ -654,14 +654,4 @@ public class StringUtil {
 
     }
 
-    /**
-     * Returns a list of words contained in the given text.
-     * Whitespace, comma and semicolon are considered as separator between words.
-     *
-     * @param text the input
-     * @return a list of words
-     */
-    public static List<String> getStringAsWords(String text) {
-        return Arrays.asList(text.split("[\\s,;]+"));
-    }
 }

--- a/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
@@ -16,6 +16,7 @@
 package net.sf.jabref.logic.util.strings;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -653,4 +654,14 @@ public class StringUtil {
 
     }
 
+    /**
+     * Returns a list of words contained in the given text.
+     * Whitespace, comma and semicolon are considered as separator between words.
+     *
+     * @param text the input
+     * @return a list of words
+     */
+    public static List<String> getStringAsWords(String text) {
+        return Arrays.asList(text.split("[\\s,;]+"));
+    }
 }

--- a/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
@@ -16,7 +16,6 @@
 package net.sf.jabref.logic.util.strings;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -34,7 +33,7 @@ public class StringUtil {
 
     private static final Pattern BRACED_TITLE_CAPITAL_PATTERN = Pattern.compile("\\{[A-Z]+\\}");
 
-    public static final UnicodeToReadableCharMap UNICODE_CHAR_MAP = new UnicodeToReadableCharMap();
+    private static final UnicodeToReadableCharMap UNICODE_CHAR_MAP = new UnicodeToReadableCharMap();
 
     /**
      * Returns the string, after shaving off whitespace at the beginning and end,

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -37,7 +37,6 @@ import java.util.TreeSet;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.event.FieldChangedEvent;
-import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.database.BibDatabase;
 
@@ -640,7 +639,7 @@ public class BibEntry implements Cloneable {
             if (fieldValue == null) {
                 return Collections.emptySet();
             } else {
-                HashSet<String> words = new HashSet<>(StringUtil.getStringAsWords(fieldValue));
+                HashSet<String> words = new HashSet<>(EntryUtil.getStringAsWords(fieldValue));
                 fieldsAsWords.put(fieldName, words);
                 return words;
             }

--- a/src/main/java/net/sf/jabref/model/entry/EntryUtil.java
+++ b/src/main/java/net/sf/jabref/model/entry/EntryUtil.java
@@ -1,6 +1,8 @@
 package net.sf.jabref.model.entry;
 
+import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
 
@@ -50,5 +52,16 @@ public class EntryUtil {
      */
     public static Set<String> getSeparatedKeywords(BibEntry entry) {
         return getSeparatedKeywords(entry.getFieldOptional(BibEntry.KEYWORDS_FIELD).orElse(null));
+    }
+
+    /**
+     * Returns a list of words contained in the given text.
+     * Whitespace, comma and semicolon are considered as separator between words.
+     *
+     * @param text the input
+     * @return a list of words
+     */
+    public static List<String> getStringAsWords(String text) {
+        return Arrays.asList(text.split("[\\s,;]+"));
     }
 }

--- a/src/test/java/net/sf/jabref/logic/groups/KeywordGroupTest.java
+++ b/src/test/java/net/sf/jabref/logic/groups/KeywordGroupTest.java
@@ -1,10 +1,12 @@
 package net.sf.jabref.logic.groups;
 
 import net.sf.jabref.importer.fileformat.ParseException;
+import net.sf.jabref.model.entry.BibEntry;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class KeywordGroupTest {
 
@@ -22,4 +24,59 @@ public class KeywordGroupTest {
         assertEquals("KeywordGroup:myExplicitGroup;1;author;asdf;0;1;", group.toString());
     }
 
+    @Test
+    public void containsSimpleWord() throws Exception {
+        KeywordGroup group = new KeywordGroup("name", "keywords", "test", false, false, GroupHierarchyType.INDEPENDENT);
+        BibEntry entry = new BibEntry().withField("keywords", "test");
+
+        assertTrue(group.isMatch(entry));
+    }
+
+    @Test
+    public void containsSimpleWordInSentence() throws Exception {
+        KeywordGroup group = new KeywordGroup("name", "keywords", "test", false, false, GroupHierarchyType.INDEPENDENT);
+        BibEntry entry = new BibEntry().withField("keywords", "Some sentence containing test word");
+
+        assertTrue(group.isMatch(entry));
+    }
+
+    @Test
+    public void containsSimpleWordCommaSeparated() throws Exception {
+        KeywordGroup group = new KeywordGroup("name", "keywords", "test", false, false, GroupHierarchyType.INDEPENDENT);
+        BibEntry entry = new BibEntry().withField("keywords", "Some,list,containing,test,word");
+
+        assertTrue(group.isMatch(entry));
+    }
+
+    @Test
+    public void containsSimpleWordSemicolonSeparated() throws Exception {
+        KeywordGroup group = new KeywordGroup("name", "keywords", "test", false, false, GroupHierarchyType.INDEPENDENT);
+        BibEntry entry = new BibEntry().withField("keywords", "Some;list;containing;test;word");
+
+        assertTrue(group.isMatch(entry));
+    }
+
+    @Test
+    public void containsComplexWord() throws Exception {
+        KeywordGroup group = new KeywordGroup("name", "keywords", "\\H2O", false, false, GroupHierarchyType.INDEPENDENT);
+        BibEntry entry = new BibEntry().withField("keywords", "\\H2O");
+
+        assertTrue(group.isMatch(entry));
+    }
+
+    @Test
+    public void containsComplexWordInSentence() throws Exception {
+        KeywordGroup group = new KeywordGroup("name", "keywords", "\\H2O", false, false, GroupHierarchyType.INDEPENDENT);
+        BibEntry entry = new BibEntry().withField("keywords", "Some sentence containing \\H2O word");
+
+        assertTrue(group.isMatch(entry));
+    }
+
+    @Test
+    public void containsWordWithWhitespaceInSentence() throws Exception {
+        KeywordGroup group = new KeywordGroup("name", "keywords", "test word", false, false, GroupHierarchyType.INDEPENDENT);
+        BibEntry entry = new BibEntry().withField("keywords", "Some sentence containing test word");
+
+        assertTrue(group.isMatch(entry));
+    }
 }


### PR DESCRIPTION
The BibEntry now stores a list of words which are contained in the field. in this way the KeywordGroup.isMatch method just has to compare two arrays instead of analyzing strings over and over again. For a big file (> 7000 entries, > 100 groups) the load time decreased by 1 sec from 4.8 seconds to 3.7. Half of the time needed for showing the groups tree is spent in calculating the number of hits. Moreover, subsequent rerendings of the groups tree (for example after changing an entry) are also quicker.

Note that the match algorithm changed slightly. For example, previously looking for `test` in `some$test` resulted in a match; this is no longer the case. However, normal word separators (like whitespace, comma and semicolon are recognized properly), i.e. searching for `test` in `some test` returns true.

Also fixed a NPE.

- [ ] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)