### PR TITLE
Adsurl to url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ## [Unreleased]
 
 ### Changed
+- We moved the `adsurl` field to `url` field when fetching with the ADS fetcher. 
 - We continued to improve the new groups interface:
   - You can now again select multiple groups (and a few related settings were added to the preferences) [#2786](https://github.com/JabRef/jabref/issues/2786).
   - We further improved performance of group operations, especially of the new filter feature [#2852](https://github.com/JabRef/jabref/issues/2852). 

--- a/src/main/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystem.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystem.java
@@ -158,6 +158,6 @@ public class AstrophysicsDataSystem implements IdBasedParserFetcher, SearchBased
         // Remove ADS note
         new FieldFormatterCleanup("adsnote", new ClearFormatter()).cleanup(entry);
         // Move adsurl to url field
-        new MoveFieldCleanup("adsurl","url").cleanup(entry);
+        new MoveFieldCleanup("adsurl", FieldName.URL).cleanup(entry);
     }
 }

--- a/src/main/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystem.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystem.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import org.jabref.logic.cleanup.MoveFieldCleanup;
 import org.jabref.logic.formatter.bibtexfields.ClearFormatter;
 import org.jabref.logic.formatter.bibtexfields.NormalizeNamesFormatter;
 import org.jabref.logic.formatter.bibtexfields.RemoveBracesFormatter;
@@ -154,8 +155,9 @@ public class AstrophysicsDataSystem implements IdBasedParserFetcher, SearchBased
         new FieldFormatterCleanup(FieldName.TITLE, new RemoveBracesFormatter()).cleanup(entry);
         new FieldFormatterCleanup(FieldName.AUTHOR, new NormalizeNamesFormatter()).cleanup(entry);
 
-        // Remove url to ADS page
+        // Remove ADS note
         new FieldFormatterCleanup("adsnote", new ClearFormatter()).cleanup(entry);
-        new FieldFormatterCleanup("adsurl", new ClearFormatter()).cleanup(entry);
+        // Move adsurl to url field
+        new MoveFieldCleanup("adsurl","url").cleanup(entry);
     }
 }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
This moves the `adsurl` field to the `url` field. The current ADS fetcher removes the field `adsurl`. The `adsurl` field is the only url given by the ADS database to *all* entry in the database. I think it is better to keep the url information rather than deleting it. It is more profitable when considering the copy command 'Edit - Copy BibTex key and link.'

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes (I have run `gradlew check` and there was no problem.)
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
