### PR TITLE
Fix when editing a bibEntry field the searchbar would be focused

### DIFF
--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -122,6 +122,7 @@ import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.model.event.EntryAddedEvent;
 import net.sf.jabref.model.event.EntryChangedEvent;
+import net.sf.jabref.model.event.EntryRemovedEvent;
 import net.sf.jabref.preferences.HighlightMatchingGroupPreferences;
 import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.shared.DBMSSynchronizer;
@@ -1280,6 +1281,12 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
         @Subscribe
         public void listen(EntryChangedEvent entryChangedEvent) {
+            frame.getGlobalSearchBar().setDontSelectSearchBar(true);
+            frame.getGlobalSearchBar().performSearch();
+        }
+
+        @Subscribe
+        public void listen(EntryRemovedEvent removedEntryEvent) {
             frame.getGlobalSearchBar().performSearch();
         }
     }

--- a/src/main/java/net/sf/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/net/sf/jabref/gui/search/GlobalSearchBar.java
@@ -65,7 +65,11 @@ public class GlobalSearchBar extends JPanel {
     private SearchResultFrame searchResultFrame;
 
     private SearchDisplayMode searchDisplayMode;
-    private boolean switchedDatabase;
+
+    /**
+     * if this flag is set the searchbar won't be selected after the next search
+     */
+    private boolean dontSelectSearchBar;
 
 
     public GlobalSearchBar(JabRefFrame frame) {
@@ -277,8 +281,8 @@ public class GlobalSearchBar extends JPanel {
             currentBasePanel.getMainTable().getTableModel().updateSearchState(MainTableDataModel.DisplayOption.DISABLED);
         }
 
-        if (switchedDatabase){
-            switchedDatabase = false;
+        if (dontSelectSearchBar){
+            dontSelectSearchBar = false;
             return;
         }
         focus();
@@ -370,15 +374,19 @@ public class GlobalSearchBar extends JPanel {
         this.searchResultFrame = searchResultFrame;
     }
 
-    public void setSearchTerm(String searchTerm, boolean switchedDatabase) {
+    public void setSearchTerm(String searchTerm, boolean dontSelectSearchBar) {
         if (searchTerm.equals(searchField.getText())){
             return;
         }
 
-        this.switchedDatabase = switchedDatabase;
+        setDontSelectSearchBar(dontSelectSearchBar);
         searchField.setText(searchTerm);
         // to hinder the autocomplete window to popup
         autoCompleteSupport.setVisible(false);
+    }
+
+    public void setDontSelectSearchBar(boolean dontSelectSearchBar) {
+        this.dontSelectSearchBar = dontSelectSearchBar;
     }
 
 }


### PR DESCRIPTION
Fix for #1549

### Steps to reproduce:
- Select a bibentry
- Edit a field
- save the change (eg. click outside the field)
- the searchbar would be focused
