### PR TITLE
Less backups

### DIFF
--- a/src/main/java/org/jabref/logic/autosaveandbackup/BackupManager.java
+++ b/src/main/java/org/jabref/logic/autosaveandbackup/BackupManager.java
@@ -41,17 +41,17 @@ public class BackupManager {
 
     private static final String BACKUP_EXTENSION = ".sav";
 
-    private final static int MINOR_CHANGES_LIMIT = 5;
-
-    private int minorChangesCount = 0;
+    private static final int MINOR_CHANGES_LIMIT = 5;
 
     private static Set<BackupManager> runningInstances = new HashSet<>();
+
+    private int minorChangesCount = 0;
 
     private final BibDatabaseContext bibDatabaseContext;
     private final JabRefPreferences preferences;
     private final ExecutorService executor;
     private final Runnable backupTask = () -> determineBackupPath().ifPresent(this::performBackup);
-    
+
     private BackupManager(BibDatabaseContext bibDatabaseContext) {
         this.bibDatabaseContext = bibDatabaseContext;
         this.preferences = JabRefPreferences.getInstance();

--- a/src/main/java/org/jabref/logic/autosaveandbackup/BackupManager.java
+++ b/src/main/java/org/jabref/logic/autosaveandbackup/BackupManager.java
@@ -41,17 +41,17 @@ public class BackupManager {
 
     private static final String BACKUP_EXTENSION = ".sav";
 
+    private final static int MINOR_CHANGES_LIMIT = 5;
+
+    private int minorChangesCount = 0;
+
     private static Set<BackupManager> runningInstances = new HashSet<>();
 
     private final BibDatabaseContext bibDatabaseContext;
     private final JabRefPreferences preferences;
     private final ExecutorService executor;
     private final Runnable backupTask = () -> determineBackupPath().ifPresent(this::performBackup);
-
-    private int minorChangesCount = 0;
-    private final static int MINOR_CHANGES_LIMIT = 5;
-
-
+    
     private BackupManager(BibDatabaseContext bibDatabaseContext) {
         this.bibDatabaseContext = bibDatabaseContext;
         this.preferences = JabRefPreferences.getInstance();

--- a/src/main/java/org/jabref/model/entry/event/FieldChangedEvent.java
+++ b/src/main/java/org/jabref/model/entry/event/FieldChangedEvent.java
@@ -11,7 +11,7 @@ public class FieldChangedEvent extends EntryChangedEvent {
     private final String fieldName;
     private final String newValue;
     private final String oldValue;
-    private final int delta = 0;
+    private int delta = 0;
 
 
     /**

--- a/src/main/java/org/jabref/model/entry/event/FieldChangedEvent.java
+++ b/src/main/java/org/jabref/model/entry/event/FieldChangedEvent.java
@@ -11,7 +11,7 @@ public class FieldChangedEvent extends EntryChangedEvent {
     private final String fieldName;
     private final String newValue;
     private final String oldValue;
-    private int delta = 0;
+    private final int delta = 0;
 
 
     /**

--- a/src/main/java/org/jabref/model/entry/event/FieldChangedEvent.java
+++ b/src/main/java/org/jabref/model/entry/event/FieldChangedEvent.java
@@ -57,6 +57,10 @@ public class FieldChangedEvent extends EntryChangedEvent {
         delta = computeDelta(oldValue, newValue);
     }
 
+    public FieldChangedEvent(FieldChange fieldChange) {
+        this(fieldChange, EntryEventSource.LOCAL);
+    }
+
     private int computeDelta(String oldValue, String newValue) {
         if (oldValue == newValue) {
             return 0;
@@ -67,10 +71,6 @@ public class FieldChangedEvent extends EntryChangedEvent {
         } else {
             return Math.abs(newValue.length() - oldValue.length());
         }
-    }
-
-    public FieldChangedEvent(FieldChange fieldChange) {
-        this(fieldChange, EntryEventSource.LOCAL);
     }
 
     public String getFieldName() {

--- a/src/main/java/org/jabref/model/entry/event/FieldChangedEvent.java
+++ b/src/main/java/org/jabref/model/entry/event/FieldChangedEvent.java
@@ -11,46 +11,62 @@ public class FieldChangedEvent extends EntryChangedEvent {
     private final String fieldName;
     private final String newValue;
     private final String oldValue;
+    private int delta = 0;
 
 
     /**
-     * @param bibEntry Affected BibEntry object
+     * @param bibEntry  Affected BibEntry object
      * @param fieldName Name of field which has been changed
-     * @param newValue new field value
-     * @param newValue old field value
-     * @param location location Location affected by this event
+     * @param newValue  new field value
+     * @param newValue  old field value
+     * @param location  location Location affected by this event
      */
     public FieldChangedEvent(BibEntry bibEntry, String fieldName, String newValue, String oldValue,
-            EntryEventSource location) {
+                             EntryEventSource location) {
         super(bibEntry, location);
         this.fieldName = fieldName;
         this.newValue = newValue;
         this.oldValue = oldValue;
+        delta = computeDelta(oldValue, newValue);
     }
 
     /**
-     * @param bibEntry Affected BibEntry object
+     * @param bibEntry  Affected BibEntry object
      * @param fieldName Name of field which has been changed
-     * @param newValue new field value
+     * @param newValue  new field value
      */
     public FieldChangedEvent(BibEntry bibEntry, String fieldName, String newValue, String oldValue) {
         super(bibEntry);
         this.fieldName = fieldName;
         this.newValue = newValue;
         this.oldValue = oldValue;
+        delta = computeDelta(oldValue, newValue);
     }
 
     /**
-     * @param bibEntry Affected BibEntry object
+     * @param bibEntry  Affected BibEntry object
      * @param fieldName Name of field which has been changed
-     * @param newValue new field value
-     * @param location location Location affected by this event
+     * @param newValue  new field value
+     * @param location  location Location affected by this event
      */
     public FieldChangedEvent(FieldChange fieldChange, EntryEventSource location) {
         super(fieldChange.getEntry(), location);
         this.fieldName = fieldChange.getField();
         this.newValue = fieldChange.getNewValue();
         this.oldValue = fieldChange.getOldValue();
+        delta = computeDelta(oldValue, newValue);
+    }
+
+    private int computeDelta(String oldValue, String newValue) {
+        if (oldValue == newValue) {
+            return 0;
+        } else if (oldValue == null && newValue != null) {
+            return newValue.length();
+        } else if (newValue == null && oldValue != null) {
+            return oldValue.length();
+        } else {
+            return Math.abs(newValue.length() - oldValue.length());
+        }
     }
 
     public FieldChangedEvent(FieldChange fieldChange) {
@@ -67,6 +83,10 @@ public class FieldChangedEvent extends EntryChangedEvent {
 
     public String getOldValue() {
         return oldValue;
+    }
+
+    public int getDelta() {
+        return delta;
     }
 
 }


### PR DESCRIPTION
Addresses #2993

The frequent events are due to the bidirectional binding which transfers every change directly into the BibEntry. If we want fewer events, the only solution will probably be to break the binding, which would be very disappointing for the JavaFX implementation. In my point of view the problem is not on the side of event creation. After all, every change should trigger an event and JavaFX triggers many changes. Imho, this should be fixed in how we react to events.

I also noticed the exception, but do not get a dialog. This seems to happen because of the save operation invoked by the backup.

A solution might be to do less backups, by:
 1. Doing backups only every X events and not for every event
 2. Ignoring FieldChangeEvents in the Backup
 3. Adding the size of the field change in the FieldChangeEvent class, so that you can ignore it if only 1 character changed.

This PR combines options 1. and 3., i.e.: The backup manager ignores events that are very minor and only does a backup if enough of them have happened (currently set to five).

What do you think?


- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
