### PR TITLE
Initializing EntryEditor Tabs on focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We now set the WM_CLASS of the UI to org-jabref-JabRefMain to allow certain Un*x window managers to properly identify its windows
 - We changed the default paths for the OpenOffice/LibreOffice binaries to the default path for LibreOffice
 - We no longer create a new entry editor when selecting a new entry to increase performance. [#3187](https://github.com/JabRef/jabref/pull/3187)
+- We increased performance and decreased the memory footprint of the entry editor drastically. [#3331](https://github.com/JabRef/jabref/pull/3331)
+
 
 ### Fixed
  - We fixed the translation of \textendash in the entry preview [#3307](https://github.com/JabRef/jabref/issues/3307)

--- a/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
@@ -39,19 +39,21 @@ import org.jabref.model.entry.InternalBibtexFields;
  */
 class FieldsEditorTab extends EntryEditorTab {
 
-    private final Region panel;
     private final List<String> fields;
     private final EntryEditor parent;
     private final Map<String, FieldEditorFX> editors = new LinkedHashMap<>();
     private final JabRefFrame frame;
     private final BasePanel basePanel;
     private final BibEntry entry;
+    private final boolean isCompressed;
+    private Region panel;
     private FieldEditorFX activeField;
+
 
     public FieldsEditorTab(JabRefFrame frame, BasePanel basePanel, List<String> fields, EntryEditor parent, boolean addKeyField, boolean compressed, BibEntry entry) {
         this.entry = Objects.requireNonNull(entry);
         this.fields = new ArrayList<>(Objects.requireNonNull(fields));
-
+        this.isCompressed = compressed;
         // Add the edit field for Bibtex-key.
         if (addKeyField) {
             this.fields.add(BibEntry.KEY_FIELD);
@@ -60,8 +62,6 @@ class FieldsEditorTab extends EntryEditorTab {
         this.parent = parent;
         this.frame = frame;
         this.basePanel = basePanel;
-
-        panel = setupPanel(frame, basePanel, compressed);
 
         // The following line makes sure focus cycles inside tab instead of being lost to other parts of the frame:
         //panel.setFocusCycleRoot(true);
@@ -305,6 +305,7 @@ class FieldsEditorTab extends EntryEditorTab {
 
     @Override
     protected void initialize() {
+        panel = setupPanel(frame, basePanel, isCompressed);
         setContent(panel);
     }
 }


### PR DESCRIPTION
This is a very small fix with big implications for performance and memory. The reasoning is simple: Currently, all editor tabs (extending from `FieldsEditorTab`) are initialized when a new entry is selected. So even if the user is only browsing through the entry table with the editor open, on each new BibEntry we create all the tabs for each entry from scratch. This can in the case of `FieldsEditorTab` simply prevented by moving this initialization to `initialize` which is called when the tab gets focus. This PR addresses this issue.

I want to give a detailed analysis because there is much more potential when we slightly rework how the `EntryEditor` and its tabs work. First of all, this is the memory increase when I scroll the 209 entry example `jabref-authors.bib` with the current master branch.

![img](http://i.imgur.com/tt99OZf.png)

In the middle I start after running the GC with about 140MB and after scrolling the list, I ended up with 1.9GB. 99% of this comes directly from the `EntryEditor`. After the patch I propose, the memory situation is vastly improved

![img](http://i.imgur.com/AhRSD0E.png)

We need less than 400MB at the peaks and the GC seems to be able to do a much better job. It's not only an improvement in memory, but the performance increases dramatically.

## Where to go from here?

These things should be fixed in a next step:

1. `org.jabref.gui.entryeditor.EntryEditor#addTabs` is the major hotspot now because it recreates all tabs on a new entry.
2. ensure that all tabs get this late initialization on focus.
3. tabs should not be recreated at all, they should be kept as objects in `EntryEditor` and only get notified when a new entry is selected.

Unfortunately, I don't see that I can do this on my own without breaking some of the various information flows on updates in the tabs (esp. the source tab). But if someone started to work on this I would join. These are the things I would change first:

1. almost all tabs get `frame, panel, entryType, this, entry` on construction. This needs to go away. `EntryEditor` is an instance of `EntryContainer` and tabs can get the current entry. We need similar things for the other parameters. In essences, it should be `new EntryEditorTab(entryEditorInstance)`.
2. On `initialize` the tab should check if it is initialized and if the entry has changed
3. The entryEditor has a list of *all* tabs that are created on construction and it only notifies them on entry change.

### The "sliding tab problem"

Especially with this faster version, the problem of the tabs sliding in from the left on recreation becomes more visible. I have no simple solution to this especially since I'm not sure how many tabs there theoretically can be. It's these line in `addTabs`

```
        // General fields from preferences
        EntryEditorTabList tabList = Globals.prefs.getEntryEditorTabList();
        for (int i = 0; i < tabList.getTabCount(); i++) {
            FieldsEditorTab newFieldsEditorTab = new FieldsEditorTab(frame, panel, tabList.getTabFields(i), this, false,
                    false, entry);
            newFieldsEditorTab.setText(tabList.getTabName(i));
            tabs.add(newFieldsEditorTab);
        }
```

If we have a reasonable number of tabs, the best and clearest solution would be to just disable the ones that should not be shown. This will give a fixed EntryEditor layout that works nice, but I'm not sure it would piss user of if they have to endure disabled tabs.

The second solution would be to maintain a list of all tabs and one with the currently visible tabs (`tabbed.getTabs()`). This will again lead to a wiggling tabs header, but not as bad as before. On entry change, we just modify `tabbed` to display correct tabs.

The third solution would be to simply close tabs programmatically but that interferes with the current `TabClosingPolicy.UNAVAILABLE`