### PR TITLE
Remove four Blob listeners

### DIFF
--- a/src/main/java/net/sf/jabref/gui/EntryCustomizationDialog.java
+++ b/src/main/java/net/sf/jabref/gui/EntryCustomizationDialog.java
@@ -45,7 +45,7 @@ import net.sf.jabref.model.strings.StringUtil;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 
-public class EntryCustomizationDialog extends JDialog implements ListSelectionListener, ActionListener {
+public class EntryCustomizationDialog extends JDialog implements ListSelectionListener {
 
     private final JabRefFrame frame;
     protected GridBagLayout gbl = new GridBagLayout();
@@ -106,7 +106,7 @@ public class EntryCustomizationDialog extends JDialog implements ListSelectionLi
 
         typeComp = new EntryTypeList(entryTypes, bibDatabaseMode);
         typeComp.addListSelectionListener(this);
-        typeComp.addAdditionActionListener(this);
+        typeComp.addAdditionActionListener(e -> typeComp.selectField(e.getActionCommand()));
         typeComp.addDefaultActionListener(new DefaultListener());
         typeComp.setListSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 
@@ -137,9 +137,12 @@ public class EntryCustomizationDialog extends JDialog implements ListSelectionLi
         ok = new JButton(Localization.lang("OK"));
         cancel = new JButton(Localization.lang("Cancel"));
         apply = new JButton(Localization.lang("Apply"));
-        ok.addActionListener(this);
-        apply.addActionListener(this);
-        cancel.addActionListener(this);
+        ok.addActionListener(e -> {
+            applyChanges();
+            dispose();
+        });
+        apply.addActionListener(e -> applyChanges());
+        cancel.addActionListener(e -> dispose());
         ButtonBarBuilder bb = new ButtonBarBuilder(buttons);
         buttons.setBorder(BorderFactory.createEmptyBorder(2, 2, 2, 2));
         bb.addGlue();
@@ -356,20 +359,6 @@ public class EntryCustomizationDialog extends JDialog implements ListSelectionLi
         }
         // If we get here, all entries have matched.
         return true;
-    }
-
-    @Override
-    public void actionPerformed(ActionEvent e) {
-        if (e.getSource() == ok) {
-            applyChanges();
-            dispose();
-        } else if (e.getSource() == cancel) {
-            dispose();
-        } else if (e.getSource() == apply) {
-            applyChanges();
-        } else if (e.getSource() == typeComp) {
-            typeComp.selectField(e.getActionCommand());
-        }
     }
 
     /**

--- a/src/main/java/net/sf/jabref/gui/EntryTypeList.java
+++ b/src/main/java/net/sf/jabref/gui/EntryTypeList.java
@@ -1,7 +1,6 @@
 package net.sf.jabref.gui;
 
 import java.awt.GridBagConstraints;
-import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.List;
 import java.util.Optional;
@@ -42,7 +41,7 @@ public class EntryTypeList extends FieldSetComponent implements ListSelectionLis
         gbl.setConstraints(def, con);
         add(def);
         list.addListSelectionListener(this);
-        def.addActionListener(this);
+        def.addActionListener(e -> def.setEnabled(false));
         def.setEnabled(false);
         remove.setEnabled(false);
     }
@@ -124,16 +123,6 @@ public class EntryTypeList extends FieldSetComponent implements ListSelectionLis
 
     public void addDefaultActionListener(ActionListener l) {
         def.addActionListener(l);
-    }
-
-    @Override
-    public void actionPerformed(ActionEvent e) {
-        // Default button pressed.
-        if (e.getSource() == def) {
-            def.setEnabled(false);
-        } else {
-            super.actionPerformed(e);
-        }
     }
 
     @Override

--- a/src/main/java/net/sf/jabref/gui/FieldSetComponent.java
+++ b/src/main/java/net/sf/jabref/gui/FieldSetComponent.java
@@ -162,17 +162,6 @@ class FieldSetComponent extends JPanel {
         } else {
             sel = new JComboBox<>(preset.toArray(new String[preset.size()]));
             sel.setEditable(true);
-//            sel.addActionListener(e -> {
-//                if ("comboBoxChanged".equals(e.getActionCommand()) && (e.getModifiers() == 0)) {
-//                    // These conditions signify arrow key navigation in the dropdown list, so we should
-//                    // not react to it. I'm not sure if this is well defined enough to be guaranteed to work
-//                    // everywhere.
-//                    return;
-//                }
-//                String s = sel.getSelectedItem().toString();
-//                addField(s);
-//                sel.getEditor().selectAll();
-//            });
             gbl.setConstraints(sel, con);
             add(sel);
         }

--- a/src/main/java/net/sf/jabref/gui/FieldSetComponent.java
+++ b/src/main/java/net/sf/jabref/gui/FieldSetComponent.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 import javax.swing.Box;
@@ -40,7 +39,7 @@ import net.sf.jabref.preferences.JabRefPreferences;
 /**
  * @author alver
  */
