### PR TITLE
Add Local Maven repo as first lookup resource

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ install4j {
 
 
 repositories {
+    mavenLocal()
     jcenter()
     maven {
         url 'https://oss.sonatype.org/content/groups/public'


### PR DESCRIPTION
to avoid having duplicate libs in gradle and maven

Background story is: I have a big project which still uses maven and JabRef uses gradle. Previously libraries would be downloaded also if they already existed in a local repo. This avoids unnecessary space consumption. If no local libs are found, they are of course downloaded 


<!-- describe the changes you have made here: what, why, ... -->

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
