### PR TITLE
When browsing through the MainTable remember which EntryEditor tab was open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed a bug where new groups information was not stored on save [#2932](https://github.com/JabRef/jabref/issues/2932)
 - We fixed a bug where the language files for Brazilian Portugese could not be loaded and the GUI localization remained in English [#1128](https://github.com/JabRef/jabref/issues/1182)
 - We fixed a bug where the database was not marked as dirty when entries or groups were changed [#2787](https://github.com/JabRef/jabref/issues/2787)
-- We restored the original functionality that when browsing through the MainTable remembers which tab was opened before in the EntryEditor [#2896](https://github.com/JabRef/jabref/issues/2896)
+- We restored the original functionality that when browsing through the MainTable, the Entry Editor remembers which tab was opened before [#2896](https://github.com/JabRef/jabref/issues/2896)
 ### Removed
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed a bug where new groups information was not stored on save [#2932](https://github.com/JabRef/jabref/issues/2932)
 - We fixed a bug where the language files for Brazilian Portugese could not be loaded and the GUI localization remained in English [#1128](https://github.com/JabRef/jabref/issues/1182)
 - We fixed a bug where the database was not marked as dirty when entries or groups were changed [#2787](https://github.com/JabRef/jabref/issues/2787)
-
+- We restored the original functionality that when browsing through the MainTable remembers which tab was opened before in the EntryEditor [#2896](https://github.com/JabRef/jabref/issues/2896)
 ### Removed
 
 

--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -197,7 +197,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
     private StringDialog stringDialog;
     private SuggestionProviders suggestionProviders;
 
-    /** the query the user searches when this basepanel is active */
+    // the query the user searches when this BasePanel is active
     private Optional<SearchQuery> currentSearchQuery = Optional.empty();
 
     public BasePanel(JabRefFrame frame, BibDatabaseContext bibDatabaseContext) {
@@ -379,7 +379,6 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             } else {
                 preambleEditor.setVisible(true);
             }
-
         });
 
         // The action for opening the string editor
@@ -391,7 +390,6 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             } else {
                 stringDialog.setVisible(true);
             }
-
         });
 
         actions.put(FindUnlinkedFilesDialog.ACTION_COMMAND, (BaseAction) () -> {
@@ -722,6 +720,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
     /**
      * Generates and copies citations based on the selected entries to the clipboard
+     *
      * @param outputFormat the desired {@link CitationStyleOutputFormat}
      */
     private void copyCitationToClipboard(CitationStyleOutputFormat outputFormat) {
@@ -762,9 +761,9 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
     /**
      * Removes the selected entries from the database
-     * @param cut If false the user will get asked if he really wants to delete the entries, and it will be localized
-     *            as "deleted".
-     *            If true the action will be localized as "cut"
+     *
+     * @param cut If false the user will get asked if he really wants to delete the entries, and it will be localized as
+     *            "deleted". If true the action will be localized as "cut"
      */
     private void delete(boolean cut) {
         List<BibEntry> entries = mainTable.getSelectedEntries();
@@ -839,7 +838,6 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 bibDatabaseContext.getDatabase().insertEntry(be);
 
                 ce.addEdit(new UndoableInsertEntry(bibDatabaseContext.getDatabase(), be, BasePanel.this));
-
             }
             ce.end();
             getUndoManager().addEdit(ce);
@@ -946,7 +944,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             try {
                 layout = new LayoutHelper(sr,
                         Globals.prefs.getLayoutFormatterPreferences(Globals.journalAbbreviationLoader))
-                                .getLayoutFromText();
+                        .getLayoutFromText();
             } catch (IOException e) {
                 LOGGER.info("Could not get layout", e);
                 return;
@@ -1038,7 +1036,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
     }
 
     private boolean saveDatabase(File file, boolean selectedOnly, Charset enc,
-            SavePreferences.DatabaseSaveType saveType) throws SaveException {
+                                 SavePreferences.DatabaseSaveType saveType) throws SaveException {
         SaveSession session;
         frame.block();
         final String SAVE_DATABASE = Localization.lang("Save library");
@@ -1074,7 +1072,6 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             JOptionPane.showMessageDialog(frame, Localization.lang("Could not save file.") + "\n" + ex.getMessage(),
                     SAVE_DATABASE, JOptionPane.ERROR_MESSAGE);
             throw new SaveException("rt");
-
         } finally {
             frame.unblock();
         }
@@ -1092,7 +1089,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             String tryDiff = Localization.lang("Try different encoding");
             int answer = JOptionPane.showOptionDialog(frame, builder.getPanel(), SAVE_DATABASE,
                     JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null,
-                    new String[] {Localization.lang("Save"), tryDiff, Localization.lang("Cancel")}, tryDiff);
+                    new String[]{Localization.lang("Save"), tryDiff, Localization.lang("Cancel")}, tryDiff);
 
             if (answer == JOptionPane.NO_OPTION) {
                 // The user wants to use another encoding.
@@ -1103,12 +1100,10 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 } else {
                     Charset newEncoding = Charset.forName((String) choice);
                     return saveDatabase(file, selectedOnly, newEncoding, saveType);
-
                 }
             } else if (answer == JOptionPane.CANCEL_OPTION) {
                 commit = false;
             }
-
         }
 
         if (commit) {
@@ -1258,19 +1253,19 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             public void actionPerformed(ActionEvent e) {
                 // need to close these here, b/c this action overshadows the responsible actions when the main table is selected
                 switch (mode) {
-                case SHOWING_NOTHING:
-                    frame.getGlobalSearchBar().endSearch();
-                    break;
-                case SHOWING_PREVIEW:
-                    getPreviewPanel().close();
-                    break;
-                case SHOWING_EDITOR:
-                case WILL_SHOW_EDITOR:
-                    entryEditorClosing(getCurrentEditor());
-                    break;
-                default:
-                    LOGGER.warn("unknown BasePanelMode: '" + mode + "', doing nothing");
-                    break;
+                    case SHOWING_NOTHING:
+                        frame.getGlobalSearchBar().endSearch();
+                        break;
+                    case SHOWING_PREVIEW:
+                        getPreviewPanel().close();
+                        break;
+                    case SHOWING_EDITOR:
+                    case WILL_SHOW_EDITOR:
+                        entryEditorClosing(getCurrentEditor());
+                        break;
+                    default:
+                        LOGGER.warn("unknown BasePanelMode: '" + mode + "', doing nothing");
+                        break;
                 }
             }
         });
@@ -1317,16 +1312,16 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
 
                 if (e.isControlDown()) {
                     switch (keyCode) {
-                    case KeyEvent.VK_PAGE_DOWN:
-                        frame.nextTab.actionPerformed(null);
-                        e.consume();
-                        break;
-                    case KeyEvent.VK_PAGE_UP:
-                        frame.prevTab.actionPerformed(null);
-                        e.consume();
-                        break;
-                    default:
-                        break;
+                        case KeyEvent.VK_PAGE_DOWN:
+                            frame.nextTab.actionPerformed(null);
+                            e.consume();
+                            break;
+                        case KeyEvent.VK_PAGE_UP:
+                            frame.prevTab.actionPerformed(null);
+                            e.consume();
+                            break;
+                        default:
+                            break;
                     }
                 } else if (keyCode == KeyEvent.VK_ENTER) {
                     e.consume();
@@ -1443,7 +1438,6 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         } else {
             splitPane.setDividerLocation(
                     splitPane.getHeight() - Globals.prefs.getInt(JabRefPreferences.ENTRY_EDITOR_HEIGHT));
-
         }
     }
 
@@ -1451,9 +1445,9 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         return (splitPane.getBottomComponent() != null) && (splitPane.getBottomComponent() instanceof EntryEditor);
     }
 
-    public void showEntry(final BibEntry be) {
+    public void showEntry(final BibEntry bibEntry) {
 
-        if (getShowing() == be) {
+        if (getShowing() == bibEntry) {
             if (splitPane.getBottomComponent() == null) {
                 // This is the special occasion when showing is set to an
                 // entry, but no entry editor is in fact shown. This happens
@@ -1461,10 +1455,9 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 // must make sure the same entry is shown again. We do this by
                 // setting showing to null, and recursively calling this method.
                 newEntryShowing(null);
-                showEntry(be);
+                showEntry(bibEntry);
             }
             return;
-
         }
 
         String visName = null;
@@ -1473,25 +1466,27 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         }
 
         // We must instantiate a new editor.
-        EntryEditor entryEditor = new EntryEditor(frame, BasePanel.this, be);
+        EntryEditor entryEditor = getEntryEditor(bibEntry);
         if (visName != null) {
             entryEditor.setVisibleTab(visName);
         }
         showEntryEditor(entryEditor);
 
-        newEntryShowing(be);
+        newEntryShowing(bibEntry);
     }
 
     /**
-     * Get an entry editor ready to edit the given entry. If an appropriate editor is already cached, it will be updated
-     * and returned.
+     * Get an entry editor ready to edit the given entry.
      *
      * @param entry The entry to be edited.
      * @return A suitable entry editor.
      */
     public EntryEditor getEntryEditor(BibEntry entry) {
-        // Then start the new one:
-        return new EntryEditor(frame, BasePanel.this, entry);
+        String lastTabName = "";
+        if (currentEditor != null) {
+            lastTabName = currentEditor.getVisibleTabName();
+        }
+        return new EntryEditor(frame, BasePanel.this, entry, lastTabName);
     }
 
     public EntryEditor getCurrentEditor() {
@@ -1621,7 +1616,6 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 LOGGER.info("Problem marking database as changed", e);
             }
         }
-
     }
 
     private void markBasedChangedInternal() {
@@ -1723,7 +1717,6 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         } else {
             return true;
         }
