### PR TITLE
Make sure that unregistered event sources do not stop JabRef from shu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - The [ACM fetcher](https://help.jabref.org/en/ACMPortal) does no longer add HTML code to the bib-file. Fixes [#2472](https://github.com/JabRef/jabref/issues/2472).
 - When [finding unlinked files](https://help.jabref.org/en/FindUnlinkedFiles), JabRef does not freeze any more. Fixes [#2309]()https://github.com/JabRef/jabref/issues/2309).
 - Collapse and expand all buttons in the group assignment dialog no longer lead to a crash of JabRef.
-- The aux export command line function does no longer add duplicates of references that were resolved via `crossref`. Fixes [#2475](https://github.com/JabRef/jabref/issues/2475). 
+- The aux export command line function does no longer add duplicates of references that were resolved via `crossref`. Fixes [#2475](https://github.com/JabRef/jabref/issues/2475).
+- When the database is changed external, JabRef is no longer prevented from an orderly shutdown. Fixes [#2486](https://github.com/JabRef/jabref/issues/2486).
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/logic/autosaveandbackup/AutosaveManager.java
+++ b/src/main/java/net/sf/jabref/logic/autosaveandbackup/AutosaveManager.java
@@ -91,7 +91,7 @@ public class AutosaveManager {
     public void unregisterListener(Object listener) {
         try {
             eventBus.unregister(listener);
-        } catch(IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             // occurs if the event source has not been registered, should not prevent shutdown
             LOGGER.debug(e);
         }

--- a/src/main/java/net/sf/jabref/logic/autosaveandbackup/AutosaveManager.java
+++ b/src/main/java/net/sf/jabref/logic/autosaveandbackup/AutosaveManager.java
@@ -53,18 +53,8 @@ public class AutosaveManager {
     }
 
     private void shutdown() {
-        try {
-            bibDatabaseContext.getDatabase().unregisterListener(this);
-        } catch(IllegalArgumentException e) {
-            // occurs if the event source has not been registered, should not prevent shutdown
-            LOGGER.debug(e);
-        }
-        try {
-            bibDatabaseContext.getMetaData().unregisterListener(this);
-        } catch(IllegalArgumentException e) {
-            // occurs if the event source has not been registered, should not prevent shutdown
-            LOGGER.debug(e);
-        }
+        bibDatabaseContext.getDatabase().unregisterListener(this);
+        bibDatabaseContext.getMetaData().unregisterListener(this);
         executor.shutdown();
     }
 
@@ -99,6 +89,11 @@ public class AutosaveManager {
     }
 
     public void unregisterListener(Object listener) {
-        eventBus.unregister(listener);
+        try {
+            eventBus.unregister(listener);
+        } catch(IllegalArgumentException e) {
+            // occurs if the event source has not been registered, should not prevent shutdown
+            LOGGER.debug(e);
+        }
     }
 }

--- a/src/main/java/net/sf/jabref/logic/autosaveandbackup/AutosaveManager.java
+++ b/src/main/java/net/sf/jabref/logic/autosaveandbackup/AutosaveManager.java
@@ -53,8 +53,18 @@ public class AutosaveManager {
     }
 
     private void shutdown() {
-        bibDatabaseContext.getDatabase().unregisterListener(this);
-        bibDatabaseContext.getMetaData().unregisterListener(this);
+        try {
+            bibDatabaseContext.getDatabase().unregisterListener(this);
+        } catch(IllegalArgumentException e) {
+            // occurs if the event source has not been registered, should not prevent shutdown
+            LOGGER.debug(e);
+        }
+        try {
+            bibDatabaseContext.getMetaData().unregisterListener(this);
+        } catch(IllegalArgumentException e) {
+            // occurs if the event source has not been registered, should not prevent shutdown
+            LOGGER.debug(e);
+        }
         executor.shutdown();
     }
 

--- a/src/main/java/net/sf/jabref/logic/autosaveandbackup/BackupManager.java
+++ b/src/main/java/net/sf/jabref/logic/autosaveandbackup/BackupManager.java
@@ -145,18 +145,8 @@ public class BackupManager {
      * This method should only be used when closing a database/JabRef legally.
      */
     private void shutdown() {
-        try {
-            bibDatabaseContext.getDatabase().unregisterListener(this);
-        } catch(IllegalArgumentException e) {
-            // occurs if the event source has not been registered, should not prevent shutdown
-            LOGGER.debug(e);
-        }
-        try {
-            bibDatabaseContext.getMetaData().unregisterListener(this);
-        } catch(IllegalArgumentException e) {
-            // occurs if the event source has not been registered, should not prevent shutdown
-            LOGGER.debug(e);
-        }
+        bibDatabaseContext.getDatabase().unregisterListener(this);
+        bibDatabaseContext.getMetaData().unregisterListener(this);
         executor.shutdown();
         determineBackupPath().ifPresent(this::deleteBackupFile);
     }

--- a/src/main/java/net/sf/jabref/logic/autosaveandbackup/BackupManager.java
+++ b/src/main/java/net/sf/jabref/logic/autosaveandbackup/BackupManager.java
@@ -145,8 +145,18 @@ public class BackupManager {
      * This method should only be used when closing a database/JabRef legally.
      */
     private void shutdown() {
-        bibDatabaseContext.getDatabase().unregisterListener(this);
-        bibDatabaseContext.getMetaData().unregisterListener(this);
+        try {
+            bibDatabaseContext.getDatabase().unregisterListener(this);
+        } catch(IllegalArgumentException e) {
+            // occurs if the event source has not been registered, should not prevent shutdown
+            LOGGER.debug(e);
+        }
+        try {
+            bibDatabaseContext.getMetaData().unregisterListener(this);
+        } catch(IllegalArgumentException e) {
+            // occurs if the event source has not been registered, should not prevent shutdown
+            LOGGER.debug(e);
+        }
         executor.shutdown();
         determineBackupPath().ifPresent(this::deleteBackupFile);
     }

--- a/src/main/java/net/sf/jabref/logic/search/SearchQueryHighlightObservable.java
+++ b/src/main/java/net/sf/jabref/logic/search/SearchQueryHighlightObservable.java
@@ -31,7 +31,11 @@ public class SearchQueryHighlightObservable {
     public void removeSearchListener(SearchQueryHighlightListener listener) {
         Objects.requireNonNull(listener);
 
-        eventBus.unregister(listener);
+        try {
+            eventBus.unregister(listener);
+        } catch(IllegalArgumentException e) {
+            // occurs if the event source has not been registered, should not prevent shutdown
+        }
     }
     /**
      * Fires an event if a search was started (or cleared)

--- a/src/main/java/net/sf/jabref/logic/search/SearchQueryHighlightObservable.java
+++ b/src/main/java/net/sf/jabref/logic/search/SearchQueryHighlightObservable.java
@@ -33,7 +33,7 @@ public class SearchQueryHighlightObservable {
 
         try {
             eventBus.unregister(listener);
-        } catch(IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             // occurs if the event source has not been registered, should not prevent shutdown
         }
     }

--- a/src/main/java/net/sf/jabref/model/database/BibDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabase.java
@@ -532,8 +532,8 @@ public class BibDatabase {
     public void unregisterListener(Object listener) {
         try {
             this.eventBus.unregister(listener);
-        } catch(IllegalArgumentException e) {
-        // occurs if the event source has not been registered, should not prevent shutdown
+        } catch (IllegalArgumentException e) {
+            // occurs if the event source has not been registered, should not prevent shutdown
             LOGGER.debug(e);
         }
     }

--- a/src/main/java/net/sf/jabref/model/database/BibDatabase.java
+++ b/src/main/java/net/sf/jabref/model/database/BibDatabase.java
@@ -530,7 +530,12 @@ public class BibDatabase {
      * @param listener listener (subscriber) to remove
      */
     public void unregisterListener(Object listener) {
-        this.eventBus.unregister(listener);
+        try {
+            this.eventBus.unregister(listener);
+        } catch(IllegalArgumentException e) {
+        // occurs if the event source has not been registered, should not prevent shutdown
+            LOGGER.debug(e);
+        }
     }
 
     @Subscribe

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -766,7 +766,7 @@ public class BibEntry implements Cloneable {
     public void unregisterListener(Object object) {
         try {
             this.eventBus.unregister(object);
-        } catch(IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             // occurs if the event source has not been registered, should not prevent shutdown
             LOGGER.debug(e);
         }

--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -764,7 +764,12 @@ public class BibEntry implements Cloneable {
     }
 
     public void unregisterListener(Object object) {
-        this.eventBus.unregister(object);
+        try {
+            this.eventBus.unregister(object);
+        } catch(IllegalArgumentException e) {
+            // occurs if the event source has not been registered, should not prevent shutdown
+            LOGGER.debug(e);
+        }
     }
 
     public BibEntry withField(String field, String value) {

--- a/src/main/java/net/sf/jabref/model/metadata/MetaData.java
+++ b/src/main/java/net/sf/jabref/model/metadata/MetaData.java
@@ -254,7 +254,11 @@ public class MetaData {
     }
 
     public void unregisterListener(Object listener) {
-        this.eventBus.unregister(listener);
+        try {
+            this.eventBus.unregister(listener);
+        } catch(IllegalArgumentException e) {
+            // occurs if the event source has not been registered, should not prevent shutdown
+        }
     }
 
     private Optional<String> getDefaultCiteKeyPattern() {

--- a/src/main/java/net/sf/jabref/model/metadata/MetaData.java
+++ b/src/main/java/net/sf/jabref/model/metadata/MetaData.java
@@ -256,7 +256,7 @@ public class MetaData {
     public void unregisterListener(Object listener) {
         try {
             this.eventBus.unregister(listener);
-        } catch(IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             // occurs if the event source has not been registered, should not prevent shutdown
         }
     }


### PR DESCRIPTION
…tting down

Fixes #2486. Unregistering event sources that have not been registered before should not stop JabRef from shutting down orderly. This PR logs such a problem instead of halting the shutdown of the program

- [X] Change in CHANGELOG.md described
- [X] Manually tested changed features in running JabRef

