### PR TITLE
Fix Entrytypedialog

### DIFF
--- a/src/main/java/net/sf/jabref/gui/EntryTypeDialog.java
+++ b/src/main/java/net/sf/jabref/gui/EntryTypeDialog.java
@@ -256,11 +256,18 @@ public class EntryTypeDialog extends JDialog implements ActionListener {
         return jPanel;
     }
 
+    private void stopFetching() {
+        if (fetcherWorker.getState() == SwingWorker.StateValue.STARTED) {
+            fetcherWorker.cancel(true);
+        }
+    }
+
     @Override
     public void actionPerformed(ActionEvent e) {
         if (e.getSource() instanceof TypeButton) {
             type = ((TypeButton) e.getSource()).getType();
         }
+        stopFetching();
         dispose();
     }
 
@@ -276,7 +283,7 @@ public class EntryTypeDialog extends JDialog implements ActionListener {
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            fetcherWorker.cancel(true);
+            stopFetching();
             dispose();
         }
     }


### PR DESCRIPTION
Fixing a problem when closing the EntryTypeDialog. The problem is that it is not checked if the fetcherWorker already started. So if we closed the Dialog with `ESC` or `X` a CancelException was thrown. To fix this we check the status of the SwingWorker when we try to close the window.


