### PR TITLE
Set eclipse line wrapping to maximum

### DIFF
--- a/eclipse.gradle
+++ b/eclipse.gradle
@@ -196,7 +196,7 @@ tasks.eclipse.doFirst {
         org.eclipse.jdt.core.formatter.comment.indent_root_tags=true
         org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags=insert
         org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter=do not insert
-        org.eclipse.jdt.core.formatter.comment.line_length=120
+        org.eclipse.jdt.core.formatter.comment.line_length=9999
         org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries=true
         org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries=true
         org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments=false


### PR DESCRIPTION
This changes the default line length from 120 to the maximum 9999, so long lines are no longer wrapped when running the formatter 