### PR TITLE
[WIP] Implement native messaging

### DIFF
--- a/buildres/jabref.json
+++ b/buildres/jabref.json
@@ -1,0 +1,7 @@
+{
+	"name": "org.jabref.jabref",
+	"description": "JabRef",
+	"path": "JabRef.exe",
+	"type": "stdio",
+	"allowed_extensions": ["jabfox@jabref.org"]
+}

--- a/src/main/java/org/jabref/Globals.java
+++ b/src/main/java/org/jabref/Globals.java
@@ -1,6 +1,9 @@
 package org.jabref;
 
 import java.awt.Toolkit;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -21,6 +24,8 @@ import com.google.common.base.StandardSystemProperty;
 import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.TelemetryConfiguration;
 import com.microsoft.applicationinsights.telemetry.SessionState;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 public class Globals {
 
@@ -28,7 +33,6 @@ public class Globals {
     public static final BuildInfo BUILD_INFO = new BuildInfo();
     // Remote listener
     public static final RemoteListenerServerLifecycle REMOTE_LISTENER = new RemoteListenerServerLifecycle();
-
     public static final ImportFormatReader IMPORT_FORMAT_READER = new ImportFormatReader();
     public static final TaskExecutor TASK_EXECUTOR = new DefaultTaskExecutor();
     // In the main program, this field is initialized in JabRef.java
@@ -48,6 +52,7 @@ public class Globals {
      * Manager for the state of the GUI.
      */
     public static StateManager stateManager = new StateManager();
+    private static final Log LOGGER = LogFactory.getLog(Globals.class);
     // Key binding preferences
     private static KeyBindingRepository keyBindingRepository;
     // Background tasks
@@ -87,6 +92,13 @@ public class Globals {
     }
 
     private static void startTelemetryClient() {
+
+        // Ugly workaround: while reading the configuration file, Application Insights directly writes to System.err
+        // In order to suppress this output, we temporarily redirect System.err to a output stream
+        PrintStream oldErr = System.err;
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(outputStream));
+
         TelemetryConfiguration telemetryConfiguration = TelemetryConfiguration.getActive();
         telemetryConfiguration.setInstrumentationKey(Globals.BUILD_INFO.getAzureInstrumentationKey());
         telemetryConfiguration.setTrackingIsDisabled(!Globals.prefs.shouldCollectTelemetry());
@@ -101,6 +113,11 @@ public class Globals {
                 Toolkit.getDefaultToolkit().getScreenSize().toString());
 
         telemetryClient.trackSessionState(SessionState.Start);
+
+        // Second part of the workaround: reset System.err and log initialization message from Application Insights
+        System.setErr(oldErr);
+        String log = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+        LOGGER.debug(log);
     }
 
     public static GlobalFocusListener getFocusListener() {

--- a/src/main/java/org/jabref/JabRefMain.java
+++ b/src/main/java/org/jabref/JabRefMain.java
@@ -11,6 +11,8 @@ import javafx.stage.Stage;
 
 import org.jabref.cli.ArgumentProcessor;
 import org.jabref.gui.nativemessaging.NativeMessagingClient;
+import org.jabref.gui.nativemessaging.NativeMessagingService;
+import org.jabref.gui.nativemessaging.NativeMessagingServiceImpl;
 import org.jabref.gui.nativemessaging.StreamNativeMessagingClient;
 import org.jabref.gui.remote.JabRefMessageHandler;
 import org.jabref.logic.exporter.ExportFormat;
@@ -169,9 +171,8 @@ public class JabRefMain extends Application {
         }
 
         // Start native messaging
-
         nativeMessagingClient.sendAsync("{\"m\":\"hi\"}");
-
+        NativeMessagingService messagingService = new NativeMessagingServiceImpl(nativeMessagingClient);
 
         // If not, start GUI
         SwingUtilities

--- a/src/main/java/org/jabref/cli/JabRefCLI.java
+++ b/src/main/java/org/jabref/cli/JabRefCLI.java
@@ -1,6 +1,6 @@
 package org.jabref.cli;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.jabref.Globals;
@@ -20,8 +20,8 @@ public class JabRefCLI {
 
     private static final Log LOGGER = LogFactory.getLog(JabRefCLI.class);
     private final CommandLine cl;
+    private final boolean isNativeMessaging;
     private List<String> leftOver;
-
 
     public JabRefCLI(String[] args) {
 
@@ -29,7 +29,17 @@ public class JabRefCLI {
 
         try {
             this.cl = new DefaultParser().parse(options, args);
-            this.leftOver = Arrays.asList(cl.getArgs());
+
+            List<String> rest = cl.getArgList();
+            if (rest.size() == 2 && rest.get(1).equals("jabfox@jabref.org")) {
+                // Firefox passes the path to the manifest as first argument and the native messaging identifier as second argument
+                // So do not handle these arguments
+                this.leftOver = new ArrayList<>();
+                this.isNativeMessaging = true;
+            } else {
+                this.leftOver = rest;
+                this.isNativeMessaging = false;
+            }
         } catch (ParseException e) {
             LOGGER.warn("Problem parsing arguments", e);
 
@@ -261,5 +271,9 @@ public class JabRefCLI {
 
     public List<String> getLeftOver() {
         return leftOver;
+    }
+
+    public boolean isNativeMessaging() {
+        return isNativeMessaging;
     }
 }

--- a/src/main/java/org/jabref/gui/nativemessaging/NativeMessagingClient.java
+++ b/src/main/java/org/jabref/gui/nativemessaging/NativeMessagingClient.java
@@ -1,0 +1,10 @@
+package org.jabref.gui.nativemessaging;
+
+import java.util.concurrent.Future;
+
+import org.json.JSONObject;
+
+public interface NativeMessagingClient {
+
+    Future<JSONObject> sendAsync(String message);
+}

--- a/src/main/java/org/jabref/gui/nativemessaging/NativeMessagingClient.java
+++ b/src/main/java/org/jabref/gui/nativemessaging/NativeMessagingClient.java
@@ -1,10 +1,30 @@
 package org.jabref.gui.nativemessaging;
 
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.function.Consumer;
 
 import org.json.JSONObject;
 
 public interface NativeMessagingClient {
 
-    Future<JSONObject> sendAsync(String message);
+    /**
+     * Sends a message asynchronously, i.e. sends the message immediately but returns a future waiting for a response.
+     * @param message the message to send
+     * @return a future object that will contain the response
+     */
+    CompletableFuture<JSONObject> sendAsync(String message);
+
+    /**
+     * Adds a listener for push notifications
+     * @param listener the listener for the push message (encoded as a JSON object)
+     */
+    void addPushListener(Consumer<JSONObject> listener);
+
+    /**
+     * Sends a message immediately without expecting a response
+     * @param message the message to send
+     */
+    void send(String message) throws IOException;
 }

--- a/src/main/java/org/jabref/gui/nativemessaging/NativeMessagingResponse.java
+++ b/src/main/java/org/jabref/gui/nativemessaging/NativeMessagingResponse.java
@@ -1,0 +1,56 @@
+package org.jabref.gui.nativemessaging;
+
+import java.util.Optional;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class NativeMessagingResponse {
+
+    private final Optional<JSONObject> jsonResponse;
+    private final Optional<String> errorMessage;
+    private final Optional<Exception> errorCause;
+    private final boolean successful;
+
+    private NativeMessagingResponse(JSONObject jsonResponse) {
+        this.jsonResponse = Optional.of(jsonResponse);
+        this.errorMessage = Optional.empty();
+        this.errorCause = Optional.empty();
+        this.successful = true;
+    }
+
+    private NativeMessagingResponse(String message, Exception cause) {
+        this.errorMessage = Optional.of(message);
+        this.errorCause = Optional.ofNullable(cause);
+        this.jsonResponse = Optional.empty();
+        this.successful = false;
+    }
+
+    public static NativeMessagingResponse fromContent(String content) {
+        try {
+            return new NativeMessagingResponse(new JSONObject(content));
+        } catch (JSONException exception) {
+            return fromException("Failed to parse response.", exception);
+        }
+    }
+
+    public static NativeMessagingResponse fromException(String message, Exception cause) {
+        return new NativeMessagingResponse(message, cause);
+    }
+
+    public boolean isSuccessful() {
+        return successful;
+    }
+
+    public Optional<JSONObject> getJsonResponse() {
+        return jsonResponse;
+    }
+
+    public Optional<Exception> getErrorCause() {
+        return errorCause;
+    }
+
+    public Optional<String> getErrorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/org/jabref/gui/nativemessaging/NativeMessagingService.java
+++ b/src/main/java/org/jabref/gui/nativemessaging/NativeMessagingService.java
@@ -1,0 +1,7 @@
+package org.jabref.gui.nativemessaging;
+
+import java.util.concurrent.Future;
+
+public interface NativeMessagingService {
+     Future<Boolean> isOnline();
+}

--- a/src/main/java/org/jabref/gui/nativemessaging/NativeMessagingServiceImpl.java
+++ b/src/main/java/org/jabref/gui/nativemessaging/NativeMessagingServiceImpl.java
@@ -1,0 +1,56 @@
+package org.jabref.gui.nativemessaging;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.Future;
+
+import org.jabref.Globals;
+import org.jabref.JabRefGUI;
+import org.jabref.logic.importer.ImportException;
+import org.jabref.logic.importer.ParserResult;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.json.JSONObject;
+
+public class NativeMessagingServiceImpl implements NativeMessagingService {
+
+    private static final Log LOGGER = LogFactory.getLog(NativeMessagingServiceImpl.class);
+
+    private NativeMessagingClient client;
+
+    public NativeMessagingServiceImpl(NativeMessagingClient client) {
+        this.client = Objects.requireNonNull(client);
+        this.client.addPushListener(this::handlePushMessage);
+    }
+
+    @Override
+    public Future<Boolean> isOnline() {
+        return client
+                .sendAsync(new JSONObject().put("type", "ping").toString())
+                .thenApply(response -> response.optString("type").equals("pong"));
+    }
+
+    private void handlePushMessage(JSONObject message) {
+        String type = message.optString("type");
+        try {
+        switch (type) {
+            case "ping":
+                client.send(new JSONObject().put("type", "pong").toString());
+            case "import":
+                handleImportMessage(message.optString("format"), message.optString("data"));
+        }
+        } catch (IOException e) {
+            LOGGER.error("Error while handling push message of type " + type, e);
+        }
+    }
+
+    private void handleImportMessage(String importFormat, String data) {
+        try {
+            ParserResult result = Globals.IMPORT_FORMAT_READER.importFromFile(importFormat, data);
+            JabRefGUI.getMainFrame().addParserResult(result, true);
+        } catch (ImportException e) {
+            LOGGER.error("Error while importing with " + importFormat, e);
+        }
+    }
+}

--- a/src/main/java/org/jabref/gui/nativemessaging/StreamNativeMessagingClient.java
+++ b/src/main/java/org/jabref/gui/nativemessaging/StreamNativeMessagingClient.java
@@ -29,9 +29,9 @@ public class StreamNativeMessagingClient implements NativeMessagingClient {
     private final ExecutorService requestExecutor = Executors.newSingleThreadExecutor();
 
     /**
-     * A list of all requests performed in this session.
+     * A list of all (active) requests.
      */
-    private final List<Future<NativeMessagingResponse>> requests = new ArrayList<>();
+    private final List<Future<NativeMessagingResponse>> activeRequests = new ArrayList<>();
 
     private final InputStream in;
     private final PrintStream out;
@@ -75,7 +75,8 @@ public class StreamNativeMessagingClient implements NativeMessagingClient {
     }
 
     private boolean allRequestsAreDone() {
-        return requests.stream().anyMatch(request -> !request.isDone());
+        activeRequests.removeIf(Future::isDone);
+        return activeRequests.isEmpty();
     }
 
     private NativeMessagingResponse send(String message) throws IOException {

--- a/src/main/java/org/jabref/gui/nativemessaging/StreamNativeMessagingClient.java
+++ b/src/main/java/org/jabref/gui/nativemessaging/StreamNativeMessagingClient.java
@@ -1,0 +1,126 @@
+package org.jabref.gui.nativemessaging;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.jabref.JabRefExecutorService;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.json.JSONObject;
+
+public class StreamNativeMessagingClient implements NativeMessagingClient {
+
+    private static final Log LOGGER = LogFactory.getLog(StreamNativeMessagingClient.class);
+
+    /**
+     * Executor which is used to send messages. We use a single thread executor which runs sequentially in order to
+     * circumvent concurrence problems (i.e. only one request is waiting for a response at a given time)
+     */
+    private final ExecutorService requestExecutor = Executors.newSingleThreadExecutor();
+
+    /**
+     * A list of all requests performed in this session.
+     */
+    private final List<Future<NativeMessagingResponse>> requests = new ArrayList<>();
+
+    private final InputStream in;
+    private final PrintStream out;
+
+    public StreamNativeMessagingClient(InputStream in, PrintStream out) {
+        this.in = Objects.requireNonNull(in);
+        this.out = Objects.requireNonNull(out);
+
+        startPushListener();
+    }
+
+    private static int getLength(byte[] lengthBytes) {
+        return (lengthBytes[3] << 24) & 0xff000000 |
+                (lengthBytes[2] << 16) & 0x00ff0000 |
+                (lengthBytes[1] << 8) & 0x0000ff00 |
+                (lengthBytes[0]) & 0x000000ff;
+    }
+
+    private static byte[] getLengthBytes(String message) {
+        int length = message.length();
+        byte[] lengthBytes = new byte[4];
+        lengthBytes[0] = (byte) (length & 0xFF);
+        lengthBytes[1] = (byte) ((length >> 8) & 0xFF);
+        lengthBytes[2] = (byte) ((length >> 16) & 0xFF);
+        lengthBytes[3] = (byte) ((length >> 24) & 0xFF);
+        return lengthBytes;
+    }
+
+    /**
+     * Starts to listen for additional messages on the input stream, that are not coming
+     */
+    private void startPushListener() {
+        JabRefExecutorService.INSTANCE.executeInterruptableTask(() -> {
+            //noinspection InfiniteLoopStatement
+            while (true) {
+                if (allRequestsAreDone()) {
+                    NativeMessagingResponse response = waitForResponse();
+                }
+            }
+        }, "NativeMessaging");
+    }
+
+    private boolean allRequestsAreDone() {
+        return requests.stream().anyMatch(request -> !request.isDone());
+    }
+
+    private NativeMessagingResponse send(String message) throws IOException {
+        // First write the message length (with appended zeros)
+        byte[] lengthBytes = getLengthBytes(message);
+        out.write(lengthBytes);
+
+        // Write message
+        out.write(message.getBytes(StandardCharsets.UTF_8));
+
+        out.flush();
+
+        return waitForResponse();
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private NativeMessagingResponse waitForResponse() {
+        try {
+            // The first 4 bytes give the message length
+            byte[] lengthBytes = new byte[4];
+            in.read(lengthBytes);
+            int length = getLength(lengthBytes);
+
+            // Read content of message
+            byte[] contentBytes = new byte[length];
+            in.read(contentBytes);
+            String content = new String(contentBytes, "UTF-8");
+
+            return NativeMessagingResponse.fromContent(content);
+        } catch (UnsupportedEncodingException e) {
+            return NativeMessagingResponse.fromException("Failed to decode response", e);
+        } catch (IOException e) {
+            return NativeMessagingResponse.fromException("Failed to write to native messaging channel", e);
+        }
+    }
+
+    @Override
+    public Future<JSONObject> sendAsync(String message) {
+        return requestExecutor.submit(() -> {
+            NativeMessagingResponse response = send(message);
+            if (response.isSuccessful()) {
+                return response.getJsonResponse().orElse(null);
+            } else {
+                throw new IOException(response.getErrorMessage().orElse(""), response.getErrorCause().orElse(null));
+            }
+        });
+    }
+}

--- a/src/main/java/org/jabref/logic/importer/ImportFormatReader.java
+++ b/src/main/java/org/jabref/logic/importer/ImportFormatReader.java
@@ -1,6 +1,8 @@
 package org.jabref.logic.importer;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.StringReader;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
@@ -91,6 +93,20 @@ public class ImportFormatReader {
             }
         }
         return Optional.empty();
+    }
+
+    public ParserResult importFromFile(String format, String data) throws ImportException {
+        Optional<Importer> importer = getByCliId(format);
+
+        if (!importer.isPresent()) {
+            throw new ImportException(Localization.lang("Unknown import format") + ": " + format);
+        }
+
+        try {
+            return importer.get().importDatabase(new BufferedReader(new StringReader(data)));
+        } catch (IOException e) {
+            throw new ImportException(e);
+        }
     }
 
     public ParserResult importFromFile(String format, Path file) throws ImportException {

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -18,7 +18,6 @@
             <AppenderRef ref="CONSOLE"/>
         </Logger>
         <Root level="INFO">
-            <AppenderRef ref="CONSOLE"/>
             <AppenderRef ref="applicationInsightsAppender" level="ERROR"/>
         </Root>
     </Loggers>

--- a/src/test/java/org/jabref/cli/JabRefCLITest.java
+++ b/src/test/java/org/jabref/cli/JabRefCLITest.java
@@ -36,4 +36,11 @@ public class JabRefCLITest {
         Assert.assertTrue(cli.isDisableGui());
     }
 
+    @Test
+    public void recognizesNativeMessaging() {
+        JabRefCLI cli = new JabRefCLI(new String[]{"C:\\Program Files\\JabRef\\jabref.json", "jabfox@jabref.org"});
+
+        Assert.assertEquals(Collections.emptyList(), cli.getLeftOver());
+        Assert.assertTrue(cli.isNativeMessaging());
+    }
 }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

This PR is a first shot at implementing `Native Messaging` so that JabRef is able to talk to Firefox and Chrome (or other browser) extensions https://github.com/JabRef/jabref/issues/1284. 

Currently, this is just a working proof of concept. Many things are not yet (correctly) implemented. As I will not be able to work on in in the next months, others are kindly asked to continue working on it (especially these developers that want a browser add-on for chrome 😉).
Things still left to do are:

- [ ] Move the new `JabRef.json` to the install dir during installation
- [ ] [Register](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging#App_manifest_location) `JabRef.json` during installation
- [ ] Find a way to automate these steps for Linux
- [ ] [Breakaway from Firefox process group](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging#Closing_the_native_app) (otherwise closing Firefox automatically closes JabRef if native messaging was used to open JabRef)
- [ ] Redirect communication over socket if JabRef was already started in a single-instance mode before Firefox requested a start
- [ ] Code cleanup (especially proper error handling)
- [ ] Document native messaging interface
- [ ] Implement things that are [special to Chrome](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging#Chrome_incompatibilities)

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
