### PR TITLE
Improve focus of the maintable after a sidepane gets closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ## [Unreleased]
 
 ### Changed
-- Improve focus of the maintable after a sidepane gets closed
 - [#970](https://github.com/JabRef/jabref/issues/970): Implementation of shared database support (full system) with event based synchronization for MySQL, PostgreSQL and Oracle database systems.
 - Externally fetched information can be merged for entries with an ISBN
 - Externally fetched information can be merged for entries with an ArXiv eprint
@@ -41,6 +40,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - [#1758](https://github.com/JabRef/jabref/issues/1758) Added a button to open Database Properties dialog help
 
 
+- Improve focus of the maintable after a sidepane gets closed (Before it would focus the toolbar or it would focus the wrong entry)
 
 ### Fixed
 - Fixed [#1632](https://github.com/JabRef/jabref/issues/1632): User comments (@Comment) with or without brackets are now kept

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,6 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Add integrity check to avoid non-ASCII characters in BibTeX files
 - [#1751](https://github.com/JabRef/jabref/issues/1751) Added tooltip to web search button
 - [#1758](https://github.com/JabRef/jabref/issues/1758) Added a button to open Database Properties dialog help
-
-
 - Improve focus of the maintable after a sidepane gets closed (Before it would focus the toolbar or it would focus the wrong entry)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ## [Unreleased]
 
 ### Changed
+- Improve focus of the maintable after a sidepane gets closed
 - [#970](https://github.com/JabRef/jabref/issues/970): Implementation of shared database support (full system) with event based synchronization for MySQL, PostgreSQL and Oracle database systems.
 - Externally fetched information can be merged for entries with an ISBN
 - Externally fetched information can be merged for entries with an ArXiv eprint

--- a/src/main/java/net/sf/jabref/gui/SidePaneManager.java
+++ b/src/main/java/net/sf/jabref/gui/SidePaneManager.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import javax.swing.SwingUtilities;
 
 import net.sf.jabref.Globals;
+import net.sf.jabref.gui.maintable.MainTable;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;
@@ -100,12 +101,13 @@ public class SidePaneManager {
 
     public synchronized void hide(String name) {
         SidePaneComponent sidePaneComponent = components.get(name);
+        MainTable mainTable = frame.getCurrentBasePanel().getMainTable();
         if (sidePaneComponent == null) {
             LOGGER.warn("Side pane component '" + name + "' unknown.");
         } else {
             hideComponent(sidePaneComponent);
-            frame.getCurrentBasePanel().getMainTable().setSelected(frame.getCurrentBasePanel().getMainTable().getSelectedRow());
-            frame.getCurrentBasePanel().getMainTable().requestFocus();
+            mainTable.setSelected(mainTable.getSelectedRow());
+            mainTable.requestFocus();
         }
     }
 

--- a/src/main/java/net/sf/jabref/gui/SidePaneManager.java
+++ b/src/main/java/net/sf/jabref/gui/SidePaneManager.java
@@ -104,6 +104,8 @@ public class SidePaneManager {
             LOGGER.warn("Side pane component '" + name + "' unknown.");
         } else {
             hideComponent(sidePaneComponent);
+            frame.getCurrentBasePanel().getMainTable().setSelected(frame.getCurrentBasePanel().getMainTable().getSelectedRow());
+            frame.getCurrentBasePanel().getMainTable().requestFocus();
         }
     }
 


### PR DESCRIPTION
Follow up of https://github.com/JabRef/jabref/pull/1525

The minimum quality is achieved: The new system is better then the old one.

Some issues remain, which i try to improve in this PR. Also thanks to @koppor for finding these and even providing a .gif.

## Focus of "new database" instead of entry.
Expectation: When I toggle something, the focus after toggling twice should be the same. This is not the case.

1. Click on first entry
2. Show web search (<kbd>alt</kbd>+<kbd>4</kbd>)
3. Click on first entry
4. Hide web search (<kbd>alt</kbd>+<kbd>4</kbd>)
5. Show web search (<kbd>alt</kbd>+<kbd>4</kbd>)
6. Hide web search (<kbd>alt</kbd>+<kbd>4</kbd>)
7. "New database" is focused instead of the first entry.

Sometimes, this happens after step 4, but not reproducable.

## Position in entry table
(updated)

The position in the entry table changes depended of the selected group.

Expected behavior: When I select the third entry, show the groups interface, hide the groups interface, press cursor up, the entry above the current entry should be shown.

Example:

1. open `complex.bib`
2. Select fourth entry **in** table
3. Press <kbd>cursor down</kbd>
4. Show groups interface (<kbd>alt</kbd>+<kbd>3</kbd>)
5. Select a group "StaticGroup"
6. Click on selected entry
7. Hide groups interface (<kbd>alt</kbd>+<kbd>3</kbd>)
7. Press <kbd>cursor down</kbd>
8. Effect: first entry in table is selected.

![issue2](https://cloud.githubusercontent.com/assets/1366654/17632362/33847918-60c8-11e6-9e7a-692063fe089c.gif)

Just play around a bit with "complex.bib"

