### PR TITLE
Fix #2394 groups matching with brackets in name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Fixed
 - Fixed [#2391](https://github.com/JabRef/jabref/issues/2391): Clicking on "Get Fulltext" button sets links correctly for the entry being edited.
 - The integrity check now determines the set of BibLaTeX-only fields differently. Fixes [#2390](https://github.com/JabRef/jabref/issues/2390).
+- We fixed an issue where groups containing brackets were not working properly. [#2394](https://github.com/JabRef/jabref/issues/2394)
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/model/groups/WordKeywordGroup.java
+++ b/src/main/java/net/sf/jabref/model/groups/WordKeywordGroup.java
@@ -1,7 +1,9 @@
 package net.sf.jabref.model.groups;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -17,7 +19,7 @@ import net.sf.jabref.model.strings.StringUtil;
 public class WordKeywordGroup extends KeywordGroup implements GroupEntryChanger {
 
     protected final Character keywordSeparator;
-    private final List<String> searchWords;
+    private final Set<String> searchWords;
     private final boolean onlySplitWordsAtSeparator;
 
     public WordKeywordGroup(String name, GroupHierarchyType context, String searchField,
@@ -26,11 +28,11 @@ public class WordKeywordGroup extends KeywordGroup implements GroupEntryChanger 
         super(name, context, searchField, searchExpression, caseSensitive);
 
         this.keywordSeparator = keywordSeparator;
-        this.searchWords = StringUtil.getStringAsWords(searchExpression);
         this.onlySplitWordsAtSeparator = onlySplitWordsAtSeparator;
+        this.searchWords = getSearchWords(searchExpression);
     }
 
-    private static boolean containsCaseInsensitive(Set<String> searchIn, List<String> searchFor) {
+    private static boolean containsCaseInsensitive(Set<String> searchIn, Collection<String> searchFor) {
         for (String searchWord : searchFor) {
             if (!containsCaseInsensitive(searchIn, searchWord)) {
                 return false;
@@ -116,6 +118,14 @@ public class WordKeywordGroup extends KeywordGroup implements GroupEntryChanger 
                     .orElse(Collections.emptySet());
         } else {
             return entry.getFieldAsWords(searchField);
+        }
+    }
+
+    private Set<String> getSearchWords(String searchExpression) {
+        if (onlySplitWordsAtSeparator) {
+            return KeywordList.parse(searchExpression, keywordSeparator).toStringList();
+        } else {
+            return new HashSet<>(StringUtil.getStringAsWords(searchExpression));
         }
     }
 

--- a/src/test/java/net/sf/jabref/model/entry/KeywordListTest.java
+++ b/src/test/java/net/sf/jabref/model/entry/KeywordListTest.java
@@ -64,6 +64,11 @@ public class KeywordListTest {
     }
 
     @Test
+    public void parseWordsWithBracketsReturnsOneKeyword() throws Exception {
+        assertEquals(new KeywordList("[a] keyword"), KeywordList.parse("[a] keyword", ','));
+    }
+
+    @Test
     public void asStringAddsSpaceAfterDelimiter() throws Exception {
         assertEquals("keywordOne, keywordTwo", keywords.getAsString(','));
     }

--- a/src/test/java/net/sf/jabref/model/groups/ExplicitGroupTest.java
+++ b/src/test/java/net/sf/jabref/model/groups/ExplicitGroupTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ExplicitGroupTest {
 
@@ -88,5 +89,14 @@ public class ExplicitGroupTest {
         entry.setField(FieldName.GROUPS, "myExplicitGroup/b");
 
         assertFalse(group.contains(entry));
+    }
+
+    @Test
+    // For https://github.com/JabRef/jabref/issues/2394
+    public void containsMatchesPhraseWithBrackets() throws Exception {
+        entry.setField(FieldName.GROUPS, "[aa] Subgroup1");
+        ExplicitGroup explicitGroup = new ExplicitGroup("[aa] Subgroup1", GroupHierarchyType.INCLUDING, ',');
+
+        assertTrue(explicitGroup.contains(entry));
     }
 }


### PR DESCRIPTION
Fixes #2394.

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
