### PR TITLE
Fixed undo when update time stamp on edit is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed [#1507](https://github.com/JabRef/jabref/issues/1507): Keywords are now separated by the delimiter specified in the preferences
 - Fixed [#1484](https://github.com/JabRef/jabref/issues/1484): HTML export handles some UTF characters wrong
 - Fixed [#1534](https://github.com/JabRef/jabref/issues/1534): "Mark entries imported into database" does not work correctly
+- Fixed issue where field changes were not undoable if the time stamp was updated on editing
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -1126,6 +1126,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
                     ce.addEdit(undoableKeyChange);
                     TimeStamp.doUpdateTimeStamp(entry)
                             .ifPresent(fieldChange -> ce.addEdit(new UndoableFieldChange(fieldChange)));
+                    ce.end();
                     panel.getUndoManager().addEdit(ce);
                 } else {
                     panel.getUndoManager().addEdit(undoableKeyChange);
@@ -1193,8 +1194,10 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
                             TimeStamp.doUpdateTimeStamp(entry)
                                     .ifPresent(fieldChange -> ce.addEdit(new UndoableFieldChange(fieldChange)));
+                            ce.end();
 
                             panel.getUndoManager().addEdit(ce);
+
                         } else {
                             panel.getUndoManager().addEdit(undoableFieldChange);
                         }


### PR DESCRIPTION
Fixed a bug where the field change compound was not ended, leading to that field changes could not be undone when "automatically update time stamp on edit" was enabled.

- [x] Change in CHANGELOG.md described


