### PR TITLE
Escaping of escape symbols in the MetaData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 ### Fixed
 - The formatter for normalizing pages now also can treat ACM pages such as `2:1--2:33`.
+- Backslashes in content selectors are now corretly escaped. Fixes [#2426](https://github.com/JabRef/jabref/issues/2426).
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/logic/exporter/MetaDataSerializer.java
+++ b/src/main/java/net/sf/jabref/logic/exporter/MetaDataSerializer.java
@@ -61,7 +61,7 @@ public class MetaDataSerializer {
             StringBuilder stringBuilder = new StringBuilder();
             for (String dataItem : metaItem.getValue()) {
                 stringBuilder.append(StringUtil.quote(dataItem, MetaData.SEPARATOR_STRING, MetaData.ESCAPE_CHARACTER)).append(MetaData.SEPARATOR_STRING);
-
+                
                 //in case of save actions, add an additional newline after the enabled flag
                 if (metaItem.getKey().equals(MetaData.SAVE_ACTIONS)
                         && (FieldFormatterCleanups.ENABLED.equals(dataItem)

--- a/src/main/java/net/sf/jabref/logic/importer/util/MetaDataParser.java
+++ b/src/main/java/net/sf/jabref/logic/importer/util/MetaDataParser.java
@@ -16,6 +16,7 @@ import net.sf.jabref.model.database.BibDatabaseMode;
 import net.sf.jabref.model.metadata.ContentSelectors;
 import net.sf.jabref.model.metadata.MetaData;
 import net.sf.jabref.model.metadata.SaveOrderConfig;
+import net.sf.jabref.model.strings.StringUtil;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -53,7 +54,7 @@ public class MetaDataParser {
                 metaData.setUserFileDirectory(user, getSingleItem(value));
                 continue;
             } else if(entry.getKey().startsWith(MetaData.SELECTOR_META_PREFIX)){
-                metaData.addContentSelector(ContentSelectors.parse(entry.getKey().substring(MetaData.SELECTOR_META_PREFIX.length()), entry.getValue()));
+                metaData.addContentSelector(ContentSelectors.parse(entry.getKey().substring(MetaData.SELECTOR_META_PREFIX.length()), StringUtil.unquote(entry.getValue(), MetaData.ESCAPE_CHARACTER)));
                 continue;
             }
 

--- a/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -1,5 +1,7 @@
 package net.sf.jabref.logic.exporter;
 
+import java.io.IOException;
+import java.io.StringReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -558,6 +560,22 @@ public class BibtexDatabaseWriterTest {
                         "@Comment{jabref-meta: databaseType:bibtex;}"
                         + OS.NEWLINE
                 , session.getStringValue());
+    }
+
+    @Test
+    public void roundtripWithContentSelectorsAndUmlauts() throws IOException, SaveException {
+        String fileContent = "% Encoding: UTF-8" + OS.NEWLINE + OS.NEWLINE + "@Comment{jabref-meta: selector_journal:Test {\\\"U}mlaut;}" + OS.NEWLINE;
+        Charset encoding = StandardCharsets.UTF_8;
+
+        ParserResult firstParse = new BibtexParser(importFormatPreferences).parse(new StringReader(fileContent));
+
+        SavePreferences preferences = new SavePreferences().withEncoding(encoding).withSaveInOriginalOrder(true);
+        BibDatabaseContext context = new BibDatabaseContext(firstParse.getDatabase(), firstParse.getMetaData(),
+                new Defaults(BibDatabaseMode.BIBTEX));
+
+        StringSaveSession session = databaseWriter.savePartOfDatabase(context, firstParse.getDatabase().getEntries(), preferences);
+
+        assertEquals(fileContent, session.getStringValue());
     }
 
 }

--- a/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/net/sf/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -564,7 +564,7 @@ public class BibtexDatabaseWriterTest {
 
     @Test
     public void roundtripWithContentSelectorsAndUmlauts() throws IOException, SaveException {
-        String fileContent = "% Encoding: UTF-8" + OS.NEWLINE + OS.NEWLINE + "@Comment{jabref-meta: selector_journal:Test {\\\"U}mlaut;}" + OS.NEWLINE;
+        String fileContent = "% Encoding: UTF-8" + OS.NEWLINE + OS.NEWLINE + "@Comment{jabref-meta: selector_journal:Test {\\\\\"U}mlaut;}" + OS.NEWLINE;
         Charset encoding = StandardCharsets.UTF_8;
 
         ParserResult firstParse = new BibtexParser(importFormatPreferences).parse(new StringReader(fileContent));


### PR DESCRIPTION
Fixes #2426 and is ready for review.

# Old discussion
Attempts to fix  #2426.

Is not yet functional, since the issue goes somewhat deeper and affects LaTeX-encoding things in all MetaData, also groups. The problem is line 64 in MetaDataSerializer:
```
 stringBuilder.append(StringUtil.quote(dataItem, MetaData.SEPARATOR_STRING, MetaData.ESCAPE_CHARACTER)).append(MetaData.SEPARATOR_STRING);
```
For every MetaData item, all special characters are quoted, including the quoting symbol (`\`). Thus, if there is a `\` in the MetaData, it is quoted during serialization, resulting in `\\`, which is read as such and requoted on the next serialization, resulting in `\\\\` and so on. 

Unfortunately, unquoting the text during parsing and quoting it again during writing does not help, since a single `\` will simply be lost. E.g.: unquoting `\"U` would result in `"U`, which upon quoting anew would stay `"U`.

The same problem should occur for groups, if I am not mistaken.

I now have the following options to resolve the problem:
 1. Add special handling for content selectors to avoid quoting for them
 2. Change `StringUtil.quote` to avoid quoting the quoting char (`\`)
 3. Add another method in StringUtil that avoids quoting the quoting char and use it for MetaData in general.

I am afraid that changing `StringUtil.quote` has wider implications that I am not aware of., especially relating to groups Hence, there is a need for discussion. 

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef

