### PR TITLE
Removed Globals from BibDatabaseContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Fixed
 
 ### Removed
-
+- The non-supported feature of being able to define file directories for any extension is removed. Still, it should work for older databases using the legacy `ps` and `pdf` fields, although we strongly encourage using the `file` field. 
 
 
 

--- a/src/main/java/net/sf/jabref/BibDatabaseContext.java
+++ b/src/main/java/net/sf/jabref/BibDatabaseContext.java
@@ -10,6 +10,7 @@ import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.database.BibDatabaseModeDetection;
 import net.sf.jabref.model.database.DatabaseLocation;
+import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.shared.DBMSSynchronizer;
 
 /**
@@ -117,23 +118,28 @@ public class BibDatabaseContext {
         return getMode() == BibDatabaseMode.BIBLATEX;
     }
 
-    /**
-     * Look up the directory set up for the given field type for this database.
-     * If no directory is set up, return that defined in global preferences.
-     * There can be up to three directory definitions for these files:
-     * the database's metadata can specify a general directory and/or a user-specific directory
-     * or the preferences can specify one.
-     * <p>
-     * The settings are prioritized in the following order and the first defined setting is used:
-     * 1. metadata user-specific directory
-     * 2. metadata general directory
-     * 3. preferences directory
-     * 4. BIB file directory
-     *
-     * @param fieldName The field type
-     * @return The default directory for this field type.
-     */
     public List<String> getFileDirectory(FileDirectoryPreferences preferences) {
+        return getFileDirectory(FieldName.FILE, preferences);
+    }
+
+    /**
+    * Look up the directory set up for the given field type for this database.
+    * If no directory is set up, return that defined in global preferences.
+    * There can be up to three directory definitions for these files:
+    * the database's metadata can specify a general directory and/or a user-specific directory
+    * or the preferences can specify one.
+    * <p>
+    * The settings are prioritized in the following order and the first defined setting is used:
+    * 1. metadata user-specific directory
+    * 2. metadata general directory
+    * 3. preferences directory
+    * 4. BIB file directory
+    *
+    * @param
+    * @param fieldName The field type
+    * @return The default directory for this field type.
+    */
+    public List<String> getFileDirectory(String fieldName, FileDirectoryPreferences preferences) {
         List<String> fileDirs = new ArrayList<>();
 
         // 1. metadata user-specific directory
@@ -149,7 +155,7 @@ public class BibDatabaseContext {
         }
 
         // 3. preferences directory
-        preferences.getFieldDirectory().ifPresent(fileDirs::add);
+        preferences.getFileDirectory(fieldName).ifPresent(fileDirs::add);
 
         // 4. BIB file directory
         if (getDatabaseFile() != null) {

--- a/src/main/java/net/sf/jabref/BibDatabaseContext.java
+++ b/src/main/java/net/sf/jabref/BibDatabaseContext.java
@@ -6,13 +6,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import net.sf.jabref.logic.layout.format.FileLinkPreferences;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.database.BibDatabaseModeDetection;
 import net.sf.jabref.model.database.DatabaseLocation;
-import net.sf.jabref.model.entry.FieldName;
-import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.shared.DBMSSynchronizer;
 
 /**
@@ -136,11 +133,11 @@ public class BibDatabaseContext {
      * @param fieldName The field type
      * @return The default directory for this field type.
      */
-    public List<String> getFileDirectory(String fieldName) {
+    public List<String> getFileDirectory(FileDirectoryPreferences preferences) {
         List<String> fileDirs = new ArrayList<>();
 
         // 1. metadata user-specific directory
-        Optional<String> userFileDirectory = metaData.getUserFileDirectory(Globals.prefs.getUser());
+        Optional<String> userFileDirectory = metaData.getUserFileDirectory(preferences.getUser());
         if(userFileDirectory.isPresent()) {
             fileDirs.add(getFileDirectoryPath(userFileDirectory.get()));
         }
@@ -152,16 +149,13 @@ public class BibDatabaseContext {
         }
 
         // 3. preferences directory
-        String dir = Globals.prefs.get(fieldName + FileLinkPreferences.DIR_SUFFIX); // FILE_DIR
-        if (dir != null) {
-            fileDirs.add(dir);
-        }
+        preferences.getFieldDirectory().ifPresent(fileDirs::add);
 
         // 4. BIB file directory
         if (getDatabaseFile() != null) {
             String parentDir = getDatabaseFile().getParent();
             // Check if we should add it as primary file dir (first in the list) or not:
-            if (Globals.prefs.getBoolean(JabRefPreferences.BIB_LOC_AS_PRIMARY_DIR)) {
+            if (preferences.isBibLocationAsPrimary()) {
                 fileDirs.add(0, parentDir);
             } else {
                 fileDirs.add(parentDir);
@@ -190,10 +184,6 @@ public class BibDatabaseContext {
             }
         }
         return dir;
-    }
-
-    public List<String> getFileDirectory() {
-        return getFileDirectory(FieldName.FILE);
     }
 
     public DBMSSynchronizer getDBSynchronizer() {

--- a/src/main/java/net/sf/jabref/FileDirectoryPreferences.java
+++ b/src/main/java/net/sf/jabref/FileDirectoryPreferences.java
@@ -1,17 +1,20 @@
 package net.sf.jabref;
 
+import java.util.Map;
 import java.util.Optional;
+
+import net.sf.jabref.model.entry.FieldName;
 
 public class FileDirectoryPreferences {
     private final String user;
-    private final String fieldDirectory;
+    private final Map<String, String> fieldFileDirectories;
     private final boolean bibLocationAsPrimary;
-    private final String fieldName;
 
-    public FileDirectoryPreferences(String fieldName, String user, String fieldDirectory, boolean bibLocationAsPrimary) {
-        this.fieldName = fieldName;
+
+    public FileDirectoryPreferences(String user, Map<String, String> fieldFileDirectories,
+            boolean bibLocationAsPrimary) {
         this.user = user;
-        this.fieldDirectory = fieldDirectory;
+        this.fieldFileDirectories = fieldFileDirectories;
         this.bibLocationAsPrimary = bibLocationAsPrimary;
     }
 
@@ -19,15 +22,15 @@ public class FileDirectoryPreferences {
         return user;
     }
 
-    public Optional<String> getFieldDirectory() {
-        return Optional.ofNullable(fieldDirectory);
+    public Optional<String> getFileDirectory(String field) {
+        return Optional.ofNullable(fieldFileDirectories.get(field));
+    }
+
+    public Optional<String> getFileDirectory() {
+        return getFileDirectory(FieldName.FILE);
     }
 
     public boolean isBibLocationAsPrimary() {
         return bibLocationAsPrimary;
-    }
-
-    public String getFieldName() {
-        return fieldName;
     }
 }

--- a/src/main/java/net/sf/jabref/FileDirectoryPreferences.java
+++ b/src/main/java/net/sf/jabref/FileDirectoryPreferences.java
@@ -1,0 +1,33 @@
+package net.sf.jabref;
+
+import java.util.Optional;
+
+public class FileDirectoryPreferences {
+    private final String user;
+    private final String fieldDirectory;
+    private final boolean bibLocationAsPrimary;
+    private final String fieldName;
+
+    public FileDirectoryPreferences(String fieldName, String user, String fieldDirectory, boolean bibLocationAsPrimary) {
+        this.fieldName = fieldName;
+        this.user = user;
+        this.fieldDirectory = fieldDirectory;
+        this.bibLocationAsPrimary = bibLocationAsPrimary;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public Optional<String> getFieldDirectory() {
+        return Optional.ofNullable(fieldDirectory);
+    }
+
+    public boolean isBibLocationAsPrimary() {
+        return bibLocationAsPrimary;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+}

--- a/src/main/java/net/sf/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/net/sf/jabref/cli/ArgumentProcessor.java
@@ -372,7 +372,8 @@ public class ArgumentProcessor {
             }
             BibDatabaseContext databaseContext = pr.getDatabaseContext();
             databaseContext.setDatabaseFile(theFile);
-            Globals.prefs.fileDirForDatabase = databaseContext.getFileDirectory();
+            Globals.prefs.fileDirForDatabase = databaseContext
+                    .getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
             System.out.println(Localization.lang("Exporting") + ": " + data[0]);
             IExportFormat format = ExportFormats.getExportFormat(data[1]);
             if (format == null) {

--- a/src/main/java/net/sf/jabref/external/AutoSetLinks.java
+++ b/src/main/java/net/sf/jabref/external/AutoSetLinks.java
@@ -92,7 +92,7 @@ public class AutoSetLinks {
             public void run() {
                 // determine directories to search in
                 List<File> dirs = new ArrayList<>();
-                List<String> dirsS = databaseContext.getFileDirectory();
+                List<String> dirsS = databaseContext.getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
                 dirs.addAll(dirsS.stream().map(File::new).collect(Collectors.toList()));
 
                 // determine extensions

--- a/src/main/java/net/sf/jabref/external/DownloadExternalFile.java
+++ b/src/main/java/net/sf/jabref/external/DownloadExternalFile.java
@@ -147,7 +147,7 @@ public class DownloadExternalFile {
         }
 
         String suggestedName = getSuggestedFileName(suffix);
-        List<String> fDirectory = databaseContext.getFileDirectory();
+        List<String> fDirectory = databaseContext.getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
         String directory;
         if (fDirectory.isEmpty()) {
             directory = null;

--- a/src/main/java/net/sf/jabref/external/DroppedFileHandler.java
+++ b/src/main/java/net/sf/jabref/external/DroppedFileHandler.java
@@ -140,7 +140,10 @@ public class DroppedFileHandler {
         String destFilename;
 
         if (linkInPlace.isSelected()) {
-            destFilename = FileUtil.shortenFileName(new File(fileName), panel.getBibDatabaseContext().getFileDirectory()).toString();
+            destFilename = FileUtil
+                    .shortenFileName(new File(fileName),
+                            panel.getBibDatabaseContext().getFileDirectory(Globals.prefs.getFileDirectoryPreferences()))
+                    .toString();
         } else {
             destFilename = renameCheckBox.isSelected() ? renameToTextBox.getText() : new File(fileName).getName();
             if (copyRadioButton.isSelected()) {
@@ -190,7 +193,10 @@ public class DroppedFileHandler {
         NamedCompound edits = new NamedCompound(Localization.lang("Drop %0", fileType.getExtension()));
 
         if (linkInPlace.isSelected()) {
-            destFilename = FileUtil.shortenFileName(new File(fileName), panel.getBibDatabaseContext().getFileDirectory()).toString();
+            destFilename = FileUtil
+                    .shortenFileName(new File(fileName),
+                            panel.getBibDatabaseContext().getFileDirectory(Globals.prefs.getFileDirectoryPreferences()))
+                    .toString();
         } else {
             destFilename = renameCheckBox.isSelected() ? renameToTextBox.getText() : new File(fileName).getName();
             if (copyRadioButton.isSelected()) {
@@ -264,7 +270,10 @@ public class DroppedFileHandler {
         String destFilename;
 
         if (linkInPlace.isSelected()) {
-            destFilename = FileUtil.shortenFileName(new File(fileName), panel.getBibDatabaseContext().getFileDirectory()).toString();
+            destFilename = FileUtil
+                    .shortenFileName(new File(fileName),
+                            panel.getBibDatabaseContext().getFileDirectory(Globals.prefs.getFileDirectoryPreferences()))
+                    .toString();
         } else {
             if (renameCheckBox.isSelected()) {
                 destFilename = fileName;
@@ -301,7 +310,7 @@ public class DroppedFileHandler {
             BibDatabase database) {
 
         String dialogTitle = Localization.lang("Link to file %0", linkFileName);
-        List<String> dirs = panel.getBibDatabaseContext().getFileDirectory();
+        List<String> dirs = panel.getBibDatabaseContext().getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
         int found = -1;
         for (int i = 0; i < dirs.size(); i++) {
             if (new File(dirs.get(i)).exists()) {
@@ -388,7 +397,8 @@ public class DroppedFileHandler {
         // If avoidDuplicate==true, we should check if this file is already linked:
         if (avoidDuplicate) {
             // For comparison, find the absolute filename:
-            List<String> dirs = panel.getBibDatabaseContext().getFileDirectory();
+            List<String> dirs = panel.getBibDatabaseContext()
+                    .getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
             String absFilename;
             if (new File(filename).isAbsolute() || dirs.isEmpty()) {
                 absFilename = filename;
@@ -448,7 +458,7 @@ public class DroppedFileHandler {
      */
     private boolean doMove(String fileName, String destFilename,
                            NamedCompound edits) {
-        List<String> dirs = panel.getBibDatabaseContext().getFileDirectory();
+        List<String> dirs = panel.getBibDatabaseContext().getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
         int found = -1;
         for (int i = 0; i < dirs.size(); i++) {
             if (new File(dirs.get(i)).exists()) {
@@ -498,7 +508,7 @@ public class DroppedFileHandler {
      */
     private boolean doCopy(String fileName, String toFile, NamedCompound edits) {
 
-        List<String> dirs = panel.getBibDatabaseContext().getFileDirectory();
+        List<String> dirs = panel.getBibDatabaseContext().getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
         int found = -1;
         for (int i = 0; i < dirs.size(); i++) {
             if (new File(dirs.get(i)).exists()) {

--- a/src/main/java/net/sf/jabref/external/FindFullTextAction.java
+++ b/src/main/java/net/sf/jabref/external/FindFullTextAction.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 import javax.swing.JOptionPane;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.FileListTableModel;
 import net.sf.jabref.gui.undo.UndoableFieldChange;
@@ -53,7 +54,8 @@ public class FindFullTextAction extends AbstractWorker {
     @Override
     public void update() {
         if (result.isPresent()) {
-            List<String> dirs = basePanel.getBibDatabaseContext().getFileDirectory();
+            List<String> dirs = basePanel.getBibDatabaseContext()
+                    .getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
             if (dirs.isEmpty()) {
                 JOptionPane.showMessageDialog(basePanel.frame(),
                         Localization.lang("Main file directory not set!") + " " + Localization.lang("Preferences")

--- a/src/main/java/net/sf/jabref/external/MoveFileAction.java
+++ b/src/main/java/net/sf/jabref/external/MoveFileAction.java
@@ -69,7 +69,8 @@ public class MoveFileAction extends AbstractAction {
         }
 
         // Get an absolute path representation:
-        List<String> dirs = frame.getCurrentBasePanel().getBibDatabaseContext().getFileDirectory();
+        List<String> dirs = frame.getCurrentBasePanel().getBibDatabaseContext()
+                .getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
         int found = -1;
         for (int i = 0; i < dirs.size(); i++) {
             if (new File(dirs.get(i)).exists()) {

--- a/src/main/java/net/sf/jabref/external/SynchronizeFileField.java
+++ b/src/main/java/net/sf/jabref/external/SynchronizeFileField.java
@@ -137,7 +137,8 @@ public class SynchronizeFileField extends AbstractWorker {
                     tableModel.setContentDontGuessTypes(old.get());
 
                     // We need to specify which directories to search in for Util.expandFilename:
-                    List<String> dirsS = panel.getBibDatabaseContext().getFileDirectory();
+                    List<String> dirsS = panel.getBibDatabaseContext()
+                            .getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
                     List<File> dirs = new ArrayList<>();
                     for (String dirs1 : dirsS) {
                         dirs.add(new File(dirs1));
@@ -365,7 +366,7 @@ public class SynchronizeFileField extends AbstractWorker {
                 canceled = true;
             }
 
-            List<String> dirs = databaseContext.getFileDirectory();
+            List<String> dirs = databaseContext.getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
             if (dirs.isEmpty()) {
                 autoSetNone.setSelected(true);
                 autoSetNone.setEnabled(false);

--- a/src/main/java/net/sf/jabref/external/TransferableFileLinkSelection.java
+++ b/src/main/java/net/sf/jabref/external/TransferableFileLinkSelection.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.gui.BasePanel;
 import net.sf.jabref.gui.FileListTableModel;
 import net.sf.jabref.logic.util.io.FileUtil;
@@ -32,7 +33,8 @@ public class TransferableFileLinkSelection implements Transferable {
         selection.get(0).getFieldOptional(FieldName.FILE).ifPresent(tm::setContent);
         if (tm.getRowCount() > 0) {
             // Find the default directory for this field type, if any:
-            List<String> dirs = panel.getBibDatabaseContext().getFileDirectory();
+            List<String> dirs = panel.getBibDatabaseContext()
+                    .getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
             FileUtil.expandFilename(tm.getEntry(0).link, dirs).ifPresent(fileList::add);
         }
 

--- a/src/main/java/net/sf/jabref/external/WriteXMPAction.java
+++ b/src/main/java/net/sf/jabref/external/WriteXMPAction.java
@@ -121,11 +121,16 @@ public class WriteXMPAction extends AbstractWorker {
             List<File> files = new ArrayList<>();
 
             // First check the (legacy) "pdf" field:
-            entry.getFieldOptional(FieldName.PDF).ifPresent(pdf ->
-                FileUtil.expandFilename(pdf, panel.getBibDatabaseContext().getFileDirectory("pdf"))
-                    .ifPresent(files::add));
+            entry.getFieldOptional(FieldName.PDF)
+                    .ifPresent(
+                            pdf -> FileUtil
+                                    .expandFilename(pdf,
+                                            panel.getBibDatabaseContext().getFileDirectory(
+                                                    Globals.prefs.getFileDirectoryPreferences(FieldName.PDF)))
+                            .ifPresent(files::add));
             // Then check the "file" field:
-            List<String> dirs = panel.getBibDatabaseContext().getFileDirectory();
+            List<String> dirs = panel.getBibDatabaseContext()
+                    .getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
             if (entry.hasField(FieldName.FILE)) {
                 FileListTableModel tm = new FileListTableModel();
                 entry.getFieldOptional(FieldName.FILE).ifPresent(tm::setContent);

--- a/src/main/java/net/sf/jabref/external/WriteXMPAction.java
+++ b/src/main/java/net/sf/jabref/external/WriteXMPAction.java
@@ -125,8 +125,8 @@ public class WriteXMPAction extends AbstractWorker {
                     .ifPresent(
                             pdf -> FileUtil
                                     .expandFilename(pdf,
-                                            panel.getBibDatabaseContext().getFileDirectory(
-                                                    Globals.prefs.getFileDirectoryPreferences(FieldName.PDF)))
+                                            panel.getBibDatabaseContext().getFileDirectory(FieldName.PDF,
+                                                    Globals.prefs.getFileDirectoryPreferences()))
                             .ifPresent(files::add));
             // Then check the "file" field:
             List<String> dirs = panel.getBibDatabaseContext()

--- a/src/main/java/net/sf/jabref/external/WriteXMPEntryEditorAction.java
+++ b/src/main/java/net/sf/jabref/external/WriteXMPEntryEditorAction.java
@@ -55,11 +55,16 @@ public class WriteXMPEntryEditorAction extends AbstractAction {
         List<File> files = new ArrayList<>();
 
         // First check the (legacy) "pdf" field:
-        entry.getFieldOptional(FieldName.PDF).ifPresent(pdf -> FileUtil
-                .expandFilename(pdf, panel.getBibDatabaseContext().getFileDirectory("pdf")).ifPresent(files::add));
+        entry.getFieldOptional(FieldName.PDF)
+                .ifPresent(
+                        pdf -> FileUtil
+                                .expandFilename(pdf,
+                                        panel.getBibDatabaseContext().getFileDirectory(
+                                                Globals.prefs.getFileDirectoryPreferences(FieldName.PDF)))
+                        .ifPresent(files::add));
 
         // Then check the "file" field:
-        List<String> dirs = panel.getBibDatabaseContext().getFileDirectory();
+        List<String> dirs = panel.getBibDatabaseContext().getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
         if (entry.hasField(FieldName.FILE)) {
             FileListTableModel tm = new FileListTableModel();
             entry.getFieldOptional(FieldName.FILE).ifPresent(tm::setContent);

--- a/src/main/java/net/sf/jabref/external/WriteXMPEntryEditorAction.java
+++ b/src/main/java/net/sf/jabref/external/WriteXMPEntryEditorAction.java
@@ -56,12 +56,9 @@ public class WriteXMPEntryEditorAction extends AbstractAction {
 
         // First check the (legacy) "pdf" field:
         entry.getFieldOptional(FieldName.PDF)
-                .ifPresent(
-                        pdf -> FileUtil
-                                .expandFilename(pdf,
-                                        panel.getBibDatabaseContext().getFileDirectory(
-                                                Globals.prefs.getFileDirectoryPreferences(FieldName.PDF)))
-                        .ifPresent(files::add));
+                .ifPresent(pdf -> FileUtil.expandFilename(pdf, panel.getBibDatabaseContext()
+                        .getFileDirectory(FieldName.PDF, Globals.prefs.getFileDirectoryPreferences()))
+                .ifPresent(files::add));
 
         // Then check the "file" field:
         List<String> dirs = panel.getBibDatabaseContext().getFileDirectory(Globals.prefs.getFileDirectoryPreferences());

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -538,7 +538,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
         actions.put(Actions.OPEN_FOLDER, (BaseAction) () -> JabRefExecutorService.INSTANCE.execute(() -> {
             final List<File> files = FileUtil.getListOfLinkedFiles(mainTable.getSelectedEntries(),
-                    bibDatabaseContext.getFileDirectory());
+                    bibDatabaseContext.getFileDirectory(Globals.prefs.getFileDirectoryPreferences()));
             for (final File f : files) {
                 try {
                     JabRefDesktop.openFolderAndSelectFile(f.getAbsolutePath());
@@ -2358,12 +2358,10 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
             final Set<ExternalFileType> types = ExternalFileTypes.getInstance().getExternalFileTypeSelection();
             final List<File> dirs = new ArrayList<>();
-            if (!basePanel.getBibDatabaseContext().getFileDirectory().isEmpty()) {
-                final List<String> mdDirs = basePanel.getBibDatabaseContext().getFileDirectory();
-                for (final String mdDir : mdDirs) {
-                    dirs.add(new File(mdDir));
-
-                }
+            final List<String> mdDirs = basePanel.getBibDatabaseContext()
+                    .getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
+            for (final String mdDir : mdDirs) {
+                dirs.add(new File(mdDir));
             }
             final List<String> extensions = new ArrayList<>();
             for (final ExternalFileType type : types) {

--- a/src/main/java/net/sf/jabref/gui/FileListEntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/FileListEntryEditor.java
@@ -295,7 +295,7 @@ public class FileListEntryEditor {
         String link = "";
         // See if we should trim the file link to be relative to the file directory:
         try {
-            List<String> dirs = databaseContext.getFileDirectory();
+            List<String> dirs = databaseContext.getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
             if (dirs.isEmpty()) {
                 link = this.link.getText().trim();
             } else {
@@ -352,7 +352,7 @@ public class FileListEntryEditor {
             Globals.prefs.put(JabRefPreferences.FILE_WORKING_DIRECTORY, newFile.getPath());
 
             // If the file is below the file directory, make the path relative:
-            List<String> fileDirs = this.databaseContext.getFileDirectory();
+            List<String> fileDirs = this.databaseContext.getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
             newFile = FileUtil.shortenFileName(newFile, fileDirs);
 
             link.setText(newFile.getPath());

--- a/src/main/java/net/sf/jabref/gui/FileListEntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/FileListEntryEditor.java
@@ -335,7 +335,8 @@ public class FileListEntryEditor {
 
     private final ActionListener browsePressed = e -> {
         String filePath = link.getText().trim();
-        Optional<File> file = FileUtil.expandFilename(this.databaseContext, filePath);
+        Optional<File> file = FileUtil.expandFilename(this.databaseContext, filePath,
+                Globals.prefs.getFileDirectoryPreferences());
         String workingDir;
         // no file set yet or found
         if (file.isPresent()) {

--- a/src/main/java/net/sf/jabref/gui/actions/CleanupAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/CleanupAction.java
@@ -149,7 +149,8 @@ public class CleanupAction extends AbstractWorker {
         BibDatabaseContext bibDatabaseContext = panel.getBibDatabaseContext();
         CleanupWorker cleaner = new CleanupWorker(bibDatabaseContext,
                 Globals.prefs.get(JabRefPreferences.IMPORT_FILENAMEPATTERN),
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, Globals.journalAbbreviationLoader));
+                LayoutFormatterPreferences.fromPreferences(Globals.prefs, Globals.journalAbbreviationLoader),
+                Globals.prefs.getFileDirectoryPreferences());
         List<FieldChange> changes = cleaner.cleanup(preset, entry);
 
         unsuccessfulRenames = cleaner.getUnsuccessfulRenames();

--- a/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
@@ -19,6 +19,7 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.util.GUIUtil;
 import net.sf.jabref.logic.integrity.IntegrityCheck;
@@ -43,7 +44,8 @@ public class IntegrityCheckAction extends MnemonicAwareAction {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        IntegrityCheck check = new IntegrityCheck(frame.getCurrentBasePanel().getBibDatabaseContext());
+        IntegrityCheck check = new IntegrityCheck(frame.getCurrentBasePanel().getBibDatabaseContext(),
+                Globals.prefs.getFileDirectoryPreferences());
         List<IntegrityMessage> messages = check.checkBibtexDatabase();
 
         if (messages.isEmpty()) {

--- a/src/main/java/net/sf/jabref/gui/desktop/JabRefDesktop.java
+++ b/src/main/java/net/sf/jabref/gui/desktop/JabRefDesktop.java
@@ -61,7 +61,7 @@ public class JabRefDesktop {
         String fieldName = initialFieldName;
         if (FieldName.PS.equals(fieldName) || FieldName.PDF.equals(fieldName)) {
             // Find the default directory for this field type:
-            List<String> dir = databaseContext.getFileDirectory(fieldName);
+            List<String> dir = databaseContext.getFileDirectory(Globals.prefs.getFileDirectoryPreferences(fieldName));
 
             Optional<File> file = FileUtil.expandFilename(link, dir);
 

--- a/src/main/java/net/sf/jabref/gui/desktop/JabRefDesktop.java
+++ b/src/main/java/net/sf/jabref/gui/desktop/JabRefDesktop.java
@@ -61,7 +61,7 @@ public class JabRefDesktop {
         String fieldName = initialFieldName;
         if (FieldName.PS.equals(fieldName) || FieldName.PDF.equals(fieldName)) {
             // Find the default directory for this field type:
-            List<String> dir = databaseContext.getFileDirectory(Globals.prefs.getFileDirectoryPreferences(fieldName));
+            List<String> dir = databaseContext.getFileDirectory(fieldName, Globals.prefs.getFileDirectoryPreferences());
 
             Optional<File> file = FileUtil.expandFilename(link, dir);
 
@@ -144,7 +144,8 @@ public class JabRefDesktop {
         File file = new File(link);
 
         if (!httpLink) {
-            Optional<File> tmp = FileUtil.expandFilename(databaseContext, link);
+            Optional<File> tmp = FileUtil.expandFilename(databaseContext, link,
+                    Globals.prefs.getFileDirectoryPreferences());
             if (tmp.isPresent()) {
                 file = tmp.get();
             }

--- a/src/main/java/net/sf/jabref/gui/exporter/ExportAction.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/ExportAction.java
@@ -105,7 +105,7 @@ public class ExportAction {
                     // so formatters can resolve linked files correctly.
                     // (This is an ugly hack!)
                     Globals.prefs.fileDirForDatabase = frame.getCurrentBasePanel().getBibDatabaseContext()
-                            .getFileDirectory();
+                            .getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
 
                     // Make sure we remember which filter was used, to set
                     // the default for next time:

--- a/src/main/java/net/sf/jabref/gui/exporter/ExportToClipboardAction.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/ExportToClipboardAction.java
@@ -90,7 +90,7 @@ public class ExportToClipboardAction extends AbstractWorker {
         // so formatters can resolve linked files correctly.
         // (This is an ugly hack!)
         Globals.prefs.fileDirForDatabase = frame.getCurrentBasePanel().getBibDatabaseContext()
-                .getFileDirectory();
+                .getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
 
         File tmp = null;
         try {

--- a/src/main/java/net/sf/jabref/gui/fieldeditors/FileListEditor.java
+++ b/src/main/java/net/sf/jabref/gui/fieldeditors/FileListEditor.java
@@ -230,7 +230,8 @@ public class FileListEditor extends JTable implements FieldEditor, DownloadExter
 
                 FileListEntry entry = tableModel.getEntry(row);
                 // null if file does not exist
-                Optional<File> file = FileUtil.expandFilename(databaseContext, entry.link);
+                Optional<File> file = FileUtil.expandFilename(databaseContext, entry.link,
+                        Globals.prefs.getFileDirectoryPreferences());
 
                 // transactional delete and unlink
                 try {

--- a/src/main/java/net/sf/jabref/gui/fieldeditors/FileListEditor.java
+++ b/src/main/java/net/sf/jabref/gui/fieldeditors/FileListEditor.java
@@ -190,7 +190,8 @@ public class FileListEditor extends JTable implements FieldEditor, DownloadExter
                         path = Paths.get(entry.link).toString();
                     } else {
                         // relative to file folder
-                        for (String folder : databaseContext.getFileDirectory()) {
+                        for (String folder : databaseContext
+                                .getFileDirectory(Globals.prefs.getFileDirectoryPreferences())) {
                             Path file = Paths.get(folder, entry.link);
                             if (Files.exists(file)) {
                                 path = file.toString();
@@ -353,7 +354,7 @@ public class FileListEditor extends JTable implements FieldEditor, DownloadExter
     }
 
     private void addEntry() {
-        List<String> defaultDirectory = databaseContext.getFileDirectory();
+        List<String> defaultDirectory = databaseContext.getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
         if (defaultDirectory.isEmpty() || (defaultDirectory.get(0) == null)) {
             addEntry("");
         } else {

--- a/src/main/java/net/sf/jabref/gui/importer/EntryFromFileCreator.java
+++ b/src/main/java/net/sf/jabref/gui/importer/EntryFromFileCreator.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.StringTokenizer;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefGUI;
 import net.sf.jabref.external.ExternalFileType;
 import net.sf.jabref.external.ExternalFileTypes;
@@ -140,7 +141,8 @@ public abstract class EntryFromFileCreator implements FileFilter {
         Optional<ExternalFileType> fileType = ExternalFileTypes.getInstance()
                 .getExternalFileTypeByExt(externalFileType.getFieldName());
 
-        List<String> possibleFilePaths = JabRefGUI.getMainFrame().getCurrentBasePanel().getBibDatabaseContext().getFileDirectory();
+        List<String> possibleFilePaths = JabRefGUI.getMainFrame().getCurrentBasePanel().getBibDatabaseContext()
+                .getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
         File shortenedFileName = FileUtil.shortenFileName(file, possibleFilePaths);
         FileListEntry fileListEntry = new FileListEntry("", shortenedFileName.getPath(), fileType);
 

--- a/src/main/java/net/sf/jabref/gui/importer/UnlinkedPDFFileFilter.java
+++ b/src/main/java/net/sf/jabref/gui/importer/UnlinkedPDFFileFilter.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileFilter;
 
 import net.sf.jabref.BibDatabaseContext;
+import net.sf.jabref.Globals;
 import net.sf.jabref.logic.util.io.DatabaseFileLookup;
 import net.sf.jabref.model.database.BibDatabase;
 
@@ -28,7 +29,7 @@ public class UnlinkedPDFFileFilter implements FileFilter {
 
     public UnlinkedPDFFileFilter(FileFilter fileFilter, BibDatabaseContext databaseContext) {
         this.fileFilter = fileFilter;
-        this.lookup = new DatabaseFileLookup(databaseContext);
+        this.lookup = new DatabaseFileLookup(databaseContext, Globals.prefs.getFileDirectoryPreferences());
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/gui/worker/SendAsEMailAction.java
+++ b/src/main/java/net/sf/jabref/gui/worker/SendAsEMailAction.java
@@ -83,8 +83,8 @@ public class SendAsEMailAction extends AbstractWorker {
         //   the unofficial "mailto:attachment" property
         boolean openFolders = JabRefPreferences.getInstance().getBoolean(JabRefPreferences.OPEN_FOLDERS_OF_ATTACHED_FILES);
 
-        List<File> fileList = FileUtil.getListOfLinkedFiles(bes,
-                frame.getCurrentBasePanel().getBibDatabaseContext().getFileDirectory());
+        List<File> fileList = FileUtil.getListOfLinkedFiles(bes, frame.getCurrentBasePanel().getBibDatabaseContext()
+                .getFileDirectory(Globals.prefs.getFileDirectoryPreferences()));
         for (File f : fileList) {
             attachments.add(f.getPath());
             if (openFolders) {

--- a/src/main/java/net/sf/jabref/logic/cleanup/CleanupWorker.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/CleanupWorker.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Objects;
 
 import net.sf.jabref.BibDatabaseContext;
+import net.sf.jabref.FileDirectoryPreferences;
 import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;
@@ -16,14 +17,16 @@ public class CleanupWorker {
     private final BibDatabaseContext databaseContext;
     private final String fileNamePattern;
     private final LayoutFormatterPreferences prefs;
+    private final FileDirectoryPreferences fileDirectoryPreferences;
     private int unsuccessfulRenames;
 
 
-    public CleanupWorker(BibDatabaseContext databaseContext, String fileNamePattern,
-            LayoutFormatterPreferences prefs) {
+    public CleanupWorker(BibDatabaseContext databaseContext, String fileNamePattern, LayoutFormatterPreferences prefs,
+            FileDirectoryPreferences fileDirectoryPreferences) {
         this.databaseContext = databaseContext;
         this.fileNamePattern = fileNamePattern;
         this.prefs = prefs;
+        this.fileDirectoryPreferences = fileDirectoryPreferences;
     }
 
     public int getUnsuccessfulRenames() {
@@ -60,14 +63,14 @@ public class CleanupWorker {
             jobs.add(new FileLinksCleanup());
         }
         if (preset.isMovePDF()) {
-            jobs.add(new MoveFilesCleanup(databaseContext));
+            jobs.add(new MoveFilesCleanup(databaseContext, fileDirectoryPreferences));
         }
         if (preset.isMakePathsRelative()) {
-            jobs.add(new RelativePathsCleanup(databaseContext));
+            jobs.add(new RelativePathsCleanup(databaseContext, fileDirectoryPreferences));
         }
         if (preset.isRenamePDF()) {
             RenamePdfCleanup cleaner = new RenamePdfCleanup(preset.isRenamePdfOnlyRelativePaths(), databaseContext,
-                    fileNamePattern, prefs);
+                    fileNamePattern, prefs, fileDirectoryPreferences);
             jobs.add(cleaner);
             unsuccessfulRenames += cleaner.getUnsuccessfulRenames();
         }

--- a/src/main/java/net/sf/jabref/logic/cleanup/MoveFilesCleanup.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/MoveFilesCleanup.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import net.sf.jabref.BibDatabaseContext;
+import net.sf.jabref.FileDirectoryPreferences;
 import net.sf.jabref.logic.TypedBibEntry;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.FieldChange;
@@ -17,9 +18,12 @@ import net.sf.jabref.model.entry.ParsedFileField;
 public class MoveFilesCleanup implements CleanupJob {
 
     private final BibDatabaseContext databaseContext;
+    private final FileDirectoryPreferences fileDirectoryPreferences;
 
-    public MoveFilesCleanup(BibDatabaseContext databaseContext) {
+
+    public MoveFilesCleanup(BibDatabaseContext databaseContext, FileDirectoryPreferences fileDirectoryPreferences) {
         this.databaseContext = Objects.requireNonNull(databaseContext);
+        this.fileDirectoryPreferences = Objects.requireNonNull(fileDirectoryPreferences);
     }
 
     @Override
@@ -28,7 +32,7 @@ public class MoveFilesCleanup implements CleanupJob {
             return Collections.emptyList();
         }
 
-        List<String> paths = databaseContext.getFileDirectory();
+        List<String> paths = databaseContext.getFileDirectory(fileDirectoryPreferences);
         String defaultFileDirectory = databaseContext.getMetaData().getDefaultFileDirectory().get();
         Optional<File> targetDirectory = FileUtil.expandFilename(defaultFileDirectory, paths);
         if(!targetDirectory.isPresent()) {

--- a/src/main/java/net/sf/jabref/logic/cleanup/RelativePathsCleanup.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/RelativePathsCleanup.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import net.sf.jabref.BibDatabaseContext;
+import net.sf.jabref.FileDirectoryPreferences;
 import net.sf.jabref.logic.TypedBibEntry;
 import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.FieldChange;
@@ -17,9 +18,12 @@ import net.sf.jabref.model.entry.ParsedFileField;
 public class RelativePathsCleanup implements CleanupJob {
 
     private final BibDatabaseContext databaseContext;
+    private final FileDirectoryPreferences fileDirectoryPreferences;
 
-    public RelativePathsCleanup(BibDatabaseContext databaseContext) {
+
+    public RelativePathsCleanup(BibDatabaseContext databaseContext, FileDirectoryPreferences fileDirectoryPreferences) {
         this.databaseContext = Objects.requireNonNull(databaseContext);
+        this.fileDirectoryPreferences = Objects.requireNonNull(fileDirectoryPreferences);
     }
 
     @Override
@@ -31,7 +35,8 @@ public class RelativePathsCleanup implements CleanupJob {
 
         for (ParsedFileField fileEntry : fileList) {
             String oldFileName = fileEntry.getLink();
-            String newFileName = FileUtil.shortenFileName(new File(oldFileName), databaseContext.getFileDirectory())
+            String newFileName = FileUtil
+                    .shortenFileName(new File(oldFileName), databaseContext.getFileDirectory(fileDirectoryPreferences))
                     .toString();
 
             ParsedFileField newFileEntry = fileEntry;

--- a/src/main/java/net/sf/jabref/logic/cleanup/RenamePdfCleanup.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/RenamePdfCleanup.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import net.sf.jabref.BibDatabaseContext;
+import net.sf.jabref.FileDirectoryPreferences;
 import net.sf.jabref.logic.TypedBibEntry;
 import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.logic.util.OS;
@@ -22,16 +23,19 @@ public class RenamePdfCleanup implements CleanupJob {
     private final boolean onlyRelativePaths;
     private final String fileNamePattern;
     private final LayoutFormatterPreferences prefs;
+    private final FileDirectoryPreferences fileDirectoryPreferences;
 
     private int unsuccessfulRenames;
 
 
     public RenamePdfCleanup(boolean onlyRelativePaths, BibDatabaseContext databaseContext,
-            String fileNamePattern, LayoutFormatterPreferences prefs) {
+ String fileNamePattern,
+            LayoutFormatterPreferences prefs, FileDirectoryPreferences fileDirectoryPreferences) {
         this.databaseContext = Objects.requireNonNull(databaseContext);
         this.onlyRelativePaths = onlyRelativePaths;
         this.fileNamePattern = Objects.requireNonNull(fileNamePattern);
         this.prefs = Objects.requireNonNull(prefs);
+        this.fileDirectoryPreferences = fileDirectoryPreferences;
     }
 
     @Override
@@ -58,7 +62,7 @@ public class RenamePdfCleanup implements CleanupJob {
             //get new Filename with path
             //Create new Path based on old Path and new filename
             Optional<File> expandedOldFile = FileUtil.expandFilename(realOldFilename,
-                    databaseContext.getFileDirectory());
+                    databaseContext.getFileDirectory(fileDirectoryPreferences));
             if ((!expandedOldFile.isPresent()) || (expandedOldFile.get().getParent() == null)) {
                 // something went wrong. Just skip this entry
                 newFileList.add(flEntry);
@@ -91,7 +95,8 @@ public class RenamePdfCleanup implements CleanupJob {
                 // we cannot use "newPath" to generate a FileListEntry as newPath is absolute, but we want to keep relative paths whenever possible
                 File parent = (new File(realOldFilename)).getParentFile();
                 String newFileEntryFileName;
-                if ((parent == null) || databaseContext.getFileDirectory().contains(parent.getAbsolutePath())) {
+                if ((parent == null) || databaseContext.getFileDirectory(fileDirectoryPreferences)
+                        .contains(parent.getAbsolutePath())) {
                     newFileEntryFileName = newFilename.toString();
                 } else {
                     newFileEntryFileName = parent.toString().concat(OS.FILE_SEPARATOR).concat(newFilename.toString());

--- a/src/main/java/net/sf/jabref/logic/util/io/DatabaseFileLookup.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/DatabaseFileLookup.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import net.sf.jabref.BibDatabaseContext;
+import net.sf.jabref.FileDirectoryPreferences;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
@@ -34,9 +35,10 @@ public class DatabaseFileLookup {
      *
      * @param database A {@link BibDatabase}.
      */
-    public DatabaseFileLookup(BibDatabaseContext databaseContext) {
+    public DatabaseFileLookup(BibDatabaseContext databaseContext, FileDirectoryPreferences fileDirectoryPreferences) {
         Objects.requireNonNull(databaseContext);
-        possibleFilePaths = Optional.ofNullable(databaseContext.getFileDirectory()).orElse(new ArrayList<>());
+        possibleFilePaths = Optional.ofNullable(databaseContext.getFileDirectory(fileDirectoryPreferences))
+                .orElse(new ArrayList<>());
 
         for (BibEntry entry : databaseContext.getDatabase().getEntries()) {
             fileCache.addAll(parseFileField(entry));

--- a/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
@@ -21,6 +21,7 @@ import java.util.Vector;
 import java.util.regex.Pattern;
 
 import net.sf.jabref.BibDatabaseContext;
+import net.sf.jabref.Globals;
 import net.sf.jabref.logic.layout.Layout;
 import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.logic.layout.LayoutHelper;
@@ -168,9 +169,10 @@ public class FileUtil {
     public static Optional<File> expandFilename(final BibDatabaseContext databaseContext, String name) {
         Optional<String> extension = getFileExtension(name);
         // Find the default directory for this field type, if any:
-        List<String> directories = databaseContext.getFileDirectory(extension.orElse(null));
+        List<String> directories = databaseContext
+                .getFileDirectory(Globals.prefs.getFileDirectoryPreferences(extension.orElse(null)));
         // Include the standard "file" directory:
-        List<String> fileDir = databaseContext.getFileDirectory();
+        List<String> fileDir = databaseContext.getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
         // Include the directory of the BIB file:
         List<String> al = new ArrayList<>();
         for (String dir : directories) {

--- a/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
@@ -21,7 +21,7 @@ import java.util.Vector;
 import java.util.regex.Pattern;
 
 import net.sf.jabref.BibDatabaseContext;
-import net.sf.jabref.Globals;
+import net.sf.jabref.FileDirectoryPreferences;
 import net.sf.jabref.logic.layout.Layout;
 import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.logic.layout.LayoutHelper;
@@ -166,13 +166,13 @@ public class FileUtil {
      * @param databaseContext The database this file belongs to.
      * @param name     The filename, may also be a relative path to the file
      */
-    public static Optional<File> expandFilename(final BibDatabaseContext databaseContext, String name) {
+    public static Optional<File> expandFilename(final BibDatabaseContext databaseContext, String name,
+            FileDirectoryPreferences fileDirectoryPreferences) {
         Optional<String> extension = getFileExtension(name);
         // Find the default directory for this field type, if any:
-        List<String> directories = databaseContext
-                .getFileDirectory(Globals.prefs.getFileDirectoryPreferences(extension.orElse(null)));
+        List<String> directories = databaseContext.getFileDirectory(extension.orElse(null), fileDirectoryPreferences);
         // Include the standard "file" directory:
-        List<String> fileDir = databaseContext.getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
+        List<String> fileDir = databaseContext.getFileDirectory(fileDirectoryPreferences);
         // Include the directory of the BIB file:
         List<String> al = new ArrayList<>();
         for (String dir : directories) {

--- a/src/main/java/net/sf/jabref/migrations/FileLinksUpgradeWarning.java
+++ b/src/main/java/net/sf/jabref/migrations/FileLinksUpgradeWarning.java
@@ -65,7 +65,8 @@ public class FileLinksUpgradeWarning implements PostOpenAction {
         offerChangeDatabase = linksFound(pr.getDatabase(), FileLinksUpgradeWarning.FIELDS_TO_LOOK_FOR);
         // If the "file" directory is not set, offer to migrate pdf/ps dir:
         offerSetFileDir = !Globals.prefs.hasKey(FieldName.FILE + FileLinkPreferences.DIR_SUFFIX)
-                && (Globals.prefs.hasKey("pdfDirectory") || Globals.prefs.hasKey("psDirectory"));
+                && (Globals.prefs.hasKey(FieldName.PDF + FileLinkPreferences.DIR_SUFFIX)
+                        || Globals.prefs.hasKey(FieldName.PS + FileLinkPreferences.DIR_SUFFIX));
 
         // First check if this warning is disabled:
         return Globals.prefs.getBoolean(JabRefPreferences.SHOW_FILE_LINKS_UPGRADE_WARNING) && isThereSomethingToBeDone();
@@ -114,10 +115,10 @@ public class FileLinksUpgradeWarning implements PostOpenAction {
             formBuilder.add(changeDatabase).xy(1, row);
         }
         if (offerSetFileDir) {
-            if (Globals.prefs.hasKey("pdfDirectory")) {
-                fileDir.setText(Globals.prefs.get("pdfDirectory"));
+            if (Globals.prefs.hasKey(FieldName.PDF + FileLinkPreferences.DIR_SUFFIX)) {
+                fileDir.setText(Globals.prefs.get(FieldName.PDF + FileLinkPreferences.DIR_SUFFIX));
             } else {
-                fileDir.setText(Globals.prefs.get("psDirectory"));
+                fileDir.setText(Globals.prefs.get(FieldName.PS + FileLinkPreferences.DIR_SUFFIX));
             }
             JPanel builderPanel = new JPanel();
             builderPanel.add(setFileDir);

--- a/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
+++ b/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
@@ -199,7 +199,8 @@ public class PdfImporter {
         FileListTableModel tm = new FileListTableModel();
         File toLink = new File(fileName);
         // Get a list of file directories:
-        List<String> dirsS = panel.getBibDatabaseContext().getFileDirectory();
+        List<String> dirsS = panel.getBibDatabaseContext()
+                .getFileDirectory(Globals.prefs.getFileDirectoryPreferences());
 
         tm.addEntry(0, new FileListEntry(toLink.getName(), FileUtil.shortenFileName(toLink, dirsS).getPath(),
                 ExternalFileTypes.getInstance().getExternalFileTypeByName("PDF")));

--- a/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import javax.swing.JTable;
 import javax.swing.UIManager;
 
+import net.sf.jabref.FileDirectoryPreferences;
 import net.sf.jabref.JabRefException;
 import net.sf.jabref.JabRefMain;
 import net.sf.jabref.gui.desktop.JabRefDesktop;
@@ -50,6 +51,7 @@ import net.sf.jabref.logic.formatter.bibtexfields.NormalizePagesFormatter;
 import net.sf.jabref.logic.formatter.bibtexfields.UnitsToLatexFormatter;
 import net.sf.jabref.logic.formatter.casechanger.ProtectTermsFormatter;
 import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.layout.format.FileLinkPreferences;
 import net.sf.jabref.logic.openoffice.OpenOfficePreferences;
 import net.sf.jabref.logic.openoffice.StyleLoader;
 import net.sf.jabref.logic.protectedterms.ProtectedTermsLoader;
@@ -1373,6 +1375,15 @@ public class JabRefPreferences {
         if (!history.isEmpty()) {
             putStringList(RECENT_FILES, history.getHistory());
         }
+    }
+
+    public FileDirectoryPreferences getFileDirectoryPreferences() {
+        return getFileDirectoryPreferences(FieldName.FILE);
+    }
+
+    public FileDirectoryPreferences getFileDirectoryPreferences(String fieldName) {
+        return new FileDirectoryPreferences(fieldName, getUser(), get(fieldName + FileLinkPreferences.DIR_SUFFIX),
+                getBoolean(JabRefPreferences.BIB_LOC_AS_PRIMARY_DIR));
     }
 
     public UpdateFieldPreferences getUpdateFieldPreferences() {

--- a/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
@@ -1377,12 +1377,13 @@ public class JabRefPreferences {
         }
     }
 
-    public FileDirectoryPreferences getFileDirectoryPreferences() {
-        return getFileDirectoryPreferences(FieldName.FILE);
-    }
 
-    public FileDirectoryPreferences getFileDirectoryPreferences(String fieldName) {
-        return new FileDirectoryPreferences(fieldName, getUser(), get(fieldName + FileLinkPreferences.DIR_SUFFIX),
+    public FileDirectoryPreferences getFileDirectoryPreferences() {
+        List<String> fields = Arrays.asList(FieldName.FILE, FieldName.PDF, FieldName.PS);
+        Map<String, String> fieldDirectories = new HashMap<>();
+        fields.stream()
+                .forEach(fieldName -> fieldDirectories.put(fieldName, get(fieldName + FileLinkPreferences.DIR_SUFFIX)));
+        return new FileDirectoryPreferences(getUser(), fieldDirectories,
                 getBoolean(JabRefPreferences.BIB_LOC_AS_PRIMARY_DIR));
     }
 

--- a/src/test/java/net/sf/jabref/BibDatabaseContextTest.java
+++ b/src/test/java/net/sf/jabref/BibDatabaseContextTest.java
@@ -2,19 +2,12 @@ package net.sf.jabref;
 
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
-import net.sf.jabref.preferences.JabRefPreferences;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 public class BibDatabaseContextTest {
-
-    @Before
-    public void setUp() throws Exception {
-        Globals.prefs = JabRefPreferences.getInstance();
-    }
 
     @Test
     public void testTypeBasedOnDefaultBibtex() {

--- a/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
@@ -49,6 +49,7 @@ public class CleanupWorkerTest {
 
     @Before
     public void setUp() throws IOException {
+        // Needed for ExternalFileTypes
         if (Globals.prefs == null) {
             Globals.prefs = JabRefPreferences.getInstance();
         }
@@ -58,8 +59,9 @@ public class CleanupWorkerTest {
         MetaData metaData = new MetaData();
         metaData.setDefaultFileDirectory(pdfFolder.getAbsolutePath());
         BibDatabaseContext context = new BibDatabaseContext(new BibDatabase(), metaData, bibFolder.newFile("test.bib"));
-        worker = new CleanupWorker(context, Globals.prefs.get(JabRefPreferences.IMPORT_FILENAMEPATTERN),
-                mock(LayoutFormatterPreferences.class));
+        worker = new CleanupWorker(context,
+                JabRefPreferences.getInstance().get(JabRefPreferences.IMPORT_FILENAMEPATTERN),
+                mock(LayoutFormatterPreferences.class), JabRefPreferences.getInstance().getFileDirectoryPreferences());
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/net/sf/jabref/logic/cleanup/ISSNCleanupTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/ISSNCleanupTest.java
@@ -3,6 +3,7 @@ package net.sf.jabref.logic.cleanup;
 import java.util.Optional;
 
 import net.sf.jabref.BibDatabaseContext;
+import net.sf.jabref.FileDirectoryPreferences;
 import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.model.entry.BibEntry;
 
@@ -19,7 +20,8 @@ public class ISSNCleanupTest {
 
     @Before
     public void setUp() {
-        worker = new CleanupWorker(mock(BibDatabaseContext.class), "", mock(LayoutFormatterPreferences.class));
+        worker = new CleanupWorker(mock(BibDatabaseContext.class), "", mock(LayoutFormatterPreferences.class),
+                mock(FileDirectoryPreferences.class));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/cleanup/MoveFilesCleanupTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/MoveFilesCleanupTest.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import net.sf.jabref.BibDatabaseContext;
-import net.sf.jabref.Globals;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
@@ -34,14 +33,12 @@ public class MoveFilesCleanupTest {
 
     @Before
     public void setUp() throws IOException {
-        Globals.prefs = JabRefPreferences.getInstance();
-
         pdfFolder = bibFolder.newFolder();
         MetaData metaData = new MetaData();
         metaData.setDefaultFileDirectory(pdfFolder.getAbsolutePath());
         databaseContext = new BibDatabaseContext(new BibDatabase(), metaData, bibFolder.newFile("test.bib"));
 
-        cleanup = new MoveFilesCleanup(databaseContext);
+        cleanup = new MoveFilesCleanup(databaseContext, JabRefPreferences.getInstance().getFileDirectoryPreferences());
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/cleanup/RenamePdfCleanupTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/RenamePdfCleanupTest.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Defaults;
-import net.sf.jabref.Globals;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
@@ -31,11 +30,11 @@ public class RenamePdfCleanupTest {
     public TemporaryFolder testFolder = new TemporaryFolder();
     private BibDatabaseContext context;
     private BibEntry entry;
+    private JabRefPreferences prefs;
 
     @Before
     public void setUp() throws Exception {
-        Globals.prefs = mock(JabRefPreferences.class);
-
+        prefs = JabRefPreferences.getInstance();
         MetaData metaData = new MetaData();
         context = new BibDatabaseContext(new BibDatabase(), metaData, new Defaults());
         context.setDatabaseFile(testFolder.newFile("test.bib"));
@@ -55,7 +54,7 @@ public class RenamePdfCleanupTest {
         entry.setField("file", FileField.getStringRepresentation(fileField));
 
         RenamePdfCleanup cleanup = new RenamePdfCleanup(false, context, fileNamePattern,
-                mock(LayoutFormatterPreferences.class));
+                mock(LayoutFormatterPreferences.class), prefs.getFileDirectoryPreferences());
         cleanup.cleanup(entry);
 
         ParsedFileField newFileField = new ParsedFileField("", "Toot.tmp", "");
@@ -72,7 +71,7 @@ public class RenamePdfCleanupTest {
                 new ParsedFileField("", tempFile.getAbsolutePath(), ""), new ParsedFileField("","",""))));
 
         RenamePdfCleanup cleanup = new RenamePdfCleanup(false, context, fileNamePattern,
-                mock(LayoutFormatterPreferences.class));
+                mock(LayoutFormatterPreferences.class), prefs.getFileDirectoryPreferences());
         cleanup.cleanup(entry);
 
         assertEquals(
@@ -90,7 +89,7 @@ public class RenamePdfCleanupTest {
         entry.setField("title", "test title");
 
         RenamePdfCleanup cleanup = new RenamePdfCleanup(false, context, fileNamePattern,
-                mock(LayoutFormatterPreferences.class));
+                mock(LayoutFormatterPreferences.class), prefs.getFileDirectoryPreferences());
         cleanup.cleanup(entry);
 
         ParsedFileField newFileField = new ParsedFileField("", "Toot - test title.tmp", "");
@@ -106,7 +105,8 @@ public class RenamePdfCleanupTest {
         entry.setField("title", "test title");
 
         RenamePdfCleanup cleanup = new RenamePdfCleanup(false, context, fileNamePattern,
-                LayoutFormatterPreferences.fromPreferences(Globals.prefs, mock(JournalAbbreviationLoader.class)));
+                LayoutFormatterPreferences.fromPreferences(prefs, mock(JournalAbbreviationLoader.class)),
+                prefs.getFileDirectoryPreferences());
         cleanup.cleanup(entry);
 
         ParsedFileField newFileField = new ParsedFileField("", "Toot - test title.pdf", "PDF");

--- a/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -10,7 +10,6 @@ import java.util.Scanner;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Defaults;
-import net.sf.jabref.Globals;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.logic.cleanup.FieldFormatterCleanup;
 import net.sf.jabref.logic.config.SaveOrderConfig;
@@ -49,10 +48,11 @@ public class BibtexDatabaseWriterTest {
     private MetaData metaData;
     private BibDatabaseContext bibtexContext;
     private ImportFormatPreferences importFormatPreferences;
+    private JabRefPreferences prefs;
 
     @Before
     public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
+        prefs = JabRefPreferences.getInstance();
 
         // Write to a string instead of to a file
         databaseWriter = new BibtexDatabaseWriter<>(StringSaveSession::new);
@@ -60,7 +60,7 @@ public class BibtexDatabaseWriterTest {
         database = new BibDatabase();
         metaData = new MetaData();
         bibtexContext = new BibDatabaseContext(database, metaData, new Defaults(BibDatabaseMode.BIBTEX));
-        importFormatPreferences = ImportFormatPreferences.fromPreferences(Globals.prefs);
+        importFormatPreferences = ImportFormatPreferences.fromPreferences(prefs);
     }
 
     @Test(expected = NullPointerException.class)
@@ -159,7 +159,7 @@ public class BibtexDatabaseWriterTest {
 
     @Test
     public void writeMetadata() throws Exception {
-        DatabaseBibtexKeyPattern bibtexKeyPattern = new DatabaseBibtexKeyPattern(Globals.prefs.getKeyPattern());
+        DatabaseBibtexKeyPattern bibtexKeyPattern = new DatabaseBibtexKeyPattern(prefs.getKeyPattern());
         bibtexKeyPattern.setDefaultValue("test");
         metaData.setBibtexKeyPattern(bibtexKeyPattern);
 
@@ -172,7 +172,7 @@ public class BibtexDatabaseWriterTest {
     @Test
     public void writeMetadataAndEncoding() throws Exception {
         SavePreferences preferences = new SavePreferences().withEncoding(Charsets.US_ASCII);
-        DatabaseBibtexKeyPattern bibtexKeyPattern = new DatabaseBibtexKeyPattern(Globals.prefs.getKeyPattern());
+        DatabaseBibtexKeyPattern bibtexKeyPattern = new DatabaseBibtexKeyPattern(prefs.getKeyPattern());
         bibtexKeyPattern.setDefaultValue("test");
         metaData.setBibtexKeyPattern(bibtexKeyPattern);
 
@@ -186,7 +186,7 @@ public class BibtexDatabaseWriterTest {
     @Test
     public void writeGroups() throws Exception {
         GroupTreeNode groupRoot = GroupTreeNode.fromGroup(new AllEntriesGroup());
-        groupRoot.addSubgroup(new ExplicitGroup("test", GroupHierarchyType.INCLUDING, Globals.prefs));
+        groupRoot.addSubgroup(new ExplicitGroup("test", GroupHierarchyType.INCLUDING, prefs));
         metaData.setGroups(groupRoot);
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
@@ -205,8 +205,7 @@ public class BibtexDatabaseWriterTest {
         SavePreferences preferences = new SavePreferences().withEncoding(Charsets.US_ASCII);
 
         GroupTreeNode groupRoot = GroupTreeNode.fromGroup(new AllEntriesGroup());
-        groupRoot.addChild(
-                GroupTreeNode.fromGroup(new ExplicitGroup("test", GroupHierarchyType.INCLUDING, Globals.prefs)));
+        groupRoot.addChild(GroupTreeNode.fromGroup(new ExplicitGroup("test", GroupHierarchyType.INCLUDING, prefs)));
         metaData.setGroups(groupRoot);
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);
@@ -429,7 +428,7 @@ public class BibtexDatabaseWriterTest {
 
     @Test
     public void writeCustomKeyPattern() throws Exception {
-        AbstractBibtexKeyPattern pattern = new DatabaseBibtexKeyPattern(Globals.prefs.getKeyPattern());
+        AbstractBibtexKeyPattern pattern = new DatabaseBibtexKeyPattern(prefs.getKeyPattern());
         pattern.setDefaultValue("test");
         pattern.addBibtexKeyPattern("article", "articleTest");
         metaData.setBibtexKeyPattern(pattern);

--- a/src/test/java/net/sf/jabref/logic/exporter/ExportFormatTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/ExportFormatTest.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 
 import net.sf.jabref.BibDatabaseContext;
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.model.entry.BibEntry;
@@ -76,14 +75,14 @@ public class ExportFormatTest {
     @Parameterized.Parameters(name = "{index}: {1}")
     public static Collection<Object[]> exportFormats() {
         Collection<Object[]> result = new ArrayList<>();
-        Globals.prefs = JabRefPreferences.getInstance();
+        JabRefPreferences prefs = JabRefPreferences.getInstance();
         JournalAbbreviationLoader journalAbbreviationLoader = new JournalAbbreviationLoader();
 
-        Map<String, ExportFormat> customFormats = Globals.prefs.customExports.getCustomExportFormats(Globals.prefs,
+        Map<String, ExportFormat> customFormats = prefs.customExports.getCustomExportFormats(prefs,
                 journalAbbreviationLoader);
-        LayoutFormatterPreferences layoutPreferences = LayoutFormatterPreferences.fromPreferences(Globals.prefs,
+        LayoutFormatterPreferences layoutPreferences = LayoutFormatterPreferences.fromPreferences(prefs,
                 journalAbbreviationLoader);
-        SavePreferences savePreferences = SavePreferences.loadForExportFromPreferences(Globals.prefs);
+        SavePreferences savePreferences = SavePreferences.loadForExportFromPreferences(prefs);
         ExportFormats.initAllExports(customFormats, layoutPreferences, savePreferences);
 
         for (IExportFormat format : ExportFormats.getExportFormats().values()) {

--- a/src/test/java/net/sf/jabref/logic/exporter/HtmlExportFormatTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/HtmlExportFormatTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 
 import net.sf.jabref.BibDatabaseContext;
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.logic.layout.LayoutFormatterPreferences;
 import net.sf.jabref.model.entry.BibEntry;
@@ -34,13 +33,13 @@ public class HtmlExportFormatTest {
 
     @Before
     public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance();
+        JabRefPreferences prefs = JabRefPreferences.getInstance();
         JournalAbbreviationLoader journalAbbreviationLoader = new JournalAbbreviationLoader();
-        Map<String, ExportFormat> customFormats = Globals.prefs.customExports.getCustomExportFormats(Globals.prefs,
+        Map<String, ExportFormat> customFormats = prefs.customExports.getCustomExportFormats(prefs,
                 journalAbbreviationLoader);
-        LayoutFormatterPreferences layoutPreferences = LayoutFormatterPreferences.fromPreferences(Globals.prefs,
+        LayoutFormatterPreferences layoutPreferences = LayoutFormatterPreferences.fromPreferences(prefs,
                 journalAbbreviationLoader);
-        SavePreferences savePreferences = SavePreferences.loadForExportFromPreferences(Globals.prefs);
+        SavePreferences savePreferences = SavePreferences.loadForExportFromPreferences(prefs);
         ExportFormats.initAllExports(customFormats, layoutPreferences, savePreferences);
 
         exportFormat = ExportFormats.getExportFormat("html");

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 
 import net.sf.jabref.BibDatabaseContext;
 import net.sf.jabref.Defaults;
-import net.sf.jabref.Globals;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
@@ -17,7 +16,6 @@ import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.InternalBibtexFields;
 import net.sf.jabref.preferences.JabRefPreferences;
 
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -31,13 +29,6 @@ public class IntegrityCheckTest {
 
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
-
-
-    @Before
-    public void setUp() {
-        // Needed for FileUtil.expandFilename
-        Globals.prefs = JabRefPreferences.getInstance();
-    }
 
     @Test
     public void testUrlChecks() {
@@ -244,12 +235,15 @@ public class IntegrityCheckTest {
     }
 
     private void assertWrong(BibDatabaseContext context) {
-        List<IntegrityMessage> messages = new IntegrityCheck(context).checkBibtexDatabase();
+        List<IntegrityMessage> messages = new IntegrityCheck(context,
+                JabRefPreferences.getInstance().getFileDirectoryPreferences())
+                .checkBibtexDatabase();
         assertFalse(messages.toString(), messages.isEmpty());
     }
 
     private void assertCorrect(BibDatabaseContext context) {
-        List<IntegrityMessage> messages = new IntegrityCheck(context).checkBibtexDatabase();
+        List<IntegrityMessage> messages = new IntegrityCheck(context,
+                JabRefPreferences.getInstance().getFileDirectoryPreferences()).checkBibtexDatabase();
         assertEquals(Collections.emptyList(), messages);
     }
 

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -32,8 +32,10 @@ public class IntegrityCheckTest {
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
 
+
     @Before
     public void setUp() {
+        // Needed for FileUtil.expandFilename
         Globals.prefs = JabRefPreferences.getInstance();
     }
 


### PR DESCRIPTION
This almost worked. The penalty was that I had to (temporarily) introduce it in `FileUtil.expandFilename` where the arbitrary extension line makes it extremely cumbersome to get around it.
