### PR TITLE
Fix switching edited textfield in the entry editor with TAB

### DIFF
--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableSelectionListener.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableSelectionListener.java
@@ -102,6 +102,12 @@ public class MainTableSelectionListener implements ListEventListener<BibEntry>, 
         }
 
         final BibEntry newSelected = selected.get(0);
+        if ((panel.getMode() == BasePanelMode.SHOWING_EDITOR || panel.getMode() == BasePanelMode.WILL_SHOW_EDITOR)
+                && newSelected == panel.getCurrentEditor().getEntry()) {
+            // entry already selected and currently editing it, do not steal the focus from the selected textfield
+            return;
+        }
+
         if (newSelected != null) {
             final BasePanelMode mode = panel.getMode(); // What is the panel already showing?
             if ((mode == BasePanelMode.WILL_SHOW_EDITOR) || (mode == BasePanelMode.SHOWING_EDITOR)) {


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/2136

### Steps to reproduce
1. open any entry
- edit any field
- try switching to the next field with <kbd>TAB</kbd>
- focus is taken away from the next field