### PR TITLE
Double authors removed

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -32,7 +32,8 @@ Tobias Diez <tobiasdiez@gmx.de>
 Waluyo Adi Siswanto <was.uthm@gmail.com> <was123@users.sourceforge.net>
 Michael Falkenthal <michael.falkenthal@googlemail.com>
 Michael Falkenthal <michael.falkenthal@googlemail.com> <michael.falkenthal@iaas.uni-stuttgart.de>
-<ambro2@users.noreply.github.com> <ambro2@users.sourceforge.net>
+Ambrogio Oliva <ambro2@users.noreply.github.com>
+Ambrogio Oliva <ambro2@users.sourceforge.net>
 Eduardo Greco <eduardogreco93@gmail.com>
 Daniel Bruehl <bruehl.dev@gmail.com>
 Egon Willighagen <egon.willighagen@gmail.com> <egonw@users.sourceforge.net>
@@ -100,3 +101,4 @@ Jorge Tornero <portpel@portpel.cd.ieo.es>
 Mélanie Tremblay <mel_4_7@yahoo.ca>
 Christoph Schwentker <cschwentker@gmail.com>
 Jens Döcke <jens.doecke@gmail.com>
+Jürgen Lange <juergen.lange@unitybox.de>

--- a/AUTHORS
+++ b/AUTHORS
@@ -8,7 +8,6 @@ Alessio Pollero
 Alex Montgomery
 Alexis Gallagher
 Alexsandro Lauber
-ambro2
 Ambrogio Oliva
 Andreas Amann
 Andreas Rudert
@@ -55,7 +54,6 @@ Fred
 Frédéric Darboux
 Gert Renckens
 Gregor Herrmann
-grimes2
 Guillaume Gardey
 Hakan Duran
 Hannes Restel


### PR DESCRIPTION
.mailmap edited, AUTHORS generated by script.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)

