### PR TITLE
Fixes jacoco by excluding the fetcher tests from analysis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -290,7 +290,7 @@ tasks.withType(Test) {
 }
 
 task jacocoMerge(type: JacocoMerge) {
-    executionData test, fetcherTest, databaseTest
+    executionData test, databaseTest
 }
 
 jacocoTestReport {


### PR DESCRIPTION
Two months ago Codecov stopped working. I have identified the problem being the failing fetcher tests.
By removing these from the jacoco test suite, the reports are generated again solving the issue.
 