### PR TITLE
Store LaTeX-free fields in BibEntry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Improve language quality of the German translation of shared database
 
 ### Fixed
+- Fixed [#1993](https://github.com/JabRef/jabref/issues/1993): Various optimizations regarding search performance
 - Fixed [koppor#160](https://github.com/koppor/jabref/issues/160): Tooltips now working in the main table
 - Fixed [#2054](https://github.com/JabRef/jabref/issues/2054): Ignoring a new version now works as expected
 - Fixed selecting an entry out of multiple duplicates

--- a/jabref.install4j
+++ b/jabref.install4j
@@ -750,4 +750,9 @@ return true;</string>
   </mediaSets>
   <buildIds buildAll="true" />
   <buildOptions verbose="false" faster="false" disableSigning="false" disableJreBundling="false" debug="false" />
+  <jvmArguments>
+      <arg>-XX:+UseG1GC</arg>
+      <arg>-XX:+UseStringDeduplication</arg>
+      <arg>-XX:StringTableSize=1000003</arg>
+  </jvmArguments>
 </install4j>

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -53,17 +53,18 @@ public class BibEntry implements Cloneable {
 
     private String type;
     private Map<String, String> fields = new ConcurrentHashMap<>();
-    /*
+
+    /**
      * Map to store the words in every field
      */
     private final Map<String, Set<String>> fieldsAsWords = new HashMap<>();
 
-    /*
-     * Cache that stores latex free versions of fields. Is populated as a cash
+    /**
+     * Cache that stores latex free versions of fields.
      */
     private final Map<String, String> latexFreeFields = new ConcurrentHashMap<>();
 
-    /*
+    /**
      * Used to cleanse field values for internal LaTeX-free storage
      */
     private LatexToUnicode unicodeConverter = new LatexToUnicode();
@@ -76,7 +77,7 @@ public class BibEntry implements Cloneable {
 
     private String commentsBeforeEntry = "";
 
-    /*
+    /**
      * Marks whether the complete serialization, which was read from file, should be used.
      *
      * Is set to false, if parts of the entry change. This causes the entry to be serialized based on the internal state (and not based on the old serialization)

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -59,7 +59,7 @@ public class BibEntry implements Cloneable {
     private final Map<String, Set<String>> fieldsAsWords = new HashMap<>();
 
     /*
-     * Map that stores latex free versions of fields. Is populated as a cash
+     * Cache that stores latex free versions of fields. Is populated as a cash
      */
     private final Map<String, String> latexFreeFields = new ConcurrentHashMap<>();
 
@@ -191,7 +191,6 @@ public class BibEntry implements Cloneable {
 
     /**
      * Sets the cite key AKA citation key AKA BibTeX key.
-     * <p>
      * Note: This is <emph>not</emph> the internal Id of this entry. The internal Id is always present, whereas the BibTeX key might not be present.
      *
      * @param newCiteKey The cite key to set. Must not be null; use {@link #clearCiteKey()} to remove the cite key.

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -201,7 +201,6 @@ public class BibEntry implements Cloneable {
 
     /**
      * Returns the cite key AKA citation key AKA BibTeX key, or null if it is not set.
-     * <p>
      * Note: this is <emph>not</emph> the internal Id of this entry. The internal Id is always present, whereas the BibTeX key might not be present.
      */
     @Deprecated

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -433,7 +433,7 @@ public class BibEntry implements Cloneable {
 
         changed = true;
 
-        fields.put(fieldName, value);
+        fields.put(fieldName, value.intern());
         fieldsAsWords.remove(fieldName);
         invalidateLatexFreeCache(fieldName);
 
@@ -791,7 +791,7 @@ public class BibEntry implements Cloneable {
         } else if (latexFreeFields.containsKey(name)) {
             return Optional.ofNullable(latexFreeFields.get(toLowerCase(name)));
         } else {
-            String latexFreeField = unicodeConverter.format(getField(name).get());
+            String latexFreeField = unicodeConverter.format(getField(name).get()).intern();
             latexFreeFields.put(name, latexFreeField);
             return Optional.of(latexFreeField);
         }

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -433,8 +433,7 @@ public class BibEntry implements Cloneable {
         changed = true;
 
         fields.put(fieldName, value.intern());
-        fieldsAsWords.remove(fieldName);
-        invalidateLatexFreeCache(fieldName);
+        invalidateFieldCache(fieldName);
 
         FieldChange change = new FieldChange(this, fieldName, oldValue, value);
         eventBus.post(new FieldChangedEvent(change, eventSource));
@@ -490,8 +489,7 @@ public class BibEntry implements Cloneable {
         changed = true;
 
         fields.remove(fieldName);
-        fieldsAsWords.remove(fieldName);
-        invalidateLatexFreeCache(fieldName);
+        invalidateFieldCache(fieldName);
 
         FieldChange change = new FieldChange(this, fieldName, oldValue.get(), null);
         eventBus.post(new FieldChangedEvent(change, eventSource));
@@ -780,8 +778,9 @@ public class BibEntry implements Cloneable {
         return clearField(KEY_FIELD);
     }
 
-    private void invalidateLatexFreeCache(String fieldName) {
+    private void invalidateFieldCache(String fieldName) {
         latexFreeFields.remove(fieldName);
+        fieldsAsWords.remove(fieldName);
     }
 
     public Optional<String> getLatexFreeField(String name) {

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -27,6 +27,7 @@ import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.event.EntryEventSource;
 import net.sf.jabref.model.entry.event.FieldChangedEvent;
+import net.sf.jabref.model.strings.LatexToUnicode;
 import net.sf.jabref.model.strings.StringUtil;
 
 import com.google.common.base.Strings;
@@ -56,6 +57,16 @@ public class BibEntry implements Cloneable {
      * Map to store the words in every field
      */
     private final Map<String, Set<String>> fieldsAsWords = new HashMap<>();
+
+    /*
+     * Map that stores latex free versions of fields. Is populated as a cash
+     */
+    private final Map<String, String> latexFreeFields = new ConcurrentHashMap<>();
+
+    /*
+     * Used to cleanse field values for internal LaTeX-free storage
+     */
+    private LatexToUnicode unicodeConverter = new LatexToUnicode();
 
     // Search and grouping status is stored in boolean fields for quick reference:
     private boolean searchHit;
@@ -95,7 +106,7 @@ public class BibEntry implements Cloneable {
     /**
      * Constructs a new BibEntry with the given ID and given type
      *
-     * @param id The ID to be used
+     * @param id   The ID to be used
      * @param type The type to set. May be null or empty. In that case, DEFAULT_TYPE is used.
      */
     public BibEntry(String id, String type) {
@@ -107,7 +118,7 @@ public class BibEntry implements Cloneable {
     }
 
     public Optional<FieldChange> replaceKeywords(KeywordList keywordsToReplace, Optional<Keyword> newValue,
-            Character keywordDelimiter) {
+                                                 Character keywordDelimiter) {
         KeywordList keywordList = getKeywords(keywordDelimiter);
         keywordList.replaceKeywords(keywordsToReplace, newValue);
 
@@ -180,7 +191,7 @@ public class BibEntry implements Cloneable {
 
     /**
      * Sets the cite key AKA citation key AKA BibTeX key.
-     *
+     * <p>
      * Note: This is <emph>not</emph> the internal Id of this entry. The internal Id is always present, whereas the BibTeX key might not be present.
      *
      * @param newCiteKey The cite key to set. Must not be null; use {@link #clearCiteKey()} to remove the cite key.
@@ -191,7 +202,7 @@ public class BibEntry implements Cloneable {
 
     /**
      * Returns the cite key AKA citation key AKA BibTeX key, or null if it is not set.
-     *
+     * <p>
      * Note: this is <emph>not</emph> the internal Id of this entry. The internal Id is always present, whereas the BibTeX key might not be present.
      */
     @Deprecated
@@ -396,8 +407,9 @@ public class BibEntry implements Cloneable {
 
     /**
      * Set a field, and notify listeners about the change.
-     * @param name  The field to set
-     * @param value The value to set
+     *
+     * @param name        The field to set
+     * @param value       The value to set
      * @param eventSource Source the event is sent from
      */
     public Optional<FieldChange> setField(String name, String value, EntryEventSource eventSource) {
@@ -423,6 +435,7 @@ public class BibEntry implements Cloneable {
 
         fields.put(fieldName, value);
         fieldsAsWords.remove(fieldName);
+        invalidateLatexFreeCache(fieldName);
 
         FieldChange change = new FieldChange(this, fieldName, oldValue, value);
         eventBus.post(new FieldChangedEvent(change, eventSource));
@@ -460,7 +473,7 @@ public class BibEntry implements Cloneable {
      * Remove the mapping for the field name, and notify listeners about
      * the change including the {@link EntryEventSource}.
      *
-     * @param name The field to clear.
+     * @param name        The field to clear.
      * @param eventSource the source a new {@link FieldChangedEvent} should be posten from.
      */
     public Optional<FieldChange> clearField(String name, EntryEventSource eventSource) {
@@ -479,6 +492,8 @@ public class BibEntry implements Cloneable {
 
         fields.remove(fieldName);
         fieldsAsWords.remove(fieldName);
+        invalidateLatexFreeCache(fieldName);
+
         FieldChange change = new FieldChange(this, fieldName, oldValue.get(), null);
         eventBus.post(new FieldChangedEvent(change, eventSource));
         return Optional.of(change);
@@ -570,7 +585,7 @@ public class BibEntry implements Cloneable {
      * Author1, Author2: Title (Year)
      */
     public String getAuthorTitleYear(int maxCharacters) {
-        String[] s = new String[] {getField(FieldName.AUTHOR).orElse("N/A"), getField(FieldName.TITLE).orElse("N/A"),
+        String[] s = new String[]{getField(FieldName.AUTHOR).orElse("N/A"), getField(FieldName.TITLE).orElse("N/A"),
                 getField(FieldName.YEAR).orElse("N/A")};
 
         String text = s[0] + ": \"" + s[1] + "\" (" + s[2] + ')';
@@ -764,5 +779,21 @@ public class BibEntry implements Cloneable {
 
     public Optional<FieldChange> clearCiteKey() {
         return clearField(KEY_FIELD);
+    }
+
+    private void invalidateLatexFreeCache(String fieldName) {
+        latexFreeFields.remove(fieldName);
+    }
+
+    public Optional<String> getLatexFreeField(String name) {
+        if (!hasField(name)) {
+            return Optional.empty();
+        } else if (latexFreeFields.containsKey(name)) {
+            return Optional.ofNullable(latexFreeFields.get(toLowerCase(name)));
+        } else {
+            String latexFreeField = unicodeConverter.format(getField(name).get());
+            latexFreeFields.put(name, latexFreeField);
+            return Optional.of(latexFreeField);
+        }
     }
 }

--- a/src/main/java/net/sf/jabref/model/search/rules/ContainBasedSearchRule.java
+++ b/src/main/java/net/sf/jabref/model/search/rules/ContainBasedSearchRule.java
@@ -38,8 +38,8 @@ public class ContainBasedSearchRule implements SearchRule {
 
         List<String> unmatchedWords = new SentenceAnalyzer(searchString).getWords();
 
-        for (String fieldContent : bibEntry.getFieldValues()) {
-            String formattedFieldContent = LATEX_TO_UNICODE_FORMATTER.format(fieldContent);
+        for (String fieldKey : bibEntry.getFieldNames()) {
+            String formattedFieldContent = bibEntry.getLatexFreeField(fieldKey).get();
             if (!caseSensitive) {
                 formattedFieldContent = formattedFieldContent.toLowerCase();
             }

--- a/src/main/java/net/sf/jabref/model/search/rules/GrammarBasedSearchRule.java
+++ b/src/main/java/net/sf/jabref/model/search/rules/GrammarBasedSearchRule.java
@@ -162,7 +162,7 @@ public class GrammarBasedSearchRule implements SearchRule {
             }
 
             for (String field : fieldsKeys) {
-                Optional<String> fieldValue = entry.getField(field);
+                Optional<String> fieldValue = entry.getLatexFreeField(field);
                 if (fieldValue.isPresent()) {
                     if (matchFieldValue(fieldValue.get())) {
                         return true;

--- a/src/main/java/net/sf/jabref/model/search/rules/RegexBasedSearchRule.java
+++ b/src/main/java/net/sf/jabref/model/search/rules/RegexBasedSearchRule.java
@@ -53,8 +53,7 @@ public class RegexBasedSearchRule implements SearchRule {
         for (String field : bibEntry.getFieldNames()) {
             Optional<String> fieldOptional = bibEntry.getField(field);
             if (fieldOptional.isPresent()) {
-                String fieldContent = RegexBasedSearchRule.LATEX_TO_UNICODE_FORMATTER.format(fieldOptional.get());
-                String fieldContentNoBrackets = RegexBasedSearchRule.LATEX_TO_UNICODE_FORMATTER.format(fieldContent);
+                String fieldContentNoBrackets = bibEntry.getLatexFreeField(field).get();
                 Matcher m = pattern.matcher(fieldContentNoBrackets);
                 if (m.find()) {
                     return true;

--- a/src/main/java/net/sf/jabref/model/strings/LatexToUnicode.java
+++ b/src/main/java/net/sf/jabref/model/strings/LatexToUnicode.java
@@ -8,9 +8,15 @@ public class LatexToUnicode {
     private static final Map<String, String> CHARS = HTMLUnicodeConversionMaps.LATEX_UNICODE_CONVERSION_MAP;
     private static final Map<String, String> ACCENTS = HTMLUnicodeConversionMaps.UNICODE_ESCAPED_ACCENTS;
 
-    private Pattern AMP_LATEX = Pattern.compile("&|\\\\&");
-    private Pattern P_LATEX = Pattern.compile("[\\n]{1,}");
-    private Pattern DOLLARS_LATEX = Pattern.compile("\\$([^\\$]*)\\$");
+    private static final Pattern AMP_LATEX = Pattern.compile("&|\\\\&");
+    private static final Pattern P_LATEX = Pattern.compile("[\\n]{1,}");
+    private static final Pattern DOLLAR_LATEX = Pattern.compile("\\\\\\$");
+    private static final Pattern DOLLARS_LATEX = Pattern.compile("\\$([^\\$]*)\\$");
+
+    private static final Pattern AMP = Pattern.compile("\\&amp;");
+    private static final Pattern P = Pattern.compile("<p>");
+    private static final Pattern DOLLAR = Pattern.compile("\\&dollar;");
+    private static final Pattern TILDE = Pattern.compile("~");
 
     public String format(String inField) {
         if (inField.isEmpty()) {
@@ -20,7 +26,7 @@ public class LatexToUnicode {
         // TODO: document what does this do
         String field = AMP_LATEX.matcher(inField).replaceAll("&amp;");
         field = P_LATEX.matcher(field).replaceAll("<p>");
-        field = field.replace("\\$", "&dollar;"); // Replace \$ with &dollar;
+        field = DOLLAR_LATEX.matcher(field).replaceAll("&dollar;");
         field = DOLLARS_LATEX.matcher(field).replaceAll("\\{$1\\}");
 
         StringBuilder sb = new StringBuilder();
@@ -193,8 +199,11 @@ public class LatexToUnicode {
             }
         }
 
-        return sb.toString().replace("&amp;", "&").replace("<p>", "\n").replace("&dollar;", "$").replace("~",
-                "\u00A0");
+        String result = AMP.matcher(sb.toString()).replaceAll("&");
+        result = P.matcher(result).replaceAll("\n");
+        result = DOLLAR.matcher(result).replaceAll("\\$");
+        result = TILDE.matcher(result).replaceAll("\u00A0");
+        return result;
 
     }
 }

--- a/src/main/java/net/sf/jabref/model/strings/LatexToUnicode.java
+++ b/src/main/java/net/sf/jabref/model/strings/LatexToUnicode.java
@@ -1,12 +1,16 @@
 package net.sf.jabref.model.strings;
 
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public class LatexToUnicode {
 
     private static final Map<String, String> CHARS = HTMLUnicodeConversionMaps.LATEX_UNICODE_CONVERSION_MAP;
     private static final Map<String, String> ACCENTS = HTMLUnicodeConversionMaps.UNICODE_ESCAPED_ACCENTS;
 
+    private Pattern AMP_LATEX = Pattern.compile("&|\\\\&");
+    private Pattern P_LATEX = Pattern.compile("[\\n]{1,}");
+    private Pattern DOLLARS_LATEX = Pattern.compile("\\$([^\\$]*)\\$");
 
     public String format(String inField) {
         if (inField.isEmpty()) {
@@ -14,8 +18,10 @@ public class LatexToUnicode {
         }
         int i;
         // TODO: document what does this do
-        String field = inField.replaceAll("&|\\\\&", "&amp;").replaceAll("[\\n]{1,}", "<p>").replace("\\$", "&dollar;") // Replace \$ with &dollar;
-                .replaceAll("\\$([^\\$]*)\\$", "\\{$1\\}");
+        String field = AMP_LATEX.matcher(inField).replaceAll("&amp;");
+        field = P_LATEX.matcher(field).replaceAll("<p>");
+        field = field.replace("\\$", "&dollar;"); // Replace \$ with &dollar;
+        field = DOLLARS_LATEX.matcher(field).replaceAll("\\{$1\\}");
 
         StringBuilder sb = new StringBuilder();
         StringBuilder currentCommand = null;


### PR DESCRIPTION
Based on the discussion in #1993 and the work of @bartsch-dev in #2091, this PR aims to improve the speed of search by storing LaTeX-free versions of field values in a cache. It aims at a balance between better performance and an acceptable memory footprint. Basically, all ideas from #1993 are implemented: a cached store of LaTeX-free fields which is computed on demand, String internalization, and regex performance improvements in `LatexToUnicode`.

Here are measurements with the new branch:
```
Benchmark                             Mode  Cnt         Score        Error  Unit
Benchmarks.latexToUnicodeConversion  thrpt   20    119823.078   2063.425  ops/s
Benchmarks.parallelSearch            thrpt   20       735.890    113.685  ops/s
Benchmarks.search                    thrpt   20       397.807     28.557  ops/s
```
The memory footprint of a database with 6500 entries is ~ 912 MB on my machine

And on current master:
```
Benchmark                             Mode  Cnt         Score        Error  Unit
Benchmarks.latexToUnicodeConversion  thrpt   20     94367.718   2570.784  ops/s
Benchmarks.parallelSearch            thrpt   20        58.204       3.285  ops/s
Benchmarks.search                    thrpt   20        30.531       0.952  ops/s
```
The memory footprint of the same 6500 entry database is ~ 888 MB.

All in all, this looks like a hefty performance improvement at little memory cost.

- [x] Change in CHANGELOG.md described
- [x] Manually tested changed features in running JabRef

