### PR TITLE
Fix code coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_script:
 script:
   # --scan enables the Gradle build scan, which can be used to investigate the time each action consumes
   # For more information see https://gradle.com/scans/get-started
-  - if [ "$TEST_SUITE" != "guiTest" ] && [ "$TEST_SUITE" != "checkstyle" ]; then ./gradlew $TEST_SUITE $OPTIONS --scan; fi
+  - if [ "$TEST_SUITE" != "guiTest" ] && [ "$TEST_SUITE" != "checkstyle" ] && [ "$TEST_SUITE" != "codecov" ]; then ./gradlew $TEST_SUITE $OPTIONS --scan; fi
   - if [ "$TEST_SUITE" == "checkstyle" ]; then ./gradlew checkstyleMain checkstyleTest checkstyleJmh; fi
   - if [ "$TEST_SUITE" == "guiTest" ]; then ./buildres/gui-tests.sh; fi
   - if [ "$TEST_SUITE" == "codecov" ]; then ./gradlew jacocoJunit5TestReport; bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ script:
 
 after_success:
   # enable codecov report
-  - ./gradlew jacocoTestReport
+  - ./gradlew jacocoJunit5TestReport
   - bash <(curl -s https://codecov.io/bash)
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,13 @@ env:
     - TEST_SUITE=databaseTest
     - TEST_SUITE=guiTest
     - TEST_SUITE=checkstyle
+    - TEST_SUITE=codecov
 
 matrix:
     fast_finish: true
     allow_failures:
       - env: TEST_SUITE=fetcherTest
+      - env: TEST_SUITE=codecov
 
 # JavaFX localization tests need a running X environment
 before_install:
@@ -43,11 +45,7 @@ script:
   - if [ "$TEST_SUITE" != "guiTest" ] && [ "$TEST_SUITE" != "checkstyle" ]; then ./gradlew $TEST_SUITE $OPTIONS --scan; fi
   - if [ "$TEST_SUITE" == "checkstyle" ]; then ./gradlew checkstyleMain checkstyleTest checkstyleJmh; fi
   - if [ "$TEST_SUITE" == "guiTest" ]; then ./buildres/gui-tests.sh; fi
-
-after_success:
-  # enable codecov report
-  - ./gradlew jacocoJunit5TestReport
-  - bash <(curl -s https://codecov.io/bash)
+  - if [ "$TEST_SUITE" == "codecov" ]; then ./gradlew jacocoJunit5TestReport; bash <(curl -s https://codecov.io/bash) fi
 
 after_failure:
   # show test results if build fails

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
   - if [ "$TEST_SUITE" != "guiTest" ] && [ "$TEST_SUITE" != "checkstyle" ]; then ./gradlew $TEST_SUITE $OPTIONS --scan; fi
   - if [ "$TEST_SUITE" == "checkstyle" ]; then ./gradlew checkstyleMain checkstyleTest checkstyleJmh; fi
   - if [ "$TEST_SUITE" == "guiTest" ]; then ./buildres/gui-tests.sh; fi
-  - if [ "$TEST_SUITE" == "codecov" ]; then ./gradlew jacocoJunit5TestReport; bash <(curl -s https://codecov.io/bash) fi
+  - if [ "$TEST_SUITE" == "codecov" ]; then ./gradlew jacocoJunit5TestReport; bash <(curl -s https://codecov.io/bash); fi
 
 after_failure:
   # show test results if build fails

--- a/build.gradle
+++ b/build.gradle
@@ -304,7 +304,8 @@ tasks.withType(Test) {
 }
 
 task jacocoMerge(type: JacocoMerge) {
-    executionData file("$buildDir/jacoco/databaseTest.exec"), file("$buildDir/jacoco/fetcherTest.exec"), file("$buildDir/jacoco/junitPlatformTest.exec")
+    executionData file("$buildDir/jacoco/junitPlatformTest.exec"), file("$buildDir/jacoco/databaseTest.exec"), file("$buildDir/jacoco/fetcherTest.exec")
+    dependsOn junitPlatformTest, databaseTest, fetcherTest
 }
 
 jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -317,6 +317,26 @@ jacocoTestReport {
     }
 }
 
+afterEvaluate {
+    def junitPlatformTest = tasks.junitPlatformTest
+
+    jacoco {
+        applyTo(junitPlatformTest)
+    }
+
+    task jacocoJunit5TestReport(type: JacocoReport) {
+        executionData junitPlatformTest
+        sourceSets sourceSets.main
+        sourceDirectories = files(sourceSets.main.allSource.srcDirs)
+        classDirectories = files(sourceSets.main.output)
+
+        reports {
+            xml.enabled true
+            html.enabled true
+        }
+    }
+}
+
 shadowJar {
     classifier 'fat'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -304,7 +304,7 @@ tasks.withType(Test) {
 }
 
 task jacocoMerge(type: JacocoMerge) {
-    executionData junitPlatformTest, databaseTest, fetcherTest
+    executionData file("$buildDir/jacoco/databaseTest.exec"), file("$buildDir/jacoco/fetcherTest.exec"), file("$buildDir/jacoco/junitPlatformTest.exec")
 }
 
 jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -304,7 +304,7 @@ tasks.withType(Test) {
 }
 
 task jacocoMerge(type: JacocoMerge) {
-    executionData test, databaseTest
+    executionData junitPlatformTest, databaseTest, fetcherTest
 }
 
 jacocoTestReport {
@@ -325,7 +325,8 @@ afterEvaluate {
     }
 
     task jacocoJunit5TestReport(type: JacocoReport) {
-        executionData junitPlatformTest
+        executionData jacocoMerge.destinationFile
+        dependsOn jacocoMerge
         sourceSets sourceSets.main
         sourceDirectories = files(sourceSets.main.allSource.srcDirs)
         classDirectories = files(sourceSets.main.output)


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
With the switch to JUnit 5, the upload of test coverage data to codecov stopped working. Hopefully, this is working again with this PR. The added code essentially comes from https://github.com/junit-team/junit5/issues/1024.

I also included the fetcher tests in the calculation of the code coverage. Was there a reason to exclude them?

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
