### PR TITLE
Write groups under tag `group` instead of `groupstree` to enhance compatibility with previous versions

### DIFF
--- a/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
@@ -61,37 +61,36 @@ public class MetaDataParser {
             }
 
             switch (entry.getKey()) {
-            case MetaData.GROUPSTREE:
+                case MetaData.GROUPSTREE:
                 case MetaData.GROUPSTREE_LEGACY:
-                metaData.setGroups(GroupsParser.importGroups(value, keywordSeparator));
-                break;
-            case MetaData.SAVE_ACTIONS:
-                metaData.setSaveActions(Cleanups.parse(value));
-                break;
-            case MetaData.DATABASE_TYPE:
-                metaData.setMode(BibDatabaseMode.parse(getSingleItem(value)));
-                break;
-            case MetaData.KEYPATTERNDEFAULT:
-                defaultCiteKeyPattern = Collections.singletonList(getSingleItem(value));
-                break;
-            case MetaData.PROTECTED_FLAG_META:
-                if (Boolean.parseBoolean(getSingleItem(value))) {
-                    metaData.markAsProtected();
-                } else {
-                    metaData.markAsNotProtected();
-                }
-                break;
-            case MetaData.FILE_DIRECTORY:
-                metaData.setDefaultFileDirectory(getSingleItem(value));
-                break;
-            case MetaData.SAVE_ORDER_CONFIG:
-                metaData.setSaveOrderConfig(SaveOrderConfig.parse(value));
-                break;
-            case "groupsversion":
-            case "groups":
-                // These keys were used in previous JabRef versions, we will not support them anymore -> ignored
-                break;
-
+                    metaData.setGroups(GroupsParser.importGroups(value, keywordSeparator));
+                    break;
+                case MetaData.SAVE_ACTIONS:
+                    metaData.setSaveActions(Cleanups.parse(value));
+                    break;
+                case MetaData.DATABASE_TYPE:
+                    metaData.setMode(BibDatabaseMode.parse(getSingleItem(value)));
+                    break;
+                case MetaData.KEYPATTERNDEFAULT:
+                    defaultCiteKeyPattern = Collections.singletonList(getSingleItem(value));
+                    break;
+                case MetaData.PROTECTED_FLAG_META:
+                    if (Boolean.parseBoolean(getSingleItem(value))) {
+                        metaData.markAsProtected();
+                    } else {
+                        metaData.markAsNotProtected();
+                    }
+                    break;
+                case MetaData.FILE_DIRECTORY:
+                    metaData.setDefaultFileDirectory(getSingleItem(value));
+                    break;
+                case MetaData.SAVE_ORDER_CONFIG:
+                    metaData.setSaveOrderConfig(SaveOrderConfig.parse(value));
+                    break;
+                case "groupsversion":
+                case "groups":
+                    // These keys were used in previous JabRef versions, we will not support them anymore -> ignored
+                    break;
             }
         }
         if (!defaultCiteKeyPattern.isEmpty() || !nonDefaultCiteKeyPatterns.isEmpty()) {

--- a/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/MetaDataParser.java
@@ -62,6 +62,7 @@ public class MetaDataParser {
 
             switch (entry.getKey()) {
             case MetaData.GROUPSTREE:
+                case MetaData.GROUPSTREE_LEGACY:
                 metaData.setGroups(GroupsParser.importGroups(value, keywordSeparator));
                 break;
             case MetaData.SAVE_ACTIONS:

--- a/src/main/java/org/jabref/model/metadata/MetaData.java
+++ b/src/main/java/org/jabref/model/metadata/MetaData.java
@@ -29,7 +29,8 @@ public class MetaData {
     public static final String PREFIX_KEYPATTERN = "keypattern_";
     public static final String KEYPATTERNDEFAULT = "keypatterndefault";
     public static final String DATABASE_TYPE = "databaseType";
-    public static final String GROUPSTREE = "groupstree";
+    public static final String GROUPSTREE = "group";
+    public static final String GROUPSTREE_LEGACY = "groupstree";
     public static final String FILE_DIRECTORY = FieldName.FILE + FileDirectoryPreferences.DIR_SUFFIX;
     public static final String PROTECTED_FLAG_META = "protectedFlag";
     public static final String SELECTOR_META_PREFIX = "selector_";
@@ -39,11 +40,11 @@ public class MetaData {
     public static final String SEPARATOR_STRING = String.valueOf(SEPARATOR_CHARACTER);
 
     private final EventBus eventBus = new EventBus();
+    private final Map<String, String> citeKeyPatterns = new HashMap<>(); // <BibType, Pattern>
+    private final Map<String, String> userFileDirectory = new HashMap<>(); // <User, FilePath>
     private GroupTreeNode groupsRoot;
     private Charset encoding;
     private SaveOrderConfig saveOrderConfig;
-    private final Map<String, String> citeKeyPatterns = new HashMap<>(); // <BibType, Pattern>
-    private final Map<String, String> userFileDirectory = new HashMap<>(); // <User, FilePath>
     private String defaultCiteKeyPattern;
     private FieldFormatterCleanups saveActions;
     private BibDatabaseMode mode;

--- a/src/main/java/org/jabref/model/metadata/MetaData.java
+++ b/src/main/java/org/jabref/model/metadata/MetaData.java
@@ -29,7 +29,7 @@ public class MetaData {
     public static final String PREFIX_KEYPATTERN = "keypattern_";
     public static final String KEYPATTERNDEFAULT = "keypatterndefault";
     public static final String DATABASE_TYPE = "databaseType";
-    public static final String GROUPSTREE = "group";
+    public static final String GROUPSTREE = "grouping";
     public static final String GROUPSTREE_LEGACY = "groupstree";
     public static final String FILE_DIRECTORY = FieldName.FILE + FileDirectoryPreferences.DIR_SUFFIX;
     public static final String PROTECTED_FLAG_META = "protectedFlag";

--- a/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -194,7 +194,7 @@ public class BibtexDatabaseWriterTest {
 
         // @formatter:off
         assertEquals(OS.NEWLINE
-                + "@Comment{jabref-meta: groupstree:" + OS.NEWLINE
+                + "@Comment{jabref-meta: group:" + OS.NEWLINE
                 + "0 AllEntriesGroup:;" + OS.NEWLINE
                 + "1 StaticGroup:test\\;2\\;1\\;\\;\\;\\;;" + OS.NEWLINE
                 + "}" + OS.NEWLINE, session.getStringValue());
@@ -215,7 +215,7 @@ public class BibtexDatabaseWriterTest {
         assertEquals(
                 "% Encoding: US-ASCII" + OS.NEWLINE +
                 OS.NEWLINE
-                + "@Comment{jabref-meta: groupstree:" + OS.NEWLINE
+                        + "@Comment{jabref-meta: group:" + OS.NEWLINE
                 + "0 AllEntriesGroup:;" + OS.NEWLINE
                         + "1 StaticGroup:test\\;2\\;1\\;\\;\\;\\;;" + OS.NEWLINE
                 + "}" + OS.NEWLINE, session.getStringValue());

--- a/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/BibtexDatabaseWriterTest.java
@@ -194,7 +194,7 @@ public class BibtexDatabaseWriterTest {
 
         // @formatter:off
         assertEquals(OS.NEWLINE
-                + "@Comment{jabref-meta: group:" + OS.NEWLINE
+                + "@Comment{jabref-meta: grouping:" + OS.NEWLINE
                 + "0 AllEntriesGroup:;" + OS.NEWLINE
                 + "1 StaticGroup:test\\;2\\;1\\;\\;\\;\\;;" + OS.NEWLINE
                 + "}" + OS.NEWLINE, session.getStringValue());
@@ -215,7 +215,7 @@ public class BibtexDatabaseWriterTest {
         assertEquals(
                 "% Encoding: US-ASCII" + OS.NEWLINE +
                 OS.NEWLINE
-                        + "@Comment{jabref-meta: group:" + OS.NEWLINE
+                        + "@Comment{jabref-meta: grouping:" + OS.NEWLINE
                 + "0 AllEntriesGroup:;" + OS.NEWLINE
                         + "1 StaticGroup:test\\;2\\;1\\;\\;\\;\\;;" + OS.NEWLINE
                 + "}" + OS.NEWLINE, session.getStringValue());

--- a/src/test/resources/testbib/complex.bib
+++ b/src/test/resources/testbib/complex.bib
@@ -289,7 +289,7 @@ This is some user comment in front of a string, should also be preserved.
 
 @Comment{jabref-meta: fileDirectory-defaultOwner-user:D:\\Documents;}
 
-@Comment{jabref-meta: groupstree:
+@Comment{jabref-meta: group:
 0 AllEntriesGroup:;
 1 StaticGroup:StaticGroup\;0\;1\;\;\;A test static group\;;
 1 KeywordGroup:DynamicGroup\;0\;author\;Churchill\;0\;0\;1\;\;\;\;;

--- a/src/test/resources/testbib/complex.bib
+++ b/src/test/resources/testbib/complex.bib
@@ -289,7 +289,7 @@ This is some user comment in front of a string, should also be preserved.
 
 @Comment{jabref-meta: fileDirectory-defaultOwner-user:D:\\Documents;}
 
-@Comment{jabref-meta: group:
+@Comment{jabref-meta: grouping:
 0 AllEntriesGroup:;
 1 StaticGroup:StaticGroup\;0\;1\;\;\;A test static group\;;
 1 KeywordGroup:DynamicGroup\;0\;author\;Churchill\;0\;0\;1\;\;\;\;;


### PR DESCRIPTION
Right now, files written with 4.0 cannot be opened in older versions. The new format of the groups leads to a NPE. 
As a way out, I changed the tag for the groups tree from `groupstree` to `group` (`groups` was already used by previous version way back). Thus older versions completely ignore the group tree and no longer try to parse it, so no NPE is thrown. On the downside, however, the groups tree is deleted upon save in the older version. Still a bit better than a crashing Jabref in my opinion.

<!-- describe the changes you have made here: what, why, ... -->

- [ ] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
