### PR TITLE
Fix exception when parsing groups which contain a top level group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,14 +50,13 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - Sciencedirect/Elsevier fetcher is now able to scrape new HTML structure [#2576](https://github.com/JabRef/jabref/issues/2576)
  - Fixed the synchronization logic of keywords and special fields and vice versa [#2580](https://github.com/JabRef/jabref/issues/2580)
  - Fixed a display issue when removing a group with a long name [#1407](https://github.com/JabRef/jabref/issues/1407)
- 
  - The group selection is no longer lost when switching tabs [#1104](https://github.com/JabRef/jabref/issues/1104)
- 
  - We fixed an issue where the "find unlinked files" functionality threw an error when only one PDF was imported but not assigned to an entry [#2577](https://github.com/JabRef/jabref/issues/2577)
  - We fixed issue where escaped braces were incorrectly counted when calculating brace balance in a field [#2561](https://github.com/JabRef/jabref/issues/2561)
  - We fixed an issue introduced with Version 3.8.2 where executing the `Rename PDFs`-cleanup operation moved the files to the file directory. [#2526](https://github.com/JabRef/jabref/issues/2526)
  - We fixed an issue where the `Move linked files to default file directory`- cleanup operation did not move the files to the location of the bib-file. [#2454](https://github.com/JabRef/jabref/issues/2454)
  - We fixed an issue where executing `Move file` on a selected file in the `general`-tab could overwrite an existing file. [#2385](https://github.com/JabRef/jabref/issues/2358)
+ - We fixed an issue with importing groups and subgroups [#2600](https://github.com/JabRef/jabref/issues/2600)
 ### Removed
 
 

--- a/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
@@ -47,7 +47,7 @@ public class GroupsParser {
                     root = cursor;
                 } else {
                     // insert at desired location
-                    while (level <= cursor.getLevel()) {
+                    while ((level <= cursor.getLevel()) && (cursor.getParent().isPresent())) {
                         cursor = cursor.getParent().get();
                     }
                     cursor.addChild(newNode);

--- a/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java
@@ -1,9 +1,13 @@
 package org.jabref.logic.importer.util;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.jabref.logic.importer.ParseException;
 import org.jabref.model.groups.AbstractGroup;
 import org.jabref.model.groups.ExplicitGroup;
 import org.jabref.model.groups.GroupHierarchyType;
+import org.jabref.model.groups.GroupTreeNode;
 
 import org.junit.Test;
 
@@ -24,4 +28,33 @@ public class GroupsParserTest {
     public void fromStringThrowsParseExceptionForNotEscapedGroupName() throws Exception {
         GroupsParser.fromString("ExplicitGroup:slit\\\\;0\\;mertsch_slit2_2007\\;;", ',');
     }
+
+    @Test
+    public void testImportSubGroups() throws ParseException {
+
+        List<String> orderedData = Arrays.asList("0 AllEntriesGroup:", "1 ExplicitGroup:1;0;",
+                "2 ExplicitGroup:2;0;;", "0 ExplicitGroup:3;0;;");
+        //Create group hierarchy:
+        //  Level 0 Name: All entries
+        //  Level 1 Name: 1
+        //  Level 2 Name: 2
+        //  Level 1 Name: 3
+
+        GroupTreeNode rootNode = new GroupTreeNode(
+                new ExplicitGroup("All entries", GroupHierarchyType.INDEPENDENT, ','));
+
+        AbstractGroup firstSubGrpLvl1 = new ExplicitGroup("1", GroupHierarchyType.INDEPENDENT, ',');
+        rootNode.addSubgroup(firstSubGrpLvl1);
+
+        AbstractGroup subLvl2 = new ExplicitGroup("2", GroupHierarchyType.INDEPENDENT, ',');
+        rootNode.getFirstChild().ifPresent(c -> c.addSubgroup(subLvl2));
+
+        AbstractGroup thirdSubGrpLvl1 = new ExplicitGroup("3", GroupHierarchyType.INDEPENDENT, ',');
+        rootNode.addSubgroup(thirdSubGrpLvl1);
+
+        GroupTreeNode parsedNode = GroupsParser.importGroups(orderedData, ',');
+        assertEquals(rootNode.getChildren(), parsedNode.getChildren());
+
+    }
+
 }


### PR DESCRIPTION
Fixes the import of #2600 

The problem occurred when after the definition of a subgroup of level >0 a group definition with level 0 followed.
```
2 ExplicitGroup:15\;0\;;
0 ExplicitGroup:16\;0\;;
2 ExplicitGroup:17\;0\;;
```

<!-- describe the changes you have made here: what, why, ... -->

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
~~- [ ] Screenshots added (for bigger UI changes)~~
- [x] Manually tested changed features in running JabRef
~~- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org]~~(https://github.com/JabRef/help.jabref.org/issues)?)
~~- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?~~
