### PR TITLE
Fix for #2184: Add space after separator

### DIFF
--- a/src/main/java/net/sf/jabref/model/groups/KeywordGroup.java
+++ b/src/main/java/net/sf/jabref/model/groups/KeywordGroup.java
@@ -96,7 +96,7 @@ public class KeywordGroup extends AbstractGroup {
                 if (!contains(entry)) {
                     String oldContent = entry.getField(searchField).orElse(null);
                     String newContent = (oldContent == null ? "" : oldContent
-                            + keywordSeparator)
+                            + keywordSeparator + " ")
                             + searchExpression;
                     entry.setField(searchField, newContent);
 

--- a/src/main/java/net/sf/jabref/model/groups/KeywordGroup.java
+++ b/src/main/java/net/sf/jabref/model/groups/KeywordGroup.java
@@ -9,6 +9,7 @@ import java.util.regex.PatternSyntaxException;
 
 import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.model.entry.KeywordList;
 import net.sf.jabref.model.strings.StringUtil;
 
 import org.apache.commons.logging.Log;
@@ -95,9 +96,9 @@ public class KeywordGroup extends AbstractGroup {
             for (BibEntry entry : entriesToAdd) {
                 if (!contains(entry)) {
                     String oldContent = entry.getField(searchField).orElse(null);
-                    String newContent = (oldContent == null ? "" : oldContent
-                            + keywordSeparator + " ")
-                            + searchExpression;
+                    KeywordList wordlist = KeywordList.parse(oldContent, keywordSeparator);
+                    wordlist.add(searchExpression);
+                    String newContent = wordlist.getAsString(keywordSeparator);
                     entry.setField(searchField, newContent);
 
                     // Store change information.

--- a/src/test/java/net/sf/jabref/model/groups/ExplicitGroupTest.java
+++ b/src/test/java/net/sf/jabref/model/groups/ExplicitGroupTest.java
@@ -5,52 +5,58 @@ import java.util.Optional;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 public class ExplicitGroupTest {
 
+    private ExplicitGroup group;
+    private ExplicitGroup group2;
+
+    private BibEntry emptyEntry;
+
+    @Before
+    public void setUp() {
+        group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INDEPENDENT, ',');
+        group2 = new ExplicitGroup("myExplicitGroup2", GroupHierarchyType.INCLUDING, ',');
+        emptyEntry = new BibEntry();
+    }
 
     @Test
      public void testToStringSimple() {
-        ExplicitGroup group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INDEPENDENT, ',');
         assertEquals("ExplicitGroup:myExplicitGroup;0;", group.toString());
     }
 
     @Test
     public void toStringDoesNotWriteAssignedEntries() {
-        ExplicitGroup group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INCLUDING, ',');
-        group.add(new BibEntry());
-        assertEquals("ExplicitGroup:myExplicitGroup;2;", group.toString());
+        group.add(emptyEntry);
+
+        assertEquals("ExplicitGroup:myExplicitGroup;0;", group.toString());
     }
 
     @Test
-    public void testEntryStorageSingleGroups() {
-        BibEntry entry = new BibEntry();
-        ExplicitGroup group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INDEPENDENT, ',');
-        group.add(entry);
-        assertEquals(Optional.of("myExplicitGroup"), entry.getField(FieldName.GROUPS));
+    public void addSingleGroupToBibEntrySuccessfullyIfEmptyBefore() {
+        group.add(emptyEntry);
+
+        assertEquals(Optional.of("myExplicitGroup"), emptyEntry.getField(FieldName.GROUPS));
     }
 
     @Test
-    public void testEntryStorageTwoGroups() {
-        BibEntry entry = new BibEntry();
-        ExplicitGroup group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INDEPENDENT, ',');
-        ExplicitGroup group2 = new ExplicitGroup("myExplicitGroup2", GroupHierarchyType.INDEPENDENT, ',');
-        group.add(entry);
-        group2.add(entry);
-        assertEquals(Optional.of("myExplicitGroup, myExplicitGroup2"), entry.getField(FieldName.GROUPS));
+    public void addTwoGroupsToBibEntrySuccessfully() {
+        group.add(emptyEntry);
+        group2.add(emptyEntry);
+
+        assertEquals(Optional.of("myExplicitGroup, myExplicitGroup2"), emptyEntry.getField(FieldName.GROUPS));
     }
 
     @Test
-    public void testGroupStorageAlreadyInGroup() throws Exception {
-        ExplicitGroup group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INDEPENDENT, ',');
-        BibEntry entry = new BibEntry().withField(FieldName.GROUPS, "myExplicitGroup");
+    public void noDuplicateStoredIfAlreadyInGroup() throws Exception {
+        emptyEntry.setField(FieldName.GROUPS, "myExplicitGroup");
+        group.add(emptyEntry);
 
-        group.add(entry);
-
-        assertEquals(Optional.of("myExplicitGroup"), entry.getField(FieldName.GROUPS));
+        assertEquals(Optional.of("myExplicitGroup"), emptyEntry.getField(FieldName.GROUPS));
     }
 
 }

--- a/src/test/java/net/sf/jabref/model/groups/ExplicitGroupTest.java
+++ b/src/test/java/net/sf/jabref/model/groups/ExplicitGroupTest.java
@@ -1,8 +1,9 @@
 package net.sf.jabref.model.groups;
 
+import java.util.Optional;
+
 import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.model.entry.BibtexEntryTypes;
-import net.sf.jabref.model.entry.IdGenerator;
+import net.sf.jabref.model.entry.FieldName;
 
 import org.junit.Test;
 
@@ -20,17 +21,36 @@ public class ExplicitGroupTest {
     @Test
     public void toStringDoesNotWriteAssignedEntries() {
         ExplicitGroup group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INCLUDING, ',');
-        group.add(makeBibtexEntry());
+        group.add(new BibEntry());
         assertEquals("ExplicitGroup:myExplicitGroup;2;", group.toString());
     }
 
-    private BibEntry makeBibtexEntry() {
-        BibEntry e = new BibEntry(IdGenerator.next(), BibtexEntryTypes.INCOLLECTION.getName());
-        e.setField("title", "Marine finfish larviculture in Europe");
-        e.setField("bibtexkey", "shields01");
-        e.setField("year", "2001");
-        e.setField("author", "Kevin Shields");
-        return e;
+    @Test
+    public void testEntryStorageSingleGroups() {
+        BibEntry entry = new BibEntry();
+        ExplicitGroup group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INDEPENDENT, ',');
+        group.add(entry);
+        assertEquals(Optional.of("myExplicitGroup"), entry.getField(FieldName.GROUPS));
+    }
+
+    @Test
+    public void testEntryStorageTwoGroups() {
+        BibEntry entry = new BibEntry();
+        ExplicitGroup group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INDEPENDENT, ',');
+        ExplicitGroup group2 = new ExplicitGroup("myExplicitGroup2", GroupHierarchyType.INDEPENDENT, ',');
+        group.add(entry);
+        group2.add(entry);
+        assertEquals(Optional.of("myExplicitGroup, myExplicitGroup2"), entry.getField(FieldName.GROUPS));
+    }
+
+    @Test
+    public void testGroupStorageAlreadyInGroup() throws Exception {
+        ExplicitGroup group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INDEPENDENT, ',');
+        BibEntry entry = new BibEntry().withField(FieldName.GROUPS, "myExplicitGroup");
+
+        group.add(entry);
+
+        assertEquals(Optional.of("myExplicitGroup"), entry.getField(FieldName.GROUPS));
     }
 
 }

