### PR TITLE
Fix Brazilian Portugese language loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed a bug which which could result in an exception when opening/saving files from/to a nonexistent directory [#2917](https://github.com/JabRef/jabref/issues/2917).
 - We fixed a bug where recursive RegExpBased search found a file in a subdirectory multiple times and non-recursive RegExpBased search erroneously found files in subdirectories.
 - We fixed a bug where new groups information was not stored on save [#2932](https://github.com/JabRef/jabref/issues/2932)
+- We fixed a bug where the language files for Brazilian Portugese could not be loaded and the GUI localization remained in English [#1128](https://github.com/JabRef/jabref/issues/1182)
 
 ### Removed
 

--- a/src/main/java/org/jabref/logic/l10n/Languages.java
+++ b/src/main/java/org/jabref/logic/l10n/Languages.java
@@ -41,17 +41,22 @@ public class Languages {
         Objects.requireNonNull(language);
 
         if (!LANGUAGES.values().contains(language)) {
-            if (!language.contains("_")) {
-                return Optional.empty();
-            }
-
-            String lang = language.split("_")[0];
-            if (!LANGUAGES.values().contains(lang)) {
-                return Optional.empty();
-            }
-            return Optional.of(new Locale(lang));
+            return Optional.empty();
+        }
+        //Very important to split languages like pt_BR into two parts, because otherwise the country would be threated lowercase
+        //and create problems in loading
+        String[] languageParts = language.split("_");
+        Locale locale;
+        if (languageParts.length == 1) {
+            locale = new Locale(languageParts[0]);
+        } else if (languageParts.length == 2) {
+            locale = new Locale(languageParts[0], languageParts[1]);
+        } else {
+            locale = Locale.ENGLISH;
         }
 
-        return Optional.of(new Locale(language));
+        return Optional.of(locale);
+
     }
+
 }

--- a/src/test/java/org/jabref/logic/l10n/LanguagesTest.java
+++ b/src/test/java/org/jabref/logic/l10n/LanguagesTest.java
@@ -6,8 +6,10 @@ import java.util.Optional;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class LanguagesTest {
+
     @Test
     public void convertKnownLanguageOnly() {
         assertEquals(Optional.of(new Locale("en")), Languages.convertToSupportedLocale("en"));
@@ -19,13 +21,25 @@ public class LanguagesTest {
     }
 
     @Test
+    public void convertKnownLanguageAndCountryCorrect() {
+        //Language and country code have to be separated see: https://stackoverflow.com/a/3318598
+        assertEquals(Optional.of(new Locale("pt", "BR")), Languages.convertToSupportedLocale("pt_BR"));
+    }
+
+    @Test
+    public void convertKnownLanguageAndCountryInCorrect() {
+        //Language and country code have to be separated see: https://stackoverflow.com/a/3318598
+        assertFalse(Optional.of(new Locale("pt_BR")).equals(Languages.convertToSupportedLocale("pt_BR")));
+    }
+
+    @Test
     public void convertKnownLanguageAndCountryOnly() {
-        assertEquals(Optional.of(new Locale("en")), Languages.convertToSupportedLocale("en_US"));
+        assertEquals(Optional.empty(), Languages.convertToSupportedLocale("en_US"));
     }
 
     @Test
     public void convertKnownLanguageAndUnknownCountry() {
-        assertEquals(Optional.of(new Locale("en")), Languages.convertToSupportedLocale("en_GB_unknownvariant"));
+        assertEquals(Optional.empty(), Languages.convertToSupportedLocale("en_GB_unknownvariant"));
     }
 
     @Test


### PR DESCRIPTION
Fix regression bug #1182
Pass language and country as separate args for Locale constructor

<!-- describe the changes you have made here: what, why, ... -->

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [x] If you changed the localization: Did you run `gradle localizationUpdate`?
