### PR TITLE
Fix search mixed from contains and grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,15 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 ### Changed
 - Added fetcher for [MathSciNet](http://www.ams.org/mathscinet), [zbMATH](https://www.zbmath.org/) and [Astrophysics Data System](http://www.adsabs.harvard.edu/)
-- Implemented [#825](https://github.com/JabRef/jabref/issues/825): Search Bar across all bib files instead each having its own
-- Implemented [#573](https://github.com/JabRef/jabref/issues/573): Add key shortcut for global search (`ctrl+shift+f`, if the searchfield is empty it will be focused instead)
-- The search result Window will now show which entry belongs to which bib file
-- The search result Window will now remember its location
-- The search result Window won't stay on top anymore if the main Window is focused and will be present in the taskbar
-- The user can jump from the searchbar to the maintable  with `ctrl+enter`
-- Implemented [#573 (comment)](https://github.com/JabRef/jabref/issues/573#issuecomment-232284156): Added shortcut: closing the search result window with `ctrl+w`
+- Improved search:
+  - Search queries consisting of a normal query and a field-based query are now supported (for example, `JabRef AND author == you`)
+  - Implemented [#825](https://github.com/JabRef/jabref/issues/825): Search Bar across all bib files instead each having its own
+  - Implemented [#573](https://github.com/JabRef/jabref/issues/573): Add key shortcut for global search (`ctrl+shift+f`, if the searchfield is empty it will be focused instead)
+  - The search result Window will now show which entry belongs to which bib file
+  - The search result Window will now remember its location
+  - The search result Window won't stay on top anymore if the main Window is focused and will be present in the taskbar
+  - The user can jump from the searchbar to the maintable  with `ctrl+enter`
+  - Implemented [#573 (comment)](https://github.com/JabRef/jabref/issues/573#issuecomment-232284156): Added shortcut: closing the search result window with `ctrl+w`
 - Added integrity check for fields with BibTeX keys, e.g., `crossref` and `related`, to check that the key exists
 - [#1496](https://github.com/JabRef/jabref/issues/1496) Keep track of which entry a downloaded file belongs to
 - Made it possible to download multiple entries in one action

--- a/src/main/antlr4/net/sf/jabref/search/Search.g4
+++ b/src/main/antlr4/net/sf/jabref/search/Search.g4
@@ -41,7 +41,9 @@ expression:
     ;
 
 comparison:
-    left=name operator=(CONTAINS | MATCHES | EQUAL | EEQUAL | NEQUAL) right=name; // example: author != miller
+    left=name operator=(CONTAINS | MATCHES | EQUAL | EEQUAL | NEQUAL) right=name // example: author != miller
+    | right=name                                                                 // example: miller (search all fields)
+    ;
 
 name:
     STRING // example: "miller"

--- a/src/main/java/net/sf/jabref/logic/search/SearchQuery.java
+++ b/src/main/java/net/sf/jabref/logic/search/SearchQuery.java
@@ -1,5 +1,7 @@
 package net.sf.jabref.logic.search;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 import net.sf.jabref.logic.l10n.Localization;
@@ -10,6 +12,7 @@ import net.sf.jabref.model.search.rules.ContainBasedSearchRule;
 import net.sf.jabref.model.search.rules.GrammarBasedSearchRule;
 import net.sf.jabref.model.search.rules.SearchRule;
 import net.sf.jabref.model.search.rules.SearchRules;
+import net.sf.jabref.model.search.rules.SentenceAnalyzer;
 
 public class SearchQuery implements SearchMatcher {
 
@@ -104,4 +107,17 @@ public class SearchQuery implements SearchMatcher {
         return description;
     }
 
+    /**
+     * Returns a list of words this query searches for.
+     * The returned strings can be a regular expression.
+     */
+    public List<String> getSearchWords() {
+        if (isRegularExpression()) {
+            return Collections.singletonList(getQuery());
+        } else {
+            // Parses the search query for valid words and returns a list these words.
+            // For example, "The great Vikinger" will give ["The","great","Vikinger"]
+            return (new SentenceAnalyzer(getQuery())).getWords();
+        }
+    }
 }

--- a/src/main/java/net/sf/jabref/logic/search/SearchQuery.java
+++ b/src/main/java/net/sf/jabref/logic/search/SearchQuery.java
@@ -3,7 +3,6 @@ package net.sf.jabref.logic.search;
 import java.util.Objects;
 
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.logic.search.rules.describer.SearchDescriber;
 import net.sf.jabref.logic.search.rules.describer.SearchDescribers;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.search.SearchMatcher;
@@ -24,8 +23,8 @@ public class SearchQuery implements SearchMatcher {
         this.query = Objects.requireNonNull(query);
         this.caseSensitive = caseSensitive;
         this.regularExpression = regularExpression;
-        this.rule = Objects.requireNonNull(getSearchRule());
-        this.description = Objects.requireNonNull(getSearchDescriber().getDescription());
+        this.rule = SearchRules.getSearchRuleByQuery(query, caseSensitive, regularExpression);
+        this.description = SearchDescribers.getSearchDescriberFor(rule, query).getDescription();
     }
 
     @Override
@@ -35,23 +34,15 @@ public class SearchQuery implements SearchMatcher {
 
     @Override
     public boolean isMatch(BibEntry entry) {
-        return this.getRule().applyRule(getQuery(), entry);
+        return rule.applyRule(getQuery(), entry);
     }
 
     public boolean isValid() {
-        return this.getRule().validateSearchStrings(getQuery());
+        return rule.validateSearchStrings(getQuery());
     }
 
     public boolean isContainsBasedSearch() {
-        return this.getRule() instanceof ContainBasedSearchRule;
-    }
-
-    private SearchRule getSearchRule() {
-        return SearchRules.getSearchRuleByQuery(getQuery(), isCaseSensitive(), isRegularExpression());
-    }
-
-    private SearchDescriber getSearchDescriber() {
-        return SearchDescribers.getSearchDescriberFor(getSearchRule(), getQuery());
+        return rule instanceof ContainBasedSearchRule;
     }
 
     private String getCaseSensitiveDescription() {
@@ -94,7 +85,7 @@ public class SearchQuery implements SearchMatcher {
     }
 
     public boolean isGrammarBasedSearch() {
-        return this.getRule() instanceof GrammarBasedSearchRule;
+        return rule instanceof GrammarBasedSearchRule;
     }
 
     public String getQuery() {
@@ -113,7 +104,4 @@ public class SearchQuery implements SearchMatcher {
         return description;
     }
 
-    private SearchRule getRule() {
-        return rule;
-    }
 }

--- a/src/main/java/net/sf/jabref/logic/search/SearchQueryHighlightObservable.java
+++ b/src/main/java/net/sf/jabref/logic/search/SearchQueryHighlightObservable.java
@@ -1,15 +1,16 @@
 package net.sf.jabref.logic.search;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.regex.Pattern;
 
-import net.sf.jabref.model.search.rules.SentenceAnalyzer;
-
+/**
+ * @deprecated rewrite this class using the EventBus framework
+ */
+@Deprecated
 public class SearchQueryHighlightObservable {
 
     private final List<SearchQueryHighlightListener> listeners = new ArrayList<>();
@@ -34,17 +35,6 @@ public class SearchQueryHighlightObservable {
     }
 
     /**
-     * Parses the search query for valid words and returns a list these words. For example, "The great Vikinger" will
-     * give ["The","great","Vikinger"]
-     *
-     * @param searchText the search query
-     * @return list of words found in the search query
-     */
-    private List<String> getSearchwords(String searchText) {
-        return (new SentenceAnalyzer(searchText)).getWords();
-    }
-
-    /**
      * Fires an event if a search was started (or cleared)
      *
      * @param searchQuery the search query
@@ -53,13 +43,8 @@ public class SearchQueryHighlightObservable {
         Objects.requireNonNull(searchQuery);
 
         // Parse the search string to words
-        if (searchQuery.isGrammarBasedSearch()) {
-            pattern = Optional.empty();
-        } else if (searchQuery.isRegularExpression()) {
-            pattern = getPatternForWords(Collections.singletonList(searchQuery.getQuery()), true, searchQuery.isCaseSensitive());
-        } else {
-            pattern = getPatternForWords(getSearchwords(searchQuery.getQuery()), searchQuery.isRegularExpression(), searchQuery.isCaseSensitive());
-        }
+        pattern = getPatternForWords(searchQuery.getSearchWords(), searchQuery.isRegularExpression(),
+                searchQuery.isCaseSensitive());
 
         update();
     }

--- a/src/main/java/net/sf/jabref/logic/search/SearchQueryHighlightObservable.java
+++ b/src/main/java/net/sf/jabref/logic/search/SearchQueryHighlightObservable.java
@@ -33,21 +33,6 @@ public class SearchQueryHighlightObservable {
         return this;
     }
 
-    public int getListenerCount() {
-        return listeners.size();
-    }
-
-    /**
-     * Remove a SearchQueryHighlightListener
-     *
-     * @param l SearchQueryHighlightListener to be removed
-     */
-    public void removeSearchListener(SearchQueryHighlightListener l) {
-        Objects.requireNonNull(l);
-
-        listeners.remove(l);
-    }
-
     /**
      * Parses the search query for valid words and returns a list these words. For example, "The great Vikinger" will
      * give ["The","great","Vikinger"]

--- a/src/main/java/net/sf/jabref/logic/search/rules/describer/GrammarBasedSearchRuleDescriber.java
+++ b/src/main/java/net/sf/jabref/logic/search/rules/describer/GrammarBasedSearchRuleDescriber.java
@@ -10,7 +10,6 @@ import net.sf.jabref.model.search.rules.GrammarBasedSearchRule;
 import net.sf.jabref.search.SearchBaseVisitor;
 import net.sf.jabref.search.SearchParser;
 
-import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
 
 public class GrammarBasedSearchRuleDescriber implements SearchDescriber {

--- a/src/main/java/net/sf/jabref/logic/search/rules/describer/GrammarBasedSearchRuleDescriber.java
+++ b/src/main/java/net/sf/jabref/logic/search/rules/describer/GrammarBasedSearchRuleDescriber.java
@@ -1,6 +1,7 @@
 package net.sf.jabref.logic.search.rules.describer;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 import net.sf.jabref.logic.l10n.Localization;
@@ -9,6 +10,7 @@ import net.sf.jabref.model.search.rules.GrammarBasedSearchRule;
 import net.sf.jabref.search.SearchBaseVisitor;
 import net.sf.jabref.search.SearchParser;
 
+import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
 
 public class GrammarBasedSearchRuleDescriber implements SearchDescriber {
@@ -57,8 +59,13 @@ public class GrammarBasedSearchRuleDescriber implements SearchDescriber {
             @Override
             public String visitComparison(SearchParser.ComparisonContext context) {
 
-                final String field = StringUtil.unquote(context.left.getText(), '"');
+                final Optional<SearchParser.NameContext> fieldDescriptor = Optional.ofNullable(context.left);
                 final String value = StringUtil.unquote(context.right.getText(), '"');
+                if (!fieldDescriptor.isPresent()) {
+                    return new ContainsAndRegexBasedSearchRuleDescriber(caseSensitive, regExp, value).getDescription();
+                }
+
+                final String field = StringUtil.unquote(fieldDescriptor.get().getText(), '"');
                 final GrammarBasedSearchRule.ComparisonOperator operator = GrammarBasedSearchRule.ComparisonOperator.build(context.operator.getText());
 
                 final boolean regExpFieldSpec = !Pattern.matches("\\w+", field);

--- a/src/main/java/net/sf/jabref/model/search/rules/ContainBasedSearchRule.java
+++ b/src/main/java/net/sf/jabref/model/search/rules/ContainBasedSearchRule.java
@@ -39,7 +39,7 @@ public class ContainBasedSearchRule implements SearchRule {
         List<String> unmatchedWords = new SentenceAnalyzer(searchString).getWords();
 
         for (String fieldContent : bibEntry.getFieldValues()) {
-            String formattedFieldContent = ContainBasedSearchRule.LATEX_TO_UNICODE_FORMATTER.format(fieldContent);
+            String formattedFieldContent = LATEX_TO_UNICODE_FORMATTER.format(fieldContent);
             if (!caseSensitive) {
                 formattedFieldContent = formattedFieldContent.toLowerCase();
             }

--- a/src/test/java/net/sf/jabref/logic/search/SearchQueryHighlightObservableTest.java
+++ b/src/test/java/net/sf/jabref/logic/search/SearchQueryHighlightObservableTest.java
@@ -8,24 +8,23 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SearchQueryHighlightObservableTest {
 
-        private SearchQueryHighlightObservable observable;
-        private SearchQueryHighlightListener listener;
     @Captor ArgumentCaptor<Optional<Pattern>> captor;
+    @Mock private SearchQueryHighlightListener listener;
+    private SearchQueryHighlightObservable observable;
 
     @Before
     public void setUp() throws Exception {
         observable = new SearchQueryHighlightObservable();
-        listener = mock(SearchQueryHighlightListener.class);
     }
 
     @Test
@@ -49,12 +48,13 @@ public class SearchQueryHighlightObservableTest {
     }
 
     @Test
-    public void addSearchListenerDoesNotNotifiesRegisteredListenerAboutGrammarBasedSearches() throws Exception {
+    public void addSearchListenerNotifiesRegisteredListenerAboutGrammarBasedSearches() throws Exception {
         observable.addSearchListener(listener);
 
         observable.fireSearchlistenerEvent(new SearchQuery("author=harrer", false, false));
 
         verify(listener, atLeastOnce()).highlightPattern(captor.capture());
-        assertEquals(Optional.empty(), captor.getValue());
+        // TODO: We would expect "harrer" here
+        assertEquals("(\\Qauthor=harrer\\E)", captor.getValue().get().pattern());
     }
 }

--- a/src/test/java/net/sf/jabref/logic/search/SearchQueryHighlightObservableTest.java
+++ b/src/test/java/net/sf/jabref/logic/search/SearchQueryHighlightObservableTest.java
@@ -1,33 +1,60 @@
 package net.sf.jabref.logic.search;
 
 import java.util.Optional;
+import java.util.regex.Pattern;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
+@RunWith(MockitoJUnitRunner.class)
 public class SearchQueryHighlightObservableTest {
 
-    @Test
-    public void testUsage() {
-        SearchQueryHighlightObservable observable = new SearchQueryHighlightObservable();
-        assertEquals(0, observable.getListenerCount());
-        observable.fireSearchlistenerEvent(new SearchQuery("test", false, false));
-        SearchQueryHighlightListener listener = highlightPattern -> assertTrue("pattern must be there", highlightPattern.isPresent());
-        observable.addSearchListener(listener);
-        assertEquals(1, observable.getListenerCount());
+        private SearchQueryHighlightObservable observable;
+        private SearchQueryHighlightListener listener;
+    @Captor ArgumentCaptor<Optional<Pattern>> captor;
 
-        observable.addSearchListener(listener);
-        assertEquals(1, observable.getListenerCount());
-
-        observable.fireSearchlistenerEvent(new SearchQuery("test", true, true));
-        observable.removeSearchListener(listener);
-        assertEquals(0, observable.getListenerCount());
-
-        observable.fireSearchlistenerEvent(new SearchQuery("author=harrer", true, true));
-        observable.addSearchListener(p -> assertEquals(Optional.empty(), p));
-        assertEquals(1, observable.getListenerCount());
+    @Before
+    public void setUp() throws Exception {
+        observable = new SearchQueryHighlightObservable();
+        listener = mock(SearchQueryHighlightListener.class);
     }
 
+    @Test
+    public void addSearchListenerNotifiesListenerAboutPreviousPattern() throws Exception {
+        observable.fireSearchlistenerEvent(new SearchQuery("test", false, false));
+
+        observable.addSearchListener(listener);
+
+        verify(listener).highlightPattern(captor.capture());
+        assertEquals("(\\Qtest\\E)", captor.getValue().get().pattern());
+    }
+
+    @Test
+    public void addSearchListenerNotifiesRegisteredListener() throws Exception {
+        observable.addSearchListener(listener);
+
+        observable.fireSearchlistenerEvent(new SearchQuery("test", false, false));
+
+        verify(listener, atLeastOnce()).highlightPattern(captor.capture());
+        assertEquals("(\\Qtest\\E)", captor.getValue().get().pattern());
+    }
+
+    @Test
+    public void addSearchListenerDoesNotNotifiesRegisteredListenerAboutGrammarBasedSearches() throws Exception {
+        observable.addSearchListener(listener);
+
+        observable.fireSearchlistenerEvent(new SearchQuery("author=harrer", false, false));
+
+        verify(listener, atLeastOnce()).highlightPattern(captor.capture());
+        assertEquals(Optional.empty(), captor.getValue());
+    }
 }

--- a/src/test/java/net/sf/jabref/logic/search/SearchQueryTest.java
+++ b/src/test/java/net/sf/jabref/logic/search/SearchQueryTest.java
@@ -21,15 +21,15 @@ public class SearchQueryTest {
 
     @Test
     public void testIsContainsBasedSearch() {
-        assertTrue(new SearchQuery("asdf", true, false).isContainsBasedSearch());
+        assertFalse(new SearchQuery("asdf", true, false).isContainsBasedSearch());
         assertFalse(new SearchQuery("asdf", true, true).isContainsBasedSearch());
         assertFalse(new SearchQuery("author=asdf", true, false).isContainsBasedSearch());
     }
 
     @Test
     public void testIsGrammarBasedSearch() {
-        assertFalse(new SearchQuery("asdf", true, false).isGrammarBasedSearch());
-        assertFalse(new SearchQuery("asdf", true, true).isGrammarBasedSearch());
+        assertTrue(new SearchQuery("asdf", true, false).isGrammarBasedSearch());
+        assertTrue(new SearchQuery("asdf", true, true).isGrammarBasedSearch());
         assertTrue(new SearchQuery("author=asdf", true, false).isGrammarBasedSearch());
     }
 
@@ -90,7 +90,7 @@ public class SearchQueryTest {
 
     @Test
     public void testIsNotValidQueryContainsBracketNotAsRegEx() {
-        assertFalse(new SearchQuery("asdf[", true, true).isValid());
+        assertTrue(new SearchQuery("asdf[", true, true).isValid());
     }
 
     @Test
@@ -105,7 +105,7 @@ public class SearchQueryTest {
 
     @Test
     public void testIsValidQueryContainsBracketAsRegEx() {
-        assertFalse(new SearchQuery("asdf[", true, true).isValid());
+        assertTrue(new SearchQuery("asdf[", true, true).isValid());
     }
 
     @Test
@@ -126,5 +126,15 @@ public class SearchQueryTest {
     @Test
     public void testIsValidQueryWithNumbersAndEqualSignNotAsRegEx() {
         assertTrue(new SearchQuery("author=123", true, false).isValid());
+    }
+
+    @Test
+    public void isMatchedForNormalAndFieldBasedSearchMixed() {
+        BibEntry entry = new BibEntry();
+        entry.setType(BibtexEntryTypes.ARTICLE);
+        entry.setField("author", "asdf");
+        entry.setField("abstract", "text");
+
+        assertTrue(new SearchQuery("text AND author=asdf", true, true).isMatch(entry));
     }
 }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

As observed by @oscargus in https://github.com/JabRef/jabref/pull/1876#issuecomment-247533268 certain mixed search queries does not work (for example, `fruity and keywords=apple`).
This PR fixes this issue.

Side-effect: simple queries as `fruity` are also recognized as "grammar based" (which is why I had to change a few tests). However, there should be no major performance decline since the query parsing is quite fast and for the actual search in the end the same code gets called.

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)

