### PR TITLE
Fix execution of preference migrations

### DIFF
--- a/src/main/java/net/sf/jabref/JabRefGUI.java
+++ b/src/main/java/net/sf/jabref/JabRefGUI.java
@@ -30,7 +30,6 @@ import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.util.OS;
 import net.sf.jabref.logic.util.Version;
-import net.sf.jabref.migrations.PreferencesMigrations;
 import net.sf.jabref.preferences.JabRefPreferences;
 import net.sf.jabref.shared.exception.DatabaseNotSupportedException;
 
@@ -74,10 +73,6 @@ public class JabRefGUI {
     }
 
     private void openWindow() {
-        // Perform checks and changes for users with a preference set from an older JabRef version.
-        PreferencesMigrations.upgradeSortOrder();
-        PreferencesMigrations.upgradeFaultyEncodingStrings();
-        PreferencesMigrations.upgradeLabelPatternToBibtexKeyPattern();
 
         // This property is set to make the Mac OSX Java VM move the menu bar to the top of the screen
         if (OS.OS_X) {

--- a/src/main/java/net/sf/jabref/JabRefMain.java
+++ b/src/main/java/net/sf/jabref/JabRefMain.java
@@ -22,6 +22,7 @@ import net.sf.jabref.logic.protectedterms.ProtectedTermsLoader;
 import net.sf.jabref.logic.remote.RemotePreferences;
 import net.sf.jabref.logic.remote.client.RemoteListenerClient;
 import net.sf.jabref.logic.util.OS;
+import net.sf.jabref.migrations.PreferencesMigrations;
 import net.sf.jabref.model.entry.InternalBibtexFields;
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -51,6 +52,12 @@ public class JabRefMain {
         Globals.prefs = preferences;
         Localization.setLanguage(preferences.get(JabRefPreferences.LANGUAGE));
         Globals.prefs.setLanguageDependentDefaultValues();
+
+        // Perform Migrations
+        // Perform checks and changes for users with a preference set from an older JabRef version.
+        PreferencesMigrations.upgradeSortOrder();
+        PreferencesMigrations.upgradeFaultyEncodingStrings();
+        PreferencesMigrations.upgradeLabelPatternToBibtexKeyPattern();
 
         // Update handling of special fields based on preferences
         InternalBibtexFields


### PR DESCRIPTION
Follow up of #1704 to fix the key pattern part of #2021

Preference migrations are executed too late after other operations already worked on the prefs node --> execute them directly in the main class.