### PR TITLE
Make all files selectable in file chooser dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed [#2060](https://github.com/JabRef/jabref/issues/2060): Medline fetcher now imports data in UTF-8 encoding
 - Fixed file menu displays wrong hotkey in the German translation
 - Fixed [#2090](https://github.com/JabRef/jabref/issues/#2090): If special fields were not selected, two menu item separator were shown
+- Fixed [#2021](https://github.com/JabRef/jabref/issues/2021): All filetypes can be selected on MacOS again
 - Fixed [#2064](https://github.com/JabRef/jabref/issues/2064): Not all `other fields` are shown on entry change of same type
 - Fixed [#2104](https://github.com/JabRef/jabref/issues/#2104): Crash after saving BibTeX source with parsing error
 - Fixed [#2109](https://github.com/JabRef/jabref/issues/#2109): <kbd>Ctrl-s</kbd> doesn't trigger parsing error message

--- a/src/main/java/net/sf/jabref/gui/FileDialog.java
+++ b/src/main/java/net/sf/jabref/gui/FileDialog.java
@@ -101,6 +101,7 @@ public class FileDialog {
         for (FileExtensions ext : fileExtensions) {
             FileNameExtensionFilter extFilter = new FileNameExtensionFilter(ext.getDescription(), ext.getExtensions());
             fileChooser.addChoosableFileFilter(extFilter);
+            fileChooser.setAcceptAllFileFilterUsed(true);
         }
 
         return this;

--- a/src/main/java/net/sf/jabref/gui/FileDialog.java
+++ b/src/main/java/net/sf/jabref/gui/FileDialog.java
@@ -101,6 +101,7 @@ public class FileDialog {
         for (FileExtensions ext : fileExtensions) {
             FileNameExtensionFilter extFilter = new FileNameExtensionFilter(ext.getDescription(), ext.getExtensions());
             fileChooser.addChoosableFileFilter(extFilter);
+            // explictly needed for OSX to enable *.* file filter
             fileChooser.setAcceptAllFileFilterUsed(true);
         }
 


### PR DESCRIPTION
make all files selectable in filechooser

 fixed #2021
- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?

