### PR TITLE
Better layout of general preferences tab

### DIFF
--- a/src/main/java/net/sf/jabref/gui/preftabs/GeneralTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/GeneralTab.java
@@ -111,8 +111,9 @@ class GeneralTab extends JPanel implements PrefsTab {
         encodings = new JComboBox<>();
         encodings.setModel(new DefaultComboBoxModel<>(Encodings.ENCODINGS));
 
-        FormLayout layout = new FormLayout
-                ("8dlu, 1dlu, left:170dlu, 4dlu, fill:pref, 4dlu, fill:pref, 4dlu, left:pref, 4dlu, left:pref, 4dlu, left:pref", "");
+        FormLayout layout = new FormLayout(
+                "8dlu, 1dlu, left:pref:grow, 4dlu, fill:pref, 4dlu, fill:pref, 4dlu, left:pref, 1dlu, left:pref, 4dlu, left:pref",
+                "");
         DefaultFormBuilder builder = new DefaultFormBuilder(layout);
 
         builder.appendSeparator(Localization.lang("General"));
@@ -146,7 +147,7 @@ class GeneralTab extends JPanel implements PrefsTab {
         builder.nextLine();
 
         builder.append(new JPanel());
-        builder.append(updateTimeStamp, 2);
+        builder.append(updateTimeStamp, 11);
         builder.nextLine();
 
         builder.append(markImportedEntries, 13);


### PR DESCRIPTION
I know I have strange font settings, but I couldn't see some preferences on my portrait screen:

![before](https://cloud.githubusercontent.com/assets/8114497/17619874/8b8f94d4-6088-11e6-88ab-5053c4d04782.png)

Hence, I changed the layout a bit to scale:

![after](https://cloud.githubusercontent.com/assets/8114497/17619879/973c6bc2-6088-11e6-92a4-9ddf67dee248.png)

It is not perfect since all the stuff to the right keeps moving, even though all text is shown but still more practical than the current layout.

- [x] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)

