### PR TITLE
Add initial .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+insert_final_newline = true


### PR DESCRIPTION
This adds an initial [editorconfig](http://editorconfig.org/) to ensure that all files are encoded in UTF-8 and end with a new line.