### PR TITLE
Consider dev tag in version comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the file permissions of the .bib-file were changed upon saving [#2279](https://github.com/JabRef/jabref/issues/2279).
 - We fixed an issue which prevented that a database was saved successfully if JabRef failed to generate new BibTeX-keys [#2285](https://github.com/JabRef/jabref/issues/2285).
 - We fixed an issue when JabRef restores its session and a shared database was used: The error message "No suitable driver found" will not appear.
-- Fixed: [#2298](https://github.com/JabRef/jabref/issues/2298): dev-Tag is now considered by the Version check
+- Update check now correctly notifies about new release if development version is used. [#2298](https://github.com/JabRef/jabref/issues/2298)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the file permissions of the .bib-file were changed upon saving [#2279](https://github.com/JabRef/jabref/issues/2279).
 - We fixed an issue which prevented that a database was saved successfully if JabRef failed to generate new BibTeX-keys [#2285](https://github.com/JabRef/jabref/issues/2285).
 - We fixed an issue when JabRef restores its session and a shared database was used: The error message "No suitable driver found" will not appear.
+- Fixed: [#2298](https://github.com/JabRef/jabref/issues/2298): dev-Tag is now considered by the Version check
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/logic/util/Version.java
+++ b/src/main/java/net/sf/jabref/logic/util/Version.java
@@ -128,7 +128,12 @@ public class Version {
                     return true;
                 } else if (this.getPatch() == otherVersion.getPatch()) {
                     // if the patch numbers are equal compare the development stages
-                    return this.developmentStage.isMoreStableThan(otherVersion.developmentStage);
+                    if (this.developmentStage.isMoreStableThan(otherVersion.developmentStage)) {
+                        return true;
+                    } else if (this.developmentStage == otherVersion.developmentStage) {
+                        // if the stage is equal check if this version is in development and the other is not
+                        return !this.isDevelopmentVersion && otherVersion.isDevelopmentVersion;
+                    }
                 }
             }
         }

--- a/src/test/java/net/sf/jabref/logic/util/VersionTest.java
+++ b/src/test/java/net/sf/jabref/logic/util/VersionTest.java
@@ -112,7 +112,7 @@ public class VersionTest {
     }
 
     @Test
-    public void unknownVersionIsNotNewerThanvalidVersion() {
+    public void unknownVersionIsNotNewerThanValidVersion() {
         Version unknownVersion = Version.parse(BuildInfo.UNKNOWN_VERSION);
         Version validVersion = Version.parse("4.2");
         assertFalse(unknownVersion.isNewerThan(validVersion));
@@ -144,6 +144,14 @@ public class VersionTest {
         Version older = Version.parse("4.2");
         Version newer = Version.parse("4.3dev");
         assertTrue(newer.isNewerThan(older));
+    }
+
+    @Test
+    public void versionNewerThanDevVersion() {
+        Version older = Version.parse("1.2dev");
+        Version newer = Version.parse("1.2");
+        assertTrue(newer.isNewerThan(older));
+        assertFalse(older.isNewerThan(newer));
     }
 
     @Test


### PR DESCRIPTION
Fixes: https://github.com/JabRef/jabref/issues/2298

The version check now considers the dev tag.