### PR TITLE
[WIP] Fix for issue 3109

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ## [Unreleased]
 
 ### Changed
+- Reorganised annotation information on the right side of the "File annotations" tab. [#3109](https://github.com/JabRef/jabref/issues/3109)
+- Changed list item format in list of annotations for the "File annotations" tab. [#3109](https://github.com/JabRef/jabref/issues/3109)
+- Added gui solution for "no annotations in linked file" for the "File annotations" tab. [#3109](https://github.com/JabRef/jabref/issues/3109)
 - We added bracketed expresion support for file search patterns, import file name patterns and file directory patters, in addition to bibtexkey patterns.
 - We added support for '[entrytype]' bracketed expression.
 - Updated French translation

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.fxml
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.fxml
@@ -1,82 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.control.TextArea?>
-<?import javafx.scene.control.Tooltip?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.RowConstraints?>
-<?import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIconView?>
 <?import org.controlsfx.control.MasterDetailPane?>
-<ScrollPane xmlns:fx="http://javafx.com/fxml/1" fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER"
-            styleClass="fileAnnotationTab" xmlns="http://javafx.com/javafx/8.0.112"
-            fx:controller="org.jabref.gui.entryeditor.fileannotationtab.FileAnnotationTabController">
+
+<ScrollPane fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" styleClass="fileAnnotationTab" xmlns="http://javafx.com/javafx/8.0.112" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.entryeditor.fileannotationtab.FileAnnotationTabController">
     <MasterDetailPane dividerPosition="0.6">
         <masterNode>
             <BorderPane>
                 <padding>
-                    <Insets top="5" right="5" bottom="5" left="5"/>
+                    <Insets bottom="5" left="5" right="5" top="5" />
                 </padding>
                 <top>
                     <HBox alignment="BASELINE_LEFT">
-                        <Label text="%Filename" prefWidth="70.0" alignment="BASELINE_LEFT"/>
-                        <ComboBox fx:id="files" maxWidth="Infinity" HBox.hgrow="ALWAYS"/>
+                        <Label alignment="BASELINE_LEFT" prefWidth="70.0" text="%Filename" />
+                        <ComboBox fx:id="files" maxWidth="Infinity" HBox.hgrow="ALWAYS" />
                     </HBox>
                 </top>
                 <center>
-                    <ListView fx:id="annotationList"/>
+                    <ListView fx:id="annotationList" />
                 </center>
             </BorderPane>
         </masterNode>
         <detailNode>
             <GridPane fx:id="grid">
                 <padding>
-                    <Insets top="5" right="5" bottom="5" left="10"/>
+                    <Insets bottom="5" left="10" right="5" top="5" />
                 </padding>
                 <columnConstraints>
-                    <ColumnConstraints hgrow="SOMETIMES" minWidth="60.0" prefWidth="70.0"/>
-                    <ColumnConstraints hgrow="ALWAYS" minWidth="10.0"/>
-                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="20.0"/>
+                    <ColumnConstraints hgrow="SOMETIMES" minWidth="60.0" prefWidth="70.0" />
+                    <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" />
+                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="20.0" />
                 </columnConstraints>
                 <rowConstraints>
-                    <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" valignment="TOP"/>
-                    <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                    <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
-                    <RowConstraints minHeight="10.0" prefHeight="100.0" vgrow="ALWAYS"/>
-                    <RowConstraints minHeight="10.0" prefHeight="100.0" vgrow="ALWAYS"/>
+                    <RowConstraints minHeight="10.0" prefHeight="30.0" valignment="TOP" vgrow="SOMETIMES" />
+                    <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                    <RowConstraints minHeight="10.0" prefHeight="100.0" vgrow="ALWAYS" />
+                    <RowConstraints minHeight="10.0" prefHeight="10.0" vgrow="ALWAYS" />
+               <RowConstraints />
                 </rowConstraints>
-                <Label text="%Author" minHeight="35.0" prefHeight="30.0" GridPane.columnIndex="0" GridPane.rowIndex="1"
-                       alignment="TOP_LEFT"/>
-                <HBox GridPane.columnIndex="1" GridPane.rowIndex="1">
-                    <Label fx:id="author"/>
-                    <Pane HBox.hgrow="ALWAYS"/>
-                    <Button onAction="#copy" styleClass="flatButton">
-                        <graphic>
-                            <MaterialDesignIconView glyphName="CONTENT_COPY"/>
-                        </graphic>
-                        <tooltip>
-                            <Tooltip text="%Copy to clipboard"/>
-                        </tooltip>
-                    </Button>
-                </HBox>
-                <Label text="%Page" GridPane.columnIndex="0" GridPane.rowIndex="2"/>
-                <Label fx:id="page" GridPane.columnIndex="1" GridPane.rowIndex="2"/>
-                <Label text="%Date" GridPane.columnIndex="0" GridPane.rowIndex="3"/>
-                <Label fx:id="date" GridPane.columnIndex="1" GridPane.rowIndex="3"/>
-                <Label text="%Content" GridPane.columnIndex="0" GridPane.rowIndex="4"/>
-                <TextArea fx:id="content" GridPane.columnIndex="1" GridPane.rowIndex="4" editable="false"
-                          wrapText="true"/>
-                <Label text="%Marking" GridPane.columnIndex="0" GridPane.rowIndex="5"/>
-                <TextArea fx:id="marking" GridPane.columnIndex="1" GridPane.rowIndex="5" editable="false"
-                          wrapText="true"/>
+                <Label text="%Marking" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                <TextArea fx:id="marking" editable="false" wrapText="true" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+                <Label text="%Content" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                <TextArea fx:id="content" editable="false" wrapText="true" GridPane.columnIndex="1" GridPane.rowIndex="4" />
             </GridPane>
         </detailNode>
     </MasterDetailPane>

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.fxml
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.fxml
@@ -74,7 +74,7 @@
                         </cursor></MaterialDesignIconView>
                         </graphic>
                         <tooltip>
-                            <Tooltip text="Copy to clipboard" />
+                            <Tooltip text="%Copy to clipboard" />
                         </tooltip>
                     </Button>
                 </HBox>

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.fxml
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.fxml
@@ -37,21 +37,27 @@
                     <Insets bottom="5" left="10" right="5" top="5" />
                 </padding>
                 <columnConstraints>
-                    <ColumnConstraints hgrow="SOMETIMES" minWidth="60.0" prefWidth="70.0" />
+                    <ColumnConstraints hgrow="SOMETIMES" maxWidth="-Infinity" minWidth="10.0" prefWidth="10.0" />
                     <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" />
-                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="20.0" />
+                    <ColumnConstraints hgrow="SOMETIMES" maxWidth="-Infinity" minWidth="10.0" prefWidth="10.0" />
                 </columnConstraints>
                 <rowConstraints>
-                    <RowConstraints minHeight="10.0" prefHeight="30.0" valignment="TOP" vgrow="SOMETIMES" />
-                    <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                    <RowConstraints maxHeight="-Infinity" minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                     <RowConstraints minHeight="10.0" prefHeight="100.0" vgrow="ALWAYS" />
-                    <RowConstraints minHeight="10.0" prefHeight="10.0" vgrow="ALWAYS" />
+                    <RowConstraints maxHeight="-Infinity" minHeight="20.0" prefHeight="40.0" vgrow="ALWAYS" />
                <RowConstraints />
+               <RowConstraints maxHeight="-Infinity" minHeight="10.0" prefHeight="10.0" />
                 </rowConstraints>
-                <Label text="%Marking" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-                <TextArea fx:id="marking" editable="false" wrapText="true" GridPane.columnIndex="1" GridPane.rowIndex="2" />
-                <Label text="%Content" GridPane.columnIndex="1" GridPane.rowIndex="3" />
-                <TextArea fx:id="content" editable="false" wrapText="true" GridPane.columnIndex="1" GridPane.rowIndex="4" />
+                <Label text="%Marking" GridPane.columnIndex="1" GridPane.valignment="BOTTOM">
+               <padding>
+                  <Insets bottom="3.0" />
+               </padding></Label>
+                <TextArea fx:id="marking" editable="false" wrapText="true" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+                <Label text="%Content" GridPane.columnIndex="1" GridPane.rowIndex="2" GridPane.valignment="BOTTOM">
+               <padding>
+                  <Insets bottom="5.0" />
+               </padding></Label>
+                <TextArea fx:id="content" editable="false" wrapText="true" GridPane.columnIndex="1" GridPane.rowIndex="3" />
             </GridPane>
         </detailNode>
     </MasterDetailPane>

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.fxml
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.fxml
@@ -1,15 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIconView?>
 <?import javafx.geometry.Insets?>
+<?import javafx.scene.Cursor?>
+<?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.control.TextArea?>
+<?import javafx.scene.control.Tooltip?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import org.controlsfx.control.MasterDetailPane?>
 
@@ -39,7 +44,7 @@
                 <columnConstraints>
                     <ColumnConstraints hgrow="SOMETIMES" maxWidth="-Infinity" minWidth="10.0" prefWidth="10.0" />
                     <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" />
-                    <ColumnConstraints hgrow="SOMETIMES" maxWidth="-Infinity" minWidth="10.0" prefWidth="10.0" />
+                    <ColumnConstraints hgrow="SOMETIMES" maxWidth="-Infinity" minWidth="40.0" prefWidth="40.0" />
                 </columnConstraints>
                 <rowConstraints>
                     <RowConstraints maxHeight="-Infinity" minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
@@ -58,6 +63,21 @@
                   <Insets bottom="5.0" />
                </padding></Label>
                 <TextArea fx:id="content" editable="false" wrapText="true" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                <HBox GridPane.columnIndex="2" GridPane.rowIndex="1">
+                    <Label fx:id="author" />
+                    <Pane HBox.hgrow="ALWAYS" />
+                    <Button onAction="#copy" styleClass="flatButton">
+                        <graphic>
+                            <MaterialDesignIconView glyphName="CONTENT_COPY">
+                        <cursor>
+                           <Cursor fx:constant="HAND" />
+                        </cursor></MaterialDesignIconView>
+                        </graphic>
+                        <tooltip>
+                            <Tooltip text="Copy to clipboard" />
+                        </tooltip>
+                    </Button>
+                </HBox>
             </GridPane>
         </detailNode>
     </MasterDetailPane>

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.fxml
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.fxml
@@ -37,7 +37,7 @@
             </BorderPane>
         </masterNode>
         <detailNode>
-            <GridPane>
+            <GridPane fx:id="grid">
                 <padding>
                     <Insets top="5" right="5" bottom="5" left="10"/>
                 </padding>

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.fxml
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTab.fxml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIconView?>
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.Cursor?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Label?>
@@ -10,12 +8,14 @@
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.control.Tooltip?>
+<?import javafx.scene.Cursor?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.RowConstraints?>
+<?import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIconView?>
 <?import org.controlsfx.control.MasterDetailPane?>
 
 <ScrollPane fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" styleClass="fileAnnotationTab" xmlns="http://javafx.com/javafx/8.0.112" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.entryeditor.fileannotationtab.FileAnnotationTabController">

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabController.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabController.java
@@ -19,6 +19,7 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.RowConstraints;
 import javafx.scene.text.Font;
+
 import javafx.scene.text.TextAlignment;
 import org.jabref.gui.AbstractController;
 import org.jabref.gui.util.FileUpdateMonitor;
@@ -94,8 +95,8 @@ public class FileAnnotationTabController extends AbstractController<FileAnnotati
                     Label date = new Label(annotation.getDate());
                     Label page = new Label(Localization.lang("Page") + ": " + annotation.getPage());
 
-                    marking.setFont(new Font("System Bold", 14));
-                    marking.setPrefWidth(100);
+                    marking.setFont(new Font("System Bold", 15));
+                    marking.setPrefWidth(250);
                     author.setFont(new Font("System", 14));
 
                     marking.setPrefHeight(10);

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabController.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabController.java
@@ -15,9 +15,9 @@ import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TextArea;
+import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.RowConstraints;
-import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.text.Font;
 import javafx.scene.text.TextAlignment;
 

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabController.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabController.java
@@ -16,11 +16,11 @@ import javafx.scene.control.ListView;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TextArea;
 import javafx.scene.layout.GridPane;
-import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.RowConstraints;
+import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.text.Font;
-
 import javafx.scene.text.TextAlignment;
+
 import org.jabref.gui.AbstractController;
 import org.jabref.gui.util.FileUpdateMonitor;
 import org.jabref.gui.util.ViewModelListCellFactory;

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabController.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabController.java
@@ -15,12 +15,10 @@ import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TextArea;
-//import javafx.scene.layout.*;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.RowConstraints;
 import javafx.scene.text.Font;
-
 import javafx.scene.text.TextAlignment;
 import org.jabref.gui.AbstractController;
 import org.jabref.gui.util.FileUpdateMonitor;

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabController.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabController.java
@@ -57,7 +57,7 @@ public class FileAnnotationTabController extends AbstractController<FileAnnotati
     @FXML
     public void initialize() {
         viewModel = new FileAnnotationTabViewModel(fileAnnotationCache, entry, fileMonitor);
-        
+
         // Set-up files list
         files.getItems().setAll(viewModel.filesProperty().get());
         files.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> viewModel.notifyNewSelectedFile(newValue));
@@ -66,7 +66,7 @@ public class FileAnnotationTabController extends AbstractController<FileAnnotati
         // Set-up annotation list
         annotationList.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
         annotationList.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> viewModel.notifyNewSelectedAnnotation(newValue));
-        annotationList.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> grid.setDisable(newValue == null));
+        //annotationList.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> grid.setDisable(newValue == null));
         ViewModelListCellFactory<FileAnnotationViewModel> cellFactory = new ViewModelListCellFactory<FileAnnotationViewModel>()
                 .withTooltip(FileAnnotationViewModel::getDescription)
                 .withGraphic(annotation -> {
@@ -100,7 +100,7 @@ public class FileAnnotationTabController extends AbstractController<FileAnnotati
         content.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::contentProperty));
         marking.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::markingProperty));
         grid.setDisable(true);
