### PR TITLE
Replaced LRUMap with a Guava Cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
     - Font sizes can now be increased <kbd>Ctrl</kbd> + <kbd>Plus</kbd>, decreased <kbd>Ctrl</kbd> + <kbd>Minus</kbd>, and reset to default <kbd>CTRL</kbd> + <kbd>0</kbd>.
 - We integrated support for the [paper recommender system Mr.DLib](http://help.jabref.org/en/EntryEditor#related-articles-tab) in a new tab in the entry editor.
 - We renamed "database" to "library" to have a real distinction to SQL and NoSQL databases. [#2095](https://github.com/JabRef/jabref/issues/2095)
+- Removed the apache.commons.collections library
 
 ### Fixed
  - We fixed an issue where authors with multiple surnames were not presented correctly in the main table. [#2534](https://github.com/JabRef/jabref/issues/2534)

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,6 @@ dependencies {
 
     compile 'commons-logging:commons-logging:1.2'
 
-    compile 'org.apache.commons:commons-collections4:4.0'
     compile 'org.apache.commons:commons-lang3:3.5'
 
     compile 'org.jsoup:jsoup:1.10.2'

--- a/external-libraries.txt
+++ b/external-libraries.txt
@@ -55,11 +55,6 @@ Project: Apache Commons Lang
 URL:     https://commons.apache.org/proper/commons-lang/
 License: Apache-2.0
 
-Id:      org.apache.commons:commons-collections4
-Project: Apache Commons Collections
-URL:     https://commons.apache.org/proper/commons-collections/
-License: Apache-2.0
-
 Id:      com.github.bkromhout:java-diff-utils
 Project: java-diff-utils
 URL:     https://github.com/bkromhout/java-diff-utils

--- a/src/main/java/net/sf/jabref/gui/BasePanel.java
+++ b/src/main/java/net/sf/jabref/gui/BasePanel.java
@@ -206,7 +206,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         this.tableModel = new MainTableDataModel(getBibDatabaseContext());
 
         citationStyleCache = new CitationStyleCache(bibDatabaseContext);
-        annotationCache = new FileAnnotationCache(bibDatabaseContext);
+        annotationCache = new FileAnnotationCache();
 
         setupMainPanel();
 
@@ -2055,6 +2055,10 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         return selectionListener.getPreview();
     }
 
+    public FileAnnotationCache getAnnotationCache() {
+        return annotationCache;
+    }
+
     private static class SearchAndOpenFile {
         private final BibEntry entry;
         private final BasePanel basePanel;
@@ -2346,10 +2350,6 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
             markChangedOrUnChanged();
         }
-    }
-
-    public FileAnnotationCache getAnnotationCache() {
-        return annotationCache;
     }
 
     private class PrintPreviewAction implements BaseAction {

--- a/src/main/java/net/sf/jabref/logic/pdf/FileAnnotationCache.java
+++ b/src/main/java/net/sf/jabref/logic/pdf/FileAnnotationCache.java
@@ -1,43 +1,58 @@
 package net.sf.jabref.logic.pdf;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import net.sf.jabref.model.database.BibDatabaseContext;
 import net.sf.jabref.model.entry.BibEntry;
 import net.sf.jabref.model.pdf.FileAnnotation;
 
-import org.apache.commons.collections4.map.LRUMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
 
 public class FileAnnotationCache {
 
     //cache size in entries
-    final static int CACHE_SIZE = 10;
-    //the inner list holds the annotations of a file, the outer list holds such a list for every file attached to an entry
-    LRUMap<BibEntry, Map<String, List<FileAnnotation>>> annotationCache;
+    private final static int CACHE_SIZE = 10;
+    //the inner list holds the annotations per file, the outer collection maps this to a BibEntry.
+    LoadingCache<BibEntry, Map<String, List<FileAnnotation>>> annotationCache;
     BibDatabaseContext bibDatabaseContext;
 
     public FileAnnotationCache(BibDatabaseContext bibDatabaseContext) {
         this.bibDatabaseContext = bibDatabaseContext;
-        annotationCache  = new LRUMap<>(CACHE_SIZE);
+        annotationCache = CacheBuilder.newBuilder().maximumSize(CACHE_SIZE).build(new CacheLoader<BibEntry, Map<String, List<FileAnnotation>>>() {
+
+            @Override
+            public Map<String, List<FileAnnotation>> load(BibEntry entry) throws Exception {
+                // Automated reloading of entries is not supported.
+                return new HashMap<>();
+            }
+        });
     }
 
-    public void addToCache(BibEntry entry, final Map<String, List<FileAnnotation>> annotations){
+    public void addToCache(BibEntry entry, final Map<String, List<FileAnnotation>> annotations) {
         annotationCache.put(entry, annotations);
     }
 
     /**
      * Note that entry becomes the most recent entry in the cache
+     *
      * @param entry entry for which to get the annotations
      * @return Map containing a list of annotations in a list for each file
      */
     public Optional<Map<String, List<FileAnnotation>>> getFromCache(Optional<BibEntry> entry) {
-        Optional<Map<String, List<FileAnnotation>>> cachedAnnotations = Optional.empty();
-        if(entry.isPresent() && annotationCache.containsKey(entry.get())){
-            return Optional.of(annotationCache.get(entry.get()));
-        } else {
-            return cachedAnnotations;
+        Optional<Map<String, List<FileAnnotation>>> emptyAnnotation = Optional.empty();
+        try {
+            if (entry.isPresent() && annotationCache.get(entry.get()).size() > 0) {
+                return Optional.of(annotationCache.get(entry.get()));
+            }
+        } catch (ExecutionException failure) {
+            return emptyAnnotation;
         }
+        return emptyAnnotation;
     }
 }

--- a/src/main/java/net/sf/jabref/logic/pdf/FileAnnotationCache.java
+++ b/src/main/java/net/sf/jabref/logic/pdf/FileAnnotationCache.java
@@ -1,33 +1,29 @@
 package net.sf.jabref.logic.pdf;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import net.sf.jabref.model.database.BibDatabaseContext;
-import net.sf.jabref.model.entry.BibEntry;
-import net.sf.jabref.model.pdf.FileAnnotation;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
+import net.sf.jabref.model.entry.BibEntry;
+import net.sf.jabref.model.pdf.FileAnnotation;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 
 public class FileAnnotationCache {
 
     //cache size in entries
     private final static int CACHE_SIZE = 10;
     //the inner list holds the annotations per file, the outer collection maps this to a BibEntry.
-    LoadingCache<BibEntry, Map<String, List<FileAnnotation>>> annotationCache;
-    BibDatabaseContext bibDatabaseContext;
+    private LoadingCache<BibEntry, Map<String, List<FileAnnotation>>> annotationCache;
 
-    public FileAnnotationCache(BibDatabaseContext bibDatabaseContext) {
-        this.bibDatabaseContext = bibDatabaseContext;
+    public FileAnnotationCache() {
         annotationCache = CacheBuilder.newBuilder().maximumSize(CACHE_SIZE).build(new CacheLoader<BibEntry, Map<String, List<FileAnnotation>>>() {
-
             @Override
-            public Map<String, List<FileAnnotation>> load(BibEntry entry) throws Exception {
+            public Map<String, List<FileAnnotation>> load(BibEntry notUsed) throws Exception {
                 // Automated reloading of entries is not supported.
                 return new HashMap<>();
             }


### PR DESCRIPTION
This is intended as a fix for #2546.

Note that the Guava Caches would allow for automated reloading of the entries, but this is not undertaken in this implementation. Instead everything should work as before with the LRUMap.

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)