### PR TITLE
Remove the redundant worker interface

### DIFF
--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -94,7 +94,6 @@ import net.sf.jabref.gui.worker.CallBack;
 import net.sf.jabref.gui.worker.CitationStyleToClipboardWorker;
 import net.sf.jabref.gui.worker.MarkEntriesAction;
 import net.sf.jabref.gui.worker.SendAsEMailAction;
-import net.sf.jabref.gui.worker.Worker;
 import net.sf.jabref.logic.autocompleter.AutoCompletePreferences;
 import net.sf.jabref.logic.autocompleter.AutoCompleter;
 import net.sf.jabref.logic.autocompleter.AutoCompleterFactory;
@@ -988,7 +987,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 ((BaseAction) o).action();
             } else {
                 // This part uses Spin's features:
-                Worker wrk = ((AbstractWorker) o).getWorker();
+                Runnable wrk = ((AbstractWorker) o).getWorker();
                 // The Worker returned by getWorker() has been wrapped
                 // by Spin.off(), which makes its methods be run in
                 // a different thread from the EDT.

--- a/src/main/java/net/sf/jabref/gui/exporter/SaveAllAction.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/SaveAllAction.java
@@ -11,7 +11,6 @@ import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.actions.Actions;
 import net.sf.jabref.gui.actions.MnemonicAwareAction;
 import net.sf.jabref.gui.keyboard.KeyBinding;
-import net.sf.jabref.gui.worker.Worker;
 import net.sf.jabref.logic.l10n.Localization;
 
 import spin.Spin;
@@ -20,7 +19,7 @@ import spin.Spin;
  *
  * @author alver
  */
-public class SaveAllAction extends MnemonicAwareAction implements Worker {
+public class SaveAllAction extends MnemonicAwareAction implements Runnable {
 
     private final JabRefFrame frame;
     private int databases;

--- a/src/main/java/net/sf/jabref/gui/exporter/SaveDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/exporter/SaveDatabaseAction.java
@@ -21,7 +21,6 @@ import net.sf.jabref.gui.JabRefFrame;
 import net.sf.jabref.gui.autosaveandbackup.AutosaveUIManager;
 import net.sf.jabref.gui.worker.AbstractWorker;
 import net.sf.jabref.gui.worker.CallBack;
-import net.sf.jabref.gui.worker.Worker;
 import net.sf.jabref.logic.autosaveandbackup.AutosaveManager;
 import net.sf.jabref.logic.autosaveandbackup.BackupManager;
 import net.sf.jabref.logic.exporter.BibtexDatabaseWriter;
@@ -282,7 +281,7 @@ public class SaveDatabaseAction extends AbstractWorker {
      */
     public void runCommand() throws Exception {
         // This part uses Spin's features:
-        Worker worker = getWorker();
+        Runnable worker = getWorker();
         // The Worker returned by getWorker() has been wrapped
         // by Spin.off(), which makes its methods be run in
         // a different thread from the EDT.

--- a/src/main/java/net/sf/jabref/gui/worker/AbstractWorker.java
+++ b/src/main/java/net/sf/jabref/gui/worker/AbstractWorker.java
@@ -11,14 +11,14 @@ import spin.Spin;
  * the CallBack interface. This procedure ensures that run() cannot freeze
  * the GUI, and that update() can safely update GUI components.
  */
-public abstract class AbstractWorker implements Worker, CallBack {
+public abstract class AbstractWorker implements Runnable, CallBack {
 
-    private final Worker worker;
+    private final Runnable worker;
     private final CallBack callBack;
 
 
     public AbstractWorker() {
-        worker = (Worker) Spin.off(this);
+        worker = (Runnable) Spin.off(this);
         callBack = (CallBack) Spin.over(this);
 
     }
@@ -31,7 +31,7 @@ public abstract class AbstractWorker implements Worker, CallBack {
      * This method returns a wrapped Worker instance of this AbstractWorker.
      * whose methods will automatically be run off the EDT (Swing) thread.
      */
-    public Worker getWorker() {
+    public Runnable getWorker() {
         return worker;
     }
 

--- a/src/main/java/net/sf/jabref/gui/worker/Worker.java
+++ b/src/main/java/net/sf/jabref/gui/worker/Worker.java
@@ -1,8 +1,0 @@
-package net.sf.jabref.gui.worker;
-
-/**
- * Represents a task that is not to be executed on the GUI thread
- */
-public interface Worker extends Runnable {
-    // Nothing
-}


### PR DESCRIPTION
This is a refactoring PR (yeah, I know we do not really want pure refactoring PRs for now), and it is open for discussion (I will not throw a tantrum if it does not get merged).

I ran into the `Worker` interface, which does really nothing but extend the `Runnable` interface. I fail to see the point in this additional level of indirection. The `Worker` interface is supposed to mark tasks that should not be executed on the EDT, but there is nothing in the interface to actually maintain that apart from a comment line. All code using the `Worker` depends on the object being a `Runnable`, the `Worker` aspect is basically ignored, as there is nothing to consider in the first place. 

Instead, there is class `AbstractWorker` which implements the `Worker` aka `Runnable` interface and actually does provide the support for executing the task off the EDT. `AbstractWorker` is the class that is actually used in most of the code and it works just as fine if you have it implement `Runnable` directly.

Therefore, in the spirit of science, I suggest to apply Occam's razor and to use the simplest solution (remove the additional indirection of `Worker`).
