### PR TITLE
Moved preference constants to JabRefPreferences and renamed

### DIFF
--- a/src/main/java/net/sf/jabref/JabRefGUI.java
+++ b/src/main/java/net/sf/jabref/JabRefGUI.java
@@ -44,9 +44,9 @@ import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.Version;
-import net.sf.jabref.logic.util.VersionPreferences;
 import net.sf.jabref.migrations.PreferencesMigrations;
 import net.sf.jabref.preferences.JabRefPreferences;
+import net.sf.jabref.preferences.VersionPreferences;
 
 import com.jgoodies.looks.plastic.Plastic3DLookAndFeel;
 import com.jgoodies.looks.plastic.theme.SkyBluer;

--- a/src/main/java/net/sf/jabref/JabRefMain.java
+++ b/src/main/java/net/sf/jabref/JabRefMain.java
@@ -72,7 +72,7 @@ public class JabRefMain {
 
         // Update handling of special fields based on preferences
         InternalBibtexFields
-                .updateSpecialFields(Globals.prefs.getBoolean(JabRefPreferences.PREF_SERIALIZESPECIALFIELDS));
+                .updateSpecialFields(Globals.prefs.getBoolean(JabRefPreferences.SERIALIZESPECIALFIELDS));
         // Update name of the time stamp field based on preferences
         InternalBibtexFields.updateTimeStampField(Globals.prefs.get(JabRefPreferences.TIME_STAMP_FIELD));
         // Update which fields should be treated as numeric, based on preferences:

--- a/src/main/java/net/sf/jabref/external/DroppedFileHandler.java
+++ b/src/main/java/net/sf/jabref/external/DroppedFileHandler.java
@@ -48,6 +48,7 @@ import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.model.entry.IdGenerator;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.FormBuilder;
 import com.jgoodies.forms.layout.FormLayout;
@@ -69,11 +70,6 @@ import org.apache.commons.logging.LogFactory;
 public class DroppedFileHandler {
 
     private static final Log LOGGER = LogFactory.getLog(DroppedFileHandler.class);
-
-    public static final String DFH_LEAVE = "DroppedFileHandler_LeaveFileInDir";
-    public static final String DFH_COPY = "DroppedFileHandler_CopyFile";
-    public static final String DFH_MOVE = "DroppedFileHandler_MoveFile";
-    public static final String DFH_RENAME = "DroppedFileHandler_RenameFile";
 
     private final JabRefFrame frame;
 
@@ -358,10 +354,10 @@ public class DroppedFileHandler {
 
         renameToTextBox.setText(targetName.concat(".").concat(fileType.getExtension()));
 
-        linkInPlace.setSelected(frame.prefs().getBoolean(DroppedFileHandler.DFH_LEAVE));
-        copyRadioButton.setSelected(frame.prefs().getBoolean(DroppedFileHandler.DFH_COPY));
-        moveRadioButton.setSelected(frame.prefs().getBoolean(DroppedFileHandler.DFH_MOVE));
-        renameCheckBox.setSelected(frame.prefs().getBoolean(DroppedFileHandler.DFH_RENAME));
+        linkInPlace.setSelected(frame.prefs().getBoolean(JabRefPreferences.DROPPEDFILEHANDLER_LEAVE));
+        copyRadioButton.setSelected(frame.prefs().getBoolean(JabRefPreferences.DROPPEDFILEHANDLER_COPY));
+        moveRadioButton.setSelected(frame.prefs().getBoolean(JabRefPreferences.DROPPEDFILEHANDLER_MOVE));
+        renameCheckBox.setSelected(frame.prefs().getBoolean(JabRefPreferences.DROPPEDFILEHANDLER_RENAME));
 
         linkInPlace.addChangeListener(cl);
         cl.stateChanged(new ChangeEvent(linkInPlace));
@@ -373,10 +369,10 @@ public class DroppedFileHandler {
                     JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
             if (reply == JOptionPane.OK_OPTION) {
                 // store user's choice
-                frame.prefs().putBoolean(DroppedFileHandler.DFH_LEAVE, linkInPlace.isSelected());
-                frame.prefs().putBoolean(DroppedFileHandler.DFH_COPY, copyRadioButton.isSelected());
-                frame.prefs().putBoolean(DroppedFileHandler.DFH_MOVE, moveRadioButton.isSelected());
-                frame.prefs().putBoolean(DroppedFileHandler.DFH_RENAME, renameCheckBox.isSelected());
+                frame.prefs().putBoolean(JabRefPreferences.DROPPEDFILEHANDLER_LEAVE, linkInPlace.isSelected());
+                frame.prefs().putBoolean(JabRefPreferences.DROPPEDFILEHANDLER_COPY, copyRadioButton.isSelected());
+                frame.prefs().putBoolean(JabRefPreferences.DROPPEDFILEHANDLER_MOVE, moveRadioButton.isSelected());
+                frame.prefs().putBoolean(JabRefPreferences.DROPPEDFILEHANDLER_RENAME, renameCheckBox.isSelected());
                 return true;
             } else {
                 return false;

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -125,7 +125,6 @@ import net.sf.jabref.logic.importer.OutputPrinter;
 import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.logging.GuiAppender;
-import net.sf.jabref.logic.preferences.LastFocusedTabPreferences;
 import net.sf.jabref.logic.undo.AddUndoableActionEvent;
 import net.sf.jabref.logic.undo.UndoChangeEvent;
 import net.sf.jabref.logic.undo.UndoRedoEvent;
@@ -138,6 +137,7 @@ import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.EntryType;
 import net.sf.jabref.preferences.HighlightMatchingGroupPreferences;
 import net.sf.jabref.preferences.JabRefPreferences;
+import net.sf.jabref.preferences.LastFocusedTabPreferences;
 import net.sf.jabref.specialfields.Printed;
 import net.sf.jabref.specialfields.Priority;
 import net.sf.jabref.specialfields.Quality;
@@ -1210,28 +1210,28 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         edit.add(unmark);
         edit.add(unmarkAll);
         edit.addSeparator();
-        if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SPECIALFIELDSENABLED)) {
+        if (Globals.prefs.getBoolean(JabRefPreferences.SPECIALFIELDSENABLED)) {
             JMenu m;
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_RANKING)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_RANKING)) {
                 m = new JMenu();
                 RightClickMenu.populateSpecialFieldMenu(m, Rank.getInstance(), this);
                 edit.add(m);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_RELEVANCE)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_RELEVANCE)) {
                 edit.add(toggleRelevance);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_QUALITY)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_QUALITY)) {
                 edit.add(toggleQualityAssured);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_PRIORITY)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_PRIORITY)) {
                 m = new JMenu();
                 RightClickMenu.populateSpecialFieldMenu(m, Priority.getInstance(), this);
                 edit.add(m);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_PRINTED)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_PRINTED)) {
                 edit.add(togglePrinted);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_READ)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_READ)) {
                 m = new JMenu();
                 RightClickMenu.populateSpecialFieldMenu(m, ReadStatus.getInstance(), this);
                 edit.add(m);
@@ -1456,29 +1456,29 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         tlb.addSeparator();
         tlb.addAction(mark);
         tlb.addAction(unmark);
-        if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SPECIALFIELDSENABLED)) {
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_RANKING)) {
+        if (Globals.prefs.getBoolean(JabRefPreferences.SPECIALFIELDSENABLED)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_RANKING)) {
                 JButton button = net.sf.jabref.specialfields.SpecialFieldDropDown
                         .generateSpecialFieldButtonWithDropDown(Rank.getInstance(), this);
                 tlb.add(button);
                 specialFieldButtons.add(button);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_RELEVANCE)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_RELEVANCE)) {
                 tlb.addAction(toggleRelevance);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_QUALITY)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_QUALITY)) {
                 tlb.addAction(toggleQualityAssured);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_PRIORITY)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_PRIORITY)) {
                 JButton button = net.sf.jabref.specialfields.SpecialFieldDropDown
                         .generateSpecialFieldButtonWithDropDown(Priority.getInstance(), this);
                 tlb.add(button);
                 specialFieldButtons.add(button);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_PRINTED)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_PRINTED)) {
                 tlb.addAction(togglePrinted);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_READ)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_READ)) {
                 JButton button = net.sf.jabref.specialfields.SpecialFieldDropDown
                         .generateSpecialFieldButtonWithDropDown(ReadStatus.getInstance(), this);
                 tlb.add(button);

--- a/src/main/java/net/sf/jabref/gui/actions/CleanupAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/CleanupAction.java
@@ -87,14 +87,14 @@ public class CleanupAction extends AbstractWorker {
         CleanupPreset cleanupPreset = presetPanel.getCleanupPreset();
         cleanupPreset.storeInPreferences(preferences);
 
-        if (cleanupPreset.isRenamePDF() && Globals.prefs.getBoolean(JabRefPreferences.AKS_AUTO_NAMING_PDFS_AGAIN)) {
+        if (cleanupPreset.isRenamePDF() && Globals.prefs.getBoolean(JabRefPreferences.ASK_AUTO_NAMING_PDFS_AGAIN)) {
             CheckBoxMessage cbm = new CheckBoxMessage(
                     Localization.lang("Auto-generating PDF-Names does not support undo. Continue?"),
                     Localization.lang("Disable this confirmation dialog"), false);
             int answer = JOptionPane.showConfirmDialog(frame, cbm, Localization.lang("Autogenerate PDF Names"),
                     JOptionPane.YES_NO_OPTION);
             if (cbm.isSelected()) {
-                Globals.prefs.putBoolean(JabRefPreferences.AKS_AUTO_NAMING_PDFS_AGAIN, false);
+                Globals.prefs.putBoolean(JabRefPreferences.ASK_AUTO_NAMING_PDFS_AGAIN, false);
             }
             if (answer == JOptionPane.NO_OPTION) {
                 canceled = true;

--- a/src/main/java/net/sf/jabref/gui/cleanup/CleanupPresetPanel.java
+++ b/src/main/java/net/sf/jabref/gui/cleanup/CleanupPresetPanel.java
@@ -82,7 +82,7 @@ public class CleanupPresetPanel {
         builder.add(cleanUpMakePathsRelative).xyw(1, 4, 2);
         builder.add(cleanUpRenamePDF).xyw(1, 5, 2);
         String currentPattern = Localization.lang("Filename format pattern").concat(": ")
-                .concat(Globals.prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN));
+                .concat(Globals.prefs.get(JabRefPreferences.IMPORT_FILENAMEPATTERN));
         builder.add(new JLabel(currentPattern)).xy(2, 6);
         builder.add(cleanUpRenamePDFonlyRelativePaths).xy(2, 7);
         builder.add(cleanUpBibLatex).xyw(1, 8, 2);

--- a/src/main/java/net/sf/jabref/gui/help/NewVersionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/help/NewVersionDialog.java
@@ -32,7 +32,7 @@ import net.sf.jabref.Globals;
 import net.sf.jabref.gui.desktop.JabRefDesktop;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.Version;
-import net.sf.jabref.logic.util.VersionPreferences;
+import net.sf.jabref.preferences.VersionPreferences;
 
 public class NewVersionDialog extends JDialog {
 

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableFormat.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableFormat.java
@@ -142,23 +142,23 @@ public class MainTableFormat implements TableFormat<BibEntry> {
 
 
         // Add the "special" icon columns (e.g., ranking, file, ...) that are enabled in preferences.
-        if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SPECIALFIELDSENABLED)) {
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_RANKING)) {
+        if (Globals.prefs.getBoolean(JabRefPreferences.SPECIALFIELDSENABLED)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_RANKING)) {
                 tableColumns.add(SpecialMainTableColumns.RANKING_COLUMN);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_RELEVANCE)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_RELEVANCE)) {
                 tableColumns.add(SpecialMainTableColumns.RELEVANCE_COLUMN);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_QUALITY)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_QUALITY)) {
                 tableColumns.add(SpecialMainTableColumns.QUALITY_COLUMN);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_PRIORITY)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_PRIORITY)) {
                 tableColumns.add(SpecialMainTableColumns.PRIORITY_COLUMN);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_PRINTED)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_PRINTED)) {
                 tableColumns.add(SpecialMainTableColumns.PRINTED_COLUMN);
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_READ)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_READ)) {
                 tableColumns.add(SpecialMainTableColumns.READ_STATUS_COLUMN);
             }
         }

