### PR TITLE
Fix the function "Edit - Copy BibTeX key and link" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Links in the Recommended Articles tab (Mr.DLib), when clicked, are now opened in the system's default browser. [2931](https://github.com/JabRef/jabref/issues/2931)
 
 ### Fixed
+- We fixed the function "Edit - Copy BibTeX key and link" to pass a hyperlink rather than an HTML statement.
 - We fixed the adding of a new entry from DOI which led to a connection error. The DOI resolution now uses HTTPS to protect the user's privacy.[#2879](https://github.com/JabRef/jabref/issues/2897)
 - We fixed the IEEE Xplore web search functionality [#2789](https://github.com/JabRef/jabref/issues/2789)
 - We fixed an error in the CrossRef fetcher that occurred if one of the fetched entries had no title

--- a/src/main/java/org/jabref/gui/actions/CopyBibTeXKeyAndLinkAction.java
+++ b/src/main/java/org/jabref/gui/actions/CopyBibTeXKeyAndLinkAction.java
@@ -3,6 +3,9 @@ package org.jabref.gui.actions;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javafx.application.Platform;
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.ClipboardContent;
 import org.jabref.JabRefGUI;
 import org.jabref.gui.ClipBoardManager;
 import org.jabref.gui.maintable.MainTable;
@@ -44,8 +47,20 @@ public class CopyBibTeXKeyAndLinkAction implements BaseAction {
                 sb.append(OS.NEWLINE);
             }
 
-            ClipBoardManager clipboard = new ClipBoardManager();
-            clipboard.setClipboardContents(sb.toString());
+//            // This works only on Mac, not on Windows 10 and Ubuntu 16.04
+//            ClipBoardManager clipboard = new ClipBoardManager();
+//            clipboard.setTransferableClipboardContents(new HtmlTransferable(sb.toString()));
+
+            // This works on Mac and Windows 10, but not on Ubuntu 16.04
+            Platform.runLater(new Runnable() {
+                @Override
+                public void run() {
+                    final Clipboard clipboard = Clipboard.getSystemClipboard();
+                    final ClipboardContent content = new ClipboardContent();
+                    content.putHtml(sb.toString());
+                    clipboard.setContent(content);
+                }
+            });
 
             int copied = entriesWithKey.size();
             int toCopy = entries.size();

--- a/src/main/java/org/jabref/gui/actions/CopyBibTeXKeyAndLinkAction.java
+++ b/src/main/java/org/jabref/gui/actions/CopyBibTeXKeyAndLinkAction.java
@@ -6,8 +6,8 @@ import java.util.stream.Collectors;
 import javafx.application.Platform;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
+
 import org.jabref.JabRefGUI;
-import org.jabref.gui.ClipBoardManager;
 import org.jabref.gui.maintable.MainTable;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.OS;

--- a/src/main/java/org/jabref/gui/actions/CopyBibTeXKeyAndLinkAction.java
+++ b/src/main/java/org/jabref/gui/actions/CopyBibTeXKeyAndLinkAction.java
@@ -47,10 +47,6 @@ public class CopyBibTeXKeyAndLinkAction implements BaseAction {
                 sb.append(OS.NEWLINE);
             }
 
-//            // This works only on Mac, not on Windows 10 and Ubuntu 16.04
-//            ClipBoardManager clipboard = new ClipBoardManager();
-//            clipboard.setTransferableClipboardContents(new HtmlTransferable(sb.toString()));
-
             // This works on Mac and Windows 10, but not on Ubuntu 16.04
             Platform.runLater(new Runnable() {
                 @Override


### PR DESCRIPTION
This PR fixes the function "Edit - Copy BibTeX key and link"  to pass a hyperlink rather than an HTML statement. A copied hyperlink is more useful than an HTML statement in practice, like when writing emails. This is related with [#549](https://github.com/JabRef/jabref/issues/549).

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
