### PR TITLE
BibLaTeX mode: Add month and year field to deprecated tab

### DIFF
--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -263,8 +263,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
                 // Get all optional fields which are deprecated
                 usedOptionalFieldsDeprecated.retainAll(optionalFieldsAndAliases);
 
-                // Get deprecated parts of the date field
-                usedOptionalFieldsDeprecated.add(FieldName.YEAR);
+                // Get other deprecated fields
                 usedOptionalFieldsDeprecated.add(FieldName.MONTH);
 
                 // Add tabs

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -263,6 +263,10 @@ public class EntryEditor extends JPanel implements EntryContainer {
                 // Get all optional fields which are deprecated
                 usedOptionalFieldsDeprecated.retainAll(optionalFieldsAndAliases);
 
+                // Get deprecated parts of the date field
+                usedOptionalFieldsDeprecated.add(FieldName.YEAR);
+                usedOptionalFieldsDeprecated.add(FieldName.MONTH);
+
                 // Add tabs
                 EntryEditorTab optPan2 = new EntryEditorTab(frame, panel, optionalFieldsNotPrimaryOrDeprecated, this,
                         false, true, Localization.lang("Optional fields 2"));


### PR DESCRIPTION
Issue #2233: In BibLaTeX the `date` field is recommended. For backward compatibility the BibTeX fields `month` and `year` are also accepted. I've added both fields to the deprecated fields tab, although the year field is present in the required fields tab too.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?

