### PR TITLE
Removed dependencies of Globals.prefs in some tests

### DIFF
--- a/src/main/java/net/sf/jabref/logic/openoffice/OpenOfficePreferences.java
+++ b/src/main/java/net/sf/jabref/logic/openoffice/OpenOfficePreferences.java
@@ -133,6 +133,9 @@ public class OpenOfficePreferences {
         return preferences.get(JabRefPreferences.OO_BIBLIOGRAPHY_STYLE_FILE);
     }
 
+    public void clearCurrentStyle() {
+        preferences.remove(JabRefPreferences.OO_BIBLIOGRAPHY_STYLE_FILE);
+    }
     public void setCurrentStyle(String path) {
         preferences.put(JabRefPreferences.OO_BIBLIOGRAPHY_STYLE_FILE, path);
     }

--- a/src/test/java/net/sf/jabref/logic/bibtex/EntryTypesTestBibLatex.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/EntryTypesTestBibLatex.java
@@ -2,37 +2,18 @@ package net.sf.jabref.logic.bibtex;
 
 import java.util.Optional;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibLatexEntryTypes;
-import net.sf.jabref.preferences.JabRefPreferences;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 public class EntryTypesTestBibLatex {
 
-    private JabRefPreferences backup;
-
-
-    @Before
-    public void setUp() throws Exception {
-        Globals.prefs = JabRefPreferences.getInstance();
-        backup = Globals.prefs;
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        Globals.prefs.overwritePreferences(backup);
-    }
 
     @Test
-    @Ignore
     public void testBibLatexMode() {
         // BibLatex mode
         assertEquals(BibLatexEntryTypes.ARTICLE, EntryTypes.getType("article", BibDatabaseMode.BIBLATEX).get());

--- a/src/test/java/net/sf/jabref/logic/bibtex/EntryTypesTestBibtex.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/EntryTypesTestBibtex.java
@@ -4,15 +4,11 @@ import java.util.ArrayList;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.CustomEntryType;
-import net.sf.jabref.preferences.JabRefPreferences;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -20,20 +16,6 @@ import static org.junit.Assert.assertNotEquals;
 
 
 public class EntryTypesTestBibtex {
-
-    private JabRefPreferences backup;
-
-
-    @Before
-    public void setUp() throws Exception {
-        Globals.prefs = JabRefPreferences.getInstance();
-        backup = Globals.prefs;
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        Globals.prefs.overwritePreferences(backup);
-    }
 
     @Test
     public void testBibtexMode() {

--- a/src/test/java/net/sf/jabref/logic/bibtex/FieldContentParserTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/FieldContentParserTest.java
@@ -1,11 +1,10 @@
 package net.sf.jabref.logic.bibtex;
 
-import net.sf.jabref.Globals;
+import java.util.Collections;
+
 import net.sf.jabref.logic.util.OS;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -13,15 +12,12 @@ import static org.junit.Assert.assertEquals;
 public class FieldContentParserTest {
 
     private FieldContentParser parser;
-
-    @BeforeClass
-    public static void loadPreferences() {
-        Globals.prefs = JabRefPreferences.getInstance();
-    }
+    private FieldContentParserPreferences prefs;
 
     @Before
     public void setUp() throws Exception {
-        parser = new FieldContentParser(FieldContentParserPreferences.fromPreferences(Globals.prefs));
+        prefs = new FieldContentParserPreferences(Collections.emptyList());
+        parser = new FieldContentParser(prefs);
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/formatter/FormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/FormatterTest.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.formatter.bibtexfields.ClearFormatter;
 import net.sf.jabref.logic.formatter.bibtexfields.HtmlToLatexFormatter;
 import net.sf.jabref.logic.formatter.bibtexfields.HtmlToUnicodeFormatter;
@@ -27,7 +26,6 @@ import net.sf.jabref.logic.formatter.minifier.MinifyNameListFormatter;
 import net.sf.jabref.logic.layout.format.LatexToUnicodeFormatter;
 import net.sf.jabref.logic.protectedterms.ProtectedTermsLoader;
 import net.sf.jabref.logic.protectedterms.ProtectedTermsPreferences;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -51,7 +49,6 @@ public class FormatterTest {
 
     @BeforeClass
     public static void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
         ProtectTermsFormatter
                 .setProtectedTermsLoader(
                         new ProtectedTermsLoader(new ProtectedTermsPreferences(ProtectedTermsLoader.getInternalLists(),

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/HtmlToLatexFormatterTest.java
@@ -1,10 +1,6 @@
 package net.sf.jabref.logic.formatter.bibtexfields;
 
-import net.sf.jabref.Globals;
-import net.sf.jabref.preferences.JabRefPreferences;
-
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -15,11 +11,6 @@ import static org.junit.Assert.assertEquals;
 public class HtmlToLatexFormatterTest {
 
     private HtmlToLatexFormatter formatter;
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-        Globals.prefs = JabRefPreferences.getInstance();
-    }
 
     @Before
     public void setUp() {

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/UnicodeConverterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/UnicodeConverterTest.java
@@ -1,10 +1,6 @@
 package net.sf.jabref.logic.formatter.bibtexfields;
 
-import net.sf.jabref.Globals;
-import net.sf.jabref.preferences.JabRefPreferences;
-
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -16,11 +12,6 @@ import static org.junit.Assert.assertEquals;
 public class UnicodeConverterTest {
 
     private  UnicodeToLatexFormatter formatter;
-
-    @BeforeClass
-    public static void setUpBeforeClass() {
-        Globals.prefs = JabRefPreferences.getInstance();
-    }
 
     @Before
     public void setUp() {

--- a/src/test/java/net/sf/jabref/logic/groups/ExplicitGroupTest.java
+++ b/src/test/java/net/sf/jabref/logic/groups/ExplicitGroupTest.java
@@ -1,33 +1,29 @@
 package net.sf.jabref.logic.groups;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.importer.fileformat.ParseException;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.preferences.JabRefPreferences;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 public class ExplicitGroupTest {
 
-    @Before
-    public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
-    }
 
     @Test
      public void testToStringSimple() throws ParseException {
-        ExplicitGroup group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INDEPENDENT, Globals.prefs);
+        ExplicitGroup group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INDEPENDENT,
+                JabRefPreferences.getInstance());
         assertEquals("ExplicitGroup:myExplicitGroup;0;", group.toString());
     }
 
     @Test
     public void toStringDoesNotWriteAssignedEntries() throws ParseException {
-        ExplicitGroup group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INCLUDING, Globals.prefs);
+        ExplicitGroup group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INCLUDING,
+                JabRefPreferences.getInstance());
         group.add(makeBibtexEntry());
         assertEquals("ExplicitGroup:myExplicitGroup;2;", group.toString());
     }

--- a/src/test/java/net/sf/jabref/logic/groups/GroupTreeNodeTest.java
+++ b/src/test/java/net/sf/jabref/logic/groups/GroupTreeNodeTest.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.importer.fileformat.ParseException;
 import net.sf.jabref.logic.search.matchers.AndMatcher;
 import net.sf.jabref.logic.search.matchers.OrMatcher;
@@ -31,8 +30,6 @@ public class GroupTreeNodeTest {
         entries.add(entry);
         entries.add(new BibEntry().withField("author", "author1 and author2"));
         entries.add(new BibEntry().withField("author", "author1"));
-
-        Globals.prefs = JabRefPreferences.getInstance();
     }
 
 
@@ -44,11 +41,13 @@ public class GroupTreeNodeTest {
      *          B ExplicitNode, Refining (<-- this)
      */
     private GroupTreeNode getNodeInSimpleTree(GroupTreeNode root) throws ParseException {
-        root.addSubgroup(new ExplicitGroup("ExplicitA", GroupHierarchyType.INCLUDING, Globals.prefs));
+        root.addSubgroup(new ExplicitGroup("ExplicitA", GroupHierarchyType.INCLUDING, JabRefPreferences.getInstance()));
         GroupTreeNode parent = root
-                .addSubgroup(new ExplicitGroup("ExplicitParent", GroupHierarchyType.INDEPENDENT, Globals.prefs));
+                .addSubgroup(new ExplicitGroup("ExplicitParent", GroupHierarchyType.INDEPENDENT,
+                        JabRefPreferences.getInstance()));
         GroupTreeNode node = parent
-                .addSubgroup(new ExplicitGroup("ExplicitNode", GroupHierarchyType.REFINING, Globals.prefs));
+                .addSubgroup(new ExplicitGroup("ExplicitNode", GroupHierarchyType.REFINING,
+                        JabRefPreferences.getInstance()));
         return node;
     }
 
@@ -75,9 +74,10 @@ public class GroupTreeNodeTest {
      */
     private GroupTreeNode getNodeInComplexTree(GroupTreeNode root) throws ParseException {
         root.addSubgroup(getSearchGroup("SearchA"));
-        root.addSubgroup(new ExplicitGroup("ExplicitA", GroupHierarchyType.INCLUDING, Globals.prefs));
+        root.addSubgroup(new ExplicitGroup("ExplicitA", GroupHierarchyType.INCLUDING, JabRefPreferences.getInstance()));
         GroupTreeNode grandParent = root
-                .addSubgroup(new ExplicitGroup("ExplicitGrandParent", GroupHierarchyType.INDEPENDENT, Globals.prefs));
+                .addSubgroup(new ExplicitGroup("ExplicitGrandParent", GroupHierarchyType.INDEPENDENT,
+                        JabRefPreferences.getInstance()));
         root.addSubgroup(getKeywordGroup("KeywordA"));
 
         grandParent.addSubgroup(getExplict("ExplicitB"));
@@ -96,7 +96,7 @@ public class GroupTreeNodeTest {
 
     private AbstractGroup getKeywordGroup(String name) throws ParseException {
         return new KeywordGroup(name, "searchField", "searchExpression", true, false, GroupHierarchyType.INDEPENDENT,
-                Globals.prefs);
+                JabRefPreferences.getInstance());
     }
 
     private AbstractGroup getSearchGroup(String name) {
@@ -104,7 +104,7 @@ public class GroupTreeNodeTest {
     }
 
     private AbstractGroup getExplict(String name) throws ParseException {
-        return new ExplicitGroup(name, GroupHierarchyType.REFINING, Globals.prefs);
+        return new ExplicitGroup(name, GroupHierarchyType.REFINING, JabRefPreferences.getInstance());
     }
 
     /*
@@ -176,15 +176,17 @@ public class GroupTreeNodeTest {
     @Test
     public void getSearchRuleForIndependentGroupReturnsGroupAsMatcher() throws ParseException {
         GroupTreeNode node = GroupTreeNode
-                .fromGroup(new ExplicitGroup("node", GroupHierarchyType.INDEPENDENT, Globals.prefs));
+                .fromGroup(new ExplicitGroup("node", GroupHierarchyType.INDEPENDENT, JabRefPreferences.getInstance()));
         assertEquals(node.getGroup(), node.getSearchRule());
     }
 
     @Test
     public void getSearchRuleForRefiningGroupReturnsParentAndGroupAsMatcher() throws ParseException {
         GroupTreeNode parent = GroupTreeNode
-                .fromGroup(new ExplicitGroup("parent", GroupHierarchyType.INDEPENDENT, Globals.prefs));
-        GroupTreeNode node = parent.addSubgroup(new ExplicitGroup("node", GroupHierarchyType.REFINING, Globals.prefs));
+                .fromGroup(
+                        new ExplicitGroup("parent", GroupHierarchyType.INDEPENDENT, JabRefPreferences.getInstance()));
+        GroupTreeNode node = parent
+                .addSubgroup(new ExplicitGroup("node", GroupHierarchyType.REFINING, JabRefPreferences.getInstance()));
 
         AndMatcher matcher = new AndMatcher();
         matcher.addRule(node.getGroup());
@@ -195,9 +197,10 @@ public class GroupTreeNodeTest {
     @Test
     public void getSearchRuleForIncludingGroupReturnsGroupOrSubgroupAsMatcher() throws ParseException {
         GroupTreeNode node = GroupTreeNode
-                .fromGroup(new ExplicitGroup("node", GroupHierarchyType.INCLUDING, Globals.prefs));
+                .fromGroup(new ExplicitGroup("node", GroupHierarchyType.INCLUDING, JabRefPreferences.getInstance()));
         GroupTreeNode child = node
-                .addSubgroup(new ExplicitGroup("child", GroupHierarchyType.INDEPENDENT, Globals.prefs));
+                .addSubgroup(
+                        new ExplicitGroup("child", GroupHierarchyType.INDEPENDENT, JabRefPreferences.getInstance()));
 
         OrMatcher matcher = new OrMatcher();
         matcher.addRule(node.getGroup());
@@ -215,7 +218,7 @@ public class GroupTreeNodeTest {
         GroupTreeNode parent = getNodeInSimpleTree();
         GroupTreeNode node = parent.addSubgroup(
                 new KeywordGroup("node", "author", "author2", true, false, GroupHierarchyType.INDEPENDENT,
-                        Globals.prefs));
+                        JabRefPreferences.getInstance()));
         assertEquals(1, node.numberOfHits(entries));
     }
 
@@ -224,7 +227,7 @@ public class GroupTreeNodeTest {
         GroupTreeNode parent = getNodeInSimpleTree();
         GroupTreeNode node = parent.addSubgroup(
                 new KeywordGroup("node", "author", "author1", true, false, GroupHierarchyType.INDEPENDENT,
-                        Globals.prefs));
+                        JabRefPreferences.getInstance()));
         assertEquals(2, node.numberOfHits(entries));
     }
 
@@ -233,9 +236,10 @@ public class GroupTreeNodeTest {
         GroupTreeNode grandParent = getNodeInSimpleTree();
         GroupTreeNode parent = grandParent.addSubgroup(
                 new KeywordGroup("node", "author", "author2", true, false, GroupHierarchyType.INDEPENDENT,
-                        Globals.prefs));
+                        JabRefPreferences.getInstance()));
         GroupTreeNode node = parent.addSubgroup(
-                new KeywordGroup("node", "author", "author1", true, false, GroupHierarchyType.REFINING, Globals.prefs));
+                new KeywordGroup("node", "author", "author1", true, false, GroupHierarchyType.REFINING,
+                        JabRefPreferences.getInstance()));
         assertEquals(1, node.numberOfHits(entries));
     }
 
@@ -244,17 +248,18 @@ public class GroupTreeNodeTest {
         GroupTreeNode grandParent = getNodeInSimpleTree();
         GroupTreeNode parent = grandParent.addSubgroup(
                 new KeywordGroup("node", "author", "author2", true, false, GroupHierarchyType.INDEPENDENT,
-                        Globals.prefs));
+                        JabRefPreferences.getInstance()));
         GroupTreeNode node = parent.addSubgroup(
                 new KeywordGroup("node", "author", "author1", true, false, GroupHierarchyType.INDEPENDENT,
-                        Globals.prefs));
+                        JabRefPreferences.getInstance()));
         assertEquals(2, node.numberOfHits(entries));
     }
 
     @Test
     public void setGroupChangesUnderlyingGroup() throws Exception {
         GroupTreeNode node = getNodeInSimpleTree();
-        AbstractGroup newGroup = new ExplicitGroup("NewGroup", GroupHierarchyType.INDEPENDENT, Globals.prefs);
+        AbstractGroup newGroup = new ExplicitGroup("NewGroup", GroupHierarchyType.INDEPENDENT,
+                JabRefPreferences.getInstance());
 
         node.setGroup(newGroup, true, entries);
 
@@ -263,10 +268,12 @@ public class GroupTreeNodeTest {
 
     @Test
     public void setGroupAddsPreviousAssignmentsExplicitToExplicit() throws Exception {
-        AbstractGroup oldGroup = new ExplicitGroup("OldGroup", GroupHierarchyType.INDEPENDENT, Globals.prefs);
+        AbstractGroup oldGroup = new ExplicitGroup("OldGroup", GroupHierarchyType.INDEPENDENT,
+                JabRefPreferences.getInstance());
         oldGroup.add(entry);
         GroupTreeNode node = GroupTreeNode.fromGroup(oldGroup);
-        AbstractGroup newGroup = new ExplicitGroup("NewGroup", GroupHierarchyType.INDEPENDENT, Globals.prefs);
+        AbstractGroup newGroup = new ExplicitGroup("NewGroup", GroupHierarchyType.INDEPENDENT,
+                JabRefPreferences.getInstance());
 
         node.setGroup(newGroup, true, entries);
 
@@ -275,10 +282,12 @@ public class GroupTreeNodeTest {
 
     @Test
     public void setGroupWithFalseDoesNotAddsPreviousAssignments() throws Exception {
-        AbstractGroup oldGroup = new ExplicitGroup("OldGroup", GroupHierarchyType.INDEPENDENT, Globals.prefs);
+        AbstractGroup oldGroup = new ExplicitGroup("OldGroup", GroupHierarchyType.INDEPENDENT,
+                JabRefPreferences.getInstance());
         oldGroup.add(entry);
         GroupTreeNode node = GroupTreeNode.fromGroup(oldGroup);
-        AbstractGroup newGroup = new ExplicitGroup("NewGroup", GroupHierarchyType.INDEPENDENT, Globals.prefs);
+        AbstractGroup newGroup = new ExplicitGroup("NewGroup", GroupHierarchyType.INDEPENDENT,
+                JabRefPreferences.getInstance());
 
         node.setGroup(newGroup, false, entries);
 
@@ -287,10 +296,12 @@ public class GroupTreeNodeTest {
 
     @Test
     public void setGroupAddsOnlyPreviousAssignments() throws Exception {
-        AbstractGroup oldGroup = new ExplicitGroup("OldGroup", GroupHierarchyType.INDEPENDENT, Globals.prefs);
+        AbstractGroup oldGroup = new ExplicitGroup("OldGroup", GroupHierarchyType.INDEPENDENT,
+                JabRefPreferences.getInstance());
         assertFalse(oldGroup.isMatch(entry));
         GroupTreeNode node = GroupTreeNode.fromGroup(oldGroup);
-        AbstractGroup newGroup = new ExplicitGroup("NewGroup", GroupHierarchyType.INDEPENDENT, Globals.prefs);
+        AbstractGroup newGroup = new ExplicitGroup("NewGroup", GroupHierarchyType.INDEPENDENT,
+                JabRefPreferences.getInstance());
 
         node.setGroup(newGroup, true, entries);
 
@@ -299,7 +310,8 @@ public class GroupTreeNodeTest {
 
     @Test
     public void setGroupExplicitToSearchDoesNotKeepPreviousAssignments() throws Exception {
-        AbstractGroup oldGroup = new ExplicitGroup("OldGroup", GroupHierarchyType.INDEPENDENT, Globals.prefs);
+        AbstractGroup oldGroup = new ExplicitGroup("OldGroup", GroupHierarchyType.INDEPENDENT,
+                JabRefPreferences.getInstance());
         oldGroup.add(entry);
         GroupTreeNode node = GroupTreeNode.fromGroup(oldGroup);
         AbstractGroup newGroup = new SearchGroup("NewGroup", "test", false, false, GroupHierarchyType.INDEPENDENT);
@@ -311,10 +323,12 @@ public class GroupTreeNodeTest {
 
     @Test
     public void setGroupExplicitToExplicitIsRenameAndSoRemovesPreviousAssignment() throws Exception {
-        AbstractGroup oldGroup = new ExplicitGroup("OldGroup", GroupHierarchyType.INDEPENDENT, Globals.prefs);
+        AbstractGroup oldGroup = new ExplicitGroup("OldGroup", GroupHierarchyType.INDEPENDENT,
+                JabRefPreferences.getInstance());
         oldGroup.add(entry);
         GroupTreeNode node = GroupTreeNode.fromGroup(oldGroup);
-        AbstractGroup newGroup = new ExplicitGroup("NewGroup", GroupHierarchyType.INDEPENDENT, Globals.prefs);
+        AbstractGroup newGroup = new ExplicitGroup("NewGroup", GroupHierarchyType.INDEPENDENT,
+                JabRefPreferences.getInstance());
 
         node.setGroup(newGroup, true, entries);
 

--- a/src/test/java/net/sf/jabref/logic/groups/KeywordGroupTest.java
+++ b/src/test/java/net/sf/jabref/logic/groups/KeywordGroupTest.java
@@ -1,8 +1,8 @@
 package net.sf.jabref.logic.groups;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.importer.fileformat.ParseException;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Test;
 
@@ -14,21 +14,21 @@ public class KeywordGroupTest {
     @Test
     public void testToString() throws ParseException {
         KeywordGroup group = new KeywordGroup("myExplicitGroup", "author","asdf", true, true,
-                GroupHierarchyType.INDEPENDENT, Globals.prefs);
+                GroupHierarchyType.INDEPENDENT, JabRefPreferences.getInstance());
         assertEquals("KeywordGroup:myExplicitGroup;0;author;asdf;1;1;", group.toString());
     }
 
     @Test
     public void testToString2() throws ParseException {
         KeywordGroup group = new KeywordGroup("myExplicitGroup", "author","asdf", false, true,
-                GroupHierarchyType.REFINING, Globals.prefs);
+                GroupHierarchyType.REFINING, JabRefPreferences.getInstance());
         assertEquals("KeywordGroup:myExplicitGroup;1;author;asdf;0;1;", group.toString());
     }
 
     @Test
     public void containsSimpleWord() throws Exception {
         KeywordGroup group = new KeywordGroup("name", "keywords", "test", false, false, GroupHierarchyType.INDEPENDENT,
-                Globals.prefs);
+                JabRefPreferences.getInstance());
         BibEntry entry = new BibEntry().withField("keywords", "test");
 
         assertTrue(group.isMatch(entry));
@@ -37,7 +37,7 @@ public class KeywordGroupTest {
     @Test
     public void containsSimpleWordInSentence() throws Exception {
         KeywordGroup group = new KeywordGroup("name", "keywords", "test", false, false, GroupHierarchyType.INDEPENDENT,
-                Globals.prefs);
+                JabRefPreferences.getInstance());
         BibEntry entry = new BibEntry().withField("keywords", "Some sentence containing test word");
 
         assertTrue(group.isMatch(entry));
@@ -46,7 +46,7 @@ public class KeywordGroupTest {
     @Test
     public void containsSimpleWordCommaSeparated() throws Exception {
         KeywordGroup group = new KeywordGroup("name", "keywords", "test", false, false, GroupHierarchyType.INDEPENDENT,
-                Globals.prefs);
+                JabRefPreferences.getInstance());
         BibEntry entry = new BibEntry().withField("keywords", "Some,list,containing,test,word");
 
         assertTrue(group.isMatch(entry));
@@ -55,7 +55,7 @@ public class KeywordGroupTest {
     @Test
     public void containsSimpleWordSemicolonSeparated() throws Exception {
         KeywordGroup group = new KeywordGroup("name", "keywords", "test", false, false, GroupHierarchyType.INDEPENDENT,
-                Globals.prefs);
+                JabRefPreferences.getInstance());
         BibEntry entry = new BibEntry().withField("keywords", "Some;list;containing;test;word");
 
         assertTrue(group.isMatch(entry));
@@ -64,7 +64,7 @@ public class KeywordGroupTest {
     @Test
     public void containsComplexWord() throws Exception {
         KeywordGroup group = new KeywordGroup("name", "keywords", "\\H2O", false, false, GroupHierarchyType.INDEPENDENT,
-                Globals.prefs);
+                JabRefPreferences.getInstance());
         BibEntry entry = new BibEntry().withField("keywords", "\\H2O");
 
         assertTrue(group.isMatch(entry));
@@ -73,7 +73,7 @@ public class KeywordGroupTest {
     @Test
     public void containsComplexWordInSentence() throws Exception {
         KeywordGroup group = new KeywordGroup("name", "keywords", "\\H2O", false, false, GroupHierarchyType.INDEPENDENT,
-                Globals.prefs);
+                JabRefPreferences.getInstance());
         BibEntry entry = new BibEntry().withField("keywords", "Some sentence containing \\H2O word");
 
         assertTrue(group.isMatch(entry));
@@ -82,7 +82,7 @@ public class KeywordGroupTest {
     @Test
     public void containsWordWithWhitespaceInSentence() throws Exception {
         KeywordGroup group = new KeywordGroup("name", "keywords", "test word", false, false,
-                GroupHierarchyType.INDEPENDENT, Globals.prefs);
+                GroupHierarchyType.INDEPENDENT, JabRefPreferences.getInstance());
         BibEntry entry = new BibEntry().withField("keywords", "Some sentence containing test word");
 
         assertTrue(group.isMatch(entry));

--- a/src/test/java/net/sf/jabref/logic/groups/SearchGroupTest.java
+++ b/src/test/java/net/sf/jabref/logic/groups/SearchGroupTest.java
@@ -1,10 +1,7 @@
 package net.sf.jabref.logic.groups;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.preferences.JabRefPreferences;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -13,10 +10,6 @@ import static org.junit.Assert.assertTrue;
 
 public class SearchGroupTest {
 
-    @BeforeClass
-    public static void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
-    }
 
     @Test
     public void testContains() {

--- a/src/test/java/net/sf/jabref/logic/journals/AbbreviationsTest.java
+++ b/src/test/java/net/sf/jabref/logic/journals/AbbreviationsTest.java
@@ -1,6 +1,5 @@
 package net.sf.jabref.logic.journals;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
@@ -20,7 +19,6 @@ public class AbbreviationsTest {
 
     @Before
     public void setUp() throws Exception {
-        Globals.prefs = prefs;
         abbreviations = new JournalAbbreviationLoader();
     }
 
@@ -29,7 +27,7 @@ public class AbbreviationsTest {
         when(prefs.getBoolean(JabRefPreferences.USE_IEEE_ABRV)).thenReturn(true);
 
         assertEquals("#IEEE_J_PROC#",
-                abbreviations.getRepository(JournalAbbreviationPreferences.fromPreferences(Globals.prefs))
+                abbreviations.getRepository(JournalAbbreviationPreferences.fromPreferences(prefs))
                         .getNextAbbreviation("Proceedings of the IEEE").get());
     }
 
@@ -38,28 +36,28 @@ public class AbbreviationsTest {
         when(prefs.getBoolean(JabRefPreferences.USE_IEEE_ABRV)).thenReturn(true);
 
         assertEquals("Proceedings of the IEEE",
-                abbreviations.getRepository(JournalAbbreviationPreferences.fromPreferences(Globals.prefs))
+                abbreviations.getRepository(JournalAbbreviationPreferences.fromPreferences(prefs))
                         .getNextAbbreviation("#IEEE_J_PROC#").get());
     }
 
     @Test
     public void getNextAbbreviationAbbreviatesJournalTitle() {
         assertEquals("Proc. IEEE",
-                abbreviations.getRepository(JournalAbbreviationPreferences.fromPreferences(Globals.prefs))
+                abbreviations.getRepository(JournalAbbreviationPreferences.fromPreferences(prefs))
                         .getNextAbbreviation("Proceedings of the IEEE").get());
     }
 
     @Test
     public void getNextAbbreviationRemovesPoint() {
         assertEquals("Proc IEEE",
-                abbreviations.getRepository(JournalAbbreviationPreferences.fromPreferences(Globals.prefs))
+                abbreviations.getRepository(JournalAbbreviationPreferences.fromPreferences(prefs))
                         .getNextAbbreviation("Proc. IEEE").get());
     }
 
     @Test
     public void getNextAbbreviationExpandsAbbreviation() {
         assertEquals("Proceedings of the IEEE",
-                abbreviations.getRepository(JournalAbbreviationPreferences.fromPreferences(Globals.prefs))
+                abbreviations.getRepository(JournalAbbreviationPreferences.fromPreferences(prefs))
                         .getNextAbbreviation("Proc IEEE").get());
     }
 

--- a/src/test/java/net/sf/jabref/logic/labelpattern/LabelPatternUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/labelpattern/LabelPatternUtilTest.java
@@ -37,6 +37,7 @@ public class LabelPatternUtilTest {
     private static final String TITLE_STRING_CASED_TWO_SMALL_WORDS_ONE_CONNECTED_WORD = "Towards Choreography-based Process Distribution in the Cloud";
     private static final String TITLE_STRING_CASED_FOUR_SMALL_WORDS_TWO_CONNECTED_WORDS = "On the Measurement of Design-Time Adaptability for Process-Based Systems ";
 
+
     @BeforeClass
     public static void setUpGlobalsPrefs() {
         Globals.prefs = JabRefPreferences.getInstance();
@@ -705,26 +706,23 @@ public class LabelPatternUtilTest {
     }
 
     @Test
-    public void testCheckLegalKey2() {
-        // Enforce legal keys
+    public void testCheckLegalKeyEnforceLegal() {
         assertEquals("AAAA", LabelPatternUtil.checkLegalKey("AA AA", true));
         assertEquals("SPECIALCHARS", LabelPatternUtil.checkLegalKey("SPECIAL CHARS#{\\\"}~,^", true));
         assertEquals("", LabelPatternUtil.checkLegalKey("\n\t\r", true));
+    }
 
-        // Do not enforce legal keys
+    @Test
+    public void testCheckLegalKeyDoNotEnforceLegal() {
         assertEquals("AAAA", LabelPatternUtil.checkLegalKey("AA AA", false));
         assertEquals("SPECIALCHARS#~^", LabelPatternUtil.checkLegalKey("SPECIAL CHARS#{\\\"}~,^", false));
         assertEquals("", LabelPatternUtil.checkLegalKey("\n\t\r", false));
+    }
 
-        // Check null input
+    @Test
+    public void testCheckLegalNullInNullOut() {
         assertNull(LabelPatternUtil.checkLegalKey(null, true));
         assertNull(LabelPatternUtil.checkLegalKey(null, false));
-
-        // Use preferences setting
-        assertEquals("AAAA", LabelPatternUtil.checkLegalKey("AA AA",
-                Globals.prefs.getBoolean(JabRefPreferences.ENFORCE_LEGAL_BIBTEX_KEY)));
-        assertEquals("", LabelPatternUtil.checkLegalKey("\n\t\r",
-                Globals.prefs.getBoolean(JabRefPreferences.ENFORCE_LEGAL_BIBTEX_KEY)));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/layout/LayoutTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/LayoutTest.java
@@ -20,14 +20,17 @@ import static org.mockito.Mockito.mock;
 
 public class LayoutTest {
 
+    private LayoutFormatterPreferences prefs;
+
+
     /**
      * Initialize Preferences.
      */
     @Before
     public void setUp() {
-        if (Globals.prefs == null) {
-            Globals.prefs = JabRefPreferences.getInstance();
-        }
+        Globals.prefs = JabRefPreferences.getInstance();
+        prefs = LayoutFormatterPreferences.fromPreferences(JabRefPreferences.getInstance(),
+                mock(JournalAbbreviationLoader.class));
     }
 
     /**
@@ -53,8 +56,7 @@ public class LayoutTest {
 
         BibEntry be = LayoutTest.bibtexString2BibtexEntry(entry);
         StringReader sr = new StringReader(layoutFile.replace("__NEWLINE__", "\n"));
-        Layout layout = new LayoutHelper(sr,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)))
+        Layout layout = new LayoutHelper(sr, prefs)
                         .getLayoutFromText();
 
         return layout.doLayout(be, null);

--- a/src/test/java/net/sf/jabref/logic/layout/format/FileLinkTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/format/FileLinkTest.java
@@ -1,6 +1,5 @@
 package net.sf.jabref.logic.layout.format;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.layout.ParamLayoutFormatter;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -12,50 +11,52 @@ import static org.junit.Assert.assertEquals;
 
 public class FileLinkTest {
 
+    private FileLinkPreferences prefs;
     @Before
     public void setUp() throws Exception {
-        if (Globals.prefs == null) {
-            Globals.prefs = JabRefPreferences.getInstance();
-        }
+        prefs = FileLinkPreferences.fromPreferences(JabRefPreferences.getInstance());
     }
 
     @Test
     public void testEmpty() {
-        assertEquals("", new FileLink(FileLinkPreferences.fromPreferences(Globals.prefs)).format(""));
+        assertEquals("", new FileLink(prefs).format(""));
     }
 
     @Test
     public void testNull() {
-        assertEquals("", new FileLink(FileLinkPreferences.fromPreferences(Globals.prefs)).format(null));
+        assertEquals("",
+                new FileLink(prefs).format(null));
     }
 
     @Test
     public void testOnlyFilename() {
-        assertEquals("test.pdf", new FileLink(FileLinkPreferences.fromPreferences(Globals.prefs)).format("test.pdf"));
+        assertEquals("test.pdf",
+                new FileLink(prefs).format("test.pdf"));
     }
 
     @Test
     public void testCompleteRecord() {
         assertEquals("test.pdf",
-                new FileLink(FileLinkPreferences.fromPreferences(Globals.prefs)).format("paper:test.pdf:PDF"));
+                new FileLink(prefs)
+                        .format("paper:test.pdf:PDF"));
     }
 
     @Test
     public void testMultipleFiles() {
-        ParamLayoutFormatter a = new FileLink(FileLinkPreferences.fromPreferences(Globals.prefs));
+        ParamLayoutFormatter a = new FileLink(prefs);
         assertEquals("test.pdf", a.format("paper:test.pdf:PDF;presentation:pres.ppt:PPT"));
     }
 
     @Test
     public void testMultipleFilesPick() {
-        ParamLayoutFormatter a = new FileLink(FileLinkPreferences.fromPreferences(Globals.prefs));
+        ParamLayoutFormatter a = new FileLink(prefs);
         a.setArgument("ppt");
         assertEquals("pres.ppt", a.format("paper:test.pdf:PDF;presentation:pres.ppt:PPT"));
     }
 
     @Test
     public void testMultipleFilesPickNonExistant() {
-        ParamLayoutFormatter a = new FileLink(FileLinkPreferences.fromPreferences(Globals.prefs));
+        ParamLayoutFormatter a = new FileLink(prefs);
         a.setArgument("doc");
         assertEquals("", a.format("paper:test.pdf:PDF;presentation:pres.ppt:PPT"));
     }

--- a/src/test/java/net/sf/jabref/logic/net/URLDownloadTest.java
+++ b/src/test/java/net/sf/jabref/logic/net/URLDownloadTest.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
@@ -23,15 +22,10 @@ public class URLDownloadTest {
 
     @Test
     public void testStringDownload() throws IOException {
-        Globals.prefs = JabRefPreferences.getInstance();
-        try {
-            URLDownload dl = new URLDownload(new URL("http://www.google.com"));
+        URLDownload dl = new URLDownload(new URL("http://www.google.com"));
 
-            Assert.assertTrue("google.com should contain google",
-                    dl.downloadToString(Globals.prefs.getDefaultEncoding()).contains("Google"));
-        } finally {
-            Globals.prefs = null;
-        }
+        Assert.assertTrue("google.com should contain google",
+                dl.downloadToString(JabRefPreferences.getInstance().getDefaultEncoding()).contains("Google"));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/openoffice/OOBibStyleTest.java
+++ b/src/test/java/net/sf/jabref/logic/openoffice/OOBibStyleTest.java
@@ -25,7 +25,6 @@ import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -38,20 +37,18 @@ import static org.mockito.Mockito.mock;
 
 public class OOBibStyleTest {
 
+    private LayoutFormatterPreferences layoutFormatterPreferences;
+
+
     @Before
     public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
-    }
-
-    @After
-    public void tearDown() {
-        Globals.prefs = null;
+        layoutFormatterPreferences = LayoutFormatterPreferences.fromPreferences(JabRefPreferences.getInstance(),
+                mock(JournalAbbreviationLoader.class));
     }
 
     @Test
     public void testAuthorYear() throws IOException {
-        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+        OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH, layoutFormatterPreferences);
         assertTrue(style.isValid());
         assertTrue(style.isFromResource());
         assertFalse(style.isBibtexKeyCiteMarkers());
@@ -68,9 +65,8 @@ public class OOBibStyleTest {
         File defFile = Paths.get(JabRefMain.class.getResource(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH).toURI())
                 .toFile();
 
-        OOBibStyle style = new OOBibStyle(defFile,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)),
-                Globals.prefs.getDefaultEncoding());
+        OOBibStyle style = new OOBibStyle(defFile, layoutFormatterPreferences,
+                JabRefPreferences.getInstance().getDefaultEncoding());
         assertTrue(style.isValid());
         assertFalse(style.isFromResource());
         assertFalse(style.isBibtexKeyCiteMarkers());
@@ -85,7 +81,7 @@ public class OOBibStyleTest {
     public void testNumerical() throws IOException {
 
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
         assertTrue(style.isValid());
         assertFalse(style.isBibtexKeyCiteMarkers());
         assertFalse(style.isBoldCitations());
@@ -99,7 +95,7 @@ public class OOBibStyleTest {
     @Test
     public void testGetNumCitationMarker() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
         assertEquals("[1] ", style.getNumCitationMarker(Arrays.asList(1), -1, true));
         assertEquals("[1]", style.getNumCitationMarker(Arrays.asList(1), -1, false));
         assertEquals("[1] ", style.getNumCitationMarker(Arrays.asList(1), 0, true));
@@ -116,7 +112,7 @@ public class OOBibStyleTest {
     @Test
     public void testGetNumCitationMarkerUndefined() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
         assertEquals("[" + OOBibStyle.UNDEFINED_CITATION_MARKER + "; 2-4] ",
                 style.getNumCitationMarker(Arrays.asList(4, 2, 3, 0), 1, true));
 
@@ -134,7 +130,7 @@ public class OOBibStyleTest {
     @Test
     public void testGetCitProperty() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
         assertEquals(", ", style.getStringCitProperty("AuthorSeparator"));
         assertEquals(3, style.getIntCitProperty("MaxAuthors"));
         assertTrue(style.getBooleanCitProperty(OOBibStyle.MULTI_CITE_CHRONOLOGICAL));
@@ -146,10 +142,11 @@ public class OOBibStyleTest {
 
     @Test
     public void testGetCitationMarker() throws IOException {
+        Globals.prefs = JabRefPreferences.getInstance();
         Path testBibtexFile = Paths.get("src/test/resources/testbib/complex.bib");
         ParserResult result = BibtexParser.parse(ImportFormat.getReader(testBibtexFile, StandardCharsets.UTF_8));
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         BibDatabase db = result.getDatabase();
         for (BibEntry entry : db.getEntries()) {
@@ -167,10 +164,11 @@ public class OOBibStyleTest {
 
     @Test
     public void testLayout() throws IOException {
+        Globals.prefs = JabRefPreferences.getInstance();
         Path testBibtexFile = Paths.get("src/test/resources/testbib/complex.bib");
         ParserResult result = BibtexParser.parse(ImportFormat.getReader(testBibtexFile, StandardCharsets.UTF_8));
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
         BibDatabase db = result.getDatabase();
 
         Layout l = style.getReferenceFormat("default");
@@ -190,7 +188,7 @@ public class OOBibStyleTest {
     @Test
     public void testInstitutionAuthor() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
         BibDatabase database = new BibDatabase();
 
         Layout l = style.getReferenceFormat("article");
@@ -209,7 +207,7 @@ public class OOBibStyleTest {
     @Test
     public void testVonAuthor() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
         BibDatabase database = new BibDatabase();
 
         Layout l = style.getReferenceFormat("article");
@@ -228,7 +226,7 @@ public class OOBibStyleTest {
     @Test
     public void testInstitutionAuthorMarker() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -248,7 +246,7 @@ public class OOBibStyleTest {
     @Test
     public void testVonAuthorMarker() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -268,7 +266,7 @@ public class OOBibStyleTest {
     @Test
     public void testNullAuthorMarker() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -286,7 +284,7 @@ public class OOBibStyleTest {
     @Test
     public void testNullYearMarker() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -304,7 +302,7 @@ public class OOBibStyleTest {
     @Test
     public void testEmptyEntryMarker() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -321,7 +319,7 @@ public class OOBibStyleTest {
     @Test
     public void testGetCitationMarkerInParenthesisUniquefiers() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -357,7 +355,7 @@ public class OOBibStyleTest {
     @Test
     public void testGetCitationMarkerInTextUniquefiers() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -393,7 +391,7 @@ public class OOBibStyleTest {
     @Test
     public void testGetCitationMarkerInParenthesisUniquefiersThreeSameAuthor() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -428,7 +426,7 @@ public class OOBibStyleTest {
     @Test
     public void testGetCitationMarkerInTextUniquefiersThreeSameAuthor() throws IOException {
         OOBibStyle style = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
 
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
@@ -464,9 +462,9 @@ public class OOBibStyleTest {
     // TODO: equals only work when initialized from file, not from reader
     public void testEquals() throws IOException {
         OOBibStyle style1 = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
         OOBibStyle style2 = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
         assertEquals(style1, style2);
     }
 
@@ -474,27 +472,27 @@ public class OOBibStyleTest {
     // TODO: equals only work when initialized from file, not from reader
     public void testNotEquals() throws IOException {
         OOBibStyle style1 = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
         OOBibStyle style2 = new OOBibStyle(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
         assertNotEquals(style1, style2);
     }
 
     @Test
     public void testCompareToEqual() throws IOException {
         OOBibStyle style1 = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
         OOBibStyle style2 = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
         assertEquals(0, style1.compareTo(style2));
     }
 
     @Test
     public void testCompareToNotEqual() throws IOException {
         OOBibStyle style1 = new OOBibStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
         OOBibStyle style2 = new OOBibStyle(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
         assertTrue(style1.compareTo(style2) > 0);
         assertFalse(style2.compareTo(style1) > 0);
     }
@@ -504,7 +502,7 @@ public class OOBibStyleTest {
     public void testEmptyStringPropertyAndOxfordComma() throws URISyntaxException, IOException {
         String fileName = Paths.get(OOBibStyleTest.class.getResource("test.jstyle").toURI()).toString();
         OOBibStyle style = new OOBibStyle(fileName,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                layoutFormatterPreferences);
         Map<BibEntry, BibDatabase> entryDBMap = new HashMap<>();
         List<BibEntry> entries = new ArrayList<>();
         BibDatabase database = new BibDatabase();

--- a/src/test/java/net/sf/jabref/logic/openoffice/StyleLoaderTest.java
+++ b/src/test/java/net/sf/jabref/logic/openoffice/StyleLoaderTest.java
@@ -7,13 +7,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import net.sf.jabref.Globals;
-import net.sf.jabref.JabRefMain;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.preferences.JabRefPreferences;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,56 +22,46 @@ import static org.mockito.Mockito.mock;
 
 public class StyleLoaderTest {
 
-    private JabRefPreferences backup;
     private static int numberOfInternalStyles = 2;
     private StyleLoader loader;
 
     private OpenOfficePreferences preferences;
+    private LayoutFormatterPreferences layoutPreferences;
+    private Charset encoding;
+
+
     @Before
     public void setUp() {
-        backup = JabRefPreferences.getInstance();
-        if (Globals.prefs == null) {
-            Globals.prefs = JabRefPreferences.getInstance();
-        }
-        if (Globals.journalAbbreviationLoader == null) {
-            Globals.journalAbbreviationLoader = mock(JournalAbbreviationLoader.class);
-        }
-        preferences = new OpenOfficePreferences(Globals.prefs);
-    }
+        preferences = new OpenOfficePreferences(JabRefPreferences.getInstance());
+        layoutPreferences = LayoutFormatterPreferences.fromPreferences(JabRefPreferences.getInstance(),
+                mock(JournalAbbreviationLoader.class));
+        encoding = JabRefPreferences.getInstance().getDefaultEncoding();
 
-    @After
-    public void tearDown() throws Exception {
-        Globals.prefs.overwritePreferences(backup);
     }
 
     @Test(expected = NullPointerException.class)
     public void throwNPEWithNullPreferences() {
-        loader = new StyleLoader(null,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)),
-                mock(Charset.class));
+        loader = new StyleLoader(null, layoutPreferences, mock(Charset.class));
         fail();
     }
 
     @Test(expected = NullPointerException.class)
     public void throwNPEWithNullRepository() {
         loader = new StyleLoader(mock(OpenOfficePreferences.class),
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, null), mock(Charset.class));
+                LayoutFormatterPreferences.fromPreferences(JabRefPreferences.getInstance(), null), mock(Charset.class));
         fail();
     }
 
     @Test(expected = NullPointerException.class)
     public void throwNPEWithNullCharset() {
-        loader = new StyleLoader(mock(OpenOfficePreferences.class),
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)), null);
+        loader = new StyleLoader(mock(OpenOfficePreferences.class), layoutPreferences, null);
         fail();
     }
 
     @Test
     public void testGetStylesWithEmptyExternal() {
         preferences.setExternalStyles(Collections.emptyList());
-        loader = new StyleLoader(preferences,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)),
-                Globals.prefs.getDefaultEncoding());
+        loader = new StyleLoader(preferences, layoutPreferences, encoding);
 
         assertEquals(2, loader.getStyles().size());
     }
@@ -82,11 +69,9 @@ public class StyleLoaderTest {
     @Test
     public void testAddStyleLeadsToOneMoreStyle() throws URISyntaxException {
         preferences.setExternalStyles(Collections.emptyList());
-        loader = new StyleLoader(preferences,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)),
-                Globals.prefs.getDefaultEncoding());
+        loader = new StyleLoader(preferences, layoutPreferences, encoding);
 
-        String filename = Paths.get(JabRefMain.class.getResource(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH).toURI())
+        String filename = Paths.get(StyleLoader.class.getResource(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH).toURI())
                 .toFile().getPath();
         loader.addStyleIfValid(filename);
         assertEquals(numberOfInternalStyles + 1, loader.getStyles().size());
@@ -95,10 +80,7 @@ public class StyleLoaderTest {
     @Test
     public void testAddInvalidStyleLeadsToNoMoreStyle() {
         preferences.setExternalStyles(Collections.emptyList());
-        Globals.prefs.putStringList(JabRefPreferences.OO_EXTERNAL_STYLE_FILES, Collections.emptyList());
-        loader = new StyleLoader(preferences,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)),
-                Globals.prefs.getDefaultEncoding());
+        loader = new StyleLoader(preferences, layoutPreferences, encoding);
         int beforeAdding = loader.getStyles().size();
         loader.addStyleIfValid("DefinitelyNotAValidFileNameOrWeAreExtremelyUnlucky");
         assertEquals(beforeAdding, loader.getStyles().size());
@@ -106,12 +88,10 @@ public class StyleLoaderTest {
 
     @Test
     public void testInitalizeWithOneExternalFile() throws URISyntaxException {
-        String filename = Paths.get(JabRefMain.class.getResource(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH).toURI())
+        String filename = Paths.get(StyleLoader.class.getResource(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH).toURI())
                 .toFile().getPath();
         preferences.setExternalStyles(Collections.singletonList(filename));
-        loader = new StyleLoader(preferences,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)),
-                Globals.prefs.getDefaultEncoding());
+        loader = new StyleLoader(preferences, layoutPreferences, encoding);
         assertEquals(numberOfInternalStyles + 1, loader.getStyles().size());
     }
 
@@ -119,21 +99,17 @@ public class StyleLoaderTest {
     public void testInitalizeWithIncorrectExternalFile() {
         preferences.setExternalStyles(Collections.singletonList("DefinitelyNotAValidFileNameOrWeAreExtremelyUnlucky"));
 
-        loader = new StyleLoader(new OpenOfficePreferences(Globals.prefs),
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)),
-                Globals.prefs.getDefaultEncoding());
+        loader = new StyleLoader(preferences, layoutPreferences, encoding);
         assertEquals(numberOfInternalStyles, loader.getStyles().size());
     }
 
     @Test
     public void testInitalizeWithOneExternalFileRemoveStyle() throws URISyntaxException {
-        String filename = Paths.get(JabRefMain.class.getResource(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH).toURI())
+        String filename = Paths.get(StyleLoader.class.getResource(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH).toURI())
                 .toFile().getPath();
         preferences.setExternalStyles(Collections.singletonList(filename));
 
-        loader = new StyleLoader(new OpenOfficePreferences(Globals.prefs),
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)),
-                Globals.prefs.getDefaultEncoding());
+        loader = new StyleLoader(preferences, layoutPreferences, encoding);
         List<OOBibStyle> toremove = new ArrayList<>();
         int beforeRemoving = loader.getStyles().size();
         for (OOBibStyle style : loader.getStyles()) {
@@ -150,13 +126,11 @@ public class StyleLoaderTest {
 
     @Test
     public void testInitalizeWithOneExternalFileRemoveStyleUpdatesPreferences() throws URISyntaxException {
-        String filename = Paths.get(JabRefMain.class.getResource(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH).toURI())
+        String filename = Paths.get(StyleLoader.class.getResource(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH).toURI())
                 .toFile().getPath();
         preferences.setExternalStyles(Collections.singletonList(filename));
 
-        loader = new StyleLoader(preferences,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)),
-                Globals.prefs.getDefaultEncoding());
+        loader = new StyleLoader(preferences, layoutPreferences, encoding);
         List<OOBibStyle> toremove = new ArrayList<>();
         for (OOBibStyle style : loader.getStyles()) {
             if (!style.isFromResource()) {
@@ -173,11 +147,9 @@ public class StyleLoaderTest {
     @Test
     public void testAddSameStyleTwiceLeadsToOneMoreStyle() throws URISyntaxException {
         preferences.setExternalStyles(Collections.emptyList());
-        loader = new StyleLoader(new OpenOfficePreferences(Globals.prefs),
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)),
-                Globals.prefs.getDefaultEncoding());
+        loader = new StyleLoader(preferences, layoutPreferences, encoding);
         int beforeAdding = loader.getStyles().size();
-        String filename = Paths.get(JabRefMain.class.getResource(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH).toURI())
+        String filename = Paths.get(StyleLoader.class.getResource(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH).toURI())
                 .toFile().getPath();
         loader.addStyleIfValid(filename);
         loader.addStyleIfValid(filename);
@@ -186,20 +158,15 @@ public class StyleLoaderTest {
 
     @Test(expected = NullPointerException.class)
     public void testAddNullStyleThrowsNPE() {
-        loader = new StyleLoader(new OpenOfficePreferences(Globals.prefs),
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)),
-                Globals.prefs.getDefaultEncoding());
+        loader = new StyleLoader(preferences, layoutPreferences, encoding);
         loader.addStyleIfValid(null);
         fail();
     }
 
-
     @Test
     public void testGetDefaultUsedStyleWhenEmpty() {
-        Globals.prefs.remove(JabRefPreferences.OO_BIBLIOGRAPHY_STYLE_FILE);
-        loader = new StyleLoader(new OpenOfficePreferences(Globals.prefs),
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)),
-                Globals.prefs.getDefaultEncoding());
+        preferences.clearCurrentStyle();
+        loader = new StyleLoader(preferences, layoutPreferences, encoding);
         OOBibStyle style = loader.getUsedStyle();
         assertTrue(style.isValid());
         assertEquals(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH, style.getPath());
@@ -209,9 +176,7 @@ public class StyleLoaderTest {
     @Test
     public void testGetStoredUsedStyle() {
         preferences.setCurrentStyle(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH);
-        loader = new StyleLoader(new OpenOfficePreferences(Globals.prefs),
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)),
-                Globals.prefs.getDefaultEncoding());
+        loader = new StyleLoader(preferences, layoutPreferences, encoding);
         OOBibStyle style = loader.getUsedStyle();
         assertTrue(style.isValid());
         assertEquals(StyleLoader.DEFAULT_NUMERICAL_STYLE_PATH, style.getPath());
@@ -221,9 +186,7 @@ public class StyleLoaderTest {
     @Test
     public void testGtDefaultUsedStyleWhenIncorrect() {
         preferences.setCurrentStyle("ljlkjlkjnljnvdlsjniuhwelfhuewfhlkuewhfuwhelu");
-        loader = new StyleLoader(new OpenOfficePreferences(Globals.prefs),
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)),
-                Globals.prefs.getDefaultEncoding());
+        loader = new StyleLoader(preferences, layoutPreferences, encoding);
         OOBibStyle style = loader.getUsedStyle();
         assertTrue(style.isValid());
         assertEquals(StyleLoader.DEFAULT_AUTHORYEAR_STYLE_PATH, style.getPath());
@@ -234,9 +197,7 @@ public class StyleLoaderTest {
     public void testRemoveInternalStyleReturnsFalseAndDoNotRemove() {
         preferences.setExternalStyles(Collections.emptyList());
 
-        loader = new StyleLoader(preferences,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)),
-                Globals.prefs.getDefaultEncoding());
+        loader = new StyleLoader(preferences, layoutPreferences, encoding);
         List<OOBibStyle> toremove = new ArrayList<>();
         for (OOBibStyle style : loader.getStyles()) {
             if (style.isFromResource()) {

--- a/src/test/java/net/sf/jabref/logic/search/MatchesHighlighterTest.java
+++ b/src/test/java/net/sf/jabref/logic/search/MatchesHighlighterTest.java
@@ -5,10 +5,6 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
-import net.sf.jabref.Globals;
-import net.sf.jabref.preferences.JabRefPreferences;
-
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -16,11 +12,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class MatchesHighlighterTest {
-
-    @BeforeClass
-    public static void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
-    }
 
     @Test
     public void testHighlightWords() {

--- a/src/test/java/net/sf/jabref/logic/search/rules/ContainBasedSearchRuleTest.java
+++ b/src/test/java/net/sf/jabref/logic/search/rules/ContainBasedSearchRuleTest.java
@@ -1,10 +1,8 @@
 package net.sf.jabref.logic.search.rules;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.IdGenerator;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -16,8 +14,6 @@ public class ContainBasedSearchRuleTest {
 
     @Test
     public void testBasicSearchParsing() {
-        Globals.prefs = JabRefPreferences.getInstance();
-
         BibEntry be = makeBibtexEntry();
         ContainBasedSearchRule bsCaseSensitive = new ContainBasedSearchRule(true);
         ContainBasedSearchRule bsCaseInsensitive = new ContainBasedSearchRule(false);

--- a/src/test/java/net/sf/jabref/logic/util/io/FileUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/io/FileUtilTest.java
@@ -5,12 +5,10 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -21,21 +19,19 @@ import static org.mockito.Mockito.when;
 
 public class FileUtilTest {
 
+    private JabRefPreferences prefs;
+
+
     @Before
     public void setUp() {
-        Globals.prefs = mock(JabRefPreferences.class);
+        prefs = mock(JabRefPreferences.class);
     }
 
-    @After
-    public void tearDown() {
-        Globals.prefs = null;
-        Globals.journalAbbreviationLoader = null;
-    }
 
     @Test
     public void testGetLinkedFileNameDefault() {
         // bibkey - title
-        when(Globals.prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN))
+        when(prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN))
                 .thenReturn("\\bibtexkey\\begin{title} - \\format[RemoveBrackets]{\\title}\\end{title}");
 
         BibEntry entry = new BibEntry();
@@ -43,20 +39,20 @@ public class FileUtilTest {
         entry.setField("title", "mytitle");
 
         assertEquals("1234 - mytitle",
-                FileUtil.createFileNameFromPattern(null, entry, mock(JournalAbbreviationLoader.class), Globals.prefs));
+                FileUtil.createFileNameFromPattern(null, entry, mock(JournalAbbreviationLoader.class), prefs));
     }
 
     @Test
     public void testGetLinkedFileNameBibTeXKey() {
         // bibkey
-        when(Globals.prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN)).thenReturn("\\bibtexkey");
+        when(prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN)).thenReturn("\\bibtexkey");
 
         BibEntry entry = new BibEntry();
         entry.setCiteKey("1234");
         entry.setField("title", "mytitle");
 
         assertEquals("1234",
-                FileUtil.createFileNameFromPattern(null, entry, mock(JournalAbbreviationLoader.class), Globals.prefs));
+                FileUtil.createFileNameFromPattern(null, entry, mock(JournalAbbreviationLoader.class), prefs));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/strings/StringUtilTest.java
@@ -1,11 +1,8 @@
 package net.sf.jabref.logic.util.strings;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.model.entry.FileField;
-import net.sf.jabref.preferences.JabRefPreferences;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -25,11 +22,6 @@ public class StringUtilTest {
     private static final String[][] STRING_ARRAY_3 = {{"a", ":b"}, {"c;", "d"}};
     private static final String ENCODED_STRING_ARRAY_3 = "a:\\:b;c\\;:d";
 
-
-    @BeforeClass
-    public static void loadPreferences() {
-        Globals.prefs = JabRefPreferences.getInstance();
-    }
 
     @Test
     public void testUnifyLineBreaks() {


### PR DESCRIPTION
As a consequence of the introduced preference classes, it is no longer as often required to set `Globals.prefs`.

