### PR TITLE
Avoid conversion of single underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Entries with a single corporate author are now correclty exported to the corresponding `corporate` author field in MS-Office XML. [#1497](https://github.com/JabRef/jabref/issues/1497)
 - Improved author handling in MS-Office Import/Export
 - The `day` part of the biblatex `date` field is now exported to the corresponding `day` field in MS-Office XML. [#2691](https://github.com/JabRef/jabref/issues/2691)
+- Single underscores are not converted to during the LaTeX to unicode conversion, which does not follow the rules of LaTeX, but is what users requre. [#2664](https://github.com/JabRef/jabref/issues/2664)
 
 ### Fixed
  - We fixed an issue of duplicate keys after using a fetcher, e.g., DOI or ISBN [#2867](https://github.com/JabRef/jabref/issues/2687)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Entries with a single corporate author are now correclty exported to the corresponding `corporate` author field in MS-Office XML. [#1497](https://github.com/JabRef/jabref/issues/1497)
 - Improved author handling in MS-Office Import/Export
 - The `day` part of the biblatex `date` field is now exported to the corresponding `day` field in MS-Office XML. [#2691](https://github.com/JabRef/jabref/issues/2691)
-- Single underscores are not converted to during the LaTeX to unicode conversion, which does not follow the rules of LaTeX, but is what users requre. [#2664](https://github.com/JabRef/jabref/issues/2664)
+- Single underscores are not converted during the LaTeX to unicode conversion, which does not follow the rules of LaTeX, but is what users require. [#2664](https://github.com/JabRef/jabref/issues/2664)
 
 ### Fixed
  - We fixed an issue of duplicate keys after using a fetcher, e.g., DOI or ISBN [#2867](https://github.com/JabRef/jabref/issues/2687)

--- a/src/main/java/org/jabref/logic/layout/format/LatexToUnicodeFormatter.java
+++ b/src/main/java/org/jabref/logic/layout/format/LatexToUnicodeFormatter.java
@@ -1,5 +1,7 @@
 package org.jabref.logic.layout.format;
 
+import java.util.regex.Pattern;
+
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.layout.LayoutFormatter;
 import org.jabref.model.cleanup.Formatter;
@@ -10,6 +12,12 @@ import org.jabref.model.strings.LatexToUnicodeAdapter;
  * and removes other LaTeX commands without handling them.
  */
 public class LatexToUnicodeFormatter implements LayoutFormatter, Formatter {
+
+    private Pattern underscoreMatcher = Pattern.compile("_(?!\\{)");
+
+    private String underscorePlaceholder = "JABREFUNDERSCORE";
+
+    private Pattern underscorePlaceholderMatcher = Pattern.compile(underscorePlaceholder);
 
     @Override
     public String getName() {
@@ -23,7 +31,9 @@ public class LatexToUnicodeFormatter implements LayoutFormatter, Formatter {
 
     @Override
     public String format(String inField) {
-        return LatexToUnicodeAdapter.format(inField);
+        String toFormat = underscoreMatcher.matcher(inField).replaceAll(underscorePlaceholder);
+        toFormat = LatexToUnicodeAdapter.format(toFormat);
+        return underscorePlaceholderMatcher.matcher(toFormat).replaceAll("_");
     }
 
     @Override

--- a/src/main/java/org/jabref/logic/layout/format/LatexToUnicodeFormatter.java
+++ b/src/main/java/org/jabref/logic/layout/format/LatexToUnicodeFormatter.java
@@ -15,9 +15,9 @@ public class LatexToUnicodeFormatter implements LayoutFormatter, Formatter {
 
     private Pattern underscoreMatcher = Pattern.compile("_(?!\\{)");
 
-    private String underscorePlaceholder = "JABREFUNDERSCORE";
+    private String replacementChar = "\uFFFD";
 
-    private Pattern underscorePlaceholderMatcher = Pattern.compile(underscorePlaceholder);
+    private Pattern underscorePlaceholderMatcher = Pattern.compile(replacementChar);
 
     @Override
     public String getName() {
@@ -31,7 +31,7 @@ public class LatexToUnicodeFormatter implements LayoutFormatter, Formatter {
 
     @Override
     public String format(String inField) {
-        String toFormat = underscoreMatcher.matcher(inField).replaceAll(underscorePlaceholder);
+        String toFormat = underscoreMatcher.matcher(inField).replaceAll(replacementChar);
         toFormat = LatexToUnicodeAdapter.format(toFormat);
         return underscorePlaceholderMatcher.matcher(toFormat).replaceAll("_");
     }

--- a/src/main/java/org/jabref/logic/layout/format/LatexToUnicodeFormatter.java
+++ b/src/main/java/org/jabref/logic/layout/format/LatexToUnicodeFormatter.java
@@ -13,12 +13,6 @@ import org.jabref.model.strings.LatexToUnicodeAdapter;
  */
 public class LatexToUnicodeFormatter implements LayoutFormatter, Formatter {
 
-    private Pattern underscoreMatcher = Pattern.compile("_(?!\\{)");
-
-    private String replacementChar = "\uFFFD";
-
-    private Pattern underscorePlaceholderMatcher = Pattern.compile(replacementChar);
-
     @Override
     public String getName() {
         return Localization.lang("LaTeX to Unicode");
@@ -31,9 +25,7 @@ public class LatexToUnicodeFormatter implements LayoutFormatter, Formatter {
 
     @Override
     public String format(String inField) {
-        String toFormat = underscoreMatcher.matcher(inField).replaceAll(replacementChar);
-        toFormat = LatexToUnicodeAdapter.format(toFormat);
-        return underscorePlaceholderMatcher.matcher(toFormat).replaceAll("_");
+        return LatexToUnicodeAdapter.format(inField);
     }
 
     @Override

--- a/src/main/java/org/jabref/logic/layout/format/LatexToUnicodeFormatter.java
+++ b/src/main/java/org/jabref/logic/layout/format/LatexToUnicodeFormatter.java
@@ -1,7 +1,5 @@
 package org.jabref.logic.layout.format;
 
-import java.util.regex.Pattern;
-
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.layout.LayoutFormatter;
 import org.jabref.model.cleanup.Formatter;

--- a/src/main/java/org/jabref/model/strings/LatexToUnicodeAdapter.java
+++ b/src/main/java/org/jabref/model/strings/LatexToUnicodeAdapter.java
@@ -2,6 +2,7 @@ package org.jabref.model.strings;
 
 import java.text.Normalizer;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 import com.github.tomtung.latex2unicode.LaTeX2Unicode;
 
@@ -10,9 +11,17 @@ import com.github.tomtung.latex2unicode.LaTeX2Unicode;
  */
 public class LatexToUnicodeAdapter {
 
+    private static Pattern underscoreMatcher = Pattern.compile("_(?!\\{)");
+
+    private static String replacementChar = "\uFFFD";
+
+    private static Pattern underscorePlaceholderMatcher = Pattern.compile(replacementChar);
+
     public static String format(String inField) {
         Objects.requireNonNull(inField);
 
-        return Normalizer.normalize(LaTeX2Unicode.convert(inField), Normalizer.Form.NFKC);
+        String toFormat = underscoreMatcher.matcher(inField).replaceAll(replacementChar);
+        toFormat = Normalizer.normalize(LaTeX2Unicode.convert(toFormat), Normalizer.Form.NFKC);
+        return underscorePlaceholderMatcher.matcher(toFormat).replaceAll("_");
     }
 }

--- a/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -152,6 +152,10 @@ public class LatexToUnicodeFormatterTest {
         assertEquals("L'oscillation", formatter.format("L'oscillation"));
     }
 
+    public void testApostrophC() {
+        assertEquals("O'Connor", formatter.format("O'Connor"));
+    }
+
     @Test
     public void testCustomUnderscoreConversion() {
         // our custom version which should preserve the _

--- a/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -153,7 +153,11 @@ public class LatexToUnicodeFormatterTest {
     }
 
     @Test
-    public void testApostrophC() {
-        assertEquals("O'Connor", formatter.format("O'Connor"));
+    public void testCustomUnderscoreConversion() {
+        // our custom version which should preserve the _
+        assertEquals("Lorem ipsum_lorem ipsum", formatter.format("Lorem ipsum_lorem ipsum"));
+        // when used with braces the normal unicode conversion should kick in
+        assertEquals("Lorem ipsum_(lorem ipsum)", formatter.format("Lorem ipsum_{lorem ipsum}"));
     }
+
 }

--- a/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -158,10 +158,12 @@ public class LatexToUnicodeFormatterTest {
     }
 
     @Test
-    public void testCustomUnderscoreConversion() {
-        // our custom version which should preserve the _
+    public void testPreservationOfSingleUnderscore() {
         assertEquals("Lorem ipsum_lorem ipsum", formatter.format("Lorem ipsum_lorem ipsum"));
-        // when used with braces the normal unicode conversion should kick in
+    }
+
+    @Test
+    public void testConversionOfUnderscoreWithBraces() {
         assertEquals("Lorem ipsum_(lorem ipsum)", formatter.format("Lorem ipsum_{lorem ipsum}"));
     }
 

--- a/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -152,6 +152,7 @@ public class LatexToUnicodeFormatterTest {
         assertEquals("L'oscillation", formatter.format("L'oscillation"));
     }
 
+    @Test
     public void testApostrophC() {
         assertEquals("O'Connor", formatter.format("O'Connor"));
     }


### PR DESCRIPTION
Fixes #2664

Single underscores that are not followed by `{` are not converted to unicode during the LaTeX to unicode conversion. This is not actually correct according to the rules of LaTeX, but seems to be an important exception required by our users.

This is achieved by the following:
 1. Replace all single underscores with `JABREFUNDERSCORE`
 2. Do the unicode conversion
 3. Replace `JABREFUNDERSCORE` with an underscore

TODO: We should find a better magic word instead of `JABREFUNDERSCORE`, because every character will be processed by latex2unicode and that costs performance. However, it should still be long and unique enough so that we avoid accidental conversions. Suggestions anyone?

- [X] Change in CHANGELOG.md described
- [X] Tests created for changes
- [X] Manually tested changed features in running JabRef
