### PR TITLE
Fix "collapse sub tree" functionality for groups tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where groups containing brackets were not working properly. Fixes [#2394](https://github.com/JabRef/jabref/issues/2394).
 - We fixed issues with the [timestamp](http://help.jabref.org/en/TimeStamp) field. However, clearing with the clear button is not possible if timestamp format does not match the current settings. Fixes [#2403](https://github.com/JabRef/jabref/issues/2403).
 - Fixes [#2406](https://github.com/JabRef/jabref/issues/2406) so that the integrity check filter works again
+- Closing of subtrees in the groups panel using "close subtree" is working again. Fixes [#2319](https://github.com/JabRef/jabref/issues/2319).
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/gui/groups/GroupTreeNodeViewModel.java
+++ b/src/main/java/net/sf/jabref/gui/groups/GroupTreeNodeViewModel.java
@@ -151,11 +151,10 @@ public class GroupTreeNodeViewModel implements Transferable, TreeNode {
 
     /** Collapse this node and all its children. */
     public void collapseSubtree(JTree tree) {
-        tree.collapsePath(this.getTreePath());
-
-        for(GroupTreeNodeViewModel child : getChildren()) {
+        for (GroupTreeNodeViewModel child : getChildren()) {
             child.collapseSubtree(tree);
         }
+        tree.collapsePath(this.getTreePath());
     }
 
     /** Expand this node and all its children. */


### PR DESCRIPTION
Fix of #2319: Function "collapse subtree" is working again

- [x] Change in CHANGELOG.md described
- ~~[ ] Tests created for changes~~ UI only
- ~~[ ] Screenshots added (for bigger UI changes)~~
- [x] Manually tested changed features in running JabRef
- ~~[ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)~~
- ~~[ ] If you changed the localization: Did you run `gradle localizationUpdate`?~~
