### PR TITLE
Only load the telementry service as a background task if used

### DIFF
--- a/src/main/java/org/jabref/Globals.java
+++ b/src/main/java/org/jabref/Globals.java
@@ -1,6 +1,7 @@
 package org.jabref;
 
 import java.awt.Toolkit;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.jabref.collab.FileUpdateMonitor;
@@ -80,8 +81,8 @@ public class Globals {
 
     private static void stopTelemetryClient() {
         if (Globals.prefs.shouldCollectTelemetry()) {
-            telemetryClient.trackSessionState(SessionState.End);
-            telemetryClient.flush();
+            getTelemetryClient().ifPresent(client -> client.trackSessionState(SessionState.End));
+            getTelemetryClient().ifPresent(client -> client.flush());
         }
     }
 
@@ -119,7 +120,7 @@ public class Globals {
         stopTelemetryClient();
     }
 
-    public static TelemetryClient getTelemetryClient() {
-        return telemetryClient;
+    public static Optional<TelemetryClient> getTelemetryClient() {
+        return Optional.ofNullable(telemetryClient);
     }
 }

--- a/src/main/java/org/jabref/Globals.java
+++ b/src/main/java/org/jabref/Globals.java
@@ -73,12 +73,16 @@ public class Globals {
         Globals.fileUpdateMonitor = new FileUpdateMonitor();
         JabRefExecutorService.INSTANCE.executeInterruptableTask(Globals.fileUpdateMonitor, "FileUpdateMonitor");
 
-        startTelemetryClient();
+        if (Globals.prefs.shouldCollectTelemetry()) {
+            startTelemetryClient();
+        }
     }
 
     private static void stopTelemetryClient() {
-        telemetryClient.trackSessionState(SessionState.End);
-        telemetryClient.flush();
+        if (Globals.prefs.shouldCollectTelemetry()) {
+            telemetryClient.trackSessionState(SessionState.End);
+            telemetryClient.flush();
+        }
     }
 
     private static void startTelemetryClient() {

--- a/src/main/java/org/jabref/gui/JabRefDialog.java
+++ b/src/main/java/org/jabref/gui/JabRefDialog.java
@@ -54,8 +54,6 @@ public class JabRefDialog extends JDialog {
     }
 
     private <T extends JabRefDialog> void trackDialogOpening(Class<T> clazz) {
-        if (Globals.getTelemetryClient()!=null) {
-            Globals.getTelemetryClient().trackPageView(clazz.getName());
-        }
+        Globals.getTelemetryClient().ifPresent(client -> client.trackPageView(clazz.getName()));
     }
 }

--- a/src/main/java/org/jabref/gui/JabRefDialog.java
+++ b/src/main/java/org/jabref/gui/JabRefDialog.java
@@ -54,6 +54,8 @@ public class JabRefDialog extends JDialog {
     }
 
     private <T extends JabRefDialog> void trackDialogOpening(Class<T> clazz) {
-        Globals.getTelemetryClient().trackPageView(clazz.getName());
+        if (Globals.getTelemetryClient()!=null) {
+            Globals.getTelemetryClient().trackPageView(clazz.getName());
+        }
     }
 }

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -1584,7 +1584,9 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         Map<String, Double> measurements = new HashMap<>();
         measurements.put("NumberOfEntries", (double)basePanel.getDatabaseContext().getDatabase().getEntryCount());
 
-        Globals.getTelemetryClient().trackEvent("OpenNewDatabase", properties, measurements);
+        if (Globals.getTelemetryClient()!=null) {
+            Globals.getTelemetryClient().trackEvent("OpenNewDatabase", properties, measurements);
+        }
     }
 
     public BasePanel addTab(BibDatabaseContext databaseContext, boolean raisePanel) {

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -1584,9 +1584,7 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
         Map<String, Double> measurements = new HashMap<>();
         measurements.put("NumberOfEntries", (double)basePanel.getDatabaseContext().getDatabase().getEntryCount());
 
-        if (Globals.getTelemetryClient()!=null) {
-            Globals.getTelemetryClient().trackEvent("OpenNewDatabase", properties, measurements);
-        }
+        Globals.getTelemetryClient().ifPresent(client -> client.trackEvent("OpenNewDatabase", properties, measurements));
     }
 
     public BasePanel addTab(BibDatabaseContext databaseContext, boolean raisePanel) {

--- a/src/main/java/org/jabref/gui/logging/ApplicationInsightsAppender.java
+++ b/src/main/java/org/jabref/gui/logging/ApplicationInsightsAppender.java
@@ -48,6 +48,8 @@ public class ApplicationInsightsAppender extends AbstractAppender {
         }
         telemetry.getContext().getProperties().putAll(event.getCustomParameters());
 
-        Globals.getTelemetryClient().track(telemetry);
+        if (Globals.getTelemetryClient()!=null) {
+            Globals.getTelemetryClient().track(telemetry);
+        }
     }
 }

--- a/src/main/java/org/jabref/gui/logging/ApplicationInsightsAppender.java
+++ b/src/main/java/org/jabref/gui/logging/ApplicationInsightsAppender.java
@@ -48,8 +48,6 @@ public class ApplicationInsightsAppender extends AbstractAppender {
         }
         telemetry.getContext().getProperties().putAll(event.getCustomParameters());
 
-        if (Globals.getTelemetryClient()!=null) {
-            Globals.getTelemetryClient().track(telemetry);
-        }
+        Globals.getTelemetryClient().ifPresent(client -> client.track(telemetry));
     }
 }


### PR DESCRIPTION
Up to now, the telemetry service was always running (even if the reporting was turned of).
This initialization already requires a lot of time during startup, which is already rather long on MacOS

I hope I have caught all usages of the telemetry client to avoid nullpointer exceptions, but i would be great if @lynyus could have a look at it.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
