### PR TITLE
Save deletion of current searchquery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Non-ISO timestamp settings prevented the opening of the entry editor (see [#2447](https://github.com/JabRef/jabref/issues/2447))
 - When pressing <kbd>Ctrl</kbd> + <kbd>F</kbd> and the searchbar is already focused the text will be selected.
 - LaTeX symbols are now displayed as Unicode for the author column in the main table. "'n" and "\'{n}" are parsed correctly. Fixes [#2458](https://github.com/JabRef/jabref/issues/2458).
-- Fixes [#2468](https://github.com/JabRef/jabref/issues/2468): Save deletion of current searchquery.
+- If one deleted the current query it was not saved (every basepanel can have it's own query). Fixes [#2468](https://github.com/JabRef/jabref/issues/2468).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Non-ISO timestamp settings prevented the opening of the entry editor (see [#2447](https://github.com/JabRef/jabref/issues/2447))
 - When pressing <kbd>Ctrl</kbd> + <kbd>F</kbd> and the searchbar is already focused the text will be selected.
 - LaTeX symbols are now displayed as Unicode for the author column in the main table. "'n" and "\'{n}" are parsed correctly. Fixes [#2458](https://github.com/JabRef/jabref/issues/2458).
+- Fixes [#2468](https://github.com/JabRef/jabref/issues/2468): Save deletion of current searchquery.
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -207,7 +207,8 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
     private ContentAutoCompleters autoCompleters;
 
-    private SearchQuery currentSearchQuery;
+    /** the query the user searches when this basepanel is active */
+    private Optional<SearchQuery> currentSearchQuery = Optional.empty();
 
 
     public BasePanel(JabRefFrame frame, BibDatabaseContext bibDatabaseContext) {
@@ -2405,12 +2406,20 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         return bibDatabaseContext;
     }
 
-    public SearchQuery getCurrentSearchQuery() {
+    public Optional<SearchQuery> getCurrentSearchQuery() {
         return currentSearchQuery;
     }
 
+    /**
+     * Set the query the user currently searches while this basepanel is active
+     * @param currentSearchQuery can be null
+     */
     public void setCurrentSearchQuery(SearchQuery currentSearchQuery) {
-        this.currentSearchQuery = currentSearchQuery;
+        if (currentSearchQuery == null) {
+            this.currentSearchQuery = Optional.empty();
+        } else {
+            this.currentSearchQuery = Optional.of(currentSearchQuery);
+        }
     }
 
     public CitationStyleCache getCitationStyleCache() {

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -2415,11 +2415,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
      * @param currentSearchQuery can be null
      */
     public void setCurrentSearchQuery(SearchQuery currentSearchQuery) {
-        if (currentSearchQuery == null) {
-            this.currentSearchQuery = Optional.empty();
-        } else {
-            this.currentSearchQuery = Optional.of(currentSearchQuery);
-        }
+        this.currentSearchQuery = Optional.ofNullable(currentSearchQuery);
     }
 
     public CitationStyleCache getCitationStyleCache() {

--- a/src/main/java/net/sf/jabref/gui/JabRefFrame.java
+++ b/src/main/java/net/sf/jabref/gui/JabRefFrame.java
@@ -640,9 +640,9 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
                 globalSearchBar.performSearch();
             } else {
                 String content = "";
-                SearchQuery currentSearchQuery = currentBasePanel.getCurrentSearchQuery();
-                if ((currentSearchQuery != null) && !currentSearchQuery.getQuery().trim().isEmpty()) {
-                    content = currentSearchQuery.getQuery();
+                Optional<SearchQuery> currentSearchQuery = currentBasePanel.getCurrentSearchQuery();
+                if (currentSearchQuery.isPresent()) {
+                    content = currentSearchQuery.get().getQuery();
                 }
                 globalSearchBar.setSearchTerm(content, true);
             }

--- a/src/main/java/net/sf/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/net/sf/jabref/gui/search/GlobalSearchBar.java
@@ -304,6 +304,7 @@ public class GlobalSearchBar extends JPanel {
 
         if (currentBasePanel != null) {
             currentBasePanel.getMainTable().getTableModel().updateSearchState(MainTableDataModel.DisplayOption.DISABLED);
+            currentBasePanel.setCurrentSearchQuery(null);
         }
 
         if (dontSelectSearchBar){


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/2468.

If one deleted the current query it was not saved (every basepanel can have it's own query).

The only neede change is the line in `GlobalSearchBar.java`.

- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
