### PR TITLE
Moved, removed, and used String constants

### DIFF
--- a/src/main/java/net/sf/jabref/BibDatabaseContext.java
+++ b/src/main/java/net/sf/jabref/BibDatabaseContext.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import net.sf.jabref.logic.layout.format.FileLinkPreferences;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.database.BibDatabaseModeDetection;
@@ -137,7 +138,7 @@ public class BibDatabaseContext {
         }
 
         // 3. preferences directory
-        String dir = Globals.prefs.get(fieldName + Globals.DIR_SUFFIX); // FILE_DIR
+        String dir = Globals.prefs.get(fieldName + FileLinkPreferences.DIR_SUFFIX); // FILE_DIR
         if (dir != null) {
             fileDirs.add(dir);
         }

--- a/src/main/java/net/sf/jabref/Globals.java
+++ b/src/main/java/net/sf/jabref/Globals.java
@@ -33,9 +33,6 @@ public class Globals {
 
     // JabRef version info
     public static final BuildInfo BUILD_INFO = new BuildInfo();
-    // Signature written at the top of the .bib file.
-    public static final String SIGNATURE = "This file was created with JabRef";
-    public static final String ENCODING_PREFIX = "Encoding: ";
     // Remote listener
     public static final RemoteListenerServerLifecycle REMOTE_LISTENER = new RemoteListenerServerLifecycle();
 

--- a/src/main/java/net/sf/jabref/Globals.java
+++ b/src/main/java/net/sf/jabref/Globals.java
@@ -31,29 +31,16 @@ import net.sf.jabref.preferences.JabRefPreferences;
 
 public class Globals {
 
-    public static final String DIR_SUFFIX = "Directory";
-
     // JabRef version info
     public static final BuildInfo BUILD_INFO = new BuildInfo();
     // Signature written at the top of the .bib file.
     public static final String SIGNATURE = "This file was created with JabRef";
     public static final String ENCODING_PREFIX = "Encoding: ";
-    // Character separating field names that are to be used in sequence as
-    // fallbacks for a single column (e.g. "author/editor" to use editor where
-    // author is not set):
-    public static final String COL_DEFINITION_FIELD_SEPARATOR = "/";
-    // Newlines
-    // will be overridden in initialization due to feature #857 @ JabRef.java
-    public static String NEWLINE = System.lineSeparator();
-
     // Remote listener
     public static final RemoteListenerServerLifecycle REMOTE_LISTENER = new RemoteListenerServerLifecycle();
 
     public static final ImportFormatReader IMPORT_FORMAT_READER = new ImportFormatReader();
 
-
-    // Non-letters which are used to denote accents in LaTeX-commands, e.g., in {\"{a}}
-    public static final String SPECIAL_COMMAND_CHARS = "\"`^~'=.|";
 
     // In the main program, this field is initialized in JabRef.java
     // Each test case initializes this field if required

--- a/src/main/java/net/sf/jabref/JabRefMain.java
+++ b/src/main/java/net/sf/jabref/JabRefMain.java
@@ -30,7 +30,7 @@ import net.sf.jabref.logic.net.ProxyPreferences;
 import net.sf.jabref.logic.net.ProxyRegisterer;
 import net.sf.jabref.logic.remote.RemotePreferences;
 import net.sf.jabref.logic.remote.client.RemoteListenerClient;
-import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.entry.InternalBibtexFields;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -93,7 +93,7 @@ public class JabRefMain {
 
         // override used newline character with the one stored in the preferences
         // The preferences return the system newline character sequence as default
-        StringUtil.NEWLINE = Globals.prefs.get(JabRefPreferences.NEWLINE);
+        FileUtil.NEWLINE = Globals.prefs.get(JabRefPreferences.NEWLINE);
 
         // Process arguments
         ArgumentProcessor argumentProcessor = new ArgumentProcessor(args, ArgumentProcessor.Mode.INITIAL_START);

--- a/src/main/java/net/sf/jabref/JabRefMain.java
+++ b/src/main/java/net/sf/jabref/JabRefMain.java
@@ -30,7 +30,7 @@ import net.sf.jabref.logic.net.ProxyPreferences;
 import net.sf.jabref.logic.net.ProxyRegisterer;
 import net.sf.jabref.logic.remote.RemotePreferences;
 import net.sf.jabref.logic.remote.client.RemoteListenerClient;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.entry.InternalBibtexFields;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -93,7 +93,7 @@ public class JabRefMain {
 
         // override used newline character with the one stored in the preferences
         // The preferences return the system newline character sequence as default
-        FileUtil.NEWLINE = Globals.prefs.get(JabRefPreferences.NEWLINE);
+        OS.NEWLINE = Globals.prefs.get(JabRefPreferences.NEWLINE);
 
         // Process arguments
         ArgumentProcessor argumentProcessor = new ArgumentProcessor(args, ArgumentProcessor.Mode.INITIAL_START);

--- a/src/main/java/net/sf/jabref/JabRefMain.java
+++ b/src/main/java/net/sf/jabref/JabRefMain.java
@@ -30,6 +30,7 @@ import net.sf.jabref.logic.net.ProxyPreferences;
 import net.sf.jabref.logic.net.ProxyRegisterer;
 import net.sf.jabref.logic.remote.RemotePreferences;
 import net.sf.jabref.logic.remote.client.RemoteListenerClient;
+import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.InternalBibtexFields;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -92,7 +93,7 @@ public class JabRefMain {
 
         // override used newline character with the one stored in the preferences
         // The preferences return the system newline character sequence as default
-        Globals.NEWLINE = Globals.prefs.get(JabRefPreferences.NEWLINE);
+        StringUtil.NEWLINE = Globals.prefs.get(JabRefPreferences.NEWLINE);
 
         // Process arguments
         ArgumentProcessor argumentProcessor = new ArgumentProcessor(args, ArgumentProcessor.Mode.INITIAL_START);

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -39,6 +39,7 @@ import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.labelpattern.AbstractLabelPattern;
 import net.sf.jabref.logic.labelpattern.DatabaseLabelPattern;
 import net.sf.jabref.logic.layout.format.FileLinkPreferences;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.FieldName;
@@ -365,7 +366,7 @@ public class MetaData implements Iterable<String> {
 
                 //in case of save actions, add an additional newline after the enabled flag
                 if (metaItem.getKey().equals(SAVE_ACTIONS) && ("enabled".equals(dataItem) || "disabled".equals(dataItem))) {
-                    stringBuilder.append(StringUtil.NEWLINE);
+                    stringBuilder.append(FileUtil.NEWLINE);
                 }
             }
 
@@ -380,12 +381,12 @@ public class MetaData implements Iterable<String> {
         // (which is always the AllEntriesGroup).
         if ((groupsRoot != null) && (groupsRoot.getNumberOfChildren() > 0)) {
             StringBuilder stringBuilder = new StringBuilder();
-            stringBuilder.append(StringUtil.NEWLINE);
+            stringBuilder.append(FileUtil.NEWLINE);
 
             for (String groupNode : groupsRoot.getTreeAsString()) {
                 stringBuilder.append(StringUtil.quote(groupNode, ";", '\\'));
                 stringBuilder.append(";");
-                stringBuilder.append(StringUtil.NEWLINE);
+                stringBuilder.append(FileUtil.NEWLINE);
             }
             serializedMetaData.put(GROUPSTREE, stringBuilder.toString());
         }

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -39,7 +39,7 @@ import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.labelpattern.AbstractLabelPattern;
 import net.sf.jabref.logic.labelpattern.DatabaseLabelPattern;
 import net.sf.jabref.logic.layout.format.FileLinkPreferences;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.FieldName;
@@ -366,7 +366,7 @@ public class MetaData implements Iterable<String> {
 
                 //in case of save actions, add an additional newline after the enabled flag
                 if (metaItem.getKey().equals(SAVE_ACTIONS) && ("enabled".equals(dataItem) || "disabled".equals(dataItem))) {
-                    stringBuilder.append(FileUtil.NEWLINE);
+                    stringBuilder.append(OS.NEWLINE);
                 }
             }
 
@@ -381,12 +381,12 @@ public class MetaData implements Iterable<String> {
         // (which is always the AllEntriesGroup).
         if ((groupsRoot != null) && (groupsRoot.getNumberOfChildren() > 0)) {
             StringBuilder stringBuilder = new StringBuilder();
-            stringBuilder.append(FileUtil.NEWLINE);
+            stringBuilder.append(OS.NEWLINE);
 
             for (String groupNode : groupsRoot.getTreeAsString()) {
                 stringBuilder.append(StringUtil.quote(groupNode, ";", '\\'));
                 stringBuilder.append(";");
-                stringBuilder.append(FileUtil.NEWLINE);
+                stringBuilder.append(OS.NEWLINE);
             }
             serializedMetaData.put(GROUPSTREE, stringBuilder.toString());
         }

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -38,6 +38,7 @@ import net.sf.jabref.logic.groups.GroupTreeNode;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.labelpattern.AbstractLabelPattern;
 import net.sf.jabref.logic.labelpattern.DatabaseLabelPattern;
+import net.sf.jabref.logic.layout.format.FileLinkPreferences;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.FieldName;
@@ -58,7 +59,7 @@ public class MetaData implements Iterable<String> {
     private static final String DATABASE_TYPE = "databaseType";
 
     private static final String GROUPSTREE = "groupstree";
-    private static final String FILE_DIRECTORY = FieldName.FILE + Globals.DIR_SUFFIX;
+    private static final String FILE_DIRECTORY = FieldName.FILE + FileLinkPreferences.DIR_SUFFIX;
     public static final String SELECTOR_META_PREFIX = "selector_";
     private static final String PROTECTED_FLAG_META = "protectedFlag";
 
@@ -364,7 +365,7 @@ public class MetaData implements Iterable<String> {
 
                 //in case of save actions, add an additional newline after the enabled flag
                 if (metaItem.getKey().equals(SAVE_ACTIONS) && ("enabled".equals(dataItem) || "disabled".equals(dataItem))) {
-                    stringBuilder.append(Globals.NEWLINE);
+                    stringBuilder.append(StringUtil.NEWLINE);
                 }
             }
 
@@ -379,12 +380,12 @@ public class MetaData implements Iterable<String> {
         // (which is always the AllEntriesGroup).
         if ((groupsRoot != null) && (groupsRoot.getNumberOfChildren() > 0)) {
             StringBuilder stringBuilder = new StringBuilder();
-            stringBuilder.append(Globals.NEWLINE);
+            stringBuilder.append(StringUtil.NEWLINE);
 
             for (String groupNode : groupsRoot.getTreeAsString()) {
                 stringBuilder.append(StringUtil.quote(groupNode, ";", '\\'));
                 stringBuilder.append(";");
-                stringBuilder.append(Globals.NEWLINE);
+                stringBuilder.append(StringUtil.NEWLINE);
             }
             serializedMetaData.put(GROUPSTREE, stringBuilder.toString());
         }

--- a/src/main/java/net/sf/jabref/external/DownloadExternalFile.java
+++ b/src/main/java/net/sf/jabref/external/DownloadExternalFile.java
@@ -200,10 +200,10 @@ public class DownloadExternalFile {
             if (directory == null) {
                 dirPrefix = null;
             } else {
-                if (directory.endsWith(System.getProperty("file.separator"))) {
+                if (directory.endsWith(FileUtil.FILE_SEPARATOR)) {
                     dirPrefix = directory;
                 } else {
-                    dirPrefix = directory + System.getProperty("file.separator");
+                    dirPrefix = directory + FileUtil.FILE_SEPARATOR;
                 }
             }
 
@@ -249,7 +249,7 @@ public class DownloadExternalFile {
     private File expandFilename(String directory, String link) {
         File toFile = new File(link);
         // If this is a relative link, we should perhaps append the directory:
-        String dirPrefix = directory + System.getProperty("file.separator");
+        String dirPrefix = directory + FileUtil.FILE_SEPARATOR;
         if (!toFile.isAbsolute()) {
             toFile = new File(dirPrefix + link);
         }

--- a/src/main/java/net/sf/jabref/external/DownloadExternalFile.java
+++ b/src/main/java/net/sf/jabref/external/DownloadExternalFile.java
@@ -200,10 +200,10 @@ public class DownloadExternalFile {
             if (directory == null) {
                 dirPrefix = null;
             } else {
-                if (directory.endsWith(FileUtil.FILE_SEPARATOR)) {
+                if (directory.endsWith(OS.FILE_SEPARATOR)) {
                     dirPrefix = directory;
                 } else {
-                    dirPrefix = directory + FileUtil.FILE_SEPARATOR;
+                    dirPrefix = directory + OS.FILE_SEPARATOR;
                 }
             }
 
@@ -249,7 +249,7 @@ public class DownloadExternalFile {
     private File expandFilename(String directory, String link) {
         File toFile = new File(link);
         // If this is a relative link, we should perhaps append the directory:
-        String dirPrefix = directory + FileUtil.FILE_SEPARATOR;
+        String dirPrefix = directory + OS.FILE_SEPARATOR;
         if (!toFile.isAbsolute()) {
             toFile = new File(dirPrefix + link);
         }

--- a/src/main/java/net/sf/jabref/external/DroppedFileHandler.java
+++ b/src/main/java/net/sf/jabref/external/DroppedFileHandler.java
@@ -40,6 +40,7 @@ import net.sf.jabref.gui.undo.NamedCompound;
 import net.sf.jabref.gui.undo.UndoableFieldChange;
 import net.sf.jabref.gui.undo.UndoableInsertEntry;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.logic.xmp.XMPUtil;
 import net.sf.jabref.model.database.BibDatabase;
@@ -478,7 +479,7 @@ public class DroppedFileHandler {
             LOGGER.warn("Cannot determine destination directory or destination directory does not exist");
             return false;
         }
-        File toFile = new File(dirs.get(found) + FileUtil.FILE_SEPARATOR + destFilename);
+        File toFile = new File(dirs.get(found) + OS.FILE_SEPARATOR + destFilename);
         if (toFile.exists()) {
             int answer = JOptionPane.showConfirmDialog(frame,
                     Localization.lang("'%0' exists. Overwrite file?", toFile.getAbsolutePath()),
@@ -530,7 +531,7 @@ public class DroppedFileHandler {
         }
         String destinationFileName = new File(toFile).getName();
 
-        File destFile = new File(dirs.get(found) + FileUtil.FILE_SEPARATOR + destinationFileName);
+        File destFile = new File(dirs.get(found) + OS.FILE_SEPARATOR + destinationFileName);
         if (destFile.equals(new File(fileName))) {
             // File is already in the correct position. Don't override!
             return true;

--- a/src/main/java/net/sf/jabref/external/DroppedFileHandler.java
+++ b/src/main/java/net/sf/jabref/external/DroppedFileHandler.java
@@ -478,7 +478,7 @@ public class DroppedFileHandler {
             LOGGER.warn("Cannot determine destination directory or destination directory does not exist");
             return false;
         }
-        File toFile = new File(dirs.get(found) + System.getProperty("file.separator") + destFilename);
+        File toFile = new File(dirs.get(found) + FileUtil.FILE_SEPARATOR + destFilename);
         if (toFile.exists()) {
             int answer = JOptionPane.showConfirmDialog(frame,
                     Localization.lang("'%0' exists. Overwrite file?", toFile.getAbsolutePath()),
@@ -530,7 +530,7 @@ public class DroppedFileHandler {
         }
         String destinationFileName = new File(toFile).getName();
 
-        File destFile = new File(dirs.get(found) + System.getProperty("file.separator") + destinationFileName);
+        File destFile = new File(dirs.get(found) + FileUtil.FILE_SEPARATOR + destinationFileName);
         if (destFile.equals(new File(fileName))) {
             // File is already in the correct position. Don't override!
             return true;

--- a/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
@@ -184,7 +184,6 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
     private static final int FILE_COL = 2;
     private static final int URL_COL = 3;
     private static final int PAD = 4;
-    private static final String URL_FIELD = FieldName.URL;
 
 
     /**
@@ -917,7 +916,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
                                 fl.type)).actionPerformed(null);
                     }
                 } else { // Must be URL_COL
-                    openExternalLink(URL_FIELD, e);
+                    openExternalLink(FieldName.URL, e);
                 }
             }
         }
@@ -1130,14 +1129,14 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
             }
             BibEntry entry = selectionModel.getSelected().get(0);
             String result = JOptionPane.showInputDialog(ImportInspectionDialog.this, Localization.lang("Enter URL"),
-                    entry.getFieldOptional(URL_FIELD).orElse(""));
+                    entry.getFieldOptional(FieldName.URL).orElse(""));
             entries.getReadWriteLock().writeLock().lock();
             try {
                 if (result != null) {
                     if (result.isEmpty()) {
-                        entry.clearField(URL_FIELD);
+                        entry.clearField(FieldName.URL);
                     } else {
-                        entry.setField(URL_FIELD, result);
+                        entry.setField(FieldName.URL, result);
                     }
                 }
             } finally {
@@ -1308,7 +1307,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
             if (i == FILE_COL) {
                 comparators.add(new IconComparator(Collections.singletonList(FieldName.FILE)));
             } else if (i == URL_COL) {
-                comparators.add(new IconComparator(Collections.singletonList(URL_FIELD)));
+                comparators.add(new IconComparator(Collections.singletonList(FieldName.URL)));
             }
 
         }
@@ -1428,7 +1427,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
                         FileListTableModel model = new FileListTableModel();
                         entry.getFieldOptional(FieldName.FILE).ifPresent(model::setContent);
                         fileLabel.setToolTipText(model.getToolTipHTMLRepresentation());
-                        if (model.getRowCount() > 0 && model.getEntry(0).type.isPresent()) {
+                        if ((model.getRowCount() > 0) && model.getEntry(0).type.isPresent()) {
                             fileLabel.setIcon(model.getEntry(0).type.get().getIcon());
                         }
                         return fileLabel;
@@ -1436,8 +1435,8 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
                         return null;
                     }
                 case URL_COL:
-                    if (entry.hasField(URL_FIELD)) {
-                        urlLabel.setToolTipText(entry.getFieldOptional(URL_FIELD).orElse(""));
+                    if (entry.hasField(FieldName.URL)) {
+                        urlLabel.setToolTipText(entry.getFieldOptional(FieldName.URL).orElse(""));
                         return urlLabel;
                     } else {
                         return null;

--- a/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
+++ b/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
@@ -68,7 +68,7 @@ import net.sf.jabref.logic.journals.Abbreviation;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.logic.journals.JournalAbbreviationPreferences;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
@@ -374,7 +374,7 @@ class ManageJournalsPanel extends JPanel {
                     writer.write(entry.getName());
                     writer.write(" = ");
                     writer.write(entry.getAbbreviation());
-                    writer.write(FileUtil.NEWLINE);
+                    writer.write(OS.NEWLINE);
                 }
             } catch (IOException e) {
                 LOGGER.warn("Problem writing abbreviation file", e);

--- a/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
+++ b/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
@@ -68,6 +68,7 @@ import net.sf.jabref.logic.journals.Abbreviation;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.logic.journals.JournalAbbreviationPreferences;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
@@ -373,7 +374,7 @@ class ManageJournalsPanel extends JPanel {
                     writer.write(entry.getName());
                     writer.write(" = ");
                     writer.write(entry.getAbbreviation());
-                    writer.write(Globals.NEWLINE);
+                    writer.write(StringUtil.NEWLINE);
                 }
             } catch (IOException e) {
                 LOGGER.warn("Problem writing abbreviation file", e);

--- a/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
+++ b/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
@@ -68,7 +68,7 @@ import net.sf.jabref.logic.journals.Abbreviation;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.logic.journals.JournalAbbreviationPreferences;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
@@ -374,7 +374,7 @@ class ManageJournalsPanel extends JPanel {
                     writer.write(entry.getName());
                     writer.write(" = ");
                     writer.write(entry.getAbbreviation());
-                    writer.write(StringUtil.NEWLINE);
+                    writer.write(FileUtil.NEWLINE);
                 }
             } catch (IOException e) {
                 LOGGER.warn("Problem writing abbreviation file", e);

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableColumn.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableColumn.java
@@ -7,12 +7,12 @@ import java.util.StringJoiner;
 
 import javax.swing.JLabel;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.layout.LayoutFormatter;
 import net.sf.jabref.logic.layout.format.LatexToUnicodeFormatter;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.EntryUtil;
+import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.model.entry.FieldProperties;
 import net.sf.jabref.model.entry.InternalBibtexFields;
 
@@ -64,7 +64,7 @@ public class MainTableColumn {
             return null;
         }
 
-        StringJoiner joiner = new StringJoiner(Globals.COL_DEFINITION_FIELD_SEPARATOR);
+        StringJoiner joiner = new StringJoiner(FieldName.FIELD_SEPARATOR);
         for (String field : bibtexFields) {
             joiner.add(field);
         }

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableFormat.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableFormat.java
@@ -137,7 +137,7 @@ public class MainTableFormat implements TableFormat<BibEntry> {
             // stored column name will be used as columnName
             // There might be more than one field to display, e.g., "author/editor" or "date/year" - so split
             // at MainTableFormat.COL_DEFINITION_FIELD_SEPARATOR
-            String[] fields = columnName.split(Globals.COL_DEFINITION_FIELD_SEPARATOR);
+            String[] fields = columnName.split(FieldName.FIELD_SEPARATOR);
             tableColumns.add(new MainTableColumn(columnName, Arrays.asList(fields), database));
         }
 

--- a/src/main/java/net/sf/jabref/gui/maintable/PersistenceTableColumnListener.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/PersistenceTableColumnListener.java
@@ -41,10 +41,6 @@ import net.sf.jabref.preferences.JabRefPreferences;
  */
 public class PersistenceTableColumnListener implements TableColumnModelListener {
 
-    public static final String ACTIVATE_PREF_KEY = "ActivatePersistenceTableColumnListener";
-
-    public static final boolean DEFAULT_ENABLED = true;
-
     private static final String SIMPLE_CLASS_NAME = PersistenceTableColumnListener.class.getSimpleName();
 
     // needed to get column names / indices mapped from view to model

--- a/src/main/java/net/sf/jabref/gui/plaintextimport/TextInputDialog.java
+++ b/src/main/java/net/sf/jabref/gui/plaintextimport/TextInputDialog.java
@@ -126,6 +126,7 @@ import net.sf.jabref.logic.bibtex.LatexFieldFormatter;
 import net.sf.jabref.logic.bibtex.LatexFieldFormatterPreferences;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.UpdateField;
+import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.EntryType;
@@ -507,11 +508,11 @@ public class TextInputDialog extends JDialog {
 
         // we have to remove line breaks (but keep empty lines)
         // otherwise, the result is broken
-        text = text.replace(Globals.NEWLINE.concat(Globals.NEWLINE), "##NEWLINE##");
+        text = text.replace(StringUtil.NEWLINE.concat(StringUtil.NEWLINE), "##NEWLINE##");
         // possible URL line breaks are removed completely.
-        text = text.replace("/".concat(Globals.NEWLINE), "/");
-        text = text.replace(Globals.NEWLINE, " ");
-        text = text.replace("##NEWLINE##", Globals.NEWLINE);
+        text = text.replace("/".concat(StringUtil.NEWLINE), "/");
+        text = text.replace(StringUtil.NEWLINE, " ");
+        text = text.replace("##NEWLINE##", StringUtil.NEWLINE);
 
         ParserResult importerResult = fimp.importEntries(text);
         if(importerResult.hasWarnings()) {

--- a/src/main/java/net/sf/jabref/gui/plaintextimport/TextInputDialog.java
+++ b/src/main/java/net/sf/jabref/gui/plaintextimport/TextInputDialog.java
@@ -125,8 +125,8 @@ import net.sf.jabref.logic.bibtex.BibEntryWriter;
 import net.sf.jabref.logic.bibtex.LatexFieldFormatter;
 import net.sf.jabref.logic.bibtex.LatexFieldFormatterPreferences;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.UpdateField;
-import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.EntryType;
@@ -508,11 +508,11 @@ public class TextInputDialog extends JDialog {
 
         // we have to remove line breaks (but keep empty lines)
         // otherwise, the result is broken
-        text = text.replace(FileUtil.NEWLINE.concat(FileUtil.NEWLINE), "##NEWLINE##");
+        text = text.replace(OS.NEWLINE.concat(OS.NEWLINE), "##NEWLINE##");
         // possible URL line breaks are removed completely.
-        text = text.replace("/".concat(FileUtil.NEWLINE), "/");
-        text = text.replace(FileUtil.NEWLINE, " ");
-        text = text.replace("##NEWLINE##", FileUtil.NEWLINE);
+        text = text.replace("/".concat(OS.NEWLINE), "/");
+        text = text.replace(OS.NEWLINE, " ");
+        text = text.replace("##NEWLINE##", OS.NEWLINE);
 
         ParserResult importerResult = fimp.importEntries(text);
         if(importerResult.hasWarnings()) {

--- a/src/main/java/net/sf/jabref/gui/plaintextimport/TextInputDialog.java
+++ b/src/main/java/net/sf/jabref/gui/plaintextimport/TextInputDialog.java
@@ -126,7 +126,7 @@ import net.sf.jabref.logic.bibtex.LatexFieldFormatter;
 import net.sf.jabref.logic.bibtex.LatexFieldFormatterPreferences;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.UpdateField;
-import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.EntryType;
@@ -508,11 +508,11 @@ public class TextInputDialog extends JDialog {
 
         // we have to remove line breaks (but keep empty lines)
         // otherwise, the result is broken
-        text = text.replace(StringUtil.NEWLINE.concat(StringUtil.NEWLINE), "##NEWLINE##");
+        text = text.replace(FileUtil.NEWLINE.concat(FileUtil.NEWLINE), "##NEWLINE##");
         // possible URL line breaks are removed completely.
-        text = text.replace("/".concat(StringUtil.NEWLINE), "/");
-        text = text.replace(StringUtil.NEWLINE, " ");
-        text = text.replace("##NEWLINE##", StringUtil.NEWLINE);
+        text = text.replace("/".concat(FileUtil.NEWLINE), "/");
+        text = text.replace(FileUtil.NEWLINE, " ");
+        text = text.replace("##NEWLINE##", FileUtil.NEWLINE);
 
         ParserResult importerResult = fimp.importEntries(text);
         if(importerResult.hasWarnings()) {

--- a/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
@@ -38,7 +38,7 @@ import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.layout.format.FileLinkPreferences;
-import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -267,7 +267,7 @@ class FileTab extends JPanel implements PrefsTab {
         }
         prefs.put(JabRefPreferences.NEWLINE, newline);
         // we also have to change Globals variable as globals is not a getter, but a constant
-        StringUtil.NEWLINE = newline;
+        FileUtil.NEWLINE = newline;
 
         prefs.putBoolean(JabRefPreferences.REFORMAT_FILE_ON_SAVE_AND_EXPORT, reformatFileOnSaveAndExport.isSelected());
         prefs.putBoolean(JabRefPreferences.BACKUP, backup.isSelected());

--- a/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
@@ -37,6 +37,8 @@ import net.sf.jabref.gui.actions.BrowseAction;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.layout.format.FileLinkPreferences;
+import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -200,7 +202,7 @@ class FileTab extends JPanel implements PrefsTab {
 
     @Override
     public void setValues() {
-        fileDir.setText(prefs.get(FieldName.FILE + Globals.DIR_SUFFIX));
+        fileDir.setText(prefs.get(FieldName.FILE + FileLinkPreferences.DIR_SUFFIX));
         bibLocAsPrimaryDir.setSelected(prefs.getBoolean(JabRefPreferences.BIB_LOC_AS_PRIMARY_DIR));
         runAutoFileSearch.setSelected(prefs.getBoolean(JabRefPreferences.RUN_AUTOMATIC_FILE_SEARCH));
         allowFileAutoOpenBrowse.setSelected(prefs.getBoolean(JabRefPreferences.ALLOW_FILE_AUTO_OPEN_BROWSE));
@@ -241,7 +243,7 @@ class FileTab extends JPanel implements PrefsTab {
 
     @Override
     public void storeSettings() {
-        prefs.put(FieldName.FILE + Globals.DIR_SUFFIX, fileDir.getText());
+        prefs.put(FieldName.FILE + FileLinkPreferences.DIR_SUFFIX, fileDir.getText());
         prefs.putBoolean(JabRefPreferences.BIB_LOC_AS_PRIMARY_DIR, bibLocAsPrimaryDir.isSelected());
         prefs.putBoolean(JabRefPreferences.RUN_AUTOMATIC_FILE_SEARCH, runAutoFileSearch.isSelected());
         prefs.putBoolean(JabRefPreferences.ALLOW_FILE_AUTO_OPEN_BROWSE, allowFileAutoOpenBrowse.isSelected());
@@ -265,7 +267,7 @@ class FileTab extends JPanel implements PrefsTab {
         }
         prefs.put(JabRefPreferences.NEWLINE, newline);
         // we also have to change Globals variable as globals is not a getter, but a constant
-        Globals.NEWLINE = newline;
+        StringUtil.NEWLINE = newline;
 
         prefs.putBoolean(JabRefPreferences.REFORMAT_FILE_ON_SAVE_AND_EXPORT, reformatFileOnSaveAndExport.isSelected());
         prefs.putBoolean(JabRefPreferences.BACKUP, backup.isSelected());

--- a/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
@@ -38,7 +38,7 @@ import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.layout.format.FileLinkPreferences;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -267,7 +267,7 @@ class FileTab extends JPanel implements PrefsTab {
         }
         prefs.put(JabRefPreferences.NEWLINE, newline);
         // we also have to change Globals variable as globals is not a getter, but a constant
-        FileUtil.NEWLINE = newline;
+        OS.NEWLINE = newline;
 
         prefs.putBoolean(JabRefPreferences.REFORMAT_FILE_ON_SAVE_AND_EXPORT, reformatFileOnSaveAndExport.isSelected());
         prefs.putBoolean(JabRefPreferences.BACKUP, backup.isSelected());

--- a/src/main/java/net/sf/jabref/importer/EntryFromPDFCreator.java
+++ b/src/main/java/net/sf/jabref/importer/EntryFromPDFCreator.java
@@ -14,9 +14,9 @@ import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.xmp.XMPUtil;
 import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.model.entry.InternalBibtexFields;
 import net.sf.jabref.pdfimport.PdfImporter;
 import net.sf.jabref.pdfimport.PdfImporter.ImportPdfFilesResult;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDDocumentInformation;
@@ -97,7 +97,7 @@ public class EntryFromPDFCreator extends EntryFromFileCreator {
                         // default time stamp follows ISO-8601. Reason: https://xkcd.com/1179/
                         String date = new SimpleDateFormat("yyyy-MM-dd")
                                 .format(creationDate.getTime());
-                        appendToField(entry, InternalBibtexFields.TIMESTAMP, date);
+                        appendToField(entry, Globals.prefs.get(JabRefPreferences.TIME_STAMP_FIELD), date);
                     }
 
                     if (pdfDocInfo.getCustomMetadataValue("bibtex/bibtexkey") != null) {

--- a/src/main/java/net/sf/jabref/importer/fetcher/GVKParser.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/GVKParser.java
@@ -337,7 +337,7 @@ public class GVKParser {
         // Dokumenttyp bestimmen und Eintrag anlegen
 
         if (mak.startsWith("As")) {
-            entryType = "misc";
+            entryType = BibEntry.DEFAULT_TYPE;
 
             if (quelle.contains("ISBN")) {
                 entryType = "incollection";
@@ -346,9 +346,9 @@ public class GVKParser {
                 entryType = "article";
             }
         } else if (mak.isEmpty()) {
-            entryType = "misc";
+            entryType = BibEntry.DEFAULT_TYPE;
         } else if (mak.startsWith("O")) {
-            entryType = "misc";
+            entryType = BibEntry.DEFAULT_TYPE;
             // FIXME: online only available in Biblatex
             //entryType = "online";
         }

--- a/src/main/java/net/sf/jabref/importer/fileformat/BiblioscapeImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BiblioscapeImporter.java
@@ -199,9 +199,9 @@ public class BiblioscapeImporter extends ImportFormat {
                     }
                 }
 
-                String bibtexType = "misc";
+                String bibtexType = BibEntry.DEFAULT_TYPE;
                 // to find type, first check TW, then RT
-                for (int i = 1; (i >= 0) && "misc".equals(bibtexType); --i) {
+                for (int i = 1; (i >= 0) && BibEntry.DEFAULT_TYPE.equals(bibtexType); --i) {
                     if (type[i] == null) {
                         continue;
                     }

--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexImporter.java
@@ -24,8 +24,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.importer.ParserResult;
+import net.sf.jabref.logic.exporter.SavePreferences;
 
 /**
  * This importer exists only to enable `--importToOpen someEntry.bib`
@@ -34,6 +34,9 @@ import net.sf.jabref.importer.ParserResult;
  * The metadata is not required to be read here, as this class is NOT called at --import
  */
 public class BibtexImporter extends ImportFormat {
+
+    // Signature written at the top of the .bib file in earlier versions.
+    private static final String SIGNATURE = "This file was created with JabRef";
 
     /**
      * @return true as we have no effective way to decide whether a file is in bibtex format or not. See
@@ -109,17 +112,17 @@ public class BibtexImporter extends ImportFormat {
                 // Only keep the part after %
                 line = line.substring(1).trim();
 
-                if (line.startsWith(Globals.SIGNATURE)) {
+                if (line.startsWith(BibtexImporter.SIGNATURE)) {
                     // Signature line, so keep reading and skip to next line
-                } else if (line.startsWith(Globals.ENCODING_PREFIX)) {
+                } else if (line.startsWith(SavePreferences.ENCODING_PREFIX)) {
                     // Line starts with "Encoding: ", so the rest of the line should contain the name of the encoding
                     // Except if there is already a @ symbol signaling the starting of a BibEntry
                     Integer atSymbolIndex = line.indexOf('@');
                     String encoding;
                     if (atSymbolIndex > 0) {
-                        encoding = line.substring(Globals.ENCODING_PREFIX.length(), atSymbolIndex);
+                        encoding = line.substring(SavePreferences.ENCODING_PREFIX.length(), atSymbolIndex);
                     } else {
-                        encoding = line.substring(Globals.ENCODING_PREFIX.length());
+                        encoding = line.substring(SavePreferences.ENCODING_PREFIX.length());
                     }
 
                     return Optional.of(Charset.forName(encoding));

--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
@@ -34,6 +34,7 @@ import net.sf.jabref.MetaData;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.logic.bibtex.FieldContentParser;
 import net.sf.jabref.logic.bibtex.FieldContentParserPreferences;
+import net.sf.jabref.logic.exporter.SavePreferences;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.KeyCollisionException;
@@ -328,9 +329,9 @@ public class BibtexParser {
         // if there is no entry found, simply return the content (necessary to parse text remaining after the last entry)
         if (indexOfAt == -1) {
             return purgeEOFCharacters(result);
-        } else if(result.contains(Globals.ENCODING_PREFIX)) {
+        } else if(result.contains(SavePreferences.ENCODING_PREFIX)) {
             // purge the encoding line if it exists
-            int runningIndex = result.indexOf(Globals.ENCODING_PREFIX);
+            int runningIndex = result.indexOf(SavePreferences.ENCODING_PREFIX);
             while(runningIndex < indexOfAt) {
                 if(result.charAt(runningIndex) == '\n') {
                     break;

--- a/src/main/java/net/sf/jabref/importer/fileformat/EndnoteImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/EndnoteImporter.java
@@ -107,7 +107,7 @@ public class EndnoteImporter extends ImportFormat {
         for (String entry : entries) {
             hm.clear();
             author = "";
-            type = "misc";
+            type = BibEntry.DEFAULT_TYPE;
             editor = "";
             artnum = "";
 
@@ -169,7 +169,7 @@ public class EndnoteImporter extends ImportFormat {
                     } else if (val.indexOf("Thesis") == 0) {
                         type = "phdthesis";
                     } else {
-                        type = "misc"; //
+                        type = BibEntry.DEFAULT_TYPE; //
                     }
                 } else if ("7".equals(prefix)) {
                     hm.put(FieldName.EDITION, val);

--- a/src/main/java/net/sf/jabref/importer/fileformat/FreeCiteImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/FreeCiteImporter.java
@@ -40,7 +40,7 @@ import net.sf.jabref.JabRefGUI;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.labelpattern.LabelPatternUtil;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.EntryType;
@@ -193,7 +193,7 @@ public class FreeCiteImporter extends ImportFormat {
                                 noteSB.append(ln);
                                 noteSB.append(':');
                                 noteSB.append(parser.getElementText());
-                                noteSB.append(FileUtil.NEWLINE);
+                                noteSB.append(OS.NEWLINE);
                             }
                         }
                         parser.next();
@@ -203,7 +203,7 @@ public class FreeCiteImporter extends ImportFormat {
                         String note;
                         if (e.hasField(FieldName.NOTE)) {
                             // "note" could have been set during the parsing as FreeCite also returns "note"
-                            note = e.getFieldOptional(FieldName.NOTE).get().concat(FileUtil.NEWLINE).concat(noteSB.toString());
+                            note = e.getFieldOptional(FieldName.NOTE).get().concat(OS.NEWLINE).concat(noteSB.toString());
                         } else {
                             note = noteSB.toString();
                         }

--- a/src/main/java/net/sf/jabref/importer/fileformat/FreeCiteImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/FreeCiteImporter.java
@@ -40,7 +40,7 @@ import net.sf.jabref.JabRefGUI;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.labelpattern.LabelPatternUtil;
-import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.EntryType;
@@ -193,7 +193,7 @@ public class FreeCiteImporter extends ImportFormat {
                                 noteSB.append(ln);
                                 noteSB.append(':');
                                 noteSB.append(parser.getElementText());
-                                noteSB.append(StringUtil.NEWLINE);
+                                noteSB.append(FileUtil.NEWLINE);
                             }
                         }
                         parser.next();
@@ -203,7 +203,7 @@ public class FreeCiteImporter extends ImportFormat {
                         String note;
                         if (e.hasField(FieldName.NOTE)) {
                             // "note" could have been set during the parsing as FreeCite also returns "note"
-                            note = e.getFieldOptional(FieldName.NOTE).get().concat(StringUtil.NEWLINE).concat(noteSB.toString());
+                            note = e.getFieldOptional(FieldName.NOTE).get().concat(FileUtil.NEWLINE).concat(noteSB.toString());
                         } else {
                             note = noteSB.toString();
                         }

--- a/src/main/java/net/sf/jabref/importer/fileformat/FreeCiteImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/FreeCiteImporter.java
@@ -40,6 +40,7 @@ import net.sf.jabref.JabRefGUI;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.labelpattern.LabelPatternUtil;
+import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.EntryType;
@@ -192,7 +193,7 @@ public class FreeCiteImporter extends ImportFormat {
                                 noteSB.append(ln);
                                 noteSB.append(':');
                                 noteSB.append(parser.getElementText());
-                                noteSB.append(Globals.NEWLINE);
+                                noteSB.append(StringUtil.NEWLINE);
                             }
                         }
                         parser.next();
@@ -202,7 +203,7 @@ public class FreeCiteImporter extends ImportFormat {
                         String note;
                         if (e.hasField(FieldName.NOTE)) {
                             // "note" could have been set during the parsing as FreeCite also returns "note"
-                            note = e.getFieldOptional(FieldName.NOTE).get().concat(Globals.NEWLINE).concat(noteSB.toString());
+                            note = e.getFieldOptional(FieldName.NOTE).get().concat(StringUtil.NEWLINE).concat(noteSB.toString());
                         } else {
                             note = noteSB.toString();
                         }

--- a/src/main/java/net/sf/jabref/importer/fileformat/IsiImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/IsiImporter.java
@@ -293,7 +293,7 @@ public class IsiImporter extends ImportFormat {
                     } else if (Type.startsWith("Article") || Type.startsWith("Journal") || "article".equals(PT)) {
                         Type = "article";
                     } else {
-                        Type = "misc";
+                        Type = BibEntry.DEFAULT_TYPE;
                     }
                 } else if ("CR".equals(beg)) {
                     hm.put("CitedReferences", value.replace("EOLEOL", " ; ").trim());

--- a/src/main/java/net/sf/jabref/importer/fileformat/MedlinePlainImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/MedlinePlainImporter.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import net.sf.jabref.importer.ParserResult;
-import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.entry.AuthorList;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
@@ -375,7 +375,7 @@ public class MedlinePlainImporter extends ImportFormat {
             if (oldAb == null) {
                 hm.put(FieldName.ABSTRACT, abstractValue);
             } else {
-                hm.put(FieldName.ABSTRACT, oldAb + StringUtil.NEWLINE + abstractValue);
+                hm.put(FieldName.ABSTRACT, oldAb + FileUtil.NEWLINE + abstractValue);
             }
         } else if ("OAB".equals(lab) || "OABL".equals(lab)) {
             hm.put("other-abstract", value);

--- a/src/main/java/net/sf/jabref/importer/fileformat/MedlinePlainImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/MedlinePlainImporter.java
@@ -98,7 +98,7 @@ public class MedlinePlainImporter extends ImportFormat {
                 continue;
             }
 
-            String type = "misc";
+            String type = BibEntry.DEFAULT_TYPE;
             String author = "";
             String editor = "";
             String comment = "";

--- a/src/main/java/net/sf/jabref/importer/fileformat/MedlinePlainImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/MedlinePlainImporter.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import net.sf.jabref.importer.ParserResult;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.entry.AuthorList;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
@@ -375,7 +375,7 @@ public class MedlinePlainImporter extends ImportFormat {
             if (oldAb == null) {
                 hm.put(FieldName.ABSTRACT, abstractValue);
             } else {
-                hm.put(FieldName.ABSTRACT, oldAb + FileUtil.NEWLINE + abstractValue);
+                hm.put(FieldName.ABSTRACT, oldAb + OS.NEWLINE + abstractValue);
             }
         } else if ("OAB".equals(lab) || "OABL".equals(lab)) {
             hm.put("other-abstract", value);

--- a/src/main/java/net/sf/jabref/importer/fileformat/MedlinePlainImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/MedlinePlainImporter.java
@@ -27,8 +27,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.importer.ParserResult;
+import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.AuthorList;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
@@ -375,7 +375,7 @@ public class MedlinePlainImporter extends ImportFormat {
             if (oldAb == null) {
                 hm.put(FieldName.ABSTRACT, abstractValue);
             } else {
-                hm.put(FieldName.ABSTRACT, oldAb + Globals.NEWLINE + abstractValue);
+                hm.put(FieldName.ABSTRACT, oldAb + StringUtil.NEWLINE + abstractValue);
             }
         } else if ("OAB".equals(lab) || "OABL".equals(lab)) {
             hm.put("other-abstract", value);

--- a/src/main/java/net/sf/jabref/importer/fileformat/OvidImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/OvidImporter.java
@@ -214,7 +214,7 @@ public class OvidImporter extends ImportFormat {
             }
 
             // Set the entrytype properly:
-            String entryType = h.containsKey("entrytype") ? h.get("entrytype") : "misc";
+            String entryType = h.containsKey("entrytype") ? h.get("entrytype") : BibEntry.DEFAULT_TYPE;
             h.remove("entrytype");
             if ("book".equals(entryType) && h.containsKey("chaptertitle")) {
                 // This means we have an "incollection" entry.

--- a/src/main/java/net/sf/jabref/importer/fileformat/RisImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/RisImporter.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import net.sf.jabref.importer.ParserResult;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.entry.AuthorList;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
@@ -194,7 +194,7 @@ public class RisImporter extends ImportFormat {
                         if (oldAb == null) {
                             hm.put(FieldName.ABSTRACT, val);
                         } else {
-                            hm.put(FieldName.ABSTRACT, oldAb + FileUtil.NEWLINE + val);
+                            hm.put(FieldName.ABSTRACT, oldAb + OS.NEWLINE + val);
                         }
                     } else if ("UR".equals(lab)) {
                         hm.put(FieldName.URL, val);

--- a/src/main/java/net/sf/jabref/importer/fileformat/RisImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/RisImporter.java
@@ -24,8 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.importer.ParserResult;
+import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.AuthorList;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
@@ -194,7 +194,7 @@ public class RisImporter extends ImportFormat {
                         if (oldAb == null) {
                             hm.put(FieldName.ABSTRACT, val);
                         } else {
-                            hm.put(FieldName.ABSTRACT, oldAb + Globals.NEWLINE + val);
+                            hm.put(FieldName.ABSTRACT, oldAb + StringUtil.NEWLINE + val);
                         }
                     } else if ("UR".equals(lab)) {
                         hm.put(FieldName.URL, val);

--- a/src/main/java/net/sf/jabref/importer/fileformat/RisImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/RisImporter.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import net.sf.jabref.importer.ParserResult;
-import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.entry.AuthorList;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
@@ -194,7 +194,7 @@ public class RisImporter extends ImportFormat {
                         if (oldAb == null) {
                             hm.put(FieldName.ABSTRACT, val);
                         } else {
-                            hm.put(FieldName.ABSTRACT, oldAb + StringUtil.NEWLINE + val);
+                            hm.put(FieldName.ABSTRACT, oldAb + FileUtil.NEWLINE + val);
                         }
                     } else if ("UR".equals(lab)) {
                         hm.put(FieldName.URL, val);

--- a/src/main/java/net/sf/jabref/logic/bibtex/BibEntryWriter.java
+++ b/src/main/java/net/sf/jabref/logic/bibtex/BibEntryWriter.java
@@ -10,7 +10,7 @@ import java.util.TreeSet;
 import java.util.function.Predicate;
 
 import net.sf.jabref.logic.TypedBibEntry;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.database.BibDatabaseMode;
@@ -50,16 +50,16 @@ public class BibEntryWriter {
         }
 
         writeUserComments(entry, out);
-        out.write(FileUtil.NEWLINE);
+        out.write(OS.NEWLINE);
         writeRequiredFieldsFirstRemainingFieldsSecond(entry, out, bibDatabaseMode);
-        out.write(FileUtil.NEWLINE);
+        out.write(OS.NEWLINE);
     }
 
     private void writeUserComments(BibEntry entry, Writer out) throws IOException {
         String userComments = entry.getUserComments();
 
         if(!userComments.isEmpty()) {
-            out.write(userComments + FileUtil.NEWLINE);
+            out.write(userComments + OS.NEWLINE);
         }
     }
 
@@ -131,7 +131,7 @@ public class BibEntryWriter {
 
     private void writeKeyField(BibEntry entry, Writer out) throws IOException {
         String keyField = StringUtil.shaveString(entry.getCiteKey());
-        out.write(keyField + ',' + FileUtil.NEWLINE);
+        out.write(keyField + ',' + OS.NEWLINE);
     }
 
     /**
@@ -151,7 +151,7 @@ public class BibEntryWriter {
 
             try {
                 out.write(fieldFormatter.format(field.get(), name));
-                out.write(',' + FileUtil.NEWLINE);
+                out.write(',' + OS.NEWLINE);
             } catch (IOException ex) {
                 throw new IOException("Error in field '" + name + "': " + ex.getMessage());
             }

--- a/src/main/java/net/sf/jabref/logic/bibtex/BibEntryWriter.java
+++ b/src/main/java/net/sf/jabref/logic/bibtex/BibEntryWriter.java
@@ -10,6 +10,7 @@ import java.util.TreeSet;
 import java.util.function.Predicate;
 
 import net.sf.jabref.logic.TypedBibEntry;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.database.BibDatabaseMode;
@@ -49,16 +50,16 @@ public class BibEntryWriter {
         }
 
         writeUserComments(entry, out);
-        out.write(StringUtil.NEWLINE);
+        out.write(FileUtil.NEWLINE);
         writeRequiredFieldsFirstRemainingFieldsSecond(entry, out, bibDatabaseMode);
-        out.write(StringUtil.NEWLINE);
+        out.write(FileUtil.NEWLINE);
     }
 
     private void writeUserComments(BibEntry entry, Writer out) throws IOException {
         String userComments = entry.getUserComments();
 
         if(!userComments.isEmpty()) {
-            out.write(userComments + StringUtil.NEWLINE);
+            out.write(userComments + FileUtil.NEWLINE);
         }
     }
 
@@ -130,7 +131,7 @@ public class BibEntryWriter {
 
     private void writeKeyField(BibEntry entry, Writer out) throws IOException {
         String keyField = StringUtil.shaveString(entry.getCiteKey());
-        out.write(keyField + ',' + StringUtil.NEWLINE);
+        out.write(keyField + ',' + FileUtil.NEWLINE);
     }
 
     /**
@@ -150,7 +151,7 @@ public class BibEntryWriter {
 
             try {
                 out.write(fieldFormatter.format(field.get(), name));
-                out.write(',' + StringUtil.NEWLINE);
+                out.write(',' + FileUtil.NEWLINE);
             } catch (IOException ex) {
                 throw new IOException("Error in field '" + name + "': " + ex.getMessage());
             }

--- a/src/main/java/net/sf/jabref/logic/bibtex/BibEntryWriter.java
+++ b/src/main/java/net/sf/jabref/logic/bibtex/BibEntryWriter.java
@@ -9,7 +9,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Predicate;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.TypedBibEntry;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.EntryTypes;
@@ -50,16 +49,16 @@ public class BibEntryWriter {
         }
 
         writeUserComments(entry, out);
-        out.write(Globals.NEWLINE);
+        out.write(StringUtil.NEWLINE);
         writeRequiredFieldsFirstRemainingFieldsSecond(entry, out, bibDatabaseMode);
-        out.write(Globals.NEWLINE);
+        out.write(StringUtil.NEWLINE);
     }
 
     private void writeUserComments(BibEntry entry, Writer out) throws IOException {
         String userComments = entry.getUserComments();
 
         if(!userComments.isEmpty()) {
-            out.write(userComments + Globals.NEWLINE);
+            out.write(userComments + StringUtil.NEWLINE);
         }
     }
 
@@ -131,7 +130,7 @@ public class BibEntryWriter {
 
     private void writeKeyField(BibEntry entry, Writer out) throws IOException {
         String keyField = StringUtil.shaveString(entry.getCiteKey());
-        out.write(keyField + ',' + Globals.NEWLINE);
+        out.write(keyField + ',' + StringUtil.NEWLINE);
     }
 
     /**
@@ -151,7 +150,7 @@ public class BibEntryWriter {
 
             try {
                 out.write(fieldFormatter.format(field.get(), name));
-                out.write(',' + Globals.NEWLINE);
+                out.write(',' + StringUtil.NEWLINE);
             } catch (IOException ex) {
                 throw new IOException("Error in field '" + name + "': " + ex.getMessage());
             }

--- a/src/main/java/net/sf/jabref/logic/bibtex/LatexFieldFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/bibtex/LatexFieldFormatter.java
@@ -18,6 +18,7 @@ package net.sf.jabref.logic.bibtex;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.InternalBibtexFields;
 
@@ -76,11 +77,11 @@ public class LatexFieldFormatter {
         String result = content;
 
         // normalize newlines
-        boolean shouldNormalizeNewlines = !result.contains(StringUtil.NEWLINE) && result.contains("\n");
+        boolean shouldNormalizeNewlines = !result.contains(FileUtil.NEWLINE) && result.contains("\n");
         if (shouldNormalizeNewlines) {
             // if we don't have real new lines, but pseudo newlines, we replace them
             // On Win 8.1, this is always true for multiline fields
-            result = result.replace("\n", StringUtil.NEWLINE);
+            result = result.replace("\n", FileUtil.NEWLINE);
         }
 
         // If the field is non-standard, we will just append braces,

--- a/src/main/java/net/sf/jabref/logic/bibtex/LatexFieldFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/bibtex/LatexFieldFormatter.java
@@ -18,7 +18,6 @@ package net.sf.jabref.logic.bibtex;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.InternalBibtexFields;
 
@@ -77,11 +76,11 @@ public class LatexFieldFormatter {
         String result = content;
 
         // normalize newlines
-        boolean shouldNormalizeNewlines = !result.contains(Globals.NEWLINE) && result.contains("\n");
+        boolean shouldNormalizeNewlines = !result.contains(StringUtil.NEWLINE) && result.contains("\n");
         if (shouldNormalizeNewlines) {
             // if we don't have real new lines, but pseudo newlines, we replace them
             // On Win 8.1, this is always true for multiline fields
-            result = result.replace("\n", Globals.NEWLINE);
+            result = result.replace("\n", StringUtil.NEWLINE);
         }
 
         // If the field is non-standard, we will just append braces,

--- a/src/main/java/net/sf/jabref/logic/bibtex/LatexFieldFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/bibtex/LatexFieldFormatter.java
@@ -18,7 +18,7 @@ package net.sf.jabref.logic.bibtex;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.InternalBibtexFields;
 
@@ -77,11 +77,11 @@ public class LatexFieldFormatter {
         String result = content;
 
         // normalize newlines
-        boolean shouldNormalizeNewlines = !result.contains(FileUtil.NEWLINE) && result.contains("\n");
+        boolean shouldNormalizeNewlines = !result.contains(OS.NEWLINE) && result.contains("\n");
         if (shouldNormalizeNewlines) {
             // if we don't have real new lines, but pseudo newlines, we replace them
             // On Win 8.1, this is always true for multiline fields
-            result = result.replace("\n", FileUtil.NEWLINE);
+            result = result.replace("\n", OS.NEWLINE);
         }
 
         // If the field is non-standard, we will just append braces,

--- a/src/main/java/net/sf/jabref/logic/bibtex/comparator/FieldComparator.java
+++ b/src/main/java/net/sf/jabref/logic/bibtex/comparator/FieldComparator.java
@@ -23,7 +23,6 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.config.SaveOrderConfig;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.AuthorList;
@@ -65,7 +64,7 @@ public class FieldComparator implements Comparator<BibEntry> {
 
     public FieldComparator(String field, boolean reversed) {
         this.fieldName = Objects.requireNonNull(field);
-        this.field = fieldName.split(Globals.COL_DEFINITION_FIELD_SEPARATOR);
+        this.field = fieldName.split(FieldName.FIELD_SEPARATOR);
         fieldType = determineFieldType();
         isNumeric = InternalBibtexFields.isNumeric(this.field[0]);
 

--- a/src/main/java/net/sf/jabref/logic/cleanup/RenamePdfCleanup.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/RenamePdfCleanup.java
@@ -76,7 +76,7 @@ public class RenamePdfCleanup implements CleanupJob {
                 newFileList.add(flEntry);
                 continue;
             }
-            String newPath = expandedOldFile.get().getParent().concat(System.getProperty("file.separator"))
+            String newPath = expandedOldFile.get().getParent().concat(FileUtil.FILE_SEPARATOR)
                     .concat(newFilename.toString());
 
             String expandedOldFilePath = expandedOldFile.get().toString();
@@ -107,8 +107,8 @@ public class RenamePdfCleanup implements CleanupJob {
                 if ((parent == null) || databaseContext.getFileDirectory().contains(parent.getAbsolutePath())) {
                     newFileEntryFileName = newFilename.toString();
                 } else {
-                    newFileEntryFileName = parent.toString().concat(System.getProperty("file.separator")).concat(
-                            newFilename.toString());
+                    newFileEntryFileName = parent.toString().concat(FileUtil.FILE_SEPARATOR)
+                            .concat(newFilename.toString());
                 }
                 newFileList.add(new ParsedFileField(description, newFileEntryFileName, type));
             } else {

--- a/src/main/java/net/sf/jabref/logic/cleanup/RenamePdfCleanup.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/RenamePdfCleanup.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.logic.TypedBibEntry;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;
@@ -76,7 +77,7 @@ public class RenamePdfCleanup implements CleanupJob {
                 newFileList.add(flEntry);
                 continue;
             }
-            String newPath = expandedOldFile.get().getParent().concat(FileUtil.FILE_SEPARATOR)
+            String newPath = expandedOldFile.get().getParent().concat(OS.FILE_SEPARATOR)
                     .concat(newFilename.toString());
 
             String expandedOldFilePath = expandedOldFile.get().toString();
@@ -107,7 +108,7 @@ public class RenamePdfCleanup implements CleanupJob {
                 if ((parent == null) || databaseContext.getFileDirectory().contains(parent.getAbsolutePath())) {
                     newFileEntryFileName = newFilename.toString();
                 } else {
-                    newFileEntryFileName = parent.toString().concat(FileUtil.FILE_SEPARATOR)
+                    newFileEntryFileName = parent.toString().concat(OS.FILE_SEPARATOR)
                             .concat(newFilename.toString());
                 }
                 newFileList.add(new ParsedFileField(description, newFileEntryFileName, type));

--- a/src/main/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriter.java
+++ b/src/main/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriter.java
@@ -21,7 +21,6 @@ import java.nio.charset.Charset;
 import java.util.Map;
 
 import net.sf.jabref.BibDatabaseContext;
-import net.sf.jabref.Globals;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.bibtex.BibEntryWriter;
 import net.sf.jabref.logic.bibtex.LatexFieldFormatter;
@@ -151,7 +150,7 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
         // Writes the file encoding information.
         try {
             getWriter().write("% ");
-            getWriter().write(Globals.ENCODING_PREFIX + encoding);
+            getWriter().write(SavePreferences.ENCODING_PREFIX + encoding);
             getWriter().write(OS.NEWLINE);
         } catch (IOException e) {
             throw new SaveException(e);

--- a/src/main/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriter.java
+++ b/src/main/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriter.java
@@ -26,7 +26,7 @@ import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.bibtex.BibEntryWriter;
 import net.sf.jabref.logic.bibtex.LatexFieldFormatter;
 import net.sf.jabref.logic.bibtex.LatexFieldFormatterPreferences;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
@@ -48,9 +48,9 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
     protected void writeEpilogue(String epilogue) throws SaveException {
         if (!StringUtil.isNullOrEmpty(epilogue)) {
             try {
-                getWriter().write(FileUtil.NEWLINE);
+                getWriter().write(OS.NEWLINE);
                 getWriter().write(epilogue);
-                getWriter().write(FileUtil.NEWLINE);
+                getWriter().write(OS.NEWLINE);
             } catch (IOException e) {
                 throw new SaveException(e);
             }
@@ -60,11 +60,11 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
     @Override
     protected void writeMetaDataItem(Map.Entry<String, String> metaItem) throws SaveException {
         StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append(FileUtil.NEWLINE);
+        stringBuilder.append(OS.NEWLINE);
         stringBuilder.append(COMMENT_PREFIX + "{").append(MetaData.META_FLAG).append(metaItem.getKey()).append(":");
         stringBuilder.append(metaItem.getValue());
         stringBuilder.append("}");
-        stringBuilder.append(FileUtil.NEWLINE);
+        stringBuilder.append(OS.NEWLINE);
 
         try {
             getWriter().write(stringBuilder.toString());
@@ -77,10 +77,10 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
     protected void writePreamble(String preamble) throws SaveException {
         if (!StringUtil.isNullOrEmpty(preamble)) {
             try {
-                getWriter().write(FileUtil.NEWLINE);
+                getWriter().write(OS.NEWLINE);
                 getWriter().write(PREAMBLE_PREFIX + "{");
                 getWriter().write(preamble);
-                getWriter().write('}' + FileUtil.NEWLINE);
+                getWriter().write('}' + OS.NEWLINE);
             } catch (IOException e) {
                 throw new SaveException(e);
             }
@@ -100,11 +100,11 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
             // Write user comments
             String userComments = bibtexString.getUserComments();
             if(!userComments.isEmpty()) {
-                getWriter().write(userComments + FileUtil.NEWLINE);
+                getWriter().write(userComments + OS.NEWLINE);
             }
 
             if (isFirstString) {
-                getWriter().write(FileUtil.NEWLINE);
+                getWriter().write(OS.NEWLINE);
             }
 
             getWriter().write(STRING_PREFIX + "{" + bibtexString.getName() + StringUtil
@@ -123,7 +123,7 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
                 }
             }
 
-            getWriter().write("}" + FileUtil.NEWLINE);
+            getWriter().write("}" + OS.NEWLINE);
         } catch (IOException e) {
             throw new SaveException(e);
         }
@@ -132,11 +132,11 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
     @Override
     protected void writeEntryTypeDefinition(CustomEntryType customType) throws SaveException {
         try {
-            getWriter().write(FileUtil.NEWLINE);
+            getWriter().write(OS.NEWLINE);
             getWriter().write(COMMENT_PREFIX + "{");
             getWriter().write(customType.getAsString());
             getWriter().write("}");
-            getWriter().write(FileUtil.NEWLINE);
+            getWriter().write(OS.NEWLINE);
         } catch (IOException e) {
             throw new SaveException(e);
         }
@@ -152,7 +152,7 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
         try {
             getWriter().write("% ");
             getWriter().write(Globals.ENCODING_PREFIX + encoding);
-            getWriter().write(FileUtil.NEWLINE);
+            getWriter().write(OS.NEWLINE);
         } catch (IOException e) {
             throw new SaveException(e);
         }

--- a/src/main/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriter.java
+++ b/src/main/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriter.java
@@ -47,9 +47,9 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
     protected void writeEpilogue(String epilogue) throws SaveException {
         if (!StringUtil.isNullOrEmpty(epilogue)) {
             try {
-                getWriter().write(Globals.NEWLINE);
+                getWriter().write(StringUtil.NEWLINE);
                 getWriter().write(epilogue);
-                getWriter().write(Globals.NEWLINE);
+                getWriter().write(StringUtil.NEWLINE);
             } catch (IOException e) {
                 throw new SaveException(e);
             }
@@ -59,11 +59,11 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
     @Override
     protected void writeMetaDataItem(Map.Entry<String, String> metaItem) throws SaveException {
         StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append(Globals.NEWLINE);
+        stringBuilder.append(StringUtil.NEWLINE);
         stringBuilder.append(COMMENT_PREFIX + "{").append(MetaData.META_FLAG).append(metaItem.getKey()).append(":");
         stringBuilder.append(metaItem.getValue());
         stringBuilder.append("}");
-        stringBuilder.append(Globals.NEWLINE);
+        stringBuilder.append(StringUtil.NEWLINE);
 
         try {
             getWriter().write(stringBuilder.toString());
@@ -76,10 +76,10 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
     protected void writePreamble(String preamble) throws SaveException {
         if (!StringUtil.isNullOrEmpty(preamble)) {
             try {
-                getWriter().write(Globals.NEWLINE);
+                getWriter().write(StringUtil.NEWLINE);
                 getWriter().write(PREAMBLE_PREFIX + "{");
                 getWriter().write(preamble);
-                getWriter().write('}' + Globals.NEWLINE);
+                getWriter().write('}' + StringUtil.NEWLINE);
             } catch (IOException e) {
                 throw new SaveException(e);
             }
@@ -99,11 +99,11 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
             // Write user comments
             String userComments = bibtexString.getUserComments();
             if(!userComments.isEmpty()) {
-                getWriter().write(userComments + Globals.NEWLINE);
+                getWriter().write(userComments + StringUtil.NEWLINE);
             }
 
             if (isFirstString) {
-                getWriter().write(Globals.NEWLINE);
+                getWriter().write(StringUtil.NEWLINE);
             }
 
             getWriter().write(STRING_PREFIX + "{" + bibtexString.getName() + StringUtil
@@ -122,7 +122,7 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
                 }
             }
 
-            getWriter().write("}" + Globals.NEWLINE);
+            getWriter().write("}" + StringUtil.NEWLINE);
         } catch (IOException e) {
             throw new SaveException(e);
         }
@@ -131,11 +131,11 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
     @Override
     protected void writeEntryTypeDefinition(CustomEntryType customType) throws SaveException {
         try {
-            getWriter().write(Globals.NEWLINE);
+            getWriter().write(StringUtil.NEWLINE);
             getWriter().write(COMMENT_PREFIX + "{");
             getWriter().write(customType.getAsString());
             getWriter().write("}");
-            getWriter().write(Globals.NEWLINE);
+            getWriter().write(StringUtil.NEWLINE);
         } catch (IOException e) {
             throw new SaveException(e);
         }
@@ -151,7 +151,7 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
         try {
             getWriter().write("% ");
             getWriter().write(Globals.ENCODING_PREFIX + encoding);
-            getWriter().write(Globals.NEWLINE);
+            getWriter().write(StringUtil.NEWLINE);
         } catch (IOException e) {
             throw new SaveException(e);
         }

--- a/src/main/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriter.java
+++ b/src/main/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriter.java
@@ -26,6 +26,7 @@ import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.bibtex.BibEntryWriter;
 import net.sf.jabref.logic.bibtex.LatexFieldFormatter;
 import net.sf.jabref.logic.bibtex.LatexFieldFormatterPreferences;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
@@ -47,9 +48,9 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
     protected void writeEpilogue(String epilogue) throws SaveException {
         if (!StringUtil.isNullOrEmpty(epilogue)) {
             try {
-                getWriter().write(StringUtil.NEWLINE);
+                getWriter().write(FileUtil.NEWLINE);
                 getWriter().write(epilogue);
-                getWriter().write(StringUtil.NEWLINE);
+                getWriter().write(FileUtil.NEWLINE);
             } catch (IOException e) {
                 throw new SaveException(e);
             }
@@ -59,11 +60,11 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
     @Override
     protected void writeMetaDataItem(Map.Entry<String, String> metaItem) throws SaveException {
         StringBuilder stringBuilder = new StringBuilder();
-        stringBuilder.append(StringUtil.NEWLINE);
+        stringBuilder.append(FileUtil.NEWLINE);
         stringBuilder.append(COMMENT_PREFIX + "{").append(MetaData.META_FLAG).append(metaItem.getKey()).append(":");
         stringBuilder.append(metaItem.getValue());
         stringBuilder.append("}");
-        stringBuilder.append(StringUtil.NEWLINE);
+        stringBuilder.append(FileUtil.NEWLINE);
 
         try {
             getWriter().write(stringBuilder.toString());
@@ -76,10 +77,10 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
     protected void writePreamble(String preamble) throws SaveException {
         if (!StringUtil.isNullOrEmpty(preamble)) {
             try {
-                getWriter().write(StringUtil.NEWLINE);
+                getWriter().write(FileUtil.NEWLINE);
                 getWriter().write(PREAMBLE_PREFIX + "{");
                 getWriter().write(preamble);
-                getWriter().write('}' + StringUtil.NEWLINE);
+                getWriter().write('}' + FileUtil.NEWLINE);
             } catch (IOException e) {
                 throw new SaveException(e);
             }
@@ -99,11 +100,11 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
             // Write user comments
             String userComments = bibtexString.getUserComments();
             if(!userComments.isEmpty()) {
-                getWriter().write(userComments + StringUtil.NEWLINE);
+                getWriter().write(userComments + FileUtil.NEWLINE);
             }
 
             if (isFirstString) {
-                getWriter().write(StringUtil.NEWLINE);
+                getWriter().write(FileUtil.NEWLINE);
             }
 
             getWriter().write(STRING_PREFIX + "{" + bibtexString.getName() + StringUtil
@@ -122,7 +123,7 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
                 }
             }
 
-            getWriter().write("}" + StringUtil.NEWLINE);
+            getWriter().write("}" + FileUtil.NEWLINE);
         } catch (IOException e) {
             throw new SaveException(e);
         }
@@ -131,11 +132,11 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
     @Override
     protected void writeEntryTypeDefinition(CustomEntryType customType) throws SaveException {
         try {
-            getWriter().write(StringUtil.NEWLINE);
+            getWriter().write(FileUtil.NEWLINE);
             getWriter().write(COMMENT_PREFIX + "{");
             getWriter().write(customType.getAsString());
             getWriter().write("}");
-            getWriter().write(StringUtil.NEWLINE);
+            getWriter().write(FileUtil.NEWLINE);
         } catch (IOException e) {
             throw new SaveException(e);
         }
@@ -151,7 +152,7 @@ public class BibtexDatabaseWriter<E extends SaveSession> extends BibDatabaseWrit
         try {
             getWriter().write("% ");
             getWriter().write(Globals.ENCODING_PREFIX + encoding);
-            getWriter().write(StringUtil.NEWLINE);
+            getWriter().write(FileUtil.NEWLINE);
         } catch (IOException e) {
             throw new SaveException(e);
         }

--- a/src/main/java/net/sf/jabref/logic/exporter/FieldFormatterCleanups.java
+++ b/src/main/java/net/sf/jabref/logic/exporter/FieldFormatterCleanups.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.cleanup.FieldFormatterCleanup;
 import net.sf.jabref.logic.formatter.Formatter;
 import net.sf.jabref.logic.formatter.Formatters;
@@ -101,7 +100,7 @@ public class FieldFormatterCleanups {
         // first remove all newlines for easier parsing
         String remainingString = formatterString;
 
-        remainingString = StringUtil.unifyLineBreaksToConfiguredLineBreaks(remainingString).replaceAll(Globals.NEWLINE, "");
+        remainingString = StringUtil.unifyLineBreaksToConfiguredLineBreaks(remainingString).replaceAll(StringUtil.NEWLINE, "");
         try {
             while (startIndex < formatterString.length()) {
                 // read the field name
@@ -191,7 +190,7 @@ public class FieldFormatterCleanups {
         for (Map.Entry<String, List<String>> entry : groupedByField.entrySet()) {
             result.append(entry.getKey());
 
-            StringJoiner joiner = new StringJoiner(",", "[", "]" + Globals.NEWLINE);
+            StringJoiner joiner = new StringJoiner(",", "[", "]" + StringUtil.NEWLINE);
             entry.getValue().forEach(joiner::add);
             result.append(joiner.toString());
         }

--- a/src/main/java/net/sf/jabref/logic/exporter/FieldFormatterCleanups.java
+++ b/src/main/java/net/sf/jabref/logic/exporter/FieldFormatterCleanups.java
@@ -15,6 +15,7 @@ import net.sf.jabref.logic.formatter.IdentityFormatter;
 import net.sf.jabref.logic.formatter.bibtexfields.NormalizeMonthFormatter;
 import net.sf.jabref.logic.formatter.bibtexfields.NormalizePagesFormatter;
 import net.sf.jabref.logic.formatter.bibtexfields.OrdinalsToSuperscriptFormatter;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;
@@ -100,7 +101,7 @@ public class FieldFormatterCleanups {
         // first remove all newlines for easier parsing
         String remainingString = formatterString;
 
-        remainingString = StringUtil.unifyLineBreaksToConfiguredLineBreaks(remainingString).replaceAll(StringUtil.NEWLINE, "");
+        remainingString = StringUtil.unifyLineBreaksToConfiguredLineBreaks(remainingString).replaceAll(FileUtil.NEWLINE, "");
         try {
             while (startIndex < formatterString.length()) {
                 // read the field name
@@ -190,7 +191,7 @@ public class FieldFormatterCleanups {
         for (Map.Entry<String, List<String>> entry : groupedByField.entrySet()) {
             result.append(entry.getKey());
 
-            StringJoiner joiner = new StringJoiner(",", "[", "]" + StringUtil.NEWLINE);
+            StringJoiner joiner = new StringJoiner(",", "[", "]" + FileUtil.NEWLINE);
             entry.getValue().forEach(joiner::add);
             result.append(joiner.toString());
         }

--- a/src/main/java/net/sf/jabref/logic/exporter/FieldFormatterCleanups.java
+++ b/src/main/java/net/sf/jabref/logic/exporter/FieldFormatterCleanups.java
@@ -15,7 +15,7 @@ import net.sf.jabref.logic.formatter.IdentityFormatter;
 import net.sf.jabref.logic.formatter.bibtexfields.NormalizeMonthFormatter;
 import net.sf.jabref.logic.formatter.bibtexfields.NormalizePagesFormatter;
 import net.sf.jabref.logic.formatter.bibtexfields.OrdinalsToSuperscriptFormatter;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;
@@ -101,7 +101,7 @@ public class FieldFormatterCleanups {
         // first remove all newlines for easier parsing
         String remainingString = formatterString;
 
-        remainingString = StringUtil.unifyLineBreaksToConfiguredLineBreaks(remainingString).replaceAll(FileUtil.NEWLINE, "");
+        remainingString = StringUtil.unifyLineBreaksToConfiguredLineBreaks(remainingString).replaceAll(OS.NEWLINE, "");
         try {
             while (startIndex < formatterString.length()) {
                 // read the field name
@@ -191,7 +191,7 @@ public class FieldFormatterCleanups {
         for (Map.Entry<String, List<String>> entry : groupedByField.entrySet()) {
             result.append(entry.getKey());
 
-            StringJoiner joiner = new StringJoiner(",", "[", "]" + FileUtil.NEWLINE);
+            StringJoiner joiner = new StringJoiner(",", "[", "]" + OS.NEWLINE);
             entry.getValue().forEach(joiner::add);
             result.append(joiner.toString());
         }

--- a/src/main/java/net/sf/jabref/logic/exporter/SavePreferences.java
+++ b/src/main/java/net/sf/jabref/logic/exporter/SavePreferences.java
@@ -8,6 +8,9 @@ import net.sf.jabref.preferences.JabRefPreferences;
 
 public class SavePreferences {
 
+    // Encoding written at the top of the .bib file.
+    public static final String ENCODING_PREFIX = "Encoding: ";
+
     private final boolean reformatFile;
     private final boolean saveInOriginalOrder;
     private final SaveOrderConfig saveOrder;

--- a/src/main/java/net/sf/jabref/logic/layout/LayoutEntry.java
+++ b/src/main/java/net/sf/jabref/logic/layout/LayoutEntry.java
@@ -616,10 +616,7 @@ class LayoutEntry {
                 continue;
             }
 
-            // If not found throw exception...
-            //return new LayoutFormatter[] {new NotFoundFormatter(className)};
             results.add(new NotFoundFormatter(className));
-            //throw new Exception(Localization.lang("Formatter not found") + ": "+ className);
         }
 
         return results;

--- a/src/main/java/net/sf/jabref/logic/layout/LayoutEntry.java
+++ b/src/main/java/net/sf/jabref/logic/layout/LayoutEntry.java
@@ -619,7 +619,7 @@ class LayoutEntry {
             // If not found throw exception...
             //return new LayoutFormatter[] {new NotFoundFormatter(className)};
             results.add(new NotFoundFormatter(className));
-            //throw new Exception(Globals.lang("Formatter not found") + ": "+ className);
+            //throw new Exception(Localization.lang("Formatter not found") + ": "+ className);
         }
 
         return results;

--- a/src/main/java/net/sf/jabref/logic/layout/format/FileLinkPreferences.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/FileLinkPreferences.java
@@ -3,7 +3,6 @@ package net.sf.jabref.logic.layout.format;
 import java.util.Collections;
 import java.util.List;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -11,6 +10,7 @@ public class FileLinkPreferences {
 
     private final List<String> generatedDirForDatabase;
     private final List<String> fileDirForDatabase;
+    public static final String DIR_SUFFIX = "Directory";
 
 
     public FileLinkPreferences(List<String> generatedDirForDatabase, List<String> fileDirForDatabase) {
@@ -19,7 +19,7 @@ public class FileLinkPreferences {
     }
 
     public static FileLinkPreferences fromPreferences(JabRefPreferences prefs) {
-        return new FileLinkPreferences(Collections.singletonList(prefs.get(FieldName.FILE + Globals.DIR_SUFFIX)),
+        return new FileLinkPreferences(Collections.singletonList(prefs.get(FieldName.FILE + FileLinkPreferences.DIR_SUFFIX)),
                 prefs.fileDirForDatabase);
     }
 

--- a/src/main/java/net/sf/jabref/logic/layout/format/HTMLChars.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/HTMLChars.java
@@ -17,7 +17,6 @@ package net.sf.jabref.logic.layout.format;
 
 import java.util.Map;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.layout.LayoutFormatter;
 import net.sf.jabref.logic.util.strings.HTMLUnicodeConversionMaps;
 import net.sf.jabref.logic.util.strings.StringUtil;
@@ -67,7 +66,7 @@ public class HTMLChars implements LayoutFormatter {
             } else if (!incommand && ((c == '{') || (c == '}'))) {
                 // Swallow the brace.
             } else if (Character.isLetter(c) || (c == '%')
-                    || Globals.SPECIAL_COMMAND_CHARS.contains(String.valueOf(c))) {
+                    || StringUtil.SPECIAL_COMMAND_CHARS.contains(String.valueOf(c))) {
                 escaped = false;
 
                 if (!incommand) {
@@ -75,7 +74,7 @@ public class HTMLChars implements LayoutFormatter {
                 } else {
                     currentCommand.append(c);
                     testCharCom: if ((currentCommand.length() == 1)
-                            && Globals.SPECIAL_COMMAND_CHARS.contains(currentCommand.toString())) {
+                            && StringUtil.SPECIAL_COMMAND_CHARS.contains(currentCommand.toString())) {
                         // This indicates that we are in a command of the type
                         // \^o or \~{n}
                         if (i >= (field.length() - 1)) {

--- a/src/main/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatter.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import net.sf.jabref.logic.formatter.Formatter;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.layout.LayoutFormatter;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.logic.util.strings.HTMLUnicodeConversionMaps;
 import net.sf.jabref.logic.util.strings.StringUtil;
 
@@ -224,7 +225,7 @@ public class LatexToUnicodeFormatter implements LayoutFormatter, Formatter {
             }
         }
 
-        return sb.toString().replace("&amp;", "&").replace("<p>", StringUtil.NEWLINE).replace("&dollar;", "$").replace("~",
+        return sb.toString().replace("&amp;", "&").replace("<p>", FileUtil.NEWLINE).replace("&dollar;", "$").replace("~",
                 "\u00A0");
     }
 

--- a/src/main/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatter.java
@@ -17,7 +17,6 @@ package net.sf.jabref.logic.layout.format;
 
 import java.util.Map;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.formatter.Formatter;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.layout.LayoutFormatter;
@@ -83,7 +82,7 @@ public class LatexToUnicodeFormatter implements LayoutFormatter, Formatter {
             } else if (!incommand && ((c == '{') || (c == '}'))) {
                 // Swallow the brace.
             } else if (Character.isLetter(c) || (c == '%')
-                    || Globals.SPECIAL_COMMAND_CHARS.contains(String.valueOf(c))) {
+                    || StringUtil.SPECIAL_COMMAND_CHARS.contains(String.valueOf(c))) {
                 escaped = false;
 
                 if (!incommand) {
@@ -91,7 +90,7 @@ public class LatexToUnicodeFormatter implements LayoutFormatter, Formatter {
                 } else {
                     currentCommand.append(c);
                     if ((currentCommand.length() == 1)
-                            && Globals.SPECIAL_COMMAND_CHARS.contains(currentCommand.toString())
+                            && StringUtil.SPECIAL_COMMAND_CHARS.contains(currentCommand.toString())
                             && !(i >= (field.length() - 1))) {
                         // This indicates that we are in a command of the type
                         // \^o or \~{n}
@@ -225,7 +224,7 @@ public class LatexToUnicodeFormatter implements LayoutFormatter, Formatter {
             }
         }
 
-        return sb.toString().replace("&amp;", "&").replace("<p>", Globals.NEWLINE).replace("&dollar;", "$").replace("~",
+        return sb.toString().replace("&amp;", "&").replace("<p>", StringUtil.NEWLINE).replace("&dollar;", "$").replace("~",
                 "\u00A0");
     }
 

--- a/src/main/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatter.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import net.sf.jabref.logic.formatter.Formatter;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.layout.LayoutFormatter;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.strings.HTMLUnicodeConversionMaps;
 import net.sf.jabref.logic.util.strings.StringUtil;
 
@@ -225,7 +225,7 @@ public class LatexToUnicodeFormatter implements LayoutFormatter, Formatter {
             }
         }
 
-        return sb.toString().replace("&amp;", "&").replace("<p>", FileUtil.NEWLINE).replace("&dollar;", "$").replace("~",
+        return sb.toString().replace("&amp;", "&").replace("<p>", OS.NEWLINE).replace("&dollar;", "$").replace("~",
                 "\u00A0");
     }
 

--- a/src/main/java/net/sf/jabref/logic/layout/format/RTFChars.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/RTFChars.java
@@ -15,10 +15,10 @@
 */
 package net.sf.jabref.logic.layout.format;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.layout.LayoutFormatter;
 import net.sf.jabref.logic.layout.StringInt;
 import net.sf.jabref.logic.util.strings.RtfCharMap;
+import net.sf.jabref.logic.util.strings.StringUtil;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -65,13 +65,13 @@ public class RTFChars implements LayoutFormatter {
             } else if (!incommand && ((c == '{') || (c == '}'))) {
                 // Swallow the brace.
             } else if (Character.isLetter(c)
-                    || Globals.SPECIAL_COMMAND_CHARS.contains(String.valueOf(c))) {
+                    || StringUtil.SPECIAL_COMMAND_CHARS.contains(String.valueOf(c))) {
                 escaped = false;
                 if (incommand) {
                     // Else we are in a command, and should not keep the letter.
                     currentCommand.append(c);
                     testCharCom: if ((currentCommand.length() == 1)
-                            && Globals.SPECIAL_COMMAND_CHARS.contains(currentCommand.toString())) {
+                            && StringUtil.SPECIAL_COMMAND_CHARS.contains(currentCommand.toString())) {
                         // This indicates that we are in a command of the type
                         // \^o or \~{n}
                         if (i >= (field.length() - 1)) {

--- a/src/main/java/net/sf/jabref/logic/layout/format/RemoveLatexCommands.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/RemoveLatexCommands.java
@@ -15,8 +15,8 @@
 */
 package net.sf.jabref.logic.layout.format;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.layout.LayoutFormatter;
+import net.sf.jabref.logic.util.strings.StringUtil;
 
 public class RemoveLatexCommands implements LayoutFormatter {
 
@@ -42,12 +42,12 @@ public class RemoveLatexCommands implements LayoutFormatter {
             } else if (!incommand && ((c == '{') || (c == '}'))) {
                 // Swallow the brace.
             } else if (Character.isLetter(c) ||
-                    Globals.SPECIAL_COMMAND_CHARS.contains(String.valueOf(c))) {
+                    StringUtil.SPECIAL_COMMAND_CHARS.contains(String.valueOf(c))) {
                 escaped = false;
                 if (incommand) {
                     currentCommand.append(c);
                     if ((currentCommand.length() == 1)
-                            && Globals.SPECIAL_COMMAND_CHARS.contains(currentCommand.toString())) {
+                            && StringUtil.SPECIAL_COMMAND_CHARS.contains(currentCommand.toString())) {
                         // This indicates that we are in a command of the type \^o or \~{n}
                         incommand = false;
                         escaped = false;

--- a/src/main/java/net/sf/jabref/logic/layout/format/RisAuthors.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/RisAuthors.java
@@ -16,7 +16,7 @@
 package net.sf.jabref.logic.layout.format;
 
 import net.sf.jabref.logic.layout.ParamLayoutFormatter;
-import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.entry.AuthorList;
 
 public class RisAuthors implements ParamLayoutFormatter {
@@ -36,7 +36,7 @@ public class RisAuthors implements ParamLayoutFormatter {
             sb.append("  - ");
             sb.append(authors[i]);
             if (i < authors.length - 1) {
-                sb.append(StringUtil.NEWLINE);
+                sb.append(FileUtil.NEWLINE);
             }
         }
         return sb.toString();

--- a/src/main/java/net/sf/jabref/logic/layout/format/RisAuthors.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/RisAuthors.java
@@ -15,8 +15,8 @@
 */
 package net.sf.jabref.logic.layout.format;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.layout.ParamLayoutFormatter;
+import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.AuthorList;
 
 public class RisAuthors implements ParamLayoutFormatter {
@@ -36,7 +36,7 @@ public class RisAuthors implements ParamLayoutFormatter {
             sb.append("  - ");
             sb.append(authors[i]);
             if (i < authors.length - 1) {
-                sb.append(Globals.NEWLINE);
+                sb.append(StringUtil.NEWLINE);
             }
         }
         return sb.toString();

--- a/src/main/java/net/sf/jabref/logic/layout/format/RisAuthors.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/RisAuthors.java
@@ -16,7 +16,7 @@
 package net.sf.jabref.logic.layout.format;
 
 import net.sf.jabref.logic.layout.ParamLayoutFormatter;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.entry.AuthorList;
 
 public class RisAuthors implements ParamLayoutFormatter {
@@ -36,7 +36,7 @@ public class RisAuthors implements ParamLayoutFormatter {
             sb.append("  - ");
             sb.append(authors[i]);
             if (i < authors.length - 1) {
-                sb.append(FileUtil.NEWLINE);
+                sb.append(OS.NEWLINE);
             }
         }
         return sb.toString();

--- a/src/main/java/net/sf/jabref/logic/layout/format/RisKeywords.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/RisKeywords.java
@@ -17,8 +17,8 @@ package net.sf.jabref.logic.layout.format;
 
 import java.util.Set;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.layout.LayoutFormatter;
+import net.sf.jabref.logic.util.strings.StringUtil;
 
 public class RisKeywords implements LayoutFormatter {
 
@@ -34,7 +34,7 @@ public class RisKeywords implements LayoutFormatter {
             sb.append("KW  - ");
             sb.append(keyword);
             if (i < (keywords.size() - 1)) {
-                sb.append(Globals.NEWLINE);
+                sb.append(StringUtil.NEWLINE);
             }
             i++;
         }

--- a/src/main/java/net/sf/jabref/logic/layout/format/RisKeywords.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/RisKeywords.java
@@ -18,7 +18,7 @@ package net.sf.jabref.logic.layout.format;
 import java.util.Set;
 
 import net.sf.jabref.logic.layout.LayoutFormatter;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 
 public class RisKeywords implements LayoutFormatter {
 
@@ -34,7 +34,7 @@ public class RisKeywords implements LayoutFormatter {
             sb.append("KW  - ");
             sb.append(keyword);
             if (i < (keywords.size() - 1)) {
-                sb.append(FileUtil.NEWLINE);
+                sb.append(OS.NEWLINE);
             }
             i++;
         }

--- a/src/main/java/net/sf/jabref/logic/layout/format/RisKeywords.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/RisKeywords.java
@@ -18,7 +18,7 @@ package net.sf.jabref.logic.layout.format;
 import java.util.Set;
 
 import net.sf.jabref.logic.layout.LayoutFormatter;
-import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.logic.util.io.FileUtil;
 
 public class RisKeywords implements LayoutFormatter {
 
@@ -34,7 +34,7 @@ public class RisKeywords implements LayoutFormatter {
             sb.append("KW  - ");
             sb.append(keyword);
             if (i < (keywords.size() - 1)) {
-                sb.append(StringUtil.NEWLINE);
+                sb.append(FileUtil.NEWLINE);
             }
             i++;
         }

--- a/src/main/java/net/sf/jabref/logic/openoffice/OOBibStyle.java
+++ b/src/main/java/net/sf/jabref/logic/openoffice/OOBibStyle.java
@@ -729,7 +729,7 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
      */
     private String getCitationMarkerField(BibEntry entry, BibDatabase database, String field) {
         String authorField = getStringCitProperty(AUTHOR_FIELD);
-        String[] fields = field.split("/");
+        String[] fields = field.split(FieldName.FIELD_SEPARATOR);
         for (String s : fields) {
             String content = BibDatabase.getResolvedField(s, entry, database);
 

--- a/src/main/java/net/sf/jabref/logic/openoffice/OOPreFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/openoffice/OOPreFormatter.java
@@ -17,7 +17,6 @@ package net.sf.jabref.logic.openoffice;
 
 import java.util.Map;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.layout.LayoutFormatter;
 import net.sf.jabref.logic.util.strings.HTMLUnicodeConversionMaps;
 import net.sf.jabref.logic.util.strings.StringUtil;
@@ -71,7 +70,7 @@ public class OOPreFormatter implements LayoutFormatter {
                 //Swallow braces, necessary for replacing encoded characters
 
             } else if (Character.isLetter(c) || (c == '%')
-                    || Globals.SPECIAL_COMMAND_CHARS.contains(String.valueOf(c))) {
+                    || StringUtil.SPECIAL_COMMAND_CHARS.contains(String.valueOf(c))) {
                 escaped = false;
 
                 if (!incommand) {
@@ -79,7 +78,7 @@ public class OOPreFormatter implements LayoutFormatter {
                 } else {
                     currentCommand.append(c);
                     testCharCom: if ((currentCommand.length() == 1)
-                            && Globals.SPECIAL_COMMAND_CHARS.contains(currentCommand.toString())) {
+                            && StringUtil.SPECIAL_COMMAND_CHARS.contains(currentCommand.toString())) {
                         // This indicates that we are in a command of the type
                         // \^o or \~{n}
                         if (i >= (finalResult.length() - 1)) {

--- a/src/main/java/net/sf/jabref/logic/util/OS.java
+++ b/src/main/java/net/sf/jabref/logic/util/OS.java
@@ -25,4 +25,11 @@ public class OS {
     public static final boolean LINUX = OS_NAME.startsWith("linux");
     public static final boolean WINDOWS = OS_NAME.startsWith("win");
     public static final boolean OS_X = OS_NAME.startsWith("mac");
+
+    // File separator obtained from system
+    public static final String FILE_SEPARATOR = System.getProperty("file.separator");
+
+    // Newlines
+    // will be overridden in initialization due to feature #857 @ JabRef.java
+    public static String NEWLINE = System.lineSeparator();
 }

--- a/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
@@ -56,13 +56,6 @@ public class FileUtil {
 
     private static final Log LOGGER = LogFactory.getLog(FileUtil.class);
 
-    // Newlines
-    // will be overridden in initialization due to feature #857 @ JabRef.java
-    public static String NEWLINE = System.lineSeparator();
-
-    // File separator obtained from system
-    public static final String FILE_SEPARATOR = System.getProperty("file.separator");
-
     private static final Pattern SLASH = Pattern.compile("/");
     private static final Pattern BACKSLASH = Pattern.compile("\\\\");
 
@@ -249,10 +242,10 @@ public class FileUtil {
             return Optional.of(file);
         }
 
-        if (dir.endsWith(FILE_SEPARATOR)) {
+        if (dir.endsWith(OS.FILE_SEPARATOR)) {
             name = dir + name;
         } else {
-            name = dir + FILE_SEPARATOR + name;
+            name = dir + OS.FILE_SEPARATOR + name;
         }
 
         // fix / and \ problems:
@@ -311,8 +304,8 @@ public class FileUtil {
             longName = fileName.toString();
         }
 
-        if (!dir.endsWith(FILE_SEPARATOR)) {
-            dir = dir.concat(FILE_SEPARATOR);
+        if (!dir.endsWith(OS.FILE_SEPARATOR)) {
+            dir = dir.concat(OS.FILE_SEPARATOR);
         }
 
         if (longName.startsWith(dir)) {

--- a/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
@@ -56,7 +56,13 @@ public class FileUtil {
 
     private static final Log LOGGER = LogFactory.getLog(FileUtil.class);
 
-    private static final String FILE_SEPARATOR = System.getProperty("file.separator");
+    // Newlines
+    // will be overridden in initialization due to feature #857 @ JabRef.java
+    public static String NEWLINE = System.lineSeparator();
+
+    // File separator obtained from system
+    public static final String FILE_SEPARATOR = System.getProperty("file.separator");
+
     private static final Pattern SLASH = Pattern.compile("/");
     private static final Pattern BACKSLASH = Pattern.compile("\\\\");
 

--- a/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
@@ -23,7 +23,7 @@ import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 
 import com.google.common.base.CharMatcher;
 import org.apache.commons.lang3.StringUtils;
@@ -179,12 +179,12 @@ public class StringUtil {
         for (int i = 1; i < lines.length; i++) {
 
             if (lines[i].trim().isEmpty()) {
-                result.append(FileUtil.NEWLINE);
+                result.append(OS.NEWLINE);
                 result.append('\t');
             } else {
-                result.append(FileUtil.NEWLINE);
+                result.append(OS.NEWLINE);
                 result.append('\t');
-                result.append(FileUtil.NEWLINE);
+                result.append(OS.NEWLINE);
                 result.append('\t');
                 // remove all whitespace at the end of the string, this especially includes \r created when the field content has \r\n as line separator
                 String line = CharMatcher.WHITESPACE.trimTrailingFrom(lines[i]);
@@ -207,8 +207,8 @@ public class StringUtil {
             }
 
             result.deleteCharAt(current);
-            result.insert(current, FileUtil.NEWLINE + "\t");
-            length = current + FileUtil.NEWLINE.length();
+            result.insert(current, OS.NEWLINE + "\t");
+            length = current + OS.NEWLINE.length();
 
         }
     }
@@ -414,7 +414,7 @@ public class StringUtil {
      * @return a String with only Globals.NEWLINE as line breaks
      */
     public static String unifyLineBreaksToConfiguredLineBreaks(String s) {
-        return LINE_BREAKS.matcher(s).replaceAll(FileUtil.NEWLINE);
+        return LINE_BREAKS.matcher(s).replaceAll(OS.NEWLINE);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
@@ -23,12 +23,17 @@ import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import net.sf.jabref.Globals;
-
 import com.google.common.base.CharMatcher;
 import org.apache.commons.lang3.StringUtils;
 
 public class StringUtil {
+
+    // Non-letters which are used to denote accents in LaTeX-commands, e.g., in {\"{a}}
+    public static final String SPECIAL_COMMAND_CHARS = "\"`^~'=.|";
+
+    // Newlines
+    // will be overridden in initialization due to feature #857 @ JabRef.java
+    public static String NEWLINE = System.lineSeparator();
 
     // contains all possible line breaks, not omitting any break such as "\\n"
     private static final Pattern LINE_BREAKS = Pattern.compile("\\r\\n|\\r|\\n");
@@ -176,12 +181,12 @@ public class StringUtil {
         for (int i = 1; i < lines.length; i++) {
 
             if (lines[i].trim().isEmpty()) {
-                result.append(Globals.NEWLINE);
+                result.append(StringUtil.NEWLINE);
                 result.append('\t');
             } else {
-                result.append(Globals.NEWLINE);
+                result.append(StringUtil.NEWLINE);
                 result.append('\t');
-                result.append(Globals.NEWLINE);
+                result.append(StringUtil.NEWLINE);
                 result.append('\t');
                 // remove all whitespace at the end of the string, this especially includes \r created when the field content has \r\n as line separator
                 String line = CharMatcher.WHITESPACE.trimTrailingFrom(lines[i]);
@@ -204,8 +209,8 @@ public class StringUtil {
             }
 
             result.deleteCharAt(current);
-            result.insert(current, Globals.NEWLINE + "\t");
-            length = current + Globals.NEWLINE.length();
+            result.insert(current, StringUtil.NEWLINE + "\t");
+            length = current + StringUtil.NEWLINE.length();
 
         }
     }
@@ -411,7 +416,7 @@ public class StringUtil {
      * @return a String with only Globals.NEWLINE as line breaks
      */
     public static String unifyLineBreaksToConfiguredLineBreaks(String s) {
-        return LINE_BREAKS.matcher(s).replaceAll(Globals.NEWLINE);
+        return LINE_BREAKS.matcher(s).replaceAll(StringUtil.NEWLINE);
     }
 
     /**
@@ -656,7 +661,7 @@ public class StringUtil {
     }
 
     public static boolean isNullOrEmpty(String toTest) {
-        return (toTest == null || toTest.isEmpty());
+        return ((toTest == null) || toTest.isEmpty());
     }
 
     public static boolean isNotBlank(Optional<String> string) {
@@ -666,4 +671,5 @@ public class StringUtil {
     public static boolean isNotBlank(String string) {
         return StringUtils.isNotBlank(string);
     }
+
 }

--- a/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
@@ -23,6 +23,8 @@ import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import net.sf.jabref.logic.util.io.FileUtil;
+
 import com.google.common.base.CharMatcher;
 import org.apache.commons.lang3.StringUtils;
 
@@ -30,10 +32,6 @@ public class StringUtil {
 
     // Non-letters which are used to denote accents in LaTeX-commands, e.g., in {\"{a}}
     public static final String SPECIAL_COMMAND_CHARS = "\"`^~'=.|";
-
-    // Newlines
-    // will be overridden in initialization due to feature #857 @ JabRef.java
-    public static String NEWLINE = System.lineSeparator();
 
     // contains all possible line breaks, not omitting any break such as "\\n"
     private static final Pattern LINE_BREAKS = Pattern.compile("\\r\\n|\\r|\\n");
@@ -181,12 +179,12 @@ public class StringUtil {
         for (int i = 1; i < lines.length; i++) {
 
             if (lines[i].trim().isEmpty()) {
-                result.append(StringUtil.NEWLINE);
+                result.append(FileUtil.NEWLINE);
                 result.append('\t');
             } else {
-                result.append(StringUtil.NEWLINE);
+                result.append(FileUtil.NEWLINE);
                 result.append('\t');
-                result.append(StringUtil.NEWLINE);
+                result.append(FileUtil.NEWLINE);
                 result.append('\t');
                 // remove all whitespace at the end of the string, this especially includes \r created when the field content has \r\n as line separator
                 String line = CharMatcher.WHITESPACE.trimTrailingFrom(lines[i]);
@@ -209,8 +207,8 @@ public class StringUtil {
             }
 
             result.deleteCharAt(current);
-            result.insert(current, StringUtil.NEWLINE + "\t");
-            length = current + StringUtil.NEWLINE.length();
+            result.insert(current, FileUtil.NEWLINE + "\t");
+            length = current + FileUtil.NEWLINE.length();
 
         }
     }
@@ -416,7 +414,7 @@ public class StringUtil {
      * @return a String with only Globals.NEWLINE as line breaks
      */
     public static String unifyLineBreaksToConfiguredLineBreaks(String s) {
-        return LINE_BREAKS.matcher(s).replaceAll(StringUtil.NEWLINE);
+        return LINE_BREAKS.matcher(s).replaceAll(FileUtil.NEWLINE);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/strings/StringUtil.java
@@ -402,16 +402,16 @@ public class StringUtil {
     }
 
     /**
-     * Replaces all platform-dependent line breaks by Globals.NEWLINE line breaks.
+     * Replaces all platform-dependent line breaks by OS.NEWLINE line breaks.
      *
      * We do NOT use UNIX line breaks as the user explicitly configures its linebreaks and this method is used in bibtex field writing
      *
      * <example>
-     * Legacy Macintosh \r -> Globals.NEWLINE
-     * Windows \r\n -> Globals.NEWLINE
+     * Legacy Macintosh \r -> OS.NEWLINE
+     * Windows \r\n -> OS.NEWLINE
      * </example>
      *
-     * @return a String with only Globals.NEWLINE as line breaks
+     * @return a String with only OS.NEWLINE as line breaks
      */
     public static String unifyLineBreaksToConfiguredLineBreaks(String s) {
         return LINE_BREAKS.matcher(s).replaceAll(OS.NEWLINE);

--- a/src/main/java/net/sf/jabref/logic/xmp/XMPUtil.java
+++ b/src/main/java/net/sf/jabref/logic/xmp/XMPUtil.java
@@ -197,7 +197,7 @@ public class XMPUtil {
 
                     BibEntry entry = bib.getBibtexEntry();
                     if (entry.getType() == null) {
-                        entry.setType("misc");
+                        entry.setType(BibEntry.DEFAULT_TYPE);
                     }
                     result.add(entry);
                 }
@@ -212,7 +212,7 @@ public class XMPUtil {
 
                         if (entry.isPresent()) {
                             if (entry.get().getType() == null) {
-                                entry.get().setType("misc");
+                                entry.get().setType(BibEntry.DEFAULT_TYPE);
                             }
                             result.add(entry.get());
                         }
@@ -259,7 +259,7 @@ public class XMPUtil {
             PDDocumentInformation di) {
 
         BibEntry entry = new BibEntry();
-        entry.setType("misc");
+        entry.setType(BibEntry.DEFAULT_TYPE);
 
         String s = di.getAuthor();
         if (s != null) {

--- a/src/main/java/net/sf/jabref/migrations/FileLinksUpgradeWarning.java
+++ b/src/main/java/net/sf/jabref/migrations/FileLinksUpgradeWarning.java
@@ -35,6 +35,7 @@ import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.PostOpenAction;
 import net.sf.jabref.logic.cleanup.UpgradePdfPsToFileCleanup;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.layout.format.FileLinkPreferences;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
@@ -78,7 +79,7 @@ public class FileLinksUpgradeWarning implements PostOpenAction {
         // Only offer to upgrade links if the pdf/ps fields are used:
         offerChangeDatabase = linksFound(pr.getDatabase(), FileLinksUpgradeWarning.FIELDS_TO_LOOK_FOR);
         // If the "file" directory is not set, offer to migrate pdf/ps dir:
-        offerSetFileDir = !Globals.prefs.hasKey(FieldName.FILE + Globals.DIR_SUFFIX)
+        offerSetFileDir = !Globals.prefs.hasKey(FieldName.FILE + FileLinkPreferences.DIR_SUFFIX)
                 && (Globals.prefs.hasKey("pdfDirectory") || Globals.prefs.hasKey("psDirectory"));
 
         // First check if this warning is disabled:
@@ -200,7 +201,7 @@ public class FileLinksUpgradeWarning implements PostOpenAction {
         }
 
         if (fileDir != null) {
-            Globals.prefs.put(FieldName.FILE + Globals.DIR_SUFFIX, fileDir);
+            Globals.prefs.put(FieldName.FILE + FileLinkPreferences.DIR_SUFFIX, fileDir);
         }
 
         if (upgradePrefs) {

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -49,7 +49,7 @@ public class BibEntry implements Cloneable {
     public static final String TYPE_HEADER = "entrytype";
     public static final String KEY_FIELD = "bibtexkey";
     protected static final String ID_FIELD = "id";
-    private static final String DEFAULT_TYPE = "misc";
+    public static final String DEFAULT_TYPE = "misc";
 
     private String id;
     private String type;

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -410,13 +410,12 @@ public class BibEntry implements Cloneable {
      * @return true if all fields are set or could be resolved, false otherwise.
      */
     public boolean allFieldsPresent(List<String> allFields, BibDatabase database) {
-        final String orSeparator = "/";
 
         for (String field : allFields) {
             String fieldName = toLowerCase(field);
             // OR fields
-            if (fieldName.contains(orSeparator)) {
-                String[] altFields = field.split(orSeparator);
+            if (fieldName.contains(FieldName.FIELD_SEPARATOR)) {
+                String[] altFields = field.split(FieldName.FIELD_SEPARATOR);
 
                 if (!atLeastOnePresent(altFields, database)) {
                     return false;

--- a/src/main/java/net/sf/jabref/model/entry/EntryType.java
+++ b/src/main/java/net/sf/jabref/model/entry/EntryType.java
@@ -41,7 +41,7 @@ public interface EntryType extends Comparable<EntryType> {
      */
     default List<String> getRequiredFieldsFlat() {
         List<String> requiredFlat = getRequiredFields().stream()
-                .map(field -> field.split("/"))
+                .map(field -> field.split(FieldName.FIELD_SEPARATOR))
                 .flatMap(Arrays::stream)
                 .collect(Collectors.toList());
 

--- a/src/main/java/net/sf/jabref/model/entry/FieldName.java
+++ b/src/main/java/net/sf/jabref/model/entry/FieldName.java
@@ -3,6 +3,12 @@ package net.sf.jabref.model.entry;
 
 public class FieldName {
 
+    // Character separating field names that are to be used in sequence as
+    // fallbacks for a single column (e.g. "author/editor" to use editor where
+    // author is not set):
+    public static final String FIELD_SEPARATOR = "/";
+
+    // Field name constants
     public static final String ABSTRACT = "abstract";
     public static final String ADDRESS = "address";
     public static final String AUTHOR = "author";

--- a/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
+++ b/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
@@ -43,6 +43,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import net.sf.jabref.Globals;
+import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.specialfields.SpecialFieldsUtils;
 
 public class InternalBibtexFields {
@@ -53,7 +54,6 @@ public class InternalBibtexFields {
     public static final String MARKED = "__markedentry";
     public static final String OWNER = "owner";
     public static final String TIMESTAMP = "timestamp";
-    private static final String ENTRYTYPE = "entrytype";
     public static final String NUMBER_COL = "#";
 
 
@@ -224,12 +224,13 @@ public class InternalBibtexFields {
         dummy.setPrivate();
         add(dummy);
 
-        dummy = new BibtexSingleField(InternalBibtexFields.TIMESTAMP, false, BibtexSingleField.SMALL_W);
+        dummy = new BibtexSingleField(Globals.prefs.get(JabRefPreferences.TIME_STAMP_FIELD), false,
+                BibtexSingleField.SMALL_W);
         dummy.setExtras(EnumSet.of(FieldProperties.DATE));
         dummy.setPrivate();
         add(dummy);
 
-        dummy = new BibtexSingleField(InternalBibtexFields.ENTRYTYPE, false, 75);
+        dummy = new BibtexSingleField(BibEntry.TYPE_HEADER, false, 75);
         dummy.setPrivate();
         add(dummy);
 

--- a/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
@@ -51,7 +51,6 @@ import net.sf.jabref.JabRefMain;
 import net.sf.jabref.external.DroppedFileHandler;
 import net.sf.jabref.gui.desktop.JabRefDesktop;
 import net.sf.jabref.gui.entryeditor.EntryEditorTabList;
-import net.sf.jabref.gui.maintable.PersistenceTableColumnListener;
 import net.sf.jabref.gui.preftabs.ImportSettingsTab;
 import net.sf.jabref.importer.CustomImportList;
 import net.sf.jabref.logic.autocompleter.AutoCompletePreferences;
@@ -565,8 +564,6 @@ public class JabRefPreferences {
 
         defaults.put(COLUMN_NAMES, "entrytype;author/editor;title;year;journal/booktitle;bibtexkey");
         defaults.put(COLUMN_WIDTHS, "75;300;470;60;130;100");
-        defaults.put(PersistenceTableColumnListener.ACTIVATE_PREF_KEY,
-                PersistenceTableColumnListener.DEFAULT_ENABLED);
         defaults.put(XMP_PRIVACY_FILTERS, "pdf;timestamp;keywords;owner;note;review");
         defaults.put(USE_XMP_PRIVACY_FILTER, Boolean.FALSE);
         defaults.put(NUMBER_COL_WIDTH, 32);

--- a/src/test/java/net/sf/jabref/MetaDataTest.java
+++ b/src/test/java/net/sf/jabref/MetaDataTest.java
@@ -7,6 +7,7 @@ import java.util.TreeMap;
 import net.sf.jabref.logic.cleanup.FieldFormatterCleanup;
 import net.sf.jabref.logic.exporter.FieldFormatterCleanups;
 import net.sf.jabref.logic.formatter.casechanger.LowerCaseFormatter;
+import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
@@ -37,7 +38,7 @@ public class MetaDataTest {
 
         Map<String, String> expectedSerialization = new TreeMap<>();
         expectedSerialization.put("saveActions",
-                "enabled;" + Globals.NEWLINE + "title[lower_case]" + Globals.NEWLINE + ";");
+                "enabled;" + StringUtil.NEWLINE + "title[lower_case]" + StringUtil.NEWLINE + ";");
         assertEquals(expectedSerialization, metaData.getAsStringMap());
     }
 }

--- a/src/test/java/net/sf/jabref/MetaDataTest.java
+++ b/src/test/java/net/sf/jabref/MetaDataTest.java
@@ -7,7 +7,7 @@ import java.util.TreeMap;
 import net.sf.jabref.logic.cleanup.FieldFormatterCleanup;
 import net.sf.jabref.logic.exporter.FieldFormatterCleanups;
 import net.sf.jabref.logic.formatter.casechanger.LowerCaseFormatter;
-import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
@@ -38,7 +38,7 @@ public class MetaDataTest {
 
         Map<String, String> expectedSerialization = new TreeMap<>();
         expectedSerialization.put("saveActions",
-                "enabled;" + StringUtil.NEWLINE + "title[lower_case]" + StringUtil.NEWLINE + ";");
+                "enabled;" + FileUtil.NEWLINE + "title[lower_case]" + FileUtil.NEWLINE + ";");
         assertEquals(expectedSerialization, metaData.getAsStringMap());
     }
 }

--- a/src/test/java/net/sf/jabref/MetaDataTest.java
+++ b/src/test/java/net/sf/jabref/MetaDataTest.java
@@ -7,7 +7,7 @@ import java.util.TreeMap;
 import net.sf.jabref.logic.cleanup.FieldFormatterCleanup;
 import net.sf.jabref.logic.exporter.FieldFormatterCleanups;
 import net.sf.jabref.logic.formatter.casechanger.LowerCaseFormatter;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
@@ -38,7 +38,7 @@ public class MetaDataTest {
 
         Map<String, String> expectedSerialization = new TreeMap<>();
         expectedSerialization.put("saveActions",
-                "enabled;" + FileUtil.NEWLINE + "title[lower_case]" + FileUtil.NEWLINE + ";");
+                "enabled;" + OS.NEWLINE + "title[lower_case]" + OS.NEWLINE + ";");
         assertEquals(expectedSerialization, metaData.getAsStringMap());
     }
 }

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -25,7 +25,7 @@ import net.sf.jabref.logic.groups.GroupTreeNode;
 import net.sf.jabref.logic.groups.KeywordGroup;
 import net.sf.jabref.logic.labelpattern.AbstractLabelPattern;
 import net.sf.jabref.logic.labelpattern.DatabaseLabelPattern;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexString;
@@ -341,9 +341,9 @@ public class BibtexParserTest {
     public void parseSetsParsedSerialization() throws IOException {
         String firstEntry = "@article{canh05,"
                 + "  author = {Crowston, K. and Annabi, H.},"
-                + FileUtil.NEWLINE
+                + OS.NEWLINE
                 + "  title = {Title A}}"
-                + FileUtil.NEWLINE;
+                + OS.NEWLINE;
         String secondEntry = "@inProceedings{foo," + "  author={Norton Bar}}";
 
         ParserResult result = BibtexParser.parse(new StringReader(firstEntry + secondEntry));
@@ -896,8 +896,8 @@ public class BibtexParserTest {
     @Test
     public void parseSavesOneNewlineAfterStringInParsedSerialization() throws IOException {
 
-        String string = "@string{bourdieu = {Bourdieu, Pierre}}" + FileUtil.NEWLINE;
-        ParserResult result = BibtexParser.parse(new StringReader(string + FileUtil.NEWLINE + FileUtil.NEWLINE));
+        String string = "@string{bourdieu = {Bourdieu, Pierre}}" + OS.NEWLINE;
+        ParserResult result = BibtexParser.parse(new StringReader(string + OS.NEWLINE + OS.NEWLINE));
         assertEquals(1, result.getDatabase().getStringCount());
 
         BibtexString s = result.getDatabase().getStringValues().iterator().next();
@@ -1234,36 +1234,36 @@ public class BibtexParserTest {
     @Test
     public void parseSavesOneNewlineAfterEntryInParsedSerialization() throws IOException {
         String testEntry = "@article{test,author={Ed von Test}}";
-        ParserResult result = BibtexParser.parse(new StringReader(testEntry + FileUtil.NEWLINE + FileUtil.NEWLINE));
+        ParserResult result = BibtexParser.parse(new StringReader(testEntry + OS.NEWLINE + OS.NEWLINE));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(1, c.size());
 
         BibEntry e = c.iterator().next();
-        assertEquals(testEntry + FileUtil.NEWLINE, e.getParsedSerialization());
+        assertEquals(testEntry + OS.NEWLINE, e.getParsedSerialization());
     }
 
     @Test
     public void parseSavesNewlinesBeforeEntryInParsedSerialization() throws IOException {
         String testEntry = "@article{test,author={Ed von Test}}";
         ParserResult result = BibtexParser
-                .parse(new StringReader(FileUtil.NEWLINE + FileUtil.NEWLINE + FileUtil.NEWLINE + testEntry));
+                .parse(new StringReader(OS.NEWLINE + OS.NEWLINE + OS.NEWLINE + testEntry));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(1, c.size());
 
         BibEntry e = c.iterator().next();
-        assertEquals(FileUtil.NEWLINE + FileUtil.NEWLINE + FileUtil.NEWLINE + testEntry, e.getParsedSerialization());
+        assertEquals(OS.NEWLINE + OS.NEWLINE + OS.NEWLINE + testEntry, e.getParsedSerialization());
     }
 
     @Test
     public void parseRemovesEncodingLineInParsedSerialization() throws IOException {
         String testEntry = "@article{test,author={Ed von Test}}";
         ParserResult result = BibtexParser.parse(
-                new StringReader(Globals.ENCODING_PREFIX + FileUtil.NEWLINE + FileUtil.NEWLINE + FileUtil.NEWLINE + testEntry));
+                new StringReader(Globals.ENCODING_PREFIX + OS.NEWLINE + OS.NEWLINE + OS.NEWLINE + testEntry));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(1, c.size());
 
         BibEntry e = c.iterator().next();
-        assertEquals(FileUtil.NEWLINE + FileUtil.NEWLINE + testEntry, e.getParsedSerialization());
+        assertEquals(OS.NEWLINE + OS.NEWLINE + testEntry, e.getParsedSerialization());
     }
 
     @Test
@@ -1271,7 +1271,7 @@ public class BibtexParserTest {
         String testEntryOne = "@article{test1,author={Ed von Test}}";
         String testEntryTwo = "@article{test2,author={Ed von Test}}";
         ParserResult result = BibtexParser.parse(
-                new StringReader(testEntryOne + FileUtil.NEWLINE + FileUtil.NEWLINE + FileUtil.NEWLINE + testEntryTwo));
+                new StringReader(testEntryOne + OS.NEWLINE + OS.NEWLINE + OS.NEWLINE + testEntryTwo));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(2, c.size());
 
@@ -1286,13 +1286,13 @@ public class BibtexParserTest {
             b = tmp;
         }
 
-        assertEquals(testEntryOne + FileUtil.NEWLINE, a.getParsedSerialization());
-        assertEquals(FileUtil.NEWLINE + FileUtil.NEWLINE + testEntryTwo, b.getParsedSerialization());
+        assertEquals(testEntryOne + OS.NEWLINE, a.getParsedSerialization());
+        assertEquals(OS.NEWLINE + OS.NEWLINE + testEntryTwo, b.getParsedSerialization());
     }
 
     @Test
     public void parseIgnoresWhitespaceInEpilogue() throws IOException {
-        ParserResult result = BibtexParser.parse(new StringReader("   " + FileUtil.NEWLINE));
+        ParserResult result = BibtexParser.parse(new StringReader("   " + OS.NEWLINE));
 
         assertEquals("", result.getDatabase().getEpilog());
     }
@@ -1301,12 +1301,12 @@ public class BibtexParserTest {
     public void parseIgnoresWhitespaceInEpilogueAfterEntry() throws IOException {
         String testEntry = "@article{test,author={Ed von Test}}";
         ParserResult result = BibtexParser.parse(new StringReader(
-                testEntry + FileUtil.NEWLINE + FileUtil.NEWLINE + FileUtil.NEWLINE + "  " + FileUtil.NEWLINE));
+                testEntry + OS.NEWLINE + OS.NEWLINE + OS.NEWLINE + "  " + OS.NEWLINE));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(1, c.size());
 
         BibEntry e = c.iterator().next();
-        assertEquals(testEntry + FileUtil.NEWLINE, e.getParsedSerialization());
+        assertEquals(testEntry + OS.NEWLINE, e.getParsedSerialization());
         assertEquals("", result.getDatabase().getEpilog());
     }
 
@@ -1314,12 +1314,12 @@ public class BibtexParserTest {
     public void parseTrimsWhitespaceInEpilogueAfterEntry() throws IOException {
         String testEntry = "@article{test,author={Ed von Test}}";
         ParserResult result = BibtexParser.parse(new StringReader(
-                testEntry + FileUtil.NEWLINE + FileUtil.NEWLINE + FileUtil.NEWLINE + " epilogue " + FileUtil.NEWLINE));
+                testEntry + OS.NEWLINE + OS.NEWLINE + OS.NEWLINE + " epilogue " + OS.NEWLINE));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(1, c.size());
 
         BibEntry e = c.iterator().next();
-        assertEquals(testEntry + FileUtil.NEWLINE, e.getParsedSerialization());
+        assertEquals(testEntry + OS.NEWLINE, e.getParsedSerialization());
         assertEquals("epilogue", result.getDatabase().getEpilog());
     }
 
@@ -1389,7 +1389,7 @@ public class BibtexParserTest {
         ParserResult result = BibtexParser
                 .parse(new StringReader(
                         "@comment{jabref-meta: keypattern_article:articleTest;}"
-                                + FileUtil.NEWLINE
+                                + OS.NEWLINE
                                 + "@comment{jabref-meta: keypatterndefault:test;}"));
 
         AbstractLabelPattern labelPattern = result.getMetaData().getLabelPattern();
@@ -1414,15 +1414,15 @@ public class BibtexParserTest {
     public void integrationTestGroupTree() throws IOException, ParseException {
         ParserResult result = BibtexParser.parse(new StringReader(
                 "@comment{jabref-meta: groupsversion:3;}"
-                        + FileUtil.NEWLINE +
+                        + OS.NEWLINE +
                         "@comment{jabref-meta: groupstree:"
-                        + FileUtil.NEWLINE
+                        + OS.NEWLINE
                         + "0 AllEntriesGroup:;"
-                        + FileUtil.NEWLINE
+                        + OS.NEWLINE
                         + "1 KeywordGroup:Fréchet\\;0\\;keywords\\;FrechetSpace\\;0\\;1\\;;"
-                        + FileUtil.NEWLINE
+                        + OS.NEWLINE
                         + "1 KeywordGroup:Invariant theory\\;0\\;keywords\\;GIT\\;0\\;0\\;;"
-                        + FileUtil.NEWLINE
+                        + OS.NEWLINE
                         + "1 ExplicitGroup:TestGroup\\;0\\;Key1\\;Key2\\;;"
                         + "}"));
 
@@ -1470,7 +1470,7 @@ public class BibtexParserTest {
     @Test
     public void parseReturnsEntriesInSameOrder() throws IOException {
         ParserResult result = BibtexParser.parse(new StringReader(
-                "@article{a}" + FileUtil.NEWLINE + "@article{b}" + FileUtil.NEWLINE + "@inProceedings{c}"));
+                "@article{a}" + OS.NEWLINE + "@article{b}" + OS.NEWLINE + "@inProceedings{c}"));
 
         List<BibEntry> expected = new ArrayList<>();
         BibEntry a = new BibEntry();
@@ -1494,12 +1494,12 @@ public class BibtexParserTest {
     @Test
     public void parsePrecedingComment() throws IOException {
         // @formatter:off
-        String bibtexEntry = "% Some random comment that should stay here" + FileUtil.NEWLINE +
-                "@Article{test," + FileUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
-                "  Note                     = {some note}," + FileUtil.NEWLINE +
-                "  Number                   = {1}" + FileUtil.NEWLINE +
+        String bibtexEntry = "% Some random comment that should stay here" + OS.NEWLINE +
+                "@Article{test," + OS.NEWLINE +
+                "  Author                   = {Foo Bar}," + OS.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + OS.NEWLINE +
+                "  Note                     = {some note}," + OS.NEWLINE +
+                "  Number                   = {1}" + OS.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -1521,11 +1521,11 @@ public class BibtexParserTest {
     @Test
     public void parseCommentAndEntryInOneLine() throws IOException {
         // @formatter:off
-        String bibtexEntry = "Some random comment that should stay here @Article{test," + FileUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
-                "  Note                     = {some note}," + FileUtil.NEWLINE +
-                "  Number                   = {1}" + FileUtil.NEWLINE +
+        String bibtexEntry = "Some random comment that should stay here @Article{test," + OS.NEWLINE +
+                "  Author                   = {Foo Bar}," + OS.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + OS.NEWLINE +
+                "  Note                     = {some note}," + OS.NEWLINE +
+                "  Number                   = {1}" + OS.NEWLINE +
                 "}";
         // @formatter:on
 

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -25,7 +25,7 @@ import net.sf.jabref.logic.groups.GroupTreeNode;
 import net.sf.jabref.logic.groups.KeywordGroup;
 import net.sf.jabref.logic.labelpattern.AbstractLabelPattern;
 import net.sf.jabref.logic.labelpattern.DatabaseLabelPattern;
-import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexString;
@@ -341,9 +341,9 @@ public class BibtexParserTest {
     public void parseSetsParsedSerialization() throws IOException {
         String firstEntry = "@article{canh05,"
                 + "  author = {Crowston, K. and Annabi, H.},"
-                + StringUtil.NEWLINE
+                + FileUtil.NEWLINE
                 + "  title = {Title A}}"
-                + StringUtil.NEWLINE;
+                + FileUtil.NEWLINE;
         String secondEntry = "@inProceedings{foo," + "  author={Norton Bar}}";
 
         ParserResult result = BibtexParser.parse(new StringReader(firstEntry + secondEntry));
@@ -896,8 +896,8 @@ public class BibtexParserTest {
     @Test
     public void parseSavesOneNewlineAfterStringInParsedSerialization() throws IOException {
 
-        String string = "@string{bourdieu = {Bourdieu, Pierre}}" + StringUtil.NEWLINE;
-        ParserResult result = BibtexParser.parse(new StringReader(string + StringUtil.NEWLINE + StringUtil.NEWLINE));
+        String string = "@string{bourdieu = {Bourdieu, Pierre}}" + FileUtil.NEWLINE;
+        ParserResult result = BibtexParser.parse(new StringReader(string + FileUtil.NEWLINE + FileUtil.NEWLINE));
         assertEquals(1, result.getDatabase().getStringCount());
 
         BibtexString s = result.getDatabase().getStringValues().iterator().next();
@@ -1234,36 +1234,36 @@ public class BibtexParserTest {
     @Test
     public void parseSavesOneNewlineAfterEntryInParsedSerialization() throws IOException {
         String testEntry = "@article{test,author={Ed von Test}}";
-        ParserResult result = BibtexParser.parse(new StringReader(testEntry + StringUtil.NEWLINE + StringUtil.NEWLINE));
+        ParserResult result = BibtexParser.parse(new StringReader(testEntry + FileUtil.NEWLINE + FileUtil.NEWLINE));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(1, c.size());
 
         BibEntry e = c.iterator().next();
-        assertEquals(testEntry + StringUtil.NEWLINE, e.getParsedSerialization());
+        assertEquals(testEntry + FileUtil.NEWLINE, e.getParsedSerialization());
     }
 
     @Test
     public void parseSavesNewlinesBeforeEntryInParsedSerialization() throws IOException {
         String testEntry = "@article{test,author={Ed von Test}}";
         ParserResult result = BibtexParser
-                .parse(new StringReader(StringUtil.NEWLINE + StringUtil.NEWLINE + StringUtil.NEWLINE + testEntry));
+                .parse(new StringReader(FileUtil.NEWLINE + FileUtil.NEWLINE + FileUtil.NEWLINE + testEntry));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(1, c.size());
 
         BibEntry e = c.iterator().next();
-        assertEquals(StringUtil.NEWLINE + StringUtil.NEWLINE + StringUtil.NEWLINE + testEntry, e.getParsedSerialization());
+        assertEquals(FileUtil.NEWLINE + FileUtil.NEWLINE + FileUtil.NEWLINE + testEntry, e.getParsedSerialization());
     }
 
     @Test
     public void parseRemovesEncodingLineInParsedSerialization() throws IOException {
         String testEntry = "@article{test,author={Ed von Test}}";
         ParserResult result = BibtexParser.parse(
-                new StringReader(Globals.ENCODING_PREFIX + StringUtil.NEWLINE + StringUtil.NEWLINE + StringUtil.NEWLINE + testEntry));
+                new StringReader(Globals.ENCODING_PREFIX + FileUtil.NEWLINE + FileUtil.NEWLINE + FileUtil.NEWLINE + testEntry));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(1, c.size());
 
         BibEntry e = c.iterator().next();
-        assertEquals(StringUtil.NEWLINE + StringUtil.NEWLINE + testEntry, e.getParsedSerialization());
+        assertEquals(FileUtil.NEWLINE + FileUtil.NEWLINE + testEntry, e.getParsedSerialization());
     }
 
     @Test
@@ -1271,7 +1271,7 @@ public class BibtexParserTest {
         String testEntryOne = "@article{test1,author={Ed von Test}}";
         String testEntryTwo = "@article{test2,author={Ed von Test}}";
         ParserResult result = BibtexParser.parse(
-                new StringReader(testEntryOne + StringUtil.NEWLINE + StringUtil.NEWLINE + StringUtil.NEWLINE + testEntryTwo));
+                new StringReader(testEntryOne + FileUtil.NEWLINE + FileUtil.NEWLINE + FileUtil.NEWLINE + testEntryTwo));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(2, c.size());
 
@@ -1286,13 +1286,13 @@ public class BibtexParserTest {
             b = tmp;
         }
 
-        assertEquals(testEntryOne + StringUtil.NEWLINE, a.getParsedSerialization());
-        assertEquals(StringUtil.NEWLINE + StringUtil.NEWLINE + testEntryTwo, b.getParsedSerialization());
+        assertEquals(testEntryOne + FileUtil.NEWLINE, a.getParsedSerialization());
+        assertEquals(FileUtil.NEWLINE + FileUtil.NEWLINE + testEntryTwo, b.getParsedSerialization());
     }
 
     @Test
     public void parseIgnoresWhitespaceInEpilogue() throws IOException {
-        ParserResult result = BibtexParser.parse(new StringReader("   " + StringUtil.NEWLINE));
+        ParserResult result = BibtexParser.parse(new StringReader("   " + FileUtil.NEWLINE));
 
         assertEquals("", result.getDatabase().getEpilog());
     }
@@ -1301,12 +1301,12 @@ public class BibtexParserTest {
     public void parseIgnoresWhitespaceInEpilogueAfterEntry() throws IOException {
         String testEntry = "@article{test,author={Ed von Test}}";
         ParserResult result = BibtexParser.parse(new StringReader(
-                testEntry + StringUtil.NEWLINE + StringUtil.NEWLINE + StringUtil.NEWLINE + "  " + StringUtil.NEWLINE));
+                testEntry + FileUtil.NEWLINE + FileUtil.NEWLINE + FileUtil.NEWLINE + "  " + FileUtil.NEWLINE));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(1, c.size());
 
         BibEntry e = c.iterator().next();
-        assertEquals(testEntry + StringUtil.NEWLINE, e.getParsedSerialization());
+        assertEquals(testEntry + FileUtil.NEWLINE, e.getParsedSerialization());
         assertEquals("", result.getDatabase().getEpilog());
     }
 
@@ -1314,12 +1314,12 @@ public class BibtexParserTest {
     public void parseTrimsWhitespaceInEpilogueAfterEntry() throws IOException {
         String testEntry = "@article{test,author={Ed von Test}}";
         ParserResult result = BibtexParser.parse(new StringReader(
-                testEntry + StringUtil.NEWLINE + StringUtil.NEWLINE + StringUtil.NEWLINE + " epilogue " + StringUtil.NEWLINE));
+                testEntry + FileUtil.NEWLINE + FileUtil.NEWLINE + FileUtil.NEWLINE + " epilogue " + FileUtil.NEWLINE));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(1, c.size());
 
         BibEntry e = c.iterator().next();
-        assertEquals(testEntry + StringUtil.NEWLINE, e.getParsedSerialization());
+        assertEquals(testEntry + FileUtil.NEWLINE, e.getParsedSerialization());
         assertEquals("epilogue", result.getDatabase().getEpilog());
     }
 
@@ -1389,7 +1389,7 @@ public class BibtexParserTest {
         ParserResult result = BibtexParser
                 .parse(new StringReader(
                         "@comment{jabref-meta: keypattern_article:articleTest;}"
-                                + StringUtil.NEWLINE
+                                + FileUtil.NEWLINE
                                 + "@comment{jabref-meta: keypatterndefault:test;}"));
 
         AbstractLabelPattern labelPattern = result.getMetaData().getLabelPattern();
@@ -1414,15 +1414,15 @@ public class BibtexParserTest {
     public void integrationTestGroupTree() throws IOException, ParseException {
         ParserResult result = BibtexParser.parse(new StringReader(
                 "@comment{jabref-meta: groupsversion:3;}"
-                        + StringUtil.NEWLINE +
+                        + FileUtil.NEWLINE +
                         "@comment{jabref-meta: groupstree:"
-                        + StringUtil.NEWLINE
+                        + FileUtil.NEWLINE
                         + "0 AllEntriesGroup:;"
-                        + StringUtil.NEWLINE
+                        + FileUtil.NEWLINE
                         + "1 KeywordGroup:Fréchet\\;0\\;keywords\\;FrechetSpace\\;0\\;1\\;;"
-                        + StringUtil.NEWLINE
+                        + FileUtil.NEWLINE
                         + "1 KeywordGroup:Invariant theory\\;0\\;keywords\\;GIT\\;0\\;0\\;;"
-                        + StringUtil.NEWLINE
+                        + FileUtil.NEWLINE
                         + "1 ExplicitGroup:TestGroup\\;0\\;Key1\\;Key2\\;;"
                         + "}"));
 
@@ -1470,7 +1470,7 @@ public class BibtexParserTest {
     @Test
     public void parseReturnsEntriesInSameOrder() throws IOException {
         ParserResult result = BibtexParser.parse(new StringReader(
-                "@article{a}" + StringUtil.NEWLINE + "@article{b}" + StringUtil.NEWLINE + "@inProceedings{c}"));
+                "@article{a}" + FileUtil.NEWLINE + "@article{b}" + FileUtil.NEWLINE + "@inProceedings{c}"));
 
         List<BibEntry> expected = new ArrayList<>();
         BibEntry a = new BibEntry();
@@ -1494,12 +1494,12 @@ public class BibtexParserTest {
     @Test
     public void parsePrecedingComment() throws IOException {
         // @formatter:off
-        String bibtexEntry = "% Some random comment that should stay here" + StringUtil.NEWLINE +
-                "@Article{test," + StringUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
-                "  Note                     = {some note}," + StringUtil.NEWLINE +
-                "  Number                   = {1}" + StringUtil.NEWLINE +
+        String bibtexEntry = "% Some random comment that should stay here" + FileUtil.NEWLINE +
+                "@Article{test," + FileUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
+                "  Note                     = {some note}," + FileUtil.NEWLINE +
+                "  Number                   = {1}" + FileUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -1521,11 +1521,11 @@ public class BibtexParserTest {
     @Test
     public void parseCommentAndEntryInOneLine() throws IOException {
         // @formatter:off
-        String bibtexEntry = "Some random comment that should stay here @Article{test," + StringUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
-                "  Note                     = {some note}," + StringUtil.NEWLINE +
-                "  Number                   = {1}" + StringUtil.NEWLINE +
+        String bibtexEntry = "Some random comment that should stay here @Article{test," + FileUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
+                "  Note                     = {some note}," + FileUtil.NEWLINE +
+                "  Number                   = {1}" + FileUtil.NEWLINE +
                 "}";
         // @formatter:on
 

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -25,6 +25,7 @@ import net.sf.jabref.logic.groups.GroupTreeNode;
 import net.sf.jabref.logic.groups.KeywordGroup;
 import net.sf.jabref.logic.labelpattern.AbstractLabelPattern;
 import net.sf.jabref.logic.labelpattern.DatabaseLabelPattern;
+import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexString;
@@ -340,9 +341,9 @@ public class BibtexParserTest {
     public void parseSetsParsedSerialization() throws IOException {
         String firstEntry = "@article{canh05,"
                 + "  author = {Crowston, K. and Annabi, H.},"
-                + Globals.NEWLINE
+                + StringUtil.NEWLINE
                 + "  title = {Title A}}"
-                + Globals.NEWLINE;
+                + StringUtil.NEWLINE;
         String secondEntry = "@inProceedings{foo," + "  author={Norton Bar}}";
 
         ParserResult result = BibtexParser.parse(new StringReader(firstEntry + secondEntry));
@@ -895,8 +896,8 @@ public class BibtexParserTest {
     @Test
     public void parseSavesOneNewlineAfterStringInParsedSerialization() throws IOException {
 
-        String string = "@string{bourdieu = {Bourdieu, Pierre}}" + Globals.NEWLINE;
-        ParserResult result = BibtexParser.parse(new StringReader(string + Globals.NEWLINE + Globals.NEWLINE));
+        String string = "@string{bourdieu = {Bourdieu, Pierre}}" + StringUtil.NEWLINE;
+        ParserResult result = BibtexParser.parse(new StringReader(string + StringUtil.NEWLINE + StringUtil.NEWLINE));
         assertEquals(1, result.getDatabase().getStringCount());
 
         BibtexString s = result.getDatabase().getStringValues().iterator().next();
@@ -1233,36 +1234,36 @@ public class BibtexParserTest {
     @Test
     public void parseSavesOneNewlineAfterEntryInParsedSerialization() throws IOException {
         String testEntry = "@article{test,author={Ed von Test}}";
-        ParserResult result = BibtexParser.parse(new StringReader(testEntry + Globals.NEWLINE + Globals.NEWLINE));
+        ParserResult result = BibtexParser.parse(new StringReader(testEntry + StringUtil.NEWLINE + StringUtil.NEWLINE));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(1, c.size());
 
         BibEntry e = c.iterator().next();
-        assertEquals(testEntry + Globals.NEWLINE, e.getParsedSerialization());
+        assertEquals(testEntry + StringUtil.NEWLINE, e.getParsedSerialization());
     }
 
     @Test
     public void parseSavesNewlinesBeforeEntryInParsedSerialization() throws IOException {
         String testEntry = "@article{test,author={Ed von Test}}";
         ParserResult result = BibtexParser
-                .parse(new StringReader(Globals.NEWLINE + Globals.NEWLINE + Globals.NEWLINE + testEntry));
+                .parse(new StringReader(StringUtil.NEWLINE + StringUtil.NEWLINE + StringUtil.NEWLINE + testEntry));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(1, c.size());
 
         BibEntry e = c.iterator().next();
-        assertEquals(Globals.NEWLINE + Globals.NEWLINE + Globals.NEWLINE + testEntry, e.getParsedSerialization());
+        assertEquals(StringUtil.NEWLINE + StringUtil.NEWLINE + StringUtil.NEWLINE + testEntry, e.getParsedSerialization());
     }
 
     @Test
     public void parseRemovesEncodingLineInParsedSerialization() throws IOException {
         String testEntry = "@article{test,author={Ed von Test}}";
         ParserResult result = BibtexParser.parse(
-                new StringReader(Globals.ENCODING_PREFIX + Globals.NEWLINE + Globals.NEWLINE + Globals.NEWLINE + testEntry));
+                new StringReader(Globals.ENCODING_PREFIX + StringUtil.NEWLINE + StringUtil.NEWLINE + StringUtil.NEWLINE + testEntry));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(1, c.size());
 
         BibEntry e = c.iterator().next();
-        assertEquals(Globals.NEWLINE + Globals.NEWLINE + testEntry, e.getParsedSerialization());
+        assertEquals(StringUtil.NEWLINE + StringUtil.NEWLINE + testEntry, e.getParsedSerialization());
     }
 
     @Test
@@ -1270,7 +1271,7 @@ public class BibtexParserTest {
         String testEntryOne = "@article{test1,author={Ed von Test}}";
         String testEntryTwo = "@article{test2,author={Ed von Test}}";
         ParserResult result = BibtexParser.parse(
-                new StringReader(testEntryOne + Globals.NEWLINE + Globals.NEWLINE + Globals.NEWLINE + testEntryTwo));
+                new StringReader(testEntryOne + StringUtil.NEWLINE + StringUtil.NEWLINE + StringUtil.NEWLINE + testEntryTwo));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(2, c.size());
 
@@ -1285,13 +1286,13 @@ public class BibtexParserTest {
             b = tmp;
         }
 
-        assertEquals(testEntryOne + Globals.NEWLINE, a.getParsedSerialization());
-        assertEquals(Globals.NEWLINE + Globals.NEWLINE + testEntryTwo, b.getParsedSerialization());
+        assertEquals(testEntryOne + StringUtil.NEWLINE, a.getParsedSerialization());
+        assertEquals(StringUtil.NEWLINE + StringUtil.NEWLINE + testEntryTwo, b.getParsedSerialization());
     }
 
     @Test
     public void parseIgnoresWhitespaceInEpilogue() throws IOException {
-        ParserResult result = BibtexParser.parse(new StringReader("   " + Globals.NEWLINE));
+        ParserResult result = BibtexParser.parse(new StringReader("   " + StringUtil.NEWLINE));
 
         assertEquals("", result.getDatabase().getEpilog());
     }
@@ -1300,12 +1301,12 @@ public class BibtexParserTest {
     public void parseIgnoresWhitespaceInEpilogueAfterEntry() throws IOException {
         String testEntry = "@article{test,author={Ed von Test}}";
         ParserResult result = BibtexParser.parse(new StringReader(
-                testEntry + Globals.NEWLINE + Globals.NEWLINE + Globals.NEWLINE + "  " + Globals.NEWLINE));
+                testEntry + StringUtil.NEWLINE + StringUtil.NEWLINE + StringUtil.NEWLINE + "  " + StringUtil.NEWLINE));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(1, c.size());
 
         BibEntry e = c.iterator().next();
-        assertEquals(testEntry + Globals.NEWLINE, e.getParsedSerialization());
+        assertEquals(testEntry + StringUtil.NEWLINE, e.getParsedSerialization());
         assertEquals("", result.getDatabase().getEpilog());
     }
 
@@ -1313,12 +1314,12 @@ public class BibtexParserTest {
     public void parseTrimsWhitespaceInEpilogueAfterEntry() throws IOException {
         String testEntry = "@article{test,author={Ed von Test}}";
         ParserResult result = BibtexParser.parse(new StringReader(
-                testEntry + Globals.NEWLINE + Globals.NEWLINE + Globals.NEWLINE + " epilogue " + Globals.NEWLINE));
+                testEntry + StringUtil.NEWLINE + StringUtil.NEWLINE + StringUtil.NEWLINE + " epilogue " + StringUtil.NEWLINE));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(1, c.size());
 
         BibEntry e = c.iterator().next();
-        assertEquals(testEntry + Globals.NEWLINE, e.getParsedSerialization());
+        assertEquals(testEntry + StringUtil.NEWLINE, e.getParsedSerialization());
         assertEquals("epilogue", result.getDatabase().getEpilog());
     }
 
@@ -1388,7 +1389,7 @@ public class BibtexParserTest {
         ParserResult result = BibtexParser
                 .parse(new StringReader(
                         "@comment{jabref-meta: keypattern_article:articleTest;}"
-                                + Globals.NEWLINE
+                                + StringUtil.NEWLINE
                                 + "@comment{jabref-meta: keypatterndefault:test;}"));
 
         AbstractLabelPattern labelPattern = result.getMetaData().getLabelPattern();
@@ -1413,15 +1414,15 @@ public class BibtexParserTest {
     public void integrationTestGroupTree() throws IOException, ParseException {
         ParserResult result = BibtexParser.parse(new StringReader(
                 "@comment{jabref-meta: groupsversion:3;}"
-                        + Globals.NEWLINE +
+                        + StringUtil.NEWLINE +
                         "@comment{jabref-meta: groupstree:"
-                        + Globals.NEWLINE
+                        + StringUtil.NEWLINE
                         + "0 AllEntriesGroup:;"
-                        + Globals.NEWLINE
+                        + StringUtil.NEWLINE
                         + "1 KeywordGroup:Fréchet\\;0\\;keywords\\;FrechetSpace\\;0\\;1\\;;"
-                        + Globals.NEWLINE
+                        + StringUtil.NEWLINE
                         + "1 KeywordGroup:Invariant theory\\;0\\;keywords\\;GIT\\;0\\;0\\;;"
-                        + Globals.NEWLINE
+                        + StringUtil.NEWLINE
                         + "1 ExplicitGroup:TestGroup\\;0\\;Key1\\;Key2\\;;"
                         + "}"));
 
@@ -1469,7 +1470,7 @@ public class BibtexParserTest {
     @Test
     public void parseReturnsEntriesInSameOrder() throws IOException {
         ParserResult result = BibtexParser.parse(new StringReader(
-                "@article{a}" + Globals.NEWLINE + "@article{b}" + Globals.NEWLINE + "@inProceedings{c}"));
+                "@article{a}" + StringUtil.NEWLINE + "@article{b}" + StringUtil.NEWLINE + "@inProceedings{c}"));
 
         List<BibEntry> expected = new ArrayList<>();
         BibEntry a = new BibEntry();
@@ -1493,12 +1494,12 @@ public class BibtexParserTest {
     @Test
     public void parsePrecedingComment() throws IOException {
         // @formatter:off
-        String bibtexEntry = "% Some random comment that should stay here" + Globals.NEWLINE +
-                "@Article{test," + Globals.NEWLINE +
-                "  Author                   = {Foo Bar}," + Globals.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + Globals.NEWLINE +
-                "  Note                     = {some note}," + Globals.NEWLINE +
-                "  Number                   = {1}" + Globals.NEWLINE +
+        String bibtexEntry = "% Some random comment that should stay here" + StringUtil.NEWLINE +
+                "@Article{test," + StringUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
+                "  Note                     = {some note}," + StringUtil.NEWLINE +
+                "  Number                   = {1}" + StringUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -1520,11 +1521,11 @@ public class BibtexParserTest {
     @Test
     public void parseCommentAndEntryInOneLine() throws IOException {
         // @formatter:off
-        String bibtexEntry = "Some random comment that should stay here @Article{test," + Globals.NEWLINE +
-                "  Author                   = {Foo Bar}," + Globals.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + Globals.NEWLINE +
-                "  Note                     = {some note}," + Globals.NEWLINE +
-                "  Number                   = {1}" + Globals.NEWLINE +
+        String bibtexEntry = "Some random comment that should stay here @Article{test," + StringUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
+                "  Note                     = {some note}," + StringUtil.NEWLINE +
+                "  Number                   = {1}" + StringUtil.NEWLINE +
                 "}";
         // @formatter:on
 

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -17,6 +17,7 @@ import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.logic.cleanup.FieldFormatterCleanup;
 import net.sf.jabref.logic.config.SaveOrderConfig;
 import net.sf.jabref.logic.exporter.FieldFormatterCleanups;
+import net.sf.jabref.logic.exporter.SavePreferences;
 import net.sf.jabref.logic.formatter.casechanger.LowerCaseFormatter;
 import net.sf.jabref.logic.groups.AllEntriesGroup;
 import net.sf.jabref.logic.groups.ExplicitGroup;
@@ -1258,7 +1259,7 @@ public class BibtexParserTest {
     public void parseRemovesEncodingLineInParsedSerialization() throws IOException {
         String testEntry = "@article{test,author={Ed von Test}}";
         ParserResult result = BibtexParser.parse(
-                new StringReader(Globals.ENCODING_PREFIX + OS.NEWLINE + OS.NEWLINE + OS.NEWLINE + testEntry));
+                new StringReader(SavePreferences.ENCODING_PREFIX + OS.NEWLINE + OS.NEWLINE + OS.NEWLINE + testEntry));
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(1, c.size());
 
@@ -1546,12 +1547,12 @@ public class BibtexParserTest {
 
     @Test
     public void preserveEncodingPrefixInsideEntry() {
-        List<BibEntry> parsed = BibtexParser.fromString("@article{test,author={" + Globals.ENCODING_PREFIX + "}}");
+        List<BibEntry> parsed = BibtexParser.fromString("@article{test,author={" + SavePreferences.ENCODING_PREFIX + "}}");
 
         BibEntry expected = new BibEntry();
         expected.setType("article");
         expected.setCiteKey("test");
-        expected.setField("author", Globals.ENCODING_PREFIX);
+        expected.setField("author", SavePreferences.ENCODING_PREFIX);
         assertEquals(Collections.singletonList(expected), parsed);
     }
 

--- a/src/test/java/net/sf/jabref/logic/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/BibEntryWriterTest.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import net.sf.jabref.Globals;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
+import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
@@ -60,12 +61,12 @@ public class BibEntryWriterTest {
         String actual = stringWriter.toString();
 
         // @formatter:off
-        String expected = Globals.NEWLINE + "@Article{," + Globals.NEWLINE +
-                "  author  = {Foo Bar}," + Globals.NEWLINE +
-                "  journal = {International Journal of Something}," + Globals.NEWLINE +
-                "  number  = {1}," + Globals.NEWLINE +
-                "  note    = {some note}," + Globals.NEWLINE +
-                "}" + Globals.NEWLINE;
+        String expected = StringUtil.NEWLINE + "@Article{," + StringUtil.NEWLINE +
+                "  author  = {Foo Bar}," + StringUtil.NEWLINE +
+                "  journal = {International Journal of Something}," + StringUtil.NEWLINE +
+                "  number  = {1}," + StringUtil.NEWLINE +
+                "  note    = {some note}," + StringUtil.NEWLINE +
+                "}" + StringUtil.NEWLINE;
         // @formatter:on
 
         assertEquals(expected, actual);
@@ -74,11 +75,11 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripTest() throws IOException {
         // @formatter:off
-        String bibtexEntry = "@Article{test," + Globals.NEWLINE +
-                "  Author                   = {Foo Bar}," + Globals.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + Globals.NEWLINE +
-                "  Note                     = {some note}," + Globals.NEWLINE +
-                "  Number                   = {1}" + Globals.NEWLINE +
+        String bibtexEntry = "@Article{test," + StringUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
+                "  Note                     = {some note}," + StringUtil.NEWLINE +
+                "  Number                   = {1}" + StringUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -98,11 +99,11 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripWithPrependingNewlines() throws IOException {
         // @formatter:off
-        String bibtexEntry = "\r\n@Article{test," + Globals.NEWLINE +
-                "  Author                   = {Foo Bar}," + Globals.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + Globals.NEWLINE +
-                "  Note                     = {some note}," + Globals.NEWLINE +
-                "  Number                   = {1}" + Globals.NEWLINE +
+        String bibtexEntry = "\r\n@Article{test," + StringUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
+                "  Note                     = {some note}," + StringUtil.NEWLINE +
+                "  Number                   = {1}" + StringUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -122,11 +123,11 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripWithModification() throws IOException {
         // @formatter:off
-        String bibtexEntry = Globals.NEWLINE + "@Article{test," + Globals.NEWLINE +
-                "  Author                   = {Foo Bar}," + Globals.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + Globals.NEWLINE +
-                "  Note                     = {some note}," + Globals.NEWLINE +
-                "  Number                   = {1}," + Globals.NEWLINE +
+        String bibtexEntry = StringUtil.NEWLINE + "@Article{test," + StringUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
+                "  Note                     = {some note}," + StringUtil.NEWLINE +
+                "  Number                   = {1}," + StringUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -144,12 +145,12 @@ public class BibEntryWriterTest {
         String actual = stringWriter.toString();
 
         // @formatter:off
-        String expected = Globals.NEWLINE + "@Article{test," + Globals.NEWLINE +
-                "  author  = {BlaBla}," + Globals.NEWLINE +
-                "  journal = {International Journal of Something}," + Globals.NEWLINE +
-                "  number  = {1}," + Globals.NEWLINE +
-                "  note    = {some note}," + Globals.NEWLINE +
-                "}" + Globals.NEWLINE;
+        String expected = StringUtil.NEWLINE + "@Article{test," + StringUtil.NEWLINE +
+                "  author  = {BlaBla}," + StringUtil.NEWLINE +
+                "  journal = {International Journal of Something}," + StringUtil.NEWLINE +
+                "  number  = {1}," + StringUtil.NEWLINE +
+                "  note    = {some note}," + StringUtil.NEWLINE +
+                "}" + StringUtil.NEWLINE;
         // @formatter:on
         assertEquals(expected, actual);
     }
@@ -157,12 +158,12 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripWithCamelCasingInTheOriginalEntryAndResultInLowerCase() throws IOException {
         // @formatter:off
-        String bibtexEntry = Globals.NEWLINE + "@Article{test," + Globals.NEWLINE +
-                "  Author                   = {Foo Bar}," + Globals.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + Globals.NEWLINE +
-                "  Note                     = {some note}," + Globals.NEWLINE +
-                "  Number                   = {1}," + Globals.NEWLINE +
-                "  HowPublished             = {asdf}," + Globals.NEWLINE +
+        String bibtexEntry = StringUtil.NEWLINE + "@Article{test," + StringUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
+                "  Note                     = {some note}," + StringUtil.NEWLINE +
+                "  Number                   = {1}," + StringUtil.NEWLINE +
+                "  HowPublished             = {asdf}," + StringUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -180,13 +181,13 @@ public class BibEntryWriterTest {
         String actual = stringWriter.toString();
 
         // @formatter:off
-        String expected = Globals.NEWLINE + "@Article{test," + Globals.NEWLINE +
-                "  author       = {BlaBla}," + Globals.NEWLINE +
-                "  journal      = {International Journal of Something}," + Globals.NEWLINE +
-                "  number       = {1}," + Globals.NEWLINE +
-                "  note         = {some note}," + Globals.NEWLINE +
-                "  howpublished = {asdf}," + Globals.NEWLINE +
-                "}" + Globals.NEWLINE;
+        String expected = StringUtil.NEWLINE + "@Article{test," + StringUtil.NEWLINE +
+                "  author       = {BlaBla}," + StringUtil.NEWLINE +
+                "  journal      = {International Journal of Something}," + StringUtil.NEWLINE +
+                "  number       = {1}," + StringUtil.NEWLINE +
+                "  note         = {some note}," + StringUtil.NEWLINE +
+                "  howpublished = {asdf}," + StringUtil.NEWLINE +
+                "}" + StringUtil.NEWLINE;
         // @formatter:on
         assertEquals(expected, actual);
     }
@@ -194,13 +195,13 @@ public class BibEntryWriterTest {
     @Test
     public void testEntryTypeChange() throws IOException {
         // @formatter:off
-        String expected = Globals.NEWLINE + "@Article{test," + Globals.NEWLINE +
-                "  author       = {BlaBla}," + Globals.NEWLINE +
-                "  journal      = {International Journal of Something}," + Globals.NEWLINE +
-                "  number       = {1}," + Globals.NEWLINE +
-                "  note         = {some note}," + Globals.NEWLINE +
-                "  howpublished = {asdf}," + Globals.NEWLINE +
-                "}" + Globals.NEWLINE;
+        String expected = StringUtil.NEWLINE + "@Article{test," + StringUtil.NEWLINE +
+                "  author       = {BlaBla}," + StringUtil.NEWLINE +
+                "  journal      = {International Journal of Something}," + StringUtil.NEWLINE +
+                "  number       = {1}," + StringUtil.NEWLINE +
+                "  note         = {some note}," + StringUtil.NEWLINE +
+                "  howpublished = {asdf}," + StringUtil.NEWLINE +
+                "}" + StringUtil.NEWLINE;
         // @formatter:on
 
         // read in bibtex string
@@ -217,13 +218,13 @@ public class BibEntryWriterTest {
         String actual = stringWriter.toString();
 
         // @formatter:off
-        String expectedNewEntry = Globals.NEWLINE + "@InProceedings{test," + Globals.NEWLINE +
-                "  author       = {BlaBla}," + Globals.NEWLINE +
-                "  number       = {1}," + Globals.NEWLINE +
-                "  note         = {some note}," + Globals.NEWLINE +
-                "  howpublished = {asdf}," + Globals.NEWLINE +
-                "  journal      = {International Journal of Something}," + Globals.NEWLINE +
-                "}" + Globals.NEWLINE;
+        String expectedNewEntry = StringUtil.NEWLINE + "@InProceedings{test," + StringUtil.NEWLINE +
+                "  author       = {BlaBla}," + StringUtil.NEWLINE +
+                "  number       = {1}," + StringUtil.NEWLINE +
+                "  note         = {some note}," + StringUtil.NEWLINE +
+                "  howpublished = {asdf}," + StringUtil.NEWLINE +
+                "  journal      = {International Journal of Something}," + StringUtil.NEWLINE +
+                "}" + StringUtil.NEWLINE;
         // @formatter:on
         assertEquals(expectedNewEntry, actual);
     }
@@ -232,11 +233,11 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripWithAppendedNewlines() throws IOException {
         // @formatter:off
-        String bibtexEntry = "@Article{test," + Globals.NEWLINE +
-                "  Author                   = {Foo Bar}," + Globals.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + Globals.NEWLINE +
-                "  Note                     = {some note}," + Globals.NEWLINE +
-                "  Number                   = {1}" + Globals.NEWLINE +
+        String bibtexEntry = "@Article{test," + StringUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
+                "  Note                     = {some note}," + StringUtil.NEWLINE +
+                "  Number                   = {1}" + StringUtil.NEWLINE +
                 "}\n\n";
         // @formatter:on
 
@@ -257,11 +258,11 @@ public class BibEntryWriterTest {
     @Test
     public void multipleWritesWithoutModification() throws IOException {
         // @formatter:off
-        String bibtexEntry = "@Article{test," + Globals.NEWLINE +
-                "  Author                   = {Foo Bar}," + Globals.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + Globals.NEWLINE +
-                "  Note                     = {some note}," + Globals.NEWLINE +
-                "  Number                   = {1}" + Globals.NEWLINE +
+        String bibtexEntry = "@Article{test," + StringUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
+                "  Note                     = {some note}," + StringUtil.NEWLINE +
+                "  Number                   = {1}" + StringUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -290,10 +291,10 @@ public class BibEntryWriterTest {
     @Test
     public void monthFieldSpecialSyntax() throws IOException {
         // @formatter:off
-        String bibtexEntry = "@Article{test," + Globals.NEWLINE +
-                "  Author                   = {Foo Bar}," + Globals.NEWLINE +
-                "  Month                    = mar," + Globals.NEWLINE +
-                "  Number                   = {1}" + Globals.NEWLINE +
+        String bibtexEntry = "@Article{test," + StringUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
+                "  Month                    = mar," + StringUtil.NEWLINE +
+                "  Number                   = {1}" + StringUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -318,11 +319,11 @@ public class BibEntryWriterTest {
     @Test
     public void addFieldWithLongerLength() throws IOException {
         // @formatter:off
-        String bibtexEntry = Globals.NEWLINE + Globals.NEWLINE + "@Article{test," + Globals.NEWLINE +
-                "  author =  {BlaBla}," + Globals.NEWLINE +
-                "  journal = {International Journal of Something}," + Globals.NEWLINE +
-                "  number =  {1}," + Globals.NEWLINE +
-                "  note =    {some note}," + Globals.NEWLINE +
+        String bibtexEntry = StringUtil.NEWLINE + StringUtil.NEWLINE + "@Article{test," + StringUtil.NEWLINE +
+                "  author =  {BlaBla}," + StringUtil.NEWLINE +
+                "  journal = {International Journal of Something}," + StringUtil.NEWLINE +
+                "  number =  {1}," + StringUtil.NEWLINE +
+                "  note =    {some note}," + StringUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -340,13 +341,13 @@ public class BibEntryWriterTest {
         String actual = stringWriter.toString();
 
         // @formatter:off
-        String expected = Globals.NEWLINE + "@Article{test," + Globals.NEWLINE +
-                "  author       = {BlaBla}," + Globals.NEWLINE +
-                "  journal      = {International Journal of Something}," + Globals.NEWLINE +
-                "  number       = {1}," + Globals.NEWLINE +
-                "  note         = {some note}," + Globals.NEWLINE +
-                "  howpublished = {asdf}," + Globals.NEWLINE +
-                "}" + Globals.NEWLINE;
+        String expected = StringUtil.NEWLINE + "@Article{test," + StringUtil.NEWLINE +
+                "  author       = {BlaBla}," + StringUtil.NEWLINE +
+                "  journal      = {International Journal of Something}," + StringUtil.NEWLINE +
+                "  number       = {1}," + StringUtil.NEWLINE +
+                "  note         = {some note}," + StringUtil.NEWLINE +
+                "  howpublished = {asdf}," + StringUtil.NEWLINE +
+                "}" + StringUtil.NEWLINE;
         // @formatter:on
         assertEquals(expected, actual);
     }
@@ -363,9 +364,9 @@ public class BibEntryWriterTest {
 
         String actual = stringWriter.toString();
 
-        String expected = Globals.NEWLINE + "@Article{," + Globals.NEWLINE +
-                "  note   = {some note}," + Globals.NEWLINE +
-                "}" + Globals.NEWLINE;
+        String expected = StringUtil.NEWLINE + "@Article{," + StringUtil.NEWLINE +
+                "  note   = {some note}," + StringUtil.NEWLINE +
+                "}" + StringUtil.NEWLINE;
 
         assertEquals(expected, actual);
     }
@@ -381,9 +382,9 @@ public class BibEntryWriterTest {
 
         String actual = stringWriter.toString();
 
-        String expected = Globals.NEWLINE + "@Article{," + Globals.NEWLINE +
-                "  note = {some note}," + Globals.NEWLINE +
-                "}" + Globals.NEWLINE;
+        String expected = StringUtil.NEWLINE + "@Article{," + StringUtil.NEWLINE +
+                "  note = {some note}," + StringUtil.NEWLINE +
+                "}" + StringUtil.NEWLINE;
 
         assertEquals(expected, actual);
     }
@@ -391,12 +392,12 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripWithPrecedingCommentTest() throws IOException {
         // @formatter:off
-        String bibtexEntry = "% Some random comment that should stay here" + Globals.NEWLINE +
-                "@Article{test," + Globals.NEWLINE +
-                "  Author                   = {Foo Bar}," + Globals.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + Globals.NEWLINE +
-                "  Note                     = {some note}," + Globals.NEWLINE +
-                "  Number                   = {1}" + Globals.NEWLINE +
+        String bibtexEntry = "% Some random comment that should stay here" + StringUtil.NEWLINE +
+                "@Article{test," + StringUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
+                "  Note                     = {some note}," + StringUtil.NEWLINE +
+                "  Number                   = {1}" + StringUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -416,12 +417,12 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripWithPrecedingCommentAndModificationTest() throws IOException {
         // @formatter:off
-        String bibtexEntry = "% Some random comment that should stay here" + Globals.NEWLINE +
-                "@Article{test," + Globals.NEWLINE +
-                "  Author                   = {Foo Bar}," + Globals.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + Globals.NEWLINE +
-                "  Note                     = {some note}," + Globals.NEWLINE +
-                "  Number                   = {1}" + Globals.NEWLINE +
+        String bibtexEntry = "% Some random comment that should stay here" + StringUtil.NEWLINE +
+                "@Article{test," + StringUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
+                "  Note                     = {some note}," + StringUtil.NEWLINE +
+                "  Number                   = {1}" + StringUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -438,13 +439,13 @@ public class BibEntryWriterTest {
         writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
         String actual = stringWriter.toString();
         // @formatter:off
-        String expected = "% Some random comment that should stay here" + Globals.NEWLINE + Globals.NEWLINE +
-                "@Article{test," + Globals.NEWLINE +
-                "  author  = {John Doe}," + Globals.NEWLINE +
-                "  journal = {International Journal of Something}," + Globals.NEWLINE +
-                "  number  = {1}," + Globals.NEWLINE +
-                "  note    = {some note}," + Globals.NEWLINE +
-                "}" + Globals.NEWLINE;
+        String expected = "% Some random comment that should stay here" + StringUtil.NEWLINE + StringUtil.NEWLINE +
+                "@Article{test," + StringUtil.NEWLINE +
+                "  author  = {John Doe}," + StringUtil.NEWLINE +
+                "  journal = {International Journal of Something}," + StringUtil.NEWLINE +
+                "  number  = {1}," + StringUtil.NEWLINE +
+                "  note    = {some note}," + StringUtil.NEWLINE +
+                "}" + StringUtil.NEWLINE;
         // @formatter:on
 
         assertEquals(expected, actual);

--- a/src/test/java/net/sf/jabref/logic/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/BibEntryWriterTest.java
@@ -9,7 +9,7 @@ import java.util.Set;
 import net.sf.jabref.Globals;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
@@ -61,12 +61,12 @@ public class BibEntryWriterTest {
         String actual = stringWriter.toString();
 
         // @formatter:off
-        String expected = FileUtil.NEWLINE + "@Article{," + FileUtil.NEWLINE +
-                "  author  = {Foo Bar}," + FileUtil.NEWLINE +
-                "  journal = {International Journal of Something}," + FileUtil.NEWLINE +
-                "  number  = {1}," + FileUtil.NEWLINE +
-                "  note    = {some note}," + FileUtil.NEWLINE +
-                "}" + FileUtil.NEWLINE;
+        String expected = OS.NEWLINE + "@Article{," + OS.NEWLINE +
+                "  author  = {Foo Bar}," + OS.NEWLINE +
+                "  journal = {International Journal of Something}," + OS.NEWLINE +
+                "  number  = {1}," + OS.NEWLINE +
+                "  note    = {some note}," + OS.NEWLINE +
+                "}" + OS.NEWLINE;
         // @formatter:on
 
         assertEquals(expected, actual);
@@ -75,11 +75,11 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripTest() throws IOException {
         // @formatter:off
-        String bibtexEntry = "@Article{test," + FileUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
-                "  Note                     = {some note}," + FileUtil.NEWLINE +
-                "  Number                   = {1}" + FileUtil.NEWLINE +
+        String bibtexEntry = "@Article{test," + OS.NEWLINE +
+                "  Author                   = {Foo Bar}," + OS.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + OS.NEWLINE +
+                "  Note                     = {some note}," + OS.NEWLINE +
+                "  Number                   = {1}" + OS.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -99,11 +99,11 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripWithPrependingNewlines() throws IOException {
         // @formatter:off
-        String bibtexEntry = "\r\n@Article{test," + FileUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
-                "  Note                     = {some note}," + FileUtil.NEWLINE +
-                "  Number                   = {1}" + FileUtil.NEWLINE +
+        String bibtexEntry = "\r\n@Article{test," + OS.NEWLINE +
+                "  Author                   = {Foo Bar}," + OS.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + OS.NEWLINE +
+                "  Note                     = {some note}," + OS.NEWLINE +
+                "  Number                   = {1}" + OS.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -123,11 +123,11 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripWithModification() throws IOException {
         // @formatter:off
-        String bibtexEntry = FileUtil.NEWLINE + "@Article{test," + FileUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
-                "  Note                     = {some note}," + FileUtil.NEWLINE +
-                "  Number                   = {1}," + FileUtil.NEWLINE +
+        String bibtexEntry = OS.NEWLINE + "@Article{test," + OS.NEWLINE +
+                "  Author                   = {Foo Bar}," + OS.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + OS.NEWLINE +
+                "  Note                     = {some note}," + OS.NEWLINE +
+                "  Number                   = {1}," + OS.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -145,12 +145,12 @@ public class BibEntryWriterTest {
         String actual = stringWriter.toString();
 
         // @formatter:off
-        String expected = FileUtil.NEWLINE + "@Article{test," + FileUtil.NEWLINE +
-                "  author  = {BlaBla}," + FileUtil.NEWLINE +
-                "  journal = {International Journal of Something}," + FileUtil.NEWLINE +
-                "  number  = {1}," + FileUtil.NEWLINE +
-                "  note    = {some note}," + FileUtil.NEWLINE +
-                "}" + FileUtil.NEWLINE;
+        String expected = OS.NEWLINE + "@Article{test," + OS.NEWLINE +
+                "  author  = {BlaBla}," + OS.NEWLINE +
+                "  journal = {International Journal of Something}," + OS.NEWLINE +
+                "  number  = {1}," + OS.NEWLINE +
+                "  note    = {some note}," + OS.NEWLINE +
+                "}" + OS.NEWLINE;
         // @formatter:on
         assertEquals(expected, actual);
     }
@@ -158,12 +158,12 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripWithCamelCasingInTheOriginalEntryAndResultInLowerCase() throws IOException {
         // @formatter:off
-        String bibtexEntry = FileUtil.NEWLINE + "@Article{test," + FileUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
-                "  Note                     = {some note}," + FileUtil.NEWLINE +
-                "  Number                   = {1}," + FileUtil.NEWLINE +
-                "  HowPublished             = {asdf}," + FileUtil.NEWLINE +
+        String bibtexEntry = OS.NEWLINE + "@Article{test," + OS.NEWLINE +
+                "  Author                   = {Foo Bar}," + OS.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + OS.NEWLINE +
+                "  Note                     = {some note}," + OS.NEWLINE +
+                "  Number                   = {1}," + OS.NEWLINE +
+                "  HowPublished             = {asdf}," + OS.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -181,13 +181,13 @@ public class BibEntryWriterTest {
         String actual = stringWriter.toString();
 
         // @formatter:off
-        String expected = FileUtil.NEWLINE + "@Article{test," + FileUtil.NEWLINE +
-                "  author       = {BlaBla}," + FileUtil.NEWLINE +
-                "  journal      = {International Journal of Something}," + FileUtil.NEWLINE +
-                "  number       = {1}," + FileUtil.NEWLINE +
-                "  note         = {some note}," + FileUtil.NEWLINE +
-                "  howpublished = {asdf}," + FileUtil.NEWLINE +
-                "}" + FileUtil.NEWLINE;
+        String expected = OS.NEWLINE + "@Article{test," + OS.NEWLINE +
+                "  author       = {BlaBla}," + OS.NEWLINE +
+                "  journal      = {International Journal of Something}," + OS.NEWLINE +
+                "  number       = {1}," + OS.NEWLINE +
+                "  note         = {some note}," + OS.NEWLINE +
+                "  howpublished = {asdf}," + OS.NEWLINE +
+                "}" + OS.NEWLINE;
         // @formatter:on
         assertEquals(expected, actual);
     }
@@ -195,13 +195,13 @@ public class BibEntryWriterTest {
     @Test
     public void testEntryTypeChange() throws IOException {
         // @formatter:off
-        String expected = FileUtil.NEWLINE + "@Article{test," + FileUtil.NEWLINE +
-                "  author       = {BlaBla}," + FileUtil.NEWLINE +
-                "  journal      = {International Journal of Something}," + FileUtil.NEWLINE +
-                "  number       = {1}," + FileUtil.NEWLINE +
-                "  note         = {some note}," + FileUtil.NEWLINE +
-                "  howpublished = {asdf}," + FileUtil.NEWLINE +
-                "}" + FileUtil.NEWLINE;
+        String expected = OS.NEWLINE + "@Article{test," + OS.NEWLINE +
+                "  author       = {BlaBla}," + OS.NEWLINE +
+                "  journal      = {International Journal of Something}," + OS.NEWLINE +
+                "  number       = {1}," + OS.NEWLINE +
+                "  note         = {some note}," + OS.NEWLINE +
+                "  howpublished = {asdf}," + OS.NEWLINE +
+                "}" + OS.NEWLINE;
         // @formatter:on
 
         // read in bibtex string
@@ -218,13 +218,13 @@ public class BibEntryWriterTest {
         String actual = stringWriter.toString();
 
         // @formatter:off
-        String expectedNewEntry = FileUtil.NEWLINE + "@InProceedings{test," + FileUtil.NEWLINE +
-                "  author       = {BlaBla}," + FileUtil.NEWLINE +
-                "  number       = {1}," + FileUtil.NEWLINE +
-                "  note         = {some note}," + FileUtil.NEWLINE +
-                "  howpublished = {asdf}," + FileUtil.NEWLINE +
-                "  journal      = {International Journal of Something}," + FileUtil.NEWLINE +
-                "}" + FileUtil.NEWLINE;
+        String expectedNewEntry = OS.NEWLINE + "@InProceedings{test," + OS.NEWLINE +
+                "  author       = {BlaBla}," + OS.NEWLINE +
+                "  number       = {1}," + OS.NEWLINE +
+                "  note         = {some note}," + OS.NEWLINE +
+                "  howpublished = {asdf}," + OS.NEWLINE +
+                "  journal      = {International Journal of Something}," + OS.NEWLINE +
+                "}" + OS.NEWLINE;
         // @formatter:on
         assertEquals(expectedNewEntry, actual);
     }
@@ -233,11 +233,11 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripWithAppendedNewlines() throws IOException {
         // @formatter:off
-        String bibtexEntry = "@Article{test," + FileUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
-                "  Note                     = {some note}," + FileUtil.NEWLINE +
-                "  Number                   = {1}" + FileUtil.NEWLINE +
+        String bibtexEntry = "@Article{test," + OS.NEWLINE +
+                "  Author                   = {Foo Bar}," + OS.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + OS.NEWLINE +
+                "  Note                     = {some note}," + OS.NEWLINE +
+                "  Number                   = {1}" + OS.NEWLINE +
                 "}\n\n";
         // @formatter:on
 
@@ -258,11 +258,11 @@ public class BibEntryWriterTest {
     @Test
     public void multipleWritesWithoutModification() throws IOException {
         // @formatter:off
-        String bibtexEntry = "@Article{test," + FileUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
-                "  Note                     = {some note}," + FileUtil.NEWLINE +
-                "  Number                   = {1}" + FileUtil.NEWLINE +
+        String bibtexEntry = "@Article{test," + OS.NEWLINE +
+                "  Author                   = {Foo Bar}," + OS.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + OS.NEWLINE +
+                "  Note                     = {some note}," + OS.NEWLINE +
+                "  Number                   = {1}" + OS.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -291,10 +291,10 @@ public class BibEntryWriterTest {
     @Test
     public void monthFieldSpecialSyntax() throws IOException {
         // @formatter:off
-        String bibtexEntry = "@Article{test," + FileUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
-                "  Month                    = mar," + FileUtil.NEWLINE +
-                "  Number                   = {1}" + FileUtil.NEWLINE +
+        String bibtexEntry = "@Article{test," + OS.NEWLINE +
+                "  Author                   = {Foo Bar}," + OS.NEWLINE +
+                "  Month                    = mar," + OS.NEWLINE +
+                "  Number                   = {1}" + OS.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -319,11 +319,11 @@ public class BibEntryWriterTest {
     @Test
     public void addFieldWithLongerLength() throws IOException {
         // @formatter:off
-        String bibtexEntry = FileUtil.NEWLINE + FileUtil.NEWLINE + "@Article{test," + FileUtil.NEWLINE +
-                "  author =  {BlaBla}," + FileUtil.NEWLINE +
-                "  journal = {International Journal of Something}," + FileUtil.NEWLINE +
-                "  number =  {1}," + FileUtil.NEWLINE +
-                "  note =    {some note}," + FileUtil.NEWLINE +
+        String bibtexEntry = OS.NEWLINE + OS.NEWLINE + "@Article{test," + OS.NEWLINE +
+                "  author =  {BlaBla}," + OS.NEWLINE +
+                "  journal = {International Journal of Something}," + OS.NEWLINE +
+                "  number =  {1}," + OS.NEWLINE +
+                "  note =    {some note}," + OS.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -341,13 +341,13 @@ public class BibEntryWriterTest {
         String actual = stringWriter.toString();
 
         // @formatter:off
-        String expected = FileUtil.NEWLINE + "@Article{test," + FileUtil.NEWLINE +
-                "  author       = {BlaBla}," + FileUtil.NEWLINE +
-                "  journal      = {International Journal of Something}," + FileUtil.NEWLINE +
-                "  number       = {1}," + FileUtil.NEWLINE +
-                "  note         = {some note}," + FileUtil.NEWLINE +
-                "  howpublished = {asdf}," + FileUtil.NEWLINE +
-                "}" + FileUtil.NEWLINE;
+        String expected = OS.NEWLINE + "@Article{test," + OS.NEWLINE +
+                "  author       = {BlaBla}," + OS.NEWLINE +
+                "  journal      = {International Journal of Something}," + OS.NEWLINE +
+                "  number       = {1}," + OS.NEWLINE +
+                "  note         = {some note}," + OS.NEWLINE +
+                "  howpublished = {asdf}," + OS.NEWLINE +
+                "}" + OS.NEWLINE;
         // @formatter:on
         assertEquals(expected, actual);
     }
@@ -364,9 +364,9 @@ public class BibEntryWriterTest {
 
         String actual = stringWriter.toString();
 
-        String expected = FileUtil.NEWLINE + "@Article{," + FileUtil.NEWLINE +
-                "  note   = {some note}," + FileUtil.NEWLINE +
-                "}" + FileUtil.NEWLINE;
+        String expected = OS.NEWLINE + "@Article{," + OS.NEWLINE +
+                "  note   = {some note}," + OS.NEWLINE +
+                "}" + OS.NEWLINE;
 
         assertEquals(expected, actual);
     }
@@ -382,9 +382,9 @@ public class BibEntryWriterTest {
 
         String actual = stringWriter.toString();
 
-        String expected = FileUtil.NEWLINE + "@Article{," + FileUtil.NEWLINE +
-                "  note = {some note}," + FileUtil.NEWLINE +
-                "}" + FileUtil.NEWLINE;
+        String expected = OS.NEWLINE + "@Article{," + OS.NEWLINE +
+                "  note = {some note}," + OS.NEWLINE +
+                "}" + OS.NEWLINE;
 
         assertEquals(expected, actual);
     }
@@ -392,12 +392,12 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripWithPrecedingCommentTest() throws IOException {
         // @formatter:off
-        String bibtexEntry = "% Some random comment that should stay here" + FileUtil.NEWLINE +
-                "@Article{test," + FileUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
-                "  Note                     = {some note}," + FileUtil.NEWLINE +
-                "  Number                   = {1}" + FileUtil.NEWLINE +
+        String bibtexEntry = "% Some random comment that should stay here" + OS.NEWLINE +
+                "@Article{test," + OS.NEWLINE +
+                "  Author                   = {Foo Bar}," + OS.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + OS.NEWLINE +
+                "  Note                     = {some note}," + OS.NEWLINE +
+                "  Number                   = {1}" + OS.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -417,12 +417,12 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripWithPrecedingCommentAndModificationTest() throws IOException {
         // @formatter:off
-        String bibtexEntry = "% Some random comment that should stay here" + FileUtil.NEWLINE +
-                "@Article{test," + FileUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
-                "  Note                     = {some note}," + FileUtil.NEWLINE +
-                "  Number                   = {1}" + FileUtil.NEWLINE +
+        String bibtexEntry = "% Some random comment that should stay here" + OS.NEWLINE +
+                "@Article{test," + OS.NEWLINE +
+                "  Author                   = {Foo Bar}," + OS.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + OS.NEWLINE +
+                "  Note                     = {some note}," + OS.NEWLINE +
+                "  Number                   = {1}" + OS.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -439,13 +439,13 @@ public class BibEntryWriterTest {
         writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
         String actual = stringWriter.toString();
         // @formatter:off
-        String expected = "% Some random comment that should stay here" + FileUtil.NEWLINE + FileUtil.NEWLINE +
-                "@Article{test," + FileUtil.NEWLINE +
-                "  author  = {John Doe}," + FileUtil.NEWLINE +
-                "  journal = {International Journal of Something}," + FileUtil.NEWLINE +
-                "  number  = {1}," + FileUtil.NEWLINE +
-                "  note    = {some note}," + FileUtil.NEWLINE +
-                "}" + FileUtil.NEWLINE;
+        String expected = "% Some random comment that should stay here" + OS.NEWLINE + OS.NEWLINE +
+                "@Article{test," + OS.NEWLINE +
+                "  author  = {John Doe}," + OS.NEWLINE +
+                "  journal = {International Journal of Something}," + OS.NEWLINE +
+                "  number  = {1}," + OS.NEWLINE +
+                "  note    = {some note}," + OS.NEWLINE +
+                "}" + OS.NEWLINE;
         // @formatter:on
 
         assertEquals(expected, actual);

--- a/src/test/java/net/sf/jabref/logic/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/BibEntryWriterTest.java
@@ -9,7 +9,7 @@ import java.util.Set;
 import net.sf.jabref.Globals;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
-import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
@@ -61,12 +61,12 @@ public class BibEntryWriterTest {
         String actual = stringWriter.toString();
 
         // @formatter:off
-        String expected = StringUtil.NEWLINE + "@Article{," + StringUtil.NEWLINE +
-                "  author  = {Foo Bar}," + StringUtil.NEWLINE +
-                "  journal = {International Journal of Something}," + StringUtil.NEWLINE +
-                "  number  = {1}," + StringUtil.NEWLINE +
-                "  note    = {some note}," + StringUtil.NEWLINE +
-                "}" + StringUtil.NEWLINE;
+        String expected = FileUtil.NEWLINE + "@Article{," + FileUtil.NEWLINE +
+                "  author  = {Foo Bar}," + FileUtil.NEWLINE +
+                "  journal = {International Journal of Something}," + FileUtil.NEWLINE +
+                "  number  = {1}," + FileUtil.NEWLINE +
+                "  note    = {some note}," + FileUtil.NEWLINE +
+                "}" + FileUtil.NEWLINE;
         // @formatter:on
 
         assertEquals(expected, actual);
@@ -75,11 +75,11 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripTest() throws IOException {
         // @formatter:off
-        String bibtexEntry = "@Article{test," + StringUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
-                "  Note                     = {some note}," + StringUtil.NEWLINE +
-                "  Number                   = {1}" + StringUtil.NEWLINE +
+        String bibtexEntry = "@Article{test," + FileUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
+                "  Note                     = {some note}," + FileUtil.NEWLINE +
+                "  Number                   = {1}" + FileUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -99,11 +99,11 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripWithPrependingNewlines() throws IOException {
         // @formatter:off
-        String bibtexEntry = "\r\n@Article{test," + StringUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
-                "  Note                     = {some note}," + StringUtil.NEWLINE +
-                "  Number                   = {1}" + StringUtil.NEWLINE +
+        String bibtexEntry = "\r\n@Article{test," + FileUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
+                "  Note                     = {some note}," + FileUtil.NEWLINE +
+                "  Number                   = {1}" + FileUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -123,11 +123,11 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripWithModification() throws IOException {
         // @formatter:off
-        String bibtexEntry = StringUtil.NEWLINE + "@Article{test," + StringUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
-                "  Note                     = {some note}," + StringUtil.NEWLINE +
-                "  Number                   = {1}," + StringUtil.NEWLINE +
+        String bibtexEntry = FileUtil.NEWLINE + "@Article{test," + FileUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
+                "  Note                     = {some note}," + FileUtil.NEWLINE +
+                "  Number                   = {1}," + FileUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -145,12 +145,12 @@ public class BibEntryWriterTest {
         String actual = stringWriter.toString();
 
         // @formatter:off
-        String expected = StringUtil.NEWLINE + "@Article{test," + StringUtil.NEWLINE +
-                "  author  = {BlaBla}," + StringUtil.NEWLINE +
-                "  journal = {International Journal of Something}," + StringUtil.NEWLINE +
-                "  number  = {1}," + StringUtil.NEWLINE +
-                "  note    = {some note}," + StringUtil.NEWLINE +
-                "}" + StringUtil.NEWLINE;
+        String expected = FileUtil.NEWLINE + "@Article{test," + FileUtil.NEWLINE +
+                "  author  = {BlaBla}," + FileUtil.NEWLINE +
+                "  journal = {International Journal of Something}," + FileUtil.NEWLINE +
+                "  number  = {1}," + FileUtil.NEWLINE +
+                "  note    = {some note}," + FileUtil.NEWLINE +
+                "}" + FileUtil.NEWLINE;
         // @formatter:on
         assertEquals(expected, actual);
     }
@@ -158,12 +158,12 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripWithCamelCasingInTheOriginalEntryAndResultInLowerCase() throws IOException {
         // @formatter:off
-        String bibtexEntry = StringUtil.NEWLINE + "@Article{test," + StringUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
-                "  Note                     = {some note}," + StringUtil.NEWLINE +
-                "  Number                   = {1}," + StringUtil.NEWLINE +
-                "  HowPublished             = {asdf}," + StringUtil.NEWLINE +
+        String bibtexEntry = FileUtil.NEWLINE + "@Article{test," + FileUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
+                "  Note                     = {some note}," + FileUtil.NEWLINE +
+                "  Number                   = {1}," + FileUtil.NEWLINE +
+                "  HowPublished             = {asdf}," + FileUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -181,13 +181,13 @@ public class BibEntryWriterTest {
         String actual = stringWriter.toString();
 
         // @formatter:off
-        String expected = StringUtil.NEWLINE + "@Article{test," + StringUtil.NEWLINE +
-                "  author       = {BlaBla}," + StringUtil.NEWLINE +
-                "  journal      = {International Journal of Something}," + StringUtil.NEWLINE +
-                "  number       = {1}," + StringUtil.NEWLINE +
-                "  note         = {some note}," + StringUtil.NEWLINE +
-                "  howpublished = {asdf}," + StringUtil.NEWLINE +
-                "}" + StringUtil.NEWLINE;
+        String expected = FileUtil.NEWLINE + "@Article{test," + FileUtil.NEWLINE +
+                "  author       = {BlaBla}," + FileUtil.NEWLINE +
+                "  journal      = {International Journal of Something}," + FileUtil.NEWLINE +
+                "  number       = {1}," + FileUtil.NEWLINE +
+                "  note         = {some note}," + FileUtil.NEWLINE +
+                "  howpublished = {asdf}," + FileUtil.NEWLINE +
+                "}" + FileUtil.NEWLINE;
         // @formatter:on
         assertEquals(expected, actual);
     }
@@ -195,13 +195,13 @@ public class BibEntryWriterTest {
     @Test
     public void testEntryTypeChange() throws IOException {
         // @formatter:off
-        String expected = StringUtil.NEWLINE + "@Article{test," + StringUtil.NEWLINE +
-                "  author       = {BlaBla}," + StringUtil.NEWLINE +
-                "  journal      = {International Journal of Something}," + StringUtil.NEWLINE +
-                "  number       = {1}," + StringUtil.NEWLINE +
-                "  note         = {some note}," + StringUtil.NEWLINE +
-                "  howpublished = {asdf}," + StringUtil.NEWLINE +
-                "}" + StringUtil.NEWLINE;
+        String expected = FileUtil.NEWLINE + "@Article{test," + FileUtil.NEWLINE +
+                "  author       = {BlaBla}," + FileUtil.NEWLINE +
+                "  journal      = {International Journal of Something}," + FileUtil.NEWLINE +
+                "  number       = {1}," + FileUtil.NEWLINE +
+                "  note         = {some note}," + FileUtil.NEWLINE +
+                "  howpublished = {asdf}," + FileUtil.NEWLINE +
+                "}" + FileUtil.NEWLINE;
         // @formatter:on
 
         // read in bibtex string
@@ -218,13 +218,13 @@ public class BibEntryWriterTest {
         String actual = stringWriter.toString();
 
         // @formatter:off
-        String expectedNewEntry = StringUtil.NEWLINE + "@InProceedings{test," + StringUtil.NEWLINE +
-                "  author       = {BlaBla}," + StringUtil.NEWLINE +
-                "  number       = {1}," + StringUtil.NEWLINE +
-                "  note         = {some note}," + StringUtil.NEWLINE +
-                "  howpublished = {asdf}," + StringUtil.NEWLINE +
-                "  journal      = {International Journal of Something}," + StringUtil.NEWLINE +
-                "}" + StringUtil.NEWLINE;
+        String expectedNewEntry = FileUtil.NEWLINE + "@InProceedings{test," + FileUtil.NEWLINE +
+                "  author       = {BlaBla}," + FileUtil.NEWLINE +
+                "  number       = {1}," + FileUtil.NEWLINE +
+                "  note         = {some note}," + FileUtil.NEWLINE +
+                "  howpublished = {asdf}," + FileUtil.NEWLINE +
+                "  journal      = {International Journal of Something}," + FileUtil.NEWLINE +
+                "}" + FileUtil.NEWLINE;
         // @formatter:on
         assertEquals(expectedNewEntry, actual);
     }
@@ -233,11 +233,11 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripWithAppendedNewlines() throws IOException {
         // @formatter:off
-        String bibtexEntry = "@Article{test," + StringUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
-                "  Note                     = {some note}," + StringUtil.NEWLINE +
-                "  Number                   = {1}" + StringUtil.NEWLINE +
+        String bibtexEntry = "@Article{test," + FileUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
+                "  Note                     = {some note}," + FileUtil.NEWLINE +
+                "  Number                   = {1}" + FileUtil.NEWLINE +
                 "}\n\n";
         // @formatter:on
 
@@ -258,11 +258,11 @@ public class BibEntryWriterTest {
     @Test
     public void multipleWritesWithoutModification() throws IOException {
         // @formatter:off
-        String bibtexEntry = "@Article{test," + StringUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
-                "  Note                     = {some note}," + StringUtil.NEWLINE +
-                "  Number                   = {1}" + StringUtil.NEWLINE +
+        String bibtexEntry = "@Article{test," + FileUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
+                "  Note                     = {some note}," + FileUtil.NEWLINE +
+                "  Number                   = {1}" + FileUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -291,10 +291,10 @@ public class BibEntryWriterTest {
     @Test
     public void monthFieldSpecialSyntax() throws IOException {
         // @formatter:off
-        String bibtexEntry = "@Article{test," + StringUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
-                "  Month                    = mar," + StringUtil.NEWLINE +
-                "  Number                   = {1}" + StringUtil.NEWLINE +
+        String bibtexEntry = "@Article{test," + FileUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
+                "  Month                    = mar," + FileUtil.NEWLINE +
+                "  Number                   = {1}" + FileUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -319,11 +319,11 @@ public class BibEntryWriterTest {
     @Test
     public void addFieldWithLongerLength() throws IOException {
         // @formatter:off
-        String bibtexEntry = StringUtil.NEWLINE + StringUtil.NEWLINE + "@Article{test," + StringUtil.NEWLINE +
-                "  author =  {BlaBla}," + StringUtil.NEWLINE +
-                "  journal = {International Journal of Something}," + StringUtil.NEWLINE +
-                "  number =  {1}," + StringUtil.NEWLINE +
-                "  note =    {some note}," + StringUtil.NEWLINE +
+        String bibtexEntry = FileUtil.NEWLINE + FileUtil.NEWLINE + "@Article{test," + FileUtil.NEWLINE +
+                "  author =  {BlaBla}," + FileUtil.NEWLINE +
+                "  journal = {International Journal of Something}," + FileUtil.NEWLINE +
+                "  number =  {1}," + FileUtil.NEWLINE +
+                "  note =    {some note}," + FileUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -341,13 +341,13 @@ public class BibEntryWriterTest {
         String actual = stringWriter.toString();
 
         // @formatter:off
-        String expected = StringUtil.NEWLINE + "@Article{test," + StringUtil.NEWLINE +
-                "  author       = {BlaBla}," + StringUtil.NEWLINE +
-                "  journal      = {International Journal of Something}," + StringUtil.NEWLINE +
-                "  number       = {1}," + StringUtil.NEWLINE +
-                "  note         = {some note}," + StringUtil.NEWLINE +
-                "  howpublished = {asdf}," + StringUtil.NEWLINE +
-                "}" + StringUtil.NEWLINE;
+        String expected = FileUtil.NEWLINE + "@Article{test," + FileUtil.NEWLINE +
+                "  author       = {BlaBla}," + FileUtil.NEWLINE +
+                "  journal      = {International Journal of Something}," + FileUtil.NEWLINE +
+                "  number       = {1}," + FileUtil.NEWLINE +
+                "  note         = {some note}," + FileUtil.NEWLINE +
+                "  howpublished = {asdf}," + FileUtil.NEWLINE +
+                "}" + FileUtil.NEWLINE;
         // @formatter:on
         assertEquals(expected, actual);
     }
@@ -364,9 +364,9 @@ public class BibEntryWriterTest {
 
         String actual = stringWriter.toString();
 
-        String expected = StringUtil.NEWLINE + "@Article{," + StringUtil.NEWLINE +
-                "  note   = {some note}," + StringUtil.NEWLINE +
-                "}" + StringUtil.NEWLINE;
+        String expected = FileUtil.NEWLINE + "@Article{," + FileUtil.NEWLINE +
+                "  note   = {some note}," + FileUtil.NEWLINE +
+                "}" + FileUtil.NEWLINE;
 
         assertEquals(expected, actual);
     }
@@ -382,9 +382,9 @@ public class BibEntryWriterTest {
 
         String actual = stringWriter.toString();
 
-        String expected = StringUtil.NEWLINE + "@Article{," + StringUtil.NEWLINE +
-                "  note = {some note}," + StringUtil.NEWLINE +
-                "}" + StringUtil.NEWLINE;
+        String expected = FileUtil.NEWLINE + "@Article{," + FileUtil.NEWLINE +
+                "  note = {some note}," + FileUtil.NEWLINE +
+                "}" + FileUtil.NEWLINE;
 
         assertEquals(expected, actual);
     }
@@ -392,12 +392,12 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripWithPrecedingCommentTest() throws IOException {
         // @formatter:off
-        String bibtexEntry = "% Some random comment that should stay here" + StringUtil.NEWLINE +
-                "@Article{test," + StringUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
-                "  Note                     = {some note}," + StringUtil.NEWLINE +
-                "  Number                   = {1}" + StringUtil.NEWLINE +
+        String bibtexEntry = "% Some random comment that should stay here" + FileUtil.NEWLINE +
+                "@Article{test," + FileUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
+                "  Note                     = {some note}," + FileUtil.NEWLINE +
+                "  Number                   = {1}" + FileUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -417,12 +417,12 @@ public class BibEntryWriterTest {
     @Test
     public void roundTripWithPrecedingCommentAndModificationTest() throws IOException {
         // @formatter:off
-        String bibtexEntry = "% Some random comment that should stay here" + StringUtil.NEWLINE +
-                "@Article{test," + StringUtil.NEWLINE +
-                "  Author                   = {Foo Bar}," + StringUtil.NEWLINE +
-                "  Journal                  = {International Journal of Something}," + StringUtil.NEWLINE +
-                "  Note                     = {some note}," + StringUtil.NEWLINE +
-                "  Number                   = {1}" + StringUtil.NEWLINE +
+        String bibtexEntry = "% Some random comment that should stay here" + FileUtil.NEWLINE +
+                "@Article{test," + FileUtil.NEWLINE +
+                "  Author                   = {Foo Bar}," + FileUtil.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + FileUtil.NEWLINE +
+                "  Note                     = {some note}," + FileUtil.NEWLINE +
+                "  Number                   = {1}" + FileUtil.NEWLINE +
                 "}";
         // @formatter:on
 
@@ -439,13 +439,13 @@ public class BibEntryWriterTest {
         writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
         String actual = stringWriter.toString();
         // @formatter:off
-        String expected = "% Some random comment that should stay here" + StringUtil.NEWLINE + StringUtil.NEWLINE +
-                "@Article{test," + StringUtil.NEWLINE +
-                "  author  = {John Doe}," + StringUtil.NEWLINE +
-                "  journal = {International Journal of Something}," + StringUtil.NEWLINE +
-                "  number  = {1}," + StringUtil.NEWLINE +
-                "  note    = {some note}," + StringUtil.NEWLINE +
-                "}" + StringUtil.NEWLINE;
+        String expected = "% Some random comment that should stay here" + FileUtil.NEWLINE + FileUtil.NEWLINE +
+                "@Article{test," + FileUtil.NEWLINE +
+                "  author  = {John Doe}," + FileUtil.NEWLINE +
+                "  journal = {International Journal of Something}," + FileUtil.NEWLINE +
+                "  number  = {1}," + FileUtil.NEWLINE +
+                "  note    = {some note}," + FileUtil.NEWLINE +
+                "}" + FileUtil.NEWLINE;
         // @formatter:on
 
         assertEquals(expected, actual);

--- a/src/test/java/net/sf/jabref/logic/bibtex/FieldContentParserTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/FieldContentParserTest.java
@@ -1,6 +1,7 @@
 package net.sf.jabref.logic.bibtex;
 
 import net.sf.jabref.Globals;
+import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
@@ -26,7 +27,7 @@ public class FieldContentParserTest {
     @Test
     public void unifiesLineBreaks() {
         String original = "I\r\nunify\nline\rbreaks.";
-        String expected = "I\nunify\nline\nbreaks.".replace("\n", Globals.NEWLINE);
+        String expected = "I\nunify\nline\nbreaks.".replace("\n", StringUtil.NEWLINE);
         String processed = parser.format(new StringBuilder(original), "abstract").toString();
 
         assertEquals(expected, processed);
@@ -35,7 +36,7 @@ public class FieldContentParserTest {
     @Test
     public void retainsWhitespaceForMultiLineFields() {
         String original = "I\nkeep\nline\nbreaks\nand\n\ttabs.";
-        String formatted = original.replace("\n", Globals.NEWLINE);
+        String formatted = original.replace("\n", StringUtil.NEWLINE);
 
         String abstrakt = parser.format(new StringBuilder(original), "abstract").toString();
         String review = parser.format(new StringBuilder(original), "review").toString();

--- a/src/test/java/net/sf/jabref/logic/bibtex/FieldContentParserTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/FieldContentParserTest.java
@@ -1,7 +1,7 @@
 package net.sf.jabref.logic.bibtex;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
@@ -27,7 +27,7 @@ public class FieldContentParserTest {
     @Test
     public void unifiesLineBreaks() {
         String original = "I\r\nunify\nline\rbreaks.";
-        String expected = "I\nunify\nline\nbreaks.".replace("\n", FileUtil.NEWLINE);
+        String expected = "I\nunify\nline\nbreaks.".replace("\n", OS.NEWLINE);
         String processed = parser.format(new StringBuilder(original), "abstract").toString();
 
         assertEquals(expected, processed);
@@ -36,7 +36,7 @@ public class FieldContentParserTest {
     @Test
     public void retainsWhitespaceForMultiLineFields() {
         String original = "I\nkeep\nline\nbreaks\nand\n\ttabs.";
-        String formatted = original.replace("\n", FileUtil.NEWLINE);
+        String formatted = original.replace("\n", OS.NEWLINE);
 
         String abstrakt = parser.format(new StringBuilder(original), "abstract").toString();
         String review = parser.format(new StringBuilder(original), "review").toString();

--- a/src/test/java/net/sf/jabref/logic/bibtex/FieldContentParserTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/FieldContentParserTest.java
@@ -1,7 +1,7 @@
 package net.sf.jabref.logic.bibtex;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
@@ -27,7 +27,7 @@ public class FieldContentParserTest {
     @Test
     public void unifiesLineBreaks() {
         String original = "I\r\nunify\nline\rbreaks.";
-        String expected = "I\nunify\nline\nbreaks.".replace("\n", StringUtil.NEWLINE);
+        String expected = "I\nunify\nline\nbreaks.".replace("\n", FileUtil.NEWLINE);
         String processed = parser.format(new StringBuilder(original), "abstract").toString();
 
         assertEquals(expected, processed);
@@ -36,7 +36,7 @@ public class FieldContentParserTest {
     @Test
     public void retainsWhitespaceForMultiLineFields() {
         String original = "I\nkeep\nline\nbreaks\nand\n\ttabs.";
-        String formatted = original.replace("\n", StringUtil.NEWLINE);
+        String formatted = original.replace("\n", FileUtil.NEWLINE);
 
         String abstrakt = parser.format(new StringBuilder(original), "abstract").toString();
         String review = parser.format(new StringBuilder(original), "review").toString();

--- a/src/test/java/net/sf/jabref/logic/bibtex/LatexFieldFormatterTests.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/LatexFieldFormatterTests.java
@@ -1,7 +1,7 @@
 package net.sf.jabref.logic.bibtex;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
@@ -27,13 +27,13 @@ public class LatexFieldFormatterTests {
     @Test
     public void normalizeNewlineInAbstractField() {
         String fieldName = "abstract";
-        String text = "lorem" + StringUtil.NEWLINE + " ipsum lorem ipsum\nlorem ipsum \rlorem ipsum\r\ntest";
+        String text = "lorem" + FileUtil.NEWLINE + " ipsum lorem ipsum\nlorem ipsum \rlorem ipsum\r\ntest";
 
         // The newlines are normalized according to the globally configured newline setting in the formatter
-        String expected = "{" + "lorem" + StringUtil.NEWLINE + " ipsum lorem ipsum" + StringUtil.NEWLINE
+        String expected = "{" + "lorem" + FileUtil.NEWLINE + " ipsum lorem ipsum" + FileUtil.NEWLINE
  + "lorem ipsum "
-                + StringUtil.NEWLINE + "lorem ipsum"
-                + StringUtil.NEWLINE + "test" + "}";
+                + FileUtil.NEWLINE + "lorem ipsum"
+                + FileUtil.NEWLINE + "test" + "}";
 
         String result = formatter.format(text, fieldName);
 
@@ -44,7 +44,7 @@ public class LatexFieldFormatterTests {
     public void preserveNewlineInAbstractField() {
         String fieldName = "abstract";
         // The newlines are normalized according to the globally configured newline setting in the formatter
-        String text = "lorem ipsum lorem ipsum" + StringUtil.NEWLINE + "lorem ipsum lorem ipsum" + StringUtil.NEWLINE;
+        String text = "lorem ipsum lorem ipsum" + FileUtil.NEWLINE + "lorem ipsum lorem ipsum" + FileUtil.NEWLINE;
 
         String result = formatter.format(text, fieldName);
         String expected = "{" + text + "}";
@@ -56,8 +56,8 @@ public class LatexFieldFormatterTests {
     public void preserveMultipleNewlinesInAbstractField() {
         String fieldName = "abstract";
         // The newlines are normalized according to the globally configured newline setting in the formatter
-        String text = "lorem ipsum lorem ipsum" + StringUtil.NEWLINE + StringUtil.NEWLINE + "lorem ipsum lorem ipsum"
-                + StringUtil.NEWLINE;
+        String text = "lorem ipsum lorem ipsum" + FileUtil.NEWLINE + FileUtil.NEWLINE + "lorem ipsum lorem ipsum"
+                + FileUtil.NEWLINE;
 
         String result = formatter.format(text, fieldName);
         String expected = "{" + text + "}";
@@ -69,7 +69,7 @@ public class LatexFieldFormatterTests {
     public void preserveNewlineInReviewField() {
         String fieldName = "review";
         // The newlines are normalized according to the globally configured newline setting in the formatter
-        String text = "lorem ipsum lorem ipsum" + StringUtil.NEWLINE + "lorem ipsum lorem ipsum" + StringUtil.NEWLINE;
+        String text = "lorem ipsum lorem ipsum" + FileUtil.NEWLINE + "lorem ipsum lorem ipsum" + FileUtil.NEWLINE;
 
         String result = formatter.format(text, fieldName);
         String expected = "{"+text+"}";

--- a/src/test/java/net/sf/jabref/logic/bibtex/LatexFieldFormatterTests.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/LatexFieldFormatterTests.java
@@ -1,6 +1,7 @@
 package net.sf.jabref.logic.bibtex;
 
 import net.sf.jabref.Globals;
+import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
@@ -26,13 +27,13 @@ public class LatexFieldFormatterTests {
     @Test
     public void normalizeNewlineInAbstractField() {
         String fieldName = "abstract";
-        String text = "lorem" + Globals.NEWLINE + " ipsum lorem ipsum\nlorem ipsum \rlorem ipsum\r\ntest";
+        String text = "lorem" + StringUtil.NEWLINE + " ipsum lorem ipsum\nlorem ipsum \rlorem ipsum\r\ntest";
 
         // The newlines are normalized according to the globally configured newline setting in the formatter
-        String expected = "{" + "lorem" + Globals.NEWLINE + " ipsum lorem ipsum" + Globals.NEWLINE
+        String expected = "{" + "lorem" + StringUtil.NEWLINE + " ipsum lorem ipsum" + StringUtil.NEWLINE
  + "lorem ipsum "
-                + Globals.NEWLINE + "lorem ipsum"
-                + Globals.NEWLINE + "test" + "}";
+                + StringUtil.NEWLINE + "lorem ipsum"
+                + StringUtil.NEWLINE + "test" + "}";
 
         String result = formatter.format(text, fieldName);
 
@@ -43,7 +44,7 @@ public class LatexFieldFormatterTests {
     public void preserveNewlineInAbstractField() {
         String fieldName = "abstract";
         // The newlines are normalized according to the globally configured newline setting in the formatter
-        String text = "lorem ipsum lorem ipsum" + Globals.NEWLINE + "lorem ipsum lorem ipsum" + Globals.NEWLINE;
+        String text = "lorem ipsum lorem ipsum" + StringUtil.NEWLINE + "lorem ipsum lorem ipsum" + StringUtil.NEWLINE;
 
         String result = formatter.format(text, fieldName);
         String expected = "{" + text + "}";
@@ -55,8 +56,8 @@ public class LatexFieldFormatterTests {
     public void preserveMultipleNewlinesInAbstractField() {
         String fieldName = "abstract";
         // The newlines are normalized according to the globally configured newline setting in the formatter
-        String text = "lorem ipsum lorem ipsum" + Globals.NEWLINE + Globals.NEWLINE + "lorem ipsum lorem ipsum"
-                + Globals.NEWLINE;
+        String text = "lorem ipsum lorem ipsum" + StringUtil.NEWLINE + StringUtil.NEWLINE + "lorem ipsum lorem ipsum"
+                + StringUtil.NEWLINE;
 
         String result = formatter.format(text, fieldName);
         String expected = "{" + text + "}";
@@ -68,7 +69,7 @@ public class LatexFieldFormatterTests {
     public void preserveNewlineInReviewField() {
         String fieldName = "review";
         // The newlines are normalized according to the globally configured newline setting in the formatter
-        String text = "lorem ipsum lorem ipsum" + Globals.NEWLINE + "lorem ipsum lorem ipsum" + Globals.NEWLINE;
+        String text = "lorem ipsum lorem ipsum" + StringUtil.NEWLINE + "lorem ipsum lorem ipsum" + StringUtil.NEWLINE;
 
         String result = formatter.format(text, fieldName);
         String expected = "{"+text+"}";

--- a/src/test/java/net/sf/jabref/logic/bibtex/LatexFieldFormatterTests.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/LatexFieldFormatterTests.java
@@ -1,7 +1,7 @@
 package net.sf.jabref.logic.bibtex;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
@@ -27,13 +27,13 @@ public class LatexFieldFormatterTests {
     @Test
     public void normalizeNewlineInAbstractField() {
         String fieldName = "abstract";
-        String text = "lorem" + FileUtil.NEWLINE + " ipsum lorem ipsum\nlorem ipsum \rlorem ipsum\r\ntest";
+        String text = "lorem" + OS.NEWLINE + " ipsum lorem ipsum\nlorem ipsum \rlorem ipsum\r\ntest";
 
         // The newlines are normalized according to the globally configured newline setting in the formatter
-        String expected = "{" + "lorem" + FileUtil.NEWLINE + " ipsum lorem ipsum" + FileUtil.NEWLINE
+        String expected = "{" + "lorem" + OS.NEWLINE + " ipsum lorem ipsum" + OS.NEWLINE
  + "lorem ipsum "
-                + FileUtil.NEWLINE + "lorem ipsum"
-                + FileUtil.NEWLINE + "test" + "}";
+                + OS.NEWLINE + "lorem ipsum"
+                + OS.NEWLINE + "test" + "}";
 
         String result = formatter.format(text, fieldName);
 
@@ -44,7 +44,7 @@ public class LatexFieldFormatterTests {
     public void preserveNewlineInAbstractField() {
         String fieldName = "abstract";
         // The newlines are normalized according to the globally configured newline setting in the formatter
-        String text = "lorem ipsum lorem ipsum" + FileUtil.NEWLINE + "lorem ipsum lorem ipsum" + FileUtil.NEWLINE;
+        String text = "lorem ipsum lorem ipsum" + OS.NEWLINE + "lorem ipsum lorem ipsum" + OS.NEWLINE;
 
         String result = formatter.format(text, fieldName);
         String expected = "{" + text + "}";
@@ -56,8 +56,8 @@ public class LatexFieldFormatterTests {
     public void preserveMultipleNewlinesInAbstractField() {
         String fieldName = "abstract";
         // The newlines are normalized according to the globally configured newline setting in the formatter
-        String text = "lorem ipsum lorem ipsum" + FileUtil.NEWLINE + FileUtil.NEWLINE + "lorem ipsum lorem ipsum"
-                + FileUtil.NEWLINE;
+        String text = "lorem ipsum lorem ipsum" + OS.NEWLINE + OS.NEWLINE + "lorem ipsum lorem ipsum"
+                + OS.NEWLINE;
 
         String result = formatter.format(text, fieldName);
         String expected = "{" + text + "}";
@@ -69,7 +69,7 @@ public class LatexFieldFormatterTests {
     public void preserveNewlineInReviewField() {
         String fieldName = "review";
         // The newlines are normalized according to the globally configured newline setting in the formatter
-        String text = "lorem ipsum lorem ipsum" + FileUtil.NEWLINE + "lorem ipsum lorem ipsum" + FileUtil.NEWLINE;
+        String text = "lorem ipsum lorem ipsum" + OS.NEWLINE + "lorem ipsum lorem ipsum" + OS.NEWLINE;
 
         String result = formatter.format(text, fieldName);
         String expected = "{"+text+"}";

--- a/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -24,7 +24,7 @@ import net.sf.jabref.logic.groups.GroupHierarchyType;
 import net.sf.jabref.logic.groups.GroupTreeNode;
 import net.sf.jabref.logic.labelpattern.AbstractLabelPattern;
 import net.sf.jabref.logic.labelpattern.DatabaseLabelPattern;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
@@ -81,7 +81,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
 
-        assertEquals("% Encoding: US-ASCII" + FileUtil.NEWLINE, session.getStringValue());
+        assertEquals("% Encoding: US-ASCII" + OS.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -90,7 +90,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(FileUtil.NEWLINE + "@Preamble{Test preamble}" + FileUtil.NEWLINE, session.getStringValue());
+        assertEquals(OS.NEWLINE + "@Preamble{Test preamble}" + OS.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -100,8 +100,8 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
 
-        assertEquals("% Encoding: US-ASCII" + FileUtil.NEWLINE + FileUtil.NEWLINE +
-                "@Preamble{Test preamble}" + FileUtil.NEWLINE, session.getStringValue());
+        assertEquals("% Encoding: US-ASCII" + OS.NEWLINE + OS.NEWLINE +
+                "@Preamble{Test preamble}" + OS.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -112,10 +112,10 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), new SavePreferences());
 
-        assertEquals(FileUtil.NEWLINE +
-                "@Article{," + FileUtil.NEWLINE + "}" + FileUtil.NEWLINE + FileUtil.NEWLINE
+        assertEquals(OS.NEWLINE +
+                "@Article{," + OS.NEWLINE + "}" + OS.NEWLINE + OS.NEWLINE
                 + "@Comment{jabref-meta: databaseType:bibtex;}"
-                + FileUtil.NEWLINE, session.getStringValue());
+                + OS.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -127,11 +127,11 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), preferences);
 
-        assertEquals("% Encoding: US-ASCII" + FileUtil.NEWLINE + FileUtil.NEWLINE +
-                "@Article{," + FileUtil.NEWLINE + "}"
-                + FileUtil.NEWLINE + FileUtil.NEWLINE
+        assertEquals("% Encoding: US-ASCII" + OS.NEWLINE + OS.NEWLINE +
+                "@Article{," + OS.NEWLINE + "}"
+                + OS.NEWLINE + OS.NEWLINE
                 + "@Comment{jabref-meta: databaseType:bibtex;}"
-                + FileUtil.NEWLINE, session.getStringValue());
+                + OS.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -140,7 +140,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(FileUtil.NEWLINE + "Test epilog" + FileUtil.NEWLINE, session.getStringValue());
+        assertEquals(OS.NEWLINE + "Test epilog" + OS.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -150,8 +150,8 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
 
-        assertEquals("% Encoding: US-ASCII" + FileUtil.NEWLINE + FileUtil.NEWLINE +
-                "Test epilog" + FileUtil.NEWLINE, session.getStringValue());
+        assertEquals("% Encoding: US-ASCII" + OS.NEWLINE + OS.NEWLINE +
+                "Test epilog" + OS.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -162,7 +162,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(FileUtil.NEWLINE + "@Comment{jabref-meta: keypatterndefault:test;}" + FileUtil.NEWLINE,
+        assertEquals(OS.NEWLINE + "@Comment{jabref-meta: keypatterndefault:test;}" + OS.NEWLINE,
                 session.getStringValue());
     }
 
@@ -175,9 +175,9 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
 
-        assertEquals("% Encoding: US-ASCII" + FileUtil.NEWLINE + FileUtil.NEWLINE
+        assertEquals("% Encoding: US-ASCII" + OS.NEWLINE + OS.NEWLINE
                 +
-                "@Comment{jabref-meta: keypatterndefault:test;}" + FileUtil.NEWLINE, session.getStringValue());
+                "@Comment{jabref-meta: keypatterndefault:test;}" + OS.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -189,11 +189,11 @@ public class BibtexDatabaseWriterTest {
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
         // @formatter:off
-        assertEquals(FileUtil.NEWLINE
-                + "@Comment{jabref-meta: groupstree:" + FileUtil.NEWLINE
-                + "0 AllEntriesGroup:;" + FileUtil.NEWLINE
-                + "1 ExplicitGroup:test\\;2\\;;" + FileUtil.NEWLINE
-                + "}" + FileUtil.NEWLINE, session.getStringValue());
+        assertEquals(OS.NEWLINE
+                + "@Comment{jabref-meta: groupstree:" + OS.NEWLINE
+                + "0 AllEntriesGroup:;" + OS.NEWLINE
+                + "1 ExplicitGroup:test\\;2\\;;" + OS.NEWLINE
+                + "}" + OS.NEWLINE, session.getStringValue());
         // @formatter:on
     }
 
@@ -210,12 +210,12 @@ public class BibtexDatabaseWriterTest {
 
         // @formatter:off
         assertEquals(
-                "% Encoding: US-ASCII" + FileUtil.NEWLINE +
-                FileUtil.NEWLINE
-                + "@Comment{jabref-meta: groupstree:" + FileUtil.NEWLINE
-                + "0 AllEntriesGroup:;" + FileUtil.NEWLINE
-                + "1 ExplicitGroup:test\\;2\\;;" + FileUtil.NEWLINE
-                + "}" + FileUtil.NEWLINE, session.getStringValue());
+                "% Encoding: US-ASCII" + OS.NEWLINE +
+                OS.NEWLINE
+                + "@Comment{jabref-meta: groupstree:" + OS.NEWLINE
+                + "0 AllEntriesGroup:;" + OS.NEWLINE
+                + "1 ExplicitGroup:test\\;2\\;;" + OS.NEWLINE
+                + "}" + OS.NEWLINE, session.getStringValue());
         // @formatter:on
     }
 
@@ -225,7 +225,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(FileUtil.NEWLINE + "@String{name = {content}}" + FileUtil.NEWLINE, session.getStringValue());
+        assertEquals(OS.NEWLINE + "@String{name = {content}}" + OS.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -235,8 +235,8 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
 
-        assertEquals("% Encoding: US-ASCII" + FileUtil.NEWLINE + FileUtil.NEWLINE +
-                "@String{name = {content}}" + FileUtil.NEWLINE, session.getStringValue());
+        assertEquals("% Encoding: US-ASCII" + OS.NEWLINE + OS.NEWLINE +
+                "@String{name = {content}}" + OS.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -250,11 +250,11 @@ public class BibtexDatabaseWriterTest {
             StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), new SavePreferences());
 
             assertEquals(
-                    FileUtil.NEWLINE +
-                            "@Customizedtype{," + FileUtil.NEWLINE + "}" + FileUtil.NEWLINE + FileUtil.NEWLINE
+                    OS.NEWLINE +
+                            "@Customizedtype{," + OS.NEWLINE + "}" + OS.NEWLINE + OS.NEWLINE
                             + "@Comment{jabref-meta: databaseType:bibtex;}"
-                            + FileUtil.NEWLINE + FileUtil.NEWLINE
-                            + "@Comment{jabref-entrytype: Customizedtype: req[required] opt[optional]}" + FileUtil.NEWLINE,
+                            + OS.NEWLINE + OS.NEWLINE
+                            + "@Comment{jabref-entrytype: Customizedtype: req[required] opt[optional]}" + OS.NEWLINE,
                     session.getStringValue());
         } finally {
             EntryTypes.removeAllCustomEntryTypes();
@@ -346,8 +346,8 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), new SavePreferences());
 
-        assertEquals("presaved serialization" + FileUtil.NEWLINE + "@Comment{jabref-meta: databaseType:bibtex;}"
-                + FileUtil.NEWLINE, session.getStringValue());
+        assertEquals("presaved serialization" + OS.NEWLINE + "@Comment{jabref-meta: databaseType:bibtex;}"
+                + OS.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -362,11 +362,11 @@ public class BibtexDatabaseWriterTest {
         SavePreferences preferences = new SavePreferences().withReformatFile(true);
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), preferences);
 
-        assertEquals(FileUtil.NEWLINE +
-                        "@Article{," + FileUtil.NEWLINE + "  author = {Mr. author}," + FileUtil.NEWLINE + "}"
-                        + FileUtil.NEWLINE + FileUtil.NEWLINE
+        assertEquals(OS.NEWLINE +
+                        "@Article{," + OS.NEWLINE + "  author = {Mr. author}," + OS.NEWLINE + "}"
+                        + OS.NEWLINE + OS.NEWLINE
                         + "@Comment{jabref-meta: databaseType:bibtex;}"
-                        + FileUtil.NEWLINE,
+                        + OS.NEWLINE,
                 session.getStringValue());
     }
 
@@ -390,7 +390,7 @@ public class BibtexDatabaseWriterTest {
         SavePreferences preferences = new SavePreferences().withReformatFile(true);
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
 
-        assertEquals(FileUtil.NEWLINE + "@String{name = {content}}" + FileUtil.NEWLINE, session.getStringValue());
+        assertEquals(OS.NEWLINE + "@String{name = {content}}" + OS.NEWLINE, session.getStringValue());
 
     }
 
@@ -402,8 +402,8 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(FileUtil.NEWLINE + "@Comment{jabref-meta: saveActions:enabled;" + FileUtil.NEWLINE
-                + "title[lower_case]" + FileUtil.NEWLINE + ";}" + FileUtil.NEWLINE, session.getStringValue());
+        assertEquals(OS.NEWLINE + "@Comment{jabref-meta: saveActions:enabled;" + OS.NEWLINE
+                + "title[lower_case]" + OS.NEWLINE + ";}" + OS.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -415,9 +415,9 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(FileUtil.NEWLINE
+        assertEquals(OS.NEWLINE
                 + "@Comment{jabref-meta: saveOrderConfig:specified;author;false;year;true;abstract;false;}"
-                + FileUtil.NEWLINE, session.getStringValue());
+                + OS.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -429,8 +429,8 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(FileUtil.NEWLINE + "@Comment{jabref-meta: keypattern_article:articleTest;}" + FileUtil.NEWLINE
-                        + FileUtil.NEWLINE + "@Comment{jabref-meta: keypatterndefault:test;}" + FileUtil.NEWLINE,
+        assertEquals(OS.NEWLINE + "@Comment{jabref-meta: keypattern_article:articleTest;}" + OS.NEWLINE
+                        + OS.NEWLINE + "@Comment{jabref-meta: keypatterndefault:test;}" + OS.NEWLINE,
                 session.getStringValue());
     }
 
@@ -440,7 +440,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(FileUtil.NEWLINE + "@Comment{jabref-meta: databaseType:biblatex;}" + FileUtil.NEWLINE,
+        assertEquals(OS.NEWLINE + "@Comment{jabref-meta: databaseType:biblatex;}" + OS.NEWLINE,
                 session.getStringValue());
     }
 
@@ -450,7 +450,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(FileUtil.NEWLINE + "@Comment{jabref-meta: protectedFlag:true;}" + FileUtil.NEWLINE,
+        assertEquals(OS.NEWLINE + "@Comment{jabref-meta: protectedFlag:true;}" + OS.NEWLINE,
                 session.getStringValue());
     }
 
@@ -460,7 +460,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(FileUtil.NEWLINE + "@Comment{jabref-meta: selector_title:testWord;word2;}" + FileUtil.NEWLINE,
+        assertEquals(OS.NEWLINE + "@Comment{jabref-meta: selector_title:testWord;word2;}" + OS.NEWLINE,
                 session.getStringValue());
     }
 
@@ -471,9 +471,9 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(FileUtil.NEWLINE + "@Comment{jabref-meta: fileDirectory:\\\\Literature\\\\;}" + FileUtil.NEWLINE +
-                FileUtil.NEWLINE + "@Comment{jabref-meta: fileDirectory-defaultOwner-user:D:\\\\Documents;}"
-                + FileUtil.NEWLINE, session.getStringValue());
+        assertEquals(OS.NEWLINE + "@Comment{jabref-meta: fileDirectory:\\\\Literature\\\\;}" + OS.NEWLINE +
+                OS.NEWLINE + "@Comment{jabref-meta: fileDirectory-defaultOwner-user:D:\\\\Documents;}"
+                + OS.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -523,23 +523,23 @@ public class BibtexDatabaseWriterTest {
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, database.getEntries(), new SavePreferences());
 
         assertEquals(
-                FileUtil.NEWLINE +
-                "@Article{," + FileUtil.NEWLINE +
-                "  author = {A}," + FileUtil.NEWLINE +
-                "  year   = {2000}," + FileUtil.NEWLINE +
-                "}"  + FileUtil.NEWLINE + FileUtil.NEWLINE +
-                "@Article{," + FileUtil.NEWLINE +
-                "  author = {A}," + FileUtil.NEWLINE +
-                "  year   = {2010}," + FileUtil.NEWLINE +
-                "}" + FileUtil.NEWLINE + FileUtil.NEWLINE +
-                "@Article{," + FileUtil.NEWLINE +
-                "  author = {B}," + FileUtil.NEWLINE +
-                "  year   = {2000}," + FileUtil.NEWLINE +
-                "}" + FileUtil.NEWLINE + FileUtil.NEWLINE +
+                OS.NEWLINE +
+                "@Article{," + OS.NEWLINE +
+                "  author = {A}," + OS.NEWLINE +
+                "  year   = {2000}," + OS.NEWLINE +
+                "}"  + OS.NEWLINE + OS.NEWLINE +
+                "@Article{," + OS.NEWLINE +
+                "  author = {A}," + OS.NEWLINE +
+                "  year   = {2010}," + OS.NEWLINE +
+                "}" + OS.NEWLINE + OS.NEWLINE +
+                "@Article{," + OS.NEWLINE +
+                "  author = {B}," + OS.NEWLINE +
+                "  year   = {2000}," + OS.NEWLINE +
+                "}" + OS.NEWLINE + OS.NEWLINE +
                 "@Comment{jabref-meta: databaseType:bibtex;}"
-                 + FileUtil.NEWLINE + FileUtil.NEWLINE +
+                 + OS.NEWLINE + OS.NEWLINE +
                 "@Comment{jabref-meta: saveOrderConfig:specified;author;false;year;true;abstract;false;}" +
-                FileUtil.NEWLINE
+                OS.NEWLINE
                 , session.getStringValue());
     }
 
@@ -568,22 +568,22 @@ public class BibtexDatabaseWriterTest {
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, database.getEntries(), preferences);
 
         assertEquals(
-                FileUtil.NEWLINE +
-                        "@Article{," + FileUtil.NEWLINE +
-                        "  author = {A}," + FileUtil.NEWLINE +
-                        "  year   = {2010}," + FileUtil.NEWLINE +
-                        "}" + FileUtil.NEWLINE + FileUtil.NEWLINE +
-                        "@Article{," + FileUtil.NEWLINE +
-                        "  author = {B}," + FileUtil.NEWLINE +
-                        "  year   = {2000}," + FileUtil.NEWLINE +
-                        "}" + FileUtil.NEWLINE + FileUtil.NEWLINE +
-                        "@Article{," + FileUtil.NEWLINE +
-                        "  author = {A}," + FileUtil.NEWLINE +
-                        "  year   = {2000}," + FileUtil.NEWLINE +
+                OS.NEWLINE +
+                        "@Article{," + OS.NEWLINE +
+                        "  author = {A}," + OS.NEWLINE +
+                        "  year   = {2010}," + OS.NEWLINE +
+                        "}" + OS.NEWLINE + OS.NEWLINE +
+                        "@Article{," + OS.NEWLINE +
+                        "  author = {B}," + OS.NEWLINE +
+                        "  year   = {2000}," + OS.NEWLINE +
+                        "}" + OS.NEWLINE + OS.NEWLINE +
+                        "@Article{," + OS.NEWLINE +
+                        "  author = {A}," + OS.NEWLINE +
+                        "  year   = {2000}," + OS.NEWLINE +
                         "}"
-                        + FileUtil.NEWLINE + FileUtil.NEWLINE +
+                        + OS.NEWLINE + OS.NEWLINE +
                         "@Comment{jabref-meta: databaseType:bibtex;}"
-                        + FileUtil.NEWLINE
+                        + OS.NEWLINE
                 , session.getStringValue());
     }
 

--- a/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -24,6 +24,7 @@ import net.sf.jabref.logic.groups.GroupHierarchyType;
 import net.sf.jabref.logic.groups.GroupTreeNode;
 import net.sf.jabref.logic.labelpattern.AbstractLabelPattern;
 import net.sf.jabref.logic.labelpattern.DatabaseLabelPattern;
+import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
@@ -80,7 +81,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
 
-        assertEquals("% Encoding: US-ASCII" + Globals.NEWLINE, session.getStringValue());
+        assertEquals("% Encoding: US-ASCII" + StringUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -89,7 +90,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(Globals.NEWLINE + "@Preamble{Test preamble}" + Globals.NEWLINE, session.getStringValue());
+        assertEquals(StringUtil.NEWLINE + "@Preamble{Test preamble}" + StringUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -99,8 +100,8 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
 
-        assertEquals("% Encoding: US-ASCII" + Globals.NEWLINE + Globals.NEWLINE +
-                "@Preamble{Test preamble}" + Globals.NEWLINE, session.getStringValue());
+        assertEquals("% Encoding: US-ASCII" + StringUtil.NEWLINE + StringUtil.NEWLINE +
+                "@Preamble{Test preamble}" + StringUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -111,10 +112,10 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), new SavePreferences());
 
-        assertEquals(Globals.NEWLINE +
-                "@Article{," + Globals.NEWLINE + "}" + Globals.NEWLINE + Globals.NEWLINE
+        assertEquals(StringUtil.NEWLINE +
+                "@Article{," + StringUtil.NEWLINE + "}" + StringUtil.NEWLINE + StringUtil.NEWLINE
                 + "@Comment{jabref-meta: databaseType:bibtex;}"
-                + Globals.NEWLINE, session.getStringValue());
+                + StringUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -126,11 +127,11 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), preferences);
 
-        assertEquals("% Encoding: US-ASCII" + Globals.NEWLINE + Globals.NEWLINE +
-                "@Article{," + Globals.NEWLINE + "}"
-                + Globals.NEWLINE + Globals.NEWLINE
+        assertEquals("% Encoding: US-ASCII" + StringUtil.NEWLINE + StringUtil.NEWLINE +
+                "@Article{," + StringUtil.NEWLINE + "}"
+                + StringUtil.NEWLINE + StringUtil.NEWLINE
                 + "@Comment{jabref-meta: databaseType:bibtex;}"
-                + Globals.NEWLINE, session.getStringValue());
+                + StringUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -139,7 +140,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(Globals.NEWLINE + "Test epilog" + Globals.NEWLINE, session.getStringValue());
+        assertEquals(StringUtil.NEWLINE + "Test epilog" + StringUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -149,8 +150,8 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
 
-        assertEquals("% Encoding: US-ASCII" + Globals.NEWLINE + Globals.NEWLINE +
-                "Test epilog" + Globals.NEWLINE, session.getStringValue());
+        assertEquals("% Encoding: US-ASCII" + StringUtil.NEWLINE + StringUtil.NEWLINE +
+                "Test epilog" + StringUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -161,7 +162,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(Globals.NEWLINE + "@Comment{jabref-meta: keypatterndefault:test;}" + Globals.NEWLINE,
+        assertEquals(StringUtil.NEWLINE + "@Comment{jabref-meta: keypatterndefault:test;}" + StringUtil.NEWLINE,
                 session.getStringValue());
     }
 
@@ -174,9 +175,9 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
 
-        assertEquals("% Encoding: US-ASCII" + Globals.NEWLINE + Globals.NEWLINE
+        assertEquals("% Encoding: US-ASCII" + StringUtil.NEWLINE + StringUtil.NEWLINE
                 +
-                "@Comment{jabref-meta: keypatterndefault:test;}" + Globals.NEWLINE, session.getStringValue());
+                "@Comment{jabref-meta: keypatterndefault:test;}" + StringUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -188,11 +189,11 @@ public class BibtexDatabaseWriterTest {
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
         // @formatter:off
-        assertEquals(Globals.NEWLINE
-                + "@Comment{jabref-meta: groupstree:" + Globals.NEWLINE
-                + "0 AllEntriesGroup:;" + Globals.NEWLINE
-                + "1 ExplicitGroup:test\\;2\\;;" + Globals.NEWLINE
-                + "}" + Globals.NEWLINE, session.getStringValue());
+        assertEquals(StringUtil.NEWLINE
+                + "@Comment{jabref-meta: groupstree:" + StringUtil.NEWLINE
+                + "0 AllEntriesGroup:;" + StringUtil.NEWLINE
+                + "1 ExplicitGroup:test\\;2\\;;" + StringUtil.NEWLINE
+                + "}" + StringUtil.NEWLINE, session.getStringValue());
         // @formatter:on
     }
 
@@ -209,12 +210,12 @@ public class BibtexDatabaseWriterTest {
 
         // @formatter:off
         assertEquals(
-                "% Encoding: US-ASCII" + Globals.NEWLINE +
-                Globals.NEWLINE
-                + "@Comment{jabref-meta: groupstree:" + Globals.NEWLINE
-                + "0 AllEntriesGroup:;" + Globals.NEWLINE
-                + "1 ExplicitGroup:test\\;2\\;;" + Globals.NEWLINE
-                + "}" + Globals.NEWLINE, session.getStringValue());
+                "% Encoding: US-ASCII" + StringUtil.NEWLINE +
+                StringUtil.NEWLINE
+                + "@Comment{jabref-meta: groupstree:" + StringUtil.NEWLINE
+                + "0 AllEntriesGroup:;" + StringUtil.NEWLINE
+                + "1 ExplicitGroup:test\\;2\\;;" + StringUtil.NEWLINE
+                + "}" + StringUtil.NEWLINE, session.getStringValue());
         // @formatter:on
     }
 
@@ -224,7 +225,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(Globals.NEWLINE + "@String{name = {content}}" + Globals.NEWLINE, session.getStringValue());
+        assertEquals(StringUtil.NEWLINE + "@String{name = {content}}" + StringUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -234,8 +235,8 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
 
-        assertEquals("% Encoding: US-ASCII" + Globals.NEWLINE + Globals.NEWLINE +
-                "@String{name = {content}}" + Globals.NEWLINE, session.getStringValue());
+        assertEquals("% Encoding: US-ASCII" + StringUtil.NEWLINE + StringUtil.NEWLINE +
+                "@String{name = {content}}" + StringUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -249,11 +250,11 @@ public class BibtexDatabaseWriterTest {
             StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), new SavePreferences());
 
             assertEquals(
-                    Globals.NEWLINE +
-                            "@Customizedtype{," + Globals.NEWLINE + "}" + Globals.NEWLINE + Globals.NEWLINE
+                    StringUtil.NEWLINE +
+                            "@Customizedtype{," + StringUtil.NEWLINE + "}" + StringUtil.NEWLINE + StringUtil.NEWLINE
                             + "@Comment{jabref-meta: databaseType:bibtex;}"
-                            + Globals.NEWLINE + Globals.NEWLINE
-                            + "@Comment{jabref-entrytype: Customizedtype: req[required] opt[optional]}" + Globals.NEWLINE,
+                            + StringUtil.NEWLINE + StringUtil.NEWLINE
+                            + "@Comment{jabref-entrytype: Customizedtype: req[required] opt[optional]}" + StringUtil.NEWLINE,
                     session.getStringValue());
         } finally {
             EntryTypes.removeAllCustomEntryTypes();
@@ -345,8 +346,8 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), new SavePreferences());
 
-        assertEquals("presaved serialization" + Globals.NEWLINE + "@Comment{jabref-meta: databaseType:bibtex;}"
-                + Globals.NEWLINE, session.getStringValue());
+        assertEquals("presaved serialization" + StringUtil.NEWLINE + "@Comment{jabref-meta: databaseType:bibtex;}"
+                + StringUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -361,11 +362,11 @@ public class BibtexDatabaseWriterTest {
         SavePreferences preferences = new SavePreferences().withReformatFile(true);
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), preferences);
 
-        assertEquals(Globals.NEWLINE +
-                        "@Article{," + Globals.NEWLINE + "  author = {Mr. author}," + Globals.NEWLINE + "}"
-                        + Globals.NEWLINE + Globals.NEWLINE
+        assertEquals(StringUtil.NEWLINE +
+                        "@Article{," + StringUtil.NEWLINE + "  author = {Mr. author}," + StringUtil.NEWLINE + "}"
+                        + StringUtil.NEWLINE + StringUtil.NEWLINE
                         + "@Comment{jabref-meta: databaseType:bibtex;}"
-                        + Globals.NEWLINE,
+                        + StringUtil.NEWLINE,
                 session.getStringValue());
     }
 
@@ -389,7 +390,7 @@ public class BibtexDatabaseWriterTest {
         SavePreferences preferences = new SavePreferences().withReformatFile(true);
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
 
-        assertEquals(Globals.NEWLINE + "@String{name = {content}}" + Globals.NEWLINE, session.getStringValue());
+        assertEquals(StringUtil.NEWLINE + "@String{name = {content}}" + StringUtil.NEWLINE, session.getStringValue());
 
     }
 
@@ -401,8 +402,8 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(Globals.NEWLINE + "@Comment{jabref-meta: saveActions:enabled;" + Globals.NEWLINE
-                + "title[lower_case]" + Globals.NEWLINE + ";}" + Globals.NEWLINE, session.getStringValue());
+        assertEquals(StringUtil.NEWLINE + "@Comment{jabref-meta: saveActions:enabled;" + StringUtil.NEWLINE
+                + "title[lower_case]" + StringUtil.NEWLINE + ";}" + StringUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -414,9 +415,9 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(Globals.NEWLINE
+        assertEquals(StringUtil.NEWLINE
                 + "@Comment{jabref-meta: saveOrderConfig:specified;author;false;year;true;abstract;false;}"
-                + Globals.NEWLINE, session.getStringValue());
+                + StringUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -428,8 +429,8 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(Globals.NEWLINE + "@Comment{jabref-meta: keypattern_article:articleTest;}" + Globals.NEWLINE
-                        + Globals.NEWLINE + "@Comment{jabref-meta: keypatterndefault:test;}" + Globals.NEWLINE,
+        assertEquals(StringUtil.NEWLINE + "@Comment{jabref-meta: keypattern_article:articleTest;}" + StringUtil.NEWLINE
+                        + StringUtil.NEWLINE + "@Comment{jabref-meta: keypatterndefault:test;}" + StringUtil.NEWLINE,
                 session.getStringValue());
     }
 
@@ -439,7 +440,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(Globals.NEWLINE + "@Comment{jabref-meta: databaseType:biblatex;}" + Globals.NEWLINE,
+        assertEquals(StringUtil.NEWLINE + "@Comment{jabref-meta: databaseType:biblatex;}" + StringUtil.NEWLINE,
                 session.getStringValue());
     }
 
@@ -449,7 +450,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(Globals.NEWLINE + "@Comment{jabref-meta: protectedFlag:true;}" + Globals.NEWLINE,
+        assertEquals(StringUtil.NEWLINE + "@Comment{jabref-meta: protectedFlag:true;}" + StringUtil.NEWLINE,
                 session.getStringValue());
     }
 
@@ -459,7 +460,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(Globals.NEWLINE + "@Comment{jabref-meta: selector_title:testWord;word2;}" + Globals.NEWLINE,
+        assertEquals(StringUtil.NEWLINE + "@Comment{jabref-meta: selector_title:testWord;word2;}" + StringUtil.NEWLINE,
                 session.getStringValue());
     }
 
@@ -470,9 +471,9 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(Globals.NEWLINE + "@Comment{jabref-meta: fileDirectory:\\\\Literature\\\\;}" + Globals.NEWLINE +
-                Globals.NEWLINE + "@Comment{jabref-meta: fileDirectory-defaultOwner-user:D:\\\\Documents;}"
-                + Globals.NEWLINE, session.getStringValue());
+        assertEquals(StringUtil.NEWLINE + "@Comment{jabref-meta: fileDirectory:\\\\Literature\\\\;}" + StringUtil.NEWLINE +
+                StringUtil.NEWLINE + "@Comment{jabref-meta: fileDirectory-defaultOwner-user:D:\\\\Documents;}"
+                + StringUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -522,23 +523,23 @@ public class BibtexDatabaseWriterTest {
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, database.getEntries(), new SavePreferences());
 
         assertEquals(
-                Globals.NEWLINE +
-                "@Article{," + Globals.NEWLINE +
-                "  author = {A}," + Globals.NEWLINE +
-                "  year   = {2000}," + Globals.NEWLINE +
-                "}"  + Globals.NEWLINE + Globals.NEWLINE +
-                "@Article{," + Globals.NEWLINE +
-                "  author = {A}," + Globals.NEWLINE +
-                "  year   = {2010}," + Globals.NEWLINE +
-                "}" + Globals.NEWLINE + Globals.NEWLINE +
-                "@Article{," + Globals.NEWLINE +
-                "  author = {B}," + Globals.NEWLINE +
-                "  year   = {2000}," + Globals.NEWLINE +
-                "}" + Globals.NEWLINE + Globals.NEWLINE +
+                StringUtil.NEWLINE +
+                "@Article{," + StringUtil.NEWLINE +
+                "  author = {A}," + StringUtil.NEWLINE +
+                "  year   = {2000}," + StringUtil.NEWLINE +
+                "}"  + StringUtil.NEWLINE + StringUtil.NEWLINE +
+                "@Article{," + StringUtil.NEWLINE +
+                "  author = {A}," + StringUtil.NEWLINE +
+                "  year   = {2010}," + StringUtil.NEWLINE +
+                "}" + StringUtil.NEWLINE + StringUtil.NEWLINE +
+                "@Article{," + StringUtil.NEWLINE +
+                "  author = {B}," + StringUtil.NEWLINE +
+                "  year   = {2000}," + StringUtil.NEWLINE +
+                "}" + StringUtil.NEWLINE + StringUtil.NEWLINE +
                 "@Comment{jabref-meta: databaseType:bibtex;}"
-                 + Globals.NEWLINE + Globals.NEWLINE +
+                 + StringUtil.NEWLINE + StringUtil.NEWLINE +
                 "@Comment{jabref-meta: saveOrderConfig:specified;author;false;year;true;abstract;false;}" +
-                Globals.NEWLINE
+                StringUtil.NEWLINE
                 , session.getStringValue());
     }
 
@@ -567,22 +568,22 @@ public class BibtexDatabaseWriterTest {
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, database.getEntries(), preferences);
 
         assertEquals(
-                Globals.NEWLINE +
-                        "@Article{," + Globals.NEWLINE +
-                        "  author = {A}," + Globals.NEWLINE +
-                        "  year   = {2010}," + Globals.NEWLINE +
-                        "}" + Globals.NEWLINE + Globals.NEWLINE +
-                        "@Article{," + Globals.NEWLINE +
-                        "  author = {B}," + Globals.NEWLINE +
-                        "  year   = {2000}," + Globals.NEWLINE +
-                        "}" + Globals.NEWLINE + Globals.NEWLINE +
-                        "@Article{," + Globals.NEWLINE +
-                        "  author = {A}," + Globals.NEWLINE +
-                        "  year   = {2000}," + Globals.NEWLINE +
+                StringUtil.NEWLINE +
+                        "@Article{," + StringUtil.NEWLINE +
+                        "  author = {A}," + StringUtil.NEWLINE +
+                        "  year   = {2010}," + StringUtil.NEWLINE +
+                        "}" + StringUtil.NEWLINE + StringUtil.NEWLINE +
+                        "@Article{," + StringUtil.NEWLINE +
+                        "  author = {B}," + StringUtil.NEWLINE +
+                        "  year   = {2000}," + StringUtil.NEWLINE +
+                        "}" + StringUtil.NEWLINE + StringUtil.NEWLINE +
+                        "@Article{," + StringUtil.NEWLINE +
+                        "  author = {A}," + StringUtil.NEWLINE +
+                        "  year   = {2000}," + StringUtil.NEWLINE +
                         "}"
-                        + Globals.NEWLINE + Globals.NEWLINE +
+                        + StringUtil.NEWLINE + StringUtil.NEWLINE +
                         "@Comment{jabref-meta: databaseType:bibtex;}"
-                        + Globals.NEWLINE
+                        + StringUtil.NEWLINE
                 , session.getStringValue());
     }
 

--- a/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -24,7 +24,7 @@ import net.sf.jabref.logic.groups.GroupHierarchyType;
 import net.sf.jabref.logic.groups.GroupTreeNode;
 import net.sf.jabref.logic.labelpattern.AbstractLabelPattern;
 import net.sf.jabref.logic.labelpattern.DatabaseLabelPattern;
-import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
@@ -81,7 +81,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
 
-        assertEquals("% Encoding: US-ASCII" + StringUtil.NEWLINE, session.getStringValue());
+        assertEquals("% Encoding: US-ASCII" + FileUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -90,7 +90,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(StringUtil.NEWLINE + "@Preamble{Test preamble}" + StringUtil.NEWLINE, session.getStringValue());
+        assertEquals(FileUtil.NEWLINE + "@Preamble{Test preamble}" + FileUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -100,8 +100,8 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
 
-        assertEquals("% Encoding: US-ASCII" + StringUtil.NEWLINE + StringUtil.NEWLINE +
-                "@Preamble{Test preamble}" + StringUtil.NEWLINE, session.getStringValue());
+        assertEquals("% Encoding: US-ASCII" + FileUtil.NEWLINE + FileUtil.NEWLINE +
+                "@Preamble{Test preamble}" + FileUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -112,10 +112,10 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), new SavePreferences());
 
-        assertEquals(StringUtil.NEWLINE +
-                "@Article{," + StringUtil.NEWLINE + "}" + StringUtil.NEWLINE + StringUtil.NEWLINE
+        assertEquals(FileUtil.NEWLINE +
+                "@Article{," + FileUtil.NEWLINE + "}" + FileUtil.NEWLINE + FileUtil.NEWLINE
                 + "@Comment{jabref-meta: databaseType:bibtex;}"
-                + StringUtil.NEWLINE, session.getStringValue());
+                + FileUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -127,11 +127,11 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), preferences);
 
-        assertEquals("% Encoding: US-ASCII" + StringUtil.NEWLINE + StringUtil.NEWLINE +
-                "@Article{," + StringUtil.NEWLINE + "}"
-                + StringUtil.NEWLINE + StringUtil.NEWLINE
+        assertEquals("% Encoding: US-ASCII" + FileUtil.NEWLINE + FileUtil.NEWLINE +
+                "@Article{," + FileUtil.NEWLINE + "}"
+                + FileUtil.NEWLINE + FileUtil.NEWLINE
                 + "@Comment{jabref-meta: databaseType:bibtex;}"
-                + StringUtil.NEWLINE, session.getStringValue());
+                + FileUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -140,7 +140,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(StringUtil.NEWLINE + "Test epilog" + StringUtil.NEWLINE, session.getStringValue());
+        assertEquals(FileUtil.NEWLINE + "Test epilog" + FileUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -150,8 +150,8 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
 
-        assertEquals("% Encoding: US-ASCII" + StringUtil.NEWLINE + StringUtil.NEWLINE +
-                "Test epilog" + StringUtil.NEWLINE, session.getStringValue());
+        assertEquals("% Encoding: US-ASCII" + FileUtil.NEWLINE + FileUtil.NEWLINE +
+                "Test epilog" + FileUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -162,7 +162,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(StringUtil.NEWLINE + "@Comment{jabref-meta: keypatterndefault:test;}" + StringUtil.NEWLINE,
+        assertEquals(FileUtil.NEWLINE + "@Comment{jabref-meta: keypatterndefault:test;}" + FileUtil.NEWLINE,
                 session.getStringValue());
     }
 
@@ -175,9 +175,9 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
 
-        assertEquals("% Encoding: US-ASCII" + StringUtil.NEWLINE + StringUtil.NEWLINE
+        assertEquals("% Encoding: US-ASCII" + FileUtil.NEWLINE + FileUtil.NEWLINE
                 +
-                "@Comment{jabref-meta: keypatterndefault:test;}" + StringUtil.NEWLINE, session.getStringValue());
+                "@Comment{jabref-meta: keypatterndefault:test;}" + FileUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -189,11 +189,11 @@ public class BibtexDatabaseWriterTest {
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
         // @formatter:off
-        assertEquals(StringUtil.NEWLINE
-                + "@Comment{jabref-meta: groupstree:" + StringUtil.NEWLINE
-                + "0 AllEntriesGroup:;" + StringUtil.NEWLINE
-                + "1 ExplicitGroup:test\\;2\\;;" + StringUtil.NEWLINE
-                + "}" + StringUtil.NEWLINE, session.getStringValue());
+        assertEquals(FileUtil.NEWLINE
+                + "@Comment{jabref-meta: groupstree:" + FileUtil.NEWLINE
+                + "0 AllEntriesGroup:;" + FileUtil.NEWLINE
+                + "1 ExplicitGroup:test\\;2\\;;" + FileUtil.NEWLINE
+                + "}" + FileUtil.NEWLINE, session.getStringValue());
         // @formatter:on
     }
 
@@ -210,12 +210,12 @@ public class BibtexDatabaseWriterTest {
 
         // @formatter:off
         assertEquals(
-                "% Encoding: US-ASCII" + StringUtil.NEWLINE +
-                StringUtil.NEWLINE
-                + "@Comment{jabref-meta: groupstree:" + StringUtil.NEWLINE
-                + "0 AllEntriesGroup:;" + StringUtil.NEWLINE
-                + "1 ExplicitGroup:test\\;2\\;;" + StringUtil.NEWLINE
-                + "}" + StringUtil.NEWLINE, session.getStringValue());
+                "% Encoding: US-ASCII" + FileUtil.NEWLINE +
+                FileUtil.NEWLINE
+                + "@Comment{jabref-meta: groupstree:" + FileUtil.NEWLINE
+                + "0 AllEntriesGroup:;" + FileUtil.NEWLINE
+                + "1 ExplicitGroup:test\\;2\\;;" + FileUtil.NEWLINE
+                + "}" + FileUtil.NEWLINE, session.getStringValue());
         // @formatter:on
     }
 
@@ -225,7 +225,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(StringUtil.NEWLINE + "@String{name = {content}}" + StringUtil.NEWLINE, session.getStringValue());
+        assertEquals(FileUtil.NEWLINE + "@String{name = {content}}" + FileUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -235,8 +235,8 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
 
-        assertEquals("% Encoding: US-ASCII" + StringUtil.NEWLINE + StringUtil.NEWLINE +
-                "@String{name = {content}}" + StringUtil.NEWLINE, session.getStringValue());
+        assertEquals("% Encoding: US-ASCII" + FileUtil.NEWLINE + FileUtil.NEWLINE +
+                "@String{name = {content}}" + FileUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -250,11 +250,11 @@ public class BibtexDatabaseWriterTest {
             StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), new SavePreferences());
 
             assertEquals(
-                    StringUtil.NEWLINE +
-                            "@Customizedtype{," + StringUtil.NEWLINE + "}" + StringUtil.NEWLINE + StringUtil.NEWLINE
+                    FileUtil.NEWLINE +
+                            "@Customizedtype{," + FileUtil.NEWLINE + "}" + FileUtil.NEWLINE + FileUtil.NEWLINE
                             + "@Comment{jabref-meta: databaseType:bibtex;}"
-                            + StringUtil.NEWLINE + StringUtil.NEWLINE
-                            + "@Comment{jabref-entrytype: Customizedtype: req[required] opt[optional]}" + StringUtil.NEWLINE,
+                            + FileUtil.NEWLINE + FileUtil.NEWLINE
+                            + "@Comment{jabref-entrytype: Customizedtype: req[required] opt[optional]}" + FileUtil.NEWLINE,
                     session.getStringValue());
         } finally {
             EntryTypes.removeAllCustomEntryTypes();
@@ -346,8 +346,8 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), new SavePreferences());
 
-        assertEquals("presaved serialization" + StringUtil.NEWLINE + "@Comment{jabref-meta: databaseType:bibtex;}"
-                + StringUtil.NEWLINE, session.getStringValue());
+        assertEquals("presaved serialization" + FileUtil.NEWLINE + "@Comment{jabref-meta: databaseType:bibtex;}"
+                + FileUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -362,11 +362,11 @@ public class BibtexDatabaseWriterTest {
         SavePreferences preferences = new SavePreferences().withReformatFile(true);
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), preferences);
 
-        assertEquals(StringUtil.NEWLINE +
-                        "@Article{," + StringUtil.NEWLINE + "  author = {Mr. author}," + StringUtil.NEWLINE + "}"
-                        + StringUtil.NEWLINE + StringUtil.NEWLINE
+        assertEquals(FileUtil.NEWLINE +
+                        "@Article{," + FileUtil.NEWLINE + "  author = {Mr. author}," + FileUtil.NEWLINE + "}"
+                        + FileUtil.NEWLINE + FileUtil.NEWLINE
                         + "@Comment{jabref-meta: databaseType:bibtex;}"
-                        + StringUtil.NEWLINE,
+                        + FileUtil.NEWLINE,
                 session.getStringValue());
     }
 
@@ -390,7 +390,7 @@ public class BibtexDatabaseWriterTest {
         SavePreferences preferences = new SavePreferences().withReformatFile(true);
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
 
-        assertEquals(StringUtil.NEWLINE + "@String{name = {content}}" + StringUtil.NEWLINE, session.getStringValue());
+        assertEquals(FileUtil.NEWLINE + "@String{name = {content}}" + FileUtil.NEWLINE, session.getStringValue());
 
     }
 
@@ -402,8 +402,8 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(StringUtil.NEWLINE + "@Comment{jabref-meta: saveActions:enabled;" + StringUtil.NEWLINE
-                + "title[lower_case]" + StringUtil.NEWLINE + ";}" + StringUtil.NEWLINE, session.getStringValue());
+        assertEquals(FileUtil.NEWLINE + "@Comment{jabref-meta: saveActions:enabled;" + FileUtil.NEWLINE
+                + "title[lower_case]" + FileUtil.NEWLINE + ";}" + FileUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -415,9 +415,9 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(StringUtil.NEWLINE
+        assertEquals(FileUtil.NEWLINE
                 + "@Comment{jabref-meta: saveOrderConfig:specified;author;false;year;true;abstract;false;}"
-                + StringUtil.NEWLINE, session.getStringValue());
+                + FileUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -429,8 +429,8 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(StringUtil.NEWLINE + "@Comment{jabref-meta: keypattern_article:articleTest;}" + StringUtil.NEWLINE
-                        + StringUtil.NEWLINE + "@Comment{jabref-meta: keypatterndefault:test;}" + StringUtil.NEWLINE,
+        assertEquals(FileUtil.NEWLINE + "@Comment{jabref-meta: keypattern_article:articleTest;}" + FileUtil.NEWLINE
+                        + FileUtil.NEWLINE + "@Comment{jabref-meta: keypatterndefault:test;}" + FileUtil.NEWLINE,
                 session.getStringValue());
     }
 
@@ -440,7 +440,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(StringUtil.NEWLINE + "@Comment{jabref-meta: databaseType:biblatex;}" + StringUtil.NEWLINE,
+        assertEquals(FileUtil.NEWLINE + "@Comment{jabref-meta: databaseType:biblatex;}" + FileUtil.NEWLINE,
                 session.getStringValue());
     }
 
@@ -450,7 +450,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(StringUtil.NEWLINE + "@Comment{jabref-meta: protectedFlag:true;}" + StringUtil.NEWLINE,
+        assertEquals(FileUtil.NEWLINE + "@Comment{jabref-meta: protectedFlag:true;}" + FileUtil.NEWLINE,
                 session.getStringValue());
     }
 
@@ -460,7 +460,7 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(StringUtil.NEWLINE + "@Comment{jabref-meta: selector_title:testWord;word2;}" + StringUtil.NEWLINE,
+        assertEquals(FileUtil.NEWLINE + "@Comment{jabref-meta: selector_title:testWord;word2;}" + FileUtil.NEWLINE,
                 session.getStringValue());
     }
 
@@ -471,9 +471,9 @@ public class BibtexDatabaseWriterTest {
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
 
-        assertEquals(StringUtil.NEWLINE + "@Comment{jabref-meta: fileDirectory:\\\\Literature\\\\;}" + StringUtil.NEWLINE +
-                StringUtil.NEWLINE + "@Comment{jabref-meta: fileDirectory-defaultOwner-user:D:\\\\Documents;}"
-                + StringUtil.NEWLINE, session.getStringValue());
+        assertEquals(FileUtil.NEWLINE + "@Comment{jabref-meta: fileDirectory:\\\\Literature\\\\;}" + FileUtil.NEWLINE +
+                FileUtil.NEWLINE + "@Comment{jabref-meta: fileDirectory-defaultOwner-user:D:\\\\Documents;}"
+                + FileUtil.NEWLINE, session.getStringValue());
     }
 
     @Test
@@ -523,23 +523,23 @@ public class BibtexDatabaseWriterTest {
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, database.getEntries(), new SavePreferences());
 
         assertEquals(
-                StringUtil.NEWLINE +
-                "@Article{," + StringUtil.NEWLINE +
-                "  author = {A}," + StringUtil.NEWLINE +
-                "  year   = {2000}," + StringUtil.NEWLINE +
-                "}"  + StringUtil.NEWLINE + StringUtil.NEWLINE +
-                "@Article{," + StringUtil.NEWLINE +
-                "  author = {A}," + StringUtil.NEWLINE +
-                "  year   = {2010}," + StringUtil.NEWLINE +
-                "}" + StringUtil.NEWLINE + StringUtil.NEWLINE +
-                "@Article{," + StringUtil.NEWLINE +
-                "  author = {B}," + StringUtil.NEWLINE +
-                "  year   = {2000}," + StringUtil.NEWLINE +
-                "}" + StringUtil.NEWLINE + StringUtil.NEWLINE +
+                FileUtil.NEWLINE +
+                "@Article{," + FileUtil.NEWLINE +
+                "  author = {A}," + FileUtil.NEWLINE +
+                "  year   = {2000}," + FileUtil.NEWLINE +
+                "}"  + FileUtil.NEWLINE + FileUtil.NEWLINE +
+                "@Article{," + FileUtil.NEWLINE +
+                "  author = {A}," + FileUtil.NEWLINE +
+                "  year   = {2010}," + FileUtil.NEWLINE +
+                "}" + FileUtil.NEWLINE + FileUtil.NEWLINE +
+                "@Article{," + FileUtil.NEWLINE +
+                "  author = {B}," + FileUtil.NEWLINE +
+                "  year   = {2000}," + FileUtil.NEWLINE +
+                "}" + FileUtil.NEWLINE + FileUtil.NEWLINE +
                 "@Comment{jabref-meta: databaseType:bibtex;}"
-                 + StringUtil.NEWLINE + StringUtil.NEWLINE +
+                 + FileUtil.NEWLINE + FileUtil.NEWLINE +
                 "@Comment{jabref-meta: saveOrderConfig:specified;author;false;year;true;abstract;false;}" +
-                StringUtil.NEWLINE
+                FileUtil.NEWLINE
                 , session.getStringValue());
     }
 
@@ -568,22 +568,22 @@ public class BibtexDatabaseWriterTest {
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, database.getEntries(), preferences);
 
         assertEquals(
-                StringUtil.NEWLINE +
-                        "@Article{," + StringUtil.NEWLINE +
-                        "  author = {A}," + StringUtil.NEWLINE +
-                        "  year   = {2010}," + StringUtil.NEWLINE +
-                        "}" + StringUtil.NEWLINE + StringUtil.NEWLINE +
-                        "@Article{," + StringUtil.NEWLINE +
-                        "  author = {B}," + StringUtil.NEWLINE +
-                        "  year   = {2000}," + StringUtil.NEWLINE +
-                        "}" + StringUtil.NEWLINE + StringUtil.NEWLINE +
-                        "@Article{," + StringUtil.NEWLINE +
-                        "  author = {A}," + StringUtil.NEWLINE +
-                        "  year   = {2000}," + StringUtil.NEWLINE +
+                FileUtil.NEWLINE +
+                        "@Article{," + FileUtil.NEWLINE +
+                        "  author = {A}," + FileUtil.NEWLINE +
+                        "  year   = {2010}," + FileUtil.NEWLINE +
+                        "}" + FileUtil.NEWLINE + FileUtil.NEWLINE +
+                        "@Article{," + FileUtil.NEWLINE +
+                        "  author = {B}," + FileUtil.NEWLINE +
+                        "  year   = {2000}," + FileUtil.NEWLINE +
+                        "}" + FileUtil.NEWLINE + FileUtil.NEWLINE +
+                        "@Article{," + FileUtil.NEWLINE +
+                        "  author = {A}," + FileUtil.NEWLINE +
+                        "  year   = {2000}," + FileUtil.NEWLINE +
                         "}"
-                        + StringUtil.NEWLINE + StringUtil.NEWLINE +
+                        + FileUtil.NEWLINE + FileUtil.NEWLINE +
                         "@Comment{jabref-meta: databaseType:bibtex;}"
-                        + StringUtil.NEWLINE
+                        + FileUtil.NEWLINE
                 , session.getStringValue());
     }
 

--- a/src/test/java/net/sf/jabref/logic/layout/format/RisKeywordsTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/format/RisKeywordsTest.java
@@ -1,6 +1,6 @@
 package net.sf.jabref.logic.layout.format;
 
-import net.sf.jabref.logic.util.strings.StringUtil;
+import net.sf.jabref.logic.util.io.FileUtil;
 
 import org.junit.Test;
 
@@ -26,12 +26,12 @@ public class RisKeywordsTest {
 
     @Test
     public void testTwoKeywords() {
-        assertEquals("KW  - abcd" + StringUtil.NEWLINE + "KW  - efg", new RisKeywords().format("abcd, efg"));
+        assertEquals("KW  - abcd" + FileUtil.NEWLINE + "KW  - efg", new RisKeywords().format("abcd, efg"));
     }
 
     @Test
     public void testMultipleKeywords() {
-        assertEquals("KW  - abcd" + StringUtil.NEWLINE + "KW  - efg" + StringUtil.NEWLINE + "KW  - hij" + StringUtil.NEWLINE
+        assertEquals("KW  - abcd" + FileUtil.NEWLINE + "KW  - efg" + FileUtil.NEWLINE + "KW  - hij" + FileUtil.NEWLINE
                 + "KW  - klm", new RisKeywords().format("abcd, efg, hij, klm"));
     }
 }

--- a/src/test/java/net/sf/jabref/logic/layout/format/RisKeywordsTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/format/RisKeywordsTest.java
@@ -1,6 +1,6 @@
 package net.sf.jabref.logic.layout.format;
 
-import net.sf.jabref.Globals;
+import net.sf.jabref.logic.util.strings.StringUtil;
 
 import org.junit.Test;
 
@@ -26,12 +26,12 @@ public class RisKeywordsTest {
 
     @Test
     public void testTwoKeywords() {
-        assertEquals("KW  - abcd" + Globals.NEWLINE + "KW  - efg", new RisKeywords().format("abcd, efg"));
+        assertEquals("KW  - abcd" + StringUtil.NEWLINE + "KW  - efg", new RisKeywords().format("abcd, efg"));
     }
 
     @Test
     public void testMultipleKeywords() {
-        assertEquals("KW  - abcd" + Globals.NEWLINE + "KW  - efg" + Globals.NEWLINE + "KW  - hij" + Globals.NEWLINE
+        assertEquals("KW  - abcd" + StringUtil.NEWLINE + "KW  - efg" + StringUtil.NEWLINE + "KW  - hij" + StringUtil.NEWLINE
                 + "KW  - klm", new RisKeywords().format("abcd, efg, hij, klm"));
     }
 }

--- a/src/test/java/net/sf/jabref/logic/layout/format/RisKeywordsTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/format/RisKeywordsTest.java
@@ -1,6 +1,6 @@
 package net.sf.jabref.logic.layout.format;
 
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 
 import org.junit.Test;
 
@@ -26,12 +26,12 @@ public class RisKeywordsTest {
 
     @Test
     public void testTwoKeywords() {
-        assertEquals("KW  - abcd" + FileUtil.NEWLINE + "KW  - efg", new RisKeywords().format("abcd, efg"));
+        assertEquals("KW  - abcd" + OS.NEWLINE + "KW  - efg", new RisKeywords().format("abcd, efg"));
     }
 
     @Test
     public void testMultipleKeywords() {
-        assertEquals("KW  - abcd" + FileUtil.NEWLINE + "KW  - efg" + FileUtil.NEWLINE + "KW  - hij" + FileUtil.NEWLINE
+        assertEquals("KW  - abcd" + OS.NEWLINE + "KW  - efg" + OS.NEWLINE + "KW  - hij" + OS.NEWLINE
                 + "KW  - klm", new RisKeywords().format("abcd, efg, hij, klm"));
     }
 }

--- a/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
@@ -1,6 +1,7 @@
 package net.sf.jabref.logic.util.strings;
 
 import net.sf.jabref.Globals;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.entry.FileField;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -33,13 +34,13 @@ public class StringUtilTest {
     public void testUnifyLineBreaks() {
         // Mac < v9
         String result = StringUtil.unifyLineBreaksToConfiguredLineBreaks("\r");
-        assertEquals(StringUtil.NEWLINE, result);
+        assertEquals(FileUtil.NEWLINE, result);
         // Windows
         result = StringUtil.unifyLineBreaksToConfiguredLineBreaks("\r\n");
-        assertEquals(StringUtil.NEWLINE, result);
+        assertEquals(FileUtil.NEWLINE, result);
         // Unix
         result = StringUtil.unifyLineBreaksToConfiguredLineBreaks("\n");
-        assertEquals(StringUtil.NEWLINE, result);
+        assertEquals(FileUtil.NEWLINE, result);
     }
 
     @Test
@@ -127,19 +128,19 @@ public class StringUtilTest {
 
     @Test
     public void testWrap() {
-        assertEquals("aaaaa" + StringUtil.NEWLINE + "\tbbbbb" + StringUtil.NEWLINE + "\tccccc",
+        assertEquals("aaaaa" + FileUtil.NEWLINE + "\tbbbbb" + FileUtil.NEWLINE + "\tccccc",
                 StringUtil.wrap("aaaaa bbbbb ccccc", 5));
-        assertEquals("aaaaa bbbbb" + StringUtil.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa bbbbb ccccc", 8));
-        assertEquals("aaaaa bbbbb" + StringUtil.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa bbbbb ccccc", 11));
+        assertEquals("aaaaa bbbbb" + FileUtil.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa bbbbb ccccc", 8));
+        assertEquals("aaaaa bbbbb" + FileUtil.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa bbbbb ccccc", 11));
         assertEquals("aaaaa bbbbb ccccc", StringUtil.wrap("aaaaa bbbbb ccccc", 12));
-        assertEquals("aaaaa" + StringUtil.NEWLINE + "\t" + StringUtil.NEWLINE + "\tbbbbb" + StringUtil.NEWLINE + "\t"
-                + StringUtil.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa\nbbbbb\nccccc", 12));
+        assertEquals("aaaaa" + FileUtil.NEWLINE + "\t" + FileUtil.NEWLINE + "\tbbbbb" + FileUtil.NEWLINE + "\t"
+                + FileUtil.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa\nbbbbb\nccccc", 12));
         assertEquals(
-                "aaaaa" + StringUtil.NEWLINE + "\t" + StringUtil.NEWLINE + "\t" + StringUtil.NEWLINE + "\tbbbbb"
-                        + StringUtil.NEWLINE + "\t" + StringUtil.NEWLINE + "\tccccc",
+                "aaaaa" + FileUtil.NEWLINE + "\t" + FileUtil.NEWLINE + "\t" + FileUtil.NEWLINE + "\tbbbbb"
+                        + FileUtil.NEWLINE + "\t" + FileUtil.NEWLINE + "\tccccc",
                 StringUtil.wrap("aaaaa\n\nbbbbb\nccccc", 12));
-        assertEquals("aaaaa" + StringUtil.NEWLINE + "\t" + StringUtil.NEWLINE + "\tbbbbb" + StringUtil.NEWLINE + "\t"
-                + StringUtil.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa\r\nbbbbb\r\nccccc", 12));
+        assertEquals("aaaaa" + FileUtil.NEWLINE + "\t" + FileUtil.NEWLINE + "\tbbbbb" + FileUtil.NEWLINE + "\t"
+                + FileUtil.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa\r\nbbbbb\r\nccccc", 12));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
@@ -1,7 +1,7 @@
 package net.sf.jabref.logic.util.strings;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.entry.FileField;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -34,13 +34,13 @@ public class StringUtilTest {
     public void testUnifyLineBreaks() {
         // Mac < v9
         String result = StringUtil.unifyLineBreaksToConfiguredLineBreaks("\r");
-        assertEquals(FileUtil.NEWLINE, result);
+        assertEquals(OS.NEWLINE, result);
         // Windows
         result = StringUtil.unifyLineBreaksToConfiguredLineBreaks("\r\n");
-        assertEquals(FileUtil.NEWLINE, result);
+        assertEquals(OS.NEWLINE, result);
         // Unix
         result = StringUtil.unifyLineBreaksToConfiguredLineBreaks("\n");
-        assertEquals(FileUtil.NEWLINE, result);
+        assertEquals(OS.NEWLINE, result);
     }
 
     @Test
@@ -128,19 +128,19 @@ public class StringUtilTest {
 
     @Test
     public void testWrap() {
-        assertEquals("aaaaa" + FileUtil.NEWLINE + "\tbbbbb" + FileUtil.NEWLINE + "\tccccc",
+        assertEquals("aaaaa" + OS.NEWLINE + "\tbbbbb" + OS.NEWLINE + "\tccccc",
                 StringUtil.wrap("aaaaa bbbbb ccccc", 5));
-        assertEquals("aaaaa bbbbb" + FileUtil.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa bbbbb ccccc", 8));
-        assertEquals("aaaaa bbbbb" + FileUtil.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa bbbbb ccccc", 11));
+        assertEquals("aaaaa bbbbb" + OS.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa bbbbb ccccc", 8));
+        assertEquals("aaaaa bbbbb" + OS.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa bbbbb ccccc", 11));
         assertEquals("aaaaa bbbbb ccccc", StringUtil.wrap("aaaaa bbbbb ccccc", 12));
-        assertEquals("aaaaa" + FileUtil.NEWLINE + "\t" + FileUtil.NEWLINE + "\tbbbbb" + FileUtil.NEWLINE + "\t"
-                + FileUtil.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa\nbbbbb\nccccc", 12));
+        assertEquals("aaaaa" + OS.NEWLINE + "\t" + OS.NEWLINE + "\tbbbbb" + OS.NEWLINE + "\t"
+                + OS.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa\nbbbbb\nccccc", 12));
         assertEquals(
-                "aaaaa" + FileUtil.NEWLINE + "\t" + FileUtil.NEWLINE + "\t" + FileUtil.NEWLINE + "\tbbbbb"
-                        + FileUtil.NEWLINE + "\t" + FileUtil.NEWLINE + "\tccccc",
+                "aaaaa" + OS.NEWLINE + "\t" + OS.NEWLINE + "\t" + OS.NEWLINE + "\tbbbbb"
+                        + OS.NEWLINE + "\t" + OS.NEWLINE + "\tccccc",
                 StringUtil.wrap("aaaaa\n\nbbbbb\nccccc", 12));
-        assertEquals("aaaaa" + FileUtil.NEWLINE + "\t" + FileUtil.NEWLINE + "\tbbbbb" + FileUtil.NEWLINE + "\t"
-                + FileUtil.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa\r\nbbbbb\r\nccccc", 12));
+        assertEquals("aaaaa" + OS.NEWLINE + "\t" + OS.NEWLINE + "\tbbbbb" + OS.NEWLINE + "\t"
+                + OS.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa\r\nbbbbb\r\nccccc", 12));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
@@ -33,13 +33,13 @@ public class StringUtilTest {
     public void testUnifyLineBreaks() {
         // Mac < v9
         String result = StringUtil.unifyLineBreaksToConfiguredLineBreaks("\r");
-        assertEquals(Globals.NEWLINE, result);
+        assertEquals(StringUtil.NEWLINE, result);
         // Windows
         result = StringUtil.unifyLineBreaksToConfiguredLineBreaks("\r\n");
-        assertEquals(Globals.NEWLINE, result);
+        assertEquals(StringUtil.NEWLINE, result);
         // Unix
         result = StringUtil.unifyLineBreaksToConfiguredLineBreaks("\n");
-        assertEquals(Globals.NEWLINE, result);
+        assertEquals(StringUtil.NEWLINE, result);
     }
 
     @Test
@@ -127,19 +127,19 @@ public class StringUtilTest {
 
     @Test
     public void testWrap() {
-        assertEquals("aaaaa" + Globals.NEWLINE + "\tbbbbb" + Globals.NEWLINE + "\tccccc",
+        assertEquals("aaaaa" + StringUtil.NEWLINE + "\tbbbbb" + StringUtil.NEWLINE + "\tccccc",
                 StringUtil.wrap("aaaaa bbbbb ccccc", 5));
-        assertEquals("aaaaa bbbbb" + Globals.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa bbbbb ccccc", 8));
-        assertEquals("aaaaa bbbbb" + Globals.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa bbbbb ccccc", 11));
+        assertEquals("aaaaa bbbbb" + StringUtil.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa bbbbb ccccc", 8));
+        assertEquals("aaaaa bbbbb" + StringUtil.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa bbbbb ccccc", 11));
         assertEquals("aaaaa bbbbb ccccc", StringUtil.wrap("aaaaa bbbbb ccccc", 12));
-        assertEquals("aaaaa" + Globals.NEWLINE + "\t" + Globals.NEWLINE + "\tbbbbb" + Globals.NEWLINE + "\t"
-                + Globals.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa\nbbbbb\nccccc", 12));
+        assertEquals("aaaaa" + StringUtil.NEWLINE + "\t" + StringUtil.NEWLINE + "\tbbbbb" + StringUtil.NEWLINE + "\t"
+                + StringUtil.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa\nbbbbb\nccccc", 12));
         assertEquals(
-                "aaaaa" + Globals.NEWLINE + "\t" + Globals.NEWLINE + "\t" + Globals.NEWLINE + "\tbbbbb"
-                        + Globals.NEWLINE + "\t" + Globals.NEWLINE + "\tccccc",
+                "aaaaa" + StringUtil.NEWLINE + "\t" + StringUtil.NEWLINE + "\t" + StringUtil.NEWLINE + "\tbbbbb"
+                        + StringUtil.NEWLINE + "\t" + StringUtil.NEWLINE + "\tccccc",
                 StringUtil.wrap("aaaaa\n\nbbbbb\nccccc", 12));
-        assertEquals("aaaaa" + Globals.NEWLINE + "\t" + Globals.NEWLINE + "\tbbbbb" + Globals.NEWLINE + "\t"
-                + Globals.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa\r\nbbbbb\r\nccccc", 12));
+        assertEquals("aaaaa" + StringUtil.NEWLINE + "\t" + StringUtil.NEWLINE + "\tbbbbb" + StringUtil.NEWLINE + "\t"
+                + StringUtil.NEWLINE + "\tccccc", StringUtil.wrap("aaaaa\r\nbbbbb\r\nccccc", 12));
     }
 
     @Test


### PR DESCRIPTION
Moved some String constants from `Globals` to better places. Maybe we should introduce a class `logic.util.string.StringConstant`? Not sure if there is a better long term plan for `Globals.NEWLINE`? 

Unified used of the constant `"/"` as field separator.

Removed unused preference key and default value in `PersistenceTableColumnListener`.