### PR TITLE
Fix NPE when calling with bib file as cmd argument

### DIFF
--- a/src/main/java/org/jabref/gui/util/FileUpdateMonitor.java
+++ b/src/main/java/org/jabref/gui/util/FileUpdateMonitor.java
@@ -71,7 +71,7 @@ public class FileUpdateMonitor implements Runnable {
      */
     public void addListenerForFile(Path file, FileUpdateListener listener) throws IOException {
         // We can't watch files directly, so monitor their parent directory for updates
-        Path directory = file.getParent();
+        Path directory = file.toAbsolutePath().getParent();
         directory.register(watcher, StandardWatchEventKinds.ENTRY_MODIFY);
 
         listeners.put(file, listener);


### PR DESCRIPTION
Fixes #3342, follow up issue from #3325 
Use toAbsolutePath before calling of getParent

<!-- describe the changes you have made here: what, why, ... -->

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
