### PR TITLE
Fix #2680 and fix #2667: Swing errors are catched properly and without freezing

### DIFF
--- a/src/main/java/org/jabref/JabRefException.java
+++ b/src/main/java/org/jabref/JabRefException.java
@@ -5,9 +5,8 @@ import org.apache.commons.logging.LogFactory;
 
 public class JabRefException extends Exception {
 
-    private String localizedMessage;
-
     private static final Log LOGGER = LogFactory.getLog(JabRefException.class);
+    private String localizedMessage;
 
     public JabRefException(String message) {
         super(message);
@@ -34,7 +33,7 @@ public class JabRefException extends Exception {
     @Override
     public String getLocalizedMessage() {
         if (localizedMessage == null) {
-            LOGGER.warn("No localized message exception message defined. Falling back to getMessage().");
+            LOGGER.debug("No localized message exception message defined. Falling back to getMessage().");
             return getMessage();
         } else {
             return localizedMessage;

--- a/src/main/java/org/jabref/gui/logging/GuiAppender.java
+++ b/src/main/java/org/jabref/gui/logging/GuiAppender.java
@@ -2,6 +2,7 @@ package org.jabref.gui.logging;
 
 import java.io.Serializable;
 
+import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.logic.logging.LogMessages;
 
 import org.apache.logging.log4j.core.Filter;
@@ -43,6 +44,6 @@ public class GuiAppender extends AbstractAppender {
      */
     @Override
     public void append(LogEvent event) {
-        LogMessages.getInstance().add(event);
+        DefaultTaskExecutor.runInJavaFXThread(() -> LogMessages.getInstance().add(event));
     }
 }

--- a/src/main/java/org/jabref/gui/util/DefaultTaskExecutor.java
+++ b/src/main/java/org/jabref/gui/util/DefaultTaskExecutor.java
@@ -19,6 +19,21 @@ public class DefaultTaskExecutor implements TaskExecutor {
 
     private static final Log LOGGER = LogFactory.getLog(DefaultTaskExecutor.class);
 
+    public static <V> V runInJavaFXThread(Callable<V> callable) {
+        FutureTask<V> task = new FutureTask<>(callable);
+        Platform.runLater(task);
+        try {
+            return task.get();
+        } catch (InterruptedException | ExecutionException e) {
+            LOGGER.error(e);
+            return null;
+        }
+    }
+
+    public static void runInJavaFXThread(Runnable runnable) {
+        Platform.runLater(runnable);
+    }
+
     @Override
     public <V> void execute(BackgroundTask<V> task) {
         new Thread(getJavaFXTask(task)).start();
@@ -54,16 +69,4 @@ public class DefaultTaskExecutor implements TaskExecutor {
             return new Exception(throwable);
         }
     }
-
-    public static <V> V runInJavaFXThread(Callable<V> callable) {
-        FutureTask<V> task = new FutureTask<>(callable);
-        Platform.runLater(task);
-        try {
-            return task.get();
-        } catch (InterruptedException | ExecutionException e) {
-            LOGGER.error(e);
-            return null;
-        }
-    }
-
 }


### PR DESCRIPTION
Hopefully, fixes that the error console is not updated properly #2667 as well as that Swing errors lead to frezzing #2680. At least for me, it works now without problems. @stefan-kolb @lynyus can you please also check it.

For the error console, I took the suggestion https://github.com/JabRef/jabref/issues/2667#issuecomment-288742546 by @matthiasgeiger. The freezing after a Swing message occurred since 
̀`LOGGER.warn("No localized message exception message defined. Falling back to getMessage().");`
lead to recursive calls (actually, Log4j has some logic to prevent deadlocks but these don't take effect since the original message is thrown in the Swing thread, while the above "no localized messsage" is posted in the JavaFX thread.). I simply changed it to log level "debug", which effectively hides it in most cases. As a positive side effect, the scroll issue mentioned in https://github.com/JabRef/jabref/issues/2667#issuecomment-288714639 is also fixed.

<!-- describe the changes you have made here: what, why, ... -->

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
