### PR TITLE
Add bibtex key deviation check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Changed
 - URLs can now be passed as arguments to the `-import` and `-importToOpen` command line options. The referenced file is downloaded and then imported as usual.
 - The default emacs executable name on linux changed from `gnuclient` to `emacsclient`. [feature-request 433](https://sourceforge.net/p/jabref/feature-requests/433/)
+- Adds integrity check to detect all bibtex keys which deviate from their generation pattern [#2206](https://github.com/JabRef/jabref/issues/2206)
 
 ### Fixed
 - We fixed an issue which caused a metadata loss on reconnection to shared database. [#2219](https://github.com/JabRef/jabref/issues/2219)

--- a/src/databaseTest/java/net/sf/jabref/shared/DBMSSynchronizerTest.java
+++ b/src/databaseTest/java/net/sf/jabref/shared/DBMSSynchronizerTest.java
@@ -53,7 +53,7 @@ public class DBMSSynchronizerTest {
         bibDatabase = new BibDatabase();
         BibDatabaseContext context = new BibDatabaseContext(bibDatabase);
 
-        pattern = new GlobalBibtexKeyPattern(AbstractBibtexKeyPattern.split("[auth][year]"));
+        pattern = GlobalBibtexKeyPattern.fromPattern("[auth][year]");
 
         dbmsSynchronizer = new DBMSSynchronizer(context, ',', pattern);
         dbmsProcessor = DBMSProcessor.getProcessorInstance(dbmsConnection);

--- a/src/databaseTest/java/net/sf/jabref/shared/DBMSSynchronizerTest.java
+++ b/src/databaseTest/java/net/sf/jabref/shared/DBMSSynchronizerTest.java
@@ -10,7 +10,6 @@ import java.util.Map;
 
 import net.sf.jabref.logic.exporter.MetaDataSerializer;
 import net.sf.jabref.logic.formatter.casechanger.LowerCaseFormatter;
-import net.sf.jabref.model.bibtexkeypattern.AbstractBibtexKeyPattern;
 import net.sf.jabref.model.bibtexkeypattern.GlobalBibtexKeyPattern;
 import net.sf.jabref.model.cleanup.FieldFormatterCleanup;
 import net.sf.jabref.model.cleanup.FieldFormatterCleanups;

--- a/src/databaseTest/java/net/sf/jabref/shared/SynchronizationTestSimulator.java
+++ b/src/databaseTest/java/net/sf/jabref/shared/SynchronizationTestSimulator.java
@@ -40,7 +40,7 @@ public class SynchronizationTestSimulator {
     public void setUp() throws SQLException, DatabaseNotSupportedException, InvalidDBMSConnectionPropertiesException {
         this.dbmsConnection = TestConnector.getTestDBMSConnection(dbmsType);
 
-        GlobalBibtexKeyPattern pattern = new GlobalBibtexKeyPattern(AbstractBibtexKeyPattern.split("[auth][year]"));
+        GlobalBibtexKeyPattern pattern = GlobalBibtexKeyPattern.fromPattern("[auth][year]");
         clientContextA = new BibDatabaseContext(new Defaults(BibDatabaseMode.BIBTEX), DatabaseLocation.SHARED, ',',
                 pattern);
         clientContextA.getDBMSSynchronizer().openSharedDatabase(dbmsConnection);

--- a/src/databaseTest/java/net/sf/jabref/shared/SynchronizationTestSimulator.java
+++ b/src/databaseTest/java/net/sf/jabref/shared/SynchronizationTestSimulator.java
@@ -4,7 +4,6 @@ import java.sql.SQLException;
 import java.util.Collection;
 
 import net.sf.jabref.model.Defaults;
-import net.sf.jabref.model.bibtexkeypattern.AbstractBibtexKeyPattern;
 import net.sf.jabref.model.bibtexkeypattern.GlobalBibtexKeyPattern;
 import net.sf.jabref.model.database.BibDatabaseContext;
 import net.sf.jabref.model.database.BibDatabaseMode;

--- a/src/main/java/net/sf/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/net/sf/jabref/cli/ArgumentProcessor.java
@@ -453,7 +453,7 @@ public class ArgumentProcessor {
                 LOGGER.info(Localization.lang("Regenerating BibTeX keys according to metadata"));
                 for (BibEntry entry : database.getEntries()) {
                     // try to make a new label
-                    BibtexKeyPatternUtil.makeLabel(
+                    BibtexKeyPatternUtil.makeAndSetLabel(
                             metaData.getCiteKeyPattern(Globals.prefs.getBibtexKeyPatternPreferences().getKeyPattern()),
                             database, entry, Globals.prefs.getBibtexKeyPatternPreferences());
                 }

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -433,7 +433,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                         .getCiteKeyPattern(Globals.prefs.getBibtexKeyPatternPreferences().getKeyPattern());
                 for (BibEntry entry : entries) {
                     String oldCiteKey = entry.getCiteKeyOptional().orElse("");
-                    BibtexKeyPatternUtil.makeLabel(citeKeyPattern, bibDatabaseContext.getDatabase(),
+                    BibtexKeyPatternUtil.makeAndSetLabel(citeKeyPattern, bibDatabaseContext.getDatabase(),
                             entry, Globals.prefs.getBibtexKeyPatternPreferences());
                     String newCiteKey = entry.getCiteKeyOptional().orElse("");
                     if (!oldCiteKey.equals(newCiteKey)) {
@@ -1893,7 +1893,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             for (BibEntry bes : bibDatabaseContext.getDatabase().getEntries()) {
                 Optional<String> oldKey = bes.getCiteKeyOptional();
                 if (!(oldKey.isPresent()) || oldKey.get().isEmpty()) {
-                    BibtexKeyPatternUtil.makeLabel(bibDatabaseContext.getMetaData()
+                    BibtexKeyPatternUtil.makeAndSetLabel(bibDatabaseContext.getMetaData()
                             .getCiteKeyPattern(Globals.prefs.getBibtexKeyPatternPreferences().getKeyPattern()),
                             bibDatabaseContext.getDatabase(),
                             bes, Globals.prefs.getBibtexKeyPatternPreferences());

--- a/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
+++ b/src/main/java/net/sf/jabref/gui/actions/IntegrityCheckAction.java
@@ -47,7 +47,8 @@ public class IntegrityCheckAction extends MnemonicAwareAction {
     @Override
     public void actionPerformed(ActionEvent e) {
         IntegrityCheck check = new IntegrityCheck(frame.getCurrentBasePanel().getBibDatabaseContext(),
-                Globals.prefs.getFileDirectoryPreferences());
+                Globals.prefs.getFileDirectoryPreferences(),
+                Globals.prefs.getBibtexKeyPatternPreferences());
         List<IntegrityMessage> messages = check.checkBibtexDatabase();
 
         if (messages.isEmpty()) {

--- a/src/main/java/net/sf/jabref/gui/bibtexkeypattern/BibtexKeyPatternPanel.java
+++ b/src/main/java/net/sf/jabref/gui/bibtexkeypattern/BibtexKeyPatternPanel.java
@@ -224,8 +224,9 @@ public class BibtexKeyPatternPanel extends JPanel {
     }
 
     protected GlobalBibtexKeyPattern getKeyPatternAsGlobalBibtexKeyPattern() {
-        GlobalBibtexKeyPattern res = new GlobalBibtexKeyPattern(
-                AbstractBibtexKeyPattern.split(JabRefPreferences.getInstance().get(JabRefPreferences.DEFAULT_BIBTEX_KEY_PATTERN)));
+        GlobalBibtexKeyPattern res = GlobalBibtexKeyPattern.fromPattern(
+                JabRefPreferences.getInstance().get(JabRefPreferences.DEFAULT_BIBTEX_KEY_PATTERN)
+        );
         fillPatternUsingPanelData(res);
         return res;
     }

--- a/src/main/java/net/sf/jabref/gui/bibtexkeypattern/SearchFixDuplicateLabels.java
+++ b/src/main/java/net/sf/jabref/gui/bibtexkeypattern/SearchFixDuplicateLabels.java
@@ -93,7 +93,7 @@ public class SearchFixDuplicateLabels extends AbstractWorker {
             NamedCompound ce = new NamedCompound(Localization.lang("Resolve duplicate BibTeX keys"));
             for (BibEntry entry : toGenerateFor) {
                 String oldKey = entry.getCiteKeyOptional().orElse(null);
-                BibtexKeyPatternUtil.makeLabel(panel.getBibDatabaseContext().getMetaData()
+                BibtexKeyPatternUtil.makeAndSetLabel(panel.getBibDatabaseContext().getMetaData()
                         .getCiteKeyPattern(Globals.prefs.getBibtexKeyPatternPreferences().getKeyPattern()),
                         panel.getDatabase(), entry,
                         Globals.prefs.getBibtexKeyPatternPreferences());

--- a/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/net/sf/jabref/gui/entryeditor/EntryEditor.java
@@ -1256,7 +1256,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
                 }
             }
 
-            BibtexKeyPatternUtil.makeLabel(panel.getBibDatabaseContext().getMetaData()
+            BibtexKeyPatternUtil.makeAndSetLabel(panel.getBibDatabaseContext().getMetaData()
                     .getCiteKeyPattern(Globals.prefs.getBibtexKeyPatternPreferences().getKeyPattern()), panel.getDatabase(), entry,
                     Globals.prefs.getBibtexKeyPatternPreferences());
 

--- a/src/main/java/net/sf/jabref/gui/importer/ImportInspectionDialog.java
+++ b/src/main/java/net/sf/jabref/gui/importer/ImportInspectionDialog.java
@@ -462,7 +462,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
             database.insertEntry(entry);
 
             // Generate a unique key:
-            BibtexKeyPatternUtil.makeLabel(
+            BibtexKeyPatternUtil.makeAndSetLabel(
                     localMetaData.getCiteKeyPattern(Globals.prefs.getBibtexKeyPatternPreferences().getKeyPattern()),
                     database, entry,
                     Globals.prefs.getBibtexKeyPatternPreferences());
@@ -506,7 +506,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
                 entry.setId(IdGenerator.next());
                 database.insertEntry(entry);
 
-                BibtexKeyPatternUtil.makeLabel(
+                BibtexKeyPatternUtil.makeAndSetLabel(
                         localMetaData.getCiteKeyPattern(Globals.prefs.getBibtexKeyPatternPreferences().getKeyPattern()),
                         database, entry,
                         Globals.prefs.getBibtexKeyPatternPreferences());

--- a/src/main/java/net/sf/jabref/gui/openoffice/OpenOfficePanel.java
+++ b/src/main/java/net/sf/jabref/gui/openoffice/OpenOfficePanel.java
@@ -685,7 +685,7 @@ public class OpenOfficePanel extends AbstractWorker {
                 if (!entry.getCiteKeyOptional().isPresent()) {
                     // Generate key
                     BibtexKeyPatternUtil
-                            .makeLabel(
+                            .makeAndSetLabel(
                                     panel.getBibDatabaseContext().getMetaData().getCiteKeyPattern(prefs.getKeyPattern()),
                                     panel.getDatabase(), entry,
                             prefs);

--- a/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -10,12 +10,14 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import net.sf.jabref.Globals;
 import net.sf.jabref.logic.formatter.Formatters;
 import net.sf.jabref.logic.formatter.casechanger.Word;
 import net.sf.jabref.logic.layout.format.RemoveLatexCommandsFormatter;
 import net.sf.jabref.model.bibtexkeypattern.AbstractBibtexKeyPattern;
 import net.sf.jabref.model.cleanup.Formatter;
 import net.sf.jabref.model.database.BibDatabase;
+import net.sf.jabref.model.database.BibDatabaseContext;
 import net.sf.jabref.model.entry.AuthorList;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
@@ -1304,4 +1306,13 @@ public class BibtexKeyPatternUtil {
         return StringUtil.replaceSpecialCharacters(newKey.toString());
     }
 
+    public static String generateNewCityKey(BibDatabaseContext bibDatabaseContext, BibEntry entry) {
+        // clone as new city key is always set during generation; avoids side effects in database
+        BibEntry clonedEntry = (BibEntry) entry.clone();
+
+        final BibtexKeyPatternPreferences keyPatterns = Globals.prefs.getBibtexKeyPatternPreferences();
+        AbstractBibtexKeyPattern citeKeyPattern = bibDatabaseContext.getMetaData().getCiteKeyPattern(keyPatterns.getKeyPattern());
+        makeLabel(citeKeyPattern, bibDatabaseContext.getDatabase(), clonedEntry, keyPatterns);
+        return clonedEntry.getCiteKeyOptional().orElse("");
+    }
 }

--- a/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -368,8 +368,13 @@ public class BibtexKeyPatternUtil {
      * @param entry a <code>BibEntry</code>
      * @return modified BibEntry
      */
-    public static void makeLabel(AbstractBibtexKeyPattern citeKeyPattern, BibDatabase database, BibEntry entry,
+    public static void makeAndSetLabel(AbstractBibtexKeyPattern citeKeyPattern, BibDatabase database, BibEntry entry,
             BibtexKeyPatternPreferences bibtexKeyPatternPreferences) {
+        String newKey = makeLabel(citeKeyPattern, database, entry, bibtexKeyPatternPreferences);
+        entry.setCiteKey(newKey);
+    }
+
+    private static String makeLabel(AbstractBibtexKeyPattern citeKeyPattern, BibDatabase database, BibEntry entry, BibtexKeyPatternPreferences bibtexKeyPatternPreferences) {
         String key;
         StringBuilder stringBuilder = new StringBuilder();
         try {
@@ -390,7 +395,7 @@ public class BibtexKeyPatternUtil {
                     // check whether there is a modifier on the end such as
                     // ":lower"
                     List<String> parts = parseFieldMarker(typeListEntry);
-                    String label = makeLabel(entry, parts.get(0), bibtexKeyPatternPreferences.getKeywordDelimiter(), database);
+                    String label = makeAndSetLabel(entry, parts.get(0), bibtexKeyPatternPreferences.getKeywordDelimiter(), database);
 
                     // apply modifier if present
                     if (parts.size() > 1) {
@@ -427,8 +432,9 @@ public class BibtexKeyPatternUtil {
         boolean alwaysAddLetter = bibtexKeyPatternPreferences.isAlwaysAddLetter();
         boolean firstLetterA = bibtexKeyPatternPreferences.isFirstLetterA();
 
+        String newKey;
         if (!alwaysAddLetter && (occurrences == 0)) {
-            entry.setCiteKey(key);
+            newKey = key;
         } else {
             // The key is already in use, so we must modify it.
             int number = !alwaysAddLetter && !firstLetterA ? 1 : 0;
@@ -445,8 +451,9 @@ public class BibtexKeyPatternUtil {
                 }
             } while (occurrences > 0);
 
-            entry.setCiteKey(moddedKey);
+            newKey = moddedKey;
         }
+        return newKey;
     }
 
     /**
@@ -497,7 +504,7 @@ public class BibtexKeyPatternUtil {
         return resultingLabel;
     }
 
-    public static String makeLabel(BibEntry entry, String value, Character keywordDelimiter, BibDatabase database) {
+    public static String makeAndSetLabel(BibEntry entry, String value, Character keywordDelimiter, BibDatabase database) {
         String val = value;
         try {
             if (val.startsWith("auth") || val.startsWith("pureauth")) {
@@ -1293,12 +1300,10 @@ public class BibtexKeyPatternUtil {
         return StringUtil.replaceSpecialCharacters(newKey.toString());
     }
 
-    public static String generateNewCityKey(BibDatabaseContext bibDatabaseContext, BibEntry entry, BibtexKeyPatternPreferences bibtexKeyPatternPreferences) {
-        // clone as new city key is always set during generation; avoids side effects in database
-        BibEntry clonedEntry = (BibEntry) entry.clone();
-
+    public static String makeLabel(BibDatabaseContext bibDatabaseContext,
+            BibEntry entry,
+            BibtexKeyPatternPreferences bibtexKeyPatternPreferences) {
         AbstractBibtexKeyPattern citeKeyPattern = bibDatabaseContext.getMetaData().getCiteKeyPattern(bibtexKeyPatternPreferences.getKeyPattern());
-        makeLabel(citeKeyPattern, bibDatabaseContext.getDatabase(), clonedEntry, bibtexKeyPatternPreferences);
-        return clonedEntry.getCiteKeyOptional().orElse("");
+        return makeLabel(citeKeyPattern, bibDatabaseContext.getDatabase(), entry, bibtexKeyPatternPreferences);
     }
 }

--- a/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -43,17 +43,6 @@ public class BibtexKeyPatternUtil {
 
     private static final int CHARS_OF_FIRST = 5;
 
-    private static BibDatabase database;
-
-    /**
-     * Required for LabelPatternUtilTest
-     *
-     * @param db the DB to use as global database
-     */
-    public static void setDataBase(BibDatabase db) {
-        database = db;
-    }
-
     private static String normalize(String content) {
         List<String> tokens = new ArrayList<>();
         int b = 0;
@@ -375,13 +364,12 @@ public class BibtexKeyPatternUtil {
      * The given database is used to avoid duplicate keys.
      *
      * @param citeKeyPattern
-     * @param dBase a <code>BibDatabase</code>
+     * @param database a <code>BibDatabase</code>
      * @param entry a <code>BibEntry</code>
      * @return modified BibEntry
      */
-    public static void makeLabel(AbstractBibtexKeyPattern citeKeyPattern, BibDatabase dBase, BibEntry entry,
+    public static void makeLabel(AbstractBibtexKeyPattern citeKeyPattern, BibDatabase database, BibEntry entry,
             BibtexKeyPatternPreferences bibtexKeyPatternPreferences) {
-        database = dBase;
         String key;
         StringBuilder stringBuilder = new StringBuilder();
         try {
@@ -402,7 +390,7 @@ public class BibtexKeyPatternUtil {
                     // check whether there is a modifier on the end such as
                     // ":lower"
                     List<String> parts = parseFieldMarker(typeListEntry);
-                    String label = makeLabel(entry, parts.get(0), bibtexKeyPatternPreferences.getKeywordDelimiter());
+                    String label = makeLabel(entry, parts.get(0), bibtexKeyPatternPreferences.getKeywordDelimiter(), database);
 
                     // apply modifier if present
                     if (parts.size() > 1) {
@@ -509,7 +497,7 @@ public class BibtexKeyPatternUtil {
         return resultingLabel;
     }
 
-    public static String makeLabel(BibEntry entry, String value, Character keywordDelimiter) {
+    public static String makeLabel(BibEntry entry, String value, Character keywordDelimiter, BibDatabase database) {
         String val = value;
         try {
             if (val.startsWith("auth") || val.startsWith("pureauth")) {

--- a/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.logic.formatter.Formatters;
 import net.sf.jabref.logic.formatter.casechanger.Word;
 import net.sf.jabref.logic.layout.format.RemoveLatexCommandsFormatter;
@@ -1306,13 +1305,12 @@ public class BibtexKeyPatternUtil {
         return StringUtil.replaceSpecialCharacters(newKey.toString());
     }
 
-    public static String generateNewCityKey(BibDatabaseContext bibDatabaseContext, BibEntry entry) {
+    public static String generateNewCityKey(BibDatabaseContext bibDatabaseContext, BibEntry entry, BibtexKeyPatternPreferences bibtexKeyPatternPreferences) {
         // clone as new city key is always set during generation; avoids side effects in database
         BibEntry clonedEntry = (BibEntry) entry.clone();
 
-        final BibtexKeyPatternPreferences keyPatterns = Globals.prefs.getBibtexKeyPatternPreferences();
-        AbstractBibtexKeyPattern citeKeyPattern = bibDatabaseContext.getMetaData().getCiteKeyPattern(keyPatterns.getKeyPattern());
-        makeLabel(citeKeyPattern, bibDatabaseContext.getDatabase(), clonedEntry, keyPatterns);
+        AbstractBibtexKeyPattern citeKeyPattern = bibDatabaseContext.getMetaData().getCiteKeyPattern(bibtexKeyPatternPreferences.getKeyPattern());
+        makeLabel(citeKeyPattern, bibDatabaseContext.getDatabase(), clonedEntry, bibtexKeyPatternPreferences);
         return clonedEntry.getCiteKeyOptional().orElse("");
     }
 }

--- a/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -395,7 +395,7 @@ public class BibtexKeyPatternUtil {
                     // check whether there is a modifier on the end such as
                     // ":lower"
                     List<String> parts = parseFieldMarker(typeListEntry);
-                    String label = makeAndSetLabel(entry, parts.get(0), bibtexKeyPatternPreferences.getKeywordDelimiter(), database);
+                    String label = makeLabel(entry, parts.get(0), bibtexKeyPatternPreferences.getKeywordDelimiter(), database);
 
                     // apply modifier if present
                     if (parts.size() > 1) {
@@ -504,7 +504,7 @@ public class BibtexKeyPatternUtil {
         return resultingLabel;
     }
 
-    public static String makeAndSetLabel(BibEntry entry, String value, Character keywordDelimiter, BibDatabase database) {
+    public static String makeLabel(BibEntry entry, String value, Character keywordDelimiter, BibDatabase database) {
         String val = value;
         try {
             if (val.startsWith("auth") || val.startsWith("pureauth")) {

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/FreeCiteImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/FreeCiteImporter.java
@@ -203,7 +203,7 @@ public class FreeCiteImporter extends Importer {
                     e.setType(type);
 
                     // autogenerate label (BibTeX key)
-                    BibtexKeyPatternUtil.makeLabel(
+                    BibtexKeyPatternUtil.makeAndSetLabel(
                             JabRefGUI.getMainFrame().getCurrentBasePanel().getBibDatabaseContext().getMetaData()
                                     .getCiteKeyPattern(importFormatPreferences.getBibtexKeyPatternPreferences().getKeyPattern()),
                             JabRefGUI.getMainFrame().getCurrentBasePanel().getDatabase(), e,

--- a/src/main/java/net/sf/jabref/logic/integrity/BibtexkeyDeviationChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/BibtexkeyDeviationChecker.java
@@ -32,7 +32,7 @@ public class BibtexkeyDeviationChecker implements Checker {
         String key = valuekey.get();
 
         // generate new key
-        String generatedKey = BibtexKeyPatternUtil.generateNewCityKey(bibDatabaseContext, entry, bibtexKeyPatternPreferences);
+        String generatedKey = BibtexKeyPatternUtil.makeLabel(bibDatabaseContext, entry, bibtexKeyPatternPreferences);
 
         if (!Objects.equals(key, generatedKey)) {
             return Collections.singletonList(new IntegrityMessage(

--- a/src/main/java/net/sf/jabref/logic/integrity/BibtexkeyDeviationChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/BibtexkeyDeviationChecker.java
@@ -1,0 +1,42 @@
+package net.sf.jabref.logic.integrity;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import net.sf.jabref.logic.bibtexkeypattern.BibtexKeyPatternUtil;
+import net.sf.jabref.logic.integrity.IntegrityCheck.Checker;
+import net.sf.jabref.logic.l10n.Localization;
+import net.sf.jabref.model.database.BibDatabaseContext;
+import net.sf.jabref.model.entry.BibEntry;
+
+public class BibtexkeyDeviationChecker implements Checker {
+
+    private final BibDatabaseContext bibDatabaseContext;
+
+    public BibtexkeyDeviationChecker(BibDatabaseContext bibDatabaseContext) {
+        this.bibDatabaseContext = Objects.requireNonNull(bibDatabaseContext);
+    }
+
+    @Override
+    public List<IntegrityMessage> check(BibEntry entry) {
+        Optional<String> valuekey = entry.getCiteKeyOptional();
+        if (!valuekey.isPresent()) {
+            return Collections.emptyList();
+        }
+
+        String key = valuekey.get();
+
+        // generate new key
+        String generatedKey = BibtexKeyPatternUtil.generateNewCityKey(bibDatabaseContext, entry);
+
+        if (!Objects.equals(key, generatedKey)) {
+            return Collections.singletonList(new IntegrityMessage(
+                    Localization.lang("BibTeX key %0 deviates from generated key %1", key, generatedKey), entry, BibEntry.KEY_FIELD));
+        }
+
+        return Collections.emptyList();
+    }
+
+}

--- a/src/main/java/net/sf/jabref/logic/integrity/BibtexkeyDeviationChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/BibtexkeyDeviationChecker.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import net.sf.jabref.logic.bibtexkeypattern.BibtexKeyPatternPreferences;
 import net.sf.jabref.logic.bibtexkeypattern.BibtexKeyPatternUtil;
 import net.sf.jabref.logic.integrity.IntegrityCheck.Checker;
 import net.sf.jabref.logic.l10n.Localization;
@@ -14,9 +15,11 @@ import net.sf.jabref.model.entry.BibEntry;
 public class BibtexkeyDeviationChecker implements Checker {
 
     private final BibDatabaseContext bibDatabaseContext;
+    private final BibtexKeyPatternPreferences bibtexKeyPatternPreferences;
 
-    public BibtexkeyDeviationChecker(BibDatabaseContext bibDatabaseContext) {
+    public BibtexkeyDeviationChecker(BibDatabaseContext bibDatabaseContext, BibtexKeyPatternPreferences bibtexKeyPatternPreferences) {
         this.bibDatabaseContext = Objects.requireNonNull(bibDatabaseContext);
+        this.bibtexKeyPatternPreferences = Objects.requireNonNull(bibtexKeyPatternPreferences);
     }
 
     @Override
@@ -29,7 +32,7 @@ public class BibtexkeyDeviationChecker implements Checker {
         String key = valuekey.get();
 
         // generate new key
-        String generatedKey = BibtexKeyPatternUtil.generateNewCityKey(bibDatabaseContext, entry);
+        String generatedKey = BibtexKeyPatternUtil.generateNewCityKey(bibDatabaseContext, entry, bibtexKeyPatternPreferences);
 
         if (!Objects.equals(key, generatedKey)) {
             return Collections.singletonList(new IntegrityMessage(

--- a/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import net.sf.jabref.logic.bibtexkeypattern.BibtexKeyPatternPreferences;
 import net.sf.jabref.model.database.BibDatabaseContext;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
@@ -14,10 +15,15 @@ public class IntegrityCheck {
 
     private final BibDatabaseContext bibDatabaseContext;
     private final FileDirectoryPreferences fileDirectoryPreferences;
+    private final BibtexKeyPatternPreferences bibtexKeyPatternPreferences;
 
-    public IntegrityCheck(BibDatabaseContext bibDatabaseContext, FileDirectoryPreferences fileDirectoryPreferences) {
+    public IntegrityCheck(BibDatabaseContext bibDatabaseContext,
+            FileDirectoryPreferences fileDirectoryPreferences,
+            BibtexKeyPatternPreferences bibtexKeyPatternPreferences
+    ) {
         this.bibDatabaseContext = Objects.requireNonNull(bibDatabaseContext);
         this.fileDirectoryPreferences = Objects.requireNonNull(fileDirectoryPreferences);
+        this.bibtexKeyPatternPreferences = Objects.requireNonNull(bibtexKeyPatternPreferences);
     }
 
     public List<IntegrityMessage> checkBibtexDatabase() {
@@ -71,7 +77,7 @@ public class IntegrityCheck {
         result.addAll(new ISSNChecker().check(entry));
         result.addAll(new ISBNChecker().check(entry));
         result.addAll(new EntryLinkChecker(bibDatabaseContext.getDatabase()).check(entry));
-        result.addAll(new BibtexkeyDeviationChecker(bibDatabaseContext).check(entry));
+        result.addAll(new BibtexkeyDeviationChecker(bibDatabaseContext, bibtexKeyPatternPreferences).check(entry));
 
         return result;
     }

--- a/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/IntegrityCheck.java
@@ -71,6 +71,7 @@ public class IntegrityCheck {
         result.addAll(new ISSNChecker().check(entry));
         result.addAll(new ISBNChecker().check(entry));
         result.addAll(new EntryLinkChecker(bibDatabaseContext.getDatabase()).check(entry));
+        result.addAll(new BibtexkeyDeviationChecker(bibDatabaseContext).check(entry));
 
         return result;
     }

--- a/src/main/java/net/sf/jabref/logic/util/io/RegExpFileSearch.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/RegExpFileSearch.java
@@ -324,7 +324,7 @@ public class RegExpFileSearch {
 
         // If no field value was found, try to interpret it as a key generator field marker:
         String fieldValue = entry.getResolvedFieldOrAlias(beforeColon, database)
-                .orElse(BibtexKeyPatternUtil.makeLabel(entry, beforeColon, keywordDelimiter, database));
+                .orElse(BibtexKeyPatternUtil.makeAndSetLabel(entry, beforeColon, keywordDelimiter, database));
 
         if (fieldValue == null) {
             return "";

--- a/src/main/java/net/sf/jabref/logic/util/io/RegExpFileSearch.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/RegExpFileSearch.java
@@ -324,7 +324,7 @@ public class RegExpFileSearch {
 
         // If no field value was found, try to interpret it as a key generator field marker:
         String fieldValue = entry.getResolvedFieldOrAlias(beforeColon, database)
-                .orElse(BibtexKeyPatternUtil.makeLabel(entry, beforeColon, keywordDelimiter));
+                .orElse(BibtexKeyPatternUtil.makeLabel(entry, beforeColon, keywordDelimiter, database));
 
         if (fieldValue == null) {
             return "";

--- a/src/main/java/net/sf/jabref/logic/util/io/RegExpFileSearch.java
+++ b/src/main/java/net/sf/jabref/logic/util/io/RegExpFileSearch.java
@@ -324,7 +324,7 @@ public class RegExpFileSearch {
 
         // If no field value was found, try to interpret it as a key generator field marker:
         String fieldValue = entry.getResolvedFieldOrAlias(beforeColon, database)
-                .orElse(BibtexKeyPatternUtil.makeAndSetLabel(entry, beforeColon, keywordDelimiter, database));
+                .orElse(BibtexKeyPatternUtil.makeLabel(entry, beforeColon, keywordDelimiter, database));
 
         if (fieldValue == null) {
             return "";

--- a/src/main/java/net/sf/jabref/migrations/PreferencesMigrations.java
+++ b/src/main/java/net/sf/jabref/migrations/PreferencesMigrations.java
@@ -7,7 +7,6 @@ import java.util.prefs.Preferences;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.JabRefMain;
-import net.sf.jabref.model.bibtexkeypattern.AbstractBibtexKeyPattern;
 import net.sf.jabref.model.bibtexkeypattern.GlobalBibtexKeyPattern;
 import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.preferences.JabRefPreferences;

--- a/src/main/java/net/sf/jabref/migrations/PreferencesMigrations.java
+++ b/src/main/java/net/sf/jabref/migrations/PreferencesMigrations.java
@@ -131,8 +131,9 @@ public class PreferencesMigrations {
             throws BackingStoreException {
         LOGGER.info("Found old Bibtex Key patterns which will be migrated to new version.");
 
-        GlobalBibtexKeyPattern keyPattern = new GlobalBibtexKeyPattern(AbstractBibtexKeyPattern
-                .split(prefs.get(JabRefPreferences.DEFAULT_BIBTEX_KEY_PATTERN)));
+        GlobalBibtexKeyPattern keyPattern = GlobalBibtexKeyPattern.fromPattern(
+                prefs.get(JabRefPreferences.DEFAULT_BIBTEX_KEY_PATTERN)
+        );
         for (String key : oldPatternPrefs.keys()) {
             keyPattern.addBibtexKeyPattern(key, oldPatternPrefs.get(key, null));
         }

--- a/src/main/java/net/sf/jabref/model/bibtexkeypattern/GlobalBibtexKeyPattern.java
+++ b/src/main/java/net/sf/jabref/model/bibtexkeypattern/GlobalBibtexKeyPattern.java
@@ -10,6 +10,10 @@ public class GlobalBibtexKeyPattern extends AbstractBibtexKeyPattern {
         defaultBibtexKeyPattern = bibtexKeyPattern;
     }
 
+    public static GlobalBibtexKeyPattern fromPattern(String pattern) {
+        return new GlobalBibtexKeyPattern(split(pattern));
+    }
+
     @Override
     public List<String> getLastLevelBibtexKeyPattern(String key) {
         return defaultBibtexKeyPattern;

--- a/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
+++ b/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
@@ -236,7 +236,7 @@ public class PdfImporter {
         // insert entry to database and link file
         panel.getDatabase().insertEntry(entry);
         panel.markBaseChanged();
-        BibtexKeyPatternUtil.makeLabel(panel.getBibDatabaseContext().getMetaData()
+        BibtexKeyPatternUtil.makeAndSetLabel(panel.getBibDatabaseContext().getMetaData()
                 .getCiteKeyPattern(Globals.prefs.getBibtexKeyPatternPreferences().getKeyPattern()), panel.getDatabase(), entry,
                 Globals.prefs.getBibtexKeyPatternPreferences());
         DroppedFileHandler dfh = new DroppedFileHandler(frame, panel);

--- a/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
@@ -67,7 +67,6 @@ import net.sf.jabref.logic.util.UpdateFieldPreferences;
 import net.sf.jabref.logic.util.Version;
 import net.sf.jabref.logic.util.io.FileHistory;
 import net.sf.jabref.logic.xmp.XMPPreferences;
-import net.sf.jabref.model.bibtexkeypattern.AbstractBibtexKeyPattern;
 import net.sf.jabref.model.bibtexkeypattern.GlobalBibtexKeyPattern;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;

--- a/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
@@ -1078,7 +1078,7 @@ public class JabRefPreferences {
      * @return LabelPattern containing all keys. Returned LabelPattern has no parent
      */
     public GlobalBibtexKeyPattern getKeyPattern() {
-        keyPattern = new GlobalBibtexKeyPattern(AbstractBibtexKeyPattern.split(get(DEFAULT_BIBTEX_KEY_PATTERN)));
+        keyPattern = GlobalBibtexKeyPattern.fromPattern(get(DEFAULT_BIBTEX_KEY_PATTERN));
         Preferences pre = Preferences.userNodeForPackage(JabRefMain.class).node(BIBTEX_KEY_PATTERNS_NODE);
         try {
             String[] keys = pre.keys();

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+BibTeX_key_%0_deviates_from_generated_key_%1=

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=Empfohlen_für_%0
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=Dies_kann_durch_eine_Downloadbeschränkung_von_Google_Scholar_ausgelöst_werden_(mehr_Details_in_der_'Hilfe').
 
 Problem_downloading_from_%1=
+BibTeX_key_%0_deviates_from_generated_key_%1=

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=Recommended_for_%0
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).
 
 Problem_downloading_from_%1=Problem_downloading_from_%1
+BibTeX_key_%0_deviates_from_generated_key_%1=BibTeX_key_%0_deviates_from_generated_key_%1

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=Recomendado_para_%0
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=Esto_puede_ser_debido_a_alcanzar_el_límite_de_tráfico_de_GoogleScholar_(vea_la_'Ayuda'_para_más_detalles)
 
 Problem_downloading_from_%1=
+BibTeX_key_%0_deviates_from_generated_key_%1=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+BibTeX_key_%0_deviates_from_generated_key_%1=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=Recommandé_pour_%0
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=La_limitation_de_trafic_de_Google_Scholar_pourrait_avoir_été_atteinte_(voir_l'aide_pour_plus_de_détails).
 
 Problem_downloading_from_%1=
+BibTeX_key_%0_deviates_from_generated_key_%1=

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+BibTeX_key_%0_deviates_from_generated_key_%1=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=Raccomandato_per_%0
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=Questo_può_essere_dovuto_al_raggiungimento_del_limite_di_traffico_di_Google_Scholar_(vedi_'Aiuto'_per_i_dettagli).
 
 Problem_downloading_from_%1=Problema_scaricando_da_%1
+BibTeX_key_%0_deviates_from_generated_key_%1=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+BibTeX_key_%0_deviates_from_generated_key_%1=

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+BibTeX_key_%0_deviates_from_generated_key_%1=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+BibTeX_key_%0_deviates_from_generated_key_%1=

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+BibTeX_key_%0_deviates_from_generated_key_%1=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+BibTeX_key_%0_deviates_from_generated_key_%1=

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+BibTeX_key_%0_deviates_from_generated_key_%1=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=%0_için_önerilir
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=Bu,_Google_Scholar'ın_trafik_limitine_erişmekten_dolayı_olabilir_(ayrıntılar_için_'Yardım'a_bakınız).
 
 Problem_downloading_from_%1=%1'den_indirmede_hata
+BibTeX_key_%0_deviates_from_generated_key_%1=

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+BibTeX_key_%0_deviates_from_generated_key_%1=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -2304,3 +2304,4 @@ Recommended_for_%0=
 This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
 
 Problem_downloading_from_%1=
+BibTeX_key_%0_deviates_from_generated_key_%1=

--- a/src/test/java/net/sf/jabref/MetaDataTest.java
+++ b/src/test/java/net/sf/jabref/MetaDataTest.java
@@ -8,7 +8,6 @@ import java.util.TreeMap;
 import net.sf.jabref.logic.exporter.MetaDataSerializer;
 import net.sf.jabref.logic.formatter.casechanger.LowerCaseFormatter;
 import net.sf.jabref.logic.util.OS;
-import net.sf.jabref.model.bibtexkeypattern.AbstractBibtexKeyPattern;
 import net.sf.jabref.model.bibtexkeypattern.GlobalBibtexKeyPattern;
 import net.sf.jabref.model.cleanup.FieldFormatterCleanup;
 import net.sf.jabref.model.cleanup.FieldFormatterCleanups;

--- a/src/test/java/net/sf/jabref/MetaDataTest.java
+++ b/src/test/java/net/sf/jabref/MetaDataTest.java
@@ -27,7 +27,7 @@ public class MetaDataTest {
     @Before
     public void setUp() {
         metaData = new MetaData();
-        pattern = new GlobalBibtexKeyPattern(AbstractBibtexKeyPattern.split("[auth][year]"));
+        pattern = GlobalBibtexKeyPattern.fromPattern("[auth][year]");
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtilTest.java
@@ -50,7 +50,7 @@ public class BibtexKeyPatternUtilTest {
         Optional<BibEntry> entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Simon Holland}}",
                 importFormatPreferences);
         assertEquals("Holland",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth",
                         ',', new BibDatabase()), true));
     }
 
@@ -59,7 +59,7 @@ public class BibtexKeyPatternUtilTest {
         String bibtexString = "@ARTICLE{whatevery, author={Mari D. Herland and Mona-Iren Hauge and Ingeborg M. Helgeland}}";
         Optional<BibEntry> entry = BibtexParser.singleFromString(bibtexString, importFormatPreferences);
         assertEquals("HerlandHaugeHelgeland",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry.get(), "authors3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry.get(), "authors3",
                         ',', new BibDatabase()), true));
     }
 
@@ -68,7 +68,7 @@ public class BibtexKeyPatternUtilTest {
         Optional<BibEntry> entry = BibtexParser.singleFromString(
                 "@ARTICLE{kohn, author={Simon Popovi\\v{c}ov\\'{a}}}", importFormatPreferences);
         assertEquals("Popovicova",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry.get(), "auth",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry.get(), "auth",
                         ',', new BibDatabase()), true));
     }
 
@@ -82,73 +82,73 @@ public class BibtexKeyPatternUtilTest {
         Optional<BibEntry> entry0 = BibtexParser.singleFromString(
                 "@ARTICLE{kohn, author={Andreas Köning}, year={2000}}", importFormatPreferences);
         assertEquals("Koen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Áöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Aoen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Éöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Eoen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Íöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Ioen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Ĺöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Loen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Ńöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Noen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Óöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Ooen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Ŕöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Roen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Śöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Soen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Úöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Uoen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Ýöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Yoen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Źöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Zoen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
     }
 
@@ -160,31 +160,31 @@ public class BibtexKeyPatternUtilTest {
         Optional<BibEntry> entry0 = BibtexParser.singleFromString(
                 "@ARTICLE{kohn, author={Andreas Àöning}, year={2000}}", importFormatPreferences);
         assertEquals("Aoen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Èöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Eoen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Ìöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Ioen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Òöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Ooen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Ùöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Uoen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
     }
 
@@ -273,7 +273,7 @@ public class BibtexKeyPatternUtilTest {
         Optional<BibEntry> entry = BibtexParser.singleFromString(
                 "@ARTICLE{kohn, author={{Link{\\\"{o}}ping University}}}", importFormatPreferences);
         assertEquals("UniLinkoeping",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry.get(), "auth",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry.get(), "auth",
                         ',', new BibDatabase()), true));
     }
 
@@ -283,7 +283,7 @@ public class BibtexKeyPatternUtilTest {
                 "@ARTICLE{kohn, author={{Link{\\\"{o}}ping University, Department of Electrical Engineering}}}",
                 importFormatPreferences);
         assertEquals("UniLinkoepingEE",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry.get(), "auth",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry.get(), "auth",
                         ',', new BibDatabase()), true));
     }
 
@@ -293,7 +293,7 @@ public class BibtexKeyPatternUtilTest {
                 "@ARTICLE{kohn, author={{Link{\\\"{o}}ping University, School of Computer Engineering}}}",
                 importFormatPreferences);
         assertEquals("UniLinkoepingCE",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry.get(), "auth",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry.get(), "auth",
                         ',', new BibDatabase()), true));
     }
 
@@ -302,7 +302,7 @@ public class BibtexKeyPatternUtilTest {
         Optional<BibEntry> entry = BibtexParser.singleFromString(
                 "@ARTICLE{kohn, author={{Massachusetts Institute of Technology}}}", importFormatPreferences);
         assertEquals("MIT",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry.get(), "auth",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry.get(), "auth",
                         ',', new BibDatabase()), true));
     }
 
@@ -663,15 +663,15 @@ public class BibtexKeyPatternUtilTest {
         BibEntry entry = new BibEntry();
         entry.setField("keywords", "w1, w2a w2b, w3");
 
-        String result = BibtexKeyPatternUtil.makeAndSetLabel(entry, "keyword1", ',', new BibDatabase());
+        String result = BibtexKeyPatternUtil.makeLabel(entry, "keyword1", ',', new BibDatabase());
         assertEquals("w1", result);
 
         // check keywords with space
-        result = BibtexKeyPatternUtil.makeAndSetLabel(entry, "keyword2", ',', new BibDatabase());
+        result = BibtexKeyPatternUtil.makeLabel(entry, "keyword2", ',', new BibDatabase());
         assertEquals("w2a w2b", result);
 
         // check out of range
-        result = BibtexKeyPatternUtil.makeAndSetLabel(entry, "keyword4", ',', new BibDatabase());
+        result = BibtexKeyPatternUtil.makeLabel(entry, "keyword4", ',', new BibDatabase());
         assertEquals("", result);
     }
 
@@ -681,15 +681,15 @@ public class BibtexKeyPatternUtilTest {
         entry.setField("keywords", "w1, w2a w2b, w3");
 
         // all keywords
-        String result = BibtexKeyPatternUtil.makeAndSetLabel(entry, "keywords", ',', new BibDatabase());
+        String result = BibtexKeyPatternUtil.makeLabel(entry, "keywords", ',', new BibDatabase());
         assertEquals("w1w2aw2bw3", result);
 
         // check keywords with space
-        result = BibtexKeyPatternUtil.makeAndSetLabel(entry, "keywords2", ',', new BibDatabase());
+        result = BibtexKeyPatternUtil.makeLabel(entry, "keywords2", ',', new BibDatabase());
         assertEquals("w1w2aw2b", result);
 
         // check out of range
-        result = BibtexKeyPatternUtil.makeAndSetLabel(entry, "keywords55", ',', new BibDatabase());
+        result = BibtexKeyPatternUtil.makeLabel(entry, "keywords55", ',', new BibDatabase());
         assertEquals("w1w2aw2bw3", result);
     }
 
@@ -717,8 +717,8 @@ public class BibtexKeyPatternUtilTest {
     public void testApplyModifiers() {
         BibEntry entry = new BibEntry();
         entry.setField("title", "Green Scheduling of Whatever");
-        assertEquals("GSW", BibtexKeyPatternUtil.makeAndSetLabel(entry, "shorttitleINI", ',', new BibDatabase()));
-        assertEquals("GreenSchedulingWhatever", BibtexKeyPatternUtil.makeAndSetLabel(entry, "shorttitle",
+        assertEquals("GSW", BibtexKeyPatternUtil.makeLabel(entry, "shorttitleINI", ',', new BibDatabase()));
+        assertEquals("GreenSchedulingWhatever", BibtexKeyPatternUtil.makeLabel(entry, "shorttitle",
                 ',', new BibDatabase()));
     }
 

--- a/src/test/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtilTest.java
@@ -43,7 +43,6 @@ public class BibtexKeyPatternUtilTest {
     @Before
     public void setUp() {
         importFormatPreferences = JabRefPreferences.getInstance().getImportFormatPreferences();
-        BibtexKeyPatternUtil.setDataBase(new BibDatabase());
     }
 
     @Test
@@ -52,7 +51,7 @@ public class BibtexKeyPatternUtilTest {
                 importFormatPreferences);
         assertEquals("Holland",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth",
-                        ','), true));
+                        ',', new BibDatabase()), true));
     }
 
     @Test
@@ -61,7 +60,7 @@ public class BibtexKeyPatternUtilTest {
         Optional<BibEntry> entry = BibtexParser.singleFromString(bibtexString, importFormatPreferences);
         assertEquals("HerlandHaugeHelgeland",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry.get(), "authors3",
-                        ','), true));
+                        ',', new BibDatabase()), true));
     }
 
     @Test
@@ -70,7 +69,7 @@ public class BibtexKeyPatternUtilTest {
                 "@ARTICLE{kohn, author={Simon Popovi\\v{c}ov\\'{a}}}", importFormatPreferences);
         assertEquals("Popovicova",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry.get(), "auth",
-                        ','), true));
+                        ',', new BibDatabase()), true));
     }
 
     /**
@@ -84,73 +83,73 @@ public class BibtexKeyPatternUtilTest {
                 "@ARTICLE{kohn, author={Andreas Köning}, year={2000}}", importFormatPreferences);
         assertEquals("Koen",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
-                        ','), true));
+                        ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Áöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Aoen",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
-                        ','), true));
+                        ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Éöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Eoen",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
-                        ','), true));
+                        ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Íöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Ioen",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
-                        ','), true));
+                        ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Ĺöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Loen",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
-                        ','), true));
+                        ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Ńöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Noen",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
-                        ','), true));
+                        ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Óöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Ooen",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
-                        ','), true));
+                        ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Ŕöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Roen",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
-                        ','), true));
+                        ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Śöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Soen",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
-                        ','), true));
+                        ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Úöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Uoen",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
-                        ','), true));
+                        ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Ýöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Yoen",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
-                        ','), true));
+                        ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Źöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Zoen",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
-                        ','), true));
+                        ',', new BibDatabase()), true));
     }
 
     /**
@@ -162,31 +161,31 @@ public class BibtexKeyPatternUtilTest {
                 "@ARTICLE{kohn, author={Andreas Àöning}, year={2000}}", importFormatPreferences);
         assertEquals("Aoen",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
-                        ','), true));
+                        ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Èöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Eoen",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
-                        ','), true));
+                        ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Ìöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Ioen",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
-                        ','), true));
+                        ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Òöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Ooen",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
-                        ','), true));
+                        ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Ùöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Uoen",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
-                        ','), true));
+                        ',', new BibDatabase()), true));
     }
 
     /**
@@ -275,7 +274,7 @@ public class BibtexKeyPatternUtilTest {
                 "@ARTICLE{kohn, author={{Link{\\\"{o}}ping University}}}", importFormatPreferences);
         assertEquals("UniLinkoeping",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry.get(), "auth",
-                        ','), true));
+                        ',', new BibDatabase()), true));
     }
 
     @Test
@@ -285,7 +284,7 @@ public class BibtexKeyPatternUtilTest {
                 importFormatPreferences);
         assertEquals("UniLinkoepingEE",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry.get(), "auth",
-                        ','), true));
+                        ',', new BibDatabase()), true));
     }
 
     @Test
@@ -295,7 +294,7 @@ public class BibtexKeyPatternUtilTest {
                 importFormatPreferences);
         assertEquals("UniLinkoepingCE",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry.get(), "auth",
-                        ','), true));
+                        ',', new BibDatabase()), true));
     }
 
     @Test
@@ -304,7 +303,7 @@ public class BibtexKeyPatternUtilTest {
                 "@ARTICLE{kohn, author={{Massachusetts Institute of Technology}}}", importFormatPreferences);
         assertEquals("MIT",
                 BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry.get(), "auth",
-                        ','), true));
+                        ',', new BibDatabase()), true));
     }
 
     @Test
@@ -664,15 +663,15 @@ public class BibtexKeyPatternUtilTest {
         BibEntry entry = new BibEntry();
         entry.setField("keywords", "w1, w2a w2b, w3");
 
-        String result = BibtexKeyPatternUtil.makeLabel(entry, "keyword1", ',');
+        String result = BibtexKeyPatternUtil.makeLabel(entry, "keyword1", ',', new BibDatabase());
         assertEquals("w1", result);
 
         // check keywords with space
-        result = BibtexKeyPatternUtil.makeLabel(entry, "keyword2", ',');
+        result = BibtexKeyPatternUtil.makeLabel(entry, "keyword2", ',', new BibDatabase());
         assertEquals("w2a w2b", result);
 
         // check out of range
-        result = BibtexKeyPatternUtil.makeLabel(entry, "keyword4", ',');
+        result = BibtexKeyPatternUtil.makeLabel(entry, "keyword4", ',', new BibDatabase());
         assertEquals("", result);
     }
 
@@ -682,15 +681,15 @@ public class BibtexKeyPatternUtilTest {
         entry.setField("keywords", "w1, w2a w2b, w3");
 
         // all keywords
-        String result = BibtexKeyPatternUtil.makeLabel(entry, "keywords", ',');
+        String result = BibtexKeyPatternUtil.makeLabel(entry, "keywords", ',', new BibDatabase());
         assertEquals("w1w2aw2bw3", result);
 
         // check keywords with space
-        result = BibtexKeyPatternUtil.makeLabel(entry, "keywords2", ',');
+        result = BibtexKeyPatternUtil.makeLabel(entry, "keywords2", ',', new BibDatabase());
         assertEquals("w1w2aw2b", result);
 
         // check out of range
-        result = BibtexKeyPatternUtil.makeLabel(entry, "keywords55", ',');
+        result = BibtexKeyPatternUtil.makeLabel(entry, "keywords55", ',', new BibDatabase());
         assertEquals("w1w2aw2bw3", result);
     }
 
@@ -718,9 +717,9 @@ public class BibtexKeyPatternUtilTest {
     public void testApplyModifiers() {
         BibEntry entry = new BibEntry();
         entry.setField("title", "Green Scheduling of Whatever");
-        assertEquals("GSW", BibtexKeyPatternUtil.makeLabel(entry, "shorttitleINI", ','));
+        assertEquals("GSW", BibtexKeyPatternUtil.makeLabel(entry, "shorttitleINI", ',', new BibDatabase()));
         assertEquals("GreenSchedulingWhatever", BibtexKeyPatternUtil.makeLabel(entry, "shorttitle",
-                ','));
+                ',', new BibDatabase()));
     }
 
 }

--- a/src/test/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtilTest.java
@@ -40,7 +40,6 @@ public class BibtexKeyPatternUtilTest {
 
     private static ImportFormatPreferences importFormatPreferences;
 
-
     @Before
     public void setUp() {
         importFormatPreferences = JabRefPreferences.getInstance().getImportFormatPreferences();

--- a/src/test/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtilTest.java
@@ -50,7 +50,7 @@ public class BibtexKeyPatternUtilTest {
         Optional<BibEntry> entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Simon Holland}}",
                 importFormatPreferences);
         assertEquals("Holland",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth",
                         ',', new BibDatabase()), true));
     }
 
@@ -59,7 +59,7 @@ public class BibtexKeyPatternUtilTest {
         String bibtexString = "@ARTICLE{whatevery, author={Mari D. Herland and Mona-Iren Hauge and Ingeborg M. Helgeland}}";
         Optional<BibEntry> entry = BibtexParser.singleFromString(bibtexString, importFormatPreferences);
         assertEquals("HerlandHaugeHelgeland",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry.get(), "authors3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry.get(), "authors3",
                         ',', new BibDatabase()), true));
     }
 
@@ -68,7 +68,7 @@ public class BibtexKeyPatternUtilTest {
         Optional<BibEntry> entry = BibtexParser.singleFromString(
                 "@ARTICLE{kohn, author={Simon Popovi\\v{c}ov\\'{a}}}", importFormatPreferences);
         assertEquals("Popovicova",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry.get(), "auth",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry.get(), "auth",
                         ',', new BibDatabase()), true));
     }
 
@@ -82,73 +82,73 @@ public class BibtexKeyPatternUtilTest {
         Optional<BibEntry> entry0 = BibtexParser.singleFromString(
                 "@ARTICLE{kohn, author={Andreas Köning}, year={2000}}", importFormatPreferences);
         assertEquals("Koen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Áöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Aoen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Éöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Eoen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Íöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Ioen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Ĺöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Loen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Ńöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Noen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Óöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Ooen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Ŕöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Roen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Śöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Soen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Úöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Uoen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Ýöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Yoen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Źöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Zoen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
     }
 
@@ -160,31 +160,31 @@ public class BibtexKeyPatternUtilTest {
         Optional<BibEntry> entry0 = BibtexParser.singleFromString(
                 "@ARTICLE{kohn, author={Andreas Àöning}, year={2000}}", importFormatPreferences);
         assertEquals("Aoen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Èöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Eoen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Ìöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Ioen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Òöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Ooen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
 
         entry0 = BibtexParser.singleFromString("@ARTICLE{kohn, author={Andreas Ùöning}, year={2000}}",
                 importFormatPreferences);
         assertEquals("Uoen",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry0.get(), "auth3",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry0.get(), "auth3",
                         ',', new BibDatabase()), true));
     }
 
@@ -273,7 +273,7 @@ public class BibtexKeyPatternUtilTest {
         Optional<BibEntry> entry = BibtexParser.singleFromString(
                 "@ARTICLE{kohn, author={{Link{\\\"{o}}ping University}}}", importFormatPreferences);
         assertEquals("UniLinkoeping",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry.get(), "auth",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry.get(), "auth",
                         ',', new BibDatabase()), true));
     }
 
@@ -283,7 +283,7 @@ public class BibtexKeyPatternUtilTest {
                 "@ARTICLE{kohn, author={{Link{\\\"{o}}ping University, Department of Electrical Engineering}}}",
                 importFormatPreferences);
         assertEquals("UniLinkoepingEE",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry.get(), "auth",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry.get(), "auth",
                         ',', new BibDatabase()), true));
     }
 
@@ -293,7 +293,7 @@ public class BibtexKeyPatternUtilTest {
                 "@ARTICLE{kohn, author={{Link{\\\"{o}}ping University, School of Computer Engineering}}}",
                 importFormatPreferences);
         assertEquals("UniLinkoepingCE",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry.get(), "auth",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry.get(), "auth",
                         ',', new BibDatabase()), true));
     }
 
@@ -302,7 +302,7 @@ public class BibtexKeyPatternUtilTest {
         Optional<BibEntry> entry = BibtexParser.singleFromString(
                 "@ARTICLE{kohn, author={{Massachusetts Institute of Technology}}}", importFormatPreferences);
         assertEquals("MIT",
-                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeLabel(entry.get(), "auth",
+                BibtexKeyPatternUtil.checkLegalKey(BibtexKeyPatternUtil.makeAndSetLabel(entry.get(), "auth",
                         ',', new BibDatabase()), true));
     }
 
@@ -663,15 +663,15 @@ public class BibtexKeyPatternUtilTest {
         BibEntry entry = new BibEntry();
         entry.setField("keywords", "w1, w2a w2b, w3");
 
-        String result = BibtexKeyPatternUtil.makeLabel(entry, "keyword1", ',', new BibDatabase());
+        String result = BibtexKeyPatternUtil.makeAndSetLabel(entry, "keyword1", ',', new BibDatabase());
         assertEquals("w1", result);
 
         // check keywords with space
-        result = BibtexKeyPatternUtil.makeLabel(entry, "keyword2", ',', new BibDatabase());
+        result = BibtexKeyPatternUtil.makeAndSetLabel(entry, "keyword2", ',', new BibDatabase());
         assertEquals("w2a w2b", result);
 
         // check out of range
-        result = BibtexKeyPatternUtil.makeLabel(entry, "keyword4", ',', new BibDatabase());
+        result = BibtexKeyPatternUtil.makeAndSetLabel(entry, "keyword4", ',', new BibDatabase());
         assertEquals("", result);
     }
 
@@ -681,15 +681,15 @@ public class BibtexKeyPatternUtilTest {
         entry.setField("keywords", "w1, w2a w2b, w3");
 
         // all keywords
-        String result = BibtexKeyPatternUtil.makeLabel(entry, "keywords", ',', new BibDatabase());
+        String result = BibtexKeyPatternUtil.makeAndSetLabel(entry, "keywords", ',', new BibDatabase());
         assertEquals("w1w2aw2bw3", result);
 
         // check keywords with space
-        result = BibtexKeyPatternUtil.makeLabel(entry, "keywords2", ',', new BibDatabase());
+        result = BibtexKeyPatternUtil.makeAndSetLabel(entry, "keywords2", ',', new BibDatabase());
         assertEquals("w1w2aw2b", result);
 
         // check out of range
-        result = BibtexKeyPatternUtil.makeLabel(entry, "keywords55", ',', new BibDatabase());
+        result = BibtexKeyPatternUtil.makeAndSetLabel(entry, "keywords55", ',', new BibDatabase());
         assertEquals("w1w2aw2bw3", result);
     }
 
@@ -717,8 +717,8 @@ public class BibtexKeyPatternUtilTest {
     public void testApplyModifiers() {
         BibEntry entry = new BibEntry();
         entry.setField("title", "Green Scheduling of Whatever");
-        assertEquals("GSW", BibtexKeyPatternUtil.makeLabel(entry, "shorttitleINI", ',', new BibDatabase()));
-        assertEquals("GreenSchedulingWhatever", BibtexKeyPatternUtil.makeLabel(entry, "shorttitle",
+        assertEquals("GSW", BibtexKeyPatternUtil.makeAndSetLabel(entry, "shorttitleINI", ',', new BibDatabase()));
+        assertEquals("GreenSchedulingWhatever", BibtexKeyPatternUtil.makeAndSetLabel(entry, "shorttitle",
                 ',', new BibDatabase()));
     }
 

--- a/src/test/java/net/sf/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
@@ -2,7 +2,6 @@ package net.sf.jabref.logic.bibtexkeypattern;
 
 import java.util.Optional;
 
-import net.sf.jabref.model.bibtexkeypattern.AbstractBibtexKeyPattern;
 import net.sf.jabref.model.bibtexkeypattern.DatabaseBibtexKeyPattern;
 import net.sf.jabref.model.bibtexkeypattern.GlobalBibtexKeyPattern;
 import net.sf.jabref.model.database.BibDatabase;

--- a/src/test/java/net/sf/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
@@ -30,7 +30,7 @@ public class MakeLabelWithDatabaseTest {
         entry.setField("year", "2016");
         entry.setField("title", "An awesome paper on JabRef");
         database.insertEntry(entry);
-        pattern = new GlobalBibtexKeyPattern(AbstractBibtexKeyPattern.split("[auth][year]"));
+        pattern = GlobalBibtexKeyPattern.fromPattern("[auth][year]");
         bibtexKeyPattern = new DatabaseBibtexKeyPattern(pattern);
         preferences = new BibtexKeyPatternPreferences("", "", false, true, true, pattern, ',');
     }

--- a/src/test/java/net/sf/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
@@ -36,24 +36,24 @@ public class MakeLabelWithDatabaseTest {
 
     @Test
     public void generateDefaultKey() {
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("Doe2016"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateDefaultKeyAlreadyExistsDuplicatesStartAtA() {
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         BibEntry entry2 = new BibEntry();
         entry2.setField("author", "John Doe");
         entry2.setField("year", "2016");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry2, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry2, preferences);
         assertEquals(Optional.of("Doe2016a"), entry2.getCiteKeyOptional());
     }
 
     @Test
     public void generateDefaultKeyAlwaysLetter() {
         preferences = new BibtexKeyPatternPreferences("", "", true, true, true, pattern, ',');
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("Doe2016a"), entry.getCiteKeyOptional());
     }
 
@@ -61,18 +61,18 @@ public class MakeLabelWithDatabaseTest {
     public void generateDefaultKeyAlwaysLetterAlreadyExistsDuplicatesStartAtB() {
         preferences = new BibtexKeyPatternPreferences("", "", true, true, true, pattern, ',');
 
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         BibEntry entry2 = new BibEntry();
         entry2.setField("author", "John Doe");
         entry2.setField("year", "2016");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry2, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry2, preferences);
         assertEquals(Optional.of("Doe2016b"), entry2.getCiteKeyOptional());
     }
 
     @Test
     public void generateDefaultKeyStartDuplicatesAtB() {
         preferences = new BibtexKeyPatternPreferences("", "", false, false, true, pattern, ',');
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("Doe2016"), entry.getCiteKeyOptional());
     }
 
@@ -80,17 +80,17 @@ public class MakeLabelWithDatabaseTest {
     public void generateDefaultKeyAlreadyExistsDuplicatesStartAtB() {
         preferences = new BibtexKeyPatternPreferences("", "", false, false, true, pattern, ',');
 
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         BibEntry entry2 = new BibEntry();
         entry2.setField("author", "John Doe");
         entry2.setField("year", "2016");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry2, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry2, preferences);
         assertEquals(Optional.of("Doe2016b"), entry2.getCiteKeyOptional());
     }
 
     @Test
     public void generateDefaultKeyAlreadyExistsManyDuplicates() {
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         BibEntry entry2 = new BibEntry();
         entry2.setField("author", "John Doe");
         entry2.setField("year", "2016");
@@ -101,73 +101,73 @@ public class MakeLabelWithDatabaseTest {
         entry3.setField("year", "2016");
         entry3.setCiteKey(entry.getCiteKeyOptional().get());
         database.insertEntry(entry3);
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry3, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry3, preferences);
         assertEquals(Optional.of("Doe2016a"), entry3.getCiteKeyOptional());
     }
 
     @Test
     public void generateDefaultKeyFirstTwoAlreadyExists() {
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         BibEntry entry2 = new BibEntry();
         entry2.setField("author", "John Doe");
         entry2.setField("year", "2016");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry2, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry2, preferences);
         database.insertEntry(entry2);
         BibEntry entry3 = new BibEntry();
         entry3.setField("author", "John Doe");
         entry3.setField("year", "2016");
         entry3.setCiteKey(entry.getCiteKeyOptional().get());
         database.insertEntry(entry3);
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry3, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry3, preferences);
         assertEquals(Optional.of("Doe2016b"), entry3.getCiteKeyOptional());
     }
 
     @Test
     public void generateDefaultKeyLowerModified() {
         bibtexKeyPattern.setDefaultValue("[auth:lower][year]");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("doe2016"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateDefaultKeyUpperModified() {
         bibtexKeyPattern.setDefaultValue("[auth:upper][year]");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("DOE2016"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateDefaultKeyFixedValue() {
         bibtexKeyPattern.setDefaultValue("[auth]Test[year]");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("DoeTest2016"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyShortYear() {
         bibtexKeyPattern.setDefaultValue("[shortyear]");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("16"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyAuthN() {
         bibtexKeyPattern.setDefaultValue("[auth2]");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("Do"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyAuthNShortName() {
         bibtexKeyPattern.setDefaultValue("[auth10]");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("Doe"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyEmptyField() {
         entry = new BibEntry();
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.empty(), entry.getCiteKeyOptional());
     }
 
@@ -175,7 +175,7 @@ public class MakeLabelWithDatabaseTest {
     public void generateKeyEmptyFieldDefaultText() {
         bibtexKeyPattern.setDefaultValue("[author:(No Author Provided)]");
         entry.clearField("author");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("NoAuthorProvided"), entry.getCiteKeyOptional());
     }
 
@@ -183,42 +183,42 @@ public class MakeLabelWithDatabaseTest {
     public void generateKeyEmptyFieldColonInDefaultText() {
         bibtexKeyPattern.setDefaultValue("[author:(Problem:No Author Provided)]");
         entry.clearField("author");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("Problem:NoAuthorProvided"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyTitle() {
         bibtexKeyPattern.setDefaultValue("[title]");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("AnawesomepaperonJabRef"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyTitleAbbr() {
         bibtexKeyPattern.setDefaultValue("[title:abbr]");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("AapoJ"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyShorttitle() {
         bibtexKeyPattern.setDefaultValue("[shorttitle]");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("awesomepaperJabRef"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyVeryshorttitle() {
         bibtexKeyPattern.setDefaultValue("[veryshorttitle]");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("awesome"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyShorttitleINI() {
         bibtexKeyPattern.setDefaultValue("[shorttitleINI]");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("apJ"), entry.getCiteKeyOptional());
     }
 
@@ -226,7 +226,7 @@ public class MakeLabelWithDatabaseTest {
     public void generateKeyAuthNM() {
         bibtexKeyPattern.setDefaultValue("[auth4_3]");
         entry.setField("author", "John Doe and Donald Smith and Will Wonder");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("Wond"), entry.getCiteKeyOptional());
     }
 
@@ -234,7 +234,7 @@ public class MakeLabelWithDatabaseTest {
     public void generateKeyAuthNMLargeN() {
         bibtexKeyPattern.setDefaultValue("[auth20_3]");
         entry.setField("author", "John Doe and Donald Smith and Will Wonder");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("Wonder"), entry.getCiteKeyOptional());
     }
 
@@ -242,7 +242,7 @@ public class MakeLabelWithDatabaseTest {
     public void generateKeyAuthNMLargeM() {
         bibtexKeyPattern.setDefaultValue("[auth2_4]");
         entry.setField("author", "John Doe and Donald Smith and Will Wonder");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.empty(), entry.getCiteKeyOptional());
     }
 
@@ -250,7 +250,7 @@ public class MakeLabelWithDatabaseTest {
     public void generateKeyAuthNMLargeMReallyReturnsEmptyString() {
         bibtexKeyPattern.setDefaultValue("[auth2_4][year]");
         entry.setField("author", "John Doe and Donald Smith and Will Wonder");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("2016"), entry.getCiteKeyOptional());
     }
 
@@ -259,7 +259,7 @@ public class MakeLabelWithDatabaseTest {
         preferences = new BibtexKeyPatternPreferences("2", "3", false, true, true, pattern, ',');
         bibtexKeyPattern.setDefaultValue("[auth][year]");
         entry.setField("author", "John Doe and Donald Smith and Will Wonder");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("Doe3016"), entry.getCiteKeyOptional());
     }
 
@@ -267,7 +267,7 @@ public class MakeLabelWithDatabaseTest {
     public void generateKeyAuthIni() {
         bibtexKeyPattern.setDefaultValue("[authIni2]");
         entry.setField("author", "John Doe and Donald Smith and Will Wonder");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("DS"), entry.getCiteKeyOptional());
     }
 
@@ -275,49 +275,49 @@ public class MakeLabelWithDatabaseTest {
     public void generateKeyAuthIniMany() {
         bibtexKeyPattern.setDefaultValue("[authIni10]");
         entry.setField("author", "John Doe and Donald Smith and Will Wonder");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("DoeSmiWon"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyTitleTitleCase() {
         bibtexKeyPattern.setDefaultValue("[title:title_case]");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("AnAwesomePaperonJabref"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyTitleCapitalize() {
         bibtexKeyPattern.setDefaultValue("[title:capitalize]");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("AnAwesomePaperOnJabref"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyTitleSentenceCase() {
         bibtexKeyPattern.setDefaultValue("[title:sentence_case]");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("Anawesomepaperonjabref"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyTitleTitleCaseAbbr() {
         bibtexKeyPattern.setDefaultValue("[title:title_case:abbr]");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("AAPoJ"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyTitleCapitalizeAbbr() {
         bibtexKeyPattern.setDefaultValue("[title:capitalize:abbr]");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("AAPOJ"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyTitleSentenceCaseAbbr() {
         bibtexKeyPattern.setDefaultValue("[title:sentence_case:abbr]");
-        BibtexKeyPatternUtil.makeLabel(bibtexKeyPattern, database, entry, preferences);
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("Aapoj"), entry.getCiteKeyOptional());
     }
 }

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -309,14 +309,16 @@ public class IntegrityCheckTest {
 
     private void assertWrong(BibDatabaseContext context) {
         List<IntegrityMessage> messages = new IntegrityCheck(context,
-                JabRefPreferences.getInstance().getFileDirectoryPreferences())
+                JabRefPreferences.getInstance().getFileDirectoryPreferences(),
+                JabRefPreferences.getInstance().getBibtexKeyPatternPreferences())
                 .checkBibtexDatabase();
         assertFalse(messages.toString(), messages.isEmpty());
     }
 
     private void assertCorrect(BibDatabaseContext context) {
         List<IntegrityMessage> messages = new IntegrityCheck(context,
-                JabRefPreferences.getInstance().getFileDirectoryPreferences()).checkBibtexDatabase();
+                JabRefPreferences.getInstance().getFileDirectoryPreferences(),
+                JabRefPreferences.getInstance().getBibtexKeyPatternPreferences()).checkBibtexDatabase();
         assertEquals(Collections.emptyList(), messages);
     }
 

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -320,14 +320,21 @@ public class IntegrityCheckTest {
     private void assertWrong(BibDatabaseContext context) {
         List<IntegrityMessage> messages = new IntegrityCheck(context,
                 JabRefPreferences.getInstance().getFileDirectoryPreferences(),
-                JabRefPreferences.getInstance().getBibtexKeyPatternPreferences())
+                createBibtexKeyPatternPreferences())
                 .checkBibtexDatabase();
         assertFalse(messages.toString(), messages.isEmpty());
     }
 
     private void assertCorrect(BibDatabaseContext context) {
+        List<IntegrityMessage> messages = new IntegrityCheck(context,
+                JabRefPreferences.getInstance().getFileDirectoryPreferences(),
+                createBibtexKeyPatternPreferences()).checkBibtexDatabase();
+        assertEquals(Collections.emptyList(), messages);
+    }
+
+    private BibtexKeyPatternPreferences createBibtexKeyPatternPreferences() {
         final GlobalBibtexKeyPattern keyPattern = GlobalBibtexKeyPattern.fromPattern("[auth][year]");
-        final BibtexKeyPatternPreferences bibtexKeyPatternPreferences = new BibtexKeyPatternPreferences(
+        return new BibtexKeyPatternPreferences(
                 "",
                 "",
                 false,
@@ -335,10 +342,6 @@ public class IntegrityCheckTest {
                 false,
                 keyPattern,
                 ',');
-        List<IntegrityMessage> messages = new IntegrityCheck(context,
-                JabRefPreferences.getInstance().getFileDirectoryPreferences(),
-                bibtexKeyPatternPreferences).checkBibtexDatabase();
-        assertEquals(Collections.emptyList(), messages);
     }
 
     private BibDatabaseContext withMode(BibDatabaseContext context, BibDatabaseMode mode) {

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -121,10 +121,15 @@ public class IntegrityCheckTest {
 
     @Test
     public void testBibtexkeyChecks() {
-        final BibDatabaseContext context = createContext("bibtexkey", "Knuth2014");
-        context.getDatabase().getEntries().get(0).setField("author","Knuth");
-        context.getDatabase().getEntries().get(0).setField("year","2014");
-        assertCorrect(context);
+        final BibDatabaseContext correctContext = createContext("bibtexkey", "Knuth2014");
+        correctContext.getDatabase().getEntries().get(0).setField("author","Knuth");
+        correctContext.getDatabase().getEntries().get(0).setField("year","2014");
+        assertCorrect(correctContext);
+
+        final BibDatabaseContext wrongContext = createContext("bibtexkey", "Knuth2014a");
+        wrongContext.getDatabase().getEntries().get(0).setField("author","Knuth");
+        wrongContext.getDatabase().getEntries().get(0).setField("year","2014");
+        assertWrong(wrongContext);
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -7,7 +7,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import net.sf.jabref.logic.bibtexkeypattern.BibtexKeyPatternPreferences;
 import net.sf.jabref.model.Defaults;
+import net.sf.jabref.model.bibtexkeypattern.GlobalBibtexKeyPattern;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseContext;
 import net.sf.jabref.model.database.BibDatabaseMode;
@@ -119,7 +121,10 @@ public class IntegrityCheckTest {
 
     @Test
     public void testBibtexkeyChecks() {
-        assertCorrect(createContext("bibtexkey", "Knuth2014"));
+        final BibDatabaseContext context = createContext("bibtexkey", "Knuth2014");
+        context.getDatabase().getEntries().get(0).setField("author","Knuth");
+        context.getDatabase().getEntries().get(0).setField("year","2014");
+        assertCorrect(context);
     }
 
     @Test
@@ -316,9 +321,18 @@ public class IntegrityCheckTest {
     }
 
     private void assertCorrect(BibDatabaseContext context) {
+        final GlobalBibtexKeyPattern keyPattern = GlobalBibtexKeyPattern.fromPattern("[auth][year]");
+        final BibtexKeyPatternPreferences bibtexKeyPatternPreferences = new BibtexKeyPatternPreferences(
+                "",
+                "",
+                false,
+                false,
+                false,
+                keyPattern,
+                ',');
         List<IntegrityMessage> messages = new IntegrityCheck(context,
                 JabRefPreferences.getInstance().getFileDirectoryPreferences(),
-                JabRefPreferences.getInstance().getBibtexKeyPatternPreferences()).checkBibtexDatabase();
+                bibtexKeyPatternPreferences).checkBibtexDatabase();
         assertEquals(Collections.emptyList(), messages);
     }
 


### PR DESCRIPTION
Refs #2206 

Adds integrity check to determine all entries which bibtex keys deviate from the set bibtex key generation pattern.

- [x] Change in CHANGELOG.md described
- [x] Manually tested changed features in running JabRef
- [x] If you changed the localization: Did you run `gradle localizationUpdate`?

