### PR TITLE
Added filter to not show selected integrity checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - [#1026](https://github.com/JabRef/jabref/issues/1026) JabRef does no longer delete user comments outside of BibTeX entries and strings
 - [#1249](https://github.com/JabRef/jabref/issues/1249) Date layout formatter added
 - Added ISBN integrity checker
+- Added filter to not show selected integrity checks
 
 ### Fixed
 - Fixed [#1264](https://github.com/JabRef/jabref/issues/1264): S with caron does not render correctly

--- a/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
@@ -1,14 +1,25 @@
 package net.sf.jabref.gui.actions;
 
 import java.awt.event.ActionEvent;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import javax.swing.Action;
+import javax.swing.JButton;
+import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JDialog;
 import javax.swing.JOptionPane;
+import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
+import javax.swing.RowFilter;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.TableModel;
+import javax.swing.table.TableRowSorter;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.gui.JabRefFrame;
@@ -16,6 +27,9 @@ import net.sf.jabref.logic.integrity.IntegrityCheck;
 import net.sf.jabref.logic.integrity.IntegrityMessage;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.preferences.JabRefPreferences;
+
+import com.jgoodies.forms.builder.FormBuilder;
+import com.jgoodies.forms.layout.FormLayout;
 
 public class IntegrityCheckAction extends MnemonicAwareAction {
 
@@ -38,6 +52,8 @@ public class IntegrityCheckAction extends MnemonicAwareAction {
         if (messages.isEmpty()) {
             JOptionPane.showMessageDialog(frame.getCurrentBasePanel(), Localization.lang("No problems found."));
         } else {
+            Set<String> messageVariants = new HashSet<>();
+            Map<String, Boolean> showMessage = new HashMap<>();
             // prepare data model
             Object[][] model = new Object[messages.size()][3];
             int i = 0;
@@ -45,6 +61,8 @@ public class IntegrityCheckAction extends MnemonicAwareAction {
                 model[i][0] = message.getEntry().getCiteKey();
                 model[i][1] = message.getFieldName();
                 model[i][2] = message.getMessage();
+                messageVariants.add(message.getMessage());
+                showMessage.put(message.getMessage(), true);
                 i++;
             }
 
@@ -53,30 +71,62 @@ public class IntegrityCheckAction extends MnemonicAwareAction {
                     new Object[] {Localization.lang("BibTeX key"), Localization.lang("Field"),
                             Localization.lang("Message")});
 
-            table.setAutoCreateRowSorter(true);
+            RowFilter<Object, Object> filter = new RowFilter<Object, Object>() {
+
+                @Override
+                public boolean include(Entry<?, ?> entry) {
+                    return showMessage.get(entry.getStringValue(2));
+                }
+            };
+
+            TableRowSorter<TableModel> sorter = new TableRowSorter<>(table.getModel());
+            sorter.setRowFilter(filter);
+            table.setRowSorter(sorter);
             table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
             table.setDefaultEditor(Object.class, null);
             ListSelectionModel selectionModel = table.getSelectionModel();
 
+
             selectionModel.addListSelectionListener(event -> {
                 if (!event.getValueIsAdjusting()) {
+                    try {
                     String citeKey = (String) model[table.convertRowIndexToModel(table.getSelectedRow())][0];
                     String fieldName = (String) model[table.convertRowIndexToModel(table.getSelectedRow())][1];
                     frame.getCurrentBasePanel().editEntryByKeyAndFocusField(citeKey, fieldName);
+                    } catch (ArrayIndexOutOfBoundsException exception) {
+                        // Ignore -- most likely caused by filtering out the earlier selected row
+                    }
                 }
             });
 
             table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
 
-            table.getColumnModel().getColumn(0).setPreferredWidth(80);
-            table.getColumnModel().getColumn(1).setPreferredWidth(30);
-            table.getColumnModel().getColumn(2).setPreferredWidth(250);
+            table.getColumnModel().getColumn(0).setPreferredWidth(100);
+            table.getColumnModel().getColumn(1).setPreferredWidth(60);
+            table.getColumnModel().getColumn(2).setPreferredWidth(400);
             table.setAutoResizeMode(JTable.AUTO_RESIZE_LAST_COLUMN);
             JScrollPane scrollPane = new JScrollPane(table);
             String title = Localization.lang("%0 problem(s) found", String.valueOf(messages.size()));
             JDialog dialog = new JDialog(frame, title, false);
-            dialog.add(scrollPane);
-            dialog.setSize(600, 500);
+
+            JPopupMenu menu = new JPopupMenu();
+            for (String messageString : showMessage.keySet()) {
+                JCheckBoxMenuItem menuItem = new JCheckBoxMenuItem(messageString, true);
+                menuItem.addActionListener(event -> {
+                    showMessage.put(messageString, menuItem.isSelected());
+                    ((AbstractTableModel) table.getModel()).fireTableDataChanged();
+                });
+                menu.add(menuItem);
+            }
+            JButton menuButton = new JButton(Localization.lang("Filter"));
+            menuButton.addActionListener(entry -> menu.show(menuButton, 0, menuButton.getHeight()));
+            FormBuilder builder = FormBuilder.create()
+                    .layout(new FormLayout("fill:pref:grow", "fill:pref:grow, 2dlu, pref"));
+
+            builder.add(scrollPane).xy(1, 1);
+            builder.add(menuButton).xy(1, 3, "c, b");
+            dialog.add(builder.getPanel());
+            dialog.setSize(600, 600);
 
             // show view
             dialog.setVisible(true);

--- a/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
@@ -2,10 +2,8 @@ package net.sf.jabref.gui.actions;
 
 import java.awt.event.ActionEvent;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.swing.Action;
 import javax.swing.JButton;
@@ -52,7 +50,6 @@ public class IntegrityCheckAction extends MnemonicAwareAction {
         if (messages.isEmpty()) {
             JOptionPane.showMessageDialog(frame.getCurrentBasePanel(), Localization.lang("No problems found."));
         } else {
-            Set<String> messageVariants = new HashSet<>();
             Map<String, Boolean> showMessage = new HashMap<>();
             // prepare data model
             Object[][] model = new Object[messages.size()][3];
@@ -61,7 +58,6 @@ public class IntegrityCheckAction extends MnemonicAwareAction {
                 model[i][0] = message.getEntry().getCiteKey();
                 model[i][1] = message.getFieldName();
                 model[i][2] = message.getMessage();
-                messageVariants.add(message.getMessage());
                 showMessage.put(message.getMessage(), true);
                 i++;
             }
@@ -90,9 +86,9 @@ public class IntegrityCheckAction extends MnemonicAwareAction {
             selectionModel.addListSelectionListener(event -> {
                 if (!event.getValueIsAdjusting()) {
                     try {
-                    String citeKey = (String) model[table.convertRowIndexToModel(table.getSelectedRow())][0];
-                    String fieldName = (String) model[table.convertRowIndexToModel(table.getSelectedRow())][1];
-                    frame.getCurrentBasePanel().editEntryByKeyAndFocusField(citeKey, fieldName);
+                        String citeKey = (String) model[table.convertRowIndexToModel(table.getSelectedRow())][0];
+                        String fieldName = (String) model[table.convertRowIndexToModel(table.getSelectedRow())][1];
+                        frame.getCurrentBasePanel().editEntryByKeyAndFocusField(citeKey, fieldName);
                     } catch (ArrayIndexOutOfBoundsException exception) {
                         // Ignore -- most likely caused by filtering out the earlier selected row
                     }


### PR DESCRIPTION
Added the possibility to dynamically filter out some classes of integrity check messages.
<img width="356" alt="capture5" src="https://cloud.githubusercontent.com/assets/8114497/16875208/7bded892-4a9e-11e6-8799-6419a27b636b.PNG">

- [x] Change in CHANGELOG.md described
- [x] Screenshots added (for bigger UI changes)

