### PR TITLE
Add update from DOI to the entryeditor sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ## [Unreleased]
 
 ### Changed
+- Added the option to update bibliographic information from DOI to the sidebar of the entryeditor. Implements [#2432](https://github.com/JabRef/jabref/issues/2432).
 
 ### Fixed
 - The formatter for normalizing pages now also can treat ACM pages such as `2:1--2:33`.

--- a/src/main/java/net/sf/jabref/gui/importer/fetcher/EntryFetchers.java
+++ b/src/main/java/net/sf/jabref/gui/importer/fetcher/EntryFetchers.java
@@ -53,7 +53,7 @@ public class EntryFetchers {
         return Collections.unmodifiableList(this.entryFetchers);
     }
 
-    public static ArrayList<IdBasedFetcher> getIdFetchers(ImportFormatPreferences importFormatPreferences) {
+    public static List<IdBasedFetcher> getIdFetchers(ImportFormatPreferences importFormatPreferences) {
         ArrayList<IdBasedFetcher> list = new ArrayList<>();
         list.add(new ArXiv(importFormatPreferences));
         list.add(new AstrophysicsDataSystem(importFormatPreferences));
@@ -66,9 +66,10 @@ public class EntryFetchers {
         return list;
     }
 
-    public static ArrayList<EntryBasedFetcher> getEntryBasedFetchers(ImportFormatPreferences importFormatPreferences) {
+    public static List<EntryBasedFetcher> getEntryBasedFetchers(ImportFormatPreferences importFormatPreferences) {
         ArrayList<EntryBasedFetcher> list = new ArrayList<>();
         list.add(new AstrophysicsDataSystem(importFormatPreferences));
+        list.add(new DoiFetcher(importFormatPreferences));
         list.add(new MathSciNet(importFormatPreferences));
         list.sort(Comparator.comparing(WebFetcher::getName));
         return list;

--- a/src/main/java/net/sf/jabref/logic/importer/fetcher/DoiFetcher.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fetcher/DoiFetcher.java
@@ -3,11 +3,14 @@ package net.sf.jabref.logic.importer.fetcher;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import net.sf.jabref.logic.formatter.bibtexfields.ClearFormatter;
 import net.sf.jabref.logic.formatter.bibtexfields.NormalizePagesFormatter;
 import net.sf.jabref.logic.help.HelpFile;
+import net.sf.jabref.logic.importer.EntryBasedFetcher;
 import net.sf.jabref.logic.importer.FetcherException;
 import net.sf.jabref.logic.importer.IdBasedFetcher;
 import net.sf.jabref.logic.importer.ImportFormatPreferences;
@@ -20,7 +23,7 @@ import net.sf.jabref.model.cleanup.FieldFormatterCleanup;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.entry.FieldName;
 
-public class DoiFetcher implements IdBasedFetcher {
+public class DoiFetcher implements IdBasedFetcher, EntryBasedFetcher {
 
     private final ImportFormatPreferences preferences;
 
@@ -69,4 +72,13 @@ public class DoiFetcher implements IdBasedFetcher {
         new FieldFormatterCleanup(FieldName.PAGES, new NormalizePagesFormatter()).cleanup(entry);
         new FieldFormatterCleanup(FieldName.URL, new ClearFormatter()).cleanup(entry);
     }
+
+    @Override
+    public List<BibEntry> performSearch(BibEntry entry) throws FetcherException {
+        Optional<BibEntry> bibEntry = performSearchById(entry.getField(FieldName.DOI).orElse(""));
+        List<BibEntry> list = new ArrayList<>();
+        bibEntry.ifPresent(list::add);
+        return list;
+    }
+
 }

--- a/src/test/java/net/sf/jabref/gui/importer/fetcher/EntryFetchersTest.java
+++ b/src/test/java/net/sf/jabref/gui/importer/fetcher/EntryFetchersTest.java
@@ -1,6 +1,5 @@
 package net.sf.jabref.gui.importer.fetcher;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -33,7 +32,7 @@ public class EntryFetchersTest {
 
     @Test
     public void getIdFetchersReturnsAllFetcherDerivingFromIdFetcher() throws Exception {
-        ArrayList<IdBasedFetcher> idFetchers = EntryFetchers.getIdFetchers(importFormatPreferences);
+        List<IdBasedFetcher> idFetchers = EntryFetchers.getIdFetchers(importFormatPreferences);
 
         Set<Class<? extends IdBasedFetcher>> expected = reflections.getSubTypesOf(IdBasedFetcher.class);
         expected.remove(AbstractIsbnFetcher.class);
@@ -46,7 +45,7 @@ public class EntryFetchersTest {
 
     @Test
     public void getEntryBasedFetchersReturnsAllFetcherDerivingFromEntryBasedFetcher() throws Exception {
-        ArrayList<EntryBasedFetcher> idFetchers = EntryFetchers.getEntryBasedFetchers(importFormatPreferences);
+        List<EntryBasedFetcher> idFetchers = EntryFetchers.getEntryBasedFetchers(importFormatPreferences);
 
         Set<Class<? extends EntryBasedFetcher>> expected = reflections.getSubTypesOf(EntryBasedFetcher.class);
         expected.remove(EntryBasedParserFetcher.class);


### PR DESCRIPTION
Implement https://github.com/JabRef/jabref/issues/2432.

Added the option to update bibliographic information from DOI to the sidebar of the entryeditor.

![doisidebar](https://cloud.githubusercontent.com/assets/15333371/22174431/b16aa1e6-dfde-11e6-8166-aad2a8c1f138.png)


- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [X] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
