### PR TITLE
Always provide encoding in MetaData constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - [#1758](https://github.com/JabRef/jabref/issues/1758) Added a button to open Database Properties dialog help
 - Improve focus of the maintable after a sidepane gets closed (Before it would focus the toolbar or it would focus the wrong entry)
 - File open dialogs now use default extensions as primary file filter
+- Custom import formats must be slightly redesigned and recompiled as the constructor now takes an argument of the type `ImportFormatPreferences`. Just add a constructor and call `super` with the argument and you have a variable `importFormatPreferences` that contains some of the more relevant preference values. The reason behind the change is that we want to have a better architecture and not access `Globals.prefs` from all classes. It is still possible to access `Globals.prefs` in custom importers though.
 
 ### Fixed
 - Fixed [#1632](https://github.com/JabRef/jabref/issues/1632): User comments (@Comment) with or without brackets are now kept

--- a/src/databaseTest/java/net/sf/jabref/shared/DBMSSynchronizerTest.java
+++ b/src/databaseTest/java/net/sf/jabref/shared/DBMSSynchronizerTest.java
@@ -118,7 +118,7 @@ public class DBMSSynchronizerTest {
 
     @Test
     public void testMetaDataChangedEventListener() {
-        MetaData testMetaData = new MetaData(Globals.prefs.getDefaultEncoding());
+        MetaData testMetaData = new MetaData();
         testMetaData.registerListener(dbmsSynchronizer);
         dbmsSynchronizer.setMetaData(testMetaData);
         testMetaData.putData("databaseType", Arrays.asList("bibtex"));
@@ -184,7 +184,7 @@ public class DBMSSynchronizerTest {
         BibEntry bibEntry = getBibEntryExample(1);
         bibDatabase.insertEntry(bibEntry);
 
-        MetaData testMetaData = new MetaData(Globals.prefs.getDefaultEncoding());
+        MetaData testMetaData = new MetaData();
         testMetaData.putData("saveActions", Arrays.asList("enabled", "author[lower_case]"));
         dbmsSynchronizer.setMetaData(testMetaData);
 

--- a/src/databaseTest/java/net/sf/jabref/shared/DBMSSynchronizerTest.java
+++ b/src/databaseTest/java/net/sf/jabref/shared/DBMSSynchronizerTest.java
@@ -118,7 +118,7 @@ public class DBMSSynchronizerTest {
 
     @Test
     public void testMetaDataChangedEventListener() {
-        MetaData testMetaData = new MetaData();
+        MetaData testMetaData = new MetaData(Globals.prefs.getDefaultEncoding());
         testMetaData.registerListener(dbmsSynchronizer);
         dbmsSynchronizer.setMetaData(testMetaData);
         testMetaData.putData("databaseType", Arrays.asList("bibtex"));
@@ -184,7 +184,7 @@ public class DBMSSynchronizerTest {
         BibEntry bibEntry = getBibEntryExample(1);
         bibDatabase.insertEntry(bibEntry);
 
-        MetaData testMetaData = new MetaData();
+        MetaData testMetaData = new MetaData(Globals.prefs.getDefaultEncoding());
         testMetaData.putData("saveActions", Arrays.asList("enabled", "author[lower_case]"));
         dbmsSynchronizer.setMetaData(testMetaData);
 

--- a/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
+++ b/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
@@ -63,8 +63,8 @@ public class Benchmarks {
         }
         BibtexDatabaseWriter<StringSaveSession> databaseWriter = new BibtexDatabaseWriter<>(StringSaveSession::new);
         StringSaveSession saveSession = databaseWriter.savePartOfDatabase(
-                new BibDatabaseContext(database, new MetaData(Globals.prefs.getDefaultEncoding()), new Defaults()),
-                database.getEntries(), new SavePreferences());
+                new BibDatabaseContext(database, new MetaData(), new Defaults()), database.getEntries(),
+                new SavePreferences());
         bibtexString = saveSession.getStringValue();
 
         latexConversionString = "{A} \\textbf{bold} approach {\\it to} ${{\\Sigma}}{\\Delta}$ modulator \\textsuperscript{2} \\$";
@@ -84,8 +84,8 @@ public class Benchmarks {
     public String write() throws Exception {
         BibtexDatabaseWriter<StringSaveSession> databaseWriter = new BibtexDatabaseWriter<>(StringSaveSession::new);
         StringSaveSession saveSession = databaseWriter.savePartOfDatabase(
-                new BibDatabaseContext(database, new MetaData(Globals.prefs.getDefaultEncoding()), new Defaults()),
-                database.getEntries(), new SavePreferences());
+                new BibDatabaseContext(database, new MetaData(), new Defaults()), database.getEntries(),
+                new SavePreferences());
         return saveSession.getStringValue();
     }
 

--- a/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
+++ b/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
@@ -63,8 +63,8 @@ public class Benchmarks {
         }
         BibtexDatabaseWriter<StringSaveSession> databaseWriter = new BibtexDatabaseWriter<>(StringSaveSession::new);
         StringSaveSession saveSession = databaseWriter.savePartOfDatabase(
-                new BibDatabaseContext(database, new MetaData(), new Defaults()), database.getEntries(),
-                new SavePreferences());
+                new BibDatabaseContext(database, new MetaData(Globals.prefs.getDefaultEncoding()), new Defaults()),
+                database.getEntries(), new SavePreferences());
         bibtexString = saveSession.getStringValue();
 
         latexConversionString = "{A} \\textbf{bold} approach {\\it to} ${{\\Sigma}}{\\Delta}$ modulator \\textsuperscript{2} \\$";
@@ -84,8 +84,8 @@ public class Benchmarks {
     public String write() throws Exception {
         BibtexDatabaseWriter<StringSaveSession> databaseWriter = new BibtexDatabaseWriter<>(StringSaveSession::new);
         StringSaveSession saveSession = databaseWriter.savePartOfDatabase(
-                new BibDatabaseContext(database, new MetaData(), new Defaults()), database.getEntries(),
-                new SavePreferences());
+                new BibDatabaseContext(database, new MetaData(Globals.prefs.getDefaultEncoding()), new Defaults()),
+                database.getEntries(), new SavePreferences());
         return saveSession.getStringValue();
     }
 

--- a/src/main/java/net/sf/jabref/BibDatabaseContext.java
+++ b/src/main/java/net/sf/jabref/BibDatabaseContext.java
@@ -43,7 +43,7 @@ public class BibDatabaseContext {
     }
 
     public BibDatabaseContext(BibDatabase database, Defaults defaults) {
-        this(database, new MetaData(), defaults);
+        this(database, new MetaData(Globals.prefs.getDefaultEncoding()), defaults);
     }
 
     public BibDatabaseContext(BibDatabase database, MetaData metaData, Defaults defaults) {
@@ -73,7 +73,7 @@ public class BibDatabaseContext {
     }
 
     public BibDatabaseContext(Defaults defaults, DatabaseLocation location) {
-        this(new BibDatabase(), new MetaData(), defaults, location);
+        this(new BibDatabase(), new MetaData(Globals.prefs.getDefaultEncoding()), defaults, location);
     }
 
     public BibDatabaseMode getMode() {

--- a/src/main/java/net/sf/jabref/BibDatabaseContext.java
+++ b/src/main/java/net/sf/jabref/BibDatabaseContext.java
@@ -43,7 +43,7 @@ public class BibDatabaseContext {
     }
 
     public BibDatabaseContext(BibDatabase database, Defaults defaults) {
-        this(database, new MetaData(Globals.prefs.getDefaultEncoding()), defaults);
+        this(database, new MetaData(), defaults);
     }
 
     public BibDatabaseContext(BibDatabase database, MetaData metaData, Defaults defaults) {
@@ -73,7 +73,7 @@ public class BibDatabaseContext {
     }
 
     public BibDatabaseContext(Defaults defaults, DatabaseLocation location) {
-        this(new BibDatabase(), new MetaData(Globals.prefs.getDefaultEncoding()), defaults, location);
+        this(new BibDatabase(), new MetaData(), defaults, location);
     }
 
     public BibDatabaseMode getMode() {

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -83,24 +83,15 @@ public class MetaData implements Iterable<String> {
     private MetaData(Map<String, String> inData, Charset encoding) throws ParseException {
         Objects.requireNonNull(inData);
         setData(inData);
-        this.encoding = encoding;
+        this.encoding = Objects.requireNonNull(encoding);
     }
 
     /**
-     * The MetaData object can be constructed with no data in it.
+     * The MetaData object can be constructed with no data in it, but needs encoding information
      */
-    @Deprecated
-    public MetaData() {
-        this(Globals.prefs.getDefaultEncoding());
-    }
 
     public MetaData(Charset encoding) {
         this.encoding = encoding;
-    }
-
-    @Deprecated
-    public static MetaData parse(Map<String, String> data) throws ParseException {
-        return new MetaData(data, Globals.prefs.getDefaultEncoding());
     }
 
     public static MetaData parse(Map<String, String> data, Charset encoding) throws ParseException {

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -86,9 +86,13 @@ public class MetaData implements Iterable<String> {
         this.encoding = Objects.requireNonNull(encoding);
     }
 
+
     /**
-     * The MetaData object can be constructed with no data in it, but needs encoding information
+     * The MetaData object can be constructed with no data in it
      */
+
+    public MetaData() {
+    }
 
     public MetaData(Charset encoding) {
         this.encoding = encoding;
@@ -462,8 +466,8 @@ public class MetaData implements Iterable<String> {
     /**
      * Returns the encoding used during parsing.
      */
-    public Charset getEncoding() {
-        return encoding;
+    public Optional<Charset> getEncoding() {
+        return Optional.ofNullable(encoding);
     }
 
     public void setEncoding(Charset encoding) {

--- a/src/main/java/net/sf/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/net/sf/jabref/cli/ArgumentProcessor.java
@@ -200,7 +200,9 @@ public class ArgumentProcessor {
                 // We have an ExportFormat instance:
                 try {
                     System.out.println(Localization.lang("Exporting") + ": " + data[1]);
-                    format.performExport(databaseContext, data[1], databaseContext.getMetaData().getEncoding(), matches);
+                    format.performExport(databaseContext, data[1],
+                            databaseContext.getMetaData().getEncoding().orElse(Globals.prefs.getDefaultEncoding()),
+                            matches);
                 } catch (Exception ex) {
                     System.err.println(Localization.lang("Could not export file") + " '" + data[1] + "': "
                             + ex.getMessage());
@@ -378,8 +380,8 @@ public class ArgumentProcessor {
             } else {
                 // We have an ExportFormat instance:
                 try {
-                    format.performExport(pr.getDatabaseContext(), data[0],
-                            pr.getDatabaseContext().getMetaData().getEncoding(), null);
+                    format.performExport(pr.getDatabaseContext(), data[0], pr.getDatabaseContext().getMetaData()
+                            .getEncoding().orElse(Globals.prefs.getDefaultEncoding()), null);
                 } catch (Exception ex) {
                     System.err.println(Localization.lang("Could not export file") + " '" + data[0] + "': "
                             + ex.getMessage());

--- a/src/main/java/net/sf/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/net/sf/jabref/cli/ArgumentProcessor.java
@@ -502,7 +502,7 @@ public class ArgumentProcessor {
             return Optional.empty();
         }
 
-        return Optional.of(new ParserResult(result));
+        return Optional.of(new ParserResult(result, Globals.prefs.getDefaultEncoding()));
     }
 
     public boolean isBlank() {

--- a/src/main/java/net/sf/jabref/collab/ChangeScanner.java
+++ b/src/main/java/net/sf/jabref/collab/ChangeScanner.java
@@ -166,7 +166,8 @@ public class ChangeScanner implements Runnable {
         JabRefExecutorService.INSTANCE.execute(() -> {
             try {
                 SavePreferences prefs = SavePreferences.loadForSaveFromPreferences(Globals.prefs).withMakeBackup(false)
-                        .withEncoding(panel.getBibDatabaseContext().getMetaData().getEncoding());
+                        .withEncoding(panel.getBibDatabaseContext().getMetaData().getEncoding()
+                                .orElse(Globals.prefs.getDefaultEncoding()));
 
                 Defaults defaults = new Defaults(BibDatabaseMode
                         .fromPreference(Globals.prefs.getBoolean(JabRefPreferences.BIBLATEX_DEFAULT_MODE)));

--- a/src/main/java/net/sf/jabref/external/DownloadExternalFile.java
+++ b/src/main/java/net/sf/jabref/external/DownloadExternalFile.java
@@ -33,9 +33,11 @@ import net.sf.jabref.gui.FileListEntryEditor;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.net.MonitoredURLDownload;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.logic.net.URLDownload;
 import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.io.FileUtil;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -270,8 +272,9 @@ public class DownloadExternalFile {
     // FIXME: will break download if no bibtexkey is present!
     private String getSuggestedFileName(String suffix) {
         String plannedName = FileUtil.createFileNameFromPattern(databaseContext.getDatabase(),
-                frame.getCurrentBasePanel().getSelectedEntries().get(0), Globals.journalAbbreviationLoader,
-                Globals.prefs);
+                frame.getCurrentBasePanel().getSelectedEntries().get(0),
+                Globals.prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN),
+                LayoutFormatterPreferences.fromPreferences(Globals.prefs, Globals.journalAbbreviationLoader));
 
         if (!suffix.isEmpty()) {
             plannedName += "." + suffix;

--- a/src/main/java/net/sf/jabref/external/DroppedFileHandler.java
+++ b/src/main/java/net/sf/jabref/external/DroppedFileHandler.java
@@ -40,6 +40,7 @@ import net.sf.jabref.gui.undo.NamedCompound;
 import net.sf.jabref.gui.undo.UndoableFieldChange;
 import net.sf.jabref.gui.undo.UndoableInsertEntry;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.logic.xmp.XMPPreferences;
@@ -48,6 +49,7 @@ import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.model.entry.IdGenerator;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.FormBuilder;
 import com.jgoodies.forms.layout.FormLayout;
@@ -353,8 +355,9 @@ public class DroppedFileHandler {
         renameCheckBox.setText(Localization.lang("Rename file to").concat(": "));
 
         // Determine which name to suggest:
-        String targetName = FileUtil.createFileNameFromPattern(database, entry, Globals.journalAbbreviationLoader,
-                Globals.prefs);
+        String targetName = FileUtil.createFileNameFromPattern(database, entry,
+                Globals.prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN),
+                LayoutFormatterPreferences.fromPreferences(Globals.prefs, Globals.journalAbbreviationLoader));
 
         renameToTextBox.setText(targetName.concat(".").concat(fileType.getExtension()));
 

--- a/src/main/java/net/sf/jabref/external/MoveFileAction.java
+++ b/src/main/java/net/sf/jabref/external/MoveFileAction.java
@@ -35,6 +35,7 @@ import net.sf.jabref.gui.entryeditor.EntryEditor;
 import net.sf.jabref.gui.fieldeditors.FileListEditor;
 import net.sf.jabref.gui.util.component.CheckBoxMessage;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -112,7 +113,9 @@ public class MoveFileAction extends AbstractAction {
                     // Determine which name to suggest:
                     String suggName = FileUtil
                             .createFileNameFromPattern(eEditor.getDatabase(), eEditor.getEntry(),
-                                    Globals.journalAbbreviationLoader, Globals.prefs)
+                                    Globals.prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN),
+                                    LayoutFormatterPreferences.fromPreferences(Globals.prefs,
+                                            Globals.journalAbbreviationLoader))
                             .concat(entry.type.isPresent() ? "." + entry.type.get().getExtension() : "");
                     CheckBoxMessage cbm = new CheckBoxMessage(Localization.lang("Move file to file directory?"),
                             Localization.lang("Rename to '%0'", suggName),

--- a/src/main/java/net/sf/jabref/external/WriteXMPAction.java
+++ b/src/main/java/net/sf/jabref/external/WriteXMPAction.java
@@ -135,9 +135,10 @@ public class WriteXMPAction extends AbstractWorker {
             List<File> files = new ArrayList<>();
 
             // First check the (legacy) "pdf" field:
-            entry.getFieldOptional(FieldName.PDF).ifPresent(pdf ->
-                FileUtil.expandFilename(pdf, panel.getBibDatabaseContext().getFileDirectory("pdf"))
-                    .ifPresent(files::add));
+            entry.getFieldOptional(FieldName.PDF)
+                    .ifPresent(pdf -> FileUtil
+                            .expandFilename(pdf, panel.getBibDatabaseContext().getFileDirectory(FieldName.PDF))
+                            .ifPresent(files::add));
             // Then check the "file" field:
             List<String> dirs = panel.getBibDatabaseContext().getFileDirectory();
             if (entry.hasField(FieldName.FILE)) {

--- a/src/main/java/net/sf/jabref/external/WriteXMPEntryEditorAction.java
+++ b/src/main/java/net/sf/jabref/external/WriteXMPEntryEditorAction.java
@@ -70,8 +70,10 @@ public class WriteXMPEntryEditorAction extends AbstractAction {
         List<File> files = new ArrayList<>();
 
         // First check the (legacy) "pdf" field:
-        entry.getFieldOptional(FieldName.PDF).ifPresent(pdf -> FileUtil
-                .expandFilename(pdf, panel.getBibDatabaseContext().getFileDirectory("pdf")).ifPresent(files::add));
+        entry.getFieldOptional(FieldName.PDF)
+                .ifPresent(pdf -> FileUtil
+                        .expandFilename(pdf, panel.getBibDatabaseContext().getFileDirectory(FieldName.PDF))
+                        .ifPresent(files::add));
 
         // Then check the "file" field:
         List<String> dirs = panel.getBibDatabaseContext().getFileDirectory();

--- a/src/main/java/net/sf/jabref/gui/actions/CleanupAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/CleanupAction.java
@@ -32,6 +32,7 @@ import net.sf.jabref.gui.worker.AbstractWorker;
 import net.sf.jabref.logic.cleanup.CleanupPreset;
 import net.sf.jabref.logic.cleanup.CleanupWorker;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
@@ -161,7 +162,9 @@ public class CleanupAction extends AbstractWorker {
     private void doCleanup(CleanupPreset preset, BibEntry entry, NamedCompound ce) {
         // Create and run cleaner
         BibDatabaseContext bibDatabaseContext = panel.getBibDatabaseContext();
-        CleanupWorker cleaner = new CleanupWorker(bibDatabaseContext, Globals.journalAbbreviationLoader, Globals.prefs);
+        CleanupWorker cleaner = new CleanupWorker(bibDatabaseContext,
+                Globals.prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN),
+                LayoutFormatterPreferences.fromPreferences(Globals.prefs, Globals.journalAbbreviationLoader));
         List<FieldChange> changes = cleaner.cleanup(preset, entry);
 
         unsuccessfulRenames = cleaner.getUnsuccessfulRenames();

--- a/src/main/java/net/sf/jabref/gui/dbproperties/DatabasePropertiesDialog.java
+++ b/src/main/java/net/sf/jabref/gui/dbproperties/DatabasePropertiesDialog.java
@@ -190,7 +190,8 @@ public class DatabasePropertiesDialog extends JDialog {
     }
 
     private void setValues() {
-        encoding.setSelectedItem(panel.getBibDatabaseContext().getMetaData().getEncoding());
+        encoding.setSelectedItem(
+                panel.getBibDatabaseContext().getMetaData().getEncoding().orElse(Globals.prefs.getDefaultEncoding()));
 
         Optional<SaveOrderConfig> storedSaveOrderConfig = metaData.getSaveOrderConfig();
         boolean selected;
@@ -235,7 +236,8 @@ public class DatabasePropertiesDialog extends JDialog {
 
     private void storeSettings() {
 
-        Charset oldEncoding = panel.getBibDatabaseContext().getMetaData().getEncoding();
+        Charset oldEncoding = panel.getBibDatabaseContext().getMetaData().getEncoding()
+                .orElse(Globals.prefs.getDefaultEncoding());
         Charset newEncoding = (Charset) encoding.getSelectedItem();
         panel.getBibDatabaseContext().getMetaData().setEncoding(newEncoding);
 

--- a/src/main/java/net/sf/jabref/gui/exporter/AutoSaveManager.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/AutoSaveManager.java
@@ -92,7 +92,8 @@ public class AutoSaveManager {
         try {
             SavePreferences prefs = SavePreferences.loadForSaveFromPreferences(Globals.prefs)
                     .withMakeBackup(false)
-                    .withEncoding(panel.getBibDatabaseContext().getMetaData().getEncoding());
+                    .withEncoding(panel.getBibDatabaseContext().getMetaData().getEncoding()
+                            .orElse(Globals.prefs.getDefaultEncoding()));
 
             BibDatabaseWriter databaseWriter = new BibtexDatabaseWriter(FileSaveSession::new);
             SaveSession ss = databaseWriter.saveDatabase(panel.getBibDatabaseContext(), prefs);

--- a/src/main/java/net/sf/jabref/gui/exporter/ExportAction.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/ExportAction.java
@@ -124,7 +124,8 @@ public class ExportAction {
                             try {
                                 format.performExport(frame.getCurrentBasePanel().getBibDatabaseContext(),
                                         finFile.getPath(),
-                                        frame.getCurrentBasePanel().getBibDatabaseContext().getMetaData().getEncoding(),
+                                        frame.getCurrentBasePanel().getBibDatabaseContext().getMetaData().getEncoding()
+                                                .orElse(Globals.prefs.getDefaultEncoding()),
                                         finEntries);
                             } catch (Exception ex) {
                                 LOGGER.warn("Problem exporting", ex);

--- a/src/main/java/net/sf/jabref/gui/exporter/ExportToClipboardAction.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/ExportToClipboardAction.java
@@ -117,11 +117,14 @@ public class ExportToClipboardAction extends AbstractWorker {
 
             // Write to file:
             format.performExport(panel.getBibDatabaseContext(), tmp.getPath(),
-                    panel.getBibDatabaseContext().getMetaData().getEncoding(), entries);
+                    panel.getBibDatabaseContext().getMetaData().getEncoding()
+                            .orElse(Globals.prefs.getDefaultEncoding()),
+                    entries);
             // Read the file and put the contents on the clipboard:
             StringBuilder sb = new StringBuilder();
             try (Reader reader = new InputStreamReader(new FileInputStream(tmp),
-                    panel.getBibDatabaseContext().getMetaData().getEncoding())) {
+                    panel.getBibDatabaseContext().getMetaData().getEncoding()
+                            .orElse(Globals.prefs.getDefaultEncoding()))) {
                 int s;
                 while ((s = reader.read()) != -1) {
                     sb.append((char) s);

--- a/src/main/java/net/sf/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/SaveDatabaseAction.java
@@ -135,8 +135,10 @@ public class SaveDatabaseAction extends AbstractWorker {
                     return;
                 }
 
-                // Save the database
-                success = saveDatabase(panel.getBibDatabaseContext().getDatabaseFile(), false, panel.getBibDatabaseContext().getMetaData().getEncoding());
+                // Save the database:
+                success = saveDatabase(panel.getBibDatabaseContext().getDatabaseFile(), false,
+                        panel.getBibDatabaseContext().getMetaData().getEncoding()
+                                .orElse(Globals.prefs.getDefaultEncoding()));
 
                 Globals.getFileUpdateMonitor().updateTimeStamp(panel.getFileMonitorHandle());
             } else {

--- a/src/main/java/net/sf/jabref/gui/importer/ImportCustomizationDialog.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ImportCustomizationDialog.java
@@ -22,6 +22,7 @@ import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 import java.util.EnumSet;
 import java.util.Optional;
@@ -99,8 +100,9 @@ public class ImportCustomizationDialog extends JDialog {
         if (customImporterTable.getRowCount() > 0) {
             customImporterTable.setRowSelectionInterval(0, 0);
         }
-
         GUIUtil.correctRowHeight(customImporterTable);
+
+        ImportFormatPreferences importFormatPreferences = ImportFormatPreferences.fromPreferences(Globals.prefs);
 
         JButton addFromFolderButton = new JButton(Localization.lang("Add from folder"));
         addFromFolderButton.addActionListener(e -> {
@@ -116,8 +118,9 @@ public class ImportCustomizationDialog extends JDialog {
 
                 try {
                     importer.setClassName(pathToClass(importer.getFileFromBasePath(), new File(chosenFileStr)));
-                    importer.setName(importer.getInstance().getFormatName());
-                    importer.setCliId(importer.getInstance().getId());
+                    ImportFormat importFormat = importer.getInstance(importFormatPreferences);
+                    importer.setName(importFormat.getFormatName());
+                    importer.setCliId(importFormat.getId());
                     addOrReplaceImporter(importer);
                     customImporterTable.revalidate();
                     customImporterTable.repaint();
@@ -171,9 +174,10 @@ public class ImportCustomizationDialog extends JDialog {
             } else {
                 CustomImporter importer = ((ImportTableModel) customImporterTable.getModel()).getImporter(row);
                 try {
-                    ImportFormat importFormat = importer.getInstance();
+                    ImportFormat importFormat = importer.getInstance(importFormatPreferences);
                     JOptionPane.showMessageDialog(frame, importFormat.getDescription());
-                } catch (IOException | ClassNotFoundException | InstantiationException | IllegalAccessException exc) {
+                } catch (IOException | ClassNotFoundException | InstantiationException | NoSuchMethodException |
+                        IllegalAccessException | InvocationTargetException exc) {
                     LOGGER.warn("Could not instantiate importer " + importer.getName(), exc);
                     JOptionPane.showMessageDialog(frame, Localization.lang("Could not instantiate %0 %1",
                             importer.getName() + ":\n", exc.getMessage()));

--- a/src/main/java/net/sf/jabref/gui/importer/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ImportInspectionDialog.java
@@ -465,7 +465,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
             // Relate to existing database, if any:
             if (panel == null) {
                 database = new BibDatabase();
-                localMetaData = new MetaData();
+                localMetaData = new MetaData(Globals.prefs.getDefaultEncoding());
             } else {
                 database = panel.getDatabase();
                 localMetaData = panel.getBibDatabaseContext().getMetaData();
@@ -503,7 +503,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
             // Relate to existing database, if any:
             if (panel == null) {
                 database = new BibDatabase();
-                localMetaData = new MetaData();
+                localMetaData = new MetaData(Globals.prefs.getDefaultEncoding());
             } else {
                 database = panel.getDatabase();
                 localMetaData = panel.getBibDatabaseContext().getMetaData();

--- a/src/main/java/net/sf/jabref/gui/importer/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ImportInspectionDialog.java
@@ -465,7 +465,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
             // Relate to existing database, if any:
             if (panel == null) {
                 database = new BibDatabase();
-                localMetaData = new MetaData(Globals.prefs.getDefaultEncoding());
+                localMetaData = new MetaData();
             } else {
                 database = panel.getDatabase();
                 localMetaData = panel.getBibDatabaseContext().getMetaData();
@@ -503,7 +503,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
             // Relate to existing database, if any:
             if (panel == null) {
                 database = new BibDatabase();
-                localMetaData = new MetaData(Globals.prefs.getDefaultEncoding());
+                localMetaData = new MetaData();
             } else {
                 database = panel.getDatabase();
                 localMetaData = panel.getBibDatabaseContext().getMetaData();

--- a/src/main/java/net/sf/jabref/gui/importer/ImportMenuItem.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ImportMenuItem.java
@@ -261,7 +261,7 @@ public class ImportMenuItem extends JMenuItem implements ActionListener {
             return directParserResult;
         } else {
 
-            return new ParserResult(database);
+            return new ParserResult(database, Globals.prefs.getDefaultEncoding());
 
         }
     }

--- a/src/main/java/net/sf/jabref/gui/importer/ZipFileChooser.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ZipFileChooser.java
@@ -29,6 +29,7 @@ package net.sf.jabref.gui.importer;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -53,8 +54,10 @@ import javax.swing.ListSelectionModel;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumnModel;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.gui.util.FocusRequester;
 import net.sf.jabref.gui.util.GUIUtil;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.fileformat.CustomImporter;
 import net.sf.jabref.logic.importer.fileformat.ImportFormat;
 import net.sf.jabref.logic.l10n.Localization;
@@ -115,12 +118,14 @@ class ZipFileChooser extends JDialog {
                         .replace("/", ".");
                 importer.setClassName(className);
                 try {
-                    ImportFormat importFormat = importer.getInstance();
+                    ImportFormat importFormat = importer
+                            .getInstance(ImportFormatPreferences.fromPreferences(Globals.prefs));
                     importer.setName(importFormat.getFormatName());
                     importer.setCliId(importFormat.getId());
                     importCustomizationDialog.addOrReplaceImporter(importer);
                     dispose();
-                } catch (IOException | ClassNotFoundException | InstantiationException | IllegalAccessException exc) {
+                } catch (IOException | ClassNotFoundException | InstantiationException | IllegalAccessException |
+                        NoSuchMethodException | InvocationTargetException exc) {
                     LOGGER.warn("Could not instantiate importer: " + importer.getName(), exc);
                     JOptionPane.showMessageDialog(this, Localization.lang("Could not instantiate %0 %1",
                             importer.getName() + ":\n", exc.getMessage()));

--- a/src/main/java/net/sf/jabref/gui/importer/fetcher/DOItoBibTeXFetcher.java
+++ b/src/main/java/net/sf/jabref/gui/importer/fetcher/DOItoBibTeXFetcher.java
@@ -23,7 +23,7 @@ public class DOItoBibTeXFetcher implements EntryFetcher {
 
     @Override
     public boolean processQuery(String query, ImportInspector inspector, OutputPrinter status) {
-        ParserResult parserResult = new ParserResult();
+        ParserResult parserResult = new ParserResult(Globals.prefs.getDefaultEncoding());
         Optional<BibEntry> entry = DOItoBibTeX.getEntryFromDOI(query, parserResult,
                 ImportFormatPreferences.fromPreferences(Globals.prefs));
         if (parserResult.hasWarnings()) {

--- a/src/main/java/net/sf/jabref/gui/importer/fetcher/MedlineFetcher.java
+++ b/src/main/java/net/sf/jabref/gui/importer/fetcher/MedlineFetcher.java
@@ -29,7 +29,9 @@ import java.util.regex.Pattern;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.logic.help.HelpFile;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.ImportInspector;
 import net.sf.jabref.logic.importer.OutputPrinter;
 import net.sf.jabref.logic.importer.ParserResult;
@@ -238,8 +240,8 @@ public class MedlineFetcher implements EntryFetcher {
         try {
             URL url = new URL(baseUrl);
             URLConnection data = url.openConnection();
-            ParserResult result = new MedlineImporter().importDatabase(
-                    new BufferedReader(new InputStreamReader(data.getInputStream())));
+            ParserResult result = new MedlineImporter(ImportFormatPreferences.fromPreferences(Globals.prefs))
+                    .importDatabase(new BufferedReader(new InputStreamReader(data.getInputStream())));
             if (result.hasWarnings()) {
                 status.showMessage(result.getErrorMessage());
             }

--- a/src/main/java/net/sf/jabref/logic/cleanup/CleanupWorker.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/CleanupWorker.java
@@ -20,24 +20,23 @@ import java.util.List;
 import java.util.Objects;
 
 import net.sf.jabref.BibDatabaseContext;
-import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
+import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 public class CleanupWorker {
 
     private final BibDatabaseContext databaseContext;
-    private final JournalAbbreviationLoader repositoryLoader;
-    private final JabRefPreferences prefs;
+    private final String importFilenamePattern;
+    private final LayoutFormatterPreferences prefs;
     private int unsuccessfulRenames;
 
 
-    public CleanupWorker(BibDatabaseContext databaseContext, JournalAbbreviationLoader repositoryLoader,
-            JabRefPreferences prefs) {
+    public CleanupWorker(BibDatabaseContext databaseContext, String importFilenamePattern,
+            LayoutFormatterPreferences prefs) {
         this.databaseContext = databaseContext;
-        this.repositoryLoader = repositoryLoader;
+        this.importFilenamePattern = importFilenamePattern;
         this.prefs = prefs;
     }
 
@@ -82,7 +81,7 @@ public class CleanupWorker {
         }
         if (preset.isRenamePDF()) {
             RenamePdfCleanup cleaner = new RenamePdfCleanup(preset.isRenamePdfOnlyRelativePaths(), databaseContext,
-                    repositoryLoader, prefs);
+                    importFilenamePattern, prefs);
             jobs.add(cleaner);
             unsuccessfulRenames += cleaner.getUnsuccessfulRenames();
         }

--- a/src/main/java/net/sf/jabref/logic/cleanup/RenamePdfCleanup.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/RenamePdfCleanup.java
@@ -22,29 +22,28 @@ import java.util.Optional;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.logic.TypedBibEntry;
-import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
+import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.ParsedFileField;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 public class RenamePdfCleanup implements CleanupJob {
 
     private final BibDatabaseContext databaseContext;
     private final boolean onlyRelativePaths;
-    private final JournalAbbreviationLoader repositoryLoader;
-    private final JabRefPreferences prefs;
+    private final String importFilenamePattern;
+    private final LayoutFormatterPreferences prefs;
 
     private int unsuccessfulRenames;
 
 
     public RenamePdfCleanup(boolean onlyRelativePaths, BibDatabaseContext databaseContext,
-            JournalAbbreviationLoader repositoryLoader, JabRefPreferences prefs) {
+            String importFilenamePattern, LayoutFormatterPreferences prefs) {
         this.databaseContext = Objects.requireNonNull(databaseContext);
         this.onlyRelativePaths = onlyRelativePaths;
-        this.repositoryLoader = Objects.requireNonNull(repositoryLoader);
+        this.importFilenamePattern = Objects.requireNonNull(importFilenamePattern);
         this.prefs = Objects.requireNonNull(prefs);
     }
 
@@ -63,9 +62,9 @@ public class RenamePdfCleanup implements CleanupJob {
                 continue;
             }
 
-            StringBuilder newFilename = new StringBuilder(
-                    FileUtil.createFileNameFromPattern(databaseContext.getDatabase(), entry, repositoryLoader, prefs)
-                            .trim());
+            StringBuilder newFilename = new StringBuilder(FileUtil
+                    .createFileNameFromPattern(databaseContext.getDatabase(), entry, importFilenamePattern, prefs)
+                    .trim());
 
             //Add extension to newFilename
             newFilename.append('.').append(FileUtil.getFileExtension(realOldFilename).orElse("pdf"));

--- a/src/main/java/net/sf/jabref/logic/importer/ImportFormatReader.java
+++ b/src/main/java/net/sf/jabref/logic/importer/ImportFormatReader.java
@@ -16,6 +16,7 @@
 package net.sf.jabref.logic.importer;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -93,9 +94,11 @@ public class ImportFormatReader {
          */
         for (CustomImporter importer : importFormatPreferences.getCustomImportList()) {
             try {
-                ImportFormat imFo = importer.getInstance();
+                ImportFormat imFo = importer.getInstance(importFormatPreferences);
                 formats.add(imFo);
-            } catch (IOException | ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+            } catch (IOException | ClassNotFoundException | InstantiationException | IllegalAccessException |
+                    IllegalArgumentException | InvocationTargetException | NoSuchMethodException |
+                    SecurityException e) {
                 LOGGER.error("Could not instantiate " + importer.getName()
                         + " importer, will ignore it. Please check if the class is still available.", e);
             }

--- a/src/main/java/net/sf/jabref/logic/importer/ImportFormatReader.java
+++ b/src/main/java/net/sf/jabref/logic/importer/ImportFormatReader.java
@@ -70,23 +70,23 @@ public class ImportFormatReader {
 
         formats.clear();
 
-        formats.add(new BiblioscapeImporter());
+        formats.add(new BiblioscapeImporter(importFormatPreferences));
         formats.add(new BibtexImporter(importFormatPreferences));
-        formats.add(new BibTeXMLImporter());
-        formats.add(new CopacImporter());
+        formats.add(new BibTeXMLImporter(importFormatPreferences));
+        formats.add(new CopacImporter(importFormatPreferences));
         formats.add(new EndnoteImporter(importFormatPreferences));
         formats.add(new FreeCiteImporter(importFormatPreferences));
-        formats.add(new InspecImporter());
-        formats.add(new IsiImporter());
-        formats.add(new MedlineImporter());
-        formats.add(new MedlinePlainImporter());
-        formats.add(new MsBibImporter());
-        formats.add(new OvidImporter());
+        formats.add(new InspecImporter(importFormatPreferences));
+        formats.add(new IsiImporter(importFormatPreferences));
+        formats.add(new MedlineImporter(importFormatPreferences));
+        formats.add(new MedlinePlainImporter(importFormatPreferences));
+        formats.add(new MsBibImporter(importFormatPreferences));
+        formats.add(new OvidImporter(importFormatPreferences));
         formats.add(new PdfContentImporter(importFormatPreferences));
-        formats.add(new PdfXmpImporter(xmpPreferences));
+        formats.add(new PdfXmpImporter(xmpPreferences, importFormatPreferences));
         formats.add(new RepecNepImporter(importFormatPreferences));
-        formats.add(new RisImporter());
-        formats.add(new SilverPlatterImporter());
+        formats.add(new RisImporter(importFormatPreferences));
+        formats.add(new SilverPlatterImporter(importFormatPreferences));
 
         /**
          * Get custom import formats
@@ -237,7 +237,7 @@ public class ImportFormatReader {
 
         if (bestResult != null) {
             // we found something
-            ParserResult parserResult = new ParserResult(bestResult);
+            ParserResult parserResult = new ParserResult(bestResult, importFormatPreferences.getEncoding());
             return new UnknownFormatImport(bestFormatName, parserResult);
         }
 

--- a/src/main/java/net/sf/jabref/logic/importer/ParserResult.java
+++ b/src/main/java/net/sf/jabref/logic/importer/ParserResult.java
@@ -16,6 +16,7 @@
 package net.sf.jabref.logic.importer;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -47,16 +48,17 @@ public class ParserResult {
     private boolean invalid;
     private boolean toOpenTab;
 
-    public ParserResult() {
-        this(Collections.emptyList());
+
+    public ParserResult(Charset encoding) {
+        this(Collections.emptyList(), encoding);
     }
 
-    public ParserResult(Collection<BibEntry> entries) {
-        this(BibDatabases.createDatabase(BibDatabases.purgeEmptyEntries(entries)));
+    public ParserResult(Collection<BibEntry> entries, Charset encoding) {
+        this(BibDatabases.createDatabase(BibDatabases.purgeEmptyEntries(entries)), encoding);
     }
 
-    public ParserResult(BibDatabase database) {
-        this(database, new MetaData(), new HashMap<>());
+    public ParserResult(BibDatabase database, Charset encoding) {
+        this(database, new MetaData(encoding), new HashMap<>());
     }
 
     public ParserResult(BibDatabase base, MetaData metaData, Map<String, EntryType> entryTypes) {
@@ -65,8 +67,8 @@ public class ParserResult {
         this.entryTypes = entryTypes;
     }
 
-    public static ParserResult fromErrorMessage(String message) {
-        ParserResult parserResult = new ParserResult();
+    public static ParserResult fromErrorMessage(String message, Charset encoding) {
+        ParserResult parserResult = new ParserResult(encoding);
         parserResult.addWarning(message);
         return parserResult;
     }

--- a/src/main/java/net/sf/jabref/logic/importer/ParserResult.java
+++ b/src/main/java/net/sf/jabref/logic/importer/ParserResult.java
@@ -49,12 +49,24 @@ public class ParserResult {
     private boolean toOpenTab;
 
 
+    public ParserResult() {
+        this(Collections.emptyList());
+    }
+
     public ParserResult(Charset encoding) {
         this(Collections.emptyList(), encoding);
     }
 
+    public ParserResult(Collection<BibEntry> entries) {
+        this(BibDatabases.createDatabase(BibDatabases.purgeEmptyEntries(entries)));
+    }
+
     public ParserResult(Collection<BibEntry> entries, Charset encoding) {
         this(BibDatabases.createDatabase(BibDatabases.purgeEmptyEntries(entries)), encoding);
+    }
+
+    public ParserResult(BibDatabase database) {
+        this(database, new MetaData(), new HashMap<>());
     }
 
     public ParserResult(BibDatabase database, Charset encoding) {
@@ -67,11 +79,12 @@ public class ParserResult {
         this.entryTypes = entryTypes;
     }
 
-    public static ParserResult fromErrorMessage(String message, Charset encoding) {
-        ParserResult parserResult = new ParserResult(encoding);
+    public static ParserResult fromErrorMessage(String message) {
+        ParserResult parserResult = new ParserResult();
         parserResult.addWarning(message);
         return parserResult;
     }
+
 
     /**
      * Check if this base is marked to be added to the currently open tab. Default is false.

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/BibTeXMLImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/BibTeXMLImporter.java
@@ -34,6 +34,7 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.datatype.XMLGregorianCalendar;
 
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.importer.fileformat.bibtexml.Entry;
 import net.sf.jabref.logic.importer.fileformat.bibtexml.File;
@@ -61,6 +62,11 @@ public class BibTeXMLImporter extends ImportFormat {
     private static final List<String> IGNORED_METHODS = Arrays.asList("getClass", "getAnnotate", "getContents",
             "getPrice", "getSize", "getChapter");
 
+    private final ImportFormatPreferences importFormatPreferences;
+
+    public BibTeXMLImporter(ImportFormatPreferences importFormatPreferences) {
+        this.importFormatPreferences = importFormatPreferences;
+    }
 
     @Override
     public String getFormatName() {
@@ -161,9 +167,9 @@ public class BibTeXMLImporter extends ImportFormat {
             }
         } catch (JAXBException e) {
             LOGGER.error("Error with XML parser configuration", e);
-            return ParserResult.fromErrorMessage(e.getLocalizedMessage());
+            return ParserResult.fromErrorMessage(e.getLocalizedMessage(), importFormatPreferences.getEncoding());
         }
-        return new ParserResult(bibItems);
+        return new ParserResult(bibItems, importFormatPreferences.getEncoding());
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/BibTeXMLImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/BibTeXMLImporter.java
@@ -55,6 +55,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class BibTeXMLImporter extends ImportFormat {
 
+
     private static final Log LOGGER = LogFactory.getLog(BibTeXMLImporter.class);
 
     private static final Pattern START_PATTERN = Pattern.compile("<(bibtex:)?file .*");
@@ -62,10 +63,9 @@ public class BibTeXMLImporter extends ImportFormat {
     private static final List<String> IGNORED_METHODS = Arrays.asList("getClass", "getAnnotate", "getContents",
             "getPrice", "getSize", "getChapter");
 
-    private final ImportFormatPreferences importFormatPreferences;
 
     public BibTeXMLImporter(ImportFormatPreferences importFormatPreferences) {
-        this.importFormatPreferences = importFormatPreferences;
+        super(importFormatPreferences);
     }
 
     @Override
@@ -167,7 +167,7 @@ public class BibTeXMLImporter extends ImportFormat {
             }
         } catch (JAXBException e) {
             LOGGER.error("Error with XML parser configuration", e);
-            return ParserResult.fromErrorMessage(e.getLocalizedMessage(), importFormatPreferences.getEncoding());
+            return ParserResult.fromErrorMessage(e.getLocalizedMessage());
         }
         return new ParserResult(bibItems, importFormatPreferences.getEncoding());
     }

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/BiblioscapeImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/BiblioscapeImporter.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.model.entry.BibEntry;
@@ -35,6 +36,13 @@ import net.sf.jabref.model.entry.FieldName;
  * field "comment".
  */
 public class BiblioscapeImporter extends ImportFormat {
+
+    private final ImportFormatPreferences preferences;
+
+
+    public BiblioscapeImporter(ImportFormatPreferences preferences) {
+        this.preferences = preferences;
+    }
 
     @Override
     public String getFormatName() {
@@ -287,12 +295,12 @@ public class BiblioscapeImporter extends ImportFormat {
             }
             // continuation (folding) of previous line
             if (previousLine == null) {
-                return new ParserResult();
+                return new ParserResult(preferences.getEncoding());
             }
             previousLine.append(line.trim());
         }
 
-        return new ParserResult(bibItems);
+        return new ParserResult(bibItems, preferences.getEncoding());
     }
 
 }

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/BiblioscapeImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/BiblioscapeImporter.java
@@ -37,11 +37,8 @@ import net.sf.jabref.model.entry.FieldName;
  */
 public class BiblioscapeImporter extends ImportFormat {
 
-    private final ImportFormatPreferences preferences;
-
-
-    public BiblioscapeImporter(ImportFormatPreferences preferences) {
-        this.preferences = preferences;
+    public BiblioscapeImporter(ImportFormatPreferences importFormatPreferences) {
+        super(importFormatPreferences);
     }
 
     @Override
@@ -295,12 +292,12 @@ public class BiblioscapeImporter extends ImportFormat {
             }
             // continuation (folding) of previous line
             if (previousLine == null) {
-                return new ParserResult(preferences.getEncoding());
+                return new ParserResult();
             }
             previousLine.append(line.trim());
         }
 
-        return new ParserResult(bibItems, preferences.getEncoding());
+        return new ParserResult(bibItems);
     }
 
 }

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/BibtexImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/BibtexImporter.java
@@ -38,12 +38,12 @@ public class BibtexImporter extends ImportFormat {
     // Signature written at the top of the .bib file in earlier versions.
     private static final String SIGNATURE = "This file was created with JabRef";
 
-    private final ImportFormatPreferences importFormatPreferences;
-
 
     public BibtexImporter(ImportFormatPreferences importFormatPreferences) {
-        this.importFormatPreferences = importFormatPreferences;
+        super(importFormatPreferences);
     }
+
+
     /**
      * @return true as we have no effective way to decide whether a file is in bibtex format or not. See
      *         https://github.com/JabRef/jabref/pull/379#issuecomment-158685726 for more details.

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/CopacImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/CopacImporter.java
@@ -39,11 +39,9 @@ public class CopacImporter extends ImportFormat {
 
     private static final Pattern COPAC_PATTERN = Pattern.compile("^\\s*TI- ");
 
-    private final ImportFormatPreferences importFormatPreferences;
-
 
     public CopacImporter(ImportFormatPreferences importFormatPreferences) {
-        this.importFormatPreferences = importFormatPreferences;
+        super(importFormatPreferences);
     }
 
     @Override
@@ -158,7 +156,7 @@ public class CopacImporter extends ImportFormat {
             results.add(b);
         }
 
-        return new ParserResult(results, importFormatPreferences.getEncoding());
+        return new ParserResult(results);
     }
 
     private static void setOrAppend(BibEntry b, String field, String value, String separator) {

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/CopacImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/CopacImporter.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.model.entry.BibEntry;
@@ -37,6 +38,13 @@ import net.sf.jabref.model.entry.FieldName;
 public class CopacImporter extends ImportFormat {
 
     private static final Pattern COPAC_PATTERN = Pattern.compile("^\\s*TI- ");
+
+    private final ImportFormatPreferences importFormatPreferences;
+
+
+    public CopacImporter(ImportFormatPreferences importFormatPreferences) {
+        this.importFormatPreferences = importFormatPreferences;
+    }
 
     @Override
     public String getFormatName() {
@@ -150,7 +158,7 @@ public class CopacImporter extends ImportFormat {
             results.add(b);
         }
 
-        return new ParserResult(results);
+        return new ParserResult(results, importFormatPreferences.getEncoding());
     }
 
     private static void setOrAppend(BibEntry b, String field, String value, String separator) {

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/CustomImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/CustomImporter.java
@@ -30,12 +30,15 @@ package net.sf.jabref.logic.importer.fileformat;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 
 /**
  * Object with data for a custom importer.
@@ -147,11 +150,14 @@ public class CustomImporter implements Comparable<CustomImporter> {
         return this.name;
     }
 
-    public ImportFormat getInstance() throws IOException, ClassNotFoundException,
-            InstantiationException, IllegalAccessException {
+    public ImportFormat getInstance(ImportFormatPreferences importFormatPreferences)
+            throws IOException, ClassNotFoundException, InstantiationException, IllegalAccessException,
+            IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException {
         try (URLClassLoader cl = new URLClassLoader(new URL[] {getBasePathUrl()})) {
             Class<?> clazz = Class.forName(className, true, cl);
-            ImportFormat importFormat = (ImportFormat) clazz.newInstance();
+            ImportFormat importFormat = (ImportFormat) clazz
+                    .getDeclaredConstructor(new Class[] {ImportFormatPreferences.class})
+                    .newInstance(importFormatPreferences);
             return importFormat;
         }
     }

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/EndnoteImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/EndnoteImporter.java
@@ -46,10 +46,10 @@ public class EndnoteImporter extends ImportFormat {
     private static final Pattern A_PATTERN = Pattern.compile("%A .*");
     private static final Pattern E_PATTERN = Pattern.compile("%E .*");
 
-    private final ImportFormatPreferences preferences;
+    private final ImportFormatPreferences importFormatPreferences;
 
-    public EndnoteImporter(ImportFormatPreferences preferences) {
-        this.preferences = preferences;
+    public EndnoteImporter(ImportFormatPreferences importFormatPreferences) {
+        this.importFormatPreferences = importFormatPreferences;
     }
 
     @Override
@@ -244,7 +244,7 @@ public class EndnoteImporter extends ImportFormat {
                     }
                 } else if ("F".equals(prefix)) {
                     hm.put(BibEntry.KEY_FIELD, BibtexKeyPatternUtil.checkLegalKey(val,
-                            preferences.getBibtexKeyPatternPreferences().isEnforceLegalKey()));
+                            importFormatPreferences.getBibtexKeyPatternPreferences().isEnforceLegalKey()));
                 }
             }
 
@@ -276,7 +276,7 @@ public class EndnoteImporter extends ImportFormat {
 
         }
 
-        return new ParserResult(bibitems);
+        return new ParserResult(bibitems, importFormatPreferences.getEncoding());
 
     }
 

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/EndnoteImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/EndnoteImporter.java
@@ -46,10 +46,9 @@ public class EndnoteImporter extends ImportFormat {
     private static final Pattern A_PATTERN = Pattern.compile("%A .*");
     private static final Pattern E_PATTERN = Pattern.compile("%E .*");
 
-    private final ImportFormatPreferences importFormatPreferences;
 
     public EndnoteImporter(ImportFormatPreferences importFormatPreferences) {
-        this.importFormatPreferences = importFormatPreferences;
+        super(importFormatPreferences);
     }
 
     @Override
@@ -276,7 +275,7 @@ public class EndnoteImporter extends ImportFormat {
 
         }
 
-        return new ParserResult(bibitems, importFormatPreferences.getEncoding());
+        return new ParserResult(bibitems);
 
     }
 

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/FreeCiteImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/FreeCiteImporter.java
@@ -96,10 +96,10 @@ public class FreeCiteImporter extends ImportFormat {
             conn = url.openConnection();
         } catch (MalformedURLException e) {
             LOGGER.warn("Bad URL", e);
-            return new ParserResult();
+            return new ParserResult(importFormatPreferences.getEncoding());
         } catch (IOException e) {
             LOGGER.warn("Could not download", e);
-            return new ParserResult();
+            return new ParserResult(importFormatPreferences.getEncoding());
         }
         try {
             conn.setRequestProperty("accept", "text/xml");
@@ -114,7 +114,8 @@ public class FreeCiteImporter extends ImportFormat {
             LOGGER.warn("Already connected.", e);
         } catch (IOException e) {
             LOGGER.warn("Unable to connect to FreeCite online service.", e);
-            return ParserResult.fromErrorMessage(Localization.lang("Unable to connect to FreeCite online service."));
+            return ParserResult.fromErrorMessage(Localization.lang("Unable to connect to FreeCite online service."),
+                    importFormatPreferences.getEncoding());
         }
         // output is in conn.getInputStream();
         // new InputStreamReader(conn.getInputStream())
@@ -229,10 +230,10 @@ public class FreeCiteImporter extends ImportFormat {
             parser.close();
         } catch (IOException | XMLStreamException ex) {
             LOGGER.warn("Could not parse", ex);
-            return new ParserResult();
+            return new ParserResult(importFormatPreferences.getEncoding());
         }
 
-        return new ParserResult(res);
+        return new ParserResult(res, importFormatPreferences.getEncoding());
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/FreeCiteImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/FreeCiteImporter.java
@@ -34,13 +34,14 @@ import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
-import net.sf.jabref.JabRefGUI;
+import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.bibtexkeypattern.BibtexKeyPatternUtil;
 import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.logic.util.OS;
+import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.EntryType;
@@ -57,11 +58,9 @@ public class FreeCiteImporter extends ImportFormat {
 
     private static final Log LOGGER = LogFactory.getLog(FreeCiteImporter.class);
 
-    private final ImportFormatPreferences importFormatPreferences;
-
 
     public FreeCiteImporter(ImportFormatPreferences importFormatPreferences) {
-        this.importFormatPreferences = importFormatPreferences;
+        super(importFormatPreferences);
     }
 
     @Override
@@ -96,10 +95,10 @@ public class FreeCiteImporter extends ImportFormat {
             conn = url.openConnection();
         } catch (MalformedURLException e) {
             LOGGER.warn("Bad URL", e);
-            return new ParserResult(importFormatPreferences.getEncoding());
+            return new ParserResult();
         } catch (IOException e) {
             LOGGER.warn("Could not download", e);
-            return new ParserResult(importFormatPreferences.getEncoding());
+            return new ParserResult();
         }
         try {
             conn.setRequestProperty("accept", "text/xml");
@@ -114,8 +113,7 @@ public class FreeCiteImporter extends ImportFormat {
             LOGGER.warn("Already connected.", e);
         } catch (IOException e) {
             LOGGER.warn("Unable to connect to FreeCite online service.", e);
-            return ParserResult.fromErrorMessage(Localization.lang("Unable to connect to FreeCite online service."),
-                    importFormatPreferences.getEncoding());
+            return ParserResult.fromErrorMessage(Localization.lang("Unable to connect to FreeCite online service."));
         }
         // output is in conn.getInputStream();
         // new InputStreamReader(conn.getInputStream())
@@ -218,9 +216,7 @@ public class FreeCiteImporter extends ImportFormat {
                     e.setType(type);
 
                     // autogenerate label (BibTeX key)
-                    BibtexKeyPatternUtil.makeLabel(
-                            JabRefGUI.getMainFrame().getCurrentBasePanel().getBibDatabaseContext().getMetaData(),
-                            JabRefGUI.getMainFrame().getCurrentBasePanel().getDatabase(), e,
+                    BibtexKeyPatternUtil.makeLabel(new MetaData(), new BibDatabase(), e,
                             importFormatPreferences.getBibtexKeyPatternPreferences());
 
                     res.add(e);
@@ -230,10 +226,10 @@ public class FreeCiteImporter extends ImportFormat {
             parser.close();
         } catch (IOException | XMLStreamException ex) {
             LOGGER.warn("Could not parse", ex);
-            return new ParserResult(importFormatPreferences.getEncoding());
+            return new ParserResult();
         }
 
-        return new ParserResult(res, importFormatPreferences.getEncoding());
+        return new ParserResult(res);
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/ImportFormat.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/ImportFormat.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Objects;
 
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.util.FileExtensions;
 
@@ -40,6 +41,20 @@ public abstract class ImportFormat implements Comparable<ImportFormat> {
      * TODO: Is this field really needed or would calling IdGenerator.next() suffice?
      */
     public static final String DEFAULT_BIBTEXENTRY_ID = "__ID";
+
+    /*
+     * The available preferences. If more are needed, add them to ImportFormatPreferences through a pull request.
+     */
+    protected final ImportFormatPreferences importFormatPreferences;
+
+
+    /**
+     * Any ImportFormat has a constructor with an ImportFormatPreferences argument
+     */
+
+    public ImportFormat(ImportFormatPreferences importFormatPreferences) {
+        this.importFormatPreferences = importFormatPreferences;
+    }
 
     /**
      * Check whether the source is in the correct format for this importer.

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/InspecImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/InspecImporter.java
@@ -35,14 +35,12 @@ import net.sf.jabref.model.entry.FieldName;
  */
 public class InspecImporter extends ImportFormat {
 
-    private static final Pattern INSPEC_PATTERN = Pattern.compile("Record.*INSPEC.*");
-
-    private final ImportFormatPreferences importFormatPreferences;
-
-
     public InspecImporter(ImportFormatPreferences importFormatPreferences) {
-        this.importFormatPreferences = importFormatPreferences;
+        super(importFormatPreferences);
     }
+
+
+    private static final Pattern INSPEC_PATTERN = Pattern.compile("Record.*INSPEC.*");
 
     @Override
     public String getFormatName() {
@@ -150,6 +148,6 @@ public class InspecImporter extends ImportFormat {
 
         }
 
-        return new ParserResult(bibitems, importFormatPreferences.getEncoding());
+        return new ParserResult(bibitems);
     }
 }

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/InspecImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/InspecImporter.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.model.entry.AuthorList;
@@ -35,6 +36,13 @@ import net.sf.jabref.model.entry.FieldName;
 public class InspecImporter extends ImportFormat {
 
     private static final Pattern INSPEC_PATTERN = Pattern.compile("Record.*INSPEC.*");
+
+    private final ImportFormatPreferences importFormatPreferences;
+
+
+    public InspecImporter(ImportFormatPreferences importFormatPreferences) {
+        this.importFormatPreferences = importFormatPreferences;
+    }
 
     @Override
     public String getFormatName() {
@@ -142,6 +150,6 @@ public class InspecImporter extends ImportFormat {
 
         }
 
-        return new ParserResult(bibitems);
+        return new ParserResult(bibitems, importFormatPreferences.getEncoding());
     }
 }

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/IsiImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/IsiImporter.java
@@ -52,17 +52,16 @@ import net.sf.jabref.model.entry.MonthUtil;
  */
 public class IsiImporter extends ImportFormat {
 
+
     private static final Pattern SUB_SUP_PATTERN = Pattern.compile("/(sub|sup)\\s+(.*?)\\s*/");
 
     // 2006.09.05: Modified pattern to avoid false positives for other files due to an
     // extra | at the end:
     private static final Pattern ISI_PATTERN = Pattern.compile("FN ISI Export Format|VR 1.|PY \\d{4}");
 
-    private final ImportFormatPreferences importFormatPreferences;
-
 
     public IsiImporter(ImportFormatPreferences importFormatPreferences) {
-        this.importFormatPreferences = importFormatPreferences;
+        super(importFormatPreferences);
     }
 
     @Override
@@ -346,7 +345,7 @@ public class IsiImporter extends ImportFormat {
 
             bibitems.add(b);
         }
-        return new ParserResult(bibitems, importFormatPreferences.getEncoding());
+        return new ParserResult(bibitems);
     }
 
     private static String parsePages(String value) {

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/IsiImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/IsiImporter.java
@@ -26,6 +26,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import net.sf.jabref.logic.formatter.casechanger.TitleCaseFormatter;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.model.entry.BibEntry;
@@ -57,6 +58,12 @@ public class IsiImporter extends ImportFormat {
     // extra | at the end:
     private static final Pattern ISI_PATTERN = Pattern.compile("FN ISI Export Format|VR 1.|PY \\d{4}");
 
+    private final ImportFormatPreferences importFormatPreferences;
+
+
+    public IsiImporter(ImportFormatPreferences importFormatPreferences) {
+        this.importFormatPreferences = importFormatPreferences;
+    }
 
     @Override
     public String getFormatName() {
@@ -339,7 +346,7 @@ public class IsiImporter extends ImportFormat {
 
             bibitems.add(b);
         }
-        return new ParserResult(bibitems);
+        return new ParserResult(bibitems, importFormatPreferences.getEncoding());
     }
 
     private static String parsePages(String value) {

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/MedlineImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/MedlineImporter.java
@@ -33,6 +33,7 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.importer.fileformat.medline.Abstract;
 import net.sf.jabref.logic.importer.fileformat.medline.AbstractText;
@@ -101,6 +102,12 @@ public class MedlineImporter extends ImportFormat {
 
     private static final Locale ENGLISH = Locale.ENGLISH;
 
+    private final ImportFormatPreferences importFormatPreferences;
+
+
+    public MedlineImporter(ImportFormatPreferences importFormatPreferences) {
+        this.importFormatPreferences = importFormatPreferences;
+    }
 
     @Override
     public String getFormatName() {
@@ -184,9 +191,9 @@ public class MedlineImporter extends ImportFormat {
             }
         } catch (JAXBException | XMLStreamException e) {
             LOGGER.debug("could not parse document", e);
-            return ParserResult.fromErrorMessage(e.getLocalizedMessage());
+            return ParserResult.fromErrorMessage(e.getLocalizedMessage(), importFormatPreferences.getEncoding());
         }
-        return new ParserResult(bibItems);
+        return new ParserResult(bibItems, importFormatPreferences.getEncoding());
     }
 
     private void parseBookArticle(PubmedBookArticle currentArticle, List<BibEntry> bibItems) {

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/MedlineImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/MedlineImporter.java
@@ -97,16 +97,15 @@ import org.apache.commons.logging.LogFactory;
  */
 public class MedlineImporter extends ImportFormat {
 
+
     private static final Log LOGGER = LogFactory.getLog(MedlineImporter.class);
     private static final String KEYWORD_SEPARATOR = "; ";
 
     private static final Locale ENGLISH = Locale.ENGLISH;
 
-    private final ImportFormatPreferences importFormatPreferences;
-
 
     public MedlineImporter(ImportFormatPreferences importFormatPreferences) {
-        this.importFormatPreferences = importFormatPreferences;
+        super(importFormatPreferences);
     }
 
     @Override
@@ -191,9 +190,9 @@ public class MedlineImporter extends ImportFormat {
             }
         } catch (JAXBException | XMLStreamException e) {
             LOGGER.debug("could not parse document", e);
-            return ParserResult.fromErrorMessage(e.getLocalizedMessage(), importFormatPreferences.getEncoding());
+            return ParserResult.fromErrorMessage(e.getLocalizedMessage());
         }
-        return new ParserResult(bibItems, importFormatPreferences.getEncoding());
+        return new ParserResult(bibItems);
     }
 
     private void parseBookArticle(PubmedBookArticle currentArticle, List<BibEntry> bibItems) {

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/MedlinePlainImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/MedlinePlainImporter.java
@@ -50,11 +50,9 @@ public class MedlinePlainImporter extends ImportFormat {
     private static final Pattern CREATE_DATE_PATTERN = Pattern.compile("\\d{4}/[0123]?\\d/\\s?[012]\\d:[0-5]\\d");
     private static final Pattern COMPLETE_DATE_PATTERN = Pattern.compile("\\d{8}");
 
-    private final ImportFormatPreferences importFormatPreferences;
-
 
     public MedlinePlainImporter(ImportFormatPreferences importFormatPreferences) {
-        this.importFormatPreferences = importFormatPreferences;
+        super(importFormatPreferences);
     }
 
     @Override
@@ -239,7 +237,7 @@ public class MedlinePlainImporter extends ImportFormat {
             bibitems.add(b);
         }
 
-        return new ParserResult(bibitems, importFormatPreferences.getEncoding());
+        return new ParserResult(bibitems);
 
     }
 

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/MedlinePlainImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/MedlinePlainImporter.java
@@ -26,6 +26,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.logic.util.OS;
@@ -49,6 +50,12 @@ public class MedlinePlainImporter extends ImportFormat {
     private static final Pattern CREATE_DATE_PATTERN = Pattern.compile("\\d{4}/[0123]?\\d/\\s?[012]\\d:[0-5]\\d");
     private static final Pattern COMPLETE_DATE_PATTERN = Pattern.compile("\\d{8}");
 
+    private final ImportFormatPreferences importFormatPreferences;
+
+
+    public MedlinePlainImporter(ImportFormatPreferences importFormatPreferences) {
+        this.importFormatPreferences = importFormatPreferences;
+    }
 
     @Override
     public String getFormatName() {
@@ -232,7 +239,7 @@ public class MedlinePlainImporter extends ImportFormat {
             bibitems.add(b);
         }
 
-        return new ParserResult(bibitems);
+        return new ParserResult(bibitems, importFormatPreferences.getEncoding());
 
     }
 

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/MsBibImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/MsBibImporter.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.msbib.MSBibDatabase;
 import net.sf.jabref.logic.util.FileExtensions;
@@ -36,6 +37,13 @@ import org.xml.sax.InputSource;
  * ...
  */
 public class MsBibImporter extends ImportFormat {
+
+    private final ImportFormatPreferences importFormatPreferences;
+
+
+    public MsBibImporter(ImportFormatPreferences importFormatPreferences) {
+        this.importFormatPreferences = importFormatPreferences;
+    }
 
     @Override
     public boolean isRecognizedFormat(BufferedReader reader) throws IOException {
@@ -63,7 +71,7 @@ public class MsBibImporter extends ImportFormat {
         Objects.requireNonNull(reader);
 
         MSBibDatabase dbase = new MSBibDatabase();
-        return new ParserResult(dbase.importEntries(reader));
+        return new ParserResult(dbase.importEntries(reader), importFormatPreferences.getEncoding());
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/MsBibImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/MsBibImporter.java
@@ -38,11 +38,8 @@ import org.xml.sax.InputSource;
  */
 public class MsBibImporter extends ImportFormat {
 
-    private final ImportFormatPreferences importFormatPreferences;
-
-
     public MsBibImporter(ImportFormatPreferences importFormatPreferences) {
-        this.importFormatPreferences = importFormatPreferences;
+        super(importFormatPreferences);
     }
 
     @Override
@@ -71,7 +68,7 @@ public class MsBibImporter extends ImportFormat {
         Objects.requireNonNull(reader);
 
         MSBibDatabase dbase = new MSBibDatabase();
-        return new ParserResult(dbase.importEntries(reader), importFormatPreferences.getEncoding());
+        return new ParserResult(dbase.importEntries(reader));
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/OvidImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/OvidImporter.java
@@ -57,11 +57,8 @@ public class OvidImporter extends ImportFormat {
 
     private static final int MAX_ITEMS = 50;
 
-    private final ImportFormatPreferences importFormatPreferences;
-
-
     public OvidImporter(ImportFormatPreferences importFormatPreferences) {
-        this.importFormatPreferences = importFormatPreferences;
+        super(importFormatPreferences);
     }
 
     @Override
@@ -237,7 +234,7 @@ public class OvidImporter extends ImportFormat {
 
         }
 
-        return new ParserResult(bibitems, importFormatPreferences.getEncoding());
+        return new ParserResult(bibitems);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/OvidImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/OvidImporter.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.model.entry.AuthorList;
@@ -55,6 +56,13 @@ public class OvidImporter extends ImportFormat {
     private static final Pattern OVID_PATTERN = Pattern.compile(OVID_PATTERN_STRING);
 
     private static final int MAX_ITEMS = 50;
+
+    private final ImportFormatPreferences importFormatPreferences;
+
+
+    public OvidImporter(ImportFormatPreferences importFormatPreferences) {
+        this.importFormatPreferences = importFormatPreferences;
+    }
 
     @Override
     public String getFormatName() {
@@ -229,7 +237,7 @@ public class OvidImporter extends ImportFormat {
 
         }
 
-        return new ParserResult(bibitems);
+        return new ParserResult(bibitems, importFormatPreferences.getEncoding());
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/PdfContentImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/PdfContentImporter.java
@@ -64,11 +64,8 @@ public class PdfContentImporter extends ImportFormat {
 
     private String year;
 
-    private final ImportFormatPreferences importFormatPreferences;
-
-
     public PdfContentImporter(ImportFormatPreferences importFormatPreferences) {
-        this.importFormatPreferences = importFormatPreferences;
+        super(importFormatPreferences);
     }
     /**
      * Removes all non-letter characters at the end
@@ -240,7 +237,7 @@ public class PdfContentImporter extends ImportFormat {
             if (i >= lines.length) {
                 // PDF could not be parsed or is empty
                 // return empty list
-                return new ParserResult(importFormatPreferences.getEncoding());
+                return new ParserResult();
             }
 
             // we start at the current line
@@ -489,14 +486,12 @@ public class PdfContentImporter extends ImportFormat {
 
             result.add(entry);
         } catch (EncryptedPdfsNotSupportedException e) {
-            return ParserResult.fromErrorMessage(Localization.lang("Decryption not supported."),
-                    importFormatPreferences.getEncoding());
+            return ParserResult.fromErrorMessage(Localization.lang("Decryption not supported."));
         } catch(IOException exception) {
-            return ParserResult.fromErrorMessage(exception.getLocalizedMessage(),
-                    importFormatPreferences.getEncoding());
+            return ParserResult.fromErrorMessage(exception.getLocalizedMessage());
         }
 
-        return new ParserResult(result, importFormatPreferences.getEncoding());
+        return new ParserResult(result);
     }
 
     private String getFirstPageContents(PDDocument document) throws IOException {

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/PdfContentImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/PdfContentImporter.java
@@ -219,7 +219,7 @@ public class PdfContentImporter extends ImportFormat {
 
             Optional<DOI> doi = DOI.findInText(firstPageContents);
             if (doi.isPresent()) {
-                ParserResult parserResult = new ParserResult(result);
+                ParserResult parserResult = new ParserResult(result, importFormatPreferences.getEncoding());
                 Optional<BibEntry> entry = DOItoBibTeX.getEntryFromDOI(doi.get().getDOI(), parserResult,
                         importFormatPreferences);
                 entry.ifPresent(parserResult.getDatabase()::insertEntry);
@@ -240,7 +240,7 @@ public class PdfContentImporter extends ImportFormat {
             if (i >= lines.length) {
                 // PDF could not be parsed or is empty
                 // return empty list
-                return new ParserResult();
+                return new ParserResult(importFormatPreferences.getEncoding());
             }
 
             // we start at the current line
@@ -489,12 +489,14 @@ public class PdfContentImporter extends ImportFormat {
 
             result.add(entry);
         } catch (EncryptedPdfsNotSupportedException e) {
-            return ParserResult.fromErrorMessage(Localization.lang("Decryption not supported."));
+            return ParserResult.fromErrorMessage(Localization.lang("Decryption not supported."),
+                    importFormatPreferences.getEncoding());
         } catch(IOException exception) {
-            return ParserResult.fromErrorMessage(exception.getLocalizedMessage());
+            return ParserResult.fromErrorMessage(exception.getLocalizedMessage(),
+                    importFormatPreferences.getEncoding());
         }
 
-        return new ParserResult(result);
+        return new ParserResult(result, importFormatPreferences.getEncoding());
     }
 
     private String getFirstPageContents(PDDocument document) throws IOException {

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/PdfXmpImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/PdfXmpImporter.java
@@ -34,12 +34,11 @@ import net.sf.jabref.logic.xmp.XMPUtil;
 public class PdfXmpImporter extends ImportFormat {
 
     private final XMPPreferences xmpPreferences;
-    private final ImportFormatPreferences importFormatPreferences;
 
 
     public PdfXmpImporter(XMPPreferences xmpPreferences, ImportFormatPreferences importFormatPreferences) {
+        super(importFormatPreferences);
         this.xmpPreferences = xmpPreferences;
-        this.importFormatPreferences = importFormatPreferences;
     }
 
     @Override
@@ -64,10 +63,9 @@ public class PdfXmpImporter extends ImportFormat {
     public ParserResult importDatabase(Path filePath, Charset defaultEncoding) {
         Objects.requireNonNull(filePath);
         try {
-            return new ParserResult(XMPUtil.readXMP(filePath, xmpPreferences), importFormatPreferences.getEncoding());
+            return new ParserResult(XMPUtil.readXMP(filePath, xmpPreferences));
         } catch (IOException exception) {
-            return ParserResult.fromErrorMessage(exception.getLocalizedMessage(),
-                    importFormatPreferences.getEncoding());
+            return ParserResult.fromErrorMessage(exception.getLocalizedMessage());
         }
     }
 

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/PdfXmpImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/PdfXmpImporter.java
@@ -21,6 +21,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.Objects;
 
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.FileExtensions;
@@ -33,10 +34,12 @@ import net.sf.jabref.logic.xmp.XMPUtil;
 public class PdfXmpImporter extends ImportFormat {
 
     private final XMPPreferences xmpPreferences;
+    private final ImportFormatPreferences importFormatPreferences;
 
 
-    public PdfXmpImporter(XMPPreferences xmpPreferences) {
+    public PdfXmpImporter(XMPPreferences xmpPreferences, ImportFormatPreferences importFormatPreferences) {
         this.xmpPreferences = xmpPreferences;
+        this.importFormatPreferences = importFormatPreferences;
     }
 
     @Override
@@ -61,9 +64,10 @@ public class PdfXmpImporter extends ImportFormat {
     public ParserResult importDatabase(Path filePath, Charset defaultEncoding) {
         Objects.requireNonNull(filePath);
         try {
-            return new ParserResult(XMPUtil.readXMP(filePath, xmpPreferences));
+            return new ParserResult(XMPUtil.readXMP(filePath, xmpPreferences), importFormatPreferences.getEncoding());
         } catch (IOException exception) {
-            return ParserResult.fromErrorMessage(exception.getLocalizedMessage());
+            return ParserResult.fromErrorMessage(exception.getLocalizedMessage(),
+                    importFormatPreferences.getEncoding());
         }
     }
 

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/RepecNepImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/RepecNepImporter.java
@@ -465,9 +465,9 @@ public class RepecNepImporter extends ImportFormat {
             }
             message += e.getLocalizedMessage();
             LOGGER.error(message, e);
-            return ParserResult.fromErrorMessage(message);
+            return ParserResult.fromErrorMessage(message, importFormatPreferences.getEncoding());
         }
 
-        return new ParserResult(bibitems);
+        return new ParserResult(bibitems, importFormatPreferences.getEncoding());
     }
 }

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/RepecNepImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/RepecNepImporter.java
@@ -172,11 +172,9 @@ public class RepecNepImporter extends ImportFormat {
     private String preLine = "";
     private boolean inOverviewSection;
 
-    private final ImportFormatPreferences importFormatPreferences;
-
 
     public RepecNepImporter(ImportFormatPreferences importFormatPreferences) {
-        this.importFormatPreferences = importFormatPreferences;
+        super(importFormatPreferences);
     }
 
     @Override
@@ -465,9 +463,9 @@ public class RepecNepImporter extends ImportFormat {
             }
             message += e.getLocalizedMessage();
             LOGGER.error(message, e);
-            return ParserResult.fromErrorMessage(message, importFormatPreferences.getEncoding());
+            return ParserResult.fromErrorMessage(message);
         }
 
-        return new ParserResult(bibitems, importFormatPreferences.getEncoding());
+        return new ParserResult(bibitems);
     }
 }

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/RisImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/RisImporter.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.logic.util.OS;
@@ -40,6 +41,13 @@ import net.sf.jabref.model.entry.MonthUtil;
 public class RisImporter extends ImportFormat {
 
     private static final Pattern RECOGNIZED_FORMAT_PATTERN = Pattern.compile("TY  - .*");
+
+    private final ImportFormatPreferences importFormatPreferences;
+
+
+    public RisImporter(ImportFormatPreferences importFormatPreferences) {
+        this.importFormatPreferences = importFormatPreferences;
+    }
 
     @Override
     public String getFormatName() {
@@ -273,7 +281,7 @@ public class RisImporter extends ImportFormat {
 
         }
 
-        return new ParserResult(bibitems);
+        return new ParserResult(bibitems, importFormatPreferences.getEncoding());
 
     }
 }

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/RisImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/RisImporter.java
@@ -42,11 +42,8 @@ public class RisImporter extends ImportFormat {
 
     private static final Pattern RECOGNIZED_FORMAT_PATTERN = Pattern.compile("TY  - .*");
 
-    private final ImportFormatPreferences importFormatPreferences;
-
-
     public RisImporter(ImportFormatPreferences importFormatPreferences) {
-        this.importFormatPreferences = importFormatPreferences;
+        super(importFormatPreferences);
     }
 
     @Override
@@ -281,7 +278,7 @@ public class RisImporter extends ImportFormat {
 
         }
 
-        return new ParserResult(bibitems, importFormatPreferences.getEncoding());
+        return new ParserResult(bibitems);
 
     }
 }

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/SilverPlatterImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/SilverPlatterImporter.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.model.entry.AuthorList;
@@ -36,6 +37,13 @@ import net.sf.jabref.model.entry.FieldName;
 public class SilverPlatterImporter extends ImportFormat {
 
     private static final Pattern START_PATTERN = Pattern.compile("Record.*INSPEC.*");
+
+    private final ImportFormatPreferences importFormatPreferences;
+
+
+    public SilverPlatterImporter(ImportFormatPreferences importFormatPreferences) {
+        this.importFormatPreferences = importFormatPreferences;
+    }
 
     @Override
     public String getFormatName() {
@@ -201,6 +209,6 @@ public class SilverPlatterImporter extends ImportFormat {
 
         }
 
-        return new ParserResult(bibitems);
+        return new ParserResult(bibitems, importFormatPreferences.getEncoding());
     }
 }

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/SilverPlatterImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/SilverPlatterImporter.java
@@ -38,11 +38,8 @@ public class SilverPlatterImporter extends ImportFormat {
 
     private static final Pattern START_PATTERN = Pattern.compile("Record.*INSPEC.*");
 
-    private final ImportFormatPreferences importFormatPreferences;
-
-
     public SilverPlatterImporter(ImportFormatPreferences importFormatPreferences) {
-        this.importFormatPreferences = importFormatPreferences;
+        super(importFormatPreferences);
     }
 
     @Override
@@ -209,6 +206,6 @@ public class SilverPlatterImporter extends ImportFormat {
 
         }
 
-        return new ParserResult(bibitems, importFormatPreferences.getEncoding());
+        return new ParserResult(bibitems);
     }
 }

--- a/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
@@ -36,7 +36,6 @@ import java.util.Vector;
 import java.util.regex.Pattern;
 
 import net.sf.jabref.BibDatabaseContext;
-import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.logic.layout.Layout;
 import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.logic.layout.LayoutHelper;
@@ -46,7 +45,6 @@ import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.model.entry.FileField;
 import net.sf.jabref.model.entry.ParsedFileField;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -392,13 +390,12 @@ public class FileUtil {
      * @return a suggested fileName
      */
     public static String createFileNameFromPattern(BibDatabase database, BibEntry entry,
-            JournalAbbreviationLoader repositoryLoader, JabRefPreferences prefs) {
+            String importFilenamePattern, LayoutFormatterPreferences prefs) {
         String targetName = entry.getCiteKeyOptional().orElse("default");
-        StringReader sr = new StringReader(prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN));
+        StringReader sr = new StringReader(importFilenamePattern);
         Layout layout = null;
         try {
-            layout = new LayoutHelper(sr, LayoutFormatterPreferences.fromPreferences(prefs, repositoryLoader))
-                    .getLayoutFromText();
+            layout = new LayoutHelper(sr, prefs).getLayoutFromText();
         } catch (IOException e) {
             LOGGER.info("Wrong format " + e.getMessage(), e);
         }

--- a/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
+++ b/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
@@ -188,7 +188,8 @@ public class PdfImporter {
 
     private void doXMPImport(String fileName, List<BibEntry> res) {
         List<BibEntry> localRes = new ArrayList<>();
-        PdfXmpImporter importer = new PdfXmpImporter(XMPPreferences.fromPreferences(Globals.prefs));
+        PdfXmpImporter importer = new PdfXmpImporter(XMPPreferences.fromPreferences(Globals.prefs),
+                ImportFormatPreferences.fromPreferences(Globals.prefs));
         Path filePath = Paths.get(fileName);
         ParserResult result = importer.importDatabase(filePath, Globals.prefs.getDefaultEncoding());
         if (result.hasWarnings()) {

--- a/src/test/java/net/sf/jabref/BibDatabaseContextTest.java
+++ b/src/test/java/net/sf/jabref/BibDatabaseContextTest.java
@@ -2,7 +2,6 @@ package net.sf.jabref;
 
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Test;
 
@@ -13,7 +12,7 @@ public class BibDatabaseContextTest {
     @Test
     public void testTypeBasedOnDefaultBibtex() {
         BibDatabaseContext bibDatabaseContext = new BibDatabaseContext(new BibDatabase(),
-                new MetaData(JabRefPreferences.getInstance().getDefaultEncoding()),
+                new MetaData(),
                 new Defaults(BibDatabaseMode.BIBTEX));
         assertEquals(BibDatabaseMode.BIBTEX, bibDatabaseContext.getMode());
 
@@ -24,7 +23,7 @@ public class BibDatabaseContextTest {
     @Test
     public void testTypeBasedOnDefaultBiblatex() {
         BibDatabaseContext bibDatabaseContext = new BibDatabaseContext(new BibDatabase(),
-                new MetaData(JabRefPreferences.getInstance().getDefaultEncoding()),
+                new MetaData(),
                 new Defaults(BibDatabaseMode.BIBLATEX));
         assertEquals(BibDatabaseMode.BIBLATEX, bibDatabaseContext.getMode());
 

--- a/src/test/java/net/sf/jabref/BibDatabaseContextTest.java
+++ b/src/test/java/net/sf/jabref/BibDatabaseContextTest.java
@@ -4,21 +4,17 @@ import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.preferences.JabRefPreferences;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 public class BibDatabaseContextTest {
 
-    @Before
-    public void setUp() throws Exception {
-        Globals.prefs = JabRefPreferences.getInstance();
-    }
-
     @Test
     public void testTypeBasedOnDefaultBibtex() {
-        BibDatabaseContext bibDatabaseContext = new BibDatabaseContext(new BibDatabase(), new MetaData(), new Defaults(BibDatabaseMode.BIBTEX));
+        BibDatabaseContext bibDatabaseContext = new BibDatabaseContext(new BibDatabase(),
+                new MetaData(JabRefPreferences.getInstance().getDefaultEncoding()),
+                new Defaults(BibDatabaseMode.BIBTEX));
         assertEquals(BibDatabaseMode.BIBTEX, bibDatabaseContext.getMode());
 
         bibDatabaseContext.setMode(BibDatabaseMode.BIBLATEX);
@@ -27,7 +23,9 @@ public class BibDatabaseContextTest {
 
     @Test
     public void testTypeBasedOnDefaultBiblatex() {
-        BibDatabaseContext bibDatabaseContext = new BibDatabaseContext(new BibDatabase(), new MetaData(), new Defaults(BibDatabaseMode.BIBLATEX));
+        BibDatabaseContext bibDatabaseContext = new BibDatabaseContext(new BibDatabase(),
+                new MetaData(JabRefPreferences.getInstance().getDefaultEncoding()),
+                new Defaults(BibDatabaseMode.BIBLATEX));
         assertEquals(BibDatabaseMode.BIBLATEX, bibDatabaseContext.getMode());
 
         bibDatabaseContext.setMode(BibDatabaseMode.BIBTEX);

--- a/src/test/java/net/sf/jabref/BibtexTestData.java
+++ b/src/test/java/net/sf/jabref/BibtexTestData.java
@@ -8,6 +8,7 @@ import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.importer.fileformat.BibtexParser;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 public class BibtexTestData {
 
@@ -26,7 +27,8 @@ public class BibtexTestData {
                         + "  doi = {http://dx.doi.org/10.1287/orsc.14.2.209.14992}," + "\n" + "  issn = {1526-5455},"
                         + "\n" + "  publisher = {INFORMS}\n" + "}");
 
-        BibtexParser parser = new BibtexParser(reader, ImportFormatPreferences.fromPreferences(Globals.prefs));
+        BibtexParser parser = new BibtexParser(reader,
+                ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance()));
         ParserResult result = parser.parse();
 
         return result.getDatabase();

--- a/src/test/java/net/sf/jabref/MetaDataTest.java
+++ b/src/test/java/net/sf/jabref/MetaDataTest.java
@@ -21,8 +21,7 @@ public class MetaDataTest {
 
     @Before
     public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
-        metaData = new MetaData();
+        metaData = new MetaData(JabRefPreferences.getInstance().getDefaultEncoding());
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/MetaDataTest.java
+++ b/src/test/java/net/sf/jabref/MetaDataTest.java
@@ -8,7 +8,6 @@ import net.sf.jabref.logic.cleanup.FieldFormatterCleanup;
 import net.sf.jabref.logic.exporter.FieldFormatterCleanups;
 import net.sf.jabref.logic.formatter.casechanger.LowerCaseFormatter;
 import net.sf.jabref.logic.util.OS;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -21,7 +20,7 @@ public class MetaDataTest {
 
     @Before
     public void setUp() {
-        metaData = new MetaData(JabRefPreferences.getInstance().getDefaultEncoding());
+        metaData = new MetaData();
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/gui/importer/actions/ConvertLegacyExplicitGroupsTest.java
+++ b/src/test/java/net/sf/jabref/gui/importer/actions/ConvertLegacyExplicitGroupsTest.java
@@ -77,7 +77,8 @@ public class ConvertLegacyExplicitGroupsTest {
     }
 
     private ParserResult generateParserResult(BibEntry entry, GroupTreeNode groupRoot) {
-        ParserResult parserResult = new ParserResult(Collections.singletonList(entry));
+        ParserResult parserResult = new ParserResult(Collections.singletonList(entry),
+                Globals.prefs.getDefaultEncoding());
         parserResult.getMetaData().setGroups(groupRoot);
         return parserResult;
     }

--- a/src/test/java/net/sf/jabref/logic/bibtex/BibEntryAssert.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/BibEntryAssert.java
@@ -13,7 +13,6 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.importer.fileformat.BibtexParser;
@@ -32,13 +31,14 @@ public class BibEntryAssert {
      * @param resourceName the resource to read
      * @param entry the entry to compare with
      */
-    public static void assertEquals(Class<?> clazz, String resourceName, BibEntry entry)
+    public static void assertEquals(Class<?> clazz, String resourceName, BibEntry entry,
+            ImportFormatPreferences importFormatPreferences)
             throws IOException {
         Assert.assertNotNull(clazz);
         Assert.assertNotNull(resourceName);
         Assert.assertNotNull(entry);
         try (InputStream shouldBeIs = clazz.getResourceAsStream(resourceName)) {
-            BibEntryAssert.assertEquals(shouldBeIs, entry);
+            BibEntryAssert.assertEquals(shouldBeIs, entry, importFormatPreferences);
         }
     }
 
@@ -50,21 +50,22 @@ public class BibEntryAssert {
      * @param resourceName the resource to read
      * @param asIsEntries a list containing a single entry to compare with
      */
-    public static void assertEquals(Class<?> clazz, String resourceName, List<BibEntry> asIsEntries)
+    public static void assertEquals(Class<?> clazz, String resourceName, List<BibEntry> asIsEntries,
+            ImportFormatPreferences importFormatPreferences)
             throws IOException {
         Assert.assertNotNull(clazz);
         Assert.assertNotNull(resourceName);
         Assert.assertNotNull(asIsEntries);
         try (InputStream shouldBeIs = clazz.getResourceAsStream(resourceName)) {
-            BibEntryAssert.assertEquals(shouldBeIs, asIsEntries);
+            BibEntryAssert.assertEquals(shouldBeIs, asIsEntries, importFormatPreferences);
         }
     }
 
-    private static List<BibEntry> getListFromInputStream(InputStream is) throws IOException {
+    private static List<BibEntry> getListFromInputStream(InputStream is,
+            ImportFormatPreferences importFormatPreferences) throws IOException {
         ParserResult result;
         try (Reader reader = new InputStreamReader(is, StandardCharsets.UTF_8)) {
-            BibtexParser parser = new BibtexParser(reader,
-                    ImportFormatPreferences.fromPreferences(Globals.prefs));
+            BibtexParser parser = new BibtexParser(reader, importFormatPreferences);
             result = parser.parse();
         }
         Assert.assertNotNull(result);
@@ -78,18 +79,20 @@ public class BibEntryAssert {
      * @param expectedInputStream the inputStream reading the entry from
      * @param actualEntries a list containing a single entry to compare with
      */
-    public static void assertEquals(InputStream expectedInputStream, List<BibEntry> actualEntries)
+    public static void assertEquals(InputStream expectedInputStream, List<BibEntry> actualEntries,
+            ImportFormatPreferences importFormatPreferences)
             throws IOException {
         Assert.assertNotNull(expectedInputStream);
         Assert.assertNotNull(actualEntries);
-        Assert.assertEquals(getListFromInputStream(expectedInputStream), actualEntries);
+        Assert.assertEquals(getListFromInputStream(expectedInputStream, importFormatPreferences), actualEntries);
     }
 
-    public static void assertEquals(List<BibEntry> expectedEntries, InputStream actualInputStream)
+    public static void assertEquals(List<BibEntry> expectedEntries, InputStream actualInputStream,
+            ImportFormatPreferences importFormatPreferences)
             throws IOException {
         Assert.assertNotNull(actualInputStream);
         Assert.assertNotNull(expectedEntries);
-        Assert.assertEquals(expectedEntries, getListFromInputStream(actualInputStream));
+        Assert.assertEquals(expectedEntries, getListFromInputStream(actualInputStream, importFormatPreferences));
     }
 
     /**
@@ -99,9 +102,10 @@ public class BibEntryAssert {
      * @param expected the inputStream reading the entry from
      * @param actual the entry to compare with
      */
-    public static void assertEquals(InputStream expected, BibEntry actual)
+    public static void assertEquals(InputStream expected, BibEntry actual,
+            ImportFormatPreferences importFormatPreferences)
             throws IOException {
-        assertEquals(expected, Collections.singletonList(actual));
+        assertEquals(expected, Collections.singletonList(actual), importFormatPreferences);
     }
 
     /**
@@ -111,14 +115,16 @@ public class BibEntryAssert {
      * @param importFormat The fileformat you want to use to read the passed file to get the list of expected BibEntries
      * @throws IOException
      */
-    public static void assertEquals(InputStream expectedIs, Path fileToImport, ImportFormat importFormat)
+    public static void assertEquals(InputStream expectedIs, Path fileToImport, ImportFormat importFormat,
+            ImportFormatPreferences importFormatPreferences)
             throws IOException {
-        assertEquals(getListFromInputStream(expectedIs), fileToImport, importFormat);
+        assertEquals(getListFromInputStream(expectedIs, importFormatPreferences), fileToImport, importFormat);
     }
 
-    public static void assertEquals(InputStream expectedIs, URL fileToImport, ImportFormat importFormat)
+    public static void assertEquals(InputStream expectedIs, URL fileToImport, ImportFormat importFormat,
+            ImportFormatPreferences importFormatPreferences)
             throws URISyntaxException, IOException {
-        assertEquals(expectedIs, Paths.get(fileToImport.toURI()), importFormat);
+        assertEquals(expectedIs, Paths.get(fileToImport.toURI()), importFormat, importFormatPreferences);
     }
 
     /**

--- a/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
@@ -19,7 +19,7 @@ import net.sf.jabref.logic.formatter.bibtexfields.NormalizeMonthFormatter;
 import net.sf.jabref.logic.formatter.bibtexfields.NormalizePagesFormatter;
 import net.sf.jabref.logic.formatter.bibtexfields.UnitsToLatexFormatter;
 import net.sf.jabref.logic.formatter.casechanger.ProtectTermsFormatter;
-import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
+import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.logic.protectedterms.ProtectedTermsLoader;
 import net.sf.jabref.logic.protectedterms.ProtectedTermsPreferences;
 import net.sf.jabref.model.FieldChange;
@@ -52,16 +52,14 @@ public class CleanupWorkerTest {
         if (Globals.prefs == null) {
             Globals.prefs = JabRefPreferences.getInstance();
         }
-        if (Globals.journalAbbreviationLoader == null) {
-            Globals.journalAbbreviationLoader = mock(JournalAbbreviationLoader.class);
-        }
 
         pdfFolder = bibFolder.newFolder();
 
-        MetaData metaData = new MetaData();
+        MetaData metaData = new MetaData(Globals.prefs.getDefaultEncoding());
         metaData.setDefaultFileDirectory(pdfFolder.getAbsolutePath());
         BibDatabaseContext context = new BibDatabaseContext(new BibDatabase(), metaData, bibFolder.newFile("test.bib"));
-        worker = new CleanupWorker(context, mock(JournalAbbreviationLoader.class), Globals.prefs);
+        worker = new CleanupWorker(context, Globals.prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN),
+                mock(LayoutFormatterPreferences.class));
     }
 
     @SuppressWarnings("unused")

--- a/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
@@ -55,7 +55,7 @@ public class CleanupWorkerTest {
 
         pdfFolder = bibFolder.newFolder();
 
-        MetaData metaData = new MetaData(Globals.prefs.getDefaultEncoding());
+        MetaData metaData = new MetaData();
         metaData.setDefaultFileDirectory(pdfFolder.getAbsolutePath());
         BibDatabaseContext context = new BibDatabaseContext(new BibDatabase(), metaData, bibFolder.newFile("test.bib"));
         worker = new CleanupWorker(context, Globals.prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN),

--- a/src/test/java/net/sf/jabref/logic/cleanup/ISSNCleanupTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/ISSNCleanupTest.java
@@ -3,9 +3,8 @@ package net.sf.jabref.logic.cleanup;
 import java.util.Optional;
 
 import net.sf.jabref.BibDatabaseContext;
-import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
+import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -20,8 +19,7 @@ public class ISSNCleanupTest {
 
     @Before
     public void setUp() {
-        worker = new CleanupWorker(mock(BibDatabaseContext.class), mock(JournalAbbreviationLoader.class),
-                JabRefPreferences.getInstance());
+        worker = new CleanupWorker(mock(BibDatabaseContext.class), "", mock(LayoutFormatterPreferences.class));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/cleanup/MoveFilesCleanupTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/MoveFilesCleanupTest.java
@@ -37,7 +37,7 @@ public class MoveFilesCleanupTest {
         Globals.prefs = JabRefPreferences.getInstance();
 
         pdfFolder = bibFolder.newFolder();
-        MetaData metaData = new MetaData(Globals.prefs.getDefaultEncoding());
+        MetaData metaData = new MetaData();
         metaData.setDefaultFileDirectory(pdfFolder.getAbsolutePath());
         databaseContext = new BibDatabaseContext(new BibDatabase(), metaData, bibFolder.newFile("test.bib"));
 

--- a/src/test/java/net/sf/jabref/logic/cleanup/MoveFilesCleanupTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/MoveFilesCleanupTest.java
@@ -37,7 +37,7 @@ public class MoveFilesCleanupTest {
         Globals.prefs = JabRefPreferences.getInstance();
 
         pdfFolder = bibFolder.newFolder();
-        MetaData metaData = new MetaData();
+        MetaData metaData = new MetaData(Globals.prefs.getDefaultEncoding());
         metaData.setDefaultFileDirectory(pdfFolder.getAbsolutePath());
         databaseContext = new BibDatabaseContext(new BibDatabase(), metaData, bibFolder.newFile("test.bib"));
 

--- a/src/test/java/net/sf/jabref/logic/cleanup/RenamePdfCleanupTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/RenamePdfCleanupTest.java
@@ -10,6 +10,7 @@ import net.sf.jabref.Defaults;
 import net.sf.jabref.Globals;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
+import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FileField;
@@ -23,7 +24,6 @@ import org.junit.rules.TemporaryFolder;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class RenamePdfCleanupTest {
 
@@ -34,14 +34,14 @@ public class RenamePdfCleanupTest {
 
     @Before
     public void setUp() throws Exception {
-        Globals.prefs = mock(JabRefPreferences.class);
-
-        MetaData metaData = new MetaData();
+        Globals.prefs = JabRefPreferences.getInstance();
+        MetaData metaData = new MetaData(Globals.prefs.getDefaultEncoding());
         context = new BibDatabaseContext(new BibDatabase(), metaData, new Defaults());
         context.setDatabaseFile(testFolder.newFile("test.bib"));
 
         entry = new BibEntry();
         entry.setCiteKey("Toot");
+
     }
 
     /**
@@ -49,13 +49,13 @@ public class RenamePdfCleanupTest {
      */
     @Test
     public void cleanupRenamePdfRenamesFileEvenIfOnlyDifferenceIsCase() throws IOException {
-        when(Globals.prefs.get("importFileNamePattern")).thenReturn("\\bibtexkey");
         File tempFile = testFolder.newFile("toot.tmp");
         ParsedFileField fileField = new ParsedFileField("", tempFile.getAbsolutePath(), "");
         entry.setField("file", FileField.getStringRepresentation(fileField));
 
-        RenamePdfCleanup cleanup = new RenamePdfCleanup(false, context, mock(JournalAbbreviationLoader.class),
-                Globals.prefs);
+        RenamePdfCleanup cleanup = new RenamePdfCleanup(false, context, "\\bibtexkey",
+                LayoutFormatterPreferences.fromPreferences(Globals.prefs,
+                        mock(JournalAbbreviationLoader.class)));
         cleanup.cleanup(entry);
 
         ParsedFileField newFileField = new ParsedFileField("", "Toot.tmp", "");
@@ -64,15 +64,15 @@ public class RenamePdfCleanupTest {
 
     @Test
     public void cleanupRenamePdfRenamesWithMultipleFiles() throws IOException {
-        when(Globals.prefs.get("importFileNamePattern")).thenReturn("\\bibtexkey - \\title");
         File tempFile = testFolder.newFile("Toot.tmp");
 
         entry.setField("title", "test title");
         entry.setField("file", FileField.getStringRepresentation(Arrays.asList(new ParsedFileField("","",""),
                 new ParsedFileField("", tempFile.getAbsolutePath(), ""), new ParsedFileField("","",""))));
 
-        RenamePdfCleanup cleanup = new RenamePdfCleanup(false, context, mock(JournalAbbreviationLoader.class),
-                Globals.prefs);
+        RenamePdfCleanup cleanup = new RenamePdfCleanup(false, context, "\\bibtexkey - \\title",
+                LayoutFormatterPreferences.fromPreferences(Globals.prefs,
+                        mock(JournalAbbreviationLoader.class)));
         cleanup.cleanup(entry);
 
         assertEquals(
@@ -83,14 +83,14 @@ public class RenamePdfCleanupTest {
 
     @Test
     public void cleanupRenamePdfRenamesFileStartingWithBibtexKey() throws IOException {
-        when(Globals.prefs.get("importFileNamePattern")).thenReturn("\\bibtexkey - \\title");
         File tempFile = testFolder.newFile("Toot.tmp");
         ParsedFileField fileField = new ParsedFileField("", tempFile.getAbsolutePath(), "");
         entry.setField("file", FileField.getStringRepresentation(fileField));
         entry.setField("title", "test title");
 
-        RenamePdfCleanup cleanup = new RenamePdfCleanup(false, context, mock(JournalAbbreviationLoader.class),
-                Globals.prefs);
+        RenamePdfCleanup cleanup = new RenamePdfCleanup(false, context, "\\bibtexkey - \\title",
+                LayoutFormatterPreferences.fromPreferences(Globals.prefs,
+                        mock(JournalAbbreviationLoader.class)));
         cleanup.cleanup(entry);
 
         ParsedFileField newFileField = new ParsedFileField("", "Toot - test title.tmp", "");
@@ -99,14 +99,15 @@ public class RenamePdfCleanupTest {
 
     @Test
     public void cleanupRenamePdfRenamesFileInSameFolder() throws IOException {
-        when(Globals.prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN)).thenReturn("\\bibtexkey\\begin{title} - \\format[RemoveBrackets]{\\title}\\end{title}");
         testFolder.newFile("Toot.pdf");
         ParsedFileField fileField = new ParsedFileField("", "Toot.pdf", "PDF");
         entry.setField("file", FileField.getStringRepresentation(fileField));
         entry.setField("title", "test title");
 
-        RenamePdfCleanup cleanup = new RenamePdfCleanup(false, context, mock(JournalAbbreviationLoader.class),
-                Globals.prefs);
+        RenamePdfCleanup cleanup = new RenamePdfCleanup(false, context,
+                "\\bibtexkey\\begin{title} - \\format[RemoveBrackets]{\\title}\\end{title}",
+                LayoutFormatterPreferences.fromPreferences(Globals.prefs,
+                        mock(JournalAbbreviationLoader.class)));
         cleanup.cleanup(entry);
 
         ParsedFileField newFileField = new ParsedFileField("", "Toot - test title.pdf", "PDF");

--- a/src/test/java/net/sf/jabref/logic/cleanup/RenamePdfCleanupTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/RenamePdfCleanupTest.java
@@ -35,7 +35,7 @@ public class RenamePdfCleanupTest {
     @Before
     public void setUp() throws Exception {
         Globals.prefs = JabRefPreferences.getInstance();
-        MetaData metaData = new MetaData(Globals.prefs.getDefaultEncoding());
+        MetaData metaData = new MetaData();
         context = new BibDatabaseContext(new BibDatabase(), metaData, new Defaults());
         context.setDatabaseFile(testFolder.newFile("test.bib"));
 

--- a/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -58,7 +58,7 @@ public class BibtexDatabaseWriterTest {
         databaseWriter = new BibtexDatabaseWriter<>(StringSaveSession::new);
 
         database = new BibDatabase();
-        metaData = new MetaData(prefs.getDefaultEncoding());
+        metaData = new MetaData();
         bibtexContext = new BibDatabaseContext(database, metaData, new Defaults(BibDatabaseMode.BIBTEX));
         importFormatPreferences = ImportFormatPreferences.fromPreferences(prefs);
     }

--- a/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -52,15 +52,15 @@ public class BibtexDatabaseWriterTest {
 
     @Before
     public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
+        JabRefPreferences prefs = JabRefPreferences.getInstance();
 
         // Write to a string instead of to a file
         databaseWriter = new BibtexDatabaseWriter<>(StringSaveSession::new);
 
         database = new BibDatabase();
-        metaData = new MetaData();
+        metaData = new MetaData(prefs.getDefaultEncoding());
         bibtexContext = new BibDatabaseContext(database, metaData, new Defaults(BibDatabaseMode.BIBTEX));
-        importFormatPreferences = ImportFormatPreferences.fromPreferences(Globals.prefs);
+        importFormatPreferences = ImportFormatPreferences.fromPreferences(prefs);
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/net/sf/jabref/logic/importer/OpenDatabaseTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/OpenDatabaseTest.java
@@ -54,27 +54,27 @@ public class OpenDatabaseTest {
     @Test
     public void useFallbackEncodingIfNoHeader() throws IOException {
         ParserResult result = OpenDatabase.loadDatabase(bibNoHeader, importFormatPreferences);
-        Assert.assertEquals(defaultEncoding, result.getMetaData().getEncoding());
+        Assert.assertEquals(defaultEncoding, result.getMetaData().getEncoding().get());
     }
 
     @Test
     public void useFallbackEncodingIfUnknownHeader() throws IOException {
         ParserResult result = OpenDatabase.loadDatabase(bibWrongHeader, importFormatPreferences);
-        Assert.assertEquals(defaultEncoding, result.getMetaData().getEncoding());
+        Assert.assertEquals(defaultEncoding, result.getMetaData().getEncoding().get());
     }
 
     @Test
     public void useSpecifiedEncoding() throws IOException {
         ParserResult result = OpenDatabase.loadDatabase(bibHeader,
                 importFormatPreferences.withEncoding(StandardCharsets.US_ASCII));
-        Assert.assertEquals(defaultEncoding, result.getMetaData().getEncoding());
+        Assert.assertEquals(defaultEncoding, result.getMetaData().getEncoding().get());
     }
 
     @Test
     public void useSpecifiedEncodingWithSignature() throws IOException {
         ParserResult result = OpenDatabase.loadDatabase(bibHeaderAndSignature,
                 importFormatPreferences.withEncoding(StandardCharsets.US_ASCII));
-        Assert.assertEquals(defaultEncoding, result.getMetaData().getEncoding());
+        Assert.assertEquals(defaultEncoding, result.getMetaData().getEncoding().get());
     }
 
     @Test
@@ -113,7 +113,7 @@ public class OpenDatabaseTest {
     @Test
     public void correctlyParseEncodingWithoutNewline() throws IOException {
         ParserResult result = OpenDatabase.loadDatabase(bibEncodingWithoutNewline, importFormatPreferences);
-        Assert.assertEquals(StandardCharsets.US_ASCII, result.getMetaData().getEncoding());
+        Assert.assertEquals(StandardCharsets.US_ASCII, result.getMetaData().getEncoding().get());
 
         BibDatabase db = result.getDatabase();
         Assert.assertEquals("testPreamble", db.getPreamble());

--- a/src/test/java/net/sf/jabref/logic/importer/fetcher/GVKParserTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fetcher/GVKParserTest.java
@@ -11,6 +11,7 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -35,7 +36,8 @@ public class GVKParserTest {
             Assert.assertEquals(expectedSize, entries.size());
             int i = 0;
             for (String resourceName : resourceNames) {
-                BibEntryAssert.assertEquals(GVKParser.class, resourceName, entries.get(i));
+                BibEntryAssert.assertEquals(GVKParser.class, resourceName, entries.get(i),
+                        ImportFormatPreferences.fromPreferences(Globals.prefs));
                 i++;
             }
         }

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/BibTeXMLImporterTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/BibTeXMLImporterTest.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import net.sf.jabref.Globals;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -46,8 +46,7 @@ public class BibTeXMLImporterTest {
 
     @Before
     public void setUp() throws Exception {
-        Globals.prefs = JabRefPreferences.getInstance();
-        importer = new BibTeXMLImporter();
+        importer = new BibTeXMLImporter(ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance()));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/BibTeXMLImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/BibTeXMLImporterTestFiles.java
@@ -13,8 +13,8 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -33,6 +33,7 @@ public class BibTeXMLImporterTestFiles {
     private final static String FILEFORMAT_PATH = "src/test/resources/net/sf/jabref/logic/importer/fileformat";
 
     private BibTeXMLImporter bibtexmlImporter;
+    private ImportFormatPreferences importFormatPreferences;
 
     @Parameter
     public Path importFile;
@@ -40,8 +41,8 @@ public class BibTeXMLImporterTestFiles {
 
     @Before
     public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
-        bibtexmlImporter = new BibTeXMLImporter();
+        importFormatPreferences = ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance());
+        bibtexmlImporter = new BibTeXMLImporter(importFormatPreferences);
     }
 
     @Parameters(name = "{0}")
@@ -70,7 +71,8 @@ public class BibTeXMLImporterTestFiles {
         if (bibtexmlEntries.isEmpty()) {
             Assert.assertEquals(Collections.emptyList(), bibtexmlEntries);
         } else {
-            BibEntryAssert.assertEquals(BibTeXMLImporterTest.class, bibFileName, bibtexmlEntries);
+            BibEntryAssert.assertEquals(BibTeXMLImporterTest.class, bibFileName, bibtexmlEntries,
+                    importFormatPreferences);
         }
     }
 }

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/BibTeXMLImporterTestTypes.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/BibTeXMLImporterTestTypes.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import net.sf.jabref.Globals;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -41,8 +41,8 @@ public class BibTeXMLImporterTestTypes {
 
     @Before
     public void setUp() throws Exception {
-        Globals.prefs = JabRefPreferences.getInstance();
-        bibteXMLImporter = new BibTeXMLImporter();
+        bibteXMLImporter = new BibTeXMLImporter(
+                ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance()));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/BiblioscapeImporterTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/BiblioscapeImporterTest.java
@@ -5,7 +5,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 
-import net.sf.jabref.Globals;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -20,8 +20,7 @@ public class BiblioscapeImporterTest {
 
     @Before
     public void setUp() throws Exception {
-        Globals.prefs = JabRefPreferences.getInstance();
-        importer = new BiblioscapeImporter();
+        importer = new BiblioscapeImporter(ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance()));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/BiblioscapeImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/BiblioscapeImporterTestFiles.java
@@ -9,8 +9,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -25,6 +25,7 @@ import org.junit.runners.Parameterized.Parameters;
 public class BiblioscapeImporterTestFiles {
 
     private BiblioscapeImporter bsImporter;
+    private ImportFormatPreferences importFormatPreferences;
 
     public Path importFile;
     public String bibFile;
@@ -36,8 +37,8 @@ public class BiblioscapeImporterTestFiles {
 
     @Before
     public void setUp() throws Exception {
-        Globals.prefs = JabRefPreferences.getInstance();
-        bsImporter = new BiblioscapeImporter();
+        importFormatPreferences = ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance());
+        bsImporter = new BiblioscapeImporter(importFormatPreferences);
     }
 
     @Parameters(name = "{0}")
@@ -63,6 +64,6 @@ public class BiblioscapeImporterTestFiles {
     public void testImportEntries() throws IOException {
         List<BibEntry> bsEntries = bsImporter.importDatabase(importFile, Charset.defaultCharset()).getDatabase().getEntries();
         Assert.assertEquals(1, bsEntries.size());
-        BibEntryAssert.assertEquals(BiblioscapeImporterTest.class, bibFile, bsEntries);
+        BibEntryAssert.assertEquals(BiblioscapeImporterTest.class, bibFile, bsEntries, importFormatPreferences);
     }
 }

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/BiblioscapeImporterTestTypes.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/BiblioscapeImporterTestTypes.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import net.sf.jabref.Globals;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -41,8 +41,7 @@ public class BiblioscapeImporterTestTypes {
 
     @Before
     public void setUp() throws Exception {
-        Globals.prefs = JabRefPreferences.getInstance();
-        bsImporter = new BiblioscapeImporter();
+        bsImporter = new BiblioscapeImporter(ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance()));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -514,7 +514,7 @@ public class BibtexParserTest {
                         + "\n"
                         + "}))"),
                 importFormatPreferences);
-        assertEquals(Globals.prefs.getDefaultEncoding(), result.getMetaData().getEncoding());
+        assertEquals(Globals.prefs.getDefaultEncoding(), result.getMetaData().getEncoding().get());
 
         Collection<BibEntry> c = result.getDatabase().getEntries();
         assertEquals(1, c.size());

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/CopacImporterTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/CopacImporterTest.java
@@ -12,7 +12,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import net.sf.jabref.Globals;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
@@ -43,8 +43,7 @@ public class CopacImporterTest {
 
     @Before
     public void setUp() throws Exception {
-        Globals.prefs = JabRefPreferences.getInstance();
-        importer = new CopacImporter();
+        importer = new CopacImporter(ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance()));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/CopacImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/CopacImporterTestFiles.java
@@ -13,8 +13,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
@@ -30,6 +30,7 @@ public class CopacImporterTestFiles {
 
     private CopacImporter copacImporter;
     private final static String FILEFORMAT_PATH = "src/test/resources/net/sf/jabref/logic/importer/fileformat";
+    private ImportFormatPreferences importFormatPreferences;
 
     @Parameter
     public String fileName;
@@ -37,8 +38,8 @@ public class CopacImporterTestFiles {
 
     @Before
     public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
-        copacImporter = new CopacImporter();
+        importFormatPreferences = ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance());
+        copacImporter = new CopacImporter(importFormatPreferences);
     }
 
     @Parameters(name = "{0}")
@@ -62,7 +63,8 @@ public class CopacImporterTestFiles {
         String bibFileName = fileName.replace(".txt", ".bib");
 
         try (InputStream bibStream = BibtexImporterTest.class.getResourceAsStream(bibFileName)) {
-            BibEntryAssert.assertEquals(bibStream, CopacImporterTest.class.getResource(fileName), copacImporter);
+            BibEntryAssert.assertEquals(bibStream, CopacImporterTest.class.getResource(fileName), copacImporter,
+                    importFormatPreferences);
         }
     }
 }

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/CustomImporterTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/CustomImporterTest.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
-import net.sf.jabref.Globals;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
@@ -17,11 +17,11 @@ import static org.junit.Assert.assertTrue;
 public class CustomImporterTest {
 
     private CustomImporter importer;
-
+    private ImportFormatPreferences importFormatPreferences;
     @Before
     public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
-        importer = new CustomImporter(new CopacImporter());
+        importFormatPreferences = ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance());
+        importer = new CustomImporter(new CopacImporter(importFormatPreferences));
     }
 
     @Test
@@ -47,7 +47,7 @@ public class CustomImporterTest {
 
     @Test
     public void testGetInstance() throws Exception {
-        assertEquals(new CopacImporter(), importer.getInstance());
+        assertEquals(new CopacImporter(importFormatPreferences), importer.getInstance());
     }
 
     @Test
@@ -79,27 +79,28 @@ public class CustomImporterTest {
 
     @Test
     public void testEqualsFalse() {
-        assertNotEquals(new CopacImporter(), importer);
+        assertNotEquals(new CopacImporter(importFormatPreferences), importer);
     }
 
     @Test
     public void testCompareToSmaller() {
-        CustomImporter ovidImporter = new CustomImporter(new OvidImporter());
+        CustomImporter ovidImporter = new CustomImporter(new OvidImporter(importFormatPreferences));
 
         assertTrue(importer.compareTo(ovidImporter) < 0);
     }
 
     @Test
     public void testCompareToGreater() {
-        CustomImporter bibtexmlImporter = new CustomImporter(new BibTeXMLImporter());
-        CustomImporter ovidImporter = new CustomImporter(new OvidImporter());
+        CustomImporter bibtexmlImporter = new CustomImporter(
+                new BibTeXMLImporter(importFormatPreferences));
+        CustomImporter ovidImporter = new CustomImporter(new OvidImporter(importFormatPreferences));
 
         assertTrue(ovidImporter.compareTo(bibtexmlImporter) > 0);
     }
 
     @Test
     public void testCompareToEven() {
-        assertEquals(0, importer.compareTo(new CustomImporter(new CopacImporter())));
+        assertEquals(0, importer.compareTo(new CustomImporter(new CopacImporter(importFormatPreferences))));
     }
 
     @Test
@@ -120,7 +121,7 @@ public class CustomImporterTest {
         List<String> dataTest = Arrays.asList("Ovid", "ovid", "net.sf.jabref.logic.importer.fileformat.OvidImporter",
                 "src/main/java/net/sf/jabref/logic/importer/fileformat/OvidImporter.java");
         CustomImporter customImporter = new CustomImporter(dataTest);
-        CustomImporter customOvidImporter = new CustomImporter(new OvidImporter());
+        CustomImporter customOvidImporter = new CustomImporter(new OvidImporter(importFormatPreferences));
 
         assertEquals(customImporter, customOvidImporter);
     }
@@ -133,7 +134,7 @@ public class CustomImporterTest {
         customImporter.setClassName("net.sf.jabref.logic.importer.fileformat.OvidImporter");
         customImporter.setBasePath("src/main/java/net/sf/jabref/logic/importer/fileformat/OvidImporter.java");
 
-        CustomImporter customOvidImporter = new CustomImporter(new OvidImporter());
+        CustomImporter customOvidImporter = new CustomImporter(new OvidImporter(importFormatPreferences));
 
         assertEquals(customImporter, customOvidImporter);
     }

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/CustomImporterTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/CustomImporterTest.java
@@ -47,7 +47,7 @@ public class CustomImporterTest {
 
     @Test
     public void testGetInstance() throws Exception {
-        assertEquals(new CopacImporter(importFormatPreferences), importer.getInstance());
+        assertEquals(new CopacImporter(importFormatPreferences), importer.getInstance(importFormatPreferences));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/ImportFormatTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/ImportFormatTest.java
@@ -78,23 +78,23 @@ public class ImportFormatTest {
         XMPPreferences xmpPreferences = XMPPreferences.fromPreferences(JabRefPreferences.getInstance());
         // @formatter:off
         return Arrays.asList(
-                new Object[]{new BiblioscapeImporter()},
+                new Object[]{new BiblioscapeImporter(importFormatPreferences)},
                 new Object[]{new BibtexImporter(importFormatPreferences)},
-                new Object[]{new BibTeXMLImporter()},
-                new Object[]{new CopacImporter()},
+                new Object[]{new BibTeXMLImporter(importFormatPreferences)},
+                new Object[]{new CopacImporter(importFormatPreferences)},
                 new Object[]{new EndnoteImporter(importFormatPreferences)},
                 new Object[]{new FreeCiteImporter(importFormatPreferences)},
-                new Object[]{new InspecImporter()},
-                new Object[]{new IsiImporter()},
-                new Object[]{new MedlineImporter()},
-                new Object[]{new MedlinePlainImporter()},
-                new Object[]{new MsBibImporter()},
-                new Object[]{new OvidImporter()},
+                new Object[]{new InspecImporter(importFormatPreferences)},
+                new Object[]{new IsiImporter(importFormatPreferences)},
+                new Object[]{new MedlineImporter(importFormatPreferences)},
+                new Object[]{new MedlinePlainImporter(importFormatPreferences)},
+                new Object[]{new MsBibImporter(importFormatPreferences)},
+                new Object[]{new OvidImporter(importFormatPreferences)},
                 new Object[]{new PdfContentImporter(importFormatPreferences)},
-                new Object[]{new PdfXmpImporter(xmpPreferences)},
+                new Object[]{new PdfXmpImporter(xmpPreferences, importFormatPreferences)},
                 new Object[]{new RepecNepImporter(importFormatPreferences)},
-                new Object[]{new RisImporter()},
-                new Object[]{new SilverPlatterImporter()}
+                new Object[]{new RisImporter(importFormatPreferences)},
+                new Object[]{new SilverPlatterImporter(importFormatPreferences)}
         );
         // @formatter:on
     }

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/InspecImportTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/InspecImportTest.java
@@ -11,8 +11,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
@@ -30,8 +30,7 @@ public class InspecImportTest {
 
     @Before
     public void setUp() throws Exception {
-        Globals.prefs = JabRefPreferences.getInstance();
-        this.importer = new InspecImporter();
+        this.importer = new InspecImporter(ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance()));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/IsiImporterTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/IsiImporterTest.java
@@ -10,12 +10,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 
-import net.sf.jabref.Globals;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -29,15 +29,15 @@ import static org.junit.Assert.assertTrue;
  */
 public class IsiImporterTest {
 
-    private final IsiImporter importer = new IsiImporter();
+    private IsiImporter importer;
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
 
-    @BeforeClass
-    public static void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
+    @Before
+    public void setUp() {
+        importer = new IsiImporter(ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance()));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/MedlineImporterTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/MedlineImporterTest.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import net.sf.jabref.Globals;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -55,8 +55,7 @@ public class MedlineImporterTest {
 
     @Before
     public void setUp() throws Exception {
-        Globals.prefs = JabRefPreferences.getInstance();
-        this.importer = new MedlineImporter();
+        this.importer = new MedlineImporter(ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance()));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/MedlineImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/MedlineImporterTestFiles.java
@@ -12,8 +12,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -33,15 +33,15 @@ public class MedlineImporterTestFiles {
     private final static String FILEFORMAT_PATH = "src/test/resources/net/sf/jabref/logic/importer/fileformat";
 
     private MedlineImporter medlineImporter;
-
+    private ImportFormatPreferences importFormatPreferences;
     @Parameter
     public Path importFile;
 
 
     @Before
     public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
-        medlineImporter = new MedlineImporter();
+        importFormatPreferences = ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance());
+        medlineImporter = new MedlineImporter(importFormatPreferences);
     }
 
     @Parameters(name = "{0}")
@@ -67,7 +67,8 @@ public class MedlineImporterTestFiles {
             if (medlineEntries.isEmpty()) {
                 assertEquals(Collections.emptyList(), medlineEntries);
             } else {
-                BibEntryAssert.assertEquals(MedlineImporterTest.class, bibFileName, medlineEntries);
+            BibEntryAssert.assertEquals(MedlineImporterTest.class, bibFileName, medlineEntries,
+                    importFormatPreferences);
             }
     }
 }

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/MedlinePlainImporterTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/MedlinePlainImporterTest.java
@@ -13,8 +13,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
@@ -30,6 +30,8 @@ import static org.junit.Assert.fail;
 public class MedlinePlainImporterTest {
 
     private MedlinePlainImporter importer;
+    private ImportFormatPreferences importFormatPreferences;
+
 
 
     private BufferedReader readerForString(String string) {
@@ -38,8 +40,8 @@ public class MedlinePlainImporterTest {
 
     @Before
     public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
-        importer = new MedlinePlainImporter();
+        importFormatPreferences = ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance());
+        importer = new MedlinePlainImporter(importFormatPreferences);
     }
 
     @Test
@@ -154,7 +156,7 @@ public class MedlinePlainImporterTest {
             List<BibEntry> entries = importer.importDatabase(file, Charset.defaultCharset()).getDatabase().getEntries();
             Assert.assertNotNull(entries);
             assertEquals(1, entries.size());
-            BibEntryAssert.assertEquals(nis, entries.get(0));
+            BibEntryAssert.assertEquals(nis, entries.get(0), importFormatPreferences);
         }
     }
 
@@ -192,7 +194,8 @@ public class MedlinePlainImporterTest {
     public void testWithNbibFile() throws IOException, URISyntaxException {
         Path file = Paths.get(MedlinePlainImporter.class.getResource("NbibImporterTest.nbib").toURI());
         List<BibEntry> entries = importer.importDatabase(file, Charset.defaultCharset()).getDatabase().getEntries();
-        BibEntryAssert.assertEquals(MedlinePlainImporter.class, "NbibImporterTest.bib", entries);
+        BibEntryAssert.assertEquals(MedlinePlainImporter.class, "NbibImporterTest.bib", entries,
+                importFormatPreferences);
     }
 
     @Test
@@ -200,7 +203,8 @@ public class MedlinePlainImporterTest {
         Path file = Paths
                 .get(MedlinePlainImporter.class.getResource("MedlinePlainImporterStringOutOfBounds.txt").toURI());
         List<BibEntry> entries = importer.importDatabase(file, Charsets.UTF_8).getDatabase().getEntries();
-        BibEntryAssert.assertEquals(MedlinePlainImporter.class, "MedlinePlainImporterStringOutOfBounds.bib", entries);
+        BibEntryAssert.assertEquals(MedlinePlainImporter.class, "MedlinePlainImporterStringOutOfBounds.bib", entries,
+                importFormatPreferences);
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/MsBibImporterTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/MsBibImporterTest.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import net.sf.jabref.Globals;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
@@ -22,26 +22,29 @@ import static org.junit.Assert.assertFalse;
 
 public class MsBibImporterTest {
 
+    private ImportFormatPreferences importFormatPreferences;
+
+
     @Before
     public void setUp() throws Exception {
-        Globals.prefs = JabRefPreferences.getInstance();
+        importFormatPreferences = ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance());
     }
 
     @Test
     public void testsGetExtensions() {
-        MsBibImporter importer = new MsBibImporter();
+        MsBibImporter importer = new MsBibImporter(importFormatPreferences);
         assertEquals(FileExtensions.MSBIB, importer.getExtensions());
     }
 
     @Test
     public void testGetDescription() {
-        MsBibImporter importer = new MsBibImporter();
+        MsBibImporter importer = new MsBibImporter(importFormatPreferences);
         assertEquals("Importer for the MS Office 2007 XML bibliography format.", importer.getDescription());
     }
 
     @Test
     public final void testIsNotRecognizedFormat() throws Exception {
-        MsBibImporter testImporter = new MsBibImporter();
+        MsBibImporter testImporter = new MsBibImporter(importFormatPreferences);
         List<String> notAccepted = Arrays.asList("CopacImporterTest1.txt", "IsiImporterTest1.isi",
                 "IsiImporterTestInspec.isi", "emptyFile.xml", "IsiImporterTestWOS.isi");
         for (String s : notAccepted) {
@@ -52,7 +55,7 @@ public class MsBibImporterTest {
 
     @Test
     public final void testImportEntriesEmpty() throws IOException, URISyntaxException {
-        MsBibImporter testImporter = new MsBibImporter();
+        MsBibImporter testImporter = new MsBibImporter(importFormatPreferences);
         Path file = Paths.get(MsBibImporter.class.getResource("MsBibImporterTest.xml").toURI());
         List<BibEntry> entries = testImporter.importDatabase(file, Charset.defaultCharset()).getDatabase().getEntries();
         assertEquals(Collections.emptyList(), entries);
@@ -60,7 +63,7 @@ public class MsBibImporterTest {
 
     @Test
     public final void testImportEntriesNotRecognizedFormat() throws IOException, URISyntaxException {
-        MsBibImporter testImporter = new MsBibImporter();
+        MsBibImporter testImporter = new MsBibImporter(importFormatPreferences);
         Path file = Paths.get(MsBibImporter.class.getResource("CopacImporterTest1.txt").toURI());
         List<BibEntry> entries = testImporter.importDatabase(file, Charset.defaultCharset()).getDatabase().getEntries();
         assertEquals(0, entries.size());
@@ -68,13 +71,13 @@ public class MsBibImporterTest {
 
     @Test
     public final void testGetFormatName() {
-        MsBibImporter testImporter = new MsBibImporter();
+        MsBibImporter testImporter = new MsBibImporter(importFormatPreferences);
         assertEquals("MSBib", testImporter.getFormatName());
     }
 
     @Test
     public final void testGetCommandLineId() {
-        MsBibImporter testImporter = new MsBibImporter();
+        MsBibImporter testImporter = new MsBibImporter(importFormatPreferences);
         assertEquals("msbib", testImporter.getId());
     }
 

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/MsBibImporterTestfiles.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/MsBibImporterTestfiles.java
@@ -9,8 +9,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -29,10 +29,11 @@ public class MsBibImporterTestfiles {
     public String fileName;
 
     private Path xmlFile;
+    private ImportFormatPreferences importFormatPreferences;
 
     @Before
     public void setUp() throws URISyntaxException {
-        Globals.prefs = JabRefPreferences.getInstance();
+        importFormatPreferences = ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance());
         xmlFile = Paths.get(MsBibImporter.class.getResource(fileName + ".xml").toURI());
     }
 
@@ -46,7 +47,7 @@ public class MsBibImporterTestfiles {
 
     @Test
     public final void testIsRecognizedFormat() throws Exception {
-        MsBibImporter testImporter = new MsBibImporter();
+        MsBibImporter testImporter = new MsBibImporter(importFormatPreferences);
         Assert.assertTrue(testImporter.isRecognizedFormat(xmlFile, Charset.defaultCharset()));
     }
 
@@ -55,9 +56,9 @@ public class MsBibImporterTestfiles {
     public void testImportEntries() throws IOException {
 
         String bibFileName = fileName + ".bib";
-        MsBibImporter testImporter = new MsBibImporter();
+        MsBibImporter testImporter = new MsBibImporter(importFormatPreferences);
         List<BibEntry> result = testImporter.importDatabase(xmlFile, Charset.defaultCharset()).getDatabase().getEntries();
-        BibEntryAssert.assertEquals(MsBibImporterTest.class, bibFileName, result);
+        BibEntryAssert.assertEquals(MsBibImporterTest.class, bibFileName, result, importFormatPreferences);
     }
 
 }

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/OvidImporterTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/OvidImporterTest.java
@@ -11,8 +11,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
@@ -24,12 +24,12 @@ import org.junit.Test;
 public class OvidImporterTest {
 
     private OvidImporter importer;
-
+    private ImportFormatPreferences importFormatPreferences;
 
     @Before
     public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
-        importer = new OvidImporter();
+        importFormatPreferences = ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance());
+        importer = new OvidImporter(importFormatPreferences);
     }
 
     @Test
@@ -151,7 +151,7 @@ public class OvidImporterTest {
                 List<BibEntry> entries = importer.importDatabase(file, Charset.defaultCharset()).getDatabase().getEntries();
                 Assert.assertNotNull(entries);
                 Assert.assertEquals(1, entries.size());
-                BibEntryAssert.assertEquals(nis, entries.get(0));
+                BibEntryAssert.assertEquals(nis, entries.get(0), importFormatPreferences);
             }
         }
     }

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/PdfContentImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/PdfContentImporterTestFiles.java
@@ -9,13 +9,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
 import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -28,11 +26,6 @@ public class PdfContentImporterTestFiles {
     @Parameter
     public String fileName;
 
-
-    @Before
-    public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
-    }
 
     @Parameters(name = "{index}: {0}")
     public static Collection<Object[]> fileNames() {
@@ -51,11 +44,12 @@ public class PdfContentImporterTestFiles {
     public void correctContent() throws IOException, URISyntaxException {
         String pdfFileName = fileName + ".pdf";
         String bibFileName = fileName + ".bib";
-        PdfContentImporter importer = new PdfContentImporter(
-                ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance()));
+        ImportFormatPreferences importFormatPreferences = ImportFormatPreferences
+                .fromPreferences(JabRefPreferences.getInstance());
+        PdfContentImporter importer = new PdfContentImporter(importFormatPreferences);
         Path pdfFile = Paths.get(PdfContentImporter.class.getResource(pdfFileName).toURI());
         List<BibEntry> result = importer.importDatabase(pdfFile, StandardCharsets.UTF_8).getDatabase().getEntries();
-        BibEntryAssert.assertEquals(PdfContentImporterTest.class, bibFileName, result);
+        BibEntryAssert.assertEquals(PdfContentImporterTest.class, bibFileName, result, importFormatPreferences);
     }
 
 }

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/PdfXmpImporterTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/PdfXmpImporterTest.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import net.sf.jabref.Globals;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.logic.xmp.XMPPreferences;
@@ -31,8 +31,8 @@ public class PdfXmpImporterTest {
 
     @Before
     public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
-        importer = new PdfXmpImporter(XMPPreferences.fromPreferences(JabRefPreferences.getInstance()));
+        importer = new PdfXmpImporter(XMPPreferences.fromPreferences(JabRefPreferences.getInstance()),
+                ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance()));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/RISImporterTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/RISImporterTest.java
@@ -6,7 +6,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import net.sf.jabref.Globals;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -21,8 +21,7 @@ public class RISImporterTest {
 
     @Before
     public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
-        importer = new RisImporter();
+        importer = new RisImporter(ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance()));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/RISImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/RISImporterTestFiles.java
@@ -9,8 +9,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -31,11 +31,12 @@ public class RISImporterTestFiles {
     public String fileName;
 
     private Path risFile;
+    private ImportFormatPreferences importFormatPreferences;
 
     @Before
     public void setUp() throws URISyntaxException {
-        Globals.prefs = JabRefPreferences.getInstance();
-        risImporter = new RisImporter();
+        importFormatPreferences = ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance());
+        risImporter = new RisImporter(importFormatPreferences);
         risFile = Paths.get(RISImporterTest.class.getResource(fileName + ".ris").toURI());
     }
 
@@ -53,6 +54,6 @@ public class RISImporterTestFiles {
     @Test
     public void testImportEntries() throws IOException {
         List<BibEntry> risEntries = risImporter.importDatabase(risFile, Charset.defaultCharset()).getDatabase().getEntries();
-        BibEntryAssert.assertEquals(RISImporterTest.class, fileName + ".bib", risEntries);
+        BibEntryAssert.assertEquals(RISImporterTest.class, fileName + ".bib", risEntries, importFormatPreferences);
     }
 }

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/RepecNepImporterTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/RepecNepImporterTest.java
@@ -9,7 +9,6 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
 import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.util.FileExtensions;
@@ -24,11 +23,11 @@ public class RepecNepImporterTest {
 
     private RepecNepImporter testImporter;
 
-
+    private ImportFormatPreferences importFormatPreferences;
     @Before
     public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
-        testImporter = new RepecNepImporter(ImportFormatPreferences.fromPreferences(Globals.prefs));
+        importFormatPreferences = ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance());
+        testImporter = new RepecNepImporter(importFormatPreferences);
     }
 
     @Test
@@ -57,7 +56,7 @@ public class RepecNepImporterTest {
         try (InputStream bibIn = RepecNepImporter.class.getResourceAsStream("RepecNepImporterTest1.bib")) {
             List<BibEntry> entries = testImporter.importDatabase(file, Charset.defaultCharset()).getDatabase().getEntries();
             Assert.assertEquals(1, entries.size());
-            BibEntryAssert.assertEquals(bibIn, entries.get(0));
+            BibEntryAssert.assertEquals(bibIn, entries.get(0), importFormatPreferences);
         }
     }
 
@@ -67,7 +66,7 @@ public class RepecNepImporterTest {
         try (InputStream bibIn = RepecNepImporter.class.getResourceAsStream("RepecNepImporterTest2.bib")) {
             List<BibEntry> entries = testImporter.importDatabase(file, Charset.defaultCharset()).getDatabase().getEntries();
             Assert.assertEquals(1, entries.size());
-            BibEntryAssert.assertEquals(bibIn, entries.get(0));
+            BibEntryAssert.assertEquals(bibIn, entries.get(0), importFormatPreferences);
         }
     }
 
@@ -77,7 +76,7 @@ public class RepecNepImporterTest {
         try (InputStream bibIn = RepecNepImporter.class.getResourceAsStream("RepecNepImporterTest3.bib")) {
             List<BibEntry> entries = testImporter.importDatabase(file, Charset.defaultCharset()).getDatabase().getEntries();
             Assert.assertEquals(1, entries.size());
-            BibEntryAssert.assertEquals(bibIn, entries.get(0));
+            BibEntryAssert.assertEquals(bibIn, entries.get(0), importFormatPreferences);
         }
     }
 

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/SilverPlatterImporterTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/SilverPlatterImporterTest.java
@@ -8,8 +8,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.bibtex.BibEntryAssert;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
@@ -36,10 +36,12 @@ public class SilverPlatterImporterTest {
     public String bibName;
 
 
+    private ImportFormatPreferences importFormatPreferences;
+
     @Before
     public void setUp() throws Exception {
-        Globals.prefs = JabRefPreferences.getInstance();
-        testImporter = new SilverPlatterImporter();
+        importFormatPreferences = ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance());
+        testImporter = new SilverPlatterImporter(importFormatPreferences);
         txtFile = Paths.get(SilverPlatterImporterTest.class.getResource(filename + ".txt").toURI());
         bibName = filename + ".bib";
     }
@@ -69,7 +71,7 @@ public class SilverPlatterImporterTest {
     public final void testImportEntries() throws Exception {
         try (InputStream bibIn = SilverPlatterImporterTest.class.getResourceAsStream(bibName)) {
             List<BibEntry> entries = testImporter.importDatabase(txtFile, Charset.defaultCharset()).getDatabase().getEntries();
-            BibEntryAssert.assertEquals(bibIn, entries);
+            BibEntryAssert.assertEquals(bibIn, entries, importFormatPreferences);
         }
     }
 }

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/SilverPlatterImporterTestNotRecognized.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/SilverPlatterImporterTestNotRecognized.java
@@ -7,7 +7,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
-import net.sf.jabref.Globals;
+import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
@@ -23,8 +23,8 @@ public class SilverPlatterImporterTestNotRecognized {
 
     @Before
     public void setUp() throws Exception {
-        Globals.prefs = JabRefPreferences.getInstance();
-        testImporter = new SilverPlatterImporter();
+        testImporter = new SilverPlatterImporter(
+                ImportFormatPreferences.fromPreferences(JabRefPreferences.getInstance()));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Defaults;
-import net.sf.jabref.Globals;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
@@ -17,7 +16,6 @@ import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.InternalBibtexFields;
 import net.sf.jabref.preferences.JabRefPreferences;
 
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -31,11 +29,6 @@ public class IntegrityCheckTest {
 
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
-
-    @Before
-    public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
-    }
 
     @Test
     public void testUrlChecks() {
@@ -238,7 +231,7 @@ public class IntegrityCheckTest {
     }
 
     private BibDatabaseContext createContext(String field, String value) {
-        return createContext(field, value, new MetaData());
+        return createContext(field, value, new MetaData(JabRefPreferences.getInstance().getDefaultEncoding()));
     }
 
     private void assertWrong(BibDatabaseContext context) {

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Defaults;
+import net.sf.jabref.Globals;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
@@ -16,6 +17,7 @@ import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.InternalBibtexFields;
 import net.sf.jabref.preferences.JabRefPreferences;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -29,6 +31,12 @@ public class IntegrityCheckTest {
 
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
+
+
+    @Before
+    public void setUp() {
+        Globals.prefs = JabRefPreferences.getInstance();
+    }
 
     @Test
     public void testUrlChecks() {
@@ -231,7 +239,7 @@ public class IntegrityCheckTest {
     }
 
     private BibDatabaseContext createContext(String field, String value) {
-        return createContext(field, value, new MetaData(JabRefPreferences.getInstance().getDefaultEncoding()));
+        return createContext(field, value, new MetaData());
     }
 
     private void assertWrong(BibDatabaseContext context) {

--- a/src/test/java/net/sf/jabref/logic/util/io/FileBasedTestCase.java
+++ b/src/test/java/net/sf/jabref/logic/util/io/FileBasedTestCase.java
@@ -12,10 +12,8 @@ import java.util.Map;
 import java.util.Set;
 
 import net.sf.jabref.BibtexTestData;
-import net.sf.jabref.Globals;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -25,7 +23,6 @@ import org.junit.rules.TemporaryFolder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 public class FileBasedTestCase {
 
@@ -38,8 +35,6 @@ public class FileBasedTestCase {
 
     @Before
     public void setUp() throws IOException {
-        Globals.prefs = mock(JabRefPreferences.class);
-
         BibDatabase database = BibtexTestData.getBibtexDatabase();
         entry = database.getEntries().iterator().next();
 

--- a/src/test/java/net/sf/jabref/logic/util/io/FileUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/io/FileUtilTest.java
@@ -6,53 +6,40 @@ import java.util.Arrays;
 import java.util.List;
 
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
+import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class FileUtilTest {
-
-    private JabRefPreferences prefs;
-
-
-    @Before
-    public void setUp() {
-        prefs = mock(JabRefPreferences.class);
-    }
-
 
     @Test
     public void testGetLinkedFileNameDefault() {
         // bibkey - title
-        when(prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN))
-                .thenReturn("\\bibtexkey\\begin{title} - \\format[RemoveBrackets]{\\title}\\end{title}");
 
         BibEntry entry = new BibEntry();
         entry.setCiteKey("1234");
         entry.setField("title", "mytitle");
-
-        assertEquals("1234 - mytitle",
-                FileUtil.createFileNameFromPattern(null, entry, mock(JournalAbbreviationLoader.class), prefs));
+        assertEquals("1234 - mytitle", FileUtil.createFileNameFromPattern(null, entry,
+                "\\bibtexkey\\begin{title} - \\format[RemoveBrackets]{\\title}\\end{title}", LayoutFormatterPreferences
+                        .fromPreferences(JabRefPreferences.getInstance(), mock(JournalAbbreviationLoader.class))));
     }
 
     @Test
     public void testGetLinkedFileNameBibTeXKey() {
         // bibkey
-        when(prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN)).thenReturn("\\bibtexkey");
 
         BibEntry entry = new BibEntry();
         entry.setCiteKey("1234");
         entry.setField("title", "mytitle");
 
         assertEquals("1234",
-                FileUtil.createFileNameFromPattern(null, entry, mock(JournalAbbreviationLoader.class), prefs));
+                FileUtil.createFileNameFromPattern(null, entry, "\\bibtexkey", mock(LayoutFormatterPreferences.class)));
     }
 
     @Test


### PR DESCRIPTION
Unfortunately there was still a `Globals` dependency recently introduced...


