### PR TITLE
Fix conversion of tilde n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 ### Fixed
 - The formatter for normalizing pages now also can treat ACM pages such as `2:1--2:33`.
-- Backslashes in content selectors are now corretly escaped. Fixes [#2426](https://github.com/JabRef/jabref/issues/2426).
+- Backslashes in content selectors are now correctly escaped. Fixes [#2426](https://github.com/JabRef/jabref/issues/2426).
 - Non-ISO timestamp settings prevented the opening of the entry editor (see [#2447](https://github.com/JabRef/jabref/issues/2447))
 - When pressing <kbd>Ctrl</kbd> + <kbd>F</kbd> and the searchbar is already focused the text will be selected.
-
+- LaTeX symbols are now displayed as Unicode for the author column in the main table. Fixes [#2458](https://github.com/JabRef/jabref/issues/2458).
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableColumn.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableColumn.java
@@ -104,7 +104,7 @@ public class MainTableColumn {
         String result = content.orElse(null);
 
         if (isNameColumn) {
-            result = MainTableNameFormatter.formatName(result);
+            result = MainTableNameFormatter.formatName(toUnicode.format(result));
         }
 
         if (result != null) {

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableNameFormatter.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableNameFormatter.java
@@ -2,12 +2,9 @@ package net.sf.jabref.gui.maintable;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.model.entry.AuthorList;
-import net.sf.jabref.model.strings.LatexToUnicode;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 public class MainTableNameFormatter {
-
-    private static final LatexToUnicode latexToUnicode = new LatexToUnicode();
 
     /**
      * Format a name field for the table, according to user preferences.
@@ -15,7 +12,7 @@ public class MainTableNameFormatter {
      * @param nameToFormat The contents of the name field.
      * @return The formatted name field.
      */
-    public static String formatName(String nameToFormat) {
+    public static String formatName(final String nameToFormat) {
         if (nameToFormat == null) {
             return null;
         }
@@ -27,8 +24,6 @@ public class MainTableNameFormatter {
         final boolean namesFf = Globals.prefs.getBoolean(JabRefPreferences.NAMES_FIRST_LAST);
 
         final boolean abbrAuthorNames = Globals.prefs.getBoolean(JabRefPreferences.ABBR_AUTHOR_NAMES); //MK:
-
-        nameToFormat = latexToUnicode.format(nameToFormat);
 
         if (namesAsIs) {
             return nameToFormat;

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableNameFormatter.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableNameFormatter.java
@@ -2,9 +2,12 @@ package net.sf.jabref.gui.maintable;
 
 import net.sf.jabref.Globals;
 import net.sf.jabref.model.entry.AuthorList;
+import net.sf.jabref.model.strings.LatexToUnicode;
 import net.sf.jabref.preferences.JabRefPreferences;
 
 public class MainTableNameFormatter {
+
+    private static final LatexToUnicode latexToUnicode = new LatexToUnicode();
 
     /**
      * Format a name field for the table, according to user preferences.
@@ -12,7 +15,7 @@ public class MainTableNameFormatter {
      * @param nameToFormat The contents of the name field.
      * @return The formatted name field.
      */
-    public static String formatName(final String nameToFormat) {
+    public static String formatName(String nameToFormat) {
         if (nameToFormat == null) {
             return null;
         }
@@ -24,6 +27,8 @@ public class MainTableNameFormatter {
         final boolean namesFf = Globals.prefs.getBoolean(JabRefPreferences.NAMES_FIRST_LAST);
 
         final boolean abbrAuthorNames = Globals.prefs.getBoolean(JabRefPreferences.ABBR_AUTHOR_NAMES); //MK:
+
+        nameToFormat = latexToUnicode.format(nameToFormat);
 
         if (namesAsIs) {
             return nameToFormat;

--- a/src/test/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -87,4 +87,9 @@ public class LatexToUnicodeFormatterTest {
     public void unknownCommandWithEmptyArgumentIsKept() {
         assertEquals("aaaa", formatter.format("\\aaaa{}"));
     }
+
+    @Test
+    public void testTildeN () {
+        assertEquals("Montaña", formatter.format("Monta\\~{n}a"));
+    }
 }


### PR DESCRIPTION
And although I said that I would not work on JabRef for the next two weeks, here is a PR. This stuff is addictive and I need help :-/

Fixes #2458. Author name formatting in the main table is handled different from the formatting of the remaining columns and we simply forgot to perform the unicode conversion also for the author column.

- [X] Change in CHANGELOG.md described
- [X] Tests created for changes
- [X] Manually tested changed features in running JabRef

