### PR TITLE
Files can be dropped to entry preview panel to attach a file again.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 ### Fixed
  - We fixed a memory leak in the source tab of the entry editor [#3113](https://github.com/JabRef/jabref/issues/3113)
+ - We fixed a regression introduced in v4.0-beta2: A file can be dropped to the entry preview to attach it to the entry [koppor#245](https://github.com/koppor/jabref/issues/245)
 
 ### Removed
 

--- a/src/main/java/org/jabref/gui/fieldeditors/FileListEditorTransferHandler.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/FileListEditorTransferHandler.java
@@ -82,9 +82,11 @@ class FileListEditorTransferHandler extends TransferHandler {
             List<Path> files = new ArrayList<>();
             // This flavor is used for dragged file links in Windows:
             if (t.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
+                // javaFileListFlavor returns a list of java.io.File (as the string *File* in File indicates) and not a list of java.nio.file
+                // There is no DataFlavor.javaPathListFlavor, so we have to deal with java.io.File
                 @SuppressWarnings("unchecked")
                 List<File> transferedFiles = (List<File>) t.getTransferData(DataFlavor.javaFileListFlavor);
-                files.addAll(transferedFiles.stream().map(file -> file.toPath()).collect(Collectors.toList()));
+                files.addAll(transferedFiles.stream().map(File::toPath).collect(Collectors.toList()));
             } else if (t.isDataFlavorSupported(urlFlavor)) {
                 URL dropLink = (URL) t.getTransferData(urlFlavor);
                 LOGGER.warn("Dropped URL, which is currently not implemented " + dropLink);


### PR DESCRIPTION
This fixes https://github.com/koppor/jabref/issues/245. The issue was caused during a code cleanup at https://github.com/JabRef/jabref/pull/2723: https://github.com/JabRef/jabref/pull/2723/files#diff-093fbc56554f6c75313823ee81f28ec6L152

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
