### PR TITLE
When an ISBN is not available on ebook.de, the error message is more clear.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Updated Vietnamese translation
 - Added greyed-out suggestion for `year`/`date`/`url` fields
 - [#1908](https://github.com/JabRef/jabref/issues/1908) Add a shortcut for check integrity <kbd>CTRL</kbd>+<kbd>F8</kbd>
+- When creatig an entry based on an ISBN, but the ISBN is not available on ebook.de, the error message is now more clear.
 
 ### Fixed
 - Fixed problem where closing brackets could not be used as texts in layout arguments

--- a/src/main/java/net/sf/jabref/logic/importer/IdBasedParserFetcher.java
+++ b/src/main/java/net/sf/jabref/logic/importer/IdBasedParserFetcher.java
@@ -1,6 +1,7 @@
 package net.sf.jabref.logic.importer;
 
 import java.io.BufferedInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -80,6 +81,9 @@ public interface IdBasedParserFetcher extends IdBasedFetcher {
             return Optional.of(entry);
         } catch (URISyntaxException e) {
             throw new FetcherException("Search URI is malformed", e);
+        } catch (FileNotFoundException e) {
+            LOGGER.debug("Id not found");
+            return Optional.empty();
         } catch (IOException e) {
             // TODO: Catch HTTP Response 401 errors and report that user has no rights to access resource
             throw new FetcherException("An I/O exception occurred", e);

--- a/src/test/java/net/sf/jabref/logic/importer/fetcher/AstrophysicsDataSystemTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fetcher/AstrophysicsDataSystemTest.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Optional;
 
 import net.sf.jabref.logic.bibtex.FieldContentParserPreferences;
-import net.sf.jabref.logic.importer.FetcherException;
 import net.sf.jabref.logic.importer.ImportFormatPreferences;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibLatexEntryTypes;
@@ -18,7 +17,6 @@ import org.junit.Test;
 import static net.sf.jabref.logic.util.OS.NEWLINE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -169,10 +167,10 @@ public class AstrophysicsDataSystemTest {
         assertEquals(Optional.empty(), fetchedEntry);
     }
 
-    @Test(expected = FetcherException.class)
+    @Test
     public void testPerformSearchByIdInvalidDoi() throws Exception {
-        fetcher.performSearchById("this.doi.will.fail");
-        fail();
+        Optional<BibEntry> fetchedEntry = fetcher.performSearchById("this.doi.will.fail");
+        assertEquals(Optional.empty(), fetchedEntry);
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/importer/fetcher/IsbnFetcherTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fetcher/IsbnFetcherTest.java
@@ -76,4 +76,15 @@ public class IsbnFetcherTest {
     public void searchByIdThrowsExceptionForInvalidISBN() throws FetcherException {
         fetcher.performSearchById("jabref-4-ever");
     }
+
+    /**
+     * This test searches for a valid ISBN. See https://www.amazon.de/dp/3728128155/?tag=jabref-21
+     * However, this ISBN is not available on ebook.de. The fetcher should return nothing rather than throwing an exeption.
+     */
+    @Test
+    public void searchForValidButNotFoundISBN() throws Exception {
+        Optional<BibEntry> fetchedEntry = fetcher.performSearchById("3728128155");
+        assertEquals(Optional.empty(), fetchedEntry);
+    }
+
 }


### PR DESCRIPTION
When fetching a valid ISBN from ebook.de, but the site has no data of the ISBN, the error message just showed "FileNotFoundException". This PR fixes that.

The issue itself is a kind of regression as it has been fixed for verison 3.3 - see #684.

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [n/a] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [n/a] If you changed the localization: Did you run `gradle localizationUpdate`?
