### PR TITLE
Change key binding for cleanup from F8 to ALT+F8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 ### Changed
 - Added the option to update bibliographic information from DOI to the sidebar of the entryeditor. Implements [#2432](https://github.com/JabRef/jabref/issues/2432).
+- The default shortcut for "Cleanup entries" is now <kbd>Alt</kbd> + <kbd>F8</kbd> since <kbd>F8</kbd> alone did not work.
+  Please [reset your key bindings](http://help.jabref.org/en/CustomKeyBindings) to get <kbd>Alt</kbd> + <kbd>F8</kbd> as default.
+  Fixes [#2251](https://github.com/JabRef/jabref/issues/2251).
 
 ### Fixed
 - The formatter for normalizing pages now also can treat ACM pages such as `2:1--2:33`.

--- a/src/main/java/net/sf/jabref/gui/keyboard/KeyBinding.java
+++ b/src/main/java/net/sf/jabref/gui/keyboard/KeyBinding.java
@@ -10,7 +10,7 @@ public enum KeyBinding {
     AUTOMATICALLY_LINK_FILES("Automatically link files", Localization.lang("Automatically set file links"), "F7"),
     BACK("Back", Localization.lang("Back"), "alt LEFT"),
     CHECK_INTEGRITY("Check integrity", Localization.menuTitle("Check integrity"), "ctrl F8"),
-    CLEANUP("Cleanup", Localization.lang("Cleanup entries"), "F8"),
+    CLEANUP("Cleanup", Localization.lang("Cleanup entries"), "alt F8"),
     CLEAR_SEARCH("Clear search", Localization.lang("Clear search"), "ESCAPE"),
     CLOSE_DATABASE("Close database", Localization.lang("Close database"), "ctrl W"),
     CLOSE_DIALOG("Close dialog", Localization.lang("Close dialog"), "ESCAPE"),


### PR DESCRIPTION
Fixes #2251. This solution is the quick solution by changing the shortcut. The alternative is to change the ActionTable etcl.

- [x] Change in CHANGELOG.md described
- [no] Tests created for changes
- [n/a] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [n/a] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [n/a] If you changed the localization: Did you run `gradle localizationUpdate`?
