### PR TITLE
Update protected terms list in context menu when a new list is added.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - We fixed an issue in the "Replace String" dialog (<kbd>Ctrl</kbd>+<kbd>R</kbd> where search and replace did not work for the `bibtexkey` field. [#3132](https://github.com/JabRef/jabref/issues/3132)
 -  We fixed an issue in the entry editor where adding a term to a new protected terms list freezed JabRef completely. [#3157](https://github.com/JabRef/jabref/issues/3157)
 -  We fixed an issue in the "Manage protected terms" dialog where an 'Open file' dialog instead of a 'Save file' dialog was shown when creating a new list. [#3157](https://github.com/JabRef/jabref/issues/3157)
+-  We fixed an issue where a new protected terms list was not available immediately after its addition. [#3161](https://github.com/JabRef/jabref/issues/3161)
 ### Removed
 
 

--- a/src/main/java/org/jabref/gui/fieldeditors/contextmenu/ProtectedTermsMenu.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/contextmenu/ProtectedTermsMenu.java
@@ -63,12 +63,15 @@ class ProtectedTermsMenu extends Menu {
             NewProtectedTermsFileDialog dialog = new NewProtectedTermsFileDialog(JabRefGUI.getMainFrame(),
                     Globals.protectedTermsLoader);
 
-            SwingUtilities.invokeLater(() -> dialog.setVisible(true));
+            SwingUtilities.invokeLater(() -> {
+                dialog.setVisible(true);
 
-            if (dialog.isOKPressed()) {
-                // Update preferences with new list
-                Globals.prefs.setProtectedTermsPreferences(Globals.protectedTermsLoader);
-            }
+                if (dialog.isOKPressed()) {
+                    // Update preferences with new list
+                    Globals.prefs.setProtectedTermsPreferences(Globals.protectedTermsLoader);
+                    this.updateFiles();
+                }
+            });
         });
         externalFiles.getItems().add(addToNewFileItem);
     }


### PR DESCRIPTION
Fixes  #3161

The result of the dialog needs to be evaluated *after* the dialog is actually finished and the update of the context menu needs to be called.

- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