-        //grid.disableProperty().bind(Bindings.and(viewModel.isAnnotationsEmpty(), false));
+        grid.disableProperty().bind(viewModel.isAnnotationsEmpty());
     }
 
     public void copy(ActionEvent event) {

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabController.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabController.java
@@ -66,7 +66,6 @@ public class FileAnnotationTabController extends AbstractController<FileAnnotati
         // Set-up annotation list
         annotationList.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
         annotationList.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> viewModel.notifyNewSelectedAnnotation(newValue));
-        //annotationList.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> grid.setDisable(newValue == null));
         ViewModelListCellFactory<FileAnnotationViewModel> cellFactory = new ViewModelListCellFactory<FileAnnotationViewModel>()
                 .withTooltip(FileAnnotationViewModel::getDescription)
                 .withGraphic(annotation -> {
@@ -99,7 +98,6 @@ public class FileAnnotationTabController extends AbstractController<FileAnnotati
         date.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::dateProperty));
         content.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::contentProperty));
         marking.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::markingProperty));
-        grid.setDisable(true);
         grid.disableProperty().bind(viewModel.isAnnotationsEmpty());
     }
 

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabController.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabController.java
@@ -11,14 +11,15 @@ import javafx.fxml.FXML;
 import javafx.geometry.HPos;
 import javafx.geometry.Pos;
 import javafx.scene.control.ComboBox;
