### PR TITLE
[WIP] Word cloud generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,8 @@ dependencies {
     compile 'org.apache.logging.log4j:log4j-jcl:2.6.2'
     compile 'org.apache.logging.log4j:log4j-api:2.6.2'
     compile 'org.apache.logging.log4j:log4j-core:2.6.2'
+    
+    compile 'com.kennycason:kumo:1.8'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -74,6 +74,7 @@ import net.sf.jabref.gui.actions.OpenBrowserAction;
 import net.sf.jabref.gui.actions.OpenSharedDatabaseAction;
 import net.sf.jabref.gui.actions.SearchForUpdateAction;
 import net.sf.jabref.gui.actions.SortTabsAction;
+import net.sf.jabref.gui.actions.WordCloudAction;
 import net.sf.jabref.gui.dbproperties.DatabasePropertiesDialog;
 import net.sf.jabref.gui.exporter.AutoSaveManager;
 import net.sf.jabref.gui.exporter.ExportAction;
@@ -121,6 +122,7 @@ import net.sf.jabref.model.database.DatabaseLocation;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.EntryType;
+import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.preferences.HighlightMatchingGroupPreferences;
 import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.preferences.LastFocusedTabPreferences;
@@ -415,6 +417,9 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
     private final AbstractAction databaseProperties = new DatabasePropertiesAction();
     private final AbstractAction bibtexKeyPattern = new BibtexKeyPatternAction();
     private final AbstractAction errorConsole = new ErrorConsoleAction(this, Globals.getStreamEavesdropper(), GuiAppender.CACHE);
+
+    private final AbstractAction titleCloud = new WordCloudAction(this, FieldName.TITLE);
+    private final AbstractAction authorCloud = new WordCloudAction(this, FieldName.AUTHOR);
 
     private final AbstractAction cleanupEntries = new GeneralAction(Actions.CLEANUP,
             Localization.menuTitle("Cleanup entries") + ELLIPSES,
@@ -1330,6 +1335,9 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         tools.add(abbreviateIso);
         tools.add(abbreviateMedline);
         tools.add(unabbreviate);
+        tools.addSeparator();
+        tools.add(titleCloud);
+        tools.add(authorCloud);
         mb.add(tools);
 
         options.add(showPrefs);

--- a/src/main/java/net/sf/jabref/gui/actions/WordCloudAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/WordCloudAction.java
@@ -1,0 +1,62 @@
+package net.sf.jabref.gui.actions;
+
+import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.AbstractAction;
+import javax.swing.ImageIcon;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+
+import net.sf.jabref.gui.JabRefFrame;
+import net.sf.jabref.logic.layout.format.LatexToUnicodeFormatter;
+import net.sf.jabref.model.entry.BibEntry;
+
+import com.kennycason.kumo.CollisionMode;
+import com.kennycason.kumo.WordCloud;
+import com.kennycason.kumo.WordFrequency;
+import com.kennycason.kumo.bg.RectangleBackground;
+import com.kennycason.kumo.font.scale.LinearFontScalar;
+import com.kennycason.kumo.nlp.FrequencyAnalyzer;
+
+public class WordCloudAction extends AbstractAction {
+
+    private final JabRefFrame frame;
+    private final String field;
+
+    private final LatexToUnicodeFormatter formatter = new LatexToUnicodeFormatter();
+
+    public WordCloudAction(JabRefFrame frame, String field) {
+        super("Word cloud for " + field);
+        this.frame = frame;
+        this.field = field;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent arg0) {
+        final FrequencyAnalyzer frequencyAnalyzer = new FrequencyAnalyzer();
+        frequencyAnalyzer.setWordFrequenciesToReturn(500);
+        frequencyAnalyzer.setMinWordLength(3);
+        List<String> words = new ArrayList<>();
+
+        for (BibEntry entry : frame.getCurrentBasePanel().getDatabase().getEntries()) {
+            entry.getFieldOptional(field).map(formatter::format).ifPresent(words::add);
+        }
+        final List<WordFrequency> wordFrequencies = frequencyAnalyzer.load(words);
+        Dimension dimension = new Dimension(1000, 1000);
+        WordCloud wordCloud = new WordCloud(dimension, CollisionMode.PIXEL_PERFECT);
+
+        wordCloud.setPadding(0);
+        wordCloud.setBackground(new RectangleBackground(dimension));
+        wordCloud.setFontScalar(new LinearFontScalar(20, 40));
+        wordCloud.build(wordFrequencies);
+        final JLabel wordCloudLabel = new JLabel(new ImageIcon(wordCloud.getBufferedImage()));
+        JDialog dialog = new JDialog(frame, "Word cloud for " + field);
+        dialog.add(wordCloudLabel);
+        dialog.pack();
+        dialog.setVisible(true);
+    }
+
+}


### PR DESCRIPTION
A totally not required feature, but still quite fun (or at least requested):

<img width="513" alt="capture22" src="https://cloud.githubusercontent.com/assets/8114497/17911021/f3207c10-698b-11e6-82e6-78d6925b0bef.PNG">

Try it out at https://builds.jabref.org/wordcloud 

Many things must be improved before I remove the [WIP]. Now it resides in the Tools menu as two hard coded items.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)

