### PR TITLE
Don't highlight odd rows in file list editor

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.css
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.css
@@ -31,3 +31,7 @@
     -fx-text-fill: text-area-foreground;
     -fx-text-origin: baseline;
 }
+
+.list-cell:odd {
+    -fx-background-color: text-area-background;
+}


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
Right now the odd rows in the file list have a slightly darker background. This makes sens for bigger lists as the eye can follow the row more easily. However, it is just disturbing for our case of 2-3 files. 

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