-import javafx.scene.control.Control;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TextArea;
-import javafx.scene.layout.*;
+//import javafx.scene.layout.*;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.RowConstraints;
 import javafx.scene.text.Font;
-import javafx.scene.text.Text;
 
 import javafx.scene.text.TextAlignment;
 import org.jabref.gui.AbstractController;
@@ -94,8 +95,6 @@ public class FileAnnotationTabController extends AbstractController<FileAnnotati
                     Label author = new Label(annotation.getAuthor());
                     Label date = new Label(annotation.getDate());
                     Label page = new Label(Localization.lang("Page") + ": " + annotation.getPage());
-                    //marking.getStyleClass().setAll("marking");
-
 
                     marking.setFont(new Font("System Bold", 14));
                     marking.setPrefWidth(100);
@@ -106,15 +105,13 @@ public class FileAnnotationTabController extends AbstractController<FileAnnotati
                     date.setPrefHeight(10);
                     page.setPrefHeight(30);
 
+                    // add alignment for text in the list
                     marking.setTextAlignment(TextAlignment.LEFT);
                     marking.setAlignment(Pos.TOP_LEFT);
-
                     author.setTextAlignment(TextAlignment.LEFT);
                     author.setAlignment(Pos.TOP_LEFT);
-
                     date.setTextAlignment(TextAlignment.RIGHT);
                     date.setAlignment(Pos.TOP_RIGHT);
