### PR TITLE
Use parallel stream while searching

### DIFF
--- a/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
+++ b/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
@@ -2,7 +2,6 @@ package net.sf.jabref.benchmarks;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -90,9 +89,14 @@ public class Benchmarks {
     public List<BibEntry> search() {
         // FIXME: Reuse SearchWorker here
         SearchQuery searchQuery = new SearchQuery("Journal Title 500", false, false);
-        List<BibEntry> matchedEntries = new ArrayList<>();
-        matchedEntries.addAll(database.getEntries().parallelStream().filter(searchQuery::isMatch).collect(Collectors.toList()));
-        return matchedEntries;
+        return database.getEntries().stream().filter(searchQuery::isMatch).collect(Collectors.toList());
+    }
+
+    @Benchmark
+    public List<BibEntry> parallelSearch() {
+        // FIXME: Reuse SearchWorker here
+        SearchQuery searchQuery = new SearchQuery("Journal Title 500", false, false);
+        return database.getEntries().parallelStream().filter(searchQuery::isMatch).collect(Collectors.toList());
     }
 
     @Benchmark

--- a/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
+++ b/src/jmh/java/net/sf/jabref/benchmarks/Benchmarks.java
@@ -91,7 +91,7 @@ public class Benchmarks {
         // FIXME: Reuse SearchWorker here
         SearchQuery searchQuery = new SearchQuery("Journal Title 500", false, false);
         List<BibEntry> matchedEntries = new ArrayList<>();
-        matchedEntries.addAll(database.getEntries().stream().filter(searchQuery::isMatch).collect(Collectors.toList()));
+        matchedEntries.addAll(database.getEntries().parallelStream().filter(searchQuery::isMatch).collect(Collectors.toList()));
         return matchedEntries;
     }
 

--- a/src/main/java/net/sf/jabref/gui/search/GlobalSearchWorker.java
+++ b/src/main/java/net/sf/jabref/gui/search/GlobalSearchWorker.java
@@ -42,7 +42,7 @@ class GlobalSearchWorker extends SwingWorker<Map<BasePanel, List<BibEntry>>, Voi
     protected Map<BasePanel, List<BibEntry>> doInBackground() throws Exception {
         Map<BasePanel, List<BibEntry>> matches = new HashMap<>();
         for (BasePanel basePanel : frame.getBasePanelList()) {
-            matches.put(basePanel, basePanel.getDatabase().getEntries().stream()
+            matches.put(basePanel, basePanel.getDatabase().getEntries().parallelStream()
                     .filter(searchQuery::isMatch)
                     .collect(Collectors.toList()));
         }

--- a/src/main/java/net/sf/jabref/gui/search/SearchWorker.java
+++ b/src/main/java/net/sf/jabref/gui/search/SearchWorker.java
@@ -41,7 +41,7 @@ class SearchWorker extends SwingWorker<List<BibEntry>, Void> {
 
     @Override
     protected List<BibEntry> doInBackground() throws Exception {
-        return database.getEntries().stream()
+        return database.getEntries().parallelStream()
                 .filter(searchQuery::isMatch)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
With this the search should be much faster on platforms where multiple cores are available. (#1993)