### PR TITLE
Fix 2701 too may files found

### DIFF
--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -526,10 +526,8 @@ public class BibtexKeyPatternUtil {
                  */
                 String authString;
                 if (database != null) {
-                    Optional<String> authorFieldValue = entry.getField(FieldName.AUTHOR);
-                    Optional<String> mappedFieldValue = authorFieldValue
-                            .map(authorString -> normalize(database.resolveForStrings(authorString)));
-                    authString = mappedFieldValue.orElse("");
+                    authString = entry.getField(FieldName.AUTHOR)
+                            .map(authorString -> normalize(database.resolveForStrings(authorString))).orElse("");
                 } else {
                     authString = entry.getField(FieldName.AUTHOR).orElse("");
                 }

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -524,8 +524,10 @@ public class BibtexKeyPatternUtil {
                  * form "pureauth..." which does not do this fallback
                  * substitution of editor.
                  */
-                String authString = entry.getField(FieldName.AUTHOR)
-                        .map(authorString -> normalize(database.resolveForStrings(authorString))).orElse("");
+                Optional<String> authorFieldValue = entry.getField(FieldName.AUTHOR);
+                Optional<String> mappedFieldValue = authorFieldValue
+                        .map(authorString -> normalize(database.resolveForStrings(authorString)));
+                String authString = mappedFieldValue.orElse("");
 
                 if (val.startsWith("pure")) {
                     // remove the "pure" prefix so the remaining

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -524,10 +524,15 @@ public class BibtexKeyPatternUtil {
                  * form "pureauth..." which does not do this fallback
                  * substitution of editor.
                  */
-                Optional<String> authorFieldValue = entry.getField(FieldName.AUTHOR);
-                Optional<String> mappedFieldValue = authorFieldValue
-                        .map(authorString -> normalize(database.resolveForStrings(authorString)));
-                String authString = mappedFieldValue.orElse("");
+                String authString;
+                if (database != null) {
+                    Optional<String> authorFieldValue = entry.getField(FieldName.AUTHOR);
+                    Optional<String> mappedFieldValue = authorFieldValue
+                            .map(authorString -> normalize(database.resolveForStrings(authorString)));
+                    authString = mappedFieldValue.orElse("");
+                } else {
+                    authString = entry.getField(FieldName.AUTHOR).orElse("");
+                }
 
                 if (val.startsWith("pure")) {
                     // remove the "pure" prefix so the remaining
@@ -536,8 +541,12 @@ public class BibtexKeyPatternUtil {
                 }
 
                 if (authString.isEmpty()) {
-                    authString = entry.getField(FieldName.EDITOR)
+                    if (database != null) {
+                        authString = entry.getField(FieldName.EDITOR)
                             .map(authorString -> normalize(database.resolveForStrings(authorString))).orElse("");
+                    } else {
+                        authString = entry.getField(FieldName.EDITOR).orElse("");
+                    }
                 }
 
                 // Gather all author-related checks, so we don't

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithoutDatabaseTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithoutDatabaseTest.java
@@ -11,7 +11,6 @@ public class MakeLabelWithoutDatabaseTest {
 
     // private GlobalBibtexKeyPattern pattern;
     private BibEntry entry;
-    private String patternString;
 
     @Before
     public void setUp() {

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithoutDatabaseTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithoutDatabaseTest.java
@@ -1,0 +1,33 @@
+package org.jabref.logic.bibtexkeypattern;
+
+import org.jabref.model.entry.BibEntry;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MakeLabelWithoutDatabaseTest {
+
+    // private GlobalBibtexKeyPattern pattern;
+    private BibEntry entry;
+    private String patternString;
+
+    @Before
+    public void setUp() {
+        entry = new BibEntry();
+        entry.setField("author", "John Doe");
+        entry.setField("year", "2016");
+        entry.setField("title", "An awesome paper on JabRef");
+    }
+
+    @Test
+    public void makeLabelForFileSearch() {
+        String label = BibtexKeyPatternUtil.makeLabel(entry,
+                /*value=*/ "auth",
+                /*keywordDelimiter=*/ ',',
+                /*database=*/ null);
+        assertEquals("Doe", label);
+    }
+
+}

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithoutDatabaseTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithoutDatabaseTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.assertEquals;
 
 public class MakeLabelWithoutDatabaseTest {
 
-    // private GlobalBibtexKeyPattern pattern;
     private BibEntry entry;
 
     @Before

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithoutDatabaseTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithoutDatabaseTest.java
@@ -22,10 +22,8 @@ public class MakeLabelWithoutDatabaseTest {
 
     @Test
     public void makeLabelForFileSearch() {
-        String label = BibtexKeyPatternUtil.makeLabel(entry,
-                /*value=*/ "auth",
-                /*keywordDelimiter=*/ ',',
-                /*database=*/ null);
+        String label =
+            BibtexKeyPatternUtil.makeLabel(entry, "auth", ',', null);
         assertEquals("Doe", label);
     }
 
@@ -36,10 +34,8 @@ public class MakeLabelWithoutDatabaseTest {
         localEntry.setField("year", "2016");
         localEntry.setField("title", "An awesome paper on JabRef");
 
-        String label = BibtexKeyPatternUtil.makeLabel(localEntry,
-                /*value=*/ "auth",
-                /*keywordDelimiter=*/ ',',
-                /*database=*/ null);
+        String label =
+            BibtexKeyPatternUtil.makeLabel(localEntry, "auth", ',', null);
         assertEquals("Doe", label);
     }
 

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithoutDatabaseTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithoutDatabaseTest.java
@@ -29,4 +29,18 @@ public class MakeLabelWithoutDatabaseTest {
         assertEquals("Doe", label);
     }
 
+    @Test
+    public void makeEditorLabelForFileSearch() {
+        BibEntry localEntry = new BibEntry();
+        localEntry.setField("editor", "John Doe");
+        localEntry.setField("year", "2016");
+        localEntry.setField("title", "An awesome paper on JabRef");
+
+        String label = BibtexKeyPatternUtil.makeLabel(localEntry,
+                /*value=*/ "auth",
+                /*keywordDelimiter=*/ ',',
+                /*database=*/ null);
+        assertEquals("Doe", label);
+    }
+
 }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

I would like to offer my fix for the issue  2701: JabRef would find too many files when they are search with the [year]_[auth].* pattern. The reason seems to be a 'null' database passed to the BibtexKeyPatternUtil.makeLabel(BibEntry, String, Character, BibDatabase) method, and a null pointer exception is triggered. As a result, the '[auth]' part of the pattern was erased and ignored. With the suggested fix, JabRef uses the '[auth]' part of the pattern and finds just the files with the matching author, as expected. A relevant unit test was added; no other tests were broken.

- [ ] Change in CHANGELOG.md described -- no functionality changes, restored the previous state
- [x ] Tests created for changes -- 1 unit test added;
- [ ] Screenshots added (for bigger UI changes) -- no GUI changes;
- [ ] Manually tested changed features in running JabRef -- none
- [x ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?) -- the issue #2701 still open.
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`? -- no localisation changes.
