### PR TITLE
Fix freezing on browse in protected terms dialog 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - We fixed a [java bug](https://bugs.openjdk.java.net/browse/JDK-8185792) where linux users could not enter accented characters in the entry editor and the search bar [#3028](https://github.com/JabRef/jabref/issues/3028)  
  - We fixed a regression introduced in v4.0-beta2: A file can be dropped to the entry preview to attach it to the entry [koppor#245](https://github.com/koppor/jabref/issues/245)
  - We fixed an issue in the "Replace String" dialog (<kbd>Ctrl</kbd>+<kbd>R</kbd> where search and replace did not work for the `bibtexkey` field. [#3132](https://github.com/JabRef/jabref/issues/3132)
+-  We fixed an issue in the entry editor where adding a term to a new protected terms list freezed JabRef completely. [#3157](https://github.com/JabRef/jabref/issues/3157)
+-  We fixed an issue in the "Manage protected terms" dialog where an 'Open file' dialog instead of a 'Save file' dialog was shown when creating a new list. [#3157](https://github.com/JabRef/jabref/issues/3157)
 ### Removed
 
 

--- a/src/main/java/org/jabref/gui/fieldeditors/contextmenu/ProtectedTermsMenu.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/contextmenu/ProtectedTermsMenu.java
@@ -1,5 +1,7 @@
 package org.jabref.gui.fieldeditors.contextmenu;
 
+import javax.swing.SwingUtilities;
+
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.SeparatorMenuItem;
@@ -60,7 +62,9 @@ class ProtectedTermsMenu extends Menu {
         addToNewFileItem.setOnAction(event -> {
             NewProtectedTermsFileDialog dialog = new NewProtectedTermsFileDialog(JabRefGUI.getMainFrame(),
                     Globals.protectedTermsLoader);
-            dialog.setVisible(true);
+
+            SwingUtilities.invokeLater(() -> dialog.setVisible(true));
+
             if (dialog.isOKPressed()) {
                 // Update preferences with new list
                 Globals.prefs.setProtectedTermsPreferences(Globals.protectedTermsLoader);

--- a/src/main/java/org/jabref/gui/protectedterms/NewProtectedTermsFileDialog.java
+++ b/src/main/java/org/jabref/gui/protectedterms/NewProtectedTermsFileDialog.java
@@ -67,7 +67,7 @@ public class NewProtectedTermsFileDialog extends JabRefDialog {
 
         browse.addActionListener(e -> {
             Optional<Path> file = DefaultTaskExecutor
-                    .runInJavaFXThread(() -> ds.showFileOpenDialog(fileDialogConfiguration));
+                    .runInJavaFXThread(() -> ds.showFileSaveDialog(fileDialogConfiguration));
             file.ifPresent(f -> newFile.setText(f.toAbsolutePath().toString()));
         });
 


### PR DESCRIPTION
when adding from entrry editor

changed open file dialog to save file dialog
Fix #3157

<!-- describe the changes you have made here: what, why, ... -->

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
