### PR TITLE
Fix editor freeze

### DIFF
--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -1614,29 +1614,17 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
         }
 
-        EntryEditor entryEditor;
-        int divLoc = -1;
         String visName = null;
         if ((getShowing() != null) && isShowingEditor()) {
             visName = ((EntryEditor) splitPane.getBottomComponent()).getVisiblePanelName();
         }
-        if (getShowing() != null) {
-            divLoc = splitPane.getDividerLocation();
-        }
 
         // We must instantiate a new editor.
-        entryEditor = new EntryEditor(frame, BasePanel.this, be);
+        EntryEditor entryEditor = new EntryEditor(frame, BasePanel.this, be);
         if (visName != null) {
             entryEditor.setVisiblePanel(visName);
         }
-        splitPane.setBottomComponent(entryEditor);
-
-        if (divLoc > 0) {
-            splitPane.setDividerLocation(divLoc);
-        } else {
-            splitPane.setDividerLocation(
-                    splitPane.getHeight() - Globals.prefs.getInt(JabRefPreferences.ENTRY_EDITOR_HEIGHT));
-        }
+        showEntryEditor(entryEditor);
 
         newEntryShowing(be);
         setEntryEditorEnabled(true); // Make sure it is enabled.
@@ -1650,15 +1638,10 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
      * @return A suitable entry editor.
      */
     public EntryEditor getEntryEditor(BibEntry entry) {
-        EntryEditor entryEditor;
-
-        // We must instantiate a new editor. First make sure the old one
-        // stores its last edit:
+        // We must instantiate a new editor. First make sure the old one stores its last edit:
         storeCurrentEdit();
         // Then start the new one:
-        entryEditor = new EntryEditor(frame, BasePanel.this, entry);
-
-        return entryEditor;
+        return new EntryEditor(frame, BasePanel.this, entry);
     }
 
     public EntryEditor getCurrentEditor() {
@@ -1677,6 +1660,9 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                     splitPane.getHeight() - splitPane.getDividerLocation());
         }
         mode = BasePanelMode.SHOWING_EDITOR;
+        if (currentEditor != null) {
+            currentEditor.setMovingToDifferentEntry();
+        }
         currentEditor = editor;
         splitPane.setBottomComponent(editor);
         if (editor.getEntry() != getShowing()) {

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -547,7 +547,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
                 // Set the current Entry to be selected.
                 // Fixes the bug of losing selection after, e.g. an autogeneration of a BibTeX key.
-                SwingUtilities.invokeLater(() -> panel.highlightEntry(entry));
+                panel.highlightEntry(entry);
             } catch (IOException ex) {
                 source.setText(ex.getMessage() + "\n\n" +
                         Localization.lang("Correct the entry, and reopen editor to display/edit source."));
@@ -781,7 +781,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
             // TODO: does updating work properly after source stored?
             panel.markBaseChanged();
 
-            SwingUtilities.invokeLater(() -> panel.highlightEntry(entry));
+            panel.highlightEntry(entry);
 
             return true;
         } catch (IllegalStateException | IOException ex) {
@@ -1153,7 +1153,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
             // Make sure we scroll to the entry if it moved in the table.
             // Should only be done if this editor is currently showing:
             if (!movingAway && isShowing()) {
-                SwingUtilities.invokeLater(() -> panel.highlightEntry(entry));
+                panel.highlightEntry(entry);
             }
         }
     }

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableSelectionListener.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableSelectionListener.java
@@ -117,12 +117,8 @@ public class MainTableSelectionListener implements ListEventListener<BibEntry>, 
                 if (oldEditor != null) {
                     visName = oldEditor.getVisiblePanelName();
                 }
-                // Get an old or new editor for the entry to edit:
+                // Get a new editor for the entry to edit:
                 EntryEditor newEditor = panel.getEntryEditor(newSelected);
-
-                if (oldEditor != null) {
-                    oldEditor.setMovingToDifferentEntry();
-                }
 
                 // Show the new editor unless it was already visible:
                 if (!Objects.equals(newEditor, oldEditor) || (mode != BasePanelMode.SHOWING_EDITOR)) {
@@ -132,6 +128,9 @@ public class MainTableSelectionListener implements ListEventListener<BibEntry>, 
                     }
                     panel.showEntryEditor(newEditor);
                     SwingUtilities.invokeLater(() -> table.ensureVisible(table.getSelectedRow()));
+                } else {
+                    // if not used destroy the EntryEditor
+                    newEditor.setMovingToDifferentEntry();
                 }
             } else {
                 // Either nothing or a preview was shown. Update the preview.


### PR DESCRIPTION
Possibly fixes: #2220.

Mainly I removed `SwingUtilities.invokeLater(() ->`. I also added some lines to remove the event listener from the old entry editors. 