### PR TITLE
Don't enforce default Windows font

### DIFF
--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -452,7 +452,7 @@ public class JabRefPreferences implements PreferencesService {
             defaults.put(WIN_LOOK_AND_FEEL, UIManager.getSystemLookAndFeelClassName());
             defaults.put(EMACS_PATH, "emacsclient");
         } else if (OS.WINDOWS) {
-            defaults.put(FONT_FAMILY, "Arial");
+            defaults.put(FONT_FAMILY, "Unifont");
             defaults.put(WIN_LOOK_AND_FEEL, "com.jgoodies.looks.windows.WindowsLookAndFeel");
             defaults.put(EMACS_PATH, "emacsclient.exe");
         } else {

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -452,7 +452,6 @@ public class JabRefPreferences implements PreferencesService {
             defaults.put(WIN_LOOK_AND_FEEL, UIManager.getSystemLookAndFeelClassName());
             defaults.put(EMACS_PATH, "emacsclient");
         } else if (OS.WINDOWS) {
-            defaults.put(FONT_FAMILY, "Unifont");
             defaults.put(WIN_LOOK_AND_FEEL, "com.jgoodies.looks.windows.WindowsLookAndFeel");
             defaults.put(EMACS_PATH, "emacsclient.exe");
         } else {


### PR DESCRIPTION
Check below https://github.com/JabRef/jabref/pull/3008#issuecomment-315136683

> 
> Default Arial has only 3988 glyphs (cf. https://en.wikipedia.org/wiki/Unicode_font#List_of_Unicode_fonts), where italics don't seem to be supported.
> 
> To fix the issue at hand I would propose to change the font to GNU Unifont](https://en.wikipedia.org/wiki/GNU_Unifont) which supports 63,449 glyphs.
> 
> License-wise there shouldn't be any issues:
> 
> > The software on this site, unless otherwise noted, is released under the terms of the GNU General Public License (GNU GPL) version 2.0, or (at your option) a later version. The precompiled fonts are released under the terms of the GNU GPL version 2, or (at your option) a later version, with the exception that embedding the font in a document does not in itself bind that document to the terms of the GPL.
>  [source: unifoundry.com](http://www.unifoundry.com/)
> 

- [x] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef

<img width="271" alt="unifont" src="https://user-images.githubusercontent.com/1254003/28175224-ec053954-67f3-11e7-8563-d45da49d7231.PNG">


