### PR TITLE
Fix title-related key patterns in BibtexKeyPatternUtil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - We fixed an issue where the `Move linked files to default file directory`- cleanup operation did not move the files to the location of the bib-file. [#2454](https://github.com/JabRef/jabref/issues/2454)
  - We fixed an issue where executing `Move file` on a selected file in the `general`-tab could overwrite an existing file. [#2385](https://github.com/JabRef/jabref/issues/2358)
  - We fixed an issue with importing groups and subgroups [#2600](https://github.com/JabRef/jabref/issues/2600)
+ - Fixed an issue where title-related key patterns did not correspond to the documentation [#2604](https://github.com/JabRef/jabref/issues/2604) [#2589](https://github.com/JabRef/jabref/issues/2589)
 ### Removed
 
 

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Scanner;
+import java.util.StringJoiner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -791,7 +792,7 @@ public class BibtexKeyPatternUtil {
      * Capitalises the significant words of the "title" field in the given BibTeX entry
      */
     public static String camelizeSignificantWordsInTitle(String title) {
-        StringBuilder stringBuilder = new StringBuilder();
+        StringJoiner stringJoiner = new StringJoiner(" ");
         String formattedTitle = formatTitle(title);
         Boolean camelize;
 
@@ -808,25 +809,22 @@ public class BibtexKeyPatternUtil {
                     }
                 }
                 // We want to capitalize significant words and the first word of the title
-                if (camelize || (stringBuilder.length() == 0)) {
+                if (camelize || (stringJoiner.length() == 0)) {
                     word = word.substring(0, 1).toUpperCase() + word.substring(1);
                 } else {
                     word = word.substring(0, 1).toLowerCase() + word.substring(1);
                 }
 
-                if (stringBuilder.length() > 0) {
-                    stringBuilder.append(' ');
-                }
-                stringBuilder.append(word);
+                stringJoiner.add(word);
             }
         }
 
-        return stringBuilder.toString();
+        return stringJoiner.toString();
     }
 
 
     public static String removeSmallWords(String title) {
-        StringBuilder stringBuilder = new StringBuilder();
+        StringJoiner stringJoiner = new StringJoiner(" ");
         String formattedTitle = formatTitle(title);
 
         try (Scanner titleScanner = new Scanner(formattedTitle)) {
@@ -839,18 +837,15 @@ public class BibtexKeyPatternUtil {
                     }
                 }
 
-                if (stringBuilder.length() > 0) {
-                    stringBuilder.append(' ');
-                }
-                stringBuilder.append(word);
+                stringJoiner.add(word);
             }
         }
 
-        return stringBuilder.toString();
+        return stringJoiner.toString();
     }
 
     private static String getTitleWordsWithSpaces(int number, String title) {
-        StringBuilder stringBuilder = new StringBuilder();
+        StringJoiner stringJoiner = new StringJoiner(" ");
         String formattedTitle = formatTitle(title);
         int words = 0;
 
@@ -858,15 +853,12 @@ public class BibtexKeyPatternUtil {
             while (titleScanner.hasNext() && (words < number)) {
                 String word = titleScanner.next();
 
-                if (stringBuilder.length() > 0) {
-                    stringBuilder.append(' ');
-                }
-                stringBuilder.append(word);
+                stringJoiner.add(word);
                 words++;
             }
         }
 
-        return stringBuilder.toString();
+        return stringJoiner.toString();
     }
 
     private static String keepLettersAndDigitsOnly(String in) {

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Scanner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -484,7 +485,7 @@ public class BibtexKeyPatternUtil {
                     Optional<Formatter> formatter = Formatters.getFormatterForModifier(modifier);
                     if (formatter.isPresent()) {
                         resultingLabel = formatter.get().format(label);
-                    } else if (!modifier.isEmpty() && modifier.length()>= 2 && (modifier.charAt(0) == '(') && modifier.endsWith(")")) {
+                    } else if (!modifier.isEmpty() && (modifier.length()>= 2) && (modifier.charAt(0) == '(') && modifier.endsWith(")")) {
                         // Alternate text modifier in parentheses. Should be inserted if
                         // the label is empty:
                         if (label.isEmpty() && (modifier.length() > 2)) {
@@ -632,6 +633,8 @@ public class BibtexKeyPatternUtil {
                 return firstPage(entry.getField(FieldName.PAGES).orElse(""));
             } else if ("lastpage".equals(val)) {
                 return lastPage(entry.getField(FieldName.PAGES).orElse(""));
+            } else if ("title".equals(val)) {
+                return getTitleWithSignificantWordsCamelized(entry.getField(FieldName.TITLE).orElse(""));
             } else if ("shorttitle".equals(val)) {
                 return getTitleWords(3, entry.getField(FieldName.TITLE).orElse(""));
             } else if ("shorttitleINI".equals(val)) {
@@ -639,7 +642,10 @@ public class BibtexKeyPatternUtil {
                         applyModifiers(getTitleWordsWithSpaces(3, entry.getField(FieldName.TITLE).orElse("")),
                                 Collections.singletonList("abbr"), 0));
             } else if ("veryshorttitle".equals(val)) {
-                return getTitleWords(1, entry.getField(FieldName.TITLE).orElse(""));
+                return getTitleWords(1,
+                        removeSmallWords(entry.getField(FieldName.TITLE).orElse("")));
+            } else if ("camel".equals(val)) {
+                return getCamelizedTitle(entry.getField(FieldName.TITLE).orElse(""));
             } else if ("shortyear".equals(val)) {
                 String yearString = entry.getFieldOrAlias(FieldName.YEAR).orElse("");
                 if (yearString.isEmpty()) {
@@ -719,16 +725,16 @@ public class BibtexKeyPatternUtil {
         return keepLettersAndDigitsOnly(getTitleWordsWithSpaces(number, title));
     }
 
-    private static String getTitleWordsWithSpaces(int number, String title) {
+    /**
+     * Removes any '-', unnecessary whitespace and latex commands formatting
+     */
+    private static String formatTitle(String title) {
         String ss = new RemoveLatexCommandsFormatter().format(title);
         StringBuilder stringBuilder = new StringBuilder();
         StringBuilder current;
         int piv = 0;
-        int words = 0;
 
-        // sorry for being English-centric. I guess these
-        // words should really be an editable preference.
-        mainl: while ((piv < ss.length()) && (words < number)) {
+        while (piv < ss.length()) {
             current = new StringBuilder();
             // Get the next word:
             while ((piv < ss.length()) && !Character.isWhitespace(ss.charAt(piv))
@@ -742,18 +748,126 @@ public class BibtexKeyPatternUtil {
             if (word.isEmpty()) {
                 continue;
             }
-            for (String smallWord: Word.SMALLER_WORDS) {
-                if (word.equalsIgnoreCase(smallWord)) {
-                    continue mainl;
-                }
-            }
 
             // If we get here, the word was accepted.
             if (stringBuilder.length() > 0) {
                 stringBuilder.append(' ');
             }
             stringBuilder.append(word);
-            words++;
+        }
+
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Capitalises and concatenates the words out of the "title" field in the given BibTeX entry
+     */
+    public static String getCamelizedTitle(String title) {
+        return keepLettersAndDigitsOnly(camelizeTitle(title));
+    }
+
+    /**
+     * Capitalises the significant words and concatenates all the words out of the "title" field in the given BibTeX entry
+     */
+    public static String getTitleWithSignificantWordsCamelized(String title) {
+        return keepLettersAndDigitsOnly(camelizeSignificantWordsInTitle(title));
+    }
+
+    private static String camelizeTitle(String title) {
+        StringBuilder stringBuilder = new StringBuilder();
+        String formattedTitle = formatTitle(title);
+
+        try (Scanner titleScanner = new Scanner(formattedTitle)) {
+            while (titleScanner.hasNext()) {
+                String word = titleScanner.next();
+
+                // Camelize the word
+                word = word.substring(0, 1).toUpperCase() + word.substring(1);
+
+                if (stringBuilder.length() > 0) {
+                    stringBuilder.append(' ');
+                }
+                stringBuilder.append(word);
+            }
+        }
+
+        return stringBuilder.toString();
+    }
+
+    private static String camelizeSignificantWordsInTitle(String title) {
+        StringBuilder stringBuilder = new StringBuilder();
+        String formattedTitle = formatTitle(title);
+        Boolean camelize;
+
+        try (Scanner titleScanner = new Scanner(formattedTitle)) {
+            while (titleScanner.hasNext()) {
+                String word = titleScanner.next();
+                camelize = true;
+
+                // Camelize the word if it is significant
+                for (String smallWord : Word.SMALLER_WORDS) {
+                    if (word.equalsIgnoreCase(smallWord)) {
+                        camelize = false;
+                        continue;
+                    }
+                }
+                // We want to capitalize significant words and the first word of the title
+                if (camelize || (stringBuilder.length() == 0)) {
+                    word = word.substring(0, 1).toUpperCase() + word.substring(1);
+                } else {
+                    word = word.substring(0, 1).toLowerCase() + word.substring(1);
+                }
+
+                if (stringBuilder.length() > 0) {
+                    stringBuilder.append(' ');
+                }
+                stringBuilder.append(word);
+            }
+        }
+
+        return stringBuilder.toString();
+    }
+
+
+    public static String removeSmallWords(String title) {
+        StringBuilder stringBuilder = new StringBuilder();
+        String formattedTitle = formatTitle(title);
+
+        try (Scanner titleScanner = new Scanner(formattedTitle)) {
+            mainl: while (titleScanner.hasNext()) {
+                String word = titleScanner.next();
+
+                for (String smallWord : Word.SMALLER_WORDS) {
+                    if (word.equalsIgnoreCase(smallWord)) {
+                        continue mainl;
+                    }
+                }
+
+                if (stringBuilder.length() > 0) {
+                    stringBuilder.append(' ');
+                }
+                stringBuilder.append(word);
+            }
+        }
+
+        return stringBuilder.toString();
+    }
+
+    private static String getTitleWordsWithSpaces(int number, String title) {
+        StringBuilder stringBuilder = new StringBuilder();
+        String formattedTitle = formatTitle(title);
+        int words = 0;
+
+        try (Scanner titleScanner = new Scanner(formattedTitle)) {
+            while (titleScanner.hasNext() && (words < number)) {
+                String word = titleScanner.next();
+
+                if (stringBuilder.length() > 0) {
+                    stringBuilder.append(' ');
+                }
+                stringBuilder.append(word);
+                words++;
+            }
         }
 
         return stringBuilder.toString();

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -634,7 +634,7 @@ public class BibtexKeyPatternUtil {
             } else if ("lastpage".equals(val)) {
                 return lastPage(entry.getField(FieldName.PAGES).orElse(""));
             } else if ("title".equals(val)) {
-                return getTitleWithSignificantWordsCamelized(entry.getField(FieldName.TITLE).orElse(""));
+                return camelizeSignificantWordsInTitle(entry.getField(FieldName.TITLE).orElse(""));
             } else if ("shorttitle".equals(val)) {
                 return getTitleWords(3, entry.getField(FieldName.TITLE).orElse(""));
             } else if ("shorttitleINI".equals(val)) {
@@ -766,13 +766,6 @@ public class BibtexKeyPatternUtil {
         return keepLettersAndDigitsOnly(camelizeTitle(title));
     }
 
-    /**
-     * Capitalises the significant words and concatenates all the words out of the "title" field in the given BibTeX entry
-     */
-    public static String getTitleWithSignificantWordsCamelized(String title) {
-        return keepLettersAndDigitsOnly(camelizeSignificantWordsInTitle(title));
-    }
-
     private static String camelizeTitle(String title) {
         StringBuilder stringBuilder = new StringBuilder();
         String formattedTitle = formatTitle(title);
@@ -794,7 +787,10 @@ public class BibtexKeyPatternUtil {
         return stringBuilder.toString();
     }
 
-    private static String camelizeSignificantWordsInTitle(String title) {
+    /**
+     * Capitalises the significant words of the "title" field in the given BibTeX entry
+     */
+    public static String camelizeSignificantWordsInTitle(String title) {
         StringBuilder stringBuilder = new StringBuilder();
         String formattedTitle = formatTitle(title);
         Boolean camelize;

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtilTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtilTest.java
@@ -619,20 +619,29 @@ public class BibtexKeyPatternUtilTest {
         // veryShortTitle is getTitleWords with "1" as count
         int count = 1;
         assertEquals("application",
-                BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_ALL_LOWER_FOUR_SMALL_WORDS_ONE_EN_DASH));
+                BibtexKeyPatternUtil.getTitleWords(count,
+                        BibtexKeyPatternUtil.removeSmallWords(TITLE_STRING_ALL_LOWER_FOUR_SMALL_WORDS_ONE_EN_DASH)));
         assertEquals("BPEL", BibtexKeyPatternUtil.getTitleWords(count,
-                TITLE_STRING_ALL_LOWER_FIRST_WORD_IN_BRACKETS_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON));
-        assertEquals("Process", BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_CASED));
+                BibtexKeyPatternUtil.removeSmallWords(
+                        TITLE_STRING_ALL_LOWER_FIRST_WORD_IN_BRACKETS_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON)));
+        assertEquals("Process", BibtexKeyPatternUtil.getTitleWords(count,
+                BibtexKeyPatternUtil.removeSmallWords(TITLE_STRING_CASED)));
         assertEquals("BPMN",
-                BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_CASED_ONE_UPPER_WORD_ONE_SMALL_WORD));
+                BibtexKeyPatternUtil.getTitleWords(count,
+                        BibtexKeyPatternUtil.removeSmallWords(TITLE_STRING_CASED_ONE_UPPER_WORD_ONE_SMALL_WORD)));
         assertEquals("Difference", BibtexKeyPatternUtil.getTitleWords(count,
-                TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AT_THE_BEGINNING));
+                BibtexKeyPatternUtil.removeSmallWords(TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AT_THE_BEGINNING)));
         assertEquals("Cloud",
-                BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON));
+                BibtexKeyPatternUtil.getTitleWords(count,
+                        BibtexKeyPatternUtil
+                                .removeSmallWords(TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON)));
         assertEquals("Towards",
-                BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_CASED_TWO_SMALL_WORDS_ONE_CONNECTED_WORD));
+                BibtexKeyPatternUtil.getTitleWords(count,
+                        BibtexKeyPatternUtil.removeSmallWords(TITLE_STRING_CASED_TWO_SMALL_WORDS_ONE_CONNECTED_WORD)));
         assertEquals("Measurement",
-                BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_CASED_FOUR_SMALL_WORDS_TWO_CONNECTED_WORDS));
+                BibtexKeyPatternUtil.getTitleWords(count,
+                        BibtexKeyPatternUtil
+                                .removeSmallWords(TITLE_STRING_CASED_FOUR_SMALL_WORDS_TWO_CONNECTED_WORDS)));
     }
 
     /**
@@ -644,19 +653,75 @@ public class BibtexKeyPatternUtilTest {
         int count = 3;
         assertEquals("applicationmigrationeffort",
                 BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_ALL_LOWER_FOUR_SMALL_WORDS_ONE_EN_DASH));
-        assertEquals("BPELconformanceopen", BibtexKeyPatternUtil.getTitleWords(count,
+        assertEquals("BPELconformancein", BibtexKeyPatternUtil.getTitleWords(count,
                 TITLE_STRING_ALL_LOWER_FIRST_WORD_IN_BRACKETS_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON));
         assertEquals("ProcessViewingPatterns", BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_CASED));
-        assertEquals("BPMNConformanceOpen",
+        assertEquals("BPMNConformancein",
                 BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_CASED_ONE_UPPER_WORD_ONE_SMALL_WORD));
-        assertEquals("DifferenceGraphBased", BibtexKeyPatternUtil.getTitleWords(count,
+        assertEquals("TheDifferenceBetween", BibtexKeyPatternUtil.getTitleWords(count,
                 TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AT_THE_BEGINNING));
-        assertEquals("CloudComputingNext",
+        assertEquals("CloudComputingThe",
                 BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON));
         assertEquals("TowardsChoreographybased",
                 BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_CASED_TWO_SMALL_WORDS_ONE_CONNECTED_WORD));
-        assertEquals("MeasurementDesignTime",
+        assertEquals("OntheMeasurement",
                 BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_CASED_FOUR_SMALL_WORDS_TWO_CONNECTED_WORDS));
+    }
+
+    /**
+    * Tests [camel]
+    */
+    @Test
+    public void camel() {
+        // camel capitalises and concatenates all the words of the title
+        assertEquals("ApplicationMigrationEffortInTheCloudTheCaseOfCloudPlatforms",
+                BibtexKeyPatternUtil.getCamelizedTitle(TITLE_STRING_ALL_LOWER_FOUR_SMALL_WORDS_ONE_EN_DASH));
+        assertEquals("BPELConformanceInOpenSourceEnginesTheCaseOfStaticAnalysis",
+                BibtexKeyPatternUtil.getCamelizedTitle(
+                        TITLE_STRING_ALL_LOWER_FIRST_WORD_IN_BRACKETS_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON));
+        assertEquals("ProcessViewingPatterns", BibtexKeyPatternUtil.getCamelizedTitle(TITLE_STRING_CASED));
+        assertEquals("BPMNConformanceInOpenSourceEngines",
+                BibtexKeyPatternUtil.getCamelizedTitle(TITLE_STRING_CASED_ONE_UPPER_WORD_ONE_SMALL_WORD));
+        assertEquals("TheDifferenceBetweenGraphBasedAndBlockStructuredBusinessProcessModellingLanguages",
+                BibtexKeyPatternUtil.getCamelizedTitle(
+                        TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AT_THE_BEGINNING));
+        assertEquals("CloudComputingTheNextRevolutionInIT",
+                BibtexKeyPatternUtil.getCamelizedTitle(TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON));
+        assertEquals("TowardsChoreographyBasedProcessDistributionInTheCloud",
+                BibtexKeyPatternUtil.getCamelizedTitle(TITLE_STRING_CASED_TWO_SMALL_WORDS_ONE_CONNECTED_WORD));
+        assertEquals("OnTheMeasurementOfDesignTimeAdaptabilityForProcessBasedSystems",
+                BibtexKeyPatternUtil.getCamelizedTitle(TITLE_STRING_CASED_FOUR_SMALL_WORDS_TWO_CONNECTED_WORDS));
+    }
+
+    /**
+     * Tests [title]
+     */
+    @Test
+    public void title() {
+        // title capitalises the significant words and concatenates all the words of the title
+        assertEquals("ApplicationMigrationEffortintheCloudtheCaseofCloudPlatforms",
+                BibtexKeyPatternUtil
+                        .getTitleWithSignificantWordsCamelized(TITLE_STRING_ALL_LOWER_FOUR_SMALL_WORDS_ONE_EN_DASH));
+        assertEquals("BPELConformanceinOpenSourceEnginestheCaseofStaticAnalysis",
+                BibtexKeyPatternUtil.getTitleWithSignificantWordsCamelized(
+                        TITLE_STRING_ALL_LOWER_FIRST_WORD_IN_BRACKETS_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON));
+        assertEquals("ProcessViewingPatterns",
+                BibtexKeyPatternUtil.getTitleWithSignificantWordsCamelized(TITLE_STRING_CASED));
+        assertEquals("BPMNConformanceinOpenSourceEngines",
+                BibtexKeyPatternUtil
+                        .getTitleWithSignificantWordsCamelized(TITLE_STRING_CASED_ONE_UPPER_WORD_ONE_SMALL_WORD));
+        assertEquals("TheDifferencebetweenGraphBasedandBlockStructuredBusinessProcessModellingLanguages",
+                BibtexKeyPatternUtil.getTitleWithSignificantWordsCamelized(
+                        TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AT_THE_BEGINNING));
+        assertEquals("CloudComputingtheNextRevolutioninIT",
+                BibtexKeyPatternUtil.getTitleWithSignificantWordsCamelized(
+                        TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON));
+        assertEquals("TowardsChoreographyBasedProcessDistributionintheCloud",
+                BibtexKeyPatternUtil
+                        .getTitleWithSignificantWordsCamelized(TITLE_STRING_CASED_TWO_SMALL_WORDS_ONE_CONNECTED_WORD));
+        assertEquals("OntheMeasurementofDesignTimeAdaptabilityforProcessBasedSystems",
+                BibtexKeyPatternUtil.getTitleWithSignificantWordsCamelized(
+                        TITLE_STRING_CASED_FOUR_SMALL_WORDS_TWO_CONNECTED_WORDS));
     }
 
     @Test
@@ -718,8 +783,8 @@ public class BibtexKeyPatternUtilTest {
     public void testApplyModifiers() {
         BibEntry entry = new BibEntry();
         entry.setField("title", "Green Scheduling of Whatever");
-        assertEquals("GSW", BibtexKeyPatternUtil.makeLabel(entry, "shorttitleINI", ',', new BibDatabase()));
-        assertEquals("GreenSchedulingWhatever", BibtexKeyPatternUtil.makeLabel(entry, "shorttitle",
+        assertEquals("GSo", BibtexKeyPatternUtil.makeLabel(entry, "shorttitleINI", ',', new BibDatabase()));
+        assertEquals("GreenSchedulingof", BibtexKeyPatternUtil.makeLabel(entry, "shorttitle",
                 ',', new BibDatabase()));
     }
 

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtilTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtilTest.java
@@ -698,29 +698,30 @@ public class BibtexKeyPatternUtilTest {
      */
     @Test
     public void title() {
-        // title capitalises the significant words and concatenates all the words of the title
-        assertEquals("ApplicationMigrationEffortintheCloudtheCaseofCloudPlatforms",
+        // title capitalises the significant words of the title
+        // for the title case the concatenation happens at formatting, which is tested in MakeLabelWithDatabaseTest.java
+        assertEquals("Application Migration Effort in the Cloud the Case of Cloud Platforms",
                 BibtexKeyPatternUtil
-                        .getTitleWithSignificantWordsCamelized(TITLE_STRING_ALL_LOWER_FOUR_SMALL_WORDS_ONE_EN_DASH));
-        assertEquals("BPELConformanceinOpenSourceEnginestheCaseofStaticAnalysis",
-                BibtexKeyPatternUtil.getTitleWithSignificantWordsCamelized(
+                        .camelizeSignificantWordsInTitle(TITLE_STRING_ALL_LOWER_FOUR_SMALL_WORDS_ONE_EN_DASH));
+        assertEquals("BPEL Conformance in Open Source Engines: the Case of Static Analysis",
+                BibtexKeyPatternUtil.camelizeSignificantWordsInTitle(
                         TITLE_STRING_ALL_LOWER_FIRST_WORD_IN_BRACKETS_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON));
-        assertEquals("ProcessViewingPatterns",
-                BibtexKeyPatternUtil.getTitleWithSignificantWordsCamelized(TITLE_STRING_CASED));
-        assertEquals("BPMNConformanceinOpenSourceEngines",
+        assertEquals("Process Viewing Patterns",
+                BibtexKeyPatternUtil.camelizeSignificantWordsInTitle(TITLE_STRING_CASED));
+        assertEquals("BPMN Conformance in Open Source Engines",
                 BibtexKeyPatternUtil
-                        .getTitleWithSignificantWordsCamelized(TITLE_STRING_CASED_ONE_UPPER_WORD_ONE_SMALL_WORD));
-        assertEquals("TheDifferencebetweenGraphBasedandBlockStructuredBusinessProcessModellingLanguages",
-                BibtexKeyPatternUtil.getTitleWithSignificantWordsCamelized(
+                        .camelizeSignificantWordsInTitle(TITLE_STRING_CASED_ONE_UPPER_WORD_ONE_SMALL_WORD));
+        assertEquals("The Difference between Graph Based and Block Structured Business Process Modelling Languages",
+                BibtexKeyPatternUtil.camelizeSignificantWordsInTitle(
                         TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AT_THE_BEGINNING));
-        assertEquals("CloudComputingtheNextRevolutioninIT",
-                BibtexKeyPatternUtil.getTitleWithSignificantWordsCamelized(
+        assertEquals("Cloud Computing: the Next Revolution in IT",
+                BibtexKeyPatternUtil.camelizeSignificantWordsInTitle(
                         TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON));
-        assertEquals("TowardsChoreographyBasedProcessDistributionintheCloud",
+        assertEquals("Towards Choreography Based Process Distribution in the Cloud",
                 BibtexKeyPatternUtil
-                        .getTitleWithSignificantWordsCamelized(TITLE_STRING_CASED_TWO_SMALL_WORDS_ONE_CONNECTED_WORD));
-        assertEquals("OntheMeasurementofDesignTimeAdaptabilityforProcessBasedSystems",
-                BibtexKeyPatternUtil.getTitleWithSignificantWordsCamelized(
+                        .camelizeSignificantWordsInTitle(TITLE_STRING_CASED_TWO_SMALL_WORDS_ONE_CONNECTED_WORD));
+        assertEquals("On the Measurement of Design Time Adaptability for Process Based Systems",
+                BibtexKeyPatternUtil.camelizeSignificantWordsInTitle(
                         TITLE_STRING_CASED_FOUR_SMALL_WORDS_TWO_CONNECTED_WORDS));
     }
 

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
@@ -191,21 +191,21 @@ public class MakeLabelWithDatabaseTest {
     public void generateKeyTitle() {
         bibtexKeyPattern.setDefaultValue("[title]");
         BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
-        assertEquals(Optional.of("AnawesomepaperonJabRef"), entry.getCiteKeyOptional());
+        assertEquals(Optional.of("AnAwesomePaperonJabRef"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyTitleAbbr() {
         bibtexKeyPattern.setDefaultValue("[title:abbr]");
         BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
-        assertEquals(Optional.of("AapoJ"), entry.getCiteKeyOptional());
+        assertEquals(Optional.of("AAPoJ"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyShorttitle() {
         bibtexKeyPattern.setDefaultValue("[shorttitle]");
         BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
-        assertEquals(Optional.of("awesomepaperJabRef"), entry.getCiteKeyOptional());
+        assertEquals(Optional.of("Anawesomepaper"), entry.getCiteKeyOptional());
     }
 
     @Test
@@ -219,7 +219,7 @@ public class MakeLabelWithDatabaseTest {
     public void generateKeyShorttitleINI() {
         bibtexKeyPattern.setDefaultValue("[shorttitleINI]");
         BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
-        assertEquals(Optional.of("apJ"), entry.getCiteKeyOptional());
+        assertEquals(Optional.of("Aap"), entry.getCiteKeyOptional());
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
@@ -223,6 +223,13 @@ public class MakeLabelWithDatabaseTest {
     }
 
     @Test
+    public void generateKeyCamel() {
+        bibtexKeyPattern.setDefaultValue("[camel]");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
+        assertEquals(Optional.of("AnAwesomePaperOnJabRef"), entry.getCiteKeyOptional());
+    }
+
+    @Test
     public void generateKeyAuthNM() {
         bibtexKeyPattern.setDefaultValue("[auth4_3]");
         entry.setField("author", "John Doe and Donald Smith and Will Wonder");


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
Related to [#2604](https://github.com/JabRef/jabref/issues/2604) and [#2589](https://github.com/JabRef/jabref/issues/2589)

In the class BibtexKeyPatternUtil I've added cases for [title] and [camel] to try and make them conform to the [documentation](http://help.jabref.org/en/BibtexKeyPatterns).

@Siedlerchr was also working on this issue [here](https://github.com/JabRef/jabref/pull/2597). I found out that  
`CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_CAMEL, entry.getField(FieldName.TITLE).orElse("").replaceAll("\\s+", ""));`
didn't work because to be able to transform the title into upper_camel this way the title has to be in  lower_camel case initially, which is often not the case.

I've added some test cases and changed a few others to conform to the documentation. 
I still need to take a look at the failing tests.

- [x] Change in CHANGELOG.md described
- [X] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
