### PR TITLE
OO formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - We fixed an issue which prohibited the citation export to external programms on MacOS.  [#2613](https://github.com/JabRef/jabref/issues/2613)
  - We fixed an issue where the file folder could not be changed when running `Get fulltext` in the `general`-tab. [#2572](https://github.com/JabRef/jabref/issues/2572)
  - Newly created libraries no longer have the executable bit set under POSIX/Linux systems. The file permissions are now set to `664 (-rw-rw-r--)`. [#2635](https://github.com/JabRef/jabref/issues/#2635)
+ - OpenOffice text formatting now handles nested tags properly [#2483](https://github.com/JabRef/jabref/issues/#2483)
+ 
 ### Removed
 
 

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;

--- a/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
+++ b/src/main/java/org/jabref/gui/openoffice/OOBibBase.java
@@ -427,7 +427,6 @@ class OOBibBase {
         }
     }
 
-
     public List<String> getJabRefReferenceMarks(XNameAccess nameAccess) {
         String[] names = nameAccess.getElementNames();
         // Remove all reference marks that don't look like JabRef citations:
@@ -1006,8 +1005,7 @@ class OOBibBase {
             if (style.isNumberEntries()) {
                 int minGroupingCount = style.getIntCitProperty(OOBibStyle.MINIMUM_GROUPING_COUNT);
                 OOUtil.insertTextAtCurrentLocation(text, cursor,
-                        style.getNumCitationMarker(Collections.singletonList(number++), minGroupingCount, true),
-                        EnumSet.noneOf(OOUtil.Formatting.class));
+                        style.getNumCitationMarker(Collections.singletonList(number++), minGroupingCount, true), Collections.emptyList());
             }
             Layout layout = style.getReferenceFormat(entry.getKey().getType());
             layout.setPostFormatter(POSTFORMATTER);
@@ -1282,7 +1280,6 @@ class OOBibBase {
 
     }
 
-
     public static XTextDocument selectComponent(List<XTextDocument> list)
             throws UnknownPropertyException, WrappedTargetException, IndexOutOfBoundsException {
         String[] values = new String[list.size()];
@@ -1302,7 +1299,6 @@ class OOBibBase {
             return null;
         }
     }
-
 
     private static class ComparableMark implements Comparable<ComparableMark> {
 

--- a/src/main/java/org/jabref/logic/openoffice/CitationEntry.java
+++ b/src/main/java/org/jabref/logic/openoffice/CitationEntry.java
@@ -9,7 +9,6 @@ public class CitationEntry implements Comparable<CitationEntry> {
     private final String context;
     private final Optional<String> origPageInfo;
 
-
     // Only used for testing...
     public CitationEntry(String refMarkName, String context) {
         this(refMarkName, context, Optional.empty());

--- a/src/main/java/org/jabref/logic/openoffice/OOPreFormatter.java
+++ b/src/main/java/org/jabref/logic/openoffice/OOPreFormatter.java
@@ -9,8 +9,6 @@ import org.jabref.model.strings.StringUtil;
 /**
  * This formatter preprocesses JabRef fields before they are run through the layout of the
  * bibliography style. It handles translation of LaTeX italic/bold commands into HTML tags.
- *
- * @version $Revision: 2568 $ ($Date: 2008-01-15 18:40:26 +0100 (Tue, 15 Jan 2008) $)
  */
 public class OOPreFormatter implements LayoutFormatter {
 
@@ -22,8 +20,6 @@ public class OOPreFormatter implements LayoutFormatter {
         String finalResult = field.replaceAll("&|\\\\&", "&") // Replace & and \& with &
                 .replace("\\$", "&dollar;") // Replace \$ with &dollar;
                 .replaceAll("\\$([^\\$]*)\\$", "\\{$1\\}"); // Replace $...$ with {...} to simplify conversion
-
-
 
         StringBuilder sb = new StringBuilder();
         StringBuilder currentCommand = null;

--- a/src/main/java/org/jabref/logic/openoffice/OOUtil.java
+++ b/src/main/java/org/jabref/logic/openoffice/OOUtil.java
@@ -1,6 +1,7 @@
 package org.jabref.logic.openoffice;
 
-import java.util.EnumSet;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -35,7 +36,6 @@ public class OOUtil {
     private static final String CHAR_ESCAPEMENT_HEIGHT = "CharEscapementHeight";
     private static final String CHAR_ESCAPEMENT = "CharEscapement";
 
-
     public enum Formatting {
         BOLD,
         ITALIC,
@@ -50,7 +50,6 @@ public class OOUtil {
     private static final Pattern HTML_TAG = Pattern.compile("</?[a-z]+>");
 
     private static final String UNIQUEFIER_FIELD = "uniq";
-
 
     private OOUtil() {
         // Just to hide the public constructor
@@ -83,7 +82,7 @@ public class OOUtil {
         }
 
         // Do the layout for this entry:
-        String lText = layout.doLayout(entry, database);
+        String formattedText = layout.doLayout(entry, database);
 
         // Afterwards, reset the old value:
         if (oldUniqVal.isPresent()) {
@@ -93,7 +92,7 @@ public class OOUtil {
         }
 
         // Insert the formatted text:
-        OOUtil.insertOOFormattedTextAtCurrentLocation(text, cursor, lText, parStyle);
+        OOUtil.insertOOFormattedTextAtCurrentLocation(text, cursor, formattedText, parStyle);
     }
 
     /**
@@ -123,14 +122,14 @@ public class OOUtil {
             throw new UndefinedParagraphFormatException(parStyle);
         }
 
-        Set<Formatting> formatting = EnumSet.noneOf(Formatting.class);
+        List<Formatting> formatting = new ArrayList<>();
         // We need to extract formatting. Use a simple regexp search iteration:
         int piv = 0;
         Matcher m = OOUtil.HTML_TAG.matcher(lText);
         while (m.find()) {
-            String ss = lText.substring(piv, m.start());
-            if (!ss.isEmpty()) {
-                OOUtil.insertTextAtCurrentLocation(text, cursor, ss, formatting);
+            String currentSubstring = lText.substring(piv, m.start());
+            if (!currentSubstring.isEmpty()) {
+                OOUtil.insertTextAtCurrentLocation(text, cursor, currentSubstring, formatting);
             }
             String tag = m.group();
             // Handle tags:
@@ -185,7 +184,7 @@ public class OOUtil {
     }
 
     public static void insertTextAtCurrentLocation(XText text, XTextCursor cursor, String string,
-            Set<Formatting> formatting)
+            List<Formatting> formatting)
                     throws UnknownPropertyException, PropertyVetoException, WrappedTargetException,
                     IllegalArgumentException {
         text.insertString(cursor, string, true);
@@ -256,7 +255,6 @@ public class OOUtil {
             xCursorProps.setPropertyValue(CHAR_STRIKEOUT, com.sun.star.awt.FontStrikeout.NONE);
         }
         cursor.collapseToEnd();
-
     }
 
     public static void insertTextAtCurrentLocation(XText text, XTextCursor cursor, String string, String parStyle)

--- a/src/main/java/org/jabref/logic/openoffice/OOUtil.java
+++ b/src/main/java/org/jabref/logic/openoffice/OOUtil.java
@@ -3,7 +3,6 @@ package org.jabref.logic.openoffice;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 


### PR DESCRIPTION
OpenOffice text formatting now handles nested tags properly [#2483](https://github.com/JabRef/jabref/issues/#2483)

Formerly it was a Set, so nested tags were not kept and consequently the first closing tag removes (both) opening tags.

```
Formerly: <i>some<i>test</i>text</i> ->[i], [i], []
Now: -> [i], [i,i], [i], []

```