### PR TITLE
Additional filter functionality for Check Integrity popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 ## [Unreleased]
 
+##2017-08-17
 ### Changed
+-Added 'Filter All' and 'Filter None' buttons with corresponding functionality to Quality Check tool.  
 
 ### Fixed
 

--- a/src/main/java/org/jabref/gui/actions/IntegrityCheckAction.java
+++ b/src/main/java/org/jabref/gui/actions/IntegrityCheckAction.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.actions;
 
+import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.util.HashMap;
 import java.util.List;
@@ -128,6 +129,38 @@ public class IntegrityCheckAction extends MnemonicAwareAction {
             FormBuilder builder = FormBuilder.create()
                     .layout(new FormLayout("fill:pref:grow", "fill:pref:grow, 2dlu, pref"));
 
+
+
+            JButton filterNoneButton = new JButton(Localization.lang("Filter None"));
+            filterNoneButton.addActionListener(event -> {
+                for (Component component : menu.getComponents()) {
+                    if (component instanceof JCheckBoxMenuItem) {
+                        JCheckBoxMenuItem checkBox = (JCheckBoxMenuItem) component;
+                        if (checkBox.isSelected()) {
+                            checkBox.setSelected(false);
+                            showMessage.put(checkBox.getText(), checkBox.isSelected());
+                        }
+                    }
+                    ((AbstractTableModel) table.getModel()).fireTableDataChanged();
+                }
+            });
+
+            JButton filterAllButton = new JButton(Localization.lang("Filter All"));
+            filterAllButton.addActionListener(event -> {
+                for (Component component : menu.getComponents()) {
+                    if (component instanceof JCheckBoxMenuItem) {
+                        JCheckBoxMenuItem checkBox = (JCheckBoxMenuItem) component;
+                        if (!checkBox.isSelected()) {
+                            checkBox.setSelected(true);
+                            showMessage.put(checkBox.getText(), checkBox.isSelected());
+                        }
+                    }
+                    ((AbstractTableModel) table.getModel()).fireTableDataChanged();
+                }
+            });
+
+            builder.add(filterNoneButton).xy(1, 3, "left, b");
+            builder.add(filterAllButton).xy(1, 3, "right, b");
             builder.add(scrollPane).xy(1, 1);
             builder.add(menuButton).xy(1, 3, "c, b");
             dialog.add(builder.getPanel());

--- a/src/main/java/org/jabref/gui/actions/IntegrityCheckAction.java
+++ b/src/main/java/org/jabref/gui/actions/IntegrityCheckAction.java
@@ -124,12 +124,11 @@ public class IntegrityCheckAction extends MnemonicAwareAction {
                 });
                 menu.add(menuItem);
             }
+
             JButton menuButton = new JButton(Localization.lang("Filter"));
             menuButton.addActionListener(entry -> menu.show(menuButton, 0, menuButton.getHeight()));
             FormBuilder builder = FormBuilder.create()
                     .layout(new FormLayout("fill:pref:grow", "fill:pref:grow, 2dlu, pref"));
