### PR TITLE
Reorder pferences tab to be more intuitive

### DIFF
--- a/src/main/java/net/sf/jabref/gui/preftabs/ExportSettingsTab.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/ExportSettingsTab.java
@@ -19,7 +19,7 @@ import com.jgoodies.forms.layout.FormLayout;
 /**
  * Preference tab for file sorting options.
  */
-class FileSortTab extends JPanel implements PrefsTab {
+class ExportSettingsTab extends JPanel implements PrefsTab {
 
     private final JabRefPreferences prefs;
 
@@ -29,7 +29,7 @@ class FileSortTab extends JPanel implements PrefsTab {
     private final SaveOrderConfigDisplay exportOrderPanel;
 
 
-    public FileSortTab(JabRefPreferences prefs) {
+    public ExportSettingsTab(JabRefPreferences prefs) {
         this.prefs = prefs;
         FormLayout layout = new FormLayout("4dlu, left:pref, 4dlu, fill:pref", "");
         DefaultFormBuilder builder = new DefaultFormBuilder(layout);

--- a/src/main/java/net/sf/jabref/gui/preftabs/PreferencesDialog.java
+++ b/src/main/java/net/sf/jabref/gui/preftabs/PreferencesDialog.java
@@ -83,21 +83,21 @@ public class PreferencesDialog extends JDialog {
 
         List<PrefsTab> tabs = new ArrayList<>();
         tabs.add(new GeneralTab(prefs));
-        tabs.add(new NetworkTab(prefs));
         tabs.add(new FileTab(frame, prefs));
-        tabs.add(new FileSortTab(prefs));
-        tabs.add(new EntryEditorPrefsTab(prefs));
-        tabs.add(new GroupsPrefsTab(prefs));
-        tabs.add(new AppearancePrefsTab(prefs));
-        tabs.add(new ExternalTab(frame, this, prefs));
         tabs.add(new TablePrefsTab(prefs));
         tabs.add(new TableColumnsTab(prefs, parent));
-        tabs.add(new BibtexKeyPatternPrefTab(prefs, parent.getCurrentBasePanel()));
         tabs.add(new PreviewPrefsTab());
-        tabs.add(new NameFormatterTab(prefs));
+        tabs.add(new ExternalTab(frame, this, prefs));
+        tabs.add(new GroupsPrefsTab(prefs));
+        tabs.add(new EntryEditorPrefsTab(prefs));
+        tabs.add(new BibtexKeyPatternPrefTab(prefs, parent.getCurrentBasePanel()));
         tabs.add(new ImportSettingsTab(prefs));
+        tabs.add(new ExportSettingsTab(prefs));
+        tabs.add(new NameFormatterTab(prefs));
         tabs.add(new XmpPrefsTab(prefs));
+        tabs.add(new NetworkTab(prefs));
         tabs.add(new AdvancedTab(prefs));
+        tabs.add(new AppearancePrefsTab(prefs));
 
         // add all tabs
         tabs.forEach(tab -> main.add((Component) tab, tab.getTabName()));


### PR DESCRIPTION
I reordered the preferences tab as the current ordering made no sense to me.

![grafik](https://cloud.githubusercontent.com/assets/1366654/23041309/cdaac352-f494-11e6-815a-daf66cb6950a.png)

We currently don't have a help on the preferences screen. So, it is not urgent to update the help pages. I found http://help.jabref.org/en/Autosave#activation, but the users will find the preference as I did not change the titles.