### PR TITLE
Fix main table bug when creating a duplicate

### DIFF
--- a/src/main/java/net/sf/jabref/gui/maintable/ListSynchronizer.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/ListSynchronizer.java
@@ -40,8 +40,8 @@ public class ListSynchronizer {
     public void listen(EntryChangedEvent entryChangedEvent) {
         lock();
         try {
-            // can't use list#indexOf b/c it won't distinguish between duplicates
-            for (int i=0; i<list.size(); i++) {
+            // cannot use list#indexOf b/c it won't distinguish between duplicates
+            for (int i = 0; i < list.size(); i++) {
                 if (list.get(i) == entryChangedEvent.getBibEntry()) {
                     list.set(i, entryChangedEvent.getBibEntry());
                     break;

--- a/src/main/java/net/sf/jabref/gui/maintable/ListSynchronizer.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/ListSynchronizer.java
@@ -40,12 +40,12 @@ public class ListSynchronizer {
     public void listen(EntryChangedEvent entryChangedEvent) {
         lock();
         try {
-            int index = list.indexOf(entryChangedEvent.getBibEntry());
-            if (index != -1) {
-                // SpecialFieldUtils.syncSpecialFieldsFromKeywords update an entry during
-                // DatabaseChangeEvent.ADDED_ENTRY
-                // thus,
-                list.set(index, entryChangedEvent.getBibEntry());
+            // can't use list#indexOf b/c it won't distinguish between duplicates
+            for (int i=0; i<list.size(); i++) {
+                if (list.get(i) == entryChangedEvent.getBibEntry()) {
+                    list.set(i, entryChangedEvent.getBibEntry());
+                    break;
+                }
             }
         } finally {
             unlock();


### PR DESCRIPTION
### Steps to reproduce:

- have at least 2 entries in a database
- edit the lower one so that it matches the first one in every detail (creating a duplicate)
- now the upper one will be internally replaced with the lower one (and will be lost visually), both entries in the table are now one and the same


This is again caused by the `BibEntry#equals` method which doesn't recognize duplicates, maybe we have to do something about that?
