### PR TITLE
Improve braces checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - Sciencedirect/Elsevier fetcher is now able to scrape new HTML structure [#2576](https://github.com/JabRef/jabref/issues/2576)
  - Fixed the synchronization logic of keywords and special fields and vice versa [#2580](https://github.com/JabRef/jabref/issues/2580)
  - We fixed an issue where the "find unlinked files" functionality threw an error when only one PDF was imported but not assigned to an entry [#2577](https://github.com/JabRef/jabref/issues/2577)
- 
+ - We fixed issue where escaped braces were incorrectly counted when calculating brace balance in a field [#2561](https://github.com/JabRef/jabref/issues/2561)
+
 ### Removed
 
 

--- a/src/main/java/org/jabref/logic/bibtex/LatexFieldFormatter.java
+++ b/src/main/java/org/jabref/logic/bibtex/LatexFieldFormatter.java
@@ -259,11 +259,19 @@ public class LatexFieldFormatter {
         int current = -1;
 
         // First we collect all occurrences:
-        while ((current = text.indexOf('{', current + 1)) != -1) {
-            left.add(current);
-        }
-        while ((current = text.indexOf('}', current + 1)) != -1) {
-            right.add(current);
+        for (int i = 0; i < text.length(); i++) {
+            char item = text.charAt(i);
+
+            boolean charBeforeIsEscape = false;
+            if(i > 0 && text.charAt(i - 1) == '\\') {
+                charBeforeIsEscape = true;
+            }
+
+            if(!charBeforeIsEscape && item == '{') {
+                left.add(current);
+            } else if (!charBeforeIsEscape && item == '{') {
+                right.add(current);
+            }
         }
 
         // Then we throw an exception if the error criteria are met.

--- a/src/test/java/org/jabref/logic/bibtex/LatexFieldFormatterTests.java
+++ b/src/test/java/org/jabref/logic/bibtex/LatexFieldFormatterTests.java
@@ -81,4 +81,18 @@ public class LatexFieldFormatterTests {
         assertEquals(expected, title);
         assertEquals(expected, any);
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void reportUnbalancedBracing() {
+        String unbalanced = "{";
+
+        formatter.format(unbalanced, "anyfield");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void reportUnbalancedBracingWithEscapedBraces() {
+        String unbalanced = "{\\}";
+
+        formatter.format(unbalanced, "anyfield");
+    }
 }


### PR DESCRIPTION
This is my take at  #2561

So far, escaped braces were counted in when calculating brace balance in a field. This PR avoids counting them in. As a result, when somebody enters `{\}` into a field in the entry editor, a warning dialog appears. Previously, there was no dialog.

- [X] Change in CHANGELOG.md described
- [X] Tests created for changes
- [X] Manually tested changed features in running JabRef
