### PR TITLE
Some OS didn't show directories when a file type was selected in the import dialog

### DIFF
--- a/src/main/java/net/sf/jabref/gui/importer/ImportFileFilter.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ImportFileFilter.java
@@ -27,14 +27,14 @@ class ImportFileFilter extends FileFilter implements Comparable<ImportFileFilter
 
     private final ImportFormat format;
     private final String name;
-    private final FileNameExtensionFilter filextFilter;
+    private final FileNameExtensionFilter extensionFilter;
 
 
     public ImportFileFilter(ImportFormat format) {
         this.format = format;
         FileExtensions extensions = format.getExtensions();
         this.name = extensions.getDescription();
-        filextFilter = new FileNameExtensionFilter(extensions.getDescription(), extensions.getExtensions());
+        this.extensionFilter = new FileNameExtensionFilter(extensions.getDescription(), extensions.getExtensions());
     }
 
     public ImportFormat getImportFormat() {
@@ -43,7 +43,7 @@ class ImportFileFilter extends FileFilter implements Comparable<ImportFileFilter
 
     @Override
     public boolean accept(File file) {
-        return filextFilter.accept(file);
+        return (file != null) && (file.isDirectory() || extensionFilter.accept(file));
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/gui/importer/ImportFormats.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ImportFormats.java
@@ -26,7 +26,6 @@ import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
-
 import javax.swing.filechooser.FileFilter;
 
 import net.sf.jabref.Globals;

--- a/src/main/java/net/sf/jabref/logic/util/FileExtensions.java
+++ b/src/main/java/net/sf/jabref/logic/util/FileExtensions.java
@@ -12,7 +12,7 @@ import net.sf.jabref.logic.l10n.Localization;
 public enum FileExtensions {
     //important: No dot before the extension!
     BIBTEX_DB(String.format("%1s %2s", "BibTex", Localization.lang("Database")), "bib"),
-    BIBTEXML(Localization.lang("%0 file", "BibTeXML"), "bibx"),
+    BIBTEXML(Localization.lang("%0 file", "BibTeXML"), "bibx", "xml"),
     BILBIOSCAPE(Localization.lang("%0 file", "Biblioscape"), "txt"),
     COPAC(Localization.lang("%0 file", "Copac"), "txt"),
     ENDNOTE(Localization.lang("%0 file", "Endnote/Refer"), "ref", "enw"),


### PR DESCRIPTION
When importing a file (`Import into new | current Database`) and a file type was selected sometimes the directories weren't shown anymore (we experienced it under win10 and linux).

 Furthermore BibTeXml can also be in .xml format.