### PR TITLE
[WIP] Proper copying of entries

### DIFF
--- a/src/main/java/net/sf/jabref/logic/auxparser/AuxParser.java
+++ b/src/main/java/net/sf/jabref/logic/auxparser/AuxParser.java
@@ -141,7 +141,7 @@ public class AuxParser {
         // Copy database definitions
         if (result.getGeneratedBibDatabase().hasEntries()) {
             result.getGeneratedBibDatabase().copyPreamble(masterDatabase);
-            result.getGeneratedBibDatabase().copyStrings(masterDatabase);
+            result.insertStrings(masterDatabase.getUsedStrings(result.getGeneratedBibDatabase().getEntries()));
         }
     }
 

--- a/src/main/java/net/sf/jabref/logic/auxparser/AuxParserResult.java
+++ b/src/main/java/net/sf/jabref/logic/auxparser/AuxParserResult.java
@@ -1,12 +1,14 @@
 package net.sf.jabref.logic.auxparser;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.database.BibDatabase;
+import net.sf.jabref.model.entry.BibtexString;
 
 public class AuxParserResult {
 
@@ -17,6 +19,7 @@ public class AuxParserResult {
     private final BibDatabase auxDatabase = new BibDatabase();
     private int nestedAuxCount;
     private int crossRefEntriesCount;
+    private int insertedStrings;
 
     public AuxParserResult(BibDatabase masterDatabase) {
         this.masterDatabase = masterDatabase;
@@ -42,6 +45,10 @@ public class AuxParserResult {
         return unresolvedKeys.size();
     }
 
+    public int getInsertedStringsCount() {
+        return insertedStrings;
+    }
+
     /**
      * Query the number of extra entries pulled in due to crossrefs from other entries.
      *
@@ -59,6 +66,13 @@ public class AuxParserResult {
         nestedAuxCount++;
     }
 
+    public void insertStrings(Collection<BibtexString> usedStrings) {
+        for (BibtexString string : usedStrings) {
+            auxDatabase.addString(string);
+            insertedStrings++;
+        }
+    }
+
     /**
      * Prints parsing statistics
      *
@@ -73,7 +87,8 @@ public class AuxParserResult {
                 .append(Localization.lang("resolved")).append(' ').append(getResolvedKeysCount()).append('\n')
                 .append(Localization.lang("not_found")).append(' ').append(getUnresolvedKeysCount()).append('\n')
                 .append(Localization.lang("crossreferenced entries included")).append(' ')
-                .append(crossRefEntriesCount).append('\n');
+                .append(crossRefEntriesCount).append(Localization.lang("strings included")).append(' ')
+                .append(insertedStrings).append('\n');
 
         if (includeMissingEntries && (getUnresolvedKeysCount() > 0)) {
             for (String entry : unresolvedKeys) {

--- a/src/test/java/net/sf/jabref/model/database/BibDatabaseTest.java
+++ b/src/test/java/net/sf/jabref/model/database/BibDatabaseTest.java
@@ -4,7 +4,10 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.importer.ParserResult;
@@ -316,5 +319,53 @@ public class BibDatabaseTest {
         BibtexString string = new BibtexString(IdGenerator.next(), "AAA", "aaa");
         database.addString(string);
         assertEquals(database.resolveForStrings("AAA#AAA#AAA#"), "AAAaaaAAA#");
+    }
+
+    @Test
+    public void getUsedStringsSingleStringWithString() {
+        BibEntry entry = new BibEntry(IdGenerator.next());
+        entry.setField("author", "#AAA#");
+        BibtexString string = new BibtexString(IdGenerator.next(), "AAA", "Some other #BBB#");
+        BibtexString string2 = new BibtexString(IdGenerator.next(), "BBB", "Some more text");
+        BibtexString string3 = new BibtexString(IdGenerator.next(), "CCC", "Even more text");
+        database.addString(string);
+        database.addString(string2);
+        database.addString(string3);
+        database.insertEntry(entry);
+        List<BibtexString> usedStrings = (List<BibtexString>) database.getUsedStrings(Arrays.asList(entry));
+        assertEquals(2, usedStrings.size());
+        assertTrue((string.getName() == usedStrings.get(0).getName())
+                || (string.getName() == usedStrings.get(1).getName()));
+        assertTrue((string2.getName() == usedStrings.get(0).getName())
+                || (string2.getName() == usedStrings.get(1).getName()));
+        assertTrue((string.getContent() == usedStrings.get(0).getContent())
+                || (string.getContent() == usedStrings.get(1).getContent()));
+        assertTrue((string2.getContent() == usedStrings.get(0).getContent())
+                || (string2.getContent() == usedStrings.get(1).getContent()));
+    }
+
+    @Test
+    public void getUsedStringsSingleString() {
+        BibEntry entry = new BibEntry(IdGenerator.next());
+        entry.setField("author", "#AAA#");
+        BibtexString string = new BibtexString(IdGenerator.next(), "AAA", "Some other text");
+        BibtexString string2 = new BibtexString(IdGenerator.next(), "BBB", "Some more text");
+        database.addString(string);
+        database.addString(string2);
+        database.insertEntry(entry);
+        List<BibtexString> usedStrings = (List<BibtexString>) database.getUsedStrings(Arrays.asList(entry));
+        assertEquals(string.getName(), usedStrings.get(0).getName());
+        assertEquals(string.getContent(), usedStrings.get(0).getContent());
+    }
+
+    @Test
+    public void getUsedStringsNoString() {
+        BibEntry entry = new BibEntry(IdGenerator.next());
+        entry.setField("author", "Oscar Gustafsson");
+        BibtexString string = new BibtexString(IdGenerator.next(), "AAA", "Some other text");
+        database.addString(string);
+        database.insertEntry(entry);
+        Collection<BibtexString> usedStrings = database.getUsedStrings(Arrays.asList(entry));
+        assertEquals(Collections.emptyList(), usedStrings);
     }
 }

--- a/src/test/resources/net/sf/jabref/logic/auxparser/config.bib
+++ b/src/test/resources/net/sf/jabref/logic/auxparser/config.bib
@@ -1,5 +1,6 @@
 @String {maintainer = "Stefan Kolb"}
 @preamble {"Maintained by " # maintainer}
+@String {einstein = "Einstein, Albert"}
 
 @Book{Newton1999,
   title =     {The Principia: mathematical principles of natural philosophy},
@@ -19,7 +20,7 @@
   title =     {Relativity: The special and general theory},
   publisher = {Penguin},
   year =      {1920},
-  author =    {Einstein, Albert}
+  author =    einstein
 }
 
 @Comment{jabref-meta: databaseType:bibtex;}


### PR DESCRIPTION
I'm making a method to properly copy entries from one database to another, including crossref entries and used strings. This is useful in generating a database from an aux file and for generating a database based on an OO/LO document. It could also be useful for generating a subdatabase from selected entries (or copying relevant strings when copying entries).

There are some problems though related to the preamble. In OO/LO the entries may come from several databases and there it is not obvious how to deal with the preamble. However, a possibly solvable problem is to detect which strings are used in the preamble.

In AuxParserTest @stefan-kolb have generated a test file with a string in the preamble. JabRef doesn't parse this in a way such that the string can be resolved automatically. Earlier, the preamble and all strings were copied in AuxParser, but I was hoping to only copy the relevant strings. Any input on how the preamble issue should be solved? One way would simply be to parse the preamble for strings, I guess. Any other suggestions?
- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
