### PR TITLE
Replace swingx with standard swing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,10 +80,6 @@ dependencies {
     compile 'com.jgoodies:jgoodies-forms:1.9.0'
     compile 'com.jgoodies:jgoodies-looks:2.7.0'
 
-    // Later versions cannot be used. Tested until 1.6.5-1.
-    // See https://github.com/JabRef/jabref/issues/271 for details.
-    compile 'org.swinglabs.swingx:swingx-core:1.6.4'
-
     // update to 2.0.x is not possible - see https://github.com/JabRef/jabref/pull/1096#issuecomment-208857517
     compile 'org.apache.pdfbox:pdfbox:1.8.13'
     compile 'org.apache.pdfbox:fontbox:1.8.13'

--- a/external-libraries.txt
+++ b/external-libraries.txt
@@ -225,11 +225,6 @@ Project: OpenOffice.org
 URL:     http://www.openoffice.org/api/SDK
 License: Apache-2.0
 
-Id:      org.swinglabs.swingx:swingx-core
-Project: SwingX
-URL:     https://swingx.java.net/
-License: LGPL-3.0
-
 Id:      org.xmlunit:xmlunit-core
 Project: XMLUnit
 URL:     http://www.xmlunit.org/

--- a/src/main/java/org/jabref/gui/EntryTypeDialog.java
+++ b/src/main/java/org/jabref/gui/EntryTypeDialog.java
@@ -15,6 +15,7 @@ import java.util.concurrent.ExecutionException;
 
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
@@ -46,7 +47,6 @@ import org.jabref.model.entry.IEEETranEntryTypes;
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.jdesktop.swingx.VerticalLayout;
 
 /**
  * Dialog that prompts the user to choose a type for an entry.
@@ -89,7 +89,7 @@ public class EntryTypeDialog extends JabRefDialog implements ActionListener {
 
     private JPanel createEntryGroupsPanel() {
         JPanel panel = new JPanel();
-        panel.setLayout(new VerticalLayout());
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
 
         if (frame.getCurrentBasePanel().getBibDatabaseContext().isBiblatexMode()) {
             panel.add(createEntryGroupPanel("biblatex", BiblatexEntryTypes.ALL));

--- a/src/main/java/org/jabref/gui/SidePaneComponent.java
+++ b/src/main/java/org/jabref/gui/SidePaneComponent.java
@@ -1,7 +1,9 @@
 package org.jabref.gui;
 
+import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.GridLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
@@ -11,15 +13,13 @@ import javax.swing.BorderFactory;
 import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
+import javax.swing.JPanel;
 import javax.swing.JToolBar;
 import javax.swing.KeyStroke;
 
 import org.jabref.gui.actions.MnemonicAwareAction;
 
-import org.jdesktop.swingx.JXTitledPanel;
-import org.jdesktop.swingx.painter.MattePainter;
-
-public abstract class SidePaneComponent extends JXTitledPanel {
+public abstract class SidePaneComponent extends JPanel {
 
     protected final JButton close = new JButton(IconTheme.JabRefIcon.CLOSE.getSmallIcon());
 
@@ -29,12 +29,9 @@ public abstract class SidePaneComponent extends JXTitledPanel {
 
 
     public SidePaneComponent(SidePaneManager manager, Icon icon, String title) {
-        super(title);
+        super(new BorderLayout());
         this.manager = manager;
 
-        this.add(new JLabel(icon));
-
-        setTitleForeground(new Color(79, 95, 143));
         setBorder(BorderFactory.createEmptyBorder());
 
         close.setMargin(new Insets(0, 0, 0, 0));
@@ -51,15 +48,28 @@ public abstract class SidePaneComponent extends JXTitledPanel {
         down.setBorder(null);
         down.addActionListener(e -> moveDown());
 
-        JToolBar tlb = new OSXCompatibleToolbar();
-        tlb.add(up);
-        tlb.add(down);
-        tlb.add(close);
-        tlb.setOpaque(false);
-        tlb.setFloatable(false);
-        this.getUI().getTitleBar().add(tlb);
-        setTitlePainter(new MattePainter(Color.lightGray));
+        JPanel titlePanel = new JPanel(new BorderLayout());
+        titlePanel.add(new JLabel(icon), BorderLayout.WEST);
+        JLabel titleLabel = new JLabel(title);
+        titleLabel.setOpaque(true);
+        titleLabel.setForeground(new Color(79, 95, 143));
+        titlePanel.add(titleLabel, BorderLayout.CENTER);
 
+        JToolBar toolbar = new OSXCompatibleToolbar();
+        toolbar.add(up);
+        toolbar.add(down);
+        toolbar.add(close);
+        toolbar.setOpaque(false);
+        toolbar.setFloatable(false);
+
+        titlePanel.add(toolbar, BorderLayout.EAST);
+
+
+        this.add(titlePanel, BorderLayout.NORTH);
+    }
+
+    public void setContentContainer(JPanel panel) {
+        this.add(panel, BorderLayout.CENTER);
     }
 
     private void hideAway() {

--- a/src/main/java/org/jabref/gui/SidePaneComponent.java
+++ b/src/main/java/org/jabref/gui/SidePaneComponent.java
@@ -3,7 +3,6 @@ package org.jabref.gui;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.GridLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;

--- a/src/main/java/org/jabref/gui/groups/GroupSidePane.java
+++ b/src/main/java/org/jabref/gui/groups/GroupSidePane.java
@@ -62,8 +62,6 @@ public class GroupSidePane extends SidePaneComponent {
 
         this.frame = frame;
 
-        this.setTitle(Localization.lang("Groups"));
-
         JFXPanel groupsPane = OS.LINUX ? new CustomJFXPanel() : new JFXPanel();
 
         add(groupsPane);


### PR DESCRIPTION
In order to be able to properly move to Java 9 (see #2594), we need to get rid of all accesses of internal APIs. Unfortunately, we also use libraries that make such internal accesses and we need to find a solution for that.

One of these libraries is swingx. Originally by Sun, it is no longer maintained since quite a while we could not even upgrade to the newest version, because of bugs in the library. It is time to get rid of this dependency. This PR replaces the usage of swingx with regular Swing components. Only the new entries dialog and the side pane are affected. For the new entries dialog, the change is trivial (just using a regular layout manager). For the side pane, a few changes are needed, but I can make it roughly resemble the old layout. 

There's one bigger change, though, that I happen to like very much: The side panes are no longer exclusive, you can display them together. That means that I can have the web search and the groups panel open at the same time. Personally, I think that's pretty cool and I would like to keep it that way. You can of course still disable the side panes independent of each other. Here's a screenshot:
![sidepane](https://user-images.githubusercontent.com/1515701/33206932-2e6bd6fa-d10c-11e7-96b2-58f28f0f3bee.png)

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
