### PR TITLE
Use only last name for auto completion in search bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Renaming files now truncates the filename to not exceed the limit of 255 chars [#2622](https://github.com/JabRef/jabref/issues/2622)
 - We improved the handling of hyphens in names. [#2775](https://github.com/JabRef/jabref/issues/2775)
 - We fixed an issue where an entered file description was not written to the bib-file [#3208](https://github.com/JabRef/jabref/issues/3208)
+- We improved the auto completion in the search bar. [koppor#253](https://github.com/koppor/jabref/issues/253)
+
 ### Removed
 - We removed support for LatexEditor, as it is not under active development. [#3199](https://github.com/JabRef/jabref/issues/3199)
 

--- a/src/main/java/org/jabref/gui/autocompleter/PersonNameStringConverter.java
+++ b/src/main/java/org/jabref/gui/autocompleter/PersonNameStringConverter.java
@@ -59,7 +59,7 @@ public class PersonNameStringConverter extends StringConverter<Author> {
                     break;
             }
         }
-        return author.getLastFirst(false);
+        return author.getLastOnly();
     }
 
     @Override

--- a/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
@@ -364,7 +364,7 @@ public class GlobalSearchBar extends JPanel {
     public void setAutoCompleter(AutoCompleteSuggestionProvider<Author> searchCompleter) {
         AutoCompletionTextInputBinding.autoComplete(searchField,
                 searchCompleter,
-                new PersonNameStringConverter(true, true, AutoCompleteFirstNameMode.BOTH),
+                new PersonNameStringConverter(false, false, AutoCompleteFirstNameMode.BOTH),
                 new AppendPersonNamesStrategy());
 
     }


### PR DESCRIPTION
Now only the last name of the author is added (and shown as a suggestion) to the search bar. Previously it was in the format "Last, F.". Thus authors specified as "Last, First" were not found correctly because of the "dot".

Fixes https://github.com/koppor/jabref/issues/253.

<!-- describe the changes you have made here: what, why, ... -->

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
