### PR TITLE
Set POSIX filepermissions to 644

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,9 +62,10 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - We fixed an issue where the `Move linked files to default file directory`- cleanup operation did not move the files to the location of the bib-file. [#2454](https://github.com/JabRef/jabref/issues/2454)
  - We fixed an issue where executing `Move file` on a selected file in the `general`-tab could overwrite an existing file. [#2385](https://github.com/JabRef/jabref/issues/2358)
  - We fixed an issue with importing groups and subgroups [#2600](https://github.com/JabRef/jabref/issues/2600)
- - Fixed an issue where title-related key patterns did not correspond to the documentation [#2604](https://github.com/JabRef/jabref/issues/2604) [#2589](https://github.com/JabRef/jabref/issues/2589)
- - We fixed an issue which prohibited the citation export to external programms on MacOS  [#2613](https://github.com/JabRef/jabref/issues/2613)
- - We fixed an issue where the file folder could not be changed when running `Get fulltext` in the `general`-tab [#2572](https://github.com/JabRef/jabref/issues/2572)
+ - Fixed an issue where title-related key patterns did not correspond to the documentation. [#2604](https://github.com/JabRef/jabref/issues/2604) [#2589](https://github.com/JabRef/jabref/issues/2589)
+ - We fixed an issue which prohibited the citation export to external programms on MacOS.  [#2613](https://github.com/JabRef/jabref/issues/2613)
+ - We fixed an issue where the file folder could not be changed when running `Get fulltext` in the `general`-tab. [#2572](https://github.com/JabRef/jabref/issues/2572)
+ - Newly created libraries no longer have the executable bit set under POSIX/Linux systems. The file permissions are now set to `664 (-rw-rw-r--)`. [#2635](https://github.com/JabRef/jabref/issues/#2635)
 ### Removed
 
 

--- a/src/main/java/org/jabref/logic/exporter/FileSaveSession.java
+++ b/src/main/java/org/jabref/logic/exporter/FileSaveSession.java
@@ -38,7 +38,6 @@ public class FileSaveSession extends SaveSession {
     private static final String TEMP_SUFFIX = "save.bib";
     private final Path temporaryFile;
 
-
     public FileSaveSession(Charset encoding, boolean backup) throws SaveException {
         this(encoding, backup, createTemporaryFile());
     }
@@ -86,8 +85,12 @@ public class FileSaveSession extends SaveSession {
                 LOGGER.error("Error when creating lock file.", ex);
             }
 
-            // Try to save file permissions to restore them later (by default: allow everything)
-            Set<PosixFilePermission> oldFilePermissions = EnumSet.allOf(PosixFilePermission.class);
+            // Try to save file permissions to restore them later (by default: 664)
+            Set<PosixFilePermission> oldFilePermissions = EnumSet.of(PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.GROUP_READ,
+                    PosixFilePermission.GROUP_WRITE,
+                    PosixFilePermission.OTHERS_READ);
             if (FileUtil.isPosixCompilant && Files.exists(file)) {
                 try {
                     oldFilePermissions = Files.getPosixFilePermissions(file);


### PR DESCRIPTION
Fix for #2635

Just tested in my Ubuntu VM. Works fine:
Permissions are now: 
`-rw-rw-r-- `

<!-- describe the changes you have made here: what, why, ... -->

- [x] Change in CHANGELOG.md described
~- [ ] Tests created for changes~
~- [ ] Screenshots added (for bigger UI changes)~
- [x] Manually tested changed features in running JabRef
~- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org]~(https://github.com/JabRef/help.jabref.org/issues)?)
~- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?~
