### PR TITLE
Removed last Globals dependency in MetaData

### DIFF
--- a/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
+++ b/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
@@ -123,7 +123,7 @@ public class Benchmarks {
     @Benchmark
     public boolean keywordGroupContains() throws ParseException {
         KeywordGroup group = new KeywordGroup("testGroup", "keyword", "testkeyword", false, false,
-                GroupHierarchyType.INDEPENDENT, Globals.prefs);
+                GroupHierarchyType.INDEPENDENT, Globals.prefs.get(JabRefPreferences.KEYWORD_SEPARATOR));
         return group.containsAll(database.getEntries());
     }
 

--- a/src/main/java/net/sf/jabref/MetaData.java
+++ b/src/main/java/net/sf/jabref/MetaData.java
@@ -66,12 +66,13 @@ public class MetaData implements Iterable<String> {
      * must simply make sure the appropriate changes are reflected in the Vector
      * it has been passed.
      */
-    private MetaData(Map<String, String> inData) throws ParseException {
+    private MetaData(Map<String, String> inData, String keywordSeparator) throws ParseException {
         Objects.requireNonNull(inData);
-        setData(inData);
+        setData(inData, keywordSeparator);
     }
-    private MetaData(Map<String, String> inData, Charset encoding) throws ParseException {
-        this(inData);
+
+    private MetaData(Map<String, String> inData, Charset encoding, String keywordSeparator) throws ParseException {
+        this(inData, keywordSeparator);
         this.encoding = Objects.requireNonNull(encoding);
     }
 
@@ -86,15 +87,16 @@ public class MetaData implements Iterable<String> {
         this.encoding = encoding;
     }
 
-    public static MetaData parse(Map<String, String> data) throws ParseException {
-        return new MetaData(data);
+    public static MetaData parse(Map<String, String> data, String keywordSeparator) throws ParseException {
+        return new MetaData(data, keywordSeparator);
     }
 
-    public static MetaData parse(Map<String, String> data, Charset encoding) throws ParseException {
-        return new MetaData(data, encoding);
+    public static MetaData parse(Map<String, String> data, Charset encoding, String keywordSeparator)
+            throws ParseException {
+        return new MetaData(data, encoding, keywordSeparator);
     }
 
-    public void setData(Map<String, String> inData) throws ParseException {
+    public void setData(Map<String, String> inData, String keywordSeparator) throws ParseException {
         clearMetaData();
         for (Map.Entry<String, String> entry : inData.entrySet()) {
             StringReader data = new StringReader(entry.getValue());
@@ -109,7 +111,7 @@ public class MetaData implements Iterable<String> {
                 LOGGER.error("Weird error while parsing meta data.", ex);
             }
             if (GROUPSTREE.equals(entry.getKey())) {
-                putGroups(orderedData);
+                putGroups(orderedData, keywordSeparator);
                 // the keys "groupsversion" and "groups" were used in JabRef versions around 1.3, we will not support them anymore
                 eventBus.post(new GroupUpdatedEvent(this));
             } else if (SAVE_ACTIONS.equals(entry.getKey())) {
@@ -186,9 +188,9 @@ public class MetaData implements Iterable<String> {
      *
      * @param orderedData The vector of metadata strings
      */
-    private void putGroups(List<String> orderedData) throws ParseException {
+    private void putGroups(List<String> orderedData, String keywordSeparator) throws ParseException {
         try {
-            groupsRoot = GroupTreeNode.parse(orderedData, Globals.prefs);
+            groupsRoot = GroupTreeNode.parse(orderedData, keywordSeparator);
             eventBus.post(new GroupUpdatedEvent(this));
         } catch (ParseException e) {
             throw new ParseException(Localization.lang(

--- a/src/main/java/net/sf/jabref/gui/actions/ManageKeywordsAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/ManageKeywordsAction.java
@@ -286,7 +286,7 @@ public class ManageKeywordsAction extends MnemonicAwareAction {
             return;
         }
 
-        if (SpecialFieldsUtils.keywordSyncEnabled() && !keywordsToAdd.isEmpty()) {
+        if (Globals.prefs.isKeywordSyncEnabled() && !keywordsToAdd.isEmpty()) {
             synchronizeSpecialFields(keywordsToAdd, keywordsToRemove);
         }
 
@@ -312,7 +312,7 @@ public class ManageKeywordsAction extends MnemonicAwareAction {
                 ce.addEdit(new UndoableFieldChange(change.get()));
             }
 
-            if (SpecialFieldsUtils.keywordSyncEnabled()) {
+            if (Globals.prefs.isKeywordSyncEnabled()) {
                 SpecialFieldsUtils.syncSpecialFieldsFromKeywords(entry, ce);
             }
         }

--- a/src/main/java/net/sf/jabref/gui/groups/AutoGroupDialog.java
+++ b/src/main/java/net/sf/jabref/gui/groups/AutoGroupDialog.java
@@ -36,6 +36,7 @@ import net.sf.jabref.logic.importer.util.ParseException;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.layout.format.LatexToUnicodeFormatter;
 import net.sf.jabref.model.entry.FieldName;
+import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import com.jgoodies.forms.builder.FormBuilder;
@@ -82,7 +83,8 @@ class AutoGroupDialog extends JDialog implements CaretListener {
                 try {
                     GroupTreeNode autoGroupsRoot = GroupTreeNode.fromGroup(
                             new ExplicitGroup(Localization.lang("Automatically created groups"),
-                                    GroupHierarchyType.INCLUDING, Globals.prefs));
+                                    GroupHierarchyType.INCLUDING,
+                                    Globals.prefs.get(JabRefPreferences.KEYWORD_SEPARATOR)));
                     Set<String> hs;
                     String fieldText = field.getText();
                     if (keywords.isSelected()) {
@@ -110,7 +112,7 @@ class AutoGroupDialog extends JDialog implements CaretListener {
 
                     for (String keyword : hs) {
                         KeywordGroup group = new KeywordGroup(formatter.format(keyword), fieldText, keyword, false, false,
-                                GroupHierarchyType.INDEPENDENT, Globals.prefs);
+                                GroupHierarchyType.INDEPENDENT, Globals.prefs.get(JabRefPreferences.KEYWORD_SEPARATOR));
                         autoGroupsRoot.addChild(GroupTreeNode.fromGroup(group));
                     }
 

--- a/src/main/java/net/sf/jabref/gui/groups/GroupDialog.java
+++ b/src/main/java/net/sf/jabref/gui/groups/GroupDialog.java
@@ -265,14 +265,15 @@ class GroupDialog extends JDialog {
                 isOkPressed = true;
             try {
                 if (explicitRadioButton.isSelected()) {
-                    resultingGroup = new ExplicitGroup(nameField.getText().trim(), getContext(), Globals.prefs);
+                    resultingGroup = new ExplicitGroup(nameField.getText().trim(), getContext(),
+                            Globals.prefs.get(JabRefPreferences.KEYWORD_SEPARATOR));
                 } else if (keywordsRadioButton.isSelected()) {
                     // regex is correct, otherwise OK would have been disabled
                     // therefore I don't catch anything here
-                    resultingGroup = new KeywordGroup(nameField.getText().trim(), keywordGroupSearchField.getText().trim(),
-                            keywordGroupSearchTerm.getText().trim(), keywordGroupCaseSensitive.isSelected(), keywordGroupRegExp
-                            .isSelected(),
-                            getContext(), Globals.prefs);
+                    resultingGroup = new KeywordGroup(nameField.getText().trim(),
+                            keywordGroupSearchField.getText().trim(), keywordGroupSearchTerm.getText().trim(),
+                            keywordGroupCaseSensitive.isSelected(), keywordGroupRegExp.isSelected(), getContext(),
+                            Globals.prefs.get(JabRefPreferences.KEYWORD_SEPARATOR));
                 } else if (searchRadioButton.isSelected()) {
                     try {
                         // regex is correct, otherwise OK would have been

--- a/src/main/java/net/sf/jabref/gui/importer/actions/AppendDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/importer/actions/AppendDatabaseAction.java
@@ -141,7 +141,7 @@ public class AppendDatabaseAction implements BaseAction {
                     // create a dummy group
                     try {
                         ExplicitGroup group = new ExplicitGroup("Imported", GroupHierarchyType.INDEPENDENT,
-                                Globals.prefs);
+                                Globals.prefs.get(JabRefPreferences.KEYWORD_SEPARATOR));
                         newGroups.setGroup(group);
                         group.add(appendedEntries);
                     } catch (ParseException e) {

--- a/src/main/java/net/sf/jabref/logic/groups/AbstractGroup.java
+++ b/src/main/java/net/sf/jabref/logic/groups/AbstractGroup.java
@@ -8,7 +8,6 @@ import net.sf.jabref.logic.importer.util.ParseException;
 import net.sf.jabref.logic.search.SearchMatcher;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * A group of BibtexEntries.
@@ -48,9 +47,9 @@ public abstract class AbstractGroup implements SearchMatcher {
      * @throws ParseException If an error occurred and a group could not be created,
      *                        e.g. due to a malformed regular expression.
      */
-    public static AbstractGroup fromString(String s, JabRefPreferences jabRefPreferences) throws ParseException {
+    public static AbstractGroup fromString(String s, String keywordSeparator) throws ParseException {
         if (s.startsWith(KeywordGroup.ID)) {
-            return KeywordGroup.fromString(s, jabRefPreferences);
+            return KeywordGroup.fromString(s, keywordSeparator);
         }
         if (s.startsWith(AllEntriesGroup.ID)) {
             return AllEntriesGroup.fromString(s);
@@ -59,7 +58,7 @@ public abstract class AbstractGroup implements SearchMatcher {
             return SearchGroup.fromString(s);
         }
         if (s.startsWith(ExplicitGroup.ID)) {
-            return ExplicitGroup.fromString(s, jabRefPreferences);
+            return ExplicitGroup.fromString(s, keywordSeparator);
         }
         return null; // unknown group
     }

--- a/src/main/java/net/sf/jabref/logic/groups/ExplicitGroup.java
+++ b/src/main/java/net/sf/jabref/logic/groups/ExplicitGroup.java
@@ -11,6 +11,7 @@ import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.strings.QuotedStringTokenizer;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.FieldName;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/src/main/java/net/sf/jabref/logic/groups/ExplicitGroup.java
+++ b/src/main/java/net/sf/jabref/logic/groups/ExplicitGroup.java
@@ -11,8 +11,6 @@ import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.strings.QuotedStringTokenizer;
 import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.entry.FieldName;
-import net.sf.jabref.preferences.JabRefPreferences;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -29,12 +27,13 @@ public class ExplicitGroup extends KeywordGroup {
 
     private static final Log LOGGER = LogFactory.getLog(ExplicitGroup.class);
 
-    public ExplicitGroup(String name, GroupHierarchyType context, JabRefPreferences jabRefPreferences)
+
+    public ExplicitGroup(String name, GroupHierarchyType context, String keywordSeparator)
             throws ParseException {
-        super(name, FieldName.GROUPS, name, true, false, context, jabRefPreferences);
+        super(name, FieldName.GROUPS, name, true, false, context, keywordSeparator);
     }
 
-    public static ExplicitGroup fromString(String s, JabRefPreferences jabRefPreferences) throws ParseException {
+    public static ExplicitGroup fromString(String s, String keywordSeparator) throws ParseException {
         if (!s.startsWith(ExplicitGroup.ID)) {
             throw new IllegalArgumentException("ExplicitGroup cannot be created from \"" + s + "\".");
         }
@@ -43,7 +42,7 @@ public class ExplicitGroup extends KeywordGroup {
 
         String name = tok.nextToken();
         int context = Integer.parseInt(tok.nextToken());
-        ExplicitGroup newGroup = new ExplicitGroup(name, GroupHierarchyType.getByNumber(context), jabRefPreferences);
+        ExplicitGroup newGroup = new ExplicitGroup(name, GroupHierarchyType.getByNumber(context), keywordSeparator);
         newGroup.addLegacyEntryKeys(tok);
         return newGroup;
     }
@@ -68,7 +67,7 @@ public class ExplicitGroup extends KeywordGroup {
     @Override
     public AbstractGroup deepCopy() {
         try {
-            ExplicitGroup copy = new ExplicitGroup(getName(), getContext(), jabRefPreferences);
+            ExplicitGroup copy = new ExplicitGroup(getName(), getContext(), keywordSeparator);
             copy.legacyEntryKeys.addAll(legacyEntryKeys);
             return copy;
         } catch (ParseException exception) {

--- a/src/main/java/net/sf/jabref/logic/groups/GroupTreeNode.java
+++ b/src/main/java/net/sf/jabref/logic/groups/GroupTreeNode.java
@@ -234,9 +234,9 @@ public class GroupTreeNode extends TreeNode<GroupTreeNode> {
         return GroupTreeNode.fromGroup(group);
     }
 
-    public static GroupTreeNode parse(List<String> orderedData, JabRefPreferences jabRefPreferences)
+    public static GroupTreeNode parse(List<String> orderedData, String keywordSeparator)
             throws ParseException {
-        return GroupsParser.importGroups(orderedData, jabRefPreferences);
+        return GroupsParser.importGroups(orderedData, keywordSeparator);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/groups/GroupTreeNode.java
+++ b/src/main/java/net/sf/jabref/logic/groups/GroupTreeNode.java
@@ -12,7 +12,6 @@ import net.sf.jabref.logic.search.matchers.MatcherSet;
 import net.sf.jabref.logic.search.matchers.MatcherSets;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * A node in the groups tree that holds exactly one AbstractGroup.

--- a/src/main/java/net/sf/jabref/logic/groups/GroupsParser.java
+++ b/src/main/java/net/sf/jabref/logic/groups/GroupsParser.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import net.sf.jabref.logic.importer.util.ParseException;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.preferences.JabRefPreferences;
 
 /**
  * Converts string representation of groups to a parsed {@link GroupTreeNode}.

--- a/src/main/java/net/sf/jabref/logic/groups/GroupsParser.java
+++ b/src/main/java/net/sf/jabref/logic/groups/GroupsParser.java
@@ -11,7 +11,7 @@ import net.sf.jabref.preferences.JabRefPreferences;
  */
 class GroupsParser {
 
-    public static GroupTreeNode importGroups(List<String> orderedData, JabRefPreferences jabRefPreferences)
+    public static GroupTreeNode importGroups(List<String> orderedData, String keywordSeparator)
             throws ParseException {
         GroupTreeNode cursor = null;
         GroupTreeNode root = null;
@@ -27,7 +27,7 @@ class GroupsParser {
                 throw new ParseException(Localization.lang("Expected \"%0\" to contain whitespace", string));
             }
             int level = Integer.parseInt(string.substring(0, spaceIndex));
-            AbstractGroup group = AbstractGroup.fromString(string.substring(spaceIndex + 1), jabRefPreferences);
+            AbstractGroup group = AbstractGroup.fromString(string.substring(spaceIndex + 1), keywordSeparator);
             GroupTreeNode newNode = GroupTreeNode.fromGroup(group);
             if (cursor == null) {
                 // create new root

--- a/src/main/java/net/sf/jabref/logic/groups/KeywordGroup.java
+++ b/src/main/java/net/sf/jabref/logic/groups/KeywordGroup.java
@@ -14,6 +14,7 @@ import net.sf.jabref.logic.util.strings.StringUtil;
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.EntryUtil;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/src/main/java/net/sf/jabref/logic/importer/ImportFormatPreferences.java
+++ b/src/main/java/net/sf/jabref/logic/importer/ImportFormatPreferences.java
@@ -22,11 +22,13 @@ public class ImportFormatPreferences {
     private final boolean useCaseKeeperOnSearch;
     private final boolean convertUnitsOnSearch;
 
+    private final boolean keywordSyncEnabled;
+
 
     public ImportFormatPreferences(Set<CustomImporter> customImportList, Charset encoding,
             String keywordSeparator, BibtexKeyPatternPreferences bibtexKeyPatternPreferences,
             FieldContentParserPreferences fieldContentParserPreferences, boolean convertUnitsOnSearch,
-            boolean useCaseKeeperOnSearch) {
+            boolean useCaseKeeperOnSearch, boolean keywordSyncEnabled) {
         this.customImportList = customImportList;
         this.encoding = encoding;
         this.keywordSeparator = keywordSeparator;
@@ -34,6 +36,7 @@ public class ImportFormatPreferences {
         this.fieldContentParserPreferences = fieldContentParserPreferences;
         this.convertUnitsOnSearch = convertUnitsOnSearch;
         this.useCaseKeeperOnSearch = useCaseKeeperOnSearch;
+        this.keywordSyncEnabled = keywordSyncEnabled;
     }
 
     public Set<CustomImporter> getCustomImportList() {
@@ -66,6 +69,10 @@ public class ImportFormatPreferences {
 
     public ImportFormatPreferences withEncoding(Charset newEncoding) {
         return new ImportFormatPreferences(customImportList, newEncoding, keywordSeparator, bibtexKeyPatternPreferences,
-                fieldContentParserPreferences, convertUnitsOnSearch, useCaseKeeperOnSearch);
+                fieldContentParserPreferences, convertUnitsOnSearch, useCaseKeeperOnSearch, keywordSyncEnabled);
+    }
+
+    public boolean isKeywordSyncEnabled() {
+        return keywordSyncEnabled;
     }
 }

--- a/src/main/java/net/sf/jabref/logic/importer/OpenDatabase.java
+++ b/src/main/java/net/sf/jabref/logic/importer/OpenDatabase.java
@@ -87,7 +87,7 @@ public class OpenDatabase {
         ParserResult result = new BibtexImporter(importFormatPreferences).importDatabase(fileToOpen.toPath(),
                 importFormatPreferences.getEncoding());
 
-        if (SpecialFieldsUtils.keywordSyncEnabled()) {
+        if (importFormatPreferences.isKeywordSyncEnabled()) {
             for (BibEntry entry : result.getDatabase().getEntries()) {
                 SpecialFieldsUtils.syncSpecialFieldsFromKeywords(entry);
             }

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/BibtexParser.java
@@ -187,7 +187,7 @@ public class BibtexParser {
 
         // Instantiate meta data:
         try {
-            parserResult.setMetaData(MetaData.parse(meta));
+            parserResult.setMetaData(MetaData.parse(meta, importFormatPreferences.getKeywordSeparator()));
         } catch (ParseException exception) {
             parserResult.addWarning(exception.getLocalizedMessage());
         }

--- a/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
@@ -1416,10 +1416,16 @@ public class JabRefPreferences {
         return new FieldContentParserPreferences(getStringList(NON_WRAPPABLE_FIELDS));
     }
 
+    public boolean isKeywordSyncEnabled() {
+        return getBoolean(JabRefPreferences.SPECIALFIELDSENABLED)
+                && getBoolean(JabRefPreferences.AUTOSYNCSPECIALFIELDSTOKEYWORDS);
+    }
+
     public ImportFormatPreferences getImportFormatPreferences() {
         return new ImportFormatPreferences(customImports, getDefaultEncoding(), get(KEYWORD_SEPARATOR),
                 getBibtexKeyPatternPreferences(), getFieldContentParserPreferences(),
-                getBoolean(USE_UNIT_FORMATTER_ON_SEARCH), getBoolean(USE_CASE_KEEPER_ON_SEARCH));
+                getBoolean(USE_UNIT_FORMATTER_ON_SEARCH), getBoolean(USE_CASE_KEEPER_ON_SEARCH),
+                isKeywordSyncEnabled());
     }
 
     public BibtexKeyPatternPreferences getBibtexKeyPatternPreferences() {

--- a/src/main/java/net/sf/jabref/shared/DBMSSynchronizer.java
+++ b/src/main/java/net/sf/jabref/shared/DBMSSynchronizer.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import net.sf.jabref.BibDatabaseContext;
+import net.sf.jabref.Globals;
 import net.sf.jabref.MetaData;
 import net.sf.jabref.event.MetaDataChangedEvent;
 import net.sf.jabref.event.source.EntryEventSource;
@@ -19,6 +20,7 @@ import net.sf.jabref.model.event.EntryAddedEvent;
 import net.sf.jabref.model.event.EntryEvent;
 import net.sf.jabref.model.event.EntryRemovedEvent;
 import net.sf.jabref.model.event.FieldChangedEvent;
+import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.shared.event.ConnectionLostEvent;
 import net.sf.jabref.shared.event.SharedEntryNotPresentEvent;
 import net.sf.jabref.shared.event.UpdateRefusedEvent;
@@ -246,7 +248,7 @@ public class DBMSSynchronizer {
         }
 
         try {
-            metaData.setData(dbmsProcessor.getSharedMetaData());
+            metaData.setData(dbmsProcessor.getSharedMetaData(), Globals.prefs.get(JabRefPreferences.KEYWORD_SEPARATOR));
         } catch (ParseException e) {
             LOGGER.error("Parse error", e);
         }

--- a/src/main/java/net/sf/jabref/specialfields/SpecialFieldDatabaseChangeListener.java
+++ b/src/main/java/net/sf/jabref/specialfields/SpecialFieldDatabaseChangeListener.java
@@ -1,5 +1,6 @@
 package net.sf.jabref.specialfields;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.gui.undo.NamedCompound;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
@@ -20,7 +21,7 @@ public class SpecialFieldDatabaseChangeListener {
 
     @Subscribe
     public void listen(EntryAddedEvent event) {
-        if (SpecialFieldsUtils.keywordSyncEnabled()) {
+        if (Globals.prefs.isKeywordSyncEnabled()) {
             final BibEntry entry = event.getBibEntry();
             // NamedCompount code similar to SpecialFieldUpdateListener
             NamedCompound nc = new NamedCompound(Localization.lang("Synchronized special fields based on keywords"));

--- a/src/main/java/net/sf/jabref/specialfields/SpecialFieldsUtils.java
+++ b/src/main/java/net/sf/jabref/specialfields/SpecialFieldsUtils.java
@@ -45,7 +45,7 @@ public class SpecialFieldsUtils {
 
     private static void exportFieldToKeywords(SpecialField e, String newValue, BibEntry entry,
             NamedCompound ce) {
-        if (!SpecialFieldsUtils.keywordSyncEnabled()) {
+        if (!Globals.prefs.isKeywordSyncEnabled()) {
             return;
         }
         List<String> keywordList = new ArrayList<>(entry.getKeywords());
@@ -165,10 +165,4 @@ public class SpecialFieldsUtils {
     public static boolean isSpecialField(String fieldName) {
         return SpecialFieldsUtils.getSpecialFieldInstanceFromFieldName(fieldName).isPresent();
     }
-
-    public static boolean keywordSyncEnabled() {
-        return Globals.prefs.getBoolean(JabRefPreferences.SPECIALFIELDSENABLED) &&
-                Globals.prefs.getBoolean(JabRefPreferences.AUTOSYNCSPECIALFIELDSTOKEYWORDS);
-    }
-
 }

--- a/src/test/java/net/sf/jabref/gui/importer/actions/ConvertLegacyExplicitGroupsTest.java
+++ b/src/test/java/net/sf/jabref/gui/importer/actions/ConvertLegacyExplicitGroupsTest.java
@@ -35,7 +35,8 @@ public class ConvertLegacyExplicitGroupsTest {
 
         entry = new BibEntry();
         entry.setCiteKey("Entry1");
-        group = new ExplicitGroup("TestGroup", GroupHierarchyType.INCLUDING, Globals.prefs);
+        group = new ExplicitGroup("TestGroup", GroupHierarchyType.INCLUDING,
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
         group.addLegacyEntryKey("Entry1");
     }
 
@@ -60,7 +61,8 @@ public class ConvertLegacyExplicitGroupsTest {
     @Test
     public void performActionWritesGroupMembershipInEntryForComplexGroupTree() throws Exception {
         GroupTreeNode root = GroupTreeNode.fromGroup(new AllEntriesGroup());
-        root.addSubgroup(new ExplicitGroup("TestGroup2", GroupHierarchyType.INCLUDING, Globals.prefs));
+        root.addSubgroup(new ExplicitGroup("TestGroup2", GroupHierarchyType.INCLUDING,
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)));
         root.addSubgroup(group);
         ParserResult parserResult = generateParserResult(entry, root);
 

--- a/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -186,7 +186,8 @@ public class BibtexDatabaseWriterTest {
     @Test
     public void writeGroups() throws Exception {
         GroupTreeNode groupRoot = GroupTreeNode.fromGroup(new AllEntriesGroup());
-        groupRoot.addSubgroup(new ExplicitGroup("test", GroupHierarchyType.INCLUDING, prefs));
+        groupRoot.addSubgroup(new ExplicitGroup("test", GroupHierarchyType.INCLUDING,
+                prefs.get(JabRefPreferences.KEYWORD_SEPARATOR)));
         metaData.setGroups(groupRoot);
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), new SavePreferences());
@@ -205,7 +206,8 @@ public class BibtexDatabaseWriterTest {
         SavePreferences preferences = new SavePreferences().withEncoding(Charsets.US_ASCII);
 
         GroupTreeNode groupRoot = GroupTreeNode.fromGroup(new AllEntriesGroup());
-        groupRoot.addChild(GroupTreeNode.fromGroup(new ExplicitGroup("test", GroupHierarchyType.INCLUDING, prefs)));
+        groupRoot.addChild(GroupTreeNode.fromGroup(new ExplicitGroup("test", GroupHierarchyType.INCLUDING,
+                prefs.get(JabRefPreferences.KEYWORD_SEPARATOR))));
         metaData.setGroups(groupRoot);
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.emptyList(), preferences);

--- a/src/test/java/net/sf/jabref/logic/groups/ExplicitGroupTest.java
+++ b/src/test/java/net/sf/jabref/logic/groups/ExplicitGroupTest.java
@@ -16,14 +16,14 @@ public class ExplicitGroupTest {
     @Test
      public void testToStringSimple() throws ParseException {
         ExplicitGroup group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INDEPENDENT,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
         assertEquals("ExplicitGroup:myExplicitGroup;0;", group.toString());
     }
 
     @Test
     public void toStringDoesNotWriteAssignedEntries() throws ParseException {
         ExplicitGroup group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INCLUDING,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
         group.add(makeBibtexEntry());
         assertEquals("ExplicitGroup:myExplicitGroup;2;", group.toString());
     }

--- a/src/test/java/net/sf/jabref/logic/groups/GroupTreeNodeTest.java
+++ b/src/test/java/net/sf/jabref/logic/groups/GroupTreeNodeTest.java
@@ -41,13 +41,14 @@ public class GroupTreeNodeTest {
      *          B ExplicitNode, Refining (<-- this)
      */
     private GroupTreeNode getNodeInSimpleTree(GroupTreeNode root) throws ParseException {
-        root.addSubgroup(new ExplicitGroup("ExplicitA", GroupHierarchyType.INCLUDING, JabRefPreferences.getInstance()));
+        root.addSubgroup(new ExplicitGroup("ExplicitA", GroupHierarchyType.INCLUDING,
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)));
         GroupTreeNode parent = root
                 .addSubgroup(new ExplicitGroup("ExplicitParent", GroupHierarchyType.INDEPENDENT,
-                        JabRefPreferences.getInstance()));
+                        JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)));
         GroupTreeNode node = parent
                 .addSubgroup(new ExplicitGroup("ExplicitNode", GroupHierarchyType.REFINING,
-                        JabRefPreferences.getInstance()));
+                        JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)));
         return node;
     }
 
@@ -74,10 +75,11 @@ public class GroupTreeNodeTest {
      */
     private GroupTreeNode getNodeInComplexTree(GroupTreeNode root) throws ParseException {
         root.addSubgroup(getSearchGroup("SearchA"));
-        root.addSubgroup(new ExplicitGroup("ExplicitA", GroupHierarchyType.INCLUDING, JabRefPreferences.getInstance()));
+        root.addSubgroup(new ExplicitGroup("ExplicitA", GroupHierarchyType.INCLUDING,
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)));
         GroupTreeNode grandParent = root
                 .addSubgroup(new ExplicitGroup("ExplicitGrandParent", GroupHierarchyType.INDEPENDENT,
-                        JabRefPreferences.getInstance()));
+                        JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)));
         root.addSubgroup(getKeywordGroup("KeywordA"));
 
         grandParent.addSubgroup(getExplict("ExplicitB"));
@@ -96,7 +98,7 @@ public class GroupTreeNodeTest {
 
     private AbstractGroup getKeywordGroup(String name) throws ParseException {
         return new KeywordGroup(name, "searchField", "searchExpression", true, false, GroupHierarchyType.INDEPENDENT,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
     }
 
     private AbstractGroup getSearchGroup(String name) {
@@ -104,7 +106,8 @@ public class GroupTreeNodeTest {
     }
 
     private AbstractGroup getExplict(String name) throws ParseException {
-        return new ExplicitGroup(name, GroupHierarchyType.REFINING, JabRefPreferences.getInstance());
+        return new ExplicitGroup(name, GroupHierarchyType.REFINING,
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
     }
 
     /*
@@ -176,7 +179,8 @@ public class GroupTreeNodeTest {
     @Test
     public void getSearchRuleForIndependentGroupReturnsGroupAsMatcher() throws ParseException {
         GroupTreeNode node = GroupTreeNode
-                .fromGroup(new ExplicitGroup("node", GroupHierarchyType.INDEPENDENT, JabRefPreferences.getInstance()));
+                .fromGroup(new ExplicitGroup("node", GroupHierarchyType.INDEPENDENT,
+                        JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)));
         assertEquals(node.getGroup(), node.getSearchRule());
     }
 
@@ -184,9 +188,11 @@ public class GroupTreeNodeTest {
     public void getSearchRuleForRefiningGroupReturnsParentAndGroupAsMatcher() throws ParseException {
         GroupTreeNode parent = GroupTreeNode
                 .fromGroup(
-                        new ExplicitGroup("parent", GroupHierarchyType.INDEPENDENT, JabRefPreferences.getInstance()));
+                        new ExplicitGroup("parent", GroupHierarchyType.INDEPENDENT,
+                                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)));
         GroupTreeNode node = parent
-                .addSubgroup(new ExplicitGroup("node", GroupHierarchyType.REFINING, JabRefPreferences.getInstance()));
+                .addSubgroup(new ExplicitGroup("node", GroupHierarchyType.REFINING,
+                        JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)));
 
         AndMatcher matcher = new AndMatcher();
         matcher.addRule(node.getGroup());
@@ -197,10 +203,12 @@ public class GroupTreeNodeTest {
     @Test
     public void getSearchRuleForIncludingGroupReturnsGroupOrSubgroupAsMatcher() throws ParseException {
         GroupTreeNode node = GroupTreeNode
-                .fromGroup(new ExplicitGroup("node", GroupHierarchyType.INCLUDING, JabRefPreferences.getInstance()));
+                .fromGroup(new ExplicitGroup("node", GroupHierarchyType.INCLUDING,
+                        JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)));
         GroupTreeNode child = node
                 .addSubgroup(
-                        new ExplicitGroup("child", GroupHierarchyType.INDEPENDENT, JabRefPreferences.getInstance()));
+                        new ExplicitGroup("child", GroupHierarchyType.INDEPENDENT,
+                                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)));
 
         OrMatcher matcher = new OrMatcher();
         matcher.addRule(node.getGroup());
@@ -218,7 +226,7 @@ public class GroupTreeNodeTest {
         GroupTreeNode parent = getNodeInSimpleTree();
         GroupTreeNode node = parent.addSubgroup(
                 new KeywordGroup("node", "author", "author2", true, false, GroupHierarchyType.INDEPENDENT,
-                        JabRefPreferences.getInstance()));
+                        JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)));
         assertEquals(1, node.numberOfHits(entries));
     }
 
@@ -227,7 +235,7 @@ public class GroupTreeNodeTest {
         GroupTreeNode parent = getNodeInSimpleTree();
         GroupTreeNode node = parent.addSubgroup(
                 new KeywordGroup("node", "author", "author1", true, false, GroupHierarchyType.INDEPENDENT,
-                        JabRefPreferences.getInstance()));
+                        JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)));
         assertEquals(2, node.numberOfHits(entries));
     }
 
@@ -236,10 +244,10 @@ public class GroupTreeNodeTest {
         GroupTreeNode grandParent = getNodeInSimpleTree();
         GroupTreeNode parent = grandParent.addSubgroup(
                 new KeywordGroup("node", "author", "author2", true, false, GroupHierarchyType.INDEPENDENT,
-                        JabRefPreferences.getInstance()));
+                        JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)));
         GroupTreeNode node = parent.addSubgroup(
                 new KeywordGroup("node", "author", "author1", true, false, GroupHierarchyType.REFINING,
-                        JabRefPreferences.getInstance()));
+                        JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)));
         assertEquals(1, node.numberOfHits(entries));
     }
 
@@ -248,10 +256,10 @@ public class GroupTreeNodeTest {
         GroupTreeNode grandParent = getNodeInSimpleTree();
         GroupTreeNode parent = grandParent.addSubgroup(
                 new KeywordGroup("node", "author", "author2", true, false, GroupHierarchyType.INDEPENDENT,
-                        JabRefPreferences.getInstance()));
+                        JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)));
         GroupTreeNode node = parent.addSubgroup(
                 new KeywordGroup("node", "author", "author1", true, false, GroupHierarchyType.INDEPENDENT,
-                        JabRefPreferences.getInstance()));
+                        JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)));
         assertEquals(2, node.numberOfHits(entries));
     }
 
@@ -259,7 +267,7 @@ public class GroupTreeNodeTest {
     public void setGroupChangesUnderlyingGroup() throws Exception {
         GroupTreeNode node = getNodeInSimpleTree();
         AbstractGroup newGroup = new ExplicitGroup("NewGroup", GroupHierarchyType.INDEPENDENT,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
 
         node.setGroup(newGroup, true, entries);
 
@@ -269,11 +277,11 @@ public class GroupTreeNodeTest {
     @Test
     public void setGroupAddsPreviousAssignmentsExplicitToExplicit() throws Exception {
         AbstractGroup oldGroup = new ExplicitGroup("OldGroup", GroupHierarchyType.INDEPENDENT,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
         oldGroup.add(entry);
         GroupTreeNode node = GroupTreeNode.fromGroup(oldGroup);
         AbstractGroup newGroup = new ExplicitGroup("NewGroup", GroupHierarchyType.INDEPENDENT,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
 
         node.setGroup(newGroup, true, entries);
 
@@ -283,11 +291,11 @@ public class GroupTreeNodeTest {
     @Test
     public void setGroupWithFalseDoesNotAddsPreviousAssignments() throws Exception {
         AbstractGroup oldGroup = new ExplicitGroup("OldGroup", GroupHierarchyType.INDEPENDENT,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
         oldGroup.add(entry);
         GroupTreeNode node = GroupTreeNode.fromGroup(oldGroup);
         AbstractGroup newGroup = new ExplicitGroup("NewGroup", GroupHierarchyType.INDEPENDENT,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
 
         node.setGroup(newGroup, false, entries);
 
@@ -297,11 +305,11 @@ public class GroupTreeNodeTest {
     @Test
     public void setGroupAddsOnlyPreviousAssignments() throws Exception {
         AbstractGroup oldGroup = new ExplicitGroup("OldGroup", GroupHierarchyType.INDEPENDENT,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
         assertFalse(oldGroup.isMatch(entry));
         GroupTreeNode node = GroupTreeNode.fromGroup(oldGroup);
         AbstractGroup newGroup = new ExplicitGroup("NewGroup", GroupHierarchyType.INDEPENDENT,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
 
         node.setGroup(newGroup, true, entries);
 
@@ -311,7 +319,7 @@ public class GroupTreeNodeTest {
     @Test
     public void setGroupExplicitToSearchDoesNotKeepPreviousAssignments() throws Exception {
         AbstractGroup oldGroup = new ExplicitGroup("OldGroup", GroupHierarchyType.INDEPENDENT,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
         oldGroup.add(entry);
         GroupTreeNode node = GroupTreeNode.fromGroup(oldGroup);
         AbstractGroup newGroup = new SearchGroup("NewGroup", "test", false, false, GroupHierarchyType.INDEPENDENT);
@@ -324,11 +332,11 @@ public class GroupTreeNodeTest {
     @Test
     public void setGroupExplicitToExplicitIsRenameAndSoRemovesPreviousAssignment() throws Exception {
         AbstractGroup oldGroup = new ExplicitGroup("OldGroup", GroupHierarchyType.INDEPENDENT,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
         oldGroup.add(entry);
         GroupTreeNode node = GroupTreeNode.fromGroup(oldGroup);
         AbstractGroup newGroup = new ExplicitGroup("NewGroup", GroupHierarchyType.INDEPENDENT,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
 
         node.setGroup(newGroup, true, entries);
 

--- a/src/test/java/net/sf/jabref/logic/groups/KeywordGroupTest.java
+++ b/src/test/java/net/sf/jabref/logic/groups/KeywordGroupTest.java
@@ -13,22 +13,23 @@ public class KeywordGroupTest {
 
     @Test
     public void testToString() throws ParseException {
-        KeywordGroup group = new KeywordGroup("myExplicitGroup", "author","asdf", true, true,
-                GroupHierarchyType.INDEPENDENT, JabRefPreferences.getInstance());
+        KeywordGroup group = new KeywordGroup("myExplicitGroup", "author", "asdf", true, true,
+                GroupHierarchyType.INDEPENDENT,
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
         assertEquals("KeywordGroup:myExplicitGroup;0;author;asdf;1;1;", group.toString());
     }
 
     @Test
     public void testToString2() throws ParseException {
-        KeywordGroup group = new KeywordGroup("myExplicitGroup", "author","asdf", false, true,
-                GroupHierarchyType.REFINING, JabRefPreferences.getInstance());
+        KeywordGroup group = new KeywordGroup("myExplicitGroup", "author", "asdf", false, true,
+                GroupHierarchyType.REFINING, JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
         assertEquals("KeywordGroup:myExplicitGroup;1;author;asdf;0;1;", group.toString());
     }
 
     @Test
     public void containsSimpleWord() throws Exception {
         KeywordGroup group = new KeywordGroup("name", "keywords", "test", false, false, GroupHierarchyType.INDEPENDENT,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
         BibEntry entry = new BibEntry().withField("keywords", "test");
 
         assertTrue(group.isMatch(entry));
@@ -37,7 +38,7 @@ public class KeywordGroupTest {
     @Test
     public void containsSimpleWordInSentence() throws Exception {
         KeywordGroup group = new KeywordGroup("name", "keywords", "test", false, false, GroupHierarchyType.INDEPENDENT,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
         BibEntry entry = new BibEntry().withField("keywords", "Some sentence containing test word");
 
         assertTrue(group.isMatch(entry));
@@ -46,7 +47,7 @@ public class KeywordGroupTest {
     @Test
     public void containsSimpleWordCommaSeparated() throws Exception {
         KeywordGroup group = new KeywordGroup("name", "keywords", "test", false, false, GroupHierarchyType.INDEPENDENT,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
         BibEntry entry = new BibEntry().withField("keywords", "Some,list,containing,test,word");
 
         assertTrue(group.isMatch(entry));
@@ -55,7 +56,7 @@ public class KeywordGroupTest {
     @Test
     public void containsSimpleWordSemicolonSeparated() throws Exception {
         KeywordGroup group = new KeywordGroup("name", "keywords", "test", false, false, GroupHierarchyType.INDEPENDENT,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
         BibEntry entry = new BibEntry().withField("keywords", "Some;list;containing;test;word");
 
         assertTrue(group.isMatch(entry));
@@ -64,7 +65,7 @@ public class KeywordGroupTest {
     @Test
     public void containsComplexWord() throws Exception {
         KeywordGroup group = new KeywordGroup("name", "keywords", "\\H2O", false, false, GroupHierarchyType.INDEPENDENT,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
         BibEntry entry = new BibEntry().withField("keywords", "\\H2O");
 
         assertTrue(group.isMatch(entry));
@@ -73,7 +74,7 @@ public class KeywordGroupTest {
     @Test
     public void containsComplexWordInSentence() throws Exception {
         KeywordGroup group = new KeywordGroup("name", "keywords", "\\H2O", false, false, GroupHierarchyType.INDEPENDENT,
-                JabRefPreferences.getInstance());
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
         BibEntry entry = new BibEntry().withField("keywords", "Some sentence containing \\H2O word");
 
         assertTrue(group.isMatch(entry));
@@ -82,7 +83,8 @@ public class KeywordGroupTest {
     @Test
     public void containsWordWithWhitespaceInSentence() throws Exception {
         KeywordGroup group = new KeywordGroup("name", "keywords", "test word", false, false,
-                GroupHierarchyType.INDEPENDENT, JabRefPreferences.getInstance());
+                GroupHierarchyType.INDEPENDENT,
+                JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR));
         BibEntry entry = new BibEntry().withField("keywords", "Some sentence containing test word");
 
         assertTrue(group.isMatch(entry));

--- a/src/test/java/net/sf/jabref/logic/importer/ImportFormatReaderIntegrationTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/ImportFormatReaderIntegrationTest.java
@@ -7,7 +7,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
@@ -36,10 +35,9 @@ public class ImportFormatReaderIntegrationTest {
 
     @Before
     public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance(); // Needed for special fields
         reader = new ImportFormatReader();
-        reader.resetImportFormats(Globals.prefs.getImportFormatPreferences(),
-                Globals.prefs.getXMPPreferences());
+        reader.resetImportFormats(JabRefPreferences.getInstance().getImportFormatPreferences(),
+                JabRefPreferences.getInstance().getXMPPreferences());
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/importer/ImportFormatReaderTestParameterless.java
+++ b/src/test/java/net/sf/jabref/logic/importer/ImportFormatReaderTestParameterless.java
@@ -5,7 +5,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Before;
@@ -20,10 +19,9 @@ public class ImportFormatReaderTestParameterless {
 
     @Before
     public void setUp() {
-        Globals.prefs = JabRefPreferences.getInstance(); // Needed for special fields
         reader = new ImportFormatReader();
-        reader.resetImportFormats(Globals.prefs.getImportFormatPreferences(),
-                Globals.prefs.getXMPPreferences());
+        reader.resetImportFormats(JabRefPreferences.getInstance().getImportFormatPreferences(),
+                JabRefPreferences.getInstance().getXMPPreferences());
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/importer/OpenDatabaseTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/OpenDatabaseTest.java
@@ -9,14 +9,12 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Optional;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class OpenDatabaseTest {
@@ -38,12 +36,6 @@ public class OpenDatabaseTest {
                 .toFile();
         bibEncodingWithoutNewline = Paths
                 .get(OpenDatabaseTest.class.getResource("encodingWithoutNewline.bib").toURI()).toFile();
-    }
-
-    @BeforeClass
-    public static void setUpGlobalsPrefs() {
-        // otherwise FieldContentParser (called by BibtexParser) and SpecialFields crashes
-        Globals.prefs = JabRefPreferences.getInstance();
     }
 
     @Before

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.cleanup.FieldFormatterCleanup;
 import net.sf.jabref.logic.config.SaveOrderConfig;
 import net.sf.jabref.logic.exporter.FieldFormatterCleanups;

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -1497,10 +1497,14 @@ public class BibtexParserTest {
 
         assertEquals(new AllEntriesGroup(), root.getGroup());
         assertEquals(3, root.getNumberOfChildren());
-        assertEquals(new KeywordGroup("Fréchet", "keywords", "FrechetSpace", false, true,
-                GroupHierarchyType.INDEPENDENT, Globals.prefs), root.getChildren().get(0).getGroup());
-        assertEquals(new KeywordGroup("Invariant theory", "keywords", "GIT", false, false,
-                GroupHierarchyType.INDEPENDENT, Globals.prefs), root.getChildren().get(1).getGroup());
+        assertEquals(
+                new KeywordGroup("Fréchet", "keywords", "FrechetSpace", false, true, GroupHierarchyType.INDEPENDENT,
+                        JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)),
+                root.getChildren().get(0).getGroup());
+        assertEquals(
+                new KeywordGroup("Invariant theory", "keywords", "GIT", false, false, GroupHierarchyType.INDEPENDENT,
+                        JabRefPreferences.getInstance().get(JabRefPreferences.KEYWORD_SEPARATOR)),
+                root.getChildren().get(1).getGroup());
         assertEquals(Arrays.asList("Key1", "Key2"),
                 ((ExplicitGroup) root.getChildren().get(2).getGroup()).getLegacyEntryKeys());
     }

--- a/src/test/java/net/sf/jabref/logic/layout/LayoutEntryTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/LayoutEntryTest.java
@@ -5,7 +5,6 @@ import java.io.StringReader;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.journals.JournalAbbreviationLoader;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.preferences.JabRefPreferences;
@@ -50,10 +49,6 @@ public class LayoutEntryTest {
      */
     @Before
     public void setUp() {
-        if (Globals.prefs == null) {
-            Globals.prefs = JabRefPreferences.getInstance();
-            Globals.prefs.putBoolean("highLightWords", Boolean.TRUE);
-        }
 
         // create Bibtext Entry
 
@@ -87,7 +82,7 @@ public class LayoutEntryTest {
     public String layout(String layoutFile, BibEntry entry, Optional<Pattern> highlightPattern) throws IOException {
         StringReader sr = new StringReader(layoutFile.replace("__NEWLINE__", "\n"));
         Layout layout = new LayoutHelper(sr,
-                Globals.prefs.getLayoutFormatterPreferences(mock(JournalAbbreviationLoader.class)))
+                JabRefPreferences.getInstance().getLayoutFormatterPreferences(mock(JournalAbbreviationLoader.class)))
                         .getLayoutFromText();
 
         return layout.doLayout(entry, null, highlightPattern);


### PR DESCRIPTION
Still a bit of logic dependencies left to be able to move to model.

All Globals dependencies in `logic`-test except one is now gone, so it is not possible to add an architecture test yet. It is only the Globals dependency of ExternalFileType that remains (good to be able to move external to logic and gui as well).
