### PR TITLE
Fix EntryTypeDialog using BibLaTeX-mode

### DIFF
--- a/src/main/java/net/sf/jabref/gui/EntryTypeDialog.java
+++ b/src/main/java/net/sf/jabref/gui/EntryTypeDialog.java
@@ -120,9 +120,8 @@ public class EntryTypeDialog extends JDialog implements ActionListener {
             if (!CustomEntryTypesManager.ALL.isEmpty()) {
                 panel.add(createEntryGroupPanel(Localization.lang("Custom"), CustomEntryTypesManager.ALL));
             }
-
-            panel.add(createIdFetcherPanel());
         }
+        panel.add(createIdFetcherPanel());
 
         return panel;
     }


### PR DESCRIPTION
While fixing another bug (#1987) in the EntryTypeDialog I created a new one. To fix this bug I added the IdFetcher section to the BibLaTeX-mode, as it was intended. Before, it was only in the BibTeX mode. The problem was that the fetcherWorker was null in the BibLaTeX-mode, because `createIdFetcherPanel()` was only called in the `else` part. So the fetcherWorker was never initialized.
The ParameterizedDialogNewEntryTest works fine again.

- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef

Fixes #2001

