### PR TITLE
Disalbe Google Scholar tests on all CI environments

### DIFF
--- a/src/test/java/org/jabref/logic/importer/fetcher/GoogleScholarTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/GoogleScholarTest.java
@@ -53,7 +53,7 @@ public class GoogleScholarTest {
     @Test
     public void linkFound() throws IOException, FetcherException {
         // CI server is blocked by Google
-        Assume.assumeFalse(DevEnvironment.isCircleCI() || DevEnvironment.isSnapCI());
+        Assume.assumeFalse(DevEnvironment.isCIServer());
 
         entry.setField("title", "Towards Application Portability in Platform as a Service");
 
@@ -66,7 +66,7 @@ public class GoogleScholarTest {
     @Test
     public void noLinkFound() throws IOException, FetcherException {
         // CI server is blocked by Google
-        Assume.assumeFalse(DevEnvironment.isCircleCI() || DevEnvironment.isSnapCI());
+        Assume.assumeFalse(DevEnvironment.isCIServer());
 
         entry.setField("title", "Pro WF: Windows Workflow in NET 3.5");
 
@@ -76,7 +76,7 @@ public class GoogleScholarTest {
     @Test
     public void findSingleEntry() throws FetcherException {
         // CI server is blocked by Google
-        Assume.assumeFalse(DevEnvironment.isCircleCI() || DevEnvironment.isSnapCI());
+        Assume.assumeFalse(DevEnvironment.isCIServer());
 
         entry.setType(BibtexEntryTypes.INPROCEEDINGS.getName());
         entry.setCiteKey("geiger2013detecting");
@@ -94,7 +94,7 @@ public class GoogleScholarTest {
     @Test
     public void find20Entries() throws FetcherException {
         // CI server is blocked by Google
-        Assume.assumeFalse(DevEnvironment.isCircleCI() || DevEnvironment.isSnapCI());
+        Assume.assumeFalse(DevEnvironment.isCIServer());
 
         List<BibEntry> foundEntries = finder.performSearch("random test string");
 

--- a/src/test/java/org/jabref/support/DevEnvironment.java
+++ b/src/test/java/org/jabref/support/DevEnvironment.java
@@ -18,9 +18,4 @@ public class DevEnvironment {
         return Boolean.valueOf(System.getenv("CIRCLECI"));
     }
 
-    public static boolean isSnapCI() {
-        // See https://docs.snap-ci.com/environment-variables/
-        return Boolean.valueOf(System.getenv("SNAP_CI"));
-    }
-
 }

--- a/src/test/java/org/jabref/support/DevEnvironment.java
+++ b/src/test/java/org/jabref/support/DevEnvironment.java
@@ -2,20 +2,14 @@ package org.jabref.support;
 
 /**
  * Checks whether we are on a local development environment and not on a CI server.
- * This is needed as some remote fetcher tests are blocked by Google when executed by CI servers.
+ * This is needed as some remote fetcher tests are blocked by Google when executed on CI servers.
  */
 public class DevEnvironment {
 
     public static boolean isCIServer() {
         // See http://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
         // See https://circleci.com/docs/environment-variables
-        // See https://docs.snap-ci.com/environment-variables/
         return Boolean.valueOf(System.getenv("CI"));
-    }
-
-    public static boolean isCircleCI() {
-        // See https://circleci.com/docs/environment-variables
-        return Boolean.valueOf(System.getenv("CIRCLECI"));
     }
 
 }


### PR DESCRIPTION
Google Scholar tests currently fail. This PR just follows the comment given within the test cases and disables the Google Scholar tests on **all** CI Servers.

We might revert this if we have time to fix Google Scholar.

Refs #2173 