### PR TITLE
Don't add file name as description

### DIFF
--- a/src/main/java/org/jabref/gui/externalfiles/AutoSetLinks.java
+++ b/src/main/java/org/jabref/gui/externalfiles/AutoSetLinks.java
@@ -122,14 +122,13 @@ public class AutoSetLinks {
                         tableModel = singleTableModel;
                     }
                     List<Path> files = entryFilePair.getValue();
-                    for (Path f : files) {
-                        f = FileUtil.shortenFileName(f, dirs);
+                    for (Path file : files) {
+                        file = FileUtil.shortenFileName(file, dirs);
                         boolean alreadyHas = false;
-                        //System.out.println("File: "+f.getPath());
+
                         for (int j = 0; j < tableModel.getRowCount(); j++) {
                             FileListEntry existingEntry = tableModel.getEntry(j);
-                            //System.out.println("Comp: "+existingEntry.getLink());
-                            if (Paths.get(existingEntry.getLink()).equals(f)) {
+                            if (Paths.get(existingEntry.getLink()).equals(file)) {
                                 alreadyHas = true;
                                 foundAny = true;
                                 break;
@@ -137,14 +136,10 @@ public class AutoSetLinks {
                         }
                         if (!alreadyHas) {
                             foundAny = true;
-                            Optional<ExternalFileType> type;
-                            Optional<String> extension = FileHelper.getFileExtension(f);
-                            if (extension.isPresent()) {
-                                type = ExternalFileTypes.getInstance().getExternalFileTypeByExt(extension.get());
-                            } else {
-                                type = Optional.of(new UnknownExternalFileType(""));
-                            }
-                            FileListEntry flEntry = new FileListEntry(f.getFileName().toString(), f.toString(), type);
+                            Optional<ExternalFileType> type = FileHelper.getFileExtension(file)
+                                    .map(extension -> ExternalFileTypes.getInstance().getExternalFileTypeByExt(extension))
+                                    .orElse(Optional.of(new UnknownExternalFileType("")));
+                            FileListEntry flEntry = new FileListEntry("", file.toString(), type);
                             tableModel.addEntry(tableModel.getRowCount(), flEntry);
 
                             String newVal = tableModel.getStringRepresentation();

--- a/src/main/java/org/jabref/pdfimport/PdfImporter.java
+++ b/src/main/java/org/jabref/pdfimport/PdfImporter.java
@@ -176,7 +176,7 @@ public class PdfImporter {
         List<Path> dirsS = panel.getBibDatabaseContext()
                 .getFileDirectoriesAsPaths(Globals.prefs.getFileDirectoryPreferences());
 
-        tm.addEntry(0, new FileListEntry(toLink.getFileName().toString(), FileUtil.shortenFileName(toLink, dirsS).toString(),
+        tm.addEntry(0, new FileListEntry("", FileUtil.shortenFileName(toLink, dirsS).toString(),
                 ExternalFileTypes.getInstance().getExternalFileTypeByName("PDF")));
         entry.setField(FieldName.FILE, tm.getStringRepresentation());
         res.add(entry);


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
The autolink feature added the file name also as a description to the newly added linked file. This resulted in a strange display of the linked file in the entry editor as the file name is shown twice (once as description and once as the name of the file).

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
