### PR TITLE
Fixed BibTeXMLImporter

### DIFF
--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/BibTeXMLImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/BibTeXMLImporter.java
@@ -34,11 +34,11 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import net.sf.jabref.importer.fileformat.bibtexml.Entry;
-import net.sf.jabref.importer.fileformat.bibtexml.File;
-import net.sf.jabref.importer.fileformat.bibtexml.Inbook;
-import net.sf.jabref.importer.fileformat.bibtexml.Incollection;
 import net.sf.jabref.logic.importer.ParserResult;
+import net.sf.jabref.logic.importer.fileformat.bibtexml.Entry;
+import net.sf.jabref.logic.importer.fileformat.bibtexml.File;
+import net.sf.jabref.logic.importer.fileformat.bibtexml.Inbook;
+import net.sf.jabref.logic.importer.fileformat.bibtexml.Incollection;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
@@ -96,7 +96,7 @@ public class BibTeXMLImporter extends ImportFormat {
         List<BibEntry> bibItems = new ArrayList<>();
 
         try {
-            JAXBContext context = JAXBContext.newInstance("net.sf.jabref.importer.fileformat.bibtexml");
+            JAXBContext context = JAXBContext.newInstance("net.sf.jabref.logic.importer.fileformat.bibtexml");
             Unmarshaller unmarshaller = context.createUnmarshaller();
             File file = (File) unmarshaller.unmarshal(reader);
 

--- a/xjc.gradle
+++ b/xjc.gradle
@@ -9,8 +9,8 @@ dependencies {
 task xjc {
     inputs.dir "src/main/resources/xjc/medline/"
     inputs.dir "src/main/resources/xjc/bibtexml/"
-    outputs.dir "src/main/gen/net/sf/jabref/importer/fileformat/medline"
-    outputs.dir "src/main/gen/net/sf/jabref/importer/fileformat/bibtexml"
+    outputs.dir "src/main/gen/net/sf/jabref/logic/importer/fileformat/medline"
+    outputs.dir "src/main/gen/net/sf/jabref/logic/importer/fileformat/bibtexml"
 
     ant.taskdef(name: 'xjc', classname: 'com.sun.tools.xjc.XJCTask', classpath: configurations.xjc.asPath)
 
@@ -18,7 +18,7 @@ task xjc {
         ant.xjc(destdir: 'src/main/gen/', package: 'net.sf.jabref.logic.importer.fileformat.medline') {
             schema(dir: 'src/main/resources/xjc/medline', includes: 'medline.xsd')
         }
-        ant.xjc(destdir: 'src/main/gen/', package: 'net.sf.jabref.importer.fileformat.bibtexml') {
+        ant.xjc(destdir: 'src/main/gen/', package: 'net.sf.jabref.logic.importer.fileformat.bibtexml') {
             schema(dir: 'src/main/resources/xjc/bibtexml', includes: 'bibtexml.xsd')
         }
     }


### PR DESCRIPTION
Moved location of generated files from importer to logic.importer. Will merge when the tests pass.

- [x] Manually tested changed features in running JabRef

