### PR TITLE
[FX] Review key bindings dialog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,7 @@ dependencies {
     compile 'com.airhacks:afterburner.fx:1.7.0'
     compile 'de.codecentric.centerdevice:javafxsvg:1.2.1'
     compile 'org.controlsfx:controlsfx:8.40.12'
+    compile 'org.fxmisc.easybind:easybind:1.0.3'
 
 
     compile 'commons-logging:commons-logging:1.2'

--- a/src/main/java/net/sf/jabref/gui/AbstractController.java
+++ b/src/main/java/net/sf/jabref/gui/AbstractController.java
@@ -1,11 +1,15 @@
 package net.sf.jabref.gui;
 
+import java.util.Objects;
+
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
+import javafx.stage.Stage;
 
 public class AbstractController<T extends AbstractViewModel> {
 
     @FXML protected T viewModel;
+    private Stage stage;
 
     /**
      * Gets the associated view model.
@@ -15,5 +19,17 @@ public class AbstractController<T extends AbstractViewModel> {
      */
     public T getViewModel() {
         return viewModel;
+    }
+
+    /**
+     * Returns the stage where this controller is displayed.
+     * The stage can be used to e.g. close the dialog.
+     */
+    public Stage getStage() {
+        return stage;
+    }
+
+    public void setStage(Stage stage) {
+        this.stage = Objects.requireNonNull(stage);
     }
 }

--- a/src/main/java/net/sf/jabref/gui/AbstractDialogView.java
+++ b/src/main/java/net/sf/jabref/gui/AbstractDialogView.java
@@ -1,5 +1,10 @@
 package net.sf.jabref.gui;
 
+import java.util.Optional;
+
+import javafx.scene.Parent;
+import javafx.stage.Stage;
+
 import net.sf.jabref.logic.l10n.Localization;
 
 import com.airhacks.afterburner.views.FXMLView;
@@ -11,6 +16,22 @@ public abstract class AbstractDialogView extends FXMLView {
 
         // Set resource bundle to internal localizations
         bundle = Localization.getMessages();
+    }
+
+    @Override
+    public Parent getView() {
+        Parent view = super.getView();
+
+        // Notify controller about the stage, where it is displayed
+        view.sceneProperty().addListener((observable, oldValue, newValue) ->
+                getController().ifPresent(controller -> controller.setStage( (Stage) newValue.getWindow() ))
+        );
+        return view;
+    }
+
+    private Optional<AbstractController> getController() {
+        return Optional.ofNullable(presenterProperty.get()).map(
+                presenter -> (AbstractController)presenter);
     }
 
     public abstract void show();

--- a/src/main/java/net/sf/jabref/gui/errorconsole/ErrorConsoleController.java
+++ b/src/main/java/net/sf/jabref/gui/errorconsole/ErrorConsoleController.java
@@ -15,7 +15,6 @@ import javafx.scene.control.SelectionMode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
-import javafx.stage.Stage;
 import javafx.util.Callback;
 
 import net.sf.jabref.gui.AbstractController;
@@ -28,7 +27,6 @@ import net.sf.jabref.logic.util.BuildInfo;
 
 public class ErrorConsoleController extends AbstractController<ErrorConsoleViewModel> {
 
-    @FXML private Button closeButton;
     @FXML private Button copyLogButton;
     @FXML private Button createIssueButton;
     @FXML private ListView<LogEventViewModel> messagesListView;
@@ -113,7 +111,6 @@ public class ErrorConsoleController extends AbstractController<ErrorConsoleViewM
 
     @FXML
     private void closeErrorDialog() {
-        Stage stage = (Stage) closeButton.getScene().getWindow();
-        stage.close();
+        getStage().close();
     }
 }

--- a/src/main/java/net/sf/jabref/gui/help/AboutDialogController.java
+++ b/src/main/java/net/sf/jabref/gui/help/AboutDialogController.java
@@ -3,10 +3,8 @@ package net.sf.jabref.gui.help;
 import javax.inject.Inject;
 
 import javafx.fxml.FXML;
-import javafx.scene.control.Button;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.stage.Stage;
 
 import net.sf.jabref.gui.AbstractController;
 import net.sf.jabref.gui.ClipBoardManager;
@@ -17,7 +15,6 @@ import de.codecentric.centerdevice.javafxsvg.SvgImageLoaderFactory;
 
 public class AboutDialogController extends AbstractController<AboutDialogViewModel> {
 
-    @FXML protected Button closeButton;
     @FXML protected ImageView iconImage;
     @Inject private DialogService dialogService;
     @Inject private ClipBoardManager clipBoardManager;
@@ -34,8 +31,7 @@ public class AboutDialogController extends AbstractController<AboutDialogViewMod
 
     @FXML
     private void closeAboutDialog() {
-        Stage stage = (Stage) closeButton.getScene().getWindow();
-        stage.close();
+        getStage().close();
     }
 
     @FXML

--- a/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingAction.java
+++ b/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingAction.java
@@ -7,7 +7,6 @@ import javax.swing.Action;
 
 import javafx.application.Platform;
 
-import net.sf.jabref.Globals;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.logic.l10n.Localization;
 
@@ -24,7 +23,7 @@ public class KeyBindingAction extends AbstractAction {
     public void actionPerformed(ActionEvent e) {
         Platform.runLater(() -> {
             KeyBindingsDialogView view = new KeyBindingsDialogView();
-            view.show(Globals.getKeyPrefs());
+            view.show();
         });
     }
 

--- a/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingViewModel.java
+++ b/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingViewModel.java
@@ -1,9 +1,15 @@
 package net.sf.jabref.gui.keyboard;
 
+import java.util.Optional;
+
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
+
+import net.sf.jabref.gui.IconTheme;
 
 import com.google.common.base.CaseFormat;
 
@@ -22,15 +28,23 @@ public class KeyBindingViewModel {
     private final SimpleStringProperty shownBinding = new SimpleStringProperty();
     private final KeyBindingCategory category;
 
+    public ObservableList<KeyBindingViewModel> getChildren() {
+        return children;
+    }
 
-    public KeyBindingViewModel(KeyBinding keyBinding, String binding) {
-        this(keyBinding.getCategory());
+    private ObservableList<KeyBindingViewModel> children = FXCollections.observableArrayList();
+    private KeyBindingRepository keyBindingRepository;
+
+
+    public KeyBindingViewModel(KeyBindingRepository keyBindingRepository, KeyBinding keyBinding, String binding) {
+        this(keyBindingRepository, keyBinding.getCategory());
         this.keyBinding = keyBinding;
         setDisplayName();
         setBinding(binding);
     }
 
-    public KeyBindingViewModel(KeyBindingCategory category) {
+    public KeyBindingViewModel(KeyBindingRepository keyBindingRepository, KeyBindingCategory category) {
+        this.keyBindingRepository = keyBindingRepository;
         this.category = category;
         setDisplayName();
     }
@@ -111,10 +125,8 @@ public class KeyBindingViewModel {
 
     /**
      * This method will reset the key bind of this models KeyBinding object to it's default bind
-     *
-     * @param keyBindingRepository as KeyBindingRepository
      */
-    public void resetToDefault(KeyBindingRepository keyBindingRepository) {
+    public void resetToDefault() {
         if (!isCategory()) {
             String key = getKeyBinding().getKey();
             keyBindingRepository.resetToDefault(key);
@@ -122,4 +134,7 @@ public class KeyBindingViewModel {
         }
     }
 
+    public Optional<IconTheme.JabRefIcon> getIcon() {
+        return isCategory() ? Optional.empty() : Optional.of(IconTheme.JabRefIcon.CLEANUP_ENTRIES);
+    }
 }

--- a/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingsDialogController.java
+++ b/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingsDialogController.java
@@ -1,0 +1,68 @@
+package net.sf.jabref.gui.keyboard;
+
+import javax.inject.Inject;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.SelectionMode;
+import javafx.scene.control.SelectionModel;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeTableColumn;
+import javafx.scene.control.TreeTableView;
+
+import net.sf.jabref.gui.AbstractController;
+import net.sf.jabref.gui.DialogService;
+import net.sf.jabref.gui.IconTheme;
+import net.sf.jabref.gui.util.RecursiveTreeItem;
+import net.sf.jabref.gui.util.ViewModelTreeTableCellFactory;
+
+import org.fxmisc.easybind.EasyBind;
+
+public class KeyBindingsDialogController extends AbstractController<KeyBindingsDialogViewModel> {
+
+    @FXML private TreeTableView<KeyBindingViewModel> keyBindingsTable;
+    @FXML private TreeTableColumn<KeyBindingViewModel, String> actionColumn;
+    @FXML private TreeTableColumn<KeyBindingViewModel, String> shortcutColumn;
+    @FXML private TreeTableColumn<KeyBindingViewModel, String> resetColumn;
+
+    @Inject private KeyBindingPreferences keyBindingPreferences;
+    @Inject private DialogService dialogService;
+
+    @FXML
+    private void initialize() {
+        viewModel = new KeyBindingsDialogViewModel(keyBindingPreferences, dialogService);
+
+        keyBindingsTable.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
+        viewModel.selectedKeyBindingProperty().bind(
+                EasyBind.monadic(keyBindingsTable.selectionModelProperty())
+                        .flatMap(SelectionModel::selectedItemProperty)
+                        .selectProperty(TreeItem::valueProperty)
+        );
+        keyBindingsTable.setOnKeyPressed(evt -> viewModel.setNewBindingForCurrent(evt));
+        keyBindingsTable.rootProperty().bind(
+                EasyBind.map(viewModel.rootKeyBindingProperty(),
+                        keybinding -> new RecursiveTreeItem<>(keybinding, KeyBindingViewModel::getChildren))
+        );
+        actionColumn.setCellValueFactory(cellData -> cellData.getValue().getValue().nameProperty());
+        shortcutColumn.setCellValueFactory(cellData -> cellData.getValue().getValue().shownBindingProperty());
+        resetColumn.setCellFactory(new ViewModelTreeTableCellFactory<KeyBindingViewModel, String>()
+                .withGraphic(keyBinding -> keyBinding.getIcon().map(IconTheme.JabRefIcon::getGraphicNode).orElse(null))
+                .withOnMouseClickedEvent(keyBinding -> evt -> keyBinding.resetToDefault())
+        );
+    }
+
+    @FXML
+    private void closeDialog() {
+        getStage().close();
+    }
+
+    @FXML
+    private void saveKeyBindingsAndCloseDialog() {
+        viewModel.saveKeyBindings();
+        closeDialog();
+    }
+
+    @FXML
+    private void setDefaultBindings() {
+        viewModel.resetToDefault();
+    }
+}

--- a/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingsDialogView.java
+++ b/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingsDialogView.java
@@ -4,24 +4,16 @@ import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.DialogPane;
 import javafx.stage.Stage;
 
+import net.sf.jabref.gui.AbstractDialogView;
 import net.sf.jabref.gui.FXDialog;
 import net.sf.jabref.logic.l10n.Localization;
 
-import com.airhacks.afterburner.views.FXMLView;
+public class KeyBindingsDialogView extends AbstractDialogView {
 
-public class KeyBindingsDialogView extends FXMLView {
-
-    public KeyBindingsDialogView() {
-        super();
-        bundle = Localization.getMessages();
-    }
-
-    public void show(KeyBindingPreferences keyBindingPreferences) {
+    @Override
+    public void show() {
         FXDialog keyBindingsDialog = new FXDialog(AlertType.INFORMATION, Localization.lang("Key bindings"));
         keyBindingsDialog.setDialogPane((DialogPane) this.getView());
-        KeyBindingsDialogViewModel controller = (KeyBindingsDialogViewModel) fxmlLoader.getController();
-        controller.setKeyBindingPreferences(keyBindingPreferences);
-        controller.initializeView();
         keyBindingsDialog.setResizable(true);
         ((Stage) keyBindingsDialog.getDialogPane().getScene().getWindow()).setMinHeight(475);
         ((Stage) keyBindingsDialog.getDialogPane().getScene().getWindow()).setMinWidth(375);

--- a/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingsDialogViewModel.java
+++ b/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingsDialogViewModel.java
@@ -15,13 +15,14 @@ import javafx.scene.control.TreeTableView;
 import javafx.scene.input.KeyEvent;
 import javafx.stage.Stage;
 
+import net.sf.jabref.gui.AbstractController;
 import net.sf.jabref.gui.DialogService;
 import net.sf.jabref.gui.FXDialogService;
 import net.sf.jabref.gui.IconTheme;
 import net.sf.jabref.gui.util.ViewModelTreeTableCellFactory;
 import net.sf.jabref.logic.l10n.Localization;
 
-public class KeyBindingsDialogViewModel {
+public class KeyBindingsDialogViewModel extends AbstractController<KeyBindingsDialogViewModel> {
 
     private KeyBindingRepository keyBindingRepository;
     private KeyBindingPreferences keyBindingPreferences;
@@ -52,9 +53,6 @@ public class KeyBindingsDialogViewModel {
         keyBindingsTable.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
         ButtonBar.setButtonData(resetButton, ButtonData.LEFT);
         selectedKeyBinding.bind(keyBindingsTable.getSelectionModel().selectedItemProperty());
-    }
-
-    public void initializeView() {
         registerKeyEvents();
         populateTable();
         bindColumnValues();
@@ -97,14 +95,9 @@ public class KeyBindingsDialogViewModel {
         keyBindingsTable.setOnKeyPressed(evt -> grabKey(evt));
     }
 
-    private Stage getDialogStage() {
-        return (Stage) closeButton.getScene().getWindow();
-    }
-
     @FXML
     private void closeDialog() {
-        Stage stage = getDialogStage();
-        stage.close();
+        getStage().close();
     }
 
     public void saveKeyBindings() {

--- a/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingsDialogViewModel.java
+++ b/src/main/java/net/sf/jabref/gui/keyboard/KeyBindingsDialogViewModel.java
@@ -1,166 +1,94 @@
 package net.sf.jabref.gui.keyboard;
 
+import java.util.Objects;
+
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
-import javafx.fxml.FXML;
-import javafx.scene.control.Alert.AlertType;
-import javafx.scene.control.Button;
+import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonBar;
-import javafx.scene.control.ButtonBar.ButtonData;
 import javafx.scene.control.ButtonType;
-import javafx.scene.control.SelectionMode;
-import javafx.scene.control.TreeItem;
-import javafx.scene.control.TreeTableColumn;
-import javafx.scene.control.TreeTableView;
 import javafx.scene.input.KeyEvent;
-import javafx.stage.Stage;
 
-import net.sf.jabref.gui.AbstractController;
+import net.sf.jabref.gui.AbstractViewModel;
 import net.sf.jabref.gui.DialogService;
-import net.sf.jabref.gui.FXDialogService;
-import net.sf.jabref.gui.IconTheme;
-import net.sf.jabref.gui.util.ViewModelTreeTableCellFactory;
 import net.sf.jabref.logic.l10n.Localization;
 
-public class KeyBindingsDialogViewModel extends AbstractController<KeyBindingsDialogViewModel> {
+public class KeyBindingsDialogViewModel extends AbstractViewModel {
 
+    private final KeyBindingPreferences keyBindingPreferences;
     private KeyBindingRepository keyBindingRepository;
-    private KeyBindingPreferences keyBindingPreferences;
-    private final ObjectProperty<TreeItem<KeyBindingViewModel>> selectedKeyBinding = new SimpleObjectProperty<>();
+    private DialogService dialogService;
 
+    public ObjectProperty<KeyBindingViewModel> selectedKeyBindingProperty() {
+        return selectedKeyBinding;
+    }
 
-    @FXML
-    private TreeTableView<KeyBindingViewModel> keyBindingsTable;
+    private final ObjectProperty<KeyBindingViewModel> selectedKeyBinding = new SimpleObjectProperty<>();
+    private final ObjectProperty<KeyBindingViewModel> rootKeyBinding = new SimpleObjectProperty<>();
 
-    @FXML
-    private TreeTableColumn<KeyBindingViewModel, String> actionColumn;
+    public ObjectProperty<KeyBindingViewModel> rootKeyBindingProperty() {
+        return rootKeyBinding;
+    }
 
-    @FXML
-    private TreeTableColumn<KeyBindingViewModel, String> shortcutColumn;
-
-    @FXML
-    private TreeTableColumn<KeyBindingViewModel, String> resetColumn;
-
-    @FXML
-    private Button closeButton;
-
-    @FXML
-    private Button resetButton;
-
-
-    @FXML
-    private void initialize() {
-        keyBindingsTable.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
-        ButtonBar.setButtonData(resetButton, ButtonData.LEFT);
-        selectedKeyBinding.bind(keyBindingsTable.getSelectionModel().selectedItemProperty());
-        registerKeyEvents();
+    public KeyBindingsDialogViewModel(KeyBindingPreferences keyBindingPreferences, DialogService dialogService) {
+        this.keyBindingPreferences = Objects.requireNonNull(keyBindingPreferences);
+        this.dialogService = Objects.requireNonNull(dialogService);
+        keyBindingRepository = new KeyBindingRepository(keyBindingPreferences.getKeyBindings());
         populateTable();
-        bindColumnValues();
     }
 
     /**
-     * Read all keybindings from the keybinding repository and create table keybinding
-     * models for them
+     * Read all keybindings from the keybinding repository and create table keybinding models for them
      */
     private void populateTable() {
-        TreeItem<KeyBindingViewModel> root = new TreeItem<>(new KeyBindingViewModel(KeyBindingCategory.FILE));
+        KeyBindingViewModel root = new KeyBindingViewModel(keyBindingRepository, KeyBindingCategory.FILE);
         for (KeyBindingCategory category : KeyBindingCategory.values()) {
-            TreeItem<KeyBindingViewModel> categoryItem = new TreeItem<>(new KeyBindingViewModel(category));
+            KeyBindingViewModel categoryItem = new KeyBindingViewModel(keyBindingRepository, category);
             keyBindingRepository.getKeyBindings().forEach((keyBinding, bind) -> {
                 if (keyBinding.getCategory() == category) {
-                    KeyBindingViewModel keyBindViewModel = new KeyBindingViewModel(keyBinding, bind);
-                    TreeItem<KeyBindingViewModel> keyBindTreeItem = new TreeItem<>(keyBindViewModel);
-                    categoryItem.getChildren().add(keyBindTreeItem);
+                    KeyBindingViewModel keyBindViewModel = new KeyBindingViewModel(keyBindingRepository, keyBinding, bind);
+                    categoryItem.getChildren().add(keyBindViewModel);
                 }
             });
-            categoryItem.setExpanded(true);
             root.getChildren().add(categoryItem);
         }
-        root.setExpanded(true);
-        keyBindingsTable.setRoot(root);
+        rootKeyBinding.set(root);
     }
 
-    private void bindColumnValues() {
-        actionColumn.setCellValueFactory(cellData -> cellData.getValue().getValue().nameProperty());
-        shortcutColumn.setCellValueFactory(cellData -> cellData.getValue().getValue().shownBindingProperty());
-        resetColumn.setCellFactory(new ViewModelTreeTableCellFactory<KeyBindingViewModel, String>().
-                withGraphic(
-                    viewModel -> viewModel.isCategory() ? null : IconTheme.JabRefIcon.CLEANUP_ENTRIES.getGraphicNode()).
-                withOnMouseClickedEvent(
-                    viewModel -> viewModel.isCategory() ? null : evt -> viewModel.resetToDefault(keyBindingRepository))
-        );
-    }
-
-    private void registerKeyEvents() {
-        keyBindingsTable.setOnKeyPressed(evt -> grabKey(evt));
-    }
-
-    @FXML
-    private void closeDialog() {
-        getStage().close();
-    }
-
-    public void saveKeyBindings() {
-        keyBindingPreferences.setNewKeyBindings(keyBindingRepository.getKeyBindings());
-    }
-
-    @FXML
-    private void saveKeyBindingsAndCloseDialog() {
-        saveKeyBindings();
-
-        String title = Localization.lang("Key bindings changed");
-        String content = Localization.lang("Your new key bindings have been stored.") + '\n'
-                + Localization.lang("You must restart JabRef for the new key bindings to work properly.");
-        DialogService dialogService = new FXDialogService();
-        dialogService.showInformationDialogAndWait(title, content);
-        closeDialog();
-    }
-
-    @FXML
-    private void setDefaultBindings() {
-        String title = Localization.lang("Resetting all key bindings");
-        String content = Localization.lang("All key bindings will be reset to their defaults.");
-        ButtonType resetButtonType = new ButtonType("Reset", ButtonData.OK_DONE);
-        DialogService dialogService = new FXDialogService();
-        dialogService.showCustomButtonDialogAndWait(AlertType.INFORMATION, title, content, resetButtonType,
-                ButtonType.CANCEL).ifPresent(response -> {
-                    if (response == resetButtonType) {
-                        resetKeyBindingsToDefault();
-                        populateTable();
-                    }
-                });
-    }
-
-    public void resetKeyBindingsToDefault() {
-        keyBindingRepository.resetToDefault();
-    }
-
-    public void grabKey(KeyEvent evt) {
+    public void setNewBindingForCurrent(KeyEvent event) {
         // first check if a valid entry is selected
         if (selectedKeyBinding.isNull().get()) {
             return;
         }
-        KeyBindingViewModel selectedEntry = selectedKeyBinding.get().getValue();
+        KeyBindingViewModel selectedEntry = selectedKeyBinding.get();
         if ((selectedEntry == null) || (selectedEntry.isCategory())) {
             return;
         }
 
-        if (selectedEntry.setNewBinding(evt)) {
+        if (selectedEntry.setNewBinding(event)) {
             keyBindingRepository.put(selectedEntry.getKeyBinding(), selectedEntry.getBinding());
         }
     }
 
-    public void setKeyBindingPreferences(KeyBindingPreferences keyBindingPreferences) {
-        this.keyBindingPreferences = keyBindingPreferences;
-        this.keyBindingRepository = new KeyBindingRepository(keyBindingPreferences.getKeyBindings());
+    public void saveKeyBindings() {
+        keyBindingPreferences.setNewKeyBindings(keyBindingRepository.getKeyBindings());
+
+        String title = Localization.lang("Key bindings changed");
+        String content = Localization.lang("Your new key bindings have been stored.") + '\n'
+                + Localization.lang("You must restart JabRef for the new key bindings to work properly.");
+        dialogService.showInformationDialogAndWait(title, content);
     }
 
-    public ObjectProperty<TreeItem<KeyBindingViewModel>> getSelectedKeyBinding() {
-        return selectedKeyBinding;
+    public void resetToDefault() {
+        String title = Localization.lang("Resetting all key bindings");
+        String content = Localization.lang("All key bindings will be reset to their defaults.");
+        ButtonType resetButtonType = new ButtonType("Reset", ButtonBar.ButtonData.OK_DONE);
+        dialogService.showCustomButtonDialogAndWait(Alert.AlertType.INFORMATION, title, content, resetButtonType,
+                ButtonType.CANCEL).ifPresent(response -> {
+            if (response == resetButtonType) {
+                keyBindingRepository.resetToDefault();
+                populateTable();
+            }
+        });
     }
-
-    public KeyBindingRepository getKeyBindingRepository() {
-        return keyBindingRepository;
-    }
-
 }

--- a/src/main/java/net/sf/jabref/gui/util/RecursiveTreeItem.java
+++ b/src/main/java/net/sf/jabref/gui/util/RecursiveTreeItem.java
@@ -1,0 +1,66 @@
+package net.sf.jabref.gui.util;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.scene.Node;
+import javafx.scene.control.TreeItem;
+import javafx.util.Callback;
+
+/**
+ * Taken from https://gist.github.com/lestard/011e9ed4433f9eb791a8
+ */
+public class RecursiveTreeItem<T> extends TreeItem<T> {
+
+    private Callback<T, ObservableList<T>> childrenFactory;
+
+    public RecursiveTreeItem(Callback<T, ObservableList<T>> func){
+        this(null, func);
+    }
+
+    public RecursiveTreeItem(final T value, Callback<T, ObservableList<T>> func){
+        this(value, (Node) null, func);
+    }
+
+    public RecursiveTreeItem(final T value, Node graphic, Callback<T, ObservableList<T>> func){
+        super(value, graphic);
+
+        this.childrenFactory = func;
+
+        if(value != null) {
+            addChildrenListener(value);
+        }
+
+        valueProperty().addListener((obs, oldValue, newValue)->{
+            if(newValue != null){
+                addChildrenListener(newValue);
+            }
+        });
+    }
+
+    private void addChildrenListener(T value){
+        final ObservableList<T> children = childrenFactory.call(value);
+
+        children.forEach(child ->  RecursiveTreeItem.this.getChildren().add(new RecursiveTreeItem<>(child, getGraphic(), childrenFactory)));
+
+        children.addListener((ListChangeListener<T>) change -> {
+            while(change.next()){
+
+                if(change.wasAdded()){
+                    change.getAddedSubList().forEach(t-> RecursiveTreeItem.this.getChildren().add(new RecursiveTreeItem<>(t, getGraphic(), childrenFactory)));
+                }
+
+                if(change.wasRemoved()){
+                    change.getRemoved().forEach(t->{
+                        final List<TreeItem<T>> itemsToRemove = RecursiveTreeItem.this.getChildren().stream().filter(treeItem -> treeItem.getValue().equals(t)).collect(Collectors.toList());
+
+                        RecursiveTreeItem.this.getChildren().removeAll(itemsToRemove);
+                    });
+                }
+
+            }
+        });
+    }
+}

--- a/src/main/resources/net/sf/jabref/gui/keyboard/KeyBindingsDialog.fxml
+++ b/src/main/resources/net/sf/jabref/gui/keyboard/KeyBindingsDialog.fxml
@@ -8,15 +8,15 @@
 <?import javafx.scene.control.TreeTableView?>
 <?import javafx.scene.layout.BorderPane?>
 
-<DialogPane minHeight="450.0" minWidth="375.0" prefHeight="450.0" prefWidth="407.0" xmlns="http://javafx.com/javafx/8.0.65" xmlns:fx="http://javafx.com/fxml/1" fx:controller="net.sf.jabref.gui.keyboard.KeyBindingsDialogViewModel">
+<DialogPane minHeight="450.0" minWidth="375.0" prefHeight="450.0" prefWidth="407.0" xmlns="http://javafx.com/javafx/8.0.65" xmlns:fx="http://javafx.com/fxml/1" fx:controller="net.sf.jabref.gui.keyboard.KeyBindingsDialogController">
    <content>
       <BorderPane prefHeight="428.0" prefWidth="402.0">
          <bottom>
             <ButtonBar minWidth="350.0" prefHeight="40.0" prefWidth="250.0" styleClass="custom-buttons" BorderPane.alignment="CENTER">
               <buttons>
-                  <Button fx:id="resetButton" mnemonicParsing="false" onAction="#setDefaultBindings" text="%Reset Bindings" />
-                  <Button defaultButton="true" mnemonicParsing="false" onAction="#saveKeyBindingsAndCloseDialog" text="%Save" />
-                  <Button fx:id="closeButton" mnemonicParsing="false" onAction="#closeDialog" text="%Cancel" />
+                  <Button fx:id="resetButton" mnemonicParsing="false" onAction="#setDefaultBindings" text="%Reset Bindings" ButtonBar.buttonData="LEFT" />
+                  <Button defaultButton="true" mnemonicParsing="false" onAction="#saveKeyBindingsAndCloseDialog" text="%Save" ButtonBar.buttonData="OK_DONE" />
+                  <Button fx:id="closeButton" mnemonicParsing="false" onAction="#closeDialog" text="%Cancel" ButtonBar.buttonData="CANCEL_CLOSE" />
               </buttons>
             </ButtonBar>
          </bottom>


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
Another step for #2290.
Only change in behavior is that all the categories are collapsed by default. The reason is that I have no idea how to cleanly implement "expanded by default". But in the end I actually think in this way the dialog is a bit more usuable as the user sees all the categories.

@koppor the localization tests fail, I think this issue resulted from the recent merge.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
