### PR TITLE
Localization script: Simplify update output and fix printing of special characters

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,4 @@
 - [ ] Screenshots added (for bigger UI changes)
 - [ ] Manually tested changed features in running JabRef
 - [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
+- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?

--- a/scripts/logger.py
+++ b/scripts/logger.py
@@ -11,19 +11,19 @@ OUTPUT_COLORS = enum(
 
 
 def error(content):
-    print "{color_error}{content}{color_end}" \
-        .format(color_error=OUTPUT_COLORS.ERROR, content=str(content), color_end=OUTPUT_COLORS.ENDC)
+    print u"{color_error}{content}{color_end}".encode('utf8') \
+        .format(color_error=OUTPUT_COLORS.ERROR, content=str(content.encode('utf8')), color_end=OUTPUT_COLORS.ENDC)
 
 
 def warn(content):
-    print "{color_error}{content}{color_end}" \
-        .format(color_error=OUTPUT_COLORS.WARN, content=str(content), color_end=OUTPUT_COLORS.ENDC)
+    print u"{color_error}{content}{color_end}".encode('utf8') \
+        .format(color_error=OUTPUT_COLORS.WARN, content=str(content.encode('utf8')), color_end=OUTPUT_COLORS.ENDC).encode('utf8')
 
 
 def ok(content):
-    print "{color_error}{content}{color_end}" \
-        .format(color_error=OUTPUT_COLORS.OK, content=str(content), color_end=OUTPUT_COLORS.ENDC)
+    print u"{color_error}{content}{color_end}".encode('utf8') \
+        .format(color_error=OUTPUT_COLORS.OK, content=str(content.encode('utf8')), color_end=OUTPUT_COLORS.ENDC).encode('utf8')
 
 
 def neutral(content):
-    print content
+    print content.encode('utf8')

--- a/src/main/resources/l10n/Menu_vi.properties
+++ b/src/main/resources/l10n/Menu_vi.properties
@@ -2,133 +2,136 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-# Menu names
-File=Tập_tin
-Edit=Chỉnh_sửa
-Search=Tìm
-Groups=Các_nhóm
-View=Xem
-Quality=Chất_Lượng
-Tools=Công_cụ
-Options=Tùy_chọn
-Help=Trợ_giúp
-
-# File menu
-New_%0_database=Mở_dữ_liệu_%0_mới
-Open_database=Mở_CSDL
+Abbreviate_journal_names_(ISO)=Viết_tắt_tên_các_tạp_chí_(ISO)
+Abbreviate_journal_names_(MEDLINE)=Viết_tắt_tên_các_tạp_chí_(MEDLINE)
+About_JabRef=Nói_về_JabRef
 Append_database=Nối_CSDL
-Save_database=Lưu_CSDL
-Save_database_as...=Lưu_CSDL_thành_...
-Save_all=Lưu_tất_cả
-Save_selected_as...=Lưu_phần_chọn_thành_...
-Save_selected_as_plain_BibTeX...=Lưu_phần_chọn_thành_plain_Bibtex...
-Import_into_new_database=Nhập_vào_thành_CSDL_mới
-Import_into_current_database=Nhập_vào_CSDL_hiện_tại
-Export=Xuất
-Export_selected_entries=Xuất_các_mục_được_chọn
-Open_shared_database=Mở_CSDL_chia_sẻ
-Pull_changes_from_shared_database=Cập_nhập_thông_tin_từ_CSDL_chia_sẻ
-Database_properties=Thuộc_tính_CSDL
-Switch_to_%0_mode=Chuyển_sang_hệ_%0
-Recent_files=Các_tập_tin_gần_đây
+Autogenerate_BibTeX_keys=Tự_động_tạo_khóa_BibTeX
 Close_database=Đóng_CSDL
-Quit=Thoát
-
-# Edit menu
-Undo=Quay_ngược_lệnh
-Redo=Làm_lại
-Cut=Cắt
 Copy=Sao_chép
-Paste=Nhập_vào
-Copy_BibTeX_key=Sao_chép_khóa_BibTeX
 Copy_\\cite{BibTeX_key}=Sao_chép\\trích_dẫn{khóa_BibTeX}
-Copy_BibTeX_key_and_title=Sao_chép_khóa_Bibtex_và_danh_hiệu
-Copy_BibTeX_key_and_link=Sao_chép_khóa_BibTex_và_đường_liên_kết
-Export_selected_entries_to_clipboard=Xuất_các_mục_đã_chọn_ra_từ_bộ_nhớ_tạm_thời
-Mark_entries=Đánh_dấu_các_mục
-Mark_specific_color=Đánh_dấu_bằng_màu_cụ_thể
-Unmark_entries=Xóa_bỏ_đánh_dấu_các_mục
-Unmark_all=Xóa_bỏ_đánh_dấu_tất_cả
-Manage_keywords=Quản_lý_các_từ_khóa
-Set/clear/rename_fields=Thiết_lập/Xóa/Đổi_tên_trường
-Select_all=Chọn_tất_cả
-
-# Search menu
-Replace_string=Thay_chuỗi
-
-# Groups menu
-Toggle_groups_interface=Bật/tắt_giao_diện_nhóm
-Highlight_groups_matching_any_selected_entry=Tô_sáng_các_nhóm_khớp_bất_kỳ_mục_chọn_nào
-Highlight_groups_matching_all_selected_entries=Tô_sáng_các_nhóm_khớp_tất_cả_các_mục_chọn
-Disable_highlight_groups_matching_entries=Xóa_bỏ_tô_sáng_các_nhóm_trùng_khớp_mục
-
-# View menu
-Back=Lui
-Forward=Tới
-Focus_entry_table=Tập_trung_vào_bảng_chứa_mục
-Next_tab=Thẻ_tiếp_theo
-Previous_tab=Thẻ_trước
-Sort_tabs=Phân_loại_thẻ
-Increase_table_font_size=Tăng_kích_thước_phông_của_bảng
-Decrease_table_font_size=Giảm_kích_thước_phông_của_bảng
-Hide/show_toolbar=Tắt/Bật_toolbar
-Toggle_entry_preview=Bật/tắt_xem_trước_mục
-Next_preview_layout=Xem_trước_bố_trí_tiếp_theo
-Previous_preview_layout=Xem_trước_bố_trí_trước_đó
-
-# Bibtex menu
-New_entry=Mục_mới
-New_entry_by_type...=Mục_mới...
-New_entry_from_plain_text=Mục_mới_từ_văn_bản_trơn
+Copy_BibTeX_key=Sao_chép_khóa_BibTeX
+Customize_entry_types=Tùy_biến_kiểu_các_mục
+Cut=Cắt
+Database_properties=Thuộc_tính_CSDL
+Edit=Chỉnh_sửa
+# Bibtex
 Edit_entry=Chỉnh_sửa_mục
 Edit_preamble=Chỉnh_sửa_phần_mở_đầu
 Edit_strings=Chỉnh_sửa_chuỗi
-Customize_entry_types=Tùy_biến_kiểu_các_mục
-Delete_entry=Xóa_mục
+Export=Xuất
+Export_selected_entries_to_clipboard=Xuất_các_mục_đã_chọn_ra_từ_bộ_nhớ_tạm_thời
 
-# Quality menu
+# Menu names
+File=Tập_tin
 Find_duplicates=Tìm_các_mục_trùng
-Merge_entries=Phối_các_mục_vào
-Resolve_duplicate_BibTeX_keys=Giải_quyết_khóa_Bibtex_bị_lặp_lại
-Check_integrity=Kiểm_tra_tính_nguyên_vẹn
-Cleanup_entries=Dọn_dẹp_các_mục
-Autogenerate_BibTeX_keys=Tự_động_tạo_khóa_BibTeX
-Find_unlinked_files...=Tìm_các_tập_tin_bị_ngắt_liên_kết...
-Look_up_full_text_document=Tìm_tài_liệu_đầy_đủ
+Help=Trợ_giúp
+Highlight_groups_matching_all_selected_entries=Tô_sáng_các_nhóm_khớp_tất_cả_các_mục_chọn
+Highlight_groups_matching_any_selected_entry=Tô_sáng_các_nhóm_khớp_bất_kỳ_mục_chọn_nào
+Disable_highlight_groups_matching_entries=Xóa_bỏ_tô_sáng_các_nhóm_trùng_khớp_mục
 
-# Tools menu
-New_subdatabase_based_on_AUX_file=Cơ_sở_dữ_liệu_con_mới_dựa_trên_tập_tin_AUX
-Write_XMP-metadata_to_PDFs=Ghi_XMP-metadata_thành_các_PDF
-Push_entries_to_external_application_(%0)=Đưa_các_mục_ra_ứng_dụng_ngoài_(%0)
-Open_folder=Mở_thư_mục
-Open_file=Mở_tập_tin
-Open_URL_or_DOI=Mở_URL_hoặc_DOI
-Open_terminal_here=Mở_thiết_bị_đầu_cuối_ở_đây
-Abbreviate_journal_names_(ISO)=Viết_tắt_tên_các_tạp_chí_(ISO)
-Abbreviate_journal_names_(MEDLINE)=Viết_tắt_tên_các_tạp_chí_(MEDLINE)
-Unabbreviate_journal_names=Không_viết_tắt_tên_các_tạp_chí
-
-# Options menu
-Preferences=Tùy_thích
-Set_up_general_fields=Thiết_lập_các_trường_tổng_quát
+# Help
+Online_help=Trợ_giúp_trực_tuyến
+Donate_to_JabRef=Hỗ_trợ_cho_JabRef
 Manage_custom_exports=Quản_lý_xuất_theo_tùy_chọn
 Manage_custom_imports=Quản_lý_nhập_theo_tùy_chọn
-Manage_external_file_types=Quản_lý_các_kiểu_tập_tin_ngoài
 Manage_journal_abbreviations=Quản_lý_viết_tắt_tên_tạp_chí
-Manage_protected_terms=Quản_lý_bảo_vệ_thuật_ngữ
-
-# Help menu
-Online_help=Trợ_giúp_trực_tuyến
-Online_help_forum=Diễn_đàn_trợ_giúp_trực_tuyến
+Mark_entries=Đánh_dấu_các_mục
+# File menu
+New_%0_database=Mở_dữ_liệu_%0_mới
+# Menu BibTeX (BibTeX)
+New_entry=Mục_mới
+New_entry_by_type...=Mục_mới...
+New_entry_from_plain_text=Mục_mới_từ_văn_bản_trơn
+New_subdatabase_based_on_AUX_file=Cơ_sở_dữ_liệu_con_mới_dựa_trên_tập_tin_AUX
+# View
+Next_tab=Thẻ_tiếp_theo
+Open_database=Mở_CSDL
+Open_URL_or_DOI=Mở_URL_hoặc_DOI
+Open_shared_database=Mở_CSDL_chia_sẻ
+Open_terminal_here=Mở_thiết_bị_đầu_cuối_ở_đây
+Options=Tùy_chọn
+Paste=Nhập_vào
+# Options
+Preferences=Tùy_thích
+Previous_tab=Thẻ_trước
+Quit=Thoát
+Recent_files=Các_tập_tin_gần_đây
+Redo=Làm_lại
+Replace_string=Thay_chuỗi
+Save_database=Lưu_CSDL
+Save_database_as...=Lưu_CSDL_thành_...
+Save_selected_as...=Lưu_phần_chọn_thành_...
+# Tools
+Search=Tìm
+Global_Search=Tìm_kiếm_toàn_cầu
+Select_all=Chọn_tất_cả
+Set_up_general_fields=Thiết_lập_các_trường_tổng_quát
 Show_error_console=Hiển_thị_cửa_sổ_báo_lỗi
-JabRef_resources=Nguồn_của_JabRef
+Sort_tabs=Phân_loại_thẻ
+Next_preview_layout=Xem_trước_bố_trí_tiếp_theo
+Previous_preview_layout=Xem_trước_bố_trí_trước_đó
+# Export menu
+Toggle_entry_preview=Bật/tắt_xem_trước_mục
+Toggle_groups_interface=Bật/tắt_giao_diện_nhóm
+Tools=Công_cụ
+Unabbreviate_journal_names=Không_viết_tắt_tên_các_tạp_chí
+# Edit
+Undo=Quay_ngược_lệnh
+Mark_specific_color=Đánh_dấu_bằng_màu_cụ_thể
+Unmark_all=Xóa_bỏ_đánh_dấu_tất_cả
+Unmark_entries=Xóa_bỏ_đánh_dấu_các_mục
+View=Xem
+Import_into_new_database=Nhập_vào_thành_CSDL_mới
+Import_into_current_database=Nhập_vào_CSDL_hiện_tại
+
+Switch_to_%0_mode=Chuyển_sang_hệ_%0
+Push_entries_to_external_application_(%0)=Đưa_các_mục_ra_ứng_dụng_ngoài_(%0)
+Pull_changes_from_shared_database=Cập_nhập_thông_tin_từ_CSDL_chia_sẻ
+Write_XMP-metadata_to_PDFs=Ghi_XMP-metadata_thành_các_PDF
+
+Export_selected_entries=Xuất_các_mục_được_chọn
+
+Save_all=Lưu_tất_cả
+
+Manage_external_file_types=Quản_lý_các_kiểu_tập_tin_ngoài
+
+Open_file=Mở_tập_tin
+
+Focus_entry_table=Tập_trung_vào_bảng_chứa_mục
+
+Increase_table_font_size=Tăng_kích_thước_phông_của_bảng
+Decrease_table_font_size=Giảm_kích_thước_phông_của_bảng
+Forward=Tới
+Back=Lui
+
+Look_up_full_text_document=Tìm_tài_liệu_đầy_đủ
+Set/clear/rename_fields=Thiết_lập/Xóa/Đổi_tên_trường
+
+Resolve_duplicate_BibTeX_keys=Giải_quyết_khóa_Bibtex_bị_lặp_lại
+Copy_BibTeX_key_and_title=Sao_chép_khóa_Bibtex_và_danh_hiệu
+
+Cleanup_entries=Dọn_dẹp_các_mục
+Manage_keywords=Quản_lý_các_từ_khóa
+Merge_entries=Phối_các_mục_vào
+Open_folder=Mở_thư_mục
+Find_unlinked_files...=Tìm_các_tập_tin_bị_ngắt_liên_kết...
+Hide/show_toolbar=Tắt/Bật_toolbar
+
+Fork_me_on_GitHub=Nhánh_rẽ_từ_GitHub
+Save_selected_as_plain_BibTeX...=Lưu_phần_chọn_thành_plain_Bibtex...
+
+Groups=Các_nhóm
+Delete_entry=Xóa_mục
+Check_integrity=Kiểm_tra_tính_nguyên_vẹn
+
+Quality=Chất_Lượng
+Online_help_forum=Diễn_đàn_trợ_giúp_trực_tuyến
+Manage_protected_terms=Quản_lý_bảo_vệ_thuật_ngữ
 Website=Trang_web
 Blog=Blog
-Fork_me_on_GitHub=Nhánh_rẽ_từ_GitHub
+JabRef_resources=Nguồn_của_JabRef
 Development_version=Phiên_bản_phát_triển
 View_change_log=Xem_nhật_kí_thay_đổi
-Donate_to_JabRef=Hỗ_trợ_cho_JabRef
-About_JabRef=Nói_về_JabRef
-# Not in menu
-Global_Search=Tìm_kiếm_toàn_cầu
+Copy_BibTeX_key_and_link=Sao_chép_khóa_BibTex_và_đường_liên_kết
 Copy_DOI_url=Sao_chép_DOI_url


### PR DESCRIPTION
I really don't like the missing type safety in python ...

Now the problematic translations get printed to the terminal correctly.
I simplified the output while running the update task; printing only the changes.
I also added a new checkbox to the PR-template to make it easier for new people. 