### PR TITLE
Fix localization task hints

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ because <additional rationale>.
 Add new Localization.lang("KEY") to Java file.
 Tests fail. In the test output a snippet is generated which must be added to the English translation file. There is also a snippet generated for the non-English files, but this is irrelevant.
 Add snippet to English translation file located at `src/main/resources/l10n/JabRef_en.properties`
-With `gradlew update` the "KEY" is added to the other translation files as well.
+With `gradlew localizationUpdate` the "KEY" is added to the other translation files as well.
 Tests are green again.
 
 You can also directly run the specific test in your IDE. The test "LocalizationConsistencyTest" is placed under `src/test/java/net.sf.jabref.logic.l10n/LocalizationConsistencyTest.java`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ because <additional rationale>.
 Add new Localization.lang("KEY") to Java file.
 Tests fail. In the test output a snippet is generated which must be added to the English translation file. There is also a snippet generated for the non-English files, but this is irrelevant.
 Add snippet to English translation file located at `src/main/resources/l10n/JabRef_en.properties`
-With `gradlew generateMissingTranslationKeys` the "KEY" is added to the other translation files as well.
+With `gradlew update` the "KEY" is added to the other translation files as well.
 Tests are green again.
 
 You can also directly run the specific test in your IDE. The test "LocalizationConsistencyTest" is placed under `src/test/java/net.sf.jabref.logic.l10n/LocalizationConsistencyTest.java`

--- a/localization.gradle
+++ b/localization.gradle
@@ -10,7 +10,7 @@ dependencies {
     jython 'org.python:jython-standalone:2.7.0'
 }
 