-
-
 
             JButton filterNoneButton = new JButton(Localization.lang("Filter None"));
             filterNoneButton.addActionListener(event -> {

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -518,6 +518,10 @@ Files_opened=Filer_åbnet
 
 Filter=Filter
 
+Filter_All=
+
+Filter_None=
+
 Finished_automatically_setting_external_links.=Fuldførte_automatisk_udfyldning_af_eksterne_links.
 
 Finished_synchronizing_file_links._Entries_changed\:_%0.=Fuldførte_synkronisering_af_fil-links._Poster_ændret\:_%0.

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -518,6 +518,10 @@ Files_opened=Dateien_geöffnet
 
 Filter=Filter
 
+Filter_All=
+
+Filter_None=
+
 Finished_automatically_setting_external_links.=Automatische_Einstellung_externer_Links_abgeschlossen.
 
 Finished_synchronizing_file_links._Entries_changed\:_%0.=Synchronisierung_von_Datei_Links_abgeschlossen._Geänderte_Einträge\:_%0.

--- a/src/main/resources/l10n/JabRef_el.properties
+++ b/src/main/resources/l10n/JabRef_el.properties
@@ -518,6 +518,10 @@ Files_opened=Files_opened
 
 Filter=Filter
 
+Filter_All=
+
+Filter_None=
+
 Finished_automatically_setting_external_links.=Finished_automatically_setting_external_links.
 
 Finished_synchronizing_file_links._Entries_changed\:_%0.=Finished_synchronizing_file_links._Entries_changed\:_%0.

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -518,6 +518,10 @@ Files_opened=Files_opened
 
 Filter=Filter
 
+Filter_All=Filter_All
+
+Filter_None=Filter_None
+
 Finished_automatically_setting_external_links.=Finished_automatically_setting_external_links.
 
 Finished_synchronizing_file_links._Entries_changed\:_%0.=Finished_synchronizing_file_links._Entries_changed\:_%0.

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -518,6 +518,10 @@ Files_opened=Archivos_abiertos
 
 Filter=Filtro
 
+Filter_All=
+
+Filter_None=
+
 Finished_automatically_setting_external_links.=Se_ha_finalizado_la_configuración_automática_de_enlaces_esternos.
 
 Finished_synchronizing_file_links._Entries_changed\:_%0.=Se_ha_finalizado_la_sincronización_de_archivo_enlaces._Se_cambiaron_\:_%0_entradas.

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -518,6 +518,10 @@ Files_opened=
 
 Filter=
 
+Filter_All=
+
+Filter_None=
+
 Finished_automatically_setting_external_links.=
 
 Finished_synchronizing_file_links._Entries_changed\:_%0.=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -518,6 +518,10 @@ Files_opened=Fichiers_ouverts
 
 Filter=Filtre
 
+Filter_All=
+
+Filter_None=
+
 Finished_automatically_setting_external_links.=La_définition_automatique_des_liens_externes_est_terminée.
 
 Finished_synchronizing_file_links._Entries_changed\:_%0.=Synchronisation_des_liens_fichier_terminée._Entrées_modifiées_\:_%0.

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -518,6 +518,10 @@ Files_opened=Berkas_dibuka
 
 Filter=Penapis
 
+Filter_All=
+
+Filter_None=
+
 Finished_automatically_setting_external_links.=Selesai_pengaturan_otomatis_tautan_eksternal.
 
 Finished_synchronizing_file_links._Entries_changed\:_%0.=Selesai_menyelaraskan_berkas_tautan._Entri_diubah\:_%0.

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -518,6 +518,10 @@ Files_opened=File_aperti
 
 Filter=Filtro
 
+Filter_All=
+
+Filter_None=
+
 Finished_automatically_setting_external_links.=Impostazione_automatica_dei_collegamenti_esterni_terminata.
 
 Finished_synchronizing_file_links._Entries_changed\:_%0.=Sincronizzazione_di_collegamenti_a_file:_Voci_cambiate\:_%0.

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -518,6 +518,10 @@ Files_opened=ファイルは開かれています
 
 Filter=フィルタ
 
+Filter_All=
+
+Filter_None=
+
 Finished_automatically_setting_external_links.=外部リンクの自動設定が終了しました
 
 Finished_synchronizing_file_links._Entries_changed\:_%0.=ファイルリンクの同期し終えました。変更された項目\:_%0。

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -518,6 +518,10 @@ Files_opened=Bestanden_geopend
 
 Filter=Filter
 
+Filter_All=
+
+Filter_None=
+
 Finished_automatically_setting_external_links.=
 
 Finished_synchronizing_file_links._Entries_changed\:_%0.=Synchroniseren_van_bestand_snelkoppelingen_voltooid._Aantal_veranderde_entries\:_%0.

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -518,6 +518,10 @@ Files_opened=Filer_\u00e5pnet
 
 Filter=Filter
 
+Filter_All=
+
+Filter_None=
+
 Finished_automatically_setting_external_links.=Fullf\u00f8rte_automatisk_setting_av_eksterne_linker.
 
 Finished_synchronizing_file_links._Entries_changed\:_%0.=Fullf\u00f8rte_synkronisering_av_fil-linker._Enheter_endret\:_%0.

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -518,6 +518,10 @@ Files_opened=Arquivos_abertos
 
 Filter=Filtro
 
+Filter_All=
+
+Filter_None=
+
 Finished_automatically_setting_external_links.=A_definição_automática_de_links_externos_foi_finalizada.
 
 Finished_synchronizing_file_links._Entries_changed\:_%0.=A_sincronização_de_arquivo_links_foi_finalizada._Referências_modificadas\:_%0.

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -518,6 +518,10 @@ Files_opened=Открытые_файлы
 
 Filter=Фильтр
 
+Filter_All=
+
+Filter_None=
+
 Finished_automatically_setting_external_links.=Автоопределение_внешних_ссылок_выполнено.
 
 Finished_synchronizing_file_links._Entries_changed\:_%0.=Синхронизация_ссылок_файл_выполнена._Записей_с_изменениями\:_%0.

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -518,6 +518,10 @@ Files_opened=Filer_öppnade
 
 Filter=Filtrera
 
+Filter_All=
+
+Filter_None=
+
 Finished_automatically_setting_external_links.=
 
 Finished_synchronizing_file_links._Entries_changed\:_%0.=Synkronisering_av_fillänkar_avslutad._Ändrade_poster\:_%0.

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -518,6 +518,10 @@ Files_opened=Açılmış_dosyalar
 
 Filter=Süzgeç
 
+Filter_All=
+
+Filter_None=
+
 Finished_automatically_setting_external_links.=Harici_linklerin_otokurulması_bitti.
 
 Finished_synchronizing_file_links._Entries_changed\:_%0.=Dosya_linkin_eşzamanlaması_bitti._Değişen_girdiler\:_%0.

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -518,6 +518,10 @@ Files_opened=Các_tập_tin_đã_mở
 
 Filter=Lọc
 
+Filter_All=
+
+Filter_None=
+
 Finished_automatically_setting_external_links.=Thiết_lập_tự_động_các_liên_kết_ngoài_hoàn_tất.
 
 Finished_synchronizing_file_links._Entries_changed\:_%0.=Đồng_bộ_hóa_tập_tin_liên_kết_hoàn_tất._Các_mục_thay_đổi\:_%0.

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -518,6 +518,10 @@ Files_opened=已打开文件
 
 Filter=过滤
 
+Filter_All=
+
+Filter_None=
+
 Finished_automatically_setting_external_links.=完成自动设置外部链接。
 
 Finished_synchronizing_file_links._Entries_changed\:_%0.=完成同步文件条链接，记录改变\:_%0.


### PR DESCRIPTION
Fixes #2718 

I added new 'Filter All' and 'Filter None' buttons.  They can be clicked by the user to
check/uncheck all options in the filter menu.  When one of the buttons gets clicked the system will iterate through the existing menu components and toggle the checkmarks and info displayed.

I wasnt sure on the best placement of the buttons in the window so went with the simplest solution
![image](https://user-images.githubusercontent.com/17808285/29439562-4f3e84fe-8373-11e7-9d15-5e811d90578a.png)

Updated localization info with text for aforementioned buttons.

