### PR TITLE
Update applicationinsights from  1.0.9 -> 1.0.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,8 +126,8 @@ dependencies {
 
     compile 'com.github.tomtung:latex2unicode_2.12:0.2.2'
 
-    compile group: 'com.microsoft.azure', name: 'applicationinsights-core', version: '1.0.9'
-    compile group: 'com.microsoft.azure', name: 'applicationinsights-logging-log4j2', version: '1.0.9'
+    compile group: 'com.microsoft.azure', name: 'applicationinsights-core', version: '1.0.10'
+    compile group: 'com.microsoft.azure', name: 'applicationinsights-logging-log4j2', version: '1.0.10'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.10.0'


### PR DESCRIPTION
Applicationinsights is outdated.
Is there any reason, for not updating it? 

If so it should be stated in the gradle build file.

refs https://github.com/JabRef/jabref/commit/8840da5767bd05e6bd538ff344807c65b3eeace6