### PR TITLE
Fix focus and keybinding in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where a new protected terms list was not available immediately after its addition. [#3161](https://github.com/JabRef/jabref/issues/3161)
 - We fixed an issue where an online file link could not be removed from an entry [#3165](https://github.com/JabRef/jabref/issues/3165)
 - We fixed an issue where an online file link did not open the browser and created an error [#3165](https://github.com/JabRef/jabref/issues/3165)
-
+- We fixed an issue where the arrow keys in the search bar did not work as expected [#3081](https://github.com/JabRef/jabref/issues/3081)
 ### Removed
 
 

--- a/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
@@ -195,6 +195,18 @@ public class GlobalSearchBar extends JPanel {
 
                 @Override
                 public void keyPressed(java.awt.event.KeyEvent e) {
+                    switch (e.getKeyCode()) {
+                        //This "hack" prevents that the focus moves out of the field
+                        case java.awt.event.KeyEvent.VK_RIGHT:
+                        case java.awt.event.KeyEvent.VK_LEFT:
+                        case java.awt.event.KeyEvent.VK_UP:
+                        case java.awt.event.KeyEvent.VK_DOWN:
+                            e.consume();
+                            break;
+                        default:
+                            //do nothing
+                    }
+
                     //We need to consume this event here to prevent the propgation of keybinding events back to the JFrame
                     Optional<KeyBinding> keyBinding = Globals.getKeyPrefs().mapToKeyBinding(e);
                     if (keyBinding.isPresent()) {

--- a/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
@@ -191,39 +191,7 @@ public class GlobalSearchBar extends JPanel {
         container = OS.LINUX ? new CustomJFXPanel() : new JFXPanel();
         DefaultTaskExecutor.runInJavaFXThread(() -> {
             container.setScene(new Scene(searchField));
-            container.addKeyListener(new KeyAdapter() {
-
-                @Override
-                public void keyPressed(java.awt.event.KeyEvent e) {
-                    switch (e.getKeyCode()) {
-                        //This "hack" prevents that the focus moves out of the field
-                        case java.awt.event.KeyEvent.VK_RIGHT:
-                        case java.awt.event.KeyEvent.VK_LEFT:
-                        case java.awt.event.KeyEvent.VK_UP:
-                        case java.awt.event.KeyEvent.VK_DOWN:
-                            e.consume();
-                            break;
-                        default:
-                            //do nothing
-                    }
-
-                    //We need to consume this event here to prevent the propgation of keybinding events back to the JFrame
-                    Optional<KeyBinding> keyBinding = Globals.getKeyPrefs().mapToKeyBinding(e);
-                    if (keyBinding.isPresent()) {
-                        switch (keyBinding.get()) {
-                            case CUT:
-                            case COPY:
-                            case PASTE:
-                            case DELETE_ENTRY:
-                            case SELECT_ALL:
-                                e.consume();
-                                break;
-                            default:
-                                //do nothing
-                        }
-                    }
-                }
-            });
+            container.addKeyListener(new SearchKeyAdapter());
 
         });
 
@@ -454,4 +422,37 @@ public class GlobalSearchBar extends JPanel {
         }
     }
 
+    private class SearchKeyAdapter extends KeyAdapter {
+
+        @Override
+        public void keyPressed(java.awt.event.KeyEvent e) {
+            switch (e.getKeyCode()) {
+                //This "hack" prevents that the focus moves out of the field
+                case java.awt.event.KeyEvent.VK_RIGHT:
+                case java.awt.event.KeyEvent.VK_LEFT:
+                case java.awt.event.KeyEvent.VK_UP:
+                case java.awt.event.KeyEvent.VK_DOWN:
+                    e.consume();
+                    break;
+                default:
+                    //do nothing
+            }
+
+            //We need to consume this event here to prevent the propgation of keybinding events back to the JFrame
+            Optional<KeyBinding> keyBinding = Globals.getKeyPrefs().mapToKeyBinding(e);
+            if (keyBinding.isPresent()) {
+                switch (keyBinding.get()) {
+                    case CUT:
+                    case COPY:
+                    case PASTE:
+                    case DELETE_ENTRY:
+                    case SELECT_ALL:
+                        e.consume();
+                        break;
+                    default:
+                        //do nothing
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION

Fix #3081 
Arrow keys (left, right, up and down no work as expected and the up/down + Enter can be used to select an entry from the autocomplete menu)

<!-- describe the changes you have made here: what, why, ... -->

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
