### PR TITLE
Change title/tooltip of source panel in biblatex mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ## [Unreleased]
 
 ### Changed
+- Source tab in the entry editor displays "BibLaTeX Source" when using biblatex mode
 - Add session restoring functionality for shared database. Related to [#1703](https://github.com/JabRef/jabref/issues/1703)
 - Implementation of LiveUpdate for PostgreSQL & Oracle systems. Related to [#970](https://github.com/JabRef/jabref/issues/970).
 - [koppor#31](https://github.com/koppor/jabref/issues/31): Number column in the main table is always Left aligned

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -325,16 +325,19 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
     private void addSourceTab() {
         boolean isBibtexMode = panel.getBibDatabaseContext().getMode().equals(BibDatabaseMode.BIBTEX);
+        String panelName = "";
+        String toolTip = "";
 
         if(isBibtexMode) {
-            srcPanel.setName(Localization.lang("BibTeX source"));
-            tabbed.addTab(Localization.lang("BibTeX source"), IconTheme.JabRefIcon.SOURCE.getSmallIcon(), srcPanel,
-                    Localization.lang("Show/edit BibTeX source"));
+            panelName = Localization.lang("%0 source", "BibTeX");
+            toolTip = Localization.lang("Show/edit %0 source", "BibTeX");
         } else {
-            tabbed.addTab(Localization.lang("BibLaTeX source"), IconTheme.JabRefIcon.SOURCE.getSmallIcon(), srcPanel,
-                    Localization.lang("Show/edit BibLaTeX source"));
+            panelName = Localization.lang("%0 source", "BibLaTeX");
+            toolTip = Localization.lang("Show/edit %0 source", "BibLaTeX");
         }
 
+        srcPanel.setName(panelName);
+        tabbed.addTab(panelName, IconTheme.JabRefIcon.SOURCE.getSmallIcon(), srcPanel, toolTip);
         tabs.add(srcPanel);
         sourceIndex = tabs.size() - 1; // Set the sourceIndex variable.
         srcPanel.setFocusCycleRoot(true);

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -324,9 +324,17 @@ public class EntryEditor extends JPanel implements EntryContainer {
     }
 
     private void addSourceTab() {
-        srcPanel.setName(Localization.lang("BibTeX source"));
-        tabbed.addTab(Localization.lang("BibTeX source"), IconTheme.JabRefIcon.SOURCE.getSmallIcon(), srcPanel,
-                Localization.lang("Show/edit BibTeX source"));
+        boolean isBibtexMode = panel.getBibDatabaseContext().getMode().equals(BibDatabaseMode.BIBTEX);
+
+        if(isBibtexMode) {
+            srcPanel.setName(Localization.lang("BibTeX source"));
+            tabbed.addTab(Localization.lang("BibTeX source"), IconTheme.JabRefIcon.SOURCE.getSmallIcon(), srcPanel,
+                    Localization.lang("Show/edit BibTeX source"));
+        } else {
+            tabbed.addTab(Localization.lang("BibLaTeX source"), IconTheme.JabRefIcon.SOURCE.getSmallIcon(), srcPanel,
+                    Localization.lang("Show/edit BibLaTeX source"));
+        }
+
         tabs.add(srcPanel);
         sourceIndex = tabs.size() - 1; // Set the sourceIndex variable.
         srcPanel.setFocusCycleRoot(true);

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -324,18 +324,8 @@ public class EntryEditor extends JPanel implements EntryContainer {
     }
 
     private void addSourceTab() {
-        boolean isBibtexMode = panel.getBibDatabaseContext().getMode().equals(BibDatabaseMode.BIBTEX);
-        String panelName = "";
-        String toolTip = "";
-
-        if(isBibtexMode) {
-            panelName = Localization.lang("%0 source", "BibTeX");
-            toolTip = Localization.lang("Show/edit %0 source", "BibTeX");
-        } else {
-            panelName = Localization.lang("%0 source", "BibLaTeX");
-            toolTip = Localization.lang("Show/edit %0 source", "BibLaTeX");
-        }
-
+        String panelName = Localization.lang("%0 source", panel.getBibDatabaseContext().getMode().getFormattedName());
+        String toolTip = Localization.lang("Show/edit %0 source", panel.getBibDatabaseContext().getMode().getFormattedName());
         srcPanel.setName(panelName);
         tabbed.addTab(panelName, IconTheme.JabRefIcon.SOURCE.getSmallIcon(), srcPanel, toolTip);
         tabs.add(srcPanel);

--- a/src/main/java/net/sf/jabref/gui/plaintextimport/TextInputDialog.java
+++ b/src/main/java/net/sf/jabref/gui/plaintextimport/TextInputDialog.java
@@ -90,13 +90,13 @@ import org.apache.commons.logging.LogFactory;
 
 /**
  * import from plain text => simple mark/copy/paste into bibtex entry
- *
+ * <p>
  * TODO
- *   - change colors and fonts
- *   - delete selected text
- *   - make textarea editable
- *   - create several bibtex entries in dialog
- *   - if the dialog works with an existing entry (right click menu item), the cancel option doesn't work well
+ * - change colors and fonts
+ * - delete selected text
+ * - make textarea editable
+ * - create several bibtex entries in dialog
+ * - if the dialog works with an existing entry (right click menu item), the cancel option doesn't work well
  */
 public class TextInputDialog extends JDialog {
 
@@ -163,7 +163,7 @@ public class TextInputDialog extends JDialog {
         JTabbedPane tabbed = new JTabbedPane();
 
         tabbed.add(rawPanel, Localization.lang("Raw source"));
-        tabbed.add(sourcePanel, Localization.lang("BibTeX source"));
+        tabbed.add(sourcePanel, Localization.lang("%0 source", frame.getCurrentBasePanel().getBibDatabaseContext().getMode().getFormattedName()));
 
         // Panel Layout
         panel1.setLayout(new BorderLayout());
@@ -241,7 +241,7 @@ public class TextInputDialog extends JDialog {
 
         JLabel desc = new JLabel("<html><h3>" + Localization.lang("Plain text import") + "</h3><p>"
                 + Localization.lang("This is a simple copy and paste dialog. First load or paste some text into "
-                        + "the text input area.<br>After that, you can mark text and assign it to a BibTeX field.")
+                + "the text input area.<br>After that, you can mark text and assign it to a BibTeX field.")
                 + "</p></html>");
         desc.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 
@@ -451,6 +451,7 @@ public class TextInputDialog extends JDialog {
 
     /**
      * tries to parse the pasted reference with freecite
+     *
      * @return true if successful, false otherwise
      */
     private boolean parseWithFreeCiteAndAddEntries() {
@@ -634,9 +635,9 @@ public class TextInputDialog extends JDialog {
          */
         @Override
         public Component getListCellRendererComponent(JList<?> list, Object value, // value to display
-                int index, // cell index
-                boolean iss, // is the cell selected
-                boolean chf) // the list and the cell have the focus
+                                                      int index, // cell index
+                                                      boolean iss, // is the cell selected
+                                                      boolean chf) // the list and the cell have the focus
         {
             /* The DefaultListCellRenderer class will take care of
              * the JLabels text property, it's foreground and background

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -154,6 +154,7 @@ Backup_old_file_when_saving=Lav_sikkerhedskopi_ved_gemning
 BibTeX_key_is_unique.=BibTeX-nøglen_er_unik
 
 BibTeX_source=BibTeX-kilde
+BibLaTeX_source=
 
 Broken_link=Ugyldigt_link
 
@@ -1150,6 +1151,7 @@ Settings=Indstillinger
 Shortcut=Genvej
 
 Show/edit_BibTeX_source=Vis/rediger_BibTeX-kilde
+Show/edit_BibLaTeX_source=
 
 Show_'Firstname_Lastname'=Vis_'Fornavn_Efternavn'
 

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -153,8 +153,7 @@ Backup_old_file_when_saving=Lav_sikkerhedskopi_ved_gemning
 
 BibTeX_key_is_unique.=BibTeX-nøglen_er_unik
 
-BibTeX_source=BibTeX-kilde
-BibLaTeX_source=
+%0_source=%0-kilde
 
 Broken_link=Ugyldigt_link
 
@@ -1150,8 +1149,7 @@ Settings=Indstillinger
 
 Shortcut=Genvej
 
-Show/edit_BibTeX_source=Vis/rediger_BibTeX-kilde
-Show/edit_BibLaTeX_source=
+Show/edit_%0_source=Vis/rediger_%0-kilde
 
 Show_'Firstname_Lastname'=Vis_'Fornavn_Efternavn'
 

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -154,6 +154,7 @@ Backup_old_file_when_saving=Beim_Speichern_ein_Backup_der_alten_Datei_anlegen
 BibTeX_key_is_unique.=Der_BibTeX-Key_ist_eindeutig.
 
 BibTeX_source=BibTeX-Quelltext
+BibLaTeX_source=BibLaTeX-Quelltext
 
 Broken_link=Ungültiger_Link
 
@@ -1149,7 +1150,8 @@ Settings=Einstellungen
 
 Shortcut=Tastenkürzel
 
-Show/edit_BibTeX_source=BibTeX-Quelltextpanel_anzeigen
+Show/edit_BibTeX_source=BibTeX-Quelltextpanel_anzeigen/editieren
+Show/edit_BibLaTeX_source=BibLaTeX-Quelltextpanel_anzeigen/editieren
 
 Show_'Firstname_Lastname'='Vorname_Nachname'_anzeigen
 

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -153,8 +153,7 @@ Backup_old_file_when_saving=Beim_Speichern_ein_Backup_der_alten_Datei_anlegen
 
 BibTeX_key_is_unique.=Der_BibTeX-Key_ist_eindeutig.
 
-BibTeX_source=BibTeX-Quelltext
-BibLaTeX_source=BibLaTeX-Quelltext
+%0_source=%0-Quelltext
 
 Broken_link=Ungültiger_Link
 
@@ -1150,8 +1149,7 @@ Settings=Einstellungen
 
 Shortcut=Tastenkürzel
 
-Show/edit_BibTeX_source=BibTeX-Quelltextpanel_anzeigen/editieren
-Show/edit_BibLaTeX_source=BibLaTeX-Quelltextpanel_anzeigen/editieren
+Show/edit_%0_source=%0-Quelltext_anzeigen/editieren
 
 Show_'Firstname_Lastname'='Vorname_Nachname'_anzeigen
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -154,6 +154,7 @@ Backup_old_file_when_saving=Backup_old_file_when_saving
 BibTeX_key_is_unique.=BibTeX_key_is_unique.
 
 BibTeX_source=BibTeX_source
+BibLaTeX_source=BibLaTeX_source
 
 Broken_link=Broken_link
 
@@ -1150,6 +1151,7 @@ Settings=Settings
 Shortcut=Shortcut
 
 Show/edit_BibTeX_source=Show/edit_BibTeX_source
+Show/edit_BibLaTeX_source=Show/edit_BibLaTeX_source
 
 Show_'Firstname_Lastname'=Show_'Firstname_Lastname'
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -153,8 +153,7 @@ Backup_old_file_when_saving=Backup_old_file_when_saving
 
 BibTeX_key_is_unique.=BibTeX_key_is_unique.
 
-BibTeX_source=BibTeX_source
-BibLaTeX_source=BibLaTeX_source
+%0_source=%0_source
 
 Broken_link=Broken_link
 
@@ -1150,8 +1149,7 @@ Settings=Settings
 
 Shortcut=Shortcut
 
-Show/edit_BibTeX_source=Show/edit_BibTeX_source
-Show/edit_BibLaTeX_source=Show/edit_BibLaTeX_source
+Show/edit_%0_source=Show/edit_%0_source
 
 Show_'Firstname_Lastname'=Show_'Firstname_Lastname'
 

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -154,6 +154,7 @@ Backup_old_file_when_saving=Hacer_copia_de_respaldo_del_archivo_antiguo_al_graba
 BibTeX_key_is_unique.=La_clave_BibTeX_es_única
 
 BibTeX_source=Origen_BibTeX
+BibLaTeX_source=
 
 Broken_link=Enlace_roto
 
@@ -1150,6 +1151,7 @@ Settings=Ajustes
 Shortcut=Atajo
 
 Show/edit_BibTeX_source=Mostrar/editar_fuente_BibTeX
+Show/edit_BibLaTeX_source=
 
 Show_'Firstname_Lastname'=Mostrar_'Nombre_Apellido'
 

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -153,8 +153,7 @@ Backup_old_file_when_saving=Hacer_copia_de_respaldo_del_archivo_antiguo_al_graba
 
 BibTeX_key_is_unique.=La_clave_BibTeX_es_única
 
-BibTeX_source=Origen_BibTeX
-BibLaTeX_source=
+%0_source=Origen_%0
 
 Broken_link=Enlace_roto
 
@@ -1150,8 +1149,7 @@ Settings=Ajustes
 
 Shortcut=Atajo
 
-Show/edit_BibTeX_source=Mostrar/editar_fuente_BibTeX
-Show/edit_BibLaTeX_source=
+Show/edit_%0_source=Mostrar/editar_fuente_%0
 
 Show_'Firstname_Lastname'=Mostrar_'Nombre_Apellido'
 

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -153,8 +153,7 @@ Backup_old_file_when_saving=
 
 BibTeX_key_is_unique.=
 
-BibTeX_source=
-BibLaTeX_source=
+%0_source=Source_%0
 
 Broken_link=
 
@@ -1150,8 +1149,7 @@ Settings=
 
 Shortcut=
 
-Show/edit_BibTeX_source=
-Show/edit_BibLaTeX_source=
+Show/edit_%0_source=Montrer/éditer_le_source_BibTeX
 
 Show_'Firstname_Lastname'=
 

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -154,6 +154,7 @@ Backup_old_file_when_saving=
 BibTeX_key_is_unique.=
 
 BibTeX_source=
+BibLaTeX_source=
 
 Broken_link=
 
@@ -1150,6 +1151,7 @@ Settings=
 Shortcut=
 
 Show/edit_BibTeX_source=
+Show/edit_BibLaTeX_source=
 
 Show_'Firstname_Lastname'=
 

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -154,6 +154,7 @@ Backup_old_file_when_saving=Créer_une_copie_de_sauvegarde_lors_de_l'enregistrem
 BibTeX_key_is_unique.=La_clef_BibTeX_est_unique.
 
 BibTeX_source=Source_BibTeX
+BibLaTeX_source=
 
 Broken_link=Lien_invalide
 
@@ -1150,6 +1151,7 @@ Settings=Paramètres
 Shortcut=Raccourci
 
 Show/edit_BibTeX_source=Montrer/éditer_le_source_BibTeX
+Show/edit_BibLaTeX_source=
 
 Show_'Firstname_Lastname'=Ordre_d'affichage_'Prénom_Nom'
 

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -153,8 +153,7 @@ Backup_old_file_when_saving=Créer_une_copie_de_sauvegarde_lors_de_l'enregistrem
 
 BibTeX_key_is_unique.=La_clef_BibTeX_est_unique.
 
-BibTeX_source=Source_BibTeX
-BibLaTeX_source=
+%0_source=
 
 Broken_link=Lien_invalide
 
@@ -1150,8 +1149,7 @@ Settings=Paramètres
 
 Shortcut=Raccourci
 
-Show/edit_BibTeX_source=Montrer/éditer_le_source_BibTeX
-Show/edit_BibLaTeX_source=
+Show/edit_%0_source=
 
 Show_'Firstname_Lastname'=Ordre_d'affichage_'Prénom_Nom'
 

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -153,8 +153,7 @@ Backup_old_file_when_saving=Cadangan_berkas_lama_ketika_menyimpan
 
 BibTeX_key_is_unique.=Kunci_BibTeX_tidak_boleh_sama.
 
-BibTeX_source=Sumber_BibTeX
-BibLaTeX_source=
+%0_source=
 
 Broken_link=Tautan_rusak
 
@@ -1150,8 +1149,7 @@ Settings=Pengaturan
 
 Shortcut=Pintasan
 
-Show/edit_BibTeX_source=Tampil/Sunting_sumber_BibTeX
-Show/edit_BibLaTeX_source=
+Show/edit_%0_source=
 
 Show_'Firstname_Lastname'=Tampil_'Depan_Belakang'
 

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -154,6 +154,7 @@ Backup_old_file_when_saving=Cadangan_berkas_lama_ketika_menyimpan
 BibTeX_key_is_unique.=Kunci_BibTeX_tidak_boleh_sama.
 
 BibTeX_source=Sumber_BibTeX
+BibLaTeX_source=
 
 Broken_link=Tautan_rusak
 
@@ -1150,6 +1151,7 @@ Settings=Pengaturan
 Shortcut=Pintasan
 
 Show/edit_BibTeX_source=Tampil/Sunting_sumber_BibTeX
+Show/edit_BibLaTeX_source=
 
 Show_'Firstname_Lastname'=Tampil_'Depan_Belakang'
 

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -154,6 +154,7 @@ Backup_old_file_when_saving=Fai_una_copia_di_backup_del_vecchio_file_quando_vien
 BibTeX_key_is_unique.=La_chiave_BibTeX_è_unica.
 
 BibTeX_source=Sorgente_BibTeX
+BibLaTeX_source=
 
 Broken_link=Collegamento_interrotto
 
@@ -1150,6 +1151,7 @@ Settings=Parametri
 Shortcut=Scorciatoia
 
 Show/edit_BibTeX_source=Mostra/Modifica_codice_sorgente_BibTeX
+Show/edit_BibLaTeX_source=
 
 Show_'Firstname_Lastname'=Mostra_'Nome_Cognome'
 

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -153,8 +153,7 @@ Backup_old_file_when_saving=Fai_una_copia_di_backup_del_vecchio_file_quando_vien
 
 BibTeX_key_is_unique.=La_chiave_BibTeX_è_unica.
 
-BibTeX_source=Sorgente_BibTeX
-BibLaTeX_source=
+%0_source=Sorgente_%0
 
 Broken_link=Collegamento_interrotto
 
@@ -1150,8 +1149,7 @@ Settings=Parametri
 
 Shortcut=Scorciatoia
 
-Show/edit_BibTeX_source=Mostra/Modifica_codice_sorgente_BibTeX
-Show/edit_BibLaTeX_source=
+Show/edit_%0_source=Mostra/Modifica_codice_sorgente_%0
 
 Show_'Firstname_Lastname'=Mostra_'Nome_Cognome'
 

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -153,8 +153,7 @@ Backup_old_file_when_saving=保存時に旧ファイルをバックアップ
 
 BibTeX_key_is_unique.=BibTeX鍵は一意です。
 
-BibTeX_source=BibTeXソース
-BibLaTeX_source=
+%0_source=%0ソース
 
 Broken_link=壊れたリンク
 
@@ -1150,8 +1149,7 @@ Settings=設定
 
 Shortcut=捷径(ショートカット)
 
-Show/edit_BibTeX_source=BibTeXソースを表示・編集
-Show/edit_BibLaTeX_source=
+Show/edit_%0_source=%0ソースを表示・編集
 
 Show_'Firstname_Lastname'=「名_姓」と表示
 

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -154,6 +154,7 @@ Backup_old_file_when_saving=保存時に旧ファイルをバックアップ
 BibTeX_key_is_unique.=BibTeX鍵は一意です。
 
 BibTeX_source=BibTeXソース
+BibLaTeX_source=
 
 Broken_link=壊れたリンク
 
@@ -1150,6 +1151,7 @@ Settings=設定
 Shortcut=捷径(ショートカット)
 
 Show/edit_BibTeX_source=BibTeXソースを表示・編集
+Show/edit_BibLaTeX_source=
 
 Show_'Firstname_Lastname'=「名_姓」と表示
 

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -154,6 +154,7 @@ Backup_old_file_when_saving=Maak_reservekopie_van_oud_bestand_bij_het_opslaan
 BibTeX_key_is_unique.=BibTeX-sleutel_is_uniek
 
 BibTeX_source=BibTeX-broncode
+BibLaTeX_source=
 
 Broken_link=
 
@@ -1150,6 +1151,7 @@ Settings=Instellingen
 Shortcut=Snelkoppeling
 
 Show/edit_BibTeX_source=Toon/bewerk_BibTeX-broncode
+Show/edit_BibLaTeX_source=
 
 Show_'Firstname_Lastname'=Toon_'Voornaam_Familienaam'
 

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -153,8 +153,7 @@ Backup_old_file_when_saving=Maak_reservekopie_van_oud_bestand_bij_het_opslaan
 
 BibTeX_key_is_unique.=BibTeX-sleutel_is_uniek
 
-BibTeX_source=BibTeX-broncode
-BibLaTeX_source=
+%0_source=%0-broncode
 
 Broken_link=
 
@@ -1150,8 +1149,7 @@ Settings=Instellingen
 
 Shortcut=Snelkoppeling
 
-Show/edit_BibTeX_source=Toon/bewerk_BibTeX-broncode
-Show/edit_BibLaTeX_source=
+Show/edit_%0_source=Toon/bewerk_%0-broncode
 
 Show_'Firstname_Lastname'=Toon_'Voornaam_Familienaam'
 

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -154,6 +154,7 @@ Backup_old_file_when_saving=Lag_sikkerhetskopi_ved_lagring
 BibTeX_key_is_unique.=BibTeX-n\u00f8kkelen_er_unik
 
 BibTeX_source=BibTeX-kilde
+BibLaTeX_source=
 
 Broken_link=Ugyldig_link
 
@@ -1150,6 +1151,7 @@ Settings=Innstillinger
 Shortcut=Snarvei
 
 Show/edit_BibTeX_source=Vis/rediger_BibTeX-kilde
+Show/edit_BibLaTeX_source=
 
 Show_'Firstname_Lastname'=Vis_'Fornavn_Etternavn'
 

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -153,8 +153,7 @@ Backup_old_file_when_saving=Lag_sikkerhetskopi_ved_lagring
 
 BibTeX_key_is_unique.=BibTeX-n\u00f8kkelen_er_unik
 
-BibTeX_source=BibTeX-kilde
-BibLaTeX_source=
+%0_source=%0-kilde
 
 Broken_link=Ugyldig_link
 
@@ -1150,8 +1149,7 @@ Settings=Innstillinger
 
 Shortcut=Snarvei
 
-Show/edit_BibTeX_source=Vis/rediger_BibTeX-kilde
-Show/edit_BibLaTeX_source=
+Show/edit_%0_source=Vis/rediger_%0-kilde
 
 Show_'Firstname_Lastname'=Vis_'Fornavn_Etternavn'
 

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -153,8 +153,7 @@ Backup_old_file_when_saving=Criar_uma_cópia_de_segurança_do_arquivo_antigo_qua
 
 BibTeX_key_is_unique.=A_chave_BibTeX_é_única.
 
-BibTeX_source=Fonte_BibTeX
-BibLaTeX_source=
+%0_source=Fonte_%0
 
 Broken_link=Link_quebrado
 
@@ -1150,8 +1149,7 @@ Settings=Configurações
 
 Shortcut=Atalho
 
-Show/edit_BibTeX_source=Exibir/editar_fonte_BibTeX
-Show/edit_BibLaTeX_source=
+Show/edit_%0_source=Exibir/editar_fonte_%0
 
 Show_'Firstname_Lastname'=Exibir_'Nome,_Sobrenome'
 

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -154,6 +154,7 @@ Backup_old_file_when_saving=Criar_uma_cópia_de_segurança_do_arquivo_antigo_qua
 BibTeX_key_is_unique.=A_chave_BibTeX_é_única.
 
 BibTeX_source=Fonte_BibTeX
+BibLaTeX_source=
 
 Broken_link=Link_quebrado
 
@@ -1150,6 +1151,7 @@ Settings=Configurações
 Shortcut=Atalho
 
 Show/edit_BibTeX_source=Exibir/editar_fonte_BibTeX
+Show/edit_BibLaTeX_source=
 
 Show_'Firstname_Lastname'=Exibir_'Nome,_Sobrenome'
 

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -153,8 +153,7 @@ Backup_old_file_when_saving=Создание_резервной_копии_ст�
 
 BibTeX_key_is_unique.=Ключ_BibTeX_является_уникальным.
 
-BibTeX_source=Источник_BibTeX
-BibLaTeX_source=
+%0_source=Источник_%0
 
 Broken_link=Ссылка_с_ошибкой
 
@@ -1150,8 +1149,7 @@ Settings=Параметры
 
 Shortcut=Ярлык
 
-Show/edit_BibTeX_source=Показать/изменить_источник_BibTeX
-Show/edit_BibLaTeX_source=
+Show/edit_%0_source=Показать/изменить_источник_%0
 
 Show_'Firstname_Lastname'=Порядок_вывода_'Имя_Фамилия'
 

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -154,6 +154,7 @@ Backup_old_file_when_saving=Создание_резервной_копии_ст�
 BibTeX_key_is_unique.=Ключ_BibTeX_является_уникальным.
 
 BibTeX_source=Источник_BibTeX
+BibLaTeX_source=
 
 Broken_link=Ссылка_с_ошибкой
 
@@ -1150,6 +1151,7 @@ Settings=Параметры
 Shortcut=Ярлык
 
 Show/edit_BibTeX_source=Показать/изменить_источник_BibTeX
+Show/edit_BibLaTeX_source=
 
 Show_'Firstname_Lastname'=Порядок_вывода_'Имя_Фамилия'
 

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -154,6 +154,7 @@ Backup_old_file_when_saving=Skapa_en_säkerhetskopia_av_den_gamla_filen_vid_spar
 BibTeX_key_is_unique.=BibTeX-nyckeln_är_unik.
 
 BibTeX_source=BibTeX-källkod
+BibLaTeX_source=
 
 Broken_link=Trasig_länk
 
@@ -1150,6 +1151,7 @@ Settings=Alternativ
 Shortcut=Genväg
 
 Show/edit_BibTeX_source=Visa/ändra_BibTeX-källkod
+Show/edit_BibLaTeX_source=
 
 Show_'Firstname_Lastname'=Visa_som_'Förnamn_Efternamn'
 

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -153,8 +153,7 @@ Backup_old_file_when_saving=Skapa_en_säkerhetskopia_av_den_gamla_filen_vid_spar
 
 BibTeX_key_is_unique.=BibTeX-nyckeln_är_unik.
 
-BibTeX_source=BibTeX-källkod
-BibLaTeX_source=
+%0_source=%0_källkod
 
 Broken_link=Trasig_länk
 
@@ -1150,8 +1149,7 @@ Settings=Alternativ
 
 Shortcut=Genväg
 
-Show/edit_BibTeX_source=Visa/ändra_BibTeX-källkod
-Show/edit_BibLaTeX_source=
+Show/edit_%0_source=Visa/Ändra_%0-källkod
 
 Show_'Firstname_Lastname'=Visa_som_'Förnamn_Efternamn'
 

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -154,6 +154,7 @@ Backup_old_file_when_saving=Kaydederken_eski_dosyayı_yedekle
 BibTeX_key_is_unique.=BibTeX_anahtarı_benzersizdir.
 
 BibTeX_source=BibTeX_kaynağı
+BibLaTeX_source=
 
 Broken_link=Bozuk_link
 
@@ -1150,6 +1151,7 @@ Settings=Ayarlar
 Shortcut=Kısayol
 
 Show/edit_BibTeX_source=BibTeX_kaynağın_göster/düzenle
+Show/edit_BibLaTeX_source=
 
 Show_'Firstname_Lastname'='Ad_Soyad'_göster
 

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -153,8 +153,7 @@ Backup_old_file_when_saving=Kaydederken_eski_dosyayı_yedekle
 
 BibTeX_key_is_unique.=BibTeX_anahtarı_benzersizdir.
 
-BibTeX_source=BibTeX_kaynağı
-BibLaTeX_source=
+%0_source=%0_kaynağı
 
 Broken_link=Bozuk_link
 
@@ -1150,8 +1149,7 @@ Settings=Ayarlar
 
 Shortcut=Kısayol
 
-Show/edit_BibTeX_source=BibTeX_kaynağın_göster/düzenle
-Show/edit_BibLaTeX_source=
+Show/edit_%0_source=%0_kaynağın_göster/düzenle
 
 Show_'Firstname_Lastname'='Ad_Soyad'_göster
 

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -154,6 +154,7 @@ Backup_old_file_when_saving=Sao_lại_tập_tin_cũ_khi_lưu
 BibTeX_key_is_unique.=Khóa_BibTeX_không_được_trùng.
 
 BibTeX_source=Nguồn_BibTeX
+BibLaTeX_source=
 
 Broken_link=Liên_kết_bị_đứt
 
@@ -1150,6 +1151,7 @@ Settings=Các_thiết_lập
 Shortcut=Phím_tắt
 
 Show/edit_BibTeX_source=Hiển_thị/Chỉnh_sửa_nguồn_BibTeX
+Show/edit_BibLaTeX_source=
 
 Show_'Firstname_Lastname'=Hiển_thị_'Tên.gọi_Họ'
 

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -153,8 +153,7 @@ Backup_old_file_when_saving=Sao_lại_tập_tin_cũ_khi_lưu
 
 BibTeX_key_is_unique.=Khóa_BibTeX_không_được_trùng.
 
-BibTeX_source=Nguồn_BibTeX
-BibLaTeX_source=
+%0_source=Nguồn_%0
 
 Broken_link=Liên_kết_bị_đứt
 
@@ -1150,8 +1149,7 @@ Settings=Các_thiết_lập
 
 Shortcut=Phím_tắt
 
-Show/edit_BibTeX_source=Hiển_thị/Chỉnh_sửa_nguồn_BibTeX
-Show/edit_BibLaTeX_source=
+Show/edit_%0_source=Hiển_thị/Chỉnh_sửa_nguồn_%0
 
 Show_'Firstname_Lastname'=Hiển_thị_'Tên.gọi_Họ'
 

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -153,8 +153,7 @@ Backup_old_file_when_saving=保存数据库时保留备份
 
 BibTeX_key_is_unique.=BibTeX_键值是唯一的。
 
-BibTeX_source=BibTeX_源代码
-BibLaTeX_source=
+%0_source=%0_源代码
 
 Broken_link=失效链接
 
@@ -1150,8 +1149,7 @@ Settings=设置
 
 Shortcut=快捷键
 
-Show/edit_BibTeX_source=显示/编辑_BibTeX_源代码
-Show/edit_BibLaTeX_source=
+Show/edit_%0_source=显示/编辑_%0_源代码
 
 Show_'Firstname_Lastname'=显示_'名_(Firstname)_姓_(Lastname)'
 

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -154,6 +154,7 @@ Backup_old_file_when_saving=保存数据库时保留备份
 BibTeX_key_is_unique.=BibTeX_键值是唯一的。
 
 BibTeX_source=BibTeX_源代码
+BibLaTeX_source=
 
 Broken_link=失效链接
 
@@ -1150,6 +1151,7 @@ Settings=设置
 Shortcut=快捷键
 
 Show/edit_BibTeX_source=显示/编辑_BibTeX_源代码
+Show/edit_BibLaTeX_source=
 
 Show_'Firstname_Lastname'=显示_'名_(Firstname)_姓_(Lastname)'
 


### PR DESCRIPTION
This is a minor change to the source panel, which used to always display "BibTeX source" as title and a similar tooltip. Now, that is dependent on the mode of the database and reads "BibLaTeX source" in biblatex mode.

- [X] Change in CHANGELOG.md described
- [X] Manually tested changed features in running JabRef
- [X] If you changed the localization: Did you run `gradle localizationUpdate`?

