### PR TITLE
Import/Export preferences dialog default directory set to working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Added integrity check for fields with BibTeX keys, e.g., `crossref` and `related`, to check that the key exists
 - [#1496](https://github.com/JabRef/jabref/issues/1496) Keep track of which entry a downloaded file belongs to
 - Made it possible to download multiple entries in one action
+- [#1813](https://github.com/JabRef/jabref/issues/1813) Import/Export preferences dialog default directory set to working directory
 
 ### Fixed
 - Fixed NullPointerException when opening search result window for an untitled database 

--- a/src/main/java/net/sf/jabref/gui/preftabs/PreferencesDialog.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/PreferencesDialog.java
@@ -153,7 +153,7 @@ public class PreferencesDialog extends JDialog {
         // Import and export actions:
         exportPreferences.setToolTipText(Localization.lang("Export preferences to file"));
         exportPreferences.addActionListener(e -> {
-            FileDialog dialog = new FileDialog(frame, System.getProperty("user.home")).withExtension(FileExtensions.XML);
+            FileDialog dialog = new FileDialog(frame).withExtension(FileExtensions.XML);
             dialog.setDefaultExtension(FileExtensions.XML);
             Optional<Path> path = dialog.saveNewFile();
 
@@ -170,7 +170,7 @@ public class PreferencesDialog extends JDialog {
 
         importPreferences.setToolTipText(Localization.lang("Import preferences from file"));
         importPreferences.addActionListener(e -> {
-            FileDialog dialog = new FileDialog(frame, System.getProperty("user.home")).withExtension(FileExtensions.XML);
+            FileDialog dialog = new FileDialog(frame).withExtension(FileExtensions.XML);
             dialog.setDefaultExtension(FileExtensions.XML);
             Optional<Path> fileName = dialog.showDialogAndGetSelectedFile();
 


### PR DESCRIPTION
Changed: #1813 Request: Import/Export preferences dialog with working directory as default

- [x] Change in CHANGELOG.md described
- [x] Manually tested changed features in running JabRef
