### PR TITLE
Hotfix: Fix loop when pulling changes when current selected field has changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed download files failed silently when an invalid directory is selected
 - Fixed [#1949](https://github.com/JabRef/jabref/issues/1949): Error message directs to the wrong preference tab
 - Fixed InvalidBackgroundColor flickering with Ctrl-s and File > Save database
+- Fixed loop when pulling changes (shared database) when current selected field has changed
 
 ### Removed
 - The non-supported feature of being able to define file directories for any extension is removed. Still, it should work for older databases using the legacy `ps` and `pdf` fields, although we strongly encourage using the `file` field. 

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableSelectionListener.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableSelectionListener.java
@@ -113,6 +113,11 @@ public class MainTableSelectionListener implements ListEventListener<BibEntry>, 
         }
 
         final BibEntry newSelected = selected.get(0);
+        if (Objects.nonNull(panel.getCurrentEditor()) && (newSelected == panel.getCurrentEditor().getEntry())) {
+            // is already selected
+            return;
+        }
+
         if (newSelected != null) {
             final BasePanelMode mode = panel.getMode(); // What is the panel already showing?
             if ((mode == BasePanelMode.WILL_SHOW_EDITOR) || (mode == BasePanelMode.SHOWING_EDITOR)) {


### PR DESCRIPTION
@obraliar and I fixed a critical Bug in the shared Database (broken in v3.6):

### Steps to Reproduce:
- open 2 JabRef instances with shared database
- edit a field of an entry in the first instance and push the change (eg. selecting another field)
- select the same entry/field which was edited int the second instance
- pull changes in the second instance
- second JabRef loops indefinitely
