### PR TITLE
Strip invalid prolog when loading CitationStyles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - We fixed several issues with the automatic linking of files in the entry editor where files were not found or not correctly saved in the bibtex source [#3346](https://github.com/JabRef/jabref/issues/3346)
  - We fixed an issue where fetching entries from crossref that had no titles caused an error [#3376](https://github.com/JabRef/jabref/issues/3376)
  - We fixed an issue where the same Java Look and Feel would be listed more than once in the Preferences. [#3391](https://github.com/JabRef/jabref/issues/3391)
- - We avoid the logging of an exception that happens when you do not use citation styles and open the preferences dialog [#3389](https://github.com/JabRef/jabref/issues/3389)
+ - We fixed an issue where errors in citation styles triggered an exception when opening the preferences dialog [#3389](https://github.com/JabRef/jabref/issues/3389)
 
  ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - We fixed several issues with the automatic linking of files in the entry editor where files were not found or not correctly saved in the bibtex source [#3346](https://github.com/JabRef/jabref/issues/3346)
  - We fixed an issue where fetching entries from crossref that had no titles caused an error [#3376](https://github.com/JabRef/jabref/issues/3376)
  - We fixed an issue where the same Java Look and Feel would be listed more than once in the Preferences. [#3391](https://github.com/JabRef/jabref/issues/3391)
+ - We avoid the logging of an exception that happens when you do not use citation styles and open the preferences dialog [#3389](https://github.com/JabRef/jabref/issues/3389)
 
  ### Removed
 

--- a/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
@@ -80,7 +80,7 @@ public class CitationStyle {
 
     private static String stripInvalidProlog(String source) {
         int startIndex = source.indexOf("<");
-        if(startIndex > 0) {
+        if (startIndex > 0) {
             return source.substring(startIndex, source.length());
         } else {
             return source;

--- a/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
@@ -58,7 +58,7 @@ public class CitationStyle {
      * Creates an CitationStyle instance out of the style string
      */
     private static CitationStyle createCitationStyleFromSource(final String source, final String filename) {
-        if (source != null && !source.isEmpty() && filename != null && !filename.isEmpty()) {
+        if (filename != null && !filename.isEmpty() && source != null && !source.isEmpty() && source.startsWith("<")) {
             try {
                 DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
                 InputSource is = new InputSource();
@@ -71,9 +71,7 @@ public class CitationStyle {
                 String title = ((CharacterData) titleNode.item(0).getFirstChild()).getData();
 
                 return new CitationStyle(filename, title, source);
-            } catch (SAXException ignore) {
-                // is triggered when a use has not configured CitationStyles -> ignore
-            } catch (ParserConfigurationException | IOException e) {
+            } catch (ParserConfigurationException | SAXException | IOException e) {
                 LOGGER.error("Error while parsing source", e);
             }
         }

--- a/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
@@ -58,11 +58,11 @@ public class CitationStyle {
      * Creates an CitationStyle instance out of the style string
      */
     private static CitationStyle createCitationStyleFromSource(final String source, final String filename) {
-        if (filename != null && !filename.isEmpty() && source != null && !source.isEmpty() && source.startsWith("<")) {
+        if (filename != null && !filename.isEmpty() && source != null && !source.isEmpty()) {
             try {
                 DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
                 InputSource is = new InputSource();
-                is.setCharacterStream(new StringReader(source));
+                is.setCharacterStream(new StringReader(stripInvalidProlog(source)));
 
                 Document doc = db.parse(is);
                 NodeList nodes = doc.getElementsByTagName("info");
@@ -76,6 +76,15 @@ public class CitationStyle {
             }
         }
         return null;
+    }
+
+    private static String stripInvalidProlog(String source) {
+        int startIndex = source.indexOf("<");
+        if(startIndex > 0) {
+            return source.substring(startIndex, source.length());
+        } else {
+            return source;
+        }
     }
 
     /**

--- a/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CitationStyle.java
@@ -71,7 +71,9 @@ public class CitationStyle {
                 String title = ((CharacterData) titleNode.item(0).getFirstChild()).getData();
 
                 return new CitationStyle(filename, title, source);
-            } catch (ParserConfigurationException | SAXException | IOException e) {
+            } catch (SAXException ignore) {
+                // is triggered when a use has not configured CitationStyles -> ignore
+            } catch (ParserConfigurationException | IOException e) {
                 LOGGER.error("Error while parsing source", e);
             }
         }


### PR DESCRIPTION
Fixes #3389 by skipping invalid parts of the prolog of citation styles.

- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
