### PR TITLE
Moved the main part of XMPUtil to jabref.XMPUtilMain and injected a b…

### DIFF
--- a/src/main/java/net/sf/jabref/XMPUtilMain.java
+++ b/src/main/java/net/sf/jabref/XMPUtilMain.java
@@ -16,6 +16,7 @@ import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.logic.bibtex.BibEntryWriter;
 import net.sf.jabref.logic.bibtex.LatexFieldFormatter;
 import net.sf.jabref.logic.bibtex.LatexFieldFormatterPreferences;
+import net.sf.jabref.logic.xmp.XMPPreferences;
 import net.sf.jabref.logic.xmp.XMPUtil;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
@@ -57,6 +58,8 @@ public class XMPUtilMain {
             Globals.prefs = JabRefPreferences.getInstance();
         }
 
+        XMPPreferences xmpPreferences = XMPPreferences.fromPreferences(Globals.prefs);
+
         switch (args.length) {
         case 0:
             usage();
@@ -65,7 +68,7 @@ public class XMPUtilMain {
 
             if (args[0].endsWith(".pdf")) {
                 // Read from pdf and write as BibTex
-                List<BibEntry> l = XMPUtil.readXMP(new File(args[0]), Globals.prefs);
+                List<BibEntry> l = XMPUtil.readXMP(new File(args[0]), xmpPreferences);
 
                 BibEntryWriter bibtexEntryWriter = new BibEntryWriter(
                         new LatexFieldFormatter(LatexFieldFormatterPreferences.fromPreferences(Globals.prefs)), false);
@@ -85,7 +88,7 @@ public class XMPUtilMain {
                     if (entries.isEmpty()) {
                         System.err.println("Could not find BibEntry in " + args[0]);
                     } else {
-                        System.out.println(XMPUtil.toXMP(entries, result.getDatabase()));
+                        System.out.println(XMPUtil.toXMP(entries, result.getDatabase(), xmpPreferences));
                     }
                 }
             } else {
@@ -113,7 +116,7 @@ public class XMPUtilMain {
                 if (entries.isEmpty()) {
                     System.err.println("Could not find BibEntry in " + args[0]);
                 } else {
-                    XMPUtil.writeXMP(new File(args[1]), entries, result.getDatabase(), false, Globals.prefs);
+                    XMPUtil.writeXMP(new File(args[1]), entries, result.getDatabase(), false, xmpPreferences);
                     System.out.println("XMP written.");
                 }
                 break;
@@ -132,7 +135,7 @@ public class XMPUtilMain {
             Optional<BibEntry> bibEntry = result.getDatabase().getEntryByKey(args[0]);
 
             if (bibEntry.isPresent()) {
-                XMPUtil.writeXMP(new File(args[2]), bibEntry.get(), result.getDatabase(), Globals.prefs);
+                XMPUtil.writeXMP(new File(args[2]), bibEntry.get(), result.getDatabase(), xmpPreferences);
 
                 System.out.println("XMP written.");
             } else {

--- a/src/main/java/net/sf/jabref/XMPUtilMain.java
+++ b/src/main/java/net/sf/jabref/XMPUtilMain.java
@@ -1,0 +1,171 @@
+package net.sf.jabref;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import javax.xml.transform.TransformerException;
+
+import net.sf.jabref.importer.ParserResult;
+import net.sf.jabref.importer.fileformat.BibtexParser;
+import net.sf.jabref.logic.bibtex.BibEntryWriter;
+import net.sf.jabref.logic.bibtex.LatexFieldFormatter;
+import net.sf.jabref.logic.bibtex.LatexFieldFormatterPreferences;
+import net.sf.jabref.logic.xmp.XMPUtil;
+import net.sf.jabref.model.database.BibDatabaseMode;
+import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
+
+import org.apache.jempbox.impl.XMLUtil;
+import org.apache.jempbox.xmp.XMPMetadata;
+
+public class XMPUtilMain {
+
+    /**
+     * Command-line tool for working with XMP-data.
+     *
+     * Read or write XMP-metadata from or to pdf file.
+     *
+     * Usage:
+     * <dl>
+     * <dd>Read from PDF and print as bibtex:</dd>
+     * <dt>xmpUtil PDF</dt>
+     * <dd>Read from PDF and print raw XMP:</dd>
+     * <dt>xmpUtil -x PDF</dt>
+     * <dd>Write the entry in BIB given by KEY to the PDF:</dd>
+     * <dt>xmpUtil KEY BIB PDF</dt>
+     * <dd>Write all entries in BIB to the PDF:</dd>
+     * <dt>xmpUtil BIB PDF</dt>
+     * </dl>
+     *
+     * @param args
+     *            Command line strings passed to utility.
+     * @throws IOException
+     *             If any of the given files could not be read or written.
+     * @throws TransformerException
+     *             If the given BibEntry is malformed.
+     */
+    public static void main(String[] args) throws IOException, TransformerException {
+
+        // Don't forget to initialize the preferences
+        if (Globals.prefs == null) {
+            Globals.prefs = JabRefPreferences.getInstance();
+        }
+
+        switch (args.length) {
+        case 0:
+            usage();
+            break;
+        case 1:
+
+            if (args[0].endsWith(".pdf")) {
+                // Read from pdf and write as BibTex
+                List<BibEntry> l = XMPUtil.readXMP(new File(args[0]), Globals.prefs);
+
+                BibEntryWriter bibtexEntryWriter = new BibEntryWriter(
+                        new LatexFieldFormatter(LatexFieldFormatterPreferences.fromPreferences(Globals.prefs)), false);
+
+                for (BibEntry entry : l) {
+                    StringWriter sw = new StringWriter();
+                    bibtexEntryWriter.write(entry, sw, BibDatabaseMode.BIBTEX);
+                    System.out.println(sw.getBuffer());
+                }
+
+            } else if (args[0].endsWith(".bib")) {
+                // Read from BIB and write as XMP
+                try (FileReader fr = new FileReader(args[0])) {
+                    ParserResult result = BibtexParser.parse(fr);
+                    Collection<BibEntry> entries = result.getDatabase().getEntries();
+
+                    if (entries.isEmpty()) {
+                        System.err.println("Could not find BibEntry in " + args[0]);
+                    } else {
+                        System.out.println(XMPUtil.toXMP(entries, result.getDatabase()));
+                    }
+                }
+            } else {
+                usage();
+            }
+            break;
+        case 2:
+            if ("-x".equals(args[0]) && args[1].endsWith(".pdf")) {
+                // Read from pdf and write as BibTex
+                Optional<XMPMetadata> meta = XMPUtil.readRawXMP(new File(args[1]));
+
+                if (meta.isPresent()) {
+                    XMLUtil.save(meta.get().getXMPDocument(), System.out, StandardCharsets.UTF_8.name());
+                } else {
+                    System.err.println("The given pdf does not contain any XMP-metadata.");
+                }
+                break;
+            }
+
+            if (args[0].endsWith(".bib") && args[1].endsWith(".pdf")) {
+                ParserResult result = BibtexParser.parse(new FileReader(args[0]));
+
+                Collection<BibEntry> entries = result.getDatabase().getEntries();
+
+                if (entries.isEmpty()) {
+                    System.err.println("Could not find BibEntry in " + args[0]);
+                } else {
+                    XMPUtil.writeXMP(new File(args[1]), entries, result.getDatabase(), false, Globals.prefs);
+                    System.out.println("XMP written.");
+                }
+                break;
+            }
+
+            usage();
+            break;
+        case 3:
+            if (!args[1].endsWith(".bib") && !args[2].endsWith(".pdf")) {
+                usage();
+                break;
+            }
+
+            ParserResult result = BibtexParser.parse(new FileReader(args[1]));
+
+            Optional<BibEntry> bibEntry = result.getDatabase().getEntryByKey(args[0]);
+
+            if (bibEntry.isPresent()) {
+                XMPUtil.writeXMP(new File(args[2]), bibEntry.get(), result.getDatabase(), Globals.prefs);
+
+                System.out.println("XMP written.");
+            } else {
+                System.err.println("Could not find BibEntry " + args[0] + " in " + args[0]);
+            }
+            break;
+
+        default:
+            usage();
+        }
+    }
+
+    /**
+     * Print usage information for the command line tool xmpUtil.
+     *
+     * @see XMPUtil#main(String[])
+     */
+    private static void usage() {
+        System.out.println("Read or write XMP-metadata from or to pdf file.");
+        System.out.println("");
+        System.out.println("Usage:");
+        System.out.println("Read from PDF and print as bibtex:");
+        System.out.println("  xmpUtil <pdf>");
+        System.out.println("Read from PDF and print raw XMP:");
+        System.out.println("  xmpUtil -x <pdf>");
+        System.out
+        .println("Write the entry in <bib> given by <key> to the PDF:");
+        System.out.println("  xmpUtil <key> <bib> <pdf>");
+        System.out.println("Write all entries in <bib> to the PDF:");
+        System.out.println("  xmpUtil <bib> <pdf>");
+        System.out.println("");
+        System.out
+        .println("To report bugs visit http://jabref.sourceforge.net");
+    }
+
+}

--- a/src/main/java/net/sf/jabref/cli/XMPUtilMain.java
+++ b/src/main/java/net/sf/jabref/cli/XMPUtilMain.java
@@ -1,4 +1,4 @@
-package net.sf.jabref;
+package net.sf.jabref.cli;
 
 import java.io.File;
 import java.io.FileReader;
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 import javax.xml.transform.TransformerException;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.logic.bibtex.BibEntryWriter;

--- a/src/main/java/net/sf/jabref/external/DroppedFileHandler.java
+++ b/src/main/java/net/sf/jabref/external/DroppedFileHandler.java
@@ -42,6 +42,7 @@ import net.sf.jabref.gui.undo.UndoableInsertEntry;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.xmp.XMPPreferences;
 import net.sf.jabref.logic.xmp.XMPUtil;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
@@ -235,7 +236,7 @@ public class DroppedFileHandler {
 
         List<BibEntry> xmpEntriesInFile;
         try {
-            xmpEntriesInFile = XMPUtil.readXMP(fileName, Globals.prefs);
+            xmpEntriesInFile = XMPUtil.readXMP(fileName, XMPPreferences.fromPreferences(Globals.prefs));
         } catch (IOException e) {
             LOGGER.warn("Problem reading XMP", e);
             return false;

--- a/src/main/java/net/sf/jabref/external/WriteXMPAction.java
+++ b/src/main/java/net/sf/jabref/external/WriteXMPAction.java
@@ -159,7 +159,7 @@ public class WriteXMPAction extends AbstractWorker {
                 for (File file : files) {
                     if (file.exists()) {
                         try {
-                            XMPUtil.writeXMP(file, entry, database);
+                            XMPUtil.writeXMP(file, entry, database, Globals.prefs);
                             optDiag.getProgressArea().append("  " + Localization.lang("OK") + ".\n");
                             entriesChanged++;
                         } catch (Exception e) {

--- a/src/main/java/net/sf/jabref/external/WriteXMPAction.java
+++ b/src/main/java/net/sf/jabref/external/WriteXMPAction.java
@@ -46,6 +46,7 @@ import net.sf.jabref.gui.util.FocusRequester;
 import net.sf.jabref.gui.worker.AbstractWorker;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.xmp.XMPPreferences;
 import net.sf.jabref.logic.xmp.XMPUtil;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
@@ -159,7 +160,7 @@ public class WriteXMPAction extends AbstractWorker {
                 for (File file : files) {
                     if (file.exists()) {
                         try {
-                            XMPUtil.writeXMP(file, entry, database, Globals.prefs);
+                            XMPUtil.writeXMP(file, entry, database, XMPPreferences.fromPreferences(Globals.prefs));
                             optDiag.getProgressArea().append("  " + Localization.lang("OK") + ".\n");
                             entriesChanged++;
                         } catch (Exception e) {

--- a/src/main/java/net/sf/jabref/external/WriteXMPEntryEditorAction.java
+++ b/src/main/java/net/sf/jabref/external/WriteXMPEntryEditorAction.java
@@ -25,6 +25,7 @@ import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.xml.transform.TransformerException;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.FileListEntry;
 import net.sf.jabref.gui.FileListTableModel;
@@ -126,7 +127,7 @@ public class WriteXMPEntryEditorAction extends AbstractAction {
 
                     } else {
                         try {
-                            XMPUtil.writeXMP(file, entry, panel.getDatabase());
+                            XMPUtil.writeXMP(file, entry, panel.getDatabase(), Globals.prefs);
                             if (files.size() == 1) {
                                 message = Localization.lang("Wrote XMP-metadata");
                             }

--- a/src/main/java/net/sf/jabref/external/WriteXMPEntryEditorAction.java
+++ b/src/main/java/net/sf/jabref/external/WriteXMPEntryEditorAction.java
@@ -34,6 +34,7 @@ import net.sf.jabref.gui.entryeditor.EntryEditor;
 import net.sf.jabref.gui.worker.AbstractWorker;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.xmp.XMPPreferences;
 import net.sf.jabref.logic.xmp.XMPUtil;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
@@ -127,7 +128,8 @@ public class WriteXMPEntryEditorAction extends AbstractAction {
 
                     } else {
                         try {
-                            XMPUtil.writeXMP(file, entry, panel.getDatabase(), Globals.prefs);
+                            XMPUtil.writeXMP(file, entry, panel.getDatabase(),
+                                    XMPPreferences.fromPreferences(Globals.prefs));
                             if (files.size() == 1) {
                                 message = Localization.lang("Wrote XMP-metadata");
                             }

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -440,7 +440,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
         leftPan.add(closeBut, BorderLayout.NORTH);
 
         // Create type-label
-        TypedBibEntry typedEntry = new TypedBibEntry(entry, Optional.empty(), panel.getBibDatabaseContext().getMode());
+        TypedBibEntry typedEntry = new TypedBibEntry(entry, panel.getBibDatabaseContext().getMode());
         leftPan.add(new TypeLabel(typedEntry.getTypeForDisplay()), BorderLayout.CENTER);
         TypeButton typeButton = new TypeButton();
 

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
@@ -510,7 +510,7 @@ public class MainTable extends JTable {
     private boolean isComplete(int row) {
         try {
             BibEntry entry = getBibEntry(row);
-            TypedBibEntry typedEntry = new TypedBibEntry(entry, Optional.of(panel.getDatabase()), panel.getBibDatabaseContext().getMode());
+            TypedBibEntry typedEntry = new TypedBibEntry(entry, panel.getBibDatabaseContext());
             return typedEntry.hasAllRequiredFields();
         } catch (NullPointerException ex) {
             return true;

--- a/src/main/java/net/sf/jabref/gui/util/comparator/FirstColumnComparator.java
+++ b/src/main/java/net/sf/jabref/gui/util/comparator/FirstColumnComparator.java
@@ -16,7 +16,6 @@
 package net.sf.jabref.gui.util.comparator;
 
 import java.util.Comparator;
-import java.util.Optional;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.logic.TypedBibEntry;
@@ -35,8 +34,8 @@ public class FirstColumnComparator implements Comparator<BibEntry> {
         int score1 = 0;
         int score2 = 0;
 
-        TypedBibEntry typedEntry1 = new TypedBibEntry(e1, Optional.of(database.getDatabase()), database.getMode());
-        TypedBibEntry typedEntry2 = new TypedBibEntry(e2, Optional.of(database.getDatabase()), database.getMode());
+        TypedBibEntry typedEntry1 = new TypedBibEntry(e1, database);
+        TypedBibEntry typedEntry2 = new TypedBibEntry(e2, database);
         if (typedEntry1.hasAllRequiredFields()) {
             score1++;
         }

--- a/src/main/java/net/sf/jabref/importer/EntryFromPDFCreator.java
+++ b/src/main/java/net/sf/jabref/importer/EntryFromPDFCreator.java
@@ -13,6 +13,7 @@ import net.sf.jabref.JabRefGUI;
 import net.sf.jabref.external.ExternalFileType;
 import net.sf.jabref.external.ExternalFileTypes;
 import net.sf.jabref.gui.IconTheme;
+import net.sf.jabref.logic.xmp.XMPPreferences;
 import net.sf.jabref.logic.xmp.XMPUtil;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.pdfimport.PdfImporter;
@@ -122,7 +123,8 @@ public class EntryFromPDFCreator extends EntryFromFileCreator {
      */
     private void addEntryDataFromXMP(File aFile, BibEntry entry) {
         try {
-            List<BibEntry> entrys = XMPUtil.readXMP(aFile.getAbsoluteFile(), Globals.prefs);
+            List<BibEntry> entrys = XMPUtil.readXMP(aFile.getAbsoluteFile(),
+                    XMPPreferences.fromPreferences(Globals.prefs));
             addEntrysToEntry(entry, entrys);
         } catch (IOException e) {
             // no canceling here, just no data added.

--- a/src/main/java/net/sf/jabref/importer/fileformat/PdfXmpImporter.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/PdfXmpImporter.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import net.sf.jabref.Globals;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.xmp.XMPPreferences;
 import net.sf.jabref.logic.xmp.XMPUtil;
 
 /**
@@ -55,7 +56,7 @@ public class PdfXmpImporter extends ImportFormat {
     public ParserResult importDatabase(Path filePath, Charset defaultEncoding) {
         Objects.requireNonNull(filePath);
         try {
-            return new ParserResult(XMPUtil.readXMP(filePath, Globals.prefs));
+            return new ParserResult(XMPUtil.readXMP(filePath, XMPPreferences.fromPreferences(Globals.prefs)));
         } catch (IOException exception) {
             return ParserResult.fromErrorMessage(exception.getLocalizedMessage());
         }
@@ -76,7 +77,7 @@ public class PdfXmpImporter extends ImportFormat {
     @Override
     public boolean isRecognizedFormat(Path filePath, Charset defaultEncoding) throws IOException {
         Objects.requireNonNull(filePath);
-        return XMPUtil.hasMetadata(filePath, Globals.prefs);
+        return XMPUtil.hasMetadata(filePath, XMPPreferences.fromPreferences(Globals.prefs));
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/logic/TypedBibEntry.java
+++ b/src/main/java/net/sf/jabref/logic/TypedBibEntry.java
@@ -42,18 +42,14 @@ public class TypedBibEntry {
         this(entry, Optional.empty(), mode);
     }
 
-    public TypedBibEntry(BibEntry entry, Optional<BibDatabase> database, BibDatabaseMode mode) {
+    private TypedBibEntry(BibEntry entry, Optional<BibDatabase> database, BibDatabaseMode mode) {
         this.entry = Objects.requireNonNull(entry);
         this.database = Objects.requireNonNull(database);
         this.mode = mode;
     }
 
     public TypedBibEntry(BibEntry entry, BibDatabaseContext databaseContext) {
-        this(entry, databaseContext.getDatabase(), databaseContext.getMode());
-    }
-
-    public TypedBibEntry(BibEntry entry, BibDatabase database, BibDatabaseMode mode) {
-        this(entry, Optional.of(database), mode);
+        this(entry, Optional.of(databaseContext.getDatabase()), databaseContext.getMode());
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/bibtex/BibEntryWriter.java
+++ b/src/main/java/net/sf/jabref/logic/bibtex/BibEntryWriter.java
@@ -83,7 +83,7 @@ public class BibEntryWriter {
     private void writeRequiredFieldsFirstRemainingFieldsSecond(BibEntry entry, Writer out,
                                                                BibDatabaseMode bibDatabaseMode) throws IOException {
         // Write header with type and bibtex-key.
-        TypedBibEntry typedEntry = new TypedBibEntry(entry, Optional.empty(), bibDatabaseMode);
+        TypedBibEntry typedEntry = new TypedBibEntry(entry, bibDatabaseMode);
         out.write('@' + typedEntry.getTypeForDisplay() + '{');
 
         writeKeyField(entry, out);

--- a/src/main/java/net/sf/jabref/logic/xmp/XMPPreferences.java
+++ b/src/main/java/net/sf/jabref/logic/xmp/XMPPreferences.java
@@ -1,0 +1,37 @@
+package net.sf.jabref.logic.xmp;
+
+import java.util.List;
+
+import net.sf.jabref.preferences.JabRefPreferences;
+
+public class XMPPreferences {
+
+    private final boolean useXMPPrivacyFilter;
+    private final List<String> xmpPrivacyFilter;
+    private final String keywordSeparator;
+
+
+    public XMPPreferences(boolean useXMPPrivacyFilter, List<String> xmpPrivacyFilter, String keywordSeparator) {
+        this.useXMPPrivacyFilter = useXMPPrivacyFilter;
+        this.xmpPrivacyFilter = xmpPrivacyFilter;
+        this.keywordSeparator = keywordSeparator;
+    }
+
+    public static XMPPreferences fromPreferences(JabRefPreferences jabrefPreferences) {
+        return new XMPPreferences(jabrefPreferences.getBoolean(JabRefPreferences.USE_XMP_PRIVACY_FILTER),
+                jabrefPreferences.getStringList(JabRefPreferences.XMP_PRIVACY_FILTERS),
+                jabrefPreferences.get(JabRefPreferences.KEYWORD_SEPARATOR));
+    }
+
+    public boolean isUseXMPPrivacyFilter() {
+        return useXMPPrivacyFilter;
+    }
+
+    public List<String> getXmpPrivacyFilter() {
+        return xmpPrivacyFilter;
+    }
+
+    public String getKeywordSeparator() {
+        return keywordSeparator;
+    }
+}

--- a/src/main/java/net/sf/jabref/logic/xmp/XMPSchemaBibtex.java
+++ b/src/main/java/net/sf/jabref/logic/xmp/XMPSchemaBibtex.java
@@ -32,7 +32,6 @@ import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.model.entry.FieldProperties;
 import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.model.entry.InternalBibtexFields;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.jempbox.xmp.XMPMetadata;
 import org.apache.jempbox.xmp.XMPSchema;
@@ -276,8 +275,8 @@ public class XMPSchemaBibtex extends XMPSchema {
 
 
 
-    public void setBibtexEntry(BibEntry entry) {
-        setBibtexEntry(entry, null);
+    public void setBibtexEntry(BibEntry entry, XMPPreferences xmpPreferences) {
+        setBibtexEntry(entry, null, xmpPreferences);
     }
 
     /**
@@ -285,13 +284,12 @@ public class XMPSchemaBibtex extends XMPSchema {
      * @param entry
      * @param database maybenull
      */
-    public void setBibtexEntry(BibEntry entry, BibDatabase database) {
+    public void setBibtexEntry(BibEntry entry, BibDatabase database, XMPPreferences xmpPreferences) {
         // Set all the values including key and entryType
         Set<String> fields = entry.getFieldNames();
 
-        JabRefPreferences prefs = JabRefPreferences.getInstance();
-        if (prefs.getBoolean(JabRefPreferences.USE_XMP_PRIVACY_FILTER)) {
-            Set<String> filters = new TreeSet<>(prefs.getStringList(JabRefPreferences.XMP_PRIVACY_FILTERS));
+        if (xmpPreferences.isUseXMPPrivacyFilter()) {
+            Set<String> filters = new TreeSet<>(xmpPreferences.getXmpPrivacyFilter());
             fields.removeAll(filters);
         }
 

--- a/src/main/java/net/sf/jabref/logic/xmp/XMPUtil.java
+++ b/src/main/java/net/sf/jabref/logic/xmp/XMPUtil.java
@@ -868,7 +868,7 @@ public class XMPUtil {
          *
          * Bibtex-Fields used: title
          */
-        TypedBibEntry typedEntry = new TypedBibEntry(entry, Optional.empty(), BibDatabaseMode.BIBTEX);
+        TypedBibEntry typedEntry = new TypedBibEntry(entry, BibDatabaseMode.BIBTEX);
         String o = typedEntry.getTypeForDisplay();
         if (!o.isEmpty()) {
             dcSchema.addType(o);

--- a/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
+++ b/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
@@ -45,6 +45,7 @@ import net.sf.jabref.logic.labelpattern.LabelPatternPreferences;
 import net.sf.jabref.logic.labelpattern.LabelPatternUtil;
 import net.sf.jabref.logic.util.UpdateField;
 import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.logic.xmp.XMPPreferences;
 import net.sf.jabref.logic.xmp.XMPUtil;
 import net.sf.jabref.model.database.KeyCollisionException;
 import net.sf.jabref.model.entry.BibEntry;
@@ -151,7 +152,7 @@ public class PdfImporter {
         for (String fileName : fileNames) {
             if (!neverShow && !doNotShowAgain) {
                 importDialog = new ImportDialog(dropRow >= 0, fileName);
-                if (!XMPUtil.hasMetadata(Paths.get(fileName), Globals.prefs)) {
+                if (!XMPUtil.hasMetadata(Paths.get(fileName), XMPPreferences.fromPreferences(Globals.prefs))) {
                     importDialog.disableXMPChoice();
                 }
                 importDialog.setLocationRelativeTo(frame);

--- a/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
@@ -27,6 +27,7 @@ import java.util.TimeZone;
 import javax.xml.transform.TransformerException;
 
 import net.sf.jabref.Globals;
+import net.sf.jabref.XMPUtilMain;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.logic.bibtex.BibEntryWriter;
@@ -320,7 +321,7 @@ public class XMPUtilTest {
             prefs.putBoolean("useXmpPrivacyFilter", true);
             prefs.putStringList(JabRefPreferences.XMP_PRIVACY_FILTERS, Arrays.asList("author", "title", "note"));
 
-            XMPUtil.writeXMP(pdfFile, e, null);
+            XMPUtil.writeXMP(pdfFile, e, null, Globals.prefs);
 
             List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
             Assert.assertEquals(1, l.size());
@@ -338,7 +339,7 @@ public class XMPUtilTest {
 
         BibEntry e = t1BibtexEntry();
 
-        XMPUtil.writeXMP(pdfFile, e, null);
+        XMPUtil.writeXMP(pdfFile, e, null, Globals.prefs);
 
         List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
         Assert.assertEquals(1, l.size());
@@ -465,7 +466,7 @@ public class XMPUtilTest {
 
         BibEntry e = c.iterator().next();
 
-        XMPUtil.writeXMP(pdfFile, e, null);
+        XMPUtil.writeXMP(pdfFile, e, null, Globals.prefs);
 
         List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
         Assert.assertEquals(1, l.size());
@@ -575,7 +576,7 @@ public class XMPUtilTest {
 
         {
             // Now write new packet and check if it was correctly written
-            XMPUtil.writeXMP(pdfFile, t1BibtexEntry(), null);
+            XMPUtil.writeXMP(pdfFile, t1BibtexEntry(), null, Globals.prefs);
 
             List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
             Assert.assertEquals(1, l.size());
@@ -651,7 +652,7 @@ public class XMPUtilTest {
         BibEntry toSet = t1BibtexEntry();
         toSet.setField("author", "Pokemon!");
 
-        XMPUtil.writeXMP(pdfFile, toSet, null);
+        XMPUtil.writeXMP(pdfFile, toSet, null, Globals.prefs);
 
         List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
         Assert.assertEquals(1, l.size());
@@ -742,7 +743,7 @@ public class XMPUtilTest {
 
         BibEntry e = c.iterator().next();
 
-        XMPUtil.writeXMP(pdfFile, e, null);
+        XMPUtil.writeXMP(pdfFile, e, null, Globals.prefs);
 
         List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
         Assert.assertEquals(1, l.size());
@@ -868,7 +869,7 @@ public class XMPUtilTest {
         l.add(t2BibtexEntry());
         l.add(t3BibtexEntry());
 
-        XMPUtil.writeXMP(pdfFile, l, null, false);
+        XMPUtil.writeXMP(pdfFile, l, null, false, Globals.prefs);
 
         l = XMPUtil.readXMP(pdfFile, Globals.prefs);
 
@@ -919,7 +920,7 @@ public class XMPUtilTest {
         List<BibEntry> l = new LinkedList<>();
         l.add(t3BibtexEntry());
 
-        XMPUtil.writeXMP(pdfFile, l, null, true);
+        XMPUtil.writeXMP(pdfFile, l, null, true, Globals.prefs);
 
         try (PDDocument document = PDDocument.load(pdfFile.getAbsoluteFile())) {
             if (document.isEncrypted()) {
@@ -985,7 +986,7 @@ public class XMPUtilTest {
         List<BibEntry> l = new LinkedList<>();
         l.add(t3BibtexEntry());
 
-        XMPUtil.writeXMP(pdfFile, l, null, true);
+        XMPUtil.writeXMP(pdfFile, l, null, true, Globals.prefs);
 
         try (PDDocument document = PDDocument.load(pdfFile.getAbsoluteFile())) {
             if (document.isEncrypted()) {
@@ -1060,7 +1061,7 @@ public class XMPUtilTest {
 
         BibEntry e = c.iterator().next();
 
-        XMPUtil.writeXMP(pdfFile, e, null);
+        XMPUtil.writeXMP(pdfFile, e, null, Globals.prefs);
 
         Optional<XMPMetadata> metadata = XMPUtil.readRawXMP(pdfFile);
 
@@ -1110,7 +1111,7 @@ public class XMPUtilTest {
             try (ByteArrayOutputStream s = new ByteArrayOutputStream()) {
                 PrintStream oldOut = System.out;
                 System.setOut(new PrintStream(s));
-                XMPUtil.main(new String[] {tempBib.getAbsolutePath()});
+                XMPUtilMain.main(new String[] {tempBib.getAbsolutePath()});
                 System.setOut(oldOut);
                 String xmp = s.toString();
 
@@ -1140,12 +1141,12 @@ public class XMPUtilTest {
 
             BibEntry e = t1BibtexEntry();
 
-            XMPUtil.writeXMP(pdfFile, e, null);
+            XMPUtil.writeXMP(pdfFile, e, null, Globals.prefs);
 
             try (ByteArrayOutputStream s = new ByteArrayOutputStream()) {
                 PrintStream oldOut = System.out;
                 System.setOut(new PrintStream(s));
-                XMPUtil.main(new String[] {pdfFile.getAbsolutePath()});
+                XMPUtilMain.main(new String[] {pdfFile.getAbsolutePath()});
                 System.setOut(oldOut);
                 String bibtex = s.toString();
 
@@ -1160,12 +1161,12 @@ public class XMPUtilTest {
         // Write XMP to file
         BibEntry e = t1BibtexEntry();
 
-        XMPUtil.writeXMP(pdfFile, e, null);
+        XMPUtil.writeXMP(pdfFile, e, null, Globals.prefs);
 
         try (ByteArrayOutputStream s = new ByteArrayOutputStream()) {
             PrintStream oldOut = System.out;
             System.setOut(new PrintStream(s));
-            XMPUtil.main(new String[] {"-x", pdfFile.getAbsolutePath()});
+            XMPUtilMain.main(new String[] {"-x", pdfFile.getAbsolutePath()});
             System.setOut(oldOut);
             s.close();
             String xmp = s.toString();
@@ -1211,7 +1212,7 @@ public class XMPUtilTest {
                 PrintStream oldOut = System.out;
                 try (ByteArrayOutputStream s = new ByteArrayOutputStream()) {
                     System.setOut(new PrintStream(s));
-                    XMPUtil.main(new String[] {"canh05", tempBib.getAbsolutePath(), pdfFile.getAbsolutePath()});
+                    XMPUtilMain.main(new String[] {"canh05", tempBib.getAbsolutePath(), pdfFile.getAbsolutePath()});
                 } finally {
                     System.setOut(oldOut);
                 }
@@ -1226,7 +1227,7 @@ public class XMPUtilTest {
                 PrintStream oldOut = System.out;
                 System.setOut(new PrintStream(s));
                 try {
-                    XMPUtil.main(new String[] {"OezbekC06", tempBib.getAbsolutePath(), pdfFile.getAbsolutePath()});
+                    XMPUtilMain.main(new String[] {"OezbekC06", tempBib.getAbsolutePath(), pdfFile.getAbsolutePath()});
                 } finally {
                     System.setOut(oldOut);
                 }
@@ -1263,7 +1264,7 @@ public class XMPUtilTest {
             try (ByteArrayOutputStream s = new ByteArrayOutputStream()) {
                 PrintStream oldOut = System.out;
                 System.setOut(new PrintStream(s));
-                XMPUtil.main(new String[] {tempBib.getAbsolutePath(), pdfFile.getAbsolutePath()});
+                XMPUtilMain.main(new String[] {tempBib.getAbsolutePath(), pdfFile.getAbsolutePath()});
                 System.setOut(oldOut);
             }
             List<BibEntry> l = XMPUtil.readXMP(pdfFile, Globals.prefs);
@@ -1318,7 +1319,7 @@ public class XMPUtilTest {
 
         BibEntry e = c.iterator().next();
 
-        XMPUtil.writeXMP(pdfFile, e, original.getDatabase());
+        XMPUtil.writeXMP(pdfFile, e, original.getDatabase(), Globals.prefs);
 
         List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
         Assert.assertEquals(1, l.size());
@@ -1337,7 +1338,7 @@ public class XMPUtilTest {
 
     @Test(expected = EncryptedPdfsNotSupportedException.class)
     public void expectedEncryptionNotSupportedExceptionAtWrite() throws IOException, TransformerException {
-        XMPUtil.writeXMP("src/test/resources/pdfs/encrypted.pdf", t1BibtexEntry(), null);
+        XMPUtil.writeXMP("src/test/resources/pdfs/encrypted.pdf", t1BibtexEntry(), null, Globals.prefs);
     }
 
     /**
@@ -1362,7 +1363,7 @@ public class XMPUtilTest {
 
             try {
                 XMPUtil.writeXMP(pdfFile, result.getDatabase().getEntryByKey("Patterson06").get(),
-                        result.getDatabase());
+                        result.getDatabase(), Globals.prefs);
 
                 // Test whether we the main function can load the bibtex correctly
                 BibEntry b = XMPUtil.readXMP(pdfFile, Globals.prefs).get(0);

--- a/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
@@ -74,6 +74,8 @@ public class XMPUtilTest {
 
     private List<String> privacyFilters;
 
+    private XMPPreferences xmpPreferences;
+
 
     /**
      * Wrap bibtex-data (<bibtex:author>...) into an rdf:Description.
@@ -240,6 +242,8 @@ public class XMPUtilTest {
             Globals.prefs = JabRefPreferences.getInstance();
         }
 
+        xmpPreferences = XMPPreferences.fromPreferences(Globals.prefs);
+
         // Store Privacy Settings
         prefs = JabRefPreferences.getInstance();
 
@@ -270,7 +274,7 @@ public class XMPUtilTest {
 
         writeManually(pdfFile, XMPUtilTest.bibtexXPacket(XMPUtilTest.bibtexDescription(bibtex)));
 
-        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
+        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), xmpPreferences);
         Assert.assertEquals(1, l.size());
         BibEntry e = l.get(0);
 
@@ -295,7 +299,7 @@ public class XMPUtilTest {
 
         writeManually(pdfFile, XMPUtilTest.bibtexXPacket(XMPUtilTest.bibtexDescription(bibtex)));
 
-        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
+        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), xmpPreferences);
         Assert.assertEquals(1, l.size());
         BibEntry e = l.get(0);
 
@@ -321,9 +325,9 @@ public class XMPUtilTest {
             prefs.putBoolean("useXmpPrivacyFilter", true);
             prefs.putStringList(JabRefPreferences.XMP_PRIVACY_FILTERS, Arrays.asList("author", "title", "note"));
 
-            XMPUtil.writeXMP(pdfFile, e, null, Globals.prefs);
+            XMPUtil.writeXMP(pdfFile, e, null, XMPPreferences.fromPreferences(prefs));
 
-            List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
+            List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), XMPPreferences.fromPreferences(prefs));
             Assert.assertEquals(1, l.size());
             BibEntry x = l.get(0);
 
@@ -339,9 +343,9 @@ public class XMPUtilTest {
 
         BibEntry e = t1BibtexEntry();
 
-        XMPUtil.writeXMP(pdfFile, e, null, Globals.prefs);
+        XMPUtil.writeXMP(pdfFile, e, null, XMPPreferences.fromPreferences(prefs));
 
-        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
+        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), XMPPreferences.fromPreferences(prefs));
         Assert.assertEquals(1, l.size());
         BibEntry x = l.get(0);
         Set<String> ts = x.getFieldNames();
@@ -369,7 +373,7 @@ public class XMPUtilTest {
 
         writeManually(pdfFile, XMPUtilTest.bibtexXPacket(XMPUtilTest.bibtexDescription(bibtex)));
 
-        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
+        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), xmpPreferences);
         Assert.assertEquals(1, l.size());
         BibEntry e = l.get(0);
 
@@ -393,7 +397,7 @@ public class XMPUtilTest {
 
         writeManually(pdfFile, XMPUtilTest.bibtexXPacket(XMPUtilTest.bibtexDescription(bibtex)));
 
-        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
+        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), xmpPreferences);
         Assert.assertEquals(1, l.size());
         BibEntry e = l.get(0);
 
@@ -466,9 +470,9 @@ public class XMPUtilTest {
 
         BibEntry e = c.iterator().next();
 
-        XMPUtil.writeXMP(pdfFile, e, null, Globals.prefs);
+        XMPUtil.writeXMP(pdfFile, e, null, xmpPreferences);
 
-        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
+        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), xmpPreferences);
         Assert.assertEquals(1, l.size());
         BibEntry x = l.get(0);
 
@@ -490,7 +494,7 @@ public class XMPUtilTest {
 
         writeManually(pdfFile, XMPUtilTest.bibtexXPacket(XMPUtilTest.bibtexDescription(bibtex)));
 
-        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
+        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), xmpPreferences);
         Assert.assertEquals(1, l.size());
         BibEntry e = l.get(0);
 
@@ -514,7 +518,7 @@ public class XMPUtilTest {
 
         writeManually(pdfFile, XMPUtilTest.bibtexXPacket(bibtex));
 
-        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
+        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), xmpPreferences);
         Assert.assertEquals(1, l.size());
         BibEntry e = l.get(0);
 
@@ -524,7 +528,7 @@ public class XMPUtilTest {
     @Test
     public void testEmpty() throws Exception {
 
-        Assert.assertEquals(Collections.emptyList(), XMPUtil.readXMP(pdfFile, Globals.prefs));
+        Assert.assertEquals(Collections.emptyList(), XMPUtil.readXMP(pdfFile, xmpPreferences));
 
     }
 
@@ -552,7 +556,7 @@ public class XMPUtilTest {
         writeManually(pdfFile, XMPUtilTest.bibtexXPacket(s));
 
         // Nothing there yet, but should not crash
-        Assert.assertEquals(Collections.emptyList(), XMPUtil.readXMP(pdfFile, Globals.prefs));
+        Assert.assertEquals(Collections.emptyList(), XMPUtil.readXMP(pdfFile, xmpPreferences));
 
         s = " <rdf:Description rdf:about=''" + "  xmlns:xmp='http://ns.adobe.com/xap/1.0/'>"
                 + "  <xmp:CreatorTool>Acrobat PDFMaker 7.0.7</xmp:CreatorTool>"
@@ -572,13 +576,13 @@ public class XMPUtilTest {
 
         // Title is Questionnaire.pdf so the DublinCore fallback should hit
         // in...
-        Assert.assertEquals(1, XMPUtil.readXMP(pdfFile, Globals.prefs).size());
+        Assert.assertEquals(1, XMPUtil.readXMP(pdfFile, xmpPreferences).size());
 
         {
             // Now write new packet and check if it was correctly written
-            XMPUtil.writeXMP(pdfFile, t1BibtexEntry(), null, Globals.prefs);
+            XMPUtil.writeXMP(pdfFile, t1BibtexEntry(), null, xmpPreferences);
 
-            List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
+            List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), xmpPreferences);
             Assert.assertEquals(1, l.size());
             BibEntry e = l.get(0);
 
@@ -652,9 +656,9 @@ public class XMPUtilTest {
         BibEntry toSet = t1BibtexEntry();
         toSet.setField("author", "Pokemon!");
 
-        XMPUtil.writeXMP(pdfFile, toSet, null, Globals.prefs);
+        XMPUtil.writeXMP(pdfFile, toSet, null, xmpPreferences);
 
-        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
+        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), xmpPreferences);
         Assert.assertEquals(1, l.size());
         BibEntry e = l.get(0);
 
@@ -743,9 +747,9 @@ public class XMPUtilTest {
 
         BibEntry e = c.iterator().next();
 
-        XMPUtil.writeXMP(pdfFile, e, null, Globals.prefs);
+        XMPUtil.writeXMP(pdfFile, e, null, xmpPreferences);
 
-        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
+        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), xmpPreferences);
         Assert.assertEquals(1, l.size());
         BibEntry x = l.get(0);
 
@@ -787,7 +791,7 @@ public class XMPUtilTest {
         Collection<BibEntry> c = result.getDatabase().getEntries();
         Assert.assertEquals(2, c.size());
 
-        String xmp = XMPUtil.toXMP(c, null);
+        String xmp = XMPUtil.toXMP(c, null, xmpPreferences);
 
         /* Test minimal syntaxical completeness */
         Assert.assertTrue(xmp.indexOf("xpacket") > 0);
@@ -805,7 +809,7 @@ public class XMPUtilTest {
         /* Test contents of string */
         writeManually(pdfFile, xmp);
 
-        List<BibEntry> l = XMPUtil.readXMP(pdfFile, Globals.prefs);
+        List<BibEntry> l = XMPUtil.readXMP(pdfFile, xmpPreferences);
 
         Assert.assertEquals(2, l.size());
 
@@ -840,7 +844,7 @@ public class XMPUtilTest {
         writeManually(pdfFile, XMPUtilTest.bibtexXPacket(bibtex));
 
         // Read from file
-        List<BibEntry> l = XMPUtil.readXMP(pdfFile, Globals.prefs);
+        List<BibEntry> l = XMPUtil.readXMP(pdfFile, xmpPreferences);
 
         Assert.assertEquals(2, l.size());
 
@@ -869,9 +873,9 @@ public class XMPUtilTest {
         l.add(t2BibtexEntry());
         l.add(t3BibtexEntry());
 
-        XMPUtil.writeXMP(pdfFile, l, null, false, Globals.prefs);
+        XMPUtil.writeXMP(pdfFile, l, null, false, xmpPreferences);
 
-        l = XMPUtil.readXMP(pdfFile, Globals.prefs);
+        l = XMPUtil.readXMP(pdfFile, xmpPreferences);
 
         Assert.assertEquals(2, l.size());
 
@@ -894,7 +898,7 @@ public class XMPUtilTest {
     @Test
     public void testReadProtectedPDFHasMetaData() throws Exception {
         try (InputStream is = XMPUtilTest.class.getResourceAsStream("/pdfs/write-protected.pdf")) {
-            Assert.assertTrue(XMPUtil.hasMetadata(is, Globals.prefs));
+            Assert.assertTrue(XMPUtil.hasMetadata(is, xmpPreferences));
         }
     }
 
@@ -904,7 +908,7 @@ public class XMPUtilTest {
     @Test
     public void testReadProtectedPDFHasCorrectMetaData() throws Exception {
         try (InputStream is = XMPUtilTest.class.getResourceAsStream("/pdfs/write-protected.pdf")) {
-            List<BibEntry> readEntries = XMPUtil.readXMP(is, Globals.prefs);
+            List<BibEntry> readEntries = XMPUtil.readXMP(is, xmpPreferences);
 
             BibEntry entry = new BibEntry();
             entry.setType("misc");
@@ -920,7 +924,7 @@ public class XMPUtilTest {
         List<BibEntry> l = new LinkedList<>();
         l.add(t3BibtexEntry());
 
-        XMPUtil.writeXMP(pdfFile, l, null, true, Globals.prefs);
+        XMPUtil.writeXMP(pdfFile, l, null, true, xmpPreferences);
 
         try (PDDocument document = PDDocument.load(pdfFile.getAbsoluteFile())) {
             if (document.isEncrypted()) {
@@ -975,7 +979,7 @@ public class XMPUtilTest {
             Assert.assertEquals(4, dcSchema.getRelationships().size());
 
             assertEqualsBibtexEntry(t3BibtexEntry(),
-                    XMPUtil.getBibtexEntryFromDublinCore(dcSchema, Globals.prefs).get());
+                    XMPUtil.getBibtexEntryFromDublinCore(dcSchema, xmpPreferences).get());
 
         }
 
@@ -986,7 +990,7 @@ public class XMPUtilTest {
         List<BibEntry> l = new LinkedList<>();
         l.add(t3BibtexEntry());
 
-        XMPUtil.writeXMP(pdfFile, l, null, true, Globals.prefs);
+        XMPUtil.writeXMP(pdfFile, l, null, true, xmpPreferences);
 
         try (PDDocument document = PDDocument.load(pdfFile.getAbsoluteFile())) {
             if (document.isEncrypted()) {
@@ -1041,7 +1045,7 @@ public class XMPUtilTest {
             Assert.assertEquals(4, dcSchema.getRelationships().size());
 
             assertEqualsBibtexEntry(t3BibtexEntry(),
-                    XMPUtil.getBibtexEntryFromDublinCore(dcSchema, Globals.prefs).get());
+                    XMPUtil.getBibtexEntryFromDublinCore(dcSchema, xmpPreferences).get());
 
         }
     }
@@ -1061,7 +1065,7 @@ public class XMPUtilTest {
 
         BibEntry e = c.iterator().next();
 
-        XMPUtil.writeXMP(pdfFile, e, null, Globals.prefs);
+        XMPUtil.writeXMP(pdfFile, e, null, xmpPreferences);
 
         Optional<XMPMetadata> metadata = XMPUtil.readRawXMP(pdfFile);
 
@@ -1117,7 +1121,7 @@ public class XMPUtilTest {
 
                 writeManually(pdfFile, xmp);
             }
-            List<BibEntry> l = XMPUtil.readXMP(pdfFile, Globals.prefs);
+            List<BibEntry> l = XMPUtil.readXMP(pdfFile, xmpPreferences);
             Assert.assertEquals(1, l.size());
             assertEqualsBibtexEntry(t1BibtexEntry(), l.get(0));
 
@@ -1141,7 +1145,7 @@ public class XMPUtilTest {
 
             BibEntry e = t1BibtexEntry();
 
-            XMPUtil.writeXMP(pdfFile, e, null, Globals.prefs);
+            XMPUtil.writeXMP(pdfFile, e, null, xmpPreferences);
 
             try (ByteArrayOutputStream s = new ByteArrayOutputStream()) {
                 PrintStream oldOut = System.out;
@@ -1161,7 +1165,7 @@ public class XMPUtilTest {
         // Write XMP to file
         BibEntry e = t1BibtexEntry();
 
-        XMPUtil.writeXMP(pdfFile, e, null, Globals.prefs);
+        XMPUtil.writeXMP(pdfFile, e, null, xmpPreferences);
 
         try (ByteArrayOutputStream s = new ByteArrayOutputStream()) {
             PrintStream oldOut = System.out;
@@ -1186,7 +1190,7 @@ public class XMPUtilTest {
 
             /* Test contents of string */
             writeManually(pdfFile, xmp);
-            List<BibEntry> l = XMPUtil.readXMP(pdfFile, Globals.prefs);
+            List<BibEntry> l = XMPUtil.readXMP(pdfFile, xmpPreferences);
             Assert.assertEquals(1, l.size());
 
             assertEqualsBibtexEntry(t1BibtexEntry(), l.get(0));
@@ -1218,7 +1222,7 @@ public class XMPUtilTest {
                 }
 
                 // PDF should be annotated:
-                List<BibEntry> l = XMPUtil.readXMP(pdfFile, Globals.prefs);
+                List<BibEntry> l = XMPUtil.readXMP(pdfFile, xmpPreferences);
                 Assert.assertEquals(1, l.size());
                 assertEqualsBibtexEntry(t1BibtexEntry(), l.get(0));
             }
@@ -1234,7 +1238,7 @@ public class XMPUtilTest {
             }
 
             // PDF should be annotated:
-            List<BibEntry> l = XMPUtil.readXMP(pdfFile, Globals.prefs);
+            List<BibEntry> l = XMPUtil.readXMP(pdfFile, xmpPreferences);
             Assert.assertEquals(1, l.size());
             assertEqualsBibtexEntry(t2BibtexEntry(), l.get(0));
         } finally {
@@ -1267,7 +1271,7 @@ public class XMPUtilTest {
                 XMPUtilMain.main(new String[] {tempBib.getAbsolutePath(), pdfFile.getAbsolutePath()});
                 System.setOut(oldOut);
             }
-            List<BibEntry> l = XMPUtil.readXMP(pdfFile, Globals.prefs);
+            List<BibEntry> l = XMPUtil.readXMP(pdfFile, xmpPreferences);
 
             Assert.assertEquals(2, l.size());
 
@@ -1319,9 +1323,9 @@ public class XMPUtilTest {
 
         BibEntry e = c.iterator().next();
 
-        XMPUtil.writeXMP(pdfFile, e, original.getDatabase(), Globals.prefs);
+        XMPUtil.writeXMP(pdfFile, e, original.getDatabase(), xmpPreferences);
 
-        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), Globals.prefs);
+        List<BibEntry> l = XMPUtil.readXMP(pdfFile.getAbsoluteFile(), xmpPreferences);
         Assert.assertEquals(1, l.size());
         BibEntry x = l.get(0);
 
@@ -1332,13 +1336,13 @@ public class XMPUtilTest {
     @Test(expected = EncryptedPdfsNotSupportedException.class)
     public void expectedEncryptionNotSupportedExceptionAtRead() throws IOException {
         try (InputStream is = XMPUtilTest.class.getResourceAsStream("/pdfs/encrypted.pdf")) {
-            XMPUtil.readXMP(is, Globals.prefs);
+            XMPUtil.readXMP(is, xmpPreferences);
         }
     }
 
     @Test(expected = EncryptedPdfsNotSupportedException.class)
     public void expectedEncryptionNotSupportedExceptionAtWrite() throws IOException, TransformerException {
-        XMPUtil.writeXMP("src/test/resources/pdfs/encrypted.pdf", t1BibtexEntry(), null, Globals.prefs);
+        XMPUtil.writeXMP("src/test/resources/pdfs/encrypted.pdf", t1BibtexEntry(), null, xmpPreferences);
     }
 
     /**
@@ -1363,10 +1367,10 @@ public class XMPUtilTest {
 
             try {
                 XMPUtil.writeXMP(pdfFile, result.getDatabase().getEntryByKey("Patterson06").get(),
-                        result.getDatabase(), Globals.prefs);
+                        result.getDatabase(), xmpPreferences);
 
                 // Test whether we the main function can load the bibtex correctly
-                BibEntry b = XMPUtil.readXMP(pdfFile, Globals.prefs).get(0);
+                BibEntry b = XMPUtil.readXMP(pdfFile, xmpPreferences).get(0);
                 Assert.assertNotNull(b);
                 Assert.assertEquals(originalAuthors, AuthorList.parse(b.getFieldOptional("author").get()));
 
@@ -1401,7 +1405,7 @@ public class XMPUtilTest {
                     Assert.assertEquals("Arvind", dcSchema.getCreators().get(1));
                     Assert.assertEquals("Krste Asanov\\'\\i{}c", dcSchema.getCreators().get(2));
 
-                    b = XMPUtil.getBibtexEntryFromDublinCore(dcSchema, Globals.prefs).get();
+                    b = XMPUtil.getBibtexEntryFromDublinCore(dcSchema, xmpPreferences).get();
                     Assert.assertNotNull(b);
                     Assert.assertEquals(originalAuthors, AuthorList.parse(b.getFieldOptional("author").get()));
                 }

--- a/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
@@ -27,7 +27,7 @@ import java.util.TimeZone;
 import javax.xml.transform.TransformerException;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.XMPUtilMain;
+import net.sf.jabref.cli.XMPUtilMain;
 import net.sf.jabref.importer.ParserResult;
 import net.sf.jabref.importer.fileformat.BibtexParser;
 import net.sf.jabref.logic.bibtex.BibEntryWriter;


### PR DESCRIPTION
Not sure about the future of the stand-alone tool, but from a dependency point of view it made sense to move it.

Note that the tests are not moved since there were some strange problems I couldn't really (find worthwhile at the moment to) solve, related to common test data for XMPUtil and XMPUtilMain.