### PR TITLE
[minor change] Fix assertion by removing typo

### DIFF
--- a/src/test/java/org/jabref/gui/importer/fetcher/OAI2HandlerFetcherTest.java
+++ b/src/test/java/org/jabref/gui/importer/fetcher/OAI2HandlerFetcherTest.java
@@ -72,7 +72,7 @@ public class OAI2HandlerFetcherTest {
 
             Assert.assertEquals(Optional.of("Heavy Particles from Inflation"), be.getField("title"));
             Assert.assertTrue(be.getField("abstract").isPresent());
-            Assert.assertEquals(Optional.of("23 pages"), be.getField("comments"));
+            Assert.assertEquals(Optional.of("23 pages"), be.getField("comment"));
             Assert.assertEquals(Optional.of("CERN-PH-TH/2004-151"), be.getField("reportno"));
         } catch (SAXException e) {
             throw e.getException();


### PR DESCRIPTION
FieldName is "comment" not "comments".
Removing "s" fixes the assertion failure

<!-- describe the changes you have made here: what, why, ... -->

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
