### PR TITLE
Added button to crossref entry editor field to select parent entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Updated German translation
 - When resolving duplicate BibTeX-keys there is now an "Ignore" button. "Cancel" and close key now quits the resolving.
 - The [online forum](http://discourse.jabref.org/) is now directly accessible via the "Help" menu
-- Implemented [#1338](https://github.com/JabRef/jabref/issues/1338) partly: Added a button in the entry editor to select the crossref parent entry.
+- Implemented [#1338](https://github.com/JabRef/jabref/issues/1338): clicking on a crossref in the main table selects the parent entry and added a button in the entry editor to select the parent entry.
 
 ### Fixed
 - Fixed [#405](https://github.com/JabRef/jabref/issues/405): Added more {} around capital letters in Unicode/HTML to LaTeX conversion to preserve them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Updated German translation
 - When resolving duplicate BibTeX-keys there is now an "Ignore" button. "Cancel" and close key now quits the resolving.
 - The [online forum](http://discourse.jabref.org/) is now directly accessible via the "Help" menu
+- Implemented [#1338](https://github.com/JabRef/jabref/issues/1338) partly: Added a button in the entry editor to select the crossref parent entry.
 
 ### Fixed
 - Fixed [#405](https://github.com/JabRef/jabref/issues/405): Added more {} around capital letters in Unicode/HTML to LaTeX conversion to preserve them

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -529,6 +529,8 @@ public class EntryEditor extends JPanel implements EntryContainer {
             return FieldExtraComponents.getPaginationExtraComponent(editor, this);
         } else if (fieldExtras.contains(FieldProperties.TYPE)) {
             return FieldExtraComponents.getTypeExtraComponent(editor, this, "patent".equalsIgnoreCase(entry.getType()));
+        } else if (fieldExtras.contains(FieldProperties.CROSSREF)) {
+            return FieldExtraComponents.getCrossrefExtraComponent(editor, frame.getCurrentBasePanel());
         }
         return Optional.empty();
     }

--- a/src/main/java/net/sf/jabref/gui/entryeditor/FieldExtraComponents.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/FieldExtraComponents.java
@@ -507,7 +507,7 @@ public class FieldExtraComponents {
             }
 
             private void checkValidKey() {
-                if (panel.getDatabase().containsEntryWithKey(crossref.getText())) {
+                if (panel.getDatabase().getEntryByKey(crossref.getText()) != null) {
                     button.setEnabled(true);
                 } else {
                     button.setEnabled(false);

--- a/src/main/java/net/sf/jabref/gui/entryeditor/FieldExtraComponents.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/FieldExtraComponents.java
@@ -134,7 +134,7 @@ public class FieldExtraComponents {
         // enable/disable button
         JTextComponent url = (JTextComponent) fieldEditor;
 
-        DocumentListener documentListener = new DocumentListener() {
+        url.getDocument().addDocumentListener(new DocumentListener() {
             @Override
             public void changedUpdate(DocumentEvent documentEvent) {
                 checkUrl();
@@ -157,8 +157,7 @@ public class FieldExtraComponents {
                     button.setEnabled(false);
                 }
             }
-        };
-        url.getDocument().addDocumentListener(documentListener);
+        });
 
         return Optional.of(controls);
     }
@@ -205,7 +204,7 @@ public class FieldExtraComponents {
         // enable/disable button
         JTextComponent doi = (JTextComponent) fieldEditor;
 
-        DocumentListener documentListener = new DocumentListener() {
+        doi.getDocument().addDocumentListener(new DocumentListener() {
             @Override
             public void changedUpdate(DocumentEvent documentEvent) {
                 checkDoi();
@@ -231,8 +230,7 @@ public class FieldExtraComponents {
                     fetchButton.setEnabled(false);
                 }
             }
-        };
-        doi.getDocument().addDocumentListener(documentListener);
+        });
 
         return Optional.of(controls);
     }
@@ -476,9 +474,9 @@ public class FieldExtraComponents {
     }
 
     /**
-     * Return a button which sets the owner if the field for fields with EXTRA_SET_OWNER
-     * @param fieldEditor
-     * @param storeFieldAction
+     * Return a button which allows to go to the parent entry of the crossref field
+     * @param fieldEditor The FieldEditor component to get the entry key from
+     * @param panel The current BasePanel
      * @return
      */
 
@@ -487,39 +485,35 @@ public class FieldExtraComponents {
         JButton button = new JButton(Localization.lang("Select"));
         JTextComponent crossref = (JTextComponent) fieldEditor;
 
-        button.addActionListener(actionEvent -> {
-            panel.highlightEntry(panel.getDatabase().getEntryByKey(crossref.getText()));
-        });
+        button.addActionListener(
+                actionEvent -> panel.highlightEntry(panel.getDatabase().getEntryByKey(crossref.getText())));
 
         // enable/disable button
-
-        DocumentListener documentListener = new DocumentListener() {
+        crossref.getDocument().addDocumentListener(new DocumentListener() {
 
             @Override
             public void changedUpdate(DocumentEvent documentEvent) {
-                checkUrl();
+                checkValidKey();
             }
 
             @Override
             public void insertUpdate(DocumentEvent documentEvent) {
-                checkUrl();
+                checkValidKey();
             }
 
             @Override
             public void removeUpdate(DocumentEvent documentEvent) {
-                checkUrl();
+                checkValidKey();
             }
 
-            private void checkUrl() {
+            private void checkValidKey() {
                 if (panel.getDatabase().containsEntryWithKey(crossref.getText())) {
                     button.setEnabled(true);
                 } else {
                     button.setEnabled(false);
                 }
             }
-        };
-
-        crossref.getDocument().addDocumentListener(documentListener);
+        });
 
         return Optional.of(button);
 

--- a/src/main/java/net/sf/jabref/gui/entryeditor/FieldExtraComponents.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/FieldExtraComponents.java
@@ -520,6 +520,7 @@ public class FieldExtraComponents {
         };
 
         crossref.getDocument().addDocumentListener(documentListener);
+
         return Optional.of(button);
 
     }

--- a/src/main/java/net/sf/jabref/gui/entryeditor/FieldExtraComponents.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/FieldExtraComponents.java
@@ -474,4 +474,54 @@ public class FieldExtraComponents {
         return Optional.of(gender);
 
     }
+
+    /**
+     * Return a button which sets the owner if the field for fields with EXTRA_SET_OWNER
+     * @param fieldEditor
+     * @param storeFieldAction
+     * @return
+     */
+
+    public static Optional<JComponent> getCrossrefExtraComponent(FieldEditor fieldEditor,
+            BasePanel panel) {
+        JButton button = new JButton(Localization.lang("Select"));
+        JTextComponent crossref = (JTextComponent) fieldEditor;
+
+        button.addActionListener(actionEvent -> {
+            panel.highlightEntry(panel.getDatabase().getEntryByKey(crossref.getText()));
+        });
+
+        // enable/disable button
+
+        DocumentListener documentListener = new DocumentListener() {
+
+            @Override
+            public void changedUpdate(DocumentEvent documentEvent) {
+                checkUrl();
+            }
+
+            @Override
+            public void insertUpdate(DocumentEvent documentEvent) {
+                checkUrl();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent documentEvent) {
+                checkUrl();
+            }
+
+            private void checkUrl() {
+                if (panel.getDatabase().containsEntryWithKey(crossref.getText())) {
+                    button.setEnabled(true);
+                } else {
+                    button.setEnabled(false);
+                }
+            }
+        };
+
+        crossref.getDocument().addDocumentListener(documentListener);
+        return Optional.of(button);
+
+    }
+
 }

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableSelectionListener.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableSelectionListener.java
@@ -337,6 +337,9 @@ public class MainTableSelectionListener implements ListEventListener<BibEntry>, 
                     }
                 }
             });
+        } else if (modelColumn.getBibtexFields().contains("crossref")) { // Clicking on crossref column
+            tableRows.get(row).getFieldOptional("crossref")
+                    .ifPresent(crossref -> panel.highlightEntry(panel.getDatabase().getEntryByKey(crossref)));
         }
     }
 

--- a/src/main/java/net/sf/jabref/model/database/BibDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabase.java
@@ -120,6 +120,20 @@ public class BibDatabase {
         return internalIDs.contains(id);
     }
 
+    /**
+     * Returns whether an entry with the given bibtex key exists.
+     */
+    public synchronized boolean containsEntryWithKey(String key) {
+        int keyHash = key.hashCode(); // key hash for better performance
+
+        for (BibEntry entry : entries) {
+            if ((entry != null) && (entry.getCiteKey() != null) && (keyHash == entry.getCiteKey().hashCode())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public List<BibEntry> getEntries() {
         return Collections.unmodifiableList(entries);
     }

--- a/src/main/java/net/sf/jabref/model/database/BibDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabase.java
@@ -120,20 +120,6 @@ public class BibDatabase {
         return internalIDs.contains(id);
     }
 
-    /**
-     * Returns whether an entry with the given bibtex key exists.
-     */
-    public synchronized boolean containsEntryWithKey(String key) {
-        int keyHash = key.hashCode(); // key hash for better performance
-
-        for (BibEntry entry : entries) {
-            if ((entry != null) && (entry.getCiteKey() != null) && (keyHash == entry.getCiteKey().hashCode())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     public List<BibEntry> getEntries() {
         return Collections.unmodifiableList(entries);
     }

--- a/src/main/java/net/sf/jabref/model/entry/FieldProperties.java
+++ b/src/main/java/net/sf/jabref/model/entry/FieldProperties.java
@@ -22,7 +22,8 @@ public enum FieldProperties {
     DOI,
     EDITOR_TYPE,
     PAGINATION,
-    TYPE;
+    TYPE,
+    CROSSREF;
 
     public static final Set<FieldProperties> ALL_OPTS = EnumSet.allOf(FieldProperties.class);
 

--- a/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
+++ b/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
@@ -95,7 +95,9 @@ public class InternalBibtexFields {
         add(new BibtexSingleField("author", true, BibtexSingleField.MEDIUM_W, 280));
         add(new BibtexSingleField("booktitle", true, 175));
         add(new BibtexSingleField("chapter", true, BibtexSingleField.SMALL_W));
-        add(new BibtexSingleField("crossref", true, BibtexSingleField.SMALL_W));
+        dummy = new BibtexSingleField("crossref", true, BibtexSingleField.SMALL_W);
+        dummy.setExtras(EnumSet.of(FieldProperties.CROSSREF));
+        add(dummy);
         add(new BibtexSingleField("edition", true, BibtexSingleField.SMALL_W));
         add(new BibtexSingleField("editor", true, BibtexSingleField.MEDIUM_W, 280));
         add(new BibtexSingleField("howpublished", true, BibtexSingleField.MEDIUM_W));


### PR DESCRIPTION
Based on the idea in #1338 a button is added in the crossref entry editor field to select the parent entry in the main table. It is not exactly the same thing as suggested in #1338 though.

- [x] Change in CHANGELOG.md described
