### PR TITLE
Fixes #2789 Add Referer to API call

### DIFF
--- a/src/main/java/org/jabref/gui/importer/fetcher/IEEEXploreFetcher.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/IEEEXploreFetcher.java
@@ -105,6 +105,7 @@ public class IEEEXploreFetcher implements EntryFetcher {
             //add request header
             dl.addHeader("Accept", "application/json");
             dl.addHeader("Content-Type", "application/json");
+            dl.addHeader("Referer", "http://ieeexplore.ieee.org/search/searchresult.jsp");
 
             // set post data
             dl.setPostData(postData);


### PR DESCRIPTION
See #2789.
> JabRef version 4.0.0-beta on Windows 10
>Steps to reproduce:
>Perform a web search using the "IEEEXplore" fetcher
>result is always "Invalid search term"


Please check if this works for you.
