### PR TITLE
Fix exception/freezing on EntryChangedEvent in Entry Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,9 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 ### Fixed
  - We fixed an issue where JabRef would not terminated after asking to collect anonymous statistics [#2955 comment](https://github.com/JabRef/jabref/issues/2955#issuecomment-334591123)
- - We fixed an issue where JabRef would not shut down when started with the '-n' (No GUI) option.
+ - We fixed an issue where JabRef would not shut down when started with the '-n' (No GUI) option. [#3247](https://github.com/JabRef/jabref/issues/3247)
  - We improved the way metadata is updated in remote databases. [#3235](https://github.com/JabRef/jabref/issues/3235)
-
+ - We fixed an issue where JabRef would freeze when trying to replace the original entry after a merge with new information from identifiers like DOI/ISBN etc. [3294](https://github.com/JabRef/jabref/issues/3294)
 ### Removed
 
 

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -234,7 +234,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
     @Subscribe
     public synchronized void listen(EntryChangedEvent event) {
-        sourceTab.updateSourcePane();
+        DefaultTaskExecutor.runInJavaFXThread(() -> sourceTab.updateSourcePane());
     }
 
     private void rebuildOtherFieldsTab() {


### PR DESCRIPTION

Fixes #3294  Digging down in the log file I found that the problem is that the sourceTab.update is not executed in the FXThread. This could also be 

<!-- describe the changes you have made here: what, why, ... -->

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
