### PR TITLE
Set WM_CLASS to org-jabref-JabRefMain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Updated French translation
 - We added support for pasting entries in different formats [#3143](https://github.com/JabRef/jabref/issues/3143)
 - Crossreferenced entries are now used when a BibTex key is generated for an entry with empty fields. [#2811](https://github.com/JabRef/jabref/issues/2811)
+- We now set the WM_CLASS of the UI to org-jabref-JabRefMain to allow certain Un*x window managers to properly identify its windows
 
 ### Fixed
  - We fixed an issue where JabRef would not terminated after asking to collect anonymous statistics [#2955 comment](https://github.com/JabRef/jabref/issues/2955#issuecomment-334591123)

--- a/src/main/java/org/jabref/gui/GUIGlobals.java
+++ b/src/main/java/org/jabref/gui/GUIGlobals.java
@@ -2,6 +2,7 @@ package org.jabref.gui;
 
 import java.awt.Color;
 import java.awt.Font;
+import java.awt.Toolkit;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -13,6 +14,7 @@ import org.jabref.gui.externalfiletype.ExternalFileTypes;
 import org.jabref.gui.keyboard.EmacsKeyBindings;
 import org.jabref.gui.specialfields.SpecialFieldViewModel;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.logic.util.OS;
 import org.jabref.model.entry.FieldName;
 import org.jabref.model.entry.specialfields.SpecialField;
 import org.jabref.preferences.JabRefPreferences;
@@ -155,6 +157,18 @@ public class GUIGlobals {
 
         GUIGlobals.currentFont = new Font(Globals.prefs.get(JabRefPreferences.FONT_FAMILY),
                 Globals.prefs.getInt(JabRefPreferences.FONT_STYLE), Globals.prefs.getInt(JabRefPreferences.FONT_SIZE));
+
+        // Set WM_CLASS using reflection for certain Un*x window managers
+        if (!OS.WINDOWS && !OS.OS_X) {
+            try {
+                Toolkit xToolkit = Toolkit.getDefaultToolkit();
+                java.lang.reflect.Field awtAppClassNameField = xToolkit.getClass().getDeclaredField("awtAppClassName");
+                awtAppClassNameField.setAccessible(true);
+                awtAppClassNameField.set(xToolkit, "org-jabref-JabRefMain");
+            } catch (Exception e) {
+                // ignore any error since this code only works for certain toolkits
+            }
+        }
 
     }
 


### PR DESCRIPTION
WM_CLASS is used by certain Un*x window managers, such as GNOME, to map windows
to the corresponding application. Currently WM_CLASS is set to java-lang-Thread
which is very generic and not unique to JabRef. Instead, use reflection to set
it to org-jabref-JabRefMain which resembles the main class name.

The implementation in this PR is based on this blog post:
http://elliotth.blogspot.de/2007/02/fixing-wmclass-for-your-java.html
By now you find similar solutions in several Java applications. I'm not aware of a more convenient way to manually set WM_CLASS.

I tested the change on a Linux system running GNOME 3 and also on macOS to rule out any cross-platform issues. Also I chose the WM_CLASS name that matches the StartupWMClass in [buildres/snapcraft/jabref.desktop](../blob/master/buildres/snapcraft/jabref.desktop), so no changes are necessary in there.

<!-- describe the changes you have made here: what, why, ... -->

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
