### PR TITLE
Remove groups edit mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
     - Redesigned group panel.
       - Number of matched entries is always shown.
       - The background color of the hit counter signals whether the group contains all/any of the entries selected in the main table. 
+      - Removed edit mode.
     - Redesigned about dialog.
     - Redesigned key bindings dialog.
     - Redesigned journal abbreviations dialog.

--- a/src/main/java/org/jabref/gui/groups/GroupSelector.java
+++ b/src/main/java/org/jabref/gui/groups/GroupSelector.java
@@ -1,8 +1,6 @@
 package org.jabref.gui.groups;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -32,7 +30,6 @@ import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
-import javax.swing.border.TitledBorder;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.PopupMenuEvent;
@@ -100,8 +97,6 @@ public class GroupSelector extends SidePaneComponent implements TreeSelectionLis
             Localization.lang("Highlight overlapping groups"));
     private final JCheckBoxMenuItem autoAssignGroup = new JCheckBoxMenuItem(
             Localization.lang("Automatically assign new entry to selected groups"));
-    private final JCheckBoxMenuItem editModeCb = new JCheckBoxMenuItem(Localization.lang("Edit group membership"),
-            false);
     private final JMenu moveSubmenu = new JMenu(Localization.lang("Move"));
     private final JMenu sortSubmenu = new JMenu(Localization.lang("Sort alphabetically"));
     private final AbstractAction editGroupAction = new EditGroupAction();
@@ -124,8 +119,6 @@ public class GroupSelector extends SidePaneComponent implements TreeSelectionLis
     private final ToggleAction toggleAction;
     private DefaultTreeModel groupsTreeModel;
     private GroupTreeNodeViewModel groupsRoot;
