### PR TITLE
Fix preview update when selecting single entry after selecting multiple entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - File open dialogs now use default extensions as primary file filter
 
 ### Fixed
+- Fixed [#1760](https://github.com/JabRef/jabref/issues/1760): Preview updated correctly when selecting a single entry after selecting multiple entries
 - Fixed [#1632](https://github.com/JabRef/jabref/issues/1632): User comments (@Comment) with or without brackets are now kept
 - Fixed [#1264](https://github.com/JabRef/jabref/issues/1264): S with caron does not render correctly
 - LaTeX to Unicode converter now handles combining accents

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableSelectionListener.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableSelectionListener.java
@@ -105,24 +105,14 @@ public class MainTableSelectionListener implements ListEventListener<BibEntry>, 
         if (!enabled) {
             return;
         }
+
         EventList<BibEntry> selected = e.getSourceList();
-        BibEntry newSelected = null;
-        while (e.next()) {
-            if (e.getType() == ListEvent.INSERT) {
-                if (newSelected == null) {
-                    if (e.getIndex() < selected.size()) {
-                        newSelected = selected.get(e.getIndex());
-                    }
-                } else {
-                    return; // More than one new selected. Do nothing.
-                }
-            }
+        if (selected.isEmpty()){
+            return;
         }
 
+        final BibEntry newSelected = selected.get(0);
         if (newSelected != null) {
-
-            // Ok, we have a single new entry that has been selected. Now decide what to do with it:
-            final BibEntry toShow = newSelected;
             final BasePanelMode mode = panel.getMode(); // What is the panel already showing?
             if ((mode == BasePanelMode.WILL_SHOW_EDITOR) || (mode == BasePanelMode.SHOWING_EDITOR)) {
                 // An entry is currently being edited.
@@ -132,7 +122,7 @@ public class MainTableSelectionListener implements ListEventListener<BibEntry>, 
                     visName = oldEditor.getVisiblePanelName();
                 }
                 // Get an old or new editor for the entry to edit:
-                EntryEditor newEditor = panel.getEntryEditor(toShow);
+                EntryEditor newEditor = panel.getEntryEditor(newSelected);
 
                 if (oldEditor != null) {
                     oldEditor.setMovingToDifferentEntry();
@@ -150,7 +140,7 @@ public class MainTableSelectionListener implements ListEventListener<BibEntry>, 
             } else {
                 // Either nothing or a preview was shown. Update the preview.
                 if (previewActive) {
-                    updatePreview(toShow, false);
+                    updatePreview(newSelected, false);
                 }
             }
         }


### PR DESCRIPTION
Fixes #1760.

Preview is now updated correctly when selecting a single entry after selecting multiple entries.
