### PR TITLE
Add support for pages in the format 2:1-2:33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Changed
 
 ### Fixed
+The formatter for normalizing pages now also can treat ACM pages such as `2:1--2:33`.
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatter.java
@@ -20,10 +20,10 @@ import com.google.common.base.Strings;
  */
 public class NormalizePagesFormatter implements Formatter {
 
-    private static final Pattern PAGES_DETECT_PATTERN = Pattern.compile("\\A(\\d+)(?:-{1,2}(\\d+))?\\Z");
+    private static final Pattern PAGES_DETECT_PATTERN = Pattern.compile("\\A((\\d+:)?\\d+)(?:-{1,2}((\\d+:)?\\d+))?\\Z");
 
-    private static final String REJECT_LITERALS = "[^a-zA-Z0-9,\\-\\+,]";
-    private static final String PAGES_REPLACE_PATTERN = "$1--$2";
+    private static final String REJECT_LITERALS = "[^a-zA-Z0-9,\\-\\+,:]";
+    private static final String PAGES_REPLACE_PATTERN = "$1--$3";
     private static final String SINGLE_PAGE_REPLACE_PATTERN = "$1";
 
 
@@ -66,9 +66,9 @@ public class NormalizePagesFormatter implements Formatter {
         cleanValue = cleanValue.replaceAll("\u2013|\u2014", "-").replaceAll(REJECT_LITERALS, "");
         // try to find pages pattern
         Matcher matcher = PAGES_DETECT_PATTERN.matcher(cleanValue);
-        if(matcher.matches()) {
+        if (matcher.matches()) {
             // replace
-            if(Strings.isNullOrEmpty(matcher.group(2))) {
+            if (Strings.isNullOrEmpty(matcher.group(3))) {
                 return matcher.replaceFirst(SINGLE_PAGE_REPLACE_PATTERN);
             } else {
                 return matcher.replaceFirst(PAGES_REPLACE_PATTERN);

--- a/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatter.java
+++ b/src/main/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatter.java
@@ -10,9 +10,9 @@ import net.sf.jabref.model.cleanup.Formatter;
 import com.google.common.base.Strings;
 
 /**
- * This class includes sensible defaults for consistent formatting of BibTex page numbers.
+ * This class includes sensible defaults for consistent formatting of BibTeX page numbers.
  *
- * From BibTex manual:
+ * From BibTeX manual:
  * One or more page numbers or range of numbers, such as 42--111 or 7,41,73--97 or 43+
  * (the '+' in this last example indicates pages following that don't form a simple range).
  * To make it easier to maintain Scribe-compatible databases, the standard styles convert
@@ -20,10 +20,11 @@ import com.google.common.base.Strings;
  */
 public class NormalizePagesFormatter implements Formatter {
 
-    private static final Pattern PAGES_DETECT_PATTERN = Pattern.compile("\\A((\\d+:)?\\d+)(?:-{1,2}((\\d+:)?\\d+))?\\Z");
+    // "startpage" and "endpage" are named groups. See http://stackoverflow.com/a/415635/873282 for a documentation
+    private static final Pattern PAGES_DETECT_PATTERN = Pattern.compile("\\A(?<startpage>(\\d+:)?\\d+)(?:-{1,2}(?<endpage>(\\d+:)?\\d+))?\\Z");
 
     private static final String REJECT_LITERALS = "[^a-zA-Z0-9,\\-\\+,:]";
-    private static final String PAGES_REPLACE_PATTERN = "$1--$3";
+    private static final String PAGES_REPLACE_PATTERN = "${startpage}--${endpage}";
     private static final String SINGLE_PAGE_REPLACE_PATTERN = "$1";
 
 
@@ -68,7 +69,7 @@ public class NormalizePagesFormatter implements Formatter {
         Matcher matcher = PAGES_DETECT_PATTERN.matcher(cleanValue);
         if (matcher.matches()) {
             // replace
-            if (Strings.isNullOrEmpty(matcher.group(3))) {
+            if (Strings.isNullOrEmpty(matcher.group("endpage"))) {
                 return matcher.replaceFirst(SINGLE_PAGE_REPLACE_PATTERN);
             } else {
                 return matcher.replaceFirst(PAGES_REPLACE_PATTERN);

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatterTest.java
@@ -18,93 +18,94 @@ public class NormalizePagesFormatterTest {
 
     @Test
     public void formatSinglePageResultsInNoChange() {
-        expectCorrect("1", "1");
+        Assert.assertEquals("1", formatter.format("1"));
     }
 
     @Test
     public void formatPageNumbers() {
-        expectCorrect("1-2", "1--2");
+        Assert.assertEquals("1--2", formatter.format("1-2"));
     }
 
     @Test
     public void formatPageNumbersCommaSeparated() {
-        expectCorrect("1,2,3", "1,2,3");
+        Assert.assertEquals("1,2,3", formatter.format("1,2,3"));
     }
 
     @Test
     public void formatPageNumbersPlusRange() {
-        expectCorrect("43+", "43+");
+        Assert.assertEquals("43+", formatter.format("43+"));
     }
 
     @Test
     public void ignoreWhitespaceInPageNumbers() {
-        expectCorrect("   1  - 2 ", "1--2");
+        Assert.assertEquals("1--2", formatter.format("   1  - 2 "));
     }
 
     @Test
-    public void removeWhitespace() {
-        expectCorrect("   1  ", "1");
-        expectCorrect("   1 -- 2  ", "1--2");
+    public void removeWhitespaceSinglePage() {
+        Assert.assertEquals("1", formatter.format("   1  "));
+    }
+
+    @Test
+    public void removeWhitespacePageRange() {
+        Assert.assertEquals("1--2", formatter.format("   1 -- 2  "));
     }
 
     @Test
     public void ignoreWhitespaceInPageNumbersWithDoubleDash() {
-        expectCorrect("43 -- 103", "43--103");
+        Assert.assertEquals("43--103", formatter.format("43 -- 103"));
     }
 
     @Test
     public void keepCorrectlyFormattedPageNumbers() {
-        expectCorrect("1--2", "1--2");
+        Assert.assertEquals("1--2", formatter.format("1--2"));
     }
 
     @Test
     public void formatPageNumbersRemoveUnexpectedLiterals() {
-        expectCorrect("{1}-{2}", "1--2");
+        Assert.assertEquals("1--2", formatter.format("{1}-{2}"));
     }
 
     @Test
     public void formatPageNumbersRegexNotMatching() {
-        expectCorrect("12", "12");
+        Assert.assertEquals("12", formatter.format("12"));
     }
 
     @Test
     public void doNotRemoveLetters() {
-        expectCorrect("R1-R50", "R1-R50");
+        Assert.assertEquals("R1-R50", formatter.format("R1-R50"));
     }
 
     @Test
     public void replaceLongDashWithDoubleDash() {
-        expectCorrect("1 \u2014 50", "1--50");
+        Assert.assertEquals("1--50", formatter.format("1 \u2014 50"));
     }
 
     @Test
     public void removePagePrefix() {
-        expectCorrect("p.50", "50");
+        Assert.assertEquals("50", formatter.format("p.50"));
     }
 
     @Test
     public void removePagesPrefix() {
-        expectCorrect("pp.50", "50");
+        Assert.assertEquals("50", formatter.format("pp.50"));
     }
 
     @Test
     public void formatACMPages() {
         // This appears in https://doi.org/10.1145/1658373.1658375
-        expectCorrect("2:1-2:33", "2:1--2:33");
+        Assert.assertEquals("2:1--2:33", formatter.format("2:1-2:33"));
     }
 
     @Test
     public void keepFormattedACMPages() {
         // This appears in https://doi.org/10.1145/1658373.1658375
-        expectCorrect("2:1--2:33", "2:1--2:33");
+        Assert.assertEquals("2:1--2:33", formatter.format("2:1--2:33"));
     }
 
     @Test
     public void formatExample() {
-        expectCorrect(formatter.getExampleInput(), "1--2");
+        Assert.assertEquals("1--2", formatter.format(formatter.getExampleInput()));
     }
 
-    private void expectCorrect(String input, String expected) {
-        Assert.assertEquals(expected, formatter.format(input));
-    }
 }

--- a/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/formatter/bibtexfields/NormalizePagesFormatterTest.java
@@ -88,6 +88,18 @@ public class NormalizePagesFormatterTest {
     }
 
     @Test
+    public void formatACMPages() {
+        // This appears in https://doi.org/10.1145/1658373.1658375
+        expectCorrect("2:1-2:33", "2:1--2:33");
+    }
+
+    @Test
+    public void keepFormattedACMPages() {
+        // This appears in https://doi.org/10.1145/1658373.1658375
+        expectCorrect("2:1--2:33", "2:1--2:33");
+    }
+
+    @Test
     public void formatExample() {
         expectCorrect(formatter.getExampleInput(), "1--2");
     }


### PR DESCRIPTION
This fixes https://github.com/koppor/jabref/issues/212

I worked with the article https://doi.org/10.1145/1658373.1658375 which had pages formatted as `2:1--2:33`. Since I use the recommended BibTeX save actions, these pages got destroyed. This PR fixes that.

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [n/a] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [n/a] If you changed the localization: Did you run `gradle localizationUpdate`?
