### PR TITLE
Move event processing from source tab into entry editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Changed
 
 ### Fixed
+ - We fixed a memory leak in the source tab of the entry editor [#3113](https://github.com/JabRef/jabref/issues/3113)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -77,6 +77,7 @@ import org.jabref.model.EntryTypes;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.EntryType;
+import org.jabref.model.entry.event.EntryChangedEvent;
 import org.jabref.model.entry.event.FieldAddedOrRemovedEvent;
 import org.jabref.preferences.JabRefPreferences;
 
@@ -223,6 +224,11 @@ public class EntryEditor extends JPanel implements EntryContainer {
         if (OtherFieldsTab.isOtherField(entryType, event.getFieldName())) {
             DefaultTaskExecutor.runInJavaFXThread(() -> rebuildOtherFieldsTab());
         }
+    }
+
+    @Subscribe
+    public synchronized void listen(EntryChangedEvent event) {
+        sourceTab.updateSourcePane();
     }
 
     private void rebuildOtherFieldsTab() {
@@ -526,9 +532,6 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
     private void unregisterListeners() {
         this.entry.unregisterListener(this);
-        if (sourceTab != null) {
-            this.sourceTab.deregisterListeners();
-        }
         removeSearchListeners();
 
     }

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -29,9 +29,7 @@ import org.jabref.model.database.BibDatabase;
 import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.InternalBibtexFields;
-import org.jabref.model.entry.event.EntryChangedEvent;
 
-import com.google.common.eventbus.Subscribe;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.fxmisc.easybind.EasyBind;
@@ -52,7 +50,6 @@ public class SourceTab extends EntryEditorTab {
         this.entry = entry;
         this.panel = panel;
         this.movingToDifferentEntry = movingToDifferentEntry;
-        panel.getBibDatabaseContext().getDatabase().registerListener(this);
         this.setText(Localization.lang("%0 source", mode.getFormattedName()));
         this.setTooltip(new Tooltip(Localization.lang("Show/edit %0 source", mode.getFormattedName())));
         this.setGraphic(IconTheme.JabRefIcon.SOURCE.getGraphicNode());
@@ -67,26 +64,17 @@ public class SourceTab extends EntryEditorTab {
         return stringWriter.getBuffer().toString();
     }
 
-    @Subscribe
-    public void listen(EntryChangedEvent event) {
-        if (codeArea != null && this.entry.equals(event.getBibEntry())) {
-            DefaultTaskExecutor.runInJavaFXThread(() -> updateSourcePane());
-        }
-    }
-
-    public void deregisterListeners() {
-        this.entry.unregisterListener(this);
-    }
-
-    private void updateSourcePane() {
-        try {
-            codeArea.clear();
-            codeArea.appendText(getSourceString(entry, mode));
-        } catch (IOException ex) {
-            codeArea.appendText(ex.getMessage() + "\n\n" +
-                    Localization.lang("Correct the entry, and reopen editor to display/edit source."));
-            codeArea.setEditable(false);
-            LOGGER.debug("Incorrect entry", ex);
+    public void updateSourcePane() {
+        if (codeArea != null) {
+            try {
+                codeArea.clear();
+                codeArea.appendText(getSourceString(entry, mode));
+            } catch (IOException ex) {
+                codeArea.appendText(ex.getMessage() + "\n\n" +
+                        Localization.lang("Correct the entry, and reopen editor to display/edit source."));
+                codeArea.setEditable(false);
+                LOGGER.debug("Incorrect entry", ex);
+            }
         }
     }
 


### PR DESCRIPTION
Solves the most critical part of #3113

The source tab did not properly unregister itself from the event bus. For some reason, I did not manage to get this working when the source tab takes care of deregistration. Therefore, I moved all event handling out of the source tab and into the entry editor.

Using jvisualvm, I can see that garbage collection works with this PR. Cycling through the main table with the entry editor open increases used RAM. When you force garbage collection, the used heap goes down to close to zero again, instead of staying at a higher plateau. See attached screenshot

![heap](https://user-images.githubusercontent.com/1515701/29381572-f60537f6-82c9-11e7-9ad9-20e6208ca648.png)

So this fixes the memory leak. The overall heap size doesn't go down, but that's a different issue.

- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
