### PR TITLE
Table row height adjusts on Windows as the font scales with the menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - [#462](https://github.com/JabRef/jabref/issues/462) Extend the OpenConsoleFeature by offering a selection between default terminal emulator and configurable command execution.
 - The field name in the layout files for entry type is changed from `bibtextype` to `entrytype`. Please update your existing files as support for `bibtextype` will be removed eventually.
 - [#1516](https://github.com/JabRef/jabref/issues/1516) Selected field names are written in uppercase in the entry editor
+- Table row height is adjusted on Windows which is useful for high resolution displays
 - For developers: Moved the bst package into logic. This requires the regeneration of antlr sources, execute: gradlew generateSource
 - [#1026](https://github.com/JabRef/jabref/issues/1026) JabRef does no longer delete user comments outside of BibTeX entries and strings
 - [#1249](https://github.com/JabRef/jabref/issues/1249) Date layout formatter added

--- a/src/main/java/net/sf/jabref/collab/ChangeDisplayDialog.java
+++ b/src/main/java/net/sf/jabref/collab/ChangeDisplayDialog.java
@@ -35,10 +35,13 @@ import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
 import javax.swing.tree.DefaultMutableTreeNode;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.undo.NamedCompound;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.database.BibDatabase;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 class ChangeDisplayDialog extends JDialog implements TreeSelectionListener {
 
@@ -64,6 +67,9 @@ class ChangeDisplayDialog extends JDialog implements TreeSelectionListener {
         }
         tree = new JTree(root);
         tree.addTreeSelectionListener(this);
+        if (OS.WINDOWS) { // Arbitrary trees scale with menu font size on Windows
+            tree.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+        }
         JSplitPane pane = new JSplitPane();
         pane.setLeftComponent(new JScrollPane(tree));
         JPanel infoBorder = new JPanel();

--- a/src/main/java/net/sf/jabref/collab/ChangeDisplayDialog.java
+++ b/src/main/java/net/sf/jabref/collab/ChangeDisplayDialog.java
@@ -16,6 +16,7 @@
 package net.sf.jabref.collab;
 
 import java.awt.BorderLayout;
+import java.awt.FontMetrics;
 import java.awt.Insets;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -35,13 +36,10 @@ import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
 import javax.swing.tree.DefaultMutableTreeNode;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.undo.NamedCompound;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.database.BibDatabase;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 class ChangeDisplayDialog extends JDialog implements TreeSelectionListener {
 
@@ -67,9 +65,10 @@ class ChangeDisplayDialog extends JDialog implements TreeSelectionListener {
         }
         tree = new JTree(root);
         tree.addTreeSelectionListener(this);
-        if (OS.WINDOWS) { // Arbitrary trees scale with menu font size on Windows
-            tree.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-        }
+        // Fix tree row height
+        FontMetrics metrics = tree.getFontMetrics(tree.getFont());
+        tree.setRowHeight(Math.max(tree.getRowHeight(), metrics.getHeight()));
+
         JSplitPane pane = new JSplitPane();
         pane.setLeftComponent(new JScrollPane(tree));
         JPanel infoBorder = new JPanel();

--- a/src/main/java/net/sf/jabref/collab/ChangeDisplayDialog.java
+++ b/src/main/java/net/sf/jabref/collab/ChangeDisplayDialog.java
@@ -16,7 +16,6 @@
 package net.sf.jabref.collab;
 
 import java.awt.BorderLayout;
-import java.awt.FontMetrics;
 import java.awt.Insets;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -38,6 +37,7 @@ import javax.swing.tree.DefaultMutableTreeNode;
 
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.undo.NamedCompound;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibDatabase;
 
@@ -65,9 +65,7 @@ class ChangeDisplayDialog extends JDialog implements TreeSelectionListener {
         }
         tree = new JTree(root);
         tree.addTreeSelectionListener(this);
-        // Fix tree row height
-        FontMetrics metrics = tree.getFontMetrics(tree.getFont());
-        tree.setRowHeight(Math.max(tree.getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(tree);
 
         JSplitPane pane = new JSplitPane();
         pane.setLeftComponent(new JScrollPane(tree));

--- a/src/main/java/net/sf/jabref/external/ExternalFileTypeEditor.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFileTypeEditor.java
@@ -51,6 +51,8 @@ import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.actions.MnemonicAwareAction;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.OS;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import com.jgoodies.forms.builder.ButtonStackBuilder;
@@ -180,6 +182,10 @@ public class ExternalFileTypeEditor extends JDialog {
         table.getColumnModel().getColumn(2).setMinWidth(60);
         table.getColumnModel().getColumn(3).setMinWidth(100);
         table.getColumnModel().getColumn(0).setResizable(false);
+
+        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+        }
 
         JScrollPane sp = new JScrollPane(table);
 

--- a/src/main/java/net/sf/jabref/external/ExternalFileTypeEditor.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFileTypeEditor.java
@@ -17,7 +17,6 @@ package net.sf.jabref.external;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
-import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -51,6 +50,7 @@ import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.actions.MnemonicAwareAction;
 import net.sf.jabref.gui.keyboard.KeyBinding;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.logic.l10n.Localization;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
@@ -182,9 +182,7 @@ public class ExternalFileTypeEditor extends JDialog {
         table.getColumnModel().getColumn(3).setMinWidth(100);
         table.getColumnModel().getColumn(0).setResizable(false);
 
-        // Set table height
-        FontMetrics metrics = table.getFontMetrics(table.getFont());
-        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(table);
 
         JScrollPane sp = new JScrollPane(table);
 

--- a/src/main/java/net/sf/jabref/external/ExternalFileTypeEditor.java
+++ b/src/main/java/net/sf/jabref/external/ExternalFileTypeEditor.java
@@ -17,6 +17,7 @@ package net.sf.jabref.external;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
+import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -51,8 +52,6 @@ import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.actions.MnemonicAwareAction;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.logic.util.OS;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import com.jgoodies.forms.builder.ButtonStackBuilder;
@@ -183,9 +182,9 @@ public class ExternalFileTypeEditor extends JDialog {
         table.getColumnModel().getColumn(3).setMinWidth(100);
         table.getColumnModel().getColumn(0).setResizable(false);
 
-        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-        }
+        // Set table height
+        FontMetrics metrics = table.getFontMetrics(table.getFont());
+        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
 
         JScrollPane sp = new JScrollPane(table);
 

--- a/src/main/java/net/sf/jabref/gui/FindUnlinkedFilesDialog.java
+++ b/src/main/java/net/sf/jabref/gui/FindUnlinkedFilesDialog.java
@@ -89,6 +89,7 @@ import net.sf.jabref.gui.importer.EntryFromFileCreatorManager;
 import net.sf.jabref.gui.importer.UnlinkedFilesCrawler;
 import net.sf.jabref.gui.importer.UnlinkedPDFFileFilter;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.entry.EntryType;
 import net.sf.jabref.model.entry.FieldName;
@@ -798,6 +799,9 @@ public class FindUnlinkedFilesDialog extends JDialog {
         labelImportingInfo.setVisible(false);
 
         tree = new JTree();
+        if (OS.WINDOWS) { // Arbitrary trees scale with menu font size on Windows
+            tree.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+        }
         scrollpaneTree = new JScrollPane(tree);
         scrollpaneTree.setWheelScrollingEnabled(true);
 

--- a/src/main/java/net/sf/jabref/gui/FindUnlinkedFilesDialog.java
+++ b/src/main/java/net/sf/jabref/gui/FindUnlinkedFilesDialog.java
@@ -18,7 +18,6 @@ package net.sf.jabref.gui;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.awt.Frame;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -89,6 +88,7 @@ import net.sf.jabref.gui.importer.EntryFromFileCreator;
 import net.sf.jabref.gui.importer.EntryFromFileCreatorManager;
 import net.sf.jabref.gui.importer.UnlinkedFilesCrawler;
 import net.sf.jabref.gui.importer.UnlinkedPDFFileFilter;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.entry.EntryType;
@@ -799,9 +799,7 @@ public class FindUnlinkedFilesDialog extends JDialog {
         labelImportingInfo.setVisible(false);
 
         tree = new JTree();
-        // Fix tree row height
-        FontMetrics metrics = tree.getFontMetrics(tree.getFont());
-        tree.setRowHeight(Math.max(tree.getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(tree);
 
         scrollpaneTree = new JScrollPane(tree);
         scrollpaneTree.setWheelScrollingEnabled(true);

--- a/src/main/java/net/sf/jabref/gui/FindUnlinkedFilesDialog.java
+++ b/src/main/java/net/sf/jabref/gui/FindUnlinkedFilesDialog.java
@@ -18,6 +18,7 @@ package net.sf.jabref.gui;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.Frame;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -89,7 +90,6 @@ import net.sf.jabref.gui.importer.EntryFromFileCreatorManager;
 import net.sf.jabref.gui.importer.UnlinkedFilesCrawler;
 import net.sf.jabref.gui.importer.UnlinkedPDFFileFilter;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.entry.EntryType;
 import net.sf.jabref.model.entry.FieldName;
@@ -799,9 +799,10 @@ public class FindUnlinkedFilesDialog extends JDialog {
         labelImportingInfo.setVisible(false);
 
         tree = new JTree();
-        if (OS.WINDOWS) { // Arbitrary trees scale with menu font size on Windows
-            tree.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-        }
+        // Fix tree row height
+        FontMetrics metrics = tree.getFontMetrics(tree.getFont());
+        tree.setRowHeight(Math.max(tree.getRowHeight(), metrics.getHeight()));
+
         scrollpaneTree = new JScrollPane(tree);
         scrollpaneTree.setWheelScrollingEnabled(true);
 

--- a/src/main/java/net/sf/jabref/gui/StringDialog.java
+++ b/src/main/java/net/sf/jabref/gui/StringDialog.java
@@ -58,6 +58,7 @@ import net.sf.jabref.logic.bibtex.LatexFieldFormatterPreferences;
 import net.sf.jabref.logic.bibtex.comparator.BibtexStringComparator;
 import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.KeyCollisionException;
 import net.sf.jabref.model.entry.BibtexString;
@@ -121,6 +122,10 @@ class StringDialog extends JDialog {
         table = new StringTable(stm);
         if (!base.hasNoStrings()) {
             table.setRowSelectionInterval(0, 0);
+        }
+
+        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
         }
 
         gbl.setConstraints(table.getPane(), con);

--- a/src/main/java/net/sf/jabref/gui/StringDialog.java
+++ b/src/main/java/net/sf/jabref/gui/StringDialog.java
@@ -18,6 +18,7 @@ package net.sf.jabref.gui;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Container;
+import java.awt.FontMetrics;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
@@ -58,7 +59,6 @@ import net.sf.jabref.logic.bibtex.LatexFieldFormatterPreferences;
 import net.sf.jabref.logic.bibtex.comparator.BibtexStringComparator;
 import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.KeyCollisionException;
 import net.sf.jabref.model.entry.BibtexString;
@@ -124,9 +124,9 @@ class StringDialog extends JDialog {
             table.setRowSelectionInterval(0, 0);
         }
 
-        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-        }
+        // Fix tree row height
+        FontMetrics metrics = table.getFontMetrics(table.getFont());
+        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
 
         gbl.setConstraints(table.getPane(), con);
         pan.add(table.getPane());

--- a/src/main/java/net/sf/jabref/gui/StringDialog.java
+++ b/src/main/java/net/sf/jabref/gui/StringDialog.java
@@ -18,7 +18,6 @@ package net.sf.jabref.gui;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Container;
-import java.awt.FontMetrics;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
@@ -53,6 +52,7 @@ import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.gui.undo.UndoableInsertString;
 import net.sf.jabref.gui.undo.UndoableRemoveString;
 import net.sf.jabref.gui.undo.UndoableStringChange;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.gui.util.PositionWindow;
 import net.sf.jabref.logic.bibtex.LatexFieldFormatter;
 import net.sf.jabref.logic.bibtex.LatexFieldFormatterPreferences;
@@ -123,10 +123,7 @@ class StringDialog extends JDialog {
         if (!base.hasNoStrings()) {
             table.setRowSelectionInterval(0, 0);
         }
-
-        // Fix tree row height
-        FontMetrics metrics = table.getFontMetrics(table.getFont());
-        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(table);
 
         gbl.setConstraints(table.getPane(), con);
         pan.add(table.getPane());

--- a/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
@@ -1,6 +1,5 @@
 package net.sf.jabref.gui.actions;
 
-import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.util.HashMap;
 import java.util.List;
@@ -21,6 +20,7 @@ import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
 
 import net.sf.jabref.gui.JabRefFrame;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.logic.integrity.IntegrityCheck;
 import net.sf.jabref.logic.integrity.IntegrityMessage;
 import net.sf.jabref.logic.l10n.Localization;
@@ -94,9 +94,7 @@ public class IntegrityCheckAction extends MnemonicAwareAction {
                 }
             });
 
-            // Set table row height
-            FontMetrics metrics = table.getFontMetrics(table.getFont());
-            table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+            GUIUtil.correctRowHeight(table);
 
             table.getColumnModel().getColumn(0).setPreferredWidth(100);
             table.getColumnModel().getColumn(1).setPreferredWidth(60);

--- a/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
@@ -24,6 +24,7 @@ import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.logic.integrity.IntegrityCheck;
 import net.sf.jabref.logic.integrity.IntegrityMessage;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.FormBuilder;
@@ -95,7 +96,9 @@ public class IntegrityCheckAction extends MnemonicAwareAction {
                 }
             });
 
-            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+            if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+                table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+            }
 
             table.getColumnModel().getColumn(0).setPreferredWidth(100);
             table.getColumnModel().getColumn(1).setPreferredWidth(60);

--- a/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
@@ -1,5 +1,6 @@
 package net.sf.jabref.gui.actions;
 
+import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.util.HashMap;
 import java.util.List;
@@ -19,13 +20,10 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.logic.integrity.IntegrityCheck;
 import net.sf.jabref.logic.integrity.IntegrityMessage;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.logic.util.OS;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.FormBuilder;
 import com.jgoodies.forms.layout.FormLayout;
@@ -96,9 +94,9 @@ public class IntegrityCheckAction extends MnemonicAwareAction {
                 }
             });
 
-            if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-                table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-            }
+            // Set table row height
+            FontMetrics metrics = table.getFontMetrics(table.getFont());
+            table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
 
             table.getColumnModel().getColumn(0).setPreferredWidth(100);
             table.getColumnModel().getColumn(1).setPreferredWidth(60);

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditorTab.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditorTab.java
@@ -19,7 +19,6 @@ import java.awt.AWTKeyStroke;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.awt.KeyboardFocusManager;
 import java.awt.event.FocusListener;
 import java.util.Collections;
@@ -49,6 +48,7 @@ import net.sf.jabref.gui.fieldeditors.TextArea;
 import net.sf.jabref.gui.fieldeditors.TextField;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.gui.util.FocusRequester;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.logic.autocompleter.AutoCompleter;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldProperties;
@@ -154,9 +154,8 @@ class EntryEditorTab {
                 fieldEditor = new FileListEditor(frame, bPanel.getBibDatabaseContext(), field, null, parent);
 
                 fileListEditor = (FileListEditor) fieldEditor;
-                // Fix table row height
-                FontMetrics metrics = fileListEditor.getFontMetrics(fileListEditor.getFont());
-                fileListEditor.setRowHeight(Math.max(fileListEditor.getRowHeight(), metrics.getHeight()));
+                GUIUtil.correctRowHeight(fileListEditor);
+
                 defaultHeight = 0;
             } else {
                 fieldEditor = new TextArea(field, null);

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditorTab.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditorTab.java
@@ -19,6 +19,7 @@ import java.awt.AWTKeyStroke;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.KeyboardFocusManager;
 import java.awt.event.FocusListener;
 import java.util.Collections;
@@ -49,11 +50,9 @@ import net.sf.jabref.gui.fieldeditors.TextField;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.gui.util.FocusRequester;
 import net.sf.jabref.logic.autocompleter.AutoCompleter;
-import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldProperties;
 import net.sf.jabref.model.entry.InternalBibtexFields;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;
@@ -155,9 +154,9 @@ class EntryEditorTab {
                 fieldEditor = new FileListEditor(frame, bPanel.getBibDatabaseContext(), field, null, parent);
 
                 fileListEditor = (FileListEditor) fieldEditor;
-                if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-                    fileListEditor.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-                }
+                // Fix table row height
+                FontMetrics metrics = fileListEditor.getFontMetrics(fileListEditor.getFont());
+                fileListEditor.setRowHeight(Math.max(fileListEditor.getRowHeight(), metrics.getHeight()));
                 defaultHeight = 0;
             } else {
                 fieldEditor = new TextArea(field, null);

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditorTab.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditorTab.java
@@ -49,9 +49,11 @@ import net.sf.jabref.gui.fieldeditors.TextField;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.gui.util.FocusRequester;
 import net.sf.jabref.logic.autocompleter.AutoCompleter;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldProperties;
 import net.sf.jabref.model.entry.InternalBibtexFields;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
 import com.jgoodies.forms.layout.FormLayout;
@@ -151,7 +153,11 @@ class EntryEditorTab {
             int wHeight = (int) (50.0 * InternalBibtexFields.getFieldWeight(field));
             if (InternalBibtexFields.getFieldExtras(field).contains(FieldProperties.FILE_EDITOR)) {
                 fieldEditor = new FileListEditor(frame, bPanel.getBibDatabaseContext(), field, null, parent);
+
                 fileListEditor = (FileListEditor) fieldEditor;
+                if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+                    fileListEditor.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+                }
                 defaultHeight = 0;
             } else {
                 fieldEditor = new TextArea(field, null);

--- a/src/main/java/net/sf/jabref/gui/exporter/ExportCustomizationDialog.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/ExportCustomizationDialog.java
@@ -44,6 +44,8 @@ import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.gui.util.FocusRequester;
 import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.OS;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import ca.odell.glazedlists.gui.TableFormat;
 import ca.odell.glazedlists.swing.DefaultEventTableModel;
@@ -83,6 +85,9 @@ public class ExportCustomizationDialog extends JDialog {
             table.setRowSelectionInterval(0, 0);
         }
 
+        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+        }
 
         JButton addExport = new JButton(Localization.lang("Add new"));
         addExport.addActionListener(e -> {

--- a/src/main/java/net/sf/jabref/gui/exporter/ExportCustomizationDialog.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/ExportCustomizationDialog.java
@@ -17,7 +17,6 @@ package net.sf.jabref.gui.exporter;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,6 +42,7 @@ import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.gui.util.FocusRequester;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.l10n.Localization;
 
@@ -84,9 +84,7 @@ public class ExportCustomizationDialog extends JDialog {
             table.setRowSelectionInterval(0, 0);
         }
 
-        // Fix table row height
-        FontMetrics metrics = table.getFontMetrics(table.getFont());
-        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(table);
 
         JButton addExport = new JButton(Localization.lang("Add new"));
         addExport.addActionListener(e -> {

--- a/src/main/java/net/sf/jabref/gui/exporter/ExportCustomizationDialog.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/ExportCustomizationDialog.java
@@ -17,6 +17,7 @@ package net.sf.jabref.gui.exporter;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,8 +45,6 @@ import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.gui.util.FocusRequester;
 import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.logic.util.OS;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 import ca.odell.glazedlists.gui.TableFormat;
 import ca.odell.glazedlists.swing.DefaultEventTableModel;
@@ -85,9 +84,9 @@ public class ExportCustomizationDialog extends JDialog {
             table.setRowSelectionInterval(0, 0);
         }
 
-        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-        }
+        // Fix table row height
+        FontMetrics metrics = table.getFontMetrics(table.getFont());
+        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
 
         JButton addExport = new JButton(Localization.lang("Add new"));
         addExport.addActionListener(e -> {

--- a/src/main/java/net/sf/jabref/gui/fieldeditors/FileListEditor.java
+++ b/src/main/java/net/sf/jabref/gui/fieldeditors/FileListEditor.java
@@ -18,6 +18,7 @@ package net.sf.jabref.gui.fieldeditors;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.FontMetrics;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -105,6 +106,10 @@ public class FileListEditor extends JTable implements FieldEditor, DownloadExter
         JScrollPane sPane = new JScrollPane(this);
         setTableHeader(null);
         addMouseListener(new TableClickListener());
+
+        // Fix table row height
+        FontMetrics metrics = getFontMetrics(getFont());
+        setRowHeight(Math.max(getRowHeight(), metrics.getHeight()));
 
         JButton add = new JButton(IconTheme.JabRefIcon.ADD_NOBOX.getSmallIcon());
         add.setToolTipText(Localization.lang("New file link (INSERT)"));

--- a/src/main/java/net/sf/jabref/gui/fieldeditors/FileListEditor.java
+++ b/src/main/java/net/sf/jabref/gui/fieldeditors/FileListEditor.java
@@ -18,7 +18,6 @@ package net.sf.jabref.gui.fieldeditors;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.FontMetrics;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -66,6 +65,7 @@ import net.sf.jabref.gui.autocompleter.AutoCompleteListener;
 import net.sf.jabref.gui.desktop.JabRefDesktop;
 import net.sf.jabref.gui.entryeditor.EntryEditor;
 import net.sf.jabref.gui.keyboard.KeyBinding;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.entry.BibEntry;
@@ -107,9 +107,7 @@ public class FileListEditor extends JTable implements FieldEditor, DownloadExter
         setTableHeader(null);
         addMouseListener(new TableClickListener());
 
-        // Fix table row height
-        FontMetrics metrics = getFontMetrics(getFont());
-        setRowHeight(Math.max(getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(this);
 
         JButton add = new JButton(IconTheme.JabRefIcon.ADD_NOBOX.getSmallIcon());
         add.setToolTipText(Localization.lang("New file link (INSERT)"));

--- a/src/main/java/net/sf/jabref/gui/groups/GroupsTree.java
+++ b/src/main/java/net/sf/jabref/gui/groups/GroupsTree.java
@@ -16,7 +16,6 @@
 package net.sf.jabref.gui.groups;
 
 import java.awt.Cursor;
-import java.awt.FontMetrics;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.datatransfer.Transferable;
@@ -49,6 +48,7 @@ import javax.swing.ToolTipManager;
 import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
 
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.logic.groups.AbstractGroup;
 import net.sf.jabref.logic.groups.EntriesGroupChange;
 import net.sf.jabref.logic.groups.GroupTreeNode;
@@ -96,9 +96,7 @@ public class GroupsTree extends JTree implements DragSourceListener,
      * @param groupSelector the parent UI component
      */
     public GroupsTree(GroupSelector groupSelector) {
-        // Adjust height according to http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4760081
-        FontMetrics metrics = getFontMetrics(getFont());
-        setRowHeight(Math.max(getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(this);
 
         this.groupSelector = groupSelector;
         DragGestureRecognizer dgr = DragSource.getDefaultDragSource()

--- a/src/main/java/net/sf/jabref/gui/importer/ImportCustomizationDialog.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ImportCustomizationDialog.java
@@ -56,6 +56,8 @@ import net.sf.jabref.logic.importer.fileformat.ImportFormat;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.logic.xmp.XMPPreferences;
+import net.sf.jabref.logic.util.OS;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import org.apache.commons.logging.Log;
@@ -97,6 +99,10 @@ public class ImportCustomizationDialog extends JDialog {
         customImporterTable.setPreferredScrollableViewportSize(getSize());
         if (customImporterTable.getRowCount() > 0) {
             customImporterTable.setRowSelectionInterval(0, 0);
+        }
+
+        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+            customImporterTable.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
         }
 
         JButton addFromFolderButton = new JButton(Localization.lang("Add from folder"));

--- a/src/main/java/net/sf/jabref/gui/importer/ImportCustomizationDialog.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ImportCustomizationDialog.java
@@ -19,7 +19,6 @@ package net.sf.jabref.gui.importer;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.io.IOException;
@@ -50,6 +49,7 @@ import net.sf.jabref.gui.NewFileDialogs;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.gui.util.FocusRequester;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.fileformat.CustomImporter;
@@ -100,9 +100,7 @@ public class ImportCustomizationDialog extends JDialog {
             customImporterTable.setRowSelectionInterval(0, 0);
         }
 
-        // Set table height
-        FontMetrics metrics = customImporterTable.getFontMetrics(customImporterTable.getFont());
-        customImporterTable.setRowHeight(Math.max(customImporterTable.getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(customImporterTable);
 
         JButton addFromFolderButton = new JButton(Localization.lang("Add from folder"));
         addFromFolderButton.addActionListener(e -> {

--- a/src/main/java/net/sf/jabref/gui/importer/ImportCustomizationDialog.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ImportCustomizationDialog.java
@@ -19,6 +19,7 @@ package net.sf.jabref.gui.importer;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.io.IOException;
@@ -56,8 +57,6 @@ import net.sf.jabref.logic.importer.fileformat.ImportFormat;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.logic.xmp.XMPPreferences;
-import net.sf.jabref.logic.util.OS;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import org.apache.commons.logging.Log;
@@ -101,9 +100,9 @@ public class ImportCustomizationDialog extends JDialog {
             customImporterTable.setRowSelectionInterval(0, 0);
         }
 
-        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-            customImporterTable.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-        }
+        // Set table height
+        FontMetrics metrics = customImporterTable.getFontMetrics(customImporterTable.getFont());
+        customImporterTable.setRowHeight(Math.max(customImporterTable.getRowHeight(), metrics.getHeight()));
 
         JButton addFromFolderButton = new JButton(Localization.lang("Add from folder"));
         addFromFolderButton.addActionListener(e -> {

--- a/src/main/java/net/sf/jabref/gui/importer/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ImportInspectionDialog.java
@@ -18,6 +18,7 @@ package net.sf.jabref.gui.importer;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -103,7 +104,6 @@ import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.importer.ImportInspector;
 import net.sf.jabref.logic.importer.OutputPrinter;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.UpdateField;
 import net.sf.jabref.model.DuplicateCheck;
 import net.sf.jabref.model.database.BibDatabase;
@@ -238,9 +238,9 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
         setupComparatorChooser();
         glTable.addMouseListener(new TableClickListener());
 
-        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-            glTable.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-        }
+        // Fix table row height
+        FontMetrics metrics = glTable.getFontMetrics(glTable.getFont());
+        glTable.setRowHeight(Math.max(glTable.getRowHeight(), metrics.getHeight()));
 
         setWidths();
 

--- a/src/main/java/net/sf/jabref/gui/importer/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ImportInspectionDialog.java
@@ -103,6 +103,7 @@ import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.importer.ImportInspector;
 import net.sf.jabref.logic.importer.OutputPrinter;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.UpdateField;
 import net.sf.jabref.model.DuplicateCheck;
 import net.sf.jabref.model.database.BibDatabase;
@@ -236,6 +237,10 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
                 AbstractTableComparatorChooser.MULTIPLE_COLUMN_KEYBOARD);
         setupComparatorChooser();
         glTable.addMouseListener(new TableClickListener());
+
+        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+            glTable.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+        }
 
         setWidths();
 

--- a/src/main/java/net/sf/jabref/gui/importer/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ImportInspectionDialog.java
@@ -18,7 +18,6 @@ package net.sf.jabref.gui.importer;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -92,6 +91,7 @@ import net.sf.jabref.gui.renderer.GeneralRenderer;
 import net.sf.jabref.gui.undo.NamedCompound;
 import net.sf.jabref.gui.undo.UndoableInsertEntry;
 import net.sf.jabref.gui.undo.UndoableRemoveEntry;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.gui.util.comparator.IconComparator;
 import net.sf.jabref.gui.util.component.CheckBoxMessage;
 import net.sf.jabref.logic.bibtex.comparator.FieldComparator;
@@ -238,9 +238,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
         setupComparatorChooser();
         glTable.addMouseListener(new TableClickListener());
 
-        // Fix table row height
-        FontMetrics metrics = glTable.getFontMetrics(glTable.getFont());
-        glTable.setRowHeight(Math.max(glTable.getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(glTable);
 
         setWidths();
 

--- a/src/main/java/net/sf/jabref/gui/importer/ZipFileChooser.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ZipFileChooser.java
@@ -28,7 +28,6 @@ package net.sf.jabref.gui.importer;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.io.IOException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -55,6 +54,7 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumnModel;
 
 import net.sf.jabref.gui.util.FocusRequester;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.logic.importer.fileformat.CustomImporter;
 import net.sf.jabref.logic.importer.fileformat.ImportFormat;
 import net.sf.jabref.logic.l10n.Localization;
@@ -95,9 +95,7 @@ class ZipFileChooser extends JDialog {
         if (table.getRowCount() > 0) {
             table.setRowSelectionInterval(0, 0);
         }
-        // Fix table row height
-        FontMetrics metrics = table.getFontMetrics(table.getFont());
-        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(table);
 
         // cancel: no entry is selected
         JButton cancelButton = new JButton(Localization.lang("Cancel"));

--- a/src/main/java/net/sf/jabref/gui/importer/ZipFileChooser.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ZipFileChooser.java
@@ -28,6 +28,7 @@ package net.sf.jabref.gui.importer;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.io.IOException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -53,13 +54,10 @@ import javax.swing.ListSelectionModel;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumnModel;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.gui.util.FocusRequester;
 import net.sf.jabref.logic.importer.fileformat.CustomImporter;
 import net.sf.jabref.logic.importer.fileformat.ImportFormat;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.logic.util.OS;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -97,9 +95,9 @@ class ZipFileChooser extends JDialog {
         if (table.getRowCount() > 0) {
             table.setRowSelectionInterval(0, 0);
         }
-        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-        }
+        // Fix table row height
+        FontMetrics metrics = table.getFontMetrics(table.getFont());
+        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
 
         // cancel: no entry is selected
         JButton cancelButton = new JButton(Localization.lang("Cancel"));

--- a/src/main/java/net/sf/jabref/gui/importer/ZipFileChooser.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ZipFileChooser.java
@@ -53,10 +53,13 @@ import javax.swing.ListSelectionModel;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumnModel;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.gui.util.FocusRequester;
 import net.sf.jabref.logic.importer.fileformat.CustomImporter;
 import net.sf.jabref.logic.importer.fileformat.ImportFormat;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.OS;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -93,6 +96,9 @@ class ZipFileChooser extends JDialog {
         table.setPreferredScrollableViewportSize(new Dimension(500, 150));
         if (table.getRowCount() > 0) {
             table.setRowSelectionInterval(0, 0);
+        }
+        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
         }
 
         // cancel: no entry is selected

--- a/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
+++ b/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
@@ -17,7 +17,6 @@ package net.sf.jabref.gui.journals;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -67,7 +66,7 @@ import net.sf.jabref.gui.actions.BrowseAction;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.gui.net.MonitoredURLDownload;
-
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.journals.Abbreviation;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
@@ -193,9 +192,7 @@ class ManageJournalsPanel extends JPanel {
         viewBuiltin.addActionListener(e -> {
             JTable table = new JTable(JournalAbbreviationsUtil.getTableModel(Globals.journalAbbreviationLoader
                     .getRepository(JournalAbbreviationPreferences.fromPreferences(Globals.prefs)).getAbbreviations()));
-            // Fix table row height
-            FontMetrics metrics = table.getFontMetrics(table.getFont());
-            table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+            GUIUtil.correctRowHeight(table);
 
             JScrollPane pane = new JScrollPane(table);
             JOptionPane.showMessageDialog(null, pane, Localization.lang("Journal list preview"),
@@ -330,9 +327,7 @@ class ManageJournalsPanel extends JPanel {
 
         tableModel.setJournals(userAbbreviations);
         userTable = new JTable(tableModel);
-        // Fix table row height
-        FontMetrics metrics = userTable.getFontMetrics(userTable.getFont());
-        userTable.setRowHeight(Math.max(userTable.getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(userTable);
 
         userTable.addMouseListener(tableModel.getMouseListener());
         userPanel.add(new JScrollPane(userTable), BorderLayout.CENTER);
@@ -589,9 +584,7 @@ class ManageJournalsPanel extends JPanel {
                             .readJournalListFromFile(new File(tf.getText()));
 
                     JTable table = new JTable(JournalAbbreviationsUtil.getTableModel(abbreviations));
-                    // Fix table row height
-                    FontMetrics metrics = table.getFontMetrics(table.getFont());
-                    table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+                    GUIUtil.correctRowHeight(table);
 
                     JScrollPane pane = new JScrollPane(table);
                     JOptionPane.showMessageDialog(null, pane, Localization.lang("Journal list preview"),

--- a/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
+++ b/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
@@ -192,6 +192,9 @@ class ManageJournalsPanel extends JPanel {
         viewBuiltin.addActionListener(e -> {
             JTable table = new JTable(JournalAbbreviationsUtil.getTableModel(Globals.journalAbbreviationLoader
                     .getRepository(JournalAbbreviationPreferences.fromPreferences(Globals.prefs)).getAbbreviations()));
+            if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+                table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+            }
             JScrollPane pane = new JScrollPane(table);
             JOptionPane.showMessageDialog(null, pane, Localization.lang("Journal list preview"),
                     JOptionPane.INFORMATION_MESSAGE);
@@ -325,6 +328,9 @@ class ManageJournalsPanel extends JPanel {
 
         tableModel.setJournals(userAbbreviations);
         userTable = new JTable(tableModel);
+        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+            userTable.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+        }
         userTable.addMouseListener(tableModel.getMouseListener());
         userPanel.add(new JScrollPane(userTable), BorderLayout.CENTER);
     }
@@ -580,6 +586,9 @@ class ManageJournalsPanel extends JPanel {
                             .readJournalListFromFile(new File(tf.getText()));
 
                     JTable table = new JTable(JournalAbbreviationsUtil.getTableModel(abbreviations));
+                    if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+                        table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+                    }
                     JScrollPane pane = new JScrollPane(table);
                     JOptionPane.showMessageDialog(null, pane, Localization.lang("Journal list preview"),
                             JOptionPane.INFORMATION_MESSAGE);

--- a/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
+++ b/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
@@ -17,6 +17,7 @@ package net.sf.jabref.gui.journals;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -192,9 +193,10 @@ class ManageJournalsPanel extends JPanel {
         viewBuiltin.addActionListener(e -> {
             JTable table = new JTable(JournalAbbreviationsUtil.getTableModel(Globals.journalAbbreviationLoader
                     .getRepository(JournalAbbreviationPreferences.fromPreferences(Globals.prefs)).getAbbreviations()));
-            if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-                table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-            }
+            // Fix table row height
+            FontMetrics metrics = table.getFontMetrics(table.getFont());
+            table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+
             JScrollPane pane = new JScrollPane(table);
             JOptionPane.showMessageDialog(null, pane, Localization.lang("Journal list preview"),
                     JOptionPane.INFORMATION_MESSAGE);
@@ -328,9 +330,10 @@ class ManageJournalsPanel extends JPanel {
 
         tableModel.setJournals(userAbbreviations);
         userTable = new JTable(tableModel);
-        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-            userTable.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-        }
+        // Fix table row height
+        FontMetrics metrics = userTable.getFontMetrics(userTable.getFont());
+        userTable.setRowHeight(Math.max(userTable.getRowHeight(), metrics.getHeight()));
+
         userTable.addMouseListener(tableModel.getMouseListener());
         userPanel.add(new JScrollPane(userTable), BorderLayout.CENTER);
     }
@@ -586,9 +589,10 @@ class ManageJournalsPanel extends JPanel {
                             .readJournalListFromFile(new File(tf.getText()));
 
                     JTable table = new JTable(JournalAbbreviationsUtil.getTableModel(abbreviations));
-                    if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-                        table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-                    }
+                    // Fix table row height
+                    FontMetrics metrics = table.getFontMetrics(table.getFont());
+                    table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+
                     JScrollPane pane = new JScrollPane(table);
                     JOptionPane.showMessageDialog(null, pane, Localization.lang("Journal list preview"),
                             JOptionPane.INFORMATION_MESSAGE);

--- a/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingsDialog.java
+++ b/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingsDialog.java
@@ -31,6 +31,8 @@ import javax.swing.table.TableColumnModel;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.OS;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * Dialog to customize key bindings
@@ -93,6 +95,9 @@ public class KeyBindingsDialog extends JDialog {
         table.setColumnSelectionAllowed(false);
         table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         table.setAutoCreateRowSorter(true);
+        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+        }
         return table;
     }
 

--- a/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingsDialog.java
+++ b/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingsDialog.java
@@ -17,6 +17,7 @@ package net.sf.jabref.gui.keyboard;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 
@@ -31,8 +32,6 @@ import javax.swing.table.TableColumnModel;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.logic.util.OS;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * Dialog to customize key bindings
@@ -95,9 +94,10 @@ public class KeyBindingsDialog extends JDialog {
         table.setColumnSelectionAllowed(false);
         table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         table.setAutoCreateRowSorter(true);
-        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-        }
+        // Fix table row height
+        FontMetrics metrics = table.getFontMetrics(table.getFont());
+        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+
         return table;
     }
 

--- a/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingsDialog.java
+++ b/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingsDialog.java
@@ -17,7 +17,6 @@ package net.sf.jabref.gui.keyboard;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 
@@ -31,6 +30,7 @@ import javax.swing.ListSelectionModel;
 import javax.swing.table.TableColumnModel;
 
 import net.sf.jabref.Globals;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.logic.l10n.Localization;
 
 /**
@@ -94,9 +94,7 @@ public class KeyBindingsDialog extends JDialog {
         table.setColumnSelectionAllowed(false);
         table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         table.setAutoCreateRowSorter(true);
-        // Fix table row height
-        FontMetrics metrics = table.getFontMetrics(table.getFont());
-        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(table);
 
         return table;
     }

--- a/src/main/java/net/sf/jabref/gui/openoffice/CitationManager.java
+++ b/src/main/java/net/sf/jabref/gui/openoffice/CitationManager.java
@@ -39,6 +39,8 @@ import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.openoffice.CitationEntry;
+import net.sf.jabref.logic.util.OS;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import ca.odell.glazedlists.BasicEventList;
 import ca.odell.glazedlists.EventList;
@@ -87,6 +89,10 @@ class CitationManager {
         }
         tableModel = new DefaultEventTableModel<>(list, new CitationEntryFormat());
         table = new JTable(tableModel);
+        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+        }
+
         diag.add(new JScrollPane(table), BorderLayout.CENTER);
 
         ButtonBarBuilder bb = new ButtonBarBuilder();

--- a/src/main/java/net/sf/jabref/gui/openoffice/CitationManager.java
+++ b/src/main/java/net/sf/jabref/gui/openoffice/CitationManager.java
@@ -17,6 +17,7 @@ package net.sf.jabref.gui.openoffice;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -39,8 +40,6 @@ import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.openoffice.CitationEntry;
-import net.sf.jabref.logic.util.OS;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 import ca.odell.glazedlists.BasicEventList;
 import ca.odell.glazedlists.EventList;
@@ -89,9 +88,9 @@ class CitationManager {
         }
         tableModel = new DefaultEventTableModel<>(list, new CitationEntryFormat());
         table = new JTable(tableModel);
-        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-        }
+        // Fix table row height
+        FontMetrics metrics = table.getFontMetrics(table.getFont());
+        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
 
         diag.add(new JScrollPane(table), BorderLayout.CENTER);
 

--- a/src/main/java/net/sf/jabref/gui/openoffice/CitationManager.java
+++ b/src/main/java/net/sf/jabref/gui/openoffice/CitationManager.java
@@ -17,7 +17,6 @@ package net.sf.jabref.gui.openoffice;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -38,6 +37,7 @@ import javax.swing.JTextField;
 import net.sf.jabref.Globals;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.keyboard.KeyBinding;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.openoffice.CitationEntry;
 
@@ -88,9 +88,7 @@ class CitationManager {
         }
         tableModel = new DefaultEventTableModel<>(list, new CitationEntryFormat());
         table = new JTable(tableModel);
-        // Fix table row height
-        FontMetrics metrics = table.getFontMetrics(table.getFont());
-        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(table);
 
         diag.add(new JScrollPane(table), BorderLayout.CENTER);
 

--- a/src/main/java/net/sf/jabref/gui/openoffice/StyleSelectDialog.java
+++ b/src/main/java/net/sf/jabref/gui/openoffice/StyleSelectDialog.java
@@ -17,7 +17,6 @@ package net.sf.jabref.gui.openoffice;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -58,6 +57,7 @@ import net.sf.jabref.gui.PreviewPanel;
 import net.sf.jabref.gui.actions.BrowseAction;
 import net.sf.jabref.gui.desktop.JabRefDesktop;
 import net.sf.jabref.gui.keyboard.KeyBinding;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.gui.util.PositionWindow;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.openoffice.OOBibStyle;
@@ -229,9 +229,7 @@ class StyleSelectDialog {
         cm.getColumn(0).setPreferredWidth(100);
         cm.getColumn(1).setPreferredWidth(200);
         cm.getColumn(2).setPreferredWidth(80);
-        // Fix table row height
-        FontMetrics metrics = table.getFontMetrics(table.getFont());
-        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(table);
 
         selectionModel = (DefaultEventSelectionModel<OOBibStyle>) GlazedListsSwing
                 .eventSelectionModelWithThreadProxyList(sortedStyles);

--- a/src/main/java/net/sf/jabref/gui/openoffice/StyleSelectDialog.java
+++ b/src/main/java/net/sf/jabref/gui/openoffice/StyleSelectDialog.java
@@ -17,6 +17,7 @@ package net.sf.jabref.gui.openoffice;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -63,7 +64,6 @@ import net.sf.jabref.logic.openoffice.OOBibStyle;
 import net.sf.jabref.logic.openoffice.OpenOfficePreferences;
 import net.sf.jabref.logic.openoffice.StyleLoader;
 import net.sf.jabref.logic.util.FileExtensions;
-import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.TestEntry;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
@@ -229,9 +229,10 @@ class StyleSelectDialog {
         cm.getColumn(0).setPreferredWidth(100);
         cm.getColumn(1).setPreferredWidth(200);
         cm.getColumn(2).setPreferredWidth(80);
-        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-        }
+        // Fix table row height
+        FontMetrics metrics = table.getFontMetrics(table.getFont());
+        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+
         selectionModel = (DefaultEventSelectionModel<OOBibStyle>) GlazedListsSwing
                 .eventSelectionModelWithThreadProxyList(sortedStyles);
         table.setSelectionModel(selectionModel);

--- a/src/main/java/net/sf/jabref/gui/openoffice/StyleSelectDialog.java
+++ b/src/main/java/net/sf/jabref/gui/openoffice/StyleSelectDialog.java
@@ -63,6 +63,7 @@ import net.sf.jabref.logic.openoffice.OOBibStyle;
 import net.sf.jabref.logic.openoffice.OpenOfficePreferences;
 import net.sf.jabref.logic.openoffice.StyleLoader;
 import net.sf.jabref.logic.util.FileExtensions;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.TestEntry;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
@@ -228,6 +229,9 @@ class StyleSelectDialog {
         cm.getColumn(0).setPreferredWidth(100);
         cm.getColumn(1).setPreferredWidth(200);
         cm.getColumn(2).setPreferredWidth(80);
+        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+        }
         selectionModel = (DefaultEventSelectionModel<OOBibStyle>) GlazedListsSwing
                 .eventSelectionModelWithThreadProxyList(sortedStyles);
         table.setSelectionModel(selectionModel);

--- a/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
@@ -35,12 +35,14 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.OSXCompatibleToolbar;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.layout.format.NameFormatter;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
@@ -169,6 +171,9 @@ public class NameFormatterTab extends JPanel implements PrefsTab {
         };
 
         table = new JTable(tableModel);
+        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+        }
         TableColumnModel columnModel = table.getColumnModel();
         columnModel.getColumn(0).setPreferredWidth(140);
         columnModel.getColumn(1).setPreferredWidth(400);

--- a/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
@@ -17,6 +17,7 @@ package net.sf.jabref.gui.preftabs;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,14 +36,12 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.OSXCompatibleToolbar;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.layout.format.NameFormatter;
-import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
@@ -171,9 +170,10 @@ public class NameFormatterTab extends JPanel implements PrefsTab {
         };
 
         table = new JTable(tableModel);
-        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-        }
+        // Fix table row height
+        FontMetrics metrics = table.getFontMetrics(table.getFont());
+        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+
         TableColumnModel columnModel = table.getColumnModel();
         columnModel.getColumn(0).setPreferredWidth(140);
         columnModel.getColumn(1).setPreferredWidth(400);

--- a/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/NameFormatterTab.java
@@ -17,7 +17,6 @@ package net.sf.jabref.gui.preftabs;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +38,7 @@ import javax.swing.table.TableModel;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.OSXCompatibleToolbar;
 import net.sf.jabref.gui.help.HelpAction;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.layout.format.NameFormatter;
@@ -170,9 +170,7 @@ public class NameFormatterTab extends JPanel implements PrefsTab {
         };
 
         table = new JTable(tableModel);
-        // Fix table row height
-        FontMetrics metrics = table.getFontMetrics(table.getFont());
-        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(table);
 
         TableColumnModel columnModel = table.getColumnModel();
         columnModel.getColumn(0).setPreferredWidth(140);

--- a/src/main/java/net/sf/jabref/gui/preftabs/PreferencesFilterDialog.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/PreferencesFilterDialog.java
@@ -2,6 +2,7 @@ package net.sf.jabref.gui.preftabs;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.util.List;
 import java.util.Objects;
 
@@ -14,11 +15,8 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.table.AbstractTableModel;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.gui.WrapLayout;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.logic.util.OS;
-import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.preferences.JabRefPreferencesFilter;
 
 class PreferencesFilterDialog extends JDialog {
@@ -51,9 +49,10 @@ class PreferencesFilterDialog extends JDialog {
 
         table = new JTable();
         table.setAutoCreateRowSorter(true);
-        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-        }
+        // Fix table row height
+        FontMetrics metrics = table.getFontMetrics(table.getFont());
+        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+
         updateModel();
         panel.add(new JScrollPane(table), BorderLayout.CENTER);
 

--- a/src/main/java/net/sf/jabref/gui/preftabs/PreferencesFilterDialog.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/PreferencesFilterDialog.java
@@ -14,8 +14,11 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.table.AbstractTableModel;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.gui.WrapLayout;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.OS;
+import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.preferences.JabRefPreferencesFilter;
 
 class PreferencesFilterDialog extends JDialog {
@@ -48,6 +51,9 @@ class PreferencesFilterDialog extends JDialog {
 
         table = new JTable();
         table.setAutoCreateRowSorter(true);
+        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+        }
         updateModel();
         panel.add(new JScrollPane(table), BorderLayout.CENTER);
 
@@ -102,7 +108,7 @@ class PreferencesFilterDialog extends JDialog {
 
         @Override
         public Object getValueAt(int rowIndex, int columnIndex) {
-            if (rowIndex < 0 || rowIndex - 1 > preferences.size()) {
+            if ((rowIndex < 0) || ((rowIndex - 1) > preferences.size())) {
                 return "n/a";
             }
 

--- a/src/main/java/net/sf/jabref/gui/preftabs/PreferencesFilterDialog.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/PreferencesFilterDialog.java
@@ -2,7 +2,6 @@ package net.sf.jabref.gui.preftabs;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.util.List;
 import java.util.Objects;
 
@@ -16,6 +15,7 @@ import javax.swing.JTable;
 import javax.swing.table.AbstractTableModel;
 
 import net.sf.jabref.gui.WrapLayout;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.preferences.JabRefPreferencesFilter;
 
@@ -49,9 +49,7 @@ class PreferencesFilterDialog extends JDialog {
 
         table = new JTable();
         table.setAutoCreateRowSorter(true);
-        // Fix table row height
-        FontMetrics metrics = table.getFontMetrics(table.getFont());
-        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(table);
 
         updateModel();
         panel.add(new JScrollPane(table), BorderLayout.CENTER);

--- a/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
@@ -17,7 +17,6 @@ package net.sf.jabref.gui.preftabs;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -53,6 +52,7 @@ import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.OSXCompatibleToolbar;
 import net.sf.jabref.gui.help.HelpAction;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibtexSingleField;
@@ -248,9 +248,7 @@ class TableColumnsTab extends JPanel implements PrefsTab {
         TableColumnModel cm = colSetup.getColumnModel();
         cm.getColumn(0).setPreferredWidth(140);
         cm.getColumn(1).setPreferredWidth(80);
-        // Fix table row height
-        FontMetrics metrics = colSetup.getFontMetrics(colSetup.getFont());
-        colSetup.setRowHeight(Math.max(colSetup.getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(colSetup);
 
         FormLayout layout = new FormLayout
                 ("1dlu, 8dlu, left:pref, 4dlu, fill:pref","");

--- a/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
@@ -17,6 +17,7 @@ package net.sf.jabref.gui.preftabs;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,7 +46,6 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.external.ExternalFileType;
 import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.gui.BasePanel;
@@ -55,7 +55,6 @@ import net.sf.jabref.gui.OSXCompatibleToolbar;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.entry.BibtexSingleField;
 import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.preferences.JabRefPreferences;
@@ -249,9 +248,9 @@ class TableColumnsTab extends JPanel implements PrefsTab {
         TableColumnModel cm = colSetup.getColumnModel();
         cm.getColumn(0).setPreferredWidth(140);
         cm.getColumn(1).setPreferredWidth(80);
-        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-            colSetup.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-        }
+        // Fix table row height
+        FontMetrics metrics = colSetup.getFontMetrics(colSetup.getFont());
+        colSetup.setRowHeight(Math.max(colSetup.getRowHeight(), metrics.getHeight()));
 
         FormLayout layout = new FormLayout
                 ("1dlu, 8dlu, left:pref, 4dlu, fill:pref","");

--- a/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
@@ -45,6 +45,7 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.external.ExternalFileType;
 import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.gui.BasePanel;
@@ -54,6 +55,7 @@ import net.sf.jabref.gui.OSXCompatibleToolbar;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.entry.BibtexSingleField;
 import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.preferences.JabRefPreferences;
@@ -247,6 +249,9 @@ class TableColumnsTab extends JPanel implements PrefsTab {
         TableColumnModel cm = colSetup.getColumnModel();
         cm.getColumn(0).setPreferredWidth(140);
         cm.getColumn(1).setPreferredWidth(80);
+        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+            colSetup.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+        }
 
         FormLayout layout = new FormLayout
                 ("1dlu, 8dlu, left:pref, 4dlu, fill:pref","");

--- a/src/main/java/net/sf/jabref/gui/preftabs/XmpPrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/XmpPrefsTab.java
@@ -17,6 +17,7 @@ package net.sf.jabref.gui.preftabs;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,11 +38,9 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.OSXCompatibleToolbar;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
@@ -127,9 +126,9 @@ class XmpPrefsTab extends JPanel implements PrefsTab {
         };
 
         table = new JTable(tableModel);
-        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-        }
+        // Fix table row height
+        FontMetrics metrics = table.getFontMetrics(table.getFont());
+        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
 
         TableColumnModel columnModel = table.getColumnModel();
         columnModel.getColumn(0).setPreferredWidth(140);

--- a/src/main/java/net/sf/jabref/gui/preftabs/XmpPrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/XmpPrefsTab.java
@@ -37,9 +37,11 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.OSXCompatibleToolbar;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.DefaultFormBuilder;
@@ -125,6 +127,10 @@ class XmpPrefsTab extends JPanel implements PrefsTab {
         };
 
         table = new JTable(tableModel);
+        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+        }
+
         TableColumnModel columnModel = table.getColumnModel();
         columnModel.getColumn(0).setPreferredWidth(140);
 

--- a/src/main/java/net/sf/jabref/gui/preftabs/XmpPrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/XmpPrefsTab.java
@@ -17,7 +17,6 @@ package net.sf.jabref.gui.preftabs;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +39,7 @@ import javax.swing.table.TableModel;
 
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.OSXCompatibleToolbar;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -126,9 +126,7 @@ class XmpPrefsTab extends JPanel implements PrefsTab {
         };
 
         table = new JTable(tableModel);
-        // Fix table row height
-        FontMetrics metrics = table.getFontMetrics(table.getFont());
-        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(table);
 
         TableColumnModel columnModel = table.getColumnModel();
         columnModel.getColumn(0).setPreferredWidth(140);

--- a/src/main/java/net/sf/jabref/gui/protectedterms/ProtectedTermsDialog.java
+++ b/src/main/java/net/sf/jabref/gui/protectedterms/ProtectedTermsDialog.java
@@ -17,6 +17,7 @@ package net.sf.jabref.gui.protectedterms;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -64,7 +65,6 @@ import net.sf.jabref.logic.protectedterms.ProtectedTermsList;
 import net.sf.jabref.logic.protectedterms.ProtectedTermsLoader;
 import net.sf.jabref.logic.protectedterms.ProtectedTermsPreferences;
 import net.sf.jabref.logic.util.FileExtensions;
-import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -203,9 +203,9 @@ public class ProtectedTermsDialog {
         cm.getColumn(0).setMaxWidth((cm.getColumn(0).getPreferredWidth() * 11) / 10);
         cm.getColumn(1).setPreferredWidth(100);
         cm.getColumn(2).setPreferredWidth(100);
-        if (OS.WINDOWS) { // On Windows the table font scales with the menu font
-            table.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-        }
+        // Fix table row height
+        FontMetrics metrics = table.getFontMetrics(table.getFont());
+        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
 
         table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         table.addMouseListener(new MouseAdapter() {

--- a/src/main/java/net/sf/jabref/gui/protectedterms/ProtectedTermsDialog.java
+++ b/src/main/java/net/sf/jabref/gui/protectedterms/ProtectedTermsDialog.java
@@ -17,7 +17,6 @@ package net.sf.jabref.gui.protectedterms;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -59,6 +58,7 @@ import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.actions.BrowseAction;
 import net.sf.jabref.gui.desktop.JabRefDesktop;
 import net.sf.jabref.gui.keyboard.KeyBinding;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.gui.util.PositionWindow;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.protectedterms.ProtectedTermsList;
@@ -203,9 +203,7 @@ public class ProtectedTermsDialog {
         cm.getColumn(0).setMaxWidth((cm.getColumn(0).getPreferredWidth() * 11) / 10);
         cm.getColumn(1).setPreferredWidth(100);
         cm.getColumn(2).setPreferredWidth(100);
-        // Fix table row height
-        FontMetrics metrics = table.getFontMetrics(table.getFont());
-        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(table);
 
         table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         table.addMouseListener(new MouseAdapter() {

--- a/src/main/java/net/sf/jabref/gui/search/SearchResultsDialog.java
+++ b/src/main/java/net/sf/jabref/gui/search/SearchResultsDialog.java
@@ -18,7 +18,6 @@ package net.sf.jabref.gui.search;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -61,6 +60,7 @@ import net.sf.jabref.gui.desktop.JabRefDesktop;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.gui.maintable.MainTableNameFormatter;
 import net.sf.jabref.gui.renderer.GeneralRenderer;
+import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.gui.util.comparator.IconComparator;
 import net.sf.jabref.logic.bibtex.comparator.EntryComparator;
 import net.sf.jabref.logic.bibtex.comparator.FieldComparator;
@@ -136,9 +136,7 @@ public class SearchResultsDialog {
         model = (DefaultEventTableModel<BibEntry>) GlazedListsSwing.eventTableModelWithThreadProxyList(sortedEntries,
                 new EntryTableFormat());
         entryTable = new JTable(model);
-        // Fix table row height
-        FontMetrics metrics = entryTable.getFontMetrics(entryTable.getFont());
-        entryTable.setRowHeight(Math.max(entryTable.getRowHeight(), metrics.getHeight()));
+        GUIUtil.correctRowHeight(entryTable);
 
         GeneralRenderer renderer = new GeneralRenderer(Color.white);
         entryTable.setDefaultRenderer(JLabel.class, renderer);

--- a/src/main/java/net/sf/jabref/gui/search/SearchResultsDialog.java
+++ b/src/main/java/net/sf/jabref/gui/search/SearchResultsDialog.java
@@ -18,6 +18,7 @@ package net.sf.jabref.gui.search;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -64,7 +65,6 @@ import net.sf.jabref.gui.util.comparator.IconComparator;
 import net.sf.jabref.logic.bibtex.comparator.EntryComparator;
 import net.sf.jabref.logic.bibtex.comparator.FieldComparator;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.EntryUtil;
 import net.sf.jabref.model.entry.FieldName;
@@ -136,9 +136,9 @@ public class SearchResultsDialog {
         model = (DefaultEventTableModel<BibEntry>) GlazedListsSwing.eventTableModelWithThreadProxyList(sortedEntries,
                 new EntryTableFormat());
         entryTable = new JTable(model);
-        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
-            entryTable.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
-        }
+        // Fix table row height
+        FontMetrics metrics = entryTable.getFontMetrics(entryTable.getFont());
+        entryTable.setRowHeight(Math.max(entryTable.getRowHeight(), metrics.getHeight()));
 
         GeneralRenderer renderer = new GeneralRenderer(Color.white);
         entryTable.setDefaultRenderer(JLabel.class, renderer);

--- a/src/main/java/net/sf/jabref/gui/search/SearchResultsDialog.java
+++ b/src/main/java/net/sf/jabref/gui/search/SearchResultsDialog.java
@@ -64,6 +64,7 @@ import net.sf.jabref.gui.util.comparator.IconComparator;
 import net.sf.jabref.logic.bibtex.comparator.EntryComparator;
 import net.sf.jabref.logic.bibtex.comparator.FieldComparator;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.EntryUtil;
 import net.sf.jabref.model.entry.FieldName;
@@ -135,6 +136,10 @@ public class SearchResultsDialog {
         model = (DefaultEventTableModel<BibEntry>) GlazedListsSwing.eventTableModelWithThreadProxyList(sortedEntries,
                 new EntryTableFormat());
         entryTable = new JTable(model);
+        if (OS.WINDOWS) { // Arbitrary tables scales with menu font size on Windows
+            entryTable.setRowHeight(Globals.prefs.getInt(JabRefPreferences.MENU_FONT_SIZE) + 2);
+        }
+
         GeneralRenderer renderer = new GeneralRenderer(Color.white);
         entryTable.setDefaultRenderer(JLabel.class, renderer);
         entryTable.setDefaultRenderer(String.class, renderer);

--- a/src/main/java/net/sf/jabref/gui/util/GUIUtil.java
+++ b/src/main/java/net/sf/jabref/gui/util/GUIUtil.java
@@ -1,0 +1,39 @@
+package net.sf.jabref.gui.util;
+
+import java.awt.FontMetrics;
+
+import javax.swing.JTable;
+import javax.swing.JTree;
+
+public final class GUIUtil {
+
+    private GUIUtil() {
+        // Private constructor as all methods are static
+    }
+
+    /**
+     * Update table row height to the best possible considering font size changes on the current platform
+     *
+     * http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4760081
+     *
+     * @param table
+     */
+    public static void correctRowHeight(JTable table) {
+        // Fix tree row height
+        FontMetrics metrics = table.getFontMetrics(table.getFont());
+        table.setRowHeight(Math.max(table.getRowHeight(), metrics.getHeight()));
+    }
+
+    /**
+     * Update tree row height to the best possible considering font size changes on the current platform
+     *
+     * http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4760081
+     *
+     * @param table
+     */
+    public static void correctRowHeight(JTree tree) {
+        // Fix tree row height
+        FontMetrics metrics = tree.getFontMetrics(tree.getFont());
+        tree.setRowHeight(Math.max(tree.getRowHeight(), metrics.getHeight()));
+    }
+}


### PR DESCRIPTION
When increasing the menu font size on Windows (at least WIndows 10), the tables also scale but not the row width. This has been fixed in some dialogs earlier, but this is a general fix.

I have no idea how it works on OSX, but on Linux (my CentOS office machine) it seems like the table font is not the same as the menu font.

This is relevant for high resolution displays (although I cannot find the issue that discussed it...)

Before:
<img width="366" alt="capture8" src="https://cloud.githubusercontent.com/assets/8114497/17086432/41e08464-51f2-11e6-95d0-8a6b4e7d6787.PNG">

After:
<img width="368" alt="capture9" src="https://cloud.githubusercontent.com/assets/8114497/17086436/4adfd06a-51f2-11e6-9f74-8d058aabfc80.PNG">

- [x] Change in CHANGELOG.md described
- [x] Screenshots added (for bigger UI changes)

