### PR TITLE
Change download URL to downloads.jabref.org

### DIFF
--- a/src/main/java/net/sf/jabref/logic/util/Version.java
+++ b/src/main/java/net/sf/jabref/logic/util/Version.java
@@ -17,7 +17,7 @@ import org.json.JSONObject;
  */
 public class Version {
 
-    public static final String JABREF_DOWNLOAD_URL = "http://www.fosshub.com/JabRef.html";
+    public static final String JABREF_DOWNLOAD_URL = "https://downloads.jabref.org";
     private static final Log LOGGER = LogFactory.getLog(Version.class);
     private static final String JABREF_GITHUB_URL = "https://api.github.com/repos/JabRef/jabref/releases/latest";
 


### PR DESCRIPTION
We want to get back control of the download site we offer. Thus, we created https://downloads.jabref.org (https://github.com/JabRef/downloads.jabref.org) with a redirection to fosshub.

Refs #1670