### PR TITLE
Implement Datepicker "none"-button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Change "Recent files" to "Recent databases" to keep the file menu consistent
 
 ### Fixed
+- Fixed [#2092](https://github.com/JabRef/jabref/issues/2092): "None"-button in date picker clears the date field
 - Fixed [#1993](https://github.com/JabRef/jabref/issues/1993): Various optimizations regarding search performance
 - Fixed [koppor#160](https://github.com/koppor/jabref/issues/160): Tooltips now working in the main table
 - Fixed [#2054](https://github.com/JabRef/jabref/issues/2054): Ignoring a new version now works as expected

--- a/src/main/java/net/sf/jabref/gui/date/DatePickerButton.java
+++ b/src/main/java/net/sf/jabref/gui/date/DatePickerButton.java
@@ -47,9 +47,12 @@ public class DatePickerButton implements ActionListener {
                         .fromTimeStampFormat(Globals.prefs.get(JabRefPreferences.TIME_STAMP_FORMAT))
                         .getDateAt(date));
             }
-            // Set focus to editor component after changing its text:
-            editor.getTextComponent().requestFocus();
+        } else {
+            // in this case the user selected "none" in the date picker, so we just clear the field
+            editor.setText("");
         }
+        // Set focus to editor component after changing its text:
+        editor.getTextComponent().requestFocus();
     }
 
     public JComponent getDatePicker() {


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/2092

Implemented behavior for the "none"-button of the data picker, which now clears the content of the date field.

- [X] Change in CHANGELOG.md described
- [X] Manually tested changed features in running JabRef
