### PR TITLE
Update entry for every change in the source panel

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -83,7 +83,6 @@ import org.jabref.model.EntryTypes;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.EntryType;
-import org.jabref.model.entry.event.EntryChangedEvent;
 import org.jabref.model.entry.event.FieldAddedOrRemovedEvent;
 import org.jabref.preferences.JabRefPreferences;
 
@@ -196,7 +195,6 @@ public class EntryEditor extends JPanel implements EntryContainer {
 
     public void setEntry(BibEntry entry) {
         this.entry = Objects.requireNonNull(entry);
-        entry.registerListener(this);
         entryType = EntryTypes.getTypeOrDefault(entry.getType(),
                 this.frame.getCurrentBasePanel().getBibDatabaseContext().getMode());
 
@@ -221,11 +219,6 @@ public class EntryEditor extends JPanel implements EntryContainer {
     public synchronized void listen(FieldAddedOrRemovedEvent event) {
         // Rebuild entry editor based on new information (e.g. hide/add tabs)
         recalculateVisibleTabs();
-    }
-
-    @Subscribe
-    public synchronized void listen(EntryChangedEvent event) {
-        DefaultTaskExecutor.runInJavaFXThread(() -> sourceTab.updateSourcePane(entry));
     }
 
     /**
@@ -520,7 +513,6 @@ public class EntryEditor extends JPanel implements EntryContainer {
     }
 
     private void unregisterListeners() {
-        this.entry.unregisterListener(this);
         removeSearchListeners();
 
     }

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -21,6 +21,7 @@ import org.jabref.gui.undo.NamedCompound;
 import org.jabref.gui.undo.UndoableChangeType;
 import org.jabref.gui.undo.UndoableFieldChange;
 import org.jabref.gui.util.BindingsHelper;
+import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.logic.bibtex.BibEntryWriter;
 import org.jabref.logic.bibtex.InvalidFieldValueException;
 import org.jabref.logic.bibtex.LatexFieldFormatter;
@@ -94,15 +95,17 @@ public class SourceTab extends EntryEditorTab {
         // Store source for every change in the source code
         // and update source code for every change of entry field values
         BindingsHelper.bindContentBidirectional(entry.getFieldsObservable(), codeArea.textProperty(), this::storeSource, fields -> {
-            codeArea.clear();
-            try {
-                codeArea.appendText(getSourceString(entry, mode));
-            } catch (IOException ex) {
-                codeArea.setEditable(false);
-                codeArea.appendText(ex.getMessage() + "\n\n" +
-                        Localization.lang("Correct the entry, and reopen editor to display/edit source."));
-                LOGGER.debug("Incorrect entry", ex);
-            }
+            DefaultTaskExecutor.runInJavaFXThread(() -> {
+                codeArea.clear();
+                try {
+                    codeArea.appendText(getSourceString(entry, mode));
+                } catch (IOException ex) {
+                    codeArea.setEditable(false);
+                    codeArea.appendText(ex.getMessage() + "\n\n" +
+                            Localization.lang("Correct the entry, and reopen editor to display/edit source."));
+                    LOGGER.debug("Incorrect entry", ex);
+                }
+            });
         });
     }
 

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -8,17 +8,19 @@ import java.util.Objects;
 
 import javax.swing.undo.UndoManager;
 
-import javafx.scene.Node;
+import javafx.application.Platform;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.ListChangeListener;
 import javafx.scene.control.Tooltip;
 
 import org.jabref.Globals;
 import org.jabref.gui.BasePanel;
-import org.jabref.gui.DialogService;
-import org.jabref.gui.FXDialogService;
 import org.jabref.gui.IconTheme;
 import org.jabref.gui.undo.NamedCompound;
 import org.jabref.gui.undo.UndoableChangeType;
 import org.jabref.gui.undo.UndoableFieldChange;
+import org.jabref.gui.util.BindingsHelper;
 import org.jabref.logic.bibtex.BibEntryWriter;
 import org.jabref.logic.bibtex.InvalidFieldValueException;
 import org.jabref.logic.bibtex.LatexFieldFormatter;
@@ -30,9 +32,11 @@ import org.jabref.model.database.BibDatabaseMode;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.InternalBibtexFields;
 
+import de.saxsys.mvvmfx.utils.validation.ObservableRuleBasedValidator;
+import de.saxsys.mvvmfx.utils.validation.ValidationMessage;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.fxmisc.easybind.EasyBind;
+import org.controlsfx.control.NotificationPane;
 import org.fxmisc.flowless.VirtualizedScrollPane;
 import org.fxmisc.richtext.CodeArea;
 
@@ -40,13 +44,12 @@ public class SourceTab extends EntryEditorTab {
 
     private static final Log LOGGER = LogFactory.getLog(SourceTab.class);
     private final BibDatabaseMode mode;
-    private final BasePanel panel;
-    private CodeArea codeArea;
     private UndoManager undoManager;
+    private final ObjectProperty<ValidationMessage> sourceIsValid = new SimpleObjectProperty<>();
+    private final ObservableRuleBasedValidator sourceValidator = new ObservableRuleBasedValidator(sourceIsValid);
 
     public SourceTab(BasePanel panel) {
         this.mode = panel.getBibDatabaseContext().getMode();
-        this.panel = panel;
         this.setText(Localization.lang("%0 source", mode.getFormattedName()));
         this.setTooltip(new Tooltip(Localization.lang("Show/edit %0 source", mode.getFormattedName())));
         this.setGraphic(IconTheme.JabRefIcon.SOURCE.getGraphicNode());
@@ -62,50 +65,12 @@ public class SourceTab extends EntryEditorTab {
         return stringWriter.getBuffer().toString();
     }
 
-    public void updateSourcePane(BibEntry entry) {
-        if (codeArea != null) {
-            try {
-                codeArea.clear();
-                codeArea.appendText(getSourceString(entry, mode));
-            } catch (IOException ex) {
-                codeArea.appendText(ex.getMessage() + "\n\n" +
-                        Localization.lang("Correct the entry, and reopen editor to display/edit source."));
-                codeArea.setEditable(false);
-                LOGGER.debug("Incorrect entry", ex);
-            }
-        }
-    }
-
-    private Node createSourceEditor(BibDatabaseMode mode) {
-        codeArea = new CodeArea();
+    private CodeArea createSourceEditor() {
+        CodeArea codeArea = new CodeArea();
         codeArea.setWrapText(true);
         codeArea.lookup(".styled-text-area").setStyle(
                 "-fx-font-size: " + Globals.prefs.getFontSizeFX() + "pt;");
-        // store source if new tab is selected (if this one is not focused anymore)
-        EasyBind.subscribe(codeArea.focusedProperty(), focused -> {
-            if (!focused) {
-                storeSource();
-            }
-        });
-
-        try {
-            String srcString = getSourceString(this.currentEntry, mode);
-            codeArea.appendText(srcString);
-        } catch (IOException ex) {
-            codeArea.appendText(ex.getMessage() + "\n\n" +
-                    Localization.lang("Correct the entry, and reopen editor to display/edit source."));
-            codeArea.setEditable(false);
-            LOGGER.debug("Incorrect entry", ex);
-        }
-
-        // set the database to dirty when something is changed in the source tab
-        EasyBind.subscribe(codeArea.beingUpdatedProperty(), updated -> {
-            if (updated) {
-                panel.markBaseChanged();
-            }
-        });
-
-        return new VirtualizedScrollPane<>(codeArea);
+        return codeArea;
     }
 
     @Override
@@ -115,17 +80,40 @@ public class SourceTab extends EntryEditorTab {
 
     @Override
     protected void bindToEntry(BibEntry entry) {
-        this.setContent(createSourceEditor(mode));
+        CodeArea codeArea = createSourceEditor();
+        VirtualizedScrollPane<CodeArea> node = new VirtualizedScrollPane<>(codeArea);
+        NotificationPane notificationPane = new NotificationPane(node);
+        notificationPane.setShowFromTop(false);
+        sourceValidator.getValidationStatus().getMessages().addListener((ListChangeListener<ValidationMessage>) c -> {
+            while (c.next()) {
+                Platform.runLater(() -> sourceValidator.getValidationStatus().getHighestMessage().ifPresent(validationMessage -> notificationPane.show(validationMessage.getMessage())));
+            }
+        });
+        this.setContent(notificationPane);
+
+        // Store source for every change in the source code
+        // and update source code for every change of entry field values
+        BindingsHelper.bindContentBidirectional(entry.getFieldsObservable(), codeArea.textProperty(), this::storeSource, fields -> {
+            codeArea.clear();
+            try {
+                codeArea.appendText(getSourceString(entry, mode));
+            } catch (IOException ex) {
+                codeArea.setEditable(false);
+                codeArea.appendText(ex.getMessage() + "\n\n" +
+                        Localization.lang("Correct the entry, and reopen editor to display/edit source."));
+                LOGGER.debug("Incorrect entry", ex);
+            }
+        });
     }
 
-    private void storeSource() {
-        if (codeArea.getText().isEmpty()) {
+    private void storeSource(String text) {
+        if (text.isEmpty()) {
             return;
         }
 
         BibtexParser bibtexParser = new BibtexParser(Globals.prefs.getImportFormatPreferences());
         try {
-            ParserResult parserResult = bibtexParser.parse(new StringReader(codeArea.getText()));
+            ParserResult parserResult = bibtexParser.parse(new StringReader(text));
             BibDatabase database = parserResult.getDatabase();
 
             if (database.getEntryCount() > 1) {
@@ -185,29 +173,9 @@ public class SourceTab extends EntryEditorTab {
             }
             compound.end();
             undoManager.addEdit(compound);
-
-        } catch (InvalidFieldValueException | IOException ex) {
-            // The source couldn't be parsed, so the user is given an
-            // error message, and the choice to keep or revert the contents
-            // of the source text field.
-
+        } catch (InvalidFieldValueException | IllegalStateException | IOException ex) {
+            sourceIsValid.setValue(ValidationMessage.error(Localization.lang("Problem with parsing entry") + ": " + ex.getMessage()));
             LOGGER.debug("Incorrect source", ex);
-            DialogService dialogService = new FXDialogService();
-            boolean keepEditing = dialogService.showConfirmationDialogAndWait(
-                    Localization.lang("Problem with parsing entry"),
-                    Localization.lang("Error") + ": " + ex.getMessage(),
-                    Localization.lang("Edit"),
-                    Localization.lang("Revert to original source")
-            );
-
-            if (!keepEditing) {
-                // Revert
-                try {
-                    codeArea.replaceText(0, codeArea.getText().length(), getSourceString(this.currentEntry, mode));
-                } catch (IOException e) {
-                    LOGGER.debug("Incorrect source", e);
-                }
-            }
         }
     }
 }

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -843,6 +843,10 @@ public class BibEntry implements Cloneable {
         return setFiles(linkedFiles);
     }
 
+    public ObservableMap<String, String> getFieldsObservable() {
+        return fields;
+    }
+
     private interface GetFieldInterface {
 
         Optional<String> getValueForField(String fieldName);

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -1025,8 +1025,6 @@ Resolve_strings_for_standard_BibTeX_fields_only=Slå_kun_strenge_op_for_standard
 
 resolved=løst
 
-Revert_to_original_source=Ret_tilbage_til_oprindelig_kildekode
-
 Review=Kommentarer
 
 Review_changes=Gennemse_ændringer

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -1025,8 +1025,6 @@ Resolve_strings_for_standard_BibTeX_fields_only=Strings_nur_für_Standard-BibTeX
 
 resolved=davon_aufgelöst
 
-Revert_to_original_source=Original_wiederherstellen
-
 Review=Überprüfung
 
 Review_changes=Änderungen_überprüfen

--- a/src/main/resources/l10n/JabRef_el.properties
+++ b/src/main/resources/l10n/JabRef_el.properties
@@ -1025,8 +1025,6 @@ Resolve_strings_for_standard_BibTeX_fields_only=
 
 resolved=
 
-Revert_to_original_source=
-
 Review=
 
 Review_changes=

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1025,8 +1025,6 @@ Resolve_strings_for_standard_BibTeX_fields_only=Resolve_strings_for_standard_Bib
 
 resolved=resolved
 
-Revert_to_original_source=Revert_to_original_source
-
 Review=Review
 
 Review_changes=Review_changes

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -1025,8 +1025,6 @@ Resolve_strings_for_standard_BibTeX_fields_only=Resolver_cadenas_únicamente_par
 
 resolved=resuelto
 
-Revert_to_original_source=Volver_a_la_fuente_original
-
 Review=Revisar
 
 Review_changes=Revisar_cambios

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -1025,8 +1025,6 @@ Resolve_strings_for_standard_BibTeX_fields_only=
 
 resolved=
 
-Revert_to_original_source=
-
 Review=
 
 Review_changes=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -1025,8 +1025,6 @@ Resolve_strings_for_standard_BibTeX_fields_only=Traiter_les_chaînes_pour_les_ch
 
 resolved=résolu
 
-Revert_to_original_source=Rétablir_le_contenu_initial
-
 Review=Remarques
 
 Review_changes=Revoir_les_changements

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -1025,8 +1025,6 @@ Resolve_strings_for_standard_BibTeX_fields_only=Selesaikan_masalah_string_hanya_
 
 resolved=sudah_diselesaikan
 
-Revert_to_original_source=Kembalikan_ke_sumber_asli
-
 Review=Periksa_ulang
 
 Review_changes=Periksa_ulang_perubahan

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -1025,8 +1025,6 @@ Resolve_strings_for_standard_BibTeX_fields_only=Risolve_le_stringhe_solo_per_i_c
 
 resolved=risolto
 
-Revert_to_original_source=Ripristina_il_contenuto_iniziale
-
 Review=Rivedi
 
 Review_changes=Rivedi_le_modifiche

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -1025,8 +1025,6 @@ Resolve_strings_for_standard_BibTeX_fields_only=文字列をBibTeX標準フィ�
 
 resolved=解消しました
 
-Revert_to_original_source=元のソースに復帰する
-
 Review=論評
 
 Review_changes=変更を検査する

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -1025,8 +1025,6 @@ Resolve_strings_for_standard_BibTeX_fields_only=
 
 resolved=opgelost
 
-Revert_to_original_source=Herstel_naar_originele_bron
-
 Review=Recensie
 
 Review_changes=Bekijk_veranderingen

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -1025,8 +1025,6 @@ Resolve_strings_for_standard_BibTeX_fields_only=Sl\u00e5_opp_strenger_kun_for_st
 
 resolved=tatt_h\u00e5nd_om
 
-Revert_to_original_source=Resett_til_opprinnelig_kildekode
-
 Review=Kommentarer
 
 Review_changes=Se_over_endringer

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -1025,8 +1025,6 @@ Resolve_strings_for_standard_BibTeX_fields_only=Resolver_strings_apenas_para_cam
 
 resolved=resolvido
 
-Revert_to_original_source=Reverter_para_o_original
-
 Review=Revisar
 
 Review_changes=Revisar_mudanças

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -1025,8 +1025,6 @@ Resolve_strings_for_standard_BibTeX_fields_only=Разрешение_для_ст
 
 resolved=разрешено
 
-Revert_to_original_source=Восстановить_исходный_источник
-
 Review=Просмотр
 
 Review_changes=Просмотр_изменений

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -1025,8 +1025,6 @@ Resolve_strings_for_standard_BibTeX_fields_only=Ersätt_bara_strängar_för_de_v
 
 resolved=
 
-Revert_to_original_source=
-
 Review=
 
 Review_changes=Kontrollera_ändringar

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -1025,8 +1025,6 @@ Resolve_strings_for_standard_BibTeX_fields_only=Yalnızca_standart_BibTeX_alan_d
 
 resolved=çözümlendi
 
-Revert_to_original_source=Orijinal_kaynağa_döndür
-
 Review=Gözden_geçir
 
 Review_changes=Değişklikleri_incele

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -1025,8 +1025,6 @@ Resolve_strings_for_standard_BibTeX_fields_only=Chỉ_giải_các_chuỗi_cho_c�
 
 resolved=được_giải
 
-Revert_to_original_source=Trả_ngược_lại_nguồn_ban_đầu
-
 Review=Xem_xét_lại
 
 Review_changes=Xem_xét_lại_các_thay_đổi

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -1025,8 +1025,6 @@ Resolve_strings_for_standard_BibTeX_fields_only=只处理标准_BibTeX_域的简
 
 resolved=已解决
 
-Revert_to_original_source=恢复到初始源
-
 Review=评论
 
 Review_changes=复查修改


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

In https://github.com/JabRef/jabref/issues/3352#issuecomment-339910785, @lenhard suggested to update the entry as soon as the source code is changed (instead of only on focus lost). This is accomplished in this PR. 
Jörg mentioned that the most direct solution does not work since
> the store operation will move the cursor to the end of the source tab.

This problem is circumvented by implementing a proper bidirectional binding between the entry and the source code, which prevents update cycles.

Moreover, in case of a parse error, the message is no longer shown in a dialog but inline as a notification:
![image](https://user-images.githubusercontent.com/5037600/32131671-c8ec5e74-bbe6-11e7-8089-7b3eb0151de1.png)


- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
