### PR TITLE
In JUnit tests, always state the expected value before the actual

### DIFF
--- a/src/test/java/org/jabref/gui/journals/ManageJournalAbbreviationsViewModelTest.java
+++ b/src/test/java/org/jabref/gui/journals/ManageJournalAbbreviationsViewModelTest.java
@@ -76,8 +76,8 @@ public class ManageJournalAbbreviationsViewModelTest {
 
     @Test
     public void testInitialHasNoFilesAndNoAbbreviations() {
-        Assert.assertEquals(viewModel.journalFilesProperty().size(), 0);
-        Assert.assertEquals(viewModel.abbreviationsProperty().size(), 0);
+        Assert.assertEquals(0, viewModel.journalFilesProperty().size());
+        Assert.assertEquals(0, viewModel.abbreviationsProperty().size());
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/citationstyle/CitationStyleTest.java
+++ b/src/test/java/org/jabref/logic/citationstyle/CitationStyleTest.java
@@ -24,7 +24,7 @@ public class CitationStyleTest {
                 "<i>BibTeX Journal</i>, vol. 34, no. 3, pp. 45–67, Jul. 2016.</div>\n" +
                 "  </div>\n";
 
-        Assert.assertEquals(citation, expected);
+        Assert.assertEquals(expected, citation);
     }
 
 }

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatterTest.java
@@ -111,7 +111,7 @@ public class NormalizeNamesFormatterTest {
 
     @Test
     public void formatExample() {
-        assertEquals(formatter.format(formatter.getExampleInput()), "Einstein, Albert and Turing, Alan");
+        assertEquals("Einstein, Albert and Turing, Alan", formatter.format(formatter.getExampleInput()));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fileformat/BiblioscapeImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BiblioscapeImporterTest.java
@@ -23,7 +23,7 @@ public class BiblioscapeImporterTest {
 
     @Test
     public void testGetFormatName() {
-        Assert.assertEquals(importer.getName(), "Biblioscape");
+        Assert.assertEquals("Biblioscape", importer.getName());
     }
 
     @Test
@@ -39,7 +39,7 @@ public class BiblioscapeImporterTest {
 
     @Test
     public void testGetCLIID() {
-        Assert.assertEquals(importer.getId(), "biblioscape");
+        Assert.assertEquals("biblioscape", importer.getId());
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fileformat/IsiImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/IsiImporterTest.java
@@ -39,12 +39,12 @@ public class IsiImporterTest {
 
     @Test
     public void testGetFormatName() {
-        assertEquals(importer.getName(), "ISI");
+        assertEquals("ISI", importer.getName());
     }
 
     @Test
     public void testGetCLIId() {
-        assertEquals(importer.getId(), "isi");
+        assertEquals("isi", importer.getId());
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fileformat/RISImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/RISImporterTest.java
@@ -24,12 +24,12 @@ public class RISImporterTest {
 
     @Test
     public void testGetFormatName() {
-        Assert.assertEquals(importer.getName(), "RIS");
+        Assert.assertEquals("RIS", importer.getName());
     }
 
     @Test
     public void testGetCLIId() {
-        Assert.assertEquals(importer.getId(), "ris");
+        Assert.assertEquals("ris", importer.getId());
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/util/DevelopmentStageTest.java
+++ b/src/test/java/org/jabref/logic/util/DevelopmentStageTest.java
@@ -13,25 +13,25 @@ public class DevelopmentStageTest {
         assertTrue(Version.DevelopmentStage.BETA.isMoreStableThan(Version.DevelopmentStage.ALPHA));
         assertTrue(Version.DevelopmentStage.STABLE.isMoreStableThan(Version.DevelopmentStage.BETA));
 
-        assertEquals("It seems that the development stages have been changed, please adjust the test",
-                Version.DevelopmentStage.values().length, 4);
+        assertEquals("It seems that the development stages have been changed, please adjust the test", 4,
+                Version.DevelopmentStage.values().length);
     }
 
     @Test
     public void parseStages() {
-        assertEquals(Version.DevelopmentStage.parse("-alpha"), Version.DevelopmentStage.ALPHA);
-        assertEquals(Version.DevelopmentStage.parse("-beta"), Version.DevelopmentStage.BETA);
-        assertEquals(Version.DevelopmentStage.parse(""), Version.DevelopmentStage.STABLE);
+        assertEquals(Version.DevelopmentStage.ALPHA, Version.DevelopmentStage.parse("-alpha"));
+        assertEquals(Version.DevelopmentStage.BETA, Version.DevelopmentStage.parse("-beta"));
+        assertEquals(Version.DevelopmentStage.STABLE, Version.DevelopmentStage.parse(""));
     }
 
     @Test
     public void parseNull() {
-        assertEquals(Version.DevelopmentStage.parse(null), Version.DevelopmentStage.UNKNOWN);
+        assertEquals(Version.DevelopmentStage.UNKNOWN, Version.DevelopmentStage.parse(null));
     }
 
     @Test
     public void parseUnknownString() {
-        assertEquals(Version.DevelopmentStage.parse("asdf"), Version.DevelopmentStage.UNKNOWN);
+        assertEquals(Version.DevelopmentStage.UNKNOWN, Version.DevelopmentStage.parse("asdf"));
     }
 
 }

--- a/src/test/java/org/jabref/model/database/BibDatabaseTest.java
+++ b/src/test/java/org/jabref/model/database/BibDatabaseTest.java
@@ -43,8 +43,8 @@ public class BibDatabaseTest {
     public void insertEntryAddsEntryToEntriesList() {
         BibEntry entry = new BibEntry();
         database.insertEntry(entry);
-        assertEquals(database.getEntries().size(), 1);
-        assertEquals(database.getEntryCount(), 1);
+        assertEquals(1, database.getEntries().size());
+        assertEquals(1, database.getEntryCount());
         assertEquals(entry, database.getEntries().get(0));
     }
 
@@ -100,8 +100,8 @@ public class BibDatabaseTest {
         BibtexString string = new BibtexString("DSP", "Digital Signal Processing");
         database.addString(string);
         assertFalse(database.hasNoStrings());
-        assertEquals(database.getStringKeySet().size(), 1);
-        assertEquals(database.getStringCount(), 1);
+        assertEquals(1, database.getStringKeySet().size());
+        assertEquals(1, database.getStringCount());
         assertTrue(database.getStringValues().contains(string));
         assertTrue(database.getStringKeySet().contains(string.getId()));
         assertEquals(string, database.getString(string.getId()));
@@ -113,8 +113,8 @@ public class BibDatabaseTest {
         database.addString(string);
         database.removeString(string.getId());
         assertTrue(database.hasNoStrings());
-        assertEquals(database.getStringKeySet().size(), 0);
-        assertEquals(database.getStringCount(), 0);
+        assertEquals(0, database.getStringKeySet().size());
+        assertEquals(0, database.getStringCount());
         assertFalse(database.getStringValues().contains(string));
         assertFalse(database.getStringKeySet().contains(string.getId()));
         assertNull(database.getString(string.getId()));
@@ -186,7 +186,7 @@ public class BibDatabaseTest {
         BibEntry entry = new BibEntry();
         entry.setCiteKey("AAA");
         database.insertEntry(entry);
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 1);
+        assertEquals(1, database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"));
     }
 
     @Test
@@ -197,7 +197,7 @@ public class BibDatabaseTest {
         entry = new BibEntry();
         entry.setCiteKey("AAA");
         database.insertEntry(entry);
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 2);
+        assertEquals(2, database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"));
     }
 
     @Test
@@ -209,7 +209,7 @@ public class BibDatabaseTest {
         entry.setCiteKey("AAA");
         database.insertEntry(entry);
         database.removeEntry(entry);
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 1);
+        assertEquals(1, database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"));
     }
 
     @Test
@@ -218,8 +218,8 @@ public class BibDatabaseTest {
         database.addString(string);
         string = new BibtexString("BBB", "#AAA#");
         database.addString(string);
-        assertEquals(database.resolveForStrings("#AAA#"), "AAA");
-        assertEquals(database.resolveForStrings("#BBB#"), "BBB");
+        assertEquals("AAA", database.resolveForStrings("#AAA#"));
+        assertEquals("BBB", database.resolveForStrings("#BBB#"));
     }
 
     @Test
@@ -232,29 +232,29 @@ public class BibDatabaseTest {
         database.addString(string);
         string = new BibtexString( "DDD", "#AAA#");
         database.addString(string);
-        assertEquals(database.resolveForStrings("#AAA#"), "AAA");
-        assertEquals(database.resolveForStrings("#BBB#"), "BBB");
-        assertEquals(database.resolveForStrings("#CCC#"), "CCC");
-        assertEquals(database.resolveForStrings("#DDD#"), "DDD");
+        assertEquals("AAA", database.resolveForStrings("#AAA#"));
+        assertEquals("BBB", database.resolveForStrings("#BBB#"));
+        assertEquals("CCC", database.resolveForStrings("#CCC#"));
+        assertEquals("DDD", database.resolveForStrings("#DDD#"));
     }
 
     @Test
     public void resolveForStringsMonth() {
-        assertEquals(database.resolveForStrings("#jan#"), "January");
+        assertEquals("January", database.resolveForStrings("#jan#"));
     }
 
     @Test
     public void resolveForStringsSurroundingContent() {
         BibtexString string = new BibtexString("AAA", "aaa");
         database.addString(string);
-        assertEquals(database.resolveForStrings("aa#AAA#AAA"), "aaaaaAAA");
+        assertEquals("aaaaaAAA", database.resolveForStrings("aa#AAA#AAA"));
     }
 
     @Test
     public void resolveForStringsOddHashMarkAtTheEnd() {
         BibtexString string = new BibtexString("AAA", "aaa");
         database.addString(string);
-        assertEquals(database.resolveForStrings("AAA#AAA#AAA#"), "AAAaaaAAA#");
+        assertEquals("AAAaaaAAA#", database.resolveForStrings("AAA#AAA#AAA#"));
     }
 
     @Test

--- a/src/test/java/org/jabref/model/database/DuplicationCheckerTest.java
+++ b/src/test/java/org/jabref/model/database/DuplicationCheckerTest.java
@@ -23,7 +23,7 @@ public class DuplicationCheckerTest {
         BibEntry entry = new BibEntry();
         entry.setCiteKey("AAA");
         database.insertEntry(entry);
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 1);
+        assertEquals(1, database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"));
     }
 
     @Test
@@ -31,9 +31,9 @@ public class DuplicationCheckerTest {
         BibEntry entry = new BibEntry();
         entry.setCiteKey("AAA");
         database.insertEntry(entry);
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 1);
+        assertEquals(1, database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"));
         database.removeEntry(entry);
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 0);
+        assertEquals(0, database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"));
     }
 
     @Test
@@ -41,10 +41,10 @@ public class DuplicationCheckerTest {
         BibEntry entry = new BibEntry();
         entry.setCiteKey("AAA");
         database.insertEntry(entry);
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 1);
+        assertEquals(1, database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"));
         entry.setCiteKey("BBB");
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 0);
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("BBB"), 1);
+        assertEquals(0, database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"));
+        assertEquals(1, database.getDuplicationChecker().getNumberOfKeyOccurrences("BBB"));
     }
 
 
@@ -56,12 +56,12 @@ public class DuplicationCheckerTest {
         BibEntry entry1 = new BibEntry();
         entry1.setCiteKey("BBB");
         database.insertEntry(entry1);
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 1);
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("BBB"), 1);
+        assertEquals(1, database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"));
+        assertEquals(1, database.getDuplicationChecker().getNumberOfKeyOccurrences("BBB"));
 
         entry1.setCiteKey("AAA");
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 2);
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("BBB"), 0);
+        assertEquals(2, database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"));
+        assertEquals(0, database.getDuplicationChecker().getNumberOfKeyOccurrences("BBB"));
     }
 
     @Test
@@ -75,16 +75,16 @@ public class DuplicationCheckerTest {
         BibEntry entry2 = new BibEntry();
         entry2.setCiteKey("AAA");
         database.insertEntry(entry2);
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 3);
+        assertEquals(3, database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"));
 
         database.removeEntry(entry2);
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 2);
+        assertEquals(2, database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"));
 
         database.removeEntry(entry1);
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 1);
+        assertEquals(1, database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"));
 
         database.removeEntry(entry0);
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 0);
+        assertEquals(0, database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"));
     }
 
     @Test
@@ -93,7 +93,7 @@ public class DuplicationCheckerTest {
         entry.setCiteKey("");
         database.insertEntry(entry);
 
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences(""), 0);
+        assertEquals(0, database.getDuplicationChecker().getNumberOfKeyOccurrences(""));
     }
 
     @Test
@@ -101,11 +101,11 @@ public class DuplicationCheckerTest {
         BibEntry entry = new BibEntry();
         entry.setCiteKey("AAA");
         database.insertEntry(entry);
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 1);
+        assertEquals(1, database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"));
 
         entry.setCiteKey("");
         database.removeEntry(entry);
-        assertEquals(database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"), 0);
+        assertEquals(0, database.getDuplicationChecker().getNumberOfKeyOccurrences("AAA"));
     }
 
 }


### PR DESCRIPTION
This is only an internal change, no functionality was actually changed. I thought it would be good to open a PR anyways to raise awareness.


