### PR TITLE
Add Hint for checking master version

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,8 +2,12 @@
 Feature requests,  questions and general feedback is now handled at http://discourse.jabref.org 
 Thanks! --> 
 
+[] I have tested the latest master version from http://builds.jabref.org/master/ and the problem persists
+
+
 JabRef version <!-- version as shown in the about box --> on <!-- Windows 10|Ubuntu 14.04|Mac OS X 10.8|... -->
 <!-- Hint: If you use a development version (available at http://builds.jabref.org/master/), ensure that you use the latest one. -->
+
 
 Steps to reproduce:
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 Feature requests,  questions and general feedback is now handled at http://discourse.jabref.org 
 Thanks! --> 
 
-[ ] I have tested the latest master version from http://builds.jabref.org/master/ and the problem persists
+- [ ] I have tested the latest master version from http://builds.jabref.org/master/ and the problem persists
 
 
 JabRef version <!-- version as shown in the about box --> on <!-- Windows 10|Ubuntu 14.04|Mac OS X 10.8|... -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 Feature requests,  questions and general feedback is now handled at http://discourse.jabref.org 
 Thanks! --> 
 
-[] I have tested the latest master version from http://builds.jabref.org/master/ and the problem persists
+[ ] I have tested the latest master version from http://builds.jabref.org/master/ and the problem persists
 
 
 JabRef version <!-- version as shown in the about box --> on <!-- Windows 10|Ubuntu 14.04|Mac OS X 10.8|... -->


### PR DESCRIPTION
I added a tasklist checkbox with the hint to verify the problem with the latest master

<!-- describe the changes you have made here: what, why, ... -->

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
