### PR TITLE
Fix opening of preference dialog with Java 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue which prevented that a database was saved successfully if JabRef failed to generate new BibTeX-keys [#2285](https://github.com/JabRef/jabref/issues/2285).
 - We fixed an issue when JabRef restores its session and a shared database was used: The error message "No suitable driver found" will not appear.
 - Update check now correctly notifies about new release if development version is used. [#2298](https://github.com/JabRef/jabref/issues/2298)
+- We fixed an issue which prevented the preference dialog to open on systems with Java 9.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the file permissions of the .bib-file were changed upon saving [#2279](https://github.com/JabRef/jabref/issues/2279).
 - We fixed an issue which prevented that a database was saved successfully if JabRef failed to generate new BibTeX-keys [#2285](https://github.com/JabRef/jabref/issues/2285).
 - We fixed an issue when JabRef restores its session and a shared database was used: The error message "No suitable driver found" will not appear.
-- Update check now correctly notifies about new release if development version is used. [#2298](https://github.com/JabRef/jabref/issues/2298)
 - We fixed an issue which prevented the preference dialog to open on systems with Java 9.
+- Update check now correctly notifies about new release if development version is used. [#2298](https://github.com/JabRef/jabref/issues/2298)
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/gui/preftabs/AppearancePrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/AppearancePrefsTab.java
@@ -63,8 +63,9 @@ class AppearancePrefsTab extends JPanel implements PrefsTab {
                     // Try to find L&F
                     Class.forName(l);
                     lookAndFeels.add(l);
-                } catch (ClassNotFoundException ignored) {
-                    // Ignored
+                } catch (ClassNotFoundException|IllegalAccessError ignored) {
+                    // LookAndFeel class does not exists or we don't have rights to access it
+                    // Ignore it
                 }
             }
             return lookAndFeels;

--- a/src/main/java/net/sf/jabref/gui/preftabs/AppearancePrefsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/AppearancePrefsTab.java
@@ -64,7 +64,7 @@ class AppearancePrefsTab extends JPanel implements PrefsTab {
                     Class.forName(l);
                     lookAndFeels.add(l);
                 } catch (ClassNotFoundException|IllegalAccessError ignored) {
-                    // LookAndFeel class does not exists or we don't have rights to access it
+                    // LookAndFeel class does not exist or we don't have rights to access it
                     // Ignore it
                 }
             }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
Fixes the issue mentioned in http://discourse.jabref.org/t/cannot-start-jabref-3-7-3-6-on-ubuntu-16-04/361/4

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?

