### PR TITLE
Improvements to the JavaFX Error Console

### DIFF
--- a/src/main/java/net/sf/jabref/gui/errorconsole/ErrorConsoleController.java
+++ b/src/main/java/net/sf/jabref/gui/errorconsole/ErrorConsoleController.java
@@ -1,7 +1,5 @@
 package net.sf.jabref.gui.errorconsole;
 
-import java.util.stream.Collectors;
-
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
@@ -13,7 +11,6 @@ import javafx.scene.input.KeyEvent;
 import javafx.stage.Stage;
 
 import net.sf.jabref.Globals;
-import net.sf.jabref.gui.ClipBoardManager;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.gui.keyboard.KeyBindingPreferences;
@@ -61,7 +58,7 @@ public class ErrorConsoleController {
         if (keyPreferences.checkKeyCombinationEquality(KeyBinding.COPY, event)) {
             ObservableList<LogEvent> selectedEntries = allMessages.getSelectionModel().getSelectedItems();
             if (!selectedEntries.isEmpty()) {
-                new ClipBoardManager().setClipboardContents(selectedEntries.stream().map(message -> message.getMessage().getFormattedMessage()).collect(Collectors.joining(System.lineSeparator())));
+                errorViewModel.copyLog(selectedEntries);
             }
         }
     }

--- a/src/main/java/net/sf/jabref/gui/errorconsole/ErrorConsoleViewModel.java
+++ b/src/main/java/net/sf/jabref/gui/errorconsole/ErrorConsoleViewModel.java
@@ -5,8 +5,10 @@ import java.net.URISyntaxException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.stream.Collectors;
 
 import javafx.beans.property.ListProperty;
+import javafx.collections.ObservableList;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefGUI;
@@ -34,23 +36,30 @@ public class ErrorConsoleViewModel {
     }
 
     /**
-     * Handler for get of log messages in listview
+     * Concatenates the formatted message of the given LogEvents by using the a new line separator
      *
+     * @param selectedEntries as {@link ObservableList<LogEvent>}
      * @return all messages as String
      */
-    private String getLogMessagesAsString() {
-        StringBuilder logMessagesContent = new StringBuilder();
-        for (LogEvent message : allMessagesDataproperty()) {
-            logMessagesContent.append(message.getMessage().getFormattedMessage() + System.lineSeparator());
-        }
-        return logMessagesContent.toString();
+    private String getLogMessagesAsString(ObservableList<LogEvent> selectedEntries) {
+        String logMessagesContent = selectedEntries.stream().map(message -> message.getMessage().getFormattedMessage()).collect(Collectors.joining(System.lineSeparator()));
+        return logMessagesContent;
     }
 
     /**
-     * Handler for copy of Log Entry in clipboard by click of Copy Log Button
+     * Copies the whole log to the clipboard
      */
     public void copyLog() {
-        new ClipBoardManager().setClipboardContents(getLogMessagesAsString());
+        copyLog(allMessagesData);
+    }
+
+    /**
+     * Copies the selected LogEvents to the Clipboard
+     *
+     * @param selectedEntries as ObservableList of LogEvents
+     */
+    public void copyLog(ObservableList<LogEvent> selectedEntries) {
+        new ClipBoardManager().setClipboardContents(getLogMessagesAsString(selectedEntries));
         JabRefGUI.getMainFrame().output(Localization.lang("Log copied to clipboard."));
     }
 
@@ -71,7 +80,7 @@ public class ErrorConsoleViewModel {
                     .setParameter("title", issueTitle).setParameter("body", issueBody);
             JabRefDesktop.openBrowser(uriBuilder.build().toString());
             // Format the contents of listview in Issue Description
-            String issueDetails = ("<details>\n" + "<summary>" + "Detail information:" + "</summary>\n```\n" + getLogMessagesAsString() + "\n```\n</details>");
+            String issueDetails = ("<details>\n" + "<summary>" + "Detail information:" + "</summary>\n```\n" + getLogMessagesAsString(allMessagesData) + "\n```\n</details>");
             new ClipBoardManager().setClipboardContents(issueDetails);
         } catch (IOException e) {
             LOGGER.error(e);

--- a/src/main/resources/net/sf/jabref/gui/errorconsole/ErrorConsole.css
+++ b/src/main/resources/net/sf/jabref/gui/errorconsole/ErrorConsole.css
@@ -13,6 +13,11 @@
 .list-cell {
     -fx-background-color: white;
  }
+
+.list-cell:selected {
+	-fx-background-color: blue;
+	-fx-text-fill: white;
+}
  
  .icon {
  	-fx-font-family: 'Material Design Icons';

--- a/src/main/resources/net/sf/jabref/gui/errorconsole/ErrorConsole.fxml
+++ b/src/main/resources/net/sf/jabref/gui/errorconsole/ErrorConsole.fxml
@@ -23,7 +23,7 @@
                 </ButtonBar>
             </bottom>
             <center>
-                <ListView fx:id="allMessages" styleClass="list-content" BorderPane.alignment="CENTER" />
+                <ListView fx:id="allMessages" onKeyPressed="#copySelectedLogEntries" styleClass="list-content" BorderPane.alignment="CENTER" />
             </center>
         </BorderPane>
     </content>


### PR DESCRIPTION
The log messages in the list view of the error console can now be selected and copied. The error message will also automatically scroll to the newest log message. Refs #2210 
