### PR TITLE
Fixed some issues in Manage content selector dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed [#1321](https://github.com/JabRef/jabref/issues/1321): LaTeX commands in fields not displayed in the list of references
 - Fixed [#1639](https://github.com/JabRef/jabref/issues/1639): Google Scholar fetching works again.
 - Date fields in the BibLatex standard are now always formatted in the correct way, independent of the preferences
+- Manage content selectors now saves edited existing lists again and only marks database as changed when the content selectors are changed
 - Fixed [#1554](https://github.com/JabRef/jabref/issues/1554): Import dialog is no longer hidden behind main window
 - Fixed [#1643](https://github.com/JabRef/jabref/issues/1643): Searching with double quotes in a specific field ignores the last character
 - Fixed [#1288](https://github.com/JabRef/jabref/issues/1288): Newly opened bib-file is not focused


### PR DESCRIPTION
Fixed an issue in Manage content selectors introduced in https://github.com/JabRef/jabref/commit/625d17d736805aa6a4f6d879b0f7e7bd4b9e7ae0 where the content selectors were only saved if they didn't exist before. Also improved some other things such as not having to select a field for it to show (issue on startup) and not showing database as changed if it is not.

- [x] Change in CHANGELOG.md described
- [x] Manually tested changed features in running JabRef
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)

