### PR TITLE
Upgrade error-prone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id "de.sebastianboegl.shadow.transformer.log4j" version "2.1.1"
     id "com.simonharrer.modernizer" version '1.5.0-1'
     id 'me.champeau.gradle.jmh' version '0.4.3'
-    id 'net.ltgt.errorprone' version '0.0.11'
+    id 'net.ltgt.errorprone' version '0.0.13'
 }
 
 // use the gradle build scan feature: https://scans.gradle.com/get-started


### PR DESCRIPTION
Upgraded error-prone gradle plugin to version 0.0.13 (up from 0.0.11) #hacktoberfest