### PR TITLE
Finally write the new group properties to the bib file: icon with color, description, expanded status and automatic groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We renamed "database" to "library" to have a real distinction to SQL and NoSQL databases. [#2095](https://github.com/JabRef/jabref/issues/2095)
 - We added MathSciNet as a ID-based fetcher in the `BibTeX -> New entry` dialog (implements a [feature request in the forum](http://discourse.jabref.org/t/allow-to-search-by-mr-number-mathscinet))
 - Removed the apache.commons.collections library
+- We added a few properties to a group:
+    - Icon (with customizable color) that is shown in the groups panel (implements a [feature request in the forum](http://discourse.jabref.org/t/assign-colors-to-groups/321)).
+    - Description text that is shown on mouse hover (implements old feature requests [489](https://sourceforge.net/p/jabref/feature-requests/489/) and [818](https://sourceforge.net/p/jabref/feature-requests/818/)
+- We introduced "automatic groups" that automatically create subgroups based on a certain criteria (e.g. a subgroup for every author or keyword). Implements [91](https://sourceforge.net/p/jabref/feature-requests/91/), [398](https://sourceforge.net/p/jabref/feature-requests/398/) and [#1173](https://github.com/JabRef/jabref/issues/1173).
+- Expansion status of groups are saved across sessions. [#1428](https://github.com/JabRef/jabref/issues/1428)
 - We removed the ordinals-to-superscript formatter from the recommendations for biblatex save actions [#2596](https://github.com/JabRef/jabref/issues/2596)
 - The `Move linked files to default file directory`-Cleanup operation respects the `File directory pattern` setting 
 - We separated the `Move file` and `Rename Pdfs` logic and context menu entries in the `General`-Tab for the Field `file` to improve the semantics

--- a/src/main/java/org/jabref/logic/exporter/GroupSerializer.java
+++ b/src/main/java/org/jabref/logic/exporter/GroupSerializer.java
@@ -8,6 +8,9 @@ import javafx.scene.paint.Color;
 import org.jabref.logic.util.MetadataSerializationConfiguration;
 import org.jabref.model.groups.AbstractGroup;
 import org.jabref.model.groups.AllEntriesGroup;
+import org.jabref.model.groups.AutomaticGroup;
+import org.jabref.model.groups.AutomaticKeywordGroup;
+import org.jabref.model.groups.AutomaticPersonsGroup;
 import org.jabref.model.groups.ExplicitGroup;
 import org.jabref.model.groups.GroupTreeNode;
 import org.jabref.model.groups.KeywordGroup;
@@ -117,8 +120,41 @@ public class GroupSerializer {
             return serializeKeywordGroup((KeywordGroup)group);
         } else if (group instanceof SearchGroup) {
             return serializeSearchGroup((SearchGroup)group);
+        } else if (group instanceof AutomaticKeywordGroup) {
+            return serializeAutomaticKeywordGroup((AutomaticKeywordGroup)group);
+        } else if (group instanceof AutomaticPersonsGroup) {
+            return serializeAutomaticPersonsGroup((AutomaticPersonsGroup)group);
         } else {
             throw new UnsupportedOperationException("Don't know how to serialize group" + group.getClass().getName());
         }
+    }
+
+    private String serializeAutomaticPersonsGroup(AutomaticPersonsGroup group) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(MetadataSerializationConfiguration.AUTOMATIC_PERSONS_GROUP_ID);
+        appendAutomaticGroupDetails(sb, group);
+        sb.append(StringUtil.quote(group.getField(), MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR, MetadataSerializationConfiguration.GROUP_QUOTE_CHAR));
+        sb.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
+        appendGroupDetails(sb, group);
+        return sb.toString();
+    }
+
+    private void appendAutomaticGroupDetails(StringBuilder builder, AutomaticGroup group) {
+        builder.append(StringUtil.quote(group.getName(), MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR, MetadataSerializationConfiguration.GROUP_QUOTE_CHAR));
+        builder.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
+        builder.append(group.getHierarchicalContext().ordinal());
+        builder.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
+    }
+
+    private String serializeAutomaticKeywordGroup(AutomaticKeywordGroup group) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(MetadataSerializationConfiguration.AUTOMATIC_KEYWORD_GROUP_ID);
+        appendAutomaticGroupDetails(sb, group);
+        sb.append(StringUtil.quote(group.getField(), MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR, MetadataSerializationConfiguration.GROUP_QUOTE_CHAR));
+        sb.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
+        sb.append(group.getKeywordSeperator());
+        sb.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
+        appendGroupDetails(sb, group);
+        return sb.toString();
     }
 }

--- a/src/main/java/org/jabref/logic/exporter/GroupSerializer.java
+++ b/src/main/java/org/jabref/logic/exporter/GroupSerializer.java
@@ -2,8 +2,8 @@ package org.jabref.logic.exporter;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
+
+import javafx.scene.paint.Color;
 
 import org.jabref.logic.util.MetadataSerializationConfiguration;
 import org.jabref.model.groups.AbstractGroup;
@@ -28,14 +28,8 @@ public class GroupSerializer {
         sb.append(group.getHierarchicalContext().ordinal());
         sb.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
 
-        // write legacy entry keys in well-defined order for CVS compatibility
-        Set<String> sortedKeys = new TreeSet<>();
-        sortedKeys.addAll(group.getLegacyEntryKeys());
+        appendGroupDetails(sb, group);
 
-        for (String sortedKey : sortedKeys) {
-            sb.append(StringUtil.quote(sortedKey, MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR, MetadataSerializationConfiguration.GROUP_QUOTE_CHAR));
-            sb.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
-        }
         return sb.toString();
     }
 
@@ -55,6 +49,9 @@ public class GroupSerializer {
         sb.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
         sb.append(StringUtil.booleanToBinaryString(isRegex));
         sb.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
+
+        appendGroupDetails(sb, group);
+
         return sb.toString();
     }
 
@@ -71,9 +68,22 @@ public class GroupSerializer {
         sb.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
         sb.append(StringUtil.booleanToBinaryString(group.isRegularExpression()));
         sb.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
+
+        appendGroupDetails(sb, group);
+
         return sb.toString();
     }
 
+    private void appendGroupDetails(StringBuilder builder, AbstractGroup group) {
+        builder.append(StringUtil.booleanToBinaryString(group.isExpanded()));
+        builder.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
+        builder.append(group.getColor().map(Color::toString).orElse(""));
+        builder.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
+        builder.append(group.getIconCode().orElse(""));
+        builder.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
+        builder.append(group.getDescription().orElse(""));
+        builder.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
+    }
 
     /**
      * Returns a textual representation of this node and its children. This

--- a/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
@@ -8,6 +8,8 @@ import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.MetadataSerializationConfiguration;
 import org.jabref.logic.util.strings.QuotedStringTokenizer;
 import org.jabref.model.groups.AbstractGroup;
+import org.jabref.model.groups.AutomaticKeywordGroup;
+import org.jabref.model.groups.AutomaticPersonsGroup;
 import org.jabref.model.groups.ExplicitGroup;
 import org.jabref.model.groups.GroupHierarchyType;
 import org.jabref.model.groups.GroupTreeNode;
@@ -87,7 +89,41 @@ public class GroupsParser {
         if (s.startsWith(MetadataSerializationConfiguration.LEGACY_EXPLICIT_GROUP_ID)) {
             return GroupsParser.legacyExplicitGroupFromString(s, keywordSeparator);
         }
-        return null; // unknown group
+        if (s.startsWith(MetadataSerializationConfiguration.AUTOMATIC_PERSONS_GROUP_ID)) {
+            return GroupsParser.automaticPersonsGroupFromString(s, keywordSeparator);
+        }
+        if (s.startsWith(MetadataSerializationConfiguration.AUTOMATIC_KEYWORD_GROUP_ID)) {
+            return GroupsParser.automaticKeywordGroupFromString(s, keywordSeparator);
+        }
+
+        throw new ParseException("Unknown group: " + s);
+    }
+
+    private static AbstractGroup automaticPersonsGroupFromString(String string, Character keywordSeparator) {
+        if (!string.startsWith(MetadataSerializationConfiguration.AUTOMATIC_PERSONS_GROUP_ID)) {
+            throw new IllegalArgumentException("KeywordGroup cannot be created from \"" + string + "\".");
+        }
+        QuotedStringTokenizer tok = new QuotedStringTokenizer(string.substring(MetadataSerializationConfiguration.AUTOMATIC_PERSONS_GROUP_ID
+                .length()), MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR, MetadataSerializationConfiguration.GROUP_QUOTE_CHAR);
+
+        String name = StringUtil.unquote(tok.nextToken(), MetadataSerializationConfiguration.GROUP_QUOTE_CHAR);
+        GroupHierarchyType context = GroupHierarchyType.getByNumberOrDefault(Integer.parseInt(tok.nextToken()));
+        String field = StringUtil.unquote(tok.nextToken(), MetadataSerializationConfiguration.GROUP_QUOTE_CHAR);
+        return new AutomaticPersonsGroup(name, context, field);
+    }
+
+    private static AbstractGroup automaticKeywordGroupFromString(String string, Character keywordSeparator) {
+        if (!string.startsWith(MetadataSerializationConfiguration.AUTOMATIC_KEYWORD_GROUP_ID)) {
+            throw new IllegalArgumentException("KeywordGroup cannot be created from \"" + string + "\".");
+        }
+        QuotedStringTokenizer tok = new QuotedStringTokenizer(string.substring(MetadataSerializationConfiguration.AUTOMATIC_KEYWORD_GROUP_ID
+                .length()), MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR, MetadataSerializationConfiguration.GROUP_QUOTE_CHAR);
+
+        String name = StringUtil.unquote(tok.nextToken(), MetadataSerializationConfiguration.GROUP_QUOTE_CHAR);
+        GroupHierarchyType context = GroupHierarchyType.getByNumberOrDefault(Integer.parseInt(tok.nextToken()));
+        String field = StringUtil.unquote(tok.nextToken(), MetadataSerializationConfiguration.GROUP_QUOTE_CHAR);
+        Character separator = tok.nextToken().charAt(0);
+        return new AutomaticKeywordGroup(name, context, field, separator);
     }
 
     /**

--- a/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
@@ -90,16 +90,16 @@ public class GroupsParser {
             return GroupsParser.legacyExplicitGroupFromString(s, keywordSeparator);
         }
         if (s.startsWith(MetadataSerializationConfiguration.AUTOMATIC_PERSONS_GROUP_ID)) {
-            return GroupsParser.automaticPersonsGroupFromString(s, keywordSeparator);
+            return GroupsParser.automaticPersonsGroupFromString(s);
         }
         if (s.startsWith(MetadataSerializationConfiguration.AUTOMATIC_KEYWORD_GROUP_ID)) {
-            return GroupsParser.automaticKeywordGroupFromString(s, keywordSeparator);
+            return GroupsParser.automaticKeywordGroupFromString(s);
         }
 
         throw new ParseException("Unknown group: " + s);
     }
 
-    private static AbstractGroup automaticPersonsGroupFromString(String string, Character keywordSeparator) {
+    private static AbstractGroup automaticPersonsGroupFromString(String string) {
         if (!string.startsWith(MetadataSerializationConfiguration.AUTOMATIC_PERSONS_GROUP_ID)) {
             throw new IllegalArgumentException("KeywordGroup cannot be created from \"" + string + "\".");
         }
@@ -112,7 +112,7 @@ public class GroupsParser {
         return new AutomaticPersonsGroup(name, context, field);
     }
 
-    private static AbstractGroup automaticKeywordGroupFromString(String string, Character keywordSeparator) {
+    private static AbstractGroup automaticKeywordGroupFromString(String string) {
         if (!string.startsWith(MetadataSerializationConfiguration.AUTOMATIC_KEYWORD_GROUP_ID)) {
             throw new IllegalArgumentException("KeywordGroup cannot be created from \"" + string + "\".");
         }

--- a/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
@@ -109,7 +109,9 @@ public class GroupsParser {
         String name = StringUtil.unquote(tok.nextToken(), MetadataSerializationConfiguration.GROUP_QUOTE_CHAR);
         GroupHierarchyType context = GroupHierarchyType.getByNumberOrDefault(Integer.parseInt(tok.nextToken()));
         String field = StringUtil.unquote(tok.nextToken(), MetadataSerializationConfiguration.GROUP_QUOTE_CHAR);
-        return new AutomaticPersonsGroup(name, context, field);
+        AutomaticPersonsGroup newGroup = new AutomaticPersonsGroup(name, context, field);
+        addGroupDetails(tok, newGroup);
+        return newGroup;
     }
 
     private static AbstractGroup automaticKeywordGroupFromString(String string) {
@@ -123,7 +125,9 @@ public class GroupsParser {
         GroupHierarchyType context = GroupHierarchyType.getByNumberOrDefault(Integer.parseInt(tok.nextToken()));
         String field = StringUtil.unquote(tok.nextToken(), MetadataSerializationConfiguration.GROUP_QUOTE_CHAR);
         Character separator = tok.nextToken().charAt(0);
-        return new AutomaticKeywordGroup(name, context, field, separator);
+        AutomaticKeywordGroup newGroup = new AutomaticKeywordGroup(name, context, field, separator);
+        addGroupDetails(tok, newGroup);
+        return newGroup;
     }
 
     /**
@@ -145,11 +149,14 @@ public class GroupsParser {
         String expression = StringUtil.unquote(tok.nextToken(), MetadataSerializationConfiguration.GROUP_QUOTE_CHAR);
         boolean caseSensitive = Integer.parseInt(tok.nextToken()) == 1;
         boolean regExp = Integer.parseInt(tok.nextToken()) == 1;
+        KeywordGroup newGroup;
         if (regExp) {
-            return new RegexKeywordGroup(name, context, field, expression, caseSensitive);
+            newGroup = new RegexKeywordGroup(name, context, field, expression, caseSensitive);
         } else {
-            return new WordKeywordGroup(name, context, field, expression, caseSensitive, keywordSeparator, false);
+            newGroup = new WordKeywordGroup(name, context, field, expression, caseSensitive, keywordSeparator, false);
         }
+        addGroupDetails(tok, newGroup);
+        return newGroup;
     }
 
     private static ExplicitGroup explicitGroupFromString(String input, Character keywordSeparator) throws ParseException {
@@ -234,9 +241,11 @@ public class GroupsParser {
     }
 
     private static void addGroupDetails(QuotedStringTokenizer tokenizer, AbstractGroup group) {
-        group.setExpanded(Integer.parseInt(tokenizer.nextToken()) == 1);
-        group.setColor(tokenizer.nextToken());
-        group.setIconCode(tokenizer.nextToken());
-        group.setDescription(tokenizer.nextToken());
+        if (tokenizer.hasMoreTokens()) {
+            group.setExpanded(Integer.parseInt(tokenizer.nextToken()) == 1);
+            group.setColor(tokenizer.nextToken());
+            group.setIconCode(tokenizer.nextToken());
+            group.setDescription(tokenizer.nextToken());
+        }
     }
 }

--- a/src/main/java/org/jabref/logic/util/MetadataSerializationConfiguration.java
+++ b/src/main/java/org/jabref/logic/util/MetadataSerializationConfiguration.java
@@ -1,12 +1,12 @@
 package org.jabref.logic.util;
 
 import org.jabref.model.groups.AllEntriesGroup;
+import org.jabref.model.groups.AutomaticKeywordGroup;
+import org.jabref.model.groups.AutomaticPersonsGroup;
 import org.jabref.model.groups.ExplicitGroup;
 import org.jabref.model.groups.RegexKeywordGroup;
 import org.jabref.model.groups.SearchGroup;
 import org.jabref.model.groups.WordKeywordGroup;
-import org.jabref.model.groups.AutomaticPersonsGroup;
-import org.jabref.model.groups.AutomaticKeywordGroup;
 
 /**
  * Specifies how metadata is read and written.

--- a/src/main/java/org/jabref/logic/util/MetadataSerializationConfiguration.java
+++ b/src/main/java/org/jabref/logic/util/MetadataSerializationConfiguration.java
@@ -31,9 +31,15 @@ public class MetadataSerializationConfiguration {
     public static final String ALL_ENTRIES_GROUP_ID = "AllEntriesGroup:";
 
     /**
+     * Old identifier for {@link ExplicitGroup} (explicitly contained a list of {@link
+     * org.jabref.model.entry.BibEntry}).
+     */
+    public static final String LEGACY_EXPLICIT_GROUP_ID = "ExplicitGroup:";
+
+    /**
      * Identifier for {@link ExplicitGroup}.
      */
-    public static final String EXPLICIT_GROUP_ID = "ExplicitGroup:";
+    public static final String EXPLICIT_GROUP_ID = "StaticGroup:";
 
     /**
      * Identifier for {@link SearchGroup}.

--- a/src/main/java/org/jabref/logic/util/MetadataSerializationConfiguration.java
+++ b/src/main/java/org/jabref/logic/util/MetadataSerializationConfiguration.java
@@ -5,6 +5,8 @@ import org.jabref.model.groups.ExplicitGroup;
 import org.jabref.model.groups.RegexKeywordGroup;
 import org.jabref.model.groups.SearchGroup;
 import org.jabref.model.groups.WordKeywordGroup;
+import org.jabref.model.groups.AutomaticPersonsGroup;
+import org.jabref.model.groups.AutomaticKeywordGroup;
 
 /**
  * Specifies how metadata is read and written.
@@ -45,4 +47,14 @@ public class MetadataSerializationConfiguration {
      * Identifier for {@link SearchGroup}.
      */
     public static final String SEARCH_GROUP_ID = "SearchGroup:";
+
+    /**
+     * Identifier for {@link AutomaticPersonsGroup}.
+     */
+    public static final String AUTOMATIC_PERSONS_GROUP_ID = "AutomaticPersonsGroup:";
+
+    /**
+     * Identifier for {@link AutomaticKeywordGroup}.
+     */
+    public static final String AUTOMATIC_KEYWORD_GROUP_ID = "AutomaticKeywordGroup:";
 }

--- a/src/main/java/org/jabref/logic/util/strings/QuotedStringTokenizer.java
+++ b/src/main/java/org/jabref/logic/util/strings/QuotedStringTokenizer.java
@@ -47,9 +47,7 @@ public class QuotedStringTokenizer {
                 }
             } else if (isDelimiter(c)) { // unit finished
                 // advance index until next token or end
-                do {
-                    ++index;
-                } while (index < contentLength && isDelimiter(content.charAt(index)));
+                ++index;
                 return stringBuilder.toString();
             } else {
                 stringBuilder.append(c);

--- a/src/main/java/org/jabref/model/groups/AbstractGroup.java
+++ b/src/main/java/org/jabref/model/groups/AbstractGroup.java
@@ -8,6 +8,7 @@ import javafx.scene.paint.Color;
 
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.search.SearchMatcher;
+import org.jabref.model.strings.StringUtil;
 
 /**
  * Base class for all groups.
@@ -34,6 +35,14 @@ public abstract class AbstractGroup implements SearchMatcher {
 
     public Optional<Color> getColor() {
         return color;
+    }
+
+    public void setColor(String colorString) {
+        if (StringUtil.isBlank(colorString)) {
+            color = Optional.empty();
+        } else {
+            setColor(Color.valueOf(colorString));
+        }
     }
 
     public void setColor(Color color) {

--- a/src/main/java/org/jabref/model/groups/AutomaticKeywordGroup.java
+++ b/src/main/java/org/jabref/model/groups/AutomaticKeywordGroup.java
@@ -1,5 +1,6 @@
 package org.jabref.model.groups;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -30,6 +31,20 @@ public class AutomaticKeywordGroup extends AutomaticGroup {
     @Override
     public AbstractGroup deepCopy() {
         return new AutomaticKeywordGroup(this.name, this.context, field, this.keywordSeperator);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AutomaticKeywordGroup that = (AutomaticKeywordGroup) o;
+        return Objects.equals(keywordSeperator, that.keywordSeperator) &&
+                Objects.equals(field, that.field);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(keywordSeperator, field);
     }
 
     @Override

--- a/src/main/java/org/jabref/model/groups/AutomaticPersonsGroup.java
+++ b/src/main/java/org/jabref/model/groups/AutomaticPersonsGroup.java
@@ -1,5 +1,6 @@
 package org.jabref.model.groups;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -16,6 +17,19 @@ public class AutomaticPersonsGroup extends AutomaticGroup {
     public AutomaticPersonsGroup(String name, GroupHierarchyType context, String field) {
         super(name, context);
         this.field = field;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AutomaticPersonsGroup that = (AutomaticPersonsGroup) o;
+        return Objects.equals(field, that.field);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(field);
     }
 
     @Override

--- a/src/main/java/org/jabref/model/groups/ExplicitGroup.java
+++ b/src/main/java/org/jabref/model/groups/ExplicitGroup.java
@@ -45,8 +45,13 @@ public class ExplicitGroup extends WordKeywordGroup {
             return false;
         }
         ExplicitGroup other = (ExplicitGroup) o;
-        return Objects.equals(getName(), other.getName()) && Objects.equals(getHierarchicalContext(),
-                other.getHierarchicalContext()) && Objects.equals(getLegacyEntryKeys(), other.getLegacyEntryKeys());
+        return Objects.equals(getName(), other.getName())
+                && Objects.equals(getHierarchicalContext(), other.getHierarchicalContext())
+                && Objects.equals(getIconCode(), other.getIconCode())
+                && Objects.equals(getDescription(), other.getDescription())
+                && Objects.equals(getColor(), other.getColor())
+                && Objects.equals(isExpanded(), other.isExpanded())
+                && Objects.equals(getLegacyEntryKeys(), other.getLegacyEntryKeys());
     }
 
     public void clearLegacyEntryKeys() {
@@ -59,7 +64,7 @@ public class ExplicitGroup extends WordKeywordGroup {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, context, legacyEntryKeys);
+        return Objects.hash(name, context, legacyEntryKeys, iconCode, color, description, isExpanded);
     }
 
     @Override

--- a/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -196,7 +196,7 @@ public class BibtexDatabaseWriterTest {
         assertEquals(OS.NEWLINE
                 + "@Comment{jabref-meta: groupstree:" + OS.NEWLINE
                 + "0 AllEntriesGroup:;" + OS.NEWLINE
-                + "1 ExplicitGroup:test\\;2\\;;" + OS.NEWLINE
+                + "1 StaticGroup:test\\;2\\;1\\;\\;\\;\\;;" + OS.NEWLINE
                 + "}" + OS.NEWLINE, session.getStringValue());
         // @formatter:on
     }
@@ -217,7 +217,7 @@ public class BibtexDatabaseWriterTest {
                 OS.NEWLINE
                 + "@Comment{jabref-meta: groupstree:" + OS.NEWLINE
                 + "0 AllEntriesGroup:;" + OS.NEWLINE
-                + "1 ExplicitGroup:test\\;2\\;;" + OS.NEWLINE
+                        + "1 StaticGroup:test\\;2\\;1\\;\\;\\;\\;;" + OS.NEWLINE
                 + "}" + OS.NEWLINE, session.getStringValue());
         // @formatter:on
     }

--- a/src/test/java/org/jabref/logic/exporter/GroupSerializerTest.java
+++ b/src/test/java/org/jabref/logic/exporter/GroupSerializerTest.java
@@ -7,6 +7,9 @@ import java.util.List;
 import javafx.scene.paint.Color;
 
 import org.jabref.model.groups.AllEntriesGroup;
+import org.jabref.model.groups.AutomaticGroup;
+import org.jabref.model.groups.AutomaticKeywordGroup;
+import org.jabref.model.groups.AutomaticPersonsGroup;
 import org.jabref.model.groups.ExplicitGroup;
 import org.jabref.model.groups.GroupHierarchyType;
 import org.jabref.model.groups.GroupTreeNode;
@@ -89,6 +92,20 @@ public class GroupSerializerTest {
         SearchGroup group = new SearchGroup("myExplicitGroup", GroupHierarchyType.INCLUDING, "author=\"harrer\"", true, false);
         List<String> serialization = groupSerializer.serializeTree(GroupTreeNode.fromGroup(group));
         assertEquals(Collections.singletonList("0 SearchGroup:myExplicitGroup;2;author=\"harrer\";1;0;1;;;;"), serialization);
+    }
+
+    @Test
+    public void serializeSingleAutomaticKeywordGroup() {
+        AutomaticGroup group = new AutomaticKeywordGroup("myAutomaticGroup", GroupHierarchyType.INDEPENDENT, "keywords", ',');
+        List<String> serialization = groupSerializer.serializeTree(GroupTreeNode.fromGroup(group));
+        assertEquals(Collections.singletonList("0 AutomaticKeywordGroup:myAutomaticGroup;0;keywords;,;1;;;;"), serialization);
+    }
+
+    @Test
+    public void serializeSingleAutomaticPersonGroup() {
+        AutomaticPersonsGroup group = new AutomaticPersonsGroup("myAutomaticGroup", GroupHierarchyType.INDEPENDENT, "authors");
+        List<String> serialization = groupSerializer.serializeTree(GroupTreeNode.fromGroup(group));
+        assertEquals(Collections.singletonList("0 AutomaticPersonsGroup:myAutomaticGroup;0;authors;1;;;;"), serialization);
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/exporter/GroupSerializerTest.java
+++ b/src/test/java/org/jabref/logic/exporter/GroupSerializerTest.java
@@ -4,6 +4,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import javafx.scene.paint.Color;
+
 import org.jabref.model.groups.AllEntriesGroup;
 import org.jabref.model.groups.ExplicitGroup;
 import org.jabref.model.groups.GroupHierarchyType;
@@ -39,7 +41,18 @@ public class GroupSerializerTest {
     public void serializeSingleExplicitGroup() {
         ExplicitGroup group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INDEPENDENT, ',');
         List<String> serialization = groupSerializer.serializeTree(GroupTreeNode.fromGroup(group));
-        assertEquals(Collections.singletonList("0 ExplicitGroup:myExplicitGroup;0;"), serialization);
+        assertEquals(Collections.singletonList("0 StaticGroup:myExplicitGroup;0;1;;;;"), serialization);
+    }
+
+    @Test
+    public void serializeSingleExplicitGroupWithIconAndDescription() {
+        ExplicitGroup group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INDEPENDENT, ',');
+        group.setIconCode("test icon");
+        group.setExpanded(true);
+        group.setColor(Color.ALICEBLUE);
+        group.setDescription("test description");
+        List<String> serialization = groupSerializer.serializeTree(GroupTreeNode.fromGroup(group));
+        assertEquals(Collections.singletonList("0 StaticGroup:myExplicitGroup;0;1;0xf0f8ffff;test icon;test description;"), serialization);
     }
 
     @Test
@@ -47,35 +60,35 @@ public class GroupSerializerTest {
     public void serializeSingleExplicitGroupWithEscapedSlash() {
         ExplicitGroup group = new ExplicitGroup("B{\\\"{o}}hmer", GroupHierarchyType.INDEPENDENT, ',');
         List<String> serialization = groupSerializer.serializeTree(GroupTreeNode.fromGroup(group));
-        assertEquals(Collections.singletonList("0 ExplicitGroup:B{\\\\\"{o}}hmer;0;"), serialization);
+        assertEquals(Collections.singletonList("0 StaticGroup:B{\\\\\"{o}}hmer;0;1;;;;"), serialization);
     }
 
     @Test
     public void serializeSingleSimpleKeywordGroup() {
         WordKeywordGroup group = new WordKeywordGroup("name", GroupHierarchyType.INDEPENDENT, "keywords", "test", false, ',', false);
         List<String> serialization = groupSerializer.serializeTree(GroupTreeNode.fromGroup(group));
-        assertEquals(Collections.singletonList("0 KeywordGroup:name;0;keywords;test;0;0;"), serialization);
+        assertEquals(Collections.singletonList("0 KeywordGroup:name;0;keywords;test;0;0;1;;;;"), serialization);
     }
 
     @Test
     public void serializeSingleRegexKeywordGroup() {
         KeywordGroup group = new RegexKeywordGroup("myExplicitGroup", GroupHierarchyType.REFINING, "author", "asdf", false);
         List<String> serialization = groupSerializer.serializeTree(GroupTreeNode.fromGroup(group));
-        assertEquals(Collections.singletonList("0 KeywordGroup:myExplicitGroup;1;author;asdf;0;1;"), serialization);
+        assertEquals(Collections.singletonList("0 KeywordGroup:myExplicitGroup;1;author;asdf;0;1;1;;;;"), serialization);
     }
 
     @Test
     public void serializeSingleSearchGroup() {
         SearchGroup group = new SearchGroup("myExplicitGroup", GroupHierarchyType.INDEPENDENT, "author=harrer", true, true);
         List<String> serialization = groupSerializer.serializeTree(GroupTreeNode.fromGroup(group));
-        assertEquals(Collections.singletonList("0 SearchGroup:myExplicitGroup;0;author=harrer;1;1;"), serialization);
+        assertEquals(Collections.singletonList("0 SearchGroup:myExplicitGroup;0;author=harrer;1;1;1;;;;"), serialization);
     }
 
     @Test
     public void serializeSingleSearchGroupWithRegex() {
         SearchGroup group = new SearchGroup("myExplicitGroup", GroupHierarchyType.INCLUDING, "author=\"harrer\"", true, false);
         List<String> serialization = groupSerializer.serializeTree(GroupTreeNode.fromGroup(group));
-        assertEquals(Collections.singletonList("0 SearchGroup:myExplicitGroup;2;author=\"harrer\";1;0;"), serialization);
+        assertEquals(Collections.singletonList("0 SearchGroup:myExplicitGroup;2;author=\"harrer\";1;0;1;;;;"), serialization);
     }
 
     @Test
@@ -85,9 +98,9 @@ public class GroupSerializerTest {
 
         List<String> expected = Arrays.asList(
                 "0 AllEntriesGroup:",
-                "1 ExplicitGroup:ExplicitA;2;",
-                "1 ExplicitGroup:ExplicitParent;0;",
-                "2 ExplicitGroup:ExplicitNode;1;"
+                "1 StaticGroup:ExplicitA;2;1;;;;",
+                "1 StaticGroup:ExplicitParent;0;1;;;;",
+                "2 StaticGroup:ExplicitNode;1;1;;;;"
         );
         assertEquals(expected, groupSerializer.serializeTree(root));
     }
@@ -99,19 +112,19 @@ public class GroupSerializerTest {
 
         List<String> expected = Arrays.asList(
                 "0 AllEntriesGroup:",
-                "1 SearchGroup:SearchA;2;searchExpression;1;0;",
-                "1 ExplicitGroup:ExplicitA;2;",
-                "1 ExplicitGroup:ExplicitGrandParent;0;",
-                "2 ExplicitGroup:ExplicitB;1;",
-                "2 KeywordGroup:KeywordParent;0;searchField;searchExpression;1;0;",
-                "3 KeywordGroup:KeywordNode;0;searchField;searchExpression;1;0;",
-                "4 ExplicitGroup:ExplicitChild;1;",
-                "3 SearchGroup:SearchC;2;searchExpression;1;0;",
-                "3 ExplicitGroup:ExplicitC;1;",
-                "3 KeywordGroup:KeywordC;0;searchField;searchExpression;1;0;",
-                "2 SearchGroup:SearchB;2;searchExpression;1;0;",
-                "2 KeywordGroup:KeywordB;0;searchField;searchExpression;1;0;",
-                "1 KeywordGroup:KeywordA;0;searchField;searchExpression;1;0;"
+                "1 SearchGroup:SearchA;2;searchExpression;1;0;1;;;;",
+                "1 StaticGroup:ExplicitA;2;1;;;;",
+                "1 StaticGroup:ExplicitGrandParent;0;1;;;;",
+                "2 StaticGroup:ExplicitB;1;1;;;;",
+                "2 KeywordGroup:KeywordParent;0;searchField;searchExpression;1;0;1;;;;",
+                "3 KeywordGroup:KeywordNode;0;searchField;searchExpression;1;0;1;;;;",
+                "4 StaticGroup:ExplicitChild;1;1;;;;",
+                "3 SearchGroup:SearchC;2;searchExpression;1;0;1;;;;",
+                "3 StaticGroup:ExplicitC;1;1;;;;",
+                "3 KeywordGroup:KeywordC;0;searchField;searchExpression;1;0;1;;;;",
+                "2 SearchGroup:SearchB;2;searchExpression;1;0;1;;;;",
+                "2 KeywordGroup:KeywordB;0;searchField;searchExpression;1;0;1;;;;",
+                "1 KeywordGroup:KeywordA;0;searchField;searchExpression;1;0;1;;;;"
         );
         assertEquals(expected, groupSerializer.serializeTree(root));
     }

--- a/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java
@@ -1,12 +1,16 @@
 package org.jabref.logic.importer.util;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import javafx.scene.paint.Color;
 
 import org.jabref.logic.importer.ParseException;
 import org.jabref.model.groups.AbstractGroup;
+import org.jabref.model.groups.AutomaticGroup;
+import org.jabref.model.groups.AutomaticKeywordGroup;
+import org.jabref.model.groups.AutomaticPersonsGroup;
 import org.jabref.model.groups.ExplicitGroup;
 import org.jabref.model.groups.GroupHierarchyType;
 import org.jabref.model.groups.GroupTreeNode;
@@ -69,5 +73,24 @@ public class GroupsParserTest {
         AbstractGroup parsed = GroupsParser.fromString("StaticGroup:myExplicitGroup;0;1;0xf0f8ffff;test icon;test description;", ',');
 
         assertEquals(expected, parsed);
+    }
+
+    @Test
+    public void fromStringParsesAutomaticKeywordGroup() throws Exception {
+        AutomaticGroup expected = new AutomaticKeywordGroup("myAutomaticGroup", GroupHierarchyType.INDEPENDENT, "keywords", ',');
+        AbstractGroup parsed = GroupsParser.fromString("AutomaticKeywordGroup:myAutomaticGroup;0;keywords;,;1;;;;", ',');
+        assertEquals(expected, parsed);
+    }
+
+    @Test
+    public void fromStringParsesAutomaticPersonGroup() throws Exception {
+        AutomaticPersonsGroup expected = new AutomaticPersonsGroup("myAutomaticGroup", GroupHierarchyType.INDEPENDENT, "authors");
+        AbstractGroup parsed = GroupsParser.fromString("AutomaticPersonsGroup:myAutomaticGroup;0;authors;1;;;;", ',');
+        assertEquals(expected, parsed);
+    }
+
+    @Test(expected = ParseException.class)
+    public void fromStringUnknownGroupThrowsException() throws Exception {
+        GroupsParser.fromString("0 UnknownGroup:myUnknownGroup;0;;1;;;;", ',');
     }
 }

--- a/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java
@@ -3,6 +3,8 @@ package org.jabref.logic.importer.util;
 import java.util.Arrays;
 import java.util.List;
 
+import javafx.scene.paint.Color;
+
 import org.jabref.logic.importer.ParseException;
 import org.jabref.model.groups.AbstractGroup;
 import org.jabref.model.groups.ExplicitGroup;
@@ -57,4 +59,15 @@ public class GroupsParserTest {
 
     }
 
+    @Test
+    public void fromStringParsesExplicitGroupWithIconAndDesrcitpion() throws Exception {
+        ExplicitGroup expected = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INDEPENDENT, ',');
+        expected.setIconCode("test icon");
+        expected.setExpanded(true);
+        expected.setColor(Color.ALICEBLUE);
+        expected.setDescription("test description");
+        AbstractGroup parsed = GroupsParser.fromString("StaticGroup:myExplicitGroup;0;1;0xf0f8ffff;test icon;test description;", ',');
+
+        assertEquals(expected, parsed);
+    }
 }

--- a/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java
@@ -1,7 +1,6 @@
 package org.jabref.logic.importer.util;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import javafx.scene.paint.Color;

--- a/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java
@@ -38,7 +38,7 @@ public class GroupsParserTest {
     public void testImportSubGroups() throws ParseException {
 
         List<String> orderedData = Arrays.asList("0 AllEntriesGroup:", "1 ExplicitGroup:1;0;",
-                "2 ExplicitGroup:2;0;;", "0 ExplicitGroup:3;0;;");
+                "2 ExplicitGroup:2;0;", "0 ExplicitGroup:3;0;");
         //Create group hierarchy:
         //  Level 0 Name: All entries
         //  Level 1 Name: 1

--- a/src/test/resources/testbib/complex.bib
+++ b/src/test/resources/testbib/complex.bib
@@ -24,21 +24,20 @@ This is some user comment in front of a string, should also be preserved.
   publisher = {Springer-Verlag}
 }
 
-@INPROCEEDINGS{1137631,
-  author = {Gustav Bostr\"{o}m and Jaana W\"{a}yrynen and Marine Bod\'{e}n and
-	Konstantin Beznosov and Philippe Kruchten},
-  title = {Extending XP practices to support security requirements engineering},
-  booktitle = {SESS '06: Proceedings of the 2006 international workshop on Software
-	engineering for secure systems},
-  year = {2006},
-  pages = {11--18},
-  address = {New York, NY, USA},
-  publisher = {ACM},
+@InProceedings{1137631,
+  author     = {Gustav Bostr\"{o}m and Jaana W\"{a}yrynen and Marine Bod\'{e}n and Konstantin Beznosov and Philippe Kruchten},
+  title      = {Extending XP practices to support security requirements engineering},
+  booktitle  = {SESS '06: Proceedings of the 2006 international workshop on Software engineering for secure systems},
+  year       = {2006},
+  publisher  = {ACM},
+  location   = {Shanghai, China},
+  isbn       = {1-59593-411-1},
+  pages      = {11--18},
+  doi        = {http://doi.acm.org/10.1145/1137627.1137631},
+  address    = {New York, NY, USA},
   bdsk-url-1 = {http://doi.acm.org/10.1145/1137627.1137631},
-  doi = {http://doi.acm.org/10.1145/1137627.1137631},
-  file = {:/Volumes/iDisk/Freie Universität Berlin/Semester 9/Softwareprozesse/p11-bostrom.pdf:PDF},
-  isbn = {1-59593-411-1},
-  location = {Shanghai, China}
+  file       = {:/Volumes/iDisk/Freie Universität Berlin/Semester 9/Softwareprozesse/p11-bostrom.pdf:PDF},
+  groups     = {StaticGroup},
 }
 
 @INPROCEEDINGS{1132768,
@@ -126,19 +125,19 @@ This is some user comment in front of a string, should also be preserved.
   location = {Pittsburgh, Pennsylvania}
 }
 
-@INPROCEEDINGS{1233448,
-  author = {Cheryl Hinds and Chinedu Ekwueme},
-  title = {Increasing security and usability of computer systems with graphical
-	passwords},
-  booktitle = {ACM-SE 45: Proceedings of the 45th annual southeast regional conference},
-  year = {2007},
-  pages = {529--530},
-  address = {New York, NY, USA},
-  publisher = {ACM},
+@InProceedings{1233448,
+  author     = {Cheryl Hinds and Chinedu Ekwueme},
+  title      = {Increasing security and usability of computer systems with graphical passwords},
+  booktitle  = {ACM-SE 45: Proceedings of the 45th annual southeast regional conference},
+  year       = {2007},
+  publisher  = {ACM},
+  location   = {Winston-Salem, North Carolina},
+  isbn       = {978-1-59593-629-5},
+  pages      = {529--530},
+  doi        = {http://doi.acm.org/10.1145/1233341.1233448},
+  address    = {New York, NY, USA},
   bdsk-url-1 = {http://doi.acm.org/10.1145/1233341.1233448},
-  doi = {http://doi.acm.org/10.1145/1233341.1233448},
-  isbn = {978-1-59593-629-5},
-  location = {Winston-Salem, North Carolina}
+  groups     = {StaticGroup},
 }
 
 @ARTICLE{10250999,
@@ -156,19 +155,19 @@ This is some user comment in front of a string, should also be preserved.
   publisher = {IEEE Educational Activities Department}
 }
 
-@INPROCEEDINGS{1314293,
-  author = {Mariusz H. Jakubowski and Ramarathnam Venkatesan},
-  title = {Randomized radon transforms for biometric authentication via fingerprint
-	hashing},
-  booktitle = {DRM '07: Proceedings of the 2007 ACM workshop on Digital Rights Management},
-  year = {2007},
-  pages = {90--94},
-  address = {New York, NY, USA},
-  publisher = {ACM},
+@InProceedings{1314293,
+  author     = {Mariusz H. Jakubowski and Ramarathnam Venkatesan},
+  title      = {Randomized radon transforms for biometric authentication via fingerprint hashing},
+  booktitle  = {DRM '07: Proceedings of the 2007 ACM workshop on Digital Rights Management},
+  year       = {2007},
+  publisher  = {ACM},
+  location   = {Alexandria, Virginia, USA},
+  isbn       = {978-1-59593-884-8},
+  pages      = {90--94},
+  doi        = {http://doi.acm.org/10.1145/1314276.1314293},
+  address    = {New York, NY, USA},
   bdsk-url-1 = {http://doi.acm.org/10.1145/1314276.1314293},
-  doi = {http://doi.acm.org/10.1145/1314276.1314293},
-  isbn = {978-1-59593-884-8},
-  location = {Alexandria, Virginia, USA}
+  groups     = {StaticGroup},
 }
 
 @INPROCEEDINGS{1358810,
@@ -292,8 +291,8 @@ This is some user comment in front of a string, should also be preserved.
 
 @Comment{jabref-meta: groupstree:
 0 AllEntriesGroup:;
-1 ExplicitGroup:StaticGroup\;0\;1137631\;1233448\;1314293\;;
-1 KeywordGroup:DynamicGroup\;0\;author\;Churchill\;0\;0\;;
+1 StaticGroup:StaticGroup\;0\;1\;\;\;\;;
+1 KeywordGroup:DynamicGroup\;0\;author\;Churchill\;0\;0\;1\;\;\;\;;
 }
 
 @Comment{jabref-meta: keypattern_article:articleTest;}

--- a/src/test/resources/testbib/complex.bib
+++ b/src/test/resources/testbib/complex.bib
@@ -291,9 +291,9 @@ This is some user comment in front of a string, should also be preserved.
 
 @Comment{jabref-meta: groupstree:
 0 AllEntriesGroup:;
-1 StaticGroup:StaticGroup\;0\;1\;\;\;\;;
+1 StaticGroup:StaticGroup\;0\;1\;\;\;A test static group\;;
 1 KeywordGroup:DynamicGroup\;0\;author\;Churchill\;0\;0\;1\;\;\;\;;
-1 AutomaticKeywordGroup:Automatic group\;0\;author\;,\;1\;\;\;Automatic group for all authors\;;
+1 AutomaticPersonsGroup:Automatic group (Authors)\;0\;author\;1\;\;\;Automatic group for all authors\;;
 }
 
 @Comment{jabref-meta: keypattern_article:articleTest;}

--- a/src/test/resources/testbib/complex.bib
+++ b/src/test/resources/testbib/complex.bib
@@ -293,6 +293,7 @@ This is some user comment in front of a string, should also be preserved.
 0 AllEntriesGroup:;
 1 StaticGroup:StaticGroup\;0\;1\;\;\;\;;
 1 KeywordGroup:DynamicGroup\;0\;author\;Churchill\;0\;0\;1\;\;\;\;;
+1 AutomaticKeywordGroup:Automatic group\;0\;author\;,\;1\;\;\;Automatic group for all authors\;;
 }
 
 @Comment{jabref-meta: keypattern_article:articleTest;}


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

Serialize and parse:
- Icon (with customizable color) that is shown in the groups panel (implements a [feature request in the forum](http://discourse.jabref.org/t/assign-colors-to-groups/321)).
- Description text that is shown on mouse hover (implements old feature requests [489](https://sourceforge.net/p/jabref/feature-requests/489/) and [818](https://sourceforge.net/p/jabref/feature-requests/818/))
- "automatic groups" that automatically create subgroups based on a certain criteria (e.g. a subgroup for every author or keyword). Implements [91](https://sourceforge.net/p/jabref/feature-requests/91/), [398](https://sourceforge.net/p/jabref/feature-requests/398/) and [#1173](https://github.com/JabRef/jabref/issues/1173).
- Expansion status [#1428](https://github.com/JabRef/jabref/issues/1428)

While implementing these changes, I had to introduce a new "StaticGroup" label in the bib file that replaces the old "ExplicitGroup". The problem was that the old group with legacy bib references
````
ExplicitGroup:StaticGroup\;0\;1137631\;1233448\;1314293\;;
````
otherwise couldn't be distinguished from a new explicit group with icon and color:
 ````
StaticGroup:StaticGroup\;0\;expansion\;icon\;color\;description\;;
````
I think we really should switch to https://github.com/koppor/jabref/issues/232 at some point.

-----

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
