### PR TITLE
Fix #2775: Hyphens in last names are properly parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed wrong hotkey being displayed at "automatically file links" in the entry editor
 - We fixed an issue where metadata syncing with local and shared database were unstable. It will also fix syncing groups and sub-groups in database. [#2284](https://github.com/JabRef/jabref/issues/2284)
 - Renaming files now truncates the filename to not exceed the limit of 255 chars [#2622](https://github.com/JabRef/jabref/issues/2622)
+- We improved the handling of hyphens in names. [#2775](https://github.com/JabRef/jabref/issues/2775)
 
 ### Removed
 - We removed support for LatexEditor, as it is not under active development. [#3199](https://github.com/JabRef/jabref/issues/3199)

--- a/src/test/java/org/jabref/model/entry/AuthorListTest.java
+++ b/src/test/java/org/jabref/model/entry/AuthorListTest.java
@@ -7,6 +7,10 @@ import org.junit.Test;
 
 public class AuthorListTest {
 
+    public static int size(String bibtex) {
+        return AuthorList.parse(bibtex).getNumberOfAuthors();
+    }
+
     @Test
     public void testFixAuthorNatbib() {
         Assert.assertEquals("", AuthorList.fixAuthorNatbib(""));
@@ -284,10 +288,6 @@ public class AuthorListTest {
                 "Neumann, J. and Smith, J. and Black Brown, Jr., P.",
                 AuthorList
                         .fixAuthorForAlphabetization("John von Neumann and John Smith and de Black Brown, Jr., Peter"));
-    }
-
-    public static int size(String bibtex) {
-        return AuthorList.parse(bibtex).getNumberOfAuthors();
     }
 
     @Test
@@ -623,6 +623,25 @@ public class AuthorListTest {
     public void parseNameWithHyphenInLastName() throws Exception {
         Author expected = new Author("Firstname", "F.", null, "Bailey-Jones", null);
         Assert.assertEquals(new AuthorList(expected), AuthorList.parse("Firstname Bailey-Jones"));
+    }
+
+    @Test
+    public void parseNameWithHyphenInLastNameWithInitials() throws Exception {
+        Author expected = new Author("E. S.", "E. S.", null, "El-{M}allah", null);
+        Assert.assertEquals(new AuthorList(expected), AuthorList.parse("E. S. El-{M}allah"));
+    }
+
+    @Test
+    public void parseNameWithHyphenInLastNameWithEscaped() throws Exception {
+        Author expected = new Author("E. S.", "E. S.", null, "{K}ent-{B}oswell", null);
+        Assert.assertEquals(new AuthorList(expected), AuthorList.parse("E. S. {K}ent-{B}oswell"));
+    }
+
+    @Test
+    public void parseNameWithHyphenInLastNameWhenLastNameGivenFirst() throws Exception {
+        // TODO: Fix abbreviation to be "A."
+        Author expected = new Author("ʿAbdallāh", "ʿ.", null, "al-Ṣāliḥ", null);
+        Assert.assertEquals(new AuthorList(expected), AuthorList.parse("al-Ṣāliḥ, ʿAbdallāh"));
     }
 
     @Test


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
I missed JabRef so much, that I even dared to touch the name parsing algorithm.  
The only real changed consists in the few added lines https://github.com/JabRef/jabref/compare/fix3142?expand=1#diff-b8249d741d31352dd2bcafcab07d9457R147, the rest is only code formatting/renaming of variables. The added tests come from [biblatex](https://github.com/plk/biber/blob/f418da9b1975847461fad884fedf910aed73c13b/t/names.t).

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
