### PR TITLE
Added getEntryByKeyOptional and used it. Changed result of getFieldOr…

### DIFF
--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableColumn.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableColumn.java
@@ -112,9 +112,13 @@ public class MainTableColumn {
             if (field.equals(BibEntry.TYPE_HEADER)) {
                 content = EntryUtil.capitalizeFirst(entry.getType());
             } else {
-                content = entry.getFieldOrAlias(field);
-                if (database.isPresent() && "Author".equalsIgnoreCase(columnName) && (content != null)) {
-                    content = database.get().resolveForStrings(content);
+                Optional<String> newContent = entry.getFieldOrAlias(field);
+                if (newContent.isPresent()) {
+                    if (database.isPresent() && "Author".equalsIgnoreCase(columnName)) {
+                        content = database.get().resolveForStrings(newContent.get());
+                    } else {
+                        content = newContent.get();
+                    }
                 }
             }
             if (content != null) {

--- a/src/main/java/net/sf/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/net/sf/jabref/gui/openoffice/OOBibBase.java
@@ -486,11 +486,13 @@ class OOBibBase {
                 BibEntry[] cEntries = new BibEntry[keys.length];
                 for (int j = 0; j < cEntries.length; j++) {
                     BibDatabase database = linkSourceBase.get(keys[j]);
-                    cEntries[j] = null;
+                    Optional<BibEntry> tmpEntry = Optional.empty();
                     if (database != null) {
-                        cEntries[j] = database.getEntryByKey(keys[j]);
+                        tmpEntry = database.getEntryByKeyOptional(keys[j]);
                     }
-                    if (cEntries[j] == null) {
+                    if (tmpEntry.isPresent()) {
+                        cEntries[j] = tmpEntry.get();
+                    } else {
                         LOGGER.info("BibTeX key not found: '" + keys[j] + '\'');
                         LOGGER.info("Problem with reference mark: '" + names.get(i) + '\'');
                         cEntries[j] = new UndefinedBibtexEntry(keys[j]);
@@ -798,9 +800,9 @@ class OOBibBase {
         for (String key : keys) {
             boolean found = false;
             for (BibDatabase database : databases) {
-                BibEntry entry = database.getEntryByKey(key);
-                if (entry != null) {
-                    entries.put(entry, database);
+                Optional<BibEntry> entry = database.getEntryByKeyOptional(key);
+                if (entry.isPresent()) {
+                    entries.put(entry.get(), database);
                     linkSourceBase.put(key, database);
                     found = true;
                     break;
@@ -845,18 +847,18 @@ class OOBibBase {
                 String[] keys = m.group(2).split(",");
                 for (String key : keys) {
                     BibDatabase database = linkSourceBase.get(key);
-                    BibEntry origEntry = null;
+                    Optional<BibEntry> origEntry = Optional.empty();
                     if (database != null) {
-                        origEntry = database.getEntryByKey(key);
+                        origEntry = database.getEntryByKeyOptional(key);
                     }
-                    if (origEntry == null) {
+                    if (origEntry.isPresent()) {
+                        if (!newList.containsKey(origEntry.get())) {
+                            newList.put(origEntry.get(), database);
+                        }
+                    } else {
                         LOGGER.info("BibTeX key not found: '" + key + "'");
                         LOGGER.info("Problem with reference mark: '" + name + "'");
                         newList.put(new UndefinedBibtexEntry(key), null);
-                    } else {
-                        if (!newList.containsKey(origEntry)) {
-                            newList.put(origEntry, database);
-                        }
                     }
                 }
             }
@@ -1202,9 +1204,9 @@ class OOBibBase {
                 List<BibEntry> entries = new ArrayList<>();
                 for (String key : keys) {
                     for (BibDatabase database : databases) {
-                        BibEntry entry = database.getEntryByKey(key);
-                        if (entry != null) {
-                            entries.add(entry);
+                        Optional<BibEntry> entry = database.getEntryByKeyOptional(key);
+                        if (entry.isPresent()) {
+                            entries.add(entry.get());
                             break;
                         }
                     }

--- a/src/main/java/net/sf/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/net/sf/jabref/gui/openoffice/OOBibBase.java
@@ -488,7 +488,7 @@ class OOBibBase {
                     BibDatabase database = linkSourceBase.get(keys[j]);
                     Optional<BibEntry> tmpEntry = Optional.empty();
                     if (database != null) {
-                        tmpEntry = database.getEntryByKeyOptional(keys[j]);
+                        tmpEntry = database.getEntryByKey(keys[j]);
                     }
                     if (tmpEntry.isPresent()) {
                         cEntries[j] = tmpEntry.get();
@@ -643,28 +643,31 @@ class OOBibBase {
                         seenBefore.add(currentKey);
                     }
                     String uniq = uniquefiers.get(currentKey);
+                    Optional<BibEntry> tmpEntry = Optional.empty();
                     if (uniq == null) {
                         if (firstLimAuthors[k] > 0) {
                             needsChange = true;
                             BibDatabase database = linkSourceBase.get(currentKey);
                             if (database != null) {
-                                cEntries[k] = database.getEntryByKey(currentKey);
+                                tmpEntry = database.getEntryByKey(currentKey);
                             }
-                            uniquif[k] = "";
                         } else {
                             BibDatabase database = linkSourceBase.get(currentKey);
                             if (database != null) {
-                                cEntries[k] = database.getEntryByKey(currentKey);
+                                tmpEntry = database.getEntryByKey(currentKey);
                             }
-                            uniquif[k] = "";
                         }
+                        uniquif[k] = "";
                     } else {
                         needsChange = true;
                         BibDatabase database = linkSourceBase.get(currentKey);
                         if (database != null) {
-                            cEntries[k] = database.getEntryByKey(currentKey);
+                            tmpEntry = database.getEntryByKey(currentKey);
                         }
                         uniquif[k] = uniq;
+                    }
+                    if (tmpEntry.isPresent()) {
+                        cEntries[k] = tmpEntry.get();
                     }
                 }
                 if (needsChange) {
@@ -800,7 +803,7 @@ class OOBibBase {
         for (String key : keys) {
             boolean found = false;
             for (BibDatabase database : databases) {
-                Optional<BibEntry> entry = database.getEntryByKeyOptional(key);
+                Optional<BibEntry> entry = database.getEntryByKey(key);
                 if (entry.isPresent()) {
                     entries.put(entry.get(), database);
                     linkSourceBase.put(key, database);
@@ -849,7 +852,7 @@ class OOBibBase {
                     BibDatabase database = linkSourceBase.get(key);
                     Optional<BibEntry> origEntry = Optional.empty();
                     if (database != null) {
-                        origEntry = database.getEntryByKeyOptional(key);
+                        origEntry = database.getEntryByKey(key);
                     }
                     if (origEntry.isPresent()) {
                         if (!newList.containsKey(origEntry.get())) {
@@ -1204,7 +1207,7 @@ class OOBibBase {
                 List<BibEntry> entries = new ArrayList<>();
                 for (String key : keys) {
                     for (BibDatabase database : databases) {
-                        Optional<BibEntry> entry = database.getEntryByKeyOptional(key);
+                        Optional<BibEntry> entry = database.getEntryByKey(key);
                         if (entry.isPresent()) {
                             entries.add(entry.get());
                             break;

--- a/src/main/java/net/sf/jabref/logic/auxparser/AuxParser.java
+++ b/src/main/java/net/sf/jabref/logic/auxparser/AuxParser.java
@@ -127,7 +127,7 @@ public class AuxParser {
      */
     private void resolveTags(AuxParserResult result) {
         for (String key : result.getUniqueKeys()) {
-            Optional<BibEntry> entry = masterDatabase.getEntryByKeyOptional(key);
+            Optional<BibEntry> entry = masterDatabase.getEntryByKey(key);
 
             if (entry.isPresent()) {
                 insertEntry(entry.get(), result);
@@ -150,7 +150,7 @@ public class AuxParser {
     private void resolveCrossReferences(BibEntry entry, AuxParserResult result) {
         entry.getFieldOptional("crossref").ifPresent(crossref -> {
             if (!result.getUniqueKeys().contains(crossref)) {
-                Optional<BibEntry> refEntry = masterDatabase.getEntryByKeyOptional(crossref);
+                Optional<BibEntry> refEntry = masterDatabase.getEntryByKey(crossref);
 
                 if (refEntry.isPresent()) {
                     insertEntry(refEntry.get(), result);

--- a/src/main/java/net/sf/jabref/logic/auxparser/AuxParser.java
+++ b/src/main/java/net/sf/jabref/logic/auxparser/AuxParser.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -126,13 +127,13 @@ public class AuxParser {
      */
     private void resolveTags(AuxParserResult result) {
         for (String key : result.getUniqueKeys()) {
-            BibEntry entry = masterDatabase.getEntryByKey(key);
+            Optional<BibEntry> entry = masterDatabase.getEntryByKeyOptional(key);
 
-            if (entry == null) {
-                result.getUnresolvedKeys().add(key);
+            if (entry.isPresent()) {
+                insertEntry(entry.get(), result);
+                resolveCrossReferences(entry.get(), result);
             } else {
-                insertEntry(entry, result);
-                resolveCrossReferences(entry, result);
+                result.getUnresolvedKeys().add(key);
             }
         }
 
@@ -149,13 +150,13 @@ public class AuxParser {
     private void resolveCrossReferences(BibEntry entry, AuxParserResult result) {
         entry.getFieldOptional("crossref").ifPresent(crossref -> {
             if (!result.getUniqueKeys().contains(crossref)) {
-                BibEntry refEntry = masterDatabase.getEntryByKey(crossref);
+                Optional<BibEntry> refEntry = masterDatabase.getEntryByKeyOptional(crossref);
 
-                if (refEntry == null) {
-                    result.getUnresolvedKeys().add(crossref);
-                } else {
-                    insertEntry(refEntry, result);
+                if (refEntry.isPresent()) {
+                    insertEntry(refEntry.get(), result);
                     result.increaseCrossRefEntriesCounter();
+                } else {
+                    result.getUnresolvedKeys().add(crossref);
                 }
             }
         });

--- a/src/main/java/net/sf/jabref/logic/bibtex/comparator/FieldComparator.java
+++ b/src/main/java/net/sf/jabref/logic/bibtex/comparator/FieldComparator.java
@@ -21,6 +21,7 @@ import java.text.RuleBasedCollator;
 import java.util.Comparator;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.logic.config.SaveOrderConfig;
@@ -170,9 +171,9 @@ public class FieldComparator implements Comparator<BibEntry> {
 
     private String getField(BibEntry entry) {
         for (String aField : field) {
-            String o = entry.getFieldOrAlias(aField);
-            if (o != null) {
-                return o;
+            Optional<String> o = entry.getFieldOrAlias(aField);
+            if (o.isPresent()) {
+                return o.get();
             }
         }
         return null;

--- a/src/main/java/net/sf/jabref/logic/labelpattern/LabelPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/labelpattern/LabelPatternUtil.java
@@ -746,9 +746,9 @@ public class LabelPatternUtil {
             } else if ("veryshorttitle".equals(val)) {
                 return getTitleWords(1, entry.getField("title"));
             } else if ("shortyear".equals(val)) {
-                String ss = entry.getFieldOrAlias("year");
-                if (ss == null) {
-                    return "";
+                String ss = entry.getFieldOrAlias("year").orElse("");
+                if (ss.isEmpty()) {
+                    return ss;
                 } else if (ss.startsWith("in") || ss.startsWith("sub")) {
                     return "IP";
                 } else if (ss.length() > 2) {
@@ -808,8 +808,7 @@ public class LabelPatternUtil {
      * @return The field value.
      */
     private static String getField(BibEntry entry, String field) {
-        String s = entry.getFieldOrAlias(field);
-        return s == null ? "" : s;
+        return entry.getFieldOrAlias(field).orElse("");
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/xmp/XMPUtil.java
+++ b/src/main/java/net/sf/jabref/logic/xmp/XMPUtil.java
@@ -1257,7 +1257,7 @@ public class XMPUtil {
 
             ParserResult result = BibtexParser.parse(new FileReader(args[1]));
 
-            Optional<BibEntry> bibEntry = result.getDatabase().getEntryByKeyOptional(args[0]);
+            Optional<BibEntry> bibEntry = result.getDatabase().getEntryByKey(args[0]);
 
             if (bibEntry.isPresent()) {
                 XMPUtil.writeXMP(new File(args[2]), bibEntry.get(), result.getDatabase());

--- a/src/main/java/net/sf/jabref/logic/xmp/XMPUtil.java
+++ b/src/main/java/net/sf/jabref/logic/xmp/XMPUtil.java
@@ -1257,15 +1257,14 @@ public class XMPUtil {
 
             ParserResult result = BibtexParser.parse(new FileReader(args[1]));
 
-            BibEntry bibEntry = result.getDatabase().getEntryByKey(args[0]);
+            Optional<BibEntry> bibEntry = result.getDatabase().getEntryByKeyOptional(args[0]);
 
-            if (bibEntry == null) {
-                System.err.println("Could not find BibEntry " + args[0]
-                        + " in " + args[0]);
-            } else {
-                XMPUtil.writeXMP(new File(args[2]), bibEntry, result.getDatabase());
+            if (bibEntry.isPresent()) {
+                XMPUtil.writeXMP(new File(args[2]), bibEntry.get(), result.getDatabase());
 
                 System.out.println("XMP written.");
+            } else {
+                System.err.println("Could not find BibEntry " + args[0] + " in " + args[0]);
             }
             break;
 

--- a/src/main/java/net/sf/jabref/model/database/BibDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabase.java
@@ -141,20 +141,7 @@ public class BibDatabase {
     /**
      * Returns the entry with the given bibtex key.
      */
-    @Deprecated
-    public synchronized BibEntry getEntryByKey(String key) {
-        for (BibEntry entry : entries) {
-            if (key.equals(entry.getCiteKey())) {
-                return entry;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Returns the entry with the given bibtex key.
-     */
-    public synchronized Optional<BibEntry> getEntryByKeyOptional(String key) {
+    public synchronized Optional<BibEntry> getEntryByKey(String key) {
         for (BibEntry entry : entries) {
             if (key.equals(entry.getCiteKey())) {
                 return Optional.of(entry);
@@ -529,7 +516,7 @@ public class BibDatabase {
         if (!result.isPresent() && (database != null) && !field.equals(BibEntry.KEY_FIELD)) {
             Optional<String> crossrefKey = entry.getFieldOptional("crossref");
             if (crossrefKey.isPresent()) {
-                Optional<BibEntry> referred = database.getEntryByKeyOptional(crossrefKey.get());
+                Optional<BibEntry> referred = database.getEntryByKey(crossrefKey.get());
                 if (referred.isPresent()) {
                     // Ok, we found the referred entry. Get the field value from that
                     // entry. If it is unset there, too, stop looking:

--- a/src/main/java/net/sf/jabref/model/database/BibDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabase.java
@@ -141,6 +141,7 @@ public class BibDatabase {
     /**
      * Returns the entry with the given bibtex key.
      */
+    @Deprecated
     public synchronized BibEntry getEntryByKey(String key) {
         BibEntry back = null;
 
@@ -154,6 +155,21 @@ public class BibDatabase {
         return back;
     }
 
+    /**
+     * Returns the entry with the given bibtex key.
+     */
+    public synchronized Optional<BibEntry> getEntryByKeyOptional(String key) {
+        BibEntry back = null;
+
+        int keyHash = key.hashCode(); // key hash for better performance
+
+        for (BibEntry entry : entries) {
+            if ((entry != null) && (entry.getCiteKey() != null) && (keyHash == entry.getCiteKey().hashCode())) {
+                back = entry;
+            }
+        }
+        return Optional.ofNullable(back);
+    }
     public synchronized List<BibEntry> getEntriesByKey(String key) {
         List<BibEntry> result = new ArrayList<>();
 
@@ -390,9 +406,8 @@ public class BibDatabase {
             resultingEntry = (BibEntry) entry.clone();
         }
 
-        for (String field : resultingEntry.getFieldNames()) {
-            resultingEntry.getFieldOptional(field)
-                    .ifPresent(fieldValue -> resultingEntry.setField(field, this.resolveForStrings(fieldValue)));
+        for (Map.Entry<String, String> field : resultingEntry.getFieldMap().entrySet()) {
+            resultingEntry.setField(field.getKey(), this.resolveForStrings(field.getValue()));
         }
         return resultingEntry;
     }
@@ -514,26 +529,23 @@ public class BibDatabase {
         // TODO: Changed this to also consider alias fields, which is the expected
         // behavior for the preview layout and for the check whatever all fields are present.
         // But there might be unwanted side-effects?!
-        Object o = entry.getFieldOrAlias(field);
+        Optional<String> result = entry.getFieldOrAlias(field);
 
         // If this field is not set, and the entry has a crossref, try to look up the
         // field in the referred entry: Do not do this for the bibtex key.
-        if ((o == null) && (database != null) && !field.equals(BibEntry.KEY_FIELD)) {
+        if (!result.isPresent() && (database != null) && !field.equals(BibEntry.KEY_FIELD)) {
             Optional<String> crossrefKey = entry.getFieldOptional("crossref");
             if (crossrefKey.isPresent()) {
-                BibEntry referred = database.getEntryByKey(crossrefKey.get());
-                if (referred != null) {
+                Optional<BibEntry> referred = database.getEntryByKeyOptional(crossrefKey.get());
+                if (referred.isPresent()) {
                     // Ok, we found the referred entry. Get the field value from that
                     // entry. If it is unset there, too, stop looking:
-                    Optional<String> crossrefContent = referred.getFieldOptional(field);
-                    if (crossrefContent.isPresent()) {
-                        o = crossrefContent.get();
-                    }
+                    result = referred.get().getFieldOptional(field);
                 }
             }
         }
 
-        return BibDatabase.getText((String) o, database);
+        return BibDatabase.getText(result.orElse(null), database);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/model/database/BibDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabase.java
@@ -143,33 +143,26 @@ public class BibDatabase {
      */
     @Deprecated
     public synchronized BibEntry getEntryByKey(String key) {
-        BibEntry back = null;
-
-        int keyHash = key.hashCode(); // key hash for better performance
-
         for (BibEntry entry : entries) {
-            if ((entry != null) && (entry.getCiteKey() != null) && (keyHash == entry.getCiteKey().hashCode())) {
-                back = entry;
+            if (key.equals(entry.getCiteKey())) {
+                return entry;
             }
         }
-        return back;
+        return null;
     }
 
     /**
      * Returns the entry with the given bibtex key.
      */
     public synchronized Optional<BibEntry> getEntryByKeyOptional(String key) {
-        BibEntry back = null;
-
-        int keyHash = key.hashCode(); // key hash for better performance
-
         for (BibEntry entry : entries) {
-            if ((entry != null) && (entry.getCiteKey() != null) && (keyHash == entry.getCiteKey().hashCode())) {
-                back = entry;
+            if (key.equals(entry.getCiteKey())) {
+                return Optional.of(entry);
             }
         }
-        return Optional.ofNullable(back);
+        return Optional.empty();
     }
+
     public synchronized List<BibEntry> getEntriesByKey(String key) {
         List<BibEntry> result = new ArrayList<>();
 

--- a/src/test/java/net/sf/jabref/BibtexTestData.java
+++ b/src/test/java/net/sf/jabref/BibtexTestData.java
@@ -12,7 +12,7 @@ public class BibtexTestData {
 
     public static BibEntry getBibtexEntry() throws IOException {
         BibDatabase database = getBibtexDatabase();
-        return database.getEntryByKey("HipKro03");
+        return database.getEntryByKeyOptional("HipKro03").get();
     }
 
     public static BibDatabase getBibtexDatabase() throws IOException {

--- a/src/test/java/net/sf/jabref/BibtexTestData.java
+++ b/src/test/java/net/sf/jabref/BibtexTestData.java
@@ -12,7 +12,7 @@ public class BibtexTestData {
 
     public static BibEntry getBibtexEntry() throws IOException {
         BibDatabase database = getBibtexDatabase();
-        return database.getEntryByKeyOptional("HipKro03").get();
+        return database.getEntryByKey("HipKro03").get();
     }
 
     public static BibDatabase getBibtexDatabase() throws IOException {

--- a/src/test/java/net/sf/jabref/external/RegExpFileSearchTests.java
+++ b/src/test/java/net/sf/jabref/external/RegExpFileSearchTests.java
@@ -66,7 +66,7 @@ public class RegExpFileSearchTests {
         result = parser.parse();
 
         database = result.getDatabase();
-        entry = database.getEntryByKey("HipKro03");
+        entry = database.getEntryByKeyOptional("HipKro03").get();
 
         Assert.assertNotNull(database);
         Assert.assertNotNull(entry);

--- a/src/test/java/net/sf/jabref/external/RegExpFileSearchTests.java
+++ b/src/test/java/net/sf/jabref/external/RegExpFileSearchTests.java
@@ -66,7 +66,7 @@ public class RegExpFileSearchTests {
         result = parser.parse();
 
         database = result.getDatabase();
-        entry = database.getEntryByKeyOptional("HipKro03").get();
+        entry = database.getEntryByKey("HipKro03").get();
 
         Assert.assertNotNull(database);
         Assert.assertNotNull(entry);

--- a/src/test/java/net/sf/jabref/importer/DatabaseFileLookupTest.java
+++ b/src/test/java/net/sf/jabref/importer/DatabaseFileLookupTest.java
@@ -40,8 +40,8 @@ public class DatabaseFileLookupTest {
             database = result.getDatabase();
             entries = database.getEntries();
 
-            entry1 = database.getEntryByKey("entry1");
-            entry2 = database.getEntryByKey("entry2");
+            entry1 = database.getEntryByKeyOptional("entry1").get();
+            entry2 = database.getEntryByKeyOptional("entry2").get();
         }
     }
 

--- a/src/test/java/net/sf/jabref/importer/DatabaseFileLookupTest.java
+++ b/src/test/java/net/sf/jabref/importer/DatabaseFileLookupTest.java
@@ -40,8 +40,8 @@ public class DatabaseFileLookupTest {
             database = result.getDatabase();
             entries = database.getEntries();
 
-            entry1 = database.getEntryByKeyOptional("entry1").get();
-            entry2 = database.getEntryByKeyOptional("entry2").get();
+            entry1 = database.getEntryByKey("entry1").get();
+            entry2 = database.getEntryByKey("entry2").get();
         }
     }
 

--- a/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
+++ b/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
@@ -74,7 +74,7 @@ public class OpenDatabaseActionTest {
 
         // Entry
         Assert.assertEquals(1, db.getEntryCount());
-        Assert.assertEquals("2014", db.getEntryByKey("1").getField("year"));
+        Assert.assertEquals("2014", db.getEntryByKeyOptional("1").get().getFieldOptional("year").get());
     }
 
     @Test
@@ -84,7 +84,7 @@ public class OpenDatabaseActionTest {
 
         // Entry
         Assert.assertEquals(1, db.getEntryCount());
-        Assert.assertEquals("2014", db.getEntryByKey("1").getField("year"));
+        Assert.assertEquals("2014", db.getEntryByKeyOptional("1").get().getFieldOptional("year").get());
     }
 
     @Test
@@ -94,7 +94,7 @@ public class OpenDatabaseActionTest {
 
         // Entry
         Assert.assertEquals(1, db.getEntryCount());
-        Assert.assertEquals("2014", db.getEntryByKey("1").getField("year"));
+        Assert.assertEquals("2014", db.getEntryByKeyOptional("1").get().getFieldOptional("year").get());
     }
 
     /**

--- a/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
+++ b/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
@@ -7,6 +7,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.Optional;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefPreferences;
@@ -74,7 +75,7 @@ public class OpenDatabaseActionTest {
 
         // Entry
         Assert.assertEquals(1, db.getEntryCount());
-        Assert.assertEquals("2014", db.getEntryByKey("1").get().getFieldOptional("year").get());
+        Assert.assertEquals(Optional.of("2014"), db.getEntryByKey("1").get().getFieldOptional("year"));
     }
 
     @Test
@@ -84,7 +85,7 @@ public class OpenDatabaseActionTest {
 
         // Entry
         Assert.assertEquals(1, db.getEntryCount());
-        Assert.assertEquals("2014", db.getEntryByKey("1").get().getFieldOptional("year").get());
+        Assert.assertEquals(Optional.of("2014"), db.getEntryByKey("1").get().getFieldOptional("year"));
     }
 
     @Test
@@ -94,7 +95,7 @@ public class OpenDatabaseActionTest {
 
         // Entry
         Assert.assertEquals(1, db.getEntryCount());
-        Assert.assertEquals("2014", db.getEntryByKey("1").get().getFieldOptional("year").get());
+        Assert.assertEquals(Optional.of("2014"), db.getEntryByKey("1").get().getFieldOptional("year"));
     }
 
     /**

--- a/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
+++ b/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
@@ -74,7 +74,7 @@ public class OpenDatabaseActionTest {
 
         // Entry
         Assert.assertEquals(1, db.getEntryCount());
-        Assert.assertEquals("2014", db.getEntryByKeyOptional("1").get().getFieldOptional("year").get());
+        Assert.assertEquals("2014", db.getEntryByKey("1").get().getFieldOptional("year").get());
     }
 
     @Test
@@ -84,7 +84,7 @@ public class OpenDatabaseActionTest {
 
         // Entry
         Assert.assertEquals(1, db.getEntryCount());
-        Assert.assertEquals("2014", db.getEntryByKeyOptional("1").get().getFieldOptional("year").get());
+        Assert.assertEquals("2014", db.getEntryByKey("1").get().getFieldOptional("year").get());
     }
 
     @Test
@@ -94,7 +94,7 @@ public class OpenDatabaseActionTest {
 
         // Entry
         Assert.assertEquals(1, db.getEntryCount());
-        Assert.assertEquals("2014", db.getEntryByKeyOptional("1").get().getFieldOptional("year").get());
+        Assert.assertEquals("2014", db.getEntryByKey("1").get().getFieldOptional("year").get());
     }
 
     /**

--- a/src/test/java/net/sf/jabref/logic/openoffice/OOBibStyleTest.java
+++ b/src/test/java/net/sf/jabref/logic/openoffice/OOBibStyleTest.java
@@ -154,7 +154,7 @@ public class OOBibStyleTest {
             entryDBMap.put(entry, db);
         }
 
-        BibEntry entry = db.getEntryByKey("1137631");
+        BibEntry entry = db.getEntryByKeyOptional("1137631").get();
         assertEquals("[Boström et al., 2006]",
                 style.getCitationMarker(Arrays.asList(entry), entryDBMap, true, null, null));
         assertEquals("Boström et al. [2006]",
@@ -173,7 +173,7 @@ public class OOBibStyleTest {
 
         Layout l = style.getReferenceFormat("default");
         l.setPostFormatter(new OOPreFormatter());
-        BibEntry entry = db.getEntryByKey("1137631");
+        BibEntry entry = db.getEntryByKeyOptional("1137631").get();
         assertEquals(
                 "Boström, G.; Wäyrynen, J.; Bodén, M.; Beznosov, K. and Kruchten, P. (<b>2006</b>). <i>Extending XP practices to support security requirements engineering</i>,   : 11-18.",
                 l.doLayout(entry, db));

--- a/src/test/java/net/sf/jabref/logic/openoffice/OOBibStyleTest.java
+++ b/src/test/java/net/sf/jabref/logic/openoffice/OOBibStyleTest.java
@@ -154,7 +154,7 @@ public class OOBibStyleTest {
             entryDBMap.put(entry, db);
         }
 
-        BibEntry entry = db.getEntryByKeyOptional("1137631").get();
+        BibEntry entry = db.getEntryByKey("1137631").get();
         assertEquals("[Boström et al., 2006]",
                 style.getCitationMarker(Arrays.asList(entry), entryDBMap, true, null, null));
         assertEquals("Boström et al. [2006]",
@@ -173,7 +173,7 @@ public class OOBibStyleTest {
 
         Layout l = style.getReferenceFormat("default");
         l.setPostFormatter(new OOPreFormatter());
-        BibEntry entry = db.getEntryByKeyOptional("1137631").get();
+        BibEntry entry = db.getEntryByKey("1137631").get();
         assertEquals(
                 "Boström, G.; Wäyrynen, J.; Bodén, M.; Beznosov, K. and Kruchten, P. (<b>2006</b>). <i>Extending XP practices to support security requirements engineering</i>,   : 11-18.",
                 l.doLayout(entry, db));

--- a/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
@@ -1356,7 +1356,7 @@ public class XMPUtilTest {
                     "Patterson, David and Arvind and Asanov\\'\\i{}c, Krste and Chiou, Derek and Hoe, James and Kozyrakis, Christos and Lu, S{hih-Lien} and Oskin, Mark and Rabaey, Jan and Wawrzynek, John");
 
             try {
-                XMPUtil.writeXMP(pdfFile, result.getDatabase().getEntryByKeyOptional("Patterson06").get(),
+                XMPUtil.writeXMP(pdfFile, result.getDatabase().getEntryByKey("Patterson06").get(),
                         result.getDatabase());
 
                 // Test whether we the main function can load the bibtex correctly

--- a/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
@@ -273,8 +273,9 @@ public class XMPUtilTest {
 
         Assert.assertNotNull(e);
         Assert.assertEquals("OezbekC06", e.getCiteKey());
-        Assert.assertEquals("2003", e.getFieldOptional("year").get());
-        Assert.assertEquals("Beach sand convolution by surf-wave optimzation", e.getFieldOptional("title").get());
+        Assert.assertEquals(Optional.of("2003"), e.getFieldOptional("year"));
+        Assert.assertEquals(Optional.of("Beach sand convolution by surf-wave optimzation"),
+                e.getFieldOptional("title"));
         Assert.assertEquals("misc", e.getType());
     }
 
@@ -297,8 +298,8 @@ public class XMPUtilTest {
 
         Assert.assertNotNull(e);
         Assert.assertEquals("OezbekC06", e.getCiteKey());
-        Assert.assertEquals("2003", e.getFieldOptional("year").get());
-        Assert.assertEquals("�pt�mz�t��n", e.getFieldOptional("title").get());
+        Assert.assertEquals(Optional.of("2003"), e.getFieldOptional("year"));
+        Assert.assertEquals(Optional.of("�pt�mz�t��n"), e.getFieldOptional("title"));
         Assert.assertEquals("misc", e.getType());
     }
 

--- a/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
@@ -273,8 +273,8 @@ public class XMPUtilTest {
 
         Assert.assertNotNull(e);
         Assert.assertEquals("OezbekC06", e.getCiteKey());
-        Assert.assertEquals("2003", e.getField("year"));
-        Assert.assertEquals("Beach sand convolution by surf-wave optimzation", e.getField("title"));
+        Assert.assertEquals("2003", e.getFieldOptional("year").get());
+        Assert.assertEquals("Beach sand convolution by surf-wave optimzation", e.getFieldOptional("title").get());
         Assert.assertEquals("misc", e.getType());
     }
 
@@ -297,8 +297,8 @@ public class XMPUtilTest {
 
         Assert.assertNotNull(e);
         Assert.assertEquals("OezbekC06", e.getCiteKey());
-        Assert.assertEquals("2003", e.getField("year"));
-        Assert.assertEquals("�pt�mz�t��n", e.getField("title"));
+        Assert.assertEquals("2003", e.getFieldOptional("year").get());
+        Assert.assertEquals("�pt�mz�t��n", e.getFieldOptional("title").get());
         Assert.assertEquals("misc", e.getType());
     }
 
@@ -371,8 +371,8 @@ public class XMPUtilTest {
 
         Assert.assertNotNull(e);
         Assert.assertEquals("Clarkson06", e.getCiteKey());
-        Assert.assertEquals("Kelly Clarkson and Ozzy Osbourne", e.getField("author"));
-        Assert.assertEquals("Huey Duck and Dewey Duck and Louie Duck", e.getField("editor"));
+        Assert.assertEquals("Kelly Clarkson and Ozzy Osbourne", e.getFieldOptional("author").get());
+        Assert.assertEquals("Huey Duck and Dewey Duck and Louie Duck", e.getFieldOptional("editor").get());
         Assert.assertEquals("misc", e.getType());
     }
 
@@ -491,9 +491,9 @@ public class XMPUtilTest {
         BibEntry e = l.get(0);
 
         Assert.assertNotNull(e);
-        Assert.assertEquals("Hallo World this is not an exercise .", e.getField("title"));
-        Assert.assertEquals("Hallo World this is not an exercise .", e.getField("tabs"));
-        Assert.assertEquals("\n\nAbstract preserve\n\t Whitespace\n\n", e.getField("abstract"));
+        Assert.assertEquals("Hallo World this is not an exercise .", e.getFieldOptional("title").get());
+        Assert.assertEquals("Hallo World this is not an exercise .", e.getFieldOptional("tabs").get());
+        Assert.assertEquals("\n\nAbstract preserve\n\t Whitespace\n\n", e.getFieldOptional("abstract").get());
     }
 
     /**
@@ -758,11 +758,12 @@ public class XMPUtilTest {
 
             if ("author".equalsIgnoreCase(field) || "editor".equalsIgnoreCase(field)) {
 
-                AuthorList expectedAuthors = AuthorList.parse(expected.getField(field));
-                AuthorList actualAuthors = AuthorList.parse(actual.getField(field));
+                AuthorList expectedAuthors = AuthorList.parse(expected.getFieldOptional(field).get());
+                AuthorList actualAuthors = AuthorList.parse(actual.getFieldOptional(field).get());
                 Assert.assertEquals(expectedAuthors, actualAuthors);
             } else {
-                Assert.assertEquals("comparing " + field, expected.getField(field), actual.getField(field));
+                Assert.assertEquals("comparing " + field, expected.getFieldOptional(field),
+                        actual.getFieldOptional(field));
             }
         }
 
@@ -814,12 +815,12 @@ public class XMPUtilTest {
         }
 
         Assert.assertEquals("canh05", a.getCiteKey());
-        Assert.assertEquals("K. Crowston and H. Annabi", a.getField("author"));
-        Assert.assertEquals("Title A", a.getField("title"));
+        Assert.assertEquals("K. Crowston and H. Annabi", a.getFieldOptional("author").get());
+        Assert.assertEquals("Title A", a.getFieldOptional("title").get());
         Assert.assertEquals("article", a.getType());
 
         Assert.assertEquals("foo", b.getCiteKey());
-        Assert.assertEquals("Norton Bar", b.getField("author"));
+        Assert.assertEquals("Norton Bar", b.getFieldOptional("author").get());
         Assert.assertEquals("inproceedings", b.getType());
     }
 
@@ -1319,7 +1320,7 @@ public class XMPUtilTest {
         BibEntry x = l.get(0);
 
         Assert.assertEquals(AuthorList.parse("Crowston, K. and Annabi, H. and Howison, J. and Masango, C."),
-                AuthorList.parse(x.getField("author")));
+                AuthorList.parse(x.getFieldOptional("author").get()));
     }
 
     @Test(expected = EncryptedPdfsNotSupportedException.class)
@@ -1355,12 +1356,13 @@ public class XMPUtilTest {
                     "Patterson, David and Arvind and Asanov\\'\\i{}c, Krste and Chiou, Derek and Hoe, James and Kozyrakis, Christos and Lu, S{hih-Lien} and Oskin, Mark and Rabaey, Jan and Wawrzynek, John");
 
             try {
-                XMPUtil.writeXMP(pdfFile, result.getDatabase().getEntryByKey("Patterson06"), result.getDatabase());
+                XMPUtil.writeXMP(pdfFile, result.getDatabase().getEntryByKeyOptional("Patterson06").get(),
+                        result.getDatabase());
 
                 // Test whether we the main function can load the bibtex correctly
                 BibEntry b = XMPUtil.readXMP(pdfFile).get(0);
                 Assert.assertNotNull(b);
-                Assert.assertEquals(originalAuthors, AuthorList.parse(b.getField("author")));
+                Assert.assertEquals(originalAuthors, AuthorList.parse(b.getFieldOptional("author").get()));
 
                 // Next check from Document Information
                 try (PDDocument document = PDDocument.load(pdfFile.getAbsoluteFile())) {
@@ -1369,7 +1371,7 @@ public class XMPUtilTest {
                             AuthorList.parse(document.getDocumentInformation().getAuthor()));
 
                     b = XMPUtil.getBibtexEntryFromDocumentInformation(document.getDocumentInformation()).get();
-                    Assert.assertEquals(originalAuthors, AuthorList.parse(b.getField("author")));
+                    Assert.assertEquals(originalAuthors, AuthorList.parse(b.getFieldOptional("author").get()));
 
                     // Now check from Dublin Core
                     PDDocumentCatalog catalog = document.getDocumentCatalog();
@@ -1395,7 +1397,7 @@ public class XMPUtilTest {
 
                     b = XMPUtil.getBibtexEntryFromDublinCore(dcSchema).get();
                     Assert.assertNotNull(b);
-                    Assert.assertEquals(originalAuthors, AuthorList.parse(b.getField("author")));
+                    Assert.assertEquals(originalAuthors, AuthorList.parse(b.getFieldOptional("author").get()));
                 }
             } finally {
                 if (!pdfFile.delete()) {

--- a/src/test/java/net/sf/jabref/model/entry/BibEntryTests.java
+++ b/src/test/java/net/sf/jabref/model/entry/BibEntryTests.java
@@ -43,7 +43,7 @@ public class BibEntryTests {
         // we have to use `getType("misc")` in the case of biblatex mode
         Assert.assertEquals("misc", entry.getType());
         Assert.assertNotNull(entry.getId());
-        Assert.assertNull(entry.getField("author"));
+        Assert.assertFalse(entry.getFieldOptional("author").isPresent());
     }
 
     @Test
@@ -144,63 +144,63 @@ public class BibEntryTests {
     public void getFieldOrAliasDateWithYearNumericalMonthString() {
         emptyEntry.setField("year", "2003");
         emptyEntry.setField("month", "3");
-        Assert.assertEquals("2003-03", emptyEntry.getFieldOrAlias("date"));
+        Assert.assertEquals("2003-03", emptyEntry.getFieldOrAlias("date").get());
     }
 
     @Test
     public void getFieldOrAliasDateWithYearAbbreviatedMonth() {
         emptyEntry.setField("year", "2003");
         emptyEntry.setField("month", "#mar#");
-        Assert.assertEquals("2003-03", emptyEntry.getFieldOrAlias("date"));
+        Assert.assertEquals("2003-03", emptyEntry.getFieldOrAlias("date").get());
     }
 
     @Test
     public void getFieldOrAliasDateWithYearAbbreviatedMonthString() {
         emptyEntry.setField("year", "2003");
         emptyEntry.setField("month", "mar");
-        Assert.assertEquals("2003-03", emptyEntry.getFieldOrAlias("date"));
+        Assert.assertEquals("2003-03", emptyEntry.getFieldOrAlias("date").get());
     }
 
     @Test
     public void getFieldOrAliasDateWithOnlyYear() {
         emptyEntry.setField("year", "2003");
-        Assert.assertEquals("2003", emptyEntry.getFieldOrAlias("date"));
+        Assert.assertEquals("2003", emptyEntry.getFieldOrAlias("date").get());
     }
 
     @Test
     public void getFieldOrAliasYearWithDateYYYY() {
         emptyEntry.setField("date", "2003");
-        Assert.assertEquals("2003", emptyEntry.getFieldOrAlias("year"));
+        Assert.assertEquals("2003", emptyEntry.getFieldOrAlias("year").get());
     }
 
     @Test
     public void getFieldOrAliasYearWithDateYYYYMM() {
         emptyEntry.setField("date", "2003-03");
-        Assert.assertEquals("2003", emptyEntry.getFieldOrAlias("year"));
+        Assert.assertEquals("2003", emptyEntry.getFieldOrAlias("year").get());
     }
 
     @Test
     public void getFieldOrAliasYearWithDateYYYYMMDD() {
         emptyEntry.setField("date", "2003-03-30");
-        Assert.assertEquals("2003", emptyEntry.getFieldOrAlias("year"));
+        Assert.assertEquals("2003", emptyEntry.getFieldOrAlias("year").get());
     }
 
     @Test
     public void getFieldOrAliasMonthWithDateYYYYReturnsNull() {
         emptyEntry.setField("date", "2003");
-        Assert.assertNull(emptyEntry.getFieldOrAlias("month"));
+        Assert.assertFalse(emptyEntry.getFieldOrAlias("month").isPresent());
     }
 
     @Test
     public void getFieldOrAliasMonthWithDateYYYYMM() {
         emptyEntry.setField("date", "2003-03");
-        Assert.assertEquals("3", emptyEntry.getFieldOrAlias("month"));
+        Assert.assertEquals("3", emptyEntry.getFieldOrAlias("month").get());
     }
 
     @Test
     public void getFieldOrAliasMonthWithDateYYYYMMDD() {
         emptyEntry.setField("date", "2003-03-30");
-        Assert.assertEquals("3", emptyEntry.getFieldOrAlias("month"));
+        Assert.assertEquals("3", emptyEntry.getFieldOrAlias("month").get());
     }
 
     @Test(expected = NullPointerException.class)
@@ -381,9 +381,9 @@ public class BibEntryTests {
         be.setCiteKey("Einstein1931");
         Assert.assertTrue(be.hasCiteKey());
         Assert.assertEquals("Einstein1931", be.getCiteKey());
-        Assert.assertEquals("Albert Einstein", be.getField("author"));
+        Assert.assertEquals("Albert Einstein", be.getFieldOptional("author").get());
         be.clearField("author");
-        Assert.assertNull(be.getField("author"));
+        Assert.assertFalse(be.getFieldOptional("author").isPresent());
 
         String id = IdGenerator.next();
         be.setId(id);

--- a/src/test/java/net/sf/jabref/model/entry/BibEntryTests.java
+++ b/src/test/java/net/sf/jabref/model/entry/BibEntryTests.java
@@ -144,63 +144,63 @@ public class BibEntryTests {
     public void getFieldOrAliasDateWithYearNumericalMonthString() {
         emptyEntry.setField("year", "2003");
         emptyEntry.setField("month", "3");
-        Assert.assertEquals("2003-03", emptyEntry.getFieldOrAlias("date").get());
+        Assert.assertEquals(Optional.of("2003-03"), emptyEntry.getFieldOrAlias("date"));
     }
 
     @Test
     public void getFieldOrAliasDateWithYearAbbreviatedMonth() {
         emptyEntry.setField("year", "2003");
         emptyEntry.setField("month", "#mar#");
-        Assert.assertEquals("2003-03", emptyEntry.getFieldOrAlias("date").get());
+        Assert.assertEquals(Optional.of("2003-03"), emptyEntry.getFieldOrAlias("date"));
     }
 
     @Test
     public void getFieldOrAliasDateWithYearAbbreviatedMonthString() {
         emptyEntry.setField("year", "2003");
         emptyEntry.setField("month", "mar");
-        Assert.assertEquals("2003-03", emptyEntry.getFieldOrAlias("date").get());
+        Assert.assertEquals(Optional.of("2003-03"), emptyEntry.getFieldOrAlias("date"));
     }
 
     @Test
     public void getFieldOrAliasDateWithOnlyYear() {
         emptyEntry.setField("year", "2003");
-        Assert.assertEquals("2003", emptyEntry.getFieldOrAlias("date").get());
+        Assert.assertEquals(Optional.of("2003"), emptyEntry.getFieldOrAlias("date"));
     }
 
     @Test
     public void getFieldOrAliasYearWithDateYYYY() {
         emptyEntry.setField("date", "2003");
-        Assert.assertEquals("2003", emptyEntry.getFieldOrAlias("year").get());
+        Assert.assertEquals(Optional.of("2003"), emptyEntry.getFieldOrAlias("year"));
     }
 
     @Test
     public void getFieldOrAliasYearWithDateYYYYMM() {
         emptyEntry.setField("date", "2003-03");
-        Assert.assertEquals("2003", emptyEntry.getFieldOrAlias("year").get());
+        Assert.assertEquals(Optional.of("2003"), emptyEntry.getFieldOrAlias("year"));
     }
 
     @Test
     public void getFieldOrAliasYearWithDateYYYYMMDD() {
         emptyEntry.setField("date", "2003-03-30");
-        Assert.assertEquals("2003", emptyEntry.getFieldOrAlias("year").get());
+        Assert.assertEquals(Optional.of("2003"), emptyEntry.getFieldOrAlias("year"));
     }
 
     @Test
     public void getFieldOrAliasMonthWithDateYYYYReturnsNull() {
         emptyEntry.setField("date", "2003");
-        Assert.assertFalse(emptyEntry.getFieldOrAlias("month").isPresent());
+        Assert.assertEquals(Optional.empty(), emptyEntry.getFieldOrAlias("month"));
     }
 
     @Test
     public void getFieldOrAliasMonthWithDateYYYYMM() {
         emptyEntry.setField("date", "2003-03");
-        Assert.assertEquals("3", emptyEntry.getFieldOrAlias("month").get());
+        Assert.assertEquals(Optional.of("3"), emptyEntry.getFieldOrAlias("month"));
     }
 
     @Test
     public void getFieldOrAliasMonthWithDateYYYYMMDD() {
         emptyEntry.setField("date", "2003-03-30");
-        Assert.assertEquals("3", emptyEntry.getFieldOrAlias("month").get());
+        Assert.assertEquals(Optional.of("3"), emptyEntry.getFieldOrAlias("month"));
     }
 
     @Test(expected = NullPointerException.class)
@@ -381,9 +381,9 @@ public class BibEntryTests {
         be.setCiteKey("Einstein1931");
         Assert.assertTrue(be.hasCiteKey());
         Assert.assertEquals("Einstein1931", be.getCiteKey());
-        Assert.assertEquals("Albert Einstein", be.getFieldOptional("author").get());
+        Assert.assertEquals(Optional.of("Albert Einstein"), be.getFieldOptional("author"));
         be.clearField("author");
-        Assert.assertFalse(be.getFieldOptional("author").isPresent());
+        Assert.assertEquals(Optional.empty(), be.getFieldOptional("author"));
 
         String id = IdGenerator.next();
         be.setId(id);


### PR DESCRIPTION
* Added `getEntryByKeyOptional` and almost managed to completely remove the use of `getEntryByKey`.
* Changed the return type of `getFieldOrAlias` to be `Optional<String>`
* Some more conversions of `getField` to `getFieldOptional` 
