### PR TITLE
[WIP] Found entries will be shown when dropping a pdf with xmp meta data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Improve language quality of the German translation of shared database
 - Change "Recent files" to "Recent databases" to keep the file menu consistent
 - Customized importer files need to be slightly changed since the class `ImportFormat` was renamed to `Importer`
+- [koppor#5](https://github.com/koppor/jabref/issues/5) When entries are found while dropping a pdf with xmp meta data to the "File" field the found entries will be displayed in the information dialog
 
 ### Fixed
 - Fixed [#2092](https://github.com/JabRef/jabref/issues/2092): "None"-button in date picker clears the date field

--- a/src/main/java/net/sf/jabref/gui/externalfiles/DroppedFileHandler.java
+++ b/src/main/java/net/sf/jabref/gui/externalfiles/DroppedFileHandler.java
@@ -1,17 +1,20 @@
 package net.sf.jabref.gui.externalfiles;
 
+import java.awt.BorderLayout;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 
+import javax.swing.BoxLayout;
 import javax.swing.ButtonGroup;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
+import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -239,8 +242,19 @@ public class DroppedFileHandler {
                 Localization.lang("The PDF contains one or several BibTeX-records.")
                         + "\n"
                         + Localization.lang("Do you want to import these as new entries into the current database?"));
+        JPanel entriesPanel = new JPanel();
+        entriesPanel.setLayout(new BoxLayout(entriesPanel, BoxLayout.Y_AXIS));
+        xmpEntriesInFile.forEach(entry -> {
+            JTextArea entryArea = new JTextArea(entry.toString());
+            entryArea.setEditable(false);
+            entriesPanel.add(entryArea);
+        });
 
-        int reply = JOptionPane.showConfirmDialog(frame, confirmationMessage,
+        JPanel contentPanel = new JPanel(new BorderLayout());
+        contentPanel.add(confirmationMessage, BorderLayout.NORTH);
+        contentPanel.add(entriesPanel, BorderLayout.CENTER);
+
+        int reply = JOptionPane.showConfirmDialog(frame, contentPanel,
                 Localization.lang("XMP-metadata found in PDF: %0", fileName), JOptionPane.YES_NO_CANCEL_OPTION,
                 JOptionPane.QUESTION_MESSAGE);
 


### PR DESCRIPTION
When dropping a pdf with xmp meta data to the "File" field of an entry the information dialog should diplay the found entries. See https://github.com/koppor/jabref/issues/5 for reference.

![xmpmetaentries](https://cloud.githubusercontent.com/assets/15340757/19234596/dac5bf50-8eec-11e6-8cdb-c81668b40fbb.PNG)

- [ ] Internal quality assurance
- [x] Change in CHANGELOG.md described
- [x] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef