### PR TITLE
Improved LaTeX to Unicode/HTML formatters to output more sensible val…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - LaTeX to Unicode converter now handles combining accents
 - Fixed [#1527](https://github.com/JabRef/jabref/issues/1527): 'Get BibTeX data from DOI' Removes Marking
 - Fixed [#1592](https://github.com/JabRef/jabref/issues/1592): LibreOffice: wrong numbers in citation labels
+- Fixed [#1321](https://github.com/JabRef/jabref/issues/1321): LaTeX commands in fields not displayed in the list of references
 
 ### Removed
 - It is not longer possible to choose to convert HTML sub- and superscripts to equations

--- a/src/main/java/net/sf/jabref/logic/layout/format/HTMLChars.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/HTMLChars.java
@@ -85,18 +85,20 @@ public class HTMLChars implements LayoutFormatter {
                         String command = currentCommand.toString();
                         i++;
                         c = field.charAt(i);
-                        String combody;
+                        String commandBody;
                         if (c == '{') {
                             String part = StringUtil.getPart(field, i, false);
                             i += part.length();
-                            combody = part;
+                            commandBody = part;
                         } else {
-                            combody = field.substring(i, i + 1);
+                            commandBody = field.substring(i, i + 1);
                         }
-                        Object result = HTML_CHARS.get(command + combody);
+                        String result = HTML_CHARS.get(command + commandBody);
 
-                        if (result != null) {
-                            sb.append((String) result);
+                        if (result == null) {
+                            sb.append(commandBody);
+                        } else {
+                            sb.append(result);
                         }
 
                         incommand = false;
@@ -105,7 +107,7 @@ public class HTMLChars implements LayoutFormatter {
                         //	Are we already at the end of the string?
                         if ((i + 1) == field.length()) {
                             String command = currentCommand.toString();
-                            Object result = HTML_CHARS.get(command);
+                            String result = HTML_CHARS.get(command);
                             /* If found, then use translated version. If not,
                              * then keep
                              * the text of the parameter intact.
@@ -113,7 +115,7 @@ public class HTMLChars implements LayoutFormatter {
                             if (result == null) {
                                 sb.append(command);
                             } else {
-                                sb.append((String) result);
+                                sb.append(result);
                             }
 
                         }
@@ -141,14 +143,21 @@ public class HTMLChars implements LayoutFormatter {
                         argument = part;
                         if (argument != null) {
                             // handle common case of general latex command
-                            Object result = HTML_CHARS.get(command + argument);
+                            String result = HTML_CHARS.get(command + argument);
                             // If found, then use translated version. If not, then keep
                             // the
                             // text of the parameter intact.
+
                             if (result == null) {
-                                sb.append(argument);
+                                if (argument.length() == 0) {
+                                    // Maybe a separator, such as in \LaTeX{}, so use command
+                                    sb.append(command);
+                                } else {
+                                    // Otherwise, use argument
+                                    sb.append(argument);
+                                }
                             } else {
-                                sb.append((String) result);
+                                sb.append(result);
                             }
                         }
                     } else if (c == '}') {

--- a/src/main/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatter.java
@@ -107,18 +107,21 @@ public class LatexToUnicodeFormatter implements LayoutFormatter, Formatter {
                         } else {
                             commandBody = field.substring(i, i + 1);
                         }
-                        Object result = LatexToUnicodeFormatter.CHARS.get(command + commandBody);
+                        String result = LatexToUnicodeFormatter.CHARS.get(command + commandBody);
 
                         if (result == null) {
                             // Use combining accents if argument is single character or empty
                             if (commandBody.length() <= 1) {
                                 String accent = LatexToUnicodeFormatter.ACCENTS.get(command);
-                                if (accent != null) {
+                                if (accent == null) {
+                                    // Shouldn't happen
+                                    sb.append(commandBody);
+                                } else {
                                     sb.append(commandBody).append(accent);
                                 }
                             }
                         } else {
-                            sb.append((String) result);
+                            sb.append(result);
                         }
 
                         incommand = false;
@@ -127,7 +130,7 @@ public class LatexToUnicodeFormatter implements LayoutFormatter, Formatter {
                         //	Are we already at the end of the string?
                         if ((i + 1) == field.length()) {
                             String command = currentCommand.toString();
-                            Object result = LatexToUnicodeFormatter.CHARS.get(command);
+                            String result = LatexToUnicodeFormatter.CHARS.get(command);
                             /* If found, then use translated version. If not,
                              * then keep
                              * the text of the parameter intact.
@@ -135,7 +138,7 @@ public class LatexToUnicodeFormatter implements LayoutFormatter, Formatter {
                             if (result == null) {
                                 sb.append(command);
                             } else {
-                                sb.append((String) result);
+                                sb.append(result);
                             }
 
                         }
@@ -168,10 +171,15 @@ public class LatexToUnicodeFormatter implements LayoutFormatter, Formatter {
                                 // Use combining accents if argument is single character or empty
                                 if (argument.length() <= 1) {
                                     String accent = LatexToUnicodeFormatter.ACCENTS.get(command);
-                                    if (accent != null) {
-                                        sb.append(argument).append(accent);
+                                    if (accent == null) {
+                                        if (argument.length() == 0) {
+                                            // Empty argument, may be used as separator as in \LaTeX{}, so keep the command
+                                            sb.append(command);
+                                        } else {
+                                            sb.append(argument);
+                                        }
                                     } else {
-                                        sb.append(argument);
+                                        sb.append(argument).append(accent);
                                     }
                                 } else {
                                     sb.append(argument);

--- a/src/test/java/net/sf/jabref/logic/layout/format/HTMLCharsTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/format/HTMLCharsTest.java
@@ -3,14 +3,22 @@ package net.sf.jabref.logic.layout.format;
 import net.sf.jabref.logic.layout.LayoutFormatter;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class HTMLCharsTest {
 
+    private LayoutFormatter layout;
+
+    @Before
+    public void setUp() {
+        layout = new HTMLChars();
+    }
+
     @Test
     public void testBasicFormat() {
-
-        LayoutFormatter layout = new HTMLChars();
 
         Assert.assertEquals("", layout.format(""));
 
@@ -39,9 +47,6 @@ public class HTMLCharsTest {
 
     @Test
     public void testLaTeXHighlighting() {
-
-        LayoutFormatter layout = new HTMLChars();
-
         Assert.assertEquals("<em>hallo</em>", layout.format("\\emph{hallo}"));
         Assert.assertEquals("<em>hallo</em>", layout.format("{\\emph hallo}"));
         Assert.assertEquals("<em>hallo</em>", layout.format("{\\em hallo}"));
@@ -65,8 +70,6 @@ public class HTMLCharsTest {
 
     @Test
     public void testEquations() {
-        LayoutFormatter layout = new HTMLChars();
-
         Assert.assertEquals("&dollar;", layout.format("\\$"));
         Assert.assertEquals("&sigma;", layout.format("$\\sigma$"));
         Assert.assertEquals("A 32&nbsp;mA &Sigma;&Delta;-modulator",
@@ -75,11 +78,25 @@ public class HTMLCharsTest {
 
     @Test
     public void testNewLine() {
-        LayoutFormatter layout = new HTMLChars();
         Assert.assertEquals("a<br>b", layout.format("a\nb"));
         Assert.assertEquals("a<p>b", layout.format("a\n\nb"));
     }
     /*
      * Is missing a lot of test cases for the individual chars...
      */
+
+    @Test
+    public void unknownCommandIsKept() {
+        assertEquals("aaaa", layout.format("\\aaaa"));
+    }
+
+    @Test
+    public void unknownCommandKeepsArgument() {
+        assertEquals("bbbb", layout.format("\\aaaa{bbbb}"));
+    }
+
+    @Test
+    public void unknownCommandWithEmptyArgumentIsKept() {
+        assertEquals("aaaa", layout.format("\\aaaa{}"));
+    }
 }

--- a/src/test/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -97,4 +97,19 @@ public class LatexToUnicodeFormatterTest {
     public void testCombiningAccentsCase2() {
         assertEquals("a͍", formatter.format("\\spreadlips{a}"));
     }
+
+    @Test
+    public void unknownCommandIsKept() {
+        assertEquals("aaaa", formatter.format("\\aaaa"));
+    }
+
+    @Test
+    public void unknownCommandKeepsArgument() {
+        assertEquals("bbbb", formatter.format("\\aaaa{bbbb}"));
+    }
+
+    @Test
+    public void unknownCommandWithEmptyArgumentIsKept() {
+        assertEquals("aaaa", formatter.format("\\aaaa{}"));
+    }
 }


### PR DESCRIPTION
See #1321. Main thing is that `\LaTeX{}` outputs `LaTeX`, same for all unknown commands. Also behaves a bit better for some other situations with unknown commands and there are now tests for it to make sure that it happens.

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes

