### PR TITLE
Improve SyncLang.py

### DIFF
--- a/scripts/syncLang.py
+++ b/scripts/syncLang.py
@@ -36,7 +36,7 @@ def call_command(command: str) -> str:
     return subprocess.check_output(command.split(" ")).decode("utf-8").rstrip()
 
 
-def get_filename(filepath):
+def get_filename(filepath) -> str:
     """
     removes the res_dir path
 
@@ -46,7 +46,7 @@ def get_filename(filepath):
     return filepath.replace("{}\\".format(RES_DIR), "")
 
 
-def read_file(filename, encoding="UTF-8"):
+def read_file(filename, encoding="UTF-8") -> list:
     """
     :param filename: string
     :param encoding: string: the encoding of the file to read (standard: `UTF-8`)
@@ -65,215 +65,183 @@ def write_file(filename, content):
     codecs.open(filename, "w", encoding='utf-8').writelines(content)
 
 
-def get_main_jabref_preferences():
-    """
-    :return: string: path to JabRef_en.preference
-    """
-    return os.path.join(RES_DIR, "JabRef_en.properties")
+class Keys:
+    def __init__(self, lines):
+        self.lines = lines
 
+    def get_duplicates(self):
+        """
+        return: list of unicode strings
+        """
+        duplicates = []
+        keys_checked = {}
+        for line in self.lines:
+            key, value = self.__get_key_and_value_from_line(line=line)
+            if key:
+                if key in keys_checked:
+                    duplicates.append("{key}={value}".format(key=key, value=value))
+                    translation_in_list = "{key}={value}".format(key=key, value=keys_checked[key])
+                    if translation_in_list not in duplicates:
+                        duplicates.append(translation_in_list)
+                else:
+                    keys_checked[key] = value
+        return duplicates
 
-def get_other_jabref_properties() -> list:
-    """
-    :return: list of strings: all the JabRef_*.preferences files without the english one
-    """
-    jabref_property_files = [s for s in os.listdir(RES_DIR) if (s.startswith('JabRef_') and not (s.startswith('JabRef_en')))]
-    return [os.path.join(RES_DIR, file) for file in jabref_property_files]
+    def fix(self):
+        """
+        Fixes all unambiguous duplicates
 
-
-def get_all_jabref_properties():
-    """
-    :return: list of strings: all the JabRef_*.preferences files with the english at the beginning
-    """
-    jabref_property_files = sorted(get_other_jabref_properties())
-    jabref_property_files.insert(0, os.path.join(RES_DIR, "JabRef_en.properties"))
-    return jabref_property_files
-
-
-def get_main_menu_properties():
-    """
-    :return: string: path to Menu_en.preference
-    """
-    return os.path.join(RES_DIR, "Menu_en.properties")
-
-
-def get_other_menu_properties():
-    """
-    :return: list of strings: all the Menu_*.preferences files without the english one
-    """
-    menu_property_files = [s for s in os.listdir(RES_DIR) if (s.startswith('Menu_') and not (s.startswith('Menu_en')))]
-    return [os.path.join(RES_DIR, file) for file in menu_property_files]
-
-
-def get_all_menu_properties() -> list:
-    """
-    :return: list of strings: all the Menu_*.preferences files with the english at the beginning
-    """
-    menu_property_files = sorted(get_other_menu_properties())
-    menu_property_files.insert(0, os.path.join(RES_DIR, "Menu_en.properties"))
-    return menu_property_files
-
-
-def get_key_from_line(line):
-    """
-    Tries to extract the key from the line
-
-    :param line: unicode string
-    :return: unicode string: the key or None
-    """
-    if line.find("#") != 0 or line.find("!") != 0:
-        index_key_end = line.find("=")
-        while (index_key_end > 0) and (line[index_key_end - 1] == "\\"):
-            index_key_end = line.find("=", index_key_end + 1)
-        if index_key_end > 0:
-            return line[0:index_key_end].strip()
-    return None
-
-
-def get_key_and_value_from_line(line):
-    """
-    Tries to extract the key and value from the line
-
-    :param line: unicode string
-    :return: (unicode string, unicode string) or (None, None): (key, value)
-    """
-    if line.find("#") != 0 or line.find("!") != 0:
-        index_key_end = line.find("=")
-        while (index_key_end > 0) and (line[index_key_end - 1] == "\\"):
-            index_key_end = line.find("=", index_key_end + 1)
-        if index_key_end > 0:
-            return line[0:index_key_end].strip(), line[index_key_end + 1:].strip()
-    return None, None
-
-
-def get_translations_as_dict(lines):
-    """
-    :param lines: list of unicode strings
-    :return: dict of unicode strings:
-    """
-    translations = {}
-    for line in lines:
-        key, value = get_key_and_value_from_line(line=line)
-        if key:
-            translations[key] = value
-    return translations
-
-
-def get_empty_keys(lines):
-    """
-    :param lines: list of unicode strings
-    :return: list of unicode strings: the keys with empty values
-    """
-    not_translated = []
-    keys = get_translations_as_dict(lines=lines)
-    for key, value in keys.items():
-        if not value:
-            not_translated.append(key)
-    return not_translated
-
-
-def fix_duplicates(lines):
-    """
-    Fixes all unambiguous duplicates
-
-    :param lines: list of unicode strings
-    :return: (list of unicode strings, list of unicode strings): not fixed ambiguous duplicates, fixed unambiguous duplicates
-    """
-    keys = {}
-    fixed = []
-    not_fixed = []
-    for line in lines:
-        key, value = get_key_and_value_from_line(line=line)
-        if key:
-            if key in keys:
-                if not keys[key]:
-                    fixed.append("{key}={value}".format(key=key, value=keys[key]))
+        :param lines: list of unicode strings
+        :return: (list of unicode strings, list of unicode strings): not fixed ambiguous duplicates, fixed unambiguous duplicates
+        """
+        keys = {}
+        fixed = []
+        not_fixed = []
+        for line in self.lines:
+            key, value = self.__get_key_and_value_from_line(line=line)
+            if key:
+                if key in keys:
+                    if not keys[key]:
+                        fixed.append("{key}={value}".format(key=key, value=keys[key]))
+                        keys[key] = value
+                    elif not value:
+                        fixed.append("{key}={value}".format(key=key, value=value))
+                    elif keys[key] == value:
+                        fixed.append("{key}={value}".format(key=key, value=value))
+                    elif keys[key] != value:
+                        not_fixed.append("{key}={value}".format(key=key, value=value))
+                        not_fixed.append("{key}={value}".format(key=key, value=keys[key]))
+                else:
                     keys[key] = value
