### PR TITLE
Add validation to entry editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We made the font size in the entry editor and group panel customizable by "Menu and label font size". [#3034](https://github.com/JabRef/jabref/issues/3034)
 - If fetched article is already in database, then the entry merge dialog is shown.
 - An error message is now displayed if you try to create a group containing the keyword separator or if there is already a group with the same name. [#3075](https://github.com/JabRef/jabref/issues/3075) and [#1495](https://github.com/JabRef/jabref/issues/1495)
+- Integrity warnings are now directly displayed in the entry editor.
 
 ### Fixed
 
@@ -26,6 +27,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where <kbd>DEL</kbd>, <kbd>Ctrl</kbd>+<kbd>C</kbd>, <kbd>Ctrl</kbd>+<kbd>V</kbd> and <kbd>Ctrl</kbd>+<kbd>A</kbd> in the search field triggered corresponding actions in the main table [#3067](https://github.com/JabRef/jabref/issues/3067)
 - We fixed an issue where JabRef freezed when editing an assigned file in the `General`-Tab [#2930, comment](https://github.com/JabRef/jabref/issues/2930#issuecomment-311050976)
 - We fixed an issue where a file could not be assigned to an existing entry via the entry context menu action `Attach file` [#3080](https://github.com/JabRef/jabref/issues/3080)
+
 ### Removed
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,7 @@ dependencies {
     compile 'de.codecentric.centerdevice:javafxsvg:1.2.1'
     compile 'org.controlsfx:controlsfx:8.40.13'
     compile 'org.fxmisc.easybind:easybind:1.0.3'
+    compile 'de.saxsys:mvvmfx-validation:1.6.0'
 
     compile 'org.fxmisc.flowless:flowless:0.5.2'
     compile 'de.jensd:fontawesomefx-materialdesignfont:1.7.22-4'

--- a/external-libraries.txt
+++ b/external-libraries.txt
@@ -224,6 +224,11 @@ Project: javafxsvg
 URL:     https://github.com/codecentric/javafxsvg
 License: BSD 3-Clause
 
+Id:      de.saxsys:mvvmfx
+Project: mvvm(fx)
+URL:     https://github.com/sialcasa/mvvmFX
+License: Apache-2.0
+
 Id:      com.github.tomtung
 Project: latex2unicode
 URL:     https://github.com/tomtung/latex2unicode

--- a/src/main/java/org/jabref/gui/fieldeditors/DateEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/DateEditor.java
@@ -9,6 +9,7 @@ import javafx.scene.layout.HBox;
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
 import org.jabref.gui.util.ControlHelper;
 import org.jabref.gui.util.component.TemporalAccessorPicker;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.model.entry.BibEntry;
 
 public class DateEditor extends HBox implements FieldEditorFX {
@@ -16,8 +17,8 @@ public class DateEditor extends HBox implements FieldEditorFX {
     @FXML private DateEditorViewModel viewModel;
     @FXML private TemporalAccessorPicker datePicker;
 
-    public DateEditor(String fieldName, DateTimeFormatter dateFormatter, AutoCompleteSuggestionProvider<?> suggestionProvider) {
-        this.viewModel = new DateEditorViewModel(fieldName, suggestionProvider, dateFormatter);
+    public DateEditor(String fieldName, DateTimeFormatter dateFormatter, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
+        this.viewModel = new DateEditorViewModel(fieldName, suggestionProvider, dateFormatter, fieldCheckers);
 
         ControlHelper.loadFXMLForControl(this);
 

--- a/src/main/java/org/jabref/gui/fieldeditors/DateEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/DateEditorViewModel.java
@@ -7,14 +7,15 @@ import java.time.temporal.TemporalAccessor;
 import javafx.util.StringConverter;
 
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.model.entry.Date;
 import org.jabref.model.strings.StringUtil;
 
 public class DateEditorViewModel extends AbstractEditorViewModel {
     private final DateTimeFormatter dateFormatter;
 
-    public DateEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, DateTimeFormatter dateFormatter) {
-        super(fieldName, suggestionProvider);
+    public DateEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, DateTimeFormatter dateFormatter, FieldCheckers fieldCheckers) {
+        super(fieldName, suggestionProvider, fieldCheckers);
         this.dateFormatter = dateFormatter;
     }
 

--- a/src/main/java/org/jabref/gui/fieldeditors/EditorTypeEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/EditorTypeEditorViewModel.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.fieldeditors;
 
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.logic.l10n.Localization;
 
 import com.google.common.collect.BiMap;
@@ -10,8 +11,8 @@ public class EditorTypeEditorViewModel extends MapBasedEditorViewModel<String> {
 
     private BiMap<String, String> itemMap = HashBiMap.create(7);
 
-    public EditorTypeEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider) {
-        super(fieldName, suggestionProvider);
+    public EditorTypeEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
+        super(fieldName, suggestionProvider, fieldCheckers);
 
         itemMap.put("editor", Localization.lang("Editor"));
         itemMap.put("compiler", Localization.lang("Compiler"));

--- a/src/main/java/org/jabref/gui/fieldeditors/FieldEditors.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/FieldEditors.java
@@ -10,6 +10,7 @@ import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
 import org.jabref.gui.autocompleter.ContentSelectorSuggestionProvider;
 import org.jabref.gui.autocompleter.SuggestionProviders;
 import org.jabref.gui.util.TaskExecutor;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.logic.journals.JournalAbbreviationLoader;
 import org.jabref.logic.journals.JournalAbbreviationPreferences;
 import org.jabref.model.database.BibDatabaseContext;
@@ -30,46 +31,48 @@ public class FieldEditors {
 
         AutoCompleteSuggestionProvider<?> suggestionProvider = getSuggestionProvider(fieldName, suggestionProviders, databaseContext.getMetaData());
 
+        FieldCheckers fieldCheckers = new FieldCheckers(databaseContext, preferences.getFileDirectoryPreferences());
+
         if (Globals.prefs.get(JabRefPreferences.TIME_STAMP_FIELD).equals(fieldName) || fieldExtras.contains(FieldProperty.DATE)) {
             if (fieldExtras.contains(FieldProperty.ISO_DATE)) {
-                return new DateEditor(fieldName, DateTimeFormatter.ofPattern("[uuuu][-MM][-dd]"), suggestionProvider);
+                return new DateEditor(fieldName, DateTimeFormatter.ofPattern("[uuuu][-MM][-dd]"), suggestionProvider, fieldCheckers);
             } else {
-                return new DateEditor(fieldName, DateTimeFormatter.ofPattern(Globals.prefs.get(JabRefPreferences.TIME_STAMP_FORMAT)), suggestionProvider);
+                return new DateEditor(fieldName, DateTimeFormatter.ofPattern(Globals.prefs.get(JabRefPreferences.TIME_STAMP_FORMAT)), suggestionProvider, fieldCheckers);
             }
         } else if (fieldExtras.contains(FieldProperty.EXTERNAL)) {
-            return new UrlEditor(fieldName, dialogService, suggestionProvider);
+            return new UrlEditor(fieldName, dialogService, suggestionProvider, fieldCheckers);
         } else if (fieldExtras.contains(FieldProperty.JOURNAL_NAME)) {
-            return new JournalEditor(fieldName, journalAbbreviationLoader, journalAbbreviationPreferences, suggestionProvider);
+            return new JournalEditor(fieldName, journalAbbreviationLoader, journalAbbreviationPreferences, suggestionProvider, fieldCheckers);
         } else if (fieldExtras.contains(FieldProperty.DOI) || fieldExtras.contains(FieldProperty.EPRINT) || fieldExtras.contains(FieldProperty.ISBN)) {
-            return new IdentifierEditor(fieldName, taskExecutor, dialogService, suggestionProvider);
+            return new IdentifierEditor(fieldName, taskExecutor, dialogService, suggestionProvider, fieldCheckers);
         } else if (fieldExtras.contains(FieldProperty.OWNER)) {
-            return new OwnerEditor(fieldName, preferences, suggestionProvider);
+            return new OwnerEditor(fieldName, preferences, suggestionProvider, fieldCheckers);
         } else if (fieldExtras.contains(FieldProperty.FILE_EDITOR)) {
-            return new LinkedFilesEditor(fieldName, dialogService, databaseContext, taskExecutor, suggestionProvider);
+            return new LinkedFilesEditor(fieldName, dialogService, databaseContext, taskExecutor, suggestionProvider, fieldCheckers);
         } else if (fieldExtras.contains(FieldProperty.YES_NO)) {
-            return new OptionEditor<>(fieldName, new YesNoEditorViewModel(fieldName, suggestionProvider));
+            return new OptionEditor<>(fieldName, new YesNoEditorViewModel(fieldName, suggestionProvider, fieldCheckers));
         } else if (fieldExtras.contains(FieldProperty.MONTH)) {
-            return new OptionEditor<>(fieldName, new MonthEditorViewModel(fieldName, suggestionProvider, databaseContext.getMode()));
+            return new OptionEditor<>(fieldName, new MonthEditorViewModel(fieldName, suggestionProvider, databaseContext.getMode(), fieldCheckers));
         } else if (fieldExtras.contains(FieldProperty.GENDER)) {
-            return new OptionEditor<>(fieldName, new GenderEditorViewModel(fieldName, suggestionProvider));
+            return new OptionEditor<>(fieldName, new GenderEditorViewModel(fieldName, suggestionProvider, fieldCheckers));
         } else if (fieldExtras.contains(FieldProperty.EDITOR_TYPE)) {
-            return new OptionEditor<>(fieldName, new EditorTypeEditorViewModel(fieldName, suggestionProvider));
+            return new OptionEditor<>(fieldName, new EditorTypeEditorViewModel(fieldName, suggestionProvider, fieldCheckers));
         } else if (fieldExtras.contains(FieldProperty.PAGINATION)) {
-            return new OptionEditor<>(fieldName, new PaginationEditorViewModel(fieldName, suggestionProvider));
+            return new OptionEditor<>(fieldName, new PaginationEditorViewModel(fieldName, suggestionProvider, fieldCheckers));
         } else if (fieldExtras.contains(FieldProperty.TYPE)) {
             if ("patent".equalsIgnoreCase(entryType)) {
-                return new OptionEditor<>(fieldName, new PatentTypeEditorViewModel(fieldName, suggestionProvider));
+                return new OptionEditor<>(fieldName, new PatentTypeEditorViewModel(fieldName, suggestionProvider, fieldCheckers));
             } else {
-                return new OptionEditor<>(fieldName, new TypeEditorViewModel(fieldName, suggestionProvider));
+                return new OptionEditor<>(fieldName, new TypeEditorViewModel(fieldName, suggestionProvider, fieldCheckers));
             }
         } else if (fieldExtras.contains(FieldProperty.SINGLE_ENTRY_LINK) || fieldExtras.contains(FieldProperty.MULTIPLE_ENTRY_LINK)) {
-            return new LinkedEntriesEditor(fieldName, databaseContext, suggestionProvider);
+            return new LinkedEntriesEditor(fieldName, databaseContext, suggestionProvider, fieldCheckers);
         } else if (fieldExtras.contains(FieldProperty.PERSON_NAMES)) {
-            return new PersonsEditor(fieldName, suggestionProvider, preferences.getAutoCompletePreferences());
+            return new PersonsEditor(fieldName, suggestionProvider, preferences.getAutoCompletePreferences(), fieldCheckers);
         }
 
         // default
-        return new SimpleEditor(fieldName, suggestionProvider);
+        return new SimpleEditor(fieldName, suggestionProvider, fieldCheckers);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/jabref/gui/fieldeditors/GenderEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/GenderEditorViewModel.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.fieldeditors;
 
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.logic.l10n.Localization;
 
 import com.google.common.collect.BiMap;
@@ -10,8 +11,8 @@ public class GenderEditorViewModel extends MapBasedEditorViewModel<String> {
 
     private BiMap<String, String> itemMap = HashBiMap.create(7);
 
-    public GenderEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider) {
-        super(fieldName, suggestionProvider);
+    public GenderEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
+        super(fieldName, suggestionProvider, fieldCheckers);
 
         itemMap.put("sf", Localization.lang("Female name"));
         itemMap.put("sm", Localization.lang("Male name"));

--- a/src/main/java/org/jabref/gui/fieldeditors/IdentifierEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/IdentifierEditor.java
@@ -17,9 +17,12 @@ import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
 import org.jabref.gui.fieldeditors.contextmenu.EditorMenus;
 import org.jabref.gui.util.ControlHelper;
 import org.jabref.gui.util.TaskExecutor;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.FieldName;
+
+import de.saxsys.mvvmfx.utils.validation.visualization.ControlsFxVisualizer;
 
 public class IdentifierEditor extends HBox implements FieldEditorFX {
 
@@ -29,8 +32,8 @@ public class IdentifierEditor extends HBox implements FieldEditorFX {
     @FXML private Button lookupIdentifierButton;
     private Optional<BibEntry> entry;
 
-    public IdentifierEditor(String fieldName, TaskExecutor taskExecutor, DialogService dialogService, AutoCompleteSuggestionProvider<?> suggestionProvider) {
-        this.viewModel = new IdentifierEditorViewModel(fieldName, suggestionProvider, taskExecutor, dialogService);
+    public IdentifierEditor(String fieldName, TaskExecutor taskExecutor, DialogService dialogService, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
+        this.viewModel = new IdentifierEditorViewModel(fieldName, suggestionProvider, taskExecutor, dialogService, fieldCheckers);
 
         ControlHelper.loadFXMLForControl(this);
 
@@ -47,6 +50,9 @@ public class IdentifierEditor extends HBox implements FieldEditorFX {
         }
         menuItems.addAll(EditorMenus.getDefaultMenu(textArea));
         textArea.addToContextMenu(menuItems);
+
+        ControlsFxVisualizer validationVisualizer = new ControlsFxVisualizer();
+        validationVisualizer.initVisualization(viewModel.getFieldValidator().getValidationStatus(), textArea);
     }
 
     public IdentifierEditorViewModel getViewModel() {

--- a/src/main/java/org/jabref/gui/fieldeditors/IdentifierEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/IdentifierEditorViewModel.java
@@ -16,6 +16,7 @@ import org.jabref.gui.util.BackgroundTask;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.importer.WebFetchers;
 import org.jabref.logic.importer.util.IdentifierParser;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.FieldName;
@@ -31,8 +32,8 @@ public class IdentifierEditorViewModel extends AbstractEditorViewModel {
     private TaskExecutor taskExecutor;
     private DialogService dialogService;
 
-    public IdentifierEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, TaskExecutor taskExecutor, DialogService dialogService) {
-        super(fieldName, suggestionProvider);
+    public IdentifierEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, TaskExecutor taskExecutor, DialogService dialogService, FieldCheckers fieldCheckers) {
+        super(fieldName, suggestionProvider, fieldCheckers);
 
         this.taskExecutor = taskExecutor;
         this.dialogService = dialogService;

--- a/src/main/java/org/jabref/gui/fieldeditors/JournalEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/JournalEditor.java
@@ -11,9 +11,12 @@ import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
 import org.jabref.gui.autocompleter.AutoCompletionTextInputBinding;
 import org.jabref.gui.fieldeditors.contextmenu.EditorMenus;
 import org.jabref.gui.util.ControlHelper;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.logic.journals.JournalAbbreviationLoader;
 import org.jabref.logic.journals.JournalAbbreviationPreferences;
 import org.jabref.model.entry.BibEntry;
+
+import de.saxsys.mvvmfx.utils.validation.visualization.ControlsFxVisualizer;
 
 public class JournalEditor extends HBox implements FieldEditorFX {
 
@@ -21,8 +24,8 @@ public class JournalEditor extends HBox implements FieldEditorFX {
     @FXML private EditorTextArea textArea;
     private Optional<BibEntry> entry;
 
-    public JournalEditor(String fieldName, JournalAbbreviationLoader journalAbbreviationLoader, JournalAbbreviationPreferences journalAbbreviationPreferences, AutoCompleteSuggestionProvider<?> suggestionProvider) {
-        this.viewModel = new JournalEditorViewModel(fieldName, suggestionProvider, journalAbbreviationLoader, journalAbbreviationPreferences);
+    public JournalEditor(String fieldName, JournalAbbreviationLoader journalAbbreviationLoader, JournalAbbreviationPreferences journalAbbreviationPreferences, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
+        this.viewModel = new JournalEditorViewModel(fieldName, suggestionProvider, journalAbbreviationLoader, journalAbbreviationPreferences, fieldCheckers);
 
         ControlHelper.loadFXMLForControl(this);
 
@@ -30,6 +33,9 @@ public class JournalEditor extends HBox implements FieldEditorFX {
         textArea.addToContextMenu(EditorMenus.getDefaultMenu(textArea));
 
         AutoCompletionTextInputBinding.autoComplete(textArea, viewModel::complete);
+
+        ControlsFxVisualizer validationVisualizer = new ControlsFxVisualizer();
+        validationVisualizer.initVisualization(viewModel.getFieldValidator().getValidationStatus(), textArea);
     }
 
     public JournalEditorViewModel getViewModel() {

--- a/src/main/java/org/jabref/gui/fieldeditors/JournalEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/JournalEditorViewModel.java
@@ -3,6 +3,7 @@ package org.jabref.gui.fieldeditors;
 import java.util.Optional;
 
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.logic.journals.JournalAbbreviationLoader;
 import org.jabref.logic.journals.JournalAbbreviationPreferences;
 import org.jabref.logic.journals.JournalAbbreviationRepository;
@@ -12,8 +13,8 @@ public class JournalEditorViewModel extends AbstractEditorViewModel {
     private final JournalAbbreviationLoader journalAbbreviationLoader;
     private final JournalAbbreviationPreferences journalAbbreviationPreferences;
 
-    public JournalEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, JournalAbbreviationLoader journalAbbreviationLoader, JournalAbbreviationPreferences journalAbbreviationPreferences) {
-        super(fieldName, suggestionProvider);
+    public JournalEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, JournalAbbreviationLoader journalAbbreviationLoader, JournalAbbreviationPreferences journalAbbreviationPreferences, FieldCheckers fieldCheckers) {
+        super(fieldName, suggestionProvider, fieldCheckers);
 
         this.journalAbbreviationLoader = journalAbbreviationLoader;
         this.journalAbbreviationPreferences = journalAbbreviationPreferences;

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditor.java
@@ -8,6 +8,7 @@ import javafx.scene.layout.HBox;
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
 import org.jabref.gui.util.ControlHelper;
 import org.jabref.gui.util.component.TagBar;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.ParsedEntryLink;
@@ -17,8 +18,8 @@ public class LinkedEntriesEditor extends HBox implements FieldEditorFX {
     @FXML private LinkedEntriesEditorViewModel viewModel;
     @FXML private TagBar<ParsedEntryLink> linkedEntriesBar;
 
-    public LinkedEntriesEditor(String fieldName, BibDatabaseContext databaseContext, AutoCompleteSuggestionProvider<?> suggestionProvider) {
-        this.viewModel = new LinkedEntriesEditorViewModel(fieldName, suggestionProvider, databaseContext);
+    public LinkedEntriesEditor(String fieldName, BibDatabaseContext databaseContext, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
+        this.viewModel = new LinkedEntriesEditorViewModel(fieldName, suggestionProvider, databaseContext, fieldCheckers);
 
         ControlHelper.loadFXMLForControl(this);
 

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedEntriesEditorViewModel.java
@@ -7,6 +7,7 @@ import javafx.util.StringConverter;
 
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
 import org.jabref.gui.util.BindingsHelper;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.EntryLinkList;
 import org.jabref.model.entry.ParsedEntryLink;
@@ -16,8 +17,8 @@ public class LinkedEntriesEditorViewModel extends AbstractEditorViewModel {
     private final BibDatabaseContext databaseContext;
     private final ListProperty<ParsedEntryLink> linkedEntries;
 
-    public LinkedEntriesEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, BibDatabaseContext databaseContext) {
-        super(fieldName, suggestionProvider);
+    public LinkedEntriesEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, BibDatabaseContext databaseContext, FieldCheckers fieldCheckers) {
+        super(fieldName, suggestionProvider, fieldCheckers);
 
         this.databaseContext = databaseContext;
         linkedEntries = new SimpleListProperty<>(FXCollections.observableArrayList());

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditor.java
@@ -27,6 +27,7 @@ import org.jabref.gui.keyboard.KeyBinding;
 import org.jabref.gui.util.ControlHelper;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.gui.util.ViewModelListCellFactory;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -39,8 +40,8 @@ public class LinkedFilesEditor extends HBox implements FieldEditorFX {
     @FXML private final LinkedFilesEditorViewModel viewModel;
     @FXML private ListView<LinkedFileViewModel> listView;
 
-    public LinkedFilesEditor(String fieldName, DialogService dialogService, BibDatabaseContext databaseContext, TaskExecutor taskExecutor, AutoCompleteSuggestionProvider<?> suggestionProvider) {
-        this.viewModel = new LinkedFilesEditorViewModel(fieldName, suggestionProvider, dialogService, databaseContext, taskExecutor);
+    public LinkedFilesEditor(String fieldName, DialogService dialogService, BibDatabaseContext databaseContext, TaskExecutor taskExecutor, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
+        this.viewModel = new LinkedFilesEditorViewModel(fieldName, suggestionProvider, dialogService, databaseContext, taskExecutor, fieldCheckers);
 
         ControlHelper.loadFXMLForControl(this);
 

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
@@ -30,6 +30,7 @@ import org.jabref.gui.util.BindingsHelper;
 import org.jabref.gui.util.FileDialogConfiguration;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.importer.FulltextFetchers;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.net.URLDownload;
 import org.jabref.logic.util.OS;
@@ -57,8 +58,8 @@ public class LinkedFilesEditorViewModel extends AbstractEditorViewModel {
     private final BibDatabaseContext databaseContext;
     private final TaskExecutor taskExecutor;
 
-    public LinkedFilesEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, DialogService dialogService, BibDatabaseContext databaseContext, TaskExecutor taskExecutor) {
-        super(fieldName, suggestionProvider);
+    public LinkedFilesEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, DialogService dialogService, BibDatabaseContext databaseContext, TaskExecutor taskExecutor, FieldCheckers fieldCheckers) {
+        super(fieldName, suggestionProvider, fieldCheckers);
 
         this.dialogService = dialogService;
         this.databaseContext = databaseContext;

--- a/src/main/java/org/jabref/gui/fieldeditors/MapBasedEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/MapBasedEditorViewModel.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javafx.util.StringConverter;
 
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
+import org.jabref.logic.integrity.FieldCheckers;
 
 import com.google.common.collect.BiMap;
 
@@ -14,8 +15,8 @@ import com.google.common.collect.BiMap;
  */
 public abstract class MapBasedEditorViewModel<T> extends OptionEditorViewModel<T> {
 
-    public MapBasedEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider) {
-        super(fieldName, suggestionProvider);
+    public MapBasedEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
+        super(fieldName, suggestionProvider, fieldCheckers);
     }
 
     protected abstract BiMap<String, T> getItemMap();

--- a/src/main/java/org/jabref/gui/fieldeditors/MonthEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/MonthEditorViewModel.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javafx.util.StringConverter;
 
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.Month;
 import org.jabref.model.strings.StringUtil;
@@ -13,8 +14,8 @@ import org.jabref.model.strings.StringUtil;
 public class MonthEditorViewModel extends OptionEditorViewModel<Month> {
     private BibDatabaseMode databaseMode;
 
-    public MonthEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, BibDatabaseMode databaseMode) {
-        super(fieldName, suggestionProvider);
+    public MonthEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, BibDatabaseMode databaseMode, FieldCheckers fieldCheckers) {
+        super(fieldName, suggestionProvider, fieldCheckers);
         this.databaseMode = databaseMode;
     }
 

--- a/src/main/java/org/jabref/gui/fieldeditors/OptionEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/OptionEditorViewModel.java
@@ -5,11 +5,12 @@ import java.util.List;
 import javafx.util.StringConverter;
 
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
+import org.jabref.logic.integrity.FieldCheckers;
 
 public abstract class OptionEditorViewModel<T> extends AbstractEditorViewModel {
 
-    public OptionEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider) {
-        super(fieldName, suggestionProvider);
+    public OptionEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
+        super(fieldName, suggestionProvider, fieldCheckers);
     }
 
     public abstract StringConverter<T> getStringConverter();

--- a/src/main/java/org/jabref/gui/fieldeditors/OwnerEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/OwnerEditor.java
@@ -7,20 +7,26 @@ import javafx.scene.layout.HBox;
 
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
 import org.jabref.gui.util.ControlHelper;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.preferences.JabRefPreferences;
+
+import de.saxsys.mvvmfx.utils.validation.visualization.ControlsFxVisualizer;
 
 public class OwnerEditor extends HBox implements FieldEditorFX {
 
     @FXML private OwnerEditorViewModel viewModel;
     @FXML private EditorTextArea textArea;
 
-    public OwnerEditor(String fieldName, JabRefPreferences preferences, AutoCompleteSuggestionProvider<?> suggestionProvider) {
-        this.viewModel = new OwnerEditorViewModel(fieldName, suggestionProvider, preferences);
+    public OwnerEditor(String fieldName, JabRefPreferences preferences, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
+        this.viewModel = new OwnerEditorViewModel(fieldName, suggestionProvider, preferences, fieldCheckers);
 
         ControlHelper.loadFXMLForControl(this);
 
         textArea.textProperty().bindBidirectional(viewModel.textProperty());
+
+        ControlsFxVisualizer validationVisualizer = new ControlsFxVisualizer();
+        validationVisualizer.initVisualization(viewModel.getFieldValidator().getValidationStatus(), textArea);
     }
 
     public OwnerEditorViewModel getViewModel() {

--- a/src/main/java/org/jabref/gui/fieldeditors/OwnerEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/OwnerEditorViewModel.java
@@ -1,13 +1,14 @@
 package org.jabref.gui.fieldeditors;
 
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.preferences.JabRefPreferences;
 
 public class OwnerEditorViewModel extends AbstractEditorViewModel {
     private final JabRefPreferences preferences;
 
-    public OwnerEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, JabRefPreferences preferences) {
-        super(fieldName, suggestionProvider);
+    public OwnerEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, JabRefPreferences preferences, FieldCheckers fieldCheckers) {
+        super(fieldName, suggestionProvider, fieldCheckers);
         this.preferences = preferences;
     }
 

--- a/src/main/java/org/jabref/gui/fieldeditors/PaginationEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/PaginationEditorViewModel.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.fieldeditors;
 
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.logic.l10n.Localization;
 
 import com.google.common.collect.BiMap;
@@ -10,8 +11,8 @@ public class PaginationEditorViewModel extends MapBasedEditorViewModel<String> {
 
     private BiMap<String, String> itemMap = HashBiMap.create(7);
 
-    public PaginationEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider) {
-        super(fieldName, suggestionProvider);
+    public PaginationEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
+        super(fieldName, suggestionProvider, fieldCheckers);
 
         itemMap.put("page", Localization.lang("Page"));
         itemMap.put("column", Localization.lang("Column"));

--- a/src/main/java/org/jabref/gui/fieldeditors/PatentTypeEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/PatentTypeEditorViewModel.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.fieldeditors;
 
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.logic.l10n.Localization;
 
 import com.google.common.collect.BiMap;
@@ -10,8 +11,8 @@ public class PatentTypeEditorViewModel extends MapBasedEditorViewModel<String> {
 
     private BiMap<String, String> itemMap = HashBiMap.create(12);
 
-    public PatentTypeEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider) {
-        super(fieldName, suggestionProvider);
+    public PatentTypeEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
+        super(fieldName, suggestionProvider, fieldCheckers);
 
         itemMap.put("patent", Localization.lang("Patent"));
         itemMap.put("patentde", Localization.lang("German patent"));

--- a/src/main/java/org/jabref/gui/fieldeditors/PersonsEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/PersonsEditor.java
@@ -9,14 +9,17 @@ import org.jabref.gui.autocompleter.AutoCompletePreferences;
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
 import org.jabref.gui.autocompleter.AutoCompletionTextInputBinding;
 import org.jabref.gui.fieldeditors.contextmenu.EditorMenus;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.model.entry.BibEntry;
+
+import de.saxsys.mvvmfx.utils.validation.visualization.ControlsFxVisualizer;
 
 public class PersonsEditor extends HBox implements FieldEditorFX {
 
     @FXML private final PersonsEditorViewModel viewModel;
 
-    public PersonsEditor(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, AutoCompletePreferences autoCompletePreferences) {
-        this.viewModel = new PersonsEditorViewModel(fieldName, suggestionProvider, autoCompletePreferences);
+    public PersonsEditor(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, AutoCompletePreferences autoCompletePreferences, FieldCheckers fieldCheckers) {
+        this.viewModel = new PersonsEditorViewModel(fieldName, suggestionProvider, autoCompletePreferences, fieldCheckers);
 
         EditorTextArea textArea = new EditorTextArea();
         HBox.setHgrow(textArea, Priority.ALWAYS);
@@ -25,6 +28,9 @@ public class PersonsEditor extends HBox implements FieldEditorFX {
         this.getChildren().add(textArea);
 
         AutoCompletionTextInputBinding.autoComplete(textArea, viewModel::complete, viewModel.getAutoCompletionConverter(), viewModel.getAutoCompletionStrategy());
+
+        ControlsFxVisualizer validationVisualizer = new ControlsFxVisualizer();
+        validationVisualizer.initVisualization(viewModel.getFieldValidator().getValidationStatus(), textArea);
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/fieldeditors/PersonsEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/PersonsEditorViewModel.java
@@ -9,6 +9,7 @@ import org.jabref.gui.autocompleter.AutoCompletePreferences;
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
 import org.jabref.gui.autocompleter.AutoCompletionStrategy;
 import org.jabref.gui.autocompleter.PersonNameStringConverter;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.model.entry.Author;
 
 import org.controlsfx.control.textfield.AutoCompletionBinding;
@@ -17,8 +18,8 @@ public class PersonsEditorViewModel extends AbstractEditorViewModel {
 
     private final AutoCompletePreferences preferences;
 
-    public PersonsEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, AutoCompletePreferences preferences) {
-        super(fieldName, suggestionProvider);
+    public PersonsEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, AutoCompletePreferences preferences, FieldCheckers fieldCheckers) {
+        super(fieldName, suggestionProvider, fieldCheckers);
         this.preferences = preferences;
     }
 

--- a/src/main/java/org/jabref/gui/fieldeditors/SimpleEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/SimpleEditor.java
@@ -9,14 +9,17 @@ import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
 import org.jabref.gui.autocompleter.AutoCompletionTextInputBinding;
 import org.jabref.gui.autocompleter.ContentSelectorSuggestionProvider;
 import org.jabref.gui.fieldeditors.contextmenu.EditorMenus;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.model.entry.BibEntry;
+
+import de.saxsys.mvvmfx.utils.validation.visualization.ControlsFxVisualizer;
 
 public class SimpleEditor extends HBox implements FieldEditorFX {
 
     @FXML private final SimpleEditorViewModel viewModel;
 
-    public SimpleEditor(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider) {
-        this.viewModel = new SimpleEditorViewModel(fieldName, suggestionProvider);
+    public SimpleEditor(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
+        this.viewModel = new SimpleEditorViewModel(fieldName, suggestionProvider, fieldCheckers);
 
         EditorTextArea textArea = new EditorTextArea();
         HBox.setHgrow(textArea, Priority.ALWAYS);
@@ -29,6 +32,9 @@ public class SimpleEditor extends HBox implements FieldEditorFX {
             // If content selector values are present, then we want to show the auto complete suggestions immediately on focus
             autoCompleter.setShowOnFocus(true);
         }
+
+        ControlsFxVisualizer validationVisualizer = new ControlsFxVisualizer();
+        validationVisualizer.initVisualization(viewModel.getFieldValidator().getValidationStatus(), textArea);
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/fieldeditors/SimpleEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/SimpleEditorViewModel.java
@@ -3,11 +3,12 @@ package org.jabref.gui.fieldeditors;
 import org.jabref.gui.autocompleter.AppendWordsStrategy;
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
 import org.jabref.gui.autocompleter.AutoCompletionStrategy;
+import org.jabref.logic.integrity.FieldCheckers;
 
 public class SimpleEditorViewModel extends AbstractEditorViewModel {
 
-    public SimpleEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider) {
-        super(fieldName, suggestionProvider);
+    public SimpleEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
+        super(fieldName, suggestionProvider, fieldCheckers);
     }
 
     public AutoCompletionStrategy getAutoCompletionStrategy() {

--- a/src/main/java/org/jabref/gui/fieldeditors/TypeEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/TypeEditorViewModel.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.fieldeditors;
 
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.logic.l10n.Localization;
 
 import com.google.common.collect.BiMap;
@@ -10,8 +11,8 @@ public class TypeEditorViewModel extends MapBasedEditorViewModel<String> {
 
     private BiMap<String, String> itemMap = HashBiMap.create(8);
 
-    public TypeEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider) {
-        super(fieldName, suggestionProvider);
+    public TypeEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
+        super(fieldName, suggestionProvider, fieldCheckers);
 
         itemMap.put("mathesis", Localization.lang("Master's thesis"));
         itemMap.put("phdthesis", Localization.lang("PhD thesis"));

--- a/src/main/java/org/jabref/gui/fieldeditors/UrlEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/UrlEditor.java
@@ -8,19 +8,25 @@ import javafx.scene.layout.HBox;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
 import org.jabref.gui.util.ControlHelper;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.model.entry.BibEntry;
+
+import de.saxsys.mvvmfx.utils.validation.visualization.ControlsFxVisualizer;
 
 public class UrlEditor extends HBox implements FieldEditorFX {
 
     @FXML private UrlEditorViewModel viewModel;
     @FXML private EditorTextArea textArea;
 
-    public UrlEditor(String fieldName, DialogService dialogService, AutoCompleteSuggestionProvider<?> suggestionProvider) {
-        this.viewModel = new UrlEditorViewModel(fieldName, suggestionProvider, dialogService);
+    public UrlEditor(String fieldName, DialogService dialogService, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
+        this.viewModel = new UrlEditorViewModel(fieldName, suggestionProvider, dialogService, fieldCheckers);
 
         ControlHelper.loadFXMLForControl(this);
 
         textArea.textProperty().bindBidirectional(viewModel.textProperty());
+
+        ControlsFxVisualizer validationVisualizer = new ControlsFxVisualizer();
+        validationVisualizer.initVisualization(viewModel.getFieldValidator().getValidationStatus(), textArea);
     }
 
     public UrlEditorViewModel getViewModel() {

--- a/src/main/java/org/jabref/gui/fieldeditors/UrlEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/UrlEditorViewModel.java
@@ -8,6 +8,7 @@ import javafx.beans.property.SimpleBooleanProperty;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
 import org.jabref.gui.desktop.JabRefDesktop;
+import org.jabref.logic.integrity.FieldCheckers;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.net.URLUtil;
 import org.jabref.model.strings.StringUtil;
@@ -18,8 +19,8 @@ public class UrlEditorViewModel extends AbstractEditorViewModel {
     private DialogService dialogService;
     private BooleanProperty validUrlIsNotPresent = new SimpleBooleanProperty(true);
 
-    public UrlEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, DialogService dialogService) {
-        super(fieldName, suggestionProvider);
+    public UrlEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, DialogService dialogService, FieldCheckers fieldCheckers) {
+        super(fieldName, suggestionProvider, fieldCheckers);
         this.dialogService = dialogService;
 
         validUrlIsNotPresent.bind(

--- a/src/main/java/org/jabref/gui/fieldeditors/YesNoEditorViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/YesNoEditorViewModel.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.fieldeditors;
 
 import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
+import org.jabref.logic.integrity.FieldCheckers;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -9,8 +10,8 @@ public class YesNoEditorViewModel extends MapBasedEditorViewModel<String> {
 
     private BiMap<String, String> itemMap = HashBiMap.create(2);
 
-    public YesNoEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider) {
-        super(fieldName, suggestionProvider);
+    public YesNoEditorViewModel(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers) {
+        super(fieldName, suggestionProvider, fieldCheckers);
 
         itemMap.put("yes", "Yes");
         itemMap.put("no", "No");

--- a/src/main/java/org/jabref/logic/integrity/AbbreviationChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/AbbreviationChecker.java
@@ -3,11 +3,16 @@ package org.jabref.logic.integrity;
 import java.util.Optional;
 
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.strings.StringUtil;
 
 public class AbbreviationChecker implements ValueChecker {
 
     @Override
     public Optional<String> checkValue(String value) {
+        if (StringUtil.isBlank(value)) {
+            return Optional.empty();
+        }
+
         if (value.contains(".")) {
             return Optional.of(Localization.lang("abbreviation detected"));
         }

--- a/src/main/java/org/jabref/logic/integrity/BooktitleChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/BooktitleChecker.java
@@ -4,11 +4,16 @@ import java.util.Locale;
 import java.util.Optional;
 
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.strings.StringUtil;
 
 public class BooktitleChecker implements ValueChecker {
 
     @Override
     public Optional<String> checkValue(String value) {
+        if (StringUtil.isBlank(value)) {
+            return Optional.empty();
+        }
+
         if (value.toLowerCase(Locale.ENGLISH).endsWith("conference on")) {
             return Optional.of(Localization.lang("booktitle ends with 'conference on'"));
         }

--- a/src/main/java/org/jabref/logic/integrity/BracketChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/BracketChecker.java
@@ -3,11 +3,16 @@ package org.jabref.logic.integrity;
 import java.util.Optional;
 
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.strings.StringUtil;
 
 public class BracketChecker implements ValueChecker {
 
     @Override
     public Optional<String> checkValue(String value) {
+        if (StringUtil.isBlank(value)) {
+            return Optional.empty();
+        }
+
         // metaphor: integer-based stack (push + / pop -)
         int counter = 0;
         for (char a : value.trim().toCharArray()) {

--- a/src/main/java/org/jabref/logic/integrity/DOIValidityChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/DOIValidityChecker.java
@@ -4,11 +4,16 @@ import java.util.Optional;
 
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.identifier.DOI;
+import org.jabref.model.strings.StringUtil;
 
 public class DOIValidityChecker implements ValueChecker {
 
     @Override
     public Optional<String> checkValue(String value) {
+        if (StringUtil.isBlank(value)) {
+            return Optional.empty();
+        }
+
         if (DOI.isValid(value)) {
             return Optional.empty();
         } else {

--- a/src/main/java/org/jabref/logic/integrity/EditionChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/EditionChecker.java
@@ -7,6 +7,7 @@ import java.util.regex.Pattern;
 
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.strings.StringUtil;
 
 public class EditionChecker implements ValueChecker {
 
@@ -33,6 +34,10 @@ public class EditionChecker implements ValueChecker {
      */
     @Override
     public Optional<String> checkValue(String value) {
+        if (StringUtil.isBlank(value)) {
+            return Optional.empty();
+        }
+
         //biblatex
         if (bibDatabaseContextEdition.isBiblatexMode() && !ONLY_NUMERALS_OR_LITERALS.test(value.trim())) {
             return Optional.of(Localization.lang("should contain an integer or a literal"));

--- a/src/main/java/org/jabref/logic/integrity/FieldCheckers.java
+++ b/src/main/java/org/jabref/logic/integrity/FieldCheckers.java
@@ -1,5 +1,6 @@
 package org.jabref.logic.integrity;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -13,14 +14,10 @@ import com.google.common.collect.Multimap;
 
 public class FieldCheckers {
 
-    private FieldCheckers() {
-    }
+    private Multimap<String, ValueChecker> fieldChecker;
 
-    static List<FieldChecker> getAll(BibDatabaseContext databaseContext, FileDirectoryPreferences fileDirectoryPreferences) {
-        return getAllMap(databaseContext, fileDirectoryPreferences)
-                .entries().stream()
-                .map(pair -> new FieldChecker(pair.getKey(), pair.getValue()))
-                .collect(Collectors.toList());
+    public FieldCheckers(BibDatabaseContext databaseContext, FileDirectoryPreferences fileDirectoryPreferences) {
+        fieldChecker = getAllMap(databaseContext, fileDirectoryPreferences);
     }
 
     private static Multimap<String, ValueChecker> getAllMap(BibDatabaseContext databaseContext, FileDirectoryPreferences fileDirectoryPreferences) {
@@ -51,5 +48,18 @@ public class FieldCheckers {
         fieldCheckers.put(FieldName.YEAR, new YearChecker());
 
         return fieldCheckers;
+    }
+
+    public List<FieldChecker> getAll() {
+        return fieldChecker
+                .entries()
+                .stream()
+                .map(pair -> new FieldChecker(pair.getKey(), pair.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    public Collection<ValueChecker> getForField(String field) {
+        return fieldChecker
+                .get(field);
     }
 }

--- a/src/main/java/org/jabref/logic/integrity/FileChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/FileChecker.java
@@ -11,6 +11,7 @@ import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.FileFieldParser;
 import org.jabref.model.entry.LinkedFile;
 import org.jabref.model.metadata.FileDirectoryPreferences;
+import org.jabref.model.strings.StringUtil;
 
 public class FileChecker implements ValueChecker {
 
@@ -25,6 +26,10 @@ public class FileChecker implements ValueChecker {
 
     @Override
     public Optional<String> checkValue(String value) {
+        if (StringUtil.isBlank(value)) {
+            return Optional.empty();
+        }
+
         List<LinkedFile> linkedFiles = FileFieldParser.parse(value).stream()
                 .filter(file -> !file.isOnlineLink())
                 .collect(Collectors.toList());

--- a/src/main/java/org/jabref/logic/integrity/HowPublishedChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/HowPublishedChecker.java
@@ -7,6 +7,7 @@ import java.util.regex.Pattern;
 
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.strings.StringUtil;
 
 public class HowPublishedChecker implements ValueChecker {
 
@@ -27,6 +28,10 @@ public class HowPublishedChecker implements ValueChecker {
      */
     @Override
     public Optional<String> checkValue(String value) {
+        if (StringUtil.isBlank(value)) {
+            return Optional.empty();
+        }
+
         //BibTeX
         if (!databaseContext.isBiblatexMode() && !FIRST_LETTER_CAPITALIZED.test(value.trim())) {
             return Optional.of(Localization.lang("should have the first letter capitalized"));

--- a/src/main/java/org/jabref/logic/integrity/ISBNChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/ISBNChecker.java
@@ -4,11 +4,16 @@ import java.util.Optional;
 
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.identifier.ISBN;
+import org.jabref.model.strings.StringUtil;
 
 public class ISBNChecker implements ValueChecker {
 
     @Override
     public Optional<String> checkValue(String value) {
+        if (StringUtil.isBlank(value)) {
+            return Optional.empty();
+        }
+
         // Check that the ISBN is on the correct form
         ISBN isbn = new ISBN(value);
 

--- a/src/main/java/org/jabref/logic/integrity/ISSNChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/ISSNChecker.java
@@ -4,11 +4,16 @@ import java.util.Optional;
 
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.identifier.ISSN;
+import org.jabref.model.strings.StringUtil;
 
 public class ISSNChecker implements ValueChecker {
 
     @Override
     public Optional<String> checkValue(String value) {
+        if (StringUtil.isBlank(value)) {
+            return Optional.empty();
+        }
+
         // Check that the ISSN is on the correct form
         String issnString = value.trim();
 

--- a/src/main/java/org/jabref/logic/integrity/IntegrityCheck.java
+++ b/src/main/java/org/jabref/logic/integrity/IntegrityCheck.java
@@ -46,7 +46,8 @@ public class IntegrityCheck {
             return result;
         }
 
-        for (FieldChecker checker : FieldCheckers.getAll(bibDatabaseContext, fileDirectoryPreferences)) {
+        FieldCheckers fieldCheckers = new FieldCheckers(bibDatabaseContext, fileDirectoryPreferences);
+        for (FieldChecker checker : fieldCheckers.getAll()) {
             result.addAll(checker.check(entry));
         }
 

--- a/src/main/java/org/jabref/logic/integrity/MonthChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/MonthChecker.java
@@ -7,6 +7,7 @@ import java.util.regex.Pattern;
 
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.strings.StringUtil;
 
 public class MonthChecker implements ValueChecker {
 
@@ -33,6 +34,10 @@ public class MonthChecker implements ValueChecker {
      */
     @Override
     public Optional<String> checkValue(String value) {
+        if (StringUtil.isBlank(value)) {
+            return Optional.empty();
+        }
+
         //biblatex
         if (bibDatabaseContextMonth.isBiblatexMode()
                 && !(ONLY_AN_INTEGER.test(value.trim()) || MONTH_NORMALIZED.test(value.trim()))) {

--- a/src/main/java/org/jabref/logic/integrity/NoteChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/NoteChecker.java
@@ -7,6 +7,7 @@ import java.util.regex.Pattern;
 
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.strings.StringUtil;
 
 public class NoteChecker implements ValueChecker {
 
@@ -27,6 +28,10 @@ public class NoteChecker implements ValueChecker {
      */
     @Override
     public Optional<String> checkValue(String value) {
+        if (StringUtil.isBlank(value)) {
+            return Optional.empty();
+        }
+
         //BibTeX
         if (!bibDatabaseContextEdition.isBiblatexMode() && !FIRST_LETTER_CAPITALIZED.test(value.trim())) {
             return Optional.of(Localization.lang("should have the first letter capitalized"));

--- a/src/main/java/org/jabref/logic/integrity/PagesChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/PagesChecker.java
@@ -6,6 +6,7 @@ import java.util.regex.Pattern;
 
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.strings.StringUtil;
 
 public class PagesChecker implements ValueChecker {
 
@@ -52,6 +53,10 @@ public class PagesChecker implements ValueChecker {
      */
     @Override
     public Optional<String> checkValue(String value) {
+        if (StringUtil.isBlank(value)) {
+            return Optional.empty();
+        }
+
         if (!isValidPageNumber.test(value.trim())) {
             return Optional.of(Localization.lang("should contain a valid page number range"));
         }

--- a/src/main/java/org/jabref/logic/integrity/PersonNamesChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/PersonNamesChecker.java
@@ -5,11 +5,16 @@ import java.util.Optional;
 
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.AuthorList;
+import org.jabref.model.strings.StringUtil;
 
 public class PersonNamesChecker implements ValueChecker {
 
     @Override
     public Optional<String> checkValue(String value) {
+        if (StringUtil.isBlank(value)) {
+            return Optional.empty();
+        }
+
         String valueTrimmedAndLowerCase = value.trim().toLowerCase(Locale.ROOT);
         if (valueTrimmedAndLowerCase.startsWith("and ") || valueTrimmedAndLowerCase.startsWith(",")) {
             return Optional.of(Localization.lang("should start with a name"));

--- a/src/main/java/org/jabref/logic/integrity/TitleChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/TitleChecker.java
@@ -7,6 +7,7 @@ import java.util.regex.Pattern;
 
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.strings.StringUtil;
 
 public class TitleChecker implements ValueChecker {
 
@@ -28,6 +29,10 @@ public class TitleChecker implements ValueChecker {
      */
     @Override
     public Optional<String> checkValue(String value) {
+        if (StringUtil.isBlank(value)) {
+            return Optional.empty();
+        }
+
         if (databaseContext.isBiblatexMode()) {
             return Optional.empty();
         }

--- a/src/main/java/org/jabref/logic/integrity/UrlChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/UrlChecker.java
@@ -3,11 +3,16 @@ package org.jabref.logic.integrity;
 import java.util.Optional;
 
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.strings.StringUtil;
 
 public class UrlChecker implements ValueChecker {
 
     @Override
     public Optional<String> checkValue(String value) {
+        if (StringUtil.isBlank(value)) {
+            return Optional.empty();
+        }
+
         if (!value.contains("://")) {
             return Optional.of(Localization.lang("should contain a protocol") + ": http[s]://, file://, ftp://, ...");
         }

--- a/src/main/java/org/jabref/logic/integrity/YearChecker.java
+++ b/src/main/java/org/jabref/logic/integrity/YearChecker.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.strings.StringUtil;
 
 public class YearChecker implements ValueChecker {
 
@@ -22,6 +23,10 @@ public class YearChecker implements ValueChecker {
      */
     @Override
     public Optional<String> checkValue(String value) {
+        if (StringUtil.isBlank(value)) {
+            return Optional.empty();
+        }
+
         if (!CONTAINS_FOUR_DIGIT.test(value.trim())) {
             return Optional.of(Localization.lang("should contain a four digit number"));
         }

--- a/src/test/java/org/jabref/gui/fieldeditors/IdentifierEditorViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/IdentifierEditorViewModelTest.java
@@ -3,6 +3,7 @@ package org.jabref.gui.fieldeditors;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.autocompleter.WordSuggestionProvider;
 import org.jabref.gui.util.CurrentThreadTaskExecutor;
+import org.jabref.logic.integrity.FieldCheckers;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -16,7 +17,7 @@ public class IdentifierEditorViewModelTest {
 
     @Before
     public void setUp() throws Exception {
-        viewModel = new IdentifierEditorViewModel("DOI", new WordSuggestionProvider("DOI"), new CurrentThreadTaskExecutor(), mock(DialogService.class));
+        viewModel = new IdentifierEditorViewModel("DOI", new WordSuggestionProvider("DOI"), new CurrentThreadTaskExecutor(), mock(DialogService.class), mock(FieldCheckers.class));
     }
 
     @Test


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

I just remembered that my initial motivation to convert the entry editor to JavaFX came from my desire to display the integrity check messages directly in the entry editor. This PR accomplishes exactly this. 
![image](https://user-images.githubusercontent.com/5037600/29142996-f7732d44-7d53-11e7-9461-bbd06e90697a.png)
The location and style of the tooltip is not perfect but as of now these things cannot be changed since they are hardcoded in `controlsfx` (will create a feature request).

What do you think, should this still merged before the beta3 release? In the end it is only a minor change and shouldn't break anything.

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
