### PR TITLE
Used late initialization for context menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We changed the default paths for the OpenOffice/LibreOffice binaries to the default path for LibreOffice
 - We no longer create a new entry editor when selecting a new entry to increase performance. [#3187](https://github.com/JabRef/jabref/pull/3187)
 - We increased performance and decreased the memory footprint of the entry editor drastically. [#3331](https://github.com/JabRef/jabref/pull/3331)
+- Late initialization of the context menus in the entry editor. This improves performance and memory footprint further [#3340](https://github.com/JabRef/jabref/pull/3340)
 
 
 ### Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -355,7 +355,7 @@ task media(type: com.install4j.gradle.Install4jTask, dependsOn: "releaseJar") {
 checkstyle {
     // do not use other packages for checkstyle, excluding gen(erated) sources
     checkstyleMain.source = "src/main/java"
-    toolVersion = '8.0'
+    toolVersion = '8.3'
 }
 
 checkstyleMain.shouldRunAfter test

--- a/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
@@ -3,6 +3,7 @@ package org.jabref.gui.fieldeditors;
 import java.net.URL;
 import java.util.List;
 import java.util.ResourceBundle;
+import java.util.function.Supplier;
 
 import javafx.fxml.Initializable;
 import javafx.scene.control.ContextMenu;
@@ -49,14 +50,16 @@ public class EditorTextArea extends javafx.scene.control.TextArea implements Ini
     }
 
     /**
-     * Adds the given list of menu items to the context menu.
+     * Adds the given list of menu items to the context menu. The usage of {@link Supplier} prevents that the menus need
+     * to be instantiated at this point. They are populated when the user needs them which prevents many unnecessary
+     * allocations when the main table is just scrolled with the entry editor open.
      */
-    public void addToContextMenu(List<MenuItem> items) {
+    public void addToContextMenu(Supplier<List<MenuItem>> items) {
         TextAreaSkin customContextSkin = new TextAreaSkin(this) {
             @Override
             public void populateContextMenu(ContextMenu contextMenu) {
                 super.populateContextMenu(contextMenu);
-                contextMenu.getItems().addAll(0, items);
+                contextMenu.getItems().addAll(0, items.get());
             }
         };
         setSkin(customContextSkin);

--- a/src/main/java/org/jabref/gui/fieldeditors/IdentifierEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/IdentifierEditor.java
@@ -1,14 +1,11 @@
 package org.jabref.gui.fieldeditors;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.Parent;
 import javafx.scene.control.Button;
-import javafx.scene.control.MenuItem;
 import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
 
@@ -25,10 +22,14 @@ import org.jabref.preferences.JabRefPreferences;
 
 public class IdentifierEditor extends HBox implements FieldEditorFX {
 
-    @FXML private IdentifierEditorViewModel viewModel;
-    @FXML private EditorTextArea textArea;
-    @FXML private Button fetchInformationByIdentifierButton;
-    @FXML private Button lookupIdentifierButton;
+    @FXML
+    private IdentifierEditorViewModel viewModel;
+    @FXML
+    private EditorTextArea textArea;
+    @FXML
+    private Button fetchInformationByIdentifierButton;
+    @FXML
+    private Button lookupIdentifierButton;
     private Optional<BibEntry> entry;
 
     public IdentifierEditor(String fieldName, TaskExecutor taskExecutor, DialogService dialogService, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers, JabRefPreferences preferences) {
@@ -43,12 +44,11 @@ public class IdentifierEditor extends HBox implements FieldEditorFX {
         lookupIdentifierButton.setTooltip(
                 new Tooltip(Localization.lang("Look up %0", FieldName.getDisplayName(fieldName))));
 
-        List<MenuItem> menuItems = new ArrayList<>();
         if (fieldName.equalsIgnoreCase(FieldName.DOI)) {
-            menuItems.addAll(EditorMenus.getDOIMenu(textArea));
+            textArea.addToContextMenu(EditorMenus.getDOIMenu(textArea));
+        } else {
+            textArea.addToContextMenu(EditorMenus.getDefaultMenu(textArea));
         }
-        menuItems.addAll(EditorMenus.getDefaultMenu(textArea));
-        textArea.addToContextMenu(menuItems);
 
         new EditorValidator(preferences).configureValidation(viewModel.getFieldValidator().getValidationStatus(), textArea);
     }
@@ -82,5 +82,4 @@ public class IdentifierEditor extends HBox implements FieldEditorFX {
     private void openExternalLink(ActionEvent event) {
         viewModel.openExternalLink();
     }
-
 }

--- a/src/main/java/org/jabref/gui/fieldeditors/IdentifierEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/IdentifierEditor.java
@@ -22,14 +22,10 @@ import org.jabref.preferences.JabRefPreferences;
 
 public class IdentifierEditor extends HBox implements FieldEditorFX {
 
-    @FXML
-    private IdentifierEditorViewModel viewModel;
-    @FXML
-    private EditorTextArea textArea;
-    @FXML
-    private Button fetchInformationByIdentifierButton;
-    @FXML
-    private Button lookupIdentifierButton;
+    @FXML private IdentifierEditorViewModel viewModel;
+    @FXML private EditorTextArea textArea;
+    @FXML private Button fetchInformationByIdentifierButton;
+    @FXML private Button lookupIdentifierButton;
     private Optional<BibEntry> entry;
 
     public IdentifierEditor(String fieldName, TaskExecutor taskExecutor, DialogService dialogService, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers, JabRefPreferences preferences) {

--- a/src/main/java/org/jabref/gui/fieldeditors/contextmenu/EditorMenus.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/contextmenu/EditorMenus.java
@@ -2,6 +2,7 @@ package org.jabref.gui.fieldeditors.contextmenu;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -14,42 +15,73 @@ import javafx.scene.control.TextArea;
 import javafx.scene.control.Tooltip;
 
 import org.jabref.gui.actions.CopyDoiUrlAction;
+import org.jabref.gui.fieldeditors.EditorTextArea;
 import org.jabref.logic.formatter.bibtexfields.NormalizeNamesFormatter;
 import org.jabref.logic.l10n.Localization;
 
+/**
+ * Provides context menus for the text fields of the entry editor. Note that we use {@link Supplier} to prevent an early
+ * instantiation of the menus. Therefore, they are attached to each text field but instantiation happens on the first
+ * right-click of the user in that field. The late instantiation is done by {@link
+ * EditorTextArea#addToContextMenu(java.util.function.Supplier)}.
+ */
 public class EditorMenus {
 
-    public static List<MenuItem> getDefaultMenu(TextArea textArea) {
-        List<MenuItem> menuItems = new ArrayList<>(5);
-        menuItems.add(new CaseChangeMenu(textArea.textProperty()));
-        menuItems.add(new ConversionMenu(textArea.textProperty()));
-        menuItems.add(new SeparatorMenuItem());
-        menuItems.add(new ProtectedTermsMenu(textArea));
-        menuItems.add(new SeparatorMenuItem());
-        return menuItems;
+    /**
+     * The default menu that contains functions for changing the case of text and doing several conversions.
+     *
+     * @param textArea text-area that this menu will be connected to
+     * @return default context menu available for most text fields
+     */
+    public static Supplier<List<MenuItem>> getDefaultMenu(TextArea textArea) {
+        return () -> {
+            List<MenuItem> menuItems = new ArrayList<>(5);
+            menuItems.add(new CaseChangeMenu(textArea.textProperty()));
+            menuItems.add(new ConversionMenu(textArea.textProperty()));
+            menuItems.add(new SeparatorMenuItem());
+            menuItems.add(new ProtectedTermsMenu(textArea));
+            menuItems.add(new SeparatorMenuItem());
+            return menuItems;
+        };
     }
 
-    public static List<MenuItem> getNameMenu(TextArea textArea) {
-        CustomMenuItem normalizeNames = new CustomMenuItem(new Label(Localization.lang("Normalize to BibTeX name format")));
-        normalizeNames.setOnAction(event -> textArea.setText(new NormalizeNamesFormatter().format(textArea.getText())));
-        Tooltip toolTip = new Tooltip(Localization.lang("If possible, normalize this list of names to conform to standard BibTeX name formatting"));
-        Tooltip.install(normalizeNames.getContent(),toolTip);
+    /**
+     * The default context menu with a specific menu for normalizing person names regarding to BibTex rules.
+     *
+     * @param textArea text-area that this menu will be connected to
+     * @return menu containing items of the default menu and an item for normalizing person names
+     */
+    public static Supplier<List<MenuItem>> getNameMenu(TextArea textArea) {
+        return () -> {
+            CustomMenuItem normalizeNames = new CustomMenuItem(new Label(Localization.lang("Normalize to BibTeX name format")));
+            normalizeNames.setOnAction(event -> textArea.setText(new NormalizeNamesFormatter().format(textArea.getText())));
+            Tooltip toolTip = new Tooltip(Localization.lang("If possible, normalize this list of names to conform to standard BibTeX name formatting"));
+            Tooltip.install(normalizeNames.getContent(), toolTip);
 
-        List<MenuItem> menuItems = new ArrayList<>(6);
-        menuItems.add(normalizeNames);
-        menuItems.addAll(getDefaultMenu(textArea));
-
-        return menuItems;
+            List<MenuItem> menuItems = new ArrayList<>(6);
+            menuItems.add(normalizeNames);
+            menuItems.addAll(getDefaultMenu(textArea).get());
+            return menuItems;
+        };
     }
 
-    public static List<MenuItem> getDOIMenu(TextArea textArea) {
-        AbstractAction copyDoiUrlAction = new CopyDoiUrlAction(textArea);
-        MenuItem copyDoiUrlMenuItem = new MenuItem((String) copyDoiUrlAction.getValue(Action.NAME));
-        copyDoiUrlMenuItem.setOnAction(event -> copyDoiUrlAction.actionPerformed(null));
+    /**
+     * The default context menu with a specific menu copying a DOI URL.
+     *
+     * @param textArea text-area that this menu will be connected to
+     * @return menu containing items of the default menu and an item for copying a DOI URL
+     */
+    public static Supplier<List<MenuItem>> getDOIMenu(TextArea textArea) {
+        return () -> {
+            AbstractAction copyDoiUrlAction = new CopyDoiUrlAction(textArea);
+            MenuItem copyDoiUrlMenuItem = new MenuItem((String) copyDoiUrlAction.getValue(Action.NAME));
+            copyDoiUrlMenuItem.setOnAction(event -> copyDoiUrlAction.actionPerformed(null));
 
-        List<MenuItem> menuItems = new ArrayList<>();
-        menuItems.add(copyDoiUrlMenuItem);
-        menuItems.add(new SeparatorMenuItem());
-        return menuItems;
+            List<MenuItem> menuItems = new ArrayList<>();
+            menuItems.add(copyDoiUrlMenuItem);
+            menuItems.add(new SeparatorMenuItem());
+            menuItems.addAll(getDefaultMenu(textArea).get());
+            return menuItems;
+        };
     }
 }


### PR DESCRIPTION
I believe I could bring down the performance impact of the context menus to a bare minimum. I reported this in https://github.com/JabRef/jabref/issues/3335 and @tobiasdiez provided me with the hint how this could work. Against his suggestion to not overshoot, I decided to prove my point that even those small context menus have a significant impact because things will sum up in the end and those menus are newly instantiated for every visible field in the editor.

The starting point was the current master-branch and profiling it by going through only 50 bib-entries. This means that the context menus are instantiated for the visible text fields. This has an impact on performance and memory and, unfortunately, it is not only a tiny fraction. 

## Memory

Notable are the columns "Objects", which are all objects that are created by this method and underlying sub calls and the overall "Size".

![mem1](http://i.imgur.com/pjBJSlF.png)

With almost 40% of the overall memory size, it's definitely something to look into.

## Performance

The performance is with 8% not so large but still noticeable. 

![perf1](http://i.imgur.com/STSGgNj.png)

## Fixing it

By using the `Supplier` interface, we can move the instantiation to the point where the user actually right-clicks into the field. I debugged this, and it seems to work nice. The outcome was as expected. Since no one actually triggers the context menu by just browsing through the list, it vanished altogether. Here is the used memory with this PR created by exactly scrolling through the 50 entries. First the memory footprint

![mem2](http://i.imgur.com/dRrKaxs.png)

and here the performance impact

![perf2](http://i.imgur.com/HgJNhLl.png)

In conclusion, this means as long as the user doesn't need a context menu, we have no memory or performance impact at all.

## Note

I updated the `checkstyle` version in the Gradle built. I like to write comments, and now it doesn't prevent me any longer from using `{@link ...}` in doc-comments to classes that are otherwise not used.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
