### PR TITLE
Fix removal of special fields when syncing them via keywords

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -182,6 +182,7 @@ Thomas Arildsen
 Thomas Ilsche
 Thorsten Dahlheimer
 Tim van Rossum
+Tim Würtele
 Tobias Boceck
 Tobias Denkinger
 Tobias Diez

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - We fixed an issue where fetching entries from crossref that had no titles caused an error [#3376](https://github.com/JabRef/jabref/issues/3376)
  - We fixed an issue where the same Java Look and Feel would be listed more than once in the Preferences. [#3391](https://github.com/JabRef/jabref/issues/3391)
  - We fixed an issue where errors in citation styles triggered an exception when opening the preferences dialog [#3389](https://github.com/JabRef/jabref/issues/3389)
- - We fixed an issue where special fields (such as **printed**) could not be cleared when syncing special fields via the keywords [#3432](https://github.com/JabRef/jabref/issues/3432)
+ - We fixed an issue where special fields (such as `printed`) could not be cleared when syncing special fields via the keywords [#3432](https://github.com/JabRef/jabref/issues/3432)
 
  ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - We fixed an issue where fetching entries from crossref that had no titles caused an error [#3376](https://github.com/JabRef/jabref/issues/3376)
  - We fixed an issue where the same Java Look and Feel would be listed more than once in the Preferences. [#3391](https://github.com/JabRef/jabref/issues/3391)
  - We fixed an issue where errors in citation styles triggered an exception when opening the preferences dialog [#3389](https://github.com/JabRef/jabref/issues/3389)
+ - We fixed an issue where special fields (such as **printed**) could not be cleared when syncing special fields via the keywords [#3432](https://github.com/JabRef/jabref/issues/3432)
 
  ### Removed
 

--- a/src/main/java/org/jabref/logic/specialfields/SpecialFieldsUtils.java
+++ b/src/main/java/org/jabref/logic/specialfields/SpecialFieldsUtils.java
@@ -46,7 +46,7 @@ public class SpecialFieldsUtils {
 
         KeywordList keyWords = specialField.getKeyWords();
         Optional<Keyword> newValue = entry.getField(specialField.getFieldName()).map(Keyword::new);
-        newValue.map(value -> entry.replaceKeywords(keyWords, newValue, keywordDelimiter))
+        newValue.map(value -> entry.replaceKeywords(keyWords, newValue.get(), keywordDelimiter))
                 .orElseGet(() -> entry.removeKeywords(keyWords, keywordDelimiter))
                 .ifPresent(changeValue -> fieldChanges.add(changeValue));
 

--- a/src/main/java/org/jabref/logic/specialfields/SpecialFieldsUtils.java
+++ b/src/main/java/org/jabref/logic/specialfields/SpecialFieldsUtils.java
@@ -46,9 +46,12 @@ public class SpecialFieldsUtils {
 
         Optional<Keyword> newValue = entry.getField(specialField.getFieldName()).map(Keyword::new);
         KeywordList keyWords = specialField.getKeyWords();
-
-        Optional<FieldChange> change = entry.replaceKeywords(keyWords, newValue, keywordDelimiter);
-        change.ifPresent(changeValue -> fieldChanges.add(changeValue));
+        if(newValue.isPresent()) {
+            Optional<FieldChange> change = entry.replaceKeywords(keyWords, newValue, keywordDelimiter);
+            change.ifPresent(changeValue -> fieldChanges.add(changeValue));
+        } else {
+            entry.removeKeywords(keyWords, keywordDelimiter).ifPresent(changeValue -> fieldChanges.add(changeValue));
+        }
 
         return fieldChanges;
     }

--- a/src/main/java/org/jabref/logic/specialfields/SpecialFieldsUtils.java
+++ b/src/main/java/org/jabref/logic/specialfields/SpecialFieldsUtils.java
@@ -46,7 +46,7 @@ public class SpecialFieldsUtils {
 
         Optional<Keyword> newValue = entry.getField(specialField.getFieldName()).map(Keyword::new);
         KeywordList keyWords = specialField.getKeyWords();
-        if(newValue.isPresent()) {
+        if (newValue.isPresent()) {
             Optional<FieldChange> change = entry.replaceKeywords(keyWords, newValue, keywordDelimiter);
             change.ifPresent(changeValue -> fieldChanges.add(changeValue));
         } else {

--- a/src/main/java/org/jabref/logic/specialfields/SpecialFieldsUtils.java
+++ b/src/main/java/org/jabref/logic/specialfields/SpecialFieldsUtils.java
@@ -44,14 +44,11 @@ public class SpecialFieldsUtils {
     private static List<FieldChange> exportFieldToKeywords(SpecialField specialField, BibEntry entry, Character keywordDelimiter) {
         List<FieldChange> fieldChanges = new ArrayList<>();
 
-        Optional<Keyword> newValue = entry.getField(specialField.getFieldName()).map(Keyword::new);
         KeywordList keyWords = specialField.getKeyWords();
-        if (newValue.isPresent()) {
-            Optional<FieldChange> change = entry.replaceKeywords(keyWords, newValue, keywordDelimiter);
-            change.ifPresent(changeValue -> fieldChanges.add(changeValue));
-        } else {
-            entry.removeKeywords(keyWords, keywordDelimiter).ifPresent(changeValue -> fieldChanges.add(changeValue));
-        }
+        Optional<Keyword> newValue = entry.getField(specialField.getFieldName()).map(Keyword::new);
+        newValue.map(value -> entry.replaceKeywords(keyWords, newValue, keywordDelimiter))
+                .orElseGet(() -> entry.removeKeywords(keyWords, keywordDelimiter))
+                .ifPresent(changeValue -> fieldChanges.add(changeValue));
 
         return fieldChanges;
     }
@@ -62,7 +59,7 @@ public class SpecialFieldsUtils {
     public static List<FieldChange> syncKeywordsFromSpecialFields(BibEntry entry, Character keywordDelimiter) {
         List<FieldChange> fieldChanges = new ArrayList<>();
 
-        for (SpecialField field: SpecialField.values()) {
+        for (SpecialField field : SpecialField.values()) {
             fieldChanges.addAll(SpecialFieldsUtils.exportFieldToKeywords(field, entry, keywordDelimiter));
         }
 
@@ -99,7 +96,7 @@ public class SpecialFieldsUtils {
 
         KeywordList keywordList = entry.getKeywords(keywordDelimiter);
 
-        for (SpecialField field: SpecialField.values()) {
+        for (SpecialField field : SpecialField.values()) {
             fieldChanges.addAll(SpecialFieldsUtils.importKeywordsForField(keywordList, field, entry));
         }
 
@@ -116,7 +113,7 @@ public class SpecialFieldsUtils {
 
         // Priority
         clone = keywordsToAdd.createClone();
-        for (SpecialField field: SpecialField.values()) {
+        for (SpecialField field : SpecialField.values()) {
             clone.retainAll(field.getKeyWords());
             if (!clone.isEmpty()) {
                 keywordsToRemove.addAll(field.getKeyWords());

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -678,6 +678,12 @@ public class BibEntry implements Cloneable {
         return KeywordList.parse(keywordsContent, delimiter);
     }
 
+    public Optional<FieldChange> removeKeywords(KeywordList keywordsToRemove, Character keywordDelimiter) {
+        KeywordList keywordList = getKeywords(keywordDelimiter);
+        keywordList.removeAll(keywordsToRemove);
+        return putKeywords(keywordList, keywordDelimiter);
+    }
+
     public Optional<FieldChange> replaceKeywords(KeywordList keywordsToReplace, Optional<Keyword> newValue,
                                                  Character keywordDelimiter) {
         KeywordList keywordList = getKeywords(keywordDelimiter);

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -105,16 +105,6 @@ public class BibEntry implements Cloneable {
         return setField(FieldName.MONTH, parsedMonth.getJabRefFormat());
     }
 
-    public Optional<FieldChange> replaceKeywords(KeywordList keywordsToReplace, Optional<Keyword> newValue,
-            Character keywordDelimiter) {
-        KeywordList keywordList = getKeywords(keywordDelimiter);
-        if (newValue.isPresent()) {
-            keywordList.replaceAll(keywordsToReplace, newValue.get());
-        }
-
-        return putKeywords(keywordList, keywordDelimiter);
-    }
-
     /**
      * Returns the text stored in the given field of the given bibtex entry
      * which belongs to the given database.
@@ -686,6 +676,16 @@ public class BibEntry implements Cloneable {
     public KeywordList getResolvedKeywords(Character delimiter, BibDatabase database) {
         Optional<String> keywordsContent = getResolvedFieldOrAlias(FieldName.KEYWORDS, database);
         return KeywordList.parse(keywordsContent, delimiter);
+    }
+
+    public Optional<FieldChange> replaceKeywords(KeywordList keywordsToReplace, Optional<Keyword> newValue,
+                                                 Character keywordDelimiter) {
+        KeywordList keywordList = getKeywords(keywordDelimiter);
+        if (newValue.isPresent()) {
+            keywordList.replaceAll(keywordsToReplace, newValue.get());
+        }
+
+        return putKeywords(keywordList, keywordDelimiter);
     }
 
     public Collection<String> getFieldValues() {

--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -684,12 +684,10 @@ public class BibEntry implements Cloneable {
         return putKeywords(keywordList, keywordDelimiter);
     }
 
-    public Optional<FieldChange> replaceKeywords(KeywordList keywordsToReplace, Optional<Keyword> newValue,
+    public Optional<FieldChange> replaceKeywords(KeywordList keywordsToReplace, Keyword newValue,
                                                  Character keywordDelimiter) {
         KeywordList keywordList = getKeywords(keywordDelimiter);
-        if (newValue.isPresent()) {
-            keywordList.replaceAll(keywordsToReplace, newValue.get());
-        }
+        keywordList.replaceAll(keywordsToReplace, newValue);
 
         return putKeywords(keywordList, keywordDelimiter);
     }

--- a/src/test/java/org/jabref/logic/specialfields/SpecialFieldsUtilsTest.java
+++ b/src/test/java/org/jabref/logic/specialfields/SpecialFieldsUtilsTest.java
@@ -1,11 +1,13 @@
 package org.jabref.logic.specialfields;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
 import org.jabref.model.FieldChange;
 import org.jabref.model.entry.BibEntry;
 
+import org.jabref.model.entry.FieldName;
 import org.jabref.model.entry.Keyword;
 import org.jabref.model.entry.KeywordList;
 import org.jabref.model.entry.specialfields.SpecialField;
@@ -82,7 +84,8 @@ public class SpecialFieldsUtilsTest {
         SpecialFieldsUtils.updateField(specialField, specialFieldKeyword.get(), entry, true, true, ',');
         // Remove it
         List<FieldChange> changes = SpecialFieldsUtils.updateField(specialField, specialFieldKeyword.get(), entry, true, true, ',');
-        assertTrue(changes.size() > 0);
+        assertEquals(Arrays.asList(new FieldChange(entry, specialField.getFieldName(), specialFieldKeyword.get(), null),
+                new FieldChange(entry, FieldName.KEYWORDS, specialFieldKeyword.get(), null)), changes);
         KeywordList remainingKeywords = entry.getKeywords(',');
         assertFalse(remainingKeywords.contains(specialFieldKeyword));
     }

--- a/src/test/java/org/jabref/logic/specialfields/SpecialFieldsUtilsTest.java
+++ b/src/test/java/org/jabref/logic/specialfields/SpecialFieldsUtilsTest.java
@@ -6,6 +6,9 @@ import java.util.Optional;
 import org.jabref.model.FieldChange;
 import org.jabref.model.entry.BibEntry;
 
+import org.jabref.model.entry.Keyword;
+import org.jabref.model.entry.KeywordList;
+import org.jabref.model.entry.specialfields.SpecialField;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -68,5 +71,19 @@ public class SpecialFieldsUtilsTest {
         BibEntry entry = new BibEntry();
         List<FieldChange> changes = SpecialFieldsUtils.syncSpecialFieldsFromKeywords(entry, ',');
         assertFalse(changes.size() > 0);
+    }
+
+    @Test
+    public void updateFieldRemovesSpecialFieldKeywordWhenKeywordSyncIsUsed() {
+        BibEntry entry = new BibEntry();
+        SpecialField specialField = SpecialField.PRINTED;
+        Keyword specialFieldKeyword = specialField.getKeyWords().get(0);
+        // Add the special field
+        SpecialFieldsUtils.updateField(specialField, specialFieldKeyword.get(), entry, true, true, ',');
+        // Remove it
+        List<FieldChange> changes = SpecialFieldsUtils.updateField(specialField, specialFieldKeyword.get(), entry, true, true, ',');
+        assertTrue(changes.size() > 0);
+        KeywordList remainingKeywords = entry.getKeywords(',');
+        assertFalse(remainingKeywords.contains(specialFieldKeyword));
     }
 }

--- a/src/test/java/org/jabref/model/entry/BibEntryTests.java
+++ b/src/test/java/org/jabref/model/entry/BibEntryTests.java
@@ -8,11 +8,14 @@ import java.util.Optional;
 
 import org.jabref.model.FieldChange;
 
+import org.jabref.model.entry.specialfields.SpecialField;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class BibEntryTests {
 
@@ -367,6 +370,36 @@ public class BibEntryTests {
         BibEntry entry = new BibEntry();
         entry.setField(FieldName.KEYWORDS, "w1, w2a w2b, w3");
         assertEquals(new KeywordList("w1", "w2a w2b", "w3"), entry.getKeywords(','));
+    }
+
+    @Test
+    public void removeKeywordsOnEntryWithoutKeywordsDoesNothing() {
+        BibEntry entry = new BibEntry();
+        Optional<FieldChange> change = entry.removeKeywords(SpecialField.RANKING.getKeyWords(), ',');
+        assertEquals(Optional.empty(), change);
+    }
+
+    @Test
+    public void removeKeywordsWithEmptyListDoesNothing() {
+        keywordEntry.putKeywords(Arrays.asList("kw1", "kw2"), ',');
+        Optional<FieldChange> change = keywordEntry.removeKeywords(new KeywordList(), ',');
+        assertEquals(Optional.empty(), change);
+    }
+
+    @Test
+    public void removeKeywordsWithNonExistingKeywordsDoesNothing() {
+        keywordEntry.putKeywords(Arrays.asList("kw1", "kw2"), ',');
+        Optional<FieldChange> change = keywordEntry.removeKeywords(KeywordList.parse("kw3, kw4", ','), ',');
+        assertEquals(Optional.empty(), change);
+        assertEquals(2, keywordEntry.getKeywords(',').size());
+    }
+
+    @Test
+    public void removeKeywordsWithExistingKeywordsRemovesThem() {
+        keywordEntry.putKeywords(Arrays.asList("kw1", "kw2", "kw3"), ',');
+        Optional<FieldChange> change = keywordEntry.removeKeywords(KeywordList.parse("kw1, kw2", ','), ',');
+        assertTrue(change.isPresent());
+        assertEquals(KeywordList.parse("kw3", ','), keywordEntry.getKeywords(','));
     }
 
     @Test

--- a/src/test/java/org/jabref/model/entry/BibEntryTests.java
+++ b/src/test/java/org/jabref/model/entry/BibEntryTests.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import com.google.common.collect.Sets;
 import org.jabref.model.FieldChange;
 
 import org.jabref.model.entry.specialfields.SpecialField;
@@ -391,7 +392,7 @@ public class BibEntryTests {
         keywordEntry.putKeywords(Arrays.asList("kw1", "kw2"), ',');
         Optional<FieldChange> change = keywordEntry.removeKeywords(KeywordList.parse("kw3, kw4", ','), ',');
         assertEquals(Optional.empty(), change);
-        assertEquals(2, keywordEntry.getKeywords(',').size());
+        assertEquals(Sets.newHashSet("kw1", "kw2"), keywordEntry.getKeywords(',').toStringList());
     }
 
     @Test


### PR DESCRIPTION
Fixes a bug where JabRef special fields (such as 'printed', 'relevant', ...) were not cleared (e.g. removing the 'printed' flag) when using synchronization of special fields via the bibtex keywords field.

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef

See #3432 for more details.