### PR TITLE
Fix #3235: remote metadata is updated instead of delete + insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Fixed
  - We fixed an issue where JabRef would not terminated after asking to collect anonymous statistics [#2955 comment](https://github.com/JabRef/jabref/issues/2955#issuecomment-334591123)
  - We fixed an issue where JabRef would not shut down when started with the '-n' (No GUI) option.
+ - We improved the way metadata is updated in remote databases. [#3235](https://github.com/JabRef/jabref/issues/3235)
 
 ### Removed
 

--- a/src/main/java/org/jabref/shared/DBMSProcessor.java
+++ b/src/main/java/org/jabref/shared/DBMSProcessor.java
@@ -557,7 +557,7 @@ public abstract class DBMSProcessor {
                         insertStatement.setString(2, metaEntry.getValue());
                         insertStatement.executeUpdate();
                     } catch (SQLException e) {
-                            LOGGER.error("SQL Error: ", e);
+                        LOGGER.error("SQL Error: ", e);
                     }                    
                 }
             } catch (SQLException e) {

--- a/src/main/java/org/jabref/shared/DBMSProcessor.java
+++ b/src/main/java/org/jabref/shared/DBMSProcessor.java
@@ -561,7 +561,7 @@ public abstract class DBMSProcessor {
                     }                    
                 }
             } catch (SQLException e) {
-                    LOGGER.error("SQL Error: ", e);
+                LOGGER.error("SQL Error: ", e);
             }
         }
     }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

Fix for https://github.com/JabRef/jabref/issues/3235. Instead of completely deleting and refiling the metadata table, now an `update` is preformed. I've never touched the SQL code before and didn't tested it, so I appreciate feedback from someone with more experience on this part of the code.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
