### PR TITLE
Preview panel height is not saved after the PreferencesDialog has closed

### DIFF
--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -246,11 +246,6 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 LOGGER.warn("Could not register FileUpdateMonitor", ex);
             }
         }
-
-        // saves the divider position as soon as it changes
-        splitPane.addPropertyChangeListener(JSplitPane.DIVIDER_LOCATION_PROPERTY, propertyChangeEvent -> {
-            saveDividerLocation();
-        });
     }
 
     // Returns a collection of AutoCompleters, which are populated from the current database
@@ -1523,6 +1518,9 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         splitPane.revalidate();
         revalidate();
         repaint();
+
+        // saves the divider position as soon as it changes
+        splitPane.addPropertyChangeListener(JSplitPane.DIVIDER_LOCATION_PROPERTY, event -> saveDividerLocation());
     }
 
     public void updateSearchManager() {


### PR DESCRIPTION
Follow up to #1811.

I didn't consider that the splitpane is reinitialized each time the preferencesDialog is closed (then the listener would get lost and the divider position wouldn't get saved anymore).

This fixes that. 