### PR TITLE
improve find entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - [#1897](https://github.com/JabRef/jabref/issues/1897) Implemented integrity check for `year` field: Last four nonpunctuation characters should be numerals
 
 ### Fixed
+- Fixed selecting an entry out of multiple duplicates
 - Fixed NullPointerException when opening search result window for an untitled database 
 - Fixed entry table traversal with Tab (no column traversal thus no double jump)
 - Fixed [#1757](https://github.com/JabRef/jabref/issues/1757): Crash after saving illegal argument in entry editor

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -838,8 +838,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 selectionListener.editSignalled(firstBE);
             }
 
-            // If we inserted a duplicate we want to select the duplicate (thus we have to search from the back)
-            highlightLastEntry(firstBE);
+            highlightEntry(firstBE);
         }
     }
 
@@ -1045,10 +1044,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         } catch (SaveException ex) {
             if (ex.specificEntry()) {
                 // Error occurred during processing of the entry. Highlight it:
-                final int row = mainTable.findEntry(ex.getEntry());
-                final int topShow = Math.max(0, row - 3);
-                mainTable.setRowSelectionInterval(row, row);
-                mainTable.scrollTo(topShow);
+                highlightEntry(ex.getEntry());
                 showEntry(ex.getEntry());
             } else {
                 LOGGER.warn("Could not save", ex);
@@ -1154,14 +1150,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     mode = BasePanelMode.WILL_SHOW_EDITOR;
                 }
 
-                int row = mainTable.findEntry(be);
-                if (row >= 0) {
-                    highlightEntry(be); // Selects the entry. The selection listener will open the editor.
-                } else {
-                    // The entry is not visible in the table, perhaps due to a filtering search
-                    // or group selection. Show the entry editor anyway:
-                    showEntry(be);
-                }
+                highlightEntry(be);
 
                 markBaseChanged(); // The database just changed.
                 new FocusRequester(getEntryEditor(be));
@@ -1476,11 +1465,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         // otherwise set the bottom component to null.
         if (mode == BasePanelMode.SHOWING_PREVIEW) {
             mode = BasePanelMode.SHOWING_NOTHING;
-            int row = mainTable.findEntry(currentPreview.getEntry());
-            if (row >= 0) {
-                mainTable.setRowSelectionInterval(row, row);
-            }
-
+            highlightEntry(currentPreview.getEntry());
         } else if (mode == BasePanelMode.SHOWING_EDITOR) {
             mode = BasePanelMode.SHOWING_NOTHING;
         } else {
@@ -1720,21 +1705,12 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
     }
 
     /**
-     * This method selects the given entry (searches from the back), and scrolls it into view in the table.
-     * If an entryEditor is shown, it is given focus afterwards.
-     */
-    public void highlightLastEntry(final BibEntry bibEntry) {
-        highlightEntry(mainTable.findLastEntry(bibEntry));
-    }
-
-    /**
      * This method selects the entry on the given position, and scrolls it into view in the table.
      * If an entryEditor is shown, it is given focus afterwards.
      */
     public void highlightEntry(int pos) {
-        if (pos >= 0) {
-            mainTable.clearSelection();
-            mainTable.addRowSelectionInterval(pos, pos);
+        if (pos >= 0 && pos < mainTable.getRowCount()) {
+            mainTable.setRowSelectionInterval(pos, pos);
             mainTable.ensureVisible(pos);
         }
     }

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
@@ -502,7 +502,7 @@ public class MainTable extends JTable {
         EventList<BibEntry> tableRows = model.getTableRows();
         for (int row = 0; row < tableRows.size(); row++) {
             BibEntry bibEntry = tableRows.get(row);
-            if (entry == bibEntry) {
+            if (entry == bibEntry) { // NOPMD (equals doesn't recognise duplicates)
                 return row;
             }
         }

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
@@ -499,11 +499,14 @@ public class MainTable extends JTable {
     }
 
     public int findEntry(BibEntry entry) {
-        return model.getTableRows().indexOf(entry);
-    }
-
-    public int findLastEntry(BibEntry entry) {
-        return model.getTableRows().lastIndexOf(entry);
+        EventList<BibEntry> tableRows = model.getTableRows();
+        for (int i = 0; i < tableRows.size(); i++) {
+            BibEntry bibEntry = tableRows.get(i);
+            if (entry.getId().equals(bibEntry.getId())) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     /**

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
@@ -502,7 +502,7 @@ public class MainTable extends JTable {
         EventList<BibEntry> tableRows = model.getTableRows();
         for (int row = 0; row < tableRows.size(); row++) {
             BibEntry bibEntry = tableRows.get(row);
-            if (entry.getId().equals(bibEntry.getId())) {
+            if (entry == bibEntry) {
                 return row;
             }
         }

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
@@ -500,10 +500,10 @@ public class MainTable extends JTable {
 
     public int findEntry(BibEntry entry) {
         EventList<BibEntry> tableRows = model.getTableRows();
-        for (int i = 0; i < tableRows.size(); i++) {
-            BibEntry bibEntry = tableRows.get(i);
+        for (int row = 0; row < tableRows.size(); row++) {
+            BibEntry bibEntry = tableRows.get(row);
             if (entry.getId().equals(bibEntry.getId())) {
-                return i;
+                return row;
             }
         }
         return -1;


### PR DESCRIPTION
I imroved the `findEntry`-method some more. Now it always finds the correct Entry (by searching it with the id and not with the canonical representation.

### Steps to reproduce a situation in which the problem occurs
- have multiple duplicates in a database
- search them and open the results in the extra window
- select one of the duplicates in the extra window but the first
- in the main window always the first of the duplicates is selected
