### PR TITLE
Remove duplicate code getResolvedFieldOrAlias

### DIFF
--- a/src/main/java/net/sf/jabref/gui/groups/GroupDialog.java
+++ b/src/main/java/net/sf/jabref/gui/groups/GroupDialog.java
@@ -34,7 +34,6 @@ import net.sf.jabref.gui.keyboard.KeyBinding;
 import net.sf.jabref.logic.groups.GroupDescriptions;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.logic.search.SearchQuery;
-
 import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.model.groups.AbstractGroup;
 import net.sf.jabref.model.groups.ExplicitGroup;

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableColumn.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableColumn.java
@@ -94,7 +94,7 @@ public class MainTableColumn {
 
         Optional<String> content = Optional.empty();
         for (String field : bibtexFields) {
-            content = BibDatabase.getResolvedField(field, entry, database.orElse(null));
+            content = entry.getResolvedFieldOrAlias(field, database.orElse(null));
             if (content.isPresent()) {
                 isNameColumn = InternalBibtexFields.getFieldProperties(field).contains(FieldProperty.PERSON_NAMES);
                 break;
@@ -127,9 +127,9 @@ public class MainTableColumn {
      * The reasons for being different are (combinations may also happen):
      * - The entry has a crossref where the field content is obtained from
      * - The field has a string in it (which getColumnValue() resolves)
-     * - There are some alias fields. For example, if the entry has a date field but no year field, getResolvedField()
-     *   will return the year value from the date field when queried for year
-     *
+     * - There are some alias fields. For example, if the entry has a date field but no year field,
+     *   {@link BibEntry#getResolvedFieldOrAlias(String, BibDatabase)} will return the year value from the date field
+     *   when queried for year
      *
      * @param entry the BibEntry
      * @return true if the value returned by getColumnValue() is resolved as outlined above
@@ -148,7 +148,7 @@ public class MainTableColumn {
                 return false;
             } else {
                 plainFieldContent = entry.getField(field);
-                resolvedFieldContent = BibDatabase.getResolvedField(field, entry, database.orElse(null));
+                resolvedFieldContent = entry.getResolvedFieldOrAlias(field, database.orElse(null));
             }
 
             if (resolvedFieldContent.isPresent()) {

--- a/src/main/java/net/sf/jabref/gui/specialfields/SpecialFieldValueViewModel.java
+++ b/src/main/java/net/sf/jabref/gui/specialfields/SpecialFieldValueViewModel.java
@@ -5,7 +5,6 @@ import java.util.Objects;
 import javax.swing.Icon;
 import javax.swing.JLabel;
 
-
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.specialfields.SpecialFieldValue;

--- a/src/main/java/net/sf/jabref/logic/exporter/OpenDocumentRepresentation.java
+++ b/src/main/java/net/sf/jabref/logic/exporter/OpenDocumentRepresentation.java
@@ -199,7 +199,7 @@ class OpenDocumentRepresentation {
     }
 
     private String getField(BibEntry e, String field) {
-        return BibDatabase.getResolvedField(field, e, database).orElse("");
+        return e.getResolvedFieldOrAlias(field, database).orElse("");
     }
 
     private void addTableCell(Document doc, Element parent, String content) {

--- a/src/main/java/net/sf/jabref/logic/layout/LayoutEntry.java
+++ b/src/main/java/net/sf/jabref/logic/layout/LayoutEntry.java
@@ -184,7 +184,7 @@ class LayoutEntry {
         case LayoutHelper.IS_LAYOUT_TEXT:
             return text;
         case LayoutHelper.IS_SIMPLE_FIELD:
-            String value = BibDatabase.getResolvedField(text, bibtex, database).orElse("");
+            String value = bibtex.getResolvedFieldOrAlias(text, database).orElse("");
 
             // If a post formatter has been set, call it:
             if (postFormatter != null) {
@@ -203,7 +203,7 @@ class LayoutEntry {
             // Printing the encoding name is not supported in entry layouts, only
             // in begin/end layouts. This prevents breakage if some users depend
             // on a field called "encoding". We simply return this field instead:
-            return BibDatabase.getResolvedField("encoding", bibtex, database).orElse(null);
+            return bibtex.getResolvedFieldOrAlias("encoding", database).orElse(null);
         default:
             return "";
         }
@@ -222,8 +222,8 @@ class LayoutEntry {
         } else {
             // changed section begin - arudert
             // resolve field (recognized by leading backslash) or text
-            fieldEntry = text.startsWith("\\") ? BibDatabase
-                    .getResolvedField(text.substring(1), bibtex, database)
+            fieldEntry = text.startsWith("\\") ? bibtex
+                    .getResolvedFieldOrAlias(text.substring(1), database)
                     .orElse("") : BibDatabase.getText(text, database);
             // changed section end - arudert
         }
@@ -245,13 +245,13 @@ class LayoutEntry {
     private String handleFieldOrGroupStart(BibEntry bibtex, BibDatabase database) {
         Optional<String> field;
         if (type == LayoutHelper.IS_GROUP_START) {
-            field = BibDatabase.getResolvedField(text, bibtex, database);
+            field = bibtex.getResolvedFieldOrAlias(text, database);
         } else if (text.matches(".*(;|(\\&+)).*")) {
             // split the strings along &, && or ; for AND formatter
             String[] parts = text.split("\\s*(;|(\\&+))\\s*");
             field = Optional.empty();
             for (String part : parts) {
-                field = BibDatabase.getResolvedField(part, bibtex, database);
+                field = bibtex.getResolvedFieldOrAlias(part, database);
                 if (!field.isPresent()) {
                     break;
                 }
@@ -261,7 +261,7 @@ class LayoutEntry {
             String[] parts = text.split("\\s*(\\|+)\\s*");
             field = Optional.empty();
             for (String part : parts) {
-                field = BibDatabase.getResolvedField(part, bibtex, database);
+                field = bibtex.getResolvedFieldOrAlias(part, database);
                 if (field.isPresent()) {
                     break;
                 }

--- a/src/main/java/net/sf/jabref/logic/openoffice/OOBibStyle.java
+++ b/src/main/java/net/sf/jabref/logic/openoffice/OOBibStyle.java
@@ -717,7 +717,7 @@ public class OOBibStyle implements Comparable<OOBibStyle> {
         String authorField = getStringCitProperty(AUTHOR_FIELD);
         String[] fields = field.split(FieldName.FIELD_SEPARATOR);
         for (String s : fields) {
-            Optional<String> content = BibDatabase.getResolvedField(s, entry, database);
+            Optional<String> content = entry.getResolvedFieldOrAlias(s, database);
 
             if ((content.isPresent()) && !content.get().trim().isEmpty()) {
                 if (field.equals(authorField) && StringUtil.isInCurlyBrackets(content.get())) {

--- a/src/main/java/net/sf/jabref/logic/util/io/RegExpFileSearch.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/RegExpFileSearch.java
@@ -323,7 +323,7 @@ public class RegExpFileSearch {
         }
 
         // If no field value was found, try to interpret it as a key generator field marker:
-        String fieldValue = BibDatabase.getResolvedField(beforeColon, entry, database)
+        String fieldValue = entry.getResolvedFieldOrAlias(beforeColon, database)
                 .orElse(BibtexKeyPatternUtil.makeLabel(entry, beforeColon, keywordDelimiter));
 
         if (fieldValue == null) {

--- a/src/main/java/net/sf/jabref/logic/xmp/XMPSchemaBibtex.java
+++ b/src/main/java/net/sf/jabref/logic/xmp/XMPSchemaBibtex.java
@@ -283,7 +283,7 @@ public class XMPSchemaBibtex extends XMPSchema {
         }
 
         for (String field : fields) {
-            String value = BibDatabase.getResolvedField(field, entry, database).orElse("");
+            String value = entry.getResolvedFieldOrAlias(field, database).orElse("");
             if (InternalBibtexFields.getFieldProperties(field).contains(FieldProperty.PERSON_NAMES)) {
                 setPersonList(field, value);
             } else {

--- a/src/main/java/net/sf/jabref/model/database/BibDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabase.java
@@ -17,12 +17,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import net.sf.jabref.model.EntryTypes;
 import net.sf.jabref.model.database.event.EntryAddedEvent;
 import net.sf.jabref.model.database.event.EntryRemovedEvent;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexString;
-import net.sf.jabref.model.entry.EntryType;
 import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.model.entry.InternalBibtexFields;
 import net.sf.jabref.model.entry.MonthUtil;

--- a/src/main/java/net/sf/jabref/model/database/BibDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabase.java
@@ -480,59 +480,6 @@ public class BibDatabase {
     }
 
     /**
-     * Returns the text stored in the given field of the given bibtex entry
-     * which belongs to the given database.
-     * <p>
-     * If a database is given, this function will try to resolve any string
-     * references in the field-value.
-     * Also, if a database is given, this function will try to find values for
-     * unset fields in the entry linked by the "crossref" field, if any.
-     *
-     * @param field    The field to return the value of.
-     * @param entry    The bibtex entry which contains the field.
-     * @param database maybenull
-     *                 The database of the bibtex entry.
-     * @return The resolved field value or null if not found.
-     */
-    public static Optional<String> getResolvedField(String field, BibEntry entry, BibDatabase database) {
-        Objects.requireNonNull(entry, "entry cannot be null");
-
-        if (BibEntry.TYPE_HEADER.equals(field) || BibEntry.OBSOLETE_TYPE_HEADER.equals(field)) {
-            Optional<EntryType> entryType = EntryTypes.getType(entry.getType(), BibDatabaseMode.BIBLATEX);
-            if (entryType.isPresent()) {
-                return Optional.of(entryType.get().getName());
-            } else {
-                return Optional.of(StringUtil.capitalizeFirst(entry.getType()));
-            }
-        }
-
-        if (BibEntry.KEY_FIELD.equals(field)) {
-            return entry.getCiteKeyOptional();
-        }
-
-        // Changed this to also consider alias fields, which is the expected
-        // behavior for the preview layout and for the check whatever all fields are present.
-        // TODO: But there might be unwanted side-effects?!
-        Optional<String> result = entry.getFieldOrAlias(field);
-
-        // If this field is not set, and the entry has a crossref, try to look up the
-        // field in the referred entry: Do not do this for the bibtex key.
-        if (!result.isPresent() && (database != null)) {
-            Optional<String> crossrefKey = entry.getField(FieldName.CROSSREF);
-            if (crossrefKey.isPresent() && !crossrefKey.get().isEmpty()) {
-                Optional<BibEntry> referred = database.getEntryByKey(crossrefKey.get());
-                if (referred.isPresent()) {
-                    // Ok, we found the referred entry. Get the field value from that
-                    // entry. If it is unset there, too, stop looking:
-                    result = referred.get().getFieldOrAlias(field);
-                }
-            }
-        }
-
-        return result.map(resultText -> BibDatabase.getText(resultText, database));
-    }
-
-    /**
      * @deprecated use  {@link BibDatabase#resolveForStrings(String)}
      *
      * Returns a text with references resolved according to an optionally given database.


### PR DESCRIPTION
The method getResolvedField was in BibDatabase and in BibEntry with identical same code. This PR removes the copy from BibDatabase.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?

