### PR TITLE
Fix conversion of "'n" and "\'{n}" from LaTeX to Unicode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Backslashes in content selectors are now correctly escaped. Fixes [#2426](https://github.com/JabRef/jabref/issues/2426).
 - Non-ISO timestamp settings prevented the opening of the entry editor (see [#2447](https://github.com/JabRef/jabref/issues/2447))
 - When pressing <kbd>Ctrl</kbd> + <kbd>F</kbd> and the searchbar is already focused the text will be selected.
-- LaTeX symbols are now displayed as Unicode for the author column in the main table. Fixes [#2458](https://github.com/JabRef/jabref/issues/2458).
+- LaTeX symbols are now displayed as Unicode for the author column in the main table. "'n" and "\'{n}" are parsed correctly. Fixes [#2458](https://github.com/JabRef/jabref/issues/2458).
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/model/strings/LatexToUnicode.java
+++ b/src/main/java/net/sf/jabref/model/strings/LatexToUnicode.java
@@ -62,6 +62,12 @@ public class LatexToUnicode {
                     || StringUtil.SPECIAL_COMMAND_CHARS.contains(String.valueOf(c))) {
                 escaped = false;
 
+                // a single ' can also be a command
+                if('\'' == c){
+                    incommand = true;
+                    currentCommand = new StringBuilder();
+                }
+
                 if (!incommand) {
                     sb.append(c);
                 } else {
@@ -83,7 +89,7 @@ public class LatexToUnicode {
                         } else {
                             commandBody = field.substring(i, i + 1);
                         }
-                        String result = CHARS.get(command + commandBody);
+                        String result = fixCollidingCommand(CHARS.get(command + commandBody), c);
 
                         if (result == null) {
                             // Use combining accents if argument is single character or empty
@@ -205,5 +211,14 @@ public class LatexToUnicode {
         result = TILDE.matcher(result).replaceAll("\u00A0");
         return result;
 
+    }
+
+    private String fixCollidingCommand(String currentChar, Character bracket) {
+        // when stripping Latex, there is a collision between unicode characters 324 and 329. Hence, this needs to be checked
+        if (!("ŉ".equals(currentChar) && '{' == bracket)) {
+            return currentChar;
+        } else {
+            return "ń";
+        }
     }
 }

--- a/src/test/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -92,4 +92,10 @@ public class LatexToUnicodeFormatterTest {
     public void testTildeN () {
         assertEquals("Montaña", formatter.format("Monta\\~{n}a"));
     }
+
+    @Test
+    public void testApostrophN () {
+        assertEquals("Maliński", formatter.format("Mali\\'{n}ski"));
+        assertEquals("Maliŉski", formatter.format("Mali'nski"));
+    }
 }


### PR DESCRIPTION
This is a follow up for fixing  #2458

The combinations `\'n` and `\\'{n}` are converted from LaTeX to different symbols in Unicode.

This was really hard to track down. It was not a problem in our conversion maps, but in `LatexToUnicode`. The ultimate reason is that this code is just an utter mess of hacks and I could only fix this by adding another ugly map on top of this heap.

We have already identified this class to cause performance issues and, as you can see here, it is very difficult to maintain. We should consider removing the functionality and rewriting it from scratch or (preferably) replace it with an external library. After all, converting a LaTeX string to Unicode seems sufficiently well-defined that there is some library for this out there.

- [X] Change in CHANGELOG.md described
- [X] Tests created for changes
- [X] Manually tested changed features in running JabRef
