### PR TITLE
[WIP] Fix entry table traversal with Tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 ### Fixed
 - Fixed NullPointerException when opening search result window for an untitled database 
+- Fixed entry table traversal with Tab (no column traversal thus no double jump)
 - Fixed [#1757](https://github.com/JabRef/jabref/issues/1757): Crash after saving illegal argument in entry editor
 - Fixed [#1663](https://github.com/JabRef/jabref/issues/1663): Better multi-monitor support
 - Fixed [#1882](https://github.com/JabRef/jabref/issues/1882): Crash after saving illegal bibtexkey in entry editor

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -1739,6 +1739,14 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         }
     }
 
+    public void selectPreviousEntry() {
+        highlightEntry((mainTable.getSelectedRow() - 1 + mainTable.getRowCount()) % mainTable.getRowCount());
+    }
+
+    public void selectNextEntry() {
+        highlightEntry((mainTable.getSelectedRow() + 1) % mainTable.getRowCount());
+    }
+
     /**
      * This method is called from an EntryEditor when it should be closed. We relay to the selection listener, which
      * takes care of the rest.

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -1280,22 +1280,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
         @Override
         public void actionPerformed(ActionEvent e) {
-
-            int thisRow = panel.getMainTable().findEntry(entry);
-            int newRow;
-
-            if ((thisRow + 1) < panel.getDatabase().getEntryCount()) {
-                newRow = thisRow + 1;
-            } else if (thisRow > 0) {
-                newRow = 0;
-            } else {
-                return; // newRow is still -1, so we can assume the database has
-                // only one entry.
-            }
-
-            scrollTo(newRow);
-            panel.getMainTable().setRowSelectionInterval(newRow, newRow);
-
+            panel.selectNextEntry();
         }
     }
 
@@ -1308,22 +1293,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            int thisRow = panel.getMainTable().findEntry(entry);
-            int newRow;
-
-            if ((thisRow - 1) >= 0) {
-                newRow = thisRow - 1;
-            } else if (thisRow != (panel.getDatabase().getEntryCount() - 1)) {
-                newRow = panel.getDatabase().getEntryCount() - 1;
-            } else {
-                return; // newRow is still -1, so we can assume the database has
-                // only one entry.
-
-            }
-
-            scrollTo(newRow);
-            panel.getMainTable().setRowSelectionInterval(newRow, newRow);
-
+            panel.selectPreviousEntry();
         }
     }
 

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
@@ -5,16 +5,15 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.awt.event.KeyAdapter;
-import java.awt.event.KeyEvent;
+import java.awt.event.ActionEvent;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
+import javax.swing.AbstractAction;
+import javax.swing.ActionMap;
 import javax.swing.BorderFactory;
 import javax.swing.JLabel;
 import javax.swing.JScrollBar;
@@ -169,7 +168,20 @@ public class MainTable extends JTable {
         model.updateMarkingState(Globals.prefs.getBoolean(JabRefPreferences.FLOAT_MARKED_ENTRIES));
         setWidths();
 
-        addKeyListener(new TableKeyListener());
+        //Override 'selectNextColumnCell' and 'selectPreviousColumnCell' to move rows instead of cells on TAB
+        ActionMap am = getActionMap();
+        am.put("selectNextColumnCell", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                panel.selectNextEntry();
+            }
+        });
+        am.put("selectPreviousColumnCell", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                panel.selectPreviousEntry();
+            }
+        });
     }
 
     public void addSelectionListener(ListEventListener<BibEntry> listener) {
@@ -645,28 +657,6 @@ public class MainTable extends JTable {
     private TableComparatorChooser<BibEntry> createTableComparatorChooser(JTable table, SortedList<BibEntry> list,
                                                                              Object sortingStrategy) {
         return TableComparatorChooser.install(table, list, sortingStrategy);
-    }
-
-    /**
-     * KeyEvent handling of Tab
-     */
-    private class TableKeyListener extends KeyAdapter {
-
-        private final Set<Integer> pressed = new HashSet<>();
-
-        @Override
-        public void keyPressed(KeyEvent e) {
-            pressed.add(e.getExtendedKeyCode());
-            if (pressed.contains(KeyEvent.VK_TAB)) {
-                int change = pressed.contains(KeyEvent.VK_SHIFT) ? -1 : 1;
-                setSelected((getSelectedRow() + change + getRowCount()) % getRowCount());
-            }
-        }
-
-        @Override
-        public void keyReleased(KeyEvent e) {
-            pressed.remove(e.getExtendedKeyCode());
-        }
     }
 
     /**


### PR DESCRIPTION
When traversing the entry table with Tab not only changed the selected row but the column did too.
When the most right column was selected and the user would press Tab one entry would be skipped,

Extracted some logic too.