### PR TITLE
Disable some actions while no database is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - [#1897](https://github.com/JabRef/jabref/issues/1897) Implemented integrity check for `year` field: Last four nonpunctuation characters should be numerals
 - Address in MS-Office 2007 xml format is now imported as `location`
 - [#1912](https://github.com/JabRef/jabref/issues/1912) Implemented integrity check for `edition` field: Should have the first letter capitalized (BibTeX), Should contain an integer or a literal (BibLaTeX)
+- [#463](https://github.com/JabRef/jabref/issues/463): Disable menu-item and toolbar-buttons while no database is open
 
 ### Fixed
 - Fixed selecting an entry out of multiple duplicates

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -1,6 +1,7 @@
 package net.sf.jabref.gui;
 
 import java.awt.Component;
+import java.awt.Container;
 import java.awt.Cursor;
 import java.awt.Font;
 import java.awt.Frame;
@@ -1191,8 +1192,8 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         edit.add(unmark);
         edit.add(unmarkAll);
         edit.addSeparator();
-        if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SPECIALFIELDSENABLED)) {
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_RANKING)) {
+        if (Globals.prefs.getBoolean(JabRefPreferences.SPECIALFIELDSENABLED)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_RANKING)) {
                 rankSubMenue = new JMenu();
                 RightClickMenu.populateSpecialFieldMenu(rankSubMenue, Rank.getInstance(), this);
                 edit.add(rankSubMenue);
@@ -1203,7 +1204,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_QUALITY)) {
                 edit.add(toggleQualityAssured);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_PRIORITY)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_PRIORITY)) {
                 rankSubMenue = new JMenu();
                 RightClickMenu.populateSpecialFieldMenu(rankSubMenue, Priority.getInstance(), this);
                 edit.add(rankSubMenue);
@@ -1211,7 +1212,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_PRINTED)) {
                 edit.add(togglePrinted);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_READ)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_READ)) {
                 rankSubMenue = new JMenu();
                 RightClickMenu.populateSpecialFieldMenu(rankSubMenue, ReadStatus.getInstance(), this);
                 edit.add(rankSubMenue);
@@ -1493,6 +1494,8 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         tlb.addSeparator();
         tlb.add(donationAction);
         tlb.add(forkMeOnGitHubAction);
+
+        createDisabledIconsForButtons(tlb);
     }
 
     /**
@@ -1548,6 +1551,12 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             }
             if (o instanceof Component) {
                 ((Component) o).setEnabled(enabled);
+                if (o instanceof JPanel) {
+                    JPanel root = (JPanel) o;
+                    for (int index = 0; index < root.getComponentCount(); index++) {
+                        root.getComponent(index).setEnabled(enabled);
+                    }
+                }
             }
         }
     }
@@ -1690,6 +1699,20 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
                 if (item.getIcon() instanceof IconTheme.FontBasedIcon) {
                     item.setDisabledIcon(((IconTheme.FontBasedIcon) item.getIcon()).createDisabledIcon());
                 }
+            }
+        }
+    }
+
+    public void createDisabledIconsForButtons(Container container) {
+        for (int index = 0; index < container.getComponentCount(); index++) {
+            Component component = container.getComponent(index);
+            if (component instanceof JButton) {
+                JButton item = (JButton) component;
+                if (item.getIcon() instanceof IconTheme.FontBasedIcon) {
+                    item.setDisabledIcon(((IconTheme.FontBasedIcon) item.getIcon()).createDisabledIcon());
+                }
+            } else if (component instanceof JPanel) {
+                createDisabledIconsForButtons((JPanel)component);
             }
         }
     }

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -285,7 +285,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             Localization.menuTitle("Unmark entries"), Localization.lang("Unmark entries"),
             Globals.getKeyPrefs().getKey(KeyBinding.UNMARK_ENTRIES), IconTheme.JabRefIcon.UNMARK_ENTRIES.getIcon());
     private final AbstractAction unmarkAll = new GeneralAction(Actions.UNMARK_ALL, Localization.menuTitle("Unmark all"));
-    private JMenu rankSubMenue;
+    private JMenu rankSubMenu;
     private final AbstractAction toggleRelevance = new GeneralAction(
             Relevance.getInstance().getValues().get(0).getActionName(),
             Relevance.getInstance().getValues().get(0).getMenuString(),
@@ -383,7 +383,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             Localization.lang("Will write XMP-metadata to the PDFs linked from selected entries."),
             Globals.getKeyPrefs().getKey(KeyBinding.WRITE_XMP));
 
-    private JMenuItem optMenueItem;
+    private JMenuItem optMenuItem;
 
     private final AbstractAction openFolder = new GeneralAction(Actions.OPEN_FOLDER,
             Localization.menuTitle("Open folder"), Localization.lang("Open folder"),
@@ -1194,9 +1194,9 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         edit.addSeparator();
         if (Globals.prefs.getBoolean(JabRefPreferences.SPECIALFIELDSENABLED)) {
             if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_RANKING)) {
-                rankSubMenue = new JMenu();
-                RightClickMenu.populateSpecialFieldMenu(rankSubMenue, Rank.getInstance(), this);
-                edit.add(rankSubMenue);
+                rankSubMenu = new JMenu();
+                RightClickMenu.populateSpecialFieldMenu(rankSubMenu, Rank.getInstance(), this);
+                edit.add(rankSubMenu);
             }
             if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_RELEVANCE)) {
                 edit.add(toggleRelevance);
@@ -1205,17 +1205,17 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
                 edit.add(toggleQualityAssured);
             }
             if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_PRIORITY)) {
-                rankSubMenue = new JMenu();
-                RightClickMenu.populateSpecialFieldMenu(rankSubMenue, Priority.getInstance(), this);
-                edit.add(rankSubMenue);
+                rankSubMenu = new JMenu();
+                RightClickMenu.populateSpecialFieldMenu(rankSubMenu, Priority.getInstance(), this);
+                edit.add(rankSubMenu);
             }
             if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_PRINTED)) {
                 edit.add(togglePrinted);
             }
             if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_READ)) {
-                rankSubMenue = new JMenu();
-                RightClickMenu.populateSpecialFieldMenu(rankSubMenue, ReadStatus.getInstance(), this);
-                edit.add(rankSubMenue);
+                rankSubMenu = new JMenu();
+                RightClickMenu.populateSpecialFieldMenu(rankSubMenu, ReadStatus.getInstance(), this);
+                edit.add(rankSubMenu);
             }
             edit.addSeparator();
         }
@@ -1318,8 +1318,8 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         tools.add(writeXmpAction);
         OpenOfficePanel otp = OpenOfficePanel.getInstance();
         otp.init(this, sidePaneManager);
-        optMenueItem = otp.getMenuItem();
-        tools.add(optMenueItem);
+        optMenuItem = otp.getMenuItem();
+        tools.add(optMenuItem);
         tools.add(pushExternalButton.getMenuAction());
         tools.addSeparator();
         tools.add(openFolder);
@@ -1511,9 +1511,9 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         openDatabaseOnlyActions.clear();
         openDatabaseOnlyActions.addAll(Arrays.asList(manageSelectors, mergeDatabaseAction, newSubDatabaseAction, save,
                 saveAs, saveSelectedAs, saveSelectedAsPlain, editModeAction, undo, redo, cut, deleteEntry, copy, paste, mark, markSpecific, unmark,
-                unmarkAll, rankSubMenue, editEntry, selectAll, copyKey, copyCiteKey, copyKeyAndTitle, editPreamble, editStrings,
+                unmarkAll, rankSubMenu, editEntry, selectAll, copyKey, copyCiteKey, copyKeyAndTitle, editPreamble, editStrings,
                 toggleGroups, makeKeyAction, normalSearch, generalFetcher.getAction(), mergeEntries, cleanupEntries, exportToClipboard, replaceAll,
-                sendAsEmail, downloadFullText, writeXmpAction,optMenueItem, findUnlinkedFiles, addToGroup, removeFromGroup,
+                sendAsEmail, downloadFullText, writeXmpAction, optMenuItem, findUnlinkedFiles, addToGroup, removeFromGroup,
                 moveToGroup, autoLinkFile, resolveDuplicateKeys, openUrl, openFolder, openFile, togglePreview,
                 dupliCheck, autoSetFile, newEntryAction, newSpec, customizeAction, plainTextImport, getMassSetField(), getManageKeywords(),
                 pushExternalButton.getMenuAction(), closeDatabaseAction, getSwitchPreviewAction(), checkIntegrity,
@@ -1711,7 +1711,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
                     button.setDisabledIcon(((IconTheme.FontBasedIcon) button.getIcon()).createDisabledIcon());
                 }
             } else if (component instanceof JPanel) {
-                createDisabledIconsForButtons((JPanel)component);
+                createDisabledIconsForButtons((JPanel) component);
             }
         }
     }

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -382,6 +382,8 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             Localization.lang("Will write XMP-metadata to the PDFs linked from selected entries."),
             Globals.getKeyPrefs().getKey(KeyBinding.WRITE_XMP));
 
+    private JMenuItem optMenueItem;
+
     private final AbstractAction openFolder = new GeneralAction(Actions.OPEN_FOLDER,
             Localization.menuTitle("Open folder"), Localization.lang("Open folder"),
             Globals.getKeyPrefs().getKey(KeyBinding.OPEN_FOLDER));
@@ -474,6 +476,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
     // The action for adding a new entry of unspecified type.
     private final NewEntryAction newEntryAction = new NewEntryAction(this, Globals.getKeyPrefs().getKey(KeyBinding.NEW_ENTRY));
+    private JMenu newSpec;
     private final List<NewEntryAction> newSpecificEntryAction = getNewEntryActions();
 
     // The action for closing the current database and leaving the window open.
@@ -1130,7 +1133,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         JMenu view = JabRefFrame.subMenu(Localization.menuTitle("View"));
         JMenu tools = JabRefFrame.subMenu(Localization.menuTitle("Tools"));
         JMenu options = JabRefFrame.subMenu(Localization.menuTitle("Options"));
-        JMenu newSpec = JabRefFrame.subMenu(Localization.menuTitle("New entry by type..."));
+        newSpec = JabRefFrame.subMenu(Localization.menuTitle("New entry by type..."));
         JMenu helpMenu = JabRefFrame.subMenu(Localization.menuTitle("Help"));
 
         file.add(newBibtexDatabaseAction);
@@ -1314,7 +1317,8 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         tools.add(writeXmpAction);
         OpenOfficePanel otp = OpenOfficePanel.getInstance();
         otp.init(this, sidePaneManager);
-        tools.add(otp.getMenuItem());
+        optMenueItem = otp.getMenuItem();
+        tools.add(optMenueItem);
         tools.add(pushExternalButton.getMenuAction());
         tools.addSeparator();
         tools.add(openFolder);
@@ -1506,9 +1510,9 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
                 saveAs, saveSelectedAs, saveSelectedAsPlain, editModeAction, undo, redo, cut, deleteEntry, copy, paste, mark, markSpecific, unmark,
                 unmarkAll, rankSubMenue, editEntry, selectAll, copyKey, copyCiteKey, copyKeyAndTitle, editPreamble, editStrings,
                 toggleGroups, makeKeyAction, normalSearch, generalFetcher.getAction(), mergeEntries, cleanupEntries, exportToClipboard, replaceAll,
-                sendAsEmail, downloadFullText, writeXmpAction, findUnlinkedFiles, addToGroup, removeFromGroup,
+                sendAsEmail, downloadFullText, writeXmpAction,optMenueItem, findUnlinkedFiles, addToGroup, removeFromGroup,
                 moveToGroup, autoLinkFile, resolveDuplicateKeys, openUrl, openFolder, openFile, togglePreview,
-                dupliCheck, autoSetFile, newEntryAction, plainTextImport, getMassSetField(), getManageKeywords(),
+                dupliCheck, autoSetFile, newEntryAction, newSpec, customizeAction, plainTextImport, getMassSetField(), getManageKeywords(),
                 pushExternalButton.getMenuAction(), closeDatabaseAction, getSwitchPreviewAction(), checkIntegrity,
                 toggleHighlightAny, toggleHighlightAll, toggleHighlightDisable, databaseProperties, abbreviateIso, abbreviateMedline,
                 unabbreviate, exportAll, exportSelected, importCurrent, saveAll, focusTable, increaseFontSize, decreseFontSize,

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -1476,7 +1476,6 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
                 specialFieldButtons.add(button);
             }
         }
-
         tlb.addSeparator();
 
         fetcherToggle = new JToggleButton(generalFetcher.getAction());
@@ -1545,14 +1544,14 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
      * @param enabled
      */
     private static void setEnabled(List<Object> list, boolean enabled) {
-        for (Object o : list) {
-            if (o instanceof Action) {
-                ((Action) o).setEnabled(enabled);
+        for (Object actionOrComponent : list) {
+            if (actionOrComponent instanceof Action) {
+                ((Action) actionOrComponent).setEnabled(enabled);
             }
-            if (o instanceof Component) {
-                ((Component) o).setEnabled(enabled);
-                if (o instanceof JPanel) {
-                    JPanel root = (JPanel) o;
+            if (actionOrComponent instanceof Component) {
+                ((Component) actionOrComponent).setEnabled(enabled);
+                if (actionOrComponent instanceof JPanel) {
+                    JPanel root = (JPanel) actionOrComponent;
                     for (int index = 0; index < root.getComponentCount(); index++) {
                         root.getComponent(index).setEnabled(enabled);
                     }
@@ -1707,9 +1706,9 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         for (int index = 0; index < container.getComponentCount(); index++) {
             Component component = container.getComponent(index);
             if (component instanceof JButton) {
-                JButton item = (JButton) component;
-                if (item.getIcon() instanceof IconTheme.FontBasedIcon) {
-                    item.setDisabledIcon(((IconTheme.FontBasedIcon) item.getIcon()).createDisabledIcon());
+                JButton button = (JButton) component;
+                if (button.getIcon() instanceof IconTheme.FontBasedIcon) {
+                    button.setDisabledIcon(((IconTheme.FontBasedIcon) button.getIcon()).createDisabledIcon());
                 }
             } else if (component instanceof JPanel) {
                 createDisabledIconsForButtons((JPanel)component);

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -1475,6 +1475,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
                 specialFieldButtons.add(button);
             }
         }
+
         tlb.addSeparator();
 
         fetcherToggle = new JToggleButton(generalFetcher.getAction());

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -279,10 +279,12 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
     private final AbstractAction mark = new GeneralAction(Actions.MARK_ENTRIES, Localization.menuTitle("Mark entries"),
             Localization.lang("Mark entries"), Globals.getKeyPrefs().getKey(KeyBinding.MARK_ENTRIES), IconTheme.JabRefIcon.MARK_ENTRIES.getIcon());
+    private final JMenu markSpecific = JabRefFrame.subMenu(Localization.menuTitle("Mark specific color"));
     private final AbstractAction unmark = new GeneralAction(Actions.UNMARK_ENTRIES,
             Localization.menuTitle("Unmark entries"), Localization.lang("Unmark entries"),
             Globals.getKeyPrefs().getKey(KeyBinding.UNMARK_ENTRIES), IconTheme.JabRefIcon.UNMARK_ENTRIES.getIcon());
     private final AbstractAction unmarkAll = new GeneralAction(Actions.UNMARK_ALL, Localization.menuTitle("Unmark all"));
+    private JMenu rankSubMenue;
     private final AbstractAction toggleRelevance = new GeneralAction(
             Relevance.getInstance().getValues().get(0).getActionName(),
             Relevance.getInstance().getValues().get(0).getMenuString(),
@@ -1179,7 +1181,6 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
         edit.addSeparator();
         edit.add(mark);
-        JMenu markSpecific = JabRefFrame.subMenu(Localization.menuTitle("Mark specific color"));
         for (int i = 0; i < EntryMarker.MAX_MARKING_LEVEL; i++) {
             markSpecific.add(new MarkEntriesAction(this, i).getMenuItem());
         }
@@ -1187,12 +1188,11 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         edit.add(unmark);
         edit.add(unmarkAll);
         edit.addSeparator();
-        if (Globals.prefs.getBoolean(JabRefPreferences.SPECIALFIELDSENABLED)) {
-            JMenu m;
-            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_RANKING)) {
-                m = new JMenu();
-                RightClickMenu.populateSpecialFieldMenu(m, Rank.getInstance(), this);
-                edit.add(m);
+        if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SPECIALFIELDSENABLED)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_RANKING)) {
+                rankSubMenue = new JMenu();
+                RightClickMenu.populateSpecialFieldMenu(rankSubMenue, Rank.getInstance(), this);
+                edit.add(rankSubMenue);
             }
             if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_RELEVANCE)) {
                 edit.add(toggleRelevance);
@@ -1200,18 +1200,18 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
             if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_QUALITY)) {
                 edit.add(toggleQualityAssured);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_PRIORITY)) {
-                m = new JMenu();
-                RightClickMenu.populateSpecialFieldMenu(m, Priority.getInstance(), this);
-                edit.add(m);
+            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_PRIORITY)) {
+                rankSubMenue = new JMenu();
+                RightClickMenu.populateSpecialFieldMenu(rankSubMenue, Priority.getInstance(), this);
+                edit.add(rankSubMenue);
             }
             if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_PRINTED)) {
                 edit.add(togglePrinted);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_READ)) {
-                m = new JMenu();
-                RightClickMenu.populateSpecialFieldMenu(m, ReadStatus.getInstance(), this);
-                edit.add(m);
+            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_READ)) {
+                rankSubMenue = new JMenu();
+                RightClickMenu.populateSpecialFieldMenu(rankSubMenue, ReadStatus.getInstance(), this);
+                edit.add(rankSubMenue);
             }
             edit.addSeparator();
         }
