### PR TITLE
[WIP] Define xjc input/ouput dir (subsequent builds will be faster)

### DIFF
--- a/medline.gradle
+++ b/medline.gradle
@@ -1,18 +1,22 @@
-
 configurations {
- xjc
-} 
+    xjc
+}
 
 dependencies {
- xjc group: 'com.sun.xml.bind', name: 'jaxb-xjc', version: '2.2.4-1'
+    xjc 'com.sun.xml.bind:jaxb-xjc:2.2.4-1'
 }
 
-task xjc () << { 
- ant.taskdef(name: 'xjc', classname: 'com.sun.tools.xjc.XJCTask', classpath: configurations.xjc.asPath)
- 
- ant.xjc(destdir: 'src/main/gen/', package: 'net.sf.jabref.importer.fileformat.medline'){
-  schema(dir: 'src/main/resources/xjc/medline', includes: 'medline.xsd')
-  }
+task xjc {
+    inputs.dir "src/main/resources/xjc/medline/"
+    outputs.dir "src/main/gen/net/sf/jabref/importer/fileformat/medline"
+
+    ant.taskdef(name: 'xjc', classname: 'com.sun.tools.xjc.XJCTask', classpath: configurations.xjc.asPath)
+
+    doLast {
+        ant.xjc(destdir: 'src/main/gen/', package: 'net.sf.jabref.importer.fileformat.medline') {
+            schema(dir: 'src/main/resources/xjc/medline', includes: 'medline.xsd')
+        }
+    }
 }
 
-tasks. compileJava.dependsOn xjc
+tasks.compileJava.dependsOn xjc


### PR DESCRIPTION
I defined the input/output dirs for xjc in the configuration phase. Now the Task will only executed if the input/output dir has changed which will speed up starting JabRef with Gradle a little.

~~- [ ] Change in CHANGELOG.md described~~
~~- [ ] Tests created for changes~~
~~- [ ] Screenshots added (for bigger UI changes)~~
- [X] Manually tested changed features in running JabRef

