### PR TITLE
Add undo functionality to the source tab

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -895,7 +895,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            panel.runCommand(Actions.UNDO);
+            DefaultTaskExecutor.runInJavaFXThread(() -> panel.runCommand(Actions.UNDO));
         }
     }
 

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -6,6 +6,8 @@ import java.io.StringWriter;
 import java.util.Map;
 import java.util.Objects;
 
+import javax.swing.undo.UndoManager;
+
 import javafx.beans.property.BooleanProperty;
 import javafx.scene.Node;
 import javafx.scene.control.Tooltip;
@@ -35,8 +37,6 @@ import org.apache.commons.logging.LogFactory;
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.flowless.VirtualizedScrollPane;
 import org.fxmisc.richtext.CodeArea;
-
-import javax.swing.undo.UndoManager;
 
 public class SourceTab extends EntryEditorTab {
 

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -36,6 +36,8 @@ import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.flowless.VirtualizedScrollPane;
 import org.fxmisc.richtext.CodeArea;
 
+import javax.swing.undo.UndoManager;
+
 public class SourceTab extends EntryEditorTab {
 
     private static final Log LOGGER = LogFactory.getLog(SourceTab.class);
@@ -44,6 +46,7 @@ public class SourceTab extends EntryEditorTab {
     private final BasePanel panel;
     private CodeArea codeArea;
     private BooleanProperty movingToDifferentEntry;
+    private UndoManager undoManager;
 
     public SourceTab(BasePanel panel, BibEntry entry, BooleanProperty movingToDifferentEntry) {
         this.mode = panel.getBibDatabaseContext().getMode();
@@ -53,6 +56,7 @@ public class SourceTab extends EntryEditorTab {
         this.setText(Localization.lang("%0 source", mode.getFormattedName()));
         this.setTooltip(new Tooltip(Localization.lang("Show/edit %0 source", mode.getFormattedName())));
         this.setGraphic(IconTheme.JabRefIcon.SOURCE.getGraphicNode());
+        this.undoManager = panel.getUndoManager();
     }
 
     private static String getSourceString(BibEntry entry, BibDatabaseMode type) throws IOException {
@@ -193,6 +197,7 @@ public class SourceTab extends EntryEditorTab {
                 entry.setType(newEntry.getType());
             }
             compound.end();
+            undoManager.addEdit(compound);
 
         } catch (InvalidFieldValueException | IOException ex) {
             // The source couldn't be parsed, so the user is given an


### PR DESCRIPTION
Fixes #3170 The problem here, as far as I understand, was that the undo didn't happen on the FXApplication thread.

On top of that, I found the the source tab isn't integrated in the undo framework at all, so I have added this as well. However, it doesn't work problem-free. It seems that the FX CodeArea consumes undo events as well. So when you hit undo in the sourcetab, the CodeArea does the undo and then the UndoManager tries to do it again and fails. It has no consequence, though, apart from an exception, the undo happens anyway.

Since this is an improvement (add undo to source tab again), I would like to merge this even if it's not perfect. I have zero time to dig deeper into these FX problems, and I assume that no one else will do it. So, we can just merge the current state. 

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
