### PR TITLE
Do not log an exception if side pane was not found

### DIFF
--- a/src/main/java/org/jabref/gui/SidePaneManager.java
+++ b/src/main/java/org/jabref/gui/SidePaneManager.java
@@ -167,11 +167,11 @@ public class SidePaneManager {
                 Class<? extends SidePaneComponent> componentClass = (Class<? extends SidePaneComponent>) Class.forName(componentName);
                 preferredPositions.put(componentClass, Integer.parseInt(componentPositions.get(i)));
             } catch (ClassNotFoundException e) {
-                LOGGER.error("Following side pane could not be found: " + componentName, e);
+                LOGGER.debug("Following side pane could not be found: " + componentName, e);
             } catch (ClassCastException e) {
-                LOGGER.error("Following Class is no side pane: '" + componentName, e);
+                LOGGER.debug("Following Class is no side pane: '" + componentName, e);
             } catch (NumberFormatException e) {
-                LOGGER.info("Invalid number format for side pane component '" + componentName + "'.", e);
+                LOGGER.debug("Invalid number format for side pane component '" + componentName + "'.", e);
             }
         }
 


### PR DESCRIPTION
Some older versions had different names for the side pane components and their preferred sizes are still associated with these old names. Thus opening a newer JabRef always logged some errors, which only can be resolved by resetting the preferences. 
This PR changes the log level from error to debug since I don't think that the size of a side pane is that essential.

<!-- describe the changes you have made here: what, why, ... -->

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