-                elif not value:
-                    fixed.append("{key}={value}".format(key=key, value=value))
-                elif keys[key] == value:
-                    fixed.append("{key}={value}".format(key=key, value=value))
-                elif keys[key] != value:
-                    not_fixed.append("{key}={value}".format(key=key, value=value))
-                    not_fixed.append("{key}={value}".format(key=key, value=keys[key]))
-            else:
-                keys[key] = value
 
-    return keys, not_fixed, fixed
+        return keys, not_fixed, fixed
+
+    def get_keys_from_lines(self):
+        """
+        Builds a list of all translation keys in the list of lines.
+
+        :param lines: a list of unicode strings
+        :return: list of unicode strings: the sorted keys within the lines
+        """
+
+        keys = []
+        for line in self.lines:
+            key = self.key_from_line(line)
+            if key:
+                keys.append(key)
+        return keys
+
+    def key_from_line(self, line):
+        """
+        Tries to extract the key from the line
+
+        :param line: unicode string
+        :return: unicode string: the key or None
+        """
+        if line.find("#") != 0 or line.find("!") != 0:
+            index_key_end = line.find("=")
+            while (index_key_end > 0) and (line[index_key_end - 1] == "\\"):
+                index_key_end = line.find("=", index_key_end + 1)
+            if index_key_end > 0:
+                return line[0:index_key_end].strip()
+        return None
+
+    def empty_keys(self):
+        """
+        :param lines: list of unicode strings
+        :return: list of unicode strings: the keys with empty values
+        """
+        not_translated = []
+        keys = self.translations_as_dict()
+        for key, value in keys.items():
+            if not value:
+                not_translated.append(key)
+        return not_translated
+
+    def translations_as_dict(self):
+        """
+        :param lines: list of unicode strings
+        :return: dict of unicode strings:
+        """
+        translations = {}
+        for line in self.lines:
+            key, value = self.__get_key_and_value_from_line(line=line)
+            if key:
+                translations[key] = value
+        return translations
+
+    def __get_key_and_value_from_line(self, line):
+        """
+        Tries to extract the key and value from the line
+
+        :param line: unicode string
+        :return: (unicode string, unicode string) or (None, None): (key, value)
+        """
+        if line.find("#") != 0 or line.find("!") != 0:
+            index_key_end = line.find("=")
+            while (index_key_end > 0) and (line[index_key_end - 1] == "\\"):
+                index_key_end = line.find("=", index_key_end + 1)
+            if index_key_end > 0:
+                return line[0:index_key_end].strip(), line[index_key_end + 1:].strip()
+        return None, None
 
 
-def get_keys_from_lines(lines):
-    """
-    Builds a list of all translation keys in the list of lines.
+class SyncLang:
+    def __init__(self, extended, out_file='status.md'):
+        """
+        :param extended: boolean: if the keys with problems should be printed
 
-    :param lines: a list of unicode strings
-    :return: list of unicode strings: the sorted keys within the lines
-    """
-    keys = []
-    for line in lines:
-        key = get_key_from_line(line)
-        if key:
-            keys.append(key)
-    return keys
+        """
+        self.extended = extended
+        self.main_jabref_preferences = os.path.join(RES_DIR, "JabRef_en.properties")
+        self.main_menu_preferences = os.path.join(RES_DIR, "Menu_en.properties")
+        self.markdown_output = out_file
 
+    def status(self):
+        """
+        prints the current status to the terminal
+        """
 
-def get_missing_keys(first_list, second_list):
-    """
-    Finds all keys in the first list that are not present in the second list
+        self.__print_status_jabref_properties()
+        self.__print_status_menu_properties()
 
-    :param first_list: list of unicode strings
-    :param second_list: list of unicode strings
-    :return: list of unicode strings
-    """
-    missing = []
-    for key in first_list:
-        if key not in second_list:
-            missing.append(key)
-    return missing
+    def __print_status_menu_properties(self):
+        self.__check_properties(main_property_file=self.main_menu_preferences, property_files=self.__all_menu_properties())
 
