### PR TITLE
Page prefix

### DIFF
--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -644,6 +644,8 @@ public class BibtexKeyPatternUtil {
                 }
             } else if ("firstpage".equals(val)) {
                 return firstPage(entry.getField(FieldName.PAGES).orElse(""));
+            } else if ("pageprefix".equals(val)) {
+                return Pageprefix(entry.getField(FieldName.PAGES).orElse(""));
             } else if ("lastpage".equals(val)) {
                 return lastPage(entry.getField(FieldName.PAGES).orElse(""));
             } else if ("title".equals(val)) {
@@ -1301,6 +1303,26 @@ public class BibtexKeyPatternUtil {
             return "";
         } else {
             return String.valueOf(result);
+        }
+    }
+
+    /**
+     * Return the non-digit prefix of pages
+     *
+     * @param pages
+     *            a pages string such as L42--111 or L7,41,73--97 or L43+
+     *
+     * @return the non-digit prefix of pages (like "L" of L7)
+     *         or "" if no non-digit prefix is found in the string
+     *
+     * @throws NullPointerException
+     *             if pages is null.
+     */
+    public static String Pageprefix(String pages) {
+        if (pages.matches("^\\D+.*$")) {
+            return (pages.split("\\d+"))[0];
+        } else {
+            return "";
         }
     }
 

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -645,7 +645,7 @@ public class BibtexKeyPatternUtil {
             } else if ("firstpage".equals(val)) {
                 return firstPage(entry.getField(FieldName.PAGES).orElse(""));
             } else if ("pageprefix".equals(val)) {
-                return Pageprefix(entry.getField(FieldName.PAGES).orElse(""));
+                return pagePrefix(entry.getField(FieldName.PAGES).orElse(""));
             } else if ("lastpage".equals(val)) {
                 return lastPage(entry.getField(FieldName.PAGES).orElse(""));
             } else if ("title".equals(val)) {
@@ -1318,7 +1318,7 @@ public class BibtexKeyPatternUtil {
      * @throws NullPointerException
      *             if pages is null.
      */
-    public static String Pageprefix(String pages) {
+    private static String pagePrefix(String pages) {
         if (pages.matches("^\\D+.*$")) {
             return (pages.split("\\d+"))[0];
         } else {

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -1318,7 +1318,7 @@ public class BibtexKeyPatternUtil {
      * @throws NullPointerException
      *             if pages is null.
      */
-    private static String pagePrefix(String pages) {
+    public static String pagePrefix(String pages) {
         if (pages.matches("^\\D+.*$")) {
             return (pages.split("\\d+"))[0];
         } else {

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtilTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtilTest.java
@@ -595,6 +595,28 @@ public class BibtexKeyPatternUtilTest {
         BibtexKeyPatternUtil.firstPage(null);
     }
 
+    public void testPagePrefix() {
+        assertEquals("L", BibtexKeyPatternUtil.pagePrefix("L7--27"));
+        assertEquals("L", BibtexKeyPatternUtil.pagePrefix("L--27"));
+        assertEquals("L", BibtexKeyPatternUtil.pagePrefix("L"));
+        assertEquals("L", BibtexKeyPatternUtil.pagePrefix("L42--111"));
+        assertEquals("L", BibtexKeyPatternUtil.pagePrefix("L7,L41,L73--97"));
+        assertEquals("L", BibtexKeyPatternUtil.pagePrefix("L41,L7,L73--97"));
+        assertEquals("L", BibtexKeyPatternUtil.pagePrefix("L43+"));
+        assertEquals("", BibtexKeyPatternUtil.pagePrefix("7--27"));
+        assertEquals("", BibtexKeyPatternUtil.pagePrefix("--27"));
+        assertEquals("", BibtexKeyPatternUtil.pagePrefix(""));
+        assertEquals("", BibtexKeyPatternUtil.pagePrefix("42--111"));
+        assertEquals("", BibtexKeyPatternUtil.pagePrefix("7,41,73--97"));
+        assertEquals("", BibtexKeyPatternUtil.pagePrefix("41,7,73--97"));
+        assertEquals("", BibtexKeyPatternUtil.pagePrefix("43+"));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testPagePrefixNull() {
+        BibtexKeyPatternUtil.pagePrefix(null);
+    }
+
     @Test
     public void testLastPage() {
 


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
This PR adds a new special field marker for BibTeX key generator [pageprefix]. It returns the non-digit prefix of `pages` (like "L" of L7) or "" if no non-digit prefix is found in `pages`. Some journals use non-digit letters for their pages, e.g. http://iopscience.iop.org/journal/2041-8205. (I have run `gradlew check` and there was no problem.)

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?