### PR TITLE
Allow setting the etal-string empty. Implements #1841

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - [#1758](https://github.com/JabRef/jabref/issues/1758) Added a button to open Database Properties dialog help
 - Improve focus of the maintable after a sidepane gets closed (Before it would focus the toolbar or it would focus the wrong entry)
 - File open dialogs now use default extensions as primary file filter
+- [#1841](https://github.com/JabRef/jabref/issues/1841) The "etal"-string in the Authors layout formatter can now be empty
 
 ### Fixed
 - Fixed [#1760](https://github.com/JabRef/jabref/issues/1760): Preview updated correctly when selecting a single entry after selecting multiple entries

--- a/src/main/java/net/sf/jabref/logic/layout/format/Authors.java
+++ b/src/main/java/net/sf/jabref/logic/layout/format/Authors.java
@@ -198,7 +198,7 @@ public class Authors extends AbstractParamLayoutFormatter {
             } else if (comp(key, "LastSep") && !value.isEmpty()) {
                 lastSeparator = value;
             }
-        } else if ("etal".equalsIgnoreCase(key.trim()) && !value.isEmpty()) {
+        } else if ("etal".equalsIgnoreCase(key.trim())) {
             etAlString = value;
         } else if (Authors.NUMBER_PATTERN.matcher(key.trim()).matches()) {
             // Just a number:

--- a/src/test/java/net/sf/jabref/logic/layout/format/AuthorsTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/format/AuthorsTest.java
@@ -129,4 +129,12 @@ public class AuthorsTest {
         Assert.assertEquals("B C Bruce, C K von Manson and J Jumper",
                 a.format("Bruce, Bob Croydon and Charles Kermit von Manson and Jumper, Jolly"));
     }
+
+    @Test
+    public void testEmptyEtAl() {
+        ParamLayoutFormatter a = new Authors();
+        a.setArgument("fullname, LastFirst, Comma, 3, etal=");
+        Assert.assertEquals("Bruce, Bob Croydon",
+                a.format("Bob Croydon Bruce and Charles Manson and Jolly Jumper and Chuck Chuckles"));
+    }
 }


### PR DESCRIPTION
Earlier it was not allowed to set the etal-string in the Authors layout formatter to be empty. However, as clear from #1841 there is at least one use case for it and it is not obvious why it wasn't allowed earlier.

A side note: it is still not allowed to set Sep and LastSep empty. Maybe there are good reasons for that?

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)

