### PR TITLE
Changed fixed position of special columns. #3354

### DIFF
--- a/src/main/java/org/jabref/gui/maintable/MainTableFormat.java
+++ b/src/main/java/org/jabref/gui/maintable/MainTableFormat.java
@@ -113,19 +113,6 @@ public class MainTableFormat implements TableFormat<BibEntry> {
                 tableColumns.add(builder.createFileIconColumn(desiredColumn));
             }
         }
-
-        // Add 'normal' bibtex fields as configured in the preferences
-        // Read table columns from prefs:
-        List<String> colSettings = Globals.prefs.getStringList(JabRefPreferences.COLUMN_NAMES);
-
-        for (String columnName : colSettings) {
-            // stored column name will be used as columnName
-            // There might be more than one field to display, e.g., "author/editor" or "date/year" - so split
-            // at MainTableFormat.COL_DEFINITION_FIELD_SEPARATOR
-            String[] fields = columnName.split(FieldName.FIELD_SEPARATOR);
-            tableColumns.add(new MainTableColumn(columnName, Arrays.asList(fields), database));
-        }
-
         // Add the "special" icon columns (e.g., ranking, file, ...) that are enabled in preferences.
         if (Globals.prefs.getBoolean(JabRefPreferences.SPECIALFIELDSENABLED)) {
             if (Globals.prefs.getBoolean(JabRefPreferences.SHOWCOLUMN_RANKING)) {
@@ -147,6 +134,19 @@ public class MainTableFormat implements TableFormat<BibEntry> {
                 tableColumns.add(builder.buildReadStatusColumn());
             }
         }
+        // Add 'normal' bibtex fields as configured in the preferences
+        // Read table columns from prefs:
+        List<String> colSettings = Globals.prefs.getStringList(JabRefPreferences.COLUMN_NAMES);
+
+        for (String columnName : colSettings) {
+            // stored column name will be used as columnName
+            // There might be more than one field to display, e.g., "author/editor" or "date/year" - so split
+            // at MainTableFormat.COL_DEFINITION_FIELD_SEPARATOR
+            String[] fields = columnName.split(FieldName.FIELD_SEPARATOR);
+            tableColumns.add(new MainTableColumn(columnName, Arrays.asList(fields), database));
+        }
+
+
 
     }
 


### PR DESCRIPTION
When activating the special columns in the preferences, all of them are added to the right of the maintable. Each restart of Jabref or rebuild of the maintable caused the columns to be added on the right side. #3354 

I changed the fixed position of the special columns from the right of the maintable to the right of the URL column. I think this position makes it easier to work with these columns, because you have interesting information like read status in the beginning of the table. 

I did this by rearranging the order in which the columns are added to the maintable. Because the special columns are treated different to the basic columns, you cannot change order within  preferences.

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
