### PR TITLE
Fix translation warning

### DIFF
--- a/src/main/java/net/sf/jabref/gui/keyboard/KeyBinding.java
+++ b/src/main/java/net/sf/jabref/gui/keyboard/KeyBinding.java
@@ -9,7 +9,7 @@ public enum KeyBinding {
     ACCEPT("Accept", Localization.lang("Accept"), "ctrl ENTER", KeyBindingCategory.EDIT),
     AUTOMATICALLY_LINK_FILES("Automatically link files", Localization.lang("Automatically set file links"), "F7", KeyBindingCategory.QUALITY),
     BACK("Back", Localization.lang("Back"), "alt LEFT", KeyBindingCategory.VIEW),
-    CHECK_INTEGRITY("Check integrity", Localization.lang("Check integrity"), "ctrl F8", KeyBindingCategory.QUALITY),
+    CHECK_INTEGRITY("Check integrity", Localization.menuTitle("Check integrity"), "ctrl F8", KeyBindingCategory.QUALITY),
     CLEANUP("Cleanup", Localization.lang("Cleanup entries"), "F8", KeyBindingCategory.QUALITY),
     CLEAR_SEARCH("Clear search", Localization.lang("Clear search"), "ESCAPE", KeyBindingCategory.SEARCH),
     CLOSE_DATABASE("Close database", Localization.lang("Close database"), "ctrl W", KeyBindingCategory.FILE),


### PR DESCRIPTION
In the JavaFX branch, JabRef outputs

```
09:52:15.355 [AWT-EventQueue-0] WARN  net.sf.jabref.logic.l10n.Localization - Warning: could not get message translation for "Check integrity" for locale en
09:52:15.356 [AWT-EventQueue-0] WARN  net.sf.jabref.logic.l10n.Localization - Warning: no message translation for "Check integrity" for locale en
```

This is fixed with this PR.

When digging deeper, it seems also other calls to `Localization.lang` should be replaced by `Localization.menuTitle`.

For other cases, like "Copy_BibTeX_key_and_title" (or "Open Database"), some calls might get replaced. The RightClickMenu calls `lang` with that string, whereas JabReFrame calls `menuTitle`. I would opt for changing the call of RightClickMenu. Reason: When adding a new language, first the menu strings are translated, then the other strings. To offer a huge coverage of the translation, these translated strings should be used at so many places as possible.

"Open file" also appears twice, this should be consolidated.

"Quit JabRef" seems to be at the wrong file: It is only in the full language, but this is a global menu action.