@@ -1503,15 +1503,15 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     private void initActions() {
         openDatabaseOnlyActions.clear();
         openDatabaseOnlyActions.addAll(Arrays.asList(manageSelectors, mergeDatabaseAction, newSubDatabaseAction, save,
-                saveAs, saveSelectedAs, saveSelectedAsPlain, undo, redo, cut, deleteEntry, copy, paste, mark, unmark,
-                unmarkAll, editEntry, selectAll, copyKey, copyCiteKey, copyKeyAndTitle, editPreamble, editStrings,
-                toggleGroups, makeKeyAction, normalSearch, mergeEntries, cleanupEntries, exportToClipboard, replaceAll,
+                saveAs, saveSelectedAs, saveSelectedAsPlain, editModeAction, undo, redo, cut, deleteEntry, copy, paste, mark, markSpecific, unmark,
+                unmarkAll, rankSubMenue, editEntry, selectAll, copyKey, copyCiteKey, copyKeyAndTitle, editPreamble, editStrings,
+                toggleGroups, makeKeyAction, normalSearch, generalFetcher.getAction(), mergeEntries, cleanupEntries, exportToClipboard, replaceAll,
                 sendAsEmail, downloadFullText, writeXmpAction, findUnlinkedFiles, addToGroup, removeFromGroup,
                 moveToGroup, autoLinkFile, resolveDuplicateKeys, openUrl, openFolder, openFile, togglePreview,
                 dupliCheck, autoSetFile, newEntryAction, plainTextImport, getMassSetField(), getManageKeywords(),
                 pushExternalButton.getMenuAction(), closeDatabaseAction, getSwitchPreviewAction(), checkIntegrity,
                 toggleHighlightAny, toggleHighlightAll, toggleHighlightDisable, databaseProperties, abbreviateIso, abbreviateMedline,
-                unabbreviate, exportAll, exportSelected, importCurrent, saveAll, focusTable,
+                unabbreviate, exportAll, exportSelected, importCurrent, saveAll, focusTable, increaseFontSize, decreseFontSize,
                 toggleRelevance, toggleQualityAssured, togglePrinted, pushExternalButton.getComponent()));
 
         openDatabaseOnlyActions.addAll(newSpecificEntryAction);


### PR DESCRIPTION
I am working on this issue https://github.com/JabRef/jabref/issues/463

I have disabled and greyed out all menu items and toolbar buttons that should not be active if no database is open. (take a look at screenshots)

![2016-09-05_14h06_41](https://cloud.githubusercontent.com/assets/13031192/18247487/26cbd33e-7373-11e6-95c6-abab90cd9665.png)
![2016-09-05_14h08_15](https://cloud.githubusercontent.com/assets/13031192/18247490/2950383e-7373-11e6-9fa4-4f0a8df47dad.png)
![2016-09-05_14h08_31](https://cloud.githubusercontent.com/assets/13031192/18247493/2c1b102a-7373-11e6-9a7f-e973775fe9d2.png)
![2016-09-05_14h08_52](https://cloud.githubusercontent.com/assets/13031192/18247495/2e4699b4-7373-11e6-9ac3-38f39651aced.png)
![2016-09-05_14h09_09](https://cloud.githubusercontent.com/assets/13031192/18247496/303c5fc4-7373-11e6-9e17-46cf61e8413b.png)
![2016-09-05_14h09_22](https://cloud.githubusercontent.com/assets/13031192/18247499/321ceb9c-7373-11e6-9f6a-2fafa4049210.png)
![2016-09-05_14h11_28](https://cloud.githubusercontent.com/assets/13031192/18247500/33fd410a-7373-11e6-91a9-be15fb04e209.png)
![2016-09-05_14h11_41](https://cloud.githubusercontent.com/assets/13031192/18247501/36426a08-7373-11e6-8ce7-eb3ac6052e33.png)
![2016-09-05_14h11_55](https://cloud.githubusercontent.com/assets/13031192/18247504/3876d43a-7373-11e6-88be-3ebd5f475eae.png)
![2016-09-05_14h12_04](https://cloud.githubusercontent.com/assets/13031192/18247506/3a9b7400-7373-11e6-8a46-e0b5997d2de3.png)
![2016-09-05_14h12_20](https://cloud.githubusercontent.com/assets/13031192/18247510/3c9b5536-7373-11e6-8b43-97b9b251da60.png)

- [x] Change in CHANGELOG.md described
- [x] Insert screenshots of menu item and toolbar item, if no database is open.