### PR TITLE
Save test reports as build artifacts on circle ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,10 @@ dependencies:
 test:
   override:
     - ./gradlew -Pdev=true -Pinstall4jDir="install4j6" release --stacktrace
+  post:
+    # save test reports as build artifacts
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+    - find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
 
 deployment:
   release:


### PR DESCRIPTION
I just stumbled over https://circleci.com/docs/test-metadata/#gradle-junit-results .
Not sure if we still use circle ci ?!

<!-- describe the changes you have made here: what, why, ... -->

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
