### PR TITLE
fix for #2482 deadlock on PDF import

### DIFF
--- a/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
+++ b/src/main/java/net/sf/jabref/pdfimport/PdfImporter.java
@@ -240,7 +240,9 @@ public class PdfImporter {
                 Globals.prefs.getBibtexKeyPatternPreferences());
         DroppedFileHandler dfh = new DroppedFileHandler(frame, panel);
         dfh.linkPdfToEntry(fileName, entry);
-        panel.highlightEntry(entry);
+
+        SwingUtilities.invokeLater(() -> panel.highlightEntry(entry));
+
         if (Globals.prefs.getBoolean(JabRefPreferences.AUTO_OPEN_FORM)) {
             EntryEditor editor = panel.getEntryEditor(entry);
             panel.showEntryEditor(editor);


### PR DESCRIPTION
Prevented deadlock for #2482 when importing PDF by removing UI update via multiple threads.  Likely to be similar resolution for #2489 but insufficient information on non AWT thread to identify where fix should be made.