### PR TITLE
Replace ".bib.swp" by ".bib.sav" for autosave file

### DIFF
--- a/src/main/java/net/sf/jabref/logic/autosaveandbackup/BackupManager.java
+++ b/src/main/java/net/sf/jabref/logic/autosaveandbackup/BackupManager.java
@@ -7,7 +7,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -21,6 +20,7 @@ import net.sf.jabref.logic.exporter.BibtexDatabaseWriter;
 import net.sf.jabref.logic.exporter.FileSaveSession;
 import net.sf.jabref.logic.exporter.SaveException;
 import net.sf.jabref.logic.exporter.SavePreferences;
+import net.sf.jabref.logic.util.io.FileUtil;
 import net.sf.jabref.model.database.BibDatabaseContext;
 import net.sf.jabref.model.database.event.BibDatabaseContextChangedEvent;
 import net.sf.jabref.preferences.JabRefPreferences;
@@ -97,10 +97,7 @@ public class BackupManager {
     }
 
     static Path getBackupPath(Path originalPath) {
-        Objects.requireNonNull(originalPath.getParent());
-        Path oldFileName = originalPath.getFileName();
-        String newFileName = oldFileName.toString() + BACKUP_FILENAME_ENDING;
-        return originalPath.getParent().resolve(newFileName);
+        return FileUtil.addExtension(originalPath, BACKUP_FILENAME_ENDING);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/autosaveandbackup/BackupManager.java
+++ b/src/main/java/net/sf/jabref/logic/autosaveandbackup/BackupManager.java
@@ -5,9 +5,9 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -37,7 +37,7 @@ public class BackupManager {
 
     private static final Log LOGGER = LogFactory.getLog(BackupManager.class);
 
-    private static final String BACKUP_FILENAME_ENDING = ".swp";
+    private static final String BACKUP_FILENAME_ENDING = ".sav";
 
     private static Set<BackupManager> runningInstances = new HashSet<>();
 
@@ -84,8 +84,6 @@ public class BackupManager {
     /**
      * Unregisters the BackupManager from the eventBus of {@link BibDatabaseContext} and deletes the backup file.
      * This method should only be used when closing a database/JabRef legally.
-     *
-     * @param bibDatabaseContext Associated {@link BibDatabaseContext}
      */
     private void shutdown() {
         bibDatabaseContext.getDatabase().unregisterListener(this);
@@ -96,6 +94,13 @@ public class BackupManager {
         } catch (IOException e) {
             LOGGER.error("Error while deleting the backup file.", e);
         }
+    }
+
+    static Path getBackupPath(Path originalPath) {
+        Objects.requireNonNull(originalPath.getParent());
+        Path oldFileName = originalPath.getFileName();
+        String newFileName = oldFileName.toString().replace(".bib", BACKUP_FILENAME_ENDING);
+        return originalPath.getParent().resolve(newFileName);
     }
 
     /**
@@ -111,7 +116,7 @@ public class BackupManager {
 
         if (originalFile.isPresent()) {
             backupManager.originalPath = originalFile.get().toPath();
-            backupManager.backupPath = Paths.get(backupManager.originalPath.toString() + BACKUP_FILENAME_ENDING);
+            backupManager.backupPath = getBackupPath(backupManager.originalPath);
             bibDatabaseContext.getDatabase().registerListener(backupManager);
             bibDatabaseContext.getMetaData().registerListener(backupManager);
             runningInstances.add(backupManager);
@@ -139,7 +144,7 @@ public class BackupManager {
      * @param originalPath Path to the file a backup should be checked for.
      */
     public static boolean checkForBackupFile(Path originalPath) {
-        Path backupPath = Paths.get(originalPath.toString() + BACKUP_FILENAME_ENDING);
+        Path backupPath = getBackupPath(originalPath);
         return Files.exists(backupPath) && !Files.isDirectory(backupPath);
     }
 
@@ -149,7 +154,7 @@ public class BackupManager {
      * @param originalPath Path to the file which should be equalized to the backup file.
      */
     public static void restoreBackup(Path originalPath) {
-        Path backupPath = Paths.get(originalPath.toString() + BACKUP_FILENAME_ENDING);
+        Path backupPath = getBackupPath(originalPath);
         try {
             Files.copy(backupPath, originalPath, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {

--- a/src/main/java/net/sf/jabref/logic/autosaveandbackup/BackupManager.java
+++ b/src/main/java/net/sf/jabref/logic/autosaveandbackup/BackupManager.java
@@ -99,7 +99,7 @@ public class BackupManager {
     static Path getBackupPath(Path originalPath) {
         Objects.requireNonNull(originalPath.getParent());
         Path oldFileName = originalPath.getFileName();
-        String newFileName = oldFileName.toString().replace(".bib", BACKUP_FILENAME_ENDING);
+        String newFileName = oldFileName.toString() + BACKUP_FILENAME_ENDING;
         return originalPath.getParent().resolve(newFileName);
     }
 

--- a/src/main/java/net/sf/jabref/logic/autosaveandbackup/BackupManager.java
+++ b/src/main/java/net/sf/jabref/logic/autosaveandbackup/BackupManager.java
@@ -37,7 +37,7 @@ public class BackupManager {
 
     private static final Log LOGGER = LogFactory.getLog(BackupManager.class);
 
-    private static final String BACKUP_FILENAME_ENDING = ".sav";
+    private static final String BACKUP_EXTENSION = ".sav";
 
     private static Set<BackupManager> runningInstances = new HashSet<>();
 
@@ -97,7 +97,7 @@ public class BackupManager {
     }
 
     static Path getBackupPath(Path originalPath) {
-        return FileUtil.addExtension(originalPath, BACKUP_FILENAME_ENDING);
+        return FileUtil.addExtension(originalPath, BACKUP_EXTENSION);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/logic/exporter/FileSaveSession.java
+++ b/src/main/java/net/sf/jabref/logic/exporter/FileSaveSession.java
@@ -67,8 +67,7 @@ public class FileSaveSession extends SaveSession {
             return;
         }
         if (backup && Files.exists(file)) {
-            Path fileName = file.getFileName();
-            Path backupFile = file.resolveSibling(fileName + BACKUP_EXTENSION);
+            Path backupFile = FileUtil.addExtension(file, BACKUP_EXTENSION);
             FileUtil.copyFile(file, backupFile, true);
         }
         try {

--- a/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
@@ -68,6 +68,19 @@ public class FileUtil {
     }
 
     /**
+     * Adds an extension to the given file name. The original extension is not replaced. That means,
+     * "demo.bib", ".sav" gets "demo.bib.sav" and not "demo.sav"
+     *
+     * @param path the path to add the extension to
+     * @param extension the extension to add
+     * @return the with the modified file name
+     */
+    public static Path addExtension(Path path, String extension) {
+        Path fileName = path.getFileName();
+        return path.resolveSibling(fileName + extension);
+    }
+
+    /**
      * Creates the minimal unique path substring for each file among multiple file paths.
      *
      * @param paths the file paths

--- a/src/test/java/net/sf/jabref/logic/autosaveandbackup/BackupManagerTest.java
+++ b/src/test/java/net/sf/jabref/logic/autosaveandbackup/BackupManagerTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 public class BackupManagerTest {
 
     @Test
-    public void testBackupFileNameGenerationWithLinuxPath() {
+    public void backupFileNameIsCorrectlyGeneratedWithinTmpDirectory() {
         Path bibPath = Paths.get("tmp", "test.bib");
         Path savPath = BackupManager.getBackupPath(bibPath);
         Assert.assertEquals(Paths.get("tmp", "test.bib.sav"), savPath);

--- a/src/test/java/net/sf/jabref/logic/autosaveandbackup/BackupManagerTest.java
+++ b/src/test/java/net/sf/jabref/logic/autosaveandbackup/BackupManagerTest.java
@@ -12,7 +12,7 @@ public class BackupManagerTest {
     public void testBackupFileNameGenerationWithLinuxPath() {
         Path bibPath = Paths.get("tmp", "test.bib");
         Path savPath = BackupManager.getBackupPath(bibPath);
-        Assert.assertEquals(Paths.get("tmp", "test.sav"), savPath);
+        Assert.assertEquals(Paths.get("tmp", "test.bib.sav"), savPath);
     }
 
 }

--- a/src/test/java/net/sf/jabref/logic/autosaveandbackup/BackupManagerTest.java
+++ b/src/test/java/net/sf/jabref/logic/autosaveandbackup/BackupManagerTest.java
@@ -1,0 +1,18 @@
+package net.sf.jabref.logic.autosaveandbackup;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BackupManagerTest {
+
+    @Test
+    public void testBackupFileNameGenerationWithLinuxPath() {
+        Path bibPath = Paths.get("tmp", "test.bib");
+        Path savPath = BackupManager.getBackupPath(bibPath);
+        Assert.assertEquals(Paths.get("tmp", "test.sav"), savPath);
+    }
+
+}

--- a/src/test/java/net/sf/jabref/logic/util/io/FileUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/io/FileUtilTest.java
@@ -43,6 +43,18 @@ public class FileUtilTest {
     }
 
     @Test
+    public void extensionBakAddedCorrectly() {
+        assertEquals(Paths.get("demo.bib.bak"),
+                FileUtil.addExtension(Paths.get("demo.bib"), ".bak"));
+    }
+
+    @Test
+    public void extensionBakAddedCorrectlyToAFileContainedInTmpDirectory() {
+        assertEquals(Paths.get("tmp", "demo.bib.bak"),
+                FileUtil.addExtension(Paths.get("tmp", "demo.bib"), ".bak"));
+    }
+
+    @Test
     public void testGetLinkedFileNameDefault() {
         // bibkey - title
         String fileNamePattern = "\\bibtexkey\\begin{title} - \\format[RemoveBrackets]{\\title}\\end{title}";


### PR DESCRIPTION
While updating `.gitignore` files to contain `.bib.swp`, I [saw that there is a WinEdt setting for `*.sav`](https://www.gitignore.io/api/latex). To avoid complaints by users, I think, we should also use `.sav` for the autosave extension.

I know, that this is the typical backup functionality. However, we use `.bak` during saving an thus, I opted for `.sav`.

WinEdt settings:

![WinEdt Settings](http://i.stack.imgur.com/Hi78O.png)

Source: http://tex.stackexchange.com/a/240965/9075