### PR TITLE
Corrected month value when using drop-down in entry editor

### DIFF
--- a/src/main/java/net/sf/jabref/gui/entryeditor/FieldExtraComponents.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/FieldExtraComponents.java
@@ -276,7 +276,7 @@ public class FieldExtraComponents {
                 if (type == BibDatabaseMode.BIBLATEX) {
                     fieldEditor.setText(String.valueOf(monthnumber));
                 } else {
-                    fieldEditor.setText("#" + (MonthUtil.getMonthByNumber(monthnumber).bibtexFormat) + "#");
+                    fieldEditor.setText(MonthUtil.getMonthByNumber(monthnumber).bibtexFormat);
                 }
             } else {
                 fieldEditor.setText("");


### PR DESCRIPTION
Using the drop down resulted in strings like `##jan##`. Now, the correct `#jan#` is obtained.

