### PR TITLE
[WIP] Testing bibtex key patterns and fixing title_case/capitalize modifiers

### DIFF
--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -726,7 +726,7 @@ public class BibtexKeyPatternUtil {
      * Determines "number" words out of the "title" field in the given BibTeX entry
      */
     public static String getTitleWords(int number, String title) {
-        return keepLettersAndDigitsOnly(getTitleWordsWithSpaces(number, title));
+        return getTitleWordsWithSpaces(number, title);
     }
 
     /**

--- a/src/main/java/org/jabref/logic/formatter/Formatters.java
+++ b/src/main/java/org/jabref/logic/formatter/Formatters.java
@@ -16,6 +16,7 @@ import org.jabref.logic.formatter.bibtexfields.NormalizeMonthFormatter;
 import org.jabref.logic.formatter.bibtexfields.NormalizeNamesFormatter;
 import org.jabref.logic.formatter.bibtexfields.NormalizePagesFormatter;
 import org.jabref.logic.formatter.bibtexfields.OrdinalsToSuperscriptFormatter;
+import org.jabref.logic.formatter.bibtexfields.RegexFormatter;
 import org.jabref.logic.formatter.bibtexfields.RemoveBracesFormatter;
 import org.jabref.logic.formatter.bibtexfields.UnicodeToLatexFormatter;
 import org.jabref.logic.formatter.bibtexfields.UnitsToLatexFormatter;
@@ -56,6 +57,7 @@ public class Formatters {
             new NormalizeNamesFormatter(),
             new NormalizePagesFormatter(),
             new OrdinalsToSuperscriptFormatter(),
+            new RegexFormatter(),
             new RemoveBracesFormatter(),
             new UnitsToLatexFormatter(),
             new EscapeUnderscoresFormatter()
@@ -68,7 +70,16 @@ public class Formatters {
 
     public static Optional<Formatter> getFormatterForModifier(String modifier) {
         Objects.requireNonNull(modifier);
-        Optional<Formatter> formatter = ALL.stream().filter(f -> f.getKey().equals(modifier)).findAny();
+        Optional<Formatter> formatter;
+
+        if (modifier.matches("regex.*")) {
+            String regex = modifier.substring(5);
+            RegexFormatter.setRegex(regex);
+            formatter = ALL.stream().filter(f -> f.getKey().equals("regex")).findAny();
+
+        } else {
+            formatter = ALL.stream().filter(f -> f.getKey().equals(modifier)).findAny();
+        }
         if (formatter.isPresent()) {
             return formatter;
         }

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
@@ -1,13 +1,11 @@
 package org.jabref.logic.formatter.bibtexfields;
 
-import java.util.Objects;
-
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.cleanup.Formatter;
 
 public class RegexFormatter implements Formatter {
 
-    private static String[] rex;
+    private static String[] regex;
 
     @Override
     public String getName() {
@@ -20,12 +18,11 @@ public class RegexFormatter implements Formatter {
     }
 
     @Override
-    public String format(String oldString) {
-        Objects.requireNonNull(oldString);
-        rex[0] = rex[0].replaceAll("\"", "");
-        rex[1] = rex[1].replaceAll("\"", "");
-
-        return oldString.replaceAll(rex[0], rex[1]);
+    public String format(String input) {
+        if (regex == null) {
+            return input;
+        }
+        return input.replaceAll(regex[0], regex[1]);
     }
 
     @Override
@@ -38,12 +35,11 @@ public class RegexFormatter implements Formatter {
         return "Please replace the spaces";
     }
 
-    public static void setRegex(String regex) {
-        regex = regex.substring(1, regex.length() - 1);
-        String[] parts = regex.split("\",\"");
-        parts[0] += "\"";
-        parts[1] = "\"" + parts[1];
-        rex = parts;
+    public static void setRegex(String rex) {
+        // formatting is like ("exp1","exp2"), we want to remove (" and ")
+        rex = rex.substring(2, rex.length() - 2);
+        String[] parts = rex.split("\",\"");
+        regex = parts;
     }
 
 }

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
@@ -1,0 +1,49 @@
+package org.jabref.logic.formatter.bibtexfields;
+
+import java.util.Objects;
+
+import org.jabref.logic.l10n.Localization;
+import org.jabref.model.cleanup.Formatter;
+
+public class RegexFormatter implements Formatter {
+
+    private static String[] rex;
+
+    @Override
+    public String getName() {
+        return Localization.lang("Regex");
+    }
+
+    @Override
+    public String getKey() {
+        return "regex";
+    }
+
+    @Override
+    public String format(String oldString) {
+        Objects.requireNonNull(oldString);
+        rex[0] = rex[0].replaceAll("\"", "");
+        rex[1] = rex[1].replaceAll("\"", "");
+
+        return oldString.replaceAll(rex[0], rex[1]);
+    }
+
+    @Override
+    public String getDescription() {
+        return Localization.lang("Add a regular expression for the key pattern.");
+    }
+
+    @Override
+    public String getExampleInput() {
+        return "Please replace the spaces";
+    }
+
+    public static void setRegex(String regex) {
+        regex = regex.substring(1, regex.length() - 1);
+        String[] parts = regex.split("\",\"");
+        parts[0] += "\"";
+        parts[1] = "\"" + parts[1];
+        rex = parts;
+    }
+
+}

--- a/src/main/java/org/jabref/logic/formatter/casechanger/SentenceCaseFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/casechanger/SentenceCaseFormatter.java
@@ -16,7 +16,7 @@ public class SentenceCaseFormatter implements Formatter {
     }
 
     /**
-     * Converts the first character of the first word of the given string to upper case (and the remaining characters of the first word to lower case), but does not change anything if word starts with "{"
+     * Converts the first character of the first word of the given string to upper case (and the remaining characters of the first word to lower case) and changes other words to lower case, but does not change anything if word starts with "{"
      */
     @Override
     public String format(String input) {

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -991,6 +991,8 @@ Reference_library=Referencelibrary
 
 Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Undergruppe\:_Vis_poster_indeholdt_både_i_denne_gruppe_og_gruppe_over
 
+Regex=
+
 regular_expression=Regulærudtryk
 
 Related_articles=

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -991,6 +991,8 @@ Reference_library=Referenz-Datenbank
 
 Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Obergruppe_einbeziehen\:_Einträge_aus_dieser_Gruppe_und_ihrer_übergeordneten_Gruppe_anzeigen
 
+Regex=
+
 regular_expression=Regulärer_Ausdruck
 
 Related_articles=ähnliche_Dokumente

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -50,6 +50,8 @@ The_path_need_not_be_on_the_classpath_of_JabRef.=The_path_need_not_be_on_the_cla
 Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.
 The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.
 
+Add_a_regular_expression_for_the_key_pattern.=Add_a_regular_expression_for_the_key_pattern.
+
 Add_entry_selection_to_this_group=Add_entry_selection_to_this_group
 
 Add_from_folder=Add_from_folder
@@ -990,6 +992,8 @@ Reference_library=Reference_library
 %0_references_found._Number_of_references_to_fetch?=%0_references_found._Number_of_references_to_fetch?
 
 Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup
+
+Regex=Regex
 
 regular_expression=regular_expression
 

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -991,6 +991,8 @@ Reference_library=Base_de_datos_de_referencia
 
 Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Refinar_supergrupo\:_Ver_entradas_contenidas_en_este_grupo_y_sus_subgrupos_cuando_estén_seleccionadas
 
+Regex=
+
 regular_expression=Expresión_Regular
 
 Related_articles=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -991,6 +991,8 @@ Reference_library=
 
 Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=
 
+Regex=
+
 regular_expression=
 
 Related_articles=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -991,6 +991,8 @@ Reference_library=Fichier_de_référence
 
 Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Raffine_le_super-groupe_\:_Quand_sélectionné,_afficher_les_entrées_contenues_à_la_fois_dans_ce_groupe_et_son_super-groupe
 
+Regex=
+
 regular_expression=Expression_régulière
 
 Related_articles=Articles_liés

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -991,6 +991,8 @@ Reference_library=Basisdata_acuan
 
 Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Perbaiki_supergrup\:_Ketika_dipilih,_lihat_entri_yang_ada_di_grup_ini_dan_supergrup
 
+Regex=
+
 regular_expression=Ekspresi_reguler
 
 Related_articles=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -991,6 +991,8 @@ Reference_library=Library_di_riferimenti
 
 Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Perfeziona_il_super-gruppo\:_Quando_selezionato,_mostra_le_voci_contenute_sia_in_questo_gruppo_sia_nel_suo_super-gruppo
 
+Regex=
+
 regular_expression=Espressione_regolare
 
 Related_articles=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -991,6 +991,8 @@ Reference_library=参照データベース
 
 Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=上層グループの絞り込み：このグループとその上層グループの両方に含まれている項目を表示
 
+Regex=
+
 regular_expression=正規表現
 
 Related_articles=

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -991,6 +991,8 @@ Reference_library=Referentie_library
 
 Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Verfijn_supergroep\:_Wanneer_geselecteerd,_toon_de_entries_die_in_deze_groep_en_zijn_supergroep_zitten
 
+Regex=
+
 regular_expression=Regular_Expression
 
 Related_articles=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -991,6 +991,8 @@ Reference_library=Referanselibrary
 
 Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Undergruppe\:_Vis_enheter_innehold_b\u00e5de_i_denne_gruppen_og_gruppen_over
 
+Regex=
+
 regular_expression=Regul\u00e6ruttrykk
 
 Related_articles=

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -991,6 +991,8 @@ Reference_library=Base_de_dados_de_referência
 
 Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Refinar_supergrupo\:_Quando_selecionado,_visualiza_referências_contidas_em_ambos_os_grupos_e_seu_supergrupo.
 
+Regex=
+
 regular_expression=Expressão_regular
 
 Related_articles=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -991,6 +991,8 @@ Reference_library=БД_для_ссылки
 
 Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Детализировать_супергруппу\:_Просмотр_записей,_содержащихся_в_группе_и_ее_супергруппе_(если_выбрано)
 
+Regex=
+
 regular_expression=Регулярное_выражение
 
 Related_articles=

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -991,6 +991,8 @@ Reference_library=Referensdatabas
 
 Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=
 
+Regex=
+
 regular_expression=reguljärt_uttryck
 
 Related_articles=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -991,6 +991,8 @@ Reference_library=Başvuru_veritabanı
 
 Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Supergrubu_arıt\:_Seçildiğinde,_hem_bu_grubun,_hem_de_süpergrubunun_içerdiği_girdileri_görüntüle
 
+Regex=
+
 regular_expression=Düzenli_İfade
 
 Related_articles=

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -991,6 +991,8 @@ Reference_library=CSDL_tham_khảo
 
 Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Tinh_chỉnh_nhóm_lớn\:_Khi_được_chọn,_xem_các_mục_chứa_các_trong_nhóm_này_và_nhóm_lớn_của_nó
 
+Regex=
+
 regular_expression=Biểu_thức_chính_tắc
 
 Related_articles=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -991,6 +991,8 @@ Reference_library=参考文献数据库
 
 Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=提炼父分组：当分组被选中时，显示同时包含在该分组和它父分组中的记录
 
+Regex=
+
 regular_expression=正则表达式
 
 Related_articles=

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtilTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtilTest.java
@@ -651,20 +651,20 @@ public class BibtexKeyPatternUtilTest {
     public void shortTitle() {
         // shortTitle is getTitleWords with "3" as count
         int count = 3;
-        assertEquals("applicationmigrationeffort",
+        assertEquals("application migration effort",
                 BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_ALL_LOWER_FOUR_SMALL_WORDS_ONE_EN_DASH));
-        assertEquals("BPELconformancein", BibtexKeyPatternUtil.getTitleWords(count,
+        assertEquals("BPEL conformance in", BibtexKeyPatternUtil.getTitleWords(count,
                 TITLE_STRING_ALL_LOWER_FIRST_WORD_IN_BRACKETS_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON));
-        assertEquals("ProcessViewingPatterns", BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_CASED));
-        assertEquals("BPMNConformancein",
+        assertEquals("Process Viewing Patterns", BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_CASED));
+        assertEquals("BPMN Conformance in",
                 BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_CASED_ONE_UPPER_WORD_ONE_SMALL_WORD));
-        assertEquals("TheDifferenceBetween", BibtexKeyPatternUtil.getTitleWords(count,
+        assertEquals("The Difference Between", BibtexKeyPatternUtil.getTitleWords(count,
                 TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AT_THE_BEGINNING));
-        assertEquals("CloudComputingThe",
+        assertEquals("Cloud Computing: The",
                 BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON));
-        assertEquals("TowardsChoreographybased",
+        assertEquals("Towards Choreography based",
                 BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_CASED_TWO_SMALL_WORDS_ONE_CONNECTED_WORD));
-        assertEquals("OntheMeasurement",
+        assertEquals("On the Measurement",
                 BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_CASED_FOUR_SMALL_WORDS_TWO_CONNECTED_WORDS));
     }
 
@@ -785,7 +785,7 @@ public class BibtexKeyPatternUtilTest {
         BibEntry entry = new BibEntry();
         entry.setField("title", "Green Scheduling of Whatever");
         assertEquals("GSo", BibtexKeyPatternUtil.makeLabel(entry, "shorttitleINI", ',', new BibDatabase()));
-        assertEquals("GreenSchedulingof", BibtexKeyPatternUtil.makeLabel(entry, "shorttitle",
+        assertEquals("Green Scheduling of", BibtexKeyPatternUtil.makeLabel(entry, "shorttitle",
                 ',', new BibDatabase()));
     }
 

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
@@ -123,17 +123,38 @@ public class MakeLabelWithDatabaseTest {
     }
 
     @Test
-    public void generateDefaultKeyLowerModified() {
+    public void generateKeyAuthLowerModified() {
         bibtexKeyPattern.setDefaultValue("[auth:lower][year]");
         BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("doe2016"), entry.getCiteKeyOptional());
     }
 
     @Test
-    public void generateDefaultKeyUpperModified() {
+    public void generateKeyAuthUpperModified() {
         bibtexKeyPattern.setDefaultValue("[auth:upper][year]");
         BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("DOE2016"), entry.getCiteKeyOptional());
+    }
+
+    @Test
+    public void generateKeyAuthTitleCaseModified() {
+        bibtexKeyPattern.setDefaultValue("[auth:title_case][year]");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
+        assertEquals(Optional.of("Doe2016"), entry.getCiteKeyOptional());
+    }
+
+    @Test
+    public void generateKeyAuthSentenceCaseModified() {
+        bibtexKeyPattern.setDefaultValue("[auth:sentence_case][year]");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
+        assertEquals(Optional.of("Doe2016"), entry.getCiteKeyOptional());
+    }
+
+    @Test
+    public void generateKeyAuthCapitalizeModified() {
+        bibtexKeyPattern.setDefaultValue("[auth:capitalize][year]");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
+        assertEquals(Optional.of("Doe2016"), entry.getCiteKeyOptional());
     }
 
     @Test
@@ -206,6 +227,51 @@ public class MakeLabelWithDatabaseTest {
         bibtexKeyPattern.setDefaultValue("[shorttitle]");
         BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("Anawesomepaper"), entry.getCiteKeyOptional());
+    }
+
+    @Test
+    public void generateKeyShorttitleLowerModified() {
+        bibtexKeyPattern.setDefaultValue("[shorttitle:lower]");
+        BibEntry entry2 = new BibEntry();
+        entry2.setField("title", "An aweSOme Paper on JabRef");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry2, preferences);
+        assertEquals(Optional.of("anawesomepaper"), entry2.getCiteKeyOptional());
+    }
+
+    @Test
+    public void generateKeyShorttitleUpperModified() {
+        bibtexKeyPattern.setDefaultValue("[shorttitle:upper]");
+        BibEntry entry2 = new BibEntry();
+        entry2.setField("title", "An aweSOme Paper on JabRef");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry2, preferences);
+        assertEquals(Optional.of("ANAWESOMEPAPER"), entry2.getCiteKeyOptional());
+    }
+
+    @Test
+    public void generateKeyShorttitleTitleCaseModified() {
+        bibtexKeyPattern.setDefaultValue("[shorttitle:title_case]");
+        BibEntry entry2 = new BibEntry();
+        entry2.setField("title", "An aweSOme Paper on JabRef");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry2, preferences);
+        assertEquals(Optional.of("AnAwesomePaper"), entry2.getCiteKeyOptional());
+    }
+
+    @Test
+    public void generateKeyShorttitleSentenceCaseModified() {
+        bibtexKeyPattern.setDefaultValue("[shorttitle:sentence_case]");
+        BibEntry entry2 = new BibEntry();
+        entry2.setField("title", "An aweSOme Paper on JabRef");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry2, preferences);
+        assertEquals(Optional.of("Anawesomepaper"), entry2.getCiteKeyOptional());
+    }
+
+    @Test
+    public void generateKeyShorttitleCapitalizeModified() {
+        bibtexKeyPattern.setDefaultValue("[shorttitle:capitalize]");
+        BibEntry entry2 = new BibEntry();
+        entry2.setField("title", "An aweSOme Paper on JabRef");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry2, preferences);
+        assertEquals(Optional.of("AnAwesomePaper"), entry2.getCiteKeyOptional());
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
@@ -388,6 +388,14 @@ public class MakeLabelWithDatabaseTest {
     }
 
     @Test
+    public void generateKeyTitleRegexe() {
+        bibtexKeyPattern.setDefaultValue("[title:regex(\" \",\"-\")]");
+        entry.setField("title", "Please replace the spaces");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
+        assertEquals(Optional.of("Please-Replace-the-Spaces"), entry.getCiteKeyOptional());
+    }
+
+    @Test
     public void generateKeyTitleTitleCase() {
         bibtexKeyPattern.setDefaultValue("[title:title_case]");
         BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
@@ -232,46 +232,41 @@ public class MakeLabelWithDatabaseTest {
     @Test
     public void generateKeyShorttitleLowerModified() {
         bibtexKeyPattern.setDefaultValue("[shorttitle:lower]");
-        BibEntry entry2 = new BibEntry();
-        entry2.setField("title", "An aweSOme Paper on JabRef");
-        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry2, preferences);
-        assertEquals(Optional.of("anawesomepaper"), entry2.getCiteKeyOptional());
+        entry.setField("title", "An aweSOme Paper on JabRef");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
+        assertEquals(Optional.of("anawesomepaper"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyShorttitleUpperModified() {
         bibtexKeyPattern.setDefaultValue("[shorttitle:upper]");
-        BibEntry entry2 = new BibEntry();
-        entry2.setField("title", "An aweSOme Paper on JabRef");
-        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry2, preferences);
-        assertEquals(Optional.of("ANAWESOMEPAPER"), entry2.getCiteKeyOptional());
+        entry.setField("title", "An aweSOme Paper on JabRef");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
+        assertEquals(Optional.of("ANAWESOMEPAPER"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyShorttitleTitleCaseModified() {
         bibtexKeyPattern.setDefaultValue("[shorttitle:title_case]");
-        BibEntry entry2 = new BibEntry();
-        entry2.setField("title", "An aweSOme Paper on JabRef");
-        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry2, preferences);
-        assertEquals(Optional.of("AnAwesomePaper"), entry2.getCiteKeyOptional());
+        entry.setField("title", "An aweSOme Paper on JabRef");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
+        assertEquals(Optional.of("AnAwesomePaper"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyShorttitleSentenceCaseModified() {
         bibtexKeyPattern.setDefaultValue("[shorttitle:sentence_case]");
-        BibEntry entry2 = new BibEntry();
-        entry2.setField("title", "An aweSOme Paper on JabRef");
-        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry2, preferences);
-        assertEquals(Optional.of("Anawesomepaper"), entry2.getCiteKeyOptional());
+        entry.setField("title", "An aweSOme Paper on JabRef");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
+        assertEquals(Optional.of("Anawesomepaper"), entry.getCiteKeyOptional());
     }
 
     @Test
     public void generateKeyShorttitleCapitalizeModified() {
         bibtexKeyPattern.setDefaultValue("[shorttitle:capitalize]");
-        BibEntry entry2 = new BibEntry();
-        entry2.setField("title", "An aweSOme Paper on JabRef");
-        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry2, preferences);
-        assertEquals(Optional.of("AnAwesomePaper"), entry2.getCiteKeyOptional());
+        entry.setField("title", "An aweSOme Paper on JabRef");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
+        assertEquals(Optional.of("AnAwesomePaper"), entry.getCiteKeyOptional());
     }
 
     @Test
@@ -279,6 +274,46 @@ public class MakeLabelWithDatabaseTest {
         bibtexKeyPattern.setDefaultValue("[veryshorttitle]");
         BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
         assertEquals(Optional.of("awesome"), entry.getCiteKeyOptional());
+    }
+
+    @Test
+    public void generateKeyVeryshorttitleLowerModified() {
+        bibtexKeyPattern.setDefaultValue("[veryshorttitle:lower]");
+        entry.setField("title", "An aweSOme Paper on JabRef");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
+        assertEquals(Optional.of("awesome"), entry.getCiteKeyOptional());
+    }
+
+    @Test
+    public void generateKeyVeryshorttitleUpperModified() {
+        bibtexKeyPattern.setDefaultValue("[veryshorttitle:upper]");
+        entry.setField("title", "An aweSOme Paper on JabRef");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
+        assertEquals(Optional.of("AWESOME"), entry.getCiteKeyOptional());
+    }
+
+    @Test
+    public void generateKeyVeryshorttitleTitleCaseModified() {
+        bibtexKeyPattern.setDefaultValue("[veryshorttitle:title_case]");
+        entry.setField("title", "An aweSOme Paper on JabRef");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
+        assertEquals(Optional.of("Awesome"), entry.getCiteKeyOptional());
+    }
+
+    @Test
+    public void generateKeyVeryshorttitleSentenceCaseModified() {
+        bibtexKeyPattern.setDefaultValue("[veryshorttitle:sentence_case]");
+        entry.setField("title", "An aweSOme Paper on JabRef");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
+        assertEquals(Optional.of("Awesome"), entry.getCiteKeyOptional());
+    }
+
+    @Test
+    public void generateKeyVeryshorttitleCapitalizeModified() {
+        bibtexKeyPattern.setDefaultValue("[veryshorttitle:capitalize]");
+        entry.setField("title", "An aweSOme Paper on JabRef");
+        BibtexKeyPatternUtil.makeAndSetLabel(bibtexKeyPattern, database, entry, preferences);
+        assertEquals(Optional.of("Awesome"), entry.getCiteKeyOptional());
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/formatter/FormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/FormatterTest.java
@@ -13,6 +13,7 @@ import org.jabref.logic.formatter.bibtexfields.NormalizeMonthFormatter;
 import org.jabref.logic.formatter.bibtexfields.NormalizeNamesFormatter;
 import org.jabref.logic.formatter.bibtexfields.NormalizePagesFormatter;
 import org.jabref.logic.formatter.bibtexfields.OrdinalsToSuperscriptFormatter;
+import org.jabref.logic.formatter.bibtexfields.RegexFormatter;
 import org.jabref.logic.formatter.bibtexfields.RemoveBracesFormatter;
 import org.jabref.logic.formatter.bibtexfields.UnicodeToLatexFormatter;
 import org.jabref.logic.formatter.bibtexfields.UnitsToLatexFormatter;
@@ -123,6 +124,7 @@ public class FormatterTest {
                 new Object[]{new NormalizePagesFormatter()},
                 new Object[]{new OrdinalsToSuperscriptFormatter()},
                 new Object[]{new ProtectTermsFormatter()},
+                new Object[]{new RegexFormatter()},
                 new Object[]{new RemoveBracesFormatter()},
                 new Object[]{new SentenceCaseFormatter()},
                 new Object[]{new TitleCaseFormatter()},

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/RegexFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/RegexFormatterTest.java
@@ -1,0 +1,32 @@
+package org.jabref.logic.formatter.bibtexfields;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests in addition to the general tests from {@link org.jabref.logic.formatter.FormatterTest}
+ */
+public class RegexFormatterTest {
+
+    private RegexFormatter formatter;
+
+    @Before
+    public void setUp() {
+        formatter = new RegexFormatter();
+    }
+
+    @Test
+    public void test() {
+        String regexInput = "(\" \",\"-\")";
+        formatter.setRegex(regexInput);
+        Assert.assertEquals("replace-all-spaces", formatter.format("replace all spaces"));
+        Assert.assertEquals("replace-spaces-{not these ones}", formatter.format("replace spaces {not these ones}"));
+    }
+
+    @Test
+    public void formatExample() {
+        Assert.assertEquals("Please-replace-the-spaces", formatter.format(formatter.getExampleInput()));
+    }
+
+}


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
Related to https://github.com/koppor/jabref/issues/237
I'm working on adding tests for key patterns + key patterns in combination with modifiers.

I found out why the title_case and capitalize modifiers didn't work with shorttitle. It went wrong because before the modifier was applied the shorttitle was already a concatenated string, so the formatter would just see it as a single word.
For example if we have the title "An Awesome Paper on JabRef", it would first turn into "AnAwesomePaper", and then the modifier would turn it into "Anawesomepaper".

- [ ] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
