### PR TITLE
Fix location field not exported to office 2007 xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,14 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - [#1813](https://github.com/JabRef/jabref/issues/1813) Import/Export preferences dialog default directory set to working directory
 - [#1897](https://github.com/JabRef/jabref/issues/1897) Implemented integrity check for `year` field: Last four nonpunctuation characters should be numerals
 
+
 ### Fixed
 - Fixed NullPointerException when opening search result window for an untitled database 
 - Fixed entry table traversal with Tab (no column traversal thus no double jump)
 - Fixed [#1757](https://github.com/JabRef/jabref/issues/1757): Crash after saving illegal argument in entry editor
 - Fixed [#1663](https://github.com/JabRef/jabref/issues/1663): Better multi-monitor support
 - Fixed [#1882](https://github.com/JabRef/jabref/issues/1882): Crash after saving illegal bibtexkey in entry editor
+- Fixed field `location` containing only city is not exported correctly to MS-Office 2007 xml format
 
 ### Removed
 - The non-supported feature of being able to define file directories for any extension is removed. Still, it should work for older databases using the legacy `ps` and `pdf` fields, although we strongly encourage using the `file` field. 

--- a/src/main/java/net/sf/jabref/logic/msbib/MSBibEntry.java
+++ b/src/main/java/net/sf/jabref/logic/msbib/MSBibEntry.java
@@ -65,10 +65,11 @@ class MSBibEntry {
     private String bibtexEntryType;
 
     // reduced subset, supports only "CITY , STATE, COUNTRY"
-    // \b(\w+)\s?[,]?\s?(\w+)\s?[,]?\s?(\w+)\b
-    // WORD SPACE , SPACE WORD SPACE , SPACE WORD
-    // tested using http://www.javaregex.com/test.html
-    private static final Pattern ADDRESS_PATTERN = Pattern.compile("\\b(\\w+)\\s?[,]?\\s?(\\w+)\\s?[,]?\\s?(\\w+)\\b");
+    // \b(\w+)\s?[,]?\s?(\w+)\s?[,]?\s?(\w*)\b
+    // WORD SPACE , SPACE WORD SPACE (zero or more) , SPACE WORD (zero or word)
+    // tested using http://www.regexpal.com/
+    //Matches both single locations like Berlin or Stroudsburg, PA, USA
+    private static final Pattern ADDRESS_PATTERN = Pattern.compile("\\b(\\w+)\\s?[,]?\\s?(\\w*)\\s?[,]?\\s?(\\w*)\\b");
 
     // Allows 20.3-2007|||20/3-  2007 etc.
     // (\d{1,2})\s?[.,-/]\s?(\d{1,2})\s?[.,-/]\s?(\d{2,4})
@@ -128,6 +129,7 @@ class MSBibEntry {
         String city = getXmlElementTextContent("City", entry);
         String state = getXmlElementTextContent("StateProvince", entry);
         String country = getXmlElementTextContent("CountryRegion", entry);
+
         StringBuilder addressBuffer = new StringBuilder();
         if (city != null) {
             addressBuffer.append(city).append(", ");


### PR DESCRIPTION
Fix location field not exported to office 2007 xml

- [X] Change in CHANGELOG.md described
- [X] Tests created for changes
- [X] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [X] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)

