### PR TITLE
Add ArXiv identifier batch lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - The `Move linked files to default file directory`-Cleanup operation respects the `File directory pattern` setting 
 - We separated the `Move file` and `Rename Pdfs` logic and context menu entries in the `General`-Tab for the Field `file` to improve the semantics
 - A scrollbar was added to the cleanup panel, as a result of issue [#2501](https://github.com/JabRef/jabref/issues/2501)
-- Using "Look up document identifier" in the quality menu, it is possible to look up DOIs and other identifiers for multiple entries.
+- Using "Look up document identifier" in the quality menu, it is possible to look up DOIs, ArXiv ids and other identifiers for multiple entries.
 - F4 opens selected file in current JTable context not just from selected entry inside the main table [#2355](https://github.com/JabRef/jabref/issues/2355)
 - We added an option to copy the title of BibTeX entries to the clipboard through `Edit -> Copy title` (implements [#210](https://github.com/koppor/jabref/issues/210))
 - Several scrollbars were added to the preference dialog which show up when content is too large [#2559](https://github.com/JabRef/jabref/issues/2559)

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -1177,7 +1177,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         quality.add(findUnlinkedFiles);
         quality.add(autoLinkFile);
 
-        for (IdFetcher fetcher : WebFetchers.getIdFetchers()) {
+        for (IdFetcher fetcher : WebFetchers.getIdFetchers(Globals.prefs.getImportFormatPreferences())) {
             lookupIdentifiers.add(new LookupIdentifierAction(this, fetcher));
         }
         quality.add(lookupIdentifiers);

--- a/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -94,9 +94,10 @@ public class WebFetchers {
         return list;
     }
 
-    public static List<IdFetcher> getIdFetchers() {
+    public static List<IdFetcher> getIdFetchers(ImportFormatPreferences importFormatPreferences) {
         ArrayList<IdFetcher> list = new ArrayList<>();
         list.add(new CrossRef());
+        list.add(new ArXiv(importFormatPreferences));
         list.sort(Comparator.comparing(WebFetcher::getName));
         return list;
     }

--- a/src/main/java/org/jabref/model/entry/identifier/ArXivIdentifier.java
+++ b/src/main/java/org/jabref/model/entry/identifier/ArXivIdentifier.java
@@ -3,7 +3,9 @@ package org.jabref.model.entry.identifier;
 import java.util.Objects;
 import java.util.Optional;
 
-public class ArXivIdentifier {
+import org.jabref.model.entry.FieldName;
+
+public class ArXivIdentifier implements Identifier {
 
     private final String identifier;
 
@@ -31,6 +33,12 @@ public class ArXivIdentifier {
         return identifier.hashCode();
     }
 
+    @Override
+    public String getDefaultField() {
+        return FieldName.EPRINT;
+    }
+
+    @Override
     public String getNormalized() {
         return identifier;
     }

--- a/src/test/java/org/jabref/logic/importer/WebFetchersTest.java
+++ b/src/test/java/org/jabref/logic/importer/WebFetchersTest.java
@@ -60,7 +60,7 @@ public class WebFetchersTest {
 
     @Test
     public void getIdFetchersReturnsAllFetcherDerivingFromIdFetcher() throws Exception {
-        List<IdFetcher> idFetchers = WebFetchers.getIdFetchers();
+        List<IdFetcher> idFetchers = WebFetchers.getIdFetchers(importFormatPreferences);
 
         Set<Class<? extends IdFetcher>> expected = reflections.getSubTypesOf(IdFetcher.class);
         expected.remove(IdParserFetcher.class);


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

Find arXiv ids for multiple entries using Quality -> Lookup identifier -> ArXiv (similar to the same solution for DOI).

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
