### PR TITLE
Fix #3046: No longer allow duplicate fields in customized entry types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - We improved the way metadata is updated in remote databases. [#3235](https://github.com/JabRef/jabref/issues/3235)
  - We improved font rendering of the Entry Editor for Linux based systems [#3295](https://github.com/JabRef/jabref/issues/3295)
  - We fixed an issue where JabRef would freeze when trying to replace the original entry after a merge with new information from identifiers like DOI/ISBN etc. [3294](https://github.com/JabRef/jabref/issues/3294)
+ - We no longer allow to add a field multiple times in customized entry types and thereby fix an issue in the entry editor that resulted from having a field multiple times. [#3046](https://github.com/JabRef/jabref/issues/3046)
  - We fixed an issue where JabRef would not show the translated content at some points, although there existed a translation
  - We fixed an issue where editing in the source tab would override content of other entries [#3352](https://github.com/JabRef/jabref/issues/3352#issue-268580818)
  - We fixed several issues with the automatic linking of files in the entry editor where files were not found or not correctly saved in the bibtex source [#3346](https://github.com/JabRef/jabref/issues/3346)

--- a/src/main/java/org/jabref/gui/customentrytypes/EntryCustomizationDialog.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/EntryCustomizationDialog.java
@@ -66,9 +66,9 @@ public class EntryCustomizationDialog extends JabRefDialog implements ListSelect
     private JButton apply;
     private final List<String> preset = InternalBibtexFields.getAllPublicFieldNames();
     private String lastSelected;
-    private final Map<String, List<String>> reqLists = new HashMap<>();
-    private final Map<String, List<String>> optLists = new HashMap<>();
-    private final Map<String, List<String>> opt2Lists = new HashMap<>();
+    private final Map<String, Set<String>> reqLists = new HashMap<>();
+    private final Map<String, Set<String>> optLists = new HashMap<>();
+    private final Map<String, Set<String>> opt2Lists = new HashMap<>();
     private final Set<String> defaulted = new HashSet<>();
     private final Set<String> changed = new HashSet<>();
 
@@ -198,17 +198,17 @@ public class EntryCustomizationDialog extends JabRefDialog implements ListSelect
         if (selectedTypeName == null) {
             return;
         }
-        List<String> requiredFieldsSelectedType = reqLists.get(selectedTypeName);
+        Set<String> requiredFieldsSelectedType = reqLists.get(selectedTypeName);
         if (requiredFieldsSelectedType == null) {
             Optional<EntryType> type = EntryTypes.getType(selectedTypeName, bibDatabaseMode);
             if (type.isPresent()) {
-                List<String> req = type.get().getRequiredFields();
+                Set<String> req = type.get().getRequiredFields();
 
-                List<String> opt;
+                Set<String> opt;
                 if (biblatexMode) {
                     opt = type.get().getPrimaryOptionalFields();
 
-                    List<String> opt2 = type.get().getSecondaryOptionalFields();
+                    Set<String> opt2 = type.get().getSecondaryOptionalFields();
 
                     optComp2.setFields(opt2);
                     optComp2.setEnabled(true);
@@ -221,12 +221,12 @@ public class EntryCustomizationDialog extends JabRefDialog implements ListSelect
                 optComp.setEnabled(true);
             } else {
                 // New entry
-                reqComp.setFields(new ArrayList<>());
+                reqComp.setFields(new HashSet<>());
                 reqComp.setEnabled(true);
-                optComp.setFields(new ArrayList<>());
+                optComp.setFields(new HashSet<>());
                 optComp.setEnabled(true);
                 if (biblatexMode) {
-                    optComp2.setFields(new ArrayList<>());
+                    optComp2.setFields(new HashSet<>());
                     optComp2.setEnabled(true);
                 }
                 reqComp.requestFocus();
@@ -249,18 +249,18 @@ public class EntryCustomizationDialog extends JabRefDialog implements ListSelect
         List<String> actuallyChangedTypes = new ArrayList<>();
 
         // Iterate over our map of required fields, and list those types if necessary:
-        List<String> types = typeComp.getFields();
-        for (Map.Entry<String, List<String>> stringListEntry : reqLists.entrySet()) {
+        Set<String> types = typeComp.getFields();
+        for (Map.Entry<String, Set<String>> stringListEntry : reqLists.entrySet()) {
             if (!types.contains(stringListEntry.getKey())) {
                 continue;
             }
 
-            List<String> requiredFieldsList = stringListEntry.getValue();
-            List<String> optionalFieldsList = optLists.get(stringListEntry.getKey());
-            List<String> secondaryOptionalFieldsLists = opt2Lists.get(stringListEntry.getKey());
+            Set<String> requiredFieldsList = stringListEntry.getValue();
+            Set<String> optionalFieldsList = optLists.get(stringListEntry.getKey());
+            Set<String> secondaryOptionalFieldsLists = opt2Lists.get(stringListEntry.getKey());
 
             if (secondaryOptionalFieldsLists == null) {
-                secondaryOptionalFieldsLists = new ArrayList<>(0);
+                secondaryOptionalFieldsLists = new HashSet<>(0);
             }
 
             // If this type is already existing, check if any changes have
@@ -278,16 +278,16 @@ public class EntryCustomizationDialog extends JabRefDialog implements ListSelect
 
             Optional<EntryType> oldType = EntryTypes.getType(stringListEntry.getKey(), bibDatabaseMode);
             if (oldType.isPresent()) {
-                List<String> oldRequiredFieldsList = oldType.get().getRequiredFieldsFlat();
-                List<String> oldOptionalFieldsList = oldType.get().getOptionalFields();
+                Set<String> oldRequiredFieldsList = oldType.get().getRequiredFieldsFlat();
+                Set<String> oldOptionalFieldsList = oldType.get().getOptionalFields();
                 if (biblatexMode) {
-                    List<String> oldPrimaryOptionalFieldsLists = oldType.get().getPrimaryOptionalFields();
-                    List<String> oldSecondaryOptionalFieldsList = oldType.get().getSecondaryOptionalFields();
-                    if (equalLists(oldRequiredFieldsList, requiredFieldsList) && equalLists(oldPrimaryOptionalFieldsLists, optionalFieldsList) &&
-                            equalLists(oldSecondaryOptionalFieldsList, secondaryOptionalFieldsLists)) {
+                    Set<String> oldPrimaryOptionalFieldsLists = oldType.get().getPrimaryOptionalFields();
+                    Set<String> oldSecondaryOptionalFieldsList = oldType.get().getSecondaryOptionalFields();
+                    if (oldRequiredFieldsList.equals(requiredFieldsList) && oldPrimaryOptionalFieldsLists.equals(optionalFieldsList) &&
+                            oldSecondaryOptionalFieldsList.equals(secondaryOptionalFieldsLists)) {
                         changesMade = false;
                     }
-                } else if (equalLists(oldRequiredFieldsList, requiredFieldsList) && equalLists(oldOptionalFieldsList, optionalFieldsList)) {
+                } else if (oldRequiredFieldsList.equals(requiredFieldsList) && oldOptionalFieldsList.equals(optionalFieldsList)) {
                     changesMade = false;
                 }
             }
@@ -352,26 +352,6 @@ public class EntryCustomizationDialog extends JabRefDialog implements ListSelect
         }
     }
 
-    private static boolean equalLists(List<String> one, List<String> two) {
-        if ((one == null) && (two == null)) {
-            return true; // Both null.
-        }
-        if ((one == null) || (two == null)) {
-            return false; // One of them null, the other not.
-        }
-        if (one.size() != two.size()) {
-            return false; // Different length.
-        }
-        // If we get here, we know that both are non-null, and that they have the same length.
-        for (int i = 0; i < one.size(); i++) {
-            if (!one.get(i).equals(two.get(i))) {
-                return false;
-            }
-        }
-        // If we get here, all entries have matched.
-        return true;
-    }
-
     private void updateEntriesForChangedTypes(List<String> actuallyChangedTypes) {
         for (BasePanel bp : frame.getBasePanelList()) {
             // get all affected entries
@@ -403,10 +383,10 @@ public class EntryCustomizationDialog extends JabRefDialog implements ListSelect
 
             Optional<EntryType> type = EntryTypes.getStandardType(lastSelected, bibDatabaseMode);
             if (type.isPresent()) {
-                List<String> of = type.get().getOptionalFields();
-                List<String> req = type.get().getRequiredFields();
-                List<String> opt1 = new ArrayList<>();
-                List<String> opt2 = new ArrayList<>();
+                Set<String> of = type.get().getOptionalFields();
+                Set<String> req = type.get().getRequiredFields();
+                Set<String> opt1 = new HashSet<>();
+                Set<String> opt2 = new HashSet<>();
 
                 if (!(of.isEmpty())) {
                     if (biblatexMode) {

--- a/src/main/java/org/jabref/gui/customentrytypes/FieldSetComponent.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/FieldSetComponent.java
@@ -9,7 +9,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
-import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
@@ -217,16 +216,16 @@ class FieldSetComponent extends JPanel {
         remove.setEnabled(en);
     }
 
-    public void setFields(List<String> fields) {
-        DefaultListModel<String> newListModel = new DefaultListModel<>();
-        for (String field : fields) {
-            newListModel.addElement(field);
+    /**
+     * Return the current list.
+     */
+    public Set<String> getFields() {
+        Set<String> res = new HashSet<>(listModel.getSize());
+        Enumeration<String> elements = listModel.elements();
+        while (elements.hasMoreElements()) {
+            res.add(elements.nextElement());
         }
-        this.listModel = newListModel;
-        for (ListDataListener modelListener : modelListeners) {
-            newListModel.addListDataListener(modelListener);
-        }
-        list.setModel(newListModel);
+        return res;
     }
 
     /**
@@ -279,16 +278,16 @@ class FieldSetComponent extends JPanel {
 
     }
 
-    /**
-     * Return the current list.
-     */
-    public List<String> getFields() {
-        List<String> res = new ArrayList<>(listModel.getSize());
-        Enumeration<String> elements = listModel.elements();
-        while (elements.hasMoreElements()) {
-            res.add(elements.nextElement());
+    public void setFields(Set<String> fields) {
+        DefaultListModel<String> newListModel = new DefaultListModel<>();
+        for (String field : fields) {
+            newListModel.addElement(field);
         }
-        return res;
+        this.listModel = newListModel;
+        for (ListDataListener modelListener : modelListeners) {
+            newListModel.addListDataListener(modelListener);
+        }
+        list.setModel(newListModel);
     }
 
     /**

--- a/src/main/java/org/jabref/gui/entryeditor/DeprecatedFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/DeprecatedFieldsTab.java
@@ -1,6 +1,6 @@
 package org.jabref.gui.entryeditor;
 
-import java.util.List;
+import java.util.Collection;
 
 import javafx.scene.control.Tooltip;
 
@@ -21,7 +21,7 @@ public class DeprecatedFieldsTab extends FieldsEditorTab {
     }
 
     @Override
-    protected List<String> determineFieldsToShow(BibEntry entry, EntryType entryType) {
+    protected Collection<String> determineFieldsToShow(BibEntry entry, EntryType entryType) {
         return entryType.getDeprecatedFields();
     }
 }

--- a/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
@@ -1,6 +1,7 @@
 package org.jabref.gui.entryeditor;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,7 +70,7 @@ abstract class FieldsEditorTab extends EntryEditorTab {
         List<Label> labels = new ArrayList<>();
 
         EntryType entryType = EntryTypes.getTypeOrDefault(entry.getType(), databaseContext.getMode());
-        List<String> fields = determineFieldsToShow(entry, entryType);
+        Collection<String> fields = determineFieldsToShow(entry, entryType);
         for (String fieldName : fields) {
             FieldEditorFX fieldEditor = FieldEditors.getForField(fieldName, Globals.TASK_EXECUTOR, new FXDialogService(),
                     Globals.journalAbbreviationLoader, Globals.prefs.getJournalAbbreviationPreferences(), Globals.prefs,
@@ -138,7 +139,7 @@ abstract class FieldsEditorTab extends EntryEditorTab {
         return scrollPane;
     }
 
-    private void setRegularRowLayout(GridPane gridPane, List<String> fields, int rows) {
+    private void setRegularRowLayout(GridPane gridPane, Collection<String> fields, int rows) {
         List<RowConstraints> constraints = new ArrayList<>(rows);
         for (String field : fields) {
             RowConstraints rowExpand = new RowConstraints();
@@ -220,5 +221,5 @@ abstract class FieldsEditorTab extends EntryEditorTab {
         setContent(panel);
     }
 
-    protected abstract List<String> determineFieldsToShow(BibEntry entry, EntryType entryType);
+    protected abstract Collection<String> determineFieldsToShow(BibEntry entry, EntryType entryType);
 }

--- a/src/main/java/org/jabref/gui/entryeditor/OptionalFields2Tab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OptionalFields2Tab.java
@@ -1,6 +1,6 @@
 package org.jabref.gui.entryeditor;
 
-import java.util.List;
+import java.util.Collection;
 
 import javafx.scene.control.Tooltip;
 
@@ -21,7 +21,7 @@ public class OptionalFields2Tab extends FieldsEditorTab {
     }
 
     @Override
-    protected List<String> determineFieldsToShow(BibEntry entry, EntryType entryType) {
+    protected Collection<String> determineFieldsToShow(BibEntry entry, EntryType entryType) {
         return entryType.getSecondaryOptionalNotDeprecatedFields();
     }
 }

--- a/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OptionalFieldsTab.java
@@ -1,6 +1,6 @@
 package org.jabref.gui.entryeditor;
 
-import java.util.List;
+import java.util.Collection;
 
 import javafx.scene.control.Tooltip;
 
@@ -21,7 +21,7 @@ public class OptionalFieldsTab extends FieldsEditorTab {
     }
 
     @Override
-    protected List<String> determineFieldsToShow(BibEntry entry, EntryType entryType) {
+    protected Collection<String> determineFieldsToShow(BibEntry entry, EntryType entryType) {
         return entryType.getPrimaryOptionalFields();
     }
 }

--- a/src/main/java/org/jabref/gui/entryeditor/OtherFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/OtherFieldsTab.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.entryeditor;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,7 +38,7 @@ public class OtherFieldsTab extends FieldsEditorTab {
     }
 
     @Override
-    protected List<String> determineFieldsToShow(BibEntry entry, EntryType entryType) {
+    protected Collection<String> determineFieldsToShow(BibEntry entry, EntryType entryType) {
         List<String> allKnownFields = entryType.getAllFields().stream().map(String::toLowerCase)
                 .collect(Collectors.toList());
         List<String> otherFields = entry.getFieldNames().stream().map(String::toLowerCase)

--- a/src/main/java/org/jabref/gui/entryeditor/RequiredFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/RequiredFieldsTab.java
@@ -1,7 +1,8 @@
 package org.jabref.gui.entryeditor;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import javafx.scene.control.Tooltip;
 
@@ -22,8 +23,8 @@ public class RequiredFieldsTab extends FieldsEditorTab {
     }
 
     @Override
-    protected List<String> determineFieldsToShow(BibEntry entry, EntryType entryType) {
-        List<String> fields = new ArrayList<>();
+    protected Collection<String> determineFieldsToShow(BibEntry entry, EntryType entryType) {
+        Set<String> fields = new LinkedHashSet<>();
         fields.addAll(entryType.getRequiredFieldsFlat());
 
         // Add the edit field for Bibtex-key.

--- a/src/main/java/org/jabref/gui/entryeditor/UserDefinedFieldsTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/UserDefinedFieldsTab.java
@@ -1,5 +1,6 @@
 package org.jabref.gui.entryeditor;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.jabref.gui.IconTheme;
@@ -20,7 +21,7 @@ public class UserDefinedFieldsTab extends FieldsEditorTab {
     }
 
     @Override
-    protected List<String> determineFieldsToShow(BibEntry entry, EntryType entryType) {
+    protected Collection<String> determineFieldsToShow(BibEntry entry, EntryType entryType) {
         return fields;
     }
 }

--- a/src/main/java/org/jabref/logic/bibtex/BibEntryWriter.java
+++ b/src/main/java/org/jabref/logic/bibtex/BibEntryWriter.java
@@ -2,8 +2,8 @@ package org.jabref.logic.bibtex;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
@@ -95,7 +95,7 @@ public class BibEntryWriter {
         EntryType type = EntryTypes.getTypeOrDefault(entry.getType(), bibDatabaseMode);
 
         // Write required fields first.
-        List<String> fields = type.getRequiredFieldsFlat();
+        Collection<String> fields = type.getRequiredFieldsFlat();
         if (fields != null) {
             for (String value : fields) {
                 writeField(entry, out, value, indentation);

--- a/src/main/java/org/jabref/logic/bibtex/DuplicateCheck.java
+++ b/src/main/java/org/jabref/logic/bibtex/DuplicateCheck.java
@@ -1,8 +1,8 @@
 package org.jabref.logic.bibtex;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -80,7 +80,7 @@ public class DuplicateCheck {
 
         EntryType type = EntryTypes.getTypeOrDefault(one.getType(), bibDatabaseMode);
         // The check if they have the same required fields:
-        List<String> var = type.getRequiredFieldsFlat();
+        Collection<String> var = type.getRequiredFieldsFlat();
         double[] req;
         if (var == null) {
             req = new double[]{0., 0.};
@@ -93,7 +93,7 @@ public class DuplicateCheck {
             return req[0] >= DuplicateCheck.DUPLICATE_THRESHOLD;
         }
         // Close to the threshold value, so we take a look at the optional fields, if any:
-        List<String> optionalFields = type.getOptionalFields();
+        Collection<String> optionalFields = type.getOptionalFields();
         if (optionalFields != null) {
             double[] opt = DuplicateCheck.compareFieldSet(optionalFields, one, two);
             double totValue = ((DuplicateCheck.REQUIRED_WEIGHT * req[0] * req[1]) + (opt[0] * opt[1])) / ((req[1] * DuplicateCheck.REQUIRED_WEIGHT) + opt[1]);
@@ -120,7 +120,7 @@ public class DuplicateCheck {
         return false;
     }
 
-    private static double[] compareFieldSet(List<String> fields, BibEntry one, BibEntry two) {
+    private static double[] compareFieldSet(Collection<String> fields, BibEntry one, BibEntry two) {
         double res = 0;
         double totWeights = 0.;
         for (String field : fields) {

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -497,7 +497,7 @@ public class BibEntry implements Cloneable {
      *                  argument can be null, meaning that no attempt will be made to follow crossrefs.
      * @return true if all fields are set or could be resolved, false otherwise.
      */
-    public boolean allFieldsPresent(List<String> allFields, BibDatabase database) {
+    public boolean allFieldsPresent(Collection<String> allFields, BibDatabase database) {
 
         for (String field : allFields) {
             String fieldName = toLowerCase(field);

--- a/src/main/java/org/jabref/model/entry/BiblatexEntryType.java
+++ b/src/main/java/org/jabref/model/entry/BiblatexEntryType.java
@@ -1,9 +1,9 @@
 package org.jabref.model.entry;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -11,23 +11,23 @@ import java.util.stream.Collectors;
  */
 public abstract class BiblatexEntryType implements EntryType {
 
-    private final List<String> requiredFields;
-    private final List<String> optionalFields;
+    private final Set<String> requiredFields;
+    private final Set<String> optionalFields;
 
 
     public BiblatexEntryType() {
-        requiredFields = new ArrayList<>();
-        optionalFields = new ArrayList<>();
+        requiredFields = new LinkedHashSet<>();
+        optionalFields = new LinkedHashSet<>();
     }
 
     @Override
-    public List<String> getOptionalFields() {
-        return Collections.unmodifiableList(optionalFields);
+    public Set<String> getOptionalFields() {
+        return Collections.unmodifiableSet(optionalFields);
     }
 
     @Override
-    public List<String> getRequiredFields() {
-        return Collections.unmodifiableList(requiredFields);
+    public Set<String> getRequiredFields() {
+        return Collections.unmodifiableSet(requiredFields);
     }
 
     void addAllOptional(String... fieldNames) {
@@ -39,28 +39,17 @@ public abstract class BiblatexEntryType implements EntryType {
     }
 
     @Override
-    public List<String> getPrimaryOptionalFields() {
+    public Set<String> getPrimaryOptionalFields() {
         return getOptionalFields();
     }
 
     @Override
-    public List<String> getSecondaryOptionalFields() {
-        List<String> myOptionalFields = getOptionalFields();
-
-        if (myOptionalFields == null) {
-            return Collections.emptyList();
-        }
-
-        return myOptionalFields.stream().filter(field -> !isPrimary(field)).collect(Collectors.toList());
+    public Set<String> getSecondaryOptionalFields() {
+        return getOptionalFields().stream().filter(field -> !isPrimary(field)).collect(Collectors.toSet());
     }
 
     private boolean isPrimary(String field) {
-        List<String> primaryFields = getPrimaryOptionalFields();
-
-        if (primaryFields == null) {
-            return false;
-        }
-        return primaryFields.contains(field);
+        return getPrimaryOptionalFields().contains(field);
     }
 
     @Override

--- a/src/main/java/org/jabref/model/entry/BiblatexEntryTypes.java
+++ b/src/main/java/org/jabref/model/entry/BiblatexEntryTypes.java
@@ -2,8 +2,10 @@ package org.jabref.model.entry;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * This class defines entry types for biblatex support.
@@ -13,10 +15,10 @@ public class BiblatexEntryTypes {
 
     public static final BiblatexEntryType ARTICLE = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(
+        private final Set<String> primaryOptionalFields = Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(
                 FieldName.SUBTITLE, FieldName.EDITOR, FieldName.SERIES, FieldName.VOLUME, FieldName.NUMBER,
                 FieldName.EID, FieldName.ISSUE, FieldName.PAGES, FieldName.NOTE, FieldName.ISSN, FieldName.DOI,
-                FieldName.EPRINT, FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                FieldName.EPRINT, FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.AUTHOR, FieldName.TITLE,
@@ -37,18 +39,18 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
 
     public static final BiblatexEntryType BOOK = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(FieldName.EDITOR,
+        private final Set<String> primaryOptionalFields = Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(FieldName.EDITOR,
                 FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.MAINTITLE, FieldName.MAINSUBTITLE,
                 FieldName.MAINTITLEADDON, FieldName.VOLUME, FieldName.EDITION, FieldName.PUBLISHER, FieldName.ISBN,
                 FieldName.CHAPTER, FieldName.PAGES, FieldName.PAGETOTAL, FieldName.DOI, FieldName.EPRINT,
-                FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.AUTHOR, FieldName.TITLE, FieldName.orFields(FieldName.YEAR, FieldName.DATE));
@@ -69,17 +71,17 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
 
     public static final BiblatexEntryType MVBOOK = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections.unmodifiableList(
+        private final Set<String> primaryOptionalFields = Collections.unmodifiableSet(new LinkedHashSet<>(
                 Arrays.asList(FieldName.EDITOR, FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.EDITION,
                         FieldName.PUBLISHER, FieldName.ISBN, FieldName.PAGETOTAL, FieldName.DOI, FieldName.EPRINT,
-                        FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                        FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.AUTHOR, FieldName.TITLE, FieldName.orFields(FieldName.YEAR, FieldName.DATE));
@@ -98,19 +100,19 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
 
     public static final BiblatexEntryType INBOOK = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections.unmodifiableList(
+        private final Set<String> primaryOptionalFields = Collections.unmodifiableSet(new LinkedHashSet<>(
                 Arrays.asList(FieldName.BOOKAUTHOR, FieldName.EDITOR, FieldName.SUBTITLE, FieldName.TITLEADDON,
                         FieldName.MAINTITLE, FieldName.MAINSUBTITLE, FieldName.MAINTITLEADDON, FieldName.BOOKSUBTITLE,
                         FieldName.BOOKTITLEADDON, FieldName.VOLUME, FieldName.EDITION, FieldName.PUBLISHER,
                         FieldName.ISBN, FieldName.CHAPTER, FieldName.PAGES, FieldName.DOI, FieldName.EPRINT,
-                        FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                        FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.AUTHOR, FieldName.TITLE, FieldName.BOOKTITLE,
@@ -132,7 +134,7 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
@@ -146,17 +148,17 @@ public class BiblatexEntryTypes {
 
         // Same fields as "INBOOK" according to Biblatex 1.0:
         @Override
-        public List<String> getRequiredFields() {
+        public Set<String> getRequiredFields() {
             return BiblatexEntryTypes.INBOOK.getRequiredFields();
         }
 
         @Override
-        public List<String> getOptionalFields() {
+        public Set<String> getOptionalFields() {
             return BiblatexEntryTypes.INBOOK.getOptionalFields();
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return BiblatexEntryTypes.INBOOK.getPrimaryOptionalFields();
         }
     };
@@ -170,27 +172,27 @@ public class BiblatexEntryTypes {
 
         // Same fields as "INBOOK" according to Biblatex 1.0:
         @Override
-        public List<String> getRequiredFields() {
+        public Set<String> getRequiredFields() {
             return BiblatexEntryTypes.INBOOK.getRequiredFields();
         }
 
         @Override
-        public List<String> getOptionalFields() {
+        public Set<String> getOptionalFields() {
             return BiblatexEntryTypes.INBOOK.getOptionalFields();
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return BiblatexEntryTypes.INBOOK.getPrimaryOptionalFields();
         }
     };
 
     public static final BiblatexEntryType BOOKLET = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections
-                .unmodifiableList(Arrays.asList(FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.HOWPUBLISHED,
+        private final Set<String> primaryOptionalFields = Collections
+                .unmodifiableSet(new LinkedHashSet<>(Arrays.asList(FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.HOWPUBLISHED,
                         FieldName.CHAPTER, FieldName.PAGES, FieldName.DOI, FieldName.EPRINT, FieldName.EPRINTCLASS,
-                        FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                        FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.orFields(FieldName.AUTHOR, FieldName.EDITOR), FieldName.TITLE,
@@ -207,18 +209,18 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
 
     public static final BiblatexEntryType COLLECTION = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(
+        private final Set<String> primaryOptionalFields = Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(
                 FieldName.TRANSLATOR, FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.MAINTITLE,
                 FieldName.MAINSUBTITLE, FieldName.MAINTITLEADDON, FieldName.VOLUME, FieldName.EDITION,
                 FieldName.PUBLISHER, FieldName.ISBN, FieldName.CHAPTER, FieldName.PAGES, FieldName.DOI,
-                FieldName.EPRINT, FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                FieldName.EPRINT, FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.EDITOR, FieldName.TITLE, FieldName.orFields(FieldName.YEAR, FieldName.DATE));
@@ -239,17 +241,17 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
 
     public static final BiblatexEntryType MVCOLLECTION = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections
-                .unmodifiableList(Arrays.asList(FieldName.TRANSLATOR, FieldName.SUBTITLE, FieldName.TITLEADDON,
+        private final Set<String> primaryOptionalFields = Collections
+                .unmodifiableSet(new LinkedHashSet<>(Arrays.asList(FieldName.TRANSLATOR, FieldName.SUBTITLE, FieldName.TITLEADDON,
                         FieldName.EDITION, FieldName.PUBLISHER, FieldName.ISBN, FieldName.DOI, FieldName.EPRINT,
-                        FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                        FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.EDITOR, FieldName.TITLE, FieldName.orFields(FieldName.YEAR, FieldName.DATE));
@@ -268,19 +270,19 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
 
     public static final BiblatexEntryType INCOLLECTION = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections
-                .unmodifiableList(Arrays.asList(FieldName.TRANSLATOR, FieldName.SUBTITLE, FieldName.TITLEADDON,
+        private final Set<String> primaryOptionalFields = Collections
+                .unmodifiableSet(new LinkedHashSet<>(Arrays.asList(FieldName.TRANSLATOR, FieldName.SUBTITLE, FieldName.TITLEADDON,
                         FieldName.MAINTITLE, FieldName.MAINSUBTITLE, FieldName.MAINTITLEADDON, FieldName.BOOKSUBTITLE,
                         FieldName.BOOKTITLEADDON, FieldName.VOLUME, FieldName.EDITION, FieldName.PUBLISHER,
                         FieldName.ISBN, FieldName.CHAPTER, FieldName.PAGES, FieldName.DOI, FieldName.EPRINT,
-                        FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                        FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.AUTHOR, FieldName.TITLE, FieldName.BOOKTITLE,
@@ -302,7 +304,7 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
@@ -316,27 +318,27 @@ public class BiblatexEntryTypes {
 
         // Treated as alias of "INCOLLECTION" according to Biblatex 1.0:
         @Override
-        public List<String> getRequiredFields() {
+        public Set<String> getRequiredFields() {
             return BiblatexEntryTypes.INCOLLECTION.getRequiredFields();
         }
 
         @Override
-        public List<String> getOptionalFields() {
+        public Set<String> getOptionalFields() {
             return BiblatexEntryTypes.INCOLLECTION.getOptionalFields();
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return BiblatexEntryTypes.INCOLLECTION.getPrimaryOptionalFields();
         }
     };
 
     public static final BiblatexEntryType MANUAL = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections.unmodifiableList(
-                Arrays.asList(FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.EDITION, FieldName.PUBLISHER,
+        private final Set<String> primaryOptionalFields = Collections.unmodifiableSet(
+                new LinkedHashSet<>(Arrays.asList(FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.EDITION, FieldName.PUBLISHER,
                         FieldName.ISBN, FieldName.CHAPTER, FieldName.PAGES, FieldName.DOI, FieldName.EPRINT,
-                        FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                        FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.orFields(FieldName.AUTHOR, FieldName.EDITOR), FieldName.TITLE,
@@ -354,16 +356,16 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
 
     public static final BiblatexEntryType MISC = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(
+        private final Set<String> primaryOptionalFields = Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(
                 FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.HOWPUBLISHED, FieldName.LOCATION, FieldName.DOI,
-                FieldName.EPRINT, FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                FieldName.EPRINT, FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.orFields(FieldName.AUTHOR, FieldName.EDITOR), FieldName.TITLE,
@@ -380,15 +382,15 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
 
     public static final BiblatexEntryType ONLINE = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(
-                FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.NOTE, FieldName.ORGANIZATION, FieldName.URLDATE));
+        private final Set<String> primaryOptionalFields = Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(
+                FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.NOTE, FieldName.ORGANIZATION, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.orFields(FieldName.AUTHOR, FieldName.EDITOR), FieldName.TITLE,
@@ -404,16 +406,16 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
 
     public static final BiblatexEntryType PATENT = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(FieldName.HOLDER,
+        private final Set<String> primaryOptionalFields = Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(FieldName.HOLDER,
                 FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.DOI, FieldName.EPRINT, FieldName.EPRINTCLASS,
-                FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.AUTHOR, FieldName.TITLE, FieldName.NUMBER,
@@ -430,16 +432,16 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
 
     public static final BiblatexEntryType PERIODICAL = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(
+        private final Set<String> primaryOptionalFields = Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(
                 FieldName.SUBTITLE, FieldName.ISSUETITLE, FieldName.ISSUESUBTITLE, FieldName.ISSN, FieldName.DOI,
-                FieldName.EPRINT, FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                FieldName.EPRINT, FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.EDITOR, FieldName.TITLE, FieldName.orFields(FieldName.YEAR, FieldName.DATE));
@@ -456,7 +458,7 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
@@ -470,28 +472,28 @@ public class BiblatexEntryTypes {
 
         // Treated as alias of "ARTICLE" according to Biblatex 1.0:
         @Override
-        public List<String> getRequiredFields() {
+        public Set<String> getRequiredFields() {
             return BiblatexEntryTypes.ARTICLE.getRequiredFields();
         }
 
         @Override
-        public List<String> getOptionalFields() {
+        public Set<String> getOptionalFields() {
             return BiblatexEntryTypes.ARTICLE.getOptionalFields();
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return BiblatexEntryTypes.ARTICLE.getPrimaryOptionalFields();
         }
     };
 
     public static final BiblatexEntryType PROCEEDINGS = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(
+        private final Set<String> primaryOptionalFields = Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(
                 FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.MAINTITLE, FieldName.MAINSUBTITLE,
                 FieldName.MAINTITLEADDON, FieldName.EVENTTITLE, FieldName.VOLUME, FieldName.PUBLISHER, FieldName.ISBN,
                 FieldName.CHAPTER, FieldName.PAGES, FieldName.PAGETOTAL, FieldName.DOI, FieldName.EPRINT,
-                FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.TITLE, FieldName.orFields(FieldName.YEAR, FieldName.DATE));
@@ -511,18 +513,18 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
 
     public static final BiblatexEntryType MVPROCEEDINGS = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(
+        private final Set<String> primaryOptionalFields = Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(
                 FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.MAINTITLE, FieldName.MAINSUBTITLE,
                 FieldName.MAINTITLEADDON, FieldName.EVENTTITLE, FieldName.VOLUME, FieldName.PUBLISHER, FieldName.ISBN,
                 FieldName.CHAPTER, FieldName.PAGES, FieldName.PAGETOTAL, FieldName.DOI, FieldName.EPRINT,
-                FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.TITLE, FieldName.orFields(FieldName.YEAR, FieldName.DATE));
@@ -541,19 +543,19 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
 
     public static final BiblatexEntryType INPROCEEDINGS = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections
-                .unmodifiableList(Arrays.asList(FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.MAINTITLE,
+        private final Set<String> primaryOptionalFields = Collections
+                .unmodifiableSet(new LinkedHashSet<>(Arrays.asList(FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.MAINTITLE,
                         FieldName.MAINSUBTITLE, FieldName.MAINTITLEADDON, FieldName.BOOKSUBTITLE,
                         FieldName.BOOKTITLEADDON, FieldName.EVENTTITLE, FieldName.VOLUME, FieldName.PUBLISHER,
                         FieldName.ISBN, FieldName.CHAPTER, FieldName.PAGES, FieldName.DOI, FieldName.EPRINT,
-                        FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                        FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.AUTHOR, FieldName.TITLE, FieldName.BOOKTITLE,
@@ -574,7 +576,7 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
@@ -588,17 +590,17 @@ public class BiblatexEntryTypes {
 
         // Treated as alias of "COLLECTION" according to Biblatex 1.0:
         @Override
-        public List<String> getRequiredFields() {
+        public Set<String> getRequiredFields() {
             return BiblatexEntryTypes.COLLECTION.getRequiredFields();
         }
 
         @Override
-        public List<String> getOptionalFields() {
+        public Set<String> getOptionalFields() {
             return BiblatexEntryTypes.COLLECTION.getOptionalFields();
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return BiblatexEntryTypes.COLLECTION.getPrimaryOptionalFields();
         }
     };
@@ -612,17 +614,17 @@ public class BiblatexEntryTypes {
 
         // Treated as alias of "MVCOLLECTION" according to Biblatex 1.0:
         @Override
-        public List<String> getRequiredFields() {
+        public Set<String> getRequiredFields() {
             return BiblatexEntryTypes.MVCOLLECTION.getRequiredFields();
         }
 
         @Override
-        public List<String> getOptionalFields() {
+        public Set<String> getOptionalFields() {
             return BiblatexEntryTypes.MVCOLLECTION.getOptionalFields();
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return BiblatexEntryTypes.MVCOLLECTION.getPrimaryOptionalFields();
         }
     };
@@ -636,27 +638,27 @@ public class BiblatexEntryTypes {
 
         // Treated as alias of "INCOLLECTION" according to Biblatex 1.0:
         @Override
-        public List<String> getRequiredFields() {
+        public Set<String> getRequiredFields() {
             return BiblatexEntryTypes.INCOLLECTION.getRequiredFields();
         }
 
         @Override
-        public List<String> getOptionalFields() {
+        public Set<String> getOptionalFields() {
             return BiblatexEntryTypes.INCOLLECTION.getOptionalFields();
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return BiblatexEntryTypes.INCOLLECTION.getPrimaryOptionalFields();
         }
     };
 
     public static final BiblatexEntryType REPORT = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections.unmodifiableList(
+        private final Set<String> primaryOptionalFields = Collections.unmodifiableSet(new LinkedHashSet<>(
                 Arrays.asList(FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.NUMBER, FieldName.ISRN,
                         FieldName.CHAPTER, FieldName.PAGES, FieldName.PAGETOTAL, FieldName.DOI, FieldName.EPRINT,
-                        FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                        FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.AUTHOR, FieldName.TITLE, FieldName.TYPE, FieldName.INSTITUTION,
@@ -674,7 +676,7 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
@@ -693,10 +695,10 @@ public class BiblatexEntryTypes {
 
     public static final BiblatexEntryType THESIS = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections
-                .unmodifiableList(Arrays.asList(FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.CHAPTER,
+        private final Set<String> primaryOptionalFields = Collections
+                .unmodifiableSet(new LinkedHashSet<>(Arrays.asList(FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.CHAPTER,
                         FieldName.PAGES, FieldName.PAGETOTAL, FieldName.DOI, FieldName.EPRINT, FieldName.EPRINTCLASS,
-                        FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                        FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.AUTHOR, FieldName.TITLE, FieldName.TYPE, FieldName.INSTITUTION,
@@ -713,16 +715,16 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
 
     public static final BiblatexEntryType UNPUBLISHED = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections
-                .unmodifiableList(Arrays.asList(FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.HOWPUBLISHED,
-                        FieldName.PUBSTATE, FieldName.URL, FieldName.URLDATE));
+        private final Set<String> primaryOptionalFields = Collections
+                .unmodifiableSet(new LinkedHashSet<>(Arrays.asList(FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.HOWPUBLISHED,
+                        FieldName.PUBSTATE, FieldName.URL, FieldName.URLDATE)));
 
         {
             addAllRequired(FieldName.AUTHOR, FieldName.TITLE, FieldName.orFields(FieldName.YEAR, FieldName.DATE));
@@ -737,7 +739,7 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
@@ -753,17 +755,17 @@ public class BiblatexEntryTypes {
 
         // Treated as alias of "INPROCEEDINGS" according to Biblatex 1.0:
         @Override
-        public List<String> getRequiredFields() {
+        public Set<String> getRequiredFields() {
             return BiblatexEntryTypes.INPROCEEDINGS.getRequiredFields();
         }
 
         @Override
-        public List<String> getOptionalFields() {
+        public Set<String> getOptionalFields() {
             return BiblatexEntryTypes.INPROCEEDINGS.getOptionalFields();
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return BiblatexEntryTypes.INPROCEEDINGS.getPrimaryOptionalFields();
         }
     };
@@ -777,27 +779,27 @@ public class BiblatexEntryTypes {
 
         // Treated as alias of "ONLINE" according to Biblatex 1.0:
         @Override
-        public List<String> getRequiredFields() {
+        public Set<String> getRequiredFields() {
             return BiblatexEntryTypes.ONLINE.getRequiredFields();
         }
 
         @Override
-        public List<String> getOptionalFields() {
+        public Set<String> getOptionalFields() {
             return BiblatexEntryTypes.ONLINE.getOptionalFields();
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return BiblatexEntryTypes.ONLINE.getPrimaryOptionalFields();
         }
     };
 
     public static final BiblatexEntryType MASTERSTHESIS = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections
-                .unmodifiableList(Arrays.asList(FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.TYPE,
+        private final Set<String> primaryOptionalFields = Collections
+                .unmodifiableSet(new LinkedHashSet<>(Arrays.asList(FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.TYPE,
                         FieldName.CHAPTER, FieldName.PAGES, FieldName.PAGETOTAL, FieldName.DOI, FieldName.EPRINT,
-                        FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                        FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             // Treated as alias of "THESIS", except FieldName.TYPE field is optional
@@ -815,17 +817,17 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
 
     public static final BiblatexEntryType PHDTHESIS = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections
-                .unmodifiableList(Arrays.asList(FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.TYPE,
+        private final Set<String> primaryOptionalFields = Collections
+                .unmodifiableSet(new LinkedHashSet<>(Arrays.asList(FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.TYPE,
                         FieldName.CHAPTER, FieldName.PAGES, FieldName.PAGETOTAL, FieldName.DOI, FieldName.EPRINT,
-                        FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                        FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             // Treated as alias of "THESIS", except FieldName.TYPE field is optional
@@ -843,17 +845,17 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
 
     public static final BiblatexEntryType TECHREPORT = new BiblatexEntryType() {
 
-        private final List<String> primaryOptionalFields = Collections.unmodifiableList(Arrays.asList(
+        private final Set<String> primaryOptionalFields = Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(
                 FieldName.SUBTITLE, FieldName.TITLEADDON, FieldName.TYPE, FieldName.NUMBER, FieldName.ISRN,
                 FieldName.CHAPTER, FieldName.PAGES, FieldName.PAGETOTAL, FieldName.DOI, FieldName.EPRINT,
-                FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE));
+                FieldName.EPRINTCLASS, FieldName.EPRINTTYPE, FieldName.URL, FieldName.URLDATE)));
 
         {
             // Treated as alias of "REPORT", except FieldName.TYPE field is optional
@@ -872,7 +874,7 @@ public class BiblatexEntryTypes {
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return primaryOptionalFields;
         }
     };
@@ -886,17 +888,17 @@ public class BiblatexEntryTypes {
 
         // Treated as alias of "ONLINE" according to Biblatex 1.0:
         @Override
-        public List<String> getRequiredFields() {
+        public Set<String> getRequiredFields() {
             return BiblatexEntryTypes.ONLINE.getRequiredFields();
         }
 
         @Override
-        public List<String> getOptionalFields() {
+        public Set<String> getOptionalFields() {
             return BiblatexEntryTypes.ONLINE.getOptionalFields();
         }
 
         @Override
-        public List<String> getPrimaryOptionalFields() {
+        public Set<String> getPrimaryOptionalFields() {
             return BiblatexEntryTypes.ONLINE.getPrimaryOptionalFields();
         }
     };

--- a/src/main/java/org/jabref/model/entry/BibtexEntryType.java
+++ b/src/main/java/org/jabref/model/entry/BibtexEntryType.java
@@ -1,9 +1,9 @@
 package org.jabref.model.entry;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -11,13 +11,13 @@ import java.util.stream.Collectors;
  */
 public abstract class BibtexEntryType implements EntryType {
 
-    private final List<String> requiredFields;
-    private final List<String> optionalFields;
+    private final Set<String> requiredFields;
+    private final Set<String> optionalFields;
 
 
     public BibtexEntryType() {
-        requiredFields = new ArrayList<>();
-        optionalFields = new ArrayList<>();
+        requiredFields = new LinkedHashSet<>();
+        optionalFields = new LinkedHashSet<>();
     }
 
     void addAllOptional(String... fieldNames) {
@@ -29,13 +29,13 @@ public abstract class BibtexEntryType implements EntryType {
     }
 
     @Override
-    public List<String> getOptionalFields() {
-        return Collections.unmodifiableList(optionalFields);
+    public Set<String> getOptionalFields() {
+        return Collections.unmodifiableSet(optionalFields);
     }
 
     @Override
-    public List<String> getRequiredFields() {
-        return Collections.unmodifiableList(requiredFields);
+    public Set<String> getRequiredFields() {
+        return Collections.unmodifiableSet(requiredFields);
     }
 
     @Override
@@ -44,13 +44,13 @@ public abstract class BibtexEntryType implements EntryType {
     }
 
     @Override
-    public List<String> getPrimaryOptionalFields() {
+    public Set<String> getPrimaryOptionalFields() {
         return getOptionalFields();
     }
 
     @Override
-    public List<String> getSecondaryOptionalFields() {
-        return getOptionalFields().stream().filter(field -> !isPrimary(field)).collect(Collectors.toList());
+    public Set<String> getSecondaryOptionalFields() {
+        return getOptionalFields().stream().filter(field -> !isPrimary(field)).collect(Collectors.toSet());
     }
 
     private boolean isPrimary(String field) {

--- a/src/main/java/org/jabref/model/entry/CustomEntryType.java
+++ b/src/main/java/org/jabref/model/entry/CustomEntryType.java
@@ -1,11 +1,12 @@
 package org.jabref.model.entry;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -18,22 +19,22 @@ public class CustomEntryType implements EntryType {
 
     public static final String ENTRYTYPE_FLAG = "jabref-entrytype: ";
     private final String name;
-    private final List<String> required;
-    private final List<String> optional;
-    private final List<String> primaryOptional;
+    private final Set<String> required;
+    private final Set<String> optional;
+    private final Set<String> primaryOptional;
 
-    public CustomEntryType(String name, List<String> required, List<String> primaryOptional, List<String> secondaryOptional) {
+    public CustomEntryType(String name, Collection<String> required, Collection<String> primaryOptional, Collection<String> secondaryOptional) {
         this.name = StringUtil.capitalizeFirst(name);
-        this.primaryOptional = primaryOptional;
-        this.required = required;
-        this.optional = Stream.concat(primaryOptional.stream(), secondaryOptional.stream()).collect(Collectors.toList());
+        this.primaryOptional = new LinkedHashSet<>(primaryOptional);
+        this.required = new LinkedHashSet<>(required);
+        this.optional = Stream.concat(primaryOptional.stream(), secondaryOptional.stream()).collect(Collectors.toSet());
     }
 
-    public CustomEntryType(String name, List<String> required, List<String> optional) {
+    public CustomEntryType(String name, Collection<String> required, Collection<String> optional) {
         this.name = StringUtil.capitalizeFirst(name);
-        this.required = required;
-        this.optional = optional;
-        this.primaryOptional = optional;
+        this.required = new LinkedHashSet<>(required);
+        this.optional = new LinkedHashSet<>(optional);
+        this.primaryOptional = new LinkedHashSet<>(optional);
     }
 
     public CustomEntryType(String name, String required, String optional) {
@@ -82,25 +83,25 @@ public class CustomEntryType implements EntryType {
     }
 
     @Override
-    public List<String> getOptionalFields() {
-        return Collections.unmodifiableList(optional);
+    public Set<String> getOptionalFields() {
+        return Collections.unmodifiableSet(optional);
     }
 
     @Override
-    public List<String> getRequiredFields() {
-        return Collections.unmodifiableList(required);
+    public Set<String> getRequiredFields() {
+        return Collections.unmodifiableSet(required);
     }
 
     @Override
-    public List<String> getPrimaryOptionalFields() {
-        return Collections.unmodifiableList(primaryOptional);
+    public Set<String> getPrimaryOptionalFields() {
+        return Collections.unmodifiableSet(primaryOptional);
     }
 
     @Override
-    public List<String> getSecondaryOptionalFields() {
-        List<String> result = new ArrayList<>(optional);
+    public Set<String> getSecondaryOptionalFields() {
+        Set<String> result = new LinkedHashSet<>(optional);
         result.removeAll(primaryOptional);
-        return Collections.unmodifiableList(result);
+        return Collections.unmodifiableSet(result);
     }
 
     /**

--- a/src/main/java/org/jabref/model/entry/EntryType.java
+++ b/src/main/java/org/jabref/model/entry/EntryType.java
@@ -1,9 +1,8 @@
 package org.jabref.model.entry;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -25,7 +24,7 @@ public interface EntryType extends Comparable<EntryType> {
      *
      * @return a List of optional field name Strings
      */
-    List<String> getOptionalFields();
+    Set<String> getOptionalFields();
 
     /**
      * Returns all required field names.
@@ -34,7 +33,7 @@ public interface EntryType extends Comparable<EntryType> {
      *
      * @return a List of required field name Strings
      */
-    List<String> getRequiredFields();
+    Set<String> getRequiredFields();
 
     /**
      * Returns all required field names.
@@ -42,13 +41,13 @@ public interface EntryType extends Comparable<EntryType> {
      *
      * @return a List of required field name Strings
      */
-    default List<String> getRequiredFieldsFlat() {
+    default Set<String> getRequiredFieldsFlat() {
         List<String> requiredFlat = getRequiredFields().stream()
                 .map(field -> field.split(FieldName.FIELD_SEPARATOR))
                 .flatMap(Arrays::stream)
                 .collect(Collectors.toList());
 
-        return Collections.unmodifiableList(requiredFlat);
+        return Collections.unmodifiableSet(new LinkedHashSet<>(requiredFlat));
     }
 
     /**
@@ -57,35 +56,35 @@ public interface EntryType extends Comparable<EntryType> {
      *
      * @return a List of all defined field name Strings
      */
-    default List<String> getAllFields() {
+    default Set<String> getAllFields() {
         List<String> allFields = Stream.concat(getRequiredFieldsFlat().stream(), getOptionalFields().stream())
                 .collect(Collectors.toList());
 
-        return Collections.unmodifiableList(allFields);
+        return Collections.unmodifiableSet(new LinkedHashSet<>(allFields));
     }
 
     /**
      * TODO: move inside GUI
      */
-    List<String> getPrimaryOptionalFields();
+    Set<String> getPrimaryOptionalFields();
 
     /**
      * TODO: move inside GUI
      */
-    List<String> getSecondaryOptionalFields();
+    Set<String> getSecondaryOptionalFields();
 
-    default List<String> getDeprecatedFields() {
-        Set<String> deprecatedFields = new HashSet<>(EntryConverter.FIELD_ALIASES_TEX_TO_LTX.keySet());
+    default Set<String> getDeprecatedFields() {
+        Set<String> deprecatedFields = new LinkedHashSet<>(EntryConverter.FIELD_ALIASES_TEX_TO_LTX.keySet());
         deprecatedFields.add(FieldName.YEAR);
         deprecatedFields.add(FieldName.MONTH);
 
         deprecatedFields.retainAll(getOptionalFieldsAndAliases());
 
-        return new ArrayList<>(deprecatedFields);
+        return deprecatedFields;
     }
 
-    default List<String> getSecondaryOptionalNotDeprecatedFields() {
-        List<String> optionalFieldsNotPrimaryOrDeprecated = new ArrayList<>(getSecondaryOptionalFields());
+    default Set<String> getSecondaryOptionalNotDeprecatedFields() {
+        Set<String> optionalFieldsNotPrimaryOrDeprecated = new LinkedHashSet<>(getSecondaryOptionalFields());
         optionalFieldsNotPrimaryOrDeprecated.removeAll(getDeprecatedFields());
         return optionalFieldsNotPrimaryOrDeprecated;
     }
@@ -94,7 +93,7 @@ public interface EntryType extends Comparable<EntryType> {
      * Get list of all optional fields of this entry and their aliases.
      */
     default Set<String> getOptionalFieldsAndAliases() {
-        Set<String> optionalFieldsAndAliases = new HashSet<>();
+        Set<String> optionalFieldsAndAliases = new LinkedHashSet<>();
         for (String field : getOptionalFields()) {
             optionalFieldsAndAliases.add(field);
             if (EntryConverter.FIELD_ALIASES_LTX_TO_TEX.containsKey(field)) {

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -1395,8 +1396,8 @@ public class BibtexParserTest {
         assertEquals("Lecturenotes", customEntryTypes.keySet().toArray()[0]);
         EntryType entryType = customEntryTypes.get("Lecturenotes");
         assertEquals("Lecturenotes", entryType.getName());
-        assertEquals(Arrays.asList("author", "title"), entryType.getRequiredFields());
-        assertEquals(Arrays.asList("language", "url"), entryType.getOptionalFields());
+        assertEquals(new HashSet<>(Arrays.asList("author", "title")), entryType.getRequiredFields());
+        assertEquals(new HashSet<>(Arrays.asList("language", "url")), entryType.getOptionalFields());
     }
 
     @Test

--- a/src/test/java/org/jabref/model/entry/IEEETranEntryTypesTest.java
+++ b/src/test/java/org/jabref/model/entry/IEEETranEntryTypesTest.java
@@ -1,5 +1,6 @@
 package org.jabref.model.entry;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.junit.Assert;
@@ -9,7 +10,7 @@ public class IEEETranEntryTypesTest {
 
     @Test
     public void ctlTypeContainsYesNoFields() {
-        List<String> ctlFields = IEEETranEntryTypes.IEEETRANBSTCTL.getAllFields();
+        Collection<String> ctlFields = IEEETranEntryTypes.IEEETRANBSTCTL.getAllFields();
         List<String> ynFields = InternalBibtexFields.getIEEETranBSTctlYesNoFields();
 
         Assert.assertTrue(ctlFields.containsAll(ynFields));


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
Fixes #3046 (problems in the entry editor caused by duplicate fields in customized entry types) by no longer allowing duplicate fields, i.e. moved from List to Set.

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
