### PR TITLE
Minimize depdencies fetched by using net.corda:jfx

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,10 @@ dependencies {
     compile 'de.codecentric.centerdevice:javafxsvg:1.2.1'
     compile 'org.controlsfx:controlsfx:8.40.12'
     compile 'org.fxmisc.easybind:easybind:1.0.3'
-    compile 'net.corda:jfx:0.12.1'
+    compile('net.corda:jfx:0.12.1') {
+        transitive = false
+    }
+    compile 'org.jetbrains.kotlin:kotlin-stdlib:1.1.2' // required by net.corda:jfxc
     compile 'org.fxmisc.flowless:flowless:0.5.2'
     compile 'de.jensd:fontawesomefx-materialdesignfont:1.7.22-4'
     compile 'org.fxmisc.richtext:richtextfx:0.7-M5'


### PR DESCRIPTION
This is to reduce the mass of transitive dependencies fetched by using corda.net. See https://github.com/JabRef/jabref/issues/3014.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
