### PR TITLE
Implemented Integrity NoBibtexFieldChecker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - [#2012](https://github.com/JabRef/jabref/issues/2012) Implemented integrity check for `month` field: Should be an integer or normalized (BibLaTeX), Should be normalized (BibTeX)
 - [#1779](https://github.com/JabRef/jabref/issues/1779) Implemented integrity check for `bibtexkey` field: Empty BibTeX key
 - Prohibit more than one connections to the same shared database.
-- Implemented integrity check for `journaltitle` field: No BibTeX field (BibTeX)
+- Implemented integrity check for `journaltitle` field: BibLaTeX field only (BibTeX)
 
 ### Fixed
 - Fixed [#2054](https://github.com/JabRef/jabref/issues/2054): Ignoring a new version now works as expected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - [#2012](https://github.com/JabRef/jabref/issues/2012) Implemented integrity check for `month` field: Should be an integer or normalized (BibLaTeX), Should be normalized (BibTeX)
 - [#1779](https://github.com/JabRef/jabref/issues/1779) Implemented integrity check for `bibtexkey` field: Empty BibTeX key
 - Prohibit more than one connections to the same shared database.
+- Implemented integrity check for `journaltitle` field: No BibTeX field (BibTeX)
 
 ### Fixed
 - Fixed [#2054](https://github.com/JabRef/jabref/issues/2054): Ignoring a new version now works as expected

--- a/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
@@ -44,6 +44,7 @@ public class IntegrityCheck {
             result.addAll(new TitleChecker().check(entry));
             result.addAll(new PagesChecker().check(entry));
             result.addAll(new ASCIICharacterChecker().check(entry));
+            result.addAll(new NoBibtexFieldChecker().check(entry));
         } else {
             result.addAll(new BiblatexPagesChecker().check(entry));
         }
@@ -55,7 +56,6 @@ public class IntegrityCheck {
         result.addAll(new NoteChecker(bibDatabaseContext).check(entry));
         result.addAll(new HowpublishedChecker(bibDatabaseContext).check(entry));
         result.addAll(new MonthChecker(bibDatabaseContext).check(entry));
-        result.addAll(new NoBibtexFieldChecker(bibDatabaseContext).check(entry));
         result.addAll(new UrlChecker().check(entry));
         result.addAll(new FileChecker(bibDatabaseContext, fileDirectoryPreferences).check(entry));
         result.addAll(new TypeChecker().check(entry));

--- a/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
@@ -55,6 +55,7 @@ public class IntegrityCheck {
         result.addAll(new NoteChecker(bibDatabaseContext).check(entry));
         result.addAll(new HowpublishedChecker(bibDatabaseContext).check(entry));
         result.addAll(new MonthChecker(bibDatabaseContext).check(entry));
+        result.addAll(new NoBibtexFieldChecker(bibDatabaseContext).check(entry));
         result.addAll(new UrlChecker().check(entry));
         result.addAll(new FileChecker(bibDatabaseContext, fileDirectoryPreferences).check(entry));
         result.addAll(new TypeChecker().check(entry));

--- a/src/main/java/net/sf/jabref/logic/integrity/NoBibtexFieldChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/NoBibtexFieldChecker.java
@@ -26,7 +26,7 @@ public class NoBibtexFieldChecker implements Checker {
         //BibTeX
         if (value.isPresent()) {
             return Collections.singletonList(
-                    new IntegrityMessage(Localization.lang("no BibTeX field"), entry, FieldName.JOURNALTITLE));
+                    new IntegrityMessage(Localization.lang("BibLaTeX field only"), entry, FieldName.JOURNALTITLE));
         }
 
         return Collections.emptyList();

--- a/src/main/java/net/sf/jabref/logic/integrity/NoBibtexFieldChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/NoBibtexFieldChecker.java
@@ -19,16 +19,13 @@ public class NoBibtexFieldChecker implements Checker {
     public List<IntegrityMessage> check(BibEntry entry) {
         Optional<String> value = entry.getField(FieldName.JOURNALTITLE);
 
+        //BibTeX
         if (!value.isPresent()) {
             return Collections.emptyList();
         }
-
-        //BibTeX
-        if (value.isPresent()) {
+        else {
             return Collections.singletonList(
                     new IntegrityMessage(Localization.lang("BibLaTeX field only"), entry, FieldName.JOURNALTITLE));
         }
-
-        return Collections.emptyList();
     }
 }

--- a/src/main/java/net/sf/jabref/logic/integrity/NoBibtexFieldChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/NoBibtexFieldChecker.java
@@ -2,39 +2,29 @@ package net.sf.jabref.logic.integrity;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 import net.sf.jabref.logic.integrity.IntegrityCheck.Checker;
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.model.database.BibDatabaseContext;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
 
 public class NoBibtexFieldChecker implements Checker {
 
-    private final BibDatabaseContext bibDatabaseContextEdition;
-
-
-    public NoBibtexFieldChecker(BibDatabaseContext bibDatabaseContext) {
-        this.bibDatabaseContextEdition = Objects.requireNonNull(bibDatabaseContext);
-    }
-
     /**
-     * BibLaTeX package documentation (Section 4.9.1):
-     * The BibLaTeX package will automatically capitalize the first word when required at the beginning of a sentence.
-     * Official BibTeX specification:
-     * note: Any additional information that can help the reader. The first word should be capitalized.
+     * BibLaTeX package documentation (Section 2.1.1):
+     * The title of the periodical is given in the journaltitle field.
      */
     @Override
     public List<IntegrityMessage> check(BibEntry entry) {
         Optional<String> value = entry.getField(FieldName.JOURNALTITLE);
+
         if (!value.isPresent()) {
             return Collections.emptyList();
         }
 
         //BibTeX
-        if (!bibDatabaseContextEdition.isBiblatexMode() && value.isPresent()) {
+        if (value.isPresent()) {
             return Collections.singletonList(
                     new IntegrityMessage(Localization.lang("no BibTeX field"), entry, FieldName.JOURNALTITLE));
         }

--- a/src/main/java/net/sf/jabref/logic/integrity/NoBibtexFieldChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/NoBibtexFieldChecker.java
@@ -1,0 +1,44 @@
+package net.sf.jabref.logic.integrity;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import net.sf.jabref.logic.integrity.IntegrityCheck.Checker;
+import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.model.database.BibDatabaseContext;
+import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.model.entry.FieldName;
+
+public class NoBibtexFieldChecker implements Checker {
+
+    private final BibDatabaseContext bibDatabaseContextEdition;
+
+
+    public NoBibtexFieldChecker(BibDatabaseContext bibDatabaseContext) {
+        this.bibDatabaseContextEdition = Objects.requireNonNull(bibDatabaseContext);
+    }
+
+    /**
+     * BibLaTeX package documentation (Section 4.9.1):
+     * The BibLaTeX package will automatically capitalize the first word when required at the beginning of a sentence.
+     * Official BibTeX specification:
+     * note: Any additional information that can help the reader. The first word should be capitalized.
+     */
+    @Override
+    public List<IntegrityMessage> check(BibEntry entry) {
+        Optional<String> value = entry.getField(FieldName.JOURNALTITLE);
+        if (!value.isPresent()) {
+            return Collections.emptyList();
+        }
+
+        //BibTeX
+        if (!bibDatabaseContextEdition.isBiblatexMode() && value.isPresent()) {
+            return Collections.singletonList(
+                    new IntegrityMessage(Localization.lang("no BibTeX field"), entry, FieldName.JOURNALTITLE));
+        }
+
+        return Collections.emptyList();
+    }
+}

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -2306,3 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
+no_BibTeX_field=

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -2306,4 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
-no_BibTeX_field=
+BibLaTeX_field_only=

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2306,3 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
+no_BibTeX_field=

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2306,4 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
-no_BibTeX_field=
+BibLaTeX_field_only=

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2306,3 +2306,4 @@ Invalid_ISBN\:_'%0'.=Invalid_ISBN\:_'%0'.
 should_be_an_integer_or_normalized=should_be_an_integer_or_normalized
 should_be_normalized=should_be_normalized
 empty_BibTeX_key=empty_BibTeX_key
+no_BibTeX_field=no_BibTeX_field

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2306,4 +2306,4 @@ Invalid_ISBN\:_'%0'.=Invalid_ISBN\:_'%0'.
 should_be_an_integer_or_normalized=should_be_an_integer_or_normalized
 should_be_normalized=should_be_normalized
 empty_BibTeX_key=empty_BibTeX_key
-no_BibTeX_field=no_BibTeX_field
+BibLaTeX_field_only=BibLaTeX_field_only

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -2306,3 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
+no_BibTeX_field=

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -2306,4 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
-no_BibTeX_field=
+BibLaTeX_field_only=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -2306,3 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
+no_BibTeX_field=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -2306,4 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
-no_BibTeX_field=
+BibLaTeX_field_only=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -2306,4 +2306,4 @@ Invalid_ISBN\:_'%0'.=ISBN_invalide_:_%0.
 should_be_an_integer_or_normalized=devrait_être_un_entier_ou_une_abréviation_standard
 should_be_normalized=devrait_être_une_abréviation_standard
 empty_BibTeX_key=Clef_BibTeX_vide
-no_BibTeX_field=
+BibLaTeX_field_only=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -2306,3 +2306,4 @@ Invalid_ISBN\:_'%0'.=ISBN_invalide_:_%0.
 should_be_an_integer_or_normalized=devrait_être_un_entier_ou_une_abréviation_standard
 should_be_normalized=devrait_être_une_abréviation_standard
 empty_BibTeX_key=Clef_BibTeX_vide
+no_BibTeX_field=

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -2306,3 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
+no_BibTeX_field=

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -2306,4 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
-no_BibTeX_field=
+BibLaTeX_field_only=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -2306,3 +2306,4 @@ Invalid_ISBN\:_'%0'.=ISBN_invalido\:'%0'
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
+no_BibTeX_field=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -2306,4 +2306,4 @@ Invalid_ISBN\:_'%0'.=ISBN_invalido\:'%0'
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
-no_BibTeX_field=
+BibLaTeX_field_only=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2306,3 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
+no_BibTeX_field=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2306,4 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
-no_BibTeX_field=
+BibLaTeX_field_only=

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -2306,3 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
+no_BibTeX_field=

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -2306,4 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
-no_BibTeX_field=
+BibLaTeX_field_only=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -2306,3 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
+no_BibTeX_field=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -2306,4 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
-no_BibTeX_field=
+BibLaTeX_field_only=

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -2306,3 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
+no_BibTeX_field=

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -2306,4 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
-no_BibTeX_field=
+BibLaTeX_field_only=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2306,3 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
+no_BibTeX_field=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2306,4 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
-no_BibTeX_field=
+BibLaTeX_field_only=

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -2306,3 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
+no_BibTeX_field=

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -2306,4 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
-no_BibTeX_field=
+BibLaTeX_field_only=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -2306,3 +2306,4 @@ Invalid_ISBN\:_'%0'.=Geçersiz_ISBN\:_'%0'.
 should_be_an_integer_or_normalized=bir_tamsayı_olmalı_ya_da_normalleştirilmelidir
 should_be_normalized=normalleştirilmelidir
 empty_BibTeX_key=boş_BibTeX_anahtarı
+no_BibTeX_field=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -2306,4 +2306,4 @@ Invalid_ISBN\:_'%0'.=Geçersiz_ISBN\:_'%0'.
 should_be_an_integer_or_normalized=bir_tamsayı_olmalı_ya_da_normalleştirilmelidir
 should_be_normalized=normalleştirilmelidir
 empty_BibTeX_key=boş_BibTeX_anahtarı
-no_BibTeX_field=
+BibLaTeX_field_only=

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -2306,3 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
+no_BibTeX_field=

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -2306,4 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
-no_BibTeX_field=
+BibLaTeX_field_only=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -2306,3 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
+no_BibTeX_field=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -2306,4 +2306,4 @@ Invalid_ISBN\:_'%0'.=
 should_be_an_integer_or_normalized=
 should_be_normalized=
 empty_BibTeX_key=
-no_BibTeX_field=
+BibLaTeX_field_only=

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -112,6 +112,12 @@ public class IntegrityCheckTest {
     }
 
     @Test
+    public void testJournaltitleChecks() {
+        assertCorrect(withMode(createContext("journaltitle", "A journal"), BibDatabaseMode.BIBLATEX));
+        assertWrong(withMode(createContext("journaltitle", "A journal"), BibDatabaseMode.BIBTEX));
+    }
+
+    @Test
     public void testBibtexkeyChecks() {
         assertCorrect(createContext("bibtexkey", "Knuth2014"));
     }


### PR DESCRIPTION
Background: Converting to Biblatex format changes journal to journaltitle. Because journaltitle is a Biblatex field only, Integrity check now reports a problem for a journaltitle field in a BibTeX mode database.

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)

