### PR TITLE
Add test for ordinals

### DIFF
--- a/src/main/java/org/jabref/model/strings/LatexToUnicodeAdapter.java
+++ b/src/main/java/org/jabref/model/strings/LatexToUnicodeAdapter.java
@@ -21,7 +21,7 @@ public class LatexToUnicodeAdapter {
         Objects.requireNonNull(inField);
 
         String toFormat = underscoreMatcher.matcher(inField).replaceAll(replacementChar);
-        toFormat = Normalizer.normalize(LaTeX2Unicode.convert(toFormat), Normalizer.Form.NFKC);
+        toFormat = Normalizer.normalize(LaTeX2Unicode.convert(toFormat), Normalizer.Form.NFC);
         return underscorePlaceholderMatcher.matcher(toFormat).replaceAll("_");
     }
 }

--- a/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -29,7 +29,7 @@ public class LatexToUnicodeFormatterTest {
     @Test
     public void testFormatTextit() {
         // See #1464
-        assertEquals("text", formatter.format("\\textit{text}"));
+        assertEquals("\uD835\uDC61\uD835\uDC52\uD835\uDC65\uD835\uDC61", formatter.format("\\textit{text}"));
     }
 
 
@@ -169,27 +169,27 @@ public class LatexToUnicodeFormatterTest {
 
     @Test
     public void testConversionOfOrdinal1st() {
-        assertEquals("1st", formatter.format("1\\textsuperscript{st}"));
+        assertEquals("1ˢᵗ", formatter.format("1\\textsuperscript{st}"));
     }
 
     @Test
     public void testConversionOfOrdinal2nd() {
-        assertEquals("2nd", formatter.format("2\\textsuperscript{nd}"));
+        assertEquals("2ⁿᵈ", formatter.format("2\\textsuperscript{nd}"));
     }
 
     @Test
     public void testConversionOfOrdinal3rd() {
-        assertEquals("3rd", formatter.format("3\\textsuperscript{rd}"));
+        assertEquals("3ʳᵈ", formatter.format("3\\textsuperscript{rd}"));
     }
 
     @Test
     public void testConversionOfOrdinal4th() {
-        assertEquals("4th", formatter.format("4\\textsuperscript{th}"));
+        assertEquals("4ᵗʰ", formatter.format("4\\textsuperscript{th}"));
     }
 
     @Test
     public void testConversionOfOrdinal9th() {
-        assertEquals("9th", formatter.format("9\\textsuperscript{th}"));
+        assertEquals("9ᵗʰ", formatter.format("9\\textsuperscript{th}"));
     }
 
 }

--- a/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/LatexToUnicodeFormatterTest.java
@@ -167,4 +167,29 @@ public class LatexToUnicodeFormatterTest {
         assertEquals("Lorem ipsum_(lorem ipsum)", formatter.format("Lorem ipsum_{lorem ipsum}"));
     }
 
+    @Test
+    public void testConversionOfOrdinal1st() {
+        assertEquals("1st", formatter.format("1\\textsuperscript{st}"));
+    }
+
+    @Test
+    public void testConversionOfOrdinal2nd() {
+        assertEquals("2nd", formatter.format("2\\textsuperscript{nd}"));
+    }
+
+    @Test
+    public void testConversionOfOrdinal3rd() {
+        assertEquals("3rd", formatter.format("3\\textsuperscript{rd}"));
+    }
+
+    @Test
+    public void testConversionOfOrdinal4th() {
+        assertEquals("4th", formatter.format("4\\textsuperscript{th}"));
+    }
+
+    @Test
+    public void testConversionOfOrdinal9th() {
+        assertEquals("9th", formatter.format("9\\textsuperscript{th}"));
+    }
+
 }


### PR DESCRIPTION
This is a follow up for https://github.com/JabRef/jabref/issues/2596 and https://github.com/JabRef/jabref/pull/2601. I'd like to test how I can reproduce the behavior of ordinals.

Can someone explain me, why I don't get Unicode as result here?

