### PR TITLE
Fix #3034: Make font size in entry editor and group panel customizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ## [Unreleased]
 
 ### Changed
-
+- We made the font size in the entry editor and group panel customizable by "Menu and label font size". [#3034](https://github.com/JabRef/jabref/issues/3034)
 - If fetched article is already in database, then the entry merge dialog is shown.
 - An error message is now displayed if you try to create a group containing the keyword separator or if there is already a group with the same name. [#3075](https://github.com/JabRef/jabref/issues/3075) and [#1495](https://github.com/JabRef/jabref/issues/1495)
 

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -186,6 +186,9 @@ public class EntryEditor extends JPanel implements EntryContainer {
         });
         DefaultTaskExecutor.runInJavaFXThread(() -> {
             addTabs(lastTabName);
+
+            tabbed.setStyle("-fx-font-size: " + Globals.prefs.getFontSizeFX() + "pt;");
+
             container.setScene(new Scene(tabbed));
         });
         add(container, BorderLayout.CENTER);

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -52,6 +52,15 @@ public class SourceTab extends EntryEditorTab {
         this.setGraphic(IconTheme.JabRefIcon.SOURCE.getGraphicNode());
     }
 
+    private static String getSourceString(BibEntry entry, BibDatabaseMode type) throws IOException {
+        StringWriter stringWriter = new StringWriter(200);
+        LatexFieldFormatter formatter = LatexFieldFormatter
+                .buildIgnoreHashes(Globals.prefs.getLatexFieldFormatterPreferences());
+        new BibEntryWriter(formatter, false).writeWithoutPrependedNewlines(entry, stringWriter, type);
+
+        return stringWriter.getBuffer().toString();
+    }
+
     @Subscribe
     public void listen(EntryChangedEvent event) {
         if (codeArea != null && this.entry.equals(event.getBibEntry())) {
@@ -67,19 +76,11 @@ public class SourceTab extends EntryEditorTab {
         }
     }
 
-    private static String getSourceString(BibEntry entry, BibDatabaseMode type) throws IOException {
-        StringWriter stringWriter = new StringWriter(200);
-        LatexFieldFormatter formatter = LatexFieldFormatter
-                .buildIgnoreHashes(Globals.prefs.getLatexFieldFormatterPreferences());
-        new BibEntryWriter(formatter, false).writeWithoutPrependedNewlines(entry, stringWriter, type);
-
-        return stringWriter.getBuffer().toString();
-    }
-
     private Node createSourceEditor(BibEntry entry, BibDatabaseMode mode) {
         codeArea = new CodeArea();
         codeArea.setWrapText(true);
-        //codeArea.(Font.font("Monospaced", Globals.prefs.getInt(JabRefPreferences.FONT_SIZE)));
+        codeArea.lookup(".styled-text-area").setStyle(
+                "-fx-font-size: " + Globals.prefs.getFontSizeFX() + "pt;");
         EasyBind.subscribe(codeArea.focusedProperty(), focused -> {
             if (!focused) {
                 storeSource();

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -123,6 +123,7 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
 
     private ContextMenu createContextMenuForFile(LinkedFileViewModel linkedFile) {
         ContextMenu menu = new ContextMenu();
+        menu.setStyle("-fx-font-size: " + Globals.prefs.getFontSizeFX() + "pt;");
 
         MenuItem edit = new MenuItem(Localization.lang("Edit"));
         edit.setOnAction(event -> linkedFile.edit());

--- a/src/main/java/org/jabref/gui/groups/GroupTreeController.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeController.java
@@ -31,6 +31,7 @@ import javafx.scene.input.TransferMode;
 import javafx.scene.layout.StackPane;
 import javafx.scene.text.Text;
 
+import org.jabref.Globals;
 import org.jabref.gui.AbstractController;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.DragAndDropDataFormats;
@@ -72,6 +73,7 @@ public class GroupTreeController extends AbstractController<GroupTreeViewModel> 
         viewModel = new GroupTreeViewModel(stateManager, dialogService, taskExecutor);
 
         // Set-up groups tree
+        groupTree.setStyle("-fx-font-size: " + Globals.prefs.getFontSizeFX() + "pt;");
         groupTree.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
 
         // Set-up bindings

--- a/src/main/java/org/jabref/preferences/JabRefPreferences.java
+++ b/src/main/java/org/jabref/preferences/JabRefPreferences.java
@@ -913,6 +913,11 @@ public class JabRefPreferences implements PreferencesService {
         storage.put(CLEANUP_FORMATTERS, convertListToString(preset.getFormatterCleanups().getAsStringList(OS.NEWLINE)));
     }
 
+    public int getFontSizeFX() {
+        // Decrease font size by 3 since JavaFX has default font size of 9, while Swing uses 12
+        return getInt(MENU_FONT_SIZE) - 3;
+    }
+
     public String getUser() {
         try {
             return get(DEFAULT_OWNER) + '-' + InetAddress.getLocalHost().getHostName();


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

This fix for #3034 is inspired and based on https://github.com/JabRef/jabref/pull/3042. Due to my limited git knowledge I was not able to directly hijack the other PR; sorry @lenhard.


- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
