### PR TITLE
Fix importing preferences after resetting without restarting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Fixed
 We fixed an issue where the fetcher for the Astrophysics Data System (ADS) added some non-bibtex data to the entry returned from the search [#3035](https://github.com/JabRef/jabref/issues/3035)
 We fixed an issue where assigning an entry via drag and drop to a group caused JabRef to stop/freeze completely [#3036](https://github.com/JabRef/jabref/issues/3036)
+We fixed an issue where the preferences could not be imported without a restart of JabRef [#3064](https://github.com/JabRef/jabref/issues/3064)
 ### Removed
 
 

--- a/src/main/java/org/jabref/gui/util/FileDialogConfiguration.java
+++ b/src/main/java/org/jabref/gui/util/FileDialogConfiguration.java
@@ -80,7 +80,8 @@ public class FileDialogConfiguration {
                 }
                 //The lines above work also if the dir does not exist at all!
                 //NULL is accepted by the filechooser as no inital path
-                if (!Files.exists(directory)) {
+                //Explicit null check, if somehow the parent is null, as Files.exists throws an NPE otherwise
+                if ((directory != null) && !Files.exists(directory)) {
                     directory = null;
                 }
                 initialDirectory = directory;

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -536,7 +536,7 @@ public class JabRefPreferences implements PreferencesService {
         defaults.put(EXPORT_WORKING_DIRECTORY, USER_HOME);
         // Remembers working directory of last import
         defaults.put(IMPORT_WORKING_DIRECTORY, USER_HOME);
-        defaults.put(PREFS_EXPORT_PATH, WORKING_DIRECTORY);
+        defaults.put(PREFS_EXPORT_PATH, USER_HOME);
         defaults.put(AUTO_OPEN_FORM, Boolean.TRUE);
         defaults.put(BACKUP, Boolean.TRUE);
         defaults.put(OPEN_LAST_EDITED, Boolean.TRUE);

--- a/src/test/java/org/jabref/gui/util/FileDialogConfigurationTest.java
+++ b/src/test/java/org/jabref/gui/util/FileDialogConfigurationTest.java
@@ -61,6 +61,15 @@ public class FileDialogConfigurationTest {
     }
 
     @Test
+    public void testWithNonExistingDirectoryAndParentNull() {
+        String tempFolder = "workingDirectory";
+        FileDialogConfiguration fileDialogConfiguration = new FileDialogConfiguration.Builder()
+                .withInitialDirectory(tempFolder).build();
+
+        assertEquals(Optional.ofNullable(null), fileDialogConfiguration.getInitialDirectory());
+    }
+
+    @Test
     public void testSingleExtension() {
         FileDialogConfiguration fileDialogConfiguration = new FileDialogConfiguration.Builder()
                 .withDefaultExtension(FileExtensions.BIBTEX_DB).build();


### PR DESCRIPTION
Set default Prefs to USER_HOME instead of working dir which could not have been intialized
Fix for #3064 

A rare case: When you did not restart JabRef after resetting the prefs, but directly imported them, the EXPORT_Path pref returned the key for WORKING_DIRECTORY - and in that case, the String "workingDirectory" which is a non existing directory and led to an NPE in File exists


<!-- describe the changes you have made here: what, why, ... -->

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
