### PR TITLE
Fix apostrophe conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
     - All file dialogs now use the native file selector of the OS. [#1711](https://github.com/JabRef/jabref/issues/1711)
 
 ### Fixed
+ - Repairs the handling of apostrophes in the LaTeX to unicode conversion. [#2500](https://github.com/JabRef/jabref/issues/2500)
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/model/strings/HTMLUnicodeConversionMaps.java
+++ b/src/main/java/net/sf/jabref/model/strings/HTMLUnicodeConversionMaps.java
@@ -888,6 +888,7 @@ public class HTMLUnicodeConversionMaps {
         // Manual corrections
         LATEX_HTML_CONVERSION_MAP.put("AA", "&Aring;"); // Overwritten by &angst; which is less supported
         LATEX_UNICODE_CONVERSION_MAP.put("AA", "Å"); // Overwritten by Ångstrom symbol
+        LATEX_UNICODE_CONVERSION_MAP.put("'n", "ń");
 
         // Manual additions
         // Support relax to the extent that it is simply removed

--- a/src/main/java/net/sf/jabref/model/strings/LatexToUnicode.java
+++ b/src/main/java/net/sf/jabref/model/strings/LatexToUnicode.java
@@ -17,6 +17,8 @@ public class LatexToUnicode {
     private static final Pattern P = Pattern.compile("<p>");
     private static final Pattern DOLLAR = Pattern.compile("\\&dollar;");
     private static final Pattern TILDE = Pattern.compile("~");
+    private static final Pattern N_APOSTROPHE_SPECIAL_VERSION_LOWERCASE = Pattern.compile("'n");
+    private static final Pattern N_APOSTROPHE_SPECIAL_VERSION_UPPERCASE = Pattern.compile("'N");
 
     public String format(String inField) {
         if (inField.isEmpty()) {
@@ -28,6 +30,8 @@ public class LatexToUnicode {
         field = P_LATEX.matcher(field).replaceAll("<p>");
         field = DOLLAR_LATEX.matcher(field).replaceAll("&dollar;");
         field = DOLLARS_LATEX.matcher(field).replaceAll("\\{$1\\}");
+        field = N_APOSTROPHE_SPECIAL_VERSION_LOWERCASE.matcher(field).replaceAll("ń");
+        field = N_APOSTROPHE_SPECIAL_VERSION_UPPERCASE.matcher(field).replaceAll("Ń");
 
         StringBuilder sb = new StringBuilder();
         StringBuilder currentCommand = null;
@@ -62,12 +66,6 @@ public class LatexToUnicode {
                     || StringUtil.SPECIAL_COMMAND_CHARS.contains(String.valueOf(c))) {
                 escaped = false;
 
-                // a single ' can also be a command
-                if('\'' == c){
-                    incommand = true;
-                    currentCommand = new StringBuilder();
-                }
-
                 if (!incommand) {
                     sb.append(c);
                 } else {
@@ -89,7 +87,7 @@ public class LatexToUnicode {
                         } else {
                             commandBody = field.substring(i, i + 1);
                         }
-                        String result = fixCollidingCommand(CHARS.get(command + commandBody), c);
+                        String result = CHARS.get(command + commandBody);
 
                         if (result == null) {
                             // Use combining accents if argument is single character or empty
@@ -213,12 +211,4 @@ public class LatexToUnicode {
 
     }
 
-    private String fixCollidingCommand(String currentChar, Character bracket) {
-        // when stripping Latex, there is a collision between unicode characters 324 and 329. Hence, this needs to be checked
-        if (!("ŉ".equals(currentChar) && '{' == bracket)) {
-            return currentChar;
-        } else {
-            return "ń";
-        }
-    }
 }

--- a/src/main/java/net/sf/jabref/model/strings/LatexToUnicode.java
+++ b/src/main/java/net/sf/jabref/model/strings/LatexToUnicode.java
@@ -17,8 +17,7 @@ public class LatexToUnicode {
     private static final Pattern P = Pattern.compile("<p>");
     private static final Pattern DOLLAR = Pattern.compile("\\&dollar;");
     private static final Pattern TILDE = Pattern.compile("~");
-    private static final Pattern N_APOSTROPHE_SPECIAL_VERSION_LOWERCASE = Pattern.compile("'n");
-    private static final Pattern N_APOSTROPHE_SPECIAL_VERSION_UPPERCASE = Pattern.compile("'N");
+    private static final Pattern APOSTROPHE_N = Pattern.compile("(?<!\\\\)'n");
 
     public String format(String inField) {
         if (inField.isEmpty()) {
@@ -30,8 +29,7 @@ public class LatexToUnicode {
         field = P_LATEX.matcher(field).replaceAll("<p>");
         field = DOLLAR_LATEX.matcher(field).replaceAll("&dollar;");
         field = DOLLARS_LATEX.matcher(field).replaceAll("\\{$1\\}");
-        field = N_APOSTROPHE_SPECIAL_VERSION_LOWERCASE.matcher(field).replaceAll("ń");
-        field = N_APOSTROPHE_SPECIAL_VERSION_UPPERCASE.matcher(field).replaceAll("Ń");
+        field = APOSTROPHE_N.matcher(field).replaceAll("ŉ");
 
         StringBuilder sb = new StringBuilder();
         StringBuilder currentCommand = null;

--- a/src/test/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -94,15 +94,21 @@ public class LatexToUnicodeFormatterTest {
     }
 
     @Test
-    public void testApostrophNLongVersion () {
+    public void testAcuteNLongVersion () {
         assertEquals("Maliński", formatter.format("Mali\\'{n}ski"));
         assertEquals("MaliŃski", formatter.format("Mali\\'{N}ski"));
     }
 
     @Test
-    public void testApostrophNShortVersion () {
-        assertEquals("Maliński", formatter.format("Mali'nski"));
-        assertEquals("MaliŃski", formatter.format("Mali'Nski"));
+    public void testAcuteNShortVersion () {
+        assertEquals("Maliński", formatter.format("Mali\\'nski"));
+        assertEquals("MaliŃski", formatter.format("Mali\\'Nski"));
+    }
+
+    @Test
+    public void testApostrophN () {
+        assertEquals("Maliŉski", formatter.format("Mali'nski"));
+        assertEquals("Maliŉski", formatter.format("Mali'Nski"));
     }
 
     @Test

--- a/src/test/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -94,8 +94,24 @@ public class LatexToUnicodeFormatterTest {
     }
 
     @Test
-    public void testApostrophN () {
+    public void testApostrophNLongVersion () {
         assertEquals("Maliński", formatter.format("Mali\\'{n}ski"));
-        assertEquals("Maliŉski", formatter.format("Mali'nski"));
+        assertEquals("MaliŃski", formatter.format("Mali\\'{N}ski"));
+    }
+
+    @Test
+    public void testApostrophNShortVersion () {
+        assertEquals("Maliński", formatter.format("Mali'nski"));
+        assertEquals("MaliŃski", formatter.format("Mali'Nski"));
+    }
+
+    @Test
+    public void testApostrophO () {
+        assertEquals("L'oscillation", formatter.format("L'oscillation"));
+    }
+
+    @Test
+    public void testApostrophC () {
+        assertEquals("O'Connor", formatter.format("O'Connor"));
     }
 }

--- a/src/test/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/net/sf/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -108,7 +108,7 @@ public class LatexToUnicodeFormatterTest {
     @Test
     public void testApostrophN () {
         assertEquals("Maliŉski", formatter.format("Mali'nski"));
-        assertEquals("Maliŉski", formatter.format("Mali'Nski"));
+        assertEquals("Mali'Nski", formatter.format("Mali'Nski"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #2500. This repairs the apostrophe handling in the LaTeX to unicode conversion broken by #2464 and maintains the special handling of apostrophes in conjunction with the character 'n' that #2464 intended to fix. 

It increases complexity and reduces performance in the unicode conversion a tiny bit (through the additional checks that are now in there). Ultimately, the goal should be to replace the conversion with an external library.

- [X] Change in CHANGELOG.md described
- [X] Tests created for changes
- [X] Manually tested changed features in running JabRef