### PR TITLE
Make sure that JavaFx shuts down in case another JabRef instance is a…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - The `day` part of the biblatex `date` field is now exported to the corresponding `day` field in MS-Office XML. [#2691](https://github.com/JabRef/jabref/issues/2691)
 
 ### Fixed
+ - We fixed an issue that prevented multiple parallel JabRef instances from terminating gracefully. [#2698](https://github.com/JabRef/jabref/issues/2698)
  - We fixed an issue where authors with multiple surnames were not presented correctly in the main table. [#2534](https://github.com/JabRef/jabref/issues/2534)
  - Repairs the handling of apostrophes in the LaTeX to unicode conversion. [#2500](https://github.com/JabRef/jabref/issues/2500)
  - Fix import of journal title in ris format. [#2506](https://github.com/JabRef/jabref/issues/2506)

--- a/src/main/java/org/jabref/JabRefMain.java
+++ b/src/main/java/org/jabref/JabRefMain.java
@@ -116,6 +116,8 @@ public class JabRefMain extends Application {
                     // So we assume it's all taken care of, and quit.
                     LOGGER.info(Localization.lang("Arguments passed on to running JabRef instance. Shutting down."));
                     Globals.shutdownThreadPools();
+                    // needed to tell JavaFx to stop
+                    Platform.exit();
                     return;
                 }
             }


### PR DESCRIPTION
…lready open

Fixes #2698. The problem was that JavaFX requires `Platform.exit();` to be called on shutdown. Otherwise the JavaFX application thread does not terminate. In the case of this issue, a GUI was never opened and therefore this statement was never reached. This should be mitigated now.

- [X] Change in CHANGELOG.md described
- [X] Manually tested changed features in running JabRef