-class FieldSetComponent extends JPanel implements ActionListener {
+class FieldSetComponent extends JPanel {
 
     private final Set<ActionListener> additionListeners = new HashSet<>();
     protected final JList<String> list;
@@ -94,8 +93,16 @@ class FieldSetComponent extends JPanel implements ActionListener {
         list = new JList<>(listModel);
         list.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         // Set up GUI:
-        add.addActionListener(this);
-        remove.addActionListener(this);
+        add.addActionListener(e -> {
+            // Selection has been made, or add button pressed:
+            if ((sel != null) && (sel.getSelectedItem() != null)) {
+                String s = sel.getSelectedItem().toString();
+                addField(s);
+            } else if ((input != null) && !"".equals(input.getText())) {
+                addField(input.getText());
+            }
+        });
+        remove.addActionListener(e -> removeSelected()); // Remove button pressed
 
         setLayout(gbl);
         con.insets = new Insets(1, 1, 1, 1);
@@ -118,8 +125,8 @@ class FieldSetComponent extends JPanel implements ActionListener {
             con.weightx = 0;
             up = new JButton(IconTheme.JabRefIcon.UP.getSmallIcon());
             down = new JButton(IconTheme.JabRefIcon.DOWN.getSmallIcon());
-            up.addActionListener(this);
-            down.addActionListener(this);
+            up.addActionListener(e -> move(-1));
+            down.addActionListener(e -> move(1));
             up.setToolTipText(Localization.lang("Move up"));
             down.setToolTipText(Localization.lang("Move down"));
             gbl.setConstraints(up, con);
@@ -149,13 +156,23 @@ class FieldSetComponent extends JPanel implements ActionListener {
         con.weightx = 1;
         if (preset == null) {
             input = new JTextField(20);
-            input.addActionListener(this);
+            input.addActionListener(e -> addField(input.getText()));
             gbl.setConstraints(input, con);
             add(input);
         } else {
             sel = new JComboBox<>(preset.toArray(new String[preset.size()]));
             sel.setEditable(true);
-            //sel.addActionListener(this);
+//            sel.addActionListener(e -> {
+//                if ("comboBoxChanged".equals(e.getActionCommand()) && (e.getModifiers() == 0)) {
+//                    // These conditions signify arrow key navigation in the dropdown list, so we should
+//                    // not react to it. I'm not sure if this is well defined enough to be guaranteed to work
+//                    // everywhere.
+//                    return;
+//                }
+//                String s = sel.getSelectedItem().toString();
+//                addField(s);
+//                sel.getEditor().selectAll();
+//            });
             gbl.setConstraints(sel, con);
             add(sel);
         }
@@ -319,39 +336,6 @@ class FieldSetComponent extends JPanel implements ActionListener {
         list.setSelectedIndex(newInd);
     }
 
-    @Override
-    public void actionPerformed(ActionEvent e) {
-        Object src = e.getSource();
-
-        if (Objects.equals(src, add)) {
-            // Selection has been made, or add button pressed:
-            if ((sel != null) && (sel.getSelectedItem() != null)) {
-                String s = sel.getSelectedItem().toString();
-                addField(s);
-            } else if ((input != null) && !"".equals(input.getText())) {
-                addField(input.getText());
-            }
-        } else if (Objects.equals(src, input)) {
-            addField(input.getText());
-        } else if (Objects.equals(src, remove)) {
-            // Remove button pressed:
-            removeSelected();
-        } else if (Objects.equals(src, sel)) {
-            if ("comboBoxChanged".equals(e.getActionCommand()) && (e.getModifiers() == 0)) {
-                // These conditions signify arrow key navigation in the dropdown list, so we should
-                // not react to it. I'm not sure if this is well defined enough to be guaranteed to work
-                // everywhere.
-                return;
-            }
-            String s = sel.getSelectedItem().toString();
-            addField(s);
-            sel.getEditor().selectAll();
-        } else if (Objects.equals(src, up)) {
-            move(-1);
-        } else if (Objects.equals(src, down)) {
-            move(1);
-        }
-    }
 
     /**
      * FocusListener to select the first entry in the list of fields when they are focused

--- a/src/main/java/net/sf/jabref/gui/preftabs/FontSelectorDialog.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/FontSelectorDialog.java
@@ -61,8 +61,6 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.TitledBorder;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
 
 import net.sf.jabref.logic.l10n.Localization;
 
@@ -169,10 +167,27 @@ public class FontSelectorDialog extends JDialog {
         styleList.setSelectedIndex(font.getStyle());
         styleField.setText(styleList.getSelectedValue());
 
-        ListHandler listHandler = new ListHandler();
-        familyList.addListSelectionListener(listHandler);
-        sizeList.addListSelectionListener(listHandler);
-        styleList.addListSelectionListener(listHandler);
+        familyList.addListSelectionListener(evt -> {
+            String family = familyList.getSelectedValue();
+            if (family != null) {
+                familyField.setText(family);
+            }
+            updatePreview();
+        });
+        sizeList.addListSelectionListener(evt -> {
+            String size = sizeList.getSelectedValue();
+            if (size != null) {
+                sizeField.setText(size);
+            }
+            updatePreview();
+        });
+        styleList.addListSelectionListener(evt -> {
+            String style = styleList.getSelectedValue();
+            if (style != null) {
+                styleField.setText(style);
+            }
+            updatePreview();
+        });
 
         content.add(BorderLayout.NORTH, listPanel);
 
@@ -320,31 +335,5 @@ public class FontSelectorDialog extends JDialog {
         }
         int style = styleList.getSelectedIndex();
         preview.setFont(new Font(family, style, size));
-    }
-
-
-    private class ListHandler implements ListSelectionListener {
-
-        @Override
-        public void valueChanged(ListSelectionEvent evt) {
-            Object source = evt.getSource();
-            if (familyList.equals(source)) {
-                String family = familyList.getSelectedValue();
-                if (family != null) {
-                    familyField.setText(family);
-                }
-            } else if (sizeList.equals(source)) {
-                String size = sizeList.getSelectedValue();
-                if (size != null) {
-                    sizeField.setText(size);
-                }
-            } else if (styleList.equals(source)) {
-                String style = styleList.getSelectedValue();
-                if (style != null) {
-                    styleField.setText(style);
-                }
-            }
-            updatePreview();
-        }
     }
 }


### PR DESCRIPTION
Hi guys,

Sorry in advance for the long text.

We are researchers in software engineering that currently work on user interface (UI) bad coding practices. We are studying UI listeners, in particular listeners that manage several widgets, like the following listener extracted from JabRef:

```
public void valueChanged(ListSelectionEvent evt) {
    Object source = evt.getSource();
    if (familyList.equals(source)) {
        String family = familyList.getSelectedValue();
        if (family != null) {
            familyField.setText(family);
        }
    } else if (sizeList.equals(source)) {
        String size = sizeList.getSelectedValue();
        if (size != null) {
            sizeField.setText(size);
        }
    } else if (styleList.equals(source)) {
        String style = styleList.getSelectedValue();
        if (style != null) {
            styleField.setText(style);
        }
    }
    updatePreview();
}
```

In such listeners, the source widget is identified using if/switch statements. Thanks to empirical studies we have indications that such a practice has a negative impact on the code quality. We call UI listeners that control three or more widgets, Blob Listeners (see this PDF document for more details: https://hal.inria.fr/hal-01308625v2/document).

We identified in JabRef six instances of the Blob listener and for four of them we have a refactoring solution. This pull request (PR) removes these four Blob listeners by splitting them into atomic UI listeners (i.e. they manage a single widget). Each commit of this PR refers to one or two Blob listeners. We manually tested JabRef for any regression. The new code is less complex in terms of cyclomatic complexity (CC) and lines of code (LoC): the new code has -38 LoCs and -21 of CC on the refactored files (according to Sonar analyses).


Complementary to this PR, we have several questions for the JabRef's developers:

1/ Do you think that coding UI listeners that manage several widgets is a bad coding practice?


2/ Do you think that the threshold of three or more widgets per listener relevant for characterising a Blob listener?


3/ Do you think that the refactored code relevant to remove Blob listeners?


4/ Do you have any idea of the reason of the presence of Blob listeners in your code?
For example, lack of programming experience? Lack of anonymous functions (aka lambdas) in Java 7 (and previous JDKs)?


5/ We identified two Blob listener for which we do not have a refactoring solution:
https://github.com/JabRef/jabref/blob/master/src/main/java/net/sf/jabref/gui/autocompleter/AutoCompleteListener.java#L70
https://github.com/JabRef/jabref/blob/master/src/main/java/net/sf/jabref/gui/BasePanel.java#L1409
Do you have any idea if these listener have to and can be refactored?


6/ Do you have suggestions about other bad user interface coding practices? This can concern controllers, commands, GUIs, widgets, data bindings, GUI testing, etc. 
