### PR TITLE
Abbreviate journal names in parallel

### DIFF
--- a/src/main/java/org/jabref/JabRefExecutorService.java
+++ b/src/main/java/org/jabref/JabRefExecutorService.java
@@ -2,6 +2,7 @@ package org.jabref;
 
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -10,6 +11,7 @@ import java.util.concurrent.Future;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 
 /**
  * Responsible for managing of all threads (except Swing threads) in JabRef
@@ -23,6 +25,7 @@ public class JabRefExecutorService implements Executor {
         thread.setName("JabRef CachedThreadPool");
         thread.setUncaughtExceptionHandler(new FallbackExceptionHandler());
         return thread;
+
     });
     private final ExecutorService lowPriorityExecutorService = Executors.newCachedThreadPool(r -> {
         Thread thread = new Thread(r);
@@ -60,6 +63,26 @@ public class JabRefExecutorService implements Executor {
                 // Ignored
             } catch (ExecutionException e) {
                 LOGGER.error("Problem executing command", e);
+            }
+        }
+    }
+
+    public boolean executeAndWait(Callable command) {
+        if (command == null) {
+            LOGGER.debug("Received null as command for execution");
+            return false;
+        }
+
+        Future<?> future = executorService.submit(command);
+        while (true) {
+            try {
+                future.get();
+                return true;
+            } catch (InterruptedException ignored) {
+                // Ignored
+            } catch (ExecutionException e) {
+                LOGGER.error("Problem executing command", e);
+                return false;
             }
         }
     }

--- a/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
+++ b/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
@@ -1,8 +1,11 @@
 package org.jabref.gui.journals;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import org.jabref.Globals;
+import org.jabref.JabRefExecutorService;
 import org.jabref.gui.BasePanel;
 import org.jabref.gui.undo.NamedCompound;
 import org.jabref.gui.worker.AbstractWorker;
@@ -42,12 +45,25 @@ public class AbbreviateAction extends AbstractWorker {
 
         NamedCompound ce = new NamedCompound(Localization.lang("Abbreviate journal names"));
         int count = 0;
+
+        List<Boolean> futures = new ArrayList<>();
         for (BibEntry entry : entries) {
-            for (String journalField : InternalBibtexFields.getJournalNameFields()) {
-                if (undoableAbbreviator.abbreviate(panel.getDatabase(), entry, journalField, ce)) {
-                    count++;
+            Callable<Boolean> callable = () -> {
+                for (String journalField : InternalBibtexFields.getJournalNameFields()) {
+                    if (undoableAbbreviator.abbreviate(panel.getDatabase(), entry, journalField, ce)) {
+                        return true;
+                    }
                 }
-            }
+
+                return false;
+            };
+            JabRefExecutorService.INSTANCE.executeAndWait(callable);
+            futures.add(JabRefExecutorService.INSTANCE.executeAndWait(callable));
+        }
+
+        for (Boolean future : futures) {
+            if (future)
+                count++;
         }
 
         if (count > 0) {


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

Made changes in the AbbreviateAction class to abbreviate journal names in parallel by splitting up the work among threads.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [X] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
