### PR TITLE
Improve duplicate detection

### DIFF
--- a/src/main/java/net/sf/jabref/model/DuplicateCheck.java
+++ b/src/main/java/net/sf/jabref/model/DuplicateCheck.java
@@ -24,6 +24,8 @@ import org.apache.commons.logging.LogFactory;
 
 /**
  * This class contains utility method for duplicate checking of entries.
+ *
+ * TODO: http://hpi.de/naumann/projects/data-quality-and-cleansing/dude-duplicate-detection.html
  */
 public class DuplicateCheck {
     private static final Log LOGGER = LogFactory.getLog(DuplicateCheck.class);

--- a/src/main/java/net/sf/jabref/model/DuplicateCheck.java
+++ b/src/main/java/net/sf/jabref/model/DuplicateCheck.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -185,14 +186,12 @@ public class DuplicateCheck {
         for (String field : allFields) {
             Optional<String> stringOne = one.getField(field);
             Optional<String> stringTwo = two.getField(field);
-            if (stringOne.equals(stringTwo)) {
+            if (Objects.equals(stringOne, stringTwo)) {
                 score++;
             }
         }
         if (score == allFields.size()) {
-            return 1.01; // Just to make sure we can
-            // use score>1 without
-            // trouble.
+            return 1.0;
         }
         return (double) score / allFields.size();
     }

--- a/src/main/java/net/sf/jabref/model/DuplicateCheck.java
+++ b/src/main/java/net/sf/jabref/model/DuplicateCheck.java
@@ -106,6 +106,7 @@ public class DuplicateCheck {
             }
             totWeights += weight;
 
+            // TODO: EMPTY_IN_ONE, EMPTY_IN_TWO, NOT_EQUAL is not used
             CheckResult result = DuplicateCheck.compareSingleField(field, one, two);
             if (result == CheckResult.EQUAL) {
                 res += weight;

--- a/src/test/java/net/sf/jabref/model/DuplicateCheckTest.java
+++ b/src/test/java/net/sf/jabref/model/DuplicateCheckTest.java
@@ -11,14 +11,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-/**
- * Created by IntelliJ IDEA.
- * User: alver
- * Date: Nov 9, 2007
- * Time: 7:04:25 PM
- * To change this template use File | Settings | File Templates.
- */
 public class DuplicateCheckTest {
+    @Test
+    public void noDuplicateForDifferentTypes() {
+        BibEntry e1 = new BibEntry("1", "article");
+        BibEntry e2 = new BibEntry("2", "journal");
+        assertFalse(DuplicateCheck.isDuplicate(e1, e2, BibDatabaseMode.BIBTEX));
+        assertFalse(DuplicateCheck.isDuplicate(e1, e2, BibDatabaseMode.BIBLATEX));
+    }
 
     @Test
     public void testDuplicateDetection() {
@@ -77,14 +77,31 @@ public class DuplicateCheckTest {
     }
 
     @Test
-    public void testWordCorrelation() {
-        String d1 = "Characterization of Calanus finmarchicus habitat in the North Sea";
-        String d2 = "Characterization of Calunus finmarchicus habitat in the North Sea";
-        String d3 = "Characterization of Calanus glacialissss habitat in the South Sea";
-
-        assertEquals(1.0, (DuplicateCheck.correlateByWords(d1, d2)), 0.01);
-        assertEquals(0.78, (DuplicateCheck.correlateByWords(d1, d3)), 0.01);
-        assertEquals(0.78, (DuplicateCheck.correlateByWords(d2, d3)), 0.01);
+    public void wordCorrelationIsOneForEmptyStrings() {
+        assertEquals(1.0, DuplicateCheck.correlateByWords("", ""), 0.01);
     }
 
+    @Test
+    public void wordCorrelationForSmallerFirstString() {
+        String d1 = "a test";
+        String d2 = "this a test";
+
+        assertEquals(0.0, DuplicateCheck.correlateByWords(d1, d2), 0.01);
+    }
+
+    @Test
+    public void wordCorrelationForBiggerFirstString() {
+        String d1 = "Characterization of me";
+        String d2 = "Characterization";
+
+        assertEquals(1.0, DuplicateCheck.correlateByWords(d1, d2), 0.01);
+    }
+
+    @Test
+    public void wordCorrelationForEqualStrings() {
+        String d1 = "Characterization";
+        String d2 = "Characterization";
+
+        assertEquals(1.0, DuplicateCheck.correlateByWords(d1, d2), 0.01);
+    }
 }

--- a/src/test/java/net/sf/jabref/model/DuplicateCheckTest.java
+++ b/src/test/java/net/sf/jabref/model/DuplicateCheckTest.java
@@ -21,6 +21,60 @@ public class DuplicateCheckTest {
     }
 
     @Test
+    public void noStrictDuplicateForDifferentTypes() {
+        BibEntry e1 = new BibEntry("1", "article");
+        BibEntry e2 = new BibEntry("2", "journal");
+        assertEquals(0, DuplicateCheck.compareEntriesStrictly(e1, e2), 0.01);
+    }
+
+    @Test
+    public void strictDuplicateForEqualFields() {
+        BibEntry e1 = new BibEntry();
+        e1.setField("key1", "value1");
+        e1.setField("key2", "value2");
+        BibEntry e2 = new BibEntry();
+        e2.setField("key1", "value1");
+        e2.setField("key2", "value2");
+        assertEquals(1, DuplicateCheck.compareEntriesStrictly(e1, e2), 0.01);
+    }
+
+    @Test
+    public void noStrictDuplicateForDifferentKeys() {
+        BibEntry e1 = new BibEntry();
+        e1.setField("key", "value1");
+        BibEntry e2 = new BibEntry();
+        e2.setField("key1", "value1");;
+        assertEquals(0, DuplicateCheck.compareEntriesStrictly(e1, e2), 0.01);
+    }
+
+    @Test
+    public void noStrictDuplicateForDifferentValues() {
+        BibEntry e1 = new BibEntry();
+        e1.setField("key1", "value");
+        BibEntry e2 = new BibEntry();
+        e2.setField("key1", "value1");
+        assertEquals(0, DuplicateCheck.compareEntriesStrictly(e1, e2), 0.01);
+    }
+
+    @Test
+    public void noStrictDuplicateIsCaseInsensitiveForKey() {
+        BibEntry e1 = new BibEntry();
+        e1.setField("KEY1", "value");
+        BibEntry e2 = new BibEntry();
+        e2.setField("key1", "value");
+        assertEquals(1, DuplicateCheck.compareEntriesStrictly(e1, e2), 0.01);
+    }
+
+    @Test
+    public void noStrictDuplicateIsCaseSensitiveForValue() {
+        BibEntry e1 = new BibEntry();
+        e1.setField("key1", "Value");
+        BibEntry e2 = new BibEntry();
+        e2.setField("key1", "value");
+        assertEquals(0, DuplicateCheck.compareEntriesStrictly(e1, e2), 0.01);
+    }
+
+    @Test
     public void testDuplicateDetection() {
         BibEntry one = new BibEntry(IdGenerator.next(), BibtexEntryTypes.ARTICLE.getName());
 
@@ -45,11 +99,9 @@ public class DuplicateCheckTest {
         one.setField("journal", "A");
         two.setField("journal", "A");
         assertTrue(DuplicateCheck.isDuplicate(one, two, BibDatabaseMode.BIBTEX));
-        assertEquals(1.01, DuplicateCheck.compareEntriesStrictly(one, two), 0.01);
 
         two.setField("journal", "B");
         assertTrue(DuplicateCheck.isDuplicate(one, two, BibDatabaseMode.BIBTEX));
-        assertEquals(0.75, DuplicateCheck.compareEntriesStrictly(one, two), 0.01);
 
         two.setField("journal", "A");
         one.setField("number", "1");

--- a/src/test/resources/net/sf/jabref/model/duplicates.bib
+++ b/src/test/resources/net/sf/jabref/model/duplicates.bib
@@ -1,0 +1,17 @@
+% Encoding: UTF-8
+
+@InProceedings{dupJournalTechreport,
+  author    = {Kolb, Stefan and Wirtz, Guido},
+  title     = {This was published at a Workshop and a Journal with the same Title},
+  booktitle = {Proc. Workshop Cloud},
+  year      = {2016},
+}
+
+@Article{dupJournalTechreport,
+  author  = {Kolb, Stefan and Wirtz, Guido},
+  title   = {This was published at a Workshop and a Journal with the same Title},
+  journal = {Transactions on Cloud Computing},
+  year    = {2016},
+}
+
+@Comment{jabref-meta: databaseType:bibtex;}


### PR DESCRIPTION
- [ ] strict comparison does not care about entry type. Is this intended?

``` java
    @Test
    public void noStrictDuplicateForDifferentTypes() {
        BibEntry e1 = new BibEntry("1", "article");
        BibEntry e2 = new BibEntry("2", "journal");
        assertEquals(0, DuplicateCheck.compareEntriesStrictly(e1, e2), 0.01);
    }
```
- [ ] Correlate by words has a strange algorithm. Only works good for words appended at the end of the String.

``` java
     * Compare two strings on the basis of word-by-word correlation analysis.
     * TODO: strange algorithm as when there are only words inserted this gives a bad value, e.g.,
     * a test -> this a test (0.0)
     * characterization -> characterization of me (1.0)
```
- [ ] We need a small benchmark for the duplicate testing, i.e., a DB that has all kinds of expected duplicates.
