### PR TITLE
[WIP] Use v8 engine for CSL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,26 @@ configurations {
     integrationTestRuntime.extendsFrom testRuntime
 }
 
+def getV8Dependency() {
+    def arch = System.getProperty('os.arch')
+    def dep = null
+    if (OperatingSystem.current().isWindows()) {
+        dep = 'win32_x86'
+        if (arch.equals('amd64')) {
+            dep += '_64'
+        }
+    } else if (OperatingSystem.current().isMacOsX() && (arch.equals('amd64') || arch.equals('x86_64'))) {
+        dep = 'macosx_x86_64'
+    } else if (OperatingSystem.current().isLinux() && arch.equals('amd64')) {
+        dep = 'linux_x86_64'
+    }
+    if (dep == null) {
+        logger.error("Could not find V8 runtime compatible to this system")
+        return null
+    }
+    return 'com.eclipsesource.j2v8:j2v8_' + dep + ':4.5.0'
+}
+
 dependencies {
     compile 'com.jgoodies:jgoodies-common:1.8.1'
     compile 'com.jgoodies:jgoodies-forms:1.9.0'
@@ -123,6 +143,8 @@ dependencies {
     compile 'org.citationstyles:styles:1.0.1-SNAPSHOT'
     compile 'org.citationstyles:locales:1.0.1-SNAPSHOT'
     compile 'de.undercouch:citeproc-java:1.0.0-SNAPSHOT'
+
+    compile getV8Dependency()
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.2.9'

--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,10 @@ dependencies {
     compile 'org.citationstyles:locales:1.0.1-SNAPSHOT'
     compile 'de.undercouch:citeproc-java:1.0.0-SNAPSHOT'
 
-    compile getV8Dependency()
+    // if available, use platform specific build of V8
+    if (getV8Dependency() != null) {
+        compile getV8Dependency()
+    }
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.2.9'

--- a/external-libraries.txt
+++ b/external-libraries.txt
@@ -177,6 +177,6 @@ Licence: Apache License, Version 2.0
 Id:      com.eclipse.j2v8
 Project: J2V8
 URL:     https://github.com/eclipsesource/J2V8
-Licence: EPL- 1.0
+Licence: EPL-1.0
 
 The last entry has to end with an empty line. Otherwise the entry is not present in About.html.

--- a/external-libraries.txt
+++ b/external-libraries.txt
@@ -174,4 +174,9 @@ Project: Citeproc-Java
 URL:     http://michel-kraemer.github.io/citeproc-java/
 Licence: Apache License, Version 2.0
 
+Id:      com.eclipse.j2v8
+Project: J2V8
+URL:     https://github.com/eclipsesource/J2V8
+Licence: EPL- 1.0
+
 The last entry has to end with an empty line. Otherwise the entry is not present in About.html.


### PR DESCRIPTION
Changes made:
- Added a compile dependency on com.eclipsesource.j2v8 in build.gradle

We are using citeproc-java library in CitationStyleGenerator to generate previews, which itself is basically a wrapper around the javascript library citeproc-js. Switching to V8 engine dramatically improves the time taken to generate these previews. For example, on my laptop, generating preview used to take about 20s for the first preview, and 10s for each subsequent preview; using V8 reduces both by a factor of 10.


- [x] Manually tested changed features in running JabRef

