### PR TITLE
Fix strange styling behaviour of the error console

### DIFF
--- a/src/main/java/net/sf/jabref/gui/errorconsole/ErrorConsoleController.java
+++ b/src/main/java/net/sf/jabref/gui/errorconsole/ErrorConsoleController.java
@@ -3,12 +3,11 @@ package net.sf.jabref.gui.errorconsole;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
-import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.stage.Stage;
-import javafx.util.Callback;
 
 import net.sf.jabref.gui.IconTheme;
+import net.sf.jabref.gui.util.ViewModelListCellFactory;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
@@ -59,43 +58,35 @@ public class ErrorConsoleController {
      */
     private void listViewStyle() {
         // Handler for listCell appearance (example for exception Cell)
-        allMessages.setCellFactory(
-                new Callback<ListView<LogEvent>, ListCell<LogEvent>>() {
-                    @Override
-                    public ListCell<LogEvent> call(
-                            ListView<LogEvent> listView) {
-                        return new ListCell<LogEvent>() {
-
-                            @Override
-                            public void updateItem(LogEvent logMessage, boolean empty) {
-                                super.updateItem(logMessage, empty);
-                                if (logMessage != null) {
-                                    setText(logMessage.getMessage().toString());
-
-                                    Level logLevel = logMessage.getLevel();
-                                    switch (logLevel.getStandardLevel()) {
-                                        case ERROR:
-                                            getStyleClass().add("exception");
-                                            setGraphic(IconTheme.JabRefIcon.INTEGRITY_FAIL.getGraphicNode());
-                                            break;
-                                        case WARN:
-                                            getStyleClass().add("output");
-                                            setGraphic(IconTheme.JabRefIcon.INTEGRITY_WARN.getGraphicNode());
-                                            break;
-                                        case INFO:
-                                            getStyleClass().add("log");
-                                            setGraphic(IconTheme.JabRefIcon.INTEGRITY_INFO.getGraphicNode());
-                                            break;
-                                        default:
-                                            setText(null);
-                                            setGraphic(null);
-                                            break;
-                                    }
-                                }
-                            }
-                        };
+        allMessages.setCellFactory(new ViewModelListCellFactory<LogEvent>().
+                withGraphic( viewModel -> {
+                    Level logLevel = viewModel.getLevel();
+                    switch (logLevel.getStandardLevel()) {
+                        case ERROR:
+                            return (IconTheme.JabRefIcon.INTEGRITY_FAIL.getGraphicNode());
+                        case WARN:
+                            return (IconTheme.JabRefIcon.INTEGRITY_WARN.getGraphicNode());
+                        case INFO:
+                            return (IconTheme.JabRefIcon.INTEGRITY_INFO.getGraphicNode());
+                        default:
+                            return null;
                     }
-                });
+                }).
+                withStyleClass( viewModel -> {
+                    Level logLevel = viewModel.getLevel();
+                    switch (logLevel.getStandardLevel()) {
+                        case ERROR:
+                            return "exception";
+                        case WARN:
+                            return "output";
+                        case INFO:
+                            return "log";
+                        default:
+                            return null;
+                    }
+                }).
+                withText( viewModel -> viewModel.getMessage().getFormattedMessage())
+        );
     }
 
 }

--- a/src/main/java/net/sf/jabref/gui/errorconsole/ErrorConsoleView.java
+++ b/src/main/java/net/sf/jabref/gui/errorconsole/ErrorConsoleView.java
@@ -1,18 +1,3 @@
-/*  Copyright (C) 2016 JabRef contributors.
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*/
 package net.sf.jabref.gui.errorconsole;
 
 import javafx.scene.control.Alert.AlertType;

--- a/src/main/java/net/sf/jabref/gui/errorconsole/ErrorConsoleViewModel.java
+++ b/src/main/java/net/sf/jabref/gui/errorconsole/ErrorConsoleViewModel.java
@@ -1,18 +1,3 @@
-/*  Copyright (C) 2016 JabRef contributors.
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*/
 package net.sf.jabref.gui.errorconsole;
 
 import java.io.IOException;

--- a/src/main/java/net/sf/jabref/gui/util/ViewModelListCellFactory.java
+++ b/src/main/java/net/sf/jabref/gui/util/ViewModelListCellFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2003-2016 JabRef contributors.
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+package net.sf.jabref.gui.util;
+
+import javafx.event.EventHandler;
+import javafx.scene.Node;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.input.MouseEvent;
+import javafx.util.Callback;
+
+/**
+ * Constructs a {@link ListCell} based on the view model of the row and a bunch of specified converter methods.
+ *
+ * @param <T> cell value
+ */
+public class ViewModelListCellFactory<T> implements Callback<ListView<T>, ListCell<T>> {
+
+    private Callback<T, String> toText;
+    private Callback<T, Node> toGraphic;
+    private Callback<T, EventHandler<? super MouseEvent>> toOnMouseClickedEvent;
+    private Callback<T, String> toStyleClass;
+
+    public ViewModelListCellFactory<T> withText(Callback<T, String> toText) {
+        this.toText = toText;
+        return this;
+    }
+
+    public ViewModelListCellFactory<T> withGraphic(Callback<T, Node> toGraphic) {
+        this.toGraphic = toGraphic;
+        return this;
+    }
+
+    public ViewModelListCellFactory<T> withStyleClass(Callback<T, String> toStyleClass) {
+        this.toStyleClass = toStyleClass;
+        return this;
+    }
+
+    public ViewModelListCellFactory<T> withOnMouseClickedEvent(
+            Callback<T, EventHandler<? super MouseEvent>> toOnMouseClickedEvent) {
+        this.toOnMouseClickedEvent = toOnMouseClickedEvent;
+        return this;
+    }
+
+    @Override
+    public ListCell<T> call(ListView<T> param) {
+
+        return new ListCell<T>() {
+
+            @Override
+            protected void updateItem(T item, boolean empty) {
+                super.updateItem(item, empty);
+
+                T viewModel = getItem();
+                if (empty || viewModel == null) {
+                    setText(null);
+                    setGraphic(null);
+                    setOnMouseClicked(null);
+                } else {
+                    if (toText != null) {
+                        setText(toText.call(viewModel));
+                    }
+                    if (toGraphic != null) {
+                        setGraphic(toGraphic.call(viewModel));
+                    }
+                    if (toOnMouseClickedEvent != null) {
+                        setOnMouseClicked(toOnMouseClickedEvent.call(viewModel));
+                    }
+                    if (toStyleClass != null) {
+                        getStyleClass().clear();
+                        getStyleClass().add(toStyleClass.call(viewModel));
+                    }
+                }
+                getListView().refresh();
+            }
+        };
+    }
+}

--- a/src/main/java/net/sf/jabref/gui/util/ViewModelListCellFactory.java
+++ b/src/main/java/net/sf/jabref/gui/util/ViewModelListCellFactory.java
@@ -1,20 +1,3 @@
-/*
- * Copyright (C) 2003-2016 JabRef contributors.
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- */
-
 package net.sf.jabref.gui.util;
 
 import javafx.event.EventHandler;


### PR DESCRIPTION
This should fix the wrong styling behaviour of the different log messages when scrolling. It seems like the styling error came because we never resetted the style classes of the cells when adding new ones.
I also created a generic ListFactory class (similar to #1917) so this issue won't occur in the future. Refs #2210
