### PR TITLE
Fix local metadata synchronization (fixes: #2219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - URLs can now be passed as arguments to the `-import` and `-importToOpen` command line options. The referenced file is downloaded and then imported as usual.
 
 ### Fixed
+- We fixed an issue which caused a metadata loss on reconnection to shared database. [#2219](https://github.com/JabRef/jabref/issues/2219)
 - We fixed an issue which caused an internal error when leaving the file path field empty and connecting to a shared database.
 - We fixed an issue where the file permissions of the .bib-file were changed upon saving [#2279](https://github.com/JabRef/jabref/issues/2279).
 - We fixed an issue which prevented that a database was saved successfully if JabRef failed to generate new BibTeX-keys [#2285](https://github.com/JabRef/jabref/issues/2285).

--- a/src/main/java/net/sf/jabref/logic/importer/util/MetaDataParser.java
+++ b/src/main/java/net/sf/jabref/logic/importer/util/MetaDataParser.java
@@ -24,9 +24,18 @@ public class MetaDataParser {
 
     private static final Log LOGGER = LogFactory.getLog(MetaDataParser.class);
 
-    public static MetaData parse(Map<String, String> data, Character keywordSeparator) throws ParseException {
-        MetaData metaData = new MetaData();
 
+    /**
+     * Parses the given data map and returns a new resulting {@link MetaData} instance.
+     */
+    public static MetaData parse(Map<String, String> data, Character keywordSeparator) throws ParseException {
+        return parse(new MetaData(), data, keywordSeparator);
+    }
+
+    /**
+     * Parses the data map and changes the given {@link MetaData} instance respectively.
+     */
+    public static MetaData parse(MetaData metaData, Map<String, String> data, Character keywordSeparator) throws ParseException {
         List<String> defaultCiteKeyPattern = new ArrayList<>();
         Map<String, List<String>> nonDefaultCiteKeyPatterns = new HashMap<>();
 

--- a/src/main/java/net/sf/jabref/shared/DBMSSynchronizer.java
+++ b/src/main/java/net/sf/jabref/shared/DBMSSynchronizer.java
@@ -261,7 +261,7 @@ public class DBMSSynchronizer {
         }
 
         try {
-            metaData = MetaDataParser.parse(dbmsProcessor.getSharedMetaData(), keywordSeparator);
+            MetaDataParser.parse(metaData, dbmsProcessor.getSharedMetaData(), keywordSeparator);
         } catch (ParseException e) {
             LOGGER.error("Parse error", e);
         }


### PR DESCRIPTION
Issue: https://github.com/JabRef/jabref/issues/2219.

This issue is fixed by overloading and using the `parse(...)` method in `MetaDataParser`.

The reason was a reset of the local field `metaData` in `DBMSSynchronizer`. This caused other instances containing this field not to be up-to-date.


- [X] Change in CHANGELOG.md described
- [X] Manually tested changed features in running JabRef