### PR TITLE
Only build master branch on push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,10 @@ after_failure:
   # show test results if build fails
   - $TRAVIS_BUILD_DIR/scripts/after-failure.sh
 
+branches:
+  only: 
+    - master
+
 # cache gradle dependencies
 # https://docs.travis-ci.com/user/languages/java#Caching
 before_cache:


### PR DESCRIPTION
Our current workflow is to create a branch on the main JabRef fork and then open a PR for it. This, however, leads to two travis builds: one for the new push to JabRef and one for the PR.
There seems to be no elegant way to force travis to

- always build PRs
- but don't build PRs from main branches twice

See https://github.com/travis-ci/travis-ci/issues/6612. I followed [the suggested solution on stackoverflow](https://stackoverflow.com/a/31882307/873661) and only white-listed the master branch.
Thus pushes to master still trigger a build, as well as all PRs. However, pushes to other branches on main does not result in build. Thus only one build is executed if you open a PR from a main branch. Disadvantage: you have to open a PR to get a build from a different branch. I don't think this is a huge disadvantage since it is exactly our current workflow. 

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
