### PR TITLE
Add scroll bars to preference dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - A scrollbar was added to the cleanup panel, as a result of issue [#2501](https://github.com/JabRef/jabref/issues/2501)
 - F4 opens selected file in current JTable context not just from selected entry inside the main table [#2355](https://github.com/JabRef/jabref/issues/2355)
 - We added an option to copy the title of BibTeX entries to the clipboard through `Edit -> Copy title` (implements [#210](https://github.com/koppor/jabref/issues/210))
+- Several scrollbars were added to the preference dialog which show up when content is too large [#2559](https://github.com/JabRef/jabref/issues/2559)
 
 ### Fixed
  - We fixed an issue where authors with multiple surnames were not presented correctly in the main table. [#2534](https://github.com/JabRef/jabref/issues/2534)

--- a/src/main/java/org/jabref/gui/preftabs/PreferencesDialog.java
+++ b/src/main/java/org/jabref/gui/preftabs/PreferencesDialog.java
@@ -19,6 +19,7 @@ import javax.swing.JDialog;
 import javax.swing.JList;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
 import javax.swing.ListSelectionModel;
 
 import org.jabref.Globals;
@@ -63,7 +64,6 @@ public class PreferencesDialog extends JDialog {
     private final JButton showPreferences = new JButton(Localization.lang("Show preferences"));
 
     private final JButton resetPreferences = new JButton(Localization.lang("Reset preferences"));
-
 
     public PreferencesDialog(JabRefFrame parent) {
         super(parent, Localization.lang("JabRef preferences"), false);
@@ -134,8 +134,8 @@ public class PreferencesDialog extends JDialog {
         westPanel.add(chooser, BorderLayout.CENTER);
         westPanel.add(buttons, BorderLayout.SOUTH);
         mainPanel.setLayout(new BorderLayout());
-        mainPanel.add(main, BorderLayout.CENTER);
-        mainPanel.add(westPanel, BorderLayout.WEST);
+        mainPanel.add(putPanelInScrollPane(main), BorderLayout.CENTER);
+        mainPanel.add(putPanelInScrollPane(westPanel), BorderLayout.WEST);
 
         JButton ok = new JButton(Localization.lang("OK"));
         JButton cancel = new JButton(Localization.lang("Cancel"));
@@ -203,6 +203,14 @@ public class PreferencesDialog extends JDialog {
 
         pack();
 
+    }
+
+    private JScrollPane putPanelInScrollPane(JPanel panel) {
+        JScrollPane scrollPane = new JScrollPane(panel);
+        scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+        scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+        scrollPane.setBorder(null);
+        return scrollPane;
     }
 
     private String getPrefsExportPath() {


### PR DESCRIPTION
Fix for issue [#2559](https://github.com/JabRef/jabref/issues/2559).
Shows horizontal and vertical scroll bars when the content in the preference dialog gets too big.

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