-task statusWithMarkdown(type: JavaExec) {
+task localizationStatusWithMarkdown(type: JavaExec) {
     description "Creates an update file in Markdown"
     group = 'Localization'
     main 'org.python.util.jython'
@@ -19,7 +19,7 @@ task statusWithMarkdown(type: JavaExec) {
     args "markdown"
 }
 
-task status(type: JavaExec) {
+task localizationStatus(type: JavaExec) {
     description "Prints the current status"
     group = 'Localization'
     main 'org.python.util.jython'
@@ -28,7 +28,7 @@ task status(type: JavaExec) {
     args "status"
 }
 
-task statusExtended(type: JavaExec) {
+task localizationStatusExtended(type: JavaExec) {
     description "Prints the current status (extended output)"
     group = 'Localization'
     main 'org.python.util.jython'
@@ -38,7 +38,7 @@ task statusExtended(type: JavaExec) {
     args "--extended"
 }
 
-task update(type: JavaExec) {
+task localizationUpdate(type: JavaExec) {
     description "Updates the localization files (fixes duplicates, adds missing keys, and sort them"
     group = 'Localization'
     main 'org.python.util.jython'
@@ -47,7 +47,7 @@ task update(type: JavaExec) {
     args "update"
 }
 
-task updateExtended(type: JavaExec) {
+task localizationUpdateExtended(type: JavaExec) {
     description "Updates the localization files (fixes duplicates, adds missing keys, and sort them (extended output)"
     group = 'Localization'
     main 'org.python.util.jython'

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,19 +5,19 @@ The Script has following commands available
   - prints the current status to the terminal
   - `[--extended]` if the translations keys which create problems should be printed
   - usable with Gradle tasks
-    - `$ gradle status`
-    - `$ gradle statusExtended`
+    - `$ gradle localizationStatus`
+    - `$ gradle localizationStatusExtended`
 
 
 - `$ python scripts/syncLang.py markdown`
   - Creates a markdown file of the current status and opens it
   - usable with Gradle tasks
-    - `$ gradle statusWithMarkdown`
+    - `$ gradle localizationStatusWithMarkdown`
 
 
 - `$ python scripts/syncLang.py update [--extended]`
   - compares all the localization files against the English one and fixes unambiguous duplicates, removes obsolete keys, adds missing keys, and sorts them
   - `[--extended]` if the translations keys which create problems should be printed
   - usable with Gradle tasks
-    - `$ gradle update`
-    - `$ gradle updateExtended`
+    - `$ gradle localizationUpdate`
+    - `$ gradle localizationUpdateExtended`

--- a/src/test/java/net/sf/jabref/logic/l10n/LocalizationConsistencyTest.java
+++ b/src/test/java/net/sf/jabref/logic/l10n/LocalizationConsistencyTest.java
@@ -156,7 +156,7 @@ public class LocalizationConsistencyTest {
             System.out.println();
             System.out.println("1. CAREFULLY CHECK IF THE KEY IS REALLY NOT USED ANYMORE");
             System.out.println("2. REMOVE THESE FROM THE ENGLISH LANGUAGE FILE");
-            System.out.println("3. EXECUTE gradlew update");
+            System.out.println("3. EXECUTE gradlew localizationUpdate");
             System.out.println("REMOVE THESE FROM THE NON-ENGLISH LANGUAGE FILES");
             fail("Obsolete keys " + obsoleteKeys + " found in properties file which should be removed");
         }
@@ -172,7 +172,7 @@ public class LocalizationConsistencyTest {
             System.out.println(obsoleteKeys.stream().map(Object::toString).collect(Collectors.joining("\n")));
             System.out.println();
             System.out.println("1. REMOVE THESE FROM THE ENGLISH LANGUAGE FILE");
-            System.out.println("3. EXECUTE gradlew update");
+            System.out.println("2. EXECUTE gradlew localizationUpdate");
             System.out.println("REMOVE THESE FROM THE NON-ENGLISH LANGUAGE FILES");
             fail("Obsolete keys " + obsoleteKeys + " found in menu properties file which should be removed");
         }
@@ -189,7 +189,7 @@ public class LocalizationConsistencyTest {
 
     private String convertToEnglishPropertiesFile(List<LocalizationEntry> missingKeys) {
         System.out.println("PASTE THIS INTO THE ENGLISH LANGUAGE FILE");
-        System.out.println("AND EXECUTE gradlew update");
+        System.out.println("AND EXECUTE gradlew localizationUpdate");
         StringJoiner result = new StringJoiner("\n");
         for (LocalizationEntry key : missingKeys) {
             result.add(String.format("%s=%s", key.getKey(), key.getKey()));
@@ -198,7 +198,7 @@ public class LocalizationConsistencyTest {
     }
 
     private String convertPropertiesFile(List<LocalizationEntry> missingKeys) {
-        System.out.println("EXECUTE gradlew update");
+        System.out.println("EXECUTE gradlew localizationUpdate");
         System.out.println("PASTE THIS INTO THE NON-ENGLISH LANGUAGE FILES");
         StringJoiner result = new StringJoiner("\n");
         for (LocalizationEntry key : missingKeys) {

--- a/src/test/java/net/sf/jabref/logic/l10n/LocalizationConsistencyTest.java
+++ b/src/test/java/net/sf/jabref/logic/l10n/LocalizationConsistencyTest.java
@@ -128,7 +128,7 @@ public class LocalizationConsistencyTest {
                 missingKeys.parallelStream()
                         .map(key -> String.format("%s=%s", key.getKey(), key.getKey()))
                         .collect(Collectors.toList()),
-                Collections.EMPTY_LIST, missingKeys);
+                Collections.<LocalizationEntry>emptyList(), missingKeys);
     }
 
     @Test
@@ -142,7 +142,7 @@ public class LocalizationConsistencyTest {
                 missingKeys.parallelStream()
                         .map(key -> String.format("%s=%s", key.getKey(), key.getKey()))
                         .collect(Collectors.toList()),
-                Collections.EMPTY_LIST, missingKeys);
+                Collections.<LocalizationEntry>emptyList(), missingKeys);
     }
 
     @Test
@@ -153,7 +153,7 @@ public class LocalizationConsistencyTest {
                 "1. CHECK IF THE KEY IS REALLY NOT USED ANYMORE\n" +
                 "2. REMOVE THESE FROM THE ENGLISH LANGUAGE FILE\n" +
                 "3. EXECUTE: gradlew localizationUpdate\n",
-                Collections.EMPTY_LIST, obsoleteKeys);
+                Collections.<String>emptyList(), obsoleteKeys);
     }
 
     @Test
@@ -164,7 +164,7 @@ public class LocalizationConsistencyTest {
                 "1. CHECK IF THE KEY IS REALLY NOT USED ANYMORE\n" +
                 "2. REMOVE THESE FROM THE ENGLISH MENU FILE\n" +
                 "3. EXECUTE: gradlew localizationUpdate\n",
-                Collections.EMPTY_LIST, obsoleteKeys);
+                Collections.<String>emptyList(), obsoleteKeys);
     }
 
 }

--- a/src/test/java/net/sf/jabref/logic/l10n/LocalizationConsistencyTest.java
+++ b/src/test/java/net/sf/jabref/logic/l10n/LocalizationConsistencyTest.java
@@ -156,7 +156,7 @@ public class LocalizationConsistencyTest {
             System.out.println();
             System.out.println("1. CAREFULLY CHECK IF THE KEY IS REALLY NOT USED ANYMORE");
             System.out.println("2. REMOVE THESE FROM THE ENGLISH LANGUAGE FILE");
-            System.out.println("3. EXECUTE gradlew -b localization.gradle generateMissingTranslationKeys TO");
+            System.out.println("3. EXECUTE gradlew update");
             System.out.println("REMOVE THESE FROM THE NON-ENGLISH LANGUAGE FILES");
             fail("Obsolete keys " + obsoleteKeys + " found in properties file which should be removed");
         }
@@ -172,7 +172,7 @@ public class LocalizationConsistencyTest {
             System.out.println(obsoleteKeys.stream().map(Object::toString).collect(Collectors.joining("\n")));
             System.out.println();
             System.out.println("1. REMOVE THESE FROM THE ENGLISH LANGUAGE FILE");
-            System.out.println("2. EXECUTE gradlew -b localization.gradle generateMissingTranslationKeys" + " TO");
+            System.out.println("3. EXECUTE gradlew update");
             System.out.println("REMOVE THESE FROM THE NON-ENGLISH LANGUAGE FILES");
             fail("Obsolete keys " + obsoleteKeys + " found in menu properties file which should be removed");
         }
@@ -189,6 +189,7 @@ public class LocalizationConsistencyTest {
 
     private String convertToEnglishPropertiesFile(List<LocalizationEntry> missingKeys) {
         System.out.println("PASTE THIS INTO THE ENGLISH LANGUAGE FILE");
+        System.out.println("AND EXECUTE gradlew update");
         StringJoiner result = new StringJoiner("\n");
         for (LocalizationEntry key : missingKeys) {
             result.add(String.format("%s=%s", key.getKey(), key.getKey()));
@@ -197,7 +198,7 @@ public class LocalizationConsistencyTest {
     }
 
     private String convertPropertiesFile(List<LocalizationEntry> missingKeys) {
-        System.out.println("EXECUTE gradlew -b localization.gradle generateMissingTranslationKeys TO");
+        System.out.println("EXECUTE gradlew update");
         System.out.println("PASTE THIS INTO THE NON-ENGLISH LANGUAGE FILES");
         StringJoiner result = new StringJoiner("\n");
         for (LocalizationEntry key : missingKeys) {

--- a/src/test/java/net/sf/jabref/logic/l10n/LocalizationConsistencyTest.java
+++ b/src/test/java/net/sf/jabref/logic/l10n/LocalizationConsistencyTest.java
@@ -10,13 +10,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 public class LocalizationConsistencyTest {
 
@@ -124,12 +122,13 @@ public class LocalizationConsistencyTest {
         List<LocalizationEntry> missingKeys = LocalizationParser.find(LocalizationBundle.LANG).stream().sorted()
                 .distinct().collect(Collectors.toList());
 
-        printInfos(missingKeys);
-
-        String resultString = missingKeys.stream().map(Object::toString).collect(Collectors.joining("\n"));
-        assertEquals(
-                "source code contains language keys for the messages which are not in the corresponding properties file",
-                "", resultString);
+        assertEquals("DETECTED LANGUAGE KEYS WHICH ARE NOT IN THE ENGLISH LANGUAGE FILE\n" +
+                "1. PASTE THESE INTO THE ENGLISH LANGUAGE FILE\n" +
+                "2. EXECUTE: gradlew localizationUpdate\n" +
+                missingKeys.parallelStream()
+                        .map(key -> String.format("%s=%s", key.getKey(), key.getKey()))
+                        .collect(Collectors.toList()),
+                Collections.EMPTY_LIST, missingKeys);
     }
 
     @Test
@@ -137,74 +136,35 @@ public class LocalizationConsistencyTest {
         List<LocalizationEntry> missingKeys = LocalizationParser.find(LocalizationBundle.MENU).stream()
                 .collect(Collectors.toList());
 
-        printInfos(missingKeys);
-
-        String resultString = missingKeys.stream().map(Object::toString).collect(Collectors.joining("\n"));
-        assertEquals(
-                "source code contains language keys for the menu which are not in the corresponding properties file",
-                "", resultString);
+        assertEquals("DETECTED LANGUAGE KEYS WHICH ARE NOT IN THE ENGLISH MENU FILE\n" +
+                "1. PASTE THESE INTO THE ENGLISH MENU FILE\n" +
+                "2. EXECUTE: gradlew localizationUpdate\n" +
+                missingKeys.parallelStream()
+                        .map(key -> String.format("%s=%s", key.getKey(), key.getKey()))
+                        .collect(Collectors.toList()),
+                Collections.EMPTY_LIST, missingKeys);
     }
 
     @Test
     public void findObsoleteLocalizationKeys() throws IOException {
         List<String> obsoleteKeys = LocalizationParser.findObsolete(LocalizationBundle.LANG);
 
-        if (!obsoleteKeys.isEmpty()) {
-            System.out.println();
-            System.out.println("Obsolete keys found:");
-            System.out.println(obsoleteKeys.stream().map(Object::toString).collect(Collectors.joining("\n")));
-            System.out.println();
-            System.out.println("1. CAREFULLY CHECK IF THE KEY IS REALLY NOT USED ANYMORE");
-            System.out.println("2. REMOVE THESE FROM THE ENGLISH LANGUAGE FILE");
-            System.out.println("3. EXECUTE gradlew localizationUpdate");
-            System.out.println("REMOVE THESE FROM THE NON-ENGLISH LANGUAGE FILES");
-            fail("Obsolete keys " + obsoleteKeys + " found in properties file which should be removed");
-        }
+        assertEquals("Obsolete keys found in language properties file: " + obsoleteKeys + "\n" +
+                "1. CHECK IF THE KEY IS REALLY NOT USED ANYMORE\n" +
+                "2. REMOVE THESE FROM THE ENGLISH LANGUAGE FILE\n" +
+                "3. EXECUTE: gradlew localizationUpdate\n",
+                Collections.EMPTY_LIST, obsoleteKeys);
     }
 
     @Test
     public void findObsoleteMenuLocalizationKeys() throws IOException {
         List<String> obsoleteKeys = LocalizationParser.findObsolete(LocalizationBundle.MENU);
 
-        if (!obsoleteKeys.isEmpty()) {
-            System.out.println();
-            System.out.println("Obsolete menu keys found:");
-            System.out.println(obsoleteKeys.stream().map(Object::toString).collect(Collectors.joining("\n")));
-            System.out.println();
-            System.out.println("1. REMOVE THESE FROM THE ENGLISH LANGUAGE FILE");
-            System.out.println("2. EXECUTE gradlew localizationUpdate");
-            System.out.println("REMOVE THESE FROM THE NON-ENGLISH LANGUAGE FILES");
-            fail("Obsolete keys " + obsoleteKeys + " found in menu properties file which should be removed");
-        }
-    }
-
-    private void printInfos(List<LocalizationEntry> missingKeys) {
-        if (!missingKeys.isEmpty()) {
-            System.out.println(convertToEnglishPropertiesFile(missingKeys));
-            System.out.println();
-            System.out.println();
-            System.out.println(convertPropertiesFile(missingKeys));
-        }
-    }
-
-    private String convertToEnglishPropertiesFile(List<LocalizationEntry> missingKeys) {
-        System.out.println("PASTE THIS INTO THE ENGLISH LANGUAGE FILE");
-        System.out.println("AND EXECUTE gradlew localizationUpdate");
-        StringJoiner result = new StringJoiner("\n");
-        for (LocalizationEntry key : missingKeys) {
-            result.add(String.format("%s=%s", key.getKey(), key.getKey()));
-        }
-        return result.toString();
-    }
-
-    private String convertPropertiesFile(List<LocalizationEntry> missingKeys) {
-        System.out.println("EXECUTE gradlew localizationUpdate");
-        System.out.println("PASTE THIS INTO THE NON-ENGLISH LANGUAGE FILES");
-        StringJoiner result = new StringJoiner("\n");
-        for (LocalizationEntry key : missingKeys) {
-            result.add(String.format("%s=", key.getKey()));
-        }
-        return result.toString();
+        assertEquals("Obsolete keys found in the menu properties file: " + obsoleteKeys + "\n" +
+                "1. CHECK IF THE KEY IS REALLY NOT USED ANYMORE\n" +
+                "2. REMOVE THESE FROM THE ENGLISH MENU FILE\n" +
+                "3. EXECUTE: gradlew localizationUpdate\n",
+                Collections.EMPTY_LIST, obsoleteKeys);
     }
 
 }


### PR DESCRIPTION
fixes: #2029

Replaces hints to the old gradle localization task names with the new ones.