### PR TITLE
Open statistics dialog from correct thread

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -664,7 +664,9 @@ public class JabRefFrame extends JFrame implements OutputPrinter {
 
                 @Override
                 public void run() {
-                    DefaultTaskExecutor.runInJavaFXThread(JabRefFrame.this::showTrackingNotification);
+                    SwingUtilities.invokeLater(() -> {
+                        DefaultTaskExecutor.runInJavaFXThread(JabRefFrame.this::showTrackingNotification);
+                    });
                 }
             }, 60000); // run in one minute
         }


### PR DESCRIPTION
The dialog to ask for collecting anonymous statistics needs to be created in
the Swing EDT. Do so using SwingUtilities.invokeLater().

This is a follow-up on 7ef2b3a and should finally fix #2955.

<!-- describe the changes you have made here: what, why, ... -->

No addition to CHANGELOG.md as 7ef2b3a already included a corresponding entry.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
