### PR TITLE
Refactoring: Lazy init of all editor tabs

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -213,7 +213,6 @@ public class EntryEditor extends JPanel implements EntryContainer {
             selectedTab.notifyAboutFocus(entry);
         });
 
-
         TypedBibEntry typedEntry = new TypedBibEntry(entry, panel.getBibDatabaseContext().getMode());
         typeLabel.setText(typedEntry.getTypeForDisplay());
     }

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -173,7 +173,9 @@ public class EntryEditor extends JPanel implements EntryContainer {
         setupToolBar();
         DefaultTaskExecutor.runInJavaFXThread(() -> {
             tabbed.setTabClosingPolicy(TabPane.TabClosingPolicy.UNAVAILABLE);
-            tabbed.setStyle("-fx-font-size: " + Globals.prefs.getFontSizeFX() + "pt;");
+            tabbed.setStyle(
+                    "-fx-font-size: " + Globals.prefs.getFontSizeFX() + "pt;" +
+                            "-fx-open-tab-animation: NONE; -fx-close-tab-animation: NONE;");
             container.setScene(new Scene(tabbed));
         });
         add(container, BorderLayout.CENTER);

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditorTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditorTab.java
@@ -2,28 +2,38 @@ package org.jabref.gui.entryeditor;
 
 import javafx.scene.control.Tab;
 
+import org.jabref.model.entry.BibEntry;
+
 public abstract class EntryEditorTab extends Tab {
 
+    protected BibEntry currentEntry;
+
     /**
-     * Used for lazy-loading of the tab content.
+     * Decide whether to show this tab for the given entry.
      */
-    protected boolean isInitialized = false;
+    public abstract boolean shouldShow(BibEntry entry);
 
-    public abstract boolean shouldShow();
+    /**
+     * Updates the view with the contents of the given entry.
+     */
+    protected abstract void bindToEntry(BibEntry entry);
 
-    public void requestFocus() {
-
+    /**
+     * The tab just got the focus. Override this method if you want to perform a special action on focus (like selecting
+     * the first field in the editor)
+     */
+    protected void handleFocus() {
+        // Do nothing by default
     }
 
     /**
-     * This method is called when the user focuses this tab.
+     * Notifies the tab that it got focus and should display the given entry.
      */
-    public void notifyAboutFocus() {
-        if (!isInitialized) {
-            initialize();
-            isInitialized = true;
+    public void notifyAboutFocus(BibEntry entry) {
+        if (!entry.equals(currentEntry)) {
+            currentEntry = entry;
+            bindToEntry(entry);
         }
+        handleFocus();
     }
-
-    protected abstract void initialize();
 }

--- a/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
@@ -1,11 +1,9 @@
 package org.jabref.gui.entryeditor;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -21,15 +19,17 @@ import javafx.scene.layout.Region;
 import javafx.scene.layout.RowConstraints;
 
 import org.jabref.Globals;
-import org.jabref.gui.BasePanel;
 import org.jabref.gui.FXDialogService;
 import org.jabref.gui.GUIGlobals;
-import org.jabref.gui.JabRefFrame;
+import org.jabref.gui.autocompleter.SuggestionProviders;
 import org.jabref.gui.fieldeditors.FieldEditorFX;
 import org.jabref.gui.fieldeditors.FieldEditors;
 import org.jabref.gui.fieldeditors.FieldNameLabel;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.EntryTypes;
+import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.EntryType;
 import org.jabref.model.entry.FieldName;
 import org.jabref.model.entry.FieldProperty;
 import org.jabref.model.entry.InternalBibtexFields;
@@ -37,34 +37,18 @@ import org.jabref.model.entry.InternalBibtexFields;
 /**
  * A single tab displayed in the EntryEditor holding several FieldEditors.
  */
-class FieldsEditorTab extends EntryEditorTab {
+abstract class FieldsEditorTab extends EntryEditorTab {
 
-    private final Region panel;
-    private final List<String> fields;
-    private final EntryEditor parent;
     private final Map<String, FieldEditorFX> editors = new LinkedHashMap<>();
-    private final JabRefFrame frame;
-    private final BasePanel basePanel;
-    private final BibEntry entry;
+    private final boolean compressed;
+    private final SuggestionProviders suggestionProviders;
     private FieldEditorFX activeField;
+    private final BibDatabaseContext databaseContext;
 
-    public FieldsEditorTab(JabRefFrame frame, BasePanel basePanel, List<String> fields, EntryEditor parent, boolean addKeyField, boolean compressed, BibEntry entry) {
-        this.entry = Objects.requireNonNull(entry);
-        this.fields = new ArrayList<>(Objects.requireNonNull(fields));
-
-        // Add the edit field for Bibtex-key.
-        if (addKeyField) {
-            this.fields.add(BibEntry.KEY_FIELD);
-        }
-
-        this.parent = parent;
-        this.frame = frame;
-        this.basePanel = basePanel;
-
-        panel = setupPanel(frame, basePanel, compressed);
-
-        // The following line makes sure focus cycles inside tab instead of being lost to other parts of the frame:
-        //panel.setFocusCycleRoot(true);
+    public FieldsEditorTab(boolean compressed, BibDatabaseContext databaseContext, SuggestionProviders suggestionProviders) {
+        this.compressed = compressed;
+        this.databaseContext = databaseContext;
+        this.suggestionProviders = suggestionProviders;
     }
 
     private static void addColumn(GridPane gridPane, int columnIndex, List<Label> nodes) {
@@ -79,42 +63,17 @@ class FieldsEditorTab extends EntryEditorTab {
         return String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
     }
 
-    private Region setupPanel(JabRefFrame frame, BasePanel bPanel, boolean compressed) {
-
-        //setupKeyBindings(panel.getInputMap(JComponent.WHEN_FOCUSED), panel.getActionMap());
-
+    private Region setupPanel(BibEntry entry, boolean compressed, SuggestionProviders suggestionProviders) {
         editors.clear();
         List<Label> labels = new ArrayList<>();
 
+        EntryType entryType = EntryTypes.getTypeOrDefault(entry.getType(), databaseContext.getMode());
+        List<String> fields = determineFieldsToShow(entry, entryType);
         for (String fieldName : fields) {
-
-            // TODO: Reenable/migrate this
-            // Store the editor for later reference:
-            /*
-            FieldEditor fieldEditor;
-            int defaultHeight;
-            int wHeight = (int) (50.0 * InternalBibtexFields.getFieldWeight(field));
-            if (InternalBibtexFields.getProperties(field).contains(FieldProperty.SINGLE_ENTRY_LINK)) {
-                fieldEditor = new EntryLinkListEditor(frame, bPanel.getBibDatabaseContext(), field, null, parent,
-                        true);
-                defaultHeight = 0;
-            } else if (InternalBibtexFields.getProperties(field).contains(FieldProperty.MULTIPLE_ENTRY_LINK)) {
-                fieldEditor = new EntryLinkListEditor(frame, bPanel.getBibDatabaseContext(), field, null, parent,
-                        false);
-                defaultHeight = 0;
-            } else {
-                fieldEditor = new TextArea(field, null, getPrompt(field));
-                //parent.addSearchListener((TextArea) fieldEditor);
-                defaultHeight = fieldEditor.getPane().getPreferredSize().height;
-            }
-
-            Optional<JComponent> extra = parent.getExtra(fieldEditor);
-            */
-
             FieldEditorFX fieldEditor = FieldEditors.getForField(fieldName, Globals.TASK_EXECUTOR, new FXDialogService(),
                     Globals.journalAbbreviationLoader, Globals.prefs.getJournalAbbreviationPreferences(), Globals.prefs,
-                    bPanel.getBibDatabaseContext(), entry.getType(),
-                    bPanel.getSuggestionProviders());
+                    databaseContext, entry.getType(),
+                    suggestionProviders);
             fieldEditor.bindToEntry(entry);
 
             editors.put(fieldName, fieldEditor);
@@ -122,13 +81,6 @@ class FieldsEditorTab extends EntryEditorTab {
             // TODO: Reenable this
             if (i == 0) {
                 activeField = fieldEditor;
-            }
-            */
-
-            /*
-            // TODO: Reenable this
-            if (!compressed) {
-                fieldEditor.getPane().setPreferredSize(new Dimension(100, Math.max(defaultHeight, wHeight)));
             }
             */
 
@@ -164,7 +116,7 @@ class FieldsEditorTab extends EntryEditorTab {
 
             gridPane.getColumnConstraints().addAll(columnDoNotContract, columnExpand);
 
-            setRegularRowLayout(gridPane, rows);
+            setRegularRowLayout(gridPane, fields, rows);
         }
 
         if (GUIGlobals.currentFont != null) {
@@ -185,7 +137,7 @@ class FieldsEditorTab extends EntryEditorTab {
         return scrollPane;
     }
 
-    private void setRegularRowLayout(GridPane gridPane, int rows) {
+    private void setRegularRowLayout(GridPane gridPane, List<String> fields, int rows) {
         List<RowConstraints> constraints = new ArrayList<>(rows);
         for (String field : fields) {
             RowConstraints rowExpand = new RowConstraints();
@@ -239,72 +191,33 @@ class FieldsEditorTab extends EntryEditorTab {
     }
 
     /**
-     * Only sets the activeField variable but does not focus it.
-     * <p>
-     * If you want to focus it call {@link #focus()} afterwards.
+     * Focuses the given field.
      */
-    public void setActive(String fieldName) {
+    public void requestFocus(String fieldName) {
         if (editors.containsKey(fieldName)) {
             activeField = editors.get(fieldName);
-        }
-    }
-
-    public List<String> getFields() {
-        return Collections.unmodifiableList(fields);
-    }
-
-    public void focus() {
-        if (activeField != null) {
             activeField.requestFocus();
         }
     }
 
-    public boolean updateField(String field, String content) {
-        if (!editors.containsKey(field)) {
-            return false;
-        }
-        // TODO: Reenable or probably better delete this
-        /*
-        FieldEditor fieldEditor = editors.get(field);
-        if (fieldEditor.getText().equals(content)) {
-            return true;
-        }
-
-        // trying to preserve current edit position (fixes SF bug #1285)
-        if (fieldEditor.getTextComponent() instanceof JTextComponent) {
-            int initialCaretPosition = ((JTextComponent) fieldEditor).getCaretPosition();
-            fieldEditor.setText(content);
-            int textLength = fieldEditor.getText().length();
-            if (initialCaretPosition < textLength) {
-                ((JTextComponent) fieldEditor).setCaretPosition(initialCaretPosition);
-            } else {
-                ((JTextComponent) fieldEditor).setCaretPosition(textLength);
-            }
-        } else {
-            fieldEditor.setText(content);
-        }
-        */
-        return true;
-    }
-
-    public EntryEditor getParent() {
-        return parent;
+    @Override
+    public boolean shouldShow(BibEntry entry) {
+        EntryType entryType = EntryTypes.getTypeOrDefault(entry.getType(), databaseContext.getMode());
+        return !determineFieldsToShow(entry, entryType).isEmpty();
     }
 
     @Override
-    public boolean shouldShow() {
-        return !fields.isEmpty();
-    }
-
-    @Override
-    public void requestFocus() {
+    public void handleFocus() {
         if (activeField != null) {
             activeField.requestFocus();
         }
     }
 
     @Override
-    protected void initialize() {
+    protected void bindToEntry(BibEntry entry) {
+        Region panel = setupPanel(entry, compressed, suggestionProviders);
         setContent(panel);
     }
+
+    protected abstract List<String> determineFieldsToShow(BibEntry entry, EntryType entryType);
 }

--- a/src/main/java/org/jabref/gui/entryeditor/MathSciNetTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/MathSciNetTab.java
@@ -13,15 +13,15 @@ import org.jabref.model.entry.identifier.MathSciNetId;
 
 public class MathSciNetTab extends EntryEditorTab {
 
-    private Optional<MathSciNetId> mathSciNetId;
-
-    public MathSciNetTab(BibEntry entry) {
-        this.mathSciNetId = entry.getField(FieldName.MR_NUMBER).flatMap(MathSciNetId::parse);
-
+    public MathSciNetTab() {
         setText(Localization.lang("MathSciNet Review"));
     }
 
-    private StackPane getPane() {
+    private Optional<MathSciNetId> getMathSciNetId(BibEntry entry) {
+        return entry.getField(FieldName.MR_NUMBER).flatMap(MathSciNetId::parse);
+    }
+
+    private StackPane getPane(BibEntry entry) {
         StackPane root = new StackPane();
         ProgressIndicator progress = new ProgressIndicator();
         progress.setMaxSize(100, 100);
@@ -33,6 +33,7 @@ public class MathSciNetTab extends EntryEditorTab {
 
         root.getChildren().addAll(browser, progress);
 
+        Optional<MathSciNetId> mathSciNetId = getMathSciNetId(entry);
         mathSciNetId.flatMap(MathSciNetId::getExternalURI)
                 .ifPresent(url -> browser.getEngine().load(url.toASCIIString()));
 
@@ -46,12 +47,12 @@ public class MathSciNetTab extends EntryEditorTab {
     }
 
     @Override
-    public boolean shouldShow() {
-        return mathSciNetId.isPresent();
+    public boolean shouldShow(BibEntry entry) {
+        return getMathSciNetId(entry).isPresent();
     }
 
     @Override
-    protected void initialize() {
-        setContent(getPane());
+    protected void bindToEntry(BibEntry entry) {
+        setContent(getPane(entry));
     }
 }

--- a/src/main/java/org/jabref/gui/entryeditor/OptionalFields2Tab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OptionalFields2Tab.java
@@ -1,20 +1,27 @@
 package org.jabref.gui.entryeditor;
 
+import java.util.List;
+
 import javafx.scene.control.Tooltip;
 
-import org.jabref.gui.BasePanel;
 import org.jabref.gui.IconTheme;
-import org.jabref.gui.JabRefFrame;
+import org.jabref.gui.autocompleter.SuggestionProviders;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.EntryType;
 
 public class OptionalFields2Tab extends FieldsEditorTab {
-    public OptionalFields2Tab(JabRefFrame frame, BasePanel basePanel, EntryType entryType, EntryEditor parent, BibEntry entry) {
-        super(frame, basePanel, entryType.getSecondaryOptionalNotDeprecatedFields(), parent, false, true, entry);
+    public OptionalFields2Tab(BibDatabaseContext databaseContext, SuggestionProviders suggestionProviders) {
+        super(true, databaseContext, suggestionProviders);
 
         setText(Localization.lang("Optional fields 2"));
         setTooltip(new Tooltip(Localization.lang("Show optional fields")));
         setGraphic(IconTheme.JabRefIcon.OPTIONAL.getGraphicNode());
+    }
+
+    @Override
+    protected List<String> determineFieldsToShow(BibEntry entry, EntryType entryType) {
+        return entryType.getSecondaryOptionalNotDeprecatedFields();
     }
 }

--- a/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTab.java
@@ -1,20 +1,27 @@
 package org.jabref.gui.entryeditor;
 
+import java.util.List;
+
 import javafx.scene.control.Tooltip;
 
-import org.jabref.gui.BasePanel;
 import org.jabref.gui.IconTheme;
-import org.jabref.gui.JabRefFrame;
+import org.jabref.gui.autocompleter.SuggestionProviders;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.EntryType;
 
 public class OptionalFieldsTab extends FieldsEditorTab {
-    public OptionalFieldsTab(JabRefFrame frame, BasePanel basePanel, EntryType entryType, EntryEditor parent, BibEntry entry) {
-        super(frame, basePanel, entryType.getPrimaryOptionalFields(), parent, false, true, entry);
+    public OptionalFieldsTab(BibDatabaseContext databaseContext, SuggestionProviders suggestionProviders) {
+        super(true, databaseContext, suggestionProviders);
 
         setText(Localization.lang("Optional fields"));
         setTooltip(new Tooltip(Localization.lang("Show optional fields")));
         setGraphic(IconTheme.JabRefIcon.OPTIONAL.getGraphicNode());
+    }
+
+    @Override
+    protected List<String> determineFieldsToShow(BibEntry entry, EntryType entryType) {
+        return entryType.getPrimaryOptionalFields();
     }
 }

--- a/src/main/java/org/jabref/gui/entryeditor/OtherFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OtherFieldsTab.java
@@ -6,33 +6,21 @@ import java.util.stream.Collectors;
 import javafx.scene.control.Tooltip;
 
 import org.jabref.Globals;
-import org.jabref.gui.BasePanel;
 import org.jabref.gui.IconTheme;
-import org.jabref.gui.JabRefFrame;
+import org.jabref.gui.autocompleter.SuggestionProviders;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.EntryType;
 
 public class OtherFieldsTab extends FieldsEditorTab {
 
-    public OtherFieldsTab(JabRefFrame frame, BasePanel basePanel, EntryType entryType, EntryEditor parent, BibEntry entry) {
-        super(frame, basePanel, getOtherFields(entryType, entry), parent, false, false, entry);
+    public OtherFieldsTab(BibDatabaseContext databaseContext, SuggestionProviders suggestionProviders) {
+        super(false, databaseContext, suggestionProviders);
 
         setText(Localization.lang("Other fields"));
         setTooltip(new Tooltip(Localization.lang("Show remaining fields")));
         setGraphic(IconTheme.JabRefIcon.OPTIONAL.getGraphicNode());
-    }
-
-    private static List<String> getOtherFields(EntryType entryType, BibEntry entry) {
-        List<String> allKnownFields = entryType.getAllFields().stream().map(String::toLowerCase)
-                .collect(Collectors.toList());
-        List<String> otherFields = entry.getFieldNames().stream().map(String::toLowerCase)
-                .filter(field -> !allKnownFields.contains(field)).collect(Collectors.toList());
-
-        otherFields.removeAll(entryType.getDeprecatedFields());
-        otherFields.remove(BibEntry.KEY_FIELD);
-        otherFields.removeAll(Globals.prefs.getCustomTabFieldNames());
-        return otherFields;
     }
 
     public static boolean isOtherField(EntryType entryType, String fieldToCheck) {
@@ -46,5 +34,18 @@ public class OtherFieldsTab extends FieldsEditorTab {
         } else {
             return true;
         }
+    }
+
+    @Override
+    protected List<String> determineFieldsToShow(BibEntry entry, EntryType entryType) {
+        List<String> allKnownFields = entryType.getAllFields().stream().map(String::toLowerCase)
+                .collect(Collectors.toList());
+        List<String> otherFields = entry.getFieldNames().stream().map(String::toLowerCase)
+                .filter(field -> !allKnownFields.contains(field)).collect(Collectors.toList());
+
+        otherFields.removeAll(entryType.getDeprecatedFields());
+        otherFields.remove(BibEntry.KEY_FIELD);
+        otherFields.removeAll(Globals.prefs.getCustomTabFieldNames());
+        return otherFields;
     }
 }

--- a/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
@@ -20,12 +20,12 @@ import org.jabref.preferences.JabRefPreferences;
 
 public class RelatedArticlesTab extends EntryEditorTab {
 
-    private final BibEntry entry;
+    private final JabRefPreferences preferences;
 
-    public RelatedArticlesTab(BibEntry entry) {
-        this.entry = entry;
+    public RelatedArticlesTab(JabRefPreferences preferences) {
         setText(Localization.lang("Related articles"));
         setTooltip(new Tooltip(Localization.lang("Related articles")));
+        this.preferences = preferences;
     }
 
     private StackPane getPane(BibEntry entry) {
@@ -80,12 +80,12 @@ public class RelatedArticlesTab extends EntryEditorTab {
     }
 
     @Override
-    public boolean shouldShow() {
-        return Globals.prefs.getBoolean(JabRefPreferences.SHOW_RECOMMENDATIONS);
+    public boolean shouldShow(BibEntry entry) {
+        return preferences.getBoolean(JabRefPreferences.SHOW_RECOMMENDATIONS);
     }
 
     @Override
-    protected void initialize() {
+    protected void bindToEntry(BibEntry entry) {
         setContent(getPane(entry));
     }
 }

--- a/src/main/java/org/jabref/gui/entryeditor/RequiredFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/RequiredFieldsTab.java
@@ -1,20 +1,34 @@
 package org.jabref.gui.entryeditor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javafx.scene.control.Tooltip;
 
-import org.jabref.gui.BasePanel;
 import org.jabref.gui.IconTheme;
-import org.jabref.gui.JabRefFrame;
+import org.jabref.gui.autocompleter.SuggestionProviders;
 import org.jabref.logic.l10n.Localization;
+import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.EntryType;
 
 public class RequiredFieldsTab extends FieldsEditorTab {
-    public RequiredFieldsTab(JabRefFrame frame, BasePanel basePanel, EntryType entryType, EntryEditor parent, BibEntry entry) {
-        super(frame, basePanel, entryType.getRequiredFieldsFlat(), parent, true, false, entry);
+    public RequiredFieldsTab(BibDatabaseContext databaseContext, SuggestionProviders suggestionProviders) {
+        super(false, databaseContext, suggestionProviders);
 
         setText(Localization.lang("Required fields"));
         setTooltip(new Tooltip(Localization.lang("Show required fields")));
         setGraphic(IconTheme.JabRefIcon.REQUIRED.getGraphicNode());
+    }
+
+    @Override
+    protected List<String> determineFieldsToShow(BibEntry entry, EntryType entryType) {
+        List<String> fields = new ArrayList<>();
+        fields.addAll(entryType.getRequiredFieldsFlat());
+
+        // Add the edit field for Bibtex-key.
+        fields.add(BibEntry.KEY_FIELD);
+
+        return fields;
     }
 }

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -42,15 +42,13 @@ public class SourceTab extends EntryEditorTab {
 
     private static final Log LOGGER = LogFactory.getLog(SourceTab.class);
     private final BibDatabaseMode mode;
-    private final BibEntry entry;
     private final BasePanel panel;
     private CodeArea codeArea;
     private BooleanProperty movingToDifferentEntry;
     private UndoManager undoManager;
 
-    public SourceTab(BasePanel panel, BibEntry entry, BooleanProperty movingToDifferentEntry) {
+    public SourceTab(BasePanel panel, BooleanProperty movingToDifferentEntry) {
         this.mode = panel.getBibDatabaseContext().getMode();
-        this.entry = entry;
         this.panel = panel;
         this.movingToDifferentEntry = movingToDifferentEntry;
         this.setText(Localization.lang("%0 source", mode.getFormattedName()));
@@ -68,7 +66,7 @@ public class SourceTab extends EntryEditorTab {
         return stringWriter.getBuffer().toString();
     }
 
-    public void updateSourcePane() {
+    public void updateSourcePane(BibEntry entry) {
         if (codeArea != null) {
             try {
                 codeArea.clear();
@@ -90,14 +88,14 @@ public class SourceTab extends EntryEditorTab {
         // store source if new tab is selected (if this one is not focused anymore)
         EasyBind.subscribe(codeArea.focusedProperty(), focused -> {
             if (!focused) {
-                storeSource();
+                storeSource(entry);
             }
         });
 
         // store source if new entry is selected in the maintable and the source tab is focused
         EasyBind.subscribe(movingToDifferentEntry, newEntrySelected -> {
             if (newEntrySelected && codeArea.focusedProperty().get()) {
-                DefaultTaskExecutor.runInJavaFXThread(() -> storeSource());
+                DefaultTaskExecutor.runInJavaFXThread(() -> storeSource(entry));
             }
         });
 
@@ -122,16 +120,16 @@ public class SourceTab extends EntryEditorTab {
     }
 
     @Override
-    public boolean shouldShow() {
+    public boolean shouldShow(BibEntry entry) {
         return true;
     }
 
     @Override
-    protected void initialize() {
+    protected void bindToEntry(BibEntry entry) {
         this.setContent(createSourceEditor(entry, mode));
     }
 
-    private void storeSource() {
+    private void storeSource(BibEntry entry) {
         if (codeArea.getText().isEmpty()) {
             return;
         }

--- a/src/main/java/org/jabref/gui/entryeditor/UserDefinedFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/UserDefinedFieldsTab.java
@@ -2,26 +2,25 @@ package org.jabref.gui.entryeditor;
 
 import java.util.List;
 
-import javafx.scene.control.Tooltip;
-
 import org.jabref.gui.IconTheme;
 import org.jabref.gui.autocompleter.SuggestionProviders;
-import org.jabref.logic.l10n.Localization;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.EntryType;
 
-public class DeprecatedFieldsTab extends FieldsEditorTab {
-    public DeprecatedFieldsTab(BibDatabaseContext databaseContext, SuggestionProviders suggestionProviders) {
-        super(false, databaseContext, suggestionProviders);
+public class UserDefinedFieldsTab extends FieldsEditorTab {
+    private final List<String> fields;
 
-        setText(Localization.lang("Deprecated fields"));
-        setTooltip(new Tooltip(Localization.lang("Show deprecated BibTeX fields")));
+    public UserDefinedFieldsTab(String name, List<String> fields, BibDatabaseContext databaseContext, SuggestionProviders suggestionProviders) {
+        super(false, databaseContext, suggestionProviders);
+        this.fields = fields;
+
+        setText(name);
         setGraphic(IconTheme.JabRefIcon.OPTIONAL.getGraphicNode());
     }
 
     @Override
     protected List<String> determineFieldsToShow(BibEntry entry, EntryType entryType) {
-        return entryType.getDeprecatedFields();
+        return fields;
     }
 }

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.java
@@ -11,28 +11,21 @@ import org.jabref.model.entry.FieldName;
 public class FileAnnotationTab extends EntryEditorTab {
 
     private final FileAnnotationCache fileAnnotationCache;
-    private final BibEntry entry;
 
-    public FileAnnotationTab(FileAnnotationCache cache, BibEntry entry) {
+    public FileAnnotationTab(FileAnnotationCache cache) {
         this.fileAnnotationCache = cache;
-        this.entry = entry;
 
         setText(Localization.lang("File annotations"));
         setTooltip(new Tooltip(Localization.lang("Show file annotations")));
     }
 
     @Override
-    public boolean shouldShow() {
+    public boolean shouldShow(BibEntry entry) {
         return entry.getField(FieldName.FILE).isPresent();
     }
 
     @Override
-    public void notifyAboutFocus() {
-        initialize();
-    }
-
-    @Override
-    protected void initialize() {
+    protected void bindToEntry(BibEntry entry) {
         setContent(new FileAnnotationTabView(entry, fileAnnotationCache).getView());
     }
 }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

Not to let @halirutan and @lenhard have all the fun, I'll jump onto the "improve-the-entry-editor"-train. So this PR is a natural continuation of https://github.com/JabRef/jabref/pull/3331. 

Changes:
- The entry editor tabs are only initialized once and then later notified about getting the focus or the change of entry.
- The different tabs no longer rely on the JabRefFrame and BasePanel (finally!)
- I removed some commented-out code in the FieldsEditorTab, that was a relic of previous (incomplete) refactorings.
- Disable tab animation.


------

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
