### PR TITLE
[WIP] Speed up search

### DIFF
--- a/jabref.install4j
+++ b/jabref.install4j
@@ -750,4 +750,9 @@ return true;</string>
   </mediaSets>
   <buildIds buildAll="true" />
   <buildOptions verbose="false" faster="false" disableSigning="false" disableJreBundling="false" debug="false" />
+  <jvmArguments>
+      <arg>-XX:+UseG1GC</arg>
+      <arg>-XX:+UseStringDeduplication</arg>
+      <arg>-XX:StringTableSize=1000003</arg>
+  </jvmArguments>
 </install4j>

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -426,8 +426,8 @@ public class BibEntry implements Cloneable {
 
         changed = true;
 
-        fields.put(fieldName, value);
-        fieldsLatexFree.put(fieldName, LATEX_TO_UNICODE_FORMATTER.format(value));
+        fields.put(fieldName, value.intern());
+        fieldsLatexFree.put(fieldName, LATEX_TO_UNICODE_FORMATTER.format(value).intern());
         fieldsAsWords.remove(fieldName);
 
         FieldChange change = new FieldChange(this, fieldName, oldValue, value);

--- a/src/main/java/net/sf/jabref/model/search/rules/ContainBasedSearchRule.java
+++ b/src/main/java/net/sf/jabref/model/search/rules/ContainBasedSearchRule.java
@@ -4,14 +4,11 @@ import java.util.Iterator;
 import java.util.List;
 
 import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.model.strings.LatexToUnicode;
 
 /**
  * Search rule for contain-based search.
  */
 public class ContainBasedSearchRule implements SearchRule {
-
-    private static final LatexToUnicode LATEX_TO_UNICODE_FORMATTER = new LatexToUnicode();
 
     private final boolean caseSensitive;
 
@@ -38,16 +35,15 @@ public class ContainBasedSearchRule implements SearchRule {
 
         List<String> unmatchedWords = new SentenceAnalyzer(searchString).getWords();
 
-        for (String fieldContent : bibEntry.getFieldValues()) {
-            String formattedFieldContent = LATEX_TO_UNICODE_FORMATTER.format(fieldContent);
+        for (String fieldContent : bibEntry.getFieldsLatexFree().values()) {
             if (!caseSensitive) {
-                formattedFieldContent = formattedFieldContent.toLowerCase();
+                fieldContent = fieldContent.toLowerCase();
             }
 
             Iterator<String> unmatchedWordsIterator = unmatchedWords.iterator();
             while (unmatchedWordsIterator.hasNext()) {
                 String word = unmatchedWordsIterator.next();
-                if(formattedFieldContent.contains(word)) {
+                if (fieldContent.contains(word)) {
                     unmatchedWordsIterator.remove();
                 }
             }


### PR DESCRIPTION
Refers to: #1993 

At the request of @koppor I speed up the search by using a second map of fields inside BibEntry which stores the field latex free.
I also internalize these fields and set the necessary JVM arguments in install4j (I hope those are right).

#### TODO: 
- Identifiy all the uses of the LatexToUnicodeFormatter and replace it.
