### PR TITLE
Some enhancements and cleanups related to dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed [#1527](https://github.com/JabRef/jabref/issues/1527): 'Get BibTeX data from DOI' Removes Marking
 - Fixed [#1592](https://github.com/JabRef/jabref/issues/1592): LibreOffice: wrong numbers in citation labels
 - Fixed [#1321](https://github.com/JabRef/jabref/issues/1321): LaTeX commands in fields not displayed in the list of references
+- Date fields in the BibLatex standard are now always formatted in the correct way, independent of the preferences
 
 ### Removed
 - It is not longer possible to choose to convert HTML sub- and superscripts to equations

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -700,7 +700,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             tidialog.setVisible(true);
 
             if (tidialog.okPressed()) {
-                UpdateField.setAutomaticFields(Collections.singletonList(bibEntry), false, false);
+                UpdateField.setAutomaticFields(Collections.singletonList(bibEntry), false, false, Globals.prefs);
                 insertEntry(bibEntry);
             }
         });
@@ -898,7 +898,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     firstBE = be;
                 }
                 UpdateField.setAutomaticFields(be, Globals.prefs.getBoolean(JabRefPreferences.OVERWRITE_OWNER),
-                        Globals.prefs.getBoolean(JabRefPreferences.OVERWRITE_TIME_STAMP));
+                        Globals.prefs.getBoolean(JabRefPreferences.OVERWRITE_TIME_STAMP), Globals.prefs);
 
                 // We have to clone the
                 // entries, since the pasted
@@ -1223,7 +1223,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 // Set owner/timestamp if options are enabled:
                 List<BibEntry> list = new ArrayList<>();
                 list.add(be);
-                UpdateField.setAutomaticFields(list, true, true);
+                UpdateField.setAutomaticFields(list, true, true, Globals.prefs);
 
                 // Create an UndoableInsertEntry object.
                 getUndoManager().addEdit(new UndoableInsertEntry(database, be, BasePanel.this));
@@ -1372,7 +1372,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 database.insertEntry(bibEntry);
                 if (Globals.prefs.getBoolean(JabRefPreferences.USE_OWNER)) {
                     // Set owner field to default value
-                    UpdateField.setAutomaticFields(bibEntry, true, true);
+                    UpdateField.setAutomaticFields(bibEntry, true, true, Globals.prefs);
                 }
                 // Create an UndoableInsertEntry object.
                 getUndoManager().addEdit(new UndoableInsertEntry(database, bibEntry, BasePanel.this));

