### PR TITLE
Some cleanups to initialize empty MetaData at fewer positions

### DIFF
--- a/src/main/java/net/sf/jabref/importer/ImportMenuItem.java
+++ b/src/main/java/net/sf/jabref/importer/ImportMenuItem.java
@@ -24,14 +24,12 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.MetaData;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.EntryMarker;
 import net.sf.jabref.gui.FileDialogs;
@@ -278,7 +276,7 @@ public class ImportMenuItem extends JMenuItem implements ActionListener {
             return directParserResult;
         } else {
 
-            return new ParserResult(database, new MetaData(), new HashMap<>());
+            return new ParserResult(database);
 
         }
     }

--- a/src/main/java/net/sf/jabref/importer/ParserResult.java
+++ b/src/main/java/net/sf/jabref/importer/ParserResult.java
@@ -52,7 +52,11 @@ public class ParserResult {
     }
 
     public ParserResult(Collection<BibEntry> entries) {
-        this(BibDatabases.createDatabase(BibDatabases.purgeEmptyEntries(entries)), new MetaData(), new HashMap<>());
+        this(BibDatabases.createDatabase(BibDatabases.purgeEmptyEntries(entries)));
+    }
+
+    public ParserResult(BibDatabase database) {
+        this(database, new MetaData(), new HashMap<>());
     }
 
     public ParserResult(BibDatabase base, MetaData metaData, Map<String, EntryType> entryTypes) {

--- a/src/test/java/net/sf/jabref/logic/exporter/ExportFormatTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/ExportFormatTest.java
@@ -10,9 +10,7 @@ import java.util.List;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
-import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -47,7 +45,7 @@ public class ExportFormatTest {
     @Before
     public void setUp() {
         Globals.journalAbbreviationLoader = new JournalAbbreviationLoader();
-        databaseContext = new BibDatabaseContext(new BibDatabase(), new MetaData());
+        databaseContext = new BibDatabaseContext();
         charset = Charsets.UTF_8;
         entries = Collections.emptyList();
     }

--- a/src/test/java/net/sf/jabref/logic/exporter/HtmlExportFormatTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/HtmlExportFormatTest.java
@@ -8,9 +8,7 @@ import java.util.List;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
-import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -39,7 +37,7 @@ public class HtmlExportFormatTest {
         exportFormat = ExportFormats.getExportFormat("html");
 
         Globals.journalAbbreviationLoader = new JournalAbbreviationLoader();
-        databaseContext = new BibDatabaseContext(new BibDatabase(), new MetaData());
+        databaseContext = new BibDatabaseContext();
         charset = Charsets.UTF_8;
         BibEntry entry = new BibEntry();
         entry.setField("title", "my paper title");

--- a/src/test/java/net/sf/jabref/logic/exporter/MSBibExportFormatTestFiles.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/MSBibExportFormatTestFiles.java
@@ -15,9 +15,7 @@ import java.util.stream.Stream;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.MetaData;
 import net.sf.jabref.importer.fileformat.BibtexImporter;
-import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -62,7 +60,7 @@ public class MSBibExportFormatTestFiles {
     @Before
     public void setUp() throws Exception {
         Globals.prefs = JabRefPreferences.getInstance();
-        databaseContext = new BibDatabaseContext(new BibDatabase(), new MetaData());
+        databaseContext = new BibDatabaseContext();
         charset = Charsets.UTF_8;
         msBibExportFormat = new MSBibExportFormat();
         tempFile = testFolder.newFile();

--- a/src/test/java/net/sf/jabref/logic/exporter/MsBibExportFormatTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/MsBibExportFormatTest.java
@@ -9,8 +9,6 @@ import java.util.List;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Globals;
-import net.sf.jabref.MetaData;
-import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -37,7 +35,7 @@ public class MsBibExportFormatTest {
     @Before
     public void setUp() throws Exception {
         Globals.prefs = JabRefPreferences.getInstance();
-        databaseContext = new BibDatabaseContext(new BibDatabase(), new MetaData());
+        databaseContext = new BibDatabaseContext();
         charset = Charsets.UTF_8;
         msBibExportFormat = new MSBibExportFormat();
         tempFile = testFolder.newFile();


### PR DESCRIPTION
Fewer initialization of empty `MetaData` to simplify when moving to `model`.


