### PR TITLE
Fixed #1804: URL field is not removed by integrity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed [#1499](https://github.com/JabRef/jabref/issues/1499): {} braces are now treated correctly in in author/editor
 - Fixed [#1531](https://github.com/JabRef/jabref/issues/1531): `\relax` can be used for abbreviation of author names
 - Fixed [#1771](https://github.com/JabRef/jabref/issues/1771): Show all supported import types as default
+- Fixed [#1804](https://github.com/JabRef/jabref/issues/1804): Integrity check no longer removes URL field by mistake
+
  
 
 ### Removed

--- a/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
@@ -410,19 +410,19 @@ public class IntegrityCheck {
             List<IntegrityMessage> results = new ArrayList<>();
 
             Map<String, String> fields = entry.getFieldMap();
-            // the url field should not be checked for hashes, as they are legal in this field
-            fields.remove(FieldName.URL);
+
 
             for (Map.Entry<String, String> field : fields.entrySet()) {
-                Matcher hashMatcher = UNESCAPED_HASH.matcher(field.getValue());
-                int hashCount = 0;
-                while (hashMatcher.find()) {
-                    hashCount++;
-                }
-                if ((hashCount & 1) == 1) { // Check if odd
-                    results.add(
-                            new IntegrityMessage(Localization.lang("odd number of unescaped '#'"), entry,
-                                    field.getKey()));
+                if (!InternalBibtexFields.getFieldExtras(field.getKey()).contains(FieldProperties.VERBATIM)) {
+                    Matcher hashMatcher = UNESCAPED_HASH.matcher(field.getValue());
+                    int hashCount = 0;
+                    while (hashMatcher.find()) {
+                        hashCount++;
+                    }
+                    if ((hashCount & 1) == 1) { // Check if odd
+                        results.add(new IntegrityMessage(Localization.lang("odd number of unescaped '#'"), entry,
+                                field.getKey()));
+                    }
                 }
             }
             return results;

--- a/src/main/java/net/sf/jabref/model/entry/FieldProperties.java
+++ b/src/main/java/net/sf/jabref/model/entry/FieldProperties.java
@@ -30,7 +30,8 @@ public enum FieldProperties {
     BOOK_NAME,
     SINGLE_ENTRY_LINK,
     MULTIPLE_ENTRY_LINK,
-    PUBLICATION_STATE;
+    PUBLICATION_STATE,
+    VERBATIM;
 
     public static final Set<FieldProperties> ALL_OPTS = EnumSet.allOf(FieldProperties.class);
 

--- a/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
+++ b/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
@@ -38,7 +38,8 @@ public class InternalBibtexFields {
             "ctlalt_stretch_factor", FieldName.VOLUMES);
     public static final List<String> IEEETRANBSTCTL_YES_NO_FIELDS = Arrays.asList("ctluse_article_number",
             "ctluse_paper", "ctluse_url", "ctluse_forced_etal", "ctluse_alt_spacing", "ctldash_repeated_names");
-    public static final List<String> BIBLATEX_DATE_FIELDS = Arrays.asList(FieldName.DATE, "eventdate", "origdate", FieldName.URLDATE);
+    public static final List<String> BIBLATEX_DATE_FIELDS = Arrays.asList(FieldName.DATE, "eventdate", "origdate",
+            FieldName.URLDATE);
     public static final List<String> BIBLATEX_PERSON_NAME_FIELDS = Arrays.asList(FieldName.AUTHOR, FieldName.EDITOR,
             "editora", "editorb", "editorc", FieldName.TRANSLATOR, "annotator", "commentator", "introduction", "foreword",
             "afterword", FieldName.BOOKAUTHOR, "holder", "shortauthor", "shorteditor", "sortname", "nameaddon");
@@ -156,14 +157,14 @@ public class InternalBibtexFields {
         add(new BibtexSingleField(FieldName.ABSTRACT, false, BibtexSingleField.LARGE_W, 400));
 
         dummy = new BibtexSingleField(FieldName.URL, false, BibtexSingleField.SMALL_W);
-        dummy.setExtras(EnumSet.of(FieldProperties.EXTERNAL));
+        dummy.setExtras(EnumSet.of(FieldProperties.EXTERNAL, FieldProperties.VERBATIM));
         add(dummy);
 
         add(new BibtexSingleField("comment", false, BibtexSingleField.MEDIUM_W));
         add(new BibtexSingleField(FieldName.KEYWORDS, false, BibtexSingleField.SMALL_W));
 
         dummy = new BibtexSingleField(FieldName.FILE, false);
-        dummy.setExtras(EnumSet.of(FieldProperties.FILE_EDITOR));
+        dummy.setExtras(EnumSet.of(FieldProperties.FILE_EDITOR, FieldProperties.VERBATIM));
         add(dummy);
 
         add(new BibtexSingleField("search", false, 75));


### PR DESCRIPTION
Better to disable the check than remove the field from the entry. ;-)

Fixes #1804 

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes (one may think of adding a test that no fields are removed from the entry in the integrity check, but I haven't done that here, ideally the entry should have every possible field included...)
- [x] Manually tested changed features in running JabRef
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)

