### PR TITLE
Prevent the search to get focus when deleting/pasting an entry

### DIFF
--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -772,6 +772,13 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             return;
         }
 
+        // select the next entry to stay at the same place as before (or the previous if we're already at the end)
+        if (mainTable.getSelectedRow() != mainTable.getRowCount() -1){
+            selectNextEntry();
+        } else {
+            selectPreviousEntry();
+        }
+
         NamedCompound compound = new NamedCompound(
                 (entries.size() > 1 ? Localization.lang("delete entries") : Localization.lang("delete entry")));
         for (BibEntry entry : entries) {
@@ -784,6 +791,9 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
         markBaseChanged();
         frame.output(formatOutputMessage(Localization.lang("Deleted"), entries.size()));
+
+        // prevent the main table from loosing focus
+        mainTable.requestFocus();
     }
 
     private void paste() {
@@ -827,11 +837,12 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             output(formatOutputMessage(Localization.lang("Pasted"), bes.size()));
             markBaseChanged();
 
+            highlightEntry(firstBE);
+            mainTable.requestFocus();
+
             if (Globals.prefs.getBoolean(JabRefPreferences.AUTO_OPEN_FORM)) {
                 selectionListener.editSignalled(firstBE);
             }
-
-            highlightEntry(firstBE);
         }
     }
 
@@ -1724,7 +1735,6 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
     public void selectNextEntry() {
         highlightEntry((mainTable.getSelectedRow() + 1) % mainTable.getRowCount());
     }
-
 
     public void selectFirstEntry() {
         highlightEntry(0);

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -750,7 +750,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
      * Removes the selected entries from the database
      * @param cut If false the user will get asked if he really wants to delete the entries, and it will be localized
      *            as "deleted".
-     *            If true it will be localized as "cut"
+     *            If true the action will be localized as "cut"
      */
     private void delete(boolean cut) {
         List<BibEntry> entries = mainTable.getSelectedEntries();
@@ -769,12 +769,12 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         }
 
         NamedCompound compound;
-        if (!cut) {
-            compound = new NamedCompound(
-                    (entries.size() > 1 ? Localization.lang("delete entries") : Localization.lang("delete entry")));
-        } else {
+        if (cut) {
             compound = new NamedCompound(
                     (entries.size() > 1 ? Localization.lang("cut entries") : Localization.lang("cut entry")));
+        } else {
+            compound = new NamedCompound(
+                    (entries.size() > 1 ? Localization.lang("delete entries") : Localization.lang("delete entry")));
         }
         for (BibEntry entry : entries) {
             compound.addEdit(new UndoableRemoveEntry(bibDatabaseContext.getDatabase(), entry, BasePanel.this));
@@ -785,7 +785,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         getUndoManager().addEdit(compound);
 
         markBaseChanged();
-        frame.output(formatOutputMessage(!cut ? Localization.lang("Deleted") : Localization.lang("Cut"), entries.size()));
+        frame.output(formatOutputMessage(cut ? Localization.lang("Cut") : Localization.lang("Deleted"), entries.size()));
 
         // prevent the main table from loosing focus
         mainTable.requestFocus();

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableSelectionListener.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableSelectionListener.java
@@ -183,11 +183,10 @@ public class MainTableSelectionListener implements ListEventListener<BibEntry>, 
 
     public void editSignalled(BibEntry entry) {
         final BasePanelMode mode = panel.getMode();
-        EntryEditor editor = panel.getEntryEditor(entry);
         if (mode != BasePanelMode.SHOWING_EDITOR) {
-            panel.showEntryEditor(editor);
+            panel.showEntryEditor(panel.getEntryEditor(entry));
         }
-        editor.requestFocus();
+        panel.getCurrentEditor().requestFocus();
     }
 
     @Override


### PR DESCRIPTION
Fixes: #2208

When you delete an entry the focus will no longer jump to the searchbar, instead it will select the next entry (also counts for pasting).