### PR TITLE
[WIP] Introduce explicit list of ALL_BIBLATEX_ONLY_FIELDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 ### Fixed
 - Fixed [#2391](https://github.com/JabRef/jabref/issues/2391): Clicking on "Get Fulltext" button sets links correctly for the entry being edited.
+- The integrigrity check now determines the set of biblatex only fields differently. Fixes [#2390](https://github.com/JabRef/jabref/issues/2390).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ## [Unreleased]
 
 ### Changed
+- When editing an article, the tab "Optional fields" now shows "ISSN"
+- When editing a book, the tab "Optional fields" now shows "ISBN"
 
 ### Fixed
 - Fixed [#2391](https://github.com/JabRef/jabref/issues/2391): Clicking on "Get Fulltext" button sets links correctly for the entry being edited.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 ### Fixed
 - Fixed [#2391](https://github.com/JabRef/jabref/issues/2391): Clicking on "Get Fulltext" button sets links correctly for the entry being edited.
-- The integrigrity check now determines the set of biblatex only fields differently. Fixes [#2390](https://github.com/JabRef/jabref/issues/2390).
+- The integrity check now determines the set of BibLaTeX-only fields differently. Fixes [#2390](https://github.com/JabRef/jabref/issues/2390).
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/BiblioscapeImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/BiblioscapeImporter.java
@@ -252,7 +252,7 @@ public class BiblioscapeImporter extends Importer {
                 }
 
                 if (!comments.isEmpty()) { // set comment if present
-                    hm.put("comment", String.join(";", comments));
+                    hm.put(FieldName.COMMENT, String.join(";", comments));
                 }
                 BibEntry b = new BibEntry(bibtexType);
                 b.setField(hm);

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/MedlinePlainImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/MedlinePlainImporter.java
@@ -203,7 +203,7 @@ public class MedlinePlainImporter extends Importer {
             fixAuthors(fields, author, FieldName.AUTHOR);
             fixAuthors(fields, editor, FieldName.EDITOR);
             if (!comment.isEmpty()) {
-                fields.put("comment", comment);
+                fields.put(FieldName.COMMENT, comment);
             }
 
             BibEntry b = new BibEntry(type);

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/RisImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/RisImporter.java
@@ -233,7 +233,7 @@ public class RisImporter extends Importer {
                     fields.put(FieldName.EDITOR, editor);
                 }
                 if (!comment.isEmpty()) {
-                    fields.put("comment", comment);
+                    fields.put(FieldName.COMMENT, comment);
                 }
 
                 fields.put(FieldName.PAGES, startPage + endPage);

--- a/src/main/java/net/sf/jabref/logic/importer/util/OAI2Handler.java
+++ b/src/main/java/net/sf/jabref/logic/importer/util/OAI2Handler.java
@@ -87,7 +87,7 @@ public class OAI2Handler extends DefaultHandler {
         } else if ("abstract".equals(qualifiedName)) {
             entry.setField(FieldName.ABSTRACT, content);
         } else if ("comments".equals(qualifiedName)) {
-            entry.setField(FieldName.COMMENTS, content);
+            entry.setField(FieldName.COMMENT, content);
         } else if ("report-no".equals(qualifiedName)) {
             entry.setField(FieldName.REPORTNO, content);
         } else if ("doi".equals(qualifiedName)) {

--- a/src/main/java/net/sf/jabref/logic/integrity/NoBibtexFieldChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/NoBibtexFieldChecker.java
@@ -1,6 +1,5 @@
 package net.sf.jabref.logic.integrity;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -10,24 +9,19 @@ import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibLatexEntryTypes;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
-import net.sf.jabref.model.entry.FieldName;
+import net.sf.jabref.model.entry.InternalBibtexFields;
 
 /**
  * This checker checks whether the entry does not contain any field appearing only in BibLaTeX (and not in BibTeX)
  */
 public class NoBibtexFieldChecker implements Checker {
 
-
     private List<String> getAllBiblatexOnlyFields() {
         Set<String> allBibtexFields = BibtexEntryTypes.ALL.stream().flatMap(type -> type.getAllFields().stream()).collect(Collectors.toSet());
-
-        // fields as set at net.sf.jabref.preferences.JabRefPreferences.setLanguageDependentDefaultValues()
-        final List<String> JABREF_GENERAL_FIELDS =  Arrays.asList(FieldName.CROSSREF, FieldName.KEYWORDS, FieldName.FILE, FieldName.DOI, FieldName.URL, FieldName.COMMENT, FieldName.OWNER, FieldName.TIMESTAMP, FieldName.ABSTRACT, FieldName.REVIEW);
-
         return BibLatexEntryTypes.ALL.stream()
                 .flatMap(type -> type.getAllFields().stream())
                 .filter(fieldName -> !allBibtexFields.contains(fieldName))
-                .filter(fieldName -> !JABREF_GENERAL_FIELDS.contains(fieldName))
+                .filter(fieldName -> !InternalBibtexFields.DEFAULT_GENERAL_FIELDS.contains(fieldName))
                 .sorted()
                 .collect(Collectors.toList());
     }
@@ -35,9 +29,9 @@ public class NoBibtexFieldChecker implements Checker {
     @Override
     public List<IntegrityMessage> check(BibEntry entry) {
         // non-static initalization of ALL_BIBLATEX_ONLY_FIELDS as the user can customize the entry types during runtime
-        final List<String> ALL_BIBLATEX_ONLY_FIELDS = getAllBiblatexOnlyFields();
+        final List<String> allBiblatexOnlyFields = getAllBiblatexOnlyFields();
         return entry.getFieldNames().stream()
-                .filter(name ->  ALL_BIBLATEX_ONLY_FIELDS.contains(name))
+                .filter(name ->  allBiblatexOnlyFields.contains(name))
                 .map(name -> new IntegrityMessage(Localization.lang("BibLaTeX field only"), entry, name)).collect(Collectors.toList());
     }
 

--- a/src/main/java/net/sf/jabref/logic/integrity/NoBibtexFieldChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/NoBibtexFieldChecker.java
@@ -1,34 +1,31 @@
 package net.sf.jabref.logic.integrity;
 
 import java.util.List;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import net.sf.jabref.logic.integrity.IntegrityCheck.Checker;
 import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.model.entry.EntryConverter;
-import net.sf.jabref.model.entry.FieldName;
+import net.sf.jabref.model.entry.BibLatexEntryTypes;
+import net.sf.jabref.model.entry.BibtexEntryTypes;
 
 /**
  * This checker checks whether the entry does not contain any field appearing only in BibLaTeX (and not in BibTex)
  */
 public class NoBibtexFieldChecker implements Checker {
 
+    private static final List<String> ALL_BIBLATEX_ONLY_FIELDS;
+
+    static {
+        Set<String> allBibtexFields = BibtexEntryTypes.ALL.stream().flatMap(type -> type.getAllFields().stream()).collect(Collectors.toSet());
+        ALL_BIBLATEX_ONLY_FIELDS = BibLatexEntryTypes.ALL.stream().flatMap(type -> type.getAllFields().stream()).filter(fieldName -> !allBibtexFields.contains(fieldName)).sorted().collect(Collectors.toList());
+    }
+
     @Override
     public List<IntegrityMessage> check(BibEntry entry) {
-        SortedSet<String> allBibLaTeXOnlyFields = new TreeSet<>();
-        allBibLaTeXOnlyFields.addAll(EntryConverter.FIELD_ALIASES_LTX_TO_TEX.keySet());
-
-        // file is both in BibTeX and BibLaTeX
-        allBibLaTeXOnlyFields.remove(FieldName.FILE);
-
-        // this exists in BibLaTeX only (and is no aliased field)
-        allBibLaTeXOnlyFields.add(FieldName.JOURNALSUBTITLE);
-
         return entry.getFieldNames().stream()
-                .filter(name ->  allBibLaTeXOnlyFields.contains(name))
+                .filter(name ->  ALL_BIBLATEX_ONLY_FIELDS.contains(name))
                 .map(name -> new IntegrityMessage(Localization.lang("BibLaTeX field only"), entry, name)).collect(Collectors.toList());
     }
 

--- a/src/main/java/net/sf/jabref/logic/integrity/NoBibtexFieldChecker.java
+++ b/src/main/java/net/sf/jabref/logic/integrity/NoBibtexFieldChecker.java
@@ -1,5 +1,6 @@
 package net.sf.jabref.logic.integrity;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -9,21 +10,32 @@ import net.sf.jabref.logic.l10n.Localization;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.BibLatexEntryTypes;
 import net.sf.jabref.model.entry.BibtexEntryTypes;
+import net.sf.jabref.model.entry.FieldName;
 
 /**
- * This checker checks whether the entry does not contain any field appearing only in BibLaTeX (and not in BibTex)
+ * This checker checks whether the entry does not contain any field appearing only in BibLaTeX (and not in BibTeX)
  */
 public class NoBibtexFieldChecker implements Checker {
 
-    private static final List<String> ALL_BIBLATEX_ONLY_FIELDS;
 
-    static {
+    private List<String> getAllBiblatexOnlyFields() {
         Set<String> allBibtexFields = BibtexEntryTypes.ALL.stream().flatMap(type -> type.getAllFields().stream()).collect(Collectors.toSet());
-        ALL_BIBLATEX_ONLY_FIELDS = BibLatexEntryTypes.ALL.stream().flatMap(type -> type.getAllFields().stream()).filter(fieldName -> !allBibtexFields.contains(fieldName)).sorted().collect(Collectors.toList());
+
+        // fields as set at net.sf.jabref.preferences.JabRefPreferences.setLanguageDependentDefaultValues()
+        final List<String> JABREF_GENERAL_FIELDS =  Arrays.asList(FieldName.CROSSREF, FieldName.KEYWORDS, FieldName.FILE, FieldName.DOI, FieldName.URL, FieldName.COMMENT, FieldName.OWNER, FieldName.TIMESTAMP, FieldName.ABSTRACT, FieldName.REVIEW);
+
+        return BibLatexEntryTypes.ALL.stream()
+                .flatMap(type -> type.getAllFields().stream())
+                .filter(fieldName -> !allBibtexFields.contains(fieldName))
+                .filter(fieldName -> !JABREF_GENERAL_FIELDS.contains(fieldName))
+                .sorted()
+                .collect(Collectors.toList());
     }
 
     @Override
     public List<IntegrityMessage> check(BibEntry entry) {
+        // non-static initalization of ALL_BIBLATEX_ONLY_FIELDS as the user can customize the entry types during runtime
+        final List<String> ALL_BIBLATEX_ONLY_FIELDS = getAllBiblatexOnlyFields();
         return entry.getFieldNames().stream()
                 .filter(name ->  ALL_BIBLATEX_ONLY_FIELDS.contains(name))
                 .map(name -> new IntegrityMessage(Localization.lang("BibLaTeX field only"), entry, name)).collect(Collectors.toList());

--- a/src/main/java/net/sf/jabref/model/entry/BibtexEntryTypes.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibtexEntryTypes.java
@@ -21,7 +21,7 @@ public class BibtexEntryTypes {
 
         {
             addAllRequired(FieldName.AUTHOR, FieldName.TITLE, FieldName.JOURNAL, FieldName.YEAR);
-            addAllOptional(FieldName.VOLUME, FieldName.NUMBER, FieldName.PAGES, FieldName.MONTH, FieldName.NOTE);
+            addAllOptional(FieldName.VOLUME, FieldName.NUMBER, FieldName.PAGES, FieldName.MONTH, FieldName.ISSN, FieldName.NOTE);
         }
 
         @Override
@@ -40,7 +40,7 @@ public class BibtexEntryTypes {
 
         {
             addAllRequired(FieldName.TITLE, FieldName.PUBLISHER, FieldName.YEAR, FieldName.orFields(FieldName.AUTHOR, FieldName.EDITOR));
-            addAllOptional(FieldName.VOLUME, FieldName.NUMBER, FieldName.SERIES, FieldName.ADDRESS, FieldName.EDITION, FieldName.MONTH, FieldName.NOTE);
+            addAllOptional(FieldName.VOLUME, FieldName.NUMBER, FieldName.SERIES, FieldName.ADDRESS, FieldName.EDITION, FieldName.MONTH, FieldName.ISBN, FieldName.NOTE);
         }
 
         @Override
@@ -98,7 +98,7 @@ public class BibtexEntryTypes {
 
         {
             addAllRequired(FieldName.orFields(FieldName.CHAPTER, FieldName.PAGES), FieldName.TITLE, FieldName.PUBLISHER, FieldName.YEAR, FieldName.orFields(FieldName.AUTHOR, FieldName.EDITOR));
-            addAllOptional(FieldName.VOLUME, FieldName.NUMBER, FieldName.SERIES, FieldName.TYPE, FieldName.ADDRESS, FieldName.EDITION, FieldName.MONTH, FieldName.NOTE);
+            addAllOptional(FieldName.VOLUME, FieldName.NUMBER, FieldName.SERIES, FieldName.TYPE, FieldName.ADDRESS, FieldName.EDITION, FieldName.MONTH, FieldName.ISBN, FieldName.NOTE);
         }
 
         @Override
@@ -117,7 +117,7 @@ public class BibtexEntryTypes {
         {
             addAllRequired(FieldName.AUTHOR, FieldName.TITLE, FieldName.BOOKTITLE, FieldName.PUBLISHER, FieldName.YEAR);
             addAllOptional(FieldName.EDITOR, FieldName.VOLUME, FieldName.NUMBER, FieldName.SERIES, FieldName.TYPE, FieldName.CHAPTER, FieldName.PAGES, FieldName.ADDRESS, FieldName.EDITION,
-                    FieldName.MONTH, FieldName.NOTE);
+                    FieldName.MONTH, FieldName.ISBN, FieldName.NOTE);
         }
 
         @Override
@@ -155,7 +155,7 @@ public class BibtexEntryTypes {
 
         {
             addAllRequired(FieldName.TITLE);
-            addAllOptional(FieldName.AUTHOR, FieldName.ORGANIZATION, FieldName.ADDRESS, FieldName.EDITION, FieldName.MONTH, FieldName.YEAR, FieldName.NOTE);
+            addAllOptional(FieldName.AUTHOR, FieldName.ORGANIZATION, FieldName.ADDRESS, FieldName.EDITION, FieldName.MONTH, FieldName.YEAR, FieldName.ISBN, FieldName.NOTE);
         }
 
         @Override
@@ -230,8 +230,8 @@ public class BibtexEntryTypes {
 
         {
             addAllRequired(FieldName.TITLE, FieldName.YEAR);
-            addAllOptional(FieldName.EDITOR, FieldName.VOLUME, FieldName.NUMBER, FieldName.SERIES, FieldName.ADDRESS, FieldName.PUBLISHER, FieldName.NOTE, FieldName.MONTH,
-                    FieldName.ORGANIZATION);
+            addAllOptional(FieldName.EDITOR, FieldName.VOLUME, FieldName.NUMBER, FieldName.SERIES, FieldName.ADDRESS, FieldName.PUBLISHER, FieldName.MONTH,
+                    FieldName.ORGANIZATION, FieldName.ISBN, FieldName.NOTE);
         }
 
         @Override

--- a/src/main/java/net/sf/jabref/model/entry/FieldName.java
+++ b/src/main/java/net/sf/jabref/model/entry/FieldName.java
@@ -39,7 +39,7 @@ public class FieldName {
     public static final String BOOKTITLEADDON = "booktitleaddon";
     public static final String CHAPTER = "chapter";
     public static final String COMMENTATOR = "commentator";
-    public static final String COMMENTS = "comments";
+    public static final String COMMENT = "comment";
     public static final String CROSSREF = "crossref";
     public static final String DATE = "date";
     public static final String DAY = "day";

--- a/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
+++ b/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
@@ -72,7 +72,7 @@ public class InternalBibtexFields {
 
     private static final List<String> VERBATIM_FIELDS = Arrays.asList(FieldName.URL, FieldName.FILE,
             FieldName.CTLNAME_FORMAT_STRING, FieldName.CTLNAME_LATEX_CMD, FieldName.CTLNAME_URL_PREFIX);
-    
+
     private static final List<String> SPECIAL_FIELDS = Arrays.asList(SpecialField.PRINTED.getFieldName(),
             SpecialField.PRIORITY.getFieldName(), SpecialField.QUALITY.getFieldName(),
             SpecialField.RANKING.getFieldName(), SpecialField.READ_STATUS.getFieldName(),
@@ -87,8 +87,8 @@ public class InternalBibtexFields {
         BibtexSingleField dummy;
 
         // FIRST: all standard fields
-        // These are the fields that BibTex might want to treat, so these
-        // must conform to BibTex rules.
+        // These are the fields that BibTeX might want to treat, so these
+        // must conform to BibTeX rules.
         add(new BibtexSingleField(FieldName.ADDRESS, true, BibtexSingleField.SMALL_W));
         // An annotation. It is not used by the standard bibliography styles,
         // but may be used by others that produce an annotated bibliography.

--- a/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
+++ b/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
@@ -175,7 +175,7 @@ public class InternalBibtexFields {
         dummy.setExtras(EnumSet.of(FieldProperty.EXTERNAL, FieldProperty.VERBATIM));
         add(dummy);
 
-        add(new BibtexSingleField("comment", false, BibtexSingleField.MEDIUM_W));
+        add(new BibtexSingleField(FieldName.COMMENT, false, BibtexSingleField.MEDIUM_W));
         add(new BibtexSingleField(FieldName.KEYWORDS, false, BibtexSingleField.SMALL_W));
 
         dummy = new BibtexSingleField(FieldName.FILE, false);

--- a/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
+++ b/src/main/java/net/sf/jabref/model/entry/InternalBibtexFields.java
@@ -18,16 +18,24 @@ import net.sf.jabref.model.entry.specialfields.SpecialField;
 /**
  * Handling of bibtex fields.
  * All bibtex-field related stuff should be placed here!
- * Because we can export these informations into additional
- * config files -> simple extension and definition of new fields....
+ * Because we can export this information into additional
+ * config files -> simple extension and definition of new fields
  *
  * TODO:
- *  - handling of identically fields with different names
- *    e.g. LCCN = lib-congress
- *  - group id for each fields, e.g. standard, jurabib, bio....
+ *  - handling of identically fields with different names (https://github.com/JabRef/jabref/issues/521)
+ *    e.g. LCCN = lib-congress, journaltitle = journal
+ *  - group id for each fields, e.g. standard, jurabib, bio, ...
  *  - add a additional properties functionality into the BibtexSingleField class
  */
 public class InternalBibtexFields {
+
+    /**
+     * These are the fields JabRef always displays as default
+     * {@link net.sf.jabref.preferences.JabRefPreferences#setLanguageDependentDefaultValues()}
+     *
+     * A user can change them. The change is curently stored in the preferences only and not explicitley exposed as separte preferences object
+     */
+    public static final List<String> DEFAULT_GENERAL_FIELDS =  Arrays.asList(FieldName.CROSSREF, FieldName.KEYWORDS, FieldName.FILE, FieldName.DOI, FieldName.URL, FieldName.COMMENT, FieldName.OWNER, FieldName.TIMESTAMP, FieldName.ABSTRACT, FieldName.REVIEW);
 
     // contains all bibtex-field objects (BibtexSingleField)
     private final Map<String, BibtexSingleField> fieldSet;

--- a/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
@@ -72,6 +72,7 @@ import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.CustomEntryType;
 import net.sf.jabref.model.entry.FieldName;
+import net.sf.jabref.model.entry.InternalBibtexFields;
 import net.sf.jabref.model.metadata.FileDirectoryPreferences;
 import net.sf.jabref.model.metadata.SaveOrderConfig;
 import net.sf.jabref.model.strings.StringUtil;
@@ -855,7 +856,7 @@ public class JabRefPreferences {
     public void setLanguageDependentDefaultValues() {
         // Entry editor tab 0:
         defaults.put(CUSTOM_TAB_NAME + "_def0", Localization.lang("General"));
-        String fieldNames = Arrays.asList(FieldName.CROSSREF, FieldName.KEYWORDS, FieldName.FILE, FieldName.DOI, FieldName.URL, FieldName.COMMENT, FieldName.OWNER, FieldName.TIMESTAMP).stream().collect(Collectors.joining(";"));
+        String fieldNames = InternalBibtexFields.DEFAULT_GENERAL_FIELDS.stream().collect(Collectors.joining(";"));
         defaults.put(CUSTOM_TAB_FIELDS + "_def0", fieldNames);
 
         // Entry editor tab 1:

--- a/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.StringReader;
+import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
@@ -855,7 +856,8 @@ public class JabRefPreferences {
     public void setLanguageDependentDefaultValues() {
         // Entry editor tab 0:
         defaults.put(CUSTOM_TAB_NAME + "_def0", Localization.lang("General"));
-        defaults.put(CUSTOM_TAB_FIELDS + "_def0", "crossref;keywords;file;doi;url;" + "comment;owner;timestamp");
+        String fieldNames = Arrays.asList(FieldName.CROSSREF, FieldName.KEYWORDS, FieldName.FILE, FieldName.DOI, FieldName.URL, FieldName.COMMENT, FieldName.OWNER, FieldName.TIMESTAMP).stream().collect(Collectors.joining(";"));
+        defaults.put(CUSTOM_TAB_FIELDS + "_def0", fieldNames);
 
         // Entry editor tab 1:
         defaults.put(CUSTOM_TAB_FIELDS + "_def1", FieldName.ABSTRACT);

--- a/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
@@ -10,7 +10,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.StringReader;
-import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;

--- a/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/net/sf/jabref/preferences/JabRefPreferences.java
@@ -427,7 +427,7 @@ public class JabRefPreferences {
     private static final String USER_HOME = System.getProperty("user.home");
 
     /**
-     * Set with all custom {@link Importer}s
+     * Set with all custom {@link net.sf.jabref.logic.importer.Importer}s
      */
     public final CustomImportList customImports;
 

--- a/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/IntegrityCheckTest.java
@@ -153,15 +153,17 @@ public class IntegrityCheckTest {
     @Test
     public void testAuthorNameChecks() {
         for (String field : InternalBibtexFields.getPersonNameFields()) {
-            assertCorrect(createContext(field, ""));
-            assertCorrect(createContext(field, "Knuth"));
-            assertCorrect(createContext(field, "   Knuth, Donald E. "));
-            assertCorrect(createContext(field, "Knuth, Donald E. and Kurt Cobain and A. Einstein"));
-            assertCorrect(createContext(field, "Donald E. Knuth and Kurt Cobain and A. Einstein"));
-            assertWrong(createContext(field, ", and Kurt Cobain and A. Einstein"));
-            assertWrong(createContext(field, "Donald E. Knuth and Kurt Cobain and ,"));
-            assertWrong(createContext(field, "and Kurt Cobain and A. Einstein"));
-            assertWrong(createContext(field, "Donald E. Knuth and Kurt Cobain and"));
+            // getPersonNameFields returns fields that are available in BibLaTeX only
+            // if run without mode, the NoBibtexFieldChecker will complain that "afterword" is a BibLaTeX only field
+            assertCorrect(withMode(createContext(field, ""), BibDatabaseMode.BIBLATEX));
+            assertCorrect(withMode(createContext(field, "Knuth"), BibDatabaseMode.BIBLATEX));
+            assertCorrect(withMode(createContext(field, "   Knuth, Donald E. "), BibDatabaseMode.BIBLATEX));
+            assertCorrect(withMode(createContext(field, "Knuth, Donald E. and Kurt Cobain and A. Einstein"), BibDatabaseMode.BIBLATEX));
+            assertCorrect(withMode(createContext(field, "Donald E. Knuth and Kurt Cobain and A. Einstein"), BibDatabaseMode.BIBLATEX));
+            assertWrong(withMode(createContext(field, ", and Kurt Cobain and A. Einstein"), BibDatabaseMode.BIBLATEX));
+            assertWrong(withMode(createContext(field, "Donald E. Knuth and Kurt Cobain and ,"), BibDatabaseMode.BIBLATEX));
+            assertWrong(withMode(createContext(field, "and Kurt Cobain and A. Einstein"), BibDatabaseMode.BIBLATEX));
+            assertWrong(withMode(createContext(field, "Donald E. Knuth and Kurt Cobain and"), BibDatabaseMode.BIBLATEX));
         }
     }
 

--- a/src/test/java/net/sf/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
@@ -22,6 +22,13 @@ public class NoBibTexFieldCheckerTest {
     }
 
     @Test
+    public void commentIsNotRecognizedAsBibLaTeXOnlyField() {
+        BibEntry entry = new BibEntry();
+        entry.setField("comment", "test");
+        assertEquals(Collections.emptyList(), checker.check(entry));
+    }
+
+    @Test
     public void instituationIsNotRecognizedAsBibLaTeXOnlyField() {
         BibEntry entry = new BibEntry();
         entry.setField("institution", "test");
@@ -42,6 +49,13 @@ public class NoBibTexFieldCheckerTest {
         IntegrityMessage message = new IntegrityMessage("BibLaTeX field only", entry, "journaltitle");
         List<IntegrityMessage> messages = checker.check(entry);
         assertEquals(messages, Collections.singletonList(message));
+    }
+
+    @Test
+    public void keywordsNotRecognizedAsBibLaTeXOnlyField() {
+        BibEntry entry = new BibEntry();
+        entry.setField("keywords", "test");
+        assertEquals(Collections.emptyList(), checker.check(entry));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
@@ -22,6 +22,15 @@ public class NoBibTexFieldCheckerTest {
     }
 
     @Test
+    public void afterwordIsRecognizedAsBibLaTeXOnlyField() {
+        BibEntry entry = new BibEntry();
+        entry.setField("afterword", "test");
+        IntegrityMessage message = new IntegrityMessage("BibLaTeX field only", entry, "afterword");
+        List<IntegrityMessage> messages = checker.check(entry);
+        assertEquals(messages, Collections.singletonList(message));
+    }
+
+    @Test
     public void arbitraryNonBibLaTeXFieldIsNotRecognizedAsBibLaTeXOnlyField() {
         BibEntry entry = new BibEntry();
         entry.setField("fieldNameNotDefinedInTheBibLaTeXManual", "test");

--- a/src/test/java/net/sf/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
@@ -22,6 +22,13 @@ public class NoBibTexFieldCheckerTest {
     }
 
     @Test
+    public void instituationIsNotRecognizedAsBibLaTeXOnlyField() {
+        BibEntry entry = new BibEntry();
+        entry.setField("institution", "test");
+        assertEquals(Collections.emptyList(), checker.check(entry));
+    }
+
+    @Test
     public void journalIsNotRecognizedAsBibLaTeXOnlyField() {
         BibEntry entry = new BibEntry();
         entry.setField("journal", "test");

--- a/src/test/java/net/sf/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
@@ -27,7 +27,7 @@ public class NoBibTexFieldCheckerTest {
         entry.setField("afterword", "test");
         IntegrityMessage message = new IntegrityMessage("BibLaTeX field only", entry, "afterword");
         List<IntegrityMessage> messages = checker.check(entry);
-        assertEquals(messages, Collections.singletonList(message));
+        assertEquals(Collections.singletonList(message), messages);
     }
 
     @Test
@@ -64,7 +64,7 @@ public class NoBibTexFieldCheckerTest {
         entry.setField("journaltitle", "test");
         IntegrityMessage message = new IntegrityMessage("BibLaTeX field only", entry, "journaltitle");
         List<IntegrityMessage> messages = checker.check(entry);
-        assertEquals(messages, Collections.singletonList(message));
+        assertEquals(Collections.singletonList(message), messages);
     }
 
     @Test
@@ -80,7 +80,7 @@ public class NoBibTexFieldCheckerTest {
         entry.setField("location", "test");
         IntegrityMessage message = new IntegrityMessage("BibLaTeX field only", entry, "location");
         List<IntegrityMessage> messages = checker.check(entry);
-        assertEquals(messages, Collections.singletonList(message));
+        assertEquals(Collections.singletonList(message), messages);
     }
 
 }

--- a/src/test/java/net/sf/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
+++ b/src/test/java/net/sf/jabref/logic/integrity/NoBibTexFieldCheckerTest.java
@@ -22,6 +22,13 @@ public class NoBibTexFieldCheckerTest {
     }
 
     @Test
+    public void arbitraryNonBibLaTeXFieldIsNotRecognizedAsBibLaTeXOnlyField() {
+        BibEntry entry = new BibEntry();
+        entry.setField("fieldNameNotDefinedInTheBibLaTeXManual", "test");
+        assertEquals(Collections.emptyList(), checker.check(entry));
+    }
+
+    @Test
     public void commentIsNotRecognizedAsBibLaTeXOnlyField() {
         BibEntry entry = new BibEntry();
         entry.setField("comment", "test");


### PR DESCRIPTION
This fixes #2390. The last implementation used `EntryConverter.FIELD_ALIASES_LTX_TO_TEX`. This implementation is based on `BibtexEntryTypes` and `BiblatexEntryTypes`. 

## Issue
`JabRefPreferences.CUSTOM_TAB_NAME_num_` should be used to really determine the fields to check. This, however, is really a **huge** architectural rework.

It has to be checked, in following (seldom) situation:

- Field X is defined in JabRef's BiblatexEntryTypes
- Field X is added by the user to a general tab

JabRef now complains that X is Biblatex only.

## Further changes
 * ISBN and ISBN are now BibTeX fields, too.
   - Reason: Even though, both are not listed in [WikiPedia](https://en.wikipedia.org/wiki/BibTeX) and the [lncs style](ftp://ftp.springer.de/pub/tex/latex/llncs/latex2e/splncs03.bst), I see them so hard tied to a book and article, that I would add it. In the case of a DOI, JabRef (more or less) enforces it by offering that field in the "General" tab. Moreover, [it is part of plainnat.bst](http://tex.stackexchange.com/a/52046/9075) and [natbib](https://www.ctan.org/pkg/natbib) is a popular package.
 * `FieldName.COMMENT` instead of `FieldName.COMMENTS` (affects OaiImporter only)
 * Preferences: Use FieldName constants at `setLanguageDependentDefaultValues()`

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [n/a] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [n/a] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [n/a] If you changed the localization: Did you run `gradle localizationUpdate`?
