### PR TITLE
Fix DuplicationChecker and key generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Customized importer files need to be slightly changed since the class `ImportFormat` was renamed to `Importer`
 
 ### Fixed
+- Fixed [#2089](https://github.com/JabRef/jabref/issues/2089): Fixed faulty cite key generation
 - Fixed [#2092](https://github.com/JabRef/jabref/issues/2092): "None"-button in date picker clears the date field
 - Fixed [#1993](https://github.com/JabRef/jabref/issues/1993): Various optimizations regarding search performance
 - Fixed [koppor#160](https://github.com/koppor/jabref/issues/160): Tooltips now working in the main table

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -436,27 +435,18 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             @Override
             public void run() {
                 if (Globals.prefs.getBoolean(JabRefPreferences.AVOID_OVERWRITING_KEY)) {
-                    for (final Iterator<BibEntry> i = entries.iterator(); i.hasNext();) {
-                        if (i.next().hasCiteKey()) {
-                            i.remove();
-                        }
-                    }
+                    entries.removeIf(BibEntry::hasCiteKey);
                 } else if (Globals.prefs.getBoolean(JabRefPreferences.WARN_BEFORE_OVERWRITING_KEY)) {
-                    for (final BibEntry entry : entries) {
-                        if (entry.hasCiteKey()) {
-                            CheckBoxMessage cbm = new CheckBoxMessage(
-                                    Localization.lang("One or more keys will be overwritten. Continue?"),
-                                    Localization.lang("Disable this confirmation dialog"), false);
-                            final int answer = JOptionPane.showConfirmDialog(frame, cbm,
-                                    Localization.lang("Overwrite keys"), JOptionPane.YES_NO_OPTION);
-                            Globals.prefs.putBoolean(JabRefPreferences.WARN_BEFORE_OVERWRITING_KEY, !cbm.isSelected());
-                            if (answer == JOptionPane.NO_OPTION) {
-                                canceled = true;
-                                return;
-                            }
-                            // No need to check more entries, because the user has already confirmed
-                            // that it's ok to overwrite keys:
-                            break;
+                    if (entries.parallelStream().anyMatch(BibEntry::hasCiteKey)) {
+                        CheckBoxMessage cbm = new CheckBoxMessage(
+                                Localization.lang("One or more keys will be overwritten. Continue?"),
+                                Localization.lang("Disable this confirmation dialog"), false);
+                        final int answer = JOptionPane.showConfirmDialog(frame, cbm,
+                                Localization.lang("Overwrite keys"), JOptionPane.YES_NO_OPTION);
+                        Globals.prefs.putBoolean(JabRefPreferences.WARN_BEFORE_OVERWRITING_KEY, !cbm.isSelected());
+                        if (answer == JOptionPane.NO_OPTION) {
+                            canceled = true;
+                            return;
                         }
                     }
                 }

--- a/src/main/java/net/sf/jabref/gui/bibtexkeypattern/SearchFixDuplicateLabels.java
+++ b/src/main/java/net/sf/jabref/gui/bibtexkeypattern/SearchFixDuplicateLabels.java
@@ -97,7 +97,7 @@ public class SearchFixDuplicateLabels extends AbstractWorker {
                         .getCiteKeyPattern(Globals.prefs.getBibtexKeyPatternPreferences().getKeyPattern()),
                         panel.getDatabase(), entry,
                         Globals.prefs.getBibtexKeyPatternPreferences());
-                ce.addEdit(new UndoableKeyChange(panel.getDatabase(), entry, oldKey, entry.getCiteKeyOptional().get()));
+                ce.addEdit(new UndoableKeyChange(entry, oldKey, entry.getCiteKeyOptional().get()));
             }
             ce.end();
             panel.getUndoManager().addEdit(ce);

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -778,11 +778,9 @@ public class EntryEditor extends JPanel implements EntryContainer {
             BibEntry newEntry = database.getEntries().get(0);
             String newKey = newEntry.getCiteKeyOptional().orElse(null);
             boolean entryChanged = false;
-            boolean duplicateWarning = false;
             boolean emptyWarning = (newKey == null) || newKey.isEmpty();
 
             entry.setCiteKey(newKey);
-            duplicateWarning = panel.getDatabase().getDuplicationChecker().isDuplicateExisting(newKey);
 
             // First, remove fields that the user has removed.
             for (Entry<String, String> field : entry.getFieldMap().entrySet()) {
@@ -827,7 +825,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
             panel.getUndoManager().addEdit(compound);
 
-            if (duplicateWarning) {
+            if (panel.getDatabase().getDuplicationChecker().isDuplicateCiteKeyExisting(entry)) {
                 warnDuplicateBibtexkey();
             } else if (emptyWarning) {
                 warnEmptyBibtexkey();
@@ -1108,7 +1106,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
                 if (newValue == null) {
                     warnEmptyBibtexkey();
                 } else {
-                    boolean isDuplicate = panel.getDatabase().getDuplicationChecker().isDuplicateExisting(newValue);
+                    boolean isDuplicate = panel.getDatabase().getDuplicationChecker().isDuplicateCiteKeyExisting(entry);
                     if (isDuplicate) {
                         warnDuplicateBibtexkey();
                     } else {

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -781,9 +781,8 @@ public class EntryEditor extends JPanel implements EntryContainer {
             boolean duplicateWarning = false;
             boolean emptyWarning = (newKey == null) || newKey.isEmpty();
 
-            if (panel.getDatabase().setCiteKeyForEntry(entry, newKey)) {
-                duplicateWarning = true;
-            }
+            entry.setCiteKey(newKey);
+            duplicateWarning = panel.getDatabase().getDuplicationChecker().isDuplicateExisting(newKey);
 
             // First, remove fields that the user has removed.
             for (Entry<String, String> field : entry.getFieldMap().entrySet()) {
@@ -1104,11 +1103,12 @@ public class EntryEditor extends JPanel implements EntryContainer {
                     return;
                 }
 
-                boolean isDuplicate = panel.getDatabase().setCiteKeyForEntry(entry, newValue);
+                entry.setCiteKey(newValue);
 
                 if (newValue == null) {
                     warnEmptyBibtexkey();
                 } else {
+                    boolean isDuplicate = panel.getDatabase().getDuplicationChecker().isDuplicateExisting(newValue);
                     if (isDuplicate) {
                         warnDuplicateBibtexkey();
                     } else {
@@ -1117,7 +1117,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
                 }
 
                 // Add an UndoableKeyChange to the baseframe's undoManager.
-                UndoableKeyChange undoableKeyChange = new UndoableKeyChange(panel.getDatabase(), entry, oldValue, newValue);
+                UndoableKeyChange undoableKeyChange = new UndoableKeyChange(entry, oldValue, newValue);
                 if (updateTimeStampIsSet()) {
                     NamedCompound ce = new NamedCompound(undoableKeyChange.getPresentationName());
                     ce.addEdit(undoableKeyChange);
@@ -1337,7 +1337,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
             // Store undo information:
             panel.getUndoManager().addEdit(
-                    new UndoableKeyChange(panel.getDatabase(), entry, oldValue.orElse(null),
+                    new UndoableKeyChange(entry, oldValue.orElse(null),
                             entry.getCiteKeyOptional().get())); // Cite key always set here
 
             // here we update the field

--- a/src/main/java/net/sf/jabref/gui/openoffice/OpenOfficePanel.java
+++ b/src/main/java/net/sf/jabref/gui/openoffice/OpenOfficePanel.java
@@ -719,7 +719,7 @@ public class OpenOfficePanel extends AbstractWorker {
                             prefs);
                     // Add undo change
                     undoCompound.addEdit(
-                            new UndoableKeyChange(panel.getDatabase(), entry, null, entry.getCiteKeyOptional().get()));
+                            new UndoableKeyChange(entry, null, entry.getCiteKeyOptional().get()));
                 }
             }
             undoCompound.end();

--- a/src/main/java/net/sf/jabref/gui/undo/UndoableKeyChange.java
+++ b/src/main/java/net/sf/jabref/gui/undo/UndoableKeyChange.java
@@ -1,7 +1,6 @@
 package net.sf.jabref.gui.undo;
 
 import net.sf.jabref.logic.l10n.Localization;
-import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.strings.StringUtil;
 
@@ -13,14 +12,11 @@ import net.sf.jabref.model.strings.StringUtil;
 public class UndoableKeyChange extends AbstractUndoableJabRefEdit {
 
     private final BibEntry entry;
-    private final BibDatabase base;
     private final String oldValue;
     private final String newValue;
 
 
-    public UndoableKeyChange(BibDatabase base, BibEntry entry,
-            String oldValue, String newValue) {
-        this.base = base;
+    public UndoableKeyChange(BibEntry entry, String oldValue, String newValue) {
         this.entry = entry;
         this.oldValue = oldValue;
         this.newValue = newValue;
@@ -31,27 +27,18 @@ public class UndoableKeyChange extends AbstractUndoableJabRefEdit {
         return Localization.lang("change key from %0 to %1",
                 StringUtil.boldHTML(oldValue, Localization.lang("undefined")),
                 StringUtil.boldHTML(newValue, Localization.lang("undefined")));
-
     }
 
     @Override
     public void undo() {
         super.undo();
-
-        // Revert the change.
-        set(oldValue);
+        entry.setCiteKey(oldValue);
     }
 
     @Override
     public void redo() {
         super.redo();
-
-        // Redo the change.
-        set(newValue);
-    }
-
-    private void set(String to) {
-        base.setCiteKeyForEntry(entry, to);
+        entry.setCiteKey(newValue);
     }
 
 }

--- a/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -429,7 +429,7 @@ public class BibtexKeyPatternUtil {
         }
 
         String oldKey = entry.getCiteKeyOptional().orElse(null);
-        int occurrences = database.getNumberOfKeyOccurrences(key);
+        int occurrences = database.getDuplicationChecker().getNumberOfKeyOccurrences(key);
 
         if (Objects.equals(oldKey, key)) {
             occurrences--; // No change, so we can accept one dupe.
@@ -439,16 +439,7 @@ public class BibtexKeyPatternUtil {
         boolean firstLetterA = bibtexKeyPatternPreferences.isFirstLetterA();
 
         if (!alwaysAddLetter && (occurrences == 0)) {
-            // No dupes found, so we can just go ahead.
-            if (!key.equals(oldKey)) {
-                if (database.containsEntryWithId(entry.getId())) {
-                    database.setCiteKeyForEntry(entry, key);
-                } else {
-                    // entry does not (yet) exist in the database, just update the entry
-                    entry.setCiteKey(key);
-                }
-            }
-
+            entry.setCiteKey(key);
         } else {
             // The key is already in use, so we must modify it.
             int number = 0;
@@ -457,7 +448,7 @@ public class BibtexKeyPatternUtil {
             }
 
             String moddedKey = key + getAddition(number);
-            occurrences = database.getNumberOfKeyOccurrences(moddedKey);
+            occurrences = database.getDuplicationChecker().getNumberOfKeyOccurrences(moddedKey);
 
             if (Objects.equals(oldKey, moddedKey)) {
                 occurrences--;
@@ -467,20 +458,13 @@ public class BibtexKeyPatternUtil {
                 number++;
                 moddedKey = key + getAddition(number);
 
-                occurrences = database.getNumberOfKeyOccurrences(moddedKey);
+                occurrences = database.getDuplicationChecker().getNumberOfKeyOccurrences(moddedKey);
                 if (Objects.equals(oldKey, moddedKey)) {
                     occurrences--;
                 }
             }
 
-            if (!moddedKey.equals(oldKey)) {
-                if (database.containsEntryWithId(entry.getId())) {
-                    database.setCiteKeyForEntry(entry, moddedKey);
-                } else {
-                    // entry does not (yet) exist in the database, just update the entry
-                    entry.setCiteKey(moddedKey);
-                }
-            }
+            entry.setCiteKey(moddedKey);
         }
     }
 

--- a/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -442,27 +442,19 @@ public class BibtexKeyPatternUtil {
             entry.setCiteKey(key);
         } else {
             // The key is already in use, so we must modify it.
-            int number = 0;
-            if (!alwaysAddLetter && !firstLetterA) {
-                number = 1;
-            }
+            int number = !alwaysAddLetter && !firstLetterA ? 1 : 0;
+            String moddedKey;
 
-            String moddedKey = key + getAddition(number);
-            occurrences = database.getDuplicationChecker().getNumberOfKeyOccurrences(moddedKey);
-
-            if (Objects.equals(oldKey, moddedKey)) {
-                occurrences--;
-            }
-
-            while (occurrences > 0) {
-                number++;
+            do {
                 moddedKey = key + getAddition(number);
+                number++;
 
                 occurrences = database.getDuplicationChecker().getNumberOfKeyOccurrences(moddedKey);
+                // only happens if #getAddition() is buggy
                 if (Objects.equals(oldKey, moddedKey)) {
                     occurrences--;
                 }
-            }
+            } while (occurrences > 0);
 
             entry.setCiteKey(moddedKey);
         }

--- a/src/main/java/net/sf/jabref/model/database/BibDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabase.java
@@ -182,7 +182,7 @@ public class BibDatabase {
         entry.registerListener(this);
 
         eventBus.post(new EntryAddedEvent(entry, eventSource));
-        return duplicationChecker.isDuplicateExisting(entry.getCiteKeyOptional());
+        return duplicationChecker.isDuplicateCiteKeyExisting(entry);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/model/database/DuplicationChecker.java
+++ b/src/main/java/net/sf/jabref/model/database/DuplicationChecker.java
@@ -2,7 +2,6 @@ package net.sf.jabref.model.database;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import net.sf.jabref.model.database.event.EntryAddedEvent;
 import net.sf.jabref.model.database.event.EntryRemovedEvent;
@@ -23,15 +22,15 @@ public class DuplicationChecker {
     /**
      * Checks if there is more than one occurrence of this key
      */
-    public boolean isDuplicateExisting(String citeKey) {
+    public boolean isDuplicateCiteKeyExisting(String citeKey) {
         return getNumberOfKeyOccurrences(citeKey) > 1;
     }
 
     /**
-     * Checks if there is more than one occurrence of this key
+     * Checks if there is more than one occurrence of the cite key
      */
-    public boolean isDuplicateExisting(Optional<String> citeKey) {
-        return isDuplicateExisting(citeKey.orElse(""));
+    public boolean isDuplicateCiteKeyExisting(BibEntry entry) {
+        return isDuplicateCiteKeyExisting(entry.getCiteKeyOptional().orElse(null));
     }
 
     /**

--- a/src/main/java/net/sf/jabref/model/database/DuplicationChecker.java
+++ b/src/main/java/net/sf/jabref/model/database/DuplicationChecker.java
@@ -55,14 +55,12 @@ public class DuplicationChecker {
      * Thus, I need a way to count the number of keys of each type.
      * Solution: hashmap=>int (increment each time at add and decrement each time at remove)
      */
-    private boolean addKeyToSet(String key) {
+    private void addKeyToSet(String key) {
         if (key == null || key.isEmpty()) {
-            return false;
+            return;
         }
 
-        int numberOfKeyOccurrences = getNumberOfKeyOccurrences(key);
-        allKeys.put(key, numberOfKeyOccurrences + 1);
-        return numberOfKeyOccurrences != 0;
+        allKeys.put(key, getNumberOfKeyOccurrences(key) + 1);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/model/database/DuplicationChecker.java
+++ b/src/main/java/net/sf/jabref/model/database/DuplicationChecker.java
@@ -2,6 +2,7 @@ package net.sf.jabref.model.database;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import net.sf.jabref.model.database.event.EntryAddedEvent;
 import net.sf.jabref.model.database.event.EntryRemovedEvent;
@@ -94,12 +95,18 @@ public class DuplicationChecker {
 
     @Subscribe
     public void listen(EntryRemovedEvent entryRemovedEvent) {
-        removeKeyFromSet(entryRemovedEvent.getBibEntry().getCiteKeyOptional().orElse(null));
+        Optional<String> citeKey = entryRemovedEvent.getBibEntry().getCiteKeyOptional();
+        if (citeKey.isPresent()) {
+            removeKeyFromSet(citeKey.get());
+        }
     }
 
     @Subscribe
     public void listen(EntryAddedEvent entryAddedEvent) {
-        addKeyToSet(entryAddedEvent.getBibEntry().getCiteKeyOptional().orElse(null));
+        Optional<String> citekey = entryAddedEvent.getBibEntry().getCiteKeyOptional();
+        if (citekey.isPresent()) {
+            addKeyToSet(citekey.get());
+        }
     }
 
 }

--- a/src/test/java/net/sf/jabref/model/database/BibDatabaseTest.java
+++ b/src/test/java/net/sf/jabref/model/database/BibDatabaseTest.java
@@ -178,7 +178,7 @@ public class BibDatabaseTest {
         BibEntry entry = new BibEntry();
         entry.setCiteKey("AAA");
         database.insertEntry(entry);
-        assertEquals(database.getNumberOfKeyOccurrences("AAA"), 1);
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 1);
     }
 
     @Test
@@ -189,51 +189,7 @@ public class BibDatabaseTest {
         entry = new BibEntry();
         entry.setCiteKey("AAA");
         database.insertEntry(entry);
-        assertEquals(database.getNumberOfKeyOccurrences("AAA"), 2);
-    }
-
-    @Test
-    public void setCiteKeySameKeySameEntry() {
-        BibEntry entry = new BibEntry();
-        entry.setCiteKey("AAA");
-        database.insertEntry(entry);
-        assertFalse(database.setCiteKeyForEntry(entry, "AAA"));
-        assertEquals(database.getNumberOfKeyOccurrences("AAA"), 1);
-    }
-
-    @Test
-    public void setCiteKeyRemoveKey() {
-        BibEntry entry = new BibEntry();
-        entry.setCiteKey("AAA");
-        database.insertEntry(entry);
-        assertFalse(database.setCiteKeyForEntry(entry, null));
-        assertEquals(database.getNumberOfKeyOccurrences("AAA"), 0);
-        assertEquals(Optional.empty(), entry.getCiteKeyOptional());
-    }
-
-    @Test
-    public void setCiteKeyDifferentKeySameEntry() {
-        BibEntry entry = new BibEntry();
-        entry.setCiteKey("AAA");
-        database.insertEntry(entry);
-        assertFalse(database.setCiteKeyForEntry(entry, "BBB"));
-        assertEquals(database.getNumberOfKeyOccurrences("AAA"), 0);
-        assertEquals(database.getNumberOfKeyOccurrences("BBB"), 1);
-    }
-
-
-    @Test
-    public void setCiteKeySameKeyDifferentEntries() {
-        BibEntry entry = new BibEntry();
-        entry.setCiteKey("AAA");
-        database.insertEntry(entry);
-        entry = new BibEntry();
-        entry.setCiteKey("BBB");
-        database.insertEntry(entry);
-        assertTrue(database.setCiteKeyForEntry(entry, "AAA"));
-        assertEquals(entry.getCiteKeyOptional(), Optional.of("AAA"));
-        assertEquals(database.getNumberOfKeyOccurrences("AAA"), 2);
-        assertEquals(database.getNumberOfKeyOccurrences("BBB"), 0);
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 2);
     }
 
     @Test
@@ -245,7 +201,7 @@ public class BibDatabaseTest {
         entry.setCiteKey("AAA");
         database.insertEntry(entry);
         database.removeEntry(entry);
-        assertEquals(database.getNumberOfKeyOccurrences("AAA"), 1);
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 1);
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/model/database/DuplicationCheckerTest.java
+++ b/src/test/java/net/sf/jabref/model/database/DuplicationCheckerTest.java
@@ -1,0 +1,111 @@
+package net.sf.jabref.model.database;
+
+import net.sf.jabref.model.entry.BibEntry;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class DuplicationCheckerTest {
+
+    private BibDatabase database;
+
+
+    @Before
+    public void setUp() {
+        database = new BibDatabase();
+    }
+
+    @Test
+    public void addEntry() {
+        BibEntry entry = new BibEntry();
+        entry.setCiteKey("AAA");
+        database.insertEntry(entry);
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 1);
+    }
+
+    @Test
+    public void addAndRemoveEntry() {
+        BibEntry entry = new BibEntry();
+        entry.setCiteKey("AAA");
+        database.insertEntry(entry);
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 1);
+        database.removeEntry(entry);
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 0);
+    }
+
+    @Test
+    public void changeCiteKey() {
+        BibEntry entry = new BibEntry();
+        entry.setCiteKey("AAA");
+        database.insertEntry(entry);
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 1);
+        entry.setCiteKey("BBB");
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 0);
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("BBB"), 1);
+    }
+
+
+    @Test
+    public void setCiteKeySameKeyDifferentEntries() {
+        BibEntry entry0 = new BibEntry();
+        entry0.setCiteKey("AAA");
+        database.insertEntry(entry0);
+        BibEntry entry1 = new BibEntry();
+        entry1.setCiteKey("BBB");
+        database.insertEntry(entry1);
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 1);
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("BBB"), 1);
+
+        entry1.setCiteKey("AAA");
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 2);
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("BBB"), 0);
+    }
+
+    @Test
+    public void removeMultipleCiteKeys(){
+        BibEntry entry0 = new BibEntry();
+        entry0.setCiteKey("AAA");
+        database.insertEntry(entry0);
+        BibEntry entry1 = new BibEntry();
+        entry1.setCiteKey("AAA");
+        database.insertEntry(entry1);
+        BibEntry entry2 = new BibEntry();
+        entry2.setCiteKey("AAA");
+        database.insertEntry(entry2);
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 3);
+
+        database.removeEntry(entry2);
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 2);
+
+        database.removeEntry(entry1);
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 1);
+
+        database.removeEntry(entry0);
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 0);
+    }
+
+    @Test
+    public void addEmptyCiteKey(){
+        BibEntry entry = new BibEntry();
+        entry.setCiteKey("");
+        database.insertEntry(entry);
+
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences(""), 0);
+    }
+
+    @Test
+    public void removeEmptyCiteKey(){
+        BibEntry entry = new BibEntry();
+        entry.setCiteKey("AAA");
+        database.insertEntry(entry);
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 1);
+
+        entry.setCiteKey("");
+        database.removeEntry(entry);
+        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 0);
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/2089.

The Duplication checker was faulty and didn't catch all the cite keys. There needed to be used a special method in the BasePanel which wasn't used at all.
I registered the DuplicationChecker with the Eventbus which now gets notified when an Entry changes, gets added, or removed.

This fixes the automatic Key generation which before had wrong information on what cite keys exist.