### PR TITLE
Only do a back up for bigger changes or if a different field is edited

### DIFF
--- a/src/main/java/org/jabref/logic/autosaveandbackup/BackupManager.java
+++ b/src/main/java/org/jabref/logic/autosaveandbackup/BackupManager.java
@@ -41,11 +41,9 @@ public class BackupManager {
 
     private static final String BACKUP_EXTENSION = ".sav";
 
-    private static final int MINOR_CHANGES_LIMIT = 5;
-
     private static Set<BackupManager> runningInstances = new HashSet<>();
 
-    private int minorChangesCount = 0;
+    private String lastFieldChanged;
 
     private final BibDatabaseContext bibDatabaseContext;
     private final JabRefPreferences preferences;
@@ -136,13 +134,13 @@ public class BackupManager {
         if (!(event instanceof FieldChangedEvent)) {
             startBackupTask();
         } else {
-            // only do a backup if the field changes are more than one character or if there are enough of them
+            // only do a backup if the field changes are more than one character or a new field is edited
             FieldChangedEvent fieldChange = (FieldChangedEvent) event;
-            if (fieldChange.getDelta() > 1 || minorChangesCount >= MINOR_CHANGES_LIMIT) {
+            boolean isEditOnNewField = lastFieldChanged == null || !lastFieldChanged.equals(fieldChange.getFieldName());
+
+            if (fieldChange.getDelta() > 1 || isEditOnNewField) {
+                lastFieldChanged = fieldChange.getFieldName();
                 startBackupTask();
-                minorChangesCount = 0;
-            } else {
-                minorChangesCount++;
             }
         }
     }


### PR DESCRIPTION
This PR makes the BackupManager a little more intelligent. It fixes a bug that I've only noticed locally and discussed with @tobiasdiez in chat. There's no issue for it, but the fix comes directly here.

If you have save actions configured (say LatexToUnicode) and the backup triggers too early (say after 5 characters) then the BackupManager interrupts you if you add a longer command in the entry edior (say `\alpha`). With this PR, the BackupManager is no longer triggered every five characters, but only if there are changes of more than one character (a user pastes text into the entry editor) or if the user edits a different field than before. This seems way more reasonable to me and is as it has been before (only backups when a user changes the field, edits a group, etc.)

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
