### PR TITLE
Tooltips now working in the main table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Implemented integrity check for `journaltitle` field: BibLaTeX field only (BibTeX)
 
 ### Fixed
+- Fixed [koppor#160](https://github.com/koppor/jabref/issues/160): Tooltips now working in the main table
 - Fixed [#2054](https://github.com/JabRef/jabref/issues/2054): Ignoring a new version now works as expected
 - Fixed selecting an entry out of multiple duplicates
 - Fixed [#617](https://github.com/JabRef/jabref/issues/617): `Enter` in global search opens the selected entry & `Enter` in search dialog window opens the selected entry

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
@@ -1,7 +1,6 @@
 package net.sf.jabref.gui.maintable;
 
 import java.awt.Color;
-import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Point;
 import java.awt.Rectangle;
@@ -231,18 +230,14 @@ public class MainTable extends JTable {
 
     @Override
     public String getToolTipText(MouseEvent e) {
-
-        // Set tooltip text for all columns which are not fully displayed
-
-        String toolTipText = null;
+        String toolTipText = super.getToolTipText(e);
         Point p = e.getPoint();
         int col = columnAtPoint(p);
         int row = rowAtPoint(p);
-        Component comp = prepareRenderer(getCellRenderer(row, col), row, col);
 
         Rectangle bounds = getCellRect(row, col, false);
-
-        Dimension d = comp.getPreferredSize();
+        Dimension d = prepareRenderer(getCellRenderer(row, col), row, col).getPreferredSize();
+        // if the content of the cell is bigger than the cell itself render it as the tooltip (thus throwing the original tooltip away)
         if ((d != null) && (d.width > bounds.width) && (getValueAt(row, col) != null)) {
             toolTipText = getValueAt(row, col).toString();
         }


### PR DESCRIPTION
Fixes: https://github.com/koppor/jabref/issues/160.

Tool tips in the main table now work as expected.

If the content of the cell is too big to be rendered in the cell itself it will be shown as a tool tip. What is more important, the original tool tip or the content?
