### PR TITLE
Keyword - Special field synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - We fixed the import of MS-Office XML files, when the `month` field contained an invalid value.
  - ArXiV fetcher now checks similarity of entry when using DOI retrieval to avoid false positives [#2575](https://github.com/JabRef/jabref/issues/2575)
  - Sciencedirect/Elsevier fetcher is now able to scrape new HTML structure [#2576](https://github.com/JabRef/jabref/issues/2576)
- 
+ - Fixed the synchronization logic of keywords and special fields and vice versa [#2580](https://github.com/JabRef/jabref/issues/2580)
  
  
 ### Removed

--- a/src/main/java/org/jabref/gui/FileDialog.java
+++ b/src/main/java/org/jabref/gui/FileDialog.java
@@ -35,7 +35,6 @@ import org.apache.commons.logging.LogFactory;
  */
 @Deprecated
 public class FileDialog {
-
     private static final Log LOGGER = LogFactory.getLog(FileDialog.class);
 
     private final FileChooser fileChooser;

--- a/src/main/java/org/jabref/gui/specialfields/SpecialFieldDatabaseChangeListener.java
+++ b/src/main/java/org/jabref/gui/specialfields/SpecialFieldDatabaseChangeListener.java
@@ -26,19 +26,19 @@ public class SpecialFieldDatabaseChangeListener {
 
     @Subscribe
     public void listen(EntryAddedEvent event) {
-        if (Globals.prefs.isKeywordSyncEnabled()) {
-            final BibEntry entry = event.getBibEntry();
-            // NamedCompount code similar to SpecialFieldUpdateListener
-            NamedCompound nc = new NamedCompound(Localization.lang("Synchronized special fields based on keywords"));
-            List<FieldChange> changes = SpecialFieldsUtils.syncSpecialFieldsFromKeywords(entry, Globals.prefs.getKeywordDelimiter());
-            for(FieldChange change: changes) {
-                nc.addEdit(new UndoableFieldChange(change));
-            }
-
-            // Don't insert the compound into the undoManager,
-            // it would be added before the component which undoes the insertion of the entry and creates heavy problems
-            // (which prohibits the undo the deleting multiple entries)
+        if (!Globals.prefs.isKeywordSyncEnabled()) {
+            return;
         }
-    }
 
+        final BibEntry entry = event.getBibEntry();
+        // NamedCompount code similar to SpecialFieldUpdateListener
+        NamedCompound nc = new NamedCompound(Localization.lang("Synchronized special fields based on keywords"));
+        List<FieldChange> changes = SpecialFieldsUtils.syncSpecialFieldsFromKeywords(entry, Globals.prefs.getKeywordDelimiter());
+        for(FieldChange change: changes) {
+            nc.addEdit(new UndoableFieldChange(change));
+        }
+        // Don't insert the compound into the undoManager,
+        // it would be added before the component which undoes the insertion of the entry and creates heavy problems
+        // (which prohibits the undo the deleting multiple entries)
+    }
 }

--- a/src/main/java/org/jabref/gui/specialfields/SpecialFieldUpdateListener.java
+++ b/src/main/java/org/jabref/gui/specialfields/SpecialFieldUpdateListener.java
@@ -23,6 +23,11 @@ public class SpecialFieldUpdateListener {
 
     @Subscribe
     public void listen(FieldChangedEvent fieldChangedEvent) {
+        // only sync if keyword sync is enabled
+        if (!Globals.prefs.isKeywordSyncEnabled()) {
+            return;
+        }
+
         final BibEntry entry = fieldChangedEvent.getBibEntry();
         final String fieldName = fieldChangedEvent.getFieldName();
         // Source editor cycles through all entries
@@ -32,15 +37,10 @@ public class SpecialFieldUpdateListener {
         SwingUtilities.invokeLater(() -> {
             if (FieldName.KEYWORDS.equals(fieldName)) {
                 SpecialFieldsUtils.syncSpecialFieldsFromKeywords(entry, Globals.prefs.getKeywordDelimiter());
-                SwingUtilities
-                        .invokeLater(() -> JabRefGUI.getMainFrame().getCurrentBasePanel().updateEntryEditorIfShowing());
-            } else {
-                if (SpecialField.isSpecialField(fieldName)) {
-                    SpecialFieldsUtils.syncKeywordsFromSpecialFields(entry, Globals.prefs.isKeywordSyncEnabled(), Globals.prefs.getKeywordDelimiter());
-                    SwingUtilities.invokeLater(
-                            () -> JabRefGUI.getMainFrame().getCurrentBasePanel().updateEntryEditorIfShowing());
-                }
+            } else if (SpecialField.isSpecialField(fieldName)) {
+                SpecialFieldsUtils.syncKeywordsFromSpecialFields(entry, Globals.prefs.getKeywordDelimiter());
             }
+            SwingUtilities.invokeLater(() -> JabRefGUI.getMainFrame().getCurrentBasePanel().updateEntryEditorIfShowing());
         });
     }
 

--- a/src/main/java/org/jabref/logic/importer/OpenDatabase.java
+++ b/src/main/java/org/jabref/logic/importer/OpenDatabase.java
@@ -3,7 +3,6 @@ package org.jabref.logic.importer;
 import java.io.File;
 import java.io.IOException;
 
-import org.jabref.Globals;
 import org.jabref.logic.importer.fileformat.BibtexImporter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.specialfields.SpecialFieldsUtils;
@@ -67,9 +66,7 @@ public class OpenDatabase {
 
         if (importFormatPreferences.isKeywordSyncEnabled()) {
             for (BibEntry entry : result.getDatabase().getEntries()) {
-                if (Globals.prefs.isKeywordSyncEnabled()) {
-                    SpecialFieldsUtils.syncSpecialFieldsFromKeywords(entry, importFormatPreferences.getKeywordSeparator());
-                }
+                SpecialFieldsUtils.syncSpecialFieldsFromKeywords(entry, importFormatPreferences.getKeywordSeparator());
             }
             LOGGER.debug("Synchronized special fields based on keywords");
         }

--- a/src/main/java/org/jabref/logic/importer/OpenDatabase.java
+++ b/src/main/java/org/jabref/logic/importer/OpenDatabase.java
@@ -3,6 +3,7 @@ package org.jabref.logic.importer;
 import java.io.File;
 import java.io.IOException;
 
+import org.jabref.Globals;
 import org.jabref.logic.importer.fileformat.BibtexImporter;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.specialfields.SpecialFieldsUtils;
@@ -66,7 +67,9 @@ public class OpenDatabase {
 
         if (importFormatPreferences.isKeywordSyncEnabled()) {
             for (BibEntry entry : result.getDatabase().getEntries()) {
-                SpecialFieldsUtils.syncSpecialFieldsFromKeywords(entry, importFormatPreferences.getKeywordSeparator());
+                if (Globals.prefs.isKeywordSyncEnabled()) {
+                    SpecialFieldsUtils.syncSpecialFieldsFromKeywords(entry, importFormatPreferences.getKeywordSeparator());
+                }
             }
             LOGGER.debug("Synchronized special fields based on keywords");
         }

--- a/src/main/java/org/jabref/logic/specialfields/SpecialFieldsUtils.java
+++ b/src/main/java/org/jabref/logic/specialfields/SpecialFieldsUtils.java
@@ -35,17 +35,15 @@ public class SpecialFieldsUtils {
         UpdateField.updateField(entry, field.getFieldName(), value, nullFieldIfValueIsTheSame)
                 .ifPresent(fieldChange -> fieldChanges.add(fieldChange));
         // we cannot use "value" here as updateField has side effects: "nullFieldIfValueIsTheSame" nulls the field if value is the same
-        fieldChanges.addAll(SpecialFieldsUtils.exportFieldToKeywords(field, entry, isKeywordSyncEnabled, keywordDelimiter));
+        if (isKeywordSyncEnabled) {
+            fieldChanges.addAll(SpecialFieldsUtils.exportFieldToKeywords(field, entry, keywordDelimiter));
+        }
 
         return fieldChanges;
     }
 
-    private static List<FieldChange> exportFieldToKeywords(SpecialField specialField, BibEntry entry, boolean isKeywordSyncEnabled, Character keywordDelimiter) {
+    private static List<FieldChange> exportFieldToKeywords(SpecialField specialField, BibEntry entry, Character keywordDelimiter) {
         List<FieldChange> fieldChanges = new ArrayList<>();
-
-        if (!isKeywordSyncEnabled) {
-            return fieldChanges;
-        }
 
         Optional<Keyword> newValue = entry.getField(specialField.getFieldName()).map(Keyword::new);
         KeywordList keyWords = specialField.getKeyWords();
@@ -59,11 +57,11 @@ public class SpecialFieldsUtils {
     /**
      * Update keywords according to values of special fields
      */
-    public static List<FieldChange> syncKeywordsFromSpecialFields(BibEntry entry, boolean isKeywordSyncEnabled, Character keywordDelimiter) {
+    public static List<FieldChange> syncKeywordsFromSpecialFields(BibEntry entry, Character keywordDelimiter) {
         List<FieldChange> fieldChanges = new ArrayList<>();
 
         for(SpecialField field: SpecialField.values()) {
-            fieldChanges.addAll(SpecialFieldsUtils.exportFieldToKeywords(field, entry, isKeywordSyncEnabled, keywordDelimiter));
+            fieldChanges.addAll(SpecialFieldsUtils.exportFieldToKeywords(field, entry, keywordDelimiter));
         }
 
         return fieldChanges;
@@ -71,6 +69,7 @@ public class SpecialFieldsUtils {
 
     private static List<FieldChange> importKeywordsForField(KeywordList keywordList, SpecialField field, BibEntry entry) {
         List<FieldChange> fieldChanges = new ArrayList<>();
+
         KeywordList values = field.getKeyWords();
         Optional<Keyword> newValue = Optional.empty();
         for (Keyword keyword : values) {
@@ -88,7 +87,7 @@ public class SpecialFieldsUtils {
     }
 
     /**
-     * updates field values according to keywords
+     * Updates special field values according to keywords
      */
     public static List<FieldChange> syncSpecialFieldsFromKeywords(BibEntry entry, Character keywordDelimiter) {
         List<FieldChange> fieldChanges = new ArrayList<>();

--- a/src/test/java/org/jabref/logic/specialfields/SpecialFieldsUtilsTest.java
+++ b/src/test/java/org/jabref/logic/specialfields/SpecialFieldsUtilsTest.java
@@ -19,7 +19,7 @@ public class SpecialFieldsUtilsTest {
     public void syncKeywordsFromSpecialFieldsWritesToKeywords() {
         BibEntry entry = new BibEntry();
         entry.setField("ranking", "rank2");
-        SpecialFieldsUtils.syncKeywordsFromSpecialFields(entry, true, ',');
+        SpecialFieldsUtils.syncKeywordsFromSpecialFields(entry, ',');
         assertEquals(Optional.of("rank2"), entry.getField("keywords"));
     }
 
@@ -27,7 +27,7 @@ public class SpecialFieldsUtilsTest {
     public void syncKeywordsFromSpecialFieldsCausesChange() {
         BibEntry entry = new BibEntry();
         entry.setField("ranking", "rank2");
-        List<FieldChange> changes = SpecialFieldsUtils.syncKeywordsFromSpecialFields(entry, true, ',');
+        List<FieldChange> changes = SpecialFieldsUtils.syncKeywordsFromSpecialFields(entry, ',');
         assertTrue(changes.size() > 0);
     }
 
@@ -36,14 +36,14 @@ public class SpecialFieldsUtilsTest {
         BibEntry entry = new BibEntry();
         entry.setField("ranking", "rank2");
         entry.setField("keywords", "rank3");
-        SpecialFieldsUtils.syncKeywordsFromSpecialFields(entry, true, ',');
+        SpecialFieldsUtils.syncKeywordsFromSpecialFields(entry, ',');
         assertEquals(Optional.of("rank2"), entry.getField("keywords"));
     }
 
     @Test
     public void syncKeywordsFromSpecialFieldsForEmptyFieldCausesNoChange() {
         BibEntry entry = new BibEntry();
-        List<FieldChange> changes = SpecialFieldsUtils.syncKeywordsFromSpecialFields(entry, true, ',');
+        List<FieldChange> changes = SpecialFieldsUtils.syncKeywordsFromSpecialFields(entry, ',');
         assertFalse(changes.size() > 0);
     }
 


### PR DESCRIPTION
Fixes #2580 
Synch should now work appropriately.

Few questions here @koppor and all others:

- [x] If keyword sync is enabled, there is the possibility that we have multiple `rank1, rank4` keywords.
Only the first one is synched with the special field. Was this always like this? Seems like a bug to me. 

- [x] If we change the preferences from write special fields to file to keyword synchronization the data gets lost. Did I introduce this or was this a bug?
