### PR TITLE
Display LaTeX-free version of field content in entry preview panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
     - All file dialogs now use the native file selector of the OS. [#1711](https://github.com/JabRef/jabref/issues/1711)
 
 ### Fixed
+- LaTeX symbols are now escaped to Unicode in the entry preview panel. Fixes [#2498](https://github.com/JabRef/jabref/issues/2498).
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/logic/layout/LayoutEntry.java
+++ b/src/main/java/net/sf/jabref/logic/layout/LayoutEntry.java
@@ -184,7 +184,7 @@ class LayoutEntry {
         case LayoutHelper.IS_LAYOUT_TEXT:
             return text;
         case LayoutHelper.IS_SIMPLE_FIELD:
-            String value = bibtex.getResolvedFieldOrAlias(text, database).orElse("");
+            String value = bibtex.getResolvedFieldOrAliasLatexFree(text, database).orElse("");
 
             // If a post formatter has been set, call it:
             if (postFormatter != null) {
@@ -223,7 +223,7 @@ class LayoutEntry {
             // changed section begin - arudert
             // resolve field (recognized by leading backslash) or text
             fieldEntry = text.startsWith("\\") ? bibtex
-                    .getResolvedFieldOrAlias(text.substring(1), database)
+                    .getResolvedFieldOrAliasLatexFree(text.substring(1), database)
                     .orElse("") : BibDatabase.getText(text, database);
             // changed section end - arudert
         }
@@ -245,13 +245,13 @@ class LayoutEntry {
     private String handleFieldOrGroupStart(BibEntry bibtex, BibDatabase database) {
         Optional<String> field;
         if (type == LayoutHelper.IS_GROUP_START) {
-            field = bibtex.getResolvedFieldOrAlias(text, database);
+            field = bibtex.getResolvedFieldOrAliasLatexFree(text, database);
         } else if (text.matches(".*(;|(\\&+)).*")) {
             // split the strings along &, && or ; for AND formatter
             String[] parts = text.split("\\s*(;|(\\&+))\\s*");
             field = Optional.empty();
             for (String part : parts) {
-                field = bibtex.getResolvedFieldOrAlias(part, database);
+                field = bibtex.getResolvedFieldOrAliasLatexFree(part, database);
                 if (!field.isPresent()) {
                     break;
                 }
@@ -261,7 +261,7 @@ class LayoutEntry {
             String[] parts = text.split("\\s*(\\|+)\\s*");
             field = Optional.empty();
             for (String part : parts) {
-                field = bibtex.getResolvedFieldOrAlias(part, database);
+                field = bibtex.getResolvedFieldOrAliasLatexFree(part, database);
                 if (field.isPresent()) {
                     break;
                 }


### PR DESCRIPTION
Fixes #2498.

The PR implements a new method in `BibEntry`: `getResolvedFieldOrAliasLatexFree` that builds upon our existing `LatexFree` methods and extends this functionality to resolved fields. This method can be reused in the UI parts of JabRef that should rather display a Unicode version of a field than a LaTeX version, such as the entry preview.

- [X] Change in CHANGELOG.md described
- [X] Manually tested changed features in running JabRef
