### PR TITLE
Move preferences

### DIFF
--- a/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
+++ b/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
@@ -10,7 +10,6 @@ import java.util.stream.Collectors;
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Defaults;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
@@ -28,6 +27,7 @@ import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.database.BibDatabaseModeDetection;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.openjdk.jmh.Main;
 import org.openjdk.jmh.annotations.Benchmark;

--- a/src/main/java/net/sf/jabref/BibDatabaseContext.java
+++ b/src/main/java/net/sf/jabref/BibDatabaseContext.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.database.BibDatabaseModeDetection;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * Represents everything related to a .bib file.

--- a/src/main/java/net/sf/jabref/Globals.java
+++ b/src/main/java/net/sf/jabref/Globals.java
@@ -27,6 +27,7 @@ import net.sf.jabref.logic.error.StreamEavesdropper;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.logic.remote.server.RemoteListenerServerLifecycle;
 import net.sf.jabref.logic.util.BuildInfo;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class Globals {
 

--- a/src/main/java/net/sf/jabref/JabRefGUI.java
+++ b/src/main/java/net/sf/jabref/JabRefGUI.java
@@ -46,6 +46,7 @@ import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.Version;
 import net.sf.jabref.logic.util.VersionPreferences;
 import net.sf.jabref.migrations.PreferencesMigrations;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.looks.plastic.Plastic3DLookAndFeel;
 import com.jgoodies.looks.plastic.theme.SkyBluer;

--- a/src/main/java/net/sf/jabref/JabRefMain.java
+++ b/src/main/java/net/sf/jabref/JabRefMain.java
@@ -31,6 +31,7 @@ import net.sf.jabref.logic.net.ProxyRegisterer;
 import net.sf.jabref.logic.remote.RemotePreferences;
 import net.sf.jabref.logic.remote.client.RemoteListenerClient;
 import net.sf.jabref.model.entry.InternalBibtexFields;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/net/sf/jabref/cli/ArgumentProcessor.java
@@ -17,7 +17,6 @@ import net.sf.jabref.Defaults;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefException;
 import net.sf.jabref.JabRefGUI;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.external.AutoSetLinks;
 import net.sf.jabref.importer.ImportFormatReader;
@@ -45,6 +44,7 @@ import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/collab/ChangeScanner.java
+++ b/src/main/java/net/sf/jabref/collab/ChangeScanner.java
@@ -33,7 +33,6 @@ import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Defaults;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefExecutorService;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.JabRefFrame;
@@ -54,6 +53,7 @@ import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.database.EntrySorter;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexString;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/collab/EntryAddChange.java
+++ b/src/main/java/net/sf/jabref/collab/EntryAddChange.java
@@ -19,7 +19,6 @@ import javax.swing.JComponent;
 import javax.swing.JScrollPane;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.PreviewPanel;
 import net.sf.jabref.gui.undo.NamedCompound;
@@ -28,6 +27,7 @@ import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.IdGenerator;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 class EntryAddChange extends Change {
 

--- a/src/main/java/net/sf/jabref/collab/EntryDeleteChange.java
+++ b/src/main/java/net/sf/jabref/collab/EntryDeleteChange.java
@@ -19,7 +19,6 @@ import javax.swing.JComponent;
 import javax.swing.JScrollPane;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.PreviewPanel;
 import net.sf.jabref.gui.undo.NamedCompound;
@@ -28,6 +27,7 @@ import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.DuplicateCheck;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/external/AutoSetLinks.java
+++ b/src/main/java/net/sf/jabref/external/AutoSetLinks.java
@@ -22,7 +22,6 @@ import javax.swing.SwingUtilities;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.FileListEntry;
 import net.sf.jabref.gui.FileListTableModel;
 import net.sf.jabref.gui.undo.NamedCompound;
@@ -30,6 +29,7 @@ import net.sf.jabref.gui.undo.UndoableFieldChange;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class AutoSetLinks {
 

--- a/src/main/java/net/sf/jabref/external/ExternalFileTypeEntryEditor.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFileTypeEntryEditor.java
@@ -36,11 +36,11 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.FileDialogs;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.OS;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import com.jgoodies.forms.builder.FormBuilder;

--- a/src/main/java/net/sf/jabref/external/ExternalFileTypes.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFileTypes.java
@@ -8,11 +8,11 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.FileField;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public final class ExternalFileTypes {
 

--- a/src/main/java/net/sf/jabref/external/MoveFileAction.java
+++ b/src/main/java/net/sf/jabref/external/MoveFileAction.java
@@ -27,7 +27,6 @@ import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.FileDialogs;
 import net.sf.jabref.gui.FileListEntry;
 import net.sf.jabref.gui.JabRefFrame;
@@ -36,6 +35,7 @@ import net.sf.jabref.gui.fieldeditors.FileListEditor;
 import net.sf.jabref.gui.util.component.CheckBoxMessage;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/external/push/AbstractPushToApplication.java
+++ b/src/main/java/net/sf/jabref/external/push/AbstractPushToApplication.java
@@ -24,13 +24,13 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.actions.BrowseAction;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.FormBuilder;
 import com.jgoodies.forms.layout.FormLayout;

--- a/src/main/java/net/sf/jabref/external/push/PushToApplicationButton.java
+++ b/src/main/java/net/sf/jabref/external/push/PushToApplicationButton.java
@@ -42,13 +42,13 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.actions.MnemonicAwareAction;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.OS;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 

--- a/src/main/java/net/sf/jabref/external/push/PushToEmacs.java
+++ b/src/main/java/net/sf/jabref/external/push/PushToEmacs.java
@@ -27,7 +27,6 @@ import javax.swing.JTextField;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefExecutorService;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.IconTheme;
@@ -35,6 +34,7 @@ import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/external/push/PushToLatexEditor.java
+++ b/src/main/java/net/sf/jabref/external/push/PushToLatexEditor.java
@@ -17,8 +17,8 @@ package net.sf.jabref.external.push;
 
 import javax.swing.Icon;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.IconTheme;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * Class for pushing entries into LatexEditor.

--- a/src/main/java/net/sf/jabref/external/push/PushToLyx.java
+++ b/src/main/java/net/sf/jabref/external/push/PushToLyx.java
@@ -27,13 +27,13 @@ import javax.swing.JPanel;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefExecutorService;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/external/push/PushToTeXstudio.java
+++ b/src/main/java/net/sf/jabref/external/push/PushToTeXstudio.java
@@ -17,8 +17,8 @@ package net.sf.jabref.external.push;
 
 import javax.swing.Icon;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.IconTheme;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * Created by IntelliJ IDEA. User: alver Date: Jan 14, 2006 Time: 4:55:23 PM To change this template use File | Settings

--- a/src/main/java/net/sf/jabref/external/push/PushToTexmaker.java
+++ b/src/main/java/net/sf/jabref/external/push/PushToTexmaker.java
@@ -18,8 +18,8 @@ package net.sf.jabref.external.push;
 
 import javax.swing.Icon;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.IconTheme;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * Class for pushing entries into TexMaker.

--- a/src/main/java/net/sf/jabref/external/push/PushToVim.java
+++ b/src/main/java/net/sf/jabref/external/push/PushToVim.java
@@ -26,13 +26,13 @@ import javax.swing.JTextField;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefExecutorService;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/external/push/PushToWinEdt.java
+++ b/src/main/java/net/sf/jabref/external/push/PushToWinEdt.java
@@ -17,8 +17,8 @@ package net.sf.jabref.external.push;
 
 import javax.swing.Icon;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.IconTheme;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class PushToWinEdt extends AbstractPushToApplication implements PushToApplication {
 

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -55,9 +55,7 @@ import javax.swing.undo.CannotUndoException;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.HighlightMatchingGroupPreferences;
 import net.sf.jabref.JabRefExecutorService;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.collab.ChangeScanner;
 import net.sf.jabref.collab.FileUpdateListener;
 import net.sf.jabref.collab.FileUpdatePanel;
@@ -131,6 +129,8 @@ import net.sf.jabref.model.entry.EntryType;
 import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.model.event.EntryAddedEvent;
 import net.sf.jabref.model.event.EntryChangedEvent;
+import net.sf.jabref.preferences.HighlightMatchingGroupPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.specialfields.Printed;
 import net.sf.jabref.specialfields.Priority;
 import net.sf.jabref.specialfields.Quality;

--- a/src/main/java/net/sf/jabref/gui/DuplicateResolverDialog.java
+++ b/src/main/java/net/sf/jabref/gui/DuplicateResolverDialog.java
@@ -22,11 +22,11 @@ import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.mergeentries.MergeEntries;
 import net.sf.jabref.gui.util.PositionWindow;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 // created by : ?
 //

--- a/src/main/java/net/sf/jabref/gui/EntryMarker.java
+++ b/src/main/java/net/sf/jabref/gui/EntryMarker.java
@@ -21,12 +21,12 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.undo.NamedCompound;
 import net.sf.jabref.gui.undo.UndoableFieldChange;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.InternalBibtexFields;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class EntryMarker {
 

--- a/src/main/java/net/sf/jabref/gui/FileDialogs.java
+++ b/src/main/java/net/sf/jabref/gui/FileDialogs.java
@@ -26,8 +26,8 @@ import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.util.OS;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class FileDialogs {
 

--- a/src/main/java/net/sf/jabref/gui/FileListEntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/FileListEntryEditor.java
@@ -49,7 +49,6 @@ import javax.swing.event.DocumentListener;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.external.ConfirmCloseFileListEntryEditor;
 import net.sf.jabref.external.ExternalFileType;
 import net.sf.jabref.external.ExternalFileTypes;
@@ -58,6 +57,7 @@ import net.sf.jabref.gui.desktop.JabRefDesktop;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import com.jgoodies.forms.builder.FormBuilder;

--- a/src/main/java/net/sf/jabref/gui/FindUnlinkedFilesDialog.java
+++ b/src/main/java/net/sf/jabref/gui/FindUnlinkedFilesDialog.java
@@ -82,7 +82,6 @@ import javax.swing.tree.TreePath;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefExecutorService;
 import net.sf.jabref.JabRefGUI;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.desktop.JabRefDesktop;
 import net.sf.jabref.importer.EntryFromFileCreator;
 import net.sf.jabref.importer.EntryFromFileCreatorManager;
@@ -92,6 +91,7 @@ import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.EntryType;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import org.apache.commons.logging.Log;

--- a/src/main/java/net/sf/jabref/gui/GUIGlobals.java
+++ b/src/main/java/net/sf/jabref/gui/GUIGlobals.java
@@ -23,11 +23,11 @@ import java.util.Map;
 import javax.swing.JLabel;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.external.ExternalFileType;
 import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.gui.keyboard.EmacsKeyBindings;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.specialfields.Printed;
 import net.sf.jabref.specialfields.Priority;
 import net.sf.jabref.specialfields.Quality;

--- a/src/main/java/net/sf/jabref/gui/GenFieldsCustomizer.java
+++ b/src/main/java/net/sf/jabref/gui/GenFieldsCustomizer.java
@@ -36,13 +36,13 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.entryeditor.EntryEditorTabList;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.gui.help.HelpFile;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.labelpattern.LabelPatternUtil;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import com.jgoodies.forms.layout.Sizes;

--- a/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
@@ -68,7 +68,6 @@ import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Defaults;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefExecutorService;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.external.DownloadExternalFile;
 import net.sf.jabref.external.ExternalFileMenuItem;
@@ -103,6 +102,7 @@ import net.sf.jabref.model.entry.EntryUtil;
 import net.sf.jabref.model.entry.FieldProperties;
 import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.model.entry.InternalBibtexFields;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import ca.odell.glazedlists.BasicEventList;
 import ca.odell.glazedlists.EventList;

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -71,9 +71,7 @@ import javax.swing.WindowConstants;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.HighlightMatchingGroupPreferences;
 import net.sf.jabref.JabRefExecutorService;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.external.ExternalFileTypeEditor;
 import net.sf.jabref.external.push.PushToApplicationButton;
 import net.sf.jabref.external.push.PushToApplications;
@@ -130,6 +128,8 @@ import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.EntryType;
+import net.sf.jabref.preferences.HighlightMatchingGroupPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.specialfields.Printed;
 import net.sf.jabref.specialfields.Priority;
 import net.sf.jabref.specialfields.Quality;

--- a/src/main/java/net/sf/jabref/gui/PreambleEditor.java
+++ b/src/main/java/net/sf/jabref/gui/PreambleEditor.java
@@ -35,7 +35,6 @@ import javax.swing.LayoutFocusTraversalPolicy;
 import javax.swing.text.JTextComponent;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.actions.Actions;
 import net.sf.jabref.gui.fieldeditors.FieldEditor;
 import net.sf.jabref.gui.fieldeditors.TextArea;
@@ -44,6 +43,7 @@ import net.sf.jabref.gui.undo.UndoablePreambleChange;
 import net.sf.jabref.gui.util.PositionWindow;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibDatabase;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 class PreambleEditor extends JDialog {
     // A reference to the entry this object works on.

--- a/src/main/java/net/sf/jabref/gui/PreviewPanel.java
+++ b/src/main/java/net/sf/jabref/gui/PreviewPanel.java
@@ -49,7 +49,6 @@ import javax.swing.event.HyperlinkEvent;
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefExecutorService;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.desktop.JabRefDesktop;
 import net.sf.jabref.gui.fieldeditors.PreviewPanelTransferHandler;
 import net.sf.jabref.gui.keyboard.KeyBinding;
@@ -60,6 +59,7 @@ import net.sf.jabref.logic.layout.LayoutHelper;
 import net.sf.jabref.logic.search.SearchQueryHighlightListener;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.event.FieldChangedEvent;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.google.common.eventbus.Subscribe;
 import org.apache.commons.logging.Log;

--- a/src/main/java/net/sf/jabref/gui/SidePaneManager.java
+++ b/src/main/java/net/sf/jabref/gui/SidePaneManager.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 import javax.swing.SwingUtilities;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/gui/StringDialog.java
+++ b/src/main/java/net/sf/jabref/gui/StringDialog.java
@@ -46,7 +46,6 @@ import javax.swing.table.TableColumnModel;
 import javax.swing.undo.CompoundEdit;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.actions.Actions;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.gui.help.HelpFile;
@@ -62,6 +61,7 @@ import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.KeyCollisionException;
 import net.sf.jabref.model.entry.BibtexString;
 import net.sf.jabref.model.entry.IdGenerator;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 class StringDialog extends JDialog {
 

--- a/src/main/java/net/sf/jabref/gui/actions/CleanupAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/CleanupAction.java
@@ -22,7 +22,6 @@ import javax.swing.JOptionPane;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.cleanup.CleanupPresetPanel;
@@ -35,6 +34,7 @@ import net.sf.jabref.logic.cleanup.CleanupWorker;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class CleanupAction extends AbstractWorker {
 

--- a/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
@@ -11,11 +11,11 @@ import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.logic.integrity.IntegrityCheck;
 import net.sf.jabref.logic.integrity.IntegrityMessage;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class IntegrityCheckAction extends MnemonicAwareAction {
 

--- a/src/main/java/net/sf/jabref/gui/actions/NewSubDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/NewSubDatabaseAction.java
@@ -7,13 +7,13 @@ import javax.swing.Action;
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Defaults;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.auximport.FromAuxDialog;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibDatabaseMode;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * The action concerned with generate a new (sub-)database from latex aux file.

--- a/src/main/java/net/sf/jabref/gui/cleanup/CleanupPresetPanel.java
+++ b/src/main/java/net/sf/jabref/gui/cleanup/CleanupPresetPanel.java
@@ -10,9 +10,9 @@ import javax.swing.JPanel;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.cleanup.CleanupPreset;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.FormBuilder;
 import com.jgoodies.forms.layout.FormLayout;

--- a/src/main/java/net/sf/jabref/gui/desktop/JabRefDesktop.java
+++ b/src/main/java/net/sf/jabref/gui/desktop/JabRefDesktop.java
@@ -28,7 +28,6 @@ import javax.swing.JOptionPane;
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefGUI;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.external.ExternalFileType;
 import net.sf.jabref.external.ExternalFileTypeEntryEditor;
 import net.sf.jabref.external.ExternalFileTypes;
@@ -50,6 +49,7 @@ import net.sf.jabref.logic.util.DOI;
 import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -64,7 +64,6 @@ import javax.swing.event.ChangeListener;
 import javax.swing.text.JTextComponent;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.external.WriteXMPEntryEditorAction;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.EntryContainer;
@@ -110,6 +109,7 @@ import net.sf.jabref.model.entry.EntryType;
 import net.sf.jabref.model.entry.FieldProperties;
 import net.sf.jabref.model.entry.InternalBibtexFields;
 import net.sf.jabref.model.event.FieldChangedEvent;
+import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.specialfields.SpecialFieldUpdateListener;
 
 import com.google.common.eventbus.Subscribe;

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditorTabList.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditorTabList.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * Class for holding the information about customizable entry editor tabs.

--- a/src/main/java/net/sf/jabref/gui/entryeditor/FieldExtraComponents.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/FieldExtraComponents.java
@@ -36,7 +36,6 @@ import javax.swing.event.DocumentListener;
 import javax.swing.text.JTextComponent;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.FieldContentSelector;
 import net.sf.jabref.gui.JabRefFrame;
@@ -56,6 +55,7 @@ import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldProperties;
 import net.sf.jabref.model.entry.InternalBibtexFields;
 import net.sf.jabref.model.entry.MonthUtil;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class FieldExtraComponents {
 

--- a/src/main/java/net/sf/jabref/gui/exporter/AutoSaveManager.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/AutoSaveManager.java
@@ -20,7 +20,6 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.logic.exporter.BibDatabaseWriter;
@@ -29,6 +28,7 @@ import net.sf.jabref.logic.exporter.FileSaveSession;
 import net.sf.jabref.logic.exporter.SaveException;
 import net.sf.jabref.logic.exporter.SavePreferences;
 import net.sf.jabref.logic.exporter.SaveSession;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/gui/exporter/CustomExportDialog.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/CustomExportDialog.java
@@ -37,11 +37,11 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.FileDialogs;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 

--- a/src/main/java/net/sf/jabref/gui/exporter/ExportAction.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/ExportAction.java
@@ -14,7 +14,6 @@ import javax.swing.JOptionPane;
 import javax.swing.filechooser.FileFilter;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.actions.MnemonicAwareAction;
 import net.sf.jabref.gui.worker.AbstractWorker;
@@ -22,6 +21,7 @@ import net.sf.jabref.logic.exporter.ExportFormats;
 import net.sf.jabref.logic.exporter.IExportFormat;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/SaveDatabaseAction.java
@@ -29,7 +29,6 @@ import javax.swing.SwingUtilities;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefExecutorService;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.collab.ChangeScanner;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.FileDialogs;
@@ -45,6 +44,7 @@ import net.sf.jabref.logic.exporter.SaveSession;
 import net.sf.jabref.logic.l10n.Encodings;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.io.FileBasedLock;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.FormBuilder;
 import com.jgoodies.forms.layout.FormLayout;

--- a/src/main/java/net/sf/jabref/gui/fieldeditors/JTextAreaWithHighlighting.java
+++ b/src/main/java/net/sf/jabref/gui/fieldeditors/JTextAreaWithHighlighting.java
@@ -33,10 +33,10 @@ import javax.swing.undo.CannotUndoException;
 import javax.swing.undo.UndoManager;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.actions.Actions;
 import net.sf.jabref.gui.actions.PasteAction;
 import net.sf.jabref.logic.search.SearchQueryHighlightListener;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/gui/groups/GroupDialog.java
+++ b/src/main/java/net/sf/jabref/gui/groups/GroupDialog.java
@@ -43,7 +43,6 @@ import javax.swing.SwingConstants;
 import javax.swing.event.CaretListener;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.FieldContentSelector;
 import net.sf.jabref.gui.JabRefFrame;
@@ -58,6 +57,7 @@ import net.sf.jabref.logic.groups.SearchGroup;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.search.SearchQuery;
 import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import com.jgoodies.forms.builder.DefaultFormBuilder;

--- a/src/main/java/net/sf/jabref/gui/groups/GroupSelector.java
+++ b/src/main/java/net/sf/jabref/gui/groups/GroupSelector.java
@@ -58,7 +58,6 @@ import javax.swing.undo.AbstractUndoableEdit;
 import javax.swing.undo.CompoundEdit;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.IconTheme;
@@ -81,6 +80,7 @@ import net.sf.jabref.logic.search.matchers.MatcherSet;
 import net.sf.jabref.logic.search.matchers.MatcherSets;
 import net.sf.jabref.logic.search.matchers.NotMatcher;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/gui/groups/GroupTreeNodeViewModel.java
+++ b/src/main/java/net/sf/jabref/gui/groups/GroupTreeNodeViewModel.java
@@ -34,7 +34,6 @@ import javax.swing.undo.UndoManager;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefGUI;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.undo.CountingUndoManager;
@@ -44,6 +43,7 @@ import net.sf.jabref.logic.groups.EntriesGroupChange;
 import net.sf.jabref.logic.groups.GroupTreeNode;
 import net.sf.jabref.logic.groups.MoveGroupChange;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class GroupTreeNodeViewModel implements Transferable, TreeNode {
 

--- a/src/main/java/net/sf/jabref/gui/groups/GroupsTree.java
+++ b/src/main/java/net/sf/jabref/gui/groups/GroupsTree.java
@@ -50,12 +50,12 @@ import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.groups.AbstractGroup;
 import net.sf.jabref.logic.groups.EntriesGroupChange;
 import net.sf.jabref.logic.groups.GroupTreeNode;
 import net.sf.jabref.logic.groups.MoveGroupChange;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class GroupsTree extends JTree implements DragSourceListener,
         DropTargetListener, DragGestureListener {

--- a/src/main/java/net/sf/jabref/gui/help/HelpAction.java
+++ b/src/main/java/net/sf/jabref/gui/help/HelpAction.java
@@ -24,11 +24,11 @@ import javax.swing.JButton;
 import javax.swing.KeyStroke;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.actions.MnemonicAwareAction;
 import net.sf.jabref.gui.desktop.JabRefDesktop;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
+++ b/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
@@ -57,7 +57,6 @@ import javax.swing.JTextField;
 import javax.swing.table.AbstractTableModel;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.FileDialogs;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.JabRefFrame;
@@ -68,6 +67,7 @@ import net.sf.jabref.gui.net.MonitoredURLDownload;
 import net.sf.jabref.logic.journals.Abbreviation;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import com.jgoodies.forms.builder.ButtonStackBuilder;

--- a/src/main/java/net/sf/jabref/gui/keyboard/EmacsKeyBindings.java
+++ b/src/main/java/net/sf/jabref/gui/keyboard/EmacsKeyBindings.java
@@ -62,7 +62,7 @@ import javax.swing.text.Keymap;
 import javax.swing.text.TextAction;
 import javax.swing.text.Utilities;
 
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingPreferences.java
+++ b/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingPreferences.java
@@ -12,8 +12,8 @@ import java.util.stream.Collectors;
 
 import javax.swing.KeyStroke;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.util.OS;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/gui/labelpattern/LabelPatternPanel.java
+++ b/src/main/java/net/sf/jabref/gui/labelpattern/LabelPatternPanel.java
@@ -32,7 +32,6 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.help.HelpAction;
@@ -44,6 +43,7 @@ import net.sf.jabref.logic.labelpattern.GlobalLabelPattern;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.EntryType;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class LabelPatternPanel extends JPanel {
 

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
@@ -39,7 +39,6 @@ import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumnModel;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.EntryMarker;
 import net.sf.jabref.gui.GUIGlobals;
@@ -59,6 +58,7 @@ import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexSingleField;
 import net.sf.jabref.model.entry.EntryType;
+import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.specialfields.SpecialFieldsUtils;
 
 import ca.odell.glazedlists.EventList;

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableFormat.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableFormat.java
@@ -23,10 +23,10 @@ import java.util.List;
 import javax.swing.JLabel;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.specialfields.SpecialFieldsUtils;
 
 import ca.odell.glazedlists.gui.TableFormat;

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableNameFormatter.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableNameFormatter.java
@@ -1,8 +1,8 @@
 package net.sf.jabref.gui.maintable;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.entry.AuthorList;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class MainTableNameFormatter {
 

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableSelectionListener.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableSelectionListener.java
@@ -34,7 +34,6 @@ import javax.swing.Timer;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefExecutorService;
 import net.sf.jabref.JabRefGUI;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.external.ExternalFileMenuItem;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.BasePanelMode;
@@ -50,6 +49,7 @@ import net.sf.jabref.gui.util.FocusRequester;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.specialfields.SpecialFieldValue;
 import net.sf.jabref.specialfields.SpecialFieldsUtils;
 

--- a/src/main/java/net/sf/jabref/gui/maintable/PersistenceTableColumnListener.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/PersistenceTableColumnListener.java
@@ -24,8 +24,8 @@ import javax.swing.event.TableColumnModelEvent;
 import javax.swing.event.TableColumnModelListener;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.entry.InternalBibtexFields;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * Listens for TableColumnModelEvents to keep track of changes made to the

--- a/src/main/java/net/sf/jabref/gui/menus/FileHistoryMenu.java
+++ b/src/main/java/net/sf/jabref/gui/menus/FileHistoryMenu.java
@@ -24,10 +24,10 @@ import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 
 import net.sf.jabref.JabRefExecutorService;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.io.FileHistory;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class FileHistoryMenu extends JMenu implements ActionListener {
 

--- a/src/main/java/net/sf/jabref/gui/menus/RightClickMenu.java
+++ b/src/main/java/net/sf/jabref/gui/menus/RightClickMenu.java
@@ -29,7 +29,6 @@ import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.EntryMarker;
 import net.sf.jabref.gui.FileListTableModel;
@@ -41,6 +40,7 @@ import net.sf.jabref.logic.groups.GroupTreeNode;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.InternalBibtexFields;
+import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.specialfields.Printed;
 import net.sf.jabref.specialfields.Priority;
 import net.sf.jabref.specialfields.Quality;

--- a/src/main/java/net/sf/jabref/gui/mergeentries/MergeEntries.java
+++ b/src/main/java/net/sf/jabref/gui/mergeentries/MergeEntries.java
@@ -43,7 +43,6 @@ import javax.swing.text.html.HTMLEditorKit;
 import javax.swing.text.html.StyleSheet;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.PreviewPanel;
 import net.sf.jabref.logic.bibtex.BibEntryWriter;
 import net.sf.jabref.logic.bibtex.LatexFieldFormatter;
@@ -53,6 +52,7 @@ import net.sf.jabref.logic.util.strings.DiffHighlighting;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.InternalBibtexFields;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.layout.CellConstraints;
 import com.jgoodies.forms.layout.ColumnSpec;

--- a/src/main/java/net/sf/jabref/gui/mergeentries/MergeEntriesDialog.java
+++ b/src/main/java/net/sf/jabref/gui/mergeentries/MergeEntriesDialog.java
@@ -22,7 +22,6 @@ import javax.swing.JDialog;
 import javax.swing.JOptionPane;
 import javax.swing.JSeparator;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.undo.NamedCompound;
 import net.sf.jabref.gui.undo.UndoableInsertEntry;
@@ -30,6 +29,7 @@ import net.sf.jabref.gui.undo.UndoableRemoveEntry;
 import net.sf.jabref.gui.util.PositionWindow;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import com.jgoodies.forms.layout.CellConstraints;

--- a/src/main/java/net/sf/jabref/gui/mergeentries/MergeEntryDOIDialog.java
+++ b/src/main/java/net/sf/jabref/gui/mergeentries/MergeEntryDOIDialog.java
@@ -24,7 +24,6 @@ import javax.swing.JDialog;
 import javax.swing.JOptionPane;
 import javax.swing.JSeparator;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.undo.NamedCompound;
 import net.sf.jabref.gui.undo.UndoableChangeType;
@@ -34,6 +33,7 @@ import net.sf.jabref.importer.fetcher.DOItoBibTeXFetcher;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.InternalBibtexFields;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import com.jgoodies.forms.layout.CellConstraints;

--- a/src/main/java/net/sf/jabref/gui/openoffice/StyleSelectDialog.java
+++ b/src/main/java/net/sf/jabref/gui/openoffice/StyleSelectDialog.java
@@ -49,7 +49,6 @@ import javax.swing.table.TableColumnModel;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.external.ExternalFileType;
 import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.external.UnknownExternalFileType;
@@ -66,6 +65,7 @@ import net.sf.jabref.logic.openoffice.OpenOfficePreferences;
 import net.sf.jabref.logic.openoffice.StyleLoader;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.IdGenerator;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import ca.odell.glazedlists.BasicEventList;
 import ca.odell.glazedlists.EventList;

--- a/src/main/java/net/sf/jabref/gui/plaintextimport/TextInputDialog.java
+++ b/src/main/java/net/sf/jabref/gui/plaintextimport/TextInputDialog.java
@@ -110,7 +110,6 @@ import javax.swing.text.StyleContext;
 import javax.swing.text.StyledDocument;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.ClipBoardManager;
 import net.sf.jabref.gui.EntryMarker;
 import net.sf.jabref.gui.FileDialogs;
@@ -131,6 +130,7 @@ import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.EntryType;
 import net.sf.jabref.model.entry.FieldProperties;
 import net.sf.jabref.model.entry.InternalBibtexFields;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import org.apache.commons.logging.Log;

--- a/src/main/java/net/sf/jabref/gui/preftabs/AdvancedTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/AdvancedTab.java
@@ -26,13 +26,13 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.gui.help.HelpFile;
 import net.sf.jabref.gui.remote.JabRefMessageHandler;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.remote.RemotePreferences;
 import net.sf.jabref.logic.remote.RemoteUtil;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;

--- a/src/main/java/net/sf/jabref/gui/preftabs/AppearancePrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/AppearancePrefsTab.java
@@ -32,10 +32,10 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.UIManager;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.OS;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;

--- a/src/main/java/net/sf/jabref/gui/preftabs/ColorSetupPanel.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/ColorSetupPanel.java
@@ -32,8 +32,8 @@ import javax.swing.JColorChooser;
 import javax.swing.JPanel;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.FormBuilder;
 import com.jgoodies.forms.layout.FormLayout;

--- a/src/main/java/net/sf/jabref/gui/preftabs/EntryEditorPrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/EntryEditorPrefsTab.java
@@ -28,13 +28,13 @@ import javax.swing.JSpinner;
 import javax.swing.JTextField;
 import javax.swing.SpinnerNumberModel;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.keyboard.EmacsKeyBindings;
 import net.sf.jabref.logic.autocompleter.AutoCompleteFirstNameMode;
 import net.sf.jabref.logic.autocompleter.AutoCompletePreferences;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.CellConstraints;

--- a/src/main/java/net/sf/jabref/gui/preftabs/ExternalTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/ExternalTab.java
@@ -25,13 +25,13 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.external.ExternalFileTypeEditor;
 import net.sf.jabref.external.push.PushToApplication;
 import net.sf.jabref.external.push.PushToApplicationButton;
 import net.sf.jabref.external.push.PushToApplications;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;

--- a/src/main/java/net/sf/jabref/gui/preftabs/FileSortTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/FileSortTab.java
@@ -24,10 +24,10 @@ import javax.swing.ButtonGroup;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.SaveOrderConfigDisplay;
 import net.sf.jabref.logic.config.SaveOrderConfig;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;

--- a/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
@@ -32,12 +32,12 @@ import javax.swing.JTextField;
 import javax.swing.SpinnerNumberModel;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.actions.BrowseAction;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.gui.help.HelpFile;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;

--- a/src/main/java/net/sf/jabref/gui/preftabs/GeneralTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/GeneralTab.java
@@ -33,12 +33,12 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.gui.help.HelpFile;
 import net.sf.jabref.logic.l10n.Encodings;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibDatabaseMode;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;

--- a/src/main/java/net/sf/jabref/gui/preftabs/GroupsPrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/GroupsPrefsTab.java
@@ -25,8 +25,8 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;

--- a/src/main/java/net/sf/jabref/gui/preftabs/ImportSettingsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/ImportSettingsTab.java
@@ -29,9 +29,9 @@ import javax.swing.JPopupMenu;
 import javax.swing.JRadioButton;
 import javax.swing.JTextField;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.pdfimport.ImportDialog;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;

--- a/src/main/java/net/sf/jabref/gui/preftabs/LabelPatternPrefTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/LabelPatternPrefTab.java
@@ -25,12 +25,12 @@ import javax.swing.JRadioButton;
 import javax.swing.JTextField;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.labelpattern.LabelPatternPanel;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.labelpattern.GlobalLabelPattern;
 import net.sf.jabref.logic.labelpattern.LabelPatternUtil;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;

--- a/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
@@ -35,13 +35,13 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.OSXCompatibleToolbar;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.gui.help.HelpFile;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.layout.format.NameFormatter;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;

--- a/src/main/java/net/sf/jabref/gui/preftabs/NetworkTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/NetworkTab.java
@@ -26,10 +26,10 @@ import javax.swing.JPanel;
 import javax.swing.JPasswordField;
 import javax.swing.JTextField;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.net.ProxyPreferences;
 import net.sf.jabref.logic.net.ProxyRegisterer;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.FormBuilder;
 import com.jgoodies.forms.layout.FormLayout;

--- a/src/main/java/net/sf/jabref/gui/preftabs/PreferencesDialog.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/PreferencesDialog.java
@@ -38,9 +38,6 @@ import javax.swing.ListSelectionModel;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefException;
-import net.sf.jabref.JabRefPreferences;
-import net.sf.jabref.JabRefPreferencesFilter;
-import net.sf.jabref.JabRefPreferencesFilterDialog;
 import net.sf.jabref.gui.FileDialogs;
 import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.gui.JabRefFrame;
@@ -48,6 +45,9 @@ import net.sf.jabref.gui.keyboard.KeyBinder;
 import net.sf.jabref.gui.maintable.MainTable;
 import net.sf.jabref.logic.exporter.ExportFormats;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferencesFilter;
+import net.sf.jabref.preferences.JabRefPreferencesFilterDialog;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import org.apache.commons.logging.Log;

--- a/src/main/java/net/sf/jabref/gui/preftabs/PreferencesDialog.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/PreferencesDialog.java
@@ -47,7 +47,6 @@ import net.sf.jabref.logic.exporter.ExportFormats;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.preferences.JabRefPreferencesFilter;
-import net.sf.jabref.preferences.JabRefPreferencesFilterDialog;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import org.apache.commons.logging.Log;
@@ -208,7 +207,7 @@ public class PreferencesDialog extends JDialog {
         });
 
         showPreferences.addActionListener(
-                e -> new JabRefPreferencesFilterDialog(new JabRefPreferencesFilter(Globals.prefs), frame)
+                e -> new PreferencesFilterDialog(new JabRefPreferencesFilter(Globals.prefs), frame)
                         .setVisible(true));
         resetPreferences.addActionListener(e -> {
             if (JOptionPane.showConfirmDialog(PreferencesDialog.this,

--- a/src/main/java/net/sf/jabref/gui/preftabs/PreferencesFilterDialog.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/PreferencesFilterDialog.java
@@ -1,4 +1,4 @@
-package net.sf.jabref.preferences;
+package net.sf.jabref.gui.preftabs;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
@@ -16,8 +16,9 @@ import javax.swing.table.AbstractTableModel;
 
 import net.sf.jabref.gui.WrapLayout;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferencesFilter;
 
-public class JabRefPreferencesFilterDialog extends JDialog {
+class PreferencesFilterDialog extends JDialog {
 
     private final JabRefPreferencesFilter preferencesFilter;
 
@@ -25,7 +26,7 @@ public class JabRefPreferencesFilterDialog extends JDialog {
     private final JCheckBox showOnlyDeviatingPreferenceOptions;
     private final JLabel count;
 
-    public JabRefPreferencesFilterDialog(JabRefPreferencesFilter preferencesFilter, JFrame frame) {
+    public PreferencesFilterDialog(JabRefPreferencesFilter preferencesFilter, JFrame frame) {
         super(frame, true); // is modal
 
         this.preferencesFilter = Objects.requireNonNull(preferencesFilter);

--- a/src/main/java/net/sf/jabref/gui/preftabs/PreviewPrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/PreviewPrefsTab.java
@@ -29,11 +29,11 @@ import javax.swing.JSeparator;
 import javax.swing.JTextArea;
 import javax.swing.SwingConstants;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.PreviewPanel;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.IdGenerator;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
@@ -45,7 +45,6 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.external.ExternalFileType;
 import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.gui.BasePanel;
@@ -57,6 +56,7 @@ import net.sf.jabref.gui.help.HelpFile;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibtexSingleField;
 import net.sf.jabref.model.entry.InternalBibtexFields;
+import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.specialfields.SpecialFieldsUtils;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;

--- a/src/main/java/net/sf/jabref/gui/preftabs/TablePrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/TablePrefsTab.java
@@ -31,10 +31,10 @@ import javax.swing.JRadioButton;
 import javax.swing.JTable;
 import javax.swing.JTextField;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.InternalBibtexFields;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;

--- a/src/main/java/net/sf/jabref/gui/preftabs/XmpPrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/XmpPrefsTab.java
@@ -37,10 +37,10 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.OSXCompatibleToolbar;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;

--- a/src/main/java/net/sf/jabref/gui/renderer/IncompleteRenderer.java
+++ b/src/main/java/net/sf/jabref/gui/renderer/IncompleteRenderer.java
@@ -1,8 +1,8 @@
 package net.sf.jabref.gui.renderer;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class IncompleteRenderer extends GeneralRenderer {
 

--- a/src/main/java/net/sf/jabref/gui/search/SearchBar.java
+++ b/src/main/java/net/sf/jabref/gui/search/SearchBar.java
@@ -33,7 +33,6 @@ import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.OSXCompatibleToolbar;
@@ -50,6 +49,7 @@ import net.sf.jabref.logic.search.SearchQuery;
 import net.sf.jabref.logic.search.SearchQueryHighlightObservable;
 import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/gui/search/SearchResultsDialog.java
+++ b/src/main/java/net/sf/jabref/gui/search/SearchResultsDialog.java
@@ -47,7 +47,6 @@ import javax.swing.SwingUtilities;
 import javax.swing.table.TableColumnModel;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.external.ExternalFileMenuItem;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.FileListEntry;
@@ -69,6 +68,7 @@ import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.EntryUtil;
 import net.sf.jabref.model.entry.FieldProperties;
 import net.sf.jabref.model.entry.InternalBibtexFields;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import ca.odell.glazedlists.BasicEventList;
 import ca.odell.glazedlists.EventList;

--- a/src/main/java/net/sf/jabref/gui/worker/MarkEntriesAction.java
+++ b/src/main/java/net/sf/jabref/gui/worker/MarkEntriesAction.java
@@ -22,13 +22,13 @@ import java.util.List;
 import javax.swing.JMenuItem;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.EntryMarker;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.undo.NamedCompound;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/gui/worker/SendAsEMailAction.java
+++ b/src/main/java/net/sf/jabref/gui/worker/SendAsEMailAction.java
@@ -24,7 +24,6 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.desktop.JabRefDesktop;
@@ -33,6 +32,7 @@ import net.sf.jabref.logic.bibtex.LatexFieldFormatter;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/importer/AppendDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/AppendDatabaseAction.java
@@ -25,7 +25,6 @@ import javax.swing.JOptionPane;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefExecutorService;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.FileDialogs;
@@ -47,6 +46,7 @@ import net.sf.jabref.model.database.KeyCollisionException;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexString;
 import net.sf.jabref.model.entry.IdGenerator;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/importer/AutosaveStartupPrompter.java
+++ b/src/main/java/net/sf/jabref/importer/AutosaveStartupPrompter.java
@@ -25,12 +25,12 @@ import javax.swing.JOptionPane;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.ParserResultWarningDialog;
 import net.sf.jabref.gui.exporter.AutoSaveManager;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * Runnable task that prompts the user for what to do about files loaded at startup,

--- a/src/main/java/net/sf/jabref/importer/CheckForNewEntryTypesAction.java
+++ b/src/main/java/net/sf/jabref/importer/CheckForNewEntryTypesAction.java
@@ -23,13 +23,13 @@ import javax.swing.JOptionPane;
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Defaults;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.CustomEntryType;
 import net.sf.jabref.model.entry.EntryType;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * This action checks whether any new custom entry types were loaded from this

--- a/src/main/java/net/sf/jabref/importer/CustomImportList.java
+++ b/src/main/java/net/sf/jabref/importer/CustomImportList.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.TreeSet;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/importer/ImportCustomizationDialog.java
+++ b/src/main/java/net/sf/jabref/importer/ImportCustomizationDialog.java
@@ -44,7 +44,6 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumnModel;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.FileDialogs;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.help.HelpAction;
@@ -53,6 +52,7 @@ import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.gui.util.FocusRequester;
 import net.sf.jabref.importer.fileformat.ImportFormat;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import org.apache.commons.logging.Log;

--- a/src/main/java/net/sf/jabref/importer/ImportFormats.java
+++ b/src/main/java/net/sf/jabref/importer/ImportFormats.java
@@ -29,12 +29,12 @@ import javax.swing.JOptionPane;
 import javax.swing.filechooser.FileFilter;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.actions.MnemonicAwareAction;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.importer.fileformat.ImportFormat;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/importer/ImportMenuItem.java
+++ b/src/main/java/net/sf/jabref/importer/ImportMenuItem.java
@@ -31,7 +31,6 @@ import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.EntryMarker;
@@ -48,6 +47,7 @@ import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.KeyCollisionException;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexString;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 /*
  * TODO: could separate the "menu item" functionality from the importing functionality

--- a/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/OpenDatabaseAction.java
@@ -34,7 +34,6 @@ import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Defaults;
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefExecutorService;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.FileDialogs;
@@ -53,6 +52,7 @@ import net.sf.jabref.migrations.FileLinksUpgradeWarning;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.specialfields.SpecialFieldsUtils;
 
 import org.apache.commons.logging.Log;

--- a/src/main/java/net/sf/jabref/importer/fetcher/ACMPortalFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/ACMPortalFetcher.java
@@ -42,7 +42,6 @@ import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.FetcherPreviewDialog;
 import net.sf.jabref.gui.help.HelpFile;
 import net.sf.jabref.importer.ImportInspector;
@@ -54,6 +53,7 @@ import net.sf.jabref.logic.formatter.casechanger.ProtectTermsFormatter;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.net.URLDownload;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/importer/fetcher/CrossrefFetcherEvaluator.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/CrossrefFetcherEvaluator.java
@@ -10,12 +10,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.logic.util.DOI;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * Useful for checking out new algorithm improvements and thresholds. Not used inside the JabRef code itself.

--- a/src/main/java/net/sf/jabref/importer/fetcher/DOItoBibTeXFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/DOItoBibTeXFetcher.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 import javax.swing.JPanel;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.help.HelpFile;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OutputPrinter;
@@ -22,6 +21,7 @@ import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.net.URLDownload;
 import net.sf.jabref.logic.util.DOI;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/importer/fetcher/DiVAtoBibTeXFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/DiVAtoBibTeXFetcher.java
@@ -26,7 +26,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.help.HelpFile;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OutputPrinter;
@@ -37,6 +36,7 @@ import net.sf.jabref.logic.formatter.casechanger.ProtectTermsFormatter;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.net.URLDownload;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/importer/fetcher/GeneralFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/GeneralFetcher.java
@@ -38,7 +38,6 @@ import javax.swing.SwingUtilities;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefExecutorService;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.FetcherPreviewDialog;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.ImportInspectionDialog;
@@ -50,6 +49,7 @@ import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.gui.util.FocusRequester;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.OS;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 
 public class GeneralFetcher extends SidePaneComponent implements ActionListener {

--- a/src/main/java/net/sf/jabref/importer/fetcher/IEEEXploreFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/IEEEXploreFetcher.java
@@ -36,7 +36,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.help.HelpFile;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OutputPrinter;
@@ -48,6 +47,7 @@ import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.net.URLDownload;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/importer/fetcher/ISBNtoBibTeXFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/ISBNtoBibTeXFetcher.java
@@ -27,7 +27,6 @@ import java.util.Scanner;
 import javax.swing.JPanel;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.help.HelpFile;
 import net.sf.jabref.importer.ImportInspector;
 import net.sf.jabref.importer.OutputPrinter;
@@ -36,6 +35,7 @@ import net.sf.jabref.logic.formatter.bibtexfields.UnitsToLatexFormatter;
 import net.sf.jabref.logic.formatter.casechanger.ProtectTermsFormatter;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/logic/CustomEntryTypesManager.java
+++ b/src/main/java/net/sf/jabref/logic/CustomEntryTypesManager.java
@@ -5,11 +5,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.CustomEntryType;
 import net.sf.jabref.model.entry.EntryType;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class CustomEntryTypesManager {
 

--- a/src/main/java/net/sf/jabref/logic/autocompleter/AutoCompletePreferences.java
+++ b/src/main/java/net/sf/jabref/logic/autocompleter/AutoCompletePreferences.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class AutoCompletePreferences {
 

--- a/src/main/java/net/sf/jabref/logic/bibtex/FieldContentParser.java
+++ b/src/main/java/net/sf/jabref/logic/bibtex/FieldContentParser.java
@@ -20,8 +20,8 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * This class provides the reformatting needed when reading BibTeX fields formatted

--- a/src/main/java/net/sf/jabref/logic/bibtex/LatexFieldFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/bibtex/LatexFieldFormatter.java
@@ -19,9 +19,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.InternalBibtexFields;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * Currently the only implementation of net.sf.jabref.exporter.FieldFormatter

--- a/src/main/java/net/sf/jabref/logic/cleanup/CleanupPreset.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/CleanupPreset.java
@@ -19,8 +19,8 @@ import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Set;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.exporter.FieldFormatterCleanups;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class CleanupPreset {
 

--- a/src/main/java/net/sf/jabref/logic/config/SaveOrderConfig.java
+++ b/src/main/java/net/sf/jabref/logic/config/SaveOrderConfig.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * Stores the save order config from MetaData

--- a/src/main/java/net/sf/jabref/logic/exporter/CustomExportList.java
+++ b/src/main/java/net/sf/jabref/logic/exporter/CustomExportList.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import java.util.TreeMap;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import ca.odell.glazedlists.BasicEventList;
 import ca.odell.glazedlists.EventList;

--- a/src/main/java/net/sf/jabref/logic/exporter/FileSaveSession.java
+++ b/src/main/java/net/sf/jabref/logic/exporter/FileSaveSession.java
@@ -23,10 +23,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.io.FileBasedLock;
 import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/logic/exporter/SavePreferences.java
+++ b/src/main/java/net/sf/jabref/logic/exporter/SavePreferences.java
@@ -3,8 +3,8 @@ package net.sf.jabref.logic.exporter;
 import java.nio.charset.Charset;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.config.SaveOrderConfig;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class SavePreferences {
 

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatter.java
@@ -21,11 +21,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.formatter.Formatter;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.layout.LayoutFormatter;
 import net.sf.jabref.logic.util.strings.HTMLUnicodeConversionMaps;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/logic/groups/KeywordGroup.java
+++ b/src/main/java/net/sf/jabref/logic/groups/KeywordGroup.java
@@ -23,7 +23,6 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.fileformat.ParseException;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.strings.QuotedStringTokenizer;
@@ -31,6 +30,7 @@ import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.EntryUtil;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/logic/groups/SearchGroup.java
+++ b/src/main/java/net/sf/jabref/logic/groups/SearchGroup.java
@@ -19,12 +19,12 @@ import java.util.List;
 import java.util.Optional;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.search.SearchQuery;
 import net.sf.jabref.logic.util.strings.QuotedStringTokenizer;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/logic/journals/JournalAbbreviationLoader.java
+++ b/src/main/java/net/sf/jabref/logic/journals/JournalAbbreviationLoader.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Objects;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/logic/labelpattern/LabelPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/labelpattern/LabelPatternUtil.java
@@ -27,7 +27,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.formatter.casechanger.Word;
 import net.sf.jabref.logic.layout.format.RemoveLatexCommands;
@@ -35,6 +34,7 @@ import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.AuthorList;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/logic/net/ProxyPreferences.java
+++ b/src/main/java/net/sf/jabref/logic/net/ProxyPreferences.java
@@ -2,7 +2,7 @@ package net.sf.jabref.logic.net;
 
 import java.util.Objects;
 
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class ProxyPreferences {
 

--- a/src/main/java/net/sf/jabref/logic/openoffice/OpenOfficePreferences.java
+++ b/src/main/java/net/sf/jabref/logic/openoffice/OpenOfficePreferences.java
@@ -18,8 +18,8 @@ package net.sf.jabref.logic.openoffice;
 import java.io.File;
 import java.util.List;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * The OpenOffice connection preferences are:

--- a/src/main/java/net/sf/jabref/logic/preferences/LastFocusedTabPreferences.java
+++ b/src/main/java/net/sf/jabref/logic/preferences/LastFocusedTabPreferences.java
@@ -19,7 +19,7 @@ package net.sf.jabref.logic.preferences;
 import java.io.File;
 import java.util.Objects;
 
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class LastFocusedTabPreferences {
 

--- a/src/main/java/net/sf/jabref/logic/remote/RemotePreferences.java
+++ b/src/main/java/net/sf/jabref/logic/remote/RemotePreferences.java
@@ -1,6 +1,6 @@
 package net.sf.jabref.logic.remote;
 
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * Place for handling the preferences for the remote communication

--- a/src/main/java/net/sf/jabref/logic/util/UpdateField.java
+++ b/src/main/java/net/sf/jabref/logic/util/UpdateField.java
@@ -4,11 +4,11 @@ import java.util.Collection;
 import java.util.Optional;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.util.date.EasyDateFormat;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.InternalBibtexFields;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class UpdateField {
 

--- a/src/main/java/net/sf/jabref/logic/util/VersionPreferences.java
+++ b/src/main/java/net/sf/jabref/logic/util/VersionPreferences.java
@@ -15,7 +15,7 @@
 */
 package net.sf.jabref.logic.util;
 
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 
 public class VersionPreferences {

--- a/src/main/java/net/sf/jabref/logic/util/date/EasyDateFormat.java
+++ b/src/main/java/net/sf/jabref/logic/util/date/EasyDateFormat.java
@@ -4,7 +4,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class EasyDateFormat {
 

--- a/src/main/java/net/sf/jabref/logic/util/date/TimeStamp.java
+++ b/src/main/java/net/sf/jabref/logic/util/date/TimeStamp.java
@@ -3,10 +3,10 @@ package net.sf.jabref.logic.util.date;
 import java.util.Optional;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.util.UpdateField;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class TimeStamp {
 

--- a/src/main/java/net/sf/jabref/logic/util/io/FileHistory.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileHistory.java
@@ -19,7 +19,7 @@ package net.sf.jabref.logic.util.io;
 import java.util.LinkedList;
 import java.util.List;
 
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class FileHistory {
 

--- a/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
@@ -38,7 +38,6 @@ import java.util.regex.Pattern;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.logic.layout.Layout;
 import net.sf.jabref.logic.layout.LayoutHelper;
@@ -47,6 +46,7 @@ import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FileField;
 import net.sf.jabref.model.entry.ParsedFileField;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/logic/xmp/XMPSchemaBibtex.java
+++ b/src/main/java/net/sf/jabref/logic/xmp/XMPSchemaBibtex.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.Author;
 import net.sf.jabref.model.entry.AuthorList;
@@ -32,6 +31,7 @@ import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldProperties;
 import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.model.entry.InternalBibtexFields;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.jempbox.xmp.XMPMetadata;
 import org.apache.jempbox.xmp.XMPSchema;

--- a/src/main/java/net/sf/jabref/logic/xmp/XMPUtil.java
+++ b/src/main/java/net/sf/jabref/logic/xmp/XMPUtil.java
@@ -42,7 +42,6 @@ import java.util.TreeSet;
 import javax.xml.transform.TransformerException;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.logic.TypedBibEntry;
@@ -55,6 +54,7 @@ import net.sf.jabref.model.entry.AuthorList;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.EntryUtil;
 import net.sf.jabref.model.entry.MonthUtil;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/migrations/FileLinksUpgradeWarning.java
+++ b/src/main/java/net/sf/jabref/migrations/FileLinksUpgradeWarning.java
@@ -26,7 +26,6 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.actions.BrowseAction;
 import net.sf.jabref.gui.entryeditor.EntryEditorTabList;
@@ -39,6 +38,7 @@ import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.FormBuilder;
 import com.jgoodies.forms.layout.FormLayout;

--- a/src/main/java/net/sf/jabref/migrations/PreferencesMigrations.java
+++ b/src/main/java/net/sf/jabref/migrations/PreferencesMigrations.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class PreferencesMigrations {
 

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -35,10 +35,10 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.event.FieldChangedEvent;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.google.common.base.Strings;
 import com.google.common.eventbus.EventBus;

--- a/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
+++ b/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
@@ -43,7 +43,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.specialfields.SpecialFieldsUtils;
 
 public class InternalBibtexFields {

--- a/src/main/java/net/sf/jabref/pdfimport/ImportDialog.java
+++ b/src/main/java/net/sf/jabref/pdfimport/ImportDialog.java
@@ -38,9 +38,9 @@ import javax.swing.KeyStroke;
 import javax.swing.WindowConstants;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import com.jgoodies.forms.builder.DefaultFormBuilder;

--- a/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
+++ b/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
@@ -26,7 +26,6 @@ import java.util.List;
 import javax.swing.JOptionPane;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.external.DroppedFileHandler;
 import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.gui.BasePanel;
@@ -50,6 +49,7 @@ import net.sf.jabref.model.database.KeyCollisionException;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.EntryType;
 import net.sf.jabref.model.entry.IdGenerator;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/src/main/java/net/sf/jabref/preferences/HighlightMatchingGroupPreferences.java
+++ b/src/main/java/net/sf/jabref/preferences/HighlightMatchingGroupPreferences.java
@@ -1,4 +1,4 @@
-package net.sf.jabref;
+package net.sf.jabref.preferences;
 
 public class HighlightMatchingGroupPreferences {
 

--- a/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
@@ -13,7 +13,7 @@
  with this program; if not, write to the Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-package net.sf.jabref;
+package net.sf.jabref.preferences;
 
 import java.awt.Color;
 import java.io.File;
@@ -46,6 +46,8 @@ import java.util.stream.Collectors;
 import javax.swing.JTable;
 import javax.swing.UIManager;
 
+import net.sf.jabref.JabRefException;
+import net.sf.jabref.JabRefMain;
 import net.sf.jabref.external.DroppedFileHandler;
 import net.sf.jabref.gui.desktop.JabRefDesktop;
 import net.sf.jabref.gui.entryeditor.EntryEditorTabList;

--- a/src/main/java/net/sf/jabref/preferences/JabRefPreferencesFilter.java
+++ b/src/main/java/net/sf/jabref/preferences/JabRefPreferencesFilter.java
@@ -1,4 +1,4 @@
-package net.sf.jabref;
+package net.sf.jabref.preferences;
 
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/net/sf/jabref/preferences/JabRefPreferencesFilterDialog.java
+++ b/src/main/java/net/sf/jabref/preferences/JabRefPreferencesFilterDialog.java
@@ -1,4 +1,4 @@
-package net.sf.jabref;
+package net.sf.jabref.preferences;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;

--- a/src/main/java/net/sf/jabref/sql/DBStringsPreferences.java
+++ b/src/main/java/net/sf/jabref/sql/DBStringsPreferences.java
@@ -1,6 +1,6 @@
 package net.sf.jabref.sql;
 
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public final class DBStringsPreferences {
 

--- a/src/test/java/net/sf/jabref/BibDatabaseContextTest.java
+++ b/src/test/java/net/sf/jabref/BibDatabaseContextTest.java
@@ -2,6 +2,7 @@ package net.sf.jabref;
 
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/FileBasedTestCase.java
+++ b/src/test/java/net/sf/jabref/FileBasedTestCase.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.After;
 import org.junit.Assert;

--- a/src/test/java/net/sf/jabref/JabRefPreferencesTest.java
+++ b/src/test/java/net/sf/jabref/JabRefPreferencesTest.java
@@ -3,6 +3,8 @@ package net.sf.jabref;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 
+import net.sf.jabref.preferences.JabRefPreferences;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/MetaDataTest.java
+++ b/src/test/java/net/sf/jabref/MetaDataTest.java
@@ -7,6 +7,7 @@ import java.util.TreeMap;
 import net.sf.jabref.logic.cleanup.FieldFormatterCleanup;
 import net.sf.jabref.logic.exporter.FieldFormatterCleanups;
 import net.sf.jabref.logic.formatter.casechanger.LowerCaseFormatter;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/SearchQueryHighlightListenerTest.java
+++ b/src/test/java/net/sf/jabref/SearchQueryHighlightListenerTest.java
@@ -22,6 +22,7 @@ import javax.swing.text.Highlighter;
 import javax.swing.text.Highlighter.Highlight;
 
 import net.sf.jabref.gui.fieldeditors.TextArea;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/cli/AuxCommandLineTest.java
+++ b/src/test/java/net/sf/jabref/cli/AuxCommandLineTest.java
@@ -8,10 +8,10 @@ import java.net.URISyntaxException;
 import java.nio.file.Paths;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.model.database.BibDatabase;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/external/RegExpFileSearchTests.java
+++ b/src/test/java/net/sf/jabref/external/RegExpFileSearchTests.java
@@ -25,13 +25,13 @@ import java.util.List;
 import java.util.Map;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.logic.layout.format.NameFormatter;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.After;
 import org.junit.Assert;

--- a/src/test/java/net/sf/jabref/importer/ConvertLegacyExplicitGroupsTest.java
+++ b/src/test/java/net/sf/jabref/importer/ConvertLegacyExplicitGroupsTest.java
@@ -3,13 +3,13 @@ package net.sf.jabref.importer;
 import java.util.Collections;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.logic.groups.AllEntriesGroup;
 import net.sf.jabref.logic.groups.ExplicitGroup;
 import net.sf.jabref.logic.groups.GroupHierarchyType;
 import net.sf.jabref.logic.groups.GroupTreeNode;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/importer/DatabaseFileLookupTest.java
+++ b/src/test/java/net/sf/jabref/importer/DatabaseFileLookupTest.java
@@ -8,10 +8,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/EntryFromFileCreatorManagerTest.java
+++ b/src/test/java/net/sf/jabref/importer/EntryFromFileCreatorManagerTest.java
@@ -25,10 +25,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/EntryFromPDFCreatorTest.java
+++ b/src/test/java/net/sf/jabref/importer/EntryFromPDFCreatorTest.java
@@ -20,9 +20,9 @@ import java.util.Optional;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefGUI;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/ImportFormatReaderIntegrationTest.java
+++ b/src/test/java/net/sf/jabref/importer/ImportFormatReaderIntegrationTest.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/importer/ImportFormatReaderTestParameterless.java
+++ b/src/test/java/net/sf/jabref/importer/ImportFormatReaderTestParameterless.java
@@ -6,7 +6,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
+++ b/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
@@ -10,9 +10,9 @@ import java.util.Collection;
 import java.util.Optional;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;

--- a/src/test/java/net/sf/jabref/importer/fetcher/GVKParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fetcher/GVKParserTest.java
@@ -9,9 +9,9 @@ import java.util.List;
 import javax.xml.parsers.ParserConfigurationException;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibTeXMLImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibTeXMLImporterTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibTeXMLImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibTeXMLImporterTestFiles.java
@@ -14,9 +14,9 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibTeXMLImporterTestTypes.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibTeXMLImporterTestTypes.java
@@ -9,8 +9,8 @@ import java.util.Collections;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/BiblioscapeImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BiblioscapeImporterTest.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/BiblioscapeImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BiblioscapeImporterTestFiles.java
@@ -10,9 +10,9 @@ import java.util.Collection;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/BiblioscapeImporterTestTypes.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BiblioscapeImporterTestTypes.java
@@ -9,8 +9,8 @@ import java.util.Collections;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexImporterTest.java
@@ -9,8 +9,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.logic.cleanup.FieldFormatterCleanup;
 import net.sf.jabref.logic.config.SaveOrderConfig;
@@ -30,6 +29,7 @@ import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexString;
 import net.sf.jabref.model.entry.EntryType;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.BeforeClass;
 import org.junit.Ignore;

--- a/src/test/java/net/sf/jabref/importer/fileformat/CopacImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/CopacImporterTest.java
@@ -13,8 +13,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/CopacImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/CopacImporterTestFiles.java
@@ -14,8 +14,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/EndnoteImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/EndnoteImporterTest.java
@@ -12,8 +12,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/importer/fileformat/FreeCiteImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/FreeCiteImporterTest.java
@@ -3,7 +3,7 @@ package net.sf.jabref.importer.fileformat;
 import java.util.Arrays;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/importer/fileformat/InspecImportTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/InspecImportTest.java
@@ -12,9 +12,9 @@ import java.util.Collections;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/importer/fileformat/IsiImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/IsiImporterTest.java
@@ -10,8 +10,8 @@ import java.util.HashMap;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;

--- a/src/test/java/net/sf/jabref/importer/fileformat/MedlineImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/MedlineImporterTest.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/MedlineImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/MedlineImporterTestFiles.java
@@ -13,9 +13,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/MedlinePlainImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/MedlinePlainImporterTest.java
@@ -14,9 +14,9 @@ import java.util.Collections;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/MsBibImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/MsBibImporterTest.java
@@ -11,8 +11,8 @@ import java.util.Collections;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/MsBibImporterTestfiles.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/MsBibImporterTestfiles.java
@@ -10,9 +10,9 @@ import java.util.Collection;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/OvidImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/OvidImporterTest.java
@@ -11,9 +11,9 @@ import java.util.Collections;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/PdfContentImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/PdfContentImporterTestFiles.java
@@ -10,9 +10,9 @@ import java.util.Collection;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/importer/fileformat/PdfXmpImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/PdfXmpImporterTest.java
@@ -9,9 +9,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/RISImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/RISImporterTest.java
@@ -7,7 +7,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/RISImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/RISImporterTestFiles.java
@@ -10,9 +10,9 @@ import java.util.Collection;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/RepecNepImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/RepecNepImporterTest.java
@@ -11,9 +11,9 @@ import java.util.Collections;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/SilverPlatterImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/SilverPlatterImporterTest.java
@@ -9,9 +9,9 @@ import java.util.Collection;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/importer/fileformat/SilverPlatterImporterTestNotRecognized.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/SilverPlatterImporterTestNotRecognized.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/logic/auxparser/AuxParserTest.java
+++ b/src/test/java/net/sf/jabref/logic/auxparser/AuxParserTest.java
@@ -9,10 +9,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.model.database.BibDatabase;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/logic/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/BibEntryWriterTest.java
@@ -7,11 +7,11 @@ import java.util.Collection;
 import java.util.Set;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.AfterClass;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/logic/bibtex/EntryTypesTestBibLatex.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/EntryTypesTestBibLatex.java
@@ -3,10 +3,10 @@ package net.sf.jabref.logic.bibtex;
 import java.util.Optional;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibLatexEntryTypes;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/logic/bibtex/EntryTypesTestBibtex.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/EntryTypesTestBibtex.java
@@ -5,11 +5,11 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.CustomEntryType;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/logic/bibtex/FieldContentParserTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/FieldContentParserTest.java
@@ -1,7 +1,7 @@
 package net.sf.jabref.logic.bibtex;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/src/test/java/net/sf/jabref/logic/bibtex/LatexFieldFormatterTests.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/LatexFieldFormatterTests.java
@@ -1,7 +1,7 @@
 package net.sf.jabref.logic.bibtex;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/src/test/java/net/sf/jabref/logic/bst/TestVM.java
+++ b/src/test/java/net/sf/jabref/logic/bst/TestVM.java
@@ -8,12 +8,12 @@ import java.util.Collection;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.logic.bst.VM.BstEntry;
 import net.sf.jabref.logic.bst.VM.StackFunction;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.antlr.runtime.RecognitionException;
 import org.junit.Assert;

--- a/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.exporter.FieldFormatterCleanups;
 import net.sf.jabref.logic.formatter.bibtexfields.HtmlToLatexFormatter;
@@ -25,6 +24,7 @@ import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FileField;
 import net.sf.jabref.model.entry.ParsedFileField;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/logic/cleanup/MoveFilesCleanupTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/MoveFilesCleanupTest.java
@@ -6,12 +6,12 @@ import java.util.Arrays;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FileField;
 import net.sf.jabref.model.entry.ParsedFileField;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/src/test/java/net/sf/jabref/logic/cleanup/RenamePdfCleanupTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/RenamePdfCleanupTest.java
@@ -7,13 +7,13 @@ import java.util.Arrays;
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Defaults;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FileField;
 import net.sf.jabref.model.entry.ParsedFileField;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -11,7 +11,6 @@ import java.util.Scanner;
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Defaults;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
@@ -33,6 +32,7 @@ import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.BibtexString;
 import net.sf.jabref.model.entry.CustomEntryType;
 import net.sf.jabref.model.entry.IdGenerator;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.google.common.base.Charsets;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/logic/exporter/ExportFormatTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/ExportFormatTest.java
@@ -10,11 +10,11 @@ import java.util.List;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.google.common.base.Charsets;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/logic/exporter/FieldFormatterCleanupsTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/FieldFormatterCleanupsTest.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Optional;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.cleanup.FieldFormatterCleanup;
 import net.sf.jabref.logic.formatter.IdentityFormatter;
 import net.sf.jabref.logic.formatter.bibtexfields.NormalizeDateFormatter;
@@ -14,6 +13,7 @@ import net.sf.jabref.logic.formatter.bibtexfields.NormalizePagesFormatter;
 import net.sf.jabref.logic.formatter.casechanger.LowerCaseFormatter;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/src/test/java/net/sf/jabref/logic/exporter/HtmlExportFormatTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/HtmlExportFormatTest.java
@@ -8,11 +8,11 @@ import java.util.List;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.google.common.base.Charsets;
 import org.junit.After;

--- a/src/test/java/net/sf/jabref/logic/exporter/MSBibExportFormatTestFiles.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/MSBibExportFormatTestFiles.java
@@ -15,11 +15,11 @@ import java.util.stream.Stream;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.importer.fileformat.BibtexImporter;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.google.common.base.Charsets;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/logic/exporter/MsBibExportFormatTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/MsBibExportFormatTest.java
@@ -9,10 +9,10 @@ import java.util.List;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.google.common.base.Charsets;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/logic/formatter/FormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/FormatterTest.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.formatter.bibtexfields.ClearFormatter;
 import net.sf.jabref.logic.formatter.bibtexfields.HtmlToLatexFormatter;
 import net.sf.jabref.logic.formatter.bibtexfields.HtmlToUnicodeFormatter;
@@ -25,6 +24,7 @@ import net.sf.jabref.logic.formatter.casechanger.TitleCaseFormatter;
 import net.sf.jabref.logic.formatter.casechanger.UpperCaseFormatter;
 import net.sf.jabref.logic.formatter.minifier.MinifyNameListFormatter;
 import net.sf.jabref.logic.layout.format.LatexToUnicodeFormatter;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatterTest.java
@@ -1,7 +1,7 @@
 package net.sf.jabref.logic.formatter.bibtexfields;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/UnicodeConverterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/UnicodeConverterTest.java
@@ -1,7 +1,7 @@
 package net.sf.jabref.logic.formatter.bibtexfields;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/src/test/java/net/sf/jabref/logic/groups/ExplicitGroupTest.java
+++ b/src/test/java/net/sf/jabref/logic/groups/ExplicitGroupTest.java
@@ -1,11 +1,11 @@
 package net.sf.jabref.logic.groups;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.fileformat.ParseException;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.IdGenerator;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/logic/groups/GroupTreeNodeTest.java
+++ b/src/test/java/net/sf/jabref/logic/groups/GroupTreeNodeTest.java
@@ -6,11 +6,11 @@ import java.util.Collections;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.fileformat.ParseException;
 import net.sf.jabref.logic.search.matchers.AndMatcher;
 import net.sf.jabref.logic.search.matchers.OrMatcher;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/logic/groups/GroupsUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/groups/GroupsUtilTest.java
@@ -7,10 +7,10 @@ import java.util.List;
 import java.util.Set;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.model.database.BibDatabase;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/logic/groups/SearchGroupTest.java
+++ b/src/test/java/net/sf/jabref/logic/groups/SearchGroupTest.java
@@ -1,8 +1,8 @@
 package net.sf.jabref.logic.groups;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -10,12 +10,12 @@ import java.util.Optional;
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Defaults;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.InternalBibtexFields;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/src/test/java/net/sf/jabref/logic/journals/AbbreviationsTest.java
+++ b/src/test/java/net/sf/jabref/logic/journals/AbbreviationsTest.java
@@ -1,7 +1,7 @@
 package net.sf.jabref.logic.journals;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/logic/l10n/LocalizationTest.java
+++ b/src/test/java/net/sf/jabref/logic/l10n/LocalizationTest.java
@@ -2,7 +2,7 @@ package net.sf.jabref.logic.l10n;
 
 import java.util.Locale;
 
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/logic/labelpattern/LabelPatternUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/labelpattern/LabelPatternUtilTest.java
@@ -1,10 +1,10 @@
 package net.sf.jabref.logic.labelpattern;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/src/test/java/net/sf/jabref/logic/layout/LayoutEntryTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/LayoutEntryTest.java
@@ -6,9 +6,9 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/logic/layout/LayoutTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/LayoutTest.java
@@ -5,11 +5,11 @@ import java.io.StringReader;
 import java.util.Collection;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/logic/layout/format/FileLinkTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/format/FileLinkTest.java
@@ -1,8 +1,8 @@
 package net.sf.jabref.logic.layout.format;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.layout.ParamLayoutFormatter;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/logic/net/URLDownloadTest.java
+++ b/src/test/java/net/sf/jabref/logic/net/URLDownloadTest.java
@@ -6,7 +6,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/logic/openoffice/OOBibStyleTest.java
+++ b/src/test/java/net/sf/jabref/logic/openoffice/OOBibStyleTest.java
@@ -15,7 +15,6 @@ import java.util.Set;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefMain;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.importer.fileformat.ImportFormat;
@@ -23,6 +22,7 @@ import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.logic.layout.Layout;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/logic/openoffice/StyleLoaderTest.java
+++ b/src/test/java/net/sf/jabref/logic/openoffice/StyleLoaderTest.java
@@ -9,8 +9,8 @@ import java.util.List;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefMain;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/logic/preferences/LastFocusedTabPreferencesTest.java
+++ b/src/test/java/net/sf/jabref/logic/preferences/LastFocusedTabPreferencesTest.java
@@ -2,7 +2,7 @@ package net.sf.jabref.logic.preferences;
 
 import java.io.File;
 
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/src/test/java/net/sf/jabref/logic/search/MatchesHighlighterTest.java
+++ b/src/test/java/net/sf/jabref/logic/search/MatchesHighlighterTest.java
@@ -6,7 +6,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/logic/search/rules/ContainBasedSearchRuleTest.java
+++ b/src/test/java/net/sf/jabref/logic/search/rules/ContainBasedSearchRuleTest.java
@@ -1,10 +1,10 @@
 package net.sf.jabref.logic.search.rules;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.IdGenerator;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/logic/util/io/FileHistoryTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/io/FileHistoryTest.java
@@ -2,7 +2,7 @@ package net.sf.jabref.logic.util.io;
 
 import java.util.List;
 
-import net.sf.jabref.JabRefPreferences;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/logic/util/io/FileUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/io/FileUtilTest.java
@@ -6,9 +6,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
@@ -1,8 +1,8 @@
 package net.sf.jabref.logic.util.strings;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.entry.FileField;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/logic/xmp/XMPSchemaBibtexTest.java
+++ b/src/test/java/net/sf/jabref/logic/xmp/XMPSchemaBibtexTest.java
@@ -11,8 +11,8 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import net.sf.jabref.BibtexTestData;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.jempbox.impl.XMLUtil;
 import org.apache.jempbox.xmp.XMPMetadata;

--- a/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
@@ -27,7 +27,6 @@ import java.util.TimeZone;
 import javax.xml.transform.TransformerException;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.logic.bibtex.BibEntryWriter;
@@ -37,6 +36,7 @@ import net.sf.jabref.model.entry.AuthorList;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.IdGenerator;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.google.common.io.CharStreams;
 import org.apache.jempbox.xmp.XMPMetadata;

--- a/src/test/java/net/sf/jabref/model/DuplicateCheckTest.java
+++ b/src/test/java/net/sf/jabref/model/DuplicateCheckTest.java
@@ -1,11 +1,11 @@
 package net.sf.jabref.model;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.IdGenerator;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/sf/jabref/model/database/BibDatabaseTest.java
+++ b/src/test/java/net/sf/jabref/model/database/BibDatabaseTest.java
@@ -7,13 +7,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexString;
 import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.model.event.TestEventListener;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/src/test/java/net/sf/jabref/model/entry/BibEntryTests.java
+++ b/src/test/java/net/sf/jabref/model/entry/BibEntryTests.java
@@ -8,9 +8,9 @@ import java.util.List;
 import java.util.Optional;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.model.FieldChange;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/net/sf/jabref/sql/DatabaseImportExportTests.java
+++ b/src/test/java/net/sf/jabref/sql/DatabaseImportExportTests.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefPreferences;
 import net.sf.jabref.importer.fileformat.ParseException;
 import net.sf.jabref.logic.groups.AllEntriesGroup;
 import net.sf.jabref.logic.groups.GroupHierarchyType;
@@ -15,6 +14,7 @@ import net.sf.jabref.logic.groups.KeywordGroup;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.sql.exporter.DatabaseExporter;
 import net.sf.jabref.sql.importer.DBImporterResult;
 import net.sf.jabref.sql.importer.DatabaseImporter;


### PR DESCRIPTION
Moves preferences-related classes into a new top-level package as outlined in #1579. This is a pure refactoring, no functional changes. It doesn't fix the dependencies on preferences, but separates them from the remaining classes in the root package.

Additionally, the class `JabRefPreferencesFilterDialog` is moved into the gui package, where it belongs. This also allows to rename the class and reduce its visibility.

Commits can be squashed on merge.
