### PR TITLE
Fixed freeze on Mac OS X when creating/editing groups

### DIFF
--- a/src/main/java/org/jabref/gui/groups/GroupTreeController.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeController.java
@@ -238,9 +238,9 @@ public class GroupTreeController extends AbstractController<GroupTreeViewModel> 
         removeSubgroups.setOnAction(event -> viewModel.removeSubgroups(group));
 
         MenuItem addEntries = new MenuItem(Localization.lang("Add selected entries to this group"));
-        removeSubgroups.setOnAction(event -> viewModel.addSelectedEntries(group));
+        addEntries.setOnAction(event -> viewModel.addSelectedEntries(group));
         MenuItem removeEntries = new MenuItem(Localization.lang("Remove selected entries from this group"));
-        removeSubgroups.setOnAction(event -> viewModel.removeSelectedEntries(group));
+        removeEntries.setOnAction(event -> viewModel.removeSelectedEntries(group));
 
         MenuItem sortAlphabetically = new MenuItem(Localization.lang("Sort all subgroups (recursively)"));
         sortAlphabetically.setOnAction(event -> viewModel.sortAlphabeticallyRecursive(group));

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 
+import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -23,6 +24,8 @@ import org.jabref.model.groups.AbstractGroup;
 import org.jabref.model.groups.ExplicitGroup;
 import org.jabref.model.groups.GroupTreeNode;
 import org.jabref.model.metadata.MetaData;
