### PR TITLE
Parser no longer warns about empty BibTeX keys

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -251,9 +251,6 @@ public class BibtexParser implements Parser {
             boolean duplicateKey = database.insertEntry(entry);
             if (duplicateKey) {
                 parserResult.addDuplicateKey(entry.getCiteKey());
-            } else if (!entry.getCiteKeyOptional().isPresent() || entry.getCiteKeyOptional().get().isEmpty()) {
-                parserResult.addWarning(Localization.lang("Empty BibTeX key") + ": " + entry.getAuthorTitleYear(40)
-                        + " (" + Localization.lang("Grouping may not work for this entry.") + ")");
             }
         } catch (IOException ex) {
             LOGGER.debug("Could not parse entry", ex);

--- a/src/main/java/org/jabref/logic/integrity/BibtexKeyChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/BibtexKeyChecker.java
@@ -13,23 +13,21 @@ import org.jabref.model.strings.StringUtil;
 /**
  * Currently only checks the key if there is an author, year, and title present.
  */
-public class BibtexkeyChecker implements Checker {
+public class BibtexKeyChecker implements Checker {
 
     @Override
     public List<IntegrityMessage> check(BibEntry entry) {
-        Optional<String> valuekey = entry.getCiteKeyOptional();
-        Optional<String> valueauthor = entry.getField(FieldName.AUTHOR);
-        Optional<String> valuetitle = entry.getField(FieldName.TITLE);
-        Optional<String> valueyear = entry.getField(FieldName.YEAR);
-        String authortitleyear = entry.getAuthorTitleYear(100);
-
-        if (!valueauthor.isPresent() || !valuetitle.isPresent() || !valueyear.isPresent()) {
+        Optional<String> author = entry.getField(FieldName.AUTHOR);
+        Optional<String> title = entry.getField(FieldName.TITLE);
+        Optional<String> year = entry.getField(FieldName.YEAR);
+        if (!author.isPresent() || !title.isPresent() || !year.isPresent()) {
             return Collections.emptyList();
         }
 
-        if (StringUtil.isBlank(valuekey)) {
+        if (StringUtil.isBlank(entry.getCiteKeyOptional())) {
+            String authorTitleYear = entry.getAuthorTitleYear(100);
             return Collections.singletonList(new IntegrityMessage(
-                    Localization.lang("empty BibTeX key") + ": " + authortitleyear, entry, BibEntry.KEY_FIELD));
+                    Localization.lang("empty BibTeX key") + ": " + authorTitleYear, entry, BibEntry.KEY_FIELD));
         }
 
         return Collections.emptyList();

--- a/src/main/java/org/jabref/logic/integrity/IntegrityCheck.java
+++ b/src/main/java/org/jabref/logic/integrity/IntegrityCheck.java
@@ -60,7 +60,7 @@ public class IntegrityCheck {
             result.addAll(new JournalInAbbreviationListChecker(FieldName.JOURNALTITLE, journalAbbreviationRepository).check(entry));
         }
 
-        result.addAll(new BibtexkeyChecker().check(entry));
+        result.addAll(new BibtexKeyChecker().check(entry));
         result.addAll(new TypeChecker().check(entry));
         result.addAll(new BibStringChecker().check(entry));
         result.addAll(new HTMLCharacterChecker().check(entry));

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -648,12 +648,12 @@ public class BibtexParserTest {
     }
 
     @Test
-    public void parseWarnsAboutEntryWithoutBibtexKey() throws IOException {
+    public void parseNotWarnsAboutEntryWithoutBibtexKey() throws IOException {
 
         ParserResult result = parser
                 .parse(new StringReader("@article{,author={Ed von Test}}"));
 
-        assertTrue(result.hasWarnings());
+        assertFalse(result.hasWarnings());
 
         Collection<BibEntry> c = result.getDatabase().getEntries();
 


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

As we have an integrity check for this and BibTeX keys are no longer required for the groups.
Issue was raised in https://github.com/JabRef/jabref/issues/2599#issuecomment-290681963. 

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
