### PR TITLE
Improve perfomance of opening a database that still used the old groups format

### DIFF
--- a/src/main/java/org/jabref/JabRefGUI.java
+++ b/src/main/java/org/jabref/JabRefGUI.java
@@ -179,7 +179,7 @@ public class JabRefGUI {
         for (int i = 0; (i < bibDatabases.size()) && (i < JabRefGUI.getMainFrame().getBasePanelCount()); i++) {
             ParserResult pr = bibDatabases.get(i);
             BasePanel panel = JabRefGUI.getMainFrame().getBasePanelAt(i);
-            OpenDatabaseAction.performPostOpenActions(panel, pr, true);
+            OpenDatabaseAction.performPostOpenActions(panel, pr);
         }
 
         LOGGER.debug("Finished adding panels");

--- a/src/main/java/org/jabref/gui/importer/actions/CheckForNewEntryTypesAction.java
+++ b/src/main/java/org/jabref/gui/importer/actions/CheckForNewEntryTypesAction.java
@@ -28,7 +28,7 @@ import org.jabref.model.entry.EntryType;
  * This action checks whether any new custom entry types were loaded from this
  * BIB file. If so, an offer to remember these entry types is given.
  */
-public class CheckForNewEntryTypesAction implements PostOpenAction {
+public class CheckForNewEntryTypesAction implements GUIPostOpenAction {
 
     @Override
     public boolean isActionNecessary(ParserResult parserResult) {

--- a/src/main/java/org/jabref/gui/importer/actions/GUIPostOpenAction.java
+++ b/src/main/java/org/jabref/gui/importer/actions/GUIPostOpenAction.java
@@ -12,7 +12,7 @@ import org.jabref.logic.importer.ParserResult;
  * This interface is introduced in an attempt to add such functionality in a
  * flexible manner.
  */
-public interface PostOpenAction {
+public interface GUIPostOpenAction {
 
     /**
      * This method is queried in order to find out whether the action needs to be

--- a/src/main/java/org/jabref/gui/importer/actions/HandleDuplicateWarnings.java
+++ b/src/main/java/org/jabref/gui/importer/actions/HandleDuplicateWarnings.java
@@ -8,10 +8,10 @@ import org.jabref.logic.importer.ParserResult;
 import org.jabref.logic.l10n.Localization;
 
 /**
- * PostOpenAction that checks whether there are warnings about duplicate BibTeX keys, and
+ * GUIPostOpenAction that checks whether there are warnings about duplicate BibTeX keys, and
  * if so, offers to start the duplicate resolving process.
  */
-public class HandleDuplicateWarnings implements PostOpenAction {
+public class HandleDuplicateWarnings implements GUIPostOpenAction {
 
     @Override
     public boolean isActionNecessary(ParserResult pr) {

--- a/src/main/java/org/jabref/logic/importer/OpenDatabase.java
+++ b/src/main/java/org/jabref/logic/importer/OpenDatabase.java
@@ -2,8 +2,12 @@ package org.jabref.logic.importer;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
 import org.jabref.logic.importer.fileformat.BibtexImporter;
+import org.jabref.logic.importer.util.ConvertLegacyExplicitGroups;
+import org.jabref.logic.importer.util.PostOpenAction;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.specialfields.SpecialFieldsUtils;
 import org.jabref.logic.util.io.FileBasedLock;
@@ -71,6 +75,16 @@ public class OpenDatabase {
             LOGGER.debug("Synchronized special fields based on keywords");
         }
 
+        applyPostActions(result);
+
         return result;
+    }
+
+    private static void applyPostActions(ParserResult parserResult) {
+        List<PostOpenAction> actions = Arrays.asList(new ConvertLegacyExplicitGroups());
+
+        for (PostOpenAction action : actions) {
+            action.performAction(parserResult);
+        }
     }
 }

--- a/src/main/java/org/jabref/logic/importer/util/ConvertLegacyExplicitGroups.java
+++ b/src/main/java/org/jabref/logic/importer/util/ConvertLegacyExplicitGroups.java
@@ -1,10 +1,9 @@
-package org.jabref.gui.importer.actions;
+package org.jabref.logic.importer.util;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import org.jabref.gui.BasePanel;
 import org.jabref.logic.importer.ParserResult;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.groups.ExplicitGroup;
@@ -17,23 +16,15 @@ import org.jabref.model.groups.GroupTreeNode;
 public class ConvertLegacyExplicitGroups implements PostOpenAction {
 
     @Override
-    public boolean isActionNecessary(ParserResult pr) {
-        if (pr.getMetaData().getGroups().isPresent()) {
-            return !getExplicitGroupsWithLegacyKeys(pr.getMetaData().getGroups().orElse(null)).isEmpty();
-        }
-        return false;
-    }
-
-    @Override
-    public void performAction(BasePanel panel, ParserResult pr) {
-        Objects.requireNonNull(pr);
-        if (!pr.getMetaData().getGroups().isPresent()) {
+    public void performAction(ParserResult parserResult) {
+        Objects.requireNonNull(parserResult);
+        if (!parserResult.getMetaData().getGroups().isPresent()) {
             return;
         }
 
-        for (ExplicitGroup group : getExplicitGroupsWithLegacyKeys(pr.getMetaData().getGroups().get())) {
+        for (ExplicitGroup group : getExplicitGroupsWithLegacyKeys(parserResult.getMetaData().getGroups().get())) {
             for (String entryKey : group.getLegacyEntryKeys()) {
-                for (BibEntry entry : pr.getDatabase().getEntriesByKey(entryKey)) {
+                for (BibEntry entry : parserResult.getDatabase().getEntriesByKey(entryKey)) {
                     group.add(entry);
                 }
             }

--- a/src/main/java/org/jabref/logic/importer/util/PostOpenAction.java
+++ b/src/main/java/org/jabref/logic/importer/util/PostOpenAction.java
@@ -1,0 +1,7 @@
+package org.jabref.logic.importer.util;
+
+import org.jabref.logic.importer.ParserResult;
+
+public interface PostOpenAction {
+    void performAction(ParserResult parserResult);
+}

--- a/src/test/java/org/jabref/logic/importer/util/ConvertLegacyExplicitGroupsTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/ConvertLegacyExplicitGroupsTest.java
@@ -1,30 +1,23 @@
-package org.jabref.gui.importer.actions;
+package org.jabref.logic.importer.util;
 
 import java.util.Collections;
 import java.util.Optional;
 
-import org.jabref.gui.BasePanel;
 import org.jabref.logic.importer.ParserResult;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.groups.AllEntriesGroup;
 import org.jabref.model.groups.ExplicitGroup;
 import org.jabref.model.groups.GroupHierarchyType;
 import org.jabref.model.groups.GroupTreeNode;
-import org.jabref.testutils.category.GUITests;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.mockito.Mock;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
-@Category(GUITests.class)
 public class ConvertLegacyExplicitGroupsTest {
 
-    private ConvertLegacyExplicitGroups action;
-    @Mock private BasePanel basePanel;
+    private PostOpenAction action;
     private BibEntry entry;
     private ExplicitGroup group;
 
@@ -42,7 +35,7 @@ public class ConvertLegacyExplicitGroupsTest {
     public void performActionWritesGroupMembershipInEntry() throws Exception {
         ParserResult parserResult = generateParserResult(GroupTreeNode.fromGroup(group));
 
-        action.performAction(basePanel, parserResult);
+        action.performAction(parserResult);
 
         assertEquals(Optional.of("TestGroup"), entry.getField("groups"));
     }
@@ -51,7 +44,7 @@ public class ConvertLegacyExplicitGroupsTest {
     public void performActionClearsLegacyKeys() throws Exception {
         ParserResult parserResult = generateParserResult(GroupTreeNode.fromGroup(group));
 
-        action.performAction(basePanel, parserResult);
+        action.performAction(parserResult);
 
         assertEquals(Collections.emptyList(), group.getLegacyEntryKeys());
     }
@@ -63,16 +56,9 @@ public class ConvertLegacyExplicitGroupsTest {
         root.addSubgroup(group);
         ParserResult parserResult = generateParserResult(root);
 
-        action.performAction(basePanel, parserResult);
+        action.performAction(parserResult);
 
         assertEquals(Optional.of("TestGroup"), entry.getField("groups"));
-    }
-
-    @Test
-    public void isActionNecessaryReturnsTrueIfGroupContainsLegacyKeys() throws Exception {
-        ParserResult parserResult = generateParserResult(GroupTreeNode.fromGroup(group));
-
-        assertTrue(action.isActionNecessary(parserResult));
     }
 
     private ParserResult generateParserResult(GroupTreeNode groupRoot) {


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

Previously, the conversion of the old groups format to the new one was performed after the database was completely loaded and displayed. Thus after every change during the conversion the groups panel and main table were redrawn, resulting in performance problems (in particular with larger db's). 
Now the conversion is done before the db is displayed (and thus nobody yet listens to the changes).

Fixes: http://discourse.jabref.org/t/v3-8-2-x64-windows-problem-saving-large-bib-libraries/456

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
