### PR TITLE
Improve CSL copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Changed
 - When editing an article, the tab "Optional fields" now shows "ISSN"
 - When editing a book, the tab "Optional fields" now shows "ISBN"
-- When using "Copy citation (HTML)" and pasting into Notepad++, plain text is always pasted.
+- When using "Copy citation (HTML)" and pasting into a text editor, plain text is always pasted.
 
 ### Fixed
 - Fixed [#2391](https://github.com/JabRef/jabref/issues/2391): Clicking on "Get Fulltext" button sets links correctly for the entry being edited.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Changed
 - When editing an article, the tab "Optional fields" now shows "ISSN"
 - When editing a book, the tab "Optional fields" now shows "ISBN"
+- When using "Copy citation (HTML)" and pasting into Notepad++, plain text is always pasted.
 
 ### Fixed
 - Fixed [#2391](https://github.com/JabRef/jabref/issues/2391): Clicking on "Get Fulltext" button sets links correctly for the entry being edited.

--- a/src/main/java/net/sf/jabref/gui/fieldeditors/HtmlTransferable.java
+++ b/src/main/java/net/sf/jabref/gui/fieldeditors/HtmlTransferable.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import net.sf.jabref.logic.formatter.bibtexfields.HtmlToUnicodeFormatter;
 import net.sf.jabref.logic.util.OS;
 
 
@@ -38,6 +39,8 @@ public class HtmlTransferable implements Transferable {
         plain = WHITESPACE_AROUND_NEWLINE.matcher(plain).replaceAll("");
         plain = DOUBLE_WHITESPACES.matcher(plain).replaceAll(" ");
         plain = HTML_NEWLINE.matcher(plain).replaceAll(OS.NEWLINE);
+        // replace all HTML codes such as &amp;
+        plain = new HtmlToUnicodeFormatter().format(plain);
         this.plainText = plain.trim();
     }
 

--- a/src/main/java/net/sf/jabref/gui/worker/CitationStyleToClipboardWorker.java
+++ b/src/main/java/net/sf/jabref/gui/worker/CitationStyleToClipboardWorker.java
@@ -6,8 +6,6 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import javax.swing.SwingWorker;
 
@@ -38,9 +36,6 @@ import org.apache.commons.logging.LogFactory;
 public class CitationStyleToClipboardWorker extends SwingWorker<List<String>, Void> {
 
     private static final Log LOGGER = LogFactory.getLog(CitationStyleToClipboardWorker.class);
-    private static final Pattern REMOVE_HTML = Pattern.compile("<(?!br)(?!BR).*?>");
-    private static final Pattern WHITESPACE = Pattern.compile("(?m)^\\s|\\v+");
-    private static final Pattern HTML_NEWLINE = Pattern.compile("<br>|<BR>");
 
     private final BasePanel basePanel;
     private final List<BibEntry> selectedEntries;
@@ -123,12 +118,7 @@ public class CitationStyleToClipboardWorker extends SwingWorker<List<String>, Vo
      */
     protected static HtmlTransferable processPreview(List<String> citations) {
         String html = String.join(CitationStyleOutputFormat.HTML.getLineSeparator(), citations);
-        String plain = citations.stream().map(c -> {
-            String tmp = WHITESPACE.matcher(c).replaceAll("");
-            tmp = REMOVE_HTML.matcher(tmp).replaceAll("");
-            return HTML_NEWLINE.matcher(tmp).replaceAll(OS.NEWLINE) + OS.NEWLINE;
-        }).collect(Collectors.joining(""));
-        return new HtmlTransferable(html, plain);
+        return new HtmlTransferable(html);
     }
 
     /**

--- a/src/test/java/net/sf/jabref/gui/fieldeditors/HtmlTransferableTest.java
+++ b/src/test/java/net/sf/jabref/gui/fieldeditors/HtmlTransferableTest.java
@@ -1,0 +1,72 @@
+package net.sf.jabref.gui.fieldeditors;
+
+import java.awt.datatransfer.DataFlavor;
+
+import net.sf.jabref.logic.util.OS;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class HtmlTransferableTest {
+
+    @Test
+    public void testSimpleDivConstruct() throws Exception {
+        String html = "<div>" + OS.NEWLINE +
+                "  <div>Text</div>" + OS.NEWLINE +
+                "</div>" + OS.NEWLINE;
+        HtmlTransferable htmlTransferable = new HtmlTransferable(html);
+        assertEquals("Text", htmlTransferable.getTransferData(DataFlavor.stringFlavor));
+    }
+
+    @Test
+    public void testAdvancedDivConstruct() throws Exception {
+        String html = "<!DOCTYPE html>" + OS.NEWLINE +
+                "<html>" + OS.NEWLINE +
+                "   <head>" + OS.NEWLINE +
+                "      <meta charset=\"utf-8\">" + OS.NEWLINE +
+                "   </head>" + OS.NEWLINE +
+                "   <body>" + OS.NEWLINE +
+                OS.NEWLINE +
+                "  <div class=\"csl-entry\">" + OS.NEWLINE +
+                "    <div class=\"csl-left-margin\">Content 1</div>" + OS.NEWLINE +
+                "  </div>" + OS.NEWLINE +
+                OS.NEWLINE +
+                "<br>" + OS.NEWLINE +
+                "  <div class=\"csl-entry\">" + OS.NEWLINE +
+                "    <div class=\"csl-left-margin\">Content 2</div>" + OS.NEWLINE +
+                "  </div>" + OS.NEWLINE +
+                OS.NEWLINE +
+                "   </body>" + OS.NEWLINE +
+                "</html>" + OS.NEWLINE;
+        String expected = "Content 1" + OS.NEWLINE + "Content 2";
+        HtmlTransferable htmlTransferable = new HtmlTransferable(html);
+        assertEquals(expected, htmlTransferable.getTransferData(DataFlavor.stringFlavor));
+    }
+
+    @Test
+    public void testGenerateMagicSpaces() throws Exception {
+        String html = "<!DOCTYPE html>" + OS.NEWLINE +
+                "<html>" + OS.NEWLINE +
+                "   <head>" + OS.NEWLINE +
+                "      <meta charset=\"utf-8\">" + OS.NEWLINE +
+                "   </head>" + OS.NEWLINE +
+                "   <body>" + OS.NEWLINE +
+                OS.NEWLINE +
+                "  <div class=\"csl-entry\">" + OS.NEWLINE +
+                "    <div>number1</div><div class=\"csl-left-margin\">Content 1</div>" + OS.NEWLINE +
+                "  </div>" + OS.NEWLINE +
+                OS.NEWLINE +
+                "<br>" + OS.NEWLINE +
+                "  <div class=\"csl-entry\">" + OS.NEWLINE +
+                "    <div>number2</div><div class=\"csl-left-margin\">Content 2</div>" + OS.NEWLINE +
+                "  </div>" + OS.NEWLINE +
+                OS.NEWLINE +
+                "   </body>" + OS.NEWLINE +
+                "</html>" + OS.NEWLINE;
+        String expected = "number1 Content 1" + OS.NEWLINE + "number2 Content 2";
+        HtmlTransferable htmlTransferable = new HtmlTransferable(html);
+        assertEquals(expected, htmlTransferable.getTransferData(DataFlavor.stringFlavor));
+    }
+
+}

--- a/src/test/java/net/sf/jabref/gui/fieldeditors/HtmlTransferableTest.java
+++ b/src/test/java/net/sf/jabref/gui/fieldeditors/HtmlTransferableTest.java
@@ -69,4 +69,23 @@ public class HtmlTransferableTest {
         assertEquals(expected, htmlTransferable.getTransferData(DataFlavor.stringFlavor));
     }
 
+    @Test
+    public void testAmpersandConversion() throws Exception {
+        String html = "<!DOCTYPE html>" + OS.NEWLINE +
+                "<html>" + OS.NEWLINE +
+                "   <head>" + OS.NEWLINE +
+                "      <meta charset=\"utf-8\">" + OS.NEWLINE +
+                "   </head>" + OS.NEWLINE +
+                "   <body>" + OS.NEWLINE +
+                OS.NEWLINE +
+                "  <div>Let's rock &amp; have fun" + OS.NEWLINE +
+                "  </div>" + OS.NEWLINE +
+                OS.NEWLINE +
+                "   </body>" + OS.NEWLINE +
+                "</html>" + OS.NEWLINE;
+        String expected = "Let's rock & have fun";
+        HtmlTransferable htmlTransferable = new HtmlTransferable(html);
+        assertEquals(expected, htmlTransferable.getTransferData(DataFlavor.stringFlavor));
+    }
+
 }

--- a/src/test/java/net/sf/jabref/gui/worker/CitationStyleToClipboardWorkerTest.java
+++ b/src/test/java/net/sf/jabref/gui/worker/CitationStyleToClipboardWorkerTest.java
@@ -17,8 +17,8 @@ public class CitationStyleToClipboardWorkerTest {
 
     @Test
     public void processPreviewText() throws Exception {
-        String expected = "Article (Smith2016)Smith, B.; Jones, B. &amp; Williams, J.Taylor, P. (Ed.)Title of the test entry BibTeX Journal, JabRef Publishing, 2016, 34, 45-67 Abstract:  This entry describes a test scenario which may be useful in JabRef. By providing a test entry it is possible to see how certain things will look in this graphical BIB-file mananger. " + OS.NEWLINE +
-                "Article (Smith2016)Smith, B.; Jones, B. &amp; Williams, J.Taylor, P. (Ed.)Title of the test entry BibTeX Journal, JabRef Publishing, 2016, 34, 45-67 Abstract:  This entry describes a test scenario which may be useful in JabRef. By providing a test entry it is possible to see how certain things will look in this graphical BIB-file mananger. " + OS.NEWLINE;
+        String expected = "Article (Smith2016)Smith, B.; Jones, B. &amp; Williams, J.Taylor, P. (Ed.)Title of the test entry BibTeX Journal, JabRef Publishing, 2016, 34, 45-67 Abstract: This entry describes a test scenario which may be useful in JabRef. By providing a test entry it is possible to see how certain things will look in this graphical BIB-file mananger." + OS.NEWLINE +
+                "Article (Smith2016)Smith, B.; Jones, B. &amp; Williams, J.Taylor, P. (Ed.)Title of the test entry BibTeX Journal, JabRef Publishing, 2016, 34, 45-67 Abstract: This entry describes a test scenario which may be useful in JabRef. By providing a test entry it is possible to see how certain things will look in this graphical BIB-file mananger.";
 
         String citation = "Article (Smith2016)" + OS.NEWLINE +
                 "Smith, B.; Jones, B. &amp; Williams, J." + OS.NEWLINE +
@@ -188,7 +188,7 @@ public class CitationStyleToClipboardWorkerTest {
     }
 
     @Test
-    public void processHtml() throws Exception {
+    public void processHtmlAsHtml() throws Exception {
         String expected = "<!DOCTYPE html>" + OS.NEWLINE +
                 "<html>" + OS.NEWLINE +
                 "   <head>" + OS.NEWLINE +
@@ -213,8 +213,21 @@ public class CitationStyleToClipboardWorkerTest {
                 "  </div>" + OS.NEWLINE;
         HtmlTransferable htmlTransferable = CitationStyleToClipboardWorker.processHtml(Arrays.asList(citation, citation));
 
-        Object actual = htmlTransferable.getTransferData(DataFlavor.stringFlavor);
+        Object actual = htmlTransferable.getTransferData(DataFlavor.allHtmlFlavor);
         Assert.assertEquals(expected, actual);
     }
 
+    @Test
+    public void processHtmlAsText() throws Exception {
+        String expected = "[1] B. Smith, B. Jones, and J. Williams, “Title of the test entry,” BibTeX Journal , vol. 34, no. 3, pp. 45–67, Jul. 2016." + OS.NEWLINE +
+                "[1] B. Smith, B. Jones, and J. Williams, “Title of the test entry,” BibTeX Journal , vol. 34, no. 3, pp. 45–67, Jul. 2016.";
+
+        String citation = "  <div class=\"csl-entry\">" + OS.NEWLINE +
+                "    <div class=\"csl-left-margin\">[1]</div><div class=\"csl-right-inline\">B. Smith, B. Jones, and J. Williams, “Title of the test entry,” <i>BibTeX Journal</i>, vol. 34, no. 3, pp. 45–67, Jul. 2016.</div>" + OS.NEWLINE +
+                "  </div>" + OS.NEWLINE;
+        HtmlTransferable htmlTransferable = CitationStyleToClipboardWorker.processHtml(Arrays.asList(citation, citation));
+
+        Object actual = htmlTransferable.getTransferData(DataFlavor.stringFlavor);
+        Assert.assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/net/sf/jabref/gui/worker/CitationStyleToClipboardWorkerTest.java
+++ b/src/test/java/net/sf/jabref/gui/worker/CitationStyleToClipboardWorkerTest.java
@@ -17,8 +17,8 @@ public class CitationStyleToClipboardWorkerTest {
 
     @Test
     public void processPreviewText() throws Exception {
-        String expected = "Article (Smith2016)Smith, B.; Jones, B. &amp; Williams, J.Taylor, P. (Ed.)Title of the test entry BibTeX Journal, JabRef Publishing, 2016, 34, 45-67 Abstract: This entry describes a test scenario which may be useful in JabRef. By providing a test entry it is possible to see how certain things will look in this graphical BIB-file mananger." + OS.NEWLINE +
-                "Article (Smith2016)Smith, B.; Jones, B. &amp; Williams, J.Taylor, P. (Ed.)Title of the test entry BibTeX Journal, JabRef Publishing, 2016, 34, 45-67 Abstract: This entry describes a test scenario which may be useful in JabRef. By providing a test entry it is possible to see how certain things will look in this graphical BIB-file mananger.";
+        String expected = "Article (Smith2016)Smith, B.; Jones, B. & Williams, J.Taylor, P. (Ed.)Title of the test entry BibTeX Journal, JabRef Publishing, 2016, 34, 45-67 Abstract: This entry describes a test scenario which may be useful in JabRef. By providing a test entry it is possible to see how certain things will look in this graphical BIB-file mananger." + OS.NEWLINE +
+                "Article (Smith2016)Smith, B.; Jones, B. & Williams, J.Taylor, P. (Ed.)Title of the test entry BibTeX Journal, JabRef Publishing, 2016, 34, 45-67 Abstract: This entry describes a test scenario which may be useful in JabRef. By providing a test entry it is possible to see how certain things will look in this graphical BIB-file mananger.";
 
         String citation = "Article (Smith2016)" + OS.NEWLINE +
                 "Smith, B.; Jones, B. &amp; Williams, J." + OS.NEWLINE +


### PR DESCRIPTION
When copying citations to the clipboard using HTML (introduced by #2363), pasting into Nodepad++ leads to pure HTML be pasted. We had a short discussion during #2363 what would be more useful: HTML code or Text. I think, text is better.

When using "Copy as Text" offered by using the CSL library, following is the text reaching Nodepad++:

> 1.Garcia-Molina, H., Salem, K.: Sagas. In: Dayal, U. and Traiger, I.L. (eds.) SIGMOD’87: Proceedings of the Association for Computing Machinery Special Interest Group on Management of Data 1987 Annual Conference. pp. 249–259 ACM Press (1987).

When using the results of this PR and using Copy as HTML:

> 1. Garcia-Molina, H., Salem, K.: Sagas. In: Dayal, U. and Traiger, I.L. (eds.) SIGMOD’87: Proceedings of the Association for Computing Machinery Special Interest Group on Management of Data 1987 Annual Conference. pp. 249–259 ACM Press (1987).

Note the space after "1.". Further, when copying the entry preview generated by JabRef's internal mechanism (and not CSL), plain text is also pasted into Notepad++ instead of HTML. Thus, this PR makes the behavior consistent. Further, with this PR, html entities are correctly converted to text. - I know that I could contact upstream and let CSL correctly create a text citation and then update JabRef to kick-off two conversons: HTML and Text using CSL. This, however, is IMHO more effort than "just" (more or less) correctly converting HTML to Text within JabRef.

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [n/a] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [n/a] If you changed the localization: Did you run `gradle localizationUpdate`?
