### PR TITLE
Clear searchterm with ESC from main table if neither preview nor editor is open

### DIFF
--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -1390,9 +1390,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 // need to close these here, b/c this action overshadows the responsible actions when the main table is selected
                 switch (mode) {
                     case SHOWING_NOTHING:
-                        frame.getGlobalSearchBar().setSearchTerm("", true);
-                        mainTable.requestFocus();
-                        SwingUtilities.invokeLater(() -> mainTable.ensureVisible(mainTable.getSelectedRow()));
+                        frame.getGlobalSearchBar().endSearch();
                         break;
                     case SHOWING_PREVIEW:
                         getPreviewPanel().close();

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -1400,6 +1400,9 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     case WILL_SHOW_EDITOR:
                         getCurrentEditor().close();
                         break;
+                    default:
+                        LOGGER.warn("unknown BasePanelMode: '" + mode + "', doing nothing");
+                        break;
                 }
             }
         });

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -1392,6 +1392,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     case SHOWING_NOTHING:
                         frame.getGlobalSearchBar().setSearchTerm("", true);
                         mainTable.requestFocus();
+                        SwingUtilities.invokeLater(() -> mainTable.ensureVisible(mainTable.getSelectedRow()));
                         break;
                     case SHOWING_PREVIEW:
                         getPreviewPanel().close();

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -70,6 +70,7 @@ import net.sf.jabref.gui.groups.GroupTreeNodeViewModel;
 import net.sf.jabref.gui.importer.actions.AppendDatabaseAction;
 import net.sf.jabref.gui.journals.AbbreviateAction;
 import net.sf.jabref.gui.journals.UnabbreviateAction;
+import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.gui.maintable.MainTable;
 import net.sf.jabref.gui.maintable.MainTableDataModel;
 import net.sf.jabref.gui.maintable.MainTableFormat;
@@ -1380,6 +1381,28 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             }
         };
         mainTable.addSelectionListener(groupsHighlightListener);
+
+        String clearSearch = "clearSearch";
+        mainTable.getInputMap().put(Globals.getKeyPrefs().getKey(KeyBinding.CLEAR_SEARCH), clearSearch);
+        mainTable.getActionMap().put(clearSearch, new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                // need to close these here, b/c this action overshadows the responsible actions when the main table is selected
+                switch (mode) {
+                    case SHOWING_NOTHING:
+                        frame.getGlobalSearchBar().setSearchTerm("", true);
+                        mainTable.requestFocus();
+                        break;
+                    case SHOWING_PREVIEW:
+                        getPreviewPanel().close();
+                        break;
+                    case SHOWING_EDITOR:
+                    case WILL_SHOW_EDITOR:
+                        getCurrentEditor().close();
+                        break;
+                }
+            }
+        });
 
         mainTable.getActionMap().put(Actions.CUT, new AbstractAction() {
 

--- a/src/main/java/net/sf/jabref/gui/PreviewPanel.java
+++ b/src/main/java/net/sf/jabref/gui/PreviewPanel.java
@@ -357,7 +357,10 @@ public class PreviewPanel extends JPanel implements SearchQueryHighlightListener
                 }
             });
         }
+    }
 
+    public void close() {
+        basePanel.ifPresent(BasePanel::hideBottomComponent);
     }
 
     class CloseAction extends AbstractAction {
@@ -366,12 +369,11 @@ public class PreviewPanel extends JPanel implements SearchQueryHighlightListener
             super(Localization.lang("Close window"), IconTheme.JabRefIcon.CLOSE.getSmallIcon());
             putValue(Action.SHORT_DESCRIPTION, Localization.lang("Close window"));
         }
+
         @Override
         public void actionPerformed(ActionEvent e) {
-            basePanel.ifPresent(BasePanel::hideBottomComponent);
+            close();
         }
-
-
     }
 
     class CopyPreviewAction extends AbstractAction {

--- a/src/main/java/net/sf/jabref/gui/autocompleter/AutoCompleteSupport.java
+++ b/src/main/java/net/sf/jabref/gui/autocompleter/AutoCompleteSupport.java
@@ -284,4 +284,8 @@ public class AutoCompleteSupport<E> {
         popup.setVisible(visible);
     }
 
+    public boolean isVisible() {
+        return popup.isVisible();
+    }
+
 }

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -1035,6 +1035,17 @@ public class EntryEditor extends JPanel implements EntryContainer {
         }
     }
 
+    public void close() {
+        if (tabbed.getSelectedComponent() == srcPanel) {
+            updateField(source);
+            if (lastSourceAccepted) {
+                panel.entryEditorClosing(EntryEditor.this);
+            }
+        } else {
+            panel.entryEditorClosing(EntryEditor.this);
+        }
+    }
+
     class CloseAction extends AbstractAction {
         public CloseAction() {
             super(Localization.lang("Close window"), IconTheme.JabRefIcon.CLOSE.getSmallIcon());
@@ -1043,14 +1054,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            if (tabbed.getSelectedComponent() == srcPanel) {
-                updateField(source);
-                if (lastSourceAccepted) {
-                    panel.entryEditorClosing(EntryEditor.this);
-                }
-            } else {
-                panel.entryEditorClosing(EntryEditor.this);
-            }
+            close();
         }
     }
 

--- a/src/main/java/net/sf/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/net/sf/jabref/gui/search/GlobalSearchBar.java
@@ -16,6 +16,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.gui.BasePanel;
@@ -26,6 +27,7 @@ import net.sf.jabref.gui.OSXCompatibleToolbar;
 import net.sf.jabref.gui.autocompleter.AutoCompleteSupport;
 import net.sf.jabref.gui.help.HelpAction;
 import net.sf.jabref.gui.keyboard.KeyBinding;
+import net.sf.jabref.gui.maintable.MainTable;
 import net.sf.jabref.gui.maintable.MainTableDataModel;
 import net.sf.jabref.gui.util.component.JTextFieldWithUnfocusedText;
 import net.sf.jabref.logic.autocompleter.AutoCompleter;
@@ -136,7 +138,11 @@ public class GlobalSearchBar extends JPanel {
         searchField.getActionMap().put(endSearch, new AbstractAction() {
             @Override
             public void actionPerformed(ActionEvent event) {
-                endSearch();
+                if (autoCompleteSupport.isVisible()) {
+                    autoCompleteSupport.setVisible(false);
+                } else {
+                    endSearch();
+                }
             }
         });
 
@@ -249,12 +255,14 @@ public class GlobalSearchBar extends JPanel {
         searchModeButton.setToolTipText(searchDisplayMode.getToolTipText());
     }
 
-    private void endSearch() {
+    public void endSearch() {
         BasePanel currentBasePanel = frame.getCurrentBasePanel();
         if (currentBasePanel != null) {
             clearSearch(currentBasePanel);
-            Globals.getFocusListener().setFocused(currentBasePanel.getMainTable());
-            currentBasePanel.getMainTable().requestFocus();
+            MainTable mainTable = frame.getCurrentBasePanel().getMainTable();
+            Globals.getFocusListener().setFocused(mainTable);
+            mainTable.requestFocus();
+            SwingUtilities.invokeLater(() -> mainTable.ensureVisible(mainTable.getSelectedRow()));
         }
     }
 


### PR DESCRIPTION
At request of @koppor.

When hitting `ESC` in the main table and neither preview nor editor is open the search term will be cleared.

Since the action in the main table overshadows the actions in the preview-/editorpanel I have to call the `close()` method manually (same Keybinding).