### PR TITLE
Fix for #2218: Reenable ADS fetcher

### DIFF
--- a/src/test/java/net/sf/jabref/logic/importer/fetcher/AstrophysicsDataSystemTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fetcher/AstrophysicsDataSystemTest.java
@@ -13,7 +13,6 @@ import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.FieldName;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static net.sf.jabref.logic.util.OS.NEWLINE;
@@ -130,26 +129,22 @@ public class AstrophysicsDataSystemTest {
         luceyPaulEntry.setField("year", "2000");
     }
 
-    @Ignore
     @Test
     public void testHelpPage() {
         assertEquals("ADS", fetcher.getHelpPage().getPageName());
     }
 
-    @Ignore
     @Test
     public void testGetName() {
         assertEquals("SAO/NASA Astrophysics Data System", fetcher.getName());
     }
 
-    @Ignore
     @Test
     public void searchByQueryFindsEntry() throws Exception {
         List<BibEntry> fetchedEntries = fetcher.performSearch("Diez slice theorem");
         assertEquals(Collections.singletonList(diezSliceTheoremEntry), fetchedEntries);
     }
 
-    @Ignore
     @Test
     public void searchByEntryFindsEntry() throws Exception {
         BibEntry searchEntry = new BibEntry();
@@ -161,7 +156,6 @@ public class AstrophysicsDataSystemTest {
         assertEquals(diezSliceTheoremEntry, fetchedEntries.get(0));
     }
 
-    @Ignore
     @Test
     public void testPerformSearchByFamaeyMcGaughEntry() throws Exception {
         Optional<BibEntry> fetchedEntry = fetcher.performSearchById("10.12942/lrr-2012-10");
@@ -169,21 +163,18 @@ public class AstrophysicsDataSystemTest {
         assertEquals(Optional.of(famaeyMcGaughEntry), fetchedEntry);
     }
 
-    @Ignore
     @Test
     public void testPerformSearchByIdEmptyDOI() throws Exception {
         Optional<BibEntry> fetchedEntry = fetcher.performSearchById("");
         assertEquals(Optional.empty(), fetchedEntry);
     }
 
-    @Ignore
     @Test(expected = FetcherException.class)
     public void testPerformSearchByIdInvalidDoi() throws Exception {
         fetcher.performSearchById("this.doi.will.fail");
         fail();
     }
 
-    @Ignore
     @Test
     public void testPerformSearchBySunWelchEntry() throws Exception {
         Optional<BibEntry> fetchedEntry = fetcher.performSearchById("10.1038/nmat3160");
@@ -191,21 +182,18 @@ public class AstrophysicsDataSystemTest {
         assertEquals(Optional.of(sunWelchEntry), fetchedEntry);
     }
 
-    @Ignore
     @Test
     public void testPerformSearchByXiongSunEntry() throws Exception {
         Optional<BibEntry> fetchedEntry = fetcher.performSearchById("10.1109/TGRS.2006.890567");
         assertEquals(Optional.of(xiongSunEntry), fetchedEntry);
     }
 
-    @Ignore
     @Test
     public void testPerformSearchByIngersollPollardEntry() throws Exception {
         Optional<BibEntry> fetchedEntry = fetcher.performSearchById("10.1016/0019-1035(82)90169-5");
         assertEquals(Optional.of(ingersollPollardEntry), fetchedEntry);
     }
 
-    @Ignore
     @Test
     public void testPerformSearchByLuceyPaulEntry() throws Exception {
         Optional<BibEntry> fetchedEntry = fetcher.performSearchById("10.1029/1999JE001117");


### PR DESCRIPTION
(see #2218)

Fetcher is now working again...

- ~~[ ] Change in CHANGELOG.md described~~ affected search based fetcher still unreleased
- [x] Tests ~~created for changes~~ pass again
- ~~[ ] Screenshots added (for bigger UI changes)~~
- [x] Manually tested changed features in running JabRef
- ~~[ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)~~
- ~~[ ] If you changed the localization: Did you run `gradle localizationUpdate`?~~

