### PR TITLE
[WIP] Make Drag & Drop work from Swing to javafx group panel

### DIFF
--- a/src/main/java/org/jabref/gui/ClipBoardManager.java
+++ b/src/main/java/org/jabref/gui/ClipBoardManager.java
@@ -84,9 +84,12 @@ public class ClipBoardManager implements ClipboardOwner {
         if (content.isDataFlavorSupported(TransferableBibtexEntry.entryFlavor)) {
             // We have determined that the clipboard data is a set of entries.
             try  {
+
+
                 @SuppressWarnings("unchecked")
                 List<BibEntry> contents = (List<BibEntry>) content.getTransferData(TransferableBibtexEntry.entryFlavor);
                 result = contents;
+
             } catch (UnsupportedFlavorException | ClassCastException ex) {
                 LOGGER.warn("Could not paste this type", ex);
             } catch (IOException ex) {

--- a/src/main/java/org/jabref/gui/groups/GroupTreeController.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeController.java
@@ -2,6 +2,7 @@ package org.jabref.gui.groups;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+
 import javax.inject.Inject;
 
 import javafx.beans.property.ObjectProperty;
@@ -31,6 +32,7 @@ import org.jabref.gui.util.BindingsHelper;
 import org.jabref.gui.util.RecursiveTreeItem;
 import org.jabref.gui.util.ViewModelTreeTableCellFactory;
 import org.jabref.logic.l10n.Localization;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.controlsfx.control.textfield.CustomTextField;

--- a/src/main/java/org/jabref/gui/groups/GroupTreeController.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeController.java
@@ -18,7 +18,6 @@ import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeTableColumn;
 import javafx.scene.control.TreeTableRow;
 import javafx.scene.control.TreeTableView;
-import javafx.scene.input.DataFormat;
 import javafx.scene.input.DragEvent;
 import javafx.scene.input.Dragboard;
 import javafx.scene.input.TransferMode;
@@ -153,11 +152,8 @@ public class GroupTreeController extends AbstractController<GroupTreeViewModel> 
 
             @Override
             public void handle(DragEvent event) {
-                System.out.println("OnDragDOver");
-
                 event.acceptTransferModes(TransferMode.ANY);
                 event.consume();
-
             }
         });
         groupTree.setOnDragDropped(new EventHandler<DragEvent>() {
@@ -167,10 +163,9 @@ public class GroupTreeController extends AbstractController<GroupTreeViewModel> 
 
                 Dragboard db = event.getDragboard();
 
-                for (DataFormat df1 : db.getContentTypes()) {
-                    System.out.println("GetContent DragDropped " + db.getContent(df1));
-
-                }
+                TransferableEntrySelection entrySelection = (TransferableEntrySelection) db
+                        .getContent(TransferableEntrySelection.DATAFORMAT);
+                System.out.println(entrySelection.getSelection()); //list of bib entries
 
             }
 

--- a/src/main/java/org/jabref/gui/groups/TransferableEntrySelection.java
+++ b/src/main/java/org/jabref/gui/groups/TransferableEntrySelection.java
@@ -15,7 +15,7 @@ import org.jabref.model.entry.BibEntry;
 
 public class TransferableEntrySelection implements Transferable {
 
-    public static DataFormat FORMAT = new DataFormat("application/x-java-jvm-local-objectref");
+    public static DataFormat DATAFORMAT = new DataFormat("application/x-java-jvm-local-objectref");
 
     public static final DataFlavor FLAVOR_INTERNAL;
     private static final DataFlavor FLAVOR_EXTERNAL;


### PR DESCRIPTION
First version of getting Drag & Drop from Swing main table to javafx groups panel to work

@tobiasdiez  I succesfully managed to get Drag & Drop working from Swing to the javafx groups panel and I am now able to get a list of selected BibEntries 
Maybe you can tell me where I can assign them to a group them?
(took me some time to understand the DataFlavor/DataFormat incompatibilities )



<!-- describe the changes you have made here: what, why, ... -->

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
