### PR TITLE
Added change listener for crossref field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Undo/redo are enabled/disabled and show the action in the tool tip
 - Added ISBN integrity checker
 - Added filter to not show selected integrity checks
+- The contents of `crossref` and `related` will be automatically updated if a linked entry changes key
 - Enhance the entry customization dialog to give better visual feedback
 - It is now possible to generate a new BIB database from the citations in an OpenOffice/LibreOffice document
 - The arXiv fetcher now also supports free-text search queries

--- a/src/main/java/net/sf/jabref/logic/autocompleter/AutoCompleterFactory.java
+++ b/src/main/java/net/sf/jabref/logic/autocompleter/AutoCompleterFactory.java
@@ -1,4 +1,4 @@
-/*  Copyright (C) 2003-2015 JabRef contributors.
+/*  Copyright (C) 2003-2016 JabRef contributors.
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation; either version 2 of the License, or
@@ -15,7 +15,6 @@
 */
 package net.sf.jabref.logic.autocompleter;
 
-import java.util.Arrays;
 import java.util.Objects;
 
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
@@ -44,9 +43,10 @@ public class AutoCompleterFactory {
 
         if (InternalBibtexFields.getFieldExtras(fieldName).contains(FieldProperties.PERSON_NAMES)) {
             return new NameFieldAutoCompleter(fieldName, preferences);
-        } else if (FieldName.CROSSREF.equals(fieldName)) {
+        } else if (InternalBibtexFields.getFieldExtras(fieldName).contains(FieldProperties.SINGLE_ENTRY_LINK)) {
             return new BibtexKeyAutoCompleter(preferences);
-        } else if (FieldName.JOURNAL.equals(fieldName) || FieldName.PUBLISHER.equals(fieldName)) {
+        } else if (InternalBibtexFields.getFieldExtras(fieldName).contains(FieldProperties.JOURNAL_NAME)
+                || FieldName.PUBLISHER.equals(fieldName)) {
             return new JournalAutoCompleter(fieldName, preferences, abbreviationLoader);
         } else {
             return new DefaultAutoCompleter(fieldName, preferences);
@@ -54,7 +54,7 @@ public class AutoCompleterFactory {
     }
 
     public AutoCompleter<String> getPersonAutoCompleter() {
-        return new NameFieldAutoCompleter(Arrays.asList(FieldName.AUTHOR, FieldName.EDITOR), true, preferences);
+        return new NameFieldAutoCompleter(InternalBibtexFields.getPersonNameFields(), true, preferences);
     }
 
 }

--- a/src/main/java/net/sf/jabref/model/database/BibDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabase.java
@@ -90,6 +90,11 @@ public class BibDatabase {
 
     private final EventBus eventBus = new EventBus();
 
+
+    public BibDatabase() {
+        this.registerListener(new KeyChangeListener(this));
+    }
+
     /**
      * Returns the number of entries.
      */

--- a/src/main/java/net/sf/jabref/model/database/KeyChangeListener.java
+++ b/src/main/java/net/sf/jabref/model/database/KeyChangeListener.java
@@ -1,0 +1,88 @@
+package net.sf.jabref.model.database;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.model.entry.FieldProperties;
+import net.sf.jabref.model.entry.InternalBibtexFields;
+import net.sf.jabref.model.event.EntryRemovedEvent;
+import net.sf.jabref.model.event.FieldChangedEvent;
+
+import com.google.common.eventbus.Subscribe;
+
+public class KeyChangeListener {
+
+    private final BibDatabase database;
+
+    private final List<String> keyFields = new ArrayList<>();
+
+
+    public KeyChangeListener(BibDatabase database) {
+        this.database = database;
+
+        // Look for fields with FieldProperies.SINGLE_ENTRY_LINK or FieldProperties.MULTIPLE_ENTRY_LINK to speed up the search later
+
+        for (String fieldName : InternalBibtexFields.getAllPublicFieldNames()) {
+            if (InternalBibtexFields.getFieldExtras(fieldName).contains(FieldProperties.SINGLE_ENTRY_LINK)
+                    || InternalBibtexFields.getFieldExtras(fieldName).contains(FieldProperties.MULTIPLE_ENTRY_LINK)) {
+                keyFields.add(fieldName);
+            }
+        }
+    }
+
+    @Subscribe
+    public void listen(FieldChangedEvent event) {
+        if (event.getFieldName().equals(BibEntry.KEY_FIELD)) {
+            String newKey = event.getNewValue();
+            String oldKey = event.getOldValue();
+            updateEntryLinks(newKey, oldKey);
+        }
+    }
+
+    @Subscribe
+    public void listen(EntryRemovedEvent event) {
+        String oldKey = event.getBibEntry().getCiteKey();
+        updateEntryLinks(null, oldKey);
+    }
+
+    private void updateEntryLinks(String newKey, String oldKey) {
+        for (BibEntry entry : database.getEntries()) {
+            for (String field : keyFields) {
+                entry.getFieldOptional(field).ifPresent(fieldContent -> {
+                    if (InternalBibtexFields.getFieldExtras(field).contains(FieldProperties.SINGLE_ENTRY_LINK)) {
+                        replaceSingleKeyInField(newKey, oldKey, entry, field, fieldContent);
+                    } else { // MULTIPLE_ENTRY_LINK
+                        replaceKeyInMultiplesKeyField(newKey, oldKey, entry, field, fieldContent);
+                    }
+                });
+            }
+        }
+    }
+
+    private void replaceKeyInMultiplesKeyField(String newKey, String oldKey, BibEntry entry, String field,
+            String fieldContent) {
+        List<String> keys = new ArrayList<>(Arrays.asList(fieldContent.split(",")));
+        int index = keys.indexOf(oldKey);
+        if (index != -1) {
+            if (newKey == null) {
+                keys.remove(index);
+            } else {
+                keys.set(index, newKey);
+            }
+            entry.setField(field, String.join(",", keys));
+        }
+    }
+
+    private void replaceSingleKeyInField(String newKey, String oldKey, BibEntry entry, String field,
+            String fieldContent) {
+        if (fieldContent.equals(oldKey)) {
+            if (newKey == null) {
+                entry.clearField(field);
+            } else {
+                entry.setField(field, newKey);
+            }
+        }
+    }
+}

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -125,7 +125,9 @@ public class BibEntry implements Cloneable {
     public void setId(String id) {
         Objects.requireNonNull(id, "Every BibEntry must have an ID");
 
-        eventBus.post(new FieldChangedEvent(this, BibEntry.ID_FIELD, id));
+        String oldId = this.id;
+
+        eventBus.post(new FieldChangedEvent(this, BibEntry.ID_FIELD, id, oldId));
         this.id = id;
         changed = true;
     }
@@ -183,13 +185,14 @@ public class BibEntry implements Cloneable {
         } else {
             newType = type;
         }
+        String oldType = getFieldOptional(TYPE_HEADER).orElse(null);
 
         // We set the type before throwing the changeEvent, to enable
         // the change listener to access the new value if the change
         // sets off a change in database sorting etc.
         this.type = newType.toLowerCase(Locale.ENGLISH);
         changed = true;
-        eventBus.post(new FieldChangedEvent(this, TYPE_HEADER, newType, eventSource));
+        eventBus.post(new FieldChangedEvent(this, TYPE_HEADER, newType, oldType, eventSource));
     }
 
     /**

--- a/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
+++ b/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
@@ -184,10 +184,6 @@ public class InternalBibtexFields {
         dummy.setExtras(EnumSet.of(FieldProperties.FILE_EDITOR));
         add(dummy);
 
-        dummy = new BibtexSingleField(FieldName.RELATED, false);
-        dummy.setExtras(EnumSet.of(FieldProperties.MULTIPLE_ENTRY_LINK));
-        add(dummy);
-
         add(new BibtexSingleField("search", false, 75));
 
         // some BibLatex fields
@@ -511,6 +507,12 @@ public class InternalBibtexFields {
     public static List<String> getBookNameFields() {
         return InternalBibtexFields.getAllPublicFieldNames().stream()
                 .filter(fieldName -> InternalBibtexFields.getFieldExtras(fieldName).contains(FieldProperties.BOOK_NAME))
+                .collect(Collectors.toList());
+    }
+
+    public static List<String> getPersonNameFields() {
+        return InternalBibtexFields.getAllPublicFieldNames().stream().filter(
+                fieldName -> InternalBibtexFields.getFieldExtras(fieldName).contains(FieldProperties.PERSON_NAMES))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
+++ b/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
@@ -184,6 +184,10 @@ public class InternalBibtexFields {
         dummy.setExtras(EnumSet.of(FieldProperties.FILE_EDITOR));
         add(dummy);
 
+        dummy = new BibtexSingleField(FieldName.RELATED, false);
+        dummy.setExtras(EnumSet.of(FieldProperties.MULTIPLE_ENTRY_LINK));
+        add(dummy);
+
         add(new BibtexSingleField("search", false, 75));
 
         // some BibLatex fields
@@ -209,6 +213,7 @@ public class InternalBibtexFields {
 
         dummy = new BibtexSingleField(timeStampFieldName, false, BibtexSingleField.SMALL_W);
         timeStampField = timeStampFieldName;
+
         dummy.setExtras(EnumSet.of(FieldProperties.DATE));
         dummy.setPrivate();
         add(dummy);

--- a/src/main/java/net/sf/jabref/model/event/FieldChangedEvent.java
+++ b/src/main/java/net/sf/jabref/model/event/FieldChangedEvent.java
@@ -11,17 +11,22 @@ public class FieldChangedEvent extends EntryChangedEvent {
 
     private final String fieldName;
     private final String newValue;
+    private final String oldValue;
+
 
     /**
      * @param bibEntry Affected BibEntry object
      * @param fieldName Name of field which has been changed
      * @param newValue new field value
+     * @param newValue old field value
      * @param location location Location affected by this event
      */
-    public FieldChangedEvent(BibEntry bibEntry, String fieldName, String newValue, EntryEventSource location) {
+    public FieldChangedEvent(BibEntry bibEntry, String fieldName, String newValue, String oldValue,
+            EntryEventSource location) {
         super(bibEntry, location);
         this.fieldName = fieldName;
         this.newValue = newValue;
+        this.oldValue = oldValue;
     }
 
     /**
@@ -29,10 +34,11 @@ public class FieldChangedEvent extends EntryChangedEvent {
      * @param fieldName Name of field which has been changed
      * @param newValue new field value
      */
-    public FieldChangedEvent(BibEntry bibEntry, String fieldName, String newValue) {
+    public FieldChangedEvent(BibEntry bibEntry, String fieldName, String newValue, String oldValue) {
         super(bibEntry);
         this.fieldName = fieldName;
         this.newValue = newValue;
+        this.oldValue = oldValue;
     }
 
     /**
@@ -45,6 +51,7 @@ public class FieldChangedEvent extends EntryChangedEvent {
         super(fieldChange.getEntry(), location);
         this.fieldName = fieldChange.getField();
         this.newValue = fieldChange.getNewValue();
+        this.oldValue = fieldChange.getOldValue();
     }
 
     public FieldChangedEvent(FieldChange fieldChange) {
@@ -57,6 +64,10 @@ public class FieldChangedEvent extends EntryChangedEvent {
 
     public String getNewValue() {
         return newValue;
+    }
+
+    public String getOldValue() {
+        return oldValue;
     }
 
 }

--- a/src/test/java/net/sf/jabref/model/database/KeyChangeListenerTest.java
+++ b/src/test/java/net/sf/jabref/model/database/KeyChangeListenerTest.java
@@ -1,0 +1,93 @@
+package net.sf.jabref.model.database;
+
+import java.util.Optional;
+
+import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.model.entry.FieldName;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class KeyChangeListenerTest {
+
+    private BibDatabase db;
+    private BibEntry entry1;
+    private BibEntry entry2;
+    private BibEntry entry3;
+    private BibEntry entry4;
+
+
+    @Before
+    public void setUp() {
+        db = new BibDatabase();
+
+        entry1 = new BibEntry();
+        entry1.setCiteKey("Entry1");
+        entry1.setField(FieldName.CROSSREF, "Entry4");
+        db.insertEntry(entry1);
+
+        entry2 = new BibEntry();
+        entry2.setCiteKey("Entry2");
+        entry2.setField(FieldName.RELATED, "Entry1,Entry3");
+        db.insertEntry(entry2);
+
+        entry3 = new BibEntry();
+        entry3.setCiteKey("Entry3");
+        entry3.setField(FieldName.RELATED, "Entry1,Entry2,Entry3");
+        db.insertEntry(entry3);
+
+        entry4 = new BibEntry();
+        entry4.setCiteKey("Entry4");
+        db.insertEntry(entry4);
+
+    }
+
+    @Test
+    public void testCrossrefChanged() {
+        assertEquals(Optional.of("Entry4"), entry1.getFieldOptional("crossref"));
+        entry4.setCiteKey("Banana");
+        assertEquals(Optional.of("Banana"), entry1.getFieldOptional("crossref"));
+    }
+
+    @Test
+    public void testRelatedChanged() {
+        assertEquals(Optional.of("Entry1,Entry3"), entry2.getFieldOptional("related"));
+        entry1.setCiteKey("Banana");
+        assertEquals(Optional.of("Banana,Entry3"), entry2.getFieldOptional("related"));
+    }
+
+    @Test
+    public void testRelatedChangedInSameEntry() {
+        assertEquals(Optional.of("Entry1,Entry2,Entry3"), entry3.getFieldOptional("related"));
+        entry3.setCiteKey("Banana");
+        assertEquals(Optional.of("Entry1,Entry2,Banana"), entry3.getFieldOptional("related"));
+    }
+
+    @Test
+    public void testCrossrefRemoved() {
+        entry4.clearField(BibEntry.KEY_FIELD);
+        assertEquals(Optional.empty(), entry1.getFieldOptional("crossref"));
+    }
+
+    @Test
+    public void testCrossrefEntryRemoved() {
+        db.removeEntry(entry4);
+        assertEquals(Optional.empty(), entry1.getFieldOptional("crossref"));
+    }
+
+    @Test
+    public void testRelatedEntryRemoved() {
+        db.removeEntry(entry1);
+        assertEquals(Optional.of("Entry3"), entry2.getFieldOptional("related"));
+    }
+
+    @Test
+    public void testRelatedAllEntriesRemoved() {
+        db.removeEntry(entry1);
+        db.removeEntry(entry3);
+        assertEquals(Optional.empty(), entry2.getFieldOptional("related"));
+    }
+
+}


### PR DESCRIPTION
Another WIP just to show what is coming (as I may be unavailable for a week or so now).

Change listener that updates the crossref field when the key changes. In the longer run this will be extended to all field with keys, see #1637.

Will continue with tests and CHANGELOG entries eventually.

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef

