### PR TITLE
Never manually set ID of a BibEntry

### DIFF
--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -125,7 +125,6 @@ import net.sf.jabref.model.database.event.EntryRemovedEvent;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.EntryType;
 import net.sf.jabref.model.entry.FieldName;
-import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.model.entry.event.EntryChangedEvent;
 import net.sf.jabref.model.entry.event.EntryEventSource;
 import net.sf.jabref.model.entry.specialfields.SpecialField;
@@ -799,7 +798,6 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 // entries must exist
                 // independently of the copied
                 // ones.
-                be.setId(IdGenerator.next());
                 bibDatabaseContext.getDatabase().insertEntry(be);
 
                 ce.addEdit(new UndoableInsertEntry(bibDatabaseContext.getDatabase(), be, BasePanel.this));

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -565,8 +565,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 return;
             }
 
-            String id = IdGenerator.next();
-            BibEntry bibEntry = new BibEntry(id, tp.getName());
+            BibEntry bibEntry = new BibEntry(tp.getName());
             TextInputDialog tidialog = new TextInputDialog(frame, bibEntry);
             tidialog.setLocationRelativeTo(BasePanel.this);
             tidialog.setVisible(true);
@@ -1107,8 +1106,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             actualType = etd.getChoice();
         }
         if (actualType != null) { // Only if the dialog was not canceled.
-            String id = IdGenerator.next();
-            final BibEntry be = new BibEntry(id, actualType.getName());
+            final BibEntry be = new BibEntry(actualType.getName());
             try {
                 bibDatabaseContext.getDatabase().insertEntry(be);
                 // Set owner/timestamp if options are enabled:

--- a/src/main/java/net/sf/jabref/gui/importer/actions/AppendDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/importer/actions/AppendDatabaseAction.java
@@ -26,7 +26,6 @@ import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.database.KeyCollisionException;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexString;
-import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.model.groups.AllEntriesGroup;
 import net.sf.jabref.model.groups.ExplicitGroup;
 import net.sf.jabref.model.groups.GroupHierarchyType;
@@ -112,7 +111,6 @@ public class AppendDatabaseAction implements BaseAction {
 
             for (BibEntry originalEntry : fromDatabase.getEntries()) {
                 BibEntry be = (BibEntry) originalEntry.clone();
-                be.setId(IdGenerator.next());
                 UpdateField.setAutomaticFields(be, overwriteOwner, overwriteTimeStamp,
                         Globals.prefs.getUpdateFieldPreferences());
                 database.insertEntry(be);

--- a/src/main/java/net/sf/jabref/gui/importer/fetcher/CiteSeerXFetcher.java
+++ b/src/main/java/net/sf/jabref/gui/importer/fetcher/CiteSeerXFetcher.java
@@ -19,7 +19,6 @@ import net.sf.jabref.logic.importer.OutputPrinter;
 import net.sf.jabref.logic.net.URLDownload;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
-import net.sf.jabref.model.entry.IdGenerator;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -133,7 +132,7 @@ public class CiteSeerXFetcher implements EntryFetcher {
         // Find title, and create entry if we do. Otherwise assume we did not get an entry:
         Matcher m = CiteSeerXFetcher.TITLE_PATTERN.matcher(cont);
         if (m.find()) {
-            BibEntry entry = new BibEntry(IdGenerator.next());
+            BibEntry entry = new BibEntry();
             entry.setField(FieldName.TITLE, m.group(1));
 
             // Find authors:

--- a/src/main/java/net/sf/jabref/gui/importer/fetcher/OAI2Fetcher.java
+++ b/src/main/java/net/sf/jabref/gui/importer/fetcher/OAI2Fetcher.java
@@ -171,7 +171,7 @@ public class OAI2Fetcher implements EntryFetcher {
         oai2Connection.setRequestProperty("User-Agent", "JabRef");
 
         /* create an empty BibEntry and set the oai2identifier field */
-        BibEntry entry = new BibEntry(IdGenerator.next(), "article");
+        BibEntry entry = new BibEntry("article");
         entry.setField(OAI2Fetcher.OAI2_IDENTIFIER_FIELD, fixedKey);
         DefaultHandler handlerBase = new OAI2Handler(entry);
 

--- a/src/main/java/net/sf/jabref/gui/importer/fetcher/OAI2Fetcher.java
+++ b/src/main/java/net/sf/jabref/gui/importer/fetcher/OAI2Fetcher.java
@@ -24,7 +24,6 @@ import net.sf.jabref.logic.importer.util.OAI2Handler;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
-import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.model.entry.MonthUtil;
 
 import org.apache.commons.logging.Log;

--- a/src/main/java/net/sf/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/net/sf/jabref/gui/openoffice/OOBibBase.java
@@ -44,7 +44,6 @@ import net.sf.jabref.logic.openoffice.UndefinedParagraphFormatException;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
-import net.sf.jabref.model.entry.IdGenerator;
 
 import com.sun.star.awt.Point;
 import com.sun.star.beans.IllegalTypeException;
@@ -1364,7 +1363,6 @@ class OOBibBase {
                 // If entry found
                 if (entry.isPresent()) {
                     BibEntry clonedEntry = (BibEntry) entry.get().clone();
-                    clonedEntry.setId(IdGenerator.next());
                     // Insert a copy of the entry
                     resultDatabase.insertEntry(clonedEntry);
                     // Check if the cloned entry has a crossref field

--- a/src/main/java/net/sf/jabref/logic/auxparser/AuxParser.java
+++ b/src/main/java/net/sf/jabref/logic/auxparser/AuxParser.java
@@ -15,7 +15,6 @@ import java.util.regex.Pattern;
 import net.sf.jabref.model.database.BibDatabase;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
-import net.sf.jabref.model.entry.IdGenerator;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -172,7 +171,6 @@ public class AuxParser {
      */
     private void insertEntry(BibEntry entry, AuxParserResult result) {
         BibEntry clonedEntry = (BibEntry) entry.clone();
-        clonedEntry.setId(IdGenerator.next());
         result.getGeneratedBibDatabase().insertEntry(clonedEntry);
     }
 }

--- a/src/main/java/net/sf/jabref/logic/importer/Importer.java
+++ b/src/main/java/net/sf/jabref/logic/importer/Importer.java
@@ -16,15 +16,6 @@ import net.sf.jabref.logic.util.FileExtensions;
  * Role of an importer for JabRef.
  */
 public abstract class Importer implements Comparable<Importer> {
-
-    /**
-     * Using this when I have no database open or when I read
-     * non bibtex file formats (used by the ImportFormatReader.java)
-     *
-     * TODO: Is this field really needed or would calling IdGenerator.next() suffice?
-     */
-    public static final String DEFAULT_BIBTEXENTRY_ID = "__ID";
-
     /**
      * Check whether the source is in the correct format for this importer.
      *

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/BiblioscapeImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/BiblioscapeImporter.java
@@ -254,7 +254,7 @@ public class BiblioscapeImporter extends Importer {
                 if (!comments.isEmpty()) { // set comment if present
                     hm.put("comment", String.join(";", comments));
                 }
-                BibEntry b = new BibEntry(DEFAULT_BIBTEXENTRY_ID, bibtexType);
+                BibEntry b = new BibEntry(bibtexType);
                 b.setField(hm);
                 bibItems.add(b);
 

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/BibtexParser.java
@@ -539,8 +539,7 @@ public class BibtexParser implements Parser {
     }
 
     private BibEntry parseEntry(String entryType) throws IOException {
-        String id = IdGenerator.next();
-        BibEntry result = new BibEntry(id, entryType);
+        BibEntry result = new BibEntry(entryType);
         skipWhitespace();
         consume('{', '(');
         int character = peek();

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/CopacImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/CopacImporter.java
@@ -98,7 +98,7 @@ public class CopacImporter extends Importer {
 
             // Copac does not contain enough information on the type of the
             // document. A book is assumed.
-            BibEntry b = new BibEntry(DEFAULT_BIBTEXENTRY_ID, "book");
+            BibEntry b = new BibEntry("book");
 
             String[] lines = entry.split("\n");
 

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/EndnoteImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/EndnoteImporter.java
@@ -253,8 +253,9 @@ public class EndnoteImporter extends Importer {
                 hm.put(FieldName.PAGES, artnum);
             }
 
-            BibEntry b = new BibEntry(DEFAULT_BIBTEXENTRY_ID, type); // id assumes an existing database so don't
+            // id assumes an existing database so don't
             // create one here
+            BibEntry b = new BibEntry(type);
             b.setField(hm);
             if (!b.getFieldNames().isEmpty()) {
                 bibitems.add(b);

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/EndnoteImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/EndnoteImporter.java
@@ -253,8 +253,6 @@ public class EndnoteImporter extends Importer {
                 hm.put(FieldName.PAGES, artnum);
             }
 
-            // id assumes an existing database so don't
-            // create one here
             BibEntry b = new BibEntry(type);
             b.setField(hm);
             if (!b.getFieldNames().isEmpty()) {

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/GvkParser.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/GvkParser.java
@@ -13,7 +13,6 @@ import net.sf.jabref.logic.importer.ParseException;
 import net.sf.jabref.logic.importer.Parser;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
-import net.sf.jabref.model.entry.IdGenerator;
 
 import com.google.common.base.Strings;
 import org.apache.commons.logging.Log;

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/GvkParser.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/GvkParser.java
@@ -362,7 +362,7 @@ public class GvkParser implements Parser {
          * dann @incollection annehmen, wenn weder ISBN noch
          * ZDB-ID vorhanden sind.
          */
-        BibEntry result = new BibEntry(IdGenerator.next(), entryType);
+        BibEntry result = new BibEntry(entryType);
 
         // Zuordnung der Felder in Abhängigkeit vom Dokumenttyp
         if (author != null) {

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/InspecImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/InspecImporter.java
@@ -120,8 +120,7 @@ public class InspecImporter extends Importer {
                     }
                 }
             }
-            BibEntry b = new BibEntry(DEFAULT_BIBTEXENTRY_ID, type); // id assumes an existing database so don't
-            // create one here
+            BibEntry b = new BibEntry(type);
             b.setField(h);
 
             bibitems.add(b);

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/IsiImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/IsiImporter.java
@@ -301,7 +301,7 @@ public class IsiImporter extends Importer {
                 continue;
             }
 
-            BibEntry b = new BibEntry(DEFAULT_BIBTEXENTRY_ID, Type);
+            BibEntry b = new BibEntry(Type);
             // id assumes an existing database so don't
 
             // Remove empty fields:

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/MedlineImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/MedlineImporter.java
@@ -75,7 +75,6 @@ import net.sf.jabref.logic.importer.fileformat.medline.Text;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
-import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.model.strings.StringUtil;
 
 import com.google.common.base.Joiner;

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/MedlineImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/MedlineImporter.java
@@ -247,7 +247,7 @@ public class MedlineImporter extends Importer implements Parser {
             putIfValueNotNull(fields, "pubstatus", bookData.getPublicationStatus());
         }
 
-        BibEntry entry = new BibEntry(IdGenerator.next(), "article");
+        BibEntry entry = new BibEntry("article");
         entry.setField(fields);
 
         bibItems.add(entry);
@@ -393,7 +393,7 @@ public class MedlineImporter extends Importer implements Parser {
             }
         }
 
-        BibEntry entry = new BibEntry(IdGenerator.next(), "article");
+        BibEntry entry = new BibEntry("article");
         entry.setField(fields);
 
         bibItems.add(entry);

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/MedlinePlainImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/MedlinePlainImporter.java
@@ -206,7 +206,7 @@ public class MedlinePlainImporter extends Importer {
                 fields.put("comment", comment);
             }
 
-            BibEntry b = new BibEntry(DEFAULT_BIBTEXENTRY_ID, type); // id assumes an existing database so don't
+            BibEntry b = new BibEntry(type);
 
             // Remove empty fields:
             fields.entrySet().stream().filter(n -> n.getValue().trim().isEmpty()).forEach(fields::remove);

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/OvidImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/OvidImporter.java
@@ -208,7 +208,7 @@ public class OvidImporter extends Importer {
                 // Move the "chaptertitle" to just "title":
                 h.put(FieldName.TITLE, h.remove("chaptertitle"));
             }
-            BibEntry b = new BibEntry(IdGenerator.next(), entryType);
+            BibEntry b = new BibEntry(entryType);
             b.setField(h);
 
             bibitems.add(b);

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/OvidImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/OvidImporter.java
@@ -15,7 +15,6 @@ import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.model.entry.AuthorList;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
-import net.sf.jabref.model.entry.IdGenerator;
 
 /**
  * Imports an Ovid file.

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/RepecNepImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/RepecNepImporter.java
@@ -19,7 +19,6 @@ import net.sf.jabref.logic.importer.ParserResult;
 import net.sf.jabref.logic.util.FileExtensions;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
-import net.sf.jabref.model.entry.IdGenerator;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -416,7 +415,7 @@ public class RepecNepImporter extends Importer {
                     this.inOverviewSection = this.preLine.startsWith("In this issue we have");
                 }
                 if (isStartOfWorkingPaper()) {
-                    BibEntry be = new BibEntry(IdGenerator.next());
+                    BibEntry be = new BibEntry();
                     be.setType("techreport");
                     paperNoStr = this.lastLine.substring(0, this.lastLine.indexOf('.'));
                     parseTitleString(be, reader);

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/RisImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/RisImporter.java
@@ -238,7 +238,7 @@ public class RisImporter extends Importer {
 
                 fields.put(FieldName.PAGES, startPage + endPage);
             }
-            BibEntry b = new BibEntry(DEFAULT_BIBTEXENTRY_ID, type); // id assumes an existing database so don't
+            BibEntry b = new BibEntry(type);
 
             // Remove empty fields:
             fields.entrySet().removeIf(key -> (key.getValue() == null) || key.getValue().trim().isEmpty());

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/SilverPlatterImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/SilverPlatterImporter.java
@@ -179,7 +179,7 @@ public class SilverPlatterImporter extends Importer {
 
             }
 
-            BibEntry b = new BibEntry(DEFAULT_BIBTEXENTRY_ID, type); // id assumes an existing database so don't
+            BibEntry b = new BibEntry(type);
             // create one here
             b.setField(h);
 

--- a/src/main/java/net/sf/jabref/logic/msbib/BibTeXConverter.java
+++ b/src/main/java/net/sf/jabref/logic/msbib/BibTeXConverter.java
@@ -7,7 +7,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import net.sf.jabref.logic.importer.Importer;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.model.entry.MonthUtil;
@@ -28,14 +27,7 @@ public class BibTeXConverter {
         Map<String, String> fieldValues = new HashMap<>();
 
         String bibTexEntryType = MSBibMapping.getBibLaTeXEntryType(entry.getType());
-        if (entry.getCiteKey() == null) {
-            result = new BibEntry(Importer.DEFAULT_BIBTEXENTRY_ID, bibTexEntryType);
-
-        } else {
-            // TODO: the cite key should not be the ID?!
-            // id assumes an existing database so don't
-            result = new BibEntry(entry.getCiteKey(), bibTexEntryType);
-        }
+        result = new BibEntry(bibTexEntryType);
 
         // add String fields
         for (Map.Entry<String, String> field : entry.fields.entrySet()) {

--- a/src/main/java/net/sf/jabref/logic/openoffice/UndefinedBibtexEntry.java
+++ b/src/main/java/net/sf/jabref/logic/openoffice/UndefinedBibtexEntry.java
@@ -2,7 +2,6 @@ package net.sf.jabref.logic.openoffice;
 
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
-import net.sf.jabref.model.entry.IdGenerator;
 
 /**
  * Subclass of BibEntry for representing entries referenced in a document that can't

--- a/src/main/java/net/sf/jabref/logic/openoffice/UndefinedBibtexEntry.java
+++ b/src/main/java/net/sf/jabref/logic/openoffice/UndefinedBibtexEntry.java
@@ -14,7 +14,6 @@ public class UndefinedBibtexEntry extends BibEntry {
 
 
     public UndefinedBibtexEntry(String key) {
-        super(IdGenerator.next());
         this.key = key;
         setField(FieldName.AUTHOR, OOBibStyle.UNDEFINED_CITATION_MARKER);
     }

--- a/src/main/java/net/sf/jabref/logic/util/TestEntry.java
+++ b/src/main/java/net/sf/jabref/logic/util/TestEntry.java
@@ -8,7 +8,7 @@ public class TestEntry {
 
     public static BibEntry getTestEntry() {
 
-        BibEntry entry = new BibEntry(IdGenerator.next(), "article");
+        BibEntry entry = new BibEntry("article");
         entry.setCiteKey("Smith2016");
         entry.setField(FieldName.AUTHOR, "Smith, Bill and Jones, Bob and Williams, Jeff");
         entry.setField(FieldName.EDITOR, "Taylor, Phil");

--- a/src/main/java/net/sf/jabref/logic/util/TestEntry.java
+++ b/src/main/java/net/sf/jabref/logic/util/TestEntry.java
@@ -2,7 +2,6 @@ package net.sf.jabref.logic.util;
 
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
-import net.sf.jabref.model.entry.IdGenerator;
 
 public class TestEntry {
 

--- a/src/main/java/net/sf/jabref/logic/xmp/XMPSchemaBibtex.java
+++ b/src/main/java/net/sf/jabref/logic/xmp/XMPSchemaBibtex.java
@@ -295,7 +295,7 @@ public class XMPSchemaBibtex extends XMPSchema {
 
     public BibEntry getBibtexEntry() {
         String type = getTextProperty(BibEntry.TYPE_HEADER);
-        BibEntry e = new BibEntry(IdGenerator.next(), type);
+        BibEntry e = new BibEntry(type);
 
         // Get Text Properties
         Map<String, String> text = XMPSchemaBibtex.getAllProperties(this, "bibtex");

--- a/src/main/java/net/sf/jabref/logic/xmp/XMPSchemaBibtex.java
+++ b/src/main/java/net/sf/jabref/logic/xmp/XMPSchemaBibtex.java
@@ -17,7 +17,6 @@ import net.sf.jabref.model.entry.AuthorList;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
 import net.sf.jabref.model.entry.FieldProperty;
-import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.model.entry.InternalBibtexFields;
 
 import org.apache.jempbox.xmp.XMPMetadata;

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -99,20 +99,16 @@ public class BibEntry implements Cloneable {
      * @param type The type to set. May be null or empty. In that case, DEFAULT_TYPE is used.
      */
     public BibEntry(String type) {
-        this.id = IdGenerator.next();
-        setType(type);
-        this.sharedBibEntryData = new SharedBibEntryData();
+        this(IdGenerator.next(), type);
     }
 
     /**
      * Constructs a new BibEntry with the given ID and given type
      *
-     * TODO: should be removed. ID must be set globally.
-     *
      * @param id   The ID to be used
      * @param type The type to set. May be null or empty. In that case, DEFAULT_TYPE is used.
      */
-    public BibEntry(String id, String type) {
+    private BibEntry(String id, String type) {
         Objects.requireNonNull(id, "Every BibEntry must have an ID");
 
         this.id = id;

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -572,10 +572,11 @@ public class BibEntry implements Cloneable {
 
     /**
      * Returns a clone of this entry. Useful for copying.
+     * This will set a new ID for the cloned entry to be able to distinguish both copies.
      */
     @Override
     public Object clone() {
-        BibEntry clone = new BibEntry(id, type);
+        BibEntry clone = new BibEntry(type);
         clone.fields = new HashMap<>(fields);
         return clone;
     }

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -85,26 +85,29 @@ public class BibEntry implements Cloneable {
 
     private final EventBus eventBus = new EventBus();
 
-
     /**
      * Constructs a new BibEntry. The internal ID is set to IdGenerator.next()
      */
 
     public BibEntry() {
-        this(IdGenerator.next());
+        this(IdGenerator.next(), DEFAULT_TYPE);
     }
 
     /**
-     * Constructs a new BibEntry with the given ID and DEFAULT_TYPE
+     * Constructs a new BibEntry with the given type
      *
-     * @param id The ID to be used
+     * @param type The type to set. May be null or empty. In that case, DEFAULT_TYPE is used.
      */
-    public BibEntry(String id) {
-        this(id, DEFAULT_TYPE);
+    public BibEntry(String type) {
+        this.id = IdGenerator.next();
+        setType(type);
+        this.sharedBibEntryData = new SharedBibEntryData();
     }
 
     /**
      * Constructs a new BibEntry with the given ID and given type
+     *
+     * TODO: should be removed. ID must be set globally.
      *
      * @param id   The ID to be used
      * @param type The type to set. May be null or empty. In that case, DEFAULT_TYPE is used.

--- a/src/main/java/net/sf/jabref/model/entry/IdGenerator.java
+++ b/src/main/java/net/sf/jabref/model/entry/IdGenerator.java
@@ -19,7 +19,6 @@ public class IdGenerator {
 
     private static int idCounter;
 
-
     public static synchronized String next() {
         String result = idFormat.format(idCounter);
         idCounter++;

--- a/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
+++ b/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
@@ -35,7 +35,6 @@ import net.sf.jabref.model.database.KeyCollisionException;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.EntryType;
 import net.sf.jabref.model.entry.FieldName;
-import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import org.apache.commons.logging.Log;

--- a/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
+++ b/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
@@ -258,8 +258,7 @@ public class PdfImporter {
         EntryType type = etd.getChoice();
 
         if (type != null) { // Only if the dialog was not canceled.
-            String id = IdGenerator.next();
-            final BibEntry bibEntry = new BibEntry(id, type.getName());
+            final BibEntry bibEntry = new BibEntry(type.getName());
             try {
                 panel.getDatabase().insertEntry(bibEntry);
 

--- a/src/test/java/net/sf/jabref/gui/importer/fetcher/OAI2HandlerFetcherTest.java
+++ b/src/test/java/net/sf/jabref/gui/importer/fetcher/OAI2HandlerFetcherTest.java
@@ -9,7 +9,6 @@ import javax.xml.parsers.SAXParserFactory;
 
 import net.sf.jabref.logic.importer.util.OAI2Handler;
 import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.testutils.category.GUITests;
 
 import org.junit.Assert;

--- a/src/test/java/net/sf/jabref/gui/importer/fetcher/OAI2HandlerFetcherTest.java
+++ b/src/test/java/net/sf/jabref/gui/importer/fetcher/OAI2HandlerFetcherTest.java
@@ -42,7 +42,7 @@ public class OAI2HandlerFetcherTest {
     public void setUp() throws ParserConfigurationException, SAXException {
         parserFactory = SAXParserFactory.newInstance();
         saxParser = parserFactory.newSAXParser();
-        be = new BibEntry(IdGenerator.next(), "article");
+        be = new BibEntry("article");
         handler = new OAI2Handler(be);
     }
 

--- a/src/test/java/net/sf/jabref/logic/TypedBibEntryTest.java
+++ b/src/test/java/net/sf/jabref/logic/TypedBibEntryTest.java
@@ -11,7 +11,7 @@ public class TypedBibEntryTest {
 
     @Test
     public void hasAllRequiredFieldsFail() {
-        BibEntry e = new BibEntry("id", BibtexEntryTypes.ARTICLE.getName());
+        BibEntry e = new BibEntry(BibtexEntryTypes.ARTICLE.getName());
         e.setField("author", "abc");
         e.setField("title", "abc");
         e.setField("journal", "abc");
@@ -22,7 +22,7 @@ public class TypedBibEntryTest {
 
     @Test
     public void hasAllRequiredFields() {
-        BibEntry e = new BibEntry("id", BibtexEntryTypes.ARTICLE.getName());
+        BibEntry e = new BibEntry(BibtexEntryTypes.ARTICLE.getName());
         e.setField("author", "abc");
         e.setField("title", "abc");
         e.setField("journal", "abc");
@@ -34,7 +34,7 @@ public class TypedBibEntryTest {
 
     @Test
     public void hasAllRequiredFieldsForUnknownTypeReturnsTrue() {
-        BibEntry e = new BibEntry("id", "articlllleeeee");
+        BibEntry e = new BibEntry("articlllleeeee");
 
         TypedBibEntry typedEntry = new TypedBibEntry(e, BibDatabaseMode.BIBTEX);
         Assert.assertTrue(typedEntry.hasAllRequiredFields());
@@ -42,7 +42,7 @@ public class TypedBibEntryTest {
 
     @Test
     public void getTypeForDisplayReturnsTypeName() {
-        BibEntry e = new BibEntry("id", BibtexEntryTypes.INPROCEEDINGS.getName());
+        BibEntry e = new BibEntry(BibtexEntryTypes.INPROCEEDINGS.getName());
 
         TypedBibEntry typedEntry = new TypedBibEntry(e, BibDatabaseMode.BIBTEX);
         Assert.assertEquals("InProceedings", typedEntry.getTypeForDisplay());
@@ -50,7 +50,7 @@ public class TypedBibEntryTest {
 
     @Test
     public void getTypeForDisplayForUnknownTypeCapitalizeFirstLetter() {
-        BibEntry e = new BibEntry("id", "articlllleeeee");
+        BibEntry e = new BibEntry("articlllleeeee");
 
         TypedBibEntry typedEntry = new TypedBibEntry(e, BibDatabaseMode.BIBTEX);
         Assert.assertEquals("Articlllleeeee", typedEntry.getTypeForDisplay());

--- a/src/test/java/net/sf/jabref/logic/bibtex/BibEntryWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/BibEntryWriterTest.java
@@ -37,7 +37,7 @@ public class BibEntryWriterTest {
     public void testSerialization() throws IOException {
         StringWriter stringWriter = new StringWriter();
 
-        BibEntry entry = new BibEntry("1234", "article");
+        BibEntry entry = new BibEntry("article");
         //set a required field
         entry.setField("author", "Foo Bar");
         entry.setField("journal", "International Journal of Something");
@@ -383,7 +383,7 @@ public class BibEntryWriterTest {
     public void doNotWriteEmptyFields() throws IOException {
         StringWriter stringWriter = new StringWriter();
 
-        BibEntry entry = new BibEntry("1234", "article");
+        BibEntry entry = new BibEntry("article");
         entry.setField("author", "  ");
         entry.setField("note", "some note");
 
@@ -402,7 +402,7 @@ public class BibEntryWriterTest {
     public void trimFieldContents() throws IOException {
         StringWriter stringWriter = new StringWriter();
 
-        BibEntry entry = new BibEntry("1234", "article");
+        BibEntry entry = new BibEntry("article");
         entry.setField("note", "        some note    \t");
 
         writer.write(entry, stringWriter, BibDatabaseMode.BIBTEX);

--- a/src/test/java/net/sf/jabref/logic/bibtex/comparator/FieldComparatorTest.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/comparator/FieldComparatorTest.java
@@ -94,7 +94,7 @@ public class FieldComparatorTest {
     @Test
     public void compareTypeFieldIdentity() throws Exception {
         FieldComparator comparator = new FieldComparator("entrytype");
-        BibEntry equal = new BibEntry("1", "article");
+        BibEntry equal = new BibEntry("article");
 
         assertEquals(0, comparator.compare(equal, equal));
     }
@@ -102,8 +102,10 @@ public class FieldComparatorTest {
     @Test
     public void compareTypeFieldEquality() throws Exception {
         FieldComparator comparator = new FieldComparator("entrytype");
-        BibEntry equal = new BibEntry("1", "article");
-        BibEntry equal2 = new BibEntry("1", "article");
+        BibEntry equal = new BibEntry("article");
+        equal.setId("1");
+        BibEntry equal2 = new BibEntry("article");
+        equal2.setId("1");
 
         assertEquals(0, comparator.compare(equal, equal2));
     }
@@ -111,8 +113,8 @@ public class FieldComparatorTest {
     @Test
     public void compareTypeFieldBiggerAscending() throws Exception {
         FieldComparator comparator = new FieldComparator("entrytype");
-        BibEntry smaller = new BibEntry("1", "article");
-        BibEntry bigger = new BibEntry("2", "book");
+        BibEntry smaller = new BibEntry("article");
+        BibEntry bigger = new BibEntry("book");
 
         assertEquals(1, comparator.compare(bigger, smaller));
     }
@@ -120,8 +122,8 @@ public class FieldComparatorTest {
     @Test
     public void compareTypeFieldBiggerDescending() throws Exception {
         FieldComparator comparator = new FieldComparator("entrytype", true);
-        BibEntry bigger = new BibEntry("1", "article");
-        BibEntry smaller = new BibEntry("2", "book");
+        BibEntry bigger = new BibEntry("article");
+        BibEntry smaller = new BibEntry("book");
 
         assertEquals(1, comparator.compare(bigger, smaller));
     }

--- a/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -26,7 +26,6 @@ import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.BibtexString;
 import net.sf.jabref.model.entry.CustomEntryType;
-import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.model.groups.AllEntriesGroup;
 import net.sf.jabref.model.groups.ExplicitGroup;
 import net.sf.jabref.model.groups.GroupHierarchyType;

--- a/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -523,17 +523,17 @@ public class BibtexDatabaseWriterTest {
 
     @Test
     public void writeEntriesInOriginalOrderWhenNoSaveOrderConfigIsSetInMetadata() throws Exception {
-        BibEntry firstEntry = new BibEntry(IdGenerator.next());
+        BibEntry firstEntry = new BibEntry();
         firstEntry.setType(BibtexEntryTypes.ARTICLE);
         firstEntry.setField("author", "A");
         firstEntry.setField("year", "2010");
 
-        BibEntry secondEntry = new BibEntry(IdGenerator.next());
+        BibEntry secondEntry = new BibEntry();
         secondEntry.setType(BibtexEntryTypes.ARTICLE);
         secondEntry.setField("author", "B");
         secondEntry.setField("year", "2000");
 
-        BibEntry thirdEntry = new BibEntry(IdGenerator.next());
+        BibEntry thirdEntry = new BibEntry();
         thirdEntry.setType(BibtexEntryTypes.ARTICLE);
         thirdEntry.setField("author", "A");
         thirdEntry.setField("year", "2000");

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -359,7 +359,7 @@ public class BibtexParserTest {
 
         List<BibEntry> parsed = result.getDatabase().getEntries();
 
-        BibEntry expected = new BibEntry(IdGenerator.next(), "article").withField(BibEntry.KEY_FIELD, "test")
+        BibEntry expected = new BibEntry("article").withField(BibEntry.KEY_FIELD, "test")
                 .withField("author", "Ed von T@st");
 
         assertEquals(Collections.singletonList(expected), parsed);
@@ -374,7 +374,7 @@ public class BibtexParserTest {
 
         List<BibEntry> parsed = result.getDatabase().getEntries();
 
-        BibEntry expected = new BibEntry(IdGenerator.next(), "article").withField(BibEntry.KEY_FIELD, "test")
+        BibEntry expected = new BibEntry("article").withField(BibEntry.KEY_FIELD, "test")
                 .withField("author", "Ed von T@st");
         expected.setCommentsBeforeEntry(comment);
 

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -27,7 +27,6 @@ import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexString;
 import net.sf.jabref.model.entry.EntryType;
-import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.model.groups.AllEntriesGroup;
 import net.sf.jabref.model.groups.ExplicitGroup;
 import net.sf.jabref.model.groups.GroupHierarchyType;

--- a/src/test/java/net/sf/jabref/logic/layout/LayoutEntryTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/LayoutEntryTest.java
@@ -45,7 +45,7 @@ public class LayoutEntryTest {
 
         // create Bibtext Entry
 
-        mBTE = new BibEntry("testid");
+        mBTE = new BibEntry();
         mBTE.setField("abstract", "In this paper, we initiate a formal study of security on Android: Google's new open-source platform for mobile devices. Tags: Paper android google Open-Source Devices");
         //  Specifically, we present a core typed language to describe Android applications, and to reason about their data-flow security properties. Our operational semantics and type system provide some necessary foundations to help both users and developers of Android applications deal with their security concerns.
         mBTE.setField("keywords", "android, mobile devices, security");

--- a/src/test/java/net/sf/jabref/logic/search/SearchQueryTest.java
+++ b/src/test/java/net/sf/jabref/logic/search/SearchQueryTest.java
@@ -59,7 +59,7 @@ public class SearchQueryTest {
 
     @Test
     public void testSearchingForOpenBraketInBooktitle() {
-        BibEntry e = new BibEntry(IdGenerator.next(), BibtexEntryTypes.INPROCEEDINGS.getName());
+        BibEntry e = new BibEntry(BibtexEntryTypes.INPROCEEDINGS.getName());
         e.setField(FieldName.BOOKTITLE, "Super Conference (SC)");
 
         SearchQuery searchQuery = new SearchQuery("booktitle=\"(\"", false, false);
@@ -68,7 +68,7 @@ public class SearchQueryTest {
 
     @Test
     public void testSearchMatchesSingleKeywordNotPart() {
-        BibEntry e = new BibEntry(IdGenerator.next(), BibtexEntryTypes.INPROCEEDINGS.getName());
+        BibEntry e = new BibEntry(BibtexEntryTypes.INPROCEEDINGS.getName());
         e.setField("keywords", "banana, pineapple, orange");
 
         SearchQuery searchQuery = new SearchQuery("anykeyword==apple", false, false);
@@ -77,7 +77,7 @@ public class SearchQueryTest {
 
     @Test
     public void testSearchMatchesSingleKeyword() {
-        BibEntry e = new BibEntry(IdGenerator.next(), BibtexEntryTypes.INPROCEEDINGS.getName());
+        BibEntry e = new BibEntry(BibtexEntryTypes.INPROCEEDINGS.getName());
         e.setField("keywords", "banana, pineapple, orange");
 
         SearchQuery searchQuery = new SearchQuery("anykeyword==pineapple", false, false);
@@ -86,7 +86,7 @@ public class SearchQueryTest {
 
     @Test
     public void testSearchAllFields() {
-        BibEntry e = new BibEntry(IdGenerator.next(), BibtexEntryTypes.INPROCEEDINGS.getName());
+        BibEntry e = new BibEntry(BibtexEntryTypes.INPROCEEDINGS.getName());
         e.setField("title", "Fruity features");
         e.setField("keywords", "banana, pineapple, orange");
 
@@ -96,7 +96,7 @@ public class SearchQueryTest {
 
     @Test
     public void testSearchAllFieldsNotForSpecificField() {
-        BibEntry e = new BibEntry(IdGenerator.next(), BibtexEntryTypes.INPROCEEDINGS.getName());
+        BibEntry e = new BibEntry(BibtexEntryTypes.INPROCEEDINGS.getName());
         e.setField("title", "Fruity features");
         e.setField("keywords", "banana, pineapple, orange");
 
@@ -106,7 +106,7 @@ public class SearchQueryTest {
 
     @Test
     public void testSearchAllFieldsAndSpecificField() {
-        BibEntry e = new BibEntry(IdGenerator.next(), BibtexEntryTypes.INPROCEEDINGS.getName());
+        BibEntry e = new BibEntry(BibtexEntryTypes.INPROCEEDINGS.getName());
         e.setField("title", "Fruity features");
         e.setField("keywords", "banana, pineapple, orange");
 

--- a/src/test/java/net/sf/jabref/logic/search/SearchQueryTest.java
+++ b/src/test/java/net/sf/jabref/logic/search/SearchQueryTest.java
@@ -3,7 +3,6 @@ package net.sf.jabref.logic.search;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
 import net.sf.jabref.model.entry.FieldName;
-import net.sf.jabref.model.entry.IdGenerator;
 
 import org.junit.Test;
 

--- a/src/test/java/net/sf/jabref/logic/util/io/RegExpFileSearchTests.java
+++ b/src/test/java/net/sf/jabref/logic/util/io/RegExpFileSearchTests.java
@@ -47,7 +47,7 @@ public class RegExpFileSearchTests {
     public void testFindFiles() {
         //given
         List<BibEntry> entries = new ArrayList<>();
-        BibEntry localEntry = new BibEntry("123", BibtexEntryTypes.ARTICLE.getName());
+        BibEntry localEntry = new BibEntry(BibtexEntryTypes.ARTICLE.getName());
         localEntry.setCiteKey("pdfInDatabase");
         localEntry.setField("year", "2001");
         entries.add(localEntry);

--- a/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
@@ -38,7 +38,6 @@ import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.AuthorList;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
-import net.sf.jabref.model.entry.IdGenerator;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 import com.google.common.io.CharStreams;

--- a/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
+++ b/src/test/java/net/sf/jabref/logic/xmp/XMPUtilTest.java
@@ -178,7 +178,7 @@ public class XMPUtilTest {
     }
 
     public BibEntry t2BibtexEntry() {
-        BibEntry e = new BibEntry(IdGenerator.next(), BibtexEntryTypes.INCOLLECTION.getName());
+        BibEntry e = new BibEntry(BibtexEntryTypes.INCOLLECTION.getName());
         e.setField("title", "�pt�mz�t��n");
         e.setField("bibtexkey", "OezbekC06");
         e.setField("year", "2003");

--- a/src/test/java/net/sf/jabref/model/BibDatabaseContextTest.java
+++ b/src/test/java/net/sf/jabref/model/BibDatabaseContextTest.java
@@ -32,7 +32,7 @@ public class BibDatabaseContextTest {
     @Test
     public void testTypeBasedOnInferredModeBibTeX() {
         BibDatabase db = new BibDatabase();
-        BibEntry e1 = new BibEntry("1");
+        BibEntry e1 = new BibEntry();
         db.insertEntry(e1);
 
         BibDatabaseContext bibDatabaseContext = new BibDatabaseContext(db);

--- a/src/test/java/net/sf/jabref/model/BibDatabaseContextTest.java
+++ b/src/test/java/net/sf/jabref/model/BibDatabaseContextTest.java
@@ -42,7 +42,7 @@ public class BibDatabaseContextTest {
     @Test
     public void testTypeBasedOnInferredModeBiblatex() {
         BibDatabase db = new BibDatabase();
-        BibEntry e1 = new BibEntry("1", "electronic");
+        BibEntry e1 = new BibEntry("electronic");
         db.insertEntry(e1);
 
         BibDatabaseContext bibDatabaseContext = new BibDatabaseContext(db);

--- a/src/test/java/net/sf/jabref/model/DuplicateCheckTest.java
+++ b/src/test/java/net/sf/jabref/model/DuplicateCheckTest.java
@@ -3,7 +3,6 @@ package net.sf.jabref.model;
 import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
-import net.sf.jabref.model.entry.IdGenerator;
 
 import org.junit.Test;
 

--- a/src/test/java/net/sf/jabref/model/DuplicateCheckTest.java
+++ b/src/test/java/net/sf/jabref/model/DuplicateCheckTest.java
@@ -15,9 +15,9 @@ public class DuplicateCheckTest {
 
     @Test
     public void testDuplicateDetection() {
-        BibEntry one = new BibEntry(IdGenerator.next(), BibtexEntryTypes.ARTICLE.getName());
+        BibEntry one = new BibEntry(BibtexEntryTypes.ARTICLE.getName());
 
-        BibEntry two = new BibEntry(IdGenerator.next(), BibtexEntryTypes.ARTICLE.getName());
+        BibEntry two = new BibEntry(BibtexEntryTypes.ARTICLE.getName());
 
         one.setField("author", "Billy Bob");
         two.setField("author", "Billy Bob");

--- a/src/test/java/net/sf/jabref/model/database/BibDatabaseModeDetectionTest.java
+++ b/src/test/java/net/sf/jabref/model/database/BibDatabaseModeDetectionTest.java
@@ -16,14 +16,14 @@ import static org.junit.Assert.assertEquals;
 public class BibDatabaseModeDetectionTest {
     @Test
     public void detectBiblatex() {
-        Collection<BibEntry> entries = Arrays.asList(new BibEntry("someid", BibLatexEntryTypes.MVBOOK.getName()));
+        Collection<BibEntry> entries = Arrays.asList(new BibEntry(BibLatexEntryTypes.MVBOOK.getName()));
 
         assertEquals(BibDatabaseMode.BIBLATEX, BibDatabaseModeDetection.inferMode(BibDatabases.createDatabase(entries)));
     }
 
     @Test
     public void detectUndistinguishableAsBibtex() {
-        BibEntry entry = new BibEntry("someid", BibtexEntryTypes.ARTICLE.getName());
+        BibEntry entry = new BibEntry(BibtexEntryTypes.ARTICLE.getName());
         entry.setField("title", "My cool paper");
         Collection<BibEntry> entries = Arrays.asList(entry);
 
@@ -32,9 +32,9 @@ public class BibDatabaseModeDetectionTest {
 
     @Test
     public void detectMixedModeAsBiblatex() {
-        BibEntry bibtex = new BibEntry("someid", BibtexEntryTypes.ARTICLE.getName());
+        BibEntry bibtex = new BibEntry(BibtexEntryTypes.ARTICLE.getName());
         bibtex.setField("journal", "IEEE Trans. Services Computing");
-        BibEntry biblatex = new BibEntry("someid", BibLatexEntryTypes.ARTICLE.getName());
+        BibEntry biblatex = new BibEntry(BibLatexEntryTypes.ARTICLE.getName());
         biblatex.setField("translator", "Stefan Kolb");
         Collection<BibEntry> entries = Arrays.asList(bibtex, biblatex);
 
@@ -43,7 +43,7 @@ public class BibDatabaseModeDetectionTest {
 
     @Test
     public void detectUnknownTypeAsBibtex() {
-        BibEntry entry = new BibEntry("someid", new CustomEntryType("unknowntype", new ArrayList<>(0), new ArrayList<>(0)).getName());
+        BibEntry entry = new BibEntry(new CustomEntryType("unknowntype", new ArrayList<>(0), new ArrayList<>(0)).getName());
         Collection<BibEntry> entries = Arrays.asList(entry);
 
         assertEquals(BibDatabaseMode.BIBTEX, BibDatabaseModeDetection.inferMode(BibDatabases.createDatabase(entries)));
@@ -51,9 +51,9 @@ public class BibDatabaseModeDetectionTest {
 
     @Test
     public void ignoreUnknownTypesForBibtexDecision() {
-        BibEntry custom = new BibEntry("someid", new CustomEntryType("unknowntype", new ArrayList<>(0), new ArrayList<>(0)).getName());
-        BibEntry bibtex = new BibEntry("someid", BibtexEntryTypes.ARTICLE.getName());
-        BibEntry biblatex = new BibEntry("someid", BibLatexEntryTypes.ARTICLE.getName());
+        BibEntry custom = new BibEntry(new CustomEntryType("unknowntype", new ArrayList<>(0), new ArrayList<>(0)).getName());
+        BibEntry bibtex = new BibEntry(BibtexEntryTypes.ARTICLE.getName());
+        BibEntry biblatex = new BibEntry(BibLatexEntryTypes.ARTICLE.getName());
         Collection<BibEntry> entries = Arrays.asList(custom, bibtex, biblatex);
 
         assertEquals(BibDatabaseMode.BIBTEX, BibDatabaseModeDetection.inferMode(BibDatabases.createDatabase(entries)));
@@ -61,9 +61,9 @@ public class BibDatabaseModeDetectionTest {
 
     @Test
     public void ignoreUnknownTypesForBiblatexDecision() {
-        BibEntry custom = new BibEntry("someid", new CustomEntryType("unknowntype", new ArrayList<>(0), new ArrayList<>(0)).getName());
-        BibEntry bibtex = new BibEntry("someid", BibtexEntryTypes.ARTICLE.getName());
-        BibEntry biblatex = new BibEntry("someid", BibLatexEntryTypes.MVBOOK.getName());
+        BibEntry custom = new BibEntry(new CustomEntryType("unknowntype", new ArrayList<>(0), new ArrayList<>(0)).getName());
+        BibEntry bibtex = new BibEntry(BibtexEntryTypes.ARTICLE.getName());
+        BibEntry biblatex = new BibEntry(BibLatexEntryTypes.MVBOOK.getName());
         Collection<BibEntry> entries = Arrays.asList(custom, bibtex, biblatex);
 
         assertEquals(BibDatabaseMode.BIBLATEX, BibDatabaseModeDetection.inferMode(BibDatabases.createDatabase(entries)));

--- a/src/test/java/net/sf/jabref/model/database/BibDatabaseTest.java
+++ b/src/test/java/net/sf/jabref/model/database/BibDatabaseTest.java
@@ -55,7 +55,8 @@ public class BibDatabaseTest {
         BibEntry entry0 = new BibEntry();
         database.insertEntry(entry0);
 
-        BibEntry entry1 = new BibEntry(entry0.getId());
+        BibEntry entry1 = new BibEntry();
+        entry1.setId(entry0.getId());
         database.insertEntry(entry1);
         fail();
     }

--- a/src/test/java/net/sf/jabref/model/database/EntrySorterTest.java
+++ b/src/test/java/net/sf/jabref/model/database/EntrySorterTest.java
@@ -20,7 +20,7 @@ public class EntrySorterTest {
 
     @Test
     public void testEntrySorterWithOneElement() throws Exception {
-        BibEntry entryA = new BibEntry("a", "article");
+        BibEntry entryA = new BibEntry("article");
         EntrySorter es = new EntrySorter(Collections.singletonList(entryA), Comparator.comparing(BibEntry::getId));
         assertEquals(1, es.getEntryCount());
         assertEquals(entryA, es.getEntryAt(0));
@@ -28,8 +28,10 @@ public class EntrySorterTest {
 
     @Test
     public void testEntrySorterWithTwoElements() throws Exception {
-        BibEntry entryB = new BibEntry("b", "article");
-        BibEntry entryA = new BibEntry("a", "article");
+        BibEntry entryB = new BibEntry("article");
+        entryB.setId("2");
+        BibEntry entryA = new BibEntry("article");
+        entryB.setId("1");
         EntrySorter es = new EntrySorter(Arrays.asList(entryB, entryA), Comparator.comparing(BibEntry::getId));
         assertEquals(2, es.getEntryCount());
         assertEquals(entryA, es.getEntryAt(0));

--- a/src/test/java/net/sf/jabref/model/entry/BibEntryEqualityTest.java
+++ b/src/test/java/net/sf/jabref/model/entry/BibEntryEqualityTest.java
@@ -28,9 +28,11 @@ public class BibEntryEqualityTest {
 
     @Test
     public void compareIsTrueWhenIdAndFieldsAreEqual() throws Exception {
-        BibEntry e1 = new BibEntry("1");
+        BibEntry e1 = new BibEntry();
+        e1.setId("1");
         e1.setField("key", "value");
-        BibEntry e2 = new BibEntry("1");
+        BibEntry e2 = new BibEntry();
+        e2.setId("1");
         assertFalse(e1.equals(e2));
         e2.setField("key", "value");
         assertTrue(e1.equals(e2));

--- a/src/test/java/net/sf/jabref/model/entry/BibEntryTest.java
+++ b/src/test/java/net/sf/jabref/model/entry/BibEntryTest.java
@@ -36,4 +36,12 @@ public class BibEntryTest {
 
         Assert.assertEquals(Optional.of("value"), entry.getField("tEsT"));
     }
+
+    @Test
+    public void clonedBibentryHasUniqueID() throws Exception {
+        BibEntry entry = new BibEntry();
+        BibEntry entryClone = (BibEntry) entry.clone();
+
+        Assert.assertNotEquals(entry.getId(), entryClone.getId());
+    }
 }

--- a/src/test/java/net/sf/jabref/model/entry/BibEntryTests.java
+++ b/src/test/java/net/sf/jabref/model/entry/BibEntryTests.java
@@ -47,7 +47,7 @@ public class BibEntryTests {
 
     @Test
     public void allFieldsPresentDefault() {
-        BibEntry e = new BibEntry("id", BibtexEntryTypes.ARTICLE.getName());
+        BibEntry e = new BibEntry(BibtexEntryTypes.ARTICLE.getName());
         e.setField("author", "abc");
         e.setField("title", "abc");
         e.setField("journal", "abc");
@@ -63,7 +63,7 @@ public class BibEntryTests {
 
     @Test
     public void allFieldsPresentOr() {
-        BibEntry e = new BibEntry("id", BibtexEntryTypes.ARTICLE.getName());
+        BibEntry e = new BibEntry(BibtexEntryTypes.ARTICLE.getName());
         e.setField("author", "abc");
         e.setField("title", "abc");
         e.setField("journal", "abc");
@@ -79,7 +79,7 @@ public class BibEntryTests {
 
     @Test(expected = NullPointerException.class)
     public void isNullCiteKeyThrowsNPE() {
-        BibEntry e = new BibEntry("id", BibtexEntryTypes.ARTICLE.getName());
+        BibEntry e = new BibEntry(BibtexEntryTypes.ARTICLE.getName());
 
         e.setCiteKey(null);
         Assert.fail();
@@ -87,7 +87,7 @@ public class BibEntryTests {
 
     @Test
     public void isEmptyCiteKey() {
-        BibEntry e = new BibEntry("id", BibtexEntryTypes.ARTICLE.getName());
+        BibEntry e = new BibEntry(BibtexEntryTypes.ARTICLE.getName());
         Assert.assertFalse(e.hasCiteKey());
 
         e.setCiteKey("");

--- a/src/test/java/net/sf/jabref/model/entry/BibEntryTests.java
+++ b/src/test/java/net/sf/jabref/model/entry/BibEntryTests.java
@@ -390,7 +390,7 @@ public class BibEntryTests {
     }
 
     @Test
-    public void testCiteKeyAndID() {
+    public void setCiteKey() {
         BibEntry be = new BibEntry();
         Assert.assertFalse(be.hasCiteKey());
         be.setField("author", "Albert Einstein");
@@ -400,9 +400,5 @@ public class BibEntryTests {
         assertEquals(Optional.of("Albert Einstein"), be.getField("author"));
         be.clearField("author");
         assertEquals(Optional.empty(), be.getField("author"));
-
-        String id = IdGenerator.next();
-        be.setId(id);
-        assertEquals(id, be.getId());
     }
 }

--- a/src/test/java/net/sf/jabref/model/entry/CanonicalBibEntryTest.java
+++ b/src/test/java/net/sf/jabref/model/entry/CanonicalBibEntryTest.java
@@ -7,7 +7,7 @@ public class CanonicalBibEntryTest {
 
     @Test
     public void simpleCanonicalRepresentation() {
-        BibEntry e = new BibEntry("id", BibtexEntryTypes.ARTICLE.getName());
+        BibEntry e = new BibEntry(BibtexEntryTypes.ARTICLE.getName());
         e.setCiteKey("key");
         e.setField("author", "abc");
         e.setField("title", "def");
@@ -19,7 +19,7 @@ public class CanonicalBibEntryTest {
 
     @Test
     public void canonicalRepresentationWithNewlines() {
-        BibEntry e = new BibEntry("id", BibtexEntryTypes.ARTICLE.getName());
+        BibEntry e = new BibEntry(BibtexEntryTypes.ARTICLE.getName());
         e.setCiteKey("key");
         e.setField("abstract", "line 1\nline 2");
         String canonicalRepresentation = CanonicalBibtexEntry.getCanonicalRepresentation(e);

--- a/src/test/java/net/sf/jabref/model/search/rules/ContainBasedSearchRuleTest.java
+++ b/src/test/java/net/sf/jabref/model/search/rules/ContainBasedSearchRuleTest.java
@@ -44,7 +44,7 @@ public class ContainBasedSearchRuleTest {
     }
 
     public BibEntry makeBibtexEntry() {
-        BibEntry e = new BibEntry(IdGenerator.next(), BibtexEntryTypes.INCOLLECTION.getName());
+        BibEntry e = new BibEntry(BibtexEntryTypes.INCOLLECTION.getName());
         e.setField("title", "Marine finfish larviculture in Europe");
         e.setField("bibtexkey", "shields01");
         e.setField("year", "2001");

--- a/src/test/java/net/sf/jabref/model/search/rules/ContainBasedSearchRuleTest.java
+++ b/src/test/java/net/sf/jabref/model/search/rules/ContainBasedSearchRuleTest.java
@@ -2,7 +2,6 @@ package net.sf.jabref.model.search.rules;
 
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
-import net.sf.jabref.model.entry.IdGenerator;
 
 import org.junit.Assert;
 import org.junit.Test;


### PR DESCRIPTION
The internal ID of a BibEntry should never be set manually. Closes #1721

DONE:
- Removed constructors that allow setting the ID of an entry
- __Every__ BibEntry now gets an ID on creation
- A clone of a BibEntry __always gets a unique ID__ now
- Only option to change ID of an entry is now via `setID()`

PENDING:
- [ ] Is IDGenerator really global and consistent between calls now?
- [ ] Can we import Bibentries without an open Database? See c884745. Importers used a static ID value before. Not 100% sure if this change has any side effects.
- [ ] setID may still be replaced for some occurences?! Maybe we can even remove this execpt for a few test cases or so.