### PR TITLE
Fix medline fetcher by using https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,11 +64,12 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - [koppor/#97] (https://github.com/koppor/jabref/issues/97): When importing preferences, the explorer will start where the preferences are last exported
 - [koppor#5](https://github.com/koppor/jabref/issues/5) When entries are found while dropping a pdf with xmp meta data the found entries will be displayed in the import dialog
 - [koppor#61](https://github.com/koppor/jabref/issues/61) Display gray background text in "Author" and "Editor" field to assist newcomers
-- Updated Vietnam translation
+- Updated Vietnamese translation
 - Added greyed-out suggestion for `year`/`date`/`url` fields
 - [#1908](https://github.com/JabRef/jabref/issues/1908) Add a shortcut for check integrity <kbd>CTRL</kbd>+<kbd>F8</kbd>
 
 ### Fixed
+- Fixed [#2228](https://github.com/JabRef/jabref/issues/2228): Fixed Medline fetcher no longer working. The fetcher now uses `https` for fetching 
 - Fixed [#2089](https://github.com/JabRef/jabref/issues/2089): Fixed faulty cite key generation
 - Fixed [#2092](https://github.com/JabRef/jabref/issues/2092): "None"-button in date picker clears the date field
 - Fixed [#1993](https://github.com/JabRef/jabref/issues/1993): Various optimizations regarding search performance


### PR DESCRIPTION
Fix for #2228 


- [X] Change in CHANGELOG.md described
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] Write Blog post regarding https://www.ncbi.nlm.nih.gov/home/develop/https-guidance.shtml
After November 9, 2016, NCBI HTTP servers will redirect or reject all HTTP requests.

