### PR TITLE
Implement #2785: resort groups using drag & drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We continued to improve the new groups interface:
   - You can now again select multiple groups (and a few related settings were added to the preferences) [#2786](https://github.com/JabRef/jabref/issues/2786).
   - We further improved performance of group operations, especially of the new filter feature [#2852](https://github.com/JabRef/jabref/issues/2852). 
+  - It is now possible to resort groups using drag & drop [#2785](https://github.com/JabRef/jabref/issues/2785).
 - The entry editor got a fresh coat of paint:
   - Homogenize the size of text fields.
   - The buttons were changed to icons.

--- a/src/main/java/org/jabref/gui/groups/DroppingMouseLocation.java
+++ b/src/main/java/org/jabref/gui/groups/DroppingMouseLocation.java
@@ -1,0 +1,10 @@
+package org.jabref.gui.groups;
+
+/**
+ * The mouse location within the cell when the dropping gesture occurs.
+ */
+enum DroppingMouseLocation {
+    BOTTOM,
+    CENTER,
+    TOP
+}

--- a/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
@@ -254,6 +254,51 @@ public class GroupNodeViewModel {
         //panel.getUndoManager().addEdit(new UndoableMoveGroup(this.groupsRoot, moveChange));
         //panel.markBaseChanged();
         //frame.output(Localization.lang("Moved group \"%0\".", node.getNode().getGroup().getName()));
+    }
 
+    public void moveTo(GroupTreeNode target, int targetIndex) {
+        getGroupNode().moveTo(target, targetIndex);
+    }
+
+    public Optional<GroupTreeNode> getParent() {
+        return groupNode.getParent();
+    }
+
+    public void draggedOn(GroupNodeViewModel target, DroppingMouseLocation mouseLocation) {
+        Optional<GroupTreeNode> targetParent = target.getParent();
+        if (targetParent.isPresent()) {
+            int targetIndex = target.getPositionInParent();
+
+            // In case we want to move an item in the same parent
+            // and the item is moved down, we need to adjust the target index
+            if (targetParent.equals(getParent())) {
+                int sourceIndex = this.getPositionInParent();
+                if (sourceIndex < targetIndex) {
+                    targetIndex--;
+                }
+            }
+
+            // Different actions depending on where the user releases the drop in the target row
+            // Bottom + top -> insert source row before / after this row
+            // Center -> add as child
+            switch (mouseLocation) {
+                case BOTTOM:
+                    this.moveTo(targetParent.get(), targetIndex + 1);
+                    break;
+                case CENTER:
+                    this.moveTo(target);
+                    break;
+                case TOP:
+                    this.moveTo(targetParent.get(), targetIndex);
+                    break;
+            }
+        } else {
+            // No parent = root -> just add
+            this.moveTo(target);
+        }
+    }
+
+    private int getPositionInParent() {
+        return groupNode.getPositionInParent();
     }
 }

--- a/src/main/java/org/jabref/gui/groups/GroupTree.css
+++ b/src/main/java/org/jabref/gui/groups/GroupTree.css
@@ -34,6 +34,24 @@
     -fx-font-size: 12px;
 }
 
+.tree-table-row-cell:dragOver-bottom {
+    -fx-border-color: #eea82f;
+    -fx-border-width: 0 0 2 0;
+    -fx-padding: 0 0 -2 0;
+}
+
+.tree-table-row-cell:dragOver-center {
+    -fx-border-color: #eea82f;
+    -fx-border-width: 2 2 2 2;
+    -fx-padding: -2 -2 -2 -2;
+}
+
+.tree-table-row-cell:dragOver-top {
+    -fx-border-color: #eea82f;
+    -fx-border-width: 2 0 0 0;
+    -fx-padding: -2 0 0 0;
+}
+
 .tree-table-row-cell:sub > .tree-table-cell {
     -fx-padding: 0.20em 0em 0.20em 0em;
 }

--- a/src/main/java/org/jabref/gui/util/RecursiveTreeItem.java
+++ b/src/main/java/org/jabref/gui/util/RecursiveTreeItem.java
@@ -70,28 +70,28 @@ public class RecursiveTreeItem<T> extends TreeItem<T> {
         children = new FilteredList<>(childrenFactory.call(value));
         children.predicateProperty().bind(Bindings.createObjectBinding(() -> this::showNode, filter));
 
-        children.forEach(this::addAsChild);
+        addAsChildren(children, 0);
 
         children.addListener((ListChangeListener<T>) change -> {
             while (change.next()) {
 
                 if (change.wasRemoved()) {
                     change.getRemoved().forEach(t-> {
-                        final List<TreeItem<T>> itemsToRemove = RecursiveTreeItem.this.getChildren().stream().filter(treeItem -> treeItem.getValue().equals(t)).collect(Collectors.toList());
-
-                        RecursiveTreeItem.this.getChildren().removeAll(itemsToRemove);
+                        final List<TreeItem<T>> itemsToRemove = getChildren().stream().filter(treeItem -> treeItem.getValue().equals(t)).collect(Collectors.toList());
+                        getChildren().removeAll(itemsToRemove);
                     });
                 }
 
                 if (change.wasAdded()) {
-                    change.getAddedSubList().forEach(this::addAsChild);
+                    addAsChildren(change.getAddedSubList(), change.getFrom());
                 }
             }
         });
     }
 
-    private boolean addAsChild(T child) {
-        return RecursiveTreeItem.this.getChildren().add(new RecursiveTreeItem<>(child, getGraphic(), childrenFactory, expandedProperty, filter));
+    private void addAsChildren(List<? extends T> children, int startIndex) {
+        List<RecursiveTreeItem<T>> treeItems = children.stream().map(child -> new RecursiveTreeItem<>(child, getGraphic(), childrenFactory, expandedProperty, filter)).collect(Collectors.toList());
+        getChildren().addAll(startIndex, treeItems);
     }
 
     private boolean showNode(T t) {

--- a/src/main/java/org/jabref/model/util/TreeCollector.java
+++ b/src/main/java/org/jabref/model/util/TreeCollector.java
@@ -40,7 +40,7 @@ public class TreeCollector<T> implements Collector<T, ObservableList<T>, Observa
     }
 
     public static <T extends TreeNode<T>> TreeCollector<T> mergeIntoTree(BiPredicate<T, T> equivalence) {
-        return new TreeCollector<T>(
+        return new TreeCollector<>(
                 TreeNode::getChildren,
                 (parent, child) -> child.moveTo(parent),
                 equivalence);

--- a/src/test/java/org/jabref/gui/groups/GroupNodeViewModelTest.java
+++ b/src/test/java/org/jabref/gui/groups/GroupNodeViewModelTest.java
@@ -1,5 +1,7 @@
 package org.jabref.gui.groups;
 
+import java.util.Arrays;
+
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
@@ -87,7 +89,71 @@ public class GroupNodeViewModelTest {
         assertEquals(expected, groupViewModel.getChildren());
     }
 
+    @Test
+    public void draggedOnTopOfGroupAddsBeforeIt() throws Exception {
+        GroupNodeViewModel rootViewModel = getViewModelForGroup(new WordKeywordGroup("root", GroupHierarchyType.INCLUDING, "keywords", "A", true, ',', true));
+        WordKeywordGroup groupA = new WordKeywordGroup("A", GroupHierarchyType.INCLUDING, "keywords", "A", true, ',', true);
+        WordKeywordGroup groupB = new WordKeywordGroup("B", GroupHierarchyType.INCLUDING, "keywords", "A > B", true, ',', true);
+        WordKeywordGroup groupC = new WordKeywordGroup("C", GroupHierarchyType.INCLUDING, "keywords", "A > B > B1", true, ',', true);
+        GroupNodeViewModel groupAViewModel = getViewModelForGroup(rootViewModel.addSubgroup(groupA));
+        GroupNodeViewModel groupBViewModel = getViewModelForGroup(rootViewModel.addSubgroup(groupB));
+        GroupNodeViewModel groupCViewModel = getViewModelForGroup(rootViewModel.addSubgroup(groupC));
+
+        groupCViewModel.draggedOn(groupBViewModel, DroppingMouseLocation.TOP);
+
+        assertEquals(Arrays.asList(groupAViewModel, groupCViewModel, groupBViewModel), rootViewModel.getChildren());
+    }
+
+    @Test
+    public void draggedOnBottomOfGroupAddsAfterIt() throws Exception {
+        GroupNodeViewModel rootViewModel = getViewModelForGroup(new WordKeywordGroup("root", GroupHierarchyType.INCLUDING, "keywords", "A", true, ',', true));
+        WordKeywordGroup groupA = new WordKeywordGroup("A", GroupHierarchyType.INCLUDING, "keywords", "A", true, ',', true);
+        WordKeywordGroup groupB = new WordKeywordGroup("B", GroupHierarchyType.INCLUDING, "keywords", "A > B", true, ',', true);
+        WordKeywordGroup groupC = new WordKeywordGroup("C", GroupHierarchyType.INCLUDING, "keywords", "A > B > B1", true, ',', true);
+        GroupNodeViewModel groupAViewModel = getViewModelForGroup(rootViewModel.addSubgroup(groupA));
+        GroupNodeViewModel groupBViewModel = getViewModelForGroup(rootViewModel.addSubgroup(groupB));
+        GroupNodeViewModel groupCViewModel = getViewModelForGroup(rootViewModel.addSubgroup(groupC));
+
+        groupCViewModel.draggedOn(groupAViewModel, DroppingMouseLocation.BOTTOM);
+
+        assertEquals(Arrays.asList(groupAViewModel, groupCViewModel, groupBViewModel), rootViewModel.getChildren());
+    }
+
+    @Test
+    public void draggedOnBottomOfGroupAddsAfterItWhenSourceGroupWasBefore() throws Exception {
+        GroupNodeViewModel rootViewModel = getViewModelForGroup(new WordKeywordGroup("root", GroupHierarchyType.INCLUDING, "keywords", "A", true, ',', true));
+        WordKeywordGroup groupA = new WordKeywordGroup("A", GroupHierarchyType.INCLUDING, "keywords", "A", true, ',', true);
+        WordKeywordGroup groupB = new WordKeywordGroup("B", GroupHierarchyType.INCLUDING, "keywords", "A > B", true, ',', true);
+        WordKeywordGroup groupC = new WordKeywordGroup("C", GroupHierarchyType.INCLUDING, "keywords", "A > B > B1", true, ',', true);
+        GroupNodeViewModel groupAViewModel = getViewModelForGroup(rootViewModel.addSubgroup(groupA));
+        GroupNodeViewModel groupBViewModel = getViewModelForGroup(rootViewModel.addSubgroup(groupB));
+        GroupNodeViewModel groupCViewModel = getViewModelForGroup(rootViewModel.addSubgroup(groupC));
+
+        groupAViewModel.draggedOn(groupBViewModel, DroppingMouseLocation.BOTTOM);
+
+        assertEquals(Arrays.asList(groupBViewModel, groupAViewModel, groupCViewModel), rootViewModel.getChildren());
+    }
+
+    @Test
+    public void draggedOnTopOfGroupAddsBeforeItWhenSourceGroupWasBefore() throws Exception {
+        GroupNodeViewModel rootViewModel = getViewModelForGroup(new WordKeywordGroup("root", GroupHierarchyType.INCLUDING, "keywords", "A", true, ',', true));
+        WordKeywordGroup groupA = new WordKeywordGroup("A", GroupHierarchyType.INCLUDING, "keywords", "A", true, ',', true);
+        WordKeywordGroup groupB = new WordKeywordGroup("B", GroupHierarchyType.INCLUDING, "keywords", "A > B", true, ',', true);
+        WordKeywordGroup groupC = new WordKeywordGroup("C", GroupHierarchyType.INCLUDING, "keywords", "A > B > B1", true, ',', true);
+        GroupNodeViewModel groupAViewModel = getViewModelForGroup(rootViewModel.addSubgroup(groupA));
+        GroupNodeViewModel groupBViewModel = getViewModelForGroup(rootViewModel.addSubgroup(groupB));
+        GroupNodeViewModel groupCViewModel = getViewModelForGroup(rootViewModel.addSubgroup(groupC));
+
+        groupAViewModel.draggedOn(groupCViewModel, DroppingMouseLocation.TOP);
+
+        assertEquals(Arrays.asList(groupBViewModel, groupAViewModel, groupCViewModel), rootViewModel.getChildren());
+    }
+
     private GroupNodeViewModel getViewModelForGroup(AbstractGroup group) {
+        return new GroupNodeViewModel(databaseContext, stateManager, taskExecutor, group);
+    }
+
+    private GroupNodeViewModel getViewModelForGroup(GroupTreeNode group) {
         return new GroupNodeViewModel(databaseContext, stateManager, taskExecutor, group);
     }
 }

--- a/src/test/java/org/jabref/model/TreeNodeTest.java
+++ b/src/test/java/org/jabref/model/TreeNodeTest.java
@@ -173,6 +173,36 @@ public class TreeNodeTest {
     }
 
     @Test
+    public void moveToInSameLevelWhenNodeWasBeforeTargetIndex() {
+        TreeNodeTestData.TreeNodeMock root = new TreeNodeTestData.TreeNodeMock();
+        TreeNodeTestData.TreeNodeMock child1 = new TreeNodeTestData.TreeNodeMock();
+        TreeNodeTestData.TreeNodeMock child2 = new TreeNodeTestData.TreeNodeMock();
+        TreeNodeTestData.TreeNodeMock child3 = new TreeNodeTestData.TreeNodeMock();
+        root.addChild(child1);
+        root.addChild(child2);
+        root.addChild(child3);
+
+        child1.moveTo(root, 1);
+
+        assertEquals(Arrays.asList(child2, child1, child3), root.getChildren());
+    }
+
+    @Test
+    public void moveToInSameLevelWhenNodeWasAfterTargetIndex() {
+        TreeNodeTestData.TreeNodeMock root = new TreeNodeTestData.TreeNodeMock();
+        TreeNodeTestData.TreeNodeMock child1 = new TreeNodeTestData.TreeNodeMock();
+        TreeNodeTestData.TreeNodeMock child2 = new TreeNodeTestData.TreeNodeMock();
+        TreeNodeTestData.TreeNodeMock child3 = new TreeNodeTestData.TreeNodeMock();
+        root.addChild(child1);
+        root.addChild(child2);
+        root.addChild(child3);
+
+        child3.moveTo(root, 1);
+
+        assertEquals(Arrays.asList(child1, child3, child2), root.getChildren());
+    }
+
+    @Test
     public void getPathFromRootInSimpleTree() {
         TreeNodeTestData.TreeNodeMock root = new TreeNodeTestData.TreeNodeMock();
         TreeNodeTestData.TreeNodeMock node = TreeNodeTestData.getNodeInSimpleTree(root);


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
With this PR it is now possible to resort groups using drag and drop.
When the user drags a group over the center of another one, then the target group is highlighted as follows
![image](https://cloud.githubusercontent.com/assets/5037600/26400032/79f291e0-407f-11e7-8c5f-a4036e950f20.png)
and the source group is added as a child. 

In contrast, when the user hovers over the bottom or top part of a group, then a line is added that indicates that the source group is added at this point (i.e. between Test 1 and Test 2 in this picture)
![image](https://cloud.githubusercontent.com/assets/5037600/26400066/93205328-407f-11e7-9714-7f87f0158565.png)

There are still some problems with the selection status after a drag and drop.

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