--- a/src/test/java/net/sf/jabref/model/groups/KeywordGroupTest.java
+++ b/src/test/java/net/sf/jabref/model/groups/KeywordGroupTest.java
@@ -1,6 +1,9 @@
 package net.sf.jabref.model.groups;
 
+import java.util.Optional;
+
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.model.entry.FieldName;
 
 import org.junit.Test;
 
@@ -84,5 +87,38 @@ public class KeywordGroupTest {
         BibEntry entry = new BibEntry().withField("keywords", "Some sentence containing test word");
 
         assertTrue(group.isMatch(entry));
+    }
+
+    @Test
+    public void testGroupStorageEmptyKeywords() throws Exception {
+        KeywordGroup group = new KeywordGroup("name", FieldName.KEYWORDS, "test", false, false, GroupHierarchyType.INDEPENDENT,
+                ',');
+        BibEntry entry = new BibEntry();
+
+        group.add(entry);
+
+        assertEquals(Optional.of("test"), entry.getField(FieldName.KEYWORDS));
+    }
+
+    @Test
+    public void testGroupStorageExistingKeywords() throws Exception {
+        KeywordGroup group = new KeywordGroup("name", FieldName.KEYWORDS, "test", false, false, GroupHierarchyType.INDEPENDENT,
+                ',');
+        BibEntry entry = new BibEntry().withField(FieldName.KEYWORDS, "bla, blubb");
+
+        group.add(entry);
+
+        assertEquals(Optional.of("bla, blubb, test"), entry.getField(FieldName.KEYWORDS));
+    }
+
+    @Test
+    public void testGroupStorageAlreadyInGroup() throws Exception {
+        KeywordGroup group = new KeywordGroup("name", FieldName.KEYWORDS, "test", false, false, GroupHierarchyType.INDEPENDENT,
+                ',');
+        BibEntry entry = new BibEntry().withField(FieldName.KEYWORDS, "test, blubb");
+
+        group.add(entry);
+
+        assertEquals(Optional.of("test, blubb"), entry.getField(FieldName.KEYWORDS));
     }
 }

