### PR TITLE
Fix for issue 3052

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where <kbd>DEL</kbd>, <kbd>Ctrl</kbd>+<kbd>C</kbd>, <kbd>Ctrl</kbd>+<kbd>V</kbd> and <kbd>Ctrl</kbd>+<kbd>A</kbd> in the search field triggered corresponding actions in the main table [#3067](https://github.com/JabRef/jabref/issues/3067)
 - We fixed an issue where JabRef freezed when editing an assigned file in the `General`-Tab [#2930, comment](https://github.com/JabRef/jabref/issues/2930#issuecomment-311050976)
 - We fixed an issue where a file could not be assigned to an existing entry via the entry context menu action `Attach file` [#3080](https://github.com/JabRef/jabref/issues/3080)
+- We fixed an issue where entry editor was not focused after opening up. [#3052](https://github.com/JabRef/jabref/issues/3052) 
+
 ### Removed
 
 

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -136,6 +136,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
     private final UndoAction undoAction = new UndoAction();
     private final RedoAction redoAction = new RedoAction();
     private final List<SearchQueryHighlightListener> searchListeners = new ArrayList<>();
+    private final JFXPanel container;
 
     /**
      * Indicates that we are about to go to the next or previous entry
@@ -155,7 +156,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
         setLayout(borderLayout);
         setupToolBar();
 
-        JFXPanel container = new JFXPanel();
+        container = new JFXPanel();
 
         container.addKeyListener(new KeyAdapter() {
 
@@ -414,10 +415,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
     @Override
     public void requestFocus() {
-        EntryEditorTab activeTab = (EntryEditorTab) tabbed.getSelectionModel().getSelectedItem();
-        if (activeTab != null) {
-            activeTab.requestFocus();
-        }
+        container.requestFocus();
     }
 
     /**


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
This is an atempt to fix the problem with entry editor focus as described in #3052. In detail, when `EntryEditor` opens up, it is not focused automatically. The desired behavior is to focus the first `Textfield` on any of the `EntryEditor`'s tabs.

The way the fix is implemented: when `EntryEditor` is opened, the `JFXPanel` in which is the `TabPane` of the `EntryEditor` is getting the focus, The focus is given implicitly to a focusTraversable node contained in the `JFXPanel`. The selection of the node seems to be "random" (even though consistent for a given tree of nodes). As far as I've tested it consistently focuses the first `Textfield` on any tab, which is the desired behavior. I make this pull requested as suggested in #3052 discussion by @Siedlerchr .

I should mention that I ran `gradle check` which results in "6 tests failed" in my setup but this was also the result when I ran the test before making any change.

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
