### PR TITLE
Replaced some getField and fixed some bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Fixed
 - Fixed [#1264](https://github.com/JabRef/jabref/issues/1264): S with caron does not render correctly
 - LaTeX to Unicode converter now handles combining accents
+- Fixed NullPointerException when clicking Browse in Journal abbreviations with empty text field
+- Fixed NullPointerException when opening file in Plain text import
+- Fixed NullPointerException when appending database
 - Fixed [#636](https://github.com/JabRef/jabref/issues/636): DOI in export filters
 - Fixed [#1527](https://github.com/JabRef/jabref/issues/1527): 'Get BibTeX data from DOI' Removes Marking
 - Fixed [#1592](https://github.com/JabRef/jabref/issues/1592): LibreOffice: wrong numbers in citation labels

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -35,6 +35,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -802,25 +803,30 @@ public class EntryEditor extends JPanel implements EntryContainer {
             }
 
             // First, remove fields that the user has removed.
-            for (String field : entry.getFieldNames()) {
-                if (InternalBibtexFields.isDisplayableField(field) && !newEntry.hasField(field)) {
-                    compound.addEdit(new UndoableFieldChange(entry, field, entry.getField(field), null));
-                    entry.clearField(field);
+            for (Entry<String, String> field : entry.getFieldMap().entrySet()) {
+                String fieldName = field.getKey();
+                String fieldValue = field.getValue();
+
+                if (InternalBibtexFields.isDisplayableField(fieldName) && !newEntry.hasField(fieldName)) {
+                    compound.addEdit(
+                            new UndoableFieldChange(entry, fieldName, fieldValue, null));
+                    entry.clearField(fieldName);
                     entryChanged = true;
                 }
             }
 
             // Then set all fields that have been set by the user.
-            for (String field : newEntry.getFieldNames()) {
-                String oldValue = entry.getField(field);
-                String newValue = newEntry.getField(field);
+            for (Entry<String, String> field : newEntry.getFieldMap().entrySet()) {
+                String fieldName = field.getKey();
+                String oldValue = entry.getFieldOptional(fieldName).orElse(null);
+                String newValue = field.getValue();
                 if (!Objects.equals(oldValue, newValue)) {
                     // Test if the field is legally set.
                     new LatexFieldFormatter(LatexFieldFormatterPreferences.fromPreferences(Globals.prefs))
-                            .format(newValue, field);
+                            .format(newValue, fieldName);
 
-                    compound.addEdit(new UndoableFieldChange(entry, field, oldValue, newValue));
-                    entry.setField(field, newValue);
+                    compound.addEdit(new UndoableFieldChange(entry, fieldName, oldValue, newValue));
+                    entry.setField(fieldName, newValue);
                     entryChanged = true;
                 }
             }

--- a/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
+++ b/src/main/java/net/sf/jabref/gui/journals/ManageJournalsPanel.java
@@ -196,11 +196,14 @@ class ManageJournalsPanel extends JPanel {
         });
 
         browseNew.addActionListener(e -> {
-            Path old = null;
+            String name;
             if (!newNameTf.getText().isEmpty()) {
-                old = Paths.get(newNameTf.getText());
+                name = FileDialogs.getNewFile(frame, Paths.get(newNameTf.getText()).toFile(), Collections.emptyList(), JFileChooser.SAVE_DIALOG,
+                        false);
+            } else {
+                name = FileDialogs.getNewFile(frame, null, Collections.emptyList(), JFileChooser.SAVE_DIALOG, false);
             }
-            String name = FileDialogs.getNewFile(frame, old.toFile(), null, JFileChooser.SAVE_DIALOG, false);
+
             if (name != null) {
                 newNameTf.setText(name);
                 newFile.setSelected(true);
@@ -208,11 +211,14 @@ class ManageJournalsPanel extends JPanel {
         });
 
         browseOld.addActionListener(e -> {
-            Path old = null;
+            String name;
             if (!personalFile.getText().isEmpty()) {
-                old = Paths.get(personalFile.getText());
+                name = FileDialogs.getNewFile(frame, Paths.get(personalFile.getText()).toFile(),
+                        Collections.emptyList(), JFileChooser.OPEN_DIALOG, false);
+            } else {
+                name = FileDialogs.getNewFile(frame, null, Collections.emptyList(), JFileChooser.OPEN_DIALOG, false);
             }
-            String name = FileDialogs.getNewFile(frame, old.toFile(), null, JFileChooser.OPEN_DIALOG, false);
+
             if (name != null) {
                 personalFile.setText(name);
                 oldFile.setSelected(true);

--- a/src/main/java/net/sf/jabref/gui/maintable/SpecialMainTableColumns.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/SpecialMainTableColumns.java
@@ -15,6 +15,7 @@ import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.specialfields.Printed;
 import net.sf.jabref.specialfields.Priority;
 import net.sf.jabref.specialfields.Quality;
+import net.sf.jabref.specialfields.Rank;
 import net.sf.jabref.specialfields.ReadStatus;
 import net.sf.jabref.specialfields.Relevance;
 import net.sf.jabref.specialfields.SpecialFieldsUtils;
@@ -42,7 +43,7 @@ public class SpecialMainTableColumns {
         public Object getColumnValue(BibEntry entry) {
 
             return entry.getFieldOptional(SpecialFieldsUtils.FIELDNAME_RANKING)
-                    .flatMap(Priority.getInstance()::parse).map(rank -> rank.createLabel()).orElse(null);
+                    .flatMap(Rank.getInstance()::parse).map(rank -> rank.createLabel()).orElse(null);
         }
     };
 

--- a/src/main/java/net/sf/jabref/gui/maintable/SpecialMainTableColumns.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/SpecialMainTableColumns.java
@@ -15,10 +15,8 @@ import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.specialfields.Printed;
 import net.sf.jabref.specialfields.Priority;
 import net.sf.jabref.specialfields.Quality;
-import net.sf.jabref.specialfields.Rank;
 import net.sf.jabref.specialfields.ReadStatus;
 import net.sf.jabref.specialfields.Relevance;
-import net.sf.jabref.specialfields.SpecialFieldValue;
 import net.sf.jabref.specialfields.SpecialFieldsUtils;
 
 public class SpecialMainTableColumns {
@@ -42,12 +40,9 @@ public class SpecialMainTableColumns {
 
         @Override
         public Object getColumnValue(BibEntry entry) {
-            SpecialFieldValue rank = Rank.getInstance().parse(entry.getField(SpecialFieldsUtils.FIELDNAME_RANKING));
-            if (rank == null) {
-                return null;
-            } else {
-                return rank.createLabel();
-            }
+
+            return entry.getFieldOptional(SpecialFieldsUtils.FIELDNAME_RANKING)
+                    .flatMap(Priority.getInstance()::parse).map(rank -> rank.createLabel()).orElse(null);
         }
     };
 
@@ -58,13 +53,8 @@ public class SpecialMainTableColumns {
         @Override
         public Object getColumnValue(BibEntry entry) {
 
-            SpecialFieldValue prio = Priority.getInstance()
-                    .parse(entry.getField(SpecialFieldsUtils.FIELDNAME_PRIORITY));
-            if (prio == null) {
-                return null;
-            } else {
-                return prio.createLabel();
-            }
+            return entry.getFieldOptional(SpecialFieldsUtils.FIELDNAME_PRIORITY)
+                    .flatMap(Priority.getInstance()::parse).map(prio -> prio.createLabel()).orElse(null);
         }
     };
 
@@ -75,13 +65,8 @@ public class SpecialMainTableColumns {
         @Override
         public Object getColumnValue(BibEntry entry) {
 
-            SpecialFieldValue status = ReadStatus.getInstance()
-                    .parse(entry.getField(SpecialFieldsUtils.FIELDNAME_READ));
-            if (status == null) {
-                return null;
-            } else {
-                return status.createLabel();
-            }
+            return entry.getFieldOptional(SpecialFieldsUtils.FIELDNAME_READ)
+                    .flatMap(ReadStatus.getInstance()::parse).map(status -> status.createLabel()).orElse(null);
         }
     };
 

--- a/src/main/java/net/sf/jabref/gui/plaintextimport/TextInputDialog.java
+++ b/src/main/java/net/sf/jabref/gui/plaintextimport/TextInputDialog.java
@@ -70,6 +70,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -603,7 +604,8 @@ public class TextInputDialog extends JDialog {
         @Override
         public void actionPerformed(ActionEvent e) {
             try {
-                String chosen = FileDialogs.getNewFile(frame, null, null, ".txt", JFileChooser.OPEN_DIALOG, false);
+                String chosen = FileDialogs.getNewFile(frame, null, Collections.emptyList(), ".txt",
+                        JFileChooser.OPEN_DIALOG, false);
                 if (chosen != null) {
                     File newFile = new File(chosen);
                     document.remove(0, document.getLength());

--- a/src/main/java/net/sf/jabref/importer/AppendDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/importer/AppendDatabaseAction.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import javax.swing.JOptionPane;
@@ -82,7 +83,7 @@ public class AppendDatabaseAction implements BaseAction {
         if (md.isOkPressed()) {
             List<String> chosen = FileDialogs.getMultipleFiles(frame,
                     new File(Globals.prefs.get(JabRefPreferences.WORKING_DIRECTORY)),
-                    null, false);
+                    Collections.emptyList(), false);
             //String chosenFile = Globals.getNewFile(frame, new File(Globals.prefs.get("workingDirectory")),
             //                                       null, JFileChooser.OPEN_DIALOG, false);
             if (chosen.isEmpty()) {

--- a/src/main/java/net/sf/jabref/importer/CustomImporter.java
+++ b/src/main/java/net/sf/jabref/importer/CustomImporter.java
@@ -117,6 +117,10 @@ public class CustomImporter implements Comparable<CustomImporter> {
 
     @Override
     public boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
+
         boolean equalName = this.getName().equals(((CustomImporter) o).getName());
         boolean equalCliId = this.getClidId().equals(((CustomImporter) o).getClidId());
         boolean equalClassName = this.getClassName().equals(((CustomImporter) o).getClassName());

--- a/src/main/java/net/sf/jabref/importer/CustomImporter.java
+++ b/src/main/java/net/sf/jabref/importer/CustomImporter.java
@@ -1,5 +1,5 @@
 /*
- Copyright (C) 2005-2015 Andreas Rudert, Oscar Gustafsson extracted from CustomImportList
+ Copyright (C) 2005-2016 Andreas Rudert, Oscar Gustafsson extracted from CustomImportList
 
  All programs in this directory and
  subdirectories are published under the GNU General Public License as
@@ -116,17 +116,26 @@ public class CustomImporter implements Comparable<CustomImporter> {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (o == null) {
+    public boolean equals(Object other) {
+        if (other == null) {
             return false;
         }
 
-        boolean equalName = this.getName().equals(((CustomImporter) o).getName());
-        boolean equalCliId = this.getClidId().equals(((CustomImporter) o).getClidId());
-        boolean equalClassName = this.getClassName().equals(((CustomImporter) o).getClassName());
-        boolean equalBasePath = this.getBasePath().equals(((CustomImporter) o).getBasePath());
+        if (this == other) {
+            return true;
+        }
 
-        return (o instanceof CustomImporter) && equalName && equalCliId && equalClassName && equalBasePath;
+        if (!(other instanceof CustomImporter)) {
+            return false;
+        }
+
+        CustomImporter otherImporter = (CustomImporter) other;
+        boolean equalName = this.getName().equals(otherImporter.getName());
+        boolean equalCliId = this.getClidId().equals(otherImporter.getClidId());
+        boolean equalClassName = this.getClassName().equals(otherImporter.getClassName());
+        boolean equalBasePath = this.getBasePath().equals(otherImporter.getBasePath());
+
+        return equalName && equalCliId && equalClassName && equalBasePath;
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/importer/CustomImporter.java
+++ b/src/main/java/net/sf/jabref/importer/CustomImporter.java
@@ -35,6 +35,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import net.sf.jabref.importer.fileformat.ImportFormat;
 
@@ -117,9 +118,6 @@ public class CustomImporter implements Comparable<CustomImporter> {
 
     @Override
     public boolean equals(Object other) {
-        if (other == null) {
-            return false;
-        }
 
         if (this == other) {
             return true;
@@ -130,17 +128,14 @@ public class CustomImporter implements Comparable<CustomImporter> {
         }
 
         CustomImporter otherImporter = (CustomImporter) other;
-        boolean equalName = this.getName().equals(otherImporter.getName());
-        boolean equalCliId = this.getClidId().equals(otherImporter.getClidId());
-        boolean equalClassName = this.getClassName().equals(otherImporter.getClassName());
-        boolean equalBasePath = this.getBasePath().equals(otherImporter.getBasePath());
-
-        return equalName && equalCliId && equalClassName && equalBasePath;
+        return Objects.equals(name, otherImporter.name) && Objects.equals(cliId, otherImporter.cliId)
+                && Objects.equals(className, otherImporter.className)
+                && Objects.equals(basePath, otherImporter.basePath);
     }
 
     @Override
     public int hashCode() {
-        return name.hashCode();
+        return Objects.hash(name, cliId, className, basePath);
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/logic/groups/AllEntriesGroup.java
+++ b/src/main/java/net/sf/jabref/logic/groups/AllEntriesGroup.java
@@ -53,13 +53,13 @@ public class AllEntriesGroup extends AbstractGroup {
     @Override
     public Optional<EntriesGroupChange> add(List<BibEntry> entriesToAdd) {
         // not supported -> ignore
-        return null;
+        return Optional.empty();
     }
 
     @Override
     public Optional<EntriesGroupChange> remove(List<BibEntry> entriesToRemove) {
         // not supported -> ignore
-        return null;
+        return Optional.empty();
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
@@ -412,7 +412,7 @@ public class IntegrityCheck {
                 while (hashMatcher.find()) {
                     hashCount++;
                 }
-                if ((hashCount % 2) == 1) {
+                if ((hashCount & 1) == 1) { // Check if odd
                     results.add(
                             new IntegrityMessage(Localization.lang("odd number of unescaped '#'"), entry,
                                     field.getKey()));

--- a/src/main/java/net/sf/jabref/logic/mods/MODSEntry.java
+++ b/src/main/java/net/sf/jabref/logic/mods/MODSEntry.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -98,17 +99,17 @@ class MODSEntry {
     private void populateFromBibtex(BibEntry bibtex) {
         if (bibtex.hasField(FieldName.TITLE)) {
             if (CHARFORMAT) {
-                title = chars.format(bibtex.getField(FieldName.TITLE));
+                title = chars.format(bibtex.getFieldOptional(FieldName.TITLE).get());
             } else {
-                title = bibtex.getField(FieldName.TITLE);
+                title = bibtex.getFieldOptional(FieldName.TITLE).get();
             }
         }
 
         if (bibtex.hasField(FieldName.PUBLISHER)) {
             if (CHARFORMAT) {
-                publisher = chars.format(bibtex.getField(FieldName.PUBLISHER));
+                publisher = chars.format(bibtex.getFieldOptional(FieldName.PUBLISHER).get());
             } else {
-                publisher = bibtex.getField(FieldName.PUBLISHER);
+                publisher = bibtex.getFieldOptional(FieldName.PUBLISHER).get();
             }
         }
 
@@ -126,7 +127,7 @@ class MODSEntry {
         date = getDate(bibtex);
         genre = getMODSgenre(bibtex);
         if (bibtex.hasField(FieldName.AUTHOR)) {
-            authors = getAuthors(bibtex.getField(FieldName.AUTHOR));
+            authors = getAuthors(bibtex.getFieldOptional(FieldName.AUTHOR).get());
         }
         if ("article".equals(bibtex.getType()) || "inproceedings".equals(bibtex.getType())) {
             host = new MODSEntry();
@@ -135,11 +136,11 @@ class MODSEntry {
             host.publisher = bibtex.getField(FieldName.PUBLISHER);
             host.number = bibtex.getField(FieldName.NUMBER);
             if (bibtex.hasField(FieldName.VOLUME)) {
-                host.volume = bibtex.getField(FieldName.VOLUME);
+                host.volume = bibtex.getFieldOptional(FieldName.VOLUME).get();
             }
             host.issuance = "continuing";
             if (bibtex.hasField(FieldName.PAGES)) {
-                host.pages = new PageNumbers(bibtex.getField(FieldName.PAGES));
+                host.pages = new PageNumbers(bibtex.getFieldOptional(FieldName.PAGES).get());
             }
         }
 
@@ -149,9 +150,8 @@ class MODSEntry {
 
     private void populateExtensionFields(BibEntry e) {
 
-        for (String field : e.getFieldNames()) {
-            String value = e.getField(field);
-            extensionFields.put(MODSEntry.BIBTEX + field, value);
+        for (Entry<String, String> field : e.getFieldMap().entrySet()) {
+            extensionFields.put(MODSEntry.BIBTEX + field.getKey(), field.getValue());
         }
     }
 

--- a/src/main/java/net/sf/jabref/logic/xmp/XMPUtil.java
+++ b/src/main/java/net/sf/jabref/logic/xmp/XMPUtil.java
@@ -1004,8 +1004,6 @@ public class XMPUtil {
         Set<String> filters = new TreeSet<>(prefs.getStringList(JabRefPreferences.XMP_PRIVACY_FILTERS));
 
         // Set all the values including key and entryType
-        Set<String> fields = resolvedEntry.getFieldNames();
-
         for (Entry<String, String> field : resolvedEntry.getFieldMap().entrySet()) {
 
             String fieldName = field.getKey();

--- a/src/main/java/net/sf/jabref/logic/xmp/XMPUtil.java
+++ b/src/main/java/net/sf/jabref/logic/xmp/XMPUtil.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -1005,34 +1006,37 @@ public class XMPUtil {
         // Set all the values including key and entryType
         Set<String> fields = resolvedEntry.getFieldNames();
 
-        for (String field : fields) {
+        for (Entry<String, String> field : resolvedEntry.getFieldMap().entrySet()) {
 
-            if (useXmpPrivacyFilter && filters.contains(field)) {
+            String fieldName = field.getKey();
+            String fieldContent = field.getValue();
+
+            if (useXmpPrivacyFilter && filters.contains(fieldName)) {
                 // erase field instead of adding it
-                if (FieldName.AUTHOR.equals(field)) {
+                if (FieldName.AUTHOR.equals(fieldName)) {
                     di.setAuthor(null);
-                } else if (FieldName.TITLE.equals(field)) {
+                } else if (FieldName.TITLE.equals(fieldName)) {
                     di.setTitle(null);
-                } else if (FieldName.KEYWORDS.equals(field)) {
+                } else if (FieldName.KEYWORDS.equals(fieldName)) {
                     di.setKeywords(null);
-                } else if (FieldName.ABSTRACT.equals(field)) {
+                } else if (FieldName.ABSTRACT.equals(fieldName)) {
                     di.setSubject(null);
                 } else {
-                    di.setCustomMetadataValue("bibtex/" + field, null);
+                    di.setCustomMetadataValue("bibtex/" + fieldName, null);
                 }
                 continue;
             }
 
-            if (FieldName.AUTHOR.equals(field)) {
-                di.setAuthor(resolvedEntry.getField(FieldName.AUTHOR));
-            } else if (FieldName.TITLE.equals(field)) {
-                di.setTitle(resolvedEntry.getField(FieldName.TITLE));
-            } else if (FieldName.KEYWORDS.equals(field)) {
-                di.setKeywords(resolvedEntry.getField(FieldName.KEYWORDS));
-            } else if (FieldName.ABSTRACT.equals(field)) {
-                di.setSubject(resolvedEntry.getField(FieldName.ABSTRACT));
+            if (FieldName.AUTHOR.equals(fieldName)) {
+                di.setAuthor(fieldContent);
+            } else if (FieldName.TITLE.equals(fieldName)) {
+                di.setTitle(fieldContent);
+            } else if (FieldName.KEYWORDS.equals(fieldName)) {
+                di.setKeywords(fieldContent);
+            } else if (FieldName.ABSTRACT.equals(fieldName)) {
+                di.setSubject(fieldContent);
             } else {
-                di.setCustomMetadataValue("bibtex/" + field, resolvedEntry.getField(field));
+                di.setCustomMetadataValue("bibtex/" + fieldName, fieldContent);
             }
         }
         di.setCustomMetadataValue("bibtex/entrytype", EntryUtil.capitalizeFirst(resolvedEntry.getType()));

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -353,7 +353,7 @@ public class BibEntry implements Cloneable {
             return clearField(fieldName);
         }
 
-        String oldValue = getField(fieldName);
+        String oldValue = getFieldOptional(fieldName).orElse(null);
         if (value.equals(oldValue)) {
             return Optional.empty();
         }

--- a/src/main/java/net/sf/jabref/model/entry/CanonicalBibtexEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/CanonicalBibtexEntry.java
@@ -3,6 +3,7 @@ package net.sf.jabref.model.entry;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.SortedSet;
 import java.util.StringJoiner;
 import java.util.TreeSet;
@@ -29,12 +30,14 @@ public class CanonicalBibtexEntry {
 
         // determine sorted fields -- all fields lower case
         SortedSet<String> sortedFields = new TreeSet<>();
-        for (String fieldName : e.getFieldNames()) {
+        for (Entry<String, String> field : e.getFieldMap().entrySet()) {
+            String fieldName = field.getKey();
+            String fieldValue = field.getValue();
             // JabRef stores the key in the field KEY_FIELD, which must not be serialized
             if (!fieldName.equals(BibEntry.KEY_FIELD)) {
                 String lowerCaseFieldName = fieldName.toLowerCase(Locale.US);
                 sortedFields.add(lowerCaseFieldName);
-                mapFieldToValue.put(lowerCaseFieldName, e.getField(fieldName));
+                mapFieldToValue.put(lowerCaseFieldName, fieldValue);
             }
         }
 

--- a/src/main/java/net/sf/jabref/specialfields/SpecialField.java
+++ b/src/main/java/net/sf/jabref/specialfields/SpecialField.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.swing.Icon;
 
@@ -57,8 +58,8 @@ public abstract class SpecialField {
         return this.keywords;
     }
 
-    public SpecialFieldValue parse(String s) {
-        return map.get(s);
+    public Optional<SpecialFieldValue> parse(String s) {
+        return Optional.ofNullable(map.get(s));
     }
 
     public abstract String getFieldName();


### PR DESCRIPTION
Thanks to @Siedlerchr reminding me about the brilliance of Optional, I decided to try and convert some BibEntry.getField to BibEntry.getFieldOptional in a "proper" way. I managed in a few positions, but more importantly i reinstalled Find bugs as a consequence of this. 

I found a few quite bad bugs, such as NPEs when clicking "Browse" in the journal management dialog with an empty text field. Also, there where some other example of introducing requireNonNull without really checking that all existing calling functions did call without a null hard coded...

@Siedlerchr as I know that you are a big fan of Path, Find bugs complains that some method there is quite likely to return null (I think getPath()), so stacking a number of method calls is claimed to be risky.

Still a few to be fixed (appending a database with explicit groups will most likely not work at the moment), but I leave that to the persons introducing them.

- [x] Manually tested changed features in running JabRef