--- a/src/main/java/net/sf/jabref/gui/menus/RightClickMenu.java
+++ b/src/main/java/net/sf/jabref/gui/menus/RightClickMenu.java
@@ -122,8 +122,8 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
             }
         }
 
-        if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SPECIALFIELDSENABLED)) {
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_RANKING)) {
+        if (Globals.prefs.getBoolean(JabRefPreferences.SPECIALFIELDSENABLED)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_RANKING)) {
                 JMenu rankingMenu = new JMenu();
                 RightClickMenu.populateSpecialFieldMenu(rankingMenu, Rank.getInstance(), frame);
                 add(rankingMenu);
@@ -132,23 +132,23 @@ public class RightClickMenu extends JPopupMenu implements PopupMenuListener {
             // TODO: multiple handling for relevance and quality-assurance
             // if multiple values are selected ("if (multiple)"), two options (set / clear) should be offered
             // if one value is selected either set or clear should be offered
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_RELEVANCE)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_RELEVANCE)) {
                 add(Relevance.getInstance().getValues().get(0).getMenuAction(frame));
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_QUALITY)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_QUALITY)) {
                 add(Quality.getInstance().getValues().get(0).getMenuAction(frame));
             }
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_PRINTED)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_PRINTED)) {
                 add(Printed.getInstance().getValues().get(0).getMenuAction(frame));
             }
 
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_PRIORITY)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_PRIORITY)) {
                 JMenu priorityMenu = new JMenu();
                 RightClickMenu.populateSpecialFieldMenu(priorityMenu, Priority.getInstance(), frame);
                 add(priorityMenu);
             }
 
