### PR TITLE
Update link to renamed file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where an entered file description was not written to the bib-file [#3208](https://github.com/JabRef/jabref/issues/3208)
 ### Removed
 - We removed support for LatexEditor, as it is not under active development. [#3199](https://github.com/JabRef/jabref/issues/3199)
-
+- We fixed renaming files which are not in the main directory. [#3230](https://github.com/JabRef/jabref/issues/3230)
 
 
 

--- a/src/main/java/org/jabref/logic/cleanup/RenamePdfCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/RenamePdfCleanup.java
@@ -138,7 +138,15 @@ public class RenamePdfCleanup implements CleanupJob {
                 // We use the file directory (if none is set - then bib file) to create relative file links.
                 // The .get() is legal without check because the method will always return a value.
                 Path settingsDir = databaseContext.getFirstExistingFileDir(fileDirectoryPreferences).get();
-                newFileList.add(new LinkedFile(description, settingsDir.relativize(newPath).toString(), type));
+                try {
+                    newFileList.add(new LinkedFile(description, settingsDir.relativize(newPath).toString(), type));
+                } catch (IllegalArgumentException e) {
+                    if (e.getMessage().equals("'other' has different root")) {
+                        newFileList.add(new LinkedFile(description, newPath.toString(), type));
+                    } else {
+                        LOGGER.error("Cannot add a link to renamed linked file", e);
+                    }
+                }
             } else {
                 unsuccessfulRenames++;
             }

--- a/src/main/java/org/jabref/logic/cleanup/RenamePdfCleanup.java
+++ b/src/main/java/org/jabref/logic/cleanup/RenamePdfCleanup.java
@@ -138,14 +138,10 @@ public class RenamePdfCleanup implements CleanupJob {
                 // We use the file directory (if none is set - then bib file) to create relative file links.
                 // The .get() is legal without check because the method will always return a value.
                 Path settingsDir = databaseContext.getFirstExistingFileDir(fileDirectoryPreferences).get();
-                try {
+                if (settingsDir.getRoot().equals(newPath.getRoot())) {
                     newFileList.add(new LinkedFile(description, settingsDir.relativize(newPath).toString(), type));
-                } catch (IllegalArgumentException e) {
-                    if (e.getMessage().equals("'other' has different root")) {
-                        newFileList.add(new LinkedFile(description, newPath.toString(), type));
-                    } else {
-                        LOGGER.error("Cannot add a link to renamed linked file", e);
-                    }
+                } else {
+                    newFileList.add(new LinkedFile(description, newPath.toString(), type));
                 }
             } else {
                 unsuccessfulRenames++;


### PR DESCRIPTION
This patch fixes the issue described in #3230. The link to the renamed file is successfully updated now.

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
