### PR TITLE
Fixes #2766 If file is not found annotations might be null

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/FileAnnotationTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/FileAnnotationTab.java
@@ -127,7 +127,7 @@ class FileAnnotationTab extends JPanel {
      */
     private void updateShownAnnotations(List<FileAnnotation> annotations) {
         listModel.clear();
-        if (annotations.isEmpty()) {
+        if (annotations == null || annotations.isEmpty()) {
             listModel.addElement(new FileAnnotation("", LocalDateTime.now(), 0, Localization.lang("File has no attached annotations"), NONE, Optional.empty()));
         } else {
             Comparator<FileAnnotation> byPage = Comparator.comparingInt(FileAnnotation::getPage);


### PR DESCRIPTION
Still, the real reason is a missing file...