### PR TITLE
Fix 1530: Integrity checker should ignore unescaped hashes in url field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - The [online forum](http://discourse.jabref.org/) is now directly accessible via the "Help" menu
 
 ### Fixed
+- Fixed [#1530](https://github.com/JabRef/jabref/issues/1530): Unescaped hashes in the url field are ignored by the integrity checker
 - Fixed [#405](https://github.com/JabRef/jabref/issues/405): Added more {} around capital letters in Unicode/HTML to LaTeX conversion to preserve them
 - Alleviate multiuser concurrency issue when near simultaneous saves occur to a shared database file
 - Fixed [#1476](https://github.com/JabRef/jabref/issues/1476): NPE when importing from SQL DB because of missing DatabaseMode

--- a/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
@@ -400,7 +400,12 @@ public class IntegrityCheck {
         @Override
         public List<IntegrityMessage> check(BibEntry entry) {
             List<IntegrityMessage> results = new ArrayList<>();
-            for (Map.Entry<String, String> field : entry.getFieldMap().entrySet()) {
+
+            Map<String, String> fields = entry.getFieldMap();
+            // the url field should not be checked for hashes, as they are legal in this field
+            fields.remove("url");
+
+            for (Map.Entry<String, String> field : fields.entrySet()) {
                 Matcher hashMatcher = UNESCAPED_HASH.matcher(field.getValue());
                 int hashCount = 0;
                 while (hashMatcher.find()) {

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -41,6 +41,7 @@ public class IntegrityCheckTest {
     public void testUrlChecks() {
         assertCorrect(createContext("url", "http://www.google.com"));
         assertCorrect(createContext("url", "file://c:/asdf/asdf"));
+        assertCorrect(createContext("url", "http://scikit-learn.org/stable/modules/ensemble.html#random-forests"));
 
         assertWrong(createContext("url", "www.google.com"));
         assertWrong(createContext("url", "google.com"));


### PR DESCRIPTION
Addresses #1530 

- [X] Change in CHANGELOG.md described
- [X] Tests created for changes


