### PR TITLE
update link from http to https

### DIFF
--- a/src/test/java/org/jabref/logic/importer/fetcher/DoiResolutionTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DoiResolutionTest.java
@@ -1,18 +1,17 @@
 package org.jabref.logic.importer.fetcher;
 
-import java.io.IOException;
-import java.net.URL;
-import java.util.Optional;
-
 import org.jabref.model.entry.BibEntry;
 import org.jabref.support.DevEnvironment;
 import org.jabref.testutils.category.FetcherTests;
-
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Optional;
 
 @Category(FetcherTests.class)
 public class DoiResolutionTest {
@@ -45,7 +44,7 @@ public class DoiResolutionTest {
         entry.setField("doi", "10.1051/0004-6361/201527330");
 
         Assert.assertEquals(
-                Optional.of(new URL("http://www.aanda.org/articles/aa/pdf/2016/01/aa27330-15.pdf")),
+                Optional.of(new URL("https://www.aanda.org/articles/aa/pdf/2016/01/aa27330-15.pdf")),
                 finder.findFullText(entry)
         );
     }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

DOI URL changed to https, was http.

- [ ] Change in CHANGELOG.md described
Minor change
- [ ] Tests created for changes
Updated URL 
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
  - Goto https://www.doi.org/ 
  - search for 10.1051/0004-6361/201527330
  - be redirected to http**s**://www.aanda.org/articles/aa/abs/2016/01/aa27330-15/aa27330-15.html
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
