### PR TITLE
Fix unparseable FileAnnotation dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,16 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - When the entry that is currently shown in the entry editor is deleted externally, the editor is now closed automatically [#2946](https://github.com/JabRef/jabref/issues/2946)
 
 ### Fixed
- - We re-added the "Normalize to BibTeX name format" context menu item [#3136](https://github.com/JabRef/jabref/issues/3136)
- - We fixed a memory leak in the source tab of the entry editor [#3113](https://github.com/JabRef/jabref/issues/3113)
- - We fixed a [java bug](https://bugs.openjdk.java.net/browse/JDK-8185792) where linux users could not enter accented characters in the entry editor and the search bar [#3028](https://github.com/JabRef/jabref/issues/3028)
- - We fixed a regression introduced in v4.0-beta2: A file can be dropped to the entry preview to attach it to the entry [koppor#245](https://github.com/koppor/jabref/issues/245)
- - We fixed an issue in the "Replace String" dialog (<kbd>Ctrl</kbd>+<kbd>R</kbd> where search and replace did not work for the `bibtexkey` field. [#3132](https://github.com/JabRef/jabref/issues/3132)
--  We fixed an issue in the entry editor where adding a term to a new protected terms list freezed JabRef completely. [#3157](https://github.com/JabRef/jabref/issues/3157)
--  We fixed an issue in the "Manage protected terms" dialog where an 'Open file' dialog instead of a 'Save file' dialog was shown when creating a new list. [#3157](https://github.com/JabRef/jabref/issues/3157)
+
+- We re-added the "Normalize to BibTeX name format" context menu item [#3136](https://github.com/JabRef/jabref/issues/3136)
+- We fixed a memory leak in the source tab of the entry editor [#3113](https://github.com/JabRef/jabref/issues/3113)
+- We fixed a [java bug](https://bugs.openjdk.java.net/browse/JDK-8185792) where linux users could not enter accented characters in the entry editor and the search bar [#3028](https://github.com/JabRef/jabref/issues/3028)
+- We fixed a regression introduced in v4.0-beta2: A file can be dropped to the entry preview to attach it to the entry [koppor#245](https://github.com/koppor/jabref/issues/245)
+- We fixed an issue in the "Replace String" dialog (<kbd>Ctrl</kbd>+<kbd>R</kbd> where search and replace did not work for the `bibtexkey` field. [#3132](https://github.com/JabRef/jabref/issues/3132)
+- We fixed an issue in the entry editor where adding a term to a new protected terms list freezed JabRef completely. [#3157](https://github.com/JabRef/jabref/issues/3157)
+- We fixed an issue in the "Manage protected terms" dialog where an 'Open file' dialog instead of a 'Save file' dialog was shown when creating a new list. [#3157](https://github.com/JabRef/jabref/issues/3157)
+- We fixed an issue where unparseable dates of the FileAnnotations caused the FileAnnotationsTab to crash.
+
 ### Removed
 
 

--- a/src/main/java/org/jabref/model/pdf/FileAnnotation.java
+++ b/src/main/java/org/jabref/model/pdf/FileAnnotation.java
@@ -2,13 +2,19 @@ package org.jabref.model.pdf;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
 
+
 public class FileAnnotation {
+
+    private static final Log LOGGER = LogFactory.getLog(FileAnnotation.class);
 
     private final static int ABBREVIATED_ANNOTATION_NAME_LENGTH = 45;
     private static final String DATE_TIME_STRING = "^D:\\d{14}$";
@@ -83,7 +89,12 @@ public class FileAnnotation {
             dateTimeString = dateTimeString.substring(2);
         }
 
-        return LocalDateTime.parse(dateTimeString, DateTimeFormatter.ofPattern(ANNOTATION_DATE_FORMAT));
+        try {
+            return LocalDateTime.parse(dateTimeString, DateTimeFormatter.ofPattern(ANNOTATION_DATE_FORMAT));
+        } catch (DateTimeParseException e) {
+            LOGGER.info(String.format("Expected a parseable date string! However, this text could not be parsed: '%s'", dateTimeString));
+            return LocalDateTime.now();
+        }
     }
 
     private String parseContent(final String content) {

--- a/src/main/java/org/jabref/model/pdf/FileAnnotation.java
+++ b/src/main/java/org/jabref/model/pdf/FileAnnotation.java
@@ -11,7 +11,6 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.interactive.annotation.PDAnnotation;
 
-
 public class FileAnnotation {
 
     private static final Log LOGGER = LogFactory.getLog(FileAnnotation.class);

--- a/src/test/java/org/jabref/model/pdf/FileAnnotationTest.java
+++ b/src/test/java/org/jabref/model/pdf/FileAnnotationTest.java
@@ -1,9 +1,11 @@
 package org.jabref.model.pdf;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 import org.junit.Test;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 
@@ -28,5 +30,12 @@ public class FileAnnotationTest {
         String dateString = "D:20170512224019";
         LocalDateTime date = FileAnnotation.extractModifiedTime(dateString);
         assertEquals(LocalDateTime.of(2017, 05, 12, 22, 40, 19), date);
+    }
+
+    @Test
+    public void testParseNotADate() {
+        String dateString = "gsdfgwergsdf";
+        LocalDateTime date = FileAnnotation.extractModifiedTime(dateString);
+        assertTrue(ChronoUnit.SECONDS.between(LocalDateTime.now(), date) <= 1);
     }
 }


### PR DESCRIPTION
This should be the last aspect for being able to close #3130. @HViethen85 should consider using another PDF Annotation tool (; However, the fault is of course on our side since we didn't validate the date format before.


- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
