### PR TITLE
Made BibDatabaseContext.getDatabaseFile() return Optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Changed
 
 ### Fixed
+- Fixed NullPointerException when opening search result window for an untitled database 
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/BibDatabaseContext.java
+++ b/src/main/java/net/sf/jabref/BibDatabaseContext.java
@@ -98,10 +98,10 @@ public class BibDatabaseContext {
     /**
      * Get the file where this database was last saved to or loaded from, if any.
      *
-     * @return The relevant File, or null if none is defined.
+     * @return Optional of the relevant File, or Optional.empty() if none is defined.
      */
-    public File getDatabaseFile() {
-        return file;
+    public Optional<File> getDatabaseFile() {
+        return Optional.ofNullable(file);
     }
 
     public void setDatabaseFile(File file) {
@@ -158,15 +158,15 @@ public class BibDatabaseContext {
         }
 
         // 4. BIB file directory
-        if (getDatabaseFile() != null) {
-            String parentDir = getDatabaseFile().getParent();
+        getDatabaseFile().ifPresent(databaseFile -> {
+            String parentDir = databaseFile.getParent();
             // Check if we should add it as primary file dir (first in the list) or not:
             if (Globals.prefs.getBoolean(JabRefPreferences.BIB_LOC_AS_PRIMARY_DIR)) {
                 fileDirs.add(0, parentDir);
             } else {
                 fileDirs.add(parentDir);
             }
-        }
+        });
 
         return fileDirs;
     }
@@ -175,13 +175,14 @@ public class BibDatabaseContext {
         String dir = directoryName;
         // If this directory is relative, we try to interpret it as relative to
         // the file path of this BIB file:
-        if (!new File(dir).isAbsolute() && (getDatabaseFile() != null)) {
+        Optional<File> databaseFile = getDatabaseFile();
+        if (!new File(dir).isAbsolute() && databaseFile.isPresent()) {
             String relDir;
             if (".".equals(dir)) {
                 // if dir is only "current" directory, just use its parent (== real current directory) as path
-                relDir = getDatabaseFile().getParent();
+                relDir = databaseFile.get().getParent();
             } else {
-                relDir = getDatabaseFile().getParent() + File.separator + dir;
+                relDir = databaseFile.get().getParent() + File.separator + dir;
             }
             // If this directory actually exists, it is very likely that the
             // user wants us to use it:

--- a/src/main/java/net/sf/jabref/gui/StringDialog.java
+++ b/src/main/java/net/sf/jabref/gui/StringDialog.java
@@ -8,6 +8,7 @@ import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -143,11 +144,8 @@ class StringDialog extends JDialog {
         conPane.add(tlb, BorderLayout.NORTH);
         conPane.add(pan, BorderLayout.CENTER);
 
-        if (panel.getBibDatabaseContext().getDatabaseFile() == null) {
-            setTitle(STRINGS_TITLE + ": " + GUIGlobals.UNTITLED_TITLE);
-        } else {
-            setTitle(STRINGS_TITLE + ": " + panel.getBibDatabaseContext().getDatabaseFile().getName());
-        }
+        setTitle(STRINGS_TITLE + ": "
+                + panel.getBibDatabaseContext().getDatabaseFile().map(File::getName).orElse(GUIGlobals.UNTITLED_TITLE));
         PositionWindow pw = new PositionWindow(this, JabRefPreferences.STRINGS_POS_X, JabRefPreferences.STRINGS_POS_Y,
                 JabRefPreferences.STRINGS_SIZE_X, JabRefPreferences.STRINGS_SIZE_Y);
         pw.setWindowPosition();

--- a/src/main/java/net/sf/jabref/gui/exporter/AutoSaveManager.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/AutoSaveManager.java
@@ -58,7 +58,7 @@ public class AutoSaveManager {
             // there could be changes done by the user while this method is running.
 
             for (BasePanel panel : frame.getBasePanelList()) {
-                if (panel.isModified() && (panel.getBibDatabaseContext().getDatabaseFile() != null)) {
+                if (panel.isModified() && (panel.getBibDatabaseContext().getDatabaseFile().isPresent())) {
                         AutoSaveManager.autoSave(panel);
                 }
             }
@@ -72,7 +72,7 @@ public class AutoSaveManager {
      * @return true if successful, false otherwise.
      */
     private static boolean autoSave(BasePanel panel) {
-        File databaseFile = panel.getBibDatabaseContext().getDatabaseFile();
+        File databaseFile = panel.getBibDatabaseContext().getDatabaseFile().orElse(null);
         File backupFile = AutoSaveUtil.getAutoSaveFile(databaseFile);
         try {
             SavePreferences prefs = SavePreferences.loadForSaveFromPreferences(Globals.prefs)
@@ -96,10 +96,10 @@ public class AutoSaveManager {
      * @return true if there was no autosave or if the autosave was successfully deleted, false otherwise.
      */
     public static boolean deleteAutoSaveFile(BasePanel panel) {
-        if (panel.getBibDatabaseContext().getDatabaseFile() == null) {
+        if (!panel.getBibDatabaseContext().getDatabaseFile().isPresent()) {
             return true;
         }
-        File backupFile = AutoSaveUtil.getAutoSaveFile(panel.getBibDatabaseContext().getDatabaseFile());
+        File backupFile = AutoSaveUtil.getAutoSaveFile(panel.getBibDatabaseContext().getDatabaseFile().get());
         if (backupFile.exists()) {
             return backupFile.delete();
         } else {

--- a/src/main/java/net/sf/jabref/gui/exporter/SaveAllAction.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/SaveAllAction.java
@@ -49,7 +49,7 @@ public class SaveAllAction extends MnemonicAwareAction implements Worker {
         for (int i = 0; i < databases; i++) {
             if (i < frame.getBasePanelCount()) {
                 BasePanel panel = frame.getBasePanelAt(i);
-                if (panel.getBibDatabaseContext().getDatabaseFile() == null) {
+                if (!panel.getBibDatabaseContext().getDatabaseFile().isPresent()) {
                     frame.showBasePanelAt(i);
                 }
                 panel.runCommand(Actions.SAVE);

--- a/src/main/java/net/sf/jabref/gui/importer/actions/OpenDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/importer/actions/OpenDatabaseAction.java
@@ -126,8 +126,8 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
             File file = iterator.next();
             for (int i = 0; i < frame.getTabbedPane().getTabCount(); i++) {
                 BasePanel basePanel = frame.getBasePanelAt(i);
-                if ((basePanel.getBibDatabaseContext().getDatabaseFile() != null)
-                        && basePanel.getBibDatabaseContext().getDatabaseFile().equals(file)) {
+                if ((basePanel.getBibDatabaseContext().getDatabaseFile().isPresent())
+                        && basePanel.getBibDatabaseContext().getDatabaseFile().get().equals(file)) {
                     iterator.remove();
                     removed++;
                     // See if we removed the final one. If so, we must perhaps
@@ -158,7 +158,7 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
         // already open. If so, we may have to raise the correct tab:
         else if (toRaise != null) {
             frame.output(Localization.lang("File '%0' is already open.",
-                    toRaise.getBibDatabaseContext().getDatabaseFile().getPath()));
+                    toRaise.getBibDatabaseContext().getDatabaseFile().get().getPath()));
             frame.getTabbedPane().setSelectedComponent(toRaise);
         }
 

--- a/src/main/java/net/sf/jabref/gui/search/SearchBar.java
+++ b/src/main/java/net/sf/jabref/gui/search/SearchBar.java
@@ -7,6 +7,7 @@ import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
+import java.io.File;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -19,6 +20,7 @@ import javax.swing.JToolBar;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.gui.BasePanel;
+import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.OSXCompatibleToolbar;
 import net.sf.jabref.gui.WrapLayout;
@@ -105,8 +107,9 @@ public class SearchBar extends JPanel {
         openCurrentResultsInDialog.setToolTipText(Localization.lang("Show search results in a window"));
         openCurrentResultsInDialog.addActionListener(ae -> {
             SearchResultsDialog searchDialog = new SearchResultsDialog(basePanel.frame(),
-                    Localization.lang("Search results in database %0 for %1",
-                            basePanel.getBibDatabaseContext().getDatabaseFile().getName(),
+                    Localization.lang(
+                            "Search results in database %0 for %1", basePanel.getBibDatabaseContext().getDatabaseFile()
+                                    .map(File::getName).orElse(GUIGlobals.UNTITLED_TITLE),
                             this.getSearchQuery().localize()));
             List<BibEntry> entries = basePanel.getDatabase().getEntries().stream().filter(BibEntry::isSearchHit)
                     .collect(Collectors.toList());

--- a/src/main/java/net/sf/jabref/logic/layout/LayoutEntry.java
+++ b/src/main/java/net/sf/jabref/logic/layout/LayoutEntry.java
@@ -377,12 +377,10 @@ class LayoutEntry {
             return encoding.displayName();
 
         case LayoutHelper.IS_FILENAME:
-            File f = databaseContext.getDatabaseFile();
-            return f == null ? "" : f.getName();
+            return databaseContext.getDatabaseFile().map(File::getName).orElse("");
 
         case LayoutHelper.IS_FILEPATH:
-            File f2 = databaseContext.getDatabaseFile();
-            return f2 == null ? "" : f2.getPath();
+            return databaseContext.getDatabaseFile().map(File::getPath).orElse("");
 
         default:
             break;


### PR DESCRIPTION
Plus one (or two, I couldn't confirm the second but I think there will be an NPE if starting JabRef with an already existing file as an argument and an unsaved (untitled) database open) bug fixes.

This also includes #1782 as I messed up a bit...

- [x] Change in CHANGELOG.md described
- [x] Manually tested changed features in running JabRef
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
