### PR TITLE
Disable travis email notifications about build status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,3 +61,7 @@ cache:
   directories:
   - $HOME/.gradle/caches/
   - $HOME/.gradle/wrapper/
+
+# disable email notifications about build status
+notifications:
+  email: false


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

These constant notifications whether a PR-build was successful or not are getting on my nerves. Is it just me? I think we are active enough on github to quickly recognize a failing build, and we merge only passing builds in the first place.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
