### PR TITLE
Add CheckStyle Check for Constants (final static)

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -45,6 +45,10 @@
                       PLUS, PLUS_ASSIGN, QUESTION,
                       SL, SLIST, SL_ASSIGN, SR, SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND"/>
         </module>
+
+        <module name="ConstantName">
+            <property name="format" value="^log(ger)?|[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"/>
+        </module>
     </module>
 
     <module name="SuppressionFilter">

--- a/src/main/java/org/jabref/Globals.java
+++ b/src/main/java/org/jabref/Globals.java
@@ -29,7 +29,7 @@ public class Globals {
     public static final RemoteListenerServerLifecycle REMOTE_LISTENER = new RemoteListenerServerLifecycle();
 
     public static final ImportFormatReader IMPORT_FORMAT_READER = new ImportFormatReader();
-    public static final TaskExecutor taskExecutor = new DefaultTaskExecutor();
+    public static final TaskExecutor TASK_EXECUTOR = new DefaultTaskExecutor();
     // In the main program, this field is initialized in JabRef.java
     // Each test case initializes this field if required
     public static JabRefPreferences prefs;
@@ -107,7 +107,7 @@ public class Globals {
     }
 
     public static void shutdownThreadPools() {
-        taskExecutor.shutdown();
+        TASK_EXECUTOR.shutdown();
         JabRefExecutorService.INSTANCE.shutdownEverything();
     }
 

--- a/src/main/java/org/jabref/gui/ClipBoardManager.java
+++ b/src/main/java/org/jabref/gui/ClipBoardManager.java
@@ -73,17 +73,17 @@ public class ClipBoardManager implements ClipboardOwner {
         StringSelection stringSelection = new StringSelection(aString);
         CLIPBOARD.setContents(stringSelection, this);
     }
-	
+
     public List<BibEntry> extractBibEntriesFromClipboard() {
         // Get clipboard contents, and see if TransferableBibtexEntry is among the content flavors offered
         Transferable content = CLIPBOARD.getContents(null);
         List<BibEntry> result = new ArrayList<>();
 
-        if (content.isDataFlavorSupported(TransferableBibtexEntry.entryFlavor)) {
+        if (content.isDataFlavorSupported(TransferableBibtexEntry.ENTRY_FLAVOR)) {
             // We have determined that the clipboard data is a set of entries.
             try  {
                 @SuppressWarnings("unchecked")
-                List<BibEntry> contents = (List<BibEntry>) content.getTransferData(TransferableBibtexEntry.entryFlavor);
+                List<BibEntry> contents = (List<BibEntry>) content.getTransferData(TransferableBibtexEntry.ENTRY_FLAVOR);
                 result = contents;
             } catch (UnsupportedFlavorException | ClassCastException ex) {
                 LOGGER.warn("Could not paste this type", ex);

--- a/src/main/java/org/jabref/gui/DefaultInjector.java
+++ b/src/main/java/org/jabref/gui/DefaultInjector.java
@@ -26,7 +26,7 @@ public class DefaultInjector implements PresenterFactory {
         if (clazz == DialogService.class) {
             return new FXDialogService();
         } else if (clazz == TaskExecutor.class) {
-            return Globals.taskExecutor;
+            return Globals.TASK_EXECUTOR;
         } else if (clazz == PreferencesService.class) {
             return Globals.prefs;
         } else if (clazz == KeyBindingRepository.class) {

--- a/src/main/java/org/jabref/gui/EntryTypeDialog.java
+++ b/src/main/java/org/jabref/gui/EntryTypeDialog.java
@@ -165,7 +165,7 @@ public class EntryTypeDialog extends JabRefDialog implements ActionListener {
 
         WebFetchers.getIdBasedFetchers(Globals.prefs.getImportFormatPreferences()).forEach(fetcher -> comboBox.addItem(fetcher.getName()));
         // set DOI as default
-        comboBox.setSelectedItem(DoiFetcher.name);
+        comboBox.setSelectedItem(DoiFetcher.NAME);
 
         generateButton.addActionListener(action -> {
             fetcherWorker.execute();

--- a/src/main/java/org/jabref/gui/TransferableBibtexEntry.java
+++ b/src/main/java/org/jabref/gui/TransferableBibtexEntry.java
@@ -22,7 +22,7 @@ import org.jabref.model.entry.BibEntry;
  */
 public class TransferableBibtexEntry implements Transferable {
 
-    public static final DataFlavor entryFlavor = new DataFlavor(BibEntry.class, "JabRef entry");
+    public static final DataFlavor ENTRY_FLAVOR = new DataFlavor(BibEntry.class, "JabRef entry");
     private final List<BibEntry> data;
 
 
@@ -32,19 +32,19 @@ public class TransferableBibtexEntry implements Transferable {
 
     @Override
     public DataFlavor[] getTransferDataFlavors() {
-        return new DataFlavor[] {TransferableBibtexEntry.entryFlavor,
+        return new DataFlavor[]{TransferableBibtexEntry.ENTRY_FLAVOR,
                 DataFlavor.stringFlavor};
     }
 
     @Override
     public boolean isDataFlavorSupported(DataFlavor flavor) {
-        return flavor.equals(TransferableBibtexEntry.entryFlavor) || flavor.equals(DataFlavor.stringFlavor);
+        return flavor.equals(TransferableBibtexEntry.ENTRY_FLAVOR) || flavor.equals(DataFlavor.stringFlavor);
     }
 
     @Override
     public Object getTransferData(DataFlavor flavor)
             throws UnsupportedFlavorException {
-        if (flavor.equals(TransferableBibtexEntry.entryFlavor)) {
+        if (flavor.equals(TransferableBibtexEntry.ENTRY_FLAVOR)) {
             return data;
         } else if (flavor.equals(DataFlavor.stringFlavor)) {
             try {

--- a/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
@@ -121,7 +121,7 @@ class FieldsEditorTab extends EntryEditorTab {
             fieldEditor.setAutoCompleteListener(autoCompleteListener);
             */
 
-            FieldEditorFX fieldEditor = FieldEditors.getForField(fieldName, Globals.taskExecutor, new FXDialogService(),
+            FieldEditorFX fieldEditor = FieldEditors.getForField(fieldName, Globals.TASK_EXECUTOR, new FXDialogService(),
                     Globals.journalAbbreviationLoader, Globals.prefs.getJournalAbbreviationPreferences(), Globals.prefs,
                     bPanel.getBibDatabaseContext(), entry.getType());
             fieldEditor.bindToEntry(entry);

--- a/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
@@ -44,7 +44,7 @@ public class RelatedArticlesTab extends EntryEditorTab {
                     progress.setVisible(false);
                     browser.getEngine().loadContent(convertToHtml(relatedArticles));
                 })
-                .executeWith(Globals.taskExecutor);
+                .executeWith(Globals.TASK_EXECUTOR);
 
         browser.getEngine().getLoadWorker().stateProperty().addListener(new OpenHyperlinksInExternalBrowser(browser));
 

--- a/src/main/java/org/jabref/gui/externalfiles/FindFullTextAction.java
+++ b/src/main/java/org/jabref/gui/externalfiles/FindFullTextAction.java
@@ -31,7 +31,7 @@ public class FindFullTextAction extends AbstractWorker {
 
     private static final Log LOGGER = LogFactory.getLog(FindFullTextAction.class);
 
-    private static final int warningLimit = 5; // The minimum number of selected entries to ask the user for confirmation
+    private static final int WARNING_LIMIT = 5; // The minimum number of selected entries to ask the user for confirmation
 
     private final BasePanel basePanel;
     private final Map<Optional<URL>, BibEntry> downloads = new ConcurrentHashMap<>();
@@ -51,7 +51,7 @@ public class FindFullTextAction extends AbstractWorker {
 
     @Override
     public void run() {
-        if (basePanel.getSelectedEntries().size() >= warningLimit) {
+        if (basePanel.getSelectedEntries().size() >= WARNING_LIMIT) {
             String[] options = new String[] {Localization.lang("Look up full text documents"),
                     Localization.lang("Cancel")};
             int answer = JOptionPane.showOptionDialog(basePanel.frame(),

--- a/src/main/java/org/jabref/gui/fieldeditors/contextmenu/ProtectedTermsMenu.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/contextmenu/ProtectedTermsMenu.java
@@ -14,7 +14,7 @@ import org.jabref.logic.protectedterms.ProtectedTermsList;
 
 class ProtectedTermsMenu extends Menu {
 
-    private static final ProtectTermsFormatter formatter = new ProtectTermsFormatter(Globals.protectedTermsLoader);
+    private static final ProtectTermsFormatter FORMATTER = new ProtectTermsFormatter(Globals.protectedTermsLoader);
     private final Menu externalFiles;
     private final TextArea opener;
 
@@ -30,7 +30,7 @@ class ProtectedTermsMenu extends Menu {
         });
 
         MenuItem formatItem = new MenuItem(Localization.lang("Format field"));
-        formatItem.setOnAction(event -> opener.setText(formatter.format(opener.getText())));
+        formatItem.setOnAction(event -> opener.setText(FORMATTER.format(opener.getText())));
 
         externalFiles = new Menu(Localization.lang("Add selected text to list"));
         updateFiles();
@@ -67,7 +67,5 @@ class ProtectedTermsMenu extends Menu {
             }
         });
         externalFiles.getItems().add(addToNewFileItem);
-
     }
-
 }

--- a/src/main/java/org/jabref/gui/help/AboutDialogViewModel.java
+++ b/src/main/java/org/jabref/gui/help/AboutDialogViewModel.java
@@ -22,11 +22,11 @@ import org.apache.commons.logging.LogFactory;
 
 public class AboutDialogViewModel extends AbstractViewModel {
 
-    private static final String homepageUrl = "https://www.jabref.org";
-    private static final String donationUrl = "https://donations.jabref.org";
-    private static final String librariesUrl = "https://github.com/JabRef/jabref/blob/master/external-libraries.txt";
-    private static final String githubUrl = "https://github.com/JabRef/jabref";
-    private static final String licenseUrl = "https://github.com/JabRef/jabref/blob/master/LICENSE.md";
+    private static final String HOMEPAGE_URL = "https://www.jabref.org";
+    private static final String DONATION_URL = "https://donations.jabref.org";
+    private static final String LIBRARIES_URL = "https://github.com/JabRef/jabref/blob/master/external-libraries.txt";
+    private static final String GITHUB_URL = "https://github.com/JabRef/jabref";
+    private static final String LICENSE_URL = "https://github.com/JabRef/jabref/blob/master/LICENSE.md";
     private final String changelogUrl;
     private final String versionInfo;
     private final Log logger = LogFactory.getLog(AboutDialogViewModel.class);
@@ -115,15 +115,15 @@ public class AboutDialogViewModel extends AbstractViewModel {
     }
 
     public void openJabrefWebsite() {
-        openWebsite(homepageUrl);
+        openWebsite(HOMEPAGE_URL);
     }
 
     public void openExternalLibrariesWebsite() {
-        openWebsite(librariesUrl);
+        openWebsite(LIBRARIES_URL);
     }
 
     public void openGithub() {
-        openWebsite(githubUrl);
+        openWebsite(GITHUB_URL);
     }
 
     public void openChangeLog() {
@@ -131,11 +131,11 @@ public class AboutDialogViewModel extends AbstractViewModel {
     }
 
     public void openLicense() {
-        openWebsite(licenseUrl);
+        openWebsite(LICENSE_URL);
     }
 
     public void openDonation() {
-        openWebsite(donationUrl);
+        openWebsite(DONATION_URL);
     }
 
     private void openWebsite(String url) {

--- a/src/main/java/org/jabref/gui/help/HelpAction.java
+++ b/src/main/java/org/jabref/gui/help/HelpAction.java
@@ -34,7 +34,7 @@ public class HelpAction extends MnemonicAwareAction {
     /**
      * New languages of the help have to be added here
      */
-    private static final Set<String> avaiableLangFiles = Stream.of("en", "de", "fr", "in", "ja")
+    private static final Set<String> AVAIABLE_LANG_FILES = Stream.of("en", "de", "fr", "in", "ja")
             .collect(Collectors.toCollection(HashSet::new));
 
     private HelpFile helpPage;
@@ -99,7 +99,7 @@ public class HelpAction extends MnemonicAwareAction {
         String lang = Globals.prefs.get(JabRefPreferences.LANGUAGE);
         StringBuilder sb = new StringBuilder("https://help.jabref.org/");
 
-        if (avaiableLangFiles.contains(lang)) {
+        if (AVAIABLE_LANG_FILES.contains(lang)) {
             sb.append(lang);
             sb.append("/");
         } else {

--- a/src/main/java/org/jabref/gui/preftabs/AppearancePrefsTab.java
+++ b/src/main/java/org/jabref/gui/preftabs/AppearancePrefsTab.java
@@ -54,7 +54,7 @@ class AppearancePrefsTab extends JPanel implements PrefsTab {
     private final JCheckBox customLAF;
 
     static class LookAndFeel {
-        private static final List<String> looks = Arrays.asList(
+        private static final List<String> LOOKS = Arrays.asList(
                 UIManager.getSystemLookAndFeelClassName(),
                 UIManager.getCrossPlatformLookAndFeelClassName(),
                 "com.jgoodies.looks.plastic.Plastic3DLookAndFeel",
@@ -63,7 +63,7 @@ class AppearancePrefsTab extends JPanel implements PrefsTab {
         public static List<String> getAvailableLookAndFeels() {
             List<String> lookAndFeels = new ArrayList<>();
 
-            for (String l : looks) {
+            for (String l : LOOKS) {
                 try {
                     // Try to find L&F
                     Class.forName(l);
@@ -158,16 +158,16 @@ class AppearancePrefsTab extends JPanel implements PrefsTab {
         FormBuilder generalBuilder = FormBuilder.create();
         JPanel generalPanel = generalBuilder.columns("left:pref, left:pref, 3dlu, pref, 7dlu, right:pref, 3dlu, pref")
                 .rows("pref, 3dlu, pref, 3dlu, pref")
-                .columnGroup(2,6)
-                .columnGroup(4,8)
-                .add(overrideFonts).xyw(1,1,5)
-                .add(new JLabel("    ")).xy(1,3)
-                .add(new JLabel(Localization.lang("Menu and label font size") + ":")).xy(2,3)
-                .add(fontSize).xy(4,3)
+                .columnGroup(2, 6)
+                .columnGroup(4, 8)
+                .add(overrideFonts).xyw(1, 1, 5)
+                .add(new JLabel("    ")).xy(1, 3)
+                .add(new JLabel(Localization.lang("Menu and label font size") + ":")).xy(2, 3)
+                .add(fontSize).xy(4, 3)
                 .add(new JLabel(Localization.lang("Size of large icons") + ":")).xy(2, 5)
-                .add(largeIconsTextField).xy(4,5)
+                .add(largeIconsTextField).xy(4, 5)
                 .add(new JLabel(Localization.lang("Size of small icons") + ":")).xy(6, 5)
-                .add(smallIconsTextField).xy(8,5)
+                .add(smallIconsTextField).xy(8, 5)
                 .build();
 
         builder.append(generalPanel);

--- a/src/main/java/org/jabref/gui/preftabs/FontSelectorDialog.java
+++ b/src/main/java/org/jabref/gui/preftabs/FontSelectorDialog.java
@@ -124,17 +124,17 @@ public class FontSelectorDialog extends JabRefDialog {
 
     private static final String ITALIC = "italic";
 
-    private static final String[] styles = {PLAIN, BOLD, ITALIC, BOLD_ITALIC};
+    private static final String[] STYLES = {PLAIN, BOLD, ITALIC, BOLD_ITALIC};
 
-    private static final String[] sizes = {"9", "10", "12", "14", "16", "18", "24"};
+    private static final String[] SIZES = {"9", "10", "12", "14", "16", "18", "24"};
     // private members
     private boolean isOK;
     private final JTextField familyField = new JTextField();
     private final JList<String> familyList;
     private final JTextField sizeField = new JTextField();
-    private final JList<String> sizeList = new JList<>(sizes);
+    private final JList<String> sizeList = new JList<>(SIZES);
     private final JTextField styleField = new JTextField();
-    private final JList<String> styleList = new JList<>(styles);
+    private final JList<String> styleList = new JList<>(STYLES);
 
     private final JLabel preview;
 

--- a/src/main/java/org/jabref/logic/exporter/FileSaveSession.java
+++ b/src/main/java/org/jabref/logic/exporter/FileSaveSession.java
@@ -91,7 +91,7 @@ public class FileSaveSession extends SaveSession {
                     PosixFilePermission.GROUP_READ,
                     PosixFilePermission.GROUP_WRITE,
                     PosixFilePermission.OTHERS_READ);
-            if (FileUtil.isPosixCompilant && Files.exists(file)) {
+            if (FileUtil.IS_POSIX_COMPILANT && Files.exists(file)) {
                 try {
                     oldFilePermissions = Files.getPosixFilePermissions(file);
                 } catch (IOException exception) {
@@ -102,7 +102,7 @@ public class FileSaveSession extends SaveSession {
             FileUtil.copyFile(temporaryFile, file, true);
 
             // Restore file permissions
-            if (FileUtil.isPosixCompilant) {
+            if (FileUtil.IS_POSIX_COMPILANT) {
                 try {
                     Files.setPosixFilePermissions(file, oldFilePermissions);
                 } catch (IOException exception) {

--- a/src/main/java/org/jabref/logic/importer/fetcher/DoiFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DoiFetcher.java
@@ -23,7 +23,7 @@ import org.jabref.model.entry.FieldName;
 import org.jabref.model.entry.identifier.DOI;
 
 public class DoiFetcher implements IdBasedFetcher, EntryBasedFetcher {
-    public static final String name = "DOI";
+    public static final String NAME = "DOI";
 
     private final ImportFormatPreferences preferences;
 
@@ -33,7 +33,7 @@ public class DoiFetcher implements IdBasedFetcher, EntryBasedFetcher {
 
     @Override
     public String getName() {
-        return DoiFetcher.name;
+        return DoiFetcher.NAME;
     }
 
     @Override
@@ -80,5 +80,4 @@ public class DoiFetcher implements IdBasedFetcher, EntryBasedFetcher {
         bibEntry.ifPresent(list::add);
         return list;
     }
-
 }

--- a/src/main/java/org/jabref/logic/msbib/MSBibMapping.java
+++ b/src/main/java/org/jabref/logic/msbib/MSBibMapping.java
@@ -11,73 +11,70 @@ import org.jabref.model.entry.FieldName;
 import com.google.common.collect.HashBiMap;
 
 /**
- * Mapping between Msbib and biblatex
- * All Fields: <a href = "https://msdn.microsoft.com/de-de/library/office/documentformat.openxml.bibliography">List of all MSBib fields</a>
- *
+ * Mapping between Msbib and biblatex All Fields: <a href = "https://msdn.microsoft.com/de-de/library/office/documentformat.openxml.bibliography">List
+ * of all MSBib fields</a>
  */
 public class MSBibMapping {
 
     private static final String BIBTEX_PREFIX = "BIBTEX_";
     private static final String MSBIB_PREFIX = "msbib-";
 
-    private static final HashBiMap<String, String> biblatexToMsBib = HashBiMap.create();
+    private static final HashBiMap<String, String> BIBLATEX_TO_MS_BIB = HashBiMap.create();
 
     static {
-        biblatexToMsBib.put(BibEntry.KEY_FIELD, "Tag");
-        biblatexToMsBib.put(FieldName.TITLE, "Title");
-        biblatexToMsBib.put(FieldName.YEAR, "Year");
-        biblatexToMsBib.put(FieldName.NOTE, "Comments");
-        biblatexToMsBib.put(FieldName.VOLUME, "Volume");
-        biblatexToMsBib.put(FieldName.LANGUAGE, "LCID");
-        biblatexToMsBib.put(FieldName.EDITION, "Edition");
-        biblatexToMsBib.put(FieldName.PUBLISHER, "Publisher");
-        biblatexToMsBib.put(FieldName.BOOKTITLE, "BookTitle");
-        biblatexToMsBib.put("shorttitle", "ShortTitle");
-        biblatexToMsBib.put(FieldName.NOTE, "Comments");
-        biblatexToMsBib.put(FieldName.VOLUMES, "NumberVolumes");
+        BIBLATEX_TO_MS_BIB.put(BibEntry.KEY_FIELD, "Tag");
+        BIBLATEX_TO_MS_BIB.put(FieldName.TITLE, "Title");
+        BIBLATEX_TO_MS_BIB.put(FieldName.YEAR, "Year");
+        BIBLATEX_TO_MS_BIB.put(FieldName.NOTE, "Comments");
+        BIBLATEX_TO_MS_BIB.put(FieldName.VOLUME, "Volume");
+        BIBLATEX_TO_MS_BIB.put(FieldName.LANGUAGE, "LCID");
+        BIBLATEX_TO_MS_BIB.put(FieldName.EDITION, "Edition");
+        BIBLATEX_TO_MS_BIB.put(FieldName.PUBLISHER, "Publisher");
+        BIBLATEX_TO_MS_BIB.put(FieldName.BOOKTITLE, "BookTitle");
+        BIBLATEX_TO_MS_BIB.put("shorttitle", "ShortTitle");
+        BIBLATEX_TO_MS_BIB.put(FieldName.NOTE, "Comments");
+        BIBLATEX_TO_MS_BIB.put(FieldName.VOLUMES, "NumberVolumes");
 
-        //biblatexToMsBib.put(FieldName.BOOKTITLE, "ConferenceName");
-        //biblatexToMsBib.put(FieldName.PAGES, "Pages");
-        biblatexToMsBib.put(FieldName.CHAPTER, "ChapterNumber");
+        BIBLATEX_TO_MS_BIB.put(FieldName.CHAPTER, "ChapterNumber");
 
-        biblatexToMsBib.put(FieldName.ISSUE, "Issue");
-        biblatexToMsBib.put(FieldName.SCHOOL, "Department");
-        biblatexToMsBib.put(FieldName.INSTITUTION, "Institution");
-        biblatexToMsBib.put(FieldName.DOI, "DOI");
-        biblatexToMsBib.put(FieldName.URL, "URL");
+        BIBLATEX_TO_MS_BIB.put(FieldName.ISSUE, "Issue");
+        BIBLATEX_TO_MS_BIB.put(FieldName.SCHOOL, "Department");
+        BIBLATEX_TO_MS_BIB.put(FieldName.INSTITUTION, "Institution");
+        BIBLATEX_TO_MS_BIB.put(FieldName.DOI, "DOI");
+        BIBLATEX_TO_MS_BIB.put(FieldName.URL, "URL");
         // BibTeX/Biblatex only fields
 
-        biblatexToMsBib.put(FieldName.SERIES, BIBTEX_PREFIX + "Series");
-        biblatexToMsBib.put(FieldName.ABSTRACT, BIBTEX_PREFIX + "Abstract");
-        biblatexToMsBib.put(FieldName.KEYWORDS, BIBTEX_PREFIX + "KeyWords");
-        biblatexToMsBib.put(FieldName.CROSSREF, BIBTEX_PREFIX + "CrossRef");
-        biblatexToMsBib.put(FieldName.HOWPUBLISHED, BIBTEX_PREFIX + "HowPublished");
-        biblatexToMsBib.put(FieldName.PUBSTATE, BIBTEX_PREFIX + "Pubstate");
-        biblatexToMsBib.put("affiliation", BIBTEX_PREFIX + "Affiliation");
-        biblatexToMsBib.put("contents", BIBTEX_PREFIX + "Contents");
-        biblatexToMsBib.put("copyright", BIBTEX_PREFIX + "Copyright");
-        biblatexToMsBib.put("price", BIBTEX_PREFIX + "Price");
-        biblatexToMsBib.put("size", BIBTEX_PREFIX + "Size");
-        biblatexToMsBib.put("intype", BIBTEX_PREFIX + "InType");
-        biblatexToMsBib.put("paper", BIBTEX_PREFIX + "Paper");
-        biblatexToMsBib.put(FieldName.KEY, BIBTEX_PREFIX + "Key");
+        BIBLATEX_TO_MS_BIB.put(FieldName.SERIES, BIBTEX_PREFIX + "Series");
+        BIBLATEX_TO_MS_BIB.put(FieldName.ABSTRACT, BIBTEX_PREFIX + "Abstract");
+        BIBLATEX_TO_MS_BIB.put(FieldName.KEYWORDS, BIBTEX_PREFIX + "KeyWords");
+        BIBLATEX_TO_MS_BIB.put(FieldName.CROSSREF, BIBTEX_PREFIX + "CrossRef");
+        BIBLATEX_TO_MS_BIB.put(FieldName.HOWPUBLISHED, BIBTEX_PREFIX + "HowPublished");
+        BIBLATEX_TO_MS_BIB.put(FieldName.PUBSTATE, BIBTEX_PREFIX + "Pubstate");
+        BIBLATEX_TO_MS_BIB.put("affiliation", BIBTEX_PREFIX + "Affiliation");
+        BIBLATEX_TO_MS_BIB.put("contents", BIBTEX_PREFIX + "Contents");
+        BIBLATEX_TO_MS_BIB.put("copyright", BIBTEX_PREFIX + "Copyright");
+        BIBLATEX_TO_MS_BIB.put("price", BIBTEX_PREFIX + "Price");
+        BIBLATEX_TO_MS_BIB.put("size", BIBTEX_PREFIX + "Size");
+        BIBLATEX_TO_MS_BIB.put("intype", BIBTEX_PREFIX + "InType");
+        BIBLATEX_TO_MS_BIB.put("paper", BIBTEX_PREFIX + "Paper");
+        BIBLATEX_TO_MS_BIB.put(FieldName.KEY, BIBTEX_PREFIX + "Key");
 
         // MSBib only fields
-        biblatexToMsBib.put(MSBIB_PREFIX + "periodical", "PeriodicalTitle");
-        biblatexToMsBib.put(MSBIB_PREFIX + FieldName.DAY, "Day");
-        biblatexToMsBib.put(MSBIB_PREFIX + "accessed", "Accessed");
-        biblatexToMsBib.put(MSBIB_PREFIX + "medium", "Medium");
-        biblatexToMsBib.put(MSBIB_PREFIX + "recordingnumber", "RecordingNumber");
-        biblatexToMsBib.put(MSBIB_PREFIX + "theater", "Theater");
-        biblatexToMsBib.put(MSBIB_PREFIX + "distributor", "Distributor");
-        biblatexToMsBib.put(MSBIB_PREFIX + "broadcaster", "Broadcaster");
-        biblatexToMsBib.put(MSBIB_PREFIX + "station", "Station");
-        biblatexToMsBib.put(MSBIB_PREFIX + FieldName.TYPE, "Type");
-        biblatexToMsBib.put(MSBIB_PREFIX + "court", "Court");
-        biblatexToMsBib.put(MSBIB_PREFIX + "reporter", "Reporter");
-        biblatexToMsBib.put(MSBIB_PREFIX + "casenumber", "CaseNumber");
-        biblatexToMsBib.put(MSBIB_PREFIX + "abbreviatedcasenumber", "AbbreviatedCaseNumber");
-        biblatexToMsBib.put(MSBIB_PREFIX + "productioncompany", "ProductionCompany");
+        BIBLATEX_TO_MS_BIB.put(MSBIB_PREFIX + "periodical", "PeriodicalTitle");
+        BIBLATEX_TO_MS_BIB.put(MSBIB_PREFIX + FieldName.DAY, "Day");
+        BIBLATEX_TO_MS_BIB.put(MSBIB_PREFIX + "accessed", "Accessed");
+        BIBLATEX_TO_MS_BIB.put(MSBIB_PREFIX + "medium", "Medium");
+        BIBLATEX_TO_MS_BIB.put(MSBIB_PREFIX + "recordingnumber", "RecordingNumber");
+        BIBLATEX_TO_MS_BIB.put(MSBIB_PREFIX + "theater", "Theater");
+        BIBLATEX_TO_MS_BIB.put(MSBIB_PREFIX + "distributor", "Distributor");
+        BIBLATEX_TO_MS_BIB.put(MSBIB_PREFIX + "broadcaster", "Broadcaster");
+        BIBLATEX_TO_MS_BIB.put(MSBIB_PREFIX + "station", "Station");
+        BIBLATEX_TO_MS_BIB.put(MSBIB_PREFIX + FieldName.TYPE, "Type");
+        BIBLATEX_TO_MS_BIB.put(MSBIB_PREFIX + "court", "Court");
+        BIBLATEX_TO_MS_BIB.put(MSBIB_PREFIX + "reporter", "Reporter");
+        BIBLATEX_TO_MS_BIB.put(MSBIB_PREFIX + "casenumber", "CaseNumber");
+        BIBLATEX_TO_MS_BIB.put(MSBIB_PREFIX + "abbreviatedcasenumber", "AbbreviatedCaseNumber");
+        BIBLATEX_TO_MS_BIB.put(MSBIB_PREFIX + "productioncompany", "ProductionCompany");
     }
 
     private MSBibMapping() {
@@ -128,6 +125,7 @@ public class MSBibMapping {
     /**
      * Only English is supported <br>
      * <a href="http://www.microsoft.com/globaldev/reference/lcid-all.mspx">All LCID codes</a>
+     *
      * @param language The language to transform
      * @return Returns 0 for English
      */
@@ -140,7 +138,7 @@ public class MSBibMapping {
     /**
      * Only English is supported <br>
      * <a href="http://www.microsoft.com/globaldev/reference/lcid-all.mspx">All LCID codes</a>
-     * @param language
+     *
      * @return Returns english
      */
     public static String getLanguage(int LCID) {
@@ -149,10 +147,10 @@ public class MSBibMapping {
     }
 
     public static String getMSBibField(String bibtexFieldName) {
-        return biblatexToMsBib.get(bibtexFieldName);
+        return BIBLATEX_TO_MS_BIB.get(bibtexFieldName);
     }
 
     public static String getBibTeXField(String msbibFieldName) {
-        return biblatexToMsBib.inverse().get(msbibFieldName);
+        return BIBLATEX_TO_MS_BIB.inverse().get(msbibFieldName);
     }
 }

--- a/src/main/java/org/jabref/logic/protectedterms/ProtectedTermsLoader.java
+++ b/src/main/java/org/jabref/logic/protectedterms/ProtectedTermsLoader.java
@@ -19,17 +19,17 @@ import org.apache.commons.logging.LogFactory;
 
 public class ProtectedTermsLoader {
 
-    private static final Map<String, String> internalLists = new HashMap<>();
+    private static final Map<String, String> INTERNAL_LISTS = new HashMap<>();
 
     private static final Log LOGGER = LogFactory.getLog(ProtectedTermsLoader.class);
 
     private final List<ProtectedTermsList> mainList = new ArrayList<>();
 
     static {
-        internalLists.put("/protectedterms/months_weekdays.terms", Localization.lang("Months and weekdays in English"));
-        internalLists.put("/protectedterms/countries_territories.terms",
+        INTERNAL_LISTS.put("/protectedterms/months_weekdays.terms", Localization.lang("Months and weekdays in English"));
+        INTERNAL_LISTS.put("/protectedterms/countries_territories.terms",
                 Localization.lang("Countries and territories in English"));
-        internalLists.put("/protectedterms/electrical_engineering.terms",
+        INTERNAL_LISTS.put("/protectedterms/electrical_engineering.terms",
                 Localization.lang("Electrical engineering terms"));
     }
 
@@ -38,7 +38,7 @@ public class ProtectedTermsLoader {
     }
 
     public static List<String> getInternalLists() {
-        return new ArrayList<>(internalLists.keySet());
+        return new ArrayList<>(INTERNAL_LISTS.keySet());
     }
 
     public void update(ProtectedTermsPreferences preferences) {
@@ -46,16 +46,16 @@ public class ProtectedTermsLoader {
 
         // Read internal lists
         for (String filename : preferences.getEnabledInternalTermLists()) {
-            if (internalLists.containsKey(filename)) {
-                mainList.add(readProtectedTermsListFromResource(filename, internalLists.get(filename), true));
+            if (INTERNAL_LISTS.containsKey(filename)) {
+                mainList.add(readProtectedTermsListFromResource(filename, INTERNAL_LISTS.get(filename), true));
             } else {
                 LOGGER.warn("Protected terms resource '" + filename + "' is no longer available.");
             }
         }
         for (String filename : preferences.getDisabledInternalTermLists()) {
-            if (internalLists.containsKey(filename)) {
+            if (INTERNAL_LISTS.containsKey(filename)) {
                 if (!preferences.getEnabledInternalTermLists().contains(filename)) {
-                    mainList.add(readProtectedTermsListFromResource(filename, internalLists.get(filename), false));
+                    mainList.add(readProtectedTermsListFromResource(filename, INTERNAL_LISTS.get(filename), false));
                 }
             } else {
                 LOGGER.warn("Protected terms resource '" + filename + "' is no longer available.");
@@ -63,11 +63,11 @@ public class ProtectedTermsLoader {
         }
 
         // Check if any new internal lists have emerged
-        for (String filename : internalLists.keySet()) {
+        for (String filename : INTERNAL_LISTS.keySet()) {
             if (!preferences.getEnabledInternalTermLists().contains(filename)
                     && !preferences.getDisabledInternalTermLists().contains(filename)) {
                 // New internal list, add it
-                mainList.add(readProtectedTermsListFromResource(filename, internalLists.get(filename), true));
+                mainList.add(readProtectedTermsListFromResource(filename, INTERNAL_LISTS.get(filename), true));
                 LOGGER.warn("New protected terms resource '" + filename + "' is available and enabled by default.");
             }
         }
@@ -106,7 +106,6 @@ public class ProtectedTermsLoader {
         } catch (IOException e) {
             LOGGER.warn("Problem with protected terms file '" + list.getLocation() + "'", e);
         }
-
     }
 
     public List<ProtectedTermsList> getProtectedTermsLists() {

--- a/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -29,7 +29,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 public class FileUtil {
-    public static final boolean isPosixCompilant = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+    public static final boolean IS_POSIX_COMPILANT = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
     private static final Log LOGGER = LogFactory.getLog(FileUtil.class);
 
     private FileUtil() {
@@ -51,7 +51,7 @@ public class FileUtil {
      * Adds an extension to the given file name. The original extension is not replaced. That means,
      * "demo.bib", ".sav" gets "demo.bib.sav" and not "demo.sav"
      *
-     * @param path the path to add the extension to
+     * @param path      the path to add the extension to
      * @param extension the extension to add
      * @return the with the modified file name
      */
@@ -108,7 +108,6 @@ public class FileUtil {
      * @param pathToDestinationFile Path Destination file
      * @param replaceExisting       boolean Determines whether the copy goes on even if the file exists.
      * @return boolean Whether the copy succeeded, or was stopped due to the file already existing.
-     * @throws IOException
      */
     public static boolean copyFile(Path pathToSourceFile, Path pathToDestinationFile, boolean replaceExisting) {
         // Check if the file already exists.
@@ -142,11 +141,10 @@ public class FileUtil {
     /**
      * Renames a given file
      *
-     * @param fromFile The source filename to rename
-     * @param toFile   The target fileName
+     * @param fromFile        The source filename to rename
+     * @param toFile          The target fileName
      * @param replaceExisting Wether to replace existing files or not
      * @return True if the rename was successful, false if an exception occurred
-     *
      */
     public static boolean renameFile(Path fromFile, Path toFile, boolean replaceExisting) {
         try {
@@ -188,9 +186,8 @@ public class FileUtil {
     /**
      * Returns the list of linked files. The files have the absolute filename
      *
-     * @param bes list of BibTeX entries
+     * @param bes      list of BibTeX entries
      * @param fileDirs list of directories to try for expansion
-     *
      * @return list of files. May be empty
      */
     public static List<Path> getListOfLinkedFiles(List<BibEntry> bes, List<Path> fileDirs) {
@@ -213,7 +210,7 @@ public class FileUtil {
      * @return a suggested fileName
      */
     public static String createFileNameFromPattern(BibDatabase database, BibEntry entry, String fileNamePattern,
-            LayoutFormatterPreferences prefs) {
+                                                   LayoutFormatterPreferences prefs) {
         String targetName = null;
 
         StringReader sr = new StringReader(fileNamePattern);
@@ -239,7 +236,7 @@ public class FileUtil {
      * Finds a file inside a directory structure.
      * Will also look for the file inside nested directories.
      *
-     * @param filename the name of the file that should be found
+     * @param filename      the name of the file that should be found
      * @param rootDirectory the rootDirectory that will be searched
      * @return the path to the first file that matches the defined conditions
      */
@@ -259,7 +256,7 @@ public class FileUtil {
      * Finds a file inside a list of directory structures.
      * Will also look for the file inside nested directories.
      *
-     * @param filename the name of the file that should be found
+     * @param filename    the name of the file that should be found
      * @param directories the directories that will be searched
      * @return a list including all found paths to files that match the defined conditions
      */

--- a/src/main/java/org/jabref/model/entry/AuthorList.java
+++ b/src/main/java/org/jabref/model/entry/AuthorList.java
@@ -122,7 +122,7 @@ public class AuthorList {
 
     private static final WeakHashMap<String, AuthorList> AUTHOR_CACHE = new WeakHashMap<>();
     // Avoid partition where these values are contained
-    private final static Collection<String> avoidTermsInLowerCase = Arrays.asList("jr", "sr", "jnr", "snr", "von", "zu", "van", "der");
+    private final static Collection<String> AVOID_TERMS_IN_LOWER_CASE = Arrays.asList("jr", "sr", "jnr", "snr", "von", "zu", "van", "der");
     private final List<Author> authors;
     private final String[] authorsFirstFirst = new String[4];
     private final String[] authorsLastOnly = new String[2];
@@ -196,7 +196,7 @@ public class AuthorList {
                 Collection<Integer> avoidIndex = new HashSet<>();
 
                 for (int i = 0; i < arrayNameList.size(); i++) {
-                    if (avoidTermsInLowerCase.contains(arrayNameList.get(i).toLowerCase(Locale.ROOT))) {
+                    if (AVOID_TERMS_IN_LOWER_CASE.contains(arrayNameList.get(i).toLowerCase(Locale.ROOT))) {
                         avoidIndex.add(i);
                         valuePartsCount--;
                     }
@@ -405,7 +405,8 @@ public class AuthorList {
      *
      * @param oxfordComma Whether to put a comma before the and at the end.
      * @return formatted list of authors.
-     * @see <a href="http://en.wikipedia.org/wiki/Serial_comma">serial comma for an detailed explaination about the Oxford comma.</a>
+     * @see <a href="http://en.wikipedia.org/wiki/Serial_comma">serial comma for an detailed explaination about the
+     * Oxford comma.</a>
      */
     public String getAsLastNames(boolean oxfordComma) {
         int abbrInt = oxfordComma ? 0 : 1;
@@ -455,7 +456,8 @@ public class AuthorList {
      * @param abbreviate  whether to abbreivate first names.
      * @param oxfordComma Whether to put a comma before the and at the end.
      * @return formatted list of authors.
-     * @see <a href="http://en.wikipedia.org/wiki/Serial_comma">serial comma for an detailed explaination about the Oxford comma.</a>
+     * @see <a href="http://en.wikipedia.org/wiki/Serial_comma">serial comma for an detailed explaination about the
+     * Oxford comma.</a>
      */
     public String getAsLastFirstNames(boolean abbreviate, boolean oxfordComma) {
         int abbrInt = abbreviate ? 0 : 1;
@@ -556,7 +558,8 @@ public class AuthorList {
      * @param abbr        whether to abbreivate first names.
      * @param oxfordComma Whether to put a comma before the and at the end.
      * @return formatted list of authors.
-     * @see <a href="http://en.wikipedia.org/wiki/Serial_comma">serial comma for an detailed explaination about the Oxford comma.</a>
+     * @see <a href="http://en.wikipedia.org/wiki/Serial_comma">serial comma for an detailed explaination about the
+     * Oxford comma.</a>
      */
     public String getAsFirstLastNames(boolean abbr, boolean oxfordComma) {
 

--- a/src/main/java/org/jabref/model/entry/FieldName.java
+++ b/src/main/java/org/jabref/model/entry/FieldName.java
@@ -10,7 +10,6 @@ import org.jabref.model.strings.StringUtil;
 
 /**
  * String constants for BibTeX entry field names
- *
  */
 public class FieldName {
     // Character separating field names that are to be used in sequence as
@@ -152,7 +151,7 @@ public class FieldName {
     public static final String MARKED_INTERNAL = "__markedentry";
 
     // Map to hold alternative display names
-    private static final Map<String, String> displayNames = new HashMap<>();
+    private static final Map<String, String> DISPLAY_NAMES = new HashMap<>();
 
     private FieldName() {
     }
@@ -166,15 +165,15 @@ public class FieldName {
     }
 
     static {
-        displayNames.put(FieldName.DOI, "DOI");
-        displayNames.put(FieldName.ISBN, "ISBN");
-        displayNames.put(FieldName.ISRN, "ISRN");
-        displayNames.put(FieldName.ISSN, "ISSN");
-        displayNames.put(FieldName.PMID, "PMID");
-        displayNames.put(FieldName.PS, "PS");
-        displayNames.put(FieldName.PDF, "PDF");
-        displayNames.put(FieldName.URI, "URI");
-        displayNames.put(FieldName.URL, "URL");
+        DISPLAY_NAMES.put(FieldName.DOI, "DOI");
+        DISPLAY_NAMES.put(FieldName.ISBN, "ISBN");
+        DISPLAY_NAMES.put(FieldName.ISRN, "ISRN");
+        DISPLAY_NAMES.put(FieldName.ISSN, "ISSN");
+        DISPLAY_NAMES.put(FieldName.PMID, "PMID");
+        DISPLAY_NAMES.put(FieldName.PS, "PS");
+        DISPLAY_NAMES.put(FieldName.PDF, "PDF");
+        DISPLAY_NAMES.put(FieldName.URI, "URI");
+        DISPLAY_NAMES.put(FieldName.URL, "URL");
     }
 
     /**
@@ -184,8 +183,8 @@ public class FieldName {
     public static String getDisplayName(String field) {
         String lowercaseField = field.toLowerCase(Locale.ROOT);
 
-        if (displayNames.containsKey(lowercaseField)) {
-            return displayNames.get(lowercaseField);
+        if (DISPLAY_NAMES.containsKey(lowercaseField)) {
+            return DISPLAY_NAMES.get(lowercaseField);
         }
         return StringUtil.capitalizeFirst(field);
     }
@@ -197,5 +196,4 @@ public class FieldName {
     public static List<String> getIdentifierFieldNames() {
         return Arrays.asList(FieldName.DOI, FieldName.EPRINT, FieldName.PMID);
     }
-
 }

--- a/src/main/java/org/jabref/model/entry/IdGenerator.java
+++ b/src/main/java/org/jabref/model/entry/IdGenerator.java
@@ -9,12 +9,12 @@ import java.text.NumberFormat;
  */
 public class IdGenerator {
 
-    private static final NumberFormat idFormat;
+    private static final NumberFormat ID_FORMAT;
 
     static {
-        idFormat = NumberFormat.getInstance();
-        IdGenerator.idFormat.setMinimumIntegerDigits(8);
-        IdGenerator.idFormat.setGroupingUsed(false);
+        ID_FORMAT = NumberFormat.getInstance();
+        IdGenerator.ID_FORMAT.setMinimumIntegerDigits(8);
+        IdGenerator.ID_FORMAT.setGroupingUsed(false);
     }
 
     private static int idCounter;
@@ -23,7 +23,7 @@ public class IdGenerator {
     }
 
     public static synchronized String next() {
-        String result = idFormat.format(idCounter);
+        String result = ID_FORMAT.format(idCounter);
         idCounter++;
         return result;
     }


### PR DESCRIPTION
To adhere the Java Code Conventions I have added another CheckStyle check to make sure that all `static final` variables are in CAPS. For some reason Checkstyle suggests to exclude the logger, which I am unsure if we really need it. Check the following regex for the exact specification:

```
"^log(ger)?|[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"
```

I have already fixed the instances where this rule was violated.