### PR TITLE
Replace usages of Throwable with Exception

### DIFF
--- a/src/main/java/net/sf/jabref/gui/actions/BaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/BaseAction.java
@@ -8,5 +8,5 @@ package net.sf.jabref.gui.actions;
 @FunctionalInterface
 public interface BaseAction {
 
-    void action() throws Throwable;
+    void action() throws Exception;
 }

--- a/src/main/java/net/sf/jabref/gui/actions/CopyBibTeXKeyAndLinkAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/CopyBibTeXKeyAndLinkAction.java
@@ -25,7 +25,7 @@ public class CopyBibTeXKeyAndLinkAction implements BaseAction {
     }
 
     @Override
-    public void action() throws Throwable {
+    public void action() throws Exception {
         List<BibEntry> entries = mainTable.getSelectedEntries();
         if (!entries.isEmpty()) {
             StringBuilder sb = new StringBuilder();

--- a/src/main/java/net/sf/jabref/gui/bibtexkeypattern/SearchFixDuplicateLabels.java
+++ b/src/main/java/net/sf/jabref/gui/bibtexkeypattern/SearchFixDuplicateLabels.java
@@ -64,7 +64,7 @@ public class SearchFixDuplicateLabels extends AbstractWorker {
     }
 
     @Override
-    public void init() throws Throwable {
+    public void init() throws Exception {
         panel.output(Localization.lang("Resolving duplicate BibTeX keys..."));
 
     }

--- a/src/main/java/net/sf/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/SaveDatabaseAction.java
@@ -81,7 +81,7 @@ public class SaveDatabaseAction extends AbstractWorker {
     }
 
     @Override
-    public void init() throws Throwable {
+    public void init() throws Exception {
         success = false;
         canceled = false;
         fileLockedError = false;
@@ -280,7 +280,7 @@ public class SaveDatabaseAction extends AbstractWorker {
      * Run the "Save" operation. This method offloads the actual save operation to a background thread, but
      * still runs synchronously using Spin (the method returns only after completing the operation).
      */
-    public void runCommand() throws Throwable {
+    public void runCommand() throws Exception {
         // This part uses Spin's features:
         Worker worker = getWorker();
         // The Worker returned by getWorker() has been wrapped
@@ -300,12 +300,12 @@ public class SaveDatabaseAction extends AbstractWorker {
         callback.update(); // Runs the update() method on the EDT.
     }
 
-    public void save() throws Throwable {
+    public void save() throws Exception {
         runCommand();
         frame.updateEnabledState();
     }
 
-    public void saveAs() throws Throwable {
+    public void saveAs() throws Exception {
         // configure file dialog
         FileDialog dialog = new FileDialog(frame);
         dialog.withExtension(FileExtensions.BIBTEX_DB);
@@ -324,7 +324,7 @@ public class SaveDatabaseAction extends AbstractWorker {
      * Run the "Save as" operation. This method offloads the actual save operation to a background thread, but
      * still runs synchronously using Spin (the method returns only after completing the operation).
      */
-    public void saveAs(File file) throws Throwable {
+    public void saveAs(File file) throws Exception {
         BibDatabaseContext context = panel.getBibDatabaseContext();
 
         if (context.getLocation() == DatabaseLocation.SHARED) {

--- a/src/main/java/net/sf/jabref/gui/externalfiles/FindFullTextAction.java
+++ b/src/main/java/net/sf/jabref/gui/externalfiles/FindFullTextAction.java
@@ -40,7 +40,7 @@ public class FindFullTextAction extends AbstractWorker {
     }
 
     @Override
-    public void init() throws Throwable {
+    public void init() throws Exception {
         basePanel.output(Localization.lang("Looking for full text document..."));
     }
 

--- a/src/main/java/net/sf/jabref/gui/groups/GroupAddRemoveDialog.java
+++ b/src/main/java/net/sf/jabref/gui/groups/GroupAddRemoveDialog.java
@@ -56,7 +56,7 @@ public class GroupAddRemoveDialog implements BaseAction {
     }
 
     @Override
-    public void action() throws Throwable {
+    public void action() throws Exception {
         Optional<GroupTreeNode> groups = panel.getBibDatabaseContext().getMetaData().getGroups();
         if (!groups.isPresent()) {
             return;

--- a/src/main/java/net/sf/jabref/gui/worker/AbstractWorker.java
+++ b/src/main/java/net/sf/jabref/gui/worker/AbstractWorker.java
@@ -23,7 +23,7 @@ public abstract class AbstractWorker implements Worker, CallBack {
 
     }
 
-    public void init() throws Throwable {
+    public void init() throws Exception {
         // Do nothing
     }
 


### PR DESCRIPTION
Reviewing #2307 I noticed that `BaseAction` and `AbstractWorker` use `Throwable` in their method signature. I cannot find a reason for linking to the highest possible error type here. After all, this has nothing to do with JVM errors or the like. 

I moved the type one step down in the hierarchy to `Exception` which is still basic enough to cover every possible.

- [X] Manually tested changed features in running JabRef 


