### PR TITLE
Fix freezing when editing assigned file in General Tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed the shortcut <kbd>Ctrl</kbd>+<kbd>F</kbd> for the search field.
 - We fixed an issue where the preferences could not be imported without a restart of JabRef [#3064](https://github.com/JabRef/jabref/issues/3064)
 - We fixed an issue where <kbd>DEL</kbd>, <kbd>Ctrl</kbd>+<kbd>C</kbd>, <kbd>Ctrl</kbd>+<kbd>V</kbd> and <kbd>Ctrl</kbd>+<kbd>A</kbd> in the search field triggered corresponding actions in the main table [#3067](https://github.com/JabRef/jabref/issues/3067)
-
+- We fixed an issue where JabRef freezed when editing an assigned file in the `General`-Tab [#2930, comment](https://github.com/JabRef/jabref/issues/2930#issuecomment-311050976)
 ### Removed
 
 

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -7,6 +7,8 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 
+import javax.swing.SwingUtilities;
+
 import javafx.beans.Observable;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
@@ -262,6 +264,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
 
     public void edit() {
         FileListEntryEditor editor = new FileListEntryEditor(linkedFile, false, true, databaseContext);
-        editor.setVisible(true, false);
+        SwingUtilities.invokeLater(() -> editor.setVisible(true, false));
+
     }
 }


### PR DESCRIPTION
Swing GUI was called from FXApplication Thread which lead to a freeze.
Has to be called in Swing Thread. 
<!-- describe the changes you have made here: what, why, ... -->

Fixes https://github.com/JabRef/jabref/issues/2930#issuecomment-311050976

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