-            if (Globals.prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_READ)) {
+            if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_READ)) {
                 JMenu readStatusMenu = new JMenu();
                 RightClickMenu.populateSpecialFieldMenu(readStatusMenu, ReadStatus.getInstance(), frame);
                 add(readStatusMenu);

--- a/src/main/java/net/sf/jabref/gui/preftabs/ImportSettingsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/ImportSettingsTab.java
@@ -119,8 +119,8 @@ public class ImportSettingsTab extends JPanel implements PrefsTab {
 
     @Override
     public void setValues() {
-        useDefaultPDFImportStyle.setSelected(prefs.getBoolean(JabRefPreferences.PREF_IMPORT_ALWAYSUSE));
-        int style = prefs.getInt(JabRefPreferences.PREF_IMPORT_DEFAULT_PDF_IMPORT_STYLE);
+        useDefaultPDFImportStyle.setSelected(prefs.getBoolean(JabRefPreferences.IMPORT_ALWAYSUSE));
+        int style = prefs.getInt(JabRefPreferences.IMPORT_DEFAULT_PDF_IMPORT_STYLE);
         switch (style) {
         case ImportDialog.NOMETA:
             radioButtonNoMeta.setSelected(true);
@@ -139,12 +139,12 @@ public class ImportSettingsTab extends JPanel implements PrefsTab {
             radioButtonPDFcontent.setSelected(true);
             break;
         }
-        fileNamePattern.setText(prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN));
+        fileNamePattern.setText(prefs.get(JabRefPreferences.IMPORT_FILENAMEPATTERN));
     }
 
     @Override
     public void storeSettings() {
-        prefs.putBoolean(JabRefPreferences.PREF_IMPORT_ALWAYSUSE, useDefaultPDFImportStyle.isSelected());
+        prefs.putBoolean(JabRefPreferences.IMPORT_ALWAYSUSE, useDefaultPDFImportStyle.isSelected());
         int style = ImportSettingsTab.DEFAULT_STYLE;
         if (radioButtonNoMeta.isSelected()) {
             style = ImportDialog.NOMETA;
@@ -155,8 +155,8 @@ public class ImportSettingsTab extends JPanel implements PrefsTab {
         } else if (radioButtononlyAttachPDF.isSelected()) {
             style = ImportDialog.ONLYATTACH;
         }
-        prefs.putInt(JabRefPreferences.PREF_IMPORT_DEFAULT_PDF_IMPORT_STYLE, style);
-        prefs.put(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN, fileNamePattern.getText());
+        prefs.putInt(JabRefPreferences.IMPORT_DEFAULT_PDF_IMPORT_STYLE, style);
+        prefs.put(JabRefPreferences.IMPORT_FILENAMEPATTERN, fileNamePattern.getText());
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/TableColumnsTab.java
@@ -420,32 +420,32 @@ class TableColumnsTab extends JPanel implements PrefsTab {
 
         /*** begin: special fields ***/
 
-        oldRankingColumn = prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_RANKING);
+        oldRankingColumn = prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_RANKING);
         rankingColumn.setSelected(oldRankingColumn);
 
-        oldQualityColumn = prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_QUALITY);
+        oldQualityColumn = prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_QUALITY);
         qualityColumn.setSelected(oldQualityColumn);
 
-        oldPriorityColumn = prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_PRIORITY);
+        oldPriorityColumn = prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_PRIORITY);
         priorityColumn.setSelected(oldPriorityColumn);
 
-        oldRelevanceColumn = prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_RELEVANCE);
+        oldRelevanceColumn = prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_RELEVANCE);
         relevanceColumn.setSelected(oldRelevanceColumn);
 
-        oldPrintedColumn = prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_PRINTED);
+        oldPrintedColumn = prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_PRINTED);
         printedColumn.setSelected(oldPrintedColumn);
 
-        oldReadStatusColumn = prefs.getBoolean(JabRefPreferences.PREF_SHOWCOLUMN_READ);
+        oldReadStatusColumn = prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_READ);
         readStatusColumn.setSelected(oldReadStatusColumn);
 
-        oldSyncKeyWords = prefs.getBoolean(JabRefPreferences.PREF_AUTOSYNCSPECIALFIELDSTOKEYWORDS);
+        oldSyncKeyWords = prefs.getBoolean(JabRefPreferences.AUTOSYNCSPECIALFIELDSTOKEYWORDS);
         syncKeywords.setSelected(oldSyncKeyWords);
 
-        oldWriteSpecialFields = prefs.getBoolean(JabRefPreferences.PREF_SERIALIZESPECIALFIELDS);
+        oldWriteSpecialFields = prefs.getBoolean(JabRefPreferences.SERIALIZESPECIALFIELDS);
         writeSpecialFields.setSelected(oldWriteSpecialFields);
 
         // has to be called as last to correctly enable/disable the other settings
-        oldSpecialFieldsEnabled = prefs.getBoolean(JabRefPreferences.PREF_SPECIALFIELDSENABLED);
+        oldSpecialFieldsEnabled = prefs.getBoolean(JabRefPreferences.SPECIALFIELDSENABLED);
         specialFieldsEnabled.setSelected(!oldSpecialFieldsEnabled);
         specialFieldsEnabled.setSelected(oldSpecialFieldsEnabled); // Call twice to make sure the ChangeListener is triggered
 
