### PR TITLE
Preview panel height is now saved immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 ### Fixed
 - Fixed [#1632](https://github.com/JabRef/jabref/issues/1632): User comments (@Comment) with or without brackets are now kept
+- Preview panel height is now saved immediately, thus is shown correctly if the panel height is changed, closed and opened again
 - Fixed [#1264](https://github.com/JabRef/jabref/issues/1264): S with caron does not render correctly
 - LaTeX to Unicode converter now handles combining accents
 - Fixed NullPointerException when clicking Browse in Journal abbreviations with empty text field

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -246,6 +246,11 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 LOGGER.warn("Could not register FileUpdateMonitor", ex);
             }
         }
+
+        // saves the divider position as soon as it changes
+        splitPane.addPropertyChangeListener(JSplitPane.DIVIDER_LOCATION_PROPERTY, propertyChangeEvent -> {
+            saveDividerLocation();
+        });
     }
 
     // Returns a collection of AutoCompleters, which are populated from the current database

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -747,10 +747,6 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
         dispose();
 
-        if (getCurrentBasePanel() != null) {
-            getCurrentBasePanel().saveDividerLocation();
-        }
-
         //prefs.putBoolean(JabRefPreferences.WINDOW_MAXIMISED, (getExtendedState()&MAXIMIZED_BOTH)>0);
         prefs.putBoolean(JabRefPreferences.WINDOW_MAXIMISED, getExtendedState() == Frame.MAXIMIZED_BOTH);
 


### PR DESCRIPTION
The Preview panel height is not stored when changed (only when JabRef is closed)

### Steps
 - selecting an entry (thus opening the preview panel)
 - changing the preview panel height
 - closing the preview panel
 - selecting an entry (thus opening the preview panel)
 - the preview panel has the old height, not the new one we just changed