+    def __print_status_jabref_properties(self):
+        self.__check_properties(main_property_file=self.main_jabref_preferences, property_files=self.__all_jabref_properties())
 
-def get_duplicates(lines):
-    """
-    finds all the duplicates and returns them
+    def update(self):
+        """
+        updates all the localization files
+        fixing unambiguous duplicates, removing obsolete keys, adding missing keys, and sorting them
+        """
 
-    :param lines: list of unicode strings
-    :return: list of unicode strings
-    """
-    duplicates = []
-    keys_checked = {}
-    for line in lines:
-        key, value = get_key_and_value_from_line(line=line)
-        if key:
-            if key in keys_checked:
-                duplicates.append("{key}={value}".format(key=key, value=value))
-                translation_in_list = "{key}={value}".format(key=key, value=keys_checked[key])
-                if translation_in_list not in duplicates:
-                    duplicates.append(translation_in_list)
-            else:
-                keys_checked[key] = value
-    return duplicates
+        self.__update_jabref_properties()
+        self.__update_menu_properties()
 
+    def __update_menu_properties(self):
+        self.__update_properties(main_property_file=self.main_menu_preferences, other_property_files=self.__other_menu_properties())
 
-def status(extended):
-    """
-    prints the current status to the terminal
+    def __update_jabref_properties(self):
+        self.__update_properties(main_property_file=self.main_jabref_preferences, other_property_files=self.__other_jabref_properties())
 
-    :param extended: boolean: if the keys with problems should be printed
-    """
-
-    def check_properties(main_property_file, property_files):
+    def __check_properties(self, main_property_file, property_files):
         main_lines = read_file(filename=main_property_file)
-        main_keys = get_keys_from_lines(lines=main_lines)
+        keys2 = Keys(main_lines)
+        main_keys = keys2.get_keys_from_lines()
 
         # the main property file gets compared to itself, but that is OK
         for file in property_files:
             filename = get_filename(filepath=file)
             lines = read_file(file)
-            keys = get_keys_from_lines(lines=lines)
+            keys1 = Keys(main_lines)
+            keys = keys1.get_keys_from_lines()
 
-            keys_missing = get_missing_keys(main_keys, keys)
-            keys_obsolete = get_missing_keys(keys, main_keys)
-            keys_duplicate = get_duplicates(lines=lines)
-            keys_not_translated = get_empty_keys(lines=lines)
+            keys_missing = self.__missing_keys(main_keys, keys)
+            keys_obsolete = self.__missing_keys(keys, main_keys)
+            keys_duplicate = Keys(lines).get_duplicates()
+            keys_not_translated = Keys(lines=lines).empty_keys()
 
             num_keys = len(keys)
             num_keys_missing = len(keys_missing)
@@ -288,55 +256,74 @@ def status(extended):
 
             log = logging.error if num_keys_not_translated != 0 else logging.info
             log("\t{} not translated keys".format(num_keys_not_translated))
-            if extended and num_keys_not_translated != 0:
+            if self.extended and num_keys_not_translated != 0:
                 logging.info("\t\t{}".format(", ".join(keys_not_translated)))
 
             log = logging.error if num_keys_missing != 0 else logging.info
             log("\t{} missing keys".format(num_keys_missing))
-            if extended and num_keys_missing != 0:
+            if self.extended and num_keys_missing != 0:
                 logging.info("\t\t{}".format(", ".join(keys_missing)))
 
             log = logging.error if num_keys_obsolete != 0 else logging.info
             log("\t{} obsolete keys".format(num_keys_obsolete))
-            if extended and num_keys_obsolete != 0:
+            if self.extended and num_keys_obsolete != 0:
                 logging.info("\t\t{}".format(", ".join(keys_obsolete)))
 
             log = logging.error if num_keys_duplicate != 0 else logging.info
             log("\t{} duplicates".format(num_keys_duplicate))
-            if extended and num_keys_duplicate != 0:
+            if self.extended and num_keys_duplicate != 0:
                 logging.info("\t\t{}".format(", ".join(keys_duplicate)))
 
-    check_properties(main_property_file=get_main_jabref_preferences(), property_files=get_all_jabref_properties())
-    check_properties(main_property_file=get_main_menu_properties(), property_files=get_all_menu_properties())
+    def __all_menu_properties(self) -> list:
+        """
+        :return: list of strings: all the Menu_*.preferences files with the english at the beginning
+        """
+        menu_property_files = sorted(self.__other_menu_properties())
+        menu_property_files.insert(0, self.main_menu_preferences)
+        return menu_property_files
 
+    def __other_menu_properties(self) -> list:
+        """
+        :return: list of strings: all the Menu_*.preferences files without the english one
+        """
+        menu_property_files = [s for s in os.listdir(RES_DIR) if (s.startswith('Menu_') and not (s.startswith('Menu_en')))]
+        return [os.path.join(RES_DIR, file) for file in menu_property_files]
 
-def update(extended):
-    """
-    updates all the localization files
-    fixing unambiguous duplicates, removing obsolete keys, adding missing keys, and sorting them
+    def __all_jabref_properties(self) -> list:
+        """
+        :return: list of strings: all the JabRef_*.preferences files with the english at the beginning
+        """
+        jabref_property_files = sorted(self.__other_jabref_properties())
+        jabref_property_files.insert(0, os.path.join(RES_DIR, "JabRef_en.properties"))
+        return jabref_property_files
 
-    :param extended: boolean: if the keys with problems should be printed
-    """
+    def __other_jabref_properties(self) -> list:
+        """
+        :return: list of strings: all the JabRef_*.preferences files without the english one
+        """
+        jabref_property_files = [s for s in os.listdir(RES_DIR) if (s.startswith('JabRef_') and not (s.startswith('JabRef_en')))]
+        return [os.path.join(RES_DIR, file) for file in jabref_property_files]
 
-    def update_properties(main_property_file, other_property_files):
+    def __update_properties(self, main_property_file, other_property_files):
         main_lines = read_file(filename=main_property_file)
         # saved the stripped lines
         write_file(main_property_file, main_lines)
-        main_keys = get_keys_from_lines(lines=main_lines)
+        keys_o = Keys(main_lines)
+        main_keys = keys_o.get_keys_from_lines()
 
-        main_duplicates = get_duplicates(lines=main_lines)
+        main_duplicates = keys_o.get_duplicates()
         num_main_duplicates = len(main_duplicates)
         if num_main_duplicates != 0:
             logging.error("There are {num_duplicates} duplicates in {file}, please fix them manually".format(num_duplicates=num_main_duplicates,
                                                                                                              file=get_filename(filepath=main_property_file)))
-            if extended:
+            if self.extended:
                 logging.info("\t{}".format(", ".join(main_duplicates)))
             return
 
         for other_property_file in other_property_files:
             filename = get_filename(filepath=other_property_file)
             lines = read_file(filename=other_property_file)
-            keys, not_fixed, fixed = fix_duplicates(lines=lines)
+            keys, not_fixed, fixed = Keys(lines).fix()
 
             num_keys = len(keys)
             num_not_fixed = len(not_fixed)
@@ -345,12 +332,12 @@ def update(extended):
             if num_not_fixed != 0:
                 logging.error("There are {num_not_fixed_duplicates} ambiguous duplicates in {file}, please fix them manually".format(
                     num_not_fixed_duplicates=num_not_fixed, file=filename))
-                if extended:
+                if self.extended:
                     logging.error("\t{}".format(", ".join(not_fixed)))
                 continue
 
-            keys_missing = get_missing_keys(main_keys, keys)
-            keys_obsolete = get_missing_keys(keys, main_keys)
+            keys_missing = self.__missing_keys(main_keys, keys)
+            keys_obsolete = self.__missing_keys(keys, main_keys)
 
             num_keys_missing = len(keys_missing)
             num_keys_obsolete = len(keys_obsolete)
@@ -363,7 +350,7 @@ def update(extended):
 
             other_lines_to_write = []
             for line in main_lines:
-                key = get_key_from_line(line)
+                key = keys_o.key_from_line(line)
                 if key is not None:
                     other_lines_to_write.append("{key}={value}\r\n".format(key=key, value=keys[key]))
                 else:
@@ -380,90 +367,102 @@ def update(extended):
             logging.info("Processing file '{file}' with {num_keys} Keys".format(file=filename, num_keys=num_keys))
             if num_fixed != 0:
                 logging.info("\tfixed {} unambiguous duplicates".format(num_fixed))
-                if extended:
+                if self.extended:
                     logging.info("\t\t{}".format(", ".join(fixed)))
 
             if num_keys_missing != 0:
                 logging.info("\tadded {} missing keys".format(num_keys_missing))
-                if extended:
+                if self.extended:
                     logging.info("\t\t{}".format(", ".join(keys_missing)))
 
             if num_keys_obsolete != 0:
                 logging.info("\tdeleted {} obsolete keys".format(num_keys_obsolete))
-                if extended:
+                if self.extended:
                     logging.info("\t\t{}".format(", ".join(keys_obsolete)))
 
             if sorted_lines:
                 logging.info("\thas been sorted successfully")
 
-    update_properties(main_property_file=get_main_jabref_preferences(), other_property_files=get_other_jabref_properties())
-    update_properties(main_property_file=get_main_menu_properties(), other_property_files=get_other_menu_properties())
+    def __missing_keys(self, first_list, second_list):
+        """
+        Finds all keys in the first list that are not present in the second list
+
+        :param first_list: list of unicode strings
+        :param second_list: list of unicode strings
+        :return: list of unicode strings
+        """
+        missing = []
+        for key in first_list:
+            if key not in second_list:
+                missing.append(key)
+        return missing
+
+    def status_create_markdown(self):
+        """
+        Creates a markdown file of the current status.
+        """
+
+        def _write_properties(output_file: TextIOWrapper, property_files: list):
+            output_file.write("\n| Property file | Keys | Keys translated | Keys not translated | % translated |\n")
+            output_file.write("| ------------- | ---- | --------------- | ------------------- | ------------ |\n")
+
+            for file in property_files:
+                lines = read_file(file)
+                keys = Keys(lines)
+                num_keys = len(keys.translations_as_dict())
+                num_keys_missing_value = len(keys.empty_keys())
+                num_keys_translated = num_keys - num_keys_missing_value
+
+                output_file.write(f"| [{os.path.basename(file)}]({URL_BASE}{os.path.basename(file)}) | "
+                                  f"{num_keys} | "
+                                  f"{num_keys_translated} | "
+                                  f"{num_keys_missing_value} | "
+                                  f"{_percentage(num_keys, num_keys_translated)} |\n")
+
+        def _percentage(whole: int, part: int) -> int:
+            if whole == 0:
+                return 0
+            return int(part / whole * 100.0)
+
+        with open(self.markdown_output, "w", encoding='utf-8') as status_file:
+            status_file.write(f'### Localization files status ({datetime.datetime.now().strftime("%Y-%m-%d %H:%M")} - '
+                              f'Branch `{get_current_branch()}` `{get_current_hash_short()}`)\n\n')
+            status_file.write('Note: To get the current status from your local repository, run `python ./scripts/syncLang.py markdown`\n')
+
+            _write_properties(status_file, self.__all_menu_properties())
+            _write_properties(status_file, self.__all_jabref_properties())
+
+        logging.info(f'Current status written to {self.markdown_output}')
 
 
-def status_create_markdown(markdown_output: str):
-    """
-    Creates a markdown file of the current status.
-    :param markdown_output: file to where to write the output
-    """
+if '__main__' == __name__:
 
-    def _write_properties(output_file: TextIOWrapper, property_files: list):
-        output_file.write("\n| Property file | Keys | Keys translated | Keys not translated | % translated |\n")
-        output_file.write("| ------------- | ---- | --------------- | ------------------- | ------------ |\n")
+    if len(sys.argv) == 2 and sys.argv[1] == "markdown":
+        SyncLang(extended=False, out_file='status.md').status_create_markdown()
 
-        for file in property_files:
-            lines = read_file(file)
-            num_keys = len(get_translations_as_dict(lines=lines))
-            num_keys_missing_value = len(get_empty_keys(lines=lines))
-            num_keys_translated = num_keys - num_keys_missing_value
+    elif (len(sys.argv) == 2 or len(sys.argv) == 3) and sys.argv[1] == "update":
+        SyncLang(extended=len(sys.argv) == 3 and (sys.argv[2] == "-e" or sys.argv[2] == "--extended")).update()
 
-            output_file.write(f"| [{os.path.basename(file)}]({URL_BASE}{os.path.basename(file)}) | "
-                              f"{num_keys} | "
-                              f"{num_keys_translated} | "
-                              f"{num_keys_missing_value} | "
-                              f"{_percentage(num_keys, num_keys_translated)} |\n")
+    elif (len(sys.argv) == 2 or len(sys.argv) == 3) and sys.argv[1] == "status":
+        SyncLang(extended=len(sys.argv) == 3 and (sys.argv[2] == "-e" or sys.argv[2] == "--extended")).status()
 
-    def _percentage(whole: int, part: int) -> int:
-        if whole == 0:
-            return 0
-        return int(part / whole * 100.0)
-
-    with open(markdown_output, "w", encoding='utf-8') as status_file:
-        status_file.write(f'### Localization files status ({datetime.datetime.now().strftime("%Y-%m-%d %H:%M")} - '
-                          f'Branch `{get_current_branch()}` `{get_current_hash_short()}`)\n\n')
-        status_file.write('Note: To get the current status from your local repository, run `python ./scripts/syncLang.py markdown`\n')
-
-        _write_properties(status_file, get_all_menu_properties())
-        _write_properties(status_file, get_all_jabref_properties())
-
-    logging.info(f'Current status written to {markdown_output}')
-
-
-if len(sys.argv) == 2 and sys.argv[1] == "markdown":
-    status_create_markdown('status.md')
-
-elif (len(sys.argv) == 2 or len(sys.argv) == 3) and sys.argv[1] == "update":
-    update(extended=len(sys.argv) == 3 and (sys.argv[2] == "-e" or sys.argv[2] == "--extended"))
-
-elif (len(sys.argv) == 2 or len(sys.argv) == 3) and sys.argv[1] == "status":
-    status(extended=len(sys.argv) == 3 and (sys.argv[2] == "-e" or sys.argv[2] == "--extended"))
-
-else:
-    logging.info("""This program must be run from the JabRef base directory.
-
-Usage: syncLang.py {markdown, status [-e | --extended], update [-e | --extended]}
-Option can be one of the following:
-
-    status [-e | --extended]:
-        prints the current status to the terminal
-        [-e | --extended]:
-            if the translations keys which create problems should be printed
-
-    markdown:
-        Creates a markdown file of the current status and opens it
-
-    update [-e | --extended]:
-        compares all the localization files against the English one and fixes unambiguous duplicates,
-        removes obsolete keys, adds missing keys, and sorts them
-        [-e | --extended]:
-            if the translations keys which create problems should be printed
-""")
+    else:
+        logging.info("""This program must be run from the JabRef base directory.
+    
+    Usage: syncLang.py {markdown, status [-e | --extended], update [-e | --extended]}
+    Option can be one of the following:
+    
+        status [-e | --extended]:
+            prints the current status to the terminal
+            [-e | --extended]:
+                if the translations keys which create problems should be printed
+    
+        markdown:
+            Creates a markdown file of the current status and opens it
+    
+        update [-e | --extended]:
+            compares all the localization files against the English one and fixes unambiguous duplicates,
+            removes obsolete keys, adds missing keys, and sorts them
+            [-e | --extended]:
+                if the translations keys which create problems should be printed
+    """)

