### PR TITLE
Fix entry editor

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -80,7 +80,6 @@ import org.jabref.gui.undo.UndoableChangeType;
 import org.jabref.gui.undo.UndoableFieldChange;
 import org.jabref.gui.undo.UndoableKeyChange;
 import org.jabref.gui.undo.UndoableRemoveEntry;
-import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.gui.util.component.CheckBoxMessage;
 import org.jabref.gui.util.component.VerticalLabelUI;
 import org.jabref.logic.TypedBibEntry;
@@ -239,8 +238,6 @@ public class EntryEditor extends JPanel implements EntryContainer {
         if (Globals.prefs.getBoolean(JabRefPreferences.DEFAULT_SHOW_SOURCE)) {
             tabbed.setSelectedIndex(sourceIndex);
         }
-
-        DefaultTaskExecutor.runInJavaFXThread(() -> setEntry(entry));
     }
 
     private static String getSourceString(BibEntry entry, BibDatabaseMode type) throws IOException {
@@ -455,17 +452,6 @@ public class EntryEditor extends JPanel implements EntryContainer {
     @Override
     public BibEntry getEntry() {
         return entry;
-    }
-
-    /**
-     * Sets all the text areas according to the shown entry.
-     */
-    private void setEntry(BibEntry entry) {
-        for (Object tab : tabs) {
-            if (tab instanceof EntryEditorTab) {
-                ((EntryEditorTab) tab).setEntry(entry);
-            }
-        }
     }
 
     public BibDatabase getDatabase() {

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditorTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditorTab.java
@@ -19,7 +19,6 @@ import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
-import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
@@ -222,13 +221,7 @@ class EntryEditorTab {
             gridPane.getRowConstraints().add(rowExpand);
         }
 
-        ScrollPane scrollPane = new ScrollPane();
-        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
-        scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
-        scrollPane.setHmax(500);
-        scrollPane.setPrefHeight(100);
-        scrollPane.setContent(gridPane);
-        return scrollPane;
+        return gridPane;
     }
 
     private String getPrompt(String field) {

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditorTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditorTab.java
@@ -55,7 +55,6 @@ class EntryEditorTab {
     private final BasePanel basePanel;
     private FieldEditorFX activeField;
     private BibEntry entry;
-    private boolean updating;
 
 
     public EntryEditorTab(JabRefFrame frame, BasePanel basePanel, List<String> fields, EntryEditor parent,
@@ -155,6 +154,7 @@ class EntryEditorTab {
             */
 
             FieldEditorFX fieldEditor = FieldEditors.getForField(fieldName, Globals.taskExecutor, new FXDialogService(), Globals.journalAbbreviationLoader, Globals.prefs.getJournalAbbreviationPreferences(), Globals.prefs, bPanel.getBibDatabaseContext(), entry.getType());
+            fieldEditor.bindToEntry(entry);
             editors.put(fieldName, fieldEditor);
             /*
             // TODO: Reenable this
@@ -245,18 +245,6 @@ class EntryEditorTab {
         }
 
         return "";
-    }
-
-    public void setEntry(BibEntry entry) {
-        try {
-            updating = true;
-            for (FieldEditorFX editor : editors.values()) {
-                editor.bindToEntry(entry);
-            }
-            this.entry = entry;
-        } finally {
-            updating = false;
-        }
     }
 
     /**

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditorTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditorTab.java
@@ -19,6 +19,7 @@ import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
@@ -221,7 +222,13 @@ class EntryEditorTab {
             gridPane.getRowConstraints().add(rowExpand);
         }
 
-        return gridPane;
+        ScrollPane scrollPane = new ScrollPane();
+        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+        scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
+        scrollPane.setHmax(500);
+        scrollPane.setPrefHeight(100);
+        scrollPane.setContent(gridPane);
+        return scrollPane;
     }
 
     private String getPrompt(String field) {

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.fxml
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.fxml
@@ -8,7 +8,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIconView?>
 <fx:root xmlns:fx="http://javafx.com/fxml/1" type="HBox" xmlns="http://javafx.com/javafx/8.0.112">
-    <ListView fx:id="listView" prefHeight="0" HBox.hgrow="ALWAYS"/>
+    <ListView fx:id="listView" prefHeight="0" HBox.hgrow="ALWAYS" maxHeight="100"/>
     <Button onAction="#addNewFile"
             styleClass="flatButton">
         <graphic>

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.fieldeditors;
 
+import javafx.beans.binding.Bindings;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
@@ -38,7 +39,7 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
                 .withTooltip(LinkedFileViewModel::getDescription)
                 .withGraphic(LinkedFilesEditor::createFileDisplay);
         listView.setCellFactory(cellFactory);
-        listView.itemsProperty().bind(viewModel.filesProperty());
+        Bindings.bindContent(listView.itemsProperty().get(), viewModel.filesProperty());
     }
 
     private static Node createFileDisplay(LinkedFileViewModel linkedFile) {


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
Fixes #2843 and #2851.
This was a tricky bug: JavaFX creates empty dummy cells at the end of a list view. For some reason the list view for the linked files had an initial size of `1.7976931348623157E308` and, well, creating that many dummy cells takes a while (probably longer than the universe took to create humans) and eventually lead to a freeze of the JavaFX thread.
The fix was easy, just add `maxHeight="100"` and be happy (finally, after trying to debug the problem for ages).

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
