### PR TITLE
ctrl+f selects current query while the searchbar is focusd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - The formatter for normalizing pages now also can treat ACM pages such as `2:1--2:33`.
 - Backslashes in content selectors are now corretly escaped. Fixes [#2426](https://github.com/JabRef/jabref/issues/2426).
 - Non-ISO timestamp settings prevented the opening of the entry editor (see [#2447](https://github.com/JabRef/jabref/issues/2447))
+- When pressing <kbd>Ctrl</kbd> + <kbd>F</kbd> and the searchbar is already focused the text will be selected.
 
 
 ### Removed

--- a/src/main/java/net/sf/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/net/sf/jabref/gui/search/GlobalSearchBar.java
@@ -290,8 +290,8 @@ public class GlobalSearchBar extends JPanel {
     public void focus() {
         if (!searchField.hasFocus()) {
             searchField.requestFocus();
-            searchField.selectAll();
         }
+        searchField.selectAll();
     }
 
     private void clearSearch(BasePanel currentBasePanel) {


### PR DESCRIPTION
Implemented a feature request from the forum (http://discourse.jabref.org/t/ctrl-f-behaviour/408).

When pressing <kbd>Ctrl</kbd> + <kbd>F</kbd> and the searchbar is already focused the current query will be selected.
This is the same behavior as many other programs have.


- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
