### PR TITLE
Fix DOI resolving by using https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We added integration of the Library of Congress catalog as a fetcher based on the [LCCN identifier](https://en.wikipedia.org/wiki/Library_of_Congress_Control_Number). [Feature request 636 in the forum](http://discourse.jabref.org/t/loc-marc-mods-connection/636)
 
 ### Fixed
-- We fixed the adding of a new entry from DOI which led to a connection error [#2879](https://github.com/JabRef/jabref/issues/2897)
+- We fixed the adding of a new entry from DOI which led to a connection error. The DOI resolution now uses HTTPS to protect the user's privacy [#2879](https://github.com/JabRef/jabref/issues/2897)
 - We fixed the IEEE Xplore web search functionality [#2789](https://github.com/JabRef/jabref/issues/2789)
 - We fixed an error in the CrossRef fetcher that occurred if one of the fetched entries had no title
 - We fixed an issue that prevented new entries to be automatically assigned to the currently selected group [#2783](https://github.com/JabRef/jabref/issues/2783).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We added integration of the Library of Congress catalog as a fetcher based on the [LCCN identifier](https://en.wikipedia.org/wiki/Library_of_Congress_Control_Number). [Feature request 636 in the forum](http://discourse.jabref.org/t/loc-marc-mods-connection/636)
 
 ### Fixed
+- We fixed the adding of a new entry from DOI which led to a connection error [#2879](https://github.com/JabRef/jabref/issues/2897)
 - We fixed the IEEE Xplore web search functionality [#2789](https://github.com/JabRef/jabref/issues/2789)
 - We fixed an error in the CrossRef fetcher that occurred if one of the fetched entries had no title
 - We fixed an issue that prevented new entries to be automatically assigned to the currently selected group [#2783](https://github.com/JabRef/jabref/issues/2783).

--- a/src/main/java/org/jabref/model/entry/identifier/DOI.java
+++ b/src/main/java/org/jabref/model/entry/identifier/DOI.java
@@ -21,7 +21,7 @@ public class DOI implements Identifier {
     private static final Log LOGGER = LogFactory.getLog(DOI.class);
 
     // DOI resolver
-    private static final URI RESOLVER = URI.create("http://doi.org");
+    private static final URI RESOLVER = URI.create("https://doi.org");
     // Regex
     // (see http://www.doi.org/doi_handbook/2_Numbering.html)
     private static final String DOI_EXP = ""

--- a/src/test/java/org/jabref/logic/layout/format/DOICheckTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/DOICheckTest.java
@@ -14,19 +14,19 @@ public class DOICheckTest {
         Assert.assertEquals("", lf.format(""));
         Assert.assertEquals(null, lf.format(null));
 
-        Assert.assertEquals("http://doi.org/10.1000/ISBN1-900512-44-0", lf.format("10.1000/ISBN1-900512-44-0"));
-        Assert.assertEquals("http://doi.org/10.1000/ISBN1-900512-44-0",
+        Assert.assertEquals("https://doi.org/10.1000/ISBN1-900512-44-0", lf.format("10.1000/ISBN1-900512-44-0"));
+        Assert.assertEquals("https://doi.org/10.1000/ISBN1-900512-44-0",
                 lf.format("http://dx.doi.org/10.1000/ISBN1-900512-44-0"));
 
-        Assert.assertEquals("http://doi.org/10.1000/ISBN1-900512-44-0",
+        Assert.assertEquals("https://doi.org/10.1000/ISBN1-900512-44-0",
                 lf.format("http://doi.acm.org/10.1000/ISBN1-900512-44-0"));
 
-        Assert.assertEquals("http://doi.org/10.1145/354401.354407",
+        Assert.assertEquals("https://doi.org/10.1145/354401.354407",
                 lf.format("http://doi.acm.org/10.1145/354401.354407"));
-        Assert.assertEquals("http://doi.org/10.1145/354401.354407", lf.format("10.1145/354401.354407"));
+        Assert.assertEquals("https://doi.org/10.1145/354401.354407", lf.format("10.1145/354401.354407"));
 
         // Works even when having a / at the front
-        Assert.assertEquals("http://doi.org/10.1145/354401.354407", lf.format("/10.1145/354401.354407"));
+        Assert.assertEquals("https://doi.org/10.1145/354401.354407", lf.format("/10.1145/354401.354407"));
 
         // Obviously a wrong doi, will not change anything.
         Assert.assertEquals("10", lf.format("10"));

--- a/src/test/java/org/jabref/model/entry/identifier/DOITest.java
+++ b/src/test/java/org/jabref/model/entry/identifier/DOITest.java
@@ -102,30 +102,30 @@ public class DOITest {
     public void correctlyEncodeDOIs() {
         // See http://www.doi.org/doi_handbook/2_Numbering.html#2.5.2.4
         // % -> (%25)
-        Assert.assertEquals("http://doi.org/10.1006/rwei.1999%25.0001",
-                new DOI("http://doi.org/10.1006/rwei.1999%25.0001").getURIAsASCIIString());
+        Assert.assertEquals("https://doi.org/10.1006/rwei.1999%25.0001",
+                new DOI("https://doi.org/10.1006/rwei.1999%25.0001").getURIAsASCIIString());
         // " -> (%22)
-        Assert.assertEquals("http://doi.org/10.1006/rwei.1999%22.0001",
-                new DOI("http://doi.org/10.1006/rwei.1999%22.0001").getURIAsASCIIString());
+        Assert.assertEquals("https://doi.org/10.1006/rwei.1999%22.0001",
+                new DOI("https://doi.org/10.1006/rwei.1999%22.0001").getURIAsASCIIString());
         // # -> (%23)
-        Assert.assertEquals("http://doi.org/10.1006/rwei.1999%23.0001",
-                new DOI("http://doi.org/10.1006/rwei.1999%23.0001").getURIAsASCIIString());
+        Assert.assertEquals("https://doi.org/10.1006/rwei.1999%23.0001",
+                new DOI("https://doi.org/10.1006/rwei.1999%23.0001").getURIAsASCIIString());
         // SPACE -> (%20)
-        Assert.assertEquals("http://doi.org/10.1006/rwei.1999%20.0001",
-                new DOI("http://doi.org/10.1006/rwei.1999%20.0001").getURIAsASCIIString());
+        Assert.assertEquals("https://doi.org/10.1006/rwei.1999%20.0001",
+                new DOI("https://doi.org/10.1006/rwei.1999%20.0001").getURIAsASCIIString());
         // ? -> (%3F)
-        Assert.assertEquals("http://doi.org/10.1006/rwei.1999%3F.0001",
-                new DOI("http://doi.org/10.1006/rwei.1999%3F.0001").getURIAsASCIIString());
+        Assert.assertEquals("https://doi.org/10.1006/rwei.1999%3F.0001",
+                new DOI("https://doi.org/10.1006/rwei.1999%3F.0001").getURIAsASCIIString());
     }
 
     @Test
     public void constructCorrectURLForDoi() {
         // add / to RESOLVER url if missing
-        Assert.assertEquals("http://doi.org/10.1006/jmbi.1998.2354",
+        Assert.assertEquals("https://doi.org/10.1006/jmbi.1998.2354",
                 new DOI("10.1006/jmbi.1998.2354").getURIAsASCIIString());
-        Assert.assertEquals("http://doi.org/10.1006/jmbi.1998.2354",
-                new DOI("http://doi.org/10.1006/jmbi.1998.2354").getURIAsASCIIString());
-        Assert.assertEquals("http://doi.org/10.1109/VLHCC.2004.20",
+        Assert.assertEquals("https://doi.org/10.1006/jmbi.1998.2354",
+                new DOI("https://doi.org/10.1006/jmbi.1998.2354").getURIAsASCIIString());
+        Assert.assertEquals("https://doi.org/10.1109/VLHCC.2004.20",
                 new DOI("doi:10.1109/VLHCC.2004.20").getURIAsASCIIString());
     }
 


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

I think this is an important issue with small code change.  @JabRef/developers  Should we do a fix for 3.8,2?

For 3.8.2 https://github.com/JabRef/jabref/blob/v3.8.2/src/main/java/net/sf/jabref/logic/util/DOI.java


- [X] Change in CHANGELOG.md described
- [X] Tests created for change
~~- [ ] Screenshots added (for bigger UI changes)~~
- [X] Manually tested changed features in running JabRef
~~- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org]~~(https://github.com/JabRef/help.jabref.org/issues)?)
~~- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?~~
