### PR TITLE
Add longer explanation for ID-based entry generation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,7 +148,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - [#1897](https://github.com/JabRef/jabref/issues/1897) Implemented integrity check for `year` field: Last four nonpunctuation characters should be numerals
 - Address in MS-Office 2007 xml format is now imported as `location`
 - [#1912](https://github.com/JabRef/jabref/issues/1912) Implemented integrity check for `edition` field: Should have the first letter capitalized (BibTeX), Should contain an integer or a literal (BibLaTeX)
-- The dialog for choosing new entries additionally supports ID-based entry generation
+- The dialog for choosing new entries additionally supports ID-based entry generation. For instance, when searching for a DOI or ISBN, you have to press <kbd>Ctrl</kbd> + <kbd>N</kbd> instead of using the web search (<kbd>Alt</kbd> + <kbd>4</kbd>).
 - `number` field is now exported as `number` field in MS-Office 2007 xml format, if no `issue` field is present and the entry type is not `patent`
 - `note` field is now exported as `comments` field in MS-Office 2007 xml format
 - `comments` field in MS-Office 2007 xml format is now imported as `note` field


### PR DESCRIPTION
A user suggested to improve the v3.7 changelog at http://discourse.jabref.org/t/where-is-doi-to-bibtex-websearch-option-in-jabref-3-7/359/3?u=koppor

I did this here and also updated the help page at https://github.com/JabRef/help.jabref.org/pull/138.