### PR TITLE
Removed one Globals call from MetaData

### DIFF
--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -43,6 +43,7 @@ import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.bibtexkeypattern.AbstractBibtexKeyPattern;
 import net.sf.jabref.model.bibtexkeypattern.DatabaseBibtexKeyPattern;
+import net.sf.jabref.model.bibtexkeypattern.GlobalBibtexKeyPattern;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.FieldName;
 
@@ -250,12 +251,12 @@ public class MetaData implements Iterable<String> {
     /**
      * @return the stored label patterns
      */
-    public AbstractBibtexKeyPattern getBibtexKeyPattern() {
+    public AbstractBibtexKeyPattern getBibtexKeyPattern(GlobalBibtexKeyPattern globalPattern) {
         if (bibtexKeyPattern != null) {
             return bibtexKeyPattern;
         }
 
-        bibtexKeyPattern = new DatabaseBibtexKeyPattern(Globals.prefs);
+        bibtexKeyPattern = new DatabaseBibtexKeyPattern(globalPattern);
 
         // read the data from the metadata and store it into the bibtexKeyPattern
         for (String key : this) {

--- a/src/main/java/net/sf/jabref/gui/BibtexKeyPatternDialog.java
+++ b/src/main/java/net/sf/jabref/gui/BibtexKeyPatternDialog.java
@@ -28,6 +28,7 @@ import javax.swing.JDialog;
 import javax.swing.JPanel;
 import javax.swing.WindowConstants;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.gui.bibtexkeypattern.BibtexKeyPatternPanel;
 import net.sf.jabref.gui.keyboard.KeyBinder;
@@ -58,7 +59,7 @@ public class BibtexKeyPatternDialog extends JDialog {
     public void setPanel(BasePanel panel) {
         this.panel = panel;
         this.metaData = panel.getBibDatabaseContext().getMetaData();
-        AbstractBibtexKeyPattern keypatterns = metaData.getBibtexKeyPattern();
+        AbstractBibtexKeyPattern keypatterns = metaData.getBibtexKeyPattern(Globals.prefs.getKeyPattern());
         bibtexKeyPatternPanel.setValues(keypatterns);
     }
 

--- a/src/main/java/net/sf/jabref/gui/bibtexkeypattern/BibtexKeyPatternPanel.java
+++ b/src/main/java/net/sf/jabref/gui/bibtexkeypattern/BibtexKeyPatternPanel.java
@@ -246,7 +246,7 @@ public class BibtexKeyPatternPanel extends JPanel {
     }
 
     public DatabaseBibtexKeyPattern getKeyPatternAsDatabaseBibtexKeyPattern() {
-        DatabaseBibtexKeyPattern res = new DatabaseBibtexKeyPattern(Globals.prefs);
+        DatabaseBibtexKeyPattern res = new DatabaseBibtexKeyPattern(Globals.prefs.getKeyPattern());
         fillPatternUsingPanelData(res);
         return res;
     }

--- a/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternPreferences.java
+++ b/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternPreferences.java
@@ -1,5 +1,6 @@
 package net.sf.jabref.logic.bibtexkeypattern;
 
+import net.sf.jabref.model.bibtexkeypattern.GlobalBibtexKeyPattern;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 public class BibtexKeyPatternPreferences {
@@ -10,15 +11,18 @@ public class BibtexKeyPatternPreferences {
     private final boolean alwaysAddLetter;
     private final boolean firstLetterA;
     private final boolean enforceLegalKey;
+    private final GlobalBibtexKeyPattern keyPattern;
 
     public BibtexKeyPatternPreferences(String defaultBibtexKeyPattern, String keyPatternRegex, String keyPatternReplacement,
-            boolean alwaysAddLetter, boolean firstLetterA, boolean enforceLegalKey) {
+            boolean alwaysAddLetter, boolean firstLetterA, boolean enforceLegalKey,
+            GlobalBibtexKeyPattern keyPattern) {
         this.defaultBibtexKeyPattern = defaultBibtexKeyPattern;
         this.keyPatternRegex = keyPatternRegex;
         this.keyPatternReplacement = keyPatternReplacement;
         this.alwaysAddLetter = alwaysAddLetter;
         this.firstLetterA = firstLetterA;
         this.enforceLegalKey = enforceLegalKey;
+        this.keyPattern = keyPattern;
     }
 
     public static BibtexKeyPatternPreferences fromPreferences(JabRefPreferences jabRefPreferences) {
@@ -27,7 +31,8 @@ public class BibtexKeyPatternPreferences {
                 jabRefPreferences.get(JabRefPreferences.KEY_PATTERN_REPLACEMENT),
                 jabRefPreferences.getBoolean(JabRefPreferences.KEY_GEN_ALWAYS_ADD_LETTER),
                 jabRefPreferences.getBoolean(JabRefPreferences.KEY_GEN_FIRST_LETTER_A),
-                jabRefPreferences.getBoolean(JabRefPreferences.ENFORCE_LEGAL_BIBTEX_KEY));
+                jabRefPreferences.getBoolean(JabRefPreferences.ENFORCE_LEGAL_BIBTEX_KEY),
+                jabRefPreferences.getKeyPattern());
     }
 
     public String getKeyPatternRegex() {
@@ -51,4 +56,8 @@ public class BibtexKeyPatternPreferences {
     }
 
     public String getDefaultBibtexKeyPattern() { return defaultBibtexKeyPattern;}
+
+    public GlobalBibtexKeyPattern getKeyPattern() {
+        return keyPattern;
+    }
 }

--- a/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -401,7 +401,8 @@ public class BibtexKeyPatternUtil {
             // get the type of entry
             String entryType = entry.getType();
             // Get the arrayList corresponding to the type
-            List<String> typeList = new ArrayList<>(metaData.getBibtexKeyPattern().getValue(entryType));
+            List<String> typeList = new ArrayList<>(
+                    metaData.getBibtexKeyPattern(bibtexKeyPatternPreferences.getKeyPattern()).getValue(entryType));
             if (!typeList.isEmpty()) {
                 typeList.remove(0);
             }

--- a/src/main/java/net/sf/jabref/model/bibtexkeypattern/DatabaseBibtexKeyPattern.java
+++ b/src/main/java/net/sf/jabref/model/bibtexkeypattern/DatabaseBibtexKeyPattern.java
@@ -17,20 +17,18 @@ package net.sf.jabref.model.bibtexkeypattern;
 
 import java.util.List;
 
-import net.sf.jabref.preferences.JabRefPreferences;
-
 public class DatabaseBibtexKeyPattern extends AbstractBibtexKeyPattern {
 
-    private final JabRefPreferences prefs;
+    private final GlobalBibtexKeyPattern globalBibtexKeyPattern;
 
 
-    public DatabaseBibtexKeyPattern(JabRefPreferences prefs) {
-        this.prefs = prefs;
+    public DatabaseBibtexKeyPattern(GlobalBibtexKeyPattern globalBibtexKeyPattern) {
+        this.globalBibtexKeyPattern = globalBibtexKeyPattern;
     }
 
     @Override
     public List<String> getLastLevelBibtexKeyPattern(String key) {
-        return prefs.getKeyPattern().getValue(key);
+        return globalBibtexKeyPattern.getValue(key);
     }
 
 }

--- a/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -159,7 +159,7 @@ public class BibtexDatabaseWriterTest {
 
     @Test
     public void writeMetadata() throws Exception {
-        DatabaseBibtexKeyPattern bibtexKeyPattern = new DatabaseBibtexKeyPattern(Globals.prefs);
+        DatabaseBibtexKeyPattern bibtexKeyPattern = new DatabaseBibtexKeyPattern(Globals.prefs.getKeyPattern());
         bibtexKeyPattern.setDefaultValue("test");
         metaData.setBibtexKeyPattern(bibtexKeyPattern);
 
@@ -172,7 +172,7 @@ public class BibtexDatabaseWriterTest {
     @Test
     public void writeMetadataAndEncoding() throws Exception {
         SavePreferences preferences = new SavePreferences().withEncoding(Charsets.US_ASCII);
-        DatabaseBibtexKeyPattern bibtexKeyPattern = new DatabaseBibtexKeyPattern(Globals.prefs);
+        DatabaseBibtexKeyPattern bibtexKeyPattern = new DatabaseBibtexKeyPattern(Globals.prefs.getKeyPattern());
         bibtexKeyPattern.setDefaultValue("test");
         metaData.setBibtexKeyPattern(bibtexKeyPattern);
 
@@ -429,7 +429,7 @@ public class BibtexDatabaseWriterTest {
 
     @Test
     public void writeCustomKeyPattern() throws Exception {
-        AbstractBibtexKeyPattern pattern = new DatabaseBibtexKeyPattern(Globals.prefs);
+        AbstractBibtexKeyPattern pattern = new DatabaseBibtexKeyPattern(Globals.prefs.getKeyPattern());
         pattern.setDefaultValue("test");
         pattern.addBibtexKeyPattern("article", "articleTest");
         metaData.setBibtexKeyPattern(pattern);

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -1512,9 +1512,10 @@ public class BibtexParserTest {
                                 + "@comment{jabref-meta: keypatterndefault:test;}"),
                         importFormatPreferences);
 
-        AbstractBibtexKeyPattern bibtexKeyPattern = result.getMetaData().getBibtexKeyPattern();
+        AbstractBibtexKeyPattern bibtexKeyPattern = result.getMetaData()
+                .getBibtexKeyPattern(Globals.prefs.getKeyPattern());
 
-        AbstractBibtexKeyPattern expectedPattern = new DatabaseBibtexKeyPattern(Globals.prefs);
+        AbstractBibtexKeyPattern expectedPattern = new DatabaseBibtexKeyPattern(Globals.prefs.getKeyPattern());
         expectedPattern.setDefaultValue("test");
         expectedPattern.addBibtexKeyPattern("article", "articleTest");
 


### PR DESCRIPTION
One further step towards a `Globals`-free `MetaData`.

