### PR TITLE
Updated Errorprone to 2.0.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,12 +21,6 @@ plugins {
     id 'me.champeau.gradle.jmh' version '0.3.0'
 }
 
-configurations.errorprone {
-    // 2.0.10 does not work on Windows while 2.0.9 does
-    // See https://github.com/google/error-prone/issues/432
-    resolutionStrategy.force 'com.google.errorprone:error_prone_core:2.0.9'
-}
-
 apply plugin: "java"
 apply plugin: "application"
 apply plugin: "project-report"

--- a/src/test/java/net/sf/jabref/importer/CustomImporterTest.java
+++ b/src/test/java/net/sf/jabref/importer/CustomImporterTest.java
@@ -97,7 +97,7 @@ public class CustomImporterTest {
 
     @Test
     public void testCompareToEven() {
-        assertEquals(0, importer.compareTo(importer));
+        assertEquals(0, importer.compareTo(new CustomImporter(new CopacImporter())));
     }
 
     @Test


### PR DESCRIPTION
Version 2.0.11 should have solved the issue making 2.0.10 unusable. As I did not face the problem, I have no idea if it actually is working though...

