### PR TITLE
Add \textendash to the html conversion table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 
 
 ### Fixed
+ - We fixed the translation of \textendash in the entry preview [#3307](https://github.com/JabRef/jabref/issues/3307)
  - We fixed an issue where JabRef would not terminated after asking to collect anonymous statistics [#2955 comment](https://github.com/JabRef/jabref/issues/2955#issuecomment-334591123)
  - We fixed an issue where JabRef would not shut down when started with the '-n' (No GUI) option. [#3247](https://github.com/JabRef/jabref/issues/3247)
  - We improved the way metadata is updated in remote databases. [#3235](https://github.com/JabRef/jabref/issues/3235)

--- a/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
+++ b/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
@@ -295,6 +295,7 @@ public class HTMLUnicodeConversionMaps {
 
             /* General Punctuation */
             {"8211", "ndash", "$\\textendash$"},
+            {"8212", "mdash", "$\\textemdash$"},
             {"8226", "bull", "$\\bullet$"}, // bullet = black small circle,
             //                                    U+2022 ISOpub
             /* bullet is NOT the same as bullet operator, U+2219 */

--- a/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
+++ b/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
@@ -294,6 +294,7 @@ public class HTMLUnicodeConversionMaps {
             {"982", "piv", "$\\varphi$"}, // greek pi symbol, U+03D6 ISOgrk3
 
             /* General Punctuation */
+            {"8211", "ndash", "$\\textendash$"},
             {"8226", "bull", "$\\bullet$"}, // bullet = black small circle,
             //                                    U+2022 ISOpub
             /* bullet is NOT the same as bullet operator, U+2219 */


### PR DESCRIPTION
Fixes #3307 by adding \textendash to the html conversion table

- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
