### PR TITLE
Trigger group display update when grouping changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the other tab was not updated when fields where changed in the source tab. [#3063](https://github.com/JabRef/jabref/issues/3063)
 - We fixed an issue where the source tab was not updated after fetching data by DOI. [#3103](https://github.com/JabRef/jabref/issues/3103)
 - We fixed an issue where the move to group operation did not remove the entry from other groups [#3101](https://github.com/JabRef/jabref/issues/3101)
+- We fixed an issue where the main table was not updated when grouping changes [#1903](https://github.com/JabRef/jabref/issues/1903)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/groups/GroupSidePane.java
+++ b/src/main/java/org/jabref/gui/groups/GroupSidePane.java
@@ -43,11 +43,15 @@ public class GroupSidePane extends SidePaneComponent {
 
         Globals.stateManager.activeGroupProperty()
                 .addListener((observable, oldValue, newValue) -> updateShownEntriesAccordingToSelectedGroups(newValue));
-        // register the panel to all the database contexts
+
+        // register the panel the current active context
         Globals.stateManager.activeDatabaseProperty()
-                .addListener((observable, oldValue, newValue)
-                        -> newValue.ifPresent(databaseContext
-                        -> databaseContext.getDatabase().registerListener(this)));
+                .addListener((observable, oldValue, newValue) -> {
+            newValue.ifPresent(databaseContext ->
+                    databaseContext.getDatabase().registerListener(this));
+            oldValue.ifPresent(databaseContext ->
+                    databaseContext.getDatabase().unregisterListener(this));
+        });
 
         toggleAction = new ToggleAction(Localization.menuTitle("Toggle groups interface"),
                 Localization.lang("Toggle groups interface"),


### PR DESCRIPTION
Attempts to fix #1903

Makes the maintable update whenever grouping changes and not just when group selection changes.

- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
