### PR TITLE
Fix for "Paying off technical debt: almost all utility classes have a private constructor now."

### DIFF
--- a/src/main/java/org/jabref/Globals.java
+++ b/src/main/java/org/jabref/Globals.java
@@ -49,6 +49,9 @@ public class Globals {
     private static GlobalFocusListener focusListener;
     private static FileUpdateMonitor fileUpdateMonitor;
 
+    private Globals() {
+    }
+
     // Key binding preferences
     public static KeyBindingPreferences getKeyPrefs() {
         if (keyPrefs == null) {

--- a/src/main/java/org/jabref/cli/CrossrefFetcherEvaluator.java
+++ b/src/main/java/org/jabref/cli/CrossrefFetcherEvaluator.java
@@ -25,6 +25,9 @@ import org.jabref.preferences.JabRefPreferences;
  */
 public class CrossrefFetcherEvaluator {
 
+    private CrossrefFetcherEvaluator() {
+    }
+
     public static void main(String[] args) throws IOException, InterruptedException {
         Globals.prefs = JabRefPreferences.getInstance();
         try (FileReader reader = new FileReader(args[0])) {

--- a/src/main/java/org/jabref/cli/GenerateCharacterTable.java
+++ b/src/main/java/org/jabref/cli/GenerateCharacterTable.java
@@ -7,6 +7,9 @@ import org.jabref.logic.util.strings.HTMLUnicodeConversionMaps;
 
 public class GenerateCharacterTable {
 
+    private GenerateCharacterTable() {
+    }
+
     public static void main(String[] args) {
         Map<Integer, String> characterMap = new TreeMap<>(HTMLUnicodeConversionMaps.NUMERICAL_LATEX_CONVERSION_MAP);
         System.out.println("\\documentclass[10pt, a4paper]{article}");

--- a/src/main/java/org/jabref/cli/XMPUtilMain.java
+++ b/src/main/java/org/jabref/cli/XMPUtilMain.java
@@ -28,6 +28,9 @@ import org.apache.jempbox.xmp.XMPMetadata;
 
 public class XMPUtilMain {
 
+    private XMPUtilMain() {
+    }
+
     /**
      * Command-line tool for working with XMP-data.
      *

--- a/src/main/java/org/jabref/gui/EntryMarker.java
+++ b/src/main/java/org/jabref/gui/EntryMarker.java
@@ -21,6 +21,8 @@ public class EntryMarker {
 
     private static final Pattern MARK_NUMBER_PATTERN = Pattern.compile(JabRefPreferences.getInstance().MARKING_WITH_NUMBER_PATTERN);
 
+    private EntryMarker() {
+    }
 
     /**
      * @param increment whether the given increment should be added to the current one. Currently never used in JabRef. Could be used to increase marking color ("Mark in specific color").

--- a/src/main/java/org/jabref/gui/GUIGlobals.java
+++ b/src/main/java/org/jabref/gui/GUIGlobals.java
@@ -47,6 +47,9 @@ public class GUIGlobals {
 
     public static final int MAX_BACK_HISTORY_SIZE = 10; // The maximum number of "Back" operations stored.
 
+    private GUIGlobals() {
+    }
+
     public static JLabel getTableIcon(String fieldType) {
         JLabel label = GUIGlobals.TABLE_ICONS.get(fieldType);
         if (label == null) {

--- a/src/main/java/org/jabref/gui/actions/Actions.java
+++ b/src/main/java/org/jabref/gui/actions/Actions.java
@@ -5,9 +5,6 @@ package org.jabref.gui.actions;
  */
 public class Actions {
 
-    private Actions() {
-    }
-
     public static final String ABBREVIATE_ISO = "abbreviateIso";
     public static final String ABBREVIATE_MEDLINE = "abbreviateMedline";
     public static final String ADD_FILE_LINK = "addFileLink";
@@ -72,4 +69,7 @@ public class Actions {
     public static final String UNMARK_ENTRIES = "unmarkEntries";
     public static final String WRITE_XMP = "writeXMP";
     public static final String PRINT_PREVIEW = "printPreview";
+
+    private Actions() {
+    }
 }

--- a/src/main/java/org/jabref/gui/actions/Actions.java
+++ b/src/main/java/org/jabref/gui/actions/Actions.java
@@ -5,6 +5,9 @@ package org.jabref.gui.actions;
  */
 public class Actions {
 
+    private Actions() {
+    }
+
     public static final String ABBREVIATE_ISO = "abbreviateIso";
     public static final String ABBREVIATE_MEDLINE = "abbreviateMedline";
     public static final String ADD_FILE_LINK = "addFileLink";

--- a/src/main/java/org/jabref/gui/autosaveandbackup/BackupUIManager.java
+++ b/src/main/java/org/jabref/gui/autosaveandbackup/BackupUIManager.java
@@ -13,6 +13,9 @@ import org.jabref.logic.l10n.Localization;
  */
 public class BackupUIManager {
 
+    private BackupUIManager() {
+    }
+
     public static void showRestoreBackupDialog(JFrame frame, Path originalPath) {
         int answer = JOptionPane.showConfirmDialog(frame,
                 new StringBuilder()

--- a/src/main/java/org/jabref/gui/customentrytypes/CustomEntryTypesManager.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/CustomEntryTypesManager.java
@@ -10,6 +10,9 @@ import org.jabref.preferences.JabRefPreferences;
 
 public class CustomEntryTypesManager {
 
+    private CustomEntryTypesManager() {
+    }
+
     /**
      * Iterate through all entry types, and store those that are
      * custom defined to preferences. This method is called from

--- a/src/main/java/org/jabref/gui/desktop/JabRefDesktop.java
+++ b/src/main/java/org/jabref/gui/desktop/JabRefDesktop.java
@@ -52,6 +52,9 @@ public class JabRefDesktop {
     private static final NativeDesktop NATIVE_DESKTOP = getNativeDesktop();
     private static final Pattern REMOTE_LINK_PATTERN = Pattern.compile("[a-z]+://.*");
 
+    private JabRefDesktop() {
+    }
+
     /**
      * Open a http/pdf/ps viewer for the given link string.
      */

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditorTabRelatedArticles.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditorTabRelatedArticles.java
@@ -117,7 +117,7 @@ public class EntryEditorTabRelatedArticles extends JEditorPane {
         this.addHyperlinkListener(e -> {
             try {
                 if ((e.getURL() != null) && (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED)) {
-                        new JabRefDesktop().openBrowser(e.getURL().toString());
+                    JabRefDesktop.openBrowser(e.getURL().toString());
                     }
                 } catch (IOException e1) {
                     LOGGER.error(e1.getMessage(), e1);

--- a/src/main/java/org/jabref/gui/entryeditor/FieldExtraComponents.java
+++ b/src/main/java/org/jabref/gui/entryeditor/FieldExtraComponents.java
@@ -53,6 +53,9 @@ public class FieldExtraComponents {
 
     private static final Log LOGGER = LogFactory.getLog(FieldExtraComponents.class);
 
+    private FieldExtraComponents() {
+    }
+
     private static final String ABBREVIATION_TOOLTIP_TEXT = "<HTML>"
             + Localization.lang("Switches between full and abbreviated journal name if the journal name is known.")
             + "<BR>" + Localization.lang("To set up, go to") + " <B>" + Localization.lang("Options") + " -> "

--- a/src/main/java/org/jabref/gui/exporter/ExportAction.java
+++ b/src/main/java/org/jabref/gui/exporter/ExportAction.java
@@ -33,6 +33,9 @@ public class ExportAction {
 
     private static final Log LOGGER = LogFactory.getLog(ExportAction.class);
 
+    private ExportAction() {
+    }
+
 
     /**
      * Create an AbstractAction for performing an export operation.

--- a/src/main/java/org/jabref/gui/externalfiles/AutoSetLinks.java
+++ b/src/main/java/org/jabref/gui/externalfiles/AutoSetLinks.java
@@ -39,6 +39,9 @@ import org.jabref.preferences.JabRefPreferences;
 
 public class AutoSetLinks {
 
+    private AutoSetLinks() {
+    }
+
     /**
      * Shortcut method if links are set without using the GUI
      *

--- a/src/main/java/org/jabref/gui/groups/GroupDescriptions.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDescriptions.java
@@ -8,6 +8,9 @@ import org.jabref.model.strings.StringUtil;
 
 public class GroupDescriptions {
 
+    private GroupDescriptions() {
+    }
+
     public static String getDescriptionForPreview(String field, String expr, boolean caseSensitive, boolean regExp) {
         String header = regExp ? Localization.lang(
                 "This group contains entries whose <b>%0</b> field contains the regular expression <b>%1</b>",

--- a/src/main/java/org/jabref/gui/groups/GroupSelector.java
+++ b/src/main/java/org/jabref/gui/groups/GroupSelector.java
@@ -507,19 +507,6 @@ public class GroupSelector extends SidePaneComponent implements TreeSelectionLis
         worker.update();
     }
 
-    private List<GroupTreeNodeViewModel> getLeafsOfSelection() {
-        TreePath[] selection = groupsTree.getSelectionPaths();
-        if ((selection == null) || (selection.length == 0)) {
-            return new ArrayList<>();
-        }
-
-        List<GroupTreeNodeViewModel> selectedLeafs = new ArrayList<>(selection.length);
-        for (TreePath path : selection) {
-            selectedLeafs.add((GroupTreeNodeViewModel) path.getLastPathComponent());
-        }
-        return selectedLeafs;
-    }
-
     private GroupTreeNodeViewModel getFirstSelectedNode() {
         TreePath path = groupsTree.getSelectionPath();
         if (path != null) {

--- a/src/main/java/org/jabref/gui/groups/UndoableChangeEntriesOfGroup.java
+++ b/src/main/java/org/jabref/gui/groups/UndoableChangeEntriesOfGroup.java
@@ -11,18 +11,20 @@ import org.jabref.model.FieldChange;
 
 public class UndoableChangeEntriesOfGroup {
 
+    private UndoableChangeEntriesOfGroup() {
+    }
+
     public static AbstractUndoableEdit getUndoableEdit(GroupTreeNodeViewModel node, List<FieldChange> changes) {
         boolean hasEntryChanges = false;
         NamedCompound entryChangeCompound = new NamedCompound(Localization.lang("change entries of group"));
         for (FieldChange fieldChange : changes) {
-            hasEntryChanges = true;
-            entryChangeCompound.addEdit(new UndoableFieldChange(fieldChange));
+           hasEntryChanges = true;
+           entryChangeCompound.addEdit(new UndoableFieldChange(fieldChange));
         }
         if (hasEntryChanges) {
-            entryChangeCompound.end();
-            return entryChangeCompound;
+           entryChangeCompound.end();
+           return entryChangeCompound;
         }
-
         return null;
     }
 }

--- a/src/main/java/org/jabref/gui/groups/WarnAssignmentSideEffects.java
+++ b/src/main/java/org/jabref/gui/groups/WarnAssignmentSideEffects.java
@@ -16,6 +16,9 @@ import org.jabref.model.groups.KeywordGroup;
 
 public class WarnAssignmentSideEffects {
 
+    private WarnAssignmentSideEffects() {
+    }
+
     /**
      * Warns the user of undesired side effects of an explicit assignment/removal of entries to/from this group.
      * Currently there are four types of groups: AllEntriesGroup, SearchGroup - do not support explicit assignment.

--- a/src/main/java/org/jabref/gui/importer/ImportFileFilter.java
+++ b/src/main/java/org/jabref/gui/importer/ImportFileFilter.java
@@ -12,6 +12,9 @@ import org.jabref.logic.util.FileExtensions;
 
 class ImportFileFilter {
 
+    private ImportFileFilter() {
+    }
+
     public static FileChooser.ExtensionFilter convert(Importer format) {
         return new FileChooser.ExtensionFilter(format.getExtensions().getDescription(),
                 format.getExtensions().getExtensions());

--- a/src/main/java/org/jabref/gui/importer/ImportFormats.java
+++ b/src/main/java/org/jabref/gui/importer/ImportFormats.java
@@ -32,6 +32,9 @@ import org.apache.commons.logging.LogFactory;
 public class ImportFormats {
     private static final Log LOGGER = LogFactory.getLog(ImportFormats.class);
 
+    private ImportFormats() {
+    }
+
     /**
      * Create an AbstractAction for performing an Import operation.
      * @param frame The JabRefFrame of this JabRef instance.

--- a/src/main/java/org/jabref/gui/importer/ParserResultWarningDialog.java
+++ b/src/main/java/org/jabref/gui/importer/ParserResultWarningDialog.java
@@ -18,6 +18,9 @@ import org.jabref.logic.l10n.Localization;
  */
 public class ParserResultWarningDialog {
 
+    private ParserResultWarningDialog() {
+    }
+
     /**
      * Shows a dialog with the warnings from an import or open of a file
      *

--- a/src/main/java/org/jabref/gui/journals/JournalAbbreviationsUtil.java
+++ b/src/main/java/org/jabref/gui/journals/JournalAbbreviationsUtil.java
@@ -10,6 +10,9 @@ import org.jabref.logic.l10n.Localization;
 
 public class JournalAbbreviationsUtil {
 
+    private JournalAbbreviationsUtil() {
+    }
+
     public static TableModel getTableModel(Collection<Abbreviation> abbreviations) {
         Object[][] cells = new Object[abbreviations.size()][2];
         int row = 0;

--- a/src/main/java/org/jabref/gui/keyboard/EmacsKeyBindings.java
+++ b/src/main/java/org/jabref/gui/keyboard/EmacsKeyBindings.java
@@ -188,6 +188,9 @@ public class EmacsKeyBindings {
             new JEditorPane(),
     };
 
+    private EmacsKeyBindings() {
+    }
+
     /**
      * Loads the emacs keybindings for all common <code>JTextComponent</code>s.
      *

--- a/src/main/java/org/jabref/gui/keyboard/KeyBinder.java
+++ b/src/main/java/org/jabref/gui/keyboard/KeyBinder.java
@@ -10,6 +10,9 @@ import org.jabref.Globals;
 
 public class KeyBinder {
 
+    private KeyBinder() {
+    }
+
     /**
      * Binds ESC-Key to cancel button
      *

--- a/src/main/java/org/jabref/gui/maintable/MainTableNameFormatter.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableNameFormatter.java
@@ -6,6 +6,8 @@ import org.jabref.preferences.JabRefPreferences;
 
 public class MainTableNameFormatter {
 
+    private MainTableNameFormatter(){}
+    
     /**
      * Format a name field for the table, according to user preferences.
      *

--- a/src/main/java/org/jabref/gui/search/JTextFieldChangeListenerUtil.java
+++ b/src/main/java/org/jabref/gui/search/JTextFieldChangeListenerUtil.java
@@ -19,6 +19,9 @@ import javax.swing.text.JTextComponent;
  */
 public class JTextFieldChangeListenerUtil {
 
+    private JTextFieldChangeListenerUtil() {
+    }
+
     /**
      * Installs a listener to receive notification when the text of any
      * {@code JTextComponent} is changed. Internally, it installs a

--- a/src/main/java/org/jabref/gui/specialfields/SpecialFieldDropDown.java
+++ b/src/main/java/org/jabref/gui/specialfields/SpecialFieldDropDown.java
@@ -21,6 +21,9 @@ import com.jgoodies.looks.Options;
 
 public class SpecialFieldDropDown {
 
+    private SpecialFieldDropDown() {
+    }
+
     public static JButton generateSpecialFieldButtonWithDropDown(SpecialField field, JabRefFrame frame) {
         Dimension buttonDim = new Dimension(23, 23);
         SpecialFieldViewModel viewModel = new SpecialFieldViewModel(field);

--- a/src/main/java/org/jabref/gui/util/BindingsHelper.java
+++ b/src/main/java/org/jabref/gui/util/BindingsHelper.java
@@ -16,6 +16,10 @@ import javafx.scene.Node;
  * Some methods are taken from https://bugs.openjdk.java.net/browse/JDK-8134679
  */
 public class BindingsHelper {
+
+    private BindingsHelper() {
+    }
+
     public static <T> BooleanBinding any(ObservableList<T> source, Predicate<T> predicate) {
         return Bindings.createBooleanBinding(() -> source.stream().anyMatch(predicate), source);
     }

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -45,6 +45,9 @@ public class BibtexKeyPatternUtil {
 
     private static final int CHARS_OF_FIRST = 5;
 
+    private BibtexKeyPatternUtil() {
+    }
+
     private static String normalize(String content) {
         List<String> tokens = new ArrayList<>();
         int b = 0;

--- a/src/main/java/org/jabref/logic/bst/BibtexNameFormatter.java
+++ b/src/main/java/org/jabref/logic/bst/BibtexNameFormatter.java
@@ -26,6 +26,9 @@ import org.jabref.model.entry.AuthorList;
  */
 public class BibtexNameFormatter {
 
+    private BibtexNameFormatter() {
+    }
+
     public static String formatName(String authorsNameList, int whichName, String formatString, Warn warn) {
         AuthorList al = AuthorList.parse(authorsNameList);
 

--- a/src/main/java/org/jabref/logic/bst/BibtexPurify.java
+++ b/src/main/java/org/jabref/logic/bst/BibtexPurify.java
@@ -12,6 +12,9 @@ package org.jabref.logic.bst;
  */
 public class BibtexPurify {
 
+    private BibtexPurify() {
+    }
+
     /**
      *
      * @param toPurify

--- a/src/main/java/org/jabref/logic/bst/BibtexTextPrefix.java
+++ b/src/main/java/org/jabref/logic/bst/BibtexTextPrefix.java
@@ -16,6 +16,9 @@ package org.jabref.logic.bst;
  */
 public class BibtexTextPrefix {
 
+    private BibtexTextPrefix() {
+    }
+
     /**
      *
      * @param numOfChars

--- a/src/main/java/org/jabref/logic/bst/BibtexWidth.java
+++ b/src/main/java/org/jabref/logic/bst/BibtexWidth.java
@@ -29,7 +29,6 @@ public class BibtexWidth {
 
     private static int[] widths;
 
-
     static {
         if (BibtexWidth.widths == null) {
             BibtexWidth.widths = new int[128];
@@ -133,6 +132,9 @@ public class BibtexWidth {
             BibtexWidth.widths[125] = 500;
             BibtexWidth.widths[126] = 500;
         }
+    }
+
+    private BibtexWidth() {
     }
 
     private static int getSpecialCharWidth(char[] c, int pos) {

--- a/src/main/java/org/jabref/logic/citationstyle/CitationStyleGenerator.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStyleGenerator.java
@@ -29,6 +29,9 @@ public class CitationStyleGenerator {
     private static final Log LOGGER = LogFactory.getLog(CitationStyleGenerator.class);
     private static final BibTeXConverter BIBTEX_CONVERTER = new BibTeXConverter();
 
+    private CitationStyleGenerator() {
+    }
+
     /**
      * WARNING: the citation is generated using JavaScript which may take some time, better call it from outside the main Thread
      * Generates a Citation based on the given entry and style

--- a/src/main/java/org/jabref/logic/cleanup/Cleanups.java
+++ b/src/main/java/org/jabref/logic/cleanup/Cleanups.java
@@ -56,6 +56,9 @@ public class Cleanups {
         RECOMMEND_BIBLATEX_ACTIONS = new FieldFormatterCleanups(false, recommendedBiblatexFormatters);
     }
 
+    private Cleanups() {
+    }
+
     public static List<Formatter> getAvailableFormatters() {
         return Collections.unmodifiableList(availableFormatters);
     }

--- a/src/main/java/org/jabref/logic/exporter/ExportFormats.java
+++ b/src/main/java/org/jabref/logic/exporter/ExportFormats.java
@@ -15,6 +15,8 @@ public class ExportFormats {
     // Global variable that is used for counting output entries when exporting:
     public static int entryNumber;
 
+    private ExportFormats() {
+    }
 
     public static void initAllExports(Map<String, ExportFormat> customFormats,
             LayoutFormatterPreferences layoutPreferences, SavePreferences savePreferences) {

--- a/src/main/java/org/jabref/logic/exporter/MetaDataSerializer.java
+++ b/src/main/java/org/jabref/logic/exporter/MetaDataSerializer.java
@@ -18,6 +18,9 @@ import org.jabref.model.strings.StringUtil;
 
 public class MetaDataSerializer {
 
+    private MetaDataSerializer() {
+    }
+
     /**
      * Writes all data in the format <key, serialized data>.
      */
@@ -90,7 +93,7 @@ public class MetaDataSerializer {
                 stringyPattern.put(metaDataKey, data);
             }
         }
-        if (citeKeyPattern.getDefaultValue() != null && !citeKeyPattern.getDefaultValue().isEmpty()) {
+        if ((citeKeyPattern.getDefaultValue() != null) && !citeKeyPattern.getDefaultValue().isEmpty()) {
             List<String> data = new ArrayList<>();
             data.add(citeKeyPattern.getDefaultValue().get(0));
             stringyPattern.put(MetaData.KEYPATTERNDEFAULT, data);

--- a/src/main/java/org/jabref/logic/formatter/Formatters.java
+++ b/src/main/java/org/jabref/logic/formatter/Formatters.java
@@ -63,6 +63,9 @@ public class Formatters {
 
     public static final List<Formatter> ALL = new ArrayList<>();
 
+    private Formatters() {
+    }
+
     public static Optional<Formatter> getFormatterForModifier(String modifier) {
         Objects.requireNonNull(modifier);
         Optional<Formatter> formatter = ALL.stream().filter(f -> f.getKey().equals(modifier)).findAny();

--- a/src/main/java/org/jabref/logic/groups/DefaultGroupsFactory.java
+++ b/src/main/java/org/jabref/logic/groups/DefaultGroupsFactory.java
@@ -5,6 +5,9 @@ import org.jabref.model.groups.AllEntriesGroup;
 
 public class DefaultGroupsFactory {
 
+    private DefaultGroupsFactory() {
+    }
+
     public static AllEntriesGroup getAllEntriesGroup() {
         AllEntriesGroup group = new AllEntriesGroup(Localization.lang("All entries"));
         group.setIconCode(org.jabref.gui.IconTheme.JabRefIcon.ALL_ENTRIES_GROUP_ICON.getCode());

--- a/src/main/java/org/jabref/logic/importer/OpenDatabase.java
+++ b/src/main/java/org/jabref/logic/importer/OpenDatabase.java
@@ -19,6 +19,9 @@ import org.apache.commons.logging.LogFactory;
 public class OpenDatabase {
     public static final Log LOGGER = LogFactory.getLog(OpenDatabase.class);
 
+    private OpenDatabase() {
+    }
+
     /**
      * Load database (bib-file)
      *

--- a/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -24,6 +24,9 @@ import org.jabref.model.entry.identifier.Identifier;
 
 public class WebFetchers {
 
+    private WebFetchers() {
+    }
+
     public static Optional<IdBasedFetcher> getIdBasedFetcherForField(String field, ImportFormatPreferences preferences) {
         IdBasedFetcher fetcher;
         switch (field) {

--- a/src/main/java/org/jabref/logic/importer/fetcher/BibsonomyScraper.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/BibsonomyScraper.java
@@ -24,6 +24,9 @@ public class BibsonomyScraper {
 
     private static final Log LOGGER = LogFactory.getLog(BibsonomyScraper.class);
 
+    private BibsonomyScraper() {
+    }
+
     /**
      * Return a BibEntry by looking up the given url from the BibSonomy scraper.
      * @param entryUrl

--- a/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
@@ -24,6 +24,9 @@ import org.jabref.model.strings.StringUtil;
  */
 public class GroupsParser {
 
+    private GroupsParser() {
+    }
+
     public static GroupTreeNode importGroups(List<String> orderedData, Character keywordSeparator)
             throws ParseException {
         try {

--- a/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
@@ -25,6 +25,8 @@ public class MetaDataParser {
 
     private static final Log LOGGER = LogFactory.getLog(MetaDataParser.class);
 
+    private MetaDataParser() {
+    }
 
     /**
      * Parses the given data map and returns a new resulting {@link MetaData} instance.

--- a/src/main/java/org/jabref/logic/integrity/FieldCheckers.java
+++ b/src/main/java/org/jabref/logic/integrity/FieldCheckers.java
@@ -12,6 +12,10 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 
 public class FieldCheckers {
+
+    private FieldCheckers() {
+    }
+
     static List<FieldChecker> getAll(BibDatabaseContext databaseContext, FileDirectoryPreferences fileDirectoryPreferences) {
         return getAllMap(databaseContext, fileDirectoryPreferences)
                 .entries().stream()

--- a/src/main/java/org/jabref/logic/journals/AbbreviationWriter.java
+++ b/src/main/java/org/jabref/logic/journals/AbbreviationWriter.java
@@ -15,6 +15,9 @@ import org.jabref.logic.util.OS;
  */
 public class AbbreviationWriter {
 
+    private AbbreviationWriter() {
+    }
+
     /**
      * This method will write the list of abbreviations to a file on the file system specified by the given path.
      * If the file already exists its content will be overridden, otherwise a new file will be created.

--- a/src/main/java/org/jabref/logic/l10n/Encodings.java
+++ b/src/main/java/org/jabref/logic/l10n/Encodings.java
@@ -17,4 +17,7 @@ public class Encodings {
         ENCODINGS = encodingsList.toArray(new Charset[encodingsList.size()]);
         ENCODINGS_DISPLAYNAMES = encodingsStringList.toArray(new String[encodingsStringList.size()]);
     }
+
+    private Encodings() {
+    }
 }

--- a/src/main/java/org/jabref/logic/l10n/Languages.java
+++ b/src/main/java/org/jabref/logic/l10n/Languages.java
@@ -33,6 +33,9 @@ public class Languages {
         LANGUAGES.put("Simplified Chinese", "zh");
     }
 
+    private Languages() {
+    }
+
     public static Optional<Locale> convertToSupportedLocale(String language) {
         Objects.requireNonNull(language);
 

--- a/src/main/java/org/jabref/logic/l10n/Localization.java
+++ b/src/main/java/org/jabref/logic/l10n/Localization.java
@@ -20,6 +20,9 @@ public class Localization {
     private static ResourceBundle messages;
     private static ResourceBundle menuTitles;
 
+    private Localization() {
+    }
+
     public static LocalizationBundle getMessages() {
         return new LocalizationBundle(messages);
     }

--- a/src/main/java/org/jabref/logic/layout/AbstractParamLayoutFormatter.java
+++ b/src/main/java/org/jabref/logic/layout/AbstractParamLayoutFormatter.java
@@ -12,6 +12,9 @@ public abstract class AbstractParamLayoutFormatter implements ParamLayoutFormatt
     private static final char SEPARATOR = ',';
 
 
+    protected AbstractParamLayoutFormatter() {
+    }
+
     /**
      * Parse an argument string and return the parts of the argument. The parts are
      * separated by commas, and escaped commas are reduced to literal commas.

--- a/src/main/java/org/jabref/logic/logging/JabRefLogger.java
+++ b/src/main/java/org/jabref/logic/logging/JabRefLogger.java
@@ -11,6 +11,9 @@ import org.apache.logging.log4j.core.config.LoggerConfig;
 public class JabRefLogger {
     private static final Log LOGGER = LogFactory.getLog(JabRefLogger.class);
 
+    private JabRefLogger() {
+    }
+
     public static void setDebug() {
         setLogLevelToDebugForJabRefClasses();
         LOGGER.debug("Showing debug messages");

--- a/src/main/java/org/jabref/logic/msbib/BibTeXConverter.java
+++ b/src/main/java/org/jabref/logic/msbib/BibTeXConverter.java
@@ -16,6 +16,9 @@ public class BibTeXConverter {
 
     private static final String MSBIB_PREFIX = "msbib-";
 
+    private BibTeXConverter() {
+    }
+
     /**
      * Converts an {@link MSBibEntry} to a {@link BibEntry} for import
      * @param entry The MsBibEntry to convert

--- a/src/main/java/org/jabref/logic/msbib/MSBibConverter.java
+++ b/src/main/java/org/jabref/logic/msbib/MSBibConverter.java
@@ -12,6 +12,9 @@ public class MSBibConverter {
     private static final String MSBIB_PREFIX = "msbib-";
     private static final String BIBTEX_PREFIX = "BIBTEX_";
 
+    private MSBibConverter() {
+    }
+
     public static MSBibEntry convert(BibEntry entry) {
         MSBibEntry result = new MSBibEntry();
 

--- a/src/main/java/org/jabref/logic/msbib/MSBibMapping.java
+++ b/src/main/java/org/jabref/logic/msbib/MSBibMapping.java
@@ -80,6 +80,9 @@ public class MSBibMapping {
         biblatexToMsBib.put(MSBIB_PREFIX + "productioncompany", "ProductionCompany");
     }
 
+    private MSBibMapping() {
+    }
+
     public static String getBiblatexEntryType(String msbibType) {
         final String defaultType = BibtexEntryTypes.MISC.getName();
 

--- a/src/main/java/org/jabref/logic/net/ProxyRegisterer.java
+++ b/src/main/java/org/jabref/logic/net/ProxyRegisterer.java
@@ -2,6 +2,9 @@ package org.jabref.logic.net;
 
 public class ProxyRegisterer {
 
+    private ProxyRegisterer() {
+    }
+
     public static void register(ProxyPreferences proxyPrefs) {
         if (proxyPrefs.isUseProxy()) {
             // NetworkTab.java ensures that proxyHostname and proxyPort are not null

--- a/src/main/java/org/jabref/logic/net/URLUtil.java
+++ b/src/main/java/org/jabref/logic/net/URLUtil.java
@@ -13,6 +13,9 @@ public class URLUtil {
     // Detect Google search URL
     private static final String GOOGLE_SEARCH_EXP = "^https?://(?:www\\.)?google\\.[\\.a-z]+?/url.*";
 
+    private URLUtil() {
+    }
+
     /**
      * Cleans URLs returned by Google search.
      *

--- a/src/main/java/org/jabref/logic/remote/RemoteUtil.java
+++ b/src/main/java/org/jabref/logic/remote/RemoteUtil.java
@@ -2,7 +2,10 @@ package org.jabref.logic.remote;
 
 public class RemoteUtil {
 
+    private RemoteUtil() {
+    }
+
     public static boolean isUserPort(int portNumber) {
-        return portNumber >= 1024 && portNumber <= 65535;
+        return (portNumber >= 1024) && (portNumber <= 65535);
     }
 }

--- a/src/main/java/org/jabref/logic/remote/client/RemoteListenerClient.java
+++ b/src/main/java/org/jabref/logic/remote/client/RemoteListenerClient.java
@@ -16,6 +16,9 @@ public class RemoteListenerClient {
     private static final int TIMEOUT = 2000;
 
 
+    private RemoteListenerClient() {
+    }
+
     /**
      * Attempt to send command line arguments to already running JabRef instance.
      *

--- a/src/main/java/org/jabref/logic/search/rules/describer/SearchDescribers.java
+++ b/src/main/java/org/jabref/logic/search/rules/describer/SearchDescribers.java
@@ -7,6 +7,9 @@ import org.jabref.model.search.rules.SearchRule;
 
 public class SearchDescribers {
 
+    private SearchDescribers() {
+    }
+
     /**
      * Get the search describer for a given search rule and a given search query.
      *

--- a/src/main/java/org/jabref/logic/util/MetadataSerializationConfiguration.java
+++ b/src/main/java/org/jabref/logic/util/MetadataSerializationConfiguration.java
@@ -57,4 +57,7 @@ public class MetadataSerializationConfiguration {
      * Identifier for {@link AutomaticKeywordGroup}.
      */
     public static final String AUTOMATIC_KEYWORD_GROUP_ID = "AutomaticKeywordGroup:";
+
+    private MetadataSerializationConfiguration() {
+    }
 }

--- a/src/main/java/org/jabref/logic/util/OS.java
+++ b/src/main/java/org/jabref/logic/util/OS.java
@@ -19,4 +19,7 @@ public class OS {
     // Newlines
     // will be overridden in initialization due to feature #857 @ JabRef.java
     public static String NEWLINE = System.lineSeparator();
+
+    private OS() {
+    }
 }

--- a/src/main/java/org/jabref/logic/util/TestEntry.java
+++ b/src/main/java/org/jabref/logic/util/TestEntry.java
@@ -5,6 +5,9 @@ import org.jabref.model.entry.FieldName;
 
 public class TestEntry {
 
+    private TestEntry() {
+    }
+
     public static BibEntry getTestEntry() {
 
         BibEntry entry = new BibEntry("article");

--- a/src/main/java/org/jabref/logic/util/UpdateField.java
+++ b/src/main/java/org/jabref/logic/util/UpdateField.java
@@ -11,6 +11,9 @@ import org.jabref.model.entry.FieldName;
 
 public class UpdateField {
 
+    private UpdateField() {
+    }
+
     /**
      * Updating a field will result in the entry being reformatted on save
      *

--- a/src/main/java/org/jabref/logic/util/io/FileBasedLock.java
+++ b/src/main/java/org/jabref/logic/util/io/FileBasedLock.java
@@ -22,6 +22,9 @@ public class FileBasedLock {
      */
     public static final long LOCKFILE_CRITICAL_AGE = 60000;
 
+    private FileBasedLock() {
+    }
+
     /**
      * This method checks whether there is a lock file for the given file. If
      * there is, it waits for 500 ms. This is repeated until the lock is gone

--- a/src/main/java/org/jabref/logic/util/io/FileFinder.java
+++ b/src/main/java/org/jabref/logic/util/io/FileFinder.java
@@ -20,6 +20,9 @@ public class FileFinder {
 
     private static final Log LOGGER = LogFactory.getLog(FileFinder.class);
 
+    private FileFinder() {
+    }
+
     public static Set<Path> findFiles(List<String> extensions, List<File> directories) {
 
         Objects.requireNonNull(directories, "Directories must not be null!");

--- a/src/main/java/org/jabref/logic/util/io/FileNameCleaner.java
+++ b/src/main/java/org/jabref/logic/util/io/FileNameCleaner.java
@@ -26,6 +26,9 @@ public class FileNameCleaner {
     };
     // @formatter:on
 
+    private FileNameCleaner() {
+    }
+
 
     /**
      * Replaces illegal characters in given fileName by '_'

--- a/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -44,6 +44,9 @@ public class FileUtil {
 
     public static final boolean isPosixCompilant = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
 
+    private FileUtil() {
+    }
+
     /**
      * Returns the extension of a file or Optional.empty() if the file does not have one (no . in name).
      *

--- a/src/main/java/org/jabref/logic/util/io/RegExpFileSearch.java
+++ b/src/main/java/org/jabref/logic/util/io/RegExpFileSearch.java
@@ -31,6 +31,9 @@ public class RegExpFileSearch {
     private static final Pattern SQUARE_BRACKETS_PATTERN = Pattern.compile("\\[.*?\\]");
 
 
+    private RegExpFileSearch() {
+    }
+
     /**
      * Search for file links for a set of entries using regexp. Lists of extensions and directories
      * are given.

--- a/src/main/java/org/jabref/logic/util/io/XMLUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/XMLUtil.java
@@ -28,6 +28,9 @@ import org.w3c.dom.NodeList;
 public class XMLUtil {
     private static final Log LOGGER = LogFactory.getLog(XMLUtil.class);
 
+    private XMLUtil() {
+    }
+
     /**
      * Prints out the document to standard out. Used to generate files for test cases.
      */

--- a/src/main/java/org/jabref/logic/util/strings/DiffHighlighting.java
+++ b/src/main/java/org/jabref/logic/util/strings/DiffHighlighting.java
@@ -19,6 +19,9 @@ public class DiffHighlighting {
     public static final String HTML_START = "<html><body>";
     public static final String HTML_END = "</body></html>";
 
+    private DiffHighlighting() {
+    }
+
 
     public static String generateDiffHighlighting(String baseString, String modifiedString, String separator) {
         Objects.requireNonNull(separator);

--- a/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
+++ b/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
@@ -897,6 +897,9 @@ public class HTMLUnicodeConversionMaps {
 
     }
 
+    private HTMLUnicodeConversionMaps() {
+    }
+
     private static String cleanLaTeX(String escapedString) {
         // Get rid of \{}$ from the LaTeX-string
         return escapedString.replaceAll("[\\\\\\{\\}\\$]", "");

--- a/src/main/java/org/jabref/logic/xmp/XMPUtil.java
+++ b/src/main/java/org/jabref/logic/xmp/XMPUtil.java
@@ -62,6 +62,8 @@ public class XMPUtil {
 
     private static final Log LOGGER = LogFactory.getLog(XMPUtil.class);
 
+    private XMPUtil() {
+    }
 
     /**
      * Convenience method for readXMP(File).

--- a/src/main/java/org/jabref/migrations/CustomEntryTypePreferenceMigration.java
+++ b/src/main/java/org/jabref/migrations/CustomEntryTypePreferenceMigration.java
@@ -22,6 +22,9 @@ class CustomEntryTypePreferenceMigration {
 
     private static JabRefPreferences prefs = Globals.prefs;
 
+    private CustomEntryTypePreferenceMigration() {
+    }
+
     static void upgradeStoredCustomEntryTypes(BibDatabaseMode defaultBibDatabaseMode) {
         List<CustomEntryType> storedOldTypes = new ArrayList<>();
 

--- a/src/main/java/org/jabref/migrations/PreferencesMigrations.java
+++ b/src/main/java/org/jabref/migrations/PreferencesMigrations.java
@@ -18,6 +18,9 @@ public class PreferencesMigrations {
 
     private static final Log LOGGER = LogFactory.getLog(PreferencesMigrations.class);
 
+    private PreferencesMigrations() {
+    }
+
     /**
      * Migrate all preferences from net/sf/jabref to org/jabref
      */

--- a/src/main/java/org/jabref/model/DuplicateCheck.java
+++ b/src/main/java/org/jabref/model/DuplicateCheck.java
@@ -55,6 +55,8 @@ public class DuplicateCheck {
         DuplicateCheck.FIELD_WEIGHTS.put(FieldName.JOURNAL, 2.);
     }
 
+    private DuplicateCheck() {
+    }
 
     /**
      * Checks if the two entries represent the same publication.

--- a/src/main/java/org/jabref/model/EntryTypes.java
+++ b/src/main/java/org/jabref/model/EntryTypes.java
@@ -105,6 +105,9 @@ public class EntryTypes {
     public static final InternalEntryTypes BIBLATEX = new InternalEntryTypes(BiblatexEntryTypes.MISC,
             Arrays.asList(BiblatexEntryTypes.ALL));
 
+    private EntryTypes() {
+    }
+
     /**
      * This method returns the BibtexEntryType for the name of a type,
      * or null if it does not exist.
@@ -228,15 +231,16 @@ public class EntryTypes {
      * @return returns true if the two compared entry types have the same name and equal required and optional fields
      */
     public static boolean isEqualNameAndFieldBased(EntryType type1, EntryType type2) {
-        if (type1 == null && type2 == null) {
+        if ((type1 == null) && (type2 == null)) {
             return true;
-        } else if (type1 == null || type2 == null) {
+        } else if ((type1 == null) || (type2 == null)) {
             return false;
-        } else
+        } else {
             return type1.getName().equals(type2.getName())
                     && type1.getRequiredFields().equals(type2.getRequiredFields())
                     && type1.getOptionalFields().equals(type2.getOptionalFields())
                     && type1.getSecondaryOptionalFields().equals(type2.getSecondaryOptionalFields());
+        }
     }
 
     public static boolean isExclusiveBiblatex(String type) {

--- a/src/main/java/org/jabref/model/database/BibDatabaseModeDetection.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseModeDetection.java
@@ -7,6 +7,9 @@ import org.jabref.model.EntryTypes;
 import org.jabref.model.entry.BibEntry;
 
 public class BibDatabaseModeDetection {
+
+    private BibDatabaseModeDetection() {
+    }
     /**
      * Tries to infer the database type by examining a BibDatabase database.
      *

--- a/src/main/java/org/jabref/model/database/BibDatabases.java
+++ b/src/main/java/org/jabref/model/database/BibDatabases.java
@@ -9,6 +9,9 @@ import org.jabref.model.entry.IdGenerator;
 
 public class BibDatabases {
 
+    private BibDatabases() {
+    }
+
     /**
      * Gets a collection of bibentries and sets an ID for every entry. After that
      * all entries will be inserted into a new BibDatabase.

--- a/src/main/java/org/jabref/model/entry/BiblatexEntryTypes.java
+++ b/src/main/java/org/jabref/model/entry/BiblatexEntryTypes.java
@@ -950,6 +950,9 @@ public class BiblatexEntryTypes {
             THESIS, UNPUBLISHED, CONFERENCE, ELECTRONIC, MASTERSTHESIS, PHDTHESIS, TECHREPORT, WWW, IEEETRANBSTCTL);
 
 
+    private BiblatexEntryTypes() {
+    }
+
     public static Optional<EntryType> getType(String name) {
         return ALL.stream().filter(e -> e.getName().equalsIgnoreCase(name)).findFirst();
     }

--- a/src/main/java/org/jabref/model/entry/BibtexEntryTypes.java
+++ b/src/main/java/org/jabref/model/entry/BibtexEntryTypes.java
@@ -281,6 +281,9 @@ public class BibtexEntryTypes {
     public static final List<EntryType> ALL = Arrays.asList(ARTICLE, INBOOK, BOOK, BOOKLET, INCOLLECTION, CONFERENCE,
             INPROCEEDINGS, PROCEEDINGS, MANUAL, MASTERSTHESIS, PHDTHESIS, TECHREPORT, UNPUBLISHED, MISC);
 
+    private BibtexEntryTypes() {
+    }
+
     public static Optional<EntryType> getType(String name) {
         return ALL.stream().filter(e -> e.getName().equalsIgnoreCase(name)).findFirst();
     }

--- a/src/main/java/org/jabref/model/entry/CanonicalBibtexEntry.java
+++ b/src/main/java/org/jabref/model/entry/CanonicalBibtexEntry.java
@@ -10,6 +10,9 @@ import java.util.TreeSet;
 
 public class CanonicalBibtexEntry {
 
+    private CanonicalBibtexEntry() {
+    }
+
     /**
      * This returns a canonical BibTeX serialization. Special characters such as "{" or "&" are NOT escaped, but written
      * as is

--- a/src/main/java/org/jabref/model/entry/EntryConverter.java
+++ b/src/main/java/org/jabref/model/entry/EntryConverter.java
@@ -40,4 +40,6 @@ public class EntryConverter {
         FIELD_ALIASES.putAll(EntryConverter.FIELD_ALIASES_LTX_TO_TEX);
     }
 
+    private EntryConverter() {
+    }
 }

--- a/src/main/java/org/jabref/model/entry/EntryLinkList.java
+++ b/src/main/java/org/jabref/model/entry/EntryLinkList.java
@@ -10,6 +10,8 @@ public class EntryLinkList {
 
     private static String SEPARATOR = ",";
 
+    private EntryLinkList() {
+    }
 
     public static List<ParsedEntryLink> parse(String fieldValue, BibDatabase database) {
         List<ParsedEntryLink> result = new ArrayList<>();

--- a/src/main/java/org/jabref/model/entry/FieldName.java
+++ b/src/main/java/org/jabref/model/entry/FieldName.java
@@ -155,6 +155,9 @@ public class FieldName {
     // Map to hold alternative display names
     private static final Map<String, String> displayNames = new HashMap<>();
 
+    private FieldName() {
+    }
+
     public static String orFields(String... fields) {
         return String.join(FieldName.FIELD_SEPARATOR, fields);
     }

--- a/src/main/java/org/jabref/model/entry/FileField.java
+++ b/src/main/java/org/jabref/model/entry/FileField.java
@@ -8,6 +8,9 @@ import java.util.stream.Collectors;
 
 public class FileField {
 
+    private FileField() {
+    }
+
     public static List<ParsedFileField> parse(String value) {
         if ((value == null) || value.trim().isEmpty()) {
             return Collections.emptyList();

--- a/src/main/java/org/jabref/model/entry/IEEETranEntryTypes.java
+++ b/src/main/java/org/jabref/model/entry/IEEETranEntryTypes.java
@@ -115,6 +115,9 @@ public class IEEETranEntryTypes {
 
     public static final List<EntryType> ALL = Arrays.asList(ELECTRONIC, IEEETRANBSTCTL, PERIODICAL, PATENT, STANDARD);
 
+    private IEEETranEntryTypes() {
+    }
+
     public static Optional<EntryType> getType(String name) {
         return ALL.stream().filter(e -> e.getName().equalsIgnoreCase(name)).findFirst();
     }

--- a/src/main/java/org/jabref/model/entry/IdGenerator.java
+++ b/src/main/java/org/jabref/model/entry/IdGenerator.java
@@ -19,6 +19,9 @@ public class IdGenerator {
 
     private static int idCounter;
 
+    private IdGenerator() {
+    }
+
     public static synchronized String next() {
         String result = idFormat.format(idCounter);
         idCounter++;

--- a/src/main/java/org/jabref/model/entry/MonthUtil.java
+++ b/src/main/java/org/jabref/model/entry/MonthUtil.java
@@ -63,6 +63,8 @@ public class MonthUtil {
         }
     }
 
+    private MonthUtil() {
+    }
 
     /**
      * Find month by number

--- a/src/main/java/org/jabref/model/search/rules/SearchRules.java
+++ b/src/main/java/org/jabref/model/search/rules/SearchRules.java
@@ -4,6 +4,9 @@ import org.jabref.model.strings.StringUtil;
 
 public class SearchRules {
 
+    private SearchRules() {
+    }
+
     /**
      * Returns the appropriate search rule that fits best to the given parameter.
      */


### PR DESCRIPTION
This went wrong initially in #2649 due to merge conflicts. @ohuang12 helped fixing the merge conflicts, it should be better now. We are sorry and apologize for the inconvenience we caused earlier :cry: 

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
