### PR TITLE
Quick fix google scholar entry fetching

### DIFF
--- a/src/main/java/net/sf/jabref/logic/net/URLDownload.java
+++ b/src/main/java/net/sf/jabref/logic/net/URLDownload.java
@@ -47,6 +47,12 @@ public class URLDownload {
 
     private String postData = "";
 
+    public static URLDownload createURLDownloadWithBrowserUserAgent(String address) throws MalformedURLException {
+        URLDownload downloader = new URLDownload(address);
+        downloader.addParameters("User-Agent", "Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0");
+        return downloader;
+    }
+
     /**
      * @param address the URL to download from
      * @throws MalformedURLException if no protocol is specified in the address, or an unknown protocol is found


### PR DESCRIPTION
Google Scholar fetching was broken again (see #1886)

With this fix at least getting the first 10 search hits is possible again. 

Configuration is no longer possible in the current form and google generally limits the responses (per page) to 20 hits (however, even using this will cause a captcha challenge for JabRef).

As only 10 hits are allowed a rewrite to the new FetcherInfrastructure should now be possible (thus, omitting the 2-step approach).

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
  - [ ] Update of http://help.jabref.org/en/GoogleScholar might be useful to indicate that only 10 hits are (currently) shown