-
                     page.setTextAlignment(TextAlignment.RIGHT);
                     page.setAlignment(Pos.TOP_RIGHT);
 
@@ -123,21 +120,6 @@ public class FileAnnotationTabController extends AbstractController<FileAnnotati
                     node.add(date, 1, 0);
                     node.add(page, 1, 1);
 
-                    /*
-                    VBox node = new VBox();
-
-                    Text text = new Text();
-                    text.setText(annotation.getContent());
-                    text.getStyleClass().setAll("text");
-
-                    HBox details = new HBox();
-                    details.getStyleClass().setAll("details");
-                    Text page = new Text();
-                    page.setText(Localization.lang("Page") + ": " + annotation.getPage());
-                    details.getChildren().addAll(page);
-
-                    node.getChildren().addAll(text, details);
-                    node.setMaxWidth(Control.USE_PREF_SIZE);*/
                     return node;
                 });
         annotationList.setCellFactory(cellFactory);
@@ -148,9 +130,6 @@ public class FileAnnotationTabController extends AbstractController<FileAnnotati
                 (ListChangeListener<? super FileAnnotationViewModel>) c -> annotationList.getSelectionModel().selectFirst());
 
         // Set-up details pane
-        //author.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::authorProperty));
-        //page.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::pageProperty));
-        //date.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::dateProperty));
         content.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::contentProperty));
         marking.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::markingProperty));
         grid.disableProperty().bind(viewModel.isAnnotationsEmpty());

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabController.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabController.java
@@ -8,17 +8,19 @@ import javafx.beans.binding.Bindings;
 import javafx.collections.ListChangeListener;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
