### PR TITLE
Fix maintable sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Fixed close action of entry editor not working after parsing error corrected
 - Fixed [koppor/#128](https://github.com/koppor/jabref/issues/128): Sensible default settings for "Enable save actions" and "Cleanup"
 - Fixed [#2201](https://github.com/JabRef/jabref/issues/#2201) and [#1825](https://github.com/JabRef/jabref/issues/#1825): Status of the Group panel is saved and reused for next startup of JabRef
+- Fixed [#2200](https://github.com/JabRef/jabref/issues/#2200): Sorting now uses the same unicode representation that is also used for showing the content in the maintable
 
 ### Removed
 - Removed 2nd preview style

--- a/src/main/java/net/sf/jabref/logic/bibtex/comparator/FieldComparator.java
+++ b/src/main/java/net/sf/jabref/logic/bibtex/comparator/FieldComparator.java
@@ -75,7 +75,7 @@ public class FieldComparator implements Comparator<BibEntry> {
 
     private String getField(BibEntry entry) {
         for (String aField : field) {
-            Optional<String> o = entry.getFieldOrAlias(aField);
+            Optional<String> o = entry.getFieldOrAliasLatexFree(aField);
             if (o.isPresent()) {
                 return o.get();
             }
@@ -108,7 +108,7 @@ public class FieldComparator implements Comparator<BibEntry> {
             return -multiplier;
         }
 
-        // Now we now that both f1 and f2 are != null
+        // Now we know that both f1 and f2 are != null
         if (fieldType == FieldType.NAME) {
             f1 = AuthorList.fixAuthorForAlphabetization(f1);
             f2 = AuthorList.fixAuthorForAlphabetization(f2);

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -289,28 +289,17 @@ public class BibEntry implements Cloneable {
     }
 
     /**
-     * Returns the contents of the given field or its alias as an Optional
-     * <p>
-     * The following aliases are considered (old bibtex <-> new biblatex) based
-     * on the BibLatex documentation, chapter 2.2.5:<br>
-     * address      <-> location <br>
-     * annote           <-> annotation <br>
-     * archiveprefix    <-> eprinttype <br>
-     * journal      <-> journaltitle <br>
-     * key              <-> sortkey <br>
-     * pdf          <-> file <br
-     * primaryclass     <-> eprintclass <br>
-     * school           <-> institution <br>
-     * These work bidirectional. <br>
-     * <p>
-     * Special attention is paid to dates: (see the BibLatex documentation,
-     * chapter 2.3.8)
-     * The fields 'year' and 'month' are used if the 'date'
-     * field is empty. Conversely, getFieldOrAlias("year") also tries to
-     * extract the year from the 'date' field (analogously for 'month').
+     * Internal method used to get the content of a field (or its alias)
+     *
+     * Used by {@link #getFieldOrAlias(String)} and {@link #getFieldOrAliasLatexFree(String)}
+     *
+     * @param name name of the field
+     * @param getFieldInterface
+     *
+     * @return determined field value
      */
-    public Optional<String> getFieldOrAlias(String name) {
-        Optional<String> fieldValue = getField(toLowerCase(name));
+    private Optional<String> genericGetFieldOrAlias(String name, GetFieldInterface getFieldInterface) {
+        Optional<String> fieldValue = getFieldInterface.getValueForField(toLowerCase(name));
 
         if (fieldValue.isPresent() && !fieldValue.get().isEmpty()) {
             return fieldValue;
@@ -325,9 +314,9 @@ public class BibEntry implements Cloneable {
 
         // Finally, handle dates
         if (FieldName.DATE.equals(name)) {
-            Optional<String> year = getField(FieldName.YEAR);
+            Optional<String> year = getFieldInterface.getValueForField(FieldName.YEAR);
             if (year.isPresent()) {
-                MonthUtil.Month month = MonthUtil.getMonth(getField(FieldName.MONTH).orElse(""));
+                MonthUtil.Month month = MonthUtil.getMonth(getFieldInterface.getValueForField(FieldName.MONTH).orElse(""));
                 if (month.isValid()) {
                     return Optional.of(year.get() + '-' + month.twoDigitNumber);
                 } else {
@@ -336,7 +325,7 @@ public class BibEntry implements Cloneable {
             }
         }
         if (FieldName.YEAR.equals(name) || FieldName.MONTH.equals(name)) {
-            Optional<String> date = getField(FieldName.DATE);
+            Optional<String> date = getFieldInterface.getValueForField(FieldName.DATE);
             if (!date.isPresent()) {
                 return Optional.empty();
             }
@@ -392,6 +381,47 @@ public class BibEntry implements Cloneable {
             }
         }
         return Optional.empty();
+    }
+
+    private interface GetFieldInterface {
+        Optional<String> getValueForField(String fieldName);
+    }
+
+    /**
+     * Return the LaTeX-free contents of the given field or its alias an an Optional
+     *
+     * For details see also {@link #getFieldOrAlias(String)}
+     *
+     * @param name the name of the field
+     * @return  the stored latex-free content of the field (or its alias)
+     */
+    public Optional<String> getFieldOrAliasLatexFree(String name) {
+        return genericGetFieldOrAlias(name, this::getLatexFreeField);
+    }
+
+    /**
+     * Returns the contents of the given field or its alias as an Optional
+     * <p>
+     * The following aliases are considered (old bibtex <-> new biblatex) based
+     * on the BibLatex documentation, chapter 2.2.5:<br>
+     * address      <-> location <br>
+     * annote           <-> annotation <br>
+     * archiveprefix    <-> eprinttype <br>
+     * journal      <-> journaltitle <br>
+     * key              <-> sortkey <br>
+     * pdf          <-> file <br
+     * primaryclass     <-> eprintclass <br>
+     * school           <-> institution <br>
+     * These work bidirectional. <br>
+     * <p>
+     * Special attention is paid to dates: (see the BibLatex documentation,
+     * chapter 2.3.8)
+     * The fields 'year' and 'month' are used if the 'date'
+     * field is empty. Conversely, getFieldOrAlias("year") also tries to
+     * extract the year from the 'date' field (analogously for 'month').
+     */
+    public Optional<String> getFieldOrAlias(String name) {
+        return genericGetFieldOrAlias(name, this::getField);
     }
 
     /**

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -309,7 +309,7 @@ public class BibEntry implements Cloneable {
         String aliasForField = EntryConverter.FIELD_ALIASES.get(name);
 
         if (aliasForField != null) {
-            return getField(aliasForField);
+            return getFieldInterface.getValueForField(aliasForField);
         }
 
         // Finally, handle dates

--- a/src/test/java/net/sf/jabref/model/entry/BibEntryTests.java
+++ b/src/test/java/net/sf/jabref/model/entry/BibEntryTests.java
@@ -178,6 +178,42 @@ public class BibEntryTests {
         assertEquals(Optional.of("3"), emptyEntry.getFieldOrAlias("month"));
     }
 
+    @Test
+    public void getFieldOrAliasLatexFreeAlreadyFreeValueIsUnchanged() {
+        emptyEntry.setField("title", "A Title Without any LaTeX commands");
+        assertEquals(Optional.of("A Title Without any LaTeX commands"), emptyEntry.getFieldOrAliasLatexFree("title"));
+    }
+
+    @Test
+    public void getFieldOrAliasLatexFreeAlreadyFreeAliasValueIsUnchanged() {
+        emptyEntry.setField("journal", "A Title Without any LaTeX commands");
+        assertEquals(Optional.of("A Title Without any LaTeX commands"), emptyEntry.getFieldOrAliasLatexFree("journaltitle"));
+    }
+
+    @Test
+    public void getFieldOrAliasLatexFreeBracesAreRemoved() {
+        emptyEntry.setField("title", "{A Title with some {B}ra{C}es}");
+        assertEquals(Optional.of("A Title with some BraCes"), emptyEntry.getFieldOrAliasLatexFree("title"));
+    }
+
+    @Test
+    public void getFieldOrAliasLatexFreeBracesAreRemovedFromAlias() {
+        emptyEntry.setField("journal", "{A Title with some {B}ra{C}es}");
+        assertEquals(Optional.of("A Title with some BraCes"), emptyEntry.getFieldOrAliasLatexFree("journaltitle"));
+    }
+
+    @Test
+    public void getFieldOrAliasLatexFreeComplexConversionInAlias() {
+        emptyEntry.setField("journal", "A 32~{mA} {$\\Sigma\\Delta$}-modulator");
+        assertEquals(Optional.of("A 32\u00A0mA ΣΔ-modulator"), emptyEntry.getFieldOrAliasLatexFree("journaltitle"));
+    }
+
+    @Test
+    public void getFieldOrAliasLatexFreeDoesNotChangeDateSemantics() {
+        emptyEntry.setField("date", "2003-03-30");
+        assertEquals(Optional.of("3"), emptyEntry.getFieldOrAliasLatexFree("month"));
+    }
+
     @Test(expected = NullPointerException.class)
     public void setNullField() {
         emptyEntry.setField(null);


### PR DESCRIPTION
Fixes #2200 by using the latex free value of the field for sorting the main table.

However, just using `getLatexFreeField()` was not possible as the table is using `getFieldOrAlias`. Thus I introduced a new method `getFieldOrAliasLatexFree()` which is based on the previous implementation of `getFieldOrAlias()` using lambdas. This approach is used instead of formatting the `getFieldOrAlias()` result for performance reasons as the latex-free field values are cached in the `BibEntry`.

*Sidenote: If this approach is approved by you, the same should be applied to `BibDatabase.getResolvedFields()` which is used in `MainTableColumn.getColumnValue()` to show a latex-free version of the contents in the main table)*

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- ~~[ ] Screenshots added (for bigger UI changes)~~
- [x] Manually tested changed features in running JabRef
- ~~[ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)~~
- ~~[ ] If you changed the localization: Did you run `gradle localizationUpdate`?~~
