### PR TITLE
Fix #628: implement hierarchical keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We added a few properties to a group:
     - Icon (with customizable color) that is shown in the groups panel (implements a [feature request in the forum](http://discourse.jabref.org/t/assign-colors-to-groups/321)).
     - Description text that is shown on mouse hover (implements old feature requests [489](https://sourceforge.net/p/jabref/feature-requests/489/) and [818](https://sourceforge.net/p/jabref/feature-requests/818/)
-- We introduced "automatic groups" that automatically create subgroups based on a certain criteria (e.g. a subgroup for every author or keyword). Implements [91](https://sourceforge.net/p/jabref/feature-requests/91/), [398](https://sourceforge.net/p/jabref/feature-requests/398/) and [#1173](https://github.com/JabRef/jabref/issues/1173).
+- We introduced "automatic groups" that automatically create subgroups based on a certain criteria (e.g. a subgroup for every author or keyword) and supports hierarchies. Implements [91](https://sourceforge.net/p/jabref/feature-requests/91/), [398](https://sourceforge.net/p/jabref/feature-requests/398/) and [#1173](https://github.com/JabRef/jabref/issues/1173) and [#628](https://github.com/JabRef/jabref/issues/628).
 - Expansion status of groups are saved across sessions. [#1428](https://github.com/JabRef/jabref/issues/1428)
 - We removed the ordinals-to-superscript formatter from the recommendations for biblatex save actions [#2596](https://github.com/JabRef/jabref/issues/2596)
 - The `Move linked files to default file directory`-Cleanup operation respects the `File directory pattern` setting 

--- a/src/main/java/org/jabref/gui/groups/GroupDialog.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialog.java
@@ -39,6 +39,7 @@ import org.jabref.gui.keyboard.KeyBinding;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.search.SearchQuery;
 import org.jabref.model.entry.FieldName;
+import org.jabref.model.entry.Keyword;
 import org.jabref.model.groups.AbstractGroup;
 import org.jabref.model.groups.AutomaticKeywordGroup;
 import org.jabref.model.groups.AutomaticPersonsGroup;
@@ -100,6 +101,7 @@ class GroupDialog extends JDialog implements Dialog<AbstractGroup> {
             Localization.lang("Generate groups from keywords in a BibTeX field"));
     private final JTextField autoGroupKeywordsField = new JTextField(60);
     private final JTextField autoGroupKeywordsDeliminator = new JTextField(60);
+    private final JTextField autoGroupKeywordsHierarchicalDeliminator = new JTextField(60);
     private final JRadioButton autoGroupPersonsOption = new JRadioButton(
             Localization.lang("Generate groups for author last names"));
     private final JTextField autoGroupPersonsField = new JTextField(60);
@@ -183,7 +185,7 @@ class GroupDialog extends JDialog implements Dialog<AbstractGroup> {
         bg.add(autoGroupPersonsOption);
 
         FormLayout layoutAutoGroup = new FormLayout("left:20dlu, 4dlu, left:pref, 4dlu, fill:60dlu",
-                "p, 2dlu, p, 2dlu, p, 2dlu, p, 2dlu, p");
+                "p, 2dlu, p, 2dlu, p, p, 2dlu, p, 2dlu, p");
         FormBuilder builderAutoGroup = FormBuilder.create();
         builderAutoGroup.layout(layoutAutoGroup);
         builderAutoGroup.add(autoGroupKeywordsOption).xyw(1, 1, 5);
@@ -191,14 +193,16 @@ class GroupDialog extends JDialog implements Dialog<AbstractGroup> {
         builderAutoGroup.add(autoGroupKeywordsField).xy(5, 3);
         builderAutoGroup.add(Localization.lang("Use the following delimiter character(s):")).xy(3, 5);
         builderAutoGroup.add(autoGroupKeywordsDeliminator).xy(5, 5);
-        builderAutoGroup.add(autoGroupPersonsOption).xyw(1, 7, 5);
-        builderAutoGroup.add(Localization.lang("Field to group by") + ":").xy(3, 9);
-        builderAutoGroup.add(autoGroupPersonsField).xy(5, 9);
+        builderAutoGroup.add(autoGroupKeywordsHierarchicalDeliminator).xy(5, 6);
+        builderAutoGroup.add(autoGroupPersonsOption).xyw(1, 8, 5);
+        builderAutoGroup.add(Localization.lang("Field to group by") + ":").xy(3, 10);
+        builderAutoGroup.add(autoGroupPersonsField).xy(5, 10);
         optionsPanel.add(builderAutoGroup.build(), String.valueOf(GroupDialog.INDEX_AUTO_GROUP));
 
         autoGroupKeywordsOption.setSelected(true);
         autoGroupKeywordsField.setText(Globals.prefs.get(JabRefPreferences.GROUPS_DEFAULT_FIELD));
         autoGroupKeywordsDeliminator.setText(Globals.prefs.get(JabRefPreferences.KEYWORD_SEPARATOR));
+        autoGroupKeywordsHierarchicalDeliminator.setText(Keyword.DEFAULT_HIERARCHICAL_DELIMITER.toString());
         autoGroupPersonsField.setText(FieldName.AUTHOR);
 
         // ... for buttons panel
@@ -349,9 +353,11 @@ class GroupDialog extends JDialog implements Dialog<AbstractGroup> {
                     }
                 } else if (autoRadioButton.isSelected()) {
                     if (autoGroupKeywordsOption.isSelected()) {
-                        resultingGroup = new AutomaticKeywordGroup(nameField.getText().trim(), getContext(),
+                        resultingGroup = new AutomaticKeywordGroup(
+                                nameField.getText().trim(), getContext(),
                                 autoGroupKeywordsField.getText().trim(),
-                                autoGroupKeywordsDeliminator.getText().charAt(0));
+                                autoGroupKeywordsDeliminator.getText().charAt(0),
+                                autoGroupKeywordsHierarchicalDeliminator.getText().charAt(0));
                     } else {
                         resultingGroup = new AutomaticPersonsGroup(nameField.getText().trim(), getContext(),
                                 autoGroupPersonsField.getText().trim());
@@ -429,7 +435,8 @@ class GroupDialog extends JDialog implements Dialog<AbstractGroup> {
 
                 if (editedGroup.getClass() == AutomaticKeywordGroup.class) {
                     AutomaticKeywordGroup group = (AutomaticKeywordGroup) editedGroup;
-                    autoGroupKeywordsDeliminator.setText(group.getKeywordSeperator().toString());
+                    autoGroupKeywordsDeliminator.setText(group.getKeywordDelimiter().toString());
+                    autoGroupKeywordsHierarchicalDeliminator.setText(group.getKeywordHierarchicalDelimiter().toString());
                     autoGroupKeywordsField.setText(group.getField());
                 } else if (editedGroup.getClass() == AutomaticPersonsGroup.class) {
                     AutomaticPersonsGroup group = (AutomaticPersonsGroup) editedGroup;

--- a/src/main/java/org/jabref/logic/exporter/GroupSerializer.java
+++ b/src/main/java/org/jabref/logic/exporter/GroupSerializer.java
@@ -152,7 +152,9 @@ public class GroupSerializer {
         appendAutomaticGroupDetails(sb, group);
         sb.append(StringUtil.quote(group.getField(), MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR, MetadataSerializationConfiguration.GROUP_QUOTE_CHAR));
         sb.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
-        sb.append(group.getKeywordSeperator());
+        sb.append(group.getKeywordDelimiter());
+        sb.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
+        sb.append(group.getKeywordHierarchicalDelimiter());
         sb.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
         appendGroupDetails(sb, group);
         return sb.toString();

--- a/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
@@ -127,8 +127,9 @@ public class GroupsParser {
         String name = StringUtil.unquote(tok.nextToken(), MetadataSerializationConfiguration.GROUP_QUOTE_CHAR);
         GroupHierarchyType context = GroupHierarchyType.getByNumberOrDefault(Integer.parseInt(tok.nextToken()));
         String field = StringUtil.unquote(tok.nextToken(), MetadataSerializationConfiguration.GROUP_QUOTE_CHAR);
-        Character separator = tok.nextToken().charAt(0);
-        AutomaticKeywordGroup newGroup = new AutomaticKeywordGroup(name, context, field, separator);
+        Character delimiter = tok.nextToken().charAt(0);
+        Character hierarchicalDelimiter = tok.nextToken().charAt(0);
+        AutomaticKeywordGroup newGroup = new AutomaticKeywordGroup(name, context, field, delimiter, hierarchicalDelimiter);
         addGroupDetails(tok, newGroup);
         return newGroup;
     }

--- a/src/main/java/org/jabref/logic/util/TreeCollector.java
+++ b/src/main/java/org/jabref/logic/util/TreeCollector.java
@@ -1,0 +1,101 @@
+package org.jabref.logic.util;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+import org.jabref.model.TreeNode;
+
+import org.apache.commons.lang3.NotImplementedException;
+
+/**
+ * Merges a list of nodes into a tree.
+ * Nodes with a common parent are added as direct children.
+ * For example, the list { A > A1, A > A2, B } is transformed into the forest { A > A1, A2, B}.
+ */
+public class TreeCollector<T> implements Collector<T, ObservableList<T>, ObservableList<T>> {
+
+    private Function<T, List<T>> getChildren;
+    private BiConsumer<T, T> addChild;
+    private BiPredicate<T, T> equivalence;
+
+    /**
+     * @param getChildren a function that returns a list of children of the specified node
+     * @param addChild    a function that adds the second argument as a child to the first-specified node
+     * @param equivalence a function that tells us whether two nodes are equivalent
+     */
+    private TreeCollector(Function<T, List<T>> getChildren, BiConsumer<T, T> addChild, BiPredicate<T, T> equivalence) {
+        this.getChildren = getChildren;
+        this.addChild = addChild;
+        this.equivalence = equivalence;
+    }
+
+    public static <T extends TreeNode<T>> TreeCollector<T> mergeIntoTree(BiPredicate<T, T> equivalence) {
+        return new TreeCollector<T>(
+                TreeNode::getChildren,
+                (parent, child) -> child.moveTo(parent),
+                equivalence);
+    }
+
+    @Override
+    public Supplier<ObservableList<T>> supplier() {
+        return FXCollections::observableArrayList;
+    }
+
+    @Override
+    public BiConsumer<ObservableList<T>, T> accumulator() {
+        return (alreadyProcessed, newItem) -> {
+            // Check if the node is already in the tree
+            Optional<T> sameItemInTree = alreadyProcessed.stream()
+                    .filter(item -> equivalence.test(item, newItem))
+                    .findFirst();
+            if (sameItemInTree.isPresent()) {
+                for (T child : new ArrayList<>(getChildren.apply(newItem))) {
+                    merge(sameItemInTree.get(), child);
+                }
+            } else {
+                alreadyProcessed.add(newItem);
+            }
+        };
+    }
+
+    private void merge(T target, T node) {
+        Optional<T> sameItemInTree = getChildren.apply(target).stream()
+                .filter(item -> equivalence.test(item, node))
+                .findFirst();
+        if (sameItemInTree.isPresent()) {
+            // We need to copy the list because the #addChild method might remove the child from its own parent
+            for (T child : new ArrayList<>(getChildren.apply(node))) {
+                merge(sameItemInTree.get(), child);
+            }
+        } else {
+            addChild.accept(target, node);
+        }
+    }
+
+    @Override
+    public BinaryOperator<ObservableList<T>> combiner() {
+        throw new NotImplementedException("The TreeCollector does not support parallel streams.");
+    }
+
+    @Override
+    public Function<ObservableList<T>, ObservableList<T>> finisher() {
+        return i -> i;
+    }
+
+    @Override
+    public Set<Characteristics> characteristics() {
+        return EnumSet.of(Characteristics.UNORDERED, Characteristics.IDENTITY_FINISH);
+    }
+}

--- a/src/main/java/org/jabref/logic/util/TreeCollector.java
+++ b/src/main/java/org/jabref/logic/util/TreeCollector.java
@@ -17,8 +17,6 @@ import javafx.collections.ObservableList;
 
 import org.jabref.model.TreeNode;
 
-import org.apache.commons.lang3.NotImplementedException;
-
 /**
  * Merges a list of nodes into a tree.
  * Nodes with a common parent are added as direct children.
@@ -86,7 +84,12 @@ public class TreeCollector<T> implements Collector<T, ObservableList<T>, Observa
 
     @Override
     public BinaryOperator<ObservableList<T>> combiner() {
-        throw new NotImplementedException("The TreeCollector does not support parallel streams.");
+        return (list1, list2) -> {
+            for (T item : list2) {
+                accumulator().accept(list1, item);
+            }
+            return list1;
+        };
     }
 
     @Override

--- a/src/main/java/org/jabref/model/ChainNode.java
+++ b/src/main/java/org/jabref/model/ChainNode.java
@@ -154,6 +154,7 @@ public abstract class ChainNode<T extends ChainNode<T>> {
 
     /**
      * Adds the given node at the end of the chain.
+     * E.g., "A > B > C" + "D" -> "A > B > C > D".
      */
     public void addAtEnd(T node) {
         if (child == null) {

--- a/src/main/java/org/jabref/model/ChainNode.java
+++ b/src/main/java/org/jabref/model/ChainNode.java
@@ -58,35 +58,24 @@ public abstract class ChainNode<T extends ChainNode<T>> {
     }
 
     /**
+     * Sets the parent node of this node.
+     * <p>
+     * This method does not set this node as the child of the new parent nor does it remove this node
+     * from the old parent. You should probably call {@link #moveTo(ChainNode)} to change the chain.
+     *
+     * @param parent the new parent
+     */
+    protected void setParent(T parent) {
+        this.parent = Objects.requireNonNull(parent);
+    }
+
+    /**
      * Returns this node's child or an empty Optional if this node has no child.
      *
      * @return this node's child T, or an empty Optional if this node has no child
      */
     public Optional<T> getChild() {
         return Optional.ofNullable(child);
-    }
-
-    /**
-     * Removes this node from its parent and makes it a child of the specified node.
-     * In this way the whole subchain based at this node is moved to the given node.
-     *
-     * @param target      the new parent
-     * @throws NullPointerException           if target is null
-     * @throws UnsupportedOperationException  if target is an descendant of this node
-     */
-    public void moveTo(T target) {
-        Objects.requireNonNull(target);
-
-        // Check that the target node is not an ancestor of this node, because this would create loops in the tree
-        if (this.isAncestorOf(target)) {
-            throw new UnsupportedOperationException("the target cannot be a descendant of this node");
-        }
-
-        // Remove from previous parent
-        getParent().ifPresent(oldParent -> oldParent.removeChild());
-
-        // Add as child
-        target.setChild((T) this);
     }
 
     /**
@@ -110,15 +99,26 @@ public abstract class ChainNode<T extends ChainNode<T>> {
     }
 
     /**
-     * Sets the parent node of this node.
-     * <p>
-     * This method does not set this node as the child of the new parent nor does it remove this node
-     * from the old parent. You should probably call {@link #moveTo(ChainNode)} to change the chain.
+     * Removes this node from its parent and makes it a child of the specified node.
+     * In this way the whole subchain based at this node is moved to the given node.
      *
-     * @param parent the new parent
+     * @param target      the new parent
+     * @throws NullPointerException           if target is null
+     * @throws UnsupportedOperationException  if target is an descendant of this node
      */
-    protected void setParent(T parent) {
-        this.parent = Objects.requireNonNull(parent);
+    public void moveTo(T target) {
+        Objects.requireNonNull(target);
+
+        // Check that the target node is not an ancestor of this node, because this would create loops in the tree
+        if (this.isAncestorOf(target)) {
+            throw new UnsupportedOperationException("the target cannot be a descendant of this node");
+        }
+
+        // Remove from previous parent
+        getParent().ifPresent(oldParent -> oldParent.removeChild());
+
+        // Add as child
+        target.setChild((T) this);
     }
 
     /**
@@ -149,6 +149,17 @@ public abstract class ChainNode<T extends ChainNode<T>> {
             return true;
         } else {
             return child.isAncestorOf(anotherNode);
+        }
+    }
+
+    /**
+     * Adds the given node at the end of the chain.
+     */
+    public void addAtEnd(T node) {
+        if (child == null) {
+            setChild(node);
+        } else {
+            child.addAtEnd(node);
         }
     }
 }

--- a/src/main/java/org/jabref/model/database/BibDatabase.java
+++ b/src/main/java/org/jabref/model/database/BibDatabase.java
@@ -3,6 +3,7 @@ package org.jabref.model.database;
 import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -196,6 +197,10 @@ public class BibDatabase {
     public synchronized boolean insertEntry(BibEntry entry, EntryEventSource eventSource) throws KeyCollisionException {
         insertEntries(Collections.singletonList(entry), eventSource);
         return duplicationChecker.isDuplicateCiteKeyExisting(entry);
+    }
+
+    public synchronized void insertEntries(BibEntry... entries) throws KeyCollisionException {
+        insertEntries(Arrays.asList(entries), EntryEventSource.LOCAL);
     }
 
     public synchronized void insertEntries(List<BibEntry> entries) throws KeyCollisionException {

--- a/src/main/java/org/jabref/model/entry/Keyword.java
+++ b/src/main/java/org/jabref/model/entry/Keyword.java
@@ -1,8 +1,12 @@
 package org.jabref.model.entry;
 
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.jabref.model.ChainNode;
+import org.jabref.model.util.OptionalUtil;
 
 /**
  * Represents a keyword in a chain of keywords.
@@ -20,7 +24,7 @@ public class Keyword extends ChainNode<Keyword> implements Comparable<Keyword> {
 
     /**
      * Connects all the given keywords into one chain and returns its root,
-     * e.g. "A", "B", "C" is transformed to "A > B > C".
+     * e.g. "A", "B", "C" is transformed into "A > B > C".
      */
     public static Keyword of(String... keywords) {
         if (keywords.length == 0) {
@@ -55,7 +59,7 @@ public class Keyword extends ChainNode<Keyword> implements Comparable<Keyword> {
 
     @Override
     public String toString() {
-        return getAsString(DEFAULT_HIERARCHICAL_DELIMITER);
+        return getSubchainAsString(DEFAULT_HIERARCHICAL_DELIMITER);
     }
 
     @Override
@@ -63,12 +67,60 @@ public class Keyword extends ChainNode<Keyword> implements Comparable<Keyword> {
         return keyword.compareTo(o.keyword);
     }
 
+    /**
+     * Adds the given keyword at the end of the chain.
+     * E.g., "A > B > C" + "D" -> "A > B > C > D".
+     */
     private void addAtEnd(String keyword) {
         addAtEnd(new Keyword(keyword));
     }
 
-    public String getAsString(Character hierarchicalDelimiter) {
+    /**
+     * Returns a text representation of the subchain starting at this item.
+     * E.g., calling {@link #getSubchainAsString(Character)} on the node "B" in "A > B > C" returns "B > C".
+     */
+    private String getSubchainAsString(Character hierarchicalDelimiter) {
         return keyword +
-                getChild().map(child -> " " + hierarchicalDelimiter + " " + child.getAsString(hierarchicalDelimiter)).orElse("");
+                getChild().map(child -> " " + hierarchicalDelimiter + " " + child.getSubchainAsString(hierarchicalDelimiter))
+                        .orElse("");
+    }
+
+    /**
+     * Gets the keyword of this node in the chain.
+     */
+    public String get() {
+        return keyword;
+    }
+
+    /**
+     * Returns a text representation of the path from the root to this item.
+     * E.g., calling {@link #getPathFromRootAsString(Character)} on the node "B" in "A > B > C" returns "A > B".
+     */
+    public String getPathFromRootAsString(Character hierarchicalDelimiter) {
+        return getParent()
+                .map(parent -> parent.getPathFromRootAsString(hierarchicalDelimiter) + " " + hierarchicalDelimiter + " ")
+                .orElse("")
+                + keyword;
+    }
+
+    /**
+     * Returns all nodes in this chain as separate keywords.
+     * E.g, for "A > B > C" we get {"A", "B", "C"}.
+     */
+    public Set<Keyword> flatten() {
+        return Stream.concat(
+                Stream.of(this),
+                OptionalUtil.toStream(getChild()).flatMap(child -> child.flatten().stream()))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Returns all subchains starting at this node.
+     * E.g., for the chain "A > B > C" the subchains {"A", "A > B", "A > B > C"} are returned.
+     */
+    public Set<String> getAllSubchainsAsString(Character hierarchicalDelimiter) {
+        return flatten().stream()
+                .map(subchain -> subchain.getPathFromRootAsString(hierarchicalDelimiter))
+                .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/org/jabref/model/entry/Keyword.java
+++ b/src/main/java/org/jabref/model/entry/Keyword.java
@@ -10,11 +10,28 @@ import org.jabref.model.ChainNode;
  */
 public class Keyword extends ChainNode<Keyword> implements Comparable<Keyword> {
 
+    public static Character DEFAULT_HIERARCHICAL_DELIMITER = '>';
     private final String keyword;
 
     public Keyword(String keyword) {
         super(Keyword.class);
-        this.keyword = Objects.requireNonNull(keyword);
+        this.keyword = Objects.requireNonNull(keyword).trim();
+    }
+
+    /**
+     * Connects all the given keywords into one chain and returns its root,
+     * e.g. "A", "B", "C" is transformed to "A > B > C".
+     */
+    public static Keyword of(String... keywords) {
+        if (keywords.length == 0) {
+            return new Keyword("");
+        }
+
+        Keyword root = new Keyword(keywords[0]);
+        for (int i = 1; i < keywords.length; i++) {
+            root.addAtEnd(keywords[i]);
+        }
+        return root;
     }
 
     @Override
@@ -25,7 +42,10 @@ public class Keyword extends ChainNode<Keyword> implements Comparable<Keyword> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        return Objects.equals(keyword, ((Keyword) o).keyword);
+        Keyword other = (Keyword) o;
+        return Objects.equals(this.keyword, other.keyword)
+                // && Objects.equals(this.getParent(), other.getParent()) : we can't check the parents because then we would run in circles
+                && Objects.equals(this.getChild(), other.getChild());
     }
 
     @Override
@@ -35,11 +55,20 @@ public class Keyword extends ChainNode<Keyword> implements Comparable<Keyword> {
 
     @Override
     public String toString() {
-        return keyword;
+        return getAsString(DEFAULT_HIERARCHICAL_DELIMITER);
     }
 
     @Override
     public int compareTo(Keyword o) {
         return keyword.compareTo(o.keyword);
+    }
+
+    private void addAtEnd(String keyword) {
+        addAtEnd(new Keyword(keyword));
+    }
+
+    public String getAsString(Character hierarchicalDelimiter) {
+        return keyword +
+                getChild().map(child -> " " + hierarchicalDelimiter + " " + child.getAsString(hierarchicalDelimiter)).orElse("");
     }
 }

--- a/src/main/java/org/jabref/model/entry/KeywordList.java
+++ b/src/main/java/org/jabref/model/entry/KeywordList.java
@@ -38,23 +38,32 @@ public class KeywordList implements Iterable<Keyword> {
         this(Arrays.stream(keywordChains).map(Keyword::new).collect(Collectors.toList()));
     }
 
+    public KeywordList(Keyword... keywordChains) {
+        this(Arrays.asList(keywordChains));
+    }
+
+    public static KeywordList parse(String keywordString, Character delimiter, Character hierarchicalDelimiter) {
+        if (StringUtil.isBlank(keywordString)) {
+            return new KeywordList();
+        }
+
+        KeywordList keywordList = new KeywordList();
+
+        StringTokenizer tok = new StringTokenizer(keywordString, delimiter.toString());
+        while (tok.hasMoreTokens()) {
+            String chain = tok.nextToken();
+            Keyword chainRoot = Keyword.of(chain.split(hierarchicalDelimiter.toString()));
+            keywordList.add(chainRoot);
+        }
+        return keywordList;
+    }
+
     /**
      * @param keywordString a String of keywordChains
      * @return an parsed list containing the keywordChains
      */
     public static KeywordList parse(String keywordString, Character delimiter) {
-        if (StringUtil.isBlank(keywordString)) {
-            return new KeywordList();
-        }
-
-        List<String> keywords = new ArrayList<>();
-
-        StringTokenizer tok = new StringTokenizer(keywordString, delimiter.toString());
-        while (tok.hasMoreTokens()) {
-            String word = tok.nextToken().trim();
-            keywords.add(word);
-        }
-        return new KeywordList(keywords);
+        return parse(keywordString, delimiter, Keyword.DEFAULT_HIERARCHICAL_DELIMITER);
     }
 
     public KeywordList createClone() {

--- a/src/main/java/org/jabref/model/entry/KeywordList.java
+++ b/src/main/java/org/jabref/model/entry/KeywordList.java
@@ -19,28 +19,28 @@ import org.jabref.model.strings.StringUtil;
  */
 public class KeywordList implements Iterable<Keyword> {
 
-    private final List<Keyword> keywords;
+    private final List<Keyword> keywordChains;
 
     public KeywordList() {
-        keywords = new ArrayList<>();
+        keywordChains = new ArrayList<>();
     }
 
-    public KeywordList(Collection<Keyword> keywords) {
-        this.keywords = new ArrayList<>();
-        keywords.forEach(this::add);
+    public KeywordList(Collection<Keyword> keywordChains) {
+        this.keywordChains = new ArrayList<>();
+        keywordChains.forEach(this::add);
     }
 
-    public KeywordList(List<String> keywords) {
-        this(keywords.stream().map(Keyword::new).collect(Collectors.toList()));
+    public KeywordList(List<String> keywordChains) {
+        this(keywordChains.stream().map(Keyword::new).collect(Collectors.toList()));
     }
 
-    public KeywordList(String... keywords) {
-        this(Arrays.stream(keywords).map(Keyword::new).collect(Collectors.toList()));
+    public KeywordList(String... keywordChains) {
+        this(Arrays.stream(keywordChains).map(Keyword::new).collect(Collectors.toList()));
     }
 
     /**
-     * @param keywordString a String of keywords
-     * @return an parsed list containing the keywords
+     * @param keywordString a String of keywordChains
+     * @return an parsed list containing the keywordChains
      */
     public static KeywordList parse(String keywordString, Character delimiter) {
         if (StringUtil.isBlank(keywordString)) {
@@ -58,19 +58,19 @@ public class KeywordList implements Iterable<Keyword> {
     }
 
     public KeywordList createClone() {
-        return new KeywordList(this.keywords);
+        return new KeywordList(this.keywordChains);
     }
 
     public void replaceAll(KeywordList keywordsToReplace, Keyword newValue) {
         Objects.requireNonNull(newValue);
 
-        // Remove keywords which should be replaced
+        // Remove keywordChains which should be replaced
         int foundPosition = -1; // remember position of the last found keyword
         for (Keyword specialFieldKeyword : keywordsToReplace) {
-            int pos = keywords.indexOf(specialFieldKeyword);
+            int pos = keywordChains.indexOf(specialFieldKeyword);
             if (pos >= 0) {
                 foundPosition = pos;
-                keywords.remove(pos);
+                keywordChains.remove(pos);
             }
         }
 
@@ -78,26 +78,26 @@ public class KeywordList implements Iterable<Keyword> {
         if (foundPosition == -1) {
             add(newValue);
         } else {
-            keywords.add(foundPosition, newValue);
+            keywordChains.add(foundPosition, newValue);
         }
     }
 
     public void removeAll(KeywordList keywordsToRemove) {
-        keywords.removeAll(keywordsToRemove.keywords);
+        keywordChains.removeAll(keywordsToRemove.keywordChains);
     }
 
     public boolean add(Keyword keyword) {
         if (contains(keyword)) {
-            return false; // Don't add duplicate keywords
+            return false; // Don't add duplicate keywordChains
         }
-        return keywords.add(keyword);
+        return keywordChains.add(keyword);
     }
 
     /**
      * Keywords are separated by the given delimiter and an additional space, i.e. "one, two".
      */
     public String getAsString(Character delimiter) {
-        return keywords.stream().map(Keyword::toString).collect(Collectors.joining(delimiter + " "));
+        return keywordChains.stream().map(Keyword::toString).collect(Collectors.joining(delimiter + " "));
     }
 
     public void add(String keywordsString) {
@@ -106,47 +106,47 @@ public class KeywordList implements Iterable<Keyword> {
 
     @Override
     public Iterator<Keyword> iterator() {
-        return keywords.iterator();
+        return keywordChains.iterator();
     }
 
     public int size() {
-        return keywords.size();
+        return keywordChains.size();
     }
 
     public boolean isEmpty() {
-        return keywords.isEmpty();
+        return keywordChains.isEmpty();
     }
 
     public boolean contains(Keyword o) {
-        return keywords.contains(o);
+        return keywordChains.contains(o);
     }
 
     public boolean remove(Keyword o) {
-        return keywords.remove(o);
+        return keywordChains.remove(o);
     }
 
     public boolean remove(String keywordsString) {
-        return keywords.remove(new Keyword(keywordsString));
+        return keywordChains.remove(new Keyword(keywordsString));
     }
 
     public void addAll(KeywordList keywordsToAdd) {
-        keywords.addAll(keywordsToAdd.keywords);
+        keywordChains.addAll(keywordsToAdd.keywordChains);
     }
 
     public void retainAll(KeywordList keywordToRetain) {
-        keywords.retainAll(keywordToRetain.keywords);
+        keywordChains.retainAll(keywordToRetain.keywordChains);
     }
 
     public void clear() {
-        keywords.clear();
+        keywordChains.clear();
     }
 
     public Keyword get(int index) {
-        return keywords.get(index);
+        return keywordChains.get(index);
     }
 
     public Stream<Keyword> stream() {
-        return keywords.stream();
+        return keywordChains.stream();
     }
 
     @Override
@@ -155,7 +155,7 @@ public class KeywordList implements Iterable<Keyword> {
     }
 
     public Set<String> toStringList() {
-        return keywords.stream().map(Keyword::toString).collect(Collectors.toSet());
+        return keywordChains.stream().map(Keyword::toString).collect(Collectors.toSet());
     }
 
     @Override
@@ -167,11 +167,11 @@ public class KeywordList implements Iterable<Keyword> {
             return false;
         }
         KeywordList keywords1 = (KeywordList) o;
-        return Objects.equals(keywords, keywords1.keywords);
+        return Objects.equals(keywordChains, keywords1.keywordChains);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(keywords);
+        return Objects.hash(keywordChains);
     }
 }

--- a/src/main/java/org/jabref/model/groups/AutomaticGroup.java
+++ b/src/main/java/org/jabref/model/groups/AutomaticGroup.java
@@ -4,8 +4,8 @@ import java.util.Set;
 
 import javafx.collections.ObservableList;
 
-import org.jabref.logic.util.TreeCollector;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.util.TreeCollector;
 
 public abstract class AutomaticGroup extends AbstractGroup {
     public AutomaticGroup(String name, GroupHierarchyType context) {

--- a/src/main/java/org/jabref/model/groups/AutomaticGroup.java
+++ b/src/main/java/org/jabref/model/groups/AutomaticGroup.java
@@ -2,6 +2,9 @@ package org.jabref.model.groups;
 
 import java.util.Set;
 
+import javafx.collections.ObservableList;
+
+import org.jabref.logic.util.TreeCollector;
 import org.jabref.model.entry.BibEntry;
 
 public abstract class AutomaticGroup extends AbstractGroup {
@@ -20,4 +23,11 @@ public abstract class AutomaticGroup extends AbstractGroup {
     }
 
     public abstract Set<GroupTreeNode> createSubgroups(BibEntry entry);
+
+    public ObservableList<GroupTreeNode> createSubgroups(ObservableList<BibEntry> entries) {
+        // TODO: Propagate changes to entry list (however: there is no flatMap and collect as TransformationList)
+        return entries.stream()
+                .flatMap(entry -> createSubgroups(entry).stream())
+                .collect(TreeCollector.mergeIntoTree(GroupTreeNode::isSameGroupAs));
+    }
 }

--- a/src/main/java/org/jabref/model/groups/AutomaticKeywordGroup.java
+++ b/src/main/java/org/jabref/model/groups/AutomaticKeywordGroup.java
@@ -12,18 +12,23 @@ import org.jabref.model.util.OptionalUtil;
 
 public class AutomaticKeywordGroup extends AutomaticGroup {
 
-    private Character keywordSeperator;
-    private Character keywordHierarchicalDelimiter = '>';
+    private Character keywordDelimiter;
+    private Character keywordHierarchicalDelimiter;
     private String field;
 
-    public AutomaticKeywordGroup(String name, GroupHierarchyType context, String field, Character keywordSeperator) {
+    public AutomaticKeywordGroup(String name, GroupHierarchyType context, String field, Character keywordDelimiter, Character keywordHierarchicalDelimiter) {
         super(name, context);
         this.field = field;
-        this.keywordSeperator = keywordSeperator;
+        this.keywordDelimiter = keywordDelimiter;
+        this.keywordHierarchicalDelimiter = keywordHierarchicalDelimiter;
     }
 
-    public Character getKeywordSeperator() {
-        return keywordSeperator;
+    public Character getKeywordHierarchicalDelimiter() {
+        return keywordHierarchicalDelimiter;
+    }
+
+    public Character getKeywordDelimiter() {
+        return keywordDelimiter;
     }
 
     public String getField() {
@@ -32,7 +37,7 @@ public class AutomaticKeywordGroup extends AutomaticGroup {
 
     @Override
     public AbstractGroup deepCopy() {
-        return new AutomaticKeywordGroup(this.name, this.context, field, this.keywordSeperator);
+        return new AutomaticKeywordGroup(this.name, this.context, field, this.keywordDelimiter, keywordHierarchicalDelimiter);
     }
 
     @Override
@@ -40,19 +45,19 @@ public class AutomaticKeywordGroup extends AutomaticGroup {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         AutomaticKeywordGroup that = (AutomaticKeywordGroup) o;
-        return Objects.equals(keywordSeperator, that.keywordSeperator) &&
+        return Objects.equals(keywordDelimiter, that.keywordDelimiter) &&
                 Objects.equals(field, that.field);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(keywordSeperator, field);
+        return Objects.hash(keywordDelimiter, field);
     }
 
     @Override
     public Set<GroupTreeNode> createSubgroups(BibEntry entry) {
         Optional<KeywordList> keywordList = entry.getLatexFreeField(field)
-                .map(fieldValue -> KeywordList.parse(fieldValue, keywordSeperator));
+                .map(fieldValue -> KeywordList.parse(fieldValue, keywordDelimiter));
         return OptionalUtil.toStream(keywordList)
                 .flatMap(KeywordList::stream)
                 .map(this::createGroup)
@@ -66,7 +71,7 @@ public class AutomaticKeywordGroup extends AutomaticGroup {
                 field,
                 keywordChain.getPathFromRootAsString(keywordHierarchicalDelimiter),
                 true,
-                keywordSeperator,
+                keywordDelimiter,
                 true);
         GroupTreeNode root = new GroupTreeNode(rootGroup);
         keywordChain.getChild()

--- a/src/main/java/org/jabref/model/groups/GroupTreeNode.java
+++ b/src/main/java/org/jabref/model/groups/GroupTreeNode.java
@@ -130,7 +130,8 @@ public class GroupTreeNode extends TreeNode<GroupTreeNode> {
             return false;
         }
         GroupTreeNode that = (GroupTreeNode) o;
-        return Objects.equals(group, that.group);
+        return Objects.equals(group, that.group) &&
+                Objects.equals(getChildren(), that.getChildren());
     }
 
     @Override
@@ -293,5 +294,12 @@ public class GroupTreeNode extends TreeNode<GroupTreeNode> {
         } else {
             return Collections.emptyList();
         }
+    }
+
+    /**
+     * Returns true if the underlying groups of both {@link GroupTreeNode}s is the same.
+     */
+    public boolean isSameGroupAs(GroupTreeNode other) {
+        return Objects.equals(group, other.group);
     }
 }

--- a/src/main/java/org/jabref/model/util/TreeCollector.java
+++ b/src/main/java/org/jabref/model/util/TreeCollector.java
@@ -1,4 +1,4 @@
-package org.jabref.logic.util;
+package org.jabref.model.util;
 
 import java.util.ArrayList;
 import java.util.EnumSet;

--- a/src/test/java/org/jabref/gui/groups/GroupNodeViewModelTest.java
+++ b/src/test/java/org/jabref/gui/groups/GroupNodeViewModelTest.java
@@ -65,7 +65,7 @@ public class GroupNodeViewModelTest {
         BibEntry entryThree = new BibEntry().withField("keywords", "A > B > B2");
         databaseContext.getDatabase().insertEntries(entryOne, entryTwo, entryThree);
 
-        AutomaticKeywordGroup group = new AutomaticKeywordGroup("Keywords", GroupHierarchyType.INDEPENDENT, "keywords", ',');
+        AutomaticKeywordGroup group = new AutomaticKeywordGroup("Keywords", GroupHierarchyType.INDEPENDENT, "keywords", ',', '>');
         GroupNodeViewModel groupViewModel = getViewModelForGroup(group);
 
         WordKeywordGroup expectedGroupA = new WordKeywordGroup("A", GroupHierarchyType.INCLUDING, "keywords", "A", true, ',', true);

--- a/src/test/java/org/jabref/gui/groups/GroupNodeViewModelTest.java
+++ b/src/test/java/org/jabref/gui/groups/GroupNodeViewModelTest.java
@@ -1,13 +1,17 @@
 package org.jabref.gui.groups;
 
 import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 
 import org.jabref.gui.StateManager;
 import org.jabref.gui.util.CurrentThreadTaskExecutor;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
 import org.jabref.model.groups.AbstractGroup;
+import org.jabref.model.groups.AutomaticKeywordGroup;
 import org.jabref.model.groups.GroupHierarchyType;
+import org.jabref.model.groups.GroupTreeNode;
 import org.jabref.model.groups.WordKeywordGroup;
 
 import org.junit.Before;
@@ -52,6 +56,35 @@ public class GroupNodeViewModelTest {
     @Test
     public void isMatchedIfContainsPartOfSearchString() throws Exception {
         assertTrue(viewModel.isMatchedBy("est"));
+    }
+
+    @Test
+    public void treeOfAutomaticKeywordGroupIsCombined() throws Exception {
+        BibEntry entryOne = new BibEntry().withField("keywords", "A > B > B1, A > C");
+        BibEntry entryTwo = new BibEntry().withField("keywords", "A > D, E");
+        BibEntry entryThree = new BibEntry().withField("keywords", "A > B > B2");
+        databaseContext.getDatabase().insertEntries(entryOne, entryTwo, entryThree);
+
+        AutomaticKeywordGroup group = new AutomaticKeywordGroup("Keywords", GroupHierarchyType.INDEPENDENT, "keywords", ',');
+        GroupNodeViewModel groupViewModel = getViewModelForGroup(group);
+
+        WordKeywordGroup expectedGroupA = new WordKeywordGroup("A", GroupHierarchyType.INCLUDING, "keywords", "A", true, ',', true);
+        WordKeywordGroup expectedGroupB = new WordKeywordGroup("B", GroupHierarchyType.INCLUDING, "keywords", "A > B", true, ',', true);
+        WordKeywordGroup expectedGroupB1 = new WordKeywordGroup("B1", GroupHierarchyType.INCLUDING, "keywords", "A > B > B1", true, ',', true);
+        WordKeywordGroup expectedGroupB2 = new WordKeywordGroup("B2", GroupHierarchyType.INCLUDING, "keywords", "A > B > B2", true, ',', true);
+        WordKeywordGroup expectedGroupC = new WordKeywordGroup("C", GroupHierarchyType.INCLUDING, "keywords", "A > C", true, ',', true);
+        WordKeywordGroup expectedGroupD = new WordKeywordGroup("D", GroupHierarchyType.INCLUDING, "keywords", "A > D", true, ',', true);
+        WordKeywordGroup expectedGroupE = new WordKeywordGroup("E", GroupHierarchyType.INCLUDING, "keywords", "E", true, ',', true);
+        GroupNodeViewModel expectedA = getViewModelForGroup(expectedGroupA);
+        GroupTreeNode expectedB = expectedA.addSubgroup(expectedGroupB);
+        expectedB.addSubgroup(expectedGroupB1);
+        expectedB.addSubgroup(expectedGroupB2);
+        expectedA.addSubgroup(expectedGroupC);
+        expectedA.addSubgroup(expectedGroupD);
+        GroupNodeViewModel expectedE = getViewModelForGroup(expectedGroupE);
+        ObservableList<GroupNodeViewModel> expected = FXCollections.observableArrayList(expectedA, expectedE);
+
+        assertEquals(expected, groupViewModel.getChildren());
     }
 
     private GroupNodeViewModel getViewModelForGroup(AbstractGroup group) {

--- a/src/test/java/org/jabref/logic/exporter/GroupSerializerTest.java
+++ b/src/test/java/org/jabref/logic/exporter/GroupSerializerTest.java
@@ -96,9 +96,9 @@ public class GroupSerializerTest {
 
     @Test
     public void serializeSingleAutomaticKeywordGroup() {
-        AutomaticGroup group = new AutomaticKeywordGroup("myAutomaticGroup", GroupHierarchyType.INDEPENDENT, "keywords", ',');
+        AutomaticGroup group = new AutomaticKeywordGroup("myAutomaticGroup", GroupHierarchyType.INDEPENDENT, "keywords", ',', '>');
         List<String> serialization = groupSerializer.serializeTree(GroupTreeNode.fromGroup(group));
-        assertEquals(Collections.singletonList("0 AutomaticKeywordGroup:myAutomaticGroup;0;keywords;,;1;;;;"), serialization);
+        assertEquals(Collections.singletonList("0 AutomaticKeywordGroup:myAutomaticGroup;0;keywords;,;>;1;;;;"), serialization);
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java
@@ -76,8 +76,8 @@ public class GroupsParserTest {
 
     @Test
     public void fromStringParsesAutomaticKeywordGroup() throws Exception {
-        AutomaticGroup expected = new AutomaticKeywordGroup("myAutomaticGroup", GroupHierarchyType.INDEPENDENT, "keywords", ',');
-        AbstractGroup parsed = GroupsParser.fromString("AutomaticKeywordGroup:myAutomaticGroup;0;keywords;,;1;;;;", ',');
+        AutomaticGroup expected = new AutomaticKeywordGroup("myAutomaticGroup", GroupHierarchyType.INDEPENDENT, "keywords", ',', '>');
+        AbstractGroup parsed = GroupsParser.fromString("AutomaticKeywordGroup:myAutomaticGroup;0;keywords;,;>;1;;;;", ',');
         assertEquals(expected, parsed);
     }
 

--- a/src/test/java/org/jabref/model/entry/KeywordListTest.java
+++ b/src/test/java/org/jabref/model/entry/KeywordListTest.java
@@ -72,4 +72,20 @@ public class KeywordListTest {
     public void asStringAddsSpaceAfterDelimiter() throws Exception {
         assertEquals("keywordOne, keywordTwo", keywords.getAsString(','));
     }
+
+    @Test
+    public void parseHierarchicalChain() throws Exception {
+        Keyword expected = Keyword.of("Parent", "Node", "Child");
+
+        assertEquals(new KeywordList(expected), KeywordList.parse("Parent > Node > Child", ',', '>'));
+    }
+
+    @Test
+    public void parseTwoHierarchicalChains() throws Exception {
+        Keyword expectedOne = Keyword.of("Parent1", "Node1", "Child1");
+        Keyword expectedTwo = Keyword.of("Parent2", "Node2", "Child2");
+
+        assertEquals(new KeywordList(expectedOne, expectedTwo),
+                KeywordList.parse("Parent1 > Node1 > Child1, Parent2 > Node2 > Child2", ',', '>'));
+    }
 }

--- a/src/test/java/org/jabref/model/entry/KeywordTest.java
+++ b/src/test/java/org/jabref/model/entry/KeywordTest.java
@@ -1,0 +1,28 @@
+package org.jabref.model.entry;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class KeywordTest {
+
+    @Test
+    public void getPathFromRootAsStringForSimpleChain() throws Exception {
+        Keyword keywordChain = Keyword.of("A", "B", "C");
+        assertEquals("A > B", keywordChain.getChild().get().getPathFromRootAsString('>'));
+    }
+
+    @Test
+    public void getAllSubchainsAsStringForSimpleChain() throws Exception {
+        Keyword keywordChain = Keyword.of("A", "B", "C");
+        Set<String> expected = new HashSet<>();
+        expected.add("A");
+        expected.add("A > B");
+        expected.add("A > B > C");
+
+        assertEquals(expected, keywordChain.getAllSubchainsAsString('>'));
+    }
+}

--- a/src/test/java/org/jabref/model/groups/AutomaticKeywordGroupTest.java
+++ b/src/test/java/org/jabref/model/groups/AutomaticKeywordGroupTest.java
@@ -17,8 +17,8 @@ public class AutomaticKeywordGroupTest {
         BibEntry entry = new BibEntry().withField("keywords", "A, B");
 
         Set<GroupTreeNode> expected = new HashSet<>();
-        expected.add(GroupTreeNode.fromGroup(new WordKeywordGroup("A", GroupHierarchyType.INDEPENDENT, "keywords", "A", true, ',', true)));
-        expected.add(GroupTreeNode.fromGroup(new WordKeywordGroup("B", GroupHierarchyType.INDEPENDENT, "keywords", "B", true, ',', true)));
+        expected.add(GroupTreeNode.fromGroup(new WordKeywordGroup("A", GroupHierarchyType.INCLUDING, "keywords", "A", true, ',', true)));
+        expected.add(GroupTreeNode.fromGroup(new WordKeywordGroup("B", GroupHierarchyType.INCLUDING, "keywords", "B", true, ',', true)));
         assertEquals(expected, keywordsGroup.createSubgroups(entry));
     }
 }

--- a/src/test/java/org/jabref/model/groups/AutomaticKeywordGroupTest.java
+++ b/src/test/java/org/jabref/model/groups/AutomaticKeywordGroupTest.java
@@ -13,7 +13,7 @@ public class AutomaticKeywordGroupTest {
 
     @Test
     public void createSubgroupsForTwoKeywords() throws Exception {
-        AutomaticKeywordGroup keywordsGroup = new AutomaticKeywordGroup("Keywords", GroupHierarchyType.INDEPENDENT, "keywords", ',');
+        AutomaticKeywordGroup keywordsGroup = new AutomaticKeywordGroup("Keywords", GroupHierarchyType.INDEPENDENT, "keywords", ',', '>');
         BibEntry entry = new BibEntry().withField("keywords", "A, B");
 
         Set<GroupTreeNode> expected = new HashSet<>();


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

The automatic keywords group now supports hierarchical keywords. 
The changes mainly concentrate on the keywords class...so this may have some unwanted side effects in other parts (but I didn't noticed anything unusual in my tests).

Note: Bib files containing an automatic keyword from prior 4.0 tests can no longer be opened and the lines containing `AutomaticKeywordGroup` have to be deleted.

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
