### PR TITLE
Fixed #1639

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed [#1592](https://github.com/JabRef/jabref/issues/1592): LibreOffice: wrong numbers in citation labels
 - The merge entry dialog showed wrong heading after merging from DOI
 - Fixed [#1321](https://github.com/JabRef/jabref/issues/1321): LaTeX commands in fields not displayed in the list of references
+- Fixed [#1639](https://github.com/JabRef/jabref/issues/1639): Google Scholar fetching works again.
 - Date fields in the BibLatex standard are now always formatted in the correct way, independent of the preferences
 
 ### Removed

--- a/src/main/java/net/sf/jabref/importer/fetcher/GoogleScholarFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/GoogleScholarFetcher.java
@@ -266,8 +266,11 @@ public class GoogleScholarFetcher implements PreviewEntryFetcher {
 
     private BibEntry downloadEntry(String link) throws IOException {
         try {
-            String s = new URLDownload(GoogleScholarFetcher.URL_START + link)
+            String s = new URLDownload(link).downloadToString(Globals.prefs.getDefaultEncoding());
+            // Google seems to have included the complete link from July 29, 2016. Old code kept for a while.
+            /* String s = new URLDownload(GoogleScholarFetcher.URL_START + link)
                     .downloadToString(Globals.prefs.getDefaultEncoding());
+                    */
             BibtexParser bp = new BibtexParser(new StringReader(s));
             ParserResult pr = bp.parse();
             if ((pr != null) && (pr.getDatabase() != null)) {

--- a/src/main/java/net/sf/jabref/importer/fetcher/GoogleScholarFetcher.java
+++ b/src/main/java/net/sf/jabref/importer/fetcher/GoogleScholarFetcher.java
@@ -267,10 +267,6 @@ public class GoogleScholarFetcher implements PreviewEntryFetcher {
     private BibEntry downloadEntry(String link) throws IOException {
         try {
             String s = new URLDownload(link).downloadToString(Globals.prefs.getDefaultEncoding());
-            // Google seems to have included the complete link from July 29, 2016. Old code kept for a while.
-            /* String s = new URLDownload(GoogleScholarFetcher.URL_START + link)
-                    .downloadToString(Globals.prefs.getDefaultEncoding());
-                    */
             BibtexParser bp = new BibtexParser(new StringReader(s));
             ParserResult pr = bp.parse();
             if ((pr != null) && (pr.getDatabase() != null)) {


### PR DESCRIPTION
Fixed #1639 as Google now moved the link generation to http://scholar.googleusercontent.com the full link is now provided.

- [x] Change in CHANGELOG.md described
- [x] Manually tested changed features in running JabRef