+import javafx.geometry.HPos;
+import javafx.geometry.Pos;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Control;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TextArea;
-import javafx.scene.layout.GridPane;
-import javafx.scene.layout.HBox;
-import javafx.scene.layout.VBox;
+import javafx.scene.layout.*;
+import javafx.scene.text.Font;
 import javafx.scene.text.Text;
 
+import javafx.scene.text.TextAlignment;
 import org.jabref.gui.AbstractController;
 import org.jabref.gui.util.FileUpdateMonitor;
 import org.jabref.gui.util.ViewModelListCellFactory;
@@ -67,8 +69,61 @@ public class FileAnnotationTabController extends AbstractController<FileAnnotati
         annotationList.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
         annotationList.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> viewModel.notifyNewSelectedAnnotation(newValue));
         ViewModelListCellFactory<FileAnnotationViewModel> cellFactory = new ViewModelListCellFactory<FileAnnotationViewModel>()
-                .withTooltip(FileAnnotationViewModel::getDescription)
+                .withTooltip(FileAnnotationViewModel::getMarking)
                 .withGraphic(annotation -> {
+
+                    GridPane node = new GridPane();
+
+                    ColumnConstraints firstColumn = new ColumnConstraints();
+                    ColumnConstraints secondColumn = new ColumnConstraints();
+                    firstColumn.setPercentWidth(70);
+                    secondColumn.setPercentWidth(30);
+                    firstColumn.setHalignment(HPos.LEFT);
+                    secondColumn.setHalignment(HPos.RIGHT);
+                    node.getColumnConstraints().addAll(firstColumn, secondColumn);
+
+                    RowConstraints firstRow = new RowConstraints();
+                    RowConstraints secondRow = new RowConstraints();
+                    firstRow.setMinHeight(10);
+                    firstRow.setPrefHeight(15);
+                    secondRow.setMinHeight(10);
+                    secondRow.setPrefHeight(35);
+                    node.getRowConstraints().addAll(firstRow, secondRow);
+
+                    Label marking = new Label(annotation.getMarking());
+                    Label author = new Label(annotation.getAuthor());
+                    Label date = new Label(annotation.getDate());
+                    Label page = new Label(Localization.lang("Page") + ": " + annotation.getPage());
+                    //marking.getStyleClass().setAll("marking");
+
+
+                    marking.setFont(new Font("System Bold", 14));
+                    marking.setPrefWidth(100);
+                    author.setFont(new Font("System", 14));
+
+                    marking.setPrefHeight(10);
+                    author.setPrefHeight(30);
+                    date.setPrefHeight(10);
+                    page.setPrefHeight(30);
+
+                    marking.setTextAlignment(TextAlignment.LEFT);
+                    marking.setAlignment(Pos.TOP_LEFT);
+
+                    author.setTextAlignment(TextAlignment.LEFT);
+                    author.setAlignment(Pos.TOP_LEFT);
+
+                    date.setTextAlignment(TextAlignment.RIGHT);
+                    date.setAlignment(Pos.TOP_RIGHT);
+
+                    page.setTextAlignment(TextAlignment.RIGHT);
+                    page.setAlignment(Pos.TOP_RIGHT);
+
+                    node.add(marking, 0, 0);
+                    node.add(author, 0, 1);
+                    node.add(date, 1, 0);
+                    node.add(page, 1, 1);
+
+                    /*
                     VBox node = new VBox();
 
                     Text text = new Text();
@@ -82,7 +137,7 @@ public class FileAnnotationTabController extends AbstractController<FileAnnotati
                     details.getChildren().addAll(page);
 
                     node.getChildren().addAll(text, details);
-                    node.setMaxWidth(Control.USE_PREF_SIZE);
+                    node.setMaxWidth(Control.USE_PREF_SIZE);*/
                     return node;
                 });
         annotationList.setCellFactory(cellFactory);
@@ -93,9 +148,9 @@ public class FileAnnotationTabController extends AbstractController<FileAnnotati
                 (ListChangeListener<? super FileAnnotationViewModel>) c -> annotationList.getSelectionModel().selectFirst());
 
         // Set-up details pane
-        author.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::authorProperty));
-        page.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::pageProperty));
-        date.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::dateProperty));
+        //author.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::authorProperty));
+        //page.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::pageProperty));
+        //date.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::dateProperty));
         content.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::contentProperty));
         marking.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::markingProperty));
         grid.disableProperty().bind(viewModel.isAnnotationsEmpty());

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabController.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabController.java
@@ -14,6 +14,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TextArea;
+import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
@@ -43,6 +44,8 @@ public class FileAnnotationTabController extends AbstractController<FileAnnotati
     public TextArea content;
     @FXML
     public TextArea marking;