-
     }
 
     /**
@@ -1737,7 +1730,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 Optional<String> oldKey = bes.getCiteKeyOptional();
                 if (!(oldKey.isPresent()) || oldKey.get().isEmpty()) {
                     BibtexKeyPatternUtil.makeAndSetLabel(bibDatabaseContext.getMetaData()
-                            .getCiteKeyPattern(Globals.prefs.getBibtexKeyPatternPreferences().getKeyPattern()),
+                                    .getCiteKeyPattern(Globals.prefs.getBibtexKeyPatternPreferences().getKeyPattern()),
                             bibDatabaseContext.getDatabase(),
                             bes, Globals.prefs.getBibtexKeyPatternPreferences());
                     bes.getCiteKeyOptional().ifPresent(
@@ -1756,8 +1749,6 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
     /**
      * Activates or deactivates the entry preview, depending on the argument. When deactivating, makes sure that any
      * visible preview is hidden.
-     *
-     * @param enabled
      */
     private void setPreviewActive(boolean enabled) {
         selectionListener.setPreviewActive(enabled);
@@ -1954,7 +1945,6 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             showing = entry;
             setBackAndForwardEnabledState();
         }
-
     }
 
     /**

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -142,7 +142,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
      */
     private boolean movingToDifferentEntry;
 