@@ -749,15 +749,15 @@ class TableColumnsTab extends JPanel implements PrefsTab {
         // restart required implies that the settings have been changed
         // the seetings need to be stored
         if (restartRequired) {
-            prefs.putBoolean(JabRefPreferences.PREF_SPECIALFIELDSENABLED, newSpecialFieldsEnabled);
-            prefs.putBoolean(JabRefPreferences.PREF_SHOWCOLUMN_RANKING, newRankingColumn);
-            prefs.putBoolean(JabRefPreferences.PREF_SHOWCOLUMN_PRIORITY, newPriorityColumn);
-            prefs.putBoolean(JabRefPreferences.PREF_SHOWCOLUMN_QUALITY, newQualityColumn);
-            prefs.putBoolean(JabRefPreferences.PREF_SHOWCOLUMN_RELEVANCE, newRelevanceColumn);
-            prefs.putBoolean(JabRefPreferences.PREF_SHOWCOLUMN_PRINTED, newPrintedColumn);
-            prefs.putBoolean(JabRefPreferences.PREF_SHOWCOLUMN_READ, newReadStatusColumn);
-            prefs.putBoolean(JabRefPreferences.PREF_AUTOSYNCSPECIALFIELDSTOKEYWORDS, newSyncKeyWords);
-            prefs.putBoolean(JabRefPreferences.PREF_SERIALIZESPECIALFIELDS, newWriteSpecialFields);
+            prefs.putBoolean(JabRefPreferences.SPECIALFIELDSENABLED, newSpecialFieldsEnabled);
+            prefs.putBoolean(JabRefPreferences.SHOWCOLUMN_RANKING, newRankingColumn);
+            prefs.putBoolean(JabRefPreferences.SHOWCOLUMN_PRIORITY, newPriorityColumn);
+            prefs.putBoolean(JabRefPreferences.SHOWCOLUMN_QUALITY, newQualityColumn);
+            prefs.putBoolean(JabRefPreferences.SHOWCOLUMN_RELEVANCE, newRelevanceColumn);
+            prefs.putBoolean(JabRefPreferences.SHOWCOLUMN_PRINTED, newPrintedColumn);
+            prefs.putBoolean(JabRefPreferences.SHOWCOLUMN_READ, newReadStatusColumn);
+            prefs.putBoolean(JabRefPreferences.AUTOSYNCSPECIALFIELDSTOKEYWORDS, newSyncKeyWords);
+            prefs.putBoolean(JabRefPreferences.SERIALIZESPECIALFIELDS, newWriteSpecialFields);
         }
 
         /*** end: special fields ***/

--- a/src/main/java/net/sf/jabref/logic/autocompleter/AutoCompletePreferences.java
+++ b/src/main/java/net/sf/jabref/logic/autocompleter/AutoCompletePreferences.java
@@ -26,19 +26,19 @@ public class AutoCompletePreferences {
 
     private final JabRefPreferences preferences;
 
-    private static final String PREF_SHORTEST_TO_COMPLETE = "shortestToComplete";
-    private static final String PREF_FIRSTNAME_MODE = "autoCompFirstNameMode";
-    private static final String PREF_LAST_FIRST = "autoCompLF";
-    private static final String PREF_FIRST_LAST = "autoCompFF";
-    private static final String PREF_COMPLETE_FIELDS = "autoCompleteFields";
+    private static final String AUTOCOMPLETER_SHORTEST_TO_COMPLETE = "shortestToComplete";
+    private static final String AUTOCOMPLETER_FIRSTNAME_MODE = "autoCompFirstNameMode";
+    private static final String AUTOCOMPLETER_LAST_FIRST = "autoCompLF";
+    private static final String AUTOCOMPLETER_FIRST_LAST = "autoCompFF";
+    private static final String AUTOCOMPLETER_COMPLETE_FIELDS = "autoCompleteFields";
 
 
     public static void putDefaults(Map<String, Object> defaults) {
-        defaults.put(PREF_SHORTEST_TO_COMPLETE, 1);
-        defaults.put(PREF_FIRSTNAME_MODE, AutoCompleteFirstNameMode.BOTH.name());
-        defaults.put(PREF_FIRST_LAST, Boolean.FALSE); // "Autocomplete names in 'Firstname Lastname' format only"
-        defaults.put(PREF_LAST_FIRST, Boolean.FALSE); // "Autocomplete names in 'Lastname, Firstname' format only"
-        defaults.put(PREF_COMPLETE_FIELDS, "author;editor;title;journal;publisher;keywords;crossref");
+        defaults.put(AUTOCOMPLETER_SHORTEST_TO_COMPLETE, 1);
+        defaults.put(AUTOCOMPLETER_FIRSTNAME_MODE, AutoCompleteFirstNameMode.BOTH.name());
+        defaults.put(AUTOCOMPLETER_FIRST_LAST, Boolean.FALSE); // "Autocomplete names in 'Firstname Lastname' format only"
+        defaults.put(AUTOCOMPLETER_LAST_FIRST, Boolean.FALSE); // "Autocomplete names in 'Lastname, Firstname' format only"
+        defaults.put(AUTOCOMPLETER_COMPLETE_FIELDS, "author;editor;title;journal;publisher;keywords;crossref");
     }
 
     public AutoCompletePreferences(JabRefPreferences preferences) {
@@ -46,11 +46,11 @@ public class AutoCompletePreferences {
     }
 
     public int getShortestLengthToComplete() {
-        return preferences.getInt(PREF_SHORTEST_TO_COMPLETE);
+        return preferences.getInt(AUTOCOMPLETER_SHORTEST_TO_COMPLETE);
     }
 
     public void setShortestLengthToComplete(Integer value) {
-        preferences.putInt(PREF_SHORTEST_TO_COMPLETE, value);
+        preferences.putInt(AUTOCOMPLETER_SHORTEST_TO_COMPLETE, value);
     }
 
     /**
@@ -61,7 +61,7 @@ public class AutoCompletePreferences {
      */
     public AutoCompleteFirstNameMode getFirstnameMode() {
         try {
-            return AutoCompleteFirstNameMode.valueOf(preferences.get(PREF_FIRSTNAME_MODE));
+            return AutoCompleteFirstNameMode.valueOf(preferences.get(AUTOCOMPLETER_FIRSTNAME_MODE));
         } catch (IllegalArgumentException ex) {
             // Should only occur when preferences are set directly via preferences.put and not via setFirstnameMode
             return AutoCompleteFirstNameMode.BOTH;
@@ -69,35 +69,35 @@ public class AutoCompletePreferences {
     }
 
     public void setFirstnameMode(AutoCompleteFirstNameMode mode) {
-        preferences.put(PREF_FIRSTNAME_MODE, mode.name());
+        preferences.put(AUTOCOMPLETER_FIRSTNAME_MODE, mode.name());
     }
 
     public boolean getOnlyCompleteLastFirst() {
-        return preferences.getBoolean(PREF_LAST_FIRST);
+        return preferences.getBoolean(AUTOCOMPLETER_LAST_FIRST);
     }
 
     public void setOnlyCompleteLastFirst(boolean value) {
-        preferences.putBoolean(PREF_LAST_FIRST, value);
+        preferences.putBoolean(AUTOCOMPLETER_LAST_FIRST, value);
     }
 
     public boolean getOnlyCompleteFirstLast() {
-        return preferences.getBoolean(PREF_FIRST_LAST);
+        return preferences.getBoolean(AUTOCOMPLETER_FIRST_LAST);
     }
 
     public void setOnlyCompleteFirstLast(boolean value) {
-        preferences.putBoolean(PREF_FIRST_LAST, value);
+        preferences.putBoolean(AUTOCOMPLETER_FIRST_LAST, value);
     }
 
     public List<String> getCompleteNames() {
-        return preferences.getStringList(PREF_COMPLETE_FIELDS);
+        return preferences.getStringList(AUTOCOMPLETER_COMPLETE_FIELDS);
     }
 
     public String getCompleteNamesAsString() {
-        return preferences.get(PREF_COMPLETE_FIELDS);
+        return preferences.get(AUTOCOMPLETER_COMPLETE_FIELDS);
     }
 
     public void setCompleteNames(String value) {
-        preferences.put(PREF_COMPLETE_FIELDS, value);
+        preferences.put(AUTOCOMPLETER_COMPLETE_FIELDS, value);
     }
 
     public JournalAbbreviationPreferences getJournalAbbreviationPreferences() {

--- a/src/main/java/net/sf/jabref/logic/remote/RemotePreferences.java
+++ b/src/main/java/net/sf/jabref/logic/remote/RemotePreferences.java
@@ -7,9 +7,6 @@ import net.sf.jabref.preferences.JabRefPreferences;
  */
 public class RemotePreferences {
 
-    public static final String REMOTE_SERVER_PORT = "remoteServerPort";
-    public static final String USE_REMOTE_SERVER = "useRemoteServer";
-
     private final JabRefPreferences preferences;
 
 
@@ -18,19 +15,19 @@ public class RemotePreferences {
     }
 
     public int getPort() {
-        return preferences.getInt(REMOTE_SERVER_PORT);
+        return preferences.getInt(JabRefPreferences.REMOTE_SERVER_PORT);
     }
 
     public void setPort(int port) {
-        preferences.putInt(REMOTE_SERVER_PORT, port);
+        preferences.putInt(JabRefPreferences.REMOTE_SERVER_PORT, port);
     }
 
     public boolean useRemoteServer() {
-        return preferences.getBoolean(USE_REMOTE_SERVER);
+        return preferences.getBoolean(JabRefPreferences.USE_REMOTE_SERVER);
     }
 
     public void setUseRemoteServer(boolean useRemoteServer) {
-        preferences.putBoolean(USE_REMOTE_SERVER, useRemoteServer);
+        preferences.putBoolean(JabRefPreferences.USE_REMOTE_SERVER, useRemoteServer);
     }
 
     public boolean isDifferentPort(int otherPort) {

--- a/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
@@ -394,7 +394,7 @@ public class FileUtil {
     public static String createFileNameFromPattern(BibDatabase database, BibEntry entry,
             JournalAbbreviationLoader repositoryLoader, JabRefPreferences prefs) {
         String targetName = entry.getCiteKeyOptional().orElse("default");
-        StringReader sr = new StringReader(prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN));
+        StringReader sr = new StringReader(prefs.get(JabRefPreferences.IMPORT_FILENAMEPATTERN));
         Layout layout = null;
         try {
             layout = new LayoutHelper(sr, LayoutFormatterPreferences.fromPreferences(prefs, repositoryLoader))

--- a/src/main/java/net/sf/jabref/pdfimport/ImportDialog.java
+++ b/src/main/java/net/sf/jabref/pdfimport/ImportDialog.java
@@ -148,7 +148,7 @@ public class ImportDialog extends JDialog {
         contentPane.registerKeyboardAction(e -> onCancel(), KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
                 JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
 
-        switch (Globals.prefs.getInt(JabRefPreferences.PREF_IMPORT_DEFAULT_PDF_IMPORT_STYLE)) {
+        switch (Globals.prefs.getInt(JabRefPreferences.IMPORT_DEFAULT_PDF_IMPORT_STYLE)) {
         case NOMETA:
             radioButtonNoMeta.setSelected(true);
             break;
@@ -172,9 +172,9 @@ public class ImportDialog extends JDialog {
 
     private void onOK() {
         this.result = JOptionPane.OK_OPTION;
-        Globals.prefs.putInt(JabRefPreferences.PREF_IMPORT_DEFAULT_PDF_IMPORT_STYLE, this.getChoice());
+        Globals.prefs.putInt(JabRefPreferences.IMPORT_DEFAULT_PDF_IMPORT_STYLE, this.getChoice());
         if (useDefaultPDFImportStyle.isSelected()) {
-            Globals.prefs.putBoolean(JabRefPreferences.PREF_IMPORT_ALWAYSUSE, true);
+            Globals.prefs.putBoolean(JabRefPreferences.IMPORT_ALWAYSUSE, true);
         }
         // checkBoxDoNotShowAgain handled by local variable
         dispose();

--- a/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
+++ b/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
@@ -143,8 +143,8 @@ public class PdfImporter {
         }
         ImportDialog importDialog = null;
         boolean doNotShowAgain = false;
-        boolean neverShow = Globals.prefs.getBoolean(JabRefPreferences.PREF_IMPORT_ALWAYSUSE);
-        int globalChoice = Globals.prefs.getInt(JabRefPreferences.PREF_IMPORT_DEFAULT_PDF_IMPORT_STYLE);
+        boolean neverShow = Globals.prefs.getBoolean(JabRefPreferences.IMPORT_ALWAYSUSE);
+        int globalChoice = Globals.prefs.getInt(JabRefPreferences.IMPORT_DEFAULT_PDF_IMPORT_STYLE);
 
 
         List<BibEntry> res = new ArrayList<>();

--- a/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
@@ -47,7 +47,6 @@ import javax.swing.UIManager;
 
 import net.sf.jabref.JabRefException;
 import net.sf.jabref.JabRefMain;
-import net.sf.jabref.external.DroppedFileHandler;
 import net.sf.jabref.gui.desktop.JabRefDesktop;
 import net.sf.jabref.gui.entryeditor.EntryEditorTabList;
 import net.sf.jabref.gui.preftabs.ImportSettingsTab;
@@ -68,10 +67,8 @@ import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.openoffice.OpenOfficePreferences;
 import net.sf.jabref.logic.openoffice.StyleLoader;
 import net.sf.jabref.logic.protectedterms.ProtectedTermsLoader;
-import net.sf.jabref.logic.remote.RemotePreferences;
 import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.UpdateFieldPreferences;
-import net.sf.jabref.logic.util.VersionPreferences;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.bibtexkeypattern.AbstractBibtexKeyPattern;
 import net.sf.jabref.model.bibtexkeypattern.GlobalBibtexKeyPattern;
@@ -340,7 +337,7 @@ public class JabRefPreferences {
     public static final String PROTECTED_TERMS_ENABLED_INTERNAL = "protectedTermsEnabledInternal";
     public static final String PROTECTED_TERMS_DISABLED_INTERNAL = "protectedTermsDisabledInternal";
 
-    public static final String AKS_AUTO_NAMING_PDFS_AGAIN = "AskAutoNamingPDFsAgain";
+    public static final String ASK_AUTO_NAMING_PDFS_AGAIN = "AskAutoNamingPDFsAgain";
     public static final String CLEANUP_DOI = "CleanUpDOI";
     public static final String CLEANUP_ISSN = "CleanUpISSN";
     public static final String CLEANUP_MOVE_PDF = "CleanUpMovePDF";
@@ -370,9 +367,9 @@ public class JabRefPreferences {
         CLEANUP_DEFAULT_PRESET = new CleanupPreset(EnumSet.complementOf(deactivedJobs), formatterCleanups);
     }
 
-    public static final String PREF_IMPORT_DEFAULT_PDF_IMPORT_STYLE = "importDefaultPDFimportStyle";
-    public static final String PREF_IMPORT_ALWAYSUSE = "importAlwaysUsePDFImportStyle";
-    public static final String PREF_IMPORT_FILENAMEPATTERN = "importFileNamePattern";
+    public static final String IMPORT_DEFAULT_PDF_IMPORT_STYLE = "importDefaultPDFimportStyle";
+    public static final String IMPORT_ALWAYSUSE = "importAlwaysUsePDFImportStyle";
+    public static final String IMPORT_FILENAMEPATTERN = "importFileNamePattern";
 
 
     public static final String PUSH_TO_APPLICATION = "pushToApplication";
@@ -403,18 +400,18 @@ public class JabRefPreferences {
     public static final String STYLES_POS_X = "stylesPosX";
 
     // Special field preferences
-    public static final String PREF_SHOWCOLUMN_RELEVANCE = "showRelevanceColumn";
-    public static final String PREF_SHOWCOLUMN_READ = "showReadColumn";
-    public static final String PREF_SHOWCOLUMN_RANKING = "showRankingColumn";
-    public static final String PREF_SHOWCOLUMN_QUALITY = "showQualityColumn";
-    public static final String PREF_SHOWCOLUMN_PRIORITY = "showPriorityColumn";
-    public static final String PREF_SHOWCOLUMN_PRINTED = "showPrintedColumn";
-    public static final String PREF_SPECIALFIELDSENABLED = "specialFieldsEnabled";
-    // The choice between PREF_AUTOSYNCSPECIALFIELDSTOKEYWORDS and PREF_SERIALIZESPECIALFIELDS is mutually exclusive
-    public static final String PREF_SERIALIZESPECIALFIELDS = "serializeSpecialFields";
-    // The choice between PREF_AUTOSYNCSPECIALFIELDSTOKEYWORDS and PREF_SERIALIZESPECIALFIELDS is mutually exclusive
+    public static final String SHOWCOLUMN_RELEVANCE = "showRelevanceColumn";
+    public static final String SHOWCOLUMN_READ = "showReadColumn";
+    public static final String SHOWCOLUMN_RANKING = "showRankingColumn";
+    public static final String SHOWCOLUMN_QUALITY = "showQualityColumn";
+    public static final String SHOWCOLUMN_PRIORITY = "showPriorityColumn";
+    public static final String SHOWCOLUMN_PRINTED = "showPrintedColumn";
+    public static final String SPECIALFIELDSENABLED = "specialFieldsEnabled";
+    // The choice between AUTOSYNCSPECIALFIELDSTOKEYWORDS and SERIALIZESPECIALFIELDS is mutually exclusive
+    public static final String SERIALIZESPECIALFIELDS = "serializeSpecialFields";
+    // The choice between AUTOSYNCSPECIALFIELDSTOKEYWORDS and SERIALIZESPECIALFIELDS is mutually exclusive
     // At least in the settings, not in the implementation. But having both confused the users, therefore, having activated both options at the same time has been disabled
-    public static final String PREF_AUTOSYNCSPECIALFIELDSTOKEYWORDS = "autoSyncSpecialFieldsToKeywords";
+    public static final String AUTOSYNCSPECIALFIELDSTOKEYWORDS = "autoSyncSpecialFieldsToKeywords";
 
     //non-default preferences
     private static final String CUSTOM_TYPE_NAME = "customTypeName_";
@@ -424,6 +421,19 @@ public class JabRefPreferences {
 
     // Prefs node for BibtexKeyPatterns
     public static final String BIBTEX_KEY_PATTERNS_NODE = "bibtexkeypatterns";
+
+    // Version
+    public static final String VERSION_IGNORED_UPDATE = "versionIgnoreUpdate";
+
+    // Dropped file handler
+    public static final String DROPPEDFILEHANDLER_RENAME = "DroppedFileHandler_RenameFile";
+    public static final String DROPPEDFILEHANDLER_MOVE = "DroppedFileHandler_MoveFile";
+    public static final String DROPPEDFILEHANDLER_COPY = "DroppedFileHandler_CopyFile";
+    public static final String DROPPEDFILEHANDLER_LEAVE = "DroppedFileHandler_LeaveFileInDir";
+
+    // Remote
+    public static final String USE_REMOTE_SERVER = "useRemoteServer";
+    public static final String REMOTE_SERVER_PORT = "remoteServerPort";
 
     public String WRAPPED_USERNAME;
     public final String MARKING_WITH_NUMBER_PATTERN;
@@ -452,7 +462,6 @@ public class JabRefPreferences {
     // to solve the problem of formatters not having access to any context except for the
     // string to be formatted and possible formatter arguments.
     public List<String> fileDirForDatabase;
-
 
     // The only instance of this class:
     private static JabRefPreferences singleton;
@@ -712,15 +721,15 @@ public class JabRefPreferences {
         defaults.put(STYLES_SIZE_X, 600);
         defaults.put(STYLES_SIZE_Y, 400);
 
-        defaults.put(JabRefPreferences.PREF_SPECIALFIELDSENABLED, SpecialFields.PREF_SPECIALFIELDSENABLED_DEFAULT);
-        defaults.put(JabRefPreferences.PREF_SHOWCOLUMN_PRIORITY, SpecialFields.PREF_SHOWCOLUMN_PRIORITY_DEFAULT);
-        defaults.put(JabRefPreferences.PREF_SHOWCOLUMN_QUALITY, SpecialFields.PREF_SHOWCOLUMN_QUALITY_DEFAULT);
-        defaults.put(JabRefPreferences.PREF_SHOWCOLUMN_RANKING, SpecialFields.PREF_SHOWCOLUMN_RANKING_DEFAULT);
-        defaults.put(JabRefPreferences.PREF_SHOWCOLUMN_RELEVANCE, SpecialFields.PREF_SHOWCOLUMN_RELEVANCE_DEFAULT);
-        defaults.put(JabRefPreferences.PREF_SHOWCOLUMN_PRINTED, SpecialFields.PREF_SHOWCOLUMN_PRINTED_DEFAULT);
-        defaults.put(JabRefPreferences.PREF_SHOWCOLUMN_READ, SpecialFields.PREF_SHOWCOLUMN_READ_DEFAULT);
-        defaults.put(JabRefPreferences.PREF_AUTOSYNCSPECIALFIELDSTOKEYWORDS, SpecialFields.PREF_AUTOSYNCSPECIALFIELDSTOKEYWORDS_DEFAULT);
-        defaults.put(JabRefPreferences.PREF_SERIALIZESPECIALFIELDS, SpecialFields.PREF_SERIALIZESPECIALFIELDS_DEFAULT);
+        defaults.put(JabRefPreferences.SPECIALFIELDSENABLED, SpecialFields.PREF_SPECIALFIELDSENABLED_DEFAULT);
+        defaults.put(JabRefPreferences.SHOWCOLUMN_PRIORITY, SpecialFields.PREF_SHOWCOLUMN_PRIORITY_DEFAULT);
+        defaults.put(JabRefPreferences.SHOWCOLUMN_QUALITY, SpecialFields.PREF_SHOWCOLUMN_QUALITY_DEFAULT);
+        defaults.put(JabRefPreferences.SHOWCOLUMN_RANKING, SpecialFields.PREF_SHOWCOLUMN_RANKING_DEFAULT);
+        defaults.put(JabRefPreferences.SHOWCOLUMN_RELEVANCE, SpecialFields.PREF_SHOWCOLUMN_RELEVANCE_DEFAULT);
+        defaults.put(JabRefPreferences.SHOWCOLUMN_PRINTED, SpecialFields.PREF_SHOWCOLUMN_PRINTED_DEFAULT);
+        defaults.put(JabRefPreferences.SHOWCOLUMN_READ, SpecialFields.PREF_SHOWCOLUMN_READ_DEFAULT);
+        defaults.put(JabRefPreferences.AUTOSYNCSPECIALFIELDSTOKEYWORDS, SpecialFields.PREF_AUTOSYNCSPECIALFIELDSTOKEYWORDS_DEFAULT);
+        defaults.put(JabRefPreferences.SERIALIZESPECIALFIELDS, SpecialFields.PREF_SERIALIZESPECIALFIELDS_DEFAULT);
 
         defaults.put(USE_OWNER, Boolean.FALSE);
         defaults.put(OVERWRITE_OWNER, Boolean.FALSE);
@@ -791,8 +800,8 @@ public class JabRefPreferences {
 
         defaults.put(GENERATE_KEYS_BEFORE_SAVING, Boolean.FALSE);
 
-        defaults.put(RemotePreferences.USE_REMOTE_SERVER, Boolean.TRUE);
-        defaults.put(RemotePreferences.REMOTE_SERVER_PORT, 6050);
+        defaults.put(JabRefPreferences.USE_REMOTE_SERVER, Boolean.TRUE);
+        defaults.put(JabRefPreferences.REMOTE_SERVER_PORT, 6050);
 
         defaults.put(PERSONAL_JOURNAL_LIST, "");
         defaults.put(EXTERNAL_JOURNAL_LISTS, "");
@@ -829,14 +838,14 @@ public class JabRefPreferences {
         defaults.put(DB_CONNECT_DATABASE, "jabref");
         defaults.put(DB_CONNECT_USERNAME, "root");
 
-        defaults.put(AKS_AUTO_NAMING_PDFS_AGAIN, Boolean.TRUE);
+        defaults.put(ASK_AUTO_NAMING_PDFS_AGAIN, Boolean.TRUE);
         insertCleanupPreset(defaults, CLEANUP_DEFAULT_PRESET);
 
         // defaults for DroppedFileHandler UI
-        defaults.put(DroppedFileHandler.DFH_LEAVE, Boolean.FALSE);
-        defaults.put(DroppedFileHandler.DFH_COPY, Boolean.TRUE);
-        defaults.put(DroppedFileHandler.DFH_MOVE, Boolean.FALSE);
-        defaults.put(DroppedFileHandler.DFH_RENAME, Boolean.FALSE);
+        defaults.put(JabRefPreferences.DROPPEDFILEHANDLER_LEAVE, Boolean.FALSE);
+        defaults.put(JabRefPreferences.DROPPEDFILEHANDLER_COPY, Boolean.TRUE);
+        defaults.put(JabRefPreferences.DROPPEDFILEHANDLER_MOVE, Boolean.FALSE);
+        defaults.put(JabRefPreferences.DROPPEDFILEHANDLER_RENAME, Boolean.FALSE);
 
         //defaults.put("lastAutodetectedImport", "");
         //defaults.put("autoRemoveExactDuplicates", Boolean.FALSE);
@@ -845,11 +854,11 @@ public class JabRefPreferences {
         LOGGER.debug("Temporary directory: " + System.getProperty("java.io.tempdir"));
         //defaults.put("keyPattern", new LabelPattern(KEY_PATTERN));
 
-        defaults.put(PREF_IMPORT_ALWAYSUSE, Boolean.FALSE);
-        defaults.put(PREF_IMPORT_DEFAULT_PDF_IMPORT_STYLE, ImportSettingsTab.DEFAULT_STYLE);
+        defaults.put(IMPORT_ALWAYSUSE, Boolean.FALSE);
+        defaults.put(IMPORT_DEFAULT_PDF_IMPORT_STYLE, ImportSettingsTab.DEFAULT_STYLE);
 
         // use BibTeX key appended with filename as default pattern
-        defaults.put(PREF_IMPORT_FILENAMEPATTERN, ImportSettingsTab.DEFAULT_FILENAMEPATTERNS[1]);
+        defaults.put(IMPORT_FILENAMEPATTERN, ImportSettingsTab.DEFAULT_FILENAMEPATTERNS[1]);
 
         customExports = new CustomExportList(new ExportComparator());
         customImports = new CustomImportList(this);
@@ -872,7 +881,7 @@ public class JabRefPreferences {
         }
 
         //versioncheck defaults
-        defaults.put(VersionPreferences.VERSION_IGNORED_UPDATE, "");
+        defaults.put(JabRefPreferences.VERSION_IGNORED_UPDATE, "");
     }
 
     public String getUser() {

--- a/src/main/java/net/sf/jabref/preferences/LastFocusedTabPreferences.java
+++ b/src/main/java/net/sf/jabref/preferences/LastFocusedTabPreferences.java
@@ -14,12 +14,10 @@
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-package net.sf.jabref.logic.preferences;
+package net.sf.jabref.preferences;
 
 import java.io.File;
 import java.util.Objects;
-
-import net.sf.jabref.preferences.JabRefPreferences;
 
 public class LastFocusedTabPreferences {
 

--- a/src/main/java/net/sf/jabref/preferences/VersionPreferences.java
+++ b/src/main/java/net/sf/jabref/preferences/VersionPreferences.java
@@ -13,14 +13,12 @@
     with this program; if not, write to the Free Software Foundation, Inc.,
     51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
-package net.sf.jabref.logic.util;
+package net.sf.jabref.preferences;
 
-import net.sf.jabref.preferences.JabRefPreferences;
+import net.sf.jabref.logic.util.Version;
 
 
 public class VersionPreferences {
-
-    public static final String VERSION_IGNORED_UPDATE = "versionIgnoreUpdate";
 
     private final JabRefPreferences preferences;
 
@@ -30,11 +28,11 @@ public class VersionPreferences {
     }
 
     public void setAsIgnoredVersion(Version version) {
-        preferences.put(VERSION_IGNORED_UPDATE, version.toString());
+        preferences.put(JabRefPreferences.VERSION_IGNORED_UPDATE, version.toString());
     }
 
     public Version getIgnoredVersion() {
-        return new Version(preferences.get(VERSION_IGNORED_UPDATE));
+        return new Version(preferences.get(JabRefPreferences.VERSION_IGNORED_UPDATE));
     }
 
 }

--- a/src/main/java/net/sf/jabref/specialfields/SpecialFieldsUtils.java
+++ b/src/main/java/net/sf/jabref/specialfields/SpecialFieldsUtils.java
@@ -182,8 +182,8 @@ public class SpecialFieldsUtils {
     }
 
     public static boolean keywordSyncEnabled() {
-        return Globals.prefs.getBoolean(JabRefPreferences.PREF_SPECIALFIELDSENABLED) &&
-                Globals.prefs.getBoolean(JabRefPreferences.PREF_AUTOSYNCSPECIALFIELDSTOKEYWORDS);
+        return Globals.prefs.getBoolean(JabRefPreferences.SPECIALFIELDSENABLED) &&
+                Globals.prefs.getBoolean(JabRefPreferences.AUTOSYNCSPECIALFIELDSTOKEYWORDS);
     }
 
 }

--- a/src/test/java/net/sf/jabref/logic/cleanup/RenamePdfCleanupTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/RenamePdfCleanupTest.java
@@ -99,7 +99,7 @@ public class RenamePdfCleanupTest {
 
     @Test
     public void cleanupRenamePdfRenamesFileInSameFolder() throws IOException {
-        when(Globals.prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN)).thenReturn("\\bibtexkey\\begin{title} - \\format[RemoveBrackets]{\\title}\\end{title}");
+        when(Globals.prefs.get(JabRefPreferences.IMPORT_FILENAMEPATTERN)).thenReturn("\\bibtexkey\\begin{title} - \\format[RemoveBrackets]{\\title}\\end{title}");
         testFolder.newFile("Toot.pdf");
         ParsedFileField fileField = new ParsedFileField("", "Toot.pdf", "PDF");
         entry.setField("file", FileField.getStringRepresentation(fileField));

--- a/src/test/java/net/sf/jabref/logic/util/io/FileUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/io/FileUtilTest.java
@@ -31,7 +31,7 @@ public class FileUtilTest {
     @Test
     public void testGetLinkedFileNameDefault() {
         // bibkey - title
-        when(prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN))
+        when(prefs.get(JabRefPreferences.IMPORT_FILENAMEPATTERN))
                 .thenReturn("\\bibtexkey\\begin{title} - \\format[RemoveBrackets]{\\title}\\end{title}");
 
         BibEntry entry = new BibEntry();
@@ -45,7 +45,7 @@ public class FileUtilTest {
     @Test
     public void testGetLinkedFileNameBibTeXKey() {
         // bibkey
-        when(prefs.get(JabRefPreferences.PREF_IMPORT_FILENAMEPATTERN)).thenReturn("\\bibtexkey");
+        when(prefs.get(JabRefPreferences.IMPORT_FILENAMEPATTERN)).thenReturn("\\bibtexkey");
 
         BibEntry entry = new BibEntry();
         entry.setCiteKey("1234");

--- a/src/test/java/net/sf/jabref/preferences/LastFocusedTabPreferencesTest.java
+++ b/src/test/java/net/sf/jabref/preferences/LastFocusedTabPreferencesTest.java
@@ -1,8 +1,6 @@
-package net.sf.jabref.logic.preferences;
+package net.sf.jabref.preferences;
 
 import java.io.File;
-
-import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;


### PR DESCRIPTION
All preference constants should be in `JabRefPreferences`.

Relates to https://github.com/koppor/jabref/issues/158

Also, renamed some variables (not the actual preference strings).


