### PR TITLE
Disable incompatible properties for shared database

### DIFF
--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -1994,6 +1994,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
                 propertiesDialog = new DatabasePropertiesDialog(JabRefFrame.this);
             }
             propertiesDialog.setPanel(getCurrentBasePanel());
+            propertiesDialog.updateEnableStatus();
             propertiesDialog.setLocationRelativeTo(JabRefFrame.this);
             propertiesDialog.setVisible(true);
         }

--- a/src/main/java/net/sf/jabref/gui/dbproperties/DatabasePropertiesDialog.java
+++ b/src/main/java/net/sf/jabref/gui/dbproperties/DatabasePropertiesDialog.java
@@ -34,6 +34,7 @@ import net.sf.jabref.logic.exporter.FieldFormatterCleanups;
 import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.l10n.Encodings;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.model.database.DatabaseLocation;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import com.jgoodies.forms.builder.FormBuilder;
@@ -77,6 +78,16 @@ public class DatabasePropertiesDialog extends JDialog {
     public void setPanel(BasePanel panel) {
         this.panel = panel;
         this.metaData = panel.getBibDatabaseContext().getMetaData();
+    }
+
+    public void updateEnableStatus() {
+        DatabaseLocation location = panel.getBibDatabaseContext().getLocation();
+        boolean isShared = (location == DatabaseLocation.SHARED);
+        encoding.setEnabled(!isShared); // the encoding of shared database is always UTF-8
+        saveInOriginalOrder.setEnabled(!isShared);
+        saveInSpecifiedOrder.setEnabled(!isShared);
+        saveOrderPanel.setEnabled(!isShared);
+        protect.setEnabled(!isShared);
     }
 
     private void init(JFrame parent) {


### PR DESCRIPTION
Issue: https://github.com/JabRef/jabref/issues/1703.

> Database properties dialog:
    Do not show "Save sort order" - database sorts arbitrarily :innocent:
    Do not show "Database protection" - makes no sense in a shared database setting


Depends on: ~~https://github.com/JabRef/jabref/pull/1818~~ and https://github.com/JabRef/help.jabref.org/pull/57
- [x] Manually tested changed features in running JabRef