### PR TITLE
Improve issue reporting a bit

### DIFF
--- a/src/main/java/org/jabref/gui/errorconsole/ErrorConsoleViewModel.java
+++ b/src/main/java/org/jabref/gui/errorconsole/ErrorConsoleViewModel.java
@@ -29,8 +29,8 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.core.LogEvent;
 
 public class ErrorConsoleViewModel extends AbstractViewModel {
-
     private static final Log LOGGER = LogFactory.getLog(ErrorConsoleViewModel.class);
+
     private final DateFormat dateFormat = new SimpleDateFormat("yyyyMMddHHmmss");
     private final Date date = new Date();
     private final DialogService dialogService;
@@ -86,25 +86,32 @@ public class ErrorConsoleViewModel extends AbstractViewModel {
      */
     public void reportIssue() {
         try {
-            String issueTitle = "Automatic Bug Report-" + dateFormat.format(date);
-            String issueBody = String.format("JabRef %s%n%s %s %s %nJava %s\n\n", buildInfo.getVersion(), BuildInfo.OS,
+            String issueTitle = "Automatic Bug Report - " + dateFormat.format(date);
+            // system info
+            String systemInfo = String.format("JabRef %s%n%s %s %s %nJava %s", buildInfo.getVersion(), BuildInfo.OS,
                     BuildInfo.OS_VERSION, BuildInfo.OS_ARCH, BuildInfo.JAVA_VERSION);
+            // steps to reproduce
+            String howToReproduce = "Steps to reproduce:\n\n1. ...\n2. ...\n3. ...";
+            // log messages
+            String issueDetails = "<details>\n" + "<summary>" + "Detail information:" + "</summary>\n\n```\n"
+                    + getLogMessagesAsString(allMessagesData) + "\n```\n\n</details>";
+            clipBoardManager.setClipboardContents(issueDetails);
+            // bug report body
+            String issueBody = systemInfo + "\n\n" + howToReproduce + "\n\n" + "Paste your log details here.";
+
             dialogService.notify(Localization.lang("Issue on GitHub successfully reported."));
             dialogService.showInformationDialogAndWait(Localization.lang("Issue report successful"),
                     Localization.lang("Your issue was reported in your browser.") + "\n" +
                             Localization.lang("The log and exception information was copied to your clipboard.") + " " +
-                            Localization.lang("Please paste this information (with Ctrl+V) in the issue description."));
+                            Localization.lang("Please paste this information (with Ctrl+V) in the issue description.") + "\n" +
+                            Localization.lang("Please also add all steps to reproduce this issue, if possible."));
+
             URIBuilder uriBuilder = new URIBuilder()
                     .setScheme("https").setHost("github.com")
                     .setPath("/JabRef/jabref/issues/new")
                     .setParameter("title", issueTitle)
                     .setParameter("body", issueBody);
             JabRefDesktop.openBrowser(uriBuilder.build().toString());
-
-            // Append log messages in issue description
-            String issueDetails = "<details>\n" + "<summary>" + "Detail information:" + "</summary>\n\n```\n"
-                    + getLogMessagesAsString(allMessagesData) + "\n```\n\n</details>";
-            clipBoardManager.setClipboardContents(issueDetails);
         } catch (IOException | URISyntaxException e) {
             LOGGER.error(e);
         }

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -2357,3 +2357,4 @@ Size_of_small_icons=
 Default_table_font_size=
 Escape_underscores=
 Color=
+Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -2357,3 +2357,4 @@ Size_of_small_icons=Größe_für_kleine_Icon
 Default_table_font_size=Standard_Tabellenschriftgröße
 Escape_underscores=Unterstriche_maskieren
 Color=
+Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2357,3 +2357,4 @@ Size_of_small_icons=Size_of_small_icons
 Default_table_font_size=Default_table_font_size
 Escape_underscores=Escape_underscores
 Color=Color
+Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -2357,3 +2357,4 @@ Size_of_small_icons=
 Default_table_font_size=
 Escape_underscores=
 Color=
+Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -2357,3 +2357,4 @@ Size_of_small_icons=
 Default_table_font_size=
 Escape_underscores=
 Color=
+Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -2357,3 +2357,4 @@ Size_of_small_icons=Taille_des_petits_icones
 Default_table_font_size=Taille_par_défaut_des_police_du_tableau
 Escape_underscores=Echapper_les_soulignements
 Color=
+Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -2357,3 +2357,4 @@ Size_of_small_icons=
 Default_table_font_size=
 Escape_underscores=
 Color=
+Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -2357,3 +2357,4 @@ Size_of_small_icons=
 Default_table_font_size=
 Escape_underscores=
 Color=
+Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -2357,3 +2357,4 @@ Size_of_small_icons=
 Default_table_font_size=
 Escape_underscores=
 Color=
+Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -2357,3 +2357,4 @@ Size_of_small_icons=
 Default_table_font_size=
 Escape_underscores=
 Color=
+Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -2357,3 +2357,4 @@ Size_of_small_icons=
 Default_table_font_size=
 Escape_underscores=
 Color=
+Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -2357,3 +2357,4 @@ Size_of_small_icons=
 Default_table_font_size=
 Escape_underscores=
 Color=
+Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -2357,3 +2357,4 @@ Size_of_small_icons=
 Default_table_font_size=
 Escape_underscores=
 Color=
+Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -2357,3 +2357,4 @@ Size_of_small_icons=
 Default_table_font_size=
 Escape_underscores=Maskera_understreck
 Color=
+Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -2357,3 +2357,4 @@ Size_of_small_icons=
 Default_table_font_size=
 Escape_underscores=
 Color=
+Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -2357,3 +2357,4 @@ Size_of_small_icons=
 Default_table_font_size=
 Escape_underscores=
 Color=
+Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -2357,3 +2357,4 @@ Size_of_small_icons=
 Default_table_font_size=
 Escape_underscores=
 Color=
+Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=


### PR DESCRIPTION
See #2573.
I also wanted to add the log details to the report without the necessity to paste them later on. Dunno why this was implemented this way initially (See https://github.com/JabRef/jabref/pull/1383). However, the explorer will cut off the arguments at some point so this did not work for me.
I  think it is not convenient if the user needs to add this info manually.
Maybe someone else has an idea how to change this.

I still think the current addition fixes #2573 for now.

![image](https://cloud.githubusercontent.com/assets/2141507/23855724/23d92b22-07f7-11e7-83ea-7a81c7225982.png)

![image](https://cloud.githubusercontent.com/assets/2141507/23855733/30e3d056-07f7-11e7-80c8-f3ef9dcf4a35.png)