-    private boolean editModeIndicator;
-
 
     /**
      * The first element for each group defines which field to use for the quicksearch. The next two define the name and
@@ -188,8 +181,6 @@ public class GroupSelector extends SidePaneComponent implements TreeSelectionLis
 
         invCb.setSelected(Globals.prefs.getBoolean(JabRefPreferences.GROUP_INVERT_SELECTIONS));
         showOverlappingGroups.setSelected(Globals.prefs.getBoolean(JabRefPreferences.GROUP_SHOW_OVERLAPPING));
-        editModeIndicator = Globals.prefs.getBoolean(JabRefPreferences.EDIT_GROUP_MEMBERSHIP_MODE);
-        editModeCb.setSelected(editModeIndicator);
         autoAssignGroup.setSelected(Globals.prefs.getBoolean(JabRefPreferences.AUTO_ASSIGN_GROUP));
 
         JButton openSettings = new JButton(IconTheme.JabRefIcon.PREFERENCES.getSmallIcon());
@@ -197,8 +188,6 @@ public class GroupSelector extends SidePaneComponent implements TreeSelectionLis
         settings.add(orCb);
         settings.addSeparator();
         settings.add(invCb);
-        settings.addSeparator();
-        settings.add(editModeCb);
         settings.addSeparator();
         settings.add(grayOut);
         settings.add(hideNonHits);
@@ -213,9 +202,6 @@ public class GroupSelector extends SidePaneComponent implements TreeSelectionLis
                 settings.show(src, 0, openSettings.getHeight());
             }
         });
-
-        editModeCb.addActionListener(e -> setEditMode(editModeCb.getState()));
-
 
         JButton helpButton = new HelpAction(Localization.lang("Help on groups"), HelpFile.GROUP)
                 .getHelpButton();
@@ -247,7 +233,6 @@ public class GroupSelector extends SidePaneComponent implements TreeSelectionLis
                 Localization.lang("Highlight groups that contain entries contained in any currently selected group"));
         floatCb.setToolTipText(Localization.lang("Move entries in group selection to the top"));
         highlCb.setToolTipText(Localization.lang("Gray out entries not in group selection"));
-        editModeCb.setToolTipText(Localization.lang("Click group to toggle membership of selected entries"));
         ButtonGroup bgr = new ButtonGroup();
         bgr.add(andCb);
         bgr.add(orCb);
@@ -296,7 +281,8 @@ public class GroupSelector extends SidePaneComponent implements TreeSelectionLis
         rootPanel.add(groupsTreePane);
 
         add(rootPanel, BorderLayout.CENTER);
-        setEditMode(editModeIndicator);
+        groupsTree.setBorder(BorderFactory.createEmptyBorder(5, 10, 0, 0));
+        this.setTitle(Localization.lang("Groups"));
         definePopup();
         NodeAction moveNodeUpAction = new MoveNodeUpAction();
         moveNodeUpAction.putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_UP, InputEvent.CTRL_MASK));
@@ -380,8 +366,6 @@ public class GroupSelector extends SidePaneComponent implements TreeSelectionLis
                 }
                 if ((e.getClickCount() == 2) && (e.getButton() == MouseEvent.BUTTON1)) { // edit
                     editGroupAction.actionPerformed(null); // dummy event
-                } else if ((e.getClickCount() == 1) && (e.getButton() == MouseEvent.BUTTON1)) {
-                    annotationEvent(node);
                 }
             }
         });
@@ -494,34 +478,6 @@ public class GroupSelector extends SidePaneComponent implements TreeSelectionLis
         groupsContextMenu.show(groupsTree, e.getPoint().x, e.getPoint().y);
     }
 
-    private void setEditMode(boolean editMode) {
-        Globals.prefs.putBoolean(JabRefPreferences.EDIT_GROUP_MEMBERSHIP_MODE, editModeIndicator);
-        editModeIndicator = editMode;
-
-        if (editMode) {
-            groupsTree.setBorder(BorderFactory
-                    .createTitledBorder(BorderFactory.createMatteBorder(2, 2, 2, 2, Color.RED), "Edit mode",
-                            TitledBorder.RIGHT, TitledBorder.TOP, Font.getFont("Default"), Color.RED));
-            this.setTitle("<html><font color='red'>Groups Edit mode</font></html>");
-        } else {
-            groupsTree.setBorder(BorderFactory.createEmptyBorder(5,10,0,0));
-            this.setTitle(Localization.lang("Groups"));
-        }
-        groupsTree.revalidate();
-        groupsTree.repaint();
-    }
-
-    private void annotationEvent(GroupTreeNodeViewModel node) {
-        if (editModeIndicator) {
-            LOGGER.info("Performing annotation " + node.getName());
-            List<BibEntry> entries = panel.getSelectedEntries();
-            node.changeEntriesTo(entries, panel.getUndoManager());
-            panel.markBaseChanged();
-            panel.updateEntryEditorIfShowing();
-            updateShownEntriesAccordingToSelectedGroups();
-        }
-    }
-
     @Override
     public void valueChanged(TreeSelectionEvent e) {
         if (panel == null) {
@@ -536,9 +492,7 @@ public class GroupSelector extends SidePaneComponent implements TreeSelectionLis
             return;
         }
 
-        if (!editModeIndicator) {
-            updateShownEntriesAccordingToSelectedGroups();
-        }
+        updateShownEntriesAccordingToSelectedGroups();
     }
 
     private void updateShownEntriesAccordingToSelectedGroups() {

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -191,7 +191,6 @@ public class JabRefPreferences {
     public static final String GROUP_INVERT_SELECTIONS = "groupInvertSelections";
     public static final String GROUP_INTERSECT_SELECTIONS = "groupIntersectSelections";
     public static final String GROUP_FLOAT_SELECTIONS = "groupFloatSelections";
-    public static final String EDIT_GROUP_MEMBERSHIP_MODE = "groupEditGroupMembershipMode";
     public static final String KEYWORD_SEPARATOR = "groupKeywordSeparator";
     public static final String AUTO_ASSIGN_GROUP = "autoAssignGroup";
     public static final String LIST_OF_FILE_COLUMNS = "listOfFileColumns";
@@ -392,7 +391,8 @@ public class JabRefPreferences {
     private static final String PREVIEW_ENABLED = "previewEnabled";
     // Helper string
     private static final String USER_HOME = System.getProperty("user.home");
-
+    // solves the issue java.lang.RuntimeException: Internal graphics not initialized yet
+    private final static Integer UNSET_MENU_FONT_SIZE = -123;
     // The only instance of this class:
     private static JabRefPreferences singleton;
     /**
@@ -416,9 +416,6 @@ public class JabRefPreferences {
     private GlobalBibtexKeyPattern keyPattern;
     // Object containing info about customized entry editor tabs.
     private EntryEditorTabList tabList;
-
-    // solves the issue java.lang.RuntimeException: Internal graphics not initialized yet
-    private final static Integer UNSET_MENU_FONT_SIZE = -123;
 
     // The constructor is made private to enforce this as a singleton class:
     private JabRefPreferences() {
@@ -578,7 +575,6 @@ public class JabRefPreferences {
         defaults.put(GROUP_EXPAND_TREE, Boolean.TRUE);
         defaults.put(AUTO_ASSIGN_GROUP, Boolean.TRUE);
         defaults.put(KEYWORD_SEPARATOR, ", ");
-        defaults.put(EDIT_GROUP_MEMBERSHIP_MODE, Boolean.FALSE);
         defaults.put(TOOLBAR_VISIBLE, Boolean.TRUE);
         defaults.put(DEFAULT_ENCODING, StandardCharsets.UTF_8.name());
         defaults.put(DEFAULT_OWNER, System.getProperty("user.name"));


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

In the edit mode, you were able to select a few entries and assign them to a group with a single click.
As I think that drag&drop and the special "add to groups" dialog provide sufficient facilities to add entries to groups, I hereby propose to remove this "feature".  

Resolves https://github.com/JabRef/jabref/issues/1550.

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
