### PR TITLE
list all avaiable styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We added a dialog to show that JabRef is working on checking integrity. [#3358](https://github.com/JabRef/jabref/issues/3358)
 - We added an option to mass append to fields via the Quality -> set/clear/append/rename fields dialog. [#2721](https://github.com/JabRef/jabref/issues/2721)
 - We added a check on startup to ensure JabRef is run with an adequate Java version. [3310](https://github.com/JabRef/jabref/issues/3310)
+- In the preference, all installed java Look and Feels are now listed and selectable
 
 ### Fixed
  - We fixed the translation of \textendash in the entry preview [#3307](https://github.com/JabRef/jabref/issues/3307)

--- a/src/main/java/org/jabref/gui/preftabs/AppearancePrefsTab.java
+++ b/src/main/java/org/jabref/gui/preftabs/AppearancePrefsTab.java
@@ -3,9 +3,7 @@ package org.jabref.gui.preftabs;
 import java.awt.BorderLayout;
 import java.awt.Font;
 import java.awt.GridBagLayout;
-import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import javax.swing.BorderFactory;
@@ -17,6 +15,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.UIManager;
+import javax.swing.UIManager.LookAndFeelInfo;
 
 import org.jabref.gui.GUIGlobals;
 import org.jabref.logic.l10n.Localization;
@@ -58,26 +57,16 @@ class AppearancePrefsTab extends JPanel implements PrefsTab {
 
     static class LookAndFeel {
 
-        private static final List<String> LOOKS = Arrays.asList(
-                UIManager.getSystemLookAndFeelClassName(),
-                UIManager.getCrossPlatformLookAndFeelClassName(),
-                "com.jgoodies.looks.plastic.Plastic3DLookAndFeel",
-                "com.jgoodies.looks.windows.WindowsLookAndFeel");
-
         public static Set<String> getAvailableLookAndFeels() {
 
             Set<String> lookAndFeels = new HashSet<>();
+            lookAndFeels.add("com.jgoodies.looks.plastic.Plastic3DLookAndFeel");
+            lookAndFeels.add("com.jgoodies.looks.windows.WindowsLookAndFeel");
 
-            for (String l : LOOKS) {
-                try {
-                    // Try to find L&F
-                    Class.forName(l);
-                    lookAndFeels.add(l);
-                } catch (ClassNotFoundException | IllegalAccessError ignored) {
-                    // LookAndFeel class does not exist or we don't have rights to access it
-                    // Ignore it
-                }
+            for (LookAndFeelInfo info : UIManager.getInstalledLookAndFeels()) {
+                lookAndFeels.add(info.getClassName());
             }
+
             return lookAndFeels;
         }
     }


### PR DESCRIPTION
In regard to the java9 switch I played around with some styles and noticed, that the [Nimbus Lool and Feel](https://docs.oracle.com/javase/tutorial/uiswing/lookandfeel/nimbus.html) is not avaiable 

<!-- describe the changes you have made here: what, why, ... -->


----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
