### PR TITLE
Improved main table rendering when using e.g. 'title/author'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Added filter to not show selected integrity checks
 - The contents of `crossref` and `related` will be automatically updated if a linked entry changes key
 - The information shown in the main table now resolves crossrefs and strings and it can be shown which fields are resolved in this way (Preferences -> Appearance -> Color codes for resolved fields)
+- The formatting of the main table is based on the actual field shown when using e.g. `title/author`
 - Enhance the entry customization dialog to give better visual feedback
 - It is now possible to generate a new BIB database from the citations in an OpenOffice/LibreOffice document
 - The arXiv fetcher now also supports free-text search queries

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableColumn.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableColumn.java
@@ -70,21 +70,6 @@ public class MainTableColumn {
         return joiner.toString();
     }
 
-    /**
-     * Checks whether the column should display names
-     * Relevant as name value format can be formatted.
-     *
-     * @return true if the bibtex fields contains author or editor
-     */
-    private boolean isNameColumn() {
-        for (String field : bibtexFields) {
-            if (InternalBibtexFields.getFieldExtras(field).contains(FieldProperties.PERSON_NAMES)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     public String getColumnName() {
         return columnName;
     }
@@ -105,18 +90,20 @@ public class MainTableColumn {
         if (bibtexFields.isEmpty()) {
             return null;
         }
+        boolean isNameColumn = false;
 
         Optional<String> content = Optional.empty();
         for (String field : bibtexFields) {
             content = BibDatabase.getResolvedField(field, entry, database.orElse(null));
             if (content.isPresent()) {
+                isNameColumn = InternalBibtexFields.getFieldExtras(field).contains(FieldProperties.PERSON_NAMES);
                 break;
             }
         }
 
         String result = content.orElse(null);
 
-        if (isNameColumn()) {
+        if (isNameColumn) {
             result = MainTableNameFormatter.formatName(result);
         }
 


### PR DESCRIPTION
Earlier on a name formatter was used if any of the fields in a column contained person names, now it is determined by the used field. (Marginally related to #1795, or at least one step towards a solution, figuring out which field actually was used.)

Before:
<img width="432" alt="capture18" src="https://cloud.githubusercontent.com/assets/8114497/17831868/bd234cca-66f5-11e6-9ad6-7dc84a0e7a18.PNG">

After:
<img width="527" alt="capture19" src="https://cloud.githubusercontent.com/assets/8114497/17831871/c3134324-66f5-11e6-8b17-5309354227a5.PNG">

(As can be seen, the author/editor column is still rendered as it should.)

- [x] Change in CHANGELOG.md described
- [x] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
