### PR TITLE
Ascii integrity checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - It is now possible to add your own lists of protected terms, see Options -> Manage protected terms
 - Automatically generated group names are now converted from LaTeX to Unicode
 - Unified dialogs for opening/saving files
+- Add integrity check to avoid non-ASCII characters in BibTeX files
 
 ### Fixed
 - Fixed [#1632](https://github.com/JabRef/jabref/issues/1632): User comments (@Comment) with or without brackets are now kept

--- a/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
@@ -23,6 +23,8 @@ import net.sf.jabref.model.entry.FileField;
 import net.sf.jabref.model.entry.InternalBibtexFields;
 import net.sf.jabref.model.entry.ParsedFileField;
 
+import com.google.common.base.CharMatcher;
+
 public class IntegrityCheck {
 
     private final BibDatabaseContext bibDatabaseContext;
@@ -50,9 +52,11 @@ public class IntegrityCheck {
 
         result.addAll(new AuthorNameChecker().check(entry));
 
+        // BibTeX only checkers
         if (!bibDatabaseContext.isBiblatexMode()) {
             result.addAll(new TitleChecker().check(entry));
             result.addAll(new PagesChecker().check(entry));
+            result.addAll(new ASCIICharacterChecker().check(entry));
         } else {
             result.addAll(new BiblatexPagesChecker().check(entry));
         }
@@ -394,7 +398,6 @@ public class IntegrityCheck {
         // Detect # if it doesn't have a \ in front of it or if it starts the string
         private static final Pattern UNESCAPED_HASH = Pattern.compile("(?<!\\\\)#|^#");
 
-
         /**
          * Checks, if there is an even number of unescaped #
          */
@@ -427,7 +430,6 @@ public class IntegrityCheck {
         // Detect any HTML encoded character,
         private static final Pattern HTML_CHARACTER_PATTERN = Pattern.compile("&[#\\p{Alnum}]+;");
 
-
         /**
          * Checks, if there are any HTML encoded characters in the fields
          */
@@ -438,6 +440,24 @@ public class IntegrityCheck {
                 Matcher characterMatcher = HTML_CHARACTER_PATTERN.matcher(field.getValue());
                 if (characterMatcher.find()) {
                     results.add(new IntegrityMessage(Localization.lang("HTML encoded character found"), entry,
+                            field.getKey()));
+                }
+            }
+            return results;
+        }
+    }
+
+    private static class ASCIICharacterChecker implements Checker {
+        /**
+         * Detect any non ASCII encoded characters, e.g., umlauts or unicode in the fields
+         */
+        @Override
+        public List<IntegrityMessage> check(BibEntry entry) {
+            List<IntegrityMessage> results = new ArrayList<>();
+            for (Map.Entry<String, String> field : entry.getFieldMap().entrySet()) {
+                boolean asciiOnly = CharMatcher.ascii().matchesAllOf(field.getValue());
+                if (!asciiOnly) {
+                    results.add(new IntegrityMessage(Localization.lang("Non-ASCII encoded character found"), entry,
                             field.getKey()));
                 }
             }

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -1750,3 +1750,5 @@ Open_OpenOffice/LibreOffice_connection=
 
 You_must_enter_at_least_one_field_name=
 
+
+Non-ASCII_encoded_character_found=

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2460,3 +2460,5 @@ Open_OpenOffice/LibreOffice_connection=Öffne_OpenOffice/LibreOffice_Verbindung
 
 You_must_enter_at_least_one_field_name=
 
+
+Non-ASCII_encoded_character_found=

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2288,3 +2288,4 @@ Style_file=Style_file
 
 Open_OpenOffice/LibreOffice_connection=Open_OpenOffice/LibreOffice_connection
 You_must_enter_at_least_one_field_name=You_must_enter_at_least_one_field_name
+Non-ASCII_encoded_character_found=Non-ASCII_encoded_character_found

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -1651,3 +1651,5 @@ Open_OpenOffice/LibreOffice_connection=
 
 You_must_enter_at_least_one_field_name=
 
+
+Non-ASCII_encoded_character_found=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -2432,3 +2432,5 @@ Open_OpenOffice/LibreOffice_connection=
 
 You_must_enter_at_least_one_field_name=
 
+
+Non-ASCII_encoded_character_found=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -1692,3 +1692,5 @@ Open_OpenOffice/LibreOffice_connection=
 
 You_must_enter_at_least_one_field_name=
 
+
+Non-ASCII_encoded_character_found=

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -1667,3 +1667,5 @@ Open_OpenOffice/LibreOffice_connection=
 
 You_must_enter_at_least_one_field_name=
 
+
+Non-ASCII_encoded_character_found=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -1768,3 +1768,5 @@ Open_OpenOffice/LibreOffice_connection=
 
 You_must_enter_at_least_one_field_name=
 
+
+Non-ASCII_encoded_character_found=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2409,3 +2409,5 @@ Open_OpenOffice/LibreOffice_connection=
 
 You_must_enter_at_least_one_field_name=
 
+
+Non-ASCII_encoded_character_found=

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -2441,3 +2441,5 @@ Open_OpenOffice/LibreOffice_connection=
 
 You_must_enter_at_least_one_field_name=
 
+
+Non-ASCII_encoded_character_found=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -2833,3 +2833,5 @@ Open_OpenOffice/LibreOffice_connection=
 
 You_must_enter_at_least_one_field_name=
 
+
+Non-ASCII_encoded_character_found=

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -1664,3 +1664,5 @@ Open_OpenOffice/LibreOffice_connection=
 
 You_must_enter_at_least_one_field_name=
 
+
+Non-ASCII_encoded_character_found=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2410,3 +2410,5 @@ Open_OpenOffice/LibreOffice_connection=
 
 You_must_enter_at_least_one_field_name=
 
+
+Non-ASCII_encoded_character_found=

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -1609,3 +1609,5 @@ Open_OpenOffice/LibreOffice_connection=
 
 You_must_enter_at_least_one_field_name=
 
+
+Non-ASCII_encoded_character_found=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -1682,3 +1682,5 @@ Open_OpenOffice/LibreOffice_connection=
 
 You_must_enter_at_least_one_field_name=
 
+
+Non-ASCII_encoded_character_found=

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -2436,3 +2436,5 @@ Open_OpenOffice/LibreOffice_connection=
 
 You_must_enter_at_least_one_field_name=
 
+
+Non-ASCII_encoded_character_found=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -1676,3 +1676,5 @@ Open_OpenOffice/LibreOffice_connection=
 
 You_must_enter_at_least_one_field_name=
 
+
+Non-ASCII_encoded_character_found=

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -213,6 +213,13 @@ public class IntegrityCheckTest {
         assertWrong(createContext("isbn", "978-0-306-40615-8"));
     }
 
+    @Test
+    public void testASCIIChecks() {
+        assertCorrect(createContext("title", "Only ascii characters!'@12"));
+        assertWrong(createContext("month", "Umlauts are nöt ällowed"));
+        assertWrong(createContext("author", "Some unicode ⊕"));
+    }
+
     private BibDatabaseContext createContext(String field, String value, String type) {
         BibEntry entry = new BibEntry();
         entry.setField(field, value);


### PR DESCRIPTION
To avoid problems using BibTeX and non-ASCII chars.

Quick tests show that it also marks `é` as an error. Does anyone know what chars BibTeX can really handle? Umlauts are a problem but `é`  should work?! So i cannot include all of the extended ascii table http://www.theasciicode.com.ar/extended-ascii-code/letter-e-acute-accent-e-acute-lowercase-ascii-code-130.html