### PR TITLE
Update source tab when an entry is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed a bug where the language files for Brazilian Portugese could not be loaded and the GUI localization remained in English [#1128](https://github.com/JabRef/jabref/issues/1182)
 - We fixed a bug where the database was not marked as dirty when entries or groups were changed [#2787](https://github.com/JabRef/jabref/issues/2787)
 - We restored the original functionality that when browsing through the MainTable, the Entry Editor remembers which tab was opened before [#2896](https://github.com/JabRef/jabref/issues/2896)
+- We fixed a bug where the source tab was not updated when one the fields was changed [#2888](https://github.com/JabRef/jabref/issues/2888)
+
 ### Removed
 
 

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -275,7 +275,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
         tabs.add(new RelatedArticlesTab(entry));
 
         // Source tab
-        SourceTab sourceTab = new SourceTab(panel.getBibDatabaseContext().getMode(), entry);
+        SourceTab sourceTab = new SourceTab(panel.getBibDatabaseContext(), entry);
         tabs.add(sourceTab);
 
         tabbed.getTabs().clear();

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -26,8 +26,8 @@ import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.entry.event.EntryChangedEvent;
 import org.jabref.model.entry.InternalBibtexFields;
+import org.jabref.model.entry.event.EntryChangedEvent;
 
 import com.google.common.eventbus.Subscribe;
 import org.apache.commons.logging.Log;

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -6,7 +6,6 @@ import java.io.StringWriter;
 import java.util.Map;
 import java.util.Objects;
 
-import com.google.common.eventbus.Subscribe;
 import javafx.scene.Node;
 import javafx.scene.control.Tooltip;
 
@@ -27,14 +26,15 @@ import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.event.EntryChangedEvent;
 import org.jabref.model.entry.InternalBibtexFields;
 
+import com.google.common.eventbus.Subscribe;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.flowless.VirtualizedScrollPane;
 import org.fxmisc.richtext.CodeArea;
-import org.jabref.model.entry.event.EntryChangedEvent;
 
 public class SourceTab extends EntryEditorTab {
 
@@ -53,8 +53,8 @@ public class SourceTab extends EntryEditorTab {
     }
 
     @Subscribe
-    public void listen(EntryChangedEvent event){
-        if(this.entry.equals(event.getBibEntry())) {
+    public void listen(EntryChangedEvent event) {
+        if (this.entry.equals(event.getBibEntry())) {
             try {
                 codeArea.clear();
                 codeArea.appendText(getSourceString(entry, mode));


### PR DESCRIPTION
Attempts to fix the remaining part of #2888. The source tab is now updated each time an entry is changed in the editor.

There no part of a BibEntry that represents the source tab per se to which we could bind. Therefore, this PR adds a listener to the source tab. It now listens to `EntryChangedEvents` and if the entry that it represents is changed, then it updates its content.

- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
