### PR TITLE
Fix problems in source editor

### DIFF
--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -339,7 +339,7 @@ public class EntryEditor extends JPanel implements EntryContainer {
         tabs.add(new RelatedArticlesTab(Globals.prefs));
 
         // Source tab
-        sourceTab = new SourceTab(panel);
+        sourceTab = new SourceTab(panel.getBibDatabaseContext(), panel.getUndoManager(), Globals.prefs.getLatexFieldFormatterPreferences());
         tabs.add(sourceTab);
         return tabs;
     }

--- a/src/main/java/org/jabref/gui/util/DefaultTaskExecutor.java
+++ b/src/main/java/org/jabref/gui/util/DefaultTaskExecutor.java
@@ -28,11 +28,7 @@ public class DefaultTaskExecutor implements TaskExecutor {
     public static <V> V runInJavaFXThread(Callable<V> callable) {
         FutureTask<V> task = new FutureTask<>(callable);
 
-        if (!Platform.isFxApplicationThread()) {
-            Platform.runLater(task);
-        } else {
-            EXECUTOR.submit(task);
-        }
+        Platform.runLater(task);
 
         try {
             return task.get();
@@ -43,11 +39,7 @@ public class DefaultTaskExecutor implements TaskExecutor {
     }
 
     public static void runInJavaFXThread(Runnable runnable) {
-        if (!Platform.isFxApplicationThread()) {
-            Platform.runLater(runnable);
-        } else {
-            EXECUTOR.submit(runnable);
-        }
+        Platform.runLater(runnable);
     }
 
     @Override


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

So here is now a real fix of these problems in the source editor (index out of bounds, paste, select all, update,...). The problem was that updates to the editor were not performed on the javafx thread although they were wraped in a `runInJavaFXThread` call. The reason was that this method would actually submit tasks to the executor, which would then start a new thread. So the fix only happens in `DefaultTaskExecutor`, the rest of the changes are minor cosmetic improvements to get rid of globals or base panels in the source tab.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
