### PR TITLE
Clear bibtexkey exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed [#2104](https://github.com/JabRef/jabref/issues/#2104): Crash after saving BibTeX source with parsing error
 - Fixed [#2109](https://github.com/JabRef/jabref/issues/#2109): <kbd>Ctrl-s</kbd> doesn't trigger parsing error message
 - Fixed RTFChars would only use "?" for characters with unicode over the value of 127, now it uses the base character (é -> e instead of ?)
+- Fixed [#2177](https://github.com/JabRef/jabref/issues/#2177): NullPointerException caused by clearing bibtexkey field in entry editor
 
 ### Removed
 - Removed 2nd preview style

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,6 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed [#2104](https://github.com/JabRef/jabref/issues/#2104): Crash after saving BibTeX source with parsing error
 - Fixed [#2109](https://github.com/JabRef/jabref/issues/#2109): <kbd>Ctrl-s</kbd> doesn't trigger parsing error message
 - Fixed RTFChars would only use "?" for characters with unicode over the value of 127, now it uses the base character (é -> e instead of ?)
-- Fixed [#2177](https://github.com/JabRef/jabref/issues/#2177): NullPointerException caused by clearing bibtexkey field in entry editor
 
 ### Removed
 - Removed 2nd preview style

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -793,7 +793,12 @@ public class EntryEditor extends JPanel implements EntryContainer {
             boolean entryChanged = false;
             boolean emptyWarning = (newKey == null) || newKey.isEmpty();
 
-            entry.setCiteKey(newKey);
+            if (newKey != null) {
+                entry.setCiteKey(newKey);
+            }
+            else {
+                entry.clearCiteKey();
+            }
 
             // First, remove fields that the user has removed.
             for (Entry<String, String> field : entry.getFieldMap().entrySet()) {
@@ -1123,11 +1128,11 @@ public class EntryEditor extends JPanel implements EntryContainer {
                     return;
                 }
 
-                entry.setCiteKey(newValue);
-
                 if (newValue == null) {
+                    entry.clearCiteKey();
                     warnEmptyBibtexkey();
                 } else {
+                    entry.setCiteKey(newValue);
                     boolean isDuplicate = panel.getDatabase().getDuplicationChecker().isDuplicateCiteKeyExisting(entry);
                     if (isDuplicate) {
                         warnDuplicateBibtexkey();

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -795,8 +795,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
             if (newKey != null) {
                 entry.setCiteKey(newKey);
-            }
-            else {
+            } else {
                 entry.clearCiteKey();
             }
 


### PR DESCRIPTION
Fixes #2177. NullPointerException caused by clearing bibtexkey field in entry editor.

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?

