### PR TITLE
Add DOI integrity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Changed
 - URLs can now be passed as arguments to the `-import` and `-importToOpen` command line options. The referenced file is downloaded and then imported as usual.
 - The default emacs executable name on linux changed from `gnuclient` to `emacsclient`. [feature-request 433](https://sourceforge.net/p/jabref/feature-requests/433/)
+- Adds an integrity check that detects invalid DOIs [#1445](https://github.com/JabRef/jabref/issues/2273)
 
 ### Fixed
 - We fixed an issue which caused a metadata loss on reconnection to shared database. [#2219](https://github.com/JabRef/jabref/issues/2219)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Changed
 - URLs can now be passed as arguments to the `-import` and `-importToOpen` command line options. The referenced file is downloaded and then imported as usual.
 - The default emacs executable name on linux changed from `gnuclient` to `emacsclient`. [feature-request 433](https://sourceforge.net/p/jabref/feature-requests/433/)
-- Adds an integrity check that detects invalid DOIs [#1445](https://github.com/JabRef/jabref/issues/2273)
+- Adds an integrity check that detects invalid DOIs [#1445](https://github.com/JabRef/jabref/issues/1445)
 
 ### Fixed
 - We fixed an issue which caused a metadata loss on reconnection to shared database. [#2219](https://github.com/JabRef/jabref/issues/2219)

--- a/src/main/java/net/sf/jabref/logic/integrity/DOIValidityChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/DOIValidityChecker.java
@@ -2,7 +2,6 @@ package net.sf.jabref.logic.integrity;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import net.sf.jabref.logic.integrity.IntegrityCheck.Checker;
 import net.sf.jabref.logic.l10n.Localization;
@@ -14,18 +13,10 @@ public class DOIValidityChecker implements Checker {
 
     @Override
     public List<IntegrityMessage> check(BibEntry entry) {
-        String field = FieldName.DOI;
-        Optional<String> value = entry.getField(field);
-        if (!value.isPresent()) {
-            return Collections.emptyList();
-        }
-
-        final boolean isDOIValid = value.flatMap(v -> DOI.build(v)).isPresent();
-        if (!isDOIValid) {
-            return Collections.singletonList(
-                    new IntegrityMessage(Localization.lang("DOI %0 is invalid", value.orElse("")), entry, field));
-        }
-
-        return Collections.emptyList();
+        final String field = FieldName.DOI;
+        return entry.getField(field)
+                .filter(d -> !DOI.isValid(d))
+                .map(d -> Collections.singletonList(new IntegrityMessage(Localization.lang("DOI %0 is invalid", d), entry, field)))
+                .orElse(Collections.emptyList());
     }
 }

--- a/src/main/java/net/sf/jabref/logic/integrity/DOIValidityChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/DOIValidityChecker.java
@@ -2,7 +2,6 @@ package net.sf.jabref.logic.integrity;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 
 import net.sf.jabref.logic.integrity.IntegrityCheck.Checker;
@@ -24,7 +23,7 @@ public class DOIValidityChecker implements Checker {
         final boolean isDOIValid = value.flatMap(v -> DOI.build(v)).isPresent();
         if (!isDOIValid) {
             return Collections.singletonList(
-                    new IntegrityMessage(Localization.lang("DOI is invalid"), entry, field));
+                    new IntegrityMessage(Localization.lang("DOI %0 is invalid", value.orElse("")), entry, field));
         }
 
         return Collections.emptyList();

--- a/src/main/java/net/sf/jabref/logic/integrity/DOIValidityChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/DOIValidityChecker.java
@@ -1,0 +1,32 @@
+package net.sf.jabref.logic.integrity;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import net.sf.jabref.logic.integrity.IntegrityCheck.Checker;
+import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.logic.util.DOI;
+import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.model.entry.FieldName;
+
+public class DOIValidityChecker implements Checker {
+
+    @Override
+    public List<IntegrityMessage> check(BibEntry entry) {
+        String field = FieldName.DOI;
+        Optional<String> value = entry.getField(field);
+        if (!value.isPresent()) {
+            return Collections.emptyList();
+        }
+
+        final boolean isDOIValid = value.flatMap(v -> DOI.build(v)).isPresent();
+        if (!isDOIValid) {
+            return Collections.singletonList(
+                    new IntegrityMessage(Localization.lang("DOI is invalid"), entry, field));
+        }
+
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
@@ -70,6 +70,7 @@ public class IntegrityCheck {
         result.addAll(new BooktitleChecker().check(entry));
         result.addAll(new ISSNChecker().check(entry));
         result.addAll(new ISBNChecker().check(entry));
+        result.addAll(new DOIValidityChecker().check(entry));
         result.addAll(new EntryLinkChecker(bibDatabaseContext.getDatabase()).check(entry));
 
         return result;

--- a/src/main/java/net/sf/jabref/logic/util/DOI.java
+++ b/src/main/java/net/sf/jabref/logic/util/DOI.java
@@ -107,6 +107,16 @@ public class DOI {
     }
 
     /**
+     * Determines whether a DOI is valid or not
+     *
+     * @param doi the DOI string
+     * @return true if DOI is valid, false otherwise
+     */
+    public static boolean isValid(String doi ){
+        return build(doi).isPresent();
+    }
+
+    /**
      * Tries to find a DOI inside the given text.
      *
      * @param text the Text which might contain a DOI

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -2304,4 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
-DOI_is_invalid=
+DOI_%0_is_invalid=

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+DOI_is_invalid=

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=Empfohlen_für_%0
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=Dies_kann_durch_eine_Downloadbeschränkung_von_Google_Scholar_ausgelöst_werden_(mehr_Details_in_der_'Hilfe').
 
 Problem_downloading_from_%1=
+DOI_is_invalid=

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2304,4 +2304,4 @@ Recommended_for_%0=Empfohlen_für_%0
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=Dies_kann_durch_eine_Downloadbeschränkung_von_Google_Scholar_ausgelöst_werden_(mehr_Details_in_der_'Hilfe').
 
 Problem_downloading_from_%1=
-DOI_is_invalid=
+DOI_%0_is_invalid=

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=Recommended_for_%0
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).
 
 Problem_downloading_from_%1=Problem_downloading_from_%1
+DOI_is_invalid=DOI_is_invalid

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2304,4 +2304,4 @@ Recommended_for_%0=Recommended_for_%0
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).
 
 Problem_downloading_from_%1=Problem_downloading_from_%1
-DOI_is_invalid=DOI_is_invalid
+DOI_%0_is_invalid=DOI_%0_is_invalid

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -2304,4 +2304,4 @@ Recommended_for_%0=Recomendado_para_%0
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=Esto_puede_ser_debido_a_alcanzar_el_límite_de_tráfico_de_GoogleScholar_(vea_la_'Ayuda'_para_más_detalles)
 
 Problem_downloading_from_%1=
-DOI_is_invalid=
+DOI_%0_is_invalid=

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=Recomendado_para_%0
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=Esto_puede_ser_debido_a_alcanzar_el_límite_de_tráfico_de_GoogleScholar_(vea_la_'Ayuda'_para_más_detalles)
 
 Problem_downloading_from_%1=
+DOI_is_invalid=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -2304,4 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
-DOI_is_invalid=
+DOI_%0_is_invalid=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+DOI_is_invalid=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -2304,4 +2304,4 @@ Recommended_for_%0=Recommandé_pour_%0
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=La_limitation_de_trafic_de_Google_Scholar_pourrait_avoir_été_atteinte_(voir_l'aide_pour_plus_de_détails).
 
 Problem_downloading_from_%1=
-DOI_is_invalid=
+DOI_%0_is_invalid=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=Recommandé_pour_%0
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=La_limitation_de_trafic_de_Google_Scholar_pourrait_avoir_été_atteinte_(voir_l'aide_pour_plus_de_détails).
 
 Problem_downloading_from_%1=
+DOI_is_invalid=

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -2304,4 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
-DOI_is_invalid=
+DOI_%0_is_invalid=

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+DOI_is_invalid=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=Raccomandato_per_%0
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=Questo_può_essere_dovuto_al_raggiungimento_del_limite_di_traffico_di_Google_Scholar_(vedi_'Aiuto'_per_i_dettagli).
 
 Problem_downloading_from_%1=Problema_scaricando_da_%1
+DOI_is_invalid=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -2304,4 +2304,4 @@ Recommended_for_%0=Raccomandato_per_%0
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=Questo_può_essere_dovuto_al_raggiungimento_del_limite_di_traffico_di_Google_Scholar_(vedi_'Aiuto'_per_i_dettagli).
 
 Problem_downloading_from_%1=Problema_scaricando_da_%1
-DOI_is_invalid=
+DOI_%0_is_invalid=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2304,4 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
-DOI_is_invalid=
+DOI_%0_is_invalid=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+DOI_is_invalid=

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -2304,4 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
-DOI_is_invalid=
+DOI_%0_is_invalid=

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+DOI_is_invalid=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -2304,4 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
-DOI_is_invalid=
+DOI_%0_is_invalid=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+DOI_is_invalid=

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -2304,4 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
-DOI_is_invalid=
+DOI_%0_is_invalid=

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+DOI_is_invalid=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2304,4 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
-DOI_is_invalid=
+DOI_%0_is_invalid=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+DOI_is_invalid=

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -2304,4 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
-DOI_is_invalid=
+DOI_%0_is_invalid=

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+DOI_is_invalid=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -2304,4 +2304,4 @@ Recommended_for_%0=%0_için_önerilir
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=Bu,_Google_Scholar'ın_trafik_limitine_erişmekten_dolayı_olabilir_(ayrıntılar_için_'Yardım'a_bakınız).
 
 Problem_downloading_from_%1=%1'den_indirmede_hata
-DOI_is_invalid=
+DOI_%0_is_invalid=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=%0_için_önerilir
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=Bu,_Google_Scholar'ın_trafik_limitine_erişmekten_dolayı_olabilir_(ayrıntılar_için_'Yardım'a_bakınız).
 
 Problem_downloading_from_%1=%1'den_indirmede_hata
+DOI_is_invalid=

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -2304,4 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
-DOI_is_invalid=
+DOI_%0_is_invalid=

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+DOI_is_invalid=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -2304,4 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
-DOI_is_invalid=
+DOI_%0_is_invalid=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+DOI_is_invalid=

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -280,6 +280,12 @@ public class IntegrityCheckTest {
     }
 
     @Test
+    public void testDOIChecks() {
+        assertCorrect(createContext("doi", "10.1023/A:1022883727209"));
+        assertWrong(createContext("doi", "asdf"));
+    }
+
+    @Test
     public void testASCIIChecks() {
         assertCorrect(createContext("title", "Only ascii characters!'@12"));
         assertWrong(createContext("month", "Umlauts are nöt ällowed"));

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -282,6 +282,8 @@ public class IntegrityCheckTest {
     @Test
     public void testDOIChecks() {
         assertCorrect(createContext("doi", "10.1023/A:1022883727209"));
+        assertCorrect(createContext("doi", "10.17487/rfc1436"));
+        assertCorrect(createContext("doi", "10.1002/(SICI)1097-4571(199205)43:4<284::AID-ASI3>3.0.CO;2-0"));
         assertWrong(createContext("doi", "asdf"));
     }
 


### PR DESCRIPTION
Refs #1445

Adds an integrity check to determine whether we can handle the content in the DOI field of a bib entry.

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [x] If you changed the localization: Did you run `gradle localizationUpdate`?