-    public EntryEditor(JabRefFrame frame, BasePanel panel, BibEntry entry) {
+    public EntryEditor(JabRefFrame frame, BasePanel panel, BibEntry entry, String lastTabName) {
         this.frame = frame;
         this.panel = panel;
         this.entry = Objects.requireNonNull(entry);
@@ -176,22 +176,22 @@ public class EntryEditor extends JPanel implements EntryContainer {
                 Optional<KeyBinding> keyBinding = Globals.getKeyPrefs().mapToKeyBinding(e);
                 if (keyBinding.isPresent()) {
                     switch (keyBinding.get()) {
-                    case CUT:
-                    case COPY:
-                    case PASTE:
-                    case CLOSE_ENTRY_EDITOR:
-                    case DELETE_ENTRY:
-                    case SELECT_ALL:
-                        e.consume();
-                        break;
-                    default:
-                        //do nothing
+                        case CUT:
+                        case COPY:
+                        case PASTE:
+                        case CLOSE_ENTRY_EDITOR:
+                        case DELETE_ENTRY:
+                        case SELECT_ALL:
+                            e.consume();
+                            break;
+                        default:
+                            //do nothing
                     }
                 }
             }
         });
         DefaultTaskExecutor.runInJavaFXThread(() -> {
-            addTabs();
+            addTabs(lastTabName);
             container.setScene(new Scene(tabbed));
         });
         add(container, BorderLayout.CENTER);