--- a/src/test/java/net/sf/jabref/model/groups/KeywordGroupTest.java
+++ b/src/test/java/net/sf/jabref/model/groups/KeywordGroupTest.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -12,113 +13,98 @@ import static org.junit.Assert.assertTrue;
 
 public class KeywordGroupTest {
 
+    private KeywordGroup keywordTestGroup;
+    private KeywordGroup complexKeywordGroup;
+    private BibEntry emptyEntry;
+
+    @Before
+    public void setUp() {
+        keywordTestGroup = new KeywordGroup("name", "keywords", "test", false, false, GroupHierarchyType.INDEPENDENT, ',');
+        complexKeywordGroup = new KeywordGroup("name", "keywords", "\\H2O", false, false, GroupHierarchyType.INDEPENDENT, ',');
+        emptyEntry = new BibEntry();
+    }
+
     @Test
     public void testToString() {
-        KeywordGroup group = new KeywordGroup("myExplicitGroup", "author", "asdf", true, true,
-                GroupHierarchyType.INDEPENDENT, ',');
-        assertEquals("KeywordGroup:myExplicitGroup;0;author;asdf;1;1;", group.toString());
+        assertEquals("KeywordGroup:name;0;keywords;test;0;0;", keywordTestGroup.toString());
     }
 
     @Test
     public void testToString2() {
-        KeywordGroup group = new KeywordGroup("myExplicitGroup", "author", "asdf", false, true,
+        KeywordGroup anotherGroup = new KeywordGroup("myExplicitGroup", "author", "asdf", false, true,
                 GroupHierarchyType.REFINING, ',');
-        assertEquals("KeywordGroup:myExplicitGroup;1;author;asdf;0;1;", group.toString());
+        assertEquals("KeywordGroup:myExplicitGroup;1;author;asdf;0;1;", anotherGroup.toString());
     }
 
     @Test
     public void containsSimpleWord() {
-        KeywordGroup group = new KeywordGroup("name", "keywords", "test", false, false, GroupHierarchyType.INDEPENDENT,
-                ',');
-        BibEntry entry = new BibEntry().withField("keywords", "test");
+        emptyEntry.setField("keywords", "test");
 
-        assertTrue(group.isMatch(entry));
+        assertTrue(keywordTestGroup.isMatch(emptyEntry));
     }
 
     @Test
     public void containsSimpleWordInSentence() throws Exception {
-        KeywordGroup group = new KeywordGroup("name", "keywords", "test", false, false, GroupHierarchyType.INDEPENDENT,
-                ',');
-        BibEntry entry = new BibEntry().withField("keywords", "Some sentence containing test word");
+        emptyEntry.setField("keywords", "Some sentence containing test word");
 
-        assertTrue(group.isMatch(entry));
+        assertTrue(keywordTestGroup.isMatch(emptyEntry));
     }
 
     @Test
     public void containsSimpleWordCommaSeparated() throws Exception {
-        KeywordGroup group = new KeywordGroup("name", "keywords", "test", false, false, GroupHierarchyType.INDEPENDENT,
-                ',');
-        BibEntry entry = new BibEntry().withField("keywords", "Some,list,containing,test,word");
+        emptyEntry.setField("keywords", "Some,list,containing,test,word");
 
-        assertTrue(group.isMatch(entry));
+        assertTrue(keywordTestGroup.isMatch(emptyEntry));
     }
 
     @Test
     public void containsSimpleWordSemicolonSeparated() throws Exception {
-        KeywordGroup group = new KeywordGroup("name", "keywords", "test", false, false, GroupHierarchyType.INDEPENDENT,
-                ',');
-        BibEntry entry = new BibEntry().withField("keywords", "Some;list;containing;test;word");
+        emptyEntry.setField("keywords", "Some;list;containing;test;word");
 
-        assertTrue(group.isMatch(entry));
+        assertTrue(keywordTestGroup.isMatch(emptyEntry));
     }
 
     @Test
     public void containsComplexWord() throws Exception {
-        KeywordGroup group = new KeywordGroup("name", "keywords", "\\H2O", false, false, GroupHierarchyType.INDEPENDENT,
-                ',');
-        BibEntry entry = new BibEntry().withField("keywords", "\\H2O");
+        emptyEntry.setField("keywords", "\\H2O");
 
-        assertTrue(group.isMatch(entry));
+        assertTrue(complexKeywordGroup.isMatch(emptyEntry));
     }
 
     @Test
     public void containsComplexWordInSentence() throws Exception {
-        KeywordGroup group = new KeywordGroup("name", "keywords", "\\H2O", false, false, GroupHierarchyType.INDEPENDENT,
-                ',');
-        BibEntry entry = new BibEntry().withField("keywords", "Some sentence containing \\H2O word");
+        emptyEntry.setField("keywords", "Some sentence containing \\H2O word");
 
-        assertTrue(group.isMatch(entry));
+        assertTrue(complexKeywordGroup.isMatch(emptyEntry));
     }
 
     @Test
     public void containsWordWithWhitespaceInSentence() throws Exception {
-        KeywordGroup group = new KeywordGroup("name", "keywords", "test word", false, false,
-                GroupHierarchyType.INDEPENDENT, ',');
-        BibEntry entry = new BibEntry().withField("keywords", "Some sentence containing test word");
+        emptyEntry.setField("keywords", "Some sentence containing test word");
 
-        assertTrue(group.isMatch(entry));
+        assertTrue(keywordTestGroup.isMatch(emptyEntry));
     }
 
     @Test
-    public void testGroupStorageEmptyKeywords() throws Exception {
-        KeywordGroup group = new KeywordGroup("name", FieldName.KEYWORDS, "test", false, false, GroupHierarchyType.INDEPENDENT,
-                ',');
-        BibEntry entry = new BibEntry();
+    public void addGroupToBibEntrySuccessfullyIfEmptyBefore() throws Exception {
+        keywordTestGroup.add(emptyEntry);
 
-        group.add(entry);
-
-        assertEquals(Optional.of("test"), entry.getField(FieldName.KEYWORDS));
+        assertEquals(Optional.of("test"), emptyEntry.getField(FieldName.KEYWORDS));
     }
 
     @Test
-    public void testGroupStorageExistingKeywords() throws Exception {
-        KeywordGroup group = new KeywordGroup("name", FieldName.KEYWORDS, "test", false, false, GroupHierarchyType.INDEPENDENT,
-                ',');
-        BibEntry entry = new BibEntry().withField(FieldName.KEYWORDS, "bla, blubb");
+    public void addGroupToBibEntrySuccessfullyIfNotEmptyBefore() throws Exception {
+        emptyEntry.setField(FieldName.KEYWORDS, "bla, blubb");
+        keywordTestGroup.add(emptyEntry);
 
-        group.add(entry);
-
-        assertEquals(Optional.of("bla, blubb, test"), entry.getField(FieldName.KEYWORDS));
+        assertEquals(Optional.of("bla, blubb, test"), emptyEntry.getField(FieldName.KEYWORDS));
     }
 
     @Test
-    public void testGroupStorageAlreadyInGroup() throws Exception {
-        KeywordGroup group = new KeywordGroup("name", FieldName.KEYWORDS, "test", false, false, GroupHierarchyType.INDEPENDENT,
-                ',');
-        BibEntry entry = new BibEntry().withField(FieldName.KEYWORDS, "test, blubb");
+    public void noDuplicateStoredIfAlreadyInGroup() throws Exception {
+        emptyEntry.setField(FieldName.KEYWORDS, "test, blubb");
+        keywordTestGroup.add(emptyEntry);
 
-        group.add(entry);
-
-        assertEquals(Optional.of("test, blubb"), entry.getField(FieldName.KEYWORDS));
+        assertEquals(Optional.of("test, blubb"), emptyEntry.getField(FieldName.KEYWORDS));
     }
 }


### PR DESCRIPTION
... seems to be as simple as that.

Change has been introduced as the delimitor is no longer saved as a String ", " but as a `Character` which chops away the space after the comma.

- ~~[ ] Change in CHANGELOG.md described~~ introduced in dev Builds
- [x] Tests created for changes
- ~~[ ] Screenshots added (for bigger UI changes)~~
- [x] Manually tested changed features in running JabRef
- ~~[ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)~~
- ~~[ ] If you changed the localization: Did you run `gradle localizationUpdate`?~~

