### PR TITLE
Removed (false) NPE issue reported by FindBugs

### DIFF
--- a/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
@@ -217,12 +217,12 @@ public class MainTable extends JTable {
 
         CellRendererMode status = getCellStatus(row, column);
 
-        if ((model.getSearchState() != MainTableDataModel.DisplayOption.FLOAT) || matches(row,
-                model.getSearchState() != MainTableDataModel.DisplayOption.DISABLED ? SearchMatcher.INSTANCE : null)) {
+        if ((model.getSearchState() != MainTableDataModel.DisplayOption.FLOAT)
+                || matches(row, SearchMatcher.INSTANCE)) {
             score++;
         }
-        if ((model.getGroupingState() != MainTableDataModel.DisplayOption.FLOAT) || matches(row,
-                model.getGroupingState() != MainTableDataModel.DisplayOption.DISABLED ? GroupMatcher.INSTANCE : null)) {
+        if ((model.getGroupingState() != MainTableDataModel.DisplayOption.FLOAT)
+                || matches(row, GroupMatcher.INSTANCE)) {
             score += 2;
         }
 


### PR DESCRIPTION
FindBugs reported a potential NPE here, which never occurred since it would only happen if `model.getSearchState() == MainTableDataModel.DisplayOption.DISABLED`. As this is checked for in the first part of the if-clause, I removed the second check., so this shouldn't affect any perfomance since `matches` will only be triggered under the same conditions as before.

Nothing in CHANGELOG since the NPE couldn't actually happen.

- [x] Manually tested changed features in running JabRef

