### PR TITLE
Fix #2739 null pointer exception on get fulltext

### DIFF
--- a/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -199,12 +199,12 @@ public class BibDatabaseContext {
         // 4. BIB file directory
         getDatabasePath().ifPresent(dbPath -> {
             assert dbPath != null : "dbPath is null";
-            assert dbPath.getParent() != null : "dbPath.getParent() is null";
-            assert dbPath.getParent().toAbsolutePath() != null : "dbPath.getParent().toAbsolutePath() is null";
-            assert dbPath.getParent().toAbsolutePath().toString() != null : "dbPath.getParent().toAbsolutePath().toString() is null";
-            assert preferences != null : "'preferences' is null";
-            assert fileDirs != null : "'fileDirs' is null";
-            String parentDir = dbPath.getParent().toAbsolutePath().toString();
+            Path parentPath = dbPath.getParent();
+            if( parentPath == null ) {
+                parentPath = Paths.get(System.getProperty("user.dir"));
+            }
+            assert parentPath != null : "BibTex database parent path is null";
+            String parentDir = parentPath.toAbsolutePath().toString();
             // Check if we should add it as primary file dir (first in the list) or not:
             if (preferences.isBibLocationAsPrimary()) {
                 fileDirs.add(0, parentDir);

--- a/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -200,9 +200,11 @@ public class BibDatabaseContext {
         getDatabasePath().ifPresent(dbPath -> {
             assert dbPath != null : "dbPath is null";
             Path parentPath = dbPath.getParent();
+            /*
             if( parentPath == null ) {
                 parentPath = Paths.get(System.getProperty("user.dir"));
             }
+            */
             assert parentPath != null : "BibTex database parent path is null";
             String parentDir = parentPath.toAbsolutePath().toString();
             // Check if we should add it as primary file dir (first in the list) or not:

--- a/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -198,25 +198,20 @@ public class BibDatabaseContext {
 
         // 4. BIB file directory
         getDatabasePath().ifPresent(dbPath -> {
-                if( dbPath == null ) {
-                    System.err.println( "EEE>>> dbPath is null" );
-                } else {
-                    System.err.println( "EEE>>> dbPath is NOT null: " + dbPath );
-                }
-                assert dbPath != null : "dbPath is null";
-                assert dbPath.getParent() != null : "dbPath.getParent() is null";
-                assert dbPath.getParent().toAbsolutePath() != null : "dbPath.getParent().toAbsolutePath() is null";
-                assert dbPath.getParent().toAbsolutePath().toString() != null : "dbPath.getParent().toAbsolutePath().toString() is null";
-                assert preferences != null : "'preferences' is null";
-                assert fileDirs != null : "'fileDirs' is null";
-                String parentDir = dbPath.getParent().toAbsolutePath().toString();
-                // Check if we should add it as primary file dir (first in the list) or not:
-                if (preferences.isBibLocationAsPrimary()) {
-                    fileDirs.add(0, parentDir);
-                } else {
-                    fileDirs.add(parentDir);
-                }
-            });
+            assert dbPath != null : "dbPath is null";
+            assert dbPath.getParent() != null : "dbPath.getParent() is null";
+            assert dbPath.getParent().toAbsolutePath() != null : "dbPath.getParent().toAbsolutePath() is null";
+            assert dbPath.getParent().toAbsolutePath().toString() != null : "dbPath.getParent().toAbsolutePath().toString() is null";
+            assert preferences != null : "'preferences' is null";
+            assert fileDirs != null : "'fileDirs' is null";
+            String parentDir = dbPath.getParent().toAbsolutePath().toString();
+            // Check if we should add it as primary file dir (first in the list) or not:
+            if (preferences.isBibLocationAsPrimary()) {
+                fileDirs.add(0, parentDir);
+            } else {
+                fileDirs.add(parentDir);
+            }
+        });
 
         return fileDirs;
     }

--- a/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -200,11 +200,9 @@ public class BibDatabaseContext {
         getDatabasePath().ifPresent(dbPath -> {
             assert dbPath != null : "dbPath is null";
             Path parentPath = dbPath.getParent();
-            /*
             if( parentPath == null ) {
                 parentPath = Paths.get(System.getProperty("user.dir"));
             }
-            */
             assert parentPath != null : "BibTex database parent path is null";
             String parentDir = parentPath.toAbsolutePath().toString();
             // Check if we should add it as primary file dir (first in the list) or not:

--- a/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -200,7 +200,7 @@ public class BibDatabaseContext {
         getDatabasePath().ifPresent(dbPath -> {
             assert dbPath != null : "dbPath is null";
             Path parentPath = dbPath.getParent();
-            if( parentPath == null ) {
+            if (parentPath == null) {
                 parentPath = Paths.get(System.getProperty("user.dir"));
             }
             assert parentPath != null : "BibTex database parent path is null";

--- a/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -198,12 +198,12 @@ public class BibDatabaseContext {
 
         // 4. BIB file directory
         getDatabasePath().ifPresent(dbPath -> {
-            assert dbPath != null : "dbPath is null";
+            Objects.requireNonNull(dbPath, "dbPath is null");
             Path parentPath = dbPath.getParent();
             if (parentPath == null) {
                 parentPath = Paths.get(System.getProperty("user.dir"));
             }
-            assert parentPath != null : "BibTex database parent path is null";
+            Objects.requireNonNull(parentPath, "BibTex database parent path is null");
             String parentDir = parentPath.toAbsolutePath().toString();
             // Check if we should add it as primary file dir (first in the list) or not:
             if (preferences.isBibLocationAsPrimary()) {

--- a/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -179,8 +179,6 @@ public class BibDatabaseContext {
     public List<String> getFileDirectories(String fieldName, FileDirectoryPreferences preferences) {
         List<String> fileDirs = new ArrayList<>();
 
-        System.out.println( ">>> HERE!" );
-
         // 1. metadata user-specific directory
         Optional<String> userFileDirectory = metaData.getUserFileDirectory(preferences.getUser());
         if (userFileDirectory.isPresent()) {

--- a/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -179,6 +179,8 @@ public class BibDatabaseContext {
     public List<String> getFileDirectories(String fieldName, FileDirectoryPreferences preferences) {
         List<String> fileDirs = new ArrayList<>();
 
+        System.out.println( ">>> HERE!" );
+
         // 1. metadata user-specific directory
         Optional<String> userFileDirectory = metaData.getUserFileDirectory(preferences.getUser());
         if (userFileDirectory.isPresent()) {
@@ -198,14 +200,25 @@ public class BibDatabaseContext {
 
         // 4. BIB file directory
         getDatabasePath().ifPresent(dbPath -> {
-            String parentDir = dbPath.getParent().toAbsolutePath().toString();
-            // Check if we should add it as primary file dir (first in the list) or not:
-            if (preferences.isBibLocationAsPrimary()) {
-                fileDirs.add(0, parentDir);
-            } else {
-                fileDirs.add(parentDir);
-            }
-        });
+                if( dbPath == null ) {
+                    System.err.println( "EEE>>> dbPath is null" );
+                } else {
+                    System.err.println( "EEE>>> dbPath is NOT null: " + dbPath );
+                }
+                assert dbPath != null : "dbPath is null";
+                assert dbPath.getParent() != null : "dbPath.getParent() is null";
+                assert dbPath.getParent().toAbsolutePath() != null : "dbPath.getParent().toAbsolutePath() is null";
+                assert dbPath.getParent().toAbsolutePath().toString() != null : "dbPath.getParent().toAbsolutePath().toString() is null";
+                assert preferences != null : "'preferences' is null";
+                assert fileDirs != null : "'fileDirs' is null";
+                String parentDir = dbPath.getParent().toAbsolutePath().toString();
+                // Check if we should add it as primary file dir (first in the list) or not:
+                if (preferences.isBibLocationAsPrimary()) {
+                    fileDirs.add(0, parentDir);
+                } else {
+                    fileDirs.add(parentDir);
+                }
+            });
 
         return fileDirs;
     }

--- a/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
+++ b/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
@@ -18,11 +18,10 @@ import static org.junit.Assert.assertTrue;
 public class BibDatabaseContextTest {
 
     private String currentWorkingDir;
+    private FileDirectoryPreferences preferences;
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
-
-    FileDirectoryPreferences preferences;
 
     @Before
     public void setUp() {

--- a/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
+++ b/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
@@ -2,6 +2,7 @@ package org.jabref.model.database;
 
 import java.io.File;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,7 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 public class BibDatabaseContextTest {
 
@@ -35,7 +36,8 @@ public class BibDatabaseContextTest {
         BibDatabaseContext dbContext = new BibDatabaseContext();
         dbContext.setDatabaseFile(new File("biblio.bib"));
         List<String> fileDirectories = dbContext.getFileDirectories( "file", preferences );
-        assertTrue(fileDirectories.get(0).equals(currentWorkingDir));
+        assertEquals(Collections.singletonList(currentWorkingDir),
+                fileDirectories);
     }
 
     @Test
@@ -44,7 +46,8 @@ public class BibDatabaseContextTest {
         BibDatabaseContext dbContext = new BibDatabaseContext();
         dbContext.setDatabaseFile(new File(dbDirectory + "/" + "biblio.bib"));
         List<String> fileDirectories = dbContext.getFileDirectories("file", preferences);
-        assertTrue(fileDirectories.get(0).equals(currentWorkingDir + "/" + dbDirectory));
+        assertEquals(Collections.singletonList(currentWorkingDir + "/" + dbDirectory),
+                fileDirectories);
     }
 
     @Test
@@ -53,7 +56,8 @@ public class BibDatabaseContextTest {
         BibDatabaseContext dbContext = new BibDatabaseContext();
         dbContext.setDatabaseFile(new File(dbDirectory + "/" + "biblio.bib"));
         List<String> fileDirectories = dbContext.getFileDirectories("file", preferences);
-        assertTrue(fileDirectories.get(0).equals(currentWorkingDir + "/" + dbDirectory));
+        assertEquals(Collections.singletonList(currentWorkingDir + "/" + dbDirectory),
+                fileDirectories);
     }
 
     @Test
@@ -62,6 +66,6 @@ public class BibDatabaseContextTest {
         BibDatabaseContext dbContext = new BibDatabaseContext();
         dbContext.setDatabaseFile(new File(dbDirectory + "/" + "biblio.bib"));
         List<String> fileDirectories = dbContext.getFileDirectories("file", preferences);
-        assertTrue(fileDirectories.get(0).equals(dbDirectory));
+        assertEquals(Collections.singletonList(dbDirectory), fileDirectories);
     }
 }

--- a/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
+++ b/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
@@ -2,6 +2,8 @@ package org.jabref.model.database;
 
 import java.util.List;
 import java.util.Map;
+import java.io.File;
+import java.nio.file.Paths;
 import java.util.HashMap;
 
 import org.jabref.model.metadata.FileDirectoryPreferences;
@@ -15,6 +17,8 @@ import static org.junit.Assert.assertTrue;
 
 public class BibDatabaseContextTest {
 
+    private String currentWorkingDir;
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
@@ -25,13 +29,41 @@ public class BibDatabaseContextTest {
         Map<String, String> mapFieldDirs = new HashMap<>();
         mapFieldDirs.put("pdf", "/home/saulius/jabref");
         preferences = new FileDirectoryPreferences("saulius", mapFieldDirs, true);
+        currentWorkingDir = Paths.get(System.getProperty("user.dir")).toString();
     }
 
     @Test
     public void getFileDirectoriesWithEmptyDbParent() {
         BibDatabaseContext dbContext = new BibDatabaseContext();
+        dbContext.setDatabaseFile(new File("biblio.bib"));
         List<String> fileDirectories = dbContext.getFileDirectories( "file", preferences );
-        assertTrue(fileDirectories.get(0).equals(""));
+        assertTrue(fileDirectories.get(0).equals(currentWorkingDir));
     }
 
+    @Test
+    public void getFileDirectoriesWithRelativeDbParent() {
+        String dbDirectory = "relative/subdir";
+        BibDatabaseContext dbContext = new BibDatabaseContext();
+        dbContext.setDatabaseFile(new File(dbDirectory + "/" + "biblio.bib"));
+        List<String> fileDirectories = dbContext.getFileDirectories("file", preferences);
+        assertTrue(fileDirectories.get(0).equals(currentWorkingDir + "/" + dbDirectory));
+    }
+
+    @Test
+    public void getFileDirectoriesWithRelativeDottedDbParent() {
+        String dbDirectory = "./relative/subdir";
+        BibDatabaseContext dbContext = new BibDatabaseContext();
+        dbContext.setDatabaseFile(new File(dbDirectory + "/" + "biblio.bib"));
+        List<String> fileDirectories = dbContext.getFileDirectories("file", preferences);
+        assertTrue(fileDirectories.get(0).equals(currentWorkingDir + "/" + dbDirectory));
+    }
+
+    @Test
+    public void getFileDirectoriesWithAbsoluteDbParent() {
+        String dbDirectory = "/absolute/subdir";
+        BibDatabaseContext dbContext = new BibDatabaseContext();
+        dbContext.setDatabaseFile(new File(dbDirectory + "/" + "biblio.bib"));
+        List<String> fileDirectories = dbContext.getFileDirectories("file", preferences);
+        assertTrue(fileDirectories.get(0).equals(dbDirectory));
+    }
 }

--- a/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
+++ b/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
@@ -1,0 +1,37 @@
+package org.jabref.model.database;
+
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+
+import org.jabref.model.metadata.FileDirectoryPreferences;
+
+import org.junit.Rule;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertTrue;
+
+public class BibDatabaseContextTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    FileDirectoryPreferences preferences;
+
+    @Before
+    public void setUp() {
+        Map<String, String> mapFieldDirs = new HashMap<>();
+        mapFieldDirs.put("pdf", "/home/saulius/jabref");
+        preferences = new FileDirectoryPreferences("saulius", mapFieldDirs, true);
+    }
+
+    @Test
+    public void getFileDirectoriesWithEmptyDbParent() {
+        BibDatabaseContext dbContext = new BibDatabaseContext();
+        List<String> fileDirectories = dbContext.getFileDirectories( "file", preferences );
+        assertTrue(fileDirectories.get(0).equals(""));
+    }
+
+}

--- a/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
+++ b/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
@@ -27,7 +27,6 @@ public class BibDatabaseContextTest {
     @Before
     public void setUp() {
         Map<String, String> mapFieldDirs = new HashMap<>();
-        mapFieldDirs.put("pdf", "/home/saulius/jabref");
         preferences = new FileDirectoryPreferences("saulius", mapFieldDirs, true);
         currentWorkingDir = Paths.get(System.getProperty("user.dir")).toString();
     }

--- a/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
+++ b/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
@@ -18,7 +18,20 @@ import static org.junit.Assert.assertEquals;
 
 public class BibDatabaseContextTest {
 
+    // The 'currentWorkingDir' variable is used to re-create the part
+    // of the JabRef internal state that we get when the 'jabref
+    // biblio.bib' command is invoked from a command line (on
+    // Unix/Linux, but I guess on Windows clones as well). In the
+    // above-mentioned command, the current working directory must be
+    // used as a 'biblio.bib' parent directory. Since the current
+    // working directory is different on various computers that invoke
+    // the test, we can not hard-code it into the test but must
+    // determine it at run-time:
     private String currentWorkingDir;
+
+    // Store the minimal preferences for the
+    // BibDatabaseContext.getFileDirectories(File,
+    // FileDirectoryPreferences) incocation:
     private FileDirectoryPreferences preferences;
 
     @Rule

--- a/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
+++ b/src/test/java/org/jabref/model/database/BibDatabaseContextTest.java
@@ -1,15 +1,15 @@
 package org.jabref.model.database;
 
-import java.util.List;
-import java.util.Map;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.jabref.model.metadata.FileDirectoryPreferences;
 
-import org.junit.Rule;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

Fixing issue  #2739: a check in the BibDatabaseContext.getFileDirectories(String, FileDirectoryPreferences) method is added (BibDatabaseContext.java:203) to make sure that "dbPath.getParent()" is not null before its toAbsolutePath() method is called. This fixes 'null pointer exception' when searching files for databases opened without explicit path, as in the CLI 'jabref bibliography.bib' command.

Asserts were added to make sure that dbPath.getParent() and other variables are not null before invoking methods.

- [ ] Change in CHANGELOG.md described -- internal bug fix, no functionality added -- CHANGELOG not changed.
- [x] Tests created for changes -- 1 test added to cover new code; 3 regression tests added to make sure old functionality works as before.
- [ ] Screenshots added (for bigger UI changes) -- no UI changes
- [x] Manually tested changed features in running JabRef -- manually tested on the LinuxMint 18.1 installation from the build/distributions/JabRef-4.0.0-dev.tar file.
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?) -- help pages need not be changed,
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`? -- no localisation changes.
