### PR TITLE
Run Checkstyle task after Test task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -395,6 +395,7 @@ checkstyle {
 }
 
 checkstyleMain.shouldRunAfter test
+checkstyleTest.shouldRunAfter test
 
 task release(dependsOn: ["media", "releaseJar"]) {
     group = 'JabRef - Release'

--- a/build.gradle
+++ b/build.gradle
@@ -392,8 +392,9 @@ checkstyle {
     // do not use other packages for checkstyle, excluding gen(erated) sources
     checkstyleMain.source = "src/main/java"
     toolVersion = '8.0'
-    ignoreFailures = true
 }
+
+checkstyleMain.shouldRunAfter test
 
 task release(dependsOn: ["media", "releaseJar"]) {
     group = 'JabRef - Release'


### PR DESCRIPTION
This is an followup for https://github.com/JabRef/jabref/pull/3006.

I thought about it and maybe it's a good idea to run `checkstyle` after `test` and don't allow failures as suggested in #3006.

The alternative would be to show the checkstyle warnings, then execute the tests, and let the build fail afterwards. However, I couldn't find a nice way to achieve this.

What are your thoughts?