### PR TITLE
Group names can now be rendered using LaTeXs commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - The arXiv fetcher now also supports free-text search queries
 - [#1345](https://github.com/JabRef/jabref/issues/1345) Cleanup ISSN
 - It is now possible to add your own lists of protected terms, see Options -> Manage protected terms
+- Automatically generated group names are now converted from LaTeX to Unicode
 
 ### Fixed
 - Fixed [#1632](https://github.com/JabRef/jabref/issues/1632) User comments (@Comment) with or without brackets are now kept

--- a/src/main/java/net/sf/jabref/gui/groups/AutoGroupDialog.java
+++ b/src/main/java/net/sf/jabref/gui/groups/AutoGroupDialog.java
@@ -49,6 +49,7 @@ import net.sf.jabref.logic.groups.GroupTreeNode;
 import net.sf.jabref.logic.groups.GroupsUtil;
 import net.sf.jabref.logic.groups.KeywordGroup;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.layout.format.LatexToUnicodeFormatter;
 import net.sf.jabref.model.entry.FieldName;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
@@ -72,6 +73,8 @@ class AutoGroupDialog extends JDialog implements CaretListener {
     private final GroupTreeNodeViewModel m_groupsRoot;
     private final JabRefFrame frame;
     private final BasePanel panel;
+
+    private static final LatexToUnicodeFormatter FORMATTER = new LatexToUnicodeFormatter();
 
 
     /**
@@ -121,7 +124,7 @@ class AutoGroupDialog extends JDialog implements CaretListener {
                     }
 
                     for (String keyword : hs) {
-                        KeywordGroup group = new KeywordGroup(keyword, fieldText, keyword, false, false,
+                        KeywordGroup group = new KeywordGroup(FORMATTER.format(keyword), fieldText, keyword, false, false,
                                 GroupHierarchyType.INDEPENDENT, Globals.prefs);
                         autoGroupsRoot.addChild(GroupTreeNode.fromGroup(group));
                     }

--- a/src/main/java/net/sf/jabref/gui/groups/AutoGroupDialog.java
+++ b/src/main/java/net/sf/jabref/gui/groups/AutoGroupDialog.java
@@ -74,8 +74,6 @@ class AutoGroupDialog extends JDialog implements CaretListener {
     private final JabRefFrame frame;
     private final BasePanel panel;
 
-    private static final LatexToUnicodeFormatter FORMATTER = new LatexToUnicodeFormatter();
-
 
     /**
      * @param groupsRoot The original set of groups, which is required as undo information when all groups are cleared.
@@ -123,8 +121,10 @@ class AutoGroupDialog extends JDialog implements CaretListener {
                         fieldText = FieldName.EDITOR;
                     }
 
+                    LatexToUnicodeFormatter formatter = new LatexToUnicodeFormatter();
+
                     for (String keyword : hs) {
-                        KeywordGroup group = new KeywordGroup(FORMATTER.format(keyword), fieldText, keyword, false, false,
+                        KeywordGroup group = new KeywordGroup(formatter.format(keyword), fieldText, keyword, false, false,
                                 GroupHierarchyType.INDEPENDENT, Globals.prefs);
                         autoGroupsRoot.addChild(GroupTreeNode.fromGroup(group));
                     }


### PR DESCRIPTION
Inspired by #1681 

- [x] Change in CHANGELOG.md described
- [x] Manually tested changed features in running JabRef

