### PR TITLE
Fix aux duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - If one deleted the current query it was not saved (every basepanel can have it's own query). Fixes [#2468](https://github.com/JabRef/jabref/issues/2468).
 - The [ACM fetcher](https://help.jabref.org/en/ACMPortal) does no longer add HTML code to the bib-file. Fixes [#2472](https://github.com/JabRef/jabref/issues/2472)
 - When [finding unlinked files](https://help.jabref.org/en/FindUnlinkedFiles), JabRef does not freeze any more. Fixes [#2309]()https://github.com/JabRef/jabref/issues/2309)
-- Collapse and expand all buttons in the group assignment dialog no longer lead to a crash of JabRef. 
+- Collapse and expand all buttons in the group assignment dialog no longer lead to a crash of JabRef.
+- Fixes [#2475](https://github.com/JabRef/jabref/issues/2475): The aux export command line function does no longer add duplicates of references that were resolved via crossref
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/logic/auxparser/AuxParser.java
+++ b/src/main/java/net/sf/jabref/logic/auxparser/AuxParser.java
@@ -133,7 +133,9 @@ public class AuxParser {
         for (String key : result.getUniqueKeys()) {
             Optional<BibEntry> entry = masterDatabase.getEntryByKey(key);
 
-            if (entry.isPresent()) {
+            if(result.getGeneratedBibDatabase().getEntryByKey(key).isPresent()) {
+                // do nothing, key has already been processed
+            } else if (entry.isPresent()) {
                 insertEntry(entry.get(), result);
                 resolveCrossReferences(entry.get(), result);
             } else {


### PR DESCRIPTION
Fixes #2475

A very simple change. Our aux export had some problems when there were crossrefs to other entries. Such references could result in multiple additions of the referenced entry to the generated bib file. A simple check avoids this

- [X] Change in CHANGELOG.md described
- [X] Manually tested changed features in running JabRef
