### PR TITLE
Improve performance of journal abbreviation loader

### DIFF
--- a/src/main/java/org/jabref/collab/FileUpdateMonitor.java
+++ b/src/main/java/org/jabref/collab/FileUpdateMonitor.java
@@ -20,9 +20,19 @@ public class FileUpdateMonitor implements Runnable {
     private static final Log LOGGER = LogFactory.getLog(FileUpdateMonitor.class);
 
     private static final int WAIT = 4000;
-
-    private int numberOfUpdateListener;
     private final Map<String, Entry> entries = new HashMap<>();
+    private int numberOfUpdateListener;
+
+    private static synchronized Path getTempFile() {
+        Path temporaryFile = null;
+        try {
+            temporaryFile = Files.createTempFile("jabref", null);
+            temporaryFile.toFile().deleteOnExit();
+        } catch (IOException ex) {
+            LOGGER.warn("Could not create temporary file.", ex);
+        }
+        return temporaryFile;
+    }
 
     @Override
     public void run() {
@@ -119,7 +129,7 @@ public class FileUpdateMonitor implements Runnable {
      * is used for comparison with the changed on-disk version.
      * @param key String The handle for this monitor.
      * @throws IllegalArgumentException If the handle doesn't correspond to an entry.
-     * @return File The temporary file.
+     * @return Path The temporary file.
      */
     public Path getTempFile(String key) throws IllegalArgumentException {
         Entry entry = entries.get(key);
@@ -128,7 +138,6 @@ public class FileUpdateMonitor implements Runnable {
         }
         return entry.getTmpFile();
     }
-
 
     /**
      * A class containing the File, the FileUpdateListener and the current time stamp for one file.
@@ -208,16 +217,5 @@ public class FileUpdateMonitor implements Runnable {
         public void decreaseTimeStamp() {
             timeStamp--;
         }
-    }
-
-    private static synchronized Path getTempFile() {
-        Path temporaryFile = null;
-        try {
-            temporaryFile = Files.createTempFile("jabref", null);
-            temporaryFile.toFile().deleteOnExit();
-        } catch (IOException ex) {
-            LOGGER.warn("Could not create temporary file.", ex);
-        }
-        return temporaryFile;
     }
 }

--- a/src/main/java/org/jabref/logic/journals/AbbreviationParser.java
+++ b/src/main/java/org/jabref/logic/journals/AbbreviationParser.java
@@ -11,9 +11,11 @@ import java.io.Reader;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -25,7 +27,7 @@ public class AbbreviationParser {
 
     private static final Log LOGGER = LogFactory.getLog(AbbreviationParser.class);
 
-    private final List<Abbreviation> abbreviations = new LinkedList<>();
+    private final Set<Abbreviation> abbreviations = new HashSet<>(5000);
 
     public void readJournalListFromResource(String resourceFileName) {
         URL url = Objects.requireNonNull(JournalAbbreviationRepository.class.getResource(Objects.requireNonNull(resourceFileName)));
@@ -90,9 +92,7 @@ public class AbbreviationParser {
             }
 
             Abbreviation abbreviation = new Abbreviation(fullName, abbrName);
-            if (!abbreviations.contains(abbreviation)) {
-                this.abbreviations.add(abbreviation);
-            }
+            this.abbreviations.add(abbreviation);
         }
     }
 

--- a/src/test/java/org/jabref/gui/journals/ManageJournalAbbreviationsViewModelTest.java
+++ b/src/test/java/org/jabref/gui/journals/ManageJournalAbbreviationsViewModelTest.java
@@ -430,7 +430,7 @@ public class ManageJournalAbbreviationsViewModelTest {
 
         Assert.assertEquals(expected, actual);
 
-        expected = "Abbreviations = Abb" + NEWLINE + "Test Entry = TE" + NEWLINE + "MoreEntries = ME" + NEWLINE
+        expected = "EntryEntry = EE" + NEWLINE + "Abbreviations = Abb" + NEWLINE + "Test Entry = TE" + NEWLINE
                 + "SomeOtherEntry = SOE" + NEWLINE + "";
         actual = Files.contentOf(testFile5EntriesWithDuplicate.toFile(), StandardCharsets.UTF_8);
 

--- a/src/test/java/org/jabref/logic/journals/JournalAbbreviationRepositoryTest.java
+++ b/src/test/java/org/jabref/logic/journals/JournalAbbreviationRepositoryTest.java
@@ -41,15 +41,6 @@ public class JournalAbbreviationRepositoryTest {
     }
 
     @Test
-    public void testSorting() {
-        JournalAbbreviationRepository repository = new JournalAbbreviationRepository();
-        repository.addEntry(new Abbreviation("Long Name", "L. N."));
-        repository.addEntry(new Abbreviation("A Long Name", "AL. N."));
-        assertEquals("A Long Name", repository.getAbbreviations().first().getName());
-        assertEquals("Long Name", repository.getAbbreviations().last().getName());
-    }
-
-    @Test
     public void testDuplicates() {
         JournalAbbreviationRepository repository = new JournalAbbreviationRepository();
         repository.addEntry(new Abbreviation("Long Name", "L. N."));
@@ -63,9 +54,6 @@ public class JournalAbbreviationRepositoryTest {
         repository.addEntry(new Abbreviation("Old Long Name", "L. N."));
         repository.addEntry(new Abbreviation("New Long Name", "L. N."));
         assertEquals(2, repository.size());
-
-        assertEquals("L N", repository.getNextAbbreviation("L. N.").orElse("WRONG"));
-        assertEquals("New Long Name", repository.getNextAbbreviation("L N").orElse("WRONG"));
     }
 
     @Test


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
This PR improves the performance of the journal abbreviation loader/repository/parser and thus is a partial fix for https://github.com/JabRef/jabref/issues/2966.
Previously, loading and parsing the journal repository files took nearly 10 seconds and now almost nothing:
![image](https://user-images.githubusercontent.com/5037600/28175332-3b59e1da-67f4-11e7-9560-f2a504205c0a.png)
Main boost came from using `equalsIgnoreCase` instead of using `equals(text.toLowerCase())` and changing `LinkedList` to `HashSet` as we don't care about the ordering.
I had to adopt two tests which relied on the sorting.

Moreover, only one copy of the list is now stored in memory opposed to the 1 + 4 maps previously (equates to 1/10 RAM consummation). In principle, this makes the journal auto completion slower but I couldn't notice any negative impact.


- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
