### PR TITLE
Fix display of percentage symbol in entry preview

### DIFF
--- a/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
+++ b/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
@@ -471,7 +471,7 @@ public class HTMLUnicodeConversionMaps {
             /* Manually added */
             {"35", "", "\\#"}, // Hash
             {"36", "dollar", "\\$"}, // Dollar
-            {"37", "percnt", "\\%"}, // Percent
+            {"37", "#37", "\\%"}, // Percent (&percnt; is not displayed correctly in the entry preview)
             {"39", "apos", "'"}, // Apostrophe
             {"40", "lpar", "("}, // Left bracket
             {"41", "rpar", ")"}, // Right bracket


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
Having `\%` in some of the fields, it was displayed as `&percnt;` in the entry preview. For some reason the HTML display was not able to correctly handle this HTML code (probably because it uses [IE's rendering](https://stackoverflow.com/questions/7638338/percnt-not-recognized-by-ie/7638363#7638363)).
This issue was reported at https://github.com/JabRef/jabref/issues/3148#issuecomment-324294303.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