@@ -204,7 +204,10 @@ public class EntryEditor extends JPanel implements EntryContainer {
         });
 
         setupKeyBindings();
+    }
 
+    private void selectLastUsedTab(String lastTabName) {
+        tabbed.getTabs().stream().filter(tab -> lastTabName.equals(tab.getText())).findFirst().ifPresent(tab -> tabbed.getSelectionModel().select(tab));
     }
 
     /**
@@ -215,32 +218,32 @@ public class EntryEditor extends JPanel implements EntryContainer {
             Optional<KeyBinding> keyBinding = Globals.getKeyPrefs().mapToKeyBinding(event);
             if (keyBinding.isPresent()) {
                 switch (keyBinding.get()) {
-                case ENTRY_EDITOR_NEXT_PANEL:
-                case ENTRY_EDITOR_NEXT_PANEL_2:
-                    tabbed.getSelectionModel().selectNext();
-                    event.consume();
-                    break;
-                case ENTRY_EDITOR_PREVIOUS_PANEL:
-                case ENTRY_EDITOR_PREVIOUS_PANEL_2:
-                    tabbed.getSelectionModel().selectPrevious();
-                    event.consume();
-                    break;
-                case HELP:
-                    helpAction.actionPerformed(null);
-                    event.consume();
-                    break;
-                case CLOSE_ENTRY_EDITOR:
-                    closeAction.actionPerformed(null);
-                    event.consume();
-                    break;
-                default:
-                    // Pass other keys to children
+                    case ENTRY_EDITOR_NEXT_PANEL:
+                    case ENTRY_EDITOR_NEXT_PANEL_2:
+                        tabbed.getSelectionModel().selectNext();
+                        event.consume();
+                        break;
+                    case ENTRY_EDITOR_PREVIOUS_PANEL:
+                    case ENTRY_EDITOR_PREVIOUS_PANEL_2:
+                        tabbed.getSelectionModel().selectPrevious();
+                        event.consume();
+                        break;
+                    case HELP:
+                        helpAction.actionPerformed(null);
+                        event.consume();
+                        break;
+                    case CLOSE_ENTRY_EDITOR:
+                        closeAction.actionPerformed(null);
+                        event.consume();
+                        break;
+                    default:
+                        // Pass other keys to children
                 }
             }
         });
     }
 
-    private void addTabs() {
+    private void addTabs(String lastTabName) {
         EntryType type = EntryTypes.getTypeOrDefault(entry.getType(),
                 this.frame.getCurrentBasePanel().getBibDatabaseContext().getMode());
 
@@ -285,6 +288,8 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
         if (Globals.prefs.getBoolean(JabRefPreferences.DEFAULT_SHOW_SOURCE)) {
             tabbed.getSelectionModel().select(sourceTab);
+        } else {
+            selectLastUsedTab(lastTabName);
         }
     }
 
@@ -815,7 +820,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
             }
 
             BibtexKeyPatternUtil.makeAndSetLabel(panel.getBibDatabaseContext().getMetaData()
-                    .getCiteKeyPattern(Globals.prefs.getBibtexKeyPatternPreferences().getKeyPattern()),
+                            .getCiteKeyPattern(Globals.prefs.getBibtexKeyPatternPreferences().getKeyPattern()),
                     panel.getDatabase(), entry,
                     Globals.prefs.getBibtexKeyPatternPreferences());
 


### PR DESCRIPTION
This PR aims to solve a issue which was reported frequently (https://github.com/JabRef/jabref/issues/2675, https://github.com/JabRef/jabref/issues/2984, https://github.com/JabRef/jabref/issues/2896)

The solution I propose is to pass an argument with the name of the tab to be shown when instantiating a new EntryEditor.

- [x] Change in CHANGELOG.md described
- [x] Manually tested changed features in running JabRef
