### PR TITLE
Implemented #1345 - cleanup ISSN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Added filter to not show selected integrity checks
 - Enhance the entry customization dialog to give better visual feedback
 - The arXiv fetcher now also supports free-text search queries
+- [#1345](https://github.com/JabRef/jabref/issues/1345) Cleanup ISSN
 
 ### Fixed
 - Fixed [#1264](https://github.com/JabRef/jabref/issues/1264): S with caron does not render correctly

--- a/src/main/java/net/sf/jabref/gui/cleanup/CleanupPresetPanel.java
+++ b/src/main/java/net/sf/jabref/gui/cleanup/CleanupPresetPanel.java
@@ -22,6 +22,7 @@ public class CleanupPresetPanel {
 
     private final BibDatabaseContext databaseContext;
     private JCheckBox cleanUpDOI;
+    private JCheckBox cleanUpISSN;
     private JCheckBox cleanUpMovePDF;
     private JCheckBox cleanUpMakePathsRelative;
     private JCheckBox cleanUpRenamePDF;
@@ -44,6 +45,7 @@ public class CleanupPresetPanel {
     private void init() {
         cleanUpDOI = new JCheckBox(
                 Localization.lang("Move DOIs from note and URL field to DOI field and remove http prefix"));
+        cleanUpISSN = new JCheckBox(Localization.lang("Add possibly missing dash to ISSN"));
         if (databaseContext.getMetaData().getDefaultFileDirectory().isPresent()) {
             cleanUpMovePDF = new JCheckBox(Localization.lang("Move linked files to default file directory %0",
                     databaseContext.getMetaData().getDefaultFileDirectory().get()));
@@ -71,7 +73,7 @@ public class CleanupPresetPanel {
         updateDisplay(cleanupPreset);
 
         FormLayout layout = new FormLayout("left:15dlu, pref:grow",
-                "pref, pref, pref, pref, pref, pref, pref,pref, 190dlu, fill:pref:grow,");
+                "pref, pref, pref, pref, pref, pref, pref,pref, pref,190dlu, fill:pref:grow,");
 
         FormBuilder builder = FormBuilder.create().layout(layout);
         builder.add(cleanUpDOI).xyw(1, 1, 2);
@@ -84,7 +86,8 @@ public class CleanupPresetPanel {
         builder.add(new JLabel(currentPattern)).xy(2, 6);
         builder.add(cleanUpRenamePDFonlyRelativePaths).xy(2, 7);
         builder.add(cleanUpBibLatex).xyw(1, 8, 2);
-        builder.add(cleanUpFormatters).xyw(1, 9, 2);
+        builder.add(cleanUpISSN).xyw(1, 9, 2);
+        builder.add(cleanUpFormatters).xyw(1, 10, 2);
         panel = builder.build();
     }
 
@@ -99,6 +102,7 @@ public class CleanupPresetPanel {
         cleanUpRenamePDFonlyRelativePaths.setEnabled(cleanUpRenamePDF.isSelected());
         cleanUpUpgradeExternalLinks.setSelected(preset.isCleanUpUpgradeExternalLinks());
         cleanUpBibLatex.setSelected(preset.isConvertToBiblatex());
+        cleanUpBibLatex.setSelected(preset.isCleanUpISSN());
         cleanUpFormatters.setValues(preset.getFormatterCleanups());
     }
 
@@ -116,6 +120,9 @@ public class CleanupPresetPanel {
 
         if (cleanUpDOI.isSelected()) {
             activeJobs.add(CleanupPreset.CleanupStep.CLEAN_UP_DOI);
+        }
+        if (cleanUpISSN.isSelected()) {
+            activeJobs.add(CleanupPreset.CleanupStep.CLEAN_UP_ISSN);
         }
         if (cleanUpMakePathsRelative.isSelected()) {
             activeJobs.add(CleanupPreset.CleanupStep.MAKE_PATHS_RELATIVE);

--- a/src/main/java/net/sf/jabref/gui/cleanup/CleanupPresetPanel.java
+++ b/src/main/java/net/sf/jabref/gui/cleanup/CleanupPresetPanel.java
@@ -45,7 +45,7 @@ public class CleanupPresetPanel {
     private void init() {
         cleanUpDOI = new JCheckBox(
                 Localization.lang("Move DOIs from note and URL field to DOI field and remove http prefix"));
-        cleanUpISSN = new JCheckBox(Localization.lang("Add possibly missing dash to ISSN"));
+        cleanUpISSN = new JCheckBox(Localization.lang("Reformat ISSN"));
         if (databaseContext.getMetaData().getDefaultFileDirectory().isPresent()) {
             cleanUpMovePDF = new JCheckBox(Localization.lang("Move linked files to default file directory %0",
                     databaseContext.getMetaData().getDefaultFileDirectory().get()));

--- a/src/main/java/net/sf/jabref/logic/cleanup/CleanupPreset.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/CleanupPreset.java
@@ -52,6 +52,9 @@ public class CleanupPreset {
         if (preferences.getBoolean(JabRefPreferences.CLEANUP_DOI)) {
             activeJobs.add(CleanupStep.CLEAN_UP_DOI);
         }
+        if (preferences.getBoolean(JabRefPreferences.CLEANUP_ISSN)) {
+            activeJobs.add(CleanupStep.CLEAN_UP_ISSN);
+        }
         if (preferences.getBoolean(JabRefPreferences.CLEANUP_MOVE_PDF)) {
             activeJobs.add(CleanupStep.MOVE_PDF);
         }
@@ -88,6 +91,10 @@ public class CleanupPreset {
         return isActive(CleanupStep.CLEAN_UP_DOI);
     }
 
+    public boolean isCleanUpISSN() {
+        return isActive(CleanupStep.CLEAN_UP_ISSN);
+    }
+
     public boolean isFixFileLinks() {
         return isActive(CleanupStep.FIX_FILE_LINKS);
     }
@@ -114,6 +121,7 @@ public class CleanupPreset {
 
     public void storeInPreferences(JabRefPreferences preferences) {
         preferences.putBoolean(JabRefPreferences.CLEANUP_DOI, isActive(CleanupStep.CLEAN_UP_DOI));
+        preferences.putBoolean(JabRefPreferences.CLEANUP_ISSN, isActive(CleanupStep.CLEAN_UP_ISSN));
         preferences.putBoolean(JabRefPreferences.CLEANUP_MOVE_PDF, isActive(CleanupStep.MOVE_PDF));
         preferences.putBoolean(JabRefPreferences.CLEANUP_MAKE_PATHS_RELATIVE, isActive(CleanupStep.MAKE_PATHS_RELATIVE));
         preferences.putBoolean(JabRefPreferences.CLEANUP_RENAME_PDF, isActive(CleanupStep.RENAME_PDF));
@@ -152,6 +160,8 @@ public class CleanupPreset {
          */
         CONVERT_TO_BIBLATEX,
         MOVE_PDF,
-        FIX_FILE_LINKS
+        FIX_FILE_LINKS,
+        CLEAN_UP_ISSN
     }
+
 }

--- a/src/main/java/net/sf/jabref/logic/cleanup/CleanupWorker.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/CleanupWorker.java
@@ -68,6 +68,9 @@ public class CleanupWorker {
         if (preset.isCleanUpDOI()) {
             jobs.add(new DoiCleanup());
         }
+        if (preset.isCleanUpISSN()) {
+            jobs.add(new ISSNCleanup());
+        }
         if (preset.isFixFileLinks()) {
             jobs.add(new FileLinksCleanup());
         }

--- a/src/main/java/net/sf/jabref/logic/cleanup/ISSNCleanup.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/ISSNCleanup.java
@@ -3,28 +3,26 @@ package net.sf.jabref.logic.cleanup;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import net.sf.jabref.logic.util.ISSN;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.model.entry.FieldName;
 
 
 public class ISSNCleanup implements CleanupJob {
 
-    private static final Pattern ISSN_PATTERN_NODASH = Pattern.compile("^(\\d{4})(\\d{3}[\\dxX])$");
     @Override
     public List<FieldChange> cleanup(BibEntry entry) {
-        Optional<String> issn = entry.getFieldOptional("issn");
-        if (!issn.isPresent()) {
+        Optional<String> issnString = entry.getFieldOptional(FieldName.ISSN);
+        if (!issnString.isPresent()) {
             return Collections.emptyList();
         }
 
-        Matcher matcher = ISSN_PATTERN_NODASH.matcher(issn.get());
-        if (matcher.find()) {
-            String result = matcher.replaceFirst("$1-$2");
-            entry.setField("issn", result);
-            FieldChange change = new FieldChange(entry, "issn", issn.get(), result);
+        ISSN issn = new ISSN(issnString.get());
+        if (issn.isCanBeCleaned()) {
+            String newValue = issn.getCleanedISSN();
+            FieldChange change = new FieldChange(entry, FieldName.ISSN, issnString.get(), newValue);
+            entry.setField(FieldName.ISSN, newValue);
             return Collections.singletonList(change);
         }
         return Collections.emptyList();

--- a/src/main/java/net/sf/jabref/logic/cleanup/ISSNCleanup.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/ISSNCleanup.java
@@ -3,6 +3,7 @@ package net.sf.jabref.logic.cleanup;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
 import net.sf.jabref.logic.util.ISSN;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;

--- a/src/main/java/net/sf/jabref/logic/cleanup/ISSNCleanup.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/ISSNCleanup.java
@@ -1,0 +1,33 @@
+package net.sf.jabref.logic.cleanup;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import net.sf.jabref.model.FieldChange;
+import net.sf.jabref.model.entry.BibEntry;
+
+
+public class ISSNCleanup implements CleanupJob {
+
+    private static final Pattern ISSN_PATTERN_NODASH = Pattern.compile("^(\\d{4})(\\d{3}[\\dxX])$");
+    @Override
+    public List<FieldChange> cleanup(BibEntry entry) {
+        Optional<String> issn = entry.getFieldOptional("issn");
+        if (!issn.isPresent()) {
+            return Collections.emptyList();
+        }
+
+        Matcher matcher = ISSN_PATTERN_NODASH.matcher(issn.get());
+        if (matcher.find()) {
+            String result = matcher.replaceFirst("$1-$2");
+            entry.setField("issn", result);
+            FieldChange change = new FieldChange(entry, "issn", issn.get(), result);
+            return Collections.singletonList(change);
+        }
+        return Collections.emptyList();
+    }
+
+}

--- a/src/main/java/net/sf/jabref/logic/integrity/ISSNChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/ISSNChecker.java
@@ -2,6 +2,7 @@ package net.sf.jabref.logic.integrity;
 
 import java.util.Collections;
 import java.util.List;
+
 import net.sf.jabref.logic.integrity.IntegrityCheck.Checker;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.ISSN;

--- a/src/main/java/net/sf/jabref/logic/integrity/ISSNChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/ISSNChecker.java
@@ -2,18 +2,15 @@ package net.sf.jabref.logic.integrity;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import net.sf.jabref.logic.integrity.IntegrityCheck.Checker;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.ISSN;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
 
 
 public class ISSNChecker implements Checker {
 
-    private static final Pattern ISSN_PATTERN = Pattern.compile("^\\d{4}-\\d{3}[\\dxX]$");
 
     @Override
     public List<IntegrityMessage> check(BibEntry entry) {
@@ -22,26 +19,15 @@ public class ISSNChecker implements Checker {
         }
 
         // Check that the ISSN is on the correct form
-        String issn = entry.getFieldOptional(FieldName.ISSN).get().trim();
-        Matcher issnMatcher = ISSN_PATTERN.matcher(issn);
-        if (!issnMatcher.matches()) {
+        String issnString = entry.getFieldOptional(FieldName.ISSN).get().trim();
+
+        ISSN issn = new ISSN(issnString);
+        if (!issn.isValidFormat()) {
             return Collections.singletonList(
                     new IntegrityMessage(Localization.lang("incorrect format"), entry, FieldName.ISSN));
         }
 
-        // Check that the control digit is correct, see e.g. https://en.wikipedia.org/wiki/International_Standard_Serial_Number
-        int sum = 0;
-        for (int pos = 0; pos <= 7; pos++) {
-            char c = issn.charAt(pos);
-            if (pos != 4) {
-                sum += (c - '0') * ((8 - pos) + (pos > 4 ? 1 : 0));
-            }
-        }
-        char control = issn.charAt(8);
-        if ((control == 'x') || (control == 'X')) {
-            control = '9' + 1;
-        }
-        if (((((sum % 11) + control) - '0') == 11) || ((sum % 11) == 0)) {
+        if (issn.isValidChecksum()) {
             return Collections.emptyList();
         } else {
             return Collections

--- a/src/main/java/net/sf/jabref/logic/util/ISBN.java
+++ b/src/main/java/net/sf/jabref/logic/util/ISBN.java
@@ -44,7 +44,7 @@ public class ISBN {
 
     // Check that the control digit is correct, see e.g. https://en.wikipedia.org/wiki/International_Standard_Book_Number#Check_digits
     private boolean isbn10check() {
-        if ((isbnString == null) || (isbnString.length() != 10)) {
+        if (isbnString.length() != 10) {
             return false;
         }
 
@@ -62,7 +62,7 @@ public class ISBN {
 
     // Check that the control digit is correct, see e.g. https://en.wikipedia.org/wiki/International_Standard_Book_Number#Check_digits
     private boolean isbn13check() {
-        if ((isbnString == null) || (isbnString.length() != 13)) {
+        if (isbnString.length() != 13) {
             return false;
         }
 

--- a/src/main/java/net/sf/jabref/logic/util/ISSN.java
+++ b/src/main/java/net/sf/jabref/logic/util/ISSN.java
@@ -19,7 +19,7 @@ public class ISSN {
     public boolean isValidFormat() {
         Matcher issnMatcher = ISSN_PATTERN.matcher(issnString);
         return (issnMatcher.matches());
-        }
+    }
 
     public boolean isCanBeCleaned() {
         Matcher issnNoDashMatcher = ISSN_PATTERN_NODASH.matcher(issnString);

--- a/src/main/java/net/sf/jabref/logic/util/ISSN.java
+++ b/src/main/java/net/sf/jabref/logic/util/ISSN.java
@@ -1,0 +1,52 @@
+package net.sf.jabref.logic.util;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ISSN {
+
+    private static final Pattern ISSN_PATTERN = Pattern.compile("^\\d{4}-\\d{3}[\\dxX]$");
+    private static final Pattern ISSN_PATTERN_NODASH = Pattern.compile("^(\\d{4})(\\d{3}[\\dxX])$");
+
+    private final String issnString;
+
+
+    public ISSN(String issnString) {
+        this.issnString = Objects.requireNonNull(issnString).trim();
+    }
+
+    public boolean isValidFormat() {
+        Matcher issnMatcher = ISSN_PATTERN.matcher(issnString);
+        return (issnMatcher.matches());
+        }
+
+    public boolean isCanBeCleaned() {
+        Matcher issnNoDashMatcher = ISSN_PATTERN_NODASH.matcher(issnString);
+        return (issnNoDashMatcher.matches());
+    }
+
+    public String getCleanedISSN() {
+        Matcher issnNoDashMatcher = ISSN_PATTERN_NODASH.matcher(issnString);
+        if (issnNoDashMatcher.find()) {
+            return issnNoDashMatcher.replaceFirst("$1-$2");
+        }
+        return issnString;
+    }
+
+    public boolean isValidChecksum() {
+        // Check that the control digit is correct, see e.g. https://en.wikipedia.org/wiki/International_Standard_Serial_Number
+        int sum = 0;
+        for (int pos = 0; pos <= 7; pos++) {
+            char c = issnString.charAt(pos);
+            if (pos != 4) {
+                sum += (c - '0') * ((8 - pos) + (pos > 4 ? 1 : 0));
+            }
+        }
+        char control = issnString.charAt(8);
+        if ((control == 'x') || (control == 'X')) {
+            control = '9' + 1;
+        }
+        return (((((sum % 11) + control) - '0') == 11) || ((sum % 11) == 0));
+    }
+}

--- a/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
@@ -344,6 +344,7 @@ public class JabRefPreferences {
 
     public static final String AKS_AUTO_NAMING_PDFS_AGAIN = "AskAutoNamingPDFsAgain";
     public static final String CLEANUP_DOI = "CleanUpDOI";
+    public static final String CLEANUP_ISSN = "CleanUpISSN";
     public static final String CLEANUP_MOVE_PDF = "CleanUpMovePDF";
     public static final String CLEANUP_MAKE_PATHS_RELATIVE = "CleanUpMakePathsRelative";
     public static final String CLEANUP_RENAME_PDF = "CleanUpRenamePDF";
@@ -1386,6 +1387,7 @@ public class JabRefPreferences {
 
     private static void insertCleanupPreset(Map<String, Object> storage, CleanupPreset preset) {
         storage.put(CLEANUP_DOI, preset.isCleanUpDOI());
+        storage.put(CLEANUP_ISSN, preset.isCleanUpISSN());
         storage.put(CLEANUP_MOVE_PDF, preset.isMovePDF());
         storage.put(CLEANUP_MAKE_PATHS_RELATIVE, preset.isMakePathsRelative());
         storage.put(CLEANUP_RENAME_PDF, preset.isRenamePDF());

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -1712,3 +1712,4 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
+Add_possibly_missing_dash_to_ISSN=

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -1712,6 +1712,5 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
-Add_possibly_missing_dash_to_ISSN=
 
 Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -1713,3 +1713,5 @@ Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
 Add_possibly_missing_dash_to_ISSN=
+
+Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2428,3 +2428,6 @@ Execute_command=Befehl_ausführen
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=Hinweis\:_%0_als_Platzhalter_für_den_Speicherort_der_Datenbank_benutzen.
 Executing_command_\"%0\"...=Ausführung_des_Kommandos_\"%0\"...
 Error_occured_while_executing_the_command_\"%0\".=Während_der_Ausführung_des_Befehls_\"%0\"_ist_ein_Fehler_aufgetreten.
+
+
+Add_possibly_missing_dash_to_ISSN=

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2430,4 +2430,5 @@ Executing_command_\"%0\"...=Ausführung_des_Kommandos_\"%0\"...
 Error_occured_while_executing_the_command_\"%0\".=Während_der_Ausführung_des_Befehls_\"%0\"_ist_ein_Fehler_aufgetreten.
 
 
-Add_possibly_missing_dash_to_ISSN=
+
+Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2432,3 +2432,4 @@ Error_occured_while_executing_the_command_\"%0\".=Während_der_Ausführung_des_B
 
 
 Reformat_ISSN=
+

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2279,5 +2279,4 @@ Execute_command=Execute_command
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.
 Executing_command_\"%0\"...=Executing_command_\"%0\"...
 Error_occured_while_executing_the_command_\"%0\".=Error_occured_while_executing_the_command_\"%0\".
-Add_possibly_missing_dash_to_ISSN=Add_possibly_missing_dash_to_ISSN
 Reformat_ISSN=Reformat_ISSN

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2280,3 +2280,4 @@ Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=Note
 Executing_command_\"%0\"...=Executing_command_\"%0\"...
 Error_occured_while_executing_the_command_\"%0\".=Error_occured_while_executing_the_command_\"%0\".
 Add_possibly_missing_dash_to_ISSN=Add_possibly_missing_dash_to_ISSN
+Reformat_ISSN=Reformat_ISSN

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2279,3 +2279,4 @@ Execute_command=Execute_command
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.
 Executing_command_\"%0\"...=Executing_command_\"%0\"...
 Error_occured_while_executing_the_command_\"%0\".=Error_occured_while_executing_the_command_\"%0\".
+Add_possibly_missing_dash_to_ISSN=Add_possibly_missing_dash_to_ISSN

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -1614,3 +1614,4 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
+Add_possibly_missing_dash_to_ISSN=

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -1615,3 +1615,5 @@ Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
 Add_possibly_missing_dash_to_ISSN=
+
+Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -1614,6 +1614,5 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
-Add_possibly_missing_dash_to_ISSN=
 
 Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -2400,6 +2400,5 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
-Add_possibly_missing_dash_to_ISSN=
 
 Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -2401,3 +2401,5 @@ Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
 Add_possibly_missing_dash_to_ISSN=
+
+Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -2400,3 +2400,4 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
+Add_possibly_missing_dash_to_ISSN=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -1658,6 +1658,5 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
-Add_possibly_missing_dash_to_ISSN=
 
 Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -1658,3 +1658,4 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
+Add_possibly_missing_dash_to_ISSN=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -1659,3 +1659,5 @@ Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
 Add_possibly_missing_dash_to_ISSN=
+
+Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -1634,3 +1634,5 @@ Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
 Add_possibly_missing_dash_to_ISSN=
+
+Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -1633,6 +1633,5 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
-Add_possibly_missing_dash_to_ISSN=
 
 Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -1633,3 +1633,4 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
+Add_possibly_missing_dash_to_ISSN=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -1733,3 +1733,4 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
+Add_possibly_missing_dash_to_ISSN=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -1734,3 +1734,5 @@ Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
 Add_possibly_missing_dash_to_ISSN=
+
+Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -1733,6 +1733,5 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
-Add_possibly_missing_dash_to_ISSN=
 
 Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2378,6 +2378,5 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
-Add_possibly_missing_dash_to_ISSN=
 
 Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2378,3 +2378,4 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
+Add_possibly_missing_dash_to_ISSN=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2379,3 +2379,5 @@ Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
 Add_possibly_missing_dash_to_ISSN=
+
+Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -2409,3 +2409,4 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
+Add_possibly_missing_dash_to_ISSN=

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -2409,6 +2409,5 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
-Add_possibly_missing_dash_to_ISSN=
 
 Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -2410,3 +2410,5 @@ Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
 Add_possibly_missing_dash_to_ISSN=
+
+Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -2805,3 +2805,4 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
+Add_possibly_missing_dash_to_ISSN=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -2806,3 +2806,5 @@ Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
 Add_possibly_missing_dash_to_ISSN=
+
+Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -2805,6 +2805,5 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
-Add_possibly_missing_dash_to_ISSN=
 
 Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -1627,3 +1627,4 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
+Add_possibly_missing_dash_to_ISSN=

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -1628,3 +1628,5 @@ Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
 Add_possibly_missing_dash_to_ISSN=
+
+Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -1627,6 +1627,5 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
-Add_possibly_missing_dash_to_ISSN=
 
 Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2377,6 +2377,5 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
-Add_possibly_missing_dash_to_ISSN=
 
 Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2378,3 +2378,5 @@ Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
 Add_possibly_missing_dash_to_ISSN=
+
+Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2377,3 +2377,4 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
+Add_possibly_missing_dash_to_ISSN=

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -1570,3 +1570,4 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
+Add_possibly_missing_dash_to_ISSN=

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -1570,6 +1570,5 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
-Add_possibly_missing_dash_to_ISSN=
 
 Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -1571,3 +1571,5 @@ Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
 Add_possibly_missing_dash_to_ISSN=
+
+Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -1646,6 +1646,5 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
-Add_possibly_missing_dash_to_ISSN=
 
 Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -1646,3 +1646,4 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
+Add_possibly_missing_dash_to_ISSN=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -1647,3 +1647,5 @@ Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
 Add_possibly_missing_dash_to_ISSN=
+
+Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -2401,3 +2401,4 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
+Add_possibly_missing_dash_to_ISSN=

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -2402,3 +2402,5 @@ Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
 Add_possibly_missing_dash_to_ISSN=
+
+Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -2401,6 +2401,5 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
-Add_possibly_missing_dash_to_ISSN=
 
 Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -1640,3 +1640,4 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
+Add_possibly_missing_dash_to_ISSN=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -1640,6 +1640,5 @@ Execute_command=
 Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
-Add_possibly_missing_dash_to_ISSN=
 
 Reformat_ISSN=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -1641,3 +1641,5 @@ Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_database_file.=
 Executing_command_\"%0\"...=
 Error_occured_while_executing_the_command_\"%0\".=
 Add_possibly_missing_dash_to_ISSN=
+
+Reformat_ISSN=

--- a/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
@@ -168,6 +168,36 @@ public class CleanupWorkerTest {
     }
 
     @Test
+    public void cleanupISSNReturnsCorrectISSN() {
+        CleanupPreset preset = new CleanupPreset(CleanupPreset.CleanupStep.CLEAN_UP_ISSN);
+        BibEntry entry = new BibEntry();
+        entry.setField("issn", "0123-4567");
+
+        worker.cleanup(preset, entry);
+        Assert.assertEquals(Optional.of("0123-4567"), entry.getFieldOptional("issn"));
+    }
+
+    @Test
+    public void cleanupISSNAddsMissingDash() {
+        CleanupPreset preset = new CleanupPreset(CleanupPreset.CleanupStep.CLEAN_UP_ISSN);
+        BibEntry entry = new BibEntry();
+        entry.setField("issn", "01234567");
+
+        worker.cleanup(preset, entry);
+        Assert.assertEquals(Optional.of("0123-4567"), entry.getFieldOptional("issn"));
+    }
+
+    @Test
+    public void cleanupISSNJunkStaysJunk() {
+        CleanupPreset preset = new CleanupPreset(CleanupPreset.CleanupStep.CLEAN_UP_ISSN);
+        BibEntry entry = new BibEntry();
+        entry.setField("issn", "Banana");
+
+        worker.cleanup(preset, entry);
+        Assert.assertEquals(Optional.of("Banana"), entry.getFieldOptional("issn"));
+    }
+
+    @Test
     public void cleanupMonthChangesNumberToBibtex() {
         CleanupPreset preset = new CleanupPreset(new FieldFormatterCleanups(true,
                 Collections.singletonList(new FieldFormatterCleanup("month", new NormalizeMonthFormatter()))));

--- a/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;

--- a/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Optional;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
@@ -165,36 +164,6 @@ public class CleanupWorkerTest {
         changeList.add(new FieldChange(entry, "doi", null, "10.1016/0001-8708(80)90035-3"));
         changeList.add(new FieldChange(entry, "url", "http://dx.doi.org/10.1016/0001-8708(80)90035-3", null));
         Assert.assertEquals(changeList, changes);
-    }
-
-    @Test
-    public void cleanupISSNReturnsCorrectISSN() {
-        CleanupPreset preset = new CleanupPreset(CleanupPreset.CleanupStep.CLEAN_UP_ISSN);
-        BibEntry entry = new BibEntry();
-        entry.setField("issn", "0123-4567");
-
-        worker.cleanup(preset, entry);
-        Assert.assertEquals(Optional.of("0123-4567"), entry.getFieldOptional("issn"));
-    }
-
-    @Test
-    public void cleanupISSNAddsMissingDash() {
-        CleanupPreset preset = new CleanupPreset(CleanupPreset.CleanupStep.CLEAN_UP_ISSN);
-        BibEntry entry = new BibEntry();
-        entry.setField("issn", "01234567");
-
-        worker.cleanup(preset, entry);
-        Assert.assertEquals(Optional.of("0123-4567"), entry.getFieldOptional("issn"));
-    }
-
-    @Test
-    public void cleanupISSNJunkStaysJunk() {
-        CleanupPreset preset = new CleanupPreset(CleanupPreset.CleanupStep.CLEAN_UP_ISSN);
-        BibEntry entry = new BibEntry();
-        entry.setField("issn", "Banana");
-
-        worker.cleanup(preset, entry);
-        Assert.assertEquals(Optional.of("Banana"), entry.getFieldOptional("issn"));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/cleanup/ISSNCleanupTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/ISSNCleanupTest.java
@@ -1,0 +1,55 @@
+package net.sf.jabref.logic.cleanup;
+
+import java.util.Optional;
+
+import net.sf.jabref.BibDatabaseContext;
+import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
+import net.sf.jabref.model.entry.BibEntry;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+
+public class ISSNCleanupTest {
+
+    private CleanupWorker worker;
+
+
+    @Before
+    public void setUp() {
+        worker = new CleanupWorker(mock(BibDatabaseContext.class), mock(JournalAbbreviationLoader.class));
+    }
+
+    @Test
+    public void cleanupISSNReturnsCorrectISSN() {
+        CleanupPreset preset = new CleanupPreset(CleanupPreset.CleanupStep.CLEAN_UP_ISSN);
+        BibEntry entry = new BibEntry();
+        entry.setField("issn", "0123-4567");
+
+        worker.cleanup(preset, entry);
+        Assert.assertEquals(Optional.of("0123-4567"), entry.getFieldOptional("issn"));
+    }
+
+    @Test
+    public void cleanupISSNAddsMissingDash() {
+        CleanupPreset preset = new CleanupPreset(CleanupPreset.CleanupStep.CLEAN_UP_ISSN);
+        BibEntry entry = new BibEntry();
+        entry.setField("issn", "01234567");
+
+        worker.cleanup(preset, entry);
+        Assert.assertEquals(Optional.of("0123-4567"), entry.getFieldOptional("issn"));
+    }
+
+    @Test
+    public void cleanupISSNJunkStaysJunk() {
+        CleanupPreset preset = new CleanupPreset(CleanupPreset.CleanupStep.CLEAN_UP_ISSN);
+        BibEntry entry = new BibEntry();
+        entry.setField("issn", "Banana");
+
+        worker.cleanup(preset, entry);
+        Assert.assertEquals(Optional.of("Banana"), entry.getFieldOptional("issn"));
+    }
+
+}

--- a/src/test/java/net/sf/jabref/logic/cleanup/ISSNCleanupTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/ISSNCleanupTest.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -19,7 +20,8 @@ public class ISSNCleanupTest {
 
     @Before
     public void setUp() {
-        worker = new CleanupWorker(mock(BibDatabaseContext.class), mock(JournalAbbreviationLoader.class));
+        worker = new CleanupWorker(mock(BibDatabaseContext.class), mock(JournalAbbreviationLoader.class),
+                JabRefPreferences.getInstance());
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/util/ISBNTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/ISBNTest.java
@@ -1,0 +1,15 @@
+package net.sf.jabref.logic.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class ISBNTest {
+
+    @Test
+    public void test() {
+        fail("Not yet implemented");
+    }
+
+}

--- a/src/test/java/net/sf/jabref/logic/util/ISBNTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/ISBNTest.java
@@ -2,14 +2,76 @@ package net.sf.jabref.logic.util;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 
 public class ISBNTest {
 
+
     @Test
-    public void test() {
-        fail("Not yet implemented");
+    public void testIsValidFormat10Correct() {
+        assertTrue(new ISBN("0-123456-47-9").isValidFormat());
+        assertTrue(new ISBN("0-9752298-0-X").isValidFormat());
+
+    }
+
+    @Test
+    public void testIsValidFormat10Incorrect() {
+        assertFalse(new ISBN("0-12B456-47-9").isValidFormat());
+    }
+
+    @Test
+    public void testIsValidChecksum10Correct() {
+        assertTrue(new ISBN("0-123456-47-9").isValidChecksum());
+        assertTrue(new ISBN("0-9752298-0-X").isValidChecksum());
+        assertTrue(new ISBN("0-9752298-0-x").isValidChecksum());
+    }
+
+    @Test
+    public void testIsValidChecksum10Incorrect() {
+        assertFalse(new ISBN("0-123456-47-8").isValidChecksum());
+    }
+
+    @Test
+    public void testIsValidFormat13Correct() {
+        assertTrue(new ISBN("978-1-56619-909-4").isValidFormat());
+    }
+
+    @Test
+    public void testIsValidFormat13Incorrect() {
+        assertFalse(new ISBN("978-1-56619-9O9-4 ").isValidFormat());
+    }
+
+    @Test
+    public void testIsValidChecksum13Correct() {
+        assertTrue(new ISBN("978-1-56619-909-4 ").isValidChecksum());
+    }
+
+    @Test
+    public void testIsValidChecksum13Incorrect() {
+        assertFalse(new ISBN("978-1-56619-909-5").isValidChecksum());
+    }
+
+    @Test
+    public void testIsIsbn10Correct() {
+        assertTrue(new ISBN("0-123456-47-9").isIsbn10());
+        assertTrue(new ISBN("0-9752298-0-X").isIsbn10());
+    }
+
+    @Test
+    public void testIsIsbn10Incorrect() {
+        assertFalse(new ISBN("978-1-56619-909-4").isIsbn10());
+    }
+
+    @Test
+    public void testIsIsbn13Correct() {
+        assertTrue(new ISBN("978-1-56619-909-4").isIsbn13());
+    }
+
+    @Test
+    public void testIsIsbn13Incorrect() {
+        assertFalse(new ISBN("0-123456-47-9").isIsbn13());
     }
 
 }

--- a/src/test/java/net/sf/jabref/logic/util/ISSNTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/ISSNTest.java
@@ -1,0 +1,64 @@
+package net.sf.jabref.logic.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class ISSNTest {
+
+
+    @Test
+    public void testIsCanBeCleaned() {
+        assertTrue(new ISSN("00279633").isCanBeCleaned());
+    }
+
+    @Test
+    public void testIsCanBeCleanedIncorrectRubbish() {
+        assertFalse(new ISSN("A brown fox").isCanBeCleaned());
+    }
+
+    @Test
+    public void testIsCanBeCleanedDashAlreadyThere() {
+        assertFalse(new ISSN("0027-9633").isCanBeCleaned());
+    }
+
+    @Test
+    public void testGetCleanedISSN() {
+        assertEquals("0027-9633", new ISSN("00279633").getCleanedISSN());
+    }
+
+    @Test
+    public void testGetCleanedISSNDashAlreadyThere() {
+        assertEquals("0027-9633", new ISSN("0027-9633").getCleanedISSN());
+    }
+
+    @Test
+    public void testGetCleanedISSNDashRubbish() {
+        assertEquals("A brown fox", new ISSN("A brown fox").getCleanedISSN());
+    }
+
+    @Test
+    public void testIsValidChecksumCorrect() {
+        assertTrue(new ISSN("0027-9633").isValidChecksum());
+        assertTrue(new ISSN("2434-561X").isValidChecksum());
+        assertTrue(new ISSN("2434-561x").isValidChecksum());
+    }
+
+    @Test
+    public void testIsValidChecksumIncorrect() {
+        assertFalse(new ISSN("0027-9634").isValidChecksum());
+    }
+
+    @Test
+    public void testIsValidFormatCorrect() {
+        assertTrue(new ISSN("0027-963X").isValidFormat());
+    }
+
+    @Test
+    public void testIsValidFormatIncorrect() {
+        assertFalse(new ISSN("00279634").isValidFormat());
+    }
+}


### PR DESCRIPTION
Implemented cleanup that adds a missing dash in the ISSN field if it looks like an ISSN (checksum is not controlled, but eight digits, where the last may be an x).

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
