### PR TITLE
Remove <pre> tag from entries fetched using MathSciNet

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fetcher/MathSciNet.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/MathSciNet.java
@@ -108,5 +108,8 @@ public class MathSciNet implements SearchBasedParserFetcher, EntryBasedParserFet
         new MoveFieldCleanup("mrclass", FieldName.KEYWORDS).cleanup(entry);
         new FieldFormatterCleanup("mrreviewer", new ClearFormatter()).cleanup(entry);
         new FieldFormatterCleanup(FieldName.URL, new ClearFormatter()).cleanup(entry);
+
+        // Remove comments: MathSciNet prepends a <pre> html tag
+        entry.setCommentsBeforeEntry("");
     }
 }

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -214,15 +214,15 @@ public class BibEntry implements Cloneable {
     /**
      * Sets this entry's type.
      */
-    public void setType(EntryType type) {
-        this.setType(type.getName());
+    public void setType(String type) {
+        setType(type, EntryEventSource.LOCAL);
     }
 
     /**
      * Sets this entry's type.
      */
-    public void setType(String type) {
-        setType(type, EntryEventSource.LOCAL);
+    public void setType(EntryType type) {
+        this.setType(type.getName());
     }
 
     /**
@@ -700,7 +700,9 @@ public class BibEntry implements Cloneable {
             return false;
         }
         BibEntry entry = (BibEntry) o;
-        return Objects.equals(type, entry.type) && Objects.equals(fields, entry.fields);
+        return Objects.equals(type, entry.type)
+                && Objects.equals(fields, entry.fields)
+                && Objects.equals(commentsBeforeEntry, entry.commentsBeforeEntry);
     }
 
     @Override

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -214,15 +214,15 @@ public class BibEntry implements Cloneable {
     /**
      * Sets this entry's type.
      */
-    public void setType(String type) {
-        setType(type, EntryEventSource.LOCAL);
+    public void setType(EntryType type) {
+        this.setType(type.getName());
     }
 
     /**
      * Sets this entry's type.
      */
-    public void setType(EntryType type) {
-        this.setType(type.getName());
+    public void setType(String type) {
+        setType(type, EntryEventSource.LOCAL);
     }
 
     /**
@@ -605,7 +605,8 @@ public class BibEntry implements Cloneable {
     }
 
     public void setCommentsBeforeEntry(String parsedComments) {
-        this.commentsBeforeEntry = parsedComments;
+        // delete trailing whitespaces (between entry and text)
+        this.commentsBeforeEntry = REMOVE_TRAILING_WHITESPACE.matcher(parsedComments).replaceFirst("");
     }
 
     public boolean hasChanged() {
@@ -732,8 +733,7 @@ public class BibEntry implements Cloneable {
     * Returns user comments (arbitrary text before the entry), if they exist. If not, returns the empty String
      */
     public String getUserComments() {
-        // delete trailing whitespaces (between entry and text) from stored serialization
-        return REMOVE_TRAILING_WHITESPACE.matcher(commentsBeforeEntry).replaceFirst("");
+        return commentsBeforeEntry;
     }
 
     public List<ParsedEntryLink> getEntryLinkList(String fieldName, BibDatabase database) {

--- a/src/main/java/org/jabref/model/entry/CanonicalBibtexEntry.java
+++ b/src/main/java/org/jabref/model/entry/CanonicalBibtexEntry.java
@@ -19,19 +19,21 @@ public class CanonicalBibtexEntry {
      *
      * Serializes all fields, even the JabRef internal ones. Does NOT serialize "KEY_FIELD" as field, but as key
      */
-    public static String getCanonicalRepresentation(BibEntry e) {
+    public static String getCanonicalRepresentation(BibEntry entry) {
         StringBuilder sb = new StringBuilder();
 
+        sb.append(entry.getUserComments());
+
         // generate first line: type and bibtex key
-        String citeKey = e.getCiteKeyOptional().orElse("");
-        sb.append(String.format("@%s{%s,", e.getType().toLowerCase(Locale.US), citeKey)).append('\n');
+        String citeKey = entry.getCiteKeyOptional().orElse("");
+        sb.append(String.format("@%s{%s,", entry.getType().toLowerCase(Locale.US), citeKey)).append('\n');
 
         // we have to introduce a new Map as fields are stored case-sensitive in JabRef (see https://github.com/koppor/jabref/issues/45).
         Map<String, String> mapFieldToValue = new HashMap<>();
 
         // determine sorted fields -- all fields lower case
         SortedSet<String> sortedFields = new TreeSet<>();
-        for (Entry<String, String> field : e.getFieldMap().entrySet()) {
+        for (Entry<String, String> field : entry.getFieldMap().entrySet()) {
             String fieldName = field.getKey();
             String fieldValue = field.getValue();
             // JabRef stores the key in the field KEY_FIELD, which must not be serialized

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -346,7 +346,8 @@ public class BibtexParserTest {
 
         List<BibEntry> parsed = result.getDatabase().getEntries();
 
-        BibEntry expected = new BibEntry("article").withField(BibEntry.KEY_FIELD, "test")
+        BibEntry expected = new BibEntry("article")
+                .withField(BibEntry.KEY_FIELD, "test")
                 .withField("author", "Ed von T@st");
         expected.setCommentsBeforeEntry(comment);
 

--- a/src/test/resources/org/jabref/logic/importer/fileformat/MedlinePlainImporterStringOutOfBounds.bib
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/MedlinePlainImporterStringOutOfBounds.bib
@@ -1,5 +1,6 @@
 @misc{,
   title = {This is a test title}
-}, @misc{,
+}
+@misc{,
   title = {This is also a test title}
 }

--- a/src/test/resources/org/jabref/logic/importer/fileformat/RepecNepImporterTest2.bib
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/RepecNepImporterTest2.bib
@@ -1,5 +1,3 @@
-% Encoding: UTF-8
-
 @TechReport{
   author =        {M?ller,Rudolf and Perea,Andr?s and Wolf,Sascha},
   title =         {Weak Monotonicity and Bayes-Nash Incentive Compatibility},

--- a/src/test/resources/org/jabref/logic/importer/fileformat/RepecNepImporterTest3.bib
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/RepecNepImporterTest3.bib
@@ -1,5 +1,3 @@
-% Encoding: UTF-8
-
 @TechReport{,
   title = {Commercial Television and Voter Information},
   url =   {http://d.repec.org/n?u=RePEc:cla:levrem:784828000000000363&r=ict}

--- a/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTestScopus.bib
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/RisImporterTestScopus.bib
@@ -1,5 +1,3 @@
-% Encoding: UTF-8
-
 @Article{,
   author   = {Federico, S. and Grillo, A. and Herzog, W.},
   title    = {A transversely isotropic composite with a statistical distribution of spheroidal inclusions: A geometrical approach to overall properties},


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

The MathSciNet fetcher appended a "pre" html tag in front of the entry.
This is only a small change that I deem not to be important enough for a changelog entry.
Will merge as soon as tests pass.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
