### PR TITLE
Fix UnsupportedOperationException on Windows due to Posix usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 ### Fixed
 - We fixed an issue where the file permissions of the .bib-file were changed upon saving [#2279](https://github.com/JabRef/jabref/issues/2279).
+- We fixed an issue which prevented that a database was saved successfully if JabRef failed to generate new BibTeX-keys [#2285](https://github.com/JabRef/jabref/issues/2285).
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -1897,7 +1897,8 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                             .getCiteKeyPattern(Globals.prefs.getBibtexKeyPatternPreferences().getKeyPattern()),
                             bibDatabaseContext.getDatabase(),
                             bes, Globals.prefs.getBibtexKeyPatternPreferences());
-                    ce.addEdit(new UndoableKeyChange(bes, oldKey.orElse(""), bes.getCiteKeyOptional().get()));
+                    bes.getCiteKeyOptional().ifPresent(
+                            newKey -> ce.addEdit(new UndoableKeyChange(bes, oldKey.orElse(""), newKey)));
                 }
             }
 

--- a/src/main/java/net/sf/jabref/logic/exporter/FileSaveSession.java
+++ b/src/main/java/net/sf/jabref/logic/exporter/FileSaveSession.java
@@ -88,7 +88,7 @@ public class FileSaveSession extends SaveSession {
 
             // Try to save file permissions to restore them later (by default: allow everything)
             Set<PosixFilePermission> oldFilePermissions = EnumSet.allOf(PosixFilePermission.class);
-            if (Files.exists(file)) {
+            if (FileUtil.isPosixCompilant && Files.exists(file)) {
                 try {
                     oldFilePermissions = Files.getPosixFilePermissions(file);
                 } catch (IOException exception) {
@@ -99,10 +99,12 @@ public class FileSaveSession extends SaveSession {
             FileUtil.copyFile(temporaryFile, file, true);
 
             // Restore file permissions
-            try {
-                Files.setPosixFilePermissions(file, oldFilePermissions);
-            } catch (IOException exception) {
-                throw new SaveException(exception);
+            if (FileUtil.isPosixCompilant) {
+                try {
+                    Files.setPosixFilePermissions(file, oldFilePermissions);
+                } catch (IOException exception) {
+                    throw new SaveException(exception);
+                }
             }
         } finally {
             FileBasedLock.deleteLockFile(file);

--- a/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/FileUtil.java
@@ -3,6 +3,7 @@ package net.sf.jabref.logic.util.io;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -41,6 +42,9 @@ public class FileUtil {
 
     private static final Pattern SLASH = Pattern.compile("/");
     private static final Pattern BACKSLASH = Pattern.compile("\\\\");
+
+    public static final boolean isPosixCompilant = FileSystems.getDefault().supportedFileAttributeViews().contains(
+            "posix");
 
     /**
      * Returns the extension of a file or Optional.empty() if the file does not have one (no . in name).


### PR DESCRIPTION
Fix the error message reported in https://github.com/JabRef/jabref/issues/2285, which is due to trying to use posix on Windows.

Update: also fixes the issue reported at https://github.com/JabRef/jabref/issues/2285. The original exception from http://discourse.jabref.org/t/jabref-cannot-complete-save-of-database-error-in-log/294 resulted from a `Optional.get` on an empty optional. Please merge as separate commits. 

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?

