### PR TITLE
Revert deprecation

### DIFF
--- a/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
+++ b/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
@@ -58,7 +58,7 @@ public class Benchmarks {
             entry.setField("keyword", "testkeyword");
             entry.setField("year", "1" + i);
             entry.setField("rnd", "2" + randomizer.nextInt());
-            database.insertEntryWithDuplicationCheck(entry);
+            database.insertEntry(entry);
         }
         BibtexDatabaseWriter<StringSaveSession> databaseWriter = new BibtexDatabaseWriter<>(StringSaveSession::new);
         StringSaveSession saveSession = databaseWriter.savePartOfDatabase(

--- a/src/main/java/net/sf/jabref/collab/EntryAddChange.java
+++ b/src/main/java/net/sf/jabref/collab/EntryAddChange.java
@@ -31,8 +31,8 @@ class EntryAddChange extends Change {
     @Override
     public boolean makeChange(BasePanel panel, BibDatabase secondary, NamedCompound undoEdit) {
         diskEntry.setId(IdGenerator.next());
-        panel.getDatabase().insertEntryWithDuplicationCheck(diskEntry);
-        secondary.insertEntryWithDuplicationCheck(diskEntry);
+        panel.getDatabase().insertEntry(diskEntry);
+        secondary.insertEntry(diskEntry);
         undoEdit.addEdit(new UndoableInsertEntry(panel.getDatabase(), diskEntry, panel));
         return true;
     }

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -830,7 +830,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 // independently of the copied
                 // ones.
                 be.setId(IdGenerator.next());
-                bibDatabaseContext.getDatabase().insertEntryWithDuplicationCheck(be);
+                bibDatabaseContext.getDatabase().insertEntry(be);
 
                 ce.addEdit(new UndoableInsertEntry(bibDatabaseContext.getDatabase(), be, BasePanel.this));
 
@@ -1138,7 +1138,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             String id = IdGenerator.next();
             final BibEntry be = new BibEntry(id, actualType.getName());
             try {
-                bibDatabaseContext.getDatabase().insertEntryWithDuplicationCheck(be);
+                bibDatabaseContext.getDatabase().insertEntry(be);
                 // Set owner/timestamp if options are enabled:
                 List<BibEntry> list = new ArrayList<>();
                 list.add(be);
@@ -1305,7 +1305,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
     public void insertEntry(final BibEntry bibEntry) {
         if (bibEntry != null) {
             try {
-                bibDatabaseContext.getDatabase().insertEntryWithDuplicationCheck(bibEntry);
+                bibDatabaseContext.getDatabase().insertEntry(bibEntry);
                 if (Globals.prefs.getBoolean(JabRefPreferences.USE_OWNER)) {
                     // Set owner field to default value
                     UpdateField.setAutomaticFields(bibEntry, true, true, Globals.prefs.getUpdateFieldPreferences());

--- a/src/main/java/net/sf/jabref/gui/DuplicateSearch.java
+++ b/src/main/java/net/sf/jabref/gui/DuplicateSearch.java
@@ -124,7 +124,7 @@ public class DuplicateSearch implements Runnable {
                 // and adding merged entries:
                 if (!toAdd.isEmpty()) {
                     for (BibEntry entry : toAdd) {
-                        panel.getDatabase().insertEntryWithDuplicationCheck(entry);
+                        panel.getDatabase().insertEntry(entry);
                         ce.addEdit(new UndoableInsertEntry(panel.getDatabase(), entry, panel));
                     }
                     panel.markBaseChanged();

--- a/src/main/java/net/sf/jabref/gui/externalfiles/DroppedFileHandler.java
+++ b/src/main/java/net/sf/jabref/gui/externalfiles/DroppedFileHandler.java
@@ -293,7 +293,7 @@ public class DroppedFileHandler {
 
                 aXmpEntriesInFile.setId(IdGenerator.next());
                 edits.addEdit(new UndoableInsertEntry(panel.getDatabase(), aXmpEntriesInFile, panel));
-                panel.getDatabase().insertEntryWithDuplicationCheck(aXmpEntriesInFile);
+                panel.getDatabase().insertEntry(aXmpEntriesInFile);
                 doLink(aXmpEntriesInFile, fileType, destFilename, true, edits);
 
             }

--- a/src/main/java/net/sf/jabref/gui/importer/EntryFromFileCreatorManager.java
+++ b/src/main/java/net/sf/jabref/gui/importer/EntryFromFileCreatorManager.java
@@ -147,7 +147,7 @@ public final class EntryFromFileCreatorManager {
                 if (!database.containsEntryWithId(entry.get().getId())) {
                     // Work around SIDE EFFECT of creator.createEntry. The EntryFromPDFCreator also creates the entry in the table
                     // Therefore, we only insert the entry if it is not already present
-                    if (database.insertEntryWithDuplicationCheck(entry.get())) {
+                    if (database.insertEntry(entry.get())) {
                         importGUIMessages.add("Problem importing " + f.getPath() + ": Insert into BibDatabase failed.");
                     } else {
                         count++;

--- a/src/main/java/net/sf/jabref/gui/importer/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ImportInspectionDialog.java
@@ -459,7 +459,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
 
             entry.setId(IdGenerator.next());
             // Add the entry to the database we are working with:
-            database.insertEntryWithDuplicationCheck(entry);
+            database.insertEntry(entry);
 
             // Generate a unique key:
             BibtexKeyPatternUtil.makeLabel(localMetaData, database, entry,
@@ -502,7 +502,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
             for (BibEntry entry : entries) {
 
                 entry.setId(IdGenerator.next());
-                database.insertEntryWithDuplicationCheck(entry);
+                database.insertEntry(entry);
 
                 BibtexKeyPatternUtil.makeLabel(localMetaData, database, entry,
                         Globals.prefs.getBibtexKeyPatternPreferences());
@@ -736,7 +736,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
                 }
 
                 entry.setId(IdGenerator.next());
-                panel.getDatabase().insertEntryWithDuplicationCheck(entry);
+                panel.getDatabase().insertEntry(entry);
                 ce.addEdit(new UndoableInsertEntry(panel.getDatabase(), entry, panel));
 
             }

--- a/src/main/java/net/sf/jabref/gui/importer/ImportMenuItem.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ImportMenuItem.java
@@ -206,7 +206,7 @@ public class ImportMenuItem extends JMenuItem implements ActionListener {
 
                 // Merge entries:
                 for (BibEntry entry : pr.getDatabase().getEntries()) {
-                    database.insertEntryWithDuplicationCheck(entry);
+                    database.insertEntry(entry);
                 }
 
                 // Merge strings:
@@ -233,7 +233,7 @@ public class ImportMenuItem extends JMenuItem implements ActionListener {
                     if (markEntries) {
                         EntryMarker.markEntry(entry, EntryMarker.IMPORT_MARK_LEVEL, false, new NamedCompound(""));
                     }
-                    database.insertEntryWithDuplicationCheck(entry);
+                    database.insertEntry(entry);
                 }
             }
         }

--- a/src/main/java/net/sf/jabref/gui/importer/actions/AppendDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/importer/actions/AppendDatabaseAction.java
@@ -118,7 +118,7 @@ public class AppendDatabaseAction implements BaseAction {
                 be.setId(IdGenerator.next());
                 UpdateField.setAutomaticFields(be, overwriteOwner, overwriteTimeStamp,
                         Globals.prefs.getUpdateFieldPreferences());
-                database.insertEntryWithDuplicationCheck(be);
+                database.insertEntry(be);
                 appendedEntries.add(be);
                 originalEntries.add(originalEntry);
                 ce.addEdit(new UndoableInsertEntry(database, be, panel));

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableColumn.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableColumn.java
@@ -94,7 +94,7 @@ public class MainTableColumn {
 
         Optional<String> content = Optional.empty();
         for (String field : bibtexFields) {
-            content = entry.getResolvedFieldOrAlias(field, database.orElse(null));
+            content = BibDatabase.getResolvedField(field, entry, database.orElse(null));
             if (content.isPresent()) {
                 isNameColumn = InternalBibtexFields.getFieldProperties(field).contains(FieldProperty.PERSON_NAMES);
                 break;
@@ -127,7 +127,7 @@ public class MainTableColumn {
      * The reasons for being different are (combinations may also happen):
      * - The entry has a crossref where the field content is obtained from
      * - The field has a string in it (which getColumnValue() resolves)
-     * - There are some alias fields. For example, if the entry has a date field but no year field, getResolvedFieldOrAlias()
+     * - There are some alias fields. For example, if the entry has a date field but no year field, getResolvedField()
      *   will return the year value from the date field when queried for year
      *
      *
@@ -148,7 +148,7 @@ public class MainTableColumn {
                 return false;
             } else {
                 plainFieldContent = entry.getField(field);
-                resolvedFieldContent = entry.getResolvedFieldOrAlias(field, database.orElse(null));
+                resolvedFieldContent = BibDatabase.getResolvedField(field, entry, database.orElse(null));
             }
 
             if (resolvedFieldContent.isPresent()) {

--- a/src/main/java/net/sf/jabref/gui/undo/UndoableInsertEntry.java
+++ b/src/main/java/net/sf/jabref/gui/undo/UndoableInsertEntry.java
@@ -54,7 +54,7 @@ public class UndoableInsertEntry extends AbstractUndoableJabRefEdit {
     @Override
     public void redo() {
         super.redo();
-        base.insertEntryWithDuplicationCheck(entry);
+        base.insertEntry(entry);
     }
 
 }

--- a/src/main/java/net/sf/jabref/logic/auxparser/AuxParser.java
+++ b/src/main/java/net/sf/jabref/logic/auxparser/AuxParser.java
@@ -173,6 +173,6 @@ public class AuxParser {
     private void insertEntry(BibEntry entry, AuxParserResult result) {
         BibEntry clonedEntry = (BibEntry) entry.clone();
         clonedEntry.setId(IdGenerator.next());
-        result.getGeneratedBibDatabase().insertEntryWithDuplicationCheck(clonedEntry);
+        result.getGeneratedBibDatabase().insertEntry(clonedEntry);
     }
 }

--- a/src/main/java/net/sf/jabref/logic/exporter/OpenDocumentRepresentation.java
+++ b/src/main/java/net/sf/jabref/logic/exporter/OpenDocumentRepresentation.java
@@ -199,7 +199,7 @@ class OpenDocumentRepresentation {
     }
 
     private String getField(BibEntry e, String field) {
-        return e.getResolvedFieldOrAlias(field, database).orElse("");
+        return BibDatabase.getResolvedField(field, e, database).orElse("");
     }
 
     private void addTableCell(Document doc, Element parent, String content) {

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/BibtexParser.java
@@ -243,7 +243,7 @@ public class BibtexParser implements Parser {
             // store complete parsed serialization (comments, type definition + type contents)
             entry.setParsedSerialization(commentsAndEntryTypeDefinition + dumpTextReadSoFarToString());
 
-            boolean duplicateKey = database.insertEntryWithDuplicationCheck(entry);
+            boolean duplicateKey = database.insertEntry(entry);
             if (duplicateKey) {
                 parserResult.addDuplicateKey(entry.getCiteKey());
             } else if (!entry.getCiteKeyOptional().isPresent() || entry.getCiteKeyOptional().get().isEmpty()) {

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/PdfContentImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/PdfContentImporter.java
@@ -209,7 +209,7 @@ public class PdfContentImporter extends ImportFormat {
             if (doi.isPresent()) {
                 ParserResult parserResult = new ParserResult(result);
                 Optional<BibEntry> entry = new DoiFetcher(importFormatPreferences).performSearchById(doi.get().getDOI());
-                entry.ifPresent(parserResult.getDatabase()::insertEntryWithDuplicationCheck);
+                entry.ifPresent(parserResult.getDatabase()::insertEntry);
                 return parserResult;
             }
 

--- a/src/main/java/net/sf/jabref/logic/layout/LayoutEntry.java
+++ b/src/main/java/net/sf/jabref/logic/layout/LayoutEntry.java
@@ -193,7 +193,7 @@ class LayoutEntry {
         case LayoutHelper.IS_LAYOUT_TEXT:
             return text;
         case LayoutHelper.IS_SIMPLE_FIELD:
-            String value = bibtex.getResolvedFieldOrAlias(text, database).orElse("");
+            String value = BibDatabase.getResolvedField(text, bibtex, database).orElse("");
 
             // If a post formatter has been set, call it:
             if (postFormatter != null) {
@@ -212,7 +212,7 @@ class LayoutEntry {
             // Printing the encoding name is not supported in entry layouts, only
             // in begin/end layouts. This prevents breakage if some users depend
             // on a field called "encoding". We simply return this field instead:
-            return bibtex.getResolvedFieldOrAlias("encoding", database).orElse(null);
+            return BibDatabase.getResolvedField("encoding", bibtex, database).orElse(null);
         default:
             return "";
         }
@@ -231,8 +231,8 @@ class LayoutEntry {
         } else {
             // changed section begin - arudert
             // resolve field (recognized by leading backslash) or text
-            fieldEntry = text.startsWith("\\") ? bibtex
-                    .getResolvedFieldOrAlias(text.substring(1), database)
+            fieldEntry = text.startsWith("\\") ? BibDatabase
+                    .getResolvedField(text.substring(1), bibtex, database)
                     .orElse("") : BibDatabase.getText(text, database);
             // changed section end - arudert
         }
@@ -254,13 +254,13 @@ class LayoutEntry {
     private String handleFieldOrGroupStart(BibEntry bibtex, BibDatabase database, Optional<Pattern> highlightPattern) {
         Optional<String> field;
         if (type == LayoutHelper.IS_GROUP_START) {
-            field = bibtex.getResolvedFieldOrAlias(text, database);
+            field = BibDatabase.getResolvedField(text, bibtex, database);
         } else if (text.matches(".*(;|(\\&+)).*")) {
             // split the strings along &, && or ; for AND formatter
             String[] parts = text.split("\\s*(;|(\\&+))\\s*");
             field = Optional.empty();
             for (String part : parts) {
-                field = bibtex.getResolvedFieldOrAlias(part, database);
+                field = BibDatabase.getResolvedField(part, bibtex, database);
                 if (!field.isPresent()) {
                     break;
                 }
@@ -270,7 +270,7 @@ class LayoutEntry {
             String[] parts = text.split("\\s*(\\|+)\\s*");
             field = Optional.empty();
             for (String part : parts) {
-                field = bibtex.getResolvedFieldOrAlias(part, database);
+                field = BibDatabase.getResolvedField(part, bibtex, database);
                 if (field.isPresent()) {
                     break;
                 }

--- a/src/main/java/net/sf/jabref/logic/openoffice/OOBibStyle.java
+++ b/src/main/java/net/sf/jabref/logic/openoffice/OOBibStyle.java
@@ -717,7 +717,7 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
         String authorField = getStringCitProperty(AUTHOR_FIELD);
         String[] fields = field.split(FieldName.FIELD_SEPARATOR);
         for (String s : fields) {
-            Optional<String> content = entry.getResolvedFieldOrAlias(s, database);
+            Optional<String> content = BibDatabase.getResolvedField(s, entry, database);
 
             if ((content.isPresent()) && !content.get().trim().isEmpty()) {
                 if (field.equals(authorField) && StringUtil.isInCurlyBrackets(content.get())) {

--- a/src/main/java/net/sf/jabref/logic/util/io/RegExpFileSearch.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/RegExpFileSearch.java
@@ -316,7 +316,7 @@ public class RegExpFileSearch {
         }
 
         // If no field value was found, try to interpret it as a key generator field marker:
-        String fieldValue = entry.getResolvedFieldOrAlias(beforeColon, database)
+        String fieldValue = BibDatabase.getResolvedField(beforeColon, entry, database)
                 .orElse(BibtexKeyPatternUtil.makeLabel(entry, beforeColon));
 
         if (fieldValue == null) {

--- a/src/main/java/net/sf/jabref/logic/xmp/XMPSchemaBibtex.java
+++ b/src/main/java/net/sf/jabref/logic/xmp/XMPSchemaBibtex.java
@@ -281,7 +281,7 @@ public class XMPSchemaBibtex extends XMPSchema {
         }
 
         for (String field : fields) {
-            String value = entry.getResolvedFieldOrAlias(field, database).orElse("");
+            String value = BibDatabase.getResolvedField(field, entry, database).orElse("");
             if (InternalBibtexFields.getFieldProperties(field).contains(FieldProperty.PERSON_NAMES)) {
                 setPersonList(field, value);
             } else {

--- a/src/main/java/net/sf/jabref/model/database/BibDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabase.java
@@ -15,10 +15,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.database.event.EntryAddedEvent;
 import net.sf.jabref.model.database.event.EntryRemovedEvent;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexString;
+import net.sf.jabref.model.entry.EntryType;
+import net.sf.jabref.model.entry.EntryUtil;
 import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.model.entry.InternalBibtexFields;
 import net.sf.jabref.model.entry.MonthUtil;
@@ -153,14 +156,8 @@ public class BibDatabase {
      * @return false if the insert was done without a duplicate warning
      * @throws KeyCollisionException thrown if the entry id ({@link BibEntry#getId()}) is already  present in the database
      */
-    @Deprecated // use insertEntry and DuplicationChecker separately
-    public synchronized boolean insertEntryWithDuplicationCheck(BibEntry entry) throws KeyCollisionException {
-        insertEntry(entry);
-        return duplicationChecker.checkForDuplicateKeyAndAdd(null, entry.getCiteKey());
-    }
-
-    public synchronized void insertEntry(BibEntry entry) {
-        insertEntry(entry, EntryEventSource.LOCAL);
+    public synchronized boolean insertEntry(BibEntry entry) throws KeyCollisionException {
+        return insertEntry(entry, EntryEventSource.LOCAL);
     }
 
     /**
@@ -169,8 +166,9 @@ public class BibDatabase {
      *
      * @param entry BibEntry to insert
      * @param eventSource Source the event is sent from
+     * @return false if the insert was done without a duplicate warning
      */
-    public synchronized void insertEntry(BibEntry entry, EntryEventSource eventSource) throws KeyCollisionException {
+    public synchronized boolean insertEntry(BibEntry entry, EntryEventSource eventSource) throws KeyCollisionException {
         Objects.requireNonNull(entry);
 
         String id = entry.getId();
@@ -183,6 +181,7 @@ public class BibDatabase {
         entry.registerListener(this);
 
         eventBus.post(new EntryAddedEvent(entry, eventSource));
+        return duplicationChecker.checkForDuplicateKeyAndAdd(null, entry.getCiteKey());
     }
 
     /**
@@ -222,7 +221,6 @@ public class BibDatabase {
      *
      * @return true, if the entry contains the key, false if not
      */
-    @Deprecated // use BibEntry.setCiteKey (and DuplicationChecker)
     public synchronized boolean setCiteKeyForEntry(BibEntry entry, String key) {
         String oldKey = entry.getCiteKey();
         if (key == null) {
@@ -493,7 +491,61 @@ public class BibDatabase {
     }
 
     /**
+     * Returns the text stored in the given field of the given bibtex entry
+     * which belongs to the given database.
+     * <p>
+     * If a database is given, this function will try to resolve any string
+     * references in the field-value.
+     * Also, if a database is given, this function will try to find values for
+     * unset fields in the entry linked by the "crossref" field, if any.
+     *
+     * @param field    The field to return the value of.
+     * @param entry    The bibtex entry which contains the field.
+     * @param database maybenull
+     *                 The database of the bibtex entry.
+     * @return The resolved field value or null if not found.
+     */
+    public static Optional<String> getResolvedField(String field, BibEntry entry, BibDatabase database) {
+        Objects.requireNonNull(entry, "entry cannot be null");
+
+        if (BibEntry.TYPE_HEADER.equals(field) || BibEntry.OBSOLETE_TYPE_HEADER.equals(field)) {
+            Optional<EntryType> entryType = EntryTypes.getType(entry.getType(), BibDatabaseMode.BIBLATEX);
+            if (entryType.isPresent()) {
+                return Optional.of(entryType.get().getName());
+            } else {
+                return Optional.of(EntryUtil.capitalizeFirst(entry.getType()));
+            }
+        }
+
+        if (BibEntry.KEY_FIELD.equals(field)) {
+            return entry.getCiteKeyOptional();
+        }
+
+        // Changed this to also consider alias fields, which is the expected
+        // behavior for the preview layout and for the check whatever all fields are present.
+        // TODO: But there might be unwanted side-effects?!
+        Optional<String> result = entry.getFieldOrAlias(field);
+
+        // If this field is not set, and the entry has a crossref, try to look up the
+        // field in the referred entry: Do not do this for the bibtex key.
+        if (!result.isPresent() && (database != null)) {
+            Optional<String> crossrefKey = entry.getField(FieldName.CROSSREF);
+            if (crossrefKey.isPresent() && !crossrefKey.get().isEmpty()) {
+                Optional<BibEntry> referred = database.getEntryByKey(crossrefKey.get());
+                if (referred.isPresent()) {
+                    // Ok, we found the referred entry. Get the field value from that
+                    // entry. If it is unset there, too, stop looking:
+                    result = referred.get().getFieldOrAlias(field);
+                }
+            }
+        }
+
+        return result.map(resultText -> BibDatabase.getText(resultText, database));
+    }
+
+    /**
      * @deprecated use  {@link BibDatabase#resolveForStrings(String)}
+     *
      * Returns a text with references resolved according to an optionally given database.
      *
      * @param toResolve maybenull The text to resolve.

--- a/src/main/java/net/sf/jabref/model/database/BibDatabases.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabases.java
@@ -21,7 +21,7 @@ public class BibDatabases {
 
         for (BibEntry entry : bibentries) {
             entry.setId(IdGenerator.next());
-            database.insertEntryWithDuplicationCheck(entry);
+            database.insertEntry(entry);
         }
 
         return database;

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -37,26 +37,10 @@ public class BibEntry implements Cloneable {
 
     private static final Log LOGGER = LogFactory.getLog(BibEntry.class);
 
-    // All these fields should be private or protected
-    /**
-     * @deprecated use get/setType
-     */
-    @Deprecated
     public static final String TYPE_HEADER = "entrytype";
-    @Deprecated
     public static final String OBSOLETE_TYPE_HEADER = "bibtextype";
-
-    /**
-     * @deprecated use dedicated methods like get/set/clearCiteKey
-     */
-    @Deprecated
     public static final String KEY_FIELD = "bibtexkey";
     protected static final String ID_FIELD = "id";
-
-    /**
-     * @deprecated use constructor without type
-     */
-    @Deprecated
     public static final String DEFAULT_TYPE = "misc";
 
     private static final Pattern REMOVE_TRAILING_WHITESPACE = Pattern.compile("\\s+$");

--- a/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
+++ b/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
@@ -191,7 +191,7 @@ public class PdfImporter {
         entry = localRes.get(0);
 
         // insert entry to database and link file
-        panel.getDatabase().insertEntryWithDuplicationCheck(entry);
+        panel.getDatabase().insertEntry(entry);
         panel.markBaseChanged();
         FileListTableModel tm = new FileListTableModel();
         File toLink = new File(fileName);
@@ -235,7 +235,7 @@ public class PdfImporter {
         BibEntry entry = result.getDatabase().getEntries().get(0);
 
         // insert entry to database and link file
-        panel.getDatabase().insertEntryWithDuplicationCheck(entry);
+        panel.getDatabase().insertEntry(entry);
         panel.markBaseChanged();
         BibtexKeyPatternUtil.makeLabel(panel.getBibDatabaseContext().getMetaData(), panel.getDatabase(), entry,
                 Globals.prefs.getBibtexKeyPatternPreferences());
@@ -261,7 +261,7 @@ public class PdfImporter {
             String id = IdGenerator.next();
             final BibEntry bibEntry = new BibEntry(id, type.getName());
             try {
-                panel.getDatabase().insertEntryWithDuplicationCheck(bibEntry);
+                panel.getDatabase().insertEntry(bibEntry);
 
                 // Set owner/timestamp if options are enabled:
                 List<BibEntry> list = new ArrayList<>();

--- a/src/test/java/net/sf/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
@@ -31,7 +31,7 @@ public class MakeLabelWithDatabaseTest {
         entry.setField("author", "John Doe");
         entry.setField("year", "2016");
         entry.setField("title", "An awesome paper on JabRef");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         pattern = new GlobalBibtexKeyPattern(AbstractBibtexKeyPattern.split("[auth][year]"));
         preferences = new BibtexKeyPatternPreferences("", "", false, true, true, pattern);
     }
@@ -97,12 +97,12 @@ public class MakeLabelWithDatabaseTest {
         entry2.setField("author", "John Doe");
         entry2.setField("year", "2016");
         entry2.setCiteKey(entry.getCiteKeyOptional().get());
-        database.insertEntryWithDuplicationCheck(entry2);
+        database.insertEntry(entry2);
         BibEntry entry3 = new BibEntry();
         entry3.setField("author", "John Doe");
         entry3.setField("year", "2016");
         entry3.setCiteKey(entry.getCiteKeyOptional().get());
-        database.insertEntryWithDuplicationCheck(entry3);
+        database.insertEntry(entry3);
         BibtexKeyPatternUtil.makeLabel(metadata, database, entry3, preferences);
         assertEquals(Optional.of("Doe2016a"), entry3.getCiteKeyOptional());
     }
@@ -114,12 +114,12 @@ public class MakeLabelWithDatabaseTest {
         entry2.setField("author", "John Doe");
         entry2.setField("year", "2016");
         BibtexKeyPatternUtil.makeLabel(metadata, database, entry2, preferences);
-        database.insertEntryWithDuplicationCheck(entry2);
+        database.insertEntry(entry2);
         BibEntry entry3 = new BibEntry();
         entry3.setField("author", "John Doe");
         entry3.setField("year", "2016");
         entry3.setCiteKey(entry.getCiteKeyOptional().get());
-        database.insertEntryWithDuplicationCheck(entry3);
+        database.insertEntry(entry3);
         BibtexKeyPatternUtil.makeLabel(metadata, database, entry3, preferences);
         assertEquals(Optional.of("Doe2016b"), entry3.getCiteKeyOptional());
     }

--- a/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -111,7 +111,7 @@ public class BibtexDatabaseWriterTest {
     public void writeEntry() throws Exception {
         BibEntry entry = new BibEntry();
         entry.setType(BibtexEntryTypes.ARTICLE);
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), new SavePreferences());
 
@@ -126,7 +126,7 @@ public class BibtexDatabaseWriterTest {
         SavePreferences preferences = new SavePreferences().withEncoding(Charsets.US_ASCII);
         BibEntry entry = new BibEntry();
         entry.setType(BibtexEntryTypes.ARTICLE);
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), preferences);
 
@@ -247,7 +247,7 @@ public class BibtexDatabaseWriterTest {
             EntryTypes.addOrModifyCustomEntryType(new CustomEntryType("customizedType", "required", "optional"));
             BibEntry entry = new BibEntry();
             entry.setType("customizedType");
-            database.insertEntryWithDuplicationCheck(entry);
+            database.insertEntry(entry);
 
             StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), new SavePreferences());
 
@@ -348,7 +348,7 @@ public class BibtexDatabaseWriterTest {
         entry.setField("author", "Mr. author");
         entry.setParsedSerialization("presaved serialization");
         entry.setChanged(false);
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), new SavePreferences());
 
@@ -363,7 +363,7 @@ public class BibtexDatabaseWriterTest {
         entry.setField("author", "Mr. author");
         entry.setParsedSerialization("wrong serialization");
         entry.setChanged(false);
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
 
         SavePreferences preferences = new SavePreferences().withReformatFile(true);
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, Collections.singletonList(entry), preferences);
@@ -522,9 +522,9 @@ public class BibtexDatabaseWriterTest {
         thirdEntry.setField("author", "B");
         thirdEntry.setField("year", "2000");
 
-        database.insertEntryWithDuplicationCheck(secondEntry);
-        database.insertEntryWithDuplicationCheck(thirdEntry);
-        database.insertEntryWithDuplicationCheck(firstEntry);
+        database.insertEntry(secondEntry);
+        database.insertEntry(thirdEntry);
+        database.insertEntry(firstEntry);
 
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, database.getEntries(), new SavePreferences());
 
@@ -566,9 +566,9 @@ public class BibtexDatabaseWriterTest {
         thirdEntry.setField("author", "A");
         thirdEntry.setField("year", "2000");
 
-        database.insertEntryWithDuplicationCheck(firstEntry);
-        database.insertEntryWithDuplicationCheck(secondEntry);
-        database.insertEntryWithDuplicationCheck(thirdEntry);
+        database.insertEntry(firstEntry);
+        database.insertEntry(secondEntry);
+        database.insertEntry(thirdEntry);
 
         SavePreferences preferences = new SavePreferences().withSaveInOriginalOrder(false);
         StringSaveSession session = databaseWriter.savePartOfDatabase(bibtexContext, database.getEntries(), preferences);

--- a/src/test/java/net/sf/jabref/logic/integrity/EntryLinkCheckerTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/EntryLinkCheckerTest.java
@@ -26,7 +26,7 @@ public class EntryLinkCheckerTest {
         database = new BibDatabase();
         checker = new EntryLinkChecker(database);
         entry = new BibEntry();
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
     }
 
     @SuppressWarnings("unused")
@@ -61,7 +61,7 @@ public class EntryLinkCheckerTest {
 
         BibEntry entry2 = new BibEntry();
         entry2.setCiteKey("banana");
-        database.insertEntryWithDuplicationCheck(entry2);
+        database.insertEntry(entry2);
 
         List<IntegrityMessage> message = checker.check(entry);
         assertEquals(Collections.emptyList(), message);
@@ -73,11 +73,11 @@ public class EntryLinkCheckerTest {
 
         BibEntry entry2 = new BibEntry();
         entry2.setCiteKey("banana");
-        database.insertEntryWithDuplicationCheck(entry2);
+        database.insertEntry(entry2);
 
         BibEntry entry3 = new BibEntry();
         entry3.setCiteKey("pineapple");
-        database.insertEntryWithDuplicationCheck(entry3);
+        database.insertEntry(entry3);
 
         List<IntegrityMessage> message = checker.check(entry);
         assertEquals(Collections.emptyList(), message);
@@ -87,15 +87,15 @@ public class EntryLinkCheckerTest {
     public void testCheckNonExistingRelated() {
         BibEntry entry1 = new BibEntry();
         entry1.setField("related", "banana,pineapple,strawberry");
-        database.insertEntryWithDuplicationCheck(entry1);
+        database.insertEntry(entry1);
 
         BibEntry entry2 = new BibEntry();
         entry2.setCiteKey("banana");
-        database.insertEntryWithDuplicationCheck(entry2);
+        database.insertEntry(entry2);
 
         BibEntry entry3 = new BibEntry();
         entry3.setCiteKey("pineapple");
-        database.insertEntryWithDuplicationCheck(entry3);
+        database.insertEntry(entry3);
 
         List<IntegrityMessage> message = checker.check(entry1);
         assertFalse(message.toString(), message.isEmpty());

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -280,7 +280,7 @@ public class IntegrityCheckTest {
         entry.setField(field, value);
         entry.setType(type);
         BibDatabase bibDatabase = new BibDatabase();
-        bibDatabase.insertEntryWithDuplicationCheck(entry);
+        bibDatabase.insertEntry(entry);
         return new BibDatabaseContext(bibDatabase, new Defaults());
     }
 
@@ -288,7 +288,7 @@ public class IntegrityCheckTest {
         BibEntry entry = new BibEntry();
         entry.setField(field, value);
         BibDatabase bibDatabase = new BibDatabase();
-        bibDatabase.insertEntryWithDuplicationCheck(entry);
+        bibDatabase.insertEntry(entry);
         return new BibDatabaseContext(bibDatabase, metaData, new Defaults());
     }
 

--- a/src/test/java/net/sf/jabref/logic/openoffice/OOBibStyleTest.java
+++ b/src/test/java/net/sf/jabref/logic/openoffice/OOBibStyleTest.java
@@ -198,7 +198,7 @@ public class OOBibStyleTest {
         entry.setField("author", "{JabRef Development Team}");
         entry.setField("title", "JabRef Manual");
         entry.setField("year", "2016");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         assertEquals("<b>JabRef Development Team</b> (<b>2016</b>). <i>JabRef Manual</i>,  .",
                 l.doLayout(entry, database));
     }
@@ -217,7 +217,7 @@ public class OOBibStyleTest {
         entry.setField("author", "Alpha von Beta");
         entry.setField("title", "JabRef Manual");
         entry.setField("year", "2016");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         assertEquals("<b>von Beta, A.</b> (<b>2016</b>). <i>JabRef Manual</i>,  .",
                 l.doLayout(entry, database));
     }
@@ -236,7 +236,7 @@ public class OOBibStyleTest {
         entry.setField("author", "{JabRef Development Team}");
         entry.setField("title", "JabRef Manual");
         entry.setField("year", "2016");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         entries.add(entry);
         entryDBMap.put(entry, database);
         assertEquals("[JabRef Development Team, 2016]", style.getCitationMarker(entries, entryDBMap, true, null, null));
@@ -256,7 +256,7 @@ public class OOBibStyleTest {
         entry.setField("author", "Alpha von Beta");
         entry.setField("title", "JabRef Manual");
         entry.setField("year", "2016");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         entries.add(entry);
         entryDBMap.put(entry, database);
         assertEquals("[von Beta, 2016]", style.getCitationMarker(entries, entryDBMap, true, null, null));
@@ -274,7 +274,7 @@ public class OOBibStyleTest {
         BibEntry entry = new BibEntry();
         entry.setType("article");
         entry.setField("year", "2016");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         entries.add(entry);
         entryDBMap.put(entry, database);
         assertEquals("[, 2016]", style.getCitationMarker(entries, entryDBMap, true, null, null));
@@ -292,7 +292,7 @@ public class OOBibStyleTest {
         BibEntry entry = new BibEntry();
         entry.setType("article");
         entry.setField("author", "Alpha von Beta");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         entries.add(entry);
         entryDBMap.put(entry, database);
         assertEquals("[von Beta, ]", style.getCitationMarker(entries, entryDBMap, true, null, null));
@@ -309,7 +309,7 @@ public class OOBibStyleTest {
 
         BibEntry entry = new BibEntry();
         entry.setType("article");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         entries.add(entry);
         entryDBMap.put(entry, database);
         assertEquals("[, ]", style.getCitationMarker(entries, entryDBMap, true, null, null));
@@ -329,18 +329,18 @@ public class OOBibStyleTest {
         entry1.setField("title", "Paper 1");
         entry1.setField("year", "2000");
         entries.add(entry1);
-        database.insertEntryWithDuplicationCheck(entry1);
+        database.insertEntry(entry1);
         BibEntry entry3 = new BibEntry();
         entry3.setField("author", "Alpha Beta");
         entry3.setField("title", "Paper 2");
         entry3.setField("year", "2000");
         entries.add(entry3);
-        database.insertEntryWithDuplicationCheck(entry3);
+        database.insertEntry(entry3);
         BibEntry entry2 = new BibEntry();
         entry2.setField("author", "Gamma Epsilon");
         entry2.setField("year", "2001");
         entries.add(entry2);
-        database.insertEntryWithDuplicationCheck(entry2);
+        database.insertEntry(entry2);
         for (BibEntry entry : database.getEntries()) {
             entryDBMap.put(entry, database);
         }
@@ -365,18 +365,18 @@ public class OOBibStyleTest {
         entry1.setField("title", "Paper 1");
         entry1.setField("year", "2000");
         entries.add(entry1);
-        database.insertEntryWithDuplicationCheck(entry1);
+        database.insertEntry(entry1);
         BibEntry entry3 = new BibEntry();
         entry3.setField("author", "Alpha Beta");
         entry3.setField("title", "Paper 2");
         entry3.setField("year", "2000");
         entries.add(entry3);
-        database.insertEntryWithDuplicationCheck(entry3);
+        database.insertEntry(entry3);
         BibEntry entry2 = new BibEntry();
         entry2.setField("author", "Gamma Epsilon");
         entry2.setField("year", "2001");
         entries.add(entry2);
-        database.insertEntryWithDuplicationCheck(entry2);
+        database.insertEntry(entry2);
         for (BibEntry entry : database.getEntries()) {
             entryDBMap.put(entry, database);
         }
@@ -401,19 +401,19 @@ public class OOBibStyleTest {
         entry1.setField("title", "Paper 1");
         entry1.setField("year", "2000");
         entries.add(entry1);
-        database.insertEntryWithDuplicationCheck(entry1);
+        database.insertEntry(entry1);
         BibEntry entry2 = new BibEntry();
         entry2.setField("author", "Alpha Beta");
         entry2.setField("title", "Paper 2");
         entry2.setField("year", "2000");
         entries.add(entry2);
-        database.insertEntryWithDuplicationCheck(entry2);
+        database.insertEntry(entry2);
         BibEntry entry3 = new BibEntry();
         entry3.setField("author", "Alpha Beta");
         entry3.setField("title", "Paper 3");
         entry3.setField("year", "2000");
         entries.add(entry3);
-        database.insertEntryWithDuplicationCheck(entry3);
+        database.insertEntry(entry3);
         for (BibEntry entry : database.getEntries()) {
             entryDBMap.put(entry, database);
         }
@@ -436,19 +436,19 @@ public class OOBibStyleTest {
         entry1.setField("title", "Paper 1");
         entry1.setField("year", "2000");
         entries.add(entry1);
-        database.insertEntryWithDuplicationCheck(entry1);
+        database.insertEntry(entry1);
         BibEntry entry2 = new BibEntry();
         entry2.setField("author", "Alpha Beta");
         entry2.setField("title", "Paper 2");
         entry2.setField("year", "2000");
         entries.add(entry2);
-        database.insertEntryWithDuplicationCheck(entry2);
+        database.insertEntry(entry2);
         BibEntry entry3 = new BibEntry();
         entry3.setField("author", "Alpha Beta");
         entry3.setField("title", "Paper 3");
         entry3.setField("year", "2000");
         entries.add(entry3);
-        database.insertEntryWithDuplicationCheck(entry3);
+        database.insertEntry(entry3);
         for (BibEntry entry : database.getEntries()) {
             entryDBMap.put(entry, database);
         }
@@ -511,7 +511,7 @@ public class OOBibStyleTest {
         entry.setField("author", "Alpha von Beta and Gamma Epsilon and Ypsilon Tau");
         entry.setField("title", "JabRef Manual");
         entry.setField("year", "2016");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         entries.add(entry);
         entryDBMap.put(entry, database);
         assertEquals("von Beta, Epsilon, and Tau, 2016",

--- a/src/test/java/net/sf/jabref/logic/search/DatabaseSearcherTest.java
+++ b/src/test/java/net/sf/jabref/logic/search/DatabaseSearcherTest.java
@@ -37,8 +37,8 @@ public class DatabaseSearcherTest {
     }
 
     @Test
-    public void testNoMatchesFromDatabaseWithEmptyEntry() {
-        database.insertEntryWithDuplicationCheck(new BibEntry());
+    public void testGetDatabaseFromMatchesDatabaseWithEmptyEntries() {
+        database.insertEntry(new BibEntry());
         List<BibEntry> matches = new DatabaseSearcher(new SearchQuery("whatever", true, true), database).getMatches();
         assertEquals(Collections.emptyList(), matches);
     }
@@ -48,7 +48,7 @@ public class DatabaseSearcherTest {
         BibEntry entry = new BibEntry();
         entry.setType("article");
         entry.setField("author", "harrer");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         List<BibEntry> matches = new DatabaseSearcher(new SearchQuery("whatever", true, true), database).getMatches();
         assertEquals(Collections.emptyList(), matches);
     }
@@ -58,7 +58,7 @@ public class DatabaseSearcherTest {
         BibEntry entry = new BibEntry();
         entry.setType("article");
         entry.setField("author", "harrer");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         List<BibEntry> matches = new DatabaseSearcher(new SearchQuery("harrer", true, true), database).getMatches();
         assertEquals(Collections.singletonList(entry), matches);
     }

--- a/src/test/java/net/sf/jabref/model/BibDatabaseContextTest.java
+++ b/src/test/java/net/sf/jabref/model/BibDatabaseContextTest.java
@@ -33,7 +33,7 @@ public class BibDatabaseContextTest {
     public void testTypeBasedOnInferredModeBibTeX() {
         BibDatabase db = new BibDatabase();
         BibEntry e1 = new BibEntry("1");
-        db.insertEntryWithDuplicationCheck(e1);
+        db.insertEntry(e1);
 
         BibDatabaseContext bibDatabaseContext = new BibDatabaseContext(db);
         assertEquals(BibDatabaseMode.BIBTEX, bibDatabaseContext.getMode());
@@ -43,7 +43,7 @@ public class BibDatabaseContextTest {
     public void testTypeBasedOnInferredModeBiblatex() {
         BibDatabase db = new BibDatabase();
         BibEntry e1 = new BibEntry("1", "electronic");
-        db.insertEntryWithDuplicationCheck(e1);
+        db.insertEntry(e1);
 
         BibDatabaseContext bibDatabaseContext = new BibDatabaseContext(db);
         assertEquals(BibDatabaseMode.BIBLATEX, bibDatabaseContext.getMode());

--- a/src/test/java/net/sf/jabref/model/database/BibDatabaseTest.java
+++ b/src/test/java/net/sf/jabref/model/database/BibDatabaseTest.java
@@ -36,7 +36,7 @@ public class BibDatabaseTest {
     @Test
     public void insertEntryAddsEntryToEntriesList() {
         BibEntry entry = new BibEntry();
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         assertEquals(database.getEntries().size(), 1);
         assertEquals(database.getEntryCount(), 1);
         assertEquals(entry, database.getEntries().get(0));
@@ -46,24 +46,24 @@ public class BibDatabaseTest {
     public void containsEntryIdFindsEntry() {
         BibEntry entry = new BibEntry();
         assertFalse(database.containsEntryWithId(entry.getId()));
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         assertTrue(database.containsEntryWithId(entry.getId()));
     }
 
     @Test(expected = KeyCollisionException.class)
     public void insertEntryWithSameIdThrowsException() {
         BibEntry entry0 = new BibEntry();
-        database.insertEntryWithDuplicationCheck(entry0);
+        database.insertEntry(entry0);
 
         BibEntry entry1 = new BibEntry(entry0.getId());
-        database.insertEntryWithDuplicationCheck(entry1);
+        database.insertEntry(entry1);
         fail();
     }
 
     @Test
     public void removeEntryRemovesEntryFromEntriesList() {
         BibEntry entry = new BibEntry();
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
 
         database.removeEntry(entry);
         assertEquals(Collections.emptyList(), database.getEntries());
@@ -72,7 +72,7 @@ public class BibDatabaseTest {
 
     @Test(expected = NullPointerException.class)
     public void insertNullEntryThrowsException() {
-        database.insertEntryWithDuplicationCheck(null);
+        database.insertEntry(null);
         fail();
     }
 
@@ -145,7 +145,7 @@ public class BibDatabaseTest {
         BibEntry expectedEntry = new BibEntry();
         TestEventListener tel = new TestEventListener();
         database.registerListener(tel);
-        database.insertEntryWithDuplicationCheck(expectedEntry);
+        database.insertEntry(expectedEntry);
         BibEntry actualEntry = tel.getBibEntry();
         assertEquals(expectedEntry, actualEntry);
     }
@@ -154,7 +154,7 @@ public class BibDatabaseTest {
     public void removeEntryPostsRemovedEntryEvent() {
         BibEntry expectedEntry = new BibEntry();
         TestEventListener tel = new TestEventListener();
-        database.insertEntryWithDuplicationCheck(expectedEntry);
+        database.insertEntry(expectedEntry);
         database.registerListener(tel);
         database.removeEntry(expectedEntry);
         BibEntry actualEntry = tel.getBibEntry();
@@ -165,7 +165,7 @@ public class BibDatabaseTest {
     public void changingEntryPostsChangeEntryEvent() {
         BibEntry entry = new BibEntry();
         TestEventListener tel = new TestEventListener();
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         database.registerListener(tel);
 
         entry.setField("test", "some value");
@@ -177,7 +177,7 @@ public class BibDatabaseTest {
     public void correctKeyCountOne() {
         BibEntry entry = new BibEntry();
         entry.setCiteKey("AAA");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         assertEquals(database.getNumberOfKeyOccurrences("AAA"), 1);
     }
 
@@ -185,10 +185,10 @@ public class BibDatabaseTest {
     public void correctKeyCountTwo() {
         BibEntry entry = new BibEntry();
         entry.setCiteKey("AAA");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         entry = new BibEntry();
         entry.setCiteKey("AAA");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         assertEquals(database.getNumberOfKeyOccurrences("AAA"), 2);
     }
 
@@ -196,7 +196,7 @@ public class BibDatabaseTest {
     public void setCiteKeySameKeySameEntry() {
         BibEntry entry = new BibEntry();
         entry.setCiteKey("AAA");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         assertFalse(database.setCiteKeyForEntry(entry, "AAA"));
         assertEquals(database.getNumberOfKeyOccurrences("AAA"), 1);
     }
@@ -205,7 +205,7 @@ public class BibDatabaseTest {
     public void setCiteKeyRemoveKey() {
         BibEntry entry = new BibEntry();
         entry.setCiteKey("AAA");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         assertFalse(database.setCiteKeyForEntry(entry, null));
         assertEquals(database.getNumberOfKeyOccurrences("AAA"), 0);
         assertEquals(Optional.empty(), entry.getCiteKeyOptional());
@@ -215,7 +215,7 @@ public class BibDatabaseTest {
     public void setCiteKeyDifferentKeySameEntry() {
         BibEntry entry = new BibEntry();
         entry.setCiteKey("AAA");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         assertFalse(database.setCiteKeyForEntry(entry, "BBB"));
         assertEquals(database.getNumberOfKeyOccurrences("AAA"), 0);
         assertEquals(database.getNumberOfKeyOccurrences("BBB"), 1);
@@ -226,10 +226,10 @@ public class BibDatabaseTest {
     public void setCiteKeySameKeyDifferentEntries() {
         BibEntry entry = new BibEntry();
         entry.setCiteKey("AAA");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         entry = new BibEntry();
         entry.setCiteKey("BBB");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         assertTrue(database.setCiteKeyForEntry(entry, "AAA"));
         assertEquals(entry.getCiteKeyOptional(), Optional.of("AAA"));
         assertEquals(database.getNumberOfKeyOccurrences("AAA"), 2);
@@ -240,10 +240,10 @@ public class BibDatabaseTest {
     public void correctKeyCountAfterRemoving() {
         BibEntry entry = new BibEntry();
         entry.setCiteKey("AAA");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         entry = new BibEntry();
         entry.setCiteKey("AAA");
-        database.insertEntryWithDuplicationCheck(entry);
+        database.insertEntry(entry);
         database.removeEntry(entry);
         assertEquals(database.getNumberOfKeyOccurrences("AAA"), 1);
     }

--- a/src/test/java/net/sf/jabref/model/database/KeyChangeListenerTest.java
+++ b/src/test/java/net/sf/jabref/model/database/KeyChangeListenerTest.java
@@ -26,21 +26,21 @@ public class KeyChangeListenerTest {
         entry1 = new BibEntry();
         entry1.setCiteKey("Entry1");
         entry1.setField(FieldName.CROSSREF, "Entry4");
-        db.insertEntryWithDuplicationCheck(entry1);
+        db.insertEntry(entry1);
 
         entry2 = new BibEntry();
         entry2.setCiteKey("Entry2");
         entry2.setField(FieldName.RELATED, "Entry1,Entry3");
-        db.insertEntryWithDuplicationCheck(entry2);
+        db.insertEntry(entry2);
 
         entry3 = new BibEntry();
         entry3.setCiteKey("Entry3");
         entry3.setField(FieldName.RELATED, "Entry1,Entry2,Entry3");
-        db.insertEntryWithDuplicationCheck(entry3);
+        db.insertEntry(entry3);
 
         entry4 = new BibEntry();
         entry4.setCiteKey("Entry4");
-        db.insertEntryWithDuplicationCheck(entry4);
+        db.insertEntry(entry4);
 
     }
 


### PR DESCRIPTION
Following the discussion at #1913, that PR should be reverted.

This PR reverts the `@Deprecations`, but tries to keep the other improvements.

I'm not sure whether `BibEntry.getResolvedField` should be kept.