### PR TITLE
Braces checking followup

### DIFF
--- a/src/main/java/org/jabref/logic/bibtex/LatexFieldFormatter.java
+++ b/src/main/java/org/jabref/logic/bibtex/LatexFieldFormatter.java
@@ -254,9 +254,8 @@ public class LatexFieldFormatter {
     }
 
     private static void checkBraces(String text) throws IllegalArgumentException {
-        List<Integer> left = new ArrayList<>(5);
-        List<Integer> right = new ArrayList<>(5);
-        int current = -1;
+        int left = 0;
+        int right = 0;
 
         // First we collect all occurrences:
         for (int i = 0; i < text.length(); i++) {
@@ -268,20 +267,20 @@ public class LatexFieldFormatter {
             }
 
             if(!charBeforeIsEscape && item == '{') {
-                left.add(current);
-            } else if (!charBeforeIsEscape && item == '{') {
-                right.add(current);
+                left++;
+            } else if (!charBeforeIsEscape && item == '}') {
+                right++;
             }
         }
 
         // Then we throw an exception if the error criteria are met.
-        if (!right.isEmpty() && left.isEmpty()) {
+        if (!(right == 0) && (left == 0)) {
             throw new IllegalArgumentException("'}' character ends string prematurely.");
         }
-        if (!right.isEmpty() && (right.get(0) < left.get(0))) {
+        if (!(right == 0) && (right < left)) {
             throw new IllegalArgumentException("'}' character ends string prematurely.");
         }
-        if (left.size() != right.size()) {
+        if (left != right) {
             throw new IllegalArgumentException("Braces don't match.");
         }
 

--- a/src/main/java/org/jabref/logic/bibtex/LatexFieldFormatter.java
+++ b/src/main/java/org/jabref/logic/bibtex/LatexFieldFormatter.java
@@ -1,8 +1,5 @@
 package org.jabref.logic.bibtex;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.jabref.logic.util.OS;
 import org.jabref.model.entry.InternalBibtexFields;
 import org.jabref.model.strings.StringUtil;

--- a/src/test/java/org/jabref/logic/bibtex/LatexFieldFormatterTests.java
+++ b/src/test/java/org/jabref/logic/bibtex/LatexFieldFormatterTests.java
@@ -95,4 +95,18 @@ public class LatexFieldFormatterTests {
 
         formatter.format(unbalanced, "anyfield");
     }
+
+    @Test
+    public void tolerateBalancedBrace() {
+        String text = "Incorporating evolutionary {Measures into Conservation Prioritization}";
+
+        assertEquals("{" + text + "}", formatter.format(text, "anyfield"));
+    }
+
+    @Test
+    public void tolerateEscapeCharacters() {
+        String text = "Incorporating {\\O}evolutionary {Measures into Conservation Prioritization}";
+
+        assertEquals("{" + text + "}", formatter.format(text, "anyfield"));
+    }
 }


### PR DESCRIPTION
This is a followup to #2593 (still tackles the same issue, therefore no need for an additional changelog entry). It seems that we only had error tests in `LatexFieldFormatterTest` and since I added tests for an additional error condition, our tests did not notice that my changes broke the normal case. This PR fixes the error, simplifies the code a little further and adds tests for it.

- [X] Change in CHANGELOG.md described
- [X] Tests created for changes
- [X] Manually tested changed features in running JabRef
