### PR TITLE
Better icon support for groups

### DIFF
--- a/src/main/java/org/jabref/gui/IconTheme.java
+++ b/src/main/java/org/jabref/gui/IconTheme.java
@@ -292,6 +292,14 @@ public class IconTheme {
             return new FontBasedIcon(this.unicode, this.color);
         }
 
+        public List<MaterialDesignIcon> getUnderlyingIcons() {
+            return icons;
+        }
+
+        public MaterialDesignIcon getUnderlyingIcon() {
+            return icons.get(0);
+        }
+
         public FontBasedIcon getSmallIcon() {
             return new FontBasedIcon(this.unicode, this.color, JabRefPreferences.getInstance().getInt(JabRefPreferences.ICON_SIZE_SMALL));
         }

--- a/src/main/java/org/jabref/gui/groups/GroupDialog.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialog.java
@@ -369,7 +369,7 @@ class GroupDialog extends JabRefDialog implements Dialog<AbstractGroup> {
                     // Ignore invalid color (we should probably notify the user instead...)
                 }
                 resultingGroup.setDescription(descriptionField.getText());
-                resultingGroup.setIconCode(iconField.getText());
+                resultingGroup.setIconName(iconField.getText());
 
                 dispose();
             } catch (IllegalArgumentException exception) {
@@ -401,7 +401,7 @@ class GroupDialog extends JabRefDialog implements Dialog<AbstractGroup> {
             nameField.setText(editedGroup.getName());
             colorField.setText(editedGroup.getColor().map(Color::toString).orElse(""));
             descriptionField.setText(editedGroup.getDescription().orElse(""));
-            iconField.setText(editedGroup.getIconCode().orElse(""));
+            iconField.setText(editedGroup.getIconName().orElse(""));
 
             if (editedGroup.getClass() == WordKeywordGroup.class) {
                 WordKeywordGroup group = (WordKeywordGroup) editedGroup;

--- a/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
@@ -167,7 +167,7 @@ public class GroupNodeViewModel {
         return "GroupNodeViewModel{" +
                 "displayName='" + displayName + '\'' +
                 ", isRoot=" + isRoot +
-                ", iconCode='" + getIconCode() + '\'' +
+                ", icon='" + getIcon() + '\'' +
                 ", children=" + children +
                 ", databaseContext=" + databaseContext +
                 ", groupNode=" + groupNode +
@@ -180,21 +180,14 @@ public class GroupNodeViewModel {
         return groupNode.hashCode();
     }
 
-    public String getIconCode() {
-        Optional<String> iconCode = groupNode.getGroup().getIconCode();
+    public MaterialDesignIcon getIcon() {
+        Optional<String> iconName = groupNode.getGroup().getIconName();
+        return iconName.flatMap(this::parseIcon)
+                .orElse(IconTheme.JabRefIcon.DEFAULT_GROUP_ICON.getUnderlyingIcon());
+    }
 
-        if (StringUtil.isBlank(iconCode)) {
-            return "";
-        }
-        if (iconCode.isPresent()) {
-            MaterialDesignIcon icon = EnumUtils.getEnum(MaterialDesignIcon.class, iconCode.get().toUpperCase(Locale.ENGLISH));
-            if (icon != null) {
-                return icon.unicode();
-            } else {
-                return iconCode.get();
-            }
-        }
-        return IconTheme.JabRefIcon.DEFAULT_GROUP_ICON.getCode();
+    private Optional<MaterialDesignIcon> parseIcon(String iconCode) {
+        return Optional.ofNullable(EnumUtils.getEnum(MaterialDesignIcon.class, iconCode.toUpperCase(Locale.ENGLISH)));
     }
 
     public ObservableList<GroupNodeViewModel> getChildren() {

--- a/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
@@ -178,7 +178,25 @@ public class GroupNodeViewModel {
     }
 
     public String getIconCode() {
+
         return groupNode.getGroup().getIconCode().orElse(IconTheme.JabRefIcon.DEFAULT_GROUP_ICON.getCode());
+        /*
+        Optional<String> iconCode = groupNode.getGroup().getIconCode();
+        
+        if (StringUtil.isBlank(iconCode)) {
+            return "";
+        }
+        if (iconCode.isPresent()) {
+            MaterialDesignIcon icon = EnumUtils.getEnum(MaterialDesignIcon.class, iconCode.get().toUpperCase(Locale.ENGLISH));
+            if (icon != null) {
+                return icon.unicode();
+            } else {
+                return iconCode.get();
+            }
+        }
+        
+        return IconTheme.JabRefIcon.DEFAULT_GROUP_ICON.getCode();
+        */
     }
 
     public ObservableList<GroupNodeViewModel> getChildren() {
@@ -241,7 +259,7 @@ public class GroupNodeViewModel {
         // TODO: we should also check isNodeDescendant
         boolean canDropOtherGroup = dragboard.hasContent(DragAndDropDataFormats.GROUP);
         boolean canDropEntries = dragboard.hasContent(DragAndDropDataFormats.ENTRIES)
-                && groupNode.getGroup() instanceof GroupEntryChanger;
+                && (groupNode.getGroup() instanceof GroupEntryChanger);
         return canDropOtherGroup || canDropEntries;
     }
 
@@ -282,15 +300,15 @@ public class GroupNodeViewModel {
             // Bottom + top -> insert source row before / after this row
             // Center -> add as child
             switch (mouseLocation) {
-                case BOTTOM:
-                    this.moveTo(targetParent.get(), targetIndex + 1);
-                    break;
-                case CENTER:
-                    this.moveTo(target);
-                    break;
-                case TOP:
-                    this.moveTo(targetParent.get(), targetIndex);
-                    break;
+            case BOTTOM:
+                this.moveTo(targetParent.get(), targetIndex + 1);
+                break;
+            case CENTER:
+                this.moveTo(target);
+                break;
+            case TOP:
+                this.moveTo(targetParent.get(), targetIndex);
+                break;
             }
         } else {
             // No parent = root -> just add

--- a/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupNodeViewModel.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.groups;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -33,6 +34,8 @@ import org.jabref.model.groups.GroupTreeNode;
 import org.jabref.model.strings.StringUtil;
 
 import com.google.common.eventbus.Subscribe;
+import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIcon;
+import org.apache.commons.lang3.EnumUtils;
 import org.fxmisc.easybind.EasyBind;
 
 public class GroupNodeViewModel {
@@ -178,11 +181,8 @@ public class GroupNodeViewModel {
     }
 
     public String getIconCode() {
-
-        return groupNode.getGroup().getIconCode().orElse(IconTheme.JabRefIcon.DEFAULT_GROUP_ICON.getCode());
-        /*
         Optional<String> iconCode = groupNode.getGroup().getIconCode();
-        
+
         if (StringUtil.isBlank(iconCode)) {
             return "";
         }
@@ -194,9 +194,7 @@ public class GroupNodeViewModel {
                 return iconCode.get();
             }
         }
-        
         return IconTheme.JabRefIcon.DEFAULT_GROUP_ICON.getCode();
-        */
     }
 
     public ObservableList<GroupNodeViewModel> getChildren() {
@@ -208,8 +206,8 @@ public class GroupNodeViewModel {
     }
 
     /**
-     * Gets invoked if an entry in the current database changes.
-     */
+    * Gets invoked if an entry in the current database changes.
+    */
     @Subscribe
     public void listen(@SuppressWarnings("unused") EntryEvent entryEvent) {
         calculateNumberOfMatches();

--- a/src/main/java/org/jabref/gui/groups/GroupTreeController.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeController.java
@@ -106,7 +106,7 @@ public class GroupTreeController extends AbstractController<GroupTreeViewModel> 
         mainColumn.setCellValueFactory(cellData -> cellData.getValue().valueProperty());
         mainColumn.setCellFactory(new ViewModelTreeTableCellFactory<GroupNodeViewModel, GroupNodeViewModel>()
                 .withText(GroupNodeViewModel::getDisplayName)
-                .withIcon(GroupNodeViewModel::getIconCode, GroupNodeViewModel::getColor)
+                .withIcon(GroupNodeViewModel::getIcon, GroupNodeViewModel::getColor)
                 .withTooltip(GroupNodeViewModel::getDescription));
 
         // Number of hits

--- a/src/main/java/org/jabref/gui/util/ViewModelTreeTableCellFactory.java
+++ b/src/main/java/org/jabref/gui/util/ViewModelTreeTableCellFactory.java
@@ -12,6 +12,9 @@ import javafx.util.Callback;
 
 import org.jabref.model.strings.StringUtil;
 
+import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIcon;
+import de.jensd.fx.glyphs.materialdesignicons.utils.MaterialDesignIconFactory;
+
 /**
  * Constructs a {@link TreeTableCell} based on the view model of the row and a bunch of specified converter methods.
  *
@@ -35,10 +38,9 @@ public class ViewModelTreeTableCellFactory<S, T> implements Callback<TreeTableCo
         return this;
     }
 
-    public ViewModelTreeTableCellFactory<S, T> withIcon(Callback<S, String> toIcon, Callback<S, Paint> toColor) {
+    public ViewModelTreeTableCellFactory<S, T> withIcon(Callback<S, MaterialDesignIcon> toIcon, Callback<S, Paint> toColor) {
         this.toGraphic = viewModel -> {
-            Text graphic = new Text(toIcon.call(viewModel));
-            graphic.getStyleClass().add("icon");
+            Text graphic = MaterialDesignIconFactory.get().createIcon(toIcon.call(viewModel));
             graphic.setFill(toColor.call(viewModel));
             return graphic;
         };

--- a/src/main/java/org/jabref/logic/exporter/GroupSerializer.java
+++ b/src/main/java/org/jabref/logic/exporter/GroupSerializer.java
@@ -82,7 +82,7 @@ public class GroupSerializer {
         builder.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
         builder.append(group.getColor().map(Color::toString).orElse(""));
         builder.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
-        builder.append(group.getIconCode().orElse(""));
+        builder.append(group.getIconName().orElse(""));
         builder.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);
         builder.append(group.getDescription().orElse(""));
         builder.append(MetadataSerializationConfiguration.GROUP_UNIT_SEPARATOR);

--- a/src/main/java/org/jabref/logic/groups/DefaultGroupsFactory.java
+++ b/src/main/java/org/jabref/logic/groups/DefaultGroupsFactory.java
@@ -14,7 +14,7 @@ public class DefaultGroupsFactory {
 
     public static AllEntriesGroup getAllEntriesGroup() {
         AllEntriesGroup group = new AllEntriesGroup(Localization.lang("All entries"));
-        group.setIconCode(ALL_ENTRIES_GROUP_DEFAULT_ICON.unicode());
+        group.setIconName(ALL_ENTRIES_GROUP_DEFAULT_ICON.name());
         return group;
     }
 }

--- a/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
+++ b/src/main/java/org/jabref/logic/importer/util/GroupsParser.java
@@ -248,7 +248,7 @@ public class GroupsParser {
         if (tokenizer.hasMoreTokens()) {
             group.setExpanded(Integer.parseInt(tokenizer.nextToken()) == 1);
             group.setColor(tokenizer.nextToken());
-            group.setIconCode(tokenizer.nextToken());
+            group.setIconName(tokenizer.nextToken());
             group.setDescription(tokenizer.nextToken());
         }
     }

--- a/src/main/java/org/jabref/model/groups/AbstractGroup.java
+++ b/src/main/java/org/jabref/model/groups/AbstractGroup.java
@@ -26,7 +26,7 @@ public abstract class AbstractGroup implements SearchMatcher {
     protected Optional<Color> color = Optional.empty();
     protected boolean isExpanded = true;
     protected Optional<String> description = Optional.empty();
-    protected Optional<String> iconCode = Optional.empty();
+    protected Optional<String> iconName = Optional.empty();
 
     protected AbstractGroup(String name, GroupHierarchyType context) {
         this.name = name;
@@ -41,7 +41,7 @@ public abstract class AbstractGroup implements SearchMatcher {
                 ", color=" + color +
                 ", isExpanded=" + isExpanded +
                 ", description=" + description +
-                ", iconCode=" + iconCode +
+                ", iconName=" + iconName +
                 '}';
     }
 
@@ -67,16 +67,16 @@ public abstract class AbstractGroup implements SearchMatcher {
         return color;
     }
 
+    public void setColor(Color color) {
+        this.color = Optional.of(color);
+    }
+
     public void setColor(String colorString) {
         if (StringUtil.isBlank(colorString)) {
             color = Optional.empty();
         } else {
             setColor(Color.valueOf(colorString));
         }
-    }
-
-    public void setColor(Color color) {
-        this.color = Optional.of(color);
     }
 
     public boolean isExpanded() {
@@ -95,13 +95,16 @@ public abstract class AbstractGroup implements SearchMatcher {
         this.description = Optional.of(description);
     }
 
-    public Optional<String> getIconCode() {
-        return iconCode;
+    public Optional<String> getIconName() {
+        return iconName;
     }
 
-    public void setIconCode(String iconCode) {
-        this.iconCode = Optional.of(iconCode);
-
+    public void setIconName(String iconName) {
+        if (StringUtil.isBlank(iconName)) {
+            this.iconName = Optional.empty();
+        } else {
+            this.iconName = Optional.of(iconName);
+        }
     }
 
     /**

--- a/src/main/java/org/jabref/model/groups/AbstractGroup.java
+++ b/src/main/java/org/jabref/model/groups/AbstractGroup.java
@@ -1,6 +1,7 @@
 package org.jabref.model.groups;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -9,6 +10,9 @@ import javafx.scene.paint.Color;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.search.SearchMatcher;
 import org.jabref.model.strings.StringUtil;
+
+import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIcon;
+import org.apache.commons.lang3.EnumUtils;
 
 /**
  * Base class for all groups.
@@ -27,6 +31,7 @@ public abstract class AbstractGroup implements SearchMatcher {
     protected boolean isExpanded = true;
     protected Optional<String> description = Optional.empty();
     protected Optional<String> iconCode = Optional.empty();
+    protected MaterialDesignIcon icon = null;
 
     protected AbstractGroup(String name, GroupHierarchyType context) {
         this.name = name;
@@ -96,11 +101,16 @@ public abstract class AbstractGroup implements SearchMatcher {
     }
 
     public Optional<String> getIconCode() {
+        if (icon != null) {
+            return Optional.of(icon.unicode());
+        }
         return iconCode;
     }
 
     public void setIconCode(String iconCode) {
         this.iconCode = Optional.of(iconCode);
+        this.icon = EnumUtils.getEnum(MaterialDesignIcon.class, iconCode.toUpperCase(Locale.ENGLISH));
+
     }
 
     /**

--- a/src/main/java/org/jabref/model/groups/AbstractGroup.java
+++ b/src/main/java/org/jabref/model/groups/AbstractGroup.java
@@ -1,7 +1,6 @@
 package org.jabref.model.groups;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -10,9 +9,6 @@ import javafx.scene.paint.Color;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.search.SearchMatcher;
 import org.jabref.model.strings.StringUtil;
-
-import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIcon;
-import org.apache.commons.lang3.EnumUtils;
 
 /**
  * Base class for all groups.
@@ -31,7 +27,6 @@ public abstract class AbstractGroup implements SearchMatcher {
     protected boolean isExpanded = true;
     protected Optional<String> description = Optional.empty();
     protected Optional<String> iconCode = Optional.empty();
-    protected MaterialDesignIcon icon = null;
 
     protected AbstractGroup(String name, GroupHierarchyType context) {
         this.name = name;
@@ -101,15 +96,11 @@ public abstract class AbstractGroup implements SearchMatcher {
     }
 
     public Optional<String> getIconCode() {
-        if (icon != null) {
-            return Optional.of(icon.unicode());
-        }
         return iconCode;
     }
 
     public void setIconCode(String iconCode) {
         this.iconCode = Optional.of(iconCode);
-        this.icon = EnumUtils.getEnum(MaterialDesignIcon.class, iconCode.toUpperCase(Locale.ENGLISH));
 
     }
 

--- a/src/main/java/org/jabref/model/groups/ExplicitGroup.java
+++ b/src/main/java/org/jabref/model/groups/ExplicitGroup.java
@@ -47,7 +47,7 @@ public class ExplicitGroup extends WordKeywordGroup {
         ExplicitGroup other = (ExplicitGroup) o;
         return Objects.equals(getName(), other.getName())
                 && Objects.equals(getHierarchicalContext(), other.getHierarchicalContext())
-                && Objects.equals(getIconCode(), other.getIconCode())
+                && Objects.equals(getIconName(), other.getIconName())
                 && Objects.equals(getDescription(), other.getDescription())
                 && Objects.equals(getColor(), other.getColor())
                 && Objects.equals(isExpanded(), other.isExpanded())
@@ -64,7 +64,7 @@ public class ExplicitGroup extends WordKeywordGroup {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, context, legacyEntryKeys, iconCode, color, description, isExpanded);
+        return Objects.hash(name, context, legacyEntryKeys, iconName, color, description, isExpanded);
     }
 
     @Override

--- a/src/test/java/org/jabref/logic/exporter/GroupSerializerTest.java
+++ b/src/test/java/org/jabref/logic/exporter/GroupSerializerTest.java
@@ -50,7 +50,7 @@ public class GroupSerializerTest {
     @Test
     public void serializeSingleExplicitGroupWithIconAndDescription() {
         ExplicitGroup group = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INDEPENDENT, ',');
-        group.setIconCode("test icon");
+        group.setIconName("test icon");
         group.setExpanded(true);
         group.setColor(Color.ALICEBLUE);
         group.setDescription("test description");

--- a/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/util/GroupsParserTest.java
@@ -63,9 +63,9 @@ public class GroupsParserTest {
     }
 
     @Test
-    public void fromStringParsesExplicitGroupWithIconAndDesrcitpion() throws Exception {
+    public void fromStringParsesExplicitGroupWithIconAndDescription() throws Exception {
         ExplicitGroup expected = new ExplicitGroup("myExplicitGroup", GroupHierarchyType.INDEPENDENT, ',');
-        expected.setIconCode("test icon");
+        expected.setIconName("test icon");
         expected.setExpanded(true);
         expected.setColor(Color.ALICEBLUE);
         expected.setDescription("test description");


### PR DESCRIPTION
Parse enum icon value from icon field by name (and apply to uppercase)
Only minor caveat: When you edit a group, you see only a unicode-box and not the name)


<!-- describe the changes you have made here: what, why, ... -->
No valid icon: (the illegal is just a simple string)



![groupsnovalidicon](https://user-images.githubusercontent.com/320228/27302746-9d4128b4-5538-11e7-8f17-a1646ff26d9f.PNG)

Valid icon name: `facebook`
![jabrefgroupwithicon](https://user-images.githubusercontent.com/320228/27302755-a84f8854-5538-11e7-8098-9d5ee400cbc5.PNG)

Icon Enum based on Material Design Icons v1.7.22

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
