### PR TITLE
Update swingx from 1.6.1 to 1.6.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,9 @@ dependencies {
     compile 'com.jgoodies:jgoodies-forms:1.9.0'
     compile 'com.jgoodies:jgoodies-looks:2.7.0'
 
-    compile 'org.swinglabs:swingx:1.6.1' // do not update, 1.6.5.1 is broken - see https://github.com/JabRef/jabref/issues/271
+    // Later versions cannot be used. Tested until 1.6.5-1.
+    // See https://github.com/JabRef/jabref/issues/271 for details
+    compile 'org.swinglabs.swingx:swingx-core:1.6.4'
 
     // update to 2.0.x is not possible - see https://github.com/JabRef/jabref/pull/1096#issuecomment-208857517
     compile 'org.apache.pdfbox:pdfbox:1.8.12'


### PR DESCRIPTION
The changelog of swingx is available there: https://java.net/jira/browse/SWINGX?selectedTab=com.atlassian.jira.jira-projects-plugin:changelog-panel

The only changelog entry with "memory leak" is https://java.net/jira/browse/SWINGX-299. I don't know, wether this is related.

I am aware of https://github.com/JabRef/jabref/issues/271. Thus, I manually tested which version to use and 1.6.4 seems to be the latest version usable.

We should check whether this helps solving #2247.

- [n/a] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [n/a] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [n/a] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [n/a] If you changed the localization: Did you run `gradle localizationUpdate`?

