### PR TITLE
Add test case for other and unknown type

### DIFF
--- a/src/test/java/net/sf/jabref/logic/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/BibEntryWriterTest.java
@@ -3,6 +3,7 @@ package net.sf.jabref.logic.bibtex;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Set;
 
@@ -59,6 +60,50 @@ public class BibEntryWriterTest {
         // @formatter:on
 
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void roundTripTestOtherType() throws IOException, URISyntaxException {
+        String bibtexEntry = "@Other{test," + OS.NEWLINE +
+                "  Comment                  = {testentry}" + OS.NEWLINE +
+                "}";
+
+        // read in bibtex string
+        ParserResult result = BibtexParser.parse(new StringReader(bibtexEntry), importFormatPreferences);
+        Collection<BibEntry> entries = result.getDatabase().getEntries();
+        BibEntry entry = entries.iterator().next();
+
+        String resourceName = "/testbib/othertype.bib";
+        BibEntryAssert.assertEquals(BibEntryWriter.class, resourceName, entry);
+
+        //write out bibtex string
+        StringWriter stringWriter = new StringWriter();
+        writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
+        String actual = stringWriter.toString();
+
+        assertEquals(bibtexEntry, actual);
+    }
+
+    @Test
+    public void roundTripTestReallyunknownType() throws IOException, URISyntaxException {
+        String bibtexEntry = "@ReallyUnknownType{test," + OS.NEWLINE +
+                "  Comment                  = {testentry}" + OS.NEWLINE +
+                "}";
+
+        // read in bibtex string
+        ParserResult result = BibtexParser.parse(new StringReader(bibtexEntry), importFormatPreferences);
+        Collection<BibEntry> entries = result.getDatabase().getEntries();
+        BibEntry entry = entries.iterator().next();
+
+        String resourceName = "/testbib/reallyunknowntype.bib";
+        BibEntryAssert.assertEquals(BibEntryWriter.class, resourceName, entry);
+
+        //write out bibtex string
+        StringWriter stringWriter = new StringWriter();
+        writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
+        String actual = stringWriter.toString();
+
+        assertEquals(bibtexEntry, actual);
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/BibEntryWriterTest.java
@@ -3,7 +3,6 @@ package net.sf.jabref.logic.bibtex;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Set;
 
@@ -63,47 +62,69 @@ public class BibEntryWriterTest {
     }
 
     @Test
-    public void roundTripTestOtherType() throws IOException, URISyntaxException {
+    public void readOtherTypeTest() throws Exception {
         String bibtexEntry = "@Other{test," + OS.NEWLINE +
-                "  Comment                  = {testentry}" + OS.NEWLINE +
+                " Comment                  = {testentry}" + OS.NEWLINE +
                 "}";
 
         // read in bibtex string
-        ParserResult result = BibtexParser.parse(new StringReader(bibtexEntry), importFormatPreferences);
-        Collection<BibEntry> entries = result.getDatabase().getEntries();
+        Collection<BibEntry> entries = new BibtexParser(importFormatPreferences).parseEntries(bibtexEntry);
         BibEntry entry = entries.iterator().next();
 
         String resourceName = "/testbib/othertype.bib";
         BibEntryAssert.assertEquals(BibEntryWriter.class, resourceName, entry);
+    }
+
+    @Test
+    public void writeOtherTypeTest() throws Exception {
+        String expected = OS.NEWLINE + "@Other{test," + OS.NEWLINE +
+                "  comment = {testentry}," + OS.NEWLINE +
+                "}"+ OS.NEWLINE;
+
+        BibEntry entry = new BibEntry();
+        entry.setType("other");
+        entry.setField("Comment","testentry");
+        entry.setCiteKey("test");
 
         //write out bibtex string
         StringWriter stringWriter = new StringWriter();
         writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
         String actual = stringWriter.toString();
 
-        assertEquals(bibtexEntry, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
-    public void roundTripTestReallyunknownType() throws IOException, URISyntaxException {
+    public void readReallyUnknownTypeTest() throws Exception {
         String bibtexEntry = "@ReallyUnknownType{test," + OS.NEWLINE +
-                "  Comment                  = {testentry}" + OS.NEWLINE +
+                " Comment                  = {testentry}" + OS.NEWLINE +
                 "}";
 
         // read in bibtex string
-        ParserResult result = BibtexParser.parse(new StringReader(bibtexEntry), importFormatPreferences);
-        Collection<BibEntry> entries = result.getDatabase().getEntries();
+        Collection<BibEntry> entries = new BibtexParser(importFormatPreferences).parseEntries(bibtexEntry);
         BibEntry entry = entries.iterator().next();
 
         String resourceName = "/testbib/reallyunknowntype.bib";
         BibEntryAssert.assertEquals(BibEntryWriter.class, resourceName, entry);
+    }
+
+    @Test
+    public void writeReallyunknownTypeTest() throws Exception {
+        String expected = OS.NEWLINE + "@Reallyunknowntype{test," + OS.NEWLINE +
+                "  comment = {testentry}," + OS.NEWLINE +
+                "}"+ OS.NEWLINE;
+
+        BibEntry entry = new BibEntry();
+        entry.setType("ReallyUnknownType");
+        entry.setField("Comment","testentry");
+        entry.setCiteKey("test");
 
         //write out bibtex string
         StringWriter stringWriter = new StringWriter();
         writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);
         String actual = stringWriter.toString();
 
-        assertEquals(bibtexEntry, actual);
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/BibEntryWriterTest.java
@@ -62,20 +62,6 @@ public class BibEntryWriterTest {
     }
 
     @Test
-    public void readOtherTypeTest() throws Exception {
-        String bibtexEntry = "@Other{test," + OS.NEWLINE +
-                " Comment                  = {testentry}" + OS.NEWLINE +
-                "}";
-
-        // read in bibtex string
-        Collection<BibEntry> entries = new BibtexParser(importFormatPreferences).parseEntries(bibtexEntry);
-        BibEntry entry = entries.iterator().next();
-
-        String resourceName = "/testbib/othertype.bib";
-        BibEntryAssert.assertEquals(BibEntryWriter.class, resourceName, entry);
-    }
-
-    @Test
     public void writeOtherTypeTest() throws Exception {
         String expected = OS.NEWLINE + "@Other{test," + OS.NEWLINE +
                 "  comment = {testentry}," + OS.NEWLINE +
@@ -92,20 +78,6 @@ public class BibEntryWriterTest {
         String actual = stringWriter.toString();
 
         assertEquals(expected, actual);
-    }
-
-    @Test
-    public void readReallyUnknownTypeTest() throws Exception {
-        String bibtexEntry = "@ReallyUnknownType{test," + OS.NEWLINE +
-                " Comment                  = {testentry}" + OS.NEWLINE +
-                "}";
-
-        // read in bibtex string
-        Collection<BibEntry> entries = new BibtexParser(importFormatPreferences).parseEntries(bibtexEntry);
-        BibEntry entry = entries.iterator().next();
-
-        String resourceName = "/testbib/reallyunknowntype.bib";
-        BibEntryAssert.assertEquals(BibEntryWriter.class, resourceName, entry);
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import net.sf.jabref.logic.bibtex.BibEntryAssert;
 import net.sf.jabref.logic.exporter.SavePreferences;
 import net.sf.jabref.logic.formatter.casechanger.LowerCaseFormatter;
 import net.sf.jabref.logic.importer.ImportFormatPreferences;
@@ -243,23 +242,29 @@ public class BibtexParserTest {
                 "}";
 
         Collection<BibEntry> entries = new BibtexParser(importFormatPreferences).parseEntries(bibtexEntry);
-        BibEntry entry = entries.iterator().next();
 
-        String resourceName = "/testbib/reallyunknowntype.bib";
-        BibEntryAssert.assertEquals(BibtexParser.class, resourceName, entry);
+        BibEntry expectedEntry = new BibEntry();
+        expectedEntry.setType("Reallyunknowntype");
+        expectedEntry.setCiteKey("test");
+        expectedEntry.setField("comment", "testentry");
+
+        assertEquals(Collections.singletonList(expectedEntry), entries);
     }
 
     @Test
-    public void readOtherTypeTest() throws Exception {
+    public void parseOtherTypeTest() throws Exception {
         String bibtexEntry = "@Other{test," + OS.NEWLINE +
                 " Comment                  = {testentry}" + OS.NEWLINE +
                 "}";
 
         Collection<BibEntry> entries = new BibtexParser(importFormatPreferences).parseEntries(bibtexEntry);
-        BibEntry entry = entries.iterator().next();
 
-        String resourceName = "/testbib/othertype.bib";
-        BibEntryAssert.assertEquals(BibtexParser.class, resourceName, entry);
+        BibEntry expectedEntry = new BibEntry();
+        expectedEntry.setType("Other");
+        expectedEntry.setCiteKey("test");
+        expectedEntry.setField("comment", "testentry");
+
+        assertEquals(Collections.singletonList(expectedEntry), entries);
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import net.sf.jabref.logic.bibtex.BibEntryAssert;
 import net.sf.jabref.logic.exporter.SavePreferences;
 import net.sf.jabref.logic.formatter.casechanger.LowerCaseFormatter;
 import net.sf.jabref.logic.importer.ImportFormatPreferences;
@@ -233,6 +234,32 @@ public class BibtexParserTest {
         assertEquals(Optional.of("test"), e.getCiteKeyOptional());
         assertEquals(2, e.getFieldNames().size());
         assertEquals(Optional.of("Ed von Test"), e.getField("author"));
+    }
+
+    @Test
+    public void parseReallyUnknownType() throws Exception {
+        String bibtexEntry = "@ReallyUnknownType{test," + OS.NEWLINE +
+                " Comment                  = {testentry}" + OS.NEWLINE +
+                "}";
+
+        Collection<BibEntry> entries = new BibtexParser(importFormatPreferences).parseEntries(bibtexEntry);
+        BibEntry entry = entries.iterator().next();
+
+        String resourceName = "/testbib/reallyunknowntype.bib";
+        BibEntryAssert.assertEquals(BibtexParser.class, resourceName, entry);
+    }
+
+    @Test
+    public void readOtherTypeTest() throws Exception {
+        String bibtexEntry = "@Other{test," + OS.NEWLINE +
+                " Comment                  = {testentry}" + OS.NEWLINE +
+                "}";
+
+        Collection<BibEntry> entries = new BibtexParser(importFormatPreferences).parseEntries(bibtexEntry);
+        BibEntry entry = entries.iterator().next();
+
+        String resourceName = "/testbib/othertype.bib";
+        BibEntryAssert.assertEquals(BibtexParser.class, resourceName, entry);
     }
 
     @Test


### PR DESCRIPTION
Regarding: [#29] (https://github.com/koppor/jabref/issues/29) 
I've added a test case for reading and writing a file with other and unknwon type.

