### PR TITLE
Be more friendly when using journal alias field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Adds an integrity check that detects invalid DOIs [#1445](https://github.com/JabRef/jabref/issues/1445)
 - We changed the order of the cleanup operations so that the generated file name corresponds to the cleaned-up fields. [1441](https://github.com/JabRef/jabref/issues/1441)
 - Replaces manual thread management with cached thread pool
+- We enhanced the integrity checks testing for biblatex-only fields to be aware of more fields (e.g., `location`).
+- We display both the field name `journaltitle` and `journal` in BibLaTeX mode as `journaltitle` only was causing headaches. [#2209](https://github.com/JabRef/jabref/issues/2209)
 - Files can now be moved to subfolders named by a custom format pattern, e.g., based on `entrytype`.
   The pattern can be specified in the settings like the filename pattern. [#1092](https://github.com/JabRef/jabref/issues/1092)
 

--- a/src/main/java/net/sf/jabref/logic/TypedBibEntry.java
+++ b/src/main/java/net/sf/jabref/logic/TypedBibEntry.java
@@ -6,7 +6,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 import net.sf.jabref.model.EntryTypes;
-import net.sf.jabref.model.FieldChange;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.BibDatabaseContext;
 import net.sf.jabref.model.database.BibDatabaseMode;
@@ -17,6 +16,9 @@ import net.sf.jabref.model.entry.FileField;
 import net.sf.jabref.model.entry.ParsedFileField;
 import net.sf.jabref.model.strings.StringUtil;
 
+/**
+ * Wrapper around a {@link BibEntry} offering methods for {@link BibDatabaseMode} dependend results
+ */
 public class TypedBibEntry {
 
     private final BibEntry entry;
@@ -77,16 +79,4 @@ public class TypedBibEntry {
         return FileField.parse(oldValue.get());
     }
 
-    public Optional<FieldChange> setFiles(List<ParsedFileField> files) {
-
-        Optional<String> oldValue = entry.getField(FieldName.FILE);
-        String newValue = FileField.getStringRepresentation(files);
-
-        if(oldValue.isPresent() && oldValue.get().equals(newValue)) {
-            return Optional.empty();
-        }
-
-        entry.setField(FieldName.FILE, newValue);
-        return Optional.of(new FieldChange(entry, FieldName.FILE, oldValue.orElse(""), newValue));
-    }
 }

--- a/src/main/java/net/sf/jabref/logic/cleanup/MoveFilesCleanup.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/MoveFilesCleanup.java
@@ -72,7 +72,7 @@ public class MoveFilesCleanup implements CleanupJob {
         }
 
         if (changed) {
-            Optional<FieldChange> change = typedEntry.setFiles(newFileList);
+            Optional<FieldChange> change = entry.setFiles(newFileList);
             if(change.isPresent()) {
                 return Collections.singletonList(change.get());
             } else {

--- a/src/main/java/net/sf/jabref/logic/cleanup/RelativePathsCleanup.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/RelativePathsCleanup.java
@@ -49,7 +49,7 @@ public class RelativePathsCleanup implements CleanupJob {
         }
 
         if (changed) {
-            Optional<FieldChange> change = typedEntry.setFiles(newFileList);
+            Optional<FieldChange> change = entry.setFiles(newFileList);
             if(change.isPresent()) {
                 return Collections.singletonList(change.get());
             } else {

--- a/src/main/java/net/sf/jabref/logic/cleanup/RenamePdfCleanup.java
+++ b/src/main/java/net/sf/jabref/logic/cleanup/RenamePdfCleanup.java
@@ -140,7 +140,7 @@ public class RenamePdfCleanup implements CleanupJob {
             }
         }
         if (changed) {
-            Optional<FieldChange> change = typedEntry.setFiles(newFileList);
+            Optional<FieldChange> change = entry.setFiles(newFileList);
             //we put an undo of the field content here
             //the file is not being renamed back, which leads to inconsistencies
             //if we put a null undo object here, the change by "doMakePathsRelative" would overwrite the field value nevertheless.

--- a/src/main/java/net/sf/jabref/logic/importer/fetcher/ArXiv.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fetcher/ArXiv.java
@@ -343,7 +343,7 @@ public class ArXiv implements FulltextFetcher, SearchBasedFetcher, IdBasedFetche
             abstractText.ifPresent(abstractContent -> bibEntry.setField(FieldName.ABSTRACT, abstractContent));
             getDate().ifPresent(date -> bibEntry.setField(FieldName.DATE, date));
             primaryCategory.ifPresent(category -> bibEntry.setField(FieldName.EPRINTCLASS, category));
-            journalReferenceText.ifPresent(journal -> bibEntry.setField(FieldName.JOURNAL, journal));
+            journalReferenceText.ifPresent(journal -> bibEntry.setField(FieldName.JOURNALTITLE, journal));
             getPdfUrl().ifPresent(url -> bibEntry
                     .setFiles(Collections.singletonList(new ParsedFileField("online", url, "PDF"))));
             return bibEntry;

--- a/src/main/java/net/sf/jabref/logic/importer/fetcher/ArXiv.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fetcher/ArXiv.java
@@ -16,7 +16,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import net.sf.jabref.logic.TypedBibEntry;
 import net.sf.jabref.logic.help.HelpFile;
 import net.sf.jabref.logic.importer.FetcherException;
 import net.sf.jabref.logic.importer.FulltextFetcher;
@@ -26,7 +25,6 @@ import net.sf.jabref.logic.importer.SearchBasedFetcher;
 import net.sf.jabref.logic.importer.util.OAI2Handler;
 import net.sf.jabref.logic.util.DOI;
 import net.sf.jabref.logic.util.io.XMLUtil;
-import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.FieldName;
@@ -345,10 +343,9 @@ public class ArXiv implements FulltextFetcher, SearchBasedFetcher, IdBasedFetche
             abstractText.ifPresent(abstractContent -> bibEntry.setField(FieldName.ABSTRACT, abstractContent));
             getDate().ifPresent(date -> bibEntry.setField(FieldName.DATE, date));
             primaryCategory.ifPresent(category -> bibEntry.setField(FieldName.EPRINTCLASS, category));
-            journalReferenceText.ifPresent(journal -> bibEntry.setField(FieldName.JOURNALTITLE, journal));
-            getPdfUrl().ifPresent(url -> (new TypedBibEntry(bibEntry, BibDatabaseMode.BIBLATEX))
+            journalReferenceText.ifPresent(journal -> bibEntry.setField(FieldName.JOURNAL, journal));
+            getPdfUrl().ifPresent(url -> bibEntry
                     .setFiles(Collections.singletonList(new ParsedFileField("online", url, "PDF"))));
-
             return bibEntry;
         }
     }

--- a/src/main/java/net/sf/jabref/logic/integrity/IntegrityMessage.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/IntegrityMessage.java
@@ -1,8 +1,11 @@
 package net.sf.jabref.logic.integrity;
 
-import net.sf.jabref.model.entry.BibEntry;
+import java.util.Objects;
 
-public class IntegrityMessage implements Cloneable {
+import net.sf.jabref.model.entry.BibEntry;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+
+public final class IntegrityMessage implements Cloneable {
 
     private final BibEntry entry;
     private final String fieldName;
@@ -35,4 +38,29 @@ public class IntegrityMessage implements Cloneable {
     public Object clone() {
         return new IntegrityMessage(message, entry, fieldName);
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        IntegrityMessage that = (IntegrityMessage) obj;
+        return new EqualsBuilder()
+                .append(entry, that.entry)
+                .append(fieldName, that.fieldName)
+                .append(message, that.message)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(entry, fieldName, message);
+    }
+
 }

--- a/src/main/java/net/sf/jabref/logic/integrity/IntegrityMessage.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/IntegrityMessage.java
@@ -3,6 +3,7 @@ package net.sf.jabref.logic.integrity;
 import java.util.Objects;
 
 import net.sf.jabref.model.entry.BibEntry;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 
 public final class IntegrityMessage implements Cloneable {

--- a/src/main/java/net/sf/jabref/logic/integrity/NoBibtexFieldChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/NoBibtexFieldChecker.java
@@ -1,31 +1,32 @@
 package net.sf.jabref.logic.integrity;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import net.sf.jabref.logic.integrity.IntegrityCheck.Checker;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.model.entry.EntryConverter;
 import net.sf.jabref.model.entry.FieldName;
 
 public class NoBibtexFieldChecker implements Checker {
 
-    /**
-     * BibLaTeX package documentation (Section 2.1.1):
-     * The title of the periodical is given in the journaltitle field.
-     */
     @Override
     public List<IntegrityMessage> check(BibEntry entry) {
-        Optional<String> value = entry.getField(FieldName.JOURNALTITLE);
+        SortedSet<String> allBibLaTeXOnlyFields = new TreeSet<>();
+        allBibLaTeXOnlyFields.addAll(EntryConverter.FIELD_ALIASES_LTX_TO_TEX.keySet());
 
-        //BibTeX
-        if (!value.isPresent()) {
-            return Collections.emptyList();
-        }
-        else {
-            return Collections.singletonList(
-                    new IntegrityMessage(Localization.lang("BibLaTeX field only"), entry, FieldName.JOURNALTITLE));
-        }
+        // file is both in bibtex and biblatex
+        allBibLaTeXOnlyFields.remove(FieldName.FILE);
+
+        // this exists in BibLaTeX only (and is no aliassed field)
+        allBibLaTeXOnlyFields.add(FieldName.JOURNALSUBTITLE);
+
+        return entry.getFieldNames().stream()
+                .filter(name ->  allBibLaTeXOnlyFields.contains(name))
+                .map(name -> new IntegrityMessage(Localization.lang("BibLaTeX field only"), entry, name)).collect(Collectors.toList());
     }
+
 }

--- a/src/main/java/net/sf/jabref/logic/integrity/NoBibtexFieldChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/NoBibtexFieldChecker.java
@@ -11,6 +11,9 @@ import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.EntryConverter;
 import net.sf.jabref.model.entry.FieldName;
 
+/**
+ * This checker checks whether the entry does not contain any field appearing only in BibLaTeX (and not in BibTex)
+ */
 public class NoBibtexFieldChecker implements Checker {
 
     @Override
@@ -18,10 +21,10 @@ public class NoBibtexFieldChecker implements Checker {
         SortedSet<String> allBibLaTeXOnlyFields = new TreeSet<>();
         allBibLaTeXOnlyFields.addAll(EntryConverter.FIELD_ALIASES_LTX_TO_TEX.keySet());
 
-        // file is both in bibtex and biblatex
+        // file is both in BibTeX and BibLaTeX
         allBibLaTeXOnlyFields.remove(FieldName.FILE);
 
-        // this exists in BibLaTeX only (and is no aliassed field)
+        // this exists in BibLaTeX only (and is no aliased field)
         allBibLaTeXOnlyFields.add(FieldName.JOURNALSUBTITLE);
 
         return entry.getFieldNames().stream()

--- a/src/main/java/net/sf/jabref/logic/msbib/BibTeXConverter.java
+++ b/src/main/java/net/sf/jabref/logic/msbib/BibTeXConverter.java
@@ -88,7 +88,7 @@ public class BibTeXConverter {
         }
 
         if (entry.journalName != null) {
-            fieldValues.put(FieldName.JOURNALTITLE, entry.journalName);
+            fieldValues.put(FieldName.JOURNAL, entry.journalName);
         }
         if (entry.month != null) {
             Month month = MonthUtil.getMonth(entry.month);

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -836,8 +836,7 @@ public class BibEntry implements Cloneable {
             return Optional.empty();
         }
 
-        this.setField(FieldName.FILE, newValue);
-        return Optional.of(new FieldChange(this, FieldName.FILE, oldValue.orElse(""), newValue));
+        return this.setField(FieldName.FILE, newValue);
     }
 
 }

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -404,21 +404,24 @@ public class BibEntry implements Cloneable {
      * <p>
      * The following aliases are considered (old bibtex <-> new biblatex) based
      * on the BibLatex documentation, chapter 2.2.5:<br>
-     * address      <-> location <br>
-     * annote           <-> annotation <br>
-     * archiveprefix    <-> eprinttype <br>
-     * journal      <-> journaltitle <br>
-     * key              <-> sortkey <br>
-     * pdf          <-> file <br
-     * primaryclass     <-> eprintclass <br>
-     * school           <-> institution <br>
+     * address        <-> location <br>
+     * annote         <-> annotation <br>
+     * archiveprefix  <-> eprinttype <br>
+     * journal        <-> journaltitle <br>
+     * key            <-> sortkey <br>
+     * pdf            <-> file <br
+     * primaryclass   <-> eprintclass <br>
+     * school         <-> institution <br>
      * These work bidirectional. <br>
+     * </p>
+     *
      * <p>
      * Special attention is paid to dates: (see the BibLatex documentation,
      * chapter 2.3.8)
      * The fields 'year' and 'month' are used if the 'date'
      * field is empty. Conversely, getFieldOrAlias("year") also tries to
      * extract the year from the 'date' field (analogously for 'month').
+     * </p>
      */
     public Optional<String> getFieldOrAlias(String name) {
         return genericGetFieldOrAlias(name, this::getField);
@@ -824,4 +827,17 @@ public class BibEntry implements Cloneable {
             return Optional.of(latexFreeField);
         }
     }
+
+    public Optional<FieldChange> setFiles(List<ParsedFileField> files) {
+        Optional<String> oldValue = this.getField(FieldName.FILE);
+        String newValue = FileField.getStringRepresentation(files);
+
+        if (oldValue.isPresent() && oldValue.get().equals(newValue)) {
+            return Optional.empty();
+        }
+
+        this.setField(FieldName.FILE, newValue);
+        return Optional.of(new FieldChange(this, FieldName.FILE, oldValue.orElse(""), newValue));
+    }
+
 }

--- a/src/main/java/net/sf/jabref/model/entry/BibLatexEntryTypes.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibLatexEntryTypes.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 /**
  * This class defines entry types for BibLatex support.
- * @see http://mirrors.concertpass.com/tex-archive/macros/latex/contrib/biblatex/doc/biblatex.pdf
+ * @see <a href="http://mirrors.concertpass.com/tex-archive/macros/latex/contrib/biblatex/doc/biblatex.pdf">biblatex documentation</a>
  */
 public class BibLatexEntryTypes {
 
@@ -19,7 +19,8 @@ public class BibLatexEntryTypes {
                 FieldName.EPRINT, FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
 
         {
-            addAllRequired(FieldName.AUTHOR, FieldName.TITLE, FieldName.JOURNALTITLE,
+            addAllRequired(FieldName.AUTHOR, FieldName.TITLE,
+                    FieldName.orFields(FieldName.JOURNAL, FieldName.JOURNALTITLE),
                     FieldName.orFields(FieldName.YEAR, FieldName.DATE));
             addAllOptional(FieldName.TRANSLATOR, FieldName.ANNOTATOR, FieldName.COMMENTATOR, FieldName.SUBTITLE,
                     FieldName.TITLEADDON, FieldName.EDITOR, FieldName.EDITORA, FieldName.EDITORB, FieldName.EDITORC,

--- a/src/main/java/net/sf/jabref/model/entry/EntryConverter.java
+++ b/src/main/java/net/sf/jabref/model/entry/EntryConverter.java
@@ -8,10 +8,13 @@ import java.util.stream.Collectors;
  * Converts Entry models from BibTex to BibLaTex and back.
  */
 public class EntryConverter {
-    // BibTex to BibLatex
+
+    // BibTeX to BibLaTeX
     public static Map<String, String> FIELD_ALIASES_TEX_TO_LTX;
-    // BibLatex to BibTex
+
+    // BibLaTeX to BibTeX
     public static Map<String, String> FIELD_ALIASES_LTX_TO_TEX;
+
     // All aliases
     public static Map<String, String> FIELD_ALIASES;
 
@@ -36,4 +39,5 @@ public class EntryConverter {
         FIELD_ALIASES.putAll(EntryConverter.FIELD_ALIASES_TEX_TO_LTX);
         FIELD_ALIASES.putAll(EntryConverter.FIELD_ALIASES_LTX_TO_TEX);
     }
+
 }

--- a/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
+++ b/src/test/java/net/sf/jabref/logic/cleanup/CleanupWorkerTest.java
@@ -304,6 +304,17 @@ public class CleanupWorkerTest {
     }
 
     @Test
+    public void convertToBiblatexMovesAddressToLocation() {
+        CleanupPreset preset = new CleanupPreset(CleanupPreset.CleanupStep.CONVERT_TO_BIBLATEX);
+        BibEntry entry = new BibEntry();
+        entry.setField("address", "test");
+
+        worker.cleanup(preset, entry);
+        Assert.assertEquals(Optional.empty(), entry.getField("address"));
+        Assert.assertEquals(Optional.of("test"), entry.getField("location"));
+    }
+
+    @Test
     public void convertToBiblatexMovesJournalToJournalTitle() {
         CleanupPreset preset = new CleanupPreset(CleanupPreset.CleanupStep.CONVERT_TO_BIBLATEX);
         BibEntry entry = new BibEntry();

--- a/src/test/java/net/sf/jabref/logic/importer/fetcher/ArXivTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fetcher/ArXivTest.java
@@ -123,7 +123,7 @@ public class ArXivTest {
         expected.setField("eprintclass", "hep-ex");
         expected.setField("keywords", "hep-ex");
         expected.setField("doi", "10.1140/epjc/s2003-01326-x");
-        expected.setField("journaltitle", "Eur.Phys.J.C31:17-29,2003");
+        expected.setField("journal", "Eur.Phys.J.C31:17-29,2003");
 
         assertEquals(Optional.of(expected), finder.performSearchById("hep-ex/0307015"));
     }

--- a/src/test/java/net/sf/jabref/logic/importer/fetcher/ArXivTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fetcher/ArXivTest.java
@@ -123,7 +123,7 @@ public class ArXivTest {
         expected.setField("eprintclass", "hep-ex");
         expected.setField("keywords", "hep-ex");
         expected.setField("doi", "10.1140/epjc/s2003-01326-x");
-        expected.setField("journal", "Eur.Phys.J.C31:17-29,2003");
+        expected.setField("journaltitle", "Eur.Phys.J.C31:17-29,2003");
 
         assertEquals(Optional.of(expected), finder.performSearchById("hep-ex/0307015"));
     }

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/BibtexImporterTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/BibtexImporterTest.java
@@ -61,7 +61,7 @@ public class BibtexImporterTest {
                 assertEquals(Optional.of("2006"), entry.getField("date"));
                 assertEquals(Optional.of("Effect of immobilization on catalytic characteristics"),
                         entry.getField("indextitle"));
-                assertEquals(Optional.of("#jomch#"), entry.getField("journaltitle"));
+                assertEquals(Optional.of("#jomch#"), entry.getField("journal"));
                 assertEquals(Optional.of("13"), entry.getField("number"));
                 assertEquals(Optional.of("3027-3036"), entry.getField("pages"));
                 assertEquals(Optional

--- a/src/test/java/net/sf/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
@@ -1,0 +1,45 @@
+package net.sf.jabref.logic.integrity;
+
+import java.util.Collections;
+
+import net.sf.jabref.model.entry.BibEntry;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+
+public class NoBibTexFieldCheckerTest {
+
+    private NoBibtexFieldChecker checker = new NoBibtexFieldChecker();
+
+    @Test
+    public void addressIsNotRecognizedAsBibLaTeXOnlyField() {
+        BibEntry entry = new BibEntry();
+        entry.setField("address", "test");
+        assertEquals(Collections.emptyList(), checker.check(entry));
+    }
+
+    @Test
+    public void journalIsNotRecognizedAsBibLaTeXOnlyField() {
+        BibEntry entry = new BibEntry();
+        entry.setField("journal", "test");
+        assertEquals(Collections.emptyList(), checker.check(entry));
+    }
+
+    @Test
+    public void journaltitleIsRecognizedAsBibLaTeXOnlyField() {
+        BibEntry entry = new BibEntry();
+        entry.setField("journaltitle", "test");
+        assertNotEquals(Collections.emptyList(), checker.check(entry));
+    }
+
+    @Test
+    public void locationIsRecognizedAsBibLaTeXOnlyField() {
+        BibEntry entry = new BibEntry();
+        entry.setField("location", "test");
+        assertNotEquals(Collections.emptyList(), checker.check(entry));
+    }
+
+}

--- a/src/test/java/net/sf/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 import net.sf.jabref.model.entry.BibEntry;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/net/sf/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
@@ -1,13 +1,12 @@
 package net.sf.jabref.logic.integrity;
 
 import java.util.Collections;
+import java.util.List;
 
 import net.sf.jabref.model.entry.BibEntry;
-
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 
 
 public class NoBibTexFieldCheckerTest {
@@ -32,14 +31,18 @@ public class NoBibTexFieldCheckerTest {
     public void journaltitleIsRecognizedAsBibLaTeXOnlyField() {
         BibEntry entry = new BibEntry();
         entry.setField("journaltitle", "test");
-        assertNotEquals(Collections.emptyList(), checker.check(entry));
+        IntegrityMessage message = new IntegrityMessage("BibLaTeX field only", entry, "journaltitle");
+        List<IntegrityMessage> messages = checker.check(entry);
+        assertEquals(messages, Collections.singletonList(message));
     }
 
     @Test
     public void locationIsRecognizedAsBibLaTeXOnlyField() {
         BibEntry entry = new BibEntry();
         entry.setField("location", "test");
-        assertNotEquals(Collections.emptyList(), checker.check(entry));
+        IntegrityMessage message = new IntegrityMessage("BibLaTeX field only", entry, "location");
+        List<IntegrityMessage> messages = checker.check(entry);
+        assertEquals(messages, Collections.singletonList(message));
     }
 
 }

--- a/src/test/resources/net/sf/jabref/logic/exporter/MsBibExportFormatTest7.bib
+++ b/src/test/resources/net/sf/jabref/logic/exporter/MsBibExportFormatTest7.bib
@@ -7,7 +7,7 @@
   publisher     = {Oficyna Wydawnicza Politechniki Wrocławskiej},
   pages         = {99--108},
   doi           = {10.13140/2.1.3259.2169},
-  journaltitle  = {Information Systems Architecture and Technology: Service Oriented Networked Systems},
+  journal       = {Information Systems Architecture and Technology: Service Oriented Networked Systems},
 }
 
 @Comment{jabref-meta: databaseType:biblatex;}

--- a/src/test/resources/net/sf/jabref/logic/importer/fileformat/BibtexImporter.examples.bib
+++ b/src/test/resources/net/sf/jabref/logic/importer/fileformat/BibtexImporter.examples.bib
@@ -35,7 +35,7 @@
   title        = {Effect of immobilization on catalytic characteristics of
                   saturated {Pd-N}-heterocyclic carbenes in {Mizoroki-Heck}
                   reactions},
-  journaltitle = jomch,
+  journal      = jomch,
   date         = 2006,
   volume       = 691,
   number       = 13,

--- a/src/test/resources/net/sf/jabref/logic/importer/fileformat/MsBibImporterTest3.bib
+++ b/src/test/resources/net/sf/jabref/logic/importer/fileformat/MsBibImporterTest3.bib
@@ -2,7 +2,7 @@
 
 @book{raey,
   author = {5},
-  journaltitle = {Wirtschaftsinformatik},
+  journal = {Wirtschaftsinformatik},
   keywords = {software development processes; agile software development environments; time-to-market; Extreme Programming; Crystal methods family; Adaptive Software Development},
   language = {english},
   lccn = {0937-6429},

--- a/src/test/resources/net/sf/jabref/logic/importer/fileformat/MsBibImporterTest4.bib
+++ b/src/test/resources/net/sf/jabref/logic/importer/fileformat/MsBibImporterTest4.bib
@@ -2,7 +2,7 @@
 
 @book{raey,
   issn = {0937-6429},
-  journaltitle = {Wirtschaftsinformatik},
+  journal = {Wirtschaftsinformatik},
   keywords = {software development processes; agile software development environments; time-to-market; Extreme Programming; Crystal methods family; Adaptive Software Development},
   language = {english},
   issue = {3},

--- a/src/test/resources/net/sf/jabref/logic/importer/fileformat/MsBibImporterTest5.bib
+++ b/src/test/resources/net/sf/jabref/logic/importer/fileformat/MsBibImporterTest5.bib
@@ -1,7 +1,7 @@
 % Encoding: UTF-8
 
 @techreport{,
-  journaltitle = {Wirtschaftsinformatik},
+  journal = {Wirtschaftsinformatik},
   keywords = {software development processes; agile software development environments; time-to-market; Extreme Programming; Crystal methods family; Adaptive Software Development},
   language = {english},
   mrnumber = {0937-6429},

--- a/src/test/resources/net/sf/jabref/logic/importer/fileformat/MsBibImporterTest6.bib
+++ b/src/test/resources/net/sf/jabref/logic/importer/fileformat/MsBibImporterTest6.bib
@@ -1,7 +1,7 @@
 % Encoding: UTF-8
 
 @online{,
-  journaltitle = {Wirtschaftsinformatik},
+  journal = {Wirtschaftsinformatik},
   keywords = {software development processes; agile software development environments; time-to-market; Extreme Programming; Crystal methods family; Adaptive Software Development},
   language = {english},
   mrnumber = {0937-6429},

--- a/src/test/resources/net/sf/jabref/logic/importer/fileformat/MsBibImporterTest7.bib
+++ b/src/test/resources/net/sf/jabref/logic/importer/fileformat/MsBibImporterTest7.bib
@@ -3,7 +3,7 @@
 @Article{Orlowski;2011,
   author       = {Adam and Or{\l}owski, Cezary Czarnecki},
   title        = {Application of Ontology In the ITIL Domain},
-  journaltitle = {Information Systems Architecture and Technology: Service Oriented Networked Systems},
+  journal      = {Information Systems Architecture and Technology: Service Oriented Networked Systems},
   year         = {2011},
   month 	   = {mar},
   volume       = {5},


### PR DESCRIPTION
I'd like to copy bibtex entries to biblatex databases and vice versa. When using required fields only, this works perfectly. When in biblatex mode, JabRef does not display the value of `journal` in the required fields, because JabRef demands the field `journaltitle`. This is not only confusing for me, but also for other users: #2209.

I know that a clean solution is #521. This, however, won't happen this year.

I also know that a bibtex-to-biblatex converter and biblatex-to-bibtex converter is another solution. This, however, forces users to run these when copying and pasting between databases. This could be solved by running these converters silently when copying and pasting. When JabRef is used in parallel to other software (such as Notepad++), this does not help. I cannot force everyone to use JabRef. Thus, simply supporting `journal` in JabRef is the solution for me. 

The biblatex manual states:

> journal field (literal)
> An alias for journaltitle, provided for BibTeX compatibility. See § 2.2.2.

Thus, it is not deprecated, but an alias and should IMHO be considered as full alternative for `journaltitle`.

<s>I am aware that this patch makes it hard for users using full biblatex with `journaltitle` instead of `journal`. I am assuming that not much users are aware of the different modes of JabRef and that they switch back and forth for the same file or for the bibentries.</s>

We now show both `journaltitle` and `journal` if these fields exists in as required fields.

This whole discussion somehow refs https://github.com/JabRef/jabref/issues/160

 * Minor improvement: Enhanced integrity checks testing for biblatex-only fields to be aware of more fields (e.g., `location`).
 * All fetchers return now bibtex. (Before: ArXiv and msbib created biblatex)

## Screenshot: Current JabRef
![grabbed_20161211-183240](https://cloud.githubusercontent.com/assets/1366654/21081886/48135c02-bfd0-11e6-9a2e-f2e411f76487.png)

## Screenshot: Updated JabRef
![grabbed_20161212-030057](https://cloud.githubusercontent.com/assets/1366654/21085882/3c1b3b58-c017-11e6-96ce-e83e1e9206d3.png)

## Checklist

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [n/A] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [n/a] If you changed the localization: Did you run `gradle localizationUpdate`?
