### PR TITLE
Fixed NPE when loading a style file that has no default style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed NullPointerException when clicking Browse in Journal abbreviations with empty text field
 - Fixed NullPointerException when opening file in Plain text import
 - Fixed NullPointerException when appending database
+- Fixed NullPointerException when loading a style file that has not got a default style
 - Fixed [#636](https://github.com/JabRef/jabref/issues/636): DOI in export filters
 - Fixed [#1519](https://github.com/JabRef/jabref/issues/1519): The word "Seiten" is automatically removed when fetching info from ISBN
 - Fixed [#1527](https://github.com/JabRef/jabref/issues/1527): 'Get BibTeX data from DOI' Removes Marking

--- a/src/main/java/net/sf/jabref/gui/PreviewPanel.java
+++ b/src/main/java/net/sf/jabref/gui/PreviewPanel.java
@@ -222,7 +222,7 @@ public class PreviewPanel extends JPanel
     }
 
     public void setLayout(Layout layout) {
-        this.layout = Optional.of(layout);
+        this.layout = Optional.ofNullable(layout);
     }
 
     public void setEntry(BibEntry newEntry) {


### PR DESCRIPTION
Found when trying #1841 although non-related.

- [x] Change in CHANGELOG.md described
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)

