### PR TITLE
Moved final methods from Util

### DIFF
--- a/src/main/java/net/sf/jabref/gui/groups/AddToGroupAction.java
+++ b/src/main/java/net/sf/jabref/gui/groups/AddToGroupAction.java
@@ -29,7 +29,6 @@ import net.sf.jabref.logic.groups.EntriesGroupChange;
 import net.sf.jabref.logic.groups.GroupTreeNode;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.util.Util;
 
 public class AddToGroupAction extends AbstractAction {
 
@@ -93,7 +92,7 @@ public class AddToGroupAction extends AbstractAction {
         List<AbstractGroup> affectedGroups = groupsContainingEntries.stream().map(GroupTreeNode::getGroup).collect(
                 Collectors.toList());
         affectedGroups.add(node.getNode().getGroup());
-        if (!Util.warnAssignmentSideEffects(affectedGroups, panel.frame())) {
+        if (!WarnAssignmentSideEffects.warnAssignmentSideEffects(affectedGroups, panel.frame())) {
             return; // user aborted operation
         }
 
@@ -113,7 +112,7 @@ public class AddToGroupAction extends AbstractAction {
     }
 
     public void addToGroup(List<BibEntry> entries, NamedCompound undo) {
-        if (!Util.warnAssignmentSideEffects(node.getNode().getGroup(), panel.frame())) {
+        if (!WarnAssignmentSideEffects.warnAssignmentSideEffects(node.getNode().getGroup(), panel.frame())) {
             return; // user aborted operation
         }
 

--- a/src/main/java/net/sf/jabref/gui/groups/GroupDialog.java
+++ b/src/main/java/net/sf/jabref/gui/groups/GroupDialog.java
@@ -65,7 +65,6 @@ import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.search.SearchQuery;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.util.Util;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import com.jgoodies.forms.builder.DefaultFormBuilder;
@@ -483,7 +482,7 @@ class GroupDialog extends JDialog {
             }
         }
         if (!list.isEmpty()) {
-            if (!Util.warnAssignmentSideEffects(mResultingGroup, this)) {
+            if (!WarnAssignmentSideEffects.warnAssignmentSideEffects(mResultingGroup, this)) {
                 return;
             }
             // the undo information for a conversion to an ExplicitGroup is

--- a/src/main/java/net/sf/jabref/gui/groups/GroupsTree.java
+++ b/src/main/java/net/sf/jabref/gui/groups/GroupsTree.java
@@ -56,7 +56,6 @@ import net.sf.jabref.logic.groups.EntriesGroupChange;
 import net.sf.jabref.logic.groups.GroupTreeNode;
 import net.sf.jabref.logic.groups.MoveGroupChange;
 import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.util.Util;
 
 public class GroupsTree extends JTree implements DragSourceListener,
         DropTargetListener, DragGestureListener {
@@ -302,7 +301,7 @@ public class GroupsTree extends JTree implements DragSourceListener,
 
                 // warn if assignment has undesired side effects (modifies a
                 // field != keywords)
-                if (!Util.warnAssignmentSideEffects(group, groupSelector.frame))
+                if (!WarnAssignmentSideEffects.warnAssignmentSideEffects(group, groupSelector.frame))
                  {
                     return; // user aborted operation
                 }

--- a/src/main/java/net/sf/jabref/gui/groups/RemoveFromGroupAction.java
+++ b/src/main/java/net/sf/jabref/gui/groups/RemoveFromGroupAction.java
@@ -23,7 +23,6 @@ import javax.swing.AbstractAction;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.logic.groups.EntriesGroupChange;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.util.Util;
 
 public class RemoveFromGroupAction extends AbstractAction {
 
@@ -52,7 +51,7 @@ public class RemoveFromGroupAction extends AbstractAction {
     @Override
     public void actionPerformed(ActionEvent evt) {
         // warn if assignment has undesired side effects (modifies a field != keywords)
-        if (!Util.warnAssignmentSideEffects(mNode.getNode().getGroup(), mPanel.frame())) {
+        if (!WarnAssignmentSideEffects.warnAssignmentSideEffects(mNode.getNode().getGroup(), mPanel.frame())) {
             return; // user aborted operation
         }
 

--- a/src/main/java/net/sf/jabref/gui/groups/WarnAssignmentSideEffects.java
+++ b/src/main/java/net/sf/jabref/gui/groups/WarnAssignmentSideEffects.java
@@ -1,24 +1,4 @@
-/*  Copyright (C) 2003-2016 JabRef contributors.
-    Copyright (C) 2015 Oliver Kopp
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- */
-
-// created by : Morten O. Alver 2003
-
-package net.sf.jabref.util;
+package net.sf.jabref.gui.groups;
 
 import java.awt.Component;
 import java.util.ArrayList;
@@ -27,49 +7,12 @@ import java.util.List;
 
 import javax.swing.JOptionPane;
 
-import net.sf.jabref.gui.worker.AbstractWorker;
-import net.sf.jabref.gui.worker.CallBack;
-import net.sf.jabref.gui.worker.Worker;
 import net.sf.jabref.logic.groups.AbstractGroup;
 import net.sf.jabref.logic.groups.KeywordGroup;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.InternalBibtexFields;
 
-/**
- * utility functions
- */
-public class Util {
-
-    /**
-     * Run an AbstractWorker's methods using Spin features to put each method on the correct thread.
-     *
-     * @param worker The worker to run.
-     * @throws Throwable
-     */
-    public static void runAbstractWorker(AbstractWorker worker) throws Throwable {
-        // This part uses Spin's features:
-        Worker wrk = worker.getWorker();
-        // The Worker returned by getWorker() has been wrapped
-        // by Spin.off(), which makes its methods be run in
-        // a different thread from the EDT.
-        CallBack clb = worker.getCallBack();
-
-        worker.init(); // This method runs in this same thread, the EDT.
-        // Useful for initial GUI actions, like printing a message.
-
-        // The CallBack returned by getCallBack() has been wrapped
-        // by Spin.over(), which makes its methods be run on
-        // the EDT.
-        wrk.run(); // Runs the potentially time-consuming action
-        // without freezing the GUI. The magic is that THIS line
-        // of execution will not continue until run() is finished.
-        clb.update(); // Runs the update() method on the EDT.
-    }
-
-
-    public static boolean warnAssignmentSideEffects(AbstractGroup group, Component parent) {
-        return warnAssignmentSideEffects(Collections.singletonList(group), parent);
-    }
+public class WarnAssignmentSideEffects {
 
     /**
      * Warns the user of undesired side effects of an explicit assignment/removal of entries to/from this group.
@@ -102,7 +45,7 @@ public class Util {
         if (affectedFields.isEmpty()) {
             return true; // no side effects
         }
-
+    
         // show a warning, then return
         StringBuilder message = new StringBuilder(
                 Localization.lang("This action will modify the following field(s) in at least one entry each:"))
@@ -116,7 +59,7 @@ public class Util {
         int choice = JOptionPane.showConfirmDialog(parent, message, Localization.lang("Warning"),
                 JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
         return choice != JOptionPane.NO_OPTION;
-
+    
         // if (groups instanceof KeywordGroup) {
         // KeywordGroup kg = (KeywordGroup) groups;
         // String field = kg.getSearchField().toLowerCase();
@@ -142,6 +85,10 @@ public class Util {
         // }
         // }
         // return true; // found no side effects
+    }
+
+    public static boolean warnAssignmentSideEffects(AbstractGroup group, Component parent) {
+        return warnAssignmentSideEffects(Collections.singletonList(group), parent);
     }
 
 }

--- a/src/main/java/net/sf/jabref/gui/groups/WarnAssignmentSideEffects.java
+++ b/src/main/java/net/sf/jabref/gui/groups/WarnAssignmentSideEffects.java
@@ -28,8 +28,8 @@ public class WarnAssignmentSideEffects {
         List<String> affectedFields = new ArrayList<>();
         for (AbstractGroup group : groups) {
             if (group instanceof KeywordGroup) {
-                KeywordGroup kg = (KeywordGroup) group;
-                String field = kg.getSearchField().toLowerCase();
+                KeywordGroup keywordGroup = (KeywordGroup) group;
+                String field = keywordGroup.getSearchField().toLowerCase();
                 if ("keywords".equals(field) || "groups".equals(field)) {
                     continue; // this is not undesired
                 }
@@ -45,7 +45,7 @@ public class WarnAssignmentSideEffects {
         if (affectedFields.isEmpty()) {
             return true; // no side effects
         }
-    
+
         // show a warning, then return
         StringBuilder message = new StringBuilder(
                 Localization.lang("This action will modify the following field(s) in at least one entry each:"))
@@ -59,7 +59,7 @@ public class WarnAssignmentSideEffects {
         int choice = JOptionPane.showConfirmDialog(parent, message, Localization.lang("Warning"),
                 JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
         return choice != JOptionPane.NO_OPTION;
-    
+
         // if (groups instanceof KeywordGroup) {
         // KeywordGroup kg = (KeywordGroup) groups;
         // String field = kg.getSearchField().toLowerCase();

--- a/src/main/java/net/sf/jabref/sql/importer/DbImportAction.java
+++ b/src/main/java/net/sf/jabref/sql/importer/DbImportAction.java
@@ -197,11 +197,6 @@ public class DbImportAction extends AbstractWorker {
         frame.output(Localization.lang("Imported %0 databases successfully", Integer.toString(databases.size())));
     }
 
-    /**
-     * Run using Spin features to put each method on the correct thread.
-     *
-     * @throws Throwable
-     */
     private void runInSeparateThread() throws Throwable {
         // This part uses Spin's features:
         Worker wrk = this.getWorker();

--- a/src/main/java/net/sf/jabref/sql/importer/DbImportAction.java
+++ b/src/main/java/net/sf/jabref/sql/importer/DbImportAction.java
@@ -32,6 +32,8 @@ import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.actions.MnemonicAwareAction;
 import net.sf.jabref.gui.worker.AbstractWorker;
+import net.sf.jabref.gui.worker.CallBack;
+import net.sf.jabref.gui.worker.Worker;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.sql.DBConnectDialog;
 import net.sf.jabref.sql.DBExporterAndImporterFactory;
@@ -39,7 +41,6 @@ import net.sf.jabref.sql.DBImportExportDialog;
 import net.sf.jabref.sql.DBStrings;
 import net.sf.jabref.sql.DatabaseUtil;
 import net.sf.jabref.sql.SQLUtil;
-import net.sf.jabref.util.Util;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -77,7 +78,7 @@ public class DbImportAction extends AbstractWorker {
         @Override
         public void actionPerformed(ActionEvent e) {
             try {
-                Util.runAbstractWorker(DbImportAction.this);
+                runInSeparateThread();
             } catch (Throwable throwable) {
                 LOGGER.warn("Problem importing from database", throwable);
             }
@@ -194,6 +195,31 @@ public class DbImportAction extends AbstractWorker {
             }
         }
         frame.output(Localization.lang("Imported %0 databases successfully", Integer.toString(databases.size())));
+    }
+
+    /**
+     * Run using Spin features to put each method on the correct thread.
+     *
+     * @throws Throwable
+     */
+    private void runInSeparateThread() throws Throwable {
+        // This part uses Spin's features:
+        Worker wrk = this.getWorker();
+        // The Worker returned by getWorker() has been wrapped
+        // by Spin.off(), which makes its methods be run in
+        // a different thread from the EDT.
+        CallBack clb = this.getCallBack();
+
+        this.init(); // This method runs in this same thread, the EDT.
+        // Useful for initial GUI actions, like printing a message.
+
+        // The CallBack returned by getCallBack() has been wrapped
+        // by Spin.over(), which makes its methods be run on
+        // the EDT.
+        wrk.run(); // Runs the potentially time-consuming action
+        // without freezing the GUI. The magic is that THIS line
+        // of execution will not continue until run() is finished.
+        clb.update(); // Runs the update() method on the EDT.
     }
 
 }


### PR DESCRIPTION
Final methods moved from Util and the class finally removed. I'm sure the DbImportAction can be improved by using `Thread.start()`, but this seems like a generic problem for JabRef.

