### PR TITLE
Change log level to debug

### DIFF
--- a/src/main/java/net/sf/jabref/model/search/rules/GrammarBasedSearchRule.java
+++ b/src/main/java/net/sf/jabref/model/search/rules/GrammarBasedSearchRule.java
@@ -108,7 +108,7 @@ public class GrammarBasedSearchRule implements SearchRule {
             init(query);
             return true;
         } catch (ParseCancellationException e) {
-            LOGGER.warn("Search query invalid", e);
+            LOGGER.debug("Search query invalid", e);
             return false;
         }
     }


### PR DESCRIPTION
"Fixes" a side aspects mentioned in #2249.

Currently a search will throw errors if one types "author=" as the search term is still incomplete - those exceptions should not be visible to the normal user.

