### PR TITLE
Check for different editions in the duplicate check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We added integration of the Library of Congress catalog as a fetcher based on the [LCCN identifier](https://en.wikipedia.org/wiki/Library_of_Congress_Control_Number). [Feature request 636 in the forum](http://discourse.jabref.org/t/loc-marc-mods-connection/636)
 - The integrity check for person names now also tests that the names are specified in one of the standard BibTeX formats.
 - Links in the Recommended Articles tab (Mr.DLib), when clicked, are now opened in the system's default browser. [2931](https://github.com/JabRef/jabref/issues/2931)
+- We improved the duplicate checker such that different editions of the same publication are not marked as duplicates. [2960](https://github.com/JabRef/jabref/issues/2960)
 
 ### Fixed
 - We fixed the function "Edit - Copy BibTeX key and link" to pass a hyperlink rather than an HTML statement.

--- a/src/main/java/org/jabref/logic/bibtex/DuplicateCheck.java
+++ b/src/main/java/org/jabref/logic/bibtex/DuplicateCheck.java
@@ -26,7 +26,7 @@ import org.apache.commons.logging.LogFactory;
  * This class contains utility method for duplicate checking of entries.
  */
 public class DuplicateCheck {
-    public static double duplicateThreshold = 0.75; // The overall threshold to signal a duplicate pair
+    private static final double duplicateThreshold = 0.75; // The overall threshold to signal a duplicate pair
 
     private static final Log LOGGER = LogFactory.getLog(DuplicateCheck.class);
     /*
@@ -54,7 +54,8 @@ public class DuplicateCheck {
         DuplicateCheck.FIELD_WEIGHTS.put(FieldName.JOURNAL, 2.);
     }
 
-    private DuplicateCheck() { }
+    private DuplicateCheck() {
+    }
 
     /**
      * Checks if the two entries represent the same publication.
@@ -64,13 +65,16 @@ public class DuplicateCheck {
      * @return boolean
      */
     public static boolean isDuplicate(BibEntry one, BibEntry two, BibDatabaseMode bibDatabaseMode) {
-        // same identifier
-        if (hasSameIdentifier(one, two)) {
+        if (haveSameIdentifier(one, two)) {
             return true;
         }
 
         // same entry type
         if (!one.getType().equals(two.getType())) {
+            return false;
+        }
+
+        if (haveDifferentEditions(one, two)) {
             return false;
         }
 
@@ -98,7 +102,16 @@ public class DuplicateCheck {
         return req[0] >= DuplicateCheck.duplicateThreshold;
     }
 
-    private static boolean hasSameIdentifier(BibEntry one, BibEntry two) {
+    private static boolean haveDifferentEditions(BibEntry one, BibEntry two) {
+        if (one.getField(FieldName.EDITION).isPresent() && two.getField(FieldName.EDITION).isPresent()) {
+            if (!one.getField(FieldName.EDITION).get().equals(two.getField(FieldName.EDITION).get())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean haveSameIdentifier(BibEntry one, BibEntry two) {
         for (String name : FieldName.getIdentifierFieldNames()) {
             if (one.getField(name).isPresent() && one.getField(name).equals(two.getField(name))) {
                 return true;
@@ -112,11 +125,7 @@ public class DuplicateCheck {
         double totWeights = 0.;
         for (String field : fields) {
             double weight;
-            if (DuplicateCheck.FIELD_WEIGHTS.containsKey(field)) {
-                weight = DuplicateCheck.FIELD_WEIGHTS.get(field);
-            } else {
-                weight = 1.0;
-            }
+            weight = DuplicateCheck.FIELD_WEIGHTS.getOrDefault(field, 1.0);
             totWeights += weight;
             int result = DuplicateCheck.compareSingleField(field, one, two);
             if (result == EQUAL) {
@@ -128,7 +137,7 @@ public class DuplicateCheck {
         if (totWeights > 0) {
             return new double[]{res / totWeights, totWeights};
         }
-        return new double[] {0.5, 0.0};
+        return new double[]{0.5, 0.0};
     }
 
     private static int compareSingleField(String field, BibEntry one, BibEntry two) {
@@ -218,7 +227,7 @@ public class DuplicateCheck {
      *
      * @param database The database to search.
      * @param entry    The entry of which we are looking for duplicates.
-     * @return The first duplicate entry found. null if no duplicates are found.
+     * @return The first duplicate entry found. Empty Optional if no duplicates are found.
      */
     public static Optional<BibEntry> containsDuplicate(BibDatabase database, BibEntry entry, BibDatabaseMode bibDatabaseMode) {
         for (BibEntry other : database.getEntries()) {
@@ -232,8 +241,8 @@ public class DuplicateCheck {
     /**
      * Compare two strings on the basis of word-by-word correlation analysis.
      *
-     * @param s1       The first string
-     * @param s2       The second string
+     * @param s1 The first string
+     * @param s2 The second string
      * @return a value in the interval [0, 1] indicating the degree of match.
      */
     public static double correlateByWords(String s1, String s2) {
@@ -252,17 +261,17 @@ public class DuplicateCheck {
     }
 
 
-    /**
+    /*
      * Calculates the similarity (a number within 0 and 1) between two strings.
      * http://stackoverflow.com/questions/955110/similarity-string-comparison-in-java
      */
-    private static double similarity(String s1, String s2) {
-        String longer = s1;
-        String shorter = s2;
+    private static double similarity(String first, String second) {
+        String longer = first;
+        String shorter = second;
 
-        if (s1.length() < s2.length()) {
-            longer = s2;
-            shorter = s1;
+        if (first.length() < second.length()) {
+            longer = second;
+            shorter = first;
         }
 
         int longerLength = longer.length();

--- a/src/main/java/org/jabref/logic/bibtex/DuplicateCheck.java
+++ b/src/main/java/org/jabref/logic/bibtex/DuplicateCheck.java
@@ -26,7 +26,7 @@ import org.apache.commons.logging.LogFactory;
  * This class contains utility method for duplicate checking of entries.
  */
 public class DuplicateCheck {
-    private static final double duplicateThreshold = 0.75; // The overall threshold to signal a duplicate pair
+    private static final double DUPLICATE_THRESHOLD = 0.75; // The overall threshold to signal a duplicate pair
 
     private static final Log LOGGER = LogFactory.getLog(DuplicateCheck.class);
     /*
@@ -88,18 +88,18 @@ public class DuplicateCheck {
             req = DuplicateCheck.compareFieldSet(var, one, two);
         }
 
-        if (Math.abs(req[0] - DuplicateCheck.duplicateThreshold) > DuplicateCheck.DOUBT_RANGE) {
+        if (Math.abs(req[0] - DuplicateCheck.DUPLICATE_THRESHOLD) > DuplicateCheck.DOUBT_RANGE) {
             // Far from the threshold value, so we base our decision on the req. fields only
-            return req[0] >= DuplicateCheck.duplicateThreshold;
+            return req[0] >= DuplicateCheck.DUPLICATE_THRESHOLD;
         }
         // Close to the threshold value, so we take a look at the optional fields, if any:
         List<String> optionalFields = type.getOptionalFields();
         if (optionalFields != null) {
             double[] opt = DuplicateCheck.compareFieldSet(optionalFields, one, two);
             double totValue = ((DuplicateCheck.REQUIRED_WEIGHT * req[0] * req[1]) + (opt[0] * opt[1])) / ((req[1] * DuplicateCheck.REQUIRED_WEIGHT) + opt[1]);
-            return totValue >= DuplicateCheck.duplicateThreshold;
+            return totValue >= DuplicateCheck.DUPLICATE_THRESHOLD;
         }
-        return req[0] >= DuplicateCheck.duplicateThreshold;
+        return req[0] >= DuplicateCheck.DUPLICATE_THRESHOLD;
     }
 
     private static boolean haveDifferentEditions(BibEntry one, BibEntry two) {

--- a/src/test/java/org/jabref/logic/bibtex/DuplicateCheckTest.java
+++ b/src/test/java/org/jabref/logic/bibtex/DuplicateCheckTest.java
@@ -142,4 +142,83 @@ public class DuplicateCheckTest {
         assertTrue(DuplicateCheck.isDuplicate(simpleArticle, duplicateWithDifferentType, BibDatabaseMode.BIBTEX));
     }
 
+    @Test
+    public void twoBooksWithDifferentEditionsAreNotDuplicates() {
+        BibEntry editionOne = new BibEntry(BibtexEntryTypes.BOOK.getName());
+        editionOne.setField(FieldName.TITLE, "Effective Java");
+        editionOne.setField(FieldName.AUTHOR, "Bloch, Joshua");
+        editionOne.setField(FieldName.PUBLISHER, "Prentice Hall");
+        editionOne.setField(FieldName.DATE, "2001");
+        editionOne.setField(FieldName.EDITION, "1");
+
+        BibEntry editionTwo = new BibEntry(BibtexEntryTypes.BOOK.getName());
+        editionTwo.setField(FieldName.TITLE, "Effective Java");
+        editionTwo.setField(FieldName.AUTHOR, "Bloch, Joshua");
+        editionTwo.setField(FieldName.PUBLISHER, "Prentice Hall");
+        editionTwo.setField(FieldName.DATE, "2008");
+        editionTwo.setField(FieldName.EDITION, "2");
+
+        assertFalse(DuplicateCheck.isDuplicate(editionOne, editionTwo, BibDatabaseMode.BIBTEX));
+    }
+
+    @Test
+    public void sameBooksWithMissingEditionAreDuplicates() {
+        BibEntry editionOne = new BibEntry(BibtexEntryTypes.BOOK.getName());
+        editionOne.setField(FieldName.TITLE, "Effective Java");
+        editionOne.setField(FieldName.AUTHOR, "Bloch, Joshua");
+        editionOne.setField(FieldName.PUBLISHER, "Prentice Hall");
+        editionOne.setField(FieldName.DATE, "2001");
+
+        BibEntry editionTwo = new BibEntry(BibtexEntryTypes.BOOK.getName());
+        editionTwo.setField(FieldName.TITLE, "Effective Java");
+        editionTwo.setField(FieldName.AUTHOR, "Bloch, Joshua");
+        editionTwo.setField(FieldName.PUBLISHER, "Prentice Hall");
+        editionTwo.setField(FieldName.DATE, "2008");
+
+        assertTrue(DuplicateCheck.isDuplicate(editionOne, editionTwo, BibDatabaseMode.BIBTEX));
+    }
+
+    @Test
+    public void sameBooksWithPartiallyMissingEditionAreDuplicates() {
+        BibEntry editionOne = new BibEntry(BibtexEntryTypes.BOOK.getName());
+        editionOne.setField(FieldName.TITLE, "Effective Java");
+        editionOne.setField(FieldName.AUTHOR, "Bloch, Joshua");
+        editionOne.setField(FieldName.PUBLISHER, "Prentice Hall");
+        editionOne.setField(FieldName.DATE, "2001");
+
+        BibEntry editionTwo = new BibEntry(BibtexEntryTypes.BOOK.getName());
+        editionTwo.setField(FieldName.TITLE, "Effective Java");
+        editionTwo.setField(FieldName.AUTHOR, "Bloch, Joshua");
+        editionTwo.setField(FieldName.PUBLISHER, "Prentice Hall");
+        editionTwo.setField(FieldName.DATE, "2008");
+        editionTwo.setField(FieldName.EDITION, "2");
+
+        assertTrue(DuplicateCheck.isDuplicate(editionOne, editionTwo, BibDatabaseMode.BIBTEX));
+    }
+
+    @Test
+    public void sameBooksWithDifferentEditionsAreNotDuplicates() {
+        BibEntry editionTwo = new BibEntry(BibtexEntryTypes.BOOK.getName());
+        editionTwo.setCiteKey("Sutton17reinfLrnIntroBook");
+        editionTwo.setField(FieldName.TITLE, "Reinforcement learning:An introduction");
+        editionTwo.setField(FieldName.PUBLISHER, "MIT Press");
+        editionTwo.setField(FieldName.YEAR, "2017");
+        editionTwo.setField(FieldName.AUTHOR, "Sutton, Richard S and Barto, Andrew G");
+        editionTwo.setField(FieldName.ADDRESS, "Cambridge, MA.USA");
+        editionTwo.setField(FieldName.EDITION, "Second");
+        editionTwo.setField(FieldName.JOURNAL, "MIT Press");
+        editionTwo.setField(FieldName.URL, "https://webdocs.cs.ualberta.ca/~sutton/book/the-book-2nd.html");
+
+        BibEntry editionOne = new BibEntry(BibtexEntryTypes.BOOK.getName());
+        editionOne.setCiteKey("Sutton98reinfLrnIntroBook");
+        editionOne.setField(FieldName.TITLE, "Reinforcement learning: An introduction");
+        editionOne.setField(FieldName.PUBLISHER, "MIT press Cambridge");
+        editionOne.setField(FieldName.YEAR, "1998");
+        editionOne.setField(FieldName.AUTHOR, "Sutton, Richard S and Barto, Andrew G");
+        editionOne.setField(FieldName.VOLUME, "1");
+        editionOne.setField(FieldName.NUMBER, "1");
+        editionOne.setField(FieldName.EDITION, "First");
+
+        assertFalse(DuplicateCheck.isDuplicate(editionOne, editionTwo, BibDatabaseMode.BIBTEX));
+    }
 }


### PR DESCRIPTION
Fixes #2960 by checking for different editions before the actual duplicate check.
If both BibEntries have a Edition field that mismatches, it cannot be a duplicate.

- [X] Change in CHANGELOG.md described
- [X] Tests created for changes
