### PR TITLE
Source tab entry duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - We improved font rendering of the Entry Editor for Linux based systems [#3295](https://github.com/JabRef/jabref/issues/3295)
  - We fixed an issue where JabRef would freeze when trying to replace the original entry after a merge with new information from identifiers like DOI/ISBN etc. [3294](https://github.com/JabRef/jabref/issues/3294)
  - We fixed an issue where JabRef would not show the translated content at some points, although there existed a translation
+ - We fixed an issue where editing in the source tab would override content of other entries [#3352](https://github.com/JabRef/jabref/issues/3352#issue-268580818)
 ### Removed
 
 

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -346,7 +346,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
         tabs.add(new RelatedArticlesTab(Globals.prefs));
 
         // Source tab
-        sourceTab = new SourceTab(panel, movingToDifferentEntry);
+        sourceTab = new SourceTab(panel);
         tabs.add(sourceTab);
         return tabs;
     }

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -8,7 +8,6 @@ import java.util.Objects;
 
 import javax.swing.undo.UndoManager;
 
-import javafx.beans.property.BooleanProperty;
 import javafx.scene.Node;
 import javafx.scene.control.Tooltip;
 

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -44,13 +44,11 @@ public class SourceTab extends EntryEditorTab {
     private final BibDatabaseMode mode;
     private final BasePanel panel;
     private CodeArea codeArea;
-    private BooleanProperty movingToDifferentEntry;
     private UndoManager undoManager;
 
-    public SourceTab(BasePanel panel, BooleanProperty movingToDifferentEntry) {
+    public SourceTab(BasePanel panel) {
         this.mode = panel.getBibDatabaseContext().getMode();
         this.panel = panel;
-        this.movingToDifferentEntry = movingToDifferentEntry;
         this.setText(Localization.lang("%0 source", mode.getFormattedName()));
         this.setTooltip(new Tooltip(Localization.lang("Show/edit %0 source", mode.getFormattedName())));
         this.setGraphic(IconTheme.JabRefIcon.SOURCE.getGraphicNode());
@@ -92,13 +90,6 @@ public class SourceTab extends EntryEditorTab {
             }
         });
 
-        // store source if new entry is selected in the maintable and the source tab is focused
-        EasyBind.subscribe(movingToDifferentEntry, newEntrySelected -> {
-            if (newEntrySelected && codeArea.focusedProperty().get()) {
-                DefaultTaskExecutor.runInJavaFXThread(() -> storeSource(entry));
-            }
-        });
-
         try {
             String srcString = getSourceString(entry, mode);
             codeArea.appendText(srcString);
@@ -126,6 +117,11 @@ public class SourceTab extends EntryEditorTab {
 
     @Override
     protected void bindToEntry(BibEntry entry) {
+        // store source if new entry is selected in the maintable and the source tab is focused
+        if (codeArea != null && codeArea.focusedProperty().get()) {
+            DefaultTaskExecutor.runInJavaFXThread(() -> storeSource(this.currentEntry));
+        }
+
         this.setContent(createSourceEditor(entry, mode));
     }
 

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -19,7 +19,6 @@ import org.jabref.gui.IconTheme;
 import org.jabref.gui.undo.NamedCompound;
 import org.jabref.gui.undo.UndoableChangeType;
 import org.jabref.gui.undo.UndoableFieldChange;
-import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.logic.bibtex.BibEntryWriter;
 import org.jabref.logic.bibtex.InvalidFieldValueException;
 import org.jabref.logic.bibtex.LatexFieldFormatter;

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -116,11 +116,6 @@ public class SourceTab extends EntryEditorTab {
 
     @Override
     protected void bindToEntry(BibEntry entry) {
-        // store source if new entry is selected in the maintable and the source tab is focused
-        if (codeArea != null && codeArea.focusedProperty().get()) {
-            DefaultTaskExecutor.runInJavaFXThread(() -> storeSource());
-        }
-
         this.setContent(createSourceEditor(mode));
     }
 


### PR DESCRIPTION
Adapts the source tab a little better to the new and no longer re-created entry editor. It is a fix for the problem described in this comment https://github.com/JabRef/jabref/issues/3352#issue-268580818 The remaining problems in the issue are not addressed here, so the issue should stay open when merging this and the update flow in the source tab should be reworked in further PRs.

- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
