### PR TITLE
Change dialog of download fulltext to save dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - We fixed an issue with importing groups and subgroups [#2600](https://github.com/JabRef/jabref/issues/2600)
  - Fixed an issue where title-related key patterns did not correspond to the documentation [#2604](https://github.com/JabRef/jabref/issues/2604) [#2589](https://github.com/JabRef/jabref/issues/2589)
  - We fixed an issue which prohibited the citation export to external programms on MacOS  [#2613](https://github.com/JabRef/jabref/issues/2613)
- 
+ - We fixed an issue where the file folder could not be changed when running `Get fulltext` in the `general`-tab [#2572](https://github.com/JabRef/jabref/issues/2572)
 ### Removed
 
 

--- a/src/main/java/org/jabref/gui/FXDialogService.java
+++ b/src/main/java/org/jabref/gui/FXDialogService.java
@@ -124,6 +124,7 @@ public class FXDialogService implements DialogService {
         FileChooser chooser = new FileChooser();
         chooser.getExtensionFilters().addAll(fileDialogConfiguration.getExtensionFilters());
         chooser.setSelectedExtensionFilter(fileDialogConfiguration.getDefaultExtension());
+        chooser.setInitialFileName(fileDialogConfiguration.getInitialFileName());
         fileDialogConfiguration.getInitialDirectory().map(Path::toFile).ifPresent(chooser::setInitialDirectory);
         return chooser;
     }

--- a/src/main/java/org/jabref/gui/FileDialog.java
+++ b/src/main/java/org/jabref/gui/FileDialog.java
@@ -35,6 +35,7 @@ import org.apache.commons.logging.LogFactory;
  */
 @Deprecated
 public class FileDialog {
+
     private static final Log LOGGER = LogFactory.getLog(FileDialog.class);
 
     private final FileChooser fileChooser;
@@ -69,9 +70,9 @@ public class FileDialog {
             dir = null;
         }
         fileChooser = new FileChooser();
-
         configurationBuilder = new FileDialogConfiguration.Builder();
         configurationBuilder = configurationBuilder.withInitialDirectory(dir);
+
     }
 
     /**
@@ -114,6 +115,14 @@ public class FileDialog {
     }
 
     /**
+     * Sets the initial file name, useful for saving dialogs
+     * @param fileName
+     */
+    public void setInitialFileName(String fileName) {
+        fileChooser.setInitialFileName(fileName);
+    }
+
+    /**
      * Sets a custom file filter.
      * Only use when withExtension() does not suffice.
      *
@@ -122,6 +131,7 @@ public class FileDialog {
     public void setFileFilter(FileChooser.ExtensionFilter filter) {
         fileChooser.getExtensionFilters().add(filter);
         fileChooser.setSelectedExtensionFilter(filter);
+
     }
 
     /**

--- a/src/main/java/org/jabref/gui/externalfiles/DownloadExternalFile.java
+++ b/src/main/java/org/jabref/gui/externalfiles/DownloadExternalFile.java
@@ -160,7 +160,7 @@ public class DownloadExternalFile {
         final String suggestDir = directory == null ? System.getProperty("user.home") : directory;
         File file = new File(new File(suggestDir), suggestedName);
         FileListEntry fileListEntry = new FileListEntry("", file.getCanonicalPath(), suggestedType);
-        editor = new FileListEntryEditor(frame, fileListEntry, true, false, databaseContext);
+        editor = new FileListEntryEditor(frame, fileListEntry, true, false, databaseContext, true);
         editor.getProgressBar().setIndeterminate(true);
         editor.setOkEnabled(false);
         editor.setExternalConfirm(closeEntry -> {

--- a/src/main/java/org/jabref/gui/externalfiles/FindFullTextAction.java
+++ b/src/main/java/org/jabref/gui/externalfiles/FindFullTextAction.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.LogFactory;
  * Try to download fulltext PDF for selected entry(ies) by following URL or DOI link.
  */
 public class FindFullTextAction extends AbstractWorker {
+
     private static final Log LOGGER = LogFactory.getLog(FindFullTextAction.class);
 
     private static final int warningLimit = 5; // The minimum number of selected entries to ask the user for confirmation
@@ -51,12 +52,14 @@ public class FindFullTextAction extends AbstractWorker {
     @Override
     public void run() {
         if (basePanel.getSelectedEntries().size() >= warningLimit) {
-            String[] options = new String[]{Localization.lang("Look up full text documents"), Localization.lang("Cancel")};
+            String[] options = new String[] {Localization.lang("Look up full text documents"),
+                    Localization.lang("Cancel")};
             int answer = JOptionPane.showOptionDialog(basePanel.frame(),
                     Localization.lang(
                             "You are about to look up full text documents for %0 entries.",
                             String.valueOf(basePanel.getSelectedEntries().size())) + "\n"
-                            + Localization.lang("JabRef will send at least one request per entry to a publisher.") + "\n"
+                            + Localization.lang("JabRef will send at least one request per entry to a publisher.")
+                            + "\n"
                             + Localization.lang("Do you still want to continue?"),
                     Localization.lang("Look up full text documents"), JOptionPane.OK_CANCEL_OPTION,
                     JOptionPane.WARNING_MESSAGE, null, options, options[0]);

--- a/src/main/java/org/jabref/gui/filelist/FileListEntryEditor.java
+++ b/src/main/java/org/jabref/gui/filelist/FileListEntryEditor.java
@@ -346,7 +346,7 @@ public class FileListEntryEditor {
             workingDir = Globals.prefs.get(JabRefPreferences.WORKING_DIRECTORY);
         }
 
-        Optional<Path> path = new FileDialog(this.frame, workingDir).showDialogAndGetSelectedFile();
+        Optional<Path> path = new FileDialog(this.frame, filePath).saveNewFile();
 
         path.ifPresent(selection -> {
             File newFile = selection.toFile();

--- a/src/main/java/org/jabref/gui/filelist/FileListEntryEditor.java
+++ b/src/main/java/org/jabref/gui/filelist/FileListEntryEditor.java
@@ -83,7 +83,7 @@ public class FileListEntryEditor {
 
     //Do not make this variable final, as then the lambda action listener will fail on compile
     private JabRefFrame frame;
-    private boolean showSaveDialog = false;
+    private boolean showSaveDialog;
 
     private static final Pattern REMOTE_LINK_PATTERN = Pattern.compile("[a-z]+://.*");
 

--- a/src/main/java/org/jabref/gui/importer/ImportInspectionDialog.java
+++ b/src/main/java/org/jabref/gui/importer/ImportInspectionDialog.java
@@ -1252,7 +1252,7 @@ public class ImportInspectionDialog extends JDialog implements ImportInspector, 
             }
             entry = selectionModel.getSelected().get(0);
             FileListEntry flEntry = new FileListEntry("", "");
-            FileListEntryEditor editor = new FileListEntryEditor(frame, flEntry, false, true, bibDatabaseContext);
+            FileListEntryEditor editor = new FileListEntryEditor(frame, flEntry, false, true, bibDatabaseContext, true);
             editor.setVisible(true, true);
             if (editor.okPressed()) {
                 FileListTableModel localModel = new FileListTableModel();

--- a/src/main/java/org/jabref/gui/util/FileDialogConfiguration.java
+++ b/src/main/java/org/jabref/gui/util/FileDialogConfiguration.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.util;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -16,6 +17,8 @@ public class FileDialogConfiguration {
 
     private final List<FileChooser.ExtensionFilter> extensionFilters;
     private final Path initialDirectory;
+    private final FileChooser.ExtensionFilter defaultExtension;
+    private final String initialFileName;
 
     public Optional<Path> getInitialDirectory() {
         return Optional.ofNullable(initialDirectory);
@@ -25,12 +28,16 @@ public class FileDialogConfiguration {
         return defaultExtension;
     }
 
-    private FileChooser.ExtensionFilter defaultExtension;
+    public String getInitialFileName() {
+        return initialFileName;
+    }
 
-    private FileDialogConfiguration(Path initialDirectory, List<FileChooser.ExtensionFilter> extensionFilters, FileChooser.ExtensionFilter defaultExtension) {
+    private FileDialogConfiguration(Path initialDirectory, List<FileChooser.ExtensionFilter> extensionFilters,
+            FileChooser.ExtensionFilter defaultExtension, String initialFileName) {
         this.initialDirectory = initialDirectory;
         this.extensionFilters = Objects.requireNonNull(extensionFilters);
         this.defaultExtension = defaultExtension;
+        this.initialFileName = initialFileName;
     }
 
     public List<FileChooser.ExtensionFilter> getExtensionFilters() {
@@ -38,9 +45,11 @@ public class FileDialogConfiguration {
     }
 
     public static class Builder {
+
         List<FileChooser.ExtensionFilter> extensionFilter = new ArrayList<>();
         private Path initialDirectory;
         private FileChooser.ExtensionFilter defaultExtension;
+        private String initialFileName;
 
         public Builder addExtensionFilter(FileExtensions extension) {
             extensionFilter.add(toFilter(extension));
@@ -58,10 +67,20 @@ public class FileDialogConfiguration {
         }
 
         public FileDialogConfiguration build() {
-            return new FileDialogConfiguration(initialDirectory, extensionFilter, defaultExtension);
+            return new FileDialogConfiguration(initialDirectory, extensionFilter, defaultExtension, initialFileName);
         }
 
         public Builder withInitialDirectory(Path directory) {
+
+            //Dir must be a folder, not a file
+            if (!Files.isDirectory(directory)) {
+                directory = directory.getParent();
+            }
+            //The lines above work also if the dir does not exist at all!
+            //NULL is accepted by the filechooser as no inital path
+            if (!Files.exists(directory)) {
+                directory = null;
+            }
             initialDirectory = directory;
             return this;
         }
@@ -69,6 +88,12 @@ public class FileDialogConfiguration {
         public Builder withDefaultExtension(FileExtensions extension) {
             defaultExtension = toFilter(extension);
             return this;
+        }
+
+        public Builder withInitialFileName(String initialFileName) {
+            this.initialFileName = initialFileName;
+            return this;
+
         }
     }
 }


### PR DESCRIPTION
Fix for #2572 
When running Get fulltext, the dialog is now a save dialog which enables to select a different folder or even a different filename. The initial filename which JabRef assigns is now also visible in the file dialog

<!-- describe the changes you have made here: what, why, ... -->

- [X] Change in CHANGELOG.md described
~- [ ] Tests created for changes~
~- [X] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
~- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org]~(https://github.com/JabRef/help.jabref.org/issues)?)
~- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?~


![savefile](https://cloud.githubusercontent.com/assets/320228/23722891/60519cd2-0447-11e7-8628-ed9d53c99326.png)

![grafik](https://cloud.githubusercontent.com/assets/320228/23722873/530ed71a-0447-11e7-8e1a-be3bd5273eaa.png)
