### PR TITLE
Add key shortcuts to search result frame and main table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - `comments` field in MS-Office 2007 xml format is now imported as `note` field
 - [#463](https://github.com/JabRef/jabref/issues/463): Disable menu-item and toolbar-buttons while no database is open
 - Implemented integrity check for `note` and `howpublished` field: Should have the first letter capitalized (BibTeX)
+- <kbd>Pos1</kbd> / <kbd>HOME</kbd> now select the first/last entry in the main table and the search result frame.
+- <kbd>UP</kbd> / <kbd>Down</kbd> / <kbd>Tab</kbd> / <kbd>shift+Tab</kbd> in the search result frame have now the same functionality as in the main  table.
 
 ### Fixed
 - Fixed selecting an entry out of multiple duplicates

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -1743,6 +1743,15 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         highlightEntry((mainTable.getSelectedRow() + 1) % mainTable.getRowCount());
     }
 
+
+    public void selectFirstEntry() {
+        highlightEntry(0);
+    }
+
+    public void selectLastEntry() {
+        highlightEntry(mainTable.getRowCount() - 1);
+    }
+
     /**
      * This method is called from an EntryEditor when it should be closed. We relay to the selection listener, which
      * takes care of the rest.

--- a/src/main/java/net/sf/jabref/gui/keyboard/KeyBinding.java
+++ b/src/main/java/net/sf/jabref/gui/keyboard/KeyBinding.java
@@ -78,6 +78,8 @@ public enum KeyBinding {
             "Save database as ...", Localization.lang("Save database as..."), "ctrl shift S"),
     SEARCH("Search", Localization.lang("Search"), "ctrl F"),
     SELECT_ALL("Select all", Localization.lang("Select all"), "ctrl A"),
+    SELECT_FIRST_ENTRY("Select first entry", Localization.lang("Select first entry"), "HOME"),
+    SELECT_LAST_ENTRY("Select last entry", Localization.lang("Select last entry"), "END"),
     STRING_DIALOG_ADD_STRING("String dialog, add string", Localization.lang("String dialog, add string"), "ctrl N"),
     STRING_DIALOG_REMOVE_STRING("String dialog, remove string", Localization.lang("String dialog, remove string"), "shift DELETE"),
     SWITCH_PREVIEW_LAYOUT("Switch preview layout", Localization.lang("Switch preview layout"), "F9"),

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import javax.swing.AbstractAction;
 import javax.swing.ActionMap;
 import javax.swing.BorderFactory;
+import javax.swing.InputMap;
 import javax.swing.JLabel;
 import javax.swing.JScrollBar;
 import javax.swing.JScrollPane;
@@ -33,6 +34,7 @@ import net.sf.jabref.gui.GUIGlobals;
 import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.groups.EntryTableTransferHandler;
 import net.sf.jabref.gui.groups.GroupMatcher;
+import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.gui.renderer.CompleteRenderer;
 import net.sf.jabref.gui.renderer.GeneralRenderer;
 import net.sf.jabref.gui.renderer.IncompleteRenderer;
@@ -169,29 +171,48 @@ public class MainTable extends JTable {
         setWidths();
 
         //Override 'selectNextColumnCell' and 'selectPreviousColumnCell' to move rows instead of cells on TAB
-        ActionMap am = getActionMap();
-        am.put("selectNextColumnCell", new AbstractAction() {
+        ActionMap actionMap = getActionMap();
+        InputMap inputMap = getInputMap();
+        actionMap.put("selectNextColumnCell", new AbstractAction() {
             @Override
             public void actionPerformed(ActionEvent e) {
                 panel.selectNextEntry();
             }
         });
-        am.put("selectPreviousColumnCell", new AbstractAction() {
+        actionMap.put("selectPreviousColumnCell", new AbstractAction() {
             @Override
             public void actionPerformed(ActionEvent e) {
                 panel.selectPreviousEntry();
             }
         });
-        am.put("selectNextRow", new AbstractAction() {
+        actionMap.put("selectNextRow", new AbstractAction() {
             @Override
             public void actionPerformed(ActionEvent e) {
                 panel.selectNextEntry();
             }
         });
-        am.put("selectPreviousRow", new AbstractAction() {
+        actionMap.put("selectPreviousRow", new AbstractAction() {
             @Override
             public void actionPerformed(ActionEvent e) {
                 panel.selectPreviousEntry();
+            }
+        });
+
+        String selectFirst = "selectFirst";
+        inputMap.put(Globals.getKeyPrefs().getKey(KeyBinding.SELECT_FIRST_ENTRY), selectFirst);
+        actionMap.put(selectFirst, new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent event) {
+                panel.selectFirstEntry();
+            }
+        });
+
+        String selectLast = "selectLast";
+        inputMap.put(Globals.getKeyPrefs().getKey(KeyBinding.SELECT_LAST_ENTRY), selectLast);
+        actionMap.put(selectLast, new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent event) {
+                panel.selectLastEntry();
             }
         });
     }

--- a/src/main/java/net/sf/jabref/gui/search/SearchResultFrame.java
+++ b/src/main/java/net/sf/jabref/gui/search/SearchResultFrame.java
@@ -166,14 +166,59 @@ public class SearchResultFrame {
             }
         };
 
-        ActionMap am = contentPane.getActionMap();
-        InputMap im = contentPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DATABASE), "close");
-        am.put("close", closeAction);
+        ActionMap actionMap = contentPane.getActionMap();
+        InputMap inputMap = contentPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
+        inputMap.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        inputMap.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DATABASE), "close");
+        actionMap.put("close", closeAction);
 
-        entryTable.getActionMap().put("copy", new AbstractAction() {
+        actionMap = entryTable.getActionMap();
+        inputMap = entryTable.getInputMap();
+        //Override 'selectNextColumnCell' and 'selectPreviousColumnCell' to move rows instead of cells on TAB
+        actionMap.put("selectNextColumnCell", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                selectNextEntry();
+            }
+        });
+        actionMap.put("selectPreviousColumnCell", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                selectPreviousEntry();
+            }
+        });
+        actionMap.put("selectNextRow", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                selectNextEntry();
+            }
+        });
+        actionMap.put("selectPreviousRow", new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                selectPreviousEntry();
+            }
+        });
 
+        String selectFirst = "selectFirst";
+        inputMap.put(Globals.getKeyPrefs().getKey(KeyBinding.SELECT_FIRST_ENTRY), selectFirst);
+        actionMap.put(selectFirst, new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent event) {
+                selectFirstEntry();
+            }
+        });
+
+        String selectLast = "selectLast";
+        inputMap.put(Globals.getKeyPrefs().getKey(KeyBinding.SELECT_LAST_ENTRY), selectLast);
+        actionMap.put(selectLast, new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent event) {
+                selectLastEntry();
+            }
+        });
+
+        actionMap.put("copy", new AbstractAction() {
             @Override
             public void actionPerformed(ActionEvent e) {
                 if (!selectionModel.getSelected().isEmpty()) {
@@ -191,7 +236,7 @@ public class SearchResultFrame {
 
         // override standard enter-action; enter opens the selected entry
         entryTable.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "Enter");
-        entryTable.getActionMap().put("Enter", new AbstractAction() {
+        actionMap.put("Enter", new AbstractAction() {
             @Override
             public void actionPerformed(ActionEvent ae) {
                 BibEntry entry = sortedEntries.get(entryTable.getSelectedRow());
@@ -244,8 +289,24 @@ public class SearchResultFrame {
     }
 
     public void selectFirstEntry() {
-        if (entryTable.getRowCount() > 0) {
-            entryTable.setRowSelectionInterval(0, 0);
+        selectEntry(0);
+    }
+
+    public void selectLastEntry() {
+        selectEntry(entryTable.getRowCount() - 1);
+    }
+
+    public void selectPreviousEntry() {
+        selectEntry((entryTable.getSelectedRow() - 1 + entryTable.getRowCount()) % entryTable.getRowCount());
+    }
+
+    public void selectNextEntry() {
+        selectEntry((entryTable.getSelectedRow() + 1) % entryTable.getRowCount());
+    }
+
+    public void selectEntry(int index) {
+        if (index >= 0 && index < entryTable.getRowCount()) {
+            entryTable.changeSelection(index, 0, false, false);
         } else {
             contentPane.setDividerLocation(1.0f);
         }

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -2301,3 +2301,6 @@ ID=
 ID_type=
 ID-based_entry_generator=
 Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+
+Select_first_entry=
+Select_last_entry=

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2301,3 +2301,6 @@ ID=ID
 ID_type=ID_typ
 ID-based_entry_generator=ID_basierter_Eintragsgenerator
 Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=Der_Fetcher_%0_hat_keinen_Eintrag_für_die_ID_%1_gefunden.
+
+Select_first_entry=Ersten_Eintrag_auswählen
+Select_last_entry=Letzten_Eintrag_auswählen

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2301,3 +2301,6 @@ ID=ID
 ID_type=ID_type
 ID-based_entry_generator=ID-based_entry_generator
 Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.
+
+Select_first_entry=Select_first_entry
+Select_last_entry=Select_last_entry

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -2301,3 +2301,6 @@ ID=
 ID_type=
 ID-based_entry_generator=
 Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+
+Select_first_entry=
+Select_last_entry=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -2301,3 +2301,6 @@ ID=
 ID_type=
 ID-based_entry_generator=
 Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+
+Select_first_entry=
+Select_last_entry=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -2301,3 +2301,6 @@ ID=
 ID_type=
 ID-based_entry_generator=
 Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+
+Select_first_entry=
+Select_last_entry=

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -2301,3 +2301,6 @@ ID=
 ID_type=
 ID-based_entry_generator=
 Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+
+Select_first_entry=
+Select_last_entry=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -2301,3 +2301,6 @@ ID=
 ID_type=
 ID-based_entry_generator=
 Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+
+Select_first_entry=
+Select_last_entry=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2301,3 +2301,6 @@ ID=
 ID_type=
 ID-based_entry_generator=
 Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+
+Select_first_entry=
+Select_last_entry=

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -2301,3 +2301,6 @@ ID=
 ID_type=
 ID-based_entry_generator=
 Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+
+Select_first_entry=
+Select_last_entry=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -2301,3 +2301,6 @@ ID=
 ID_type=
 ID-based_entry_generator=
 Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+
+Select_first_entry=
+Select_last_entry=

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -2301,3 +2301,6 @@ ID=
 ID_type=
 ID-based_entry_generator=
 Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+
+Select_first_entry=
+Select_last_entry=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2301,3 +2301,6 @@ ID=
 ID_type=
 ID-based_entry_generator=
 Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+
+Select_first_entry=
+Select_last_entry=

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -2301,3 +2301,6 @@ ID=
 ID_type=
 ID-based_entry_generator=
 Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+
+Select_first_entry=
+Select_last_entry=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -2301,3 +2301,6 @@ ID=
 ID_type=
 ID-based_entry_generator=
 Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+
+Select_first_entry=
+Select_last_entry=

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -2301,3 +2301,6 @@ ID=
 ID_type=
 ID-based_entry_generator=
 Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+
+Select_first_entry=
+Select_last_entry=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -2301,3 +2301,6 @@ ID=
 ID_type=
 ID-based_entry_generator=
 Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+
+Select_first_entry=
+Select_last_entry=


### PR DESCRIPTION
- <kbd>Pos1</kbd> / <kbd>HOME</kbd> now select the first/last entry in the main table and the search result frame.
- <kbd>UP</kbd> / <kbd>Down</kbd> / <kbd>Tab</kbd> / <kbd>shift+Tab</kbd> in the search result frame have now the same functionality as in the main  table.