### PR TITLE
Fix2613

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - We fixed an issue where executing `Move file` on a selected file in the `general`-tab could overwrite an existing file. [#2385](https://github.com/JabRef/jabref/issues/2358)
  - We fixed an issue with importing groups and subgroups [#2600](https://github.com/JabRef/jabref/issues/2600)
  - Fixed an issue where title-related key patterns did not correspond to the documentation [#2604](https://github.com/JabRef/jabref/issues/2604) [#2589](https://github.com/JabRef/jabref/issues/2589)
+ - We fixed an issue which prohibited the citation export to external programms on MacOS  [#2613](https://github.com/JabRef/jabref/issues/2613)
+ 
 ### Removed
 
 

--- a/src/main/java/org/jabref/gui/push/AbstractPushToApplication.java
+++ b/src/main/java/org/jabref/gui/push/AbstractPushToApplication.java
@@ -11,6 +11,7 @@ import org.jabref.Globals;
 import org.jabref.gui.BasePanel;
 import org.jabref.gui.FileDialog;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.util.OS;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.metadata.MetaData;
@@ -66,7 +67,12 @@ public abstract class AbstractPushToApplication implements PushToApplication {
 
         // Execute command
         try {
-            Runtime.getRuntime().exec(getCommandLine(keyString));
+            if (OS.OS_X) {
+                String[] commands = getCommandLine(keyString);
+                Runtime.getRuntime().exec("open -a " + commands[0] + " -n --args " + commands[1] + " " + commands[2]);
+            } else {
+                Runtime.getRuntime().exec(getCommandLine(keyString));
+            }
         }
 
         // In case it did not work


### PR DESCRIPTION
Provided a MacOS specific routine for opening Tex editors to import citations to fix #2613.
The solution has been tested with Texstudio and Texmaker

- [x ] Change in CHANGELOG.md described
- [x ] Manually tested changed features in running JabRef
