### PR TITLE
Relaxed the regex to also match negative timezone formats when parsing pdf annotation dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Fixed
 - We fixed the IEEE Xplore web search functionality [#2789](https://github.com/JabRef/jabref/issues/2789)
 - We fixed an error in the CrossRef fetcher that occurred if one of the fetched entries had no title
+- We fixed a bug that only allowed parsing positive timezones from a FileAnnotation [#2839](https://github.com/JabRef/jabref/issues/22839)
+
 ### Removed
 
 

--- a/src/main/java/org/jabref/model/pdf/FileAnnotation.java
+++ b/src/main/java/org/jabref/model/pdf/FileAnnotation.java
@@ -12,7 +12,7 @@ public class FileAnnotation {
 
     private final static int ABBREVIATED_ANNOTATION_NAME_LENGTH = 45;
     private static final String DATE_TIME_STRING = "^D:\\d{14}$";
-    private static final String DATE_TIME_STRING_WITH_TIME_ZONE = "^D:\\d{14}\\+.+";
+    private static final String DATE_TIME_STRING_WITH_TIME_ZONE = "^D:\\d{14}.+";
     private static final String ANNOTATION_DATE_FORMAT = "yyyyMMddHHmmss";
 
     private final String author;

--- a/src/test/java/org/jabref/model/pdf/FileAnnotationTest.java
+++ b/src/test/java/org/jabref/model/pdf/FileAnnotationTest.java
@@ -1,0 +1,32 @@
+package org.jabref.model.pdf;
+
+import java.time.LocalDateTime;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class FileAnnotationTest {
+
+    @Test
+    public void testParseDateMinusBeforeTimezone() {
+        String dateString = "D:20170512224019-03'00'";
+        LocalDateTime date = FileAnnotation.extractModifiedTime(dateString);
+        assertEquals(LocalDateTime.of(2017, 05, 12, 22, 40, 19), date);
+    }
+
+    @Test
+    public void testParseDatePlusBeforeTimezone() {
+        String dateString = "D:20170512224019+03'00'";
+        LocalDateTime date = FileAnnotation.extractModifiedTime(dateString);
+        assertEquals(LocalDateTime.of(2017, 05, 12, 22, 40, 19), date);
+    }
+
+    @Test
+    public void testParseDateNoTimezone() {
+        String dateString = "D:20170512224019";
+        LocalDateTime date = FileAnnotation.extractModifiedTime(dateString);
+        assertEquals(LocalDateTime.of(2017, 05, 12, 22, 40, 19), date);
+    }
+}


### PR DESCRIPTION
quickfix; bonus: has tests.

- [x] Tests created for changes