--- a/scripts/syncLang.py
+++ b/scripts/syncLang.py
@@ -1,13 +1,12 @@
 # coding=utf-8
-from __future__ import print_function
+
 import codecs
 import datetime
+import logging
 import os
 import subprocess
 import sys
 import webbrowser
-
-import logger
 
 RES_DIR = "src/main/resources/l10n"
 STATUS_FILE = "status.md"
@@ -52,7 +51,7 @@ def read_file(filename, encoding="UTF-8"):
     :return: list of unicode strings: the lines of the file
     """
     with codecs.open(filename, encoding=encoding) as file:
-        return [u"{}\r\n".format(line.strip()) for line in file.readlines()]
+        return ["{}\r\n".format(line.strip()) for line in file.readlines()]
 
 
 def write_file(filename, content):
@@ -75,7 +74,7 @@ def get_other_jabref_properties():
     """
     :return: list of strings: all the JabRef_*.preferences files without the english one
     """
-    jabref_property_files = filter(lambda s: (s.startswith('JabRef_') and not (s.startswith('JabRef_en'))), os.listdir(RES_DIR))
+    jabref_property_files = [s for s in os.listdir(RES_DIR) if (s.startswith('JabRef_') and not (s.startswith('JabRef_en')))]
     return [os.path.join(RES_DIR, file) for file in jabref_property_files]
 
 
@@ -99,7 +98,7 @@ def get_other_menu_properties():
     """
     :return: list of strings: all the Menu_*.preferences files without the english one
     """
-    menu_property_files = filter(lambda s: (s.startswith('Menu_') and not (s.startswith('Menu_en'))), os.listdir(RES_DIR))
+    menu_property_files = [s for s in os.listdir(RES_DIR) if (s.startswith('Menu_') and not (s.startswith('Menu_en')))]
     return [os.path.join(RES_DIR, file) for file in menu_property_files]
 
 
@@ -164,7 +163,7 @@ def get_empty_keys(lines):
     """
     not_translated = []
     keys = get_translations_as_dict(lines=lines)
-    for key, value in keys.iteritems():
+    for key, value in keys.items():
         if not value:
             not_translated.append(key)
     return not_translated
@@ -185,15 +184,15 @@ def fix_duplicates(lines):
         if key:
             if key in keys:
                 if not keys[key]:
-                    fixed.append(u"{key}={value}".format(key=key, value=keys[key]))
+                    fixed.append("{key}={value}".format(key=key, value=keys[key]))
                     keys[key] = value
                 elif not value:
-                    fixed.append(u"{key}={value}".format(key=key, value=value))
+                    fixed.append("{key}={value}".format(key=key, value=value))
                 elif keys[key] == value:
-                    fixed.append(u"{key}={value}".format(key=key, value=value))
+                    fixed.append("{key}={value}".format(key=key, value=value))
                 elif keys[key] != value:
-                    not_fixed.append(u"{key}={value}".format(key=key, value=value))
-                    not_fixed.append(u"{key}={value}".format(key=key, value=keys[key]))
+                    not_fixed.append("{key}={value}".format(key=key, value=value))
+                    not_fixed.append("{key}={value}".format(key=key, value=keys[key]))
             else:
                 keys[key] = value
 
@@ -243,8 +242,8 @@ def get_duplicates(lines):
         key, value = get_key_and_value_from_line(line=line)
         if key:
             if key in keys_checked:
-                duplicates.append(u"{key}={value}".format(key=key, value=value))
-                translation_in_list = u"{key}={value}".format(key=key, value=keys_checked[key])
+                duplicates.append("{key}={value}".format(key=key, value=value))
+                translation_in_list = "{key}={value}".format(key=key, value=keys_checked[key])
                 if translation_in_list not in duplicates:
                     duplicates.append(translation_in_list)
             else:
@@ -280,29 +279,29 @@ def status(extended):
             num_keys_duplicate = len(keys_duplicate)
             num_keys_translated = num_keys - num_keys_not_translated
 
-            log = logger.error if num_keys_missing != 0 or num_keys_not_translated != 0 or num_keys_obsolete != 0 or num_keys_duplicate != 0 else logger.ok
+            log = logging.error if num_keys_missing != 0 or num_keys_not_translated != 0 or num_keys_obsolete != 0 or num_keys_duplicate != 0 else logging.info
             log("Status of file '{file}' with {num_keys} Keys".format(file=filename, num_keys=num_keys))
-            logger.ok("\t{} translated keys".format(num_keys_translated))
+            logging.info("\t{} translated keys".format(num_keys_translated))
 
-            log = logger.error if num_keys_not_translated != 0 else logger.ok
+            log = logging.error if num_keys_not_translated != 0 else logging.info
             log("\t{} not translated keys".format(num_keys_not_translated))
             if extended and num_keys_not_translated != 0:
-                logger.neutral(u"\t\t{}".format(", ".join(keys_not_translated)))
+                logging.info("\t\t{}".format(", ".join(keys_not_translated)))
 
-            log = logger.error if num_keys_missing != 0 else logger.ok
+            log = logging.error if num_keys_missing != 0 else logging.info
             log("\t{} missing keys".format(num_keys_missing))
             if extended and num_keys_missing != 0:
-                logger.neutral(u"\t\t{}".format(", ".join(keys_missing)))
+                logging.info("\t\t{}".format(", ".join(keys_missing)))
 
-            log = logger.error if num_keys_obsolete != 0 else logger.ok
+            log = logging.error if num_keys_obsolete != 0 else logging.info
             log("\t{} obsolete keys".format(num_keys_obsolete))
             if extended and num_keys_obsolete != 0:
-                logger.neutral(u"\t\t{}".format(", ".join(keys_obsolete)))
+                logging.info("\t\t{}".format(", ".join(keys_obsolete)))
 
-            log = logger.error if num_keys_duplicate != 0 else logger.ok
+            log = logging.error if num_keys_duplicate != 0 else logging.info
             log("\t{} duplicates".format(num_keys_duplicate))
             if extended and num_keys_duplicate != 0:
-                logger.neutral(u"\t\t{}".format(", ".join(keys_duplicate)))
+                logging.info("\t\t{}".format(", ".join(keys_duplicate)))
 
     check_properties(main_property_file=get_main_jabref_preferences(), property_files=get_all_jabref_properties())
     check_properties(main_property_file=get_main_menu_properties(), property_files=get_all_menu_properties())
@@ -324,11 +323,11 @@ def update(extended):
         main_duplicates = get_duplicates(lines=main_lines)
         num_main_duplicates = len(main_duplicates)
         if num_main_duplicates != 0:
-            logger.error("There are {num_duplicates} duplicates in {file}, please fix them manually".format(num_duplicates=num_main_duplicates, file=get_filename(filepath=main_property_file)))
+            logging.error("There are {num_duplicates} duplicates in {file}, please fix them manually".format(num_duplicates=num_main_duplicates,
+                                                                                                             file=get_filename(filepath=main_property_file)))
             if extended:
-                logger.neutral(u"\t{}".format(", ".join(main_duplicates)))
+                logging.info("\t{}".format(", ".join(main_duplicates)))
             return
-
 
         for other_property_file in other_property_files:
             filename = get_filename(filepath=other_property_file)
@@ -340,9 +339,10 @@ def update(extended):
             num_fixed = len(fixed)
 
             if num_not_fixed != 0:
-                logger.error("There are {num_not_fixed_duplicates} ambiguous duplicates in {file}, please fix them manually".format(num_not_fixed_duplicates=num_not_fixed, file=filename))
+                logging.error("There are {num_not_fixed_duplicates} ambiguous duplicates in {file}, please fix them manually".format(
+                    num_not_fixed_duplicates=num_not_fixed, file=filename))
                 if extended:
-                    logger.error(u"\t{}".format(u", ".join(not_fixed)))
+                    logging.error("\t{}".format(", ".join(not_fixed)))
                 continue
 
             keys_missing = get_missing_keys(main_keys, keys)
@@ -361,36 +361,36 @@ def update(extended):
             for line in main_lines:
                 key = get_key_from_line(line)
                 if key is not None:
-                    other_lines_to_write.append(u"{key}={value}\r\n".format(key=key, value=keys[key]))
+                    other_lines_to_write.append("{key}={value}\r\n".format(key=key, value=keys[key]))
                 else:
                     other_lines_to_write.append(line)
 
-            sorted = len(lines) != len(other_lines_to_write)
-            if not sorted:
+            sorted_lines = len(lines) != len(other_lines_to_write)
+            if not sorted_lines:
                 for old_line, new_lines in zip(lines, other_lines_to_write):
                     if old_line != new_lines:
-                        sorted = True
+                        sorted_lines = True
 
             write_file(filename=other_property_file, content=other_lines_to_write)
 
-            logger.ok("Processing file '{file}' with {num_keys} Keys".format(file=filename, num_keys=num_keys))
+            logging.info("Processing file '{file}' with {num_keys} Keys".format(file=filename, num_keys=num_keys))
             if num_fixed != 0:
-                logger.ok("\tfixed {} unambiguous duplicates".format(num_fixed))
+                logging.info("\tfixed {} unambiguous duplicates".format(num_fixed))
                 if extended:
-                    logger.neutral(u"\t\t{}".format(", ".join(fixed)))
+                    logging.info("\t\t{}".format(", ".join(fixed)))
 
             if num_keys_missing != 0:
-                logger.ok("\tadded {} missing keys".format(num_keys_missing))
+                logging.info("\tadded {} missing keys".format(num_keys_missing))
                 if extended:
-                    logger.neutral(u"\t\t{}".format(", ".join(keys_missing)))
+                    logging.info("\t\t{}".format(", ".join(keys_missing)))
 
             if num_keys_obsolete != 0:
-                logger.ok("\tdeleted {} obsolete keys".format(num_keys_obsolete))
+                logging.info("\tdeleted {} obsolete keys".format(num_keys_obsolete))
                 if extended:
