### PR TITLE
Maintable authors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - The MS-Office XML export now exports the field `volumes` and `pubstate`.
 
 ### Fixed
+ - We fixed an issue where authors with multiple surnames were not presented correctly in the main table [#2534](https://github.com/JabRef/jabref/issues/2534)
  - Repairs the handling of apostrophes in the LaTeX to unicode conversion. [#2500](https://github.com/JabRef/jabref/issues/2500)
  - Fix import of journal title in ris format. [#2506](https://github.com/JabRef/jabref/issues/2506)
  - We fixed the export of the `number` field in MS-Office XML export. [#2509](https://github.com/JabRef/jabref/issues/2509)

--- a/src/main/java/net/sf/jabref/gui/maintable/MainTableColumn.java
+++ b/src/main/java/net/sf/jabref/gui/maintable/MainTableColumn.java
@@ -104,7 +104,7 @@ public class MainTableColumn {
         String result = content.orElse(null);
 
         if (isNameColumn) {
-            result = MainTableNameFormatter.formatName(toUnicode.format(result));
+            result = toUnicode.format(MainTableNameFormatter.formatName(result));
         }
 
         if (result != null) {


### PR DESCRIPTION
Fixes #2534 which resulted in authors with multiple surnames having their names cut off.

- [X] Change in CHANGELOG.md described
- [X] Manually tested changed features in running JabRef