### PR TITLE
Fix #2279: File permissions are kept upon save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project **does not** adhere to [Semantic Versioning](http://semver.org/).
 This file tries to follow the conventions proposed by [keepachangelog.com](http://keepachangelog.com/).
 Here, the categories "Changed" for added and changed functionality,
 "Fixed" for fixed functionality, and
-"Removed" for removed functionality is used.
+"Removed" for removed functionality are used.
 
 We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#NUM`.
 
@@ -14,6 +14,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Changed
 
 ### Fixed
+- We fixed an issue where the file permissions of the .bib-file were changed upon saving [#2279](https://github.com/JabRef/jabref/issues/2279).
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/logic/exporter/FileSaveSession.java
+++ b/src/main/java/net/sf/jabref/logic/exporter/FileSaveSession.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+import java.util.Set;
 
 import net.sf.jabref.logic.util.io.FileBasedLock;
 import net.sf.jabref.logic.util.io.FileUtil;
@@ -83,7 +86,24 @@ public class FileSaveSession extends SaveSession {
                 LOGGER.error("Error when creating lock file.", ex);
             }
 
+            // Try to save file permissions to restore them later (by default: allow everything)
+            Set<PosixFilePermission> oldFilePermissions = EnumSet.allOf(PosixFilePermission.class);
+            if (Files.exists(file)) {
+                try {
+                    oldFilePermissions = Files.getPosixFilePermissions(file);
+                } catch (IOException exception) {
+                    LOGGER.warn("Error getting file permissions.", exception);
+                }
+            }
+
             FileUtil.copyFile(temporaryFile, file, true);
+
+            // Restore file permissions
+            try {
+                Files.setPosixFilePermissions(file, oldFilePermissions);
+            } catch (IOException exception) {
+                throw new SaveException(exception);
+            }
         } finally {
             FileBasedLock.deleteLockFile(file);
         }


### PR DESCRIPTION
Fixes #2279.
JabRef does not directly writes to the bib-file upon save but creates a temporary file which is then copied over the original one. In this process the original file permissions get lost. Should be fixed with this PR (I have not tried it...).
I pushed the code to the branch https://github.com/JabRef/jabref/tree/filePermissions but for some reason the setup files do not show up on [builds.jabref.org](http://builds.jabref.org/)

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?

