### PR TITLE
Close entry editor when the shown entry is removed externally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 - Added 'Filter All' and 'Filter None' buttons with corresponding functionality to Quality Check tool.
 - We increased the size of the keywords and file text areas in the entry editor
+- When the entry that is currently shown in the entry editor is deleted externally, the editor is now closed automatically [#2946](https://github.com/JabRef/jabref/issues/2946)
 
 ### Fixed
  - We re-added the "Normalize to BibTeX name format" context menu item [#3136](https://github.com/JabRef/jabref/issues/3136)

--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -2105,6 +2105,9 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
             // if the entry that is displayed in the current entry editor is removed, close the entry editor
             if (isShowingEditor() && currentEditor.getEntry().equals(entryRemovedEvent.getBibEntry())) {
                 currentEditor.close();
+            }
+
+            if (selectionListener.getPreview().getEntry().equals(entryRemovedEvent.getBibEntry())) {
                 selectionListener.setPreviewActive(false);
             }
         }

--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -221,6 +221,7 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
         setupActions();
 
         this.getDatabase().registerListener(new SearchListener());
+        this.getDatabase().registerListener(new EntryRemovedListener());
 
         // ensure that at each addition of a new entry, the entry is added to the groups interface
         this.bibDatabaseContext.getDatabase().registerListener(new GroupTreeListener());
@@ -2093,6 +2094,18 @@ public class BasePanel extends JPanel implements ClipboardOwner, FileUpdateListe
                 final List<BibEntry> entries = Collections.singletonList(addedEntryEvent.getBibEntry());
                 Globals.stateManager.getSelectedGroup(bibDatabaseContext).forEach(
                         selectedGroup -> selectedGroup.addEntriesToGroup(entries));
+            }
+        }
+    }
+
+    private class EntryRemovedListener {
+
+        @Subscribe
+        public void listen(EntryRemovedEvent entryRemovedEvent) {
+            // if the entry that is displayed in the current entry editor is removed, close the entry editor
+            if (isShowingEditor() && currentEditor.getEntry().equals(entryRemovedEvent.getBibEntry())) {
+                currentEditor.close();
+                selectionListener.setPreviewActive(false);
             }
         }
     }

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -238,7 +238,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
         boolean isOtherFieldsTabSelected = false;
 
         // find tab index and selection status
-        for (Tab tab: tabbed.getTabs()) {
+        for (Tab tab : tabbed.getTabs()) {
             if (tab instanceof OtherFieldsTab) {
                 index = tabbed.getTabs().indexOf(tab);
                 isOtherFieldsTabSelected = tabbed.getSelectionModel().isSelected(index);
@@ -311,6 +311,10 @@ public class EntryEditor extends JPanel implements EntryContainer {
                 }
             }
         });
+    }
+
+    public void close() {
+        closeAction.actionPerformed(null);
     }
 
     private void addTabs(String lastTabName) {
@@ -866,7 +870,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
             }
 
             BibtexKeyPatternUtil.makeAndSetLabel(panel.getBibDatabaseContext().getMetaData()
-                    .getCiteKeyPattern(Globals.prefs.getBibtexKeyPatternPreferences().getKeyPattern()),
+                            .getCiteKeyPattern(Globals.prefs.getBibtexKeyPatternPreferences().getKeyPattern()),
                     panel.getDatabase(), entry,
                     Globals.prefs.getBibtexKeyPatternPreferences());
 


### PR DESCRIPTION
Fixes the remaining part of #2946

When you externally delete an entry that is opened in the entry editor and accept the change in the dialog in JabRef, then the entry editor closes. That way, it prevents you from editing an entry that does no longer exist.

As a side note: The `BasePanel` is ripe for a refactoring. There are a good dozen classes that I could extract. In the light of only doing bug fixes before the 4.0 release, I'll avoid that now. But when we've released, this class gets it...

- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
