### PR TITLE
Fix search Syntax Error

### DIFF
--- a/src/main/java/net/sf/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/net/sf/jabref/gui/search/GlobalSearchBar.java
@@ -268,9 +268,6 @@ public class GlobalSearchBar extends JPanel {
     }
 
     private void clearSearch(BasePanel currentBasePanel) {
-        SearchQuery searchQuery = getSearchQuery();
-        updateResults(0, searchQuery.getDescription(), searchQuery.isGrammarBasedSearch());
-
         currentResults.setText("");
         searchField.setText("");
         searchField.setBackground(NEUTRAL_COLOR);


### PR DESCRIPTION
This should fix following Exception which occurred since short.

```
12:51:21.727 [AWT-EventQueue-0] WARN  net.sf.jabref.model.search.rules.GrammarBasedSearchRule - Search query invalid
org.antlr.v4.runtime.misc.ParseCancellationException: line 1:0 no viable alternative at input '<EOF>'
 at net.sf.jabref.model.search.rules.GrammarBasedSearchRule$ThrowingErrorListener.syntaxError(GrammarBasedSearchRule.java:50) ~[main/:?]
       at org.antlr.v4.runtime.ProxyErrorListener.syntaxError(ProxyErrorListener.java:65) ~[antlr4-runtime-4.5.3.jar:4.5.3]
  at org.antlr.v4.runtime.Parser.notifyErrorListeners(Parser.java:564) ~[antlr4-runtime-4.5.3.jar:4.5.3]
at org.antlr.v4.runtime.DefaultErrorStrategy.reportNoViableAlternative(DefaultErrorStrategy.java:308) ~[antlr4-runtime-4.5.3.jar:4.5.3]
       at org.antlr.v4.runtime.DefaultErrorStrategy.reportError(DefaultErrorStrategy.java:145) ~[antlr4-runtime-4.5.3.jar:4.5.3]
     at net.sf.jabref.search.SearchParser.expression(SearchParser.java:283) ~[main/:?]
     at net.sf.jabref.search.SearchParser.start(SearchParser.java:108) ~[main/:?]
  at net.sf.jabref.model.search.rules.GrammarBasedSearchRule.init(GrammarBasedSearchRule.java:91) ~[main/:?]
    at net.sf.jabref.model.search.rules.GrammarBasedSearchRule.validateSearchStrings(GrammarBasedSearchRule.java:108) ~[main/:?]
  at net.sf.jabref.model.search.rules.SearchRules.getSearchRuleByQuery(SearchRules.java:12) ~[main/:?]
  at net.sf.jabref.logic.search.SearchQuery.<init>(SearchQuery.java:29) ~[main/:?]
      at net.sf.jabref.gui.search.GlobalSearchBar.getSearchQuery(GlobalSearchBar.java:348) ~[main/:?]
       at net.sf.jabref.gui.search.GlobalSearchBar.clearSearch(GlobalSearchBar.java:271) ~[main/:?]
  at net.sf.jabref.gui.search.GlobalSearchBar.performSearch(GlobalSearchBar.java:304) ~[main/:?]
```