### PR TITLE
Fix journal title in ris importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 ### Fixed
  - Repairs the handling of apostrophes in the LaTeX to unicode conversion. [#2500](https://github.com/JabRef/jabref/issues/2500)
+ - Fix import of journal title in ris format. [#2506](https://github.com/JabRef/jabref/issues/2506)
 
 ### Removed
 

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/RisImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/RisImporter.java
@@ -129,7 +129,11 @@ public class RisImporter extends Importer {
                         fields.put(FieldName.TITLE, fields.get(FieldName.TITLE).replaceAll("\\s+", " ")); // Normalize whitespaces
                     } else if ("BT".equals(tag)) {
                         fields.put(FieldName.BOOKTITLE, value);
-                    } else if ("T2".equals(tag) || "JO".equals(tag)) {
+                    } else if ("T2".equals(tag)&&(fields.get(FieldName.JOURNAL) == null || "".equals(fields.get(FieldName.JOURNAL)))){
+                        //if there is no journal title, then put second title as journal title
+                        fields.put(FieldName.JOURNAL, value);
+                    } else if ("JO".equals(tag)) {
+                        //if this field appears then this should be the journal title
                         fields.put(FieldName.JOURNAL, value);
                     } else if ("T3".equals(tag)) {
                         fields.put(FieldName.SERIES, value);

--- a/src/main/java/net/sf/jabref/logic/importer/fileformat/RisImporter.java
+++ b/src/main/java/net/sf/jabref/logic/importer/fileformat/RisImporter.java
@@ -129,7 +129,7 @@ public class RisImporter extends Importer {
                         fields.put(FieldName.TITLE, fields.get(FieldName.TITLE).replaceAll("\\s+", " ")); // Normalize whitespaces
                     } else if ("BT".equals(tag)) {
                         fields.put(FieldName.BOOKTITLE, value);
-                    } else if ("T2".equals(tag)&&(fields.get(FieldName.JOURNAL) == null || "".equals(fields.get(FieldName.JOURNAL)))){
+                    } else if ("T2".equals(tag) && (fields.get(FieldName.JOURNAL) == null || "".equals(fields.get(FieldName.JOURNAL)))) {
                         //if there is no journal title, then put second title as journal title
                         fields.put(FieldName.JOURNAL, value);
                     } else if ("JO".equals(tag)) {

--- a/src/test/java/net/sf/jabref/logic/importer/fileformat/RISImporterTestFiles.java
+++ b/src/test/java/net/sf/jabref/logic/importer/fileformat/RISImporterTestFiles.java
@@ -41,7 +41,7 @@ public class RISImporterTestFiles {
     public static Collection<String> fileNames() {
         return Arrays.asList("RisImporterTest1", "RisImporterTest3", "RisImporterTest4a", "RisImporterTest4b",
                 "RisImporterTest4c", "RisImporterTest5a", "RisImporterTest5b", "RisImporterTest6",
-                "RisImporterTestDoiAndJournalTitle", "RisImporterTestScopus");
+                "RisImporterTestDoiAndJournalTitle", "RisImporterTestScopus", "RisImporterTestScience");
     }
 
     @Test

--- a/src/test/resources/net/sf/jabref/logic/importer/fileformat/RisImporterTestScience.bib
+++ b/src/test/resources/net/sf/jabref/logic/importer/fileformat/RisImporterTestScience.bib
@@ -1,0 +1,13 @@
+@Article{,
+  author        = {Ghosh, Chanchal and Basu, Joysurya and Ramachandran, Divakar and Mohandas, E.},
+  title         = {Phase separation and ω transformation in binary V-Ti and ternary V-Ti-Cr alloys},
+  journal       = {Acta Materialia},
+  year          = {2016},
+  volume        = {121},
+  pages         = {310--324},
+  month         = dec,
+  issn          = {1359-6454},
+  abstract      = {Abstract},
+  keywords      = {V-Ti-Cr alloys, Spinodal decomposition, ω phase transformation, High-resolution electron microscopy, Energy-filtered transmission microscopy},
+  url           = {//www.sciencedirect.com/science/article/pii/S1359645416307273},
+}

--- a/src/test/resources/net/sf/jabref/logic/importer/fileformat/RisImporterTestScience.ris
+++ b/src/test/resources/net/sf/jabref/logic/importer/fileformat/RisImporterTestScience.ris
@@ -1,0 +1,25 @@
+TY  - JOUR
+T1  - Phase separation and ω transformation in binary V-Ti and ternary V-Ti-Cr alloys
+JO  - Acta Materialia
+VL  - 121
+IS  - 
+SP  - 310
+EP  - 324
+PY  - 2016/12//
+T2  - 
+AU  - Ghosh, Chanchal
+AU  - Basu, Joysurya
+AU  - Ramachandran, Divakar
+AU  - Mohandas, E.
+SN  - 1359-6454
+DO  - http://dx.doi.org/10.1016/j.actamat.2016.09.028
+UR  - //www.sciencedirect.com/science/article/pii/S1359645416307273
+KW  - V-Ti-Cr alloys
+KW  - Spinodal decomposition
+KW  - ω phase transformation
+KW  - High-resolution electron microscopy
+KW  - Energy-filtered transmission microscopy
+AB  - Abstract
+ER  - 
+
+


### PR DESCRIPTION
Fix for #2506.
The problem was that the T2 field was used for the journal title, if it comes first. Now T2 is only used for the journal title, if the field JO does not appear. I've also added the file from science direct as test case.
