### PR TITLE
Moved a few more initialization to GUIGlobals.init()

### DIFF
--- a/src/main/java/net/sf/jabref/JabRefGUI.java
+++ b/src/main/java/net/sf/jabref/JabRefGUI.java
@@ -15,7 +15,6 @@
 */
 package net.sf.jabref;
 
-import java.awt.Font;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -117,8 +116,6 @@ public class JabRefGUI {
         }
 
         GUIGlobals.init();
-        GUIGlobals.currentFont = new Font(Globals.prefs.get(JabRefPreferences.FONT_FAMILY),
-                Globals.prefs.getInt(JabRefPreferences.FONT_STYLE), Globals.prefs.getInt(JabRefPreferences.FONT_SIZE));
 
         LOGGER.debug("Initializing frame");
         JabRefGUI.mainFrame = new JabRefFrame();

--- a/src/main/java/net/sf/jabref/gui/GUIGlobals.java
+++ b/src/main/java/net/sf/jabref/gui/GUIGlobals.java
@@ -66,11 +66,6 @@ public class GUIGlobals {
     public static final int WIDTH_ICON_COL = 26;
     public static final int WIDTH_ICON_COL_RANKING = 80; // Width of Ranking Icon Column
 
-    static {
-        // Set up entry editor colors, first time:
-        GUIGlobals.updateEntryEditorColors();
-    }
-
     public static JLabel getTableIcon(String fieldType) {
         JLabel label = GUIGlobals.TABLE_ICONS.get(fieldType);
         if (label == null) {
@@ -164,6 +159,13 @@ public class GUIGlobals {
         if (Globals.prefs.getBoolean(JabRefPreferences.EDITOR_EMACS_KEYBINDINGS)) {
             EmacsKeyBindings.load();
         }
+
+        // Set up entry editor colors, first time:
+        GUIGlobals.updateEntryEditorColors();
+
+        GUIGlobals.currentFont = new Font(Globals.prefs.get(JabRefPreferences.FONT_FAMILY),
+                Globals.prefs.getInt(JabRefPreferences.FONT_STYLE), Globals.prefs.getInt(JabRefPreferences.FONT_SIZE));
+
     }
 
 }


### PR DESCRIPTION
No point in having a static initializer when there is an init method that is called at startup or a single line just after the init method call.

- [x] Manually tested changed features in running JabRef
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)