+
+import javax.swing.SwingUtilities;
 
 public class GroupTreeViewModel extends AbstractViewModel {
 
@@ -123,18 +126,20 @@ public class GroupTreeViewModel extends AbstractViewModel {
      * Opens "New Group Dialog" and add the resulting group to the specified group
      */
     public void addNewSubgroup(GroupNodeViewModel parent) {
-        Optional<AbstractGroup> newGroup = dialogService.showCustomDialogAndWait(new GroupDialog());
-        newGroup.ifPresent(group -> {
-            GroupTreeNode newGroupNode = parent.addSubgroup(group);
+        SwingUtilities.invokeLater(() -> {
+            Optional<AbstractGroup> newGroup = dialogService.showCustomDialogAndWait(new GroupDialog());
+            newGroup.ifPresent(group -> {
+                GroupTreeNode newGroupNode = parent.addSubgroup(group);
 
-            // TODO: Add undo
-            //UndoableAddOrRemoveGroup undo = new UndoableAddOrRemoveGroup(parent, new GroupTreeNodeViewModel(newGroupNode), UndoableAddOrRemoveGroup.ADD_NODE);
-            //panel.getUndoManager().addEdit(undo);
+                // TODO: Add undo
+                //UndoableAddOrRemoveGroup undo = new UndoableAddOrRemoveGroup(parent, new GroupTreeNodeViewModel(newGroupNode), UndoableAddOrRemoveGroup.ADD_NODE);
+                //panel.getUndoManager().addEdit(undo);
 
-            // TODO: Expand parent to make new group visible
-            //parent.expand();
+                // TODO: Expand parent to make new group visible
+                //parent.expand();
 
-            dialogService.notify(Localization.lang("Added group \"%0\".", group.getName()));
+                dialogService.notify(Localization.lang("Added group \"%0\".", group.getName()));
+            });
         });
     }
 
@@ -142,42 +147,46 @@ public class GroupTreeViewModel extends AbstractViewModel {
      * Opens "Edit Group Dialog" and changes the given group to the edited one.
      */
     public void editGroup(GroupNodeViewModel oldGroup) {
-        Optional<AbstractGroup> newGroup = dialogService
-                .showCustomDialogAndWait(new GroupDialog(oldGroup.getGroupNode().getGroup()));
-        newGroup.ifPresent(group -> {
+        SwingUtilities.invokeLater(() -> {
+            Optional<AbstractGroup> newGroup = dialogService
+                    .showCustomDialogAndWait(new GroupDialog(oldGroup.getGroupNode().getGroup()));
+            newGroup.ifPresent(group -> {
 
-            // TODO: Keep assignments
-            boolean keepPreviousAssignments = dialogService.showConfirmationDialogAndWait(
-                    Localization.lang("Change of Grouping Method"),
-                    Localization.lang("Assign the original group's entries to this group?"));
-            //        WarnAssignmentSideEffects.warnAssignmentSideEffects(newGroup, panel.frame());
-            boolean removePreviousAssignents = (oldGroup.getGroupNode().getGroup() instanceof ExplicitGroup)
-                    && (group instanceof ExplicitGroup);
+                Platform.runLater(() -> {
+                    // TODO: Keep assignments
+                    boolean keepPreviousAssignments = dialogService.showConfirmationDialogAndWait(
+                            Localization.lang("Change of Grouping Method"),
+                            Localization.lang("Assign the original group's entries to this group?"));
+                    //        WarnAssignmentSideEffects.warnAssignmentSideEffects(newGroup, panel.frame());
+                    boolean removePreviousAssignents = (oldGroup.getGroupNode().getGroup() instanceof ExplicitGroup)
+                            && (group instanceof ExplicitGroup);
 
-            List<FieldChange> addChange = oldGroup.getGroupNode().setGroup(
-                    group,
-                    keepPreviousAssignments,
-                    removePreviousAssignents,
-                    stateManager.getEntriesInCurrentDatabase());
+                    List<FieldChange> addChange = oldGroup.getGroupNode().setGroup(
+                            group,
+                            keepPreviousAssignments,
+                            removePreviousAssignents,
+                            stateManager.getEntriesInCurrentDatabase());
 
-            // TODO: Add undo
-            // Store undo information.
-            // AbstractUndoableEdit undoAddPreviousEntries = null;
-            // UndoableModifyGroup undo = new UndoableModifyGroup(GroupSelector.this, groupsRoot, node, newGroup);
-            // if (undoAddPreviousEntries == null) {
-            //    panel.getUndoManager().addEdit(undo);
-            //} else {
-            //    NamedCompound nc = new NamedCompound("Modify Group");
-            //    nc.addEdit(undo);
-            //    nc.addEdit(undoAddPreviousEntries);
-            //    nc.end();/
-            //      panel.getUndoManager().addEdit(nc);
-            //}
-            //if (!addChange.isEmpty()) {
-            //    undoAddPreviousEntries = UndoableChangeEntriesOfGroup.getUndoableEdit(null, addChange);
-            //}
+                    // TODO: Add undo
+                    // Store undo information.
+                    // AbstractUndoableEdit undoAddPreviousEntries = null;
+                    // UndoableModifyGroup undo = new UndoableModifyGroup(GroupSelector.this, groupsRoot, node, newGroup);
+                    // if (undoAddPreviousEntries == null) {
+                    //    panel.getUndoManager().addEdit(undo);
+                    //} else {
+                    //    NamedCompound nc = new NamedCompound("Modify Group");
+                    //    nc.addEdit(undo);
+                    //    nc.addEdit(undoAddPreviousEntries);
+                    //    nc.end();/
+                    //      panel.getUndoManager().addEdit(nc);
+                    //}
+                    //if (!addChange.isEmpty()) {
+                    //    undoAddPreviousEntries = UndoableChangeEntriesOfGroup.getUndoableEdit(null, addChange);
+                    //}
 
-            dialogService.notify(Localization.lang("Modified group \"%0\".", group.getName()));
+                    dialogService.notify(Localization.lang("Modified group \"%0\".", group.getName()));
+                });
+            });
         });
     }
 

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 
+import javax.swing.SwingUtilities;
+
 import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.ObjectProperty;
@@ -24,8 +26,6 @@ import org.jabref.model.groups.AbstractGroup;
 import org.jabref.model.groups.ExplicitGroup;
 import org.jabref.model.groups.GroupTreeNode;
 import org.jabref.model.metadata.MetaData;
-
-import javax.swing.SwingUtilities;
 
 public class GroupTreeViewModel extends AbstractViewModel {
 


### PR DESCRIPTION
Fixed that JabRef for Mac OS X was freezing / not responding when using the "add subgroup" or "edit group" feature. Also fixed some menu items which had the wrong functionality. Refs #2722 

- [x] Manually tested changed features in running JabRef