### PR TITLE
Improve telemetry

### DIFF
--- a/src/main/java/org/jabref/FallbackExceptionHandler.java
+++ b/src/main/java/org/jabref/FallbackExceptionHandler.java
@@ -1,16 +1,14 @@
 package org.jabref;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.Marker;
-import org.apache.logging.log4j.MarkerManager;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * Catch and log any unhandled exceptions.
  */
 public class FallbackExceptionHandler implements Thread.UncaughtExceptionHandler {
 
-    private static final Marker UncaughtException_MARKER = MarkerManager.getMarker("UncaughtException");
+    private static final Log LOGGER = LogFactory.getLog(FallbackExceptionHandler.class);
 
     public static void installExceptionHandler() {
         Thread.setDefaultUncaughtExceptionHandler(new FallbackExceptionHandler());
@@ -18,7 +16,6 @@ public class FallbackExceptionHandler implements Thread.UncaughtExceptionHandler
 
     @Override
     public void uncaughtException(Thread thread, Throwable exception) {
-        Logger logger = LogManager.getLogger(FallbackExceptionHandler.class);
-        logger.error(UncaughtException_MARKER, "Uncaught exception Occurred in " + thread, exception);
+        LOGGER.error("Uncaught exception occurred in " + thread, exception);
     }
 }

--- a/src/main/java/org/jabref/gui/actions/NewEntryAction.java
+++ b/src/main/java/org/jabref/gui/actions/NewEntryAction.java
@@ -1,10 +1,13 @@
 package org.jabref.gui.actions;
 
 import java.awt.event.ActionEvent;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.swing.Action;
 import javax.swing.KeyStroke;
 
+import org.jabref.Globals;
 import org.jabref.gui.EntryTypeDialog;
 import org.jabref.gui.IconTheme;
 import org.jabref.gui.JabRefFrame;
@@ -58,6 +61,8 @@ public class NewEntryAction extends MnemonicAwareAction {
                 return;
             }
             thisType = tp.getName();
+
+            trackNewEntry(tp);
         }
 
         if (jabRefFrame.getBasePanelCount() > 0) {
@@ -67,5 +72,13 @@ public class NewEntryAction extends MnemonicAwareAction {
         } else {
             LOGGER.info("Action 'New entry' must be disabled when no database is open.");
         }
+    }
+
+    private void trackNewEntry(EntryType type) {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("EntryType", type.getName());
+        Map<String, Double> measurements = new HashMap<>();
+
+        Globals.getTelemetryClient().ifPresent(client -> client.trackEvent("NewEntry", properties, measurements));
     }
 }

--- a/src/main/java/org/jabref/gui/logging/ApplicationInsightsAppender.java
+++ b/src/main/java/org/jabref/gui/logging/ApplicationInsightsAppender.java
@@ -39,6 +39,7 @@ public class ApplicationInsightsAppender extends AbstractAppender {
         Telemetry telemetry;
         if (event.isException()) {
             ExceptionTelemetry exceptionTelemetry = new ExceptionTelemetry(event.getException());
+            exceptionTelemetry.getProperties().put("Message", rawEvent.getMessage().getFormattedMessage());
             exceptionTelemetry.setSeverityLevel(event.getNormalizedSeverityLevel());
             telemetry = exceptionTelemetry;
         } else {


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
For some reason, some unhandled exceptions are report multiple (meaning in the thousands) times in the Azure telemetry. Thus we regularly hit the daily cap and I get an annoying email. I tried to investigate, but couldn't reproduce the behavior and thus I'm not sure that these changes actually fix the problem. The only difference between logging in the FallbackExceptionHandler to other loggings of errors was the direct usage of `log4j` instead of the usual `LogFactory` approach. Thus I changed it to the later and hope for the best.

While touching the telemetry, I also added logging of the creation of new entries and the created entry type. This information might serve as a guide for a forthcoming improvement of the "New entry..." dialog (with sensible defaults and/or completely different approach depending on how users use it).

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
