### PR TITLE
Fix #2427: Arxiv fetcher works with prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where groups containing brackets were not working properly. Fixes [#2394](https://github.com/JabRef/jabref/issues/2394).
 - We fixed issues with the [timestamp](http://help.jabref.org/en/TimeStamp) field. However, clearing with the clear button is not possible if timestamp format does not match the current settings. Fixes [#2403](https://github.com/JabRef/jabref/issues/2403).
 - Fixes [#2406](https://github.com/JabRef/jabref/issues/2406) so that the integrity check filter works again
+- The ArXiv fetcher also accepts identifiers that include the "arXiv:" prefix. Fixes [#2427](https://github.com/JabRef/jabref/issues/2427).
 - Closing of subtrees in the groups panel using "close subtree" is working again. Fixes [#2319](https://github.com/JabRef/jabref/issues/2319).
 - The proxy settings are now also applied to HTTPS connections. Fixes [#2249](https://github.com/JabRef/jabref/issues/2249).
 

--- a/src/main/java/net/sf/jabref/logic/importer/fetcher/ArXiv.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fetcher/ArXiv.java
@@ -107,6 +107,10 @@ public class ArXiv implements FulltextFetcher, SearchBasedFetcher, IdBasedFetche
     }
 
     private Optional<ArXivEntry> searchForEntryById(String identifier) throws FetcherException {
+        identifier = identifier.replace("arxiv:", "");
+        identifier = identifier.replace("arXiv:", "");
+        identifier = identifier.replace("arxiv", "");
+        identifier = identifier.replace("arXiv", "");
         List<ArXivEntry> entries = queryApi("", Collections.singletonList(identifier), 0, 1);
         if (entries.size() == 1) {
             return Optional.of(entries.get(0));

--- a/src/test/java/net/sf/jabref/logic/importer/fetcher/ArXivTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fetcher/ArXivTest.java
@@ -76,6 +76,14 @@ public class ArXivTest {
     }
 
     @Test
+    // Test for https://github.com/JabRef/jabref/issues/2427
+    public void findByEprintWithPrefix() throws IOException {
+        entry.setField("eprint", "arXiv:1603.06570");
+
+        assertEquals(Optional.of(new URL("http://arxiv.org/pdf/1603.06570v1")), finder.findFullText(entry));
+    }
+
+    @Test
     public void findByEprintWithUnknownDOI() throws IOException {
         entry.setField("doi", "10.1529/unknown");
         entry.setField("eprint", "1603.06570");
@@ -136,6 +144,12 @@ public class ArXivTest {
     @Test
     public void searchEntryByIdWith4Digits() throws Exception {
         assertEquals(Optional.of(sliceTheoremPaper), finder.performSearchById("1405.2249"));
+    }
+
+    @Test
+    // Test for https://github.com/JabRef/jabref/issues/2427
+    public void searchEntryByIdWith4DigitsAndPrefix() throws Exception {
+        assertEquals(Optional.of(sliceTheoremPaper), finder.performSearchById("arXiv:1405.2249"));
     }
 
     @Test


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
