### PR TITLE
Declare FreeCiteImportestTest as Fetcher Test

### DIFF
--- a/src/test/java/org/jabref/logic/importer/fileformat/FreeCiteImporterTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/FreeCiteImporterTest.java
@@ -9,13 +9,16 @@ import java.util.Optional;
 import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.logic.util.FileExtensions;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.testutils.category.FetcherTests;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
+@Category(FetcherTests.class)
 public class FreeCiteImporterTest {
 
     private FreeCiteImporter importer;


### PR DESCRIPTION
FreeCite seems to be down atm. While the issues looks to be temporary (http://freecite.library.brown.edu/) is also down, I have declared the test as a fetcher test.
