### PR TITLE
Adapt CSL tests to CRLF and LF

### DIFF
--- a/src/test/java/net/sf/jabref/logic/citationstyle/CitationStyleGeneratorTest.java
+++ b/src/test/java/net/sf/jabref/logic/citationstyle/CitationStyleGeneratorTest.java
@@ -24,9 +24,9 @@ public class CitationStyleGeneratorTest {
     }
 
     @Test
-    public void testIgnoreeCarriageReturnNewLine() {
+    public void testIgnoreCarriageReturnNewLine() {
         BibEntry entry = new BibEntry();
-        entry.setField(FieldName.AUTHOR, "Last, First and\nDoe, Jane");
+        entry.setField(FieldName.AUTHOR, "Last, First and\r\nDoe, Jane");
 
         // if the default citation style changes this has to be modified
         String expected = "  <div class=\"csl-entry\">\n" +

--- a/src/test/java/net/sf/jabref/logic/citationstyle/CitationStyleGeneratorTest.java
+++ b/src/test/java/net/sf/jabref/logic/citationstyle/CitationStyleGeneratorTest.java
@@ -11,13 +11,26 @@ import static org.junit.Assert.assertEquals;
 public class CitationStyleGeneratorTest {
 
     @Test
-    public void testIgnoreCarriageReturn() {
+    public void testIgnoreNewLine() {
         BibEntry entry = new BibEntry();
-        entry.setField(FieldName.AUTHOR, "Doe, John and \rDoe, Jane");
+        entry.setField(FieldName.AUTHOR, "Last, First and\nDoe, Jane");
 
         // if the default citation style changes this has to be modified
         String expected = "  <div class=\"csl-entry\">\n" +
-                "    <div class=\"csl-left-margin\">[1]</div><div class=\"csl-right-inline\">J. Doe and J. Doe, .</div>\n" +
+                "    <div class=\"csl-left-margin\">[1]</div><div class=\"csl-right-inline\">F. Last and J. Doe, .</div>\n" +
+                "  </div>\n";
+        String citation = CitationStyleGenerator.generateCitation(entry, CitationStyle.getDefault());
+        assertEquals(expected, citation);
+    }
+
+    @Test
+    public void testIgnoreeCarriageReturnNewLine() {
+        BibEntry entry = new BibEntry();
+        entry.setField(FieldName.AUTHOR, "Last, First and\nDoe, Jane");
+
+        // if the default citation style changes this has to be modified
+        String expected = "  <div class=\"csl-entry\">\n" +
+                "    <div class=\"csl-left-margin\">[1]</div><div class=\"csl-right-inline\">F. Last and J. Doe, .</div>\n" +
                 "  </div>\n";
         String citation = CitationStyleGenerator.generateCitation(entry, CitationStyle.getDefault());
         assertEquals(expected, citation);


### PR DESCRIPTION
The discussion at https://github.com/michel-kraemer/citeproc-java/commit/729ca2c21c508654e51a713399c8becf2c0dff39 revealed that `\r` does not appear as line separator alone. Thus, our tests should be adapted accordingly.

Refs https://github.com/koppor/jabref/issues/174