### PR TITLE
Increase relative size of abstract field in editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - Updated French translation
 - We improved the handling of abstracts in the "Astrophysics Data System" fetcher. [#2471](https://github.com/JabRef/jabref/issues/2471)
 - We added support for pasting entries in different formats [#3143](https://github.com/JabRef/jabref/issues/3143)
+- We increased the relative size of the "abstract" field in the entry editor. [Feature request in the forum](http://discourse.jabref.org/t/entry-preview-in-version-4/827)
 - Crossreferenced entries are now used when a BibTex key is generated for an entry with empty fields. [#2811](https://github.com/JabRef/jabref/issues/2811)
 - We now set the WM_CLASS of the UI to org-jabref-JabRefMain to allow certain Un*x window managers to properly identify its windows
 - We changed the default paths for the OpenOffice/LibreOffice binaries to the default path for LibreOffice

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -1,39 +1,6 @@
 package org.jabref.gui.entryeditor;
 
-import java.awt.BorderLayout;
-import java.awt.Component;
-import java.awt.Font;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.Insets;
-import java.awt.RenderingHints;
-import java.awt.event.ActionEvent;
-import java.awt.event.KeyAdapter;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.ActionMap;
-import javax.swing.InputMap;
-import javax.swing.JButton;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JMenuItem;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import javax.swing.JToolBar;
-import javax.swing.SwingConstants;
-import javax.swing.SwingUtilities;
-import javax.swing.undo.UndoableEdit;
-
+import com.google.common.eventbus.Subscribe;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.embed.swing.JFXPanel;
@@ -41,14 +8,11 @@ import javafx.scene.Scene;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.input.KeyEvent;
-
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.fxmisc.easybind.EasyBind;
 import org.jabref.Globals;
-import org.jabref.gui.BasePanel;
-import org.jabref.gui.EntryContainer;
-import org.jabref.gui.GUIGlobals;
-import org.jabref.gui.IconTheme;
-import org.jabref.gui.JabRefFrame;
-import org.jabref.gui.OSXCompatibleToolbar;
+import org.jabref.gui.*;
 import org.jabref.gui.actions.Actions;
 import org.jabref.gui.customjfx.CustomJFXPanel;
 import org.jabref.gui.entryeditor.fileannotationtab.FileAnnotationTab;
@@ -86,10 +50,16 @@ import org.jabref.model.entry.event.EntryChangedEvent;
 import org.jabref.model.entry.event.FieldAddedOrRemovedEvent;
 import org.jabref.preferences.JabRefPreferences;
 
-import com.google.common.eventbus.Subscribe;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.fxmisc.easybind.EasyBind;
+import javax.swing.*;
+import javax.swing.undo.UndoableEdit;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyAdapter;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.*;
+import java.util.List;
+import java.util.stream.Collectors;
 
 
 /**
@@ -764,7 +734,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
                         //TODO: See if we need to update an AutoCompleter instance:
                         /*
-                        AutoCompleter<String> aComp = panel.getSuggestionProviders().get(fieldEditor.getFieldName());
+                        AutoCompleter<String> aComp = panel.getSuggestionProviders().get(fieldEditor.getName());
                         if (aComp != null) {
                             aComp.addBibtexEntry(entry);
                         }

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -1,6 +1,39 @@
 package org.jabref.gui.entryeditor;
 
-import com.google.common.eventbus.Subscribe;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.RenderingHints;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyAdapter;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.ActionMap;
+import javax.swing.InputMap;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JMenuItem;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JToolBar;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.undo.UndoableEdit;
+
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.embed.swing.JFXPanel;
@@ -8,11 +41,14 @@ import javafx.scene.Scene;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.input.KeyEvent;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.fxmisc.easybind.EasyBind;
+
 import org.jabref.Globals;
-import org.jabref.gui.*;
+import org.jabref.gui.BasePanel;
+import org.jabref.gui.EntryContainer;
+import org.jabref.gui.GUIGlobals;
+import org.jabref.gui.IconTheme;
+import org.jabref.gui.JabRefFrame;
+import org.jabref.gui.OSXCompatibleToolbar;
 import org.jabref.gui.actions.Actions;
 import org.jabref.gui.customjfx.CustomJFXPanel;
 import org.jabref.gui.entryeditor.fileannotationtab.FileAnnotationTab;
@@ -50,16 +86,10 @@ import org.jabref.model.entry.event.EntryChangedEvent;
 import org.jabref.model.entry.event.FieldAddedOrRemovedEvent;
 import org.jabref.preferences.JabRefPreferences;
 
-import javax.swing.*;
-import javax.swing.undo.UndoableEdit;
-import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.KeyAdapter;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.util.*;
-import java.util.List;
-import java.util.stream.Collectors;
+import com.google.common.eventbus.Subscribe;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.fxmisc.easybind.EasyBind;
 
 
 /**

--- a/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
@@ -1,25 +1,11 @@
 package org.jabref.gui.entryeditor;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Stream;
-
 import javafx.geometry.VPos;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
-import javafx.scene.layout.ColumnConstraints;
-import javafx.scene.layout.GridPane;
-import javafx.scene.layout.Priority;
-import javafx.scene.layout.Region;
-import javafx.scene.layout.RowConstraints;
-
+import javafx.scene.layout.*;
 import org.jabref.Globals;
 import org.jabref.gui.BasePanel;
 import org.jabref.gui.FXDialogService;
@@ -33,6 +19,9 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.FieldName;
 import org.jabref.model.entry.FieldProperty;
 import org.jabref.model.entry.InternalBibtexFields;
+
+import java.util.*;
+import java.util.stream.Stream;
 
 /**
  * A single tab displayed in the EntryEditor holding several FieldEditors.
@@ -94,11 +83,11 @@ class FieldsEditorTab extends EntryEditorTab {
             FieldEditor fieldEditor;
             int defaultHeight;
             int wHeight = (int) (50.0 * InternalBibtexFields.getFieldWeight(field));
-            if (InternalBibtexFields.getFieldProperties(field).contains(FieldProperty.SINGLE_ENTRY_LINK)) {
+            if (InternalBibtexFields.getProperties(field).contains(FieldProperty.SINGLE_ENTRY_LINK)) {
                 fieldEditor = new EntryLinkListEditor(frame, bPanel.getBibDatabaseContext(), field, null, parent,
                         true);
                 defaultHeight = 0;
-            } else if (InternalBibtexFields.getFieldProperties(field).contains(FieldProperty.MULTIPLE_ENTRY_LINK)) {
+            } else if (InternalBibtexFields.getProperties(field).contains(FieldProperty.MULTIPLE_ENTRY_LINK)) {
                 fieldEditor = new EntryLinkListEditor(frame, bPanel.getBibDatabaseContext(), field, null, parent,
                         false);
                 defaultHeight = 0;
@@ -166,7 +155,7 @@ class FieldsEditorTab extends EntryEditorTab {
 
             setRegularRowLayout(gridPane, rows);
         }
-        
+
         if (GUIGlobals.currentFont != null) {
             gridPane.setStyle(
                     "text-area-background: " + convertToHex(GUIGlobals.validFieldBackgroundColor) + ";"

--- a/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
@@ -1,11 +1,25 @@
 package org.jabref.gui.entryeditor;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
 import javafx.geometry.VPos;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
-import javafx.scene.layout.*;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.RowConstraints;
+
 import org.jabref.Globals;
 import org.jabref.gui.BasePanel;
 import org.jabref.gui.FXDialogService;
@@ -19,9 +33,6 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.FieldName;
 import org.jabref.model.entry.FieldProperty;
 import org.jabref.model.entry.InternalBibtexFields;
-
-import java.util.*;
-import java.util.stream.Stream;
 
 /**
  * A single tab displayed in the EntryEditor holding several FieldEditors.

--- a/src/main/java/org/jabref/gui/fieldeditors/FieldEditors.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/FieldEditors.java
@@ -72,6 +72,8 @@ public class FieldEditors {
             return new PersonsEditor(fieldName, suggestionProvider, preferences, fieldCheckers);
         } else if (FieldName.KEYWORDS.equals(fieldName)) {
             return new KeywordsEditor(fieldName, suggestionProvider, fieldCheckers, preferences);
+        } else if (fieldExtras.contains(FieldProperty.MULTILINE_TEXT)) {
+            return new MultilineEditor(fieldName, suggestionProvider, fieldCheckers, preferences);
         }
 
         // default

--- a/src/main/java/org/jabref/gui/fieldeditors/MultilineEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/MultilineEditor.java
@@ -1,0 +1,17 @@
+package org.jabref.gui.fieldeditors;
+
+import org.jabref.gui.autocompleter.AutoCompleteSuggestionProvider;
+import org.jabref.logic.integrity.FieldCheckers;
+import org.jabref.preferences.JabRefPreferences;
+
+public class MultilineEditor extends SimpleEditor implements FieldEditorFX {
+
+    public MultilineEditor(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers, JabRefPreferences preferences) {
+        super (fieldName, suggestionProvider, fieldCheckers, preferences);
+    }
+
+    @Override
+    public double getWeight() {
+        return 4;
+    }
+}

--- a/src/main/java/org/jabref/model/entry/BibtexSingleField.java
+++ b/src/main/java/org/jabref/model/entry/BibtexSingleField.java
@@ -7,13 +7,6 @@ import java.util.Set;
  * Class for keeping properties of a single BibTeX/biblatex field
  */
 public class BibtexSingleField {
-    // some field constants
-    public static final double DEFAULT_FIELD_WEIGHT = 1;
-    public static final double MAX_FIELD_WEIGHT = 2;
-
-    public static final double SMALL_W = 0.30;
-    public static final double MEDIUM_W = 0.5;
-    public static final double LARGE_W = 1.5;
 
     public static final int DEFAULT_FIELD_LENGTH = 100;
 
@@ -31,8 +24,7 @@ public class BibtexSingleField {
     // default is: not standard, public, displayable and writable
     private final Set<Flag> flags = EnumSet.of(Flag.DISPLAYABLE, Flag.WRITEABLE);
 
-    private int length = DEFAULT_FIELD_LENGTH;
-    private double weight = DEFAULT_FIELD_WEIGHT;
+    private final int length;
 
     // properties contains a set of FieldProperty to e.g. tell the EntryEditor to add a specific
     // function to this field, to format names, or to control the integrity checks.
@@ -43,26 +35,12 @@ public class BibtexSingleField {
     // private String otherNames = null ;
 
     public BibtexSingleField(String fieldName, boolean pStandard) {
-        name = fieldName;
-        setFlag(pStandard, Flag.STANDARD);
-    }
-
-    public BibtexSingleField(String fieldName, boolean pStandard, double pWeight) {
-        name = fieldName;
-        setFlag(pStandard, Flag.STANDARD);
-        weight = pWeight;
+        this(fieldName, pStandard, DEFAULT_FIELD_LENGTH);
     }
 
     public BibtexSingleField(String fieldName, boolean pStandard, int pLength) {
         name = fieldName;
         setFlag(pStandard, Flag.STANDARD);
-        length = pLength;
-    }
-
-    public BibtexSingleField(String fieldName, boolean pStandard, double pWeight, int pLength) {
-        name = fieldName;
-        setFlag(pStandard, Flag.STANDARD);
-        weight = pWeight;
         length = pLength;
     }
 
@@ -113,27 +91,15 @@ public class BibtexSingleField {
         return flags.contains(Flag.WRITEABLE);
     }
 
-    public void setExtras(Set<FieldProperty> pExtras) {
-        properties = pExtras;
-    }
-
-    public BibtexSingleField withExtras(Set<FieldProperty> pExtras) {
-        properties = pExtras;
+    public BibtexSingleField withProperties(FieldProperty first, FieldProperty... rest) {
+        properties = EnumSet.of(first, rest);
         return this;
     }
 
     // fieldExtras contains mappings to tell the EntryEditor to add a specific
     // function to this field, for instance a "browse" button for the "pdf" field.
-    public Set<FieldProperty> getFieldProperties() {
+    public Set<FieldProperty> getProperties() {
         return properties;
-    }
-
-    public void setWeight(double value) {
-        this.weight = value;
-    }
-
-    public double getWeight() {
-        return this.weight;
     }
 
     /**
@@ -143,7 +109,7 @@ public class BibtexSingleField {
         return this.length;
     }
 
-    public String getFieldName() {
+    public String getName() {
         return name;
     }
 

--- a/src/main/java/org/jabref/model/entry/BibtexSingleField.java
+++ b/src/main/java/org/jabref/model/entry/BibtexSingleField.java
@@ -117,6 +117,11 @@ public class BibtexSingleField {
         properties = pExtras;
     }
 
+    public BibtexSingleField withExtras(Set<FieldProperty> pExtras) {
+        properties = pExtras;
+        return this;
+    }
+
     // fieldExtras contains mappings to tell the EntryEditor to add a specific
     // function to this field, for instance a "browse" button for the "pdf" field.
     public Set<FieldProperty> getFieldProperties() {

--- a/src/main/java/org/jabref/model/entry/FieldProperty.java
+++ b/src/main/java/org/jabref/model/entry/FieldProperty.java
@@ -17,7 +17,6 @@ public enum FieldProperty {
     EDITOR_TYPE,
     PAGINATION,
     TYPE,
-    CROSSREF,
     ISO_DATE,
     ISBN,
     EPRINT,

--- a/src/main/java/org/jabref/model/entry/FieldProperty.java
+++ b/src/main/java/org/jabref/model/entry/FieldProperty.java
@@ -1,8 +1,5 @@
 package org.jabref.model.entry;
 
-import java.util.EnumSet;
-import java.util.Set;
-
 public enum FieldProperty {
     YES_NO,
     DATE,
@@ -28,8 +25,6 @@ public enum FieldProperty {
     SINGLE_ENTRY_LINK,
     MULTIPLE_ENTRY_LINK,
     PUBLICATION_STATE,
-    VERBATIM;
-
-    public static final Set<FieldProperty> ALL_OPTS = EnumSet.allOf(FieldProperty.class);
-
+    MULTILINE_TEXT,
+    VERBATIM
 }

--- a/src/main/java/org/jabref/model/entry/InternalBibtexFields.java
+++ b/src/main/java/org/jabref/model/entry/InternalBibtexFields.java
@@ -1,9 +1,19 @@
 package org.jabref.model.entry;
 
-import org.jabref.model.entry.specialfields.SpecialField;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.jabref.model.entry.specialfields.SpecialField;
 
 /**
  * Handling of bibtex fields.

--- a/src/main/java/org/jabref/model/entry/InternalBibtexFields.java
+++ b/src/main/java/org/jabref/model/entry/InternalBibtexFields.java
@@ -1,19 +1,9 @@
 package org.jabref.model.entry;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.jabref.model.entry.specialfields.SpecialField;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Handling of bibtex fields.
@@ -81,7 +71,7 @@ public class InternalBibtexFields {
             SpecialField.RELEVANCE.getFieldName());
 
     // singleton instance
-    private static InternalBibtexFields RUNTIME = new InternalBibtexFields(FieldName.TIMESTAMP);
+    private static InternalBibtexFields RUNTIME = new InternalBibtexFields();
 
     // contains all bibtex-field objects (BibtexSingleField)
     private final Map<String, BibtexSingleField> fieldSet;
@@ -90,63 +80,56 @@ public class InternalBibtexFields {
     private String timeStampField;
 
 
-    private InternalBibtexFields(String timeStampFieldName) {
+    private InternalBibtexFields() {
         fieldSet = new HashMap<>();
         BibtexSingleField dummy;
 
         // FIRST: all standard fields
         // These are the fields that BibTeX might want to treat, so these
         // must conform to BibTeX rules.
-        add(new BibtexSingleField(FieldName.ADDRESS, true, BibtexSingleField.SMALL_W));
+        add(new BibtexSingleField(FieldName.ADDRESS, true));
         // An annotation. It is not used by the standard bibliography styles,
         // but may be used by others that produce an annotated bibliography.
         // http://www.ecst.csuchico.edu/~jacobsd/bib/formats/bibtex.html
-        add(new BibtexSingleField(FieldName.ANNOTE, true, BibtexSingleField.LARGE_W));
-        add(new BibtexSingleField(FieldName.AUTHOR, true, BibtexSingleField.MEDIUM_W, 280));
+        add(new BibtexSingleField(FieldName.ANNOTE, true));
+        add(new BibtexSingleField(FieldName.AUTHOR, true, 280));
         add(new BibtexSingleField(FieldName.BOOKTITLE, true, 175));
-        add(new BibtexSingleField(FieldName.CHAPTER, true, BibtexSingleField.SMALL_W));
-        dummy = new BibtexSingleField(FieldName.CROSSREF, true, BibtexSingleField.LARGE_W);
-        dummy.setExtras(EnumSet.of(FieldProperty.CROSSREF, FieldProperty.SINGLE_ENTRY_LINK));
+        add(new BibtexSingleField(FieldName.CHAPTER, true));
+        dummy = new BibtexSingleField(FieldName.CROSSREF, true).withProperties(FieldProperty.SINGLE_ENTRY_LINK);
         add(dummy);
-        add(new BibtexSingleField(FieldName.EDITION, true, BibtexSingleField.SMALL_W));
-        add(new BibtexSingleField(FieldName.EDITOR, true, BibtexSingleField.MEDIUM_W, 280));
-        dummy = new BibtexSingleField(FieldName.EPRINT, true, BibtexSingleField.SMALL_W);
-        dummy.setExtras(EnumSet.of(FieldProperty.EPRINT));
+        add(new BibtexSingleField(FieldName.EDITION, true));
+        add(new BibtexSingleField(FieldName.EDITOR, true, 280));
+        dummy = new BibtexSingleField(FieldName.EPRINT, true).withProperties(FieldProperty.EPRINT);
         add(dummy);
-        add(new BibtexSingleField(FieldName.HOWPUBLISHED, true, BibtexSingleField.MEDIUM_W));
-        add(new BibtexSingleField(FieldName.INSTITUTION, true, BibtexSingleField.MEDIUM_W));
+        add(new BibtexSingleField(FieldName.HOWPUBLISHED, true));
+        add(new BibtexSingleField(FieldName.INSTITUTION, true));
 
-        dummy = new BibtexSingleField(FieldName.ISBN, true, BibtexSingleField.SMALL_W);
-        dummy.setExtras(EnumSet.of(FieldProperty.ISBN));
+        dummy = new BibtexSingleField(FieldName.ISBN, true).withProperties(FieldProperty.ISBN);
         add(dummy);
 
-        add(new BibtexSingleField(FieldName.ISSN, true, BibtexSingleField.SMALL_W));
+        add(new BibtexSingleField(FieldName.ISSN, true));
 
-        dummy = new BibtexSingleField(FieldName.JOURNAL, true, BibtexSingleField.SMALL_W);
-        dummy.setExtras(EnumSet.of(FieldProperty.JOURNAL_NAME));
+        dummy = new BibtexSingleField(FieldName.JOURNAL, true).withProperties(FieldProperty.JOURNAL_NAME);
         add(dummy);
-        dummy = new BibtexSingleField(FieldName.JOURNALTITLE, true, BibtexSingleField.SMALL_W);
-        dummy.setExtras(EnumSet.of(FieldProperty.JOURNAL_NAME));
+        dummy = new BibtexSingleField(FieldName.JOURNALTITLE, true).withProperties(FieldProperty.JOURNAL_NAME);
         add(dummy);
 
         add(new BibtexSingleField(FieldName.KEY, true));
-        dummy = new BibtexSingleField(FieldName.MONTH, true, BibtexSingleField.SMALL_W);
-        dummy.setExtras(EnumSet.of(FieldProperty.MONTH));
+        dummy = new BibtexSingleField(FieldName.MONTH, true).withProperties(FieldProperty.MONTH);
         add(dummy);
-        add(new BibtexSingleField(FieldName.NOTE, true, BibtexSingleField.MEDIUM_W));
-        add(new BibtexSingleField(FieldName.NUMBER, true, BibtexSingleField.SMALL_W, 60).setNumeric(true));
-        add(new BibtexSingleField(FieldName.ORGANIZATION, true, BibtexSingleField.MEDIUM_W));
-        add(new BibtexSingleField(FieldName.PAGES, true, BibtexSingleField.SMALL_W));
-        add(new BibtexSingleField(FieldName.PUBLISHER, true, BibtexSingleField.MEDIUM_W));
-        add(new BibtexSingleField(FieldName.SCHOOL, true, BibtexSingleField.MEDIUM_W));
-        add(new BibtexSingleField(FieldName.SERIES, true, BibtexSingleField.SMALL_W));
+        add(new BibtexSingleField(FieldName.NOTE, true));
+        add(new BibtexSingleField(FieldName.NUMBER, true, 60).setNumeric(true));
+        add(new BibtexSingleField(FieldName.ORGANIZATION, true));
+        add(new BibtexSingleField(FieldName.PAGES, true));
+        add(new BibtexSingleField(FieldName.PUBLISHER, true));
+        add(new BibtexSingleField(FieldName.SCHOOL, true));
+        add(new BibtexSingleField(FieldName.SERIES, true));
         add(new BibtexSingleField(FieldName.TITLE, true, 400));
-        dummy = new BibtexSingleField(FieldName.TYPE, true, BibtexSingleField.SMALL_W);
-        dummy.getFieldProperties().add(FieldProperty.TYPE);
+        dummy = new BibtexSingleField(FieldName.TYPE, true).withProperties(FieldProperty.TYPE);
         add(dummy);
-        add(new BibtexSingleField(FieldName.LANGUAGE, true, BibtexSingleField.SMALL_W));
-        add(new BibtexSingleField(FieldName.VOLUME, true, BibtexSingleField.SMALL_W, 60).setNumeric(true));
-        add(new BibtexSingleField(FieldName.YEAR, true, BibtexSingleField.SMALL_W, 60).setNumeric(true));
+        add(new BibtexSingleField(FieldName.LANGUAGE, true));
+        add(new BibtexSingleField(FieldName.VOLUME, true, 60).setNumeric(true));
+        add(new BibtexSingleField(FieldName.YEAR, true, 60).setNumeric(true));
 
         // custom fields not displayed at editor, but as columns in the UI
         for (String fieldName : SPECIAL_FIELDS) {
@@ -164,43 +147,36 @@ public class InternalBibtexFields {
         dummy.setPrivate();
         add(dummy);
 
-        dummy = new BibtexSingleField(FieldName.DOI, true, BibtexSingleField.SMALL_W);
-        dummy.setExtras(EnumSet.of(FieldProperty.DOI));
+        dummy = new BibtexSingleField(FieldName.DOI, true).withProperties(FieldProperty.DOI);
         add(dummy);
-        add(new BibtexSingleField(FieldName.EID, true, BibtexSingleField.SMALL_W));
+        add(new BibtexSingleField(FieldName.EID, true));
 
-        dummy = new BibtexSingleField(FieldName.DATE, true);
-        dummy.setExtras(EnumSet.of(FieldProperty.DATE));
+        dummy = new BibtexSingleField(FieldName.DATE, true).withProperties(FieldProperty.DATE);
         add(dummy);
 
-        add(new BibtexSingleField(FieldName.PMID, false, BibtexSingleField.SMALL_W, 60).setNumeric(true));
+        add(new BibtexSingleField(FieldName.PMID, false, 60).setNumeric(true));
 
         // additional fields ------------------------------------------------------
         add(new BibtexSingleField(FieldName.LOCATION, false));
-        add(new BibtexSingleField(FieldName.ABSTRACT, false, BibtexSingleField.LARGE_W, 400).withExtras(EnumSet.of(FieldProperty.MULTILINE_TEXT)));
+        add(new BibtexSingleField(FieldName.ABSTRACT, false, 400).withProperties(FieldProperty.MULTILINE_TEXT));
 
-        dummy = new BibtexSingleField(FieldName.URL, false, BibtexSingleField.SMALL_W);
-        dummy.setExtras(EnumSet.of(FieldProperty.EXTERNAL, FieldProperty.VERBATIM));
+        dummy = new BibtexSingleField(FieldName.URL, false).withProperties(FieldProperty.EXTERNAL, FieldProperty.VERBATIM);
         add(dummy);
 
-        add(new BibtexSingleField(FieldName.COMMENT, false, BibtexSingleField.MEDIUM_W));
-        add(new BibtexSingleField(FieldName.KEYWORDS, false, BibtexSingleField.SMALL_W));
+        add(new BibtexSingleField(FieldName.COMMENT, false));
+        add(new BibtexSingleField(FieldName.KEYWORDS, false));
 
-        dummy = new BibtexSingleField(FieldName.FILE, false);
-        dummy.setExtras(EnumSet.of(FieldProperty.FILE_EDITOR, FieldProperty.VERBATIM));
+        dummy = new BibtexSingleField(FieldName.FILE, false).withProperties(FieldProperty.FILE_EDITOR, FieldProperty.VERBATIM);
         add(dummy);
 
-        dummy = new BibtexSingleField(FieldName.RELATED, false);
-        dummy.setExtras(EnumSet.of(FieldProperty.MULTIPLE_ENTRY_LINK));
+        dummy = new BibtexSingleField(FieldName.RELATED, false).withProperties(FieldProperty.MULTIPLE_ENTRY_LINK);
         add(dummy);
 
         // some biblatex fields
-        dummy = new BibtexSingleField(FieldName.GENDER, true, BibtexSingleField.SMALL_W);
-        dummy.getFieldProperties().add(FieldProperty.GENDER);
+        dummy = new BibtexSingleField(FieldName.GENDER, true).withProperties(FieldProperty.GENDER);
         add(dummy);
 
-        dummy = new BibtexSingleField(FieldName.PUBSTATE, true, BibtexSingleField.SMALL_W);
-        dummy.getFieldProperties().add(FieldProperty.PUBLICATION_STATE);
+        dummy = new BibtexSingleField(FieldName.PUBSTATE, true).withProperties(FieldProperty.PUBLICATION_STATE);
         add(dummy);
 
         // some internal fields ----------------------------------------------
@@ -210,14 +186,12 @@ public class InternalBibtexFields {
         dummy.setDisplayable(false);
         add(dummy);
 
-        dummy = new BibtexSingleField(FieldName.OWNER, false, BibtexSingleField.SMALL_W);
-        dummy.setExtras(EnumSet.of(FieldProperty.OWNER));
+        dummy = new BibtexSingleField(FieldName.OWNER, false).withProperties(FieldProperty.OWNER);
         dummy.setPrivate();
         add(dummy);
 
-        timeStampField = timeStampFieldName;
-        dummy = new BibtexSingleField(timeStampFieldName, false, BibtexSingleField.SMALL_W);
-        dummy.setExtras(EnumSet.of(FieldProperty.DATE));
+        timeStampField = FieldName.TIMESTAMP;
+        dummy = new BibtexSingleField(FieldName.TIMESTAMP, false).withProperties(FieldProperty.DATE);
         dummy.setPrivate();
         add(dummy);
 
@@ -245,8 +219,7 @@ public class InternalBibtexFields {
 
         // IEEEtranBSTCTL fields that should be "yes" or "no"
         for (String yesNoField : IEEETRANBSTCTL_YES_NO_FIELDS) {
-            dummy = new BibtexSingleField(yesNoField, false);
-            dummy.setExtras(EnumSet.of(FieldProperty.YES_NO));
+            dummy = new BibtexSingleField(yesNoField, false).withProperties(FieldProperty.YES_NO);
             add(dummy);
         }
 
@@ -254,9 +227,9 @@ public class InternalBibtexFields {
         for (String numericField : INTEGER_FIELDS) {
             BibtexSingleField field = fieldSet.get(numericField);
             if (field == null) {
-                field = new BibtexSingleField(numericField, true, BibtexSingleField.SMALL_W).setNumeric(true);
+                field = new BibtexSingleField(numericField, true).setNumeric(true);
             }
-            field.getFieldProperties().add(FieldProperty.INTEGER);
+            field.getProperties().add(FieldProperty.INTEGER);
             add(field);
         }
 
@@ -264,9 +237,9 @@ public class InternalBibtexFields {
         for (String fieldText : VERBATIM_FIELDS) {
             BibtexSingleField field = fieldSet.get(fieldText);
             if (field == null) {
-                field = new BibtexSingleField(fieldText, true, BibtexSingleField.SMALL_W);
+                field = new BibtexSingleField(fieldText, true);
             }
-            field.getFieldProperties().add(FieldProperty.VERBATIM);
+            field.getProperties().add(FieldProperty.VERBATIM);
             add(field);
         }
 
@@ -274,9 +247,9 @@ public class InternalBibtexFields {
         for (String fieldText : BIBLATEX_PERSON_NAME_FIELDS) {
             BibtexSingleField field = fieldSet.get(fieldText);
             if (field == null) {
-                field = new BibtexSingleField(fieldText, true, BibtexSingleField.SMALL_W);
+                field = new BibtexSingleField(fieldText, true);
             }
-            field.getFieldProperties().add(FieldProperty.PERSON_NAMES);
+            field.getProperties().add(FieldProperty.PERSON_NAMES);
             add(field);
         }
 
@@ -284,9 +257,9 @@ public class InternalBibtexFields {
         for (String fieldText : BIBLATEX_EDITOR_TYPE_FIELDS) {
             BibtexSingleField field = fieldSet.get(fieldText);
             if (field == null) {
-                field = new BibtexSingleField(fieldText, true, BibtexSingleField.SMALL_W);
+                field = new BibtexSingleField(fieldText, true);
             }
-            field.getFieldProperties().add(FieldProperty.EDITOR_TYPE);
+            field.getProperties().add(FieldProperty.EDITOR_TYPE);
             add(field);
         }
 
@@ -294,9 +267,9 @@ public class InternalBibtexFields {
         for (String fieldText : BIBLATEX_PAGINATION_FIELDS) {
             BibtexSingleField field = fieldSet.get(fieldText);
             if (field == null) {
-                field = new BibtexSingleField(fieldText, true, BibtexSingleField.SMALL_W);
+                field = new BibtexSingleField(fieldText, true);
             }
-            field.getFieldProperties().add(FieldProperty.PAGINATION);
+            field.getProperties().add(FieldProperty.PAGINATION);
             add(field);
         }
 
@@ -304,10 +277,10 @@ public class InternalBibtexFields {
         for (String fieldText : BIBLATEX_DATE_FIELDS) {
             BibtexSingleField field = fieldSet.get(fieldText);
             if (field == null) {
-                field = new BibtexSingleField(fieldText, true, BibtexSingleField.SMALL_W);
+                field = new BibtexSingleField(fieldText, true);
             }
-            field.getFieldProperties().add(FieldProperty.DATE);
-            field.getFieldProperties().add(FieldProperty.ISO_DATE);
+            field.getProperties().add(FieldProperty.DATE);
+            field.getProperties().add(FieldProperty.ISO_DATE);
             add(field);
         }
 
@@ -315,9 +288,9 @@ public class InternalBibtexFields {
         for (String fieldText : BIBLATEX_JOURNAL_NAME_FIELDS) {
             BibtexSingleField field = fieldSet.get(fieldText);
             if (field == null) {
-                field = new BibtexSingleField(fieldText, true, BibtexSingleField.SMALL_W);
+                field = new BibtexSingleField(fieldText, true);
             }
-            field.getFieldProperties().add(FieldProperty.JOURNAL_NAME);
+            field.getProperties().add(FieldProperty.JOURNAL_NAME);
             add(field);
         }
 
@@ -325,9 +298,9 @@ public class InternalBibtexFields {
         for (String fieldText : BIBLATEX_BOOK_NAME_FIELDS) {
             BibtexSingleField field = fieldSet.get(fieldText);
             if (field == null) {
-                field = new BibtexSingleField(fieldText, true, BibtexSingleField.SMALL_W);
+                field = new BibtexSingleField(fieldText, true);
             }
-            field.getFieldProperties().add(FieldProperty.BOOK_NAME);
+            field.getProperties().add(FieldProperty.BOOK_NAME);
             add(field);
         }
 
@@ -335,9 +308,9 @@ public class InternalBibtexFields {
         for (String fieldText : BIBLATEX_LANGUAGE_FIELDS) {
             BibtexSingleField field = fieldSet.get(fieldText);
             if (field == null) {
-                field = new BibtexSingleField(fieldText, true, BibtexSingleField.SMALL_W);
+                field = new BibtexSingleField(fieldText, true);
             }
-            field.getFieldProperties().add(FieldProperty.LANGUAGE);
+            field.getProperties().add(FieldProperty.LANGUAGE);
             add(field);
         }
 
@@ -345,9 +318,9 @@ public class InternalBibtexFields {
         for (String fieldText : BIBLATEX_MULTI_KEY_FIELDS) {
             BibtexSingleField field = fieldSet.get(fieldText);
             if (field == null) {
-                field = new BibtexSingleField(fieldText, true, BibtexSingleField.SMALL_W);
+                field = new BibtexSingleField(fieldText, true);
             }
-            field.getFieldProperties().add(FieldProperty.MULTIPLE_ENTRY_LINK);
+            field.getProperties().add(FieldProperty.MULTIPLE_ENTRY_LINK);
             add(field);
         }
     }
@@ -357,7 +330,6 @@ public class InternalBibtexFields {
             field.setName(timeStampFieldName);
             RUNTIME.timeStampField = timeStampFieldName;
         });
-
     }
 
     public static void updateSpecialFields(boolean serializeSpecialFields) {
@@ -390,7 +362,7 @@ public class InternalBibtexFields {
         for (String fieldName : InternalBibtexFields.RUNTIME.fieldSet.keySet()) {
             BibtexSingleField field = InternalBibtexFields.RUNTIME.fieldSet.get(fieldName);
             if (!field.isNumeric() && nF.contains(fieldName)) {
-                field.setNumeric(nF.contains(fieldName));
+                field.setNumeric(true);
             }
             nF.remove(fieldName); // remove, so we clear the set of all standard fields.
         }
@@ -403,13 +375,10 @@ public class InternalBibtexFields {
 
     }
 
-    /**
-     * insert a field into the internal list
-     */
-    private void add(BibtexSingleField field) {
-        // field == null check
-        String key = field.getFieldName();
-        fieldSet.put(key, field);
+    public static Set<FieldProperty> getFieldProperties(String name) {
+        return getField(name)
+                .map(BibtexSingleField::getProperties)
+                .orElse(EnumSet.noneOf(FieldProperty.class));
     }
 
     // --------------------------------------------------------------------------
@@ -423,35 +392,28 @@ public class InternalBibtexFields {
         return Optional.empty();
     }
 
-    public static Set<FieldProperty> getFieldProperties(String name) {
-        Optional<BibtexSingleField> sField = InternalBibtexFields.getField(name);
-        if (sField.isPresent()) {
-            return sField.get().getFieldProperties();
-        }
-        return EnumSet.noneOf(FieldProperty.class);
-    }
-
-    public static double getFieldWeight(String name) {
-        Optional<BibtexSingleField> sField = InternalBibtexFields.getField(name);
-        if (sField.isPresent()) {
-            return sField.get().getWeight();
-        }
-        return BibtexSingleField.DEFAULT_FIELD_WEIGHT;
-    }
-
-    public static void setFieldWeight(String fieldName, double weight) {
-        Optional<BibtexSingleField> sField = InternalBibtexFields.getField(fieldName);
-        if (sField.isPresent()) {
-            sField.get().setWeight(weight);
-        }
-    }
-
     public static int getFieldLength(String name) {
-        Optional<BibtexSingleField> sField = InternalBibtexFields.getField(name);
-        if (sField.isPresent()) {
-            return sField.get().getLength();
+        return InternalBibtexFields.getField(name)
+                .map(BibtexSingleField::getLength)
+                .orElse(BibtexSingleField.DEFAULT_FIELD_LENGTH);
+    }
+
+    /**
+     * returns a List with all fieldnames
+     */
+    public static List<String> getAllPublicFieldNames() {
+        // collect all public fields
+        List<String> publicFields = new ArrayList<>();
+        for (BibtexSingleField sField : InternalBibtexFields.RUNTIME.fieldSet.values()) {
+            if (!sField.isPrivate()) {
+                publicFields.add(sField.getName());
+            }
         }
-        return BibtexSingleField.DEFAULT_FIELD_LENGTH;
+
+        // sort the entries
+        Collections.sort(publicFields);
+
+        return publicFields;
     }
 
     public static boolean isWriteableField(String field) {
@@ -484,24 +446,8 @@ public class InternalBibtexFields {
         return field.startsWith("__");
     }
 
-    /**
-     * returns a List with all fieldnames
-     */
-    public static List<String> getAllPublicFieldNames() {
-        // collect all public fields
-        List<String> publicFields = new ArrayList<>();
-        for (BibtexSingleField sField : InternalBibtexFields.RUNTIME.fieldSet.values()) {
-            if (!sField.isPrivate()) {
-                publicFields.add(sField.getFieldName());
-                // or export the complete BibtexSingleField ?
-                // BibtexSingleField.toString() { return fieldname ; }
-            }
-        }
-
-        // sort the entries
-        Collections.sort(publicFields);
-
-        return publicFields;
+    public static List<String> getJournalNameFields() {
+        return getFieldsWithProperty(FieldProperty.JOURNAL_NAME);
     }
 
     /**
@@ -520,21 +466,20 @@ public class InternalBibtexFields {
         return publicAndInternalFields;
     }
 
-    public static List<String> getJournalNameFields() {
-        return InternalBibtexFields.getAllPublicFieldNames().stream().filter(
-                fieldName -> InternalBibtexFields.getFieldProperties(fieldName).contains(FieldProperty.JOURNAL_NAME))
-                .collect(Collectors.toList());
-    }
-
     public static List<String> getBookNameFields() {
-        return InternalBibtexFields.getAllPublicFieldNames().stream()
-                .filter(fieldName -> InternalBibtexFields.getFieldProperties(fieldName).contains(FieldProperty.BOOK_NAME))
-                .collect(Collectors.toList());
+        return getFieldsWithProperty(FieldProperty.BOOK_NAME);
     }
 
     public static List<String> getPersonNameFields() {
-        return InternalBibtexFields.getAllPublicFieldNames().stream().filter(
-                fieldName -> InternalBibtexFields.getFieldProperties(fieldName).contains(FieldProperty.PERSON_NAMES))
+        return getFieldsWithProperty(FieldProperty.PERSON_NAMES);
+    }
+
+    public static List<String> getFieldsWithProperty(FieldProperty property) {
+        return RUNTIME.fieldSet.values().stream()
+                .filter(field -> !field.isPrivate())
+                .filter(field -> field.getProperties().contains(property))
+                .map(BibtexSingleField::getName)
+                .sorted()
                 .collect(Collectors.toList());
     }
 
@@ -542,4 +487,11 @@ public class InternalBibtexFields {
         return IEEETRANBSTCTL_YES_NO_FIELDS;
     }
 
+    /**
+     * insert a field into the internal list
+     */
+    private void add(BibtexSingleField field) {
+        String key = field.getName();
+        fieldSet.put(key, field);
+    }
 }

--- a/src/main/java/org/jabref/model/entry/InternalBibtexFields.java
+++ b/src/main/java/org/jabref/model/entry/InternalBibtexFields.java
@@ -177,7 +177,7 @@ public class InternalBibtexFields {
 
         // additional fields ------------------------------------------------------
         add(new BibtexSingleField(FieldName.LOCATION, false));
-        add(new BibtexSingleField(FieldName.ABSTRACT, false, BibtexSingleField.LARGE_W, 400));
+        add(new BibtexSingleField(FieldName.ABSTRACT, false, BibtexSingleField.LARGE_W, 400).withExtras(EnumSet.of(FieldProperty.MULTILINE_TEXT)));
 
         dummy = new BibtexSingleField(FieldName.URL, false, BibtexSingleField.SMALL_W);
         dummy.setExtras(EnumSet.of(FieldProperty.EXTERNAL, FieldProperty.VERBATIM));


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

Someone had the abstract field in the "required" tab. Since all fields were treated the same way, the abstract field was as big as the other fields resulting in a inconvenient display. See http://discourse.jabref.org/t/entry-preview-in-version-4/827/7. With this PR the solution for the keywords field is adopted and the abstract gets a bigger weight.

~~Not yet ready for review, a bit of code cleanup is still coming.~~

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
