### PR TITLE
Fix number column alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Changed
 - Add session restoring functionality for shared database. Related to [#1703](https://github.com/JabRef/jabref/issues/1703)
 - Implementation of LiveUpdate for PostgreSQL & Oracle systems. Related to [#970](https://github.com/JabRef/jabref/issues/970).
-- Number column in the main table is always Left aligned
+- [koppor#31](https://github.com/koppor/jabref/issues/31): Number column in the main table is always Left aligned
 - Added support for [1.0.1 CitationStyles](http://citationstyles.org/)
 - You can set and cycle between different preview styles (including CitationStyles)
 - Added fetcher for [MathSciNet](http://www.ams.org/mathscinet), [zbMATH](https://www.zbmath.org/) and [Astrophysics Data System](http://www.adsabs.harvard.edu/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Changed
 - Add session restoring functionality for shared database. Related to [#1703](https://github.com/JabRef/jabref/issues/1703)
 - Implementation of LiveUpdate for PostgreSQL & Oracle systems. Related to [#970](https://github.com/JabRef/jabref/issues/970).
+- Number column in the main table is always Left aligned
 - Added support for [1.0.1 CitationStyles](http://citationstyles.org/)
 - You can set and cycle between different preview styles (including CitationStyles)
 - Added fetcher for [MathSciNet](http://www.ams.org/mathscinet), [zbMATH](https://www.zbmath.org/) and [Astrophysics Data System](http://www.adsabs.harvard.edu/)

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
@@ -294,7 +294,6 @@ public class MainTable extends JTable {
                 MainTable.incRenderer.setNumber(row);
                 renderer = MainTable.incRenderer;
             }
-            renderer.setHorizontalAlignment(JLabel.CENTER);
         } else if (tableColorCodes || tableResolvedColorCodes) {
             CellRendererMode status = getCellStatus(row, column, tableResolvedColorCodes);
             if (status == CellRendererMode.REQUIRED) {

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTable.java
@@ -15,7 +15,6 @@ import javax.swing.AbstractAction;
 import javax.swing.ActionMap;
 import javax.swing.BorderFactory;
 import javax.swing.InputMap;
-import javax.swing.JLabel;
 import javax.swing.JScrollBar;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;


### PR DESCRIPTION
fixes: https://github.com/koppor/jabref/issues/31

Now the number in the `#`-column is always left aligned.