+    @FXML
+    public GridPane grid;
 
     @Inject
     private FileAnnotationCache fileAnnotationCache;
@@ -54,7 +57,7 @@ public class FileAnnotationTabController extends AbstractController<FileAnnotati
     @FXML
     public void initialize() {
         viewModel = new FileAnnotationTabViewModel(fileAnnotationCache, entry, fileMonitor);
-
+        
         // Set-up files list
         files.getItems().setAll(viewModel.filesProperty().get());
         files.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> viewModel.notifyNewSelectedFile(newValue));
@@ -63,6 +66,7 @@ public class FileAnnotationTabController extends AbstractController<FileAnnotati
         // Set-up annotation list
         annotationList.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
         annotationList.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> viewModel.notifyNewSelectedAnnotation(newValue));
+        annotationList.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> grid.setDisable(newValue == null));
         ViewModelListCellFactory<FileAnnotationViewModel> cellFactory = new ViewModelListCellFactory<FileAnnotationViewModel>()
                 .withTooltip(FileAnnotationViewModel::getDescription)
                 .withGraphic(annotation -> {
@@ -95,6 +99,8 @@ public class FileAnnotationTabController extends AbstractController<FileAnnotati
         date.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::dateProperty));
         content.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::contentProperty));
         marking.textProperty().bind(EasyBind.select(viewModel.currentAnnotationProperty()).selectObject(FileAnnotationViewModel::markingProperty));
