### PR TITLE
When inserting a duplicate the right entry will be selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Fixed
 - Fixed [#1760](https://github.com/JabRef/jabref/issues/1760): Preview updated correctly when selecting a single entry after selecting multiple entries
 - Fixed [#1632](https://github.com/JabRef/jabref/issues/1632): User comments (@Comment) with or without brackets are now kept
+- When inserting a duplicate the right entry will be selected
 - Preview panel height is now saved immediately, thus is shown correctly if the panel height is changed, closed and opened again
 - Fixed [#1264](https://github.com/JabRef/jabref/issues/1264): S with caron does not render correctly
 - LaTeX to Unicode converter now handles combining accents

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -845,7 +845,9 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             if (Globals.prefs.getBoolean(JabRefPreferences.AUTO_OPEN_FORM)) {
                 selectionListener.editSignalled(firstBE);
             }
-            highlightEntry(firstBE);
+
+//            If we inserted a duplicate we want to select the duplicate
+            highlightLastEntry(firstBE);
         }
     }
 
@@ -1719,12 +1721,26 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
      * given focus afterwards.
      */
     public void highlightEntry(final BibEntry bibEntry) {
-        final int row = mainTable.findEntry(bibEntry);
-        if (row >= 0) {
-//            the selection has to be cleared in case that a duplicate later in the list is selected thus the editor doesn't get refreshed
+        highlightEntry(mainTable.findEntry(bibEntry));
+    }
+
+    /**
+     * This method selects the given entry (searches from the back), and scrolls it into view in the table.
+     * If an entryEditor is shown, it is given focus afterwards.
+     */
+    public void highlightLastEntry(final BibEntry bibEntry) {
+        highlightEntry(mainTable.findLastEntry(bibEntry));
+    }
+
+    /**
+     * This method selects the entry on the given position, and scrolls it into view in the table.
+     * If an entryEditor is shown, it is given focus afterwards.
+     */
+    public void highlightEntry(int pos) {
+        if (pos >= 0) {
             mainTable.clearSelection();
-            mainTable.setRowSelectionInterval(row, row);
-            mainTable.ensureVisible(row);
+            mainTable.addRowSelectionInterval(pos, pos);
+            mainTable.ensureVisible(pos);
         }
     }
 

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -846,7 +846,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 selectionListener.editSignalled(firstBE);
             }
 
-//            If we inserted a duplicate we want to select the duplicate
+            // If we inserted a duplicate we want to select the duplicate (thus we have to search from the back)
             highlightLastEntry(firstBE);
         }
     }

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -1721,6 +1721,8 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
     public void highlightEntry(final BibEntry be) {
         final int row = mainTable.findEntry(be);
         if (row >= 0) {
+//            the selection has to be cleared in case that a duplicate later in the list is selected thus the editor doesn't get refreshed
+            mainTable.clearSelection();
             mainTable.setRowSelectionInterval(row, row);
             mainTable.ensureVisible(row);
         }
@@ -1838,17 +1840,6 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             }
         }
         frame.setWindowTitle();
-    }
-
-    /**
-     * Selects a single entry, and scrolls the table to center it.
-     *
-     * @param pos Current position of entry to select.
-     */
-    public void selectSingleEntry(int pos) {
-        mainTable.clearSelection();
-        mainTable.addRowSelectionInterval(pos, pos);
-        mainTable.scrollToCenter(pos, 0);
     }
 
     public BibDatabase getDatabase() {

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -1718,8 +1718,8 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
      * This method selects the given entry, and scrolls it into view in the table. If an entryEditor is shown, it is
      * given focus afterwards.
      */
-    public void highlightEntry(final BibEntry be) {
-        final int row = mainTable.findEntry(be);
+    public void highlightEntry(final BibEntry bibEntry) {
+        final int row = mainTable.findEntry(bibEntry);
         if (row >= 0) {
 //            the selection has to be cleared in case that a duplicate later in the list is selected thus the editor doesn't get refreshed
             mainTable.clearSelection();

--- a/src/main/java/net/sf/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/SaveDatabaseAction.java
@@ -185,7 +185,7 @@ public class SaveDatabaseAction extends AbstractWorker {
             if (ex.specificEntry()) {
                 BibEntry entry = ex.getEntry();
                 // Error occured during processing of an entry. Highlight it!
-                highlightEntry(entry);
+                panel.highlightEntry(entry);
             } else {
                 LOGGER.error("A problem occured when trying to save the file", ex);
             }
@@ -252,14 +252,6 @@ public class SaveDatabaseAction extends AbstractWorker {
         }
 
         return success;
-    }
-
-    private void highlightEntry(BibEntry entry) {
-        int row = panel.getMainTable().findEntry(entry);
-        int topShow = Math.max(0, row - 3);
-        panel.getMainTable().setRowSelectionInterval(row, row);
-        panel.getMainTable().scrollTo(topShow);
-        panel.showEntry(entry);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
@@ -490,6 +490,10 @@ public class MainTable extends JTable {
         return model.getTableRows().indexOf(entry);
     }
 
+    public int findLastEntry(BibEntry entry) {
+        return model.getTableRows().lastIndexOf(entry);
+    }
+
     /**
      * method to check whether a MainTableColumn at the modelIndex refers to the file field (either as a specific
      * file extension filter or not)

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
@@ -555,7 +555,7 @@ public class MainTable extends JTable {
     public void ensureVisible(int row) {
         JScrollBar vert = pane.getVerticalScrollBar();
         int y = row * getRowHeight();
-        if ((y < vert.getValue()) || ((y > (vert.getValue() + vert.getVisibleAmount()))
+        if ((y < vert.getValue()) || ((y >= (vert.getValue() + vert.getVisibleAmount()))
                 && (model.getSearchState() != MainTableDataModel.DisplayOption.FLOAT))) {
             scrollToCenter(row, 1);
         }


### PR DESCRIPTION
When you insert a duplicate in your database the editor has the wrong entry linked.

### Steps to reproduce
- select an entry
- copy and paste it (`ctrl+c` & `ctrl+v`; leave the old entry selected)
- now the entry editor is open, edit any value and you'll see that the lower duplicate has changed although the upper one is selected