### PR TITLE
Fixed #1534

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed [#1444](https://github.com/JabRef/jabref/issues/1444): Implement getExtension and getDescription for importers.
 - Fixed [#1507](https://github.com/JabRef/jabref/issues/1507): Keywords are now separated by the delimiter specified in the preferences
 - Fixed [#1484](https://github.com/JabRef/jabref/issues/1484): HTML export handles some UTF characters wrong
+- Fixed [#1534](https://github.com/JabRef/jabref/issues/1534): "Mark entries imported into database" does not work correctly
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/gui/EntryMarker.java
+++ b/src/main/java/net/sf/jabref/gui/EntryMarker.java
@@ -196,8 +196,6 @@ public class EntryMarker {
     }
 
     public static boolean shouldMarkEntries() {
-        return (Globals.prefs.getBoolean(JabRefPreferences.MARK_IMPORTED_ENTRIES)
-                && (Globals.prefs.getBoolean(JabRefPreferences.USE_OWNER)
-                        || Globals.prefs.getBoolean(JabRefPreferences.USE_TIME_STAMP)));
+        return Globals.prefs.getBoolean(JabRefPreferences.MARK_IMPORTED_ENTRIES);
     }
 }


### PR DESCRIPTION
Marking of imported entries should work again (#1534). Not really sure why I introduced that bug. Looking back at the code https://github.com/JabRef/jabref/commit/8d9c806eb41b809822e3acadc9299315850bd10c it doesn't really make sense to do as I did...

- [x] Change in CHANGELOG.md described


