### PR TITLE
Open Urls for recommneded Articles in the browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Improved wording of "Show recommendations: into "Show 'Related Articles' tab" in the preferences
 - We added integration of the Library of Congress catalog as a fetcher based on the [LCCN identifier](https://en.wikipedia.org/wiki/Library_of_Congress_Control_Number). [Feature request 636 in the forum](http://discourse.jabref.org/t/loc-marc-mods-connection/636)
 - The integrity check for person names now also tests that the names are specified in one of the standard BibTeX formats.
+- Links in the Recommended Articles tab (Mr.DLib), when clicked, are now opened in the system's default browser. [2931](https://github.com/JabRef/jabref/issues/2931)
 
 ### Fixed
 - We fixed the adding of a new entry from DOI which led to a connection error. The DOI resolution now uses HTTPS to protect the user's privacy.[#2879](https://github.com/JabRef/jabref/issues/2897)

--- a/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
@@ -12,7 +12,7 @@ import javafx.scene.web.WebView;
 import org.jabref.Globals;
 import org.jabref.gui.IconTheme;
 import org.jabref.gui.util.BackgroundTask;
-import org.jabref.gui.util.HyperLinkListener;
+import org.jabref.gui.util.OpenHyperlinksInExternalBrowser;
 import org.jabref.logic.importer.fetcher.MrDLibFetcher;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
@@ -46,7 +46,7 @@ public class RelatedArticlesTab extends EntryEditorTab {
                 })
                 .executeWith(Globals.taskExecutor);
 
-        browser.getEngine().getLoadWorker().stateProperty().addListener(new HyperLinkListener(browser));
+        browser.getEngine().getLoadWorker().stateProperty().addListener(new OpenHyperlinksInExternalBrowser(browser));
 
         return root;
     }

--- a/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
@@ -12,6 +12,7 @@ import javafx.scene.web.WebView;
 import org.jabref.Globals;
 import org.jabref.gui.IconTheme;
 import org.jabref.gui.util.BackgroundTask;
+import org.jabref.gui.util.HyperLinkListener;
 import org.jabref.logic.importer.fetcher.MrDLibFetcher;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
@@ -44,6 +45,9 @@ public class RelatedArticlesTab extends EntryEditorTab {
                     browser.getEngine().loadContent(convertToHtml(relatedArticles));
                 })
                 .executeWith(Globals.taskExecutor);
+
+        browser.getEngine().getLoadWorker().stateProperty().addListener(new HyperLinkListener(browser));
+
         return root;
     }
 
@@ -68,7 +72,7 @@ public class RelatedArticlesTab extends EntryEditorTab {
         htmlContent.append("</ul>");
         htmlContent.append("<br><div style='margin-left: 5px'>");
         htmlContent.append(
-                "<a href='http://mr-dlib.org/information-for-users/information-about-mr-dlib-for-jabref-users/#'>");
+                "<a href='http://mr-dlib.org/information-for-users/information-about-mr-dlib-for-jabref-users/#' target=\"_blank\">");
         htmlContent.append(Localization.lang("What_is_Mr._DLib?"));
         htmlContent.append("</a></div>");
         htmlContent.append("</body></html>");

--- a/src/main/java/org/jabref/gui/util/HyperLinkListener.java
+++ b/src/main/java/org/jabref/gui/util/HyperLinkListener.java
@@ -1,0 +1,65 @@
+package org.jabref.gui.util;
+
+import java.io.IOException;
+
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.concurrent.Worker;
+import javafx.concurrent.Worker.State;
+import javafx.scene.web.WebView;
+
+import org.jabref.gui.desktop.JabRefDesktop;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.events.Event;
+import org.w3c.dom.events.EventListener;
+import org.w3c.dom.events.EventTarget;
+import org.w3c.dom.html.HTMLAnchorElement;
+
+/**
+ * A Hyperlink Click Listener for javafx.WebView to open links on click in the browser
+ *  Code adapted from: <a href="https://stackoverflow.com/a/33445383/">https://stackoverflow.com/a/33445383/</a>
+ */
+public class HyperLinkListener implements ChangeListener<Worker.State>, EventListener {
+
+    private static final Log LOGGER = LogFactory.getLog(HyperLinkListener.class);
+    private static final String CLICK_EVENT = "click";
+    private static final String ANCHOR_TAG = "a";
+
+    private final WebView webView;
+
+    public HyperLinkListener(WebView webView) {
+        this.webView = webView;
+    }
+
+    @Override
+    public void changed(ObservableValue<? extends State> observable, State oldValue, State newValue) {
+        if (State.SUCCEEDED.equals(newValue)) {
+            Document document = webView.getEngine().getDocument();
+            NodeList anchors = document.getElementsByTagName(ANCHOR_TAG);
+            for (int i = 0; i < anchors.getLength(); i++) {
+                Node node = anchors.item(i);
+                EventTarget eventTarget = (EventTarget) node;
+                eventTarget.addEventListener(CLICK_EVENT, this, false);
+            }
+        }
+    }
+
+    @Override
+    public void handleEvent(Event event) {
+        HTMLAnchorElement anchorElement = (HTMLAnchorElement) event.getCurrentTarget();
+        String href = anchorElement.getHref();
+
+        try {
+            JabRefDesktop.openBrowser(href);
+        } catch (IOException e) {
+            LOGGER.error(e);
+        }
+        event.preventDefault();
+    }
+
+}

--- a/src/main/java/org/jabref/gui/util/OpenHyperlinksInExternalBrowser.java
+++ b/src/main/java/org/jabref/gui/util/OpenHyperlinksInExternalBrowser.java
@@ -24,15 +24,15 @@ import org.w3c.dom.html.HTMLAnchorElement;
  * A Hyperlink Click Listener for javafx.WebView to open links on click in the browser
  *  Code adapted from: <a href="https://stackoverflow.com/a/33445383/">https://stackoverflow.com/a/33445383/</a>
  */
-public class HyperLinkListener implements ChangeListener<Worker.State>, EventListener {
+public class OpenHyperlinksInExternalBrowser implements ChangeListener<Worker.State>, EventListener {
 
-    private static final Log LOGGER = LogFactory.getLog(HyperLinkListener.class);
+    private static final Log LOGGER = LogFactory.getLog(OpenHyperlinksInExternalBrowser.class);
     private static final String CLICK_EVENT = "click";
     private static final String ANCHOR_TAG = "a";
 
     private final WebView webView;
 
-    public HyperLinkListener(WebView webView) {
+    public OpenHyperlinksInExternalBrowser(WebView webView) {
         this.webView = webView;
     }
 


### PR DESCRIPTION
Added a generic HyperLinkListener which opens any hyperlink in a new browser window.
By defeault javafx opens all urls in the same webview window
Fix #2931 

- [X] Change in CHANGELOG.md described
~~- [ ] Tests created for changes~~
~~- [ ] Screenshots added (for bigger UI changes)~~
- [X] Manually tested changed features in running JabRef
- [X] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
~~- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?~~