--- a/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
@@ -707,7 +707,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
 
             // Set owner/timestamp if options are enabled:
             UpdateField.setAutomaticFields(selected, Globals.prefs.getBoolean(JabRefPreferences.OVERWRITE_OWNER),
-                    Globals.prefs.getBoolean(JabRefPreferences.OVERWRITE_TIME_STAMP));
+                    Globals.prefs.getBoolean(JabRefPreferences.OVERWRITE_TIME_STAMP), Globals.prefs);
 
             // Mark entries if we should
             if (EntryMarker.shouldMarkEntries()) {

--- a/src/main/java/net/sf/jabref/gui/date/DatePickerButton.java
+++ b/src/main/java/net/sf/jabref/gui/date/DatePickerButton.java
@@ -1,4 +1,5 @@
 /*  Copyright (C) 2003-2011 Raik Nagel
+ * 2016 JabRef Contributors
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -37,9 +38,11 @@ public class DatePickerButton implements ActionListener {
     private final DatePicker datePicker = new DatePicker();
     private final JPanel panel = new JPanel();
     private final FieldEditor editor;
+    private final boolean isoFormat;
 
 
-    public DatePickerButton(FieldEditor pEditor) {
+    public DatePickerButton(FieldEditor pEditor, Boolean isoFormat) {
+        this.isoFormat = isoFormat;
         datePicker.showButtonOnly(true);
         datePicker.addActionListener(this);
         datePicker.setShowTodayButton(true);
@@ -52,7 +55,7 @@ public class DatePickerButton implements ActionListener {
     public void actionPerformed(ActionEvent e) {
         Date date = datePicker.getDate();
         if (date != null) {
-            editor.setText(new EasyDateFormat().getDateAt(date));
+            editor.setText(new EasyDateFormat().getDateAt(date, isoFormat));
             // Set focus to editor component after changing its text:
             new FocusRequester(editor.getTextComponent());
         }

--- a/src/main/java/net/sf/jabref/gui/date/DatePickerButton.java
+++ b/src/main/java/net/sf/jabref/gui/date/DatePickerButton.java
@@ -55,7 +55,7 @@ public class DatePickerButton implements ActionListener {
     public void actionPerformed(ActionEvent e) {
         Date date = datePicker.getDate();
         if (date != null) {
-            editor.setText(new EasyDateFormat().getDateAt(date, isoFormat));
+            editor.setText(EasyDateFormat.isoDateFormat().getDateAt(date));
             // Set focus to editor component after changing its text:
             new FocusRequester(editor.getTextComponent());
         }

--- a/src/main/java/net/sf/jabref/gui/date/DatePickerButton.java
+++ b/src/main/java/net/sf/jabref/gui/date/DatePickerButton.java
@@ -27,6 +27,7 @@ import java.util.Date;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.gui.fieldeditors.FieldEditor;
 import net.sf.jabref.gui.util.FocusRequester;
 import net.sf.jabref.logic.util.date.EasyDateFormat;
@@ -55,7 +56,11 @@ public class DatePickerButton implements ActionListener {
     public void actionPerformed(ActionEvent e) {
         Date date = datePicker.getDate();
         if (date != null) {
-            editor.setText(EasyDateFormat.isoDateFormat().getDateAt(date));
+            if (isoFormat) {
+                editor.setText(EasyDateFormat.isoDateFormat().getDateAt(date));
+            } else {
+                editor.setText(EasyDateFormat.fromPreferences(Globals.prefs).getDateAt(date));
+            }
             // Set focus to editor component after changing its text:
             new FocusRequester(editor.getTextComponent());
         }

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -503,7 +503,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
                 || fieldExtras.contains(FieldProperties.DATE)) {
             // double click AND datefield => insert the current date (today)
             return FieldExtraComponents.getDateTimeExtraComponent(editor,
-                    fieldExtras.contains(FieldProperties.DATE));
+                    fieldExtras.contains(FieldProperties.DATE), fieldExtras.contains(FieldProperties.ISO_DATE));
         } else if (fieldExtras.contains(FieldProperties.EXTERNAL)) {
             return FieldExtraComponents.getExternalExtraComponent(panel, editor);
         } else if (fieldExtras.contains(FieldProperties.JOURNAL_NAME)) {

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -1126,10 +1126,10 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
                 // Add an UndoableKeyChange to the baseframe's undoManager.
                 UndoableKeyChange undoableKeyChange = new UndoableKeyChange(panel.getDatabase(), entry, oldValue, newValue);
-                if (TimeStamp.updateTimeStampIsSet()) {
+                if (TimeStamp.updateTimeStampIsSet(Globals.prefs)) {
                     NamedCompound ce = new NamedCompound(undoableKeyChange.getPresentationName());
                     ce.addEdit(undoableKeyChange);
-                    TimeStamp.doUpdateTimeStamp(entry)
+                    TimeStamp.doUpdateTimeStamp(entry, Globals.prefs)
                             .ifPresent(fieldChange -> ce.addEdit(new UndoableFieldChange(fieldChange)));
                     ce.end();
                     panel.getUndoManager().addEdit(ce);
@@ -1194,11 +1194,11 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
                         // Add an UndoableFieldChange to the baseframe's undoManager.
                         UndoableFieldChange undoableFieldChange = new UndoableFieldChange(entry, fieldEditor.getFieldName(), oldValue, toSet);
-                        if (TimeStamp.updateTimeStampIsSet()) {
+                        if (TimeStamp.updateTimeStampIsSet(Globals.prefs)) {
                             NamedCompound ce = new NamedCompound(undoableFieldChange.getPresentationName());
                             ce.addEdit(undoableFieldChange);
 
-                            TimeStamp.doUpdateTimeStamp(entry)
+                            TimeStamp.doUpdateTimeStamp(entry, Globals.prefs)
                                     .ifPresent(fieldChange -> ce.addEdit(new UndoableFieldChange(fieldChange)));
                             ce.end();
 

--- a/src/main/java/net/sf/jabref/gui/entryeditor/FieldExtraComponents.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/FieldExtraComponents.java
@@ -349,13 +349,14 @@ public class FieldExtraComponents {
      * @param isDatePicker
      * @return
      */
-    public static Optional<JComponent> getDateTimeExtraComponent(FieldEditor editor, Boolean isDatePicker) {
+    public static Optional<JComponent> getDateTimeExtraComponent(FieldEditor editor, Boolean isDatePicker,
+            Boolean isoFormat) {
         ((JTextArea) editor).addMouseListener(new MouseAdapter() {
 
             @Override
             public void mouseClicked(MouseEvent e) {
                 if (e.getClickCount() == 2) {// double click
-                    String date = new EasyDateFormat().getCurrentDate();
+                    String date = new EasyDateFormat().getCurrentDate(isoFormat);
                     editor.setText(date);
                 }
             }
@@ -363,7 +364,7 @@ public class FieldExtraComponents {
 
         // insert a datepicker, if the extras field contains this command
         if (isDatePicker) {
-            DatePickerButton datePicker = new DatePickerButton(editor);
+            DatePickerButton datePicker = new DatePickerButton(editor, isoFormat);
             return Optional.of(datePicker.getDatePicker());
         } else {
             return Optional.empty();

--- a/src/main/java/net/sf/jabref/gui/entryeditor/FieldExtraComponents.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/FieldExtraComponents.java
@@ -356,7 +356,7 @@ public class FieldExtraComponents {
             @Override
             public void mouseClicked(MouseEvent e) {
                 if (e.getClickCount() == 2) {// double click
-                    String date = new EasyDateFormat().getCurrentDate(isoFormat);
+                    String date = EasyDateFormat.isoDateFormat().getCurrentDate();
                     editor.setText(date);
                 }
             }

--- a/src/main/java/net/sf/jabref/gui/plaintextimport/TextInputDialog.java
+++ b/src/main/java/net/sf/jabref/gui/plaintextimport/TextInputDialog.java
@@ -522,7 +522,7 @@ public class TextInputDialog extends JDialog {
         if (importedEntries.isEmpty()) {
             return false;
         } else {
-            UpdateField.setAutomaticFields(importedEntries, false, false);
+            UpdateField.setAutomaticFields(importedEntries, false, false, Globals.prefs);
             boolean markEntries = EntryMarker.shouldMarkEntries();
 
             for (BibEntry e : importedEntries) {

--- a/src/main/java/net/sf/jabref/gui/preftabs/GeneralTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/GeneralTab.java
@@ -18,7 +18,7 @@ package net.sf.jabref.gui.preftabs;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.nio.charset.Charset;
-import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 
 import javax.swing.BorderFactory;
 import javax.swing.DefaultComboBoxModel;
@@ -278,7 +278,7 @@ class GeneralTab extends JPanel implements PrefsTab {
     public boolean validateSettings() {
         try {
             // Test if date format is legal:
-            new SimpleDateFormat(timeStampFormat.getText());
+            DateTimeFormatter.ofPattern(timeStampFormat.getText());
 
         } catch (IllegalArgumentException ex2) {
             JOptionPane.showMessageDialog

--- a/src/main/java/net/sf/jabref/importer/AppendDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/AppendDatabaseAction.java
@@ -142,7 +142,7 @@ public class AppendDatabaseAction implements BaseAction {
             for (BibEntry originalEntry : fromDatabase.getEntries()) {
                 BibEntry be = (BibEntry) originalEntry.clone();
                 be.setId(IdGenerator.next());
-                UpdateField.setAutomaticFields(be, overwriteOwner, overwriteTimeStamp);
+                UpdateField.setAutomaticFields(be, overwriteOwner, overwriteTimeStamp, Globals.prefs);
                 database.insertEntry(be);
                 appendedEntries.add(be);
                 originalEntries.add(originalEntry);

--- a/src/main/java/net/sf/jabref/importer/EntryFromPDFCreator.java
+++ b/src/main/java/net/sf/jabref/importer/EntryFromPDFCreator.java
@@ -2,7 +2,8 @@ package net.sf.jabref.importer;
 
 import java.io.File;
 import java.io.IOException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Optional;
@@ -95,8 +96,8 @@ public class EntryFromPDFCreator extends EntryFromFileCreator {
                     Calendar creationDate = pdfDocInfo.getCreationDate();
                     if (creationDate != null) {
                         // default time stamp follows ISO-8601. Reason: https://xkcd.com/1179/
-                        String date = new SimpleDateFormat("yyyy-MM-dd")
-                                .format(creationDate.getTime());
+                        String date = LocalDate.of(creationDate.YEAR, creationDate.MONTH + 1, creationDate.DAY_OF_MONTH)
+                                .format(DateTimeFormatter.ISO_LOCAL_DATE);
                         appendToField(entry, Globals.prefs.get(JabRefPreferences.TIME_STAMP_FIELD), date);
                     }
 

--- a/src/main/java/net/sf/jabref/importer/ImportMenuItem.java
+++ b/src/main/java/net/sf/jabref/importer/ImportMenuItem.java
@@ -258,7 +258,7 @@ public class ImportMenuItem extends JMenuItem implements ActionListener {
 
                 // set timestamp and owner
                 UpdateField.setAutomaticFields(entries, Globals.prefs.getBoolean(JabRefPreferences.OVERWRITE_OWNER),
-                        Globals.prefs.getBoolean(JabRefPreferences.OVERWRITE_TIME_STAMP)); // set timestamp and owner
+                        Globals.prefs.getBoolean(JabRefPreferences.OVERWRITE_TIME_STAMP), Globals.prefs); // set timestamp and owner
 
                 boolean markEntries = !openInNew && EntryMarker.shouldMarkEntries();
                 for (BibEntry entry : entries) {

--- a/src/main/java/net/sf/jabref/importer/ZipFileChooser.java
+++ b/src/main/java/net/sf/jabref/importer/ZipFileChooser.java
@@ -29,8 +29,12 @@ package net.sf.jabref.importer;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.io.IOException;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Enumeration;
@@ -150,7 +154,7 @@ class ZipFileChooser extends JDialog {
      * @param zipFile  Zip-File
      * @return  entries that can be selected
      */
-    private static ZipEntry[] getSelectableZipEntries(ZipFile zipFile) {
+    private static List<ZipEntry> getSelectableZipEntries(ZipFile zipFile) {
         List<ZipEntry> entries = new ArrayList<>();
         Enumeration<? extends ZipEntry> e = zipFile.entries();
         for (ZipEntry entry : Collections.list(e)) {
@@ -158,7 +162,7 @@ class ZipFileChooser extends JDialog {
                 entries.add(entry);
             }
         }
-        return entries.toArray(new ZipEntry[entries.size()]);
+        return entries;
     }
 
     /*
@@ -188,13 +192,13 @@ class ZipFileChooser extends JDialog {
      */
     private static class ZipFileChooserTableModel extends AbstractTableModel {
 
-        private final String[] columnNames = new String[] {Localization.lang("Name"),
-                Localization.lang("Last modified"), Localization.lang("Size")};
-        private final ZipEntry[] rows;
+        private final List<String> columnNames = Arrays.asList(Localization.lang("Name"),
+                Localization.lang("Last modified"), Localization.lang("Size"));
+        private final List<ZipEntry> rows;
         private final ZipFile zipFile;
 
 
-        ZipFileChooserTableModel(ZipFile zipFile, ZipEntry[] rows) {
+        ZipFileChooserTableModel(ZipFile zipFile, List<ZipEntry> rows) {
             super();
             this.rows = rows;
             this.zipFile = zipFile;
@@ -206,7 +210,7 @@ class ZipFileChooser extends JDialog {
          */
         @Override
         public int getColumnCount() {
-            return columnNames.length;
+            return columnNames.size();
         }
 
         /*
@@ -215,7 +219,7 @@ class ZipFileChooser extends JDialog {
          */
         @Override
         public int getRowCount() {
-            return this.rows.length;
+            return this.rows.size();
         }
 
         /*
@@ -224,7 +228,7 @@ class ZipFileChooser extends JDialog {
          */
         @Override
         public String getColumnName(int col) {
-            return columnNames[col];
+            return columnNames.get(col);
         }
 
         /**
@@ -234,7 +238,7 @@ class ZipFileChooser extends JDialog {
          * @return  Zip file entry
          */
         public ZipEntry getZipEntry(int rowIndex) {
-            return this.rows[rowIndex];
+            return this.rows.get(rowIndex);
         }
 
         /**
@@ -257,7 +261,9 @@ class ZipFileChooser extends JDialog {
             if (columnIndex == 0) {
                 value = entry.getName();
             } else if (columnIndex == 1) {
-                value = SimpleDateFormat.getDateTimeInstance().format(new Date(entry.getTime()));
+                value = ZonedDateTime.ofInstant(new Date(entry.getTime()).toInstant(),
+                        ZoneId.systemDefault())
+                        .format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM));
             } else if (columnIndex == 2) {
                 value = entry.getSize();
             }

--- a/src/main/java/net/sf/jabref/logic/layout/format/CurrentDate.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/CurrentDate.java
@@ -1,5 +1,5 @@
 /*
- Copyright (C) 2005-2015 Andreas Rudert, Oscar Gustafsson
+ Copyright (C) 2005-2016 Andreas Rudert, Oscar Gustafsson
 
  All programs in this directory and
  subdirectories are published under the GNU General Public License as
@@ -25,15 +25,15 @@
 */
 package net.sf.jabref.logic.layout.format;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 import net.sf.jabref.logic.layout.LayoutFormatter;
 
 /**
  * Inserts the current date (the time a database is being exported).
  *
- * <p>If a fieldText is given, it must be a valid {@link SimpleDateFormat} pattern.
+ * <p>If a fieldText is given, it must be a valid {@link DateTimeFormatter} pattern.
  * If none is given, the format pattern will be <code>yyyy-MM-dd hh:mm:ss z</code>.
  * This follows ISO-8601. Reason: <a href="https://xkcd.com/1179/">https://xkcd.com/1179/</a>.</p>
  *
@@ -55,6 +55,6 @@ public class CurrentDate implements LayoutFormatter {
         if ((fieldText != null) && (fieldText.trim() != null) && !fieldText.trim().isEmpty()) {
             format = fieldText;
         }
-        return new SimpleDateFormat(format).format(new Date());
+        return LocalDate.now().format(DateTimeFormatter.ofPattern(format));
     }
 }

--- a/src/main/java/net/sf/jabref/logic/layout/format/CurrentDate.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/CurrentDate.java
@@ -25,7 +25,7 @@
 */
 package net.sf.jabref.logic.layout.format;
 
-import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 import net.sf.jabref.logic.layout.LayoutFormatter;
@@ -55,6 +55,6 @@ public class CurrentDate implements LayoutFormatter {
         if ((fieldText != null) && (fieldText.trim() != null) && !fieldText.trim().isEmpty()) {
             format = fieldText;
         }
-        return LocalDate.now().format(DateTimeFormatter.ofPattern(format));
+        return ZonedDateTime.now().format(DateTimeFormatter.ofPattern(format));
     }
 }

--- a/src/main/java/net/sf/jabref/logic/net/Cookie.java
+++ b/src/main/java/net/sf/jabref/logic/net/Cookie.java
@@ -16,10 +16,9 @@
 package net.sf.jabref.logic.net;
 
 import java.net.URI;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -28,15 +27,12 @@ class Cookie {
     private final String name;
     private final String value;
     private String domain;
-    private Date expires;
+    private LocalDate expires;
     private String path;
 
-    /**
-     * DateFormats should not be reused among instances (or rather among threads), because they are not thread-safe.
-     * If they are shared, their usage should be synchronized.
-     */
-    private final DateFormat whiteSpaceFormat = new SimpleDateFormat("E, dd MMM yyyy k:m:s 'GMT'", Locale.US);
-    private final DateFormat hyphenFormat = new SimpleDateFormat("E, dd-MMM-yyyy k:m:s 'GMT'", Locale.US);
+    private final DateTimeFormatter whiteSpaceFormat = DateTimeFormatter.ofPattern("E, dd MMM yyyy k:m:s 'GMT'",
+            Locale.US);
+    private final DateTimeFormatter hyphenFormat = DateTimeFormatter.ofPattern("E, dd-MMM-yyyy k:m:s 'GMT'", Locale.US);
 
 
     /**
@@ -82,11 +78,11 @@ class Cookie {
                 this.path = value;
             } else if ("expires".equalsIgnoreCase(name)) {
                 try {
-                    this.expires = whiteSpaceFormat.parse(value);
-                } catch (ParseException e) {
+                    this.expires = LocalDate.parse(value, whiteSpaceFormat);
+                } catch (DateTimeParseException e) {
                     try {
-                        this.expires = hyphenFormat.parse(value);
-                    } catch (ParseException e2) {
+                        this.expires = LocalDate.parse(value, hyphenFormat);
+                    } catch (DateTimeParseException e2) {
                         throw new IllegalArgumentException(
                                 "Bad date format in header: " + value);
                     }
@@ -99,8 +95,7 @@ class Cookie {
         if (expires == null) {
             return false;
         }
-        Date now = new Date();
-        return now.after(expires);
+        return LocalDate.now().isAfter(expires);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/net/Cookie.java
+++ b/src/main/java/net/sf/jabref/logic/net/Cookie.java
@@ -30,9 +30,9 @@ class Cookie {
     private LocalDateTime expires;
     private String path;
 
-    private final DateTimeFormatter whiteSpaceFormat = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz",
+    private final DateTimeFormatter whiteSpaceFormat = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'",
             Locale.ROOT);
-    private final DateTimeFormatter hyphenFormat = DateTimeFormatter.ofPattern("EEE, dd-MMM-yyyy HH:mm:ss zzz",
+    private final DateTimeFormatter hyphenFormat = DateTimeFormatter.ofPattern("EEE, dd-MMM-yyyy HH:mm:ss 'GMT'",
             Locale.ROOT);
 
 
@@ -45,10 +45,8 @@ class Cookie {
     public Cookie(URI uri, String header) {
         String[] attributes = header.split(";");
         String nameValue = attributes[0].trim();
-        this.name =
-                nameValue.substring(0, nameValue.indexOf('='));
-        this.value =
-                nameValue.substring(nameValue.indexOf('=') + 1);
+        this.name = nameValue.substring(0, nameValue.indexOf('='));
+        this.value = nameValue.substring(nameValue.indexOf('=') + 1);
         this.path = "/";
         this.domain = uri.getHost();
 

--- a/src/main/java/net/sf/jabref/logic/net/Cookie.java
+++ b/src/main/java/net/sf/jabref/logic/net/Cookie.java
@@ -16,7 +16,7 @@
 package net.sf.jabref.logic.net;
 
 import java.net.URI;
-import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Locale;
@@ -27,12 +27,12 @@ class Cookie {
     private final String name;
     private final String value;
     private String domain;
-    private LocalDate expires;
+    private ZonedDateTime expires;
     private String path;
 
-    private final DateTimeFormatter whiteSpaceFormat = DateTimeFormatter.ofPattern("E, dd MMM yyyy k:m:s 'GMT'",
+    private final DateTimeFormatter whiteSpaceFormat = DateTimeFormatter.ofPattern("E, dd MMM yyyy k:m:s z",
             Locale.US);
-    private final DateTimeFormatter hyphenFormat = DateTimeFormatter.ofPattern("E, dd-MMM-yyyy k:m:s 'GMT'", Locale.US);
+    private final DateTimeFormatter hyphenFormat = DateTimeFormatter.ofPattern("E, dd-MMM-yyyy k:m:s z", Locale.US);
 
 
     /**
@@ -78,10 +78,10 @@ class Cookie {
                 this.path = value;
             } else if ("expires".equalsIgnoreCase(name)) {
                 try {
-                    this.expires = LocalDate.parse(value, whiteSpaceFormat);
+                    this.expires = ZonedDateTime.parse(value, whiteSpaceFormat);
                 } catch (DateTimeParseException e) {
                     try {
-                        this.expires = LocalDate.parse(value, hyphenFormat);
+                        this.expires = ZonedDateTime.parse(value, hyphenFormat);
                     } catch (DateTimeParseException e2) {
                         throw new IllegalArgumentException(
                                 "Bad date format in header: " + value);
@@ -95,7 +95,7 @@ class Cookie {
         if (expires == null) {
             return false;
         }
-        return LocalDate.now().isAfter(expires);
+        return ZonedDateTime.now().isAfter(expires);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/net/Cookie.java
+++ b/src/main/java/net/sf/jabref/logic/net/Cookie.java
@@ -30,9 +30,11 @@ class Cookie {
     private ZonedDateTime expires;
     private String path;
 
-    private final DateTimeFormatter whiteSpaceFormat = DateTimeFormatter.ofPattern("EEE, dd MMM yy HH:mm:ss z",
+    private final DateTimeFormatter whiteSpaceFormat = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss z",
             Locale.ROOT);
-    private final DateTimeFormatter hyphenFormat = DateTimeFormatter.ofPattern("EEE, dd-MMM-yy HH:mm:ss z",
+    private final DateTimeFormatter hyphenFormat = DateTimeFormatter.ofPattern("EEE, dd-MMM-yyyy HH:mm:ss z",
+            Locale.ROOT);
+    private final DateTimeFormatter hyphenTwoDigitYearFormat = DateTimeFormatter.ofPattern("EEE, dd-MMM-yy HH:mm:ss z",
             Locale.ROOT);
 
 
@@ -82,8 +84,11 @@ class Cookie {
                     try {
                         this.expires = ZonedDateTime.parse(value, hyphenFormat);
                     } catch (DateTimeParseException e2) {
-                        throw new IllegalArgumentException(
-                                "Bad date format in header: " + value);
+                        try {
+                            this.expires = ZonedDateTime.parse(value, hyphenTwoDigitYearFormat);
+                        } catch (DateTimeParseException e3) {
+                            throw new IllegalArgumentException("Bad date format in header: " + value);
+                        }
                     }
                 }
             }

--- a/src/main/java/net/sf/jabref/logic/net/Cookie.java
+++ b/src/main/java/net/sf/jabref/logic/net/Cookie.java
@@ -19,7 +19,6 @@ import java.net.URI;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.Locale;
 import java.util.Optional;
 
 class Cookie {
@@ -30,9 +29,8 @@ class Cookie {
     private ZonedDateTime expires;
     private String path;
 
-    private final DateTimeFormatter whiteSpaceFormat = DateTimeFormatter.ofPattern("E, dd MMM yyyy k:m:s z",
-            Locale.US);
-    private final DateTimeFormatter hyphenFormat = DateTimeFormatter.ofPattern("E, dd-MMM-yyyy k:m:s z", Locale.US);
+    private final DateTimeFormatter whiteSpaceFormat = DateTimeFormatter.ofPattern("E, dd MMM yyyy k:m:s z");
+    private final DateTimeFormatter hyphenFormat = DateTimeFormatter.ofPattern("E, dd-MMM-yyyy k:m:s z");
 
 
     /**

--- a/src/main/java/net/sf/jabref/logic/net/Cookie.java
+++ b/src/main/java/net/sf/jabref/logic/net/Cookie.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Locale;
 import java.util.Optional;
 
 class Cookie {
@@ -29,8 +30,10 @@ class Cookie {
     private ZonedDateTime expires;
     private String path;
 
-    private final DateTimeFormatter whiteSpaceFormat = DateTimeFormatter.ofPattern("E, dd MMM yyyy k:m:s z");
-    private final DateTimeFormatter hyphenFormat = DateTimeFormatter.ofPattern("E, dd-MMM-yyyy k:m:s z");
+    private final DateTimeFormatter whiteSpaceFormat = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz",
+            Locale.ROOT);
+    private final DateTimeFormatter hyphenFormat = DateTimeFormatter.ofPattern("EEE, dd-MMM-yyyy HH:mm:ss zzz",
+            Locale.ROOT);
 
 
     /**
@@ -76,6 +79,7 @@ class Cookie {
                 this.path = value;
             } else if ("expires".equalsIgnoreCase(name)) {
                 try {
+                    System.err.println("*" + value + "*");
                     this.expires = ZonedDateTime.parse(value, whiteSpaceFormat);
                 } catch (DateTimeParseException e) {
                     try {

--- a/src/main/java/net/sf/jabref/logic/net/Cookie.java
+++ b/src/main/java/net/sf/jabref/logic/net/Cookie.java
@@ -79,7 +79,6 @@ class Cookie {
                 this.path = value;
             } else if ("expires".equalsIgnoreCase(name)) {
                 try {
-                    System.err.println("*" + value + "*");
                     this.expires = ZonedDateTime.parse(value, whiteSpaceFormat);
                 } catch (DateTimeParseException e) {
                     try {

--- a/src/main/java/net/sf/jabref/logic/net/Cookie.java
+++ b/src/main/java/net/sf/jabref/logic/net/Cookie.java
@@ -16,7 +16,7 @@
 package net.sf.jabref.logic.net;
 
 import java.net.URI;
-import java.time.ZonedDateTime;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Locale;
@@ -27,7 +27,7 @@ class Cookie {
     private final String name;
     private final String value;
     private String domain;
-    private ZonedDateTime expires;
+    private LocalDateTime expires;
     private String path;
 
     private final DateTimeFormatter whiteSpaceFormat = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz",
@@ -79,10 +79,10 @@ class Cookie {
                 this.path = value;
             } else if ("expires".equalsIgnoreCase(name)) {
                 try {
-                    this.expires = ZonedDateTime.parse(value, whiteSpaceFormat);
+                    this.expires = LocalDateTime.parse(value, whiteSpaceFormat);
                 } catch (DateTimeParseException e) {
                     try {
-                        this.expires = ZonedDateTime.parse(value, hyphenFormat);
+                        this.expires = LocalDateTime.parse(value, hyphenFormat);
                     } catch (DateTimeParseException e2) {
                         throw new IllegalArgumentException(
                                 "Bad date format in header: " + value);
@@ -96,7 +96,7 @@ class Cookie {
         if (expires == null) {
             return false;
         }
-        return ZonedDateTime.now().isAfter(expires);
+        return LocalDateTime.now().isAfter(expires);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/net/Cookie.java
+++ b/src/main/java/net/sf/jabref/logic/net/Cookie.java
@@ -16,7 +16,7 @@
 package net.sf.jabref.logic.net;
 
 import java.net.URI;
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Locale;
@@ -27,12 +27,12 @@ class Cookie {
     private final String name;
     private final String value;
     private String domain;
-    private LocalDateTime expires;
+    private ZonedDateTime expires;
     private String path;
 
-    private final DateTimeFormatter whiteSpaceFormat = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'",
+    private final DateTimeFormatter whiteSpaceFormat = DateTimeFormatter.ofPattern("EEE, dd MMM yy HH:mm:ss z",
             Locale.ROOT);
-    private final DateTimeFormatter hyphenFormat = DateTimeFormatter.ofPattern("EEE, dd-MMM-yyyy HH:mm:ss 'GMT'",
+    private final DateTimeFormatter hyphenFormat = DateTimeFormatter.ofPattern("EEE, dd-MMM-yy HH:mm:ss z",
             Locale.ROOT);
 
 
@@ -77,10 +77,10 @@ class Cookie {
                 this.path = value;
             } else if ("expires".equalsIgnoreCase(name)) {
                 try {
-                    this.expires = LocalDateTime.parse(value, whiteSpaceFormat);
+                    this.expires = ZonedDateTime.parse(value, whiteSpaceFormat);
                 } catch (DateTimeParseException e) {
                     try {
-                        this.expires = LocalDateTime.parse(value, hyphenFormat);
+                        this.expires = ZonedDateTime.parse(value, hyphenFormat);
                     } catch (DateTimeParseException e2) {
                         throw new IllegalArgumentException(
                                 "Bad date format in header: " + value);
@@ -94,7 +94,7 @@ class Cookie {
         if (expires == null) {
             return false;
         }
-        return LocalDateTime.now().isAfter(expires);
+        return ZonedDateTime.now().isAfter(expires);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/util/UpdateField.java
+++ b/src/main/java/net/sf/jabref/logic/util/UpdateField.java
@@ -3,7 +3,6 @@ package net.sf.jabref.logic.util;
 import java.util.Collection;
 import java.util.Optional;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.util.date.EasyDateFormat;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;
@@ -11,9 +10,6 @@ import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 public class UpdateField {
-
-    private static final EasyDateFormat DATE_FORMATTER = new EasyDateFormat();
-
 
     /**
      * Updating a field will result in the entry being reformatted on save
@@ -88,13 +84,14 @@ public class UpdateField {
      * @param overwriteOwner     Indicates whether owner should be set if it is already set.
      * @param overwriteTimestamp Indicates whether timestamp should be set if it is already set.
      */
-    public static void setAutomaticFields(BibEntry entry, boolean overwriteOwner, boolean overwriteTimestamp) {
-        String defaultOwner = Globals.prefs.get(JabRefPreferences.DEFAULT_OWNER);
-        String timestamp = DATE_FORMATTER.getCurrentDate();
-        String timeStampField = Globals.prefs.get(JabRefPreferences.TIME_STAMP_FIELD);
-        boolean setOwner = Globals.prefs.getBoolean(JabRefPreferences.USE_OWNER)
+    public static void setAutomaticFields(BibEntry entry, boolean overwriteOwner, boolean overwriteTimestamp,
+            JabRefPreferences prefs) {
+        String defaultOwner = prefs.get(JabRefPreferences.DEFAULT_OWNER);
+        String timestamp = EasyDateFormat.fromPreferences(prefs).getCurrentDate();
+        String timeStampField = prefs.get(JabRefPreferences.TIME_STAMP_FIELD);
+        boolean setOwner = prefs.getBoolean(JabRefPreferences.USE_OWNER)
                 && (overwriteOwner || (!entry.hasField(FieldName.OWNER)));
-        boolean setTimeStamp = Globals.prefs.getBoolean(JabRefPreferences.USE_TIME_STAMP)
+        boolean setTimeStamp = prefs.getBoolean(JabRefPreferences.USE_TIME_STAMP)
                 && (overwriteTimestamp || (!entry.hasField(timeStampField)));
 
         setAutomaticFields(entry, setOwner, defaultOwner, setTimeStamp, timeStampField, timestamp);
@@ -121,19 +118,19 @@ public class UpdateField {
      * @param bibs List of bibtex entries
      */
     public static void setAutomaticFields(Collection<BibEntry> bibs, boolean overwriteOwner,
-            boolean overwriteTimestamp) {
+            boolean overwriteTimestamp, JabRefPreferences prefs) {
 
-        boolean globalSetOwner = Globals.prefs.getBoolean(JabRefPreferences.USE_OWNER);
-        boolean globalSetTimeStamp = Globals.prefs.getBoolean(JabRefPreferences.USE_TIME_STAMP);
+        boolean globalSetOwner = prefs.getBoolean(JabRefPreferences.USE_OWNER);
+        boolean globalSetTimeStamp = prefs.getBoolean(JabRefPreferences.USE_TIME_STAMP);
 
         // Do not need to do anything if all options are disabled
         if (!(globalSetOwner || globalSetTimeStamp)) {
             return;
         }
 
-        String timeStampField = Globals.prefs.get(JabRefPreferences.TIME_STAMP_FIELD);
-        String defaultOwner = Globals.prefs.get(JabRefPreferences.DEFAULT_OWNER);
-        String timestamp = DATE_FORMATTER.getCurrentDate();
+        String timeStampField = prefs.get(JabRefPreferences.TIME_STAMP_FIELD);
+        String defaultOwner = prefs.get(JabRefPreferences.DEFAULT_OWNER);
+        String timestamp = EasyDateFormat.fromPreferences(prefs).getCurrentDate();
 
         // Iterate through all entries
         for (BibEntry curEntry : bibs) {

--- a/src/main/java/net/sf/jabref/logic/util/date/EasyDateFormat.java
+++ b/src/main/java/net/sf/jabref/logic/util/date/EasyDateFormat.java
@@ -5,7 +5,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 public class EasyDateFormat {
@@ -13,8 +12,16 @@ public class EasyDateFormat {
     /**
      * The formatter objects
      */
-    private DateTimeFormatter dateFormatter;
-    private boolean isISOFormat;
+    private final DateTimeFormatter dateFormatter;
+
+
+    public EasyDateFormat(String dateFormat) {
+        this(DateTimeFormatter.ofPattern(dateFormat));
+    }
+
+    public EasyDateFormat(DateTimeFormatter dateFormatter) {
+        this.dateFormatter = dateFormatter;
+    }
 
     /**
      * Creates a String containing the current date (and possibly time),
@@ -24,18 +31,7 @@ public class EasyDateFormat {
      * @return The date string.
      */
     public String getCurrentDate() {
-        return getCurrentDate(false);
-    }
-
-    /**
-     * Creates a String containing the current date (and possibly time),
-     * formatted according to the format set in preferences under the key
-     * "timeStampFormat".
-     *
-     * @return The date string.
-     */
-    public String getCurrentDate(boolean isoFormat) {
-        return getDateAt(ZonedDateTime.now(), isoFormat);
+        return getDateAt(ZonedDateTime.now());
     }
 
     /**
@@ -44,8 +40,8 @@ public class EasyDateFormat {
      *
      * @return The formatted date string.
      */
-    public String getDateAt(Date date, boolean isoFormat) {
-        return getDateAt(date.toInstant().atZone(ZoneId.systemDefault()), isoFormat);
+    public String getDateAt(Date date) {
+        return getDateAt(date.toInstant().atZone(ZoneId.systemDefault()));
     }
 
     /**
@@ -54,17 +50,17 @@ public class EasyDateFormat {
      *
      * @return The formatted date string.
      */
-    public String getDateAt(ZonedDateTime dateTime, boolean isoFormat) {
+    public String getDateAt(ZonedDateTime dateTime) {
         // first use, create an instance
-        if ((dateFormatter == null) || (isoFormat != isISOFormat)) {
-            if (isoFormat) {
-                dateFormatter = DateTimeFormatter.ISO_LOCAL_DATE;
-            } else {
-                String format = Globals.prefs.get(JabRefPreferences.TIME_STAMP_FORMAT);
-                dateFormatter = DateTimeFormatter.ofPattern(format);
-            }
-            isISOFormat = isoFormat;
-        }
         return dateTime.format(dateFormatter);
+    }
+
+
+    public static EasyDateFormat fromPreferences(JabRefPreferences preferences) {
+     return new EasyDateFormat(preferences.get(JabRefPreferences.TIME_STAMP_FORMAT));
+    }
+
+    public static EasyDateFormat isoDateFormat() {
+        return new EasyDateFormat(DateTimeFormatter.ISO_LOCAL_DATE);
     }
 }

--- a/src/main/java/net/sf/jabref/logic/util/date/EasyDateFormat.java
+++ b/src/main/java/net/sf/jabref/logic/util/date/EasyDateFormat.java
@@ -1,6 +1,8 @@
 package net.sf.jabref.logic.util.date;
 
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 import net.sf.jabref.Globals;
@@ -11,8 +13,8 @@ public class EasyDateFormat {
     /**
      * The formatter objects
      */
-    private SimpleDateFormat dateFormatter;
-
+    private DateTimeFormatter dateFormatter;
+    private boolean isISOFormat;
 
     /**
      * Creates a String containing the current date (and possibly time),
@@ -22,7 +24,18 @@ public class EasyDateFormat {
      * @return The date string.
      */
     public String getCurrentDate() {
-        return getDateAt(new Date());
+        return getCurrentDate(false);
+    }
+
+    /**
+     * Creates a String containing the current date (and possibly time),
+     * formatted according to the format set in preferences under the key
+     * "timeStampFormat".
+     *
+     * @return The date string.
+     */
+    public String getCurrentDate(boolean isoFormat) {
+        return getDateAt(LocalDate.now(), isoFormat);
     }
 
     /**
@@ -31,12 +44,27 @@ public class EasyDateFormat {
      *
      * @return The formatted date string.
      */
-    public String getDateAt(Date date) {
+    public String getDateAt(Date date, boolean isoFormat) {
+        return getDateAt(date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate(), isoFormat);
+    }
+
+    /**
+     * Creates a readable Date string from the parameter date. The format is set
+     * in preferences under the key "timeStampFormat".
+     *
+     * @return The formatted date string.
+     */
+    public String getDateAt(LocalDate localDate, boolean isoFormat) {
         // first use, create an instance
-        if (dateFormatter == null) {
-            String format = Globals.prefs.get(JabRefPreferences.TIME_STAMP_FORMAT);
-            dateFormatter = new SimpleDateFormat(format);
+        if ((dateFormatter == null) || (isoFormat != isISOFormat)) {
+            if (isoFormat) {
+                dateFormatter = DateTimeFormatter.ISO_LOCAL_DATE;
+            } else {
+                String format = Globals.prefs.get(JabRefPreferences.TIME_STAMP_FORMAT);
+                dateFormatter = DateTimeFormatter.ofPattern(format);
+            }
+            isISOFormat = isoFormat;
         }
-        return dateFormatter.format(date);
+        return localDate.format(dateFormatter);
     }
 }

--- a/src/main/java/net/sf/jabref/logic/util/date/EasyDateFormat.java
+++ b/src/main/java/net/sf/jabref/logic/util/date/EasyDateFormat.java
@@ -1,7 +1,7 @@
 package net.sf.jabref.logic.util.date;
 
-import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
@@ -35,7 +35,7 @@ public class EasyDateFormat {
      * @return The date string.
      */
     public String getCurrentDate(boolean isoFormat) {
-        return getDateAt(LocalDate.now(), isoFormat);
+        return getDateAt(ZonedDateTime.now(), isoFormat);
     }
 
     /**
@@ -45,7 +45,7 @@ public class EasyDateFormat {
      * @return The formatted date string.
      */
     public String getDateAt(Date date, boolean isoFormat) {
-        return getDateAt(date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate(), isoFormat);
+        return getDateAt(date.toInstant().atZone(ZoneId.systemDefault()), isoFormat);
     }
 
     /**
@@ -54,7 +54,7 @@ public class EasyDateFormat {
      *
      * @return The formatted date string.
      */
-    public String getDateAt(LocalDate localDate, boolean isoFormat) {
+    public String getDateAt(ZonedDateTime dateTime, boolean isoFormat) {
         // first use, create an instance
         if ((dateFormatter == null) || (isoFormat != isISOFormat)) {
             if (isoFormat) {
@@ -65,6 +65,6 @@ public class EasyDateFormat {
             }
             isISOFormat = isoFormat;
         }
-        return localDate.format(dateFormatter);
+        return dateTime.format(dateFormatter);
     }
 }

--- a/src/main/java/net/sf/jabref/logic/util/date/TimeStamp.java
+++ b/src/main/java/net/sf/jabref/logic/util/date/TimeStamp.java
@@ -10,20 +10,17 @@ import net.sf.jabref.preferences.JabRefPreferences;
 
 public class TimeStamp {
 
-    private static final EasyDateFormat DATE_FORMATTER = new EasyDateFormat();
-
-    public static boolean updateTimeStampIsSet() {
-        return Globals.prefs.getBoolean(JabRefPreferences.USE_TIME_STAMP)
-                && Globals.prefs.getBoolean(JabRefPreferences.UPDATE_TIMESTAMP);
+    public static boolean updateTimeStampIsSet(JabRefPreferences prefs) {
+        return prefs.getBoolean(JabRefPreferences.USE_TIME_STAMP)
+                && prefs.getBoolean(JabRefPreferences.UPDATE_TIMESTAMP);
     }
 
     /**
-     * Updates the timestamp of the given entry, nests the given undaoableEdit in a named compound, and returns that
-     * named compound
+     * Updates the timestamp of the given entry and returns the FieldChange
      */
-    public static Optional<FieldChange> doUpdateTimeStamp(BibEntry entry) {
+    public static Optional<FieldChange> doUpdateTimeStamp(BibEntry entry, JabRefPreferences prefs) {
         String timeStampField = Globals.prefs.get(JabRefPreferences.TIME_STAMP_FIELD);
-        String timestamp = DATE_FORMATTER.getCurrentDate();
+        String timestamp = EasyDateFormat.fromPreferences(prefs).getCurrentDate();
         return UpdateField.updateField(entry, timeStampField, timestamp);
     }
 

--- a/src/main/java/net/sf/jabref/logic/util/date/TimeStamp.java
+++ b/src/main/java/net/sf/jabref/logic/util/date/TimeStamp.java
@@ -2,7 +2,6 @@ package net.sf.jabref.logic.util.date;
 
 import java.util.Optional;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.util.UpdateField;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;
@@ -19,7 +18,7 @@ public class TimeStamp {
      * Updates the timestamp of the given entry and returns the FieldChange
      */
     public static Optional<FieldChange> doUpdateTimeStamp(BibEntry entry, JabRefPreferences prefs) {
-        String timeStampField = Globals.prefs.get(JabRefPreferences.TIME_STAMP_FIELD);
+        String timeStampField = prefs.get(JabRefPreferences.TIME_STAMP_FIELD);
         String timestamp = EasyDateFormat.fromPreferences(prefs).getCurrentDate();
         return UpdateField.updateField(entry, timeStampField, timestamp);
     }

--- a/src/main/java/net/sf/jabref/model/entry/FieldProperties.java
+++ b/src/main/java/net/sf/jabref/model/entry/FieldProperties.java
@@ -23,7 +23,8 @@ public enum FieldProperties {
     EDITOR_TYPE,
     PAGINATION,
     TYPE,
-    CROSSREF;
+    CROSSREF,
+    ISO_DATE;
 
     public static final Set<FieldProperties> ALL_OPTS = EnumSet.allOf(FieldProperties.class);
 

--- a/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
+++ b/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
@@ -176,7 +176,8 @@ public class InternalBibtexFields {
         add(new BibtexSingleField(FieldName.EID, true, BibtexSingleField.SMALL_W));
 
         dummy = new BibtexSingleField(FieldName.DATE, true);
-        dummy.setPrivate();
+        dummy.setExtras(EnumSet.of(FieldProperties.DATE));
+        dummy.setPrivate(); // TODO: Why private?
         add(dummy);
 
         add(new BibtexSingleField("pmid", false, BibtexSingleField.SMALL_W, 60).setNumeric(true));
@@ -293,6 +294,7 @@ public class InternalBibtexFields {
                 field = new BibtexSingleField(fieldText, true, BibtexSingleField.SMALL_W);
             }
             field.getExtras().add(FieldProperties.DATE);
+            field.getExtras().add(FieldProperties.ISO_DATE);
             add(field);
         }
 

--- a/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
+++ b/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
@@ -281,7 +281,7 @@ public class PdfImporter {
                 // Set owner/timestamp if options are enabled:
                 List<BibEntry> list = new ArrayList<>();
                 list.add(be);
-                UpdateField.setAutomaticFields(list, true, true);
+                UpdateField.setAutomaticFields(list, true, true, Globals.prefs);
 
                 // Create an UndoableInsertEntry object.
                 panel.getUndoManager().addEdit(new UndoableInsertEntry(panel.getDatabase(), be, panel));

--- a/src/test/java/net/sf/jabref/logic/net/CookieTest.java
+++ b/src/test/java/net/sf/jabref/logic/net/CookieTest.java
@@ -5,7 +5,8 @@ import java.net.URISyntaxException;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 
 public class CookieTest {

--- a/src/test/java/net/sf/jabref/logic/net/CookieTest.java
+++ b/src/test/java/net/sf/jabref/logic/net/CookieTest.java
@@ -1,0 +1,34 @@
+package net.sf.jabref.logic.net;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class CookieTest {
+
+    @Test
+    public void testCookieDashedFormat() throws URISyntaxException {
+        Cookie cookie = new Cookie(new URI("hhh"), "name=TestCookie; expires=Tue, 25-Jul-17 16:43:15 GMT");
+    }
+
+    @Test
+    public void testCookieSpaceFormat() throws URISyntaxException {
+        Cookie cookie = new Cookie(new URI("hhh"), "name=TestCookie; expires=Tue, 25 Jul 17 16:43:15 GMT");
+    }
+
+    @Test
+    public void testHasExpiredFalse() throws URISyntaxException {
+        Cookie cookie = new Cookie(new URI("hhh"), "name=TestCookie; expires=Tue, 25-Jul-45 16:43:15 GMT");
+        assertFalse(cookie.hasExpired());
+    }
+
+    @Test
+    public void testHasExpiredTrue() throws URISyntaxException {
+        Cookie cookie = new Cookie(new URI("hhh"), "name=Nicholas; expires=Sat, 02 May 09 23:38:25 GMT");
+        assertTrue(cookie.hasExpired());
+    }
+}

--- a/src/test/java/net/sf/jabref/logic/net/CookieTest.java
+++ b/src/test/java/net/sf/jabref/logic/net/CookieTest.java
@@ -12,13 +12,18 @@ import static org.junit.Assert.assertTrue;
 public class CookieTest {
 
     @Test
-    public void testCookieDashedFormat() throws URISyntaxException {
+    public void testCookieHyphenFormat() throws URISyntaxException {
+        Cookie cookie = new Cookie(new URI("hhh"), "name=TestCookie; expires=Tue, 25-Jul-2017 16:43:15 GMT");
+    }
+
+    @Test
+    public void testCookieHyphenTwoDigitYearFormat() throws URISyntaxException {
         Cookie cookie = new Cookie(new URI("hhh"), "name=TestCookie; expires=Tue, 25-Jul-17 16:43:15 GMT");
     }
 
     @Test
     public void testCookieSpaceFormat() throws URISyntaxException {
-        Cookie cookie = new Cookie(new URI("hhh"), "name=TestCookie; expires=Tue, 25 Jul 17 16:43:15 GMT");
+        Cookie cookie = new Cookie(new URI("hhh"), "name=TestCookie; expires=Tue, 25 Jul 2017 16:43:15 GMT");
     }
 
     @Test
@@ -29,7 +34,7 @@ public class CookieTest {
 
     @Test
     public void testHasExpiredTrue() throws URISyntaxException {
-        Cookie cookie = new Cookie(new URI("hhh"), "name=Nicholas; expires=Sat, 02 May 09 23:38:25 GMT");
+        Cookie cookie = new Cookie(new URI("hhh"), "name=Nicholas; expires=Sat, 02 May 2009 23:38:25 GMT");
         assertTrue(cookie.hasExpired());
     }
 }


### PR DESCRIPTION
Based on the discussion in another PR (primarily @Siedlerchr as I recall) the date selector now returns the date in ISO format when applicable. Basically, it returns in ISO format for all BibLatex fields related to dates, while e.g. timestamp is still based on the preferences (there is a property `FieldProperties.ISO_DATE` which can be set to enable ISO format).

I also replaced some of the SimpelDateFormat usage with the new thread safe API.

Question: should we still support a user defined date format?

