### PR TITLE
Removed maximal width of the numberColumn in the groups view

### DIFF
--- a/src/main/java/org/jabref/gui/groups/GroupTree.fxml
+++ b/src/main/java/org/jabref/gui/groups/GroupTree.fxml
@@ -15,7 +15,7 @@
         <TreeTableView fx:id="groupTree" layoutY="-7.0" prefHeight="600.0" prefWidth="250.0" styleClass="groupsPane">
             <columns>
                 <TreeTableColumn fx:id="mainColumn" prefWidth="150.0"/>
-                <TreeTableColumn fx:id="numberColumn" maxWidth="60.0" minWidth="40.0" prefWidth="50.0"
+                <TreeTableColumn fx:id="numberColumn" minWidth="40.0" prefWidth="50.0"
                                  styleClass="numberColumn"/>
                 <TreeTableColumn fx:id="disclosureNodeColumn" maxWidth="14.0" minWidth="14.0"
                                  styleClass="disclosureNodeColumn" text="Column X"/>


### PR DESCRIPTION

![5digitgroups_fixed](https://cloud.githubusercontent.com/assets/1254003/25701275/f877cb98-30cb-11e7-9906-877e4a19c4ca.png)
should be a quick fix for #2803. I'm not sure if there are side-effects, so please have a quick look @tobiasdiez 