### PR TITLE
Catch NumberFormatException if context can't be parsed in groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - When [finding unlinked files](https://help.jabref.org/en/FindUnlinkedFiles), JabRef does not freeze any more. Fixes [#2309]()https://github.com/JabRef/jabref/issues/2309).
 - Collapse and expand all buttons in the group assignment dialog no longer lead to a crash of JabRef.
 - The aux export command line function does no longer add duplicates of references that were resolved via `crossref`. Fixes [#2475](https://github.com/JabRef/jabref/issues/2475). 
+- Parsing of damaged metadata is now more robust and reports a more detailed error message. Fixes [#2477](https://github.com/JabRef/jabref/issues/2477).
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/JabRefGUI.java
+++ b/src/main/java/net/sf/jabref/JabRefGUI.java
@@ -210,7 +210,7 @@ public class JabRefGUI {
             ParserResult parsedDatabase = OpenDatabase.loadDatabase(fileName,
                     Globals.prefs.getImportFormatPreferences());
 
-            if (parsedDatabase.isNullResult()) {
+            if (parsedDatabase.isEmpty()) {
                 LOGGER.error(Localization.lang("Error opening file") + " '" + dbFile.getPath() + "'");
             } else {
                 bibDatabases.add(parsedDatabase);

--- a/src/main/java/net/sf/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/net/sf/jabref/cli/ArgumentProcessor.java
@@ -78,7 +78,7 @@ public class ArgumentProcessor {
     private static Optional<ParserResult> importToOpenBase(String argument) {
         Optional<ParserResult> result = importFile(argument);
 
-        result.ifPresent(x -> x.setToOpenTab());
+        result.ifPresent(ParserResult::setToOpenTab);
 
         return result;
     }
@@ -131,8 +131,7 @@ public class ArgumentProcessor {
                 // * means "guess the format":
                 System.out.println(Localization.lang("Importing in unknown format") + ": " + file);
 
-                ImportFormatReader.UnknownFormatImport importResult;
-                importResult = Globals.IMPORT_FORMAT_READER.importUnknownFormat(file);
+                ImportFormatReader.UnknownFormatImport importResult = Globals.IMPORT_FORMAT_READER.importUnknownFormat(file);
 
                 System.out.println(Localization.lang("Format used") + ": " + importResult.format);
                 return Optional.of(importResult.parserResult);
@@ -308,12 +307,12 @@ public class ArgumentProcessor {
                 // BIB files to open. Other files, and files that could not be opened
                 // as bib, we try to import instead.
                 boolean bibExtension = aLeftOver.toLowerCase(Locale.ENGLISH).endsWith("bib");
-                ParserResult pr = ParserResult.getNullResult();
+                ParserResult pr = new ParserResult();
                 if (bibExtension) {
                     pr = OpenDatabase.loadDatabase(aLeftOver, Globals.prefs.getImportFormatPreferences());
                 }
 
-                if (!bibExtension || (pr.isNullResult())) {
+                if (!bibExtension || (pr.isEmpty())) {
                     // We will try to import this file. Normally we
                     // will import it into a new tab, but if this import has
                     // been initiated by another instance through the remote
@@ -323,7 +322,7 @@ public class ArgumentProcessor {
                     if (startupMode == Mode.INITIAL_START) {
                         toImport.add(aLeftOver);
                     } else {
-                        loaded.add(importToOpenBase(aLeftOver).orElse(ParserResult.getNullResult()));
+                        loaded.add(importToOpenBase(aLeftOver).orElse(new ParserResult()));
                     }
                 } else {
                     loaded.add(pr);

--- a/src/main/java/net/sf/jabref/gui/importer/actions/OpenDatabaseAction.java
+++ b/src/main/java/net/sf/jabref/gui/importer/actions/OpenDatabaseAction.java
@@ -212,7 +212,7 @@ public class OpenDatabaseAction extends MnemonicAwareAction {
                 result = OpenDatabase.loadDatabase(fileToLoad, Globals.prefs.getImportFormatPreferences());
             } catch (IOException ex) {
                 LOGGER.error("Error loading database " + fileToLoad, ex);
-                result = ParserResult.getNullResult();
+                result = new ParserResult();
                 JOptionPane.showMessageDialog(null, Localization.lang("Error opening file") + " '" + fileName + "'",
                         Localization.lang("Error"), JOptionPane.ERROR_MESSAGE);
             }

--- a/src/main/java/net/sf/jabref/logic/importer/OpenDatabase.java
+++ b/src/main/java/net/sf/jabref/logic/importer/OpenDatabase.java
@@ -37,7 +37,7 @@ public class OpenDatabase {
             if (!FileBasedLock.waitForFileLock(file.toPath())) {
                 LOGGER.error(Localization.lang("Error opening file") + " '" + name + "'. "
                         + "File is locked by another JabRef instance.");
-                return ParserResult.getNullResult();
+                return new ParserResult();
             }
 
             ParserResult pr = OpenDatabase.loadDatabase(file, importFormatPreferences);

--- a/src/main/java/net/sf/jabref/logic/importer/OpenDatabase.java
+++ b/src/main/java/net/sf/jabref/logic/importer/OpenDatabase.java
@@ -26,9 +26,9 @@ public class OpenDatabase {
         LOGGER.info("Opening: " + name);
 
         if (!file.exists()) {
-            ParserResult pr = new ParserResult(null, null, null);
+            ParserResult pr = ParserResult.fromErrorMessage(Localization.lang("File not found"));
             pr.setFile(file);
-            pr.setInvalid(true);
+
             LOGGER.error(Localization.lang("Error") + ": " + Localization.lang("File not found"));
             return pr;
         }
@@ -49,10 +49,8 @@ public class OpenDatabase {
             }
             return pr;
         } catch (IOException ex) {
-            ParserResult pr = new ParserResult(null, null, null);
+            ParserResult pr = ParserResult.fromError(ex);
             pr.setFile(file);
-            pr.setInvalid(true);
-            pr.setErrorMessage(ex.getMessage());
             LOGGER.error("Problem opening .bib-file", ex);
             return pr;
         }

--- a/src/main/java/net/sf/jabref/logic/importer/ParserResult.java
+++ b/src/main/java/net/sf/jabref/logic/importer/ParserResult.java
@@ -20,7 +20,6 @@ import net.sf.jabref.model.metadata.MetaData;
 
 public class ParserResult {
 
-    private static final ParserResult NULL_RESULT = new ParserResult();
     private final Map<String, EntryType> entryTypes;
     private final List<String> warnings = new ArrayList<>();
     private final List<String> duplicateKeys = new ArrayList<>();
@@ -61,10 +60,6 @@ public class ParserResult {
             errorMessage += " Caused by: " + exception.getCause().getLocalizedMessage();
         }
         return errorMessage;
-    }
-
-    public static ParserResult getNullResult() {
-        return NULL_RESULT;
     }
 
     public static ParserResult fromError(Exception exception) {
@@ -182,7 +177,7 @@ public class ParserResult {
         file = bibDatabaseContext.getDatabaseFile().orElse(null);
     }
 
-    public boolean isNullResult() {
-        return this == NULL_RESULT;
+    public boolean isEmpty() {
+        return this == new ParserResult();
     }
 }

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/BibTeXMLImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/BibTeXMLImporter.java
@@ -147,7 +147,7 @@ public class BibTeXMLImporter extends Importer {
             }
         } catch (JAXBException e) {
             LOGGER.error("Error with XML parser configuration", e);
-            return ParserResult.fromErrorMessage(e.getLocalizedMessage());
+            return ParserResult.fromError(e);
         }
         return new ParserResult(bibItems);
     }

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/BibtexParser.java
@@ -59,17 +59,16 @@ import org.apache.commons.logging.LogFactory;
 public class BibtexParser implements Parser {
 
     private static final Log LOGGER = LogFactory.getLog(BibtexParser.class);
-
+    private static final Integer LOOKAHEAD = 64;
+    private final FieldContentParser fieldContentParser;
+    private final Deque<Character> pureTextFromFile = new LinkedList<>();
+    private final ImportFormatPreferences importFormatPreferences;
     private PushbackReader pushbackReader;
     private BibDatabase database;
     private Map<String, EntryType> entryTypes;
     private boolean eof;
     private int line = 1;
-    private final FieldContentParser fieldContentParser;
     private ParserResult parserResult;
-    private static final Integer LOOKAHEAD = 64;
-    private final Deque<Character> pureTextFromFile = new LinkedList<>();
-    private final ImportFormatPreferences importFormatPreferences;
 
 
     public BibtexParser(ImportFormatPreferences importFormatPreferences) {
@@ -157,7 +156,7 @@ public class BibtexParser implements Parser {
     private void initializeParserResult() {
         database = new BibDatabase();
         entryTypes = new HashMap<>(); // To store custom entry types parsed.
-        parserResult = new ParserResult(database, null, entryTypes);
+        parserResult = new ParserResult(database, new MetaData(), entryTypes);
     }
 
 
@@ -218,7 +217,7 @@ public class BibtexParser implements Parser {
         try {
             parserResult.setMetaData(MetaDataParser.parse(meta, importFormatPreferences.getKeywordSeparator()));
         } catch (ParseException exception) {
-            parserResult.addWarning(exception.getLocalizedMessage());
+            parserResult.addException(exception);
         }
 
         parseRemainingContent();

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/MedlineImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/MedlineImporter.java
@@ -94,6 +94,9 @@ public class MedlineImporter extends Importer implements Parser {
 
     private static final Locale ENGLISH = Locale.ENGLISH;
 
+    private static String join(List<String> list, String string) {
+        return Joiner.on(string).join(list);
+    }
 
     @Override
     public String getName() {
@@ -177,7 +180,7 @@ public class MedlineImporter extends Importer implements Parser {
             }
         } catch (JAXBException | XMLStreamException e) {
             LOGGER.debug("could not parse document", e);
-            return ParserResult.fromErrorMessage(e.getLocalizedMessage());
+            return ParserResult.fromError(e);
         }
         return new ParserResult(bibItems);
     }
@@ -565,7 +568,6 @@ public class MedlineImporter extends Importer implements Parser {
         }
     }
 
-
     private void addElocationID(Map<String, String> fields, ELocationID eLocationID) {
         if (FieldName.DOI.equals(eLocationID.getEIdType())) {
             fields.put(FieldName.DOI, eLocationID.getContent());
@@ -644,10 +646,6 @@ public class MedlineImporter extends Importer implements Parser {
             }
         }
         fields.put(FieldName.AUTHOR, join(authorNames, " and "));
-    }
-
-    private static String join(List<String> list, String string) {
-        return Joiner.on(string).join(list);
     }
 
     private void addDateRevised(Map<String, String> fields, DateRevised dateRevised) {

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/ModsImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/ModsImporter.java
@@ -106,7 +106,7 @@ public class ModsImporter extends Importer {
             }
         } catch (JAXBException e) {
             LOGGER.debug("could not parse document", e);
-            return ParserResult.fromErrorMessage(e.getLocalizedMessage());
+            return ParserResult.fromError(e);
         }
         return new ParserResult(bibItems);
     }

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/PdfContentImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/PdfContentImporter.java
@@ -41,18 +41,13 @@ import org.apache.pdfbox.util.PDFTextStripper;
 public class PdfContentImporter extends Importer {
 
     private static final Pattern YEAR_EXTRACT_PATTERN = Pattern.compile("\\d{4}");
-
+    private final ImportFormatPreferences importFormatPreferences;
     // input lines into several lines
     private String[] lines;
-
     // current index in lines
     private int i;
-
     private String curString;
-
     private String year;
-
-    private final ImportFormatPreferences importFormatPreferences;
 
 
     public PdfContentImporter(ImportFormatPreferences importFormatPreferences) {
@@ -479,7 +474,7 @@ public class PdfContentImporter extends Importer {
         } catch (EncryptedPdfsNotSupportedException e) {
             return ParserResult.fromErrorMessage(Localization.lang("Decryption not supported."));
         } catch(IOException exception) {
-            return ParserResult.fromErrorMessage(exception.getLocalizedMessage());
+            return ParserResult.fromError(exception);
         } catch (FetcherException e) {
             return ParserResult.fromErrorMessage(e.getMessage());
         }

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/PdfXmpImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/PdfXmpImporter.java
@@ -49,7 +49,7 @@ public class PdfXmpImporter extends Importer {
         try {
             return new ParserResult(XMPUtil.readXMP(filePath, xmpPreferences));
         } catch (IOException exception) {
-            return ParserResult.fromErrorMessage(exception.getLocalizedMessage());
+            return ParserResult.fromError(exception);
         }
     }
 

--- a/src/main/java/net/sf/jabref/logic/importer/util/GroupsParser.java
+++ b/src/main/java/net/sf/jabref/logic/importer/util/GroupsParser.java
@@ -113,18 +113,22 @@ public class GroupsParser {
         }
     }
 
-    public static ExplicitGroup explicitGroupFromString(String s, Character keywordSeparator) throws ParseException {
-        if (!s.startsWith(MetadataSerializationConfiguration.EXPLICIT_GROUP_ID)) {
-            throw new IllegalArgumentException("ExplicitGroup cannot be created from \"" + s + "\".");
+    private static ExplicitGroup explicitGroupFromString(String input, Character keywordSeparator) throws ParseException {
+        if (!input.startsWith(MetadataSerializationConfiguration.EXPLICIT_GROUP_ID)) {
+            throw new IllegalArgumentException("ExplicitGroup cannot be created from \"" + input + "\".");
         }
-        QuotedStringTokenizer tok = new QuotedStringTokenizer(s.substring(MetadataSerializationConfiguration.EXPLICIT_GROUP_ID.length()),
+        QuotedStringTokenizer tok = new QuotedStringTokenizer(input.substring(MetadataSerializationConfiguration.EXPLICIT_GROUP_ID.length()),
                 MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR, MetadataSerializationConfiguration.GROUP_QUOTE_CHAR);
 
         String name = tok.nextToken();
-        int context = Integer.parseInt(tok.nextToken());
-        ExplicitGroup newGroup = new ExplicitGroup(name, GroupHierarchyType.getByNumberOrDefault(context), keywordSeparator);
-        GroupsParser.addLegacyEntryKeys(tok, newGroup);
-        return newGroup;
+        try {
+            int context = Integer.parseInt(tok.nextToken());
+            ExplicitGroup newGroup = new ExplicitGroup(name, GroupHierarchyType.getByNumberOrDefault(context), keywordSeparator);
+            GroupsParser.addLegacyEntryKeys(tok, newGroup);
+            return newGroup;
+        } catch (NumberFormatException exception) {
+            throw new ParseException("Could not parse context in " + input);
+        }
     }
 
     /**
@@ -140,7 +144,7 @@ public class GroupsParser {
         }
     }
 
-    public static AbstractGroup allEntriesGroupFromString(String s) {
+    private static AbstractGroup allEntriesGroupFromString(String s) {
         if (!s.startsWith(MetadataSerializationConfiguration.ALL_ENTRIES_GROUP_ID)) {
             throw new IllegalArgumentException("AllEntriesGroup cannot be created from \"" + s + "\".");
         }
@@ -153,7 +157,7 @@ public class GroupsParser {
      * @param s The String representation obtained from
      *          SearchGroup.toString(), or null if incompatible
      */
-    public static AbstractGroup searchGroupFromString(String s) {
+    private static AbstractGroup searchGroupFromString(String s) {
         if (!s.startsWith(MetadataSerializationConfiguration.SEARCH_GROUP_ID)) {
             throw new IllegalArgumentException("SearchGroup cannot be created from \"" + s + "\".");
         }

--- a/src/test/java/net/sf/jabref/logic/bibtex/BibEntryAssert.java
+++ b/src/test/java/net/sf/jabref/logic/bibtex/BibEntryAssert.java
@@ -65,7 +65,7 @@ public class BibEntryAssert {
             result = parser.parse(reader);
         }
         Assert.assertNotNull(result);
-        Assert.assertFalse(result.isNullResult());
+        Assert.assertFalse(result.isEmpty());
         return result.getDatabase().getEntries();
     }
 

--- a/src/test/java/net/sf/jabref/logic/importer/util/GroupsParserTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/util/GroupsParserTest.java
@@ -1,5 +1,6 @@
 package net.sf.jabref.logic.importer.util;
 
+import net.sf.jabref.logic.importer.ParseException;
 import net.sf.jabref.model.groups.AbstractGroup;
 import net.sf.jabref.model.groups.ExplicitGroup;
 import net.sf.jabref.model.groups.GroupHierarchyType;
@@ -19,4 +20,8 @@ public class GroupsParserTest {
         assertEquals(expected, parsed);
     }
 
+    @Test(expected = ParseException.class)
+    public void fromStringThrowsParseExceptionForNotEscapedGroupName() throws Exception {
+        GroupsParser.fromString("3 ExplicitGroup:slit\\\\;0\\;mertsch_slit2_2007\\;;", ',');
+    }
 }

--- a/src/test/java/net/sf/jabref/logic/importer/util/GroupsParserTest.java
+++ b/src/test/java/net/sf/jabref/logic/importer/util/GroupsParserTest.java
@@ -22,6 +22,6 @@ public class GroupsParserTest {
 
     @Test(expected = ParseException.class)
     public void fromStringThrowsParseExceptionForNotEscapedGroupName() throws Exception {
-        GroupsParser.fromString("3 ExplicitGroup:slit\\\\;0\\;mertsch_slit2_2007\\;;", ',');
+        GroupsParser.fromString("ExplicitGroup:slit\\\\;0\\;mertsch_slit2_2007\\;;", ',');
     }
 }


### PR DESCRIPTION
Fixes https://github.com/JabRef/jabref/issues/2477 in the sense that a more detailed error message is displayed. 
The functional change is https://github.com/JabRef/jabref/pull/2488/files#diff-48e24aa13e9cd41a20bf4e79f4ad7d6bR129, while the rest is a bit of code cleanup (introduction of helper methods, removal of unused code, change public -> private if applicable).

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
