### PR TITLE
Remove underscore in Localized messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - We improved the way metadata is updated in remote databases. [#3235](https://github.com/JabRef/jabref/issues/3235)
  - We improved font rendering of the Entry Editor for Linux based systems [#3295](https://github.com/JabRef/jabref/issues/3295)
  - We fixed an issue where JabRef would freeze when trying to replace the original entry after a merge with new information from identifiers like DOI/ISBN etc. [3294](https://github.com/JabRef/jabref/issues/3294)
-
+ - We fixed an issue where JabRef would not show the translated content at some points, although there existed a translation
 ### Removed
 
 

--- a/src/main/java/org/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/org/jabref/cli/ArgumentProcessor.java
@@ -519,7 +519,7 @@ public class ArgumentProcessor {
                             database, entry, Globals.prefs.getBibtexKeyPatternPreferences());
                 }
             } else {
-                LOGGER.info(Localization.lang("No meta data present in BIB_file. Cannot regenerate BibTeX keys"));
+                LOGGER.info(Localization.lang("No meta data present in BIB file. Cannot regenerate BibTeX keys"));
             }
         }
     }

--- a/src/main/java/org/jabref/gui/EntryTypeDialog.java
+++ b/src/main/java/org/jabref/gui/EntryTypeDialog.java
@@ -331,7 +331,7 @@ public class EntryTypeDialog extends JabRefDialog implements ActionListener {
                 } else if (searchID.trim().isEmpty()) {
                     JOptionPane.showMessageDialog(frame, Localization.lang("The given search ID was empty."), Localization.lang("Empty search ID"), JOptionPane.WARNING_MESSAGE);
                 } else if (!fetcherException) {
-                    JOptionPane.showMessageDialog(frame, Localization.lang("Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.", fetcher.getName(), searchID) + "\n" + fetcherExceptionMessage, Localization.lang("No files found."), JOptionPane.WARNING_MESSAGE);
+                    JOptionPane.showMessageDialog(frame, Localization.lang("Fetcher '%0' did not find an entry for id '%1'.", fetcher.getName(), searchID) + "\n" + fetcherExceptionMessage, Localization.lang("No files found."), JOptionPane.WARNING_MESSAGE);
                 } else {
                     JOptionPane.showMessageDialog(frame,
                             Localization.lang("Error while fetching from %0", fetcher.getName()) + "." + "\n" + fetcherExceptionMessage,

--- a/src/main/java/org/jabref/gui/desktop/JabRefDesktop.java
+++ b/src/main/java/org/jabref/gui/desktop/JabRefDesktop.java
@@ -290,7 +290,7 @@ public class JabRefDesktop {
             LOGGER.error("Could not open browser", exception);
             String couldNotOpenBrowser = Localization.lang("Could not open browser.");
             String openManually = Localization.lang("Please open %0 manually.", url);
-            String copiedToClipboard = Localization.lang("The_link_has_been_copied_to_the_clipboard.");
+            String copiedToClipboard = Localization.lang("The link has been copied to the clipboard.");
             JabRefGUI.getMainFrame().output(couldNotOpenBrowser);
             JOptionPane.showMessageDialog(JabRefGUI.getMainFrame(), couldNotOpenBrowser + "\n" + openManually + "\n" +
                     copiedToClipboard, couldNotOpenBrowser, JOptionPane.ERROR_MESSAGE);

--- a/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/RelatedArticlesTab.java
@@ -73,7 +73,7 @@ public class RelatedArticlesTab extends EntryEditorTab {
         htmlContent.append("<br><div style='margin-left: 5px'>");
         htmlContent.append(
                 "<a href='http://mr-dlib.org/information-for-users/information-about-mr-dlib-for-jabref-users/#' target=\"_blank\">");
-        htmlContent.append(Localization.lang("What_is_Mr._DLib?"));
+        htmlContent.append(Localization.lang("What is Mr. DLib?"));
         htmlContent.append("</a></div>");
         htmlContent.append("</body></html>");
         return htmlContent.toString();

--- a/src/main/java/org/jabref/gui/preftabs/EntryEditorPrefsTab.java
+++ b/src/main/java/org/jabref/gui/preftabs/EntryEditorPrefsTab.java
@@ -56,7 +56,7 @@ class EntryEditorPrefsTab extends JPanel implements PrefsTab {
         emacsRebindCtrlA = new JCheckBox(Localization.lang("Rebind C-a, too"));
         emacsRebindCtrlF = new JCheckBox(Localization.lang("Rebind C-f, too"));
         autoComplete = new JCheckBox(Localization.lang("Enable word/name autocompletion"));
-        recommendations = new JCheckBox(Localization.lang("Show 'Related_Articles' tab"));
+        recommendations = new JCheckBox(Localization.lang("Show 'Related Articles' tab"));
 
         // allowed name formats
         autoCompFF = new JRadioButton(Localization.lang("Autocomplete names in 'Firstname Lastname' format only"));

--- a/src/main/java/org/jabref/gui/shared/SharedDatabaseUIManager.java
+++ b/src/main/java/org/jabref/gui/shared/SharedDatabaseUIManager.java
@@ -111,7 +111,7 @@ public class SharedDatabaseUIManager {
         dbmsSynchronizer = bibDatabaseContext.getDBMSSynchronizer();
         dbmsSynchronizer.openSharedDatabase(dbmsConnectionProperties);
         dbmsSynchronizer.registerListener(this);
-        frame.output(Localization.lang("Connection_to_%0_server_established.", dbmsConnectionProperties.getType().toString()));
+        frame.output(Localization.lang("Connection to %0 server established.", dbmsConnectionProperties.getType().toString()));
         return frame.addTab(bibDatabaseContext, true);
     }
 
@@ -140,6 +140,6 @@ public class SharedDatabaseUIManager {
         dbmsSynchronizer.openSharedDatabase(dbmsConnectionProperties);
         dbmsSynchronizer.registerListener(this);
         parserResult.setDatabaseContext(bibDatabaseContext);
-        frame.output(Localization.lang("Connection_to_%0_server_established.", dbmsConnectionProperties.getType().toString()));
+        frame.output(Localization.lang("Connection to %0 server established.", dbmsConnectionProperties.getType().toString()));
     }
 }

--- a/src/main/java/org/jabref/logic/auxparser/AuxParserResult.java
+++ b/src/main/java/org/jabref/logic/auxparser/AuxParserResult.java
@@ -92,7 +92,7 @@ public class AuxParserResult {
             }
         }
         if (nestedAuxCount > 0) {
-            result.append(Localization.lang("nested_AUX_files")).append(' ').append(nestedAuxCount);
+            result.append(Localization.lang("nested AUX files")).append(' ').append(nestedAuxCount);
         }
         return result.toString();
     }

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
@@ -40,7 +40,7 @@ public class RegexFormatter implements Formatter {
 
     @Override
     public String getName() {
-        return Localization.lang("regular_expression");
+        return Localization.lang("regular expression");
     }
 
     @Override

--- a/src/main/java/org/jabref/logic/importer/fetcher/AbstractIsbnFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/AbstractIsbnFetcher.java
@@ -25,7 +25,7 @@ public abstract class AbstractIsbnFetcher implements IdBasedParserFetcher {
     protected void ensureThatIsbnIsValid(String identifier) throws FetcherException {
         ISBN isbn = new ISBN(identifier);
         if (!isbn.isValid()) {
-            throw new FetcherException(Localization.lang("Invalid_ISBN:_'%0'.", identifier));
+            throw new FetcherException(Localization.lang("Invalid ISBN: '%0'.", identifier));
         }
     }
 

--- a/src/main/java/org/jabref/logic/importer/fetcher/DoiFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DoiFetcher.java
@@ -59,7 +59,7 @@ public class DoiFetcher implements IdBasedFetcher, EntryBasedFetcher {
                 fetchedEntry.ifPresent(this::doPostCleanup);
                 return fetchedEntry;
             } else {
-                throw new FetcherException(Localization.lang("Invalid_DOI:_'%0'.", identifier));
+                throw new FetcherException(Localization.lang("Invalid DOI: '%0'.", identifier));
             }
         } catch (IOException e) {
             throw new FetcherException(Localization.lang("Connection error"), e);

--- a/src/main/java/org/jabref/logic/importer/fetcher/MrDLibFetcher.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/MrDLibFetcher.java
@@ -59,7 +59,7 @@ public class MrDLibFetcher implements EntryBasedFetcher {
                     // For displaying An ErrorMessage
                     BibEntry errorBibEntry = new BibEntry();
                     errorBibEntry.setField("html_representation",
-                            Localization.lang("Error_while_fetching_from_%0", "Mr.DLib"));
+                            Localization.lang("Error while fetching from %0", "Mr.DLib"));
                     BibDatabase errorBibDataBase = new BibDatabase();
                     errorBibDataBase.insertEntry(errorBibEntry);
                     parserResult = new ParserResult(errorBibDataBase);


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
I noticed warnings in running JabRef in debug mode regarding translations. Found some places where and underscore was used instead of space.

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
