### PR TITLE
Replace LinkedFiles backslashes with forward slashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,9 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - We fixed an issue where JabRef would freeze when trying to replace the original entry after a merge with new information from identifiers like DOI/ISBN etc. [3294](https://github.com/JabRef/jabref/issues/3294)
  - We fixed an issue where JabRef would not show the translated content at some points, although there existed a translation
  - We fixed an issue where editing in the source tab would override content of other entries [#3352](https://github.com/JabRef/jabref/issues/3352#issue-268580818)
-### Removed
+ - We fixed an issue where file links created under windows could not be opened on Linux/OSX [#3311](https://github.com/JabRef/jabref/issues/3311)
+
+ ### Removed
 
 
 

--- a/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -93,15 +93,6 @@ public class FileUtil {
     }
 
     /**
-     * Checks if the given String is an online link
-     * @param toCheck The String to check
-     * @return True if it starts with http://, https:// or contains www; false otherwise
-     */
-    public static boolean isOnlineLink(String toCheck) {
-        return toCheck.startsWith("http://") || toCheck.startsWith("https://") || toCheck.contains("www.");
-    }
-
-    /**
      * Adds an extension to the given file name. The original extension is not replaced. That means, "demo.bib", ".sav"
      * gets "demo.bib.sav" and not "demo.sav"
      *

--- a/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -31,6 +31,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 public class FileUtil {
+
     public static final boolean IS_POSIX_COMPILANT = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
     public static final int MAXIMUM_FILE_NAME_LENGTH = 255;
     private static final Log LOGGER = LogFactory.getLog(FileUtil.class);
@@ -89,6 +90,15 @@ public class FileUtil {
         }
 
         return fileName;
+    }
+
+    /**
+     * Checks if the given String is an online link
+     * @param toCheck The String to check
+     * @return True if it starts with http://, https:// or contains www; false otherwise
+     */
+    public static boolean isOnlineLink(String toCheck) {
+        return toCheck.startsWith("http://") || toCheck.startsWith("https://") || toCheck.contains("www.");
     }
 
     /**
@@ -260,7 +270,7 @@ public class FileUtil {
      */
     @Deprecated
     public static String createFileNameFromPattern(BibDatabase database, BibEntry entry, String fileNamePattern,
-                                                   LayoutFormatterPreferences prefs) {
+            LayoutFormatterPreferences prefs) {
         String targetName = null;
 
         StringReader sr = new StringReader(fileNamePattern);

--- a/src/main/java/org/jabref/model/entry/LinkedFile.java
+++ b/src/main/java/org/jabref/model/entry/LinkedFile.java
@@ -15,6 +15,7 @@ import javafx.beans.Observable;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 
+import org.jabref.logic.util.io.FileUtil;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.metadata.FileDirectoryPreferences;
 import org.jabref.model.util.FileHelper;
@@ -33,7 +34,14 @@ public class LinkedFile implements Serializable {
 
     public LinkedFile(String description, String link, String fileType) {
         this.description.setValue(Objects.requireNonNull(description));
-        this.link.setValue(Objects.requireNonNull(link));
+
+        String fileLink = Objects.requireNonNull(link);
+        if (!FileUtil.isOnlineLink(fileLink)) {
+            this.link.setValue(fileLink.replace("\\", "/"));
+        } else {
+            this.link.setValue(fileLink);
+        }
+
         this.fileType.setValue(Objects.requireNonNull(fileType));
     }
 
@@ -62,7 +70,11 @@ public class LinkedFile implements Serializable {
     }
 
     public void setLink(String link) {
-        this.link.setValue(link);
+        if (!FileUtil.isOnlineLink(link)) {
+            this.link.setValue(link.replace("\\", "/"));
+        } else {
+            this.link.setValue(link);
+        }
     }
 
     public Observable[] getObservables() {
@@ -125,7 +137,7 @@ public class LinkedFile implements Serializable {
     }
 
     public boolean isOnlineLink() {
-        return link.get().startsWith("http://") || link.get().startsWith("https://") || link.get().contains("www.");
+        return FileUtil.isOnlineLink(link.get());
     }
 
     public Optional<Path> findIn(BibDatabaseContext databaseContext, FileDirectoryPreferences fileDirectoryPreferences) {

--- a/src/main/java/org/jabref/model/entry/LinkedFile.java
+++ b/src/main/java/org/jabref/model/entry/LinkedFile.java
@@ -15,7 +15,6 @@ import javafx.beans.Observable;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 
-import org.jabref.logic.util.io.FileUtil;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.metadata.FileDirectoryPreferences;
 import org.jabref.model.util.FileHelper;
@@ -36,7 +35,7 @@ public class LinkedFile implements Serializable {
         this.description.setValue(Objects.requireNonNull(description));
 
         String fileLink = Objects.requireNonNull(link);
-        if (!FileUtil.isOnlineLink(fileLink)) {
+        if (!FileHelper.isOnlineLink(fileLink)) {
             this.link.setValue(fileLink.replace("\\", "/"));
         } else {
             this.link.setValue(fileLink);
@@ -70,7 +69,7 @@ public class LinkedFile implements Serializable {
     }
 
     public void setLink(String link) {
-        if (!FileUtil.isOnlineLink(link)) {
+        if (!FileHelper.isOnlineLink(link)) {
             this.link.setValue(link.replace("\\", "/"));
         } else {
             this.link.setValue(link);
@@ -137,7 +136,7 @@ public class LinkedFile implements Serializable {
     }
 
     public boolean isOnlineLink() {
-        return FileUtil.isOnlineLink(link.get());
+        return FileHelper.isOnlineLink(link.get());
     }
 
     public Optional<Path> findIn(BibDatabaseContext databaseContext, FileDirectoryPreferences fileDirectoryPreferences) {

--- a/src/main/java/org/jabref/model/util/FileHelper.java
+++ b/src/main/java/org/jabref/model/util/FileHelper.java
@@ -15,6 +15,15 @@ import org.jabref.model.metadata.FileDirectoryPreferences;
 public class FileHelper {
 
     /**
+     * Checks if the given String is an online link
+     * @param toCheck The String to check
+     * @return True if it starts with http://, https:// or contains www; false otherwise
+     */
+    public static boolean isOnlineLink(String toCheck) {
+        return toCheck.startsWith("http://") || toCheck.startsWith("https://") || toCheck.contains("www.");
+    }
+
+    /**
      * Returns the extension of a file or Optional.empty() if the file does not have one (no . in name).
      *
      * @param file

--- a/src/test/java/org/jabref/model/entry/FileFieldWriterTest.java
+++ b/src/test/java/org/jabref/model/entry/FileFieldWriterTest.java
@@ -112,7 +112,7 @@ public class FileFieldWriterTest {
     @Test
     public void testFileFieldWriterGetStringRepresentation() {
         LinkedFile file = new LinkedFile("test", "X:\\Users\\abc.pdf", "PDF");
-        assertEquals("test:X\\:\\\\Users\\\\abc.pdf:PDF", FileFieldWriter.getStringRepresentation(file));
+        assertEquals("test:X\\:/Users/abc.pdf:PDF", FileFieldWriter.getStringRepresentation(file));
     }
 
 


### PR DESCRIPTION
Ensures cross platform compatibility
Fixes #3311 

Tested this under windows and it works fine

<!-- describe the changes you have made here: what, why, ... -->

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
