### PR TITLE
Do not mark a new database as changed

### DIFF
--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -230,19 +230,19 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         this.bibDatabaseContext.getDatabase().registerListener(new GroupTreeListener());
 
         if (file.isPresent()) {
-            if (bibDatabaseContext.getDatabase().hasEntries()) {
-                // Register so we get notifications about outside changes to the file.
-                try {
-                    fileMonitorHandle = Globals.getFileUpdateMonitor().addUpdateListener(this, file.get());
-                } catch (IOException ex) {
-                    LOGGER.warn("Could not register FileUpdateMonitor", ex);
-                }
+            // Register so we get notifications about outside changes to the file.
+            try {
+                fileMonitorHandle = Globals.getFileUpdateMonitor().addUpdateListener(this, file.get());
+            } catch (IOException ex) {
+                LOGGER.warn("Could not register FileUpdateMonitor", ex);
             }
         } else {
-            // if the database is not empty and no file is assigned,
-            // the database came from an import and has to be treated somehow
-            // -> mark as changed
-            this.baseChanged = true;
+            if (bibDatabaseContext.getDatabase().hasEntries()) {
+                // if the database is not empty and no file is assigned,
+                // the database came from an import and has to be treated somehow
+                // -> mark as changed
+                this.baseChanged = true;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #1881 . I missed an if-statement when inverting an if/else in #1830 

- ~~[ ] Change in CHANGELOG.md described~~ - introduced in development version only (fortunately)
- [x] Manually tested changed features in running JabRef