+        grid.setDisable(true);
+        //grid.disableProperty().bind(Bindings.and(viewModel.isAnnotationsEmpty(), false));
     }
 
     public void copy(ActionEvent event) {

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabViewModel.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabViewModel.java
@@ -60,8 +60,8 @@ public class FileAnnotationTabViewModel extends AbstractViewModel {
         return currentAnnotation;
     }
 
-    public boolean isAnnotationsEmpty() {
-        return annotations.isEmpty();
+    public ObjectProperty<Boolean> isAnnotationsEmpty() {
+        return annotaionEmpty;
     }
 
     public ListProperty<FileAnnotationViewModel> annotationsProperty() {
@@ -89,7 +89,10 @@ public class FileAnnotationTabViewModel extends AbstractViewModel {
                 .map(FileAnnotationViewModel::new)
                 .collect(Collectors.toList());
         annotations.setAll(newAnnotations);
-
+        if (annotations.isEmpty())
+            annotaionEmpty.setValue(true);
+        else
+            annotaionEmpty.setValue(false);
         try {
             fileMonitor.addListenerForFile(currentFile, fileListener);
         } catch (IOException e) {

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabViewModel.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabViewModel.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 
 import javafx.beans.property.ListProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.SimpleListProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
@@ -35,7 +36,7 @@ public class FileAnnotationTabViewModel extends AbstractViewModel {
     private final ListProperty<FileAnnotationViewModel> annotations = new SimpleListProperty<>(FXCollections.observableArrayList());
     private final ListProperty<Path> files = new SimpleListProperty<>(FXCollections.observableArrayList());
     private final ObjectProperty<FileAnnotationViewModel> currentAnnotation = new SimpleObjectProperty<>();
-    private final ObjectProperty<Boolean> annotationEmpty = new SimpleObjectProperty<>(null);
+    private ReadOnlyBooleanProperty annotationEmpty;
 
     private final FileAnnotationCache cache;
     private final BibEntry entry;
@@ -60,7 +61,7 @@ public class FileAnnotationTabViewModel extends AbstractViewModel {
         return currentAnnotation;
     }
 
-    public ObjectProperty<Boolean> isAnnotationsEmpty() {
+    public ReadOnlyBooleanProperty isAnnotationsEmpty() {
         return annotationEmpty;
     }
 
@@ -89,11 +90,7 @@ public class FileAnnotationTabViewModel extends AbstractViewModel {
                 .map(FileAnnotationViewModel::new)
                 .collect(Collectors.toList());
         annotations.setAll(newAnnotations);
-        if (annotations.isEmpty()) {
-            annotationEmpty.setValue(true);
-        } else {
-            annotationEmpty.setValue(false);
-        }
+        annotationEmpty = annotations.emptyProperty();
         try {
             fileMonitor.addListenerForFile(currentFile, fileListener);
         } catch (IOException e) {

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabViewModel.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabViewModel.java
@@ -35,6 +35,7 @@ public class FileAnnotationTabViewModel extends AbstractViewModel {
     private final ListProperty<FileAnnotationViewModel> annotations = new SimpleListProperty<>(FXCollections.observableArrayList());
     private final ListProperty<Path> files = new SimpleListProperty<>(FXCollections.observableArrayList());
     private final ObjectProperty<FileAnnotationViewModel> currentAnnotation = new SimpleObjectProperty<>();
+    private final ObjectProperty<Boolean> annotaionEmpty = new SimpleObjectProperty<Boolean>(null);
 
     private final FileAnnotationCache cache;
     private final BibEntry entry;
@@ -57,6 +58,10 @@ public class FileAnnotationTabViewModel extends AbstractViewModel {
 
     public ObjectProperty<FileAnnotationViewModel> currentAnnotationProperty() {
         return currentAnnotation;
+    }
+
+    public boolean isAnnotationsEmpty() {
+        return annotations.isEmpty();
     }
 
     public ListProperty<FileAnnotationViewModel> annotationsProperty() {

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabViewModel.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabViewModel.java
@@ -35,14 +35,14 @@ public class FileAnnotationTabViewModel extends AbstractViewModel {
     private final ListProperty<FileAnnotationViewModel> annotations = new SimpleListProperty<>(FXCollections.observableArrayList());
     private final ListProperty<Path> files = new SimpleListProperty<>(FXCollections.observableArrayList());
     private final ObjectProperty<FileAnnotationViewModel> currentAnnotation = new SimpleObjectProperty<>();
-    private final ObjectProperty<Boolean> annotaionEmpty = new SimpleObjectProperty<Boolean>(null);
+    private final ObjectProperty<Boolean> annotaionEmpty = new SimpleObjectProperty<>(null);
 
     private final FileAnnotationCache cache;
     private final BibEntry entry;
     private Map<Path, List<FileAnnotation>> fileAnnotations;
     private Path currentFile;
-    private FileUpdateMonitor fileMonitor;
-    private FileUpdateListener fileListener = this::reloadAnnotations;
+    private final FileUpdateMonitor fileMonitor;
+    private final FileUpdateListener fileListener = this::reloadAnnotations;
 
     public FileAnnotationTabViewModel(FileAnnotationCache cache, BibEntry entry, FileUpdateMonitor fileMonitor) {
         this.cache = cache;
@@ -89,10 +89,11 @@ public class FileAnnotationTabViewModel extends AbstractViewModel {
                 .map(FileAnnotationViewModel::new)
                 .collect(Collectors.toList());
         annotations.setAll(newAnnotations);
-        if (annotations.isEmpty())
+        if (annotations.isEmpty()) {
             annotaionEmpty.setValue(true);
-        else
+        } else {
             annotaionEmpty.setValue(false);
+        }
         try {
             fileMonitor.addListenerForFile(currentFile, fileListener);
         } catch (IOException e) {

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabViewModel.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationTabViewModel.java
@@ -35,7 +35,7 @@ public class FileAnnotationTabViewModel extends AbstractViewModel {
     private final ListProperty<FileAnnotationViewModel> annotations = new SimpleListProperty<>(FXCollections.observableArrayList());
     private final ListProperty<Path> files = new SimpleListProperty<>(FXCollections.observableArrayList());
     private final ObjectProperty<FileAnnotationViewModel> currentAnnotation = new SimpleObjectProperty<>();
-    private final ObjectProperty<Boolean> annotaionEmpty = new SimpleObjectProperty<>(null);
+    private final ObjectProperty<Boolean> annotationEmpty = new SimpleObjectProperty<>(null);
 
     private final FileAnnotationCache cache;
     private final BibEntry entry;
@@ -61,7 +61,7 @@ public class FileAnnotationTabViewModel extends AbstractViewModel {
     }
 
     public ObjectProperty<Boolean> isAnnotationsEmpty() {
-        return annotaionEmpty;
+        return annotationEmpty;
     }
 
     public ListProperty<FileAnnotationViewModel> annotationsProperty() {
@@ -90,9 +90,9 @@ public class FileAnnotationTabViewModel extends AbstractViewModel {
                 .collect(Collectors.toList());
         annotations.setAll(newAnnotations);
         if (annotations.isEmpty()) {
-            annotaionEmpty.setValue(true);
+            annotationEmpty.setValue(true);
         } else {
-            annotaionEmpty.setValue(false);
+            annotationEmpty.setValue(false);
         }
         try {
             fileMonitor.addListenerForFile(currentFile, fileListener);

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationViewModel.java
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/FileAnnotationViewModel.java
@@ -100,7 +100,7 @@ public class FileAnnotationViewModel {
         return super.toString();
     }
 
-    public String getDescription() {
+    public String getMarking() {
         return marking.get();
     }
 }

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/ListItem.fxml
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/ListItem.fxml
@@ -6,7 +6,7 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.text.Font?>
 
-<GridPane xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1">
+<GridPane xmlns="http://javafx.com/javafx/8.0.112" xmlns:fx="http://javafx.com/fxml/1">
    <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="10.0" />
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
@@ -23,13 +23,13 @@
             <ColumnConstraints hgrow="SOMETIMES" maxWidth="398.0" minWidth="10.0" prefWidth="246.0" />
          </columnConstraints>
          <rowConstraints>
-            <RowConstraints maxHeight="20.0" minHeight="10.0" prefHeight="19.0" vgrow="SOMETIMES" />
+            <RowConstraints maxHeight="20.0" minHeight="10.0" prefHeight="20.0" vgrow="SOMETIMES" />
             <RowConstraints maxHeight="36.0" minHeight="10.0" prefHeight="36.0" vgrow="SOMETIMES" />
             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
             <RowConstraints minHeight="10.0" prefHeight="10.0" vgrow="SOMETIMES" />
          </rowConstraints>
          <children>
-            <Label alignment="TOP_LEFT" prefHeight="30.0" prefWidth="241.0" text="Brunch this weekend?">
+            <Label alignment="TOP_LEFT" prefHeight="21.0" prefWidth="138.0" text="Brunch this weekend?">
                <font>
                   <Font name="System Bold" size="18.0" />
                </font>

--- a/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/ListItem.fxml
+++ b/src/main/java/org/jabref/gui/entryeditor/fileannotationtab/ListItem.fxml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.RowConstraints?>
+<?import javafx.scene.text.Font?>
+
+<GridPane xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1">
+   <columnConstraints>
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="10.0" />
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="10.0" />
+   </columnConstraints>
+   <rowConstraints>
+      <RowConstraints minHeight="10.0" prefHeight="10.0" vgrow="SOMETIMES" />
+      <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
+   </rowConstraints>
+   <children>
+      <GridPane prefHeight="90.0" prefWidth="597.0" GridPane.columnIndex="1" GridPane.rowIndex="1">
+         <columnConstraints>
+            <ColumnConstraints hgrow="SOMETIMES" maxWidth="502.0" minWidth="10.0" prefWidth="308.0" />
+            <ColumnConstraints hgrow="SOMETIMES" maxWidth="398.0" minWidth="10.0" prefWidth="246.0" />
+         </columnConstraints>
+         <rowConstraints>
+            <RowConstraints maxHeight="20.0" minHeight="10.0" prefHeight="19.0" vgrow="SOMETIMES" />
+            <RowConstraints maxHeight="36.0" minHeight="10.0" prefHeight="36.0" vgrow="SOMETIMES" />
+            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+            <RowConstraints minHeight="10.0" prefHeight="10.0" vgrow="SOMETIMES" />
+         </rowConstraints>
+         <children>
+            <Label alignment="TOP_LEFT" prefHeight="30.0" prefWidth="241.0" text="Brunch this weekend?">
+               <font>
+                  <Font name="System Bold" size="18.0" />
+               </font>
+            </Label>
+            <Label alignment="TOP_RIGHT" prefHeight="30.0" prefWidth="470.0" text="16:05 26.09.2017" textAlignment="RIGHT" GridPane.columnIndex="1" />
+            <Label alignment="TOP_LEFT" prefHeight="30.0" prefWidth="122.0" text="Brendan Lim" GridPane.rowIndex="1">
+               <font>
+                  <Font size="14.0" />
+               </font>
+            </Label>
+            <Label alignment="TOP_LEFT" prefHeight="30.0" prefWidth="516.0" text="This is a comment that discribes the marked passage in the list. It contains useful information to better understand the marked passage." GridPane.rowIndex="2" />
+            <Label alignment="TOP_RIGHT" prefHeight="30.0" prefWidth="470.0" text="Page 13" textAlignment="RIGHT" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+         </children>
+      </GridPane>
+      <Label alignment="TOP_RIGHT" prefHeight="30.0" prefWidth="470.0" text="16:05 26.09.2017" textAlignment="RIGHT" />
+   </children>
+</GridPane>


### PR DESCRIPTION
In the comments to issue #3109 I already presented my solution approaches for the FileAnnotationTab's design change. This discussion should be continued here. 

There were two situations I have presented a design approach:

1. The linked file has no annotations
2. The linked file has annotations

If there are annotations in the linked file, two design solution approaches have been discussed: Either realising it with a list or a table. No matter which of these solutions is chosen, it would be nice to be able to order the annotations by Date, Author or Page.
- So a table might be the clearest solution. 
- Sorting a list on the other hand side could be realised by implementing a DropDown Menu were the user can select what the list should be sorted by.

I implemented the "No Annotations" approach, so that the right side of the FileAnnotationTab showing the annotation's attributes is either disabled (if there are "no annotations" in the linked file) or enabled (if there are annotations).