### PR TITLE
Unified some equals

### DIFF
--- a/src/main/java/net/sf/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/net/sf/jabref/gui/openoffice/OOBibBase.java
@@ -1277,6 +1277,10 @@ class OOBibBase {
 
         @Override
         public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+
             if (o instanceof ComparableMark) {
                 ComparableMark other = (ComparableMark) o;
                 return (this.position.X == other.position.X) && (this.position.Y == other.position.Y)

--- a/src/main/java/net/sf/jabref/importer/ImportFileFilter.java
+++ b/src/main/java/net/sf/jabref/importer/ImportFileFilter.java
@@ -73,6 +73,9 @@ class ImportFileFilter extends FileFilter implements Comparable<ImportFileFilter
 
     @Override
     public boolean equals(Object o) {
+        if(this == o) {
+            return true;
+        }
         if (o instanceof ImportFileFilter) {
             return name.equals(((ImportFileFilter) o).name);
         }

--- a/src/main/java/net/sf/jabref/importer/fileformat/ImportFormat.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/ImportFormat.java
@@ -164,8 +164,8 @@ public abstract class ImportFormat implements Comparable<ImportFormat> {
 
     @Override
     public boolean equals(Object obj) {
-        if(obj == null) {
-            return false;
+        if (this == obj) {
+            return true;
         }
         if(!(obj instanceof ImportFormat)) {
             return false;

--- a/src/main/java/net/sf/jabref/logic/groups/ExplicitGroup.java
+++ b/src/main/java/net/sf/jabref/logic/groups/ExplicitGroup.java
@@ -96,6 +96,9 @@ public class ExplicitGroup extends KeywordGroup {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
         if (!(o instanceof ExplicitGroup)) {
             return false;
         }

--- a/src/main/java/net/sf/jabref/logic/groups/KeywordGroup.java
+++ b/src/main/java/net/sf/jabref/logic/groups/KeywordGroup.java
@@ -188,6 +188,9 @@ public class KeywordGroup extends AbstractGroup {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
         if (!(o instanceof KeywordGroup)) {
             return false;
         }

--- a/src/main/java/net/sf/jabref/logic/groups/SearchGroup.java
+++ b/src/main/java/net/sf/jabref/logic/groups/SearchGroup.java
@@ -119,6 +119,9 @@ public class SearchGroup extends AbstractGroup {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
         if (!(o instanceof SearchGroup)) {
             return false;
         }

--- a/src/main/java/net/sf/jabref/logic/openoffice/CitationEntry.java
+++ b/src/main/java/net/sf/jabref/logic/openoffice/CitationEntry.java
@@ -70,6 +70,9 @@ public class CitationEntry implements Comparable<CitationEntry> {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
         if (o instanceof CitationEntry) {
             CitationEntry other = (CitationEntry) o;
             return this.refMarkName.equals(other.refMarkName);

--- a/src/main/java/net/sf/jabref/logic/openoffice/OOBibStyle.java
+++ b/src/main/java/net/sf/jabref/logic/openoffice/OOBibStyle.java
@@ -888,15 +888,21 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
         if (o instanceof OOBibStyle) {
-            return path.equals(((OOBibStyle) o).path);
+            OOBibStyle otherStyle = (OOBibStyle) o;
+            return Objects.equals(path, otherStyle.path) && Objects.equals(name, otherStyle.name)
+                    && Objects.equals(citProperties, otherStyle.citProperties)
+                    && Objects.equals(properties, otherStyle.properties);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(path);
+        return Objects.hash(path, name, citProperties, properties);
     }
 
     private String createAuthorList(String author, int maxAuthors, String andString,

--- a/src/main/java/net/sf/jabref/model/entry/CustomEntryType.java
+++ b/src/main/java/net/sf/jabref/model/entry/CustomEntryType.java
@@ -23,6 +23,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.google.common.base.Objects;
+
 /**
  * This class is used to represent customized entry types.
  */
@@ -78,8 +80,11 @@ public class CustomEntryType implements EntryType {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
         if (o instanceof CustomEntryType) {
-            return this.compareTo((CustomEntryType) o) == 0;
+            return Objects.equal(name, ((CustomEntryType) o).name);
         } else {
             return false;
         }

--- a/src/main/java/net/sf/jabref/model/entry/CustomEntryType.java
+++ b/src/main/java/net/sf/jabref/model/entry/CustomEntryType.java
@@ -19,11 +19,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import com.google.common.base.Objects;
 
 /**
  * This class is used to represent customized entry types.
@@ -84,7 +83,7 @@ public class CustomEntryType implements EntryType {
             return true;
         }
         if (o instanceof CustomEntryType) {
-            return Objects.equal(name, ((CustomEntryType) o).name);
+            return Objects.equals(name, ((CustomEntryType) o).name);
         } else {
             return false;
         }


### PR DESCRIPTION
I might regret this, but I tried to unify some of the equals considering the discussion in #1631. The style is not completely identical, but the ideas are there at least.

Looking at the `equals` in `ProxyPreferences` and `FieldChange` one can conclude that hopefully that code is automatically generated, although it might not be the best way to generate that code...

In some classes implementing `Formatter`, `equals` and `hashCode` are overridden by `defaultEquals` and `defaultHashCode` but in most not. Not really clear how this really should be.
