### PR TITLE
Fix pdf file import when only one file selected and no entry created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - ArXiV fetcher now checks similarity of entry when using DOI retrieval to avoid false positives [#2575](https://github.com/JabRef/jabref/issues/2575)
  - Sciencedirect/Elsevier fetcher is now able to scrape new HTML structure [#2576](https://github.com/JabRef/jabref/issues/2576)
  - Fixed the synchronization logic of keywords and special fields and vice versa [#2580](https://github.com/JabRef/jabref/issues/2580)
- 
+ - We fixed an issue where the "find unlinked files" functionality threw an error when only one PDF was imported but not assigned to an entry [#2577](https://github.com/JabRef/jabref/issues/2577)
  
 ### Removed
 

--- a/src/main/java/org/jabref/pdfimport/PdfImporter.java
+++ b/src/main/java/org/jabref/pdfimport/PdfImporter.java
@@ -64,29 +64,24 @@ public class PdfImporter {
         this.dropRow = dropRow;
     }
 
-
     public class ImportPdfFilesResult {
 
         private final List<String> noPdfFiles;
         private final List<BibEntry> entries;
-
 
         public ImportPdfFilesResult(List<String> noPdfFiles, List<BibEntry> entries) {
             this.noPdfFiles = noPdfFiles;
             this.entries = entries;
         }
 
-
         public List<String> getNoPdfFiles() {
             return noPdfFiles;
         }
-
 
         public List<BibEntry> getEntries() {
             return entries;
         }
     }
-
 
     /**
      *
@@ -128,7 +123,6 @@ public class PdfImporter {
         boolean neverShow = Globals.prefs.getBoolean(JabRefPreferences.IMPORT_ALWAYSUSE);
         int globalChoice = Globals.prefs.getInt(JabRefPreferences.IMPORT_DEFAULT_PDF_IMPORT_STYLE);
 
-
         List<BibEntry> res = new ArrayList<>();
 
         for (String fileName : fileNames) {
@@ -156,7 +150,11 @@ public class PdfImporter {
                     break;
                 case ImportDialog.ONLYATTACH:
                     DroppedFileHandler dfh = new DroppedFileHandler(frame, panel);
-                    dfh.linkPdfToEntry(fileName, entryTable, dropRow);
+                    if (dropRow >= 0) {
+                        dfh.linkPdfToEntry(fileName, entryTable, dropRow);
+                    } else {
+                        dfh.linkPdfToEntry(fileName, entryTable, entryTable.getSelectedRow());
+                    }
                     break;
                 default:
                     break;
@@ -236,7 +234,8 @@ public class PdfImporter {
         panel.getDatabase().insertEntry(entry);
         panel.markBaseChanged();
         BibtexKeyPatternUtil.makeAndSetLabel(panel.getBibDatabaseContext().getMetaData()
-                .getCiteKeyPattern(Globals.prefs.getBibtexKeyPatternPreferences().getKeyPattern()), panel.getDatabase(), entry,
+                .getCiteKeyPattern(Globals.prefs.getBibtexKeyPatternPreferences().getKeyPattern()), panel.getDatabase(),
+                entry,
                 Globals.prefs.getBibtexKeyPatternPreferences());
         DroppedFileHandler dfh = new DroppedFileHandler(frame, panel);
         dfh.linkPdfToEntry(fileName, entry);


### PR DESCRIPTION
Fixes #2577 
Problem is not the filename 
Problem: You still get a warning that one file could not be imported, although it successfully worked.

I have unfortunately no idea if this code is at all correct, the DroppedFileHandler stuff looks suspicious to me, as it is normally used wit Drag and drop.

**Question**: Is there somewhere a method for linking pdfs?


<!-- describe the changes you have made here: what, why, ... -->

- [ ] Change in CHANGELOG.md described
- [X] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
