### PR TITLE
Added makeLabel(BibDatabaseContext, ...) method

### DIFF
--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -491,8 +491,8 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 // Finally, set the new keys:
                 for (BibEntry entry : entries) {
                     bes = entry;
-                    BibtexKeyPatternUtil.makeLabel(bibDatabaseContext.getMetaData(), bibDatabaseContext.getDatabase(),
-                            bes, BibtexKeyPatternPreferences.fromPreferences(Globals.prefs));
+                    BibtexKeyPatternUtil.makeLabel(bibDatabaseContext, bes,
+                            BibtexKeyPatternPreferences.fromPreferences(Globals.prefs));
                     ce.addEdit(new UndoableKeyChange(bibDatabaseContext.getDatabase(), bes, (String) oldvals.get(bes),
                             bes.getCiteKeyOptional().orElse(null)));
                 }
@@ -1929,8 +1929,8 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             for (BibEntry bes : bibDatabaseContext.getDatabase().getEntries()) {
                 Optional<String> oldKey = bes.getCiteKeyOptional();
                 if (!(oldKey.isPresent()) || oldKey.get().isEmpty()) {
-                    BibtexKeyPatternUtil.makeLabel(bibDatabaseContext.getMetaData(), bibDatabaseContext.getDatabase(),
-                            bes, BibtexKeyPatternPreferences.fromPreferences(Globals.prefs));
+                    BibtexKeyPatternUtil.makeLabel(bibDatabaseContext, bes,
+                            BibtexKeyPatternPreferences.fromPreferences(Globals.prefs));
                     ce.addEdit(new UndoableKeyChange(bibDatabaseContext.getDatabase(), bes, null,
                             bes.getCiteKeyOptional().get())); // Cite key is set here
                     any = true;

--- a/src/main/java/net/sf/jabref/gui/bibtexkeypattern/SearchFixDuplicateLabels.java
+++ b/src/main/java/net/sf/jabref/gui/bibtexkeypattern/SearchFixDuplicateLabels.java
@@ -110,10 +110,11 @@ public class SearchFixDuplicateLabels extends AbstractWorker {
         if (!toGenerateFor.isEmpty()) {
             NamedCompound ce = new NamedCompound(Localization.lang("Resolve duplicate BibTeX keys"));
             for (BibEntry entry : toGenerateFor) {
-                String oldKey = entry.getCiteKey();
-                BibtexKeyPatternUtil.makeLabel(panel.getBibDatabaseContext().getMetaData(), panel.getDatabase(), entry,
+                String oldKey = entry.getCiteKeyOptional().orElse(null);
+                BibtexKeyPatternUtil.makeLabel(panel.getBibDatabaseContext(), entry,
                         BibtexKeyPatternPreferences.fromPreferences(Globals.prefs));
-                ce.addEdit(new UndoableKeyChange(panel.getDatabase(), entry, oldKey, entry.getCiteKey()));
+                ce.addEdit(new UndoableKeyChange(panel.getDatabase(), entry, oldKey,
+                        entry.getCiteKeyOptional().orElse(null)));
             }
             ce.end();
             panel.getUndoManager().addEdit(ce);

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -1383,7 +1383,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
                 }
             }
 
-            BibtexKeyPatternUtil.makeLabel(panel.getBibDatabaseContext().getMetaData(), panel.getDatabase(), entry,
+            BibtexKeyPatternUtil.makeLabel(panel.getBibDatabaseContext(), entry,
                     BibtexKeyPatternPreferences.fromPreferences(Globals.prefs));
 
             // Store undo information:

--- a/src/main/java/net/sf/jabref/gui/openoffice/OpenOfficePanel.java
+++ b/src/main/java/net/sf/jabref/gui/openoffice/OpenOfficePanel.java
@@ -709,13 +709,12 @@ public class OpenOfficePanel extends AbstractWorker {
             BibtexKeyPatternPreferences prefs = BibtexKeyPatternPreferences.fromPreferences(Globals.prefs);
             NamedCompound undoCompound = new NamedCompound(Localization.lang("Cite"));
             for (BibEntry entry : entries) {
-                if (entry.getCiteKey() == null) {
+                if (!entry.getCiteKeyOptional().isPresent()) {
                     // Generate key
-                    BibtexKeyPatternUtil
-                            .makeLabel(panel.getBibDatabaseContext().getMetaData(), panel.getDatabase(), entry,
-                            prefs);
+                    BibtexKeyPatternUtil.makeLabel(panel.getBibDatabaseContext(), entry, prefs);
                     // Add undo change
-                    undoCompound.addEdit(new UndoableKeyChange(panel.getDatabase(), entry, null, entry.getCiteKey()));
+                    undoCompound.addEdit(
+                            new UndoableKeyChange(panel.getDatabase(), entry, null, entry.getCiteKeyOptional().get()));
                 }
             }
             undoCompound.end();

--- a/src/main/java/net/sf/jabref/gui/plaintextimport/TextInputDialog.java
+++ b/src/main/java/net/sf/jabref/gui/plaintextimport/TextInputDialog.java
@@ -508,7 +508,7 @@ public class TextInputDialog extends JDialog {
         text = text.replace(OS.NEWLINE, " ");
         text = text.replace("##NEWLINE##", OS.NEWLINE);
 
-        ParserResult importerResult = fimp.importEntries(text);
+        ParserResult importerResult = fimp.importEntries(text, frame.getCurrentBasePanel().getBibDatabaseContext());
         if (importerResult.hasWarnings()) {
             frame.showMessage(importerResult.getErrorMessage());
         }

--- a/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.formatter.casechanger.Word;
 import net.sf.jabref.logic.layout.format.RemoveLatexCommands;
@@ -377,6 +378,23 @@ public class BibtexKeyPatternUtil {
                 + ((department == null)
                 || ((school != null) && department.equals(school)) ?
                         "" : department);
+    }
+
+    /**
+     * Generates a BibTeX label according to the pattern for a given entry type, and saves the unique label in the
+     * <code>Bibtexentry</code>.
+     *
+     * The given database context is used to avoid duplicate keys.
+     *
+     * @param databaseContext a <code>BibDatabaseContext</code>
+     * @param entry a <code>BibEntry</code>
+     * @param bibtexKeyPatternPreferences the current <code>BibtexKeyPatternPreferences</code>
+     * @return modified BibEntry
+     */
+
+    public static void makeLabel(BibDatabaseContext databaseContext, BibEntry entry,
+            BibtexKeyPatternPreferences bibtexKeyPatternPreferences) {
+        makeLabel(databaseContext.getMetaData(), databaseContext.getDatabase(), entry, bibtexKeyPatternPreferences);
     }
 
     /**
@@ -1384,5 +1402,6 @@ public class BibtexKeyPatternUtil {
 
         return StringUtil.replaceSpecialCharacters(newKey.toString());
     }
+
 
 }

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/FreeCiteImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/FreeCiteImporter.java
@@ -35,7 +35,7 @@ import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
-import net.sf.jabref.JabRefGUI;
+import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.logic.bibtexkeypattern.BibtexKeyPatternUtil;
 import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.ParserResult;
@@ -76,11 +76,11 @@ public class FreeCiteImporter extends ImportFormat {
             throws IOException {
         try (Scanner scan = new Scanner(reader)) {
             String text = scan.useDelimiter("\\A").next();
-            return importEntries(text);
+            return importEntries(text, new BibDatabaseContext());
         }
     }
 
-    public ParserResult importEntries(String text) {
+    public ParserResult importEntries(String text, BibDatabaseContext databaseContext) {
         // URLencode the string for transmission
         String urlencodedCitation = null;
         try {
@@ -222,9 +222,7 @@ public class FreeCiteImporter extends ImportFormat {
                     e.setType(type);
 
                     // autogenerate label (BibTeX key)
-                    BibtexKeyPatternUtil.makeLabel(
-                            JabRefGUI.getMainFrame().getCurrentBasePanel().getBibDatabaseContext().getMetaData(),
-                            JabRefGUI.getMainFrame().getCurrentBasePanel().getDatabase(), e,
+                    BibtexKeyPatternUtil.makeLabel(databaseContext, e,
                             importFormatPreferences.getBibtexKeyPatternPreferences());
 
                     res.add(e);


### PR DESCRIPTION
Quite often `makelLabel` is called with MetaData and BibDatabase from the same BibDatabaseContext, so I created a convenience method for this.

