### PR TITLE
Source tab doi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where entry editor was not focused after opening up. [#3052](https://github.com/JabRef/jabref/issues/3052)
 - We fixed an issue where changes in the source tab were not stored when selecting a new entry. [#3086](https://github.com/JabRef/jabref/issues/3086)
 - We fixed an issue where the other tab was not updated when fields where changed in the source tab. [#3063](https://github.com/JabRef/jabref/issues/3063)
+- We fixed an issue where the source tab was not updated after fetching data by DOI. [#3103](https://github.com/JabRef/jabref/issues/3103)
 ### Removed
 
 

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -219,9 +219,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
     public synchronized void listen(FieldAddedOrRemovedEvent event) {
         // other field deleted -> update other fields tab
         if (OtherFieldsTab.isOtherField(entryType, event.getFieldName())) {
-            DefaultTaskExecutor.runInJavaFXThread(() -> {
-                rebuildOtherFieldsTab();
-            });
+            DefaultTaskExecutor.runInJavaFXThread(() -> rebuildOtherFieldsTab());
         }
     }
 

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -219,7 +219,9 @@ public class EntryEditor extends JPanel implements EntryContainer {
     public synchronized void listen(FieldAddedOrRemovedEvent event) {
         // other field deleted -> update other fields tab
         if (OtherFieldsTab.isOtherField(entryType, event.getFieldName())) {
-            rebuildOtherFieldsTab();
+            DefaultTaskExecutor.runInJavaFXThread(() -> {
+                rebuildOtherFieldsTab();
+            });
         }
     }
 

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -70,9 +70,7 @@ public class SourceTab extends EntryEditorTab {
     @Subscribe
     public void listen(EntryChangedEvent event) {
         if (codeArea != null && this.entry.equals(event.getBibEntry())) {
-            DefaultTaskExecutor.runInJavaFXThread(() -> {
-                updateSourcePane();
-            });
+            DefaultTaskExecutor.runInJavaFXThread(() -> updateSourcePane());
         }
     }
 
@@ -103,9 +101,7 @@ public class SourceTab extends EntryEditorTab {
         // store source if new entry is selected in the maintable and the source tab is focused
         EasyBind.subscribe(movingToDifferentEntry, newEntrySelected -> {
             if (newEntrySelected && codeArea.focusedProperty().get()) {
-                DefaultTaskExecutor.runInJavaFXThread(() -> {
-                    storeSource();
-                });
+                DefaultTaskExecutor.runInJavaFXThread(() -> storeSource());
             }
         });
 

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -70,15 +70,21 @@ public class SourceTab extends EntryEditorTab {
     @Subscribe
     public void listen(EntryChangedEvent event) {
         if (codeArea != null && this.entry.equals(event.getBibEntry())) {
-            try {
-                codeArea.clear();
-                codeArea.appendText(getSourceString(entry, mode));
-            } catch (IOException ex) {
-                codeArea.appendText(ex.getMessage() + "\n\n" +
-                        Localization.lang("Correct the entry, and reopen editor to display/edit source."));
-                codeArea.setEditable(false);
-                LOGGER.debug("Incorrect entry", ex);
-            }
+            DefaultTaskExecutor.runInJavaFXThread(() -> {
+                updateSourcePane();
+            });
+        }
+    }
+
+    private void updateSourcePane() {
+        try {
+            codeArea.clear();
+            codeArea.appendText(getSourceString(entry, mode));
+        } catch (IOException ex) {
+            codeArea.appendText(ex.getMessage() + "\n\n" +
+                    Localization.lang("Correct the entry, and reopen editor to display/edit source."));
+            codeArea.setEditable(false);
+            LOGGER.debug("Incorrect entry", ex);
         }
     }
 


### PR DESCRIPTION
Fixes #3103 by making sure that updates to the source tab are always performed on the FXApplication Thread.

- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
