### PR TITLE
Alllow FTP URLs for downloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - When editing an article, the tab "Optional fields" now shows "ISSN"
 - When editing a book, the tab "Optional fields" now shows "ISBN"
 - When using "Copy citation (HTML)" and pasting into a text editor, plain text is always pasted.
+- When using the "Download from URL" functionality, one is not limited to http(s) URLs, but can, for instance, enter ftp URLs.
 
 ### Fixed
 - Fixed [#2391](https://github.com/JabRef/jabref/issues/2391): Clicking on "Get Fulltext" button sets links correctly for the entry being edited.

--- a/src/main/java/net/sf/jabref/logic/net/URLDownload.java
+++ b/src/main/java/net/sf/jabref/logic/net/URLDownload.java
@@ -109,7 +109,7 @@ public class URLDownload {
     }
 
     private URLConnection openConnection() throws IOException {
-        HttpURLConnection connection = (HttpURLConnection) source.openConnection();
+        URLConnection connection = source.openConnection();
         for (Map.Entry<String, String> entry : parameters.entrySet()) {
             connection.setRequestProperty(entry.getKey(), entry.getValue());
         }
@@ -121,16 +121,18 @@ public class URLDownload {
 
         }
 
-        // normally, 3xx is redirect
-        int status = connection.getResponseCode();
-        if (status != HttpURLConnection.HTTP_OK) {
-            if (status == HttpURLConnection.HTTP_MOVED_TEMP
-                    || status == HttpURLConnection.HTTP_MOVED_PERM
-                    || status == HttpURLConnection.HTTP_SEE_OTHER) {
-                // get redirect url from "location" header field
-                String newUrl = connection.getHeaderField("Location");
-                // open the new connnection again
-                connection = (HttpURLConnection) new URLDownload(newUrl).openConnection();
+        if (connection instanceof HttpURLConnection) {
+            // normally, 3xx is redirect
+            int status = ((HttpURLConnection) connection).getResponseCode();
+            if (status != HttpURLConnection.HTTP_OK) {
+                if (status == HttpURLConnection.HTTP_MOVED_TEMP
+                        || status == HttpURLConnection.HTTP_MOVED_PERM
+                        || status == HttpURLConnection.HTTP_SEE_OTHER) {
+                    // get redirect url from "location" header field
+                    String newUrl = connection.getHeaderField("Location");
+                    // open the new connnection again
+                    connection = (HttpURLConnection) new URLDownload(newUrl).openConnection();
+                }
             }
         }
 

--- a/src/test/java/net/sf/jabref/logic/net/URLDownloadTest.java
+++ b/src/test/java/net/sf/jabref/logic/net/URLDownloadTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 
 import net.sf.jabref.preferences.JabRefPreferences;
 
@@ -64,6 +65,14 @@ public class URLDownloadTest {
 
         String path = google.downloadToTemporaryFile().toString();
         Assert.assertTrue(path, path.contains("LICENSE") && path.endsWith(".md"));
+    }
+
+    @Test
+    public void downloadOfFTPSucceeds() throws IOException {
+        URLDownload ftp = new URLDownload(new URL("ftp://ftp.informatik.uni-stuttgart.de/pub/library/ncstrl.ustuttgart_fi/INPROC-2016-15/INPROC-2016-15.pdf"));
+
+        Path path = ftp.downloadToTemporaryFile();
+        Assert.assertNotNull(path);
     }
 
 }

--- a/src/test/java/net/sf/jabref/logic/net/URLDownloadTest.java
+++ b/src/test/java/net/sf/jabref/logic/net/URLDownloadTest.java
@@ -75,4 +75,20 @@ public class URLDownloadTest {
         Assert.assertNotNull(path);
     }
 
+    @Test
+    public void downloadOfHttpSucceeds() throws IOException {
+        URLDownload ftp = new URLDownload(new URL("http://www.jabref.org"));
+
+        Path path = ftp.downloadToTemporaryFile();
+        Assert.assertNotNull(path);
+    }
+
+    @Test
+    public void downloadOfHttpsSucceeds() throws IOException {
+        URLDownload ftp = new URLDownload(new URL("https://www.jabref.org"));
+
+        Path path = ftp.downloadToTemporaryFile();
+        Assert.assertNotNull(path);
+    }
+
 }


### PR DESCRIPTION
I wanted to download ftp://ftp.informatik.uni-stuttgart.de/pub/library/ncstrl.ustuttgart_fi/INPROC-2016-15/INPROC-2016-15.pdf using the "Download from URL" button. However, this did not succeed as JabRef insisted on an HTTPURLConnection. 

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [n/a] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [n/a] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [n/a] If you changed the localization: Did you run `gradle localizationUpdate`?
