### PR TITLE
Fixed name column rendering #1499 and #1531

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed [#1257](https://github.com/JabRef/jabref/issues/1324): Preferences for the BibTeX key generator set in a version prior to 3.2 are now migrated automatically to the new version
 - Fixed [#1716](https://github.com/JabRef/jabref/issues/1716): `@`-Symbols stored in BibTeX fields no longer break the database
 - Fixed [#1499](https://github.com/JabRef/jabref/issues/1499): {} braces are now treated correctly in in author/editor
-- Fixed [#1531](https://github.com/JabRef/jabref/issues/1531): \relax can be used for abbreviation of author names
+- Fixed [#1531](https://github.com/JabRef/jabref/issues/1531): `\relax` can be used for abbreviation of author names
  
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed NullPointerException when trying to set a special field or mark an entry through the menu without having an open database
 - Fixed [#1257](https://github.com/JabRef/jabref/issues/1324): Preferences for the BibTeX key generator set in a version prior to 3.2 are now migrated automatically to the new version
 - Fixed [#1716](https://github.com/JabRef/jabref/issues/1716): `@`-Symbols stored in BibTeX fields no longer break the database
+- Fixed [#1499](https://github.com/JabRef/jabref/issues/1499): {} braces are now treated correctly in in author/editor
+- Fixed [#1531](https://github.com/JabRef/jabref/issues/1531): \relax can be used for abbreviation of author names
+ 
 
 ### Removed
 - It is not longer possible to choose to convert HTML sub- and superscripts to equations

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableColumn.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableColumn.java
@@ -78,7 +78,7 @@ public class MainTableColumn {
      *
      * @return true if the bibtex fields contains author or editor
      */
-    public boolean isNameColumn() {
+    private boolean isNameColumn() {
         for (String field : bibtexFields) {
             if (InternalBibtexFields.getFieldExtras(field).contains(FieldProperties.PERSON_NAMES)) {
                 return true;
@@ -129,13 +129,14 @@ public class MainTableColumn {
             }
         }
 
-        if (content != null) {
-            content = toUnicode.format(content);
+        if (isNameColumn()) {
+            content = MainTableNameFormatter.formatName(content);
         }
 
-        if (isNameColumn()) {
-            return MainTableNameFormatter.formatName(content);
+        if (content != null) {
+            content = toUnicode.format(content).trim();
         }
+
         return content;
 
     }

--- a/src/test/java/net/sf/jabref/model/entry/AuthorListTest.java
+++ b/src/test/java/net/sf/jabref/model/entry/AuthorListTest.java
@@ -375,6 +375,37 @@ public class AuthorListTest {
         Assert.assertEquals("von Neumann", author.getLastOnly());
         Assert.assertEquals("Neumann, Jr, J.", author.getNameForAlphabetization());
         Assert.assertEquals("von", author.getVon());
+
+    }
+
+    @Test
+    public void testCompanyAuthor() {
+        Author author = AuthorList.parse("{JabRef Developers}").getAuthor(0);
+        Assert.assertNull(author.getFirst());
+        Assert.assertNull(author.getFirstAbbr());
+        Assert.assertEquals("JabRef Developers", author.getLast());
+        Assert.assertNull(author.getJr());
+        Assert.assertNull(author.getVon());
+    }
+
+    @Test
+    public void testCompanyAuthorWithLowerCaseWord() {
+        Author author = AuthorList.parse("{JabRef Developers on Fire}").getAuthor(0);
+        Assert.assertNull(author.getFirst());
+        Assert.assertNull(author.getFirstAbbr());
+        Assert.assertEquals("JabRef Developers on Fire", author.getLast());
+        Assert.assertNull(author.getJr());
+        Assert.assertNull(author.getVon());
+    }
+
+    @Test
+    public void testAbbreviationWithRelax() {
+        Author author = AuthorList.parse("{\\relax Ch}ristoph Cholera").getAuthor(0);
+        Assert.assertEquals("{\\relax Ch}ristoph", author.getFirst());
+        Assert.assertEquals("{\\relax Ch}.", author.getFirstAbbr());
+        Assert.assertEquals("Cholera", author.getLast());
+        Assert.assertNull(author.getJr());
+        Assert.assertNull(author.getVon());
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/model/entry/AuthorListTest.java
+++ b/src/test/java/net/sf/jabref/model/entry/AuthorListTest.java
@@ -381,31 +381,22 @@ public class AuthorListTest {
     @Test
     public void testCompanyAuthor() {
         Author author = AuthorList.parse("{JabRef Developers}").getAuthor(0);
-        Assert.assertNull(author.getFirst());
-        Assert.assertNull(author.getFirstAbbr());
-        Assert.assertEquals("JabRef Developers", author.getLast());
-        Assert.assertNull(author.getJr());
-        Assert.assertNull(author.getVon());
+        Author expected = new Author(null, null, null, "JabRef Developers", null);
+        Assert.assertEquals(expected, author);
     }
 
     @Test
     public void testCompanyAuthorWithLowerCaseWord() {
         Author author = AuthorList.parse("{JabRef Developers on Fire}").getAuthor(0);
-        Assert.assertNull(author.getFirst());
-        Assert.assertNull(author.getFirstAbbr());
-        Assert.assertEquals("JabRef Developers on Fire", author.getLast());
-        Assert.assertNull(author.getJr());
-        Assert.assertNull(author.getVon());
+        Author expected = new Author(null, null, null, "JabRef Developers on Fire", null);
+        Assert.assertEquals(expected, author);
     }
 
     @Test
     public void testAbbreviationWithRelax() {
         Author author = AuthorList.parse("{\\relax Ch}ristoph Cholera").getAuthor(0);
-        Assert.assertEquals("{\\relax Ch}ristoph", author.getFirst());
-        Assert.assertEquals("{\\relax Ch}.", author.getFirstAbbr());
-        Assert.assertEquals("Cholera", author.getLast());
-        Assert.assertNull(author.getJr());
-        Assert.assertNull(author.getVon());
+        Author expected = new Author("{\\relax Ch}ristoph", "{\\relax Ch}.", null, "Cholera", null);
+        Assert.assertEquals(expected, author);
     }
 
     @Test


### PR DESCRIPTION
Fixed #1499 and #1531. Better to format the author names before converting LaTeX to Unicode... Bah!

<img width="368" alt="capture17" src="https://cloud.githubusercontent.com/assets/8114497/17715209/7202747c-6403-11e6-877b-723da18781fe.PNG">

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)