-                    logger.neutral(u"\t\t{}".format(", ".join(keys_obsolete)))
+                    logging.info("\t\t{}".format(", ".join(keys_obsolete)))
 
-            if sorted:
-                logger.ok("\thas been sorted successfully")
+            if sorted_lines:
+                logging.info("\thas been sorted successfully")
 
     update_properties(main_property_file=get_main_jabref_preferences(), other_property_files=get_other_jabref_properties())
     update_properties(main_property_file=get_main_menu_properties(), other_property_files=get_other_menu_properties())
@@ -425,7 +425,7 @@ def status_create_markdown():
     write_properties(property_files=get_all_jabref_properties())
     write_properties(property_files=get_all_menu_properties())
     write_file(STATUS_FILE, markdown)
-    logger.ok("Current status written to {}".format(STATUS_FILE))
+    logging.info("Current status written to {}".format(STATUS_FILE))
     open_file(STATUS_FILE)
 
 
@@ -439,7 +439,7 @@ elif (len(sys.argv) == 2 or len(sys.argv) == 3) and sys.argv[1] == "status":
     status(extended=len(sys.argv) == 3 and (sys.argv[2] == "-e" or sys.argv[2] == "--extended"))
 
 else:
-    logger.neutral("""This program must be run from the JabRef base directory.
+    logging.info("""This program must be run from the JabRef base directory.
 
 Usage: syncLang.py {markdown, status [-e | --extended], update [-e | --extended]}
 Option can be one of the following:

--- a/scripts/syncLang.py
+++ b/scripts/syncLang.py
@@ -432,8 +432,8 @@ def status_create_markdown(markdown_output: str):
                           f'Branch `{get_current_branch()}` `{get_current_hash_short()}`)\n\n')
         status_file.write('Note: To get the current status from your local repository, run `python ./scripts/syncLang.py markdown`\n')
 
-        _write_properties(status_file, get_all_jabref_properties())
         _write_properties(status_file, get_all_menu_properties())
+        _write_properties(status_file, get_all_jabref_properties())
 
     logging.info(f'Current status written to {markdown_output}')
 

--- a/scripts/syncLang.py
+++ b/scripts/syncLang.py
@@ -1,6 +1,5 @@
 # coding=utf-8
 
-import codecs
 import datetime
 import logging
 import os
@@ -270,8 +269,6 @@ class SyncLang:
 
     def __update_properties(self, main_property_file, other_property_files):
         main_lines = self.__read_file_as_lines(filename=main_property_file)
-        # saved the stripped lines
-        self.__write_file(main_property_file, main_lines)
         main_keys = Keys(main_lines)
 
         main_duplicates = main_keys.duplicates()
@@ -316,7 +313,7 @@ class SyncLang:
             for line in main_lines:
                 key = main_keys.key_from_line(line)
                 if key is not None:
-                    other_lines_to_write.append("{key}={value}\r\n".format(key=key, value=keys[key]))
+                    other_lines_to_write.append("{key}={value}\n".format(key=key, value=keys[key]))
                 else:
                     other_lines_to_write.append(line)
 
@@ -364,7 +361,8 @@ class SyncLang:
         :param filename: string
         :param content: list of unicode unicode: the lines to write
         """
-        codecs.open(filename, "w", encoding='utf-8').writelines(content)
+        with open(filename, 'w', newline='\n', encoding='UTF-8') as f:
+            f.writelines(content)
 
     @staticmethod
     def __read_file_as_lines(filename, encoding="UTF-8") -> list:
@@ -373,8 +371,8 @@ class SyncLang:
         :param encoding: string: the encoding of the file to read (standard: `UTF-8`)
         :return: list of unicode strings: the lines of the file
         """
-        with codecs.open(filename, encoding=encoding) as file:
-            return ["{}\r\n".format(line.strip()) for line in file.readlines()]
+        with open(filename, 'r', newline='', encoding=encoding) as file:
+            return ["{}\n".format(line.strip()) for line in file.readlines()]
 
     def __missing_keys(self, first_list: list, second_list: list) -> list:
         """
@@ -416,7 +414,7 @@ class SyncLang:
                 return 0
             return int(part / whole * 100.0)
 
-        with open(self.markdown_output, "w", encoding='utf-8') as status_file:
+        with open(self.markdown_output, "w", newline="\n", encoding='utf-8') as status_file:
             status_file.write(f'### Localization files status ({datetime.datetime.now().strftime("%Y-%m-%d %H:%M")} - '
                               f'Branch `{Git().get_current_branch()}` `{Git().get_current_hash_short()}`)\n\n')
             status_file.write('Note: To get the current status from your local repository, run `python ./scripts/syncLang.py markdown`\n')


### PR DESCRIPTION
See Issue #3181.

- [X]  Update to Python 3
- [ ]  automatically generate the translation status with each push to master and publish a html version on jabref.org
- [x]  keep a constant order for the table of languages: English first, then alphabetical
- [x]  put the table of menus first (so that is it not discouraging newcomers with a huge number of strings waiting for translation).
- [x]  align to the right the columns with numbers (easier to read, but just a tiny detail).
- [x]  Apply object-oriented design principles
