### PR TITLE
Fix NullPointerException in ConnectToSharedDatabaseDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - URLs can now be passed as arguments to the `-import` and `-importToOpen` command line options. The referenced file is downloaded and then imported as usual.
 
 ### Fixed
+- Fix NullPointerException in ConnectToSharedDatabaseDialog which occurred when leaving the file path field empty and connecting to a shared database.
 - We fixed an issue where the file permissions of the .bib-file were changed upon saving [#2279](https://github.com/JabRef/jabref/issues/2279).
 - We fixed an issue which prevented that a database was saved successfully if JabRef failed to generate new BibTeX-keys [#2285](https://github.com/JabRef/jabref/issues/2285).
 - We fixed an issue when JabRef restores its session and a shared database was used: The error message "No suitable driver found" will not appear.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - URLs can now be passed as arguments to the `-import` and `-importToOpen` command line options. The referenced file is downloaded and then imported as usual.
 
 ### Fixed
-- Fix NullPointerException in ConnectToSharedDatabaseDialog which occurred when leaving the file path field empty and connecting to a shared database.
+- We fixed an issue which caused an internal error when leaving the file path field empty and connecting to a shared database.
 - We fixed an issue where the file permissions of the .bib-file were changed upon saving [#2279](https://github.com/JabRef/jabref/issues/2279).
 - We fixed an issue which prevented that a database was saved successfully if JabRef failed to generate new BibTeX-keys [#2285](https://github.com/JabRef/jabref/issues/2285).
 - We fixed an issue when JabRef restores its session and a shared database was used: The error message "No suitable driver found" will not appear.

--- a/src/main/java/net/sf/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/SaveDatabaseAction.java
@@ -334,7 +334,9 @@ public class SaveDatabaseAction extends AbstractWorker {
         }
 
         context.setDatabaseFile(file);
-        Globals.prefs.put(JabRefPreferences.WORKING_DIRECTORY, file.getParent());
+        if (file.getParent() != null) {
+            Globals.prefs.put(JabRefPreferences.WORKING_DIRECTORY, file.getParent());
+        }
         runCommand();
         // If the operation failed, revert the file field and return:
         if (!success) {

--- a/src/main/java/net/sf/jabref/gui/shared/ConnectToSharedDatabaseDialog.java
+++ b/src/main/java/net/sf/jabref/gui/shared/ConnectToSharedDatabaseDialog.java
@@ -139,10 +139,12 @@ public class ConnectToSharedDatabaseDialog extends JDialog {
             BasePanel panel = new SharedDatabaseUIManager(frame).openNewSharedDatabaseTab(connectionProperties);
             setPreferences();
             dispose();
-            try {
-                new SaveDatabaseAction(panel, Paths.get(fileLocationField.getText())).runCommand();
-            } catch (Throwable e) {
-                LOGGER.error("Error while saving the database", e);
+            if (!fileLocationField.getText().isEmpty()) {
+                try {
+                    new SaveDatabaseAction(panel, Paths.get(fileLocationField.getText())).runCommand();
+                } catch (Throwable e) {
+                    LOGGER.error("Error while saving the database", e);
+                }
             }
 
             return; // setLoadingConnectButtonText(false) should not be reached regularly.


### PR DESCRIPTION
A `NullPointerException` occurred when leaving the file path field empty and connecting to a shared database.

Exception:
```
[AWT-EventQueue-0] ERROR net.sf.jabref.gui.shared.ConnectToSharedDatabaseDialog - Error while saving the database
java.lang.NullPointerException: null
        at java.util.prefs.AbstractPreferences.put(AbstractPreferences.java:241) ~[?:1.8.0_111]
        at net.sf.jabref.preferences.JabRefPreferences.put(JabRefPreferences.java:922) ~[main/:?]
        at net.sf.jabref.gui.exporter.SaveDatabaseAction.saveAs(SaveDatabaseAction.java:337) ~[main/:?]
...
```

- [X] Manually tested changed features in running JabRef