### PR TITLE
Fix entry preview not updated properly

### DIFF
--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableSelectionListener.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableSelectionListener.java
@@ -102,11 +102,6 @@ public class MainTableSelectionListener implements ListEventListener<BibEntry>, 
         }
 
         final BibEntry newSelected = selected.get(0);
-        if (Objects.nonNull(panel.getCurrentEditor()) && (newSelected == panel.getCurrentEditor().getEntry())) {
-            // is already selected
-            return;
-        }
-
         if (newSelected != null) {
             final BasePanelMode mode = panel.getMode(); // What is the panel already showing?
             if ((mode == BasePanelMode.WILL_SHOW_EDITOR) || (mode == BasePanelMode.SHOWING_EDITOR)) {


### PR DESCRIPTION
Fixes: #2105.

### Steps to reproduce:
1. have at least 2 entries
- open the entry editor and close it 
  - the preview will be rendered correctly
- select the other entry 
  - the preview will be rendered correctly
- select the first entry (the one you opened the editor with)
- the preview will not be updated


The problem is that the editor variable doesn't get cleared when the editor closes, thus the bottom component in the main table doesn't get updated if that entry is the last one which had the editor open.