### PR TITLE
Fixes broken serialization of bibentries containing an @

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed IndexOutOfBoundsException when trying to download a full text document without selecting an entry
 - Fixed NullPointerException when trying to set a special field or mark an entry through the menu without having an open database
 - Fixed [#1257](https://github.com/JabRef/jabref/issues/1324): Preferences for the BibTeX key generator set in a version prior to 3.2 are now migrated automatically to the new version
+- Fixed [#1716](https://github.com/JabRef/jabref/issues/1716): `@`-Symbols stored in BibTeX fields no longer break the database
 
 ### Removed
 - It is not longer possible to choose to convert HTML sub- and superscripts to equations

--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
@@ -224,10 +224,14 @@ public class BibtexParser {
          * for the user.
          */
         try {
+            String commentsAndEntryTypeDefinitionString = dumpTextReadSoFarToString();
+
             BibEntry entry = parseEntry(type);
 
+            entry.setParsedSerialization(commentsAndEntryTypeDefinitionString+dumpTextReadSoFarToString());
+            entry.setCommentsBeforeEntry(commentsAndEntryTypeDefinitionString.substring(0,commentsAndEntryTypeDefinitionString.lastIndexOf('@')));
+
             boolean duplicateKey = database.insertEntry(entry);
-            entry.setParsedSerialization(dumpTextReadSoFarToString());
             if (duplicateKey) {
                 parserResult.addDuplicateKey(entry.getCiteKey());
             } else if ((entry.getCiteKey() == null) || entry.getCiteKey().isEmpty()) {

--- a/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/importer/fileformat/BibtexParser.java
@@ -224,12 +224,15 @@ public class BibtexParser {
          * for the user.
          */
         try {
-            String commentsAndEntryTypeDefinitionString = dumpTextReadSoFarToString();
+            // collect all comments and the entry type definition in front of the actual entry
+            // this is at least `@Type`
+            String commentsAndEntryTypeDefinition = dumpTextReadSoFarToString();
 
             BibEntry entry = parseEntry(type);
-
-            entry.setParsedSerialization(commentsAndEntryTypeDefinitionString+dumpTextReadSoFarToString());
-            entry.setCommentsBeforeEntry(commentsAndEntryTypeDefinitionString.substring(0,commentsAndEntryTypeDefinitionString.lastIndexOf('@')));
+            // store comments collected without type definition
+            entry.setCommentsBeforeEntry(commentsAndEntryTypeDefinition.substring(0,commentsAndEntryTypeDefinition.lastIndexOf('@')));
+            // store complete parsed serialization (comments, type definition + type contents)
+            entry.setParsedSerialization(commentsAndEntryTypeDefinition+dumpTextReadSoFarToString());
 
             boolean duplicateKey = database.insertEntry(entry);
             if (duplicateKey) {

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -69,6 +69,8 @@ public class BibEntry implements Cloneable {
 
     private String parsedSerialization;
 
+    private String commentsBeforeEntry = "";
+
     /*
      * Marks whether the complete serialization, which was read from file, should be used.
      *
@@ -573,6 +575,11 @@ public class BibEntry implements Cloneable {
         return parsedSerialization;
     }
 
+    public void setCommentsBeforeEntry(String parsedComments) {
+        this.commentsBeforeEntry = parsedComments;
+    }
+
+
     public boolean hasChanged() {
         return changed;
     }
@@ -679,25 +686,8 @@ public class BibEntry implements Cloneable {
     * Returns user comments (arbitrary text before the entry), if they exist. If not, returns the empty String
      */
     public String getUserComments() {
-
-        if (parsedSerialization != null) {
-
-            try {
-                // get the text before the entry
-                String prolog = parsedSerialization.substring(0, parsedSerialization.lastIndexOf('@'));
-
-                // delete trailing whitespaces (between entry and text)
-                prolog = prolog.replaceFirst("\\s+$", "");
-
-                // if there is any non whitespace text, write it
-                if (prolog.length() > 0) {
-                    return prolog;
-                }
-            } catch (StringIndexOutOfBoundsException ignore) {
-                // if this occurs a broken parsed serialization has been set, so just do nothing
-            }
-        }
-        return "";
+        // delete trailing whitespaces (between entry and text) from stored serialization
+        return commentsBeforeEntry.replaceFirst("\\s+$", "");
     }
 
     public Set<String> getFieldAsWords(String field) {

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -33,6 +33,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Pattern;
 
 import net.sf.jabref.event.source.EntryEventSource;
 import net.sf.jabref.model.FieldChange;
@@ -51,6 +52,8 @@ public class BibEntry implements Cloneable {
     public static final String KEY_FIELD = "bibtexkey";
     protected static final String ID_FIELD = "id";
     public static final String DEFAULT_TYPE = "misc";
+
+    private static final Pattern REMOVE_TRAILING_WHITESPACE = Pattern.compile("\\s+$");
 
     private String id;
 
@@ -579,7 +582,6 @@ public class BibEntry implements Cloneable {
         this.commentsBeforeEntry = parsedComments;
     }
 
-
     public boolean hasChanged() {
         return changed;
     }
@@ -687,7 +689,7 @@ public class BibEntry implements Cloneable {
      */
     public String getUserComments() {
         // delete trailing whitespaces (between entry and text) from stored serialization
-        return commentsBeforeEntry.replaceFirst("\\s+$", "");
+        return REMOVE_TRAILING_WHITESPACE.matcher(commentsBeforeEntry).replaceFirst("");
     }
 
     public Set<String> getFieldAsWords(String field) {

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -1631,4 +1631,25 @@ public class BibtexParserTest {
         assertEquals(bibtexEntry, entry.getParsedSerialization());
     }
 
+    @Test
+    public void parseCommentContainingEntriesAndAtSymbols() throws IOException {
+        // @formatter:off
+        String bibtexEntry = "@Comment{@article{myarticle,}" + OS.NEWLINE +
+                "@inproceedings{blabla, title={the proceedings of bl@bl@}; }" + OS.NEWLINE +
+                "} " + OS.NEWLINE +
+                "@Article{test," + OS.NEWLINE +
+                "  Author                   = {Foo@Bar}," + OS.NEWLINE +
+                "  Journal                  = {International Journal of Something}," + OS.NEWLINE +
+                "  Note                     = {some note}," + OS.NEWLINE +
+                "  Number                   = {1}" + OS.NEWLINE +
+                "}";
+        // @formatter:on
+
+        ParserResult result = BibtexParser.parse(new StringReader(bibtexEntry));
+        Collection<BibEntry> entries = result.getDatabase().getEntries();
+        BibEntry entry = entries.iterator().next();
+
+        assertEquals(bibtexEntry, entry.getParsedSerialization());
+    }
+
 }

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -310,6 +310,40 @@ public class BibtexParserTest {
     }
 
     @Test
+    public void parseRecognizesEntryWithAtInField() throws IOException {
+        ParserResult result = BibtexParser.parse(new StringReader("@article{test,author={Ed von T@st}}"));
+
+        List<BibEntry> parsed = result.getDatabase().getEntries();
+        assertEquals(1, parsed.size());
+
+        BibEntry e = parsed.iterator().next();
+        assertEquals("article", e.getType());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
+        assertEquals(2, e.getFieldNames().size());
+        assertEquals(Optional.of("Ed von T@st"), e.getFieldOptional("author"));
+    }
+
+    @Test
+    public void parseRecognizesEntryPrecedingComment() throws IOException {
+        String comment = "@Comment{@article{myarticle,}" + OS.NEWLINE +
+                "@inproceedings{blabla, title={the proceedings of bl@bl@}; }" + OS.NEWLINE +
+                "}";
+        String entryWithComment = comment + OS.NEWLINE +
+                "@article{test,author={Ed von T@st}}";
+        ParserResult result = BibtexParser.parse(new StringReader(entryWithComment));
+
+        List<BibEntry> parsed = result.getDatabase().getEntries();
+        assertEquals(1, parsed.size());
+
+        BibEntry e = parsed.iterator().next();
+        assertEquals("article", e.getType());
+        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
+        assertEquals(2, e.getFieldNames().size());
+        assertEquals(Optional.of("Ed von T@st"), e.getFieldOptional("author"));
+        assertEquals(comment, e.getUserComments());
+    }
+
+    @Test
     public void parseRecognizesMultipleEntries() throws IOException {
 
         ParserResult result = BibtexParser

--- a/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/importer/fileformat/BibtexParserTest.java
@@ -31,6 +31,7 @@ import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexString;
 import net.sf.jabref.model.entry.EntryType;
+import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.BeforeClass;
@@ -309,38 +310,32 @@ public class BibtexParserTest {
         assertEquals(Optional.of("Ed von Test"), e.getFieldOptional("author"));
     }
 
-    @Test
-    public void parseRecognizesEntryWithAtInField() throws IOException {
+    @Test public void parseRecognizesEntryWithAtInField() throws IOException {
         ParserResult result = BibtexParser.parse(new StringReader("@article{test,author={Ed von T@st}}"));
 
         List<BibEntry> parsed = result.getDatabase().getEntries();
-        assertEquals(1, parsed.size());
 
-        BibEntry e = parsed.iterator().next();
-        assertEquals("article", e.getType());
-        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
-        assertEquals(2, e.getFieldNames().size());
-        assertEquals(Optional.of("Ed von T@st"), e.getFieldOptional("author"));
+        BibEntry expected = new BibEntry(IdGenerator.next(), "article").withField(BibEntry.KEY_FIELD, "test")
+                .withField("author", "Ed von T@st");
+
+        assertEquals(Collections.singletonList(expected), parsed);
     }
 
-    @Test
-    public void parseRecognizesEntryPrecedingComment() throws IOException {
-        String comment = "@Comment{@article{myarticle,}" + OS.NEWLINE +
-                "@inproceedings{blabla, title={the proceedings of bl@bl@}; }" + OS.NEWLINE +
-                "}";
-        String entryWithComment = comment + OS.NEWLINE +
-                "@article{test,author={Ed von T@st}}";
+    @Test public void parseRecognizesEntryPrecedingComment() throws IOException {
+        String comment = "@Comment{@article{myarticle,}" + OS.NEWLINE
+                + "@inproceedings{blabla, title={the proceedings of bl@bl@}; }" + OS.NEWLINE + "}";
+        String entryWithComment = comment + OS.NEWLINE + "@article{test,author={Ed von T@st}}";
         ParserResult result = BibtexParser.parse(new StringReader(entryWithComment));
 
         List<BibEntry> parsed = result.getDatabase().getEntries();
-        assertEquals(1, parsed.size());
 
-        BibEntry e = parsed.iterator().next();
-        assertEquals("article", e.getType());
-        assertEquals(Optional.of("test"), e.getCiteKeyOptional());
-        assertEquals(2, e.getFieldNames().size());
-        assertEquals(Optional.of("Ed von T@st"), e.getFieldOptional("author"));
-        assertEquals(comment, e.getUserComments());
+        BibEntry expected = new BibEntry(IdGenerator.next(), "article").withField(BibEntry.KEY_FIELD, "test")
+                .withField("author", "Ed von T@st");
+        expected.setCommentsBeforeEntry(comment);
+
+        assertEquals(Collections.singletonList(expected), parsed);
+
+        assertEquals(expected.getUserComments(), parsed.get(0).getUserComments());
     }
 
     @Test


### PR DESCRIPTION
Fixes #1716.

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- ~~Screenshots added (for bigger UI changes)~~
- [x] Manually tested changed features in running JabRef
- ~~Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)~~

As this is rather crucial it would be great if someone else checks what I have done ;-)

To explain: 
```
-                // get the text before the entry
-                String prolog = parsedSerialization.substring(0, parsedSerialization.lastIndexOf('@'));
``` 
... did not work properly if an `@` is used within an entry.

However, determining from the complete parsed serialization where the entry begins and what are comments before the entry is not so trivial. Thus, I added another attribute in the bibentry `commentsBeforeEntry` in which the serialized form of the comments stored in front of the entry is directly saved during parsing the entry.
