### PR TITLE
Testcoverage preferences

### DIFF
--- a/src/main/java/org/jabref/preferences/PreviewPreferences.java
+++ b/src/main/java/org/jabref/preferences/PreviewPreferences.java
@@ -12,9 +12,9 @@ public class PreviewPreferences {
     private final String previewStyleDefault;
 
 
-    public PreviewPreferences(List<String> previewCycle, int previeCyclePosition, int previewPanelHeight, boolean previewPanelEnabled, String previewStyle, String previewStyleDefault) {
+    public PreviewPreferences(List<String> previewCycle, int previewCyclePosition, int previewPanelHeight, boolean previewPanelEnabled, String previewStyle, String previewStyleDefault) {
         this.previewCycle = previewCycle;
-        this.previewCyclePosition = previeCyclePosition;
+        this.previewCyclePosition = previewCyclePosition;
         this.previewPanelHeight = previewPanelHeight;
         this.previewPanelEnabled = previewPanelEnabled;
         this.previewStyle = previewStyle;
@@ -51,7 +51,7 @@ public class PreviewPreferences {
 
     public static class Builder {
         private List<String> previewCycle;
-        private int previeCyclePosition;
+        private int previewCyclePosition;
         private int previewPanelHeight;
         private boolean previewPanelEnabled;
         private String previewStyle;
@@ -60,7 +60,7 @@ public class PreviewPreferences {
 
         public Builder(PreviewPreferences previewPreferences) {
             this.previewCycle = previewPreferences.getPreviewCycle();
-            this.previeCyclePosition = previewPreferences.getPreviewCyclePosition();
+            this.previewCyclePosition = previewPreferences.getPreviewCyclePosition();
             this.previewPanelHeight = previewPreferences.getPreviewPanelHeight();
             this.previewPanelEnabled = previewPreferences.isPreviewPanelEnabled();
             this.previewStyle = previewPreferences.getPreviewStyle();
@@ -69,15 +69,15 @@ public class PreviewPreferences {
 
         public Builder withPreviewCycle(List<String> previewCycle) {
             this.previewCycle = previewCycle;
-            return withPreviewCyclePosition(previeCyclePosition);
+            return withPreviewCyclePosition(previewCyclePosition);
         }
 
         public Builder withPreviewCyclePosition(int position) {
-            previeCyclePosition = position;
-            while (previeCyclePosition < 0) {
-                previeCyclePosition += previewCycle.size();
+            previewCyclePosition = position;
+            while (previewCyclePosition < 0) {
+                previewCyclePosition += previewCycle.size();
             }
-            previeCyclePosition %= previewCycle.size();
+            previewCyclePosition %= previewCycle.size();
             return this;
         }
 
@@ -97,7 +97,7 @@ public class PreviewPreferences {
         }
 
         public PreviewPreferences build() {
-            return new PreviewPreferences(previewCycle, previeCyclePosition, previewPanelHeight, previewPanelEnabled, previewStyle, previewStyleDefault);
+            return new PreviewPreferences(previewCycle, previewCyclePosition, previewPanelHeight, previewPanelEnabled, previewStyle, previewStyleDefault);
         }
     }
 

--- a/src/test/java/org/jabref/preferences/JabRefPreferencesFilterTest.java
+++ b/src/test/java/org/jabref/preferences/JabRefPreferencesFilterTest.java
@@ -1,0 +1,20 @@
+package org.jabref.preferences;
+
+import org.junit.Test;
+
+public class JabRefPreferencesFilterTest {
+
+    @Test
+    public void givenNothingWhenCreatingThenNothingThrown() {
+        JabRefPreferences preferences = JabRefPreferences.getInstance();
+        new JabRefPreferencesFilter(preferences);
+    }
+
+    @Test
+    public void givenNothingWhenCreatingPreferenceOptionThenNothingThrown() {
+        String key = "";
+        Object value = new Object();
+        Object defaultValue = new Object();
+        new JabRefPreferencesFilter.PreferenceOption(key, value, defaultValue);
+    }
+}

--- a/src/test/java/org/jabref/preferences/JabRefPreferencesFilterTest.java
+++ b/src/test/java/org/jabref/preferences/JabRefPreferencesFilterTest.java
@@ -2,19 +2,33 @@ package org.jabref.preferences;
 
 import org.junit.Test;
 
+import static junit.framework.TestCase.assertTrue;
+
 public class JabRefPreferencesFilterTest {
 
     @Test
     public void givenNothingWhenCreatingThenNothingThrown() {
-        JabRefPreferences preferences = JabRefPreferences.getInstance();
-        new JabRefPreferencesFilter(preferences);
+        boolean nothingThrown = true;
+        try {
+            JabRefPreferences preferences = JabRefPreferences.getInstance();
+            new JabRefPreferencesFilter(preferences);
+        } catch (Exception e) {
+            nothingThrown = false;
+        }
+        assertTrue("Simple creation should not throw exceptions.", nothingThrown);
     }
 
     @Test
     public void givenNothingWhenCreatingPreferenceOptionThenNothingThrown() {
-        String key = "";
-        Object value = new Object();
-        Object defaultValue = new Object();
-        new JabRefPreferencesFilter.PreferenceOption(key, value, defaultValue);
+        boolean nothingThrown = true;
+        try {
+            String key = "";
+            Object value = new Object();
+            Object defaultValue = new Object();
+            new JabRefPreferencesFilter.PreferenceOption(key, value, defaultValue);
+        } catch (Exception e) {
+            nothingThrown = false;
+        }
+        assertTrue("Simple creation should not throw exceptions.", nothingThrown);
     }
 }

--- a/src/test/java/org/jabref/preferences/PreviewPreferenceTest.java
+++ b/src/test/java/org/jabref/preferences/PreviewPreferenceTest.java
@@ -1,0 +1,41 @@
+package org.jabref.preferences;
+
+import org.junit.Test;
+
+import java.util.List;
+
+public class PreviewPreferenceTest {
+
+    private List<String> previewCycle = null;
+    private int previewCyclePosition = 0;
+    private int previewPanelHeight = 0;
+    private boolean previewPanelEnabled = false;
+    private String previewStyle = "";
+    private String previewStyleDefault = "";
+
+    @Test
+    public void givenNothingWhenCreatingPreviewPreferenceThenNothingThrown() {
+        new PreviewPreferences(
+                previewCycle,
+                previewCyclePosition,
+                previewPanelHeight,
+                previewPanelEnabled,
+                previewStyle,
+                previewStyleDefault
+        );
+    }
+
+    @Test
+    public void givenNothingWhenBuildingThenNothingThrown() {
+        PreviewPreferences previewPreferences =
+                new PreviewPreferences(
+                        previewCycle,
+                        previewCyclePosition,
+                        previewPanelHeight,
+                        previewPanelEnabled,
+                        previewStyle,
+                        previewStyleDefault
+        );
+        new PreviewPreferences.Builder(previewPreferences);
+    }
+}

--- a/src/test/java/org/jabref/preferences/PreviewPreferenceTest.java
+++ b/src/test/java/org/jabref/preferences/PreviewPreferenceTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static junit.framework.TestCase.assertTrue;
+
 public class PreviewPreferenceTest {
 
     private List<String> previewCycle = null;
@@ -15,27 +17,39 @@ public class PreviewPreferenceTest {
 
     @Test
     public void givenNothingWhenCreatingPreviewPreferenceThenNothingThrown() {
-        new PreviewPreferences(
-                previewCycle,
-                previewCyclePosition,
-                previewPanelHeight,
-                previewPanelEnabled,
-                previewStyle,
-                previewStyleDefault
-        );
+        boolean nothingThrown = true;
+        try {
+            new PreviewPreferences(
+                    previewCycle,
+                    previewCyclePosition,
+                    previewPanelHeight,
+                    previewPanelEnabled,
+                    previewStyle,
+                    previewStyleDefault
+            );
+        } catch (Exception e) {
+            nothingThrown = false;
+        }
+        assertTrue("Simple creation should not throw exceptions.", nothingThrown);
     }
 
     @Test
     public void givenNothingWhenBuildingThenNothingThrown() {
-        PreviewPreferences previewPreferences =
-                new PreviewPreferences(
-                        previewCycle,
-                        previewCyclePosition,
-                        previewPanelHeight,
-                        previewPanelEnabled,
-                        previewStyle,
-                        previewStyleDefault
-        );
-        new PreviewPreferences.Builder(previewPreferences);
+        boolean nothingThrown = true;
+        try {
+            PreviewPreferences previewPreferences =
+                    new PreviewPreferences(
+                            previewCycle,
+                            previewCyclePosition,
+                            previewPanelHeight,
+                            previewPanelEnabled,
+                            previewStyle,
+                            previewStyleDefault
+                    );
+            new PreviewPreferences.Builder(previewPreferences);
+        } catch (Exception e) {
+            nothingThrown = false;
+        }
+        assertTrue("Simple creation should not throw exceptions.", nothingThrown);
     }
 }

--- a/src/test/java/org/jabref/preferences/VersionPreferencesTest.java
+++ b/src/test/java/org/jabref/preferences/VersionPreferencesTest.java
@@ -1,0 +1,21 @@
+package org.jabref.preferences;
+
+import org.jabref.logic.util.Version;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class VersionPreferencesTest {
+
+    @Test
+    public void givenNothingWhenCreatingThenNothingThrown() {
+        new VersionPreferences(Version.parse(""));
+    }
+
+    @Test
+    public void givenIgnoredVersionStringWhenGetIgnoredVersionThenUnknown() {
+        Version ignoredVersion = Version.parse("");
+        VersionPreferences preferences = new VersionPreferences(ignoredVersion);
+        assertEquals("*unknown*", preferences.getIgnoredVersion().toString());
+    }
+}


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

Fixed a typo in https://github.com/JabRef/jabref/compare/master...sammann-fnordbedarf-de:testcoverage-preferences?expand=1#diff-b58b89dd0bdb3e1dad1c0ae7801bae2b: from previe to preview

Added tests for creating and building classes in preferences-package in order to increase text coverage of classes. 

Constructing classes expects nothing thrown, building classes also. Where needed the most trivial variables were used. 

Increasing tests for methods will be more rigid and are planned after (nearly) full class coverage. 

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
