### PR TITLE
Fixed close entry editor block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed [#2104](https://github.com/JabRef/jabref/issues/#2104): Crash after saving BibTeX source with parsing error
 - Fixed [#2109](https://github.com/JabRef/jabref/issues/#2109): <kbd>Ctrl-s</kbd> doesn't trigger parsing error message
 - Fixed RTFChars would only use "?" for characters with unicode over the value of 127, now it uses the base character (é -> e instead of ?)
+- Fixed close action of entry editor not working after parsing error corrected
 
 ### Removed
 - Removed 2nd preview style

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -1092,7 +1092,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
         }
     }
 
-    public class StoreFieldAction extends AbstractAction {
+    class StoreFieldAction extends AbstractAction {
 
         public StoreFieldAction() {
             super("Store field value");
@@ -1193,8 +1193,8 @@ public class EntryEditor extends JPanel implements EntryContainer {
                         // properly formatted. If that happens, the field
                         // is not stored and the textarea turns red.
                         if (toSet != null) {
-                            new LatexFieldFormatter(Globals.prefs.getLatexFieldFormatterPreferences())
-                                    .format(toSet, fieldEditor.getFieldName());
+                            new LatexFieldFormatter(Globals.prefs.getLatexFieldFormatterPreferences()).format(toSet,
+                                    fieldEditor.getFieldName());
                         }
 
                         String oldValue = entry.getField(fieldEditor.getFieldName()).orElse(null);
@@ -1214,7 +1214,8 @@ public class EntryEditor extends JPanel implements EntryContainer {
                         }
 
                         // Add an UndoableFieldChange to the baseframe's undoManager.
-                        UndoableFieldChange undoableFieldChange = new UndoableFieldChange(entry, fieldEditor.getFieldName(), oldValue, toSet);
+                        UndoableFieldChange undoableFieldChange = new UndoableFieldChange(entry,
+                                fieldEditor.getFieldName(), oldValue, toSet);
                         if (updateTimeStampIsSet()) {
                             NamedCompound ce = new NamedCompound(undoableFieldChange.getPresentationName());
                             ce.addEdit(undoableFieldChange);
@@ -1235,7 +1236,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
                         fieldEditor.setInvalidBackgroundColor();
                         if (!SwingUtilities.isEventDispatchThread()) {
                             JOptionPane.showMessageDialog(frame, Localization.lang("Error") + ": " + ex.getMessage(),
-                                Localization.lang("Error setting field"), JOptionPane.ERROR_MESSAGE);
+                                    Localization.lang("Error setting field"), JOptionPane.ERROR_MESSAGE);
                             LOGGER.debug("Error setting field", ex);
                             requestFocus();
                         }
@@ -1248,8 +1249,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
                 if (fieldEditor.getTextComponent().hasFocus()) {
                     fieldEditor.setBackground(GUIGlobals.ACTIVE_EDITOR_COLOR);
                 }
-            } else if (source.isEditable()
-                    && !source.getText().equals(lastSourceStringAccepted)) {
+            } else if (source.isEditable() && !source.getText().equals(lastSourceStringAccepted)) {
                 validEntry = storeSource();
             }
 

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -166,15 +166,12 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
     // text area from getting updated. This is used in cases where the source
     // couldn't be parsed, and the user is given the option to edit it.
-    private boolean lastSourceAccepted = true; // This indicates whether the last
-
-    // attempt
+    private boolean lastFieldAccepted = true;
+    private boolean lastSourceAccepted = true; // This indicates whether the last attempt
     // at parsing the source was successful. It is used to determine whether the
     // dialog should close; it should stay open if the user received an error
     // message about the source, whatever he or she chose to do about it.
-    private String lastSourceStringAccepted; // This is used to prevent double
-
-    // fields.
+    private String lastSourceStringAccepted; // This is used to prevent double fields.
     // These values can be used to calculate the preferred height for the form.
     // reqW starts at 1 because it needs room for the bibtex key field.
     private int sourceIndex = -1; // The index the source panel has in tabbed.
@@ -1068,9 +1065,17 @@ public class EntryEditor extends JPanel implements EntryContainer {
             updateField(source);
             if (lastSourceAccepted) {
                 panel.entryEditorClosing(EntryEditor.this);
+            } else {
+                panel.runCommand(Actions.SAVE);
+                lastSourceAccepted = true;
             }
         } else {
-            panel.entryEditorClosing(EntryEditor.this);
+            if (lastFieldAccepted) {
+                panel.entryEditorClosing(EntryEditor.this);
+            } else {
+                panel.runCommand(Actions.SAVE);
+                lastFieldAccepted = true;
+            }
         }
     }
 
@@ -1083,6 +1088,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
         @Override
         public void actionPerformed(ActionEvent e) {
             close();
+
         }
     }
 
@@ -1118,6 +1124,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
                 if ((cleaned == null) || cleaned.equals(newValue)) {
                     textField.setValidBackgroundColor();
                 } else {
+                    lastFieldAccepted = false;
                     textField.setInvalidBackgroundColor();
                     if (!SwingUtilities.isEventDispatchThread()) {
                         JOptionPane.showMessageDialog(frame, Localization.lang("Invalid BibTeX key"),
@@ -1224,6 +1231,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
                         updateSource();
                         panel.markBaseChanged();
                     } catch (IllegalArgumentException ex) {
+                        lastFieldAccepted = false;
                         fieldEditor.setInvalidBackgroundColor();
                         if (!SwingUtilities.isEventDispatchThread()) {
                             JOptionPane.showMessageDialog(frame, Localization.lang("Error") + ": " + ex.getMessage(),


### PR DESCRIPTION
Something went wrong with the old PR dealing with this issue. So here a new PR. Fixes an issue with closing the entry editor. (I've discarded some additional save action, because this might not be the desired behaviour.)
Here again the bug:
Fixed close action of entry editor not working after parsing (and invalid field) error corrected.
1. generate parsing error in source tab
2. Save database
3. error message > Edit
4. correct parsing error
5. Close entry editor (x) blocked

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?

