### PR TITLE
Fixes #1958: Verbatim URL field is no longer checked for HTML encoded chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed [#1949](https://github.com/JabRef/jabref/issues/1949): Error message directs to the wrong preference tab
 - Fixed InvalidBackgroundColor flickering with Ctrl-s and File > Save database
 - Fixed loop when pulling changes (shared database) when current selected field has changed
-- Fixed [#1958](https://github.com/JabRef/jabref/issues/1958): Verbatim URL field is no longer checked for HTML encoded characters by integrity checks
+- Fixed [#1958](https://github.com/JabRef/jabref/issues/1958): Verbatim fields are no longer checked for HTML encoded characters by integrity checks
 
 ### Removed
 - The non-supported feature of being able to define file directories for any extension is removed. Still, it should work for older databases using the legacy `ps` and `pdf` fields, although we strongly encourage using the `file` field. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed [#1949](https://github.com/JabRef/jabref/issues/1949): Error message directs to the wrong preference tab
 - Fixed InvalidBackgroundColor flickering with Ctrl-s and File > Save database
 - Fixed loop when pulling changes (shared database) when current selected field has changed
+- Fixed [#1958](https://github.com/JabRef/jabref/issues/1958): Verbatim URL field is no longer checked for HTML encoded characters by integrity checks
 
 ### Removed
 - The non-supported feature of being able to define file directories for any extension is removed. Still, it should work for older databases using the legacy `ps` and `pdf` fields, although we strongly encourage using the `file` field. 

--- a/src/main/java/net/sf/jabref/logic/integrity/HTMLCharacterChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/HTMLCharacterChecker.java
@@ -9,7 +9,8 @@ import java.util.regex.Pattern;
 import net.sf.jabref.logic.integrity.IntegrityCheck.Checker;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.model.entry.FieldName;
+import net.sf.jabref.model.entry.FieldProperty;
+import net.sf.jabref.model.entry.InternalBibtexFields;
 
 public class HTMLCharacterChecker implements Checker {
     // Detect any HTML encoded character,
@@ -24,8 +25,8 @@ public class HTMLCharacterChecker implements Checker {
     public List<IntegrityMessage> check(BibEntry entry) {
         List<IntegrityMessage> results = new ArrayList<>();
         for (Map.Entry<String, String> field : entry.getFieldMap().entrySet()) {
-            // skip verbatim URL field
-            if (field.getKey().equals(FieldName.URL)) {
+            // skip verbatim fields
+            if (InternalBibtexFields.getFieldProperties(field.getKey()).contains(FieldProperty.VERBATIM)) {
                 continue;
             }
 

--- a/src/main/java/net/sf/jabref/logic/integrity/HTMLCharacterChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/HTMLCharacterChecker.java
@@ -17,9 +17,7 @@ public class HTMLCharacterChecker implements Checker {
     private static final Pattern HTML_CHARACTER_PATTERN = Pattern.compile("&[#\\p{Alnum}]+;");
 
     /**
-     * Checks, if there are any HTML encoded characters in the fields.
-     *
-     * This check excludes the `url` field as it allows HTML encoded characters.
+     * Checks, if there are any HTML encoded characters in nonverbatim fields.
      */
     @Override
     public List<IntegrityMessage> check(BibEntry entry) {

--- a/src/main/java/net/sf/jabref/logic/integrity/HTMLCharacterChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/HTMLCharacterChecker.java
@@ -9,20 +9,26 @@ import java.util.regex.Pattern;
 import net.sf.jabref.logic.integrity.IntegrityCheck.Checker;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.model.entry.FieldName;
 
 public class HTMLCharacterChecker implements Checker {
-
     // Detect any HTML encoded character,
     private static final Pattern HTML_CHARACTER_PATTERN = Pattern.compile("&[#\\p{Alnum}]+;");
 
-
     /**
-     * Checks, if there are any HTML encoded characters in the fields
+     * Checks, if there are any HTML encoded characters in the fields.
+     *
+     * This check excludes the `url` field as it allows HTML encoded characters.
      */
     @Override
     public List<IntegrityMessage> check(BibEntry entry) {
         List<IntegrityMessage> results = new ArrayList<>();
         for (Map.Entry<String, String> field : entry.getFieldMap().entrySet()) {
+            // skip verbatim URL field
+            if (field.getKey().equals(FieldName.URL)) {
+                continue;
+            }
+
             Matcher characterMatcher = HTML_CHARACTER_PATTERN.matcher(field.getValue());
             if (characterMatcher.find()) {
                 results.add(

--- a/src/main/java/net/sf/jabref/model/entry/FieldName.java
+++ b/src/main/java/net/sf/jabref/model/entry/FieldName.java
@@ -10,7 +10,6 @@ import java.util.Map;
  *
  */
 public class FieldName {
-
     // Character separating field names that are to be used in sequence as
     // fallbacks for a single column (e.g. "author/editor" to use editor where
     // author is not set):
@@ -128,7 +127,6 @@ public class FieldName {
     // Map to hold alternative display names
     private static final Map<String, String> displayNames = new HashMap<>();
 
-
     public static String orFields(String... fields) {
         return String.join(FieldName.FIELD_SEPARATOR, fields);
     }
@@ -148,7 +146,6 @@ public class FieldName {
         displayNames.put(FieldName.URI, "URI");
         displayNames.put(FieldName.URL, "URL");
     }
-
 
     /**
      * @param field - field to get the display version for

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -225,6 +225,7 @@ public class IntegrityCheckTest {
         assertCorrect(createContext("title", "Not a single {HTML} character"));
         assertCorrect(createContext("month", "#jan#"));
         assertCorrect(createContext("author", "A. Einstein and I. Newton"));
+        assertCorrect(createContext("url", "http://www.thinkmind.org/index.php?view=article&amp;articleid=cloud_computing_2013_1_20_20130"));
         assertWrong(createContext("author", "Lenhard, J&ouml;rg"));
         assertWrong(createContext("author", "Lenhard, J&#227;rg"));
         assertWrong(createContext("journal", "&Auml;rling Str&ouml;m for &#8211; &#x2031;"));


### PR DESCRIPTION
- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef