### PR TITLE
Changes in the entry editor mark the database as dirty

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import javafx.beans.property.BooleanProperty;
 import javafx.geometry.VPos;
 import javafx.scene.Node;
 import javafx.scene.Parent;
@@ -37,7 +38,7 @@ import org.jabref.model.entry.InternalBibtexFields;
 /**
  * A single tab displayed in the EntryEditor holding several FieldEditors.
  */
-class FieldsEditorTab extends EntryEditorTab {
+public class FieldsEditorTab extends EntryEditorTab {
 
     private final Region panel;
     private final List<String> fields;
@@ -65,6 +66,10 @@ class FieldsEditorTab extends EntryEditorTab {
 
         // The following line makes sure focus cycles inside tab instead of being lost to other parts of the frame:
         //panel.setFocusCycleRoot(true);
+    }
+
+    public void markAsDirty() {
+        basePanel.markBaseChanged();
     }
 
     private static void addColumn(GridPane gridPane, int columnIndex, List<Label> nodes) {
@@ -121,7 +126,7 @@ class FieldsEditorTab extends EntryEditorTab {
             fieldEditor.setAutoCompleteListener(autoCompleteListener);
             */
 
-            FieldEditorFX fieldEditor = FieldEditors.getForField(fieldName, Globals.TASK_EXECUTOR, new FXDialogService(),
+            FieldEditorFX fieldEditor = FieldEditors.getForField(fieldName, Globals.TASK_EXECUTOR, this, new FXDialogService(),
                     Globals.journalAbbreviationLoader, Globals.prefs.getJournalAbbreviationPreferences(), Globals.prefs,
                     bPanel.getBibDatabaseContext(), entry.getType());
             fieldEditor.bindToEntry(entry);

--- a/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
@@ -9,7 +9,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import javafx.beans.property.BooleanProperty;
 import javafx.geometry.VPos;
 import javafx.scene.Node;
 import javafx.scene.Parent;

--- a/src/main/java/org/jabref/gui/fieldeditors/FieldEditors.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/FieldEditors.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import org.jabref.Globals;
 import org.jabref.gui.DialogService;
+import org.jabref.gui.entryeditor.FieldsEditorTab;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.journals.JournalAbbreviationLoader;
 import org.jabref.logic.journals.JournalAbbreviationPreferences;
@@ -15,7 +16,7 @@ import org.jabref.preferences.JabRefPreferences;
 
 public class FieldEditors {
 
-    public static FieldEditorFX getForField(String fieldName, TaskExecutor taskExecutor, DialogService dialogService, JournalAbbreviationLoader journalAbbreviationLoader, JournalAbbreviationPreferences journalAbbreviationPreferences, JabRefPreferences preferences, BibDatabaseContext databaseContext, String entryType) {
+    public static FieldEditorFX getForField(String fieldName, TaskExecutor taskExecutor, FieldsEditorTab editorTab, DialogService dialogService, JournalAbbreviationLoader journalAbbreviationLoader, JournalAbbreviationPreferences journalAbbreviationPreferences, JabRefPreferences preferences, BibDatabaseContext databaseContext, String entryType) {
         final Set<FieldProperty> fieldExtras = InternalBibtexFields.getFieldProperties(fieldName);
 
         if (Globals.prefs.get(JabRefPreferences.TIME_STAMP_FIELD).equals(fieldName) || fieldExtras.contains(FieldProperty.DATE)) {
@@ -25,36 +26,36 @@ public class FieldEditors {
                 return new DateEditor(fieldName, DateTimeFormatter.ofPattern(Globals.prefs.get(JabRefPreferences.TIME_STAMP_FORMAT)));
             }
         } else if (fieldExtras.contains(FieldProperty.EXTERNAL)) {
-            return new UrlEditor(fieldName, dialogService);
+            return new UrlEditor(fieldName, dialogService, editorTab);
         } else if (fieldExtras.contains(FieldProperty.JOURNAL_NAME)) {
-            return new JournalEditor(fieldName, journalAbbreviationLoader, journalAbbreviationPreferences);
+            return new JournalEditor(fieldName, journalAbbreviationLoader, journalAbbreviationPreferences, editorTab);
         } else if (fieldExtras.contains(FieldProperty.DOI) || fieldExtras.contains(FieldProperty.EPRINT) || fieldExtras.contains(FieldProperty.ISBN)) {
-            return new IdentifierEditor(fieldName, taskExecutor, dialogService);
+            return new IdentifierEditor(fieldName, taskExecutor, dialogService, editorTab);
         } else if (fieldExtras.contains(FieldProperty.OWNER)) {
-            return new OwnerEditor(fieldName, preferences);
+            return new OwnerEditor(fieldName, preferences, editorTab);
         } else if (fieldExtras.contains(FieldProperty.FILE_EDITOR)) {
-            return new LinkedFilesEditor(fieldName, dialogService, databaseContext, taskExecutor);
+            return new LinkedFilesEditor(fieldName, dialogService, databaseContext, taskExecutor, editorTab);
         } else if (fieldExtras.contains(FieldProperty.YES_NO)) {
-            return new OptionEditor<>(fieldName, new YesNoEditorViewModel());
+            return new OptionEditor<>(fieldName, new YesNoEditorViewModel(), editorTab);
         } else if (fieldExtras.contains(FieldProperty.MONTH)) {
-            return new OptionEditor<>(fieldName, new MonthEditorViewModel(databaseContext.getMode()));
+            return new OptionEditor<>(fieldName, new MonthEditorViewModel(databaseContext.getMode()), editorTab);
         } else if (fieldExtras.contains(FieldProperty.GENDER)) {
-            return new OptionEditor<>(fieldName, new GenderEditorViewModel());
+            return new OptionEditor<>(fieldName, new GenderEditorViewModel(), editorTab);
         } else if (fieldExtras.contains(FieldProperty.EDITOR_TYPE)) {
-            return new OptionEditor<>(fieldName, new EditorTypeEditorViewModel());
+            return new OptionEditor<>(fieldName, new EditorTypeEditorViewModel(), editorTab);
         } else if (fieldExtras.contains(FieldProperty.PAGINATION)) {
-            return new OptionEditor<>(fieldName, new PaginationEditorViewModel());
+            return new OptionEditor<>(fieldName, new PaginationEditorViewModel(), editorTab);
         } else if (fieldExtras.contains(FieldProperty.TYPE)) {
             if ("patent".equalsIgnoreCase(entryType)) {
-                return new OptionEditor<>(fieldName, new PatentTypeEditorViewModel());
+                return new OptionEditor<>(fieldName, new PatentTypeEditorViewModel(), editorTab);
             } else {
-                return new OptionEditor<>(fieldName, new TypeEditorViewModel());
+                return new OptionEditor<>(fieldName, new TypeEditorViewModel(), editorTab);
             }
         } else if (fieldExtras.contains(FieldProperty.SINGLE_ENTRY_LINK) || fieldExtras.contains(FieldProperty.MULTIPLE_ENTRY_LINK)) {
-            return new LinkedEntriesEditor(fieldName, databaseContext);
+            return new LinkedEntriesEditor(fieldName, databaseContext, editorTab);
         }
 
         // default
-        return new SimpleEditor(fieldName);
+        return new SimpleEditor(fieldName, editorTab);
     }
 }

--- a/src/main/java/org/jabref/gui/fieldeditors/IdentifierEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/IdentifierEditor.java
@@ -13,6 +13,7 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
 
 import org.jabref.gui.DialogService;
+import org.jabref.gui.entryeditor.FieldsEditorTab;
 import org.jabref.gui.fieldeditors.contextmenu.EditorMenus;
 import org.jabref.gui.util.ControlHelper;
 import org.jabref.gui.util.TaskExecutor;
@@ -29,13 +30,14 @@ public class IdentifierEditor extends HBox implements FieldEditorFX {
     @FXML private Button lookupIdentifierButton;
     private Optional<BibEntry> entry;
 
-    public IdentifierEditor(String fieldName, TaskExecutor taskExecutor, DialogService dialogService) {
+    public IdentifierEditor(String fieldName, TaskExecutor taskExecutor, DialogService dialogService, FieldsEditorTab editorTab) {
         this.fieldName = fieldName;
         this.viewModel = new IdentifierEditorViewModel(fieldName, taskExecutor, dialogService);
 
         ControlHelper.loadFXMLForControl(this);
 
         textArea.textProperty().bindBidirectional(viewModel.textProperty());
+        textArea.textProperty().addListener((observable, oldValue, newValue) -> editorTab.markAsDirty());
 
         fetchInformationByIdentifierButton.setTooltip(
                 new Tooltip(Localization.lang("Get BibTeX data from %0", FieldName.getDisplayName(fieldName))));

--- a/src/main/java/org/jabref/gui/fieldeditors/JournalEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/JournalEditor.java
@@ -7,6 +7,7 @@ import javafx.fxml.FXML;
 import javafx.scene.Parent;
 import javafx.scene.layout.HBox;
 
+import org.jabref.gui.entryeditor.FieldsEditorTab;
 import org.jabref.gui.fieldeditors.contextmenu.EditorMenus;
 import org.jabref.gui.util.ControlHelper;
 import org.jabref.logic.journals.JournalAbbreviationLoader;
@@ -20,13 +21,14 @@ public class JournalEditor extends HBox implements FieldEditorFX {
     @FXML private EditorTextArea textArea;
     private Optional<BibEntry> entry;
 
-    public JournalEditor(String fieldName, JournalAbbreviationLoader journalAbbreviationLoader, JournalAbbreviationPreferences journalAbbreviationPreferences) {
+    public JournalEditor(String fieldName, JournalAbbreviationLoader journalAbbreviationLoader, JournalAbbreviationPreferences journalAbbreviationPreferences, FieldsEditorTab editorTab) {
         this.fieldName = fieldName;
         this.viewModel = new JournalEditorViewModel(journalAbbreviationLoader, journalAbbreviationPreferences);
 
         ControlHelper.loadFXMLForControl(this);
 
         textArea.textProperty().bindBidirectional(viewModel.textProperty());
+        textArea.textProperty().addListener((observable, oldValue, newValue) -> editorTab.markAsDirty());
 
         textArea.addToContextMenu(EditorMenus.getDefaultMenu(textArea));
     }

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditor.java
@@ -5,6 +5,7 @@ import javafx.fxml.FXML;
 import javafx.scene.Parent;
 import javafx.scene.layout.HBox;
 
+import org.jabref.gui.entryeditor.FieldsEditorTab;
 import org.jabref.gui.util.ControlHelper;
 import org.jabref.gui.util.component.TagBar;
 import org.jabref.model.database.BibDatabaseContext;
@@ -17,7 +18,7 @@ public class LinkedEntriesEditor extends HBox implements FieldEditorFX {
     @FXML private LinkedEntriesEditorViewModel viewModel;
     @FXML private TagBar<ParsedEntryLink> linkedEntriesBar;
 
-    public LinkedEntriesEditor(String fieldName, BibDatabaseContext databaseContext) {
+    public LinkedEntriesEditor(String fieldName, BibDatabaseContext databaseContext, FieldsEditorTab editorTab) {
         this.fieldName = fieldName;
         this.viewModel = new LinkedEntriesEditorViewModel(databaseContext);
 
@@ -26,6 +27,7 @@ public class LinkedEntriesEditor extends HBox implements FieldEditorFX {
         linkedEntriesBar.setStringConverter(viewModel.getStringConverter());
         linkedEntriesBar.setOnTagClicked((parsedEntryLink, mouseEvent) -> viewModel.jumpToEntry(parsedEntryLink));
         Bindings.bindContentBidirectional(linkedEntriesBar.tagsProperty(), viewModel.linkedEntriesProperty());
+        linkedEntriesBar.tagsProperty().addListener((observable, oldValue, newValue) -> editorTab.markAsDirty());
     }
 
     public LinkedEntriesEditorViewModel getViewModel() {

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -22,6 +22,7 @@ import javafx.scene.text.Text;
 
 import org.jabref.Globals;
 import org.jabref.gui.DialogService;
+import org.jabref.gui.entryeditor.FieldsEditorTab;
 import org.jabref.gui.keyboard.KeyBinding;
 import org.jabref.gui.util.ControlHelper;
 import org.jabref.gui.util.TaskExecutor;
@@ -39,7 +40,7 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
     @FXML private final LinkedFilesEditorViewModel viewModel;
     @FXML private ListView<LinkedFileViewModel> listView;
 
-    public LinkedFilesEditor(String fieldName, DialogService dialogService, BibDatabaseContext databaseContext, TaskExecutor taskExecutor) {
+    public LinkedFilesEditor(String fieldName, DialogService dialogService, BibDatabaseContext databaseContext, TaskExecutor taskExecutor, FieldsEditorTab editorTab) {
         this.fieldName = fieldName;
         this.viewModel = new LinkedFilesEditorViewModel(dialogService, databaseContext, taskExecutor);
 
@@ -52,6 +53,7 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
                 .withOnMouseClickedEvent(this::handleItemMouseClick);
         listView.setCellFactory(cellFactory);
         Bindings.bindContent(listView.itemsProperty().get(), viewModel.filesProperty());
+        listView.itemsProperty().addListener((observable, oldValue, newValue) -> editorTab.markAsDirty());
         setUpKeyBindings();
     }
 

--- a/src/main/java/org/jabref/gui/fieldeditors/OptionEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/OptionEditor.java
@@ -5,6 +5,7 @@ import javafx.scene.Parent;
 import javafx.scene.control.ComboBox;
 import javafx.scene.layout.HBox;
 
+import org.jabref.gui.entryeditor.FieldsEditorTab;
 import org.jabref.gui.util.ControlHelper;
 import org.jabref.gui.util.ViewModelListCellFactory;
 import org.jabref.model.entry.BibEntry;
@@ -18,7 +19,7 @@ public class OptionEditor<T> extends HBox implements FieldEditorFX {
     @FXML private OptionEditorViewModel<T> viewModel;
     @FXML private ComboBox<T> comboBox;
 
-    public OptionEditor(String fieldName, OptionEditorViewModel<T> viewModel) {
+    public OptionEditor(String fieldName, OptionEditorViewModel<T> viewModel, FieldsEditorTab editorTab) {
         this.fieldName = fieldName;
         this.viewModel = viewModel;
 
@@ -28,6 +29,7 @@ public class OptionEditor<T> extends HBox implements FieldEditorFX {
         comboBox.setCellFactory(new ViewModelListCellFactory<T>().withText(viewModel::convertToDisplayText));
         comboBox.getItems().setAll(viewModel.getItems());
         comboBox.getEditor().textProperty().bindBidirectional(viewModel.textProperty());
+        comboBox.getEditor().textProperty().addListener((observable, oldValue, newValue) -> editorTab.markAsDirty());
     }
 
     public OptionEditorViewModel<T> getViewModel() {

--- a/src/main/java/org/jabref/gui/fieldeditors/OwnerEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/OwnerEditor.java
@@ -7,6 +7,7 @@ import javafx.fxml.FXML;
 import javafx.scene.Parent;
 import javafx.scene.layout.HBox;
 
+import org.jabref.gui.entryeditor.FieldsEditorTab;
 import org.jabref.gui.util.ControlHelper;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.preferences.JabRefPreferences;
@@ -18,13 +19,14 @@ public class OwnerEditor extends HBox implements FieldEditorFX {
     @FXML private EditorTextArea textArea;
     private Optional<BibEntry> entry;
 
-    public OwnerEditor(String fieldName, JabRefPreferences preferences) {
+    public OwnerEditor(String fieldName, JabRefPreferences preferences, FieldsEditorTab editorTab) {
         this.fieldName = fieldName;
         this.viewModel = new OwnerEditorViewModel(preferences);
 
         ControlHelper.loadFXMLForControl(this);
 
         textArea.textProperty().bindBidirectional(viewModel.textProperty());
+        textArea.textProperty().addListener((observable, oldValue, newValue) -> editorTab.markAsDirty());
     }
 
     public OwnerEditorViewModel getViewModel() {

--- a/src/main/java/org/jabref/gui/fieldeditors/SimpleEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/SimpleEditor.java
@@ -5,6 +5,7 @@ import javafx.scene.Parent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 
+import org.jabref.gui.entryeditor.FieldsEditorTab;
 import org.jabref.gui.fieldeditors.contextmenu.EditorMenus;
 import org.jabref.model.entry.BibEntry;
 
@@ -13,7 +14,7 @@ public class SimpleEditor extends HBox implements FieldEditorFX {
     protected final String fieldName;
     @FXML private final SimpleEditorViewModel viewModel;
 
-    public SimpleEditor(String fieldName) {
+    public SimpleEditor(String fieldName, FieldsEditorTab editorTab) {
         this.fieldName = fieldName;
         this.viewModel = new SimpleEditorViewModel();
 
@@ -21,6 +22,7 @@ public class SimpleEditor extends HBox implements FieldEditorFX {
         HBox.setHgrow(textArea, Priority.ALWAYS);
         textArea.textProperty().bindBidirectional(viewModel.textProperty());
         textArea.addToContextMenu(EditorMenus.getDefaultMenu(textArea));
+        textArea.textProperty().addListener((observable, oldValue, newValue) -> editorTab.markAsDirty());
         this.getChildren().add(textArea);
     }
 

--- a/src/main/java/org/jabref/gui/fieldeditors/UrlEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/UrlEditor.java
@@ -8,6 +8,7 @@ import javafx.scene.Parent;
 import javafx.scene.layout.HBox;
 
 import org.jabref.gui.DialogService;
+import org.jabref.gui.entryeditor.FieldsEditorTab;
 import org.jabref.gui.util.ControlHelper;
 import org.jabref.model.entry.BibEntry;
 
@@ -18,13 +19,14 @@ public class UrlEditor extends HBox implements FieldEditorFX {
     @FXML private EditorTextArea textArea;
     private Optional<BibEntry> entry;
 
-    public UrlEditor(String fieldName, DialogService dialogService) {
+    public UrlEditor(String fieldName, DialogService dialogService, FieldsEditorTab editorTab) {
         this.fieldName = fieldName;
         this.viewModel = new UrlEditorViewModel(dialogService);
 
         ControlHelper.loadFXMLForControl(this);
 
         textArea.textProperty().bindBidirectional(viewModel.textProperty());
+        textArea.textProperty().addListener((observable, oldValue, newValue) -> editorTab.markAsDirty());
     }
 
     public UrlEditorViewModel getViewModel() {


### PR DESCRIPTION
Partial fix to  #2787 

Changes in the entry editor now mark the database as dirty. This are somewhat proactive: even only opening the entry editor will mark the database as changed. I'd say this isn't a problem. I'd rather have it do the marking than forget one.

Essentially, this adds another listener to the properties in the entry editor that propagates the change whenever the property changes. I haven't figured out how to do this for groups.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
