### PR TITLE
Update richtext and flowless

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,8 +105,8 @@ dependencies {
     compile 'de.jensd:fontawesomefx-materialdesignfont:1.7.22-4'
     compile 'de.saxsys:mvvmfx-validation:1.7.0'
     compile 'org.fxmisc.easybind:easybind:1.0.3'
-    compile 'org.fxmisc.flowless:flowless:0.5.2'
-    compile 'org.fxmisc.richtext:richtextfx:0.7-M5'
+    compile 'org.fxmisc.flowless:flowless:0.6'
+    compile 'org.fxmisc.richtext:richtextfx:0.8.1'
 
     // Cannot be updated to 9.*.* until Jabref works with Java 9
     compile 'org.controlsfx:controlsfx:8.40.14'


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

@lenhard Can you please try if these updates fixes the `IndexOutOfBounds` exception. They fixed an issue that looks very similar https://github.com/FXMisc/RichTextFX/issues/579.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
