### PR TITLE
Fix mac keybinding by replacing ctrl it with meta key

### DIFF
--- a/src/main/java/org/jabref/gui/keyboard/KeyBindingRepository.java
+++ b/src/main/java/org/jabref/gui/keyboard/KeyBindingRepository.java
@@ -155,6 +155,10 @@ public class KeyBindingRepository {
 
     private KeyCombination getKeyCombination(KeyBinding bindName) {
         String binding = get(bindName.getConstant());
+        if (OS.OS_X) {
+            binding = binding.replace("ctrl", "meta");
+        }
+
         return KeyCombination.valueOf(binding);
     }
 

--- a/src/test/java/org/jabref/gui/keyboard/KeyBindingsDialogViewModelTest.java
+++ b/src/test/java/org/jabref/gui/keyboard/KeyBindingsDialogViewModelTest.java
@@ -14,7 +14,6 @@ import org.jabref.preferences.PreferencesService;
 
 import org.junit.Before;
 import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -175,13 +174,10 @@ public class KeyBindingsDialogViewModelTest {
 
     @Test
     public void testConversionAwtKeyEventJavafxKeyEvent() {
-
-
         java.awt.event.KeyEvent evt = new java.awt.event.KeyEvent(mock(JFrame.class), 0, 0, InputEvent.CTRL_MASK, java.awt.event.KeyEvent.VK_S, java.awt.event.KeyEvent.CHAR_UNDEFINED);
 
         Optional<KeyBinding> keyBinding = keyBindingRepository.mapToKeyBinding(evt);
         assertEquals(Optional.of(KeyBinding.SAVE_DATABASE), keyBinding);
-
     }
 
     private KeyBindingViewModel setKeyBindingViewModel(KeyBinding binding) {


### PR DESCRIPTION
This should make the entry editor commands work again with Command+X /C etc

@chochreiner  Could you please test if that works now? Copy/Cut/Paste in the entry editor with Command key instead of control key.

Unfortunately I could not add a unit test, because the OS is a static class with final vars.

<!-- describe the changes you have made here: what, why, ... -->

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
