### PR TITLE
Typos Field name constants

### DIFF
--- a/src/main/java/net/sf/jabref/model/entry/FieldName.java
+++ b/src/main/java/net/sf/jabref/model/entry/FieldName.java
@@ -46,9 +46,9 @@ public class FieldName {
     public static final String EDITORB = "editorb";
     public static final String EDITORC = "editorc";
     public static final String EDITORTYPE = "editortype";
-    public static final String EDITORTYPEA = "editortypea";
-    public static final String EDITORTYPEB = "editortypeb";
-    public static final String EDITORTYPEC = "editortypec";
+    public static final String EDITORATYPE = "editoratype";
+    public static final String EDITORBTYPE = "editorbtype";
+    public static final String EDITORCTYPE = "editorctype";
     public static final String EID = "eid";
     public static final String ENTRYSET = "entryset";
     public static final String EPRINT = "eprint";

--- a/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
+++ b/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
@@ -51,7 +51,7 @@ public class InternalBibtexFields {
             FieldName.NAMEADDON, FieldName.ASSIGNEE);
 
     private static final List<String> BIBLATEX_EDITOR_TYPE_FIELDS = Arrays.asList(FieldName.EDITORTYPE,
-            FieldName.EDITORTYPEA, FieldName.EDITORTYPEB, FieldName.EDITORTYPEC);
+            FieldName.EDITORATYPE, FieldName.EDITORBTYPE, FieldName.EDITORCTYPE);
 
     private static final List<String> BIBLATEX_PAGINATION_FIELDS = Arrays.asList(FieldName.PAGINATION,
             FieldName.BOOKPAGINATION);


### PR DESCRIPTION
I made a mistake (typos) in #2186. This PR corrects the typos (editoratype). Sorry for that.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?

