### PR TITLE
Add fileEncoding property to utf8, to fix failing tests on windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,6 +217,7 @@ javadoc {
 }
 
 test {
+	systemProperty "file.encoding", "utf-8"
     testLogging {
         events "failed"
         exceptionFormat "full"


### PR DESCRIPTION
Add fileEncoding property to utf8, to fix failing tests on windows

When I run ./gradlew check on Windows, all kind of tests fail due to wrong encoding.
This fixes the problem by explicitly setting the property to utf8