### PR TITLE
Introduced method getCiteKeyOptional and made getCiteKey deprecated

### DIFF
--- a/src/main/java/net/sf/jabref/collab/EntryChange.java
+++ b/src/main/java/net/sf/jabref/collab/EntryChange.java
@@ -17,6 +17,7 @@ package net.sf.jabref.collab;
 
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -41,11 +42,11 @@ class EntryChange extends Change {
 
     public EntryChange(BibEntry memEntry, BibEntry tmpEntry, BibEntry diskEntry) {
         super();
-        String key = tmpEntry.getCiteKey();
-        if (key == null) {
-            name = Localization.lang("Modified entry");
+        Optional<String> key = tmpEntry.getCiteKeyOptional();
+        if (key.isPresent()) {
+            name = Localization.lang("Modified entry") + ": '" + key.get() + '\'';
         } else {
-            name = Localization.lang("Modified entry") + ": '" + key + '\'';
+            name = Localization.lang("Modified entry");
         }
 
         // We know that tmpEntry is not equal to diskEntry. Check if it has been modified
@@ -56,8 +57,8 @@ class EntryChange extends Change {
         // in the same way. Check for this, too.
         boolean modificationsAgree = (DuplicateCheck.compareEntriesStrictly(memEntry, diskEntry) > 1);
 
-        LOGGER.debug("Modified entry: " + memEntry.getCiteKey() + "\n Modified locally: " + isModifiedLocally
-                + " Modifications agree: " + modificationsAgree);
+        LOGGER.debug("Modified entry: " + memEntry.getCiteKeyOptional().orElse("<no BibTeX key set>")
+                + "\n Modified locally: " + isModifiedLocally + " Modifications agree: " + modificationsAgree);
 
         Set<String> allFields = new TreeSet<>();
         allFields.addAll(memEntry.getFieldNames());

--- a/src/main/java/net/sf/jabref/collab/EntryDeleteChange.java
+++ b/src/main/java/net/sf/jabref/collab/EntryDeleteChange.java
@@ -53,7 +53,8 @@ class EntryDeleteChange extends Change {
         // Check if it has been modified locally, since last tempfile was saved.
         boolean isModifiedLocally = (matchWithTmp <= 1);
 
-        LOGGER.debug("Modified entry: " + memEntry.getCiteKey() + "\n Modified locally: " + isModifiedLocally);
+        LOGGER.debug("Modified entry: " + memEntry.getCiteKeyOptional().orElse("<no BibTeX key set>")
+                + "\n Modified locally: " + isModifiedLocally);
 
         PreviewPanel pp = new PreviewPanel(null, memEntry, null, Globals.prefs.get(JabRefPreferences.PREVIEW_0));
         sp = new JScrollPane(pp);

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -536,7 +536,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 // This is a partial clone of net.sf.jabref.gui.entryeditor.EntryEditor.GenerateKeyAction.actionPerformed(ActionEvent)
                 for (final Iterator<BibEntry> i = entries.iterator(); i.hasNext(); ) {
                     bes = i.next();
-                    if (bes.getCiteKey() != null) {
+                    if (bes.hasCiteKey()) {
                         if (Globals.prefs.getBoolean(JabRefPreferences.AVOID_OVERWRITING_KEY)) {
                             // Remove the entry, because its key is already set:
                             i.remove();
@@ -569,7 +569,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     for (BibEntry entry : entries) {
                         bes = entry;
                         // Store the old value:
-                        oldvals.put(bes, bes.getCiteKey());
+                        oldvals.put(bes, bes.getCiteKeyOptional().orElse(null));
                         database.setCiteKeyForEntry(bes, null);
                     }
                 }
@@ -582,7 +582,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     LabelPatternUtil.makeLabel(bibDatabaseContext.getMetaData(), database, bes,
                             LabelPatternPreferences.fromPreferences(Globals.prefs));
                     ce.addEdit(new UndoableKeyChange(database, bes, (String) oldvals.get(bes),
-                            bes.getCiteKey()));
+                            bes.getCiteKeyOptional().orElse(null)));
                 }
                 ce.end();
                 getUndoManager().addEdit(ce);
@@ -933,9 +933,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             List<String> keys = new ArrayList<>(bes.size());
             // Collect all non-null keys.
             for (BibEntry be : bes) {
-                if (be.getCiteKey() != null) {
-                    keys.add(be.getCiteKey());
-                }
+                be.getCiteKeyOptional().ifPresent(keys::add);
             }
             if (keys.isEmpty()) {
                 output(Localization.lang("None of the selected entries have BibTeX keys."));
@@ -963,9 +961,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             List<String> keys = new ArrayList<>(bes.size());
             // Collect all non-null keys.
             for (BibEntry be : bes) {
-                if (be.getCiteKey() != null) {
-                    keys.add(be.getCiteKey());
-                }
+                be.getCiteKeyOptional().ifPresent(keys::add);
             }
             if (keys.isEmpty()) {
                 output(Localization.lang("None of the selected entries have BibTeX keys."));
@@ -1008,7 +1004,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             int copied = 0;
             // Collect all non-null keys.
             for (BibEntry be : bes) {
-                if (be.getCiteKey() != null) {
+                if (be.hasCiteKey()) {
                     copied++;
                     sb.append(layout.doLayout(be, database));
                 }
@@ -1992,11 +1988,11 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             boolean any = false;
 
             for (BibEntry bes : database.getEntries()) {
-                String oldKey = bes.getCiteKey();
-                if ((oldKey == null) || oldKey.isEmpty()) {
+                Optional<String> oldKey = bes.getCiteKeyOptional();
+                if (!(oldKey.isPresent()) || oldKey.get().isEmpty()) {
                     LabelPatternUtil.makeLabel(bibDatabaseContext.getMetaData(), database, bes,
                             LabelPatternPreferences.fromPreferences(Globals.prefs));
-                    ce.addEdit(new UndoableKeyChange(database, bes, null, bes.getCiteKey()));
+                    ce.addEdit(new UndoableKeyChange(database, bes, null, bes.getCiteKeyOptional().get())); // Cite key is set here
                     any = true;
                 }
             }

--- a/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/ImportInspectionDialog.java
@@ -496,7 +496,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
                 localMetaData = panel.getBibDatabaseContext().getMetaData();
             }
 
-            List<String> keys = new ArrayList<>(entries.size());
+            List<Optional<String>> keys = new ArrayList<>(entries.size());
             // Iterate over the entries, add them to the database we are working
             // with,
             // and generate unique keys:
@@ -507,8 +507,8 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
 
                 LabelPatternUtil.makeLabel(localMetaData, database, entry,
                         LabelPatternPreferences.fromPreferences(Globals.prefs));
-                // Add the generated key to our list:
-                keys.add(entry.getCiteKey());
+                // Add the generated key to our list:   -- TODO: Why??
+                keys.add(entry.getCiteKeyOptional());
             }
 
             preview.update();
@@ -749,7 +749,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
 
         private boolean addToGroups(NamedCompound ce, BibEntry entry, Set<GroupTreeNode> groups) {
             boolean groupingCanceled = false;
-            if (entry.getCiteKey() == null) {
+            if (!entry.hasCiteKey()) {
                 // The entry has no key, so it can't be added to the
                 // group.
                 // The best course of action is probably to ask the
@@ -766,7 +766,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
             }
 
             // If the key existed, or exists now, go ahead:
-            if (entry.getCiteKey() != null) {
+            if (entry.hasCiteKey()) {
                 for (GroupTreeNode node : groups) {
                     if (node.supportsAddingEntries()) {
                         // Add the entry:
@@ -1166,17 +1166,17 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
                 return;
             }
             entry = selectionModel.getSelected().get(0);
-            String bibtexKey = entry.getCiteKey();
-            if (bibtexKey == null) {
+            Optional<String> bibtexKey = entry.getCiteKeyOptional();
+            if (!bibtexKey.isPresent()) {
                 int answer = JOptionPane.showConfirmDialog(frame,
                         Localization.lang("This entry has no BibTeX key. Generate key now?"),
                         Localization.lang("Download file"), JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
                 if (answer == JOptionPane.OK_OPTION) {
                     generateKeySelectedEntry();
-                    bibtexKey = entry.getCiteKey();
+                    bibtexKey = entry.getCiteKeyOptional();
                 }
             }
-            DownloadExternalFile def = new DownloadExternalFile(frame, bibDatabaseContext, bibtexKey);
+            DownloadExternalFile def = new DownloadExternalFile(frame, bibDatabaseContext, bibtexKey.get());
             try {
                 def.download(this);
             } catch (IOException ex) {
@@ -1213,7 +1213,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
                 return;
             }
             final BibEntry entry = selectionModel.getSelected().get(0);
-            if (entry.getCiteKey() == null) {
+            if (!entry.hasCiteKey()) {
                 int answer = JOptionPane.showConfirmDialog(frame,
                         Localization.lang("This entry has no BibTeX key. Generate key now?"),
                         Localization.lang("Download file"), JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);

--- a/src/main/java/net/sf/jabref/gui/PreviewPanel.java
+++ b/src/main/java/net/sf/jabref/gui/PreviewPanel.java
@@ -343,7 +343,7 @@ public class PreviewPanel extends JPanel
             JabRefExecutorService.INSTANCE.execute(() -> {
                 try {
                     PrintRequestAttributeSet pras = new HashPrintRequestAttributeSet();
-                    pras.add(new JobName(entry.map(BibEntry::getCiteKey).orElse("NO ENTRY"), null));
+                    pras.add(new JobName(entry.flatMap(BibEntry::getCiteKeyOptional).orElse("NO ENTRY"), null));
                     previewPane.print(null, null, true, null, pras, false);
 
                 } catch (PrinterException e) {

--- a/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
@@ -55,7 +55,7 @@ public class IntegrityCheckAction extends MnemonicAwareAction {
             Object[][] model = new Object[messages.size()][3];
             int i = 0;
             for (IntegrityMessage message : messages) {
-                model[i][0] = message.getEntry().getCiteKey();
+                model[i][0] = message.getEntry().getCiteKeyOptional().orElse("");
                 model[i][1] = message.getFieldName();
                 model[i][2] = message.getMessage();
                 showMessage.put(message.getMessage(), true);

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -794,7 +794,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
             NamedCompound compound = new NamedCompound(Localization.lang("source edit"));
             BibEntry newEntry = database.getEntries().get(0);
-            String newKey = newEntry.getCiteKey();
+            String newKey = newEntry.getCiteKeyOptional().orElse(null);
             boolean entryChanged = false;
             boolean duplicateWarning = false;
             boolean emptyWarning = (newKey == null) || newKey.isEmpty();
@@ -1097,7 +1097,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
             if (event.getSource() instanceof TextField) {
                 // Storage from bibtex key field.
                 TextField textField = (TextField) event.getSource();
-                String oldValue = entry.getCiteKey();
+                String oldValue = entry.getCiteKeyOptional().orElse(null);
                 String newValue = textField.getText();
 
                 if (newValue.isEmpty()) {
@@ -1355,9 +1355,9 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
             // this updates the table automatically, on close, but not
             // within the tab
-            String oldValue = entry.getCiteKey();
+            Optional<String> oldValue = entry.getCiteKeyOptional();
 
-            if (oldValue != null) {
+            if (oldValue.isPresent()) {
                 if (Globals.prefs.getBoolean(JabRefPreferences.AVOID_OVERWRITING_KEY)) {
                     panel.output(Localization.lang("Not overwriting existing key. To change this setting, open Options -> Prefererences -> BibTeX key generator"));
                     return;
@@ -1380,10 +1380,12 @@ public class EntryEditor extends JPanel implements EntryContainer {
                     LabelPatternPreferences.fromPreferences(Globals.prefs));
 
             // Store undo information:
-            panel.getUndoManager().addEdit(new UndoableKeyChange(panel.getDatabase(), entry, oldValue, entry.getCiteKey()));
+            panel.getUndoManager().addEdit(
+                    new UndoableKeyChange(panel.getDatabase(), entry, oldValue.orElse(null),
+                            entry.getCiteKeyOptional().get())); // Cite key always set here
 
             // here we update the field
-            String bibtexKeyData = entry.getCiteKey();
+            String bibtexKeyData = entry.getCiteKeyOptional().get();
             setField(BibEntry.KEY_FIELD, bibtexKeyData);
             updateSource();
             panel.markBaseChanged();

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditorTab.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditorTab.java
@@ -196,7 +196,8 @@ class EntryEditorTab {
 
         // Add the edit field for Bibtex-key.
         if (addKeyField) {
-            final TextField textField = new TextField(BibEntry.KEY_FIELD, parent.getEntry().getCiteKey(), true);
+            final TextField textField = new TextField(BibEntry.KEY_FIELD,
+                    parent.getEntry().getCiteKeyOptional().orElse(""), true);
             setupJTextComponent(textField, null);
 
             editors.put(BibEntry.KEY_FIELD, textField);

--- a/src/main/java/net/sf/jabref/gui/fieldeditors/FileListEditor.java
+++ b/src/main/java/net/sf/jabref/gui/fieldeditors/FileListEditor.java
@@ -461,8 +461,8 @@ public class FileListEditor extends JTable implements FieldEditor, DownloadExter
      * Run a file download operation.
      */
     private void downloadFile() {
-        String bibtexKey = entryEditor.getEntry().getCiteKey();
-        if (bibtexKey == null) {
+        Optional<String> bibtexKey = entryEditor.getEntry().getCiteKeyOptional();
+        if (!bibtexKey.isPresent()) {
             int answer = JOptionPane.showConfirmDialog(frame,
                     Localization.lang("This entry has no BibTeX key. Generate key now?"),
                     Localization.lang("Download file"), JOptionPane.OK_CANCEL_OPTION,
@@ -470,11 +470,11 @@ public class FileListEditor extends JTable implements FieldEditor, DownloadExter
             if (answer == JOptionPane.OK_OPTION) {
                 ActionListener l = entryEditor.getGenerateKeyAction();
                 l.actionPerformed(null);
-                bibtexKey = entryEditor.getEntry().getCiteKey();
+                bibtexKey = entryEditor.getEntry().getCiteKeyOptional();
             }
         }
         DownloadExternalFile def = new DownloadExternalFile(frame,
-                frame.getCurrentBasePanel().getBibDatabaseContext(), bibtexKey);
+                frame.getCurrentBasePanel().getBibDatabaseContext(), bibtexKey.orElse(null));
         try {
             def.download(this);
         } catch (IOException ex) {

--- a/src/main/java/net/sf/jabref/gui/push/PushToApplicationAction.java
+++ b/src/main/java/net/sf/jabref/gui/push/PushToApplicationAction.java
@@ -17,6 +17,7 @@ package net.sf.jabref.gui.push;
 
 import java.awt.event.ActionEvent;
 import java.util.List;
+import java.util.Optional;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -66,7 +67,7 @@ class PushToApplicationAction extends AbstractAction implements Runnable {
         // If required, check that all entries have BibTeX keys defined:
         if (operation.requiresBibtexKeys()) {
             for (BibEntry entry : entries) {
-                if ((entry.getCiteKey() == null) || entry.getCiteKey().trim().isEmpty()) {
+                if (!(entry.getCiteKeyOptional().isPresent()) || entry.getCiteKeyOptional().get().trim().isEmpty()) {
                     JOptionPane.showMessageDialog(frame,
                             Localization
                                     .lang("This operation requires all selected entries to have BibTeX keys defined."),
@@ -91,19 +92,20 @@ class PushToApplicationAction extends AbstractAction implements Runnable {
 
     private static String getKeyString(List<BibEntry> bibentries) {
         StringBuilder result = new StringBuilder();
-        String citeKey;
+        Optional<String> citeKey;
         boolean first = true;
         for (BibEntry bes : bibentries) {
-            citeKey = bes.getCiteKey();
+            citeKey = bes.getCiteKeyOptional();
             // if the key is empty we give a warning and ignore this entry
-            if ((citeKey == null) || citeKey.isEmpty()) {
+            // TODO: Give warning
+            if (!(citeKey.isPresent()) || citeKey.get().isEmpty()) {
                 continue;
             }
             if (first) {
-                result.append(citeKey);
+                result.append(citeKey.get());
                 first = false;
             } else {
-                result.append(',').append(citeKey);
+                result.append(',').append(citeKey.get());
             }
         }
         return result.toString();

--- a/src/main/java/net/sf/jabref/logic/autocompleter/BibtexKeyAutoCompleter.java
+++ b/src/main/java/net/sf/jabref/logic/autocompleter/BibtexKeyAutoCompleter.java
@@ -43,10 +43,7 @@ class BibtexKeyAutoCompleter extends AbstractAutoCompleter {
             return;
         }
 
-        String key = entry.getCiteKey();
-        if (key != null) {
-            addItemToIndex(key.trim());
-        }
+        entry.getCiteKeyOptional().ifPresent(key -> addItemToIndex(key.trim()));
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/logic/integrity/IntegrityMessage.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/IntegrityMessage.java
@@ -16,7 +16,7 @@ public class IntegrityMessage implements Cloneable {
 
     @Override
     public String toString() {
-        return "[" + getEntry().getCiteKey() + "] in " + getFieldName() + ": " + getMessage();
+        return "[" + getEntry().getCiteKeyOptional().orElse("") + "] in " + getFieldName() + ": " + getMessage();
     }
 
     public String getMessage() {

--- a/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
@@ -335,8 +335,9 @@ public class FileUtil {
             int dot = name.lastIndexOf('.');
             // First, look for exact matches:
             for (BibEntry entry : entries) {
-                String citeKey = entry.getCiteKey();
-                if ((citeKey != null) && !citeKey.isEmpty() && (dot > 0) && name.substring(0, dot).equals(citeKey)) {
+                Optional<String> citeKey = entry.getCiteKeyOptional();
+                if ((citeKey.isPresent()) && !citeKey.get().isEmpty() && (dot > 0)
+                        && name.substring(0, dot).equals(citeKey.get())) {
                     result.get(entry).add(file);
                     continue nextFile;
                 }
@@ -345,8 +346,8 @@ public class FileUtil {
             // matches are allowed, try to find one:
             if (!autolinkExactKeyOnly) {
                 for (BibEntry entry : entries) {
-                    String citeKey = entry.getCiteKey();
-                    if ((citeKey != null) && !citeKey.isEmpty() && name.startsWith(citeKey)) {
+                    Optional<String> citeKey = entry.getCiteKeyOptional();
+                    if ((citeKey.isPresent()) && !citeKey.get().isEmpty() && name.startsWith(citeKey.get())) {
                         result.get(entry).add(file);
                         continue nextFile;
                     }
@@ -392,7 +393,7 @@ public class FileUtil {
      */
     public static String createFileNameFromPattern(BibDatabase database, BibEntry entry,
             JournalAbbreviationLoader repositoryLoader, JabRefPreferences prefs) {
-        String targetName = entry.getCiteKey() == null ? "default" : entry.getCiteKey();
+        String targetName = entry.getCiteKeyOptional().orElse("default");
         StringReader sr = new StringReader(prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN));
         Layout layout = null;
         try {

--- a/src/main/java/net/sf/jabref/model/FieldChange.java
+++ b/src/main/java/net/sf/jabref/model/FieldChange.java
@@ -102,8 +102,7 @@ public class FieldChange {
 
     @Override
     public String toString() {
-        return "FieldChange [entry=" + entry.getCiteKey() + ", field=" + field + ", oldValue=" + oldValue
-                + ", newValue=" + newValue
-                + "]";
+        return "FieldChange [entry=" + entry.getCiteKeyOptional().orElse("") + ", field=" + field + ", oldValue="
+                + oldValue + ", newValue=" + newValue + "]";
     }
 }

--- a/src/main/java/net/sf/jabref/model/database/BibDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabase.java
@@ -197,7 +197,7 @@ public class BibDatabase {
         entry.registerListener(this);
 
         eventBus.post(new EntryAddedEvent(entry, isUndo));
-        return duplicationChecker.checkForDuplicateKeyAndAdd(null, entry.getCiteKey());
+        return duplicationChecker.checkForDuplicateKeyAndAdd(null, entry.getCiteKeyOptional().orElse(null));
     }
 
     /**
@@ -210,7 +210,7 @@ public class BibDatabase {
         boolean anyRemoved =  entries.removeIf(entry -> entry.getId().equals(toBeDeleted.getId()));
         if (anyRemoved) {
             internalIDs.remove(toBeDeleted.getId());
-            duplicationChecker.removeKeyFromSet(toBeDeleted.getCiteKey());
+            toBeDeleted.getCiteKeyOptional().ifPresent(duplicationChecker::removeKeyFromSet);
             eventBus.post(new EntryRemovedEvent(toBeDeleted));
         }
     }
@@ -220,13 +220,13 @@ public class BibDatabase {
     }
 
     public synchronized boolean setCiteKeyForEntry(BibEntry entry, String key) {
-        String oldKey = entry.getCiteKey();
+        String oldKey = entry.getCiteKeyOptional().orElse(null);
         if (key == null) {
             entry.clearField(BibEntry.KEY_FIELD);
         } else {
             entry.setCiteKey(key);
         }
-        return duplicationChecker.checkForDuplicateKeyAndAdd(oldKey, entry.getCiteKey());
+        return duplicationChecker.checkForDuplicateKeyAndAdd(oldKey, key);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -143,8 +143,13 @@ public class BibEntry implements Cloneable {
      *
      * Note: this is <emph>not</emph> the internal Id of this entry. The internal Id is always present, whereas the BibTeX key might not be present.
      */
+    @Deprecated
     public String getCiteKey() {
         return fields.get(KEY_FIELD);
+    }
+
+    public Optional<String> getCiteKeyOptional() {
+        return Optional.ofNullable(fields.get(KEY_FIELD));
     }
 
     public boolean hasCiteKey() {

--- a/src/main/java/net/sf/jabref/model/entry/CanonicalBibtexEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/CanonicalBibtexEntry.java
@@ -8,8 +8,6 @@ import java.util.SortedSet;
 import java.util.StringJoiner;
 import java.util.TreeSet;
 
-import com.google.common.base.Strings;
-
 public class CanonicalBibtexEntry {
 
     /**
@@ -22,7 +20,7 @@ public class CanonicalBibtexEntry {
         StringBuilder sb = new StringBuilder();
 
         // generate first line: type and bibtex key
-        String citeKey = Strings.nullToEmpty(e.getCiteKey());
+        String citeKey = e.getCiteKeyOptional().orElse("");
         sb.append(String.format("@%s{%s,", e.getType().toLowerCase(Locale.US), citeKey)).append('\n');
 
         // we have to introduce a new Map as fields are stored case-sensitive in JabRef (see https://github.com/koppor/jabref/issues/45).

--- a/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
+++ b/src/test/java/net/sf/jabref/importer/OpenDatabaseActionTest.java
@@ -113,6 +113,6 @@ public class OpenDatabaseActionTest {
         Assert.assertEquals(1, entries.size());
 
         BibEntry entry = entries.iterator().next();
-        Assert.assertEquals("testArticle", entry.getCiteKey());
+        Assert.assertEquals(Optional.of("testArticle"), entry.getCiteKeyOptional());
     }
 }

--- a/src/test/java/net/sf/jabref/importer/fetcher/OAI2HandlerFetcherTest.java
+++ b/src/test/java/net/sf/jabref/importer/fetcher/OAI2HandlerFetcherTest.java
@@ -66,7 +66,7 @@ public class OAI2HandlerFetcherTest {
 
             // Citekey is only generated if the user says so in the import
             // inspection dialog.
-            Assert.assertEquals(null, be.getCiteKey());
+            Assert.assertEquals(Optional.empty(), be.getCiteKeyOptional());
 
             Assert.assertEquals(Optional.of("Heavy Particles from Inflation"), be.getFieldOptional("title"));
             Assert.assertTrue(be.getFieldOptional("abstract").isPresent());

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -135,7 +135,7 @@ public class BibtexParserTest {
 
         BibEntry e = parsed.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
     }
@@ -150,7 +150,7 @@ public class BibtexParserTest {
 
         BibEntry e = parsed.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
     }
@@ -165,7 +165,7 @@ public class BibtexParserTest {
 
         BibEntry e = parsed.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
     }
 
     @Test
@@ -178,7 +178,7 @@ public class BibtexParserTest {
 
         BibEntry e = parsed.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
     }
@@ -193,7 +193,7 @@ public class BibtexParserTest {
 
         BibEntry e = parsed.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
     }
@@ -208,7 +208,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
     }
@@ -223,7 +223,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("unknown", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
     }
@@ -239,7 +239,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("thisisalongstringtotestmaybeitistolongwhoknowsnotme", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
     }
@@ -254,7 +254,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
     }
@@ -273,7 +273,7 @@ public class BibtexParserTest {
         BibEntry e = c.iterator().next();
 
         assertEquals("article", e.getType());
-        assertEquals("canh05", e.getCiteKey());
+        assertEquals(Optional.of("canh05"), e.getCiteKeyOptional());
         assertEquals(Optional.of("1234567890123456789"), e.getFieldOptional("isbn"));
         assertEquals(Optional.of("1234567890123456789"), e.getFieldOptional("isbn2"));
         assertEquals(Optional.of("1234"), e.getFieldOptional("small"));
@@ -289,7 +289,7 @@ public class BibtexParserTest {
         BibEntry e = c.iterator().next();
 
         assertEquals("article", e.getType());
-        assertEquals("te_st:with-special(characters)", e.getCiteKey());
+        assertEquals(Optional.of("te_st:with-special(characters)"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
     }
@@ -304,7 +304,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
     }
@@ -389,7 +389,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test and Second Author and Third Author"), e.getFieldOptional("author"));
     }
@@ -405,7 +405,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test and Second Author and Third Author"), e.getFieldOptional("editor"));
     }
@@ -424,7 +424,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Test, Second Keyword, Third Keyword"), e.getFieldOptional("keywords"));
     }
@@ -463,7 +463,7 @@ public class BibtexParserTest {
         BibEntry e = c.iterator().next();
         assertEquals("inproceedings", e.getType());
         assertEquals(8, e.getFieldNames().size());
-        assertEquals("CroAnnHow05", e.getCiteKey());
+        assertEquals(Optional.of("CroAnnHow05"), e.getCiteKeyOptional());
         assertEquals(Optional.of("Crowston, K. and Annabi, H. and Howison, J. and Masango, C."), e.getFieldOptional("author"));
         assertEquals(Optional.of("Effective work practices for floss development: A model and propositions"), e.getFieldOptional("title"));
         assertEquals(Optional.of("Hawaii International Conference On System Sciences (HICSS)"), e.getFieldOptional("booktitle"));
@@ -499,7 +499,7 @@ public class BibtexParserTest {
         BibEntry e = c.iterator().next();
         assertEquals("inproceedings", e.getType());
         assertEquals(8, e.getFieldNames().size());
-        assertEquals("CroAnnHow05", e.getCiteKey());
+        assertEquals(Optional.of("CroAnnHow05"), e.getCiteKeyOptional());
         assertEquals(Optional.of("Crowston, K. and Annabi, H. and Howison, J. and Masango, C."), e.getFieldOptional("author"));
         assertEquals(Optional.of("Effective work practices for floss development: A model and propositions"), e.getFieldOptional("title"));
         assertEquals(Optional.of("Hawaii International Conference On System Sciences (HICSS)"), e.getFieldOptional("booktitle"));
@@ -519,7 +519,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
     }
@@ -534,7 +534,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("2005"), e.getFieldOptional("year"));
     }
@@ -549,7 +549,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
     }
@@ -568,7 +568,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("D:\\Documents\\literature\\Tansel-PRL2006.pdf"), e.getFieldOptional("file"));
     }
@@ -586,7 +586,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("1-4~#nov#"), e.getFieldOptional("date"));
     }
@@ -677,7 +677,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(Optional.of("escaped \\{ bracket"), e.getFieldOptional("review"));
     }
 
@@ -693,7 +693,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(Optional.of("escaped \\} bracket"), e.getFieldOptional("review"));
     }
 
@@ -764,7 +764,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("author @ good"), e.getFieldOptional("author"));
     }
@@ -779,7 +779,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Test {Ed {von} Test}"), e.getFieldOptional("author"));
     }
@@ -795,7 +795,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Test {\" Test}"), e.getFieldOptional("author"));
     }
@@ -824,7 +824,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
     }
@@ -842,7 +842,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(3, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
         assertEquals(Optional.of("8,"), e.getFieldOptional("month"));
@@ -977,7 +977,7 @@ public class BibtexParserTest {
         BibEntry e = c.iterator().next();
 
         assertEquals("book", e.getType());
-        assertEquals("bourdieu-2002-questions-sociologie", e.getCiteKey());
+        assertEquals(Optional.of("bourdieu-2002-questions-sociologie"), e.getCiteKeyOptional());
         assertEquals(Optional.of("Paris"), e.getFieldOptional("address"));
         assertEquals(Optional.of("#bourdieu#"), e.getFieldOptional("author"));
         assertEquals(Optional.of("2707318256"), e.getFieldOptional("isbn"));
@@ -1019,7 +1019,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
     }
@@ -1034,7 +1034,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
     }
@@ -1056,7 +1056,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
     }
@@ -1071,7 +1071,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
     }
@@ -1183,7 +1183,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(Optional.of("H\'{e}lne Fiaux"), e.getFieldOptional("author"));
     }
 
@@ -1204,7 +1204,7 @@ public class BibtexParserTest {
 
         BibEntry e = c.iterator().next();
         assertEquals("article", e.getType());
-        assertEquals("test", e.getCiteKey());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(Optional.of("H\'{e}lne Fiaux"), e.getFieldOptional("author"));
     }
 
@@ -1511,7 +1511,7 @@ public class BibtexParserTest {
         assertEquals(1, entries.size());
 
         BibEntry entry = entries.iterator().next();
-        assertEquals("test", entry.getCiteKey());
+        assertEquals(Optional.of("test"), entry.getCiteKeyOptional());
         assertEquals(5, entry.getFieldNames().size());
         Set<String> fields = entry.getFieldNames();
         assertTrue(fields.contains("author"));
@@ -1537,7 +1537,7 @@ public class BibtexParserTest {
         assertEquals(1, entries.size());
 
         BibEntry entry = entries.iterator().next();
-        assertEquals("test", entry.getCiteKey());
+        assertEquals(Optional.of("test"), entry.getCiteKeyOptional());
         assertEquals(5, entry.getFieldNames().size());
         Set<String> fields = entry.getFieldNames();
         assertTrue(fields.contains("author"));

--- a/src/test/java/net/sf/jabref/logic/bst/TestVM.java
+++ b/src/test/java/net/sf/jabref/logic/bst/TestVM.java
@@ -6,6 +6,7 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.importer.ParserResult;
@@ -392,10 +393,10 @@ public class TestVM {
         vm.run(v);
 
         List<BstEntry> v2 = vm.getEntries();
-        Assert.assertEquals("a", v2.get(0).getBibtexEntry().getCiteKey());
-        Assert.assertEquals("b", v2.get(1).getBibtexEntry().getCiteKey());
-        Assert.assertEquals("c", v2.get(2).getBibtexEntry().getCiteKey());
-        Assert.assertEquals("d", v2.get(3).getBibtexEntry().getCiteKey());
+        Assert.assertEquals(Optional.of("a"), v2.get(0).getBibtexEntry().getCiteKeyOptional());
+        Assert.assertEquals(Optional.of("b"), v2.get(1).getBibtexEntry().getCiteKeyOptional());
+        Assert.assertEquals(Optional.of("c"), v2.get(2).getBibtexEntry().getCiteKeyOptional());
+        Assert.assertEquals(Optional.of("d"), v2.get(3).getBibtexEntry().getCiteKeyOptional());
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/xmp/XMPSchemaBibtexTest.java
+++ b/src/test/java/net/sf/jabref/logic/xmp/XMPSchemaBibtexTest.java
@@ -34,7 +34,7 @@ public class XMPSchemaBibtexTest {
     public void assertEqualsBibtexEntry(BibEntry e, BibEntry x) {
         Assert.assertNotNull(e);
         Assert.assertNotNull(x);
-        Assert.assertEquals(e.getCiteKey(), x.getCiteKey());
+        Assert.assertEquals(e.getCiteKeyOptional(), x.getCiteKeyOptional());
         Assert.assertEquals(e.getType(), x.getType());
 
         Assert.assertEquals(e.getFieldNames().size(), x.getFieldNames().size());

--- a/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
@@ -281,7 +281,7 @@ public class XMPUtilTest {
         BibEntry e = l.get(0);
 
         Assert.assertNotNull(e);
-        Assert.assertEquals("OezbekC06", e.getCiteKey());
+        Assert.assertEquals(Optional.of("OezbekC06"), e.getCiteKeyOptional());
         Assert.assertEquals(Optional.of("2003"), e.getFieldOptional("year"));
         Assert.assertEquals(Optional.of("Beach sand convolution by surf-wave optimzation"),
                 e.getFieldOptional("title"));
@@ -306,7 +306,7 @@ public class XMPUtilTest {
         BibEntry e = l.get(0);
 
         Assert.assertNotNull(e);
-        Assert.assertEquals("OezbekC06", e.getCiteKey());
+        Assert.assertEquals(Optional.of("OezbekC06"), e.getCiteKeyOptional());
         Assert.assertEquals(Optional.of("2003"), e.getFieldOptional("year"));
         Assert.assertEquals(Optional.of("�pt�mz�t��n"), e.getFieldOptional("title"));
         Assert.assertEquals("misc", e.getType());
@@ -380,7 +380,7 @@ public class XMPUtilTest {
         BibEntry e = l.get(0);
 
         Assert.assertNotNull(e);
-        Assert.assertEquals("Clarkson06", e.getCiteKey());
+        Assert.assertEquals(Optional.of("Clarkson06"), e.getCiteKeyOptional());
         Assert.assertEquals("Kelly Clarkson and Ozzy Osbourne", e.getFieldOptional("author").get());
         Assert.assertEquals("Huey Duck and Dewey Duck and Louie Duck", e.getFieldOptional("editor").get());
         Assert.assertEquals("misc", e.getType());
@@ -761,7 +761,7 @@ public class XMPUtilTest {
     public void assertEqualsBibtexEntry(BibEntry expected, BibEntry actual) {
         Assert.assertNotNull(expected);
         Assert.assertNotNull(actual);
-        Assert.assertEquals(expected.getCiteKey(), actual.getCiteKey());
+        Assert.assertEquals(expected.getCiteKeyOptional(), actual.getCiteKeyOptional());
         Assert.assertEquals(expected.getType(), actual.getType());
 
         for (String field : expected.getFieldNames()) {
@@ -824,12 +824,12 @@ public class XMPUtilTest {
             b = tmp;
         }
 
-        Assert.assertEquals("canh05", a.getCiteKey());
+        Assert.assertEquals(Optional.of("canh05"), a.getCiteKeyOptional());
         Assert.assertEquals("K. Crowston and H. Annabi", a.getFieldOptional("author").get());
         Assert.assertEquals("Title A", a.getFieldOptional("title").get());
         Assert.assertEquals("article", a.getType());
 
-        Assert.assertEquals("foo", b.getCiteKey());
+        Assert.assertEquals(Optional.of("foo"), b.getCiteKeyOptional());
         Assert.assertEquals("Norton Bar", b.getFieldOptional("author").get());
         Assert.assertEquals("inproceedings", b.getType());
     }

--- a/src/test/java/net/sf/jabref/model/database/BibDatabaseTest.java
+++ b/src/test/java/net/sf/jabref/model/database/BibDatabaseTest.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.Optional;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.importer.ParserResult;
@@ -233,7 +234,7 @@ public class BibDatabaseTest {
         database.insertEntry(entry);
         assertFalse(database.setCiteKeyForEntry(entry, null));
         assertEquals(database.getNumberOfKeyOccurrences("AAA"), 0);
-        assertNull(entry.getCiteKey());
+        assertEquals(Optional.empty(), entry.getCiteKeyOptional());
     }
 
     @Test
@@ -256,7 +257,7 @@ public class BibDatabaseTest {
         entry.setCiteKey("BBB");
         database.insertEntry(entry);
         assertTrue(database.setCiteKeyForEntry(entry, "AAA"));
-        assertEquals(entry.getCiteKey(), "AAA");
+        assertEquals(entry.getCiteKeyOptional(), Optional.of("AAA"));
         assertEquals(database.getNumberOfKeyOccurrences("AAA"), 2);
         assertEquals(database.getNumberOfKeyOccurrences("BBB"), 0);
     }

--- a/src/test/java/net/sf/jabref/model/entry/BibEntryTests.java
+++ b/src/test/java/net/sf/jabref/model/entry/BibEntryTests.java
@@ -390,7 +390,7 @@ public class BibEntryTests {
         be.setField("author", "Albert Einstein");
         be.setCiteKey("Einstein1931");
         Assert.assertTrue(be.hasCiteKey());
-        Assert.assertEquals("Einstein1931", be.getCiteKey());
+        Assert.assertEquals(Optional.of("Einstein1931"), be.getCiteKeyOptional());
         Assert.assertEquals(Optional.of("Albert Einstein"), be.getFieldOptional("author"));
         be.clearField("author");
         Assert.assertEquals(Optional.empty(), be.getFieldOptional("author"));


### PR DESCRIPTION
There are some interesting consequences in the code. Or rather it is clear that in quite a few places the code breaks with a `null` cite key.
