### PR TITLE
Initial idea for architectural decision records

### DIFF
--- a/docs/adr/0000-use-architectural-decision-records.md
+++ b/docs/adr/0000-use-architectural-decision-records.md
@@ -1,0 +1,16 @@
+# Use Architectural Decision Records
+
+We need to record the architectural decisions made on this project.
+
+## Considered Alternatives
+
+* No record
+* [DecisionRecord](https://github.com/schubmat/DecisionCapture)
+* [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions), maintainable by [adr-tools](https://github.com/npryce/adr-tools)
+* [Sustainable Architectural Decisions](https://www.infoq.com/articles/sustainable-architectural-design-decisions)
+* [Other templates](https://github.com/joelparkerhenderson/architecture_decision_record)
+
+## Conclusion
+
+* *Chosen Alternative: Decision Record*
+* That template is lean and fits most the development style

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,8 @@
+# Architectural Decision Records
+
+This lists the architectural decisions for JabRef.
+
+- [0000-use-architectural-decision-records.md](0000-use-architectural-decision-records) - Use Architectural Decision Records
+- [template.md](template/) - the template
+
+More information on architectural decision records is available at <https://adr.github.io/>.

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,36 @@
+# <Short Title of the Issue>
+
+**UserStory:** <TICKET/ISSUE-NUMBER>
+
+<WRITE ONE SENTENCE DESCRIBING THE PROBLEM. (Optional)>
+
+## Considered Alternatives
+
+* <ALTERNATIVE 1>
+* <ALTERNATIVE 2>
+* <ALTERNATIVE 3>
+
+## Conclusion
+
+* *Chosen Alternative: <ALTERNATIVE 1>*
+* <FURTHER RATIONALE (Optional)>
+
+## Comparison (Optional)
+
+### <ALTERNATIVE 1>
+
+* + <ARGUMENT 1 PRO>
+* + <ARGUMENT 2 PRO>
+* - <ARGUMENT 1 CONTRA>
+
+### <ALTERNATIVE 2>
+
+* + <ARGUMENT 1 PRO>
+* + <ARGUMENT 2 PRO>
+* - <ARGUMENT 1 CONTRA>
+
+### <ALTERNATIVE 3>
+
+* + <ARGUMENT 1 PRO>
+* + <ARGUMENT 2 PRO>
+* - <ARGUMENT 1 CONTRA>


### PR DESCRIPTION
I'd like to improve the code documentation of JabRef to make is easier for newcomers to understand the code. One part of that is to document the ideas behind of some code. This PR adds an initial directory and template for that.

I tried to collect background information at http://adr.github.io/.