### PR TITLE
Fix "No suitable driver found"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Fixed
 - We fixed an issue where the file permissions of the .bib-file were changed upon saving [#2279](https://github.com/JabRef/jabref/issues/2279).
 - We fixed an issue which prevented that a database was saved successfully if JabRef failed to generate new BibTeX-keys [#2285](https://github.com/JabRef/jabref/issues/2285).
+- We fixed an issue when JabRef restores its session and a shared database was used: The error message "No suitable driver found" will not appear.
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/shared/DBMSConnection.java
+++ b/src/main/java/net/sf/jabref/shared/DBMSConnection.java
@@ -29,6 +29,10 @@ public class DBMSConnection {
 
         try {
             DriverManager.setLoginTimeout(3);
+            // ensure that all SQL drivers are loaded - source: http://stackoverflow.com/a/22384826/873282
+            // we use the side effect of getAvailableDBMSTypes() - it loads all available drivers
+            DBMSConnection.getAvailableDBMSTypes();
+
             this.connection = DriverManager.getConnection(
                     properties.getType().getUrl(properties.getHost(), properties.getPort(), properties.getDatabase()),
                     properties.getUser(), properties.getPassword());


### PR DESCRIPTION
I got the error message "No suitable driver found for jdbc:pgsql://fizzy-cherry.db.elephantsql.com:5432/zdndklfq" when using the session restore of shared databases of JabRef. Google pointed me to http://stackoverflow.com/a/22384826/873282, which states that all drivers should be loaded before they are used.

This PR ensures that all available DBMS drivers are loaded before any connection attempt is made.

This does not fix #2294, which means that one has to enable autosave to be able to automatically reconnect.