### PR TITLE
Added error dialog when setting invalid main file directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed [#1882](https://github.com/JabRef/jabref/issues/1882): Crash after saving illegal bibtexkey in entry editor
 - Fixed field `location` containing only city is not exported correctly to MS-Office 2007 xml format
 - Fixed field `key` field is not exported to MS-Office 2008 xml format
+- Fixed download files failed silently when an invalid directory is selected
 
 ### Removed
 - The non-supported feature of being able to define file directories for any extension is removed. Still, it should work for older databases using the legacy `ps` and `pdf` fields, although we strongly encourage using the `file` field. 

--- a/src/main/java/net/sf/jabref/gui/externalfiles/DownloadExternalFile.java
+++ b/src/main/java/net/sf/jabref/gui/externalfiles/DownloadExternalFile.java
@@ -215,7 +215,10 @@ public class DownloadExternalFile {
 
                 callback.downloadComplete(fileListEntry);
             } catch (IOException ex) {
-                LOGGER.warn("Problem downloading file", ex);
+                String content = String.format("%s %n %s", Localization.lang("Error message:"),
+                        ex.getLocalizedMessage());
+                JOptionPane.showMessageDialog(this.frame, content,
+                        Localization.lang("Error while writing"), JOptionPane.ERROR_MESSAGE);
             }
 
             if (!tmp.delete()) {

--- a/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/FileTab.java
@@ -3,6 +3,9 @@ package net.sf.jabref.gui.preftabs;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.event.ItemListener;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import javax.swing.BorderFactory;
 import javax.swing.ButtonGroup;
@@ -10,6 +13,7 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JSpinner;
@@ -281,7 +285,14 @@ class FileTab extends JPanel implements PrefsTab {
 
     @Override
     public boolean validateSettings() {
-        return true;
+        Path path = Paths.get(fileDir.getText());
+        boolean valid = Files.exists(path) && Files.isDirectory(path);
+        if (!valid) {
+            String content = String.format("%s -> %s %n %n %s: %n %s", Localization.lang("File"),
+                    Localization.lang("Main file directory"), Localization.lang("Directory not found"), path);
+            JOptionPane.showMessageDialog(this.frame, content, Localization.lang("Error"), JOptionPane.ERROR_MESSAGE);
+        }
+        return valid;
     }
 
     @Override


### PR DESCRIPTION
Many users set file directories by copy pasting the path and not by opening the file chooser. This means invalid paths could be set in preferences -> File -> main file directory

See https://github.com/koppor/jabref/issues/109 for more information.

Now the preferences tab won't save an invalid path anymore and notifies the user about it.
Also there is now an error message when trying to download a file to a directory which does not exist or can not be written to.

![errormainfiledirectory](https://cloud.githubusercontent.com/assets/15340757/18251625/649d0cb6-738a-11e6-98e7-a4d69abfe084.PNG)
![filedownloadproblem](https://cloud.githubusercontent.com/assets/15340757/18251628/663db30e-738a-11e6-860b-10e35698cc0e.PNG)

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)

