### PR TITLE
Use proxy configuration also for HTTPS connections - fixes #2249

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed issues with the [timestamp](http://help.jabref.org/en/TimeStamp) field. However, clearing with the clear button is not possible if timestamp format does not match the current settings. Fixes [#2403](https://github.com/JabRef/jabref/issues/2403).
 - Fixes [#2406](https://github.com/JabRef/jabref/issues/2406) so that the integrity check filter works again
 - Closing of subtrees in the groups panel using "close subtree" is working again. Fixes [#2319](https://github.com/JabRef/jabref/issues/2319).
+- The proxy settings are now also applied to HTTPS connections. Fixes (#2249)(https://github.com/JabRef/jabref/issues/2249).
+
+
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed issues with the [timestamp](http://help.jabref.org/en/TimeStamp) field. However, clearing with the clear button is not possible if timestamp format does not match the current settings. Fixes [#2403](https://github.com/JabRef/jabref/issues/2403).
 - Fixes [#2406](https://github.com/JabRef/jabref/issues/2406) so that the integrity check filter works again
 - Closing of subtrees in the groups panel using "close subtree" is working again. Fixes [#2319](https://github.com/JabRef/jabref/issues/2319).
-- The proxy settings are now also applied to HTTPS connections. Fixes (#2249)(https://github.com/JabRef/jabref/issues/2249).
+- The proxy settings are now also applied to HTTPS connections. Fixes [#2249](https://github.com/JabRef/jabref/issues/2249).
 
 
 

--- a/src/main/java/net/sf/jabref/logic/net/ProxyRegisterer.java
+++ b/src/main/java/net/sf/jabref/logic/net/ProxyRegisterer.java
@@ -8,10 +8,16 @@ public class ProxyRegisterer {
             System.setProperty("http.proxyHost", proxyPrefs.getHostname());
             System.setProperty("http.proxyPort", proxyPrefs.getPort());
 
+            System.setProperty("https.proxyHost", proxyPrefs.getHostname());
+            System.setProperty("https.proxyPort", proxyPrefs.getPort());
+
             // NetworkTab.java ensures that proxyUsername and proxyPassword are neither null nor empty
             if (proxyPrefs.isUseAuthentication()) {
                 System.setProperty("http.proxyUser", proxyPrefs.getUsername());
                 System.setProperty("http.proxyPassword", proxyPrefs.getPassword());
+
+                System.setProperty("https.proxyUser", proxyPrefs.getUsername());
+                System.setProperty("https.proxyPassword", proxyPrefs.getPassword());
             }
         } else {
             // The following two lines signal that the system proxy settings


### PR DESCRIPTION
Another small fix... refs #2249 

Proxy settings are now also used for HTTPS connections

- [x] Change in CHANGELOG.md described
- ~~[ ] Tests created for changes~~
- ~~[ ] Screenshots added (for bigger UI changes)~~
- [x] Manually tested changed features in running JabRef
- ~~[ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)~~
- ~~[ ] If you changed the localization: Did you run `gradle localizationUpdate`?~~
