### PR TITLE
Prepare usage of crowdin: Remove underscores from l10n

### DIFF
--- a/src/main/java/org/jabref/gui/desktop/JabRefDesktop.java
+++ b/src/main/java/org/jabref/gui/desktop/JabRefDesktop.java
@@ -335,7 +335,7 @@ public class JabRefDesktop {
                     LOGGER.error("Open console", exception);
 
                     JOptionPane.showMessageDialog(JabRefGUI.getMainFrame(),
-                            Localization.lang("Error_occured_while_executing_the_command_\"%0\".", commandLoggingText),
+                            Localization.lang("Error occured while executing the command \"%0\".", commandLoggingText),
                             Localization.lang("Open console") + " - " + Localization.lang("Error"),
                             JOptionPane.ERROR_MESSAGE);
                     JabRefGUI.getMainFrame().output(null);

--- a/src/main/java/org/jabref/logic/l10n/LocalizationKey.java
+++ b/src/main/java/org/jabref/logic/l10n/LocalizationKey.java
@@ -12,17 +12,17 @@ public class LocalizationKey {
 
     public String getPropertiesKeyUnescaped() {
         // space, #, !, = and : are not allowed in properties file keys
-        return this.key.replace(" ", "_");
+        return this.key;
     }
 
     public String getPropertiesKey() {
         // space, #, !, = and : are not allowed in properties file keys (# and ! only at the beginning of the key but easier to escape every instance
-        return this.key.replace(" ", "_").replace("#", "\\#").replace("!", "\\!").replace("=", "\\=")
+        return this.key.replace(" ", "\\ ").replace("#", "\\#").replace("!", "\\!").replace("=", "\\=")
                 .replace(":", "\\:").replace("\\\\", "\\");
     }
 
     public String getTranslationValue() {
-        return this.key.replace("_", " ").replace("\\#", "#").replace("\\!", "!").replace("\\=", "=").replace("\\:",
+        return this.key.replace("\\ ", " ").replace("\\#", "#").replace("\\!", "!").replace("\\=", "=").replace("\\:",
                 ":");
     }
 }

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -3,156 +3,156 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-%0_contains_the_regular_expression_<b>%1</b>=%0_indeholder_regulærudtrykket_<b>%1</b>
+%0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 indeholder regulærudtrykket <b>%1</b>
 
-%0_contains_the_term_<b>%1</b>=%0_indeholder_udtrykket_<b>%1</b>
+%0\ contains\ the\ term\ <b>%1</b>=%0 indeholder udtrykket <b>%1</b>
 
-%0_doesn't_contain_the_regular_expression_<b>%1</b>=%0_indeholder_ikke_regulærudtrykket_<b>%1</b>
+%0\ doesn't\ contain\ the\ regular\ expression\ <b>%1</b>=%0 indeholder ikke regulærudtrykket <b>%1</b>
 
-%0_doesn't_contain_the_term_<b>%1</b>=%0_indeholder_ikke_udtrykket_<b>%1</b>
+%0\ doesn't\ contain\ the\ term\ <b>%1</b>=%0 indeholder ikke udtrykket <b>%1</b>
 
-%0_export_successful=%0-eksport_lykkedes
+%0\ export\ successful=%0-eksport lykkedes
 
-%0_matches_the_regular_expression_<b>%1</b>=%0_matcher_regulærudtrykket_<b>%1</b>
+%0\ matches\ the\ regular\ expression\ <b>%1</b>=%0 matcher regulærudtrykket <b>%1</b>
 
-%0_matches_the_term_<b>%1</b>=%0_matcher_udtrykket_<b>%1</b>
+%0\ matches\ the\ term\ <b>%1</b>=%0 matcher udtrykket <b>%1</b>
 
-<field_name>=<feltnavn>
-<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>=<HTML>Kunne_ikke_finde_filen_'%0'<BR>linket_til_fra_posten_'%1'</HTML>
+<field\ name>=<feltnavn>
+<HTML>Could\ not\ find\ file\ '%0'<BR>linked\ from\ entry\ '%1'</HTML>=<HTML>Kunne ikke finde filen '%0'<BR>linket til fra posten '%1'</HTML>
 
 <select>=<vælg>
 
-<select_word>=<vælg_ord>
-Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)=Forkort_tidsskriftsnavn_for_de_valgte_poster_(ISO-forkortelse)
-Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)=Forkort_tidsskriftsnavn_for_de_valgte_poster_(MEDLINE-forkortelse)
+<select\ word>=<vælg ord>
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (ISO\ abbreviation)=Forkort tidsskriftsnavn for de valgte poster (ISO-forkortelse)
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (MEDLINE\ abbreviation)=Forkort tidsskriftsnavn for de valgte poster (MEDLINE-forkortelse)
 
-Abbreviate_names=Forkort_navn
-Abbreviated_%0_journal_names.=Fortkortet_%0_tidsskriftsnavn.
+Abbreviate\ names=Forkort navn
+Abbreviated\ %0\ journal\ names.=Fortkortet %0 tidsskriftsnavn.
 
 Abbreviation=Forkortelse
 
-About_JabRef=Om_JabRef
+About\ JabRef=Om JabRef
 
 Abstract=Sammendrag
 
 Accept=Accepter
 
-Accept_change=Accepter_ændring
+Accept\ change=Accepter ændring
 
 Action=Handling
 
-What_is_Mr._DLib?=
+What\ is\ Mr.\ DLib?=
 
 Add=Tilføj
 
-Add_a_(compiled)_custom_Importer_class_from_a_class_path.=Tilføj_en_(kompileret)_egendefineret_Importer-klasse_fra_en_classpath.
-The_path_need_not_be_on_the_classpath_of_JabRef.=Stien_behøver_ikke_at_være_på_JabRefs_classpath.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=Tilføj en (kompileret) egendefineret Importer-klasse fra en classpath.
+The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=Stien behøver ikke at være på JabRefs classpath.
 
-Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=Tilføj_en_kompileret_Importer-klasse_fra_en_ZIP-fil.
-The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=ZIP-filen_behøver_ikke_at_være_i_din_classpath.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=Tilføj en kompileret Importer-klasse fra en ZIP-fil.
+The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=ZIP-filen behøver ikke at være i din classpath.
 
-Add_a_regular_expression_for_the_key_pattern.=
+Add\ a\ regular\ expression\ for\ the\ key\ pattern.=
 
-Add_selected_entries_to_this_group=
+Add\ selected\ entries\ to\ this\ group=
 
-Add_from_folder=Tilføj_fra_mappe
+Add\ from\ folder=Tilføj fra mappe
 
-Add_from_JAR=Tilføj_fra_JAR-fil
+Add\ from\ JAR=Tilføj fra JAR-fil
 
-add_group=tilføj_gruppe
+add\ group=tilføj gruppe
 
-Add_new=Tilføj_ny
+Add\ new=Tilføj ny
 
-Add_subgroup=Tilføj_undergruppe
+Add\ subgroup=Tilføj undergruppe
 
-Add_to_group=Tilføj_i_gruppe
+Add\ to\ group=Tilføj i gruppe
 
-Added_group_"%0".=Tilføjede_gruppe_"%0".
+Added\ group\ "%0".=Tilføjede gruppe "%0".
 
-Added_missing_braces.=
+Added\ missing\ braces.=
 
-Added_new=Tilføjede_ny
+Added\ new=Tilføjede ny
 
-Added_string=Tilføjede_streng
+Added\ string=Tilføjede streng
 
-Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.=Desuden,_poster_hvis_<b>%0</b>-felt_ikke_indeholder_<b>%1</b>_kan_føjes_manuelt_til_denne_gruppe_ved_at_vælge_dem,_og_enten_trække_dem_over_eller_bruge_kontekstmenuen._Denne_proces_tilføjer_udtrykket_<b>%1</b>_til_hver_af_posternes_<b>%0</b>-felt._Poster_kan_fjernes_manuelt_fra_denne_gruppe_ved_at_vælge_dem_og_derefter_bruge_kontekstmenuen._Denne_proces_fjerner_udtrykket_<b>%1</b>_fra_hver_af_posternes_<b>%0</b>-felt.
+Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ can\ be\ assigned\ manually\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ This\ process\ adds\ the\ term\ <b>%1</b>\ to\ each\ entry's\ <b>%0</b>\ field.\ Entries\ can\ be\ removed\ manually\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.\ This\ process\ removes\ the\ term\ <b>%1</b>\ from\ each\ entry's\ <b>%0</b>\ field.=Desuden, poster hvis <b>%0</b>-felt ikke indeholder <b>%1</b> kan føjes manuelt til denne gruppe ved at vælge dem, og enten trække dem over eller bruge kontekstmenuen. Denne proces tilføjer udtrykket <b>%1</b> til hver af posternes <b>%0</b>-felt. Poster kan fjernes manuelt fra denne gruppe ved at vælge dem og derefter bruge kontekstmenuen. Denne proces fjerner udtrykket <b>%1</b> fra hver af posternes <b>%0</b>-felt.
 
 Advanced=Avanceret
-All_entries=Alle_poster
-All_entries_of_this_type_will_be_declared_typeless._Continue?=Alle_posterne_af_denne_type_vil_blive_klassificeret_som_typeløse._Fortsæt?
+All\ entries=Alle poster
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=Alle posterne af denne type vil blive klassificeret som typeløse. Fortsæt?
 
-All_fields=Alle_felter
+All\ fields=Alle felter
 
-Always_reformat_BIB_file_on_save_and_export=
+Always\ reformat\ BIB\ file\ on\ save\ and\ export=
 
-A_SAX_exception_occurred_while_parsing_'%0'\:=En_SAXException_forekom_ved_læsning_af_'%0'\:
+A\ SAX\ exception\ occurred\ while\ parsing\ '%0'\:=En SAXException forekom ved læsning af '%0':
 
 and=og
-and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.=og_klassen_skal_være_tilgængelig_i_CLASSPATH_næste_gang,_du_starter_JabRef.
+and\ the\ class\ must\ be\ available\ in\ your\ classpath\ next\ time\ you\ start\ JabRef.=og klassen skal være tilgængelig i CLASSPATH næste gang, du starter JabRef.
 
-any_field_that_matches_the_regular_expression_<b>%0</b>=ethvert_felt_som_matcher_regulærudtrykket_<b>%0</b>
+any\ field\ that\ matches\ the\ regular\ expression\ <b>%0</b>=ethvert felt som matcher regulærudtrykket <b>%0</b>
 
 Appearance=Udseende
 
 Append=Tilføj
-Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library=Tilføj_indhold_fra_en_BibTeX-library_i_den_åbne_library
+Append\ contents\ from\ a\ BibTeX\ library\ into\ the\ currently\ viewed\ library=Tilføj indhold fra en BibTeX-library i den åbne library
 
-Append_library=Føj_til_library
+Append\ library=Føj til library
 
-Append_the_selected_text_to_BibTeX_field=Tilføj_den_valgte_tekst_til_BibTeX-nøglen
+Append\ the\ selected\ text\ to\ BibTeX\ field=Tilføj den valgte tekst til BibTeX-nøglen
 Application=Applikation
 
 Apply=Udfør
 
-Arguments_passed_on_to_running_JabRef_instance._Shutting_down.=Argumenterne_sendt_til_allerede_aktiv_JabRef-instans._Afslutter.
+Arguments\ passed\ on\ to\ running\ JabRef\ instance.\ Shutting\ down.=Argumenterne sendt til allerede aktiv JabRef-instans. Afslutter.
 
-Assign_new_file=Tildel_ny_fil
+Assign\ new\ file=Tildel ny fil
 
-Assign_the_original_group's_entries_to_this_group?=Føj_den_oprindelige_gruppes_poster_til_denne_gruppe?
+Assign\ the\ original\ group's\ entries\ to\ this\ group?=Føj den oprindelige gruppes poster til denne gruppe?
 
-Assigned_%0_entries_to_group_"%1".=Tilføjede_%0_poster_til_gruppen_"%1".
+Assigned\ %0\ entries\ to\ group\ "%1".=Tilføjede %0 poster til gruppen "%1".
 
-Assigned_1_entry_to_group_"%0".=Tilføjede_1_post_til_gruppen_"%0".
+Assigned\ 1\ entry\ to\ group\ "%0".=Tilføjede 1 post til gruppen "%0".
 
-Attach_URL=Tilføj_URL
+Attach\ URL=Tilføj URL
 
-Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.=Forsøg_at_sætte_fil-link_automatisk_for_dine_poster._Dette_virker,_hvis_en_fil_i_dit_fil-bibliotek_eller_et_underbibliotek<BR>har_navn_lignende_en_posts_BibTeX-nøgle,_plus_efternavn.
+Attempt\ to\ automatically\ set\ file\ links\ for\ your\ entries.\ Automatically\ setting\ works\ if\ a\ file\ in\ your\ file\ directory<BR>or\ a\ subdirectory\ is\ named\ identically\ to\ an\ entry's\ BibTeX\ key,\ plus\ extension.=Forsøg at sætte fil-link automatisk for dine poster. Dette virker, hvis en fil i dit fil-bibliotek eller et underbibliotek<BR>har navn lignende en posts BibTeX-nøgle, plus efternavn.
 
-Autodetect_format=Autodetekter_format
+Autodetect\ format=Autodetekter format
 
-Autogenerate_BibTeX_keys=Autogenerer_BibTeX-nøgler
+Autogenerate\ BibTeX\ keys=Autogenerer BibTeX-nøgler
 
-Autolink_files_with_names_starting_with_the_BibTeX_key=Autolink_filer_med_navn_som_starter_med_BibTeX-nøglen
+Autolink\ files\ with\ names\ starting\ with\ the\ BibTeX\ key=Autolink filer med navn som starter med BibTeX-nøglen
 
-Autolink_only_files_that_match_the_BibTeX_key=Autolink_kun_filer_med_navn_som_svarer_til_BibTeX-nøglen
+Autolink\ only\ files\ that\ match\ the\ BibTeX\ key=Autolink kun filer med navn som svarer til BibTeX-nøglen
 
-Automatically_create_groups=Generer_grupper_automatisk
+Automatically\ create\ groups=Generer grupper automatisk
 
-Automatically_remove_exact_duplicates=Fjern_eksakte_dubletter_automatisk
+Automatically\ remove\ exact\ duplicates=Fjern eksakte dubletter automatisk
 
-Allow_overwriting_existing_links.=Tillad_overskrivning_af_eksisterende_links.
+Allow\ overwriting\ existing\ links.=Tillad overskrivning af eksisterende links.
 
-Do_not_overwrite_existing_links.=Overskriv_ikke_eksisterende_links.
+Do\ not\ overwrite\ existing\ links.=Overskriv ikke eksisterende links.
 
-AUX_file_import=AUX-fil_import
+AUX\ file\ import=AUX-fil import
 
-Available_export_formats=Tilgængelige_eksportformater
+Available\ export\ formats=Tilgængelige eksportformater
 
-Available_BibTeX_fields=Tilgængelige_felter
+Available\ BibTeX\ fields=Tilgængelige felter
 
-Available_import_formats=Tilgængelige_importformater
+Available\ import\ formats=Tilgængelige importformater
 
-Background_color_for_optional_fields=Baggrundsfarve_for_valgfrie_felter
+Background\ color\ for\ optional\ fields=Baggrundsfarve for valgfrie felter
 
-Background_color_for_required_fields=Baggrundsfarve_for_obligatoriske_felter
+Background\ color\ for\ required\ fields=Baggrundsfarve for obligatoriske felter
 
-Backup_old_file_when_saving=Lav_sikkerhedskopi_ved_gemning
+Backup\ old\ file\ when\ saving=Lav sikkerhedskopi ved gemning
 
-BibTeX_key_is_unique.=BibTeX-nøglen_er_unik
+BibTeX\ key\ is\ unique.=BibTeX-nøglen er unik
 
-%0_source=%0-kilde
+%0\ source=%0-kilde
 
-Broken_link=Ugyldigt_link
+Broken\ link=Ugyldigt link
 
 Browse=Gennemse
 
@@ -160,321 +160,321 @@ by=med
 
 Cancel=Annuller
 
-Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?=Kan_ikke_føje_poster_til_en_gruppe_uden_at_generere_nøgler._Vil_du_generere_nøgler_nu?
+Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=Kan ikke føje poster til en gruppe uden at generere nøgler. Vil du generere nøgler nu?
 
-Cannot_merge_this_change=Kan_ikke_inkorporere_denne_ændring
+Cannot\ merge\ this\ change=Kan ikke inkorporere denne ændring
 
-case_insensitive=skelner_ikke_mellem_store_og_små_bogstaver
+case\ insensitive=skelner ikke mellem store og små bogstaver
 
-case_sensitive=skelner_mellem_store_og_små_bogstaver
+case\ sensitive=skelner mellem store og små bogstaver
 
-Case_sensitive=Skeln_mellem_store_og_små_bogstaver
+Case\ sensitive=Skeln mellem store og små bogstaver
 
-change_assignment_of_entries=ændre_tildeling_af_poster
+change\ assignment\ of\ entries=ændre tildeling af poster
 
-Change_case=Ændre_store/små_bogstaver
+Change\ case=Ændre store/små bogstaver
 
-Change_entry_type=Ændre_posttype
-Change_file_type=Ændre_filtype
+Change\ entry\ type=Ændre posttype
+Change\ file\ type=Ændre filtype
 
 
-Change_of_Grouping_Method=Ændre_grupperingsmetode
+Change\ of\ Grouping\ Method=Ændre grupperingsmetode
 
-change_preamble=Ændre_præambel
+change\ preamble=Ændre præambel
 
-Change_table_column_and_General_fields_settings_to_use_the_new_feature=Ændre_opsætning_for_tabelkollonner_og_generelle_felter_for_anvende_den_nye_funktion
+Change\ table\ column\ and\ General\ fields\ settings\ to\ use\ the\ new\ feature=Ændre opsætning for tabelkollonner og generelle felter for anvende den nye funktion
 
-Changed_language_settings=Ændrede_sprogindstillinger
+Changed\ language\ settings=Ændrede sprogindstillinger
 
-Changed_preamble=Ændrede_præambel
+Changed\ preamble=Ændrede præambel
 
-Check_existing_file_links=Tjek_eksisterende_fil-links
+Check\ existing\ file\ links=Tjek eksisterende fil-links
 
-Check_links=Tjek_eksterne_links
+Check\ links=Tjek eksterne links
 
-Cite_command=Citations-kommando
+Cite\ command=Citations-kommando
 
-Class_name=Klassenavn
+Class\ name=Klassenavn
 
 Clear=Ryd
 
-Clear_fields=Ryd_felter
+Clear\ fields=Ryd felter
 
 Close=Luk
-Close_others=
-Close_all=
+Close\ others=
+Close\ all=
 
-Close_dialog=Luk_dialog
+Close\ dialog=Luk dialog
 
-Close_the_current_library=Luk_denne_library
+Close\ the\ current\ library=Luk denne library
 
-Close_window=Luk_vindue
+Close\ window=Luk vindue
 
-Closed_library=Lukkede_library
+Closed\ library=Lukkede library
 
-Color_codes_for_required_and_optional_fields=Farvekoder_for_nødvendige_og_valgfrie_felter
+Color\ codes\ for\ required\ and\ optional\ fields=Farvekoder for nødvendige og valgfrie felter
 
-Color_for_marking_incomplete_entries=Farve_til_markering_af_ufuldstændige_poster
+Color\ for\ marking\ incomplete\ entries=Farve til markering af ufuldstændige poster
 
-Column_width=Kolonnebredde
+Column\ width=Kolonnebredde
 
-Command_line_id=Kommandolinje-id
+Command\ line\ id=Kommandolinje-id
 
 
-Contained_in=Indeholdt_i
+Contained\ in=Indeholdt i
 
 Content=Indhold
 
 Copied=Kopierede
 
-Copied_cell_contents=Kopierede_indhold_af_cellen
+Copied\ cell\ contents=Kopierede indhold af cellen
 
-Copied_title=
+Copied\ title=
 
-Copied_key=Kopierede_nøgle
+Copied\ key=Kopierede nøgle
 
-Copied_titles=
+Copied\ titles=
 
-Copied_keys=Kopierede_nøgler
+Copied\ keys=Kopierede nøgler
 
 Copy=Kopier
 
-Copy_BibTeX_key=Kopier_BibTeX-nøgle
-Copy_file_to_file_directory=Kopier_fil_til_filbibliotek
+Copy\ BibTeX\ key=Kopier BibTeX-nøgle
+Copy\ file\ to\ file\ directory=Kopier fil til filbibliotek
 
-Copy_to_clipboard=Kopier_til_udklipsholder
+Copy\ to\ clipboard=Kopier til udklipsholder
 
-Could_not_call_executable=Kunne_ikke_kalde_programfilen
-Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.=Kunne_ikke_forbinde_til_Vim-server._Tjek_at_Vim_kjører<BR>med_korrekt_servernavn.
+Could\ not\ call\ executable=Kunne ikke kalde programfilen
+Could\ not\ connect\ to\ Vim\ server.\ Make\ sure\ that\ Vim\ is\ running<BR>with\ correct\ server\ name.=Kunne ikke forbinde til Vim-server. Tjek at Vim kjører<BR>med korrekt servernavn.
 
-Could_not_export_file=Kunne_ikke_eksportere
+Could\ not\ export\ file=Kunne ikke eksportere
 
-Could_not_export_preferences=Kunne_ikke_eksportere_indstillinger
+Could\ not\ export\ preferences=Kunne ikke eksportere indstillinger
 
-Could_not_find_a_suitable_import_format.=Fandt_ikke_noget_passende_importformat.
-Could_not_import_preferences=Kunne_ikke_importere_indstillinger
+Could\ not\ find\ a\ suitable\ import\ format.=Fandt ikke noget passende importformat.
+Could\ not\ import\ preferences=Kunne ikke importere indstillinger
 
-Could_not_instantiate_%0=Kunne_ikke_instantiere_%0
-Could_not_instantiate_%0_%1=Kunne_ikke_instantiere_%0_%1
-Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?=Kunne_ikke_instantiere_%0._Har_du_valgt_korrekt_pakke-sti?
-Could_not_open_link=Kunne_ikke_åbne_link
+Could\ not\ instantiate\ %0=Kunne ikke instantiere %0
+Could\ not\ instantiate\ %0\ %1=Kunne ikke instantiere %0 %1
+Could\ not\ instantiate\ %0.\ Have\ you\ chosen\ the\ correct\ package\ path?=Kunne ikke instantiere %0. Har du valgt korrekt pakke-sti?
+Could\ not\ open\ link=Kunne ikke åbne link
 
-Could_not_print_preview=Kunne_ikke_printe_forhåndsvisning
+Could\ not\ print\ preview=Kunne ikke printe forhåndsvisning
 
-Could_not_run_the_'vim'_program.=Kunne_ikke_køre_'vim'-programmet
+Could\ not\ run\ the\ 'vim'\ program.=Kunne ikke køre 'vim'-programmet
 
-Could_not_save_file.=Kunne_ikke_gemme_fil.
-Character_encoding_'%0'_is_not_supported.=Tegnkodingen_'%0'_er_ikke_understøttet.
+Could\ not\ save\ file.=Kunne ikke gemme fil.
+Character\ encoding\ '%0'\ is\ not\ supported.=Tegnkodingen '%0' er ikke understøttet.
 
-crossreferenced_entries_included=refererede_poster_inkluderet
+crossreferenced\ entries\ included=refererede poster inkluderet
 
-Current_content=Nuværende_indhold
+Current\ content=Nuværende indhold
 
-Current_value=Nuværende_værdi
+Current\ value=Nuværende værdi
 
-Custom_entry_types=Brugerdefinerede_posttyper
+Custom\ entry\ types=Brugerdefinerede posttyper
 
-Custom_entry_types_found_in_file=Fandt_brugerdefinerede_posttyper_i_filen
+Custom\ entry\ types\ found\ in\ file=Fandt brugerdefinerede posttyper i filen
 
-Customize_entry_types=Tilpas_posttyper
+Customize\ entry\ types=Tilpas posttyper
 
-Customize_key_bindings=Opsætning_af_genvejstaster
+Customize\ key\ bindings=Opsætning af genvejstaster
 
 Cut=Klip
 
-cut_entries=klippede_poster
+cut\ entries=klippede poster
 
-cut_entry=klip_post
+cut\ entry=klip post
 
 
-Library_encoding=Tegnkoding_for_library
+Library\ encoding=Tegnkoding for library
 
-Library_properties=Libraryegenskaber
+Library\ properties=Libraryegenskaber
 
-Library_type=
+Library\ type=
 
-Date_format=Datoformat
+Date\ format=Datoformat
 
 Default=Standard
 
-Default_encoding=Standard_kodning
+Default\ encoding=Standard kodning
 
-Default_grouping_field=Standardfelt_for_gruppering
+Default\ grouping\ field=Standardfelt for gruppering
 
-Default_look_and_feel=Standard-udseende
+Default\ look\ and\ feel=Standard-udseende
 
-Default_pattern=Standardmønster
+Default\ pattern=Standardmønster
 
-Default_sort_criteria=Standard_sorteringskriterier
-Define_'%0'=Definer_'%0'
+Default\ sort\ criteria=Standard sorteringskriterier
+Define\ '%0'=Definer '%0'
 
 Delete=Slet
 
-Delete_custom_format=Slet_brugerdefineret_type
+Delete\ custom\ format=Slet brugerdefineret type
 
-delete_entries=slet_poster
+delete\ entries=slet poster
 
-Delete_entry=Slet_post
+Delete\ entry=Slet post
 
-delete_entry=slet_post
+delete\ entry=slet post
 
-Delete_multiple_entries=Slet_flere_poster
+Delete\ multiple\ entries=Slet flere poster
 
-Delete_rows=Slet_rækker
+Delete\ rows=Slet rækker
 
-Delete_strings=Slet_strenge
+Delete\ strings=Slet strenge
 
 Deleted=Slettet
 
-Permanently_delete_local_file=
+Permanently\ delete\ local\ file=
 
-Delimit_fields_with_semicolon,_ex.=Afgræns_felter_med_semikolon,_f.eks.
+Delimit\ fields\ with\ semicolon,\ ex.=Afgræns felter med semikolon, f.eks.
 
 Descending=Faldende
 
 Description=Beskrivelse
 
-Deselect_all=Vælg_ingen
-Deselect_all_duplicates=Fravælg_alle_dubletter
+Deselect\ all=Vælg ingen
+Deselect\ all\ duplicates=Fravælg alle dubletter
 
-Disable_this_confirmation_dialog=Deaktiver_denne_kontroldialog
+Disable\ this\ confirmation\ dialog=Deaktiver denne kontroldialog
 
-Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.=Vis_alle_poster_indeholdt_i_mindst_en_af_de_valgte_grupper.
+Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups.=Vis alle poster indeholdt i mindst en af de valgte grupper.
 
-Display_all_error_messages=Vis_alle_fejlmeddelelser
+Display\ all\ error\ messages=Vis alle fejlmeddelelser
 
-Display_help_on_command_line_options=Vis_kommandolinjehjælp
+Display\ help\ on\ command\ line\ options=Vis kommandolinjehjælp
 
-Display_only_entries_belonging_to_all_selected_groups.=Vis_kun_poster_indeholdt_i_alle_valgte_grupper.
-Display_version=Vis_versionsnummer
+Display\ only\ entries\ belonging\ to\ all\ selected\ groups.=Vis kun poster indeholdt i alle valgte grupper.
+Display\ version=Vis versionsnummer
 
-Do_not_abbreviate_names=Forkort_ikke_navn
+Do\ not\ abbreviate\ names=Forkort ikke navn
 
-Do_not_automatically_set=Sæt_ikke_links_automatisk
+Do\ not\ automatically\ set=Sæt ikke links automatisk
 
-Do_not_import_entry=Importer_ikke_post
+Do\ not\ import\ entry=Importer ikke post
 
-Do_not_open_any_files_at_startup=Åbn_ingen_filer_ved_opstart
+Do\ not\ open\ any\ files\ at\ startup=Åbn ingen filer ved opstart
 
-Do_not_overwrite_existing_keys=Overskriv_ikke_eksisterende_nøgler
-Do_not_show_these_options_in_the_future=Vis_ikke_disse_valg_igen
+Do\ not\ overwrite\ existing\ keys=Overskriv ikke eksisterende nøgler
+Do\ not\ show\ these\ options\ in\ the\ future=Vis ikke disse valg igen
 
-Do_not_wrap_the_following_fields_when_saving=Introducer_ikke_linjeskift_i_følgende_felter_ved_gemning
-Do_not_write_the_following_fields_to_XMP_Metadata\:=Skriv_ikke_følgende_felter_til_XMP-metadata\:
+Do\ not\ wrap\ the\ following\ fields\ when\ saving=Introducer ikke linjeskift i følgende felter ved gemning
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Skriv ikke følgende felter til XMP-metadata:
 
-Do_you_want_JabRef_to_do_the_following_operations?=Skal_JabRef_udføre_de_følgende_operationer?
+Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Skal JabRef udføre de følgende operationer?
 
-Donate_to_JabRef=
+Donate\ to\ JabRef=
 
 Down=Ned
 
-Download_file=Download_fil
+Download\ file=Download fil
 
 Downloading...=Downloader...
 
-Drop_%0=Slip_%0
+Drop\ %0=Slip %0
 
-duplicate_removal=fjernelse_af_dubletter
+duplicate\ removal=fjernelse af dubletter
 
-Duplicate_string_name=Ikke-unikt_navn_på_streng
+Duplicate\ string\ name=Ikke-unikt navn på streng
 
-Duplicates_found=Dubletter_fundet
+Duplicates\ found=Dubletter fundet
 
-Dynamic_groups=Dynamiske_grupper
+Dynamic\ groups=Dynamiske grupper
 
-Dynamically_group_entries_by_a_free-form_search_expression=Grupper_poster_dynamisk_ved_hjælp_af_et_standard_søgeudtryk
+Dynamically\ group\ entries\ by\ a\ free-form\ search\ expression=Grupper poster dynamisk ved hjælp af et standard søgeudtryk
 
-Dynamically_group_entries_by_searching_a_field_for_a_keyword=Grupper_poster_dynamisk_ved_at_søge_efter_nøgleord_i_et_felt
+Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=Grupper poster dynamisk ved at søge efter nøgleord i et felt
 
-Each_line_must_be_on_the_following_form=Hver_linje_skal_være_på_følgende_form
+Each\ line\ must\ be\ on\ the\ following\ form=Hver linje skal være på følgende form
 
 Edit=Rediger
 
-Edit_custom_export=Rediger_eksternt_eksportfilter
-Edit_entry=Rediger_post
-Save_file=Rediger_link
-Edit_file_type=Rediger_filtype
+Edit\ custom\ export=Rediger eksternt eksportfilter
+Edit\ entry=Rediger post
+Save\ file=Rediger link
+Edit\ file\ type=Rediger filtype
 
-Edit_group=Rediger_gruppe
+Edit\ group=Rediger gruppe
 
 
-Edit_preamble=Rediger_præambel
-Edit_strings=Rediger_tekststrenge
-Editor_options=Alternativer_for_redigering
+Edit\ preamble=Rediger præambel
+Edit\ strings=Rediger tekststrenge
+Editor\ options=Alternativer for redigering
 
-Empty_BibTeX_key=tom_BibTeX-nøgle
+Empty\ BibTeX\ key=tom BibTeX-nøgle
 
-Grouping_may_not_work_for_this_entry.=Gruppering_kan_fejle_for_denne_post.
+Grouping\ may\ not\ work\ for\ this\ entry.=Gruppering kan fejle for denne post.
 
-empty_library=tom_library
-Enable_word/name_autocompletion=Aktiver_autokomplettering_af_navn/ord
+empty\ library=tom library
+Enable\ word/name\ autocompletion=Aktiver autokomplettering af navn/ord
 
-Enter_URL=Skriv_URL
+Enter\ URL=Skriv URL
 
-Enter_URL_to_download=Skriv_URL_som_skal_hentes
+Enter\ URL\ to\ download=Skriv URL som skal hentes
 
 entries=poster
 
-Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.=Poster_kan_ikke_manuelt_tilføjes_eller_fjernes_fra_denne_gruppe.
+Entries\ cannot\ be\ manually\ assigned\ to\ or\ removed\ from\ this\ group.=Poster kan ikke manuelt tilføjes eller fjernes fra denne gruppe.
 
-Entries_exported_to_clipboard=Poster_eksporteret_til_udklipsholder
+Entries\ exported\ to\ clipboard=Poster eksporteret til udklipsholder
 
 
 entry=post
 
-Entry_editor=Postredigering
+Entry\ editor=Postredigering
 
-Entry_preview=Forhåndsvisning
+Entry\ preview=Forhåndsvisning
 
-Entry_table=Hovedtabel
+Entry\ table=Hovedtabel
 
-Entry_table_columns=Tabelkolonner
+Entry\ table\ columns=Tabelkolonner
 
-Entry_type=Posttype
+Entry\ type=Posttype
 
-Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Navn_på_typer_kan_ikke_indeholde_mellemrum_eller_nogle_af_følgende_tegn
+Entry\ type\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Navn på typer kan ikke indeholde mellemrum eller nogle af følgende tegn
 
-Entry_types=Posttyper
+Entry\ types=Posttyper
 
 Error=Fejl
-Error_exporting_to_clipboard=Fejl_ved_eksport_til_udklipsholder
+Error\ exporting\ to\ clipboard=Fejl ved eksport til udklipsholder
 
-Error_occurred_when_parsing_entry=En_fejl_opstod_ved_læsning_af_post
+Error\ occurred\ when\ parsing\ entry=En fejl opstod ved læsning af post
 
-Error_opening_file=Fejl_ved_åbning_af_fil
+Error\ opening\ file=Fejl ved åbning af fil
 
-Error_setting_field=Problem_med_at_sætte_felt
+Error\ setting\ field=Problem med at sætte felt
 
-Error_while_writing=En_fejl_opstod_ved_skrivning
-Error_writing_to_%0_file(s).=Fejl_ved_skrivning_til_%0_fil(er).
+Error\ while\ writing=En fejl opstod ved skrivning
+Error\ writing\ to\ %0\ file(s).=Fejl ved skrivning til %0 fil(er).
 
 
 
-'%0'_exists._Overwrite_file?='%0'_eksisterer._Erstat_filen?
-Overwrite_file?=Erstat_filen?
+'%0'\ exists.\ Overwrite\ file?='%0' eksisterer. Erstat filen?
+Overwrite\ file?=Erstat filen?
 
 Export=Eksporter
 
-Export_name=Navn_på_filter
+Export\ name=Navn på filter
 
-Export_preferences=Eksporter_indstillinger
+Export\ preferences=Eksporter indstillinger
 
-Export_preferences_to_file=Eksporter_indstillinger_til_fil
+Export\ preferences\ to\ file=Eksporter indstillinger til fil
 
-Export_properties=Egenskaber_for_eksportfilter
+Export\ properties=Egenskaber for eksportfilter
 
-Export_to_clipboard=Eksporter_til_udklipsholder
+Export\ to\ clipboard=Eksporter til udklipsholder
 
 Exporting=Eksporterer
 Extension=Efternavn
 
-External_changes=Eksterne_ændringer
+External\ changes=Eksterne ændringer
 
-External_file_links=Eksterne_links
+External\ file\ links=Eksterne links
 
-External_programs=Eksterne_programmer
+External\ programs=Eksterne programmer
 
-External_viewer_called=Eksternt_program_kaldt
+External\ viewer\ called=Eksternt program kaldt
 
 Fetch=Hent
 
@@ -482,210 +482,210 @@ Field=Felt
 
 field=felt
 
-Field_name=Feltnavn
-Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Feltnavn_kan_ikke_indeholde_mellemrum_eller_følgende_tegn
+Field\ name=Feltnavn
+Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Feltnavn kan ikke indeholde mellemrum eller følgende tegn
 
-Field_to_filter=Felt_som_skal_filtreres
+Field\ to\ filter=Felt som skal filtreres
 
-Field_to_group_by=Grupperingsfelt
+Field\ to\ group\ by=Grupperingsfelt
 
 File=Fil
 
 file=fil
-File_'%0'_is_already_open.=Filen_'%0'_er_allerede_åben.
+File\ '%0'\ is\ already\ open.=Filen '%0' er allerede åben.
 
-File_changed=Fil_ændret
-File_directory_is_'%0'\:=Filbiblioteket_er_'%0'\:
+File\ changed=Fil ændret
+File\ directory\ is\ '%0'\:=Filbiblioteket er '%0':
 
-File_directory_is_not_set_or_does_not_exist\!=Filbiblioteket_er_ikke_sat_eller_eksisterer_ikke\!
+File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=Filbiblioteket er ikke sat eller eksisterer ikke!
 
-File_exists=Filen_eksisterer
+File\ exists=Filen eksisterer
 
-File_has_been_updated_externally._What_do_you_want_to_do?=Filen_er_blevet_ændret_eksternt._Hvad_vil_du_gøre?
+File\ has\ been\ updated\ externally.\ What\ do\ you\ want\ to\ do?=Filen er blevet ændret eksternt. Hvad vil du gøre?
 
-File_not_found=Fil_ikke_fundet
-File_type=Filtype
+File\ not\ found=Fil ikke fundet
+File\ type=Filtype
 
-File_updated_externally=Filen_er_blevet_ændret_eksternt
+File\ updated\ externally=Filen er blevet ændret eksternt
 
 filename=filnavn
 
 Filename=
 
-Files_opened=Filer_åbnet
+Files\ opened=Filer åbnet
 
 Filter=Filter
 
-Filter_All=
+Filter\ All=
 
-Filter_None=
+Filter\ None=
 
-Finished_automatically_setting_external_links.=Fuldførte_automatisk_udfyldning_af_eksterne_links.
+Finished\ automatically\ setting\ external\ links.=Fuldførte automatisk udfyldning af eksterne links.
 
-Finished_synchronizing_file_links._Entries_changed\:_%0.=Fuldførte_synkronisering_af_fil-links._Poster_ændret\:_%0.
-Finished_writing_XMP-metadata._Wrote_to_%0_file(s).=Fuldførte_skrivning_af_XMP-metadata._Skrev_til_%0_fil(er).
-Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).=Fuldførte_skrivning_af_XMP_for_%0-fil_(sprang_over_%1,_%2_fejl).
+Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Fuldførte synkronisering af fil-links. Poster ændret: %0.
+Finished\ writing\ XMP-metadata.\ Wrote\ to\ %0\ file(s).=Fuldførte skrivning af XMP-metadata. Skrev til %0 fil(er).
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Fuldførte skrivning af XMP for %0-fil (sprang over %1, %2 fejl).
 
-First_select_the_entries_you_want_keys_to_be_generated_for.=Vælg_først_hvilke_poster_du_vil_generere_nøgler_for.
+First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Vælg først hvilke poster du vil generere nøgler for.
 
-Fit_table_horizontally_on_screen=Tilpas_tabelbredden_horisontalt
+Fit\ table\ horizontally\ on\ screen=Tilpas tabelbredden horisontalt
 
 Float=Flyt
-Float_marked_entries=Sorter_mærkede_poster_øverst
+Float\ marked\ entries=Sorter mærkede poster øverst
 
-Font_family=Skrifttype-familie
+Font\ family=Skrifttype-familie
 
-Font_preview=Skrifttype-forhåndsvisning
+Font\ preview=Skrifttype-forhåndsvisning
 
-Font_size=Skriftstørrelse
+Font\ size=Skriftstørrelse
 
-Font_style=Skrifttype-stil
+Font\ style=Skrifttype-stil
 
-Font_selection=Skrifttypevælger
+Font\ selection=Skrifttypevælger
 
 for=for
 
-Format_of_author_and_editor_names=Formattering_af_forfatter-_og_redaktørnavn
-Format_string=Formatstreng
+Format\ of\ author\ and\ editor\ names=Formattering af forfatter- og redaktørnavn
+Format\ string=Formatstreng
 
-Format_used=Format_brugt
-Formatter_name=Navn_på_formatering
+Format\ used=Format brugt
+Formatter\ name=Navn på formatering
 
-found_in_AUX_file=fundet_i_AUX-fil
+found\ in\ AUX\ file=fundet i AUX-fil
 
-Full_name=Fuldt_navn
+Full\ name=Fuldt navn
 
 General=Generelt
 
-General_fields=Generelle_felter
+General\ fields=Generelle felter
 
 Generate=Generer
 
-Generate_BibTeX_key=Generer_BibTeX-nøgle
+Generate\ BibTeX\ key=Generer BibTeX-nøgle
 
-Generate_keys=Generer_nøgler
+Generate\ keys=Generer nøgler
 
-Generate_keys_before_saving_(for_entries_without_a_key)=Generer_nøgler_før_gemning_(for_poster_uden_nøgle)
-Generate_keys_for_imported_entries=Generer_automatisk_nøgler_for_importerede_poster
+Generate\ keys\ before\ saving\ (for\ entries\ without\ a\ key)=Generer nøgler før gemning (for poster uden nøgle)
+Generate\ keys\ for\ imported\ entries=Generer automatisk nøgler for importerede poster
 
-Generate_now=Generer_nu
+Generate\ now=Generer nu
 
-Generated_BibTeX_key_for=Genererede_BibTeX-nøgle_for
+Generated\ BibTeX\ key\ for=Genererede BibTeX-nøgle for
 
-Generating_BibTeX_key_for=Genererer_BibTeX-nøgle_for
-Get_fulltext=
+Generating\ BibTeX\ key\ for=Genererer BibTeX-nøgle for
+Get\ fulltext=
 
-Gray_out_non-hits=Skraver_ikke-træffere
+Gray\ out\ non-hits=Skraver ikke-træffere
 
 Groups=Gruppering
 
-Have_you_chosen_the_correct_package_path?=Har_du_valgt_korrekt_pakke-sti?
+Have\ you\ chosen\ the\ correct\ package\ path?=Har du valgt korrekt pakke-sti?
 
 Help=Hjælp
 
-Help_on_key_patterns=Hjælp_om_nøglegenerering
-Help_on_regular_expression_search=Hjælp_om_søgning_med_regulære_udtryk
+Help\ on\ key\ patterns=Hjælp om nøglegenerering
+Help\ on\ regular\ expression\ search=Hjælp om søgning med regulære udtryk
 
-Hide_non-hits=Skjul_ikke-træffere
+Hide\ non-hits=Skjul ikke-træffere
 
-Hierarchical_context=Gruppehierarki
+Hierarchical\ context=Gruppehierarki
 
 Highlight=Fremhæv
 Marking=
 Underline=
-Empty_Highlight=
-Empty_Marking=
-Empty_Underline=
-The_marked_area_does_not_contain_any_legible_text!=
+Empty\ Highlight=
+Empty\ Marking=
+Empty\ Underline=
+The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=
 
-Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>=Hint\:_For_kun_at_søge_i_specifikke_felter,_skriv_f.eks.\:<p><tt>author\=smith_and_title\=electrical</tt>
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Hint: For kun at søge i specifikke felter, skriv f.eks.:<p><tt>author=smith and title=electrical</tt>
 
-HTML_table=HTML-tabel
-HTML_table_(with_Abstract_&_BibTeX)=HTML-tabell_(med_Abstract_&_BibTeX)
+HTML\ table=HTML-tabel
+HTML\ table\ (with\ Abstract\ &\ BibTeX)=HTML-tabell (med Abstract & BibTeX)
 Icon=Ikon
 
 Ignore=Ignorer
 
 Import=Importer
 
-Import_and_keep_old_entry=Importer_og_behold_den_gamle_post
+Import\ and\ keep\ old\ entry=Importer og behold den gamle post
 
-Import_and_remove_old_entry=Importer_og_fjern_den_gamle_post
+Import\ and\ remove\ old\ entry=Importer og fjern den gamle post
 
-Import_entries=Importer_poster
+Import\ entries=Importer poster
 
-Import_failed=Import_mislykkedes
+Import\ failed=Import mislykkedes
 
-Import_file=Importer_fil
+Import\ file=Importer fil
 
-Import_group_definitions=Importer_gruppedefinitioner
+Import\ group\ definitions=Importer gruppedefinitioner
 
-Import_name=Navn_på_import
+Import\ name=Navn på import
 
-Import_preferences=Importer_indstillinger
+Import\ preferences=Importer indstillinger
 
-Import_preferences_from_file=Importer_indstillinger_fra_fil
+Import\ preferences\ from\ file=Importer indstillinger fra fil
 
-Import_strings=Importer_strenge
+Import\ strings=Importer strenge
 
-Import_to_open_tab=Importer_til_åbent_faneblad
+Import\ to\ open\ tab=Importer til åbent faneblad
 
-Import_word_selector_definitions=Importer_definitioner_for_hurtigvælgere
+Import\ word\ selector\ definitions=Importer definitioner for hurtigvælgere
 
-Imported_entries=Importerede_poster
+Imported\ entries=Importerede poster
 
-Imported_from_library=Importerede_fra_libraryn
+Imported\ from\ library=Importerede fra libraryn
 
-Importer_class=Importer-klasse
+Importer\ class=Importer-klasse
 
 Importing=Importerer
 
-Importing_in_unknown_format=Importerer_ukendt_format
+Importing\ in\ unknown\ format=Importerer ukendt format
 
-Include_abstracts=Inkluder_abstracts
-Include_entries=Inkluder_poster
+Include\ abstracts=Inkluder abstracts
+Include\ entries=Inkluder poster
 
-Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups=Inkluder_undergrupper\:_Vis_poster_indeholdt_i_denne_gruppe_eller_en_undergruppe
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=Inkluder undergrupper: Vis poster indeholdt i denne gruppe eller en undergruppe
 
-Independent_group\:_When_selected,_view_only_this_group's_entries=Uafhængig_gruppe\:_Vis_kun_denne_gruppes_poster
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=Uafhængig gruppe: Vis kun denne gruppes poster
 
-Work_options=
+Work\ options=
 
 Insert=Tilføj
 
-Insert_rows=Tilføj_rækker
+Insert\ rows=Tilføj rækker
 
 Intersection=Fællesmænge
 
-Invalid_BibTeX_key=Ugyldig_BibTeX-nøgle
+Invalid\ BibTeX\ key=Ugyldig BibTeX-nøgle
 
-Invalid_date_format=Ugyldigt_datoformat
+Invalid\ date\ format=Ugyldigt datoformat
 
-Invalid_URL=Ugyldig_URL
+Invalid\ URL=Ugyldig URL
 
-Online_help=
+Online\ help=
 
-JabRef_preferences=JabRef-indstillinger
+JabRef\ preferences=JabRef-indstillinger
 
 Join=
 
-Joins_selected_keywords_and_deletes_selected_keywords.=
+Joins\ selected\ keywords\ and\ deletes\ selected\ keywords.=
 
-Journal_abbreviations=Tidsskriftsforkortelser
+Journal\ abbreviations=Tidsskriftsforkortelser
 
 Keep=Behold
 
-Keep_both=Behold_begge
+Keep\ both=Behold begge
 
-Key_bindings=Genvejstaster
+Key\ bindings=Genvejstaster
 
-Key_bindings_changed=Genvejstaster_ændret
+Key\ bindings\ changed=Genvejstaster ændret
 
-Key_generator_settings=Indstillinger_for_nøglegenerering
+Key\ generator\ settings=Indstillinger for nøglegenerering
 
-Key_pattern=Mønster
+Key\ pattern=Mønster
 
-keys_in_library=nøgler_i_libraryn
+keys\ in\ library=nøgler i libraryn
 
 Keyword=Nøgleord
 
@@ -693,449 +693,449 @@ Label=Navn
 
 Language=Sprog
 
-Last_modified=Sidst_ændret
+Last\ modified=Sidst ændret
 
-LaTeX_AUX_file=LaTeX_AUX-fil
-Leave_file_in_its_current_directory=Lad_filen_ligge_i_biblioteket,_den_ligger_i_nu
+LaTeX\ AUX\ file=LaTeX AUX-fil
+Leave\ file\ in\ its\ current\ directory=Lad filen ligge i biblioteket, den ligger i nu
 
 Left=Venstre
 Level=
 
-Limit_to_fields=Begræns_til_følgende_felter
+Limit\ to\ fields=Begræns til følgende felter
 
-Limit_to_selected_entries=Begræns_til_valgte_poster
+Limit\ to\ selected\ entries=Begræns til valgte poster
 
 Link=Link
-Link_local_file=Link_til_lokal_fil
-Link_to_file_%0=Link_til_filen_%0
+Link\ local\ file=Link til lokal fil
+Link\ to\ file\ %0=Link til filen %0
 
-Listen_for_remote_operation_on_port=Lyt_efter_fjernoperationer_på_port
-Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)=Hent_og_gem_indstillinger_fra/til_jabref.xml_ved_opstart_(memory_stick-tilstand)
+Listen\ for\ remote\ operation\ on\ port=Lyt efter fjernoperationer på port
+Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=Hent og gem indstillinger fra/til jabref.xml ved opstart (memory stick-tilstand)
 
-Look_and_feel=Udseende
-Main_file_directory=Hovedbibliotek
+Look\ and\ feel=Udseende
+Main\ file\ directory=Hovedbibliotek
 
-Main_layout_file=Hoved-layoutfil
+Main\ layout\ file=Hoved-layoutfil
 
-Manage_custom_exports=Opsæt_eksterne_eksportfiltre
+Manage\ custom\ exports=Opsæt eksterne eksportfiltre
 
-Manage_custom_imports=Opsæt_eksterne_importfiltre
-Manage_external_file_types=Opsæt_eksterne_filtyper
+Manage\ custom\ imports=Opsæt eksterne importfiltre
+Manage\ external\ file\ types=Opsæt eksterne filtyper
 
-Mark_entries=Mærk_poster
+Mark\ entries=Mærk poster
 
-Mark_entry=Mærk_post
+Mark\ entry=Mærk post
 
-Mark_new_entries_with_addition_date=Mærk_nye_poster_med_dato
+Mark\ new\ entries\ with\ addition\ date=Mærk nye poster med dato
 
-Mark_new_entries_with_owner_name=Mærk_nye_poster_med_navn_på_ejer
+Mark\ new\ entries\ with\ owner\ name=Mærk nye poster med navn på ejer
 
-Memory_stick_mode=Memory_Stick-tilstand
+Memory\ stick\ mode=Memory Stick-tilstand
 
-Menu_and_label_font_size=Størrelse_på_menuskrifttyper
+Menu\ and\ label\ font\ size=Størrelse på menuskrifttyper
 
-Merged_external_changes=Inkorporerede_eksterne_ændringer
+Merged\ external\ changes=Inkorporerede eksterne ændringer
 
 Messages=Meddelelser
 
-Modification_of_field=Ændring_af_felt
+Modification\ of\ field=Ændring af felt
 
-Modified_group_"%0".=ændrede_gruppen_"%0".
+Modified\ group\ "%0".=ændrede gruppen "%0".
 
-Modified_groups=ændrede_grupper
+Modified\ groups=ændrede grupper
 
-Modified_string=ændrede_streng
+Modified\ string=ændrede streng
 
 Modify=Ændre
 
-modify_group=ændre_gruppe
+modify\ group=ændre gruppe
 
-Move_down=Flyt_ned
+Move\ down=Flyt ned
 
-Move_external_links_to_'file'_field=Flyt_eksterne_links_til_'file'-feltet
+Move\ external\ links\ to\ 'file'\ field=Flyt eksterne links til 'file'-feltet
 
-move_group=flyt_gruppe
+move\ group=flyt gruppe
 
-Move_up=Flyt_op
+Move\ up=Flyt op
 
-Moved_group_"%0".=Flyttede_gruppen_"%0".
+Moved\ group\ "%0".=Flyttede gruppen "%0".
 
 Name=Navn
-Name_formatter=Navneformatering
+Name\ formatter=Navneformatering
 
-Natbib_style=Natbib-stil
+Natbib\ style=Natbib-stil
 
-nested_AUX_files='nestede'_AUX-filer
+nested\ AUX\ files='nestede' AUX-filer
 
 New=Ny
 
 new=ny
 
-New_BibTeX_entry=Ny_BibTeX-post
+New\ BibTeX\ entry=Ny BibTeX-post
 
-New_BibTeX_sublibrary=Ny_BibTeX-dellibrary
+New\ BibTeX\ sublibrary=Ny BibTeX-dellibrary
 
-New_content=Nyt_indhold
+New\ content=Nyt indhold
 
-New_library_created.=Opprettede_ny_library.
-New_%0_library=
-New_field_value=Ny_værdi
+New\ library\ created.=Opprettede ny library.
+New\ %0\ library=
+New\ field\ value=Ny værdi
 
-New_group=Ny_gruppe
+New\ group=Ny gruppe
 
-New_string=Ny_streng
+New\ string=Ny streng
 
-Next_entry=Næste_post
+Next\ entry=Næste post
 
-No_actual_changes_found.=Ingen_reelle_ændringer_fundet.
+No\ actual\ changes\ found.=Ingen reelle ændringer fundet.
 
-no_base-BibTeX-file_specified=ingen_basis-BibTeXfil_specificeret
+no\ base-BibTeX-file\ specified=ingen basis-BibTeXfil specificeret
 
-no_library_generated=ingen_library_genereret
+no\ library\ generated=ingen library genereret
 
-No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.=Ingen_poster_fundet._Kontroller_at_du_bruger_korrekt_importfilter.
+No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=Ingen poster fundet. Kontroller at du bruger korrekt importfilter.
 
 
-No_entries_found_for_the_search_string_'%0'=Fandt_ingen_poster_for_søgeteksten_'%0'
+No\ entries\ found\ for\ the\ search\ string\ '%0'=Fandt ingen poster for søgeteksten '%0'
 
-No_entries_imported.=Ingen_poster_importeret.
+No\ entries\ imported.=Ingen poster importeret.
 
-No_files_found.=Ingen_filer_fundet.
+No\ files\ found.=Ingen filer fundet.
 
-No_GUI._Only_process_command_line_options.=Ingen_GUI._Processer_kun_kommandolinjevalg.
+No\ GUI.\ Only\ process\ command\ line\ options.=Ingen GUI. Processer kun kommandolinjevalg.
 
-No_journal_names_could_be_abbreviated.=Ingen_tidsskriftsnavne_kunne_forkortes.
+No\ journal\ names\ could\ be\ abbreviated.=Ingen tidsskriftsnavne kunne forkortes.
 
-No_journal_names_could_be_unabbreviated.=Ingen_tidsskriftsnavne_kunne_ekspanderes.
-No_PDF_linked=Ingen_PDF_linket
+No\ journal\ names\ could\ be\ unabbreviated.=Ingen tidsskriftsnavne kunne ekspanderes.
+No\ PDF\ linked=Ingen PDF linket
 
-Open_PDF=
+Open\ PDF=
 
-No_URL_defined=Ingen_URL_er_defineret
+No\ URL\ defined=Ingen URL er defineret
 not=ikke
 
-not_found=ikke_fundet
+not\ found=ikke fundet
 
-Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,=Bemærk_at_du_skal_specificere_det_fuldstændige_klassenavn_for_udseendet,
+Note\ that\ you\ must\ specify\ the\ fully\ qualified\ class\ name\ for\ the\ look\ and\ feel,=Bemærk at du skal specificere det fuldstændige klassenavn for udseendet,
 
-Nothing_to_redo=Ingenting_at_gentage
+Nothing\ to\ redo=Ingenting at gentage
 
-Nothing_to_undo=Ingenting_at_fortryde
+Nothing\ to\ undo=Ingenting at fortryde
 
 occurrences=forekomster
 
 OK=OK
-One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Et_eller_flere_links_er_af_typen_'%0',_som_er_udefineret._Hvad_vil_du_gøre?
+One\ or\ more\ file\ links\ are\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Et eller flere links er af typen '%0', som er udefineret. Hvad vil du gøre?
 
-One_or_more_keys_will_be_overwritten._Continue?=En_eller_flere_nøgler_vil_blive_overskrevet._Fortsæt?
+One\ or\ more\ keys\ will\ be\ overwritten.\ Continue?=En eller flere nøgler vil blive overskrevet. Fortsæt?
 
 
 Open=Åbn
 
-Open_BibTeX_library=Åbn_BibTeX-library
+Open\ BibTeX\ library=Åbn BibTeX-library
 
-Open_library=Åbn_library
+Open\ library=Åbn library
 
-Open_editor_when_a_new_entry_is_created=Start_redigering_når_en_ny_post_oprettes
+Open\ editor\ when\ a\ new\ entry\ is\ created=Start redigering når en ny post oprettes
 
-Open_file=Åbn_fil
+Open\ file=Åbn fil
 
-Open_last_edited_libraries_at_startup=Åbn_sidst_viste_libraryr_ved_opstart
+Open\ last\ edited\ libraries\ at\ startup=Åbn sidst viste libraryr ved opstart
 
-Connect_to_shared_database=
+Connect\ to\ shared\ database=
 
-Open_terminal_here=
+Open\ terminal\ here=
 
-Open_URL_or_DOI=Åbn_URL_eller_DOI
+Open\ URL\ or\ DOI=Åbn URL eller DOI
 
-Opened_library=Åbnede_library
+Opened\ library=Åbnede library
 
 Opening=Åbner
 
-Opening_preferences...=Åbner_indstillinger...
+Opening\ preferences...=Åbner indstillinger...
 
-Operation_canceled.=Operationen_afbrudt.
-Operation_not_supported=Operation_ikke_understøttet
+Operation\ canceled.=Operationen afbrudt.
+Operation\ not\ supported=Operation ikke understøttet
 
-Optional_fields=Valgfri_felter
+Optional\ fields=Valgfri felter
 
 Options=Valg
 
 or=eller
 
-Output_or_export_file=Gem_eller_eksporter_fil
+Output\ or\ export\ file=Gem eller eksporter fil
 
 Override=Tilsidesæt
 
-Override_default_file_directories=Tilsidesæt_standard_fil-biblioteker
+Override\ default\ file\ directories=Tilsidesæt standard fil-biblioteker
 
-Override_default_font_settings=Tilsidesæt_standardskrifttyper
+Override\ default\ font\ settings=Tilsidesæt standardskrifttyper
 
-Override_the_BibTeX_field_by_the_selected_text=Tilsidesæt_BibTeX-nøglen_til_fordel_for_den_valgte_nøgle
+Override\ the\ BibTeX\ field\ by\ the\ selected\ text=Tilsidesæt BibTeX-nøglen til fordel for den valgte nøgle
 
 
 Overwrite=Overskriv
-Overwrite_existing_field_values=Overskriv_eksisterende_værdier
+Overwrite\ existing\ field\ values=Overskriv eksisterende værdier
 
-Overwrite_keys=Overskriv_nøgler
+Overwrite\ keys=Overskriv nøgler
 
-pairs_processed=par_revideret
+pairs\ processed=par revideret
 Password=Kodeord
 
 Paste=Indsæt
 
-paste_entries=indsæt_poster
+paste\ entries=indsæt poster
 
-paste_entry=indsæt_post
-Paste_from_clipboard=Indsæt_fra_udklipsholder
+paste\ entry=indsæt post
+Paste\ from\ clipboard=Indsæt fra udklipsholder
 
 Pasted=Indsat
 
-Path_to_%0_not_defined=Sti_til_%0_ikke_defineret
+Path\ to\ %0\ not\ defined=Sti til %0 ikke defineret
 
-Path_to_LyX_pipe=Sti_til_LyX-pipe
+Path\ to\ LyX\ pipe=Sti til LyX-pipe
 
-PDF_does_not_exist=PDF-filen_findes_ikke
+PDF\ does\ not\ exist=PDF-filen findes ikke
 
-File_has_no_attached_annotations=
+File\ has\ no\ attached\ annotations=
 
-Plain_text_import=Import_fra_ren_tekst
+Plain\ text\ import=Import fra ren tekst
 
-Please_enter_a_name_for_the_group.=Skriv_et_navn_til_gruppen.
+Please\ enter\ a\ name\ for\ the\ group.=Skriv et navn til gruppen.
 
-Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>=Skriv_et_søgeudtryk._For_eksempel,_for_at_søge_i_alle_felter_efter_<b>Olsen</b>,_skriv\:<p><tt>olsen</tt><p>For_at_søge_i_<b>Author</b>-feltet_efter_<b>Olsen</b>_og_i_<b>Title</b>-feltet_efter_<b>electrical</b>,_skriv\:<p><tt>author\=olsen_and_title\=electrical</tt>
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Skriv et søgeudtryk. For eksempel, for at søge i alle felter efter <b>Olsen</b>, skriv:<p><tt>olsen</tt><p>For at søge i <b>Author</b>-feltet efter <b>Olsen</b> og i <b>Title</b>-feltet efter <b>electrical</b>, skriv:<p><tt>author=olsen and title=electrical</tt>
 
-Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=Skriv_venligsts_feltet_som_skal_søges_i_(f.eks._<b>keywords</b>)_og_nøgleordet_at_søge_efter_(f.eks._<b>electrical</b>).
+Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=Skriv venligsts feltet som skal søges i (f.eks. <b>keywords</b>) og nøgleordet at søge efter (f.eks. <b>electrical</b>).
 
-Please_enter_the_string's_label=Skriv_et_navn_for_strengen
+Please\ enter\ the\ string's\ label=Skriv et navn for strengen
 
-Please_select_an_importer.=Vælg_venligst_et_importfilter.
+Please\ select\ an\ importer.=Vælg venligst et importfilter.
 
-Possible_duplicate_entries=Mulige_dubletter
+Possible\ duplicate\ entries=Mulige dubletter
 
-Possible_duplicate_of_existing_entry._Click_to_resolve.=Mulig_dublet_af_eksisterende_post._Klik_for_at_løse_problemet.
+Possible\ duplicate\ of\ existing\ entry.\ Click\ to\ resolve.=Mulig dublet af eksisterende post. Klik for at løse problemet.
 
 Preamble=Præambel
 
 Preferences=Indstillinger
 
-Preferences_recorded.=Indstillinger_gemt.
+Preferences\ recorded.=Indstillinger gemt.
 
 Preview=Forhåndsvisning
-Citation_Style=
-Current_Preview=
-Cannot_generate_preview_based_on_selected_citation_style.=
-Bad_character_inside_entry=
-Error_while_generating_citation_style=
-Preview_style_changed_to\:_%0=
-Next_preview_layout=
-Previous_preview_layout=
+Citation\ Style=
+Current\ Preview=
+Cannot\ generate\ preview\ based\ on\ selected\ citation\ style.=
+Bad\ character\ inside\ entry=
+Error\ while\ generating\ citation\ style=
+Preview\ style\ changed\ to\:\ %0=
+Next\ preview\ layout=
+Previous\ preview\ layout=
 
-Previous_entry=Forrige_post
+Previous\ entry=Forrige post
 
-Primary_sort_criterion=Primært_sorteringskriterium
-Problem_with_parsing_entry=Problem_med_at_læse_post
-Processing_%0=Arbejder_%0
-Pull_changes_from_shared_database=
+Primary\ sort\ criterion=Primært sorteringskriterium
+Problem\ with\ parsing\ entry=Problem med at læse post
+Processing\ %0=Arbejder %0
+Pull\ changes\ from\ shared\ database=
 
-Pushed_citations_to_%0=Referencer_sendt_til_%0
+Pushed\ citations\ to\ %0=Referencer sendt til %0
 
-Quit_JabRef=Afslut_JabRef
+Quit\ JabRef=Afslut JabRef
 
-Quit_synchronization=Afslut_synkronisering
+Quit\ synchronization=Afslut synkronisering
 
-Raw_source=Kilde
+Raw\ source=Kilde
 
-Rearrange_tabs_alphabetically_by_title=Omarranger_faneblade_alfabetisk_efter_titel
+Rearrange\ tabs\ alphabetically\ by\ title=Omarranger faneblade alfabetisk efter titel
 
 Redo=Gentag
 
-Reference_library=Referencelibrary
+Reference\ library=Referencelibrary
 
-%0_references_found._Number_of_references_to_fetch?=Referencer_fundet\:_%0._Antal_referencer_som_skal_hentes?
+%0\ references\ found.\ Number\ of\ references\ to\ fetch?=Referencer fundet: %0. Antal referencer som skal hentes?
 
-Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Undergruppe\:_Vis_poster_indeholdt_både_i_denne_gruppe_og_gruppe_over
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=Undergruppe: Vis poster indeholdt både i denne gruppe og gruppe over
 
-regular_expression=Regulærudtryk
+regular\ expression=Regulærudtryk
 
-Related_articles=
+Related\ articles=
 
-Remote_operation=Fjernstyring
+Remote\ operation=Fjernstyring
 
-Remote_server_port=Port_til_fjernstyring
+Remote\ server\ port=Port til fjernstyring
 
 Remove=Fjern
 
-Remove_subgroups=Fjern_undergrupper
+Remove\ subgroups=Fjern undergrupper
 
-Remove_all_subgroups_of_"%0"?=Fjern_alle_undergrupper_af_"%0"?
+Remove\ all\ subgroups\ of\ "%0"?=Fjern alle undergrupper af "%0"?
 
-Remove_entry_from_import=Fjern_post_fra_import
+Remove\ entry\ from\ import=Fjern post fra import
 
-Remove_selected_entries_from_this_group=
+Remove\ selected\ entries\ from\ this\ group=
 
-Remove_entry_type=Slet_posttype
+Remove\ entry\ type=Slet posttype
 
-Remove_from_group=Fjern_fra_gruppe
+Remove\ from\ group=Fjern fra gruppe
 
-Remove_group=Fjern_gruppe
+Remove\ group=Fjern gruppe
 
-Remove_group,_keep_subgroups=Fjern_gruppe,_behold_undergrupper
+Remove\ group,\ keep\ subgroups=Fjern gruppe, behold undergrupper
 
-Remove_group_"%0"?=Fjern_gruppen_"%0"?
+Remove\ group\ "%0"?=Fjern gruppen "%0"?
 
-Remove_group_"%0"_and_its_subgroups?=Fjern_gruppen_"%0"_og_dens_undergrupper?
+Remove\ group\ "%0"\ and\ its\ subgroups?=Fjern gruppen "%0" og dens undergrupper?
 
-remove_group_(keep_subgroups)=fjern_gruppe_(behold_undergrupper)
+remove\ group\ (keep\ subgroups)=fjern gruppe (behold undergrupper)
 
-remove_group_and_subgroups=fjern_gruppe_og_undergrupper
+remove\ group\ and\ subgroups=fjern gruppe og undergrupper
 
-Remove_group_and_subgroups=Fjern_gruppe_og_undergrupper
+Remove\ group\ and\ subgroups=Fjern gruppe og undergrupper
 
-Remove_link=Slet_link
+Remove\ link=Slet link
 
-Remove_old_entry=Fjern_gammel_post
+Remove\ old\ entry=Fjern gammel post
 
-Remove_selected_strings=Slet_valgte_strenge
+Remove\ selected\ strings=Slet valgte strenge
 
-Removed_group_"%0".=Fjernede_gruppen_"%0"
+Removed\ group\ "%0".=Fjernede gruppen "%0"
 
-Removed_group_"%0"_and_its_subgroups.=Fjernede_gruppen_"%0"_og_dens_undergrupper
+Removed\ group\ "%0"\ and\ its\ subgroups.=Fjernede gruppen "%0" og dens undergrupper
 
-Removed_string=Streng_fjernet
+Removed\ string=Streng fjernet
 
-Renamed_string=ændrede_navn_på_streng
+Renamed\ string=ændrede navn på streng
 
 Replace=
 
-Replace_(regular_expression)=Erstat_(regulærudtryk)
+Replace\ (regular\ expression)=Erstat (regulærudtryk)
 
-Replace_string=Erstat_streng
+Replace\ string=Erstat streng
 
-Replace_with=Erstat_med
+Replace\ with=Erstat med
 
 Replaced=Erstattet
 
-Required_fields=Obligatoriske_felter
+Required\ fields=Obligatoriske felter
 
-Reset_all=Nulstil_alle
+Reset\ all=Nulstil alle
 
-Resolve_strings_for_all_fields_except=Slå_strenge_op_for_alle_felter_undtagen
-Resolve_strings_for_standard_BibTeX_fields_only=Slå_kun_strenge_op_for_standard_BibTeX-felter
+Resolve\ strings\ for\ all\ fields\ except=Slå strenge op for alle felter undtagen
+Resolve\ strings\ for\ standard\ BibTeX\ fields\ only=Slå kun strenge op for standard BibTeX-felter
 
 resolved=løst
 
 Review=Kommentarer
 
-Review_changes=Gennemse_ændringer
+Review\ changes=Gennemse ændringer
 
 Right=Højre
 
 Save=Gem
-Save_all_finished.=Alle_libraryr_gemt
+Save\ all\ finished.=Alle libraryr gemt
 
-Save_all_open_libraries=Gem_alle_åbne_libraryr
+Save\ all\ open\ libraries=Gem alle åbne libraryr
 
-Save_before_closing=Gem_før_libraryn_lukkes
+Save\ before\ closing=Gem før libraryn lukkes
 
-Save_library=Gem_library
-Save_library_as...=Gem_library_som_...
+Save\ library=Gem library
+Save\ library\ as...=Gem library som ...
 
-Save_entries_in_their_original_order=Gem_poster_i_oprindelig_rækkefølge
+Save\ entries\ in\ their\ original\ order=Gem poster i oprindelig rækkefølge
 
-Save_failed=Gemning_mislykkedes
+Save\ failed=Gemning mislykkedes
 
-Save_failed_during_backup_creation=Gemning_mislykkedes_ved_oprettelse_af_sikkerhedskopi
+Save\ failed\ during\ backup\ creation=Gemning mislykkedes ved oprettelse af sikkerhedskopi
 
-Save_selected_as...=Gem_valgte_som_...
+Save\ selected\ as...=Gem valgte som ...
 
-Saved_library=Library_gemt
+Saved\ library=Library gemt
 
-Saved_selected_to_'%0'.=Gemte_valgte_i_'%0'.
+Saved\ selected\ to\ '%0'.=Gemte valgte i '%0'.
 
 Saving=Gemmer
-Saving_all_libraries...=Gemmer_alle_libraryr...
+Saving\ all\ libraries...=Gemmer alle libraryr...
 
-Saving_library=Gemmer_library
+Saving\ library=Gemmer library
 
 Search=Søg
 
-Search_expression=Søgeudtryk
+Search\ expression=Søgeudtryk
 
-Search_for=Søg_efter
+Search\ for=Søg efter
 
-Searching_for_duplicates...=Søger_efter_dubletter...
+Searching\ for\ duplicates...=Søger efter dubletter...
 
-Searching_for_files=Søger_efter_filer
+Searching\ for\ files=Søger efter filer
 
-Secondary_sort_criterion=Sekundært_sorteringskriterium
+Secondary\ sort\ criterion=Sekundært sorteringskriterium
 
-Select_all=Vælg_alle
+Select\ all=Vælg alle
 
-Select_encoding=Vælg_tegnkodning
+Select\ encoding=Vælg tegnkodning
 
-Select_entry_type=Vælg_posttype
-Select_external_application=Vælg_ekstern_applikation
+Select\ entry\ type=Vælg posttype
+Select\ external\ application=Vælg ekstern applikation
 
-Select_file_from_ZIP-archive=Vælg_fil_fra_ZIP-fil
+Select\ file\ from\ ZIP-archive=Vælg fil fra ZIP-fil
 
-Select_the_tree_nodes_to_view_and_accept_or_reject_changes=Vælg_forgreningerne_for_at_inspicere_og_acceptere_eller_forkaste_ændringer
-Selected_entries=Valgte_poster
-Set_field=Sæt_felt
-Set_fields=Sæt_felter
+Select\ the\ tree\ nodes\ to\ view\ and\ accept\ or\ reject\ changes=Vælg forgreningerne for at inspicere og acceptere eller forkaste ændringer
+Selected\ entries=Valgte poster
+Set\ field=Sæt felt
+Set\ fields=Sæt felter
 
-Set_general_fields=Tilpas_generelle_felter
-Set_main_external_file_directory=Sæt_hovedbibliotek_for_eksterne_links
+Set\ general\ fields=Tilpas generelle felter
+Set\ main\ external\ file\ directory=Sæt hovedbibliotek for eksterne links
 
-Set_table_font=Vælg_tabelskrifttype
+Set\ table\ font=Vælg tabelskrifttype
 
 Settings=Indstillinger
 
 Shortcut=Genvej
 
-Show/edit_%0_source=Vis/rediger_%0-kilde
+Show/edit\ %0\ source=Vis/rediger %0-kilde
 
-Show_'Firstname_Lastname'=Vis_'Fornavn_Efternavn'
+Show\ 'Firstname\ Lastname'=Vis 'Fornavn Efternavn'
 
-Show_'Lastname,_Firstname'=Vis_'Efternavn,_Fornavn'
+Show\ 'Lastname,\ Firstname'=Vis 'Efternavn, Fornavn'
 
-Show_BibTeX_source_by_default=Vis_BibTeX-kode_som_standard
+Show\ BibTeX\ source\ by\ default=Vis BibTeX-kode som standard
 
-Show_confirmation_dialog_when_deleting_entries=Vis_dialog_for_at_bekræfte_sletning_af_poster
+Show\ confirmation\ dialog\ when\ deleting\ entries=Vis dialog for at bekræfte sletning af poster
 
-Show_description=Vis_beskrivelse
+Show\ description=Vis beskrivelse
 
-Show_file_column=Vis_'file'-kolonne
+Show\ file\ column=Vis 'file'-kolonne
 
-Show_last_names_only=Vis_kun_efternavn
+Show\ last\ names\ only=Vis kun efternavn
 
-Show_names_unchanged=Vis_navn_uændret
+Show\ names\ unchanged=Vis navn uændret
 
-Show_optional_fields=Vis_valgfrie_felter
+Show\ optional\ fields=Vis valgfrie felter
 
-Show_required_fields=Vis_obligatoriske_felter
+Show\ required\ fields=Vis obligatoriske felter
 
-Show_URL/DOI_column=Vis_URL/DOI-kolonne
+Show\ URL/DOI\ column=Vis URL/DOI-kolonne
 
-Simple_HTML=Simpel_HTML
+Simple\ HTML=Simpel HTML
 
 Size=Størrelse
 
-Skipped_-_No_PDF_linked=Sprang_over_-_ingen_PDF-fil_linket
-Skipped_-_PDF_does_not_exist=Sprang_over_-_PDF-filen_findes_ikke
+Skipped\ -\ No\ PDF\ linked=Sprang over - ingen PDF-fil linket
+Skipped\ -\ PDF\ does\ not\ exist=Sprang over - PDF-filen findes ikke
 
-Skipped_entry.=Sprang_over_post.
+Skipped\ entry.=Sprang over post.
 
-Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.=
+Some\ appearance\ settings\ you\ changed\ require\ to\ restart\ JabRef\ to\ come\ into\ effect.=
 
-source_edit=redigering_af_kilde
-Special_name_formatters=Specielle_navneformateringer
+source\ edit=redigering af kilde
+Special\ name\ formatters=Specielle navneformateringer
 
-Special_table_columns=Specielle_kolonner
+Special\ table\ columns=Specielle kolonner
 
-Starting_import=Starter_import
+Starting\ import=Starter import
 
-Statically_group_entries_by_manual_assignment=Grupper_poster_statisk_ved_manuel_tildeling
+Statically\ group\ entries\ by\ manual\ assignment=Grupper poster statisk ved manuel tildeling
 
 Status=Status
 
@@ -1143,1019 +1143,1019 @@ Stop=Stop
 
 Strings=Strenge
 
-Strings_for_library=Strenge_for_library
+Strings\ for\ library=Strenge for library
 
-Sublibrary_from_AUX=Dellibrary_fra_AUX-fil
+Sublibrary\ from\ AUX=Dellibrary fra AUX-fil
 
-Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.=Skifter_mellem_fuldt_og_forkortet_tidsskriftsnavn_hvis_navnet_er_kendt.
+Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=Skifter mellem fuldt og forkortet tidsskriftsnavn hvis navnet er kendt.
 
-Synchronize_file_links=Synkroniser_eksterne_links
+Synchronize\ file\ links=Synkroniser eksterne links
 
-Synchronizing_file_links...=Synkroniserer_eksterne_links...
+Synchronizing\ file\ links...=Synkroniserer eksterne links...
 
-Table_appearance=Tabelopsætning
+Table\ appearance=Tabelopsætning
 
-Table_background_color=Baggrundsfarve_for_tabel
+Table\ background\ color=Baggrundsfarve for tabel
 
-Table_grid_color=Farve_på_linjer_i_tabel
+Table\ grid\ color=Farve på linjer i tabel
 
-Table_text_color=Tekstfarve_i_tabel
+Table\ text\ color=Tekstfarve i tabel
 
-Tabname=Navn_på_faneblad
-Target_file_cannot_be_a_directory.=Angivet_fil_kan_ikke_være_et_bibliotek.
+Tabname=Navn på faneblad
+Target\ file\ cannot\ be\ a\ directory.=Angivet fil kan ikke være et bibliotek.
 
-Tertiary_sort_criterion=Tertiært_sorteringskriterium
+Tertiary\ sort\ criterion=Tertiært sorteringskriterium
 
 Test=Test
 
-paste_text_here=Indtastningsfelt
+paste\ text\ here=Indtastningsfelt
 
-The_chosen_date_format_for_new_entries_is_not_valid=Det_valgte_datoformat_er_ugyldigt
+The\ chosen\ date\ format\ for\ new\ entries\ is\ not\ valid=Det valgte datoformat er ugyldigt
 
-The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:=Den_valgte_tegnkodning_'%0'_kunne_ikke_kode_de_følgende_tegn\:
+The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=Den valgte tegnkodning '%0' kunne ikke kode de følgende tegn:
 
 
-the_field_<b>%0</b>=feltet_<b>%0</b>
+the\ field\ <b>%0</b>=feltet <b>%0</b>
 
-The_file<BR>'%0'<BR>has_been_modified<BR>externally\!=Filen<BR>'%0'<BR>er_blevet_ændret<BR>eksternt\!
+The\ file<BR>'%0'<BR>has\ been\ modified<BR>externally\!=Filen<BR>'%0'<BR>er blevet ændret<BR>eksternt!
 
-The_group_"%0"_already_contains_the_selection.=Gruppen_"%0"_indeholder_allerede_de_valgte_poster.
+The\ group\ "%0"\ already\ contains\ the\ selection.=Gruppen "%0" indeholder allerede de valgte poster.
 
-The_label_of_the_string_cannot_be_a_number.=Navnet_på_strengen_kan_ikke_være_et_tal.
+The\ label\ of\ the\ string\ cannot\ be\ a\ number.=Navnet på strengen kan ikke være et tal.
 
-The_label_of_the_string_cannot_contain_spaces.=Navnet_på_strengen_kan_ikke_indeholde_mellemrum.
+The\ label\ of\ the\ string\ cannot\ contain\ spaces.=Navnet på strengen kan ikke indeholde mellemrum.
 
-The_label_of_the_string_cannot_contain_the_'\#'_character.=Navnet_på_strengen_kan_ikke_indeholde_tegnet_'\#'.
+The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=Navnet på strengen kan ikke indeholde tegnet '#'.
 
-The_output_option_depends_on_a_valid_import_option.=Output-indstillingen_er_afhængig_af_en_gyldig_import-indstilling.
-The_PDF_contains_one_or_several_BibTeX-records.=PDF-filen_indeholder_en_eller_flere_BibTeX-poster.
-Do_you_want_to_import_these_as_new_entries_into_the_current_library?=Vil_du_importere_disse_som_nye_poster_i_den_åbne_library?
+The\ output\ option\ depends\ on\ a\ valid\ import\ option.=Output-indstillingen er afhængig af en gyldig import-indstilling.
+The\ PDF\ contains\ one\ or\ several\ BibTeX-records.=PDF-filen indeholder en eller flere BibTeX-poster.
+Do\ you\ want\ to\ import\ these\ as\ new\ entries\ into\ the\ current\ library?=Vil du importere disse som nye poster i den åbne library?
 
-The_regular_expression_<b>%0</b>_is_invalid\:=Regulærudtrykket_<b>%0</b>_er_ugyldigt\:
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=Regulærudtrykket <b>%0</b> er ugyldigt:
 
-The_search_is_case_insensitive.=Søgningen_skelner_ikke_mellem_store_og_små_bogstaver.
+The\ search\ is\ case\ insensitive.=Søgningen skelner ikke mellem store og små bogstaver.
 
-The_search_is_case_sensitive.=Søgningen_skelner_mellem_store_og_små_bogstaver.
+The\ search\ is\ case\ sensitive.=Søgningen skelner mellem store og små bogstaver.
 
-The_string_has_been_removed_locally=Strengen_er_blevet_slettet_lokalt
+The\ string\ has\ been\ removed\ locally=Strengen er blevet slettet lokalt
 
-There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?=Der_findes_mulige_dubletter_(mærket_med_et_ikon)_som_ikke_er_blevet_håndteret._Fortsæt?
+There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=Der findes mulige dubletter (mærket med et ikon) som ikke er blevet håndteret. Fortsæt?
 
-This_entry_has_no_BibTeX_key._Generate_key_now?=Denne_post_har_ingen_BibTeX-nøgle._Generer_nøgle_nu?
+This\ entry\ has\ no\ BibTeX\ key.\ Generate\ key\ now?=Denne post har ingen BibTeX-nøgle. Generer nøgle nu?
 
-This_entry_is_incomplete=Denne_post_er_ufuldstændig
+This\ entry\ is\ incomplete=Denne post er ufuldstændig
 
-This_entry_type_cannot_be_removed.=Denne_posttype_kan_ikke_slettes.
+This\ entry\ type\ cannot\ be\ removed.=Denne posttype kan ikke slettes.
 
-This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Dette_eksterne_link_er_af_typen_'%0',_som_er_udefineret._Hvad_vil_du_gøre?
+This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Dette eksterne link er af typen '%0', som er udefineret. Hvad vil du gøre?
 
-This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.=Denne_gruppe_indeholder_poster_baseret_på_manuel_tildeling._Poster_kan_tildeles_til_denne_gruppe_ved_at_vælge_dem_og_derefter_trække_dem_over_til_gruppen,_eller_ved_hjælp_af_højreklikmenuen.
+This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=Denne gruppe indeholder poster baseret på manuel tildeling. Poster kan tildeles til denne gruppe ved at vælge dem og derefter trække dem over til gruppen, eller ved hjælp af højreklikmenuen.
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>=Denne_gruppe_indeholder_poster_hvis_<b>%0</b>-felt_indeholder_nøgleordet_<b>%1</b>
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Denne gruppe indeholder poster hvis <b>%0</b>-felt indeholder nøgleordet <b>%1</b>
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>=Denne_gruppe_indeholder_poster,_hvis_<b>%0</b>-felt_stemmer_med_regulærudtrykket_<b>%1</b>
-This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.=Dette_får_JabRef_til_at_slå_hvert_fil-link_op_og_tjekke,_om_filen_eksisterer._Hvis_ikke_vil_du_få_mulighed_for_at<br>løse_problemet.
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Denne gruppe indeholder poster, hvis <b>%0</b>-felt stemmer med regulærudtrykket <b>%1</b>
+This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=Dette får JabRef til at slå hvert fil-link op og tjekke, om filen eksisterer. Hvis ikke vil du få mulighed for at<br>løse problemet.
 
-This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.=Denne_operation_kræver,_at_alle_valgte_poster_har_definerede_BibTeX-nøgler.
+This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=Denne operation kræver, at alle valgte poster har definerede BibTeX-nøgler.
 
-This_operation_requires_one_or_more_entries_to_be_selected.=Denne_operation_kræver,_at_en_eller_flere_poster_er_valgt.
+This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=Denne operation kræver, at en eller flere poster er valgt.
 
-Toggle_entry_preview=Vis/skjul_forhåndsvisning
-Toggle_groups_interface=Vis/skjul_grupperingspanel
-Try_different_encoding=Prøv_en_anden_tegnkodning
+Toggle\ entry\ preview=Vis/skjul forhåndsvisning
+Toggle\ groups\ interface=Vis/skjul grupperingspanel
+Try\ different\ encoding=Prøv en anden tegnkodning
 
-Unabbreviate_journal_names_of_the_selected_entries=Ekspander_tidsskriftsnavn_for_de_valgte_poster
-Unabbreviated_%0_journal_names.=Ekspanderede_%0_tidsskriftsnavn.
+Unabbreviate\ journal\ names\ of\ the\ selected\ entries=Ekspander tidsskriftsnavn for de valgte poster
+Unabbreviated\ %0\ journal\ names.=Ekspanderede %0 tidsskriftsnavn.
 
-Unable_to_open_file.=Kan_ikke_åbne_fil.
-Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.=Kan_ikke_åbne_link._Applikationen_'%0'_associeret_med_filtypen_'%1'_kunne_ikke_kaldes.
-unable_to_write_to=kunne_ikke_skrive_til
-Undefined_file_type=Udefineret_filtype
+Unable\ to\ open\ file.=Kan ikke åbne fil.
+Unable\ to\ open\ link.\ The\ application\ '%0'\ associated\ with\ the\ file\ type\ '%1'\ could\ not\ be\ called.=Kan ikke åbne link. Applikationen '%0' associeret med filtypen '%1' kunne ikke kaldes.
+unable\ to\ write\ to=kunne ikke skrive til
+Undefined\ file\ type=Udefineret filtype
 
 Undo=Fortryd
 
 Union=Foreningsmængde
 
-Unknown_BibTeX_entries=Ukendte_BibTeX-poster
+Unknown\ BibTeX\ entries=Ukendte BibTeX-poster
 
-unknown_edit=ukendt_ændring
+unknown\ edit=ukendt ændring
 
-Unknown_export_format=Ukendt_eksportformat
+Unknown\ export\ format=Ukendt eksportformat
 
-Unmark_all=Fjern_mærkning_fra_alle
+Unmark\ all=Fjern mærkning fra alle
 
-Unmark_entries=Fjern_mærkning
+Unmark\ entries=Fjern mærkning
 
-Unmark_entry=Fjern_mærkning
+Unmark\ entry=Fjern mærkning
 
-untitled=uden_navn
+untitled=uden navn
 
 Up=Op
 
-Update_to_current_column_widths=Brug_nuværende_kolonnebredder
+Update\ to\ current\ column\ widths=Brug nuværende kolonnebredder
 
-Updated_group_selection=Gruppevalg_opdateret
-Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.=Opgrader_eksterne_PDF-_og_PS-links_til_at_bruge_'%0'-feltet.
-Upgrade_file=Opgrader_fil
-Upgrade_old_external_file_links_to_use_the_new_feature=Opgrader_gamle_eksterne_links_for_at_bruge_den_nye_funktion
+Updated\ group\ selection=Gruppevalg opdateret
+Upgrade\ external\ PDF/PS\ links\ to\ use\ the\ '%0'\ field.=Opgrader eksterne PDF- og PS-links til at bruge '%0'-feltet.
+Upgrade\ file=Opgrader fil
+Upgrade\ old\ external\ file\ links\ to\ use\ the\ new\ feature=Opgrader gamle eksterne links for at bruge den nye funktion
 
 usage=brug
-Use_autocompletion_for_the_following_fields=Brug_autoudfyldning_for_følgende_felter
+Use\ autocompletion\ for\ the\ following\ fields=Brug autoudfyldning for følgende felter
 
-Use_other_look_and_feel=Brug_andet_udseende
-Tweak_font_rendering_for_entry_editor_on_Linux=
-Use_regular_expression_search=Brug_søgning_med_regulærudtryk
+Use\ other\ look\ and\ feel=Brug andet udseende
+Tweak\ font\ rendering\ for\ entry\ editor\ on\ Linux=
+Use\ regular\ expression\ search=Brug søgning med regulærudtryk
 
 Username=Brugernavn
 
-Value_cleared_externally=Værdi_slettet_eksternt
+Value\ cleared\ externally=Værdi slettet eksternt
 
-Value_set_externally=Værdi_sat_eksternt
+Value\ set\ externally=Værdi sat eksternt
 
-verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid=kontroller_at_LyX_kører,_og_at_den_angivne_lyxpipe_stemmer
+verify\ that\ LyX\ is\ running\ and\ that\ the\ lyxpipe\ is\ valid=kontroller at LyX kører, og at den angivne lyxpipe stemmer
 
 View=Vis
-Vim_server_name=Navn_på_Vim-server
+Vim\ server\ name=Navn på Vim-server
 
-Waiting_for_ArXiv...=Venter_på_ArXiv
+Waiting\ for\ ArXiv...=Venter på ArXiv
 
-Warn_about_unresolved_duplicates_when_closing_inspection_window=Advar_om_dubletter_som_ikke_er_blevet_håndteret,_når_inspektionsvinduet_lukkes
+Warn\ about\ unresolved\ duplicates\ when\ closing\ inspection\ window=Advar om dubletter som ikke er blevet håndteret, når inspektionsvinduet lukkes
 
-Warn_before_overwriting_existing_keys=Advar_før_eksisterende_nøgler_overskrives
+Warn\ before\ overwriting\ existing\ keys=Advar før eksisterende nøgler overskrives
 
 Warning=Advarsel
 
 Warnings=Advarsler
 
-web_link=link
+web\ link=link
 
-What_do_you_want_to_do?=Hvad_vil_du_gøre?
+What\ do\ you\ want\ to\ do?=Hvad vil du gøre?
 
-When_adding/removing_keywords,_separate_them_by=Når_nøgleord_tilføjes_eller_fjernes,_adskil_dem_med
-Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.=Skriver_XMP-metadata_til_PDF-filerne_linket_fra_de_valgte_poster.
+When\ adding/removing\ keywords,\ separate\ them\ by=Når nøgleord tilføjes eller fjernes, adskil dem med
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Skriver XMP-metadata til PDF-filerne linket fra de valgte poster.
 
 with=med
 
-Write_BibTeXEntry_as_XMP-metadata_to_PDF.=Skriv_BibTeX-posten_som_XMP-metadata_til_PDF.
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Skriv BibTeX-posten som XMP-metadata til PDF.
 
-Write_XMP=Skriv_XMP
-Write_XMP-metadata=Skriv_XMP-metadata
-Write_XMP-metadata_for_all_PDFs_in_current_library?=Skriv_XMP-metadata_for_alle_PDFer_i_denne_library?
-Writing_XMP-metadata...=Skriver_XMP-metadata...
-Writing_XMP-metadata_for_selected_entries...=Skriver_XMP-metadata_for_de_valgte_poster...
+Write\ XMP=Skriv XMP
+Write\ XMP-metadata=Skriv XMP-metadata
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Skriv XMP-metadata for alle PDFer i denne library?
+Writing\ XMP-metadata...=Skriver XMP-metadata...
+Writing\ XMP-metadata\ for\ selected\ entries...=Skriver XMP-metadata for de valgte poster...
 
-Wrote_XMP-metadata=Skrev_XMP-metadata
+Wrote\ XMP-metadata=Skrev XMP-metadata
 
-XMP-annotated_PDF=XMP-annoteret_PDF
-XMP_export_privacy_settings=Indstillinger_for_XMP-eksport
+XMP-annotated\ PDF=XMP-annoteret PDF
+XMP\ export\ privacy\ settings=Indstillinger for XMP-eksport
 XMP-metadata=XMP-metadata
-XMP-metadata_found_in_PDF\:_%0=XMP-metadata_fundet_i_PDF\:_%0
-You_must_restart_JabRef_for_this_to_come_into_effect.=Du_skal_genstarte_JabRef_for,_at_dette_skal_træde_i_kraft.
-You_have_changed_the_language_setting.=Du_har_valgt_et_nyt_sprog.
-You_have_entered_an_invalid_search_'%0'.=Ugyldigt_søgeudtryk_'%0'.
+XMP-metadata\ found\ in\ PDF\:\ %0=XMP-metadata fundet i PDF: %0
+You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Du skal genstarte JabRef for, at dette skal træde i kraft.
+You\ have\ changed\ the\ language\ setting.=Du har valgt et nyt sprog.
+You\ have\ entered\ an\ invalid\ search\ '%0'.=Ugyldigt søgeudtryk '%0'.
 
-You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.=Du_skal_genstarte_JabRef_for,_at_de_nye_genvejstaster_skal_fungere.
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Du skal genstarte JabRef for, at de nye genvejstaster skal fungere.
 
-Your_new_key_bindings_have_been_stored.=Dine_nye_genvejstaster_er_blevet_gemt.
+Your\ new\ key\ bindings\ have\ been\ stored.=Dine nye genvejstaster er blevet gemt.
 
-The_following_fetchers_are_available\:=Følgende_henteværktøjer_er_tilgængelige\:
-Could_not_find_fetcher_'%0'=Kunne_ikke_finde_henteværktøjet_'%0'
-Running_query_'%0'_with_fetcher_'%1'.=Kører_forespørgsel_'%0'_med_henteværktøjet_'%1'.
-Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.=Forespørgsel_'%0'_med_henteværktøjet_'%1'_returnerede_ingen_resultater.
+The\ following\ fetchers\ are\ available\:=Følgende henteværktøjer er tilgængelige:
+Could\ not\ find\ fetcher\ '%0'=Kunne ikke finde henteværktøjet '%0'
+Running\ query\ '%0'\ with\ fetcher\ '%1'.=Kører forespørgsel '%0' med henteværktøjet '%1'.
+Query\ '%0'\ with\ fetcher\ '%1'\ did\ not\ return\ any\ results.=Forespørgsel '%0' med henteværktøjet '%1' returnerede ingen resultater.
 
-Move_file=Flyt_fil
-Rename_file=omdøb_fil
+Move\ file=Flyt fil
+Rename\ file=omdøb fil
 
-Move_file_failed=Flytning_af_fil_mislykkedes
-Could_not_move_file_'%0'.=Kunne_ikke_flytte_fil_'%0'.
-Could_not_find_file_'%0'.=Kunne_ikke_finde_filen_'%0'.
-Number_of_entries_successfully_imported=Antal_poster_korrekt_importeret
-Import_canceled_by_user=Import_afbrudt_af_bruger
-Progress\:_%0_of_%1=Fremskridt\:_%0_af_%1
-Error_while_fetching_from_%0=Fejl_under_hentning_fra_%0
+Move\ file\ failed=Flytning af fil mislykkedes
+Could\ not\ move\ file\ '%0'.=Kunne ikke flytte fil '%0'.
+Could\ not\ find\ file\ '%0'.=Kunne ikke finde filen '%0'.
+Number\ of\ entries\ successfully\ imported=Antal poster korrekt importeret
+Import\ canceled\ by\ user=Import afbrudt af bruger
+Progress\:\ %0\ of\ %1=Fremskridt: %0 af %1
+Error\ while\ fetching\ from\ %0=Fejl under hentning fra %0
 
-Please_enter_a_valid_number=Indtast_venligst_et_gyldigt_tal
-Show_search_results_in_a_window=Vis_søgeresultater_i_et_vindue
-Show_global_search_results_in_a_window=
-Search_in_all_open_libraries=
-Move_file_to_file_directory?=Flyt_fil_til_filbibliotek?
+Please\ enter\ a\ valid\ number=Indtast venligst et gyldigt tal
+Show\ search\ results\ in\ a\ window=Vis søgeresultater i et vindue
+Show\ global\ search\ results\ in\ a\ window=
+Search\ in\ all\ open\ libraries=
+Move\ file\ to\ file\ directory?=Flyt fil til filbibliotek?
 
-Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.=Libraryn_er_beskyttet._Kan_ikke_gemme_før_eksterne_ændringer_er_gennemset.
-Protected_library=Beskyttet_library
-Refuse_to_save_the_library_before_external_changes_have_been_reviewed.=Nægt_at_gemme_library_før_eksterne_ændringer_er_gennemset.
-Library_protection=Library-beskyttelse
-Unable_to_save_library=Kan_ikke_gemme_library
+Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=Libraryn er beskyttet. Kan ikke gemme før eksterne ændringer er gennemset.
+Protected\ library=Beskyttet library
+Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=Nægt at gemme library før eksterne ændringer er gennemset.
+Library\ protection=Library-beskyttelse
+Unable\ to\ save\ library=Kan ikke gemme library
 
-BibTeX_key_generator=BibTeX-nøglegenerator
-Unable_to_open_link.=Kan_ikke_åbne_link.
-Move_the_keyboard_focus_to_the_entry_table=Flyt_tastatur-fokus_til_hovedtabellen
-MIME_type=MIME-type
+BibTeX\ key\ generator=BibTeX-nøglegenerator
+Unable\ to\ open\ link.=Kan ikke åbne link.
+Move\ the\ keyboard\ focus\ to\ the\ entry\ table=Flyt tastatur-fokus til hovedtabellen
+MIME\ type=MIME-type
 
-This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.=Denne_funktion_tillader,_at_flere_filer_kan_åbnes_eller_importeres_i_en_allerede_kørende_JabRef<BR>i_stedet_for_at_åbne_programmet_påny._For_eksempel_er_dette_praktisk,_når_du_åbner_filer_i<BR>JabRef_fra_din_web_browser.<BR>Bemærk_at_dette_vil_forhindre_dig_i_at_køre_mere_end_en_instans_af_JabRef_ad_gangen.
-Run_fetcher,_e.g._"--fetch\=Medline\:cancer"=Kør_henteværktøj,_f.eks._"--fetch\=Medline\:cancer"
+This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef<BR>instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef<br>from\ your\ web\ browser.<BR>Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=Denne funktion tillader, at flere filer kan åbnes eller importeres i en allerede kørende JabRef<BR>i stedet for at åbne programmet påny. For eksempel er dette praktisk, når du åbner filer i<BR>JabRef fra din web browser.<BR>Bemærk at dette vil forhindre dig i at køre mere end en instans af JabRef ad gangen.
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=Kør henteværktøj, f.eks. "--fetch=Medline:cancer"
 
-The_ACM_Digital_Library=ACM_Digital_Library
+The\ ACM\ Digital\ Library=ACM Digital Library
 Reset=Nulstil
 
-Use_IEEE_LaTeX_abbreviations=Brug_IEEE-LaTeX-forkortelser
-The_Guide_to_Computing_Literature=The_Guide_to_Computing_Literature
+Use\ IEEE\ LaTeX\ abbreviations=Brug IEEE-LaTeX-forkortelser
+The\ Guide\ to\ Computing\ Literature=The Guide to Computing Literature
 
-When_opening_file_link,_search_for_matching_file_if_no_link_is_defined=Søg_efter_en_matchende_fil,_når_der_åbnes_et_fil-link,_der_ikke_er_defineret
-Settings_for_%0=Indstillinger_for_%0
-Mark_entries_imported_into_an_existing_library=Mærk_poster_som_importeres_til_en_eksisterende_library
-Unmark_all_entries_before_importing_new_entries_into_an_existing_library=Fjern_mærkning_fra_alle_poster_før_import_af_nye_poster_til_en_eksisterende_library
+When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=Søg efter en matchende fil, når der åbnes et fil-link, der ikke er defineret
+Settings\ for\ %0=Indstillinger for %0
+Mark\ entries\ imported\ into\ an\ existing\ library=Mærk poster som importeres til en eksisterende library
+Unmark\ all\ entries\ before\ importing\ new\ entries\ into\ an\ existing\ library=Fjern mærkning fra alle poster før import af nye poster til en eksisterende library
 
 Forward=Frem
 Back=Tilbage
-Sort_the_following_fields_as_numeric_fields=Sorter_følgende_felter_som_numeriske_felter
-Line_%0\:_Found_corrupted_BibTeX_key.=Linje_%0\:_Fandt_ødelagt_BibTeX-nøgle.
-Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).=Linje_%0\:_Fandt_ødelagt_BibTeX-nøgle_(indeholder_blanktegn).
-Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).=Linje_%0\:_Fandt_ødelagt_BibTeX-nøgle_(manglende_komma).
-Full_text_document_download_failed=Download_af_fuldtekst-dokument_mislykkedes
-Update_to_current_column_order=Brug_nuværende_kolonnerækkefølge
-Download_from_URL=
-Rename_field=Omdøb_felt
-Set/clear/append/rename_fields=Sæt/ryd/omdøb_felter
-Append_field=
-Append_to_fields=
-Rename_field_to=Omdøb_felt_til
-Move_contents_of_a_field_into_a_field_with_a_different_name=Flyt_indhold_af_et_felt_til_et_felt_med_et_andet_navn
-You_can_only_rename_one_field_at_a_time=Du_kan_kun_omdøbe_et_felt_ad_gangen
+Sort\ the\ following\ fields\ as\ numeric\ fields=Sorter følgende felter som numeriske felter
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=Linje %0: Fandt ødelagt BibTeX-nøgle.
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=Linje %0: Fandt ødelagt BibTeX-nøgle (indeholder blanktegn).
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=Linje %0: Fandt ødelagt BibTeX-nøgle (manglende komma).
+Full\ text\ document\ download\ failed=Download af fuldtekst-dokument mislykkedes
+Update\ to\ current\ column\ order=Brug nuværende kolonnerækkefølge
+Download\ from\ URL=
+Rename\ field=Omdøb felt
+Set/clear/append/rename\ fields=Sæt/ryd/omdøb felter
+Append\ field=
+Append\ to\ fields=
+Rename\ field\ to=Omdøb felt til
+Move\ contents\ of\ a\ field\ into\ a\ field\ with\ a\ different\ name=Flyt indhold af et felt til et felt med et andet navn
+You\ can\ only\ rename\ one\ field\ at\ a\ time=Du kan kun omdøbe et felt ad gangen
 
-Remove_all_broken_links=Fjern_alle_ødelagte_links
+Remove\ all\ broken\ links=Fjern alle ødelagte links
 
-Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.=Kan_ikke_bruge_port_%0_til_fjernstyring;_et_andet_program_bruger_den_måske._Prøv_en_anden_port.
+Cannot\ use\ port\ %0\ for\ remote\ operation;\ another\ application\ may\ be\ using\ it.\ Try\ specifying\ another\ port.=Kan ikke bruge port %0 til fjernstyring; et andet program bruger den måske. Prøv en anden port.
 
-Looking_for_full_text_document...=Søger_efter_tekstdokument...
-Autosave=Automatisk_sikkerhedskopi
-A_local_copy_will_be_opened.=
-Autosave_local_libraries=
-Automatically_save_the_library_to=
-Please_enter_a_valid_file_path.=
+Looking\ for\ full\ text\ document...=Søger efter tekstdokument...
+Autosave=Automatisk sikkerhedskopi
+A\ local\ copy\ will\ be\ opened.=
+Autosave\ local\ libraries=
+Automatically\ save\ the\ library\ to=
+Please\ enter\ a\ valid\ file\ path.=
 
 
-Export_in_current_table_sort_order=Eksporter_med_nuværende_tabel-sortering
-Export_entries_in_their_original_order=Eksporter_poster_med_den_oprindelige_sortering
-Error_opening_file_'%0'.=Fejl_ved_åbning_af_filen_'%0'.
+Export\ in\ current\ table\ sort\ order=Eksporter med nuværende tabel-sortering
+Export\ entries\ in\ their\ original\ order=Eksporter poster med den oprindelige sortering
+Error\ opening\ file\ '%0'.=Fejl ved åbning af filen '%0'.
 
-Formatter_not_found\:_%0=Formatering_ikke_fundet\:_%0
-Clear_inputarea=Ryd_inputområde
+Formatter\ not\ found\:\ %0=Formatering ikke fundet: %0
+Clear\ inputarea=Ryd inputområde
 
-Automatically_set_file_links_for_this_entry=Sæt_automatisk_fil-links_for_denne_post
-Could_not_save,_file_locked_by_another_JabRef_instance.=Kunne_ikke_gemme,_filen_er_låst_af_en_anden_kørende_JabRef.
-File_is_locked_by_another_JabRef_instance.=Filen_er_låst_af_en_anden_kørende_JabRef.
-Do_you_want_to_override_the_file_lock?=Vil_du_ignorere,_at_filen_er_låst?
-File_locked=Fil_låst
-Current_tmp_value=Aktuel_tmp-værdi
-Metadata_change=Metadata-ændring
-Changes_have_been_made_to_the_following_metadata_elements=Der_er_ændringer_i_følgende_metadata-elementer
+Automatically\ set\ file\ links\ for\ this\ entry=Sæt automatisk fil-links for denne post
+Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=Kunne ikke gemme, filen er låst af en anden kørende JabRef.
+File\ is\ locked\ by\ another\ JabRef\ instance.=Filen er låst af en anden kørende JabRef.
+Do\ you\ want\ to\ override\ the\ file\ lock?=Vil du ignorere, at filen er låst?
+File\ locked=Fil låst
+Current\ tmp\ value=Aktuel tmp-værdi
+Metadata\ change=Metadata-ændring
+Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=Der er ændringer i følgende metadata-elementer
 
-Generate_groups_for_author_last_names=Generer_grupper_for_forfatteres_efternavne
-Generate_groups_from_keywords_in_a_BibTeX_field=Generer_grupper_ud_fra_nøgleord_i_et_BibTeX-felt
-Enforce_legal_characters_in_BibTeX_keys=Håndhæv_tilladte_tegn_i_BibTeX-nøgler
+Generate\ groups\ for\ author\ last\ names=Generer grupper for forfatteres efternavne
+Generate\ groups\ from\ keywords\ in\ a\ BibTeX\ field=Generer grupper ud fra nøgleord i et BibTeX-felt
+Enforce\ legal\ characters\ in\ BibTeX\ keys=Håndhæv tilladte tegn i BibTeX-nøgler
 
-Save_without_backup?=Gem_uden_sikkerhedskopi?
-Unable_to_create_backup=Kan_ikke_oprette_sikkerhedskopi
-Move_file_to_file_directory=Flyt_fil_til_filbibliotek
-Rename_file_to=Omdøb_fil_til
-<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)=<b>Alle_poster</b>_(denne_gruppe_kan_ikke_redigeres_eller_flyttes)
-static_group=statisk_gruppe
-dynamic_group=dynamisk_gruppe
-refines_supergroup=afgrænser_overgruppen
-includes_subgroups=inkluderer_undergrupper
+Save\ without\ backup?=Gem uden sikkerhedskopi?
+Unable\ to\ create\ backup=Kan ikke oprette sikkerhedskopi
+Move\ file\ to\ file\ directory=Flyt fil til filbibliotek
+Rename\ file\ to=Omdøb fil til
+<b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=<b>Alle poster</b> (denne gruppe kan ikke redigeres eller flyttes)
+static\ group=statisk gruppe
+dynamic\ group=dynamisk gruppe
+refines\ supergroup=afgrænser overgruppen
+includes\ subgroups=inkluderer undergrupper
 contains=indeholder
-search_expression=søge-udtry
+search\ expression=søge-udtry
 
-Optional_fields_2=Valgfri_felter_2
-Waiting_for_save_operation_to_finish=Venter_på_gemme-operation
-Resolving_duplicate_BibTeX_keys...=Udreder_dublerede_BibTeX-nøgler...
-Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.=Udredning_af_dublerede_BibTeX-nøgler_afsluttet._%0_poster_ændret.
-This_library_contains_one_or_more_duplicated_BibTeX_keys.=Denne_library_indeholder_en_eller_flere_dublerede_BibTeX-nøgler.
-Do_you_want_to_resolve_duplicate_keys_now?=Vil_du_udrede_dublerede_BibTeX-nøgler_nu?
+Optional\ fields\ 2=Valgfri felter 2
+Waiting\ for\ save\ operation\ to\ finish=Venter på gemme-operation
+Resolving\ duplicate\ BibTeX\ keys...=Udreder dublerede BibTeX-nøgler...
+Finished\ resolving\ duplicate\ BibTeX\ keys.\ %0\ entries\ modified.=Udredning af dublerede BibTeX-nøgler afsluttet. %0 poster ændret.
+This\ library\ contains\ one\ or\ more\ duplicated\ BibTeX\ keys.=Denne library indeholder en eller flere dublerede BibTeX-nøgler.
+Do\ you\ want\ to\ resolve\ duplicate\ keys\ now?=Vil du udrede dublerede BibTeX-nøgler nu?
 
-Find_and_remove_duplicate_BibTeX_keys=Find_og_fjern_dublederede_BibTeX-nøgler
-Expected_syntax_for_--fetch\='<name_of_fetcher>\:<query>'=Forventet_syntaks_for_--fetch='<navn_på_henteværktøj>\:<forespørgsel>'
-Duplicate_BibTeX_key=Dubleret_BibTeX-nøgle
-Import_marking_color=Farve_til_mærkning_af_importerede_poster
-Always_add_letter_(a,_b,_...)_to_generated_keys=Tilføj_altid_bogstav_(a,_b,_...)_til_genererede_nøgler
+Find\ and\ remove\ duplicate\ BibTeX\ keys=Find og fjern dublederede BibTeX-nøgler
+Expected\ syntax\ for\ --fetch\='<name\ of\ fetcher>\:<query>'=Forventet syntaks for --fetch='<navn på henteværktøj>:<forespørgsel>'
+Duplicate\ BibTeX\ key=Dubleret BibTeX-nøgle
+Import\ marking\ color=Farve til mærkning af importerede poster
+Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=Tilføj altid bogstav (a, b, ...) til genererede nøgler
 
-Ensure_unique_keys_using_letters_(a,_b,_...)=Garantér_unikke_nøgler_med_bogstaver_(a,_b,_...)
-Ensure_unique_keys_using_letters_(b,_c,_...)=Garantér_unikke_nøgler_med_bogstaver_(b,_c,_...)
-Entry_editor_active_background_color=Aktiv_baggrundsfarve_i_postredigering
-Entry_editor_background_color=Baggrundsfarve_i_postredigering
-Entry_editor_font_color=Tekstfarve_i_postredigering
-Entry_editor_invalid_field_color=Farve_på_ugyldige_felter_i_postredigering
+Ensure\ unique\ keys\ using\ letters\ (a,\ b,\ ...)=Garantér unikke nøgler med bogstaver (a, b, ...)
+Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=Garantér unikke nøgler med bogstaver (b, c, ...)
+Entry\ editor\ active\ background\ color=Aktiv baggrundsfarve i postredigering
+Entry\ editor\ background\ color=Baggrundsfarve i postredigering
+Entry\ editor\ font\ color=Tekstfarve i postredigering
+Entry\ editor\ invalid\ field\ color=Farve på ugyldige felter i postredigering
 
-Table_and_entry_editor_colors=Farver_i_tabel_og_postredigering
+Table\ and\ entry\ editor\ colors=Farver i tabel og postredigering
 
-General_file_directory=Generelt_filbibliotek
-User-specific_file_directory=Brugerspecifikt_filbibliotek
-Search_failed\:_illegal_search_expression=Søgning_fejlede\:_illegalt_søgeudtryk
-Show_ArXiv_column=Vis_ArXiv-kolonne
+General\ file\ directory=Generelt filbibliotek
+User-specific\ file\ directory=Brugerspecifikt filbibliotek
+Search\ failed\:\ illegal\ search\ expression=Søgning fejlede: illegalt søgeudtryk
+Show\ ArXiv\ column=Vis ArXiv-kolonne
 
-You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for=Der_skal_indtastes_et_heltal_i_intervallet_1025-65535_i_tekstfeltet_til
-Automatically_open_browse_dialog_when_creating_new_file_link=Åbn_automatisk_fildialog_når_nyt_link_oprettes
-Import_metadata_from\:=Importer_metadata_fra\:
-Choose_the_source_for_the_metadata_import=Vælg_kilde_for_import_af_metadata
-Create_entry_based_on_XMP-metadata=Opret_post_baseret_på_XMP-data
-Create_blank_entry_linking_the_PDF=Opret_tom_post_med_link_til_PDF-filen
-Only_attach_PDF=Tilføj_kun_PDF
+You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=Der skal indtastes et heltal i intervallet 1025-65535 i tekstfeltet til
+Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Åbn automatisk fildialog når nyt link oprettes
+Import\ metadata\ from\:=Importer metadata fra:
+Choose\ the\ source\ for\ the\ metadata\ import=Vælg kilde for import af metadata
+Create\ entry\ based\ on\ XMP-metadata=Opret post baseret på XMP-data
+Create\ blank\ entry\ linking\ the\ PDF=Opret tom post med link til PDF-filen
+Only\ attach\ PDF=Tilføj kun PDF
 Title=Titel
-Create_new_entry=Opret_ny_post
-Update_existing_entry=Opdater_eksisterende_post
-Autocomplete_names_in_'Firstname_Lastname'_format_only=Autofuldfør_kun_navne_i_formatet_'Fornavn_Efternavn'
-Autocomplete_names_in_'Lastname,_Firstname'_format_only=Autofuldfør_kun_navne_i_formatet_'Efternavn,_Fornavn'
-Autocomplete_names_in_both_formats=Autofuldfør_navne_i_begge_formater
-Marking_color_%0=Mærkningsfarve_%0
-The_name_'comment'_cannot_be_used_as_an_entry_type_name.=Navnet_'comment'_kan_ikke_bruges_som_navn_på_en_posttype.
-You_must_enter_an_integer_value_in_the_text_field_for=Der_skal_indtastes_et_heltal_i_tekstfeltet_til
-Send_as_email=Send_som_email
+Create\ new\ entry=Opret ny post
+Update\ existing\ entry=Opdater eksisterende post
+Autocomplete\ names\ in\ 'Firstname\ Lastname'\ format\ only=Autofuldfør kun navne i formatet 'Fornavn Efternavn'
+Autocomplete\ names\ in\ 'Lastname,\ Firstname'\ format\ only=Autofuldfør kun navne i formatet 'Efternavn, Fornavn'
+Autocomplete\ names\ in\ both\ formats=Autofuldfør navne i begge formater
+Marking\ color\ %0=Mærkningsfarve %0
+The\ name\ 'comment'\ cannot\ be\ used\ as\ an\ entry\ type\ name.=Navnet 'comment' kan ikke bruges som navn på en posttype.
+You\ must\ enter\ an\ integer\ value\ in\ the\ text\ field\ for=Der skal indtastes et heltal i tekstfeltet til
+Send\ as\ email=Send som email
 References=Referencer
-Sending_of_emails=Afsendelse_af_emails
-Subject_for_sending_an_email_with_references=Emne_for_afsendelse_af_en_email_med_referencer
-Automatically_open_folders_of_attached_files=Åbn_automatisk_biblioteker_for_vedhæftede_filer
-Create_entry_based_on_content=Opret_post_baseret_på_indhold
-Do_not_show_this_box_again_for_this_import=Vis_ikke_denne_dialogboks_igen_for_denne_import
-Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)=Brug_altid_denne_PDF-importstil_(og_spørg_ikke_for_hver_enkelt_import)
-Error_creating_email=Fejl_ved_oprettelse_af_email
-Entries_added_to_an_email=Poster_tilføjet_til_en_email
+Sending\ of\ emails=Afsendelse af emails
+Subject\ for\ sending\ an\ email\ with\ references=Emne for afsendelse af en email med referencer
+Automatically\ open\ folders\ of\ attached\ files=Åbn automatisk biblioteker for vedhæftede filer
+Create\ entry\ based\ on\ content=Opret post baseret på indhold
+Do\ not\ show\ this\ box\ again\ for\ this\ import=Vis ikke denne dialogboks igen for denne import
+Always\ use\ this\ PDF\ import\ style\ (and\ do\ not\ ask\ for\ each\ import)=Brug altid denne PDF-importstil (og spørg ikke for hver enkelt import)
+Error\ creating\ email=Fejl ved oprettelse af email
+Entries\ added\ to\ an\ email=Poster tilføjet til en email
 exportFormat=Eksportformat
-Output_file_missing=Output-fil_mangler
-No_search_matches.=Ingen_søgeresultater.
-The_output_option_depends_on_a_valid_input_option.=Outputindstilling_kræver_en_gyldig_inputindstilling.
-Default_import_style_for_drag_and_drop_of_PDFs=Standard_importstil_for_træk&slip_af_PDFer
-Default_PDF_file_link_action=Standard_PDF_fillink-handling
-Filename_format_pattern=Filnavn-formatskabelon
-Additional_parameters=Yderligere_parametre
-Cite_selected_entries_between_parenthesis=Referer_valgte_poster
-Cite_selected_entries_with_in-text_citation=Referer_valgte_poster_med_reference_i_teksten
-Cite_special=Specialreference
-Extra_information_(e.g._page_number)=Ekstra_information_(f.eks._sidenr.)
-Manage_citations=Administrer_referencer
-Problem_modifying_citation=Der_opstod_et_problem_med_at_ændre_referencen
+Output\ file\ missing=Output-fil mangler
+No\ search\ matches.=Ingen søgeresultater.
+The\ output\ option\ depends\ on\ a\ valid\ input\ option.=Outputindstilling kræver en gyldig inputindstilling.
+Default\ import\ style\ for\ drag\ and\ drop\ of\ PDFs=Standard importstil for træk&slip af PDFer
+Default\ PDF\ file\ link\ action=Standard PDF fillink-handling
+Filename\ format\ pattern=Filnavn-formatskabelon
+Additional\ parameters=Yderligere parametre
+Cite\ selected\ entries\ between\ parenthesis=Referer valgte poster
+Cite\ selected\ entries\ with\ in-text\ citation=Referer valgte poster med reference i teksten
+Cite\ special=Specialreference
+Extra\ information\ (e.g.\ page\ number)=Ekstra information (f.eks. sidenr.)
+Manage\ citations=Administrer referencer
+Problem\ modifying\ citation=Der opstod et problem med at ændre referencen
 Citation=Reference
-Extra_information=Ekstra_information
-Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.=Kunne_ikke_udrede_BibTeX-post_for_referencen_'%0'.
-Select_style=Vælg_stil
+Extra\ information=Ekstra information
+Could\ not\ resolve\ BibTeX\ entry\ for\ citation\ marker\ '%0'.=Kunne ikke udrede BibTeX-post for referencen '%0'.
+Select\ style=Vælg stil
 Journals=Tidsskrifter
 Cite=Referer
-Cite_in-text=Referer_i_teksten
-Insert_empty_citation=Indsæt_tom_reference
-Merge_citations=Sammenføj_referencer
-Manual_connect=Manuel_tilslutning
-Select_Writer_document=Vælg_Writer-dokument
-Sync_OpenOffice/LibreOffice_bibliography=Synkroniser_med_OpenOffice/LibreOffice-bibliografi
-Select_which_open_Writer_document_to_work_on=Vælg_hvilket_åbent_Writer-dokument_du_vil_arbejde_på
-Connected_to_document=Forbundet_til_dokument
-Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)=Indsæt_en_reference_uden_tekst_(referencen_optræder_i_referencelisten)
-Cite_selected_entries_with_extra_information=Referer_valgte_poster_med_ekstra_information
-Ensure_that_the_bibliography_is_up-to-date=Sørg_for_at_bibliografien_er_opdateret
-Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.=Dit_OpenOffice/LibreOffice-dokument_refererer_til_BibTeX-nøglen_'%0',_som_ikke_kunne_findes_i_din_aktuelle_library.
-Unable_to_synchronize_bibliography=Kunne_ikke_synkronisere_bibliografi
-Combine_pairs_of_citations_that_are_separated_by_spaces_only=Kombiner_referencepar_der_kun_er_adskilt_med_mellemrum
-Autodetection_failed=Autodetektion_fejlede
+Cite\ in-text=Referer i teksten
+Insert\ empty\ citation=Indsæt tom reference
+Merge\ citations=Sammenføj referencer
+Manual\ connect=Manuel tilslutning
+Select\ Writer\ document=Vælg Writer-dokument
+Sync\ OpenOffice/LibreOffice\ bibliography=Synkroniser med OpenOffice/LibreOffice-bibliografi
+Select\ which\ open\ Writer\ document\ to\ work\ on=Vælg hvilket åbent Writer-dokument du vil arbejde på
+Connected\ to\ document=Forbundet til dokument
+Insert\ a\ citation\ without\ text\ (the\ entry\ will\ appear\ in\ the\ reference\ list)=Indsæt en reference uden tekst (referencen optræder i referencelisten)
+Cite\ selected\ entries\ with\ extra\ information=Referer valgte poster med ekstra information
+Ensure\ that\ the\ bibliography\ is\ up-to-date=Sørg for at bibliografien er opdateret
+Your\ OpenOffice/LibreOffice\ document\ references\ the\ BibTeX\ key\ '%0',\ which\ could\ not\ be\ found\ in\ your\ current\ library.=Dit OpenOffice/LibreOffice-dokument refererer til BibTeX-nøglen '%0', som ikke kunne findes i din aktuelle library.
+Unable\ to\ synchronize\ bibliography=Kunne ikke synkronisere bibliografi
+Combine\ pairs\ of\ citations\ that\ are\ separated\ by\ spaces\ only=Kombiner referencepar der kun er adskilt med mellemrum
+Autodetection\ failed=Autodetektion fejlede
 Connecting=Tilslutter
-Please_wait...=Vent_venligst...
-Set_connection_parameters=Opsæt_forbindelsesindstillinger
-Path_to_OpenOffice/LibreOffice_directory=Sti_til_OpenOffice/LibreOffice-bibliotek
-Path_to_OpenOffice/LibreOffice_executable=Sti_til_OpenOffice/LibreOffice-programfil
-Path_to_OpenOffice/LibreOffice_library_dir=Sti_til_OpenOffice/LibreOffice-biblioteksfil
-Connection_lost=Forbindelse_tabt
-The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.=Afsnitsformatet_styres_af_indstillingen_'ReferenceParagraphFormat'_eller_'ReferenceHeaderParagraphFormat'_i_stil-filen.
-The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.=Tegnformatet_styres_af_referenceindstillingen_'CitationCharacterFormat'_i_stil-filen.
-Automatically_sync_bibliography_when_inserting_citations=Synkroniser_automatisk_bibliografi_når_der_indsættes_referencer
-Look_up_BibTeX_entries_in_the_active_tab_only=Slå_kun_BibTeX-poster_op_i_det_aktive_faneblad
-Look_up_BibTeX_entries_in_all_open_libraries=Slå_BibTeX-poster_op_i_alle_åbne_libraryr
-Autodetecting_paths...=Autodetekterer_stier
-Could_not_find_OpenOffice/LibreOffice_installation=Kunne_ikke_finde_OpenOffice/LibreOffice-installation
-Found_more_than_one_OpenOffice/LibreOffice_executable.=Fandt_mere_end_en_OpenOffice/LibreOffice-programfil.
-Please_choose_which_one_to_connect_to\:=Vælg_venligst_hvilken_der_skal_tilsluttes_til\:
-Choose_OpenOffice/LibreOffice_executable=Vælg_OpenOffice/LibreOffice-programfil
-Select_document=Vælg_dokument
-HTML_list=HTML-liste
-If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting=Om_muligt,_normaliser_denne_navneliste_til_standard_BibTeX-navneformatering
-Could_not_open_%0=Kunne_ikke_åbne_%0
-Unknown_import_format=Ukendt_importformat
-Web_search=Websøgning
-Style_selection=Valg_af_stil
-No_valid_style_file_defined=Ingen_gyldig_stilfil_defineret
-Choose_pattern=Vælg_mønster
-Use_the_BIB_file_location_as_primary_file_directory=Brug_placeringen_af_BIB-filen_som_standard_filbibliotek
-Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.=Kunne_ikke_køre_gnuclient/emacsclient._Tjek_at_du_har_programmet_installeret_og_tilgængeligt_i_PATH.
-OpenOffice/LibreOffice_connection=Forbindelse_til_OpenOffice/LibreOffice
-You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.=Du_skal_enten_vælge_en_gyldig_stilfil_eller_bruge_en_af_standardstilene.
+Please\ wait...=Vent venligst...
+Set\ connection\ parameters=Opsæt forbindelsesindstillinger
+Path\ to\ OpenOffice/LibreOffice\ directory=Sti til OpenOffice/LibreOffice-bibliotek
+Path\ to\ OpenOffice/LibreOffice\ executable=Sti til OpenOffice/LibreOffice-programfil
+Path\ to\ OpenOffice/LibreOffice\ library\ dir=Sti til OpenOffice/LibreOffice-biblioteksfil
+Connection\ lost=Forbindelse tabt
+The\ paragraph\ format\ is\ controlled\ by\ the\ property\ 'ReferenceParagraphFormat'\ or\ 'ReferenceHeaderParagraphFormat'\ in\ the\ style\ file.=Afsnitsformatet styres af indstillingen 'ReferenceParagraphFormat' eller 'ReferenceHeaderParagraphFormat' i stil-filen.
+The\ character\ format\ is\ controlled\ by\ the\ citation\ property\ 'CitationCharacterFormat'\ in\ the\ style\ file.=Tegnformatet styres af referenceindstillingen 'CitationCharacterFormat' i stil-filen.
+Automatically\ sync\ bibliography\ when\ inserting\ citations=Synkroniser automatisk bibliografi når der indsættes referencer
+Look\ up\ BibTeX\ entries\ in\ the\ active\ tab\ only=Slå kun BibTeX-poster op i det aktive faneblad
+Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=Slå BibTeX-poster op i alle åbne libraryr
+Autodetecting\ paths...=Autodetekterer stier
+Could\ not\ find\ OpenOffice/LibreOffice\ installation=Kunne ikke finde OpenOffice/LibreOffice-installation
+Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=Fandt mere end en OpenOffice/LibreOffice-programfil.
+Please\ choose\ which\ one\ to\ connect\ to\:=Vælg venligst hvilken der skal tilsluttes til:
+Choose\ OpenOffice/LibreOffice\ executable=Vælg OpenOffice/LibreOffice-programfil
+Select\ document=Vælg dokument
+HTML\ list=HTML-liste
+If\ possible,\ normalize\ this\ list\ of\ names\ to\ conform\ to\ standard\ BibTeX\ name\ formatting=Om muligt, normaliser denne navneliste til standard BibTeX-navneformatering
+Could\ not\ open\ %0=Kunne ikke åbne %0
+Unknown\ import\ format=Ukendt importformat
+Web\ search=Websøgning
+Style\ selection=Valg af stil
+No\ valid\ style\ file\ defined=Ingen gyldig stilfil defineret
+Choose\ pattern=Vælg mønster
+Use\ the\ BIB\ file\ location\ as\ primary\ file\ directory=Brug placeringen af BIB-filen som standard filbibliotek
+Could\ not\ run\ the\ gnuclient/emacsclient\ program.\ Make\ sure\ you\ have\ the\ emacsclient/gnuclient\ program\ installed\ and\ available\ in\ the\ PATH.=Kunne ikke køre gnuclient/emacsclient. Tjek at du har programmet installeret og tilgængeligt i PATH.
+OpenOffice/LibreOffice\ connection=Forbindelse til OpenOffice/LibreOffice
+You\ must\ select\ either\ a\ valid\ style\ file,\ or\ use\ one\ of\ the\ default\ styles.=Du skal enten vælge en gyldig stilfil eller bruge en af standardstilene.
 
-This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.=Dette_er_et_enkelt_klip-og-indsæt-vindue._Indlæs_eller_indsæt_først_tekst_i_tekstfeltet.<br>Derefter_kan_du_markere_tekst_og_tildele_den_til_BibTeX-felter.
-This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.=Denne_funktion_genererer_en_ny_library_baseret_på,_hvilke_poster_der_er_brugt_i_et_eksisterende_LaTeX-dokument.
-You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.=Du_skal_vælge_en_af_de_åbne_libraryr,_hvor_enheder_skal_hentes_fra,_udover_AUX-filen_genereret_af_LaTeX_når_dokumentet_kompileres.
+This\ is\ a\ simple\ copy\ and\ paste\ dialog.\ First\ load\ or\ paste\ some\ text\ into\ the\ text\ input\ area.<br>After\ that,\ you\ can\ mark\ text\ and\ assign\ it\ to\ a\ BibTeX\ field.=Dette er et enkelt klip-og-indsæt-vindue. Indlæs eller indsæt først tekst i tekstfeltet.<br>Derefter kan du markere tekst og tildele den til BibTeX-felter.
+This\ feature\ generates\ a\ new\ library\ based\ on\ which\ entries\ are\ needed\ in\ an\ existing\ LaTeX\ document.=Denne funktion genererer en ny library baseret på, hvilke poster der er brugt i et eksisterende LaTeX-dokument.
+You\ need\ to\ select\ one\ of\ your\ open\ libraries\ from\ which\ to\ choose\ entries,\ as\ well\ as\ the\ AUX\ file\ produced\ by\ LaTeX\ when\ compiling\ your\ document.=Du skal vælge en af de åbne libraryr, hvor enheder skal hentes fra, udover AUX-filen genereret af LaTeX når dokumentet kompileres.
 
-First_select_entries_to_clean_up.=
-Cleanup_entry=
-Autogenerate_PDF_Names=
-Auto-generating_PDF-Names_does_not_support_undo._Continue?=
+First\ select\ entries\ to\ clean\ up.=
+Cleanup\ entry=
+Autogenerate\ PDF\ Names=
+Auto-generating\ PDF-Names\ does\ not\ support\ undo.\ Continue?=
 
-Use_full_firstname_whenever_possible=
-Use_abbreviated_firstname_whenever_possible=
-Use_abbreviated_and_full_firstname=
-Autocompletion_options=
-Name_format_used_for_autocompletion=
-Treatment_of_first_names=
-Cleanup_entries=
-Automatically_assign_new_entry_to_selected_groups=Tildel_automatisk_nye_poster_til_valgte_grupper
-%0_mode=%0-tilstand
-Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix=
-Make_paths_of_linked_files_relative_(if_possible)=
-Rename_PDFs_to_given_filename_format_pattern=
-Rename_only_PDFs_having_a_relative_path=
-What_would_you_like_to_clean_up?=
-Doing_a_cleanup_for_%0_entries...=
-No_entry_needed_a_clean_up=
-One_entry_needed_a_clean_up=
-%0_entries_needed_a_clean_up=
+Use\ full\ firstname\ whenever\ possible=
+Use\ abbreviated\ firstname\ whenever\ possible=
+Use\ abbreviated\ and\ full\ firstname=
+Autocompletion\ options=
+Name\ format\ used\ for\ autocompletion=
+Treatment\ of\ first\ names=
+Cleanup\ entries=
+Automatically\ assign\ new\ entry\ to\ selected\ groups=Tildel automatisk nye poster til valgte grupper
+%0\ mode=%0-tilstand
+Move\ DOIs\ from\ note\ and\ URL\ field\ to\ DOI\ field\ and\ remove\ http\ prefix=
+Make\ paths\ of\ linked\ files\ relative\ (if\ possible)=
+Rename\ PDFs\ to\ given\ filename\ format\ pattern=
+Rename\ only\ PDFs\ having\ a\ relative\ path=
+What\ would\ you\ like\ to\ clean\ up?=
+Doing\ a\ cleanup\ for\ %0\ entries...=
+No\ entry\ needed\ a\ clean\ up=
+One\ entry\ needed\ a\ clean\ up=
+%0\ entries\ needed\ a\ clean\ up=
 
-Remove_selected=Fjern_valgte
+Remove\ selected=Fjern valgte
 
-Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.=
-Attach_file=
-Setting_all_preferences_to_default_values.=
-Resetting_preference_key_'%0'=
-Unknown_preference_key_'%0'=
-Unable_to_clear_preferences.=
+Group\ tree\ could\ not\ be\ parsed.\ If\ you\ save\ the\ BibTeX\ library,\ all\ groups\ will\ be\ lost.=
+Attach\ file=
+Setting\ all\ preferences\ to\ default\ values.=
+Resetting\ preference\ key\ '%0'=
+Unknown\ preference\ key\ '%0'=
+Unable\ to\ clear\ preferences.=
 
-Reset_preferences_(key1,key2,..._or_'all')=
-Find_unlinked_files=
-Unselect_all=
-Expand_all=
-Collapse_all=
-Opens_the_file_browser.=
-Scan_directory=
-Searches_the_selected_directory_for_unlinked_files.=
-Starts_the_import_of_BibTeX_entries.=
-Leave_this_dialog.=
-Create_directory_based_keywords=
-Creates_keywords_in_created_entrys_with_directory_pathnames=
-Select_a_directory_where_the_search_shall_start.=
-Select_file_type\:=
-These_files_are_not_linked_in_the_active_library.=
-Entry_type_to_be_created\:=
-Searching_file_system...=
-Importing_into_Library...=
-Select_directory=
-Select_files=
-BibTeX_entry_creation=
-<No_selection>=
-Unable_to_connect_to_FreeCite_online_service.=
-Parse_with_FreeCite=
-The_current_BibTeX_key_will_be_overwritten._Continue?=
-Overwrite_key=
-Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator=
-How_would_you_like_to_link_to_'%0'?=
-BibTeX_key_patterns=
-Changed_special_field_settings=
-Clear_priority=
-Clear_rank=
-Enable_special_fields=
-One_star=
-Two_stars=
-Three_stars=
-Four_stars=
-Five_stars=
-Help_on_special_fields=
-Keywords_of_selected_entries=
-Manage_content_selectors=
-Manage_keywords=
-No_priority_information=
-No_rank_information=
+Reset\ preferences\ (key1,key2,...\ or\ 'all')=
+Find\ unlinked\ files=
+Unselect\ all=
+Expand\ all=
+Collapse\ all=
+Opens\ the\ file\ browser.=
+Scan\ directory=
+Searches\ the\ selected\ directory\ for\ unlinked\ files.=
+Starts\ the\ import\ of\ BibTeX\ entries.=
+Leave\ this\ dialog.=
+Create\ directory\ based\ keywords=
+Creates\ keywords\ in\ created\ entrys\ with\ directory\ pathnames=
+Select\ a\ directory\ where\ the\ search\ shall\ start.=
+Select\ file\ type\:=
+These\ files\ are\ not\ linked\ in\ the\ active\ library.=
+Entry\ type\ to\ be\ created\:=
+Searching\ file\ system...=
+Importing\ into\ Library...=
+Select\ directory=
+Select\ files=
+BibTeX\ entry\ creation=
+<No\ selection>=
+Unable\ to\ connect\ to\ FreeCite\ online\ service.=
+Parse\ with\ FreeCite=
+The\ current\ BibTeX\ key\ will\ be\ overwritten.\ Continue?=
+Overwrite\ key=
+Not\ overwriting\ existing\ key.\ To\ change\ this\ setting,\ open\ Options\ ->\ Prefererences\ ->\ BibTeX\ key\ generator=
+How\ would\ you\ like\ to\ link\ to\ '%0'?=
+BibTeX\ key\ patterns=
+Changed\ special\ field\ settings=
+Clear\ priority=
+Clear\ rank=
+Enable\ special\ fields=
+One\ star=
+Two\ stars=
+Three\ stars=
+Four\ stars=
+Five\ stars=
+Help\ on\ special\ fields=
+Keywords\ of\ selected\ entries=
+Manage\ content\ selectors=
+Manage\ keywords=
+No\ priority\ information=
+No\ rank\ information=
 Priority=
-Priority_high=
-Priority_low=
-Priority_medium=
+Priority\ high=
+Priority\ low=
+Priority\ medium=
 Quality=
 Rank=
 Relevance=
-Set_priority_to_high=
-Set_priority_to_low=
-Set_priority_to_medium=
-Show_priority=
-Show_quality=
-Show_rank=
-Show_relevance=
-Synchronize_with_keywords=
-Synchronized_special_fields_based_on_keywords=
-Toggle_relevance=
-Toggle_quality_assured=
-Toggle_print_status=
-Update_keywords=
-Write_values_of_special_fields_as_separate_fields_to_BibTeX=
-You_have_changed_settings_for_special_fields.=
-%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.=
-A_string_with_that_label_already_exists=Der_findes_allerede_en_streng_med_dette_navn
-Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.=
-JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.=
-Correct_the_entry,_and_reopen_editor_to_display/edit_source.=
-Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').=
-Could_not_connect_to_running_OpenOffice/LibreOffice.=
-Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.=
-If_connecting_manually,_please_verify_program_and_library_paths.=
-Error_message\:=
-If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.=
-Import_metadata_from_PDF=
-Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.=
-Removed_all_subgroups_of_group_"%0".=
-To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.=
-Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.=
-Use_the_following_delimiter_character(s)\:=
-When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above=
-Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=
-Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=
+Set\ priority\ to\ high=
+Set\ priority\ to\ low=
+Set\ priority\ to\ medium=
+Show\ priority=
+Show\ quality=
+Show\ rank=
+Show\ relevance=
+Synchronize\ with\ keywords=
+Synchronized\ special\ fields\ based\ on\ keywords=
+Toggle\ relevance=
+Toggle\ quality\ assured=
+Toggle\ print\ status=
+Update\ keywords=
+Write\ values\ of\ special\ fields\ as\ separate\ fields\ to\ BibTeX=
+You\ have\ changed\ settings\ for\ special\ fields.=
+%0\ entries\ found.\ To\ reduce\ server\ load,\ only\ %1\ will\ be\ downloaded.=
+A\ string\ with\ that\ label\ already\ exists=Der findes allerede en streng med dette navn
+Connection\ to\ OpenOffice/LibreOffice\ has\ been\ lost.\ Please\ make\ sure\ OpenOffice/LibreOffice\ is\ running,\ and\ try\ to\ reconnect.=
+JabRef\ will\ send\ at\ least\ one\ request\ per\ entry\ to\ a\ publisher.=
+Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=
+Could\ not\ connect\ to\ a\ running\ gnuserv\ process.\ Make\ sure\ that\ Emacs\ or\ XEmacs\ is\ running,<BR>and\ that\ the\ server\ has\ been\ started\ (by\ running\ the\ command\ 'server-start'/'gnuserv-start').=
+Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=
+Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=
+If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=
+Error\ message\:=
+If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=
+Import\ metadata\ from\ PDF=
+Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=
+Removed\ all\ subgroups\ of\ group\ "%0".=
+To\ disable\ the\ memory\ stick\ mode\ rename\ or\ remove\ the\ jabref.xml\ file\ in\ the\ same\ folder\ as\ JabRef.=
+Unable\ to\ connect.\ One\ possible\ reason\ is\ that\ JabRef\ and\ OpenOffice/LibreOffice\ are\ not\ both\ running\ in\ either\ 32\ bit\ mode\ or\ 64\ bit\ mode.=
+Use\ the\ following\ delimiter\ character(s)\:=
+When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\ prefer\ the\ BIB\ file\ location\ rather\ than\ the\ file\ directory\ set\ above=
+Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=
+Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=
 
 Searching...=
-You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?=
-Confirm_selection=
-Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case=
-Import_conversions=
-Please_enter_a_search_string=
-Please_open_or_start_a_new_library_before_searching=
+You\ have\ selected\ more\ than\ %0\ entries\ for\ download.\ Some\ web\ sites\ might\ block\ you\ if\ you\ make\ too\ many\ rapid\ downloads.\ Do\ you\ want\ to\ continue?=
+Confirm\ selection=
+Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=
+Import\ conversions=
+Please\ enter\ a\ search\ string=
+Please\ open\ or\ start\ a\ new\ library\ before\ searching=
 
-Canceled_merging_entries=
+Canceled\ merging\ entries=
 
-Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search=
-Merge_entries=
-Merged_entries=
-Merged_entry=
+Format\ units\ by\ adding\ non-breaking\ separators\ and\ keeping\ the\ correct\ case\ on\ search=
+Merge\ entries=
+Merged\ entries=
+Merged\ entry=
 None=
 Parse=
 Result=
-Show_DOI_first=
-Show_URL_first=
-Use_Emacs_key_bindings=
-You_have_to_choose_exactly_two_entries_to_merge.=
+Show\ DOI\ first=
+Show\ URL\ first=
+Use\ Emacs\ key\ bindings=
+You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=
 
-Update_timestamp_on_modification=
-All_key_bindings_will_be_reset_to_their_defaults.=
+Update\ timestamp\ on\ modification=
+All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=
 
-Automatically_set_file_links=
-Resetting_all_key_bindings=
+Automatically\ set\ file\ links=
+Resetting\ all\ key\ bindings=
 Hostname=
-Invalid_setting=
+Invalid\ setting=
 Network=
-Please_specify_both_hostname_and_port=
-Please_specify_both_username_and_password=
+Please\ specify\ both\ hostname\ and\ port=
+Please\ specify\ both\ username\ and\ password=
 
-Use_custom_proxy_configuration=
-Proxy_requires_authentication=
-Attention\:_Password_is_stored_in_plain_text\!=
-Clear_connection_settings=
-Cleared_connection_settings.=
+Use\ custom\ proxy\ configuration=
+Proxy\ requires\ authentication=
+Attention\:\ Password\ is\ stored\ in\ plain\ text\!=
+Clear\ connection\ settings=
+Cleared\ connection\ settings.=
 
-Rebind_C-a,_too=
-Rebind_C-f,_too=
+Rebind\ C-a,\ too=
+Rebind\ C-f,\ too=
 
-Open_folder=
-Searches_for_unlinked_PDF_files_on_the_file_system=
-Export_entries_ordered_as_specified=
-Export_sort_order=
-Export_sorting=
-Newline_separator=
+Open\ folder=
+Searches\ for\ unlinked\ PDF\ files\ on\ the\ file\ system=
+Export\ entries\ ordered\ as\ specified=
+Export\ sort\ order=
+Export\ sorting=
+Newline\ separator=
 
-Save_entries_ordered_as_specified=
-Save_sort_order=
-Show_extra_columns=
-Parsing_error=
-illegal_backslash_expression=
+Save\ entries\ ordered\ as\ specified=
+Save\ sort\ order=
+Show\ extra\ columns=
+Parsing\ error=
+illegal\ backslash\ expression=
 
-Move_to_group=
+Move\ to\ group=
 
-Clear_read_status=
-Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')=
-Could_not_apply_changes.=
-Deprecated_fields=
-Hide/show_toolbar=
-No_read_status_information=
+Clear\ read\ status=
+Convert\ to\ biblatex\ format\ (for\ example,\ move\ the\ value\ of\ the\ 'journal'\ field\ to\ 'journaltitle')=
+Could\ not\ apply\ changes.=
+Deprecated\ fields=
+Hide/show\ toolbar=
+No\ read\ status\ information=
 Printed=
-Read_status=
-Read_status_read=
-Read_status_skimmed=
-Save_selected_as_plain_BibTeX...=
-Set_read_status_to_read=
-Set_read_status_to_skimmed=
-Show_deprecated_BibTeX_fields=
+Read\ status=
+Read\ status\ read=
+Read\ status\ skimmed=
+Save\ selected\ as\ plain\ BibTeX...=
+Set\ read\ status\ to\ read=
+Set\ read\ status\ to\ skimmed=
+Show\ deprecated\ BibTeX\ fields=
 
-Show_gridlines=
-Show_printed_status=
-Show_read_status=
-Table_row_height_padding=
+Show\ gridlines=
+Show\ printed\ status=
+Show\ read\ status=
+Table\ row\ height\ padding=
 
-Marked_selected_entry=
-Marked_all_%0_selected_entries=
-Unmarked_selected_entry=
-Unmarked_all_%0_selected_entries=
+Marked\ selected\ entry=
+Marked\ all\ %0\ selected\ entries=
+Unmarked\ selected\ entry=
+Unmarked\ all\ %0\ selected\ entries=
 
 
-Unmarked_all_entries=
+Unmarked\ all\ entries=
 
-Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.=
+Unable\ to\ find\ the\ requested\ look\ and\ feel\ and\ thus\ the\ default\ one\ is\ used.=
 
-Opens_JabRef's_GitHub_page=
-Could_not_open_browser.=
-Please_open_%0_manually.=
-The_link_has_been_copied_to_the_clipboard.=
+Opens\ JabRef's\ GitHub\ page=
+Could\ not\ open\ browser.=
+Please\ open\ %0\ manually.=
+The\ link\ has\ been\ copied\ to\ the\ clipboard.=
 
-Open_%0_file=
+Open\ %0\ file=
 
-Cannot_delete_file=
-File_permission_error=
-Push_to_%0=Send_til_%0
-Path_to_%0=Sti_til_%0
+Cannot\ delete\ file=
+File\ permission\ error=
+Push\ to\ %0=Send til %0
+Path\ to\ %0=Sti til %0
 Convert=
-Normalize_to_BibTeX_name_format=
-Help_on_Name_Formatting=
+Normalize\ to\ BibTeX\ name\ format=
+Help\ on\ Name\ Formatting=
 
-Add_new_file_type=
+Add\ new\ file\ type=
 
-Left_entry=
-Right_entry=
+Left\ entry=
+Right\ entry=
 Use=
-Original_entry=
-Replace_original_entry=
-No_information_added=
-Select_at_least_one_entry_to_manage_keywords.=
-OpenDocument_text=
-OpenDocument_spreadsheet=
-OpenDocument_presentation=
-%0_image=
-Added_entry=
-Modified_entry=
-Deleted_entry=
-Modified_groups_tree=
-Removed_all_groups=
-Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.=
-Select_export_format=
-Return_to_JabRef=
-Please_move_the_file_manually_and_link_in_place.=
-Could_not_connect_to_%0=Kunne_ikke_forbinde_til_%0
-Warning\:_%0_out_of_%1_entries_have_undefined_title.=
-Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.=
+Original\ entry=
+Replace\ original\ entry=
+No\ information\ added=
+Select\ at\ least\ one\ entry\ to\ manage\ keywords.=
+OpenDocument\ text=
+OpenDocument\ spreadsheet=
+OpenDocument\ presentation=
+%0\ image=
+Added\ entry=
+Modified\ entry=
+Deleted\ entry=
+Modified\ groups\ tree=
+Removed\ all\ groups=
+Accepting\ the\ change\ replaces\ the\ complete\ groups\ tree\ with\ the\ externally\ modified\ groups\ tree.=
+Select\ export\ format=
+Return\ to\ JabRef=
+Please\ move\ the\ file\ manually\ and\ link\ in\ place.=
+Could\ not\ connect\ to\ %0=Kunne ikke forbinde til %0
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ title.=
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ BibTeX\ key.=
 occurrence=
-Added_new_'%0'_entry.=
-Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?=
-Changed_type_to_'%0'_for=Ændrede_type_til_'%0'_for
-Really_delete_the_selected_entry?=
-Really_delete_the_%0_selected_entries?=
-Keep_merged_entry_only=
-Keep_left=
-Keep_right=
-Old_entry=
-From_import=
-No_problems_found.=
-%0_problem(s)_found=
-Save_changes=
-Discard_changes=
-Library_'%0'_has_changed.=
-Print_entry_preview=
-Copy_title=
-Copy_\\cite{BibTeX_key}=Kopier_\\cite{BibTeX-nøgler}
-Copy_BibTeX_key_and_title=
-File_rename_failed_for_%0_entries.=
-Merged_BibTeX_source_code=
-Invalid_DOI\:_'%0'.=Ugyldig_DOI\:_'%0'.
-should_start_with_a_name=
-should_end_with_a_name=
-unexpected_closing_curly_bracket=
-unexpected_opening_curly_bracket=
-capital_letters_are_not_masked_using_curly_brackets_{}=
-should_contain_a_four_digit_number=
-should_contain_a_valid_page_number_range=
+Added\ new\ '%0'\ entry.=
+Multiple\ entries\ selected.\ Do\ you\ want\ to\ change\ the\ type\ of\ all\ these\ to\ '%0'?=
+Changed\ type\ to\ '%0'\ for=Ændrede type til '%0' for
+Really\ delete\ the\ selected\ entry?=
+Really\ delete\ the\ %0\ selected\ entries?=
+Keep\ merged\ entry\ only=
+Keep\ left=
+Keep\ right=
+Old\ entry=
+From\ import=
+No\ problems\ found.=
+%0\ problem(s)\ found=
+Save\ changes=
+Discard\ changes=
+Library\ '%0'\ has\ changed.=
+Print\ entry\ preview=
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=Kopier \\cite{BibTeX-nøgler}
+Copy\ BibTeX\ key\ and\ title=
+File\ rename\ failed\ for\ %0\ entries.=
+Merged\ BibTeX\ source\ code=
+Invalid\ DOI\:\ '%0'.=Ugyldig DOI: '%0'.
+should\ start\ with\ a\ name=
+should\ end\ with\ a\ name=
+unexpected\ closing\ curly\ bracket=
+unexpected\ opening\ curly\ bracket=
+capital\ letters\ are\ not\ masked\ using\ curly\ brackets\ {}=
+should\ contain\ a\ four\ digit\ number=
+should\ contain\ a\ valid\ page\ number\ range=
 Filled=
-Field_is_missing=
-Search_%0=Søg_i_%0
+Field\ is\ missing=
+Search\ %0=Søg i %0
 
-Search_results_in_all_libraries_for_%0=
-Search_results_in_library_%0_for_%1=
-Search_globally=
-No_results_found.=
-Found_%0_results.=
-plain_text=
-This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>=
-This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>=
-This_search_contains_entries_in_which=
+Search\ results\ in\ all\ libraries\ for\ %0=
+Search\ results\ in\ library\ %0\ for\ %1=
+Search\ globally=
+No\ results\ found.=
+Found\ %0\ results.=
+plain\ text=
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ regular\ expression\ <b>%0</b>=
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ term\ <b>%0</b>=
+This\ search\ contains\ entries\ in\ which=
 
-Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.=
-JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>=
-This_library_uses_outdated_file_links.=
+Unable\ to\ autodetect\ OpenOffice/LibreOffice\ installation.\ Please\ choose\ the\ installation\ directory\ manually.=
+JabRef\ no\ longer\ supports\ 'ps'\ or\ 'pdf'\ fields.<br>File\ links\ are\ now\ stored\ in\ the\ 'file'\ field\ and\ files\ are\ stored\ in\ an\ external\ file\ directory.<br>To\ make\ use\ of\ this\ feature,\ JabRef\ needs\ to\ upgrade\ file\ links.<br><br>=
+This\ library\ uses\ outdated\ file\ links.=
 
-Clear_search=
-Close_library=
-Close_entry_editor=
-Decrease_table_font_size=
-Entry_editor,_next_entry=
-Entry_editor,_next_panel=
-Entry_editor,_next_panel_2=
-Entry_editor,_previous_entry=
-Entry_editor,_previous_panel=
-Entry_editor,_previous_panel_2=
-File_list_editor,_move_entry_down=
-File_list_editor,_move_entry_up=
-Focus_entry_table=
-Import_into_current_library=
-Import_into_new_library=
-Increase_table_font_size=
-New_article=
-New_book=
-New_entry=
-New_from_plain_text=
-New_inbook=
-New_mastersthesis=
-New_phdthesis=
-New_proceedings=
-New_unpublished=
-Next_tab=
-Preamble_editor,_store_changes=
-Previous_tab=
-Push_to_application=
-Refresh_OpenOffice/LibreOffice=
-Resolve_duplicate_BibTeX_keys=
-Save_all=
-String_dialog,_add_string=
-String_dialog,_remove_string=
-Synchronize_files=
+Clear\ search=
+Close\ library=
+Close\ entry\ editor=
+Decrease\ table\ font\ size=
+Entry\ editor,\ next\ entry=
+Entry\ editor,\ next\ panel=
+Entry\ editor,\ next\ panel\ 2=
+Entry\ editor,\ previous\ entry=
+Entry\ editor,\ previous\ panel=
+Entry\ editor,\ previous\ panel\ 2=
+File\ list\ editor,\ move\ entry\ down=
+File\ list\ editor,\ move\ entry\ up=
+Focus\ entry\ table=
+Import\ into\ current\ library=
+Import\ into\ new\ library=
+Increase\ table\ font\ size=
+New\ article=
+New\ book=
+New\ entry=
+New\ from\ plain\ text=
+New\ inbook=
+New\ mastersthesis=
+New\ phdthesis=
+New\ proceedings=
+New\ unpublished=
+Next\ tab=
+Preamble\ editor,\ store\ changes=
+Previous\ tab=
+Push\ to\ application=
+Refresh\ OpenOffice/LibreOffice=
+Resolve\ duplicate\ BibTeX\ keys=
+Save\ all=
+String\ dialog,\ add\ string=
+String\ dialog,\ remove\ string=
+Synchronize\ files=
 Unabbreviate=
-should_contain_a_protocol=
-Copy_preview=
-Automatically_setting_file_links=
-Regenerating_BibTeX_keys_according_to_metadata=
-No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys=
-Regenerate_all_keys_for_the_entries_in_a_BibTeX_file=
-Show_debug_level_messages=
-Default_bibliography_mode=
-New_%0_library_created.=
-Show_only_preferences_deviating_from_their_default_value=
+should\ contain\ a\ protocol=
+Copy\ preview=
+Automatically\ setting\ file\ links=
+Regenerating\ BibTeX\ keys\ according\ to\ metadata=
+No\ meta\ data\ present\ in\ BIB\ file.\ Cannot\ regenerate\ BibTeX\ keys=
+Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=
+Show\ debug\ level\ messages=
+Default\ bibliography\ mode=
+New\ %0\ library\ created.=
+Show\ only\ preferences\ deviating\ from\ their\ default\ value=
 default=
 key=
 type=
 value=
-Show_preferences=
-Save_actions=
-Enable_save_actions=
+Show\ preferences=
+Save\ actions=
+Enable\ save\ actions=
 
-Other_fields=
-Show_remaining_fields=
+Other\ fields=
+Show\ remaining\ fields=
 
-link_should_refer_to_a_correct_file_path=
-abbreviation_detected=
-wrong_entry_type_as_proceedings_has_page_numbers=
-Abbreviate_journal_names=
+link\ should\ refer\ to\ a\ correct\ file\ path=
+abbreviation\ detected=
+wrong\ entry\ type\ as\ proceedings\ has\ page\ numbers=
+Abbreviate\ journal\ names=
 Abbreviating...=
-Abbreviation_%s_for_journal_%s_already_defined.=
-Abbreviation_cannot_be_empty=
-Duplicated_Journal_Abbreviation=
-Duplicated_Journal_File=
-Error_Occurred=
-Journal_file_%s_already_added=
-Name_cannot_be_empty=
+Abbreviation\ %s\ for\ journal\ %s\ already\ defined.=
+Abbreviation\ cannot\ be\ empty=
+Duplicated\ Journal\ Abbreviation=
+Duplicated\ Journal\ File=
+Error\ Occurred=
+Journal\ file\ %s\ already\ added=
+Name\ cannot\ be\ empty=
 
-Adding_fetched_entries=
-Display_keywords_appearing_in_ALL_entries=
-Display_keywords_appearing_in_ANY_entry=
-Fetching_entries_from_Inspire=
-None_of_the_selected_entries_have_titles.=
-None_of_the_selected_entries_have_BibTeX_keys.=
-Unabbreviate_journal_names=
+Adding\ fetched\ entries=
+Display\ keywords\ appearing\ in\ ALL\ entries=
+Display\ keywords\ appearing\ in\ ANY\ entry=
+Fetching\ entries\ from\ Inspire=
+None\ of\ the\ selected\ entries\ have\ titles.=
+None\ of\ the\ selected\ entries\ have\ BibTeX\ keys.=
+Unabbreviate\ journal\ names=
 Unabbreviating...=
 Usage=
 
 
-Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.=
-Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
-Reset_preferences=
-Ill-formed_entrytype_comment_in_BIB_file=
+Adds\ {}\ brackets\ around\ acronyms,\ month\ names\ and\ countries\ to\ preserve\ their\ case.=
+Are\ you\ sure\ you\ want\ to\ reset\ all\ settings\ to\ default\ values?=
+Reset\ preferences=
+Ill-formed\ entrytype\ comment\ in\ BIB\ file=
 
-Move_linked_files_to_default_file_directory_%0=
+Move\ linked\ files\ to\ default\ file\ directory\ %0=
 
 Clipboard=
-Could_not_paste_entry_as_text\:=
-Do_you_still_want_to_continue?=
-This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:=
-This_could_cause_undesired_changes_to_your_entries.=
-Run_field_formatter\:=
-Table_font_size_is_%0=
-%0_import_canceled=%0-import_afbrudt
-Internal_style=
-Add_style_file=
-Are_you_sure_you_want_to_remove_the_style?=
-Current_style_is_'%0'=
-Remove_style=
-Select_one_of_the_available_styles_or_add_a_style_file_from_disk.=
-You_must_select_a_valid_style_file.=
+Could\ not\ paste\ entry\ as\ text\:=
+Do\ you\ still\ want\ to\ continue?=
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=
+This\ could\ cause\ undesired\ changes\ to\ your\ entries.=
+Run\ field\ formatter\:=
+Table\ font\ size\ is\ %0=
+%0\ import\ canceled=%0-import afbrudt
+Internal\ style=
+Add\ style\ file=
+Are\ you\ sure\ you\ want\ to\ remove\ the\ style?=
+Current\ style\ is\ '%0'=
+Remove\ style=
+Select\ one\ of\ the\ available\ styles\ or\ add\ a\ style\ file\ from\ disk.=
+You\ must\ select\ a\ valid\ style\ file.=
 Reload=
 
 Capitalize=
-Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.=
-Capitalize_the_first_word,_changes_other_words_to_lower_case.=
-Changes_all_letters_to_lower_case.=
-Changes_all_letters_to_upper_case.=
-Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.=
-Cleans_up_LaTeX_code.=
-Converts_HTML_code_to_LaTeX_code.=
-Converts_HTML_code_to_Unicode.=
-Converts_LaTeX_encoding_to_Unicode_characters.=
-Converts_Unicode_characters_to_LaTeX_encoding.=
-Converts_ordinals_to_LaTeX_superscripts.=
-Converts_units_to_LaTeX_formatting.=
-HTML_to_LaTeX=
-LaTeX_cleanup=
-LaTeX_to_Unicode=
-Lower_case=
-Minify_list_of_person_names=
-Normalize_date=
-Normalize_month=
-Normalize_month_to_BibTeX_standard_abbreviation.=
-Normalize_names_of_persons=
-Normalize_page_numbers=
-Normalize_pages_to_BibTeX_standard.=
-Normalizes_lists_of_persons_to_the_BibTeX_standard.=
-Normalizes_the_date_to_ISO_date_format.=
-Ordinals_to_LaTeX_superscript=
-Protect_terms=
-Remove_enclosing_braces=
-Removes_braces_encapsulating_the_complete_field_content.=
-Sentence_case=
-Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".=
-Title_case=
-Unicode_to_LaTeX=
-Units_to_LaTeX=
-Upper_case=
-Does_nothing.=
+Capitalize\ all\ words,\ but\ converts\ articles,\ prepositions,\ and\ conjunctions\ to\ lower\ case.=
+Capitalize\ the\ first\ word,\ changes\ other\ words\ to\ lower\ case.=
+Changes\ all\ letters\ to\ lower\ case.=
+Changes\ all\ letters\ to\ upper\ case.=
+Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=
+Cleans\ up\ LaTeX\ code.=
+Converts\ HTML\ code\ to\ LaTeX\ code.=
+Converts\ HTML\ code\ to\ Unicode.=
+Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=
+Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=
+Converts\ ordinals\ to\ LaTeX\ superscripts.=
+Converts\ units\ to\ LaTeX\ formatting.=
+HTML\ to\ LaTeX=
+LaTeX\ cleanup=
+LaTeX\ to\ Unicode=
+Lower\ case=
+Minify\ list\ of\ person\ names=
+Normalize\ date=
+Normalize\ month=
+Normalize\ month\ to\ BibTeX\ standard\ abbreviation.=
+Normalize\ names\ of\ persons=
+Normalize\ page\ numbers=
+Normalize\ pages\ to\ BibTeX\ standard.=
+Normalizes\ lists\ of\ persons\ to\ the\ BibTeX\ standard.=
+Normalizes\ the\ date\ to\ ISO\ date\ format.=
+Ordinals\ to\ LaTeX\ superscript=
+Protect\ terms=
+Remove\ enclosing\ braces=
+Removes\ braces\ encapsulating\ the\ complete\ field\ content.=
+Sentence\ case=
+Shortens\ lists\ of\ persons\ if\ there\ are\ more\ than\ 2\ persons\ to\ "et\ al.".=
+Title\ case=
+Unicode\ to\ LaTeX=
+Units\ to\ LaTeX=
+Upper\ case=
+Does\ nothing.=
 Identity=
-Clears_the_field_completely.=
-Directory_not_found=
-Main_file_directory_not_set\!=
-This_operation_requires_exactly_one_item_to_be_selected.=
-Importing_in_%0_format=
-Female_name=
-Female_names=
-Male_name=
-Male_names=
-Mixed_names=
-Neuter_name=
-Neuter_names=
+Clears\ the\ field\ completely.=
+Directory\ not\ found=
+Main\ file\ directory\ not\ set\!=
+This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=
+Importing\ in\ %0\ format=
+Female\ name=
+Female\ names=
+Male\ name=
+Male\ names=
+Mixed\ names=
+Neuter\ name=
+Neuter\ names=
 
-Determined_%0_for_%1_entries=
-Look_up_%0=
-Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3=
+Determined\ %0\ for\ %1\ entries=
+Look\ up\ %0=
+Looking\ up\ %0...\ -\ entry\ %1\ out\ of\ %2\ -\ found\ %3=
 
-Audio_CD=
-British_patent=
-British_patent_request=
-Candidate_thesis=
+Audio\ CD=
+British\ patent=
+British\ patent\ request=
+Candidate\ thesis=
 Collaborator=
 Column=
 Compiler=
 Continuator=
-Data_CD=
+Data\ CD=
 Editor=
-European_patent=
-European_patent_request=
+European\ patent=
+European\ patent\ request=
 Founder=
-French_patent=
-French_patent_request=
-German_patent=
-German_patent_request=
+French\ patent=
+French\ patent\ request=
+German\ patent=
+German\ patent\ request=
 Line=
-Master's_thesis=
+Master's\ thesis=
 Page=
 Paragraph=
 Patent=
-Patent_request=
-PhD_thesis=
+Patent\ request=
+PhD\ thesis=
 Redactor=
-Research_report=
+Research\ report=
 Reviser=
 Section=
 Software=
-Technical_report=
-U.S._patent=
-U.S._patent_request=
+Technical\ report=
+U.S.\ patent=
+U.S.\ patent\ request=
 Verse=
 
-change_entries_of_group=
-odd_number_of_unescaped_'\#'=
+change\ entries\ of\ group=
+odd\ number\ of\ unescaped\ '\#'=
 
-Plain_text=
-Show_diff=
+Plain\ text=
+Show\ diff=
 character=
 word=
-Show_symmetric_diff=
-Copy_Version=
+Show\ symmetric\ diff=
+Copy\ Version=
 Developers=
 Authors=
 License=
 
-HTML_encoded_character_found=
-booktitle_ends_with_'conference_on'=
+HTML\ encoded\ character\ found=
+booktitle\ ends\ with\ 'conference\ on'=
 
-All_external_files=
+All\ external\ files=
 
-OpenOffice/LibreOffice_integration=
+OpenOffice/LibreOffice\ integration=
 
-incorrect_control_digit=
-incorrect_format=
-Copied_version_to_clipboard=
+incorrect\ control\ digit=
+incorrect\ format=
+Copied\ version\ to\ clipboard=
 
-BibTeX_key=
+BibTeX\ key=
 Message=
 
 
-MathSciNet_Review=
-Reset_Bindings=
+MathSciNet\ Review=
+Reset\ Bindings=
 
-Decryption_not_supported.=
+Decryption\ not\ supported.=
 
-Cleared_'%0'_for_%1_entries=
-Set_'%0'_to_'%1'_for_%2_entries=
-Toggled_'%0'_for_%1_entries=
+Cleared\ '%0'\ for\ %1\ entries=
+Set\ '%0'\ to\ '%1'\ for\ %2\ entries=
+Toggled\ '%0'\ for\ %1\ entries=
 
-Check_for_updates=
-Download_update=
-New_version_available=
-Installed_version=
-Remind_me_later=
-Ignore_this_update=
-Could_not_connect_to_the_update_server.=
-Please_try_again_later_and/or_check_your_network_connection.=
-To_see_what_is_new_view_the_changelog.=
-A_new_version_of_JabRef_has_been_released.=
-JabRef_is_up-to-date.=
-Latest_version=
-Online_help_forum=
+Check\ for\ updates=
+Download\ update=
+New\ version\ available=
+Installed\ version=
+Remind\ me\ later=
+Ignore\ this\ update=
+Could\ not\ connect\ to\ the\ update\ server.=
+Please\ try\ again\ later\ and/or\ check\ your\ network\ connection.=
+To\ see\ what\ is\ new\ view\ the\ changelog.=
+A\ new\ version\ of\ JabRef\ has\ been\ released.=
+JabRef\ is\ up-to-date.=
+Latest\ version=
+Online\ help\ forum=
 Custom=
 
-Export_cited=
-Unable_to_generate_new_library=
+Export\ cited=
+Unable\ to\ generate\ new\ library=
 
-Open_console=
-Use_default_terminal_emulator=
-Execute_command=
-Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.=
-Executing_command_\"%0\"...=
-Error_occured_while_executing_the_command_\"%0\".=
-Reformat_ISSN=
+Open\ console=
+Use\ default\ terminal\ emulator=
+Execute\ command=
+Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=
+Executing\ command\ \"%0\"...=
+Error\ occured\ while\ executing\ the\ command\ \"%0\".=
+Reformat\ ISSN=
 
-Countries_and_territories_in_English=
-Electrical_engineering_terms=
+Countries\ and\ territories\ in\ English=
+Electrical\ engineering\ terms=
 Enabled=
-Internal_list=
-Manage_protected_terms_files=
-Months_and_weekdays_in_English=
-The_text_after_the_last_line_starting_with_\#_will_be_used=
-Add_protected_terms_file=
-Are_you_sure_you_want_to_remove_the_protected_terms_file?=
-Remove_protected_terms_file=
-Add_selected_text_to_list=
-Add_{}_around_selected_text=
-Format_field=
-New_protected_terms_file=
-change_field_%0_of_entry_%1_from_%2_to_%3=
-change_key_from_%0_to_%1=
-change_string_content_%0_to_%1=
-change_string_name_%0_to_%1=
-change_type_of_entry_%0_from_%1_to_%2=
-insert_entry_%0=
-insert_string_%0=
-remove_entry_%0=
-remove_string_%0=
+Internal\ list=
+Manage\ protected\ terms\ files=
+Months\ and\ weekdays\ in\ English=
+The\ text\ after\ the\ last\ line\ starting\ with\ \#\ will\ be\ used=
+Add\ protected\ terms\ file=
+Are\ you\ sure\ you\ want\ to\ remove\ the\ protected\ terms\ file?=
+Remove\ protected\ terms\ file=
+Add\ selected\ text\ to\ list=
+Add\ {}\ around\ selected\ text=
+Format\ field=
+New\ protected\ terms\ file=
+change\ field\ %0\ of\ entry\ %1\ from\ %2\ to\ %3=
+change\ key\ from\ %0\ to\ %1=
+change\ string\ content\ %0\ to\ %1=
+change\ string\ name\ %0\ to\ %1=
+change\ type\ of\ entry\ %0\ from\ %1\ to\ %2=
+insert\ entry\ %0=
+insert\ string\ %0=
+remove\ entry\ %0=
+remove\ string\ %0=
 undefined=
-Cannot_get_info_based_on_given_%0\:_%1=
-Get_BibTeX_data_from_%0=
-No_%0_found=Ingen_%0_fundet
-Entry_from_%0=Post_fra_%0
-Merge_entry_with_%0_information=
-Updated_entry_with_info_from_%0=
+Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=
+Get\ BibTeX\ data\ from\ %0=
+No\ %0\ found=Ingen %0 fundet
+Entry\ from\ %0=Post fra %0
+Merge\ entry\ with\ %0\ information=
+Updated\ entry\ with\ info\ from\ %0=
 
-Add_existing_file=
-Create_new_list=
-Remove_list=
-Full_journal_name=
-Abbreviation_name=
+Add\ existing\ file=
+Create\ new\ list=
+Remove\ list=
+Full\ journal\ name=
+Abbreviation\ name=
 
-No_abbreviation_files_loaded=
+No\ abbreviation\ files\ loaded=
 
-Loading_built_in_lists=
+Loading\ built\ in\ lists=
 
-JabRef_built_in_list=
-IEEE_built_in_list=
+JabRef\ built\ in\ list=
+IEEE\ built\ in\ list=
 
-Event_log=
-We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.=
-Log_copied_to_clipboard.=
-Copy_Log=
-Clear_Log=
-Report_Issue=
-Issue_on_GitHub_successfully_reported.=
-Issue_report_successful=
-Your_issue_was_reported_in_your_browser.=
-The_log_and_exception_information_was_copied_to_your_clipboard.=
-Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.=
+Event\ log=
+We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef\'s\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=
+Log\ copied\ to\ clipboard.=
+Copy\ Log=
+Clear\ Log=
+Report\ Issue=
+Issue\ on\ GitHub\ successfully\ reported.=
+Issue\ report\ successful=
+Your\ issue\ was\ reported\ in\ your\ browser.=
+The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=
+Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=
 
 Connection=
 Connecting...=
@@ -2164,194 +2164,194 @@ Port=
 Library=
 User=
 Connect=Tilslut
-Connection_error=
-Connection_to_%0_server_established.=
-Required_field_"%0"_is_empty.=
-%0_driver_not_available.=
-The_connection_to_the_server_has_been_terminated.=
-Connection_lost.=
+Connection\ error=
+Connection\ to\ %0\ server\ established.=
+Required\ field\ "%0"\ is\ empty.=
+%0\ driver\ not\ available.=
+The\ connection\ to\ the\ server\ has\ been\ terminated.=
+Connection\ lost.=
 Reconnect=
-Work_offline=
-Working_offline.=
-Update_refused.=
-Update_refused=
-Local_entry=
-Shared_entry=
-Update_could_not_be_performed_due_to_existing_change_conflicts.=
-You_are_not_working_on_the_newest_version_of_BibEntry.=
-Local_version\:_%0=
-Shared_version\:_%0=
-Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.=
-Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?=
-Shared_entry_is_no_longer_present=
-The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.=
-You_can_restore_the_entry_using_the_"Undo"_operation.=
-Remember_password?=
-You_are_already_connected_to_a_database_using_entered_connection_details.=
+Work\ offline=
+Working\ offline.=
+Update\ refused.=
+Update\ refused=
+Local\ entry=
+Shared\ entry=
+Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=
+You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=
+Local\ version\:\ %0=
+Shared\ version\:\ %0=
+Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=
+Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=
+Shared\ entry\ is\ no\ longer\ present=
+The\ BibEntry\ you\ currently\ work\ on\ has\ been\ deleted\ on\ the\ shared\ side.=
+You\ can\ restore\ the\ entry\ using\ the\ "Undo"\ operation.=
+Remember\ password?=
+You\ are\ already\ connected\ to\ a\ database\ using\ entered\ connection\ details.=
 
-Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?=
-New_technical_report=
+Cannot\ cite\ entries\ without\ BibTeX\ keys.\ Generate\ keys\ now?=
+New\ technical\ report=
 
-%0_file=
-Custom_layout_file=
-Protected_terms_file=
-Style_file=
+%0\ file=
+Custom\ layout\ file=
+Protected\ terms\ file=
+Style\ file=
 
-Open_OpenOffice/LibreOffice_connection=
-You_must_enter_at_least_one_field_name=
-Non-ASCII_encoded_character_found=
-Toggle_web_search_interface=
-Background_color_for_resolved_fields=
-Color_code_for_resolved_fields=
-%0_files_found=
-%0_of_%1=
-One_file_found=
-The_import_finished_with_warnings\:=
-There_was_one_file_that_could_not_be_imported.=
-There_were_%0_files_which_could_not_be_imported.=
+Open\ OpenOffice/LibreOffice\ connection=
+You\ must\ enter\ at\ least\ one\ field\ name=
+Non-ASCII\ encoded\ character\ found=
+Toggle\ web\ search\ interface=
+Background\ color\ for\ resolved\ fields=
+Color\ code\ for\ resolved\ fields=
+%0\ files\ found=
+%0\ of\ %1=
+One\ file\ found=
+The\ import\ finished\ with\ warnings\:=
+There\ was\ one\ file\ that\ could\ not\ be\ imported.=
+There\ were\ %0\ files\ which\ could\ not\ be\ imported.=
 
-Migration_help_information=
-Entered_database_has_obsolete_structure_and_is_no_longer_supported.=
-However,_a_new_database_was_created_alongside_the_pre-3.6_one.=
-Click_here_to_learn_about_the_migration_of_pre-3.6_databases.=
-Opens_JabRef's_Facebook_page=
-Opens_JabRef's_blog=
-Opens_JabRef's_website=
-Opens_a_link_where_the_current_development_version_can_be_downloaded=
-See_what_has_been_changed_in_the_JabRef_versions=
-Referenced_BibTeX_key_does_not_exist=
-Finished_downloading_full_text_document_for_entry_%0.=
-Full_text_document_download_failed_for_entry_%0.=
-Look_up_full_text_documents=
-You_are_about_to_look_up_full_text_documents_for_%0_entries.=
-last_four_nonpunctuation_characters_should_be_numerals=
+Migration\ help\ information=
+Entered\ database\ has\ obsolete\ structure\ and\ is\ no\ longer\ supported.=
+However,\ a\ new\ database\ was\ created\ alongside\ the\ pre-3.6\ one.=
+Click\ here\ to\ learn\ about\ the\ migration\ of\ pre-3.6\ databases.=
+Opens\ JabRef's\ Facebook\ page=
+Opens\ JabRef's\ blog=
+Opens\ JabRef's\ website=
+Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=
+See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=
+Referenced\ BibTeX\ key\ does\ not\ exist=
+Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=
+Full\ text\ document\ download\ failed\ for\ entry\ %0.=
+Look\ up\ full\ text\ documents=
+You\ are\ about\ to\ look\ up\ full\ text\ documents\ for\ %0\ entries.=
+last\ four\ nonpunctuation\ characters\ should\ be\ numerals=
 
 Author=
 Date=
-File_annotations=
-Show_file_annotations=
-Adobe_Acrobat_Reader=
-Sumatra_Reader=
+File\ annotations=
+Show\ file\ annotations=
+Adobe\ Acrobat\ Reader=
+Sumatra\ Reader=
 shared=
-should_contain_an_integer_or_a_literal=
-should_have_the_first_letter_capitalized=
+should\ contain\ an\ integer\ or\ a\ literal=
+should\ have\ the\ first\ letter\ capitalized=
 Tools=
-What\'s_new_in_this_version?=
-Want_to_help?=
-Make_a_donation=
-get_involved=
-Used_libraries=
-Existing_file=Eksisterende_fil
+What\'s\ new\ in\ this\ version?=
+Want\ to\ help?=
+Make\ a\ donation=
+get\ involved=
+Used\ libraries=
+Existing\ file=Eksisterende fil
 
 ID=
-ID_type=
-ID-based_entry_generator=
-Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+ID\ type=
+ID-based\ entry\ generator=
+Fetcher\ '%0'\ did\ not\ find\ an\ entry\ for\ id\ '%1'.=
 
-Select_first_entry=
-Select_last_entry=
+Select\ first\ entry=
+Select\ last\ entry=
 
-Invalid_ISBN\:_'%0'.=
-should_be_an_integer_or_normalized=
-should_be_normalized=
+Invalid\ ISBN\:\ '%0'.=
+should\ be\ an\ integer\ or\ normalized=
+should\ be\ normalized=
 
-Empty_search_ID=
-The_given_search_ID_was_empty.=
-Copy_BibTeX_key_and_link=
-empty_BibTeX_key=
-biblatex_field_only=
+Empty\ search\ ID=
+The\ given\ search\ ID\ was\ empty.=
+Copy\ BibTeX\ key\ and\ link=
+empty\ BibTeX\ key=
+biblatex\ field\ only=
 
-Error_while_generating_fetch_URL=
-Error_while_parsing_ID_list=
-Unable_to_get_PubMed_IDs=
-Backup_found=
-A_backup_file_for_'%0'_was_found.=
-This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.=
-Do_you_want_to_recover_the_library_from_the_backup_file?=
-Firstname_Lastname=
+Error\ while\ generating\ fetch\ URL=
+Error\ while\ parsing\ ID\ list=
+Unable\ to\ get\ PubMed\ IDs=
+Backup\ found=
+A\ backup\ file\ for\ '%0'\ was\ found.=
+This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=
+Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=
+Firstname\ Lastname=
 
-Recommended_for_%0=
-Show_'Related_Articles'_tab=
-This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
+Recommended\ for\ %0=
+Show\ 'Related\ Articles'\ tab=
+This\ might\ be\ caused\ by\ reaching\ the\ traffic\ limitation\ of\ Google\ Scholar\ (see\ 'Help'\ for\ details).=
 
-Could_not_open_website.=
-Problem_downloading_from_%1=
+Could\ not\ open\ website.=
+Problem\ downloading\ from\ %1=
 
-File_directory_pattern=
-Update_with_bibliographic_information_from_the_web=
+File\ directory\ pattern=
+Update\ with\ bibliographic\ information\ from\ the\ web=
 
-Could_not_find_any_bibliographic_information.=
-BibTeX_key_deviates_from_generated_key=
-DOI_%0_is_invalid=
+Could\ not\ find\ any\ bibliographic\ information.=
+BibTeX\ key\ deviates\ from\ generated\ key=
+DOI\ %0\ is\ invalid=
 
-Select_all_customized_types_to_be_stored_in_local_preferences=
-Currently_unknown=
-Different_customization,_current_settings_will_be_overwritten=
+Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences=
+Currently\ unknown=
+Different\ customization,\ current\ settings\ will\ be\ overwritten=
 
-Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX=
-Jump_to_entry=
+Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=
+Jump\ to\ entry=
 
-Copied_%0_citations.=
+Copied\ %0\ citations.=
 Copying...=
 
-journal_not_found_in_abbreviation_list=
-Unhandled_exception_occurred.=
+journal\ not\ found\ in\ abbreviation\ list=
+Unhandled\ exception\ occurred.=
 
-strings_included=
-Color_for_disabled_icons=
-Color_for_enabled_icons=
-Size_of_large_icons=
-Size_of_small_icons=
-Default_table_font_size=
-Escape_underscores=
+strings\ included=
+Color\ for\ disabled\ icons=
+Color\ for\ enabled\ icons=
+Size\ of\ large\ icons=
+Size\ of\ small\ icons=
+Default\ table\ font\ size=
+Escape\ underscores=
 Color=
-Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=
-Fit_width=
-Fit_a_single_page=
-Zoom_in=
-Zoom_out=
-Previous_page=
-Next_page=
-Document_viewer=
+Please\ also\ add\ all\ steps\ to\ reproduce\ this\ issue,\ if\ possible.=
+Fit\ width=
+Fit\ a\ single\ page=
+Zoom\ in=
+Zoom\ out=
+Previous\ page=
+Next\ page=
+Document\ viewer=
 Live=
 Locked=
-Show_document_viewer=
-Show_the_document_of_the_currently_selected_entry.=
-Show_this_document_until_unlocked.=
-Set_current_user_name_as_owner.=
+Show\ document\ viewer=
+Show\ the\ document\ of\ the\ currently\ selected\ entry.=
+Show\ this\ document\ until\ unlocked.=
+Set\ current\ user\ name\ as\ owner.=
 
-Sort_all_subgroups_(recursively)=
-Collect_and_share_telemetry_data_to_help_improve_JabRef.=
-Don't_share=
-Share_anonymous_statistics=
-Telemetry\:_Help_make_JabRef_better=
-To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.=
-This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?=
-Names_are_not_in_the_standard_%0_format.=
+Sort\ all\ subgroups\ (recursively)=
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=
+Don't\ share=
+Share\ anonymous\ statistics=
+Telemetry\:\ Help\ make\ JabRef\ better=
+To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ statistics\ on\ the\ features\ you\ use.\ We\ will\ only\ record\ what\ features\ you\ access\ and\ how\ often\ you\ do\ it.\ We\ will\ neither\ collect\ any\ personal\ data\ nor\ the\ content\ of\ bibliographic\ items.\ If\ you\ choose\ to\ allow\ data\ collection,\ you\ can\ later\ disable\ it\ via\ Options\ ->\ Preferences\ ->\ General.=
+This\ file\ was\ found\ automatically.\ Do\ you\ want\ to\ link\ it\ to\ this\ entry?=
+Names\ are\ not\ in\ the\ standard\ %0\ format.=
 
-Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.=
-Delete_'%0'=
-Delete_from_disk=
-Remove_from_entry=
-The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.=
-There_exists_already_a_group_with_the_same_name.=
+Delete\ the\ selected\ file\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ file\ permanently\ from\ disk.=
+Delete\ '%0'=
+Delete\ from\ disk=
+Remove\ from\ entry=
+The\ group\ name\ contains\ the\ keyword\ separator\ "%0"\ and\ thus\ probably\ does\ not\ work\ as\ expected.=
+There\ exists\ already\ a\ group\ with\ the\ same\ name.=
 
-Copy_linked_files_to_folder...=
-Copied_file_successfully=
-Copying_files...=
-Copying_file_%0_of_entry_%1=
-Finished_copying=
-Could_not_copy_file=
-Copied_%0_files_of_%1_sucessfully_to_%2=
-Rename_failed=
-JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.=
-Show_console_output_(only_necessary_when_the_launcher_is_used)=
+Copy\ linked\ files\ to\ folder...=
+Copied\ file\ successfully=
+Copying\ files...=
+Copying\ file\ %0\ of\ entry\ %1=
+Finished\ copying=
+Could\ not\ copy\ file=
+Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=
+Rename\ failed=
+JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=
+Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=
 
-Remove_line_breaks=
-Removes_all_line_breaks_in_the_field_content.=
-Checking_integrity...=
+Remove\ line\ breaks=
+Removes\ all\ line\ breaks\ in\ the\ field\ content.=
+Checking\ integrity...=
 
-Remove_hyphenated_line_breaks=
-Removes_all_hyphenated_line_breaks_in_the_field_content.=
-Note_that_currently,_JabRef_does_not_run_with_Java_9.=
-Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.=
+Remove\ hyphenated\ line\ breaks=
+Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=
+Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=
+Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=

--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -1,8 +1,3 @@
-
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 indeholder regulærudtrykket <b>%1</b>
 
 %0\ contains\ the\ term\ <b>%1</b>=%0 indeholder udtrykket <b>%1</b>

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -1,8 +1,3 @@
-
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 den regulären Ausdruck <b>%1</b> enthält
 
 %0\ contains\ the\ term\ <b>%1</b>=%0 den Ausdruck <b>%1</b> enthält

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -446,7 +446,7 @@ Error\ writing\ to\ %0\ file(s).=Fehler beim Schreiben in %0 Datei(en).
 
 
 '%0'\ exists.\ Overwrite\ file?='%0' existiert bereits. Überschreiben?
-Overwrite\ file?= Überschreiben?
+Overwrite\ file?=Überschreiben?
 
 Export=Exportieren
 

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -3,156 +3,156 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-%0_contains_the_regular_expression_<b>%1</b>=%0_den_regulären_Ausdruck_<b>%1</b>_enthält
+%0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 den regulären Ausdruck <b>%1</b> enthält
 
-%0_contains_the_term_<b>%1</b>=%0_den_Ausdruck_<b>%1</b>_enthält
+%0\ contains\ the\ term\ <b>%1</b>=%0 den Ausdruck <b>%1</b> enthält
 
-%0_doesn't_contain_the_regular_expression_<b>%1</b>=%0_nicht_den_regulären_Ausdruck_<b>%1</b>_enthält
+%0\ doesn't\ contain\ the\ regular\ expression\ <b>%1</b>=%0 nicht den regulären Ausdruck <b>%1</b> enthält
 
-%0_doesn't_contain_the_term_<b>%1</b>=%0_nicht_den_Ausdruck_<b>%1</b>_enthält
+%0\ doesn't\ contain\ the\ term\ <b>%1</b>=%0 nicht den Ausdruck <b>%1</b> enthält
 
-%0_export_successful=%0-Export_erfolgreich
+%0\ export\ successful=%0-Export erfolgreich
 
-%0_matches_the_regular_expression_<b>%1</b>=%0_exakt_dem_regulären_Ausdruck_<b>%1</b>_entspricht
+%0\ matches\ the\ regular\ expression\ <b>%1</b>=%0 exakt dem regulären Ausdruck <b>%1</b> entspricht
 
-%0_matches_the_term_<b>%1</b>=%0_exakt_dem_Ausdruck_<b>%1</b>_entspricht
+%0\ matches\ the\ term\ <b>%1</b>=%0 exakt dem Ausdruck <b>%1</b> entspricht
 
-<field_name>=<Feldname>
-<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>=<HTML>Die_Datei_'%0',_die_vom_Eintrag<BR>'%1'_verlinkt_wird,_wurde_nicht_gefunden</HTML>
+<field\ name>=<Feldname>
+<HTML>Could\ not\ find\ file\ '%0'<BR>linked\ from\ entry\ '%1'</HTML>=<HTML>Die Datei '%0', die vom Eintrag<BR>'%1' verlinkt wird, wurde nicht gefunden</HTML>
 
 <select>=<auswählen>
 
-<select_word>=<Wort_auswählen>
-Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)=Zeitschriftentitel_der_ausgewählten_Einträge_abkürzen_(ISO-Abkürzung)
-Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)=Zeitschriftentitel_der_ausgewählten_Einträge_abkürzen_(MEDLINE-Abkürzung)
+<select\ word>=<Wort auswählen>
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (ISO\ abbreviation)=Zeitschriftentitel der ausgewählten Einträge abkürzen (ISO-Abkürzung)
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (MEDLINE\ abbreviation)=Zeitschriftentitel der ausgewählten Einträge abkürzen (MEDLINE-Abkürzung)
 
-Abbreviate_names=Namen_abkürzen
-Abbreviated_%0_journal_names.=%0_Zeitschriftentitel_abgekürzt.
+Abbreviate\ names=Namen abkürzen
+Abbreviated\ %0\ journal\ names.=%0 Zeitschriftentitel abgekürzt.
 
 Abbreviation=Abkürzung
 
-About_JabRef=Über_JabRef
+About\ JabRef=Über JabRef
 
 Abstract=Zusammenfassung
 
 Accept=Übernehmen
 
-Accept_change=Änderung_akzeptieren
+Accept\ change=Änderung akzeptieren
 
 Action=Aktion
 
-What_is_Mr._DLib?=Was_ist_Mr._DLib?
+What\ is\ Mr.\ DLib?=Was ist Mr. DLib?
 
 Add=Hinzufügen
 
-Add_a_(compiled)_custom_Importer_class_from_a_class_path.=Füge_eine_(kompilierte)_externe_Importer_Klasse_aus_einem_Verzeichnis_hinzu.
-The_path_need_not_be_on_the_classpath_of_JabRef.=Das_Verzeichnis_muss_nicht_im_Klassenpfad_von_JabRef_enthalten_sein.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=Füge eine (kompilierte) externe Importer Klasse aus einem Verzeichnis hinzu.
+The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=Das Verzeichnis muss nicht im Klassenpfad von JabRef enthalten sein.
 
-Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=Füge_eine_(kompilierte)_externe_Importer_Klasse_aus_Verzeichnis_hinzu.
-The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=Das_Verzeichnis_muss_nicht_im_Klassenpfad_von_JabRef_enthalten_sein.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=Füge eine (kompilierte) externe Importer Klasse aus Verzeichnis hinzu.
+The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=Das Verzeichnis muss nicht im Klassenpfad von JabRef enthalten sein.
 
-Add_a_regular_expression_for_the_key_pattern.=Füge_einen_Regulären_Ausdruck_für_ein_BibTeX-Key-Muster_hinzu
+Add\ a\ regular\ expression\ for\ the\ key\ pattern.=Füge einen Regulären Ausdruck für ein BibTeX-Key-Muster hinzu
 
-Add_selected_entries_to_this_group=Ausgewählte_Einträge_zu_dieser_Gruppe_hinzufügen
+Add\ selected\ entries\ to\ this\ group=Ausgewählte Einträge zu dieser Gruppe hinzufügen
 
-Add_from_folder=Aus_Klassenpfad_hinzufügen
+Add\ from\ folder=Aus Klassenpfad hinzufügen
 
-Add_from_JAR=Aus_Archiv-Datei_hinzufügen
+Add\ from\ JAR=Aus Archiv-Datei hinzufügen
 
-add_group=Gruppe_hinzufügen
+add\ group=Gruppe hinzufügen
 
-Add_new=Neu
+Add\ new=Neu
 
-Add_subgroup=Untergruppe_hinzufügen
+Add\ subgroup=Untergruppe hinzufügen
 
-Add_to_group=Zu_Gruppe_hinzufügen
+Add\ to\ group=Zu Gruppe hinzufügen
 
-Added_group_"%0".=Gruppe_"%0"_hinzugefügt.
+Added\ group\ "%0".=Gruppe "%0" hinzugefügt.
 
-Added_missing_braces.=Fehlende_Klammern_hinzugefügt.
+Added\ missing\ braces.=Fehlende Klammern hinzugefügt.
 
-Added_new=Neu_hinzugefügt
+Added\ new=Neu hinzugefügt
 
-Added_string=String_hinzugefügt
+Added\ string=String hinzugefügt
 
-Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.=Zusätzlich_können_Einträge,_deren_Feld_<b>%0</b>_nicht_<b>%1</b>_enthält,_dieser_Gruppe_manuell_hinzugefügt_werden,_indem_Sie_sie_selektieren_und_dann_entweder_Drag&Drop_oder_das_Kontextmenü_benutzen._Dieser_Vorgang_fügt_<b>%1</b>_dem_Feld_<b>%0</b>_jedes_Eintrags_hinzu._Einträge_können_manuell_aus_dieser_Gruppe_entfernt_werden,_indem_Sie_sie_selektieren_und_dann_das_Kontextmenü_benutzen._Dieser_Vorgang_entfernt_<b>%1</b>_aus_dem_Feld_<b>%0</b>_jedes_Eintrags.
+Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ can\ be\ assigned\ manually\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ This\ process\ adds\ the\ term\ <b>%1</b>\ to\ each\ entry's\ <b>%0</b>\ field.\ Entries\ can\ be\ removed\ manually\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.\ This\ process\ removes\ the\ term\ <b>%1</b>\ from\ each\ entry's\ <b>%0</b>\ field.=Zusätzlich können Einträge, deren Feld <b>%0</b> nicht <b>%1</b> enthält, dieser Gruppe manuell hinzugefügt werden, indem Sie sie selektieren und dann entweder Drag&Drop oder das Kontextmenü benutzen. Dieser Vorgang fügt <b>%1</b> dem Feld <b>%0</b> jedes Eintrags hinzu. Einträge können manuell aus dieser Gruppe entfernt werden, indem Sie sie selektieren und dann das Kontextmenü benutzen. Dieser Vorgang entfernt <b>%1</b> aus dem Feld <b>%0</b> jedes Eintrags.
 
 Advanced=Erweitert
-All_entries=Alle_Einträge
-All_entries_of_this_type_will_be_declared_typeless._Continue?=Alle_Einträge_dieses_Typs_werden_als_'ohne_Typ'_angesehen._Fortfahren?
+All\ entries=Alle Einträge
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=Alle Einträge dieses Typs werden als 'ohne Typ' angesehen. Fortfahren?
 
-All_fields=Alle_Felder
+All\ fields=Alle Felder
 
-Always_reformat_BIB_file_on_save_and_export=Formatiere_BIB_Datei_immer_neu_beim_Exportieren
+Always\ reformat\ BIB\ file\ on\ save\ and\ export=Formatiere BIB Datei immer neu beim Exportieren
 
-A_SAX_exception_occurred_while_parsing_'%0'\:=Beim_Parsen_von_'%0'_ist_eine_SAX-Exception_aufgetreten\:
+A\ SAX\ exception\ occurred\ while\ parsing\ '%0'\:=Beim Parsen von '%0' ist eine SAX-Exception aufgetreten:
 
 and=und
-and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.=Außerdem_muss_die_Klasse_beim_nächsten_Start_von_JabRef_durch_den_"Classpath"_erreichbar_sein.
+and\ the\ class\ must\ be\ available\ in\ your\ classpath\ next\ time\ you\ start\ JabRef.=Außerdem muss die Klasse beim nächsten Start von JabRef durch den "Classpath" erreichbar sein.
 
-any_field_that_matches_the_regular_expression_<b>%0</b>=ein_beliebiges_Feld,_auf_das_der_reguläre_Ausdruck_<b>%0</b>_passt,
+any\ field\ that\ matches\ the\ regular\ expression\ <b>%0</b>=ein beliebiges Feld, auf das der reguläre Ausdruck <b>%0</b> passt,
 
 Appearance=Erscheinungsbild
 
 Append=anfügen
-Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library=Inhalt_einer_BibTeX-Bibliothek_an_die_aktuelle_Bibliothek_anhängen
+Append\ contents\ from\ a\ BibTeX\ library\ into\ the\ currently\ viewed\ library=Inhalt einer BibTeX-Bibliothek an die aktuelle Bibliothek anhängen
 
-Append_library=Bibliothek_anhängen
+Append\ library=Bibliothek anhängen
 
-Append_the_selected_text_to_BibTeX_field=Ausgewählten_Text_an_BibTeX-Key_anhängen
+Append\ the\ selected\ text\ to\ BibTeX\ field=Ausgewählten Text an BibTeX-Key anhängen
 Application=Anwendung
 
 Apply=Übernehmen
 
-Arguments_passed_on_to_running_JabRef_instance._Shutting_down.=Argumente_wurden_der_laufenden_JabRef-Instanz_übergeben._Schließen_läuft.
+Arguments\ passed\ on\ to\ running\ JabRef\ instance.\ Shutting\ down.=Argumente wurden der laufenden JabRef-Instanz übergeben. Schließen läuft.
 
-Assign_new_file=Neue_Datei_zuordnen
+Assign\ new\ file=Neue Datei zuordnen
 
-Assign_the_original_group's_entries_to_this_group?=Einträge_der_ursprünglichen_Gruppe_zu_dieser_Gruppe_hinzufügen?
+Assign\ the\ original\ group's\ entries\ to\ this\ group?=Einträge der ursprünglichen Gruppe zu dieser Gruppe hinzufügen?
 
-Assigned_%0_entries_to_group_"%1".=%0_Einträge_zu_Gruppe_"%1"_hinzugefügt.
+Assigned\ %0\ entries\ to\ group\ "%1".=%0 Einträge zu Gruppe "%1" hinzugefügt.
 
-Assigned_1_entry_to_group_"%0".=1_Eintrag_zu_Gruppe_"%0"_hinzugefügt.
+Assigned\ 1\ entry\ to\ group\ "%0".=1 Eintrag zu Gruppe "%0" hinzugefügt.
 
-Attach_URL=URL_anfügen
+Attach\ URL=URL anfügen
 
-Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.=Versucht,_Datei-Links_für_die_Einträge_automatisch_zuzuordnen._Dies_funktioniert,_wenn_der_Name_einer_Datei_im_Datei-Verzeichnis_oder_einem_Unterverzeichnis<BR>identisch_ist_mit_dem_BibTeX-Key_eines_Eintrags_(erweitert_um_die_jeweilige_Dateiendung).
+Attempt\ to\ automatically\ set\ file\ links\ for\ your\ entries.\ Automatically\ setting\ works\ if\ a\ file\ in\ your\ file\ directory<BR>or\ a\ subdirectory\ is\ named\ identically\ to\ an\ entry's\ BibTeX\ key,\ plus\ extension.=Versucht, Datei-Links für die Einträge automatisch zuzuordnen. Dies funktioniert, wenn der Name einer Datei im Datei-Verzeichnis oder einem Unterverzeichnis<BR>identisch ist mit dem BibTeX-Key eines Eintrags (erweitert um die jeweilige Dateiendung).
 
-Autodetect_format=Format_automatisch_erkennen
+Autodetect\ format=Format automatisch erkennen
 
-Autogenerate_BibTeX_keys=BibTeX-Keys_automatisch_generieren
+Autogenerate\ BibTeX\ keys=BibTeX-Keys automatisch generieren
 
-Autolink_files_with_names_starting_with_the_BibTeX_key=Dateien,_deren_Namen_mit_dem_BibTeX-Key_beginnen,_automatisch_verlinken
+Autolink\ files\ with\ names\ starting\ with\ the\ BibTeX\ key=Dateien, deren Namen mit dem BibTeX-Key beginnen, automatisch verlinken
 
-Autolink_only_files_that_match_the_BibTeX_key=Nur_Dateien_verlinken,_deren_Namen_dem_BibTeX-Key_entsprechen
+Autolink\ only\ files\ that\ match\ the\ BibTeX\ key=Nur Dateien verlinken, deren Namen dem BibTeX-Key entsprechen
 
-Automatically_create_groups=Gruppen_automatisch_erstellen
+Automatically\ create\ groups=Gruppen automatisch erstellen
 
-Automatically_remove_exact_duplicates=Exakte_Duplikate_automatisch_löschen
+Automatically\ remove\ exact\ duplicates=Exakte Duplikate automatisch löschen
 
-Allow_overwriting_existing_links.=Vorhandene_Links_überschreiben.
+Allow\ overwriting\ existing\ links.=Vorhandene Links überschreiben.
 
-Do_not_overwrite_existing_links.=Vorhandene_Links_nicht_überschreiben.
+Do\ not\ overwrite\ existing\ links.=Vorhandene Links nicht überschreiben.
 
-AUX_file_import=AUX_Datei_Import
+AUX\ file\ import=AUX Datei Import
 
-Available_export_formats=Verfügbare_Exportformate
+Available\ export\ formats=Verfügbare Exportformate
 
-Available_BibTeX_fields=Verfügbare_BibTeX-Felder
+Available\ BibTeX\ fields=Verfügbare BibTeX-Felder
 
-Available_import_formats=Verfügbare_Importformate
+Available\ import\ formats=Verfügbare Importformate
 
-Background_color_for_optional_fields=Hintergrundfarbe_für_optionale_Felder
+Background\ color\ for\ optional\ fields=Hintergrundfarbe für optionale Felder
 
-Background_color_for_required_fields=Hintergrundfarbe_für_benötigte_Felder
+Background\ color\ for\ required\ fields=Hintergrundfarbe für benötigte Felder
 
-Backup_old_file_when_saving=Beim_Speichern_ein_Backup_der_alten_Datei_anlegen
+Backup\ old\ file\ when\ saving=Beim Speichern ein Backup der alten Datei anlegen
 
-BibTeX_key_is_unique.=Der_BibTeX-Key_ist_eindeutig.
+BibTeX\ key\ is\ unique.=Der BibTeX-Key ist eindeutig.
 
-%0_source=%0-Quelltext
+%0\ source=%0-Quelltext
 
-Broken_link=Ungültiger_Link
+Broken\ link=Ungültiger Link
 
 Browse=Durchsuchen
 
@@ -160,321 +160,321 @@ by=durch
 
 Cancel=Abbrechen
 
-Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?=Einträge_können_einer_Gruppe_nicht_hinzugefügt_werden,_ohne_Keys_zu_generieren._Sollen_die_Keys_jetzt_generiert_werden?
+Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=Einträge können einer Gruppe nicht hinzugefügt werden, ohne Keys zu generieren. Sollen die Keys jetzt generiert werden?
 
-Cannot_merge_this_change=Kann_diese_Änderung_nicht_einfügen
+Cannot\ merge\ this\ change=Kann diese Änderung nicht einfügen
 
-case_insensitive=Groß-/Kleinschreibung_wird_nicht_unterschieden
+case\ insensitive=Groß-/Kleinschreibung wird nicht unterschieden
 
-case_sensitive=Groß-/Kleinschreibung_wird_unterschieden
+case\ sensitive=Groß-/Kleinschreibung wird unterschieden
 
-Case_sensitive=Groß-/Kleinschreibung
+Case\ sensitive=Groß-/Kleinschreibung
 
-change_assignment_of_entries=Änderung_der_zugewiesenen_Einträge
+change\ assignment\ of\ entries=Änderung der zugewiesenen Einträge
 
-Change_case=Groß-_und_Kleinschreibung
+Change\ case=Groß- und Kleinschreibung
 
-Change_entry_type=Eintragstyp_ändern
-Change_file_type=Dateityp_ändern
+Change\ entry\ type=Eintragstyp ändern
+Change\ file\ type=Dateityp ändern
 
 
-Change_of_Grouping_Method=Ändern_der_Gruppierungsmethode
+Change\ of\ Grouping\ Method=Ändern der Gruppierungsmethode
 
-change_preamble=Präambel_ändern
+change\ preamble=Präambel ändern
 
-Change_table_column_and_General_fields_settings_to_use_the_new_feature=Tabellenspalte_und_Einstellungen_der_Allgemeinen_Felder_ändern,_um_die_neue_Funktion_zu_nutzen
+Change\ table\ column\ and\ General\ fields\ settings\ to\ use\ the\ new\ feature=Tabellenspalte und Einstellungen der Allgemeinen Felder ändern, um die neue Funktion zu nutzen
 
-Changed_language_settings=Spracheinstellungen_geändert
+Changed\ language\ settings=Spracheinstellungen geändert
 
-Changed_preamble=Präambel_geändert
+Changed\ preamble=Präambel geändert
 
-Check_existing_file_links=Existierende_Datei-Links_überprüfen
+Check\ existing\ file\ links=Existierende Datei-Links überprüfen
 
-Check_links=Links_überprüfen
+Check\ links=Links überprüfen
 
-Cite_command=Cite-Befehl
+Cite\ command=Cite-Befehl
 
-Class_name=Klassenname
+Class\ name=Klassenname
 
 Clear=Zurücksetzen
 
-Clear_fields=Felder_löschen
+Clear\ fields=Felder löschen
 
 Close=Schließen
-Close_others=Andere_schließen
-Close_all=Alle_schließen
+Close\ others=Andere schließen
+Close\ all=Alle schließen
 
-Close_dialog=Dialog_schließen
+Close\ dialog=Dialog schließen
 
-Close_the_current_library=Aktuelle_Bibliothek_schließen
+Close\ the\ current\ library=Aktuelle Bibliothek schließen
 
-Close_window=Fenster_schließen
+Close\ window=Fenster schließen
 
-Closed_library=Bibliothek_geschlossen
+Closed\ library=Bibliothek geschlossen
 
-Color_codes_for_required_and_optional_fields=Farbanzeige_für_benötigte_und_optionale_Felder
+Color\ codes\ for\ required\ and\ optional\ fields=Farbanzeige für benötigte und optionale Felder
 
-Color_for_marking_incomplete_entries=Farbe_zum_Markieren_unvollständiger_Einträge
+Color\ for\ marking\ incomplete\ entries=Farbe zum Markieren unvollständiger Einträge
 
-Column_width=Spaltenbreite
+Column\ width=Spaltenbreite
 
-Command_line_id=Kommandozeilen_ID
+Command\ line\ id=Kommandozeilen ID
 
 
-Contained_in=Enthalten_in
+Contained\ in=Enthalten in
 
 Content=Inhalt
 
 Copied=Kopiert
 
-Copied_cell_contents=Zelleninhalt_kopiert
+Copied\ cell\ contents=Zelleninhalt kopiert
 
-Copied_title=Titel_kopiert
+Copied\ title=Titel kopiert
 
-Copied_key=BibTeX-Key_kopiert
+Copied\ key=BibTeX-Key kopiert
 
-Copied_titles=Titel_kopiert
+Copied\ titles=Titel kopiert
 
-Copied_keys=BibTeX-Keys_kopiert
+Copied\ keys=BibTeX-Keys kopiert
 
 Copy=Kopieren
 
-Copy_BibTeX_key=BibTeX-Key_kopieren
-Copy_file_to_file_directory=Datei_in_das_Dateiverzeichnis_kopieren
+Copy\ BibTeX\ key=BibTeX-Key kopieren
+Copy\ file\ to\ file\ directory=Datei in das Dateiverzeichnis kopieren
 
-Copy_to_clipboard=In_die_Zwischenablage_kopieren
+Copy\ to\ clipboard=In die Zwischenablage kopieren
 
-Could_not_call_executable=Konnte_das_Programm_nicht_aufrufen
-Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.=Verbindung_zum_Vim-Server_fehlgeschlagen._Vergewissern_Sie_sich,<br>dass_Vim_mit_korrektem_Servernamen_läuft.
+Could\ not\ call\ executable=Konnte das Programm nicht aufrufen
+Could\ not\ connect\ to\ Vim\ server.\ Make\ sure\ that\ Vim\ is\ running<BR>with\ correct\ server\ name.=Verbindung zum Vim-Server fehlgeschlagen. Vergewissern Sie sich,<br>dass Vim mit korrektem Servernamen läuft.
 
-Could_not_export_file=Konnte_Datei_nicht_exportieren
+Could\ not\ export\ file=Konnte Datei nicht exportieren
 
-Could_not_export_preferences=Einstellungen_konnten_nicht_exportiert_werden
+Could\ not\ export\ preferences=Einstellungen konnten nicht exportiert werden
 
-Could_not_find_a_suitable_import_format.=Kein_passendes_Importer_gefunden.
-Could_not_import_preferences=Einstellungen_konnten_nicht_importiert_werden
+Could\ not\ find\ a\ suitable\ import\ format.=Kein passendes Importer gefunden.
+Could\ not\ import\ preferences=Einstellungen konnten nicht importiert werden
 
-Could_not_instantiate_%0=Konnte_Importer_nicht_erzeugen_%0
-Could_not_instantiate_%0_%1=Konnte_Importer_nicht_erzeugen_%0_%1
-Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?=Konnte_%0_nicht_realisieren._Haben_Sie_den_richtigen_Paket-Pfad_angegeben?
-Could_not_open_link=Link_konnte_nicht_geöffnet_werden
+Could\ not\ instantiate\ %0=Konnte Importer nicht erzeugen %0
+Could\ not\ instantiate\ %0\ %1=Konnte Importer nicht erzeugen %0 %1
+Could\ not\ instantiate\ %0.\ Have\ you\ chosen\ the\ correct\ package\ path?=Konnte %0 nicht realisieren. Haben Sie den richtigen Paket-Pfad angegeben?
+Could\ not\ open\ link=Link konnte nicht geöffnet werden
 
-Could_not_print_preview=Druckvorschau_fehlgeschlagen
+Could\ not\ print\ preview=Druckvorschau fehlgeschlagen
 
-Could_not_run_the_'vim'_program.=Das_Programm_'vim'_konnte_nicht_gestartet_werden.
+Could\ not\ run\ the\ 'vim'\ program.=Das Programm 'vim' konnte nicht gestartet werden.
 
-Could_not_save_file.=Datei_konnte_nicht_gespeichert_werden.
-Character_encoding_'%0'_is_not_supported.=Die_Zeichenkodierung_'%0'_wird_nicht_unterstützt.
+Could\ not\ save\ file.=Datei konnte nicht gespeichert werden.
+Character\ encoding\ '%0'\ is\ not\ supported.=Die Zeichenkodierung '%0' wird nicht unterstützt.
 
-crossreferenced_entries_included=Inklusive_querverwiesenen_Einträgen
+crossreferenced\ entries\ included=Inklusive querverwiesenen Einträgen
 
-Current_content=Aktueller_Inhalt
+Current\ content=Aktueller Inhalt
 
-Current_value=Aktueller_Wert
+Current\ value=Aktueller Wert
 
-Custom_entry_types=Benutzerdefinierte_Eintragstypen
+Custom\ entry\ types=Benutzerdefinierte Eintragstypen
 
-Custom_entry_types_found_in_file=Benutzerdefinierte_Eintragstypen_gefunden
+Custom\ entry\ types\ found\ in\ file=Benutzerdefinierte Eintragstypen gefunden
 
-Customize_entry_types=Eintragstypen_anpassen
+Customize\ entry\ types=Eintragstypen anpassen
 
-Customize_key_bindings=Tastenkürzel_anpassen
+Customize\ key\ bindings=Tastenkürzel anpassen
 
 Cut=Ausschneiden
 
-cut_entries=Einträge_ausschneiden
+cut\ entries=Einträge ausschneiden
 
-cut_entry=Eintrag_ausschneiden
+cut\ entry=Eintrag ausschneiden
 
 
-Library_encoding=Zeichenkodierung_der_Bibliothek
+Library\ encoding=Zeichenkodierung der Bibliothek
 
-Library_properties=Eigenschaften_der_Bibliothek
+Library\ properties=Eigenschaften der Bibliothek
 
-Library_type=Typ_der_Bibliothek
+Library\ type=Typ der Bibliothek
 
-Date_format=Datumsformat
+Date\ format=Datumsformat
 
 Default=Standard
 
-Default_encoding=Standard-Zeichenkodierung
+Default\ encoding=Standard-Zeichenkodierung
 
-Default_grouping_field=Standard_Gruppierungs-Feld
+Default\ grouping\ field=Standard Gruppierungs-Feld
 
-Default_look_and_feel=Standard_"look_and_feel"
+Default\ look\ and\ feel=Standard "look and feel"
 
-Default_pattern=Standardmuster
+Default\ pattern=Standardmuster
 
-Default_sort_criteria=Standard-Sortierkriterium
-Define_'%0'=Definiere_'%0'
+Default\ sort\ criteria=Standard-Sortierkriterium
+Define\ '%0'=Definiere '%0'
 
 Delete=Löschen
 
-Delete_custom_format=Format_des_Eintragstyps_löschen
+Delete\ custom\ format=Format des Eintragstyps löschen
 
-delete_entries=Einträge_löschen
+delete\ entries=Einträge löschen
 
-Delete_entry=Eintrag_löschen
+Delete\ entry=Eintrag löschen
 
-delete_entry=Eintrag_löschen
+delete\ entry=Eintrag löschen
 
-Delete_multiple_entries=Mehrere_Einträge_löschen
+Delete\ multiple\ entries=Mehrere Einträge löschen
 
-Delete_rows=Zeilen_löschen
+Delete\ rows=Zeilen löschen
 
-Delete_strings=Strings_löschen
+Delete\ strings=Strings löschen
 
 Deleted=Gelöscht
 
-Permanently_delete_local_file=Lösche_lokale_Datei
+Permanently\ delete\ local\ file=Lösche lokale Datei
 
-Delimit_fields_with_semicolon,_ex.=Felder_mit_Semikolon_abgrenzen,_z.B.
+Delimit\ fields\ with\ semicolon,\ ex.=Felder mit Semikolon abgrenzen, z.B.
 
 Descending=Absteigend
 
 Description=Beschreibung
 
-Deselect_all=Auswahl_aufheben
-Deselect_all_duplicates=Auswahl_der_Duplikate_aufheben
+Deselect\ all=Auswahl aufheben
+Deselect\ all\ duplicates=Auswahl der Duplikate aufheben
 
-Disable_this_confirmation_dialog=Diesen_Bestätigungsdialog_deaktivieren
+Disable\ this\ confirmation\ dialog=Diesen Bestätigungsdialog deaktivieren
 
-Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.=Alle_Einträge_anzeigen,_die_zu_einer_oder_mehreren_der_ausgewählten_Gruppen_gehören.
+Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups.=Alle Einträge anzeigen, die zu einer oder mehreren der ausgewählten Gruppen gehören.
 
-Display_all_error_messages=Zeige_alle_Fehlermeldugen
+Display\ all\ error\ messages=Zeige alle Fehlermeldugen
 
-Display_help_on_command_line_options=Zeige_Kommandozeilenhilfe
+Display\ help\ on\ command\ line\ options=Zeige Kommandozeilenhilfe
 
-Display_only_entries_belonging_to_all_selected_groups.=Nur_Einträge_anzeigen,_die_zu_allen_ausgewählten_Gruppen_gehören.
-Display_version=Version_anzeigen
+Display\ only\ entries\ belonging\ to\ all\ selected\ groups.=Nur Einträge anzeigen, die zu allen ausgewählten Gruppen gehören.
+Display\ version=Version anzeigen
 
-Do_not_abbreviate_names=Namen_nicht_abkürzen
+Do\ not\ abbreviate\ names=Namen nicht abkürzen
 
-Do_not_automatically_set=Nicht_automatisch_zuordnen
+Do\ not\ automatically\ set=Nicht automatisch zuordnen
 
-Do_not_import_entry=Eintrag_nicht_importieren
+Do\ not\ import\ entry=Eintrag nicht importieren
 
-Do_not_open_any_files_at_startup=Keine_Dateien_beim_Start_öffnen
+Do\ not\ open\ any\ files\ at\ startup=Keine Dateien beim Start öffnen
 
-Do_not_overwrite_existing_keys=Existierende_Keys_nicht_überschreiben
-Do_not_show_these_options_in_the_future=Diese_Optionen_in_Zukunft_nicht_anzeigen
+Do\ not\ overwrite\ existing\ keys=Existierende Keys nicht überschreiben
+Do\ not\ show\ these\ options\ in\ the\ future=Diese Optionen in Zukunft nicht anzeigen
 
-Do_not_wrap_the_following_fields_when_saving=Beim_Speichern_keinen_Zeilenumbruch_in_den_folgenden_Feldern_einfügen
-Do_not_write_the_following_fields_to_XMP_Metadata\:=Folgende_Felder_nicht_in_die_XMP-Metadaten_schreiben\:
+Do\ not\ wrap\ the\ following\ fields\ when\ saving=Beim Speichern keinen Zeilenumbruch in den folgenden Feldern einfügen
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Folgende Felder nicht in die XMP-Metadaten schreiben:
 
-Do_you_want_JabRef_to_do_the_following_operations?=Soll_JabRef_die_folgenden_Vorgänge_durchführen?
+Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Soll JabRef die folgenden Vorgänge durchführen?
 
-Donate_to_JabRef=An_JabRef_spenden
+Donate\ to\ JabRef=An JabRef spenden
 
 Down=Abwärts
 
-Download_file=Datei_herunterladen
+Download\ file=Datei herunterladen
 
-Downloading...=Download_läuft
+Downloading...=Download läuft
 
-Drop_%0=%0_streichen
+Drop\ %0=%0 streichen
 
-duplicate_removal=Duplikate_entfernen
+duplicate\ removal=Duplikate entfernen
 
-Duplicate_string_name=Doppelter_String-Name
+Duplicate\ string\ name=Doppelter String-Name
 
-Duplicates_found=Doppelte_Einträge_gefunden
+Duplicates\ found=Doppelte Einträge gefunden
 
-Dynamic_groups=Dynamische_Gruppen
+Dynamic\ groups=Dynamische Gruppen
 
-Dynamically_group_entries_by_a_free-form_search_expression=Dynamisches_Gruppieren_der_Einträge_anhand_eines_beliebigen_Suchausdrucks
+Dynamically\ group\ entries\ by\ a\ free-form\ search\ expression=Dynamisches Gruppieren der Einträge anhand eines beliebigen Suchausdrucks
 
-Dynamically_group_entries_by_searching_a_field_for_a_keyword=Dynamisches_Gruppieren_der_Einträge_anhand_eines_Stichworts_in_einem_Feld
+Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=Dynamisches Gruppieren der Einträge anhand eines Stichworts in einem Feld
 
-Each_line_must_be_on_the_following_form=Jede_Zeile_muss_das_folgende_Format_aufweisen
+Each\ line\ must\ be\ on\ the\ following\ form=Jede Zeile muss das folgende Format aufweisen
 
 Edit=Bearbeiten
 
-Edit_custom_export=Bearbeite_externen_Exportfilter
-Edit_entry=Eintrag_bearbeiten
-Save_file=Datei_speichern
-Edit_file_type=Dateityp_bearbeiten
+Edit\ custom\ export=Bearbeite externen Exportfilter
+Edit\ entry=Eintrag bearbeiten
+Save\ file=Datei speichern
+Edit\ file\ type=Dateityp bearbeiten
 
-Edit_group=Gruppe_bearbeiten
+Edit\ group=Gruppe bearbeiten
 
 
-Edit_preamble=Präambel_bearbeiten
-Edit_strings=Strings_bearbeiten
-Editor_options=Herausgeber-Optionen
+Edit\ preamble=Präambel bearbeiten
+Edit\ strings=Strings bearbeiten
+Editor\ options=Herausgeber-Optionen
 
-Empty_BibTeX_key=Leerer_BibTeX-Key
+Empty\ BibTeX\ key=Leerer BibTeX-Key
 
-Grouping_may_not_work_for_this_entry.=Es_kann_sein,_dass_die_Gruppierung_für_diesen_Eintrag_nicht_funktioniert.
+Grouping\ may\ not\ work\ for\ this\ entry.=Es kann sein, dass die Gruppierung für diesen Eintrag nicht funktioniert.
 
-empty_library=leere_Bibliothek
-Enable_word/name_autocompletion=Autovervollständigung_aktivieren
+empty\ library=leere Bibliothek
+Enable\ word/name\ autocompletion=Autovervollständigung aktivieren
 
-Enter_URL=URL_eingeben
+Enter\ URL=URL eingeben
 
-Enter_URL_to_download=URL_für_den_Download_eingeben
+Enter\ URL\ to\ download=URL für den Download eingeben
 
 entries=Einträge
 
-Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.=Ein_manuelles_Hinzufügen_oder_Entfernen_von_Einträgen_ist_für_diese_Gruppe_nicht_möglich.
+Entries\ cannot\ be\ manually\ assigned\ to\ or\ removed\ from\ this\ group.=Ein manuelles Hinzufügen oder Entfernen von Einträgen ist für diese Gruppe nicht möglich.
 
-Entries_exported_to_clipboard=Einträge_in_die_Zwischenablage_kopiert
+Entries\ exported\ to\ clipboard=Einträge in die Zwischenablage kopiert
 
 
 entry=Eintrag
 
-Entry_editor=Eintragseditor
+Entry\ editor=Eintragseditor
 
-Entry_preview=Eintragsvorschau
+Entry\ preview=Eintragsvorschau
 
-Entry_table=Tabellenansicht
+Entry\ table=Tabellenansicht
 
-Entry_table_columns=Spaltenanordnung
+Entry\ table\ columns=Spaltenanordnung
 
-Entry_type=Eintragstyp
+Entry\ type=Eintragstyp
 
-Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Namen_von_Eintragstypen_dürfen_weder_Leerzeichen_noch_die_folgenden_Zeichen_enthalten
+Entry\ type\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Namen von Eintragstypen dürfen weder Leerzeichen noch die folgenden Zeichen enthalten
 
-Entry_types=Eintragstypen
+Entry\ types=Eintragstypen
 
 Error=Fehler
-Error_exporting_to_clipboard=Fehler_beim_Exportieren_in_die_Zwischenablage
+Error\ exporting\ to\ clipboard=Fehler beim Exportieren in die Zwischenablage
 
-Error_occurred_when_parsing_entry=Fehler_beim_Analysieren_des_Eintrags
+Error\ occurred\ when\ parsing\ entry=Fehler beim Analysieren des Eintrags
 
-Error_opening_file=Fehler_beim_Öffnen_der_Datei
+Error\ opening\ file=Fehler beim Öffnen der Datei
 
-Error_setting_field=Fehler_beim_Erstellen_des_Feldes
+Error\ setting\ field=Fehler beim Erstellen des Feldes
 
-Error_while_writing=Fehler_beim_Schreiben
-Error_writing_to_%0_file(s).=Fehler_beim_Schreiben_in_%0_Datei(en).
+Error\ while\ writing=Fehler beim Schreiben
+Error\ writing\ to\ %0\ file(s).=Fehler beim Schreiben in %0 Datei(en).
 
 
 
-'%0'_exists._Overwrite_file?='%0'_existiert_bereits._Überschreiben?
-Overwrite_file?=_Überschreiben?
+'%0'\ exists.\ Overwrite\ file?='%0' existiert bereits. Überschreiben?
+Overwrite\ file?= Überschreiben?
 
 Export=Exportieren
 
-Export_name=Filtername
+Export\ name=Filtername
 
-Export_preferences=Einstellungen_exportieren
+Export\ preferences=Einstellungen exportieren
 
-Export_preferences_to_file=Exportiere_Einstellungen_in_Datei
+Export\ preferences\ to\ file=Exportiere Einstellungen in Datei
 
-Export_properties=Eigenschaften_für_Exportfilter
+Export\ properties=Eigenschaften für Exportfilter
 
-Export_to_clipboard=In_die_Zwischenablage_kopieren
+Export\ to\ clipboard=In die Zwischenablage kopieren
 
 Exporting=Exportiere
 Extension=Erweiterung
 
-External_changes=Externe_Änderungen
+External\ changes=Externe Änderungen
 
-External_file_links=Links_zu_externen_Dateien
+External\ file\ links=Links zu externen Dateien
 
-External_programs=Externe_Programme
+External\ programs=Externe Programme
 
-External_viewer_called=Externer_Betrachter_aufgerufen
+External\ viewer\ called=Externer Betrachter aufgerufen
 
 Fetch=Abrufen
 
@@ -482,210 +482,210 @@ Field=Feld
 
 field=Feld
 
-Field_name=Feldname
-Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Feldbezeichnungen_dürfen_keine_Leerzeichen_enthalten_und_keine_der_folgenden_Zeichen
+Field\ name=Feldname
+Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Feldbezeichnungen dürfen keine Leerzeichen enthalten und keine der folgenden Zeichen
 
-Field_to_filter=Feld_für_Filter
+Field\ to\ filter=Feld für Filter
 
-Field_to_group_by=Sortierfeld
+Field\ to\ group\ by=Sortierfeld
 
 File=Datei
 
 file=Datei
-File_'%0'_is_already_open.=Datei_'%0'_ist_bereits_geöffnet.
+File\ '%0'\ is\ already\ open.=Datei '%0' ist bereits geöffnet.
 
-File_changed=Datei_geändert
-File_directory_is_'%0'\:=Dateiverzeichnis_ist_'%0'\:
+File\ changed=Datei geändert
+File\ directory\ is\ '%0'\:=Dateiverzeichnis ist '%0':
 
-File_directory_is_not_set_or_does_not_exist\!=Dateiverzeichnis_ist_nicht_gesetzt_oder_existiert_nicht
+File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=Dateiverzeichnis ist nicht gesetzt oder existiert nicht
 
-File_exists=Datei_ist_vorhanden
+File\ exists=Datei ist vorhanden
 
-File_has_been_updated_externally._What_do_you_want_to_do?=Die_Datei_wurde_extern_aktualisiert._Was_wollen_Sie_tun?
+File\ has\ been\ updated\ externally.\ What\ do\ you\ want\ to\ do?=Die Datei wurde extern aktualisiert. Was wollen Sie tun?
 
-File_not_found=Datei_nicht_gefunden
-File_type=Dateityp
+File\ not\ found=Datei nicht gefunden
+File\ type=Dateityp
 
-File_updated_externally=Datei_extern_geändert
+File\ updated\ externally=Datei extern geändert
 
 filename=Dateiname
 
 Filename=Dateiname
 
-Files_opened=Dateien_geöffnet
+Files\ opened=Dateien geöffnet
 
 Filter=Filter
 
-Filter_All=Alle_filtern
+Filter\ All=Alle filtern
 
-Filter_None=Filter_aufheben
+Filter\ None=Filter aufheben
 
-Finished_automatically_setting_external_links.=Automatische_Einstellung_externer_Links_abgeschlossen.
+Finished\ automatically\ setting\ external\ links.=Automatische Einstellung externer Links abgeschlossen.
 
-Finished_synchronizing_file_links._Entries_changed\:_%0.=Synchronisierung_von_Datei_Links_abgeschlossen._Geänderte_Einträge\:_%0.
-Finished_writing_XMP-metadata._Wrote_to_%0_file(s).=Schreiben_der_XMP-Metadaten_in_%0_Datei(en)_beendet.
-Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).=Schreiben_der_XMP-Metadaten_für_Datei_%0_beendet_(%1_übersprungen,_%2_Fehler).
+Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Synchronisierung von Datei Links abgeschlossen. Geänderte Einträge: %0.
+Finished\ writing\ XMP-metadata.\ Wrote\ to\ %0\ file(s).=Schreiben der XMP-Metadaten in %0 Datei(en) beendet.
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Schreiben der XMP-Metadaten für Datei %0 beendet (%1 übersprungen, %2 Fehler).
 
-First_select_the_entries_you_want_keys_to_be_generated_for.=Wählen_Sie_zuerst_die_Einträge_aus,_für_die_Keys_erstellt_werden_sollen.
+First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Wählen Sie zuerst die Einträge aus, für die Keys erstellt werden sollen.
 
-Fit_table_horizontally_on_screen=Tabelle_horizontal_dem_Bildschirm_anpassen
+Fit\ table\ horizontally\ on\ screen=Tabelle horizontal dem Bildschirm anpassen
 
-Float=Oben_einsortieren
-Float_marked_entries=Markierte_Einträge_zuoberst_anzeigen
+Float=Oben einsortieren
+Float\ marked\ entries=Markierte Einträge zuoberst anzeigen
 
-Font_family=Schriftart
+Font\ family=Schriftart
 
-Font_preview=Vorschau
+Font\ preview=Vorschau
 
-Font_size=Schriftgröße
+Font\ size=Schriftgröße
 
-Font_style=Schriftstil
+Font\ style=Schriftstil
 
-Font_selection=Schriften_wählen
+Font\ selection=Schriften wählen
 
 for=für
 
-Format_of_author_and_editor_names=Format_der_Autoren-_und_Hrsg.-Namen
-Format_string=Formatier-Ausdruck
+Format\ of\ author\ and\ editor\ names=Format der Autoren- und Hrsg.-Namen
+Format\ string=Formatier-Ausdruck
 
-Format_used=benutztes_Format
-Formatter_name=Name_des_Formatierers
+Format\ used=benutztes Format
+Formatter\ name=Name des Formatierers
 
-found_in_AUX_file=gefundene_Schlüssel_in_AUX_Datei
+found\ in\ AUX\ file=gefundene Schlüssel in AUX Datei
 
-Full_name=Kompletter_Name
+Full\ name=Kompletter Name
 
 General=Allgemein
 
-General_fields=Allgemeine_Felder
+General\ fields=Allgemeine Felder
 
 Generate=Erzeugen
 
-Generate_BibTeX_key=BibTeX-Key_generieren
+Generate\ BibTeX\ key=BibTeX-Key generieren
 
-Generate_keys=Erstelle_Key
+Generate\ keys=Erstelle Key
 
-Generate_keys_before_saving_(for_entries_without_a_key)=Keys_vor_dem_Speichern_erstellen_(für_Einräge_ohne_Key)
-Generate_keys_for_imported_entries=Keys_für_importierte_Einträge_generieren
+Generate\ keys\ before\ saving\ (for\ entries\ without\ a\ key)=Keys vor dem Speichern erstellen (für Einräge ohne Key)
+Generate\ keys\ for\ imported\ entries=Keys für importierte Einträge generieren
 
-Generate_now=Jetzt_generieren
+Generate\ now=Jetzt generieren
 
-Generated_BibTeX_key_for=BibTeX-Key_erzeugt_für
+Generated\ BibTeX\ key\ for=BibTeX-Key erzeugt für
 
-Generating_BibTeX_key_for=Erzeuge_BibTeX-Key_für
-Get_fulltext=Hole_Volltext
+Generating\ BibTeX\ key\ for=Erzeuge BibTeX-Key für
+Get\ fulltext=Hole Volltext
 
-Gray_out_non-hits=Nicht-Treffer_grau_einfärben
+Gray\ out\ non-hits=Nicht-Treffer grau einfärben
 
 Groups=Gruppen
 
-Have_you_chosen_the_correct_package_path?=Habe_Sie_den_richtigen_Klassenpfad_gewählt?
+Have\ you\ chosen\ the\ correct\ package\ path?=Habe Sie den richtigen Klassenpfad gewählt?
 
 Help=Hilfe
 
-Help_on_key_patterns=Hilfe_zu_BibTeX-Key-Mustern
-Help_on_regular_expression_search=Hilfe_zur_Suche_mit_regulärem_Ausdruck
+Help\ on\ key\ patterns=Hilfe zu BibTeX-Key-Mustern
+Help\ on\ regular\ expression\ search=Hilfe zur Suche mit regulärem Ausdruck
 
-Hide_non-hits=Nicht-Treffer_ausblenden
+Hide\ non-hits=Nicht-Treffer ausblenden
 
-Hierarchical_context=Hierarchischer_Kontext
+Hierarchical\ context=Hierarchischer Kontext
 
 Highlight=Hervorhebung
 Marking=Markierung
 Underline=Unterstreichung
-Empty_Highlight=Leere_Hervorhebung
-Empty_Marking=Leere_Markierung
-Empty_Underline=Leere_Unterstreichung
-The_marked_area_does_not_contain_any_legible_text!=Der_markierte_Bereich_enthält_keinen_lesbaren_Text!
+Empty\ Highlight=Leere Hervorhebung
+Empty\ Marking=Leere Markierung
+Empty\ Underline=Leere Unterstreichung
+The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=Der markierte Bereich enthält keinen lesbaren Text!
 
-Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>=Hinweis\:_Um_ausschließlich_bestimmte_Felder_zu_durchsuchen,_geben_Sie_z.B._ein\:<p><tt>author\=smith_and_title\=electrical</tt>
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Hinweis: Um ausschließlich bestimmte Felder zu durchsuchen, geben Sie z.B. ein:<p><tt>author=smith and title=electrical</tt>
 
-HTML_table=HTML-Tabelle
-HTML_table_(with_Abstract_&_BibTeX)=HTML-Tabelle_(mit_Abstract_&_BibTeX)
+HTML\ table=HTML-Tabelle
+HTML\ table\ (with\ Abstract\ &\ BibTeX)=HTML-Tabelle (mit Abstract & BibTeX)
 Icon=Icon
 
 Ignore=Ignorieren
 
 Import=Importieren
 
-Import_and_keep_old_entry=Importieren_und_alten_Eintrag_behalten
+Import\ and\ keep\ old\ entry=Importieren und alten Eintrag behalten
 
-Import_and_remove_old_entry=Importieren_und_alten_Eintrag_löschen
+Import\ and\ remove\ old\ entry=Importieren und alten Eintrag löschen
 
-Import_entries=Einträge_importieren
+Import\ entries=Einträge importieren
 
-Import_failed=Import_fehlgeschlagen
+Import\ failed=Import fehlgeschlagen
 
-Import_file=Datei_importieren
+Import\ file=Datei importieren
 
-Import_group_definitions=Gruppendefinitionen_importieren
+Import\ group\ definitions=Gruppendefinitionen importieren
 
-Import_name=Name_des_Importfilters
+Import\ name=Name des Importfilters
 
-Import_preferences=Einstellungen_importieren
+Import\ preferences=Einstellungen importieren
 
-Import_preferences_from_file=Einstellungen_aus_Datei_importieren
+Import\ preferences\ from\ file=Einstellungen aus Datei importieren
 
-Import_strings=Strings_importieren
+Import\ strings=Strings importieren
 
-Import_to_open_tab=In_geöffnetes_Tab_importieren
+Import\ to\ open\ tab=In geöffnetes Tab importieren
 
-Import_word_selector_definitions=Wortauswahldefinitionen_importieren
+Import\ word\ selector\ definitions=Wortauswahldefinitionen importieren
 
-Imported_entries=Einträge_importiert
+Imported\ entries=Einträge importiert
 
-Imported_from_library=Importiert_aus_Bibliothek
+Imported\ from\ library=Importiert aus Bibliothek
 
-Importer_class=Importer_Klasse
+Importer\ class=Importer Klasse
 
 Importing=Importieren
 
-Importing_in_unknown_format=Ein_unbekanntes_Format_importieren
+Importing\ in\ unknown\ format=Ein unbekanntes Format importieren
 
-Include_abstracts=Abstracts_berücksichtigen
-Include_entries=Einträge_einschließen
+Include\ abstracts=Abstracts berücksichtigen
+Include\ entries=Einträge einschließen
 
-Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups=Untergruppen_berücksichtigen\:_Einträge_dieser_Gruppe_und_ihrer_Untergruppen_anzeigen
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=Untergruppen berücksichtigen: Einträge dieser Gruppe und ihrer Untergruppen anzeigen
 
-Independent_group\:_When_selected,_view_only_this_group's_entries=Unabhängige_Gruppen\:_Nur_die_Einträge_dieser_Gruppe_anzeigen
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=Unabhängige Gruppen: Nur die Einträge dieser Gruppe anzeigen
 
-Work_options=Bearbeitungsoptionen
+Work\ options=Bearbeitungsoptionen
 
 Insert=einfügen
 
-Insert_rows=Zeilen_einfügen
+Insert\ rows=Zeilen einfügen
 
 Intersection=Schnittmenge
 
-Invalid_BibTeX_key=Ungültiger_BibTeX-Key
+Invalid\ BibTeX\ key=Ungültiger BibTeX-Key
 
-Invalid_date_format=Ungültiges_Datumsformat
+Invalid\ date\ format=Ungültiges Datumsformat
 
-Invalid_URL=Ungültige_URL
+Invalid\ URL=Ungültige URL
 
-Online_help=Online_Hilfe
+Online\ help=Online Hilfe
 
-JabRef_preferences=JabRef_Einstellungen
+JabRef\ preferences=JabRef Einstellungen
 
 Join=Verbinden
 
-Joins_selected_keywords_and_deletes_selected_keywords.=Verbindet_ausgewählte_Stichwörter_und_löscht_ausgewählte_Stichwörter.
+Joins\ selected\ keywords\ and\ deletes\ selected\ keywords.=Verbindet ausgewählte Stichwörter und löscht ausgewählte Stichwörter.
 
-Journal_abbreviations=Abkürzung_der_Zeitschriftentitel
+Journal\ abbreviations=Abkürzung der Zeitschriftentitel
 
 Keep=Behalten
 
-Keep_both=Beide_behalten
+Keep\ both=Beide behalten
 
-Key_bindings=Tastenkürzel
+Key\ bindings=Tastenkürzel
 
-Key_bindings_changed=Tastenkürzel_geändert
+Key\ bindings\ changed=Tastenkürzel geändert
 
-Key_generator_settings=Einstellungen_des_Key-Generators
+Key\ generator\ settings=Einstellungen des Key-Generators
 
-Key_pattern=BibTeX-Key-Muster
+Key\ pattern=BibTeX-Key-Muster
 
-keys_in_library=Keys_in_der_Bibliothek
+keys\ in\ library=Keys in der Bibliothek
 
 Keyword=Stichwort
 
@@ -693,449 +693,449 @@ Label=Name
 
 Language=Sprache
 
-Last_modified=zuletzt_geändert
+Last\ modified=zuletzt geändert
 
-LaTeX_AUX_file=LaTeX_AUX-Datei
-Leave_file_in_its_current_directory=Datei_im_aktuellen_Verzeichnis_lassen
+LaTeX\ AUX\ file=LaTeX AUX-Datei
+Leave\ file\ in\ its\ current\ directory=Datei im aktuellen Verzeichnis lassen
 
 Left=Links
 Level=Ebene
 
-Limit_to_fields=Auf_folgende_Felder_begrenzen
+Limit\ to\ fields=Auf folgende Felder begrenzen
 
-Limit_to_selected_entries=Auf_ausgewählte_Einträge_begrenzen
+Limit\ to\ selected\ entries=Auf ausgewählte Einträge begrenzen
 
 Link=Link
-Link_local_file=Link_zu_lokaler_Datei
-Link_to_file_%0=Link_zur_Datei_%0
+Link\ local\ file=Link zu lokaler Datei
+Link\ to\ file\ %0=Link zur Datei %0
 
-Listen_for_remote_operation_on_port=Port_nach_externem_Zugriff_abhören
-Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)=Einstellungen_beim_Start_laden_von/speichern_in_jabref.xml_(Memory_Stick-Modus)
+Listen\ for\ remote\ operation\ on\ port=Port nach externem Zugriff abhören
+Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=Einstellungen beim Start laden von/speichern in jabref.xml (Memory Stick-Modus)
 
-Look_and_feel=Aussehen
-Main_file_directory=Standard-Verzeichnis_für_Dateien
+Look\ and\ feel=Aussehen
+Main\ file\ directory=Standard-Verzeichnis für Dateien
 
-Main_layout_file=Haupt-Layoutdatei
+Main\ layout\ file=Haupt-Layoutdatei
 
-Manage_custom_exports=Verwalte_externe_Exportfilter
+Manage\ custom\ exports=Verwalte externe Exportfilter
 
-Manage_custom_imports=Verwalte_externe_Importfilter
-Manage_external_file_types=Externe_Dateitypen_verwalten
+Manage\ custom\ imports=Verwalte externe Importfilter
+Manage\ external\ file\ types=Externe Dateitypen verwalten
 
-Mark_entries=Einträge_markieren
+Mark\ entries=Einträge markieren
 
-Mark_entry=Eintrag_markieren
+Mark\ entry=Eintrag markieren
 
-Mark_new_entries_with_addition_date=Neue_Einträge_mit_Datum_versehen
+Mark\ new\ entries\ with\ addition\ date=Neue Einträge mit Datum versehen
 
-Mark_new_entries_with_owner_name=Neue_Einträge_mit_Namen_des_Besitzers_versehen
+Mark\ new\ entries\ with\ owner\ name=Neue Einträge mit Namen des Besitzers versehen
 
-Memory_stick_mode=Memory_Stick-Modus
+Memory\ stick\ mode=Memory Stick-Modus
 
-Menu_and_label_font_size=Schriftgröße_in_Menüs
+Menu\ and\ label\ font\ size=Schriftgröße in Menüs
 
-Merged_external_changes=Externe_Änderungen_eingefügt
+Merged\ external\ changes=Externe Änderungen eingefügt
 
 Messages=Mitteilungen
 
-Modification_of_field=Änderung_des_Felds
+Modification\ of\ field=Änderung des Felds
 
-Modified_group_"%0".=Gruppe_"%0"_geändert.
+Modified\ group\ "%0".=Gruppe "%0" geändert.
 
-Modified_groups=Geänderte_Gruppen
+Modified\ groups=Geänderte Gruppen
 
-Modified_string=Veränderter_String
+Modified\ string=Veränderter String
 
 Modify=Bearbeiten
 
-modify_group=Gruppe_bearbeiten
+modify\ group=Gruppe bearbeiten
 
-Move_down=Nach_unten
+Move\ down=Nach unten
 
-Move_external_links_to_'file'_field=Externe_Links_in_das_Feld_'file'_verschieben
+Move\ external\ links\ to\ 'file'\ field=Externe Links in das Feld 'file' verschieben
 
-move_group=Gruppe_verschieben
+move\ group=Gruppe verschieben
 
-Move_up=Nach_oben
+Move\ up=Nach oben
 
-Moved_group_"%0".=Gruppe_"%0"_verschoben.
+Moved\ group\ "%0".=Gruppe "%0" verschoben.
 
 Name=Name
-Name_formatter=Namens-Formatierer
+Name\ formatter=Namens-Formatierer
 
-Natbib_style=Natbib-Stil
+Natbib\ style=Natbib-Stil
 
-nested_AUX_files=referenzierte_AUX_Dateien
+nested\ AUX\ files=referenzierte AUX Dateien
 
 New=Neu
 
 new=neu
 
-New_BibTeX_entry=Neuer_BibTeX-Eintrag
+New\ BibTeX\ entry=Neuer BibTeX-Eintrag
 
-New_BibTeX_sublibrary=Neue_BibTeX-Teilbibliothek
+New\ BibTeX\ sublibrary=Neue BibTeX-Teilbibliothek
 
-New_content=Neuer_Inhalt
+New\ content=Neuer Inhalt
 
-New_library_created.=Neue_Bibliothek_angelegt.
-New_%0_library=Neue_%0_Bibliothek
-New_field_value=Neuer_Feldwert
+New\ library\ created.=Neue Bibliothek angelegt.
+New\ %0\ library=Neue %0 Bibliothek
+New\ field\ value=Neuer Feldwert
 
-New_group=Neue_Gruppe
+New\ group=Neue Gruppe
 
-New_string=Neuer_String
+New\ string=Neuer String
 
-Next_entry=Nächster_Eintrag
+Next\ entry=Nächster Eintrag
 
-No_actual_changes_found.=Keine_aktuellen_Änderungen_gefunden.
+No\ actual\ changes\ found.=Keine aktuellen Änderungen gefunden.
 
-no_base-BibTeX-file_specified=keine_BibTeX-Datei_angegeben
+no\ base-BibTeX-file\ specified=keine BibTeX-Datei angegeben
 
-no_library_generated=keine_Bibliothek_erstellt_und_geschrieben
+no\ library\ generated=keine Bibliothek erstellt und geschrieben
 
-No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.=Keine_Einträge_gefunden._Bitte_vergewissern_Sie_sich,_dass_Sie_den_richtigen_Importfilter_benutzen.
+No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=Keine Einträge gefunden. Bitte vergewissern Sie sich, dass Sie den richtigen Importfilter benutzen.
 
 
-No_entries_found_for_the_search_string_'%0'=Für_den_Suchausdruck_'%0'_wurden_keine_Einträge_gefunden
+No\ entries\ found\ for\ the\ search\ string\ '%0'=Für den Suchausdruck '%0' wurden keine Einträge gefunden
 
-No_entries_imported.=Keine_Einträge_importiert.
+No\ entries\ imported.=Keine Einträge importiert.
 
-No_files_found.=Keine_Dateien_gefunden.
+No\ files\ found.=Keine Dateien gefunden.
 
-No_GUI._Only_process_command_line_options.=Kein_GUI._Nur_Kommandozeilenbefehle_ausführen.
+No\ GUI.\ Only\ process\ command\ line\ options.=Kein GUI. Nur Kommandozeilenbefehle ausführen.
 
-No_journal_names_could_be_abbreviated.=Es_konnten_keine_Zeitschriftentitel_abgekürzt_werden.
+No\ journal\ names\ could\ be\ abbreviated.=Es konnten keine Zeitschriftentitel abgekürzt werden.
 
-No_journal_names_could_be_unabbreviated.=Das_Aufheben_der_Abkürzung_konnte_bei_keiner_Zeitschrift_durchgeführt_werden.
-No_PDF_linked=Kein_PDF_verlinkt
+No\ journal\ names\ could\ be\ unabbreviated.=Das Aufheben der Abkürzung konnte bei keiner Zeitschrift durchgeführt werden.
+No\ PDF\ linked=Kein PDF verlinkt
 
-Open_PDF=PDF_öffnen
+Open\ PDF=PDF öffnen
 
-No_URL_defined=Keine_URL_angegeben
+No\ URL\ defined=Keine URL angegeben
 not=nicht
 
-not_found=davon_nicht_gefunden
+not\ found=davon nicht gefunden
 
-Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,=Es_muss_der_volle_Klassenname_für_das_zu_verwendende_"look_and_feel"_angegeben_werden.
+Note\ that\ you\ must\ specify\ the\ fully\ qualified\ class\ name\ for\ the\ look\ and\ feel,=Es muss der volle Klassenname für das zu verwendende "look and feel" angegeben werden.
 
-Nothing_to_redo=Wiederholen_nicht_möglich
+Nothing\ to\ redo=Wiederholen nicht möglich
 
-Nothing_to_undo=Rückgängig_nicht_möglich
+Nothing\ to\ undo=Rückgängig nicht möglich
 
 occurrences=Vorkommen
 
 OK=OK
-One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Mindestens_ein_Dateilink_ist_vom_Typ_'%0',_der_nicht_definiert_ist._Was_wollen_Sie_tun?
+One\ or\ more\ file\ links\ are\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Mindestens ein Dateilink ist vom Typ '%0', der nicht definiert ist. Was wollen Sie tun?
 
-One_or_more_keys_will_be_overwritten._Continue?=Einer_oder_mehrere_Keys_werden_überschrieben._Fortsetzen?
+One\ or\ more\ keys\ will\ be\ overwritten.\ Continue?=Einer oder mehrere Keys werden überschrieben. Fortsetzen?
 
 
 Open=Öffnen
 
-Open_BibTeX_library=BibTeX-Bibliothek_öffnen
+Open\ BibTeX\ library=BibTeX-Bibliothek öffnen
 
-Open_library=Bibliothek_öffnen
+Open\ library=Bibliothek öffnen
 
-Open_editor_when_a_new_entry_is_created=Eintragseditor_öffnen,_wenn_ein_neuer_Eintrag_angelegt_wird
+Open\ editor\ when\ a\ new\ entry\ is\ created=Eintragseditor öffnen, wenn ein neuer Eintrag angelegt wird
 
-Open_file=Datei_öffnen
+Open\ file=Datei öffnen
 
-Open_last_edited_libraries_at_startup=Beim_Starten_von_JabRef_die_letzten_bearbeiteten_Bibliotheken_öffnen
+Open\ last\ edited\ libraries\ at\ startup=Beim Starten von JabRef die letzten bearbeiteten Bibliotheken öffnen
 
-Connect_to_shared_database=Geteilte_Bibliothek_öffnen
+Connect\ to\ shared\ database=Geteilte Bibliothek öffnen
 
-Open_terminal_here=Konsole_hier_öffnen
+Open\ terminal\ here=Konsole hier öffnen
 
-Open_URL_or_DOI=URL_oder_DOI_öffnen
+Open\ URL\ or\ DOI=URL oder DOI öffnen
 
-Opened_library=Bibliothek_geöffnet
+Opened\ library=Bibliothek geöffnet
 
 Opening=Öffne
 
-Opening_preferences...=Öffne_Voreinstellungen...
+Opening\ preferences...=Öffne Voreinstellungen...
 
-Operation_canceled.=Vorgang_abgebrochen.
-Operation_not_supported=Vorgang_nicht_unterstützt
+Operation\ canceled.=Vorgang abgebrochen.
+Operation\ not\ supported=Vorgang nicht unterstützt
 
-Optional_fields=Optionale_Felder
+Optional\ fields=Optionale Felder
 
 Options=Optionen
 
 or=oder
 
-Output_or_export_file=Speichere_oder_exportiere_Datei
+Output\ or\ export\ file=Speichere oder exportiere Datei
 
 Override=überschreiben
 
-Override_default_file_directories=Standard-Verzeichnisse_überschreiben
+Override\ default\ file\ directories=Standard-Verzeichnisse überschreiben
 
-Override_default_font_settings=Standardschrifteinstellungen_überschreiben
+Override\ default\ font\ settings=Standardschrifteinstellungen überschreiben
 
-Override_the_BibTeX_field_by_the_selected_text=BibTeX-Key_mit_ausgewähltem_Text_überschreiben
+Override\ the\ BibTeX\ field\ by\ the\ selected\ text=BibTeX-Key mit ausgewähltem Text überschreiben
 
 
 Overwrite=Überschreiben
-Overwrite_existing_field_values=Bestehende_Feldwerte_überschreiben
+Overwrite\ existing\ field\ values=Bestehende Feldwerte überschreiben
 
-Overwrite_keys=Keys_überschreiben
+Overwrite\ keys=Keys überschreiben
 
-pairs_processed=Paare_überarbeitet
+pairs\ processed=Paare überarbeitet
 Password=Passwort
 
 Paste=Einfügen
 
-paste_entries=Einträge_einfügen
+paste\ entries=Einträge einfügen
 
-paste_entry=Eintrag_einfügen
-Paste_from_clipboard=Aus_der_Zwischenablage_einfügen
+paste\ entry=Eintrag einfügen
+Paste\ from\ clipboard=Aus der Zwischenablage einfügen
 
 Pasted=Eingefügt
 
-Path_to_%0_not_defined=Pfad_zu_%0_nicht_definiert
+Path\ to\ %0\ not\ defined=Pfad zu %0 nicht definiert
 
-Path_to_LyX_pipe=Pfad_zur_LyX-pipe
+Path\ to\ LyX\ pipe=Pfad zur LyX-pipe
 
-PDF_does_not_exist=PDF_existiert_nicht
+PDF\ does\ not\ exist=PDF existiert nicht
 
-File_has_no_attached_annotations=Datei_hat_keine_angefügten_Annotationen
+File\ has\ no\ attached\ annotations=Datei hat keine angefügten Annotationen
 
-Plain_text_import=Klartext_importieren
+Plain\ text\ import=Klartext importieren
 
-Please_enter_a_name_for_the_group.=Bitte_geben_Sie_einen_Namen_für_die_Gruppe_ein.
+Please\ enter\ a\ name\ for\ the\ group.=Bitte geben Sie einen Namen für die Gruppe ein.
 
-Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>=Bitte_geben_Sie_einen_Suchausdruck_ein._Um_zum_Beispiel_alle_Felder_nach_<b>Smith</b>_zu_durchsuchen,_geben_Sie_ein\:<p><tt>smith</tt><p>Um_das_Feld_<b>Author</b>_nach_<b>Smith</b>_und_das_Feld_<b>Title</b>_nach_<b>electrical</b>_zu_durchsuchen,_geben_Sie_ein\:<p><tt>author\=smith_and_title\=electrical</tt>
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Bitte geben Sie einen Suchausdruck ein. Um zum Beispiel alle Felder nach <b>Smith</b> zu durchsuchen, geben Sie ein:<p><tt>smith</tt><p>Um das Feld <b>Author</b> nach <b>Smith</b> und das Feld <b>Title</b> nach <b>electrical</b> zu durchsuchen, geben Sie ein:<p><tt>author=smith and title=electrical</tt>
 
-Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=Bitte_geben_Sie_das_zu_durchsuchende_Feld_(z.B._<b>keywords</b>)_und_das_darin_zu_suchende_Stichwort_(z.B._<b>elektrisch</b>)_ein.
+Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=Bitte geben Sie das zu durchsuchende Feld (z.B. <b>keywords</b>) und das darin zu suchende Stichwort (z.B. <b>elektrisch</b>) ein.
 
-Please_enter_the_string's_label=Geben_Sie_bitte_den_Namen_des_Strings_ein.
+Please\ enter\ the\ string's\ label=Geben Sie bitte den Namen des Strings ein.
 
-Please_select_an_importer.=Bitte_Importer_auswählen.
+Please\ select\ an\ importer.=Bitte Importer auswählen.
 
-Possible_duplicate_entries=Mögliche_doppelte_Einträge
+Possible\ duplicate\ entries=Mögliche doppelte Einträge
 
-Possible_duplicate_of_existing_entry._Click_to_resolve.=Möglicherweise_doppelter_Eintrag._Klicken_um_Konflikt_zu_lösen.
+Possible\ duplicate\ of\ existing\ entry.\ Click\ to\ resolve.=Möglicherweise doppelter Eintrag. Klicken um Konflikt zu lösen.
 
 Preamble=Präambel
 
 Preferences=Einstellungen
 
-Preferences_recorded.=Einstellungen_gespeichert.
+Preferences\ recorded.=Einstellungen gespeichert.
 
 Preview=Vorschau
-Citation_Style=Zitierstil
-Current_Preview=Aktuelle_Vorschau
-Cannot_generate_preview_based_on_selected_citation_style.=Vorschau_für_gewählten_Zitierstil_kann_nicht_generiert_werden.
-Bad_character_inside_entry=Eintrag_enthält_fehlerhaftes_Zeichen
-Error_while_generating_citation_style=Fehler_beim_Generieren_des_Zitierstils
-Preview_style_changed_to\:_%0=Vorschaustil_geändert_zu:_%0
-Next_preview_layout=Nächster_Vorschaustil
-Previous_preview_layout=Voriger_Vorschaustil
+Citation\ Style=Zitierstil
+Current\ Preview=Aktuelle Vorschau
+Cannot\ generate\ preview\ based\ on\ selected\ citation\ style.=Vorschau für gewählten Zitierstil kann nicht generiert werden.
+Bad\ character\ inside\ entry=Eintrag enthält fehlerhaftes Zeichen
+Error\ while\ generating\ citation\ style=Fehler beim Generieren des Zitierstils
+Preview\ style\ changed\ to\:\ %0=Vorschaustil geändert zu: %0
+Next\ preview\ layout=Nächster Vorschaustil
+Previous\ preview\ layout=Voriger Vorschaustil
 
-Previous_entry=Vorheriger_Eintrag
+Previous\ entry=Vorheriger Eintrag
 
-Primary_sort_criterion=Primäres_Sortierkriterium
-Problem_with_parsing_entry=Problem_beim_Analysieren_des_Eintrags
-Processing_%0=Bearbeite_%0
-Pull_changes_from_shared_database=Änderungen_der_geteilten_Datenbank_beziehen
+Primary\ sort\ criterion=Primäres Sortierkriterium
+Problem\ with\ parsing\ entry=Problem beim Analysieren des Eintrags
+Processing\ %0=Bearbeite %0
+Pull\ changes\ from\ shared\ database=Änderungen der geteilten Datenbank beziehen
 
-Pushed_citations_to_%0=Einträge_in_%0_eingefügt
+Pushed\ citations\ to\ %0=Einträge in %0 eingefügt
 
-Quit_JabRef=JabRef_beenden
+Quit\ JabRef=JabRef beenden
 
-Quit_synchronization=Synchronisation_beenden
+Quit\ synchronization=Synchronisation beenden
 
-Raw_source=Importtext
+Raw\ source=Importtext
 
-Rearrange_tabs_alphabetically_by_title=Tabs_alphabetisch_nach_Titel_sortieren
+Rearrange\ tabs\ alphabetically\ by\ title=Tabs alphabetisch nach Titel sortieren
 
 Redo=Wiederholen
 
-Reference_library=Referenz-Bibliothek
+Reference\ library=Referenz-Bibliothek
 
-%0_references_found._Number_of_references_to_fetch?=%0_Literaturangaben_gefunden._Anzahl_der_abzurufenden_Literaturangaben?
+%0\ references\ found.\ Number\ of\ references\ to\ fetch?=%0 Literaturangaben gefunden. Anzahl der abzurufenden Literaturangaben?
 
-Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Obergruppe_einbeziehen\:_Einträge_aus_dieser_Gruppe_und_ihrer_übergeordneten_Gruppe_anzeigen
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=Obergruppe einbeziehen: Einträge aus dieser Gruppe und ihrer übergeordneten Gruppe anzeigen
 
-regular_expression=Regulärer_Ausdruck
+regular\ expression=Regulärer Ausdruck
 
-Related_articles=ähnliche_Dokumente
+Related\ articles=ähnliche Dokumente
 
-Remote_operation=Externer_Zugriff
+Remote\ operation=Externer Zugriff
 
-Remote_server_port=Externer_Server-Port
+Remote\ server\ port=Externer Server-Port
 
 Remove=Löschen
 
-Remove_subgroups=Untergruppen_entfernen
+Remove\ subgroups=Untergruppen entfernen
 
-Remove_all_subgroups_of_"%0"?=Alle_Untergruppen_von_"%0"_entfernen?
+Remove\ all\ subgroups\ of\ "%0"?=Alle Untergruppen von "%0" entfernen?
 
-Remove_entry_from_import=Eintrag_von_Importierung_entfernen
+Remove\ entry\ from\ import=Eintrag von Importierung entfernen
 
-Remove_selected_entries_from_this_group=Ausgewählte_Einträge_aus_dieser_Gruppe_löschen
+Remove\ selected\ entries\ from\ this\ group=Ausgewählte Einträge aus dieser Gruppe löschen
 
-Remove_entry_type=Eintragstyp_löschen
+Remove\ entry\ type=Eintragstyp löschen
 
-Remove_from_group=Aus_Gruppe_entfernen
+Remove\ from\ group=Aus Gruppe entfernen
 
-Remove_group=Gruppe_löschen
+Remove\ group=Gruppe löschen
 
-Remove_group,_keep_subgroups=Gruppe_löschen,_Untergruppen_behalten
+Remove\ group,\ keep\ subgroups=Gruppe löschen, Untergruppen behalten
 
-Remove_group_"%0"?=Gruppe_"%0"_löschen?
+Remove\ group\ "%0"?=Gruppe "%0" löschen?
 
-Remove_group_"%0"_and_its_subgroups?=Gruppe_"%0"_inklusive_Untergruppen_löschen?
+Remove\ group\ "%0"\ and\ its\ subgroups?=Gruppe "%0" inklusive Untergruppen löschen?
 
-remove_group_(keep_subgroups)=Gruppe_löschen_(Untergruppen_behalten)
+remove\ group\ (keep\ subgroups)=Gruppe löschen (Untergruppen behalten)
 
-remove_group_and_subgroups=Gruppe_inklusive_Untergruppen_löschen
+remove\ group\ and\ subgroups=Gruppe inklusive Untergruppen löschen
 
-Remove_group_and_subgroups=Gruppe_und_Untergruppen_löschen
+Remove\ group\ and\ subgroups=Gruppe und Untergruppen löschen
 
-Remove_link=Link_löschen
+Remove\ link=Link löschen
 
-Remove_old_entry=Alten_Eintrag_entfernen
+Remove\ old\ entry=Alten Eintrag entfernen
 
-Remove_selected_strings=Ausgewählte_Strings_entfernen
+Remove\ selected\ strings=Ausgewählte Strings entfernen
 
-Removed_group_"%0".=Gruppe_"%0"_gelöscht.
+Removed\ group\ "%0".=Gruppe "%0" gelöscht.
 
-Removed_group_"%0"_and_its_subgroups.=Gruppe_"%0"_inklusive_Untergruppen_gelöscht.
+Removed\ group\ "%0"\ and\ its\ subgroups.=Gruppe "%0" inklusive Untergruppen gelöscht.
 
-Removed_string=String_gelöscht
+Removed\ string=String gelöscht
 
-Renamed_string=String_umbenannt
+Renamed\ string=String umbenannt
 
 Replace=Ersetzen
 
-Replace_(regular_expression)=Ersetzen_(regulärer_Ausdruck)
+Replace\ (regular\ expression)=Ersetzen (regulärer Ausdruck)
 
-Replace_string=String_ersetzen
+Replace\ string=String ersetzen
 
-Replace_with=Ersetzen_durch
+Replace\ with=Ersetzen durch
 
-Replaced=Ersetzt\:
+Replaced=Ersetzt:
 
-Required_fields=Benötigte_Felder
+Required\ fields=Benötigte Felder
 
-Reset_all=Alle_zurücksetzen
+Reset\ all=Alle zurücksetzen
 
-Resolve_strings_for_all_fields_except=Strings_auflösen_für_alle_Felder_außer
-Resolve_strings_for_standard_BibTeX_fields_only=Strings_nur_für_Standard-BibTeX-Felder_auflösen
+Resolve\ strings\ for\ all\ fields\ except=Strings auflösen für alle Felder außer
+Resolve\ strings\ for\ standard\ BibTeX\ fields\ only=Strings nur für Standard-BibTeX-Felder auflösen
 
-resolved=davon_aufgelöst
+resolved=davon aufgelöst
 
 Review=Überprüfung
 
-Review_changes=Änderungen_überprüfen
+Review\ changes=Änderungen überprüfen
 
 Right=Rechts
 
 Save=Speichern
-Save_all_finished.=Speichern_aller_Dateien_beendet
+Save\ all\ finished.=Speichern aller Dateien beendet
 
-Save_all_open_libraries=Alle_geöffneten_Bibliotheken_speichern
+Save\ all\ open\ libraries=Alle geöffneten Bibliotheken speichern
 
-Save_before_closing=Speichern_vor_dem_Beenden
+Save\ before\ closing=Speichern vor dem Beenden
 
-Save_library=Bibliothek_speichern
-Save_library_as...=Bibliothek_speichern_unter_...
+Save\ library=Bibliothek speichern
+Save\ library\ as...=Bibliothek speichern unter ...
 
-Save_entries_in_their_original_order=Einträge_in_ursprünglicher_Reihenfolge_abspeichern
+Save\ entries\ in\ their\ original\ order=Einträge in ursprünglicher Reihenfolge abspeichern
 
-Save_failed=Fehler_beim_Speichern
+Save\ failed=Fehler beim Speichern
 
-Save_failed_during_backup_creation=Während_der_Erstellung_des_Backups_ist_das_Speichern_fehlgeschlagen
+Save\ failed\ during\ backup\ creation=Während der Erstellung des Backups ist das Speichern fehlgeschlagen
 
-Save_selected_as...=Auswahl_speichern_unter_...
+Save\ selected\ as...=Auswahl speichern unter ...
 
-Saved_library=Bibliothek_gespeichert
+Saved\ library=Bibliothek gespeichert
 
-Saved_selected_to_'%0'.=Auswahl_gespeichert_unter_'%0'.
+Saved\ selected\ to\ '%0'.=Auswahl gespeichert unter '%0'.
 
 Saving=Speichere
-Saving_all_libraries...=Alle_Bibliotheken_werden_gespeichert...
+Saving\ all\ libraries...=Alle Bibliotheken werden gespeichert...
 
-Saving_library=Speichere_Bibliothek
+Saving\ library=Speichere Bibliothek
 
 Search=Suchen
 
-Search_expression=Suchausdruck
+Search\ expression=Suchausdruck
 
-Search_for=Suchen_nach
+Search\ for=Suchen nach
 
-Searching_for_duplicates...=Suche_nach_doppelten_Einträgen...
+Searching\ for\ duplicates...=Suche nach doppelten Einträgen...
 
-Searching_for_files=Suche_nach_Dateien
+Searching\ for\ files=Suche nach Dateien
 
-Secondary_sort_criterion=Zweites_Sortierkriterium
+Secondary\ sort\ criterion=Zweites Sortierkriterium
 
-Select_all=Alle_auswählen
+Select\ all=Alle auswählen
 
-Select_encoding=Kodierung_wählen
+Select\ encoding=Kodierung wählen
 
-Select_entry_type=Eintragstyp_auswählen
-Select_external_application=Externe_Anwendung_auswählen
+Select\ entry\ type=Eintragstyp auswählen
+Select\ external\ application=Externe Anwendung auswählen
 
-Select_file_from_ZIP-archive=Eintrag_aus_der_ZIP-Archiv_auswählen
+Select\ file\ from\ ZIP-archive=Eintrag aus der ZIP-Archiv auswählen
 
-Select_the_tree_nodes_to_view_and_accept_or_reject_changes=Wählen_Sie_die_Verzweigungen_aus,_um_die_Änderungen_zu_sehen_und_anzunehmen_oder_zu_verwerfen
-Selected_entries=Ausgewählte_Einträge
-Set_field=Setze_Feld
-Set_fields=Felder_setzen
+Select\ the\ tree\ nodes\ to\ view\ and\ accept\ or\ reject\ changes=Wählen Sie die Verzweigungen aus, um die Änderungen zu sehen und anzunehmen oder zu verwerfen
+Selected\ entries=Ausgewählte Einträge
+Set\ field=Setze Feld
+Set\ fields=Felder setzen
 
-Set_general_fields=Allgemeine_Felder_festlegen
-Set_main_external_file_directory=Standard-Verzeichnis_für_externe_Dateien_bestimmen
+Set\ general\ fields=Allgemeine Felder festlegen
+Set\ main\ external\ file\ directory=Standard-Verzeichnis für externe Dateien bestimmen
 
-Set_table_font=Tabellenschriftart_auswählen
+Set\ table\ font=Tabellenschriftart auswählen
 
 Settings=Einstellungen
 
 Shortcut=Tastenkürzel
 
-Show/edit_%0_source=%0-Quelltext_anzeigen/editieren
+Show/edit\ %0\ source=%0-Quelltext anzeigen/editieren
 
-Show_'Firstname_Lastname'='Vorname_Nachname'_anzeigen
+Show\ 'Firstname\ Lastname'='Vorname Nachname' anzeigen
 
-Show_'Lastname,_Firstname'='Nachname,_Vorname'_anzeigen
+Show\ 'Lastname,\ Firstname'='Nachname, Vorname' anzeigen
 
-Show_BibTeX_source_by_default=Quelltextpanel_standardmäßig_anzeigen
+Show\ BibTeX\ source\ by\ default=Quelltextpanel standardmäßig anzeigen
 
-Show_confirmation_dialog_when_deleting_entries=Dialog_zum_Löschen_von_Einträgen_anzeigen
+Show\ confirmation\ dialog\ when\ deleting\ entries=Dialog zum Löschen von Einträgen anzeigen
 
-Show_description=Beschreibung_anzeigen
+Show\ description=Beschreibung anzeigen
 
-Show_file_column=Datei-Spalte_anzeigen
+Show\ file\ column=Datei-Spalte anzeigen
 
-Show_last_names_only=Zeige_nur_Nachnamen
+Show\ last\ names\ only=Zeige nur Nachnamen
 
-Show_names_unchanged=Namen_unverändert_anzeigen
+Show\ names\ unchanged=Namen unverändert anzeigen
 
-Show_optional_fields=Optionale_Felder_anzeigen
+Show\ optional\ fields=Optionale Felder anzeigen
 
-Show_required_fields=Benötigte_Felder_anzeigen
+Show\ required\ fields=Benötigte Felder anzeigen
 
-Show_URL/DOI_column=URL/DOI-Spalte_anzeigen
+Show\ URL/DOI\ column=URL/DOI-Spalte anzeigen
 
-Simple_HTML=Einfaches_HTML
+Simple\ HTML=Einfaches HTML
 
 Size=Größe
 
-Skipped_-_No_PDF_linked=Übersprungen_-_Kein_PDF_verlinkt
-Skipped_-_PDF_does_not_exist=Übersprungen_-_PDF_exisitert_nicht
+Skipped\ -\ No\ PDF\ linked=Übersprungen - Kein PDF verlinkt
+Skipped\ -\ PDF\ does\ not\ exist=Übersprungen - PDF exisitert nicht
 
-Skipped_entry.=Eintrag_übersprungen.
+Skipped\ entry.=Eintrag übersprungen.
 
-Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.=Einige_Änderungen_am_Erscheinungsbild_benötigen_einen_Neustart_von_JabRef.
+Some\ appearance\ settings\ you\ changed\ require\ to\ restart\ JabRef\ to\ come\ into\ effect.=Einige Änderungen am Erscheinungsbild benötigen einen Neustart von JabRef.
 
-source_edit=Quelltextbearbeitung
-Special_name_formatters=Spezielle_Namens-Formatierer
+source\ edit=Quelltextbearbeitung
+Special\ name\ formatters=Spezielle Namens-Formatierer
 
-Special_table_columns=Spezielle_Spalten
+Special\ table\ columns=Spezielle Spalten
 
-Starting_import=Starte_Import
+Starting\ import=Starte Import
 
-Statically_group_entries_by_manual_assignment=Statisches_Gruppieren_der_Einträge_durch_manuelle_Zuweisung
+Statically\ group\ entries\ by\ manual\ assignment=Statisches Gruppieren der Einträge durch manuelle Zuweisung
 
 Status=Status
 
@@ -1143,1019 +1143,1019 @@ Stop=Stop
 
 Strings=Ersetzen
 
-Strings_for_library=Strings_für_die_Bibliothek
+Strings\ for\ library=Strings für die Bibliothek
 
-Sublibrary_from_AUX=Teilbibliothek_aus_AUX-Datei
+Sublibrary\ from\ AUX=Teilbibliothek aus AUX-Datei
 
-Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.=Wechselt_zwischen_vollem_und_abgekürztem_Zeitschriftentitel_falls_bekannt.
+Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=Wechselt zwischen vollem und abgekürztem Zeitschriftentitel falls bekannt.
 
-Synchronize_file_links=Links_zu_Dateien_synchronisieren
+Synchronize\ file\ links=Links zu Dateien synchronisieren
 
-Synchronizing_file_links...=Synchronisiere_Datei-Links...
+Synchronizing\ file\ links...=Synchronisiere Datei-Links...
 
-Table_appearance=Erscheinungsbild_der_Tabelle
+Table\ appearance=Erscheinungsbild der Tabelle
 
-Table_background_color=Hintergrundfarbe_der_Tabelle
+Table\ background\ color=Hintergrundfarbe der Tabelle
 
-Table_grid_color=Farbe_des_Tabellenrasters
+Table\ grid\ color=Farbe des Tabellenrasters
 
-Table_text_color=Textfarbe_der_Tabelle
+Table\ text\ color=Textfarbe der Tabelle
 
 Tabname=Tab-Name
-Target_file_cannot_be_a_directory.=Die_Zieldatei_darf_kein_Verzeichnis_sein.
+Target\ file\ cannot\ be\ a\ directory.=Die Zieldatei darf kein Verzeichnis sein.
 
-Tertiary_sort_criterion=Drittes_Sortierkriterium
+Tertiary\ sort\ criterion=Drittes Sortierkriterium
 
 Test=Test
 
-paste_text_here=Text_einfügen
+paste\ text\ here=Text einfügen
 
-The_chosen_date_format_for_new_entries_is_not_valid=Das_Datumsformat_für_neue_Einträge_ist_nicht_gültig
+The\ chosen\ date\ format\ for\ new\ entries\ is\ not\ valid=Das Datumsformat für neue Einträge ist nicht gültig
 
-The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:=Die_gewählte_Kodierung_'%0'_konnte_folgende_Buchstaben_nicht_darstellen\:
+The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=Die gewählte Kodierung '%0' konnte folgende Buchstaben nicht darstellen:
 
 
-the_field_<b>%0</b>=das_Feld_<b>%0</b>
+the\ field\ <b>%0</b>=das Feld <b>%0</b>
 
-The_file<BR>'%0'<BR>has_been_modified<BR>externally\!=Die_Datei<BR>_'%0'_<BR>wurde_von_einem_externen_Programm_verändert\!
+The\ file<BR>'%0'<BR>has\ been\ modified<BR>externally\!=Die Datei<BR> '%0' <BR>wurde von einem externen Programm verändert!
 
-The_group_"%0"_already_contains_the_selection.=Die_Gruppe_"%0"_enthält_bereits_diese_Auswahl.
+The\ group\ "%0"\ already\ contains\ the\ selection.=Die Gruppe "%0" enthält bereits diese Auswahl.
 
-The_label_of_the_string_cannot_be_a_number.=Der_Name_des_Strings_darf_keine_Zahl_sein.
+The\ label\ of\ the\ string\ cannot\ be\ a\ number.=Der Name des Strings darf keine Zahl sein.
 
-The_label_of_the_string_cannot_contain_spaces.=Der_Name_des_Strings_darf_keine_Leerzeichen_enthalten.
+The\ label\ of\ the\ string\ cannot\ contain\ spaces.=Der Name des Strings darf keine Leerzeichen enthalten.
 
-The_label_of_the_string_cannot_contain_the_'\#'_character.=Der_Name_des_Strings_darf_nicht_das_Zeichen_'\#'_enthalten.
+The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=Der Name des Strings darf nicht das Zeichen '#' enthalten.
 
-The_output_option_depends_on_a_valid_import_option.=Die_Ausgabe-Option_beruht_auf_einer_gültigen_Import-Option.
-The_PDF_contains_one_or_several_BibTeX-records.=Die_PDF-Datei_enthält_mindestens_einen_BibTeX-Datensatz.
-Do_you_want_to_import_these_as_new_entries_into_the_current_library?=Wollen_Sie_diese(n)_als_neue_Einträge_in_die_aktuelle_Bibliothek_importieren?
+The\ output\ option\ depends\ on\ a\ valid\ import\ option.=Die Ausgabe-Option beruht auf einer gültigen Import-Option.
+The\ PDF\ contains\ one\ or\ several\ BibTeX-records.=Die PDF-Datei enthält mindestens einen BibTeX-Datensatz.
+Do\ you\ want\ to\ import\ these\ as\ new\ entries\ into\ the\ current\ library?=Wollen Sie diese(n) als neue Einträge in die aktuelle Bibliothek importieren?
 
-The_regular_expression_<b>%0</b>_is_invalid\:=Der_reguläre_Ausdruck_<b>%0</b>_ist_ungültig\:
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=Der reguläre Ausdruck <b>%0</b> ist ungültig:
 
-The_search_is_case_insensitive.=Groß-/Kleinschreibung_wird_nicht_unterschieden.
+The\ search\ is\ case\ insensitive.=Groß-/Kleinschreibung wird nicht unterschieden.
 
-The_search_is_case_sensitive.=Groß-/Kleinschreibung_wird_unterschieden.
+The\ search\ is\ case\ sensitive.=Groß-/Kleinschreibung wird unterschieden.
 
-The_string_has_been_removed_locally=Der_String_wurde_lokal_entfernt
+The\ string\ has\ been\ removed\ locally=Der String wurde lokal entfernt
 
-There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?=Es_gibt_mögliche_Duplikate_(markiert_mit_einem_Icon),_die_nicht_geklärt_werden_konnten._Fortfahren?
+There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=Es gibt mögliche Duplikate (markiert mit einem Icon), die nicht geklärt werden konnten. Fortfahren?
 
-This_entry_has_no_BibTeX_key._Generate_key_now?=Dieser_Eintrag_hat_keinen_BibTeX-Key._Soll_jetzt_einer_erstellt_werden?
+This\ entry\ has\ no\ BibTeX\ key.\ Generate\ key\ now?=Dieser Eintrag hat keinen BibTeX-Key. Soll jetzt einer erstellt werden?
 
-This_entry_is_incomplete=Dieser_Eintrag_ist_unvollständig
+This\ entry\ is\ incomplete=Dieser Eintrag ist unvollständig
 
-This_entry_type_cannot_be_removed.=Dieser_Eintragstyp_kann_nicht_entfernt_werden.
+This\ entry\ type\ cannot\ be\ removed.=Dieser Eintragstyp kann nicht entfernt werden.
 
-This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Dies_ist_ein_externer_Link_des_Typs_'%0',_der_nicht_definiert_ist._Was_wollen_Sie_tun?
+This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Dies ist ein externer Link des Typs '%0', der nicht definiert ist. Was wollen Sie tun?
 
-This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.=Diese_Gruppe_enthält_manuell_zugewiesene_Einträge._Einträge_können_dieser_Gruppe_zugewiesen_werden,_indem_Sie_sie_selektieren_und_dann_entweder_Drag&Drop_oder_das_Kontextmenü_benutzen._Einträge_können_aus_dieser_Gruppe_entfernt_werden,_indem_Sie_sie_selektieren_und_dann_das_Kontextmenü_benutzen.
+This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=Diese Gruppe enthält manuell zugewiesene Einträge. Einträge können dieser Gruppe zugewiesen werden, indem Sie sie selektieren und dann entweder Drag&Drop oder das Kontextmenü benutzen. Einträge können aus dieser Gruppe entfernt werden, indem Sie sie selektieren und dann das Kontextmenü benutzen.
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>=Diese_Gruppe_enthält_Eintrage,_deren_Feld_<b>%0</b>_das_Stichwort_<b>%1</b>_enthält
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Diese Gruppe enthält Eintrage, deren Feld <b>%0</b> das Stichwort <b>%1</b> enthält
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>=Diese_Gruppe_enthält_Eintrage,_deren_Feld_<b>%0</b>_den_regulären_Ausdruck_<b>%1</b>_enthält
-This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.=JabRef_untersucht_damit_jeden_Datei-Link_und_überprüft,_ob_die_Datei_existiert._Falls_nicht,_werden_Ihnen_Optionen_gegeben,<BR>um_das_Problem_zu_lösen.
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Diese Gruppe enthält Eintrage, deren Feld <b>%0</b> den regulären Ausdruck <b>%1</b> enthält
+This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=JabRef untersucht damit jeden Datei-Link und überprüft, ob die Datei existiert. Falls nicht, werden Ihnen Optionen gegeben,<BR>um das Problem zu lösen.
 
-This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.=Für_diesen_Vorgang_müssen_alle_ausgewählen_Einträge_einen_BibTeX-Key_haben.
+This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=Für diesen Vorgang müssen alle ausgewählen Einträge einen BibTeX-Key haben.
 
-This_operation_requires_one_or_more_entries_to_be_selected.=Für_diesen_Vorgang_muss_mindestens_ein_Eintrag_ausgewählt_sein.
+This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=Für diesen Vorgang muss mindestens ein Eintrag ausgewählt sein.
 
-Toggle_entry_preview=Eintragsvorschau_ein-/ausblenden
-Toggle_groups_interface=Gruppenansicht_ein-/ausblenden
-Try_different_encoding=Versuchen_Sie_es_mit_einer_anderen_Kodierung
+Toggle\ entry\ preview=Eintragsvorschau ein-/ausblenden
+Toggle\ groups\ interface=Gruppenansicht ein-/ausblenden
+Try\ different\ encoding=Versuchen Sie es mit einer anderen Kodierung
 
-Unabbreviate_journal_names_of_the_selected_entries=Abkürzung_der_Zeitschriftentitel_der_ausgewählten_Einträge_aufheben
-Unabbreviated_%0_journal_names.=Bei_%0_Zeitschriftentiteln_wurde_die_Abkürzung_aufgehoben.
+Unabbreviate\ journal\ names\ of\ the\ selected\ entries=Abkürzung der Zeitschriftentitel der ausgewählten Einträge aufheben
+Unabbreviated\ %0\ journal\ names.=Bei %0 Zeitschriftentiteln wurde die Abkürzung aufgehoben.
 
-Unable_to_open_file.=Datei_kann_nicht_geöffnet_werden.
-Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.=Öffnen_des_Links_nicht_möglich._Die_Anwendung_'%0',_die_dem_Dateityp_'%1'_zugeordnet_ist,_konnte_nicht_aufgerufen_werden.
-unable_to_write_to=konnte_nicht_speichern_auf
-Undefined_file_type=Unbekannter_Dateityp
+Unable\ to\ open\ file.=Datei kann nicht geöffnet werden.
+Unable\ to\ open\ link.\ The\ application\ '%0'\ associated\ with\ the\ file\ type\ '%1'\ could\ not\ be\ called.=Öffnen des Links nicht möglich. Die Anwendung '%0', die dem Dateityp '%1' zugeordnet ist, konnte nicht aufgerufen werden.
+unable\ to\ write\ to=konnte nicht speichern auf
+Undefined\ file\ type=Unbekannter Dateityp
 
 Undo=Rückgängig
 
 Union=Vereinigung
 
-Unknown_BibTeX_entries=Unbekannte_BibTeX_Einträge
+Unknown\ BibTeX\ entries=Unbekannte BibTeX Einträge
 
-unknown_edit=unbekannter_Bearbeitungsschritt
+unknown\ edit=unbekannter Bearbeitungsschritt
 
-Unknown_export_format=Unbekanntes_Export-Format
+Unknown\ export\ format=Unbekanntes Export-Format
 
-Unmark_all=Sämtliche_Markierungen_aufheben
+Unmark\ all=Sämtliche Markierungen aufheben
 
-Unmark_entries=Markierung_aufheben
+Unmark\ entries=Markierung aufheben
 
-Unmark_entry=Markierung_aufheben
+Unmark\ entry=Markierung aufheben
 
-untitled=ohne_Titel
+untitled=ohne Titel
 
 Up=Hoch
 
-Update_to_current_column_widths=Aktuelle_Spaltenbreiten_verwenden
+Update\ to\ current\ column\ widths=Aktuelle Spaltenbreiten verwenden
 
-Updated_group_selection=Gruppenauswahl_aktualisiert
-Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.=Externe_PDF/PS-Links_aktualisieren,_um_das_Feld_'%0'_zu_benutzen.
-Upgrade_file=Datei_aktualisiert
-Upgrade_old_external_file_links_to_use_the_new_feature=Alte_Links_zu_externen_Dateien_aktualisieren,_um_die_neue_Funktion_zu_nutzen
+Updated\ group\ selection=Gruppenauswahl aktualisiert
+Upgrade\ external\ PDF/PS\ links\ to\ use\ the\ '%0'\ field.=Externe PDF/PS-Links aktualisieren, um das Feld '%0' zu benutzen.
+Upgrade\ file=Datei aktualisiert
+Upgrade\ old\ external\ file\ links\ to\ use\ the\ new\ feature=Alte Links zu externen Dateien aktualisieren, um die neue Funktion zu nutzen
 
 usage=Benutzung
-Use_autocompletion_for_the_following_fields=Autovervollständigung_für_folgende_Felder_benutzen
+Use\ autocompletion\ for\ the\ following\ fields=Autovervollständigung für folgende Felder benutzen
 
-Use_other_look_and_feel=anderes_"look_and_feel"_benutzen
-Tweak_font_rendering_for_entry_editor_on_Linux=Verbessertes_Schrift-Rendering_für_Linux
-Use_regular_expression_search=Suche_mit_regulärem_Ausdruck_benutzen
+Use\ other\ look\ and\ feel=anderes "look and feel" benutzen
+Tweak\ font\ rendering\ for\ entry\ editor\ on\ Linux=Verbessertes Schrift-Rendering für Linux
+Use\ regular\ expression\ search=Suche mit regulärem Ausdruck benutzen
 
 Username=Benutzername
 
-Value_cleared_externally=Wert_extern_gelöscht
+Value\ cleared\ externally=Wert extern gelöscht
 
-Value_set_externally=Wert_extern_gesetzt
+Value\ set\ externally=Wert extern gesetzt
 
-verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid=überprüfen_Sie,_ob_LyX_läuft_und_ob_die_Angaben_zur_lyxpipe_stimmen
+verify\ that\ LyX\ is\ running\ and\ that\ the\ lyxpipe\ is\ valid=überprüfen Sie, ob LyX läuft und ob die Angaben zur lyxpipe stimmen
 
 View=Ansicht
-Vim_server_name=Vim_Server-Name
+Vim\ server\ name=Vim Server-Name
 
-Waiting_for_ArXiv...=Warte_auf_ArXiv...
+Waiting\ for\ ArXiv...=Warte auf ArXiv...
 
-Warn_about_unresolved_duplicates_when_closing_inspection_window=Warnung_zu_ungeklärten_Duplikaten_ausgeben,_wenn_das_Kontrollfenster_geschlossen_wird
+Warn\ about\ unresolved\ duplicates\ when\ closing\ inspection\ window=Warnung zu ungeklärten Duplikaten ausgeben, wenn das Kontrollfenster geschlossen wird
 
-Warn_before_overwriting_existing_keys=Vor_dem_Überschreiben_von_existierenden_Keys_warnen
+Warn\ before\ overwriting\ existing\ keys=Vor dem Überschreiben von existierenden Keys warnen
 
 Warning=Warnung
 
 Warnings=Warnungen
 
-web_link=Web-Link
+web\ link=Web-Link
 
-What_do_you_want_to_do?=Was_möchten_Sie_tun?
+What\ do\ you\ want\ to\ do?=Was möchten Sie tun?
 
-When_adding/removing_keywords,_separate_them_by=Trennzeichen_zwischen_Stichwörtern_im_Gruppierungs-Feld
-Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.=Schreibe_XMP-Metadaten_in_die_PDFs,_die_mit_den_ausgewählten_Einträgen_verlinkt_sind.
+When\ adding/removing\ keywords,\ separate\ them\ by=Trennzeichen zwischen Stichwörtern im Gruppierungs-Feld
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Schreibe XMP-Metadaten in die PDFs, die mit den ausgewählten Einträgen verlinkt sind.
 
 with=mit
 
-Write_BibTeXEntry_as_XMP-metadata_to_PDF.=BibTeX-Eintrag_als_XMP-Metadaten_ins_PDF_schreiben.
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=BibTeX-Eintrag als XMP-Metadaten ins PDF schreiben.
 
-Write_XMP=XMP_schreiben
-Write_XMP-metadata=Schreibe_XMP-Metadaten
-Write_XMP-metadata_for_all_PDFs_in_current_library?=XMP-Metadaten_für_alle_PDFs_der_aktuellen_Bibliothek_schreiben?
-Writing_XMP-metadata...=XMP-Metadaten_werden_geschrieben...
-Writing_XMP-metadata_for_selected_entries...=XMP-Metadaten_für_ausgewählte_Einträge_werden_geschrieben...
+Write\ XMP=XMP schreiben
+Write\ XMP-metadata=Schreibe XMP-Metadaten
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=XMP-Metadaten für alle PDFs der aktuellen Bibliothek schreiben?
+Writing\ XMP-metadata...=XMP-Metadaten werden geschrieben...
+Writing\ XMP-metadata\ for\ selected\ entries...=XMP-Metadaten für ausgewählte Einträge werden geschrieben...
 
-Wrote_XMP-metadata=XMP-Metadaten_geschrieben
+Wrote\ XMP-metadata=XMP-Metadaten geschrieben
 
-XMP-annotated_PDF=PDF_mit_XMP-Anmerkungen
-XMP_export_privacy_settings=Sicherheitseinstellungen_für_den_XMP-Export
+XMP-annotated\ PDF=PDF mit XMP-Anmerkungen
+XMP\ export\ privacy\ settings=Sicherheitseinstellungen für den XMP-Export
 XMP-metadata=XMP-Metadaten
-XMP-metadata_found_in_PDF\:_%0=XMP-Metadaten_gefunden_im_PDF\:_%0
-You_must_restart_JabRef_for_this_to_come_into_effect.=Sie_müssen_JabRef_neu_starten,_damit_diese_Änderungen_in_Kraft_treten.
-You_have_changed_the_language_setting.=Sie_haben_die_Spracheinstellung_geändert.
-You_have_entered_an_invalid_search_'%0'.=Sie_haben_eine_ungültige_Suche_'%0'_eingegeben.
+XMP-metadata\ found\ in\ PDF\:\ %0=XMP-Metadaten gefunden im PDF: %0
+You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Sie müssen JabRef neu starten, damit diese Änderungen in Kraft treten.
+You\ have\ changed\ the\ language\ setting.=Sie haben die Spracheinstellung geändert.
+You\ have\ entered\ an\ invalid\ search\ '%0'.=Sie haben eine ungültige Suche '%0' eingegeben.
 
-You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.=Sie_müssen_JabRef_neu_starten,_damit_die_Tastenkürzel_funktionieren.
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Sie müssen JabRef neu starten, damit die Tastenkürzel funktionieren.
 
-Your_new_key_bindings_have_been_stored.=Ihre_neuen_Tastenkürzel_wurden_gespeichert.
+Your\ new\ key\ bindings\ have\ been\ stored.=Ihre neuen Tastenkürzel wurden gespeichert.
 
-The_following_fetchers_are_available\:=Folgende_Recherchetools_stehen_zur_Verfügung\:
-Could_not_find_fetcher_'%0'=Recherchetool_'%0'_konnte_nicht_gefunden_werden
-Running_query_'%0'_with_fetcher_'%1'.=Abfrage_'%0'_wird_mit_dem_Recherchetool_'%1'_durchgeführt.
-Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.=Die_Abfrage_'%0'_mit_dem_Recherchetool_'%1'_lieferte_keine_Ergebnisse.
+The\ following\ fetchers\ are\ available\:=Folgende Recherchetools stehen zur Verfügung:
+Could\ not\ find\ fetcher\ '%0'=Recherchetool '%0' konnte nicht gefunden werden
+Running\ query\ '%0'\ with\ fetcher\ '%1'.=Abfrage '%0' wird mit dem Recherchetool '%1' durchgeführt.
+Query\ '%0'\ with\ fetcher\ '%1'\ did\ not\ return\ any\ results.=Die Abfrage '%0' mit dem Recherchetool '%1' lieferte keine Ergebnisse.
 
-Move_file=Datei_verschoben
-Rename_file=Datei_umbenennen
+Move\ file=Datei verschoben
+Rename\ file=Datei umbenennen
 
-Move_file_failed=Fehler_beim_Verschieben_der_Datei
-Could_not_move_file_'%0'.=Datei_'%0'_konnte_nicht_verschoben_werden.
-Could_not_find_file_'%0'.=Datei_'%0'_nicht_gefunden.
-Number_of_entries_successfully_imported=Zahl_der_erfolgreich_importierten_Einträge
-Import_canceled_by_user=Import_durch_Benutzer_abgebrochen
-Progress\:_%0_of_%1=Fortschritt\:_%0_von_%1
-Error_while_fetching_from_%0=Fehler_beim_Abrufen_von_%0
+Move\ file\ failed=Fehler beim Verschieben der Datei
+Could\ not\ move\ file\ '%0'.=Datei '%0' konnte nicht verschoben werden.
+Could\ not\ find\ file\ '%0'.=Datei '%0' nicht gefunden.
+Number\ of\ entries\ successfully\ imported=Zahl der erfolgreich importierten Einträge
+Import\ canceled\ by\ user=Import durch Benutzer abgebrochen
+Progress\:\ %0\ of\ %1=Fortschritt: %0 von %1
+Error\ while\ fetching\ from\ %0=Fehler beim Abrufen von %0
 
-Please_enter_a_valid_number=Bitte_geben_Sie_eine_gültige_Zahl_ein
-Show_search_results_in_a_window=Suchergebnisse_in_einem_Fenster_anzeigen
-Show_global_search_results_in_a_window=Globale_Suchergebnisse_in_einem_Fenster_anzeigen
-Search_in_all_open_libraries=Suche_in_allen_offenen_Bibliotheken
-Move_file_to_file_directory?=Datei_in_Dateiverzeichnis_verschieben?
+Please\ enter\ a\ valid\ number=Bitte geben Sie eine gültige Zahl ein
+Show\ search\ results\ in\ a\ window=Suchergebnisse in einem Fenster anzeigen
+Show\ global\ search\ results\ in\ a\ window=Globale Suchergebnisse in einem Fenster anzeigen
+Search\ in\ all\ open\ libraries=Suche in allen offenen Bibliotheken
+Move\ file\ to\ file\ directory?=Datei in Dateiverzeichnis verschieben?
 
-Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.=Die_Bibliothek_ist_geschützt._Speichern_nicht_möglich,_bis_externe_Änderungen_geprüft_wurden.
-Protected_library=Geschützte_Bibliothek
-Refuse_to_save_the_library_before_external_changes_have_been_reviewed.=Die_Bibliothek_kann_nicht_gespeichert_werden,_bis_externe_Änderungen_geprüft_wurden.
-Library_protection=Bibliotheksschutz
-Unable_to_save_library=Speichern_der_Bibliothek_nicht_möglich
+Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=Die Bibliothek ist geschützt. Speichern nicht möglich, bis externe Änderungen geprüft wurden.
+Protected\ library=Geschützte Bibliothek
+Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=Die Bibliothek kann nicht gespeichert werden, bis externe Änderungen geprüft wurden.
+Library\ protection=Bibliotheksschutz
+Unable\ to\ save\ library=Speichern der Bibliothek nicht möglich
 
-BibTeX_key_generator=BibTeX-Key-Generator
-Unable_to_open_link.=Öffnen_des_Links_nicht_möglich
-Move_the_keyboard_focus_to_the_entry_table=Tastatur-Fokus_auf_die_Tabelle_setzen
-MIME_type=MIME-Typ
+BibTeX\ key\ generator=BibTeX-Key-Generator
+Unable\ to\ open\ link.=Öffnen des Links nicht möglich
+Move\ the\ keyboard\ focus\ to\ the\ entry\ table=Tastatur-Fokus auf die Tabelle setzen
+MIME\ type=MIME-Typ
 
-This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.=Diese_Funktion_öffnet_neue_oder_importierte_Dateien_in_einer_bereits_laufenden_Instanz_von_JabRef<BR>und_nicht_in_einem_neuen_Fenster._Das_ist_beispielsweise_nützlich,<BR>wenn_Sie_JabRef_von_einem_Webbrowser_aus_starten.<BR>Beachten_Sie,_dass_damit_nicht_mehr_als_eine_Instanz_von_JabRef_gestartet_werden_kann.
-Run_fetcher,_e.g._"--fetch\=Medline\:cancer"=Recherche_starten,_z.B._"--fetch=Medline\:cancer"
+This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef<BR>instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef<br>from\ your\ web\ browser.<BR>Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=Diese Funktion öffnet neue oder importierte Dateien in einer bereits laufenden Instanz von JabRef<BR>und nicht in einem neuen Fenster. Das ist beispielsweise nützlich,<BR>wenn Sie JabRef von einem Webbrowser aus starten.<BR>Beachten Sie, dass damit nicht mehr als eine Instanz von JabRef gestartet werden kann.
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=Recherche starten, z.B. "--fetch=Medline:cancer"
 
-The_ACM_Digital_Library=ACM_Digital_Library
+The\ ACM\ Digital\ Library=ACM Digital Library
 Reset=Zurücksetzen
 
-Use_IEEE_LaTeX_abbreviations=Benutze_IEEE-LaTeX-Abkürzungen
-The_Guide_to_Computing_Literature=The_Guide_to_Computing_Literature
+Use\ IEEE\ LaTeX\ abbreviations=Benutze IEEE-LaTeX-Abkürzungen
+The\ Guide\ to\ Computing\ Literature=The Guide to Computing Literature
 
-When_opening_file_link,_search_for_matching_file_if_no_link_is_defined=Beim_Öffnen_des_Dateilinks_die_passende_Datei_suchen,_falls_keine_verlinkt_ist
-Settings_for_%0=Einstellungen_für_%0
-Mark_entries_imported_into_an_existing_library=Markiere_Einträge,_die_in_eine_bestehende_Bibliothek_importiert_werden
-Unmark_all_entries_before_importing_new_entries_into_an_existing_library=Markierung_aller_Einträge_aufheben,_bevor_neue_Einträge_in_eine_bestehende_Bibliothek_importiert_werden
+When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=Beim Öffnen des Dateilinks die passende Datei suchen, falls keine verlinkt ist
+Settings\ for\ %0=Einstellungen für %0
+Mark\ entries\ imported\ into\ an\ existing\ library=Markiere Einträge, die in eine bestehende Bibliothek importiert werden
+Unmark\ all\ entries\ before\ importing\ new\ entries\ into\ an\ existing\ library=Markierung aller Einträge aufheben, bevor neue Einträge in eine bestehende Bibliothek importiert werden
 
 Forward=Vor
 Back=Zurück
-Sort_the_following_fields_as_numeric_fields=Sortiere_folgende_Felder_als_numerische_Felder
-Line_%0\:_Found_corrupted_BibTeX_key.=Zeile_%0\:_Beschädigter_BibTeX-Key_gefunden.
-Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).=Zeile_%0\:_Beschädigter_BibTeX-Key_gefunden_(enthält_Leerzeichen).
-Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).=Zeile_%0\:_Beschädigter_BibTeX-Key_gefunden_(Komma_fehlt).
-Full_text_document_download_failed=Herunterladen_des_Volltext-Beitrags_fehlgeschlagen
-Update_to_current_column_order=Aktuelle_Spaltenanordnung_verwenden
-Download_from_URL=Download_von_URL
-Rename_field=Feld_umbenennen
-Set/clear/append/rename_fields=Felder_setzen/löschen/umbenennen
-Append_field=
-Append_to_fields=
-Rename_field_to=Feld_umbenennen
-Move_contents_of_a_field_into_a_field_with_a_different_name=Inhalt_eines_Felds_in_ein_Feld_mit_anderem_Namen_verschieben
-You_can_only_rename_one_field_at_a_time=Sie_können_nur_eine_Datei_auf_einmal_umbenennen
+Sort\ the\ following\ fields\ as\ numeric\ fields=Sortiere folgende Felder als numerische Felder
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=Zeile %0: Beschädigter BibTeX-Key gefunden.
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=Zeile %0: Beschädigter BibTeX-Key gefunden (enthält Leerzeichen).
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=Zeile %0: Beschädigter BibTeX-Key gefunden (Komma fehlt).
+Full\ text\ document\ download\ failed=Herunterladen des Volltext-Beitrags fehlgeschlagen
+Update\ to\ current\ column\ order=Aktuelle Spaltenanordnung verwenden
+Download\ from\ URL=Download von URL
+Rename\ field=Feld umbenennen
+Set/clear/append/rename\ fields=Felder setzen/löschen/umbenennen
+Append\ field=
+Append\ to\ fields=
+Rename\ field\ to=Feld umbenennen
+Move\ contents\ of\ a\ field\ into\ a\ field\ with\ a\ different\ name=Inhalt eines Felds in ein Feld mit anderem Namen verschieben
+You\ can\ only\ rename\ one\ field\ at\ a\ time=Sie können nur eine Datei auf einmal umbenennen
 
-Remove_all_broken_links=Alle_ungültigen_Links_löschen
+Remove\ all\ broken\ links=Alle ungültigen Links löschen
 
-Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.=Port_%0_konnte_nicht_für_externen_Zugriff_genutzt_werden;_er_wird_möglicherweise_von_einer_anderen_Anwendung_benutzt._Versuchen_Sie_einen_anderen_Port.
+Cannot\ use\ port\ %0\ for\ remote\ operation;\ another\ application\ may\ be\ using\ it.\ Try\ specifying\ another\ port.=Port %0 konnte nicht für externen Zugriff genutzt werden; er wird möglicherweise von einer anderen Anwendung benutzt. Versuchen Sie einen anderen Port.
 
-Looking_for_full_text_document...=Suche_Volltext-Dokument...
-Autosave=Automatische_Speicherung
-A_local_copy_will_be_opened.=Eine_lokale_Kopie_wird_geöffnet.
-Autosave_local_libraries=Automatische_Abspeicherung_für_lokale_Bibliotheken
-Automatically_save_the_library_to=Speichere_die_Bibliothek_automatisch_nach
-Please_enter_a_valid_file_path.=Bitte_geben_Sie_einen_korrekten_Dateipfad_ein.
+Looking\ for\ full\ text\ document...=Suche Volltext-Dokument...
+Autosave=Automatische Speicherung
+A\ local\ copy\ will\ be\ opened.=Eine lokale Kopie wird geöffnet.
+Autosave\ local\ libraries=Automatische Abspeicherung für lokale Bibliotheken
+Automatically\ save\ the\ library\ to=Speichere die Bibliothek automatisch nach
+Please\ enter\ a\ valid\ file\ path.=Bitte geben Sie einen korrekten Dateipfad ein.
 
 
-Export_in_current_table_sort_order=Exportieren_sortiert_nach_der_aktuellen_Tabelle
-Export_entries_in_their_original_order=Einträge_in_ursprünglicher_Reihenfolge_exportieren
-Error_opening_file_'%0'.=Fehler_beim_Öffnen_der_Datei_'%0'.
+Export\ in\ current\ table\ sort\ order=Exportieren sortiert nach der aktuellen Tabelle
+Export\ entries\ in\ their\ original\ order=Einträge in ursprünglicher Reihenfolge exportieren
+Error\ opening\ file\ '%0'.=Fehler beim Öffnen der Datei '%0'.
 
-Formatter_not_found\:_%0=Formatierer_nicht_gefunden\:_%0
-Clear_inputarea=Eingabefeld_löschen
+Formatter\ not\ found\:\ %0=Formatierer nicht gefunden: %0
+Clear\ inputarea=Eingabefeld löschen
 
-Automatically_set_file_links_for_this_entry=Dateilinks_für_diesen_Eintrag_automatisch_festlegen
-Could_not_save,_file_locked_by_another_JabRef_instance.=Speichern_nicht_möglich,_die_Datei_wird_von_einer_anderen_JabRef-Instanz_verwendet.
-File_is_locked_by_another_JabRef_instance.=Die_Datei_ist_durch_eine_andere_JabRef-Instanz_gesperrt.
-Do_you_want_to_override_the_file_lock?=Wollen_Sie_die_Datei_trotz_Sperre_überschreiben?
-File_locked=Datei_gesperrt
-Current_tmp_value=Derzeitiger_tmp-Wert
-Metadata_change=Metadaten-Änderung
-Changes_have_been_made_to_the_following_metadata_elements=An_den_folgenden_Metadaten_wurden_Änderungen_vorgenommen
+Automatically\ set\ file\ links\ for\ this\ entry=Dateilinks für diesen Eintrag automatisch festlegen
+Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=Speichern nicht möglich, die Datei wird von einer anderen JabRef-Instanz verwendet.
+File\ is\ locked\ by\ another\ JabRef\ instance.=Die Datei ist durch eine andere JabRef-Instanz gesperrt.
+Do\ you\ want\ to\ override\ the\ file\ lock?=Wollen Sie die Datei trotz Sperre überschreiben?
+File\ locked=Datei gesperrt
+Current\ tmp\ value=Derzeitiger tmp-Wert
+Metadata\ change=Metadaten-Änderung
+Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=An den folgenden Metadaten wurden Änderungen vorgenommen
 
-Generate_groups_for_author_last_names=Erstelle_Gruppen_für_Nachnamen_der_Autoren
-Generate_groups_from_keywords_in_a_BibTeX_field=Erstelle_Gruppen_aus_den_Stichwörtern_eines_BibTeX-Feldes
-Enforce_legal_characters_in_BibTeX_keys=Erzwinge_erlaubte_Zeichen_in_BibTeX-Keys
+Generate\ groups\ for\ author\ last\ names=Erstelle Gruppen für Nachnamen der Autoren
+Generate\ groups\ from\ keywords\ in\ a\ BibTeX\ field=Erstelle Gruppen aus den Stichwörtern eines BibTeX-Feldes
+Enforce\ legal\ characters\ in\ BibTeX\ keys=Erzwinge erlaubte Zeichen in BibTeX-Keys
 
-Save_without_backup?=Ohne_Backup_Speichern?
-Unable_to_create_backup=Erstellen_des_Backups_fehlgeschlagen
-Move_file_to_file_directory=Datei_ins_Dateiverzeichnis_verschieben
-Rename_file_to=Datei_umbenennen_in
-<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)=<b>Alle_Einträge</b>_(diese_Gruppe_kann_nicht_verändert_oder_gelöscht_werden)
-static_group=statische_Gruppe
-dynamic_group=dynamische_Gruppe
-refines_supergroup=bezieht_die_Obergruppe_mit_ein
-includes_subgroups=berücksichtigt_Untergruppen
+Save\ without\ backup?=Ohne Backup Speichern?
+Unable\ to\ create\ backup=Erstellen des Backups fehlgeschlagen
+Move\ file\ to\ file\ directory=Datei ins Dateiverzeichnis verschieben
+Rename\ file\ to=Datei umbenennen in
+<b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=<b>Alle Einträge</b> (diese Gruppe kann nicht verändert oder gelöscht werden)
+static\ group=statische Gruppe
+dynamic\ group=dynamische Gruppe
+refines\ supergroup=bezieht die Obergruppe mit ein
+includes\ subgroups=berücksichtigt Untergruppen
 contains=enthält
-search_expression=Suchausdruck
+search\ expression=Suchausdruck
 
-Optional_fields_2=Optionale_Felder_2
-Waiting_for_save_operation_to_finish=Das_Ende_des_Speichervorgangs_wird_abgewartet
-Resolving_duplicate_BibTeX_keys...=Beseitige_doppelte_BibTeX-Keys...
-Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.=Beseitigen_doppelter_BibTeX-Keys_abgeschlossen._%0_Einträge_geändert.
-This_library_contains_one_or_more_duplicated_BibTeX_keys.=Diese_Bibliothek_enthält_einen_oder_mehrere_doppelte_BibTeX-Keys.
-Do_you_want_to_resolve_duplicate_keys_now?=Wollen_Sie_die_doppelten_Einträge_jetzt_beseitigen?
+Optional\ fields\ 2=Optionale Felder 2
+Waiting\ for\ save\ operation\ to\ finish=Das Ende des Speichervorgangs wird abgewartet
+Resolving\ duplicate\ BibTeX\ keys...=Beseitige doppelte BibTeX-Keys...
+Finished\ resolving\ duplicate\ BibTeX\ keys.\ %0\ entries\ modified.=Beseitigen doppelter BibTeX-Keys abgeschlossen. %0 Einträge geändert.
+This\ library\ contains\ one\ or\ more\ duplicated\ BibTeX\ keys.=Diese Bibliothek enthält einen oder mehrere doppelte BibTeX-Keys.
+Do\ you\ want\ to\ resolve\ duplicate\ keys\ now?=Wollen Sie die doppelten Einträge jetzt beseitigen?
 
-Find_and_remove_duplicate_BibTeX_keys=Finde_und_entferne_doppelte_BibTeX-Keys
-Expected_syntax_for_--fetch\='<name_of_fetcher>\:<query>'=Erwartete_Syntax_für_--fetch='<Name_des_Fetchers>\:<Anfrage>'
-Duplicate_BibTeX_key=Doppelter_BibTeX-Key
-Import_marking_color=Farbe_zum_Markieren_von_importierten_Einträgen
-Always_add_letter_(a,_b,_...)_to_generated_keys=Immer_einen_Buchstaben_(a,_b,_...)_zum_BibTeX-Key_hinzufügen
+Find\ and\ remove\ duplicate\ BibTeX\ keys=Finde und entferne doppelte BibTeX-Keys
+Expected\ syntax\ for\ --fetch\='<name\ of\ fetcher>\:<query>'=Erwartete Syntax für --fetch='<Name des Fetchers>:<Anfrage>'
+Duplicate\ BibTeX\ key=Doppelter BibTeX-Key
+Import\ marking\ color=Farbe zum Markieren von importierten Einträgen
+Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=Immer einen Buchstaben (a, b, ...) zum BibTeX-Key hinzufügen
 
-Ensure_unique_keys_using_letters_(a,_b,_...)=Eindeutige_Keys_mit_Buchstaben_(a,_b,_...)_sicherstellen
-Ensure_unique_keys_using_letters_(b,_c,_...)=Eindeutige_Keys_mit_Buchstaben_(b,_c,_...)_sicherstellen
-Entry_editor_active_background_color=Aktive_Hintergrundfarbe_des_Eintragseditors
-Entry_editor_background_color=Hintergrundfarbe_des_Eintragseditors
-Entry_editor_font_color=Schriftfarbe_des_Eintragseditors
-Entry_editor_invalid_field_color=Farbe_für_ungülte_Felder_im_Eintragseditor
+Ensure\ unique\ keys\ using\ letters\ (a,\ b,\ ...)=Eindeutige Keys mit Buchstaben (a, b, ...) sicherstellen
+Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=Eindeutige Keys mit Buchstaben (b, c, ...) sicherstellen
+Entry\ editor\ active\ background\ color=Aktive Hintergrundfarbe des Eintragseditors
+Entry\ editor\ background\ color=Hintergrundfarbe des Eintragseditors
+Entry\ editor\ font\ color=Schriftfarbe des Eintragseditors
+Entry\ editor\ invalid\ field\ color=Farbe für ungülte Felder im Eintragseditor
 
-Table_and_entry_editor_colors=Tabellen-_und_Eintragseditor-Farben
+Table\ and\ entry\ editor\ colors=Tabellen- und Eintragseditor-Farben
 
-General_file_directory=Standard-Dateiverzeichnis
-User-specific_file_directory=Benutzerdefiniertes_Dateiverzeichnis
-Search_failed\:_illegal_search_expression=Suche_fehlgeschlagen\:_Ungültiger_Suchausdruck
-Show_ArXiv_column=ArXiv-Spalte_anzeigen
+General\ file\ directory=Standard-Dateiverzeichnis
+User-specific\ file\ directory=Benutzerdefiniertes Dateiverzeichnis
+Search\ failed\:\ illegal\ search\ expression=Suche fehlgeschlagen: Ungültiger Suchausdruck
+Show\ ArXiv\ column=ArXiv-Spalte anzeigen
 
-You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for=Sie_müssen_einen_Zahlwert_zwischen_1025_und_65535_eintragen_in_das_Textfeld_für
-Automatically_open_browse_dialog_when_creating_new_file_link=Beim_Erstellen_eines_neuen_Datei-Links_den_Durchsuchen-Dialog_automatisch_öffnen
-Import_metadata_from\:=Metadaten_importieren_von\:
-Choose_the_source_for_the_metadata_import=Quelle_zum_Import_von_Metadaten_wählen
-Create_entry_based_on_XMP-metadata=Eintrag_aus_XMP-Daten_erstellen
-Create_blank_entry_linking_the_PDF=Leeren_Eintrag_erstellen_mit_Link_zum_PDF
-Only_attach_PDF=Nur_PDF_anhängen
+You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=Sie müssen einen Zahlwert zwischen 1025 und 65535 eintragen in das Textfeld für
+Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Beim Erstellen eines neuen Datei-Links den Durchsuchen-Dialog automatisch öffnen
+Import\ metadata\ from\:=Metadaten importieren von:
+Choose\ the\ source\ for\ the\ metadata\ import=Quelle zum Import von Metadaten wählen
+Create\ entry\ based\ on\ XMP-metadata=Eintrag aus XMP-Daten erstellen
+Create\ blank\ entry\ linking\ the\ PDF=Leeren Eintrag erstellen mit Link zum PDF
+Only\ attach\ PDF=Nur PDF anhängen
 Title=Titel
-Create_new_entry=Neuen_Eintrag_erstellen
-Update_existing_entry=Bestehenden_Eintrag_aktualisieren
-Autocomplete_names_in_'Firstname_Lastname'_format_only=Automatische_Vervollständigung_von_Namen_nur_im_Format_'Vorname_Nachname'
-Autocomplete_names_in_'Lastname,_Firstname'_format_only=Automatische_Vervollständigung_von_Namen_nur_im_Format_'Nachname,_Vorname'
-Autocomplete_names_in_both_formats=Automatische_Vervollständigung_von_Namen_in_beiden_Formaten
-Marking_color_%0=Markierungsfarbe_%0
-The_name_'comment'_cannot_be_used_as_an_entry_type_name.=Der_Name_'comment'_kann_nicht_als_Name_für_einen_Eintragstyp_verwendet_werden.
-You_must_enter_an_integer_value_in_the_text_field_for=Sie_müssen_einen_Zahlwert_eintragen_im_Textfeld_für
-Send_as_email=Als_E-Mail_senden
+Create\ new\ entry=Neuen Eintrag erstellen
+Update\ existing\ entry=Bestehenden Eintrag aktualisieren
+Autocomplete\ names\ in\ 'Firstname\ Lastname'\ format\ only=Automatische Vervollständigung von Namen nur im Format 'Vorname Nachname'
+Autocomplete\ names\ in\ 'Lastname,\ Firstname'\ format\ only=Automatische Vervollständigung von Namen nur im Format 'Nachname, Vorname'
+Autocomplete\ names\ in\ both\ formats=Automatische Vervollständigung von Namen in beiden Formaten
+Marking\ color\ %0=Markierungsfarbe %0
+The\ name\ 'comment'\ cannot\ be\ used\ as\ an\ entry\ type\ name.=Der Name 'comment' kann nicht als Name für einen Eintragstyp verwendet werden.
+You\ must\ enter\ an\ integer\ value\ in\ the\ text\ field\ for=Sie müssen einen Zahlwert eintragen im Textfeld für
+Send\ as\ email=Als E-Mail senden
 References=Literaturverweise
-Sending_of_emails=Senden_der_E-Mails
-Subject_for_sending_an_email_with_references=Betreff_zum_Senden_einer_E-Mail_mit_Literaturverweisen
-Automatically_open_folders_of_attached_files=Ordner_mit_angehängten_Dateien_automatisch_öffnen
-Create_entry_based_on_content=Eintrag_anhand_von_Inhalt_erstellen
-Do_not_show_this_box_again_for_this_import=Dialog_für_diesen_Import_nicht_wieder_anzeigen
-Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)=Immer_diesen_PDF-Importstil_benutzen_(nicht_bei_jedem_Import_nachfragen)
-Error_creating_email=Fehler_beim_Erstellen_der_E-Mail
-Entries_added_to_an_email=Einträge_zur_E-Mail_hinzugefügt
+Sending\ of\ emails=Senden der E-Mails
+Subject\ for\ sending\ an\ email\ with\ references=Betreff zum Senden einer E-Mail mit Literaturverweisen
+Automatically\ open\ folders\ of\ attached\ files=Ordner mit angehängten Dateien automatisch öffnen
+Create\ entry\ based\ on\ content=Eintrag anhand von Inhalt erstellen
+Do\ not\ show\ this\ box\ again\ for\ this\ import=Dialog für diesen Import nicht wieder anzeigen
+Always\ use\ this\ PDF\ import\ style\ (and\ do\ not\ ask\ for\ each\ import)=Immer diesen PDF-Importstil benutzen (nicht bei jedem Import nachfragen)
+Error\ creating\ email=Fehler beim Erstellen der E-Mail
+Entries\ added\ to\ an\ email=Einträge zur E-Mail hinzugefügt
 exportFormat=Exportformat
-Output_file_missing=Ausgabedatei_fehlt
-No_search_matches.=Keine_Übereinstimmungen_gefunden.
-The_output_option_depends_on_a_valid_input_option.=Die_Ausgabeoption_benötigt_eine_gültige_Eingabeoption.
-Default_import_style_for_drag_and_drop_of_PDFs=Standard-Importstil_für_Drag&Drop_von_PDFs
-Default_PDF_file_link_action=Standardaktion_für_PDF-Dateiverweise
-Filename_format_pattern=Formatmuster_für_Dateinamen
-Additional_parameters=Weitere_Parameter
-Cite_selected_entries_between_parenthesis=Ausgewählte_Einträge_zitieren
-Cite_selected_entries_with_in-text_citation=Ausgewählte_Einträge_im_Text_zitieren
-Cite_special=Spezielles_Zitieren
-Extra_information_(e.g._page_number)=Zusatzinformation_(z.B._Seitenzahl)
-Manage_citations=Literaturverweise_verwalten
-Problem_modifying_citation=Problem_beim_Ändern_des_Literaturverweises
+Output\ file\ missing=Ausgabedatei fehlt
+No\ search\ matches.=Keine Übereinstimmungen gefunden.
+The\ output\ option\ depends\ on\ a\ valid\ input\ option.=Die Ausgabeoption benötigt eine gültige Eingabeoption.
+Default\ import\ style\ for\ drag\ and\ drop\ of\ PDFs=Standard-Importstil für Drag&Drop von PDFs
+Default\ PDF\ file\ link\ action=Standardaktion für PDF-Dateiverweise
+Filename\ format\ pattern=Formatmuster für Dateinamen
+Additional\ parameters=Weitere Parameter
+Cite\ selected\ entries\ between\ parenthesis=Ausgewählte Einträge zitieren
+Cite\ selected\ entries\ with\ in-text\ citation=Ausgewählte Einträge im Text zitieren
+Cite\ special=Spezielles Zitieren
+Extra\ information\ (e.g.\ page\ number)=Zusatzinformation (z.B. Seitenzahl)
+Manage\ citations=Literaturverweise verwalten
+Problem\ modifying\ citation=Problem beim Ändern des Literaturverweises
 Citation=Literaturverweis
-Extra_information=Zusatzinformation
-Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.=BibTeX-Eintrag_für_Verweismarker_'0%'_konnte_nicht_aufgelöst_werden.
-Select_style=Stil_wählen
+Extra\ information=Zusatzinformation
+Could\ not\ resolve\ BibTeX\ entry\ for\ citation\ marker\ '%0'.=BibTeX-Eintrag für Verweismarker '0%' konnte nicht aufgelöst werden.
+Select\ style=Stil wählen
 Journals=Zeitschriften
 Cite=Zitieren
-Cite_in-text=Im_Text_zitieren
-Insert_empty_citation=Leeren_Verweis_einfügen
-Merge_citations=Literaturverweise_zusammenführen
-Manual_connect=Manuelle_Verbindung
-Select_Writer_document=Writer-Dokument_wählen
-Sync_OpenOffice/LibreOffice_bibliography=OpenOffice/LibreOffice-Bibliographie_synchronisieren
-Select_which_open_Writer_document_to_work_on=Bitte_wählen_Sie,_mit_welchem_geöffneten_Writer-Dokument_Sie_arbeiten_möchten
-Connected_to_document=Verbindung_zum_Dokument_hergestellt
-Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)=Literaturverweis_ohne_Text_einfügen_(der_Eintrag_wird_in_der_Literaturliste_erscheinen)
-Cite_selected_entries_with_extra_information=Ausgewählte_Einträge_mit_Zusatzinformation_zitieren
-Ensure_that_the_bibliography_is_up-to-date=Sicherstellen,_dass_die_Bibliographie_aktuell_ist
-Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.=Ihr_OpenOffice/LibreOffice-Dokument_verweist_auf_den_BibTeX-Key_'0%',_der_in_der_aktuellen_Bibliothek_nicht_gefunden_wurde.
-Unable_to_synchronize_bibliography=Synchronisieren_der_Bibliographie_fehlgeschlagen
-Combine_pairs_of_citations_that_are_separated_by_spaces_only=Verbinde_Paare_von_Literaturverweisen,_die_nur_durch_Leerzeichen_voneinander_getrennt_sind
-Autodetection_failed=Automatische_Erkennung_fehlgeschlagen
-Connecting=Verbindung_wird_hergestellt
-Please_wait...=Bitte_warten...
-Set_connection_parameters=Verbindungsparameter_einstellen
-Path_to_OpenOffice/LibreOffice_directory=Pfad_zum_OpenOffice/LibreOffice-Ordner
-Path_to_OpenOffice/LibreOffice_executable=Pfad_zum_OpenOffice/LibreOffice-Programm
-Path_to_OpenOffice/LibreOffice_library_dir=Pfad_zu_OpenOffice/LibreOffice_Library-Ordner
-Connection_lost=Verbindung_verloren
-The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.=Das_Abschnittsformat_wird_von_der_Eigenschaft_'ReferenceParagraphFormat'_oder_'ReferenceHeaderParagraphFormat'_in_der_Stildatei_bestimmt.
-The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.=Das_Zeichenformat_wird_von_der_Eigenschaft_'CitationCharacterFormat'_in_der_Stildatei_bestimmt.
-Automatically_sync_bibliography_when_inserting_citations=Bibliographie_beim_Einfügen_von_Literaturverweisen_automatisch_synchronisieren
-Look_up_BibTeX_entries_in_the_active_tab_only=BibTeX-Einträge_nur_im_aktiven_Tab_suchen
-Look_up_BibTeX_entries_in_all_open_libraries=BibTeX-Einträge_in_allen_geöffneten_Bibliotheken_suchen
-Autodetecting_paths...=Automatische_Erkennung_der_Pfade...
-Could_not_find_OpenOffice/LibreOffice_installation=Die_OpenOffice/LibreOffice-Installation_konnte_nicht_gefunden_werden
-Found_more_than_one_OpenOffice/LibreOffice_executable.=Es_wurden_mehrere_OpenOffice/LibreOffice-Programme_gefunden.
-Please_choose_which_one_to_connect_to\:=Bitte_wählen_Sie,_zu_welchem_die_Verbindung_aufgebaut_werden_soll\:
-Choose_OpenOffice/LibreOffice_executable=OpenOffice/LibreOffice-Programm_wählen
-Select_document=Datei_wählen
-HTML_list=HTML-Liste
-If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting=Diese_Namensliste_soll_nach_Möglichkeit_so_normalisiert_werden,_dass_sie_sich_nach_der_üblichen_BibTeX-Namensformatierung_richtet
-Could_not_open_%0=%0_konnte_nicht_geöffnet_werden
-Unknown_import_format=Unbekanntes_Import-Format
-Web_search=Internetrecherche
-Style_selection=Stil-Auswahl
-No_valid_style_file_defined=Keine_gültige_Stildatei_angegeben
-Choose_pattern=Muster_wählen
-Use_the_BIB_file_location_as_primary_file_directory=Pfad_der_BIB-Datei_als_primäres_Dateiverzeichnis_verwenden
-Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.=Das_gnuclient/emacsclient-Programm_konnte_nicht_gestartet_werden._Vergewissern_Sie_sich,_dass_das_emacsclient/gnuclient-Programm_installiert_und_im_PATH_enthalten_ist.
-OpenOffice/LibreOffice_connection=OpenOffice/LibreOffice-Verbindung
-You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.=Sie_müssen_entweder_eine_gültige_Stildatei_auswählen_oder_einen_der_Standard-Stile_benutzen.
+Cite\ in-text=Im Text zitieren
+Insert\ empty\ citation=Leeren Verweis einfügen
+Merge\ citations=Literaturverweise zusammenführen
+Manual\ connect=Manuelle Verbindung
+Select\ Writer\ document=Writer-Dokument wählen
+Sync\ OpenOffice/LibreOffice\ bibliography=OpenOffice/LibreOffice-Bibliographie synchronisieren
+Select\ which\ open\ Writer\ document\ to\ work\ on=Bitte wählen Sie, mit welchem geöffneten Writer-Dokument Sie arbeiten möchten
+Connected\ to\ document=Verbindung zum Dokument hergestellt
+Insert\ a\ citation\ without\ text\ (the\ entry\ will\ appear\ in\ the\ reference\ list)=Literaturverweis ohne Text einfügen (der Eintrag wird in der Literaturliste erscheinen)
+Cite\ selected\ entries\ with\ extra\ information=Ausgewählte Einträge mit Zusatzinformation zitieren
+Ensure\ that\ the\ bibliography\ is\ up-to-date=Sicherstellen, dass die Bibliographie aktuell ist
+Your\ OpenOffice/LibreOffice\ document\ references\ the\ BibTeX\ key\ '%0',\ which\ could\ not\ be\ found\ in\ your\ current\ library.=Ihr OpenOffice/LibreOffice-Dokument verweist auf den BibTeX-Key '0%', der in der aktuellen Bibliothek nicht gefunden wurde.
+Unable\ to\ synchronize\ bibliography=Synchronisieren der Bibliographie fehlgeschlagen
+Combine\ pairs\ of\ citations\ that\ are\ separated\ by\ spaces\ only=Verbinde Paare von Literaturverweisen, die nur durch Leerzeichen voneinander getrennt sind
+Autodetection\ failed=Automatische Erkennung fehlgeschlagen
+Connecting=Verbindung wird hergestellt
+Please\ wait...=Bitte warten...
+Set\ connection\ parameters=Verbindungsparameter einstellen
+Path\ to\ OpenOffice/LibreOffice\ directory=Pfad zum OpenOffice/LibreOffice-Ordner
+Path\ to\ OpenOffice/LibreOffice\ executable=Pfad zum OpenOffice/LibreOffice-Programm
+Path\ to\ OpenOffice/LibreOffice\ library\ dir=Pfad zu OpenOffice/LibreOffice Library-Ordner
+Connection\ lost=Verbindung verloren
+The\ paragraph\ format\ is\ controlled\ by\ the\ property\ 'ReferenceParagraphFormat'\ or\ 'ReferenceHeaderParagraphFormat'\ in\ the\ style\ file.=Das Abschnittsformat wird von der Eigenschaft 'ReferenceParagraphFormat' oder 'ReferenceHeaderParagraphFormat' in der Stildatei bestimmt.
+The\ character\ format\ is\ controlled\ by\ the\ citation\ property\ 'CitationCharacterFormat'\ in\ the\ style\ file.=Das Zeichenformat wird von der Eigenschaft 'CitationCharacterFormat' in der Stildatei bestimmt.
+Automatically\ sync\ bibliography\ when\ inserting\ citations=Bibliographie beim Einfügen von Literaturverweisen automatisch synchronisieren
+Look\ up\ BibTeX\ entries\ in\ the\ active\ tab\ only=BibTeX-Einträge nur im aktiven Tab suchen
+Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=BibTeX-Einträge in allen geöffneten Bibliotheken suchen
+Autodetecting\ paths...=Automatische Erkennung der Pfade...
+Could\ not\ find\ OpenOffice/LibreOffice\ installation=Die OpenOffice/LibreOffice-Installation konnte nicht gefunden werden
+Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=Es wurden mehrere OpenOffice/LibreOffice-Programme gefunden.
+Please\ choose\ which\ one\ to\ connect\ to\:=Bitte wählen Sie, zu welchem die Verbindung aufgebaut werden soll:
+Choose\ OpenOffice/LibreOffice\ executable=OpenOffice/LibreOffice-Programm wählen
+Select\ document=Datei wählen
+HTML\ list=HTML-Liste
+If\ possible,\ normalize\ this\ list\ of\ names\ to\ conform\ to\ standard\ BibTeX\ name\ formatting=Diese Namensliste soll nach Möglichkeit so normalisiert werden, dass sie sich nach der üblichen BibTeX-Namensformatierung richtet
+Could\ not\ open\ %0=%0 konnte nicht geöffnet werden
+Unknown\ import\ format=Unbekanntes Import-Format
+Web\ search=Internetrecherche
+Style\ selection=Stil-Auswahl
+No\ valid\ style\ file\ defined=Keine gültige Stildatei angegeben
+Choose\ pattern=Muster wählen
+Use\ the\ BIB\ file\ location\ as\ primary\ file\ directory=Pfad der BIB-Datei als primäres Dateiverzeichnis verwenden
+Could\ not\ run\ the\ gnuclient/emacsclient\ program.\ Make\ sure\ you\ have\ the\ emacsclient/gnuclient\ program\ installed\ and\ available\ in\ the\ PATH.=Das gnuclient/emacsclient-Programm konnte nicht gestartet werden. Vergewissern Sie sich, dass das emacsclient/gnuclient-Programm installiert und im PATH enthalten ist.
+OpenOffice/LibreOffice\ connection=OpenOffice/LibreOffice-Verbindung
+You\ must\ select\ either\ a\ valid\ style\ file,\ or\ use\ one\ of\ the\ default\ styles.=Sie müssen entweder eine gültige Stildatei auswählen oder einen der Standard-Stile benutzen.
 
-This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.=Dieser_Dialog_erm&ouml;glicht_das_schnelle_Einf&uuml;gen_von_Eintr&auml;gen_aus_normalen_Text._Die_gew&uuml;nschten_Textstellen<br>werden_markiert_und_z.B._durch_Doppelklick_einem_selektierten_BibTeX_Eintrag_zugeordnet.
-This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.=Diese_Funktion_erstellt_eine_neue_Bibliothek_basierend_auf_den_Einträgen,_die_von_einem_bestehenden_LaTeX-Dokument_benötigt_werden.
-You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.=Sie_müssen_eine_Ihrer_geöffneten_Bibliotheken,_von_denen_Einträge_genommen_werden_sollen,_sowie_die_AUX-Datei,_die_von_LaTeX_beim_Kompilieren_Ihres_Dokuments_erstellt_wird,_auswählen.
+This\ is\ a\ simple\ copy\ and\ paste\ dialog.\ First\ load\ or\ paste\ some\ text\ into\ the\ text\ input\ area.<br>After\ that,\ you\ can\ mark\ text\ and\ assign\ it\ to\ a\ BibTeX\ field.=Dieser Dialog erm&ouml;glicht das schnelle Einf&uuml;gen von Eintr&auml;gen aus normalen Text. Die gew&uuml;nschten Textstellen<br>werden markiert und z.B. durch Doppelklick einem selektierten BibTeX Eintrag zugeordnet.
+This\ feature\ generates\ a\ new\ library\ based\ on\ which\ entries\ are\ needed\ in\ an\ existing\ LaTeX\ document.=Diese Funktion erstellt eine neue Bibliothek basierend auf den Einträgen, die von einem bestehenden LaTeX-Dokument benötigt werden.
+You\ need\ to\ select\ one\ of\ your\ open\ libraries\ from\ which\ to\ choose\ entries,\ as\ well\ as\ the\ AUX\ file\ produced\ by\ LaTeX\ when\ compiling\ your\ document.=Sie müssen eine Ihrer geöffneten Bibliotheken, von denen Einträge genommen werden sollen, sowie die AUX-Datei, die von LaTeX beim Kompilieren Ihres Dokuments erstellt wird, auswählen.
 
-First_select_entries_to_clean_up.=Wählen_Sie_zuerst_die_Einträge_aus,_für_die_ein_Cleanup_durchgeführt_werden_soll.
-Cleanup_entry=Eintrag_aufräumen
-Autogenerate_PDF_Names=Automatische_PDF_Umbenennung
-Auto-generating_PDF-Names_does_not_support_undo._Continue?=Automatische_PDF_Umbenennung_kann_nicht_rückgängig_gemacht_werden._Fortfahren?
+First\ select\ entries\ to\ clean\ up.=Wählen Sie zuerst die Einträge aus, für die ein Cleanup durchgeführt werden soll.
+Cleanup\ entry=Eintrag aufräumen
+Autogenerate\ PDF\ Names=Automatische PDF Umbenennung
+Auto-generating\ PDF-Names\ does\ not\ support\ undo.\ Continue?=Automatische PDF Umbenennung kann nicht rückgängig gemacht werden. Fortfahren?
 
-Use_full_firstname_whenever_possible=Den_ganzen_Vornamen_nutzen,_wenn_möglich
-Use_abbreviated_firstname_whenever_possible=Den_abgekürzten_Vornamen_benutzen,_wenn_möglich
-Use_abbreviated_and_full_firstname=Abgekürzte_und_ganze_Vornamen_verwenden
-Autocompletion_options=Autovervollständigungs-Optionen
-Name_format_used_for_autocompletion=Namensformat_für_die_Autovervollständigung
-Treatment_of_first_names=Behandlung_von_Vornamen
-Cleanup_entries=Einträge_aufräumen
-Automatically_assign_new_entry_to_selected_groups=Neuen_Eintrag_automatisch_den_ausgewählten_Gruppen_zuordnen
-%0_mode=%0-Modus
-Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix=DOIs_von_den_Feldern_note_und_URL_ins_DOI-Feld_verschieben_und_das_http-Präfix_löschen
-Make_paths_of_linked_files_relative_(if_possible)=Pfade_verlinkter_Dateien_zu_relativen_Pfaden_ändern_(falls_möglich)
-Rename_PDFs_to_given_filename_format_pattern=PDFs_entsprechend_dem_vorgegebenen_Namensformat_umbenennen
-Rename_only_PDFs_having_a_relative_path=Nur_PDFs_mit_einem_relativen_Pfad_umbenennen
-What_would_you_like_to_clean_up?=Was_würden_Sie_gerne_aufräumen?
-Doing_a_cleanup_for_%0_entries...=Aufräumen_von_%0_Einträgen...
-No_entry_needed_a_clean_up=Aufräumen_bei_keinem_Eintrag_nötig
-One_entry_needed_a_clean_up=Aufräumen_bei_einem_Eintrag_nötig
-%0_entries_needed_a_clean_up=Aufräumen_bei_%0_Einträgen_nötig
+Use\ full\ firstname\ whenever\ possible=Den ganzen Vornamen nutzen, wenn möglich
+Use\ abbreviated\ firstname\ whenever\ possible=Den abgekürzten Vornamen benutzen, wenn möglich
+Use\ abbreviated\ and\ full\ firstname=Abgekürzte und ganze Vornamen verwenden
+Autocompletion\ options=Autovervollständigungs-Optionen
+Name\ format\ used\ for\ autocompletion=Namensformat für die Autovervollständigung
+Treatment\ of\ first\ names=Behandlung von Vornamen
+Cleanup\ entries=Einträge aufräumen
+Automatically\ assign\ new\ entry\ to\ selected\ groups=Neuen Eintrag automatisch den ausgewählten Gruppen zuordnen
+%0\ mode=%0-Modus
+Move\ DOIs\ from\ note\ and\ URL\ field\ to\ DOI\ field\ and\ remove\ http\ prefix=DOIs von den Feldern note und URL ins DOI-Feld verschieben und das http-Präfix löschen
+Make\ paths\ of\ linked\ files\ relative\ (if\ possible)=Pfade verlinkter Dateien zu relativen Pfaden ändern (falls möglich)
+Rename\ PDFs\ to\ given\ filename\ format\ pattern=PDFs entsprechend dem vorgegebenen Namensformat umbenennen
+Rename\ only\ PDFs\ having\ a\ relative\ path=Nur PDFs mit einem relativen Pfad umbenennen
+What\ would\ you\ like\ to\ clean\ up?=Was würden Sie gerne aufräumen?
+Doing\ a\ cleanup\ for\ %0\ entries...=Aufräumen von %0 Einträgen...
+No\ entry\ needed\ a\ clean\ up=Aufräumen bei keinem Eintrag nötig
+One\ entry\ needed\ a\ clean\ up=Aufräumen bei einem Eintrag nötig
+%0\ entries\ needed\ a\ clean\ up=Aufräumen bei %0 Einträgen nötig
 
-Remove_selected=Ausgewählte_löschen
+Remove\ selected=Ausgewählte löschen
 
-Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.=Der_Gruppenbaum_konnte_nicht_geparsed_werden._Wenn_Sie_die_BibTeX-Bibliothek_speichern,_gehen_alle_Gruppen_verloren.
-Attach_file=Datei_anhängen
-Setting_all_preferences_to_default_values.=Setze_alle_Einstellungen_auf_die_Standardwerte.
-Resetting_preference_key_'%0'=Setze_Einstellung_'0%'_zurück
-Unknown_preference_key_'%0'=Unbekannte_Einstellung_'0%'
-Unable_to_clear_preferences.=Einstellungen_konnten_nicht_zurückgesetzt_werden.
+Group\ tree\ could\ not\ be\ parsed.\ If\ you\ save\ the\ BibTeX\ library,\ all\ groups\ will\ be\ lost.=Der Gruppenbaum konnte nicht geparsed werden. Wenn Sie die BibTeX-Bibliothek speichern, gehen alle Gruppen verloren.
+Attach\ file=Datei anhängen
+Setting\ all\ preferences\ to\ default\ values.=Setze alle Einstellungen auf die Standardwerte.
+Resetting\ preference\ key\ '%0'=Setze Einstellung '0%' zurück
+Unknown\ preference\ key\ '%0'=Unbekannte Einstellung '0%'
+Unable\ to\ clear\ preferences.=Einstellungen konnten nicht zurückgesetzt werden.
 
-Reset_preferences_(key1,key2,..._or_'all')=Einstellungen_zurücksetzen_(key1,key2,..._oder_'all')
-Find_unlinked_files=Nicht_verlinkte_Dateien_finden
-Unselect_all=Auswahl_aufheben
-Expand_all=Alle_aufklappen
-Collapse_all=Alle_einklappen
-Opens_the_file_browser.=Öffnet_den_Dateimanager.
-Scan_directory=Ordner_durchsuchen
-Searches_the_selected_directory_for_unlinked_files.=Sucht_im_ausgewählten_Ordner_nach_nicht-verlinkten_Dateien.
-Starts_the_import_of_BibTeX_entries.=Startet_den_Import_von_BibTeX-Einträgen.
-Leave_this_dialog.=Verlasse_diesen_Dialog.
-Create_directory_based_keywords=Erstelle_Stichworte,_die_auf_Ordnern_basieren
-Creates_keywords_in_created_entrys_with_directory_pathnames=Erstellt_Stichworte_in_erstellten_Einträgen_mit_Ordner-Pfadnamen
-Select_a_directory_where_the_search_shall_start.=Verzeichnis_wählen,_in_dem_die_Suche_starten_soll.
-Select_file_type\:=Dateityp_wählen\:
-These_files_are_not_linked_in_the_active_library.=Diese_Dateien_sind_in_der_aktiven_Bibliothek_nicht_verlinkt.
-Entry_type_to_be_created\:=Eintragstyp,_der_erstellt_werden_soll\:
-Searching_file_system...=Dateisystem_wird_durchsucht...
-Importing_into_Library...=In_die_Bibliothek_importieren...
-Select_directory=Verzeichnis_wählen
-Select_files=Dateien_wählen
-BibTeX_entry_creation=Erstellung_eines_BibTeX-Eintrags
-<No_selection>=<Keine_Auswahl>
-Unable_to_connect_to_FreeCite_online_service.=Verbindung_zu_FreeCite_konnte_nicht_hergestellt_werden.
-Parse_with_FreeCite=Mit_FreeCite_parsen
-The_current_BibTeX_key_will_be_overwritten._Continue?=Der_aktuelle_BibTeX-Key_wird_überschrieben._Fortfahren?
-Overwrite_key=Key_überschreiben
-Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator=Der_existierende_Key_wird_nicht_überschrieben._Um_diese_Einstellung_zu_ändern,_öffnen_Sie_Optionen_->_Einstellungen_->_BibTeX-Key-Generator
-How_would_you_like_to_link_to_'%0'?=Wie_möchten_Sie_zu_'%0'_verlinken?
-BibTeX_key_patterns=BibTeX-Key-Muster
-Changed_special_field_settings=Einstellungen_für_spezielle_Felder_geändert
-Clear_priority=Priorität_aufheben
-Clear_rank=Rang_aufheben
-Enable_special_fields=Spezielle_Felder_aktivieren
-One_star=Ein_Stern
-Two_stars=Zwei_Sterne
-Three_stars=Drei_Sterne
-Four_stars=Vier_Sterne
-Five_stars=Fünf_Sterne
-Help_on_special_fields=Hilfe_zu_speziellen_Feldern
-Keywords_of_selected_entries=Stichworte_der_ausgewählten_Einträge
-Manage_content_selectors=Inhaltsauswahl_verwalten
-Manage_keywords=Stichworte_verwalten
-No_priority_information=Keine_Informationen_zur_Priorität
-No_rank_information=Keine_Informationen_zum_Rang
+Reset\ preferences\ (key1,key2,...\ or\ 'all')=Einstellungen zurücksetzen (key1,key2,... oder 'all')
+Find\ unlinked\ files=Nicht verlinkte Dateien finden
+Unselect\ all=Auswahl aufheben
+Expand\ all=Alle aufklappen
+Collapse\ all=Alle einklappen
+Opens\ the\ file\ browser.=Öffnet den Dateimanager.
+Scan\ directory=Ordner durchsuchen
+Searches\ the\ selected\ directory\ for\ unlinked\ files.=Sucht im ausgewählten Ordner nach nicht-verlinkten Dateien.
+Starts\ the\ import\ of\ BibTeX\ entries.=Startet den Import von BibTeX-Einträgen.
+Leave\ this\ dialog.=Verlasse diesen Dialog.
+Create\ directory\ based\ keywords=Erstelle Stichworte, die auf Ordnern basieren
+Creates\ keywords\ in\ created\ entrys\ with\ directory\ pathnames=Erstellt Stichworte in erstellten Einträgen mit Ordner-Pfadnamen
+Select\ a\ directory\ where\ the\ search\ shall\ start.=Verzeichnis wählen, in dem die Suche starten soll.
+Select\ file\ type\:=Dateityp wählen:
+These\ files\ are\ not\ linked\ in\ the\ active\ library.=Diese Dateien sind in der aktiven Bibliothek nicht verlinkt.
+Entry\ type\ to\ be\ created\:=Eintragstyp, der erstellt werden soll:
+Searching\ file\ system...=Dateisystem wird durchsucht...
+Importing\ into\ Library...=In die Bibliothek importieren...
+Select\ directory=Verzeichnis wählen
+Select\ files=Dateien wählen
+BibTeX\ entry\ creation=Erstellung eines BibTeX-Eintrags
+<No\ selection>=<Keine Auswahl>
+Unable\ to\ connect\ to\ FreeCite\ online\ service.=Verbindung zu FreeCite konnte nicht hergestellt werden.
+Parse\ with\ FreeCite=Mit FreeCite parsen
+The\ current\ BibTeX\ key\ will\ be\ overwritten.\ Continue?=Der aktuelle BibTeX-Key wird überschrieben. Fortfahren?
+Overwrite\ key=Key überschreiben
+Not\ overwriting\ existing\ key.\ To\ change\ this\ setting,\ open\ Options\ ->\ Prefererences\ ->\ BibTeX\ key\ generator=Der existierende Key wird nicht überschrieben. Um diese Einstellung zu ändern, öffnen Sie Optionen -> Einstellungen -> BibTeX-Key-Generator
+How\ would\ you\ like\ to\ link\ to\ '%0'?=Wie möchten Sie zu '%0' verlinken?
+BibTeX\ key\ patterns=BibTeX-Key-Muster
+Changed\ special\ field\ settings=Einstellungen für spezielle Felder geändert
+Clear\ priority=Priorität aufheben
+Clear\ rank=Rang aufheben
+Enable\ special\ fields=Spezielle Felder aktivieren
+One\ star=Ein Stern
+Two\ stars=Zwei Sterne
+Three\ stars=Drei Sterne
+Four\ stars=Vier Sterne
+Five\ stars=Fünf Sterne
+Help\ on\ special\ fields=Hilfe zu speziellen Feldern
+Keywords\ of\ selected\ entries=Stichworte der ausgewählten Einträge
+Manage\ content\ selectors=Inhaltsauswahl verwalten
+Manage\ keywords=Stichworte verwalten
+No\ priority\ information=Keine Informationen zur Priorität
+No\ rank\ information=Keine Informationen zum Rang
 Priority=Priorität
-Priority_high=Hohe_Priorität
-Priority_low=Niedrige_Priorität
-Priority_medium=Mittlere_Priorität
+Priority\ high=Hohe Priorität
+Priority\ low=Niedrige Priorität
+Priority\ medium=Mittlere Priorität
 Quality=Qualität
 Rank=Rang
 Relevance=Relevanz
-Set_priority_to_high=Priorität_auf_hoch_setzen
-Set_priority_to_low=Priorität_auf_niedrig_setzen
-Set_priority_to_medium=Priorität_auf_mittel_setzen
-Show_priority=Priorität_anzeigen
-Show_quality=Qualität_anzeigen
-Show_rank=Rang_anzeigen
-Show_relevance=Relevanz_anzeigen
-Synchronize_with_keywords=Mit_Stichworten_synchronisieren
-Synchronized_special_fields_based_on_keywords=Spezielle_Felder_wurden_mit_den_Stichworten_synchronisiert
-Toggle_relevance=Relevanz_ein-/ausschalten
-Toggle_quality_assured=Qualität_ein-/ausschalten
-Toggle_print_status=Druckstatus_umschalten
-Update_keywords=Stichworte_aktualisieren
-Write_values_of_special_fields_as_separate_fields_to_BibTeX=Werte_spezieller_Felder_separat_in_die_BibTeX-Datei_schreiben
-You_have_changed_settings_for_special_fields.=Sie_haben_die_Einstellungen_für_spezielle_Felder_geändert.
-%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.=%0_Einträge_gefunden._Um_die_Serverlast_zu_reduzieren,_werden_nur_%1_heruntergeladen.
-A_string_with_that_label_already_exists=Ein_String_mit_diesem_Label_ist_bereits_vorhanden
-Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.=Verbindung_zu_OpenOffice/LibreOffice_verloren._Bitte_stellen_Sie_sicher,_dass_OpenOffice/LibreOffice_läuft,_und_versuchen_Sie,_erneut_zu_verbinden.
-JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.=JabRef_sendet_pro_Eintrag_mindestens_eine_Anfrage_an_einen_Herausgeber.
-Correct_the_entry,_and_reopen_editor_to_display/edit_source.=Eintrag_korrigieren_und_Editor_erneut_öffnen,_um_den_Quelltext_anzuzeigen/zu_bearbeiten.
-Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').=Keine_Verbindung_zu_einem_laufenden_gnuserv-Prozess_möglich._Vergewissern_Sie_sich,_dass_Emacs_oder_XEmacs_läuft<BR>und_dass_der_Server_gestartet_wurde_(mit_dem_Befehl_'server-start'/'gnuserv-start').
-Could_not_connect_to_running_OpenOffice/LibreOffice.=Verbindung_zu_OpenOffice/LibreOffice_fehlgeschlagen.
-Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.=Vergewissern_Sie_sich,_dass_Sie_OpenOffice/LibreOffice_mit_Java-Unterstützung_installiert_haben.
-If_connecting_manually,_please_verify_program_and_library_paths.=Bei_manueller_Verbindung_überprüfen_Sie_bitte_die_Programm-_und_Library-Pfade.
-Error_message\:=Fehlermeldung\:
-If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.=Falls_bei_einem_eingefügten_oder_importierten_Eintrag_das_Feld_bereits_belegt_ist,_überschreiben.
-Import_metadata_from_PDF=Metadaten_aus_PDF_importieren
-Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.=Keine_Verbindung_zu_einem_Writer-Dokument._Bitte_vergewissern_Sie_sich,_dass_ein_Dokument_geöffnet_ist,_und_benutzen_Sie_die_Schaltfläche_'Writer-Dokument_wählen',_um_eine_Verbindung_herzustellen.
-Removed_all_subgroups_of_group_"%0".=Alle_Untergruppen_der_Gruppe_"%0"_wurden_entfernt.
-To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.=Um_den_USB-Stick-Modus_zu_deaktivieren,_benennen_Sie_die_Datei_jabref.xml_in_demselben_Ordner_als_JabRef_oder_löschen_Sie_sie.
-Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.=Verbindung_fehlgeschlagen._Ein_möglicher_Grund_ist,_dass_JabRef_und_OpenOffice/LibreOffice_nicht_beide_im_32-bit_oder_64-bit_Modus_laufen.
-Use_the_following_delimiter_character(s)\:=Benutzen_Sie_die_folgenden_Trennzeichen\:
-When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above=Beim_Herunterladen_von_Dateien_oder_beim_Verschieben_von_verlinkten_Dateien_in_das_Dateiverzeichnis_soll_der_Pfad_der_BIB-Datei_benutzt_werden,_nicht_das_oben_definierte_Dateiverzeichnis
-Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=Ihre_Stildatei_legt_das_Zeichenformat_'%0'_fest,_das_in_Ihrem_aktuellen_OpenOffice/LibreOffice-Dokument_nicht_definiert_ist.
-Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=Ihre_Stildatei_legt_das_Abschnittsformat_'%0'_fest,_das_in_Ihrem_aktuellen_OpenOffice/LibreOffice-Dokument_nicht_definiert_ist.
+Set\ priority\ to\ high=Priorität auf hoch setzen
+Set\ priority\ to\ low=Priorität auf niedrig setzen
+Set\ priority\ to\ medium=Priorität auf mittel setzen
+Show\ priority=Priorität anzeigen
+Show\ quality=Qualität anzeigen
+Show\ rank=Rang anzeigen
+Show\ relevance=Relevanz anzeigen
+Synchronize\ with\ keywords=Mit Stichworten synchronisieren
+Synchronized\ special\ fields\ based\ on\ keywords=Spezielle Felder wurden mit den Stichworten synchronisiert
+Toggle\ relevance=Relevanz ein-/ausschalten
+Toggle\ quality\ assured=Qualität ein-/ausschalten
+Toggle\ print\ status=Druckstatus umschalten
+Update\ keywords=Stichworte aktualisieren
+Write\ values\ of\ special\ fields\ as\ separate\ fields\ to\ BibTeX=Werte spezieller Felder separat in die BibTeX-Datei schreiben
+You\ have\ changed\ settings\ for\ special\ fields.=Sie haben die Einstellungen für spezielle Felder geändert.
+%0\ entries\ found.\ To\ reduce\ server\ load,\ only\ %1\ will\ be\ downloaded.=%0 Einträge gefunden. Um die Serverlast zu reduzieren, werden nur %1 heruntergeladen.
+A\ string\ with\ that\ label\ already\ exists=Ein String mit diesem Label ist bereits vorhanden
+Connection\ to\ OpenOffice/LibreOffice\ has\ been\ lost.\ Please\ make\ sure\ OpenOffice/LibreOffice\ is\ running,\ and\ try\ to\ reconnect.=Verbindung zu OpenOffice/LibreOffice verloren. Bitte stellen Sie sicher, dass OpenOffice/LibreOffice läuft, und versuchen Sie, erneut zu verbinden.
+JabRef\ will\ send\ at\ least\ one\ request\ per\ entry\ to\ a\ publisher.=JabRef sendet pro Eintrag mindestens eine Anfrage an einen Herausgeber.
+Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=Eintrag korrigieren und Editor erneut öffnen, um den Quelltext anzuzeigen/zu bearbeiten.
+Could\ not\ connect\ to\ a\ running\ gnuserv\ process.\ Make\ sure\ that\ Emacs\ or\ XEmacs\ is\ running,<BR>and\ that\ the\ server\ has\ been\ started\ (by\ running\ the\ command\ 'server-start'/'gnuserv-start').=Keine Verbindung zu einem laufenden gnuserv-Prozess möglich. Vergewissern Sie sich, dass Emacs oder XEmacs läuft<BR>und dass der Server gestartet wurde (mit dem Befehl 'server-start'/'gnuserv-start').
+Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=Verbindung zu OpenOffice/LibreOffice fehlgeschlagen.
+Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=Vergewissern Sie sich, dass Sie OpenOffice/LibreOffice mit Java-Unterstützung installiert haben.
+If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=Bei manueller Verbindung überprüfen Sie bitte die Programm- und Library-Pfade.
+Error\ message\:=Fehlermeldung:
+If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=Falls bei einem eingefügten oder importierten Eintrag das Feld bereits belegt ist, überschreiben.
+Import\ metadata\ from\ PDF=Metadaten aus PDF importieren
+Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=Keine Verbindung zu einem Writer-Dokument. Bitte vergewissern Sie sich, dass ein Dokument geöffnet ist, und benutzen Sie die Schaltfläche 'Writer-Dokument wählen', um eine Verbindung herzustellen.
+Removed\ all\ subgroups\ of\ group\ "%0".=Alle Untergruppen der Gruppe "%0" wurden entfernt.
+To\ disable\ the\ memory\ stick\ mode\ rename\ or\ remove\ the\ jabref.xml\ file\ in\ the\ same\ folder\ as\ JabRef.=Um den USB-Stick-Modus zu deaktivieren, benennen Sie die Datei jabref.xml in demselben Ordner als JabRef oder löschen Sie sie.
+Unable\ to\ connect.\ One\ possible\ reason\ is\ that\ JabRef\ and\ OpenOffice/LibreOffice\ are\ not\ both\ running\ in\ either\ 32\ bit\ mode\ or\ 64\ bit\ mode.=Verbindung fehlgeschlagen. Ein möglicher Grund ist, dass JabRef und OpenOffice/LibreOffice nicht beide im 32-bit oder 64-bit Modus laufen.
+Use\ the\ following\ delimiter\ character(s)\:=Benutzen Sie die folgenden Trennzeichen:
+When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\ prefer\ the\ BIB\ file\ location\ rather\ than\ the\ file\ directory\ set\ above=Beim Herunterladen von Dateien oder beim Verschieben von verlinkten Dateien in das Dateiverzeichnis soll der Pfad der BIB-Datei benutzt werden, nicht das oben definierte Dateiverzeichnis
+Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Ihre Stildatei legt das Zeichenformat '%0' fest, das in Ihrem aktuellen OpenOffice/LibreOffice-Dokument nicht definiert ist.
+Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Ihre Stildatei legt das Abschnittsformat '%0' fest, das in Ihrem aktuellen OpenOffice/LibreOffice-Dokument nicht definiert ist.
 
-Searching...=Suche_läuft...
-You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?=Sie_haben_mehr_als_%0_Einträge_zum_Download_ausgewählt._Einige_Webseiten_könnten_zu_viele_Downloads_blockieren._Möchten_Sie_fortfahren?
-Confirm_selection=Auswahl_bestätigen
-Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case=Nach_der_Suche_{}_zu_festgesetzten_Titelworten_hinzufügen,_um_Groß-/Kleinschreibung_beizubehalten
-Import_conversions=Konvertierungen_importieren
-Please_enter_a_search_string=Bitte_geben_Sie_eine_Suchphrase_ein
-Please_open_or_start_a_new_library_before_searching=Bitte_öffnen_Sie_eine_Bibliothek_oder_legen_Sie_eine_neue_an,_bevor_Sie_suchen
+Searching...=Suche läuft...
+You\ have\ selected\ more\ than\ %0\ entries\ for\ download.\ Some\ web\ sites\ might\ block\ you\ if\ you\ make\ too\ many\ rapid\ downloads.\ Do\ you\ want\ to\ continue?=Sie haben mehr als %0 Einträge zum Download ausgewählt. Einige Webseiten könnten zu viele Downloads blockieren. Möchten Sie fortfahren?
+Confirm\ selection=Auswahl bestätigen
+Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=Nach der Suche {} zu festgesetzten Titelworten hinzufügen, um Groß-/Kleinschreibung beizubehalten
+Import\ conversions=Konvertierungen importieren
+Please\ enter\ a\ search\ string=Bitte geben Sie eine Suchphrase ein
+Please\ open\ or\ start\ a\ new\ library\ before\ searching=Bitte öffnen Sie eine Bibliothek oder legen Sie eine neue an, bevor Sie suchen
 
-Canceled_merging_entries=Zusammenführen_der_Einträge_abgebrochen
+Canceled\ merging\ entries=Zusammenführen der Einträge abgebrochen
 
-Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search=Einheiten_formatieren\:_nicht-umbrechende_Trennzeichen_hinzufügen_und_bei_der_Suche_Groß-/Kleinschreibung_beibehalten
-Merge_entries=Einträge_zusammenführen
-Merged_entries=Die_Einträge_wurden_zusammengeführt
-Merged_entry=Eintrag_zusammengeführt
+Format\ units\ by\ adding\ non-breaking\ separators\ and\ keeping\ the\ correct\ case\ on\ search=Einheiten formatieren: nicht-umbrechende Trennzeichen hinzufügen und bei der Suche Groß-/Kleinschreibung beibehalten
+Merge\ entries=Einträge zusammenführen
+Merged\ entries=Die Einträge wurden zusammengeführt
+Merged\ entry=Eintrag zusammengeführt
 None=Kein(e/r)
 Parse=Parsen
 Result=Ergebnis
-Show_DOI_first=DOI_zuerst_anzeigen
-Show_URL_first=URL_zuerst_anzeigen
-Use_Emacs_key_bindings=Emacs-Tastaturkürzel_benutzen
-You_have_to_choose_exactly_two_entries_to_merge.=Sie_müssen_genau_zwei_Einträge_auswählen,_die_zusammengeführt_werden_sollen.
+Show\ DOI\ first=DOI zuerst anzeigen
+Show\ URL\ first=URL zuerst anzeigen
+Use\ Emacs\ key\ bindings=Emacs-Tastaturkürzel benutzen
+You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=Sie müssen genau zwei Einträge auswählen, die zusammengeführt werden sollen.
 
-Update_timestamp_on_modification=Zeitstempel_bei_Änderung_aktualisieren
-All_key_bindings_will_be_reset_to_their_defaults.=Alle_Tastaturkürzel_werden_auf_den_Standard_zurückgesetzt.
+Update\ timestamp\ on\ modification=Zeitstempel bei Änderung aktualisieren
+All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=Alle Tastaturkürzel werden auf den Standard zurückgesetzt.
 
-Automatically_set_file_links=Dateilinks_automatisch_setzen
-Resetting_all_key_bindings=Alle_Tastaturkürzel_werden_zurückgesetzt
+Automatically\ set\ file\ links=Dateilinks automatisch setzen
+Resetting\ all\ key\ bindings=Alle Tastaturkürzel werden zurückgesetzt
 Hostname=Host
-Invalid_setting=Ungültige_Einstellung
+Invalid\ setting=Ungültige Einstellung
 Network=Netzwerk
-Please_specify_both_hostname_and_port=Bitte_geben_Sie_den_Namen_des_Hosts_und_den_Port_an
-Please_specify_both_username_and_password=Bitte_geben_Sie_Benutzernamen_und_Passwort_an
+Please\ specify\ both\ hostname\ and\ port=Bitte geben Sie den Namen des Hosts und den Port an
+Please\ specify\ both\ username\ and\ password=Bitte geben Sie Benutzernamen und Passwort an
 
-Use_custom_proxy_configuration=Benutzerdefinierte_Proxy-Konfiguration_verwenden
-Proxy_requires_authentication=Proxy_erfordert_Authentifizierung
-Attention\:_Password_is_stored_in_plain_text\!=Achtung\:_Das_Passwort_wird_im_Klartext_gespeichert\!
-Clear_connection_settings=Verbindungseinstellungen_zurücksetzen
-Cleared_connection_settings.=Verbindungseinstellungen_wurden_zurückgesetzt.
+Use\ custom\ proxy\ configuration=Benutzerdefinierte Proxy-Konfiguration verwenden
+Proxy\ requires\ authentication=Proxy erfordert Authentifizierung
+Attention\:\ Password\ is\ stored\ in\ plain\ text\!=Achtung: Das Passwort wird im Klartext gespeichert!
+Clear\ connection\ settings=Verbindungseinstellungen zurücksetzen
+Cleared\ connection\ settings.=Verbindungseinstellungen wurden zurückgesetzt.
 
-Rebind_C-a,_too=C-a_ebenfalls_neu_zuweisen
-Rebind_C-f,_too=C-f_ebenfalls_neu_zuweisen
+Rebind\ C-a,\ too=C-a ebenfalls neu zuweisen
+Rebind\ C-f,\ too=C-f ebenfalls neu zuweisen
 
-Open_folder=Ordner_öffnen
-Searches_for_unlinked_PDF_files_on_the_file_system=Sucht_nach_nicht_verlinkten_PDF-Dateien_im_Dateisystem
-Export_entries_ordered_as_specified=Einträge_in_der_angegebenen_Reihenfolge_exportieren
-Export_sort_order=Sortierreihenfolge_exportieren
-Export_sorting=Exportiere_Sortierung
-Newline_separator=Zeichen_für_Zeilenumbruch
+Open\ folder=Ordner öffnen
+Searches\ for\ unlinked\ PDF\ files\ on\ the\ file\ system=Sucht nach nicht verlinkten PDF-Dateien im Dateisystem
+Export\ entries\ ordered\ as\ specified=Einträge in der angegebenen Reihenfolge exportieren
+Export\ sort\ order=Sortierreihenfolge exportieren
+Export\ sorting=Exportiere Sortierung
+Newline\ separator=Zeichen für Zeilenumbruch
 
-Save_entries_ordered_as_specified=Einträge_in_angegebener_Reihenfolge_speichern
-Save_sort_order=Sortierreihenfolge_speichern
-Show_extra_columns=Extraspalten_anzeigen
-Parsing_error=Syntaxfehler
-illegal_backslash_expression=ungültiger_Backslash-Ausdruck
+Save\ entries\ ordered\ as\ specified=Einträge in angegebener Reihenfolge speichern
+Save\ sort\ order=Sortierreihenfolge speichern
+Show\ extra\ columns=Extraspalten anzeigen
+Parsing\ error=Syntaxfehler
+illegal\ backslash\ expression=ungültiger Backslash-Ausdruck
 
-Move_to_group=Verschieben_in_Gruppe
+Move\ to\ group=Verschieben in Gruppe
 
-Clear_read_status=Lesestatus_leeren
-Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')=Ins_biblatex-Format_konvertieren_(verschiebe_beispielsweise_den_Wert_des_Felds_'journal'_in_das_Feld_'journaltitle')
-Could_not_apply_changes.=Die_Änderungen_konnten_nicht_übernommen_werden.
-Deprecated_fields=Abgelehnte_Felder
-Hide/show_toolbar=Toolbar_zeigen/verbergen
-No_read_status_information=Keine_Informationen_zum_Lesestatus
+Clear\ read\ status=Lesestatus leeren
+Convert\ to\ biblatex\ format\ (for\ example,\ move\ the\ value\ of\ the\ 'journal'\ field\ to\ 'journaltitle')=Ins biblatex-Format konvertieren (verschiebe beispielsweise den Wert des Felds 'journal' in das Feld 'journaltitle')
+Could\ not\ apply\ changes.=Die Änderungen konnten nicht übernommen werden.
+Deprecated\ fields=Abgelehnte Felder
+Hide/show\ toolbar=Toolbar zeigen/verbergen
+No\ read\ status\ information=Keine Informationen zum Lesestatus
 Printed=Gedruckt
-Read_status=Lesestatus
-Read_status_read=Lesestatus\:_gelesen
-Read_status_skimmed=Lesestatus\:_überflogen
-Save_selected_as_plain_BibTeX...=Ausgewählte_Einträge_als_reines_BibTeX_speichern…
-Set_read_status_to_read=Lesestatus_auf_'gelesen'_gesetzt
-Set_read_status_to_skimmed=Lesestatus_auf_'überflogen'_gesetzt
-Show_deprecated_BibTeX_fields=Abgelehnte_BibTeX-Felder_zeigen
+Read\ status=Lesestatus
+Read\ status\ read=Lesestatus: gelesen
+Read\ status\ skimmed=Lesestatus: überflogen
+Save\ selected\ as\ plain\ BibTeX...=Ausgewählte Einträge als reines BibTeX speichern…
+Set\ read\ status\ to\ read=Lesestatus auf 'gelesen' gesetzt
+Set\ read\ status\ to\ skimmed=Lesestatus auf 'überflogen' gesetzt
+Show\ deprecated\ BibTeX\ fields=Abgelehnte BibTeX-Felder zeigen
 
-Show_gridlines=Gitternetzlinien_anzeigen
-Show_printed_status=Druckstatus_anzeigen
-Show_read_status=Lesestatus_anzeigen
-Table_row_height_padding=Zeilenabstand
+Show\ gridlines=Gitternetzlinien anzeigen
+Show\ printed\ status=Druckstatus anzeigen
+Show\ read\ status=Lesestatus anzeigen
+Table\ row\ height\ padding=Zeilenabstand
 
-Marked_selected_entry=Ausgewählten_Eintrag_markiert
-Marked_all_%0_selected_entries=Alle_%0_Einträge_markiert
-Unmarked_selected_entry=Markierung_für_ausgewählten_Eintrag_aufgehoben
-Unmarked_all_%0_selected_entries=Markierung_für_alle_%0_ausgewählten_Einträge_aufgehoben
+Marked\ selected\ entry=Ausgewählten Eintrag markiert
+Marked\ all\ %0\ selected\ entries=Alle %0 Einträge markiert
+Unmarked\ selected\ entry=Markierung für ausgewählten Eintrag aufgehoben
+Unmarked\ all\ %0\ selected\ entries=Markierung für alle %0 ausgewählten Einträge aufgehoben
 
 
-Unmarked_all_entries=Markierung_für_alle_Einträge_aufgehoben
+Unmarked\ all\ entries=Markierung für alle Einträge aufgehoben
 
-Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.=Look_and_feel_konnte_nicht_gefunden_werden,_stattdessen_wird_der_Standard_verwendet.
+Unable\ to\ find\ the\ requested\ look\ and\ feel\ and\ thus\ the\ default\ one\ is\ used.=Look and feel konnte nicht gefunden werden, stattdessen wird der Standard verwendet.
 
-Opens_JabRef's_GitHub_page=Öffnet_JabRefs_GitHub-Seite
-Could_not_open_browser.=Konnte_Browser_nicht_öffnen.
-Please_open_%0_manually.=Bitte_öffnen_Sie_%0_manuell.
-The_link_has_been_copied_to_the_clipboard.=Der_Link_wurde_in_die_Zwischenablage_kopiert.
+Opens\ JabRef's\ GitHub\ page=Öffnet JabRefs GitHub-Seite
+Could\ not\ open\ browser.=Konnte Browser nicht öffnen.
+Please\ open\ %0\ manually.=Bitte öffnen Sie %0 manuell.
+The\ link\ has\ been\ copied\ to\ the\ clipboard.=Der Link wurde in die Zwischenablage kopiert.
 
-Open_%0_file=%0_Datei_öffnen
+Open\ %0\ file=%0 Datei öffnen
 
-Cannot_delete_file=Datei_kann_nicht_gelöscht_werden.
-File_permission_error=Fehler_beim_Dateizugriff.
-Push_to_%0=In_%0_einfügen
-Path_to_%0=Pfad_zu_%0
+Cannot\ delete\ file=Datei kann nicht gelöscht werden.
+File\ permission\ error=Fehler beim Dateizugriff.
+Push\ to\ %0=In %0 einfügen
+Path\ to\ %0=Pfad zu %0
 Convert=Konvertiere
-Normalize_to_BibTeX_name_format=Normalisiere_ins_BibTeX-Namensformat
-Help_on_Name_Formatting=Hilfe_zur_Namensformatierung
+Normalize\ to\ BibTeX\ name\ format=Normalisiere ins BibTeX-Namensformat
+Help\ on\ Name\ Formatting=Hilfe zur Namensformatierung
 
-Add_new_file_type=Füge_neuen_Dateityp_hinzu
+Add\ new\ file\ type=Füge neuen Dateityp hinzu
 
-Left_entry=Linker_Eintrag
-Right_entry=Rechter_Eintrag
+Left\ entry=Linker Eintrag
+Right\ entry=Rechter Eintrag
 Use=Benutze
-Original_entry=Originaleintrag
-Replace_original_entry=Ersetze_Originaleintrag
-No_information_added=Keine_Informationen_hinzugefügt
-Select_at_least_one_entry_to_manage_keywords.=Es_muss_mindestens_ein_Eintrag_ausgewählt_sein_um_Stichworte_verwalten_zu_können.
-OpenDocument_text=OpenDocument-Text
-OpenDocument_spreadsheet=OpenDocument-Tabelle
-OpenDocument_presentation=OpenDocument-Präsentation
-%0_image=%0-Bild
-Added_entry=Eintrag_hinzugefügt
-Modified_entry=Eintrag_bearbeitet
-Deleted_entry=Eintrag_gelöscht
-Modified_groups_tree=Gruppenstruktur_bearbeitet
-Removed_all_groups=Alle_Gruppen_entfernt
-Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.=Akzeptieren_der_Änderungen_führt_dazu,_dass_die_komplette_Gruppenstruktur_durch_die_externen_Änderungen_erstetzt_wird.
-Select_export_format=Export-Format_wählen
-Return_to_JabRef=Zurück_zu_JabRef
-Please_move_the_file_manually_and_link_in_place.=Bitte_die_Datei_manuell_verschieben_und_verlinken.
-Could_not_connect_to_%0=Verbindung_zu_%0_fehlgeschlagen
-Warning\:_%0_out_of_%1_entries_have_undefined_title.=Warnung\:_%0_von_%1_Einträgen_haben_keinen_Titel.
-Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.=Warnung\:_%0_von_%1_Einträgen_haben_keinen_BibTeX-Key.
+Original\ entry=Originaleintrag
+Replace\ original\ entry=Ersetze Originaleintrag
+No\ information\ added=Keine Informationen hinzugefügt
+Select\ at\ least\ one\ entry\ to\ manage\ keywords.=Es muss mindestens ein Eintrag ausgewählt sein um Stichworte verwalten zu können.
+OpenDocument\ text=OpenDocument-Text
+OpenDocument\ spreadsheet=OpenDocument-Tabelle
+OpenDocument\ presentation=OpenDocument-Präsentation
+%0\ image=%0-Bild
+Added\ entry=Eintrag hinzugefügt
+Modified\ entry=Eintrag bearbeitet
+Deleted\ entry=Eintrag gelöscht
+Modified\ groups\ tree=Gruppenstruktur bearbeitet
+Removed\ all\ groups=Alle Gruppen entfernt
+Accepting\ the\ change\ replaces\ the\ complete\ groups\ tree\ with\ the\ externally\ modified\ groups\ tree.=Akzeptieren der Änderungen führt dazu, dass die komplette Gruppenstruktur durch die externen Änderungen erstetzt wird.
+Select\ export\ format=Export-Format wählen
+Return\ to\ JabRef=Zurück zu JabRef
+Please\ move\ the\ file\ manually\ and\ link\ in\ place.=Bitte die Datei manuell verschieben und verlinken.
+Could\ not\ connect\ to\ %0=Verbindung zu %0 fehlgeschlagen
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ title.=Warnung: %0 von %1 Einträgen haben keinen Titel.
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ BibTeX\ key.=Warnung: %0 von %1 Einträgen haben keinen BibTeX-Key.
 occurrence=Vorkommen
-Added_new_'%0'_entry.=Neuer_'%0'_Eintrag_hinzugefügt.
-Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?=Mehrere_Einträge_ausgewählt._Wollen_Sie_den_Typ_aller_Einträge_zu_'%0'_ändern?
-Changed_type_to_'%0'_for=Typ_geändert_zu_'%0'_für
-Really_delete_the_selected_entry?=Ausgewählten_Eintrag_wirklich_löschen?
-Really_delete_the_%0_selected_entries?=Wirklich_alle_%0_ausgewählten_Einträge_löschen?
-Keep_merged_entry_only=Nur_den_zusammengeführten_Eintrag_beibehalten
-Keep_left=Links_beibehalten
-Keep_right=Rechts_beibehalten
-Old_entry=Alter_Eintrag
-From_import=Aus_im_Import
-No_problems_found.=Keine_Probleme_gefunden.
-%0_problem(s)_found=%0_Problem(e)_gefunden
-Save_changes=Änderungen_speichern
-Discard_changes=Änderungen_verwerfen
-Library_'%0'_has_changed.=Die_Bibliothek_'%0'_wurde_geändert.
-Print_entry_preview=Eintragsvorschau_drucken
-Copy_title=Kopiere_Titel
-Copy_\\cite{BibTeX_key}=\\cite{BibTeX_key}_kopieren
-Copy_BibTeX_key_and_title=BibTeX-Key_und_Titel_kopieren
-File_rename_failed_for_%0_entries.=Dateiumbennung_schlug_ür_%0_Einträge_fehl.
-Merged_BibTeX_source_code=BibTeX-Quelltext_zusammengeführt
-Invalid_DOI\:_'%0'.=Ungültiger_DOI\:_'%0'.
-should_start_with_a_name=sollte_mit_einem_Name_beginnen
-should_end_with_a_name=sollte_mit_einem_Name_enden
-unexpected_closing_curly_bracket=unerwartete_schließende_geschweifte_Klammer
-unexpected_opening_curly_bracket=unerwartete_öffnende_geschweifte_Klammer
-capital_letters_are_not_masked_using_curly_brackets_{}=Großbuchstaben_sind_nicht_in_geschweiften_Klammern_{}_gesetzt
-should_contain_a_four_digit_number=sollte_eine_vierstellige_Zahl_enthalten
-should_contain_a_valid_page_number_range=sollte_einen_gültigen_Seitenbereich_enthalten
+Added\ new\ '%0'\ entry.=Neuer '%0' Eintrag hinzugefügt.
+Multiple\ entries\ selected.\ Do\ you\ want\ to\ change\ the\ type\ of\ all\ these\ to\ '%0'?=Mehrere Einträge ausgewählt. Wollen Sie den Typ aller Einträge zu '%0' ändern?
+Changed\ type\ to\ '%0'\ for=Typ geändert zu '%0' für
+Really\ delete\ the\ selected\ entry?=Ausgewählten Eintrag wirklich löschen?
+Really\ delete\ the\ %0\ selected\ entries?=Wirklich alle %0 ausgewählten Einträge löschen?
+Keep\ merged\ entry\ only=Nur den zusammengeführten Eintrag beibehalten
+Keep\ left=Links beibehalten
+Keep\ right=Rechts beibehalten
+Old\ entry=Alter Eintrag
+From\ import=Aus im Import
+No\ problems\ found.=Keine Probleme gefunden.
+%0\ problem(s)\ found=%0 Problem(e) gefunden
+Save\ changes=Änderungen speichern
+Discard\ changes=Änderungen verwerfen
+Library\ '%0'\ has\ changed.=Die Bibliothek '%0' wurde geändert.
+Print\ entry\ preview=Eintragsvorschau drucken
+Copy\ title=Kopiere Titel
+Copy\ \\cite{BibTeX\ key}=\\cite{BibTeX key} kopieren
+Copy\ BibTeX\ key\ and\ title=BibTeX-Key und Titel kopieren
+File\ rename\ failed\ for\ %0\ entries.=Dateiumbennung schlug ür %0 Einträge fehl.
+Merged\ BibTeX\ source\ code=BibTeX-Quelltext zusammengeführt
+Invalid\ DOI\:\ '%0'.=Ungültiger DOI: '%0'.
+should\ start\ with\ a\ name=sollte mit einem Name beginnen
+should\ end\ with\ a\ name=sollte mit einem Name enden
+unexpected\ closing\ curly\ bracket=unerwartete schließende geschweifte Klammer
+unexpected\ opening\ curly\ bracket=unerwartete öffnende geschweifte Klammer
+capital\ letters\ are\ not\ masked\ using\ curly\ brackets\ {}=Großbuchstaben sind nicht in geschweiften Klammern {} gesetzt
+should\ contain\ a\ four\ digit\ number=sollte eine vierstellige Zahl enthalten
+should\ contain\ a\ valid\ page\ number\ range=sollte einen gültigen Seitenbereich enthalten
 Filled=Befüllt
-Field_is_missing=Feld_fehlt
-Search_%0=%0_durchsuchen
+Field\ is\ missing=Feld fehlt
+Search\ %0=%0 durchsuchen
 
-Search_results_in_all_libraries_for_%0=Suchergebnisse_in_allen_Bibliotheken_für_%0
-Search_results_in_library_%0_for_%1=Suchergebnisse_in_Bibliothek_%0_für_%1
-Search_globally=Global_suchen
-No_results_found.=Keine_Ergebnisse_gefunden.
-Found_%0_results.=%0_Ergebnisse_gefunden.
-plain_text=Klartext
-This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>=Diese_Suche_enthält_Einträge,_die_in_einem_beliebigen_Feld_den_regulären_Ausdruck_<b>%0</b>_enthalten
-This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>=Diese_Suche_enthält_Einträge,_die_in_einem_beliebigen_Feld_den_Begriff_<b>%0</b>_enthalten
-This_search_contains_entries_in_which=Diese_Suche_enthält_Einträge,_in_denen
+Search\ results\ in\ all\ libraries\ for\ %0=Suchergebnisse in allen Bibliotheken für %0
+Search\ results\ in\ library\ %0\ for\ %1=Suchergebnisse in Bibliothek %0 für %1
+Search\ globally=Global suchen
+No\ results\ found.=Keine Ergebnisse gefunden.
+Found\ %0\ results.=%0 Ergebnisse gefunden.
+plain\ text=Klartext
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ regular\ expression\ <b>%0</b>=Diese Suche enthält Einträge, die in einem beliebigen Feld den regulären Ausdruck <b>%0</b> enthalten
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ term\ <b>%0</b>=Diese Suche enthält Einträge, die in einem beliebigen Feld den Begriff <b>%0</b> enthalten
+This\ search\ contains\ entries\ in\ which=Diese Suche enthält Einträge, in denen
 
-Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.=Konnte_Openoffice/LibreOffice_Installationspfad_nicht_atuomatisch_bestimmen._Bitte_wählen_Sie_das_Installationsverzeichnis_manuell_aus.
-JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>=JabRef_unterstützt_nicht_länger_'ps'_oder_'pdf'_Felder.<br>Dateilinks_werden_ab_jetzt_im_'Datei'_Feld_gespeichert_und_Dateien_werden_in_einem_externen_Dateiverzeichnis_gespeichert.<br>Um_diese_neue_Funktion_zu_nutzen_muss_JabRef_die_Dateilinks_aktualisieren.
-This_library_uses_outdated_file_links.=Diese_Bibliothek_benutzt_veraltete_Dateilinks.
+Unable\ to\ autodetect\ OpenOffice/LibreOffice\ installation.\ Please\ choose\ the\ installation\ directory\ manually.=Konnte Openoffice/LibreOffice Installationspfad nicht atuomatisch bestimmen. Bitte wählen Sie das Installationsverzeichnis manuell aus.
+JabRef\ no\ longer\ supports\ 'ps'\ or\ 'pdf'\ fields.<br>File\ links\ are\ now\ stored\ in\ the\ 'file'\ field\ and\ files\ are\ stored\ in\ an\ external\ file\ directory.<br>To\ make\ use\ of\ this\ feature,\ JabRef\ needs\ to\ upgrade\ file\ links.<br><br>=JabRef unterstützt nicht länger 'ps' oder 'pdf' Felder.<br>Dateilinks werden ab jetzt im 'Datei' Feld gespeichert und Dateien werden in einem externen Dateiverzeichnis gespeichert.<br>Um diese neue Funktion zu nutzen muss JabRef die Dateilinks aktualisieren.
+This\ library\ uses\ outdated\ file\ links.=Diese Bibliothek benutzt veraltete Dateilinks.
 
-Clear_search=Suchergebnisse_zurücksetzen
-Close_library=Bibliothek_schließen
-Close_entry_editor=Eintragseditor_schließen
-Decrease_table_font_size=Verkleinere_Tabellenschriftgröße
-Entry_editor,_next_entry=Eintragseditor,_nächster_Eintrag
-Entry_editor,_next_panel=Eintragseditor,_nächstes_Panel
-Entry_editor,_next_panel_2=Eintragseditor,_nächstes_Panel_2
-Entry_editor,_previous_entry=Eintragseditor,_vorheriger_Eintrag
-Entry_editor,_previous_panel=Eintragseditor,_vorheriges_Panel
-Entry_editor,_previous_panel_2=Eintragseditor,_vorheriges_Panel_2
-File_list_editor,_move_entry_down=Dateilisteneditor,_verschiebe_Eintrag_nach_unten
-File_list_editor,_move_entry_up=Dateilisteneditor,_verschiebe_Eintrag_nach_oben
-Focus_entry_table=Eintragstabelle_fokussieren
-Import_into_current_library=Importieren_in_aktuelle_Bibliothek
-Import_into_new_library=Importieren_in_neue_Bibliothek
-Increase_table_font_size=Vergrößere_Tabellenschriftgröße
-New_article=Neuer_Artikel
-New_book=Neues_Buch
-New_entry=Neuer_Eintrag
-New_from_plain_text=Neuer_Eintrag_aus_Klartext
-New_inbook=Neuer_Teil_eines_Buches
-New_mastersthesis=Neue_Abschlussarbeit
-New_phdthesis=Neue_Dissertation
-New_proceedings=Neuer_Konferenzbericht
-New_unpublished=Neu_unveröffentlicht
-Next_tab=Nächster_Tab
-Preamble_editor,_store_changes=Präambeleditor,_speichere_Änderungen
-Previous_tab=Vorheriger_Tab
-Push_to_application=In_Applikation_einfügen
-Refresh_OpenOffice/LibreOffice=Aktualisiere_OpenOffice/LibreOffice
-Resolve_duplicate_BibTeX_keys=Doppelte_BibTeX-Keys_auflösen
-Save_all=Alle_speichern
-String_dialog,_add_string=Stringdialog,_String_hinzufügen
-String_dialog,_remove_string=Stringdialog,_String_entfernen
-Synchronize_files=Sychronisiere_Dateien
-Unabbreviate=Abkürzung_aufheben
-should_contain_a_protocol=sollte_ein_Protokoll_beinhalten
-Copy_preview=Kopiere_Vorschau
-Automatically_setting_file_links=Dateilinks_werden_automatisch_gesetzt
-Regenerating_BibTeX_keys_according_to_metadata=Regeneriere_BibTeX-Keys_anhand_ihrer_Metadaten
-No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys=Keine_Metadaten_in_Bibdatei_vorhanden._Kann_keine_BibTeX-Keys_regenerieren
-Regenerate_all_keys_for_the_entries_in_a_BibTeX_file=Regeneriere_alle_BibTeX-Keys_für_Einträge_in_einer_BibTeX_Datei
-Show_debug_level_messages=Zeige_Debug_Level_Meldungen
-Default_bibliography_mode=Standard_Bibliographiemodus
-New_%0_library_created.=Neue_%0_Bibliothek_erstellt.
-Show_only_preferences_deviating_from_their_default_value=Zeige_nur_Einstellungen,_die_vom_Standardwert_abweichen
+Clear\ search=Suchergebnisse zurücksetzen
+Close\ library=Bibliothek schließen
+Close\ entry\ editor=Eintragseditor schließen
+Decrease\ table\ font\ size=Verkleinere Tabellenschriftgröße
+Entry\ editor,\ next\ entry=Eintragseditor, nächster Eintrag
+Entry\ editor,\ next\ panel=Eintragseditor, nächstes Panel
+Entry\ editor,\ next\ panel\ 2=Eintragseditor, nächstes Panel 2
+Entry\ editor,\ previous\ entry=Eintragseditor, vorheriger Eintrag
+Entry\ editor,\ previous\ panel=Eintragseditor, vorheriges Panel
+Entry\ editor,\ previous\ panel\ 2=Eintragseditor, vorheriges Panel 2
+File\ list\ editor,\ move\ entry\ down=Dateilisteneditor, verschiebe Eintrag nach unten
+File\ list\ editor,\ move\ entry\ up=Dateilisteneditor, verschiebe Eintrag nach oben
+Focus\ entry\ table=Eintragstabelle fokussieren
+Import\ into\ current\ library=Importieren in aktuelle Bibliothek
+Import\ into\ new\ library=Importieren in neue Bibliothek
+Increase\ table\ font\ size=Vergrößere Tabellenschriftgröße
+New\ article=Neuer Artikel
+New\ book=Neues Buch
+New\ entry=Neuer Eintrag
+New\ from\ plain\ text=Neuer Eintrag aus Klartext
+New\ inbook=Neuer Teil eines Buches
+New\ mastersthesis=Neue Abschlussarbeit
+New\ phdthesis=Neue Dissertation
+New\ proceedings=Neuer Konferenzbericht
+New\ unpublished=Neu unveröffentlicht
+Next\ tab=Nächster Tab
+Preamble\ editor,\ store\ changes=Präambeleditor, speichere Änderungen
+Previous\ tab=Vorheriger Tab
+Push\ to\ application=In Applikation einfügen
+Refresh\ OpenOffice/LibreOffice=Aktualisiere OpenOffice/LibreOffice
+Resolve\ duplicate\ BibTeX\ keys=Doppelte BibTeX-Keys auflösen
+Save\ all=Alle speichern
+String\ dialog,\ add\ string=Stringdialog, String hinzufügen
+String\ dialog,\ remove\ string=Stringdialog, String entfernen
+Synchronize\ files=Sychronisiere Dateien
+Unabbreviate=Abkürzung aufheben
+should\ contain\ a\ protocol=sollte ein Protokoll beinhalten
+Copy\ preview=Kopiere Vorschau
+Automatically\ setting\ file\ links=Dateilinks werden automatisch gesetzt
+Regenerating\ BibTeX\ keys\ according\ to\ metadata=Regeneriere BibTeX-Keys anhand ihrer Metadaten
+No\ meta\ data\ present\ in\ BIB\ file.\ Cannot\ regenerate\ BibTeX\ keys=Keine Metadaten in Bibdatei vorhanden. Kann keine BibTeX-Keys regenerieren
+Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=Regeneriere alle BibTeX-Keys für Einträge in einer BibTeX Datei
+Show\ debug\ level\ messages=Zeige Debug Level Meldungen
+Default\ bibliography\ mode=Standard Bibliographiemodus
+New\ %0\ library\ created.=Neue %0 Bibliothek erstellt.
+Show\ only\ preferences\ deviating\ from\ their\ default\ value=Zeige nur Einstellungen, die vom Standardwert abweichen
 default=Standard
 key=Schlüssel
 type=Typ
 value=Wert
-Show_preferences=Zeige_Einstellungen
-Save_actions=Speicheraktionen
-Enable_save_actions=Speicheraktionen_aktivieren
+Show\ preferences=Zeige Einstellungen
+Save\ actions=Speicheraktionen
+Enable\ save\ actions=Speicheraktionen aktivieren
 
-Other_fields=Andere_Felder
-Show_remaining_fields=Zeige_übrige_Felder
+Other\ fields=Andere Felder
+Show\ remaining\ fields=Zeige übrige Felder
 
-link_should_refer_to_a_correct_file_path=Link_sollte_einen_korrekten_Dateipfad_referenzieren
-abbreviation_detected=Abkürzung_erkannt
-wrong_entry_type_as_proceedings_has_page_numbers=falscher_Eintragstyp,_weil_'Konferenzbericht'_Feld_mit_Seitenzahlen_hat
-Abbreviate_journal_names=Kürze_Zeitschriftentitel_ab
-Abbreviating...=Kürze_ab...
-Abbreviation_%s_for_journal_%s_already_defined.=Abkürzung_%s_für_das_Journal_%s_ist_bereits_definiert.
-Abbreviation_cannot_be_empty=Abkürzung_darf_nicht_leer_sein
-Duplicated_Journal_Abbreviation=Doppelte_Abkürzung_für_Zeitschriftentitel
-Duplicated_Journal_File=Doppelte_Datei_mit_Zeitschriftentiteln
-Error_Occurred=Fehler_aufgetreten
-Journal_file_%s_already_added=Zeitschriftentiteldatei_%s_ist_bereits_vorhanden
-Name_cannot_be_empty=Name_darf_nicht_leer_sein
+link\ should\ refer\ to\ a\ correct\ file\ path=Link sollte einen korrekten Dateipfad referenzieren
+abbreviation\ detected=Abkürzung erkannt
+wrong\ entry\ type\ as\ proceedings\ has\ page\ numbers=falscher Eintragstyp, weil 'Konferenzbericht' Feld mit Seitenzahlen hat
+Abbreviate\ journal\ names=Kürze Zeitschriftentitel ab
+Abbreviating...=Kürze ab...
+Abbreviation\ %s\ for\ journal\ %s\ already\ defined.=Abkürzung %s für das Journal %s ist bereits definiert.
+Abbreviation\ cannot\ be\ empty=Abkürzung darf nicht leer sein
+Duplicated\ Journal\ Abbreviation=Doppelte Abkürzung für Zeitschriftentitel
+Duplicated\ Journal\ File=Doppelte Datei mit Zeitschriftentiteln
+Error\ Occurred=Fehler aufgetreten
+Journal\ file\ %s\ already\ added=Zeitschriftentiteldatei %s ist bereits vorhanden
+Name\ cannot\ be\ empty=Name darf nicht leer sein
 
-Adding_fetched_entries=Füge_abgerufene_Einträge_hinzu
-Display_keywords_appearing_in_ALL_entries=Zeige_Schlüsselwörter_die_in_ALLEN_Einträgen_vorkommen
-Display_keywords_appearing_in_ANY_entry=Zeige_Schlüsselwörter_die_in_mind._EINEM_Eintrag_vorkommen
-Fetching_entries_from_Inspire=Rufe_Einträge_von_Inspire_ab
-None_of_the_selected_entries_have_titles.=Keiner_der_selektierten_Einträge_besitzt_einen_Titel.
-None_of_the_selected_entries_have_BibTeX_keys.=Keiner_der_selektieren_Einträge_besitzt_BibTeX-Keys.
-Unabbreviate_journal_names=Abkürzung_der_Zeitschriftentitel_aufheben
-Unabbreviating...=Hebe_Abkürzungen_auf...
+Adding\ fetched\ entries=Füge abgerufene Einträge hinzu
+Display\ keywords\ appearing\ in\ ALL\ entries=Zeige Schlüsselwörter die in ALLEN Einträgen vorkommen
+Display\ keywords\ appearing\ in\ ANY\ entry=Zeige Schlüsselwörter die in mind. EINEM Eintrag vorkommen
+Fetching\ entries\ from\ Inspire=Rufe Einträge von Inspire ab
+None\ of\ the\ selected\ entries\ have\ titles.=Keiner der selektierten Einträge besitzt einen Titel.
+None\ of\ the\ selected\ entries\ have\ BibTeX\ keys.=Keiner der selektieren Einträge besitzt BibTeX-Keys.
+Unabbreviate\ journal\ names=Abkürzung der Zeitschriftentitel aufheben
+Unabbreviating...=Hebe Abkürzungen auf...
 Usage=Bedienung
 
 
-Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.=Fügt_{}-Klammern_um_Akronyme,_Monatsnamen_und_Ländernamen_ein,_um_Groß-/Kleinschreibung_beizubehalten.
-Are_you_sure_you_want_to_reset_all_settings_to_default_values?=Wollen_sie_wirklich_alle_Einstellungen_auf_Standardwerte_zurücksetzen?
-Reset_preferences=Einstellungen_zurücksetzen
-Ill-formed_entrytype_comment_in_BIB_file=Fehlerhafter_Eintragstypkommentar_in_BIB_Datei
+Adds\ {}\ brackets\ around\ acronyms,\ month\ names\ and\ countries\ to\ preserve\ their\ case.=Fügt {}-Klammern um Akronyme, Monatsnamen und Ländernamen ein, um Groß-/Kleinschreibung beizubehalten.
+Are\ you\ sure\ you\ want\ to\ reset\ all\ settings\ to\ default\ values?=Wollen sie wirklich alle Einstellungen auf Standardwerte zurücksetzen?
+Reset\ preferences=Einstellungen zurücksetzen
+Ill-formed\ entrytype\ comment\ in\ BIB\ file=Fehlerhafter Eintragstypkommentar in BIB Datei
 
-Move_linked_files_to_default_file_directory_%0=Verknüpfte_Dateien_in_das_Standardverzeichnis_%0_verschieben
+Move\ linked\ files\ to\ default\ file\ directory\ %0=Verknüpfte Dateien in das Standardverzeichnis %0 verschieben
 
 Clipboard=Zwischenablage
-Could_not_paste_entry_as_text\:=Konnte_Einträge_nicht_als_Text_parsen\:
-Do_you_still_want_to_continue?=Wollen_Sie_wirklich_fortfahren?
-This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:=Diese_Aktion_wird_jeweils_das/die_folgenden_Feld(er)_in_mindestens_einem_Eintrag_ändern\:
-This_could_cause_undesired_changes_to_your_entries.=Dies_könnte_ungewollte_Änderungen_an_Ihren_Einträgen_hervorrufen.
-Run_field_formatter\:=Führe_Feldformatierer_aus\:
-Table_font_size_is_%0=Tabellenschriftgröße_ist_%0%
-%0_import_canceled=%0-Import_abgebrochen
-Internal_style=Interner_Stil
-Add_style_file=Füge_Stildatei_hinzu
-Are_you_sure_you_want_to_remove_the_style?=Wollen_Sie_wirklich_den_Stil_entfernen?
-Current_style_is_'%0'=Aktueller_Stil_ist_%0
-Remove_style=Style_entfernen
-Select_one_of_the_available_styles_or_add_a_style_file_from_disk.=Wählen_Sie_einen_der_verfügbaren_Stile_aus_oder_fügen_Sie_eine_Stildatei_von_der_Festplatte_hinzu.
-You_must_select_a_valid_style_file.=Sie_müssen_eine_valide_Stildatei_auswählen.
-Reload=Neu_laden
+Could\ not\ paste\ entry\ as\ text\:=Konnte Einträge nicht als Text parsen:
+Do\ you\ still\ want\ to\ continue?=Wollen Sie wirklich fortfahren?
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=Diese Aktion wird jeweils das/die folgenden Feld(er) in mindestens einem Eintrag ändern:
+This\ could\ cause\ undesired\ changes\ to\ your\ entries.=Dies könnte ungewollte Änderungen an Ihren Einträgen hervorrufen.
+Run\ field\ formatter\:=Führe Feldformatierer aus:
+Table\ font\ size\ is\ %0=Tabellenschriftgröße ist %0%
+%0\ import\ canceled=%0-Import abgebrochen
+Internal\ style=Interner Stil
+Add\ style\ file=Füge Stildatei hinzu
+Are\ you\ sure\ you\ want\ to\ remove\ the\ style?=Wollen Sie wirklich den Stil entfernen?
+Current\ style\ is\ '%0'=Aktueller Stil ist %0
+Remove\ style=Style entfernen
+Select\ one\ of\ the\ available\ styles\ or\ add\ a\ style\ file\ from\ disk.=Wählen Sie einen der verfügbaren Stile aus oder fügen Sie eine Stildatei von der Festplatte hinzu.
+You\ must\ select\ a\ valid\ style\ file.=Sie müssen eine valide Stildatei auswählen.
+Reload=Neu laden
 
 Capitalize=Großschreiben
-Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.=Schreibt_alle_Wörter_groß,_aber_schreibt_Artikel,_Präpositionen_und_Konjunktionen_klein.
-Capitalize_the_first_word,_changes_other_words_to_lower_case.=Schreibt_das_erste_Wort_groß,_schreibt_alle_anderen_Wörter_klein.
-Changes_all_letters_to_lower_case.=Ändere_alle_Buchstaben_in_Kleinschreibung.
-Changes_all_letters_to_upper_case.=Ändere_alle_Buchstaben_in_Großschreibung.
-Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.=Schreibt_den_ersten_Buchstaben_eines_jeden_Wortes_groß_und_schreibt_alle_anderen_Wörter_klein.
-Cleans_up_LaTeX_code.=Räumt_LaTeX-Code_auf.
-Converts_HTML_code_to_LaTeX_code.=Konvertiere_HTML-Code_in_LaTeX-Code.
-Converts_HTML_code_to_Unicode.=Konvertiere_HTML-Code_in_Unicode.
-Converts_LaTeX_encoding_to_Unicode_characters.=Konvertiere_LaTeX_Kodierung_in_Unicode_Zeichen.
-Converts_Unicode_characters_to_LaTeX_encoding.=Konvertiere_Unicode_Zeichen_in_LaTeX_Kodierung.
-Converts_ordinals_to_LaTeX_superscripts.=Konvertiere_Ordinalzahlen_in_LaTeX_Hochstellung.
-Converts_units_to_LaTeX_formatting.=Konvertiert_Einheiten_in_LaTeX-Code.
-HTML_to_LaTeX=HTML_zu_LaTeX
-LaTeX_cleanup=LaTeX_Aufräumen
-LaTeX_to_Unicode=LaTeX_zu_Unicode
-Lower_case=Kleinschreibung
-Minify_list_of_person_names=Reduziere_Liste_der_Personen
-Normalize_date=Normalisiere_Datum
-Normalize_month=Normalisiere_Monat
-Normalize_month_to_BibTeX_standard_abbreviation.=Normalisiere_Datum_in_BibTeX_Standardabkürzung.
-Normalize_names_of_persons=Normalisiere_Personennamen
-Normalize_page_numbers=Normalisiere_Seitennummern
-Normalize_pages_to_BibTeX_standard.=Normalisiere_Seiten_in_Bibtex-Standard
-Normalizes_lists_of_persons_to_the_BibTeX_standard.=Normalisiere_Liste_der_Personen_in_BibTeX-Standard
-Normalizes_the_date_to_ISO_date_format.=Normalisiere_Datum_ins_ISO-Datumsformat
-Ordinals_to_LaTeX_superscript=Ordinalzahlen_in_LaTeX_Hochstellungen
-Protect_terms=Schütze_Terme
-Remove_enclosing_braces=Entferne_einschließende_Klammern
-Removes_braces_encapsulating_the_complete_field_content.=Entferne_Klammern,_die_den_kompletten_Feldinhalt_einschließen.
-Sentence_case=Groß-/Kleinschreibung_von_Sätzen
-Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".=Verkleinert_die_Liste_von_Personen_zu_"et_al"_bei_mehr_als_2_Personen.
-Title_case=Groß-/Kleinschreibung_von_Titeln
-Unicode_to_LaTeX=Unicode_zu_LaTeX
-Units_to_LaTeX=Einheiten_zu_LaTeX
-Upper_case=Großschreibung
-Does_nothing.=Macht_nichts.
+Capitalize\ all\ words,\ but\ converts\ articles,\ prepositions,\ and\ conjunctions\ to\ lower\ case.=Schreibt alle Wörter groß, aber schreibt Artikel, Präpositionen und Konjunktionen klein.
+Capitalize\ the\ first\ word,\ changes\ other\ words\ to\ lower\ case.=Schreibt das erste Wort groß, schreibt alle anderen Wörter klein.
+Changes\ all\ letters\ to\ lower\ case.=Ändere alle Buchstaben in Kleinschreibung.
+Changes\ all\ letters\ to\ upper\ case.=Ändere alle Buchstaben in Großschreibung.
+Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=Schreibt den ersten Buchstaben eines jeden Wortes groß und schreibt alle anderen Wörter klein.
+Cleans\ up\ LaTeX\ code.=Räumt LaTeX-Code auf.
+Converts\ HTML\ code\ to\ LaTeX\ code.=Konvertiere HTML-Code in LaTeX-Code.
+Converts\ HTML\ code\ to\ Unicode.=Konvertiere HTML-Code in Unicode.
+Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=Konvertiere LaTeX Kodierung in Unicode Zeichen.
+Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=Konvertiere Unicode Zeichen in LaTeX Kodierung.
+Converts\ ordinals\ to\ LaTeX\ superscripts.=Konvertiere Ordinalzahlen in LaTeX Hochstellung.
+Converts\ units\ to\ LaTeX\ formatting.=Konvertiert Einheiten in LaTeX-Code.
+HTML\ to\ LaTeX=HTML zu LaTeX
+LaTeX\ cleanup=LaTeX Aufräumen
+LaTeX\ to\ Unicode=LaTeX zu Unicode
+Lower\ case=Kleinschreibung
+Minify\ list\ of\ person\ names=Reduziere Liste der Personen
+Normalize\ date=Normalisiere Datum
+Normalize\ month=Normalisiere Monat
+Normalize\ month\ to\ BibTeX\ standard\ abbreviation.=Normalisiere Datum in BibTeX Standardabkürzung.
+Normalize\ names\ of\ persons=Normalisiere Personennamen
+Normalize\ page\ numbers=Normalisiere Seitennummern
+Normalize\ pages\ to\ BibTeX\ standard.=Normalisiere Seiten in Bibtex-Standard
+Normalizes\ lists\ of\ persons\ to\ the\ BibTeX\ standard.=Normalisiere Liste der Personen in BibTeX-Standard
+Normalizes\ the\ date\ to\ ISO\ date\ format.=Normalisiere Datum ins ISO-Datumsformat
+Ordinals\ to\ LaTeX\ superscript=Ordinalzahlen in LaTeX Hochstellungen
+Protect\ terms=Schütze Terme
+Remove\ enclosing\ braces=Entferne einschließende Klammern
+Removes\ braces\ encapsulating\ the\ complete\ field\ content.=Entferne Klammern, die den kompletten Feldinhalt einschließen.
+Sentence\ case=Groß-/Kleinschreibung von Sätzen
+Shortens\ lists\ of\ persons\ if\ there\ are\ more\ than\ 2\ persons\ to\ "et\ al.".=Verkleinert die Liste von Personen zu "et al" bei mehr als 2 Personen.
+Title\ case=Groß-/Kleinschreibung von Titeln
+Unicode\ to\ LaTeX=Unicode zu LaTeX
+Units\ to\ LaTeX=Einheiten zu LaTeX
+Upper\ case=Großschreibung
+Does\ nothing.=Macht nichts.
 Identity=Identität
-Clears_the_field_completely.=Löscht_das_Feld_komplett
-Directory_not_found=Verzeichnis_nicht_gefunden
-Main_file_directory_not_set\!=Hauptverzeichnis_nicht_gesetzt\!
-This_operation_requires_exactly_one_item_to_be_selected.=Für_diesen_Vorgang_muss_genau_ein_Eintrag_ausgewählt_sein
-Importing_in_%0_format=Importieren_im_Format_%0
-Female_name=weiblicher_Name
-Female_names=weibliche_Namen
-Male_name=männlicher_Name
-Male_names=männliche_Namen
-Mixed_names=gemischte_Namen
-Neuter_name=neutraler_Name
-Neuter_names=neutrale_Namen
+Clears\ the\ field\ completely.=Löscht das Feld komplett
+Directory\ not\ found=Verzeichnis nicht gefunden
+Main\ file\ directory\ not\ set\!=Hauptverzeichnis nicht gesetzt!
+This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=Für diesen Vorgang muss genau ein Eintrag ausgewählt sein
+Importing\ in\ %0\ format=Importieren im Format %0
+Female\ name=weiblicher Name
+Female\ names=weibliche Namen
+Male\ name=männlicher Name
+Male\ names=männliche Namen
+Mixed\ names=gemischte Namen
+Neuter\ name=neutraler Name
+Neuter\ names=neutrale Namen
 
-Determined_%0_for_%1_entries=%0_von_%1_Einträgen_bestimmt
-Look_up_%0=%0_nachschlagen
-Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3=Schlage_%0_nach..._-_Eintrag_%1_von_%2_-_gefunden_%3
+Determined\ %0\ for\ %1\ entries=%0 von %1 Einträgen bestimmt
+Look\ up\ %0=%0 nachschlagen
+Looking\ up\ %0...\ -\ entry\ %1\ out\ of\ %2\ -\ found\ %3=Schlage %0 nach... - Eintrag %1 von %2 - gefunden %3
 
-Audio_CD=Audio_CD
-British_patent=Britisches_Patent
-British_patent_request=Britischer_Patentantrag
-Candidate_thesis=Beliebige_Abschlussarbeit
+Audio\ CD=Audio CD
+British\ patent=Britisches Patent
+British\ patent\ request=Britischer Patentantrag
+Candidate\ thesis=Beliebige Abschlussarbeit
 Collaborator=Mitarbeiter
 Column=Spalte
 Compiler=Zusammensteller
 Continuator=Fortsetzer
-Data_CD=Daten_CD
+Data\ CD=Daten CD
 Editor=Herausgeber
-European_patent=Europäisches_Patent
-European_patent_request=Europäischer_Patentantrag
+European\ patent=Europäisches Patent
+European\ patent\ request=Europäischer Patentantrag
 Founder=Gründer
-French_patent=Französisches_Patent
-French_patent_request=Französischer_Patentantrag
-German_patent=Deutsches_Patent
-German_patent_request=Deutscher_Patentantrag
+French\ patent=Französisches Patent
+French\ patent\ request=Französischer Patentantrag
+German\ patent=Deutsches Patent
+German\ patent\ request=Deutscher Patentantrag
 Line=Zeilennummer
-Master's_thesis=Master/Magisterarbeit
+Master's\ thesis=Master/Magisterarbeit
 Page=Seite
 Paragraph=Abschnitt
 Patent=Patent
-Patent_request=Patentantrag
-PhD_thesis=Dissertation
+Patent\ request=Patentantrag
+PhD\ thesis=Dissertation
 Redactor=Redaktor
-Research_report=Forschungsbericht
-Reviser=Sekundärer_Herausgeber
+Research\ report=Forschungsbericht
+Reviser=Sekundärer Herausgeber
 Section=Paragraph
 Software=Programm
-Technical_report=Technischer_Bericht
-U.S._patent=Patent_der_Vereinigen_Staaten
-U.S._patent_request=Patentantrag_der_Vereinigten_Staaten
+Technical\ report=Technischer Bericht
+U.S.\ patent=Patent der Vereinigen Staaten
+U.S.\ patent\ request=Patentantrag der Vereinigten Staaten
 Verse=Vers
 
-change_entries_of_group=Ändere_Einträge_der_Gruppe
-odd_number_of_unescaped_'\#'=Ungerade_Anzahl_an_'\#'_Maskierungszeichen
+change\ entries\ of\ group=Ändere Einträge der Gruppe
+odd\ number\ of\ unescaped\ '\#'=Ungerade Anzahl an '#' Maskierungszeichen
 
-Plain_text=Klartext
-Show_diff=Zeige_Änderungen
+Plain\ text=Klartext
+Show\ diff=Zeige Änderungen
 character=Zeichen
 word=Wort
-Show_symmetric_diff=Zeige_Änderungen_symmetisch
-Copy_Version=Kopiere_Version
+Show\ symmetric\ diff=Zeige Änderungen symmetisch
+Copy\ Version=Kopiere Version
 Developers=Entwickler
 Authors=Autoren
 License=Lizenz
 
-HTML_encoded_character_found=HTML_kodiertes_Zeichen_gefunden
-booktitle_ends_with_'conference_on'=Buchtitel_endet_mit_'Konferenzbericht'
+HTML\ encoded\ character\ found=HTML kodiertes Zeichen gefunden
+booktitle\ ends\ with\ 'conference\ on'=Buchtitel endet mit 'Konferenzbericht'
 
-All_external_files=Alle_externen_Dateien
+All\ external\ files=Alle externen Dateien
 
-OpenOffice/LibreOffice_integration=OpenOffice/LibreOffice-Integration
+OpenOffice/LibreOffice\ integration=OpenOffice/LibreOffice-Integration
 
-incorrect_control_digit=Falsche_Prüfziffer
-incorrect_format=Falsches_Format
-Copied_version_to_clipboard=Version_in_die_Zwischenablage_kopiert
+incorrect\ control\ digit=Falsche Prüfziffer
+incorrect\ format=Falsches Format
+Copied\ version\ to\ clipboard=Version in die Zwischenablage kopiert
 
-BibTeX_key=BibTeX-Key
+BibTeX\ key=BibTeX-Key
 Message=Nachricht
 
 
-MathSciNet_Review=MathSciNet_Review
-Reset_Bindings=Schnellzugriffe_zurücksetzten
+MathSciNet\ Review=MathSciNet Review
+Reset\ Bindings=Schnellzugriffe zurücksetzten
 
-Decryption_not_supported.=Entschlüsselung_wird_nicht_unterstützt.
+Decryption\ not\ supported.=Entschlüsselung wird nicht unterstützt.
 
-Cleared_'%0'_for_%1_entries='%0'_für_%1_Einträge_entfernt
-Set_'%0'_to_'%1'_for_%2_entries='%0'_für_%2_Einträge_auf_'%1'_gesetzt
-Toggled_'%0'_for_%1_entries='%0'_für_%1_Einträge_geändert
+Cleared\ '%0'\ for\ %1\ entries='%0' für %1 Einträge entfernt
+Set\ '%0'\ to\ '%1'\ for\ %2\ entries='%0' für %2 Einträge auf '%1' gesetzt
+Toggled\ '%0'\ for\ %1\ entries='%0' für %1 Einträge geändert
 
-Check_for_updates=Prüfe_auf_Aktualisierungen
-Download_update=Aktualisierung_herunterladen
-New_version_available=Neue_Version_vefügbar
-Installed_version=Installierte_Version
-Remind_me_later=Später_erinnern
-Ignore_this_update=Diese_Aktualisierung_ignorieren
-Could_not_connect_to_the_update_server.=Konnte_nicht_zum_Aktualisierungsserver_verbinden.
-Please_try_again_later_and/or_check_your_network_connection.=Bitte_versuchen_Sie_es_später_erneut_und/oder_prüfen_Sie_ihre_Netzwerkverbindung.
-To_see_what_is_new_view_the_changelog.=Für_Neuerungen/Änderungen_Changelog_ansehen.
-A_new_version_of_JabRef_has_been_released.=Eine_neue_JabRef_Version_wurde_veröffentlicht.
-JabRef_is_up-to-date.=JabRef_ist_auf_dem_aktuellsten_Stand.
-Latest_version=Neueste_Version
-Online_help_forum=Online-Hilfeforum
+Check\ for\ updates=Prüfe auf Aktualisierungen
+Download\ update=Aktualisierung herunterladen
+New\ version\ available=Neue Version vefügbar
+Installed\ version=Installierte Version
+Remind\ me\ later=Später erinnern
+Ignore\ this\ update=Diese Aktualisierung ignorieren
+Could\ not\ connect\ to\ the\ update\ server.=Konnte nicht zum Aktualisierungsserver verbinden.
+Please\ try\ again\ later\ and/or\ check\ your\ network\ connection.=Bitte versuchen Sie es später erneut und/oder prüfen Sie ihre Netzwerkverbindung.
+To\ see\ what\ is\ new\ view\ the\ changelog.=Für Neuerungen/Änderungen Changelog ansehen.
+A\ new\ version\ of\ JabRef\ has\ been\ released.=Eine neue JabRef Version wurde veröffentlicht.
+JabRef\ is\ up-to-date.=JabRef ist auf dem aktuellsten Stand.
+Latest\ version=Neueste Version
+Online\ help\ forum=Online-Hilfeforum
 Custom=Benutzerdefiniert
 
-Export_cited=Exportiere_zitierte_Einträge
-Unable_to_generate_new_library=Kann_keine_neue_Bibliothek_generieren
+Export\ cited=Exportiere zitierte Einträge
+Unable\ to\ generate\ new\ library=Kann keine neue Bibliothek generieren
 
-Open_console=Terminal_öffnen
-Use_default_terminal_emulator=Standard_Terminal-Emulator_verwenden
-Execute_command=Befehl_ausführen
-Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.=Hinweis\:_%0_als_Platzhalter_für_den_Speicherort_der_Bibliothek_benutzen.
-Executing_command_\"%0\"...=Ausführung_des_Kommandos_\"%0\"...
-Error_occured_while_executing_the_command_\"%0\".=Während_der_Ausführung_des_Befehls_\"%0\"_ist_ein_Fehler_aufgetreten.
-Reformat_ISSN=Formatiere_ISSN
+Open\ console=Terminal öffnen
+Use\ default\ terminal\ emulator=Standard Terminal-Emulator verwenden
+Execute\ command=Befehl ausführen
+Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=Hinweis: %0 als Platzhalter für den Speicherort der Bibliothek benutzen.
+Executing\ command\ \"%0\"...=Ausführung des Kommandos \"%0\"...
+Error\ occured\ while\ executing\ the\ command\ \"%0\".=Während der Ausführung des Befehls \"%0\" ist ein Fehler aufgetreten.
+Reformat\ ISSN=Formatiere ISSN
 
-Countries_and_territories_in_English=Länder_und_Territorien_in_Englisch
-Electrical_engineering_terms=Begriffe_aus_der_Elektrotechnik
+Countries\ and\ territories\ in\ English=Länder und Territorien in Englisch
+Electrical\ engineering\ terms=Begriffe aus der Elektrotechnik
 Enabled=Aktiviert
-Internal_list=Interne_Liste
-Manage_protected_terms_files=Verwalte_geschützte_Begriffsdatei
-Months_and_weekdays_in_English=Monate_und_Wochentage_in_Englisch
-The_text_after_the_last_line_starting_with_\#_will_be_used=Der_Text_nach_der_letzten_Zeile_die,_mit_\#_beginnt,_wird_benutzt
-Add_protected_terms_file=Füge_geschützte_Begriffsdatei_hinzu
-Are_you_sure_you_want_to_remove_the_protected_terms_file?=Sind_Sie_sicher,_dass_Sie_die_geschützte_Begriffsdatei_löschen_wollen?
-Remove_protected_terms_file=Lösche_geschützte_Begriffsdatei
-Add_selected_text_to_list=Markierten_Text_zur_Liste_hinzufügen
-Add_{}_around_selected_text={}_um_markierten_Text_einfügen
-Format_field=Formatfeld
-New_protected_terms_file=Neue_geschützte_Begriffsdatei
-change_field_%0_of_entry_%1_from_%2_to_%3=Ändere_Feld_%0_von_Eintrag_%1_von_%2_auf_%3
-change_key_from_%0_to_%1=Ändere_Key_von_%0_auf_%1
-change_string_content_%0_to_%1=Ändere_Stringinhalt_von_%0_auf_%1
-change_string_name_%0_to_%1=Ändere_Stringnamen_von_%0_auf_%1
-change_type_of_entry_%0_from_%1_to_%2=Ändere_Typ_des_Eintrags_%0_auf_%1
-insert_entry_%0=Füge_Eintrag_%0_hinzu
-insert_string_%0=Füge_String_%0_hinzu
-remove_entry_%0=Entferne_Eintrag_%0
-remove_string_%0=Entferne_String_%0
+Internal\ list=Interne Liste
+Manage\ protected\ terms\ files=Verwalte geschützte Begriffsdatei
+Months\ and\ weekdays\ in\ English=Monate und Wochentage in Englisch
+The\ text\ after\ the\ last\ line\ starting\ with\ \#\ will\ be\ used=Der Text nach der letzten Zeile die, mit # beginnt, wird benutzt
+Add\ protected\ terms\ file=Füge geschützte Begriffsdatei hinzu
+Are\ you\ sure\ you\ want\ to\ remove\ the\ protected\ terms\ file?=Sind Sie sicher, dass Sie die geschützte Begriffsdatei löschen wollen?
+Remove\ protected\ terms\ file=Lösche geschützte Begriffsdatei
+Add\ selected\ text\ to\ list=Markierten Text zur Liste hinzufügen
+Add\ {}\ around\ selected\ text={} um markierten Text einfügen
+Format\ field=Formatfeld
+New\ protected\ terms\ file=Neue geschützte Begriffsdatei
+change\ field\ %0\ of\ entry\ %1\ from\ %2\ to\ %3=Ändere Feld %0 von Eintrag %1 von %2 auf %3
+change\ key\ from\ %0\ to\ %1=Ändere Key von %0 auf %1
+change\ string\ content\ %0\ to\ %1=Ändere Stringinhalt von %0 auf %1
+change\ string\ name\ %0\ to\ %1=Ändere Stringnamen von %0 auf %1
+change\ type\ of\ entry\ %0\ from\ %1\ to\ %2=Ändere Typ des Eintrags %0 auf %1
+insert\ entry\ %0=Füge Eintrag %0 hinzu
+insert\ string\ %0=Füge String %0 hinzu
+remove\ entry\ %0=Entferne Eintrag %0
+remove\ string\ %0=Entferne String %0
 undefined=unbekannt
-Cannot_get_info_based_on_given_%0\:_%1=Informationen_können_für_den_angegebenen_%0_'%1'_nicht_ermittelt_werden.
-Get_BibTeX_data_from_%0=Hole_BibTeX-Daten_durch_%0
-No_%0_found=Keine_%0_gefunden
-Entry_from_%0=Eintrag_basierend_auf_%0
-Merge_entry_with_%0_information=Eintrag_mit_%0-Informationen_zusammenführen
-Updated_entry_with_info_from_%0=Eintrag_wurde_mit_%0-Information_aktualisiert.
+Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=Informationen können für den angegebenen %0 '%1' nicht ermittelt werden.
+Get\ BibTeX\ data\ from\ %0=Hole BibTeX-Daten durch %0
+No\ %0\ found=Keine %0 gefunden
+Entry\ from\ %0=Eintrag basierend auf %0
+Merge\ entry\ with\ %0\ information=Eintrag mit %0-Informationen zusammenführen
+Updated\ entry\ with\ info\ from\ %0=Eintrag wurde mit %0-Information aktualisiert.
 
-Add_existing_file=Vorhandene_Datei_hinzufügen
-Create_new_list=Neue_Liste_erstellen
-Remove_list=Liste_entfernen
-Full_journal_name=Voller_Zeitschriftentitel
-Abbreviation_name=Name_der_Abkürzung
+Add\ existing\ file=Vorhandene Datei hinzufügen
+Create\ new\ list=Neue Liste erstellen
+Remove\ list=Liste entfernen
+Full\ journal\ name=Voller Zeitschriftentitel
+Abbreviation\ name=Name der Abkürzung
 
-No_abbreviation_files_loaded=Keine_Datei_mit_Abkürzungen_geladen
+No\ abbreviation\ files\ loaded=Keine Datei mit Abkürzungen geladen
 
-Loading_built_in_lists=Lade_integrierte_Listen
+Loading\ built\ in\ lists=Lade integrierte Listen
 
-JabRef_built_in_list=Integrierte_JabRef-Liste
-IEEE_built_in_list=Integrierte_IEEE-Liste
+JabRef\ built\ in\ list=Integrierte JabRef-Liste
+IEEE\ built\ in\ list=Integrierte IEEE-Liste
 
-Event_log=Ereignisprotokoll
-We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.=Sie_erhalten_nun_Einsicht_in_die_Interna_von_JabRef._Diese_Informationen_kann_dabei_helfen_die_eigentliche_Ursache_eines_Problems_zu_ergründen.
-Log_copied_to_clipboard.=In_die_Zwischenablage_kopiert
-Copy_Log=Log_kopieren
-Clear_Log=Log_löschen
-Report_Issue=Problem_melden
-Issue_on_GitHub_successfully_reported.=Problem_erfolgreich_auf_GitHub_gemeldet.
-Issue_report_successful=Problemreport_war_erfolgreich
-Your_issue_was_reported_in_your_browser.=Ihr_Problem_wurde_im_Browser_gemeldet.
-The_log_and_exception_information_was_copied_to_your_clipboard.=Die_Log_und_Ausnahmefehler-Informationen_wurden_in_die_Zwischenablage_kopiert.
-Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.=Bitte_fügen_Sie_die_Informationen_(mit_STRG+V)_in_die_Problembeschreibung_ein.
+Event\ log=Ereignisprotokoll
+We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef\'s\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=Sie erhalten nun Einsicht in die Interna von JabRef. Diese Informationen kann dabei helfen die eigentliche Ursache eines Problems zu ergründen.
+Log\ copied\ to\ clipboard.=In die Zwischenablage kopiert
+Copy\ Log=Log kopieren
+Clear\ Log=Log löschen
+Report\ Issue=Problem melden
+Issue\ on\ GitHub\ successfully\ reported.=Problem erfolgreich auf GitHub gemeldet.
+Issue\ report\ successful=Problemreport war erfolgreich
+Your\ issue\ was\ reported\ in\ your\ browser.=Ihr Problem wurde im Browser gemeldet.
+The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=Die Log und Ausnahmefehler-Informationen wurden in die Zwischenablage kopiert.
+Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=Bitte fügen Sie die Informationen (mit STRG+V) in die Problembeschreibung ein.
 
 Connection=Verbindung
 Connecting...=Verbinde...
@@ -2164,194 +2164,194 @@ Port=Port
 Library=Bibliothek
 User=Benutzer
 Connect=Verbinden
-Connection_error=Verbindungsfehler
-Connection_to_%0_server_established.=Verbindung_zum_%0_Server_hergestellt.
-Required_field_"%0"_is_empty.=Erforederliches_Feld_"%0"_ist_leer.
-%0_driver_not_available.=%0-Treiber_nicht_verfügbar.
-The_connection_to_the_server_has_been_terminated.=Verbindung_zum_Server_wurde_abgebrochen.
-Connection_lost.=Verbindung_verloren.
-Reconnect=Neu_verbinden.
-Work_offline=Offline_arbeiten.
-Working_offline.=Arbeite_offline.
-Update_refused.=Aktualisierung_verweigert.
-Update_refused=Aktualisierung_verweigert
-Local_entry=Lokaler_Eintrag
-Shared_entry=Gemeinsam_genutzter_Eintrag
-Update_could_not_be_performed_due_to_existing_change_conflicts.=Aktualisierung_konnte_wegen_Konflikten_nicht_durchgeführt_werden.
-You_are_not_working_on_the_newest_version_of_BibEntry.=Sie_arbeiten_nicht_mit_der_neusten_Version_von_BibEntry.
-Local_version\:_%0=Lokale_Version\:_%0
-Shared_version\:_%0=Geteilte_genutzte_Version\:_%0
-Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.=Bitte_führen_Sie_den_gemeinsam_genutzten_Eintrag_mit_Ihrem_zusammen_und_klicken_Sie_auf_"Einträge_zuammenführen",_um_das_Problem_zu_beheben.
-Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?=Durch_einen_Abbruch_dieser_Operation_werden_die_Änderungen_nicht_synchronisiert._Trotzdem_abbrechen?
-Shared_entry_is_no_longer_present=Geteilter_Eintrag_ist_nicht_mehr_vorhanden
-The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.=Der_Eintrag,_welchen_Sie_zur_Zeit_bearbeiten,_ist_auf_der_geteilten_Datenbank_nicht_mehr_vorhanden.
-You_can_restore_the_entry_using_the_"Undo"_operation.=Unter_Benutzung_der_"Rückgängig"-Funktion_kann_der_Eintrag_wiederhergestellt_werden.
-Remember_password?=Passwort_merken?
-You_are_already_connected_to_a_database_using_entered_connection_details.=Eine_Datenbankverbindung_mit_den_eingegebenen_Verbindungsinformationen_besteht_bereits.
+Connection\ error=Verbindungsfehler
+Connection\ to\ %0\ server\ established.=Verbindung zum %0 Server hergestellt.
+Required\ field\ "%0"\ is\ empty.=Erforederliches Feld "%0" ist leer.
+%0\ driver\ not\ available.=%0-Treiber nicht verfügbar.
+The\ connection\ to\ the\ server\ has\ been\ terminated.=Verbindung zum Server wurde abgebrochen.
+Connection\ lost.=Verbindung verloren.
+Reconnect=Neu verbinden.
+Work\ offline=Offline arbeiten.
+Working\ offline.=Arbeite offline.
+Update\ refused.=Aktualisierung verweigert.
+Update\ refused=Aktualisierung verweigert
+Local\ entry=Lokaler Eintrag
+Shared\ entry=Gemeinsam genutzter Eintrag
+Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=Aktualisierung konnte wegen Konflikten nicht durchgeführt werden.
+You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=Sie arbeiten nicht mit der neusten Version von BibEntry.
+Local\ version\:\ %0=Lokale Version: %0
+Shared\ version\:\ %0=Geteilte genutzte Version: %0
+Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=Bitte führen Sie den gemeinsam genutzten Eintrag mit Ihrem zusammen und klicken Sie auf "Einträge zuammenführen", um das Problem zu beheben.
+Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=Durch einen Abbruch dieser Operation werden die Änderungen nicht synchronisiert. Trotzdem abbrechen?
+Shared\ entry\ is\ no\ longer\ present=Geteilter Eintrag ist nicht mehr vorhanden
+The\ BibEntry\ you\ currently\ work\ on\ has\ been\ deleted\ on\ the\ shared\ side.=Der Eintrag, welchen Sie zur Zeit bearbeiten, ist auf der geteilten Datenbank nicht mehr vorhanden.
+You\ can\ restore\ the\ entry\ using\ the\ "Undo"\ operation.=Unter Benutzung der "Rückgängig"-Funktion kann der Eintrag wiederhergestellt werden.
+Remember\ password?=Passwort merken?
+You\ are\ already\ connected\ to\ a\ database\ using\ entered\ connection\ details.=Eine Datenbankverbindung mit den eingegebenen Verbindungsinformationen besteht bereits.
 
-Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?=Kann_keine_Einträge_ohne_BibTeX-Key_zitieren._Keys_jetzt_generieren?
-New_technical_report=Neuer_technischer_Bericht
+Cannot\ cite\ entries\ without\ BibTeX\ keys.\ Generate\ keys\ now?=Kann keine Einträge ohne BibTeX-Key zitieren. Keys jetzt generieren?
+New\ technical\ report=Neuer technischer Bericht
 
-%0_file=%0-Datei
-Custom_layout_file=Benutzerdefinierte_Layoutdatei
-Protected_terms_file=Geschützte_Begriffsdatei
-Style_file=Stildatei
+%0\ file=%0-Datei
+Custom\ layout\ file=Benutzerdefinierte Layoutdatei
+Protected\ terms\ file=Geschützte Begriffsdatei
+Style\ file=Stildatei
 
-Open_OpenOffice/LibreOffice_connection=Öffne_OpenOffice/LibreOffice_Verbindung
-You_must_enter_at_least_one_field_name=Sie_müssen_mindestens_einen_Feldnamen_angeben
-Non-ASCII_encoded_character_found=Nicht_ASCII-kodiertes_Zeichen_gefunden
-Toggle_web_search_interface=Websuche_ein-/ausschalten
-Background_color_for_resolved_fields=Hintergrundfarbe_für_referenzierte_Felder
-Color_code_for_resolved_fields=Farbanzeige_für_referenzierte_Felder
-%0_files_found=%0_Dateien_gefunden
-%0_of_%1=%0_von_%1
-One_file_found=Eine_Datei_gefunden
-The_import_finished_with_warnings\:=Der_Import_wurde_mit_Warnungen_abgeschlossen\:
-There_was_one_file_that_could_not_be_imported.=Eine_Datei_konnte_nicht_importiert_werden.
-There_were_%0_files_which_could_not_be_imported.=%0_Dateien_konnten_nicht_importiert_werden.
+Open\ OpenOffice/LibreOffice\ connection=Öffne OpenOffice/LibreOffice Verbindung
+You\ must\ enter\ at\ least\ one\ field\ name=Sie müssen mindestens einen Feldnamen angeben
+Non-ASCII\ encoded\ character\ found=Nicht ASCII-kodiertes Zeichen gefunden
+Toggle\ web\ search\ interface=Websuche ein-/ausschalten
+Background\ color\ for\ resolved\ fields=Hintergrundfarbe für referenzierte Felder
+Color\ code\ for\ resolved\ fields=Farbanzeige für referenzierte Felder
+%0\ files\ found=%0 Dateien gefunden
+%0\ of\ %1=%0 von %1
+One\ file\ found=Eine Datei gefunden
+The\ import\ finished\ with\ warnings\:=Der Import wurde mit Warnungen abgeschlossen:
+There\ was\ one\ file\ that\ could\ not\ be\ imported.=Eine Datei konnte nicht importiert werden.
+There\ were\ %0\ files\ which\ could\ not\ be\ imported.=%0 Dateien konnten nicht importiert werden.
 
-Migration_help_information=Hilfe_zur_Migration
-Entered_database_has_obsolete_structure_and_is_no_longer_supported.=Die_gewählte_Datenbank_nutzt_eine_veraltete,_nicht_mehr_unterstützte_Struktur.
-However,_a_new_database_was_created_alongside_the_pre-3.6_one.=Dennoch_wurde_eine_neue_Datenbank_neben_der_alten_Datenbank_erzeugt.
-Click_here_to_learn_about_the_migration_of_pre-3.6_databases.=Klicken_um_Informationen_zur_Migration_von_vor-3.6-Datenbanken_zu_erhalten.
-Opens_JabRef's_Facebook_page=Öffnet_JabRefs_Facebookseite
-Opens_JabRef's_blog=Öffnet_JabRefs_Blog
-Opens_JabRef's_website=Öffnet_JabRefs_Webseite
-Opens_a_link_where_the_current_development_version_can_be_downloaded=Öffnet_eine_Seite_auf_der_die_aktuellste_Entwicklungsversion_heruntergeladen_werden_kann
-See_what_has_been_changed_in_the_JabRef_versions=Beschreibt_was_in_den_verschiedenen_JabRef-Versionen_geändert_wurde
-Referenced_BibTeX_key_does_not_exist=Referenzierter_BibTeX-Key_existiert_nicht
-Finished_downloading_full_text_document_for_entry_%0.=Download_des_Volltextdokuments_für_Eintrag_%0_komplett
-Full_text_document_download_failed_for_entry_%0.=Download_des_Volltextdokuments_für_Eintrag_%0_fehlgeschlagen
-Look_up_full_text_documents=Volltextdokumente_suchen
-You_are_about_to_look_up_full_text_documents_for_%0_entries.=Sie_werden_gleich_Volltextdokumente_für_%0_Einträge_suchen
-last_four_nonpunctuation_characters_should_be_numerals=Die_letzten_vier_Nichtinterpunktionszeichen_sollten_Ziffern_sein
+Migration\ help\ information=Hilfe zur Migration
+Entered\ database\ has\ obsolete\ structure\ and\ is\ no\ longer\ supported.=Die gewählte Datenbank nutzt eine veraltete, nicht mehr unterstützte Struktur.
+However,\ a\ new\ database\ was\ created\ alongside\ the\ pre-3.6\ one.=Dennoch wurde eine neue Datenbank neben der alten Datenbank erzeugt.
+Click\ here\ to\ learn\ about\ the\ migration\ of\ pre-3.6\ databases.=Klicken um Informationen zur Migration von vor-3.6-Datenbanken zu erhalten.
+Opens\ JabRef's\ Facebook\ page=Öffnet JabRefs Facebookseite
+Opens\ JabRef's\ blog=Öffnet JabRefs Blog
+Opens\ JabRef's\ website=Öffnet JabRefs Webseite
+Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=Öffnet eine Seite auf der die aktuellste Entwicklungsversion heruntergeladen werden kann
+See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=Beschreibt was in den verschiedenen JabRef-Versionen geändert wurde
+Referenced\ BibTeX\ key\ does\ not\ exist=Referenzierter BibTeX-Key existiert nicht
+Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=Download des Volltextdokuments für Eintrag %0 komplett
+Full\ text\ document\ download\ failed\ for\ entry\ %0.=Download des Volltextdokuments für Eintrag %0 fehlgeschlagen
+Look\ up\ full\ text\ documents=Volltextdokumente suchen
+You\ are\ about\ to\ look\ up\ full\ text\ documents\ for\ %0\ entries.=Sie werden gleich Volltextdokumente für %0 Einträge suchen
+last\ four\ nonpunctuation\ characters\ should\ be\ numerals=Die letzten vier Nichtinterpunktionszeichen sollten Ziffern sein
 
 Author=Autor
 Date=Datum
-File_annotations=Annotationen
-Show_file_annotations=Zeige_Annotationen_im_PDF
-Adobe_Acrobat_Reader=Adobe_Acrobat_Reader
-Sumatra_Reader=Sumatra_Reader
+File\ annotations=Annotationen
+Show\ file\ annotations=Zeige Annotationen im PDF
+Adobe\ Acrobat\ Reader=Adobe Acrobat Reader
+Sumatra\ Reader=Sumatra Reader
 shared=geteilt
-should_contain_an_integer_or_a_literal=Sollte_einen_Integer_oder_einen_Literal_enthalten
-should_have_the_first_letter_capitalized=Sollte_den_ersten_Buchstaben_großgeschrieben_haben
+should\ contain\ an\ integer\ or\ a\ literal=Sollte einen Integer oder einen Literal enthalten
+should\ have\ the\ first\ letter\ capitalized=Sollte den ersten Buchstaben großgeschrieben haben
 Tools=Werkzeuge
-What\'s_new_in_this_version?=Neuerungen_in_dieser_Version
-Want_to_help?=Wollen_Sie_helfen?
-Make_a_donation=Spenden
-get_involved=Engagieren_Sie_sich
-Used_libraries=Benutzte_Softwarebibliotheken
-Existing_file=Existierende_Datei
+What\'s\ new\ in\ this\ version?=Neuerungen in dieser Version
+Want\ to\ help?=Wollen Sie helfen?
+Make\ a\ donation=Spenden
+get\ involved=Engagieren Sie sich
+Used\ libraries=Benutzte Softwarebibliotheken
+Existing\ file=Existierende Datei
 
 ID=ID
-ID_type=ID-Typ
-ID-based_entry_generator=ID-basierter_Eintragsgenerator
-Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=Der_%0-Fetcher_hat_keinen_Eintrag_für_die_ID_'%1'_gefunden.
+ID\ type=ID-Typ
+ID-based\ entry\ generator=ID-basierter Eintragsgenerator
+Fetcher\ '%0'\ did\ not\ find\ an\ entry\ for\ id\ '%1'.=Der %0-Fetcher hat keinen Eintrag für die ID '%1' gefunden.
 
-Select_first_entry=Ersten_Eintrag_auswählen
-Select_last_entry=Letzten_Eintrag_auswählen
+Select\ first\ entry=Ersten Eintrag auswählen
+Select\ last\ entry=Letzten Eintrag auswählen
 
-Invalid_ISBN\:_'%0'.=Ungültige_ISBN\:_'%0'.
-should_be_an_integer_or_normalized=Sollte_ein_Integer_oder_normalisiert_sein
-should_be_normalized=Sollte_normalisiert_sein
+Invalid\ ISBN\:\ '%0'.=Ungültige ISBN: '%0'.
+should\ be\ an\ integer\ or\ normalized=Sollte ein Integer oder normalisiert sein
+should\ be\ normalized=Sollte normalisiert sein
 
-Empty_search_ID=Leere_Such-ID
-The_given_search_ID_was_empty.=Die_übergebene_Such-ID_ist_leer.
-Copy_BibTeX_key_and_link=BibTeX-Key_und_Link_kopieren
-empty_BibTeX_key=Leerer_BibTeX-Key
-biblatex_field_only=Nur_ein_biblatex-Feld
+Empty\ search\ ID=Leere Such-ID
+The\ given\ search\ ID\ was\ empty.=Die übergebene Such-ID ist leer.
+Copy\ BibTeX\ key\ and\ link=BibTeX-Key und Link kopieren
+empty\ BibTeX\ key=Leerer BibTeX-Key
+biblatex\ field\ only=Nur ein biblatex-Feld
 
-Error_while_generating_fetch_URL=Fehler_beim_generieren_der_Abruf_URL
-Error_while_parsing_ID_list=Fehler_beim_parsen_der_ID-Liste
-Unable_to_get_PubMed_IDs=Es_ist_nicht_möglich_die_PubMed_ID's_zu_bekommen
-Backup_found=Backup_gefunden
-A_backup_file_for_'%0'_was_found.=Es_wurde_eine_Backup-Datei_für_'%0'_gefunden.
-This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.=Dies_kann_bedeuten,_dass_JabRef_bei_der_letzten_Benutzung_nicht_korrekt_beendet_wurde.
-Do_you_want_to_recover_the_library_from_the_backup_file?=Möchten_Sie_die_Bibliothek_mit_Hilfe_der_Backup-Datei_wiederherstellen?
-Firstname_Lastname=Vorname_Nachname
+Error\ while\ generating\ fetch\ URL=Fehler beim generieren der Abruf URL
+Error\ while\ parsing\ ID\ list=Fehler beim parsen der ID-Liste
+Unable\ to\ get\ PubMed\ IDs=Es ist nicht möglich die PubMed ID's zu bekommen
+Backup\ found=Backup gefunden
+A\ backup\ file\ for\ '%0'\ was\ found.=Es wurde eine Backup-Datei für '%0' gefunden.
+This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Dies kann bedeuten, dass JabRef bei der letzten Benutzung nicht korrekt beendet wurde.
+Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Möchten Sie die Bibliothek mit Hilfe der Backup-Datei wiederherstellen?
+Firstname\ Lastname=Vorname Nachname
 
-Recommended_for_%0=Empfohlen_für_%0
-Show_'Related_Articles'_tab=Reiter_für_Empfehlungen_anzeigen
-This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=Dies_kann_durch_eine_Downloadbeschränkung_von_Google_Scholar_ausgelöst_werden_(mehr_Details_in_der_'Hilfe').
+Recommended\ for\ %0=Empfohlen für %0
+Show\ 'Related\ Articles'\ tab=Reiter für Empfehlungen anzeigen
+This\ might\ be\ caused\ by\ reaching\ the\ traffic\ limitation\ of\ Google\ Scholar\ (see\ 'Help'\ for\ details).=Dies kann durch eine Downloadbeschränkung von Google Scholar ausgelöst werden (mehr Details in der 'Hilfe').
 
-Could_not_open_website.=Konnte_Webseite_nicht_öffnen.
-Problem_downloading_from_%1=Problem_beim_Download_von_%1
+Could\ not\ open\ website.=Konnte Webseite nicht öffnen.
+Problem\ downloading\ from\ %1=Problem beim Download von %1
 
-File_directory_pattern=Dateiverzeichnis-Pattern
-Update_with_bibliographic_information_from_the_web=Aktualisiere_mit_bibliographischen_Information_aus_dem_Internet
+File\ directory\ pattern=Dateiverzeichnis-Pattern
+Update\ with\ bibliographic\ information\ from\ the\ web=Aktualisiere mit bibliographischen Information aus dem Internet
 
-Could_not_find_any_bibliographic_information.=Keine_bibliographischen_Informationen_gefunden.
-BibTeX_key_deviates_from_generated_key=BibTeX-Key_weicht_vom_generierten_Key_ab
-DOI_%0_is_invalid=DOI_%0_ist_ungültig
+Could\ not\ find\ any\ bibliographic\ information.=Keine bibliographischen Informationen gefunden.
+BibTeX\ key\ deviates\ from\ generated\ key=BibTeX-Key weicht vom generierten Key ab
+DOI\ %0\ is\ invalid=DOI %0 ist ungültig
 
-Select_all_customized_types_to_be_stored_in_local_preferences=Wählen_Sie_alle_angepassten_Eintragstypen,_die_in_den_lokalen_Einstellungen_gespeichert_werden_sollen
-Currently_unknown=Derzeit_unbekannt
-Different_customization,_current_settings_will_be_overwritten=Abweichende_Anpassung_eines_Typs,_bestehende_Anpassungen_werden_überschrieben
+Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences=Wählen Sie alle angepassten Eintragstypen, die in den lokalen Einstellungen gespeichert werden sollen
+Currently\ unknown=Derzeit unbekannt
+Different\ customization,\ current\ settings\ will\ be\ overwritten=Abweichende Anpassung eines Typs, bestehende Anpassungen werden überschrieben
 
-Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX=Eintragstyp_%0_ist_nur_für_Biblatex,_nicht_aber_für_BibTeX_definiert
-Jump_to_entry=Springe_zu_Eintrag
+Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=Eintragstyp %0 ist nur für Biblatex, nicht aber für BibTeX definiert
+Jump\ to\ entry=Springe zu Eintrag
 
-Copied_%0_citations.=Es_wurden_%0_Zitierungen_kopiert.
+Copied\ %0\ citations.=Es wurden %0 Zitierungen kopiert.
 Copying...=Kopiere...
 
-journal_not_found_in_abbreviation_list=Journal_nicht_in_Abkürzungsliste_gefunden
-Unhandled_exception_occurred.=Unbehandelte_Ausnahme_aufgetreten.
+journal\ not\ found\ in\ abbreviation\ list=Journal nicht in Abkürzungsliste gefunden
+Unhandled\ exception\ occurred.=Unbehandelte Ausnahme aufgetreten.
 
-strings_included=Strings_eingeschlossen
-Color_for_disabled_icons=Farbe_für_deaktivierte_Icons
-Color_for_enabled_icons=Farbe_für_aktivierte_Icons
-Size_of_large_icons=Größe_für_große_Icons
-Size_of_small_icons=Größe_für_kleine_Icon
-Default_table_font_size=Standard_Tabellenschriftgröße
-Escape_underscores=Unterstriche_maskieren
+strings\ included=Strings eingeschlossen
+Color\ for\ disabled\ icons=Farbe für deaktivierte Icons
+Color\ for\ enabled\ icons=Farbe für aktivierte Icons
+Size\ of\ large\ icons=Größe für große Icons
+Size\ of\ small\ icons=Größe für kleine Icon
+Default\ table\ font\ size=Standard Tabellenschriftgröße
+Escape\ underscores=Unterstriche maskieren
 Color=Farbe
-Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=Bitte_geben_Sie,_falls_möglich,_alle_Schritte_zum_reproduzieren_des_Fehlers_an.
-Fit_width=Auf_Breite_anpassen
-Fit_a_single_page=Auf_eine_Seite_anpassen
-Zoom_in=Reinzoomen
-Zoom_out=Rauszoomen
-Previous_page=Vorherige_Seite
-Next_page=Nächste_Seite
-Document_viewer=Dokumententenbetrachter
+Please\ also\ add\ all\ steps\ to\ reproduce\ this\ issue,\ if\ possible.=Bitte geben Sie, falls möglich, alle Schritte zum reproduzieren des Fehlers an.
+Fit\ width=Auf Breite anpassen
+Fit\ a\ single\ page=Auf eine Seite anpassen
+Zoom\ in=Reinzoomen
+Zoom\ out=Rauszoomen
+Previous\ page=Vorherige Seite
+Next\ page=Nächste Seite
+Document\ viewer=Dokumententenbetrachter
 Live=Live
 Locked=Gesperrt
-Show_document_viewer=Zeige_Dokumentenbetrachter
-Show_the_document_of_the_currently_selected_entry.=Zeige_das_Dokument_zum_selektierten_Eintrag.
-Show_this_document_until_unlocked.=Zeige_dieses_Dokument_solange_bis_es_entsperrt_wurde.
-Set_current_user_name_as_owner.=Setze_den_aktuellen_Benutzernamen_als_Besitzer.
+Show\ document\ viewer=Zeige Dokumentenbetrachter
+Show\ the\ document\ of\ the\ currently\ selected\ entry.=Zeige das Dokument zum selektierten Eintrag.
+Show\ this\ document\ until\ unlocked.=Zeige dieses Dokument solange bis es entsperrt wurde.
+Set\ current\ user\ name\ as\ owner.=Setze den aktuellen Benutzernamen als Besitzer.
 
-Sort_all_subgroups_(recursively)=Sortiere_alle_Untergruppen_(rekursiv)
-Collect_and_share_telemetry_data_to_help_improve_JabRef.=Sammle_und_teile_Telemetriedaten,_um_bei_der_Verbesserung_von_JabRef_zu_unterstützen.
-Don't_share=Nicht_teilen
-Share_anonymous_statistics=Teile_anonyme_Statistiken
-Telemetry\:_Help_make_JabRef_better=Telemetrie\:_Helfen_Sie,_JabRef_zu_verbessern
-To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.=Zur_Verbesserung_der_Benutzererfahrung_würden_wir_gerne_anonyme_Statistiken_über_die_Features_sammeln,_die_Sie_benutzen._Wir_zeichnen_nur_auf,_welche_Features_Sie_nutzen_und_wie_oft_Sie_diese_benutzen._Es_werden_keinerlei_persönliche_Informationen_über_Sie_oder_den_Inhalt_Ihrer_Bibliografieeinträge_gesammelt._Die_einmal_erlaubte_Datenaufzeichnnung_kann_jederzeit_unter_Optionen->Einstellungen->Allgemein_deaktiviert_werden.
-This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?=Diese_Datei_wurde_automatisch_gefunden._Möchten_Sie_sie_dem_Eintrag_zuordnen?
-Names_are_not_in_the_standard_%0_format.=Namen_entsprechen_nicht_dem_Standard_%0-Format
+Sort\ all\ subgroups\ (recursively)=Sortiere alle Untergruppen (rekursiv)
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=Sammle und teile Telemetriedaten, um bei der Verbesserung von JabRef zu unterstützen.
+Don't\ share=Nicht teilen
+Share\ anonymous\ statistics=Teile anonyme Statistiken
+Telemetry\:\ Help\ make\ JabRef\ better=Telemetrie: Helfen Sie, JabRef zu verbessern
+To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ statistics\ on\ the\ features\ you\ use.\ We\ will\ only\ record\ what\ features\ you\ access\ and\ how\ often\ you\ do\ it.\ We\ will\ neither\ collect\ any\ personal\ data\ nor\ the\ content\ of\ bibliographic\ items.\ If\ you\ choose\ to\ allow\ data\ collection,\ you\ can\ later\ disable\ it\ via\ Options\ ->\ Preferences\ ->\ General.=Zur Verbesserung der Benutzererfahrung würden wir gerne anonyme Statistiken über die Features sammeln, die Sie benutzen. Wir zeichnen nur auf, welche Features Sie nutzen und wie oft Sie diese benutzen. Es werden keinerlei persönliche Informationen über Sie oder den Inhalt Ihrer Bibliografieeinträge gesammelt. Die einmal erlaubte Datenaufzeichnnung kann jederzeit unter Optionen->Einstellungen->Allgemein deaktiviert werden.
+This\ file\ was\ found\ automatically.\ Do\ you\ want\ to\ link\ it\ to\ this\ entry?=Diese Datei wurde automatisch gefunden. Möchten Sie sie dem Eintrag zuordnen?
+Names\ are\ not\ in\ the\ standard\ %0\ format.=Namen entsprechen nicht dem Standard %0-Format
 
-Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.=Die_ausgewählte_Datei_unwiderruflich_löschen_oder_nur_vom_Eintrag_entfernen?_Drücken_sie_Entfernen,_um_die_Datei_von_der_Festplatte_zu_löschen.
-Delete_'%0'=Lösche_Datei_'%0'
-Delete_from_disk=Auf_der_Festplatte_löschen
-Remove_from_entry=Vom_Eintrag_entfernen
-The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.=Der_Gruppename_enthält_das_Trennzeichen_"%0"_und_wird_deswegen_möglicherweise_nicht_wie_erwartet_funktionieren.
-There_exists_already_a_group_with_the_same_name.=Es_existiert_bereits_eine_Gruppe_mit_demselben_Namen.
+Delete\ the\ selected\ file\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ file\ permanently\ from\ disk.=Die ausgewählte Datei unwiderruflich löschen oder nur vom Eintrag entfernen? Drücken sie Entfernen, um die Datei von der Festplatte zu löschen.
+Delete\ '%0'=Lösche Datei '%0'
+Delete\ from\ disk=Auf der Festplatte löschen
+Remove\ from\ entry=Vom Eintrag entfernen
+The\ group\ name\ contains\ the\ keyword\ separator\ "%0"\ and\ thus\ probably\ does\ not\ work\ as\ expected.=Der Gruppename enthält das Trennzeichen "%0" und wird deswegen möglicherweise nicht wie erwartet funktionieren.
+There\ exists\ already\ a\ group\ with\ the\ same\ name.=Es existiert bereits eine Gruppe mit demselben Namen.
 
-Copy_linked_files_to_folder...=
-Copied_file_successfully=
-Copying_files...=Copying_files...
-Copying_file_%0_of_entry_%1=
-Finished_copying=Finished_copying
-Could_not_copy_file=Could_not_copy_file
-Copied_%0_files_of_%1_sucessfully_to_%2=
-Rename_failed=Umbenennen_fehlgeschlagen
-JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.=JabRef_kann_nicht_auf_die_Datei_zugreifen,_da_sie_von_einem_anderen_Prozess_verwendet_wird.
-Show_console_output_(only_necessary_when_the_launcher_is_used)=Anzeigen_der_Konsolen-Ausgabe_(Nur_notwendig_wenn_der_Launcher_benutzt_wird)
+Copy\ linked\ files\ to\ folder...=
+Copied\ file\ successfully=
+Copying\ files...=Copying files...
+Copying\ file\ %0\ of\ entry\ %1=
+Finished\ copying=Finished copying
+Could\ not\ copy\ file=Could not copy file
+Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=
+Rename\ failed=Umbenennen fehlgeschlagen
+JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=JabRef kann nicht auf die Datei zugreifen, da sie von einem anderen Prozess verwendet wird.
+Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=Anzeigen der Konsolen-Ausgabe (Nur notwendig wenn der Launcher benutzt wird)
 
-Remove_line_breaks=Entfernen_der_Zeilenumbrüche
-Removes_all_line_breaks_in_the_field_content.=Entfernen_aller_Zeilenumbrüche_im_Inhalt_des_Feldes.
-Checking_integrity...=
+Remove\ line\ breaks=Entfernen der Zeilenumbrüche
+Removes\ all\ line\ breaks\ in\ the\ field\ content.=Entfernen aller Zeilenumbrüche im Inhalt des Feldes.
+Checking\ integrity...=
 
-Remove_hyphenated_line_breaks=
-Removes_all_hyphenated_line_breaks_in_the_field_content.=
-Note_that_currently,_JabRef_does_not_run_with_Java_9.=JabRef_kann_nicht_mit_Java_9_verwendet_werden.
-Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.=Die_verwendete_Java_Installation_(%0)_wird_nicht_unterstützt._Bitte_installieren_Sie_Version_%1_oder_neuer.
+Remove\ hyphenated\ line\ breaks=
+Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=
+Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=JabRef kann nicht mit Java 9 verwendet werden.
+Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=Die verwendete Java Installation (%0) wird nicht unterstützt. Bitte installieren Sie Version %1 oder neuer.

--- a/src/main/resources/l10n/JabRef_el.properties
+++ b/src/main/resources/l10n/JabRef_el.properties
@@ -1,8 +1,3 @@
-
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 περιέχει την συνήθη έκφραση <b>%1</b>
 
 %0\ contains\ the\ term\ <b>%1</b>=%0 περιέχει τον όρο <b>%1</b>

--- a/src/main/resources/l10n/JabRef_el.properties
+++ b/src/main/resources/l10n/JabRef_el.properties
@@ -3,156 +3,156 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-%0_contains_the_regular_expression_<b>%1</b>=%0_περιέχει_την_συνήθη_έκφραση_<b>%1</b>
+%0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 περιέχει την συνήθη έκφραση <b>%1</b>
 
-%0_contains_the_term_<b>%1</b>=%0_περιέχει_τον_όρο_<b>%1</b>
+%0\ contains\ the\ term\ <b>%1</b>=%0 περιέχει τον όρο <b>%1</b>
 
-%0_doesn't_contain_the_regular_expression_<b>%1</b>=%0_δεν_περιέχει_την_συνήθη_έκφραση_<b>%1</b>
+%0\ doesn't\ contain\ the\ regular\ expression\ <b>%1</b>=%0 δεν περιέχει την συνήθη έκφραση <b>%1</b>
 
-%0_doesn't_contain_the_term_<b>%1</b>=%0_δεν_περιέχει_τον_όρο_<b>%1</b>
+%0\ doesn't\ contain\ the\ term\ <b>%1</b>=%0 δεν περιέχει τον όρο <b>%1</b>
 
-%0_export_successful=%0_επιτυχής_εξαγωγή
+%0\ export\ successful=%0 επιτυχής εξαγωγή
 
-%0_matches_the_regular_expression_<b>%1</b>=%0_ταιριάζει_την_συνήθη_έκφραση_<b>%1</b>
+%0\ matches\ the\ regular\ expression\ <b>%1</b>=%0 ταιριάζει την συνήθη έκφραση <b>%1</b>
 
-%0_matches_the_term_<b>%1</b>=%0_ταιριάζει_τον_όρο_<b>%1</b>
+%0\ matches\ the\ term\ <b>%1</b>=%0 ταιριάζει τον όρο <b>%1</b>
 
-<field_name>=<όνομα_πεδίου>
-<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>=
+<field\ name>=<όνομα πεδίου>
+<HTML>Could\ not\ find\ file\ '%0'<BR>linked\ from\ entry\ '%1'</HTML>=
 
 <select>=<επιλογή>
 
-<select_word>=<επιλογή_λέξης>
-Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)=
-Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)=
+<select\ word>=<επιλογή λέξης>
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (ISO\ abbreviation)=
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (MEDLINE\ abbreviation)=
 
-Abbreviate_names=Ονόματα_συντομογραφιών
-Abbreviated_%0_journal_names.=Ονόματα_συντομογραφιών_%0_περιοδικών.
+Abbreviate\ names=Ονόματα συντομογραφιών
+Abbreviated\ %0\ journal\ names.=Ονόματα συντομογραφιών %0 περιοδικών.
 
 Abbreviation=Συντομογραφία
 
-About_JabRef=Σχετικά_JabRef
+About\ JabRef=Σχετικά JabRef
 
 Abstract=Περίληψη
 
 Accept=Αποδοχή
 
-Accept_change=Αποδοχή_αλλαγής
+Accept\ change=Αποδοχή αλλαγής
 
 Action=
 
-What_is_Mr._DLib?=
+What\ is\ Mr.\ DLib?=
 
 Add=Προσθήκη
 
-Add_a_(compiled)_custom_Importer_class_from_a_class_path.=
-The_path_need_not_be_on_the_classpath_of_JabRef.=
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=
+The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=
 
-Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=
-The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=
+The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=
 
-Add_a_regular_expression_for_the_key_pattern.=
+Add\ a\ regular\ expression\ for\ the\ key\ pattern.=
 
-Add_selected_entries_to_this_group=
+Add\ selected\ entries\ to\ this\ group=
 
-Add_from_folder=Προσθήκη_από_φάκελο
+Add\ from\ folder=Προσθήκη από φάκελο
 
-Add_from_JAR=Προσθήκη_από_JAR
+Add\ from\ JAR=Προσθήκη από JAR
 
-add_group=προσθήκη_ομάδας
+add\ group=προσθήκη ομάδας
 
-Add_new=Προσθήκη_νέου
+Add\ new=Προσθήκη νέου
 
-Add_subgroup=Προσθήκη_υποομάδας
+Add\ subgroup=Προσθήκη υποομάδας
 
-Add_to_group=Προσθήκη_στην_ομάδα
+Add\ to\ group=Προσθήκη στην ομάδα
 
-Added_group_"%0".=Προστέθηκε_στην_ομάδα_"%0".
+Added\ group\ "%0".=Προστέθηκε στην ομάδα "%0".
 
-Added_missing_braces.=
+Added\ missing\ braces.=
 
-Added_new=Προστέθηκε_νέο
+Added\ new=Προστέθηκε νέο
 
-Added_string=Προστέθηκε_string
+Added\ string=Προστέθηκε string
 
-Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.=
+Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ can\ be\ assigned\ manually\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ This\ process\ adds\ the\ term\ <b>%1</b>\ to\ each\ entry's\ <b>%0</b>\ field.\ Entries\ can\ be\ removed\ manually\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.\ This\ process\ removes\ the\ term\ <b>%1</b>\ from\ each\ entry's\ <b>%0</b>\ field.=
 
-Advanced=Για_προχωρημένους
-All_entries=Όλες_entries
-All_entries_of_this_type_will_be_declared_typeless._Continue?=
+Advanced=Για προχωρημένους
+All\ entries=Όλες entries
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=
 
-All_fields=Όλα_τα_πεδία
+All\ fields=Όλα τα πεδία
 
-Always_reformat_BIB_file_on_save_and_export=
+Always\ reformat\ BIB\ file\ on\ save\ and\ export=
 
-A_SAX_exception_occurred_while_parsing_'%0'\:=
+A\ SAX\ exception\ occurred\ while\ parsing\ '%0'\:=
 
 and=και
-and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.=
+and\ the\ class\ must\ be\ available\ in\ your\ classpath\ next\ time\ you\ start\ JabRef.=
 
-any_field_that_matches_the_regular_expression_<b>%0</b>=
+any\ field\ that\ matches\ the\ regular\ expression\ <b>%0</b>=
 
 Appearance=Εμφάνιση
 
 Append=
-Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library=
+Append\ contents\ from\ a\ BibTeX\ library\ into\ the\ currently\ viewed\ library=
 
-Append_library=
+Append\ library=
 
-Append_the_selected_text_to_BibTeX_field=
+Append\ the\ selected\ text\ to\ BibTeX\ field=
 Application=Εφαρμογή
 
 Apply=
 
-Arguments_passed_on_to_running_JabRef_instance._Shutting_down.=
+Arguments\ passed\ on\ to\ running\ JabRef\ instance.\ Shutting\ down.=
 
-Assign_new_file=
+Assign\ new\ file=
 
-Assign_the_original_group's_entries_to_this_group?=
+Assign\ the\ original\ group's\ entries\ to\ this\ group?=
 
-Assigned_%0_entries_to_group_"%1".=
+Assigned\ %0\ entries\ to\ group\ "%1".=
 
-Assigned_1_entry_to_group_"%0".=
+Assigned\ 1\ entry\ to\ group\ "%0".=
 
-Attach_URL=
+Attach\ URL=
 
-Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.=
+Attempt\ to\ automatically\ set\ file\ links\ for\ your\ entries.\ Automatically\ setting\ works\ if\ a\ file\ in\ your\ file\ directory<BR>or\ a\ subdirectory\ is\ named\ identically\ to\ an\ entry's\ BibTeX\ key,\ plus\ extension.=
 
-Autodetect_format=
+Autodetect\ format=
 
-Autogenerate_BibTeX_keys=
+Autogenerate\ BibTeX\ keys=
 
-Autolink_files_with_names_starting_with_the_BibTeX_key=
+Autolink\ files\ with\ names\ starting\ with\ the\ BibTeX\ key=
 
-Autolink_only_files_that_match_the_BibTeX_key=
+Autolink\ only\ files\ that\ match\ the\ BibTeX\ key=
 
-Automatically_create_groups=
+Automatically\ create\ groups=
 
-Automatically_remove_exact_duplicates=
+Automatically\ remove\ exact\ duplicates=
 
-Allow_overwriting_existing_links.=
+Allow\ overwriting\ existing\ links.=
 
-Do_not_overwrite_existing_links.=
+Do\ not\ overwrite\ existing\ links.=
 
-AUX_file_import=
+AUX\ file\ import=
 
-Available_export_formats=
+Available\ export\ formats=
 
-Available_BibTeX_fields=
+Available\ BibTeX\ fields=
 
-Available_import_formats=
+Available\ import\ formats=
 
-Background_color_for_optional_fields=
+Background\ color\ for\ optional\ fields=
 
-Background_color_for_required_fields=
+Background\ color\ for\ required\ fields=
 
-Backup_old_file_when_saving=
+Backup\ old\ file\ when\ saving=
 
-BibTeX_key_is_unique.=
+BibTeX\ key\ is\ unique.=
 
-%0_source=
+%0\ source=
 
-Broken_link=
+Broken\ link=
 
 Browse=Περιήγηση
 
@@ -160,321 +160,321 @@ by=από
 
 Cancel=Ακύρωση
 
-Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?=
+Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=
 
-Cannot_merge_this_change=
+Cannot\ merge\ this\ change=
 
-case_insensitive=
+case\ insensitive=
 
-case_sensitive=
+case\ sensitive=
 
-Case_sensitive=
+Case\ sensitive=
 
-change_assignment_of_entries=
+change\ assignment\ of\ entries=
 
-Change_case=
+Change\ case=
 
-Change_entry_type=
-Change_file_type=
+Change\ entry\ type=
+Change\ file\ type=
 
 
-Change_of_Grouping_Method=
+Change\ of\ Grouping\ Method=
 
-change_preamble=
+change\ preamble=
 
-Change_table_column_and_General_fields_settings_to_use_the_new_feature=
+Change\ table\ column\ and\ General\ fields\ settings\ to\ use\ the\ new\ feature=
 
-Changed_language_settings=Αλλαγή_ρυθμίσεων_γλώσσας
+Changed\ language\ settings=Αλλαγή ρυθμίσεων γλώσσας
 
-Changed_preamble=
+Changed\ preamble=
 
-Check_existing_file_links=Έλεγχος_συνδέσμων_υπάρχοντων_αρχείων
+Check\ existing\ file\ links=Έλεγχος συνδέσμων υπάρχοντων αρχείων
 
-Check_links=Έλεγχος_συνδέσμων
+Check\ links=Έλεγχος συνδέσμων
 
-Cite_command=
+Cite\ command=
 
-Class_name=
+Class\ name=
 
 Clear=Καθαρισμός
 
-Clear_fields=Καθαρισμός_πεδίων
+Clear\ fields=Καθαρισμός πεδίων
 
 Close=Κλείσιμο
-Close_others=
-Close_all=Κλείσιμο_όλων
+Close\ others=
+Close\ all=Κλείσιμο όλων
 
-Close_dialog=Κλείσμο_διαλόγου
+Close\ dialog=Κλείσμο διαλόγου
 
-Close_the_current_library=
+Close\ the\ current\ library=
 
-Close_window=Κλείσιμο_παραθύρου
+Close\ window=Κλείσιμο παραθύρου
 
-Closed_library=
+Closed\ library=
 
-Color_codes_for_required_and_optional_fields=
+Color\ codes\ for\ required\ and\ optional\ fields=
 
-Color_for_marking_incomplete_entries=
+Color\ for\ marking\ incomplete\ entries=
 
-Column_width=Μήκος_στήλης
+Column\ width=Μήκος στήλης
 
-Command_line_id=id_γραμμής_εντολών
+Command\ line\ id=id γραμμής εντολών
 
 
-Contained_in=Περιέχεται_σε
+Contained\ in=Περιέχεται σε
 
 Content=Περιεχόμενο
 
 Copied=Αντιγράφηκε
 
-Copied_cell_contents=
+Copied\ cell\ contents=
 
-Copied_title=
+Copied\ title=
 
-Copied_key=
+Copied\ key=
 
-Copied_titles=
+Copied\ titles=
 
-Copied_keys=
+Copied\ keys=
 
 Copy=Αντιγραφή
 
-Copy_BibTeX_key=
-Copy_file_to_file_directory=
+Copy\ BibTeX\ key=
+Copy\ file\ to\ file\ directory=
 
-Copy_to_clipboard=
+Copy\ to\ clipboard=
 
-Could_not_call_executable=
-Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.=
+Could\ not\ call\ executable=
+Could\ not\ connect\ to\ Vim\ server.\ Make\ sure\ that\ Vim\ is\ running<BR>with\ correct\ server\ name.=
 
-Could_not_export_file=
+Could\ not\ export\ file=
 
-Could_not_export_preferences=
+Could\ not\ export\ preferences=
 
-Could_not_find_a_suitable_import_format.=
-Could_not_import_preferences=
+Could\ not\ find\ a\ suitable\ import\ format.=
+Could\ not\ import\ preferences=
 
-Could_not_instantiate_%0=
-Could_not_instantiate_%0_%1=
-Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?=
-Could_not_open_link=
+Could\ not\ instantiate\ %0=
+Could\ not\ instantiate\ %0\ %1=
+Could\ not\ instantiate\ %0.\ Have\ you\ chosen\ the\ correct\ package\ path?=
+Could\ not\ open\ link=
 
-Could_not_print_preview=
+Could\ not\ print\ preview=
 
-Could_not_run_the_'vim'_program.=
+Could\ not\ run\ the\ 'vim'\ program.=
 
-Could_not_save_file.=
-Character_encoding_'%0'_is_not_supported.=
+Could\ not\ save\ file.=
+Character\ encoding\ '%0'\ is\ not\ supported.=
 
-crossreferenced_entries_included=
+crossreferenced\ entries\ included=
 
-Current_content=
+Current\ content=
 
-Current_value=
+Current\ value=
 
-Custom_entry_types=
+Custom\ entry\ types=
 
-Custom_entry_types_found_in_file=
+Custom\ entry\ types\ found\ in\ file=
 
-Customize_entry_types=
+Customize\ entry\ types=
 
-Customize_key_bindings=
+Customize\ key\ bindings=
 
 Cut=Αποκοπή
 
-cut_entries=αποκοπή_entries
+cut\ entries=αποκοπή entries
 
-cut_entry=αποκοπή_entry
+cut\ entry=αποκοπή entry
 
 
-Library_encoding=
+Library\ encoding=
 
-Library_properties=
+Library\ properties=
 
-Library_type=
+Library\ type=
 
-Date_format=
+Date\ format=
 
 Default=Προεπιλογή
 
-Default_encoding=Προεπιλεγμένη_κωδικοποίηση
+Default\ encoding=Προεπιλεγμένη κωδικοποίηση
 
-Default_grouping_field=
+Default\ grouping\ field=
 
-Default_look_and_feel=
+Default\ look\ and\ feel=
 
-Default_pattern=
+Default\ pattern=
 
-Default_sort_criteria=
-Define_'%0'=
+Default\ sort\ criteria=
+Define\ '%0'=
 
 Delete=Διαγραφή
 
-Delete_custom_format=
+Delete\ custom\ format=
 
-delete_entries=
+delete\ entries=
 
-Delete_entry=
+Delete\ entry=
 
-delete_entry=
+delete\ entry=
 
-Delete_multiple_entries=
+Delete\ multiple\ entries=
 
-Delete_rows=Διαγραφή_γραμμών
+Delete\ rows=Διαγραφή γραμμών
 
-Delete_strings=
+Delete\ strings=
 
 Deleted=Διαγράφηκε
 
-Permanently_delete_local_file=
+Permanently\ delete\ local\ file=
 
-Delimit_fields_with_semicolon,_ex.=
+Delimit\ fields\ with\ semicolon,\ ex.=
 
 Descending=
 
 Description=Περιγραφή
 
-Deselect_all=
-Deselect_all_duplicates=
+Deselect\ all=
+Deselect\ all\ duplicates=
 
-Disable_this_confirmation_dialog=
+Disable\ this\ confirmation\ dialog=
 
-Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.=
+Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups.=
 
-Display_all_error_messages=
+Display\ all\ error\ messages=
 
-Display_help_on_command_line_options=
+Display\ help\ on\ command\ line\ options=
 
-Display_only_entries_belonging_to_all_selected_groups.=
-Display_version=
+Display\ only\ entries\ belonging\ to\ all\ selected\ groups.=
+Display\ version=
 
-Do_not_abbreviate_names=
+Do\ not\ abbreviate\ names=
 
-Do_not_automatically_set=
+Do\ not\ automatically\ set=
 
-Do_not_import_entry=
+Do\ not\ import\ entry=
 
-Do_not_open_any_files_at_startup=
+Do\ not\ open\ any\ files\ at\ startup=
 
-Do_not_overwrite_existing_keys=
-Do_not_show_these_options_in_the_future=
+Do\ not\ overwrite\ existing\ keys=
+Do\ not\ show\ these\ options\ in\ the\ future=
 
-Do_not_wrap_the_following_fields_when_saving=
-Do_not_write_the_following_fields_to_XMP_Metadata\:=
+Do\ not\ wrap\ the\ following\ fields\ when\ saving=
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=
 
-Do_you_want_JabRef_to_do_the_following_operations?=
+Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=
 
-Donate_to_JabRef=Δωρεά_στο_JabRef
+Donate\ to\ JabRef=Δωρεά στο JabRef
 
 Down=Κάτω
 
-Download_file=Κατέβασμα_αρχείου
+Download\ file=Κατέβασμα αρχείου
 
 Downloading...=Κατεβαίνει...
 
-Drop_%0=
+Drop\ %0=
 
-duplicate_removal=διαγραφή_διπλότυπων
+duplicate\ removal=διαγραφή διπλότυπων
 
-Duplicate_string_name=
+Duplicate\ string\ name=
 
-Duplicates_found=Βρέθηκαν_διπλότυπα
+Duplicates\ found=Βρέθηκαν διπλότυπα
 
-Dynamic_groups=
+Dynamic\ groups=
 
-Dynamically_group_entries_by_a_free-form_search_expression=
+Dynamically\ group\ entries\ by\ a\ free-form\ search\ expression=
 
-Dynamically_group_entries_by_searching_a_field_for_a_keyword=
+Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=
 
-Each_line_must_be_on_the_following_form=
+Each\ line\ must\ be\ on\ the\ following\ form=
 
 Edit=Επεξεργασία
 
-Edit_custom_export=
-Edit_entry=Επεξεργασία_entry
-Save_file=Αποθήκευση_αρχείου
-Edit_file_type=
+Edit\ custom\ export=
+Edit\ entry=Επεξεργασία entry
+Save\ file=Αποθήκευση αρχείου
+Edit\ file\ type=
 
-Edit_group=Επεξεργασία_ομάδας
+Edit\ group=Επεξεργασία ομάδας
 
 
-Edit_preamble=
-Edit_strings=
-Editor_options=
+Edit\ preamble=
+Edit\ strings=
+Editor\ options=
 
-Empty_BibTeX_key=
+Empty\ BibTeX\ key=
 
-Grouping_may_not_work_for_this_entry.=
+Grouping\ may\ not\ work\ for\ this\ entry.=
 
-empty_library=
-Enable_word/name_autocompletion=
+empty\ library=
+Enable\ word/name\ autocompletion=
 
-Enter_URL=Εισάγετε_URL
+Enter\ URL=Εισάγετε URL
 
-Enter_URL_to_download=Εισάγετε_URL_για_κατέβασμα
+Enter\ URL\ to\ download=Εισάγετε URL για κατέβασμα
 
 entries=
 
-Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.=
+Entries\ cannot\ be\ manually\ assigned\ to\ or\ removed\ from\ this\ group.=
 
-Entries_exported_to_clipboard=
+Entries\ exported\ to\ clipboard=
 
 
 entry=
 
-Entry_editor=
+Entry\ editor=
 
-Entry_preview=
+Entry\ preview=
 
-Entry_table=
+Entry\ table=
 
-Entry_table_columns=
+Entry\ table\ columns=
 
-Entry_type=
+Entry\ type=
 
-Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters=
+Entry\ type\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=
 
-Entry_types=
+Entry\ types=
 
 Error=
-Error_exporting_to_clipboard=
+Error\ exporting\ to\ clipboard=
 
-Error_occurred_when_parsing_entry=
+Error\ occurred\ when\ parsing\ entry=
 
-Error_opening_file=
+Error\ opening\ file=
 
-Error_setting_field=
+Error\ setting\ field=
 
-Error_while_writing=
-Error_writing_to_%0_file(s).=
+Error\ while\ writing=
+Error\ writing\ to\ %0\ file(s).=
 
 
 
-'%0'_exists._Overwrite_file?=
-Overwrite_file?=
+'%0'\ exists.\ Overwrite\ file?=
+Overwrite\ file?=
 
 Export=Εξαγωγή
 
-Export_name=
+Export\ name=
 
-Export_preferences=
+Export\ preferences=
 
-Export_preferences_to_file=
+Export\ preferences\ to\ file=
 
-Export_properties=
+Export\ properties=
 
-Export_to_clipboard=
+Export\ to\ clipboard=
 
 Exporting=
 Extension=
 
-External_changes=
+External\ changes=
 
-External_file_links=
+External\ file\ links=
 
-External_programs=
+External\ programs=
 
-External_viewer_called=
+External\ viewer\ called=
 
 Fetch=
 
@@ -482,210 +482,210 @@ Field=
 
 field=
 
-Field_name=
-Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters=
+Field\ name=
+Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=
 
-Field_to_filter=
+Field\ to\ filter=
 
-Field_to_group_by=
+Field\ to\ group\ by=
 
 File=
 
 file=
-File_'%0'_is_already_open.=
+File\ '%0'\ is\ already\ open.=
 
-File_changed=
-File_directory_is_'%0'\:=
+File\ changed=
+File\ directory\ is\ '%0'\:=
 
-File_directory_is_not_set_or_does_not_exist\!=
+File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=
 
-File_exists=
+File\ exists=
 
-File_has_been_updated_externally._What_do_you_want_to_do?=
+File\ has\ been\ updated\ externally.\ What\ do\ you\ want\ to\ do?=
 
-File_not_found=
-File_type=
+File\ not\ found=
+File\ type=
 
-File_updated_externally=
+File\ updated\ externally=
 
 filename=
 
 Filename=
 
-Files_opened=
+Files\ opened=
 
 Filter=
 
-Filter_All=
+Filter\ All=
 
-Filter_None=
+Filter\ None=
 
-Finished_automatically_setting_external_links.=
+Finished\ automatically\ setting\ external\ links.=
 
-Finished_synchronizing_file_links._Entries_changed\:_%0.=
-Finished_writing_XMP-metadata._Wrote_to_%0_file(s).=
-Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).=
+Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=
+Finished\ writing\ XMP-metadata.\ Wrote\ to\ %0\ file(s).=
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=
 
-First_select_the_entries_you_want_keys_to_be_generated_for.=
+First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=
 
-Fit_table_horizontally_on_screen=
+Fit\ table\ horizontally\ on\ screen=
 
 Float=
-Float_marked_entries=
+Float\ marked\ entries=
 
-Font_family=
+Font\ family=
 
-Font_preview=
+Font\ preview=
 
-Font_size=
+Font\ size=
 
-Font_style=
+Font\ style=
 
-Font_selection=
+Font\ selection=
 
 for=
 
-Format_of_author_and_editor_names=
-Format_string=
+Format\ of\ author\ and\ editor\ names=
+Format\ string=
 
-Format_used=
-Formatter_name=
+Format\ used=
+Formatter\ name=
 
-found_in_AUX_file=
+found\ in\ AUX\ file=
 
-Full_name=Πλήρες_όνομα
+Full\ name=Πλήρες όνομα
 
 General=Γενικά
 
-General_fields=
+General\ fields=
 
 Generate=
 
-Generate_BibTeX_key=
+Generate\ BibTeX\ key=
 
-Generate_keys=
+Generate\ keys=
 
-Generate_keys_before_saving_(for_entries_without_a_key)=
-Generate_keys_for_imported_entries=
+Generate\ keys\ before\ saving\ (for\ entries\ without\ a\ key)=
+Generate\ keys\ for\ imported\ entries=
 
-Generate_now=
+Generate\ now=
 
-Generated_BibTeX_key_for=
+Generated\ BibTeX\ key\ for=
 
-Generating_BibTeX_key_for=
-Get_fulltext=
+Generating\ BibTeX\ key\ for=
+Get\ fulltext=
 
-Gray_out_non-hits=
+Gray\ out\ non-hits=
 
 Groups=Ομάδες
 
-Have_you_chosen_the_correct_package_path?=
+Have\ you\ chosen\ the\ correct\ package\ path?=
 
 Help=Βοήθεια
 
-Help_on_key_patterns=
-Help_on_regular_expression_search=
+Help\ on\ key\ patterns=
+Help\ on\ regular\ expression\ search=
 
-Hide_non-hits=
+Hide\ non-hits=
 
-Hierarchical_context=
+Hierarchical\ context=
 
 Highlight=
 Marking=
 Underline=
-Empty_Highlight=
-Empty_Marking=
-Empty_Underline=
-The_marked_area_does_not_contain_any_legible_text!=
+Empty\ Highlight=
+Empty\ Marking=
+Empty\ Underline=
+The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=
 
-Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>=
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=
 
-HTML_table=
-HTML_table_(with_Abstract_&_BibTeX)=
+HTML\ table=
+HTML\ table\ (with\ Abstract\ &\ BibTeX)=
 Icon=
 
 Ignore=Παράβλεψη
 
 Import=
 
-Import_and_keep_old_entry=
+Import\ and\ keep\ old\ entry=
 
-Import_and_remove_old_entry=
+Import\ and\ remove\ old\ entry=
 
-Import_entries=
+Import\ entries=
 
-Import_failed=
+Import\ failed=
 
-Import_file=
+Import\ file=
 
-Import_group_definitions=
+Import\ group\ definitions=
 
-Import_name=
+Import\ name=
 
-Import_preferences=
+Import\ preferences=
 
-Import_preferences_from_file=
+Import\ preferences\ from\ file=
 
-Import_strings=
+Import\ strings=
 
-Import_to_open_tab=
+Import\ to\ open\ tab=
 
-Import_word_selector_definitions=
+Import\ word\ selector\ definitions=
 
-Imported_entries=
+Imported\ entries=
 
-Imported_from_library=
+Imported\ from\ library=
 
-Importer_class=
+Importer\ class=
 
 Importing=
 
-Importing_in_unknown_format=
+Importing\ in\ unknown\ format=
 
-Include_abstracts=
-Include_entries=
+Include\ abstracts=
+Include\ entries=
 
-Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups=
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=
 
-Independent_group\:_When_selected,_view_only_this_group's_entries=
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=
 
-Work_options=
+Work\ options=
 
 Insert=
 
-Insert_rows=
+Insert\ rows=
 
 Intersection=
 
-Invalid_BibTeX_key=
+Invalid\ BibTeX\ key=
 
-Invalid_date_format=
+Invalid\ date\ format=
 
-Invalid_URL=
+Invalid\ URL=
 
-Online_help=
+Online\ help=
 
-JabRef_preferences=
+JabRef\ preferences=
 
 Join=
 
-Joins_selected_keywords_and_deletes_selected_keywords.=
+Joins\ selected\ keywords\ and\ deletes\ selected\ keywords.=
 
-Journal_abbreviations=
+Journal\ abbreviations=
 
 Keep=
 
-Keep_both=
+Keep\ both=
 
-Key_bindings=
+Key\ bindings=
 
-Key_bindings_changed=
+Key\ bindings\ changed=
 
-Key_generator_settings=
+Key\ generator\ settings=
 
-Key_pattern=
+Key\ pattern=
 
-keys_in_library=
+keys\ in\ library=
 
 Keyword=
 
@@ -693,449 +693,449 @@ Label=
 
 Language=
 
-Last_modified=
+Last\ modified=
 
-LaTeX_AUX_file=
-Leave_file_in_its_current_directory=
+LaTeX\ AUX\ file=
+Leave\ file\ in\ its\ current\ directory=
 
 Left=
 Level=
 
-Limit_to_fields=
+Limit\ to\ fields=
 
-Limit_to_selected_entries=
+Limit\ to\ selected\ entries=
 
 Link=
-Link_local_file=
-Link_to_file_%0=
+Link\ local\ file=
+Link\ to\ file\ %0=
 
-Listen_for_remote_operation_on_port=
-Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)=
+Listen\ for\ remote\ operation\ on\ port=
+Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=
 
-Look_and_feel=
-Main_file_directory=
+Look\ and\ feel=
+Main\ file\ directory=
 
-Main_layout_file=
+Main\ layout\ file=
 
-Manage_custom_exports=
+Manage\ custom\ exports=
 
-Manage_custom_imports=
-Manage_external_file_types=
+Manage\ custom\ imports=
+Manage\ external\ file\ types=
 
-Mark_entries=
+Mark\ entries=
 
-Mark_entry=
+Mark\ entry=
 
-Mark_new_entries_with_addition_date=
+Mark\ new\ entries\ with\ addition\ date=
 
-Mark_new_entries_with_owner_name=
+Mark\ new\ entries\ with\ owner\ name=
 
-Memory_stick_mode=
+Memory\ stick\ mode=
 
-Menu_and_label_font_size=
+Menu\ and\ label\ font\ size=
 
-Merged_external_changes=
+Merged\ external\ changes=
 
 Messages=
 
-Modification_of_field=
+Modification\ of\ field=
 
-Modified_group_"%0".=
+Modified\ group\ "%0".=
 
-Modified_groups=
+Modified\ groups=
 
-Modified_string=
+Modified\ string=
 
 Modify=
 
-modify_group=
+modify\ group=
 
-Move_down=
+Move\ down=
 
-Move_external_links_to_'file'_field=
+Move\ external\ links\ to\ 'file'\ field=
 
-move_group=
+move\ group=
 
-Move_up=
+Move\ up=
 
-Moved_group_"%0".=
+Moved\ group\ "%0".=
 
 Name=
-Name_formatter=
+Name\ formatter=
 
-Natbib_style=
+Natbib\ style=
 
-nested_AUX_files=
+nested\ AUX\ files=
 
 New=
 
 new=
 
-New_BibTeX_entry=
+New\ BibTeX\ entry=
 
-New_BibTeX_sublibrary=
+New\ BibTeX\ sublibrary=
 
-New_content=
+New\ content=
 
-New_library_created.=
-New_%0_library=
-New_field_value=
+New\ library\ created.=
+New\ %0\ library=
+New\ field\ value=
 
-New_group=
+New\ group=
 
-New_string=
+New\ string=
 
-Next_entry=
+Next\ entry=
 
-No_actual_changes_found.=
+No\ actual\ changes\ found.=
 
-no_base-BibTeX-file_specified=
+no\ base-BibTeX-file\ specified=
 
-no_library_generated=
+no\ library\ generated=
 
-No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.=
+No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=
 
 
-No_entries_found_for_the_search_string_'%0'=
+No\ entries\ found\ for\ the\ search\ string\ '%0'=
 
-No_entries_imported.=
+No\ entries\ imported.=
 
-No_files_found.=
+No\ files\ found.=
 
-No_GUI._Only_process_command_line_options.=
+No\ GUI.\ Only\ process\ command\ line\ options.=
 
-No_journal_names_could_be_abbreviated.=
+No\ journal\ names\ could\ be\ abbreviated.=
 
-No_journal_names_could_be_unabbreviated.=
-No_PDF_linked=
+No\ journal\ names\ could\ be\ unabbreviated.=
+No\ PDF\ linked=
 
-Open_PDF=
+Open\ PDF=
 
-No_URL_defined=
+No\ URL\ defined=
 not=
 
-not_found=
+not\ found=
 
-Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,=
+Note\ that\ you\ must\ specify\ the\ fully\ qualified\ class\ name\ for\ the\ look\ and\ feel,=
 
-Nothing_to_redo=
+Nothing\ to\ redo=
 
-Nothing_to_undo=
+Nothing\ to\ undo=
 
 occurrences=
 
 OK=
-One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=
+One\ or\ more\ file\ links\ are\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=
 
-One_or_more_keys_will_be_overwritten._Continue?=
+One\ or\ more\ keys\ will\ be\ overwritten.\ Continue?=
 
 
 Open=
 
-Open_BibTeX_library=
+Open\ BibTeX\ library=
 
-Open_library=
+Open\ library=
 
-Open_editor_when_a_new_entry_is_created=
+Open\ editor\ when\ a\ new\ entry\ is\ created=
 
-Open_file=
+Open\ file=
 
-Open_last_edited_libraries_at_startup=
+Open\ last\ edited\ libraries\ at\ startup=
 
-Connect_to_shared_database=
+Connect\ to\ shared\ database=
 
-Open_terminal_here=
+Open\ terminal\ here=
 
-Open_URL_or_DOI=
+Open\ URL\ or\ DOI=
 
-Opened_library=
+Opened\ library=
 
 Opening=
 
-Opening_preferences...=
+Opening\ preferences...=
 
-Operation_canceled.=
-Operation_not_supported=
+Operation\ canceled.=
+Operation\ not\ supported=
 
-Optional_fields=
+Optional\ fields=
 
 Options=
 
 or=
 
-Output_or_export_file=
+Output\ or\ export\ file=
 
 Override=
 
-Override_default_file_directories=
+Override\ default\ file\ directories=
 
-Override_default_font_settings=
+Override\ default\ font\ settings=
 
-Override_the_BibTeX_field_by_the_selected_text=
+Override\ the\ BibTeX\ field\ by\ the\ selected\ text=
 
 
 Overwrite=
-Overwrite_existing_field_values=
+Overwrite\ existing\ field\ values=
 
-Overwrite_keys=
+Overwrite\ keys=
 
-pairs_processed=
+pairs\ processed=
 Password=
 
 Paste=
 
-paste_entries=
+paste\ entries=
 
-paste_entry=
-Paste_from_clipboard=
+paste\ entry=
+Paste\ from\ clipboard=
 
 Pasted=
 
-Path_to_%0_not_defined=
+Path\ to\ %0\ not\ defined=
 
-Path_to_LyX_pipe=
+Path\ to\ LyX\ pipe=
 
-PDF_does_not_exist=
+PDF\ does\ not\ exist=
 
-File_has_no_attached_annotations=
+File\ has\ no\ attached\ annotations=
 
-Plain_text_import=
+Plain\ text\ import=
 
-Please_enter_a_name_for_the_group.=
+Please\ enter\ a\ name\ for\ the\ group.=
 
-Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>=
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=
 
-Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=
+Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=
 
-Please_enter_the_string's_label=
+Please\ enter\ the\ string's\ label=
 
-Please_select_an_importer.=
+Please\ select\ an\ importer.=
 
-Possible_duplicate_entries=
+Possible\ duplicate\ entries=
 
-Possible_duplicate_of_existing_entry._Click_to_resolve.=
+Possible\ duplicate\ of\ existing\ entry.\ Click\ to\ resolve.=
 
 Preamble=
 
 Preferences=
 
-Preferences_recorded.=
+Preferences\ recorded.=
 
 Preview=
-Citation_Style=
-Current_Preview=
-Cannot_generate_preview_based_on_selected_citation_style.=
-Bad_character_inside_entry=
-Error_while_generating_citation_style=
-Preview_style_changed_to\:_%0=
-Next_preview_layout=
-Previous_preview_layout=
+Citation\ Style=
+Current\ Preview=
+Cannot\ generate\ preview\ based\ on\ selected\ citation\ style.=
+Bad\ character\ inside\ entry=
+Error\ while\ generating\ citation\ style=
+Preview\ style\ changed\ to\:\ %0=
+Next\ preview\ layout=
+Previous\ preview\ layout=
 
-Previous_entry=
+Previous\ entry=
 
-Primary_sort_criterion=
-Problem_with_parsing_entry=
-Processing_%0=
-Pull_changes_from_shared_database=
+Primary\ sort\ criterion=
+Problem\ with\ parsing\ entry=
+Processing\ %0=
+Pull\ changes\ from\ shared\ database=
 
-Pushed_citations_to_%0=
+Pushed\ citations\ to\ %0=
 
-Quit_JabRef=
+Quit\ JabRef=
 
-Quit_synchronization=
+Quit\ synchronization=
 
-Raw_source=
+Raw\ source=
 
-Rearrange_tabs_alphabetically_by_title=
+Rearrange\ tabs\ alphabetically\ by\ title=
 
 Redo=
 
-Reference_library=
+Reference\ library=
 
-%0_references_found._Number_of_references_to_fetch?=
+%0\ references\ found.\ Number\ of\ references\ to\ fetch?=
 
-Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=
 
-regular_expression=
+regular\ expression=
 
-Related_articles=
+Related\ articles=
 
-Remote_operation=
+Remote\ operation=
 
-Remote_server_port=
+Remote\ server\ port=
 
 Remove=
 
-Remove_subgroups=
+Remove\ subgroups=
 
-Remove_all_subgroups_of_"%0"?=
+Remove\ all\ subgroups\ of\ "%0"?=
 
-Remove_entry_from_import=
+Remove\ entry\ from\ import=
 
-Remove_selected_entries_from_this_group=
+Remove\ selected\ entries\ from\ this\ group=
 
-Remove_entry_type=
+Remove\ entry\ type=
 
-Remove_from_group=
+Remove\ from\ group=
 
-Remove_group=
+Remove\ group=
 
-Remove_group,_keep_subgroups=
+Remove\ group,\ keep\ subgroups=
 
-Remove_group_"%0"?=
+Remove\ group\ "%0"?=
 
-Remove_group_"%0"_and_its_subgroups?=
+Remove\ group\ "%0"\ and\ its\ subgroups?=
 
-remove_group_(keep_subgroups)=
+remove\ group\ (keep\ subgroups)=
 
-remove_group_and_subgroups=
+remove\ group\ and\ subgroups=
 
-Remove_group_and_subgroups=
+Remove\ group\ and\ subgroups=
 
-Remove_link=
+Remove\ link=
 
-Remove_old_entry=
+Remove\ old\ entry=
 
-Remove_selected_strings=
+Remove\ selected\ strings=
 
-Removed_group_"%0".=
+Removed\ group\ "%0".=
 
-Removed_group_"%0"_and_its_subgroups.=
+Removed\ group\ "%0"\ and\ its\ subgroups.=
 
-Removed_string=
+Removed\ string=
 
-Renamed_string=
+Renamed\ string=
 
 Replace=
 
-Replace_(regular_expression)=
+Replace\ (regular\ expression)=
 
-Replace_string=
+Replace\ string=
 
-Replace_with=
+Replace\ with=
 
 Replaced=
 
-Required_fields=
+Required\ fields=
 
-Reset_all=
+Reset\ all=
 
-Resolve_strings_for_all_fields_except=
-Resolve_strings_for_standard_BibTeX_fields_only=
+Resolve\ strings\ for\ all\ fields\ except=
+Resolve\ strings\ for\ standard\ BibTeX\ fields\ only=
 
 resolved=
 
 Review=
 
-Review_changes=
+Review\ changes=
 
 Right=
 
 Save=
-Save_all_finished.=
+Save\ all\ finished.=
 
-Save_all_open_libraries=
+Save\ all\ open\ libraries=
 
-Save_before_closing=
+Save\ before\ closing=
 
-Save_library=
-Save_library_as...=
+Save\ library=
+Save\ library\ as...=
 
-Save_entries_in_their_original_order=
+Save\ entries\ in\ their\ original\ order=
 
-Save_failed=
+Save\ failed=
 
-Save_failed_during_backup_creation=
+Save\ failed\ during\ backup\ creation=
 
-Save_selected_as...=
+Save\ selected\ as...=
 
-Saved_library=
+Saved\ library=
 
-Saved_selected_to_'%0'.=
+Saved\ selected\ to\ '%0'.=
 
 Saving=
-Saving_all_libraries...=
+Saving\ all\ libraries...=
 
-Saving_library=
+Saving\ library=
 
 Search=
 
-Search_expression=
+Search\ expression=
 
-Search_for=
+Search\ for=
 
-Searching_for_duplicates...=
+Searching\ for\ duplicates...=
 
-Searching_for_files=
+Searching\ for\ files=
 
-Secondary_sort_criterion=
+Secondary\ sort\ criterion=
 
-Select_all=
+Select\ all=
 
-Select_encoding=
+Select\ encoding=
 
-Select_entry_type=
-Select_external_application=
+Select\ entry\ type=
+Select\ external\ application=
 
-Select_file_from_ZIP-archive=
+Select\ file\ from\ ZIP-archive=
 
-Select_the_tree_nodes_to_view_and_accept_or_reject_changes=
-Selected_entries=
-Set_field=
-Set_fields=
+Select\ the\ tree\ nodes\ to\ view\ and\ accept\ or\ reject\ changes=
+Selected\ entries=
+Set\ field=
+Set\ fields=
 
-Set_general_fields=
-Set_main_external_file_directory=
+Set\ general\ fields=
+Set\ main\ external\ file\ directory=
 
-Set_table_font=
+Set\ table\ font=
 
 Settings=
 
 Shortcut=
 
-Show/edit_%0_source=
+Show/edit\ %0\ source=
 
-Show_'Firstname_Lastname'=
+Show\ 'Firstname\ Lastname'=
 
-Show_'Lastname,_Firstname'=
+Show\ 'Lastname,\ Firstname'=
 
-Show_BibTeX_source_by_default=
+Show\ BibTeX\ source\ by\ default=
 
-Show_confirmation_dialog_when_deleting_entries=
+Show\ confirmation\ dialog\ when\ deleting\ entries=
 
-Show_description=
+Show\ description=
 
-Show_file_column=
+Show\ file\ column=
 
-Show_last_names_only=
+Show\ last\ names\ only=
 
-Show_names_unchanged=
+Show\ names\ unchanged=
 
-Show_optional_fields=
+Show\ optional\ fields=
 
-Show_required_fields=
+Show\ required\ fields=
 
-Show_URL/DOI_column=
+Show\ URL/DOI\ column=
 
-Simple_HTML=
+Simple\ HTML=
 
 Size=
 
-Skipped_-_No_PDF_linked=
-Skipped_-_PDF_does_not_exist=
+Skipped\ -\ No\ PDF\ linked=
+Skipped\ -\ PDF\ does\ not\ exist=
 
-Skipped_entry.=
+Skipped\ entry.=
 
-Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.=
+Some\ appearance\ settings\ you\ changed\ require\ to\ restart\ JabRef\ to\ come\ into\ effect.=
 
-source_edit=
-Special_name_formatters=
+source\ edit=
+Special\ name\ formatters=
 
-Special_table_columns=
+Special\ table\ columns=
 
-Starting_import=
+Starting\ import=
 
-Statically_group_entries_by_manual_assignment=
+Statically\ group\ entries\ by\ manual\ assignment=
 
 Status=
 
@@ -1143,1019 +1143,1019 @@ Stop=
 
 Strings=
 
-Strings_for_library=
+Strings\ for\ library=
 
-Sublibrary_from_AUX=
+Sublibrary\ from\ AUX=
 
-Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.=
+Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=
 
-Synchronize_file_links=
+Synchronize\ file\ links=
 
-Synchronizing_file_links...=
+Synchronizing\ file\ links...=
 
-Table_appearance=
+Table\ appearance=
 
-Table_background_color=
+Table\ background\ color=
 
-Table_grid_color=
+Table\ grid\ color=
 
-Table_text_color=
+Table\ text\ color=
 
 Tabname=
-Target_file_cannot_be_a_directory.=
+Target\ file\ cannot\ be\ a\ directory.=
 
-Tertiary_sort_criterion=
+Tertiary\ sort\ criterion=
 
 Test=
 
-paste_text_here=
+paste\ text\ here=
 
-The_chosen_date_format_for_new_entries_is_not_valid=
+The\ chosen\ date\ format\ for\ new\ entries\ is\ not\ valid=
 
-The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:=
+The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=
 
 
-the_field_<b>%0</b>=
+the\ field\ <b>%0</b>=
 
-The_file<BR>'%0'<BR>has_been_modified<BR>externally\!=
+The\ file<BR>'%0'<BR>has\ been\ modified<BR>externally\!=
 
-The_group_"%0"_already_contains_the_selection.=
+The\ group\ "%0"\ already\ contains\ the\ selection.=
 
-The_label_of_the_string_cannot_be_a_number.=
+The\ label\ of\ the\ string\ cannot\ be\ a\ number.=
 
-The_label_of_the_string_cannot_contain_spaces.=
+The\ label\ of\ the\ string\ cannot\ contain\ spaces.=
 
-The_label_of_the_string_cannot_contain_the_'\#'_character.=
+The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=
 
-The_output_option_depends_on_a_valid_import_option.=
-The_PDF_contains_one_or_several_BibTeX-records.=
-Do_you_want_to_import_these_as_new_entries_into_the_current_library?=
+The\ output\ option\ depends\ on\ a\ valid\ import\ option.=
+The\ PDF\ contains\ one\ or\ several\ BibTeX-records.=
+Do\ you\ want\ to\ import\ these\ as\ new\ entries\ into\ the\ current\ library?=
 
-The_regular_expression_<b>%0</b>_is_invalid\:=
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=
 
-The_search_is_case_insensitive.=
+The\ search\ is\ case\ insensitive.=
 
-The_search_is_case_sensitive.=
+The\ search\ is\ case\ sensitive.=
 
-The_string_has_been_removed_locally=
+The\ string\ has\ been\ removed\ locally=
 
-There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?=
+There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=
 
-This_entry_has_no_BibTeX_key._Generate_key_now?=
+This\ entry\ has\ no\ BibTeX\ key.\ Generate\ key\ now?=
 
-This_entry_is_incomplete=
+This\ entry\ is\ incomplete=
 
-This_entry_type_cannot_be_removed.=
+This\ entry\ type\ cannot\ be\ removed.=
 
-This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=
+This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=
 
-This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.=
+This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>=
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>=
-This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.=
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=
+This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=
 
-This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.=
+This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=
 
-This_operation_requires_one_or_more_entries_to_be_selected.=
+This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=
 
-Toggle_entry_preview=
-Toggle_groups_interface=
-Try_different_encoding=
+Toggle\ entry\ preview=
+Toggle\ groups\ interface=
+Try\ different\ encoding=
 
-Unabbreviate_journal_names_of_the_selected_entries=
-Unabbreviated_%0_journal_names.=
+Unabbreviate\ journal\ names\ of\ the\ selected\ entries=
+Unabbreviated\ %0\ journal\ names.=
 
-Unable_to_open_file.=
-Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.=
-unable_to_write_to=
-Undefined_file_type=
+Unable\ to\ open\ file.=
+Unable\ to\ open\ link.\ The\ application\ '%0'\ associated\ with\ the\ file\ type\ '%1'\ could\ not\ be\ called.=
+unable\ to\ write\ to=
+Undefined\ file\ type=
 
 Undo=
 
 Union=
 
-Unknown_BibTeX_entries=
+Unknown\ BibTeX\ entries=
 
-unknown_edit=
+unknown\ edit=
 
-Unknown_export_format=
+Unknown\ export\ format=
 
-Unmark_all=
+Unmark\ all=
 
-Unmark_entries=
+Unmark\ entries=
 
-Unmark_entry=
+Unmark\ entry=
 
 untitled=
 
 Up=
 
-Update_to_current_column_widths=
+Update\ to\ current\ column\ widths=
 
-Updated_group_selection=
-Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.=
-Upgrade_file=
-Upgrade_old_external_file_links_to_use_the_new_feature=
+Updated\ group\ selection=
+Upgrade\ external\ PDF/PS\ links\ to\ use\ the\ '%0'\ field.=
+Upgrade\ file=
+Upgrade\ old\ external\ file\ links\ to\ use\ the\ new\ feature=
 
 usage=
-Use_autocompletion_for_the_following_fields=
+Use\ autocompletion\ for\ the\ following\ fields=
 
-Use_other_look_and_feel=
-Tweak_font_rendering_for_entry_editor_on_Linux=
-Use_regular_expression_search=
+Use\ other\ look\ and\ feel=
+Tweak\ font\ rendering\ for\ entry\ editor\ on\ Linux=
+Use\ regular\ expression\ search=
 
 Username=
 
-Value_cleared_externally=
+Value\ cleared\ externally=
 
-Value_set_externally=
+Value\ set\ externally=
 
-verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid=
+verify\ that\ LyX\ is\ running\ and\ that\ the\ lyxpipe\ is\ valid=
 
 View=
-Vim_server_name=
+Vim\ server\ name=
 
-Waiting_for_ArXiv...=
+Waiting\ for\ ArXiv...=
 
-Warn_about_unresolved_duplicates_when_closing_inspection_window=
+Warn\ about\ unresolved\ duplicates\ when\ closing\ inspection\ window=
 
-Warn_before_overwriting_existing_keys=
+Warn\ before\ overwriting\ existing\ keys=
 
 Warning=
 
 Warnings=
 
-web_link=
+web\ link=
 
-What_do_you_want_to_do?=
+What\ do\ you\ want\ to\ do?=
 
-When_adding/removing_keywords,_separate_them_by=
-Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.=
+When\ adding/removing\ keywords,\ separate\ them\ by=
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=
 
 with=
 
-Write_BibTeXEntry_as_XMP-metadata_to_PDF.=
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=
 
-Write_XMP=
-Write_XMP-metadata=
-Write_XMP-metadata_for_all_PDFs_in_current_library?=
-Writing_XMP-metadata...=
-Writing_XMP-metadata_for_selected_entries...=
+Write\ XMP=
+Write\ XMP-metadata=
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=
+Writing\ XMP-metadata...=
+Writing\ XMP-metadata\ for\ selected\ entries...=
 
-Wrote_XMP-metadata=
+Wrote\ XMP-metadata=
 
-XMP-annotated_PDF=
-XMP_export_privacy_settings=
+XMP-annotated\ PDF=
+XMP\ export\ privacy\ settings=
 XMP-metadata=
-XMP-metadata_found_in_PDF\:_%0=
-You_must_restart_JabRef_for_this_to_come_into_effect.=
-You_have_changed_the_language_setting.=
-You_have_entered_an_invalid_search_'%0'.=
+XMP-metadata\ found\ in\ PDF\:\ %0=
+You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=
+You\ have\ changed\ the\ language\ setting.=
+You\ have\ entered\ an\ invalid\ search\ '%0'.=
 
-You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.=
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=
 
-Your_new_key_bindings_have_been_stored.=
+Your\ new\ key\ bindings\ have\ been\ stored.=
 
-The_following_fetchers_are_available\:=
-Could_not_find_fetcher_'%0'=
-Running_query_'%0'_with_fetcher_'%1'.=
-Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.=
+The\ following\ fetchers\ are\ available\:=
+Could\ not\ find\ fetcher\ '%0'=
+Running\ query\ '%0'\ with\ fetcher\ '%1'.=
+Query\ '%0'\ with\ fetcher\ '%1'\ did\ not\ return\ any\ results.=
 
-Move_file=
-Rename_file=
+Move\ file=
+Rename\ file=
 
-Move_file_failed=
-Could_not_move_file_'%0'.=
-Could_not_find_file_'%0'.=
-Number_of_entries_successfully_imported=
-Import_canceled_by_user=
-Progress\:_%0_of_%1=
-Error_while_fetching_from_%0=
+Move\ file\ failed=
+Could\ not\ move\ file\ '%0'.=
+Could\ not\ find\ file\ '%0'.=
+Number\ of\ entries\ successfully\ imported=
+Import\ canceled\ by\ user=
+Progress\:\ %0\ of\ %1=
+Error\ while\ fetching\ from\ %0=
 
-Please_enter_a_valid_number=
-Show_search_results_in_a_window=
-Show_global_search_results_in_a_window=
-Search_in_all_open_libraries=
-Move_file_to_file_directory?=
+Please\ enter\ a\ valid\ number=
+Show\ search\ results\ in\ a\ window=
+Show\ global\ search\ results\ in\ a\ window=
+Search\ in\ all\ open\ libraries=
+Move\ file\ to\ file\ directory?=
 
-Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.=
-Protected_library=
-Refuse_to_save_the_library_before_external_changes_have_been_reviewed.=
-Library_protection=
-Unable_to_save_library=
+Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=
+Protected\ library=
+Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=
+Library\ protection=
+Unable\ to\ save\ library=
 
-BibTeX_key_generator=
-Unable_to_open_link.=
-Move_the_keyboard_focus_to_the_entry_table=
-MIME_type=
+BibTeX\ key\ generator=
+Unable\ to\ open\ link.=
+Move\ the\ keyboard\ focus\ to\ the\ entry\ table=
+MIME\ type=
 
-This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.=
-Run_fetcher,_e.g._"--fetch\=Medline\:cancer"=
+This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef<BR>instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef<br>from\ your\ web\ browser.<BR>Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=
 
-The_ACM_Digital_Library=
+The\ ACM\ Digital\ Library=
 Reset=
 
-Use_IEEE_LaTeX_abbreviations=
-The_Guide_to_Computing_Literature=
+Use\ IEEE\ LaTeX\ abbreviations=
+The\ Guide\ to\ Computing\ Literature=
 
-When_opening_file_link,_search_for_matching_file_if_no_link_is_defined=
-Settings_for_%0=
-Mark_entries_imported_into_an_existing_library=
-Unmark_all_entries_before_importing_new_entries_into_an_existing_library=
+When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=
+Settings\ for\ %0=
+Mark\ entries\ imported\ into\ an\ existing\ library=
+Unmark\ all\ entries\ before\ importing\ new\ entries\ into\ an\ existing\ library=
 
 Forward=
 Back=
-Sort_the_following_fields_as_numeric_fields=
-Line_%0\:_Found_corrupted_BibTeX_key.=
-Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).=
-Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).=
-Full_text_document_download_failed=
-Update_to_current_column_order=
-Download_from_URL=
-Rename_field=
-Set/clear/append/rename_fields=Ρύθμιση/καθαρισμός/μετονομασία_πεδίων
-Append_field=
-Append_to_fields=
-Rename_field_to=
-Move_contents_of_a_field_into_a_field_with_a_different_name=
-You_can_only_rename_one_field_at_a_time=
+Sort\ the\ following\ fields\ as\ numeric\ fields=
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=
+Full\ text\ document\ download\ failed=
+Update\ to\ current\ column\ order=
+Download\ from\ URL=
+Rename\ field=
+Set/clear/append/rename\ fields=Ρύθμιση/καθαρισμός/μετονομασία πεδίων
+Append\ field=
+Append\ to\ fields=
+Rename\ field\ to=
+Move\ contents\ of\ a\ field\ into\ a\ field\ with\ a\ different\ name=
+You\ can\ only\ rename\ one\ field\ at\ a\ time=
 
-Remove_all_broken_links=
+Remove\ all\ broken\ links=
 
-Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.=
+Cannot\ use\ port\ %0\ for\ remote\ operation;\ another\ application\ may\ be\ using\ it.\ Try\ specifying\ another\ port.=
 
-Looking_for_full_text_document...=
+Looking\ for\ full\ text\ document...=
 Autosave=
-A_local_copy_will_be_opened.=
-Autosave_local_libraries=
-Automatically_save_the_library_to=
-Please_enter_a_valid_file_path.=
+A\ local\ copy\ will\ be\ opened.=
+Autosave\ local\ libraries=
+Automatically\ save\ the\ library\ to=
+Please\ enter\ a\ valid\ file\ path.=
 
 
-Export_in_current_table_sort_order=
-Export_entries_in_their_original_order=
-Error_opening_file_'%0'.=
+Export\ in\ current\ table\ sort\ order=
+Export\ entries\ in\ their\ original\ order=
+Error\ opening\ file\ '%0'.=
 
-Formatter_not_found\:_%0=
-Clear_inputarea=
+Formatter\ not\ found\:\ %0=
+Clear\ inputarea=
 
-Automatically_set_file_links_for_this_entry=
-Could_not_save,_file_locked_by_another_JabRef_instance.=
-File_is_locked_by_another_JabRef_instance.=
-Do_you_want_to_override_the_file_lock?=
-File_locked=
-Current_tmp_value=
-Metadata_change=
-Changes_have_been_made_to_the_following_metadata_elements=
+Automatically\ set\ file\ links\ for\ this\ entry=
+Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=
+File\ is\ locked\ by\ another\ JabRef\ instance.=
+Do\ you\ want\ to\ override\ the\ file\ lock?=
+File\ locked=
+Current\ tmp\ value=
+Metadata\ change=
+Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=
 
-Generate_groups_for_author_last_names=
-Generate_groups_from_keywords_in_a_BibTeX_field=
-Enforce_legal_characters_in_BibTeX_keys=
+Generate\ groups\ for\ author\ last\ names=
+Generate\ groups\ from\ keywords\ in\ a\ BibTeX\ field=
+Enforce\ legal\ characters\ in\ BibTeX\ keys=
 
-Save_without_backup?=
-Unable_to_create_backup=
-Move_file_to_file_directory=
-Rename_file_to=
-<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)=
-static_group=
-dynamic_group=
-refines_supergroup=
-includes_subgroups=
+Save\ without\ backup?=
+Unable\ to\ create\ backup=
+Move\ file\ to\ file\ directory=
+Rename\ file\ to=
+<b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=
+static\ group=
+dynamic\ group=
+refines\ supergroup=
+includes\ subgroups=
 contains=
-search_expression=
+search\ expression=
 
-Optional_fields_2=
-Waiting_for_save_operation_to_finish=
-Resolving_duplicate_BibTeX_keys...=
-Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.=
-This_library_contains_one_or_more_duplicated_BibTeX_keys.=
-Do_you_want_to_resolve_duplicate_keys_now?=
+Optional\ fields\ 2=
+Waiting\ for\ save\ operation\ to\ finish=
+Resolving\ duplicate\ BibTeX\ keys...=
+Finished\ resolving\ duplicate\ BibTeX\ keys.\ %0\ entries\ modified.=
+This\ library\ contains\ one\ or\ more\ duplicated\ BibTeX\ keys.=
+Do\ you\ want\ to\ resolve\ duplicate\ keys\ now?=
 
-Find_and_remove_duplicate_BibTeX_keys=
-Expected_syntax_for_--fetch\='<name_of_fetcher>\:<query>'=
-Duplicate_BibTeX_key=
-Import_marking_color=
-Always_add_letter_(a,_b,_...)_to_generated_keys=
+Find\ and\ remove\ duplicate\ BibTeX\ keys=
+Expected\ syntax\ for\ --fetch\='<name\ of\ fetcher>\:<query>'=
+Duplicate\ BibTeX\ key=
+Import\ marking\ color=
+Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=
 
-Ensure_unique_keys_using_letters_(a,_b,_...)=
-Ensure_unique_keys_using_letters_(b,_c,_...)=
-Entry_editor_active_background_color=
-Entry_editor_background_color=
-Entry_editor_font_color=
-Entry_editor_invalid_field_color=
+Ensure\ unique\ keys\ using\ letters\ (a,\ b,\ ...)=
+Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=
+Entry\ editor\ active\ background\ color=
+Entry\ editor\ background\ color=
+Entry\ editor\ font\ color=
+Entry\ editor\ invalid\ field\ color=
 
-Table_and_entry_editor_colors=
+Table\ and\ entry\ editor\ colors=
 
-General_file_directory=
-User-specific_file_directory=
-Search_failed\:_illegal_search_expression=
-Show_ArXiv_column=
+General\ file\ directory=
+User-specific\ file\ directory=
+Search\ failed\:\ illegal\ search\ expression=
+Show\ ArXiv\ column=
 
-You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for=
-Automatically_open_browse_dialog_when_creating_new_file_link=
-Import_metadata_from\:=
-Choose_the_source_for_the_metadata_import=
-Create_entry_based_on_XMP-metadata=
-Create_blank_entry_linking_the_PDF=
-Only_attach_PDF=
+You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=
+Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=
+Import\ metadata\ from\:=
+Choose\ the\ source\ for\ the\ metadata\ import=
+Create\ entry\ based\ on\ XMP-metadata=
+Create\ blank\ entry\ linking\ the\ PDF=
+Only\ attach\ PDF=
 Title=
-Create_new_entry=
-Update_existing_entry=
-Autocomplete_names_in_'Firstname_Lastname'_format_only=
-Autocomplete_names_in_'Lastname,_Firstname'_format_only=
-Autocomplete_names_in_both_formats=
-Marking_color_%0=
-The_name_'comment'_cannot_be_used_as_an_entry_type_name.=
-You_must_enter_an_integer_value_in_the_text_field_for=
-Send_as_email=
+Create\ new\ entry=
+Update\ existing\ entry=
+Autocomplete\ names\ in\ 'Firstname\ Lastname'\ format\ only=
+Autocomplete\ names\ in\ 'Lastname,\ Firstname'\ format\ only=
+Autocomplete\ names\ in\ both\ formats=
+Marking\ color\ %0=
+The\ name\ 'comment'\ cannot\ be\ used\ as\ an\ entry\ type\ name.=
+You\ must\ enter\ an\ integer\ value\ in\ the\ text\ field\ for=
+Send\ as\ email=
 References=
-Sending_of_emails=
-Subject_for_sending_an_email_with_references=
-Automatically_open_folders_of_attached_files=
-Create_entry_based_on_content=
-Do_not_show_this_box_again_for_this_import=
-Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)=
-Error_creating_email=
-Entries_added_to_an_email=
+Sending\ of\ emails=
+Subject\ for\ sending\ an\ email\ with\ references=
+Automatically\ open\ folders\ of\ attached\ files=
+Create\ entry\ based\ on\ content=
+Do\ not\ show\ this\ box\ again\ for\ this\ import=
+Always\ use\ this\ PDF\ import\ style\ (and\ do\ not\ ask\ for\ each\ import)=
+Error\ creating\ email=
+Entries\ added\ to\ an\ email=
 exportFormat=
-Output_file_missing=
-No_search_matches.=
-The_output_option_depends_on_a_valid_input_option.=
-Default_import_style_for_drag_and_drop_of_PDFs=
-Default_PDF_file_link_action=
-Filename_format_pattern=
-Additional_parameters=
-Cite_selected_entries_between_parenthesis=
-Cite_selected_entries_with_in-text_citation=
-Cite_special=
-Extra_information_(e.g._page_number)=
-Manage_citations=
-Problem_modifying_citation=
+Output\ file\ missing=
+No\ search\ matches.=
+The\ output\ option\ depends\ on\ a\ valid\ input\ option.=
+Default\ import\ style\ for\ drag\ and\ drop\ of\ PDFs=
+Default\ PDF\ file\ link\ action=
+Filename\ format\ pattern=
+Additional\ parameters=
+Cite\ selected\ entries\ between\ parenthesis=
+Cite\ selected\ entries\ with\ in-text\ citation=
+Cite\ special=
+Extra\ information\ (e.g.\ page\ number)=
+Manage\ citations=
+Problem\ modifying\ citation=
 Citation=
-Extra_information=
-Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.=
-Select_style=
+Extra\ information=
+Could\ not\ resolve\ BibTeX\ entry\ for\ citation\ marker\ '%0'.=
+Select\ style=
 Journals=
 Cite=
-Cite_in-text=
-Insert_empty_citation=
-Merge_citations=
-Manual_connect=
-Select_Writer_document=
-Sync_OpenOffice/LibreOffice_bibliography=
-Select_which_open_Writer_document_to_work_on=
-Connected_to_document=
-Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)=
-Cite_selected_entries_with_extra_information=
-Ensure_that_the_bibliography_is_up-to-date=
-Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.=
-Unable_to_synchronize_bibliography=
-Combine_pairs_of_citations_that_are_separated_by_spaces_only=
-Autodetection_failed=
+Cite\ in-text=
+Insert\ empty\ citation=
+Merge\ citations=
+Manual\ connect=
+Select\ Writer\ document=
+Sync\ OpenOffice/LibreOffice\ bibliography=
+Select\ which\ open\ Writer\ document\ to\ work\ on=
+Connected\ to\ document=
+Insert\ a\ citation\ without\ text\ (the\ entry\ will\ appear\ in\ the\ reference\ list)=
+Cite\ selected\ entries\ with\ extra\ information=
+Ensure\ that\ the\ bibliography\ is\ up-to-date=
+Your\ OpenOffice/LibreOffice\ document\ references\ the\ BibTeX\ key\ '%0',\ which\ could\ not\ be\ found\ in\ your\ current\ library.=
+Unable\ to\ synchronize\ bibliography=
+Combine\ pairs\ of\ citations\ that\ are\ separated\ by\ spaces\ only=
+Autodetection\ failed=
 Connecting=
-Please_wait...=
-Set_connection_parameters=
-Path_to_OpenOffice/LibreOffice_directory=
-Path_to_OpenOffice/LibreOffice_executable=
-Path_to_OpenOffice/LibreOffice_library_dir=
-Connection_lost=
-The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.=
-The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.=
-Automatically_sync_bibliography_when_inserting_citations=
-Look_up_BibTeX_entries_in_the_active_tab_only=
-Look_up_BibTeX_entries_in_all_open_libraries=
-Autodetecting_paths...=
-Could_not_find_OpenOffice/LibreOffice_installation=
-Found_more_than_one_OpenOffice/LibreOffice_executable.=
-Please_choose_which_one_to_connect_to\:=
-Choose_OpenOffice/LibreOffice_executable=
-Select_document=
-HTML_list=
-If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting=
-Could_not_open_%0=
-Unknown_import_format=
-Web_search=
-Style_selection=
-No_valid_style_file_defined=
-Choose_pattern=
-Use_the_BIB_file_location_as_primary_file_directory=
-Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.=
-OpenOffice/LibreOffice_connection=
-You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.=
+Please\ wait...=
+Set\ connection\ parameters=
+Path\ to\ OpenOffice/LibreOffice\ directory=
+Path\ to\ OpenOffice/LibreOffice\ executable=
+Path\ to\ OpenOffice/LibreOffice\ library\ dir=
+Connection\ lost=
+The\ paragraph\ format\ is\ controlled\ by\ the\ property\ 'ReferenceParagraphFormat'\ or\ 'ReferenceHeaderParagraphFormat'\ in\ the\ style\ file.=
+The\ character\ format\ is\ controlled\ by\ the\ citation\ property\ 'CitationCharacterFormat'\ in\ the\ style\ file.=
+Automatically\ sync\ bibliography\ when\ inserting\ citations=
+Look\ up\ BibTeX\ entries\ in\ the\ active\ tab\ only=
+Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=
+Autodetecting\ paths...=
+Could\ not\ find\ OpenOffice/LibreOffice\ installation=
+Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=
+Please\ choose\ which\ one\ to\ connect\ to\:=
+Choose\ OpenOffice/LibreOffice\ executable=
+Select\ document=
+HTML\ list=
+If\ possible,\ normalize\ this\ list\ of\ names\ to\ conform\ to\ standard\ BibTeX\ name\ formatting=
+Could\ not\ open\ %0=
+Unknown\ import\ format=
+Web\ search=
+Style\ selection=
+No\ valid\ style\ file\ defined=
+Choose\ pattern=
+Use\ the\ BIB\ file\ location\ as\ primary\ file\ directory=
+Could\ not\ run\ the\ gnuclient/emacsclient\ program.\ Make\ sure\ you\ have\ the\ emacsclient/gnuclient\ program\ installed\ and\ available\ in\ the\ PATH.=
+OpenOffice/LibreOffice\ connection=
+You\ must\ select\ either\ a\ valid\ style\ file,\ or\ use\ one\ of\ the\ default\ styles.=
 
-This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.=
-This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.=
-You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.=
+This\ is\ a\ simple\ copy\ and\ paste\ dialog.\ First\ load\ or\ paste\ some\ text\ into\ the\ text\ input\ area.<br>After\ that,\ you\ can\ mark\ text\ and\ assign\ it\ to\ a\ BibTeX\ field.=
+This\ feature\ generates\ a\ new\ library\ based\ on\ which\ entries\ are\ needed\ in\ an\ existing\ LaTeX\ document.=
+You\ need\ to\ select\ one\ of\ your\ open\ libraries\ from\ which\ to\ choose\ entries,\ as\ well\ as\ the\ AUX\ file\ produced\ by\ LaTeX\ when\ compiling\ your\ document.=
 
-First_select_entries_to_clean_up.=
-Cleanup_entry=
-Autogenerate_PDF_Names=
-Auto-generating_PDF-Names_does_not_support_undo._Continue?=
+First\ select\ entries\ to\ clean\ up.=
+Cleanup\ entry=
+Autogenerate\ PDF\ Names=
+Auto-generating\ PDF-Names\ does\ not\ support\ undo.\ Continue?=
 
-Use_full_firstname_whenever_possible=
-Use_abbreviated_firstname_whenever_possible=
-Use_abbreviated_and_full_firstname=
-Autocompletion_options=
-Name_format_used_for_autocompletion=
-Treatment_of_first_names=
-Cleanup_entries=
-Automatically_assign_new_entry_to_selected_groups=
-%0_mode=
-Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix=
-Make_paths_of_linked_files_relative_(if_possible)=
-Rename_PDFs_to_given_filename_format_pattern=
-Rename_only_PDFs_having_a_relative_path=
-What_would_you_like_to_clean_up?=
-Doing_a_cleanup_for_%0_entries...=
-No_entry_needed_a_clean_up=
-One_entry_needed_a_clean_up=
-%0_entries_needed_a_clean_up=
+Use\ full\ firstname\ whenever\ possible=
+Use\ abbreviated\ firstname\ whenever\ possible=
+Use\ abbreviated\ and\ full\ firstname=
+Autocompletion\ options=
+Name\ format\ used\ for\ autocompletion=
+Treatment\ of\ first\ names=
+Cleanup\ entries=
+Automatically\ assign\ new\ entry\ to\ selected\ groups=
+%0\ mode=
+Move\ DOIs\ from\ note\ and\ URL\ field\ to\ DOI\ field\ and\ remove\ http\ prefix=
+Make\ paths\ of\ linked\ files\ relative\ (if\ possible)=
+Rename\ PDFs\ to\ given\ filename\ format\ pattern=
+Rename\ only\ PDFs\ having\ a\ relative\ path=
+What\ would\ you\ like\ to\ clean\ up?=
+Doing\ a\ cleanup\ for\ %0\ entries...=
+No\ entry\ needed\ a\ clean\ up=
+One\ entry\ needed\ a\ clean\ up=
+%0\ entries\ needed\ a\ clean\ up=
 
-Remove_selected=
+Remove\ selected=
 
-Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.=
-Attach_file=
-Setting_all_preferences_to_default_values.=
-Resetting_preference_key_'%0'=
-Unknown_preference_key_'%0'=
-Unable_to_clear_preferences.=
+Group\ tree\ could\ not\ be\ parsed.\ If\ you\ save\ the\ BibTeX\ library,\ all\ groups\ will\ be\ lost.=
+Attach\ file=
+Setting\ all\ preferences\ to\ default\ values.=
+Resetting\ preference\ key\ '%0'=
+Unknown\ preference\ key\ '%0'=
+Unable\ to\ clear\ preferences.=
 
-Reset_preferences_(key1,key2,..._or_'all')=
-Find_unlinked_files=
-Unselect_all=
-Expand_all=
-Collapse_all=
-Opens_the_file_browser.=
-Scan_directory=
-Searches_the_selected_directory_for_unlinked_files.=
-Starts_the_import_of_BibTeX_entries.=
-Leave_this_dialog.=
-Create_directory_based_keywords=
-Creates_keywords_in_created_entrys_with_directory_pathnames=
-Select_a_directory_where_the_search_shall_start.=
-Select_file_type\:=
-These_files_are_not_linked_in_the_active_library.=
-Entry_type_to_be_created\:=
-Searching_file_system...=
-Importing_into_Library...=
-Select_directory=
-Select_files=
-BibTeX_entry_creation=
-<No_selection>=
-Unable_to_connect_to_FreeCite_online_service.=
-Parse_with_FreeCite=
-The_current_BibTeX_key_will_be_overwritten._Continue?=
-Overwrite_key=
-Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator=
-How_would_you_like_to_link_to_'%0'?=
-BibTeX_key_patterns=
-Changed_special_field_settings=
-Clear_priority=
-Clear_rank=
-Enable_special_fields=
-One_star=
-Two_stars=
-Three_stars=
-Four_stars=
-Five_stars=
-Help_on_special_fields=
-Keywords_of_selected_entries=
-Manage_content_selectors=
-Manage_keywords=
-No_priority_information=
-No_rank_information=
+Reset\ preferences\ (key1,key2,...\ or\ 'all')=
+Find\ unlinked\ files=
+Unselect\ all=
+Expand\ all=
+Collapse\ all=
+Opens\ the\ file\ browser.=
+Scan\ directory=
+Searches\ the\ selected\ directory\ for\ unlinked\ files.=
+Starts\ the\ import\ of\ BibTeX\ entries.=
+Leave\ this\ dialog.=
+Create\ directory\ based\ keywords=
+Creates\ keywords\ in\ created\ entrys\ with\ directory\ pathnames=
+Select\ a\ directory\ where\ the\ search\ shall\ start.=
+Select\ file\ type\:=
+These\ files\ are\ not\ linked\ in\ the\ active\ library.=
+Entry\ type\ to\ be\ created\:=
+Searching\ file\ system...=
+Importing\ into\ Library...=
+Select\ directory=
+Select\ files=
+BibTeX\ entry\ creation=
+<No\ selection>=
+Unable\ to\ connect\ to\ FreeCite\ online\ service.=
+Parse\ with\ FreeCite=
+The\ current\ BibTeX\ key\ will\ be\ overwritten.\ Continue?=
+Overwrite\ key=
+Not\ overwriting\ existing\ key.\ To\ change\ this\ setting,\ open\ Options\ ->\ Prefererences\ ->\ BibTeX\ key\ generator=
+How\ would\ you\ like\ to\ link\ to\ '%0'?=
+BibTeX\ key\ patterns=
+Changed\ special\ field\ settings=
+Clear\ priority=
+Clear\ rank=
+Enable\ special\ fields=
+One\ star=
+Two\ stars=
+Three\ stars=
+Four\ stars=
+Five\ stars=
+Help\ on\ special\ fields=
+Keywords\ of\ selected\ entries=
+Manage\ content\ selectors=
+Manage\ keywords=
+No\ priority\ information=
+No\ rank\ information=
 Priority=
-Priority_high=
-Priority_low=
-Priority_medium=
+Priority\ high=
+Priority\ low=
+Priority\ medium=
 Quality=
 Rank=
 Relevance=
-Set_priority_to_high=
-Set_priority_to_low=
-Set_priority_to_medium=
-Show_priority=
-Show_quality=
-Show_rank=
-Show_relevance=
-Synchronize_with_keywords=
-Synchronized_special_fields_based_on_keywords=
-Toggle_relevance=
-Toggle_quality_assured=
-Toggle_print_status=
-Update_keywords=
-Write_values_of_special_fields_as_separate_fields_to_BibTeX=
-You_have_changed_settings_for_special_fields.=
-%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.=
-A_string_with_that_label_already_exists=
-Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.=
-JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.=
-Correct_the_entry,_and_reopen_editor_to_display/edit_source.=
-Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').=
-Could_not_connect_to_running_OpenOffice/LibreOffice.=
-Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.=
-If_connecting_manually,_please_verify_program_and_library_paths.=
-Error_message\:=
-If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.=
-Import_metadata_from_PDF=
-Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.=
-Removed_all_subgroups_of_group_"%0".=
-To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.=
-Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.=
-Use_the_following_delimiter_character(s)\:=
-When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above=
-Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=
-Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=
+Set\ priority\ to\ high=
+Set\ priority\ to\ low=
+Set\ priority\ to\ medium=
+Show\ priority=
+Show\ quality=
+Show\ rank=
+Show\ relevance=
+Synchronize\ with\ keywords=
+Synchronized\ special\ fields\ based\ on\ keywords=
+Toggle\ relevance=
+Toggle\ quality\ assured=
+Toggle\ print\ status=
+Update\ keywords=
+Write\ values\ of\ special\ fields\ as\ separate\ fields\ to\ BibTeX=
+You\ have\ changed\ settings\ for\ special\ fields.=
+%0\ entries\ found.\ To\ reduce\ server\ load,\ only\ %1\ will\ be\ downloaded.=
+A\ string\ with\ that\ label\ already\ exists=
+Connection\ to\ OpenOffice/LibreOffice\ has\ been\ lost.\ Please\ make\ sure\ OpenOffice/LibreOffice\ is\ running,\ and\ try\ to\ reconnect.=
+JabRef\ will\ send\ at\ least\ one\ request\ per\ entry\ to\ a\ publisher.=
+Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=
+Could\ not\ connect\ to\ a\ running\ gnuserv\ process.\ Make\ sure\ that\ Emacs\ or\ XEmacs\ is\ running,<BR>and\ that\ the\ server\ has\ been\ started\ (by\ running\ the\ command\ 'server-start'/'gnuserv-start').=
+Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=
+Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=
+If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=
+Error\ message\:=
+If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=
+Import\ metadata\ from\ PDF=
+Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=
+Removed\ all\ subgroups\ of\ group\ "%0".=
+To\ disable\ the\ memory\ stick\ mode\ rename\ or\ remove\ the\ jabref.xml\ file\ in\ the\ same\ folder\ as\ JabRef.=
+Unable\ to\ connect.\ One\ possible\ reason\ is\ that\ JabRef\ and\ OpenOffice/LibreOffice\ are\ not\ both\ running\ in\ either\ 32\ bit\ mode\ or\ 64\ bit\ mode.=
+Use\ the\ following\ delimiter\ character(s)\:=
+When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\ prefer\ the\ BIB\ file\ location\ rather\ than\ the\ file\ directory\ set\ above=
+Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=
+Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=
 
 Searching...=
-You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?=
-Confirm_selection=
-Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case=
-Import_conversions=
-Please_enter_a_search_string=
-Please_open_or_start_a_new_library_before_searching=
+You\ have\ selected\ more\ than\ %0\ entries\ for\ download.\ Some\ web\ sites\ might\ block\ you\ if\ you\ make\ too\ many\ rapid\ downloads.\ Do\ you\ want\ to\ continue?=
+Confirm\ selection=
+Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=
+Import\ conversions=
+Please\ enter\ a\ search\ string=
+Please\ open\ or\ start\ a\ new\ library\ before\ searching=
 
-Canceled_merging_entries=
+Canceled\ merging\ entries=
 
-Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search=
-Merge_entries=
-Merged_entries=
-Merged_entry=
+Format\ units\ by\ adding\ non-breaking\ separators\ and\ keeping\ the\ correct\ case\ on\ search=
+Merge\ entries=
+Merged\ entries=
+Merged\ entry=
 None=
 Parse=
 Result=
-Show_DOI_first=
-Show_URL_first=
-Use_Emacs_key_bindings=
-You_have_to_choose_exactly_two_entries_to_merge.=
+Show\ DOI\ first=
+Show\ URL\ first=
+Use\ Emacs\ key\ bindings=
+You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=
 
-Update_timestamp_on_modification=
-All_key_bindings_will_be_reset_to_their_defaults.=
+Update\ timestamp\ on\ modification=
+All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=
 
-Automatically_set_file_links=
-Resetting_all_key_bindings=
+Automatically\ set\ file\ links=
+Resetting\ all\ key\ bindings=
 Hostname=
-Invalid_setting=
+Invalid\ setting=
 Network=
-Please_specify_both_hostname_and_port=
-Please_specify_both_username_and_password=
+Please\ specify\ both\ hostname\ and\ port=
+Please\ specify\ both\ username\ and\ password=
 
-Use_custom_proxy_configuration=
-Proxy_requires_authentication=
-Attention\:_Password_is_stored_in_plain_text\!=
-Clear_connection_settings=
-Cleared_connection_settings.=
+Use\ custom\ proxy\ configuration=
+Proxy\ requires\ authentication=
+Attention\:\ Password\ is\ stored\ in\ plain\ text\!=
+Clear\ connection\ settings=
+Cleared\ connection\ settings.=
 
-Rebind_C-a,_too=
-Rebind_C-f,_too=
+Rebind\ C-a,\ too=
+Rebind\ C-f,\ too=
 
-Open_folder=
-Searches_for_unlinked_PDF_files_on_the_file_system=
-Export_entries_ordered_as_specified=
-Export_sort_order=
-Export_sorting=
-Newline_separator=
+Open\ folder=
+Searches\ for\ unlinked\ PDF\ files\ on\ the\ file\ system=
+Export\ entries\ ordered\ as\ specified=
+Export\ sort\ order=
+Export\ sorting=
+Newline\ separator=
 
-Save_entries_ordered_as_specified=
-Save_sort_order=
-Show_extra_columns=
-Parsing_error=
-illegal_backslash_expression=
+Save\ entries\ ordered\ as\ specified=
+Save\ sort\ order=
+Show\ extra\ columns=
+Parsing\ error=
+illegal\ backslash\ expression=
 
-Move_to_group=
+Move\ to\ group=
 
-Clear_read_status=
-Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')=
-Could_not_apply_changes.=
-Deprecated_fields=
-Hide/show_toolbar=
-No_read_status_information=
+Clear\ read\ status=
+Convert\ to\ biblatex\ format\ (for\ example,\ move\ the\ value\ of\ the\ 'journal'\ field\ to\ 'journaltitle')=
+Could\ not\ apply\ changes.=
+Deprecated\ fields=
+Hide/show\ toolbar=
+No\ read\ status\ information=
 Printed=
-Read_status=
-Read_status_read=
-Read_status_skimmed=
-Save_selected_as_plain_BibTeX...=
-Set_read_status_to_read=
-Set_read_status_to_skimmed=
-Show_deprecated_BibTeX_fields=
+Read\ status=
+Read\ status\ read=
+Read\ status\ skimmed=
+Save\ selected\ as\ plain\ BibTeX...=
+Set\ read\ status\ to\ read=
+Set\ read\ status\ to\ skimmed=
+Show\ deprecated\ BibTeX\ fields=
 
-Show_gridlines=
-Show_printed_status=
-Show_read_status=
-Table_row_height_padding=
+Show\ gridlines=
+Show\ printed\ status=
+Show\ read\ status=
+Table\ row\ height\ padding=
 
-Marked_selected_entry=
-Marked_all_%0_selected_entries=
-Unmarked_selected_entry=
-Unmarked_all_%0_selected_entries=
+Marked\ selected\ entry=
+Marked\ all\ %0\ selected\ entries=
+Unmarked\ selected\ entry=
+Unmarked\ all\ %0\ selected\ entries=
 
 
-Unmarked_all_entries=
+Unmarked\ all\ entries=
 
-Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.=
+Unable\ to\ find\ the\ requested\ look\ and\ feel\ and\ thus\ the\ default\ one\ is\ used.=
 
-Opens_JabRef's_GitHub_page=
-Could_not_open_browser.=
-Please_open_%0_manually.=
-The_link_has_been_copied_to_the_clipboard.=
+Opens\ JabRef's\ GitHub\ page=
+Could\ not\ open\ browser.=
+Please\ open\ %0\ manually.=
+The\ link\ has\ been\ copied\ to\ the\ clipboard.=
 
-Open_%0_file=
+Open\ %0\ file=
 
-Cannot_delete_file=
-File_permission_error=
-Push_to_%0=
-Path_to_%0=
+Cannot\ delete\ file=
+File\ permission\ error=
+Push\ to\ %0=
+Path\ to\ %0=
 Convert=
-Normalize_to_BibTeX_name_format=
-Help_on_Name_Formatting=
+Normalize\ to\ BibTeX\ name\ format=
+Help\ on\ Name\ Formatting=
 
-Add_new_file_type=
+Add\ new\ file\ type=
 
-Left_entry=
-Right_entry=
+Left\ entry=
+Right\ entry=
 Use=
-Original_entry=
-Replace_original_entry=
-No_information_added=
-Select_at_least_one_entry_to_manage_keywords.=
-OpenDocument_text=
-OpenDocument_spreadsheet=
-OpenDocument_presentation=
-%0_image=
-Added_entry=
-Modified_entry=
-Deleted_entry=
-Modified_groups_tree=
-Removed_all_groups=
-Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.=
-Select_export_format=
-Return_to_JabRef=
-Please_move_the_file_manually_and_link_in_place.=
-Could_not_connect_to_%0=
-Warning\:_%0_out_of_%1_entries_have_undefined_title.=
-Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.=
+Original\ entry=
+Replace\ original\ entry=
+No\ information\ added=
+Select\ at\ least\ one\ entry\ to\ manage\ keywords.=
+OpenDocument\ text=
+OpenDocument\ spreadsheet=
+OpenDocument\ presentation=
+%0\ image=
+Added\ entry=
+Modified\ entry=
+Deleted\ entry=
+Modified\ groups\ tree=
+Removed\ all\ groups=
+Accepting\ the\ change\ replaces\ the\ complete\ groups\ tree\ with\ the\ externally\ modified\ groups\ tree.=
+Select\ export\ format=
+Return\ to\ JabRef=
+Please\ move\ the\ file\ manually\ and\ link\ in\ place.=
+Could\ not\ connect\ to\ %0=
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ title.=
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ BibTeX\ key.=
 occurrence=
-Added_new_'%0'_entry.=
-Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?=
-Changed_type_to_'%0'_for=
-Really_delete_the_selected_entry?=
-Really_delete_the_%0_selected_entries?=
-Keep_merged_entry_only=
-Keep_left=
-Keep_right=
-Old_entry=
-From_import=
-No_problems_found.=
-%0_problem(s)_found=
-Save_changes=
-Discard_changes=
-Library_'%0'_has_changed.=
-Print_entry_preview=
-Copy_title=
-Copy_\\cite{BibTeX_key}=
-Copy_BibTeX_key_and_title=
-File_rename_failed_for_%0_entries.=
-Merged_BibTeX_source_code=
-Invalid_DOI\:_'%0'.=
-should_start_with_a_name=
-should_end_with_a_name=
-unexpected_closing_curly_bracket=
-unexpected_opening_curly_bracket=
-capital_letters_are_not_masked_using_curly_brackets_{}=
-should_contain_a_four_digit_number=
-should_contain_a_valid_page_number_range=
+Added\ new\ '%0'\ entry.=
+Multiple\ entries\ selected.\ Do\ you\ want\ to\ change\ the\ type\ of\ all\ these\ to\ '%0'?=
+Changed\ type\ to\ '%0'\ for=
+Really\ delete\ the\ selected\ entry?=
+Really\ delete\ the\ %0\ selected\ entries?=
+Keep\ merged\ entry\ only=
+Keep\ left=
+Keep\ right=
+Old\ entry=
+From\ import=
+No\ problems\ found.=
+%0\ problem(s)\ found=
+Save\ changes=
+Discard\ changes=
+Library\ '%0'\ has\ changed.=
+Print\ entry\ preview=
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=
+Copy\ BibTeX\ key\ and\ title=
+File\ rename\ failed\ for\ %0\ entries.=
+Merged\ BibTeX\ source\ code=
+Invalid\ DOI\:\ '%0'.=
+should\ start\ with\ a\ name=
+should\ end\ with\ a\ name=
+unexpected\ closing\ curly\ bracket=
+unexpected\ opening\ curly\ bracket=
+capital\ letters\ are\ not\ masked\ using\ curly\ brackets\ {}=
+should\ contain\ a\ four\ digit\ number=
+should\ contain\ a\ valid\ page\ number\ range=
 Filled=
-Field_is_missing=
-Search_%0=
+Field\ is\ missing=
+Search\ %0=
 
-Search_results_in_all_libraries_for_%0=
-Search_results_in_library_%0_for_%1=
-Search_globally=
-No_results_found.=
-Found_%0_results.=
-plain_text=
-This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>=
-This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>=
-This_search_contains_entries_in_which=
+Search\ results\ in\ all\ libraries\ for\ %0=
+Search\ results\ in\ library\ %0\ for\ %1=
+Search\ globally=
+No\ results\ found.=
+Found\ %0\ results.=
+plain\ text=
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ regular\ expression\ <b>%0</b>=
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ term\ <b>%0</b>=
+This\ search\ contains\ entries\ in\ which=
 
-Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.=
-JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>=
-This_library_uses_outdated_file_links.=
+Unable\ to\ autodetect\ OpenOffice/LibreOffice\ installation.\ Please\ choose\ the\ installation\ directory\ manually.=
+JabRef\ no\ longer\ supports\ 'ps'\ or\ 'pdf'\ fields.<br>File\ links\ are\ now\ stored\ in\ the\ 'file'\ field\ and\ files\ are\ stored\ in\ an\ external\ file\ directory.<br>To\ make\ use\ of\ this\ feature,\ JabRef\ needs\ to\ upgrade\ file\ links.<br><br>=
+This\ library\ uses\ outdated\ file\ links.=
 
-Clear_search=
-Close_library=
-Close_entry_editor=
-Decrease_table_font_size=
-Entry_editor,_next_entry=
-Entry_editor,_next_panel=
-Entry_editor,_next_panel_2=
-Entry_editor,_previous_entry=
-Entry_editor,_previous_panel=
-Entry_editor,_previous_panel_2=
-File_list_editor,_move_entry_down=
-File_list_editor,_move_entry_up=
-Focus_entry_table=
-Import_into_current_library=
-Import_into_new_library=
-Increase_table_font_size=
-New_article=
-New_book=
-New_entry=
-New_from_plain_text=
-New_inbook=
-New_mastersthesis=
-New_phdthesis=
-New_proceedings=
-New_unpublished=
-Next_tab=
-Preamble_editor,_store_changes=
-Previous_tab=
-Push_to_application=
-Refresh_OpenOffice/LibreOffice=
-Resolve_duplicate_BibTeX_keys=
-Save_all=
-String_dialog,_add_string=
-String_dialog,_remove_string=
-Synchronize_files=
+Clear\ search=
+Close\ library=
+Close\ entry\ editor=
+Decrease\ table\ font\ size=
+Entry\ editor,\ next\ entry=
+Entry\ editor,\ next\ panel=
+Entry\ editor,\ next\ panel\ 2=
+Entry\ editor,\ previous\ entry=
+Entry\ editor,\ previous\ panel=
+Entry\ editor,\ previous\ panel\ 2=
+File\ list\ editor,\ move\ entry\ down=
+File\ list\ editor,\ move\ entry\ up=
+Focus\ entry\ table=
+Import\ into\ current\ library=
+Import\ into\ new\ library=
+Increase\ table\ font\ size=
+New\ article=
+New\ book=
+New\ entry=
+New\ from\ plain\ text=
+New\ inbook=
+New\ mastersthesis=
+New\ phdthesis=
+New\ proceedings=
+New\ unpublished=
+Next\ tab=
+Preamble\ editor,\ store\ changes=
+Previous\ tab=
+Push\ to\ application=
+Refresh\ OpenOffice/LibreOffice=
+Resolve\ duplicate\ BibTeX\ keys=
+Save\ all=
+String\ dialog,\ add\ string=
+String\ dialog,\ remove\ string=
+Synchronize\ files=
 Unabbreviate=
-should_contain_a_protocol=
-Copy_preview=
-Automatically_setting_file_links=
-Regenerating_BibTeX_keys_according_to_metadata=
-No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys=
-Regenerate_all_keys_for_the_entries_in_a_BibTeX_file=
-Show_debug_level_messages=
-Default_bibliography_mode=
-New_%0_library_created.=
-Show_only_preferences_deviating_from_their_default_value=
+should\ contain\ a\ protocol=
+Copy\ preview=
+Automatically\ setting\ file\ links=
+Regenerating\ BibTeX\ keys\ according\ to\ metadata=
+No\ meta\ data\ present\ in\ BIB\ file.\ Cannot\ regenerate\ BibTeX\ keys=
+Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=
+Show\ debug\ level\ messages=
+Default\ bibliography\ mode=
+New\ %0\ library\ created.=
+Show\ only\ preferences\ deviating\ from\ their\ default\ value=
 default=
 key=
 type=
 value=
-Show_preferences=
-Save_actions=
-Enable_save_actions=
+Show\ preferences=
+Save\ actions=
+Enable\ save\ actions=
 
-Other_fields=
-Show_remaining_fields=
+Other\ fields=
+Show\ remaining\ fields=
 
-link_should_refer_to_a_correct_file_path=
-abbreviation_detected=
-wrong_entry_type_as_proceedings_has_page_numbers=
-Abbreviate_journal_names=
+link\ should\ refer\ to\ a\ correct\ file\ path=
+abbreviation\ detected=
+wrong\ entry\ type\ as\ proceedings\ has\ page\ numbers=
+Abbreviate\ journal\ names=
 Abbreviating...=
-Abbreviation_%s_for_journal_%s_already_defined.=
-Abbreviation_cannot_be_empty=
-Duplicated_Journal_Abbreviation=
-Duplicated_Journal_File=
-Error_Occurred=
-Journal_file_%s_already_added=
-Name_cannot_be_empty=
+Abbreviation\ %s\ for\ journal\ %s\ already\ defined.=
+Abbreviation\ cannot\ be\ empty=
+Duplicated\ Journal\ Abbreviation=
+Duplicated\ Journal\ File=
+Error\ Occurred=
+Journal\ file\ %s\ already\ added=
+Name\ cannot\ be\ empty=
 
-Adding_fetched_entries=
-Display_keywords_appearing_in_ALL_entries=
-Display_keywords_appearing_in_ANY_entry=
-Fetching_entries_from_Inspire=
-None_of_the_selected_entries_have_titles.=
-None_of_the_selected_entries_have_BibTeX_keys.=
-Unabbreviate_journal_names=
+Adding\ fetched\ entries=
+Display\ keywords\ appearing\ in\ ALL\ entries=
+Display\ keywords\ appearing\ in\ ANY\ entry=
+Fetching\ entries\ from\ Inspire=
+None\ of\ the\ selected\ entries\ have\ titles.=
+None\ of\ the\ selected\ entries\ have\ BibTeX\ keys.=
+Unabbreviate\ journal\ names=
 Unabbreviating...=
 Usage=
 
 
-Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.=
-Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
-Reset_preferences=
-Ill-formed_entrytype_comment_in_BIB_file=
+Adds\ {}\ brackets\ around\ acronyms,\ month\ names\ and\ countries\ to\ preserve\ their\ case.=
+Are\ you\ sure\ you\ want\ to\ reset\ all\ settings\ to\ default\ values?=
+Reset\ preferences=
+Ill-formed\ entrytype\ comment\ in\ BIB\ file=
 
-Move_linked_files_to_default_file_directory_%0=
+Move\ linked\ files\ to\ default\ file\ directory\ %0=
 
 Clipboard=
-Could_not_paste_entry_as_text\:=
-Do_you_still_want_to_continue?=
-This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:=
-This_could_cause_undesired_changes_to_your_entries.=
-Run_field_formatter\:=
-Table_font_size_is_%0=
-%0_import_canceled=
-Internal_style=
-Add_style_file=
-Are_you_sure_you_want_to_remove_the_style?=
-Current_style_is_'%0'=
-Remove_style=
-Select_one_of_the_available_styles_or_add_a_style_file_from_disk.=
-You_must_select_a_valid_style_file.=
+Could\ not\ paste\ entry\ as\ text\:=
+Do\ you\ still\ want\ to\ continue?=
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=
+This\ could\ cause\ undesired\ changes\ to\ your\ entries.=
+Run\ field\ formatter\:=
+Table\ font\ size\ is\ %0=
+%0\ import\ canceled=
+Internal\ style=
+Add\ style\ file=
+Are\ you\ sure\ you\ want\ to\ remove\ the\ style?=
+Current\ style\ is\ '%0'=
+Remove\ style=
+Select\ one\ of\ the\ available\ styles\ or\ add\ a\ style\ file\ from\ disk.=
+You\ must\ select\ a\ valid\ style\ file.=
 Reload=
 
 Capitalize=
-Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.=
-Capitalize_the_first_word,_changes_other_words_to_lower_case.=
-Changes_all_letters_to_lower_case.=
-Changes_all_letters_to_upper_case.=
-Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.=
-Cleans_up_LaTeX_code.=
-Converts_HTML_code_to_LaTeX_code.=
-Converts_HTML_code_to_Unicode.=
-Converts_LaTeX_encoding_to_Unicode_characters.=
-Converts_Unicode_characters_to_LaTeX_encoding.=
-Converts_ordinals_to_LaTeX_superscripts.=
-Converts_units_to_LaTeX_formatting.=
-HTML_to_LaTeX=
-LaTeX_cleanup=
-LaTeX_to_Unicode=
-Lower_case=
-Minify_list_of_person_names=
-Normalize_date=
-Normalize_month=
-Normalize_month_to_BibTeX_standard_abbreviation.=
-Normalize_names_of_persons=
-Normalize_page_numbers=
-Normalize_pages_to_BibTeX_standard.=
-Normalizes_lists_of_persons_to_the_BibTeX_standard.=
-Normalizes_the_date_to_ISO_date_format.=
-Ordinals_to_LaTeX_superscript=
-Protect_terms=
-Remove_enclosing_braces=
-Removes_braces_encapsulating_the_complete_field_content.=
-Sentence_case=
-Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".=
-Title_case=
-Unicode_to_LaTeX=
-Units_to_LaTeX=
-Upper_case=
-Does_nothing.=
+Capitalize\ all\ words,\ but\ converts\ articles,\ prepositions,\ and\ conjunctions\ to\ lower\ case.=
+Capitalize\ the\ first\ word,\ changes\ other\ words\ to\ lower\ case.=
+Changes\ all\ letters\ to\ lower\ case.=
+Changes\ all\ letters\ to\ upper\ case.=
+Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=
+Cleans\ up\ LaTeX\ code.=
+Converts\ HTML\ code\ to\ LaTeX\ code.=
+Converts\ HTML\ code\ to\ Unicode.=
+Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=
+Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=
+Converts\ ordinals\ to\ LaTeX\ superscripts.=
+Converts\ units\ to\ LaTeX\ formatting.=
+HTML\ to\ LaTeX=
+LaTeX\ cleanup=
+LaTeX\ to\ Unicode=
+Lower\ case=
+Minify\ list\ of\ person\ names=
+Normalize\ date=
+Normalize\ month=
+Normalize\ month\ to\ BibTeX\ standard\ abbreviation.=
+Normalize\ names\ of\ persons=
+Normalize\ page\ numbers=
+Normalize\ pages\ to\ BibTeX\ standard.=
+Normalizes\ lists\ of\ persons\ to\ the\ BibTeX\ standard.=
+Normalizes\ the\ date\ to\ ISO\ date\ format.=
+Ordinals\ to\ LaTeX\ superscript=
+Protect\ terms=
+Remove\ enclosing\ braces=
+Removes\ braces\ encapsulating\ the\ complete\ field\ content.=
+Sentence\ case=
+Shortens\ lists\ of\ persons\ if\ there\ are\ more\ than\ 2\ persons\ to\ "et\ al.".=
+Title\ case=
+Unicode\ to\ LaTeX=
+Units\ to\ LaTeX=
+Upper\ case=
+Does\ nothing.=
 Identity=
-Clears_the_field_completely.=
-Directory_not_found=
-Main_file_directory_not_set\!=
-This_operation_requires_exactly_one_item_to_be_selected.=
-Importing_in_%0_format=
-Female_name=
-Female_names=
-Male_name=
-Male_names=
-Mixed_names=
-Neuter_name=
-Neuter_names=
+Clears\ the\ field\ completely.=
+Directory\ not\ found=
+Main\ file\ directory\ not\ set\!=
+This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=
+Importing\ in\ %0\ format=
+Female\ name=
+Female\ names=
+Male\ name=
+Male\ names=
+Mixed\ names=
+Neuter\ name=
+Neuter\ names=
 
-Determined_%0_for_%1_entries=
-Look_up_%0=
-Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3=
+Determined\ %0\ for\ %1\ entries=
+Look\ up\ %0=
+Looking\ up\ %0...\ -\ entry\ %1\ out\ of\ %2\ -\ found\ %3=
 
-Audio_CD=
-British_patent=
-British_patent_request=
-Candidate_thesis=
+Audio\ CD=
+British\ patent=
+British\ patent\ request=
+Candidate\ thesis=
 Collaborator=
 Column=
 Compiler=
 Continuator=
-Data_CD=
+Data\ CD=
 Editor=
-European_patent=
-European_patent_request=
+European\ patent=
+European\ patent\ request=
 Founder=
-French_patent=
-French_patent_request=
-German_patent=
-German_patent_request=
+French\ patent=
+French\ patent\ request=
+German\ patent=
+German\ patent\ request=
 Line=
-Master's_thesis=
+Master's\ thesis=
 Page=
 Paragraph=
 Patent=
-Patent_request=
-PhD_thesis=
+Patent\ request=
+PhD\ thesis=
 Redactor=
-Research_report=
+Research\ report=
 Reviser=
 Section=
 Software=
-Technical_report=
-U.S._patent=
-U.S._patent_request=
+Technical\ report=
+U.S.\ patent=
+U.S.\ patent\ request=
 Verse=
 
-change_entries_of_group=
-odd_number_of_unescaped_'\#'=
+change\ entries\ of\ group=
+odd\ number\ of\ unescaped\ '\#'=
 
-Plain_text=
-Show_diff=
+Plain\ text=
+Show\ diff=
 character=
 word=
-Show_symmetric_diff=
-Copy_Version=
+Show\ symmetric\ diff=
+Copy\ Version=
 Developers=
 Authors=
 License=
 
-HTML_encoded_character_found=
-booktitle_ends_with_'conference_on'=
+HTML\ encoded\ character\ found=
+booktitle\ ends\ with\ 'conference\ on'=
 
-All_external_files=
+All\ external\ files=
 
-OpenOffice/LibreOffice_integration=
+OpenOffice/LibreOffice\ integration=
 
-incorrect_control_digit=
-incorrect_format=
-Copied_version_to_clipboard=
+incorrect\ control\ digit=
+incorrect\ format=
+Copied\ version\ to\ clipboard=
 
-BibTeX_key=
+BibTeX\ key=
 Message=
 
 
-MathSciNet_Review=
-Reset_Bindings=
+MathSciNet\ Review=
+Reset\ Bindings=
 
-Decryption_not_supported.=
+Decryption\ not\ supported.=
 
-Cleared_'%0'_for_%1_entries=
-Set_'%0'_to_'%1'_for_%2_entries=
-Toggled_'%0'_for_%1_entries=
+Cleared\ '%0'\ for\ %1\ entries=
+Set\ '%0'\ to\ '%1'\ for\ %2\ entries=
+Toggled\ '%0'\ for\ %1\ entries=
 
-Check_for_updates=
-Download_update=
-New_version_available=
-Installed_version=
-Remind_me_later=
-Ignore_this_update=
-Could_not_connect_to_the_update_server.=
-Please_try_again_later_and/or_check_your_network_connection.=
-To_see_what_is_new_view_the_changelog.=
-A_new_version_of_JabRef_has_been_released.=
-JabRef_is_up-to-date.=
-Latest_version=
-Online_help_forum=
+Check\ for\ updates=
+Download\ update=
+New\ version\ available=
+Installed\ version=
+Remind\ me\ later=
+Ignore\ this\ update=
+Could\ not\ connect\ to\ the\ update\ server.=
+Please\ try\ again\ later\ and/or\ check\ your\ network\ connection.=
+To\ see\ what\ is\ new\ view\ the\ changelog.=
+A\ new\ version\ of\ JabRef\ has\ been\ released.=
+JabRef\ is\ up-to-date.=
+Latest\ version=
+Online\ help\ forum=
 Custom=
 
-Export_cited=
-Unable_to_generate_new_library=
+Export\ cited=
+Unable\ to\ generate\ new\ library=
 
-Open_console=
-Use_default_terminal_emulator=
-Execute_command=
-Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.=
-Executing_command_\"%0\"...=
-Error_occured_while_executing_the_command_\"%0\".=
-Reformat_ISSN=
+Open\ console=
+Use\ default\ terminal\ emulator=
+Execute\ command=
+Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=
+Executing\ command\ \"%0\"...=
+Error\ occured\ while\ executing\ the\ command\ \"%0\".=
+Reformat\ ISSN=
 
-Countries_and_territories_in_English=
-Electrical_engineering_terms=
+Countries\ and\ territories\ in\ English=
+Electrical\ engineering\ terms=
 Enabled=
-Internal_list=
-Manage_protected_terms_files=
-Months_and_weekdays_in_English=
-The_text_after_the_last_line_starting_with_\#_will_be_used=
-Add_protected_terms_file=
-Are_you_sure_you_want_to_remove_the_protected_terms_file?=
-Remove_protected_terms_file=
-Add_selected_text_to_list=
-Add_{}_around_selected_text=
-Format_field=
-New_protected_terms_file=
-change_field_%0_of_entry_%1_from_%2_to_%3=
-change_key_from_%0_to_%1=
-change_string_content_%0_to_%1=
-change_string_name_%0_to_%1=
-change_type_of_entry_%0_from_%1_to_%2=
-insert_entry_%0=
-insert_string_%0=
-remove_entry_%0=
-remove_string_%0=
+Internal\ list=
+Manage\ protected\ terms\ files=
+Months\ and\ weekdays\ in\ English=
+The\ text\ after\ the\ last\ line\ starting\ with\ \#\ will\ be\ used=
+Add\ protected\ terms\ file=
+Are\ you\ sure\ you\ want\ to\ remove\ the\ protected\ terms\ file?=
+Remove\ protected\ terms\ file=
+Add\ selected\ text\ to\ list=
+Add\ {}\ around\ selected\ text=
+Format\ field=
+New\ protected\ terms\ file=
+change\ field\ %0\ of\ entry\ %1\ from\ %2\ to\ %3=
+change\ key\ from\ %0\ to\ %1=
+change\ string\ content\ %0\ to\ %1=
+change\ string\ name\ %0\ to\ %1=
+change\ type\ of\ entry\ %0\ from\ %1\ to\ %2=
+insert\ entry\ %0=
+insert\ string\ %0=
+remove\ entry\ %0=
+remove\ string\ %0=
 undefined=
-Cannot_get_info_based_on_given_%0\:_%1=
-Get_BibTeX_data_from_%0=
-No_%0_found=
-Entry_from_%0=
-Merge_entry_with_%0_information=
-Updated_entry_with_info_from_%0=
+Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=
+Get\ BibTeX\ data\ from\ %0=
+No\ %0\ found=
+Entry\ from\ %0=
+Merge\ entry\ with\ %0\ information=
+Updated\ entry\ with\ info\ from\ %0=
 
-Add_existing_file=
-Create_new_list=
-Remove_list=
-Full_journal_name=
-Abbreviation_name=
+Add\ existing\ file=
+Create\ new\ list=
+Remove\ list=
+Full\ journal\ name=
+Abbreviation\ name=
 
-No_abbreviation_files_loaded=
+No\ abbreviation\ files\ loaded=
 
-Loading_built_in_lists=
+Loading\ built\ in\ lists=
 
-JabRef_built_in_list=
-IEEE_built_in_list=
+JabRef\ built\ in\ list=
+IEEE\ built\ in\ list=
 
-Event_log=
-We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.=
-Log_copied_to_clipboard.=
-Copy_Log=
-Clear_Log=
-Report_Issue=
-Issue_on_GitHub_successfully_reported.=
-Issue_report_successful=
-Your_issue_was_reported_in_your_browser.=
-The_log_and_exception_information_was_copied_to_your_clipboard.=
-Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.=
+Event\ log=
+We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef\'s\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=
+Log\ copied\ to\ clipboard.=
+Copy\ Log=
+Clear\ Log=
+Report\ Issue=
+Issue\ on\ GitHub\ successfully\ reported.=
+Issue\ report\ successful=
+Your\ issue\ was\ reported\ in\ your\ browser.=
+The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=
+Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=
 
 Connection=
 Connecting...=
@@ -2164,194 +2164,194 @@ Port=
 Library=
 User=
 Connect=Σύνδεση
-Connection_error=
-Connection_to_%0_server_established.=
-Required_field_"%0"_is_empty.=
-%0_driver_not_available.=
-The_connection_to_the_server_has_been_terminated.=
-Connection_lost.=
+Connection\ error=
+Connection\ to\ %0\ server\ established.=
+Required\ field\ "%0"\ is\ empty.=
+%0\ driver\ not\ available.=
+The\ connection\ to\ the\ server\ has\ been\ terminated.=
+Connection\ lost.=
 Reconnect=
-Work_offline=
-Working_offline.=
-Update_refused.=
-Update_refused=
-Local_entry=
-Shared_entry=
-Update_could_not_be_performed_due_to_existing_change_conflicts.=
-You_are_not_working_on_the_newest_version_of_BibEntry.=
-Local_version\:_%0=
-Shared_version\:_%0=
-Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.=
-Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?=
-Shared_entry_is_no_longer_present=
-The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.=
-You_can_restore_the_entry_using_the_"Undo"_operation.=
-Remember_password?=
-You_are_already_connected_to_a_database_using_entered_connection_details.=
+Work\ offline=
+Working\ offline.=
+Update\ refused.=
+Update\ refused=
+Local\ entry=
+Shared\ entry=
+Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=
+You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=
+Local\ version\:\ %0=
+Shared\ version\:\ %0=
+Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=
+Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=
+Shared\ entry\ is\ no\ longer\ present=
+The\ BibEntry\ you\ currently\ work\ on\ has\ been\ deleted\ on\ the\ shared\ side.=
+You\ can\ restore\ the\ entry\ using\ the\ "Undo"\ operation.=
+Remember\ password?=
+You\ are\ already\ connected\ to\ a\ database\ using\ entered\ connection\ details.=
 
-Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?=
-New_technical_report=
+Cannot\ cite\ entries\ without\ BibTeX\ keys.\ Generate\ keys\ now?=
+New\ technical\ report=
 
-%0_file=
-Custom_layout_file=
-Protected_terms_file=
-Style_file=
+%0\ file=
+Custom\ layout\ file=
+Protected\ terms\ file=
+Style\ file=
 
-Open_OpenOffice/LibreOffice_connection=
-You_must_enter_at_least_one_field_name=
-Non-ASCII_encoded_character_found=
-Toggle_web_search_interface=
-Background_color_for_resolved_fields=
-Color_code_for_resolved_fields=
-%0_files_found=
-%0_of_%1=
-One_file_found=
-The_import_finished_with_warnings\:=
-There_was_one_file_that_could_not_be_imported.=
-There_were_%0_files_which_could_not_be_imported.=
+Open\ OpenOffice/LibreOffice\ connection=
+You\ must\ enter\ at\ least\ one\ field\ name=
+Non-ASCII\ encoded\ character\ found=
+Toggle\ web\ search\ interface=
+Background\ color\ for\ resolved\ fields=
+Color\ code\ for\ resolved\ fields=
+%0\ files\ found=
+%0\ of\ %1=
+One\ file\ found=
+The\ import\ finished\ with\ warnings\:=
+There\ was\ one\ file\ that\ could\ not\ be\ imported.=
+There\ were\ %0\ files\ which\ could\ not\ be\ imported.=
 
-Migration_help_information=
-Entered_database_has_obsolete_structure_and_is_no_longer_supported.=
-However,_a_new_database_was_created_alongside_the_pre-3.6_one.=
-Click_here_to_learn_about_the_migration_of_pre-3.6_databases.=
-Opens_JabRef's_Facebook_page=
-Opens_JabRef's_blog=
-Opens_JabRef's_website=
-Opens_a_link_where_the_current_development_version_can_be_downloaded=
-See_what_has_been_changed_in_the_JabRef_versions=
-Referenced_BibTeX_key_does_not_exist=
-Finished_downloading_full_text_document_for_entry_%0.=
-Full_text_document_download_failed_for_entry_%0.=
-Look_up_full_text_documents=
-You_are_about_to_look_up_full_text_documents_for_%0_entries.=
-last_four_nonpunctuation_characters_should_be_numerals=
+Migration\ help\ information=
+Entered\ database\ has\ obsolete\ structure\ and\ is\ no\ longer\ supported.=
+However,\ a\ new\ database\ was\ created\ alongside\ the\ pre-3.6\ one.=
+Click\ here\ to\ learn\ about\ the\ migration\ of\ pre-3.6\ databases.=
+Opens\ JabRef's\ Facebook\ page=
+Opens\ JabRef's\ blog=
+Opens\ JabRef's\ website=
+Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=
+See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=
+Referenced\ BibTeX\ key\ does\ not\ exist=
+Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=
+Full\ text\ document\ download\ failed\ for\ entry\ %0.=
+Look\ up\ full\ text\ documents=
+You\ are\ about\ to\ look\ up\ full\ text\ documents\ for\ %0\ entries.=
+last\ four\ nonpunctuation\ characters\ should\ be\ numerals=
 
 Author=
 Date=
-File_annotations=
-Show_file_annotations=
-Adobe_Acrobat_Reader=
-Sumatra_Reader=
+File\ annotations=
+Show\ file\ annotations=
+Adobe\ Acrobat\ Reader=
+Sumatra\ Reader=
 shared=
-should_contain_an_integer_or_a_literal=
-should_have_the_first_letter_capitalized=
+should\ contain\ an\ integer\ or\ a\ literal=
+should\ have\ the\ first\ letter\ capitalized=
 Tools=
-What\'s_new_in_this_version?=
-Want_to_help?=
-Make_a_donation=
-get_involved=
-Used_libraries=
-Existing_file=
+What\'s\ new\ in\ this\ version?=
+Want\ to\ help?=
+Make\ a\ donation=
+get\ involved=
+Used\ libraries=
+Existing\ file=
 
 ID=
-ID_type=
-ID-based_entry_generator=
-Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+ID\ type=
+ID-based\ entry\ generator=
+Fetcher\ '%0'\ did\ not\ find\ an\ entry\ for\ id\ '%1'.=
 
-Select_first_entry=
-Select_last_entry=
+Select\ first\ entry=
+Select\ last\ entry=
 
-Invalid_ISBN\:_'%0'.=
-should_be_an_integer_or_normalized=
-should_be_normalized=
+Invalid\ ISBN\:\ '%0'.=
+should\ be\ an\ integer\ or\ normalized=
+should\ be\ normalized=
 
-Empty_search_ID=
-The_given_search_ID_was_empty.=
-Copy_BibTeX_key_and_link=
-empty_BibTeX_key=
-biblatex_field_only=
+Empty\ search\ ID=
+The\ given\ search\ ID\ was\ empty.=
+Copy\ BibTeX\ key\ and\ link=
+empty\ BibTeX\ key=
+biblatex\ field\ only=
 
-Error_while_generating_fetch_URL=
-Error_while_parsing_ID_list=
-Unable_to_get_PubMed_IDs=
-Backup_found=
-A_backup_file_for_'%0'_was_found.=
-This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.=
-Do_you_want_to_recover_the_library_from_the_backup_file?=
-Firstname_Lastname=
+Error\ while\ generating\ fetch\ URL=
+Error\ while\ parsing\ ID\ list=
+Unable\ to\ get\ PubMed\ IDs=
+Backup\ found=
+A\ backup\ file\ for\ '%0'\ was\ found.=
+This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=
+Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=
+Firstname\ Lastname=
 
-Recommended_for_%0=
-Show_'Related_Articles'_tab=
-This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
+Recommended\ for\ %0=
+Show\ 'Related\ Articles'\ tab=
+This\ might\ be\ caused\ by\ reaching\ the\ traffic\ limitation\ of\ Google\ Scholar\ (see\ 'Help'\ for\ details).=
 
-Could_not_open_website.=
-Problem_downloading_from_%1=
+Could\ not\ open\ website.=
+Problem\ downloading\ from\ %1=
 
-File_directory_pattern=
-Update_with_bibliographic_information_from_the_web=
+File\ directory\ pattern=
+Update\ with\ bibliographic\ information\ from\ the\ web=
 
-Could_not_find_any_bibliographic_information.=
-BibTeX_key_deviates_from_generated_key=
-DOI_%0_is_invalid=
+Could\ not\ find\ any\ bibliographic\ information.=
+BibTeX\ key\ deviates\ from\ generated\ key=
+DOI\ %0\ is\ invalid=
 
-Select_all_customized_types_to_be_stored_in_local_preferences=
-Currently_unknown=
-Different_customization,_current_settings_will_be_overwritten=
+Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences=
+Currently\ unknown=
+Different\ customization,\ current\ settings\ will\ be\ overwritten=
 
-Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX=
-Jump_to_entry=
+Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=
+Jump\ to\ entry=
 
-Copied_%0_citations.=
+Copied\ %0\ citations.=
 Copying...=
 
-journal_not_found_in_abbreviation_list=
-Unhandled_exception_occurred.=
+journal\ not\ found\ in\ abbreviation\ list=
+Unhandled\ exception\ occurred.=
 
-strings_included=
-Color_for_disabled_icons=
-Color_for_enabled_icons=
-Size_of_large_icons=
-Size_of_small_icons=
-Default_table_font_size=
-Escape_underscores=
+strings\ included=
+Color\ for\ disabled\ icons=
+Color\ for\ enabled\ icons=
+Size\ of\ large\ icons=
+Size\ of\ small\ icons=
+Default\ table\ font\ size=
+Escape\ underscores=
 Color=
-Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=
-Fit_width=
-Fit_a_single_page=
-Zoom_in=
-Zoom_out=
-Previous_page=
-Next_page=
-Document_viewer=
+Please\ also\ add\ all\ steps\ to\ reproduce\ this\ issue,\ if\ possible.=
+Fit\ width=
+Fit\ a\ single\ page=
+Zoom\ in=
+Zoom\ out=
+Previous\ page=
+Next\ page=
+Document\ viewer=
 Live=
 Locked=
-Show_document_viewer=
-Show_the_document_of_the_currently_selected_entry.=
-Show_this_document_until_unlocked.=
-Set_current_user_name_as_owner.=
+Show\ document\ viewer=
+Show\ the\ document\ of\ the\ currently\ selected\ entry.=
+Show\ this\ document\ until\ unlocked.=
+Set\ current\ user\ name\ as\ owner.=
 
-Sort_all_subgroups_(recursively)=
-Collect_and_share_telemetry_data_to_help_improve_JabRef.=
-Don't_share=
-Share_anonymous_statistics=
-Telemetry\:_Help_make_JabRef_better=
-To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.=
-This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?=
-Names_are_not_in_the_standard_%0_format.=
+Sort\ all\ subgroups\ (recursively)=
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=
+Don't\ share=
+Share\ anonymous\ statistics=
+Telemetry\:\ Help\ make\ JabRef\ better=
+To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ statistics\ on\ the\ features\ you\ use.\ We\ will\ only\ record\ what\ features\ you\ access\ and\ how\ often\ you\ do\ it.\ We\ will\ neither\ collect\ any\ personal\ data\ nor\ the\ content\ of\ bibliographic\ items.\ If\ you\ choose\ to\ allow\ data\ collection,\ you\ can\ later\ disable\ it\ via\ Options\ ->\ Preferences\ ->\ General.=
+This\ file\ was\ found\ automatically.\ Do\ you\ want\ to\ link\ it\ to\ this\ entry?=
+Names\ are\ not\ in\ the\ standard\ %0\ format.=
 
-Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.=
-Delete_'%0'=
-Delete_from_disk=
-Remove_from_entry=
-The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.=
-There_exists_already_a_group_with_the_same_name.=
+Delete\ the\ selected\ file\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ file\ permanently\ from\ disk.=
+Delete\ '%0'=
+Delete\ from\ disk=
+Remove\ from\ entry=
+The\ group\ name\ contains\ the\ keyword\ separator\ "%0"\ and\ thus\ probably\ does\ not\ work\ as\ expected.=
+There\ exists\ already\ a\ group\ with\ the\ same\ name.=
 
-Copy_linked_files_to_folder...=
-Copied_file_successfully=
-Copying_files...=
-Copying_file_%0_of_entry_%1=
-Finished_copying=
-Could_not_copy_file=
-Copied_%0_files_of_%1_sucessfully_to_%2=
-Rename_failed=
-JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.=
-Show_console_output_(only_necessary_when_the_launcher_is_used)=
+Copy\ linked\ files\ to\ folder...=
+Copied\ file\ successfully=
+Copying\ files...=
+Copying\ file\ %0\ of\ entry\ %1=
+Finished\ copying=
+Could\ not\ copy\ file=
+Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=
+Rename\ failed=
+JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=
+Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=
 
-Remove_line_breaks=
-Removes_all_line_breaks_in_the_field_content.=
-Checking_integrity...=
+Remove\ line\ breaks=
+Removes\ all\ line\ breaks\ in\ the\ field\ content.=
+Checking\ integrity...=
 
-Remove_hyphenated_line_breaks=
-Removes_all_hyphenated_line_breaks_in_the_field_content.=
-Note_that_currently,_JabRef_does_not_run_with_Java_9.=
-Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.=
+Remove\ hyphenated\ line\ breaks=
+Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=
+Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=
+Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -3,156 +3,156 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-%0_contains_the_regular_expression_<b>%1</b>=%0_contains_the_regular_expression_<b>%1</b>
+%0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 contains the regular expression <b>%1</b>
 
-%0_contains_the_term_<b>%1</b>=%0_contains_the_term_<b>%1</b>
+%0\ contains\ the\ term\ <b>%1</b>=%0 contains the term <b>%1</b>
 
-%0_doesn't_contain_the_regular_expression_<b>%1</b>=%0_doesn't_contain_the_regular_expression_<b>%1</b>
+%0\ doesn't\ contain\ the\ regular\ expression\ <b>%1</b>=%0 doesn't contain the regular expression <b>%1</b>
 
-%0_doesn't_contain_the_term_<b>%1</b>=%0_doesn't_contain_the_term_<b>%1</b>
+%0\ doesn't\ contain\ the\ term\ <b>%1</b>=%0 doesn't contain the term <b>%1</b>
 
-%0_export_successful=%0_export_successful
+%0\ export\ successful=%0 export successful
 
-%0_matches_the_regular_expression_<b>%1</b>=%0_matches_the_regular_expression_<b>%1</b>
+%0\ matches\ the\ regular\ expression\ <b>%1</b>=%0 matches the regular expression <b>%1</b>
 
-%0_matches_the_term_<b>%1</b>=%0_matches_the_term_<b>%1</b>
+%0\ matches\ the\ term\ <b>%1</b>=%0 matches the term <b>%1</b>
 
-<field_name>=<field_name>
-<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>=<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>
+<field\ name>=<field name>
+<HTML>Could\ not\ find\ file\ '%0'<BR>linked\ from\ entry\ '%1'</HTML>=<HTML>Could not find file '%0'<BR>linked from entry '%1'</HTML>
 
 <select>=<select>
 
-<select_word>=<select_word>
-Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)=Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)
-Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)=Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)
+<select\ word>=<select word>
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (ISO\ abbreviation)=Abbreviate journal names of the selected entries (ISO abbreviation)
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (MEDLINE\ abbreviation)=Abbreviate journal names of the selected entries (MEDLINE abbreviation)
 
-Abbreviate_names=Abbreviate_names
-Abbreviated_%0_journal_names.=Abbreviated_%0_journal_names.
+Abbreviate\ names=Abbreviate names
+Abbreviated\ %0\ journal\ names.=Abbreviated %0 journal names.
 
 Abbreviation=Abbreviation
 
-About_JabRef=About_JabRef
+About\ JabRef=About JabRef
 
 Abstract=Abstract
 
 Accept=Accept
 
-Accept_change=Accept_change
+Accept\ change=Accept change
 
 Action=Action
 
-What_is_Mr._DLib?=What_is_Mr._DLib?
+What\ is\ Mr.\ DLib?=What is Mr. DLib?
 
 Add=Add
 
-Add_a_(compiled)_custom_Importer_class_from_a_class_path.=Add_a_(compiled)_custom_Importer_class_from_a_class_path.
-The_path_need_not_be_on_the_classpath_of_JabRef.=The_path_need_not_be_on_the_classpath_of_JabRef.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=Add a (compiled) custom Importer class from a class path.
+The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=The path need not be on the classpath of JabRef.
 
-Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.
-The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=Add a (compiled) custom Importer class from a ZIP-archive.
+The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=The ZIP-archive need not be on the classpath of JabRef.
 
-Add_a_regular_expression_for_the_key_pattern.=Add_a_regular_expression_for_the_key_pattern.
+Add\ a\ regular\ expression\ for\ the\ key\ pattern.=Add a regular expression for the key pattern.
 
-Add_selected_entries_to_this_group=Add_selected_entries_to_this_group
+Add\ selected\ entries\ to\ this\ group=Add selected entries to this group
 
-Add_from_folder=Add_from_folder
+Add\ from\ folder=Add from folder
 
-Add_from_JAR=Add_from_JAR
+Add\ from\ JAR=Add from JAR
 
-add_group=add_group
+add\ group=add group
 
-Add_new=Add_new
+Add\ new=Add new
 
-Add_subgroup=Add_subgroup
+Add\ subgroup=Add subgroup
 
-Add_to_group=Add_to_group
+Add\ to\ group=Add to group
 
-Added_group_"%0".=Added_group_"%0".
+Added\ group\ "%0".=Added group "%0".
 
-Added_missing_braces.=Added_missing_braces.
+Added\ missing\ braces.=Added missing braces.
 
-Added_new=Added_new
+Added\ new=Added new
 
-Added_string=Added_string
+Added\ string=Added string
 
-Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.=Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.
+Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ can\ be\ assigned\ manually\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ This\ process\ adds\ the\ term\ <b>%1</b>\ to\ each\ entry's\ <b>%0</b>\ field.\ Entries\ can\ be\ removed\ manually\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.\ This\ process\ removes\ the\ term\ <b>%1</b>\ from\ each\ entry's\ <b>%0</b>\ field.=Additionally, entries whose <b>%0</b> field does not contain <b>%1</b> can be assigned manually to this group by selecting them then using either drag and drop or the context menu. This process adds the term <b>%1</b> to each entry's <b>%0</b> field. Entries can be removed manually from this group by selecting them then using the context menu. This process removes the term <b>%1</b> from each entry's <b>%0</b> field.
 
 Advanced=Advanced
-All_entries=All_entries
-All_entries_of_this_type_will_be_declared_typeless._Continue?=All_entries_of_this_type_will_be_declared_typeless._Continue?
+All\ entries=All entries
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=All entries of this type will be declared typeless. Continue?
 
-All_fields=All_fields
+All\ fields=All fields
 
-Always_reformat_BIB_file_on_save_and_export=Always_reformat_BIB_file_on_save_and_export
+Always\ reformat\ BIB\ file\ on\ save\ and\ export=Always reformat BIB file on save and export
 
-A_SAX_exception_occurred_while_parsing_'%0'\:=A_SAX_exception_occurred_while_parsing_'%0'\:
+A\ SAX\ exception\ occurred\ while\ parsing\ '%0'\:=A SAX exception occurred while parsing '%0':
 
 and=and
-and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.=and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.
+and\ the\ class\ must\ be\ available\ in\ your\ classpath\ next\ time\ you\ start\ JabRef.=and the class must be available in your classpath next time you start JabRef.
 
-any_field_that_matches_the_regular_expression_<b>%0</b>=any_field_that_matches_the_regular_expression_<b>%0</b>
+any\ field\ that\ matches\ the\ regular\ expression\ <b>%0</b>=any field that matches the regular expression <b>%0</b>
 
 Appearance=Appearance
 
 Append=Append
-Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library=Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library
+Append\ contents\ from\ a\ BibTeX\ library\ into\ the\ currently\ viewed\ library=Append contents from a BibTeX library into the currently viewed library
 
-Append_library=Append_library
+Append\ library=Append library
 
-Append_the_selected_text_to_BibTeX_field=Append_the_selected_text_to_BibTeX_field
+Append\ the\ selected\ text\ to\ BibTeX\ field=Append the selected text to BibTeX field
 Application=Application
 
 Apply=Apply
 
-Arguments_passed_on_to_running_JabRef_instance._Shutting_down.=Arguments_passed_on_to_running_JabRef_instance._Shutting_down.
+Arguments\ passed\ on\ to\ running\ JabRef\ instance.\ Shutting\ down.=Arguments passed on to running JabRef instance. Shutting down.
 
-Assign_new_file=Assign_new_file
+Assign\ new\ file=Assign new file
 
-Assign_the_original_group's_entries_to_this_group?=Assign_the_original_group's_entries_to_this_group?
+Assign\ the\ original\ group's\ entries\ to\ this\ group?=Assign the original group's entries to this group?
 
-Assigned_%0_entries_to_group_"%1".=Assigned_%0_entries_to_group_"%1".
+Assigned\ %0\ entries\ to\ group\ "%1".=Assigned %0 entries to group "%1".
 
-Assigned_1_entry_to_group_"%0".=Assigned_1_entry_to_group_"%0".
+Assigned\ 1\ entry\ to\ group\ "%0".=Assigned 1 entry to group "%0".
 
-Attach_URL=Attach_URL
+Attach\ URL=Attach URL
 
-Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.=Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.
+Attempt\ to\ automatically\ set\ file\ links\ for\ your\ entries.\ Automatically\ setting\ works\ if\ a\ file\ in\ your\ file\ directory<BR>or\ a\ subdirectory\ is\ named\ identically\ to\ an\ entry's\ BibTeX\ key,\ plus\ extension.=Attempt to automatically set file links for your entries. Automatically setting works if a file in your file directory<BR>or a subdirectory is named identically to an entry's BibTeX key, plus extension.
 
-Autodetect_format=Autodetect_format
+Autodetect\ format=Autodetect format
 
-Autogenerate_BibTeX_keys=Autogenerate_BibTeX_keys
+Autogenerate\ BibTeX\ keys=Autogenerate BibTeX keys
 
-Autolink_files_with_names_starting_with_the_BibTeX_key=Autolink_files_with_names_starting_with_the_BibTeX_key
+Autolink\ files\ with\ names\ starting\ with\ the\ BibTeX\ key=Autolink files with names starting with the BibTeX key
 
-Autolink_only_files_that_match_the_BibTeX_key=Autolink_only_files_that_match_the_BibTeX_key
+Autolink\ only\ files\ that\ match\ the\ BibTeX\ key=Autolink only files that match the BibTeX key
 
-Automatically_create_groups=Automatically_create_groups
+Automatically\ create\ groups=Automatically create groups
 
-Automatically_remove_exact_duplicates=Automatically_remove_exact_duplicates
+Automatically\ remove\ exact\ duplicates=Automatically remove exact duplicates
 
-Allow_overwriting_existing_links.=Allow_overwriting_existing_links.
+Allow\ overwriting\ existing\ links.=Allow overwriting existing links.
 
-Do_not_overwrite_existing_links.=Do_not_overwrite_existing_links.
+Do\ not\ overwrite\ existing\ links.=Do not overwrite existing links.
 
-AUX_file_import=AUX_file_import
+AUX\ file\ import=AUX file import
 
-Available_export_formats=Available_export_formats
+Available\ export\ formats=Available export formats
 
-Available_BibTeX_fields=Available_BibTeX_fields
+Available\ BibTeX\ fields=Available BibTeX fields
 
-Available_import_formats=Available_import_formats
+Available\ import\ formats=Available import formats
 
-Background_color_for_optional_fields=Background_color_for_optional_fields
+Background\ color\ for\ optional\ fields=Background color for optional fields
 
-Background_color_for_required_fields=Background_color_for_required_fields
+Background\ color\ for\ required\ fields=Background color for required fields
 
-Backup_old_file_when_saving=Backup_old_file_when_saving
+Backup\ old\ file\ when\ saving=Backup old file when saving
 
-BibTeX_key_is_unique.=BibTeX_key_is_unique.
+BibTeX\ key\ is\ unique.=BibTeX key is unique.
 
-%0_source=%0_source
+%0\ source=%0 source
 
-Broken_link=Broken_link
+Broken\ link=Broken link
 
 Browse=Browse
 
@@ -160,321 +160,321 @@ by=by
 
 Cancel=Cancel
 
-Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?=Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?
+Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=Cannot add entries to group without generating keys. Generate keys now?
 
-Cannot_merge_this_change=Cannot_merge_this_change
+Cannot\ merge\ this\ change=Cannot merge this change
 
-case_insensitive=case_insensitive
+case\ insensitive=case insensitive
 
-case_sensitive=case_sensitive
+case\ sensitive=case sensitive
 
-Case_sensitive=Case_sensitive
+Case\ sensitive=Case sensitive
 
-change_assignment_of_entries=change_assignment_of_entries
+change\ assignment\ of\ entries=change assignment of entries
 
-Change_case=Change_case
+Change\ case=Change case
 
-Change_entry_type=Change_entry_type
-Change_file_type=Change_file_type
+Change\ entry\ type=Change entry type
+Change\ file\ type=Change file type
 
 
-Change_of_Grouping_Method=Change_of_Grouping_Method
+Change\ of\ Grouping\ Method=Change of Grouping Method
 
-change_preamble=change_preamble
+change\ preamble=change preamble
 
-Change_table_column_and_General_fields_settings_to_use_the_new_feature=Change_table_column_and_General_fields_settings_to_use_the_new_feature
+Change\ table\ column\ and\ General\ fields\ settings\ to\ use\ the\ new\ feature=Change table column and General fields settings to use the new feature
 
-Changed_language_settings=Changed_language_settings
+Changed\ language\ settings=Changed language settings
 
-Changed_preamble=Changed_preamble
+Changed\ preamble=Changed preamble
 
-Check_existing_file_links=Check_existing_file_links
+Check\ existing\ file\ links=Check existing file links
 
-Check_links=Check_links
+Check\ links=Check links
 
-Cite_command=Cite_command
+Cite\ command=Cite command
 
-Class_name=Class_name
+Class\ name=Class name
 
 Clear=Clear
 
-Clear_fields=Clear_fields
+Clear\ fields=Clear fields
 
 Close=Close
-Close_others=Close_others
-Close_all=Close_all
+Close\ others=Close others
+Close\ all=Close all
 
-Close_dialog=Close_dialog
+Close\ dialog=Close dialog
 
-Close_the_current_library=Close_the_current_library
+Close\ the\ current\ library=Close the current library
 
-Close_window=Close_window
+Close\ window=Close window
 
-Closed_library=Closed_library
+Closed\ library=Closed library
 
-Color_codes_for_required_and_optional_fields=Color_codes_for_required_and_optional_fields
+Color\ codes\ for\ required\ and\ optional\ fields=Color codes for required and optional fields
 
-Color_for_marking_incomplete_entries=Color_for_marking_incomplete_entries
+Color\ for\ marking\ incomplete\ entries=Color for marking incomplete entries
 
-Column_width=Column_width
+Column\ width=Column width
 
-Command_line_id=Command_line_id
+Command\ line\ id=Command line id
 
 
-Contained_in=Contained_in
+Contained\ in=Contained in
 
 Content=Content
 
 Copied=Copied
 
-Copied_cell_contents=Copied_cell_contents
+Copied\ cell\ contents=Copied cell contents
 
-Copied_title=Copied_title
+Copied\ title=Copied title
 
-Copied_key=Copied_key
+Copied\ key=Copied key
 
-Copied_titles=Copied_titles
+Copied\ titles=Copied titles
 
-Copied_keys=Copied_keys
+Copied\ keys=Copied keys
 
 Copy=Copy
 
-Copy_BibTeX_key=Copy_BibTeX_key
-Copy_file_to_file_directory=Copy_file_to_file_directory
+Copy\ BibTeX\ key=Copy BibTeX key
+Copy\ file\ to\ file\ directory=Copy file to file directory
 
-Copy_to_clipboard=Copy_to_clipboard
+Copy\ to\ clipboard=Copy to clipboard
 
-Could_not_call_executable=Could_not_call_executable
-Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.=Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.
+Could\ not\ call\ executable=Could not call executable
+Could\ not\ connect\ to\ Vim\ server.\ Make\ sure\ that\ Vim\ is\ running<BR>with\ correct\ server\ name.=Could not connect to Vim server. Make sure that Vim is running<BR>with correct server name.
 
-Could_not_export_file=Could_not_export_file
+Could\ not\ export\ file=Could not export file
 
-Could_not_export_preferences=Could_not_export_preferences
+Could\ not\ export\ preferences=Could not export preferences
 
-Could_not_find_a_suitable_import_format.=Could_not_find_a_suitable_import_format.
-Could_not_import_preferences=Could_not_import_preferences
+Could\ not\ find\ a\ suitable\ import\ format.=Could not find a suitable import format.
+Could\ not\ import\ preferences=Could not import preferences
 
-Could_not_instantiate_%0=Could_not_instantiate_%0
-Could_not_instantiate_%0_%1=Could_not_instantiate_%0_%1
-Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?=Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?
-Could_not_open_link=Could_not_open_link
+Could\ not\ instantiate\ %0=Could not instantiate %0
+Could\ not\ instantiate\ %0\ %1=Could not instantiate %0 %1
+Could\ not\ instantiate\ %0.\ Have\ you\ chosen\ the\ correct\ package\ path?=Could not instantiate %0. Have you chosen the correct package path?
+Could\ not\ open\ link=Could not open link
 
-Could_not_print_preview=Could_not_print_preview
+Could\ not\ print\ preview=Could not print preview
 
-Could_not_run_the_'vim'_program.=Could_not_run_the_'vim'_program.
+Could\ not\ run\ the\ 'vim'\ program.=Could not run the 'vim' program.
 
-Could_not_save_file.=Could_not_save_file.
-Character_encoding_'%0'_is_not_supported.=Character_encoding_'%0'_is_not_supported.
+Could\ not\ save\ file.=Could not save file.
+Character\ encoding\ '%0'\ is\ not\ supported.=Character encoding '%0' is not supported.
 
-crossreferenced_entries_included=crossreferenced_entries_included
+crossreferenced\ entries\ included=crossreferenced entries included
 
-Current_content=Current_content
+Current\ content=Current content
 
-Current_value=Current_value
+Current\ value=Current value
 
-Custom_entry_types=Custom_entry_types
+Custom\ entry\ types=Custom entry types
 
-Custom_entry_types_found_in_file=Custom_entry_types_found_in_file
+Custom\ entry\ types\ found\ in\ file=Custom entry types found in file
 
-Customize_entry_types=Customize_entry_types
+Customize\ entry\ types=Customize entry types
 
-Customize_key_bindings=Customize_key_bindings
+Customize\ key\ bindings=Customize key bindings
 
 Cut=Cut
 
-cut_entries=cut_entries
+cut\ entries=cut entries
 
-cut_entry=cut_entry
+cut\ entry=cut entry
 
 
-Library_encoding=Library_encoding
+Library\ encoding=Library encoding
 
-Library_properties=Library_properties
+Library\ properties=Library properties
 
-Library_type=Library_type
+Library\ type=Library type
 
-Date_format=Date_format
+Date\ format=Date format
 
 Default=Default
 
-Default_encoding=Default_encoding
+Default\ encoding=Default encoding
 
-Default_grouping_field=Default_grouping_field
+Default\ grouping\ field=Default grouping field
 
-Default_look_and_feel=Default_look_and_feel
+Default\ look\ and\ feel=Default look and feel
 
-Default_pattern=Default_pattern
+Default\ pattern=Default pattern
 
-Default_sort_criteria=Default_sort_criteria
-Define_'%0'=Define_'%0'
+Default\ sort\ criteria=Default sort criteria
+Define\ '%0'=Define '%0'
 
 Delete=Delete
 
-Delete_custom_format=Delete_custom_format
+Delete\ custom\ format=Delete custom format
 
-delete_entries=delete_entries
+delete\ entries=delete entries
 
-Delete_entry=Delete_entry
+Delete\ entry=Delete entry
 
-delete_entry=delete_entry
+delete\ entry=delete entry
 
-Delete_multiple_entries=Delete_multiple_entries
+Delete\ multiple\ entries=Delete multiple entries
 
-Delete_rows=Delete_rows
+Delete\ rows=Delete rows
 
-Delete_strings=Delete_strings
+Delete\ strings=Delete strings
 
 Deleted=Deleted
 
-Permanently_delete_local_file=Permanently_delete_local_file
+Permanently\ delete\ local\ file=Permanently delete local file
 
-Delimit_fields_with_semicolon,_ex.=Delimit_fields_with_semicolon,_ex.
+Delimit\ fields\ with\ semicolon,\ ex.=Delimit fields with semicolon, ex.
 
 Descending=Descending
 
 Description=Description
 
-Deselect_all=Deselect_all
-Deselect_all_duplicates=Deselect_all_duplicates
+Deselect\ all=Deselect all
+Deselect\ all\ duplicates=Deselect all duplicates
 
-Disable_this_confirmation_dialog=Disable_this_confirmation_dialog
+Disable\ this\ confirmation\ dialog=Disable this confirmation dialog
 
-Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.=Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.
+Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups.=Display all entries belonging to one or more of the selected groups.
 
-Display_all_error_messages=Display_all_error_messages
+Display\ all\ error\ messages=Display all error messages
 
-Display_help_on_command_line_options=Display_help_on_command_line_options
+Display\ help\ on\ command\ line\ options=Display help on command line options
 
-Display_only_entries_belonging_to_all_selected_groups.=Display_only_entries_belonging_to_all_selected_groups.
-Display_version=Display_version
+Display\ only\ entries\ belonging\ to\ all\ selected\ groups.=Display only entries belonging to all selected groups.
+Display\ version=Display version
 
-Do_not_abbreviate_names=Do_not_abbreviate_names
+Do\ not\ abbreviate\ names=Do not abbreviate names
 
-Do_not_automatically_set=Do_not_automatically_set
+Do\ not\ automatically\ set=Do not automatically set
 
-Do_not_import_entry=Do_not_import_entry
+Do\ not\ import\ entry=Do not import entry
 
-Do_not_open_any_files_at_startup=Do_not_open_any_files_at_startup
+Do\ not\ open\ any\ files\ at\ startup=Do not open any files at startup
 
-Do_not_overwrite_existing_keys=Do_not_overwrite_existing_keys
-Do_not_show_these_options_in_the_future=Do_not_show_these_options_in_the_future
+Do\ not\ overwrite\ existing\ keys=Do not overwrite existing keys
+Do\ not\ show\ these\ options\ in\ the\ future=Do not show these options in the future
 
-Do_not_wrap_the_following_fields_when_saving=Do_not_wrap_the_following_fields_when_saving
-Do_not_write_the_following_fields_to_XMP_Metadata\:=Do_not_write_the_following_fields_to_XMP_Metadata\:
+Do\ not\ wrap\ the\ following\ fields\ when\ saving=Do not wrap the following fields when saving
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Do not write the following fields to XMP Metadata:
 
-Do_you_want_JabRef_to_do_the_following_operations?=Do_you_want_JabRef_to_do_the_following_operations?
+Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Do you want JabRef to do the following operations?
 
-Donate_to_JabRef=Donate_to_JabRef
+Donate\ to\ JabRef=Donate to JabRef
 
 Down=Down
 
-Download_file=Download_file
+Download\ file=Download file
 
 Downloading...=Downloading...
 
-Drop_%0=Drop_%0
+Drop\ %0=Drop %0
 
-duplicate_removal=duplicate_removal
+duplicate\ removal=duplicate removal
 
-Duplicate_string_name=Duplicate_string_name
+Duplicate\ string\ name=Duplicate string name
 
-Duplicates_found=Duplicates_found
+Duplicates\ found=Duplicates found
 
-Dynamic_groups=Dynamic_groups
+Dynamic\ groups=Dynamic groups
 
-Dynamically_group_entries_by_a_free-form_search_expression=Dynamically_group_entries_by_a_free-form_search_expression
+Dynamically\ group\ entries\ by\ a\ free-form\ search\ expression=Dynamically group entries by a free-form search expression
 
-Dynamically_group_entries_by_searching_a_field_for_a_keyword=Dynamically_group_entries_by_searching_a_field_for_a_keyword
+Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=Dynamically group entries by searching a field for a keyword
 
-Each_line_must_be_on_the_following_form=Each_line_must_be_on_the_following_form
+Each\ line\ must\ be\ on\ the\ following\ form=Each line must be on the following form
 
 Edit=Edit
 
-Edit_custom_export=Edit_custom_export
-Edit_entry=Edit_entry
-Save_file=Save_file
-Edit_file_type=Edit_file_type
+Edit\ custom\ export=Edit custom export
+Edit\ entry=Edit entry
+Save\ file=Save file
+Edit\ file\ type=Edit file type
 
-Edit_group=Edit_group
+Edit\ group=Edit group
 
 
-Edit_preamble=Edit_preamble
-Edit_strings=Edit_strings
-Editor_options=Editor_options
+Edit\ preamble=Edit preamble
+Edit\ strings=Edit strings
+Editor\ options=Editor options
 
-Empty_BibTeX_key=Empty_BibTeX_key
+Empty\ BibTeX\ key=Empty BibTeX key
 
-Grouping_may_not_work_for_this_entry.=Grouping_may_not_work_for_this_entry.
+Grouping\ may\ not\ work\ for\ this\ entry.=Grouping may not work for this entry.
 
-empty_library=empty_library
-Enable_word/name_autocompletion=Enable_word/name_autocompletion
+empty\ library=empty library
+Enable\ word/name\ autocompletion=Enable word/name autocompletion
 
-Enter_URL=Enter_URL
+Enter\ URL=Enter URL
 
-Enter_URL_to_download=Enter_URL_to_download
+Enter\ URL\ to\ download=Enter URL to download
 
 entries=entries
 
-Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.=Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.
+Entries\ cannot\ be\ manually\ assigned\ to\ or\ removed\ from\ this\ group.=Entries cannot be manually assigned to or removed from this group.
 
-Entries_exported_to_clipboard=Entries_exported_to_clipboard
+Entries\ exported\ to\ clipboard=Entries exported to clipboard
 
 
 entry=entry
 
-Entry_editor=Entry_editor
+Entry\ editor=Entry editor
 
-Entry_preview=Entry_preview
+Entry\ preview=Entry preview
 
-Entry_table=Entry_table
+Entry\ table=Entry table
 
-Entry_table_columns=Entry_table_columns
+Entry\ table\ columns=Entry table columns
 
-Entry_type=Entry_type
+Entry\ type=Entry type
 
-Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters
+Entry\ type\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Entry type names are not allowed to contain white space or the following characters
 
-Entry_types=Entry_types
+Entry\ types=Entry types
 
 Error=Error
-Error_exporting_to_clipboard=Error_exporting_to_clipboard
+Error\ exporting\ to\ clipboard=Error exporting to clipboard
 
-Error_occurred_when_parsing_entry=Error_occurred_when_parsing_entry
+Error\ occurred\ when\ parsing\ entry=Error occurred when parsing entry
 
-Error_opening_file=Error_opening_file
+Error\ opening\ file=Error opening file
 
-Error_setting_field=Error_setting_field
+Error\ setting\ field=Error setting field
 
-Error_while_writing=Error_while_writing
-Error_writing_to_%0_file(s).=Error_writing_to_%0_file(s).
+Error\ while\ writing=Error while writing
+Error\ writing\ to\ %0\ file(s).=Error writing to %0 file(s).
 
 
 
-'%0'_exists._Overwrite_file?='%0'_exists._Overwrite_file?
-Overwrite_file?=Overwrite_file?
+'%0'\ exists.\ Overwrite\ file?='%0' exists. Overwrite file?
+Overwrite\ file?=Overwrite file?
 
 Export=Export
 
-Export_name=Export_name
+Export\ name=Export name
 
-Export_preferences=Export_preferences
+Export\ preferences=Export preferences
 
-Export_preferences_to_file=Export_preferences_to_file
+Export\ preferences\ to\ file=Export preferences to file
 
-Export_properties=Export_properties
+Export\ properties=Export properties
 
-Export_to_clipboard=Export_to_clipboard
+Export\ to\ clipboard=Export to clipboard
 
 Exporting=Exporting
 Extension=Extension
 
-External_changes=External_changes
+External\ changes=External changes
 
-External_file_links=External_file_links
+External\ file\ links=External file links
 
-External_programs=External_programs
+External\ programs=External programs
 
-External_viewer_called=External_viewer_called
+External\ viewer\ called=External viewer called
 
 Fetch=Fetch
 
@@ -482,210 +482,210 @@ Field=Field
 
 field=field
 
-Field_name=Field_name
-Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters
+Field\ name=Field name
+Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Field names are not allowed to contain white space or the following characters
 
-Field_to_filter=Field_to_filter
+Field\ to\ filter=Field to filter
 
-Field_to_group_by=Field_to_group_by
+Field\ to\ group\ by=Field to group by
 
 File=File
 
 file=file
-File_'%0'_is_already_open.=File_'%0'_is_already_open.
+File\ '%0'\ is\ already\ open.=File '%0' is already open.
 
-File_changed=File_changed
-File_directory_is_'%0'\:=File_directory_is_'%0'\:
+File\ changed=File changed
+File\ directory\ is\ '%0'\:=File directory is '%0':
 
-File_directory_is_not_set_or_does_not_exist\!=File_directory_is_not_set_or_does_not_exist\!
+File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=File directory is not set or does not exist!
 
-File_exists=File_exists
+File\ exists=File exists
 
-File_has_been_updated_externally._What_do_you_want_to_do?=File_has_been_updated_externally._What_do_you_want_to_do?
+File\ has\ been\ updated\ externally.\ What\ do\ you\ want\ to\ do?=File has been updated externally. What do you want to do?
 
-File_not_found=File_not_found
-File_type=File_type
+File\ not\ found=File not found
+File\ type=File type
 
-File_updated_externally=File_updated_externally
+File\ updated\ externally=File updated externally
 
 filename=filename
 
 Filename=Filename
 
-Files_opened=Files_opened
+Files\ opened=Files opened
 
 Filter=Filter
 
-Filter_All=Filter_All
+Filter\ All=Filter All
 
-Filter_None=Filter_None
+Filter\ None=Filter None
 
-Finished_automatically_setting_external_links.=Finished_automatically_setting_external_links.
+Finished\ automatically\ setting\ external\ links.=Finished automatically setting external links.
 
-Finished_synchronizing_file_links._Entries_changed\:_%0.=Finished_synchronizing_file_links._Entries_changed\:_%0.
-Finished_writing_XMP-metadata._Wrote_to_%0_file(s).=Finished_writing_XMP-metadata._Wrote_to_%0_file(s).
-Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).=Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).
+Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Finished synchronizing file links. Entries changed: %0.
+Finished\ writing\ XMP-metadata.\ Wrote\ to\ %0\ file(s).=Finished writing XMP-metadata. Wrote to %0 file(s).
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Finished writing XMP for %0 file (%1 skipped, %2 errors).
 
-First_select_the_entries_you_want_keys_to_be_generated_for.=First_select_the_entries_you_want_keys_to_be_generated_for.
+First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=First select the entries you want keys to be generated for.
 
-Fit_table_horizontally_on_screen=Fit_table_horizontally_on_screen
+Fit\ table\ horizontally\ on\ screen=Fit table horizontally on screen
 
 Float=Float
-Float_marked_entries=Float_marked_entries
+Float\ marked\ entries=Float marked entries
 
-Font_family=Font_family
+Font\ family=Font family
 
-Font_preview=Font_preview
+Font\ preview=Font preview
 
-Font_size=Font_size
+Font\ size=Font size
 
-Font_style=Font_style
+Font\ style=Font style
 
-Font_selection=Font_selection
+Font\ selection=Font selection
 
 for=for
 
-Format_of_author_and_editor_names=Format_of_author_and_editor_names
-Format_string=Format_string
+Format\ of\ author\ and\ editor\ names=Format of author and editor names
+Format\ string=Format string
 
-Format_used=Format_used
-Formatter_name=Formatter_name
+Format\ used=Format used
+Formatter\ name=Formatter name
 
-found_in_AUX_file=found_in_AUX_file
+found\ in\ AUX\ file=found in AUX file
 
-Full_name=Full_name
+Full\ name=Full name
 
 General=General
 
-General_fields=General_fields
+General\ fields=General fields
 
 Generate=Generate
 
-Generate_BibTeX_key=Generate_BibTeX_key
+Generate\ BibTeX\ key=Generate BibTeX key
 
-Generate_keys=Generate_keys
+Generate\ keys=Generate keys
 
-Generate_keys_before_saving_(for_entries_without_a_key)=Generate_keys_before_saving_(for_entries_without_a_key)
-Generate_keys_for_imported_entries=Generate_keys_for_imported_entries
+Generate\ keys\ before\ saving\ (for\ entries\ without\ a\ key)=Generate keys before saving (for entries without a key)
+Generate\ keys\ for\ imported\ entries=Generate keys for imported entries
 
-Generate_now=Generate_now
+Generate\ now=Generate now
 
-Generated_BibTeX_key_for=Generated_BibTeX_key_for
+Generated\ BibTeX\ key\ for=Generated BibTeX key for
 
-Generating_BibTeX_key_for=Generating_BibTeX_key_for
-Get_fulltext=Get_fulltext
+Generating\ BibTeX\ key\ for=Generating BibTeX key for
+Get\ fulltext=Get fulltext
 
-Gray_out_non-hits=Gray_out_non-hits
+Gray\ out\ non-hits=Gray out non-hits
 
 Groups=Groups
 
-Have_you_chosen_the_correct_package_path?=Have_you_chosen_the_correct_package_path?
+Have\ you\ chosen\ the\ correct\ package\ path?=Have you chosen the correct package path?
 
 Help=Help
 
-Help_on_key_patterns=Help_on_key_patterns
-Help_on_regular_expression_search=Help_on_regular_expression_search
+Help\ on\ key\ patterns=Help on key patterns
+Help\ on\ regular\ expression\ search=Help on regular expression search
 
-Hide_non-hits=Hide_non-hits
+Hide\ non-hits=Hide non-hits
 
-Hierarchical_context=Hierarchical_context
+Hierarchical\ context=Hierarchical context
 
 Highlight=Highlight
 Marking=Marking
 Underline=Underline
-Empty_Highlight=Empty_Highlight
-Empty_Marking=Empty_Marking
-Empty_Underline=Empty_Underline
-The_marked_area_does_not_contain_any_legible_text!=The_marked_area_does_not_contain_any_legible_text!
+Empty\ Highlight=Empty Highlight
+Empty\ Marking=Empty Marking
+Empty\ Underline=Empty Underline
+The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=The marked area does not contain any legible text!
 
-Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>=Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Hint: To search specific fields only, enter for example:<p><tt>author=smith and title=electrical</tt>
 
-HTML_table=HTML_table
-HTML_table_(with_Abstract_&_BibTeX)=HTML_table_(with_Abstract_&_BibTeX)
+HTML\ table=HTML table
+HTML\ table\ (with\ Abstract\ &\ BibTeX)=HTML table (with Abstract & BibTeX)
 Icon=Icon
 
 Ignore=Ignore
 
 Import=Import
 
-Import_and_keep_old_entry=Import_and_keep_old_entry
+Import\ and\ keep\ old\ entry=Import and keep old entry
 
-Import_and_remove_old_entry=Import_and_remove_old_entry
+Import\ and\ remove\ old\ entry=Import and remove old entry
 
-Import_entries=Import_entries
+Import\ entries=Import entries
 
-Import_failed=Import_failed
+Import\ failed=Import failed
 
-Import_file=Import_file
+Import\ file=Import file
 
-Import_group_definitions=Import_group_definitions
+Import\ group\ definitions=Import group definitions
 
-Import_name=Import_name
+Import\ name=Import name
 
-Import_preferences=Import_preferences
+Import\ preferences=Import preferences
 
-Import_preferences_from_file=Import_preferences_from_file
+Import\ preferences\ from\ file=Import preferences from file
 
-Import_strings=Import_strings
+Import\ strings=Import strings
 
-Import_to_open_tab=Import_to_open_tab
+Import\ to\ open\ tab=Import to open tab
 
-Import_word_selector_definitions=Import_word_selector_definitions
+Import\ word\ selector\ definitions=Import word selector definitions
 
-Imported_entries=Imported_entries
+Imported\ entries=Imported entries
 
-Imported_from_library=Imported_from_library
+Imported\ from\ library=Imported from library
 
-Importer_class=Importer_class
+Importer\ class=Importer class
 
 Importing=Importing
 
-Importing_in_unknown_format=Importing_in_unknown_format
+Importing\ in\ unknown\ format=Importing in unknown format
 
-Include_abstracts=Include_abstracts
-Include_entries=Include_entries
+Include\ abstracts=Include abstracts
+Include\ entries=Include entries
 
-Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups=Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=Include subgroups: When selected, view entries contained in this group or its subgroups
 
-Independent_group\:_When_selected,_view_only_this_group's_entries=Independent_group\:_When_selected,_view_only_this_group's_entries
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=Independent group: When selected, view only this group's entries
 
-Work_options=Work_options
+Work\ options=Work options
 
 Insert=Insert
 
-Insert_rows=Insert_rows
+Insert\ rows=Insert rows
 
 Intersection=Intersection
 
-Invalid_BibTeX_key=Invalid_BibTeX_key
+Invalid\ BibTeX\ key=Invalid BibTeX key
 
-Invalid_date_format=Invalid_date_format
+Invalid\ date\ format=Invalid date format
 
-Invalid_URL=Invalid_URL
+Invalid\ URL=Invalid URL
 
-Online_help=Online_help
+Online\ help=Online help
 
-JabRef_preferences=JabRef_preferences
+JabRef\ preferences=JabRef preferences
 
 Join=Join
 
-Joins_selected_keywords_and_deletes_selected_keywords.=Joins_selected_keywords_and_deletes_selected_keywords.
+Joins\ selected\ keywords\ and\ deletes\ selected\ keywords.=Joins selected keywords and deletes selected keywords.
 
-Journal_abbreviations=Journal_abbreviations
+Journal\ abbreviations=Journal abbreviations
 
 Keep=Keep
 
-Keep_both=Keep_both
+Keep\ both=Keep both
 
-Key_bindings=Key_bindings
+Key\ bindings=Key bindings
 
-Key_bindings_changed=Key_bindings_changed
+Key\ bindings\ changed=Key bindings changed
 
-Key_generator_settings=Key_generator_settings
+Key\ generator\ settings=Key generator settings
 
-Key_pattern=Key_pattern
+Key\ pattern=Key pattern
 
-keys_in_library=keys_in_library
+keys\ in\ library=keys in library
 
 Keyword=Keyword
 
@@ -693,449 +693,449 @@ Label=Label
 
 Language=Language
 
-Last_modified=Last_modified
+Last\ modified=Last modified
 
-LaTeX_AUX_file=LaTeX_AUX_file
-Leave_file_in_its_current_directory=Leave_file_in_its_current_directory
+LaTeX\ AUX\ file=LaTeX AUX file
+Leave\ file\ in\ its\ current\ directory=Leave file in its current directory
 
 Left=Left
 Level=Level
 
-Limit_to_fields=Limit_to_fields
+Limit\ to\ fields=Limit to fields
 
-Limit_to_selected_entries=Limit_to_selected_entries
+Limit\ to\ selected\ entries=Limit to selected entries
 
 Link=Link
-Link_local_file=Link_local_file
-Link_to_file_%0=Link_to_file_%0
+Link\ local\ file=Link local file
+Link\ to\ file\ %0=Link to file %0
 
-Listen_for_remote_operation_on_port=Listen_for_remote_operation_on_port
-Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)=Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)
+Listen\ for\ remote\ operation\ on\ port=Listen for remote operation on port
+Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=Load and Save preferences from/to jabref.xml on start-up (memory stick mode)
 
-Look_and_feel=Look_and_feel
-Main_file_directory=Main_file_directory
+Look\ and\ feel=Look and feel
+Main\ file\ directory=Main file directory
 
-Main_layout_file=Main_layout_file
+Main\ layout\ file=Main layout file
 
-Manage_custom_exports=Manage_custom_exports
+Manage\ custom\ exports=Manage custom exports
 
-Manage_custom_imports=Manage_custom_imports
-Manage_external_file_types=Manage_external_file_types
+Manage\ custom\ imports=Manage custom imports
+Manage\ external\ file\ types=Manage external file types
 
-Mark_entries=Mark_entries
+Mark\ entries=Mark entries
 
-Mark_entry=Mark_entry
+Mark\ entry=Mark entry
 
-Mark_new_entries_with_addition_date=Mark_new_entries_with_addition_date
+Mark\ new\ entries\ with\ addition\ date=Mark new entries with addition date
 
-Mark_new_entries_with_owner_name=Mark_new_entries_with_owner_name
+Mark\ new\ entries\ with\ owner\ name=Mark new entries with owner name
 
-Memory_stick_mode=Memory_stick_mode
+Memory\ stick\ mode=Memory stick mode
 
-Menu_and_label_font_size=Menu_and_label_font_size
+Menu\ and\ label\ font\ size=Menu and label font size
 
-Merged_external_changes=Merged_external_changes
+Merged\ external\ changes=Merged external changes
 
 Messages=Messages
 
-Modification_of_field=Modification_of_field
+Modification\ of\ field=Modification of field
 
-Modified_group_"%0".=Modified_group_"%0".
+Modified\ group\ "%0".=Modified group "%0".
 
-Modified_groups=Modified_groups
+Modified\ groups=Modified groups
 
-Modified_string=Modified_string
+Modified\ string=Modified string
 
 Modify=Modify
 
-modify_group=modify_group
+modify\ group=modify group
 
-Move_down=Move_down
+Move\ down=Move down
 
-Move_external_links_to_'file'_field=Move_external_links_to_'file'_field
+Move\ external\ links\ to\ 'file'\ field=Move external links to 'file' field
 
-move_group=move_group
+move\ group=move group
 
-Move_up=Move_up
+Move\ up=Move up
 
-Moved_group_"%0".=Moved_group_"%0".
+Moved\ group\ "%0".=Moved group "%0".
 
 Name=Name
-Name_formatter=Name_formatter
+Name\ formatter=Name formatter
 
-Natbib_style=Natbib_style
+Natbib\ style=Natbib style
 
-nested_AUX_files=nested_AUX_files
+nested\ AUX\ files=nested AUX files
 
 New=New
 
 new=new
 
-New_BibTeX_entry=New_BibTeX_entry
+New\ BibTeX\ entry=New BibTeX entry
 
-New_BibTeX_sublibrary=New_BibTeX_sublibrary
+New\ BibTeX\ sublibrary=New BibTeX sublibrary
 
-New_content=New_content
+New\ content=New content
 
-New_library_created.=New_library_created.
-New_%0_library=New_%0_library
-New_field_value=New_field_value
+New\ library\ created.=New library created.
+New\ %0\ library=New %0 library
+New\ field\ value=New field value
 
-New_group=New_group
+New\ group=New group
 
-New_string=New_string
+New\ string=New string
 
-Next_entry=Next_entry
+Next\ entry=Next entry
 
-No_actual_changes_found.=No_actual_changes_found.
+No\ actual\ changes\ found.=No actual changes found.
 
-no_base-BibTeX-file_specified=no_base-BibTeX-file_specified
+no\ base-BibTeX-file\ specified=no base-BibTeX-file specified
 
-no_library_generated=no_library_generated
+no\ library\ generated=no library generated
 
-No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.=No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.
+No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=No entries found. Please make sure you are using the correct import filter.
 
 
-No_entries_found_for_the_search_string_'%0'=No_entries_found_for_the_search_string_'%0'
+No\ entries\ found\ for\ the\ search\ string\ '%0'=No entries found for the search string '%0'
 
-No_entries_imported.=No_entries_imported.
+No\ entries\ imported.=No entries imported.
 
-No_files_found.=No_files_found.
+No\ files\ found.=No files found.
 
-No_GUI._Only_process_command_line_options.=No_GUI._Only_process_command_line_options.
+No\ GUI.\ Only\ process\ command\ line\ options.=No GUI. Only process command line options.
 
-No_journal_names_could_be_abbreviated.=No_journal_names_could_be_abbreviated.
+No\ journal\ names\ could\ be\ abbreviated.=No journal names could be abbreviated.
 
-No_journal_names_could_be_unabbreviated.=No_journal_names_could_be_unabbreviated.
-No_PDF_linked=No_PDF_linked
+No\ journal\ names\ could\ be\ unabbreviated.=No journal names could be unabbreviated.
+No\ PDF\ linked=No PDF linked
 
-Open_PDF=Open_PDF
+Open\ PDF=Open PDF
 
-No_URL_defined=No_URL_defined
+No\ URL\ defined=No URL defined
 not=not
 
-not_found=not_found
+not\ found=not found
 
-Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,=Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,
+Note\ that\ you\ must\ specify\ the\ fully\ qualified\ class\ name\ for\ the\ look\ and\ feel,=Note that you must specify the fully qualified class name for the look and feel,
 
-Nothing_to_redo=Nothing_to_redo
+Nothing\ to\ redo=Nothing to redo
 
-Nothing_to_undo=Nothing_to_undo
+Nothing\ to\ undo=Nothing to undo
 
 occurrences=occurrences
 
 OK=OK
-One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?
+One\ or\ more\ file\ links\ are\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=One or more file links are of the type '%0', which is undefined. What do you want to do?
 
-One_or_more_keys_will_be_overwritten._Continue?=One_or_more_keys_will_be_overwritten._Continue?
+One\ or\ more\ keys\ will\ be\ overwritten.\ Continue?=One or more keys will be overwritten. Continue?
 
 
 Open=Open
 
-Open_BibTeX_library=Open_BibTeX_library
+Open\ BibTeX\ library=Open BibTeX library
 
-Open_library=Open_library
+Open\ library=Open library
 
-Open_editor_when_a_new_entry_is_created=Open_editor_when_a_new_entry_is_created
+Open\ editor\ when\ a\ new\ entry\ is\ created=Open editor when a new entry is created
 
-Open_file=Open_file
+Open\ file=Open file
 
-Open_last_edited_libraries_at_startup=Open_last_edited_libraries_at_startup
+Open\ last\ edited\ libraries\ at\ startup=Open last edited libraries at startup
 
-Connect_to_shared_database=Connect_to_shared_database
+Connect\ to\ shared\ database=Connect to shared database
 
-Open_terminal_here=Open_terminal_here
+Open\ terminal\ here=Open terminal here
 
-Open_URL_or_DOI=Open_URL_or_DOI
+Open\ URL\ or\ DOI=Open URL or DOI
 
-Opened_library=Opened_library
+Opened\ library=Opened library
 
 Opening=Opening
 
-Opening_preferences...=Opening_preferences...
+Opening\ preferences...=Opening preferences...
 
-Operation_canceled.=Operation_canceled.
-Operation_not_supported=Operation_not_supported
+Operation\ canceled.=Operation canceled.
+Operation\ not\ supported=Operation not supported
 
-Optional_fields=Optional_fields
+Optional\ fields=Optional fields
 
 Options=Options
 
 or=or
 
-Output_or_export_file=Output_or_export_file
+Output\ or\ export\ file=Output or export file
 
 Override=Override
 
-Override_default_file_directories=Override_default_file_directories
+Override\ default\ file\ directories=Override default file directories
 
-Override_default_font_settings=Override_default_font_settings
+Override\ default\ font\ settings=Override default font settings
 
-Override_the_BibTeX_field_by_the_selected_text=Override_the_BibTeX_field_by_the_selected_text
+Override\ the\ BibTeX\ field\ by\ the\ selected\ text=Override the BibTeX field by the selected text
 
 
 Overwrite=Overwrite
-Overwrite_existing_field_values=Overwrite_existing_field_values
+Overwrite\ existing\ field\ values=Overwrite existing field values
 
-Overwrite_keys=Overwrite_keys
+Overwrite\ keys=Overwrite keys
 
-pairs_processed=pairs_processed
+pairs\ processed=pairs processed
 Password=Password
 
 Paste=Paste
 
-paste_entries=paste_entries
+paste\ entries=paste entries
 
-paste_entry=paste_entry
-Paste_from_clipboard=Paste_from_clipboard
+paste\ entry=paste entry
+Paste\ from\ clipboard=Paste from clipboard
 
 Pasted=Pasted
 
-Path_to_%0_not_defined=Path_to_%0_not_defined
+Path\ to\ %0\ not\ defined=Path to %0 not defined
 
-Path_to_LyX_pipe=Path_to_LyX_pipe
+Path\ to\ LyX\ pipe=Path to LyX pipe
 
-PDF_does_not_exist=PDF_does_not_exist
+PDF\ does\ not\ exist=PDF does not exist
 
-File_has_no_attached_annotations=File_has_no_attached_annotations
+File\ has\ no\ attached\ annotations=File has no attached annotations
 
-Plain_text_import=Plain_text_import
+Plain\ text\ import=Plain text import
 
-Please_enter_a_name_for_the_group.=Please_enter_a_name_for_the_group.
+Please\ enter\ a\ name\ for\ the\ group.=Please enter a name for the group.
 
-Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>=Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Please enter a search term. For example, to search all fields for <b>Smith</b>, enter:<p><tt>smith</tt><p>To search the field <b>Author</b> for <b>Smith</b> and the field <b>Title</b> for <b>electrical</b>, enter:<p><tt>author=smith and title=electrical</tt>
 
-Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).
+Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=Please enter the field to search (e.g. <b>keywords</b>) and the keyword to search it for (e.g. <b>electrical</b>).
 
-Please_enter_the_string's_label=Please_enter_the_string's_label
+Please\ enter\ the\ string's\ label=Please enter the string's label
 
-Please_select_an_importer.=Please_select_an_importer.
+Please\ select\ an\ importer.=Please select an importer.
 
-Possible_duplicate_entries=Possible_duplicate_entries
+Possible\ duplicate\ entries=Possible duplicate entries
 
-Possible_duplicate_of_existing_entry._Click_to_resolve.=Possible_duplicate_of_existing_entry._Click_to_resolve.
+Possible\ duplicate\ of\ existing\ entry.\ Click\ to\ resolve.=Possible duplicate of existing entry. Click to resolve.
 
 Preamble=Preamble
 
 Preferences=Preferences
 
-Preferences_recorded.=Preferences_recorded.
+Preferences\ recorded.=Preferences recorded.
 
 Preview=Preview
-Citation_Style=Citation_Style
-Current_Preview=Current_Preview
-Cannot_generate_preview_based_on_selected_citation_style.=Cannot_generate_preview_based_on_selected_citation_style.
-Bad_character_inside_entry=Bad_character_inside_entry
-Error_while_generating_citation_style=Error_while_generating_citation_style
-Preview_style_changed_to\:_%0=Preview_style_changed_to\:_%0
-Next_preview_layout=Next_preview_layout
-Previous_preview_layout=Previous_preview_layout
+Citation\ Style=Citation Style
+Current\ Preview=Current Preview
+Cannot\ generate\ preview\ based\ on\ selected\ citation\ style.=Cannot generate preview based on selected citation style.
+Bad\ character\ inside\ entry=Bad character inside entry
+Error\ while\ generating\ citation\ style=Error while generating citation style
+Preview\ style\ changed\ to\:\ %0=Preview style changed to: %0
+Next\ preview\ layout=Next preview layout
+Previous\ preview\ layout=Previous preview layout
 
-Previous_entry=Previous_entry
+Previous\ entry=Previous entry
 
-Primary_sort_criterion=Primary_sort_criterion
-Problem_with_parsing_entry=Problem_with_parsing_entry
-Processing_%0=Processing_%0
-Pull_changes_from_shared_database=Pull_changes_from_shared_database
+Primary\ sort\ criterion=Primary sort criterion
+Problem\ with\ parsing\ entry=Problem with parsing entry
+Processing\ %0=Processing %0
+Pull\ changes\ from\ shared\ database=Pull changes from shared database
 
-Pushed_citations_to_%0=Pushed_citations_to_%0
+Pushed\ citations\ to\ %0=Pushed citations to %0
 
-Quit_JabRef=Quit_JabRef
+Quit\ JabRef=Quit JabRef
 
-Quit_synchronization=Quit_synchronization
+Quit\ synchronization=Quit synchronization
 
-Raw_source=Raw_source
+Raw\ source=Raw source
 
-Rearrange_tabs_alphabetically_by_title=Rearrange_tabs_alphabetically_by_title
+Rearrange\ tabs\ alphabetically\ by\ title=Rearrange tabs alphabetically by title
 
 Redo=Redo
 
-Reference_library=Reference_library
+Reference\ library=Reference library
 
-%0_references_found._Number_of_references_to_fetch?=%0_references_found._Number_of_references_to_fetch?
+%0\ references\ found.\ Number\ of\ references\ to\ fetch?=%0 references found. Number of references to fetch?
 
-Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=Refine supergroup: When selected, view entries contained in both this group and its supergroup
 
-regular_expression=regular_expression
+regular\ expression=regular expression
 
-Related_articles=Related_articles
+Related\ articles=Related articles
 
-Remote_operation=Remote_operation
+Remote\ operation=Remote operation
 
-Remote_server_port=Remote_server_port
+Remote\ server\ port=Remote server port
 
 Remove=Remove
 
-Remove_subgroups=Remove_subgroups
+Remove\ subgroups=Remove subgroups
 
-Remove_all_subgroups_of_"%0"?=Remove_all_subgroups_of_"%0"?
+Remove\ all\ subgroups\ of\ "%0"?=Remove all subgroups of "%0"?
 
-Remove_entry_from_import=Remove_entry_from_import
+Remove\ entry\ from\ import=Remove entry from import
 
-Remove_selected_entries_from_this_group=Remove_selected_entries_from_this_group
+Remove\ selected\ entries\ from\ this\ group=Remove selected entries from this group
 
-Remove_entry_type=Remove_entry_type
+Remove\ entry\ type=Remove entry type
 
-Remove_from_group=Remove_from_group
+Remove\ from\ group=Remove from group
 
-Remove_group=Remove_group
+Remove\ group=Remove group
 
-Remove_group,_keep_subgroups=Remove_group,_keep_subgroups
+Remove\ group,\ keep\ subgroups=Remove group, keep subgroups
 
-Remove_group_"%0"?=Remove_group_"%0"?
+Remove\ group\ "%0"?=Remove group "%0"?
 
-Remove_group_"%0"_and_its_subgroups?=Remove_group_"%0"_and_its_subgroups?
+Remove\ group\ "%0"\ and\ its\ subgroups?=Remove group "%0" and its subgroups?
 
-remove_group_(keep_subgroups)=remove_group_(keep_subgroups)
+remove\ group\ (keep\ subgroups)=remove group (keep subgroups)
 
-remove_group_and_subgroups=remove_group_and_subgroups
+remove\ group\ and\ subgroups=remove group and subgroups
 
-Remove_group_and_subgroups=Remove_group_and_subgroups
+Remove\ group\ and\ subgroups=Remove group and subgroups
 
-Remove_link=Remove_link
+Remove\ link=Remove link
 
-Remove_old_entry=Remove_old_entry
+Remove\ old\ entry=Remove old entry
 
-Remove_selected_strings=Remove_selected_strings
+Remove\ selected\ strings=Remove selected strings
 
-Removed_group_"%0".=Removed_group_"%0".
+Removed\ group\ "%0".=Removed group "%0".
 
-Removed_group_"%0"_and_its_subgroups.=Removed_group_"%0"_and_its_subgroups.
+Removed\ group\ "%0"\ and\ its\ subgroups.=Removed group "%0" and its subgroups.
 
-Removed_string=Removed_string
+Removed\ string=Removed string
 
-Renamed_string=Renamed_string
+Renamed\ string=Renamed string
 
 Replace=Replace
 
-Replace_(regular_expression)=Replace_(regular_expression)
+Replace\ (regular\ expression)=Replace (regular expression)
 
-Replace_string=Replace_string
+Replace\ string=Replace string
 
-Replace_with=Replace_with
+Replace\ with=Replace with
 
 Replaced=Replaced
 
-Required_fields=Required_fields
+Required\ fields=Required fields
 
-Reset_all=Reset_all
+Reset\ all=Reset all
 
-Resolve_strings_for_all_fields_except=Resolve_strings_for_all_fields_except
-Resolve_strings_for_standard_BibTeX_fields_only=Resolve_strings_for_standard_BibTeX_fields_only
+Resolve\ strings\ for\ all\ fields\ except=Resolve strings for all fields except
+Resolve\ strings\ for\ standard\ BibTeX\ fields\ only=Resolve strings for standard BibTeX fields only
 
 resolved=resolved
 
 Review=Review
 
-Review_changes=Review_changes
+Review\ changes=Review changes
 
 Right=Right
 
 Save=Save
-Save_all_finished.=Save_all_finished.
+Save\ all\ finished.=Save all finished.
 
-Save_all_open_libraries=Save_all_open_libraries
+Save\ all\ open\ libraries=Save all open libraries
 
-Save_before_closing=Save_before_closing
+Save\ before\ closing=Save before closing
 
-Save_library=Save_library
-Save_library_as...=Save_library_as...
+Save\ library=Save library
+Save\ library\ as...=Save library as...
 
-Save_entries_in_their_original_order=Save_entries_in_their_original_order
+Save\ entries\ in\ their\ original\ order=Save entries in their original order
 
-Save_failed=Save_failed
+Save\ failed=Save failed
 
-Save_failed_during_backup_creation=Save_failed_during_backup_creation
+Save\ failed\ during\ backup\ creation=Save failed during backup creation
 
-Save_selected_as...=Save_selected_as...
+Save\ selected\ as...=Save selected as...
 
-Saved_library=Saved_library
+Saved\ library=Saved library
 
-Saved_selected_to_'%0'.=Saved_selected_to_'%0'.
+Saved\ selected\ to\ '%0'.=Saved selected to '%0'.
 
 Saving=Saving
-Saving_all_libraries...=Saving_all_libraries...
+Saving\ all\ libraries...=Saving all libraries...
 
-Saving_library=Saving_library
+Saving\ library=Saving library
 
 Search=Search
 
-Search_expression=Search_expression
+Search\ expression=Search expression
 
-Search_for=Search_for
+Search\ for=Search for
 
-Searching_for_duplicates...=Searching_for_duplicates...
+Searching\ for\ duplicates...=Searching for duplicates...
 
-Searching_for_files=Searching_for_files
+Searching\ for\ files=Searching for files
 
-Secondary_sort_criterion=Secondary_sort_criterion
+Secondary\ sort\ criterion=Secondary sort criterion
 
-Select_all=Select_all
+Select\ all=Select all
 
-Select_encoding=Select_encoding
+Select\ encoding=Select encoding
 
-Select_entry_type=Select_entry_type
-Select_external_application=Select_external_application
+Select\ entry\ type=Select entry type
+Select\ external\ application=Select external application
 
-Select_file_from_ZIP-archive=Select_file_from_ZIP-archive
+Select\ file\ from\ ZIP-archive=Select file from ZIP-archive
 
-Select_the_tree_nodes_to_view_and_accept_or_reject_changes=Select_the_tree_nodes_to_view_and_accept_or_reject_changes
-Selected_entries=Selected_entries
-Set_field=Set_field
-Set_fields=Set_fields
+Select\ the\ tree\ nodes\ to\ view\ and\ accept\ or\ reject\ changes=Select the tree nodes to view and accept or reject changes
+Selected\ entries=Selected entries
+Set\ field=Set field
+Set\ fields=Set fields
 
-Set_general_fields=Set_general_fields
-Set_main_external_file_directory=Set_main_external_file_directory
+Set\ general\ fields=Set general fields
+Set\ main\ external\ file\ directory=Set main external file directory
 
-Set_table_font=Set_table_font
+Set\ table\ font=Set table font
 
 Settings=Settings
 
 Shortcut=Shortcut
 
-Show/edit_%0_source=Show/edit_%0_source
+Show/edit\ %0\ source=Show/edit %0 source
 
-Show_'Firstname_Lastname'=Show_'Firstname_Lastname'
+Show\ 'Firstname\ Lastname'=Show 'Firstname Lastname'
 
-Show_'Lastname,_Firstname'=Show_'Lastname,_Firstname'
+Show\ 'Lastname,\ Firstname'=Show 'Lastname, Firstname'
 
-Show_BibTeX_source_by_default=Show_BibTeX_source_by_default
+Show\ BibTeX\ source\ by\ default=Show BibTeX source by default
 
-Show_confirmation_dialog_when_deleting_entries=Show_confirmation_dialog_when_deleting_entries
+Show\ confirmation\ dialog\ when\ deleting\ entries=Show confirmation dialog when deleting entries
 
-Show_description=Show_description
+Show\ description=Show description
 
-Show_file_column=Show_file_column
+Show\ file\ column=Show file column
 
-Show_last_names_only=Show_last_names_only
+Show\ last\ names\ only=Show last names only
 
-Show_names_unchanged=Show_names_unchanged
+Show\ names\ unchanged=Show names unchanged
 
-Show_optional_fields=Show_optional_fields
+Show\ optional\ fields=Show optional fields
 
-Show_required_fields=Show_required_fields
+Show\ required\ fields=Show required fields
 
-Show_URL/DOI_column=Show_URL/DOI_column
+Show\ URL/DOI\ column=Show URL/DOI column
 
-Simple_HTML=Simple_HTML
+Simple\ HTML=Simple HTML
 
 Size=Size
 
-Skipped_-_No_PDF_linked=Skipped_-_No_PDF_linked
-Skipped_-_PDF_does_not_exist=Skipped_-_PDF_does_not_exist
+Skipped\ -\ No\ PDF\ linked=Skipped - No PDF linked
+Skipped\ -\ PDF\ does\ not\ exist=Skipped - PDF does not exist
 
-Skipped_entry.=Skipped_entry.
+Skipped\ entry.=Skipped entry.
 
-Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.=Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.
+Some\ appearance\ settings\ you\ changed\ require\ to\ restart\ JabRef\ to\ come\ into\ effect.=Some appearance settings you changed require to restart JabRef to come into effect.
 
-source_edit=source_edit
-Special_name_formatters=Special_name_formatters
+source\ edit=source edit
+Special\ name\ formatters=Special name formatters
 
-Special_table_columns=Special_table_columns
+Special\ table\ columns=Special table columns
 
-Starting_import=Starting_import
+Starting\ import=Starting import
 
-Statically_group_entries_by_manual_assignment=Statically_group_entries_by_manual_assignment
+Statically\ group\ entries\ by\ manual\ assignment=Statically group entries by manual assignment
 
 Status=Status
 
@@ -1143,1019 +1143,1019 @@ Stop=Stop
 
 Strings=Strings
 
-Strings_for_library=Strings_for_library
+Strings\ for\ library=Strings for library
 
-Sublibrary_from_AUX=Sublibrary_from_AUX
+Sublibrary\ from\ AUX=Sublibrary from AUX
 
-Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.=Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.
+Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=Switches between full and abbreviated journal name if the journal name is known.
 
-Synchronize_file_links=Synchronize_file_links
+Synchronize\ file\ links=Synchronize file links
 
-Synchronizing_file_links...=Synchronizing_file_links...
+Synchronizing\ file\ links...=Synchronizing file links...
 
-Table_appearance=Table_appearance
+Table\ appearance=Table appearance
 
-Table_background_color=Table_background_color
+Table\ background\ color=Table background color
 
-Table_grid_color=Table_grid_color
+Table\ grid\ color=Table grid color
 
-Table_text_color=Table_text_color
+Table\ text\ color=Table text color
 
 Tabname=Tabname
-Target_file_cannot_be_a_directory.=Target_file_cannot_be_a_directory.
+Target\ file\ cannot\ be\ a\ directory.=Target file cannot be a directory.
 
-Tertiary_sort_criterion=Tertiary_sort_criterion
+Tertiary\ sort\ criterion=Tertiary sort criterion
 
 Test=Test
 
-paste_text_here=paste_text_here
+paste\ text\ here=paste text here
 
-The_chosen_date_format_for_new_entries_is_not_valid=The_chosen_date_format_for_new_entries_is_not_valid
+The\ chosen\ date\ format\ for\ new\ entries\ is\ not\ valid=The chosen date format for new entries is not valid
 
-The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:=The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:
+The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=The chosen encoding '%0' could not encode the following characters:
 
 
-the_field_<b>%0</b>=the_field_<b>%0</b>
+the\ field\ <b>%0</b>=the field <b>%0</b>
 
-The_file<BR>'%0'<BR>has_been_modified<BR>externally\!=The_file<BR>'%0'<BR>has_been_modified<BR>externally\!
+The\ file<BR>'%0'<BR>has\ been\ modified<BR>externally\!=The file<BR>'%0'<BR>has been modified<BR>externally!
 
-The_group_"%0"_already_contains_the_selection.=The_group_"%0"_already_contains_the_selection.
+The\ group\ "%0"\ already\ contains\ the\ selection.=The group "%0" already contains the selection.
 
-The_label_of_the_string_cannot_be_a_number.=The_label_of_the_string_cannot_be_a_number.
+The\ label\ of\ the\ string\ cannot\ be\ a\ number.=The label of the string cannot be a number.
 
-The_label_of_the_string_cannot_contain_spaces.=The_label_of_the_string_cannot_contain_spaces.
+The\ label\ of\ the\ string\ cannot\ contain\ spaces.=The label of the string cannot contain spaces.
 
-The_label_of_the_string_cannot_contain_the_'\#'_character.=The_label_of_the_string_cannot_contain_the_'\#'_character.
+The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=The label of the string cannot contain the '#' character.
 
-The_output_option_depends_on_a_valid_import_option.=The_output_option_depends_on_a_valid_import_option.
-The_PDF_contains_one_or_several_BibTeX-records.=The_PDF_contains_one_or_several_BibTeX-records.
-Do_you_want_to_import_these_as_new_entries_into_the_current_library?=Do_you_want_to_import_these_as_new_entries_into_the_current_library?
+The\ output\ option\ depends\ on\ a\ valid\ import\ option.=The output option depends on a valid import option.
+The\ PDF\ contains\ one\ or\ several\ BibTeX-records.=The PDF contains one or several BibTeX-records.
+Do\ you\ want\ to\ import\ these\ as\ new\ entries\ into\ the\ current\ library?=Do you want to import these as new entries into the current library?
 
-The_regular_expression_<b>%0</b>_is_invalid\:=The_regular_expression_<b>%0</b>_is_invalid\:
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=The regular expression <b>%0</b> is invalid:
 
-The_search_is_case_insensitive.=The_search_is_case_insensitive.
+The\ search\ is\ case\ insensitive.=The search is case insensitive.
 
-The_search_is_case_sensitive.=The_search_is_case_sensitive.
+The\ search\ is\ case\ sensitive.=The search is case sensitive.
 
-The_string_has_been_removed_locally=The_string_has_been_removed_locally
+The\ string\ has\ been\ removed\ locally=The string has been removed locally
 
-There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?=There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?
+There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=There are possible duplicates (marked with an icon) that haven't been resolved. Continue?
 
-This_entry_has_no_BibTeX_key._Generate_key_now?=This_entry_has_no_BibTeX_key._Generate_key_now?
+This\ entry\ has\ no\ BibTeX\ key.\ Generate\ key\ now?=This entry has no BibTeX key. Generate key now?
 
-This_entry_is_incomplete=This_entry_is_incomplete
+This\ entry\ is\ incomplete=This entry is incomplete
 
-This_entry_type_cannot_be_removed.=This_entry_type_cannot_be_removed.
+This\ entry\ type\ cannot\ be\ removed.=This entry type cannot be removed.
 
-This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?
+This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=This external link is of the type '%0', which is undefined. What do you want to do?
 
-This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.=This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.
+This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=This group contains entries based on manual assignment. Entries can be assigned to this group by selecting them then using either drag and drop or the context menu. Entries can be removed from this group by selecting them then using the context menu.
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>=This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=This group contains entries whose <b>%0</b> field contains the keyword <b>%1</b>
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>=This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>
-This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.=This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=This group contains entries whose <b>%0</b> field contains the regular expression <b>%1</b>
+This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=This makes JabRef look up each file link and check if the file exists. If not, you will be given options<BR>to resolve the problem.
 
-This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.=This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.
+This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=This operation requires all selected entries to have BibTeX keys defined.
 
-This_operation_requires_one_or_more_entries_to_be_selected.=This_operation_requires_one_or_more_entries_to_be_selected.
+This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=This operation requires one or more entries to be selected.
 
-Toggle_entry_preview=Toggle_entry_preview
-Toggle_groups_interface=Toggle_groups_interface
-Try_different_encoding=Try_different_encoding
+Toggle\ entry\ preview=Toggle entry preview
+Toggle\ groups\ interface=Toggle groups interface
+Try\ different\ encoding=Try different encoding
 
-Unabbreviate_journal_names_of_the_selected_entries=Unabbreviate_journal_names_of_the_selected_entries
-Unabbreviated_%0_journal_names.=Unabbreviated_%0_journal_names.
+Unabbreviate\ journal\ names\ of\ the\ selected\ entries=Unabbreviate journal names of the selected entries
+Unabbreviated\ %0\ journal\ names.=Unabbreviated %0 journal names.
 
-Unable_to_open_file.=Unable_to_open_file.
-Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.=Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.
-unable_to_write_to=unable_to_write_to
-Undefined_file_type=Undefined_file_type
+Unable\ to\ open\ file.=Unable to open file.
+Unable\ to\ open\ link.\ The\ application\ '%0'\ associated\ with\ the\ file\ type\ '%1'\ could\ not\ be\ called.=Unable to open link. The application '%0' associated with the file type '%1' could not be called.
+unable\ to\ write\ to=unable to write to
+Undefined\ file\ type=Undefined file type
 
 Undo=Undo
 
 Union=Union
 
-Unknown_BibTeX_entries=Unknown_BibTeX_entries
+Unknown\ BibTeX\ entries=Unknown BibTeX entries
 
-unknown_edit=unknown_edit
+unknown\ edit=unknown edit
 
-Unknown_export_format=Unknown_export_format
+Unknown\ export\ format=Unknown export format
 
-Unmark_all=Unmark_all
+Unmark\ all=Unmark all
 
-Unmark_entries=Unmark_entries
+Unmark\ entries=Unmark entries
 
-Unmark_entry=Unmark_entry
+Unmark\ entry=Unmark entry
 
 untitled=untitled
 
 Up=Up
 
-Update_to_current_column_widths=Update_to_current_column_widths
+Update\ to\ current\ column\ widths=Update to current column widths
 
-Updated_group_selection=Updated_group_selection
-Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.=Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.
-Upgrade_file=Upgrade_file
-Upgrade_old_external_file_links_to_use_the_new_feature=Upgrade_old_external_file_links_to_use_the_new_feature
+Updated\ group\ selection=Updated group selection
+Upgrade\ external\ PDF/PS\ links\ to\ use\ the\ '%0'\ field.=Upgrade external PDF/PS links to use the '%0' field.
+Upgrade\ file=Upgrade file
+Upgrade\ old\ external\ file\ links\ to\ use\ the\ new\ feature=Upgrade old external file links to use the new feature
 
 usage=usage
-Use_autocompletion_for_the_following_fields=Use_autocompletion_for_the_following_fields
+Use\ autocompletion\ for\ the\ following\ fields=Use autocompletion for the following fields
 
-Use_other_look_and_feel=Use_other_look_and_feel
-Tweak_font_rendering_for_entry_editor_on_Linux=Tweak_font_rendering_for_entry_editor_on_Linux
-Use_regular_expression_search=Use_regular_expression_search
+Use\ other\ look\ and\ feel=Use other look and feel
+Tweak\ font\ rendering\ for\ entry\ editor\ on\ Linux=Tweak font rendering for entry editor on Linux
+Use\ regular\ expression\ search=Use regular expression search
 
 Username=Username
 
-Value_cleared_externally=Value_cleared_externally
+Value\ cleared\ externally=Value cleared externally
 
-Value_set_externally=Value_set_externally
+Value\ set\ externally=Value set externally
 
-verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid=verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid
+verify\ that\ LyX\ is\ running\ and\ that\ the\ lyxpipe\ is\ valid=verify that LyX is running and that the lyxpipe is valid
 
 View=View
-Vim_server_name=Vim_server_name
+Vim\ server\ name=Vim server name
 
-Waiting_for_ArXiv...=Waiting_for_ArXiv...
+Waiting\ for\ ArXiv...=Waiting for ArXiv...
 
-Warn_about_unresolved_duplicates_when_closing_inspection_window=Warn_about_unresolved_duplicates_when_closing_inspection_window
+Warn\ about\ unresolved\ duplicates\ when\ closing\ inspection\ window=Warn about unresolved duplicates when closing inspection window
 
-Warn_before_overwriting_existing_keys=Warn_before_overwriting_existing_keys
+Warn\ before\ overwriting\ existing\ keys=Warn before overwriting existing keys
 
 Warning=Warning
 
 Warnings=Warnings
 
-web_link=web_link
+web\ link=web link
 
-What_do_you_want_to_do?=What_do_you_want_to_do?
+What\ do\ you\ want\ to\ do?=What do you want to do?
 
-When_adding/removing_keywords,_separate_them_by=When_adding/removing_keywords,_separate_them_by
-Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.=Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.
+When\ adding/removing\ keywords,\ separate\ them\ by=When adding/removing keywords, separate them by
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Will write XMP-metadata to the PDFs linked from selected entries.
 
 with=with
 
-Write_BibTeXEntry_as_XMP-metadata_to_PDF.=Write_BibTeXEntry_as_XMP-metadata_to_PDF.
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Write BibTeXEntry as XMP-metadata to PDF.
 
-Write_XMP=Write_XMP
-Write_XMP-metadata=Write_XMP-metadata
-Write_XMP-metadata_for_all_PDFs_in_current_library?=Write_XMP-metadata_for_all_PDFs_in_current_library?
-Writing_XMP-metadata...=Writing_XMP-metadata...
-Writing_XMP-metadata_for_selected_entries...=Writing_XMP-metadata_for_selected_entries...
+Write\ XMP=Write XMP
+Write\ XMP-metadata=Write XMP-metadata
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Write XMP-metadata for all PDFs in current library?
+Writing\ XMP-metadata...=Writing XMP-metadata...
+Writing\ XMP-metadata\ for\ selected\ entries...=Writing XMP-metadata for selected entries...
 
-Wrote_XMP-metadata=Wrote_XMP-metadata
+Wrote\ XMP-metadata=Wrote XMP-metadata
 
-XMP-annotated_PDF=XMP-annotated_PDF
-XMP_export_privacy_settings=XMP_export_privacy_settings
+XMP-annotated\ PDF=XMP-annotated PDF
+XMP\ export\ privacy\ settings=XMP export privacy settings
 XMP-metadata=XMP-metadata
-XMP-metadata_found_in_PDF\:_%0=XMP-metadata_found_in_PDF\:_%0
-You_must_restart_JabRef_for_this_to_come_into_effect.=You_must_restart_JabRef_for_this_to_come_into_effect.
-You_have_changed_the_language_setting.=You_have_changed_the_language_setting.
-You_have_entered_an_invalid_search_'%0'.=You_have_entered_an_invalid_search_'%0'.
+XMP-metadata\ found\ in\ PDF\:\ %0=XMP-metadata found in PDF: %0
+You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=You must restart JabRef for this to come into effect.
+You\ have\ changed\ the\ language\ setting.=You have changed the language setting.
+You\ have\ entered\ an\ invalid\ search\ '%0'.=You have entered an invalid search '%0'.
 
-You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.=You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=You must restart JabRef for the new key bindings to work properly.
 
-Your_new_key_bindings_have_been_stored.=Your_new_key_bindings_have_been_stored.
+Your\ new\ key\ bindings\ have\ been\ stored.=Your new key bindings have been stored.
 
-The_following_fetchers_are_available\:=The_following_fetchers_are_available\:
-Could_not_find_fetcher_'%0'=Could_not_find_fetcher_'%0'
-Running_query_'%0'_with_fetcher_'%1'.=Running_query_'%0'_with_fetcher_'%1'.
-Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.=Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.
+The\ following\ fetchers\ are\ available\:=The following fetchers are available:
+Could\ not\ find\ fetcher\ '%0'=Could not find fetcher '%0'
+Running\ query\ '%0'\ with\ fetcher\ '%1'.=Running query '%0' with fetcher '%1'.
+Query\ '%0'\ with\ fetcher\ '%1'\ did\ not\ return\ any\ results.=Query '%0' with fetcher '%1' did not return any results.
 
-Move_file=Move_file
-Rename_file=Rename_file
+Move\ file=Move file
+Rename\ file=Rename file
 
-Move_file_failed=Move_file_failed
-Could_not_move_file_'%0'.=Could_not_move_file_'%0'.
-Could_not_find_file_'%0'.=Could_not_find_file_'%0'.
-Number_of_entries_successfully_imported=Number_of_entries_successfully_imported
-Import_canceled_by_user=Import_canceled_by_user
-Progress\:_%0_of_%1=Progress\:_%0_of_%1
-Error_while_fetching_from_%0=Error_while_fetching_from_%0
+Move\ file\ failed=Move file failed
+Could\ not\ move\ file\ '%0'.=Could not move file '%0'.
+Could\ not\ find\ file\ '%0'.=Could not find file '%0'.
+Number\ of\ entries\ successfully\ imported=Number of entries successfully imported
+Import\ canceled\ by\ user=Import canceled by user
+Progress\:\ %0\ of\ %1=Progress: %0 of %1
+Error\ while\ fetching\ from\ %0=Error while fetching from %0
 
-Please_enter_a_valid_number=Please_enter_a_valid_number
-Show_search_results_in_a_window=Show_search_results_in_a_window
-Show_global_search_results_in_a_window=Show_global_search_results_in_a_window
-Search_in_all_open_libraries=Search_in_all_open_libraries
-Move_file_to_file_directory?=Move_file_to_file_directory?
+Please\ enter\ a\ valid\ number=Please enter a valid number
+Show\ search\ results\ in\ a\ window=Show search results in a window
+Show\ global\ search\ results\ in\ a\ window=Show global search results in a window
+Search\ in\ all\ open\ libraries=Search in all open libraries
+Move\ file\ to\ file\ directory?=Move file to file directory?
 
-Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.=Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.
-Protected_library=Protected_library
-Refuse_to_save_the_library_before_external_changes_have_been_reviewed.=Refuse_to_save_the_library_before_external_changes_have_been_reviewed.
-Library_protection=Library_protection
-Unable_to_save_library=Unable_to_save_library
+Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=Library is protected. Cannot save until external changes have been reviewed.
+Protected\ library=Protected library
+Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=Refuse to save the library before external changes have been reviewed.
+Library\ protection=Library protection
+Unable\ to\ save\ library=Unable to save library
 
-BibTeX_key_generator=BibTeX_key_generator
-Unable_to_open_link.=Unable_to_open_link.
-Move_the_keyboard_focus_to_the_entry_table=Move_the_keyboard_focus_to_the_entry_table
-MIME_type=MIME_type
+BibTeX\ key\ generator=BibTeX key generator
+Unable\ to\ open\ link.=Unable to open link.
+Move\ the\ keyboard\ focus\ to\ the\ entry\ table=Move the keyboard focus to the entry table
+MIME\ type=MIME type
 
-This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.=This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.
-Run_fetcher,_e.g._"--fetch\=Medline\:cancer"=Run_fetcher,_e.g._"--fetch=Medline\:cancer"
+This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef<BR>instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef<br>from\ your\ web\ browser.<BR>Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=This feature lets new files be opened or imported into an already running instance of JabRef<BR>instead of opening a new instance. For instance, this is useful when you open a file in JabRef<br>from your web browser.<BR>Note that this will prevent you from running more than one instance of JabRef at a time.
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=Run fetcher, e.g. "--fetch=Medline:cancer"
 
-The_ACM_Digital_Library=The_ACM_Digital_Library
+The\ ACM\ Digital\ Library=The ACM Digital Library
 Reset=Reset
 
-Use_IEEE_LaTeX_abbreviations=Use_IEEE_LaTeX_abbreviations
-The_Guide_to_Computing_Literature=The_Guide_to_Computing_Literature
+Use\ IEEE\ LaTeX\ abbreviations=Use IEEE LaTeX abbreviations
+The\ Guide\ to\ Computing\ Literature=The Guide to Computing Literature
 
-When_opening_file_link,_search_for_matching_file_if_no_link_is_defined=When_opening_file_link,_search_for_matching_file_if_no_link_is_defined
-Settings_for_%0=Settings_for_%0
-Mark_entries_imported_into_an_existing_library=Mark_entries_imported_into_an_existing_library
-Unmark_all_entries_before_importing_new_entries_into_an_existing_library=Unmark_all_entries_before_importing_new_entries_into_an_existing_library
+When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=When opening file link, search for matching file if no link is defined
+Settings\ for\ %0=Settings for %0
+Mark\ entries\ imported\ into\ an\ existing\ library=Mark entries imported into an existing library
+Unmark\ all\ entries\ before\ importing\ new\ entries\ into\ an\ existing\ library=Unmark all entries before importing new entries into an existing library
 
 Forward=Forward
 Back=Back
-Sort_the_following_fields_as_numeric_fields=Sort_the_following_fields_as_numeric_fields
-Line_%0\:_Found_corrupted_BibTeX_key.=Line_%0\:_Found_corrupted_BibTeX_key.
-Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).=Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).
-Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).=Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).
-Full_text_document_download_failed=Full_text_document_download_failed
-Update_to_current_column_order=Update_to_current_column_order
-Download_from_URL=Download_from_URL
-Rename_field=Rename_field
-Set/clear/append/rename_fields=Set/clear/append/rename_fields
-Append_field=Append_field
-Append_to_fields=Append_to_fields
-Rename_field_to=Rename_field_to
-Move_contents_of_a_field_into_a_field_with_a_different_name=Move_contents_of_a_field_into_a_field_with_a_different_name
-You_can_only_rename_one_field_at_a_time=You_can_only_rename_one_field_at_a_time
+Sort\ the\ following\ fields\ as\ numeric\ fields=Sort the following fields as numeric fields
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=Line %0: Found corrupted BibTeX key.
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=Line %0: Found corrupted BibTeX key (contains whitespaces).
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=Line %0: Found corrupted BibTeX key (comma missing).
+Full\ text\ document\ download\ failed=Full text document download failed
+Update\ to\ current\ column\ order=Update to current column order
+Download\ from\ URL=Download from URL
+Rename\ field=Rename field
+Set/clear/append/rename\ fields=Set/clear/append/rename fields
+Append\ field=Append field
+Append\ to\ fields=Append to fields
+Rename\ field\ to=Rename field to
+Move\ contents\ of\ a\ field\ into\ a\ field\ with\ a\ different\ name=Move contents of a field into a field with a different name
+You\ can\ only\ rename\ one\ field\ at\ a\ time=You can only rename one field at a time
 
-Remove_all_broken_links=Remove_all_broken_links
+Remove\ all\ broken\ links=Remove all broken links
 
-Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.=Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.
+Cannot\ use\ port\ %0\ for\ remote\ operation;\ another\ application\ may\ be\ using\ it.\ Try\ specifying\ another\ port.=Cannot use port %0 for remote operation; another application may be using it. Try specifying another port.
 
-Looking_for_full_text_document...=Looking_for_full_text_document...
+Looking\ for\ full\ text\ document...=Looking for full text document...
 Autosave=Autosave
-A_local_copy_will_be_opened.=A_local_copy_will_be_opened.
-Autosave_local_libraries=Autosave_local_libraries
-Automatically_save_the_library_to=Automatically_save_the_library_to
-Please_enter_a_valid_file_path.=Please_enter_a_valid_file_path.
+A\ local\ copy\ will\ be\ opened.=A local copy will be opened.
+Autosave\ local\ libraries=Autosave local libraries
+Automatically\ save\ the\ library\ to=Automatically save the library to
+Please\ enter\ a\ valid\ file\ path.=Please enter a valid file path.
 
 
-Export_in_current_table_sort_order=Export_in_current_table_sort_order
-Export_entries_in_their_original_order=Export_entries_in_their_original_order
-Error_opening_file_'%0'.=Error_opening_file_'%0'.
+Export\ in\ current\ table\ sort\ order=Export in current table sort order
+Export\ entries\ in\ their\ original\ order=Export entries in their original order
+Error\ opening\ file\ '%0'.=Error opening file '%0'.
 
-Formatter_not_found\:_%0=Formatter_not_found\:_%0
-Clear_inputarea=Clear_inputarea
+Formatter\ not\ found\:\ %0=Formatter not found: %0
+Clear\ inputarea=Clear inputarea
 
-Automatically_set_file_links_for_this_entry=Automatically_set_file_links_for_this_entry
-Could_not_save,_file_locked_by_another_JabRef_instance.=Could_not_save,_file_locked_by_another_JabRef_instance.
-File_is_locked_by_another_JabRef_instance.=File_is_locked_by_another_JabRef_instance.
-Do_you_want_to_override_the_file_lock?=Do_you_want_to_override_the_file_lock?
-File_locked=File_locked
-Current_tmp_value=Current_tmp_value
-Metadata_change=Metadata_change
-Changes_have_been_made_to_the_following_metadata_elements=Changes_have_been_made_to_the_following_metadata_elements
+Automatically\ set\ file\ links\ for\ this\ entry=Automatically set file links for this entry
+Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=Could not save, file locked by another JabRef instance.
+File\ is\ locked\ by\ another\ JabRef\ instance.=File is locked by another JabRef instance.
+Do\ you\ want\ to\ override\ the\ file\ lock?=Do you want to override the file lock?
+File\ locked=File locked
+Current\ tmp\ value=Current tmp value
+Metadata\ change=Metadata change
+Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=Changes have been made to the following metadata elements
 
-Generate_groups_for_author_last_names=Generate_groups_for_author_last_names
-Generate_groups_from_keywords_in_a_BibTeX_field=Generate_groups_from_keywords_in_a_BibTeX_field
-Enforce_legal_characters_in_BibTeX_keys=Enforce_legal_characters_in_BibTeX_keys
+Generate\ groups\ for\ author\ last\ names=Generate groups for author last names
+Generate\ groups\ from\ keywords\ in\ a\ BibTeX\ field=Generate groups from keywords in a BibTeX field
+Enforce\ legal\ characters\ in\ BibTeX\ keys=Enforce legal characters in BibTeX keys
 
-Save_without_backup?=Save_without_backup?
-Unable_to_create_backup=Unable_to_create_backup
-Move_file_to_file_directory=Move_file_to_file_directory
-Rename_file_to=Rename_file_to
-<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)=<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)
-static_group=static_group
-dynamic_group=dynamic_group
-refines_supergroup=refines_supergroup
-includes_subgroups=includes_subgroups
+Save\ without\ backup?=Save without backup?
+Unable\ to\ create\ backup=Unable to create backup
+Move\ file\ to\ file\ directory=Move file to file directory
+Rename\ file\ to=Rename file to
+<b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=<b>All Entries</b> (this group cannot be edited or removed)
+static\ group=static group
+dynamic\ group=dynamic group
+refines\ supergroup=refines supergroup
+includes\ subgroups=includes subgroups
 contains=contains
-search_expression=search_expression
+search\ expression=search expression
 
-Optional_fields_2=Optional_fields_2
-Waiting_for_save_operation_to_finish=Waiting_for_save_operation_to_finish
-Resolving_duplicate_BibTeX_keys...=Resolving_duplicate_BibTeX_keys...
-Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.=Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.
-This_library_contains_one_or_more_duplicated_BibTeX_keys.=This_library_contains_one_or_more_duplicated_BibTeX_keys.
-Do_you_want_to_resolve_duplicate_keys_now?=Do_you_want_to_resolve_duplicate_keys_now?
+Optional\ fields\ 2=Optional fields 2
+Waiting\ for\ save\ operation\ to\ finish=Waiting for save operation to finish
+Resolving\ duplicate\ BibTeX\ keys...=Resolving duplicate BibTeX keys...
+Finished\ resolving\ duplicate\ BibTeX\ keys.\ %0\ entries\ modified.=Finished resolving duplicate BibTeX keys. %0 entries modified.
+This\ library\ contains\ one\ or\ more\ duplicated\ BibTeX\ keys.=This library contains one or more duplicated BibTeX keys.
+Do\ you\ want\ to\ resolve\ duplicate\ keys\ now?=Do you want to resolve duplicate keys now?
 
-Find_and_remove_duplicate_BibTeX_keys=Find_and_remove_duplicate_BibTeX_keys
-Expected_syntax_for_--fetch\='<name_of_fetcher>\:<query>'=Expected_syntax_for_--fetch='<name_of_fetcher>\:<query>'
-Duplicate_BibTeX_key=Duplicate_BibTeX_key
-Import_marking_color=Import_marking_color
-Always_add_letter_(a,_b,_...)_to_generated_keys=Always_add_letter_(a,_b,_...)_to_generated_keys
+Find\ and\ remove\ duplicate\ BibTeX\ keys=Find and remove duplicate BibTeX keys
+Expected\ syntax\ for\ --fetch\='<name\ of\ fetcher>\:<query>'=Expected syntax for --fetch='<name of fetcher>:<query>'
+Duplicate\ BibTeX\ key=Duplicate BibTeX key
+Import\ marking\ color=Import marking color
+Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=Always add letter (a, b, ...) to generated keys
 
-Ensure_unique_keys_using_letters_(a,_b,_...)=Ensure_unique_keys_using_letters_(a,_b,_...)
-Ensure_unique_keys_using_letters_(b,_c,_...)=Ensure_unique_keys_using_letters_(b,_c,_...)
-Entry_editor_active_background_color=Entry_editor_active_background_color
-Entry_editor_background_color=Entry_editor_background_color
-Entry_editor_font_color=Entry_editor_font_color
-Entry_editor_invalid_field_color=Entry_editor_invalid_field_color
+Ensure\ unique\ keys\ using\ letters\ (a,\ b,\ ...)=Ensure unique keys using letters (a, b, ...)
+Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=Ensure unique keys using letters (b, c, ...)
+Entry\ editor\ active\ background\ color=Entry editor active background color
+Entry\ editor\ background\ color=Entry editor background color
+Entry\ editor\ font\ color=Entry editor font color
+Entry\ editor\ invalid\ field\ color=Entry editor invalid field color
 
-Table_and_entry_editor_colors=Table_and_entry_editor_colors
+Table\ and\ entry\ editor\ colors=Table and entry editor colors
 
-General_file_directory=General_file_directory
-User-specific_file_directory=User-specific_file_directory
-Search_failed\:_illegal_search_expression=Search_failed\:_illegal_search_expression
-Show_ArXiv_column=Show_ArXiv_column
+General\ file\ directory=General file directory
+User-specific\ file\ directory=User-specific file directory
+Search\ failed\:\ illegal\ search\ expression=Search failed: illegal search expression
+Show\ ArXiv\ column=Show ArXiv column
 
-You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for=You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for
-Automatically_open_browse_dialog_when_creating_new_file_link=Automatically_open_browse_dialog_when_creating_new_file_link
-Import_metadata_from\:=Import_metadata_from\:
-Choose_the_source_for_the_metadata_import=Choose_the_source_for_the_metadata_import
-Create_entry_based_on_XMP-metadata=Create_entry_based_on_XMP-metadata
-Create_blank_entry_linking_the_PDF=Create_blank_entry_linking_the_PDF
-Only_attach_PDF=Only_attach_PDF
+You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=You must enter an integer value in the interval 1025-65535 in the text field for
+Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Automatically open browse dialog when creating new file link
+Import\ metadata\ from\:=Import metadata from:
+Choose\ the\ source\ for\ the\ metadata\ import=Choose the source for the metadata import
+Create\ entry\ based\ on\ XMP-metadata=Create entry based on XMP-metadata
+Create\ blank\ entry\ linking\ the\ PDF=Create blank entry linking the PDF
+Only\ attach\ PDF=Only attach PDF
 Title=Title
-Create_new_entry=Create_new_entry
-Update_existing_entry=Update_existing_entry
-Autocomplete_names_in_'Firstname_Lastname'_format_only=Autocomplete_names_in_'Firstname_Lastname'_format_only
-Autocomplete_names_in_'Lastname,_Firstname'_format_only=Autocomplete_names_in_'Lastname,_Firstname'_format_only
-Autocomplete_names_in_both_formats=Autocomplete_names_in_both_formats
-Marking_color_%0=Marking_color_%0
-The_name_'comment'_cannot_be_used_as_an_entry_type_name.=The_name_'comment'_cannot_be_used_as_an_entry_type_name.
-You_must_enter_an_integer_value_in_the_text_field_for=You_must_enter_an_integer_value_in_the_text_field_for
-Send_as_email=Send_as_email
+Create\ new\ entry=Create new entry
+Update\ existing\ entry=Update existing entry
+Autocomplete\ names\ in\ 'Firstname\ Lastname'\ format\ only=Autocomplete names in 'Firstname Lastname' format only
+Autocomplete\ names\ in\ 'Lastname,\ Firstname'\ format\ only=Autocomplete names in 'Lastname, Firstname' format only
+Autocomplete\ names\ in\ both\ formats=Autocomplete names in both formats
+Marking\ color\ %0=Marking color %0
+The\ name\ 'comment'\ cannot\ be\ used\ as\ an\ entry\ type\ name.=The name 'comment' cannot be used as an entry type name.
+You\ must\ enter\ an\ integer\ value\ in\ the\ text\ field\ for=You must enter an integer value in the text field for
+Send\ as\ email=Send as email
 References=References
-Sending_of_emails=Sending_of_emails
-Subject_for_sending_an_email_with_references=Subject_for_sending_an_email_with_references
-Automatically_open_folders_of_attached_files=Automatically_open_folders_of_attached_files
-Create_entry_based_on_content=Create_entry_based_on_content
-Do_not_show_this_box_again_for_this_import=Do_not_show_this_box_again_for_this_import
-Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)=Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)
-Error_creating_email=Error_creating_email
-Entries_added_to_an_email=Entries_added_to_an_email
+Sending\ of\ emails=Sending of emails
+Subject\ for\ sending\ an\ email\ with\ references=Subject for sending an email with references
+Automatically\ open\ folders\ of\ attached\ files=Automatically open folders of attached files
+Create\ entry\ based\ on\ content=Create entry based on content
+Do\ not\ show\ this\ box\ again\ for\ this\ import=Do not show this box again for this import
+Always\ use\ this\ PDF\ import\ style\ (and\ do\ not\ ask\ for\ each\ import)=Always use this PDF import style (and do not ask for each import)
+Error\ creating\ email=Error creating email
+Entries\ added\ to\ an\ email=Entries added to an email
 exportFormat=exportFormat
-Output_file_missing=Output_file_missing
-No_search_matches.=No_search_matches.
-The_output_option_depends_on_a_valid_input_option.=The_output_option_depends_on_a_valid_input_option.
-Default_import_style_for_drag_and_drop_of_PDFs=Default_import_style_for_drag_and_drop_of_PDFs
-Default_PDF_file_link_action=Default_PDF_file_link_action
-Filename_format_pattern=Filename_format_pattern
-Additional_parameters=Additional_parameters
-Cite_selected_entries_between_parenthesis=Cite_selected_entries_between_parenthesis
-Cite_selected_entries_with_in-text_citation=Cite_selected_entries_with_in-text_citation
-Cite_special=Cite_special
-Extra_information_(e.g._page_number)=Extra_information_(e.g._page_number)
-Manage_citations=Manage_citations
-Problem_modifying_citation=Problem_modifying_citation
+Output\ file\ missing=Output file missing
+No\ search\ matches.=No search matches.
+The\ output\ option\ depends\ on\ a\ valid\ input\ option.=The output option depends on a valid input option.
+Default\ import\ style\ for\ drag\ and\ drop\ of\ PDFs=Default import style for drag and drop of PDFs
+Default\ PDF\ file\ link\ action=Default PDF file link action
+Filename\ format\ pattern=Filename format pattern
+Additional\ parameters=Additional parameters
+Cite\ selected\ entries\ between\ parenthesis=Cite selected entries between parenthesis
+Cite\ selected\ entries\ with\ in-text\ citation=Cite selected entries with in-text citation
+Cite\ special=Cite special
+Extra\ information\ (e.g.\ page\ number)=Extra information (e.g. page number)
+Manage\ citations=Manage citations
+Problem\ modifying\ citation=Problem modifying citation
 Citation=Citation
-Extra_information=Extra_information
-Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.=Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.
-Select_style=Select_style
+Extra\ information=Extra information
+Could\ not\ resolve\ BibTeX\ entry\ for\ citation\ marker\ '%0'.=Could not resolve BibTeX entry for citation marker '%0'.
+Select\ style=Select style
 Journals=Journals
 Cite=Cite
-Cite_in-text=Cite_in-text
-Insert_empty_citation=Insert_empty_citation
-Merge_citations=Merge_citations
-Manual_connect=Manual_connect
-Select_Writer_document=Select_Writer_document
-Sync_OpenOffice/LibreOffice_bibliography=Sync_OpenOffice/LibreOffice_bibliography
-Select_which_open_Writer_document_to_work_on=Select_which_open_Writer_document_to_work_on
-Connected_to_document=Connected_to_document
-Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)=Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)
-Cite_selected_entries_with_extra_information=Cite_selected_entries_with_extra_information
-Ensure_that_the_bibliography_is_up-to-date=Ensure_that_the_bibliography_is_up-to-date
-Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.=Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.
-Unable_to_synchronize_bibliography=Unable_to_synchronize_bibliography
-Combine_pairs_of_citations_that_are_separated_by_spaces_only=Combine_pairs_of_citations_that_are_separated_by_spaces_only
-Autodetection_failed=Autodetection_failed
+Cite\ in-text=Cite in-text
+Insert\ empty\ citation=Insert empty citation
+Merge\ citations=Merge citations
+Manual\ connect=Manual connect
+Select\ Writer\ document=Select Writer document
+Sync\ OpenOffice/LibreOffice\ bibliography=Sync OpenOffice/LibreOffice bibliography
+Select\ which\ open\ Writer\ document\ to\ work\ on=Select which open Writer document to work on
+Connected\ to\ document=Connected to document
+Insert\ a\ citation\ without\ text\ (the\ entry\ will\ appear\ in\ the\ reference\ list)=Insert a citation without text (the entry will appear in the reference list)
+Cite\ selected\ entries\ with\ extra\ information=Cite selected entries with extra information
+Ensure\ that\ the\ bibliography\ is\ up-to-date=Ensure that the bibliography is up-to-date
+Your\ OpenOffice/LibreOffice\ document\ references\ the\ BibTeX\ key\ '%0',\ which\ could\ not\ be\ found\ in\ your\ current\ library.=Your OpenOffice/LibreOffice document references the BibTeX key '%0', which could not be found in your current library.
+Unable\ to\ synchronize\ bibliography=Unable to synchronize bibliography
+Combine\ pairs\ of\ citations\ that\ are\ separated\ by\ spaces\ only=Combine pairs of citations that are separated by spaces only
+Autodetection\ failed=Autodetection failed
 Connecting=Connecting
-Please_wait...=Please_wait...
-Set_connection_parameters=Set_connection_parameters
-Path_to_OpenOffice/LibreOffice_directory=Path_to_OpenOffice/LibreOffice_directory
-Path_to_OpenOffice/LibreOffice_executable=Path_to_OpenOffice/LibreOffice_executable
-Path_to_OpenOffice/LibreOffice_library_dir=Path_to_OpenOffice/LibreOffice_library_dir
-Connection_lost=Connection_lost
-The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.=The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.
-The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.=The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.
-Automatically_sync_bibliography_when_inserting_citations=Automatically_sync_bibliography_when_inserting_citations
-Look_up_BibTeX_entries_in_the_active_tab_only=Look_up_BibTeX_entries_in_the_active_tab_only
-Look_up_BibTeX_entries_in_all_open_libraries=Look_up_BibTeX_entries_in_all_open_libraries
-Autodetecting_paths...=Autodetecting_paths...
-Could_not_find_OpenOffice/LibreOffice_installation=Could_not_find_OpenOffice/LibreOffice_installation
-Found_more_than_one_OpenOffice/LibreOffice_executable.=Found_more_than_one_OpenOffice/LibreOffice_executable.
-Please_choose_which_one_to_connect_to\:=Please_choose_which_one_to_connect_to\:
-Choose_OpenOffice/LibreOffice_executable=Choose_OpenOffice/LibreOffice_executable
-Select_document=Select_document
-HTML_list=HTML_list
-If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting=If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting
-Could_not_open_%0=Could_not_open_%0
-Unknown_import_format=Unknown_import_format
-Web_search=Web_search
-Style_selection=Style_selection
-No_valid_style_file_defined=No_valid_style_file_defined
-Choose_pattern=Choose_pattern
-Use_the_BIB_file_location_as_primary_file_directory=Use_the_BIB_file_location_as_primary_file_directory
-Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.=Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.
-OpenOffice/LibreOffice_connection=OpenOffice/LibreOffice_connection
-You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.=You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.
+Please\ wait...=Please wait...
+Set\ connection\ parameters=Set connection parameters
+Path\ to\ OpenOffice/LibreOffice\ directory=Path to OpenOffice/LibreOffice directory
+Path\ to\ OpenOffice/LibreOffice\ executable=Path to OpenOffice/LibreOffice executable
+Path\ to\ OpenOffice/LibreOffice\ library\ dir=Path to OpenOffice/LibreOffice library dir
+Connection\ lost=Connection lost
+The\ paragraph\ format\ is\ controlled\ by\ the\ property\ 'ReferenceParagraphFormat'\ or\ 'ReferenceHeaderParagraphFormat'\ in\ the\ style\ file.=The paragraph format is controlled by the property 'ReferenceParagraphFormat' or 'ReferenceHeaderParagraphFormat' in the style file.
+The\ character\ format\ is\ controlled\ by\ the\ citation\ property\ 'CitationCharacterFormat'\ in\ the\ style\ file.=The character format is controlled by the citation property 'CitationCharacterFormat' in the style file.
+Automatically\ sync\ bibliography\ when\ inserting\ citations=Automatically sync bibliography when inserting citations
+Look\ up\ BibTeX\ entries\ in\ the\ active\ tab\ only=Look up BibTeX entries in the active tab only
+Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=Look up BibTeX entries in all open libraries
+Autodetecting\ paths...=Autodetecting paths...
+Could\ not\ find\ OpenOffice/LibreOffice\ installation=Could not find OpenOffice/LibreOffice installation
+Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=Found more than one OpenOffice/LibreOffice executable.
+Please\ choose\ which\ one\ to\ connect\ to\:=Please choose which one to connect to:
+Choose\ OpenOffice/LibreOffice\ executable=Choose OpenOffice/LibreOffice executable
+Select\ document=Select document
+HTML\ list=HTML list
+If\ possible,\ normalize\ this\ list\ of\ names\ to\ conform\ to\ standard\ BibTeX\ name\ formatting=If possible, normalize this list of names to conform to standard BibTeX name formatting
+Could\ not\ open\ %0=Could not open %0
+Unknown\ import\ format=Unknown import format
+Web\ search=Web search
+Style\ selection=Style selection
+No\ valid\ style\ file\ defined=No valid style file defined
+Choose\ pattern=Choose pattern
+Use\ the\ BIB\ file\ location\ as\ primary\ file\ directory=Use the BIB file location as primary file directory
+Could\ not\ run\ the\ gnuclient/emacsclient\ program.\ Make\ sure\ you\ have\ the\ emacsclient/gnuclient\ program\ installed\ and\ available\ in\ the\ PATH.=Could not run the gnuclient/emacsclient program. Make sure you have the emacsclient/gnuclient program installed and available in the PATH.
+OpenOffice/LibreOffice\ connection=OpenOffice/LibreOffice connection
+You\ must\ select\ either\ a\ valid\ style\ file,\ or\ use\ one\ of\ the\ default\ styles.=You must select either a valid style file, or use one of the default styles.
 
-This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.=This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.
-This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.=This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.
-You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.=You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.
+This\ is\ a\ simple\ copy\ and\ paste\ dialog.\ First\ load\ or\ paste\ some\ text\ into\ the\ text\ input\ area.<br>After\ that,\ you\ can\ mark\ text\ and\ assign\ it\ to\ a\ BibTeX\ field.=This is a simple copy and paste dialog. First load or paste some text into the text input area.<br>After that, you can mark text and assign it to a BibTeX field.
+This\ feature\ generates\ a\ new\ library\ based\ on\ which\ entries\ are\ needed\ in\ an\ existing\ LaTeX\ document.=This feature generates a new library based on which entries are needed in an existing LaTeX document.
+You\ need\ to\ select\ one\ of\ your\ open\ libraries\ from\ which\ to\ choose\ entries,\ as\ well\ as\ the\ AUX\ file\ produced\ by\ LaTeX\ when\ compiling\ your\ document.=You need to select one of your open libraries from which to choose entries, as well as the AUX file produced by LaTeX when compiling your document.
 
-First_select_entries_to_clean_up.=First_select_entries_to_clean_up.
-Cleanup_entry=Cleanup_entry
-Autogenerate_PDF_Names=Autogenerate_PDF_Names
-Auto-generating_PDF-Names_does_not_support_undo._Continue?=Auto-generating_PDF-Names_does_not_support_undo._Continue?
+First\ select\ entries\ to\ clean\ up.=First select entries to clean up.
+Cleanup\ entry=Cleanup entry
+Autogenerate\ PDF\ Names=Autogenerate PDF Names
+Auto-generating\ PDF-Names\ does\ not\ support\ undo.\ Continue?=Auto-generating PDF-Names does not support undo. Continue?
 
-Use_full_firstname_whenever_possible=Use_full_firstname_whenever_possible
-Use_abbreviated_firstname_whenever_possible=Use_abbreviated_firstname_whenever_possible
-Use_abbreviated_and_full_firstname=Use_abbreviated_and_full_firstname
-Autocompletion_options=Autocompletion_options
-Name_format_used_for_autocompletion=Name_format_used_for_autocompletion
-Treatment_of_first_names=Treatment_of_first_names
-Cleanup_entries=Cleanup_entries
-Automatically_assign_new_entry_to_selected_groups=Automatically_assign_new_entry_to_selected_groups
-%0_mode=%0_mode
-Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix=Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix
-Make_paths_of_linked_files_relative_(if_possible)=Make_paths_of_linked_files_relative_(if_possible)
-Rename_PDFs_to_given_filename_format_pattern=Rename_PDFs_to_given_filename_format_pattern
-Rename_only_PDFs_having_a_relative_path=Rename_only_PDFs_having_a_relative_path
-What_would_you_like_to_clean_up?=What_would_you_like_to_clean_up?
-Doing_a_cleanup_for_%0_entries...=Doing_a_cleanup_for_%0_entries...
-No_entry_needed_a_clean_up=No_entry_needed_a_clean_up
-One_entry_needed_a_clean_up=One_entry_needed_a_clean_up
-%0_entries_needed_a_clean_up=%0_entries_needed_a_clean_up
+Use\ full\ firstname\ whenever\ possible=Use full firstname whenever possible
+Use\ abbreviated\ firstname\ whenever\ possible=Use abbreviated firstname whenever possible
+Use\ abbreviated\ and\ full\ firstname=Use abbreviated and full firstname
+Autocompletion\ options=Autocompletion options
+Name\ format\ used\ for\ autocompletion=Name format used for autocompletion
+Treatment\ of\ first\ names=Treatment of first names
+Cleanup\ entries=Cleanup entries
+Automatically\ assign\ new\ entry\ to\ selected\ groups=Automatically assign new entry to selected groups
+%0\ mode=%0 mode
+Move\ DOIs\ from\ note\ and\ URL\ field\ to\ DOI\ field\ and\ remove\ http\ prefix=Move DOIs from note and URL field to DOI field and remove http prefix
+Make\ paths\ of\ linked\ files\ relative\ (if\ possible)=Make paths of linked files relative (if possible)
+Rename\ PDFs\ to\ given\ filename\ format\ pattern=Rename PDFs to given filename format pattern
+Rename\ only\ PDFs\ having\ a\ relative\ path=Rename only PDFs having a relative path
+What\ would\ you\ like\ to\ clean\ up?=What would you like to clean up?
+Doing\ a\ cleanup\ for\ %0\ entries...=Doing a cleanup for %0 entries...
+No\ entry\ needed\ a\ clean\ up=No entry needed a clean up
+One\ entry\ needed\ a\ clean\ up=One entry needed a clean up
+%0\ entries\ needed\ a\ clean\ up=%0 entries needed a clean up
 
-Remove_selected=Remove_selected
+Remove\ selected=Remove selected
 
-Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.=Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.
-Attach_file=Attach_file
-Setting_all_preferences_to_default_values.=Setting_all_preferences_to_default_values.
-Resetting_preference_key_'%0'=Resetting_preference_key_'%0'
-Unknown_preference_key_'%0'=Unknown_preference_key_'%0'
-Unable_to_clear_preferences.=Unable_to_clear_preferences.
+Group\ tree\ could\ not\ be\ parsed.\ If\ you\ save\ the\ BibTeX\ library,\ all\ groups\ will\ be\ lost.=Group tree could not be parsed. If you save the BibTeX library, all groups will be lost.
+Attach\ file=Attach file
+Setting\ all\ preferences\ to\ default\ values.=Setting all preferences to default values.
+Resetting\ preference\ key\ '%0'=Resetting preference key '%0'
+Unknown\ preference\ key\ '%0'=Unknown preference key '%0'
+Unable\ to\ clear\ preferences.=Unable to clear preferences.
 
-Reset_preferences_(key1,key2,..._or_'all')=Reset_preferences_(key1,key2,..._or_'all')
-Find_unlinked_files=Find_unlinked_files
-Unselect_all=Unselect_all
-Expand_all=Expand_all
-Collapse_all=Collapse_all
-Opens_the_file_browser.=Opens_the_file_browser.
-Scan_directory=Scan_directory
-Searches_the_selected_directory_for_unlinked_files.=Searches_the_selected_directory_for_unlinked_files.
-Starts_the_import_of_BibTeX_entries.=Starts_the_import_of_BibTeX_entries.
-Leave_this_dialog.=Leave_this_dialog.
-Create_directory_based_keywords=Create_directory_based_keywords
-Creates_keywords_in_created_entrys_with_directory_pathnames=Creates_keywords_in_created_entrys_with_directory_pathnames
-Select_a_directory_where_the_search_shall_start.=Select_a_directory_where_the_search_shall_start.
-Select_file_type\:=Select_file_type\:
-These_files_are_not_linked_in_the_active_library.=These_files_are_not_linked_in_the_active_library.
-Entry_type_to_be_created\:=Entry_type_to_be_created\:
-Searching_file_system...=Searching_file_system...
-Importing_into_Library...=Importing_into_Library...
-Select_directory=Select_directory
-Select_files=Select_files
-BibTeX_entry_creation=BibTeX_entry_creation
-<No_selection>=<No_selection>
-Unable_to_connect_to_FreeCite_online_service.=Unable_to_connect_to_FreeCite_online_service.
-Parse_with_FreeCite=Parse_with_FreeCite
-The_current_BibTeX_key_will_be_overwritten._Continue?=The_current_BibTeX_key_will_be_overwritten._Continue?
-Overwrite_key=Overwrite_key
-Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator=Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator
-How_would_you_like_to_link_to_'%0'?=How_would_you_like_to_link_to_'%0'?
-BibTeX_key_patterns=BibTeX_key_patterns
-Changed_special_field_settings=Changed_special_field_settings
-Clear_priority=Clear_priority
-Clear_rank=Clear_rank
-Enable_special_fields=Enable_special_fields
-One_star=One_star
-Two_stars=Two_stars
-Three_stars=Three_stars
-Four_stars=Four_stars
-Five_stars=Five_stars
-Help_on_special_fields=Help_on_special_fields
-Keywords_of_selected_entries=Keywords_of_selected_entries
-Manage_content_selectors=Manage_content_selectors
-Manage_keywords=Manage_keywords
-No_priority_information=No_priority_information
-No_rank_information=No_rank_information
+Reset\ preferences\ (key1,key2,...\ or\ 'all')=Reset preferences (key1,key2,... or 'all')
+Find\ unlinked\ files=Find unlinked files
+Unselect\ all=Unselect all
+Expand\ all=Expand all
+Collapse\ all=Collapse all
+Opens\ the\ file\ browser.=Opens the file browser.
+Scan\ directory=Scan directory
+Searches\ the\ selected\ directory\ for\ unlinked\ files.=Searches the selected directory for unlinked files.
+Starts\ the\ import\ of\ BibTeX\ entries.=Starts the import of BibTeX entries.
+Leave\ this\ dialog.=Leave this dialog.
+Create\ directory\ based\ keywords=Create directory based keywords
+Creates\ keywords\ in\ created\ entrys\ with\ directory\ pathnames=Creates keywords in created entrys with directory pathnames
+Select\ a\ directory\ where\ the\ search\ shall\ start.=Select a directory where the search shall start.
+Select\ file\ type\:=Select file type:
+These\ files\ are\ not\ linked\ in\ the\ active\ library.=These files are not linked in the active library.
+Entry\ type\ to\ be\ created\:=Entry type to be created:
+Searching\ file\ system...=Searching file system...
+Importing\ into\ Library...=Importing into Library...
+Select\ directory=Select directory
+Select\ files=Select files
+BibTeX\ entry\ creation=BibTeX entry creation
+<No\ selection>=<No selection>
+Unable\ to\ connect\ to\ FreeCite\ online\ service.=Unable to connect to FreeCite online service.
+Parse\ with\ FreeCite=Parse with FreeCite
+The\ current\ BibTeX\ key\ will\ be\ overwritten.\ Continue?=The current BibTeX key will be overwritten. Continue?
+Overwrite\ key=Overwrite key
+Not\ overwriting\ existing\ key.\ To\ change\ this\ setting,\ open\ Options\ ->\ Prefererences\ ->\ BibTeX\ key\ generator=Not overwriting existing key. To change this setting, open Options -> Prefererences -> BibTeX key generator
+How\ would\ you\ like\ to\ link\ to\ '%0'?=How would you like to link to '%0'?
+BibTeX\ key\ patterns=BibTeX key patterns
+Changed\ special\ field\ settings=Changed special field settings
+Clear\ priority=Clear priority
+Clear\ rank=Clear rank
+Enable\ special\ fields=Enable special fields
+One\ star=One star
+Two\ stars=Two stars
+Three\ stars=Three stars
+Four\ stars=Four stars
+Five\ stars=Five stars
+Help\ on\ special\ fields=Help on special fields
+Keywords\ of\ selected\ entries=Keywords of selected entries
+Manage\ content\ selectors=Manage content selectors
+Manage\ keywords=Manage keywords
+No\ priority\ information=No priority information
+No\ rank\ information=No rank information
 Priority=Priority
-Priority_high=Priority_high
-Priority_low=Priority_low
-Priority_medium=Priority_medium
+Priority\ high=Priority high
+Priority\ low=Priority low
+Priority\ medium=Priority medium
 Quality=Quality
 Rank=Rank
 Relevance=Relevance
-Set_priority_to_high=Set_priority_to_high
-Set_priority_to_low=Set_priority_to_low
-Set_priority_to_medium=Set_priority_to_medium
-Show_priority=Show_priority
-Show_quality=Show_quality
-Show_rank=Show_rank
-Show_relevance=Show_relevance
-Synchronize_with_keywords=Synchronize_with_keywords
-Synchronized_special_fields_based_on_keywords=Synchronized_special_fields_based_on_keywords
-Toggle_relevance=Toggle_relevance
-Toggle_quality_assured=Toggle_quality_assured
-Toggle_print_status=Toggle_print_status
-Update_keywords=Update_keywords
-Write_values_of_special_fields_as_separate_fields_to_BibTeX=Write_values_of_special_fields_as_separate_fields_to_BibTeX
-You_have_changed_settings_for_special_fields.=You_have_changed_settings_for_special_fields.
-%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.=%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.
-A_string_with_that_label_already_exists=A_string_with_that_label_already_exists
-Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.=Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.
-JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.=JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.
-Correct_the_entry,_and_reopen_editor_to_display/edit_source.=Correct_the_entry,_and_reopen_editor_to_display/edit_source.
-Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').=Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').
-Could_not_connect_to_running_OpenOffice/LibreOffice.=Could_not_connect_to_running_OpenOffice/LibreOffice.
-Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.=Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.
-If_connecting_manually,_please_verify_program_and_library_paths.=If_connecting_manually,_please_verify_program_and_library_paths.
-Error_message\:=Error_message\:
-If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.=If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.
-Import_metadata_from_PDF=Import_metadata_from_PDF
-Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.=Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.
-Removed_all_subgroups_of_group_"%0".=Removed_all_subgroups_of_group_"%0".
-To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.=To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.
-Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.=Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.
-Use_the_following_delimiter_character(s)\:=Use_the_following_delimiter_character(s)\:
-When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above=When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above
-Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.
-Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.
+Set\ priority\ to\ high=Set priority to high
+Set\ priority\ to\ low=Set priority to low
+Set\ priority\ to\ medium=Set priority to medium
+Show\ priority=Show priority
+Show\ quality=Show quality
+Show\ rank=Show rank
+Show\ relevance=Show relevance
+Synchronize\ with\ keywords=Synchronize with keywords
+Synchronized\ special\ fields\ based\ on\ keywords=Synchronized special fields based on keywords
+Toggle\ relevance=Toggle relevance
+Toggle\ quality\ assured=Toggle quality assured
+Toggle\ print\ status=Toggle print status
+Update\ keywords=Update keywords
+Write\ values\ of\ special\ fields\ as\ separate\ fields\ to\ BibTeX=Write values of special fields as separate fields to BibTeX
+You\ have\ changed\ settings\ for\ special\ fields.=You have changed settings for special fields.
+%0\ entries\ found.\ To\ reduce\ server\ load,\ only\ %1\ will\ be\ downloaded.=%0 entries found. To reduce server load, only %1 will be downloaded.
+A\ string\ with\ that\ label\ already\ exists=A string with that label already exists
+Connection\ to\ OpenOffice/LibreOffice\ has\ been\ lost.\ Please\ make\ sure\ OpenOffice/LibreOffice\ is\ running,\ and\ try\ to\ reconnect.=Connection to OpenOffice/LibreOffice has been lost. Please make sure OpenOffice/LibreOffice is running, and try to reconnect.
+JabRef\ will\ send\ at\ least\ one\ request\ per\ entry\ to\ a\ publisher.=JabRef will send at least one request per entry to a publisher.
+Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=Correct the entry, and reopen editor to display/edit source.
+Could\ not\ connect\ to\ a\ running\ gnuserv\ process.\ Make\ sure\ that\ Emacs\ or\ XEmacs\ is\ running,<BR>and\ that\ the\ server\ has\ been\ started\ (by\ running\ the\ command\ 'server-start'/'gnuserv-start').=Could not connect to a running gnuserv process. Make sure that Emacs or XEmacs is running,<BR>and that the server has been started (by running the command 'server-start'/'gnuserv-start').
+Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=Could not connect to running OpenOffice/LibreOffice.
+Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=Make sure you have installed OpenOffice/LibreOffice with Java support.
+If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=If connecting manually, please verify program and library paths.
+Error\ message\:=Error message:
+If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=If a pasted or imported entry already has the field set, overwrite.
+Import\ metadata\ from\ PDF=Import metadata from PDF
+Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=Not connected to any Writer document. Please make sure a document is open, and use the 'Select Writer document' button to connect to it.
+Removed\ all\ subgroups\ of\ group\ "%0".=Removed all subgroups of group "%0".
+To\ disable\ the\ memory\ stick\ mode\ rename\ or\ remove\ the\ jabref.xml\ file\ in\ the\ same\ folder\ as\ JabRef.=To disable the memory stick mode rename or remove the jabref.xml file in the same folder as JabRef.
+Unable\ to\ connect.\ One\ possible\ reason\ is\ that\ JabRef\ and\ OpenOffice/LibreOffice\ are\ not\ both\ running\ in\ either\ 32\ bit\ mode\ or\ 64\ bit\ mode.=Unable to connect. One possible reason is that JabRef and OpenOffice/LibreOffice are not both running in either 32 bit mode or 64 bit mode.
+Use\ the\ following\ delimiter\ character(s)\:=Use the following delimiter character(s):
+When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\ prefer\ the\ BIB\ file\ location\ rather\ than\ the\ file\ directory\ set\ above=When downloading files, or moving linked files to the file directory, prefer the BIB file location rather than the file directory set above
+Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Your style file specifies the character format '%0', which is undefined in your current OpenOffice/LibreOffice document.
+Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Your style file specifies the paragraph format '%0', which is undefined in your current OpenOffice/LibreOffice document.
 
 Searching...=Searching...
-You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?=You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?
-Confirm_selection=Confirm_selection
-Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case=Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case
-Import_conversions=Import_conversions
-Please_enter_a_search_string=Please_enter_a_search_string
-Please_open_or_start_a_new_library_before_searching=Please_open_or_start_a_new_library_before_searching
+You\ have\ selected\ more\ than\ %0\ entries\ for\ download.\ Some\ web\ sites\ might\ block\ you\ if\ you\ make\ too\ many\ rapid\ downloads.\ Do\ you\ want\ to\ continue?=You have selected more than %0 entries for download. Some web sites might block you if you make too many rapid downloads. Do you want to continue?
+Confirm\ selection=Confirm selection
+Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=Add {} to specified title words on search to keep the correct case
+Import\ conversions=Import conversions
+Please\ enter\ a\ search\ string=Please enter a search string
+Please\ open\ or\ start\ a\ new\ library\ before\ searching=Please open or start a new library before searching
 
-Canceled_merging_entries=Canceled_merging_entries
+Canceled\ merging\ entries=Canceled merging entries
 
-Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search=Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search
-Merge_entries=Merge_entries
-Merged_entries=Merged_entries
-Merged_entry=Merged_entry
+Format\ units\ by\ adding\ non-breaking\ separators\ and\ keeping\ the\ correct\ case\ on\ search=Format units by adding non-breaking separators and keeping the correct case on search
+Merge\ entries=Merge entries
+Merged\ entries=Merged entries
+Merged\ entry=Merged entry
 None=None
 Parse=Parse
 Result=Result
-Show_DOI_first=Show_DOI_first
-Show_URL_first=Show_URL_first
-Use_Emacs_key_bindings=Use_Emacs_key_bindings
-You_have_to_choose_exactly_two_entries_to_merge.=You_have_to_choose_exactly_two_entries_to_merge.
+Show\ DOI\ first=Show DOI first
+Show\ URL\ first=Show URL first
+Use\ Emacs\ key\ bindings=Use Emacs key bindings
+You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=You have to choose exactly two entries to merge.
 
-Update_timestamp_on_modification=Update_timestamp_on_modification
-All_key_bindings_will_be_reset_to_their_defaults.=All_key_bindings_will_be_reset_to_their_defaults.
+Update\ timestamp\ on\ modification=Update timestamp on modification
+All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=All key bindings will be reset to their defaults.
 
-Automatically_set_file_links=Automatically_set_file_links
-Resetting_all_key_bindings=Resetting_all_key_bindings
+Automatically\ set\ file\ links=Automatically set file links
+Resetting\ all\ key\ bindings=Resetting all key bindings
 Hostname=Hostname
-Invalid_setting=Invalid_setting
+Invalid\ setting=Invalid setting
 Network=Network
-Please_specify_both_hostname_and_port=Please_specify_both_hostname_and_port
-Please_specify_both_username_and_password=Please_specify_both_username_and_password
+Please\ specify\ both\ hostname\ and\ port=Please specify both hostname and port
+Please\ specify\ both\ username\ and\ password=Please specify both username and password
 
-Use_custom_proxy_configuration=Use_custom_proxy_configuration
-Proxy_requires_authentication=Proxy_requires_authentication
-Attention\:_Password_is_stored_in_plain_text\!=Attention\:_Password_is_stored_in_plain_text\!
-Clear_connection_settings=Clear_connection_settings
-Cleared_connection_settings.=Cleared_connection_settings.
+Use\ custom\ proxy\ configuration=Use custom proxy configuration
+Proxy\ requires\ authentication=Proxy requires authentication
+Attention\:\ Password\ is\ stored\ in\ plain\ text\!=Attention: Password is stored in plain text!
+Clear\ connection\ settings=Clear connection settings
+Cleared\ connection\ settings.=Cleared connection settings.
 
-Rebind_C-a,_too=Rebind_C-a,_too
-Rebind_C-f,_too=Rebind_C-f,_too
+Rebind\ C-a,\ too=Rebind C-a, too
+Rebind\ C-f,\ too=Rebind C-f, too
 
-Open_folder=Open_folder
-Searches_for_unlinked_PDF_files_on_the_file_system=Searches_for_unlinked_PDF_files_on_the_file_system
-Export_entries_ordered_as_specified=Export_entries_ordered_as_specified
-Export_sort_order=Export_sort_order
-Export_sorting=Export_sorting
-Newline_separator=Newline_separator
+Open\ folder=Open folder
+Searches\ for\ unlinked\ PDF\ files\ on\ the\ file\ system=Searches for unlinked PDF files on the file system
+Export\ entries\ ordered\ as\ specified=Export entries ordered as specified
+Export\ sort\ order=Export sort order
+Export\ sorting=Export sorting
+Newline\ separator=Newline separator
 
-Save_entries_ordered_as_specified=Save_entries_ordered_as_specified
-Save_sort_order=Save_sort_order
-Show_extra_columns=Show_extra_columns
-Parsing_error=Parsing_error
-illegal_backslash_expression=illegal_backslash_expression
+Save\ entries\ ordered\ as\ specified=Save entries ordered as specified
+Save\ sort\ order=Save sort order
+Show\ extra\ columns=Show extra columns
+Parsing\ error=Parsing error
+illegal\ backslash\ expression=illegal backslash expression
 
-Move_to_group=Move_to_group
+Move\ to\ group=Move to group
 
-Clear_read_status=Clear_read_status
-Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')=Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')
-Could_not_apply_changes.=Could_not_apply_changes.
-Deprecated_fields=Deprecated_fields
-Hide/show_toolbar=Hide/show_toolbar
-No_read_status_information=No_read_status_information
+Clear\ read\ status=Clear read status
+Convert\ to\ biblatex\ format\ (for\ example,\ move\ the\ value\ of\ the\ 'journal'\ field\ to\ 'journaltitle')=Convert to biblatex format (for example, move the value of the 'journal' field to 'journaltitle')
+Could\ not\ apply\ changes.=Could not apply changes.
+Deprecated\ fields=Deprecated fields
+Hide/show\ toolbar=Hide/show toolbar
+No\ read\ status\ information=No read status information
 Printed=Printed
-Read_status=Read_status
-Read_status_read=Read_status_read
-Read_status_skimmed=Read_status_skimmed
-Save_selected_as_plain_BibTeX...=Save_selected_as_plain_BibTeX...
-Set_read_status_to_read=Set_read_status_to_read
-Set_read_status_to_skimmed=Set_read_status_to_skimmed
-Show_deprecated_BibTeX_fields=Show_deprecated_BibTeX_fields
+Read\ status=Read status
+Read\ status\ read=Read status read
+Read\ status\ skimmed=Read status skimmed
+Save\ selected\ as\ plain\ BibTeX...=Save selected as plain BibTeX...
+Set\ read\ status\ to\ read=Set read status to read
+Set\ read\ status\ to\ skimmed=Set read status to skimmed
+Show\ deprecated\ BibTeX\ fields=Show deprecated BibTeX fields
 
-Show_gridlines=Show_gridlines
-Show_printed_status=Show_printed_status
-Show_read_status=Show_read_status
-Table_row_height_padding=Table_row_height_padding
+Show\ gridlines=Show gridlines
+Show\ printed\ status=Show printed status
+Show\ read\ status=Show read status
+Table\ row\ height\ padding=Table row height padding
 
-Marked_selected_entry=Marked_selected_entry
-Marked_all_%0_selected_entries=Marked_all_%0_selected_entries
-Unmarked_selected_entry=Unmarked_selected_entry
-Unmarked_all_%0_selected_entries=Unmarked_all_%0_selected_entries
+Marked\ selected\ entry=Marked selected entry
+Marked\ all\ %0\ selected\ entries=Marked all %0 selected entries
+Unmarked\ selected\ entry=Unmarked selected entry
+Unmarked\ all\ %0\ selected\ entries=Unmarked all %0 selected entries
 
 
-Unmarked_all_entries=Unmarked_all_entries
+Unmarked\ all\ entries=Unmarked all entries
 
-Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.=Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.
+Unable\ to\ find\ the\ requested\ look\ and\ feel\ and\ thus\ the\ default\ one\ is\ used.=Unable to find the requested look and feel and thus the default one is used.
 
-Opens_JabRef's_GitHub_page=Opens_JabRef's_GitHub_page
-Could_not_open_browser.=Could_not_open_browser.
-Please_open_%0_manually.=Please_open_%0_manually.
-The_link_has_been_copied_to_the_clipboard.=The_link_has_been_copied_to_the_clipboard.
+Opens\ JabRef's\ GitHub\ page=Opens JabRef's GitHub page
+Could\ not\ open\ browser.=Could not open browser.
+Please\ open\ %0\ manually.=Please open %0 manually.
+The\ link\ has\ been\ copied\ to\ the\ clipboard.=The link has been copied to the clipboard.
 
-Open_%0_file=Open_%0_file
+Open\ %0\ file=Open %0 file
 
-Cannot_delete_file=Cannot_delete_file
-File_permission_error=File_permission_error
-Push_to_%0=Push_to_%0
-Path_to_%0=Path_to_%0
+Cannot\ delete\ file=Cannot delete file
+File\ permission\ error=File permission error
+Push\ to\ %0=Push to %0
+Path\ to\ %0=Path to %0
 Convert=Convert
-Normalize_to_BibTeX_name_format=Normalize_to_BibTeX_name_format
-Help_on_Name_Formatting=Help_on_Name_Formatting
+Normalize\ to\ BibTeX\ name\ format=Normalize to BibTeX name format
+Help\ on\ Name\ Formatting=Help on Name Formatting
 
-Add_new_file_type=Add_new_file_type
+Add\ new\ file\ type=Add new file type
 
-Left_entry=Left_entry
-Right_entry=Right_entry
+Left\ entry=Left entry
+Right\ entry=Right entry
 Use=Use
-Original_entry=Original_entry
-Replace_original_entry=Replace_original_entry
-No_information_added=No_information_added
-Select_at_least_one_entry_to_manage_keywords.=Select_at_least_one_entry_to_manage_keywords.
-OpenDocument_text=OpenDocument_text
-OpenDocument_spreadsheet=OpenDocument_spreadsheet
-OpenDocument_presentation=OpenDocument_presentation
-%0_image=%0_image
-Added_entry=Added_entry
-Modified_entry=Modified_entry
-Deleted_entry=Deleted_entry
-Modified_groups_tree=Modified_groups_tree
-Removed_all_groups=Removed_all_groups
-Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.=Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.
-Select_export_format=Select_export_format
-Return_to_JabRef=Return_to_JabRef
-Please_move_the_file_manually_and_link_in_place.=Please_move_the_file_manually_and_link_in_place.
-Could_not_connect_to_%0=Could_not_connect_to_%0
-Warning\:_%0_out_of_%1_entries_have_undefined_title.=Warning\:_%0_out_of_%1_entries_have_undefined_title.
-Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.=Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.
+Original\ entry=Original entry
+Replace\ original\ entry=Replace original entry
+No\ information\ added=No information added
+Select\ at\ least\ one\ entry\ to\ manage\ keywords.=Select at least one entry to manage keywords.
+OpenDocument\ text=OpenDocument text
+OpenDocument\ spreadsheet=OpenDocument spreadsheet
+OpenDocument\ presentation=OpenDocument presentation
+%0\ image=%0 image
+Added\ entry=Added entry
+Modified\ entry=Modified entry
+Deleted\ entry=Deleted entry
+Modified\ groups\ tree=Modified groups tree
+Removed\ all\ groups=Removed all groups
+Accepting\ the\ change\ replaces\ the\ complete\ groups\ tree\ with\ the\ externally\ modified\ groups\ tree.=Accepting the change replaces the complete groups tree with the externally modified groups tree.
+Select\ export\ format=Select export format
+Return\ to\ JabRef=Return to JabRef
+Please\ move\ the\ file\ manually\ and\ link\ in\ place.=Please move the file manually and link in place.
+Could\ not\ connect\ to\ %0=Could not connect to %0
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ title.=Warning: %0 out of %1 entries have undefined title.
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ BibTeX\ key.=Warning: %0 out of %1 entries have undefined BibTeX key.
 occurrence=occurrence
-Added_new_'%0'_entry.=Added_new_'%0'_entry.
-Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?=Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?
-Changed_type_to_'%0'_for=Changed_type_to_'%0'_for
-Really_delete_the_selected_entry?=Really_delete_the_selected_entry?
-Really_delete_the_%0_selected_entries?=Really_delete_the_%0_selected_entries?
-Keep_merged_entry_only=Keep_merged_entry_only
-Keep_left=Keep_left
-Keep_right=Keep_right
-Old_entry=Old_entry
-From_import=From_import
-No_problems_found.=No_problems_found.
-%0_problem(s)_found=%0_problem(s)_found
-Save_changes=Save_changes
-Discard_changes=Discard_changes
-Library_'%0'_has_changed.=Library_'%0'_has_changed.
-Print_entry_preview=Print_entry_preview
-Copy_title=Copy_title
-Copy_\\cite{BibTeX_key}=Copy_\\cite{BibTeX_key}
-Copy_BibTeX_key_and_title=Copy_BibTeX_key_and_title
-File_rename_failed_for_%0_entries.=File_rename_failed_for_%0_entries.
-Merged_BibTeX_source_code=Merged_BibTeX_source_code
-Invalid_DOI\:_'%0'.=Invalid_DOI\:_'%0'.
-should_start_with_a_name=should_start_with_a_name
-should_end_with_a_name=should_end_with_a_name
-unexpected_closing_curly_bracket=unexpected_closing_curly_bracket
-unexpected_opening_curly_bracket=unexpected_opening_curly_bracket
-capital_letters_are_not_masked_using_curly_brackets_{}=capital_letters_are_not_masked_using_curly_brackets_{}
-should_contain_a_four_digit_number=should_contain_a_four_digit_number
-should_contain_a_valid_page_number_range=should_contain_a_valid_page_number_range
+Added\ new\ '%0'\ entry.=Added new '%0' entry.
+Multiple\ entries\ selected.\ Do\ you\ want\ to\ change\ the\ type\ of\ all\ these\ to\ '%0'?=Multiple entries selected. Do you want to change the type of all these to '%0'?
+Changed\ type\ to\ '%0'\ for=Changed type to '%0' for
+Really\ delete\ the\ selected\ entry?=Really delete the selected entry?
+Really\ delete\ the\ %0\ selected\ entries?=Really delete the %0 selected entries?
+Keep\ merged\ entry\ only=Keep merged entry only
+Keep\ left=Keep left
+Keep\ right=Keep right
+Old\ entry=Old entry
+From\ import=From import
+No\ problems\ found.=No problems found.
+%0\ problem(s)\ found=%0 problem(s) found
+Save\ changes=Save changes
+Discard\ changes=Discard changes
+Library\ '%0'\ has\ changed.=Library '%0' has changed.
+Print\ entry\ preview=Print entry preview
+Copy\ title=Copy title
+Copy\ \\cite{BibTeX\ key}=Copy \\cite{BibTeX key}
+Copy\ BibTeX\ key\ and\ title=Copy BibTeX key and title
+File\ rename\ failed\ for\ %0\ entries.=File rename failed for %0 entries.
+Merged\ BibTeX\ source\ code=Merged BibTeX source code
+Invalid\ DOI\:\ '%0'.=Invalid DOI: '%0'.
+should\ start\ with\ a\ name=should start with a name
+should\ end\ with\ a\ name=should end with a name
+unexpected\ closing\ curly\ bracket=unexpected closing curly bracket
+unexpected\ opening\ curly\ bracket=unexpected opening curly bracket
+capital\ letters\ are\ not\ masked\ using\ curly\ brackets\ {}=capital letters are not masked using curly brackets {}
+should\ contain\ a\ four\ digit\ number=should contain a four digit number
+should\ contain\ a\ valid\ page\ number\ range=should contain a valid page number range
 Filled=Filled
-Field_is_missing=Field_is_missing
-Search_%0=Search_%0
+Field\ is\ missing=Field is missing
+Search\ %0=Search %0
 
-Search_results_in_all_libraries_for_%0=Search_results_in_all_libraries_for_%0
-Search_results_in_library_%0_for_%1=Search_results_in_library_%0_for_%1
-Search_globally=Search_globally
-No_results_found.=No_results_found.
-Found_%0_results.=Found_%0_results.
-plain_text=plain_text
-This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>=This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>
-This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>=This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>
-This_search_contains_entries_in_which=This_search_contains_entries_in_which
+Search\ results\ in\ all\ libraries\ for\ %0=Search results in all libraries for %0
+Search\ results\ in\ library\ %0\ for\ %1=Search results in library %0 for %1
+Search\ globally=Search globally
+No\ results\ found.=No results found.
+Found\ %0\ results.=Found %0 results.
+plain\ text=plain text
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ regular\ expression\ <b>%0</b>=This search contains entries in which any field contains the regular expression <b>%0</b>
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ term\ <b>%0</b>=This search contains entries in which any field contains the term <b>%0</b>
+This\ search\ contains\ entries\ in\ which=This search contains entries in which
 
-Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.=Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.
-JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>=JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>
-This_library_uses_outdated_file_links.=This_library_uses_outdated_file_links.
+Unable\ to\ autodetect\ OpenOffice/LibreOffice\ installation.\ Please\ choose\ the\ installation\ directory\ manually.=Unable to autodetect OpenOffice/LibreOffice installation. Please choose the installation directory manually.
+JabRef\ no\ longer\ supports\ 'ps'\ or\ 'pdf'\ fields.<br>File\ links\ are\ now\ stored\ in\ the\ 'file'\ field\ and\ files\ are\ stored\ in\ an\ external\ file\ directory.<br>To\ make\ use\ of\ this\ feature,\ JabRef\ needs\ to\ upgrade\ file\ links.<br><br>=JabRef no longer supports 'ps' or 'pdf' fields.<br>File links are now stored in the 'file' field and files are stored in an external file directory.<br>To make use of this feature, JabRef needs to upgrade file links.<br><br>
+This\ library\ uses\ outdated\ file\ links.=This library uses outdated file links.
 
-Clear_search=Clear_search
-Close_library=Close_library
-Close_entry_editor=Close_entry_editor
-Decrease_table_font_size=Decrease_table_font_size
-Entry_editor,_next_entry=Entry_editor,_next_entry
-Entry_editor,_next_panel=Entry_editor,_next_panel
-Entry_editor,_next_panel_2=Entry_editor,_next_panel_2
-Entry_editor,_previous_entry=Entry_editor,_previous_entry
-Entry_editor,_previous_panel=Entry_editor,_previous_panel
-Entry_editor,_previous_panel_2=Entry_editor,_previous_panel_2
-File_list_editor,_move_entry_down=File_list_editor,_move_entry_down
-File_list_editor,_move_entry_up=File_list_editor,_move_entry_up
-Focus_entry_table=Focus_entry_table
-Import_into_current_library=Import_into_current_library
-Import_into_new_library=Import_into_new_library
-Increase_table_font_size=Increase_table_font_size
-New_article=New_article
-New_book=New_book
-New_entry=New_entry
-New_from_plain_text=New_from_plain_text
-New_inbook=New_inbook
-New_mastersthesis=New_mastersthesis
-New_phdthesis=New_phdthesis
-New_proceedings=New_proceedings
-New_unpublished=New_unpublished
-Next_tab=Next_tab
-Preamble_editor,_store_changes=Preamble_editor,_store_changes
-Previous_tab=Previous_tab
-Push_to_application=Push_to_application
-Refresh_OpenOffice/LibreOffice=Refresh_OpenOffice/LibreOffice
-Resolve_duplicate_BibTeX_keys=Resolve_duplicate_BibTeX_keys
-Save_all=Save_all
-String_dialog,_add_string=String_dialog,_add_string
-String_dialog,_remove_string=String_dialog,_remove_string
-Synchronize_files=Synchronize_files
+Clear\ search=Clear search
+Close\ library=Close library
+Close\ entry\ editor=Close entry editor
+Decrease\ table\ font\ size=Decrease table font size
+Entry\ editor,\ next\ entry=Entry editor, next entry
+Entry\ editor,\ next\ panel=Entry editor, next panel
+Entry\ editor,\ next\ panel\ 2=Entry editor, next panel 2
+Entry\ editor,\ previous\ entry=Entry editor, previous entry
+Entry\ editor,\ previous\ panel=Entry editor, previous panel
+Entry\ editor,\ previous\ panel\ 2=Entry editor, previous panel 2
+File\ list\ editor,\ move\ entry\ down=File list editor, move entry down
+File\ list\ editor,\ move\ entry\ up=File list editor, move entry up
+Focus\ entry\ table=Focus entry table
+Import\ into\ current\ library=Import into current library
+Import\ into\ new\ library=Import into new library
+Increase\ table\ font\ size=Increase table font size
+New\ article=New article
+New\ book=New book
+New\ entry=New entry
+New\ from\ plain\ text=New from plain text
+New\ inbook=New inbook
+New\ mastersthesis=New mastersthesis
+New\ phdthesis=New phdthesis
+New\ proceedings=New proceedings
+New\ unpublished=New unpublished
+Next\ tab=Next tab
+Preamble\ editor,\ store\ changes=Preamble editor, store changes
+Previous\ tab=Previous tab
+Push\ to\ application=Push to application
+Refresh\ OpenOffice/LibreOffice=Refresh OpenOffice/LibreOffice
+Resolve\ duplicate\ BibTeX\ keys=Resolve duplicate BibTeX keys
+Save\ all=Save all
+String\ dialog,\ add\ string=String dialog, add string
+String\ dialog,\ remove\ string=String dialog, remove string
+Synchronize\ files=Synchronize files
 Unabbreviate=Unabbreviate
-should_contain_a_protocol=should_contain_a_protocol
-Copy_preview=Copy_preview
-Automatically_setting_file_links=Automatically_setting_file_links
-Regenerating_BibTeX_keys_according_to_metadata=Regenerating_BibTeX_keys_according_to_metadata
-No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys=No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys
-Regenerate_all_keys_for_the_entries_in_a_BibTeX_file=Regenerate_all_keys_for_the_entries_in_a_BibTeX_file
-Show_debug_level_messages=Show_debug_level_messages
-Default_bibliography_mode=Default_bibliography_mode
-New_%0_library_created.=New_%0_library_created.
-Show_only_preferences_deviating_from_their_default_value=Show_only_preferences_deviating_from_their_default_value
+should\ contain\ a\ protocol=should contain a protocol
+Copy\ preview=Copy preview
+Automatically\ setting\ file\ links=Automatically setting file links
+Regenerating\ BibTeX\ keys\ according\ to\ metadata=Regenerating BibTeX keys according to metadata
+No\ meta\ data\ present\ in\ BIB\ file.\ Cannot\ regenerate\ BibTeX\ keys=No meta data present in BIB file. Cannot regenerate BibTeX keys
+Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=Regenerate all keys for the entries in a BibTeX file
+Show\ debug\ level\ messages=Show debug level messages
+Default\ bibliography\ mode=Default bibliography mode
+New\ %0\ library\ created.=New %0 library created.
+Show\ only\ preferences\ deviating\ from\ their\ default\ value=Show only preferences deviating from their default value
 default=default
 key=key
 type=type
 value=value
-Show_preferences=Show_preferences
-Save_actions=Save_actions
-Enable_save_actions=Enable_save_actions
+Show\ preferences=Show preferences
+Save\ actions=Save actions
+Enable\ save\ actions=Enable save actions
 
-Other_fields=Other_fields
-Show_remaining_fields=Show_remaining_fields
+Other\ fields=Other fields
+Show\ remaining\ fields=Show remaining fields
 
-link_should_refer_to_a_correct_file_path=link_should_refer_to_a_correct_file_path
-abbreviation_detected=abbreviation_detected
-wrong_entry_type_as_proceedings_has_page_numbers=wrong_entry_type_as_proceedings_has_page_numbers
-Abbreviate_journal_names=Abbreviate_journal_names
+link\ should\ refer\ to\ a\ correct\ file\ path=link should refer to a correct file path
+abbreviation\ detected=abbreviation detected
+wrong\ entry\ type\ as\ proceedings\ has\ page\ numbers=wrong entry type as proceedings has page numbers
+Abbreviate\ journal\ names=Abbreviate journal names
 Abbreviating...=Abbreviating...
-Abbreviation_%s_for_journal_%s_already_defined.=Abbreviation_%s_for_journal_%s_already_defined.
-Abbreviation_cannot_be_empty=Abbreviation_cannot_be_empty
-Duplicated_Journal_Abbreviation=Duplicated_Journal_Abbreviation
-Duplicated_Journal_File=Duplicated_Journal_File
-Error_Occurred=Error_Occurred
-Journal_file_%s_already_added=Journal_file_%s_already_added
-Name_cannot_be_empty=Name_cannot_be_empty
+Abbreviation\ %s\ for\ journal\ %s\ already\ defined.=Abbreviation %s for journal %s already defined.
+Abbreviation\ cannot\ be\ empty=Abbreviation cannot be empty
+Duplicated\ Journal\ Abbreviation=Duplicated Journal Abbreviation
+Duplicated\ Journal\ File=Duplicated Journal File
+Error\ Occurred=Error Occurred
+Journal\ file\ %s\ already\ added=Journal file %s already added
+Name\ cannot\ be\ empty=Name cannot be empty
 
-Adding_fetched_entries=Adding_fetched_entries
-Display_keywords_appearing_in_ALL_entries=Display_keywords_appearing_in_ALL_entries
-Display_keywords_appearing_in_ANY_entry=Display_keywords_appearing_in_ANY_entry
-Fetching_entries_from_Inspire=Fetching_entries_from_Inspire
-None_of_the_selected_entries_have_titles.=None_of_the_selected_entries_have_titles.
-None_of_the_selected_entries_have_BibTeX_keys.=None_of_the_selected_entries_have_BibTeX_keys.
-Unabbreviate_journal_names=Unabbreviate_journal_names
+Adding\ fetched\ entries=Adding fetched entries
+Display\ keywords\ appearing\ in\ ALL\ entries=Display keywords appearing in ALL entries
+Display\ keywords\ appearing\ in\ ANY\ entry=Display keywords appearing in ANY entry
+Fetching\ entries\ from\ Inspire=Fetching entries from Inspire
+None\ of\ the\ selected\ entries\ have\ titles.=None of the selected entries have titles.
+None\ of\ the\ selected\ entries\ have\ BibTeX\ keys.=None of the selected entries have BibTeX keys.
+Unabbreviate\ journal\ names=Unabbreviate journal names
 Unabbreviating...=Unabbreviating...
 Usage=Usage
 
 
-Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.=Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.
-Are_you_sure_you_want_to_reset_all_settings_to_default_values?=Are_you_sure_you_want_to_reset_all_settings_to_default_values?
-Reset_preferences=Reset_preferences
-Ill-formed_entrytype_comment_in_BIB_file=Ill-formed_entrytype_comment_in_BIB_file
+Adds\ {}\ brackets\ around\ acronyms,\ month\ names\ and\ countries\ to\ preserve\ their\ case.=Adds {} brackets around acronyms, month names and countries to preserve their case.
+Are\ you\ sure\ you\ want\ to\ reset\ all\ settings\ to\ default\ values?=Are you sure you want to reset all settings to default values?
+Reset\ preferences=Reset preferences
+Ill-formed\ entrytype\ comment\ in\ BIB\ file=Ill-formed entrytype comment in BIB file
 
-Move_linked_files_to_default_file_directory_%0=Move_linked_files_to_default_file_directory_%0
+Move\ linked\ files\ to\ default\ file\ directory\ %0=Move linked files to default file directory %0
 
 Clipboard=Clipboard
-Could_not_paste_entry_as_text\:=Could_not_paste_entry_as_text\:
-Do_you_still_want_to_continue?=Do_you_still_want_to_continue?
-This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:=This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:
-This_could_cause_undesired_changes_to_your_entries.=This_could_cause_undesired_changes_to_your_entries.
-Run_field_formatter\:=Run_field_formatter\:
-Table_font_size_is_%0=Table_font_size_is_%0
-%0_import_canceled=%0_import_canceled
-Internal_style=Internal_style
-Add_style_file=Add_style_file
-Are_you_sure_you_want_to_remove_the_style?=Are_you_sure_you_want_to_remove_the_style?
-Current_style_is_'%0'=Current_style_is_'%0'
-Remove_style=Remove_style
-Select_one_of_the_available_styles_or_add_a_style_file_from_disk.=Select_one_of_the_available_styles_or_add_a_style_file_from_disk.
-You_must_select_a_valid_style_file.=You_must_select_a_valid_style_file.
+Could\ not\ paste\ entry\ as\ text\:=Could not paste entry as text:
+Do\ you\ still\ want\ to\ continue?=Do you still want to continue?
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=This action will modify the following field(s) in at least one entry each:
+This\ could\ cause\ undesired\ changes\ to\ your\ entries.=This could cause undesired changes to your entries.
+Run\ field\ formatter\:=Run field formatter:
+Table\ font\ size\ is\ %0=Table font size is %0
+%0\ import\ canceled=%0 import canceled
+Internal\ style=Internal style
+Add\ style\ file=Add style file
+Are\ you\ sure\ you\ want\ to\ remove\ the\ style?=Are you sure you want to remove the style?
+Current\ style\ is\ '%0'=Current style is '%0'
+Remove\ style=Remove style
+Select\ one\ of\ the\ available\ styles\ or\ add\ a\ style\ file\ from\ disk.=Select one of the available styles or add a style file from disk.
+You\ must\ select\ a\ valid\ style\ file.=You must select a valid style file.
 Reload=Reload
 
 Capitalize=Capitalize
-Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.=Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.
-Capitalize_the_first_word,_changes_other_words_to_lower_case.=Capitalize_the_first_word,_changes_other_words_to_lower_case.
-Changes_all_letters_to_lower_case.=Changes_all_letters_to_lower_case.
-Changes_all_letters_to_upper_case.=Changes_all_letters_to_upper_case.
-Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.=Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.
-Cleans_up_LaTeX_code.=Cleans_up_LaTeX_code.
-Converts_HTML_code_to_LaTeX_code.=Converts_HTML_code_to_LaTeX_code.
-Converts_HTML_code_to_Unicode.=Converts_HTML_code_to_Unicode.
-Converts_LaTeX_encoding_to_Unicode_characters.=Converts_LaTeX_encoding_to_Unicode_characters.
-Converts_Unicode_characters_to_LaTeX_encoding.=Converts_Unicode_characters_to_LaTeX_encoding.
-Converts_ordinals_to_LaTeX_superscripts.=Converts_ordinals_to_LaTeX_superscripts.
-Converts_units_to_LaTeX_formatting.=Converts_units_to_LaTeX_formatting.
-HTML_to_LaTeX=HTML_to_LaTeX
-LaTeX_cleanup=LaTeX_cleanup
-LaTeX_to_Unicode=LaTeX_to_Unicode
-Lower_case=Lower_case
-Minify_list_of_person_names=Minify_list_of_person_names
-Normalize_date=Normalize_date
-Normalize_month=Normalize_month
-Normalize_month_to_BibTeX_standard_abbreviation.=Normalize_month_to_BibTeX_standard_abbreviation.
-Normalize_names_of_persons=Normalize_names_of_persons
-Normalize_page_numbers=Normalize_page_numbers
-Normalize_pages_to_BibTeX_standard.=Normalize_pages_to_BibTeX_standard.
-Normalizes_lists_of_persons_to_the_BibTeX_standard.=Normalizes_lists_of_persons_to_the_BibTeX_standard.
-Normalizes_the_date_to_ISO_date_format.=Normalizes_the_date_to_ISO_date_format.
-Ordinals_to_LaTeX_superscript=Ordinals_to_LaTeX_superscript
-Protect_terms=Protect_terms
-Remove_enclosing_braces=Remove_enclosing_braces
-Removes_braces_encapsulating_the_complete_field_content.=Removes_braces_encapsulating_the_complete_field_content.
-Sentence_case=Sentence_case
-Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".=Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".
-Title_case=Title_case
-Unicode_to_LaTeX=Unicode_to_LaTeX
-Units_to_LaTeX=Units_to_LaTeX
-Upper_case=Upper_case
-Does_nothing.=Does_nothing.
+Capitalize\ all\ words,\ but\ converts\ articles,\ prepositions,\ and\ conjunctions\ to\ lower\ case.=Capitalize all words, but converts articles, prepositions, and conjunctions to lower case.
+Capitalize\ the\ first\ word,\ changes\ other\ words\ to\ lower\ case.=Capitalize the first word, changes other words to lower case.
+Changes\ all\ letters\ to\ lower\ case.=Changes all letters to lower case.
+Changes\ all\ letters\ to\ upper\ case.=Changes all letters to upper case.
+Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=Changes the first letter of all words to capital case and the remaining letters to lower case.
+Cleans\ up\ LaTeX\ code.=Cleans up LaTeX code.
+Converts\ HTML\ code\ to\ LaTeX\ code.=Converts HTML code to LaTeX code.
+Converts\ HTML\ code\ to\ Unicode.=Converts HTML code to Unicode.
+Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=Converts LaTeX encoding to Unicode characters.
+Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=Converts Unicode characters to LaTeX encoding.
+Converts\ ordinals\ to\ LaTeX\ superscripts.=Converts ordinals to LaTeX superscripts.
+Converts\ units\ to\ LaTeX\ formatting.=Converts units to LaTeX formatting.
+HTML\ to\ LaTeX=HTML to LaTeX
+LaTeX\ cleanup=LaTeX cleanup
+LaTeX\ to\ Unicode=LaTeX to Unicode
+Lower\ case=Lower case
+Minify\ list\ of\ person\ names=Minify list of person names
+Normalize\ date=Normalize date
+Normalize\ month=Normalize month
+Normalize\ month\ to\ BibTeX\ standard\ abbreviation.=Normalize month to BibTeX standard abbreviation.
+Normalize\ names\ of\ persons=Normalize names of persons
+Normalize\ page\ numbers=Normalize page numbers
+Normalize\ pages\ to\ BibTeX\ standard.=Normalize pages to BibTeX standard.
+Normalizes\ lists\ of\ persons\ to\ the\ BibTeX\ standard.=Normalizes lists of persons to the BibTeX standard.
+Normalizes\ the\ date\ to\ ISO\ date\ format.=Normalizes the date to ISO date format.
+Ordinals\ to\ LaTeX\ superscript=Ordinals to LaTeX superscript
+Protect\ terms=Protect terms
+Remove\ enclosing\ braces=Remove enclosing braces
+Removes\ braces\ encapsulating\ the\ complete\ field\ content.=Removes braces encapsulating the complete field content.
+Sentence\ case=Sentence case
+Shortens\ lists\ of\ persons\ if\ there\ are\ more\ than\ 2\ persons\ to\ "et\ al.".=Shortens lists of persons if there are more than 2 persons to "et al.".
+Title\ case=Title case
+Unicode\ to\ LaTeX=Unicode to LaTeX
+Units\ to\ LaTeX=Units to LaTeX
+Upper\ case=Upper case
+Does\ nothing.=Does nothing.
 Identity=Identity
-Clears_the_field_completely.=Clears_the_field_completely.
-Directory_not_found=Directory_not_found
-Main_file_directory_not_set\!=Main_file_directory_not_set\!
-This_operation_requires_exactly_one_item_to_be_selected.=This_operation_requires_exactly_one_item_to_be_selected.
-Importing_in_%0_format=Importing_in_%0_format
-Female_name=Female_name
-Female_names=Female_names
-Male_name=Male_name
-Male_names=Male_names
-Mixed_names=Mixed_names
-Neuter_name=Neuter_name
-Neuter_names=Neuter_names
+Clears\ the\ field\ completely.=Clears the field completely.
+Directory\ not\ found=Directory not found
+Main\ file\ directory\ not\ set\!=Main file directory not set!
+This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=This operation requires exactly one item to be selected.
+Importing\ in\ %0\ format=Importing in %0 format
+Female\ name=Female name
+Female\ names=Female names
+Male\ name=Male name
+Male\ names=Male names
+Mixed\ names=Mixed names
+Neuter\ name=Neuter name
+Neuter\ names=Neuter names
 
-Determined_%0_for_%1_entries=Determined_%0_for_%1_entries
-Look_up_%0=Look_up_%0
-Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3=Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3
+Determined\ %0\ for\ %1\ entries=Determined %0 for %1 entries
+Look\ up\ %0=Look up %0
+Looking\ up\ %0...\ -\ entry\ %1\ out\ of\ %2\ -\ found\ %3=Looking up %0... - entry %1 out of %2 - found %3
 
-Audio_CD=Audio_CD
-British_patent=British_patent
-British_patent_request=British_patent_request
-Candidate_thesis=Candidate_thesis
+Audio\ CD=Audio CD
+British\ patent=British patent
+British\ patent\ request=British patent request
+Candidate\ thesis=Candidate thesis
 Collaborator=Collaborator
 Column=Column
 Compiler=Compiler
 Continuator=Continuator
-Data_CD=Data_CD
+Data\ CD=Data CD
 Editor=Editor
-European_patent=European_patent
-European_patent_request=European_patent_request
+European\ patent=European patent
+European\ patent\ request=European patent request
 Founder=Founder
-French_patent=French_patent
-French_patent_request=French_patent_request
-German_patent=German_patent
-German_patent_request=German_patent_request
+French\ patent=French patent
+French\ patent\ request=French patent request
+German\ patent=German patent
+German\ patent\ request=German patent request
 Line=Line
-Master's_thesis=Master's_thesis
+Master's\ thesis=Master's thesis
 Page=Page
 Paragraph=Paragraph
 Patent=Patent
-Patent_request=Patent_request
-PhD_thesis=PhD_thesis
+Patent\ request=Patent request
+PhD\ thesis=PhD thesis
 Redactor=Redactor
-Research_report=Research_report
+Research\ report=Research report
 Reviser=Reviser
 Section=Section
 Software=Software
-Technical_report=Technical_report
-U.S._patent=U.S._patent
-U.S._patent_request=U.S._patent_request
+Technical\ report=Technical report
+U.S.\ patent=U.S. patent
+U.S.\ patent\ request=U.S. patent request
 Verse=Verse
 
-change_entries_of_group=change_entries_of_group
-odd_number_of_unescaped_'\#'=odd_number_of_unescaped_'\#'
+change\ entries\ of\ group=change entries of group
+odd\ number\ of\ unescaped\ '\#'=odd number of unescaped '#'
 
-Plain_text=Plain_text
-Show_diff=Show_diff
+Plain\ text=Plain text
+Show\ diff=Show diff
 character=character
 word=word
-Show_symmetric_diff=Show_symmetric_diff
-Copy_Version=Copy_Version
+Show\ symmetric\ diff=Show symmetric diff
+Copy\ Version=Copy Version
 Developers=Developers
 Authors=Authors
 License=License
 
-HTML_encoded_character_found=HTML_encoded_character_found
-booktitle_ends_with_'conference_on'=booktitle_ends_with_'conference_on'
+HTML\ encoded\ character\ found=HTML encoded character found
+booktitle\ ends\ with\ 'conference\ on'=booktitle ends with 'conference on'
 
-All_external_files=All_external_files
+All\ external\ files=All external files
 
-OpenOffice/LibreOffice_integration=OpenOffice/LibreOffice_integration
+OpenOffice/LibreOffice\ integration=OpenOffice/LibreOffice integration
 
-incorrect_control_digit=incorrect_control_digit
-incorrect_format=incorrect_format
-Copied_version_to_clipboard=Copied_version_to_clipboard
+incorrect\ control\ digit=incorrect control digit
+incorrect\ format=incorrect format
+Copied\ version\ to\ clipboard=Copied version to clipboard
 
-BibTeX_key=BibTeX_key
+BibTeX\ key=BibTeX key
 Message=Message
 
 
-MathSciNet_Review=MathSciNet_Review
-Reset_Bindings=Reset_Bindings
+MathSciNet\ Review=MathSciNet Review
+Reset\ Bindings=Reset Bindings
 
-Decryption_not_supported.=Decryption_not_supported.
+Decryption\ not\ supported.=Decryption not supported.
 
-Cleared_'%0'_for_%1_entries=Cleared_'%0'_for_%1_entries
-Set_'%0'_to_'%1'_for_%2_entries=Set_'%0'_to_'%1'_for_%2_entries
-Toggled_'%0'_for_%1_entries=Toggled_'%0'_for_%1_entries
+Cleared\ '%0'\ for\ %1\ entries=Cleared '%0' for %1 entries
+Set\ '%0'\ to\ '%1'\ for\ %2\ entries=Set '%0' to '%1' for %2 entries
+Toggled\ '%0'\ for\ %1\ entries=Toggled '%0' for %1 entries
 
-Check_for_updates=Check_for_updates
-Download_update=Download_update
-New_version_available=New_version_available
-Installed_version=Installed_version
-Remind_me_later=Remind_me_later
-Ignore_this_update=Ignore_this_update
-Could_not_connect_to_the_update_server.=Could_not_connect_to_the_update_server.
-Please_try_again_later_and/or_check_your_network_connection.=Please_try_again_later_and/or_check_your_network_connection.
-To_see_what_is_new_view_the_changelog.=To_see_what_is_new_view_the_changelog.
-A_new_version_of_JabRef_has_been_released.=A_new_version_of_JabRef_has_been_released.
-JabRef_is_up-to-date.=JabRef_is_up-to-date.
-Latest_version=Latest_version
-Online_help_forum=Online_help_forum
+Check\ for\ updates=Check for updates
+Download\ update=Download update
+New\ version\ available=New version available
+Installed\ version=Installed version
+Remind\ me\ later=Remind me later
+Ignore\ this\ update=Ignore this update
+Could\ not\ connect\ to\ the\ update\ server.=Could not connect to the update server.
+Please\ try\ again\ later\ and/or\ check\ your\ network\ connection.=Please try again later and/or check your network connection.
+To\ see\ what\ is\ new\ view\ the\ changelog.=To see what is new view the changelog.
+A\ new\ version\ of\ JabRef\ has\ been\ released.=A new version of JabRef has been released.
+JabRef\ is\ up-to-date.=JabRef is up-to-date.
+Latest\ version=Latest version
+Online\ help\ forum=Online help forum
 Custom=Custom
 
-Export_cited=Export_cited
-Unable_to_generate_new_library=Unable_to_generate_new_library
+Export\ cited=Export cited
+Unable\ to\ generate\ new\ library=Unable to generate new library
 
-Open_console=Open_console
-Use_default_terminal_emulator=Use_default_terminal_emulator
-Execute_command=Execute_command
-Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.=Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.
-Executing_command_\"%0\"...=Executing_command_\"%0\"...
-Error_occured_while_executing_the_command_\"%0\".=Error_occured_while_executing_the_command_\"%0\".
-Reformat_ISSN=Reformat_ISSN
+Open\ console=Open console
+Use\ default\ terminal\ emulator=Use default terminal emulator
+Execute\ command=Execute command
+Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=Note: Use the placeholder %0 for the location of the opened library file.
+Executing\ command\ \"%0\"...=Executing command \"%0\"...
+Error\ occured\ while\ executing\ the\ command\ \"%0\".=Error occured while executing the command \"%0\".
+Reformat\ ISSN=Reformat ISSN
 
-Countries_and_territories_in_English=Countries_and_territories_in_English
-Electrical_engineering_terms=Electrical_engineering_terms
+Countries\ and\ territories\ in\ English=Countries and territories in English
+Electrical\ engineering\ terms=Electrical engineering terms
 Enabled=Enabled
-Internal_list=Internal_list
-Manage_protected_terms_files=Manage_protected_terms_files
-Months_and_weekdays_in_English=Months_and_weekdays_in_English
-The_text_after_the_last_line_starting_with_\#_will_be_used=The_text_after_the_last_line_starting_with_\#_will_be_used
-Add_protected_terms_file=Add_protected_terms_file
-Are_you_sure_you_want_to_remove_the_protected_terms_file?=Are_you_sure_you_want_to_remove_the_protected_terms_file?
-Remove_protected_terms_file=Remove_protected_terms_file
-Add_selected_text_to_list=Add_selected_text_to_list
-Add_{}_around_selected_text=Add_{}_around_selected_text
-Format_field=Format_field
-New_protected_terms_file=New_protected_terms_file
-change_field_%0_of_entry_%1_from_%2_to_%3=change_field_%0_of_entry_%1_from_%2_to_%3
-change_key_from_%0_to_%1=change_key_from_%0_to_%1
-change_string_content_%0_to_%1=change_string_content_%0_to_%1
-change_string_name_%0_to_%1=change_string_name_%0_to_%1
-change_type_of_entry_%0_from_%1_to_%2=change_type_of_entry_%0_from_%1_to_%2
-insert_entry_%0=insert_entry_%0
-insert_string_%0=insert_string_%0
-remove_entry_%0=remove_entry_%0
-remove_string_%0=remove_string_%0
+Internal\ list=Internal list
+Manage\ protected\ terms\ files=Manage protected terms files
+Months\ and\ weekdays\ in\ English=Months and weekdays in English
+The\ text\ after\ the\ last\ line\ starting\ with\ \#\ will\ be\ used=The text after the last line starting with # will be used
+Add\ protected\ terms\ file=Add protected terms file
+Are\ you\ sure\ you\ want\ to\ remove\ the\ protected\ terms\ file?=Are you sure you want to remove the protected terms file?
+Remove\ protected\ terms\ file=Remove protected terms file
+Add\ selected\ text\ to\ list=Add selected text to list
+Add\ {}\ around\ selected\ text=Add {} around selected text
+Format\ field=Format field
+New\ protected\ terms\ file=New protected terms file
+change\ field\ %0\ of\ entry\ %1\ from\ %2\ to\ %3=change field %0 of entry %1 from %2 to %3
+change\ key\ from\ %0\ to\ %1=change key from %0 to %1
+change\ string\ content\ %0\ to\ %1=change string content %0 to %1
+change\ string\ name\ %0\ to\ %1=change string name %0 to %1
+change\ type\ of\ entry\ %0\ from\ %1\ to\ %2=change type of entry %0 from %1 to %2
+insert\ entry\ %0=insert entry %0
+insert\ string\ %0=insert string %0
+remove\ entry\ %0=remove entry %0
+remove\ string\ %0=remove string %0
 undefined=undefined
-Cannot_get_info_based_on_given_%0\:_%1=Cannot_get_info_based_on_given_%0\:_%1
-Get_BibTeX_data_from_%0=Get_BibTeX_data_from_%0
-No_%0_found=No_%0_found
-Entry_from_%0=Entry_from_%0
-Merge_entry_with_%0_information=Merge_entry_with_%0_information
-Updated_entry_with_info_from_%0=Updated_entry_with_info_from_%0
+Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=Cannot get info based on given %0: %1
+Get\ BibTeX\ data\ from\ %0=Get BibTeX data from %0
+No\ %0\ found=No %0 found
+Entry\ from\ %0=Entry from %0
+Merge\ entry\ with\ %0\ information=Merge entry with %0 information
+Updated\ entry\ with\ info\ from\ %0=Updated entry with info from %0
 
-Add_existing_file=Add_existing_file
-Create_new_list=Create_new_list
-Remove_list=Remove_list
-Full_journal_name=Full_journal_name
-Abbreviation_name=Abbreviation_name
+Add\ existing\ file=Add existing file
+Create\ new\ list=Create new list
+Remove\ list=Remove list
+Full\ journal\ name=Full journal name
+Abbreviation\ name=Abbreviation name
 
-No_abbreviation_files_loaded=No_abbreviation_files_loaded
+No\ abbreviation\ files\ loaded=No abbreviation files loaded
 
-Loading_built_in_lists=Loading_built_in_lists
+Loading\ built\ in\ lists=Loading built in lists
 
-JabRef_built_in_list=JabRef_built_in_list
-IEEE_built_in_list=IEEE_built_in_list
+JabRef\ built\ in\ list=JabRef built in list
+IEEE\ built\ in\ list=IEEE built in list
 
-Event_log=Event_log
-We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.=We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.
-Log_copied_to_clipboard.=Log_copied_to_clipboard.
-Copy_Log=Copy_Log
-Clear_Log=Clear_Log
-Report_Issue=Report_Issue
-Issue_on_GitHub_successfully_reported.=Issue_on_GitHub_successfully_reported.
-Issue_report_successful=Issue_report_successful
-Your_issue_was_reported_in_your_browser.=Your_issue_was_reported_in_your_browser.
-The_log_and_exception_information_was_copied_to_your_clipboard.=The_log_and_exception_information_was_copied_to_your_clipboard.
-Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.=Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.
+Event\ log=Event log
+We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef\'s\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=We now give you insight into the inner workings of JabRef\'s internals. This information might be helpful to diagnose the root cause of a problem. Please feel free to inform the developers about an issue.
+Log\ copied\ to\ clipboard.=Log copied to clipboard.
+Copy\ Log=Copy Log
+Clear\ Log=Clear Log
+Report\ Issue=Report Issue
+Issue\ on\ GitHub\ successfully\ reported.=Issue on GitHub successfully reported.
+Issue\ report\ successful=Issue report successful
+Your\ issue\ was\ reported\ in\ your\ browser.=Your issue was reported in your browser.
+The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=The log and exception information was copied to your clipboard.
+Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=Please paste this information (with Ctrl+V) in the issue description.
 
 Connection=Connection
 Connecting...=Connecting...
@@ -2164,194 +2164,194 @@ Port=Port
 Library=Library
 User=User
 Connect=Connect
-Connection_error=Connection_error
-Connection_to_%0_server_established.=Connection_to_%0_server_established.
-Required_field_"%0"_is_empty.=Required_field_"%0"_is_empty.
-%0_driver_not_available.=%0_driver_not_available.
-The_connection_to_the_server_has_been_terminated.=The_connection_to_the_server_has_been_terminated.
-Connection_lost.=Connection_lost.
+Connection\ error=Connection error
+Connection\ to\ %0\ server\ established.=Connection to %0 server established.
+Required\ field\ "%0"\ is\ empty.=Required field "%0" is empty.
+%0\ driver\ not\ available.=%0 driver not available.
+The\ connection\ to\ the\ server\ has\ been\ terminated.=The connection to the server has been terminated.
+Connection\ lost.=Connection lost.
 Reconnect=Reconnect
-Work_offline=Work_offline
-Working_offline.=Working_offline.
-Update_refused.=Update_refused.
-Update_refused=Update_refused
-Local_entry=Local_entry
-Shared_entry=Shared_entry
-Update_could_not_be_performed_due_to_existing_change_conflicts.=Update_could_not_be_performed_due_to_existing_change_conflicts.
-You_are_not_working_on_the_newest_version_of_BibEntry.=You_are_not_working_on_the_newest_version_of_BibEntry.
-Local_version\:_%0=Local_version\:_%0
-Shared_version\:_%0=Shared_version\:_%0
-Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.=Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.
-Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?=Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?
-Shared_entry_is_no_longer_present=Shared_entry_is_no_longer_present
-The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.=The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.
-You_can_restore_the_entry_using_the_"Undo"_operation.=You_can_restore_the_entry_using_the_"Undo"_operation.
-Remember_password?=Remember_password?
-You_are_already_connected_to_a_database_using_entered_connection_details.=You_are_already_connected_to_a_database_using_entered_connection_details.
+Work\ offline=Work offline
+Working\ offline.=Working offline.
+Update\ refused.=Update refused.
+Update\ refused=Update refused
+Local\ entry=Local entry
+Shared\ entry=Shared entry
+Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=Update could not be performed due to existing change conflicts.
+You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=You are not working on the newest version of BibEntry.
+Local\ version\:\ %0=Local version: %0
+Shared\ version\:\ %0=Shared version: %0
+Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=Please merge the shared entry with yours and press "Merge entries" to resolve this problem.
+Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=Canceling this operation will leave your changes unsynchronized. Cancel anyway?
+Shared\ entry\ is\ no\ longer\ present=Shared entry is no longer present
+The\ BibEntry\ you\ currently\ work\ on\ has\ been\ deleted\ on\ the\ shared\ side.=The BibEntry you currently work on has been deleted on the shared side.
+You\ can\ restore\ the\ entry\ using\ the\ "Undo"\ operation.=You can restore the entry using the "Undo" operation.
+Remember\ password?=Remember password?
+You\ are\ already\ connected\ to\ a\ database\ using\ entered\ connection\ details.=You are already connected to a database using entered connection details.
 
-Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?=Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?
-New_technical_report=New_technical_report
+Cannot\ cite\ entries\ without\ BibTeX\ keys.\ Generate\ keys\ now?=Cannot cite entries without BibTeX keys. Generate keys now?
+New\ technical\ report=New technical report
 
-%0_file=%0_file
-Custom_layout_file=Custom_layout_file
-Protected_terms_file=Protected_terms_file
-Style_file=Style_file
+%0\ file=%0 file
+Custom\ layout\ file=Custom layout file
+Protected\ terms\ file=Protected terms file
+Style\ file=Style file
 
-Open_OpenOffice/LibreOffice_connection=Open_OpenOffice/LibreOffice_connection
-You_must_enter_at_least_one_field_name=You_must_enter_at_least_one_field_name
-Non-ASCII_encoded_character_found=Non-ASCII_encoded_character_found
-Toggle_web_search_interface=Toggle_web_search_interface
-Background_color_for_resolved_fields=Background_color_for_resolved_fields
-Color_code_for_resolved_fields=Color_code_for_resolved_fields
-%0_files_found=%0_files_found
-%0_of_%1=%0_of_%1
-One_file_found=One_file_found
-The_import_finished_with_warnings\:=The_import_finished_with_warnings\:
-There_was_one_file_that_could_not_be_imported.=There_was_one_file_that_could_not_be_imported.
-There_were_%0_files_which_could_not_be_imported.=There_were_%0_files_which_could_not_be_imported.
+Open\ OpenOffice/LibreOffice\ connection=Open OpenOffice/LibreOffice connection
+You\ must\ enter\ at\ least\ one\ field\ name=You must enter at least one field name
+Non-ASCII\ encoded\ character\ found=Non-ASCII encoded character found
+Toggle\ web\ search\ interface=Toggle web search interface
+Background\ color\ for\ resolved\ fields=Background color for resolved fields
+Color\ code\ for\ resolved\ fields=Color code for resolved fields
+%0\ files\ found=%0 files found
+%0\ of\ %1=%0 of %1
+One\ file\ found=One file found
+The\ import\ finished\ with\ warnings\:=The import finished with warnings:
+There\ was\ one\ file\ that\ could\ not\ be\ imported.=There was one file that could not be imported.
+There\ were\ %0\ files\ which\ could\ not\ be\ imported.=There were %0 files which could not be imported.
 
-Migration_help_information=Migration_help_information
-Entered_database_has_obsolete_structure_and_is_no_longer_supported.=Entered_database_has_obsolete_structure_and_is_no_longer_supported.
-However,_a_new_database_was_created_alongside_the_pre-3.6_one.=However,_a_new_database_was_created_alongside_the_pre-3.6_one.
-Click_here_to_learn_about_the_migration_of_pre-3.6_databases.=Click_here_to_learn_about_the_migration_of_pre-3.6_databases.
-Opens_JabRef's_Facebook_page=Opens_JabRef's_Facebook_page
-Opens_JabRef's_blog=Opens_JabRef's_blog
-Opens_JabRef's_website=Opens_JabRef's_website
-Opens_a_link_where_the_current_development_version_can_be_downloaded=Opens_a_link_where_the_current_development_version_can_be_downloaded
-See_what_has_been_changed_in_the_JabRef_versions=See_what_has_been_changed_in_the_JabRef_versions
-Referenced_BibTeX_key_does_not_exist=Referenced_BibTeX_key_does_not_exist
-Finished_downloading_full_text_document_for_entry_%0.=Finished_downloading_full_text_document_for_entry_%0.
-Full_text_document_download_failed_for_entry_%0.=Full_text_document_download_failed_for_entry_%0.
-Look_up_full_text_documents=Look_up_full_text_documents
-You_are_about_to_look_up_full_text_documents_for_%0_entries.=You_are_about_to_look_up_full_text_documents_for_%0_entries.
-last_four_nonpunctuation_characters_should_be_numerals=last_four_nonpunctuation_characters_should_be_numerals
+Migration\ help\ information=Migration help information
+Entered\ database\ has\ obsolete\ structure\ and\ is\ no\ longer\ supported.=Entered database has obsolete structure and is no longer supported.
+However,\ a\ new\ database\ was\ created\ alongside\ the\ pre-3.6\ one.=However, a new database was created alongside the pre-3.6 one.
+Click\ here\ to\ learn\ about\ the\ migration\ of\ pre-3.6\ databases.=Click here to learn about the migration of pre-3.6 databases.
+Opens\ JabRef's\ Facebook\ page=Opens JabRef's Facebook page
+Opens\ JabRef's\ blog=Opens JabRef's blog
+Opens\ JabRef's\ website=Opens JabRef's website
+Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=Opens a link where the current development version can be downloaded
+See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=See what has been changed in the JabRef versions
+Referenced\ BibTeX\ key\ does\ not\ exist=Referenced BibTeX key does not exist
+Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=Finished downloading full text document for entry %0.
+Full\ text\ document\ download\ failed\ for\ entry\ %0.=Full text document download failed for entry %0.
+Look\ up\ full\ text\ documents=Look up full text documents
+You\ are\ about\ to\ look\ up\ full\ text\ documents\ for\ %0\ entries.=You are about to look up full text documents for %0 entries.
+last\ four\ nonpunctuation\ characters\ should\ be\ numerals=last four nonpunctuation characters should be numerals
 
 Author=Author
 Date=Date
-File_annotations=File_annotations
-Show_file_annotations=Show_file_annotations
-Adobe_Acrobat_Reader=Adobe_Acrobat_Reader
-Sumatra_Reader=Sumatra_Reader
+File\ annotations=File annotations
+Show\ file\ annotations=Show file annotations
+Adobe\ Acrobat\ Reader=Adobe Acrobat Reader
+Sumatra\ Reader=Sumatra Reader
 shared=shared
-should_contain_an_integer_or_a_literal=should_contain_an_integer_or_a_literal
-should_have_the_first_letter_capitalized=should_have_the_first_letter_capitalized
+should\ contain\ an\ integer\ or\ a\ literal=should contain an integer or a literal
+should\ have\ the\ first\ letter\ capitalized=should have the first letter capitalized
 Tools=Tools
-What\'s_new_in_this_version?=What\'s_new_in_this_version?
-Want_to_help?=Want_to_help?
-Make_a_donation=Make_a_donation
-get_involved=get_involved
-Used_libraries=Used_libraries
-Existing_file=Existing_file
+What\'s\ new\ in\ this\ version?=What\'s new in this version?
+Want\ to\ help?=Want to help?
+Make\ a\ donation=Make a donation
+get\ involved=get involved
+Used\ libraries=Used libraries
+Existing\ file=Existing file
 
 ID=ID
-ID_type=ID_type
-ID-based_entry_generator=ID-based_entry_generator
-Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.
+ID\ type=ID type
+ID-based\ entry\ generator=ID-based entry generator
+Fetcher\ '%0'\ did\ not\ find\ an\ entry\ for\ id\ '%1'.=Fetcher '%0' did not find an entry for id '%1'.
 
-Select_first_entry=Select_first_entry
-Select_last_entry=Select_last_entry
+Select\ first\ entry=Select first entry
+Select\ last\ entry=Select last entry
 
-Invalid_ISBN\:_'%0'.=Invalid_ISBN\:_'%0'.
-should_be_an_integer_or_normalized=should_be_an_integer_or_normalized
-should_be_normalized=should_be_normalized
+Invalid\ ISBN\:\ '%0'.=Invalid ISBN: '%0'.
+should\ be\ an\ integer\ or\ normalized=should be an integer or normalized
+should\ be\ normalized=should be normalized
 
-Empty_search_ID=Empty_search_ID
-The_given_search_ID_was_empty.=The_given_search_ID_was_empty.
-Copy_BibTeX_key_and_link=Copy_BibTeX_key_and_link
-empty_BibTeX_key=empty_BibTeX_key
-biblatex_field_only=biblatex_field_only
+Empty\ search\ ID=Empty search ID
+The\ given\ search\ ID\ was\ empty.=The given search ID was empty.
+Copy\ BibTeX\ key\ and\ link=Copy BibTeX key and link
+empty\ BibTeX\ key=empty BibTeX key
+biblatex\ field\ only=biblatex field only
 
-Error_while_generating_fetch_URL=Error_while_generating_fetch_URL
-Error_while_parsing_ID_list=Error_while_parsing_ID_list
-Unable_to_get_PubMed_IDs=Unable_to_get_PubMed_IDs
-Backup_found=Backup_found
-A_backup_file_for_'%0'_was_found.=A_backup_file_for_'%0'_was_found.
-This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.=This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.
-Do_you_want_to_recover_the_library_from_the_backup_file?=Do_you_want_to_recover_the_library_from_the_backup_file?
-Firstname_Lastname=Firstname_Lastname
+Error\ while\ generating\ fetch\ URL=Error while generating fetch URL
+Error\ while\ parsing\ ID\ list=Error while parsing ID list
+Unable\ to\ get\ PubMed\ IDs=Unable to get PubMed IDs
+Backup\ found=Backup found
+A\ backup\ file\ for\ '%0'\ was\ found.=A backup file for '%0' was found.
+This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=This could indicate that JabRef did not shut down cleanly last time the file was used.
+Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Do you want to recover the library from the backup file?
+Firstname\ Lastname=Firstname Lastname
 
-Recommended_for_%0=Recommended_for_%0
-Show_'Related_Articles'_tab=Show_'Related_Articles'_tab
-This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).
+Recommended\ for\ %0=Recommended for %0
+Show\ 'Related\ Articles'\ tab=Show 'Related Articles' tab
+This\ might\ be\ caused\ by\ reaching\ the\ traffic\ limitation\ of\ Google\ Scholar\ (see\ 'Help'\ for\ details).=This might be caused by reaching the traffic limitation of Google Scholar (see 'Help' for details).
 
-Could_not_open_website.=Could_not_open_website.
-Problem_downloading_from_%1=Problem_downloading_from_%1
+Could\ not\ open\ website.=Could not open website.
+Problem\ downloading\ from\ %1=Problem downloading from %1
 
-File_directory_pattern=File_directory_pattern
-Update_with_bibliographic_information_from_the_web=Update_with_bibliographic_information_from_the_web
+File\ directory\ pattern=File directory pattern
+Update\ with\ bibliographic\ information\ from\ the\ web=Update with bibliographic information from the web
 
-Could_not_find_any_bibliographic_information.=Could_not_find_any_bibliographic_information.
-BibTeX_key_deviates_from_generated_key=BibTeX_key_deviates_from_generated_key
-DOI_%0_is_invalid=DOI_%0_is_invalid
+Could\ not\ find\ any\ bibliographic\ information.=Could not find any bibliographic information.
+BibTeX\ key\ deviates\ from\ generated\ key=BibTeX key deviates from generated key
+DOI\ %0\ is\ invalid=DOI %0 is invalid
 
-Select_all_customized_types_to_be_stored_in_local_preferences=Select_all_customized_types_to_be_stored_in_local_preferences
-Currently_unknown=Currently\_unknown
-Different_customization,_current_settings_will_be_overwritten=Different_customization,_current_settings_will_be_overwritten
+Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences=Select all customized types to be stored in local preferences
+Currently\ unknown=Currently\ unknown
+Different\ customization,\ current\ settings\ will\ be\ overwritten=Different customization, current settings will be overwritten
 
-Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX=Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX
-Jump_to_entry=Jump_to_entry
+Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=Entry type %0 is only defined for Biblatex but not for BibTeX
+Jump\ to\ entry=Jump to entry
 
-Copied_%0_citations.=Copied_%0_citations.
+Copied\ %0\ citations.=Copied %0 citations.
 Copying...=Copying...
 
-journal_not_found_in_abbreviation_list=journal_not_found_in_abbreviation_list
-Unhandled_exception_occurred.=Unhandled_exception_occurred.
+journal\ not\ found\ in\ abbreviation\ list=journal not found in abbreviation list
+Unhandled\ exception\ occurred.=Unhandled exception occurred.
 
-strings_included=strings_included
-Color_for_disabled_icons=Color_for_disabled_icons
-Color_for_enabled_icons=Color_for_enabled_icons
-Size_of_large_icons=Size_of_large_icons
-Size_of_small_icons=Size_of_small_icons
-Default_table_font_size=Default_table_font_size
-Escape_underscores=Escape_underscores
+strings\ included=strings included
+Color\ for\ disabled\ icons=Color for disabled icons
+Color\ for\ enabled\ icons=Color for enabled icons
+Size\ of\ large\ icons=Size of large icons
+Size\ of\ small\ icons=Size of small icons
+Default\ table\ font\ size=Default table font size
+Escape\ underscores=Escape underscores
 Color=Color
-Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.
-Fit_width=Fit_width
-Fit_a_single_page=Fit_a_single_page
-Zoom_in=Zoom_in
-Zoom_out=Zoom_out
-Previous_page=Previous_page
-Next_page=Next_page
-Document_viewer=Document_viewer
+Please\ also\ add\ all\ steps\ to\ reproduce\ this\ issue,\ if\ possible.=Please also add all steps to reproduce this issue, if possible.
+Fit\ width=Fit width
+Fit\ a\ single\ page=Fit a single page
+Zoom\ in=Zoom in
+Zoom\ out=Zoom out
+Previous\ page=Previous page
+Next\ page=Next page
+Document\ viewer=Document viewer
 Live=Live
 Locked=Locked
-Show_document_viewer=Show_document_viewer
-Show_the_document_of_the_currently_selected_entry.=Show_the_document_of_the_currently_selected_entry.
-Show_this_document_until_unlocked.=Show_this_document_until_unlocked.
-Set_current_user_name_as_owner.=Set_current_user_name_as_owner.
+Show\ document\ viewer=Show document viewer
+Show\ the\ document\ of\ the\ currently\ selected\ entry.=Show the document of the currently selected entry.
+Show\ this\ document\ until\ unlocked.=Show this document until unlocked.
+Set\ current\ user\ name\ as\ owner.=Set current user name as owner.
 
-Sort_all_subgroups_(recursively)=Sort_all_subgroups_(recursively)
-Collect_and_share_telemetry_data_to_help_improve_JabRef.=Collect_and_share_telemetry_data_to_help_improve_JabRef.
-Don't_share=Don't_share
-Share_anonymous_statistics=Share_anonymous_statistics
-Telemetry\:_Help_make_JabRef_better=Telemetry\:_Help_make_JabRef_better
-To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.=To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.
-This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?=This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?
-Names_are_not_in_the_standard_%0_format.=Names_are_not_in_the_standard_%0_format.
+Sort\ all\ subgroups\ (recursively)=Sort all subgroups (recursively)
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=Collect and share telemetry data to help improve JabRef.
+Don't\ share=Don't share
+Share\ anonymous\ statistics=Share anonymous statistics
+Telemetry\:\ Help\ make\ JabRef\ better=Telemetry: Help make JabRef better
+To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ statistics\ on\ the\ features\ you\ use.\ We\ will\ only\ record\ what\ features\ you\ access\ and\ how\ often\ you\ do\ it.\ We\ will\ neither\ collect\ any\ personal\ data\ nor\ the\ content\ of\ bibliographic\ items.\ If\ you\ choose\ to\ allow\ data\ collection,\ you\ can\ later\ disable\ it\ via\ Options\ ->\ Preferences\ ->\ General.=To improve the user experience, we would like to collect anonymous statistics on the features you use. We will only record what features you access and how often you do it. We will neither collect any personal data nor the content of bibliographic items. If you choose to allow data collection, you can later disable it via Options -> Preferences -> General.
+This\ file\ was\ found\ automatically.\ Do\ you\ want\ to\ link\ it\ to\ this\ entry?=This file was found automatically. Do you want to link it to this entry?
+Names\ are\ not\ in\ the\ standard\ %0\ format.=Names are not in the standard %0 format.
 
-Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.=Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.
-Delete_'%0'=Delete_'%0'
-Delete_from_disk=Delete_from_disk
-Remove_from_entry=Remove_from_entry
-The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.=The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.
-There_exists_already_a_group_with_the_same_name.=There_exists_already_a_group_with_the_same_name.
+Delete\ the\ selected\ file\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ file\ permanently\ from\ disk.=Delete the selected file permanently from disk, or just remove the file from the entry? Pressing Delete will delete the file permanently from disk.
+Delete\ '%0'=Delete '%0'
+Delete\ from\ disk=Delete from disk
+Remove\ from\ entry=Remove from entry
+The\ group\ name\ contains\ the\ keyword\ separator\ "%0"\ and\ thus\ probably\ does\ not\ work\ as\ expected.=The group name contains the keyword separator "%0" and thus probably does not work as expected.
+There\ exists\ already\ a\ group\ with\ the\ same\ name.=There exists already a group with the same name.
 
-Copy_linked_files_to_folder...=Copy_linked_files_to_folder...
-Copied_file_successfully=Copied_file_successfully
-Copying_files...=Copying_files...
-Copying_file_%0_of_entry_%1=Copying_file_%0_of_entry_%1
-Finished_copying=Finished_copying
-Could_not_copy_file=Could_not_copy_file
-Copied_%0_files_of_%1_sucessfully_to_%2=Copied_%0_files_of_%1_sucessfully_to_%2
-Rename_failed=Rename_failed
-JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.=JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.
-Show_console_output_(only_necessary_when_the_launcher_is_used)=Show_console_output_(only_necessary_when_the_launcher_is_used)
+Copy\ linked\ files\ to\ folder...=Copy linked files to folder...
+Copied\ file\ successfully=Copied file successfully
+Copying\ files...=Copying files...
+Copying\ file\ %0\ of\ entry\ %1=Copying file %0 of entry %1
+Finished\ copying=Finished copying
+Could\ not\ copy\ file=Could not copy file
+Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=Copied %0 files of %1 sucessfully to %2
+Rename\ failed=Rename failed
+JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=JabRef cannot access the file because it is being used by another process.
+Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=Show console output (only necessary when the launcher is used)
 
-Remove_line_breaks=Remove_line_breaks
-Removes_all_line_breaks_in_the_field_content.=Removes_all_line_breaks_in_the_field_content.
-Checking_integrity...=Checking_integrity...
+Remove\ line\ breaks=Remove line breaks
+Removes\ all\ line\ breaks\ in\ the\ field\ content.=Removes all line breaks in the field content.
+Checking\ integrity...=Checking integrity...
 
-Remove_hyphenated_line_breaks=Remove_hyphenated_line_breaks
-Removes_all_hyphenated_line_breaks_in_the_field_content.=Removes_all_hyphenated_line_breaks_in_the_field_content.
-Note_that_currently,_JabRef_does_not_run_with_Java_9.=Note_that_currently,_JabRef_does_not_run_with_Java_9.
-Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.=Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.
+Remove\ hyphenated\ line\ breaks=Remove hyphenated line breaks
+Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=Removes all hyphenated line breaks in the field content.
+Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=Note that currently, JabRef does not run with Java 9.
+Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=Your current Java version (%0) is not supported. Please install version %1 or higher.

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1,8 +1,3 @@
-
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 contains the regular expression <b>%1</b>
 
 %0\ contains\ the\ term\ <b>%1</b>=%0 contains the term <b>%1</b>

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -1206,9 +1206,9 @@ This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\
 
 This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=Este grupo contiene entradas basadas en asignación manual. Las entradas pueden ser asignadas a este grupo seleccionándolas usando el menú contextual o bien mediante arrastrar-soltar. Las entradas pueden ser eliminadas de este grupo seleccionándolas y luego usando el menú contextual.
 
-This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Este grupo contiene entradas cuyo campo <b>%0</b> contiene la palabra clave <b>%1</b> 
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Este grupo contiene entradas cuyo campo <b>%0</b> contiene la palabra clave <b>%1</b>
 
-This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Este grupo contiene entradas cuyo campo <b>%0</b> contiene la< expresión regular <b>%1</b> 
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Este grupo contiene entradas cuyo campo <b>%0</b> contiene la< expresión regular <b>%1</b>
 This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=JabRef inspeccionará cada enlace archivo y comprobará si el archivo existe. En caso contrario, se le ofrecerán opciones <BR> para solucionar el problema.
 
 This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=Esta operación requiere que todas las entradas seleccionadas tengan claves BibTeX definidas.

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -1,8 +1,3 @@
-
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 contiene la expresión regular <b>%1</b>
 
 %0\ contains\ the\ term\ <b>%1</b>=%0%nbsp;contiene el término <b>%1</b>

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -3,156 +3,156 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-%0_contains_the_regular_expression_<b>%1</b>=%0_contiene_la_expresión_regular_<b>%1</b>
+%0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 contiene la expresión regular <b>%1</b>
 
-%0_contains_the_term_<b>%1</b>=%0%nbsp;contiene_el_término_<b>%1</b>
+%0\ contains\ the\ term\ <b>%1</b>=%0%nbsp;contiene el término <b>%1</b>
 
-%0_doesn't_contain_the_regular_expression_<b>%1</b>=%0_no_contiene_la_Expresión_Regular_<b>&1</b>
+%0\ doesn't\ contain\ the\ regular\ expression\ <b>%1</b>=%0 no contiene la Expresión Regular <b>&1</b>
 
-%0_doesn't_contain_the_term_<b>%1</b>=%0_no_contiene_el_término_<b>%1</b>
+%0\ doesn't\ contain\ the\ term\ <b>%1</b>=%0 no contiene el término <b>%1</b>
 
-%0_export_successful=%0_exportado_con_éxito
+%0\ export\ successful=%0 exportado con éxito
 
-%0_matches_the_regular_expression_<b>%1</b>=%0_coincidencias_con_la_Expresión_Regular_<b>%1</b>
+%0\ matches\ the\ regular\ expression\ <b>%1</b>=%0 coincidencias con la Expresión Regular <b>%1</b>
 
-%0_matches_the_term_<b>%1</b>=%0_coincidencias_con_el_término_<b>%1</b>
+%0\ matches\ the\ term\ <b>%1</b>=%0 coincidencias con el término <b>%1</b>
 
-<field_name>=<nombre_del_campo>
-<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>=<HTML>No_se_encuentra_el_archivo_'%0'<BR>enlazado_desde_la_entrada_'%1'</HTML>
+<field\ name>=<nombre del campo>
+<HTML>Could\ not\ find\ file\ '%0'<BR>linked\ from\ entry\ '%1'</HTML>=<HTML>No se encuentra el archivo '%0'<BR>enlazado desde la entrada '%1'</HTML>
 
 <select>=<seleccionar>
 
-<select_word>=<seleccionar_palabra>
-Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)=Abreviar_nombres_de_revistas_de_las_entradas_seleccionadas_(Abreviatura_ISO)
-Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)=Abreviar_nombres_de_revistas_de_las_entradas_seleccionadas_(Abreviatura_MEDLINE)
+<select\ word>=<seleccionar palabra>
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (ISO\ abbreviation)=Abreviar nombres de revistas de las entradas seleccionadas (Abreviatura ISO)
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (MEDLINE\ abbreviation)=Abreviar nombres de revistas de las entradas seleccionadas (Abreviatura MEDLINE)
 
-Abbreviate_names=Abreviar_nombres
-Abbreviated_%0_journal_names.=Se_han_abreviado_%0_nombres_de_revistas
+Abbreviate\ names=Abreviar nombres
+Abbreviated\ %0\ journal\ names.=Se han abreviado %0 nombres de revistas
 
 Abbreviation=Abreviatura
 
-About_JabRef=Acerca_de_JabRef
+About\ JabRef=Acerca de JabRef
 
 Abstract=Resumen
 
 Accept=Aceptar
 
-Accept_change=Aceptar_cambio
+Accept\ change=Aceptar cambio
 
 Action=Acción
 
-What_is_Mr._DLib?=¿Qué_es_Mr._DLib?
+What\ is\ Mr.\ DLib?=¿Qué es Mr. DLib?
 
 Add=Añadir
 
-Add_a_(compiled)_custom_Importer_class_from_a_class_path.=Añadir_una_clase_personalizada_(compilada)_Importer_desde_una_classpath.
-The_path_need_not_be_on_the_classpath_of_JabRef.=La_ruta_no_debe_estar_en_la_classpath_de_JabRef.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=Añadir una clase personalizada (compilada) Importer desde una classpath.
+The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=La ruta no debe estar en la classpath de JabRef.
 
-Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=Añadir_una_clase_personalizada_(compilada)_Importer_desde_un_archivo_ZIP.
-The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=El_archivo_ZIP_no_tiene_por_qué_estar_en_la_classpath_de_JabRef.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=Añadir una clase personalizada (compilada) Importer desde un archivo ZIP.
+The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=El archivo ZIP no tiene por qué estar en la classpath de JabRef.
 
-Add_a_regular_expression_for_the_key_pattern.=
+Add\ a\ regular\ expression\ for\ the\ key\ pattern.=
 
-Add_selected_entries_to_this_group=Añadir_entradas_seleccionadas_a_este_grupo
+Add\ selected\ entries\ to\ this\ group=Añadir entradas seleccionadas a este grupo
 
-Add_from_folder=Añadir_desde_carpeta
+Add\ from\ folder=Añadir desde carpeta
 
-Add_from_JAR=Añadir_desde_JAR
+Add\ from\ JAR=Añadir desde JAR
 
-add_group=añadir_grupo
+add\ group=añadir grupo
 
-Add_new=Añadir_nuevo
+Add\ new=Añadir nuevo
 
-Add_subgroup=Añadir_subgrupo
+Add\ subgroup=Añadir subgrupo
 
-Add_to_group=Añadir_a_grupo
+Add\ to\ group=Añadir a grupo
 
-Added_group_"%0".=Grupo_"%0"_añadido
+Added\ group\ "%0".=Grupo "%0" añadido
 
-Added_missing_braces.=
+Added\ missing\ braces.=
 
-Added_new=Nuevo_añadido
+Added\ new=Nuevo añadido
 
-Added_string=Cadena_añadida
+Added\ string=Cadena añadida
 
-Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.=Adicionalmente,_entradas_cuyo_campo_<b>%0</b>_no_contenga_<b>%1</b>_pueden_ser_asignadas_manualmente_al_grupo_seleccionándolas_y_arrastrándolas_sobre_el_menu_contextual._Este_proceso_añade_el_término_<b>%1</b>_al_campo_de_cada_entrada._Las_entradas_pueden_ser_eliminadas_manualmente_del_grupo_seleccionándolas_y_usando_a_continuación_el_menú_contextual._Este_proceso_elimina_el_término_<b>%1</b>_del_campo_de_cada_entrada.
+Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ can\ be\ assigned\ manually\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ This\ process\ adds\ the\ term\ <b>%1</b>\ to\ each\ entry's\ <b>%0</b>\ field.\ Entries\ can\ be\ removed\ manually\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.\ This\ process\ removes\ the\ term\ <b>%1</b>\ from\ each\ entry's\ <b>%0</b>\ field.=Adicionalmente, entradas cuyo campo <b>%0</b> no contenga <b>%1</b> pueden ser asignadas manualmente al grupo seleccionándolas y arrastrándolas sobre el menu contextual. Este proceso añade el término <b>%1</b> al campo de cada entrada. Las entradas pueden ser eliminadas manualmente del grupo seleccionándolas y usando a continuación el menú contextual. Este proceso elimina el término <b>%1</b> del campo de cada entrada.
 
 Advanced=Avanzado
-All_entries=Todas_las_entradas
-All_entries_of_this_type_will_be_declared_typeless._Continue?=Todas_las_entradas_de_este_tipo_serán_declaradas_Sin_Tipo._¿Continuar?
+All\ entries=Todas las entradas
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=Todas las entradas de este tipo serán declaradas Sin Tipo. ¿Continuar?
 
-All_fields=Todos_los_campos
+All\ fields=Todos los campos
 
-Always_reformat_BIB_file_on_save_and_export=Siempre_reformatear_el_fichero_BIB_al_guardar_y_exportar
+Always\ reformat\ BIB\ file\ on\ save\ and\ export=Siempre reformatear el fichero BIB al guardar y exportar
 
-A_SAX_exception_occurred_while_parsing_'%0'\:=Ocurrió_una_Excepción_SAX_mientras_se_analizaba_la_sintaxis_de_'%0'\:
+A\ SAX\ exception\ occurred\ while\ parsing\ '%0'\:=Ocurrió una Excepción SAX mientras se analizaba la sintaxis de '%0':
 
 and=y
-and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.=y_la_clase_debe_estar_disponible_en_su_classpath_la_próxima_vez_que_inicie_JabRef.
+and\ the\ class\ must\ be\ available\ in\ your\ classpath\ next\ time\ you\ start\ JabRef.=y la clase debe estar disponible en su classpath la próxima vez que inicie JabRef.
 
-any_field_that_matches_the_regular_expression_<b>%0</b>=cualquier_campo_que_satisfaga_la_Expresión_Regular_<b>%0</b>
+any\ field\ that\ matches\ the\ regular\ expression\ <b>%0</b>=cualquier campo que satisfaga la Expresión Regular <b>%0</b>
 
 Appearance=Aspecto
 
 Append=Añadir
-Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library=Agregar_contenidos_desde_una_biblioteca_BibTeX_a_la_biblioteca_actual
+Append\ contents\ from\ a\ BibTeX\ library\ into\ the\ currently\ viewed\ library=Agregar contenidos desde una biblioteca BibTeX a la biblioteca actual
 
-Append_library=Agregar_biblioteca
+Append\ library=Agregar biblioteca
 
-Append_the_selected_text_to_BibTeX_field=Agregar_el_texto_seleccionado_a_la_clave_BibTeX
+Append\ the\ selected\ text\ to\ BibTeX\ field=Agregar el texto seleccionado a la clave BibTeX
 Application=Aplicación
 
 Apply=Aplicar
 
-Arguments_passed_on_to_running_JabRef_instance._Shutting_down.=Argumentos_pasados_a_una_instancia_JabRef_en_ejecución._Cerrando_el_programa.
+Arguments\ passed\ on\ to\ running\ JabRef\ instance.\ Shutting\ down.=Argumentos pasados a una instancia JabRef en ejecución. Cerrando el programa.
 
-Assign_new_file=Asignar_nuevo_archivo
+Assign\ new\ file=Asignar nuevo archivo
 
-Assign_the_original_group's_entries_to_this_group?=¿Asignar_las_entradas_del_grupo_original_a_este_grupo?
+Assign\ the\ original\ group's\ entries\ to\ this\ group?=¿Asignar las entradas del grupo original a este grupo?
 
-Assigned_%0_entries_to_group_"%1".=Se_han_asignado_%0_entradas_al_grupo_"%1"
+Assigned\ %0\ entries\ to\ group\ "%1".=Se han asignado %0 entradas al grupo "%1"
 
-Assigned_1_entry_to_group_"%0".=Asignada_una_entrada_al_grupo_"%0".
+Assigned\ 1\ entry\ to\ group\ "%0".=Asignada una entrada al grupo "%0".
 
-Attach_URL=Adjuntar_URL
+Attach\ URL=Adjuntar URL
 
-Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.=Intentar_establecer_automáticamente_archivo_enlaces_para_sus_entradas._El_establecimiento_automático_funciona_si_un_archivo_en_la_carpeta_archivo_o_un_subdirectrio_<BR>_tiene_nombre_idéntico_a_una_entrada_BibTeX_más_la_extensión.
+Attempt\ to\ automatically\ set\ file\ links\ for\ your\ entries.\ Automatically\ setting\ works\ if\ a\ file\ in\ your\ file\ directory<BR>or\ a\ subdirectory\ is\ named\ identically\ to\ an\ entry's\ BibTeX\ key,\ plus\ extension.=Intentar establecer automáticamente archivo enlaces para sus entradas. El establecimiento automático funciona si un archivo en la carpeta archivo o un subdirectrio <BR> tiene nombre idéntico a una entrada BibTeX más la extensión.
 
-Autodetect_format=Autodetectar_formato
+Autodetect\ format=Autodetectar formato
 
-Autogenerate_BibTeX_keys=Autogenerar_claves_BibTeX
+Autogenerate\ BibTeX\ keys=Autogenerar claves BibTeX
 
-Autolink_files_with_names_starting_with_the_BibTeX_key=Autoenlazar_con_nombres_comenzando_por_la_clave_BibTeX
+Autolink\ files\ with\ names\ starting\ with\ the\ BibTeX\ key=Autoenlazar con nombres comenzando por la clave BibTeX
 
-Autolink_only_files_that_match_the_BibTeX_key=Autoenlazar_sólo_archivos_cuyo_nombre_coincida_con_la_clave_BibTeX
+Autolink\ only\ files\ that\ match\ the\ BibTeX\ key=Autoenlazar sólo archivos cuyo nombre coincida con la clave BibTeX
 
-Automatically_create_groups=Crear_grupos_automáticamente
+Automatically\ create\ groups=Crear grupos automáticamente
 
-Automatically_remove_exact_duplicates=Eliminar_automáticamente_duplicados_exactos
+Automatically\ remove\ exact\ duplicates=Eliminar automáticamente duplicados exactos
 
-Allow_overwriting_existing_links.=Permitir_sobreescribir_enlaces_existentes.
+Allow\ overwriting\ existing\ links.=Permitir sobreescribir enlaces existentes.
 
-Do_not_overwrite_existing_links.=No_sobreescribir_enlaces_existentes.
+Do\ not\ overwrite\ existing\ links.=No sobreescribir enlaces existentes.
 
-AUX_file_import=Importar_archivo_AUX
+AUX\ file\ import=Importar archivo AUX
 
-Available_export_formats=Formatos_para_exportación_disponibles
+Available\ export\ formats=Formatos para exportación disponibles
 
-Available_BibTeX_fields=Campos_Disponibles
+Available\ BibTeX\ fields=Campos Disponibles
 
-Available_import_formats=Formatos_disponibles_para_importar
+Available\ import\ formats=Formatos disponibles para importar
 
-Background_color_for_optional_fields=Color_de_fondo_campos_opcionales
+Background\ color\ for\ optional\ fields=Color de fondo campos opcionales
 
-Background_color_for_required_fields=Color_de_fondo_campos_requeridos
+Background\ color\ for\ required\ fields=Color de fondo campos requeridos
 
-Backup_old_file_when_saving=Hacer_copia_de_respaldo_del_archivo_antiguo_al_grabar
+Backup\ old\ file\ when\ saving=Hacer copia de respaldo del archivo antiguo al grabar
 
-BibTeX_key_is_unique.=La_clave_BibTeX_es_única
+BibTeX\ key\ is\ unique.=La clave BibTeX es única
 
-%0_source=Origen_%0
+%0\ source=Origen %0
 
-Broken_link=Enlace_roto
+Broken\ link=Enlace roto
 
 Browse=Explorar
 
@@ -160,321 +160,321 @@ by=por
 
 Cancel=Cancelar
 
-Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?=No_se_pueden_añadir_entradas_a_un_grupo_sin_generar_claves._¿Generar_claves_ahora?
+Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=No se pueden añadir entradas a un grupo sin generar claves. ¿Generar claves ahora?
 
-Cannot_merge_this_change=No_se_puede_incorporar_este_cambio
+Cannot\ merge\ this\ change=No se puede incorporar este cambio
 
-case_insensitive=insensible_al_uso_de_mayúsculas/minúsculas
+case\ insensitive=insensible al uso de mayúsculas/minúsculas
 
-case_sensitive=sensible_al_uso_de_mayúsculas/minúsculas
+case\ sensitive=sensible al uso de mayúsculas/minúsculas
 
-Case_sensitive=Sensible_al_uso_de_mayúsculas/minúsculas
+Case\ sensitive=Sensible al uso de mayúsculas/minúsculas
 
-change_assignment_of_entries=Cambiar_asignación_de_entradas
+change\ assignment\ of\ entries=Cambiar asignación de entradas
 
-Change_case=Cambiar_mayúsculas/minúsculas
+Change\ case=Cambiar mayúsculas/minúsculas
 
-Change_entry_type=Cambiar_tipo_de_entrada
-Change_file_type=Cambiar_tipo_de_archivo
+Change\ entry\ type=Cambiar tipo de entrada
+Change\ file\ type=Cambiar tipo de archivo
 
 
-Change_of_Grouping_Method=Cambiar_método_de_agrupamiento
+Change\ of\ Grouping\ Method=Cambiar método de agrupamiento
 
-change_preamble=cambiar_preámbulo
+change\ preamble=cambiar preámbulo
 
-Change_table_column_and_General_fields_settings_to_use_the_new_feature=Cambiar_los_ajustes_de_columna_de_tabla_y_campos_generales_para_usar_la_nueva_caraterística
+Change\ table\ column\ and\ General\ fields\ settings\ to\ use\ the\ new\ feature=Cambiar los ajustes de columna de tabla y campos generales para usar la nueva caraterística
 
-Changed_language_settings=Ajustes_de_lenguaje_cambiados
+Changed\ language\ settings=Ajustes de lenguaje cambiados
 
-Changed_preamble=Preámbulo_cambiado
+Changed\ preamble=Preámbulo cambiado
 
-Check_existing_file_links=Comprobar_archivo_enlaces_existentes
+Check\ existing\ file\ links=Comprobar archivo enlaces existentes
 
-Check_links=Comprobar_enlaces
+Check\ links=Comprobar enlaces
 
-Cite_command=Comando_Citar
+Cite\ command=Comando Citar
 
-Class_name=Nombre_de_clase
+Class\ name=Nombre de clase
 
 Clear=Limpiar
 
-Clear_fields=Limpiar_campos
+Clear\ fields=Limpiar campos
 
 Close=Cerrar
-Close_others=Cerrar_otros
-Close_all=Cerrar_todos
+Close\ others=Cerrar otros
+Close\ all=Cerrar todos
 
-Close_dialog=Cerrar_diálogo
+Close\ dialog=Cerrar diálogo
 
-Close_the_current_library=Cerrar_la_biblioteca_actual
+Close\ the\ current\ library=Cerrar la biblioteca actual
 
-Close_window=Cerrar_ventana
+Close\ window=Cerrar ventana
 
-Closed_library=Biblioteca_cerrada
+Closed\ library=Biblioteca cerrada
 
-Color_codes_for_required_and_optional_fields=Códigos_de_color_para_campos_requeridos_y_opcionales
+Color\ codes\ for\ required\ and\ optional\ fields=Códigos de color para campos requeridos y opcionales
 
-Color_for_marking_incomplete_entries=Color_para_marcar_entradas_incompletas
+Color\ for\ marking\ incomplete\ entries=Color para marcar entradas incompletas
 
-Column_width=Ancho_de_columna
+Column\ width=Ancho de columna
 
-Command_line_id=Id_de_línea_de_comando
+Command\ line\ id=Id de línea de comando
 
 
-Contained_in=Contenido_en
+Contained\ in=Contenido en
 
 Content=Contenido
 
 Copied=Copiado
 
-Copied_cell_contents=Contenido_de_celda_copiado
+Copied\ cell\ contents=Contenido de celda copiado
 
-Copied_title=Título_copiado
+Copied\ title=Título copiado
 
-Copied_key=Clave_copiada
+Copied\ key=Clave copiada
 
-Copied_titles=Títulos_copiados
+Copied\ titles=Títulos copiados
 
-Copied_keys=Claves_copiadas
+Copied\ keys=Claves copiadas
 
 Copy=Copiar
 
-Copy_BibTeX_key=Copiar_clave_BibTeXt
-Copy_file_to_file_directory=Copiar_archivos_a_carpeta
+Copy\ BibTeX\ key=Copiar clave BibTeXt
+Copy\ file\ to\ file\ directory=Copiar archivos a carpeta
 
-Copy_to_clipboard=Copiar_al_portapapeles
+Copy\ to\ clipboard=Copiar al portapapeles
 
-Could_not_call_executable=No_se_puede_llamar_al_ejecutable
-Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.=No_se_puede_conectar_con_el_servidor_Vim._Asegúrese_de_que_Vim_está_corriendo<BR>_con_el_nombre_de_servidor_correcto.
+Could\ not\ call\ executable=No se puede llamar al ejecutable
+Could\ not\ connect\ to\ Vim\ server.\ Make\ sure\ that\ Vim\ is\ running<BR>with\ correct\ server\ name.=No se puede conectar con el servidor Vim. Asegúrese de que Vim está corriendo<BR> con el nombre de servidor correcto.
 
-Could_not_export_file=No_se_puede_exportar_el_archivo
+Could\ not\ export\ file=No se puede exportar el archivo
 
-Could_not_export_preferences=No_se_pueden_exportar_las_preferencias
+Could\ not\ export\ preferences=No se pueden exportar las preferencias
 
-Could_not_find_a_suitable_import_format.=No_se_encuentra_un_formato_de_importación_apropiado.
-Could_not_import_preferences=No_se_pueden_importar_las_preferencias
+Could\ not\ find\ a\ suitable\ import\ format.=No se encuentra un formato de importación apropiado.
+Could\ not\ import\ preferences=No se pueden importar las preferencias
 
-Could_not_instantiate_%0=No_se_puede_instanciar_%0
-Could_not_instantiate_%0_%1=No_se_puede_instanciar_%0_%1
-Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?=No_se_puede_instanciar_%0._¿Ha_escogido_la_ruta_del_paquete_correctamente?
-Could_not_open_link=No_se_puede_abrir_el_enlace
+Could\ not\ instantiate\ %0=No se puede instanciar %0
+Could\ not\ instantiate\ %0\ %1=No se puede instanciar %0 %1
+Could\ not\ instantiate\ %0.\ Have\ you\ chosen\ the\ correct\ package\ path?=No se puede instanciar %0. ¿Ha escogido la ruta del paquete correctamente?
+Could\ not\ open\ link=No se puede abrir el enlace
 
-Could_not_print_preview=No_se_puede_imprimir_la_vista_previa
+Could\ not\ print\ preview=No se puede imprimir la vista previa
 
-Could_not_run_the_'vim'_program.=No_se_puede_ejecutar_Vim
+Could\ not\ run\ the\ 'vim'\ program.=No se puede ejecutar Vim
 
-Could_not_save_file.=No_se_puede_guardar_el_archivo.
-Character_encoding_'%0'_is_not_supported.=La_codificaciónd_de_caracteres_'%0'_no_está_soportada.
+Could\ not\ save\ file.=No se puede guardar el archivo.
+Character\ encoding\ '%0'\ is\ not\ supported.=La codificaciónd de caracteres '%0' no está soportada.
 
-crossreferenced_entries_included=entradas_de_referencia_cruzada_incluídas
+crossreferenced\ entries\ included=entradas de referencia cruzada incluídas
 
-Current_content=Contenido_actual
+Current\ content=Contenido actual
 
-Current_value=Valor_actual
+Current\ value=Valor actual
 
-Custom_entry_types=Tipos_de_entrada_personalizados
+Custom\ entry\ types=Tipos de entrada personalizados
 
-Custom_entry_types_found_in_file=Se_han_encontrado_tipos_de_entrada_personalizados_en_el_archivo
+Custom\ entry\ types\ found\ in\ file=Se han encontrado tipos de entrada personalizados en el archivo
 
-Customize_entry_types=Tipos_de_entrada_personalizados
+Customize\ entry\ types=Tipos de entrada personalizados
 
-Customize_key_bindings=Pesonalizar_combinaciones_de_tecla
+Customize\ key\ bindings=Pesonalizar combinaciones de tecla
 
 Cut=Cortar
 
-cut_entries=Cortar_entradas
+cut\ entries=Cortar entradas
 
-cut_entry=Cortar_entrada
+cut\ entry=Cortar entrada
 
 
-Library_encoding=Codificación_de_la_biblioteca
+Library\ encoding=Codificación de la biblioteca
 
-Library_properties=Propiedades_de_la_biblioteca
+Library\ properties=Propiedades de la biblioteca
 
-Library_type=Tipo_de_biblioteca
+Library\ type=Tipo de biblioteca
 
-Date_format=Formato_de_fecha
+Date\ format=Formato de fecha
 
-Default=Por_defecto
+Default=Por defecto
 
-Default_encoding=Codificación_por_defecto
+Default\ encoding=Codificación por defecto
 
-Default_grouping_field=Campo_de_agrupación_por_defecto
+Default\ grouping\ field=Campo de agrupación por defecto
 
-Default_look_and_feel=Aspecto_por_defecto
+Default\ look\ and\ feel=Aspecto por defecto
 
-Default_pattern=Patrón_por_defecto
+Default\ pattern=Patrón por defecto
 
-Default_sort_criteria=Criterio_de_ordenación_por_defecto
-Define_'%0'=Definir_'%0'
+Default\ sort\ criteria=Criterio de ordenación por defecto
+Define\ '%0'=Definir '%0'
 
 Delete=Borrar
 
-Delete_custom_format=Borrar_formato_por_defecto
+Delete\ custom\ format=Borrar formato por defecto
 
-delete_entries=borrar_entradas
+delete\ entries=borrar entradas
 
-Delete_entry=Borrar_entrada
+Delete\ entry=Borrar entrada
 
-delete_entry=borrar_entrada
+delete\ entry=borrar entrada
 
-Delete_multiple_entries=Borrar_entradas_múltiples
+Delete\ multiple\ entries=Borrar entradas múltiples
 
-Delete_rows=Borrar_filas
+Delete\ rows=Borrar filas
 
-Delete_strings=Borrar_cadenas
+Delete\ strings=Borrar cadenas
 
 Deleted=Borrado
 
-Permanently_delete_local_file=Eliminar_archivo_local
+Permanently\ delete\ local\ file=Eliminar archivo local
 
-Delimit_fields_with_semicolon,_ex.=Delimitar_campos_con_punto_y_coma
+Delimit\ fields\ with\ semicolon,\ ex.=Delimitar campos con punto y coma
 
 Descending=Descendiente
 
 Description=Descripción
 
-Deselect_all=Deseleccionar_todos
-Deselect_all_duplicates=Deseleccionar_todos_los_duplicados
+Deselect\ all=Deseleccionar todos
+Deselect\ all\ duplicates=Deseleccionar todos los duplicados
 
-Disable_this_confirmation_dialog=Deshabilitar_este_diálogo_de_confirmación
+Disable\ this\ confirmation\ dialog=Deshabilitar este diálogo de confirmación
 
-Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.=Mostrar_todas_las_entradas_pertenecientes_a_uno_o_más_de_los_grupos_seleccionados.
+Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups.=Mostrar todas las entradas pertenecientes a uno o más de los grupos seleccionados.
 
-Display_all_error_messages=Mostrar_todos_los_mensajes_de_error
+Display\ all\ error\ messages=Mostrar todos los mensajes de error
 
-Display_help_on_command_line_options=Mosrar_ayuda_en_las_opciones_de_línea_de_comando
+Display\ help\ on\ command\ line\ options=Mosrar ayuda en las opciones de línea de comando
 
-Display_only_entries_belonging_to_all_selected_groups.=Mostrar_sólo_entradas_pertenecientes_a_todos_los_grupos_seleccionados.
-Display_version=Mostrar_versión
+Display\ only\ entries\ belonging\ to\ all\ selected\ groups.=Mostrar sólo entradas pertenecientes a todos los grupos seleccionados.
+Display\ version=Mostrar versión
 
-Do_not_abbreviate_names=No_abreviar_nombres
+Do\ not\ abbreviate\ names=No abreviar nombres
 
-Do_not_automatically_set=No_establecer_automáticamente
+Do\ not\ automatically\ set=No establecer automáticamente
 
-Do_not_import_entry=No_importar_entrada
+Do\ not\ import\ entry=No importar entrada
 
-Do_not_open_any_files_at_startup=No_abrir_ningún_archivo_al_arrancar
+Do\ not\ open\ any\ files\ at\ startup=No abrir ningún archivo al arrancar
 
-Do_not_overwrite_existing_keys=No_sobreescribir_claves_existentes
-Do_not_show_these_options_in_the_future=No_mostrar_estas_ospciones_en_el_futuro
+Do\ not\ overwrite\ existing\ keys=No sobreescribir claves existentes
+Do\ not\ show\ these\ options\ in\ the\ future=No mostrar estas ospciones en el futuro
 
-Do_not_wrap_the_following_fields_when_saving=No_envolver_los_siguientes_campos_al_guardar
-Do_not_write_the_following_fields_to_XMP_Metadata\:=No_escribir_los_campos_a_continuación_a_los_metadatos_XMP
+Do\ not\ wrap\ the\ following\ fields\ when\ saving=No envolver los siguientes campos al guardar
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=No escribir los campos a continuación a los metadatos XMP
 
-Do_you_want_JabRef_to_do_the_following_operations?=¿Quiere_que_JabRef_efectúe_las_siguientes_operaciones?
+Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=¿Quiere que JabRef efectúe las siguientes operaciones?
 
-Donate_to_JabRef=Donar_a_JabRef
+Donate\ to\ JabRef=Donar a JabRef
 
 Down=Abajo
 
-Download_file=Descargar_archivo
+Download\ file=Descargar archivo
 
 Downloading...=Descargando...
 
-Drop_%0=Soltar_%0
+Drop\ %0=Soltar %0
 
-duplicate_removal=eliminación_de_duplicados
+duplicate\ removal=eliminación de duplicados
 
-Duplicate_string_name=Nombre_de_cadena_duplicado
+Duplicate\ string\ name=Nombre de cadena duplicado
 
-Duplicates_found=Se_han_encontrado_duplicados
+Duplicates\ found=Se han encontrado duplicados
 
-Dynamic_groups=Grupos_dinámicos
+Dynamic\ groups=Grupos dinámicos
 
-Dynamically_group_entries_by_a_free-form_search_expression=Agrupar_entradas_dinámicamente_por_una_expresión_de_búsqueda_libre
+Dynamically\ group\ entries\ by\ a\ free-form\ search\ expression=Agrupar entradas dinámicamente por una expresión de búsqueda libre
 
-Dynamically_group_entries_by_searching_a_field_for_a_keyword=Agrupar_entradas_dinámicamente_buscando_palabra_clave_en_campo
+Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=Agrupar entradas dinámicamente buscando palabra clave en campo
 
-Each_line_must_be_on_the_following_form=Cada_línea_debe_tener_la_siguiente_forma
+Each\ line\ must\ be\ on\ the\ following\ form=Cada línea debe tener la siguiente forma
 
 Edit=Editar
 
-Edit_custom_export=Editar_exportación_personalizada
-Edit_entry=Editar_entrada
-Save_file=Editar_enlace_a_archivo
-Edit_file_type=Editar_tipo_de_archivo
+Edit\ custom\ export=Editar exportación personalizada
+Edit\ entry=Editar entrada
+Save\ file=Editar enlace a archivo
+Edit\ file\ type=Editar tipo de archivo
 
-Edit_group=Editar_grupo
+Edit\ group=Editar grupo
 
 
-Edit_preamble=Editar_preámbulo
-Edit_strings=Editar_cadenas
-Editor_options=Opciones_del_editor
+Edit\ preamble=Editar preámbulo
+Edit\ strings=Editar cadenas
+Editor\ options=Opciones del editor
 
-Empty_BibTeX_key=Clave_BibTeXt_vacía
+Empty\ BibTeX\ key=Clave BibTeXt vacía
 
-Grouping_may_not_work_for_this_entry.=El_agrupamiento_puede_no_funcionar_para_esta_entrada.
+Grouping\ may\ not\ work\ for\ this\ entry.=El agrupamiento puede no funcionar para esta entrada.
 
-empty_library=Biblioteca_vacía
-Enable_word/name_autocompletion=Permitir_autocompletado_de_palabra/nombre
+empty\ library=Biblioteca vacía
+Enable\ word/name\ autocompletion=Permitir autocompletado de palabra/nombre
 
-Enter_URL=Introducir_URL
+Enter\ URL=Introducir URL
 
-Enter_URL_to_download=Introducir_URL_a_descargar
+Enter\ URL\ to\ download=Introducir URL a descargar
 
 entries=entradas
 
-Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.=Las_entradas_no_se_pueden_asignar_o_eliminar_manualmente_de_este_grupo.
+Entries\ cannot\ be\ manually\ assigned\ to\ or\ removed\ from\ this\ group.=Las entradas no se pueden asignar o eliminar manualmente de este grupo.
 
-Entries_exported_to_clipboard=Entradas_exportadas_a_portapapeles
+Entries\ exported\ to\ clipboard=Entradas exportadas a portapapeles
 
 
 entry=entrada
 
-Entry_editor=Editor_de_entrada
+Entry\ editor=Editor de entrada
 
-Entry_preview=Vista_previa_de_la_entrada
+Entry\ preview=Vista previa de la entrada
 
-Entry_table=Tabla_de_entrada
+Entry\ table=Tabla de entrada
 
-Entry_table_columns=Columnas_de_la_tabla_de_entrada
+Entry\ table\ columns=Columnas de la tabla de entrada
 
-Entry_type=Tipo_de_entrada
+Entry\ type=Tipo de entrada
 
-Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters=No_se_permiten_espacios_ni_los_caracteres_siguientes_en_el_nombre_de_tipo_de_entrada
+Entry\ type\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=No se permiten espacios ni los caracteres siguientes en el nombre de tipo de entrada
 
-Entry_types=Tipos_de_entrada
+Entry\ types=Tipos de entrada
 
 Error=Error
-Error_exporting_to_clipboard=Error_exportando_al_portapapeles
+Error\ exporting\ to\ clipboard=Error exportando al portapapeles
 
-Error_occurred_when_parsing_entry=Ocurrió_un_error_al_analizar_la_entrada
+Error\ occurred\ when\ parsing\ entry=Ocurrió un error al analizar la entrada
 
-Error_opening_file=Error_al_abrir_el_archivo
+Error\ opening\ file=Error al abrir el archivo
 
-Error_setting_field=Error_estableciendo_el_campo
+Error\ setting\ field=Error estableciendo el campo
 
-Error_while_writing=Error_al_escribir
-Error_writing_to_%0_file(s).=Error_escribiendo_%0_archivo(s).
+Error\ while\ writing=Error al escribir
+Error\ writing\ to\ %0\ file(s).=Error escribiendo %0 archivo(s).
 
 
 
-'%0'_exists._Overwrite_file?='%0'_existe._¿Sobreescribir?
-Overwrite_file?=¿Sobreescribir?
+'%0'\ exists.\ Overwrite\ file?='%0' existe. ¿Sobreescribir?
+Overwrite\ file?=¿Sobreescribir?
 
 Export=Exportar
 
-Export_name=Exportar_nombre
+Export\ name=Exportar nombre
 
-Export_preferences=Exportar_preferencias
+Export\ preferences=Exportar preferencias
 
-Export_preferences_to_file=Exportar_preferencias_a_archivo
+Export\ preferences\ to\ file=Exportar preferencias a archivo
 
-Export_properties=Exportar_propiedades
+Export\ properties=Exportar propiedades
 
-Export_to_clipboard=Exportar_al_portapapeles
+Export\ to\ clipboard=Exportar al portapapeles
 
 Exporting=Exportando
 Extension=Extensión
 
-External_changes=Cambios_externos
+External\ changes=Cambios externos
 
-External_file_links=Enlaces_a_archivos_externos
+External\ file\ links=Enlaces a archivos externos
 
-External_programs=Programas_externos
+External\ programs=Programas externos
 
-External_viewer_called=Se_ha_lanzado_el_visor_externo
+External\ viewer\ called=Se ha lanzado el visor externo
 
 Fetch=Recuperar
 
@@ -482,660 +482,660 @@ Field=Campo
 
 field=campo
 
-Field_name=Nombre_del_campo
-Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters=No_se_permiten_los_espacios_o_los_siguientes_caracteres_en_los_nombres_de_campo
+Field\ name=Nombre del campo
+Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=No se permiten los espacios o los siguientes caracteres en los nombres de campo
 
-Field_to_filter=Filtro_a_partir_de_campo
+Field\ to\ filter=Filtro a partir de campo
 
-Field_to_group_by=Agrupar_a_partir_de_campo
+Field\ to\ group\ by=Agrupar a partir de campo
 
 File=Archivo
 
 file=archivo
-File_'%0'_is_already_open.=El_archivo_'%0'_ya_está_abierto.
+File\ '%0'\ is\ already\ open.=El archivo '%0' ya está abierto.
 
-File_changed=Fichero_cambiado
-File_directory_is_'%0'\:=La_carpeta_de_archivos_es_'%0'\:
+File\ changed=Fichero cambiado
+File\ directory\ is\ '%0'\:=La carpeta de archivos es '%0':
 
-File_directory_is_not_set_or_does_not_exist\!=¡La_carpeta_de_archivos_no_etá_establecida_o_no_existe\!
+File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=¡La carpeta de archivos no etá establecida o no existe!
 
-File_exists=El_archivo_ya_existe
+File\ exists=El archivo ya existe
 
-File_has_been_updated_externally._What_do_you_want_to_do?=El_archivo_ha_sido_editado
+File\ has\ been\ updated\ externally.\ What\ do\ you\ want\ to\ do?=El archivo ha sido editado
 
-File_not_found=No_se_ha_encontrado_el_archivo
-File_type=Tipo_de_archivo
+File\ not\ found=No se ha encontrado el archivo
+File\ type=Tipo de archivo
 
-File_updated_externally=Archivo_actualizado_externamente
+File\ updated\ externally=Archivo actualizado externamente
 
-filename=nombre_de_archivo
+filename=nombre de archivo
 
-Filename=Nombre_de_archivo
+Filename=Nombre de archivo
 
-Files_opened=Archivos_abiertos
+Files\ opened=Archivos abiertos
 
 Filter=Filtro
 
-Filter_All=
+Filter\ All=
 
-Filter_None=
+Filter\ None=
 
-Finished_automatically_setting_external_links.=Se_ha_finalizado_la_configuración_automática_de_enlaces_esternos.
+Finished\ automatically\ setting\ external\ links.=Se ha finalizado la configuración automática de enlaces esternos.
 
-Finished_synchronizing_file_links._Entries_changed\:_%0.=Se_ha_finalizado_la_sincronización_de_archivo_enlaces._Se_cambiaron_\:_%0_entradas.
-Finished_writing_XMP-metadata._Wrote_to_%0_file(s).=Se_ha_finalizado_la_escritura_de_los_metadtos_XMP._Se_escribió_en_%0_archivo(s).
-Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).=Se_finalizó_la_escritura_XMP_en_archivo_%0_(%1_evitados,_%2_errores).
+Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Se ha finalizado la sincronización de archivo enlaces. Se cambiaron : %0 entradas.
+Finished\ writing\ XMP-metadata.\ Wrote\ to\ %0\ file(s).=Se ha finalizado la escritura de los metadtos XMP. Se escribió en %0 archivo(s).
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Se finalizó la escritura XMP en archivo %0 (%1 evitados, %2 errores).
 
-First_select_the_entries_you_want_keys_to_be_generated_for.=En_primer_lugar,_seleccione_las_entradas_para_las_que_desea_generar_claves
+First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=En primer lugar, seleccione las entradas para las que desea generar claves
 
-Fit_table_horizontally_on_screen=Ajustar_la_tabla_al_ancho_de_pantalla
+Fit\ table\ horizontally\ on\ screen=Ajustar la tabla al ancho de pantalla
 
 Float=Flotar
-Float_marked_entries=Flotar_entradas_marcadas
+Float\ marked\ entries=Flotar entradas marcadas
 
-Font_family=Tipo_de_letra
+Font\ family=Tipo de letra
 
-Font_preview=Vista_previa_del_tipo_de_letra
+Font\ preview=Vista previa del tipo de letra
 
-Font_size=Tamaño_de_tipo_de_letra
+Font\ size=Tamaño de tipo de letra
 
-Font_style=Estilo_de_tipo_de_letra
+Font\ style=Estilo de tipo de letra
 
-Font_selection=Selector_tipo_de_letra
+Font\ selection=Selector tipo de letra
 
 for=para
 
-Format_of_author_and_editor_names=Formato_de_los_nombres_de_autor_y_editor
-Format_string=Formatear_cadena
+Format\ of\ author\ and\ editor\ names=Formato de los nombres de autor y editor
+Format\ string=Formatear cadena
 
-Format_used=Formato_usado
-Formatter_name=Nombre_del_formateador
+Format\ used=Formato usado
+Formatter\ name=Nombre del formateador
 
-found_in_AUX_file=encontrado_en_archivo_AUX
+found\ in\ AUX\ file=encontrado en archivo AUX
 
-Full_name=Nombre_completo
+Full\ name=Nombre completo
 
 General=General
 
-General_fields=Generar_campos
+General\ fields=Generar campos
 
 Generate=Generar
 
-Generate_BibTeX_key=Generar_clave_BibTeX
+Generate\ BibTeX\ key=Generar clave BibTeX
 
-Generate_keys=Generar_claves
+Generate\ keys=Generar claves
 
-Generate_keys_before_saving_(for_entries_without_a_key)=Generar_claves_antes_de_guardar_(para_entradas_sin_clave)
-Generate_keys_for_imported_entries=Generar_claves_para_claves_importadas
+Generate\ keys\ before\ saving\ (for\ entries\ without\ a\ key)=Generar claves antes de guardar (para entradas sin clave)
+Generate\ keys\ for\ imported\ entries=Generar claves para claves importadas
 
-Generate_now=Generar_ahora
+Generate\ now=Generar ahora
 
-Generated_BibTeX_key_for=Generar_clabe_BibTeX_para
+Generated\ BibTeX\ key\ for=Generar clabe BibTeX para
 
-Generating_BibTeX_key_for=Generarando_clave_BibTeX_para
-Get_fulltext=Obtener_texto_completo
+Generating\ BibTeX\ key\ for=Generarando clave BibTeX para
+Get\ fulltext=Obtener texto completo
 
-Gray_out_non-hits=Poner_en_gris_los_no_encontrados
+Gray\ out\ non-hits=Poner en gris los no encontrados
 
 Groups=Grupos
 
-Have_you_chosen_the_correct_package_path?=¿Ha_escogido_la_ruta_de_paquetes_correcta?
+Have\ you\ chosen\ the\ correct\ package\ path?=¿Ha escogido la ruta de paquetes correcta?
 
 Help=Ayuda
 
-Help_on_key_patterns=Ayuda_sobre_patrones_de_teclas
-Help_on_regular_expression_search=Ayuda_sobre_búsqueda_mediante_expresión_regular
+Help\ on\ key\ patterns=Ayuda sobre patrones de teclas
+Help\ on\ regular\ expression\ search=Ayuda sobre búsqueda mediante expresión regular
 
-Hide_non-hits=Esconder_los_no-aciertos
+Hide\ non-hits=Esconder los no-aciertos
 
-Hierarchical_context=Contexto_jerárquico
+Hierarchical\ context=Contexto jerárquico
 
 Highlight=Resaltar
 Marking=Marcado
 Underline=Subrayado
-Empty_Highlight=Resaltado_vacío
-Empty_Marking=Marcado_vacío
-Empty_Underline=Subrayado_vacío
-The_marked_area_does_not_contain_any_legible_text!=¡El_área_marcada_no_contiente_ningún_texto_legible!
+Empty\ Highlight=Resaltado vacío
+Empty\ Marking=Marcado vacío
+Empty\ Underline=Subrayado vacío
+The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=¡El área marcada no contiente ningún texto legible!
 
-Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>=Pista_\:_Para_buscar_sólo_campos_específicos,_introduzca,_por_ejemplo,_\:_<p><tt>author\=smith_and_title\=electrical</tt>
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Pista : Para buscar sólo campos específicos, introduzca, por ejemplo, : <p><tt>author=smith and title=electrical</tt>
 
-HTML_table=Tabla_HTML
-HTML_table_(with_Abstract_&_BibTeX)=Tabla_HTML_(con_Abstract_BibTeX)
+HTML\ table=Tabla HTML
+HTML\ table\ (with\ Abstract\ &\ BibTeX)=Tabla HTML (con Abstract BibTeX)
 Icon=Icono
 
 Ignore=Ignorar
 
 Import=Importar
 
-Import_and_keep_old_entry=Importar_y_conservar_entrada_antigua
+Import\ and\ keep\ old\ entry=Importar y conservar entrada antigua
 
-Import_and_remove_old_entry=Importar_y_eliminar_antigua_entrada
+Import\ and\ remove\ old\ entry=Importar y eliminar antigua entrada
 
-Import_entries=Importar_entradas
+Import\ entries=Importar entradas
 
-Import_failed=Falló_la_importación
+Import\ failed=Falló la importación
 
-Import_file=Importar_archivo
+Import\ file=Importar archivo
 
-Import_group_definitions=Importar_definiciones_de_grupo
+Import\ group\ definitions=Importar definiciones de grupo
 
-Import_name=Importar_nombre
+Import\ name=Importar nombre
 
-Import_preferences=Importar_preferencias
+Import\ preferences=Importar preferencias
 
-Import_preferences_from_file=Importar_preferencias_desde_archivo
+Import\ preferences\ from\ file=Importar preferencias desde archivo
 
-Import_strings=Importar_cadenas
+Import\ strings=Importar cadenas
 
-Import_to_open_tab=Importar_en_pestaña_abierta
+Import\ to\ open\ tab=Importar en pestaña abierta
 
-Import_word_selector_definitions=Importar_definiciones_de_selector_de_palabras
+Import\ word\ selector\ definitions=Importar definiciones de selector de palabras
 
-Imported_entries=Importar_entradas
+Imported\ entries=Importar entradas
 
-Imported_from_library=Importado_desde_biblioteca
+Imported\ from\ library=Importado desde biblioteca
 
-Importer_class=Importar_formato_de_clase
+Importer\ class=Importar formato de clase
 
 Importing=Importando
 
-Importing_in_unknown_format=Importando_en_formato_desconocido
+Importing\ in\ unknown\ format=Importando en formato desconocido
 
-Include_abstracts=Incluir_abstracts
-Include_entries=Incluir_entradas
+Include\ abstracts=Incluir abstracts
+Include\ entries=Incluir entradas
 
-Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups=Incluir_subgrupos\:_Ver_entradas_contenidas_es_este_grupo_o_sus_subgrupos_cuando_estén_seleccionadas.
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=Incluir subgrupos: Ver entradas contenidas es este grupo o sus subgrupos cuando estén seleccionadas.
 
-Independent_group\:_When_selected,_view_only_this_group's_entries=Grupo_independiente\:_ver_sólo_las_entradas_de_este_grupo_cuando_esté_seleccionado.
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=Grupo independiente: ver sólo las entradas de este grupo cuando esté seleccionado.
 
-Work_options=Opciones_de_trabajo
+Work\ options=Opciones de trabajo
 
 Insert=Insertar
 
-Insert_rows=Insertar_filas
+Insert\ rows=Insertar filas
 
 Intersection=Intersección
 
-Invalid_BibTeX_key=Clave_BibTeX_inválida
+Invalid\ BibTeX\ key=Clave BibTeX inválida
 
-Invalid_date_format=Formato_de_fecha_no_válido
+Invalid\ date\ format=Formato de fecha no válido
 
-Invalid_URL=URL_no_válida
+Invalid\ URL=URL no válida
 
-Online_help=Ayuda_online
+Online\ help=Ayuda online
 
-JabRef_preferences=Preferencias_de_JabRef
+JabRef\ preferences=Preferencias de JabRef
 
 Join=
 
-Joins_selected_keywords_and_deletes_selected_keywords.=
+Joins\ selected\ keywords\ and\ deletes\ selected\ keywords.=
 
-Journal_abbreviations=Abreviaturas_de_publicaciones
+Journal\ abbreviations=Abreviaturas de publicaciones
 
 Keep=Mantener
 
-Keep_both=Mantener_ambos
+Keep\ both=Mantener ambos
 
-Key_bindings=Combinaciones_de_teclas
+Key\ bindings=Combinaciones de teclas
 
-Key_bindings_changed=Combinaciones_de_teclas_cambiadas
+Key\ bindings\ changed=Combinaciones de teclas cambiadas
 
-Key_generator_settings=Ajustes_del_generador_de_claves
+Key\ generator\ settings=Ajustes del generador de claves
 
-Key_pattern=Patrón_de_clave
+Key\ pattern=Patrón de clave
 
-keys_in_library=claves_en_la_biblioteca
+keys\ in\ library=claves en la biblioteca
 
-Keyword=Palabra_clave
+Keyword=Palabra clave
 
 Label=Etiqueta
 
 Language=Idioma
 
-Last_modified=Modificado_por_última_vez
+Last\ modified=Modificado por última vez
 
-LaTeX_AUX_file=Archivo_LaTeX_AUX
-Leave_file_in_its_current_directory=Dejar_el_archivo_en_su_directorio_actual
+LaTeX\ AUX\ file=Archivo LaTeX AUX
+Leave\ file\ in\ its\ current\ directory=Dejar el archivo en su directorio actual
 
 Left=Dejar
 Level=Nivelar
 
-Limit_to_fields=Limitar_a_los_campos
+Limit\ to\ fields=Limitar a los campos
 
-Limit_to_selected_entries=Limitar_a_las_entradas_seleccionadas
+Limit\ to\ selected\ entries=Limitar a las entradas seleccionadas
 
 Link=Enlace
-Link_local_file=Enlazar_archivo_local
-Link_to_file_%0=Enlazar_al_archivo_%0
+Link\ local\ file=Enlazar archivo local
+Link\ to\ file\ %0=Enlazar al archivo %0
 
-Listen_for_remote_operation_on_port=Escuchar_para_operación_remota_en_el_puerto
-Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)=Cargar_y_guardar_preferencias_desde/a_jabref.xml_al_arrancar_(modo_lápiz_de_memoria)
+Listen\ for\ remote\ operation\ on\ port=Escuchar para operación remota en el puerto
+Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=Cargar y guardar preferencias desde/a jabref.xml al arrancar (modo lápiz de memoria)
 
-Look_and_feel=Aspecto
-Main_file_directory=Carpeta_del_archivo_principal
+Look\ and\ feel=Aspecto
+Main\ file\ directory=Carpeta del archivo principal
 
-Main_layout_file=Archivo_de_configuración_principal
+Main\ layout\ file=Archivo de configuración principal
 
-Manage_custom_exports=Administrar_esportaciones_personalizadas
+Manage\ custom\ exports=Administrar esportaciones personalizadas
 
-Manage_custom_imports=Administrar_importaciones_personalizadas
-Manage_external_file_types=Administrar_tipos_de_archivo_externos
+Manage\ custom\ imports=Administrar importaciones personalizadas
+Manage\ external\ file\ types=Administrar tipos de archivo externos
 
-Mark_entries=Marcar_entradas
+Mark\ entries=Marcar entradas
 
-Mark_entry=Marcar_entrada
+Mark\ entry=Marcar entrada
 
-Mark_new_entries_with_addition_date=Marcar_nuevas_entradas_con_fecha_de_incorporación
+Mark\ new\ entries\ with\ addition\ date=Marcar nuevas entradas con fecha de incorporación
 
-Mark_new_entries_with_owner_name=Marcar_nuevas_entradas_con_nombre_de_propietario
+Mark\ new\ entries\ with\ owner\ name=Marcar nuevas entradas con nombre de propietario
 
-Memory_stick_mode=Modo_lápiz_de_memoria
+Memory\ stick\ mode=Modo lápiz de memoria
 
-Menu_and_label_font_size=Tamaño_de_tipo_de_letra_para_menú_y_etiquetas
+Menu\ and\ label\ font\ size=Tamaño de tipo de letra para menú y etiquetas
 
-Merged_external_changes=Cambios_externos_incorporados
+Merged\ external\ changes=Cambios externos incorporados
 
 Messages=Mensajes
 
-Modification_of_field=Modificación_de_campo
+Modification\ of\ field=Modificación de campo
 
-Modified_group_"%0".=Se_ha_modificado_el_grupo_"%0".
+Modified\ group\ "%0".=Se ha modificado el grupo "%0".
 
-Modified_groups=Grupos_modificados
+Modified\ groups=Grupos modificados
 
-Modified_string=Cadena_modificada
+Modified\ string=Cadena modificada
 
 Modify=Modificar
 
-modify_group=Modificar_grupo
+modify\ group=Modificar grupo
 
-Move_down=Mover_hacia_abajo
+Move\ down=Mover hacia abajo
 
-Move_external_links_to_'file'_field=Mover_enlaces_externos_al_campo_'archivo'
+Move\ external\ links\ to\ 'file'\ field=Mover enlaces externos al campo 'archivo'
 
-move_group=Mover_grupo
+move\ group=Mover grupo
 
-Move_up=Mover_hacia_arriba
+Move\ up=Mover hacia arriba
 
-Moved_group_"%0".=Se_ha_movido_el_grupo_"%0".
+Moved\ group\ "%0".=Se ha movido el grupo "%0".
 
 Name=Nombre
-Name_formatter=Formateador_de_nombre
+Name\ formatter=Formateador de nombre
 
-Natbib_style=Estilo_Natbib
+Natbib\ style=Estilo Natbib
 
-nested_AUX_files=Archivos_AUX_anidados
+nested\ AUX\ files=Archivos AUX anidados
 
 New=Nuevo
 
 new=new
 
-New_BibTeX_entry=Nueva_entrada_BibTeX
+New\ BibTeX\ entry=Nueva entrada BibTeX
 
-New_BibTeX_sublibrary=Nueva_biblioteca_secundaria_BibTeX
+New\ BibTeX\ sublibrary=Nueva biblioteca secundaria BibTeX
 
-New_content=Nuevo_contenido
+New\ content=Nuevo contenido
 
-New_library_created.=Nueva_biblioteca_creada.
-New_%0_library=Nueva_biblioteca_%0
-New_field_value=Nuevo_valor_de_campo
+New\ library\ created.=Nueva biblioteca creada.
+New\ %0\ library=Nueva biblioteca %0
+New\ field\ value=Nuevo valor de campo
 
-New_group=Nuevo_grupo
+New\ group=Nuevo grupo
 
-New_string=Nueva_cadena
+New\ string=Nueva cadena
 
-Next_entry=Entrada_siguiente
+Next\ entry=Entrada siguiente
 
-No_actual_changes_found.=No_se_han_encontrado_cambios_actuales.
+No\ actual\ changes\ found.=No se han encontrado cambios actuales.
 
-no_base-BibTeX-file_specified=no_se_ha_especificado_archiv_base_BibTeX
+no\ base-BibTeX-file\ specified=no se ha especificado archiv base BibTeX
 
-no_library_generated=No_se_generó_biblioteca
+no\ library\ generated=No se generó biblioteca
 
-No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.=No_se_han_encontrado_entradas._Asegúrese_de_que_está_usando_el_filtro_de_importación_correcto.
+No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=No se han encontrado entradas. Asegúrese de que está usando el filtro de importación correcto.
 
 
-No_entries_found_for_the_search_string_'%0'=No_se_han_encontrado_entdas_para_la_cadena_de_búsqueda_'%0'
+No\ entries\ found\ for\ the\ search\ string\ '%0'=No se han encontrado entdas para la cadena de búsqueda '%0'
 
-No_entries_imported.=No_se_han_importado_entradas.
+No\ entries\ imported.=No se han importado entradas.
 
-No_files_found.=No_se_han_encontrado_archivos.
+No\ files\ found.=No se han encontrado archivos.
 
-No_GUI._Only_process_command_line_options.=Sin_GUI._Procesar_sólo_opciones_de_la_línea_de_comandos.
+No\ GUI.\ Only\ process\ command\ line\ options.=Sin GUI. Procesar sólo opciones de la línea de comandos.
 
-No_journal_names_could_be_abbreviated.=No_se_pudieron_abreviar_nombres_de_revistas.
+No\ journal\ names\ could\ be\ abbreviated.=No se pudieron abreviar nombres de revistas.
 
-No_journal_names_could_be_unabbreviated.=No_se_pudieron_expandir_nombres_de_revistas.
-No_PDF_linked=Ningún_PDF_enlazado
+No\ journal\ names\ could\ be\ unabbreviated.=No se pudieron expandir nombres de revistas.
+No\ PDF\ linked=Ningún PDF enlazado
 
-Open_PDF=Abrir_PDF
+Open\ PDF=Abrir PDF
 
-No_URL_defined=Ninguna_URL_definida
+No\ URL\ defined=Ninguna URL definida
 not=no
 
-not_found=no_encontrado
+not\ found=no encontrado
 
-Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,=Tenga_en_cuenta_que_debe_especificar_el_nombre_completo_de_clase_para_la_apariencia.
+Note\ that\ you\ must\ specify\ the\ fully\ qualified\ class\ name\ for\ the\ look\ and\ feel,=Tenga en cuenta que debe especificar el nombre completo de clase para la apariencia.
 
-Nothing_to_redo=Nada_que_rehacer
+Nothing\ to\ redo=Nada que rehacer
 
-Nothing_to_undo=Nada_que_deshacer
+Nothing\ to\ undo=Nada que deshacer
 
 occurrences=apariciones
 
 OK=Ok
-One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Uno_o_más_archivos_son_del_tipo_'%0',_que_no_está_definido._¿Qué_desea_hacer?
+One\ or\ more\ file\ links\ are\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Uno o más archivos son del tipo '%0', que no está definido. ¿Qué desea hacer?
 
-One_or_more_keys_will_be_overwritten._Continue?=Una_o_claves_se_sobreescribirán._¿Continuar?
+One\ or\ more\ keys\ will\ be\ overwritten.\ Continue?=Una o claves se sobreescribirán. ¿Continuar?
 
 
 Open=Abrir
 
-Open_BibTeX_library=Abrir_biblioteca_BIbTeX
+Open\ BibTeX\ library=Abrir biblioteca BIbTeX
 
-Open_library=Abrir_biblioteca
+Open\ library=Abrir biblioteca
 
-Open_editor_when_a_new_entry_is_created=Abrir_editor_al_crear_nueva_entrada
+Open\ editor\ when\ a\ new\ entry\ is\ created=Abrir editor al crear nueva entrada
 
-Open_file=Abrir_archivo
+Open\ file=Abrir archivo
 
-Open_last_edited_libraries_at_startup=Abrir_las_últimas_bibliotecas_editadas_al_arrancar
+Open\ last\ edited\ libraries\ at\ startup=Abrir las últimas bibliotecas editadas al arrancar
 
-Connect_to_shared_database=Conectar_a_biblioteca_compartida
+Connect\ to\ shared\ database=Conectar a biblioteca compartida
 
-Open_terminal_here=Open_terminal_here
+Open\ terminal\ here=Open terminal here
 
-Open_URL_or_DOI=Abril_URL_o_DOI
+Open\ URL\ or\ DOI=Abril URL o DOI
 
-Opened_library=Biblioteca_abierta
+Opened\ library=Biblioteca abierta
 
 Opening=Abriendo
 
-Opening_preferences...=Preferencias_de_apertura
+Opening\ preferences...=Preferencias de apertura
 
-Operation_canceled.=Operación_cancelada.
-Operation_not_supported=Operación_no_soportada
+Operation\ canceled.=Operación cancelada.
+Operation\ not\ supported=Operación no soportada
 
-Optional_fields=Campos_opcionales
+Optional\ fields=Campos opcionales
 
 Options=Opciones
 
 or=o
 
-Output_or_export_file=Sacar_o_exportar_archivo,
+Output\ or\ export\ file=Sacar o exportar archivo,
 
 Override=Ignorar
 
-Override_default_file_directories=Ignorar_carpetas_de_archivo_por_defecto
+Override\ default\ file\ directories=Ignorar carpetas de archivo por defecto
 
-Override_default_font_settings=Ignorar_ajustes_de_tipo_de_letra_por_defecto
+Override\ default\ font\ settings=Ignorar ajustes de tipo de letra por defecto
 
-Override_the_BibTeX_field_by_the_selected_text=Ignorar_la_clave_BibTeX_por_el_texto_seleccionado
+Override\ the\ BibTeX\ field\ by\ the\ selected\ text=Ignorar la clave BibTeX por el texto seleccionado
 
 
 Overwrite=Sobreescribir
-Overwrite_existing_field_values=Sobreescribir_valores_de_campo_existentes
+Overwrite\ existing\ field\ values=Sobreescribir valores de campo existentes
 
-Overwrite_keys=Sobreescribir_claves
+Overwrite\ keys=Sobreescribir claves
 
-pairs_processed=pares_procesados
+pairs\ processed=pares procesados
 Password=Contraseña
 
 Paste=Pegar
 
-paste_entries=pegar_entradas
+paste\ entries=pegar entradas
 
-paste_entry=pegar_entrada
-Paste_from_clipboard=Pegar_desde_el_portapapeles
+paste\ entry=pegar entrada
+Paste\ from\ clipboard=Pegar desde el portapapeles
 
 Pasted=Pegado
 
-Path_to_%0_not_defined=Ruta_hasta_%0_sin_definir
+Path\ to\ %0\ not\ defined=Ruta hasta %0 sin definir
 
-Path_to_LyX_pipe=Ruta_hasta_el_pipe_LyX
+Path\ to\ LyX\ pipe=Ruta hasta el pipe LyX
 
-PDF_does_not_exist=No_existe_el_PDF
+PDF\ does\ not\ exist=No existe el PDF
 
-File_has_no_attached_annotations=El_fichero_no_tiene_anotaciones_adjuntas
+File\ has\ no\ attached\ annotations=El fichero no tiene anotaciones adjuntas
 
-Plain_text_import=Importar_texto_plano
+Plain\ text\ import=Importar texto plano
 
-Please_enter_a_name_for_the_group.=Introduzca_un_nombre_para_el_grupo.
+Please\ enter\ a\ name\ for\ the\ group.=Introduzca un nombre para el grupo.
 
-Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>=Introduzca_un_término_de_búsqueda._Por_ejemplo,_para_buscar_en_todos_los_campos_<b>García</b>,_introduzca\:<p><tt>garcía</tt><p>_Para_buscar_<b>García</b>_dentro_del_campo_<b>Author</b>_y_<b>eléctrico</b>_en_el_campo_<b>Title</b>,_introduzca\:<p><tt>author\=garcía_and_title\=eléctrico</tt>
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Introduzca un término de búsqueda. Por ejemplo, para buscar en todos los campos <b>García</b>, introduzca:<p><tt>garcía</tt><p> Para buscar <b>García</b> dentro del campo <b>Author</b> y <b>eléctrico</b> en el campo <b>Title</b>, introduzca:<p><tt>author=garcía and title=eléctrico</tt>
 
-Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=Introduzca_el_campo_en_que_buscar_(p.e._<b>keywords</b>)_y_la_palabra_clave_a_buscar_(p.e._<b>eléctrico</b>).
+Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=Introduzca el campo en que buscar (p.e. <b>keywords</b>) y la palabra clave a buscar (p.e. <b>eléctrico</b>).
 
-Please_enter_the_string's_label=Introduzca_la_etiqueta_de_la_cadena
+Please\ enter\ the\ string's\ label=Introduzca la etiqueta de la cadena
 
-Please_select_an_importer.=Seleccionar_un_importador.
+Please\ select\ an\ importer.=Seleccionar un importador.
 
-Possible_duplicate_entries=Posibles_entradas_duplicadas
+Possible\ duplicate\ entries=Posibles entradas duplicadas
 
-Possible_duplicate_of_existing_entry._Click_to_resolve.=Posible_duplicado_de_entrada_existente._Clique_para_resolver.
+Possible\ duplicate\ of\ existing\ entry.\ Click\ to\ resolve.=Posible duplicado de entrada existente. Clique para resolver.
 
 Preamble=Preámbulo
 
 Preferences=Preferencias
 
-Preferences_recorded.=Preferencias_guardadas.
+Preferences\ recorded.=Preferencias guardadas.
 
-Preview=Vista_previa
-Citation_Style=Estilo_de_cita
-Current_Preview=Vista_previa_actual
-Cannot_generate_preview_based_on_selected_citation_style.=No_se_puede_generar_vista_previa_basada_en_el_estilo_de_cita_seleccionado
-Bad_character_inside_entry=Carácter_inapropiado_en_la_entrada
-Error_while_generating_citation_style=Error_al_generar_el_estilo_de_cita
-Preview_style_changed_to\:_%0=Cambiado_estilo_de_previsualización_a\:%0
-Next_preview_layout=Plantilla_de_previsualización_previa
-Previous_preview_layout=Plantilla_de_previsualización_previa
+Preview=Vista previa
+Citation\ Style=Estilo de cita
+Current\ Preview=Vista previa actual
+Cannot\ generate\ preview\ based\ on\ selected\ citation\ style.=No se puede generar vista previa basada en el estilo de cita seleccionado
+Bad\ character\ inside\ entry=Carácter inapropiado en la entrada
+Error\ while\ generating\ citation\ style=Error al generar el estilo de cita
+Preview\ style\ changed\ to\:\ %0=Cambiado estilo de previsualización a:%0
+Next\ preview\ layout=Plantilla de previsualización previa
+Previous\ preview\ layout=Plantilla de previsualización previa
 
-Previous_entry=Entrada_anterior
+Previous\ entry=Entrada anterior
 
-Primary_sort_criterion=Criterio_de_ordenación_primario
-Problem_with_parsing_entry=Problemas_analizando_entradas
-Processing_%0=Procesando_%0
-Pull_changes_from_shared_database=Obtener_cambios_desde_biblioteca_compartida
+Primary\ sort\ criterion=Criterio de ordenación primario
+Problem\ with\ parsing\ entry=Problemas analizando entradas
+Processing\ %0=Procesando %0
+Pull\ changes\ from\ shared\ database=Obtener cambios desde biblioteca compartida
 
-Pushed_citations_to_%0=Se_han_enviado_las_citas_a_%0
+Pushed\ citations\ to\ %0=Se han enviado las citas a %0
 
-Quit_JabRef=Salir_de_JabRef
+Quit\ JabRef=Salir de JabRef
 
-Quit_synchronization=Dejar_de_sincronizar
+Quit\ synchronization=Dejar de sincronizar
 
-Raw_source=Furente_de_datos_en_bruto
+Raw\ source=Furente de datos en bruto
 
-Rearrange_tabs_alphabetically_by_title=Disponer_las_pestañas_alfabéticamente_por_título
+Rearrange\ tabs\ alphabetically\ by\ title=Disponer las pestañas alfabéticamente por título
 
 Redo=Rehacer
 
-Reference_library=Biblioteca_de_referencia
+Reference\ library=Biblioteca de referencia
 
-%0_references_found._Number_of_references_to_fetch?=Referencias_encontradas\:_%0._¿Número_de_apariciones_a_recuperar?
+%0\ references\ found.\ Number\ of\ references\ to\ fetch?=Referencias encontradas: %0. ¿Número de apariciones a recuperar?
 
-Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Refinar_supergrupo\:_Ver_entradas_contenidas_en_este_grupo_y_sus_subgrupos_cuando_estén_seleccionadas
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=Refinar supergrupo: Ver entradas contenidas en este grupo y sus subgrupos cuando estén seleccionadas
 
-regular_expression=Expresión_Regular
+regular\ expression=Expresión Regular
 
-Related_articles=Artículos_relacionados
+Related\ articles=Artículos relacionados
 
-Remote_operation=Operación_remota
+Remote\ operation=Operación remota
 
-Remote_server_port=Puerto_remoto_del_servidor
+Remote\ server\ port=Puerto remoto del servidor
 
 Remove=Eliminar
 
-Remove_subgroups=Eliminar_subgrupos
+Remove\ subgroups=Eliminar subgrupos
 
-Remove_all_subgroups_of_"%0"?=¿Eliminar_todos_los_subrgrupos_de_"%0"?
+Remove\ all\ subgroups\ of\ "%0"?=¿Eliminar todos los subrgrupos de "%0"?
 
-Remove_entry_from_import=Eliminar_entrada_importada
+Remove\ entry\ from\ import=Eliminar entrada importada
 
-Remove_selected_entries_from_this_group=Eliminar_las_entradas_seleccionadas_de_este_grupo
+Remove\ selected\ entries\ from\ this\ group=Eliminar las entradas seleccionadas de este grupo
 
-Remove_entry_type=Eliminar_tipo_de_entrada
+Remove\ entry\ type=Eliminar tipo de entrada
 
-Remove_from_group=Eliminar_del_grupo
+Remove\ from\ group=Eliminar del grupo
 
-Remove_group=Eliminar_grupo
+Remove\ group=Eliminar grupo
 
-Remove_group,_keep_subgroups=Eliminar_grupo,_mantener_subgrupos
+Remove\ group,\ keep\ subgroups=Eliminar grupo, mantener subgrupos
 
-Remove_group_"%0"?=¿Eliminar_el_grupo_"%0%?
+Remove\ group\ "%0"?=¿Eliminar el grupo "%0%?
 
-Remove_group_"%0"_and_its_subgroups?=¿Ena_grupo_250"_y_sus_subgrupos?
+Remove\ group\ "%0"\ and\ its\ subgroups?=¿Ena grupo 250" y sus subgrupos?
 
-remove_group_(keep_subgroups)=eliminar_grupo_(mantener_subgrupos)
+remove\ group\ (keep\ subgroups)=eliminar grupo (mantener subgrupos)
 
-remove_group_and_subgroups=eliminar_grupo_y_subgrupos
+remove\ group\ and\ subgroups=eliminar grupo y subgrupos
 
-Remove_group_and_subgroups=Eliminar_grupo_y_subgrupos
+Remove\ group\ and\ subgroups=Eliminar grupo y subgrupos
 
-Remove_link=Eliminar_enlace
+Remove\ link=Eliminar enlace
 
-Remove_old_entry=Eliminar_vieja_entrada
+Remove\ old\ entry=Eliminar vieja entrada
 
-Remove_selected_strings=Eliminar_cadenas_seleccionadas
+Remove\ selected\ strings=Eliminar cadenas seleccionadas
 
-Removed_group_"%0".=el_grupo_"%0"_se_ha_eliminado.
+Removed\ group\ "%0".=el grupo "%0" se ha eliminado.
 
-Removed_group_"%0"_and_its_subgroups.=Se_ha_eliminado_el_grupo_"%0"_y_sus_subgrupos.
+Removed\ group\ "%0"\ and\ its\ subgroups.=Se ha eliminado el grupo "%0" y sus subgrupos.
 
-Removed_string=Cadena_eliminada
+Removed\ string=Cadena eliminada
 
-Renamed_string=Cadena_renombrada
+Renamed\ string=Cadena renombrada
 
 Replace=
 
-Replace_(regular_expression)=Reemplazar_(Expresión_regular)
+Replace\ (regular\ expression)=Reemplazar (Expresión regular)
 
-Replace_string=Reemplazar_cadena
+Replace\ string=Reemplazar cadena
 
-Replace_with=Reemplazar_con
+Replace\ with=Reemplazar con
 
 Replaced=Reemplazado
 
-Required_fields=Campos_requeridos
+Required\ fields=Campos requeridos
 
-Reset_all=Restablecer_todos
+Reset\ all=Restablecer todos
 
-Resolve_strings_for_all_fields_except=Resolver_cadenas_para_todos_los_campos_excepto
-Resolve_strings_for_standard_BibTeX_fields_only=Resolver_cadenas_únicamente_para_los_campos_BibTeX_estándar
+Resolve\ strings\ for\ all\ fields\ except=Resolver cadenas para todos los campos excepto
+Resolve\ strings\ for\ standard\ BibTeX\ fields\ only=Resolver cadenas únicamente para los campos BibTeX estándar
 
 resolved=resuelto
 
 Review=Revisar
 
-Review_changes=Revisar_cambios
+Review\ changes=Revisar cambios
 
 Right=Derecha
 
 Save=Guardar
-Save_all_finished.=Guardar_todos_los_finalizados
+Save\ all\ finished.=Guardar todos los finalizados
 
-Save_all_open_libraries=Guardar_todas_las_bibliotecas_abiertas
+Save\ all\ open\ libraries=Guardar todas las bibliotecas abiertas
 
-Save_before_closing=Guardar_antres_de_cerrar
+Save\ before\ closing=Guardar antres de cerrar
 
-Save_library=Guardar_biblioteca
-Save_library_as...=Guardar_biblioteca_como...
+Save\ library=Guardar biblioteca
+Save\ library\ as...=Guardar biblioteca como...
 
-Save_entries_in_their_original_order=Guardar_entradas_en_el_orden_original
+Save\ entries\ in\ their\ original\ order=Guardar entradas en el orden original
 
-Save_failed=Fallón_el_guardado
+Save\ failed=Fallón el guardado
 
-Save_failed_during_backup_creation=Error_durante_el_guardado_mientras_se_creaba_la_copia_de_seguridad
+Save\ failed\ during\ backup\ creation=Error durante el guardado mientras se creaba la copia de seguridad
 
-Save_selected_as...=Guardar_seleccionado_como...
+Save\ selected\ as...=Guardar seleccionado como...
 
-Saved_library=Biblioteca_guardada
+Saved\ library=Biblioteca guardada
 
-Saved_selected_to_'%0'.=Guardar_seleccionados_a_'%0'.
+Saved\ selected\ to\ '%0'.=Guardar seleccionados a '%0'.
 
 Saving=Guardando
-Saving_all_libraries...=Guardando_todas_las_bibliotecas...
+Saving\ all\ libraries...=Guardando todas las bibliotecas...
 
-Saving_library=Guardando_biblioteca
+Saving\ library=Guardando biblioteca
 
 Search=Buscar
 
-Search_expression=Buscar_expresión
+Search\ expression=Buscar expresión
 
-Search_for=Buscar
+Search\ for=Buscar
 
-Searching_for_duplicates...=Buscando_duplicados...
+Searching\ for\ duplicates...=Buscando duplicados...
 
-Searching_for_files=Buscando_archivos
+Searching\ for\ files=Buscando archivos
 
-Secondary_sort_criterion=Criterio_secundario_de_ordenación
+Secondary\ sort\ criterion=Criterio secundario de ordenación
 
-Select_all=Seleccionar_todo
+Select\ all=Seleccionar todo
 
-Select_encoding=Seleccionar_codificación
+Select\ encoding=Seleccionar codificación
 
-Select_entry_type=Seleccionar_tipo_de_entrada
-Select_external_application=Seleccionar_aplicación_externa
+Select\ entry\ type=Seleccionar tipo de entrada
+Select\ external\ application=Seleccionar aplicación externa
 
-Select_file_from_ZIP-archive=Seleccionar_archivo_desde_archivo_ZIP
+Select\ file\ from\ ZIP-archive=Seleccionar archivo desde archivo ZIP
 
-Select_the_tree_nodes_to_view_and_accept_or_reject_changes=Seleccionar_nodos_de_árbol_para_ver_y_aceptar_o_rechazar_los_cambios.
-Selected_entries=Entradas_seleccionadas
-Set_field=Establecer_campo
-Set_fields=Establecer_campos
+Select\ the\ tree\ nodes\ to\ view\ and\ accept\ or\ reject\ changes=Seleccionar nodos de árbol para ver y aceptar o rechazar los cambios.
+Selected\ entries=Entradas seleccionadas
+Set\ field=Establecer campo
+Set\ fields=Establecer campos
 
-Set_general_fields=Establecer_campos_generales
-Set_main_external_file_directory=Establecer_carpeta_de_archivo_externo_principal
+Set\ general\ fields=Establecer campos generales
+Set\ main\ external\ file\ directory=Establecer carpeta de archivo externo principal
 
-Set_table_font=Establecer_tipo_dera_para_las_tablas
+Set\ table\ font=Establecer tipo dera para las tablas
 
 Settings=Ajustes
 
 Shortcut=Atajo
 
-Show/edit_%0_source=Mostrar/editar_fuente_%0
+Show/edit\ %0\ source=Mostrar/editar fuente %0
 
-Show_'Firstname_Lastname'=Mostrar_'Nombre_Apellido'
+Show\ 'Firstname\ Lastname'=Mostrar 'Nombre Apellido'
 
-Show_'Lastname,_Firstname'=Mostrar_'Apellido,_Nombre'
+Show\ 'Lastname,\ Firstname'=Mostrar 'Apellido, Nombre'
 
-Show_BibTeX_source_by_default=Mostrar_fuente_BibTeX_por_defecto
+Show\ BibTeX\ source\ by\ default=Mostrar fuente BibTeX por defecto
 
-Show_confirmation_dialog_when_deleting_entries=Mostra_diálogo_de_confirmación_al_borrar_entradas
+Show\ confirmation\ dialog\ when\ deleting\ entries=Mostra diálogo de confirmación al borrar entradas
 
-Show_description=Mostrar_descripción
+Show\ description=Mostrar descripción
 
-Show_file_column=Mostrar_columna_de_archivo
+Show\ file\ column=Mostrar columna de archivo
 
-Show_last_names_only=Mostrar_sólo_apellidos
+Show\ last\ names\ only=Mostrar sólo apellidos
 
-Show_names_unchanged=Mostrar_nombres_sin_cambios
+Show\ names\ unchanged=Mostrar nombres sin cambios
 
-Show_optional_fields=Mostrar_campos_opcionales
+Show\ optional\ fields=Mostrar campos opcionales
 
-Show_required_fields=Mostrar_campos_requeridos
+Show\ required\ fields=Mostrar campos requeridos
 
-Show_URL/DOI_column=Mostrar_columna_URL/DOI
+Show\ URL/DOI\ column=Mostrar columna URL/DOI
 
-Simple_HTML=HTML_sencillo
+Simple\ HTML=HTML sencillo
 
 Size=Tamaño
 
-Skipped_-_No_PDF_linked=Omitido_-_No_se_enlazó_PDF
-Skipped_-_PDF_does_not_exist=Omitido_-_No_existe_el_PDF
+Skipped\ -\ No\ PDF\ linked=Omitido - No se enlazó PDF
+Skipped\ -\ PDF\ does\ not\ exist=Omitido - No existe el PDF
 
-Skipped_entry.=Entrada_omitida.
+Skipped\ entry.=Entrada omitida.
 
-Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.=
+Some\ appearance\ settings\ you\ changed\ require\ to\ restart\ JabRef\ to\ come\ into\ effect.=
 
-source_edit=editar_fuente
-Special_name_formatters=Formateadores_con_nombre_especial
+source\ edit=editar fuente
+Special\ name\ formatters=Formateadores con nombre especial
 
-Special_table_columns=Columna_de_tabla_especiales
+Special\ table\ columns=Columna de tabla especiales
 
-Starting_import=Comenzando_a_importar
+Starting\ import=Comenzando a importar
 
-Statically_group_entries_by_manual_assignment=Agrupar_entradas_estadísticamente_mediante_asgnación_manual
+Statically\ group\ entries\ by\ manual\ assignment=Agrupar entradas estadísticamente mediante asgnación manual
 
 Status=Estado
 
@@ -1143,1019 +1143,1019 @@ Stop=Parar
 
 Strings=Cadenas
 
-Strings_for_library=Cadenas_para_biblioteca
+Strings\ for\ library=Cadenas para biblioteca
 
-Sublibrary_from_AUX=Biblioteca_secundaria_desde_AUX
+Sublibrary\ from\ AUX=Biblioteca secundaria desde AUX
 
-Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.=Cambia_entre_nombre_completo_y_abreviatura_de_la_revista_si_se_conoce_en_nombe_de_la_revista.
+Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=Cambia entre nombre completo y abreviatura de la revista si se conoce en nombe de la revista.
 
-Synchronize_file_links=Sincronizar_enlaces_de_archivo
+Synchronize\ file\ links=Sincronizar enlaces de archivo
 
-Synchronizing_file_links...=Sincronizando_archivo_enlaces...
+Synchronizing\ file\ links...=Sincronizando archivo enlaces...
 
-Table_appearance=Aspecto_de_la_tabla
+Table\ appearance=Aspecto de la tabla
 
-Table_background_color=Color_de_fondo_de_la_tabla
+Table\ background\ color=Color de fondo de la tabla
 
-Table_grid_color=Color_de_las_líneas_de_la_tabla
+Table\ grid\ color=Color de las líneas de la tabla
 
-Table_text_color=Color_del_texto_de_la_tabla
+Table\ text\ color=Color del texto de la tabla
 
-Tabname=Nombre_de_pestaña
-Target_file_cannot_be_a_directory.=El_archivo_de_destino_no_puede_ser_una_carpeta.
+Tabname=Nombre de pestaña
+Target\ file\ cannot\ be\ a\ directory.=El archivo de destino no puede ser una carpeta.
 
-Tertiary_sort_criterion=Criterio_de_ordenación_terciario
+Tertiary\ sort\ criterion=Criterio de ordenación terciario
 
 Test=Prueba
 
-paste_text_here=Área_de_entrada_de_texto
+paste\ text\ here=Área de entrada de texto
 
-The_chosen_date_format_for_new_entries_is_not_valid=El_forma-to_de_fecha_escogido_para_nuevas_entradas_no_es_correcto
+The\ chosen\ date\ format\ for\ new\ entries\ is\ not\ valid=El forma-to de fecha escogido para nuevas entradas no es correcto
 
-The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:=La_codificación_de_caracteres_'%'_no_puede_codificar_los_siguientes_caracteres\:
+The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=La codificación de caracteres '%' no puede codificar los siguientes caracteres:
 
 
-the_field_<b>%0</b>=el_campo_<b>%0</b>
+the\ field\ <b>%0</b>=el campo <b>%0</b>
 
-The_file<BR>'%0'<BR>has_been_modified<BR>externally\!=¡El_archivo<BR>'%0'<BR>ha_sido_modificado<BR>_externamente\!
+The\ file<BR>'%0'<BR>has\ been\ modified<BR>externally\!=¡El archivo<BR>'%0'<BR>ha sido modificado<BR> externamente!
 
-The_group_"%0"_already_contains_the_selection.=El_grupo_"%0"_ya_contiene_la_selección.
+The\ group\ "%0"\ already\ contains\ the\ selection.=El grupo "%0" ya contiene la selección.
 
-The_label_of_the_string_cannot_be_a_number.=La_etiqueta_de_la_cadena_no_puede_ser_un_número.
+The\ label\ of\ the\ string\ cannot\ be\ a\ number.=La etiqueta de la cadena no puede ser un número.
 
-The_label_of_the_string_cannot_contain_spaces.=La_etiqueta_de_la_cadena_no_puede_contener_espacios.
+The\ label\ of\ the\ string\ cannot\ contain\ spaces.=La etiqueta de la cadena no puede contener espacios.
 
-The_label_of_the_string_cannot_contain_the_'\#'_character.=La_etiqueta_de_la_cadena_no_puede_contener_el_caracter_'\#'.
+The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=La etiqueta de la cadena no puede contener el caracter '#'.
 
-The_output_option_depends_on_a_valid_import_option.=La_opción_de_salida_depende_de_una_opción_de_importación_válida.
-The_PDF_contains_one_or_several_BibTeX-records.=El_PDF_contiene_uno_o_más_registros_BibTeX.
-Do_you_want_to_import_these_as_new_entries_into_the_current_library?=¿Desea_importarlos_como_nuevas_entradas_en_la_biblioteca_actual?
+The\ output\ option\ depends\ on\ a\ valid\ import\ option.=La opción de salida depende de una opción de importación válida.
+The\ PDF\ contains\ one\ or\ several\ BibTeX-records.=El PDF contiene uno o más registros BibTeX.
+Do\ you\ want\ to\ import\ these\ as\ new\ entries\ into\ the\ current\ library?=¿Desea importarlos como nuevas entradas en la biblioteca actual?
 
-The_regular_expression_<b>%0</b>_is_invalid\:=La_expresión_regular_<b>%0</b>_no_es_válida\:
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=La expresión regular <b>%0</b> no es válida:
 
-The_search_is_case_insensitive.=La_búsqueda_no_distingue_mayúsculas/minúsculas
+The\ search\ is\ case\ insensitive.=La búsqueda no distingue mayúsculas/minúsculas
 
-The_search_is_case_sensitive.=La_búsqueda_distingue_mayúsculas/minúsculas
+The\ search\ is\ case\ sensitive.=La búsqueda distingue mayúsculas/minúsculas
 
-The_string_has_been_removed_locally=La_cadena_ha_sido_eliminada_localmente
+The\ string\ has\ been\ removed\ locally=La cadena ha sido eliminada localmente
 
-There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?=Hay_posibles_duplicados_(marcados_con_el_icono)_que_no_han_sido_resueltos._¿Continuar?
+There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=Hay posibles duplicados (marcados con el icono) que no han sido resueltos. ¿Continuar?
 
-This_entry_has_no_BibTeX_key._Generate_key_now?=Esta_entrada_no_tiene_clave_BibTeX._¿Generar_ahora?
+This\ entry\ has\ no\ BibTeX\ key.\ Generate\ key\ now?=Esta entrada no tiene clave BibTeX. ¿Generar ahora?
 
-This_entry_is_incomplete=Esta_entrada_está_incompleta¡u+
+This\ entry\ is\ incomplete=Esta entrada está incompleta¡u+
 
-This_entry_type_cannot_be_removed.=Este_tipo_de_entrada_no_puede_ser_eliminada.
+This\ entry\ type\ cannot\ be\ removed.=Este tipo de entrada no puede ser eliminada.
 
-This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=El_enlace_externo_es_del_tipo_'%0',_que_no_está_definido._¿Qué_desea_hacer?
+This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=El enlace externo es del tipo '%0', que no está definido. ¿Qué desea hacer?
 
-This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.=Este_grupo_contiene_entradas_basadas_en_asignación_manual._Las_entradas_pueden_ser_asignadas_a_este_grupo_seleccionándolas_usando_el_menú_contextual_o_bien_mediante_arrastrar-soltar._Las_entradas_pueden_ser_eliminadas_de_este_grupo_seleccionándolas_y_luego_usando_el_menú_contextual.
+This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=Este grupo contiene entradas basadas en asignación manual. Las entradas pueden ser asignadas a este grupo seleccionándolas usando el menú contextual o bien mediante arrastrar-soltar. Las entradas pueden ser eliminadas de este grupo seleccionándolas y luego usando el menú contextual.
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>=Este_grupo_contiene_entradas_cuyo_campo_<b>%0</b>_contiene_la_palabra_clave_<b>%1</b>_
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Este grupo contiene entradas cuyo campo <b>%0</b> contiene la palabra clave <b>%1</b> 
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>=Este_grupo_contiene_entradas_cuyo_campo_<b>%0</b>_contiene_la<_expresión_regular_<b>%1</b>_
-This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.=JabRef_inspeccionará_cada_enlace_archivo_y_comprobará_si_el_archivo_existe._En_caso_contrario,_se_le_ofrecerán_opciones_<BR>_para_solucionar_el_problema.
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Este grupo contiene entradas cuyo campo <b>%0</b> contiene la< expresión regular <b>%1</b> 
+This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=JabRef inspeccionará cada enlace archivo y comprobará si el archivo existe. En caso contrario, se le ofrecerán opciones <BR> para solucionar el problema.
 
-This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.=Esta_operación_requiere_que_todas_las_entradas_seleccionadas_tengan_claves_BibTeX_definidas.
+This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=Esta operación requiere que todas las entradas seleccionadas tengan claves BibTeX definidas.
 
-This_operation_requires_one_or_more_entries_to_be_selected.=Esta_operación_requiere_seleccionar_una_o_más_entradas.
+This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=Esta operación requiere seleccionar una o más entradas.
 
-Toggle_entry_preview=Usar_vista_previa_de_la_entrada_si/no
-Toggle_groups_interface=Usar_interfaz_de_grupos_si/no
-Try_different_encoding=Probar_una_codificación_diferente
+Toggle\ entry\ preview=Usar vista previa de la entrada si/no
+Toggle\ groups\ interface=Usar interfaz de grupos si/no
+Try\ different\ encoding=Probar una codificación diferente
 
-Unabbreviate_journal_names_of_the_selected_entries=Desabreviar_nombre_de_revista_de_las_entradas_seleccionadas
-Unabbreviated_%0_journal_names.=%0_nombres_de_revista_desabreviados
+Unabbreviate\ journal\ names\ of\ the\ selected\ entries=Desabreviar nombre de revista de las entradas seleccionadas
+Unabbreviated\ %0\ journal\ names.=%0 nombres de revista desabreviados
 
-Unable_to_open_file.=No_se_puede_abrir_el_archivo
-Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.=No_se_puede_abrir_el_enlace._La_aplicación_'%'_asociada_con_el_tipo_de_archivo_'%1'_no_puede_ser_lanzada.
-unable_to_write_to=no_se_puede_escribir_en
-Undefined_file_type=Tipo_de_archivo_no_definido
+Unable\ to\ open\ file.=No se puede abrir el archivo
+Unable\ to\ open\ link.\ The\ application\ '%0'\ associated\ with\ the\ file\ type\ '%1'\ could\ not\ be\ called.=No se puede abrir el enlace. La aplicación '%' asociada con el tipo de archivo '%1' no puede ser lanzada.
+unable\ to\ write\ to=no se puede escribir en
+Undefined\ file\ type=Tipo de archivo no definido
 
 Undo=Deshacer
 
 Union=Unión
 
-Unknown_BibTeX_entries=Entradas_BibTeX_desconocidas
+Unknown\ BibTeX\ entries=Entradas BibTeX desconocidas
 
-unknown_edit=edición_desconocida
+unknown\ edit=edición desconocida
 
-Unknown_export_format=Formato_de_exportación_desconocido
+Unknown\ export\ format=Formato de exportación desconocido
 
-Unmark_all=Desmarcar_todos
+Unmark\ all=Desmarcar todos
 
-Unmark_entries=Desmarcar_entradas
+Unmark\ entries=Desmarcar entradas
 
-Unmark_entry=Desmarcar_entrada
+Unmark\ entry=Desmarcar entrada
 
-untitled=sin_título
+untitled=sin título
 
 Up=Arriba
 
-Update_to_current_column_widths=Actualizar_a_anchos_de_columna_actuales
+Update\ to\ current\ column\ widths=Actualizar a anchos de columna actuales
 
-Updated_group_selection=Actualizar_selección_de_grupo
-Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.=Actualizar_enlaces_a_PDF/PS_externos_para_usar_el_campo_'%0'.
-Upgrade_file=Actualizar_archivo
-Upgrade_old_external_file_links_to_use_the_new_feature=Actualizar_enlaces_a_archivos_externos_para_usar_la_nueva_característica.
+Updated\ group\ selection=Actualizar selección de grupo
+Upgrade\ external\ PDF/PS\ links\ to\ use\ the\ '%0'\ field.=Actualizar enlaces a PDF/PS externos para usar el campo '%0'.
+Upgrade\ file=Actualizar archivo
+Upgrade\ old\ external\ file\ links\ to\ use\ the\ new\ feature=Actualizar enlaces a archivos externos para usar la nueva característica.
 
 usage=Uso
-Use_autocompletion_for_the_following_fields=Usar_autocompletar_para_los_siguientes_campos
+Use\ autocompletion\ for\ the\ following\ fields=Usar autocompletar para los siguientes campos
 
-Use_other_look_and_feel=Usar_otro_aspecto
-Tweak_font_rendering_for_entry_editor_on_Linux=
-Use_regular_expression_search=Usar_búsqueda_de_expresión_regular
+Use\ other\ look\ and\ feel=Usar otro aspecto
+Tweak\ font\ rendering\ for\ entry\ editor\ on\ Linux=
+Use\ regular\ expression\ search=Usar búsqueda de expresión regular
 
-Username=Nombre_de_usuario
+Username=Nombre de usuario
 
-Value_cleared_externally=Valor_limpiado_externamente
+Value\ cleared\ externally=Valor limpiado externamente
 
-Value_set_externally=Valor_establecido_externamente
+Value\ set\ externally=Valor establecido externamente
 
-verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid=virificar_que_LyX_está_funcionando_y_que_lyxpipe_es_válido
+verify\ that\ LyX\ is\ running\ and\ that\ the\ lyxpipe\ is\ valid=virificar que LyX está funcionando y que lyxpipe es válido
 
 View=Ver
-Vim_server_name=Nombre_de_servidor_Vim
+Vim\ server\ name=Nombre de servidor Vim
 
-Waiting_for_ArXiv...=Esperando_a_ArXiv
+Waiting\ for\ ArXiv...=Esperando a ArXiv
 
-Warn_about_unresolved_duplicates_when_closing_inspection_window=Advertir_sobre_duplicados_sin_resolver_cuando_al_cerrar_la_ventana_de_inspección
+Warn\ about\ unresolved\ duplicates\ when\ closing\ inspection\ window=Advertir sobre duplicados sin resolver cuando al cerrar la ventana de inspección
 
-Warn_before_overwriting_existing_keys=Advertir_antes_de_sobreescribir_claves_existentes
+Warn\ before\ overwriting\ existing\ keys=Advertir antes de sobreescribir claves existentes
 
 Warning=Advertencia
 
 Warnings=Advertencias
 
-web_link=enlace_a_web
+web\ link=enlace a web
 
-What_do_you_want_to_do?=¿Qué_desea_hacer?
+What\ do\ you\ want\ to\ do?=¿Qué desea hacer?
 
-When_adding/removing_keywords,_separate_them_by=Cuando_se_eliminen/añadan_palabras_clave,_separar_por
-Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.=Escribirá_metadatos_XMP_a_los_PDF's_enlazados_desde_las_entradas_seleccionadas.
+When\ adding/removing\ keywords,\ separate\ them\ by=Cuando se eliminen/añadan palabras clave, separar por
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Escribirá metadatos XMP a los PDF's enlazados desde las entradas seleccionadas.
 
 with=con
 
-Write_BibTeXEntry_as_XMP-metadata_to_PDF.=Escribir_entrada_BibTeX_como_metadatos_XMP_al_PDF.
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Escribir entrada BibTeX como metadatos XMP al PDF.
 
-Write_XMP=Escribir_XMP
-Write_XMP-metadata=Escribir_metadatos_XMP
-Write_XMP-metadata_for_all_PDFs_in_current_library?=¿Escribir_metadatos_XMP_para_todos_los_PDF_en_la_biblioteca_actual?
-Writing_XMP-metadata...=Escribiendo_metadatos_XMP
-Writing_XMP-metadata_for_selected_entries...=Escribiendo_metadatos_XMP_para_las_entradas_seleccionadas...
+Write\ XMP=Escribir XMP
+Write\ XMP-metadata=Escribir metadatos XMP
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=¿Escribir metadatos XMP para todos los PDF en la biblioteca actual?
+Writing\ XMP-metadata...=Escribiendo metadatos XMP
+Writing\ XMP-metadata\ for\ selected\ entries...=Escribiendo metadatos XMP para las entradas seleccionadas...
 
-Wrote_XMP-metadata=Se_han_escrito_los_metadatos_XMP
+Wrote\ XMP-metadata=Se han escrito los metadatos XMP
 
-XMP-annotated_PDF=PDF_con_anotaciones_XMP
-XMP_export_privacy_settings=Ajustes_de_privacidad_en_exportación_XMP
-XMP-metadata=Metadatos_XMP
-XMP-metadata_found_in_PDF\:_%0=Metadatos_XMP_encontrados_en_PDF\:_'%0'
-You_must_restart_JabRef_for_this_to_come_into_effect.=Debe_reiniciar_JabRef_para_que_los_cambios_surtan_efecto.
-You_have_changed_the_language_setting.=Ha_cambiado_el_ajuste_de_lenguaje.
-You_have_entered_an_invalid_search_'%0'.=Ha_introducido_una_búsqueda_inválida_'%0'
+XMP-annotated\ PDF=PDF con anotaciones XMP
+XMP\ export\ privacy\ settings=Ajustes de privacidad en exportación XMP
+XMP-metadata=Metadatos XMP
+XMP-metadata\ found\ in\ PDF\:\ %0=Metadatos XMP encontrados en PDF: '%0'
+You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Debe reiniciar JabRef para que los cambios surtan efecto.
+You\ have\ changed\ the\ language\ setting.=Ha cambiado el ajuste de lenguaje.
+You\ have\ entered\ an\ invalid\ search\ '%0'.=Ha introducido una búsqueda inválida '%0'
 
-You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.=Debe_reiniciar_JabRef_para_que_las_nuevas_combinaciones_de_teclas_funcionen_correctamente.
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Debe reiniciar JabRef para que las nuevas combinaciones de teclas funcionen correctamente.
 
-Your_new_key_bindings_have_been_stored.=Sus_nuevas_combinaciones_de_teclas_han_sido_almacenadas.
+Your\ new\ key\ bindings\ have\ been\ stored.=Sus nuevas combinaciones de teclas han sido almacenadas.
 
-The_following_fetchers_are_available\:=Están_disponibles_los_siguientes_recuperadores_de_datos\:
-Could_not_find_fetcher_'%0'=No_se_puede_encontrar_el_recuperador_de_datos_'%0'
-Running_query_'%0'_with_fetcher_'%1'.=Ejecutando_consulta_'%0'_con_recuperador_'%1'
-Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.=La_consulta_'%0'_con_el_recuperador_¡%1'_no_devolvió_ningún_resultado.
+The\ following\ fetchers\ are\ available\:=Están disponibles los siguientes recuperadores de datos:
+Could\ not\ find\ fetcher\ '%0'=No se puede encontrar el recuperador de datos '%0'
+Running\ query\ '%0'\ with\ fetcher\ '%1'.=Ejecutando consulta '%0' con recuperador '%1'
+Query\ '%0'\ with\ fetcher\ '%1'\ did\ not\ return\ any\ results.=La consulta '%0' con el recuperador ¡%1' no devolvió ningún resultado.
 
-Move_file=Mover_archivo
-Rename_file=renombrar_archivo
+Move\ file=Mover archivo
+Rename\ file=renombrar archivo
 
-Move_file_failed=Error_al_mover_de_archivos
-Could_not_move_file_'%0'.=No_se_puede_mover_el_archivo_'%0'.
-Could_not_find_file_'%0'.=No_se_encuentra_el_archivo_'%0'.
-Number_of_entries_successfully_imported=Número_de_entradas_importadas_con_éxito
-Import_canceled_by_user=Importación_cancelada_por_el_usuario
-Progress\:_%0_of_%1=Progreso\:_%0_de_%1
-Error_while_fetching_from_%0=Error_al_recuperar_desde_%0
+Move\ file\ failed=Error al mover de archivos
+Could\ not\ move\ file\ '%0'.=No se puede mover el archivo '%0'.
+Could\ not\ find\ file\ '%0'.=No se encuentra el archivo '%0'.
+Number\ of\ entries\ successfully\ imported=Número de entradas importadas con éxito
+Import\ canceled\ by\ user=Importación cancelada por el usuario
+Progress\:\ %0\ of\ %1=Progreso: %0 de %1
+Error\ while\ fetching\ from\ %0=Error al recuperar desde %0
 
-Please_enter_a_valid_number=Por_favor,_introduzca_un_número_válido
-Show_search_results_in_a_window=Mostrar_los_resultados_de_la_búsqueda_en_una_ventana
-Show_global_search_results_in_a_window=Mostrar_resultados_de_búsqueda_global_en_una_ventana
-Search_in_all_open_libraries=Buscar_en_todos_los_archivos_abiertos
-Move_file_to_file_directory?=¿Mover_archivo_a_la_carpeta_de_archivos?
+Please\ enter\ a\ valid\ number=Por favor, introduzca un número válido
+Show\ search\ results\ in\ a\ window=Mostrar los resultados de la búsqueda en una ventana
+Show\ global\ search\ results\ in\ a\ window=Mostrar resultados de búsqueda global en una ventana
+Search\ in\ all\ open\ libraries=Buscar en todos los archivos abiertos
+Move\ file\ to\ file\ directory?=¿Mover archivo a la carpeta de archivos?
 
-Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.=La_biblioteca_está_protegida._No_se_puede_guardar_hasta_que_los_cambios_externos_hayan_sido_revisados.
-Protected_library=Biblioteca_protegida
-Refuse_to_save_the_library_before_external_changes_have_been_reviewed.=Rechazar_guadar_la_biblioteca_antes_qde_que_los_cambios_externos_hayan_sido_revisado.
-Library_protection=Proteccion_de_la_biblioteca
-Unable_to_save_library=No_es_posible_guardar_la_biblioteca
+Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=La biblioteca está protegida. No se puede guardar hasta que los cambios externos hayan sido revisados.
+Protected\ library=Biblioteca protegida
+Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=Rechazar guadar la biblioteca antes qde que los cambios externos hayan sido revisado.
+Library\ protection=Proteccion de la biblioteca
+Unable\ to\ save\ library=No es posible guardar la biblioteca
 
-BibTeX_key_generator=Generador_de_claves_BibTeX
-Unable_to_open_link.=No_es_posible_abrir_el_enlace.
-Move_the_keyboard_focus_to_the_entry_table=Mover_el_foco_del_teclado_a_la_tabla_de_entradas
-MIME_type=Tipo_MIME
+BibTeX\ key\ generator=Generador de claves BibTeX
+Unable\ to\ open\ link.=No es posible abrir el enlace.
+Move\ the\ keyboard\ focus\ to\ the\ entry\ table=Mover el foco del teclado a la tabla de entradas
+MIME\ type=Tipo MIME
 
-This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.=Esta_función_permite_que_nuevos_archivos_seasn_abiertos_o_importados_en_una_instancia_de_JabRef_que_ya_se_esté_ejecutando,<BR>en_lugar_de_abrir_una_nueva_instancia._Esto_es_útil,_por_ejemplo,_cuando_se_abre_un_archivo_en_JabRef_desde_<br>_el_navegador_de_internet.<BR>_Tenga_en_cuenta_que_esto_le_impedirá_ejecutar_más_de_una_instancia_de_JabRef_a_la_vez.
-Run_fetcher,_e.g._"--fetch\=Medline\:cancer"=Ejecutar_recuperador,_por_ejemplo_"--fetch=Medline\:cancer"
+This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef<BR>instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef<br>from\ your\ web\ browser.<BR>Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=Esta función permite que nuevos archivos seasn abiertos o importados en una instancia de JabRef que ya se esté ejecutando,<BR>en lugar de abrir una nueva instancia. Esto es útil, por ejemplo, cuando se abre un archivo en JabRef desde <br> el navegador de internet.<BR> Tenga en cuenta que esto le impedirá ejecutar más de una instancia de JabRef a la vez.
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=Ejecutar recuperador, por ejemplo "--fetch=Medline:cancer"
 
-The_ACM_Digital_Library=La_Biblioteca_Digital_ACM
+The\ ACM\ Digital\ Library=La Biblioteca Digital ACM
 Reset=Restablecer
 
-Use_IEEE_LaTeX_abbreviations=Usar_abreviaturas_LaTeX_IEEE
-The_Guide_to_Computing_Literature=The_Guide_to_Computing_Literature
+Use\ IEEE\ LaTeX\ abbreviations=Usar abreviaturas LaTeX IEEE
+The\ Guide\ to\ Computing\ Literature=The Guide to Computing Literature
 
-When_opening_file_link,_search_for_matching_file_if_no_link_is_defined=Al_abrir_el_enlace_al_archivo,_buscar_por_archivo_coincidente_si_no_hay_enlace_definido
-Settings_for_%0=Ajustes_para_%0
-Mark_entries_imported_into_an_existing_library=Marcar_entradas_importadas_en_una_biblioteca_existente
-Unmark_all_entries_before_importing_new_entries_into_an_existing_library=Desmarcar_todas_las_entradas_antes_de_importar_nuevas_entradas_en_una_biblioteca_existente
+When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=Al abrir el enlace al archivo, buscar por archivo coincidente si no hay enlace definido
+Settings\ for\ %0=Ajustes para %0
+Mark\ entries\ imported\ into\ an\ existing\ library=Marcar entradas importadas en una biblioteca existente
+Unmark\ all\ entries\ before\ importing\ new\ entries\ into\ an\ existing\ library=Desmarcar todas las entradas antes de importar nuevas entradas en una biblioteca existente
 
 Forward=Adelante
 Back=Atrás
-Sort_the_following_fields_as_numeric_fields=Ordenar_los_siguientes_campos_como_campos_numéricos
-Line_%0\:_Found_corrupted_BibTeX_key.=Línea_%0\:_Se_ha_encontrado_una_clave_BibTeX_corrupta.
-Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).=Línea_%0\:_Se_ha_encontrado_una_clave_BibTeX_corrupta_(contiene_espacios_en_blanco)
-Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).=Línea_%0\:_Se_ha_encontrado_clave_BibTeX_corrupta_(falta_coma).
-Full_text_document_download_failed=Falló_la_descarga_del_texto_completo_del_artículo
-Update_to_current_column_order=Actualizar_al_orden_de_columnas_actual
-Download_from_URL=Descargar_desde_URL
-Rename_field=Renombrar_campo
-Set/clear/append/rename_fields=Establecer/limpiar/renombrar_campos
-Append_field=
-Append_to_fields=
-Rename_field_to=Renombrar_campo_a
-Move_contents_of_a_field_into_a_field_with_a_different_name=Mover_contenidos_de_un_campo_en_un_campo_con_nombre_diferente
-You_can_only_rename_one_field_at_a_time=Sólo_puede_renombrar_un_campo_a_la_vez
+Sort\ the\ following\ fields\ as\ numeric\ fields=Ordenar los siguientes campos como campos numéricos
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=Línea %0: Se ha encontrado una clave BibTeX corrupta.
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=Línea %0: Se ha encontrado una clave BibTeX corrupta (contiene espacios en blanco)
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=Línea %0: Se ha encontrado clave BibTeX corrupta (falta coma).
+Full\ text\ document\ download\ failed=Falló la descarga del texto completo del artículo
+Update\ to\ current\ column\ order=Actualizar al orden de columnas actual
+Download\ from\ URL=Descargar desde URL
+Rename\ field=Renombrar campo
+Set/clear/append/rename\ fields=Establecer/limpiar/renombrar campos
+Append\ field=
+Append\ to\ fields=
+Rename\ field\ to=Renombrar campo a
+Move\ contents\ of\ a\ field\ into\ a\ field\ with\ a\ different\ name=Mover contenidos de un campo en un campo con nombre diferente
+You\ can\ only\ rename\ one\ field\ at\ a\ time=Sólo puede renombrar un campo a la vez
 
-Remove_all_broken_links=Eliminar_todos_los_enlaces_rotos
+Remove\ all\ broken\ links=Eliminar todos los enlaces rotos
 
-Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.=No_se_puede_usar_el_puerto_%0_para_operación_remota\:_Puede_estar_en_uso_por_otra_aplicación._Pruebe_a_especificar_otro_puerto.
+Cannot\ use\ port\ %0\ for\ remote\ operation;\ another\ application\ may\ be\ using\ it.\ Try\ specifying\ another\ port.=No se puede usar el puerto %0 para operación remota: Puede estar en uso por otra aplicación. Pruebe a especificar otro puerto.
 
-Looking_for_full_text_document...=Buscando_texto_completo_de_documento...
+Looking\ for\ full\ text\ document...=Buscando texto completo de documento...
 Autosave=Autoguardado
-A_local_copy_will_be_opened.=Se_abrirá_una_copia_local
-Autosave_local_libraries=Autoguardado_de_biblitecas_locales
-Automatically_save_the_library_to=Guardar_la_biblioteca_automáticamente_en
-Please_enter_a_valid_file_path.=Por_favor,_introduzca_una_ruta_de_archivo_válida
+A\ local\ copy\ will\ be\ opened.=Se abrirá una copia local
+Autosave\ local\ libraries=Autoguardado de biblitecas locales
+Automatically\ save\ the\ library\ to=Guardar la biblioteca automáticamente en
+Please\ enter\ a\ valid\ file\ path.=Por favor, introduzca una ruta de archivo válida
 
 
-Export_in_current_table_sort_order=Exportar_con_el_criterio_de_ordenación_actual
-Export_entries_in_their_original_order=Exportar_entradas_en_su_orden_original
-Error_opening_file_'%0'.=Error_abriendo_el_archivo_'%0'.
+Export\ in\ current\ table\ sort\ order=Exportar con el criterio de ordenación actual
+Export\ entries\ in\ their\ original\ order=Exportar entradas en su orden original
+Error\ opening\ file\ '%0'.=Error abriendo el archivo '%0'.
 
-Formatter_not_found\:_%0=Formateador_no_encontrado\:_%0
-Clear_inputarea=Limpiar_área_de_entrada
+Formatter\ not\ found\:\ %0=Formateador no encontrado: %0
+Clear\ inputarea=Limpiar área de entrada
 
-Automatically_set_file_links_for_this_entry=Ajustar_enlaces_de_archivo_automÃ¡ticamente_para_esta_entrada
-Could_not_save,_file_locked_by_another_JabRef_instance.=No_se_puede_guardar._Fichero_bloqueado_por_otra_instancia_JabRef.
-File_is_locked_by_another_JabRef_instance.=El_archivo_está_bloqueado_por_otra_instancia_de_JabRef.
-Do_you_want_to_override_the_file_lock?=¿Quiere_saltarse_el_bloqueo_de_archivo?
-File_locked=Archivo_bloqueado
-Current_tmp_value=Valor_temporal_actual
-Metadata_change=Cambio_de_metadatos
-Changes_have_been_made_to_the_following_metadata_elements=Se_han_efectuado_los_cambios_a_los_siguientes_elementos_de_los_metadatos
+Automatically\ set\ file\ links\ for\ this\ entry=Ajustar enlaces de archivo automÃ¡ticamente para esta entrada
+Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=No se puede guardar. Fichero bloqueado por otra instancia JabRef.
+File\ is\ locked\ by\ another\ JabRef\ instance.=El archivo está bloqueado por otra instancia de JabRef.
+Do\ you\ want\ to\ override\ the\ file\ lock?=¿Quiere saltarse el bloqueo de archivo?
+File\ locked=Archivo bloqueado
+Current\ tmp\ value=Valor temporal actual
+Metadata\ change=Cambio de metadatos
+Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=Se han efectuado los cambios a los siguientes elementos de los metadatos
 
-Generate_groups_for_author_last_names=Generar_grupos_para_apellidos_de_autor
-Generate_groups_from_keywords_in_a_BibTeX_field=Generar_grupos_desde_palabras_claves_de_un_campo_BibTeX
-Enforce_legal_characters_in_BibTeX_keys=Uso_obligado_de_caracteres_legales_en_claves_BibTeX
+Generate\ groups\ for\ author\ last\ names=Generar grupos para apellidos de autor
+Generate\ groups\ from\ keywords\ in\ a\ BibTeX\ field=Generar grupos desde palabras claves de un campo BibTeX
+Enforce\ legal\ characters\ in\ BibTeX\ keys=Uso obligado de caracteres legales en claves BibTeX
 
-Save_without_backup?=¿Guardar_sin_copia_de_seguridad?
-Unable_to_create_backup=No_es_posible_crear_la_copia_de_seguridad
-Move_file_to_file_directory=Mover_archivo_al_directorio_de_archivos
-Rename_file_to=Renombrar_archivo_a
-<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)=<b>Todas_las_entradas</b>_(este_grupo_no_puede_ser_editado_o_eliminado)
-static_group=grupo_estático
-dynamic_group=grupo_dinámico
-refines_supergroup=afina_supergrupo
-includes_subgroups=incluye_subgrupos
+Save\ without\ backup?=¿Guardar sin copia de seguridad?
+Unable\ to\ create\ backup=No es posible crear la copia de seguridad
+Move\ file\ to\ file\ directory=Mover archivo al directorio de archivos
+Rename\ file\ to=Renombrar archivo a
+<b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=<b>Todas las entradas</b> (este grupo no puede ser editado o eliminado)
+static\ group=grupo estático
+dynamic\ group=grupo dinámico
+refines\ supergroup=afina supergrupo
+includes\ subgroups=incluye subgrupos
 contains=contiene
-search_expression=expresión_de_búsqueda
+search\ expression=expresión de búsqueda
 
-Optional_fields_2=Campos_opcionales_2
-Waiting_for_save_operation_to_finish=Esperando_a_que_acabe_la_operación_de_guardado
-Resolving_duplicate_BibTeX_keys...=Resolviendo_claves_BibTeX_duplicadas...
-Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.=Resolución_de_claves_BibTeX_duplicadas_finalizada._%0_entradas_modificadas.
-This_library_contains_one_or_more_duplicated_BibTeX_keys.=Esta_biblioteca_contiene_una_o_más_claves_BibTeX_duplicadas.
-Do_you_want_to_resolve_duplicate_keys_now?=¿Quiere_resolver_las_claves_duplicadas_ahora?
+Optional\ fields\ 2=Campos opcionales 2
+Waiting\ for\ save\ operation\ to\ finish=Esperando a que acabe la operación de guardado
+Resolving\ duplicate\ BibTeX\ keys...=Resolviendo claves BibTeX duplicadas...
+Finished\ resolving\ duplicate\ BibTeX\ keys.\ %0\ entries\ modified.=Resolución de claves BibTeX duplicadas finalizada. %0 entradas modificadas.
+This\ library\ contains\ one\ or\ more\ duplicated\ BibTeX\ keys.=Esta biblioteca contiene una o más claves BibTeX duplicadas.
+Do\ you\ want\ to\ resolve\ duplicate\ keys\ now?=¿Quiere resolver las claves duplicadas ahora?
 
-Find_and_remove_duplicate_BibTeX_keys=Encontrar_y_eliminar_entradas_BibTeX_duplicadas
-Expected_syntax_for_--fetch\='<name_of_fetcher>\:<query>'=Sintaxis_esperada_para_--fetch='<nombre_del_recuperador>\:<consulta>'
-Duplicate_BibTeX_key=Clave_BibTeX_duplicada
-Import_marking_color=Importar_color_para_marcas
-Always_add_letter_(a,_b,_...)_to_generated_keys=Siempre_añadir_letra_(a,b,_...)_a_las_claves_generadas
+Find\ and\ remove\ duplicate\ BibTeX\ keys=Encontrar y eliminar entradas BibTeX duplicadas
+Expected\ syntax\ for\ --fetch\='<name\ of\ fetcher>\:<query>'=Sintaxis esperada para --fetch='<nombre del recuperador>:<consulta>'
+Duplicate\ BibTeX\ key=Clave BibTeX duplicada
+Import\ marking\ color=Importar color para marcas
+Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=Siempre añadir letra (a,b, ...) a las claves generadas
 
-Ensure_unique_keys_using_letters_(a,_b,_...)=Asegurar_unicidad_de_claves_usando_letras_(a,b,_...)
-Ensure_unique_keys_using_letters_(b,_c,_...)=Asegurar_unicidad_de_claves_usando_letras_(b,c,_...)
-Entry_editor_active_background_color=Color_de_fondo_del_editor_de_entradas_para_celdas_activas
-Entry_editor_background_color=Color_de_fondo_del_editor_de_entradas
-Entry_editor_font_color=Color_de_tipo_de_letra_del_editor_de_entradas
-Entry_editor_invalid_field_color=Color_de_campo_inválido_del_editor_de_entradas
+Ensure\ unique\ keys\ using\ letters\ (a,\ b,\ ...)=Asegurar unicidad de claves usando letras (a,b, ...)
+Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=Asegurar unicidad de claves usando letras (b,c, ...)
+Entry\ editor\ active\ background\ color=Color de fondo del editor de entradas para celdas activas
+Entry\ editor\ background\ color=Color de fondo del editor de entradas
+Entry\ editor\ font\ color=Color de tipo de letra del editor de entradas
+Entry\ editor\ invalid\ field\ color=Color de campo inválido del editor de entradas
 
-Table_and_entry_editor_colors=Colores_de_tabla_y_editor_de_entradas
+Table\ and\ entry\ editor\ colors=Colores de tabla y editor de entradas
 
-General_file_directory=Carpeta_general_de_archivos.
-User-specific_file_directory=Carpeta_de_archivos_de_usuario
-Search_failed\:_illegal_search_expression=La_búsqueda_ha_fallado._Expresión_de_búsqueda_ilegal
-Show_ArXiv_column=Mostrar_columna_ArXiv
+General\ file\ directory=Carpeta general de archivos.
+User-specific\ file\ directory=Carpeta de archivos de usuario
+Search\ failed\:\ illegal\ search\ expression=La búsqueda ha fallado. Expresión de búsqueda ilegal
+Show\ ArXiv\ column=Mostrar columna ArXiv
 
-You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for=Es_preciso_introducir_un_valor_entero_comprendido_entre_1025_y_65535_en_el_campo_de_texto_para
-Automatically_open_browse_dialog_when_creating_new_file_link=Abrir_automáticamente_el_diálogo_de_exploración_al_crear_nuevo_enlace_a_archivo
-Import_metadata_from\:=Importar_metadatos_desde\:
-Choose_the_source_for_the_metadata_import=Escoger_fuente_para_importar_metadatos
-Create_entry_based_on_XMP-metadata=Crear_entradas_a_partir_de_datos_XMP
-Create_blank_entry_linking_the_PDF=Crear_entrada_en_blanco_enlazando_el_PDF
-Only_attach_PDF=Sólo_adjnntar_PDF
+You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=Es preciso introducir un valor entero comprendido entre 1025 y 65535 en el campo de texto para
+Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Abrir automáticamente el diálogo de exploración al crear nuevo enlace a archivo
+Import\ metadata\ from\:=Importar metadatos desde:
+Choose\ the\ source\ for\ the\ metadata\ import=Escoger fuente para importar metadatos
+Create\ entry\ based\ on\ XMP-metadata=Crear entradas a partir de datos XMP
+Create\ blank\ entry\ linking\ the\ PDF=Crear entrada en blanco enlazando el PDF
+Only\ attach\ PDF=Sólo adjnntar PDF
 Title=Título
-Create_new_entry=Crear_nueva_entrada
-Update_existing_entry=Actualizar_entrada_existente
-Autocomplete_names_in_'Firstname_Lastname'_format_only=Autocompletar_nombres_sólo_en_el_formato_'Nombre_Apellidos'
-Autocomplete_names_in_'Lastname,_Firstname'_format_only=Autocompletar_nombres_sólo_en_el_formato_'Apellidos,_Nombre'
-Autocomplete_names_in_both_formats=Autocompletar_nombres_en_ambos_formatos
-Marking_color_%0=Marcando_color_%0
-The_name_'comment'_cannot_be_used_as_an_entry_type_name.=El_nombre_'comment'_no_puede_ser_usado_como_nombre_de_tipo_de_entrada.
-You_must_enter_an_integer_value_in_the_text_field_for=Es_preciso_introducir_un_valor_entero_en_el_campo_de_texto_para
-Send_as_email=Enviar_como_email
+Create\ new\ entry=Crear nueva entrada
+Update\ existing\ entry=Actualizar entrada existente
+Autocomplete\ names\ in\ 'Firstname\ Lastname'\ format\ only=Autocompletar nombres sólo en el formato 'Nombre Apellidos'
+Autocomplete\ names\ in\ 'Lastname,\ Firstname'\ format\ only=Autocompletar nombres sólo en el formato 'Apellidos, Nombre'
+Autocomplete\ names\ in\ both\ formats=Autocompletar nombres en ambos formatos
+Marking\ color\ %0=Marcando color %0
+The\ name\ 'comment'\ cannot\ be\ used\ as\ an\ entry\ type\ name.=El nombre 'comment' no puede ser usado como nombre de tipo de entrada.
+You\ must\ enter\ an\ integer\ value\ in\ the\ text\ field\ for=Es preciso introducir un valor entero en el campo de texto para
+Send\ as\ email=Enviar como email
 References=Referencias
-Sending_of_emails=Envío_de_emails
-Subject_for_sending_an_email_with_references=Asunto_para_enviar_email_con_referencias\:
-Automatically_open_folders_of_attached_files=Abrir_carpetas_de_los_archivos_adjuntos_automáticamente
-Create_entry_based_on_content=Crear_entrada_basada_en_contenido
-Do_not_show_this_box_again_for_this_import=No_mostrar_este_mensaje_de_nuevo_para_esta_importación
-Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)=Usar_siempre_este_estilo_de_importación_de_PDF_(no_preguntar_cada_vez)
-Error_creating_email=Error_creando_email
-Entries_added_to_an_email=Entradas_añadidas_al_email
-exportFormat=Formato_de_exportaciÃ³n
-Output_file_missing=Fichero_de_salida_no_encontrado
-No_search_matches.=No_hay_coincidencias_en_la_búsqueda.
-The_output_option_depends_on_a_valid_input_option.=La_opción_de_salida_depende_de_una_opción_de_entrada_válida.
-Default_import_style_for_drag_and_drop_of_PDFs=Estilo_de_importación_por_defecto_para_arrastrar-soltar_PDFs
-Default_PDF_file_link_action=Acción_por_defecto_del_enlace_a_PDF
-Filename_format_pattern=Patrón_de_formato_de_nombre_de_archivo
-Additional_parameters=Parámetros_adicionales
-Cite_selected_entries_between_parenthesis=Citar_entradas_seleccionadas
-Cite_selected_entries_with_in-text_citation=Citar_entradas_seleccionadas_con_citas_en_el_texto
-Cite_special=Cita_especial
-Extra_information_(e.g._page_number)=Información_extra_(p.e._número_de_página)
-Manage_citations=Administrar_citas
-Problem_modifying_citation=Problema_al_modificar_cita
+Sending\ of\ emails=Envío de emails
+Subject\ for\ sending\ an\ email\ with\ references=Asunto para enviar email con referencias:
+Automatically\ open\ folders\ of\ attached\ files=Abrir carpetas de los archivos adjuntos automáticamente
+Create\ entry\ based\ on\ content=Crear entrada basada en contenido
+Do\ not\ show\ this\ box\ again\ for\ this\ import=No mostrar este mensaje de nuevo para esta importación
+Always\ use\ this\ PDF\ import\ style\ (and\ do\ not\ ask\ for\ each\ import)=Usar siempre este estilo de importación de PDF (no preguntar cada vez)
+Error\ creating\ email=Error creando email
+Entries\ added\ to\ an\ email=Entradas añadidas al email
+exportFormat=Formato de exportaciÃ³n
+Output\ file\ missing=Fichero de salida no encontrado
+No\ search\ matches.=No hay coincidencias en la búsqueda.
+The\ output\ option\ depends\ on\ a\ valid\ input\ option.=La opción de salida depende de una opción de entrada válida.
+Default\ import\ style\ for\ drag\ and\ drop\ of\ PDFs=Estilo de importación por defecto para arrastrar-soltar PDFs
+Default\ PDF\ file\ link\ action=Acción por defecto del enlace a PDF
+Filename\ format\ pattern=Patrón de formato de nombre de archivo
+Additional\ parameters=Parámetros adicionales
+Cite\ selected\ entries\ between\ parenthesis=Citar entradas seleccionadas
+Cite\ selected\ entries\ with\ in-text\ citation=Citar entradas seleccionadas con citas en el texto
+Cite\ special=Cita especial
+Extra\ information\ (e.g.\ page\ number)=Información extra (p.e. número de página)
+Manage\ citations=Administrar citas
+Problem\ modifying\ citation=Problema al modificar cita
 Citation=Cita
-Extra_information=Información_extra
-Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.=No_se_puede_resolver_la_entrada_BibTeX_para_el_marcador_de_citas_'%0'
-Select_style=Seleccionar_estilo
+Extra\ information=Información extra
+Could\ not\ resolve\ BibTeX\ entry\ for\ citation\ marker\ '%0'.=No se puede resolver la entrada BibTeX para el marcador de citas '%0'
+Select\ style=Seleccionar estilo
 Journals=Publicaciones
 Cite=Citar
-Cite_in-text=Citar_en_el_texto
-Insert_empty_citation=Insertar_cita_vacía
-Merge_citations=Fundir_citas
-Manual_connect=Conexión_manual
-Select_Writer_document=Seleccionar_documento_Writer
-Sync_OpenOffice/LibreOffice_bibliography=Sincronizar_bibliografía_OpenOffice/LibreOffice
-Select_which_open_Writer_document_to_work_on=Seleccionar_el_ducomento_Writer_para_trabajar
-Connected_to_document=Conectado_al_documento
-Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)=Insertar_una_cita_sin_texto_(la_entrada_aparecerá_en_la_lista_de_referencias)
-Cite_selected_entries_with_extra_information=Citar_los_papeles_seleccionados_con_información_extra
-Ensure_that_the_bibliography_is_up-to-date=Asegurar_que_la_bibliografía_está_actualizada
-Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.=Su_documento_OpenOffice/LibreOffice_hace_referencia_a_la_clave_BibTeX_'%0'_que_no_puede_ser_encontrada_en_la_biblioteca_actual.
-Unable_to_synchronize_bibliography=No_es_posible_sincronizar_la_bibliografía
-Combine_pairs_of_citations_that_are_separated_by_spaces_only=Combinar_pares_de_citas_que_están_separadas_únicamente_por_espacios
-Autodetection_failed=Falló_la_autodetección
+Cite\ in-text=Citar en el texto
+Insert\ empty\ citation=Insertar cita vacía
+Merge\ citations=Fundir citas
+Manual\ connect=Conexión manual
+Select\ Writer\ document=Seleccionar documento Writer
+Sync\ OpenOffice/LibreOffice\ bibliography=Sincronizar bibliografía OpenOffice/LibreOffice
+Select\ which\ open\ Writer\ document\ to\ work\ on=Seleccionar el ducomento Writer para trabajar
+Connected\ to\ document=Conectado al documento
+Insert\ a\ citation\ without\ text\ (the\ entry\ will\ appear\ in\ the\ reference\ list)=Insertar una cita sin texto (la entrada aparecerá en la lista de referencias)
+Cite\ selected\ entries\ with\ extra\ information=Citar los papeles seleccionados con información extra
+Ensure\ that\ the\ bibliography\ is\ up-to-date=Asegurar que la bibliografía está actualizada
+Your\ OpenOffice/LibreOffice\ document\ references\ the\ BibTeX\ key\ '%0',\ which\ could\ not\ be\ found\ in\ your\ current\ library.=Su documento OpenOffice/LibreOffice hace referencia a la clave BibTeX '%0' que no puede ser encontrada en la biblioteca actual.
+Unable\ to\ synchronize\ bibliography=No es posible sincronizar la bibliografía
+Combine\ pairs\ of\ citations\ that\ are\ separated\ by\ spaces\ only=Combinar pares de citas que están separadas únicamente por espacios
+Autodetection\ failed=Falló la autodetección
 Connecting=Conectando...
-Please_wait...=Por_favor,_espere...
-Set_connection_parameters=Establecer_parámetros_de_conexión
-Path_to_OpenOffice/LibreOffice_directory=Ruta_al_directorio_OpenOffice/LibreOffice
-Path_to_OpenOffice/LibreOffice_executable=Ruta_al_ejecutable_de_OpenOffice/LibreOffice
-Path_to_OpenOffice/LibreOffice_library_dir=Ruta_a_la_carpeta_de_librerías_OpenOffice/LibreOffice
-Connection_lost=Se_ha_perdido_la_conexión
-The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.=El_formato_de_párrafo_está_controlado_por_la_propiedad_'ReferenceParagraphFormat'_o_'_ReferenceHeaderParagraphFormat'_en_el_archivo_de_estilo.
-The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.=El_formato_de_tipo_de_letra_está_controlado_por_la_propiedad_de_la_cita_'CitationCharacterFormat0_en_el_archivo_de_estilo.
-Automatically_sync_bibliography_when_inserting_citations=Sincronizar_automáticamente_la_bibliografía_al_insertar_citas
-Look_up_BibTeX_entries_in_the_active_tab_only=Buscar_entradas_BibTeX_sólo_en_la_pestaña_activa
-Look_up_BibTeX_entries_in_all_open_libraries=Buscar_entradas_BibTeX_en_todas_las_bibliotecas_abiertas
-Autodetecting_paths...=Autodetectando_rutas...
-Could_not_find_OpenOffice/LibreOffice_installation=No_se_encuentra_la_instalación_de_OpenOffice/LibreOffice
-Found_more_than_one_OpenOffice/LibreOffice_executable.=Se_ha_encontrado_más_de_un_ejecutable_OpenOffice/LibreOffice.
-Please_choose_which_one_to_connect_to\:=Seleccione_al_que_se_desea_conectar\:
-Choose_OpenOffice/LibreOffice_executable=Escoger_ejecutable_OpenOffice/LibreOffice
-Select_document=Seleccionar_documento
-HTML_list=Listado_HTML
-If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting=Normalizar_esta_lista_de_nombres_para_cumplir_con_el_formato_de_nombre_BibTeX_estándar
-Could_not_open_%0=No_se_puede_abrir_%0
-Unknown_import_format=Formato_de_importación_desconocido
-Web_search=Búsqueda_web
-Style_selection=Selección_de_estilo
-No_valid_style_file_defined=No_se_ha_definido_un_archivo_de_estilo_válido
-Choose_pattern=Escoger_patrón
-Use_the_BIB_file_location_as_primary_file_directory=Usar_la_ubicación_del_archivo_BIB_como_carpeta_de_archivos_primaria
-Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.=No_se_puede_ejecutar_el_programa_gnuclient/emacsclient._Asegúrese_de_que_están_instalados_y_disponibles_en_el_PATH.
-OpenOffice/LibreOffice_connection=Conexión_OpenOffice/LibreOffice
-You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.=Debe_seleccionar_un_archivo_de_estilo_válido_o_usar_uno_de_los_estilos_por_defecto.
+Please\ wait...=Por favor, espere...
+Set\ connection\ parameters=Establecer parámetros de conexión
+Path\ to\ OpenOffice/LibreOffice\ directory=Ruta al directorio OpenOffice/LibreOffice
+Path\ to\ OpenOffice/LibreOffice\ executable=Ruta al ejecutable de OpenOffice/LibreOffice
+Path\ to\ OpenOffice/LibreOffice\ library\ dir=Ruta a la carpeta de librerías OpenOffice/LibreOffice
+Connection\ lost=Se ha perdido la conexión
+The\ paragraph\ format\ is\ controlled\ by\ the\ property\ 'ReferenceParagraphFormat'\ or\ 'ReferenceHeaderParagraphFormat'\ in\ the\ style\ file.=El formato de párrafo está controlado por la propiedad 'ReferenceParagraphFormat' o ' ReferenceHeaderParagraphFormat' en el archivo de estilo.
+The\ character\ format\ is\ controlled\ by\ the\ citation\ property\ 'CitationCharacterFormat'\ in\ the\ style\ file.=El formato de tipo de letra está controlado por la propiedad de la cita 'CitationCharacterFormat0 en el archivo de estilo.
+Automatically\ sync\ bibliography\ when\ inserting\ citations=Sincronizar automáticamente la bibliografía al insertar citas
+Look\ up\ BibTeX\ entries\ in\ the\ active\ tab\ only=Buscar entradas BibTeX sólo en la pestaña activa
+Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=Buscar entradas BibTeX en todas las bibliotecas abiertas
+Autodetecting\ paths...=Autodetectando rutas...
+Could\ not\ find\ OpenOffice/LibreOffice\ installation=No se encuentra la instalación de OpenOffice/LibreOffice
+Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=Se ha encontrado más de un ejecutable OpenOffice/LibreOffice.
+Please\ choose\ which\ one\ to\ connect\ to\:=Seleccione al que se desea conectar:
+Choose\ OpenOffice/LibreOffice\ executable=Escoger ejecutable OpenOffice/LibreOffice
+Select\ document=Seleccionar documento
+HTML\ list=Listado HTML
+If\ possible,\ normalize\ this\ list\ of\ names\ to\ conform\ to\ standard\ BibTeX\ name\ formatting=Normalizar esta lista de nombres para cumplir con el formato de nombre BibTeX estándar
+Could\ not\ open\ %0=No se puede abrir %0
+Unknown\ import\ format=Formato de importación desconocido
+Web\ search=Búsqueda web
+Style\ selection=Selección de estilo
+No\ valid\ style\ file\ defined=No se ha definido un archivo de estilo válido
+Choose\ pattern=Escoger patrón
+Use\ the\ BIB\ file\ location\ as\ primary\ file\ directory=Usar la ubicación del archivo BIB como carpeta de archivos primaria
+Could\ not\ run\ the\ gnuclient/emacsclient\ program.\ Make\ sure\ you\ have\ the\ emacsclient/gnuclient\ program\ installed\ and\ available\ in\ the\ PATH.=No se puede ejecutar el programa gnuclient/emacsclient. Asegúrese de que están instalados y disponibles en el PATH.
+OpenOffice/LibreOffice\ connection=Conexión OpenOffice/LibreOffice
+You\ must\ select\ either\ a\ valid\ style\ file,\ or\ use\ one\ of\ the\ default\ styles.=Debe seleccionar un archivo de estilo válido o usar uno de los estilos por defecto.
 
-This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.=Este_es_un_diálogo_de_copia-pega_simple._Primero,_cargue_o_pegue_algo_de_texto_en_el_área_de_entrada_de_texto.<br>Posteriormente,_puede_marcar_texto_y_asignarlo_a_un_campo_BibTeX.
-This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.=Esta_funcionalidad_genera_una_nueva_biblioteca_basada_en_las_entradas_que_se_necesitan_en_un_documento_LaTeX_existente.
-You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.=Necesita_seleccionar_una_de_sus_bibliotecas_abiertas_desde_la_que_se_escogerán_entradas,_así_como_el_archivo_AUX_generado_por_LaTeX_al_compilar_su_documento.
+This\ is\ a\ simple\ copy\ and\ paste\ dialog.\ First\ load\ or\ paste\ some\ text\ into\ the\ text\ input\ area.<br>After\ that,\ you\ can\ mark\ text\ and\ assign\ it\ to\ a\ BibTeX\ field.=Este es un diálogo de copia-pega simple. Primero, cargue o pegue algo de texto en el área de entrada de texto.<br>Posteriormente, puede marcar texto y asignarlo a un campo BibTeX.
+This\ feature\ generates\ a\ new\ library\ based\ on\ which\ entries\ are\ needed\ in\ an\ existing\ LaTeX\ document.=Esta funcionalidad genera una nueva biblioteca basada en las entradas que se necesitan en un documento LaTeX existente.
+You\ need\ to\ select\ one\ of\ your\ open\ libraries\ from\ which\ to\ choose\ entries,\ as\ well\ as\ the\ AUX\ file\ produced\ by\ LaTeX\ when\ compiling\ your\ document.=Necesita seleccionar una de sus bibliotecas abiertas desde la que se escogerán entradas, así como el archivo AUX generado por LaTeX al compilar su documento.
 
-First_select_entries_to_clean_up.=Seleccione_las_entradas_a_limpiar_en_primer_lugar.
-Cleanup_entry=Limpiar_entradas
-Autogenerate_PDF_Names=Autogenerar_nombres_de_PDF
-Auto-generating_PDF-Names_does_not_support_undo._Continue?=La_autogeneración_de_nombres_de_PDF_no_se_puede_deshacer._¿Continuar?
+First\ select\ entries\ to\ clean\ up.=Seleccione las entradas a limpiar en primer lugar.
+Cleanup\ entry=Limpiar entradas
+Autogenerate\ PDF\ Names=Autogenerar nombres de PDF
+Auto-generating\ PDF-Names\ does\ not\ support\ undo.\ Continue?=La autogeneración de nombres de PDF no se puede deshacer. ¿Continuar?
 
-Use_full_firstname_whenever_possible=Usar_nombre_de_pila_completo_cuando_sea_posible
-Use_abbreviated_firstname_whenever_possible=Usar_nombre_de_pila_abreviado_cuando_sea_posible
-Use_abbreviated_and_full_firstname=Usar_apellido_completo_y_abreviado
-Autocompletion_options=Opciones_de_autocompletar
-Name_format_used_for_autocompletion=Formato_de_nombre_usado_para_autocompletar
-Treatment_of_first_names=Tratamiento_de_nombres_de_pila
-Cleanup_entries=Limpiar_entradas
-Automatically_assign_new_entry_to_selected_groups=Asignar_automáticamente_nueva_entrada_a_los_grupos_seleccionados
-%0_mode=modo_%0
-Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix=Mover_DOIs_desde_los_campos_nota_y_URL_al_campo_DOI_y_eliminar_el_prefijo_http
-Make_paths_of_linked_files_relative_(if_possible)=Hacer_rutas_de_los_ficheros_enlazados_relativas_(si_es_posible)
-Rename_PDFs_to_given_filename_format_pattern=Renombrar_PDFs_al_patron_de_formato_de_nombre_archivo_proporcionado
-Rename_only_PDFs_having_a_relative_path=Renombrar_sólo_los_PDF_con_ruta_relativa
-What_would_you_like_to_clean_up?=¿Qué_desea_limpiar?
-Doing_a_cleanup_for_%0_entries...=Haciendo_la_limpieza_de_%0_entradas
-No_entry_needed_a_clean_up=Ninguna_entrada_necesitó_de_limpieza
-One_entry_needed_a_clean_up=Sólo_una_entrada_necesitó_limpieza
-%0_entries_needed_a_clean_up=%0_entradas_necesitarion_limpieza
+Use\ full\ firstname\ whenever\ possible=Usar nombre de pila completo cuando sea posible
+Use\ abbreviated\ firstname\ whenever\ possible=Usar nombre de pila abreviado cuando sea posible
+Use\ abbreviated\ and\ full\ firstname=Usar apellido completo y abreviado
+Autocompletion\ options=Opciones de autocompletar
+Name\ format\ used\ for\ autocompletion=Formato de nombre usado para autocompletar
+Treatment\ of\ first\ names=Tratamiento de nombres de pila
+Cleanup\ entries=Limpiar entradas
+Automatically\ assign\ new\ entry\ to\ selected\ groups=Asignar automáticamente nueva entrada a los grupos seleccionados
+%0\ mode=modo %0
+Move\ DOIs\ from\ note\ and\ URL\ field\ to\ DOI\ field\ and\ remove\ http\ prefix=Mover DOIs desde los campos nota y URL al campo DOI y eliminar el prefijo http
+Make\ paths\ of\ linked\ files\ relative\ (if\ possible)=Hacer rutas de los ficheros enlazados relativas (si es posible)
+Rename\ PDFs\ to\ given\ filename\ format\ pattern=Renombrar PDFs al patron de formato de nombre archivo proporcionado
+Rename\ only\ PDFs\ having\ a\ relative\ path=Renombrar sólo los PDF con ruta relativa
+What\ would\ you\ like\ to\ clean\ up?=¿Qué desea limpiar?
+Doing\ a\ cleanup\ for\ %0\ entries...=Haciendo la limpieza de %0 entradas
+No\ entry\ needed\ a\ clean\ up=Ninguna entrada necesitó de limpieza
+One\ entry\ needed\ a\ clean\ up=Sólo una entrada necesitó limpieza
+%0\ entries\ needed\ a\ clean\ up=%0 entradas necesitarion limpieza
 
-Remove_selected=Eliminar_seleccionados
+Remove\ selected=Eliminar seleccionados
 
-Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.=El_arbol_de_grupo_no_puede_ser_examinado._Si_guarda_la_biblioteca_BibTeX,_todos_los_grupos_se_perderán.
-Attach_file=Adjuntar_archivo
-Setting_all_preferences_to_default_values.=Estableciendo_todas_las_preferencias_a_los_valores_por_defecto.
-Resetting_preference_key_'%0'=Reestableciendo_la_preferencia_con_clave_'%0'
-Unknown_preference_key_'%0'=Clave_de_preferencia_desconocida_'%0'
-Unable_to_clear_preferences.=No_es_posible_limpiar_preferencias.
+Group\ tree\ could\ not\ be\ parsed.\ If\ you\ save\ the\ BibTeX\ library,\ all\ groups\ will\ be\ lost.=El arbol de grupo no puede ser examinado. Si guarda la biblioteca BibTeX, todos los grupos se perderán.
+Attach\ file=Adjuntar archivo
+Setting\ all\ preferences\ to\ default\ values.=Estableciendo todas las preferencias a los valores por defecto.
+Resetting\ preference\ key\ '%0'=Reestableciendo la preferencia con clave '%0'
+Unknown\ preference\ key\ '%0'=Clave de preferencia desconocida '%0'
+Unable\ to\ clear\ preferences.=No es posible limpiar preferencias.
 
-Reset_preferences_(key1,key2,..._or_'all')=Restablecer_preferencias_(key1,key2,..._or_'todas')
-Find_unlinked_files=Buscar_archivos_desenlazados
-Unselect_all=Deseleccionar_todo
-Expand_all=Expandir_todo
-Collapse_all=Colapsar_todo
-Opens_the_file_browser.=Abre_el_explorador_de_archivos.
-Scan_directory=Escanear_directorio
-Searches_the_selected_directory_for_unlinked_files.=Busca_archivos_sin_enlazar_en_la_carpeta_seleccionada.
-Starts_the_import_of_BibTeX_entries.=Comienza_la_importación_de_entradas_BibTeX.
-Leave_this_dialog.=Dejar_este_diálogo.
-Create_directory_based_keywords=Crear_palabras_clave_basadas_en_carpeta
-Creates_keywords_in_created_entrys_with_directory_pathnames=Crea_palabras_clave_en_entradas_creadas_con_nombres_de_ruta_de_carpeta.
-Select_a_directory_where_the_search_shall_start.=Seleccione_el_directorio_donde_debería_comenzar_la_búsqueda.
-Select_file_type\:=Seleccione_el_tipo_de_archivo\:
-These_files_are_not_linked_in_the_active_library.=Estos_archivos_no_están_enlazados_en_la_biblioteca_activa.
-Entry_type_to_be_created\:=Tipo_de_entrada_a_crear\:
-Searching_file_system...=Buscando_en_el_sistema_de_archivos...
-Importing_into_Library...=Importando_en_biblioteca...
-Select_directory=Seleccionar_carpeta
-Select_files=Seleccionar_archivos
-BibTeX_entry_creation=Creación_de_entrada_BibTeX
-<No_selection>=<No_hay_selección>
-Unable_to_connect_to_FreeCite_online_service.=No_es_posible_conectar_con_el_servicio_online_FreeCite.
-Parse_with_FreeCite=Analizar_con_FreeCite
-The_current_BibTeX_key_will_be_overwritten._Continue?=La_clave_BibTeX_actual_va_a_ser_sobreescrita._¿Continuar?
-Overwrite_key=Sobreescribir_clave
-Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator=No_se_sobreescribirá_clave_existente._Para_cambiar_este_ajuste,_seleccione_Opciones->Preferencias->Generador_de_claves_BiBTeX
-How_would_you_like_to_link_to_'%0'?=¿Cómo_desea_enlazar_'%0'?
-BibTeX_key_patterns=Patrones_de_clave_BibTeX
-Changed_special_field_settings=Ajustes_de_campos_especiales_cambiados
-Clear_priority=Limpiar_prioridad
-Clear_rank=Limpiar_rango
-Enable_special_fields=Habilitar_campos_especiales
-One_star=Una_estrella
-Two_stars=Dos_estrellas
-Three_stars=Tres_estrellas
-Four_stars=Cuatro_estrellas
-Five_stars=Cinco_estrellas
-Help_on_special_fields=Ayuda_sobre_campos_especiales
-Keywords_of_selected_entries=Palabras_clave_de_las_entradas_seleccionadas
-Manage_content_selectors=Getionar_selectores_de_contenido
-Manage_keywords=Administrar_palabras_clave
-No_priority_information=Sin_información_de_prioridad
-No_rank_information=Sin_información_de_rango
+Reset\ preferences\ (key1,key2,...\ or\ 'all')=Restablecer preferencias (key1,key2,... or 'todas')
+Find\ unlinked\ files=Buscar archivos desenlazados
+Unselect\ all=Deseleccionar todo
+Expand\ all=Expandir todo
+Collapse\ all=Colapsar todo
+Opens\ the\ file\ browser.=Abre el explorador de archivos.
+Scan\ directory=Escanear directorio
+Searches\ the\ selected\ directory\ for\ unlinked\ files.=Busca archivos sin enlazar en la carpeta seleccionada.
+Starts\ the\ import\ of\ BibTeX\ entries.=Comienza la importación de entradas BibTeX.
+Leave\ this\ dialog.=Dejar este diálogo.
+Create\ directory\ based\ keywords=Crear palabras clave basadas en carpeta
+Creates\ keywords\ in\ created\ entrys\ with\ directory\ pathnames=Crea palabras clave en entradas creadas con nombres de ruta de carpeta.
+Select\ a\ directory\ where\ the\ search\ shall\ start.=Seleccione el directorio donde debería comenzar la búsqueda.
+Select\ file\ type\:=Seleccione el tipo de archivo:
+These\ files\ are\ not\ linked\ in\ the\ active\ library.=Estos archivos no están enlazados en la biblioteca activa.
+Entry\ type\ to\ be\ created\:=Tipo de entrada a crear:
+Searching\ file\ system...=Buscando en el sistema de archivos...
+Importing\ into\ Library...=Importando en biblioteca...
+Select\ directory=Seleccionar carpeta
+Select\ files=Seleccionar archivos
+BibTeX\ entry\ creation=Creación de entrada BibTeX
+<No\ selection>=<No hay selección>
+Unable\ to\ connect\ to\ FreeCite\ online\ service.=No es posible conectar con el servicio online FreeCite.
+Parse\ with\ FreeCite=Analizar con FreeCite
+The\ current\ BibTeX\ key\ will\ be\ overwritten.\ Continue?=La clave BibTeX actual va a ser sobreescrita. ¿Continuar?
+Overwrite\ key=Sobreescribir clave
+Not\ overwriting\ existing\ key.\ To\ change\ this\ setting,\ open\ Options\ ->\ Prefererences\ ->\ BibTeX\ key\ generator=No se sobreescribirá clave existente. Para cambiar este ajuste, seleccione Opciones->Preferencias->Generador de claves BiBTeX
+How\ would\ you\ like\ to\ link\ to\ '%0'?=¿Cómo desea enlazar '%0'?
+BibTeX\ key\ patterns=Patrones de clave BibTeX
+Changed\ special\ field\ settings=Ajustes de campos especiales cambiados
+Clear\ priority=Limpiar prioridad
+Clear\ rank=Limpiar rango
+Enable\ special\ fields=Habilitar campos especiales
+One\ star=Una estrella
+Two\ stars=Dos estrellas
+Three\ stars=Tres estrellas
+Four\ stars=Cuatro estrellas
+Five\ stars=Cinco estrellas
+Help\ on\ special\ fields=Ayuda sobre campos especiales
+Keywords\ of\ selected\ entries=Palabras clave de las entradas seleccionadas
+Manage\ content\ selectors=Getionar selectores de contenido
+Manage\ keywords=Administrar palabras clave
+No\ priority\ information=Sin información de prioridad
+No\ rank\ information=Sin información de rango
 Priority=Prioridad
-Priority_high=Prioridad_alta
-Priority_low=Prioridad_baja
-Priority_medium=Prioridad_media
+Priority\ high=Prioridad alta
+Priority\ low=Prioridad baja
+Priority\ medium=Prioridad media
 Quality=Calidad
 Rank=Rango
 Relevance=Relevancia
-Set_priority_to_high=Establecer_prioridad_alta
-Set_priority_to_low=Establecer_prioridad_baja
-Set_priority_to_medium=Establecer_prioridad_media
-Show_priority=Mostrar_prioridad
-Show_quality=Mostrar_cualidad
-Show_rank=Mostrar_rango
-Show_relevance=Mostrar_relevancia
-Synchronize_with_keywords=Sincronizar_con_palabras_clave
-Synchronized_special_fields_based_on_keywords=Sincronizar_campos_especiales_basados_en_palabras_clave
-Toggle_relevance=Conmutar_relevancia
-Toggle_quality_assured=Conmutar_calidad_asegurada
-Toggle_print_status=Cambiar_estatus_de_impresion
-Update_keywords=Actualizar_palabras_clave
-Write_values_of_special_fields_as_separate_fields_to_BibTeX=Escribir_valores_de_campos_especiales_como_campos_separados_en_BibTeX
-You_have_changed_settings_for_special_fields.=Ha_cambiado_los_ajustes_para_campos_especiales.
-%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.=%0_entradas_encontradas._Para_reducir_la_carga_del_servidor,_sólo_%1_será(n)_descargada(s).
-A_string_with_that_label_already_exists=Una_cadena_con_esa_etiqueta_ya_existe
-Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.=La_conexión_con_OpenOffice/LibreOffice_se_ha_perdido._Asegúrese_de_que_OpenOffice/LibreOffice_está_ejecutándose_e_intente_reconectar.
-JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.=JabRed_enviará_al_menos_una_solicitud_por_entrada_al_editor
-Correct_the_entry,_and_reopen_editor_to_display/edit_source.=Corregir_la_entrada_y_reabrir_el_editor_para_mostrar/editar_fuente.
-Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').=No_se_puede_conectar_con_un_proceso_gnuserv_ejecutándose._Asegúrese_de_que_Emacs_o_XEmacs_está_ejecutándose,<BR>y_que_el_servidor_se_ha_arrancado_(ejecutando_el_comando_'server-start'/'gnuserv-start').
-Could_not_connect_to_running_OpenOffice/LibreOffice.=No_se_puede_conectar_a_un_OpenOffice/LibreOffice_en_ejecución.
-Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.=Asegúrese_de_que_tiene_OpenOffice/LibreOffice_instalado_con_soporte_para_Java.
-If_connecting_manually,_please_verify_program_and_library_paths.=lf__connecting_manually,_por_favor_verifique_las_ruta_de_programa_y_librerías.
-Error_message\:=Mensaje_de_error\:
-If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.=Si_una_entrada_importada_o_pegada_ya_tiene_el_campo_establecido,_sobreescribir.
-Import_metadata_from_PDF=Importar_metadatos_desde_PDF
-Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.=No_conectado_a_ningún_documento_Writer._Asegúrese_de_que_un_documento_está_abierto_y_use_el_botón_"Seleccionar_documento_Writer'_para_conectar_con_él.
-Removed_all_subgroups_of_group_"%0".=Eliminados_todos_los_subgrupos_del_grupo_"%0".
-To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.=Para_deshabilitar_el_modo_lápiz_de_memoria,_renombre_o_elimine_el_archivo_jabrf.xml_en_la_misma_carpeta_que_JabRef.
-Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.=No_es_posible_conectar._Una_posible_razón_es_que_JabRef_y_OpenOffice/LibreOffice_no_están_funcionado_en_modo_32_bit_o_64_bit.
-Use_the_following_delimiter_character(s)\:=Usar_como_caracter(es)_delimitador(es)\:
-When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above=Al_descargar_archivos_o_mover_archivos_enlazados_a_la_carpeta_de_archivos,_preferir_la_ubicación_del_archivo_BIB_antes_que_el_directorio_de_archivos_establecido_arriba.
-Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=Su_archivo_de_estilo_especifica_el_formato_de_carácter_'%0',_que_no_está_definido_en_su_documento_OpenOffice/LibreOffice_actual.
-Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=Su_archivo_de_estilo_especifica_el_formato_de_párrafo_'%0',_que_no_está_definido_en_su_documento_OpenOffice/LibreOffice.
+Set\ priority\ to\ high=Establecer prioridad alta
+Set\ priority\ to\ low=Establecer prioridad baja
+Set\ priority\ to\ medium=Establecer prioridad media
+Show\ priority=Mostrar prioridad
+Show\ quality=Mostrar cualidad
+Show\ rank=Mostrar rango
+Show\ relevance=Mostrar relevancia
+Synchronize\ with\ keywords=Sincronizar con palabras clave
+Synchronized\ special\ fields\ based\ on\ keywords=Sincronizar campos especiales basados en palabras clave
+Toggle\ relevance=Conmutar relevancia
+Toggle\ quality\ assured=Conmutar calidad asegurada
+Toggle\ print\ status=Cambiar estatus de impresion
+Update\ keywords=Actualizar palabras clave
+Write\ values\ of\ special\ fields\ as\ separate\ fields\ to\ BibTeX=Escribir valores de campos especiales como campos separados en BibTeX
+You\ have\ changed\ settings\ for\ special\ fields.=Ha cambiado los ajustes para campos especiales.
+%0\ entries\ found.\ To\ reduce\ server\ load,\ only\ %1\ will\ be\ downloaded.=%0 entradas encontradas. Para reducir la carga del servidor, sólo %1 será(n) descargada(s).
+A\ string\ with\ that\ label\ already\ exists=Una cadena con esa etiqueta ya existe
+Connection\ to\ OpenOffice/LibreOffice\ has\ been\ lost.\ Please\ make\ sure\ OpenOffice/LibreOffice\ is\ running,\ and\ try\ to\ reconnect.=La conexión con OpenOffice/LibreOffice se ha perdido. Asegúrese de que OpenOffice/LibreOffice está ejecutándose e intente reconectar.
+JabRef\ will\ send\ at\ least\ one\ request\ per\ entry\ to\ a\ publisher.=JabRed enviará al menos una solicitud por entrada al editor
+Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=Corregir la entrada y reabrir el editor para mostrar/editar fuente.
+Could\ not\ connect\ to\ a\ running\ gnuserv\ process.\ Make\ sure\ that\ Emacs\ or\ XEmacs\ is\ running,<BR>and\ that\ the\ server\ has\ been\ started\ (by\ running\ the\ command\ 'server-start'/'gnuserv-start').=No se puede conectar con un proceso gnuserv ejecutándose. Asegúrese de que Emacs o XEmacs está ejecutándose,<BR>y que el servidor se ha arrancado (ejecutando el comando 'server-start'/'gnuserv-start').
+Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=No se puede conectar a un OpenOffice/LibreOffice en ejecución.
+Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=Asegúrese de que tiene OpenOffice/LibreOffice instalado con soporte para Java.
+If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=lf  connecting manually, por favor verifique las ruta de programa y librerías.
+Error\ message\:=Mensaje de error:
+If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=Si una entrada importada o pegada ya tiene el campo establecido, sobreescribir.
+Import\ metadata\ from\ PDF=Importar metadatos desde PDF
+Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=No conectado a ningún documento Writer. Asegúrese de que un documento está abierto y use el botón "Seleccionar documento Writer' para conectar con él.
+Removed\ all\ subgroups\ of\ group\ "%0".=Eliminados todos los subgrupos del grupo "%0".
+To\ disable\ the\ memory\ stick\ mode\ rename\ or\ remove\ the\ jabref.xml\ file\ in\ the\ same\ folder\ as\ JabRef.=Para deshabilitar el modo lápiz de memoria, renombre o elimine el archivo jabrf.xml en la misma carpeta que JabRef.
+Unable\ to\ connect.\ One\ possible\ reason\ is\ that\ JabRef\ and\ OpenOffice/LibreOffice\ are\ not\ both\ running\ in\ either\ 32\ bit\ mode\ or\ 64\ bit\ mode.=No es posible conectar. Una posible razón es que JabRef y OpenOffice/LibreOffice no están funcionado en modo 32 bit o 64 bit.
+Use\ the\ following\ delimiter\ character(s)\:=Usar como caracter(es) delimitador(es):
+When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\ prefer\ the\ BIB\ file\ location\ rather\ than\ the\ file\ directory\ set\ above=Al descargar archivos o mover archivos enlazados a la carpeta de archivos, preferir la ubicación del archivo BIB antes que el directorio de archivos establecido arriba.
+Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Su archivo de estilo especifica el formato de carácter '%0', que no está definido en su documento OpenOffice/LibreOffice actual.
+Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Su archivo de estilo especifica el formato de párrafo '%0', que no está definido en su documento OpenOffice/LibreOffice.
 
 Searching...=Buscando...
-You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?=Ha_seleccionado_más_de_%0_entradas_para_descargar._Algunos_sitios_web_podrían_bloquearle_si_hace_demasiadas_descargas._¿Desea_continuar?
-Confirm_selection=Confirmar_selección
-Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case=Añadir_{}_para_especificar_las_palabras_del_título_para_mantener_mayúsculas/minúsculas_correctamente
-Import_conversions=Importar_conversiones
-Please_enter_a_search_string=Introduzca_una_cadena_de_búsqueda,_por_favor
-Please_open_or_start_a_new_library_before_searching=Abra_o_cree_una_nueva_biblioteca_antes_de_buscar,_por_favor
+You\ have\ selected\ more\ than\ %0\ entries\ for\ download.\ Some\ web\ sites\ might\ block\ you\ if\ you\ make\ too\ many\ rapid\ downloads.\ Do\ you\ want\ to\ continue?=Ha seleccionado más de %0 entradas para descargar. Algunos sitios web podrían bloquearle si hace demasiadas descargas. ¿Desea continuar?
+Confirm\ selection=Confirmar selección
+Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=Añadir {} para especificar las palabras del título para mantener mayúsculas/minúsculas correctamente
+Import\ conversions=Importar conversiones
+Please\ enter\ a\ search\ string=Introduzca una cadena de búsqueda, por favor
+Please\ open\ or\ start\ a\ new\ library\ before\ searching=Abra o cree una nueva biblioteca antes de buscar, por favor
 
-Canceled_merging_entries=Cancelar_fusionado_de_entradas
+Canceled\ merging\ entries=Cancelar fusionado de entradas
 
-Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search=Formatear_unidades_añadiendo_separadores_no_divisores_y_manteniendo_mayúsculas/minúsculas_correctamente_en_la_búsqueda
-Merge_entries=Fusionar_entradas
-Merged_entries=Fusionar_entradas_en_una_nueva_y_mantener_la_antigua
-Merged_entry=Entrada_fusionada
+Format\ units\ by\ adding\ non-breaking\ separators\ and\ keeping\ the\ correct\ case\ on\ search=Formatear unidades añadiendo separadores no divisores y manteniendo mayúsculas/minúsculas correctamente en la búsqueda
+Merge\ entries=Fusionar entradas
+Merged\ entries=Fusionar entradas en una nueva y mantener la antigua
+Merged\ entry=Entrada fusionada
 None=Ningún
 Parse=Analizar
 Result=Resultado
-Show_DOI_first=Mostrar_DOI_en_primer_lugar
-Show_URL_first=Mostrar_URL_en_primer_lugar
-Use_Emacs_key_bindings=Usar_combinaciones_de_teclas_de_Emacs
-You_have_to_choose_exactly_two_entries_to_merge.=Tiene_que_escoger_exactamente_dos_entradas_para_fusionar.
+Show\ DOI\ first=Mostrar DOI en primer lugar
+Show\ URL\ first=Mostrar URL en primer lugar
+Use\ Emacs\ key\ bindings=Usar combinaciones de teclas de Emacs
+You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=Tiene que escoger exactamente dos entradas para fusionar.
 
-Update_timestamp_on_modification=Actualizar_marca_de_tiempo_al_modificar
-All_key_bindings_will_be_reset_to_their_defaults.=Todas_las_combinaciones_de_teclas_serán_restablecidas_a_su_configuración_por_defecto
+Update\ timestamp\ on\ modification=Actualizar marca de tiempo al modificar
+All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=Todas las combinaciones de teclas serán restablecidas a su configuración por defecto
 
-Automatically_set_file_links=Establecer_enlaces_de_archivo_automáticamente
-Resetting_all_key_bindings=Reestableciendo_todas_las_combinaciones_de_teclas
+Automatically\ set\ file\ links=Establecer enlaces de archivo automáticamente
+Resetting\ all\ key\ bindings=Reestableciendo todas las combinaciones de teclas
 Hostname=Host
-Invalid_setting=Ajuste_inválido
+Invalid\ setting=Ajuste inválido
 Network=Red
-Please_specify_both_hostname_and_port=Especifique_tanto_nombre_de_host_como_puerto
-Please_specify_both_username_and_password=Por_favor,_especifique_nombre_de_usuario_y_contraseña
+Please\ specify\ both\ hostname\ and\ port=Especifique tanto nombre de host como puerto
+Please\ specify\ both\ username\ and\ password=Por favor, especifique nombre de usuario y contraseña
 
-Use_custom_proxy_configuration=Usar_configuración_de_proxy_personalizada
-Proxy_requires_authentication=El_proxi_requiere_autenticación
-Attention\:_Password_is_stored_in_plain_text\!=Atención\:_¡La_contraseña_está_almacenada_como_texto_plano!
-Clear_connection_settings=Limpiar_ajustes_de_conexiÃ³n
-Cleared_connection_settings.=Ajustes_de_conexión_limpiados
+Use\ custom\ proxy\ configuration=Usar configuración de proxy personalizada
+Proxy\ requires\ authentication=El proxi requiere autenticación
+Attention\:\ Password\ is\ stored\ in\ plain\ text\!=Atención: ¡La contraseña está almacenada como texto plano!
+Clear\ connection\ settings=Limpiar ajustes de conexiÃ³n
+Cleared\ connection\ settings.=Ajustes de conexión limpiados
 
-Rebind_C-a,_too=Volver_a_combinar_C-a_tambiÃ©n
-Rebind_C-f,_too=Recombinar_C-f,_también
+Rebind\ C-a,\ too=Volver a combinar C-a tambiÃ©n
+Rebind\ C-f,\ too=Recombinar C-f, también
 
-Open_folder=Abrir_carpeta
-Searches_for_unlinked_PDF_files_on_the_file_system=Busca_archivos_PDF_sin_enlazar_en_el_sistema_de_archivos
-Export_entries_ordered_as_specified=Exportar_entradas_según_el_orden_especificado
-Export_sort_order=Criterio_de_ordenación_para_exportaciÃ³n
-Export_sorting=Exportar_ordenación
-Newline_separator=Separador_de_nueva_línea
+Open\ folder=Abrir carpeta
+Searches\ for\ unlinked\ PDF\ files\ on\ the\ file\ system=Busca archivos PDF sin enlazar en el sistema de archivos
+Export\ entries\ ordered\ as\ specified=Exportar entradas según el orden especificado
+Export\ sort\ order=Criterio de ordenación para exportaciÃ³n
+Export\ sorting=Exportar ordenación
+Newline\ separator=Separador de nueva línea
 
-Save_entries_ordered_as_specified=Guardar_entradas_según_el_orden_especificado
-Save_sort_order=Criterio_de_ordenación_para_guardar
-Show_extra_columns=Mostrar_columnas_extra
-Parsing_error=Error_analizando
-illegal_backslash_expression=Expresión_de_barra_inclinada_ilegal
+Save\ entries\ ordered\ as\ specified=Guardar entradas según el orden especificado
+Save\ sort\ order=Criterio de ordenación para guardar
+Show\ extra\ columns=Mostrar columnas extra
+Parsing\ error=Error analizando
+illegal\ backslash\ expression=Expresión de barra inclinada ilegal
 
-Move_to_group=Mover_al_grupo
+Move\ to\ group=Mover al grupo
 
-Clear_read_status=Borrar_status_de_lectura
-Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')=Convertir_a_formato_biblatex_(por_ejemplo,_mover_el_valor_del_campo_'journal'_a_'journaltitle')
-Could_not_apply_changes.=No_se_pudieron_aplicar_los_cambios
-Deprecated_fields=Campos_obsoletos
-Hide/show_toolbar=Mostrar/ocultar_barra_de_herramientas
-No_read_status_information=No_hay_información_sobre_status_de_lectura
+Clear\ read\ status=Borrar status de lectura
+Convert\ to\ biblatex\ format\ (for\ example,\ move\ the\ value\ of\ the\ 'journal'\ field\ to\ 'journaltitle')=Convertir a formato biblatex (por ejemplo, mover el valor del campo 'journal' a 'journaltitle')
+Could\ not\ apply\ changes.=No se pudieron aplicar los cambios
+Deprecated\ fields=Campos obsoletos
+Hide/show\ toolbar=Mostrar/ocultar barra de herramientas
+No\ read\ status\ information=No hay información sobre status de lectura
 Printed=Impreso
-Read_status=Estatus_de_lectura
-Read_status_read=Estatus_de_lectura_Leído
-Read_status_skimmed=Estatus_de_lectura_Vistazo
-Save_selected_as_plain_BibTeX...=Guardar_seleccionados_como_BibTeX_plano...
-Set_read_status_to_read=Establecer_estatus_de_lectura_a_Leído
-Set_read_status_to_skimmed=Establecer_estatus_de_lectura_a_Vistazo
-Show_deprecated_BibTeX_fields=Mostrar_campos_BibTeX_obsoletos
+Read\ status=Estatus de lectura
+Read\ status\ read=Estatus de lectura Leído
+Read\ status\ skimmed=Estatus de lectura Vistazo
+Save\ selected\ as\ plain\ BibTeX...=Guardar seleccionados como BibTeX plano...
+Set\ read\ status\ to\ read=Establecer estatus de lectura a Leído
+Set\ read\ status\ to\ skimmed=Establecer estatus de lectura a Vistazo
+Show\ deprecated\ BibTeX\ fields=Mostrar campos BibTeX obsoletos
 
-Show_gridlines=Mostrar_líneas_de_rejilla
-Show_printed_status=Mostrar_estatus_de_impresion
-Show_read_status=Mostrar_estatus_de_lectura
-Table_row_height_padding=Relleno_de_altura_de_fila
+Show\ gridlines=Mostrar líneas de rejilla
+Show\ printed\ status=Mostrar estatus de impresion
+Show\ read\ status=Mostrar estatus de lectura
+Table\ row\ height\ padding=Relleno de altura de fila
 
-Marked_selected_entry=Entrada_marcada_seleccionadas
-Marked_all_%0_selected_entries=Marcadas_todas_las_%0_entradas_seleccionadas
-Unmarked_selected_entry=Entrada_seleccionada_desmarcada
-Unmarked_all_%0_selected_entries=Desmarcadas_todas_las_%0_entradas_seleccionadas
+Marked\ selected\ entry=Entrada marcada seleccionadas
+Marked\ all\ %0\ selected\ entries=Marcadas todas las %0 entradas seleccionadas
+Unmarked\ selected\ entry=Entrada seleccionada desmarcada
+Unmarked\ all\ %0\ selected\ entries=Desmarcadas todas las %0 entradas seleccionadas
 
 
-Unmarked_all_entries=Desmarcar_todas_las_entradas
+Unmarked\ all\ entries=Desmarcar todas las entradas
 
-Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.=No_se_puede_encontrar_el_aspecto_solicitado,_por_lo_que_se_usará_el_aspecto_por_defecto
+Unable\ to\ find\ the\ requested\ look\ and\ feel\ and\ thus\ the\ default\ one\ is\ used.=No se puede encontrar el aspecto solicitado, por lo que se usará el aspecto por defecto
 
-Opens_JabRef's_GitHub_page=Abrir_la_página_de_JabRef_en_GitHub
-Could_not_open_browser.=No_se_puede_abrir_el_explorador.
-Please_open_%0_manually.=Por_favor,_abra_%0_manualmente
-The_link_has_been_copied_to_the_clipboard.=El_enlace_se_ha_copiado_al_portapapeles
+Opens\ JabRef's\ GitHub\ page=Abrir la página de JabRef en GitHub
+Could\ not\ open\ browser.=No se puede abrir el explorador.
+Please\ open\ %0\ manually.=Por favor, abra %0 manualmente
+The\ link\ has\ been\ copied\ to\ the\ clipboard.=El enlace se ha copiado al portapapeles
 
-Open_%0_file=Abrir_archivo_%0
+Open\ %0\ file=Abrir archivo %0
 
-Cannot_delete_file=No_se_puede_borrar_el_archivo
-File_permission_error=Error_de_permisos_de_archivo
-Push_to_%0=Enviar_entradas_a_%0
-Path_to_%0=Ruta_hasta_%0
+Cannot\ delete\ file=No se puede borrar el archivo
+File\ permission\ error=Error de permisos de archivo
+Push\ to\ %0=Enviar entradas a %0
+Path\ to\ %0=Ruta hasta %0
 Convert=Convertirº
-Normalize_to_BibTeX_name_format=Normalizar_a_formato_de_nombre_BibTeX
-Help_on_Name_Formatting=Ayuda_en_Formateo_de_Nombres
+Normalize\ to\ BibTeX\ name\ format=Normalizar a formato de nombre BibTeX
+Help\ on\ Name\ Formatting=Ayuda en Formateo de Nombres
 
-Add_new_file_type=Añadir_un_nuevo_tipo_de_archivo
+Add\ new\ file\ type=Añadir un nuevo tipo de archivo
 
-Left_entry=Entrada_izquierda
-Right_entry=Entrada_derecha
+Left\ entry=Entrada izquierda
+Right\ entry=Entrada derecha
 Use=Usar
-Original_entry=Entrada_original
-Replace_original_entry=Reemplazar_entrada_original
-No_information_added=No_se_ha_añadido_información
-Select_at_least_one_entry_to_manage_keywords.=Seleccionar_al_menos_una_entrada_para_gestionar_palabras_clave.
-OpenDocument_text=Texto_OpenDocument
-OpenDocument_spreadsheet=Hoja_de_cálculo_OpenDocument
-OpenDocument_presentation=Presentación_OpenDocument
-%0_image=imagen_%0
-Added_entry=Entrada_añadida
-Modified_entry=Entrada_modificada
-Deleted_entry=Entrada_eliminada
-Modified_groups_tree=Árbol_de_grupos_modificado
-Removed_all_groups=Se_eliminaron_todos_los_grupos
-Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.=Aceptar_el_cambio_reemplaza_el_árbol_completo_de_grupos_por_el_árbol_de_grupos_modificado_externamente
-Select_export_format=Seleccionar_formato_para_exportar
-Return_to_JabRef=Volver_a_JabRef
-Please_move_the_file_manually_and_link_in_place.=Por_favor,_mueva_el_fichero_manualmente_y_enlance_en_el_destino
-Could_not_connect_to_%0=No_se_puede_conectar_a_%0
-Warning\:_%0_out_of_%1_entries_have_undefined_title.=Atención\:_%0_de_%1_entradas_tienen_el_título_sin_definir
-Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.=Atención:_%0_de_un_total_de_%1_entradas_tienen_clave_BibTex_indefinida.
+Original\ entry=Entrada original
+Replace\ original\ entry=Reemplazar entrada original
+No\ information\ added=No se ha añadido información
+Select\ at\ least\ one\ entry\ to\ manage\ keywords.=Seleccionar al menos una entrada para gestionar palabras clave.
+OpenDocument\ text=Texto OpenDocument
+OpenDocument\ spreadsheet=Hoja de cálculo OpenDocument
+OpenDocument\ presentation=Presentación OpenDocument
+%0\ image=imagen %0
+Added\ entry=Entrada añadida
+Modified\ entry=Entrada modificada
+Deleted\ entry=Entrada eliminada
+Modified\ groups\ tree=Árbol de grupos modificado
+Removed\ all\ groups=Se eliminaron todos los grupos
+Accepting\ the\ change\ replaces\ the\ complete\ groups\ tree\ with\ the\ externally\ modified\ groups\ tree.=Aceptar el cambio reemplaza el árbol completo de grupos por el árbol de grupos modificado externamente
+Select\ export\ format=Seleccionar formato para exportar
+Return\ to\ JabRef=Volver a JabRef
+Please\ move\ the\ file\ manually\ and\ link\ in\ place.=Por favor, mueva el fichero manualmente y enlance en el destino
+Could\ not\ connect\ to\ %0=No se puede conectar a %0
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ title.=Atención: %0 de %1 entradas tienen el título sin definir
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ BibTeX\ key.=Atención: %0 de un total de %1 entradas tienen clave BibTex indefinida.
 occurrence=incidencia
-Added_new_'%0'_entry.=Añadida_la_nueva_entrada_'%0'
-Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?=Múltiples_entradas_seleccionadas._¿Desea_cambiar_el_tipo_de_todas_ellas_a_'%0'?
-Changed_type_to_'%0'_for=Tipo_cambiado_a_'%0'_para
-Really_delete_the_selected_entry?=¿Borrar_realmente_la_entrada_seleccionada?
-Really_delete_the_%0_selected_entries?=¿Realmente_desea_eliminar_%0_entradas?
-Keep_merged_entry_only=Mantener_sólo_la_entrada_fusionada
-Keep_left=mantener_izquierdo
-Keep_right=Mantener_derecho
-Old_entry=Entrada_antigua
-From_import=Entrada_importada
-No_problems_found.=No_se_encontraron_problemas.
-%0_problem(s)_found=%0_problema(s)_encontrado(s)
-Save_changes=Guardar_cambios
-Discard_changes=Descartar_cambios
-Library_'%0'_has_changed.=La_biblioteca_'%0'_ha_cambiado.
-Print_entry_preview=Imprimir_vista_previa_de_la_entrada
-Copy_title=Copiar_título
-Copy_\\cite{BibTeX_key}=Copiar_\\cite{clave_BibTeX}
-Copy_BibTeX_key_and_title=Copiar_clave_y_título_BibTeX
-File_rename_failed_for_%0_entries.=Ha_fallado_el_renombrado_para_%0_entradas.
-Merged_BibTeX_source_code=Código_fuente_BibTex_fusionado
-Invalid_DOI\:_'%0'.=DOI_no_válida\:_'%0'.
-should_start_with_a_name=debería_comenzar_por_un_nombre
-should_end_with_a_name=debería_acabar_por_un_nombre
-unexpected_closing_curly_bracket=Llave_de_cierre_inesperada
-unexpected_opening_curly_bracket=Llave_de_apertura_inesperada
-capital_letters_are_not_masked_using_curly_brackets_{}=la_máscara_no_afecta_a_las_mayúsculas_al_usar_llaves_{}
-should_contain_a_four_digit_number=debería_contener_un_número_de_cuatro_dígitos
-should_contain_a_valid_page_number_range=debería_contener_un_número_de_página_válido
+Added\ new\ '%0'\ entry.=Añadida la nueva entrada '%0'
+Multiple\ entries\ selected.\ Do\ you\ want\ to\ change\ the\ type\ of\ all\ these\ to\ '%0'?=Múltiples entradas seleccionadas. ¿Desea cambiar el tipo de todas ellas a '%0'?
+Changed\ type\ to\ '%0'\ for=Tipo cambiado a '%0' para
+Really\ delete\ the\ selected\ entry?=¿Borrar realmente la entrada seleccionada?
+Really\ delete\ the\ %0\ selected\ entries?=¿Realmente desea eliminar %0 entradas?
+Keep\ merged\ entry\ only=Mantener sólo la entrada fusionada
+Keep\ left=mantener izquierdo
+Keep\ right=Mantener derecho
+Old\ entry=Entrada antigua
+From\ import=Entrada importada
+No\ problems\ found.=No se encontraron problemas.
+%0\ problem(s)\ found=%0 problema(s) encontrado(s)
+Save\ changes=Guardar cambios
+Discard\ changes=Descartar cambios
+Library\ '%0'\ has\ changed.=La biblioteca '%0' ha cambiado.
+Print\ entry\ preview=Imprimir vista previa de la entrada
+Copy\ title=Copiar título
+Copy\ \\cite{BibTeX\ key}=Copiar \\cite{clave BibTeX}
+Copy\ BibTeX\ key\ and\ title=Copiar clave y título BibTeX
+File\ rename\ failed\ for\ %0\ entries.=Ha fallado el renombrado para %0 entradas.
+Merged\ BibTeX\ source\ code=Código fuente BibTex fusionado
+Invalid\ DOI\:\ '%0'.=DOI no válida: '%0'.
+should\ start\ with\ a\ name=debería comenzar por un nombre
+should\ end\ with\ a\ name=debería acabar por un nombre
+unexpected\ closing\ curly\ bracket=Llave de cierre inesperada
+unexpected\ opening\ curly\ bracket=Llave de apertura inesperada
+capital\ letters\ are\ not\ masked\ using\ curly\ brackets\ {}=la máscara no afecta a las mayúsculas al usar llaves {}
+should\ contain\ a\ four\ digit\ number=debería contener un número de cuatro dígitos
+should\ contain\ a\ valid\ page\ number\ range=debería contener un número de página válido
 Filled=Relleno
-Field_is_missing=No_se_encuentra_el_campo
-Search_%0=Buscar_en_%0
+Field\ is\ missing=No se encuentra el campo
+Search\ %0=Buscar en %0
 
-Search_results_in_all_libraries_for_%0=Resultados_para_%0_en_todas_las_bibliotecas
-Search_results_in_library_%0_for_%1=Resultados_para_%1_en_la_biblioteca_&0
-Search_globally=Buscar_globalmente.
-No_results_found.=No_se_encontraron_resultados.
-Found_%0_results.=Se_encontraron_%0_resultados.
-plain_text=texto_plano
-This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>=Esta_búsqueda_contiene_entradas_en_las_cuales_cualquier_campo_contiene_la_expresión_regular_<b>%0</b>
-This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>=Esta_búsqueda_contiene_entradas_en_las_cuales_cualquier_campo_contiene_el_término_<b>%0</b>
-This_search_contains_entries_in_which=Esta_búsqueda_contiene_entradas_en_las_cuales
+Search\ results\ in\ all\ libraries\ for\ %0=Resultados para %0 en todas las bibliotecas
+Search\ results\ in\ library\ %0\ for\ %1=Resultados para %1 en la biblioteca &0
+Search\ globally=Buscar globalmente.
+No\ results\ found.=No se encontraron resultados.
+Found\ %0\ results.=Se encontraron %0 resultados.
+plain\ text=texto plano
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ regular\ expression\ <b>%0</b>=Esta búsqueda contiene entradas en las cuales cualquier campo contiene la expresión regular <b>%0</b>
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ term\ <b>%0</b>=Esta búsqueda contiene entradas en las cuales cualquier campo contiene el término <b>%0</b>
+This\ search\ contains\ entries\ in\ which=Esta búsqueda contiene entradas en las cuales
 
-Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.=No_se_puede_autodetectar_OpenOffice/LibreOffice._Por_favor,_escoja_el_directorio_de_instalación_manualmente.
-JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>=Jabref_ya_no_soporta_los_campos_'ps'_o_'pdf'.<br>Ahora_los_enlaces_a_archivo_se_guardan_en_el_campo_'archivo'_y_los_archivos_se_guardan_en_un_directorio_externo.<br>Para_hacer_uso_de_esta_característica,_JabRef_necesita_actualizar_los_enlaces.<br><br>
-This_library_uses_outdated_file_links.=Esta_biblioteca_usa_enlaces_obsoletos
+Unable\ to\ autodetect\ OpenOffice/LibreOffice\ installation.\ Please\ choose\ the\ installation\ directory\ manually.=No se puede autodetectar OpenOffice/LibreOffice. Por favor, escoja el directorio de instalación manualmente.
+JabRef\ no\ longer\ supports\ 'ps'\ or\ 'pdf'\ fields.<br>File\ links\ are\ now\ stored\ in\ the\ 'file'\ field\ and\ files\ are\ stored\ in\ an\ external\ file\ directory.<br>To\ make\ use\ of\ this\ feature,\ JabRef\ needs\ to\ upgrade\ file\ links.<br><br>=Jabref ya no soporta los campos 'ps' o 'pdf'.<br>Ahora los enlaces a archivo se guardan en el campo 'archivo' y los archivos se guardan en un directorio externo.<br>Para hacer uso de esta característica, JabRef necesita actualizar los enlaces.<br><br>
+This\ library\ uses\ outdated\ file\ links.=Esta biblioteca usa enlaces obsoletos
 
-Clear_search=Limpiar_búsqueda
-Close_library=Cerrar_biblioteca
-Close_entry_editor=Cerrar_editor_de_entradas
-Decrease_table_font_size=Disminuir_tamaño_de_tipo_de_letra_de_tabla
-Entry_editor,_next_entry=Editor_de_entradas,_siguiente_entrada
-Entry_editor,_next_panel=Editor_de_entradas,_siguiente_panel
-Entry_editor,_next_panel_2=Editor_de_entradas,_siguiente_panel_2
-Entry_editor,_previous_entry=Editor_de_entradas,_entrada_previa
-Entry_editor,_previous_panel=Editor_de_entradas,_panel_previo
-Entry_editor,_previous_panel_2=Editor_de_entradas,_panel_previo_2
-File_list_editor,_move_entry_down=Editor_de_lista_de_archivos,_mover_entrada_hacia_abajo
-File_list_editor,_move_entry_up=Editor_de_lista_de_archivos,_mover_entrada_hacia_arriba
-Focus_entry_table=Enfocar_tabla_de_entradas
-Import_into_current_library=Importar_a_la_biblioteca_actual
-Import_into_new_library=Importar_a_una_nueva_biblioteca
-Increase_table_font_size=Incrementar_tamaño_de_tipo_de_letra_de_tabla
-New_article=Nuevo_artículo
-New_book=Nuevo_libro
-New_entry=Nueva_entrada
-New_from_plain_text=Nuevo_desde_texto_plano
-New_inbook=Nuevo_inbook
-New_mastersthesis=Nueva_tesis_de_máster
-New_phdthesis=Nueva_tesis_doctoral
-New_proceedings=Nuevo_proceedings
-New_unpublished=Nuevo_sin_publicar
-Next_tab=Siguiente_pestaña
-Preamble_editor,_store_changes=Editor_de_preámbulos,_guardar_cambios
-Previous_tab=Pestaña_previa
-Push_to_application=Enviar_a_aplicación
-Refresh_OpenOffice/LibreOffice=REfrescar_OpenOffice/LibreOffice
-Resolve_duplicate_BibTeX_keys=Resolver_claves_BibTeX_duplicadas
-Save_all=Guardar_todo
-String_dialog,_add_string=Diálogo_de_cadena,_añadir_cadena
-String_dialog,_remove_string=Diálogo_de_cadena,_eliminar_cadena
-Synchronize_files=Sincronizar_archivos
-Unabbreviate=Eliminar_abreviatura
-should_contain_a_protocol=Debería_contener_un_protocolo
-Copy_preview=Copiar_vista_previa
-Automatically_setting_file_links=Estableciendo_automáticamente_enlaces_de_archivo
-Regenerating_BibTeX_keys_according_to_metadata=Regenerando_claves_BibTeX_de_acuerdo_a_los_metadatos
-No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys=No_hay_metadatos_en_el_BIB_file._No_se_pueden_regenerar_las_claves_BibTex
-Regenerate_all_keys_for_the_entries_in_a_BibTeX_file=Regenerar_todas_las_claves_para_las_entradas_de_un_archivo_BibTeX
-Show_debug_level_messages=Mostrar_mensajes_de_nivel_de_depuración
-Default_bibliography_mode=Modo_de_bibliografía_por_defecto
-New_%0_library_created.=Creada_la_nueva_biblioteca_%0
-Show_only_preferences_deviating_from_their_default_value=Mostrar_sólo_preferencias_derivadas_de_su_valor_por_defecto
+Clear\ search=Limpiar búsqueda
+Close\ library=Cerrar biblioteca
+Close\ entry\ editor=Cerrar editor de entradas
+Decrease\ table\ font\ size=Disminuir tamaño de tipo de letra de tabla
+Entry\ editor,\ next\ entry=Editor de entradas, siguiente entrada
+Entry\ editor,\ next\ panel=Editor de entradas, siguiente panel
+Entry\ editor,\ next\ panel\ 2=Editor de entradas, siguiente panel 2
+Entry\ editor,\ previous\ entry=Editor de entradas, entrada previa
+Entry\ editor,\ previous\ panel=Editor de entradas, panel previo
+Entry\ editor,\ previous\ panel\ 2=Editor de entradas, panel previo 2
+File\ list\ editor,\ move\ entry\ down=Editor de lista de archivos, mover entrada hacia abajo
+File\ list\ editor,\ move\ entry\ up=Editor de lista de archivos, mover entrada hacia arriba
+Focus\ entry\ table=Enfocar tabla de entradas
+Import\ into\ current\ library=Importar a la biblioteca actual
+Import\ into\ new\ library=Importar a una nueva biblioteca
+Increase\ table\ font\ size=Incrementar tamaño de tipo de letra de tabla
+New\ article=Nuevo artículo
+New\ book=Nuevo libro
+New\ entry=Nueva entrada
+New\ from\ plain\ text=Nuevo desde texto plano
+New\ inbook=Nuevo inbook
+New\ mastersthesis=Nueva tesis de máster
+New\ phdthesis=Nueva tesis doctoral
+New\ proceedings=Nuevo proceedings
+New\ unpublished=Nuevo sin publicar
+Next\ tab=Siguiente pestaña
+Preamble\ editor,\ store\ changes=Editor de preámbulos, guardar cambios
+Previous\ tab=Pestaña previa
+Push\ to\ application=Enviar a aplicación
+Refresh\ OpenOffice/LibreOffice=REfrescar OpenOffice/LibreOffice
+Resolve\ duplicate\ BibTeX\ keys=Resolver claves BibTeX duplicadas
+Save\ all=Guardar todo
+String\ dialog,\ add\ string=Diálogo de cadena, añadir cadena
+String\ dialog,\ remove\ string=Diálogo de cadena, eliminar cadena
+Synchronize\ files=Sincronizar archivos
+Unabbreviate=Eliminar abreviatura
+should\ contain\ a\ protocol=Debería contener un protocolo
+Copy\ preview=Copiar vista previa
+Automatically\ setting\ file\ links=Estableciendo automáticamente enlaces de archivo
+Regenerating\ BibTeX\ keys\ according\ to\ metadata=Regenerando claves BibTeX de acuerdo a los metadatos
+No\ meta\ data\ present\ in\ BIB\ file.\ Cannot\ regenerate\ BibTeX\ keys=No hay metadatos en el BIB file. No se pueden regenerar las claves BibTex
+Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=Regenerar todas las claves para las entradas de un archivo BibTeX
+Show\ debug\ level\ messages=Mostrar mensajes de nivel de depuración
+Default\ bibliography\ mode=Modo de bibliografía por defecto
+New\ %0\ library\ created.=Creada la nueva biblioteca %0
+Show\ only\ preferences\ deviating\ from\ their\ default\ value=Mostrar sólo preferencias derivadas de su valor por defecto
 default=defecto
 key=clave
 type=tipo
 value=valor
-Show_preferences=Mostrar_preferencias
-Save_actions=Guardar_acciones
-Enable_save_actions=Habilitar_guardado_de_acciones
+Show\ preferences=Mostrar preferencias
+Save\ actions=Guardar acciones
+Enable\ save\ actions=Habilitar guardado de acciones
 
-Other_fields=Otros_campos
-Show_remaining_fields=Mostrar_campos_restantes
+Other\ fields=Otros campos
+Show\ remaining\ fields=Mostrar campos restantes
 
-link_should_refer_to_a_correct_file_path=el_enlace_debería_referirse_a_una_ruta_de_acceso_correcta
-abbreviation_detected=abreviatura_detectada
-wrong_entry_type_as_proceedings_has_page_numbers=tipo_de_entrada_incorrecto,_ya_que_proceedings_tiene_números_de_página
-Abbreviate_journal_names=Abreviar_nombres_de_publicación
+link\ should\ refer\ to\ a\ correct\ file\ path=el enlace debería referirse a una ruta de acceso correcta
+abbreviation\ detected=abreviatura detectada
+wrong\ entry\ type\ as\ proceedings\ has\ page\ numbers=tipo de entrada incorrecto, ya que proceedings tiene números de página
+Abbreviate\ journal\ names=Abreviar nombres de publicación
 Abbreviating...=Abreviando...
-Abbreviation_%s_for_journal_%s_already_defined.=La_abreviatura_%s_para_la_revista_%s_ya_está_definido
-Abbreviation_cannot_be_empty=La_abreviatura_no_puede_estar_vacía
-Duplicated_Journal_Abbreviation=Abreviatura_de_revista_duplicada
-Duplicated_Journal_File=Fichero_de_revista_duplicado
-Error_Occurred=Ha_ocurrido_un_error
-Journal_file_%s_already_added=El_fichero_de_revista_%s_ya_está_añadido
-Name_cannot_be_empty=El_nombre_no_puede_estar_vacío
+Abbreviation\ %s\ for\ journal\ %s\ already\ defined.=La abreviatura %s para la revista %s ya está definido
+Abbreviation\ cannot\ be\ empty=La abreviatura no puede estar vacía
+Duplicated\ Journal\ Abbreviation=Abreviatura de revista duplicada
+Duplicated\ Journal\ File=Fichero de revista duplicado
+Error\ Occurred=Ha ocurrido un error
+Journal\ file\ %s\ already\ added=El fichero de revista %s ya está añadido
+Name\ cannot\ be\ empty=El nombre no puede estar vacío
 
-Adding_fetched_entries=Añadiendo_las_entradas_recuperadas
-Display_keywords_appearing_in_ALL_entries=Mostrar_palabras_clave_que_aparezcan_en_TODAS_las_entradas
-Display_keywords_appearing_in_ANY_entry=Mostrar_palabras_clave_que_aparezcan_en_ALGUNA_entrada
-Fetching_entries_from_Inspire=Recuperando_entradas_desde_Inspire
-None_of_the_selected_entries_have_titles.=Ninguna_de_las_entradas_seleccionadas_tiene_título
-None_of_the_selected_entries_have_BibTeX_keys.=Ninguna_de_las_entradas_seleccionadas_tiene_clave_BibTeX
-Unabbreviate_journal_names=Eliminar_abreviatura_de_nombres_de_publicación
-Unabbreviating...=Eliminando_abreviaturas...
+Adding\ fetched\ entries=Añadiendo las entradas recuperadas
+Display\ keywords\ appearing\ in\ ALL\ entries=Mostrar palabras clave que aparezcan en TODAS las entradas
+Display\ keywords\ appearing\ in\ ANY\ entry=Mostrar palabras clave que aparezcan en ALGUNA entrada
+Fetching\ entries\ from\ Inspire=Recuperando entradas desde Inspire
+None\ of\ the\ selected\ entries\ have\ titles.=Ninguna de las entradas seleccionadas tiene título
+None\ of\ the\ selected\ entries\ have\ BibTeX\ keys.=Ninguna de las entradas seleccionadas tiene clave BibTeX
+Unabbreviate\ journal\ names=Eliminar abreviatura de nombres de publicación
+Unabbreviating...=Eliminando abreviaturas...
 Usage=Uso
 
 
-Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.=Añade_llaves_alrededor_de_los_acrónimos,_nombres_de_mes_y_países_para_preservar_las_mayúsculas
-Are_you_sure_you_want_to_reset_all_settings_to_default_values?=¿Está_seguro_de_querer_reiniciar_todos_los_ajustes_a_sus_valores_por_defecto?
-Reset_preferences=Preferencias
-Ill-formed_entrytype_comment_in_BIB_file=Comentario_de_tipo_de_entrada_mal_formado_en_fichero_bib
+Adds\ {}\ brackets\ around\ acronyms,\ month\ names\ and\ countries\ to\ preserve\ their\ case.=Añade llaves alrededor de los acrónimos, nombres de mes y países para preservar las mayúsculas
+Are\ you\ sure\ you\ want\ to\ reset\ all\ settings\ to\ default\ values?=¿Está seguro de querer reiniciar todos los ajustes a sus valores por defecto?
+Reset\ preferences=Preferencias
+Ill-formed\ entrytype\ comment\ in\ BIB\ file=Comentario de tipo de entrada mal formado en fichero bib
 
-Move_linked_files_to_default_file_directory_%0=Mover_archivos_enlazados_a_la_carpeta_de_archivos_por_defecto
+Move\ linked\ files\ to\ default\ file\ directory\ %0=Mover archivos enlazados a la carpeta de archivos por defecto
 
 Clipboard=Portapapeles
-Could_not_paste_entry_as_text\:=No_se_puede_pegar_la_entrada_como_texto\:
-Do_you_still_want_to_continue?=¿Aún_desea_continuar?
-This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:=Esta_acción_modificará_los_siguientes_campos_en_al_menos_una_entrad_por_cada_uno\:
-This_could_cause_undesired_changes_to_your_entries.=Esto_podría_causar_cambios_indeseados_a_sus_entradas.
-Run_field_formatter\:=Ejecutar_formateador_de_campo\:
-Table_font_size_is_%0=El_tamaño_de_tipo_de_letra_es_%0
-%0_import_canceled=Importación_desde_%0_cancelada
-Internal_style=Estilo_interno
-Add_style_file=Añadir_archivo_de_estilo
-Are_you_sure_you_want_to_remove_the_style?=¿Está_seguro_de_querer_eliminar_el_archivo?
-Current_style_is_'%0'=El_estilo_actual_es_'%0'
-Remove_style=Eliminar_estilo
-Select_one_of_the_available_styles_or_add_a_style_file_from_disk.=Seleccion_uno_de_los_estilos_disponibles_o_añada_un_archivo_de_estilo_desde_el_disco
-You_must_select_a_valid_style_file.=Debe_seleccionar_un_fichero_de_estilo_válidoº
+Could\ not\ paste\ entry\ as\ text\:=No se puede pegar la entrada como texto:
+Do\ you\ still\ want\ to\ continue?=¿Aún desea continuar?
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=Esta acción modificará los siguientes campos en al menos una entrad por cada uno:
+This\ could\ cause\ undesired\ changes\ to\ your\ entries.=Esto podría causar cambios indeseados a sus entradas.
+Run\ field\ formatter\:=Ejecutar formateador de campo:
+Table\ font\ size\ is\ %0=El tamaño de tipo de letra es %0
+%0\ import\ canceled=Importación desde %0 cancelada
+Internal\ style=Estilo interno
+Add\ style\ file=Añadir archivo de estilo
+Are\ you\ sure\ you\ want\ to\ remove\ the\ style?=¿Está seguro de querer eliminar el archivo?
+Current\ style\ is\ '%0'=El estilo actual es '%0'
+Remove\ style=Eliminar estilo
+Select\ one\ of\ the\ available\ styles\ or\ add\ a\ style\ file\ from\ disk.=Seleccion uno de los estilos disponibles o añada un archivo de estilo desde el disco
+You\ must\ select\ a\ valid\ style\ file.=Debe seleccionar un fichero de estilo válidoº
 Reload=Recargar
 
 Capitalize=Capitalizar
-Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.=Capitalizar_todas_las_palabras,_conviertiendo_los_artículos,_preposiciones_y_conjuciones_a_minúsculas
-Capitalize_the_first_word,_changes_other_words_to_lower_case.=Capitaliza_la_primera_palabra,_cambiando_las_otras_a_minúscula
-Changes_all_letters_to_lower_case.=Cambia_todas_las_letras_a_minúscula
-Changes_all_letters_to_upper_case.=Cambia_todas_las_letras_a_mayúscula
-Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.=Cambia_la_primera_letra_de_todas_las_palabras_a_mayúscula_y_el_resto_a_minúscula
-Cleans_up_LaTeX_code.=Limpia_el_código_LaTeX
-Converts_HTML_code_to_LaTeX_code.=Convierte_código_HTML_a_código_LaTeX
-Converts_HTML_code_to_Unicode.=Convierte_HTML_a_Unicode
-Converts_LaTeX_encoding_to_Unicode_characters.=Convierte_codificación_LaTeX_a_caracteres_Unicode
-Converts_Unicode_characters_to_LaTeX_encoding.=Conviert_caracteres_Unicode_a_codificación_LaTeX
-Converts_ordinals_to_LaTeX_superscripts.=Convierte_ordinales_LaTeX_a_superíndices
-Converts_units_to_LaTeX_formatting.=Convierte_unidades_a_formato_LaTeX
-HTML_to_LaTeX=HTML_a_LaTeX
-LaTeX_cleanup=Limpieza_LaTeX
-LaTeX_to_Unicode=LaTeX_a_Unicode
-Lower_case=Minúsuculas
-Minify_list_of_person_names=Minimizar_lista_de_nombres_de_persona
-Normalize_date=Normalizar_fecha
-Normalize_month=Normalizar_mes
-Normalize_month_to_BibTeX_standard_abbreviation.=Normalizar_mes_a_abreviatura_BibTeX_estándarº
-Normalize_names_of_persons=Normalizar_nombres_de_persona
-Normalize_page_numbers=Normalizar_números_de_página
-Normalize_pages_to_BibTeX_standard.=Normalizar_páginas_a_estándar_BibTeX
-Normalizes_lists_of_persons_to_the_BibTeX_standard.=Normaliza_listas_de_personas_a_estándar_BibTeX
-Normalizes_the_date_to_ISO_date_format.=Normaliza_la_fecha_a_formato_de_fecha_ISO
-Ordinals_to_LaTeX_superscript=Ordinales_a_superíndice_LaTeX
-Protect_terms=Proteger_términos
-Remove_enclosing_braces=Eliminar_llaves_de_envoltura
-Removes_braces_encapsulating_the_complete_field_content.=Eliminar_llaves_que_encapsulen_el_contenido_del_campo_por_completo
-Sentence_case=Mayúsculas/minúsculas_de_la_frase
-Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".=Acortar_a_"et_al."_listas_de_personas_si_contienen_mñas_de_2_personas
-Title_case=Mayúsculas/minúsculas_del_título
-Unicode_to_LaTeX=Unicode_a_LaTeX
-Units_to_LaTeX=Unidades_a_LaTeX
-Upper_case=Mayúsculas
-Does_nothing.=No_hace_nada
+Capitalize\ all\ words,\ but\ converts\ articles,\ prepositions,\ and\ conjunctions\ to\ lower\ case.=Capitalizar todas las palabras, conviertiendo los artículos, preposiciones y conjuciones a minúsculas
+Capitalize\ the\ first\ word,\ changes\ other\ words\ to\ lower\ case.=Capitaliza la primera palabra, cambiando las otras a minúscula
+Changes\ all\ letters\ to\ lower\ case.=Cambia todas las letras a minúscula
+Changes\ all\ letters\ to\ upper\ case.=Cambia todas las letras a mayúscula
+Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=Cambia la primera letra de todas las palabras a mayúscula y el resto a minúscula
+Cleans\ up\ LaTeX\ code.=Limpia el código LaTeX
+Converts\ HTML\ code\ to\ LaTeX\ code.=Convierte código HTML a código LaTeX
+Converts\ HTML\ code\ to\ Unicode.=Convierte HTML a Unicode
+Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=Convierte codificación LaTeX a caracteres Unicode
+Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=Conviert caracteres Unicode a codificación LaTeX
+Converts\ ordinals\ to\ LaTeX\ superscripts.=Convierte ordinales LaTeX a superíndices
+Converts\ units\ to\ LaTeX\ formatting.=Convierte unidades a formato LaTeX
+HTML\ to\ LaTeX=HTML a LaTeX
+LaTeX\ cleanup=Limpieza LaTeX
+LaTeX\ to\ Unicode=LaTeX a Unicode
+Lower\ case=Minúsuculas
+Minify\ list\ of\ person\ names=Minimizar lista de nombres de persona
+Normalize\ date=Normalizar fecha
+Normalize\ month=Normalizar mes
+Normalize\ month\ to\ BibTeX\ standard\ abbreviation.=Normalizar mes a abreviatura BibTeX estándarº
+Normalize\ names\ of\ persons=Normalizar nombres de persona
+Normalize\ page\ numbers=Normalizar números de página
+Normalize\ pages\ to\ BibTeX\ standard.=Normalizar páginas a estándar BibTeX
+Normalizes\ lists\ of\ persons\ to\ the\ BibTeX\ standard.=Normaliza listas de personas a estándar BibTeX
+Normalizes\ the\ date\ to\ ISO\ date\ format.=Normaliza la fecha a formato de fecha ISO
+Ordinals\ to\ LaTeX\ superscript=Ordinales a superíndice LaTeX
+Protect\ terms=Proteger términos
+Remove\ enclosing\ braces=Eliminar llaves de envoltura
+Removes\ braces\ encapsulating\ the\ complete\ field\ content.=Eliminar llaves que encapsulen el contenido del campo por completo
+Sentence\ case=Mayúsculas/minúsculas de la frase
+Shortens\ lists\ of\ persons\ if\ there\ are\ more\ than\ 2\ persons\ to\ "et\ al.".=Acortar a "et al." listas de personas si contienen mñas de 2 personas
+Title\ case=Mayúsculas/minúsculas del título
+Unicode\ to\ LaTeX=Unicode a LaTeX
+Units\ to\ LaTeX=Unidades a LaTeX
+Upper\ case=Mayúsculas
+Does\ nothing.=No hace nada
 Identity=Identidad
-Clears_the_field_completely.=Limpia_el_campo_completamente.
-Directory_not_found=Directorio_no_encontrado
-Main_file_directory_not_set\!=¡El_directorio_de_archivos_principal_no_está_establecido!
-This_operation_requires_exactly_one_item_to_be_selected.=Esta_operación_requiere_seleccionar_exactamente_un_elemento.
-Importing_in_%0_format=Importando_en_formato_%0
-Female_name=Nombre_femenino
-Female_names=Nombres_femeninos
-Male_name=Nombre_masculino
-Male_names=Nombres_masculinos
-Mixed_names=Nombres_mixtos
-Neuter_name=Nombre_neutro
-Neuter_names=Nombres_neutros
+Clears\ the\ field\ completely.=Limpia el campo completamente.
+Directory\ not\ found=Directorio no encontrado
+Main\ file\ directory\ not\ set\!=¡El directorio de archivos principal no está establecido!
+This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=Esta operación requiere seleccionar exactamente un elemento.
+Importing\ in\ %0\ format=Importando en formato %0
+Female\ name=Nombre femenino
+Female\ names=Nombres femeninos
+Male\ name=Nombre masculino
+Male\ names=Nombres masculinos
+Mixed\ names=Nombres mixtos
+Neuter\ name=Nombre neutro
+Neuter\ names=Nombres neutros
 
-Determined_%0_for_%1_entries=Se_ha_determinado_%0_para_%1_entradas
-Look_up_%0=Buscar_%0
-Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3=Buscando_%0_-_Entrada_%1_de_%2_-_encontrado_%0
+Determined\ %0\ for\ %1\ entries=Se ha determinado %0 para %1 entradas
+Look\ up\ %0=Buscar %0
+Looking\ up\ %0...\ -\ entry\ %1\ out\ of\ %2\ -\ found\ %3=Buscando %0 - Entrada %1 de %2 - encontrado %0
 
-Audio_CD=Audio_CD
-British_patent=Patente_británica
-British_patent_request=Solicitud_de_patente_británica
-Candidate_thesis=Tesis_de_Candidato
+Audio\ CD=Audio CD
+British\ patent=Patente británica
+British\ patent\ request=Solicitud de patente británica
+Candidate\ thesis=Tesis de Candidato
 Collaborator=Colaborador
 Column=Columna
 Compiler=Compilador
 Continuator=Continuador
-Data_CD=C_de_datos
+Data\ CD=C de datos
 Editor=Editor
-European_patent=Patente_Europea
-European_patent_request=Solicitud_de_patente_europea
+European\ patent=Patente Europea
+European\ patent\ request=Solicitud de patente europea
 Founder=Fundador
-French_patent=Patente_francesa
-French_patent_request=Solicitud_de_patente_francesa
-German_patent=Patente_alemana
-German_patent_request=Solicitud_de_patente_alemana
+French\ patent=Patente francesa
+French\ patent\ request=Solicitud de patente francesa
+German\ patent=Patente alemana
+German\ patent\ request=Solicitud de patente alemana
 Line=Línea
-Master's_thesis=Tesis_de_máster
+Master's\ thesis=Tesis de máster
 Page=Página
 Paragraph=Párrafo
 Patent=Patente
-Patent_request=Solicitud_de_patente
-PhD_thesis=Tesis_doctoral
+Patent\ request=Solicitud de patente
+PhD\ thesis=Tesis doctoral
 Redactor=Redactor
-Research_report=Informe_de_investigación
+Research\ report=Informe de investigación
 Reviser=Revisor
 Section=Sección
 Software=Software
-Technical_report=Informe_técnico
-U.S._patent=Patente_estadounidense
-U.S._patent_request=Solicitud_de_patente_estadounidense
+Technical\ report=Informe técnico
+U.S.\ patent=Patente estadounidense
+U.S.\ patent\ request=Solicitud de patente estadounidense
 Verse=Verso
 
-change_entries_of_group=cambiar_entradas_del_grupo
-odd_number_of_unescaped_'\#'=número_impar_de_'\#'_sin_escapar
+change\ entries\ of\ group=cambiar entradas del grupo
+odd\ number\ of\ unescaped\ '\#'=número impar de '#' sin escapar
 
-Plain_text=Texto_plano
-Show_diff=Mostrar_diff
+Plain\ text=Texto plano
+Show\ diff=Mostrar diff
 character=carácter
 word=palabra
-Show_symmetric_diff=Mostrar_diff_simétrico
-Copy_Version=Copiar_versión
+Show\ symmetric\ diff=Mostrar diff simétrico
+Copy\ Version=Copiar versión
 Developers=Desarrolladores
 Authors=Autores
 License=Licencia
 
-HTML_encoded_character_found=Se_han_encontrado_caracteres_codificados_HTML
-booktitle_ends_with_'conference_on'=El_título_del_libro_acaba_con_'conference_on'
+HTML\ encoded\ character\ found=Se han encontrado caracteres codificados HTML
+booktitle\ ends\ with\ 'conference\ on'=El título del libro acaba con 'conference on'
 
-All_external_files=Todos_los_ficheros_externos
+All\ external\ files=Todos los ficheros externos
 
-OpenOffice/LibreOffice_integration=Integración_con_OpenOffice/LibreOffice
+OpenOffice/LibreOffice\ integration=Integración con OpenOffice/LibreOffice
 
-incorrect_control_digit=dígito_de_control_incorrecto
-incorrect_format=formato_incorrecto
-Copied_version_to_clipboard=Version_copiada_al_portapapeles
+incorrect\ control\ digit=dígito de control incorrecto
+incorrect\ format=formato incorrecto
+Copied\ version\ to\ clipboard=Version copiada al portapapeles
 
-BibTeX_key=Clave_BibTeX
+BibTeX\ key=Clave BibTeX
 Message=Mensaje
 
 
-MathSciNet_Review=Revisión_MathSciNet
-Reset_Bindings=Reiniciar_combinaciones
+MathSciNet\ Review=Revisión MathSciNet
+Reset\ Bindings=Reiniciar combinaciones
 
-Decryption_not_supported.=Desencriptación_no_soportada
+Decryption\ not\ supported.=Desencriptación no soportada
 
-Cleared_'%0'_for_%1_entries=Limpieza_de_'%0'_para_%1_entradas
-Set_'%0'_to_'%1'_for_%2_entries=Establecer_'%0'_a_'%1'_para_%2_entradas
-Toggled_'%0'_for_%1_entries=Cambio_de_'%0'_para_%1_entradas
+Cleared\ '%0'\ for\ %1\ entries=Limpieza de '%0' para %1 entradas
+Set\ '%0'\ to\ '%1'\ for\ %2\ entries=Establecer '%0' a '%1' para %2 entradas
+Toggled\ '%0'\ for\ %1\ entries=Cambio de '%0' para %1 entradas
 
-Check_for_updates=Comprobar_actualizaciones
-Download_update=Descargar_actualización
-New_version_available=Nueva_versión_disponible
-Installed_version=Versión_instalada
-Remind_me_later=Recordármelo_después
-Ignore_this_update=Ignorar_esta_actualización
-Could_not_connect_to_the_update_server.=No_se_puede_conectar_al_servidor_de_actualizaciones
-Please_try_again_later_and/or_check_your_network_connection.=Por_favor,_inténtelo_de_nuevo_más_tarde_o_compruebe_su_conexión_a_la_red.
-To_see_what_is_new_view_the_changelog.=Para_ver_qué_hay_de_nuevo,_vea_el_resgistro_de_cambios.
-A_new_version_of_JabRef_has_been_released.=Se_ha_lanzado_una_nueva_versión_de_JabRef
-JabRef_is_up-to-date.=JabRef_está_actualizado.
-Latest_version=Última_versión
-Online_help_forum=Foro_de_ayuda_online
+Check\ for\ updates=Comprobar actualizaciones
+Download\ update=Descargar actualización
+New\ version\ available=Nueva versión disponible
+Installed\ version=Versión instalada
+Remind\ me\ later=Recordármelo después
+Ignore\ this\ update=Ignorar esta actualización
+Could\ not\ connect\ to\ the\ update\ server.=No se puede conectar al servidor de actualizaciones
+Please\ try\ again\ later\ and/or\ check\ your\ network\ connection.=Por favor, inténtelo de nuevo más tarde o compruebe su conexión a la red.
+To\ see\ what\ is\ new\ view\ the\ changelog.=Para ver qué hay de nuevo, vea el resgistro de cambios.
+A\ new\ version\ of\ JabRef\ has\ been\ released.=Se ha lanzado una nueva versión de JabRef
+JabRef\ is\ up-to-date.=JabRef está actualizado.
+Latest\ version=Última versión
+Online\ help\ forum=Foro de ayuda online
 Custom=Personalizado
 
-Export_cited=Exportar_citados
-Unable_to_generate_new_library=No_se_puede_generar_la_nueva_biblioteca
+Export\ cited=Exportar citados
+Unable\ to\ generate\ new\ library=No se puede generar la nueva biblioteca
 
-Open_console=Abrir_consola
-Use_default_terminal_emulator=Usar_emulador_de_consola_por_defecto
-Execute_command=Ejecutar_comando
-Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.=Nota\:usar_el_marcador_%0_para_la_ubicación_de_la_biblioteca_abierta
-Executing_command_\"%0\"...=Ejecutando_el_comando_\"%0"\...
-Error_occured_while_executing_the_command_\"%0\".=Error_durante_la_ejecución_del_comando_\"%0"\.
-Reformat_ISSN=Reformatear_ISSN
+Open\ console=Abrir consola
+Use\ default\ terminal\ emulator=Usar emulador de consola por defecto
+Execute\ command=Ejecutar comando
+Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=Nota:usar el marcador %0 para la ubicación de la biblioteca abierta
+Executing\ command\ \"%0\"...=Ejecutando el comando \"%0"\...
+Error\ occured\ while\ executing\ the\ command\ \"%0\".=Error durante la ejecución del comando \"%0"\.
+Reformat\ ISSN=Reformatear ISSN
 
-Countries_and_territories_in_English=Países_y_territorios_en_inglés.
-Electrical_engineering_terms=Términos_de_ingeniería_electrónica
+Countries\ and\ territories\ in\ English=Países y territorios en inglés.
+Electrical\ engineering\ terms=Términos de ingeniería electrónica
 Enabled=Habilitado
-Internal_list=Lista_interna
-Manage_protected_terms_files=Gestionar_ficheros_detérminos_protegidos
-Months_and_weekdays_in_English=Meses_y_días_de_la_semana_en_inglés
-The_text_after_the_last_line_starting_with_\#_will_be_used=Se_usará_el_texto_después_de_la_última_línea_con_\#
-Add_protected_terms_file=Añadir_archivo_de_términos_protegidos
-Are_you_sure_you_want_to_remove_the_protected_terms_file?=¿Está_seguro_de_querer_eliminar_el_archivo_de_términos_protegidos?
-Remove_protected_terms_file=Eliminar_el_archivo_de_términos_protegidos
-Add_selected_text_to_list=Añadir_texto_seleccionado_a_la_lista
-Add_{}_around_selected_text=Añadir_{}_alrededor_del_texto_seleccionado
-Format_field=Formatear_campo
-New_protected_terms_file=Nuevo_archivo_de_términos_protegidos
-change_field_%0_of_entry_%1_from_%2_to_%3=Cambiar_campo_%0_de_la_entrada_%1_de_%2_a_%3
-change_key_from_%0_to_%1=cambiar_clave_de_%0_a_%1
-change_string_content_%0_to_%1=cambiar_contenido_de_la_cadena_%0_a_%1
-change_string_name_%0_to_%1=cambiar_el_nombre_%0_a_%1
-change_type_of_entry_%0_from_%1_to_%2=cambiar_el_tipo_de_la_entrada_%0_de_%1_a_%2
-insert_entry_%0=insertar_entrada_%0
-insert_string_%0=insertar_cadena_%0
-remove_entry_%0=eliminar_entrada_%0
-remove_string_%0=eliminar_cadena_%0
-undefined=No_definido
-Cannot_get_info_based_on_given_%0\:_%1=No_se_encuentra_información_basada_en_%0
-Get_BibTeX_data_from_%0=Obtener_datos_BibTeX_desde_%0
-No_%0_found=No_se_encontró_%0
-Entry_from_%0=Entrada_desde_%0
-Merge_entry_with_%0_information=Fusionar_entrada_con_informaciçon_%0
-Updated_entry_with_info_from_%0=Entrada_actualizada_con_información_del_%0
+Internal\ list=Lista interna
+Manage\ protected\ terms\ files=Gestionar ficheros detérminos protegidos
+Months\ and\ weekdays\ in\ English=Meses y días de la semana en inglés
+The\ text\ after\ the\ last\ line\ starting\ with\ \#\ will\ be\ used=Se usará el texto después de la última línea con #
+Add\ protected\ terms\ file=Añadir archivo de términos protegidos
+Are\ you\ sure\ you\ want\ to\ remove\ the\ protected\ terms\ file?=¿Está seguro de querer eliminar el archivo de términos protegidos?
+Remove\ protected\ terms\ file=Eliminar el archivo de términos protegidos
+Add\ selected\ text\ to\ list=Añadir texto seleccionado a la lista
+Add\ {}\ around\ selected\ text=Añadir {} alrededor del texto seleccionado
+Format\ field=Formatear campo
+New\ protected\ terms\ file=Nuevo archivo de términos protegidos
+change\ field\ %0\ of\ entry\ %1\ from\ %2\ to\ %3=Cambiar campo %0 de la entrada %1 de %2 a %3
+change\ key\ from\ %0\ to\ %1=cambiar clave de %0 a %1
+change\ string\ content\ %0\ to\ %1=cambiar contenido de la cadena %0 a %1
+change\ string\ name\ %0\ to\ %1=cambiar el nombre %0 a %1
+change\ type\ of\ entry\ %0\ from\ %1\ to\ %2=cambiar el tipo de la entrada %0 de %1 a %2
+insert\ entry\ %0=insertar entrada %0
+insert\ string\ %0=insertar cadena %0
+remove\ entry\ %0=eliminar entrada %0
+remove\ string\ %0=eliminar cadena %0
+undefined=No definido
+Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=No se encuentra información basada en %0
+Get\ BibTeX\ data\ from\ %0=Obtener datos BibTeX desde %0
+No\ %0\ found=No se encontró %0
+Entry\ from\ %0=Entrada desde %0
+Merge\ entry\ with\ %0\ information=Fusionar entrada con informaciçon %0
+Updated\ entry\ with\ info\ from\ %0=Entrada actualizada con información del %0
 
-Add_existing_file=Añadir_fichero_existente
-Create_new_list=Crear_nueva_lista
-Remove_list=Eliminar_lista
-Full_journal_name=Nombre_completo_de_revista
-Abbreviation_name=Nombre_de_abreviatura
+Add\ existing\ file=Añadir fichero existente
+Create\ new\ list=Crear nueva lista
+Remove\ list=Eliminar lista
+Full\ journal\ name=Nombre completo de revista
+Abbreviation\ name=Nombre de abreviatura
 
-No_abbreviation_files_loaded=No_se_cargaron_ficheros_de_abreviaturas
+No\ abbreviation\ files\ loaded=No se cargaron ficheros de abreviaturas
 
-Loading_built_in_lists=Cargando_listas_preinstaladas
+Loading\ built\ in\ lists=Cargando listas preinstaladas
 
-JabRef_built_in_list=Lista_preinstalada_de_JabRef
-IEEE_built_in_list=Lista_preinstalada_de_IEEE
+JabRef\ built\ in\ list=Lista preinstalada de JabRef
+IEEE\ built\ in\ list=Lista preinstalada de IEEE
 
-Event_log=Registro_de_eventos
-We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.=Esta_es_una_visión_de_las_interioridades_de_JabRef._Esta_información_puede_ser_útil_para_diagnosticar_la_causa_principal_del_problema._Puede_informar_a_los_desarrolladores_acerca_del_problema_si_lo_desea.
-Log_copied_to_clipboard.=Registro_copiado_al_portapapeles
-Copy_Log=Copiar_registro
-Clear_Log=Limpiar_registro
-Report_Issue=Comunicar_problema
-Issue_on_GitHub_successfully_reported.=Problema_comunicado_correctamente_en_GitHub
-Issue_report_successful=Comunicación_de_problema_satisfactoria
-Your_issue_was_reported_in_your_browser.=Su_problema_fue_comunicado_a_través_del_navegador
-The_log_and_exception_information_was_copied_to_your_clipboard.=La_información_de_excepción_y_registro_fue_copiada_a_su_portapapeles
-Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.=Por_favor,_pegue_esta_información_(con_Ctrl+V)_en_la_descripción_del_problema.
+Event\ log=Registro de eventos
+We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef\'s\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=Esta es una visión de las interioridades de JabRef. Esta información puede ser útil para diagnosticar la causa principal del problema. Puede informar a los desarrolladores acerca del problema si lo desea.
+Log\ copied\ to\ clipboard.=Registro copiado al portapapeles
+Copy\ Log=Copiar registro
+Clear\ Log=Limpiar registro
+Report\ Issue=Comunicar problema
+Issue\ on\ GitHub\ successfully\ reported.=Problema comunicado correctamente en GitHub
+Issue\ report\ successful=Comunicación de problema satisfactoria
+Your\ issue\ was\ reported\ in\ your\ browser.=Su problema fue comunicado a través del navegador
+The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=La información de excepción y registro fue copiada a su portapapeles
+Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=Por favor, pegue esta información (con Ctrl+V) en la descripción del problema.
 
 Connection=Conexión
 Connecting...=Conectando...
@@ -2164,194 +2164,194 @@ Port=Puerto
 Library=Biblioteca
 User=Usuario
 Connect=Conectar
-Connection_error=Error_de_conexión
-Connection_to_%0_server_established.=Se_ha_establecido_conexión_con_el_servidor_%0.
-Required_field_"%0"_is_empty.=El_campo_%0_requerido_está_vacío
-%0_driver_not_available.=El_driver_%0_no_está_disponible.
-The_connection_to_the_server_has_been_terminated.=Se_ha_finalizado_la_conexión_con_el_servidor_%0.
-Connection_lost.=Conexión_perdida.
+Connection\ error=Error de conexión
+Connection\ to\ %0\ server\ established.=Se ha establecido conexión con el servidor %0.
+Required\ field\ "%0"\ is\ empty.=El campo %0 requerido está vacío
+%0\ driver\ not\ available.=El driver %0 no está disponible.
+The\ connection\ to\ the\ server\ has\ been\ terminated.=Se ha finalizado la conexión con el servidor %0.
+Connection\ lost.=Conexión perdida.
 Reconnect=Reconectar
-Work_offline=Trabajar_sin_conexión
-Working_offline.=Trabajando_sin_conexión
-Update_refused.=Actualización_rechazada.
-Update_refused=Actualización_rechazada
-Local_entry=Entrada_local
-Shared_entry=Entrada_compartida
-Update_could_not_be_performed_due_to_existing_change_conflicts.=No_se_pudo_actualizar_debido_a_los_conflictos_de_cambio_existentes.
-You_are_not_working_on_the_newest_version_of_BibEntry.=No_está_trabajando_con_la_versión_más_reciente_de_BibEntry.
-Local_version\:_%0=Versión_local\:_%0
-Shared_version\:_%0=Versión_compartida\:_%0
-Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.=Por_favor,_fusione_la_entrada_compartida_con_la_suya_y_presione_"Fusionar_entradas"_para_resolver_el_problema.
-Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?=Cancelar_la_operación_dejará_sus_cambios_sin_sincronizar._¿Cancelar_de_todos_modos?
-Shared_entry_is_no_longer_present=La_entrada_compartida_ya_no_está_presente.
-The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.=La_BibEntry_en_la_que_trabaja_actualmente_ha_sido_eliminada_en_la_parte_compartida.
-You_can_restore_the_entry_using_the_"Undo"_operation.=Puede_restaurar_la_entrada_mediante_la_operación_"Deshacer"
-Remember_password?=¿Recordar_contraseña?
-You_are_already_connected_to_a_database_using_entered_connection_details.=Ya_esa_conectado_a_una_vase_de_datos_usando_los_detalles_de_la_conexión_introducidos.
+Work\ offline=Trabajar sin conexión
+Working\ offline.=Trabajando sin conexión
+Update\ refused.=Actualización rechazada.
+Update\ refused=Actualización rechazada
+Local\ entry=Entrada local
+Shared\ entry=Entrada compartida
+Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=No se pudo actualizar debido a los conflictos de cambio existentes.
+You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=No está trabajando con la versión más reciente de BibEntry.
+Local\ version\:\ %0=Versión local: %0
+Shared\ version\:\ %0=Versión compartida: %0
+Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=Por favor, fusione la entrada compartida con la suya y presione "Fusionar entradas" para resolver el problema.
+Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=Cancelar la operación dejará sus cambios sin sincronizar. ¿Cancelar de todos modos?
+Shared\ entry\ is\ no\ longer\ present=La entrada compartida ya no está presente.
+The\ BibEntry\ you\ currently\ work\ on\ has\ been\ deleted\ on\ the\ shared\ side.=La BibEntry en la que trabaja actualmente ha sido eliminada en la parte compartida.
+You\ can\ restore\ the\ entry\ using\ the\ "Undo"\ operation.=Puede restaurar la entrada mediante la operación "Deshacer"
+Remember\ password?=¿Recordar contraseña?
+You\ are\ already\ connected\ to\ a\ database\ using\ entered\ connection\ details.=Ya esa conectado a una vase de datos usando los detalles de la conexión introducidos.
 
-Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?=No_se_puede_citar_entradas_sin_las_claves_BibTeX._¿Generar_ahora?
-New_technical_report=Nuevo_informe_técnico
+Cannot\ cite\ entries\ without\ BibTeX\ keys.\ Generate\ keys\ now?=No se puede citar entradas sin las claves BibTeX. ¿Generar ahora?
+New\ technical\ report=Nuevo informe técnico
 
-%0_file=Archvo_%0
-Custom_layout_file=Archivo_de_diseño_personalizado
-Protected_terms_file=Archivo_de_términos_protegidos
-Style_file=Archivo_de_estilo
+%0\ file=Archvo %0
+Custom\ layout\ file=Archivo de diseño personalizado
+Protected\ terms\ file=Archivo de términos protegidos
+Style\ file=Archivo de estilo
 
-Open_OpenOffice/LibreOffice_connection=Conexión_OpenOffice/LibreOffice
-You_must_enter_at_least_one_field_name=Debe_introducir,_al_menos,_un_nombre_de_campo
-Non-ASCII_encoded_character_found=Se_han_encontrado_caracteres_con_codificación_no-ASCII
-Toggle_web_search_interface=Cambiar_interfaz_de_búsqueda_web
-Background_color_for_resolved_fields=Color_de_fondo_para_campos_resueltos
-Color_code_for_resolved_fields=Código_de_color_para_campos_resueltos
-%0_files_found=Se_encontraron_%0_archivos
-%0_of_%1=%0_de_%1
-One_file_found=Se_encontró_un_archivo
-The_import_finished_with_warnings\:=La_importación_finalizó_con_las_siguientes_alertas\:
-There_was_one_file_that_could_not_be_imported.=No_se_pudo_importar_un_archivo.
-There_were_%0_files_which_could_not_be_imported.=No_se_pudieron_importar_%0_archivos.
+Open\ OpenOffice/LibreOffice\ connection=Conexión OpenOffice/LibreOffice
+You\ must\ enter\ at\ least\ one\ field\ name=Debe introducir, al menos, un nombre de campo
+Non-ASCII\ encoded\ character\ found=Se han encontrado caracteres con codificación no-ASCII
+Toggle\ web\ search\ interface=Cambiar interfaz de búsqueda web
+Background\ color\ for\ resolved\ fields=Color de fondo para campos resueltos
+Color\ code\ for\ resolved\ fields=Código de color para campos resueltos
+%0\ files\ found=Se encontraron %0 archivos
+%0\ of\ %1=%0 de %1
+One\ file\ found=Se encontró un archivo
+The\ import\ finished\ with\ warnings\:=La importación finalizó con las siguientes alertas:
+There\ was\ one\ file\ that\ could\ not\ be\ imported.=No se pudo importar un archivo.
+There\ were\ %0\ files\ which\ could\ not\ be\ imported.=No se pudieron importar %0 archivos.
 
-Migration_help_information=Información_de_ayuda_para_la_migración
-Entered_database_has_obsolete_structure_and_is_no_longer_supported.=La_biblioteca_introducida_tiene_una_estructura_obsoleta_y_no_se_soporta.
-However,_a_new_database_was_created_alongside_the_pre-3.6_one.=En_todo_caso,_una_nueva_biblioteca_ha_sido_creada_junto_a_la_previa_a_la_versión_3.6.
-Click_here_to_learn_about_the_migration_of_pre-3.6_databases.=Haga_click_aquí_para_aprender_sobre_la_migración_de_bibliotecas_de_versiones_previas_a_la_3.6
-Opens_JabRef's_Facebook_page=Abrir_Facebook_de_JabRef
-Opens_JabRef's_blog=Abrir_el_blog_de_JabRef
-Opens_JabRef's_website=Abrir_el_sitio_web_de_JabRef
-Opens_a_link_where_the_current_development_version_can_be_downloaded=Abre_un_enlace_donde_descarga_la_versión_de_desarrollo
-See_what_has_been_changed_in_the_JabRef_versions=Vea_lo_que_se_ha_cambiado_en_las_versiones_de_JabRef
-Referenced_BibTeX_key_does_not_exist=La_clave_BibTex_referenciada_no_existe
-Finished_downloading_full_text_document_for_entry_%0.=Se_ha_completado_la_descarga_del_texto_completo_para_la_entrada_%0.
-Full_text_document_download_failed_for_entry_%0.=Falló_la_descarga_del_texto_completo_para_la_entrada_%0.
-Look_up_full_text_documents=Buscar_textos_completos
-You_are_about_to_look_up_full_text_documents_for_%0_entries.=Está_a_punto_de_buscar_textos_completos_para_%0_entradas
-last_four_nonpunctuation_characters_should_be_numerals=los_últimos_caracteres_de_no-puntuación_deberían_ser_números.
+Migration\ help\ information=Información de ayuda para la migración
+Entered\ database\ has\ obsolete\ structure\ and\ is\ no\ longer\ supported.=La biblioteca introducida tiene una estructura obsoleta y no se soporta.
+However,\ a\ new\ database\ was\ created\ alongside\ the\ pre-3.6\ one.=En todo caso, una nueva biblioteca ha sido creada junto a la previa a la versión 3.6.
+Click\ here\ to\ learn\ about\ the\ migration\ of\ pre-3.6\ databases.=Haga click aquí para aprender sobre la migración de bibliotecas de versiones previas a la 3.6
+Opens\ JabRef's\ Facebook\ page=Abrir Facebook de JabRef
+Opens\ JabRef's\ blog=Abrir el blog de JabRef
+Opens\ JabRef's\ website=Abrir el sitio web de JabRef
+Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=Abre un enlace donde descarga la versión de desarrollo
+See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=Vea lo que se ha cambiado en las versiones de JabRef
+Referenced\ BibTeX\ key\ does\ not\ exist=La clave BibTex referenciada no existe
+Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=Se ha completado la descarga del texto completo para la entrada %0.
+Full\ text\ document\ download\ failed\ for\ entry\ %0.=Falló la descarga del texto completo para la entrada %0.
+Look\ up\ full\ text\ documents=Buscar textos completos
+You\ are\ about\ to\ look\ up\ full\ text\ documents\ for\ %0\ entries.=Está a punto de buscar textos completos para %0 entradas
+last\ four\ nonpunctuation\ characters\ should\ be\ numerals=los últimos caracteres de no-puntuación deberían ser números.
 
 Author=Autor
 Date=Fecha
-File_annotations=Anotaciones_de_fichero
-Show_file_annotations=Mostrar_anotaciones_de_fichero
-Adobe_Acrobat_Reader=Adobe_Acrobat_Reader
-Sumatra_Reader=Sumatra_Reader
+File\ annotations=Anotaciones de fichero
+Show\ file\ annotations=Mostrar anotaciones de fichero
+Adobe\ Acrobat\ Reader=Adobe Acrobat Reader
+Sumatra\ Reader=Sumatra Reader
 shared=compartido
-should_contain_an_integer_or_a_literal=debería_contener_un_entero_o_un_literal
-should_have_the_first_letter_capitalized=debería_tener_la_primera_letra_mayúscula
+should\ contain\ an\ integer\ or\ a\ literal=debería contener un entero o un literal
+should\ have\ the\ first\ letter\ capitalized=debería tener la primera letra mayúscula
 Tools=Herramientas
-What\'s_new_in_this_version?=¿Qué_hay_de_nuevo_en_esta_versión?
-Want_to_help?=¿Desea_ayudar?
-Make_a_donation=Haga_una_donación
-get_involved=participe
-Used_libraries=Librerías_usadas
-Existing_file=Fichero_existente
+What\'s\ new\ in\ this\ version?=¿Qué hay de nuevo en esta versión?
+Want\ to\ help?=¿Desea ayudar?
+Make\ a\ donation=Haga una donación
+get\ involved=participe
+Used\ libraries=Librerías usadas
+Existing\ file=Fichero existente
 
 ID=ID
-ID_type=Tipo_de_ID
-ID-based_entry_generator=Generador_de_entradas_basado_en_ID
-Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=El_recolector_'%0'_no_encontró_entradas_para_la_id_'%1'.
+ID\ type=Tipo de ID
+ID-based\ entry\ generator=Generador de entradas basado en ID
+Fetcher\ '%0'\ did\ not\ find\ an\ entry\ for\ id\ '%1'.=El recolector '%0' no encontró entradas para la id '%1'.
 
-Select_first_entry=Seleccionar_primera_entrada
-Select_last_entry=Seleccionar_última_entrada
+Select\ first\ entry=Seleccionar primera entrada
+Select\ last\ entry=Seleccionar última entrada
 
-Invalid_ISBN\:_'%0'.=El_ISBN_'%0'_no_es_válido.
-should_be_an_integer_or_normalized=debería_ser_normalizado_o_entero
-should_be_normalized=debería_ser_normalizado
+Invalid\ ISBN\:\ '%0'.=El ISBN '%0' no es válido.
+should\ be\ an\ integer\ or\ normalized=debería ser normalizado o entero
+should\ be\ normalized=debería ser normalizado
 
-Empty_search_ID=Vaciar_ID_de_búsqueda
-The_given_search_ID_was_empty.=La_ID_de_búsqueda_está_vacía.
-Copy_BibTeX_key_and_link=Copiar_clave_BibTeX_y_enlace
-empty_BibTeX_key=vaciar_clave_BibTeX
-biblatex_field_only=Sólo_campo_biblatex
+Empty\ search\ ID=Vaciar ID de búsqueda
+The\ given\ search\ ID\ was\ empty.=La ID de búsqueda está vacía.
+Copy\ BibTeX\ key\ and\ link=Copiar clave BibTeX y enlace
+empty\ BibTeX\ key=vaciar clave BibTeX
+biblatex\ field\ only=Sólo campo biblatex
 
-Error_while_generating_fetch_URL=Error_al_generar_la_URL_de_recolección
-Error_while_parsing_ID_list=Error_al_analizar_la_lista_de_ID
-Unable_to_get_PubMed_IDs=No_se_pudieron_obtener_las_ID_PubMed
-Backup_found=Encontrada_copia_de_seguridad
-A_backup_file_for_'%0'_was_found.=Una_copia_de_seguridad_para_'%0'_ha_sido_encontrada.
-This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.=Esto_puede_indicar_que_JabRef_no_se_cerró_correctamente_la_última_vez_que_se_usó_ese_archivo.
-Do_you_want_to_recover_the_library_from_the_backup_file?=¿Quiere_recuperar_la_biblioteca_desde_la_copia_de_seguridad?
-Firstname_Lastname=Nombre_Apellido
+Error\ while\ generating\ fetch\ URL=Error al generar la URL de recolección
+Error\ while\ parsing\ ID\ list=Error al analizar la lista de ID
+Unable\ to\ get\ PubMed\ IDs=No se pudieron obtener las ID PubMed
+Backup\ found=Encontrada copia de seguridad
+A\ backup\ file\ for\ '%0'\ was\ found.=Una copia de seguridad para '%0' ha sido encontrada.
+This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Esto puede indicar que JabRef no se cerró correctamente la última vez que se usó ese archivo.
+Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=¿Quiere recuperar la biblioteca desde la copia de seguridad?
+Firstname\ Lastname=Nombre Apellido
 
-Recommended_for_%0=Recomendado_para_%0
-Show_'Related_Articles'_tab=
-This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=Esto_puede_ser_debido_a_alcanzar_el_límite_de_tráfico_de_GoogleScholar_(vea_la_'Ayuda'_para_más_detalles)
+Recommended\ for\ %0=Recomendado para %0
+Show\ 'Related\ Articles'\ tab=
+This\ might\ be\ caused\ by\ reaching\ the\ traffic\ limitation\ of\ Google\ Scholar\ (see\ 'Help'\ for\ details).=Esto puede ser debido a alcanzar el límite de tráfico de GoogleScholar (vea la 'Ayuda' para más detalles)
 
-Could_not_open_website.=No_se_puede_abrir_el_sitio_web
-Problem_downloading_from_%1=Problemas_descargando_desde_%1
+Could\ not\ open\ website.=No se puede abrir el sitio web
+Problem\ downloading\ from\ %1=Problemas descargando desde %1
 
-File_directory_pattern=Patrón_de_carpetas
-Update_with_bibliographic_information_from_the_web=Actualizar_con_información_bibliográfica_desde_la_web
+File\ directory\ pattern=Patrón de carpetas
+Update\ with\ bibliographic\ information\ from\ the\ web=Actualizar con información bibliográfica desde la web
 
-Could_not_find_any_bibliographic_information.=No_se_puede_encontrar_información_bibliográfica
-BibTeX_key_deviates_from_generated_key=La_clave_BibTeX_difiere_de_la_generada
-DOI_%0_is_invalid=El_DOI_%0_no_es_válido
+Could\ not\ find\ any\ bibliographic\ information.=No se puede encontrar información bibliográfica
+BibTeX\ key\ deviates\ from\ generated\ key=La clave BibTeX difiere de la generada
+DOI\ %0\ is\ invalid=El DOI %0 no es válido
 
-Select_all_customized_types_to_be_stored_in_local_preferences=Seleccione_todos_los_tipos_personalizados_a_ser_almacenados_en_las_preferencias_locales
-Currently_unknown=Actualmente_desconocido
-Different_customization,_current_settings_will_be_overwritten=Diferente_personalización,_se_sobreescribirán_los_ajustes_actuales
+Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences=Seleccione todos los tipos personalizados a ser almacenados en las preferencias locales
+Currently\ unknown=Actualmente desconocido
+Different\ customization,\ current\ settings\ will\ be\ overwritten=Diferente personalización, se sobreescribirán los ajustes actuales
 
-Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX=El_tipo_de_entrada_%0_está_definido_para_BibLaTeX_pero_no_para_BibTeX
-Jump_to_entry=Saltar_a_la_entrada
+Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=El tipo de entrada %0 está definido para BibLaTeX pero no para BibTeX
+Jump\ to\ entry=Saltar a la entrada
 
-Copied_%0_citations.=Se_copiaron_%0_citas
+Copied\ %0\ citations.=Se copiaron %0 citas
 Copying...=Copiando...
 
-journal_not_found_in_abbreviation_list=No_se_encuentra_la_revista_en_la_lista_de_abreviaturas
-Unhandled_exception_occurred.=Ocurrió_una_excepción_no_manejada
+journal\ not\ found\ in\ abbreviation\ list=No se encuentra la revista en la lista de abreviaturas
+Unhandled\ exception\ occurred.=Ocurrió una excepción no manejada
 
-strings_included=cadenas_incluidas
-Color_for_disabled_icons=Color_para_iconos_deshabilitados
-Color_for_enabled_icons=Color_para_iconos_habilitados
-Size_of_large_icons=Tamaño_de_iconos_grandes
-Size_of_small_icons=Tamaño_de_iconos_pequeños
-Default_table_font_size=Tamaño_de_fuente_por_defecto_para_tabla
-Escape_underscores=Escapar_guiones_bajos
+strings\ included=cadenas incluidas
+Color\ for\ disabled\ icons=Color para iconos deshabilitados
+Color\ for\ enabled\ icons=Color para iconos habilitados
+Size\ of\ large\ icons=Tamaño de iconos grandes
+Size\ of\ small\ icons=Tamaño de iconos pequeños
+Default\ table\ font\ size=Tamaño de fuente por defecto para tabla
+Escape\ underscores=Escapar guiones bajos
 Color=Color
-Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=Por_favor,_añada_los_pasos_para_reproducir_el_problema_si_fuera_posible
-Fit_width=Ajustar_ancho
-Fit_a_single_page=Ajustar_a_una_página
-Zoom_in=Aumentar
-Zoom_out=Disminuir
-Previous_page=Página_anterior
-Next_page=Página_siguiente
-Document_viewer=Visor_de_Documentos
-Live=En_vivo
+Please\ also\ add\ all\ steps\ to\ reproduce\ this\ issue,\ if\ possible.=Por favor, añada los pasos para reproducir el problema si fuera posible
+Fit\ width=Ajustar ancho
+Fit\ a\ single\ page=Ajustar a una página
+Zoom\ in=Aumentar
+Zoom\ out=Disminuir
+Previous\ page=Página anterior
+Next\ page=Página siguiente
+Document\ viewer=Visor de Documentos
+Live=En vivo
 Locked=Bloqueado
-Show_document_viewer=Mostrar_el_visor_de_documentos
-Show_the_document_of_the_currently_selected_entry.=Mostrar_el_documento_de_la_entrada_seleccionada
-Show_this_document_until_unlocked.=Mostrar_este_documento_hasta_desbloqueo
-Set_current_user_name_as_owner.=
+Show\ document\ viewer=Mostrar el visor de documentos
+Show\ the\ document\ of\ the\ currently\ selected\ entry.=Mostrar el documento de la entrada seleccionada
+Show\ this\ document\ until\ unlocked.=Mostrar este documento hasta desbloqueo
+Set\ current\ user\ name\ as\ owner.=
 
-Sort_all_subgroups_(recursively)=Ordenar_todos_los_subgrupos_(recursivamente)
-Collect_and_share_telemetry_data_to_help_improve_JabRef.=Recopilar_y_compartir_datos_de_telemetría_para_ayudar_a_la_mejora_de_JabRef
-Don't_share=No_compartir
-Share_anonymous_statistics=Compartir_estadísticas_anónimas
-Telemetry\:_Help_make_JabRef_better=Telemetría:\_Ayude_a_mejorar_JabRef
-To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.=Para_mejorar_la_experiencia_de_usuario,_nos_gustaría_recopilar_estadísitcas_anónimas_sobre_las_funcionalidades_de_JabRef_que_usa._Sólo_se_registrará_qué_funcionalidades_emplea_y_con_qué_frecuencia._No_se_recopilará_ningún_dato_personal_ni_el_contenido_de_los_elementos_bibliográficos._Si_decide_permitir_la_recopilación_de_datos,_podrá_deshabilitarlo_posteriormente_en_Opciones_->_Preferencias_->General
-This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?=
-Names_are_not_in_the_standard_%0_format.=
+Sort\ all\ subgroups\ (recursively)=Ordenar todos los subgrupos (recursivamente)
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=Recopilar y compartir datos de telemetría para ayudar a la mejora de JabRef
+Don't\ share=No compartir
+Share\ anonymous\ statistics=Compartir estadísticas anónimas
+Telemetry\:\ Help\ make\ JabRef\ better=Telemetría:\ Ayude a mejorar JabRef
+To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ statistics\ on\ the\ features\ you\ use.\ We\ will\ only\ record\ what\ features\ you\ access\ and\ how\ often\ you\ do\ it.\ We\ will\ neither\ collect\ any\ personal\ data\ nor\ the\ content\ of\ bibliographic\ items.\ If\ you\ choose\ to\ allow\ data\ collection,\ you\ can\ later\ disable\ it\ via\ Options\ ->\ Preferences\ ->\ General.=Para mejorar la experiencia de usuario, nos gustaría recopilar estadísitcas anónimas sobre las funcionalidades de JabRef que usa. Sólo se registrará qué funcionalidades emplea y con qué frecuencia. No se recopilará ningún dato personal ni el contenido de los elementos bibliográficos. Si decide permitir la recopilación de datos, podrá deshabilitarlo posteriormente en Opciones -> Preferencias ->General
+This\ file\ was\ found\ automatically.\ Do\ you\ want\ to\ link\ it\ to\ this\ entry?=
+Names\ are\ not\ in\ the\ standard\ %0\ format.=
 
-Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.=
-Delete_'%0'=
-Delete_from_disk=
-Remove_from_entry=
-The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.=
-There_exists_already_a_group_with_the_same_name.=
+Delete\ the\ selected\ file\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ file\ permanently\ from\ disk.=
+Delete\ '%0'=
+Delete\ from\ disk=
+Remove\ from\ entry=
+The\ group\ name\ contains\ the\ keyword\ separator\ "%0"\ and\ thus\ probably\ does\ not\ work\ as\ expected.=
+There\ exists\ already\ a\ group\ with\ the\ same\ name.=
 
-Copy_linked_files_to_folder...=
-Copied_file_successfully=
-Copying_files...=
-Copying_file_%0_of_entry_%1=
-Finished_copying=
-Could_not_copy_file=
-Copied_%0_files_of_%1_sucessfully_to_%2=
-Rename_failed=
-JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.=
-Show_console_output_(only_necessary_when_the_launcher_is_used)=
+Copy\ linked\ files\ to\ folder...=
+Copied\ file\ successfully=
+Copying\ files...=
+Copying\ file\ %0\ of\ entry\ %1=
+Finished\ copying=
+Could\ not\ copy\ file=
+Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=
+Rename\ failed=
+JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=
+Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=
 
-Remove_line_breaks=
-Removes_all_line_breaks_in_the_field_content.=
-Checking_integrity...=
+Remove\ line\ breaks=
+Removes\ all\ line\ breaks\ in\ the\ field\ content.=
+Checking\ integrity...=
 
-Remove_hyphenated_line_breaks=
-Removes_all_hyphenated_line_breaks_in_the_field_content.=
-Note_that_currently,_JabRef_does_not_run_with_Java_9.=
-Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.=
+Remove\ hyphenated\ line\ breaks=
+Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=
+Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=
+Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -1,8 +1,3 @@
-
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=
 
 %0\ contains\ the\ term\ <b>%1</b>=

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -3,156 +3,156 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-%0_contains_the_regular_expression_<b>%1</b>=
+%0\ contains\ the\ regular\ expression\ <b>%1</b>=
 
-%0_contains_the_term_<b>%1</b>=
+%0\ contains\ the\ term\ <b>%1</b>=
 
-%0_doesn't_contain_the_regular_expression_<b>%1</b>=
+%0\ doesn't\ contain\ the\ regular\ expression\ <b>%1</b>=
 
-%0_doesn't_contain_the_term_<b>%1</b>=
+%0\ doesn't\ contain\ the\ term\ <b>%1</b>=
 
-%0_export_successful=
+%0\ export\ successful=
 
-%0_matches_the_regular_expression_<b>%1</b>=
+%0\ matches\ the\ regular\ expression\ <b>%1</b>=
 
-%0_matches_the_term_<b>%1</b>=
+%0\ matches\ the\ term\ <b>%1</b>=
 
-<field_name>=
-<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>=
+<field\ name>=
+<HTML>Could\ not\ find\ file\ '%0'<BR>linked\ from\ entry\ '%1'</HTML>=
 
 <select>=
 
-<select_word>=
-Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)=
-Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)=
+<select\ word>=
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (ISO\ abbreviation)=
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (MEDLINE\ abbreviation)=
 
-Abbreviate_names=
-Abbreviated_%0_journal_names.=
+Abbreviate\ names=
+Abbreviated\ %0\ journal\ names.=
 
 Abbreviation=
 
-About_JabRef=
+About\ JabRef=
 
 Abstract=
 
 Accept=
 
-Accept_change=
+Accept\ change=
 
 Action=
 
-What_is_Mr._DLib?=
+What\ is\ Mr.\ DLib?=
 
 Add=
 
-Add_a_(compiled)_custom_Importer_class_from_a_class_path.=
-The_path_need_not_be_on_the_classpath_of_JabRef.=
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=
+The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=
 
-Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=
-The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=
+The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=
 
-Add_a_regular_expression_for_the_key_pattern.=
+Add\ a\ regular\ expression\ for\ the\ key\ pattern.=
 
-Add_selected_entries_to_this_group=
+Add\ selected\ entries\ to\ this\ group=
 
-Add_from_folder=
+Add\ from\ folder=
 
-Add_from_JAR=
+Add\ from\ JAR=
 
-add_group=
+add\ group=
 
-Add_new=
+Add\ new=
 
-Add_subgroup=
+Add\ subgroup=
 
-Add_to_group=
+Add\ to\ group=
 
-Added_group_"%0".=
+Added\ group\ "%0".=
 
-Added_missing_braces.=
+Added\ missing\ braces.=
 
-Added_new=
+Added\ new=
 
-Added_string=
+Added\ string=
 
-Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.=
+Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ can\ be\ assigned\ manually\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ This\ process\ adds\ the\ term\ <b>%1</b>\ to\ each\ entry's\ <b>%0</b>\ field.\ Entries\ can\ be\ removed\ manually\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.\ This\ process\ removes\ the\ term\ <b>%1</b>\ from\ each\ entry's\ <b>%0</b>\ field.=
 
 Advanced=
-All_entries=
-All_entries_of_this_type_will_be_declared_typeless._Continue?=
+All\ entries=
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=
 
-All_fields=
+All\ fields=
 
-Always_reformat_BIB_file_on_save_and_export=
+Always\ reformat\ BIB\ file\ on\ save\ and\ export=
 
-A_SAX_exception_occurred_while_parsing_'%0'\:=
+A\ SAX\ exception\ occurred\ while\ parsing\ '%0'\:=
 
 and=
-and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.=
+and\ the\ class\ must\ be\ available\ in\ your\ classpath\ next\ time\ you\ start\ JabRef.=
 
-any_field_that_matches_the_regular_expression_<b>%0</b>=
+any\ field\ that\ matches\ the\ regular\ expression\ <b>%0</b>=
 
 Appearance=
 
 Append=
-Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library=
+Append\ contents\ from\ a\ BibTeX\ library\ into\ the\ currently\ viewed\ library=
 
-Append_library=
+Append\ library=
 
-Append_the_selected_text_to_BibTeX_field=
+Append\ the\ selected\ text\ to\ BibTeX\ field=
 Application=
 
 Apply=
 
-Arguments_passed_on_to_running_JabRef_instance._Shutting_down.=
+Arguments\ passed\ on\ to\ running\ JabRef\ instance.\ Shutting\ down.=
 
-Assign_new_file=
+Assign\ new\ file=
 
-Assign_the_original_group's_entries_to_this_group?=
+Assign\ the\ original\ group's\ entries\ to\ this\ group?=
 
-Assigned_%0_entries_to_group_"%1".=
+Assigned\ %0\ entries\ to\ group\ "%1".=
 
-Assigned_1_entry_to_group_"%0".=
+Assigned\ 1\ entry\ to\ group\ "%0".=
 
-Attach_URL=
+Attach\ URL=
 
-Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.=
+Attempt\ to\ automatically\ set\ file\ links\ for\ your\ entries.\ Automatically\ setting\ works\ if\ a\ file\ in\ your\ file\ directory<BR>or\ a\ subdirectory\ is\ named\ identically\ to\ an\ entry's\ BibTeX\ key,\ plus\ extension.=
 
-Autodetect_format=
+Autodetect\ format=
 
-Autogenerate_BibTeX_keys=
+Autogenerate\ BibTeX\ keys=
 
-Autolink_files_with_names_starting_with_the_BibTeX_key=
+Autolink\ files\ with\ names\ starting\ with\ the\ BibTeX\ key=
 
-Autolink_only_files_that_match_the_BibTeX_key=
+Autolink\ only\ files\ that\ match\ the\ BibTeX\ key=
 
-Automatically_create_groups=
+Automatically\ create\ groups=
 
-Automatically_remove_exact_duplicates=
+Automatically\ remove\ exact\ duplicates=
 
-Allow_overwriting_existing_links.=
+Allow\ overwriting\ existing\ links.=
 
-Do_not_overwrite_existing_links.=
+Do\ not\ overwrite\ existing\ links.=
 
-AUX_file_import=
+AUX\ file\ import=
 
-Available_export_formats=
+Available\ export\ formats=
 
-Available_BibTeX_fields=
+Available\ BibTeX\ fields=
 
-Available_import_formats=
+Available\ import\ formats=
 
-Background_color_for_optional_fields=
+Background\ color\ for\ optional\ fields=
 
-Background_color_for_required_fields=
+Background\ color\ for\ required\ fields=
 
-Backup_old_file_when_saving=
+Backup\ old\ file\ when\ saving=
 
-BibTeX_key_is_unique.=
+BibTeX\ key\ is\ unique.=
 
-%0_source=
+%0\ source=
 
-Broken_link=
+Broken\ link=
 
 Browse=
 
@@ -160,321 +160,321 @@ by=
 
 Cancel=
 
-Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?=
+Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=
 
-Cannot_merge_this_change=
+Cannot\ merge\ this\ change=
 
-case_insensitive=
+case\ insensitive=
 
-case_sensitive=
+case\ sensitive=
 
-Case_sensitive=
+Case\ sensitive=
 
-change_assignment_of_entries=
+change\ assignment\ of\ entries=
 
-Change_case=
+Change\ case=
 
-Change_entry_type=
-Change_file_type=
+Change\ entry\ type=
+Change\ file\ type=
 
 
-Change_of_Grouping_Method=
+Change\ of\ Grouping\ Method=
 
-change_preamble=
+change\ preamble=
 
-Change_table_column_and_General_fields_settings_to_use_the_new_feature=
+Change\ table\ column\ and\ General\ fields\ settings\ to\ use\ the\ new\ feature=
 
-Changed_language_settings=
+Changed\ language\ settings=
 
-Changed_preamble=
+Changed\ preamble=
 
-Check_existing_file_links=
+Check\ existing\ file\ links=
 
-Check_links=
+Check\ links=
 
-Cite_command=
+Cite\ command=
 
-Class_name=
+Class\ name=
 
 Clear=
 
-Clear_fields=
+Clear\ fields=
 
 Close=
-Close_others=
-Close_all=
+Close\ others=
+Close\ all=
 
-Close_dialog=
+Close\ dialog=
 
-Close_the_current_library=
+Close\ the\ current\ library=
 
-Close_window=
+Close\ window=
 
-Closed_library=
+Closed\ library=
 
-Color_codes_for_required_and_optional_fields=
+Color\ codes\ for\ required\ and\ optional\ fields=
 
-Color_for_marking_incomplete_entries=
+Color\ for\ marking\ incomplete\ entries=
 
-Column_width=
+Column\ width=
 
-Command_line_id=
+Command\ line\ id=
 
 
-Contained_in=
+Contained\ in=
 
 Content=
 
 Copied=
 
-Copied_cell_contents=
+Copied\ cell\ contents=
 
-Copied_title=
+Copied\ title=
 
-Copied_key=
+Copied\ key=
 
-Copied_titles=
+Copied\ titles=
 
-Copied_keys=
+Copied\ keys=
 
 Copy=
 
-Copy_BibTeX_key=
-Copy_file_to_file_directory=
+Copy\ BibTeX\ key=
+Copy\ file\ to\ file\ directory=
 
-Copy_to_clipboard=
+Copy\ to\ clipboard=
 
-Could_not_call_executable=
-Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.=
+Could\ not\ call\ executable=
+Could\ not\ connect\ to\ Vim\ server.\ Make\ sure\ that\ Vim\ is\ running<BR>with\ correct\ server\ name.=
 
-Could_not_export_file=
+Could\ not\ export\ file=
 
-Could_not_export_preferences=
+Could\ not\ export\ preferences=
 
-Could_not_find_a_suitable_import_format.=
-Could_not_import_preferences=
+Could\ not\ find\ a\ suitable\ import\ format.=
+Could\ not\ import\ preferences=
 
-Could_not_instantiate_%0=
-Could_not_instantiate_%0_%1=
-Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?=
-Could_not_open_link=
+Could\ not\ instantiate\ %0=
+Could\ not\ instantiate\ %0\ %1=
+Could\ not\ instantiate\ %0.\ Have\ you\ chosen\ the\ correct\ package\ path?=
+Could\ not\ open\ link=
 
-Could_not_print_preview=
+Could\ not\ print\ preview=
 
-Could_not_run_the_'vim'_program.=
+Could\ not\ run\ the\ 'vim'\ program.=
 
-Could_not_save_file.=
-Character_encoding_'%0'_is_not_supported.=
+Could\ not\ save\ file.=
+Character\ encoding\ '%0'\ is\ not\ supported.=
 
-crossreferenced_entries_included=
+crossreferenced\ entries\ included=
 
-Current_content=
+Current\ content=
 
-Current_value=
+Current\ value=
 
-Custom_entry_types=
+Custom\ entry\ types=
 
-Custom_entry_types_found_in_file=
+Custom\ entry\ types\ found\ in\ file=
 
-Customize_entry_types=
+Customize\ entry\ types=
 
-Customize_key_bindings=
+Customize\ key\ bindings=
 
 Cut=
 
-cut_entries=
+cut\ entries=
 
-cut_entry=
+cut\ entry=
 
 
-Library_encoding=
+Library\ encoding=
 
-Library_properties=
+Library\ properties=
 
-Library_type=
+Library\ type=
 
-Date_format=
+Date\ format=
 
 Default=
 
-Default_encoding=
+Default\ encoding=
 
-Default_grouping_field=
+Default\ grouping\ field=
 
-Default_look_and_feel=
+Default\ look\ and\ feel=
 
-Default_pattern=
+Default\ pattern=
 
-Default_sort_criteria=
-Define_'%0'=
+Default\ sort\ criteria=
+Define\ '%0'=
 
 Delete=
 
-Delete_custom_format=
+Delete\ custom\ format=
 
-delete_entries=
+delete\ entries=
 
-Delete_entry=
+Delete\ entry=
 
-delete_entry=
+delete\ entry=
 
-Delete_multiple_entries=
+Delete\ multiple\ entries=
 
-Delete_rows=
+Delete\ rows=
 
-Delete_strings=
+Delete\ strings=
 
 Deleted=
 
-Permanently_delete_local_file=
+Permanently\ delete\ local\ file=
 
-Delimit_fields_with_semicolon,_ex.=
+Delimit\ fields\ with\ semicolon,\ ex.=
 
 Descending=
 
 Description=
 
-Deselect_all=
-Deselect_all_duplicates=
+Deselect\ all=
+Deselect\ all\ duplicates=
 
-Disable_this_confirmation_dialog=
+Disable\ this\ confirmation\ dialog=
 
-Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.=
+Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups.=
 
-Display_all_error_messages=
+Display\ all\ error\ messages=
 
-Display_help_on_command_line_options=
+Display\ help\ on\ command\ line\ options=
 
-Display_only_entries_belonging_to_all_selected_groups.=
-Display_version=
+Display\ only\ entries\ belonging\ to\ all\ selected\ groups.=
+Display\ version=
 
-Do_not_abbreviate_names=
+Do\ not\ abbreviate\ names=
 
-Do_not_automatically_set=
+Do\ not\ automatically\ set=
 
-Do_not_import_entry=
+Do\ not\ import\ entry=
 
-Do_not_open_any_files_at_startup=
+Do\ not\ open\ any\ files\ at\ startup=
 
-Do_not_overwrite_existing_keys=
-Do_not_show_these_options_in_the_future=
+Do\ not\ overwrite\ existing\ keys=
+Do\ not\ show\ these\ options\ in\ the\ future=
 
-Do_not_wrap_the_following_fields_when_saving=
-Do_not_write_the_following_fields_to_XMP_Metadata\:=
+Do\ not\ wrap\ the\ following\ fields\ when\ saving=
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=
 
-Do_you_want_JabRef_to_do_the_following_operations?=
+Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=
 
-Donate_to_JabRef=
+Donate\ to\ JabRef=
 
 Down=
 
-Download_file=
+Download\ file=
 
 Downloading...=
 
-Drop_%0=
+Drop\ %0=
 
-duplicate_removal=
+duplicate\ removal=
 
-Duplicate_string_name=
+Duplicate\ string\ name=
 
-Duplicates_found=
+Duplicates\ found=
 
-Dynamic_groups=
+Dynamic\ groups=
 
-Dynamically_group_entries_by_a_free-form_search_expression=
+Dynamically\ group\ entries\ by\ a\ free-form\ search\ expression=
 
-Dynamically_group_entries_by_searching_a_field_for_a_keyword=
+Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=
 
-Each_line_must_be_on_the_following_form=
+Each\ line\ must\ be\ on\ the\ following\ form=
 
 Edit=
 
-Edit_custom_export=
-Edit_entry=
-Save_file=
-Edit_file_type=
+Edit\ custom\ export=
+Edit\ entry=
+Save\ file=
+Edit\ file\ type=
 
-Edit_group=
+Edit\ group=
 
 
-Edit_preamble=
-Edit_strings=
-Editor_options=
+Edit\ preamble=
+Edit\ strings=
+Editor\ options=
 
-Empty_BibTeX_key=
+Empty\ BibTeX\ key=
 
-Grouping_may_not_work_for_this_entry.=
+Grouping\ may\ not\ work\ for\ this\ entry.=
 
-empty_library=
-Enable_word/name_autocompletion=
+empty\ library=
+Enable\ word/name\ autocompletion=
 
-Enter_URL=
+Enter\ URL=
 
-Enter_URL_to_download=
+Enter\ URL\ to\ download=
 
 entries=
 
-Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.=
+Entries\ cannot\ be\ manually\ assigned\ to\ or\ removed\ from\ this\ group.=
 
-Entries_exported_to_clipboard=
+Entries\ exported\ to\ clipboard=
 
 
 entry=
 
-Entry_editor=
+Entry\ editor=
 
-Entry_preview=
+Entry\ preview=
 
-Entry_table=
+Entry\ table=
 
-Entry_table_columns=
+Entry\ table\ columns=
 
-Entry_type=
+Entry\ type=
 
-Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters=
+Entry\ type\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=
 
-Entry_types=
+Entry\ types=
 
 Error=
-Error_exporting_to_clipboard=
+Error\ exporting\ to\ clipboard=
 
-Error_occurred_when_parsing_entry=
+Error\ occurred\ when\ parsing\ entry=
 
-Error_opening_file=
+Error\ opening\ file=
 
-Error_setting_field=
+Error\ setting\ field=
 
-Error_while_writing=
-Error_writing_to_%0_file(s).=
+Error\ while\ writing=
+Error\ writing\ to\ %0\ file(s).=
 
 
 
-'%0'_exists._Overwrite_file?=
-Overwrite_file?=
+'%0'\ exists.\ Overwrite\ file?=
+Overwrite\ file?=
 
 Export=
 
-Export_name=
+Export\ name=
 
-Export_preferences=
+Export\ preferences=
 
-Export_preferences_to_file=
+Export\ preferences\ to\ file=
 
-Export_properties=
+Export\ properties=
 
-Export_to_clipboard=
+Export\ to\ clipboard=
 
 Exporting=
 Extension=
 
-External_changes=
+External\ changes=
 
-External_file_links=
+External\ file\ links=
 
-External_programs=
+External\ programs=
 
-External_viewer_called=
+External\ viewer\ called=
 
 Fetch=
 
@@ -482,210 +482,210 @@ Field=
 
 field=
 
-Field_name=
-Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters=
+Field\ name=
+Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=
 
-Field_to_filter=
+Field\ to\ filter=
 
-Field_to_group_by=
+Field\ to\ group\ by=
 
 File=
 
 file=
-File_'%0'_is_already_open.=
+File\ '%0'\ is\ already\ open.=
 
-File_changed=
-File_directory_is_'%0'\:=
+File\ changed=
+File\ directory\ is\ '%0'\:=
 
-File_directory_is_not_set_or_does_not_exist\!=
+File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=
 
-File_exists=
+File\ exists=
 
-File_has_been_updated_externally._What_do_you_want_to_do?=
+File\ has\ been\ updated\ externally.\ What\ do\ you\ want\ to\ do?=
 
-File_not_found=
-File_type=
+File\ not\ found=
+File\ type=
 
-File_updated_externally=
+File\ updated\ externally=
 
 filename=
 
 Filename=
 
-Files_opened=
+Files\ opened=
 
 Filter=
 
-Filter_All=
+Filter\ All=
 
-Filter_None=
+Filter\ None=
 
-Finished_automatically_setting_external_links.=
+Finished\ automatically\ setting\ external\ links.=
 
-Finished_synchronizing_file_links._Entries_changed\:_%0.=
-Finished_writing_XMP-metadata._Wrote_to_%0_file(s).=
-Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).=
+Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=
+Finished\ writing\ XMP-metadata.\ Wrote\ to\ %0\ file(s).=
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=
 
-First_select_the_entries_you_want_keys_to_be_generated_for.=
+First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=
 
-Fit_table_horizontally_on_screen=
+Fit\ table\ horizontally\ on\ screen=
 
 Float=
-Float_marked_entries=
+Float\ marked\ entries=
 
-Font_family=
+Font\ family=
 
-Font_preview=
+Font\ preview=
 
-Font_size=
+Font\ size=
 
-Font_style=
+Font\ style=
 
-Font_selection=
+Font\ selection=
 
 for=
 
-Format_of_author_and_editor_names=
-Format_string=
+Format\ of\ author\ and\ editor\ names=
+Format\ string=
 
-Format_used=
-Formatter_name=
+Format\ used=
+Formatter\ name=
 
-found_in_AUX_file=
+found\ in\ AUX\ file=
 
-Full_name=
+Full\ name=
 
 General=
 
-General_fields=
+General\ fields=
 
 Generate=
 
-Generate_BibTeX_key=
+Generate\ BibTeX\ key=
 
-Generate_keys=
+Generate\ keys=
 
-Generate_keys_before_saving_(for_entries_without_a_key)=
-Generate_keys_for_imported_entries=
+Generate\ keys\ before\ saving\ (for\ entries\ without\ a\ key)=
+Generate\ keys\ for\ imported\ entries=
 
-Generate_now=
+Generate\ now=
 
-Generated_BibTeX_key_for=
+Generated\ BibTeX\ key\ for=
 
-Generating_BibTeX_key_for=
-Get_fulltext=
+Generating\ BibTeX\ key\ for=
+Get\ fulltext=
 
-Gray_out_non-hits=
+Gray\ out\ non-hits=
 
 Groups=
 
-Have_you_chosen_the_correct_package_path?=
+Have\ you\ chosen\ the\ correct\ package\ path?=
 
 Help=
 
-Help_on_key_patterns=
-Help_on_regular_expression_search=
+Help\ on\ key\ patterns=
+Help\ on\ regular\ expression\ search=
 
-Hide_non-hits=
+Hide\ non-hits=
 
-Hierarchical_context=
+Hierarchical\ context=
 
 Highlight=
 Marking=
 Underline=
-Empty_Highlight=
-Empty_Marking=
-Empty_Underline=
-The_marked_area_does_not_contain_any_legible_text!=
+Empty\ Highlight=
+Empty\ Marking=
+Empty\ Underline=
+The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=
 
-Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>=
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=
 
-HTML_table=
-HTML_table_(with_Abstract_&_BibTeX)=
+HTML\ table=
+HTML\ table\ (with\ Abstract\ &\ BibTeX)=
 Icon=
 
 Ignore=
 
 Import=
 
-Import_and_keep_old_entry=
+Import\ and\ keep\ old\ entry=
 
-Import_and_remove_old_entry=
+Import\ and\ remove\ old\ entry=
 
-Import_entries=
+Import\ entries=
 
-Import_failed=
+Import\ failed=
 
-Import_file=
+Import\ file=
 
-Import_group_definitions=
+Import\ group\ definitions=
 
-Import_name=
+Import\ name=
 
-Import_preferences=
+Import\ preferences=
 
-Import_preferences_from_file=
+Import\ preferences\ from\ file=
 
-Import_strings=
+Import\ strings=
 
-Import_to_open_tab=
+Import\ to\ open\ tab=
 
-Import_word_selector_definitions=
+Import\ word\ selector\ definitions=
 
-Imported_entries=
+Imported\ entries=
 
-Imported_from_library=
+Imported\ from\ library=
 
-Importer_class=
+Importer\ class=
 
 Importing=
 
-Importing_in_unknown_format=
+Importing\ in\ unknown\ format=
 
-Include_abstracts=
-Include_entries=
+Include\ abstracts=
+Include\ entries=
 
-Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups=
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=
 
-Independent_group\:_When_selected,_view_only_this_group's_entries=
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=
 
-Work_options=
+Work\ options=
 
 Insert=
 
-Insert_rows=
+Insert\ rows=
 
 Intersection=
 
-Invalid_BibTeX_key=
+Invalid\ BibTeX\ key=
 
-Invalid_date_format=
+Invalid\ date\ format=
 
-Invalid_URL=
+Invalid\ URL=
 
-Online_help=
+Online\ help=
 
-JabRef_preferences=
+JabRef\ preferences=
 
 Join=
 
-Joins_selected_keywords_and_deletes_selected_keywords.=
+Joins\ selected\ keywords\ and\ deletes\ selected\ keywords.=
 
-Journal_abbreviations=
+Journal\ abbreviations=
 
 Keep=
 
-Keep_both=
+Keep\ both=
 
-Key_bindings=
+Key\ bindings=
 
-Key_bindings_changed=
+Key\ bindings\ changed=
 
-Key_generator_settings=
+Key\ generator\ settings=
 
-Key_pattern=
+Key\ pattern=
 
-keys_in_library=
+keys\ in\ library=
 
 Keyword=
 
@@ -693,449 +693,449 @@ Label=
 
 Language=
 
-Last_modified=
+Last\ modified=
 
-LaTeX_AUX_file=
-Leave_file_in_its_current_directory=
+LaTeX\ AUX\ file=
+Leave\ file\ in\ its\ current\ directory=
 
 Left=
 Level=
 
-Limit_to_fields=
+Limit\ to\ fields=
 
-Limit_to_selected_entries=
+Limit\ to\ selected\ entries=
 
 Link=
-Link_local_file=
-Link_to_file_%0=
+Link\ local\ file=
+Link\ to\ file\ %0=
 
-Listen_for_remote_operation_on_port=
-Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)=
+Listen\ for\ remote\ operation\ on\ port=
+Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=
 
-Look_and_feel=
-Main_file_directory=
+Look\ and\ feel=
+Main\ file\ directory=
 
-Main_layout_file=
+Main\ layout\ file=
 
-Manage_custom_exports=
+Manage\ custom\ exports=
 
-Manage_custom_imports=
-Manage_external_file_types=
+Manage\ custom\ imports=
+Manage\ external\ file\ types=
 
-Mark_entries=
+Mark\ entries=
 
-Mark_entry=
+Mark\ entry=
 
-Mark_new_entries_with_addition_date=
+Mark\ new\ entries\ with\ addition\ date=
 
-Mark_new_entries_with_owner_name=
+Mark\ new\ entries\ with\ owner\ name=
 
-Memory_stick_mode=
+Memory\ stick\ mode=
 
-Menu_and_label_font_size=
+Menu\ and\ label\ font\ size=
 
-Merged_external_changes=
+Merged\ external\ changes=
 
 Messages=
 
-Modification_of_field=
+Modification\ of\ field=
 
-Modified_group_"%0".=
+Modified\ group\ "%0".=
 
-Modified_groups=
+Modified\ groups=
 
-Modified_string=
+Modified\ string=
 
 Modify=
 
-modify_group=
+modify\ group=
 
-Move_down=
+Move\ down=
 
-Move_external_links_to_'file'_field=
+Move\ external\ links\ to\ 'file'\ field=
 
-move_group=
+move\ group=
 
-Move_up=
+Move\ up=
 
-Moved_group_"%0".=
+Moved\ group\ "%0".=
 
 Name=
-Name_formatter=
+Name\ formatter=
 
-Natbib_style=
+Natbib\ style=
 
-nested_AUX_files=
+nested\ AUX\ files=
 
 New=
 
 new=
 
-New_BibTeX_entry=
+New\ BibTeX\ entry=
 
-New_BibTeX_sublibrary=
+New\ BibTeX\ sublibrary=
 
-New_content=
+New\ content=
 
-New_library_created.=
-New_%0_library=
-New_field_value=
+New\ library\ created.=
+New\ %0\ library=
+New\ field\ value=
 
-New_group=
+New\ group=
 
-New_string=
+New\ string=
 
-Next_entry=
+Next\ entry=
 
-No_actual_changes_found.=
+No\ actual\ changes\ found.=
 
-no_base-BibTeX-file_specified=
+no\ base-BibTeX-file\ specified=
 
-no_library_generated=
+no\ library\ generated=
 
-No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.=
+No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=
 
 
-No_entries_found_for_the_search_string_'%0'=
+No\ entries\ found\ for\ the\ search\ string\ '%0'=
 
-No_entries_imported.=
+No\ entries\ imported.=
 
-No_files_found.=
+No\ files\ found.=
 
-No_GUI._Only_process_command_line_options.=
+No\ GUI.\ Only\ process\ command\ line\ options.=
 
-No_journal_names_could_be_abbreviated.=
+No\ journal\ names\ could\ be\ abbreviated.=
 
-No_journal_names_could_be_unabbreviated.=
-No_PDF_linked=
+No\ journal\ names\ could\ be\ unabbreviated.=
+No\ PDF\ linked=
 
-Open_PDF=
+Open\ PDF=
 
-No_URL_defined=
+No\ URL\ defined=
 not=
 
-not_found=
+not\ found=
 
-Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,=
+Note\ that\ you\ must\ specify\ the\ fully\ qualified\ class\ name\ for\ the\ look\ and\ feel,=
 
-Nothing_to_redo=
+Nothing\ to\ redo=
 
-Nothing_to_undo=
+Nothing\ to\ undo=
 
 occurrences=
 
 OK=
-One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=
+One\ or\ more\ file\ links\ are\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=
 
-One_or_more_keys_will_be_overwritten._Continue?=
+One\ or\ more\ keys\ will\ be\ overwritten.\ Continue?=
 
 
 Open=
 
-Open_BibTeX_library=
+Open\ BibTeX\ library=
 
-Open_library=
+Open\ library=
 
-Open_editor_when_a_new_entry_is_created=
+Open\ editor\ when\ a\ new\ entry\ is\ created=
 
-Open_file=
+Open\ file=
 
-Open_last_edited_libraries_at_startup=
+Open\ last\ edited\ libraries\ at\ startup=
 
-Connect_to_shared_database=
+Connect\ to\ shared\ database=
 
-Open_terminal_here=
+Open\ terminal\ here=
 
-Open_URL_or_DOI=
+Open\ URL\ or\ DOI=
 
-Opened_library=
+Opened\ library=
 
 Opening=
 
-Opening_preferences...=
+Opening\ preferences...=
 
-Operation_canceled.=
-Operation_not_supported=
+Operation\ canceled.=
+Operation\ not\ supported=
 
-Optional_fields=
+Optional\ fields=
 
 Options=
 
 or=
 
-Output_or_export_file=
+Output\ or\ export\ file=
 
 Override=
 
-Override_default_file_directories=
+Override\ default\ file\ directories=
 
-Override_default_font_settings=
+Override\ default\ font\ settings=
 
-Override_the_BibTeX_field_by_the_selected_text=
+Override\ the\ BibTeX\ field\ by\ the\ selected\ text=
 
 
 Overwrite=
-Overwrite_existing_field_values=
+Overwrite\ existing\ field\ values=
 
-Overwrite_keys=
+Overwrite\ keys=
 
-pairs_processed=
+pairs\ processed=
 Password=
 
 Paste=
 
-paste_entries=
+paste\ entries=
 
-paste_entry=
-Paste_from_clipboard=
+paste\ entry=
+Paste\ from\ clipboard=
 
 Pasted=
 
-Path_to_%0_not_defined=
+Path\ to\ %0\ not\ defined=
 
-Path_to_LyX_pipe=
+Path\ to\ LyX\ pipe=
 
-PDF_does_not_exist=
+PDF\ does\ not\ exist=
 
-File_has_no_attached_annotations=
+File\ has\ no\ attached\ annotations=
 
-Plain_text_import=
+Plain\ text\ import=
 
-Please_enter_a_name_for_the_group.=
+Please\ enter\ a\ name\ for\ the\ group.=
 
-Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>=
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=
 
-Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=
+Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=
 
-Please_enter_the_string's_label=
+Please\ enter\ the\ string's\ label=
 
-Please_select_an_importer.=
+Please\ select\ an\ importer.=
 
-Possible_duplicate_entries=
+Possible\ duplicate\ entries=
 
-Possible_duplicate_of_existing_entry._Click_to_resolve.=
+Possible\ duplicate\ of\ existing\ entry.\ Click\ to\ resolve.=
 
 Preamble=
 
 Preferences=
 
-Preferences_recorded.=
+Preferences\ recorded.=
 
 Preview=
-Citation_Style=
-Current_Preview=
-Cannot_generate_preview_based_on_selected_citation_style.=
-Bad_character_inside_entry=
-Error_while_generating_citation_style=
-Preview_style_changed_to\:_%0=
-Next_preview_layout=
-Previous_preview_layout=
+Citation\ Style=
+Current\ Preview=
+Cannot\ generate\ preview\ based\ on\ selected\ citation\ style.=
+Bad\ character\ inside\ entry=
+Error\ while\ generating\ citation\ style=
+Preview\ style\ changed\ to\:\ %0=
+Next\ preview\ layout=
+Previous\ preview\ layout=
 
-Previous_entry=
+Previous\ entry=
 
-Primary_sort_criterion=
-Problem_with_parsing_entry=
-Processing_%0=
-Pull_changes_from_shared_database=
+Primary\ sort\ criterion=
+Problem\ with\ parsing\ entry=
+Processing\ %0=
+Pull\ changes\ from\ shared\ database=
 
-Pushed_citations_to_%0=
+Pushed\ citations\ to\ %0=
 
-Quit_JabRef=
+Quit\ JabRef=
 
-Quit_synchronization=
+Quit\ synchronization=
 
-Raw_source=
+Raw\ source=
 
-Rearrange_tabs_alphabetically_by_title=
+Rearrange\ tabs\ alphabetically\ by\ title=
 
 Redo=
 
-Reference_library=
+Reference\ library=
 
-%0_references_found._Number_of_references_to_fetch?=
+%0\ references\ found.\ Number\ of\ references\ to\ fetch?=
 
-Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=
 
-regular_expression=
+regular\ expression=
 
-Related_articles=
+Related\ articles=
 
-Remote_operation=
+Remote\ operation=
 
-Remote_server_port=
+Remote\ server\ port=
 
 Remove=
 
-Remove_subgroups=
+Remove\ subgroups=
 
-Remove_all_subgroups_of_"%0"?=
+Remove\ all\ subgroups\ of\ "%0"?=
 
-Remove_entry_from_import=
+Remove\ entry\ from\ import=
 
-Remove_selected_entries_from_this_group=
+Remove\ selected\ entries\ from\ this\ group=
 
-Remove_entry_type=
+Remove\ entry\ type=
 
-Remove_from_group=
+Remove\ from\ group=
 
-Remove_group=
+Remove\ group=
 
-Remove_group,_keep_subgroups=
+Remove\ group,\ keep\ subgroups=
 
-Remove_group_"%0"?=
+Remove\ group\ "%0"?=
 
-Remove_group_"%0"_and_its_subgroups?=
+Remove\ group\ "%0"\ and\ its\ subgroups?=
 
-remove_group_(keep_subgroups)=
+remove\ group\ (keep\ subgroups)=
 
-remove_group_and_subgroups=
+remove\ group\ and\ subgroups=
 
-Remove_group_and_subgroups=
+Remove\ group\ and\ subgroups=
 
-Remove_link=
+Remove\ link=
 
-Remove_old_entry=
+Remove\ old\ entry=
 
-Remove_selected_strings=
+Remove\ selected\ strings=
 
-Removed_group_"%0".=
+Removed\ group\ "%0".=
 
-Removed_group_"%0"_and_its_subgroups.=
+Removed\ group\ "%0"\ and\ its\ subgroups.=
 
-Removed_string=
+Removed\ string=
 
-Renamed_string=
+Renamed\ string=
 
 Replace=
 
-Replace_(regular_expression)=
+Replace\ (regular\ expression)=
 
-Replace_string=
+Replace\ string=
 
-Replace_with=
+Replace\ with=
 
 Replaced=
 
-Required_fields=
+Required\ fields=
 
-Reset_all=
+Reset\ all=
 
-Resolve_strings_for_all_fields_except=
-Resolve_strings_for_standard_BibTeX_fields_only=
+Resolve\ strings\ for\ all\ fields\ except=
+Resolve\ strings\ for\ standard\ BibTeX\ fields\ only=
 
 resolved=
 
 Review=
 
-Review_changes=
+Review\ changes=
 
 Right=
 
 Save=
-Save_all_finished.=
+Save\ all\ finished.=
 
-Save_all_open_libraries=
+Save\ all\ open\ libraries=
 
-Save_before_closing=
+Save\ before\ closing=
 
-Save_library=
-Save_library_as...=
+Save\ library=
+Save\ library\ as...=
 
-Save_entries_in_their_original_order=
+Save\ entries\ in\ their\ original\ order=
 
-Save_failed=
+Save\ failed=
 
-Save_failed_during_backup_creation=
+Save\ failed\ during\ backup\ creation=
 
-Save_selected_as...=
+Save\ selected\ as...=
 
-Saved_library=
+Saved\ library=
 
-Saved_selected_to_'%0'.=
+Saved\ selected\ to\ '%0'.=
 
 Saving=
-Saving_all_libraries...=
+Saving\ all\ libraries...=
 
-Saving_library=
+Saving\ library=
 
 Search=
 
-Search_expression=
+Search\ expression=
 
-Search_for=
+Search\ for=
 
-Searching_for_duplicates...=
+Searching\ for\ duplicates...=
 
-Searching_for_files=
+Searching\ for\ files=
 
-Secondary_sort_criterion=
+Secondary\ sort\ criterion=
 
-Select_all=
+Select\ all=
 
-Select_encoding=
+Select\ encoding=
 
-Select_entry_type=
-Select_external_application=
+Select\ entry\ type=
+Select\ external\ application=
 
-Select_file_from_ZIP-archive=
+Select\ file\ from\ ZIP-archive=
 
-Select_the_tree_nodes_to_view_and_accept_or_reject_changes=
-Selected_entries=
-Set_field=
-Set_fields=
+Select\ the\ tree\ nodes\ to\ view\ and\ accept\ or\ reject\ changes=
+Selected\ entries=
+Set\ field=
+Set\ fields=
 
-Set_general_fields=
-Set_main_external_file_directory=
+Set\ general\ fields=
+Set\ main\ external\ file\ directory=
 
-Set_table_font=
+Set\ table\ font=
 
 Settings=
 
 Shortcut=
 
-Show/edit_%0_source=
+Show/edit\ %0\ source=
 
-Show_'Firstname_Lastname'=
+Show\ 'Firstname\ Lastname'=
 
-Show_'Lastname,_Firstname'=
+Show\ 'Lastname,\ Firstname'=
 
-Show_BibTeX_source_by_default=
+Show\ BibTeX\ source\ by\ default=
 
-Show_confirmation_dialog_when_deleting_entries=
+Show\ confirmation\ dialog\ when\ deleting\ entries=
 
-Show_description=
+Show\ description=
 
-Show_file_column=
+Show\ file\ column=
 
-Show_last_names_only=
+Show\ last\ names\ only=
 
-Show_names_unchanged=
+Show\ names\ unchanged=
 
-Show_optional_fields=
+Show\ optional\ fields=
 
-Show_required_fields=
+Show\ required\ fields=
 
-Show_URL/DOI_column=
+Show\ URL/DOI\ column=
 
-Simple_HTML=
+Simple\ HTML=
 
 Size=
 
-Skipped_-_No_PDF_linked=
-Skipped_-_PDF_does_not_exist=
+Skipped\ -\ No\ PDF\ linked=
+Skipped\ -\ PDF\ does\ not\ exist=
 
-Skipped_entry.=
+Skipped\ entry.=
 
-Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.=
+Some\ appearance\ settings\ you\ changed\ require\ to\ restart\ JabRef\ to\ come\ into\ effect.=
 
-source_edit=
-Special_name_formatters=
+source\ edit=
+Special\ name\ formatters=
 
-Special_table_columns=
+Special\ table\ columns=
 
-Starting_import=
+Starting\ import=
 
-Statically_group_entries_by_manual_assignment=
+Statically\ group\ entries\ by\ manual\ assignment=
 
 Status=
 
@@ -1143,1019 +1143,1019 @@ Stop=
 
 Strings=
 
-Strings_for_library=
+Strings\ for\ library=
 
-Sublibrary_from_AUX=
+Sublibrary\ from\ AUX=
 
-Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.=
+Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=
 
-Synchronize_file_links=
+Synchronize\ file\ links=
 
-Synchronizing_file_links...=
+Synchronizing\ file\ links...=
 
-Table_appearance=
+Table\ appearance=
 
-Table_background_color=
+Table\ background\ color=
 
-Table_grid_color=
+Table\ grid\ color=
 
-Table_text_color=
+Table\ text\ color=
 
 Tabname=
-Target_file_cannot_be_a_directory.=
+Target\ file\ cannot\ be\ a\ directory.=
 
-Tertiary_sort_criterion=
+Tertiary\ sort\ criterion=
 
 Test=
 
-paste_text_here=
+paste\ text\ here=
 
-The_chosen_date_format_for_new_entries_is_not_valid=
+The\ chosen\ date\ format\ for\ new\ entries\ is\ not\ valid=
 
-The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:=
+The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=
 
 
-the_field_<b>%0</b>=
+the\ field\ <b>%0</b>=
 
-The_file<BR>'%0'<BR>has_been_modified<BR>externally\!=
+The\ file<BR>'%0'<BR>has\ been\ modified<BR>externally\!=
 
-The_group_"%0"_already_contains_the_selection.=
+The\ group\ "%0"\ already\ contains\ the\ selection.=
 
-The_label_of_the_string_cannot_be_a_number.=
+The\ label\ of\ the\ string\ cannot\ be\ a\ number.=
 
-The_label_of_the_string_cannot_contain_spaces.=
+The\ label\ of\ the\ string\ cannot\ contain\ spaces.=
 
-The_label_of_the_string_cannot_contain_the_'\#'_character.=
+The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=
 
-The_output_option_depends_on_a_valid_import_option.=
-The_PDF_contains_one_or_several_BibTeX-records.=
-Do_you_want_to_import_these_as_new_entries_into_the_current_library?=
+The\ output\ option\ depends\ on\ a\ valid\ import\ option.=
+The\ PDF\ contains\ one\ or\ several\ BibTeX-records.=
+Do\ you\ want\ to\ import\ these\ as\ new\ entries\ into\ the\ current\ library?=
 
-The_regular_expression_<b>%0</b>_is_invalid\:=
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=
 
-The_search_is_case_insensitive.=
+The\ search\ is\ case\ insensitive.=
 
-The_search_is_case_sensitive.=
+The\ search\ is\ case\ sensitive.=
 
-The_string_has_been_removed_locally=
+The\ string\ has\ been\ removed\ locally=
 
-There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?=
+There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=
 
-This_entry_has_no_BibTeX_key._Generate_key_now?=
+This\ entry\ has\ no\ BibTeX\ key.\ Generate\ key\ now?=
 
-This_entry_is_incomplete=
+This\ entry\ is\ incomplete=
 
-This_entry_type_cannot_be_removed.=
+This\ entry\ type\ cannot\ be\ removed.=
 
-This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=
+This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=
 
-This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.=
+This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>=
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>=
-This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.=
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=
+This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=
 
-This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.=
+This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=
 
-This_operation_requires_one_or_more_entries_to_be_selected.=
+This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=
 
-Toggle_entry_preview=
-Toggle_groups_interface=
-Try_different_encoding=
+Toggle\ entry\ preview=
+Toggle\ groups\ interface=
+Try\ different\ encoding=
 
-Unabbreviate_journal_names_of_the_selected_entries=
-Unabbreviated_%0_journal_names.=
+Unabbreviate\ journal\ names\ of\ the\ selected\ entries=
+Unabbreviated\ %0\ journal\ names.=
 
-Unable_to_open_file.=
-Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.=
-unable_to_write_to=
-Undefined_file_type=
+Unable\ to\ open\ file.=
+Unable\ to\ open\ link.\ The\ application\ '%0'\ associated\ with\ the\ file\ type\ '%1'\ could\ not\ be\ called.=
+unable\ to\ write\ to=
+Undefined\ file\ type=
 
 Undo=
 
 Union=
 
-Unknown_BibTeX_entries=
+Unknown\ BibTeX\ entries=
 
-unknown_edit=
+unknown\ edit=
 
-Unknown_export_format=
+Unknown\ export\ format=
 
-Unmark_all=
+Unmark\ all=
 
-Unmark_entries=
+Unmark\ entries=
 
-Unmark_entry=
+Unmark\ entry=
 
 untitled=
 
 Up=
 
-Update_to_current_column_widths=
+Update\ to\ current\ column\ widths=
 
-Updated_group_selection=
-Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.=
-Upgrade_file=
-Upgrade_old_external_file_links_to_use_the_new_feature=
+Updated\ group\ selection=
+Upgrade\ external\ PDF/PS\ links\ to\ use\ the\ '%0'\ field.=
+Upgrade\ file=
+Upgrade\ old\ external\ file\ links\ to\ use\ the\ new\ feature=
 
 usage=
-Use_autocompletion_for_the_following_fields=
+Use\ autocompletion\ for\ the\ following\ fields=
 
-Use_other_look_and_feel=
-Tweak_font_rendering_for_entry_editor_on_Linux=
-Use_regular_expression_search=
+Use\ other\ look\ and\ feel=
+Tweak\ font\ rendering\ for\ entry\ editor\ on\ Linux=
+Use\ regular\ expression\ search=
 
 Username=
 
-Value_cleared_externally=
+Value\ cleared\ externally=
 
-Value_set_externally=
+Value\ set\ externally=
 
-verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid=
+verify\ that\ LyX\ is\ running\ and\ that\ the\ lyxpipe\ is\ valid=
 
 View=
-Vim_server_name=
+Vim\ server\ name=
 
-Waiting_for_ArXiv...=
+Waiting\ for\ ArXiv...=
 
-Warn_about_unresolved_duplicates_when_closing_inspection_window=
+Warn\ about\ unresolved\ duplicates\ when\ closing\ inspection\ window=
 
-Warn_before_overwriting_existing_keys=
+Warn\ before\ overwriting\ existing\ keys=
 
 Warning=
 
 Warnings=
 
-web_link=
+web\ link=
 
-What_do_you_want_to_do?=
+What\ do\ you\ want\ to\ do?=
 
-When_adding/removing_keywords,_separate_them_by=
-Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.=
+When\ adding/removing\ keywords,\ separate\ them\ by=
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=
 
 with=
 
-Write_BibTeXEntry_as_XMP-metadata_to_PDF.=
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=
 
-Write_XMP=
-Write_XMP-metadata=
-Write_XMP-metadata_for_all_PDFs_in_current_library?=
-Writing_XMP-metadata...=
-Writing_XMP-metadata_for_selected_entries...=
+Write\ XMP=
+Write\ XMP-metadata=
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=
+Writing\ XMP-metadata...=
+Writing\ XMP-metadata\ for\ selected\ entries...=
 
-Wrote_XMP-metadata=
+Wrote\ XMP-metadata=
 
-XMP-annotated_PDF=
-XMP_export_privacy_settings=
+XMP-annotated\ PDF=
+XMP\ export\ privacy\ settings=
 XMP-metadata=
-XMP-metadata_found_in_PDF\:_%0=
-You_must_restart_JabRef_for_this_to_come_into_effect.=
-You_have_changed_the_language_setting.=
-You_have_entered_an_invalid_search_'%0'.=
+XMP-metadata\ found\ in\ PDF\:\ %0=
+You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=
+You\ have\ changed\ the\ language\ setting.=
+You\ have\ entered\ an\ invalid\ search\ '%0'.=
 
-You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.=
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=
 
-Your_new_key_bindings_have_been_stored.=
+Your\ new\ key\ bindings\ have\ been\ stored.=
 
-The_following_fetchers_are_available\:=
-Could_not_find_fetcher_'%0'=
-Running_query_'%0'_with_fetcher_'%1'.=
-Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.=
+The\ following\ fetchers\ are\ available\:=
+Could\ not\ find\ fetcher\ '%0'=
+Running\ query\ '%0'\ with\ fetcher\ '%1'.=
+Query\ '%0'\ with\ fetcher\ '%1'\ did\ not\ return\ any\ results.=
 
-Move_file=
-Rename_file=
+Move\ file=
+Rename\ file=
 
-Move_file_failed=
-Could_not_move_file_'%0'.=
-Could_not_find_file_'%0'.=
-Number_of_entries_successfully_imported=
-Import_canceled_by_user=
-Progress\:_%0_of_%1=
-Error_while_fetching_from_%0=
+Move\ file\ failed=
+Could\ not\ move\ file\ '%0'.=
+Could\ not\ find\ file\ '%0'.=
+Number\ of\ entries\ successfully\ imported=
+Import\ canceled\ by\ user=
+Progress\:\ %0\ of\ %1=
+Error\ while\ fetching\ from\ %0=
 
-Please_enter_a_valid_number=
-Show_search_results_in_a_window=
-Show_global_search_results_in_a_window=
-Search_in_all_open_libraries=
-Move_file_to_file_directory?=
+Please\ enter\ a\ valid\ number=
+Show\ search\ results\ in\ a\ window=
+Show\ global\ search\ results\ in\ a\ window=
+Search\ in\ all\ open\ libraries=
+Move\ file\ to\ file\ directory?=
 
-Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.=
-Protected_library=
-Refuse_to_save_the_library_before_external_changes_have_been_reviewed.=
-Library_protection=
-Unable_to_save_library=
+Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=
+Protected\ library=
+Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=
+Library\ protection=
+Unable\ to\ save\ library=
 
-BibTeX_key_generator=
-Unable_to_open_link.=
-Move_the_keyboard_focus_to_the_entry_table=
-MIME_type=
+BibTeX\ key\ generator=
+Unable\ to\ open\ link.=
+Move\ the\ keyboard\ focus\ to\ the\ entry\ table=
+MIME\ type=
 
-This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.=
-Run_fetcher,_e.g._"--fetch\=Medline\:cancer"=Run_fetcher,_e.g._"--fetch=Medline\:cancer"
+This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef<BR>instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef<br>from\ your\ web\ browser.<BR>Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=Run fetcher, e.g. "--fetch=Medline:cancer"
 
-The_ACM_Digital_Library=
+The\ ACM\ Digital\ Library=
 Reset=
 
-Use_IEEE_LaTeX_abbreviations=
-The_Guide_to_Computing_Literature=
+Use\ IEEE\ LaTeX\ abbreviations=
+The\ Guide\ to\ Computing\ Literature=
 
-When_opening_file_link,_search_for_matching_file_if_no_link_is_defined=
-Settings_for_%0=
-Mark_entries_imported_into_an_existing_library=
-Unmark_all_entries_before_importing_new_entries_into_an_existing_library=
+When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=
+Settings\ for\ %0=
+Mark\ entries\ imported\ into\ an\ existing\ library=
+Unmark\ all\ entries\ before\ importing\ new\ entries\ into\ an\ existing\ library=
 
 Forward=
 Back=
-Sort_the_following_fields_as_numeric_fields=
-Line_%0\:_Found_corrupted_BibTeX_key.=
-Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).=
-Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).=
-Full_text_document_download_failed=
-Update_to_current_column_order=
-Download_from_URL=
-Rename_field=
-Set/clear/append/rename_fields=تنظیم/حذف/تغییرنام_حوزه‌ها
-Append_field=
-Append_to_fields=
-Rename_field_to=
-Move_contents_of_a_field_into_a_field_with_a_different_name=
-You_can_only_rename_one_field_at_a_time=
+Sort\ the\ following\ fields\ as\ numeric\ fields=
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=
+Full\ text\ document\ download\ failed=
+Update\ to\ current\ column\ order=
+Download\ from\ URL=
+Rename\ field=
+Set/clear/append/rename\ fields=تنظیم/حذف/تغییرنام حوزه‌ها
+Append\ field=
+Append\ to\ fields=
+Rename\ field\ to=
+Move\ contents\ of\ a\ field\ into\ a\ field\ with\ a\ different\ name=
+You\ can\ only\ rename\ one\ field\ at\ a\ time=
 
-Remove_all_broken_links=
+Remove\ all\ broken\ links=
 
-Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.=
+Cannot\ use\ port\ %0\ for\ remote\ operation;\ another\ application\ may\ be\ using\ it.\ Try\ specifying\ another\ port.=
 
-Looking_for_full_text_document...=
+Looking\ for\ full\ text\ document...=
 Autosave=
-A_local_copy_will_be_opened.=
-Autosave_local_libraries=
-Automatically_save_the_library_to=
-Please_enter_a_valid_file_path.=
+A\ local\ copy\ will\ be\ opened.=
+Autosave\ local\ libraries=
+Automatically\ save\ the\ library\ to=
+Please\ enter\ a\ valid\ file\ path.=
 
 
-Export_in_current_table_sort_order=
-Export_entries_in_their_original_order=
-Error_opening_file_'%0'.=
+Export\ in\ current\ table\ sort\ order=
+Export\ entries\ in\ their\ original\ order=
+Error\ opening\ file\ '%0'.=
 
-Formatter_not_found\:_%0=
-Clear_inputarea=
+Formatter\ not\ found\:\ %0=
+Clear\ inputarea=
 
-Automatically_set_file_links_for_this_entry=
-Could_not_save,_file_locked_by_another_JabRef_instance.=
-File_is_locked_by_another_JabRef_instance.=
-Do_you_want_to_override_the_file_lock?=
-File_locked=
-Current_tmp_value=
-Metadata_change=
-Changes_have_been_made_to_the_following_metadata_elements=
+Automatically\ set\ file\ links\ for\ this\ entry=
+Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=
+File\ is\ locked\ by\ another\ JabRef\ instance.=
+Do\ you\ want\ to\ override\ the\ file\ lock?=
+File\ locked=
+Current\ tmp\ value=
+Metadata\ change=
+Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=
 
-Generate_groups_for_author_last_names=
-Generate_groups_from_keywords_in_a_BibTeX_field=
-Enforce_legal_characters_in_BibTeX_keys=
+Generate\ groups\ for\ author\ last\ names=
+Generate\ groups\ from\ keywords\ in\ a\ BibTeX\ field=
+Enforce\ legal\ characters\ in\ BibTeX\ keys=
 
-Save_without_backup?=
-Unable_to_create_backup=
-Move_file_to_file_directory=
-Rename_file_to=
-<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)=
-static_group=
-dynamic_group=
-refines_supergroup=
-includes_subgroups=
+Save\ without\ backup?=
+Unable\ to\ create\ backup=
+Move\ file\ to\ file\ directory=
+Rename\ file\ to=
+<b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=
+static\ group=
+dynamic\ group=
+refines\ supergroup=
+includes\ subgroups=
 contains=
-search_expression=
+search\ expression=
 
-Optional_fields_2=
-Waiting_for_save_operation_to_finish=
-Resolving_duplicate_BibTeX_keys...=
-Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.=
-This_library_contains_one_or_more_duplicated_BibTeX_keys.=
-Do_you_want_to_resolve_duplicate_keys_now?=
+Optional\ fields\ 2=
+Waiting\ for\ save\ operation\ to\ finish=
+Resolving\ duplicate\ BibTeX\ keys...=
+Finished\ resolving\ duplicate\ BibTeX\ keys.\ %0\ entries\ modified.=
+This\ library\ contains\ one\ or\ more\ duplicated\ BibTeX\ keys.=
+Do\ you\ want\ to\ resolve\ duplicate\ keys\ now?=
 
-Find_and_remove_duplicate_BibTeX_keys=
-Expected_syntax_for_--fetch\='<name_of_fetcher>\:<query>'=
-Duplicate_BibTeX_key=
-Import_marking_color=
-Always_add_letter_(a,_b,_...)_to_generated_keys=
+Find\ and\ remove\ duplicate\ BibTeX\ keys=
+Expected\ syntax\ for\ --fetch\='<name\ of\ fetcher>\:<query>'=
+Duplicate\ BibTeX\ key=
+Import\ marking\ color=
+Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=
 
-Ensure_unique_keys_using_letters_(a,_b,_...)=
-Ensure_unique_keys_using_letters_(b,_c,_...)=
-Entry_editor_active_background_color=
-Entry_editor_background_color=
-Entry_editor_font_color=
-Entry_editor_invalid_field_color=
+Ensure\ unique\ keys\ using\ letters\ (a,\ b,\ ...)=
+Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=
+Entry\ editor\ active\ background\ color=
+Entry\ editor\ background\ color=
+Entry\ editor\ font\ color=
+Entry\ editor\ invalid\ field\ color=
 
-Table_and_entry_editor_colors=
+Table\ and\ entry\ editor\ colors=
 
-General_file_directory=
-User-specific_file_directory=
-Search_failed\:_illegal_search_expression=
-Show_ArXiv_column=
+General\ file\ directory=
+User-specific\ file\ directory=
+Search\ failed\:\ illegal\ search\ expression=
+Show\ ArXiv\ column=
 
-You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for=
-Automatically_open_browse_dialog_when_creating_new_file_link=
-Import_metadata_from\:=
-Choose_the_source_for_the_metadata_import=
-Create_entry_based_on_XMP-metadata=
-Create_blank_entry_linking_the_PDF=
-Only_attach_PDF=
+You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=
+Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=
+Import\ metadata\ from\:=
+Choose\ the\ source\ for\ the\ metadata\ import=
+Create\ entry\ based\ on\ XMP-metadata=
+Create\ blank\ entry\ linking\ the\ PDF=
+Only\ attach\ PDF=
 Title=
-Create_new_entry=
-Update_existing_entry=
-Autocomplete_names_in_'Firstname_Lastname'_format_only=
-Autocomplete_names_in_'Lastname,_Firstname'_format_only=
-Autocomplete_names_in_both_formats=
-Marking_color_%0=
-The_name_'comment'_cannot_be_used_as_an_entry_type_name.=
-You_must_enter_an_integer_value_in_the_text_field_for=
-Send_as_email=
+Create\ new\ entry=
+Update\ existing\ entry=
+Autocomplete\ names\ in\ 'Firstname\ Lastname'\ format\ only=
+Autocomplete\ names\ in\ 'Lastname,\ Firstname'\ format\ only=
+Autocomplete\ names\ in\ both\ formats=
+Marking\ color\ %0=
+The\ name\ 'comment'\ cannot\ be\ used\ as\ an\ entry\ type\ name.=
+You\ must\ enter\ an\ integer\ value\ in\ the\ text\ field\ for=
+Send\ as\ email=
 References=
-Sending_of_emails=
-Subject_for_sending_an_email_with_references=
-Automatically_open_folders_of_attached_files=
-Create_entry_based_on_content=
-Do_not_show_this_box_again_for_this_import=
-Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)=
-Error_creating_email=
-Entries_added_to_an_email=
+Sending\ of\ emails=
+Subject\ for\ sending\ an\ email\ with\ references=
+Automatically\ open\ folders\ of\ attached\ files=
+Create\ entry\ based\ on\ content=
+Do\ not\ show\ this\ box\ again\ for\ this\ import=
+Always\ use\ this\ PDF\ import\ style\ (and\ do\ not\ ask\ for\ each\ import)=
+Error\ creating\ email=
+Entries\ added\ to\ an\ email=
 exportFormat=
-Output_file_missing=
-No_search_matches.=
-The_output_option_depends_on_a_valid_input_option.=
-Default_import_style_for_drag_and_drop_of_PDFs=
-Default_PDF_file_link_action=
-Filename_format_pattern=
-Additional_parameters=
-Cite_selected_entries_between_parenthesis=
-Cite_selected_entries_with_in-text_citation=
-Cite_special=
-Extra_information_(e.g._page_number)=
-Manage_citations=
-Problem_modifying_citation=
+Output\ file\ missing=
+No\ search\ matches.=
+The\ output\ option\ depends\ on\ a\ valid\ input\ option.=
+Default\ import\ style\ for\ drag\ and\ drop\ of\ PDFs=
+Default\ PDF\ file\ link\ action=
+Filename\ format\ pattern=
+Additional\ parameters=
+Cite\ selected\ entries\ between\ parenthesis=
+Cite\ selected\ entries\ with\ in-text\ citation=
+Cite\ special=
+Extra\ information\ (e.g.\ page\ number)=
+Manage\ citations=
+Problem\ modifying\ citation=
 Citation=
-Extra_information=
-Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.=
-Select_style=
+Extra\ information=
+Could\ not\ resolve\ BibTeX\ entry\ for\ citation\ marker\ '%0'.=
+Select\ style=
 Journals=
 Cite=
-Cite_in-text=
-Insert_empty_citation=
-Merge_citations=
-Manual_connect=
-Select_Writer_document=
-Sync_OpenOffice/LibreOffice_bibliography=
-Select_which_open_Writer_document_to_work_on=
-Connected_to_document=
-Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)=
-Cite_selected_entries_with_extra_information=
-Ensure_that_the_bibliography_is_up-to-date=
-Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.=
-Unable_to_synchronize_bibliography=
-Combine_pairs_of_citations_that_are_separated_by_spaces_only=
-Autodetection_failed=
+Cite\ in-text=
+Insert\ empty\ citation=
+Merge\ citations=
+Manual\ connect=
+Select\ Writer\ document=
+Sync\ OpenOffice/LibreOffice\ bibliography=
+Select\ which\ open\ Writer\ document\ to\ work\ on=
+Connected\ to\ document=
+Insert\ a\ citation\ without\ text\ (the\ entry\ will\ appear\ in\ the\ reference\ list)=
+Cite\ selected\ entries\ with\ extra\ information=
+Ensure\ that\ the\ bibliography\ is\ up-to-date=
+Your\ OpenOffice/LibreOffice\ document\ references\ the\ BibTeX\ key\ '%0',\ which\ could\ not\ be\ found\ in\ your\ current\ library.=
+Unable\ to\ synchronize\ bibliography=
+Combine\ pairs\ of\ citations\ that\ are\ separated\ by\ spaces\ only=
+Autodetection\ failed=
 Connecting=
-Please_wait...=
-Set_connection_parameters=
-Path_to_OpenOffice/LibreOffice_directory=
-Path_to_OpenOffice/LibreOffice_executable=
-Path_to_OpenOffice/LibreOffice_library_dir=
-Connection_lost=
-The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.=
-The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.=
-Automatically_sync_bibliography_when_inserting_citations=
-Look_up_BibTeX_entries_in_the_active_tab_only=
-Look_up_BibTeX_entries_in_all_open_libraries=
-Autodetecting_paths...=
-Could_not_find_OpenOffice/LibreOffice_installation=
-Found_more_than_one_OpenOffice/LibreOffice_executable.=
-Please_choose_which_one_to_connect_to\:=
-Choose_OpenOffice/LibreOffice_executable=
-Select_document=
-HTML_list=
-If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting=
-Could_not_open_%0=
-Unknown_import_format=
-Web_search=
-Style_selection=
-No_valid_style_file_defined=
-Choose_pattern=
-Use_the_BIB_file_location_as_primary_file_directory=
-Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.=
-OpenOffice/LibreOffice_connection=
-You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.=
+Please\ wait...=
+Set\ connection\ parameters=
+Path\ to\ OpenOffice/LibreOffice\ directory=
+Path\ to\ OpenOffice/LibreOffice\ executable=
+Path\ to\ OpenOffice/LibreOffice\ library\ dir=
+Connection\ lost=
+The\ paragraph\ format\ is\ controlled\ by\ the\ property\ 'ReferenceParagraphFormat'\ or\ 'ReferenceHeaderParagraphFormat'\ in\ the\ style\ file.=
+The\ character\ format\ is\ controlled\ by\ the\ citation\ property\ 'CitationCharacterFormat'\ in\ the\ style\ file.=
+Automatically\ sync\ bibliography\ when\ inserting\ citations=
+Look\ up\ BibTeX\ entries\ in\ the\ active\ tab\ only=
+Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=
+Autodetecting\ paths...=
+Could\ not\ find\ OpenOffice/LibreOffice\ installation=
+Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=
+Please\ choose\ which\ one\ to\ connect\ to\:=
+Choose\ OpenOffice/LibreOffice\ executable=
+Select\ document=
+HTML\ list=
+If\ possible,\ normalize\ this\ list\ of\ names\ to\ conform\ to\ standard\ BibTeX\ name\ formatting=
+Could\ not\ open\ %0=
+Unknown\ import\ format=
+Web\ search=
+Style\ selection=
+No\ valid\ style\ file\ defined=
+Choose\ pattern=
+Use\ the\ BIB\ file\ location\ as\ primary\ file\ directory=
+Could\ not\ run\ the\ gnuclient/emacsclient\ program.\ Make\ sure\ you\ have\ the\ emacsclient/gnuclient\ program\ installed\ and\ available\ in\ the\ PATH.=
+OpenOffice/LibreOffice\ connection=
+You\ must\ select\ either\ a\ valid\ style\ file,\ or\ use\ one\ of\ the\ default\ styles.=
 
-This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.=
-This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.=
-You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.=
+This\ is\ a\ simple\ copy\ and\ paste\ dialog.\ First\ load\ or\ paste\ some\ text\ into\ the\ text\ input\ area.<br>After\ that,\ you\ can\ mark\ text\ and\ assign\ it\ to\ a\ BibTeX\ field.=
+This\ feature\ generates\ a\ new\ library\ based\ on\ which\ entries\ are\ needed\ in\ an\ existing\ LaTeX\ document.=
+You\ need\ to\ select\ one\ of\ your\ open\ libraries\ from\ which\ to\ choose\ entries,\ as\ well\ as\ the\ AUX\ file\ produced\ by\ LaTeX\ when\ compiling\ your\ document.=
 
-First_select_entries_to_clean_up.=
-Cleanup_entry=
-Autogenerate_PDF_Names=
-Auto-generating_PDF-Names_does_not_support_undo._Continue?=
+First\ select\ entries\ to\ clean\ up.=
+Cleanup\ entry=
+Autogenerate\ PDF\ Names=
+Auto-generating\ PDF-Names\ does\ not\ support\ undo.\ Continue?=
 
-Use_full_firstname_whenever_possible=
-Use_abbreviated_firstname_whenever_possible=
-Use_abbreviated_and_full_firstname=
-Autocompletion_options=
-Name_format_used_for_autocompletion=
-Treatment_of_first_names=
-Cleanup_entries=
-Automatically_assign_new_entry_to_selected_groups=
-%0_mode=
-Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix=
-Make_paths_of_linked_files_relative_(if_possible)=
-Rename_PDFs_to_given_filename_format_pattern=
-Rename_only_PDFs_having_a_relative_path=
-What_would_you_like_to_clean_up?=
-Doing_a_cleanup_for_%0_entries...=
-No_entry_needed_a_clean_up=
-One_entry_needed_a_clean_up=
-%0_entries_needed_a_clean_up=
+Use\ full\ firstname\ whenever\ possible=
+Use\ abbreviated\ firstname\ whenever\ possible=
+Use\ abbreviated\ and\ full\ firstname=
+Autocompletion\ options=
+Name\ format\ used\ for\ autocompletion=
+Treatment\ of\ first\ names=
+Cleanup\ entries=
+Automatically\ assign\ new\ entry\ to\ selected\ groups=
+%0\ mode=
+Move\ DOIs\ from\ note\ and\ URL\ field\ to\ DOI\ field\ and\ remove\ http\ prefix=
+Make\ paths\ of\ linked\ files\ relative\ (if\ possible)=
+Rename\ PDFs\ to\ given\ filename\ format\ pattern=
+Rename\ only\ PDFs\ having\ a\ relative\ path=
+What\ would\ you\ like\ to\ clean\ up?=
+Doing\ a\ cleanup\ for\ %0\ entries...=
+No\ entry\ needed\ a\ clean\ up=
+One\ entry\ needed\ a\ clean\ up=
+%0\ entries\ needed\ a\ clean\ up=
 
-Remove_selected=
+Remove\ selected=
 
-Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.=
-Attach_file=
-Setting_all_preferences_to_default_values.=
-Resetting_preference_key_'%0'=
-Unknown_preference_key_'%0'=
-Unable_to_clear_preferences.=
+Group\ tree\ could\ not\ be\ parsed.\ If\ you\ save\ the\ BibTeX\ library,\ all\ groups\ will\ be\ lost.=
+Attach\ file=
+Setting\ all\ preferences\ to\ default\ values.=
+Resetting\ preference\ key\ '%0'=
+Unknown\ preference\ key\ '%0'=
+Unable\ to\ clear\ preferences.=
 
-Reset_preferences_(key1,key2,..._or_'all')=
-Find_unlinked_files=
-Unselect_all=
-Expand_all=
-Collapse_all=
-Opens_the_file_browser.=
-Scan_directory=
-Searches_the_selected_directory_for_unlinked_files.=
-Starts_the_import_of_BibTeX_entries.=
-Leave_this_dialog.=
-Create_directory_based_keywords=
-Creates_keywords_in_created_entrys_with_directory_pathnames=
-Select_a_directory_where_the_search_shall_start.=
-Select_file_type\:=
-These_files_are_not_linked_in_the_active_library.=
-Entry_type_to_be_created\:=
-Searching_file_system...=
-Importing_into_Library...=
-Select_directory=
-Select_files=
-BibTeX_entry_creation=
-<No_selection>=
-Unable_to_connect_to_FreeCite_online_service.=
-Parse_with_FreeCite=
-The_current_BibTeX_key_will_be_overwritten._Continue?=
-Overwrite_key=
-Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator=
-How_would_you_like_to_link_to_'%0'?=
-BibTeX_key_patterns=
-Changed_special_field_settings=
-Clear_priority=
-Clear_rank=
-Enable_special_fields=
-One_star=
-Two_stars=
-Three_stars=
-Four_stars=
-Five_stars=
-Help_on_special_fields=
-Keywords_of_selected_entries=
-Manage_content_selectors=
-Manage_keywords=
-No_priority_information=
-No_rank_information=
+Reset\ preferences\ (key1,key2,...\ or\ 'all')=
+Find\ unlinked\ files=
+Unselect\ all=
+Expand\ all=
+Collapse\ all=
+Opens\ the\ file\ browser.=
+Scan\ directory=
+Searches\ the\ selected\ directory\ for\ unlinked\ files.=
+Starts\ the\ import\ of\ BibTeX\ entries.=
+Leave\ this\ dialog.=
+Create\ directory\ based\ keywords=
+Creates\ keywords\ in\ created\ entrys\ with\ directory\ pathnames=
+Select\ a\ directory\ where\ the\ search\ shall\ start.=
+Select\ file\ type\:=
+These\ files\ are\ not\ linked\ in\ the\ active\ library.=
+Entry\ type\ to\ be\ created\:=
+Searching\ file\ system...=
+Importing\ into\ Library...=
+Select\ directory=
+Select\ files=
+BibTeX\ entry\ creation=
+<No\ selection>=
+Unable\ to\ connect\ to\ FreeCite\ online\ service.=
+Parse\ with\ FreeCite=
+The\ current\ BibTeX\ key\ will\ be\ overwritten.\ Continue?=
+Overwrite\ key=
+Not\ overwriting\ existing\ key.\ To\ change\ this\ setting,\ open\ Options\ ->\ Prefererences\ ->\ BibTeX\ key\ generator=
+How\ would\ you\ like\ to\ link\ to\ '%0'?=
+BibTeX\ key\ patterns=
+Changed\ special\ field\ settings=
+Clear\ priority=
+Clear\ rank=
+Enable\ special\ fields=
+One\ star=
+Two\ stars=
+Three\ stars=
+Four\ stars=
+Five\ stars=
+Help\ on\ special\ fields=
+Keywords\ of\ selected\ entries=
+Manage\ content\ selectors=
+Manage\ keywords=
+No\ priority\ information=
+No\ rank\ information=
 Priority=
-Priority_high=
-Priority_low=
-Priority_medium=
+Priority\ high=
+Priority\ low=
+Priority\ medium=
 Quality=
 Rank=
 Relevance=
-Set_priority_to_high=
-Set_priority_to_low=
-Set_priority_to_medium=
-Show_priority=
-Show_quality=
-Show_rank=
-Show_relevance=
-Synchronize_with_keywords=
-Synchronized_special_fields_based_on_keywords=
-Toggle_relevance=
-Toggle_quality_assured=
-Toggle_print_status=
-Update_keywords=
-Write_values_of_special_fields_as_separate_fields_to_BibTeX=
-You_have_changed_settings_for_special_fields.=
-%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.=
-A_string_with_that_label_already_exists=
-Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.=
-JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.=
-Correct_the_entry,_and_reopen_editor_to_display/edit_source.=
-Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').=
-Could_not_connect_to_running_OpenOffice/LibreOffice.=
-Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.=
-If_connecting_manually,_please_verify_program_and_library_paths.=
-Error_message\:=
-If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.=
-Import_metadata_from_PDF=
-Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.=
-Removed_all_subgroups_of_group_"%0".=
-To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.=
-Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.=
-Use_the_following_delimiter_character(s)\:=
-When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above=
-Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=
-Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=
+Set\ priority\ to\ high=
+Set\ priority\ to\ low=
+Set\ priority\ to\ medium=
+Show\ priority=
+Show\ quality=
+Show\ rank=
+Show\ relevance=
+Synchronize\ with\ keywords=
+Synchronized\ special\ fields\ based\ on\ keywords=
+Toggle\ relevance=
+Toggle\ quality\ assured=
+Toggle\ print\ status=
+Update\ keywords=
+Write\ values\ of\ special\ fields\ as\ separate\ fields\ to\ BibTeX=
+You\ have\ changed\ settings\ for\ special\ fields.=
+%0\ entries\ found.\ To\ reduce\ server\ load,\ only\ %1\ will\ be\ downloaded.=
+A\ string\ with\ that\ label\ already\ exists=
+Connection\ to\ OpenOffice/LibreOffice\ has\ been\ lost.\ Please\ make\ sure\ OpenOffice/LibreOffice\ is\ running,\ and\ try\ to\ reconnect.=
+JabRef\ will\ send\ at\ least\ one\ request\ per\ entry\ to\ a\ publisher.=
+Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=
+Could\ not\ connect\ to\ a\ running\ gnuserv\ process.\ Make\ sure\ that\ Emacs\ or\ XEmacs\ is\ running,<BR>and\ that\ the\ server\ has\ been\ started\ (by\ running\ the\ command\ 'server-start'/'gnuserv-start').=
+Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=
+Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=
+If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=
+Error\ message\:=
+If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=
+Import\ metadata\ from\ PDF=
+Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=
+Removed\ all\ subgroups\ of\ group\ "%0".=
+To\ disable\ the\ memory\ stick\ mode\ rename\ or\ remove\ the\ jabref.xml\ file\ in\ the\ same\ folder\ as\ JabRef.=
+Unable\ to\ connect.\ One\ possible\ reason\ is\ that\ JabRef\ and\ OpenOffice/LibreOffice\ are\ not\ both\ running\ in\ either\ 32\ bit\ mode\ or\ 64\ bit\ mode.=
+Use\ the\ following\ delimiter\ character(s)\:=
+When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\ prefer\ the\ BIB\ file\ location\ rather\ than\ the\ file\ directory\ set\ above=
+Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=
+Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=
 
 Searching...=
-You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?=
-Confirm_selection=
-Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case=
-Import_conversions=
-Please_enter_a_search_string=
-Please_open_or_start_a_new_library_before_searching=
+You\ have\ selected\ more\ than\ %0\ entries\ for\ download.\ Some\ web\ sites\ might\ block\ you\ if\ you\ make\ too\ many\ rapid\ downloads.\ Do\ you\ want\ to\ continue?=
+Confirm\ selection=
+Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=
+Import\ conversions=
+Please\ enter\ a\ search\ string=
+Please\ open\ or\ start\ a\ new\ library\ before\ searching=
 
-Canceled_merging_entries=
+Canceled\ merging\ entries=
 
-Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search=
-Merge_entries=
-Merged_entries=
-Merged_entry=
+Format\ units\ by\ adding\ non-breaking\ separators\ and\ keeping\ the\ correct\ case\ on\ search=
+Merge\ entries=
+Merged\ entries=
+Merged\ entry=
 None=
 Parse=
 Result=
-Show_DOI_first=
-Show_URL_first=
-Use_Emacs_key_bindings=
-You_have_to_choose_exactly_two_entries_to_merge.=
+Show\ DOI\ first=
+Show\ URL\ first=
+Use\ Emacs\ key\ bindings=
+You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=
 
-Update_timestamp_on_modification=
-All_key_bindings_will_be_reset_to_their_defaults.=
+Update\ timestamp\ on\ modification=
+All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=
 
-Automatically_set_file_links=
-Resetting_all_key_bindings=
+Automatically\ set\ file\ links=
+Resetting\ all\ key\ bindings=
 Hostname=
-Invalid_setting=
+Invalid\ setting=
 Network=
-Please_specify_both_hostname_and_port=
-Please_specify_both_username_and_password=
+Please\ specify\ both\ hostname\ and\ port=
+Please\ specify\ both\ username\ and\ password=
 
-Use_custom_proxy_configuration=
-Proxy_requires_authentication=
-Attention\:_Password_is_stored_in_plain_text\!=
-Clear_connection_settings=
-Cleared_connection_settings.=
+Use\ custom\ proxy\ configuration=
+Proxy\ requires\ authentication=
+Attention\:\ Password\ is\ stored\ in\ plain\ text\!=
+Clear\ connection\ settings=
+Cleared\ connection\ settings.=
 
-Rebind_C-a,_too=
-Rebind_C-f,_too=
+Rebind\ C-a,\ too=
+Rebind\ C-f,\ too=
 
-Open_folder=
-Searches_for_unlinked_PDF_files_on_the_file_system=
-Export_entries_ordered_as_specified=
-Export_sort_order=
-Export_sorting=
-Newline_separator=
+Open\ folder=
+Searches\ for\ unlinked\ PDF\ files\ on\ the\ file\ system=
+Export\ entries\ ordered\ as\ specified=
+Export\ sort\ order=
+Export\ sorting=
+Newline\ separator=
 
-Save_entries_ordered_as_specified=
-Save_sort_order=
-Show_extra_columns=
-Parsing_error=
-illegal_backslash_expression=
+Save\ entries\ ordered\ as\ specified=
+Save\ sort\ order=
+Show\ extra\ columns=
+Parsing\ error=
+illegal\ backslash\ expression=
 
-Move_to_group=
+Move\ to\ group=
 
-Clear_read_status=
-Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')=
-Could_not_apply_changes.=
-Deprecated_fields=
-Hide/show_toolbar=
-No_read_status_information=
+Clear\ read\ status=
+Convert\ to\ biblatex\ format\ (for\ example,\ move\ the\ value\ of\ the\ 'journal'\ field\ to\ 'journaltitle')=
+Could\ not\ apply\ changes.=
+Deprecated\ fields=
+Hide/show\ toolbar=
+No\ read\ status\ information=
 Printed=
-Read_status=
-Read_status_read=
-Read_status_skimmed=
-Save_selected_as_plain_BibTeX...=
-Set_read_status_to_read=
-Set_read_status_to_skimmed=
-Show_deprecated_BibTeX_fields=
+Read\ status=
+Read\ status\ read=
+Read\ status\ skimmed=
+Save\ selected\ as\ plain\ BibTeX...=
+Set\ read\ status\ to\ read=
+Set\ read\ status\ to\ skimmed=
+Show\ deprecated\ BibTeX\ fields=
 
-Show_gridlines=
-Show_printed_status=
-Show_read_status=
-Table_row_height_padding=
+Show\ gridlines=
+Show\ printed\ status=
+Show\ read\ status=
+Table\ row\ height\ padding=
 
-Marked_selected_entry=
-Marked_all_%0_selected_entries=
-Unmarked_selected_entry=
-Unmarked_all_%0_selected_entries=
+Marked\ selected\ entry=
+Marked\ all\ %0\ selected\ entries=
+Unmarked\ selected\ entry=
+Unmarked\ all\ %0\ selected\ entries=
 
 
-Unmarked_all_entries=
+Unmarked\ all\ entries=
 
-Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.=
+Unable\ to\ find\ the\ requested\ look\ and\ feel\ and\ thus\ the\ default\ one\ is\ used.=
 
-Opens_JabRef's_GitHub_page=
-Could_not_open_browser.=
-Please_open_%0_manually.=
-The_link_has_been_copied_to_the_clipboard.=
+Opens\ JabRef's\ GitHub\ page=
+Could\ not\ open\ browser.=
+Please\ open\ %0\ manually.=
+The\ link\ has\ been\ copied\ to\ the\ clipboard.=
 
-Open_%0_file=
+Open\ %0\ file=
 
-Cannot_delete_file=
-File_permission_error=
-Push_to_%0=
-Path_to_%0=
+Cannot\ delete\ file=
+File\ permission\ error=
+Push\ to\ %0=
+Path\ to\ %0=
 Convert=
-Normalize_to_BibTeX_name_format=
-Help_on_Name_Formatting=
+Normalize\ to\ BibTeX\ name\ format=
+Help\ on\ Name\ Formatting=
 
-Add_new_file_type=
+Add\ new\ file\ type=
 
-Left_entry=
-Right_entry=
+Left\ entry=
+Right\ entry=
 Use=
-Original_entry=
-Replace_original_entry=
-No_information_added=
-Select_at_least_one_entry_to_manage_keywords.=
-OpenDocument_text=
-OpenDocument_spreadsheet=
-OpenDocument_presentation=
-%0_image=
-Added_entry=
-Modified_entry=
-Deleted_entry=
-Modified_groups_tree=
-Removed_all_groups=
-Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.=
-Select_export_format=
-Return_to_JabRef=
-Please_move_the_file_manually_and_link_in_place.=
-Could_not_connect_to_%0=
-Warning\:_%0_out_of_%1_entries_have_undefined_title.=
-Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.=
+Original\ entry=
+Replace\ original\ entry=
+No\ information\ added=
+Select\ at\ least\ one\ entry\ to\ manage\ keywords.=
+OpenDocument\ text=
+OpenDocument\ spreadsheet=
+OpenDocument\ presentation=
+%0\ image=
+Added\ entry=
+Modified\ entry=
+Deleted\ entry=
+Modified\ groups\ tree=
+Removed\ all\ groups=
+Accepting\ the\ change\ replaces\ the\ complete\ groups\ tree\ with\ the\ externally\ modified\ groups\ tree.=
+Select\ export\ format=
+Return\ to\ JabRef=
+Please\ move\ the\ file\ manually\ and\ link\ in\ place.=
+Could\ not\ connect\ to\ %0=
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ title.=
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ BibTeX\ key.=
 occurrence=
-Added_new_'%0'_entry.=
-Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?=
-Changed_type_to_'%0'_for=
-Really_delete_the_selected_entry?=
-Really_delete_the_%0_selected_entries?=
-Keep_merged_entry_only=
-Keep_left=
-Keep_right=
-Old_entry=
-From_import=
-No_problems_found.=
-%0_problem(s)_found=
-Save_changes=
-Discard_changes=
-Library_'%0'_has_changed.=
-Print_entry_preview=
-Copy_title=
-Copy_\\cite{BibTeX_key}=
-Copy_BibTeX_key_and_title=
-File_rename_failed_for_%0_entries.=
-Merged_BibTeX_source_code=
-Invalid_DOI\:_'%0'.=
-should_start_with_a_name=
-should_end_with_a_name=
-unexpected_closing_curly_bracket=
-unexpected_opening_curly_bracket=
-capital_letters_are_not_masked_using_curly_brackets_{}=
-should_contain_a_four_digit_number=
-should_contain_a_valid_page_number_range=
+Added\ new\ '%0'\ entry.=
+Multiple\ entries\ selected.\ Do\ you\ want\ to\ change\ the\ type\ of\ all\ these\ to\ '%0'?=
+Changed\ type\ to\ '%0'\ for=
+Really\ delete\ the\ selected\ entry?=
+Really\ delete\ the\ %0\ selected\ entries?=
+Keep\ merged\ entry\ only=
+Keep\ left=
+Keep\ right=
+Old\ entry=
+From\ import=
+No\ problems\ found.=
+%0\ problem(s)\ found=
+Save\ changes=
+Discard\ changes=
+Library\ '%0'\ has\ changed.=
+Print\ entry\ preview=
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=
+Copy\ BibTeX\ key\ and\ title=
+File\ rename\ failed\ for\ %0\ entries.=
+Merged\ BibTeX\ source\ code=
+Invalid\ DOI\:\ '%0'.=
+should\ start\ with\ a\ name=
+should\ end\ with\ a\ name=
+unexpected\ closing\ curly\ bracket=
+unexpected\ opening\ curly\ bracket=
+capital\ letters\ are\ not\ masked\ using\ curly\ brackets\ {}=
+should\ contain\ a\ four\ digit\ number=
+should\ contain\ a\ valid\ page\ number\ range=
 Filled=
-Field_is_missing=
-Search_%0=
+Field\ is\ missing=
+Search\ %0=
 
-Search_results_in_all_libraries_for_%0=
-Search_results_in_library_%0_for_%1=
-Search_globally=
-No_results_found.=
-Found_%0_results.=
-plain_text=
-This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>=
-This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>=
-This_search_contains_entries_in_which=
+Search\ results\ in\ all\ libraries\ for\ %0=
+Search\ results\ in\ library\ %0\ for\ %1=
+Search\ globally=
+No\ results\ found.=
+Found\ %0\ results.=
+plain\ text=
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ regular\ expression\ <b>%0</b>=
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ term\ <b>%0</b>=
+This\ search\ contains\ entries\ in\ which=
 
-Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.=
-JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>=
-This_library_uses_outdated_file_links.=
+Unable\ to\ autodetect\ OpenOffice/LibreOffice\ installation.\ Please\ choose\ the\ installation\ directory\ manually.=
+JabRef\ no\ longer\ supports\ 'ps'\ or\ 'pdf'\ fields.<br>File\ links\ are\ now\ stored\ in\ the\ 'file'\ field\ and\ files\ are\ stored\ in\ an\ external\ file\ directory.<br>To\ make\ use\ of\ this\ feature,\ JabRef\ needs\ to\ upgrade\ file\ links.<br><br>=
+This\ library\ uses\ outdated\ file\ links.=
 
-Clear_search=
-Close_library=
-Close_entry_editor=
-Decrease_table_font_size=
-Entry_editor,_next_entry=
-Entry_editor,_next_panel=
-Entry_editor,_next_panel_2=
-Entry_editor,_previous_entry=
-Entry_editor,_previous_panel=
-Entry_editor,_previous_panel_2=
-File_list_editor,_move_entry_down=
-File_list_editor,_move_entry_up=
-Focus_entry_table=
-Import_into_current_library=
-Import_into_new_library=
-Increase_table_font_size=
-New_article=
-New_book=
-New_entry=
-New_from_plain_text=
-New_inbook=
-New_mastersthesis=
-New_phdthesis=
-New_proceedings=
-New_unpublished=
-Next_tab=
-Preamble_editor,_store_changes=
-Previous_tab=
-Push_to_application=
-Refresh_OpenOffice/LibreOffice=
-Resolve_duplicate_BibTeX_keys=
-Save_all=
-String_dialog,_add_string=
-String_dialog,_remove_string=
-Synchronize_files=
+Clear\ search=
+Close\ library=
+Close\ entry\ editor=
+Decrease\ table\ font\ size=
+Entry\ editor,\ next\ entry=
+Entry\ editor,\ next\ panel=
+Entry\ editor,\ next\ panel\ 2=
+Entry\ editor,\ previous\ entry=
+Entry\ editor,\ previous\ panel=
+Entry\ editor,\ previous\ panel\ 2=
+File\ list\ editor,\ move\ entry\ down=
+File\ list\ editor,\ move\ entry\ up=
+Focus\ entry\ table=
+Import\ into\ current\ library=
+Import\ into\ new\ library=
+Increase\ table\ font\ size=
+New\ article=
+New\ book=
+New\ entry=
+New\ from\ plain\ text=
+New\ inbook=
+New\ mastersthesis=
+New\ phdthesis=
+New\ proceedings=
+New\ unpublished=
+Next\ tab=
+Preamble\ editor,\ store\ changes=
+Previous\ tab=
+Push\ to\ application=
+Refresh\ OpenOffice/LibreOffice=
+Resolve\ duplicate\ BibTeX\ keys=
+Save\ all=
+String\ dialog,\ add\ string=
+String\ dialog,\ remove\ string=
+Synchronize\ files=
 Unabbreviate=
-should_contain_a_protocol=
-Copy_preview=
-Automatically_setting_file_links=
-Regenerating_BibTeX_keys_according_to_metadata=
-No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys=
-Regenerate_all_keys_for_the_entries_in_a_BibTeX_file=
-Show_debug_level_messages=
-Default_bibliography_mode=
-New_%0_library_created.=
-Show_only_preferences_deviating_from_their_default_value=
+should\ contain\ a\ protocol=
+Copy\ preview=
+Automatically\ setting\ file\ links=
+Regenerating\ BibTeX\ keys\ according\ to\ metadata=
+No\ meta\ data\ present\ in\ BIB\ file.\ Cannot\ regenerate\ BibTeX\ keys=
+Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=
+Show\ debug\ level\ messages=
+Default\ bibliography\ mode=
+New\ %0\ library\ created.=
+Show\ only\ preferences\ deviating\ from\ their\ default\ value=
 default=
 key=
 type=
 value=
-Show_preferences=
-Save_actions=
-Enable_save_actions=
+Show\ preferences=
+Save\ actions=
+Enable\ save\ actions=
 
-Other_fields=
-Show_remaining_fields=
+Other\ fields=
+Show\ remaining\ fields=
 
-link_should_refer_to_a_correct_file_path=
-abbreviation_detected=
-wrong_entry_type_as_proceedings_has_page_numbers=
-Abbreviate_journal_names=
+link\ should\ refer\ to\ a\ correct\ file\ path=
+abbreviation\ detected=
+wrong\ entry\ type\ as\ proceedings\ has\ page\ numbers=
+Abbreviate\ journal\ names=
 Abbreviating...=
-Abbreviation_%s_for_journal_%s_already_defined.=
-Abbreviation_cannot_be_empty=
-Duplicated_Journal_Abbreviation=
-Duplicated_Journal_File=
-Error_Occurred=
-Journal_file_%s_already_added=
-Name_cannot_be_empty=
+Abbreviation\ %s\ for\ journal\ %s\ already\ defined.=
+Abbreviation\ cannot\ be\ empty=
+Duplicated\ Journal\ Abbreviation=
+Duplicated\ Journal\ File=
+Error\ Occurred=
+Journal\ file\ %s\ already\ added=
+Name\ cannot\ be\ empty=
 
-Adding_fetched_entries=
-Display_keywords_appearing_in_ALL_entries=
-Display_keywords_appearing_in_ANY_entry=
-Fetching_entries_from_Inspire=
-None_of_the_selected_entries_have_titles.=
-None_of_the_selected_entries_have_BibTeX_keys.=
-Unabbreviate_journal_names=
+Adding\ fetched\ entries=
+Display\ keywords\ appearing\ in\ ALL\ entries=
+Display\ keywords\ appearing\ in\ ANY\ entry=
+Fetching\ entries\ from\ Inspire=
+None\ of\ the\ selected\ entries\ have\ titles.=
+None\ of\ the\ selected\ entries\ have\ BibTeX\ keys.=
+Unabbreviate\ journal\ names=
 Unabbreviating...=
 Usage=
 
 
-Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.=
-Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
-Reset_preferences=
-Ill-formed_entrytype_comment_in_BIB_file=
+Adds\ {}\ brackets\ around\ acronyms,\ month\ names\ and\ countries\ to\ preserve\ their\ case.=
+Are\ you\ sure\ you\ want\ to\ reset\ all\ settings\ to\ default\ values?=
+Reset\ preferences=
+Ill-formed\ entrytype\ comment\ in\ BIB\ file=
 
-Move_linked_files_to_default_file_directory_%0=
+Move\ linked\ files\ to\ default\ file\ directory\ %0=
 
 Clipboard=
-Could_not_paste_entry_as_text\:=
-Do_you_still_want_to_continue?=
-This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:=
-This_could_cause_undesired_changes_to_your_entries.=
-Run_field_formatter\:=
-Table_font_size_is_%0=
-%0_import_canceled=
-Internal_style=
-Add_style_file=
-Are_you_sure_you_want_to_remove_the_style?=
-Current_style_is_'%0'=
-Remove_style=
-Select_one_of_the_available_styles_or_add_a_style_file_from_disk.=
-You_must_select_a_valid_style_file.=
+Could\ not\ paste\ entry\ as\ text\:=
+Do\ you\ still\ want\ to\ continue?=
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=
+This\ could\ cause\ undesired\ changes\ to\ your\ entries.=
+Run\ field\ formatter\:=
+Table\ font\ size\ is\ %0=
+%0\ import\ canceled=
+Internal\ style=
+Add\ style\ file=
+Are\ you\ sure\ you\ want\ to\ remove\ the\ style?=
+Current\ style\ is\ '%0'=
+Remove\ style=
+Select\ one\ of\ the\ available\ styles\ or\ add\ a\ style\ file\ from\ disk.=
+You\ must\ select\ a\ valid\ style\ file.=
 Reload=
 
 Capitalize=
-Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.=
-Capitalize_the_first_word,_changes_other_words_to_lower_case.=
-Changes_all_letters_to_lower_case.=
-Changes_all_letters_to_upper_case.=
-Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.=
-Cleans_up_LaTeX_code.=
-Converts_HTML_code_to_LaTeX_code.=
-Converts_HTML_code_to_Unicode.=
-Converts_LaTeX_encoding_to_Unicode_characters.=
-Converts_Unicode_characters_to_LaTeX_encoding.=
-Converts_ordinals_to_LaTeX_superscripts.=
-Converts_units_to_LaTeX_formatting.=
-HTML_to_LaTeX=
-LaTeX_cleanup=
-LaTeX_to_Unicode=
-Lower_case=
-Minify_list_of_person_names=
-Normalize_date=
-Normalize_month=
-Normalize_month_to_BibTeX_standard_abbreviation.=
-Normalize_names_of_persons=
-Normalize_page_numbers=
-Normalize_pages_to_BibTeX_standard.=
-Normalizes_lists_of_persons_to_the_BibTeX_standard.=
-Normalizes_the_date_to_ISO_date_format.=
-Ordinals_to_LaTeX_superscript=
-Protect_terms=
-Remove_enclosing_braces=
-Removes_braces_encapsulating_the_complete_field_content.=
-Sentence_case=
-Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".=
-Title_case=
-Unicode_to_LaTeX=
-Units_to_LaTeX=
-Upper_case=
-Does_nothing.=
+Capitalize\ all\ words,\ but\ converts\ articles,\ prepositions,\ and\ conjunctions\ to\ lower\ case.=
+Capitalize\ the\ first\ word,\ changes\ other\ words\ to\ lower\ case.=
+Changes\ all\ letters\ to\ lower\ case.=
+Changes\ all\ letters\ to\ upper\ case.=
+Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=
+Cleans\ up\ LaTeX\ code.=
+Converts\ HTML\ code\ to\ LaTeX\ code.=
+Converts\ HTML\ code\ to\ Unicode.=
+Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=
+Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=
+Converts\ ordinals\ to\ LaTeX\ superscripts.=
+Converts\ units\ to\ LaTeX\ formatting.=
+HTML\ to\ LaTeX=
+LaTeX\ cleanup=
+LaTeX\ to\ Unicode=
+Lower\ case=
+Minify\ list\ of\ person\ names=
+Normalize\ date=
+Normalize\ month=
+Normalize\ month\ to\ BibTeX\ standard\ abbreviation.=
+Normalize\ names\ of\ persons=
+Normalize\ page\ numbers=
+Normalize\ pages\ to\ BibTeX\ standard.=
+Normalizes\ lists\ of\ persons\ to\ the\ BibTeX\ standard.=
+Normalizes\ the\ date\ to\ ISO\ date\ format.=
+Ordinals\ to\ LaTeX\ superscript=
+Protect\ terms=
+Remove\ enclosing\ braces=
+Removes\ braces\ encapsulating\ the\ complete\ field\ content.=
+Sentence\ case=
+Shortens\ lists\ of\ persons\ if\ there\ are\ more\ than\ 2\ persons\ to\ "et\ al.".=
+Title\ case=
+Unicode\ to\ LaTeX=
+Units\ to\ LaTeX=
+Upper\ case=
+Does\ nothing.=
 Identity=
-Clears_the_field_completely.=
-Directory_not_found=
-Main_file_directory_not_set\!=
-This_operation_requires_exactly_one_item_to_be_selected.=
-Importing_in_%0_format=
-Female_name=
-Female_names=
-Male_name=
-Male_names=
-Mixed_names=
-Neuter_name=
-Neuter_names=
+Clears\ the\ field\ completely.=
+Directory\ not\ found=
+Main\ file\ directory\ not\ set\!=
+This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=
+Importing\ in\ %0\ format=
+Female\ name=
+Female\ names=
+Male\ name=
+Male\ names=
+Mixed\ names=
+Neuter\ name=
+Neuter\ names=
 
-Determined_%0_for_%1_entries=
-Look_up_%0=
-Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3=
+Determined\ %0\ for\ %1\ entries=
+Look\ up\ %0=
+Looking\ up\ %0...\ -\ entry\ %1\ out\ of\ %2\ -\ found\ %3=
 
-Audio_CD=
-British_patent=
-British_patent_request=
-Candidate_thesis=
+Audio\ CD=
+British\ patent=
+British\ patent\ request=
+Candidate\ thesis=
 Collaborator=
 Column=
 Compiler=
 Continuator=
-Data_CD=
+Data\ CD=
 Editor=
-European_patent=
-European_patent_request=
+European\ patent=
+European\ patent\ request=
 Founder=
-French_patent=
-French_patent_request=
-German_patent=
-German_patent_request=
+French\ patent=
+French\ patent\ request=
+German\ patent=
+German\ patent\ request=
 Line=
-Master's_thesis=
+Master's\ thesis=
 Page=
 Paragraph=
 Patent=
-Patent_request=
-PhD_thesis=
+Patent\ request=
+PhD\ thesis=
 Redactor=
-Research_report=
+Research\ report=
 Reviser=
 Section=
 Software=
-Technical_report=
-U.S._patent=
-U.S._patent_request=
+Technical\ report=
+U.S.\ patent=
+U.S.\ patent\ request=
 Verse=
 
-change_entries_of_group=
-odd_number_of_unescaped_'\#'=
+change\ entries\ of\ group=
+odd\ number\ of\ unescaped\ '\#'=
 
-Plain_text=
-Show_diff=
+Plain\ text=
+Show\ diff=
 character=
 word=
-Show_symmetric_diff=
-Copy_Version=
+Show\ symmetric\ diff=
+Copy\ Version=
 Developers=
 Authors=
 License=
 
-HTML_encoded_character_found=
-booktitle_ends_with_'conference_on'=
+HTML\ encoded\ character\ found=
+booktitle\ ends\ with\ 'conference\ on'=
 
-All_external_files=
+All\ external\ files=
 
-OpenOffice/LibreOffice_integration=
+OpenOffice/LibreOffice\ integration=
 
-incorrect_control_digit=
-incorrect_format=
-Copied_version_to_clipboard=
+incorrect\ control\ digit=
+incorrect\ format=
+Copied\ version\ to\ clipboard=
 
-BibTeX_key=
+BibTeX\ key=
 Message=
 
 
-MathSciNet_Review=
-Reset_Bindings=
+MathSciNet\ Review=
+Reset\ Bindings=
 
-Decryption_not_supported.=
+Decryption\ not\ supported.=
 
-Cleared_'%0'_for_%1_entries=
-Set_'%0'_to_'%1'_for_%2_entries=
-Toggled_'%0'_for_%1_entries=
+Cleared\ '%0'\ for\ %1\ entries=
+Set\ '%0'\ to\ '%1'\ for\ %2\ entries=
+Toggled\ '%0'\ for\ %1\ entries=
 
-Check_for_updates=
-Download_update=
-New_version_available=
-Installed_version=
-Remind_me_later=
-Ignore_this_update=
-Could_not_connect_to_the_update_server.=
-Please_try_again_later_and/or_check_your_network_connection.=
-To_see_what_is_new_view_the_changelog.=
-A_new_version_of_JabRef_has_been_released.=
-JabRef_is_up-to-date.=
-Latest_version=
-Online_help_forum=
+Check\ for\ updates=
+Download\ update=
+New\ version\ available=
+Installed\ version=
+Remind\ me\ later=
+Ignore\ this\ update=
+Could\ not\ connect\ to\ the\ update\ server.=
+Please\ try\ again\ later\ and/or\ check\ your\ network\ connection.=
+To\ see\ what\ is\ new\ view\ the\ changelog.=
+A\ new\ version\ of\ JabRef\ has\ been\ released.=
+JabRef\ is\ up-to-date.=
+Latest\ version=
+Online\ help\ forum=
 Custom=
 
-Export_cited=
-Unable_to_generate_new_library=
+Export\ cited=
+Unable\ to\ generate\ new\ library=
 
-Open_console=
-Use_default_terminal_emulator=
-Execute_command=
-Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.=
-Executing_command_\"%0\"...=
-Error_occured_while_executing_the_command_\"%0\".=
-Reformat_ISSN=
+Open\ console=
+Use\ default\ terminal\ emulator=
+Execute\ command=
+Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=
+Executing\ command\ \"%0\"...=
+Error\ occured\ while\ executing\ the\ command\ \"%0\".=
+Reformat\ ISSN=
 
-Countries_and_territories_in_English=
-Electrical_engineering_terms=
+Countries\ and\ territories\ in\ English=
+Electrical\ engineering\ terms=
 Enabled=
-Internal_list=
-Manage_protected_terms_files=
-Months_and_weekdays_in_English=
-The_text_after_the_last_line_starting_with_\#_will_be_used=
-Add_protected_terms_file=
-Are_you_sure_you_want_to_remove_the_protected_terms_file?=
-Remove_protected_terms_file=
-Add_selected_text_to_list=
-Add_{}_around_selected_text=
-Format_field=
-New_protected_terms_file=
-change_field_%0_of_entry_%1_from_%2_to_%3=
-change_key_from_%0_to_%1=
-change_string_content_%0_to_%1=
-change_string_name_%0_to_%1=
-change_type_of_entry_%0_from_%1_to_%2=
-insert_entry_%0=
-insert_string_%0=
-remove_entry_%0=
-remove_string_%0=
+Internal\ list=
+Manage\ protected\ terms\ files=
+Months\ and\ weekdays\ in\ English=
+The\ text\ after\ the\ last\ line\ starting\ with\ \#\ will\ be\ used=
+Add\ protected\ terms\ file=
+Are\ you\ sure\ you\ want\ to\ remove\ the\ protected\ terms\ file?=
+Remove\ protected\ terms\ file=
+Add\ selected\ text\ to\ list=
+Add\ {}\ around\ selected\ text=
+Format\ field=
+New\ protected\ terms\ file=
+change\ field\ %0\ of\ entry\ %1\ from\ %2\ to\ %3=
+change\ key\ from\ %0\ to\ %1=
+change\ string\ content\ %0\ to\ %1=
+change\ string\ name\ %0\ to\ %1=
+change\ type\ of\ entry\ %0\ from\ %1\ to\ %2=
+insert\ entry\ %0=
+insert\ string\ %0=
+remove\ entry\ %0=
+remove\ string\ %0=
 undefined=
-Cannot_get_info_based_on_given_%0\:_%1=
-Get_BibTeX_data_from_%0=
-No_%0_found=
-Entry_from_%0=
-Merge_entry_with_%0_information=
-Updated_entry_with_info_from_%0=
+Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=
+Get\ BibTeX\ data\ from\ %0=
+No\ %0\ found=
+Entry\ from\ %0=
+Merge\ entry\ with\ %0\ information=
+Updated\ entry\ with\ info\ from\ %0=
 
-Add_existing_file=
-Create_new_list=
-Remove_list=
-Full_journal_name=
-Abbreviation_name=
+Add\ existing\ file=
+Create\ new\ list=
+Remove\ list=
+Full\ journal\ name=
+Abbreviation\ name=
 
-No_abbreviation_files_loaded=
+No\ abbreviation\ files\ loaded=
 
-Loading_built_in_lists=
+Loading\ built\ in\ lists=
 
-JabRef_built_in_list=
-IEEE_built_in_list=
+JabRef\ built\ in\ list=
+IEEE\ built\ in\ list=
 
-Event_log=
-We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.=
-Log_copied_to_clipboard.=
-Copy_Log=
-Clear_Log=
-Report_Issue=
-Issue_on_GitHub_successfully_reported.=
-Issue_report_successful=
-Your_issue_was_reported_in_your_browser.=
-The_log_and_exception_information_was_copied_to_your_clipboard.=
-Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.=
+Event\ log=
+We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef\'s\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=
+Log\ copied\ to\ clipboard.=
+Copy\ Log=
+Clear\ Log=
+Report\ Issue=
+Issue\ on\ GitHub\ successfully\ reported.=
+Issue\ report\ successful=
+Your\ issue\ was\ reported\ in\ your\ browser.=
+The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=
+Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=
 
 Connection=
 Connecting...=
@@ -2164,194 +2164,194 @@ Port=
 Library=
 User=
 Connect=
-Connection_error=
-Connection_to_%0_server_established.=
-Required_field_"%0"_is_empty.=
-%0_driver_not_available.=
-The_connection_to_the_server_has_been_terminated.=
-Connection_lost.=
+Connection\ error=
+Connection\ to\ %0\ server\ established.=
+Required\ field\ "%0"\ is\ empty.=
+%0\ driver\ not\ available.=
+The\ connection\ to\ the\ server\ has\ been\ terminated.=
+Connection\ lost.=
 Reconnect=
-Work_offline=
-Working_offline.=
-Update_refused.=
-Update_refused=
-Local_entry=
-Shared_entry=
-Update_could_not_be_performed_due_to_existing_change_conflicts.=
-You_are_not_working_on_the_newest_version_of_BibEntry.=
-Local_version\:_%0=
-Shared_version\:_%0=
-Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.=
-Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?=
-Shared_entry_is_no_longer_present=
-The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.=
-You_can_restore_the_entry_using_the_"Undo"_operation.=
-Remember_password?=
-You_are_already_connected_to_a_database_using_entered_connection_details.=
+Work\ offline=
+Working\ offline.=
+Update\ refused.=
+Update\ refused=
+Local\ entry=
+Shared\ entry=
+Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=
+You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=
+Local\ version\:\ %0=
+Shared\ version\:\ %0=
+Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=
+Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=
+Shared\ entry\ is\ no\ longer\ present=
+The\ BibEntry\ you\ currently\ work\ on\ has\ been\ deleted\ on\ the\ shared\ side.=
+You\ can\ restore\ the\ entry\ using\ the\ "Undo"\ operation.=
+Remember\ password?=
+You\ are\ already\ connected\ to\ a\ database\ using\ entered\ connection\ details.=
 
-Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?=
-New_technical_report=
+Cannot\ cite\ entries\ without\ BibTeX\ keys.\ Generate\ keys\ now?=
+New\ technical\ report=
 
-%0_file=
-Custom_layout_file=
-Protected_terms_file=
-Style_file=
+%0\ file=
+Custom\ layout\ file=
+Protected\ terms\ file=
+Style\ file=
 
-Open_OpenOffice/LibreOffice_connection=
-You_must_enter_at_least_one_field_name=
-Non-ASCII_encoded_character_found=
-Toggle_web_search_interface=
-Background_color_for_resolved_fields=
-Color_code_for_resolved_fields=
-%0_files_found=
-%0_of_%1=
-One_file_found=
-The_import_finished_with_warnings\:=
-There_was_one_file_that_could_not_be_imported.=
-There_were_%0_files_which_could_not_be_imported.=
+Open\ OpenOffice/LibreOffice\ connection=
+You\ must\ enter\ at\ least\ one\ field\ name=
+Non-ASCII\ encoded\ character\ found=
+Toggle\ web\ search\ interface=
+Background\ color\ for\ resolved\ fields=
+Color\ code\ for\ resolved\ fields=
+%0\ files\ found=
+%0\ of\ %1=
+One\ file\ found=
+The\ import\ finished\ with\ warnings\:=
+There\ was\ one\ file\ that\ could\ not\ be\ imported.=
+There\ were\ %0\ files\ which\ could\ not\ be\ imported.=
 
-Migration_help_information=
-Entered_database_has_obsolete_structure_and_is_no_longer_supported.=
-However,_a_new_database_was_created_alongside_the_pre-3.6_one.=
-Click_here_to_learn_about_the_migration_of_pre-3.6_databases.=
-Opens_JabRef's_Facebook_page=
-Opens_JabRef's_blog=
-Opens_JabRef's_website=
-Opens_a_link_where_the_current_development_version_can_be_downloaded=
-See_what_has_been_changed_in_the_JabRef_versions=
-Referenced_BibTeX_key_does_not_exist=
-Finished_downloading_full_text_document_for_entry_%0.=
-Full_text_document_download_failed_for_entry_%0.=
-Look_up_full_text_documents=
-You_are_about_to_look_up_full_text_documents_for_%0_entries.=
-last_four_nonpunctuation_characters_should_be_numerals=
+Migration\ help\ information=
+Entered\ database\ has\ obsolete\ structure\ and\ is\ no\ longer\ supported.=
+However,\ a\ new\ database\ was\ created\ alongside\ the\ pre-3.6\ one.=
+Click\ here\ to\ learn\ about\ the\ migration\ of\ pre-3.6\ databases.=
+Opens\ JabRef's\ Facebook\ page=
+Opens\ JabRef's\ blog=
+Opens\ JabRef's\ website=
+Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=
+See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=
+Referenced\ BibTeX\ key\ does\ not\ exist=
+Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=
+Full\ text\ document\ download\ failed\ for\ entry\ %0.=
+Look\ up\ full\ text\ documents=
+You\ are\ about\ to\ look\ up\ full\ text\ documents\ for\ %0\ entries.=
+last\ four\ nonpunctuation\ characters\ should\ be\ numerals=
 
 Author=
 Date=
-File_annotations=
-Show_file_annotations=
-Adobe_Acrobat_Reader=
-Sumatra_Reader=
+File\ annotations=
+Show\ file\ annotations=
+Adobe\ Acrobat\ Reader=
+Sumatra\ Reader=
 shared=
-should_contain_an_integer_or_a_literal=
-should_have_the_first_letter_capitalized=
+should\ contain\ an\ integer\ or\ a\ literal=
+should\ have\ the\ first\ letter\ capitalized=
 Tools=
-What\'s_new_in_this_version?=
-Want_to_help?=
-Make_a_donation=
-get_involved=
-Used_libraries=
-Existing_file=
+What\'s\ new\ in\ this\ version?=
+Want\ to\ help?=
+Make\ a\ donation=
+get\ involved=
+Used\ libraries=
+Existing\ file=
 
 ID=
-ID_type=
-ID-based_entry_generator=
-Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+ID\ type=
+ID-based\ entry\ generator=
+Fetcher\ '%0'\ did\ not\ find\ an\ entry\ for\ id\ '%1'.=
 
-Select_first_entry=
-Select_last_entry=
+Select\ first\ entry=
+Select\ last\ entry=
 
-Invalid_ISBN\:_'%0'.=
-should_be_an_integer_or_normalized=
-should_be_normalized=
+Invalid\ ISBN\:\ '%0'.=
+should\ be\ an\ integer\ or\ normalized=
+should\ be\ normalized=
 
-Empty_search_ID=
-The_given_search_ID_was_empty.=
-Copy_BibTeX_key_and_link=
-empty_BibTeX_key=
-biblatex_field_only=
+Empty\ search\ ID=
+The\ given\ search\ ID\ was\ empty.=
+Copy\ BibTeX\ key\ and\ link=
+empty\ BibTeX\ key=
+biblatex\ field\ only=
 
-Error_while_generating_fetch_URL=
-Error_while_parsing_ID_list=
-Unable_to_get_PubMed_IDs=
-Backup_found=
-A_backup_file_for_'%0'_was_found.=
-This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.=
-Do_you_want_to_recover_the_library_from_the_backup_file?=
-Firstname_Lastname=
+Error\ while\ generating\ fetch\ URL=
+Error\ while\ parsing\ ID\ list=
+Unable\ to\ get\ PubMed\ IDs=
+Backup\ found=
+A\ backup\ file\ for\ '%0'\ was\ found.=
+This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=
+Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=
+Firstname\ Lastname=
 
-Recommended_for_%0=
-Show_'Related_Articles'_tab=
-This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
+Recommended\ for\ %0=
+Show\ 'Related\ Articles'\ tab=
+This\ might\ be\ caused\ by\ reaching\ the\ traffic\ limitation\ of\ Google\ Scholar\ (see\ 'Help'\ for\ details).=
 
-Could_not_open_website.=
-Problem_downloading_from_%1=
+Could\ not\ open\ website.=
+Problem\ downloading\ from\ %1=
 
-File_directory_pattern=
-Update_with_bibliographic_information_from_the_web=
+File\ directory\ pattern=
+Update\ with\ bibliographic\ information\ from\ the\ web=
 
-Could_not_find_any_bibliographic_information.=
-BibTeX_key_deviates_from_generated_key=
-DOI_%0_is_invalid=
+Could\ not\ find\ any\ bibliographic\ information.=
+BibTeX\ key\ deviates\ from\ generated\ key=
+DOI\ %0\ is\ invalid=
 
-Select_all_customized_types_to_be_stored_in_local_preferences=
-Currently_unknown=
-Different_customization,_current_settings_will_be_overwritten=
+Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences=
+Currently\ unknown=
+Different\ customization,\ current\ settings\ will\ be\ overwritten=
 
-Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX=
-Jump_to_entry=
+Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=
+Jump\ to\ entry=
 
-Copied_%0_citations.=
+Copied\ %0\ citations.=
 Copying...=
 
-journal_not_found_in_abbreviation_list=
-Unhandled_exception_occurred.=
+journal\ not\ found\ in\ abbreviation\ list=
+Unhandled\ exception\ occurred.=
 
-strings_included=
-Color_for_disabled_icons=
-Color_for_enabled_icons=
-Size_of_large_icons=
-Size_of_small_icons=
-Default_table_font_size=
-Escape_underscores=
+strings\ included=
+Color\ for\ disabled\ icons=
+Color\ for\ enabled\ icons=
+Size\ of\ large\ icons=
+Size\ of\ small\ icons=
+Default\ table\ font\ size=
+Escape\ underscores=
 Color=
-Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=
-Fit_width=
-Fit_a_single_page=
-Zoom_in=
-Zoom_out=
-Previous_page=
-Next_page=
-Document_viewer=
+Please\ also\ add\ all\ steps\ to\ reproduce\ this\ issue,\ if\ possible.=
+Fit\ width=
+Fit\ a\ single\ page=
+Zoom\ in=
+Zoom\ out=
+Previous\ page=
+Next\ page=
+Document\ viewer=
 Live=
 Locked=
-Show_document_viewer=
-Show_the_document_of_the_currently_selected_entry.=
-Show_this_document_until_unlocked.=
-Set_current_user_name_as_owner.=
+Show\ document\ viewer=
+Show\ the\ document\ of\ the\ currently\ selected\ entry.=
+Show\ this\ document\ until\ unlocked.=
+Set\ current\ user\ name\ as\ owner.=
 
-Sort_all_subgroups_(recursively)=
-Collect_and_share_telemetry_data_to_help_improve_JabRef.=
-Don't_share=
-Share_anonymous_statistics=
-Telemetry\:_Help_make_JabRef_better=
-To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.=
-This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?=
-Names_are_not_in_the_standard_%0_format.=
+Sort\ all\ subgroups\ (recursively)=
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=
+Don't\ share=
+Share\ anonymous\ statistics=
+Telemetry\:\ Help\ make\ JabRef\ better=
+To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ statistics\ on\ the\ features\ you\ use.\ We\ will\ only\ record\ what\ features\ you\ access\ and\ how\ often\ you\ do\ it.\ We\ will\ neither\ collect\ any\ personal\ data\ nor\ the\ content\ of\ bibliographic\ items.\ If\ you\ choose\ to\ allow\ data\ collection,\ you\ can\ later\ disable\ it\ via\ Options\ ->\ Preferences\ ->\ General.=
+This\ file\ was\ found\ automatically.\ Do\ you\ want\ to\ link\ it\ to\ this\ entry?=
+Names\ are\ not\ in\ the\ standard\ %0\ format.=
 
-Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.=
-Delete_'%0'=
-Delete_from_disk=
-Remove_from_entry=
-The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.=
-There_exists_already_a_group_with_the_same_name.=
+Delete\ the\ selected\ file\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ file\ permanently\ from\ disk.=
+Delete\ '%0'=
+Delete\ from\ disk=
+Remove\ from\ entry=
+The\ group\ name\ contains\ the\ keyword\ separator\ "%0"\ and\ thus\ probably\ does\ not\ work\ as\ expected.=
+There\ exists\ already\ a\ group\ with\ the\ same\ name.=
 
-Copy_linked_files_to_folder...=
-Copied_file_successfully=
-Copying_files...=
-Copying_file_%0_of_entry_%1=
-Finished_copying=
-Could_not_copy_file=
-Copied_%0_files_of_%1_sucessfully_to_%2=
-Rename_failed=
-JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.=
-Show_console_output_(only_necessary_when_the_launcher_is_used)=
+Copy\ linked\ files\ to\ folder...=
+Copied\ file\ successfully=
+Copying\ files...=
+Copying\ file\ %0\ of\ entry\ %1=
+Finished\ copying=
+Could\ not\ copy\ file=
+Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=
+Rename\ failed=
+JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=
+Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=
 
-Remove_line_breaks=
-Removes_all_line_breaks_in_the_field_content.=
-Checking_integrity...=
+Remove\ line\ breaks=
+Removes\ all\ line\ breaks\ in\ the\ field\ content.=
+Checking\ integrity...=
 
-Remove_hyphenated_line_breaks=
-Removes_all_hyphenated_line_breaks_in_the_field_content.=
-Note_that_currently,_JabRef_does_not_run_with_Java_9.=
-Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.=
+Remove\ hyphenated\ line\ breaks=
+Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=
+Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=
+Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -1,8 +1,3 @@
-
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 contient l'expression régulière <b>%1</b>
 
 %0\ contains\ the\ term\ <b>%1</b>=%0 contient le terme <b>%1</b>

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -1206,9 +1206,9 @@ This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\
 
 This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=Ce groupe contient des entrées basées sur un ajout manuel. Des entrées peuvent être ajoutées à ce groupe en les sélectionnant puis en utilisant un glisser-déplacer ou le menu contextuel. Des entrées peuvent être supprimées de ce groupe en les sélectionnant puis en utilisant le menu contextuel.
 
-This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Ce groupe contient des entrées dont le champ <b>%0</b> contient le mot-clef <b>%1</b> 
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Ce groupe contient des entrées dont le champ <b>%0</b> contient le mot-clef <b>%1</b>
 
-This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Ce groupe contient des entrées dont le champ <b>%0</b> contient l'expression régulière <b>%1</b> 
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Ce groupe contient des entrées dont le champ <b>%0</b> contient l'expression régulière <b>%1</b>
 This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=JabRef cherche chaque fichier lien et vérifie si le fichier existe. Si non, des options vous seront proposées<BR>pour résoudre le problème.
 
 This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=Cette opération nécessite que toutes les entrées sélectionnées aient des clefs BibTeX définies

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -3,156 +3,156 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-%0_contains_the_regular_expression_<b>%1</b>=%0_contient_l'expression_régulière_<b>%1</b>
+%0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 contient l'expression régulière <b>%1</b>
 
-%0_contains_the_term_<b>%1</b>=%0_contient_le_terme_<b>%1</b>
+%0\ contains\ the\ term\ <b>%1</b>=%0 contient le terme <b>%1</b>
 
-%0_doesn't_contain_the_regular_expression_<b>%1</b>=%0_ne_contient_pas_l'expression_régulière_<b>%1</b>
+%0\ doesn't\ contain\ the\ regular\ expression\ <b>%1</b>=%0 ne contient pas l'expression régulière <b>%1</b>
 
-%0_doesn't_contain_the_term_<b>%1</b>=%0_ne_contient_pas_le_terme_<b>%1</b>
+%0\ doesn't\ contain\ the\ term\ <b>%1</b>=%0 ne contient pas le terme <b>%1</b>
 
-%0_export_successful=%0_\:_Exportation_réussie
+%0\ export\ successful=%0 : Exportation réussie
 
-%0_matches_the_regular_expression_<b>%1</b>=%0_correspond_à_l'expression_régulière_<b>%1</b>
+%0\ matches\ the\ regular\ expression\ <b>%1</b>=%0 correspond à l'expression régulière <b>%1</b>
 
-%0_matches_the_term_<b>%1</b>=%0_correspond_au_terme_<b>%1</b>
+%0\ matches\ the\ term\ <b>%1</b>=%0 correspond au terme <b>%1</b>
 
-<field_name>=<nom_de_champ>
-<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>=<HTML>Le_fichier_'%0'_n'a_pas_pu_être_trouvé_<BR>à_partir_du_lien_de_l'entrée_'%1'</HTML>
+<field\ name>=<nom de champ>
+<HTML>Could\ not\ find\ file\ '%0'<BR>linked\ from\ entry\ '%1'</HTML>=<HTML>Le fichier '%0' n'a pas pu être trouvé <BR>à partir du lien de l'entrée '%1'</HTML>
 
 <select>=<sélectionner>
 
-<select_word>=<entrer_le_mot-clef>
-Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)=Abréger_les_noms_de_journaux_des_entrées_sélectionnées_(abréviations_ISO)
-Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)=Abréger_les_noms_de_journaux_des_entrées_sélectionnées_(abréviations_MEDLINE)
+<select\ word>=<entrer le mot-clef>
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (ISO\ abbreviation)=Abréger les noms de journaux des entrées sélectionnées (abréviations ISO)
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (MEDLINE\ abbreviation)=Abréger les noms de journaux des entrées sélectionnées (abréviations MEDLINE)
 
-Abbreviate_names=Abréger_les_noms
-Abbreviated_%0_journal_names.=%0_noms_de_journaux_abrégés.
+Abbreviate\ names=Abréger les noms
+Abbreviated\ %0\ journal\ names.=%0 noms de journaux abrégés.
 
 Abbreviation=Abréviation
 
-About_JabRef=A_propos_de_JabRef
+About\ JabRef=A propos de JabRef
 
 Abstract=Résumé
 
 Accept=Valider
 
-Accept_change=Accepter_la_modification
+Accept\ change=Accepter la modification
 
 Action=Action
 
-What_is_Mr._DLib?=Qu'est_ce_que_Mr._Dlib_?
+What\ is\ Mr.\ DLib?=Qu'est ce que Mr. Dlib ?
 
 Add=Ajouter
 
-Add_a_(compiled)_custom_Importer_class_from_a_class_path.=Ajouter_une_classe_Importer_personnalisée_(compilée)_à_partir_d'un_chemin_de_classe.
-The_path_need_not_be_on_the_classpath_of_JabRef.=Le_chemin_n'a_pas_besoin_d'être_dans_le_chemin_de_classe_de_JabRef.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=Ajouter une classe Importer personnalisée (compilée) à partir d'un chemin de classe.
+The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=Le chemin n'a pas besoin d'être dans le chemin de classe de JabRef.
 
-Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=Ajouter_une_classe_Importer_personnalisée_(compilée)_à_partir_d'une_archive_ZIP.
-The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=L'archive_ZIP_n'a_pas_besoin_d'être_dans_le_chemin_de_classe_de_JabRef.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=Ajouter une classe Importer personnalisée (compilée) à partir d'une archive ZIP.
+The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=L'archive ZIP n'a pas besoin d'être dans le chemin de classe de JabRef.
 
-Add_a_regular_expression_for_the_key_pattern.=Ajouter_une_expression_régulière_pour_le_modèle_de_clef
+Add\ a\ regular\ expression\ for\ the\ key\ pattern.=Ajouter une expression régulière pour le modèle de clef
 
-Add_selected_entries_to_this_group=Ajouter_les_entrées_sélectionnées_à_ce_groupe
+Add\ selected\ entries\ to\ this\ group=Ajouter les entrées sélectionnées à ce groupe
 
-Add_from_folder=Ajouter_à_partir_du_répertoire
+Add\ from\ folder=Ajouter à partir du répertoire
 
-Add_from_JAR=Ajouter_à_partir_de_JAR
+Add\ from\ JAR=Ajouter à partir de JAR
 
-add_group=ajouter_un_groupe
+add\ group=ajouter un groupe
 
-Add_new=Ajouter_nouvelle
+Add\ new=Ajouter nouvelle
 
-Add_subgroup=Ajouter_un_sous-groupe
+Add\ subgroup=Ajouter un sous-groupe
 
-Add_to_group=Ajouter_au_groupe
+Add\ to\ group=Ajouter au groupe
 
-Added_group_"%0".=Groupe_"%0"_ajouté.
+Added\ group\ "%0".=Groupe "%0" ajouté.
 
-Added_missing_braces.=Accolades_manquantes_ajoutées.
+Added\ missing\ braces.=Accolades manquantes ajoutées.
 
-Added_new=Nouvel_ajout
+Added\ new=Nouvel ajout
 
-Added_string=Chaîne_ajoutée
+Added\ string=Chaîne ajoutée
 
-Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.=De_plus,_des_entrées_dont_le_champ_<b>%0</b>_ne_contient_pas_<b>%1</b>_peuvent_être_assignée_manuellement_à_ce_groupe_en_les_sélectionnant_puis_en_utilisant_soit_un_glisser-déplacer_ou_le_menu_contextuel._Ce_processus_ajoute_le_terme_<b>%1</b>_à_chaque_champ_d'entrées_<b>%0</b>._Des_entrées_peuvent_être_supprimées_manuellement_de_ce_groupe_les_sélectionnant_puis_en_utilisant_le_menu_contextuel._Ce_processus_supprime_le_terme_<b>%1</b>_de_chaque_champ_d'entrée_<b>%0</b>.
+Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ can\ be\ assigned\ manually\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ This\ process\ adds\ the\ term\ <b>%1</b>\ to\ each\ entry's\ <b>%0</b>\ field.\ Entries\ can\ be\ removed\ manually\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.\ This\ process\ removes\ the\ term\ <b>%1</b>\ from\ each\ entry's\ <b>%0</b>\ field.=De plus, des entrées dont le champ <b>%0</b> ne contient pas <b>%1</b> peuvent être assignée manuellement à ce groupe en les sélectionnant puis en utilisant soit un glisser-déplacer ou le menu contextuel. Ce processus ajoute le terme <b>%1</b> à chaque champ d'entrées <b>%0</b>. Des entrées peuvent être supprimées manuellement de ce groupe les sélectionnant puis en utilisant le menu contextuel. Ce processus supprime le terme <b>%1</b> de chaque champ d'entrée <b>%0</b>.
 
 Advanced=Avancé
-All_entries=Toutes_les_entrées
-All_entries_of_this_type_will_be_declared_typeless._Continue?=Toutes_les_entrées_de_ce_type_seront_déclarées_'sans_type'._Continuer_?
+All\ entries=Toutes les entrées
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=Toutes les entrées de ce type seront déclarées 'sans type'. Continuer ?
 
-All_fields=Tous_les_champs
+All\ fields=Tous les champs
 
-Always_reformat_BIB_file_on_save_and_export=Toujours_remettre_en_forme_les_fichiers_BIB_lors_de_l'enregistrement_et_de_l'exportation
+Always\ reformat\ BIB\ file\ on\ save\ and\ export=Toujours remettre en forme les fichiers BIB lors de l'enregistrement et de l'exportation
 
-A_SAX_exception_occurred_while_parsing_'%0'\:=Une_exception_SAX_est_survenue_pendant_le_traitement_de_'%0'_\:
+A\ SAX\ exception\ occurred\ while\ parsing\ '%0'\:=Une exception SAX est survenue pendant le traitement de '%0' :
 
 and=et
-and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.=et_la_classe_doit_être_disponible_dans_votre_chemin_de_classe_la_prochaine_fois_que_vous_démarrez_JabRef.
+and\ the\ class\ must\ be\ available\ in\ your\ classpath\ next\ time\ you\ start\ JabRef.=et la classe doit être disponible dans votre chemin de classe la prochaine fois que vous démarrez JabRef.
 
-any_field_that_matches_the_regular_expression_<b>%0</b>=tout_champ_qui_correspond_à_l'expression_régulière_<b>%0</b>
+any\ field\ that\ matches\ the\ regular\ expression\ <b>%0</b>=tout champ qui correspond à l'expression régulière <b>%0</b>
 
 Appearance=Aspect
 
 Append=Ajouter
-Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library=Ajouter_le_contenu_d'un_fichier_BibTeX_au_fichier_actuel
+Append\ contents\ from\ a\ BibTeX\ library\ into\ the\ currently\ viewed\ library=Ajouter le contenu d'un fichier BibTeX au fichier actuel
 
-Append_library=Joindre_au_fichier
+Append\ library=Joindre au fichier
 
-Append_the_selected_text_to_BibTeX_field=Ajouter_le_texte_sélectionné_à_la_clef_BibTeX
+Append\ the\ selected\ text\ to\ BibTeX\ field=Ajouter le texte sélectionné à la clef BibTeX
 Application=Application
 
 Apply=Appliquer
 
-Arguments_passed_on_to_running_JabRef_instance._Shutting_down.=Arguments_transmis_à_l'instance_JabRef_active._Arrêt.
+Arguments\ passed\ on\ to\ running\ JabRef\ instance.\ Shutting\ down.=Arguments transmis à l'instance JabRef active. Arrêt.
 
-Assign_new_file=Assigner_un_nouveau_fichier
+Assign\ new\ file=Assigner un nouveau fichier
 
-Assign_the_original_group's_entries_to_this_group?=Assigner_les_entrées_originales_du_groupe_à_ce_groupe_?
+Assign\ the\ original\ group's\ entries\ to\ this\ group?=Assigner les entrées originales du groupe à ce groupe ?
 
-Assigned_%0_entries_to_group_"%1".=%0_entrées_ajoutées_au_groupe_"%1".
+Assigned\ %0\ entries\ to\ group\ "%1".=%0 entrées ajoutées au groupe "%1".
 
-Assigned_1_entry_to_group_"%0".=Une_entrée_ajoutée_au_groupe_"%0".
+Assigned\ 1\ entry\ to\ group\ "%0".=Une entrée ajoutée au groupe "%0".
 
-Attach_URL=Attacher_l'URL
+Attach\ URL=Attacher l'URL
 
-Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.=Cela_tente_de_définir_automatiquement_les_liens_fichier_de_vos_entrées.<BR>La_définition_automatique_fonctionne_si_un_fichier_dans_votre_répertoire_fichier<BR>ou_dans_un_sous-répertoire_porte_le_même_nom_que_la_clef_d'une_entrée_BibTeX,<BR>_l'extension_en_plus.
+Attempt\ to\ automatically\ set\ file\ links\ for\ your\ entries.\ Automatically\ setting\ works\ if\ a\ file\ in\ your\ file\ directory<BR>or\ a\ subdirectory\ is\ named\ identically\ to\ an\ entry's\ BibTeX\ key,\ plus\ extension.=Cela tente de définir automatiquement les liens fichier de vos entrées.<BR>La définition automatique fonctionne si un fichier dans votre répertoire fichier<BR>ou dans un sous-répertoire porte le même nom que la clef d'une entrée BibTeX,<BR> l'extension en plus.
 
-Autodetect_format=Détection_automatique_du_format
+Autodetect\ format=Détection automatique du format
 
-Autogenerate_BibTeX_keys=Création_automatique_des_clefs_BibTeX
+Autogenerate\ BibTeX\ keys=Création automatique des clefs BibTeX
 
-Autolink_files_with_names_starting_with_the_BibTeX_key=Lier_automatiquement_les_fichiers_commençant_par_la_clef_BibTeX
+Autolink\ files\ with\ names\ starting\ with\ the\ BibTeX\ key=Lier automatiquement les fichiers commençant par la clef BibTeX
 
-Autolink_only_files_that_match_the_BibTeX_key=Lier_automatiquement_les_fichiers_correspondant_exactement_à_la_clef_BibTeX
+Autolink\ only\ files\ that\ match\ the\ BibTeX\ key=Lier automatiquement les fichiers correspondant exactement à la clef BibTeX
 
-Automatically_create_groups=Créer_automatiquement_des_groupes
+Automatically\ create\ groups=Créer automatiquement des groupes
 
-Automatically_remove_exact_duplicates=Supprimer_automatiquement_les_doublons_identiques
+Automatically\ remove\ exact\ duplicates=Supprimer automatiquement les doublons identiques
 
-Allow_overwriting_existing_links.=Ecraser_les_liens_existants.
+Allow\ overwriting\ existing\ links.=Ecraser les liens existants.
 
-Do_not_overwrite_existing_links.=Ne_pas_écraser_les_liens_existants.
+Do\ not\ overwrite\ existing\ links.=Ne pas écraser les liens existants.
 
-AUX_file_import=Importation_de_fichier_AUX
+AUX\ file\ import=Importation de fichier AUX
 
-Available_export_formats=Formats_d'exportation_disponibles
+Available\ export\ formats=Formats d'exportation disponibles
 
-Available_BibTeX_fields=Champs_BibTeX_disponibles
+Available\ BibTeX\ fields=Champs BibTeX disponibles
 
-Available_import_formats=Formats_d'importation_disponibles
+Available\ import\ formats=Formats d'importation disponibles
 
-Background_color_for_optional_fields=Couleur_d'arrière-plan_pour_les_champs_optionnels
+Background\ color\ for\ optional\ fields=Couleur d'arrière-plan pour les champs optionnels
 
-Background_color_for_required_fields=Couleur_d'arrière-plan_pour_les_champs_requis
+Background\ color\ for\ required\ fields=Couleur d'arrière-plan pour les champs requis
 
-Backup_old_file_when_saving=Créer_une_copie_de_sauvegarde_lors_de_l'enregistrement
+Backup\ old\ file\ when\ saving=Créer une copie de sauvegarde lors de l'enregistrement
 
-BibTeX_key_is_unique.=La_clef_BibTeX_est_unique.
+BibTeX\ key\ is\ unique.=La clef BibTeX est unique.
 
-%0_source=Source_%0
+%0\ source=Source %0
 
-Broken_link=Lien_invalide
+Broken\ link=Lien invalide
 
 Browse=Explorer
 
@@ -160,321 +160,321 @@ by=par
 
 Cancel=Annuler
 
-Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?=Les_entrées_ne_peuvent_pas_être_ajoutées_au_groupe_sans_générer_des_clefs._Voulez-vous_générer_des_clefs_maintenant_?
+Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=Les entrées ne peuvent pas être ajoutées au groupe sans générer des clefs. Voulez-vous générer des clefs maintenant ?
 
-Cannot_merge_this_change=Cette_modification_ne_peut_pas_être_fusionnée
+Cannot\ merge\ this\ change=Cette modification ne peut pas être fusionnée
 
-case_insensitive=insensible_à_la_casse
+case\ insensitive=insensible à la casse
 
-case_sensitive=sensible_à_la_casse
+case\ sensitive=sensible à la casse
 
-Case_sensitive=Sensible_à_la_casse
+Case\ sensitive=Sensible à la casse
 
-change_assignment_of_entries=changer_l'assignation_des_entrées
+change\ assignment\ of\ entries=changer l'assignation des entrées
 
-Change_case=Changer_la_casse
+Change\ case=Changer la casse
 
-Change_entry_type=Changer_le_type_d'entrée
-Change_file_type=Changer_le_type_de_fichier
+Change\ entry\ type=Changer le type d'entrée
+Change\ file\ type=Changer le type de fichier
 
 
-Change_of_Grouping_Method=Changement_de_la_Méthode_de_Groupement
+Change\ of\ Grouping\ Method=Changement de la Méthode de Groupement
 
-change_preamble=changer_le_préambule
+change\ preamble=changer le préambule
 
-Change_table_column_and_General_fields_settings_to_use_the_new_feature=Modifier_les_colonnes_de_la_table_et_les_paramètres_des_champs_généraux_pour_utiliser_cette_nouvelle_fonction
+Change\ table\ column\ and\ General\ fields\ settings\ to\ use\ the\ new\ feature=Modifier les colonnes de la table et les paramètres des champs généraux pour utiliser cette nouvelle fonction
 
-Changed_language_settings=Paramètres_linguistiques_modifiés
+Changed\ language\ settings=Paramètres linguistiques modifiés
 
-Changed_preamble=Préambule_modifié
+Changed\ preamble=Préambule modifié
 
-Check_existing_file_links=Vérifier_les_liens_fichier_existants
+Check\ existing\ file\ links=Vérifier les liens fichier existants
 
-Check_links=Vérifier_les_liens
+Check\ links=Vérifier les liens
 
-Cite_command=Commande_Cite
+Cite\ command=Commande Cite
 
-Class_name=Nom_de_classe
+Class\ name=Nom de classe
 
 Clear=Vider
 
-Clear_fields=Vider_les_champs
+Clear\ fields=Vider les champs
 
 Close=Fermer
-Close_others=Fermer_les_autres
-Close_all=Fermer_toutes
+Close\ others=Fermer les autres
+Close\ all=Fermer toutes
 
-Close_dialog=Fermer_la_fenêtre
+Close\ dialog=Fermer la fenêtre
 
-Close_the_current_library=Fermer_le_fichier_courant
+Close\ the\ current\ library=Fermer le fichier courant
 
-Close_window=Fermer_la_fenêtre
+Close\ window=Fermer la fenêtre
 
-Closed_library=Fichier_fermé
+Closed\ library=Fichier fermé
 
-Color_codes_for_required_and_optional_fields=Codes_de_couleurs_pour_les_champs_requis_et_optionnels
+Color\ codes\ for\ required\ and\ optional\ fields=Codes de couleurs pour les champs requis et optionnels
 
-Color_for_marking_incomplete_entries=Couleur_pour_marquer_les_entrées_incomplètes
+Color\ for\ marking\ incomplete\ entries=Couleur pour marquer les entrées incomplètes
 
-Column_width=Largeur_de_colonne
+Column\ width=Largeur de colonne
 
-Command_line_id=Identifiant_de_la_ligne_de_commande
+Command\ line\ id=Identifiant de la ligne de commande
 
 
-Contained_in=Contenu_dans
+Contained\ in=Contenu dans
 
 Content=Contenu
 
 Copied=Copié
 
-Copied_cell_contents=Contenu_des_cellules_copié
+Copied\ cell\ contents=Contenu des cellules copié
 
-Copied_title=Titre_copié
+Copied\ title=Titre copié
 
-Copied_key=Clef_copiée
+Copied\ key=Clef copiée
 
-Copied_titles=Titres_copiés
+Copied\ titles=Titres copiés
 
-Copied_keys=Clefs_copiées
+Copied\ keys=Clefs copiées
 
 Copy=Copier
 
-Copy_BibTeX_key=Copier_la_clef_BibTeX
-Copy_file_to_file_directory=Copier_le_fichier_vers_le_répertoire_de_fichiers
+Copy\ BibTeX\ key=Copier la clef BibTeX
+Copy\ file\ to\ file\ directory=Copier le fichier vers le répertoire de fichiers
 
-Copy_to_clipboard=Copier_dans_le_presse-papier
+Copy\ to\ clipboard=Copier dans le presse-papier
 
-Could_not_call_executable=L'exécutable_n'a_pas_pu_être_lancé
-Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.=La_connexion_au_serveur_Vim_a_échoué._Assurez-vous_que_Vim_tourne<BR>avec_le_bon_nom_de_serveur.
+Could\ not\ call\ executable=L'exécutable n'a pas pu être lancé
+Could\ not\ connect\ to\ Vim\ server.\ Make\ sure\ that\ Vim\ is\ running<BR>with\ correct\ server\ name.=La connexion au serveur Vim a échoué. Assurez-vous que Vim tourne<BR>avec le bon nom de serveur.
 
-Could_not_export_file=Le_fichier_n'a_pas_pu_être_exporté
+Could\ not\ export\ file=Le fichier n'a pas pu être exporté
 
-Could_not_export_preferences=L'exportation_des_préférences_a_échoué
+Could\ not\ export\ preferences=L'exportation des préférences a échoué
 
-Could_not_find_a_suitable_import_format.=Un_format_d'importation_convenable_n'a_pas_pu_être_trouvé
-Could_not_import_preferences=L'importation_des_préférences_a_échoué
+Could\ not\ find\ a\ suitable\ import\ format.=Un format d'importation convenable n'a pas pu être trouvé
+Could\ not\ import\ preferences=L'importation des préférences a échoué
 
-Could_not_instantiate_%0=N'a_pas_pu_initialiser_%0
-Could_not_instantiate_%0_%1=N'a_pas_pu_initialiser_%0_%1
-Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?=%0_a_échoué._Avez-vous_choisi_le_chemin_de_paquetage_correct_?
-Could_not_open_link=Le_lien_n'a_pas_pu_être_ouvert
+Could\ not\ instantiate\ %0=N'a pas pu initialiser %0
+Could\ not\ instantiate\ %0\ %1=N'a pas pu initialiser %0 %1
+Could\ not\ instantiate\ %0.\ Have\ you\ chosen\ the\ correct\ package\ path?=%0 a échoué. Avez-vous choisi le chemin de paquetage correct ?
+Could\ not\ open\ link=Le lien n'a pas pu être ouvert
 
-Could_not_print_preview=Echec_de_l'impression_de_l'aperçu
+Could\ not\ print\ preview=Echec de l'impression de l'aperçu
 
-Could_not_run_the_'vim'_program.=Le_programme_'vim'_n'a_pas_pu_être_lancé.
+Could\ not\ run\ the\ 'vim'\ program.=Le programme 'vim' n'a pas pu être lancé.
 
-Could_not_save_file.=Le_fichier_n'a_pas_pu_être_enregistré_.
-Character_encoding_'%0'_is_not_supported.=L'encodage_de_caractères_'%0'_n'est_pas_supporté.
+Could\ not\ save\ file.=Le fichier n'a pas pu être enregistré .
+Character\ encoding\ '%0'\ is\ not\ supported.=L'encodage de caractères '%0' n'est pas supporté.
 
-crossreferenced_entries_included=Entrées_avec_références_croisées_incluses
+crossreferenced\ entries\ included=Entrées avec références croisées incluses
 
-Current_content=Contenu_actuel
+Current\ content=Contenu actuel
 
-Current_value=Valeur_actuelle
+Current\ value=Valeur actuelle
 
-Custom_entry_types=Types_d'entrées_personnalisées
+Custom\ entry\ types=Types d'entrées personnalisées
 
-Custom_entry_types_found_in_file=Types_d'entrées_personnalisées_trouvées_dans_le_fichier
+Custom\ entry\ types\ found\ in\ file=Types d'entrées personnalisées trouvées dans le fichier
 
-Customize_entry_types=Personnaliser_les_types_d'entrées
+Customize\ entry\ types=Personnaliser les types d'entrées
 
-Customize_key_bindings=Personnaliser_les_affectations_de_touches
+Customize\ key\ bindings=Personnaliser les affectations de touches
 
 Cut=Couper
 
-cut_entries=Couper_les_entrées
+cut\ entries=Couper les entrées
 
-cut_entry=supprimer_l'entrée
+cut\ entry=supprimer l'entrée
 
 
-Library_encoding=Encodage_du_fichier
+Library\ encoding=Encodage du fichier
 
-Library_properties=Propriétés_du_fichier
+Library\ properties=Propriétés du fichier
 
-Library_type=Type_de_fichier
+Library\ type=Type de fichier
 
-Date_format=Format_de_date
+Date\ format=Format de date
 
 Default=Défaut
 
-Default_encoding=Encodage_par_défaut
+Default\ encoding=Encodage par défaut
 
-Default_grouping_field=Champ_par_défaut_pour_les_groupes
+Default\ grouping\ field=Champ par défaut pour les groupes
 
-Default_look_and_feel=Apparence_par_défaut
+Default\ look\ and\ feel=Apparence par défaut
 
-Default_pattern=Modèle_par_défaut
+Default\ pattern=Modèle par défaut
 
-Default_sort_criteria=Critère_de_tri_par_défaut
-Define_'%0'=Définir_'%0'
+Default\ sort\ criteria=Critère de tri par défaut
+Define\ '%0'=Définir '%0'
 
 Delete=Supprimer
 
-Delete_custom_format=Supprimer_le_format_personnalisé
+Delete\ custom\ format=Supprimer le format personnalisé
 
-delete_entries=effacer_les_entrées
+delete\ entries=effacer les entrées
 
-Delete_entry=Supprimer_l'entrée
+Delete\ entry=Supprimer l'entrée
 
-delete_entry=effacer_l'entrée
+delete\ entry=effacer l'entrée
 
-Delete_multiple_entries=Effacer_plusieurs_entrées
+Delete\ multiple\ entries=Effacer plusieurs entrées
 
-Delete_rows=Supprimer_les_lignes
+Delete\ rows=Supprimer les lignes
 
-Delete_strings=Supprimer_les_chaînes
+Delete\ strings=Supprimer les chaînes
 
 Deleted=Supprimé
 
-Permanently_delete_local_file=Supprimer_le_fichier_local
+Permanently\ delete\ local\ file=Supprimer le fichier local
 
-Delimit_fields_with_semicolon,_ex.=Délimiter_les_champs_par_des_points-virgules,_ex.
+Delimit\ fields\ with\ semicolon,\ ex.=Délimiter les champs par des points-virgules, ex.
 
 Descending=Descendant
 
 Description=Description
 
-Deselect_all=Tout_désélectionner
-Deselect_all_duplicates=Désélectionner_tous_les_doublons
+Deselect\ all=Tout désélectionner
+Deselect\ all\ duplicates=Désélectionner tous les doublons
 
-Disable_this_confirmation_dialog=Désactiver_cette_demande_de_confirmation
+Disable\ this\ confirmation\ dialog=Désactiver cette demande de confirmation
 
-Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.=Afficher_toutes_les_entrées_appartenant_à_au_moins_un_des_groupes_sélectionnés.
+Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups.=Afficher toutes les entrées appartenant à au moins un des groupes sélectionnés.
 
-Display_all_error_messages=Afficher_tous_les_messages_d'erreur
+Display\ all\ error\ messages=Afficher tous les messages d'erreur
 
-Display_help_on_command_line_options=Afficher_l'aide_sur_les_options_de_la_ligne_de_commande
+Display\ help\ on\ command\ line\ options=Afficher l'aide sur les options de la ligne de commande
 
-Display_only_entries_belonging_to_all_selected_groups.=Afficher_uniquement_les_entrées_appartenant_à_tous_les_groupes_sélectionnés.
-Display_version=Afficher_la_version
+Display\ only\ entries\ belonging\ to\ all\ selected\ groups.=Afficher uniquement les entrées appartenant à tous les groupes sélectionnés.
+Display\ version=Afficher la version
 
-Do_not_abbreviate_names=Ne_pas_abréger_les_noms
+Do\ not\ abbreviate\ names=Ne pas abréger les noms
 
-Do_not_automatically_set=Ne_pas_définir_automatiquement.
+Do\ not\ automatically\ set=Ne pas définir automatiquement.
 
-Do_not_import_entry=Ne_pas_importer_l'entrée
+Do\ not\ import\ entry=Ne pas importer l'entrée
 
-Do_not_open_any_files_at_startup=N'ouvrir_aucun_fichier_au_démarrage
+Do\ not\ open\ any\ files\ at\ startup=N'ouvrir aucun fichier au démarrage
 
-Do_not_overwrite_existing_keys=Ne_pas_écraser_de_clefs_existantes
-Do_not_show_these_options_in_the_future=Ne_pas_afficher_ces_options_à_l'avenir
+Do\ not\ overwrite\ existing\ keys=Ne pas écraser de clefs existantes
+Do\ not\ show\ these\ options\ in\ the\ future=Ne pas afficher ces options à l'avenir
 
-Do_not_wrap_the_following_fields_when_saving=Ne_pas_renvoyer_à_la_ligne_les_champs_suivants_lors_de_l'enregistrement
-Do_not_write_the_following_fields_to_XMP_Metadata\:=Ne_pas_écrire_les_champs_suivants_dans_les_métadonnées_XMP_\:
+Do\ not\ wrap\ the\ following\ fields\ when\ saving=Ne pas renvoyer à la ligne les champs suivants lors de l'enregistrement
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Ne pas écrire les champs suivants dans les métadonnées XMP :
 
-Do_you_want_JabRef_to_do_the_following_operations?=Voulez-vous_que_JabRef_fasse_les_opérations_suivantes_?
+Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Voulez-vous que JabRef fasse les opérations suivantes ?
 
-Donate_to_JabRef=Faire_un_don_à_JabRef
+Donate\ to\ JabRef=Faire un don à JabRef
 
 Down=Bas
 
-Download_file=Télécharger_le_fichier
+Download\ file=Télécharger le fichier
 
 Downloading...=Téléchargement...
 
-Drop_%0=Déposer_%0
+Drop\ %0=Déposer %0
 
-duplicate_removal=Suppression_des_doublons
+duplicate\ removal=Suppression des doublons
 
-Duplicate_string_name=Dupliquer_le_nom_de_chaîne
+Duplicate\ string\ name=Dupliquer le nom de chaîne
 
-Duplicates_found=Doublons_trouvés
+Duplicates\ found=Doublons trouvés
 
-Dynamic_groups=Groupes_dynamiques
+Dynamic\ groups=Groupes dynamiques
 
-Dynamically_group_entries_by_a_free-form_search_expression=Grouper_dynamiquement_les_entrées_en_utilisant_une_expression_de_recherche_de_forme_libre
+Dynamically\ group\ entries\ by\ a\ free-form\ search\ expression=Grouper dynamiquement les entrées en utilisant une expression de recherche de forme libre
 
-Dynamically_group_entries_by_searching_a_field_for_a_keyword=Grouper_dynamiquement_les_entrées_en_cherchant_un_mot-clef_dans_un_champ
+Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=Grouper dynamiquement les entrées en cherchant un mot-clef dans un champ
 
-Each_line_must_be_on_the_following_form=Chaque_ligne_doit_être_de_la_forme_suivante
+Each\ line\ must\ be\ on\ the\ following\ form=Chaque ligne doit être de la forme suivante
 
 Edit=Editer
 
-Edit_custom_export=Editer_l'exportation_personnalisée
-Edit_entry=Editer_l'entrée
-Save_file=Editer_le_lien_de_fichier
-Edit_file_type=Editer_le_type_de_fichier
+Edit\ custom\ export=Editer l'exportation personnalisée
+Edit\ entry=Editer l'entrée
+Save\ file=Editer le lien de fichier
+Edit\ file\ type=Editer le type de fichier
 
-Edit_group=Editer_le_groupe
+Edit\ group=Editer le groupe
 
 
-Edit_preamble=Editer_le_préambule
-Edit_strings=Editer_les_chaînes
-Editor_options=Options_d'éditeur
+Edit\ preamble=Editer le préambule
+Edit\ strings=Editer les chaînes
+Editor\ options=Options d'éditeur
 
-Empty_BibTeX_key=Clef_BibTeX_vide
+Empty\ BibTeX\ key=Clef BibTeX vide
 
-Grouping_may_not_work_for_this_entry.=La_gestion_des_groupes_pourrait_ne_plus_fonctionner_pour_cette_entrée.
+Grouping\ may\ not\ work\ for\ this\ entry.=La gestion des groupes pourrait ne plus fonctionner pour cette entrée.
 
-empty_library=fichier_vide
-Enable_word/name_autocompletion=Autoriser_l'auto-génération_des_mots/noms
+empty\ library=fichier vide
+Enable\ word/name\ autocompletion=Autoriser l'auto-génération des mots/noms
 
-Enter_URL=Entrer_l'URL
+Enter\ URL=Entrer l'URL
 
-Enter_URL_to_download=Entrer_l'URL_de_téléchargement
+Enter\ URL\ to\ download=Entrer l'URL de téléchargement
 
 entries=entrées
 
-Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.=Des_entrées_ne_peuvent_pas_être_ajoutées_ou_supprimées_manuellement_de_ce_groupe.
+Entries\ cannot\ be\ manually\ assigned\ to\ or\ removed\ from\ this\ group.=Des entrées ne peuvent pas être ajoutées ou supprimées manuellement de ce groupe.
 
-Entries_exported_to_clipboard=Entrées_exportées_vers_le_presse-papiers
+Entries\ exported\ to\ clipboard=Entrées exportées vers le presse-papiers
 
 
 entry=entrée
 
-Entry_editor=Editeur_d'entrée
+Entry\ editor=Editeur d'entrée
 
-Entry_preview=Aperçu_de_l'entrée
+Entry\ preview=Aperçu de l'entrée
 
-Entry_table=Table_des_entrées
+Entry\ table=Table des entrées
 
-Entry_table_columns=Colonnes_de_la_table_des_entrées
+Entry\ table\ columns=Colonnes de la table des entrées
 
-Entry_type=Type_d'entrée
+Entry\ type=Type d'entrée
 
-Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Les_noms_de_type_d'entrée_ne_peuvent_pas_contenir_d'espace_et_les_caractères_suivants
+Entry\ type\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Les noms de type d'entrée ne peuvent pas contenir d'espace et les caractères suivants
 
-Entry_types=Types_d'entrées
+Entry\ types=Types d'entrées
 
 Error=Erreur
-Error_exporting_to_clipboard=Erreur_lors_de_l'exportation_vers_le_presse-papiers
+Error\ exporting\ to\ clipboard=Erreur lors de l'exportation vers le presse-papiers
 
-Error_occurred_when_parsing_entry=Une_erreur_est_survenue_pendant_le_traitement_de_l'entrée
+Error\ occurred\ when\ parsing\ entry=Une erreur est survenue pendant le traitement de l'entrée
 
-Error_opening_file=Erreur_lors_de_l'ouverture_du_fichier
+Error\ opening\ file=Erreur lors de l'ouverture du fichier
 
-Error_setting_field=Erreur_de_configuration_du_champ
+Error\ setting\ field=Erreur de configuration du champ
 
-Error_while_writing=Erreur_lors_de_l'écriture
-Error_writing_to_%0_file(s).=Erreur_lors_de_l'écriture_de_%0_fichier(s).
+Error\ while\ writing=Erreur lors de l'écriture
+Error\ writing\ to\ %0\ file(s).=Erreur lors de l'écriture de %0 fichier(s).
 
 
 
-'%0'_exists._Overwrite_file?='%0'_existe._Ecraser_le_fichier_?
-Overwrite_file?=Ecraser_le_fichier_?
+'%0'\ exists.\ Overwrite\ file?='%0' existe. Ecraser le fichier ?
+Overwrite\ file?=Ecraser le fichier ?
 
 Export=Exporter
 
-Export_name=Nom_de_l'exportation
+Export\ name=Nom de l'exportation
 
-Export_preferences=Exporter_les_préférences
+Export\ preferences=Exporter les préférences
 
-Export_preferences_to_file=Exporter_les_préférences_vers_un_fichier
+Export\ preferences\ to\ file=Exporter les préférences vers un fichier
 
-Export_properties=Propriétés_de_l'exportation
+Export\ properties=Propriétés de l'exportation
 
-Export_to_clipboard=Exporter_vers_le_presse-papiers
+Export\ to\ clipboard=Exporter vers le presse-papiers
 
-Exporting=Exportation_en_cours
+Exporting=Exportation en cours
 Extension=Extension
 
-External_changes=Modifications_externes
+External\ changes=Modifications externes
 
-External_file_links=Liens_vers_les_fichiers_externes
+External\ file\ links=Liens vers les fichiers externes
 
-External_programs=Programmes_externes
+External\ programs=Programmes externes
 
-External_viewer_called=Afficheur_externe_lancé
+External\ viewer\ called=Afficheur externe lancé
 
 Fetch=Rechercher
 
@@ -482,660 +482,660 @@ Field=Champ
 
 field=Champ
 
-Field_name=Nom_du_champ
-Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Les_noms_de_champs_ne_peuvent_pas_contenir_d'espace_ou_l'un_des_caractères_suivants
+Field\ name=Nom du champ
+Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Les noms de champs ne peuvent pas contenir d'espace ou l'un des caractères suivants
 
-Field_to_filter=Champ_vers_filtre
+Field\ to\ filter=Champ vers filtre
 
-Field_to_group_by=Champ_à_grouper_par
+Field\ to\ group\ by=Champ à grouper par
 
 File=Fichier
 
 file=fichier
-File_'%0'_is_already_open.=Le_fichier_'%0'_est_déjà_ouvert.
+File\ '%0'\ is\ already\ open.=Le fichier '%0' est déjà ouvert.
 
-File_changed=Fichier_changé
-File_directory_is_'%0'\:=Le_répertoire_de_fichier_est_'%0'_\:
+File\ changed=Fichier changé
+File\ directory\ is\ '%0'\:=Le répertoire de fichier est '%0' :
 
-File_directory_is_not_set_or_does_not_exist\!=Le_répertoire_de_fichiers_n'est_pas_configuré_ou_n'existe_pas_\!
+File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=Le répertoire de fichiers n'est pas configuré ou n'existe pas !
 
-File_exists=Le_fichier_existe
+File\ exists=Le fichier existe
 
-File_has_been_updated_externally._What_do_you_want_to_do?=Le_fichier_a_été_mis_à_jour_externalement._Que_voulez-vous_faire_?
+File\ has\ been\ updated\ externally.\ What\ do\ you\ want\ to\ do?=Le fichier a été mis à jour externalement. Que voulez-vous faire ?
 
-File_not_found=Fichier_non_trouvé
-File_type=Type_de_fichier
+File\ not\ found=Fichier non trouvé
+File\ type=Type de fichier
 
-File_updated_externally=Fichier_mis_à_jour_externalement
+File\ updated\ externally=Fichier mis à jour externalement
 
-filename=nom_de_fichier
+filename=nom de fichier
 
-Filename=Nom_de_fichier
+Filename=Nom de fichier
 
-Files_opened=Fichiers_ouverts
+Files\ opened=Fichiers ouverts
 
-Filter=Choix_des_filtres
+Filter=Choix des filtres
 
-Filter_All=Tous_les_filtres
+Filter\ All=Tous les filtres
 
-Filter_None=Aucun_filtre
+Filter\ None=Aucun filtre
 
-Finished_automatically_setting_external_links.=La_définition_automatique_des_liens_externes_est_terminée.
+Finished\ automatically\ setting\ external\ links.=La définition automatique des liens externes est terminée.
 
-Finished_synchronizing_file_links._Entries_changed\:_%0.=Synchronisation_des_liens_fichier_terminée._Entrées_modifiées_\:_%0.
-Finished_writing_XMP-metadata._Wrote_to_%0_file(s).=Ecriture_des_méta-données_XMP_terminée._Ecriture_de_%0_fichier(s).
-Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).=Fin_de_l'écriture_des_XMP_pour_%0_fichiers_(%1_passés,_%2_erreurs).
+Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Synchronisation des liens fichier terminée. Entrées modifiées : %0.
+Finished\ writing\ XMP-metadata.\ Wrote\ to\ %0\ file(s).=Ecriture des méta-données XMP terminée. Ecriture de %0 fichier(s).
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Fin de l'écriture des XMP pour %0 fichiers (%1 passés, %2 erreurs).
 
-First_select_the_entries_you_want_keys_to_be_generated_for.=Commencez_par_sélectionner_les_entrées_pour_lesquelles_vous_voulez_que_des_clefs_soient_générées.
+First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Commencez par sélectionner les entrées pour lesquelles vous voulez que des clefs soient générées.
 
-Fit_table_horizontally_on_screen=Ajuster_horizontalement_la_table_à_l'écran
+Fit\ table\ horizontally\ on\ screen=Ajuster horizontalement la table à l'écran
 
 Float=Flottante
-Float_marked_entries=Entrées_marquées_flottantes
+Float\ marked\ entries=Entrées marquées flottantes
 
-Font_family=Famille_de_police
+Font\ family=Famille de police
 
-Font_preview=Prévisualisation_de_la_police
+Font\ preview=Prévisualisation de la police
 
-Font_size=Taille_de_police
+Font\ size=Taille de police
 
-Font_style=Style_de_police
+Font\ style=Style de police
 
-Font_selection=Sélecteur_de_police
+Font\ selection=Sélecteur de police
 
 for=pour
 
-Format_of_author_and_editor_names=Format_des_noms_d'auteurs_et_d'éditeurs
-Format_string=Chaîne_de_format
+Format\ of\ author\ and\ editor\ names=Format des noms d'auteurs et d'éditeurs
+Format\ string=Chaîne de format
 
-Format_used=Format_utilisé
-Formatter_name=Nom_de_formateur
+Format\ used=Format utilisé
+Formatter\ name=Nom de formateur
 
-found_in_AUX_file=trouvées_dans_le_fichier_AUX
+found\ in\ AUX\ file=trouvées dans le fichier AUX
 
-Full_name=Nom_complet
+Full\ name=Nom complet
 
 General=Général
 
-General_fields=Champs_généraux
+General\ fields=Champs généraux
 
 Generate=Créer
 
-Generate_BibTeX_key=Créer_la_clef_BibTeX
+Generate\ BibTeX\ key=Créer la clef BibTeX
 
-Generate_keys=Générer_les_clefs
+Generate\ keys=Générer les clefs
 
-Generate_keys_before_saving_(for_entries_without_a_key)=Générer_les_clefs_avant_d'enregistrer_(pour_les_entrées_sans_clef)
-Generate_keys_for_imported_entries=Générer_les_clefs_pour_les_entrées_importées
+Generate\ keys\ before\ saving\ (for\ entries\ without\ a\ key)=Générer les clefs avant d'enregistrer (pour les entrées sans clef)
+Generate\ keys\ for\ imported\ entries=Générer les clefs pour les entrées importées
 
-Generate_now=Générer_maintenant
+Generate\ now=Générer maintenant
 
-Generated_BibTeX_key_for=Création_terminée_de_la_clef_BibTeX_pour
+Generated\ BibTeX\ key\ for=Création terminée de la clef BibTeX pour
 
-Generating_BibTeX_key_for=Création_en_cours_d'une_clef_BibTeX_pour
-Get_fulltext=Obtenir_le_document
+Generating\ BibTeX\ key\ for=Création en cours d'une clef BibTeX pour
+Get\ fulltext=Obtenir le document
 
-Gray_out_non-hits=Griser_les_entrées_non_correspondantes
+Gray\ out\ non-hits=Griser les entrées non correspondantes
 
 Groups=Groupes
 
-Have_you_chosen_the_correct_package_path?=Avez-vous_choisi_le_bon_chemin_pour_le_paquetage_?
+Have\ you\ chosen\ the\ correct\ package\ path?=Avez-vous choisi le bon chemin pour le paquetage ?
 
 Help=Aide
 
-Help_on_key_patterns=Aide_sur_le_paramétrage_des_clefs
-Help_on_regular_expression_search=Aide_sur_la_recherche_d'une_expression_régulière
+Help\ on\ key\ patterns=Aide sur le paramétrage des clefs
+Help\ on\ regular\ expression\ search=Aide sur la recherche d'une expression régulière
 
-Hide_non-hits=Masquer_les_entrées_non_correspondantes
+Hide\ non-hits=Masquer les entrées non correspondantes
 
-Hierarchical_context=Type_de_hiérarchie
+Hierarchical\ context=Type de hiérarchie
 
 Highlight=Surligner
 Marking=Etiqueter
 Underline=Souligner
-Empty_Highlight=Annuler_le_surlignement
-Empty_Marking=Annuler_l'étiquetage
-Empty_Underline=Annuler_le_soulignement
-The_marked_area_does_not_contain_any_legible_text!=La_zone_marquée_ne_contient_aucun_texte_lisible_!
+Empty\ Highlight=Annuler le surlignement
+Empty\ Marking=Annuler l'étiquetage
+Empty\ Underline=Annuler le soulignement
+The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=La zone marquée ne contient aucun texte lisible !
 
-Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>=Astuce_\:_Pour_chercher_uniquement_dans_des_champs_spécifiques,_entrez_par_exemple_\:<p><tt>author\=smith_and_title\=électrique</tt>
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Astuce : Pour chercher uniquement dans des champs spécifiques, entrez par exemple :<p><tt>author=smith and title=électrique</tt>
 
-HTML_table=Tableau_HTML
-HTML_table_(with_Abstract_&_BibTeX)=Tableau_HTML_(avec_Résumé_&_BibTeX)
+HTML\ table=Tableau HTML
+HTML\ table\ (with\ Abstract\ &\ BibTeX)=Tableau HTML (avec Résumé & BibTeX)
 Icon=Icône
 
 Ignore=Ignorer
 
 Import=Importer
 
-Import_and_keep_old_entry=Importer_et_conserver_l'ancienne_entrée
+Import\ and\ keep\ old\ entry=Importer et conserver l'ancienne entrée
 
-Import_and_remove_old_entry=Importer_et_supprimer_l'ancienne_entrée
+Import\ and\ remove\ old\ entry=Importer et supprimer l'ancienne entrée
 
-Import_entries=Importer_les_entrées
+Import\ entries=Importer les entrées
 
-Import_failed=L'importation_a_échoué
+Import\ failed=L'importation a échoué
 
-Import_file=Fichier_à_importer
+Import\ file=Fichier à importer
 
-Import_group_definitions=Importer_les_définitions_de_groupe
+Import\ group\ definitions=Importer les définitions de groupe
 
-Import_name=nom_Import
+Import\ name=nom Import
 
-Import_preferences=Importer_les_préférences
+Import\ preferences=Importer les préférences
 
-Import_preferences_from_file=Importer_les_préférences_depuis_un_fichier
+Import\ preferences\ from\ file=Importer les préférences depuis un fichier
 
-Import_strings=Importer_les_chaînes
+Import\ strings=Importer les chaînes
 
-Import_to_open_tab=Importer_dans_l'onglet_ouvert
+Import\ to\ open\ tab=Importer dans l'onglet ouvert
 
-Import_word_selector_definitions=Importer_les_définitions_des_sélecteurs_de_mots
+Import\ word\ selector\ definitions=Importer les définitions des sélecteurs de mots
 
-Imported_entries=Entrées_importées
+Imported\ entries=Entrées importées
 
-Imported_from_library=Importé_à_partir_du_fichier
+Imported\ from\ library=Importé à partir du fichier
 
-Importer_class=Classe_Importer
+Importer\ class=Classe Importer
 
-Importing=Importation_en_cours
+Importing=Importation en cours
 
-Importing_in_unknown_format=Importation_dans_un_format_inconnu
+Importing\ in\ unknown\ format=Importation dans un format inconnu
 
-Include_abstracts=Inclure_les_résumés
-Include_entries=Entrées_affectées
+Include\ abstracts=Inclure les résumés
+Include\ entries=Entrées affectées
 
-Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups=Inclut_les_sous-groupes_\:_Quand_sélectionné,_afficher_les_entrées_contenues_dans_ce_groupe_ou_ses_sous-groupes
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=Inclut les sous-groupes : Quand sélectionné, afficher les entrées contenues dans ce groupe ou ses sous-groupes
 
-Independent_group\:_When_selected,_view_only_this_group's_entries=Groupe_indépendant_\:_Quand_sélectionné,_afficher_uniquement_les_entrées_de_ce_groupe
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=Groupe indépendant : Quand sélectionné, afficher uniquement les entrées de ce groupe
 
-Work_options=Attribution_des_champs
+Work\ options=Attribution des champs
 
 Insert=Insérer
 
-Insert_rows=Insérer_des_lignes
+Insert\ rows=Insérer des lignes
 
 Intersection=Intersection
 
-Invalid_BibTeX_key=Clef_BibTeX_invalide
+Invalid\ BibTeX\ key=Clef BibTeX invalide
 
-Invalid_date_format=Format_de_date_invalide
+Invalid\ date\ format=Format de date invalide
 
-Invalid_URL=URL_invalide
+Invalid\ URL=URL invalide
 
-Online_help=Aide_en_ligne
+Online\ help=Aide en ligne
 
-JabRef_preferences=Préférences_pour_JabRef
+JabRef\ preferences=Préférences pour JabRef
 
 Join=Joindre
 
-Joins_selected_keywords_and_deletes_selected_keywords.=Joint_les_mots-clefs_sélectionnés_et_les_supprime.
+Joins\ selected\ keywords\ and\ deletes\ selected\ keywords.=Joint les mots-clefs sélectionnés et les supprime.
 
-Journal_abbreviations=Abréviations_de_journaux
+Journal\ abbreviations=Abréviations de journaux
 
 Keep=Garder
 
-Keep_both=Garder_les_deux
+Keep\ both=Garder les deux
 
-Key_bindings=Affectations_des_touches
+Key\ bindings=Affectations des touches
 
-Key_bindings_changed=Affectations_des_touches_modifiées
+Key\ bindings\ changed=Affectations des touches modifiées
 
-Key_generator_settings=Paramétrage_du_générateur_de_clef
+Key\ generator\ settings=Paramétrage du générateur de clef
 
-Key_pattern=Paramétrage_des_clefs
+Key\ pattern=Paramétrage des clefs
 
-keys_in_library=clefs_dans_le_fichier
+keys\ in\ library=clefs dans le fichier
 
 Keyword=Mot-clef
 
-Label=Nom_du_champ
+Label=Nom du champ
 
 Language=Langue
 
-Last_modified=Dernier_modifié
+Last\ modified=Dernier modifié
 
-LaTeX_AUX_file=Fichier_LaTeX_AUX
-Leave_file_in_its_current_directory=Laisser_le_fichier_dans_son_répertoire_courant
+LaTeX\ AUX\ file=Fichier LaTeX AUX
+Leave\ file\ in\ its\ current\ directory=Laisser le fichier dans son répertoire courant
 
 Left=Gauche
 Level=Niveau
 
-Limit_to_fields=Restreindre_aux_champs
+Limit\ to\ fields=Restreindre aux champs
 
-Limit_to_selected_entries=Restreindre_aux_seules_entrées_sélectionnées
+Limit\ to\ selected\ entries=Restreindre aux seules entrées sélectionnées
 
 Link=Lien
-Link_local_file=Lier_le_fichier_local
-Link_to_file_%0=Lien_vers_le_fichier_%0
+Link\ local\ file=Lier le fichier local
+Link\ to\ file\ %0=Lien vers le fichier %0
 
-Listen_for_remote_operation_on_port=Ecouter_le_port_pour_des_opérations_à_distance
-Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)=Charger_et_enregistrer_les_préférences_de/vers_jabref.xml_au_démarrage_(mode_clef_mémoire)
+Listen\ for\ remote\ operation\ on\ port=Ecouter le port pour des opérations à distance
+Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=Charger et enregistrer les préférences de/vers jabref.xml au démarrage (mode clef mémoire)
 
-Look_and_feel=Apparence
-Main_file_directory=Répertoire_de_fichiers_principal
+Look\ and\ feel=Apparence
+Main\ file\ directory=Répertoire de fichiers principal
 
-Main_layout_file=Principal_fichier_de_mise_en_page
+Main\ layout\ file=Principal fichier de mise en page
 
-Manage_custom_exports=Gérer_les_exportations_personnalisées
+Manage\ custom\ exports=Gérer les exportations personnalisées
 
-Manage_custom_imports=Gérer_les_importations_personnalisées
-Manage_external_file_types=Gérer_les_types_de_fichiers_externes
+Manage\ custom\ imports=Gérer les importations personnalisées
+Manage\ external\ file\ types=Gérer les types de fichiers externes
 
-Mark_entries=Etiqueter_ces_entrées
+Mark\ entries=Etiqueter ces entrées
 
-Mark_entry=Etiqueter_l'entrée
+Mark\ entry=Etiqueter l'entrée
 
-Mark_new_entries_with_addition_date=Enregistrer_la_date_d'ajout_pour_les_nouvelles_entrées
+Mark\ new\ entries\ with\ addition\ date=Enregistrer la date d'ajout pour les nouvelles entrées
 
-Mark_new_entries_with_owner_name=Nouvelles_entrées_attribuées_au_propriétaire
+Mark\ new\ entries\ with\ owner\ name=Nouvelles entrées attribuées au propriétaire
 
-Memory_stick_mode=Mode_clef_mémoire
+Memory\ stick\ mode=Mode clef mémoire
 
-Menu_and_label_font_size=Taille_de_police_pour_les_menus_et_les_champs
+Menu\ and\ label\ font\ size=Taille de police pour les menus et les champs
 
-Merged_external_changes=Fusionner_les_modifications_externes
+Merged\ external\ changes=Fusionner les modifications externes
 
 Messages=Messages
 
-Modification_of_field=Modification_du_champ
+Modification\ of\ field=Modification du champ
 
-Modified_group_"%0".=Groupe_"%0"_modifié.
+Modified\ group\ "%0".=Groupe "%0" modifié.
 
-Modified_groups=Groupes_modifiés
+Modified\ groups=Groupes modifiés
 
-Modified_string=Chaîne_modifiée
+Modified\ string=Chaîne modifiée
 
 Modify=Modifier
 
-modify_group=Modifier_le_groupe
+modify\ group=Modifier le groupe
 
-Move_down=Déplacer_vers_le_bas
+Move\ down=Déplacer vers le bas
 
-Move_external_links_to_'file'_field=Déplacer_les_liens_externes_vers_le_champ_'fichier'
+Move\ external\ links\ to\ 'file'\ field=Déplacer les liens externes vers le champ 'fichier'
 
-move_group=déplacer_le_groupe
+move\ group=déplacer le groupe
 
-Move_up=Déplacer_vers_le_haut
+Move\ up=Déplacer vers le haut
 
-Moved_group_"%0".=Groupe_"%0"_déplacé.
+Moved\ group\ "%0".=Groupe "%0" déplacé.
 
 Name=Nom
-Name_formatter=Formateur_de_nom
+Name\ formatter=Formateur de nom
 
-Natbib_style=Style_Natbib
+Natbib\ style=Style Natbib
 
-nested_AUX_files=fichiers_AUX_imbriqués
+nested\ AUX\ files=fichiers AUX imbriqués
 
 New=Nouveau
 
 new=nouveau
 
-New_BibTeX_entry=Nouvelle_entrée_BibTeX
+New\ BibTeX\ entry=Nouvelle entrée BibTeX
 
-New_BibTeX_sublibrary=Nouveau_sous-fichier_BibTeX
+New\ BibTeX\ sublibrary=Nouveau sous-fichier BibTeX
 
-New_content=Nouveau_contenu
+New\ content=Nouveau contenu
 
-New_library_created.=Nouveau_fichier_créé.
-New_%0_library=Nouveau_fichier_%0
-New_field_value=Nouvelle_valeur_du_champ
+New\ library\ created.=Nouveau fichier créé.
+New\ %0\ library=Nouveau fichier %0
+New\ field\ value=Nouvelle valeur du champ
 
-New_group=Nouveau_groupe
+New\ group=Nouveau groupe
 
-New_string=Nouvelle_chaîne
+New\ string=Nouvelle chaîne
 
-Next_entry=Entrée_suivante
+Next\ entry=Entrée suivante
 
-No_actual_changes_found.=Pas_de_changements_trouvés.
+No\ actual\ changes\ found.=Pas de changements trouvés.
 
-no_base-BibTeX-file_specified=fichier_BibTeX_non_spécifié
+no\ base-BibTeX-file\ specified=fichier BibTeX non spécifié
 
-no_library_generated=pas_de_fichier_créé
+no\ library\ generated=pas de fichier créé
 
-No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.=Pas_d'entrées_trouvées._Assurez-vous,_SVP,_que_vous_utilisez_le_filtre_d'importation_approprié.
+No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=Pas d'entrées trouvées. Assurez-vous, SVP, que vous utilisez le filtre d'importation approprié.
 
 
-No_entries_found_for_the_search_string_'%0'=Pas_d'entrée_pour_la_chaîne_de_recherche_'%0'
+No\ entries\ found\ for\ the\ search\ string\ '%0'=Pas d'entrée pour la chaîne de recherche '%0'
 
-No_entries_imported.=Pas_d'entrées_importées.
+No\ entries\ imported.=Pas d'entrées importées.
 
-No_files_found.=Fichiers_non_trouvés.
+No\ files\ found.=Fichiers non trouvés.
 
-No_GUI._Only_process_command_line_options.=Pas_d'interface_utilisateur._Traitement_limité_aux_options_de_la_ligne_de_commande.
+No\ GUI.\ Only\ process\ command\ line\ options.=Pas d'interface utilisateur. Traitement limité aux options de la ligne de commande.
 
-No_journal_names_could_be_abbreviated.=Aucun_nom_de_journal_n'a_pu_être_abrégé.
+No\ journal\ names\ could\ be\ abbreviated.=Aucun nom de journal n'a pu être abrégé.
 
-No_journal_names_could_be_unabbreviated.=Aucun_nom_de_journal_n'a_pu_être_développé.
-No_PDF_linked=Pas_de_PDF_lié
+No\ journal\ names\ could\ be\ unabbreviated.=Aucun nom de journal n'a pu être développé.
+No\ PDF\ linked=Pas de PDF lié
 
-Open_PDF=Ouvrir_le_PDF
+Open\ PDF=Ouvrir le PDF
 
-No_URL_defined=Pas_d'URL_définie
+No\ URL\ defined=Pas d'URL définie
 not=non
 
-not_found=non_trouvé
+not\ found=non trouvé
 
-Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,=Notez_que_vous_devez_spécifier_le_nom_de_classe_complet_pour_l'apparence,
+Note\ that\ you\ must\ specify\ the\ fully\ qualified\ class\ name\ for\ the\ look\ and\ feel,=Notez que vous devez spécifier le nom de classe complet pour l'apparence,
 
-Nothing_to_redo=Rien_à_répéter
+Nothing\ to\ redo=Rien à répéter
 
-Nothing_to_undo=Rien_à_annuler
+Nothing\ to\ undo=Rien à annuler
 
 occurrences=occurrences
 
 OK=Ok
-One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Un_ou_plusieurs_liens_de_fichier_sont_du_type_'%0',_qui_est_indéfini._Que_voulez-vous_faire_?
+One\ or\ more\ file\ links\ are\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Un ou plusieurs liens de fichier sont du type '%0', qui est indéfini. Que voulez-vous faire ?
 
-One_or_more_keys_will_be_overwritten._Continue?=Une_ou_plusieurs_clefs_seront_écrasées._Continuer_?
+One\ or\ more\ keys\ will\ be\ overwritten.\ Continue?=Une ou plusieurs clefs seront écrasées. Continuer ?
 
 
 Open=Ouvrir
 
-Open_BibTeX_library=Ouvrir_un_fichier_BibTeX
+Open\ BibTeX\ library=Ouvrir un fichier BibTeX
 
-Open_library=Ouvrir_un_fichier
+Open\ library=Ouvrir un fichier
 
-Open_editor_when_a_new_entry_is_created=Ouvrir_l'éditeur_quand_une_nouvelle_entrée_est_créée
+Open\ editor\ when\ a\ new\ entry\ is\ created=Ouvrir l'éditeur quand une nouvelle entrée est créée
 
-Open_file=Ouvrir_le_fichier
+Open\ file=Ouvrir le fichier
 
-Open_last_edited_libraries_at_startup=Ouvrir_les_fichiers_de_la_dernière_session_au_démarrage
+Open\ last\ edited\ libraries\ at\ startup=Ouvrir les fichiers de la dernière session au démarrage
 
-Connect_to_shared_database=Ouvrir_une_base_de_données_partagée
+Connect\ to\ shared\ database=Ouvrir une base de données partagée
 
-Open_terminal_here=Ouvrir_un_terminal_ici
+Open\ terminal\ here=Ouvrir un terminal ici
 
-Open_URL_or_DOI=Ouvrir_URL_ou_DOI
+Open\ URL\ or\ DOI=Ouvrir URL ou DOI
 
-Opened_library=Fichier_ouvert
+Opened\ library=Fichier ouvert
 
-Opening=Ouverture_en_cours
+Opening=Ouverture en cours
 
-Opening_preferences...=Ouverture_des_préférences_en_cours...
+Opening\ preferences...=Ouverture des préférences en cours...
 
-Operation_canceled.=Opération_annulée.
-Operation_not_supported=Opération_non_supportée
+Operation\ canceled.=Opération annulée.
+Operation\ not\ supported=Opération non supportée
 
-Optional_fields=Champs_optionnels
+Optional\ fields=Champs optionnels
 
 Options=Options
 
 or=ou
 
-Output_or_export_file=Fichier_de_sortie_ou_d'exportation
+Output\ or\ export\ file=Fichier de sortie ou d'exportation
 
 Override=Remplacer
 
-Override_default_file_directories=Remplacer_les_répertoires_de_fichier_par_défaut
+Override\ default\ file\ directories=Remplacer les répertoires de fichier par défaut
 
-Override_default_font_settings=Se_substituer_aux_paramètres_de_police_par_défaut
+Override\ default\ font\ settings=Se substituer aux paramètres de police par défaut
 
-Override_the_BibTeX_field_by_the_selected_text=Remplacer_la_clef_BibTeX_par_le_texte_sélectionné
+Override\ the\ BibTeX\ field\ by\ the\ selected\ text=Remplacer la clef BibTeX par le texte sélectionné
 
 
 Overwrite=Ecraser
-Overwrite_existing_field_values=Ecraser_les_valeurs_existantes_du_champ
+Overwrite\ existing\ field\ values=Ecraser les valeurs existantes du champ
 
-Overwrite_keys=Ecraser_les_clefs
+Overwrite\ keys=Ecraser les clefs
 
-pairs_processed=paires_traitées
-Password=Mot_de_passe
+pairs\ processed=paires traitées
+Password=Mot de passe
 
 Paste=Coller
 
-paste_entries=Coller_les_entrées
+paste\ entries=Coller les entrées
 
-paste_entry=Coller_l'entrée
-Paste_from_clipboard=Coller_depuis_le_presse-papiers
+paste\ entry=Coller l'entrée
+Paste\ from\ clipboard=Coller depuis le presse-papiers
 
 Pasted=Collé
 
-Path_to_%0_not_defined=Chemin_vers_%0_non_défini
+Path\ to\ %0\ not\ defined=Chemin vers %0 non défini
 
-Path_to_LyX_pipe=Chemin_du_canal_de_transmission_LyX
+Path\ to\ LyX\ pipe=Chemin du canal de transmission LyX
 
-PDF_does_not_exist=Le_PDF_n'existe_pas
+PDF\ does\ not\ exist=Le PDF n'existe pas
 
-File_has_no_attached_annotations=Le_fichier_n'a_pas_d'annotations_liées
+File\ has\ no\ attached\ annotations=Le fichier n'a pas d'annotations liées
 
-Plain_text_import=Importation_de_texte_brut
+Plain\ text\ import=Importation de texte brut
 
-Please_enter_a_name_for_the_group.=SVP,_entrez_un_nom_pour_le_groupe.
+Please\ enter\ a\ name\ for\ the\ group.=SVP, entrez un nom pour le groupe.
 
-Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>=SVP,_entrez_un_terme_à_recherche._Par_exemple,_pour_rechercher_<b>Smith</b>_dans_tout_les_champs,_entrez_\:<p><tt>smith</tt><p>Pour_rechercher_<b>Smith</b>_dans_le_champ_<b>Author</b>_et_<b>électrique</b>_dans_le_champ_<b>Title</b>,_entrez_\:<p><tt>author\=smith_and_title\=électrique</tt>
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=SVP, entrez un terme à recherche. Par exemple, pour rechercher <b>Smith</b> dans tout les champs, entrez :<p><tt>smith</tt><p>Pour rechercher <b>Smith</b> dans le champ <b>Author</b> et <b>électrique</b> dans le champ <b>Title</b>, entrez :<p><tt>author=smith and title=électrique</tt>
 
-Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=SVP,_entrez_le_champ_de_recherche_(par_ex._<b>keywords</b>)_et_le_mot-clef_à_rechercher_(par_ex._<b>électrique</b>).
+Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=SVP, entrez le champ de recherche (par ex. <b>keywords</b>) et le mot-clef à rechercher (par ex. <b>électrique</b>).
 
-Please_enter_the_string's_label=SVP,_entrez_le_nom_de_la_chaîne
+Please\ enter\ the\ string's\ label=SVP, entrez le nom de la chaîne
 
-Please_select_an_importer.=Sélectionner_un_filtre_d'importation,_SVP.
+Please\ select\ an\ importer.=Sélectionner un filtre d'importation, SVP.
 
-Possible_duplicate_entries=Entrées_potentiellement_dupliquées
+Possible\ duplicate\ entries=Entrées potentiellement dupliquées
 
-Possible_duplicate_of_existing_entry._Click_to_resolve.=Duplication_possible_d'une_entrée_existante._Cliquer_pour_vérifier.
+Possible\ duplicate\ of\ existing\ entry.\ Click\ to\ resolve.=Duplication possible d'une entrée existante. Cliquer pour vérifier.
 
 Preamble=Préambule
 
 Preferences=Préférences
 
-Preferences_recorded.=Préférences_enregistrées.
+Preferences\ recorded.=Préférences enregistrées.
 
 Preview=Aperçu
-Citation_Style=Style_de_citation
-Current_Preview=Aperçu_actuel
-Cannot_generate_preview_based_on_selected_citation_style.=La_prévisualisation_ne_peut_pas_être_générée_à_partir_du_style_de_citation_sélectionné.
-Bad_character_inside_entry=Caractère_érroné_dans_l'entrée
-Error_while_generating_citation_style=Erreur_lors_de_la_génération_du_style_de_citation
-Preview_style_changed_to\:_%0=Style_d'aperçu_modifié_en_\:_%0
-Next_preview_layout=Mode_d'aperçu_suivant
-Previous_preview_layout=Mode_d'aperçu_précédent
+Citation\ Style=Style de citation
+Current\ Preview=Aperçu actuel
+Cannot\ generate\ preview\ based\ on\ selected\ citation\ style.=La prévisualisation ne peut pas être générée à partir du style de citation sélectionné.
+Bad\ character\ inside\ entry=Caractère érroné dans l'entrée
+Error\ while\ generating\ citation\ style=Erreur lors de la génération du style de citation
+Preview\ style\ changed\ to\:\ %0=Style d'aperçu modifié en : %0
+Next\ preview\ layout=Mode d'aperçu suivant
+Previous\ preview\ layout=Mode d'aperçu précédent
 
-Previous_entry=Entrée_précédente
+Previous\ entry=Entrée précédente
 
-Primary_sort_criterion=Critère_de_tri_principal
-Problem_with_parsing_entry=Problème_de_traitement_d'une_entrée
-Processing_%0=Traitement_de_%0
-Pull_changes_from_shared_database=Récupérer_les_modification_depuis_la_base_de_données_partagée
+Primary\ sort\ criterion=Critère de tri principal
+Problem\ with\ parsing\ entry=Problème de traitement d'une entrée
+Processing\ %0=Traitement de %0
+Pull\ changes\ from\ shared\ database=Récupérer les modification depuis la base de données partagée
 
-Pushed_citations_to_%0=Envoyer_les_citations_vers_%0
+Pushed\ citations\ to\ %0=Envoyer les citations vers %0
 
-Quit_JabRef=Quitter_JabRef
+Quit\ JabRef=Quitter JabRef
 
-Quit_synchronization=Quitter_la_synchronisation
+Quit\ synchronization=Quitter la synchronisation
 
-Raw_source=Texte_brut
+Raw\ source=Texte brut
 
-Rearrange_tabs_alphabetically_by_title=Classer_les_onglets_par_ordre_alphabétique
+Rearrange\ tabs\ alphabetically\ by\ title=Classer les onglets par ordre alphabétique
 
 Redo=Répéter
 
-Reference_library=Fichier_de_référence
+Reference\ library=Fichier de référence
 
-%0_references_found._Number_of_references_to_fetch?=Références_trouvées_\:_%0._Nombre_de_références_à_récupérer_?
+%0\ references\ found.\ Number\ of\ references\ to\ fetch?=Références trouvées : %0. Nombre de références à récupérer ?
 
-Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Raffine_le_super-groupe_\:_Quand_sélectionné,_afficher_les_entrées_contenues_à_la_fois_dans_ce_groupe_et_son_super-groupe
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=Raffine le super-groupe : Quand sélectionné, afficher les entrées contenues à la fois dans ce groupe et son super-groupe
 
-regular_expression=Expression_régulière
+regular\ expression=Expression régulière
 
-Related_articles=Articles_liés
+Related\ articles=Articles liés
 
-Remote_operation=Accès_à_distance
+Remote\ operation=Accès à distance
 
-Remote_server_port=Port_du_serveur_d'accès_à_distance
+Remote\ server\ port=Port du serveur d'accès à distance
 
 Remove=Supprimer
 
-Remove_subgroups=Supprimer_les_sous-groupes
+Remove\ subgroups=Supprimer les sous-groupes
 
-Remove_all_subgroups_of_"%0"?=Supprimer_tous_les_sous-groupes_de_"%0"_?
+Remove\ all\ subgroups\ of\ "%0"?=Supprimer tous les sous-groupes de "%0" ?
 
-Remove_entry_from_import=Supprimer_l'entrée_de_l'importation
+Remove\ entry\ from\ import=Supprimer l'entrée de l'importation
 
-Remove_selected_entries_from_this_group=Supprimer_les_entrées_sélectionnées_de_ce_groupe
+Remove\ selected\ entries\ from\ this\ group=Supprimer les entrées sélectionnées de ce groupe
 
-Remove_entry_type=Supprimer_le_type_d'entrée
+Remove\ entry\ type=Supprimer le type d'entrée
 
-Remove_from_group=Supprimer_du_groupe
+Remove\ from\ group=Supprimer du groupe
 
-Remove_group=Supprimer_le_groupe
+Remove\ group=Supprimer le groupe
 
-Remove_group,_keep_subgroups=Supprimer_le_groupe,_garder_les_sous-groupes
+Remove\ group,\ keep\ subgroups=Supprimer le groupe, garder les sous-groupes
 
-Remove_group_"%0"?=Supprimer_le_groupe_"%0"_?
+Remove\ group\ "%0"?=Supprimer le groupe "%0" ?
 
-Remove_group_"%0"_and_its_subgroups?=Supprimer_le_groupe_"%0"_et_ses_sous-groupes_?
+Remove\ group\ "%0"\ and\ its\ subgroups?=Supprimer le groupe "%0" et ses sous-groupes ?
 
-remove_group_(keep_subgroups)=supprimer_le_groupe_(garder_les_sous-groupes)
+remove\ group\ (keep\ subgroups)=supprimer le groupe (garder les sous-groupes)
 
-remove_group_and_subgroups=supprimer_le_groupe_et_les_sous-groupes
+remove\ group\ and\ subgroups=supprimer le groupe et les sous-groupes
 
-Remove_group_and_subgroups=Supprimer_le_groupe_et_les_sous-groupes
+Remove\ group\ and\ subgroups=Supprimer le groupe et les sous-groupes
 
-Remove_link=Supprimer_le_lien
+Remove\ link=Supprimer le lien
 
-Remove_old_entry=Supprimer_l'ancienne_entrée
+Remove\ old\ entry=Supprimer l'ancienne entrée
 
-Remove_selected_strings=Supprimer_les_chaînes_sélectionnées
+Remove\ selected\ strings=Supprimer les chaînes sélectionnées
 
-Removed_group_"%0".=Groupe_"%0"_supprimé.
+Removed\ group\ "%0".=Groupe "%0" supprimé.
 
-Removed_group_"%0"_and_its_subgroups.=Groupe_"%0"_et_ses_sous-groupes_supprimés.
+Removed\ group\ "%0"\ and\ its\ subgroups.=Groupe "%0" et ses sous-groupes supprimés.
 
-Removed_string=Chaîne_supprimée
+Removed\ string=Chaîne supprimée
 
-Renamed_string=Chaîne_renommée
+Renamed\ string=Chaîne renommée
 
 Replace=Remplacer
 
-Replace_(regular_expression)=Remplacer_(expression_régulière)
+Replace\ (regular\ expression)=Remplacer (expression régulière)
 
-Replace_string=Remplacer_la_chaîne
+Replace\ string=Remplacer la chaîne
 
-Replace_with=Remplacer_par
+Replace\ with=Remplacer par
 
 Replaced=Remplacé
 
-Required_fields=Champs_requis
+Required\ fields=Champs requis
 
-Reset_all=Rétablir_les_options_précédentes
+Reset\ all=Rétablir les options précédentes
 
-Resolve_strings_for_all_fields_except=Traiter_les_chaînes_pour_tous_les_champs_sauf
-Resolve_strings_for_standard_BibTeX_fields_only=Traiter_les_chaînes_pour_les_champs_BibTeX_standard_uniquement
+Resolve\ strings\ for\ all\ fields\ except=Traiter les chaînes pour tous les champs sauf
+Resolve\ strings\ for\ standard\ BibTeX\ fields\ only=Traiter les chaînes pour les champs BibTeX standard uniquement
 
 resolved=résolu
 
 Review=Remarques
 
-Review_changes=Revoir_les_changements
+Review\ changes=Revoir les changements
 
 Right=Droite
 
 Save=Enregistrer
-Save_all_finished.=Enregistrement_de_tout_terminée.
+Save\ all\ finished.=Enregistrement de tout terminée.
 
-Save_all_open_libraries=Enregistrement_tous_les_fichiers_ouverts
+Save\ all\ open\ libraries=Enregistrement tous les fichiers ouverts
 
-Save_before_closing=Enregistrement_avant_fermeture
+Save\ before\ closing=Enregistrement avant fermeture
 
-Save_library=Enregistrement_le_fichier
-Save_library_as...=Enregistrement_le_fichier_sous...
+Save\ library=Enregistrement le fichier
+Save\ library\ as...=Enregistrement le fichier sous...
 
-Save_entries_in_their_original_order=Enregistrement_les_entrées_dans_leur_ordre_original
+Save\ entries\ in\ their\ original\ order=Enregistrement les entrées dans leur ordre original
 
-Save_failed=Echec_de_l'enregistrement
+Save\ failed=Echec de l'enregistrement
 
-Save_failed_during_backup_creation=L'enregistrement_a_échoué_durant_la_création_de_la_copie_de_secours
+Save\ failed\ during\ backup\ creation=L'enregistrement a échoué durant la création de la copie de secours
 
-Save_selected_as...=Enregistrer_la_sélection_sous...
+Save\ selected\ as...=Enregistrer la sélection sous...
 
-Saved_library=Fichier_enregistré
+Saved\ library=Fichier enregistré
 
-Saved_selected_to_'%0'.=Sélection_enregistrée_dans_'%0'.
+Saved\ selected\ to\ '%0'.=Sélection enregistrée dans '%0'.
 
-Saving=Enregistrement_en_cours
-Saving_all_libraries...=Enregistrement_de_tous_les_fichiers...
+Saving=Enregistrement en cours
+Saving\ all\ libraries...=Enregistrement de tous les fichiers...
 
-Saving_library=Enregistrement_du_fichier_en_cours
+Saving\ library=Enregistrement du fichier en cours
 
 Search=Recherche
 
-Search_expression=Expression_à_rechercher
+Search\ expression=Expression à rechercher
 
-Search_for=Rechercher
+Search\ for=Rechercher
 
-Searching_for_duplicates...=Recherche_des_doublons_en_cours...
+Searching\ for\ duplicates...=Recherche des doublons en cours...
 
-Searching_for_files=Recherche_de_fichiers...
+Searching\ for\ files=Recherche de fichiers...
 
-Secondary_sort_criterion=Critère_secondaire_de_tri
+Secondary\ sort\ criterion=Critère secondaire de tri
 
-Select_all=Tout_sélectionner
+Select\ all=Tout sélectionner
 
-Select_encoding=Sélectionner_l'encodage
+Select\ encoding=Sélectionner l'encodage
 
-Select_entry_type=Sélectionner_un_type_d'entrée
-Select_external_application=Sélectionner_une_application_externe
+Select\ entry\ type=Sélectionner un type d'entrée
+Select\ external\ application=Sélectionner une application externe
 
-Select_file_from_ZIP-archive=Sélectionner_un_fichier_depuis_une_archive_ZIP
+Select\ file\ from\ ZIP-archive=Sélectionner un fichier depuis une archive ZIP
 
-Select_the_tree_nodes_to_view_and_accept_or_reject_changes=Sélectionner_les_noeuds_de_l'arborescence_pour_voir,_et_accepter_ou_rejeter,_les_modifications
-Selected_entries=Les_entrées_sélectionnées
-Set_field=Configurer_le_champ
-Set_fields=Configurer_les_champs
+Select\ the\ tree\ nodes\ to\ view\ and\ accept\ or\ reject\ changes=Sélectionner les noeuds de l'arborescence pour voir, et accepter ou rejeter, les modifications
+Selected\ entries=Les entrées sélectionnées
+Set\ field=Configurer le champ
+Set\ fields=Configurer les champs
 
-Set_general_fields=Définir_les_champs_généraux
-Set_main_external_file_directory=Définir_le_répertoire_principal_des_fichiers_externes
+Set\ general\ fields=Définir les champs généraux
+Set\ main\ external\ file\ directory=Définir le répertoire principal des fichiers externes
 
-Set_table_font=Définir_la_police_de_la_table
+Set\ table\ font=Définir la police de la table
 
 Settings=Paramètres
 
 Shortcut=Raccourci
 
-Show/edit_%0_source=Montrer/éditer_le_source_%0
+Show/edit\ %0\ source=Montrer/éditer le source %0
 
-Show_'Firstname_Lastname'=Ordre_d'affichage_'Prénom_Nom'
+Show\ 'Firstname\ Lastname'=Ordre d'affichage 'Prénom Nom'
 
-Show_'Lastname,_Firstname'=Ordre_d'affichage_'Nom,_Prénom'
+Show\ 'Lastname,\ Firstname'=Ordre d'affichage 'Nom, Prénom'
 
-Show_BibTeX_source_by_default=Par_défaut,_afficher_l'onglet_Source_BibTeX
+Show\ BibTeX\ source\ by\ default=Par défaut, afficher l'onglet Source BibTeX
 
-Show_confirmation_dialog_when_deleting_entries=Demander_une_confirmation_lors_de_la_suppression_d'entrées
+Show\ confirmation\ dialog\ when\ deleting\ entries=Demander une confirmation lors de la suppression d'entrées
 
-Show_description=Montrer_la_description
+Show\ description=Montrer la description
 
-Show_file_column=Afficher_la_colonne_Fichier
+Show\ file\ column=Afficher la colonne Fichier
 
-Show_last_names_only=Afficher_uniquement_les_noms_propres
+Show\ last\ names\ only=Afficher uniquement les noms propres
 
-Show_names_unchanged=Ordre_des_noms_inchangé
+Show\ names\ unchanged=Ordre des noms inchangé
 
-Show_optional_fields=Montrer_les_champs_optionnels
+Show\ optional\ fields=Montrer les champs optionnels
 
-Show_required_fields=Montrer_les_champs_requis
+Show\ required\ fields=Montrer les champs requis
 
-Show_URL/DOI_column=Afficher_la_colonne_URL/DOI
+Show\ URL/DOI\ column=Afficher la colonne URL/DOI
 
-Simple_HTML=HTML_(simple)
+Simple\ HTML=HTML (simple)
 
 Size=Taille
 
-Skipped_-_No_PDF_linked=Sauté_-_Pas_de_PDF_lié
-Skipped_-_PDF_does_not_exist=Omis_-_Le_PDF_n'existe_pas
+Skipped\ -\ No\ PDF\ linked=Sauté - Pas de PDF lié
+Skipped\ -\ PDF\ does\ not\ exist=Omis - Le PDF n'existe pas
 
-Skipped_entry.=Entrée_omise
+Skipped\ entry.=Entrée omise
 
-Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.=Certains_des_paramètres_d'apparence_que_vous_avez_modifiés_nécessitent_de_redémarrer_JabRef_pour_prendre_effet.
+Some\ appearance\ settings\ you\ changed\ require\ to\ restart\ JabRef\ to\ come\ into\ effect.=Certains des paramètres d'apparence que vous avez modifiés nécessitent de redémarrer JabRef pour prendre effet.
 
-source_edit=édition_du_source
-Special_name_formatters=Formateurs_de_nom_spéciaux
+source\ edit=édition du source
+Special\ name\ formatters=Formateurs de nom spéciaux
 
-Special_table_columns=Colonnes_de_tableau_particulières
+Special\ table\ columns=Colonnes de tableau particulières
 
-Starting_import=Début_d'importation
+Starting\ import=Début d'importation
 
-Statically_group_entries_by_manual_assignment=Grouper_manuellement_les_entrées
+Statically\ group\ entries\ by\ manual\ assignment=Grouper manuellement les entrées
 
 Status=Etat
 
@@ -1143,1215 +1143,1215 @@ Stop=Arrêt
 
 Strings=Chaîne
 
-Strings_for_library=Chaînes_pour_le_fichier
+Strings\ for\ library=Chaînes pour le fichier
 
-Sublibrary_from_AUX=Sous-fichier_à_partir_de_LaTeX_AUX
+Sublibrary\ from\ AUX=Sous-fichier à partir de LaTeX AUX
 
-Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.=Basculer_entre_les_noms_de_journaux_développés_et_abrégés_si_le_nom_de_journal_est_connu.
+Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=Basculer entre les noms de journaux développés et abrégés si le nom de journal est connu.
 
-Synchronize_file_links=Synchroniser_les_liens_vers_les_fichiers
+Synchronize\ file\ links=Synchroniser les liens vers les fichiers
 
-Synchronizing_file_links...=Synchronisation_des_liens_fichier...
+Synchronizing\ file\ links...=Synchronisation des liens fichier...
 
-Table_appearance=Apparence_de_la_table
+Table\ appearance=Apparence de la table
 
-Table_background_color=Couleur_d'arrière-plan_de_la_table
+Table\ background\ color=Couleur d'arrière-plan de la table
 
-Table_grid_color=Couleur_de_la_grille_de_la_table
+Table\ grid\ color=Couleur de la grille de la table
 
-Table_text_color=Couleur_du_texte_de_la_table
+Table\ text\ color=Couleur du texte de la table
 
-Tabname=Nom_d'onglet
-Target_file_cannot_be_a_directory.=Le_fichier_cible_ne_peut_pas_être_un_répertoire.
+Tabname=Nom d'onglet
+Target\ file\ cannot\ be\ a\ directory.=Le fichier cible ne peut pas être un répertoire.
 
-Tertiary_sort_criterion=Critère_tertiaire_de_tri
+Tertiary\ sort\ criterion=Critère tertiaire de tri
 
 Test=Test
 
-paste_text_here=Zone_de_saisie_du_texte
+paste\ text\ here=Zone de saisie du texte
 
-The_chosen_date_format_for_new_entries_is_not_valid=Le_format_de_date_choisi_pour_les_nouvelles_entrées_n'est_pas_valide
+The\ chosen\ date\ format\ for\ new\ entries\ is\ not\ valid=Le format de date choisi pour les nouvelles entrées n'est pas valide
 
-The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:=L'encodage_'%0'_choisi_ne_peut_pas_encoder_les_caractères_suivants_\:
+The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=L'encodage '%0' choisi ne peut pas encoder les caractères suivants :
 
 
-the_field_<b>%0</b>=le_champ_<b>%0</b>
+the\ field\ <b>%0</b>=le champ <b>%0</b>
 
-The_file<BR>'%0'<BR>has_been_modified<BR>externally\!=Le_fichier<BR>'%0'<BR>a_été_modifié_<BR>externalement_\!
+The\ file<BR>'%0'<BR>has\ been\ modified<BR>externally\!=Le fichier<BR>'%0'<BR>a été modifié <BR>externalement !
 
-The_group_"%0"_already_contains_the_selection.=Le_groupe_"%0"_contient_déjà_la_sélection.
+The\ group\ "%0"\ already\ contains\ the\ selection.=Le groupe "%0" contient déjà la sélection.
 
-The_label_of_the_string_cannot_be_a_number.=L'intitulé_de_la_chaîne_ne_peut_être_un_nombre.
+The\ label\ of\ the\ string\ cannot\ be\ a\ number.=L'intitulé de la chaîne ne peut être un nombre.
 
-The_label_of_the_string_cannot_contain_spaces.=Un_nom_de_chaîne_ne_peut_pas_contenir_d'espaces.
+The\ label\ of\ the\ string\ cannot\ contain\ spaces.=Un nom de chaîne ne peut pas contenir d'espaces.
 
-The_label_of_the_string_cannot_contain_the_'\#'_character.=Le_nom_de_la_chaîne_ne_peut_pas_contenir_le_caractère_'\#'.
+The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=Le nom de la chaîne ne peut pas contenir le caractère '#'.
 
-The_output_option_depends_on_a_valid_import_option.=L'option_de_sortie_dépend_d'une_option_d'importation_valide.
-The_PDF_contains_one_or_several_BibTeX-records.=Le_PDF_contient_un_ou_plusieurs_enregistrements_BibTeX.
-Do_you_want_to_import_these_as_new_entries_into_the_current_library?=Voulez-vous_les_importer_comme_de_nouvelles_entrées_dans_le_fichier_actuel_?
+The\ output\ option\ depends\ on\ a\ valid\ import\ option.=L'option de sortie dépend d'une option d'importation valide.
+The\ PDF\ contains\ one\ or\ several\ BibTeX-records.=Le PDF contient un ou plusieurs enregistrements BibTeX.
+Do\ you\ want\ to\ import\ these\ as\ new\ entries\ into\ the\ current\ library?=Voulez-vous les importer comme de nouvelles entrées dans le fichier actuel ?
 
-The_regular_expression_<b>%0</b>_is_invalid\:=L'expression_régulière_<b>%0</b>_est_invalide_\:
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=L'expression régulière <b>%0</b> est invalide :
 
-The_search_is_case_insensitive.=La_recherche_n'est_pas_sensible_à_la_casse.
+The\ search\ is\ case\ insensitive.=La recherche n'est pas sensible à la casse.
 
-The_search_is_case_sensitive.=La_recherche_est_sensible_à_la_casse.
+The\ search\ is\ case\ sensitive.=La recherche est sensible à la casse.
 
-The_string_has_been_removed_locally=La_chaîne_a_été_supprimée_localement
+The\ string\ has\ been\ removed\ locally=La chaîne a été supprimée localement
 
-There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?=Il_y_a_des_doublons_potentiels_(marqué_avec_un_icône)_qui_n'ont_pas_été_traités._Continuer_?
+There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=Il y a des doublons potentiels (marqué avec un icône) qui n'ont pas été traités. Continuer ?
 
-This_entry_has_no_BibTeX_key._Generate_key_now?=Cette_entrée_n'a_pas_de_clef_BibTeX._En_générer_une_maintenant_?
+This\ entry\ has\ no\ BibTeX\ key.\ Generate\ key\ now?=Cette entrée n'a pas de clef BibTeX. En générer une maintenant ?
 
-This_entry_is_incomplete=Cette_entrée_est_incomplète
+This\ entry\ is\ incomplete=Cette entrée est incomplète
 
-This_entry_type_cannot_be_removed.=Ce_type_d'entrée_ne_peut_pas_être_supprimé.
+This\ entry\ type\ cannot\ be\ removed.=Ce type d'entrée ne peut pas être supprimé.
 
-This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Ce_lien_externe_est_du_type_'%0',_qui_est_indéfini._Que_voulez-vous_faire_?
+This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Ce lien externe est du type '%0', qui est indéfini. Que voulez-vous faire ?
 
-This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.=Ce_groupe_contient_des_entrées_basées_sur_un_ajout_manuel._Des_entrées_peuvent_être_ajoutées_à_ce_groupe_en_les_sélectionnant_puis_en_utilisant_un_glisser-déplacer_ou_le_menu_contextuel._Des_entrées_peuvent_être_supprimées_de_ce_groupe_en_les_sélectionnant_puis_en_utilisant_le_menu_contextuel.
+This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=Ce groupe contient des entrées basées sur un ajout manuel. Des entrées peuvent être ajoutées à ce groupe en les sélectionnant puis en utilisant un glisser-déplacer ou le menu contextuel. Des entrées peuvent être supprimées de ce groupe en les sélectionnant puis en utilisant le menu contextuel.
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>=Ce_groupe_contient_des_entrées_dont_le_champ_<b>%0</b>_contient_le_mot-clef_<b>%1</b>_
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Ce groupe contient des entrées dont le champ <b>%0</b> contient le mot-clef <b>%1</b> 
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>=Ce_groupe_contient_des_entrées_dont_le_champ_<b>%0</b>_contient_l'expression_régulière_<b>%1</b>_
-This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.=JabRef_cherche_chaque_fichier_lien_et_vérifie_si_le_fichier_existe._Si_non,_des_options_vous_seront_proposées<BR>pour_résoudre_le_problème.
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Ce groupe contient des entrées dont le champ <b>%0</b> contient l'expression régulière <b>%1</b> 
+This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=JabRef cherche chaque fichier lien et vérifie si le fichier existe. Si non, des options vous seront proposées<BR>pour résoudre le problème.
 
-This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.=Cette_opération_nécessite_que_toutes_les_entrées_sélectionnées_aient_des_clefs_BibTeX_définies
+This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=Cette opération nécessite que toutes les entrées sélectionnées aient des clefs BibTeX définies
 
-This_operation_requires_one_or_more_entries_to_be_selected.=Cette_opération_nécessite_qu'une_ou_plusieurs_entrées_soient_sélectionnées.
+This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=Cette opération nécessite qu'une ou plusieurs entrées soient sélectionnées.
 
-Toggle_entry_preview=Afficher/Masquer_l'aperçu
-Toggle_groups_interface=Afficher/Masquer_l'interface_des_groupes
-Try_different_encoding=Essayer_un_encodage_différent
+Toggle\ entry\ preview=Afficher/Masquer l'aperçu
+Toggle\ groups\ interface=Afficher/Masquer l'interface des groupes
+Try\ different\ encoding=Essayer un encodage différent
 
-Unabbreviate_journal_names_of_the_selected_entries=Développer_les_noms_de_journaux_des_entrées_sélectionnées
-Unabbreviated_%0_journal_names.=%0_noms_de_journaux_développés.
+Unabbreviate\ journal\ names\ of\ the\ selected\ entries=Développer les noms de journaux des entrées sélectionnées
+Unabbreviated\ %0\ journal\ names.=%0 noms de journaux développés.
 
-Unable_to_open_file.=Impossible_d'ouvrir_le_fichier
-Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.=Impossible_d'ouvrir_un_lien._L'application_'%0'_associée_avec_le_type_de_fichier_'%1'_n'a_pu_être_appelée.
-unable_to_write_to=Impossible_d'écrire_sur
-Undefined_file_type=Type_de_fichier_indéfini
+Unable\ to\ open\ file.=Impossible d'ouvrir le fichier
+Unable\ to\ open\ link.\ The\ application\ '%0'\ associated\ with\ the\ file\ type\ '%1'\ could\ not\ be\ called.=Impossible d'ouvrir un lien. L'application '%0' associée avec le type de fichier '%1' n'a pu être appelée.
+unable\ to\ write\ to=Impossible d'écrire sur
+Undefined\ file\ type=Type de fichier indéfini
 
 Undo=Annuler
 
 Union=Union
 
-Unknown_BibTeX_entries=Entrées_BibTeX_inconnues
+Unknown\ BibTeX\ entries=Entrées BibTeX inconnues
 
-unknown_edit=édition_inconnue
+unknown\ edit=édition inconnue
 
-Unknown_export_format=Format_d'exportation_inconnu
+Unknown\ export\ format=Format d'exportation inconnu
 
-Unmark_all=Tout_désétiqueter
+Unmark\ all=Tout désétiqueter
 
-Unmark_entries=Désétiqueter_ces_entrées
+Unmark\ entries=Désétiqueter ces entrées
 
-Unmark_entry=Désétiqueter_l'entrée
+Unmark\ entry=Désétiqueter l'entrée
 
-untitled=sans_titre
+untitled=sans titre
 
 Up=Haut
 
-Update_to_current_column_widths=Figer_les_largeurs_actuelles_des_colonnes
+Update\ to\ current\ column\ widths=Figer les largeurs actuelles des colonnes
 
-Updated_group_selection=Sélection_de_groupe_mise_à_jour
-Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.=Mettre_à_jour_les_liens_externes_PDF/PS_pour_utiliser_le_champ_'%0'.
-Upgrade_file=Mettre_à_jour_le_fichier
-Upgrade_old_external_file_links_to_use_the_new_feature=Mettre_à_jour_les_anciens_liens_vers_les_fichiers_externes_pour_utiliser_cette_nouvelle_fonction
+Updated\ group\ selection=Sélection de groupe mise à jour
+Upgrade\ external\ PDF/PS\ links\ to\ use\ the\ '%0'\ field.=Mettre à jour les liens externes PDF/PS pour utiliser le champ '%0'.
+Upgrade\ file=Mettre à jour le fichier
+Upgrade\ old\ external\ file\ links\ to\ use\ the\ new\ feature=Mettre à jour les anciens liens vers les fichiers externes pour utiliser cette nouvelle fonction
 
 usage=usage
-Use_autocompletion_for_the_following_fields=Utiliser_l'auto-génération_pour_les_champs_suivants
+Use\ autocompletion\ for\ the\ following\ fields=Utiliser l'auto-génération pour les champs suivants
 
-Use_other_look_and_feel=Utiliser_une_autre_apparence
-Tweak_font_rendering_for_entry_editor_on_Linux=Ajuster_le_rendu_des_polices_pour_l'éditeur_d'entrée_sous_Linux
-Use_regular_expression_search=Utiliser_l'expression_régulière_pour_la_recherche
+Use\ other\ look\ and\ feel=Utiliser une autre apparence
+Tweak\ font\ rendering\ for\ entry\ editor\ on\ Linux=Ajuster le rendu des polices pour l'éditeur d'entrée sous Linux
+Use\ regular\ expression\ search=Utiliser l'expression régulière pour la recherche
 
-Username=Nom_d'utilisateur
+Username=Nom d'utilisateur
 
-Value_cleared_externally=Valeur_supprimée_externalement
+Value\ cleared\ externally=Valeur supprimée externalement
 
-Value_set_externally=Valeur_paramétrée_externalement
+Value\ set\ externally=Valeur paramétrée externalement
 
-verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid=vérifier_que_LyX_tourne_et_que_le_canal_de_transmission_LyX_est_valide
+verify\ that\ LyX\ is\ running\ and\ that\ the\ lyxpipe\ is\ valid=vérifier que LyX tourne et que le canal de transmission LyX est valide
 
 View=Aperçu
-Vim_server_name=Nom_du_serveur_Vim
+Vim\ server\ name=Nom du serveur Vim
 
-Waiting_for_ArXiv...=Attente_de_ArXiv...
+Waiting\ for\ ArXiv...=Attente de ArXiv...
 
-Warn_about_unresolved_duplicates_when_closing_inspection_window=Avertir_des_doublons_non_résolus_lors_de_la_fermeture_de_la_fenêtre_d'inspection
+Warn\ about\ unresolved\ duplicates\ when\ closing\ inspection\ window=Avertir des doublons non résolus lors de la fermeture de la fenêtre d'inspection
 
-Warn_before_overwriting_existing_keys=Avertir_avant_d'écraser_des_clefs_existantes
+Warn\ before\ overwriting\ existing\ keys=Avertir avant d'écraser des clefs existantes
 
 Warning=Avertissement
 
-Warnings=Messages_d'avertissement
+Warnings=Messages d'avertissement
 
-web_link=Lien_internet
+web\ link=Lien internet
 
-What_do_you_want_to_do?=Que_voulez-vous_faire_?
+What\ do\ you\ want\ to\ do?=Que voulez-vous faire ?
 
-When_adding/removing_keywords,_separate_them_by=Lors_de_l'ajout/suppression_de_mots-clefs,_les_séparer_avec
-Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.=Ecrit_les_métadonnées_XMP_dans_les_PDFs_liés_aux_entrées_sélectionnées
+When\ adding/removing\ keywords,\ separate\ them\ by=Lors de l'ajout/suppression de mots-clefs, les séparer avec
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Ecrit les métadonnées XMP dans les PDFs liés aux entrées sélectionnées
 
 with=avec
 
-Write_BibTeXEntry_as_XMP-metadata_to_PDF.=Ecrire_l'entrée_BibTeX_comme_des_métadonnées_XMP_dans_un_PDF
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Ecrire l'entrée BibTeX comme des métadonnées XMP dans un PDF
 
-Write_XMP=Ecrire_XMP
-Write_XMP-metadata=Ecrire_les_métadonnées_XMP
-Write_XMP-metadata_for_all_PDFs_in_current_library?=Ecrire_les_métadonnées_XMP_pour_tous_les_PDFs_dans_le_fichier_courant_?
-Writing_XMP-metadata...=Ecriture_des_métadonnées_XMP
-Writing_XMP-metadata_for_selected_entries...=Ecriture_des_métadonnées_XMP_pour_les_entrées_sélectionnées
+Write\ XMP=Ecrire XMP
+Write\ XMP-metadata=Ecrire les métadonnées XMP
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Ecrire les métadonnées XMP pour tous les PDFs dans le fichier courant ?
+Writing\ XMP-metadata...=Ecriture des métadonnées XMP
+Writing\ XMP-metadata\ for\ selected\ entries...=Ecriture des métadonnées XMP pour les entrées sélectionnées
 
-Wrote_XMP-metadata=Méta-données_XMP_écrites
+Wrote\ XMP-metadata=Méta-données XMP écrites
 
-XMP-annotated_PDF=PDF_avec_annotations_XMP
-XMP_export_privacy_settings=Paramètres_de_confidentialité_pour_l'exportation_XMP
-XMP-metadata=Métadonnées_XMP
-XMP-metadata_found_in_PDF\:_%0=Métadonnées_XMP_trouvées_dans_le_PDF_\:_%0
-You_must_restart_JabRef_for_this_to_come_into_effect.=Vous_devez_redémarrer_JabRef_pour_que_ce_changement_prenne_effet.
-You_have_changed_the_language_setting.=Vous_avez_modifié_la_langue.
-You_have_entered_an_invalid_search_'%0'.=Vous_avez_entré_une_recherche_invalide_'%0'.
+XMP-annotated\ PDF=PDF avec annotations XMP
+XMP\ export\ privacy\ settings=Paramètres de confidentialité pour l'exportation XMP
+XMP-metadata=Métadonnées XMP
+XMP-metadata\ found\ in\ PDF\:\ %0=Métadonnées XMP trouvées dans le PDF : %0
+You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Vous devez redémarrer JabRef pour que ce changement prenne effet.
+You\ have\ changed\ the\ language\ setting.=Vous avez modifié la langue.
+You\ have\ entered\ an\ invalid\ search\ '%0'.=Vous avez entré une recherche invalide '%0'.
 
-You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.=Vous_devez_relancer_JabRef_pour_que_les_nouvelles_affectations_des_touches_soient_activées
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Vous devez relancer JabRef pour que les nouvelles affectations des touches soient activées
 
-Your_new_key_bindings_have_been_stored.=Votre_nouvelle_affectation_de_touche_a_été_enregistrée
+Your\ new\ key\ bindings\ have\ been\ stored.=Votre nouvelle affectation de touche a été enregistrée
 
-The_following_fetchers_are_available\:=Les_outils_de_recherche_suivants_sont_disponible_\:
-Could_not_find_fetcher_'%0'=L'outil_de_recherche_'%0'_n'a_pas_pu_être_trouvé
-Running_query_'%0'_with_fetcher_'%1'.=Execution_de_la_requête_'%0'_avec_l'outil_de_recherche_'%1'.
-Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.=Le_requête_'%0'_pour_l'outil_de_recherche_'%1'_n'a_retourné_aucun_résultats.
+The\ following\ fetchers\ are\ available\:=Les outils de recherche suivants sont disponible :
+Could\ not\ find\ fetcher\ '%0'=L'outil de recherche '%0' n'a pas pu être trouvé
+Running\ query\ '%0'\ with\ fetcher\ '%1'.=Execution de la requête '%0' avec l'outil de recherche '%1'.
+Query\ '%0'\ with\ fetcher\ '%1'\ did\ not\ return\ any\ results.=Le requête '%0' pour l'outil de recherche '%1' n'a retourné aucun résultats.
 
-Move_file=Déplacer_fichier
-Rename_file=Renommer_le_fichier
+Move\ file=Déplacer fichier
+Rename\ file=Renommer le fichier
 
-Move_file_failed=Echec_du_déplacement_du_fichier
-Could_not_move_file_'%0'.=Le_fichier_'%0'_n'a_pas_pu_être_déplacé.
-Could_not_find_file_'%0'.=Le_fichier_'%0'_n'a_pas_pu_être_trouvé.
-Number_of_entries_successfully_imported=Nombre_d'entrées_importées_avec_succès
-Import_canceled_by_user=Importation_interrompue_par_l'utilisateur
-Progress\:_%0_of_%1=Progrès_\:_%0_de_%1
-Error_while_fetching_from_%0=Erreur_au_cours_de_la_recherche_%0
+Move\ file\ failed=Echec du déplacement du fichier
+Could\ not\ move\ file\ '%0'.=Le fichier '%0' n'a pas pu être déplacé.
+Could\ not\ find\ file\ '%0'.=Le fichier '%0' n'a pas pu être trouvé.
+Number\ of\ entries\ successfully\ imported=Nombre d'entrées importées avec succès
+Import\ canceled\ by\ user=Importation interrompue par l'utilisateur
+Progress\:\ %0\ of\ %1=Progrès : %0 de %1
+Error\ while\ fetching\ from\ %0=Erreur au cours de la recherche %0
 
-Please_enter_a_valid_number=SVP,_entrez_un_nombre_valide
-Show_search_results_in_a_window=Afficher_les_résultats_de_recherche_dans_une_fenêtre
-Show_global_search_results_in_a_window=Afficher_les_résultats_de_recherche_globale_dans_une_fenêtre
-Search_in_all_open_libraries=Rechercher_sur_tous_les_fichiers_ouverts
-Move_file_to_file_directory?=Déplacer_le_fichier_vers_le_répertoire_de_fichiers_?
+Please\ enter\ a\ valid\ number=SVP, entrez un nombre valide
+Show\ search\ results\ in\ a\ window=Afficher les résultats de recherche dans une fenêtre
+Show\ global\ search\ results\ in\ a\ window=Afficher les résultats de recherche globale dans une fenêtre
+Search\ in\ all\ open\ libraries=Rechercher sur tous les fichiers ouverts
+Move\ file\ to\ file\ directory?=Déplacer le fichier vers le répertoire de fichiers ?
 
-Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.=Le_fichier_est_protégée._L'enregistrement_ne_peut_être_effectué_tant_que_les_changements_externes_n'auront_pas_été_vérifiés.
-Protected_library=Fichier_protégée
-Refuse_to_save_the_library_before_external_changes_have_been_reviewed.=Refuser_d'enregistrer_le_fichier_tant_que_les_changements_externes_ne_sont_pas_vérifiés.
-Library_protection=Protection_du_fichier
-Unable_to_save_library=Impossible_d'enregistrer_le_fichier
+Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=Le fichier est protégée. L'enregistrement ne peut être effectué tant que les changements externes n'auront pas été vérifiés.
+Protected\ library=Fichier protégée
+Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=Refuser d'enregistrer le fichier tant que les changements externes ne sont pas vérifiés.
+Library\ protection=Protection du fichier
+Unable\ to\ save\ library=Impossible d'enregistrer le fichier
 
-BibTeX_key_generator=Générateur_de_clefs_BibTeX
-Unable_to_open_link.=Impossible_d'ouvrir_un_lien.
-Move_the_keyboard_focus_to_the_entry_table=Déplacer_le_curseur_vers_la_table_des_entrées
-MIME_type=Type_MIME
+BibTeX\ key\ generator=Générateur de clefs BibTeX
+Unable\ to\ open\ link.=Impossible d'ouvrir un lien.
+Move\ the\ keyboard\ focus\ to\ the\ entry\ table=Déplacer le curseur vers la table des entrées
+MIME\ type=Type MIME
 
-This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.=Cette_fonction_permet_aux_nouveaux_fichiers_d'être_ouverts_ou_importés_dans_une_fenêtre_JabRef_déjà_active<BR>au_lieu_d'ouvrir_une_nouvelle_fenêtre._Par_exemple,_c'est_utile_quand_vous_ouvrez_un_fichier_dans_JabRef<BR>à_partir_de_notre_navigateur_internet._<BR>Notez_que_cela_vous_empêchera_de_lancer_plus_d'une_fenêtre_JabRef_à_la_fois.
-Run_fetcher,_e.g._"--fetch\=Medline\:cancer"=Lance_une_recherche,_par._ex._"--fetch=Medline\:cancer"
+This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef<BR>instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef<br>from\ your\ web\ browser.<BR>Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=Cette fonction permet aux nouveaux fichiers d'être ouverts ou importés dans une fenêtre JabRef déjà active<BR>au lieu d'ouvrir une nouvelle fenêtre. Par exemple, c'est utile quand vous ouvrez un fichier dans JabRef<BR>à partir de notre navigateur internet. <BR>Notez que cela vous empêchera de lancer plus d'une fenêtre JabRef à la fois.
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=Lance une recherche, par. ex. "--fetch=Medline:cancer"
 
-The_ACM_Digital_Library=La_Bibliothèque_Numérique_ACM
+The\ ACM\ Digital\ Library=La Bibliothèque Numérique ACM
 Reset=Réinitialiser
 
-Use_IEEE_LaTeX_abbreviations=Utiliser_les_abbréviations_LaTeX_IEEE
-The_Guide_to_Computing_Literature=Le_Guide_de_la_Littérature_Informatique
+Use\ IEEE\ LaTeX\ abbreviations=Utiliser les abbréviations LaTeX IEEE
+The\ Guide\ to\ Computing\ Literature=Le Guide de la Littérature Informatique
 
-When_opening_file_link,_search_for_matching_file_if_no_link_is_defined=A_l'ouverture_d'un_lien_de_fichier,_rechercher_un_fichier_correspondant_si_aucun_lien_n'est_défini
-Settings_for_%0=Paramètres_pour_%0
-Mark_entries_imported_into_an_existing_library=Etiqueter_les_entrées_importées_dans_un_fichier_existant
-Unmark_all_entries_before_importing_new_entries_into_an_existing_library=Désétiqueter_toutes_les_entrées_avant_d'importer_de_nouvelles_entrées_dans_un_fichier_existant
+When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=A l'ouverture d'un lien de fichier, rechercher un fichier correspondant si aucun lien n'est défini
+Settings\ for\ %0=Paramètres pour %0
+Mark\ entries\ imported\ into\ an\ existing\ library=Etiqueter les entrées importées dans un fichier existant
+Unmark\ all\ entries\ before\ importing\ new\ entries\ into\ an\ existing\ library=Désétiqueter toutes les entrées avant d'importer de nouvelles entrées dans un fichier existant
 
 Forward=Suivant
 Back=Précédent
-Sort_the_following_fields_as_numeric_fields=Trier_les_champs_suivants_comme_des_champs_numériques
-Line_%0\:_Found_corrupted_BibTeX_key.=Ligne_%0_\:_Clef_BibTeX_corrompue_trouvée.
-Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).=Ligne_%0_\:_Clef_BibTeX_corrompue_trouvée_(contient_des_espaces).
-Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).=Ligne_%0_\:_Clef_BibTeX_corrompue_trouvée_(virgule_manquante).
-Full_text_document_download_failed=Echec_du_téléchargement_du_document_cité
-Update_to_current_column_order=Enregistrer_l'ordre_actuel_des_colonnes
-Download_from_URL=Télécharger_depuis_l'URL
-Rename_field=Renommer_le_champ
-Set/clear/append/rename_fields=Définir/vider/ajouter/renommer_les_champs
-Append_field=Ajouter_au_champ
-Append_to_fields=Ajouter_aux_champs
-Rename_field_to=Renommer_le_champ_en
-Move_contents_of_a_field_into_a_field_with_a_different_name=Déplacer_le_contenu_d'un_champ_vers_un_champ_d'un_nom_différent
-You_can_only_rename_one_field_at_a_time=Vou_pouvez_supprimer_uniquement_un_champ_à_la_fois
+Sort\ the\ following\ fields\ as\ numeric\ fields=Trier les champs suivants comme des champs numériques
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=Ligne %0 : Clef BibTeX corrompue trouvée.
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=Ligne %0 : Clef BibTeX corrompue trouvée (contient des espaces).
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=Ligne %0 : Clef BibTeX corrompue trouvée (virgule manquante).
+Full\ text\ document\ download\ failed=Echec du téléchargement du document cité
+Update\ to\ current\ column\ order=Enregistrer l'ordre actuel des colonnes
+Download\ from\ URL=Télécharger depuis l'URL
+Rename\ field=Renommer le champ
+Set/clear/append/rename\ fields=Définir/vider/ajouter/renommer les champs
+Append\ field=Ajouter au champ
+Append\ to\ fields=Ajouter aux champs
+Rename\ field\ to=Renommer le champ en
+Move\ contents\ of\ a\ field\ into\ a\ field\ with\ a\ different\ name=Déplacer le contenu d'un champ vers un champ d'un nom différent
+You\ can\ only\ rename\ one\ field\ at\ a\ time=Vou pouvez supprimer uniquement un champ à la fois
 
-Remove_all_broken_links=Supprimer_tous_les_liens_invalides
+Remove\ all\ broken\ links=Supprimer tous les liens invalides
 
-Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.=Le_port_%0_ne_peut_pas_être_utilisé_pour_une_opération_à_distance_;_une_autre_application_pourrait_être_en_train_de_l'utiliser._Essayer_de_spécifier_un_autre_port.
+Cannot\ use\ port\ %0\ for\ remote\ operation;\ another\ application\ may\ be\ using\ it.\ Try\ specifying\ another\ port.=Le port %0 ne peut pas être utilisé pour une opération à distance ; une autre application pourrait être en train de l'utiliser. Essayer de spécifier un autre port.
 
-Looking_for_full_text_document...=Téléchargement_du_document_cité
-Autosave=Sauvegarde_automatique
-A_local_copy_will_be_opened.=Une_copie_locale_sera_ouverte.
-Autosave_local_libraries=Sauvegarder_automatiquement_les_fichiers_locaux
-Automatically_save_the_library_to=Sauvegarder_automatiquement_les_fichiers_dans
-Please_enter_a_valid_file_path.=Entrez_un_chemin_de_fichier_valide,_SVP.
+Looking\ for\ full\ text\ document...=Téléchargement du document cité
+Autosave=Sauvegarde automatique
+A\ local\ copy\ will\ be\ opened.=Une copie locale sera ouverte.
+Autosave\ local\ libraries=Sauvegarder automatiquement les fichiers locaux
+Automatically\ save\ the\ library\ to=Sauvegarder automatiquement les fichiers dans
+Please\ enter\ a\ valid\ file\ path.=Entrez un chemin de fichier valide, SVP.
 
 
-Export_in_current_table_sort_order=Exporter_dans_l'ordre_de_tri_actuel_de_la_table
-Export_entries_in_their_original_order=Exporter_les_entrées_dans_leur_ordre_original
-Error_opening_file_'%0'.=Erreur_lors_de_l'ouverture_du_fichier_'%0'.
+Export\ in\ current\ table\ sort\ order=Exporter dans l'ordre de tri actuel de la table
+Export\ entries\ in\ their\ original\ order=Exporter les entrées dans leur ordre original
+Error\ opening\ file\ '%0'.=Erreur lors de l'ouverture du fichier '%0'.
 
-Formatter_not_found\:_%0=Formateur_non_trouvé_\:_%0
-Clear_inputarea=Vider_la_zone_de_saisie
+Formatter\ not\ found\:\ %0=Formateur non trouvé : %0
+Clear\ inputarea=Vider la zone de saisie
 
-Automatically_set_file_links_for_this_entry=Définir_automatiquement_les_liens_de_fichier_pour_cette_entrée
-Could_not_save,_file_locked_by_another_JabRef_instance.=Echec_de_l'enregistrement,_le_fichier_est_verrouillé_par_une_autre_instance_de_JabRef.
-File_is_locked_by_another_JabRef_instance.=Le_fichier_est_verrouillé_par_une_autre_instance_de_JabRef.
-Do_you_want_to_override_the_file_lock?=Voulez-vous_outrepasser_le_verrouillage_du_fichier_?
-File_locked=Fichier_verrouillé
-Current_tmp_value=Valeur_tmp_actuelle
-Metadata_change=Changement_dans_les_métadonnées
-Changes_have_been_made_to_the_following_metadata_elements=Des_modifications_ont_été_faites_aux_éléments_de_métadonnées_suivants
+Automatically\ set\ file\ links\ for\ this\ entry=Définir automatiquement les liens de fichier pour cette entrée
+Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=Echec de l'enregistrement, le fichier est verrouillé par une autre instance de JabRef.
+File\ is\ locked\ by\ another\ JabRef\ instance.=Le fichier est verrouillé par une autre instance de JabRef.
+Do\ you\ want\ to\ override\ the\ file\ lock?=Voulez-vous outrepasser le verrouillage du fichier ?
+File\ locked=Fichier verrouillé
+Current\ tmp\ value=Valeur tmp actuelle
+Metadata\ change=Changement dans les métadonnées
+Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=Des modifications ont été faites aux éléments de métadonnées suivants
 
-Generate_groups_for_author_last_names=Création_de_groupes_pour_les_noms_d'auteurs
-Generate_groups_from_keywords_in_a_BibTeX_field=Création_de_groupes_à_partir_de_mots-clefs_d'un_champ_BibTeX
-Enforce_legal_characters_in_BibTeX_keys=Imposer_des_caractères_légaux_dans_les_clefs_BibTeX
+Generate\ groups\ for\ author\ last\ names=Création de groupes pour les noms d'auteurs
+Generate\ groups\ from\ keywords\ in\ a\ BibTeX\ field=Création de groupes à partir de mots-clefs d'un champ BibTeX
+Enforce\ legal\ characters\ in\ BibTeX\ keys=Imposer des caractères légaux dans les clefs BibTeX
 
-Save_without_backup?=Enregistrer_sans_sauvegarde_de_secours?
-Unable_to_create_backup=Impossible_de_créer_une_sauvegarde_de_secours
-Move_file_to_file_directory=Déplacer_le_fichier_vers_le_répertoire_de_fichiers
-Rename_file_to=Renommer_le_fichier_en
-<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)=<b>Toutes_les_entrées</b>_(ce_groupe_ne_peut_pas_être_édité_ou_supprimé)
-static_group=groupe_statique
-dynamic_group=groupe_dynamique
-refines_supergroup=raffinant_le_super-groupe
-includes_subgroups=incluant_les_sous-groupes
+Save\ without\ backup?=Enregistrer sans sauvegarde de secours?
+Unable\ to\ create\ backup=Impossible de créer une sauvegarde de secours
+Move\ file\ to\ file\ directory=Déplacer le fichier vers le répertoire de fichiers
+Rename\ file\ to=Renommer le fichier en
+<b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=<b>Toutes les entrées</b> (ce groupe ne peut pas être édité ou supprimé)
+static\ group=groupe statique
+dynamic\ group=groupe dynamique
+refines\ supergroup=raffinant le super-groupe
+includes\ subgroups=incluant les sous-groupes
 contains=contient
-search_expression=expression_de_recherche
+search\ expression=expression de recherche
 
-Optional_fields_2=Champs_optionnels_2
-Waiting_for_save_operation_to_finish=Attente_de_la_fin_de_l'opération_de_sauvegarde
-Resolving_duplicate_BibTeX_keys...=Traitement_des_clefs_BibTeX_dupliquées...
-Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.=Traitement_des_clefs_BibTeX_dupliquées_terminé._%0_entrées_modifiées.
-This_library_contains_one_or_more_duplicated_BibTeX_keys.=Ce_fichier_contient_au_moins_une_clef_BibTeX_dupliquée.
-Do_you_want_to_resolve_duplicate_keys_now?=Voulez-vous_traiter_les_clefs_dupliquées_maintenant_?
+Optional\ fields\ 2=Champs optionnels 2
+Waiting\ for\ save\ operation\ to\ finish=Attente de la fin de l'opération de sauvegarde
+Resolving\ duplicate\ BibTeX\ keys...=Traitement des clefs BibTeX dupliquées...
+Finished\ resolving\ duplicate\ BibTeX\ keys.\ %0\ entries\ modified.=Traitement des clefs BibTeX dupliquées terminé. %0 entrées modifiées.
+This\ library\ contains\ one\ or\ more\ duplicated\ BibTeX\ keys.=Ce fichier contient au moins une clef BibTeX dupliquée.
+Do\ you\ want\ to\ resolve\ duplicate\ keys\ now?=Voulez-vous traiter les clefs dupliquées maintenant ?
 
-Find_and_remove_duplicate_BibTeX_keys=Recherche_et_supprime_les_clefs_BibTeX_dupliquées
-Expected_syntax_for_--fetch\='<name_of_fetcher>\:<query>'=Syntaxe_attendue_pour_--fetch='<name_of_fetcher>\:<query>'
-Duplicate_BibTeX_key=Clef_BibTeX_dupliquée
-Import_marking_color=Importer_les_couleurs_de_marquage
-Always_add_letter_(a,_b,_...)_to_generated_keys=Toujours_ajouter_une_lettre_(a,_b,_...)_aux_clefs_générées
+Find\ and\ remove\ duplicate\ BibTeX\ keys=Recherche et supprime les clefs BibTeX dupliquées
+Expected\ syntax\ for\ --fetch\='<name\ of\ fetcher>\:<query>'=Syntaxe attendue pour --fetch='<name of fetcher>:<query>'
+Duplicate\ BibTeX\ key=Clef BibTeX dupliquée
+Import\ marking\ color=Importer les couleurs de marquage
+Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=Toujours ajouter une lettre (a, b, ...) aux clefs générées
 
-Ensure_unique_keys_using_letters_(a,_b,_...)=Assurer_l'unicité_des_clefs_(a,_b,_...)
-Ensure_unique_keys_using_letters_(b,_c,_...)=Assurer_l'unicité_des_clefs_(b,_c,_...)
-Entry_editor_active_background_color=Couleur_du_fond_actif_de_l'éditeur_d'entrées
-Entry_editor_background_color=Couleur_du_fond_de_l'éditeur_d'entrées
-Entry_editor_font_color=Couleur_de_la_police_de_l'éditeur_d'entrées
-Entry_editor_invalid_field_color=Couleur_de_champ_invalide_de_l'éditeur_d'entrées
+Ensure\ unique\ keys\ using\ letters\ (a,\ b,\ ...)=Assurer l'unicité des clefs (a, b, ...)
+Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=Assurer l'unicité des clefs (b, c, ...)
+Entry\ editor\ active\ background\ color=Couleur du fond actif de l'éditeur d'entrées
+Entry\ editor\ background\ color=Couleur du fond de l'éditeur d'entrées
+Entry\ editor\ font\ color=Couleur de la police de l'éditeur d'entrées
+Entry\ editor\ invalid\ field\ color=Couleur de champ invalide de l'éditeur d'entrées
 
-Table_and_entry_editor_colors=Couleurs_de_la_table_et_de_l'éditeur_d'entrées
+Table\ and\ entry\ editor\ colors=Couleurs de la table et de l'éditeur d'entrées
 
-General_file_directory=Répertoire_général
-User-specific_file_directory=Répertoire_spécifique_à_l'utilisateur
-Search_failed\:_illegal_search_expression=Echec_de_la_recherche_\:_Expression_de_recherche_illégale
-Show_ArXiv_column=Montrer_la_colonne_ArXiv
+General\ file\ directory=Répertoire général
+User-specific\ file\ directory=Répertoire spécifique à l'utilisateur
+Search\ failed\:\ illegal\ search\ expression=Echec de la recherche : Expression de recherche illégale
+Show\ ArXiv\ column=Montrer la colonne ArXiv
 
-You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for=Vous_devez_entrer_dans_le_champ_texte_une_valeur_entière_comprise_entre_1025_et_65535_pour
-Automatically_open_browse_dialog_when_creating_new_file_link=Ouvrir_automatiquement_la_fenêtre_de_navigation_lors_de_la_création_d'un_nouveau_lien_de_fichier
-Import_metadata_from\:=Importer_les_métadonnées_depuis_\:
-Choose_the_source_for_the_metadata_import=Choisir_la_source_pour_l'importation_des_métadonnées
-Create_entry_based_on_XMP-metadata=Créer_une_entrée_basée_sur_les_données_XMP
-Create_blank_entry_linking_the_PDF=Créer_une_entrée_vide_liée_au_PDF
-Only_attach_PDF=Lier_uniquement_le_PDF
+You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=Vous devez entrer dans le champ texte une valeur entière comprise entre 1025 et 65535 pour
+Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Ouvrir automatiquement la fenêtre de navigation lors de la création d'un nouveau lien de fichier
+Import\ metadata\ from\:=Importer les métadonnées depuis :
+Choose\ the\ source\ for\ the\ metadata\ import=Choisir la source pour l'importation des métadonnées
+Create\ entry\ based\ on\ XMP-metadata=Créer une entrée basée sur les données XMP
+Create\ blank\ entry\ linking\ the\ PDF=Créer une entrée vide liée au PDF
+Only\ attach\ PDF=Lier uniquement le PDF
 Title=Titre
-Create_new_entry=Créer_une_nouvelle_entrée
-Update_existing_entry=Mettre_à_jour_une_entrée_existante
-Autocomplete_names_in_'Firstname_Lastname'_format_only=Complétion_automatique_des_noms_uniquement_dans_le_format_'Prénom_Nom'
-Autocomplete_names_in_'Lastname,_Firstname'_format_only=Complétion_automatique_des_noms_uniquement_dans_le_format_'Nom,_Prénom'
-Autocomplete_names_in_both_formats=Complétion_automatique_des_noms_dans_les_2_formats
-Marking_color_%0=Marquage_de_la_couleur_%0
-The_name_'comment'_cannot_be_used_as_an_entry_type_name.=Le_nom_'comment'_ne_peut_pas_être_utilisé_comme_nom_de_type_d'entrée.
-You_must_enter_an_integer_value_in_the_text_field_for=Vous_devez_entrer_une_valeur_entière_dans_le_champ_texte_pour
-Send_as_email=Expédier_par_courriel
+Create\ new\ entry=Créer une nouvelle entrée
+Update\ existing\ entry=Mettre à jour une entrée existante
+Autocomplete\ names\ in\ 'Firstname\ Lastname'\ format\ only=Complétion automatique des noms uniquement dans le format 'Prénom Nom'
+Autocomplete\ names\ in\ 'Lastname,\ Firstname'\ format\ only=Complétion automatique des noms uniquement dans le format 'Nom, Prénom'
+Autocomplete\ names\ in\ both\ formats=Complétion automatique des noms dans les 2 formats
+Marking\ color\ %0=Marquage de la couleur %0
+The\ name\ 'comment'\ cannot\ be\ used\ as\ an\ entry\ type\ name.=Le nom 'comment' ne peut pas être utilisé comme nom de type d'entrée.
+You\ must\ enter\ an\ integer\ value\ in\ the\ text\ field\ for=Vous devez entrer une valeur entière dans le champ texte pour
+Send\ as\ email=Expédier par courriel
 References=Références
-Sending_of_emails=Envoi_des_courriels
-Subject_for_sending_an_email_with_references=Sujet_pour_l'envoi_d'un_courriel_avec_des_références
-Automatically_open_folders_of_attached_files=Ouvrir_automatiquement_les_répertoires_des_fichiers_attachés
-Create_entry_based_on_content=Créer_une_entrée_sur_la_base_du_contenu
-Do_not_show_this_box_again_for_this_import=Ne_plus_afficher_cette_boîte_de_dialogue_pour_cette_importation
-Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)=Toujours_utiliser_ce_style_d'importation_PDF_(et_ne_plus_demander_à_chaque_importation)
-Error_creating_email=Erreur_lors_de_la_création_du_courriel
-Entries_added_to_an_email=Entrées_ajoutées_à_un_courriel
-exportFormat=Format_d'exportation
-Output_file_missing=Fichier_de_sortie_manquant
-No_search_matches.=Recherche_sans_correspondance.
-The_output_option_depends_on_a_valid_input_option.=L'option_de_sortie_dépend_d'une_option_d'entrée_valide.
-Default_import_style_for_drag_and_drop_of_PDFs=Style_d'importation_par_défaut_pour_le_glisser-déplacer_des_PDFs
-Default_PDF_file_link_action=Action_par_défaut_pour_les_liens_vers_les_fichiers_PDF
-Filename_format_pattern=Modèle_de_format_de_nom_de_fichier
-Additional_parameters=Paramètres_additionnels
-Cite_selected_entries_between_parenthesis=Citer_les_entrées_sélectionnées_entre_parenthèses
-Cite_selected_entries_with_in-text_citation=Citer_les_entrées_sélectionnées_comme_incluse_dans_le_texte
-Cite_special=Citer_(cas_particuliers)
-Extra_information_(e.g._page_number)=Informations_complémentaires_(ex_\:_numéro_de_page)
-Manage_citations=Gérer_les_citations
-Problem_modifying_citation=Problème_lors_de_la_modification_de_la_citation
+Sending\ of\ emails=Envoi des courriels
+Subject\ for\ sending\ an\ email\ with\ references=Sujet pour l'envoi d'un courriel avec des références
+Automatically\ open\ folders\ of\ attached\ files=Ouvrir automatiquement les répertoires des fichiers attachés
+Create\ entry\ based\ on\ content=Créer une entrée sur la base du contenu
+Do\ not\ show\ this\ box\ again\ for\ this\ import=Ne plus afficher cette boîte de dialogue pour cette importation
+Always\ use\ this\ PDF\ import\ style\ (and\ do\ not\ ask\ for\ each\ import)=Toujours utiliser ce style d'importation PDF (et ne plus demander à chaque importation)
+Error\ creating\ email=Erreur lors de la création du courriel
+Entries\ added\ to\ an\ email=Entrées ajoutées à un courriel
+exportFormat=Format d'exportation
+Output\ file\ missing=Fichier de sortie manquant
+No\ search\ matches.=Recherche sans correspondance.
+The\ output\ option\ depends\ on\ a\ valid\ input\ option.=L'option de sortie dépend d'une option d'entrée valide.
+Default\ import\ style\ for\ drag\ and\ drop\ of\ PDFs=Style d'importation par défaut pour le glisser-déplacer des PDFs
+Default\ PDF\ file\ link\ action=Action par défaut pour les liens vers les fichiers PDF
+Filename\ format\ pattern=Modèle de format de nom de fichier
+Additional\ parameters=Paramètres additionnels
+Cite\ selected\ entries\ between\ parenthesis=Citer les entrées sélectionnées entre parenthèses
+Cite\ selected\ entries\ with\ in-text\ citation=Citer les entrées sélectionnées comme incluse dans le texte
+Cite\ special=Citer (cas particuliers)
+Extra\ information\ (e.g.\ page\ number)=Informations complémentaires (ex : numéro de page)
+Manage\ citations=Gérer les citations
+Problem\ modifying\ citation=Problème lors de la modification de la citation
 Citation=Citation
-Extra_information=Informations_complémentaires
-Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.=L'entrée_BibTeX_pour_le_marqueur_de_citation_'%0'_n'a_pas_pu_être_traitée.
-Select_style=Sélectionner_le_style
+Extra\ information=Informations complémentaires
+Could\ not\ resolve\ BibTeX\ entry\ for\ citation\ marker\ '%0'.=L'entrée BibTeX pour le marqueur de citation '%0' n'a pas pu être traitée.
+Select\ style=Sélectionner le style
 Journals=Journaux
-Cite=Citer_entre_parenthèses
-Cite_in-text=Citer_directement_dans_le_texte
-Insert_empty_citation=Insérer_des_citations_vides
-Merge_citations=Fusionner_des_citations
-Manual_connect=Connexion_manuelle
-Select_Writer_document=Sélectionner_le_document_Writer
-Sync_OpenOffice/LibreOffice_bibliography=Synchroniser_la_bibliographie_OpenOffice/LibreOffice
-Select_which_open_Writer_document_to_work_on=Sélectionner_le_document_Writer_ouvert_sur_lequel_travailler
-Connected_to_document=Connecté_au_document
-Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)=Insérer_une_citation_sans_texte_(l'entrée_apparaitra_dans_la_liste_des_références)
-Cite_selected_entries_with_extra_information=Citer_les_entrées_sélectionnées_avec_des_informations_complémentaires
-Ensure_that_the_bibliography_is_up-to-date=Assure_que_la_bibliographie_est_à_jour.
-Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.=Votre_document_OpenOffice/LibreOffice_appelle_la_clef_BibTeX_'%0',_qui_n'a_pas_pu_être_trouvée_dans_votre_fichier_actuel.
-Unable_to_synchronize_bibliography=Impossible_de_synchroniser_la_bibliographie
-Combine_pairs_of_citations_that_are_separated_by_spaces_only=Combiner_les_paires_de_citations_qui_ne_sont_séparées_que_par_des_espaces
-Autodetection_failed=La_détection_automatique_a_échouée
-Connecting=Connexion_en_cours
-Please_wait...=Patientez_s'il_vous_plait...
-Set_connection_parameters=Définir_les_paramètres_de_connexion
-Path_to_OpenOffice/LibreOffice_directory=Chemin_vers_le_répertoire_d'OpenOffice/LibreOffice
-Path_to_OpenOffice/LibreOffice_executable=Chemin_vers_l'exécutable_d'OpenOffice/LibreOffice
-Path_to_OpenOffice/LibreOffice_library_dir=Chemin_vers_le_répertoire_bibliothèque_d'OpenOffice/LibreOffice
-Connection_lost=Connexion_perdue
-The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.=Le_format_de_paragraphe_est_controlé_par_le_propriété_'ReferenceParagraphFormat'_ou_'ReferenceHeaderParagraphFormat'_du_fichier_de_style.
-The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.=Le_format_de_caractères_est_controlé_par_la_propriété_de_citation_'CitationCharacterFormat'_du_fichier_de_style.
-Automatically_sync_bibliography_when_inserting_citations=Synchroniser_automatiquement_la_bibliographie_lors_de_l'insertion_de_citations
-Look_up_BibTeX_entries_in_the_active_tab_only=Rechercher_les_entrées_BibTeX_uniquement_dans_l'onglet_actif
-Look_up_BibTeX_entries_in_all_open_libraries=Rechercher_les_entrées_BibTeX_dans_tous_les_fichiers_ouverts
-Autodetecting_paths...=Autodétection_des_chemins...
-Could_not_find_OpenOffice/LibreOffice_installation=L'installation_d'OpenOffice/LibreOffice_n'a_pas_pu_être_trouvée
-Found_more_than_one_OpenOffice/LibreOffice_executable.=Plus_d'un_exécutable_OpenOffice/LibreOffice_a_été_trouvé.
-Please_choose_which_one_to_connect_to\:=SVP,_choisissez_celui_auquel_il_faut_se_connecter_\:
-Choose_OpenOffice/LibreOffice_executable=Choisissez_l'exécutable_OpenOffice/LibreOffice
-Select_document=Sélectionner_un_document
-HTML_list=Liste_HTML
-If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting=Si_possible,_normaliser_cette_liste_de_noms_afin_de_correspondre_au_formatage_des_noms_au_standard_BibTeX
-Could_not_open_%0=%0_n'a_pas_pu_être_ouvert
-Unknown_import_format=Format_d'importation_inconnu
-Web_search=Recherche_web
-Style_selection=Sélection_du_style
-No_valid_style_file_defined=Aucun_style_de_fichier_valide_n'est_défini
-Choose_pattern=Choisissez_un_modèle
-Use_the_BIB_file_location_as_primary_file_directory=Utiliser_le_répertoire_du_fichier_BIB_comme_répertoire_principal_de_fichiers
-Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.=Le_programme_gnuclient/emacsclient_n'a_pas_pu_être_lancé._Assurez-vous_que_les_programmes_gnuclient/emacsclient_sont_installés_et_disponible_dans_le_PATH.
-OpenOffice/LibreOffice_connection=Connexion_OpenOffice/LibreOffice
-You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.=Vous_devez_sélectionner_soit_un_style_de_fichier_valide,_soit_utiliser_un_des_styles_par_défaut.
+Cite=Citer entre parenthèses
+Cite\ in-text=Citer directement dans le texte
+Insert\ empty\ citation=Insérer des citations vides
+Merge\ citations=Fusionner des citations
+Manual\ connect=Connexion manuelle
+Select\ Writer\ document=Sélectionner le document Writer
+Sync\ OpenOffice/LibreOffice\ bibliography=Synchroniser la bibliographie OpenOffice/LibreOffice
+Select\ which\ open\ Writer\ document\ to\ work\ on=Sélectionner le document Writer ouvert sur lequel travailler
+Connected\ to\ document=Connecté au document
+Insert\ a\ citation\ without\ text\ (the\ entry\ will\ appear\ in\ the\ reference\ list)=Insérer une citation sans texte (l'entrée apparaitra dans la liste des références)
+Cite\ selected\ entries\ with\ extra\ information=Citer les entrées sélectionnées avec des informations complémentaires
+Ensure\ that\ the\ bibliography\ is\ up-to-date=Assure que la bibliographie est à jour.
+Your\ OpenOffice/LibreOffice\ document\ references\ the\ BibTeX\ key\ '%0',\ which\ could\ not\ be\ found\ in\ your\ current\ library.=Votre document OpenOffice/LibreOffice appelle la clef BibTeX '%0', qui n'a pas pu être trouvée dans votre fichier actuel.
+Unable\ to\ synchronize\ bibliography=Impossible de synchroniser la bibliographie
+Combine\ pairs\ of\ citations\ that\ are\ separated\ by\ spaces\ only=Combiner les paires de citations qui ne sont séparées que par des espaces
+Autodetection\ failed=La détection automatique a échouée
+Connecting=Connexion en cours
+Please\ wait...=Patientez s'il vous plait...
+Set\ connection\ parameters=Définir les paramètres de connexion
+Path\ to\ OpenOffice/LibreOffice\ directory=Chemin vers le répertoire d'OpenOffice/LibreOffice
+Path\ to\ OpenOffice/LibreOffice\ executable=Chemin vers l'exécutable d'OpenOffice/LibreOffice
+Path\ to\ OpenOffice/LibreOffice\ library\ dir=Chemin vers le répertoire bibliothèque d'OpenOffice/LibreOffice
+Connection\ lost=Connexion perdue
+The\ paragraph\ format\ is\ controlled\ by\ the\ property\ 'ReferenceParagraphFormat'\ or\ 'ReferenceHeaderParagraphFormat'\ in\ the\ style\ file.=Le format de paragraphe est controlé par le propriété 'ReferenceParagraphFormat' ou 'ReferenceHeaderParagraphFormat' du fichier de style.
+The\ character\ format\ is\ controlled\ by\ the\ citation\ property\ 'CitationCharacterFormat'\ in\ the\ style\ file.=Le format de caractères est controlé par la propriété de citation 'CitationCharacterFormat' du fichier de style.
+Automatically\ sync\ bibliography\ when\ inserting\ citations=Synchroniser automatiquement la bibliographie lors de l'insertion de citations
+Look\ up\ BibTeX\ entries\ in\ the\ active\ tab\ only=Rechercher les entrées BibTeX uniquement dans l'onglet actif
+Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=Rechercher les entrées BibTeX dans tous les fichiers ouverts
+Autodetecting\ paths...=Autodétection des chemins...
+Could\ not\ find\ OpenOffice/LibreOffice\ installation=L'installation d'OpenOffice/LibreOffice n'a pas pu être trouvée
+Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=Plus d'un exécutable OpenOffice/LibreOffice a été trouvé.
+Please\ choose\ which\ one\ to\ connect\ to\:=SVP, choisissez celui auquel il faut se connecter :
+Choose\ OpenOffice/LibreOffice\ executable=Choisissez l'exécutable OpenOffice/LibreOffice
+Select\ document=Sélectionner un document
+HTML\ list=Liste HTML
+If\ possible,\ normalize\ this\ list\ of\ names\ to\ conform\ to\ standard\ BibTeX\ name\ formatting=Si possible, normaliser cette liste de noms afin de correspondre au formatage des noms au standard BibTeX
+Could\ not\ open\ %0=%0 n'a pas pu être ouvert
+Unknown\ import\ format=Format d'importation inconnu
+Web\ search=Recherche web
+Style\ selection=Sélection du style
+No\ valid\ style\ file\ defined=Aucun style de fichier valide n'est défini
+Choose\ pattern=Choisissez un modèle
+Use\ the\ BIB\ file\ location\ as\ primary\ file\ directory=Utiliser le répertoire du fichier BIB comme répertoire principal de fichiers
+Could\ not\ run\ the\ gnuclient/emacsclient\ program.\ Make\ sure\ you\ have\ the\ emacsclient/gnuclient\ program\ installed\ and\ available\ in\ the\ PATH.=Le programme gnuclient/emacsclient n'a pas pu être lancé. Assurez-vous que les programmes gnuclient/emacsclient sont installés et disponible dans le PATH.
+OpenOffice/LibreOffice\ connection=Connexion OpenOffice/LibreOffice
+You\ must\ select\ either\ a\ valid\ style\ file,\ or\ use\ one\ of\ the\ default\ styles.=Vous devez sélectionner soit un style de fichier valide, soit utiliser un des styles par défaut.
 
-This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.=Ceci_est_simplement_une_fen&ecirc;tre_de_copier-coller._Commencez_par_charger_ou_coller_du_texte_dans_la_zone_de_saisie_de_texte.<br>Ensuite,_vous_pouvez_s&eacute;lectionner_des_portions_de_texte_et_les_attribuer_&agrave;_des_champs_BibTeX.
-This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.=Cette_fonction_génère_un_nouveau_fichier_basé_sur_les_entrées_requises_par_un_document_LaTeX_existant.
-You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.=Vous_devez_sélectionnner_un_de_vos_fichiers_ouverts_à_partir_duquel_choisir_vos_entreées,_ainsi_que_le_fichier_AUX_produit_par_LaTeX_lors_de_la_compilation_du_document.
+This\ is\ a\ simple\ copy\ and\ paste\ dialog.\ First\ load\ or\ paste\ some\ text\ into\ the\ text\ input\ area.<br>After\ that,\ you\ can\ mark\ text\ and\ assign\ it\ to\ a\ BibTeX\ field.=Ceci est simplement une fen&ecirc;tre de copier-coller. Commencez par charger ou coller du texte dans la zone de saisie de texte.<br>Ensuite, vous pouvez s&eacute;lectionner des portions de texte et les attribuer &agrave; des champs BibTeX.
+This\ feature\ generates\ a\ new\ library\ based\ on\ which\ entries\ are\ needed\ in\ an\ existing\ LaTeX\ document.=Cette fonction génère un nouveau fichier basé sur les entrées requises par un document LaTeX existant.
+You\ need\ to\ select\ one\ of\ your\ open\ libraries\ from\ which\ to\ choose\ entries,\ as\ well\ as\ the\ AUX\ file\ produced\ by\ LaTeX\ when\ compiling\ your\ document.=Vous devez sélectionnner un de vos fichiers ouverts à partir duquel choisir vos entreées, ainsi que le fichier AUX produit par LaTeX lors de la compilation du document.
 
-First_select_entries_to_clean_up.=Commencez_par_sélectionner_les_entrées_à_nettoyer
-Cleanup_entry=Nettoyage_des_entrées
-Autogenerate_PDF_Names=Génération_automatique_des_noms_des_PDF
-Auto-generating_PDF-Names_does_not_support_undo._Continue?=La_génération_automatique_des_noms_des_PDF_ne_peut_pas_être_annulée._Continuer?
+First\ select\ entries\ to\ clean\ up.=Commencez par sélectionner les entrées à nettoyer
+Cleanup\ entry=Nettoyage des entrées
+Autogenerate\ PDF\ Names=Génération automatique des noms des PDF
+Auto-generating\ PDF-Names\ does\ not\ support\ undo.\ Continue?=La génération automatique des noms des PDF ne peut pas être annulée. Continuer?
 
-Use_full_firstname_whenever_possible=Utiliser_le_prénom_en_entier_quand_c'est_possible
-Use_abbreviated_firstname_whenever_possible=Utiliser_le_prénom_abrégé_quand_c'est_possible
-Use_abbreviated_and_full_firstname=Utiliser_le_prénom_abrégé_et_entier
-Autocompletion_options=Options_de_la_complétion_automatique
-Name_format_used_for_autocompletion=Format_de_nom_utilisé_pour_la_complétion_automatique
-Treatment_of_first_names=Traitement_des_prénoms
-Cleanup_entries=Nettoyage_des_entrées
-Automatically_assign_new_entry_to_selected_groups=Assigner_automatiquement_les_nouvelles_entrées_aux_groupes_sélectionnés
-%0_mode=Mode_%0
-Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix=Déplacer_les_DOIs_des_champs_note_et_URL_vers_le_champ_DOI,_et_supprimer_le_prefix_http
-Make_paths_of_linked_files_relative_(if_possible)=Rendre_relatifs_les_chemins_des_fichiers_liés_(si_possible)
-Rename_PDFs_to_given_filename_format_pattern=Renommer_les_PDF_selon_le_modèle_donné_de_format_de_nom_de_fichier
-Rename_only_PDFs_having_a_relative_path=Renommer_uniquement_les_PDF_ayant_un_chemin_relatif
-What_would_you_like_to_clean_up?=Voulez-vous_lancer_le_nettoyage_?
-Doing_a_cleanup_for_%0_entries...=Nettoyage_en_cours_pour_%0_entrées...
-No_entry_needed_a_clean_up=Aucune_entrée_ne_nécessitait_un_nettoyage
-One_entry_needed_a_clean_up=Une_entrée_nécessitait_un_nettoyage
-%0_entries_needed_a_clean_up=%0_entrées_nécessitaient_un_nettoyage
+Use\ full\ firstname\ whenever\ possible=Utiliser le prénom en entier quand c'est possible
+Use\ abbreviated\ firstname\ whenever\ possible=Utiliser le prénom abrégé quand c'est possible
+Use\ abbreviated\ and\ full\ firstname=Utiliser le prénom abrégé et entier
+Autocompletion\ options=Options de la complétion automatique
+Name\ format\ used\ for\ autocompletion=Format de nom utilisé pour la complétion automatique
+Treatment\ of\ first\ names=Traitement des prénoms
+Cleanup\ entries=Nettoyage des entrées
+Automatically\ assign\ new\ entry\ to\ selected\ groups=Assigner automatiquement les nouvelles entrées aux groupes sélectionnés
+%0\ mode=Mode %0
+Move\ DOIs\ from\ note\ and\ URL\ field\ to\ DOI\ field\ and\ remove\ http\ prefix=Déplacer les DOIs des champs note et URL vers le champ DOI, et supprimer le prefix http
+Make\ paths\ of\ linked\ files\ relative\ (if\ possible)=Rendre relatifs les chemins des fichiers liés (si possible)
+Rename\ PDFs\ to\ given\ filename\ format\ pattern=Renommer les PDF selon le modèle donné de format de nom de fichier
+Rename\ only\ PDFs\ having\ a\ relative\ path=Renommer uniquement les PDF ayant un chemin relatif
+What\ would\ you\ like\ to\ clean\ up?=Voulez-vous lancer le nettoyage ?
+Doing\ a\ cleanup\ for\ %0\ entries...=Nettoyage en cours pour %0 entrées...
+No\ entry\ needed\ a\ clean\ up=Aucune entrée ne nécessitait un nettoyage
+One\ entry\ needed\ a\ clean\ up=Une entrée nécessitait un nettoyage
+%0\ entries\ needed\ a\ clean\ up=%0 entrées nécessitaient un nettoyage
 
-Remove_selected=Supprimer_la_sélection
+Remove\ selected=Supprimer la sélection
 
-Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.=L'arbre_des_groupes_n'a_pu_être_analysé._Si_vous_sauvez_le_fichier_BibTeX,_tous_les_groupes_seront_perdus.
-Attach_file=Attacher_un_fichier
-Setting_all_preferences_to_default_values.=Initialiser_la_configuration_aux_valeurs_par_défaut.
-Resetting_preference_key_'%0'=Réinitialiser_la_clef_de_configuration_'%0'
-Unknown_preference_key_'%0'=Clef_de_configuration_'%0'_inconnue
-Unable_to_clear_preferences.=Impossible_d'initialiser_la_configuration.
+Group\ tree\ could\ not\ be\ parsed.\ If\ you\ save\ the\ BibTeX\ library,\ all\ groups\ will\ be\ lost.=L'arbre des groupes n'a pu être analysé. Si vous sauvez le fichier BibTeX, tous les groupes seront perdus.
+Attach\ file=Attacher un fichier
+Setting\ all\ preferences\ to\ default\ values.=Initialiser la configuration aux valeurs par défaut.
+Resetting\ preference\ key\ '%0'=Réinitialiser la clef de configuration '%0'
+Unknown\ preference\ key\ '%0'=Clef de configuration '%0' inconnue
+Unable\ to\ clear\ preferences.=Impossible d'initialiser la configuration.
 
-Reset_preferences_(key1,key2,..._or_'all')=Réinitialiser_la_configuration_(clef1,_clef2,..._ou_'toutes')
-Find_unlinked_files=Trouver_les_fichiers_non_liés
-Unselect_all=Tout_désélectionner
-Expand_all=Tout_étendre
-Collapse_all=Tout_masquer
-Opens_the_file_browser.=Ouvre_l'explorateur_de_fichier.
-Scan_directory=Examiner_le_répertoire
-Searches_the_selected_directory_for_unlinked_files.=Rechercher_les_fichiers_non_liés_dans_le_répertoire_sélectionné
-Starts_the_import_of_BibTeX_entries.=Débuter_l'importation_des_entrées_BibTeX
-Leave_this_dialog.=Quitter_cette_fenêtre_de_dialogue.
-Create_directory_based_keywords=Créer_les_mots-clefs_selon_le_répertoire
-Creates_keywords_in_created_entrys_with_directory_pathnames=Ajoute_des_mot-clefs_dans_les_répertoires_selon_les_chemins_de_répertoire
-Select_a_directory_where_the_search_shall_start.=Sélectionner_un_répertoire_où_débutera_la_recherche
-Select_file_type\:=Sélectionner_le_type_de_fichier_\:
-These_files_are_not_linked_in_the_active_library.=Ces_fichiers_ne_sont_pas_liés_dans_le_fichier_actif.
-Entry_type_to_be_created\:=Type_d'entrée_à_créer_\:
-Searching_file_system...=Recherche_dans_le_système_de_fichiers...
-Importing_into_Library...=Importation_dans_un_fichier...
-Select_directory=Sélectionner_un_répertoire
-Select_files=Sélectionner_des_fichiers
-BibTeX_entry_creation=Création_d'un_entrée_BibTeX
-<No_selection>=<Pas_de_sélection>
-Unable_to_connect_to_FreeCite_online_service.=Impossible_de_se_connecter_au_service_en_ligne_FreeCite
-Parse_with_FreeCite=Analyse_avec_FreeCite
-The_current_BibTeX_key_will_be_overwritten._Continue?=La_clef_BibTeX_courante_sera_écrasée._Continuer_?
-Overwrite_key=Ecraser_la_clef
-Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator=Pas_d'écrasement_de_clefs_existantes._Pour_changer_ce_paramétrage,_ouvrir_Options_->_Préférences_->_Générateur_de_clefs_BibTeX
-How_would_you_like_to_link_to_'%0'?=Quel_type_de_lien_souhaitez-vous_vers_'%0'_?
-BibTeX_key_patterns=Modèles_de_clef_BibTeX
-Changed_special_field_settings=Paramètres_de_champs_spéciaux_modifiés
-Clear_priority=Effacer_la_priorité
-Clear_rank=Effacer_le_rang
-Enable_special_fields=Autoriser_les_champs_spéciaux
-One_star=Une_étoile
-Two_stars=Deux_étoiles
-Three_stars=Trois_étoiles
-Four_stars=Quatre_étoiles
-Five_stars=Cinq_étoiles
-Help_on_special_fields=Aide_sur_les_champs_spéciaux
-Keywords_of_selected_entries=Mots-clefs_des_entrées_sélectionnés
-Manage_content_selectors=Gérer_les_sélecteurs_de_contenu
-Manage_keywords=Gérer_les_mots-clefs
-No_priority_information=Pas_d'information_sur_la_priorité
-No_rank_information=Pas_d'information_sur_le_rang
+Reset\ preferences\ (key1,key2,...\ or\ 'all')=Réinitialiser la configuration (clef1, clef2,... ou 'toutes')
+Find\ unlinked\ files=Trouver les fichiers non liés
+Unselect\ all=Tout désélectionner
+Expand\ all=Tout étendre
+Collapse\ all=Tout masquer
+Opens\ the\ file\ browser.=Ouvre l'explorateur de fichier.
+Scan\ directory=Examiner le répertoire
+Searches\ the\ selected\ directory\ for\ unlinked\ files.=Rechercher les fichiers non liés dans le répertoire sélectionné
+Starts\ the\ import\ of\ BibTeX\ entries.=Débuter l'importation des entrées BibTeX
+Leave\ this\ dialog.=Quitter cette fenêtre de dialogue.
+Create\ directory\ based\ keywords=Créer les mots-clefs selon le répertoire
+Creates\ keywords\ in\ created\ entrys\ with\ directory\ pathnames=Ajoute des mot-clefs dans les répertoires selon les chemins de répertoire
+Select\ a\ directory\ where\ the\ search\ shall\ start.=Sélectionner un répertoire où débutera la recherche
+Select\ file\ type\:=Sélectionner le type de fichier :
+These\ files\ are\ not\ linked\ in\ the\ active\ library.=Ces fichiers ne sont pas liés dans le fichier actif.
+Entry\ type\ to\ be\ created\:=Type d'entrée à créer :
+Searching\ file\ system...=Recherche dans le système de fichiers...
+Importing\ into\ Library...=Importation dans un fichier...
+Select\ directory=Sélectionner un répertoire
+Select\ files=Sélectionner des fichiers
+BibTeX\ entry\ creation=Création d'un entrée BibTeX
+<No\ selection>=<Pas de sélection>
+Unable\ to\ connect\ to\ FreeCite\ online\ service.=Impossible de se connecter au service en ligne FreeCite
+Parse\ with\ FreeCite=Analyse avec FreeCite
+The\ current\ BibTeX\ key\ will\ be\ overwritten.\ Continue?=La clef BibTeX courante sera écrasée. Continuer ?
+Overwrite\ key=Ecraser la clef
+Not\ overwriting\ existing\ key.\ To\ change\ this\ setting,\ open\ Options\ ->\ Prefererences\ ->\ BibTeX\ key\ generator=Pas d'écrasement de clefs existantes. Pour changer ce paramétrage, ouvrir Options -> Préférences -> Générateur de clefs BibTeX
+How\ would\ you\ like\ to\ link\ to\ '%0'?=Quel type de lien souhaitez-vous vers '%0' ?
+BibTeX\ key\ patterns=Modèles de clef BibTeX
+Changed\ special\ field\ settings=Paramètres de champs spéciaux modifiés
+Clear\ priority=Effacer la priorité
+Clear\ rank=Effacer le rang
+Enable\ special\ fields=Autoriser les champs spéciaux
+One\ star=Une étoile
+Two\ stars=Deux étoiles
+Three\ stars=Trois étoiles
+Four\ stars=Quatre étoiles
+Five\ stars=Cinq étoiles
+Help\ on\ special\ fields=Aide sur les champs spéciaux
+Keywords\ of\ selected\ entries=Mots-clefs des entrées sélectionnés
+Manage\ content\ selectors=Gérer les sélecteurs de contenu
+Manage\ keywords=Gérer les mots-clefs
+No\ priority\ information=Pas d'information sur la priorité
+No\ rank\ information=Pas d'information sur le rang
 Priority=Priorité
-Priority_high=Priorité_forte
-Priority_low=Priorité_faible
-Priority_medium=Priorité_intermédiaire
+Priority\ high=Priorité forte
+Priority\ low=Priorité faible
+Priority\ medium=Priorité intermédiaire
 Quality=Qualité
 Rank=Rang
 Relevance=Pertinence
-Set_priority_to_high=Définir_la_priorité_comme_forte
-Set_priority_to_low=Définir_la_priorité_comme_faible
-Set_priority_to_medium=Définir_la_priorité_comme_intermédiaire
-Show_priority=Montrer_la_priorité
-Show_quality=Montrer_la_qualité
-Show_rank=Montrer_le_rang
-Show_relevance=Montrer_la_pertinence
-Synchronize_with_keywords=Synchroniser_avec_les_mots-clefs
-Synchronized_special_fields_based_on_keywords=Champs_spéciaux_synchronisés_sur_la_base_des_mots-clefs
-Toggle_relevance=Changer_la_pertinence
-Toggle_quality_assured=Changer_la_vérification_de_qualité
-Toggle_print_status=Changer_le_statut_d'impression
-Update_keywords=Mettre_à_jour_les_mots-clefs
-Write_values_of_special_fields_as_separate_fields_to_BibTeX=Ecrire_les_valeurs_des_champs_spéciaux_dans_des_champs_BibTeX_séparés
-You_have_changed_settings_for_special_fields.=Vous_avez_modifié_les_paramètres_pour_les_champs_spéciaux.
-%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.=%0_entrées_trouvées._Pour_réduire_la_charge_du_serveur,_seulement_%1_seront_téléchargées.
-A_string_with_that_label_already_exists=Une_chaine_avec_cette_étiquette_existe_déja
-Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.=La_connexion_à_OpenOffice/LibreOffice_a_été_perdue._S'il_vous_plait,_assurez-vous_qu'OpenOffice/LibreOffice_soit_lancé,_et_essayez_de_vous_reconnecter.
-JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.=JabRef_fera_au_moins_une_requête_par_entrée_à_chaque_éditeur.
-Correct_the_entry,_and_reopen_editor_to_display/edit_source.=Corrigez_l'entrée_et_ré-ouvrez_l'éditeur_pour_afficher/éditer_la_source.
-Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').=La_connexion_à_un_processus_gnuserv_actif_a_échoué._Assurez-vous_que_Emacs_ou_XEmacs_soit_lancé,<BR>et_que_le_serveur_a_été_démarré_(en_lançant_la_commande_'server-start'/'gnuserv-start').
-Could_not_connect_to_running_OpenOffice/LibreOffice.=La_connexion_à_OpenOffice/LibreOffice_n'a_pas_pu_être_lancée.
-Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.=Assurez-vous_qu'OpenOffice/LibreOffice_est_installé_avec_le_support_Java.
-If_connecting_manually,_please_verify_program_and_library_paths.=En_cas_de_connexion_manuelle,_vérifiez_les_chemins_du_programme_et_de_la_bibliothèque.
-Error_message\:=Message_d'erreur_\:
-If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.=Si_une_entrée_collée_ou_importée_a_le_champ_déjà_paramétré,_écraser.
-Import_metadata_from_PDF=Importer_les_méta-données_à_partir_du_PDF
-Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.=Pas_de_connexion_à_un_document_Writer._S'il_vous_plait,_assurez-vous_qu'un_document_est_ouvert_et_utiliser_le_bouton_'Sélectionner_un_document_Writer'_pour_vous_y_connecter.
-Removed_all_subgroups_of_group_"%0".=Tous_les_sous-groupes_du_groupe_"%0"_ont_été_supprimés.
-To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.=Pour_désactiver_le_mode_Memory-stick,_renommer_ou_supprimer_le_fichier_jabref.xml_dans_le_même_répertoire_que_JabRef
-Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.=Connexion_impossible._Une_raison_potentielle_est_que_JabRef_et_OpenOffice/LibreOffice_ne_fonctionnent_pas_tous_les_deux_soit_en_mode_32_bits,_soit_en_mode_64_bits.
-Use_the_following_delimiter_character(s)\:=Utiliser_le(s)_caractère(s)_de_délimitation_suivant_\:
-When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above=Lors_du_téléchargement_de_fichiers_ou_du_déplacement_de_fichiers_liées_vers_le_répertoire_de_fichiers,_préférez_l'emplacement_du_fichier_BIB_au_répertoire_ci-dessus
-Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=Votre_fichier_de_style_spécifie_le_format_de_caractère_'%0',_qui_n'est_pas_défini_dans_votre_document_OpenOffice/LibreOffice_actuel.
-Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=Votre_fichier_de_style_spécifie_le_format_de_paragraphe_'%0',_qui_n'est_pas_défini_dans_votre_document_OpenOffice/LibreOffice_actuel.
+Set\ priority\ to\ high=Définir la priorité comme forte
+Set\ priority\ to\ low=Définir la priorité comme faible
+Set\ priority\ to\ medium=Définir la priorité comme intermédiaire
+Show\ priority=Montrer la priorité
+Show\ quality=Montrer la qualité
+Show\ rank=Montrer le rang
+Show\ relevance=Montrer la pertinence
+Synchronize\ with\ keywords=Synchroniser avec les mots-clefs
+Synchronized\ special\ fields\ based\ on\ keywords=Champs spéciaux synchronisés sur la base des mots-clefs
+Toggle\ relevance=Changer la pertinence
+Toggle\ quality\ assured=Changer la vérification de qualité
+Toggle\ print\ status=Changer le statut d'impression
+Update\ keywords=Mettre à jour les mots-clefs
+Write\ values\ of\ special\ fields\ as\ separate\ fields\ to\ BibTeX=Ecrire les valeurs des champs spéciaux dans des champs BibTeX séparés
+You\ have\ changed\ settings\ for\ special\ fields.=Vous avez modifié les paramètres pour les champs spéciaux.
+%0\ entries\ found.\ To\ reduce\ server\ load,\ only\ %1\ will\ be\ downloaded.=%0 entrées trouvées. Pour réduire la charge du serveur, seulement %1 seront téléchargées.
+A\ string\ with\ that\ label\ already\ exists=Une chaine avec cette étiquette existe déja
+Connection\ to\ OpenOffice/LibreOffice\ has\ been\ lost.\ Please\ make\ sure\ OpenOffice/LibreOffice\ is\ running,\ and\ try\ to\ reconnect.=La connexion à OpenOffice/LibreOffice a été perdue. S'il vous plait, assurez-vous qu'OpenOffice/LibreOffice soit lancé, et essayez de vous reconnecter.
+JabRef\ will\ send\ at\ least\ one\ request\ per\ entry\ to\ a\ publisher.=JabRef fera au moins une requête par entrée à chaque éditeur.
+Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=Corrigez l'entrée et ré-ouvrez l'éditeur pour afficher/éditer la source.
+Could\ not\ connect\ to\ a\ running\ gnuserv\ process.\ Make\ sure\ that\ Emacs\ or\ XEmacs\ is\ running,<BR>and\ that\ the\ server\ has\ been\ started\ (by\ running\ the\ command\ 'server-start'/'gnuserv-start').=La connexion à un processus gnuserv actif a échoué. Assurez-vous que Emacs ou XEmacs soit lancé,<BR>et que le serveur a été démarré (en lançant la commande 'server-start'/'gnuserv-start').
+Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=La connexion à OpenOffice/LibreOffice n'a pas pu être lancée.
+Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=Assurez-vous qu'OpenOffice/LibreOffice est installé avec le support Java.
+If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=En cas de connexion manuelle, vérifiez les chemins du programme et de la bibliothèque.
+Error\ message\:=Message d'erreur :
+If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=Si une entrée collée ou importée a le champ déjà paramétré, écraser.
+Import\ metadata\ from\ PDF=Importer les méta-données à partir du PDF
+Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=Pas de connexion à un document Writer. S'il vous plait, assurez-vous qu'un document est ouvert et utiliser le bouton 'Sélectionner un document Writer' pour vous y connecter.
+Removed\ all\ subgroups\ of\ group\ "%0".=Tous les sous-groupes du groupe "%0" ont été supprimés.
+To\ disable\ the\ memory\ stick\ mode\ rename\ or\ remove\ the\ jabref.xml\ file\ in\ the\ same\ folder\ as\ JabRef.=Pour désactiver le mode Memory-stick, renommer ou supprimer le fichier jabref.xml dans le même répertoire que JabRef
+Unable\ to\ connect.\ One\ possible\ reason\ is\ that\ JabRef\ and\ OpenOffice/LibreOffice\ are\ not\ both\ running\ in\ either\ 32\ bit\ mode\ or\ 64\ bit\ mode.=Connexion impossible. Une raison potentielle est que JabRef et OpenOffice/LibreOffice ne fonctionnent pas tous les deux soit en mode 32 bits, soit en mode 64 bits.
+Use\ the\ following\ delimiter\ character(s)\:=Utiliser le(s) caractère(s) de délimitation suivant :
+When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\ prefer\ the\ BIB\ file\ location\ rather\ than\ the\ file\ directory\ set\ above=Lors du téléchargement de fichiers ou du déplacement de fichiers liées vers le répertoire de fichiers, préférez l'emplacement du fichier BIB au répertoire ci-dessus
+Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Votre fichier de style spécifie le format de caractère '%0', qui n'est pas défini dans votre document OpenOffice/LibreOffice actuel.
+Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Votre fichier de style spécifie le format de paragraphe '%0', qui n'est pas défini dans votre document OpenOffice/LibreOffice actuel.
 
 Searching...=Recherche...
-You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?=Vous_avez_sélectionné_plus_de_%0_entrées_à_télécharger._Certains_sites_web_pourraient_vous_bloquer_si_vous_effectuez_de_trop_nombreux_et_rapides_téléchargements._Voulez-vous_continuer?
-Confirm_selection=Confirmez_la_sélection
-Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case=Ajouter_{}_aux_mots_du_titre_spécifiés_lors_d'une_recherche_pour_préserver_la_casse_correcte
-Import_conversions=Importer_les_conversions
-Please_enter_a_search_string=Entrez_s'il_vous_plait_une_chaine_de_recherche
-Please_open_or_start_a_new_library_before_searching=S'il_vous_plait,_ouvrez_ou_créer_un_nouveau_fichier_avant_la_recherche
+You\ have\ selected\ more\ than\ %0\ entries\ for\ download.\ Some\ web\ sites\ might\ block\ you\ if\ you\ make\ too\ many\ rapid\ downloads.\ Do\ you\ want\ to\ continue?=Vous avez sélectionné plus de %0 entrées à télécharger. Certains sites web pourraient vous bloquer si vous effectuez de trop nombreux et rapides téléchargements. Voulez-vous continuer?
+Confirm\ selection=Confirmez la sélection
+Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=Ajouter {} aux mots du titre spécifiés lors d'une recherche pour préserver la casse correcte
+Import\ conversions=Importer les conversions
+Please\ enter\ a\ search\ string=Entrez s'il vous plait une chaine de recherche
+Please\ open\ or\ start\ a\ new\ library\ before\ searching=S'il vous plait, ouvrez ou créer un nouveau fichier avant la recherche
 
-Canceled_merging_entries=Fusion_des_entrées_interrompues
+Canceled\ merging\ entries=Fusion des entrées interrompues
 
-Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search=Formatter_les_unités_en_ajouter_des_séparateurs_non_interruptibles_et_conserver_la_casse_correcte_pour_la_recherche
-Merge_entries=Fusionner_les_entrées
-Merged_entries=Entrées_fusionnées_dans_une_nouvelle_et_anciennes_conservées
-Merged_entry=Entrée_fusionnée
+Format\ units\ by\ adding\ non-breaking\ separators\ and\ keeping\ the\ correct\ case\ on\ search=Formatter les unités en ajouter des séparateurs non interruptibles et conserver la casse correcte pour la recherche
+Merge\ entries=Fusionner les entrées
+Merged\ entries=Entrées fusionnées dans une nouvelle et anciennes conservées
+Merged\ entry=Entrée fusionnée
 None=Effacer
 Parse=Analyser
 Result=Résultat
-Show_DOI_first=Montrer_le_DOI_en_premier
-Show_URL_first=Montrer_l'URL_en_premier
-Use_Emacs_key_bindings=Utiliser_les_raccourcis_clavier_d'Emacs
-You_have_to_choose_exactly_two_entries_to_merge.=Vous_devez_choisir_exactement_deux_entrées_à_fusionner.
+Show\ DOI\ first=Montrer le DOI en premier
+Show\ URL\ first=Montrer l'URL en premier
+Use\ Emacs\ key\ bindings=Utiliser les raccourcis clavier d'Emacs
+You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=Vous devez choisir exactement deux entrées à fusionner.
 
-Update_timestamp_on_modification=Mettre_à_jour_l'horodatage_en_cas_de_modification
-All_key_bindings_will_be_reset_to_their_defaults.=Tous_les_raccourcis_clavier_seront_réinitialisés_à_leurs_valeurs_par_défaut.
+Update\ timestamp\ on\ modification=Mettre à jour l'horodatage en cas de modification
+All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=Tous les raccourcis clavier seront réinitialisés à leurs valeurs par défaut.
 
-Automatically_set_file_links=Configurer_automatiquement_les_liens_de_fichier
-Resetting_all_key_bindings=Réinitialisation_de_tous_les_raccourcis_clavier
-Hostname=Ordinateur_hôte
-Invalid_setting=Paramétrage_invalide
+Automatically\ set\ file\ links=Configurer automatiquement les liens de fichier
+Resetting\ all\ key\ bindings=Réinitialisation de tous les raccourcis clavier
+Hostname=Ordinateur hôte
+Invalid\ setting=Paramétrage invalide
 Network=Réseau
-Please_specify_both_hostname_and_port=Entrez_à_la_fois_le_nom_de_l'ordinateur_hôte_et_le_port,_s'il_vous_plait
-Please_specify_both_username_and_password=Préciser_à_la_fois_le_nom_d'utilisateur_et_le_mot_de_passe,_SVP
+Please\ specify\ both\ hostname\ and\ port=Entrez à la fois le nom de l'ordinateur hôte et le port, s'il vous plait
+Please\ specify\ both\ username\ and\ password=Préciser à la fois le nom d'utilisateur et le mot de passe, SVP
 
-Use_custom_proxy_configuration=Utiliser_une_configuration_de_proxy_personnalisée
-Proxy_requires_authentication=Le_proxy_demande_une_authentification
-Attention\:_Password_is_stored_in_plain_text\!=Attention_\:_Le_mot_de_passe_est_stocké_en_clair_dans_du_texte_brut.
-Clear_connection_settings=Réinitialiser_les_paramètres_de_connexion
-Cleared_connection_settings.=Paramètres_de_connexion_réinitialisés.
+Use\ custom\ proxy\ configuration=Utiliser une configuration de proxy personnalisée
+Proxy\ requires\ authentication=Le proxy demande une authentification
+Attention\:\ Password\ is\ stored\ in\ plain\ text\!=Attention : Le mot de passe est stocké en clair dans du texte brut.
+Clear\ connection\ settings=Réinitialiser les paramètres de connexion
+Cleared\ connection\ settings.=Paramètres de connexion réinitialisés.
 
-Rebind_C-a,_too=Ré-associer_aussi_C-a
-Rebind_C-f,_too=Ré-associer_aussi_C-f
+Rebind\ C-a,\ too=Ré-associer aussi C-a
+Rebind\ C-f,\ too=Ré-associer aussi C-f
 
-Open_folder=Ouvrir_le_répertoire
-Searches_for_unlinked_PDF_files_on_the_file_system=Rechercher_les_fichiers_PDF_non_liés_dans_le_système_de_fichiers
-Export_entries_ordered_as_specified=Exporter_les_entrées_dans_l'ordre_spécifié
-Export_sort_order=Exporter_l'ordre_de_tri
-Export_sorting=Exportation_du_tri
-Newline_separator=Séparateur_de_ligne
+Open\ folder=Ouvrir le répertoire
+Searches\ for\ unlinked\ PDF\ files\ on\ the\ file\ system=Rechercher les fichiers PDF non liés dans le système de fichiers
+Export\ entries\ ordered\ as\ specified=Exporter les entrées dans l'ordre spécifié
+Export\ sort\ order=Exporter l'ordre de tri
+Export\ sorting=Exportation du tri
+Newline\ separator=Séparateur de ligne
 
-Save_entries_ordered_as_specified=Enregistrer_les_entrées_dans_l'ordre_spécifié
-Save_sort_order=Enregistrer_l'ordre_de_tri
-Show_extra_columns=Montrer_les_colonnes_supplémentaires
-Parsing_error=Erreur_de_traitement
-illegal_backslash_expression=Expression_avec_barre_oblique_inversée_(\\)_illégale
+Save\ entries\ ordered\ as\ specified=Enregistrer les entrées dans l'ordre spécifié
+Save\ sort\ order=Enregistrer l'ordre de tri
+Show\ extra\ columns=Montrer les colonnes supplémentaires
+Parsing\ error=Erreur de traitement
+illegal\ backslash\ expression=Expression avec barre oblique inversée (\\) illégale
 
-Move_to_group=Déplacer_vers_le_groupe
+Move\ to\ group=Déplacer vers le groupe
 
-Clear_read_status=Effacer_le_statut_de_lecture
-Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')=Convertir_au_format_biblatex_(par_exemple,_transformer_la_valeur_du_champ_'journal'_en_'journaltitle')
-Could_not_apply_changes.=Les_changements_n'ont_pas_pu_être_effectués.
-Deprecated_fields=Champs_obsolètes
-Hide/show_toolbar=Masquer/afficher_la_barre_d'outils
-No_read_status_information=Pas_d'information_sur_le_statut_de_lecture
+Clear\ read\ status=Effacer le statut de lecture
+Convert\ to\ biblatex\ format\ (for\ example,\ move\ the\ value\ of\ the\ 'journal'\ field\ to\ 'journaltitle')=Convertir au format biblatex (par exemple, transformer la valeur du champ 'journal' en 'journaltitle')
+Could\ not\ apply\ changes.=Les changements n'ont pas pu être effectués.
+Deprecated\ fields=Champs obsolètes
+Hide/show\ toolbar=Masquer/afficher la barre d'outils
+No\ read\ status\ information=Pas d'information sur le statut de lecture
 Printed=Imprimé
-Read_status=Statut_de_lecture
-Read_status_read=Statut_de_lecture_\:_lu
-Read_status_skimmed=Statut_de_lecture_\:_parcouru
-Save_selected_as_plain_BibTeX...=Enregistrer_la_sélection_en_BibTeX_basique...
-Set_read_status_to_read=Mettre_le_statut_de_lecture_à_lu
-Set_read_status_to_skimmed=Mettre_le_statut_de_lecture_à_parcouru
-Show_deprecated_BibTeX_fields=Montrer_les_champs_BibTeX_obsolètes
+Read\ status=Statut de lecture
+Read\ status\ read=Statut de lecture : lu
+Read\ status\ skimmed=Statut de lecture : parcouru
+Save\ selected\ as\ plain\ BibTeX...=Enregistrer la sélection en BibTeX basique...
+Set\ read\ status\ to\ read=Mettre le statut de lecture à lu
+Set\ read\ status\ to\ skimmed=Mettre le statut de lecture à parcouru
+Show\ deprecated\ BibTeX\ fields=Montrer les champs BibTeX obsolètes
 
-Show_gridlines=Afficher_la_grille
-Show_printed_status=Afficher_le_statut_d'impression
-Show_read_status=Afficher_le_statut_de_lecture
-Table_row_height_padding=Espacement_en_hauteur_des_rangées_de_tableau
+Show\ gridlines=Afficher la grille
+Show\ printed\ status=Afficher le statut d'impression
+Show\ read\ status=Afficher le statut de lecture
+Table\ row\ height\ padding=Espacement en hauteur des rangées de tableau
 
-Marked_selected_entry=Entrées_sélectionnées_étiquetées
-Marked_all_%0_selected_entries=%0_entrées_sélectionnées_étiquetées
-Unmarked_selected_entry=Entrées_sélectionnées_désétiquetées
-Unmarked_all_%0_selected_entries=%O_entrées_sélectionnées_désétiquetées
+Marked\ selected\ entry=Entrées sélectionnées étiquetées
+Marked\ all\ %0\ selected\ entries=%0 entrées sélectionnées étiquetées
+Unmarked\ selected\ entry=Entrées sélectionnées désétiquetées
+Unmarked\ all\ %0\ selected\ entries=%O entrées sélectionnées désétiquetées
 
 
-Unmarked_all_entries=Toutes_les_entrées_désétiquetées
+Unmarked\ all\ entries=Toutes les entrées désétiquetées
 
-Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.=Impossible_de_trouver_l'apparence_demandée._Aussi,_celle_par_défaut_est_utilisée.
+Unable\ to\ find\ the\ requested\ look\ and\ feel\ and\ thus\ the\ default\ one\ is\ used.=Impossible de trouver l'apparence demandée. Aussi, celle par défaut est utilisée.
 
-Opens_JabRef's_GitHub_page=Ouvre_la_page_GitHub_de_JabRef
-Could_not_open_browser.=Le_navigateur_n'a_pas_pu_être_lancé.
-Please_open_%0_manually.=Ouvrez_%0_manuellement,_SVP.
-The_link_has_been_copied_to_the_clipboard.=Le_lien_a_été_copié_dans_le_presse-papiers.
+Opens\ JabRef's\ GitHub\ page=Ouvre la page GitHub de JabRef
+Could\ not\ open\ browser.=Le navigateur n'a pas pu être lancé.
+Please\ open\ %0\ manually.=Ouvrez %0 manuellement, SVP.
+The\ link\ has\ been\ copied\ to\ the\ clipboard.=Le lien a été copié dans le presse-papiers.
 
-Open_%0_file=Ouvrir_le_fichier_%0
+Open\ %0\ file=Ouvrir le fichier %0
 
-Cannot_delete_file=Le_fichier_ne_peut_pas_être_supprimé
-File_permission_error=Erreur_due_aux_permissions_du_fichier
-Push_to_%0=Envoyer_vers_%0
-Path_to_%0=Chemin_vers_%0
+Cannot\ delete\ file=Le fichier ne peut pas être supprimé
+File\ permission\ error=Erreur due aux permissions du fichier
+Push\ to\ %0=Envoyer vers %0
+Path\ to\ %0=Chemin vers %0
 Convert=Convertir
-Normalize_to_BibTeX_name_format=Normaliser_au_format_de_nom_BibTeX
-Help_on_Name_Formatting=Aide_sur_le_formatage_des_noms
+Normalize\ to\ BibTeX\ name\ format=Normaliser au format de nom BibTeX
+Help\ on\ Name\ Formatting=Aide sur le formatage des noms
 
-Add_new_file_type=Ajouter_un_nouveau_type_de_fichier
+Add\ new\ file\ type=Ajouter un nouveau type de fichier
 
-Left_entry=Entrée_de_gauche
-Right_entry=Entrée_de_droite
+Left\ entry=Entrée de gauche
+Right\ entry=Entrée de droite
 Use=Utilisation
-Original_entry=Entrée_d'origine
-Replace_original_entry=Remplacer_l'entrée_d'origine
-No_information_added=Aucune_information_ajoutée
-Select_at_least_one_entry_to_manage_keywords.=Sélectionner_au_moins_une_entrée_pour_gérer_les_mots-clefs.
-OpenDocument_text=Texte_OpenDocument
-OpenDocument_spreadsheet=Tableau_OpenDocument
-OpenDocument_presentation=Présentation_OpenDocument
-%0_image=%0_image
-Added_entry=Entrée_ajoutée
-Modified_entry=Entrée_modifiée
-Deleted_entry=Entrée_supprimée
-Modified_groups_tree=Arbre_des_groupes_modifié
-Removed_all_groups=Supprimer_tous_les_groupes
-Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.=Acceptation_que_l'arbre_des_groupes_entier_soit_remplacé_par_l'arbre_des_groupes_modifiés_externalement.
-Select_export_format=Sélectionner_un_format_d'exportation
-Return_to_JabRef=Revenir_à_JabRef
-Please_move_the_file_manually_and_link_in_place.=Déplacez_le_fichier_manuellement_et_liez-le,_SVP.
-Could_not_connect_to_%0=La_connexion_à_%0_n'a_pas_pu_être_établie
-Warning\:_%0_out_of_%1_entries_have_undefined_title.=Attention_\:_%0_des_%1_entrées_n'ont_pas_de_titre.
-Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.=Attention_\:_%0_des_%1_entrées_n'ont_pas_de_clef_BibTeX.
+Original\ entry=Entrée d'origine
+Replace\ original\ entry=Remplacer l'entrée d'origine
+No\ information\ added=Aucune information ajoutée
+Select\ at\ least\ one\ entry\ to\ manage\ keywords.=Sélectionner au moins une entrée pour gérer les mots-clefs.
+OpenDocument\ text=Texte OpenDocument
+OpenDocument\ spreadsheet=Tableau OpenDocument
+OpenDocument\ presentation=Présentation OpenDocument
+%0\ image=%0 image
+Added\ entry=Entrée ajoutée
+Modified\ entry=Entrée modifiée
+Deleted\ entry=Entrée supprimée
+Modified\ groups\ tree=Arbre des groupes modifié
+Removed\ all\ groups=Supprimer tous les groupes
+Accepting\ the\ change\ replaces\ the\ complete\ groups\ tree\ with\ the\ externally\ modified\ groups\ tree.=Acceptation que l'arbre des groupes entier soit remplacé par l'arbre des groupes modifiés externalement.
+Select\ export\ format=Sélectionner un format d'exportation
+Return\ to\ JabRef=Revenir à JabRef
+Please\ move\ the\ file\ manually\ and\ link\ in\ place.=Déplacez le fichier manuellement et liez-le, SVP.
+Could\ not\ connect\ to\ %0=La connexion à %0 n'a pas pu être établie
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ title.=Attention : %0 des %1 entrées n'ont pas de titre.
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ BibTeX\ key.=Attention : %0 des %1 entrées n'ont pas de clef BibTeX.
 occurrence=occurrence
-Added_new_'%0'_entry.=Nouvelle_entrée_'%0'_ajoutée
-Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?=Plusieurs_entrées_sont_sélectionnées.Voulez-vous_changer_le_type_de_toutes_en_'%0'_?
-Changed_type_to_'%0'_for=Type_modifié_en_'%0'_pour
-Really_delete_the_selected_entry?=Voulez-vous_vraiment_supprimer_l'entrée_sélectionnée_?
-Really_delete_the_%0_selected_entries?=Voulez-vous_vraiment_supprimer_les_%0_entrées_sélectionnées_?
-Keep_merged_entry_only=Ne_conserver_que_les_entrées_fusionnées
-Keep_left=Conserver_le_gauche
-Keep_right=Conserver_le_droit
-Old_entry=Ancienne_entrée
-From_import=A_partir_de_l'importation
-No_problems_found.=Aucun_problème_rencontré
-%0_problem(s)_found=%0_problème(s)_trouvé(s).
-Save_changes=Enregistrer_les_modifications
-Discard_changes=Abandonner_les_modifications
-Library_'%0'_has_changed.=Le_fichier_'%0'_a_été_modifié.
-Print_entry_preview=Imprimer_la_prévisualisation_de_l'entrée
-Copy_title=Copier_le_titre
-Copy_\\cite{BibTeX_key}=Copier_\\cite{clé_BibTeX}
-Copy_BibTeX_key_and_title=Copier_la_clef_BibTeX_et_le_titre
-File_rename_failed_for_%0_entries.=Le_renommage_des_fichiers_a_échoué_pour_%0_entrées.
-Merged_BibTeX_source_code=Code_source_BibTeX_fusionné
-Invalid_DOI\:_'%0'.=DOI_invalide_\:_'%0'.
-should_start_with_a_name=devrait_débuter_par_un_nom
-should_end_with_a_name=devrait_se_terminer_par_un_nom
-unexpected_closing_curly_bracket=accolade_fermante_incongrue
-unexpected_opening_curly_bracket=accolade_ouvrante_incongrue
-capital_letters_are_not_masked_using_curly_brackets_{}=Des_majuscules_ne_sont_pas_incluses_entre_accolades_{}
-should_contain_a_four_digit_number=devrait_contenir_un_nombre_à_quatre_chiffres
-should_contain_a_valid_page_number_range=devrait_contenir_une_gamme_de_pages_valide
+Added\ new\ '%0'\ entry.=Nouvelle entrée '%0' ajoutée
+Multiple\ entries\ selected.\ Do\ you\ want\ to\ change\ the\ type\ of\ all\ these\ to\ '%0'?=Plusieurs entrées sont sélectionnées.Voulez-vous changer le type de toutes en '%0' ?
+Changed\ type\ to\ '%0'\ for=Type modifié en '%0' pour
+Really\ delete\ the\ selected\ entry?=Voulez-vous vraiment supprimer l'entrée sélectionnée ?
+Really\ delete\ the\ %0\ selected\ entries?=Voulez-vous vraiment supprimer les %0 entrées sélectionnées ?
+Keep\ merged\ entry\ only=Ne conserver que les entrées fusionnées
+Keep\ left=Conserver le gauche
+Keep\ right=Conserver le droit
+Old\ entry=Ancienne entrée
+From\ import=A partir de l'importation
+No\ problems\ found.=Aucun problème rencontré
+%0\ problem(s)\ found=%0 problème(s) trouvé(s).
+Save\ changes=Enregistrer les modifications
+Discard\ changes=Abandonner les modifications
+Library\ '%0'\ has\ changed.=Le fichier '%0' a été modifié.
+Print\ entry\ preview=Imprimer la prévisualisation de l'entrée
+Copy\ title=Copier le titre
+Copy\ \\cite{BibTeX\ key}=Copier \\cite{clé BibTeX}
+Copy\ BibTeX\ key\ and\ title=Copier la clef BibTeX et le titre
+File\ rename\ failed\ for\ %0\ entries.=Le renommage des fichiers a échoué pour %0 entrées.
+Merged\ BibTeX\ source\ code=Code source BibTeX fusionné
+Invalid\ DOI\:\ '%0'.=DOI invalide : '%0'.
+should\ start\ with\ a\ name=devrait débuter par un nom
+should\ end\ with\ a\ name=devrait se terminer par un nom
+unexpected\ closing\ curly\ bracket=accolade fermante incongrue
+unexpected\ opening\ curly\ bracket=accolade ouvrante incongrue
+capital\ letters\ are\ not\ masked\ using\ curly\ brackets\ {}=Des majuscules ne sont pas incluses entre accolades {}
+should\ contain\ a\ four\ digit\ number=devrait contenir un nombre à quatre chiffres
+should\ contain\ a\ valid\ page\ number\ range=devrait contenir une gamme de pages valide
 Filled=Rempli
-Field_is_missing=Un_champ_est_manquant
-Search_%0=Recherche_%0
+Field\ is\ missing=Un champ est manquant
+Search\ %0=Recherche %0
 
-Search_results_in_all_libraries_for_%0=Résultats_de_recherche_dans_tous_les_fichiers_pour_%0
-Search_results_in_library_%0_for_%1=Résultats_de_recherche_dans_le_fichier_%0_pour_%1
-Search_globally=Rechercher_globalement
-No_results_found.=Aucun_résultat_trouvé.
-Found_%0_results.=%0_résultats_trouvés.
-plain_text=texte_brut
-This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>=Cette_recherche_contient_des_entrées_pour_lesquelles_au_moins_un_champ_contient_l'expression_régulière_<b>%0</b>
-This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>=Cette_recherche_contient_des_entrées_pour_lesquelles_au_moins_un_champ_contient_le_terme_<b>%0</b>
-This_search_contains_entries_in_which=Cette_recherche_contient_des_entrées_pour_lequelles
+Search\ results\ in\ all\ libraries\ for\ %0=Résultats de recherche dans tous les fichiers pour %0
+Search\ results\ in\ library\ %0\ for\ %1=Résultats de recherche dans le fichier %0 pour %1
+Search\ globally=Rechercher globalement
+No\ results\ found.=Aucun résultat trouvé.
+Found\ %0\ results.=%0 résultats trouvés.
+plain\ text=texte brut
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ regular\ expression\ <b>%0</b>=Cette recherche contient des entrées pour lesquelles au moins un champ contient l'expression régulière <b>%0</b>
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ term\ <b>%0</b>=Cette recherche contient des entrées pour lesquelles au moins un champ contient le terme <b>%0</b>
+This\ search\ contains\ entries\ in\ which=Cette recherche contient des entrées pour lequelles
 
-Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.=La_détection_automatique_de_OpenOffice/LibreOffice_a_échouée._S'il_voul_plait,_sélectionnez_manuellement_le_répertoire_d'installation.
-JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>=JabRef_ne_gère_plus_les_champs_'ps'_et_'pdf'.<br>Les_liens_vers_les_fichiers_sont_maintenant_enregistrés_dans_le_champ_'file'_et_les_fichiers_sont_enregistrés_dans_un_répertoire_externe.<br>Pour_utiliser_cette_fonctionnalité,_JabRef_a_besoin_de_mettre_à_jour_les_liens_vers_les_fichiers.<br><br>
-This_library_uses_outdated_file_links.=Ce_fichier_utilise_des_liens_de_fichier_périmés
+Unable\ to\ autodetect\ OpenOffice/LibreOffice\ installation.\ Please\ choose\ the\ installation\ directory\ manually.=La détection automatique de OpenOffice/LibreOffice a échouée. S'il voul plait, sélectionnez manuellement le répertoire d'installation.
+JabRef\ no\ longer\ supports\ 'ps'\ or\ 'pdf'\ fields.<br>File\ links\ are\ now\ stored\ in\ the\ 'file'\ field\ and\ files\ are\ stored\ in\ an\ external\ file\ directory.<br>To\ make\ use\ of\ this\ feature,\ JabRef\ needs\ to\ upgrade\ file\ links.<br><br>=JabRef ne gère plus les champs 'ps' et 'pdf'.<br>Les liens vers les fichiers sont maintenant enregistrés dans le champ 'file' et les fichiers sont enregistrés dans un répertoire externe.<br>Pour utiliser cette fonctionnalité, JabRef a besoin de mettre à jour les liens vers les fichiers.<br><br>
+This\ library\ uses\ outdated\ file\ links.=Ce fichier utilise des liens de fichier périmés
 
-Clear_search=Vider_la_recherche
-Close_library=Fermer_le_fichier
-Close_entry_editor=Fermer_l'éditeur_d'entrée
-Decrease_table_font_size=Diminuer_la_taille_de_police_du_tableau
-Entry_editor,_next_entry=Editeur_d'entrée,_entrée_suivante
-Entry_editor,_next_panel=Editeur_d'entrée,_prochain_onglet
-Entry_editor,_next_panel_2=Editeur_d'entrée,_prochain_onglet_2
-Entry_editor,_previous_entry=Editeur_d'entrée,_entrée_précédente
-Entry_editor,_previous_panel=Editeur_d'entrée,_onglet_précédent
-Entry_editor,_previous_panel_2=Editeur_d'entrée,_onglet_précédent_2
-File_list_editor,_move_entry_down=Editeur_de_liste_de_fichiers,_déplacer_l'entrée_vers_le_haut
-File_list_editor,_move_entry_up=Editeur_de_liste_de_fichiers,_déplacer_l'entrée_vers_le_bas
-Focus_entry_table=Afficher_la_table_des_entrées
-Import_into_current_library=Importer_dans_le_fichier_actuel
-Import_into_new_library=Importer_dans_un_nouveau_fichier
-Increase_table_font_size=Augmenter_la_taille_de_police_du_tableau
-New_article=Nouveau_Article
-New_book=Nouveau_Book
-New_entry=Nouvelle_entrée
-New_from_plain_text=Nouveau_à_partir_de_texte_brut
-New_inbook=Nouveau_Inbook
-New_mastersthesis=Nouveau_Mastersthesis
-New_phdthesis=Nouveau_Phdthesis
-New_proceedings=Nouveau_Proceedings
-New_unpublished=Nouveau_Unpublished
-Next_tab=Onglet_suivant
-Preamble_editor,_store_changes=Editeur_de_préambule,_enregistrer_les_changements
-Previous_tab=Onglet_précédent
-Push_to_application=Envoyer_vers_le_logiciel
-Refresh_OpenOffice/LibreOffice=Rafraichir_OpenOffice/LibreOffice
-Resolve_duplicate_BibTeX_keys=Solutionner_les_clefs_BibTeX_dupliquées
-Save_all=Enregistrer_tout
-String_dialog,_add_string=Chaine_de_dialogue,_ajouter_une_chaine
-String_dialog,_remove_string=Chaine_de_dialogue,_supprimer_une_chaine
-Synchronize_files=Synchroniser_les_fichiers
+Clear\ search=Vider la recherche
+Close\ library=Fermer le fichier
+Close\ entry\ editor=Fermer l'éditeur d'entrée
+Decrease\ table\ font\ size=Diminuer la taille de police du tableau
+Entry\ editor,\ next\ entry=Editeur d'entrée, entrée suivante
+Entry\ editor,\ next\ panel=Editeur d'entrée, prochain onglet
+Entry\ editor,\ next\ panel\ 2=Editeur d'entrée, prochain onglet 2
+Entry\ editor,\ previous\ entry=Editeur d'entrée, entrée précédente
+Entry\ editor,\ previous\ panel=Editeur d'entrée, onglet précédent
+Entry\ editor,\ previous\ panel\ 2=Editeur d'entrée, onglet précédent 2
+File\ list\ editor,\ move\ entry\ down=Editeur de liste de fichiers, déplacer l'entrée vers le haut
+File\ list\ editor,\ move\ entry\ up=Editeur de liste de fichiers, déplacer l'entrée vers le bas
+Focus\ entry\ table=Afficher la table des entrées
+Import\ into\ current\ library=Importer dans le fichier actuel
+Import\ into\ new\ library=Importer dans un nouveau fichier
+Increase\ table\ font\ size=Augmenter la taille de police du tableau
+New\ article=Nouveau Article
+New\ book=Nouveau Book
+New\ entry=Nouvelle entrée
+New\ from\ plain\ text=Nouveau à partir de texte brut
+New\ inbook=Nouveau Inbook
+New\ mastersthesis=Nouveau Mastersthesis
+New\ phdthesis=Nouveau Phdthesis
+New\ proceedings=Nouveau Proceedings
+New\ unpublished=Nouveau Unpublished
+Next\ tab=Onglet suivant
+Preamble\ editor,\ store\ changes=Editeur de préambule, enregistrer les changements
+Previous\ tab=Onglet précédent
+Push\ to\ application=Envoyer vers le logiciel
+Refresh\ OpenOffice/LibreOffice=Rafraichir OpenOffice/LibreOffice
+Resolve\ duplicate\ BibTeX\ keys=Solutionner les clefs BibTeX dupliquées
+Save\ all=Enregistrer tout
+String\ dialog,\ add\ string=Chaine de dialogue, ajouter une chaine
+String\ dialog,\ remove\ string=Chaine de dialogue, supprimer une chaine
+Synchronize\ files=Synchroniser les fichiers
 Unabbreviate=Dés-abréger
-should_contain_a_protocol=doit_contenir_un_protocole
-Copy_preview=Copier_la_prévisualisation
-Automatically_setting_file_links=Définition_automatique_des_liens_de_fichier
-Regenerating_BibTeX_keys_according_to_metadata=Régénération_des_clefs_BibTeX_à_partir_des_métadonnées
-No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys=Aucune_métadonnée_dans_le_fichier_BibTeX._Les_clefs_n'ont_pas_pu_être_régénérées
-Regenerate_all_keys_for_the_entries_in_a_BibTeX_file=Régénére_toutes_les_clefs_pour_les_entrées_d'un_fichier_BibTeX
-Show_debug_level_messages=Afficher_les_messages_de_débogage
-Default_bibliography_mode=Mode_bibliographique_par_défaut
-New_%0_library_created.=Nouveau_fichier_%0_créé.
-Show_only_preferences_deviating_from_their_default_value=Afficher_uniquement_les_préférences_différentes_de_leur_valeur_par_défaut
-default=par_défaut
+should\ contain\ a\ protocol=doit contenir un protocole
+Copy\ preview=Copier la prévisualisation
+Automatically\ setting\ file\ links=Définition automatique des liens de fichier
+Regenerating\ BibTeX\ keys\ according\ to\ metadata=Régénération des clefs BibTeX à partir des métadonnées
+No\ meta\ data\ present\ in\ BIB\ file.\ Cannot\ regenerate\ BibTeX\ keys=Aucune métadonnée dans le fichier BibTeX. Les clefs n'ont pas pu être régénérées
+Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=Régénére toutes les clefs pour les entrées d'un fichier BibTeX
+Show\ debug\ level\ messages=Afficher les messages de débogage
+Default\ bibliography\ mode=Mode bibliographique par défaut
+New\ %0\ library\ created.=Nouveau fichier %0 créé.
+Show\ only\ preferences\ deviating\ from\ their\ default\ value=Afficher uniquement les préférences différentes de leur valeur par défaut
+default=par défaut
 key=clef
 type=type
 value=valeur
-Show_preferences=Afficher_les_préférences
-Save_actions=Enregistrer_les_actions
-Enable_save_actions=Autoriser_l'enregistrement_des_actions
+Show\ preferences=Afficher les préférences
+Save\ actions=Enregistrer les actions
+Enable\ save\ actions=Autoriser l'enregistrement des actions
 
-Other_fields=Autres_champs
-Show_remaining_fields=Afficher_les_champs_restants
+Other\ fields=Autres champs
+Show\ remaining\ fields=Afficher les champs restants
 
-link_should_refer_to_a_correct_file_path=Le_lien_doit_correspondre_à_un_chemin_de_fichier_valide
-abbreviation_detected=Abréviation_détectée
-wrong_entry_type_as_proceedings_has_page_numbers=Mauvais_type_d'entrée_car_le_proceedings_a_des_numéros_de_page
-Abbreviate_journal_names=Abrégez_les_noms_de_journaux
-Abbreviating...=Abrègement_en_cours
-Abbreviation_%s_for_journal_%s_already_defined.=L'abréviation_%s_pour_le_journal_%s_existe_déjà.
-Abbreviation_cannot_be_empty=L'abréviation_ne_peut_pas_être_vide
-Duplicated_Journal_Abbreviation=Abréviation_de_journal_dupliquée
-Duplicated_Journal_File=Fichier_de_journaux_dupliqué
-Error_Occurred=Une_erreur_s'est_produite
-Journal_file_%s_already_added=Le_fichier_de_journaux_%s_a_déjà_été_ajouté
-Name_cannot_be_empty=Le_nom_ne_peut_pas_être_vide
+link\ should\ refer\ to\ a\ correct\ file\ path=Le lien doit correspondre à un chemin de fichier valide
+abbreviation\ detected=Abréviation détectée
+wrong\ entry\ type\ as\ proceedings\ has\ page\ numbers=Mauvais type d'entrée car le proceedings a des numéros de page
+Abbreviate\ journal\ names=Abrégez les noms de journaux
+Abbreviating...=Abrègement en cours
+Abbreviation\ %s\ for\ journal\ %s\ already\ defined.=L'abréviation %s pour le journal %s existe déjà.
+Abbreviation\ cannot\ be\ empty=L'abréviation ne peut pas être vide
+Duplicated\ Journal\ Abbreviation=Abréviation de journal dupliquée
+Duplicated\ Journal\ File=Fichier de journaux dupliqué
+Error\ Occurred=Une erreur s'est produite
+Journal\ file\ %s\ already\ added=Le fichier de journaux %s a déjà été ajouté
+Name\ cannot\ be\ empty=Le nom ne peut pas être vide
 
-Adding_fetched_entries=Ajout_des_entrées_récupérées
-Display_keywords_appearing_in_ALL_entries=Afficher_les_mots-clefs_apparaissant_dans_TOUTES_les_entrées
-Display_keywords_appearing_in_ANY_entry=Afficher_les_mots-clefs_apparaissant_dans_AU_MOINS_UNE_entrée
-Fetching_entries_from_Inspire=Recherche_d'entrées_depuis_Inspire
-None_of_the_selected_entries_have_titles.=Aucune_des_entrées_sélectionnées_n'a_un_titre.
-None_of_the_selected_entries_have_BibTeX_keys.=Aucune_des_entrées_sélectionnées_n'a_une_clef_BibTeX.
-Unabbreviate_journal_names=Dés-abréger_des_noms_de_journaux
+Adding\ fetched\ entries=Ajout des entrées récupérées
+Display\ keywords\ appearing\ in\ ALL\ entries=Afficher les mots-clefs apparaissant dans TOUTES les entrées
+Display\ keywords\ appearing\ in\ ANY\ entry=Afficher les mots-clefs apparaissant dans AU MOINS UNE entrée
+Fetching\ entries\ from\ Inspire=Recherche d'entrées depuis Inspire
+None\ of\ the\ selected\ entries\ have\ titles.=Aucune des entrées sélectionnées n'a un titre.
+None\ of\ the\ selected\ entries\ have\ BibTeX\ keys.=Aucune des entrées sélectionnées n'a une clef BibTeX.
+Unabbreviate\ journal\ names=Dés-abréger des noms de journaux
 Unabbreviating...=Dés-abrègement...
 Usage=Usage
 
 
-Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.=Ajoute_des_accolades_{}_autour_des_acronymes,_des_noms_de_mois_et_des_pays_afin_de_préserver_leur_casse.
-Are_you_sure_you_want_to_reset_all_settings_to_default_values?=Etes-vous_sûr_de_vouloir_rétablir_toutes_les_valeurs_par_défaut_du_paramétrage_?
-Reset_preferences=Rétablir_les_préférences
-Ill-formed_entrytype_comment_in_BIB_file=Commentaire_de_type_d'entrées_mal_construit_dans_un_fichier_BIB
+Adds\ {}\ brackets\ around\ acronyms,\ month\ names\ and\ countries\ to\ preserve\ their\ case.=Ajoute des accolades {} autour des acronymes, des noms de mois et des pays afin de préserver leur casse.
+Are\ you\ sure\ you\ want\ to\ reset\ all\ settings\ to\ default\ values?=Etes-vous sûr de vouloir rétablir toutes les valeurs par défaut du paramétrage ?
+Reset\ preferences=Rétablir les préférences
+Ill-formed\ entrytype\ comment\ in\ BIB\ file=Commentaire de type d'entrées mal construit dans un fichier BIB
 
-Move_linked_files_to_default_file_directory_%0=Déplacer_les_fichiers_liés_vers_le_répertoire_par_défaut_%0
+Move\ linked\ files\ to\ default\ file\ directory\ %0=Déplacer les fichiers liés vers le répertoire par défaut %0
 
 Clipboard=Presse-papiers
-Could_not_paste_entry_as_text\:=L'entrée_n'a_pas_pu_être_collée_comme_du_texte_\:
-Do_you_still_want_to_continue?=Voulez-vous_continuer_?
-This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:=Cette_action_modifiera_le(s)_champ(s)_suivant(s)_dans_au_moins_une_entrée_chacune_\:
-This_could_cause_undesired_changes_to_your_entries.=Cela_pourrai_causer_des_changements_non_souhaités_dans_vos_entrées.
-Run_field_formatter\:=Lancer_le_formatage_des_champs_\:
-Table_font_size_is_%0=La_taille_de_police_de_la_table_est_%0
-%0_import_canceled=Importation_%0_annulée
-Internal_style=Style_interne
-Add_style_file=Ajouter_un_fichier_de_style
-Are_you_sure_you_want_to_remove_the_style?=Êtes-vous_sûr_de_vouloir_supprimer_le_style_?
-Current_style_is_'%0'=Le_style_actuel_est_'%0'
-Remove_style=Supprimer_le_style
-Select_one_of_the_available_styles_or_add_a_style_file_from_disk.=Sélectionner_l'un_des_styles_disponibles_ou_ajouter_un_fichier_de_style_depuis_le_disque.
-You_must_select_a_valid_style_file.=Vous_devez_sélectionner_un_fichier_de_style_valide.
+Could\ not\ paste\ entry\ as\ text\:=L'entrée n'a pas pu être collée comme du texte :
+Do\ you\ still\ want\ to\ continue?=Voulez-vous continuer ?
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=Cette action modifiera le(s) champ(s) suivant(s) dans au moins une entrée chacune :
+This\ could\ cause\ undesired\ changes\ to\ your\ entries.=Cela pourrai causer des changements non souhaités dans vos entrées.
+Run\ field\ formatter\:=Lancer le formatage des champs :
+Table\ font\ size\ is\ %0=La taille de police de la table est %0
+%0\ import\ canceled=Importation %0 annulée
+Internal\ style=Style interne
+Add\ style\ file=Ajouter un fichier de style
+Are\ you\ sure\ you\ want\ to\ remove\ the\ style?=Êtes-vous sûr de vouloir supprimer le style ?
+Current\ style\ is\ '%0'=Le style actuel est '%0'
+Remove\ style=Supprimer le style
+Select\ one\ of\ the\ available\ styles\ or\ add\ a\ style\ file\ from\ disk.=Sélectionner l'un des styles disponibles ou ajouter un fichier de style depuis le disque.
+You\ must\ select\ a\ valid\ style\ file.=Vous devez sélectionner un fichier de style valide.
 Reload=Recharger
 
-Capitalize=Convertir_en_majuscules
-Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.=Convertir_en_majuscules_tous_les_mots,_mais_convertir_les_articles,_prépositions_et_conjonctions_en_minuscules.
-Capitalize_the_first_word,_changes_other_words_to_lower_case.=Convertir_le_premier_mot_en_majuscules,_et_les_autres_mots_en_minuscules.
-Changes_all_letters_to_lower_case.=Convertit_toutes_les_lettres_en_minuscules.
-Changes_all_letters_to_upper_case.=Convertit_toutes_les_lettres_en_majuscules.
-Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.=Convertit_en_majuscules_la_première_lettre_de_tous_les_mots,_et_les_autres_lettres_en_minuscules.
-Cleans_up_LaTeX_code.=Nettoyer_le_code_LaTeX.
-Converts_HTML_code_to_LaTeX_code.=Convertit_le_code_HTML_en_code_LaTeX.
-Converts_HTML_code_to_Unicode.=Convertit_du_code_HTML_en_Unicode.
-Converts_LaTeX_encoding_to_Unicode_characters.=Convertit_l'encodage_LaTeX_en_caractères_Unicode.
-Converts_Unicode_characters_to_LaTeX_encoding.=Convertit_les_caractères_Unicode_en_encodage_LaTeX.
-Converts_ordinals_to_LaTeX_superscripts.=Convertit_les_numéros_ordinaux_en_exposants_LaTeX.
-Converts_units_to_LaTeX_formatting.=Convertit_les_unités_en_code_LaTeX.
-HTML_to_LaTeX=HTML_vers_LaTeX
-LaTeX_cleanup=Nettoyage_LaTeX
-LaTeX_to_Unicode=LaTeX_vers_Unicode
-Lower_case=Minuscule
-Minify_list_of_person_names=Raccourcir_la_liste_des_noms_de_personne
-Normalize_date=Harmonise_la_date
-Normalize_month=Harmonise_le_mois
-Normalize_month_to_BibTeX_standard_abbreviation.=Harmonise_le_mois_au_standard_abrégé_BibTeX.
-Normalize_names_of_persons=Harmonise_les_noms_de_personnes
-Normalize_page_numbers=Harmonise_les_numéros_de_pages
-Normalize_pages_to_BibTeX_standard.=Harmonise_les_pages_au_standard_BibTeX.
-Normalizes_lists_of_persons_to_the_BibTeX_standard.=Harmonise_les_listes_de_personnes_au_standard_BibTeX.
-Normalizes_the_date_to_ISO_date_format.=Harmonise_la_date_au_format_de_date_ISO.
-Ordinals_to_LaTeX_superscript=Numéros_ordinaux_vers_exposants_LaTeX
-Protect_terms=Protéger_les_termes
-Remove_enclosing_braces=Supprimer_les_paires_d'accolades
-Removes_braces_encapsulating_the_complete_field_content.=Supprimer_les_accolades_autour_d'un_contenu_de_champ_entier.
-Sentence_case=Casse_de_la_phrase
-Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".=Raccourcit_avec_"et_al."_les_listes_de_plus_de_deux_personnes.
-Title_case=Casse_du_titre
-Unicode_to_LaTeX=Unicode_vers_LaTeX
-Units_to_LaTeX=Unités_vers_LaTeX
-Upper_case=Majuscule
-Does_nothing.=Ne_fait_rien.
+Capitalize=Convertir en majuscules
+Capitalize\ all\ words,\ but\ converts\ articles,\ prepositions,\ and\ conjunctions\ to\ lower\ case.=Convertir en majuscules tous les mots, mais convertir les articles, prépositions et conjonctions en minuscules.
+Capitalize\ the\ first\ word,\ changes\ other\ words\ to\ lower\ case.=Convertir le premier mot en majuscules, et les autres mots en minuscules.
+Changes\ all\ letters\ to\ lower\ case.=Convertit toutes les lettres en minuscules.
+Changes\ all\ letters\ to\ upper\ case.=Convertit toutes les lettres en majuscules.
+Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=Convertit en majuscules la première lettre de tous les mots, et les autres lettres en minuscules.
+Cleans\ up\ LaTeX\ code.=Nettoyer le code LaTeX.
+Converts\ HTML\ code\ to\ LaTeX\ code.=Convertit le code HTML en code LaTeX.
+Converts\ HTML\ code\ to\ Unicode.=Convertit du code HTML en Unicode.
+Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=Convertit l'encodage LaTeX en caractères Unicode.
+Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=Convertit les caractères Unicode en encodage LaTeX.
+Converts\ ordinals\ to\ LaTeX\ superscripts.=Convertit les numéros ordinaux en exposants LaTeX.
+Converts\ units\ to\ LaTeX\ formatting.=Convertit les unités en code LaTeX.
+HTML\ to\ LaTeX=HTML vers LaTeX
+LaTeX\ cleanup=Nettoyage LaTeX
+LaTeX\ to\ Unicode=LaTeX vers Unicode
+Lower\ case=Minuscule
+Minify\ list\ of\ person\ names=Raccourcir la liste des noms de personne
+Normalize\ date=Harmonise la date
+Normalize\ month=Harmonise le mois
+Normalize\ month\ to\ BibTeX\ standard\ abbreviation.=Harmonise le mois au standard abrégé BibTeX.
+Normalize\ names\ of\ persons=Harmonise les noms de personnes
+Normalize\ page\ numbers=Harmonise les numéros de pages
+Normalize\ pages\ to\ BibTeX\ standard.=Harmonise les pages au standard BibTeX.
+Normalizes\ lists\ of\ persons\ to\ the\ BibTeX\ standard.=Harmonise les listes de personnes au standard BibTeX.
+Normalizes\ the\ date\ to\ ISO\ date\ format.=Harmonise la date au format de date ISO.
+Ordinals\ to\ LaTeX\ superscript=Numéros ordinaux vers exposants LaTeX
+Protect\ terms=Protéger les termes
+Remove\ enclosing\ braces=Supprimer les paires d'accolades
+Removes\ braces\ encapsulating\ the\ complete\ field\ content.=Supprimer les accolades autour d'un contenu de champ entier.
+Sentence\ case=Casse de la phrase
+Shortens\ lists\ of\ persons\ if\ there\ are\ more\ than\ 2\ persons\ to\ "et\ al.".=Raccourcit avec "et al." les listes de plus de deux personnes.
+Title\ case=Casse du titre
+Unicode\ to\ LaTeX=Unicode vers LaTeX
+Units\ to\ LaTeX=Unités vers LaTeX
+Upper\ case=Majuscule
+Does\ nothing.=Ne fait rien.
 Identity=Identité
-Clears_the_field_completely.=Vide_entièrement_le_champ.
-Directory_not_found=Répertoire_non_trouvé
-Main_file_directory_not_set\!=Répertoire_de_fichiers_principal_non_défini_!
-This_operation_requires_exactly_one_item_to_be_selected.=Cette_opération_nécessite_qu'un_unique_élément_soit_sélectionné.
-Importing_in_%0_format=Importation_au_format_%0
-Female_name=Nom_féminin
-Female_names=Noms_féminins
-Male_name=Nom_masculin
-Male_names=Noms_masculins
-Mixed_names=Noms_mixtes
-Neuter_name=Nom_neutre
-Neuter_names=Noms_neutres
+Clears\ the\ field\ completely.=Vide entièrement le champ.
+Directory\ not\ found=Répertoire non trouvé
+Main\ file\ directory\ not\ set\!=Répertoire de fichiers principal non défini !
+This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=Cette opération nécessite qu'un unique élément soit sélectionné.
+Importing\ in\ %0\ format=Importation au format %0
+Female\ name=Nom féminin
+Female\ names=Noms féminins
+Male\ name=Nom masculin
+Male\ names=Noms masculins
+Mixed\ names=Noms mixtes
+Neuter\ name=Nom neutre
+Neuter\ names=Noms neutres
 
-Determined_%0_for_%1_entries=%0_résolu_pour_%1_entrées
-Look_up_%0=Rechercher_%0
-Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3=Recherche_de_%0..._-_entrée_%1_sur_%2_-_%3_trouvé
+Determined\ %0\ for\ %1\ entries=%0 résolu pour %1 entrées
+Look\ up\ %0=Rechercher %0
+Looking\ up\ %0...\ -\ entry\ %1\ out\ of\ %2\ -\ found\ %3=Recherche de %0... - entrée %1 sur %2 - %3 trouvé
 
-Audio_CD=CD_audio
-British_patent=Brevet_britannique
-British_patent_request=Demande_de_brevet_britannique
-Candidate_thesis=Thèse_à_soutenir
+Audio\ CD=CD audio
+British\ patent=Brevet britannique
+British\ patent\ request=Demande de brevet britannique
+Candidate\ thesis=Thèse à soutenir
 Collaborator=Collaborateur
 Column=Colonne
 Compiler=Compilateur
 Continuator=Continuateur
-Data_CD=CD_de_données
+Data\ CD=CD de données
 Editor=Editeur
-European_patent=Brevet_européen
-European_patent_request=Demande_de_brevet_européen
+European\ patent=Brevet européen
+European\ patent\ request=Demande de brevet européen
 Founder=Fondateur
-French_patent=Brevet_français
-French_patent_request=Demande_de_brevet_français
-German_patent=Brevet_allemand
-German_patent_request=Demande_de_brevet_allemand
+French\ patent=Brevet français
+French\ patent\ request=Demande de brevet français
+German\ patent=Brevet allemand
+German\ patent\ request=Demande de brevet allemand
 Line=Ligne
-Master's_thesis=Mémoire_de_master
+Master's\ thesis=Mémoire de master
 Page=Page
 Paragraph=Paragraphe
 Patent=Brevet
-Patent_request=Demande_de_brevet
-PhD_thesis=Thèse_de_doctorat
+Patent\ request=Demande de brevet
+PhD\ thesis=Thèse de doctorat
 Redactor=Rédacteur
-Research_report=Rapport_de_recherche
+Research\ report=Rapport de recherche
 Reviser=Réviseur
 Section=Section
 Software=Logiciel
-Technical_report=Rapport_technique
-U.S._patent=Brevet_états-unien
-U.S._patent_request=Demande_de_brevet_états-unien
+Technical\ report=Rapport technique
+U.S.\ patent=Brevet états-unien
+U.S.\ patent\ request=Demande de brevet états-unien
 Verse=Verset
 
-change_entries_of_group=Changer_des_entrées_du_groupe
-odd_number_of_unescaped_'\#'=Nombre_impair_de_'\#'_non_échappé
+change\ entries\ of\ group=Changer des entrées du groupe
+odd\ number\ of\ unescaped\ '\#'=Nombre impair de '#' non échappé
 
-Plain_text=Texte_brut
-Show_diff=Montrer_les_différences
+Plain\ text=Texte brut
+Show\ diff=Montrer les différences
 character=caractère
 word=mot
-Show_symmetric_diff=Montre_les_différences_symétriques
-Copy_Version=Copier_la_version
+Show\ symmetric\ diff=Montre les différences symétriques
+Copy\ Version=Copier la version
 Developers=Développeurs
 Authors=Auteurs
 License=Licence
 
-HTML_encoded_character_found=Caractère_encodé_en_HTML_trouvé
-booktitle_ends_with_'conference_on'=le_titre_d'ouvrage_se_termine_par_'conference_on'
+HTML\ encoded\ character\ found=Caractère encodé en HTML trouvé
+booktitle\ ends\ with\ 'conference\ on'=le titre d'ouvrage se termine par 'conference on'
 
-All_external_files=Tous_les_fichiers_externes
+All\ external\ files=Tous les fichiers externes
 
-OpenOffice/LibreOffice_integration=Intégration_OpenOffice/LibreOffice
+OpenOffice/LibreOffice\ integration=Intégration OpenOffice/LibreOffice
 
-incorrect_control_digit=chiffre_de_contrôle_incorrect
-incorrect_format=format_incorrect
-Copied_version_to_clipboard=Version_copiée_dans_le_presse-papiers
+incorrect\ control\ digit=chiffre de contrôle incorrect
+incorrect\ format=format incorrect
+Copied\ version\ to\ clipboard=Version copiée dans le presse-papiers
 
-BibTeX_key=Clef_BibTeX
+BibTeX\ key=Clef BibTeX
 Message=Message
 
 
-MathSciNet_Review=Review_MathSciNet
-Reset_Bindings=Réinitialiser_les_associations
+MathSciNet\ Review=Review MathSciNet
+Reset\ Bindings=Réinitialiser les associations
 
-Decryption_not_supported.=Déchiffrement_non_supporté.
+Decryption\ not\ supported.=Déchiffrement non supporté.
 
-Cleared_'%0'_for_%1_entries=Réinitialisés_'%0'_pour_%1_entrées
-Set_'%0'_to_'%1'_for_%2_entries='%0'_mis_à_'%1'_pour_%2_entrées
-Toggled_'%0'_for_%1_entries='%0'_modifiée_pour_%1_entrées
+Cleared\ '%0'\ for\ %1\ entries=Réinitialisés '%0' pour %1 entrées
+Set\ '%0'\ to\ '%1'\ for\ %2\ entries='%0' mis à '%1' pour %2 entrées
+Toggled\ '%0'\ for\ %1\ entries='%0' modifiée pour %1 entrées
 
-Check_for_updates=Rechercher_des_mises_à_jour
-Download_update=Télécharger_la_mise_à_jour
-New_version_available=Nouvelle_version_disponible
-Installed_version=Version_installée
-Remind_me_later=Me_le_rappeler_plus_tard
-Ignore_this_update=Ignorer_cette_mise_à_jour
-Could_not_connect_to_the_update_server.=La_connexion_au_serveur_de_mise_à_jour_a_échoué.
-Please_try_again_later_and/or_check_your_network_connection.=Essayez_plus_tard_ou_vérifier_votre_connexion_réseau.
-To_see_what_is_new_view_the_changelog.=Pour_voir_les_nouveautés,_affichez_le_journal_des_modifications.
-A_new_version_of_JabRef_has_been_released.=Une_nouvelle_version_de_JabRef_a_été_publiée.
-JabRef_is_up-to-date.=JabRef_est_à_jour.
-Latest_version=Version_la_plus_récente
-Online_help_forum=Forum_d'aide_en_ligne
+Check\ for\ updates=Rechercher des mises à jour
+Download\ update=Télécharger la mise à jour
+New\ version\ available=Nouvelle version disponible
+Installed\ version=Version installée
+Remind\ me\ later=Me le rappeler plus tard
+Ignore\ this\ update=Ignorer cette mise à jour
+Could\ not\ connect\ to\ the\ update\ server.=La connexion au serveur de mise à jour a échoué.
+Please\ try\ again\ later\ and/or\ check\ your\ network\ connection.=Essayez plus tard ou vérifier votre connexion réseau.
+To\ see\ what\ is\ new\ view\ the\ changelog.=Pour voir les nouveautés, affichez le journal des modifications.
+A\ new\ version\ of\ JabRef\ has\ been\ released.=Une nouvelle version de JabRef a été publiée.
+JabRef\ is\ up-to-date.=JabRef est à jour.
+Latest\ version=Version la plus récente
+Online\ help\ forum=Forum d'aide en ligne
 Custom=Personnalisé
 
-Export_cited=Exporter_les_citées
-Unable_to_generate_new_library=Impossible_de_générer_un_nouveau_fichier
+Export\ cited=Exporter les citées
+Unable\ to\ generate\ new\ library=Impossible de générer un nouveau fichier
 
-Open_console=Ouvrir_la_console
-Use_default_terminal_emulator=Utilise_l'émulateur_de_terminal_par_défaut
-Execute_command=Lance_une_commande
-Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.=Note_\:_Utiliser_le_paramètre_%0_comme_localisation_du_fichier_ouverte.
-Executing_command_\"%0\"...=Exécution_de_la_commande_\"%0\"...
-Error_occured_while_executing_the_command_\"%0\".=Une_erreur_est_survenue_lors_de_l'exécution_de_la_commande_\"%0\".
-Reformat_ISSN=Reformater_l'ISSN
+Open\ console=Ouvrir la console
+Use\ default\ terminal\ emulator=Utilise l'émulateur de terminal par défaut
+Execute\ command=Lance une commande
+Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=Note : Utiliser le paramètre %0 comme localisation du fichier ouverte.
+Executing\ command\ \"%0\"...=Exécution de la commande \"%0\"...
+Error\ occured\ while\ executing\ the\ command\ \"%0\".=Une erreur est survenue lors de l'exécution de la commande \"%0\".
+Reformat\ ISSN=Reformater l'ISSN
 
-Countries_and_territories_in_English=Pays_et_territoires_en_anglais
-Electrical_engineering_terms=Termes_du_génie_électrique
+Countries\ and\ territories\ in\ English=Pays et territoires en anglais
+Electrical\ engineering\ terms=Termes du génie électrique
 Enabled=Activé
-Internal_list=List_interne
-Manage_protected_terms_files=Gérer_les_fichiers_des_termes_protégés
-Months_and_weekdays_in_English=Mois_et_jours_de_la_semaine_en_anglais
-The_text_after_the_last_line_starting_with_\#_will_be_used=Le_texte_après_la_dernière_ligne_commençant_par_\#_sera_utilisé
-Add_protected_terms_file=Ajouter_le_fichier_des_termes_protégés
-Are_you_sure_you_want_to_remove_the_protected_terms_file?=Etes-vous_sûr_de_vouloir_supprimer_le_fichier_des_termes_protégés_?
-Remove_protected_terms_file=Supprimer_le_fichier_des_termes_protégés
-Add_selected_text_to_list=Ajouter_le_texte_sélectionné_à_la_liste
-Add_{}_around_selected_text=Ajouter_{}_autour_du_texte_sélectionné
-Format_field=Formatter_le_champ
-New_protected_terms_file=Nouveau_fichier_de_termes_protégés
-change_field_%0_of_entry_%1_from_%2_to_%3=modifier_le_champ_%0_de_l'entrée_%1_de_%2_en_%3
-change_key_from_%0_to_%1=modifier_la_clef_de_%0_en_%1
-change_string_content_%0_to_%1=modifier_le_contenu_de_la_chaine_de_%0_en_%1
-change_string_name_%0_to_%1=modifier_le_nom_de_la_chaine_de_%0_en_%1
-change_type_of_entry_%0_from_%1_to_%2=modifier_le_type_d'entrée_0%_de_%1_en_%2
-insert_entry_%0=insèrer_l'entrée_%0
-insert_string_%0=insèrer_la_chaine_%0
-remove_entry_%0=supprimer_l'entrée_%0
-remove_string_%0=supprimer_la_chaine_%0
+Internal\ list=List interne
+Manage\ protected\ terms\ files=Gérer les fichiers des termes protégés
+Months\ and\ weekdays\ in\ English=Mois et jours de la semaine en anglais
+The\ text\ after\ the\ last\ line\ starting\ with\ \#\ will\ be\ used=Le texte après la dernière ligne commençant par # sera utilisé
+Add\ protected\ terms\ file=Ajouter le fichier des termes protégés
+Are\ you\ sure\ you\ want\ to\ remove\ the\ protected\ terms\ file?=Etes-vous sûr de vouloir supprimer le fichier des termes protégés ?
+Remove\ protected\ terms\ file=Supprimer le fichier des termes protégés
+Add\ selected\ text\ to\ list=Ajouter le texte sélectionné à la liste
+Add\ {}\ around\ selected\ text=Ajouter {} autour du texte sélectionné
+Format\ field=Formatter le champ
+New\ protected\ terms\ file=Nouveau fichier de termes protégés
+change\ field\ %0\ of\ entry\ %1\ from\ %2\ to\ %3=modifier le champ %0 de l'entrée %1 de %2 en %3
+change\ key\ from\ %0\ to\ %1=modifier la clef de %0 en %1
+change\ string\ content\ %0\ to\ %1=modifier le contenu de la chaine de %0 en %1
+change\ string\ name\ %0\ to\ %1=modifier le nom de la chaine de %0 en %1
+change\ type\ of\ entry\ %0\ from\ %1\ to\ %2=modifier le type d'entrée 0% de %1 en %2
+insert\ entry\ %0=insèrer l'entrée %0
+insert\ string\ %0=insèrer la chaine %0
+remove\ entry\ %0=supprimer l'entrée %0
+remove\ string\ %0=supprimer la chaine %0
 undefined=indéfini
-Cannot_get_info_based_on_given_%0\:_%1=Aucune_information_disponible_à_partir_de_ce_%0_\:_%1
-Get_BibTeX_data_from_%0=Récupérer_les_données_BibTEX_à_partir_du_%0
-No_%0_found=%0_non_trouvé
-Entry_from_%0=Entrée_à_partir_du_%0
-Merge_entry_with_%0_information=Fusionner_l'entrée_sur_la_base_des_informations_du_%0
-Updated_entry_with_info_from_%0=Entrée_mise_à_jour_à_partir_des_informations_du_%0
+Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=Aucune information disponible à partir de ce %0 : %1
+Get\ BibTeX\ data\ from\ %0=Récupérer les données BibTEX à partir du %0
+No\ %0\ found=%0 non trouvé
+Entry\ from\ %0=Entrée à partir du %0
+Merge\ entry\ with\ %0\ information=Fusionner l'entrée sur la base des informations du %0
+Updated\ entry\ with\ info\ from\ %0=Entrée mise à jour à partir des informations du %0
 
-Add_existing_file=Ajouter_un_fichier_existant
-Create_new_list=Créer_une_nouvelle_liste
-Remove_list=Supprimer_une_liste
-Full_journal_name=Nom_de_journal_complet
-Abbreviation_name=Nom_abrégé
+Add\ existing\ file=Ajouter un fichier existant
+Create\ new\ list=Créer une nouvelle liste
+Remove\ list=Supprimer une liste
+Full\ journal\ name=Nom de journal complet
+Abbreviation\ name=Nom abrégé
 
-No_abbreviation_files_loaded=Aucun_fichier_d'abréviation_n'est_chargé
+No\ abbreviation\ files\ loaded=Aucun fichier d'abréviation n'est chargé
 
-Loading_built_in_lists=Chargement_des_listes_internes
+Loading\ built\ in\ lists=Chargement des listes internes
 
-JabRef_built_in_list=Liste_interne_de_JabRef
-IEEE_built_in_list=List_interne_de_IEEE
+JabRef\ built\ in\ list=Liste interne de JabRef
+IEEE\ built\ in\ list=List interne de IEEE
 
-Event_log=Journal_des_évènements
-We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.=Nous_vous_donnons_à_présent_un_aperçu_du_fonctionnemment_interne_de_JabRef._Cette_information_pourrait_être_utile_pour_diagnostiquer_la_cause_du_problème._S'il_vous_plaît,_informez_les_développeurs_des_anomalies_rencontrées.
-Log_copied_to_clipboard.=Journal_copié_dans_le_presse-papiers.
-Copy_Log=Copier_le_journal
-Clear_Log=Vider_le_journal
-Report_Issue=Signaler_l'anomalie
-Issue_on_GitHub_successfully_reported.=Anomalie_signalé_avec_succès_sur_GitHub.
-Issue_report_successful=Signalement_de_l'anomalie_réussi
-Your_issue_was_reported_in_your_browser.=Votre_anomalie_a_été_affichée_dans_votre_navigateur.
-The_log_and_exception_information_was_copied_to_your_clipboard.=Le_journal_et_les_informations_d'anomalie_ont_été_copiées_dans_votre_presse-papier.
-Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.=SVP,_collez_ces_informations_(avec_Ctrl+V)_dans_la_description_de_l'anomalie.
+Event\ log=Journal des évènements
+We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef\'s\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=Nous vous donnons à présent un aperçu du fonctionnemment interne de JabRef. Cette information pourrait être utile pour diagnostiquer la cause du problème. S'il vous plaît, informez les développeurs des anomalies rencontrées.
+Log\ copied\ to\ clipboard.=Journal copié dans le presse-papiers.
+Copy\ Log=Copier le journal
+Clear\ Log=Vider le journal
+Report\ Issue=Signaler l'anomalie
+Issue\ on\ GitHub\ successfully\ reported.=Anomalie signalé avec succès sur GitHub.
+Issue\ report\ successful=Signalement de l'anomalie réussi
+Your\ issue\ was\ reported\ in\ your\ browser.=Votre anomalie a été affichée dans votre navigateur.
+The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=Le journal et les informations d'anomalie ont été copiées dans votre presse-papier.
+Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=SVP, collez ces informations (avec Ctrl+V) dans la description de l'anomalie.
 
 Connection=Connection
-Connecting...=Connexion_en_cours...
+Connecting...=Connexion en cours...
 Host=Hôte
 Port=Port
 Library=Fichier
 User=Utilisateur
-Connect=Connexion_automatique
-Connection_error=Erreur_de_connexion
-Connection_to_%0_server_established.=Connexion_au_serveur_%0_établie
-Required_field_"%0"_is_empty.=Le_champ_requis_"%0"_est_vide;
-%0_driver_not_available.=Pilote_%0_non_disponible.
-The_connection_to_the_server_has_been_terminated.=La_connexion_au_serveur_a_été_interrompue.
-Connection_lost.=Connexion_perdue.
+Connect=Connexion automatique
+Connection\ error=Erreur de connexion
+Connection\ to\ %0\ server\ established.=Connexion au serveur %0 établie
+Required\ field\ "%0"\ is\ empty.=Le champ requis "%0" est vide;
+%0\ driver\ not\ available.=Pilote %0 non disponible.
+The\ connection\ to\ the\ server\ has\ been\ terminated.=La connexion au serveur a été interrompue.
+Connection\ lost.=Connexion perdue.
 Reconnect=Reconnexion
-Work_offline=Travail_hors-ligne
-Working_offline.=Travail_hors-ligne.
-Update_refused.=Mise_à_jour_refusée;
-Update_refused=Mise_à_jour_refusée
-Local_entry=Entrée_locale
-Shared_entry=Entrée_partagée
-Update_could_not_be_performed_due_to_existing_change_conflicts.=La_mise_à_jour_n'a_pas_pu_être_effectuée_à_cause_de_conflits_dans_les_changements_existants
-You_are_not_working_on_the_newest_version_of_BibEntry.=Vous_ne_travaillez_pas_sur_la_plus_récente_version_de_cette_entrée.
-Local_version\:_%0=Version_locale_\:_%0
-Shared_version\:_%0=Version_partagée_\:_%0
-Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.=SVP,_fusionnez_l'entrée_partagée_avec_la_vôtre_et_cliquez_sur_"Fusionner_les_entr\u00e9es"_pour_résoudre_ce_problème.
-Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?=Annuler_cette_operation_laissera_vos_changements_désynchronisés._Annuler_quand_même_?
-Shared_entry_is_no_longer_present=L'entrée_partagée_n'est_plus_présente
-The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.=L'entrée_sur_laquelle_vous_travaillez_actuellement_a_été_supprimée_de_la_base_partagée.
-You_can_restore_the_entry_using_the_"Undo"_operation.=Vous_pouvez_restaurer_l'entrée_en_utilisant_l'opération_"Annuler".
-Remember_password?=Mémoriser_le_mot_de_passe_?
-You_are_already_connected_to_a_database_using_entered_connection_details.=Vous_êtes_déjà_connecté_à_un_fichier_en_utilisant_les_informations_de_connexion_entrées.
+Work\ offline=Travail hors-ligne
+Working\ offline.=Travail hors-ligne.
+Update\ refused.=Mise à jour refusée;
+Update\ refused=Mise à jour refusée
+Local\ entry=Entrée locale
+Shared\ entry=Entrée partagée
+Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=La mise à jour n'a pas pu être effectuée à cause de conflits dans les changements existants
+You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=Vous ne travaillez pas sur la plus récente version de cette entrée.
+Local\ version\:\ %0=Version locale : %0
+Shared\ version\:\ %0=Version partagée : %0
+Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=SVP, fusionnez l'entrée partagée avec la vôtre et cliquez sur "Fusionner les entr\u00e9es" pour résoudre ce problème.
+Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=Annuler cette operation laissera vos changements désynchronisés. Annuler quand même ?
+Shared\ entry\ is\ no\ longer\ present=L'entrée partagée n'est plus présente
+The\ BibEntry\ you\ currently\ work\ on\ has\ been\ deleted\ on\ the\ shared\ side.=L'entrée sur laquelle vous travaillez actuellement a été supprimée de la base partagée.
+You\ can\ restore\ the\ entry\ using\ the\ "Undo"\ operation.=Vous pouvez restaurer l'entrée en utilisant l'opération "Annuler".
+Remember\ password?=Mémoriser le mot de passe ?
+You\ are\ already\ connected\ to\ a\ database\ using\ entered\ connection\ details.=Vous êtes déjà connecté à un fichier en utilisant les informations de connexion entrées.
 
-Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?=Citation_impossible_sans_clef_BibTeX._Générer_les_clefs_maintenant?
-New_technical_report=Nouveau_rapport_technique
+Cannot\ cite\ entries\ without\ BibTeX\ keys.\ Generate\ keys\ now?=Citation impossible sans clef BibTeX. Générer les clefs maintenant?
+New\ technical\ report=Nouveau rapport technique
 
-%0_file=%0_fichier
-Custom_layout_file=Fichier_de_mise_en_page_personnalisée
-Protected_terms_file=Fichier_des_termes_protégés
-Style_file=Fichier_de_style
+%0\ file=%0 fichier
+Custom\ layout\ file=Fichier de mise en page personnalisée
+Protected\ terms\ file=Fichier des termes protégés
+Style\ file=Fichier de style
 
-Open_OpenOffice/LibreOffice_connection=Ouvrir_une_connexion_OpenOffice/LibreOffice
-You_must_enter_at_least_one_field_name=Vous_devez_entrer_au_moins_un_nom_de_champ
-Non-ASCII_encoded_character_found=Caractère_ayant_un_encodage_non-ASCII_trouvé
-Toggle_web_search_interface=Afficher/Masquer_l'interface_de_recherche_internet
-Background_color_for_resolved_fields=Couleur_de_fond_pour_les_champs_traités
-Color_code_for_resolved_fields=Code_couleur_pour_les_champs_traités
-%0_files_found=%0_fichiers_trouvés
-%0_of_%1=%0_de_%1
-One_file_found=Un_fichier_trouvé
-The_import_finished_with_warnings\:=L'importation_s'est_terminée_avec_des_messages_d'avertissement_\:
-There_was_one_file_that_could_not_be_imported.=Un_fichier_n'a_pas_pu_être_importé.
-There_were_%0_files_which_could_not_be_imported.=%0_fichiers_n'ont_pas_pu_être_importés.
+Open\ OpenOffice/LibreOffice\ connection=Ouvrir une connexion OpenOffice/LibreOffice
+You\ must\ enter\ at\ least\ one\ field\ name=Vous devez entrer au moins un nom de champ
+Non-ASCII\ encoded\ character\ found=Caractère ayant un encodage non-ASCII trouvé
+Toggle\ web\ search\ interface=Afficher/Masquer l'interface de recherche internet
+Background\ color\ for\ resolved\ fields=Couleur de fond pour les champs traités
+Color\ code\ for\ resolved\ fields=Code couleur pour les champs traités
+%0\ files\ found=%0 fichiers trouvés
+%0\ of\ %1=%0 de %1
+One\ file\ found=Un fichier trouvé
+The\ import\ finished\ with\ warnings\:=L'importation s'est terminée avec des messages d'avertissement :
+There\ was\ one\ file\ that\ could\ not\ be\ imported.=Un fichier n'a pas pu être importé.
+There\ were\ %0\ files\ which\ could\ not\ be\ imported.=%0 fichiers n'ont pas pu être importés.
 
-Migration_help_information=Aide_sur_la_migration
-Entered_database_has_obsolete_structure_and_is_no_longer_supported.=Ce_fichier_a_une_structure_obsolète_qui_n'est_plus_gérée.
-However,_a_new_database_was_created_alongside_the_pre-3.6_one.=Ainsi,_un_nouveau_fichier_a_été_créée_en_parallèle_de_celle_antérieure_à_la_version_3.6.
-Click_here_to_learn_about_the_migration_of_pre-3.6_databases.=Cliquer_ici_pour_plus_de_détails_sur_la_migration_des_fichiers_antérieurs_à_la_version_3.6.
-Opens_JabRef's_Facebook_page=Ouvre_la_page_Facebook_de_JabRef
-Opens_JabRef's_blog=Ouvre_le_blog_de_JabRef
-Opens_JabRef's_website=Ouvre_le_site_Internet_de_JabRef
-Opens_a_link_where_the_current_development_version_can_be_downloaded=Ouvre_un_lien_d'où-la_version_de_développement_actuelle_peut_être_téléchargée
-See_what_has_been_changed_in_the_JabRef_versions=Afficher_les_changements_dans_les_versions_de_JabRef
-Referenced_BibTeX_key_does_not_exist=La_clef_BibTeX_référencée_n'existe_pas
-Finished_downloading_full_text_document_for_entry_%0.=Téléchargement_terminé_pour_le_texte_intégral_de_l'entrée_%0.
-Full_text_document_download_failed_for_entry_%0.=Echec_du_téléchargement_pour_le_texte_intégral_de_l'entrée_%0.
-Look_up_full_text_documents=Recherche_des_textes_intégraux
-You_are_about_to_look_up_full_text_documents_for_%0_entries.=Vous_allez_rechercher_les_textes_intégraux_pour_%0_entrées.
-last_four_nonpunctuation_characters_should_be_numerals=Les_4_derniers_caractères_devraient_être_des_chiffres
+Migration\ help\ information=Aide sur la migration
+Entered\ database\ has\ obsolete\ structure\ and\ is\ no\ longer\ supported.=Ce fichier a une structure obsolète qui n'est plus gérée.
+However,\ a\ new\ database\ was\ created\ alongside\ the\ pre-3.6\ one.=Ainsi, un nouveau fichier a été créée en parallèle de celle antérieure à la version 3.6.
+Click\ here\ to\ learn\ about\ the\ migration\ of\ pre-3.6\ databases.=Cliquer ici pour plus de détails sur la migration des fichiers antérieurs à la version 3.6.
+Opens\ JabRef's\ Facebook\ page=Ouvre la page Facebook de JabRef
+Opens\ JabRef's\ blog=Ouvre le blog de JabRef
+Opens\ JabRef's\ website=Ouvre le site Internet de JabRef
+Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=Ouvre un lien d'où-la version de développement actuelle peut être téléchargée
+See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=Afficher les changements dans les versions de JabRef
+Referenced\ BibTeX\ key\ does\ not\ exist=La clef BibTeX référencée n'existe pas
+Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=Téléchargement terminé pour le texte intégral de l'entrée %0.
+Full\ text\ document\ download\ failed\ for\ entry\ %0.=Echec du téléchargement pour le texte intégral de l'entrée %0.
+Look\ up\ full\ text\ documents=Recherche des textes intégraux
+You\ are\ about\ to\ look\ up\ full\ text\ documents\ for\ %0\ entries.=Vous allez rechercher les textes intégraux pour %0 entrées.
+last\ four\ nonpunctuation\ characters\ should\ be\ numerals=Les 4 derniers caractères devraient être des chiffres
 
 Author=Auteur
 Date=Date
-File_annotations=Annotations_de_fichier
-Show_file_annotations=Montrer_les_annotations_de_fichier
-Adobe_Acrobat_Reader=Adobe_Acrobat_Reader
-Sumatra_Reader=Sumatra_Reader
+File\ annotations=Annotations de fichier
+Show\ file\ annotations=Montrer les annotations de fichier
+Adobe\ Acrobat\ Reader=Adobe Acrobat Reader
+Sumatra\ Reader=Sumatra Reader
 shared=partagé
-should_contain_an_integer_or_a_literal=doit_contenir_un_nombre_entier_ou_en_toutes_lettres
-should_have_the_first_letter_capitalized=doit_avoir_une_première_lettre_en_majuscule
+should\ contain\ an\ integer\ or\ a\ literal=doit contenir un nombre entier ou en toutes lettres
+should\ have\ the\ first\ letter\ capitalized=doit avoir une première lettre en majuscule
 Tools=Outils
-What\'s_new_in_this_version?=Quoi_de_neuf_dans_cette_version_?
-Want_to_help?=Vous_voulez_aider_?
-Make_a_donation=Faire_un_don
-get_involved=S'impliquer
-Used_libraries=Bibliothèques_utilisées
-Existing_file=Fichier_existant
+What\'s\ new\ in\ this\ version?=Quoi de neuf dans cette version ?
+Want\ to\ help?=Vous voulez aider ?
+Make\ a\ donation=Faire un don
+get\ involved=S'impliquer
+Used\ libraries=Bibliothèques utilisées
+Existing\ file=Fichier existant
 
 ID=Identifiant
-ID_type=Type_d'identifiant
-ID-based_entry_generator=Générateur_d'entrée_basé_sur_l'identifiant
-Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=L'outil_de_recherche_%0_n'a_pas_trouvé_d'entrée_pour_l'identifiant_%1
+ID\ type=Type d'identifiant
+ID-based\ entry\ generator=Générateur d'entrée basé sur l'identifiant
+Fetcher\ '%0'\ did\ not\ find\ an\ entry\ for\ id\ '%1'.=L'outil de recherche %0 n'a pas trouvé d'entrée pour l'identifiant %1
 
-Select_first_entry=Sélectionner_la_première_entrée
-Select_last_entry=Sélectionner_la_dernière_entrée
+Select\ first\ entry=Sélectionner la première entrée
+Select\ last\ entry=Sélectionner la dernière entrée
 
-Invalid_ISBN\:_'%0'.=ISBN_invalide_\:_%0.
-should_be_an_integer_or_normalized=devrait_être_un_entier_ou_une_abréviation_standard
-should_be_normalized=devrait_être_une_abréviation_standard
+Invalid\ ISBN\:\ '%0'.=ISBN invalide : %0.
+should\ be\ an\ integer\ or\ normalized=devrait être un entier ou une abréviation standard
+should\ be\ normalized=devrait être une abréviation standard
 
-Empty_search_ID=Identifiant_de_recherche_vide
-The_given_search_ID_was_empty.=L'Identifiant_de_recherche_entré_était_vide.
-Copy_BibTeX_key_and_link=Copier_la_clef_BibTeX_et_le_lien
-empty_BibTeX_key=Clef_BibTeX_vide
-biblatex_field_only=Champ_biblatex_uniquement
+Empty\ search\ ID=Identifiant de recherche vide
+The\ given\ search\ ID\ was\ empty.=L'Identifiant de recherche entré était vide.
+Copy\ BibTeX\ key\ and\ link=Copier la clef BibTeX et le lien
+empty\ BibTeX\ key=Clef BibTeX vide
+biblatex\ field\ only=Champ biblatex uniquement
 
-Error_while_generating_fetch_URL=Erreur_lors_de_la_créatio_de_l'URL_de_recherche
-Error_while_parsing_ID_list=Erreur_lors_du_traitement_de_la_liste_des_identifiants
-Unable_to_get_PubMed_IDs=Impossible_d'obtenir_les_identifiants_PubMed
-Backup_found=Sauvegarde_trouvée
-A_backup_file_for_'%0'_was_found.=Un_fichier_de_sauvegarde_a_été_trouvé_pour_'%0'.
-This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.=Cela_pourrait_indiquer_que_JabRef_ne_s'est_pas_fermé_proprement_lors_de_la_dernière_utilisation_du_fichier.
-Do_you_want_to_recover_the_library_from_the_backup_file?=Voulez-vous_récupérer_le_fichier_à_partir_du_fichier_de_sauvegarde_?
-Firstname_Lastname=Prénom_Nom
+Error\ while\ generating\ fetch\ URL=Erreur lors de la créatio de l'URL de recherche
+Error\ while\ parsing\ ID\ list=Erreur lors du traitement de la liste des identifiants
+Unable\ to\ get\ PubMed\ IDs=Impossible d'obtenir les identifiants PubMed
+Backup\ found=Sauvegarde trouvée
+A\ backup\ file\ for\ '%0'\ was\ found.=Un fichier de sauvegarde a été trouvé pour '%0'.
+This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Cela pourrait indiquer que JabRef ne s'est pas fermé proprement lors de la dernière utilisation du fichier.
+Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Voulez-vous récupérer le fichier à partir du fichier de sauvegarde ?
+Firstname\ Lastname=Prénom Nom
 
-Recommended_for_%0=Recommandé_pour_%0
-Show_'Related_Articles'_tab=Afficher_l'onglet_'Articles_liés'
-This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=La_limitation_de_trafic_de_Google_Scholar_pourrait_avoir_été_atteinte_(voir_l'aide_pour_plus_de_détails).
+Recommended\ for\ %0=Recommandé pour %0
+Show\ 'Related\ Articles'\ tab=Afficher l'onglet 'Articles liés'
+This\ might\ be\ caused\ by\ reaching\ the\ traffic\ limitation\ of\ Google\ Scholar\ (see\ 'Help'\ for\ details).=La limitation de trafic de Google Scholar pourrait avoir été atteinte (voir l'aide pour plus de détails).
 
-Could_not_open_website.=Le_site_internet_n'a_pas_pu_être_ouvert.
-Problem_downloading_from_%1=Problème_de_téléchargement_à_partir_de_%1
+Could\ not\ open\ website.=Le site internet n'a pas pu être ouvert.
+Problem\ downloading\ from\ %1=Problème de téléchargement à partir de %1
 
-File_directory_pattern=Modèle_de_répertoire_de_fichiers
-Update_with_bibliographic_information_from_the_web=Mettre_à_jour_avec_les_informations_bibliographiques_trouvées_sur_le_web
+File\ directory\ pattern=Modèle de répertoire de fichiers
+Update\ with\ bibliographic\ information\ from\ the\ web=Mettre à jour avec les informations bibliographiques trouvées sur le web
 
-Could_not_find_any_bibliographic_information.=Aucune_information_bibliographique_n'a_été_trouvée.
-BibTeX_key_deviates_from_generated_key=La_clef_BibTeX_diffère_de_la_clef_générée
-DOI_%0_is_invalid=Le_DOI_%0_est_invalide
+Could\ not\ find\ any\ bibliographic\ information.=Aucune information bibliographique n'a été trouvée.
+BibTeX\ key\ deviates\ from\ generated\ key=La clef BibTeX diffère de la clef générée
+DOI\ %0\ is\ invalid=Le DOI %0 est invalide
 
-Select_all_customized_types_to_be_stored_in_local_preferences=Sélectionner_tous_les_types_personnalisés_pour_les_stocker_dans_les_préférences_locales
-Currently_unknown=Actuellement_inconnue
-Different_customization,_current_settings_will_be_overwritten=Personnalisation_différente,_les_paramètres_actuels_seront_écrasés
+Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences=Sélectionner tous les types personnalisés pour les stocker dans les préférences locales
+Currently\ unknown=Actuellement inconnue
+Different\ customization,\ current\ settings\ will\ be\ overwritten=Personnalisation différente, les paramètres actuels seront écrasés
 
-Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX=Le_type_d'entrée_%0_est_uniquement_défini_pour_biblatex_et_pas_pour_BibTeX
-Jump_to_entry=Aller_à_cette_entrée
+Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=Le type d'entrée %0 est uniquement défini pour biblatex et pas pour BibTeX
+Jump\ to\ entry=Aller à cette entrée
 
-Copied_%0_citations.=%0_citations_copiées
+Copied\ %0\ citations.=%0 citations copiées
 Copying...=Copie...
 
-journal_not_found_in_abbreviation_list=journal_non_trouvé_da	ns_la_liste_d'abbréviations
-Unhandled_exception_occurred.=Une_exception_non_gérée_est_survenue.
+journal\ not\ found\ in\ abbreviation\ list=journal non trouvé da	ns la liste d'abbréviations
+Unhandled\ exception\ occurred.=Une exception non gérée est survenue.
 
-strings_included=chaînes_incluses
-Color_for_disabled_icons=Couleur_des_icones_désactivés
-Color_for_enabled_icons=Couleur_des_icones_activés
-Size_of_large_icons=Taille_des_grands_icones
-Size_of_small_icons=Taille_des_petits_icones
-Default_table_font_size=Taille_par_défaut_des_police_du_tableau
-Escape_underscores=Echapper_les_soulignements
+strings\ included=chaînes incluses
+Color\ for\ disabled\ icons=Couleur des icones désactivés
+Color\ for\ enabled\ icons=Couleur des icones activés
+Size\ of\ large\ icons=Taille des grands icones
+Size\ of\ small\ icons=Taille des petits icones
+Default\ table\ font\ size=Taille par défaut des police du tableau
+Escape\ underscores=Echapper les soulignements
 Color=Couleur
-Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=S'il_vous_plaît,_Ajouter_si_possible_toutes_les_étapes_permettant_de_reproduire_cette_anomalie.
-Fit_width=Ajuster_à_la_largeur
-Fit_a_single_page=Ajuster_à_la_page
-Zoom_in=Zoomer
-Zoom_out=Dézoomer
-Previous_page=Page_précédente
-Next_page=Page_suivante
-Document_viewer=Afficheur_de_document
+Please\ also\ add\ all\ steps\ to\ reproduce\ this\ issue,\ if\ possible.=S'il vous plaît, Ajouter si possible toutes les étapes permettant de reproduire cette anomalie.
+Fit\ width=Ajuster à la largeur
+Fit\ a\ single\ page=Ajuster à la page
+Zoom\ in=Zoomer
+Zoom\ out=Dézoomer
+Previous\ page=Page précédente
+Next\ page=Page suivante
+Document\ viewer=Afficheur de document
 Live=Actif
 Locked=Vérrouillé
-Show_document_viewer=Ouvre_l'afficheur_de_document
-Show_the_document_of_the_currently_selected_entry.=Affiche_le_document_de_l'entrée_sélectionnée.
-Show_this_document_until_unlocked.=Affiche_le_document_jusqu'à_déverrouillage.
-Set_current_user_name_as_owner.=Définir_l'utilisateur_actuel_comme_propriétaire.
+Show\ document\ viewer=Ouvre l'afficheur de document
+Show\ the\ document\ of\ the\ currently\ selected\ entry.=Affiche le document de l'entrée sélectionnée.
+Show\ this\ document\ until\ unlocked.=Affiche le document jusqu'à déverrouillage.
+Set\ current\ user\ name\ as\ owner.=Définir l'utilisateur actuel comme propriétaire.
 
-Sort_all_subgroups_(recursively)=Trier_les_sous-groupes_(récursivement)
-Collect_and_share_telemetry_data_to_help_improve_JabRef.=Collecter_et_partager_les_données_de_télémétrie_pour_contribuer_à_l'amélioration_de_JabRef
-Don't_share=Ne_pas_partager
-Share_anonymous_statistics=Partager_anonymement_les_statistiques
-Telemetry\:_Help_make_JabRef_better=Télémétrie_:_contribue_à_l'amélioration_de_JabRef
-To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.=Pour_améliorer_l'ergonomie_pour_l'utilisateur,_nous_souhaiterions_collecter_des_statistiques_anonymisées_sur_les_fonctionnalité_que_vous_utilisez._Nous_n'enregistrerons_que_les_fonctionnalités_que_vous_utilisés_et_leur_fréquence_d'utiliations._Nous_n'enregistrerons_jamais_des_données_personneles_ni_le_contenu_de_vos_entrées_bibliographiques._Si_vous_choisissez_d'autoriser_la_collecte_des_données,_vous_pourrez_plus_tard_l'interdire_via_Options_->_Préférences_->_Géneral.
-This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?=Ce_fichier_a_été_trouvé_automatiquement._Voulez-vous_le_lier_à_cette_entrée_?
-Names_are_not_in_the_standard_%0_format.=Des_noms_ne_sont_pas_au_standard_du_format_%0.
+Sort\ all\ subgroups\ (recursively)=Trier les sous-groupes (récursivement)
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=Collecter et partager les données de télémétrie pour contribuer à l'amélioration de JabRef
+Don't\ share=Ne pas partager
+Share\ anonymous\ statistics=Partager anonymement les statistiques
+Telemetry\:\ Help\ make\ JabRef\ better=Télémétrie : contribue à l'amélioration de JabRef
+To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ statistics\ on\ the\ features\ you\ use.\ We\ will\ only\ record\ what\ features\ you\ access\ and\ how\ often\ you\ do\ it.\ We\ will\ neither\ collect\ any\ personal\ data\ nor\ the\ content\ of\ bibliographic\ items.\ If\ you\ choose\ to\ allow\ data\ collection,\ you\ can\ later\ disable\ it\ via\ Options\ ->\ Preferences\ ->\ General.=Pour améliorer l'ergonomie pour l'utilisateur, nous souhaiterions collecter des statistiques anonymisées sur les fonctionnalité que vous utilisez. Nous n'enregistrerons que les fonctionnalités que vous utilisés et leur fréquence d'utiliations. Nous n'enregistrerons jamais des données personneles ni le contenu de vos entrées bibliographiques. Si vous choisissez d'autoriser la collecte des données, vous pourrez plus tard l'interdire via Options -> Préférences -> Géneral.
+This\ file\ was\ found\ automatically.\ Do\ you\ want\ to\ link\ it\ to\ this\ entry?=Ce fichier a été trouvé automatiquement. Voulez-vous le lier à cette entrée ?
+Names\ are\ not\ in\ the\ standard\ %0\ format.=Des noms ne sont pas au standard du format %0.
 
-Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.=Supprimer_définitivement_le_ficher_sélectionné_du_disque,_ou_effacer_simplement_le_fichier_de_cette_entrée_?_Presser_Suppr_supprimera_définitivement_ce_fichier_du_disque.
-Delete_'%0'=Supprimer_'%0'
-Delete_from_disk=Supprimer_du_disque
-Remove_from_entry=Effacer_de_l'entrée
-The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.=Le_nom_du_groupe_contient_le_séparateur_de_mot-clef_"%0"_et_ne_fonctionnera_probablement_donc_pas_comme_attendu.
-There_exists_already_a_group_with_the_same_name.=Un_groupe_portant_ce_nom_existe_déjà.
+Delete\ the\ selected\ file\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ file\ permanently\ from\ disk.=Supprimer définitivement le ficher sélectionné du disque, ou effacer simplement le fichier de cette entrée ? Presser Suppr supprimera définitivement ce fichier du disque.
+Delete\ '%0'=Supprimer '%0'
+Delete\ from\ disk=Supprimer du disque
+Remove\ from\ entry=Effacer de l'entrée
+The\ group\ name\ contains\ the\ keyword\ separator\ "%0"\ and\ thus\ probably\ does\ not\ work\ as\ expected.=Le nom du groupe contient le séparateur de mot-clef "%0" et ne fonctionnera probablement donc pas comme attendu.
+There\ exists\ already\ a\ group\ with\ the\ same\ name.=Un groupe portant ce nom existe déjà.
 
-Copy_linked_files_to_folder...=Copier_les_fichiers_liés_dans_un_répertoire...
-Copied_file_successfully=Fichier_copié_avec_succès
-Copying_files...=Copie_des_fichiers...
-Copying_file_%0_of_entry_%1=Copie_du_fichier_%0_de_l'entrée_%1
-Finished_copying=Copie_terminée
-Could_not_copy_file=Le_fichier_n'a_pas_pu_être_copié
-Copied_%0_files_of_%1_sucessfully_to_%2=0%_fichiers_copiés_de_%1_avec_succès_vers_%2
-Rename_failed=Échec_du_renommage
-JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.=JabRef_ne_peut_pas_accéder_au_fichier_parce_qu'il_est_utilisé_par_un_autre_processus.
-Show_console_output_(only_necessary_when_the_launcher_is_used)=Afficher_la_sortie_de_la_console_(uniquement_nécessaire_quand_le_lanceur_est_utilisé)
+Copy\ linked\ files\ to\ folder...=Copier les fichiers liés dans un répertoire...
+Copied\ file\ successfully=Fichier copié avec succès
+Copying\ files...=Copie des fichiers...
+Copying\ file\ %0\ of\ entry\ %1=Copie du fichier %0 de l'entrée %1
+Finished\ copying=Copie terminée
+Could\ not\ copy\ file=Le fichier n'a pas pu être copié
+Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=0% fichiers copiés de %1 avec succès vers %2
+Rename\ failed=Échec du renommage
+JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=JabRef ne peut pas accéder au fichier parce qu'il est utilisé par un autre processus.
+Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=Afficher la sortie de la console (uniquement nécessaire quand le lanceur est utilisé)
 
-Remove_line_breaks=Supprimer_les_sauts_de_ligne
-Removes_all_line_breaks_in_the_field_content.=Supprime_tous_les_sauts_de_ligne_du_contenu_d'un_champ
-Checking_integrity...=Vérification_d'intégrité...
+Remove\ line\ breaks=Supprimer les sauts de ligne
+Removes\ all\ line\ breaks\ in\ the\ field\ content.=Supprime tous les sauts de ligne du contenu d'un champ
+Checking\ integrity...=Vérification d'intégrité...
 
-Remove_hyphenated_line_breaks=Suppression_des_sauts_de_ligne_associé_à_un_tiret
-Removes_all_hyphenated_line_breaks_in_the_field_content.=Supprime_du_contenu_du_champ_tous_les_sauts_de_ligne_associés_à_un_tiret
-Note_that_currently,_JabRef_does_not_run_with_Java_9.=Notez_qu'actuellement,_JabRef_ne_fonctionne_pas_avec_Java_9.
-Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.=Votre_version_actuelle_de_Java_(%0)_n'est_pas_supportée._Installez_la_version_%1_ou_supérieure,_s'il_vous_plaît.
+Remove\ hyphenated\ line\ breaks=Suppression des sauts de ligne associé à un tiret
+Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=Supprime du contenu du champ tous les sauts de ligne associés à un tiret
+Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=Notez qu'actuellement, JabRef ne fonctionne pas avec Java 9.
+Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=Votre version actuelle de Java (%0) n'est pas supportée. Installez la version %1 ou supérieure, s'il vous plaît.

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -3,156 +3,156 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-%0_contains_the_regular_expression_<b>%1</b>=%0_mengandung_Ekspresi_Reguler_<b>%1</b>
+%0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 mengandung Ekspresi Reguler <b>%1</b>
 
-%0_contains_the_term_<b>%1</b>=%_mengandung_istilah_<b>%1</b>
+%0\ contains\ the\ term\ <b>%1</b>=% mengandung istilah <b>%1</b>
 
-%0_doesn't_contain_the_regular_expression_<b>%1</b>=%0_tidak_mengandung_Ekspresi_Reguler_<b>%1</b>
+%0\ doesn't\ contain\ the\ regular\ expression\ <b>%1</b>=%0 tidak mengandung Ekspresi Reguler <b>%1</b>
 
-%0_doesn't_contain_the_term_<b>%1</b>=%0_tidak_mengandung_istilah_<b>%1</b>
+%0\ doesn't\ contain\ the\ term\ <b>%1</b>=%0 tidak mengandung istilah <b>%1</b>
 
-%0_export_successful=%0_ekspor_berhasil
+%0\ export\ successful=%0 ekspor berhasil
 
-%0_matches_the_regular_expression_<b>%1</b>=%0_sesuai_dengan_Ekspresi_Reguler_<b>%1</b>
+%0\ matches\ the\ regular\ expression\ <b>%1</b>=%0 sesuai dengan Ekspresi Reguler <b>%1</b>
 
-%0_matches_the_term_<b>%1</b>=%0_sesuai_dengan_istilah_<b>%1</b>
+%0\ matches\ the\ term\ <b>%1</b>=%0 sesuai dengan istilah <b>%1</b>
 
-<field_name>=<nama_bidang>
-<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>=<HTML>tidak_bisa_menemukan_berkas_'%0'<BR>tautan_dari_entri_'%1'</HTML>
+<field\ name>=<nama bidang>
+<HTML>Could\ not\ find\ file\ '%0'<BR>linked\ from\ entry\ '%1'</HTML>=<HTML>tidak bisa menemukan berkas '%0'<BR>tautan dari entri '%1'</HTML>
 
 <select>=<pilih>
 
-<select_word>=<pilih_kata>
-Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)=Singkat_nama_jurnal_dari_entri_pilihan_(Singkatan_ISO)
-Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)=Singkat_nama_jurnal_dari_entri_pilihan_(Singkatan_MEDLINE)
+<select\ word>=<pilih kata>
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (ISO\ abbreviation)=Singkat nama jurnal dari entri pilihan (Singkatan ISO)
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (MEDLINE\ abbreviation)=Singkat nama jurnal dari entri pilihan (Singkatan MEDLINE)
 
-Abbreviate_names=Singkat_nama
-Abbreviated_%0_journal_names.=Singkatan_%0_nama_jurnal.
+Abbreviate\ names=Singkat nama
+Abbreviated\ %0\ journal\ names.=Singkatan %0 nama jurnal.
 
 Abbreviation=Singkatan
 
-About_JabRef=Tentang_JabRef
+About\ JabRef=Tentang JabRef
 
 Abstract=Abstrak
 
 Accept=Terima
 
-Accept_change=Terima_perubahan
+Accept\ change=Terima perubahan
 
 Action=Aksi
 
-What_is_Mr._DLib?=
+What\ is\ Mr.\ DLib?=
 
 Add=Tambah
 
-Add_a_(compiled)_custom_Importer_class_from_a_class_path.=Tambah_kelas_Importer_dari_lokasi_class.
-The_path_need_not_be_on_the_classpath_of_JabRef.=Lokasi_tidak_harus_pada_lokasi_kelas_JabRef.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=Tambah kelas Importer dari lokasi class.
+The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=Lokasi tidak harus pada lokasi kelas JabRef.
 
-Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=Tambah_suaian_kelas_Importer_dari_arsip_ZIP.
-The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=Lokasi_arsip_ZIP_tidak_harus_dalam_lokasi_kelas_JabRef.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=Tambah suaian kelas Importer dari arsip ZIP.
+The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=Lokasi arsip ZIP tidak harus dalam lokasi kelas JabRef.
 
-Add_a_regular_expression_for_the_key_pattern.=
+Add\ a\ regular\ expression\ for\ the\ key\ pattern.=
 
-Add_selected_entries_to_this_group=
+Add\ selected\ entries\ to\ this\ group=
 
-Add_from_folder=Tambah_dari_folder
+Add\ from\ folder=Tambah dari folder
 
-Add_from_JAR=Tambah_dari_JAR
+Add\ from\ JAR=Tambah dari JAR
 
-add_group=tambah_grup
+add\ group=tambah grup
 
-Add_new=Tambah_baru
+Add\ new=Tambah baru
 
-Add_subgroup=Tambah_Anak_Grup
+Add\ subgroup=Tambah Anak Grup
 
-Add_to_group=Tambah_ke_grup
+Add\ to\ group=Tambah ke grup
 
-Added_group_"%0".=Grup_ditambahkan_"%0".
+Added\ group\ "%0".=Grup ditambahkan "%0".
 
-Added_missing_braces.=
+Added\ missing\ braces.=
 
-Added_new=Ditambahkan_baru
+Added\ new=Ditambahkan baru
 
-Added_string=Ditambahkan_string
+Added\ string=Ditambahkan string
 
-Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.=Tambahan,_entri_bidang_<b>%0</b>_yang_tidak_mengandung<b>%1</b>_dapat_ditugaskan_secara_manual_ke_grup_ini_dengan_memilihnya_kemudian_menggunakan_dengan_cara_seret_dan_tempatkan_atau_melalui_menu_konteks._Proses_ini_menghapus_istilah_<b>%1</b>_pada_tiap_bidang_<b>%0</b>.
+Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ can\ be\ assigned\ manually\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ This\ process\ adds\ the\ term\ <b>%1</b>\ to\ each\ entry's\ <b>%0</b>\ field.\ Entries\ can\ be\ removed\ manually\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.\ This\ process\ removes\ the\ term\ <b>%1</b>\ from\ each\ entry's\ <b>%0</b>\ field.=Tambahan, entri bidang <b>%0</b> yang tidak mengandung<b>%1</b> dapat ditugaskan secara manual ke grup ini dengan memilihnya kemudian menggunakan dengan cara seret dan tempatkan atau melalui menu konteks. Proses ini menghapus istilah <b>%1</b> pada tiap bidang <b>%0</b>.
 
-Advanced=Tingkat_lanjut
-All_entries=Semua_entri
-All_entries_of_this_type_will_be_declared_typeless._Continue?=Semua_entri_tipe_ini_akan_dinyatakan_sebagai_tanpa_tipe._Teruskan?
+Advanced=Tingkat lanjut
+All\ entries=Semua entri
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=Semua entri tipe ini akan dinyatakan sebagai tanpa tipe. Teruskan?
 
-All_fields=Semua_bidang
+All\ fields=Semua bidang
 
-Always_reformat_BIB_file_on_save_and_export=
+Always\ reformat\ BIB\ file\ on\ save\ and\ export=
 
-A_SAX_exception_occurred_while_parsing_'%0'\:=SAXException_terjadi_ketika_mengurai_'%0'\:
+A\ SAX\ exception\ occurred\ while\ parsing\ '%0'\:=SAXException terjadi ketika mengurai '%0':
 
 and=dan
-and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.=dan_kelas_tersebut_harus_dinyatakan_di_lokasi_kelas_waktu_menjalankan_JabRef.
+and\ the\ class\ must\ be\ available\ in\ your\ classpath\ next\ time\ you\ start\ JabRef.=dan kelas tersebut harus dinyatakan di lokasi kelas waktu menjalankan JabRef.
 
-any_field_that_matches_the_regular_expression_<b>%0</b>=bidang_yang_sesuai_dengan_ekspresi_reguler_<b>%0</b>
+any\ field\ that\ matches\ the\ regular\ expression\ <b>%0</b>=bidang yang sesuai dengan ekspresi reguler <b>%0</b>
 
 Appearance=Penampilan
 
 Append=Menambah
-Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library=Menambah_isi_dari_basisdata_BibTeX_ke_basisdata_yang_sedang_dilihat_sekarang
+Append\ contents\ from\ a\ BibTeX\ library\ into\ the\ currently\ viewed\ library=Menambah isi dari basisdata BibTeX ke basisdata yang sedang dilihat sekarang
 
-Append_library=Menambah_basisdata
+Append\ library=Menambah basisdata
 
-Append_the_selected_text_to_BibTeX_field=Menambah_teks_pilihan_ke_kunci_BibTeX
+Append\ the\ selected\ text\ to\ BibTeX\ field=Menambah teks pilihan ke kunci BibTeX
 Application=Aplikasi
 
 Apply=Terapkan
 
-Arguments_passed_on_to_running_JabRef_instance._Shutting_down.=Argumen_dimasukkan_pada_JabRef_yang_sedang_dibuka._Dimatikan.
+Arguments\ passed\ on\ to\ running\ JabRef\ instance.\ Shutting\ down.=Argumen dimasukkan pada JabRef yang sedang dibuka. Dimatikan.
 
-Assign_new_file=Terapkan_ke_berkas_baru
+Assign\ new\ file=Terapkan ke berkas baru
 
-Assign_the_original_group's_entries_to_this_group?=Terapkan_entri_grup_asli_ke_grup_ini?
+Assign\ the\ original\ group's\ entries\ to\ this\ group?=Terapkan entri grup asli ke grup ini?
 
-Assigned_%0_entries_to_group_"%1".=Diterapkan_%0_entri_ke_grup_"%1".
+Assigned\ %0\ entries\ to\ group\ "%1".=Diterapkan %0 entri ke grup "%1".
 
-Assigned_1_entry_to_group_"%0".=Diterapkan_1_entri_ke_grup_"%0".
+Assigned\ 1\ entry\ to\ group\ "%0".=Diterapkan 1 entri ke grup "%0".
 
-Attach_URL=Lampirkan_URL
+Attach\ URL=Lampirkan URL
 
-Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.=Mencoba_atur_otomatis_berkas_tautan_untuk_entri_anda._Pengaturan_otomatis_berfungsi_jika_berkas_di_folder_berkas_atau_subfolder<BR>diberi_nama_sama_dengan_kunci_BibTeX,_tambah_ekstensi.
+Attempt\ to\ automatically\ set\ file\ links\ for\ your\ entries.\ Automatically\ setting\ works\ if\ a\ file\ in\ your\ file\ directory<BR>or\ a\ subdirectory\ is\ named\ identically\ to\ an\ entry's\ BibTeX\ key,\ plus\ extension.=Mencoba atur otomatis berkas tautan untuk entri anda. Pengaturan otomatis berfungsi jika berkas di folder berkas atau subfolder<BR>diberi nama sama dengan kunci BibTeX, tambah ekstensi.
 
-Autodetect_format=Deteksi_format_otomatis
+Autodetect\ format=Deteksi format otomatis
 
-Autogenerate_BibTeX_keys=Kunci_BibTeX_dibuat_otomatis
+Autogenerate\ BibTeX\ keys=Kunci BibTeX dibuat otomatis
 
-Autolink_files_with_names_starting_with_the_BibTeX_key=Tautan_otomatis_berkas_dgn_nama_yang_sama_kunci_BibTeX
+Autolink\ files\ with\ names\ starting\ with\ the\ BibTeX\ key=Tautan otomatis berkas dgn nama yang sama kunci BibTeX
 
-Autolink_only_files_that_match_the_BibTeX_key=Tautan_otomatis_hanya_pada_berkas_sesuai_dgn_kunci_BibTeX
+Autolink\ only\ files\ that\ match\ the\ BibTeX\ key=Tautan otomatis hanya pada berkas sesuai dgn kunci BibTeX
 
-Automatically_create_groups=Otomatis_membuat_grup
+Automatically\ create\ groups=Otomatis membuat grup
 
-Automatically_remove_exact_duplicates=Otomatis_menghapus_yang_sama
+Automatically\ remove\ exact\ duplicates=Otomatis menghapus yang sama
 
-Allow_overwriting_existing_links.=Mengijinkan_menindih_tautan_yang_ada.
+Allow\ overwriting\ existing\ links.=Mengijinkan menindih tautan yang ada.
 
-Do_not_overwrite_existing_links.=Tidak_boleh_menindih_tautan_yang_ada.
+Do\ not\ overwrite\ existing\ links.=Tidak boleh menindih tautan yang ada.
 
-AUX_file_import=Impor_berkas_AUX
+AUX\ file\ import=Impor berkas AUX
 
-Available_export_formats=Format_ekspor_yang_dikenal
+Available\ export\ formats=Format ekspor yang dikenal
 
-Available_BibTeX_fields=Bidang_tersedia
+Available\ BibTeX\ fields=Bidang tersedia
 
-Available_import_formats=Format_impor_yang_dikenal
+Available\ import\ formats=Format impor yang dikenal
 
-Background_color_for_optional_fields=Latar_bidang_tambahan
+Background\ color\ for\ optional\ fields=Latar bidang tambahan
 
-Background_color_for_required_fields=Latar_bidang_utama
+Background\ color\ for\ required\ fields=Latar bidang utama
 
-Backup_old_file_when_saving=Cadangan_berkas_lama_ketika_menyimpan
+Backup\ old\ file\ when\ saving=Cadangan berkas lama ketika menyimpan
 
-BibTeX_key_is_unique.=Kunci_BibTeX_tidak_boleh_sama.
+BibTeX\ key\ is\ unique.=Kunci BibTeX tidak boleh sama.
 
-%0_source=
+%0\ source=
 
-Broken_link=Tautan_rusak
+Broken\ link=Tautan rusak
 
 Browse=Jelajah
 
@@ -160,321 +160,321 @@ by=oleh
 
 Cancel=Batal
 
-Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?=Tidak_bisa_menambah_entri_ke_grup_tanpa_membuat_kunci._Membuat_kunci_sekarang?
+Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=Tidak bisa menambah entri ke grup tanpa membuat kunci. Membuat kunci sekarang?
 
-Cannot_merge_this_change=Tidak_bisa_menggabung_perubahan_ini
+Cannot\ merge\ this\ change=Tidak bisa menggabung perubahan ini
 
-case_insensitive=huruf_besar_kecil_tidak_penting
+case\ insensitive=huruf besar kecil tidak penting
 
-case_sensitive=memperhitungkan_huruf_besar_kecil
+case\ sensitive=memperhitungkan huruf besar kecil
 
-Case_sensitive=Huruf_besar_kecil_tidak_penting
+Case\ sensitive=Huruf besar kecil tidak penting
 
-change_assignment_of_entries=merubah_penugasan_entri
+change\ assignment\ of\ entries=merubah penugasan entri
 
-Change_case=Merubah_huruf_besar/kecil
+Change\ case=Merubah huruf besar/kecil
 
-Change_entry_type=Merubah_tipe_entri
-Change_file_type=Merubah_tipe_berkas
+Change\ entry\ type=Merubah tipe entri
+Change\ file\ type=Merubah tipe berkas
 
 
-Change_of_Grouping_Method=Metubah_Metode_Grup
+Change\ of\ Grouping\ Method=Metubah Metode Grup
 
-change_preamble=merubah_preamble
+change\ preamble=merubah preamble
 
-Change_table_column_and_General_fields_settings_to_use_the_new_feature=Merubah_kolom_tabel_dan_pengaturan_umum_bidang_dengan_menerapkan_fitur_baru
+Change\ table\ column\ and\ General\ fields\ settings\ to\ use\ the\ new\ feature=Merubah kolom tabel dan pengaturan umum bidang dengan menerapkan fitur baru
 
-Changed_language_settings=Pengaturan_bahasa_berubah
+Changed\ language\ settings=Pengaturan bahasa berubah
 
-Changed_preamble=Preamble_berubah
+Changed\ preamble=Preamble berubah
 
-Check_existing_file_links=Periksa_berkas_tautan_yang_sudah_ada
+Check\ existing\ file\ links=Periksa berkas tautan yang sudah ada
 
-Check_links=Periksa_tautan
+Check\ links=Periksa tautan
 
-Cite_command=Perintah_acuan
+Cite\ command=Perintah acuan
 
-Class_name=Nama_kelas
+Class\ name=Nama kelas
 
 Clear=Bersihkan
 
-Clear_fields=Bersihkan_beberapa_bidang
+Clear\ fields=Bersihkan beberapa bidang
 
 Close=Tutup
-Close_others=Tutup_lainnya
-Close_all=Tutup_semua
+Close\ others=Tutup lainnya
+Close\ all=Tutup semua
 
-Close_dialog=Tutup_dialog
+Close\ dialog=Tutup dialog
 
-Close_the_current_library=Tutup_basisdata_yang_sekarang
+Close\ the\ current\ library=Tutup basisdata yang sekarang
 
-Close_window=Tutup_jendela
+Close\ window=Tutup jendela
 
-Closed_library=Basisdata_ditutup
+Closed\ library=Basisdata ditutup
 
-Color_codes_for_required_and_optional_fields=Kode_warna_untuk_bidang_utama_dan_tambahan
+Color\ codes\ for\ required\ and\ optional\ fields=Kode warna untuk bidang utama dan tambahan
 
-Color_for_marking_incomplete_entries=Tanda_untuk_entri_kosong
+Color\ for\ marking\ incomplete\ entries=Tanda untuk entri kosong
 
-Column_width=Lebar_kolom
+Column\ width=Lebar kolom
 
-Command_line_id=id_perintah_baris
+Command\ line\ id=id perintah baris
 
 
-Contained_in=Terkandung_di
+Contained\ in=Terkandung di
 
 Content=Isi
 
 Copied=Disalin
 
-Copied_cell_contents=Isi_sel_disalin
+Copied\ cell\ contents=Isi sel disalin
 
-Copied_title=
+Copied\ title=
 
-Copied_key=Kunci_disalin
+Copied\ key=Kunci disalin
 
-Copied_titles=
+Copied\ titles=
 
-Copied_keys=Kunci_disalin
+Copied\ keys=Kunci disalin
 
 Copy=Salin
 
-Copy_BibTeX_key=Salin_kunci_bibTeX
-Copy_file_to_file_directory=Salin_berkas_ke_direktori_berkas
+Copy\ BibTeX\ key=Salin kunci bibTeX
+Copy\ file\ to\ file\ directory=Salin berkas ke direktori berkas
 
-Copy_to_clipboard=Salin_ke_papan_klip
+Copy\ to\ clipboard=Salin ke papan klip
 
-Could_not_call_executable=Tidak_bisa_memanggil_yang_bisa_dijalankan
-Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.=Tidak_bisa_menghubungi_server_Vim._Pastikan_Vim_sedang_berjalan<BR>dengan_nama_server_yang_sah.
+Could\ not\ call\ executable=Tidak bisa memanggil yang bisa dijalankan
+Could\ not\ connect\ to\ Vim\ server.\ Make\ sure\ that\ Vim\ is\ running<BR>with\ correct\ server\ name.=Tidak bisa menghubungi server Vim. Pastikan Vim sedang berjalan<BR>dengan nama server yang sah.
 
-Could_not_export_file=Tidak_bisa_ekspor_berkas
+Could\ not\ export\ file=Tidak bisa ekspor berkas
 
-Could_not_export_preferences=Tidak_bisa_ekspor_preferensi
+Could\ not\ export\ preferences=Tidak bisa ekspor preferensi
 
-Could_not_find_a_suitable_import_format.=Tidak_bisa_menemukan_format_impor_yang_sesuai.
-Could_not_import_preferences=Tidak_bisa_impor_preferensi
+Could\ not\ find\ a\ suitable\ import\ format.=Tidak bisa menemukan format impor yang sesuai.
+Could\ not\ import\ preferences=Tidak bisa impor preferensi
 
-Could_not_instantiate_%0=Tidak_bisa_instansiasi_%0
-Could_not_instantiate_%0_%1=Tidak_bisa_instansiasi_%0_%1
-Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?=Tidak_bisa_instansiasi_%0._Apakah_anda_sudah_memilih_lokasi_paket_yang_benar?
-Could_not_open_link=Tidak_bisa_membuka_tautan
+Could\ not\ instantiate\ %0=Tidak bisa instansiasi %0
+Could\ not\ instantiate\ %0\ %1=Tidak bisa instansiasi %0 %1
+Could\ not\ instantiate\ %0.\ Have\ you\ chosen\ the\ correct\ package\ path?=Tidak bisa instansiasi %0. Apakah anda sudah memilih lokasi paket yang benar?
+Could\ not\ open\ link=Tidak bisa membuka tautan
 
-Could_not_print_preview=Tidak_bisa_mencetak_pratampilan
+Could\ not\ print\ preview=Tidak bisa mencetak pratampilan
 
-Could_not_run_the_'vim'_program.=Tidak_bisa_menjalankan_program_'vim'.
+Could\ not\ run\ the\ 'vim'\ program.=Tidak bisa menjalankan program 'vim'.
 
-Could_not_save_file.=Tidak_bisa_membuka_berkas.
-Character_encoding_'%0'_is_not_supported.=Enkoding_karakter_'%0'_tidak_didukung.
+Could\ not\ save\ file.=Tidak bisa membuka berkas.
+Character\ encoding\ '%0'\ is\ not\ supported.=Enkoding karakter '%0' tidak didukung.
 
-crossreferenced_entries_included=entri_referensi_silang_diikutkan
+crossreferenced\ entries\ included=entri referensi silang diikutkan
 
-Current_content=Isi_sekarang
+Current\ content=Isi sekarang
 
-Current_value=Angka_sekarang
+Current\ value=Angka sekarang
 
-Custom_entry_types=Tipe_entri_suaian
+Custom\ entry\ types=Tipe entri suaian
 
-Custom_entry_types_found_in_file=Tipe_entri_suaian_ditemukan_dalam_berkas
+Custom\ entry\ types\ found\ in\ file=Tipe entri suaian ditemukan dalam berkas
 
-Customize_entry_types=Tipe_entri_ubahsuai
+Customize\ entry\ types=Tipe entri ubahsuai
 
-Customize_key_bindings=Ubahsuai_kunci_gabungan
+Customize\ key\ bindings=Ubahsuai kunci gabungan
 
 Cut=Potong
 
-cut_entries=potong_entri
+cut\ entries=potong entri
 
-cut_entry=potong_entri
+cut\ entry=potong entri
 
 
-Library_encoding=Enkoding_basisdata
+Library\ encoding=Enkoding basisdata
 
-Library_properties=Properti_basisdata
+Library\ properties=Properti basisdata
 
-Library_type=
+Library\ type=
 
-Date_format=Format_tanggal
+Date\ format=Format tanggal
 
 Default=Bawaan
 
-Default_encoding=Enkoding_bawaan
+Default\ encoding=Enkoding bawaan
 
-Default_grouping_field=Bidang_grup_bawaan
+Default\ grouping\ field=Bidang grup bawaan
 
-Default_look_and_feel=Penampilan_artistik_bawaan
+Default\ look\ and\ feel=Penampilan artistik bawaan
 
-Default_pattern=Pola_bawaan
+Default\ pattern=Pola bawaan
 
-Default_sort_criteria=Kriteria_pengurutan_bawaan
-Define_'%0'=Mendefinisi_'%0'
+Default\ sort\ criteria=Kriteria pengurutan bawaan
+Define\ '%0'=Mendefinisi '%0'
 
 Delete=Hapus
 
-Delete_custom_format=Menghapus_format_suaian
+Delete\ custom\ format=Menghapus format suaian
 
-delete_entries=hapus_entri
+delete\ entries=hapus entri
 
-Delete_entry=Hapus_entri
+Delete\ entry=Hapus entri
 
-delete_entry=hapus_entri
+delete\ entry=hapus entri
 
-Delete_multiple_entries=Hapus_entri_berganda
+Delete\ multiple\ entries=Hapus entri berganda
 
-Delete_rows=Hapus_baris
+Delete\ rows=Hapus baris
 
-Delete_strings=Hapus_string
+Delete\ strings=Hapus string
 
 Deleted=Dihapus
 
-Permanently_delete_local_file=Hapus_berkas_lokal
+Permanently\ delete\ local\ file=Hapus berkas lokal
 
-Delimit_fields_with_semicolon,_ex.=Batas_bidang_dengan_titik_koma,_misal,
+Delimit\ fields\ with\ semicolon,\ ex.=Batas bidang dengan titik koma, misal,
 
-Descending=Urutan_menurun
+Descending=Urutan menurun
 
 Description=Deskripsi
 
-Deselect_all=Lepas_semua_pilihan
-Deselect_all_duplicates=Lepas_semua_pilihan_duplikasi
+Deselect\ all=Lepas semua pilihan
+Deselect\ all\ duplicates=Lepas semua pilihan duplikasi
 
-Disable_this_confirmation_dialog=Dialog_konfirmasi_ini_tidak_aktif
+Disable\ this\ confirmation\ dialog=Dialog konfirmasi ini tidak aktif
 
-Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.=Tampilkan_semua_entri_yang_ada_di_grup_pilihan.
+Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups.=Tampilkan semua entri yang ada di grup pilihan.
 
-Display_all_error_messages=Tampilkan_semua_pesan_kesalahan
+Display\ all\ error\ messages=Tampilkan semua pesan kesalahan
 
-Display_help_on_command_line_options=Tampilkan_bantuan_pada_opsi_perindah_baris
+Display\ help\ on\ command\ line\ options=Tampilkan bantuan pada opsi perindah baris
 
-Display_only_entries_belonging_to_all_selected_groups.=Tampilkan_entri_hanya_yang_ada_di_grup_pilihan.
-Display_version=Tampilkan_versi
+Display\ only\ entries\ belonging\ to\ all\ selected\ groups.=Tampilkan entri hanya yang ada di grup pilihan.
+Display\ version=Tampilkan versi
 
-Do_not_abbreviate_names=Jangan_singkat_nama
+Do\ not\ abbreviate\ names=Jangan singkat nama
 
-Do_not_automatically_set=Jangan_pengaturan_otomatis
+Do\ not\ automatically\ set=Jangan pengaturan otomatis
 
-Do_not_import_entry=Jangan_impor_entri
+Do\ not\ import\ entry=Jangan impor entri
 
-Do_not_open_any_files_at_startup=Jangan_buka_berkas_saat_menjalankan
+Do\ not\ open\ any\ files\ at\ startup=Jangan buka berkas saat menjalankan
 
-Do_not_overwrite_existing_keys=Jangan_menindih_kunci_yang_ada
-Do_not_show_these_options_in_the_future=Untuk_selanjutnya_jangan_tampilkan_ini_lagi
+Do\ not\ overwrite\ existing\ keys=Jangan menindih kunci yang ada
+Do\ not\ show\ these\ options\ in\ the\ future=Untuk selanjutnya jangan tampilkan ini lagi
 
-Do_not_wrap_the_following_fields_when_saving=Jangan_lipat_bidang_berikut_ketika_menyimpan
-Do_not_write_the_following_fields_to_XMP_Metadata\:=Jangan_menulis_bidang_dibawah_pada_Metadata_XMP\:
+Do\ not\ wrap\ the\ following\ fields\ when\ saving=Jangan lipat bidang berikut ketika menyimpan
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Jangan menulis bidang dibawah pada Metadata XMP:
 
-Do_you_want_JabRef_to_do_the_following_operations?=Apakah_anda_ingin_JabRef_melakukan_proses_berikut?
+Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Apakah anda ingin JabRef melakukan proses berikut?
 
-Donate_to_JabRef=Sumbang_ke_JabRef
+Donate\ to\ JabRef=Sumbang ke JabRef
 
 Down=Kebawah
 
-Download_file=Muaturun_berkas
+Download\ file=Muaturun berkas
 
-Downloading...=Sedang_muaturun...
+Downloading...=Sedang muaturun...
 
-Drop_%0=Letakkan_%0
+Drop\ %0=Letakkan %0
 
-duplicate_removal=penghapus_yang_sama
+duplicate\ removal=penghapus yang sama
 
-Duplicate_string_name=Nama_string_sama
+Duplicate\ string\ name=Nama string sama
 
-Duplicates_found=Ditemukan_ada_yang_sama
+Duplicates\ found=Ditemukan ada yang sama
 
-Dynamic_groups=Grup_dinamik
+Dynamic\ groups=Grup dinamik
 
-Dynamically_group_entries_by_a_free-form_search_expression=Entri_grup_dinamik_dengan_ekspresi_pencarian_bebas
+Dynamically\ group\ entries\ by\ a\ free-form\ search\ expression=Entri grup dinamik dengan ekspresi pencarian bebas
 
-Dynamically_group_entries_by_searching_a_field_for_a_keyword=Entri_grup_dinamk_dengan_pencarian_bidang_dari_katakunci
+Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=Entri grup dinamk dengan pencarian bidang dari katakunci
 
-Each_line_must_be_on_the_following_form=Setiap_baris_harus_menurut_bentuk_berikut
+Each\ line\ must\ be\ on\ the\ following\ form=Setiap baris harus menurut bentuk berikut
 
 Edit=Sunting
 
-Edit_custom_export=Sunting_ekspor_atursendiri
-Edit_entry=Sunting_entri
-Save_file=Sunting_berkas_tautan
-Edit_file_type=Sunting_tipe_berkas
+Edit\ custom\ export=Sunting ekspor atursendiri
+Edit\ entry=Sunting entri
+Save\ file=Sunting berkas tautan
+Edit\ file\ type=Sunting tipe berkas
 
-Edit_group=Sunting_grup
+Edit\ group=Sunting grup
 
 
-Edit_preamble=Sunting_preamble
-Edit_strings=Sunting_string
-Editor_options=Pilihan_Penyunting
+Edit\ preamble=Sunting preamble
+Edit\ strings=Sunting string
+Editor\ options=Pilihan Penyunting
 
-Empty_BibTeX_key=Kunci_BibTeX_kosong
+Empty\ BibTeX\ key=Kunci BibTeX kosong
 
-Grouping_may_not_work_for_this_entry.=Grup_tidak_bisa_menggunakan_entri_ini.
+Grouping\ may\ not\ work\ for\ this\ entry.=Grup tidak bisa menggunakan entri ini.
 
-empty_library=basisdata_kosong
-Enable_word/name_autocompletion=Otomatis_melengkapi_kata/nama
+empty\ library=basisdata kosong
+Enable\ word/name\ autocompletion=Otomatis melengkapi kata/nama
 
-Enter_URL=Tulis_URL
+Enter\ URL=Tulis URL
 
-Enter_URL_to_download=Tulis_URL_untuk_muaturun
+Enter\ URL\ to\ download=Tulis URL untuk muaturun
 
 entries=entri
 
-Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.=Entri_tidak_bisa_diterapkan_secara_manual_atau_dihapus_dari_grup_ini.
+Entries\ cannot\ be\ manually\ assigned\ to\ or\ removed\ from\ this\ group.=Entri tidak bisa diterapkan secara manual atau dihapus dari grup ini.
 
-Entries_exported_to_clipboard=Entri_diekspor_ke_papan_klip
+Entries\ exported\ to\ clipboard=Entri diekspor ke papan klip
 
 
 entry=entri
 
-Entry_editor=Penyunting_entri
+Entry\ editor=Penyunting entri
 
-Entry_preview=Pratampilan_entri
+Entry\ preview=Pratampilan entri
 
-Entry_table=Tabel_entri
+Entry\ table=Tabel entri
 
-Entry_table_columns=Kolom_tabel_entri
+Entry\ table\ columns=Kolom tabel entri
 
-Entry_type=Tipe_entri
+Entry\ type=Tipe entri
 
-Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Entri_tipe_nama_tidak_diijinkan_mengandung_spasi_kosong_atau_karakter_berikut
+Entry\ type\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Entri tipe nama tidak diijinkan mengandung spasi kosong atau karakter berikut
 
-Entry_types=Tipe_entri
+Entry\ types=Tipe entri
 
 Error=Kesalahan
-Error_exporting_to_clipboard=Kesalahan_mengekspor_ke_papan_klip
+Error\ exporting\ to\ clipboard=Kesalahan mengekspor ke papan klip
 
-Error_occurred_when_parsing_entry=Kesalahan_terjadi_ketika_mengurai_entri
+Error\ occurred\ when\ parsing\ entry=Kesalahan terjadi ketika mengurai entri
 
-Error_opening_file=Kesalahan_ketika_membuka_berkas
+Error\ opening\ file=Kesalahan ketika membuka berkas
 
-Error_setting_field=Kesalahan_pengaturan_bidang
+Error\ setting\ field=Kesalahan pengaturan bidang
 
-Error_while_writing=Kesalahan_ketika_menulis
-Error_writing_to_%0_file(s).=Kesalahan_menulis_ke_berkas_%0.
+Error\ while\ writing=Kesalahan ketika menulis
+Error\ writing\ to\ %0\ file(s).=Kesalahan menulis ke berkas %0.
 
 
 
-'%0'_exists._Overwrite_file?='%0'_esudah_ada._Berkas_ditindih?
-Overwrite_file?=Berkas_ditindih?
+'%0'\ exists.\ Overwrite\ file?='%0' esudah ada. Berkas ditindih?
+Overwrite\ file?=Berkas ditindih?
 
 Export=Ekspor
 
-Export_name=Ekspor_nama
+Export\ name=Ekspor nama
 
-Export_preferences=Preferensi_Ekspor
+Export\ preferences=Preferensi Ekspor
 
-Export_preferences_to_file=Ekspor_preferensi_ke_berkas
+Export\ preferences\ to\ file=Ekspor preferensi ke berkas
 
-Export_properties=Ekspor_properti
+Export\ properties=Ekspor properti
 
-Export_to_clipboard=Ekspor_ke_papan_klip
+Export\ to\ clipboard=Ekspor ke papan klip
 
-Exporting=Proses_mengekspor
+Exporting=Proses mengekspor
 Extension=Ekstensi
 
-External_changes=Perubahan_eksternal
+External\ changes=Perubahan eksternal
 
-External_file_links=Tautan_berkas_eksternal
+External\ file\ links=Tautan berkas eksternal
 
-External_programs=Program_eksternal
+External\ programs=Program eksternal
 
-External_viewer_called=Penampil_eksternal_dijalankan
+External\ viewer\ called=Penampil eksternal dijalankan
 
 Fetch=Mengambil
 
@@ -482,210 +482,210 @@ Field=Bidang
 
 field=bidang
 
-Field_name=Nama_bidang
-Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Nama_bidang_tidak_diijinkan_mengandung_spasi_kosong_atau_karakter_berikut
+Field\ name=Nama bidang
+Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Nama bidang tidak diijinkan mengandung spasi kosong atau karakter berikut
 
-Field_to_filter=Bidang_ditapis
+Field\ to\ filter=Bidang ditapis
 
-Field_to_group_by=Bidang_ke_grup_berdasar
+Field\ to\ group\ by=Bidang ke grup berdasar
 
 File=Berkas
 
 file=berkas
-File_'%0'_is_already_open.=Berkas_'%0'_sudah_dibuka
+File\ '%0'\ is\ already\ open.=Berkas '%0' sudah dibuka
 
-File_changed=Berkas_sudah_diubah
-File_directory_is_'%0'\:=Lokasi_berkas_adalah_'%0'\:
+File\ changed=Berkas sudah diubah
+File\ directory\ is\ '%0'\:=Lokasi berkas adalah '%0':
 
-File_directory_is_not_set_or_does_not_exist\!=Lokasi_berkas_belum_ditentukan_atau_tidak_ada\!
+File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=Lokasi berkas belum ditentukan atau tidak ada!
 
-File_exists=Berkas_ada
+File\ exists=Berkas ada
 
-File_has_been_updated_externally._What_do_you_want_to_do?=Berkas_diperbarui_dengan_program_eksternal._Apakah_yang_and_inginkan?
+File\ has\ been\ updated\ externally.\ What\ do\ you\ want\ to\ do?=Berkas diperbarui dengan program eksternal. Apakah yang and inginkan?
 
-File_not_found=Berkas_tidak_ditemukan
-File_type=Tipe_berkas
+File\ not\ found=Berkas tidak ditemukan
+File\ type=Tipe berkas
 
-File_updated_externally=Berkas_diperbarui_secara_eksternal
+File\ updated\ externally=Berkas diperbarui secara eksternal
 
-filename=nama_berkas
+filename=nama berkas
 
 Filename=
 
-Files_opened=Berkas_dibuka
+Files\ opened=Berkas dibuka
 
 Filter=Penapis
 
-Filter_All=
+Filter\ All=
 
-Filter_None=
+Filter\ None=
 
-Finished_automatically_setting_external_links.=Selesai_pengaturan_otomatis_tautan_eksternal.
+Finished\ automatically\ setting\ external\ links.=Selesai pengaturan otomatis tautan eksternal.
 
-Finished_synchronizing_file_links._Entries_changed\:_%0.=Selesai_menyelaraskan_berkas_tautan._Entri_diubah\:_%0.
-Finished_writing_XMP-metadata._Wrote_to_%0_file(s).=Selesai_menulis_XMP-metadata._Ditulis_ke_berkas_%0.
-Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).=Selesai_menulis_XMP_untuk_berkas_%0_(%1_dilewati,_%2_kesalahan).
+Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Selesai menyelaraskan berkas tautan. Entri diubah: %0.
+Finished\ writing\ XMP-metadata.\ Wrote\ to\ %0\ file(s).=Selesai menulis XMP-metadata. Ditulis ke berkas %0.
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Selesai menulis XMP untuk berkas %0 (%1 dilewati, %2 kesalahan).
 
-First_select_the_entries_you_want_keys_to_be_generated_for.=Pertama_pilih_entri_yang_anda_kehendaki_untuk_dibuat_kunci.
+First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Pertama pilih entri yang anda kehendaki untuk dibuat kunci.
 
-Fit_table_horizontally_on_screen=Sesuaikan_ukuran_tabel_horisontal_sesuai_layar
+Fit\ table\ horizontally\ on\ screen=Sesuaikan ukuran tabel horisontal sesuai layar
 
 Float=Ambangan
-Float_marked_entries=Ambangan_ditandai_sebagai_entri
+Float\ marked\ entries=Ambangan ditandai sebagai entri
 
-Font_family=Keluarga_Huruf
+Font\ family=Keluarga Huruf
 
-Font_preview=Pratampilan_Huruf
+Font\ preview=Pratampilan Huruf
 
-Font_size=Ukuran_Huruf
+Font\ size=Ukuran Huruf
 
-Font_style=Corak_huruf
+Font\ style=Corak huruf
 
-Font_selection=PemilihHuruf
+Font\ selection=PemilihHuruf
 
 for=untuk
 
-Format_of_author_and_editor_names=Format_nama_penulis_dan_penyunting
-Format_string=Format_string
+Format\ of\ author\ and\ editor\ names=Format nama penulis dan penyunting
+Format\ string=Format string
 
-Format_used=Format_digunakan
-Formatter_name=Nama_Pemformat
+Format\ used=Format digunakan
+Formatter\ name=Nama Pemformat
 
-found_in_AUX_file=ditemukan_dalam_berkas_AUX
+found\ in\ AUX\ file=ditemukan dalam berkas AUX
 
-Full_name=Nama_lengkap
+Full\ name=Nama lengkap
 
 General=Umum
 
-General_fields=Bidang_umum
+General\ fields=Bidang umum
 
 Generate=Membuat
 
-Generate_BibTeX_key=Membuat_kunci_BibTeX
+Generate\ BibTeX\ key=Membuat kunci BibTeX
 
-Generate_keys=Membuat_kunci
+Generate\ keys=Membuat kunci
 
-Generate_keys_before_saving_(for_entries_without_a_key)=Buat_kunci_sebelum_menyimpan_(untuk_entri_tanpa_kunci)
-Generate_keys_for_imported_entries=Buat_kunci_untuk_entri_impor
+Generate\ keys\ before\ saving\ (for\ entries\ without\ a\ key)=Buat kunci sebelum menyimpan (untuk entri tanpa kunci)
+Generate\ keys\ for\ imported\ entries=Buat kunci untuk entri impor
 
-Generate_now=Membuat_sekarang
+Generate\ now=Membuat sekarang
 
-Generated_BibTeX_key_for=Kunci_BibTeX_dibuat_untuk
+Generated\ BibTeX\ key\ for=Kunci BibTeX dibuat untuk
 
-Generating_BibTeX_key_for=Membuat_kunci_BibTeX_untuk
-Get_fulltext=
+Generating\ BibTeX\ key\ for=Membuat kunci BibTeX untuk
+Get\ fulltext=
 
-Gray_out_non-hits=Kelabukan_non-hits
+Gray\ out\ non-hits=Kelabukan non-hits
 
 Groups=Grup
 
-Have_you_chosen_the_correct_package_path?=Apakah_anda_sudah_memilih_lokasi_paket_yang_tepat?
+Have\ you\ chosen\ the\ correct\ package\ path?=Apakah anda sudah memilih lokasi paket yang tepat?
 
 Help=Bantuan
 
-Help_on_key_patterns=Bantuan_untuk_pola_kunci
-Help_on_regular_expression_search=Bantuan_untuk_Pencarian_Ekspresi_Reguler
+Help\ on\ key\ patterns=Bantuan untuk pola kunci
+Help\ on\ regular\ expression\ search=Bantuan untuk Pencarian Ekspresi Reguler
 
-Hide_non-hits=Sembunyikan_non-hits
+Hide\ non-hits=Sembunyikan non-hits
 
-Hierarchical_context=Konteks_berhirarki
+Hierarchical\ context=Konteks berhirarki
 
 Highlight=Warnakan
 Marking=
 Underline=
-Empty_Highlight=
-Empty_Marking=
-Empty_Underline=
-The_marked_area_does_not_contain_any_legible_text!=
+Empty\ Highlight=
+Empty\ Marking=
+Empty\ Underline=
+The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=
 
-Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>=Sarant\:_untuk_mencari_hanya_bidang_tertentu,_misal_tulis\:<p><tt>author\=smith_dan_title\=electrical</tt>
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Sarant: untuk mencari hanya bidang tertentu, misal tulis:<p><tt>author=smith dan title=electrical</tt>
 
-HTML_table=Tabel_HTML
-HTML_table_(with_Abstract_&_BibTeX)=Tabel_HTML_(dengan_Abstrak_dan_BibTeX)
+HTML\ table=Tabel HTML
+HTML\ table\ (with\ Abstract\ &\ BibTeX)=Tabel HTML (dengan Abstrak dan BibTeX)
 Icon=Ikon
 
 Ignore=Abaikan
 
 Import=Impor
 
-Import_and_keep_old_entry=Impor_dan_pertahankan_entri_lama
+Import\ and\ keep\ old\ entry=Impor dan pertahankan entri lama
 
-Import_and_remove_old_entry=Impor_dan_hapus_entri_lama
+Import\ and\ remove\ old\ entry=Impor dan hapus entri lama
 
-Import_entries=Impor_entri
+Import\ entries=Impor entri
 
-Import_failed=Impor_gagal
+Import\ failed=Impor gagal
 
-Import_file=Impor_berkas
+Import\ file=Impor berkas
 
-Import_group_definitions=Impor_definisi_grup
+Import\ group\ definitions=Impor definisi grup
 
-Import_name=Impor_nama
+Import\ name=Impor nama
 
-Import_preferences=Preferensi_Impor
+Import\ preferences=Preferensi Impor
 
-Import_preferences_from_file=Impor_preferensi_dari_berkas
+Import\ preferences\ from\ file=Impor preferensi dari berkas
 
-Import_strings=Impor_string
+Import\ strings=Impor string
 
-Import_to_open_tab=Impor_ke_tab_yang_dibuka
+Import\ to\ open\ tab=Impor ke tab yang dibuka
 
-Import_word_selector_definitions=Impor_definisi_pemilih_kata
+Import\ word\ selector\ definitions=Impor definisi pemilih kata
 
-Imported_entries=entri_diimpor
+Imported\ entries=entri diimpor
 
-Imported_from_library=diimpor_dari_basisdata
+Imported\ from\ library=diimpor dari basisdata
 
-Importer_class=kelas_Importer
+Importer\ class=kelas Importer
 
-Importing=Sedang_mengimpor
+Importing=Sedang mengimpor
 
-Importing_in_unknown_format=Mengimpor_pada_format_tidak_dikenal
+Importing\ in\ unknown\ format=Mengimpor pada format tidak dikenal
 
-Include_abstracts=Termasuk_abstrak
-Include_entries=Termasuk_entri
+Include\ abstracts=Termasuk abstrak
+Include\ entries=Termasuk entri
 
-Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups=Termasuk_sub-grup\:_Ketika_dipilih,_lihat_entri_yang_ada_di_grup_atau_sub-grup_ini.
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=Termasuk sub-grup: Ketika dipilih, lihat entri yang ada di grup atau sub-grup ini.
 
-Independent_group\:_When_selected,_view_only_this_group's_entries=Grup_bebas\:_Ketika_dipilih,_lihat_hanya_entri_grup_ini
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=Grup bebas: Ketika dipilih, lihat hanya entri grup ini
 
-Work_options=
+Work\ options=
 
 Insert=Sisipkan
 
-Insert_rows=Sisipkan_baris
+Insert\ rows=Sisipkan baris
 
 Intersection=Interseksi
 
-Invalid_BibTeX_key=Kunci_BibTeX_salah
+Invalid\ BibTeX\ key=Kunci BibTeX salah
 
-Invalid_date_format=Format_hari_salah
+Invalid\ date\ format=Format hari salah
 
-Invalid_URL=URL_salah
+Invalid\ URL=URL salah
 
-Online_help=
+Online\ help=
 
-JabRef_preferences=Preferensi_JabRef
+JabRef\ preferences=Preferensi JabRef
 
 Join=
 
-Joins_selected_keywords_and_deletes_selected_keywords.=
+Joins\ selected\ keywords\ and\ deletes\ selected\ keywords.=
 
-Journal_abbreviations=Singkatan_nama_Jurnal
+Journal\ abbreviations=Singkatan nama Jurnal
 
 Keep=Tetap
 
-Keep_both=Tetap_keduanya
+Keep\ both=Tetap keduanya
 
-Key_bindings=Gabungan_kunci
+Key\ bindings=Gabungan kunci
 
-Key_bindings_changed=Gabungan_kunci_berubah
+Key\ bindings\ changed=Gabungan kunci berubah
 
-Key_generator_settings=Pengaturan_pembuat_kunci
+Key\ generator\ settings=Pengaturan pembuat kunci
 
-Key_pattern=Pola_kunci
+Key\ pattern=Pola kunci
 
-keys_in_library=daftar_kunci_di_basisdata
+keys\ in\ library=daftar kunci di basisdata
 
 Keyword=katakunci
 
@@ -693,449 +693,449 @@ Label=Label
 
 Language=Bahasa
 
-Last_modified=Terakhir_diubah
+Last\ modified=Terakhir diubah
 
-LaTeX_AUX_file=berkas_LaTeX_AUX
-Leave_file_in_its_current_directory=Tinggalkan_berkas_di_direktori_yg_sekarang
+LaTeX\ AUX\ file=berkas LaTeX AUX
+Leave\ file\ in\ its\ current\ directory=Tinggalkan berkas di direktori yg sekarang
 
 Left=Kiri
 Level=
 
-Limit_to_fields=Batasi_ke_bidang
+Limit\ to\ fields=Batasi ke bidang
 
-Limit_to_selected_entries=Batasi_ke_entri_pilihan
+Limit\ to\ selected\ entries=Batasi ke entri pilihan
 
 Link=Tautan
-Link_local_file=Tautan_berkas_lokal
-Link_to_file_%0=Tautan_ke_berkas_%0
+Link\ local\ file=Tautan berkas lokal
+Link\ to\ file\ %0=Tautan ke berkas %0
 
-Listen_for_remote_operation_on_port=Menggunakan_operasi_jarak_jauh_pada_port
-Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)=Muat_dan_Simpan_preferensi_dari/ke_jabref.xml_ketika_memulai_(mode_pena_simpan)
+Listen\ for\ remote\ operation\ on\ port=Menggunakan operasi jarak jauh pada port
+Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=Muat dan Simpan preferensi dari/ke jabref.xml ketika memulai (mode pena simpan)
 
-Look_and_feel=Penampilan_artistik
-Main_file_directory=Lokasi_berkas_utama
+Look\ and\ feel=Penampilan artistik
+Main\ file\ directory=Lokasi berkas utama
 
-Main_layout_file=Berkas_tataletak_utama
+Main\ layout\ file=Berkas tataletak utama
 
-Manage_custom_exports=Mengatur_ekspor_atursendiri
+Manage\ custom\ exports=Mengatur ekspor atursendiri
 
-Manage_custom_imports=Mengatur_impor_atursendiri
-Manage_external_file_types=Pengaturan_program_eksternal
+Manage\ custom\ imports=Mengatur impor atursendiri
+Manage\ external\ file\ types=Pengaturan program eksternal
 
-Mark_entries=Tandai_entri
+Mark\ entries=Tandai entri
 
-Mark_entry=Tandai_entri
+Mark\ entry=Tandai entri
 
-Mark_new_entries_with_addition_date=Tandai_entri_baru_dengan_tambahan_tanggal
+Mark\ new\ entries\ with\ addition\ date=Tandai entri baru dengan tambahan tanggal
 
-Mark_new_entries_with_owner_name=Tandai_entri_baru_dengan_nama_pemilik
+Mark\ new\ entries\ with\ owner\ name=Tandai entri baru dengan nama pemilik
 
-Memory_stick_mode=Mode_Pena_Simpan
+Memory\ stick\ mode=Mode Pena Simpan
 
-Menu_and_label_font_size=Ukuran_huruf_menu_dan_label
+Menu\ and\ label\ font\ size=Ukuran huruf menu dan label
 
-Merged_external_changes=Menggabung_perubahan_eksternal
+Merged\ external\ changes=Menggabung perubahan eksternal
 
 Messages=Pesan
 
-Modification_of_field=Modifikasi_bidang
+Modification\ of\ field=Modifikasi bidang
 
-Modified_group_"%0".=Grup_dimodifikasi_"%0".
+Modified\ group\ "%0".=Grup dimodifikasi "%0".
 
-Modified_groups=Grup_dimodifikasi
+Modified\ groups=Grup dimodifikasi
 
-Modified_string=String_dimodifikasi
+Modified\ string=String dimodifikasi
 
 Modify=Memodifikasi
 
-modify_group=memodifikasi_grup
+modify\ group=memodifikasi grup
 
-Move_down=Pindah_kebawah
+Move\ down=Pindah kebawah
 
-Move_external_links_to_'file'_field=Pindah_tautan_eksternal_ke_bidang_'berkas'
+Move\ external\ links\ to\ 'file'\ field=Pindah tautan eksternal ke bidang 'berkas'
 
-move_group=pindah_grup
+move\ group=pindah grup
 
-Move_up=Pindah_keatas
+Move\ up=Pindah keatas
 
-Moved_group_"%0".=Grup_dipindah_"%0".
+Moved\ group\ "%0".=Grup dipindah "%0".
 
 Name=Nama
-Name_formatter=Pemformat_nama
+Name\ formatter=Pemformat nama
 
-Natbib_style=Gaya_Natbib
+Natbib\ style=Gaya Natbib
 
-nested_AUX_files=berkas_AUX_bertingkat
+nested\ AUX\ files=berkas AUX bertingkat
 
 New=Baru
 
 new=baru
 
-New_BibTeX_entry=Entri_BibTeX_baru
+New\ BibTeX\ entry=Entri BibTeX baru
 
-New_BibTeX_sublibrary=Anak_basisdata_BibTeX_baru
+New\ BibTeX\ sublibrary=Anak basisdata BibTeX baru
 
-New_content=Isi_baru
+New\ content=Isi baru
 
-New_library_created.=Basisdata_baru_selesai_dibuat.
-New_%0_library=Basisdata_baru_%0
-New_field_value=Isi_bidang_baru
+New\ library\ created.=Basisdata baru selesai dibuat.
+New\ %0\ library=Basisdata baru %0
+New\ field\ value=Isi bidang baru
 
-New_group=Grup_baru
+New\ group=Grup baru
 
-New_string=String_baru
+New\ string=String baru
 
-Next_entry=Entri_berikutnya
+Next\ entry=Entri berikutnya
 
-No_actual_changes_found.=Tidak_ada_perubahan.
+No\ actual\ changes\ found.=Tidak ada perubahan.
 
-no_base-BibTeX-file_specified=tidak_ada_berkas_berbasis_BibTeX_dinyatakan
+no\ base-BibTeX-file\ specified=tidak ada berkas berbasis BibTeX dinyatakan
 
-no_library_generated=tidak_ada_basisdata_dibuat
+no\ library\ generated=tidak ada basisdata dibuat
 
-No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.=Entri_tidak_ditemukan._Pastikan_anda_menggunakan_penapis_impor_yang_tepat.
+No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=Entri tidak ditemukan. Pastikan anda menggunakan penapis impor yang tepat.
 
 
-No_entries_found_for_the_search_string_'%0'=Tidak_adan_entri_ditemukan_untuk_pencarian_string_'%0'
+No\ entries\ found\ for\ the\ search\ string\ '%0'=Tidak adan entri ditemukan untuk pencarian string '%0'
 
-No_entries_imported.=Tidak_ada_entri_yang_diimpor.
+No\ entries\ imported.=Tidak ada entri yang diimpor.
 
-No_files_found.=Berkas_tidak_ditemukan.
+No\ files\ found.=Berkas tidak ditemukan.
 
-No_GUI._Only_process_command_line_options.=Tidak_ada_GUI._Hanya_menggunakan_perintah_baris.
+No\ GUI.\ Only\ process\ command\ line\ options.=Tidak ada GUI. Hanya menggunakan perintah baris.
 
-No_journal_names_could_be_abbreviated.=Tidak_ada_nama_jurnal_yang_bisa_disingkat.
+No\ journal\ names\ could\ be\ abbreviated.=Tidak ada nama jurnal yang bisa disingkat.
 
-No_journal_names_could_be_unabbreviated.=Tidak_ada_ada_nama_jurnal_yang_bisa_dipanjangkan.
-No_PDF_linked=Tidak_ada_tautan_PDF
+No\ journal\ names\ could\ be\ unabbreviated.=Tidak ada ada nama jurnal yang bisa dipanjangkan.
+No\ PDF\ linked=Tidak ada tautan PDF
 
-Open_PDF=
+Open\ PDF=
 
-No_URL_defined=Tidak_ada_URL_didefinisikan
+No\ URL\ defined=Tidak ada URL didefinisikan
 not=tidak
 
-not_found=tidak_ditemukan
+not\ found=tidak ditemukan
 
-Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,=Anda_harus_menyatakan_nama_kelas_spesifik_yang_akan_digunakan
+Note\ that\ you\ must\ specify\ the\ fully\ qualified\ class\ name\ for\ the\ look\ and\ feel,=Anda harus menyatakan nama kelas spesifik yang akan digunakan
 
-Nothing_to_redo=Tidak_ada_yang_dibatalkan
+Nothing\ to\ redo=Tidak ada yang dibatalkan
 
-Nothing_to_undo=Tidak_ada_yang_dikembalikan
+Nothing\ to\ undo=Tidak ada yang dikembalikan
 
 occurrences=kali
 
 OK=Ok
-One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Satu_atau_lebih_tautan_berkas_dari_tipe_'%0',_yang_tidak_didefinisikan._Apa_yang_anda_inginkan?
+One\ or\ more\ file\ links\ are\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Satu atau lebih tautan berkas dari tipe '%0', yang tidak didefinisikan. Apa yang anda inginkan?
 
-One_or_more_keys_will_be_overwritten._Continue?=Satu_atau_lebih_kunci_akan_ditindih._Teruskan?
+One\ or\ more\ keys\ will\ be\ overwritten.\ Continue?=Satu atau lebih kunci akan ditindih. Teruskan?
 
 
 Open=Buka
 
-Open_BibTeX_library=Buka_basisdata_BibTeX
+Open\ BibTeX\ library=Buka basisdata BibTeX
 
-Open_library=Buka_basisdata
+Open\ library=Buka basisdata
 
-Open_editor_when_a_new_entry_is_created=Buka_penyunting_ketika_entri_baru_dibuat
+Open\ editor\ when\ a\ new\ entry\ is\ created=Buka penyunting ketika entri baru dibuat
 
-Open_file=Buka_berkas
+Open\ file=Buka berkas
 
-Open_last_edited_libraries_at_startup=Buka_basisdata_terakhir_ketika_memulai
+Open\ last\ edited\ libraries\ at\ startup=Buka basisdata terakhir ketika memulai
 
-Connect_to_shared_database=
+Connect\ to\ shared\ database=
 
-Open_terminal_here=Buka_terminal_di_sini
+Open\ terminal\ here=Buka terminal di sini
 
-Open_URL_or_DOI=Buka_URL_atau_DOI
+Open\ URL\ or\ DOI=Buka URL atau DOI
 
-Opened_library=Basisdata_dibuka
+Opened\ library=Basisdata dibuka
 
 Opening=Membuka
 
-Opening_preferences...=Membuka_preferensi...
+Opening\ preferences...=Membuka preferensi...
 
-Operation_canceled.=Operasi_dibatalkan.
-Operation_not_supported=Operasi_tidak_didukung
+Operation\ canceled.=Operasi dibatalkan.
+Operation\ not\ supported=Operasi tidak didukung
 
-Optional_fields=Bidang_tambahan
+Optional\ fields=Bidang tambahan
 
 Options=Pilihan
 
 or=atau
 
-Output_or_export_file=Keluaran_atau_berkas_ekspor
+Output\ or\ export\ file=Keluaran atau berkas ekspor
 
 Override=Ganti
 
-Override_default_file_directories=Ganti_direktori_berkas_bawaan
+Override\ default\ file\ directories=Ganti direktori berkas bawaan
 
-Override_default_font_settings=Ganti_ukuran_huruf_bawaan
+Override\ default\ font\ settings=Ganti ukuran huruf bawaan
 
-Override_the_BibTeX_field_by_the_selected_text=Ganti_kunci_BibTeX_dengan_pilihan_teks
+Override\ the\ BibTeX\ field\ by\ the\ selected\ text=Ganti kunci BibTeX dengan pilihan teks
 
 
 Overwrite=Tindih
-Overwrite_existing_field_values=Tindih_isi_bidang_yang_ada
+Overwrite\ existing\ field\ values=Tindih isi bidang yang ada
 
-Overwrite_keys=Tindih_kunci
+Overwrite\ keys=Tindih kunci
 
-pairs_processed=proses_berpasangan
+pairs\ processed=proses berpasangan
 Password=Katalaluan
 
 Paste=Tempel
 
-paste_entries=tempel_entri
+paste\ entries=tempel entri
 
-paste_entry=tempel_entri
-Paste_from_clipboard=Tempel_dari_papan_klip
+paste\ entry=tempel entri
+Paste\ from\ clipboard=Tempel dari papan klip
 
 Pasted=Ditempel
 
-Path_to_%0_not_defined=Lokasi_%0_tidak_ada
+Path\ to\ %0\ not\ defined=Lokasi %0 tidak ada
 
-Path_to_LyX_pipe=Lokasi_pipa_LyX
+Path\ to\ LyX\ pipe=Lokasi pipa LyX
 
-PDF_does_not_exist=PDF_tidak_ada
+PDF\ does\ not\ exist=PDF tidak ada
 
-File_has_no_attached_annotations=
+File\ has\ no\ attached\ annotations=
 
-Plain_text_import=Impor_teks_normal
+Plain\ text\ import=Impor teks normal
 
-Please_enter_a_name_for_the_group.=Tuliskan_nama_untuk_grup.
+Please\ enter\ a\ name\ for\ the\ group.=Tuliskan nama untuk grup.
 
-Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>=Tuliskan_kata_pencarian._Contoh,_untuk_mencari_di_semua_bidang_<b>Smith</b>,_tulis\:<p><tt>smith</tt><p>Untuk_mencari_pada_bidang_<b>Author</b>_untuk_<b>Smith</b>_dan_pada_bidang_<b>Title</b>_untuk_<b>electrical</b>,_tulis\:<p><tt>author\=smith_dan_title\=electrical</tt>
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Tuliskan kata pencarian. Contoh, untuk mencari di semua bidang <b>Smith</b>, tulis:<p><tt>smith</tt><p>Untuk mencari pada bidang <b>Author</b> untuk <b>Smith</b> dan pada bidang <b>Title</b> untuk <b>electrical</b>, tulis:<p><tt>author=smith dan title=electrical</tt>
 
-Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=Tulis_bidang_pencarian_(misal_<b>keywords</b>)_dan_katakunci_untuk_mencari_(misal_<b>electrical</b>).
+Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=Tulis bidang pencarian (misal <b>keywords</b>) dan katakunci untuk mencari (misal <b>electrical</b>).
 
-Please_enter_the_string's_label=Tuliskan_label_string
+Please\ enter\ the\ string's\ label=Tuliskan label string
 
-Please_select_an_importer.=Silahkan_pilih_pengimpor.
+Please\ select\ an\ importer.=Silahkan pilih pengimpor.
 
-Possible_duplicate_entries=Mungkin_entri_sama
+Possible\ duplicate\ entries=Mungkin entri sama
 
-Possible_duplicate_of_existing_entry._Click_to_resolve.=Mungkin_entri_sama_dengan_lainnya._Klik_untuk_menyelesaikan.
+Possible\ duplicate\ of\ existing\ entry.\ Click\ to\ resolve.=Mungkin entri sama dengan lainnya. Klik untuk menyelesaikan.
 
 Preamble=Preambel
 
 Preferences=Preferensi
 
-Preferences_recorded.=Preferensi_disimpan.
+Preferences\ recorded.=Preferensi disimpan.
 
 Preview=Pratampilan
-Citation_Style=
-Current_Preview=
-Cannot_generate_preview_based_on_selected_citation_style.=
-Bad_character_inside_entry=
-Error_while_generating_citation_style=
-Preview_style_changed_to\:_%0=
-Next_preview_layout=
-Previous_preview_layout=
+Citation\ Style=
+Current\ Preview=
+Cannot\ generate\ preview\ based\ on\ selected\ citation\ style.=
+Bad\ character\ inside\ entry=
+Error\ while\ generating\ citation\ style=
+Preview\ style\ changed\ to\:\ %0=
+Next\ preview\ layout=
+Previous\ preview\ layout=
 
-Previous_entry=Entri_sebelumnya
+Previous\ entry=Entri sebelumnya
 
-Primary_sort_criterion=Kriteria_pertama
-Problem_with_parsing_entry=Permasalahan_dengan_penguraian_entri
-Processing_%0=Memroses_%0
-Pull_changes_from_shared_database=
+Primary\ sort\ criterion=Kriteria pertama
+Problem\ with\ parsing\ entry=Permasalahan dengan penguraian entri
+Processing\ %0=Memroses %0
+Pull\ changes\ from\ shared\ database=
 
-Pushed_citations_to_%0=Kirim_acuan_ke_%0
+Pushed\ citations\ to\ %0=Kirim acuan ke %0
 
-Quit_JabRef=Keluar_JabRef
+Quit\ JabRef=Keluar JabRef
 
-Quit_synchronization=Keluar_sinkronisasi
+Quit\ synchronization=Keluar sinkronisasi
 
-Raw_source=Sumber_asli
+Raw\ source=Sumber asli
 
-Rearrange_tabs_alphabetically_by_title=Mengatur_tab_judul_berdasarkan_alfabet
+Rearrange\ tabs\ alphabetically\ by\ title=Mengatur tab judul berdasarkan alfabet
 
 Redo=Mengembalikan
 
-Reference_library=Basisdata_acuan
+Reference\ library=Basisdata acuan
 
-%0_references_found._Number_of_references_to_fetch?=Acuan_ditemukan\:_%0._Nomor_referensi_yang_diambil?
+%0\ references\ found.\ Number\ of\ references\ to\ fetch?=Acuan ditemukan: %0. Nomor referensi yang diambil?
 
-Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Perbaiki_supergrup\:_Ketika_dipilih,_lihat_entri_yang_ada_di_grup_ini_dan_supergrup
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=Perbaiki supergrup: Ketika dipilih, lihat entri yang ada di grup ini dan supergrup
 
-regular_expression=Ekspresi_reguler
+regular\ expression=Ekspresi reguler
 
-Related_articles=
+Related\ articles=
 
-Remote_operation=Penggunaan_jarak_jauh
+Remote\ operation=Penggunaan jarak jauh
 
-Remote_server_port=Port_server_jauh
+Remote\ server\ port=Port server jauh
 
 Remove=Hapus
 
-Remove_subgroups=Hapus_semua_sub-grup
+Remove\ subgroups=Hapus semua sub-grup
 
-Remove_all_subgroups_of_"%0"?=Hapus_semua_sub-grup_dari_"%0"?
+Remove\ all\ subgroups\ of\ "%0"?=Hapus semua sub-grup dari "%0"?
 
-Remove_entry_from_import=Hapus_entri_dari_impor
+Remove\ entry\ from\ import=Hapus entri dari impor
 
-Remove_selected_entries_from_this_group=
+Remove\ selected\ entries\ from\ this\ group=
 
-Remove_entry_type=Hapus_tipe_entri
+Remove\ entry\ type=Hapus tipe entri
 
-Remove_from_group=Hapus_dari_grup
+Remove\ from\ group=Hapus dari grup
 
-Remove_group=Hapus_grup
+Remove\ group=Hapus grup
 
-Remove_group,_keep_subgroups=Hapus_grup,_sub-grup_tetap
+Remove\ group,\ keep\ subgroups=Hapus grup, sub-grup tetap
 
-Remove_group_"%0"?=Hapus_grup_"%0"?
+Remove\ group\ "%0"?=Hapus grup "%0"?
 
-Remove_group_"%0"_and_its_subgroups?=Hapus_grup_"%0"_dan_sub-grup_nya?
+Remove\ group\ "%0"\ and\ its\ subgroups?=Hapus grup "%0" dan sub-grup nya?
 
-remove_group_(keep_subgroups)=hapus_grup_(pertahankan_sub-grup)
+remove\ group\ (keep\ subgroups)=hapus grup (pertahankan sub-grup)
 
-remove_group_and_subgroups=hapus_grup_dan_sub-grup
+remove\ group\ and\ subgroups=hapus grup dan sub-grup
 
-Remove_group_and_subgroups=Hapus_grup_dan_sub-grup
+Remove\ group\ and\ subgroups=Hapus grup dan sub-grup
 
-Remove_link=Hapus_tautan
+Remove\ link=Hapus tautan
 
-Remove_old_entry=Hapus_entri_lama
+Remove\ old\ entry=Hapus entri lama
 
-Remove_selected_strings=Hapus_string_pilihan
+Remove\ selected\ strings=Hapus string pilihan
 
-Removed_group_"%0".=Hapus_grup_"%0".
+Removed\ group\ "%0".=Hapus grup "%0".
 
-Removed_group_"%0"_and_its_subgroups.=Hapus_grup_"%0"_dan_sub-grup_nya.
+Removed\ group\ "%0"\ and\ its\ subgroups.=Hapus grup "%0" dan sub-grup nya.
 
-Removed_string=Hapus_string
+Removed\ string=Hapus string
 
-Renamed_string=Ganti_nama_string
+Renamed\ string=Ganti nama string
 
 Replace=
 
-Replace_(regular_expression)=Ganti_(ekspresi_reguler)
+Replace\ (regular\ expression)=Ganti (ekspresi reguler)
 
-Replace_string=Ganti_string
+Replace\ string=Ganti string
 
-Replace_with=Ganti_dengan
+Replace\ with=Ganti dengan
 
 Replaced=Diganti
 
-Required_fields=Bidang_diperlukan
+Required\ fields=Bidang diperlukan
 
-Reset_all=Atur_ulang_semua
+Reset\ all=Atur ulang semua
 
-Resolve_strings_for_all_fields_except=Selesaikan_masalah_string_untuk_semua_bidang_kecuali
-Resolve_strings_for_standard_BibTeX_fields_only=Selesaikan_masalah_string_hanya_pada_bidang_BibTeX_standar
+Resolve\ strings\ for\ all\ fields\ except=Selesaikan masalah string untuk semua bidang kecuali
+Resolve\ strings\ for\ standard\ BibTeX\ fields\ only=Selesaikan masalah string hanya pada bidang BibTeX standar
 
-resolved=sudah_diselesaikan
+resolved=sudah diselesaikan
 
-Review=Periksa_ulang
+Review=Periksa ulang
 
-Review_changes=Periksa_ulang_perubahan
+Review\ changes=Periksa ulang perubahan
 
 Right=Kanan
 
 Save=Simpan
-Save_all_finished.=Simpan_semua_selesai.
+Save\ all\ finished.=Simpan semua selesai.
 
-Save_all_open_libraries=Simpan_semua_basisdata_yang_dibuka
+Save\ all\ open\ libraries=Simpan semua basisdata yang dibuka
 
-Save_before_closing=Simpan_sebelum_menutup
+Save\ before\ closing=Simpan sebelum menutup
 
-Save_library=Simpan_basisdata
-Save_library_as...=Simpan_basisdata_sebagai...
+Save\ library=Simpan basisdata
+Save\ library\ as...=Simpan basisdata sebagai...
 
-Save_entries_in_their_original_order=Simpan_entri_pada_urutan_aslinya
+Save\ entries\ in\ their\ original\ order=Simpan entri pada urutan aslinya
 
-Save_failed=Gagal_menyimpan
+Save\ failed=Gagal menyimpan
 
-Save_failed_during_backup_creation=Gagal_menyimpan_waktu_membuat_cadangan
+Save\ failed\ during\ backup\ creation=Gagal menyimpan waktu membuat cadangan
 
-Save_selected_as...=Simpan_pilihan_sebagai...
+Save\ selected\ as...=Simpan pilihan sebagai...
 
-Saved_library=Basisdata_disimpan
+Saved\ library=Basisdata disimpan
 
-Saved_selected_to_'%0'.=Simpan_pilihan_ke_'%0'.
+Saved\ selected\ to\ '%0'.=Simpan pilihan ke '%0'.
 
 Saving=Menyimpan
-Saving_all_libraries...=Menyimpan_semua_basisdata...
+Saving\ all\ libraries...=Menyimpan semua basisdata...
 
-Saving_library=Menyimpan_basisdata
+Saving\ library=Menyimpan basisdata
 
 Search=Cari
 
-Search_expression=Ekspresi_pencarian
+Search\ expression=Ekspresi pencarian
 
-Search_for=Mencari
+Search\ for=Mencari
 
-Searching_for_duplicates...=pencarian_hal_yang_sama...
+Searching\ for\ duplicates...=pencarian hal yang sama...
 
-Searching_for_files=Mencari_berkas
+Searching\ for\ files=Mencari berkas
 
-Secondary_sort_criterion=Kriteria_kedua
+Secondary\ sort\ criterion=Kriteria kedua
 
-Select_all=Pilih_semua
+Select\ all=Pilih semua
 
-Select_encoding=Pilih_enkoding
+Select\ encoding=Pilih enkoding
 
-Select_entry_type=Pilih_tipe_entri
-Select_external_application=Pilih_aplikasi_eksternal
+Select\ entry\ type=Pilih tipe entri
+Select\ external\ application=Pilih aplikasi eksternal
 
-Select_file_from_ZIP-archive=Pilih_berkas_dari_arsip_ZIP
+Select\ file\ from\ ZIP-archive=Pilih berkas dari arsip ZIP
 
-Select_the_tree_nodes_to_view_and_accept_or_reject_changes=Pilih_tiga_nodal_untuk_melihat,_menerima_atau_menolak_perubahan
-Selected_entries=Entri_pilihan
-Set_field=Pilih_bidang
-Set_fields=Pilih_beberapa_bidang
+Select\ the\ tree\ nodes\ to\ view\ and\ accept\ or\ reject\ changes=Pilih tiga nodal untuk melihat, menerima atau menolak perubahan
+Selected\ entries=Entri pilihan
+Set\ field=Pilih bidang
+Set\ fields=Pilih beberapa bidang
 
-Set_general_fields=Pilih_bidang_umum
-Set_main_external_file_directory=Tetapkan_direktori_utama_berkas_eksternal
+Set\ general\ fields=Pilih bidang umum
+Set\ main\ external\ file\ directory=Tetapkan direktori utama berkas eksternal
 
-Set_table_font=Tetapkan_huruf_tabel
+Set\ table\ font=Tetapkan huruf tabel
 
 Settings=Pengaturan
 
 Shortcut=Pintasan
 
-Show/edit_%0_source=
+Show/edit\ %0\ source=
 
-Show_'Firstname_Lastname'=Tampil_'Depan_Belakang'
+Show\ 'Firstname\ Lastname'=Tampil 'Depan Belakang'
 
-Show_'Lastname,_Firstname'=Tampil_'Belakang_Depan'
+Show\ 'Lastname,\ Firstname'=Tampil 'Belakang Depan'
 
-Show_BibTeX_source_by_default=Tampilkan_sumber_BibTeX_sebagai_bawaan
+Show\ BibTeX\ source\ by\ default=Tampilkan sumber BibTeX sebagai bawaan
 
-Show_confirmation_dialog_when_deleting_entries=Tampilkan_dialog_konfirmasi_jika_menghapus_entri
+Show\ confirmation\ dialog\ when\ deleting\ entries=Tampilkan dialog konfirmasi jika menghapus entri
 
-Show_description=Tampilkan_deskripsi
+Show\ description=Tampilkan deskripsi
 
-Show_file_column=Tampilkan_kolom_berkas
+Show\ file\ column=Tampilkan kolom berkas
 
-Show_last_names_only=Tampil_hanya_nama_belakang
+Show\ last\ names\ only=Tampil hanya nama belakang
 
-Show_names_unchanged=Nama_apa_adanya
+Show\ names\ unchanged=Nama apa adanya
 
-Show_optional_fields=Tampilkan_bidang_tambahan
+Show\ optional\ fields=Tampilkan bidang tambahan
 
-Show_required_fields=Tampilkan_bidang_utama
+Show\ required\ fields=Tampilkan bidang utama
 
-Show_URL/DOI_column=Tampilkan_kolom_URL/DOI
+Show\ URL/DOI\ column=Tampilkan kolom URL/DOI
 
-Simple_HTML=HTML_sederhana
+Simple\ HTML=HTML sederhana
 
 Size=Ukuran
 
-Skipped_-_No_PDF_linked=Dilompati_-_Tanpa_tautan_PDF
-Skipped_-_PDF_does_not_exist=Dilompati_-_PDF_tidak_ada
+Skipped\ -\ No\ PDF\ linked=Dilompati - Tanpa tautan PDF
+Skipped\ -\ PDF\ does\ not\ exist=Dilompati - PDF tidak ada
 
-Skipped_entry.=Entri_dilompati.
+Skipped\ entry.=Entri dilompati.
 
-Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.=
+Some\ appearance\ settings\ you\ changed\ require\ to\ restart\ JabRef\ to\ come\ into\ effect.=
 
-source_edit=sunting_sumber
-Special_name_formatters=Pemformat_Nama_Spesial
+source\ edit=sunting sumber
+Special\ name\ formatters=Pemformat Nama Spesial
 
-Special_table_columns=Kolom_tabe_khusus
+Special\ table\ columns=Kolom tabe khusus
 
-Starting_import=Memulai_impor
+Starting\ import=Memulai impor
 
-Statically_group_entries_by_manual_assignment=Entri_grup_statik_secara_penerapan_manual
+Statically\ group\ entries\ by\ manual\ assignment=Entri grup statik secara penerapan manual
 
 Status=Status
 
@@ -1143,1019 +1143,1019 @@ Stop=Berhenti
 
 Strings=String
 
-Strings_for_library=String_untuk_basisdata
+Strings\ for\ library=String untuk basisdata
 
-Sublibrary_from_AUX=Sub-basisdata_dari_AUX
+Sublibrary\ from\ AUX=Sub-basisdata dari AUX
 
-Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.=Menukar_antara_nama_jurnal_penuh_dan_singkatan_jika_nama_jurnal_diketahui.
+Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=Menukar antara nama jurnal penuh dan singkatan jika nama jurnal diketahui.
 
-Synchronize_file_links=Sinkronkan_tautan_berkas
+Synchronize\ file\ links=Sinkronkan tautan berkas
 
-Synchronizing_file_links...=Sinkronisasi_berkas_tautan...
+Synchronizing\ file\ links...=Sinkronisasi berkas tautan...
 
-Table_appearance=Penampilan_tabel
+Table\ appearance=Penampilan tabel
 
-Table_background_color=Latar_tabel
+Table\ background\ color=Latar tabel
 
-Table_grid_color=Jejaring
+Table\ grid\ color=Jejaring
 
-Table_text_color=Teks
+Table\ text\ color=Teks
 
-Tabname=Nama_tab
-Target_file_cannot_be_a_directory.=Berkas_target_tidak_boleh_nama_folder
+Tabname=Nama tab
+Target\ file\ cannot\ be\ a\ directory.=Berkas target tidak boleh nama folder
 
-Tertiary_sort_criterion=Kriteria_ketiga
+Tertiary\ sort\ criterion=Kriteria ketiga
 
-Test=Coba_lihat
+Test=Coba lihat
 
-paste_text_here=Area_Masukan_Teks
+paste\ text\ here=Area Masukan Teks
 
-The_chosen_date_format_for_new_entries_is_not_valid=Format_hari_yang_dipilih_untuk_entri_baru_tidak_sah
+The\ chosen\ date\ format\ for\ new\ entries\ is\ not\ valid=Format hari yang dipilih untuk entri baru tidak sah
 
-The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:=Enkoding_yang_dipilih_'%0'_tidak_bisa_digunakan_untuk_karakter_berikut\:
+The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=Enkoding yang dipilih '%0' tidak bisa digunakan untuk karakter berikut:
 
 
-the_field_<b>%0</b>=bidang_<b>%0</b>
+the\ field\ <b>%0</b>=bidang <b>%0</b>
 
-The_file<BR>'%0'<BR>has_been_modified<BR>externally\!=Berkas<BR>'%0'<BR>telah_diubah<BR>oleh_program_eksternal\!
+The\ file<BR>'%0'<BR>has\ been\ modified<BR>externally\!=Berkas<BR>'%0'<BR>telah diubah<BR>oleh program eksternal!
 
-The_group_"%0"_already_contains_the_selection.=Grup_"%0"_sudah_mengandung_pilihan.
+The\ group\ "%0"\ already\ contains\ the\ selection.=Grup "%0" sudah mengandung pilihan.
 
-The_label_of_the_string_cannot_be_a_number.=Label_untuk_string_tidak_boleh_berupa_angka.
+The\ label\ of\ the\ string\ cannot\ be\ a\ number.=Label untuk string tidak boleh berupa angka.
 
-The_label_of_the_string_cannot_contain_spaces.=Label_untuk_string_tidak_boleh_ada_spasi.
+The\ label\ of\ the\ string\ cannot\ contain\ spaces.=Label untuk string tidak boleh ada spasi.
 
-The_label_of_the_string_cannot_contain_the_'\#'_character.=Label_string_tidak_boleh_mengandung_karakter_'\#'.
+The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=Label string tidak boleh mengandung karakter '#'.
 
-The_output_option_depends_on_a_valid_import_option.=Pilihan_keluaran_tergantung_dari_pilihan_impor_yang_sah.
-The_PDF_contains_one_or_several_BibTeX-records.=PDF_mengandung_satu_atau_beberapa_data_BibTeX.
-Do_you_want_to_import_these_as_new_entries_into_the_current_library?=Apakah_anda_ingin_impor_sebagai_entri_baru_pada_basisdata_sekarang?
+The\ output\ option\ depends\ on\ a\ valid\ import\ option.=Pilihan keluaran tergantung dari pilihan impor yang sah.
+The\ PDF\ contains\ one\ or\ several\ BibTeX-records.=PDF mengandung satu atau beberapa data BibTeX.
+Do\ you\ want\ to\ import\ these\ as\ new\ entries\ into\ the\ current\ library?=Apakah anda ingin impor sebagai entri baru pada basisdata sekarang?
 
-The_regular_expression_<b>%0</b>_is_invalid\:=Ekspresi_reguler_<b>%0</b>_tidak_sah\:
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=Ekspresi reguler <b>%0</b> tidak sah:
 
-The_search_is_case_insensitive.=Pencarian_tidak_meperhitungkan_huruf_besar_kecil.
+The\ search\ is\ case\ insensitive.=Pencarian tidak meperhitungkan huruf besar kecil.
 
-The_search_is_case_sensitive.=Pencarian_meperhitungkan_huruf_besar_kecil.
+The\ search\ is\ case\ sensitive.=Pencarian meperhitungkan huruf besar kecil.
 
-The_string_has_been_removed_locally=String_sudah_dihapus_secara_lokal
+The\ string\ has\ been\ removed\ locally=String sudah dihapus secara lokal
 
-There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?=Ada_kemungkinan_sama_(ditandai_dengan_ikon)_yang_belum_diselesaikan._Teruskan?
+There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=Ada kemungkinan sama (ditandai dengan ikon) yang belum diselesaikan. Teruskan?
 
-This_entry_has_no_BibTeX_key._Generate_key_now?=Entri_ini_belum_mempunyai_kunci_BibTeX._Membuat_kunci_sekarang?
+This\ entry\ has\ no\ BibTeX\ key.\ Generate\ key\ now?=Entri ini belum mempunyai kunci BibTeX. Membuat kunci sekarang?
 
-This_entry_is_incomplete=Entri_belum_lengkap
+This\ entry\ is\ incomplete=Entri belum lengkap
 
-This_entry_type_cannot_be_removed.=Tipe_entri_tidak_bisa_dihapus.
+This\ entry\ type\ cannot\ be\ removed.=Tipe entri tidak bisa dihapus.
 
-This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Tautan_eksternal_dari_tipe_'%0',_yang_belum_didefinisikan._Apa_yang_akan_anda_lakukan?
+This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Tautan eksternal dari tipe '%0', yang belum didefinisikan. Apa yang akan anda lakukan?
 
-This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.=Grup_ini_mempunyai_entri_berdasar_dari_pengisian_manual._Entri_dapat_dituliskan_dalam_grup_ini_dengan_cara_memilih_entri_kemudian_menggunakannya_melalui_seret_dan_tempatkan_atau_dari_konteks_menu._Entri_dapat_dihapus_dari_grup_dengan_memilih_dan_hapus_dari_konteks_menu.
+This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=Grup ini mempunyai entri berdasar dari pengisian manual. Entri dapat dituliskan dalam grup ini dengan cara memilih entri kemudian menggunakannya melalui seret dan tempatkan atau dari konteks menu. Entri dapat dihapus dari grup dengan memilih dan hapus dari konteks menu.
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>=Grup_ini_memiliki_entri_dimana_bidang_<b>%0</b>_memiliki_katakunci_<b>%1</b>
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Grup ini memiliki entri dimana bidang <b>%0</b> memiliki katakunci <b>%1</b>
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>=Grup_ini_memiliki_entri_dimana_bidang_<b>%0</b>_mempunyai_ekspresi_reguler_<b>%1</b>
-This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.=Ini_membuat_JabRef_mencari_disemua_tautan_berkas_dan_memeriksa_apakah_ada_berkas._Jika_tidak,_anda_diberi_pilihan_<BR>untuk_mengatasi_masalah.
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Grup ini memiliki entri dimana bidang <b>%0</b> mempunyai ekspresi reguler <b>%1</b>
+This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=Ini membuat JabRef mencari disemua tautan berkas dan memeriksa apakah ada berkas. Jika tidak, anda diberi pilihan <BR>untuk mengatasi masalah.
 
-This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.=Operasi_ini_memerlukan_semua_entri_mempunyai_kunci_BibTeX.
+This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=Operasi ini memerlukan semua entri mempunyai kunci BibTeX.
 
-This_operation_requires_one_or_more_entries_to_be_selected.=Operasi_ini_memerlukan_satu_atau_lebih_entri_yang_dipilih.
+This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=Operasi ini memerlukan satu atau lebih entri yang dipilih.
 
-Toggle_entry_preview=Gunakan_pratampilan_entri
-Toggle_groups_interface=Gunakan_antarmuka_grup
-Try_different_encoding=Coba_enkoding_lain
+Toggle\ entry\ preview=Gunakan pratampilan entri
+Toggle\ groups\ interface=Gunakan antarmuka grup
+Try\ different\ encoding=Coba enkoding lain
 
-Unabbreviate_journal_names_of_the_selected_entries=Nama_jurnal_tidak_disingkat_dari_entri_pilihan
-Unabbreviated_%0_journal_names.=%0_nama_jurnal_tidak_disingkat.
+Unabbreviate\ journal\ names\ of\ the\ selected\ entries=Nama jurnal tidak disingkat dari entri pilihan
+Unabbreviated\ %0\ journal\ names.=%0 nama jurnal tidak disingkat.
 
-Unable_to_open_file.=Tidak_bisa_membuka_berkas.
-Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.=Tidak_bisa_membuka_tautan._Aplikasi_'%0'_yang_berkaitan_dengan_berkas_tipe_'%0'_tidak_bisa_dimuat.
-unable_to_write_to=tidak_bisa_menulis_ke
-Undefined_file_type=tipe_berkas_tidak_terdefinisi
+Unable\ to\ open\ file.=Tidak bisa membuka berkas.
+Unable\ to\ open\ link.\ The\ application\ '%0'\ associated\ with\ the\ file\ type\ '%1'\ could\ not\ be\ called.=Tidak bisa membuka tautan. Aplikasi '%0' yang berkaitan dengan berkas tipe '%0' tidak bisa dimuat.
+unable\ to\ write\ to=tidak bisa menulis ke
+Undefined\ file\ type=tipe berkas tidak terdefinisi
 
 Undo=Batalkan
 
 Union=Menyatu
 
-Unknown_BibTeX_entries=Entri_BibTeX_tidak_dikenal
+Unknown\ BibTeX\ entries=Entri BibTeX tidak dikenal
 
-unknown_edit=suntingan_tidak_dikenal
+unknown\ edit=suntingan tidak dikenal
 
-Unknown_export_format=format_ekspor_tidak_dikenal
+Unknown\ export\ format=format ekspor tidak dikenal
 
-Unmark_all=Hilangkan_tanda_semua
+Unmark\ all=Hilangkan tanda semua
 
-Unmark_entries=Hilangkan_tanda_entri
+Unmark\ entries=Hilangkan tanda entri
 
-Unmark_entry=Hilangkan_tanda_entri
+Unmark\ entry=Hilangkan tanda entri
 
-untitled=tanpa_judul
+untitled=tanpa judul
 
 Up=Naik
 
-Update_to_current_column_widths=Perbarui_sesuai_lebar_kolom_sekarang
+Update\ to\ current\ column\ widths=Perbarui sesuai lebar kolom sekarang
 
-Updated_group_selection=Pilihan_grup_diperbarui
-Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.=Perbarui_tautan_eksternal_PDF/PS_untuk_digunakan_bidang_'%0'.
-Upgrade_file=Naiktaraf_berkas
-Upgrade_old_external_file_links_to_use_the_new_feature=Naiktaraf_tautan_berkas_eksternal_lama_untuk_digunakan_di_fitur_baru
+Updated\ group\ selection=Pilihan grup diperbarui
+Upgrade\ external\ PDF/PS\ links\ to\ use\ the\ '%0'\ field.=Perbarui tautan eksternal PDF/PS untuk digunakan bidang '%0'.
+Upgrade\ file=Naiktaraf berkas
+Upgrade\ old\ external\ file\ links\ to\ use\ the\ new\ feature=Naiktaraf tautan berkas eksternal lama untuk digunakan di fitur baru
 
 usage=penggunaan
-Use_autocompletion_for_the_following_fields=Gunakan_otomatis_melengkapi_pada_bidang_berikut
+Use\ autocompletion\ for\ the\ following\ fields=Gunakan otomatis melengkapi pada bidang berikut
 
-Use_other_look_and_feel=Gunakan_gaya_penampilan_lain
-Tweak_font_rendering_for_entry_editor_on_Linux=
-Use_regular_expression_search=Gunakan_ekspresi_pencarian_biasa
+Use\ other\ look\ and\ feel=Gunakan gaya penampilan lain
+Tweak\ font\ rendering\ for\ entry\ editor\ on\ Linux=
+Use\ regular\ expression\ search=Gunakan ekspresi pencarian biasa
 
-Username=Nama_pengguna
+Username=Nama pengguna
 
-Value_cleared_externally=Isi_dihapus_dari_luar
+Value\ cleared\ externally=Isi dihapus dari luar
 
-Value_set_externally=Isi_diatur_dari_luar
+Value\ set\ externally=Isi diatur dari luar
 
-verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid=pastikan_LyX_sedang_dijalankan_dan_pipalyx_nya_benar
+verify\ that\ LyX\ is\ running\ and\ that\ the\ lyxpipe\ is\ valid=pastikan LyX sedang dijalankan dan pipalyx nya benar
 
 View=Tampilkan
-Vim_server_name=Nama_Server_Vim
+Vim\ server\ name=Nama Server Vim
 
-Waiting_for_ArXiv...=Menunggu_ArXiv...
+Waiting\ for\ ArXiv...=Menunggu ArXiv...
 
-Warn_about_unresolved_duplicates_when_closing_inspection_window=Peringatkan_jika_masih_ada_duplikasi_ketika_menutup_dialog
+Warn\ about\ unresolved\ duplicates\ when\ closing\ inspection\ window=Peringatkan jika masih ada duplikasi ketika menutup dialog
 
-Warn_before_overwriting_existing_keys=Peringatan_sebelum_menindih_kunci
+Warn\ before\ overwriting\ existing\ keys=Peringatan sebelum menindih kunci
 
 Warning=Peringatan
 
 Warnings=Peringatan
 
-web_link=tautan_web
+web\ link=tautan web
 
-What_do_you_want_to_do?=Apa_yang_anda_inginkan?
+What\ do\ you\ want\ to\ do?=Apa yang anda inginkan?
 
-When_adding/removing_keywords,_separate_them_by=Ketika_menambah/menghapus_katakunci,_pisahkan_dengan_tanda
-Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.=Akan_menulis_metadata_XMP_ke_tautan_PDF_dari_entri_pilihan.
+When\ adding/removing\ keywords,\ separate\ them\ by=Ketika menambah/menghapus katakunci, pisahkan dengan tanda
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Akan menulis metadata XMP ke tautan PDF dari entri pilihan.
 
 with=dan
 
-Write_BibTeXEntry_as_XMP-metadata_to_PDF.=Menulis_BibTeXEntry_sebagai_XMP-metadata_ke_PDF.
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Menulis BibTeXEntry sebagai XMP-metadata ke PDF.
 
-Write_XMP=Menulis_XMP
-Write_XMP-metadata=Menulis_XMP-metadata
-Write_XMP-metadata_for_all_PDFs_in_current_library?=Menulis_XMP-metadata_untuk_semua_PDF_di_basisdata_sekarang?
-Writing_XMP-metadata...=Sedang_menulis_XMP_metadata...
-Writing_XMP-metadata_for_selected_entries...=Sedang_menulis_XMP_metadata_untuk_entri_pilihan...
+Write\ XMP=Menulis XMP
+Write\ XMP-metadata=Menulis XMP-metadata
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Menulis XMP-metadata untuk semua PDF di basisdata sekarang?
+Writing\ XMP-metadata...=Sedang menulis XMP metadata...
+Writing\ XMP-metadata\ for\ selected\ entries...=Sedang menulis XMP metadata untuk entri pilihan...
 
-Wrote_XMP-metadata=XMP-metadata_ditulis
+Wrote\ XMP-metadata=XMP-metadata ditulis
 
-XMP-annotated_PDF=XMP-annotated_PDF
-XMP_export_privacy_settings=Pengaturan_Info_Ekspor_XMP
-XMP-metadata=Metadata_XMP
-XMP-metadata_found_in_PDF\:_%0=XMP_metadata_ditemukan_di_PDF\:_%0
-You_must_restart_JabRef_for_this_to_come_into_effect.=Anda_harus_menjalankan_ulang_JabRef_agar_berfungsi.
-You_have_changed_the_language_setting.=Anda_telah_mengganti_pengaturan_bahasa.
-You_have_entered_an_invalid_search_'%0'.=Anda_telah_menulis_pencarian_yang_salah_'%0'.
+XMP-annotated\ PDF=XMP-annotated PDF
+XMP\ export\ privacy\ settings=Pengaturan Info Ekspor XMP
+XMP-metadata=Metadata XMP
+XMP-metadata\ found\ in\ PDF\:\ %0=XMP metadata ditemukan di PDF: %0
+You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Anda harus menjalankan ulang JabRef agar berfungsi.
+You\ have\ changed\ the\ language\ setting.=Anda telah mengganti pengaturan bahasa.
+You\ have\ entered\ an\ invalid\ search\ '%0'.=Anda telah menulis pencarian yang salah '%0'.
 
-You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.=Anda_harus_menjalankan_ulang_JabRef_agar_gabungan_kunci_dapat_berfungsi.
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Anda harus menjalankan ulang JabRef agar gabungan kunci dapat berfungsi.
 
-Your_new_key_bindings_have_been_stored.=Gabungan_kunci_anda_sudah_disimpan.
+Your\ new\ key\ bindings\ have\ been\ stored.=Gabungan kunci anda sudah disimpan.
 
-The_following_fetchers_are_available\:=Pengambil_berikut_tersedia\:
-Could_not_find_fetcher_'%0'=Tidak_bisa_menemukan_pengambil_'%0'
-Running_query_'%0'_with_fetcher_'%1'.=Jalankan_Kueri_'%0'_dengan_pengambil_'%1'.
-Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.=Kueri_'%0'_dengan_pengambil_'%1'_tidak_ada_hasilnya.
+The\ following\ fetchers\ are\ available\:=Pengambil berikut tersedia:
+Could\ not\ find\ fetcher\ '%0'=Tidak bisa menemukan pengambil '%0'
+Running\ query\ '%0'\ with\ fetcher\ '%1'.=Jalankan Kueri '%0' dengan pengambil '%1'.
+Query\ '%0'\ with\ fetcher\ '%1'\ did\ not\ return\ any\ results.=Kueri '%0' dengan pengambil '%1' tidak ada hasilnya.
 
-Move_file=Memindah_berkas
-Rename_file=Menamai_berkas
+Move\ file=Memindah berkas
+Rename\ file=Menamai berkas
 
-Move_file_failed=Gagal_memindah_berkas
-Could_not_move_file_'%0'.=Tidak_bisa_meindah_berkas_'%0'.
-Could_not_find_file_'%0'.=Tidak_bisa_menemukan_berkas_'%0'.
-Number_of_entries_successfully_imported=Jumlah_entri_yang_berhasil_diimpor
-Import_canceled_by_user=Impor_dibatalkan_oleh_pengguna
-Progress\:_%0_of_%1=Berlangsung\:_%0_of_%1
-Error_while_fetching_from_%0=Kesalahan_ketika_mengambil_dari_%0
+Move\ file\ failed=Gagal memindah berkas
+Could\ not\ move\ file\ '%0'.=Tidak bisa meindah berkas '%0'.
+Could\ not\ find\ file\ '%0'.=Tidak bisa menemukan berkas '%0'.
+Number\ of\ entries\ successfully\ imported=Jumlah entri yang berhasil diimpor
+Import\ canceled\ by\ user=Impor dibatalkan oleh pengguna
+Progress\:\ %0\ of\ %1=Berlangsung: %0 of %1
+Error\ while\ fetching\ from\ %0=Kesalahan ketika mengambil dari %0
 
-Please_enter_a_valid_number=Tuliskan_nomor_yang_benar
-Show_search_results_in_a_window=Tampilkan_hasil_pencarian_di_jendela
-Show_global_search_results_in_a_window=
-Search_in_all_open_libraries=
-Move_file_to_file_directory?=Pindah_berkas_ke_direktori_berkas?
+Please\ enter\ a\ valid\ number=Tuliskan nomor yang benar
+Show\ search\ results\ in\ a\ window=Tampilkan hasil pencarian di jendela
+Show\ global\ search\ results\ in\ a\ window=
+Search\ in\ all\ open\ libraries=
+Move\ file\ to\ file\ directory?=Pindah berkas ke direktori berkas?
 
-Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.=Basisdata_dilindungi._Tidak_bisa_disimpan_sebelum_perubahan_eksternal_diperiksa.
-Protected_library=Basisdata_terlindungi
-Refuse_to_save_the_library_before_external_changes_have_been_reviewed.=Menolak_menyimpan_basisdata_sebelum_perubahan_eksternal_diperiksa.
-Library_protection=Perlindungan_basisdata
-Unable_to_save_library=Tidak_bisa_menyimpan_basisdata
+Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=Basisdata dilindungi. Tidak bisa disimpan sebelum perubahan eksternal diperiksa.
+Protected\ library=Basisdata terlindungi
+Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=Menolak menyimpan basisdata sebelum perubahan eksternal diperiksa.
+Library\ protection=Perlindungan basisdata
+Unable\ to\ save\ library=Tidak bisa menyimpan basisdata
 
-BibTeX_key_generator=Pembuat_kunci_BibTeX
-Unable_to_open_link.=Tidak_bisa_membuka_tautan.
-Move_the_keyboard_focus_to_the_entry_table=Pindah_fokus_papanketik_ke_tabel_entri
-MIME_type=Tipe_MIME
+BibTeX\ key\ generator=Pembuat kunci BibTeX
+Unable\ to\ open\ link.=Tidak bisa membuka tautan.
+Move\ the\ keyboard\ focus\ to\ the\ entry\ table=Pindah fokus papanketik ke tabel entri
+MIME\ type=Tipe MIME
 
-This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.=Fitur_ini_memungkinkan_berkas_baru_atau_impor_ke_jendela_JabRef_yang_aktif<br>bukan_membuat_baru._Hal_ini_berguna_ketika_anda_membuka_berkas_di_JabRef<br>dari_halaman_web.<br>Hal_ini_akan_menghindari_anda_membuka_beberapa_JabRef_pada_saat_yang_sama.
-Run_fetcher,_e.g._"--fetch\=Medline\:cancer"=Jalankan_Pengambil,_misal._"--fetch=Medline\:cancer"
+This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef<BR>instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef<br>from\ your\ web\ browser.<BR>Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=Fitur ini memungkinkan berkas baru atau impor ke jendela JabRef yang aktif<br>bukan membuat baru. Hal ini berguna ketika anda membuka berkas di JabRef<br>dari halaman web.<br>Hal ini akan menghindari anda membuka beberapa JabRef pada saat yang sama.
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=Jalankan Pengambil, misal. "--fetch=Medline:cancer"
 
-The_ACM_Digital_Library=Pustaka_ACM_Dijital
-Reset=Atur_ulang
+The\ ACM\ Digital\ Library=Pustaka ACM Dijital
+Reset=Atur ulang
 
-Use_IEEE_LaTeX_abbreviations=Gunakan_singkatan_IEEE_LaTeX
-The_Guide_to_Computing_Literature=Panduan_untuk_Computing_Literature
+Use\ IEEE\ LaTeX\ abbreviations=Gunakan singkatan IEEE LaTeX
+The\ Guide\ to\ Computing\ Literature=Panduan untuk Computing Literature
 
-When_opening_file_link,_search_for_matching_file_if_no_link_is_defined=Ketika_membuka_tautan_berkas,_cari_berkas_yang_sesuai
-Settings_for_%0=Pengaturan_untuk
-Mark_entries_imported_into_an_existing_library=Tandai_entri_impor_di_basisdata_yang_sudah_ada
-Unmark_all_entries_before_importing_new_entries_into_an_existing_library=Hilangkan_tanda_semua_entri_sebelum_mengimpor_entri_baru_ke_basisdata
+When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=Ketika membuka tautan berkas, cari berkas yang sesuai
+Settings\ for\ %0=Pengaturan untuk
+Mark\ entries\ imported\ into\ an\ existing\ library=Tandai entri impor di basisdata yang sudah ada
+Unmark\ all\ entries\ before\ importing\ new\ entries\ into\ an\ existing\ library=Hilangkan tanda semua entri sebelum mengimpor entri baru ke basisdata
 
 Forward=Maju
 Back=Kembali
-Sort_the_following_fields_as_numeric_fields=Urutkan_bidang_berikut_sepeerti_angka
-Line_%0\:_Found_corrupted_BibTeX_key.=Baris_%0\:_Ditemukan_kunci_BibTeX_ada_kesalahan.
-Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).=Baris_%0\:_Ditemukan_kunci_BibTeX_ada_kesalahan_(mengandung_spasi_kosong).
-Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).=Baris_%0\:_Ditemukan_kunci_BibTeX_ada_kesalahan_(tidak_ada_koma).
-Full_text_document_download_failed=Gagal_muaturun_artikel_teks_lengkap
-Update_to_current_column_order=Perbarui_sebuai_urutan_kolom_sekarang
-Download_from_URL=
-Rename_field=Ganti_nama_bidang
-Set/clear/append/rename_fields=Pilih/hapus/namai_ulang_bidang
-Append_field=
-Append_to_fields=
-Rename_field_to=Ganti_nama_bidang_menjadi
-Move_contents_of_a_field_into_a_field_with_a_different_name=Pindah_isi_dari_bidang_ke_bidang_lain_dengan_nama_lain
-You_can_only_rename_one_field_at_a_time=Anda_bisa_mengganti_nama_satu_bidang_dalam_satu_waktu
+Sort\ the\ following\ fields\ as\ numeric\ fields=Urutkan bidang berikut sepeerti angka
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=Baris %0: Ditemukan kunci BibTeX ada kesalahan.
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=Baris %0: Ditemukan kunci BibTeX ada kesalahan (mengandung spasi kosong).
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=Baris %0: Ditemukan kunci BibTeX ada kesalahan (tidak ada koma).
+Full\ text\ document\ download\ failed=Gagal muaturun artikel teks lengkap
+Update\ to\ current\ column\ order=Perbarui sebuai urutan kolom sekarang
+Download\ from\ URL=
+Rename\ field=Ganti nama bidang
+Set/clear/append/rename\ fields=Pilih/hapus/namai ulang bidang
+Append\ field=
+Append\ to\ fields=
+Rename\ field\ to=Ganti nama bidang menjadi
+Move\ contents\ of\ a\ field\ into\ a\ field\ with\ a\ different\ name=Pindah isi dari bidang ke bidang lain dengan nama lain
+You\ can\ only\ rename\ one\ field\ at\ a\ time=Anda bisa mengganti nama satu bidang dalam satu waktu
 
-Remove_all_broken_links=Hapus_semua_tautan_rusak?
+Remove\ all\ broken\ links=Hapus semua tautan rusak?
 
-Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.=Tidak_bisa_memakai_port_%0_untuk_operasi_jauh;_aplikasi_lain_mungkin_sedang_menggunakan._Coba_port_lain.
+Cannot\ use\ port\ %0\ for\ remote\ operation;\ another\ application\ may\ be\ using\ it.\ Try\ specifying\ another\ port.=Tidak bisa memakai port %0 untuk operasi jauh; aplikasi lain mungkin sedang menggunakan. Coba port lain.
 
-Looking_for_full_text_document...=Sedang_mencari_dokumen_teks_lengkap...
-Autosave=Simpan_otomatis
-A_local_copy_will_be_opened.=
-Autosave_local_libraries=
-Automatically_save_the_library_to=
-Please_enter_a_valid_file_path.=
+Looking\ for\ full\ text\ document...=Sedang mencari dokumen teks lengkap...
+Autosave=Simpan otomatis
+A\ local\ copy\ will\ be\ opened.=
+Autosave\ local\ libraries=
+Automatically\ save\ the\ library\ to=
+Please\ enter\ a\ valid\ file\ path.=
 
 
-Export_in_current_table_sort_order=Ekspor_menurut_tabel_urutan_sekarang
-Export_entries_in_their_original_order=Ekspor_entri_dengan_urutan_aslinya
-Error_opening_file_'%0'.=Kesalahan_ketika_membuka_berkas_'%0'.
+Export\ in\ current\ table\ sort\ order=Ekspor menurut tabel urutan sekarang
+Export\ entries\ in\ their\ original\ order=Ekspor entri dengan urutan aslinya
+Error\ opening\ file\ '%0'.=Kesalahan ketika membuka berkas '%0'.
 
-Formatter_not_found\:_%0=Pemformat_tidak_ditemukan\:_%0
-Clear_inputarea=Bersihkan_area_masukan
+Formatter\ not\ found\:\ %0=Pemformat tidak ditemukan: %0
+Clear\ inputarea=Bersihkan area masukan
 
-Automatically_set_file_links_for_this_entry=Otomatis_membuat_tautan_berkas_untuk_entri_ini
-Could_not_save,_file_locked_by_another_JabRef_instance.=Tidak_bisa_menyimpan,_berkas_dikunci_oleh_JabRef_yang_jalan.
-File_is_locked_by_another_JabRef_instance.=Berkas_dikunci_oleh_JabRef_lain.
-Do_you_want_to_override_the_file_lock?=Apakah_anda_ingin_menindih_kunci_berkas?
-File_locked=Berkas_dikunci
-Current_tmp_value=Angka_tmp_sekarang
-Metadata_change=Perubahan_Metadata
-Changes_have_been_made_to_the_following_metadata_elements=Perubahan_telah_dilakukan_pada_elemen_metadata_berikut
+Automatically\ set\ file\ links\ for\ this\ entry=Otomatis membuat tautan berkas untuk entri ini
+Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=Tidak bisa menyimpan, berkas dikunci oleh JabRef yang jalan.
+File\ is\ locked\ by\ another\ JabRef\ instance.=Berkas dikunci oleh JabRef lain.
+Do\ you\ want\ to\ override\ the\ file\ lock?=Apakah anda ingin menindih kunci berkas?
+File\ locked=Berkas dikunci
+Current\ tmp\ value=Angka tmp sekarang
+Metadata\ change=Perubahan Metadata
+Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=Perubahan telah dilakukan pada elemen metadata berikut
 
-Generate_groups_for_author_last_names=Membuat_grup_untuk_nama_belakang_penulis
-Generate_groups_from_keywords_in_a_BibTeX_field=Membuat_grup_dari_katakunci_di_bidang_BibTeX
-Enforce_legal_characters_in_BibTeX_keys=Menggunakan_karakter_legal_untuk_kunci_BibTeX
+Generate\ groups\ for\ author\ last\ names=Membuat grup untuk nama belakang penulis
+Generate\ groups\ from\ keywords\ in\ a\ BibTeX\ field=Membuat grup dari katakunci di bidang BibTeX
+Enforce\ legal\ characters\ in\ BibTeX\ keys=Menggunakan karakter legal untuk kunci BibTeX
 
-Save_without_backup?=Simpan_tanpa_cadangan?
-Unable_to_create_backup=Tidak_bisa_membuat_cadangan
-Move_file_to_file_directory=Pindah_berkas_ke_direktori_berkas
-Rename_file_to=Ganti_nama_berkas_menjadi
-<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)=<b>Semua_Entri</b>_(grup_ini_tidak_bisa_diubah_atau_dihapus)
-static_group=grup_statik
-dynamic_group=grup_dinamik
-refines_supergroup=memperbaiki_supergrup
-includes_subgroups=termasuk_subgrup
+Save\ without\ backup?=Simpan tanpa cadangan?
+Unable\ to\ create\ backup=Tidak bisa membuat cadangan
+Move\ file\ to\ file\ directory=Pindah berkas ke direktori berkas
+Rename\ file\ to=Ganti nama berkas menjadi
+<b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=<b>Semua Entri</b> (grup ini tidak bisa diubah atau dihapus)
+static\ group=grup statik
+dynamic\ group=grup dinamik
+refines\ supergroup=memperbaiki supergrup
+includes\ subgroups=termasuk subgrup
 contains=kandungan
-search_expression=ekspresi_pencarian
+search\ expression=ekspresi pencarian
 
-Optional_fields_2=Bidang_tambahan_2
-Waiting_for_save_operation_to_finish=Menunggu_proses_menyimpan_selesai
-Resolving_duplicate_BibTeX_keys...=Mengatasi_masalah_kunci_BibTeX_sama...
-Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.=Selesai_mengatasi_masalah_kunci_BibTeX_sama._%0_entri_diubah.
-This_library_contains_one_or_more_duplicated_BibTeX_keys.=Basisdata_ini_mempunyai_satu_atau_lebih_kunci_BibTeX_yang_sama.
-Do_you_want_to_resolve_duplicate_keys_now?=Apakah_anda_ingin_menyelesaikan_masalah_kunci_sama_sekarang?
+Optional\ fields\ 2=Bidang tambahan 2
+Waiting\ for\ save\ operation\ to\ finish=Menunggu proses menyimpan selesai
+Resolving\ duplicate\ BibTeX\ keys...=Mengatasi masalah kunci BibTeX sama...
+Finished\ resolving\ duplicate\ BibTeX\ keys.\ %0\ entries\ modified.=Selesai mengatasi masalah kunci BibTeX sama. %0 entri diubah.
+This\ library\ contains\ one\ or\ more\ duplicated\ BibTeX\ keys.=Basisdata ini mempunyai satu atau lebih kunci BibTeX yang sama.
+Do\ you\ want\ to\ resolve\ duplicate\ keys\ now?=Apakah anda ingin menyelesaikan masalah kunci sama sekarang?
 
-Find_and_remove_duplicate_BibTeX_keys=Temukan_dan_hapus_kunci_BibTeX_yang_sama
-Expected_syntax_for_--fetch\='<name_of_fetcher>\:<query>'=Sintaks_yang_diharapkan_untuk_--fetch='<name_of_fetcher>\:<query>'
-Duplicate_BibTeX_key=kunci_BibTeX_sama
-Import_marking_color=Tanda_impor
-Always_add_letter_(a,_b,_...)_to_generated_keys=Selalu_tambah_huruf_(a,_b,_...)_untuk_kunci
+Find\ and\ remove\ duplicate\ BibTeX\ keys=Temukan dan hapus kunci BibTeX yang sama
+Expected\ syntax\ for\ --fetch\='<name\ of\ fetcher>\:<query>'=Sintaks yang diharapkan untuk --fetch='<name of fetcher>:<query>'
+Duplicate\ BibTeX\ key=kunci BibTeX sama
+Import\ marking\ color=Tanda impor
+Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=Selalu tambah huruf (a, b, ...) untuk kunci
 
-Ensure_unique_keys_using_letters_(a,_b,_...)=Pastikan_kunci_unik_dengan_huruf_(a,_b,_...)
-Ensure_unique_keys_using_letters_(b,_c,_...)=Pastikan_kunci_unik_dengan_huruf_(b,c,_...)
-Entry_editor_active_background_color=Latar_penyunting_entri_aktif
-Entry_editor_background_color=Latar_penyunting_entri
-Entry_editor_font_color=Huruf_penyunting_entri
-Entry_editor_invalid_field_color=Entri_bidang_tidak_valid
+Ensure\ unique\ keys\ using\ letters\ (a,\ b,\ ...)=Pastikan kunci unik dengan huruf (a, b, ...)
+Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=Pastikan kunci unik dengan huruf (b,c, ...)
+Entry\ editor\ active\ background\ color=Latar penyunting entri aktif
+Entry\ editor\ background\ color=Latar penyunting entri
+Entry\ editor\ font\ color=Huruf penyunting entri
+Entry\ editor\ invalid\ field\ color=Entri bidang tidak valid
 
-Table_and_entry_editor_colors=Warna_tabel_dan_penyunting_entri
+Table\ and\ entry\ editor\ colors=Warna tabel dan penyunting entri
 
-General_file_directory=Direktori_berkas_umum
-User-specific_file_directory=Direktori_berkas_khusus_pengguna
-Search_failed\:_illegal_search_expression=Pencarian_gagal\:_ekspresi_pencarian_tidak_benar
-Show_ArXiv_column=Tampilkan_kolom_ArXiv
+General\ file\ directory=Direktori berkas umum
+User-specific\ file\ directory=Direktori berkas khusus pengguna
+Search\ failed\:\ illegal\ search\ expression=Pencarian gagal: ekspresi pencarian tidak benar
+Show\ ArXiv\ column=Tampilkan kolom ArXiv
 
-You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for=Anda_harus_memasukkan_angka_bulat_antara_1025-65535_di_bidang_teks
-Automatically_open_browse_dialog_when_creating_new_file_link=Otomatis_membuka_dialog_jelajah_ketika_membuat_tautan_berkas_baru
-Import_metadata_from\:=Impor_Metadata_dari\:
-Choose_the_source_for_the_metadata_import=Pilih_sumber_untuk_impor_metadata
-Create_entry_based_on_XMP-metadata=Membuat_entri_berasal_data_XMP
-Create_blank_entry_linking_the_PDF=Membuat_entri_kosong_tautan_PDF
-Only_attach_PDF=Hanya_lampirkan_PDF
+You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=Anda harus memasukkan angka bulat antara 1025-65535 di bidang teks
+Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Otomatis membuka dialog jelajah ketika membuat tautan berkas baru
+Import\ metadata\ from\:=Impor Metadata dari:
+Choose\ the\ source\ for\ the\ metadata\ import=Pilih sumber untuk impor metadata
+Create\ entry\ based\ on\ XMP-metadata=Membuat entri berasal data XMP
+Create\ blank\ entry\ linking\ the\ PDF=Membuat entri kosong tautan PDF
+Only\ attach\ PDF=Hanya lampirkan PDF
 Title=Judul
-Create_new_entry=membuat_Entri_Baru
-Update_existing_entry=Perbarui_Entri_Yang_Sudah_Ada
-Autocomplete_names_in_'Firstname_Lastname'_format_only=Nama_isian_otomatis_hanya_untuk_format_'Namadepan_Namaakhir'
-Autocomplete_names_in_'Lastname,_Firstname'_format_only=Nama_isian_otomatis_hanya_untuk_format_'Namaakhir,_Namadepan'
-Autocomplete_names_in_both_formats=Nama_isian_otomatis_untuk_kedua_format
-Marking_color_%0=Tanda_warna_%0
-The_name_'comment'_cannot_be_used_as_an_entry_type_name.=Nama_'kometar'_tidak_dapat_digunakan_sebagai_tipe_nama_entri.
-You_must_enter_an_integer_value_in_the_text_field_for=Anda_harus_menggunakan_bilangan_bulat_di_bidang_teks_untuk
-Send_as_email=Kirim_sebagai_email
+Create\ new\ entry=membuat Entri Baru
+Update\ existing\ entry=Perbarui Entri Yang Sudah Ada
+Autocomplete\ names\ in\ 'Firstname\ Lastname'\ format\ only=Nama isian otomatis hanya untuk format 'Namadepan Namaakhir'
+Autocomplete\ names\ in\ 'Lastname,\ Firstname'\ format\ only=Nama isian otomatis hanya untuk format 'Namaakhir, Namadepan'
+Autocomplete\ names\ in\ both\ formats=Nama isian otomatis untuk kedua format
+Marking\ color\ %0=Tanda warna %0
+The\ name\ 'comment'\ cannot\ be\ used\ as\ an\ entry\ type\ name.=Nama 'kometar' tidak dapat digunakan sebagai tipe nama entri.
+You\ must\ enter\ an\ integer\ value\ in\ the\ text\ field\ for=Anda harus menggunakan bilangan bulat di bidang teks untuk
+Send\ as\ email=Kirim sebagai email
 References=Referensi
-Sending_of_emails=Sedang_Mengirim_email
-Subject_for_sending_an_email_with_references=Subyek_untuk_mengirim_email_dengan_referensi
-Automatically_open_folders_of_attached_files=Otomatis_membuka_direktori_lampiran_berkas
-Create_entry_based_on_content=Membuat_entri_dari_isi_kandungan
-Do_not_show_this_box_again_for_this_import=Tidak_menampilkan_kotak_ini_lagi_saat_impor
-Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)=Selalu_menggunakan_Impor_PDF_(tidak_menanyakan_lagi_ketika_impor)
-Error_creating_email=Gagal_menulis_email
-Entries_added_to_an_email=Entri_ditambahkan_di_emel
+Sending\ of\ emails=Sedang Mengirim email
+Subject\ for\ sending\ an\ email\ with\ references=Subyek untuk mengirim email dengan referensi
+Automatically\ open\ folders\ of\ attached\ files=Otomatis membuka direktori lampiran berkas
+Create\ entry\ based\ on\ content=Membuat entri dari isi kandungan
+Do\ not\ show\ this\ box\ again\ for\ this\ import=Tidak menampilkan kotak ini lagi saat impor
+Always\ use\ this\ PDF\ import\ style\ (and\ do\ not\ ask\ for\ each\ import)=Selalu menggunakan Impor PDF (tidak menanyakan lagi ketika impor)
+Error\ creating\ email=Gagal menulis email
+Entries\ added\ to\ an\ email=Entri ditambahkan di emel
 exportFormat=FormatEkspor
-Output_file_missing=Berkas_keluaran_hilang
-No_search_matches.=Carian_tidak_ditemukan.
-The_output_option_depends_on_a_valid_input_option.=Pilihan_keluaran_tergantung_dari_pilihan_masukan_yang_tepat.
-Default_import_style_for_drag_and_drop_of_PDFs=Gaya_impor_bawaan_PDF_untuk_seret_dan_masuk
-Default_PDF_file_link_action=Aksi_tautan_PDF_bawaan
-Filename_format_pattern=Pola_format_nama_berkas
-Additional_parameters=Parameter_tambahan
-Cite_selected_entries_between_parenthesis=Entri_acuan_pilihan
-Cite_selected_entries_with_in-text_citation=Entri_acuan_pilihan_dengan_acuan_dalam_teks
-Cite_special=Acuan_spesial
-Extra_information_(e.g._page_number)=Informasi_ekstra_(misal,_nomor_halaman)
-Manage_citations=Pengelolaan_acuan
-Problem_modifying_citation=Perubahan_acuan_bermasalah
+Output\ file\ missing=Berkas keluaran hilang
+No\ search\ matches.=Carian tidak ditemukan.
+The\ output\ option\ depends\ on\ a\ valid\ input\ option.=Pilihan keluaran tergantung dari pilihan masukan yang tepat.
+Default\ import\ style\ for\ drag\ and\ drop\ of\ PDFs=Gaya impor bawaan PDF untuk seret dan masuk
+Default\ PDF\ file\ link\ action=Aksi tautan PDF bawaan
+Filename\ format\ pattern=Pola format nama berkas
+Additional\ parameters=Parameter tambahan
+Cite\ selected\ entries\ between\ parenthesis=Entri acuan pilihan
+Cite\ selected\ entries\ with\ in-text\ citation=Entri acuan pilihan dengan acuan dalam teks
+Cite\ special=Acuan spesial
+Extra\ information\ (e.g.\ page\ number)=Informasi ekstra (misal, nomor halaman)
+Manage\ citations=Pengelolaan acuan
+Problem\ modifying\ citation=Perubahan acuan bermasalah
 Citation=Acuan
-Extra_information=Informasi_ekstra
-Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.=Tidak_bisa_memperbaiki_entri_BibTeX_untuk_penanda_acuan_'%0'.
-Select_style=Pilih_gaya
+Extra\ information=Informasi ekstra
+Could\ not\ resolve\ BibTeX\ entry\ for\ citation\ marker\ '%0'.=Tidak bisa memperbaiki entri BibTeX untuk penanda acuan '%0'.
+Select\ style=Pilih gaya
 Journals=Jurnal
 Cite=Acuan
-Cite_in-text=Acuan_dalam_teks
-Insert_empty_citation=Sisipkan_acuan_kosong
-Merge_citations=Gabung_acuan
-Manual_connect=Penautan_manual
-Select_Writer_document=Pilih_penyunting_dokumen
-Sync_OpenOffice/LibreOffice_bibliography=Sinkr_bibliografi_OpenOffice/LibreOffice
-Select_which_open_Writer_document_to_work_on=Pilih_penyunting_open_Writer_yang_digunakan
-Connected_to_document=Ditautkan_ke_dokumen
-Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)=Sisipkan_acuan_tanpa_teks_(entri_akan_muncul_dalam_daftar_acuan)
-Cite_selected_entries_with_extra_information=Acu_entri_pilihan_dengan_informasi_ekstra
-Ensure_that_the_bibliography_is_up-to-date=Pastikan_bahwa_bibliografi_adalah_yang_mutakhir
-Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.=Acuan_dokumen_OpenOffice/LibreOffice_dengan_kunci_BibTeX_'%0',_yang_tidak_ditemukan_dalam_basisdata_sekarang.
-Unable_to_synchronize_bibliography=Tidak_bisa_mensinkronkan_bibliografi
-Combine_pairs_of_citations_that_are_separated_by_spaces_only=Menggabungkan_pasangan_acuan_yang_dipisahkan_hanya_dengan_spasi
-Autodetection_failed=Deteksi_otomatis_gagal
-Connecting=Sedang_menyambungkan
-Please_wait...=Mohon_tunggu...
-Set_connection_parameters=Atur_parameter_sambungan
-Path_to_OpenOffice/LibreOffice_directory=Lokasi_direktori_OpenOffice/LibreOffice
-Path_to_OpenOffice/LibreOffice_executable=Lokasi_program_OpenOffice/LibreOffice
-Path_to_OpenOffice/LibreOffice_library_dir=Lokasi_pustaka_OpenOffice/LibreOffice
-Connection_lost=Sambungan_terlepas
-The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.=Format_paragraf_diatur_melalui_'FormatAcuanParagraf'_atau_'KepalaAcuan'
-The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.=Format_karakter_iatur_melalui_pengaturan_acauan_'FormatKarakterAcuan'_dalam_berkas_gaya.
-Automatically_sync_bibliography_when_inserting_citations=Otomatis_sinkr_bibliografi_ketika_menyisipkan_acuan
-Look_up_BibTeX_entries_in_the_active_tab_only=Mencari_entri_BibTeX_hanya_di_basisdata_yang_aktif
-Look_up_BibTeX_entries_in_all_open_libraries=Mencari_entri_BibTeX_di_semua_basisdata_yang_dibuka
-Autodetecting_paths...=Deteksi_otomatis_lokasi...
-Could_not_find_OpenOffice/LibreOffice_installation=Tidak_bisa_menemukan_instalasi_OpenOffice/LibreOffice
-Found_more_than_one_OpenOffice/LibreOffice_executable.=Menemukan_lebih_dari_satu_program_OpenOffice/LibreOffice.
-Please_choose_which_one_to_connect_to\:=Pilih_salah_satu_yang_akan_disambung
-Choose_OpenOffice/LibreOffice_executable=Pilih_program_OpenOffice/LibreOffice
-Select_document=Pilih_dokumen
-HTML_list=Daftar_HTML
-If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting=Jika_memungkinkan,_sesuaikan_daftar_nama_untuk_mengikuti_format_penamaan_BibTeX
-Could_not_open_%0=Tidak_bisa_membuka_%0
-Unknown_import_format=Format_impor_tidak_dikenal
-Web_search=Pencarian_Web
-Style_selection=Pilihan_gaya
-No_valid_style_file_defined=(gaya_yang_sah_tidak_ditemukan)
-Choose_pattern=Pilih_pola
-Use_the_BIB_file_location_as_primary_file_directory=Gunakan_lokasi_berkas_BIB_sebagai_direktori_berkas_utama
-Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.=Program_gnuclient/emacsclient_tidak_bisa_dijalankan._Pastikan_program_emacsclient/gnuclient_sudah_diinstalasi_dan_dinyatakan_di_lokasi_ini.
-OpenOffice/LibreOffice_connection=Koneksi_OpenOffice/LibreOffice
-You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.=Anda_harus_memilih_berkas_gaya_yang_sah,_atau_menggunakan_salah_satu_gaya_bawaan.
+Cite\ in-text=Acuan dalam teks
+Insert\ empty\ citation=Sisipkan acuan kosong
+Merge\ citations=Gabung acuan
+Manual\ connect=Penautan manual
+Select\ Writer\ document=Pilih penyunting dokumen
+Sync\ OpenOffice/LibreOffice\ bibliography=Sinkr bibliografi OpenOffice/LibreOffice
+Select\ which\ open\ Writer\ document\ to\ work\ on=Pilih penyunting open Writer yang digunakan
+Connected\ to\ document=Ditautkan ke dokumen
+Insert\ a\ citation\ without\ text\ (the\ entry\ will\ appear\ in\ the\ reference\ list)=Sisipkan acuan tanpa teks (entri akan muncul dalam daftar acuan)
+Cite\ selected\ entries\ with\ extra\ information=Acu entri pilihan dengan informasi ekstra
+Ensure\ that\ the\ bibliography\ is\ up-to-date=Pastikan bahwa bibliografi adalah yang mutakhir
+Your\ OpenOffice/LibreOffice\ document\ references\ the\ BibTeX\ key\ '%0',\ which\ could\ not\ be\ found\ in\ your\ current\ library.=Acuan dokumen OpenOffice/LibreOffice dengan kunci BibTeX '%0', yang tidak ditemukan dalam basisdata sekarang.
+Unable\ to\ synchronize\ bibliography=Tidak bisa mensinkronkan bibliografi
+Combine\ pairs\ of\ citations\ that\ are\ separated\ by\ spaces\ only=Menggabungkan pasangan acuan yang dipisahkan hanya dengan spasi
+Autodetection\ failed=Deteksi otomatis gagal
+Connecting=Sedang menyambungkan
+Please\ wait...=Mohon tunggu...
+Set\ connection\ parameters=Atur parameter sambungan
+Path\ to\ OpenOffice/LibreOffice\ directory=Lokasi direktori OpenOffice/LibreOffice
+Path\ to\ OpenOffice/LibreOffice\ executable=Lokasi program OpenOffice/LibreOffice
+Path\ to\ OpenOffice/LibreOffice\ library\ dir=Lokasi pustaka OpenOffice/LibreOffice
+Connection\ lost=Sambungan terlepas
+The\ paragraph\ format\ is\ controlled\ by\ the\ property\ 'ReferenceParagraphFormat'\ or\ 'ReferenceHeaderParagraphFormat'\ in\ the\ style\ file.=Format paragraf diatur melalui 'FormatAcuanParagraf' atau 'KepalaAcuan'
+The\ character\ format\ is\ controlled\ by\ the\ citation\ property\ 'CitationCharacterFormat'\ in\ the\ style\ file.=Format karakter iatur melalui pengaturan acauan 'FormatKarakterAcuan' dalam berkas gaya.
+Automatically\ sync\ bibliography\ when\ inserting\ citations=Otomatis sinkr bibliografi ketika menyisipkan acuan
+Look\ up\ BibTeX\ entries\ in\ the\ active\ tab\ only=Mencari entri BibTeX hanya di basisdata yang aktif
+Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=Mencari entri BibTeX di semua basisdata yang dibuka
+Autodetecting\ paths...=Deteksi otomatis lokasi...
+Could\ not\ find\ OpenOffice/LibreOffice\ installation=Tidak bisa menemukan instalasi OpenOffice/LibreOffice
+Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=Menemukan lebih dari satu program OpenOffice/LibreOffice.
+Please\ choose\ which\ one\ to\ connect\ to\:=Pilih salah satu yang akan disambung
+Choose\ OpenOffice/LibreOffice\ executable=Pilih program OpenOffice/LibreOffice
+Select\ document=Pilih dokumen
+HTML\ list=Daftar HTML
+If\ possible,\ normalize\ this\ list\ of\ names\ to\ conform\ to\ standard\ BibTeX\ name\ formatting=Jika memungkinkan, sesuaikan daftar nama untuk mengikuti format penamaan BibTeX
+Could\ not\ open\ %0=Tidak bisa membuka %0
+Unknown\ import\ format=Format impor tidak dikenal
+Web\ search=Pencarian Web
+Style\ selection=Pilihan gaya
+No\ valid\ style\ file\ defined=(gaya yang sah tidak ditemukan)
+Choose\ pattern=Pilih pola
+Use\ the\ BIB\ file\ location\ as\ primary\ file\ directory=Gunakan lokasi berkas BIB sebagai direktori berkas utama
+Could\ not\ run\ the\ gnuclient/emacsclient\ program.\ Make\ sure\ you\ have\ the\ emacsclient/gnuclient\ program\ installed\ and\ available\ in\ the\ PATH.=Program gnuclient/emacsclient tidak bisa dijalankan. Pastikan program emacsclient/gnuclient sudah diinstalasi dan dinyatakan di lokasi ini.
+OpenOffice/LibreOffice\ connection=Koneksi OpenOffice/LibreOffice
+You\ must\ select\ either\ a\ valid\ style\ file,\ or\ use\ one\ of\ the\ default\ styles.=Anda harus memilih berkas gaya yang sah, atau menggunakan salah satu gaya bawaan.
 
-This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.=Inilah_dialog_salin-tempel_yang_dasar._Pertama,_memuat_atau_menempel_ke_dalam_area_masukan_teks.<br>Setelah_itu,_anda_bisa_menanda_teks_dan_menulisnya_ke_dalam_bidang_BibTeX.
-This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.=Fitur_ini_membuat_basisdata_yang_baru_berdasar_para_entri_yang_dibutuhkan_dalam_dokumen_LaTeX_yang_sudah_ada.
-You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.=Anda_harus_memilih_salah_satu_basisdata_yang_terbuka_dari_mana_entri_akan_dipilih_dan_berkas_AUX_yang_dibuat_oleh_LaTeX_saat_dokumen_disusun.
+This\ is\ a\ simple\ copy\ and\ paste\ dialog.\ First\ load\ or\ paste\ some\ text\ into\ the\ text\ input\ area.<br>After\ that,\ you\ can\ mark\ text\ and\ assign\ it\ to\ a\ BibTeX\ field.=Inilah dialog salin-tempel yang dasar. Pertama, memuat atau menempel ke dalam area masukan teks.<br>Setelah itu, anda bisa menanda teks dan menulisnya ke dalam bidang BibTeX.
+This\ feature\ generates\ a\ new\ library\ based\ on\ which\ entries\ are\ needed\ in\ an\ existing\ LaTeX\ document.=Fitur ini membuat basisdata yang baru berdasar para entri yang dibutuhkan dalam dokumen LaTeX yang sudah ada.
+You\ need\ to\ select\ one\ of\ your\ open\ libraries\ from\ which\ to\ choose\ entries,\ as\ well\ as\ the\ AUX\ file\ produced\ by\ LaTeX\ when\ compiling\ your\ document.=Anda harus memilih salah satu basisdata yang terbuka dari mana entri akan dipilih dan berkas AUX yang dibuat oleh LaTeX saat dokumen disusun.
 
-First_select_entries_to_clean_up.=Pilih_entri_untuk_dibersihkan_dulu.
-Cleanup_entry=Bersihkan_entri
-Autogenerate_PDF_Names=Buat_otomatis_nama_PDF
-Auto-generating_PDF-Names_does_not_support_undo._Continue?=Pembuatan_otomatis_nama_PDF_tidak_ada_fungsi_pengembalian._Teruskan?
+First\ select\ entries\ to\ clean\ up.=Pilih entri untuk dibersihkan dulu.
+Cleanup\ entry=Bersihkan entri
+Autogenerate\ PDF\ Names=Buat otomatis nama PDF
+Auto-generating\ PDF-Names\ does\ not\ support\ undo.\ Continue?=Pembuatan otomatis nama PDF tidak ada fungsi pengembalian. Teruskan?
 
-Use_full_firstname_whenever_possible=Gunakan_nama_kecil_penuh_kalau_mungkin
-Use_abbreviated_firstname_whenever_possible=Gunakan_singkatan_nama_kecil_kalau_mungkin
-Use_abbreviated_and_full_firstname=Gunakan_nama_kecil_yang_penuh_dan_disingkatkan
-Autocompletion_options=Opsi_pelengkapian_otomatis
-Name_format_used_for_autocompletion=Format_nama_yang_digunakan_untuk_pelengkapan_otomatis
-Treatment_of_first_names=
-Cleanup_entries=Bersihkan_entri
-Automatically_assign_new_entry_to_selected_groups=Tulis_entri_yang_baru_ke_pilihan_grup_secara_otomatis
-%0_mode=Mode_%0
-Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix=Pindah_DOI_dari_bidang_catatan_dan_URL_ke_bidang_DOI_dan_hapuskan_prefiks_http
-Make_paths_of_linked_files_relative_(if_possible)=Menjadikan_lokasi_berkas_yang_ditautkan_relatif_(kalau_mungkin)
-Rename_PDFs_to_given_filename_format_pattern=Ganti_nama_PDF_dengan_pola_format_nama_berkas
-Rename_only_PDFs_having_a_relative_path=Hanya_ganti_nama_PDF_yang_berlokasi_relatif
-What_would_you_like_to_clean_up?=Anda_mau_membersihkan_apa?
-Doing_a_cleanup_for_%0_entries...=Melakukan_pembersihan_%0_entri...
-No_entry_needed_a_clean_up=Tidak_ada_entri_yang_membutuhkan_pembersihan
-One_entry_needed_a_clean_up=Sebuah_entri_membutuhkan_pembersihan
-%0_entries_needed_a_clean_up=%0_entri_membutuhkan_pembersihan
+Use\ full\ firstname\ whenever\ possible=Gunakan nama kecil penuh kalau mungkin
+Use\ abbreviated\ firstname\ whenever\ possible=Gunakan singkatan nama kecil kalau mungkin
+Use\ abbreviated\ and\ full\ firstname=Gunakan nama kecil yang penuh dan disingkatkan
+Autocompletion\ options=Opsi pelengkapian otomatis
+Name\ format\ used\ for\ autocompletion=Format nama yang digunakan untuk pelengkapan otomatis
+Treatment\ of\ first\ names=
+Cleanup\ entries=Bersihkan entri
+Automatically\ assign\ new\ entry\ to\ selected\ groups=Tulis entri yang baru ke pilihan grup secara otomatis
+%0\ mode=Mode %0
+Move\ DOIs\ from\ note\ and\ URL\ field\ to\ DOI\ field\ and\ remove\ http\ prefix=Pindah DOI dari bidang catatan dan URL ke bidang DOI dan hapuskan prefiks http
+Make\ paths\ of\ linked\ files\ relative\ (if\ possible)=Menjadikan lokasi berkas yang ditautkan relatif (kalau mungkin)
+Rename\ PDFs\ to\ given\ filename\ format\ pattern=Ganti nama PDF dengan pola format nama berkas
+Rename\ only\ PDFs\ having\ a\ relative\ path=Hanya ganti nama PDF yang berlokasi relatif
+What\ would\ you\ like\ to\ clean\ up?=Anda mau membersihkan apa?
+Doing\ a\ cleanup\ for\ %0\ entries...=Melakukan pembersihan %0 entri...
+No\ entry\ needed\ a\ clean\ up=Tidak ada entri yang membutuhkan pembersihan
+One\ entry\ needed\ a\ clean\ up=Sebuah entri membutuhkan pembersihan
+%0\ entries\ needed\ a\ clean\ up=%0 entri membutuhkan pembersihan
 
-Remove_selected=Hapuskan_pilihan
+Remove\ selected=Hapuskan pilihan
 
-Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.=
-Attach_file=Lampirkan_berkas
-Setting_all_preferences_to_default_values.=Tetapkan_semua_pengaturan_menjadi_pengaturan_bawaan.
-Resetting_preference_key_'%0'=Kembalikan_kunci_pengaturan_'%0'
-Unknown_preference_key_'%0'=Kunci_pengaturan_'%0'_tidak_dikenal
-Unable_to_clear_preferences.=Tidak_bisa_hapus_pengaturan.
+Group\ tree\ could\ not\ be\ parsed.\ If\ you\ save\ the\ BibTeX\ library,\ all\ groups\ will\ be\ lost.=
+Attach\ file=Lampirkan berkas
+Setting\ all\ preferences\ to\ default\ values.=Tetapkan semua pengaturan menjadi pengaturan bawaan.
+Resetting\ preference\ key\ '%0'=Kembalikan kunci pengaturan '%0'
+Unknown\ preference\ key\ '%0'=Kunci pengaturan '%0' tidak dikenal
+Unable\ to\ clear\ preferences.=Tidak bisa hapus pengaturan.
 
-Reset_preferences_(key1,key2,..._or_'all')=Kembalikan_pengaturan_(kunci1,kunci2,..._atau_'all')
-Find_unlinked_files=Temukan_berkas_yang_tidak_bertautan
-Unselect_all=Tidak_memilih_semua
-Expand_all=
-Collapse_all=
-Opens_the_file_browser.=Buka_penjelajah_berkas.
-Scan_directory=Pindai_direktori
-Searches_the_selected_directory_for_unlinked_files.=Mencari_berkas_yang_belum_ditautkan_dalam_direktori_pilihan.
-Starts_the_import_of_BibTeX_entries.=Memulai_impor_entri_BibTeX.
-Leave_this_dialog.=Tinggalkan_dialog_ini.
-Create_directory_based_keywords=Buat_katakunci_berdasar_direktori
-Creates_keywords_in_created_entrys_with_directory_pathnames=Buat_katakunci_dalam_entri_pembuatan_dengan_direktori
-Select_a_directory_where_the_search_shall_start.=Pilih_direktori_mulaan_pencarian.
-Select_file_type\:=Pilih_tipe_berkas\:
-These_files_are_not_linked_in_the_active_library.=Para_berkas_ini_tidak_bertautan_dalam_basisdata_yang_aktif
-Entry_type_to_be_created\:=Tipe_entri_untuk_dibuat\:
-Searching_file_system...=Pencarian_dalam_sistem_berkas...
-Importing_into_Library...=Impor_ke_basisdata...
-Select_directory=Pilih_direktori
-Select_files=Pilih_berkas
-BibTeX_entry_creation=Pembuatan_entri_BibTeX
-<No_selection>=<Tidak_ada_pilihan>
-Unable_to_connect_to_FreeCite_online_service.=Koneksi_ke_layanan_online_FreeCite_gagal.
-Parse_with_FreeCite=Urai_dengan_FreeCite
-The_current_BibTeX_key_will_be_overwritten._Continue?=Kunci_BibTeX_terkini_akan_ditindih._Teruskan?
-Overwrite_key=Tindih_kunci
-Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator=Kunci_yang_sudah_ada_tidak_akan_ditindih._Untuk_merubah_pengaturan_ini,_bukalah_Opsi_->_Preferensi_-_Pembuat_kunci_BibTeX
-How_would_you_like_to_link_to_'%0'?=Bagaimana_mau_menautkan_ke_'%0'?
-BibTeX_key_patterns=Pola_kunci_BibTeX
-Changed_special_field_settings=Pengaturan_bidang_khusus_diubah
-Clear_priority=Hapus_prioritas
-Clear_rank=Hapus_pangkat
-Enable_special_fields=Aktifkan_bidang_khusus
-One_star=Satu_bintang
-Two_stars=Dua_bintang
-Three_stars=Tiga_bintang
-Four_stars=Empat_bintang
-Five_stars=Lima_bintang
-Help_on_special_fields=Bantuan_bidang_khusus
-Keywords_of_selected_entries=Katakunci_entri_pilihan
-Manage_content_selectors=Atur_kata_pemilih_isi
-Manage_keywords=Atur_katakunci
-No_priority_information=Tidak_ada_informasi_prioritas
-No_rank_information=Tidak_ada_informasi_pangkat
+Reset\ preferences\ (key1,key2,...\ or\ 'all')=Kembalikan pengaturan (kunci1,kunci2,... atau 'all')
+Find\ unlinked\ files=Temukan berkas yang tidak bertautan
+Unselect\ all=Tidak memilih semua
+Expand\ all=
+Collapse\ all=
+Opens\ the\ file\ browser.=Buka penjelajah berkas.
+Scan\ directory=Pindai direktori
+Searches\ the\ selected\ directory\ for\ unlinked\ files.=Mencari berkas yang belum ditautkan dalam direktori pilihan.
+Starts\ the\ import\ of\ BibTeX\ entries.=Memulai impor entri BibTeX.
+Leave\ this\ dialog.=Tinggalkan dialog ini.
+Create\ directory\ based\ keywords=Buat katakunci berdasar direktori
+Creates\ keywords\ in\ created\ entrys\ with\ directory\ pathnames=Buat katakunci dalam entri pembuatan dengan direktori
+Select\ a\ directory\ where\ the\ search\ shall\ start.=Pilih direktori mulaan pencarian.
+Select\ file\ type\:=Pilih tipe berkas:
+These\ files\ are\ not\ linked\ in\ the\ active\ library.=Para berkas ini tidak bertautan dalam basisdata yang aktif
+Entry\ type\ to\ be\ created\:=Tipe entri untuk dibuat:
+Searching\ file\ system...=Pencarian dalam sistem berkas...
+Importing\ into\ Library...=Impor ke basisdata...
+Select\ directory=Pilih direktori
+Select\ files=Pilih berkas
+BibTeX\ entry\ creation=Pembuatan entri BibTeX
+<No\ selection>=<Tidak ada pilihan>
+Unable\ to\ connect\ to\ FreeCite\ online\ service.=Koneksi ke layanan online FreeCite gagal.
+Parse\ with\ FreeCite=Urai dengan FreeCite
+The\ current\ BibTeX\ key\ will\ be\ overwritten.\ Continue?=Kunci BibTeX terkini akan ditindih. Teruskan?
+Overwrite\ key=Tindih kunci
+Not\ overwriting\ existing\ key.\ To\ change\ this\ setting,\ open\ Options\ ->\ Prefererences\ ->\ BibTeX\ key\ generator=Kunci yang sudah ada tidak akan ditindih. Untuk merubah pengaturan ini, bukalah Opsi -> Preferensi - Pembuat kunci BibTeX
+How\ would\ you\ like\ to\ link\ to\ '%0'?=Bagaimana mau menautkan ke '%0'?
+BibTeX\ key\ patterns=Pola kunci BibTeX
+Changed\ special\ field\ settings=Pengaturan bidang khusus diubah
+Clear\ priority=Hapus prioritas
+Clear\ rank=Hapus pangkat
+Enable\ special\ fields=Aktifkan bidang khusus
+One\ star=Satu bintang
+Two\ stars=Dua bintang
+Three\ stars=Tiga bintang
+Four\ stars=Empat bintang
+Five\ stars=Lima bintang
+Help\ on\ special\ fields=Bantuan bidang khusus
+Keywords\ of\ selected\ entries=Katakunci entri pilihan
+Manage\ content\ selectors=Atur kata pemilih isi
+Manage\ keywords=Atur katakunci
+No\ priority\ information=Tidak ada informasi prioritas
+No\ rank\ information=Tidak ada informasi pangkat
 Priority=Prioritas
-Priority_high=Prioritas_tinggi
-Priority_low=Prioritas_rendah
-Priority_medium=Prioritas_menengah
+Priority\ high=Prioritas tinggi
+Priority\ low=Prioritas rendah
+Priority\ medium=Prioritas menengah
 Quality=Kualitas
 Rank=Pangkat
 Relevance=Relevansi
-Set_priority_to_high=Menjadikan_prioritas_tinggi
-Set_priority_to_low=Menjadikan_prioritas_rendah
-Set_priority_to_medium=Menjadikan_prioritas_menengah
-Show_priority=Tampilkan_prioritas
-Show_quality=Tampilkan_kualitas
-Show_rank=Tampilkan_pangkat
-Show_relevance=Tampilkan_relevansi
-Synchronize_with_keywords=Sinkronkan_dengan_katakunci
-Synchronized_special_fields_based_on_keywords=Bidang_khusus_disinkronkan_berdasar_katakunci
-Toggle_relevance=Gunakan_relevansi
-Toggle_quality_assured=
-Toggle_print_status=
-Update_keywords=Perbarui_katakunci
-Write_values_of_special_fields_as_separate_fields_to_BibTeX=Tulis_isi_bidang_khusus_sebagai_bidang_terpisah_ke_BibTeX
-You_have_changed_settings_for_special_fields.=Anda_telah_merubah_pengaturan_bidang_khusus.
-%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.=%0_entri_ditemukan._Untuk_mengurangi_beban_server,_hanya_%1_akan_dimuatturun.
-A_string_with_that_label_already_exists=String_dengan_label_tadi_sudah_ada
-Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.=Sambungan_ke_OpenOffice/LibreOffice_terlepas._Pastikan_OpenOffice/LibreOffice_dijalankan,_dan_coba_menyambung_sekali_lagi.
-JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.=
-Correct_the_entry,_and_reopen_editor_to_display/edit_source.=Koreksi_entri_dan_buka_editor_penunjuk/pengedit_sumber_sekali_lagi.
-Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').=Tidak_bisa_menyambung_ke_proses_gnuserv_yang_sudah_dijalankan._Pastikan_Emacs_atau_XEmacs<br>dan_server_sudah_dijalankan_(dengan_perintah_'server-start'/'gnuserv-start')
-Could_not_connect_to_running_OpenOffice/LibreOffice.=Tidak_bisa_menyambung_dengan_OpenOffice/LibreOffice.
-Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.=Pastikan_OpenOffice/LibreOffice_diinstal_dengan_dukungan_Java.
-If_connecting_manually,_please_verify_program_and_library_paths.=Kalau_menyambung_secara_manual,_pastikan_lokasi_program_dan_pustaka.
-Error_message\:=Pesan_kesalahan\:
-If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.=
-Import_metadata_from_PDF=Impor_metadata_dari_PDF
-Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.=Tidak_tersambung_dengan_dokumen_Writer._Pastikan_salah_satu_dokumen_terbuka_dan_gunakan_tombol_'Select_Writer_document'_untuk_menyambung_dengan_dokumen_itu.
-Removed_all_subgroups_of_group_"%0".=Semua_anak_grup_dari_grup_"%0"_dihapus.
-To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.=Untuk_mengtidakaktifkan_mode_pena_simpan_ubah_atau_hapus_berkas_jabref.xml_dalam_direktori_yang_sama_dengan_JabRef.
-Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.=
-Use_the_following_delimiter_character(s)\:=Gunakan_karakter_pembatas_berikut\:
-When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above=
-Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=Berkas_gaya_anda_menspesifikasi_format_karakter_'%0',_yang_tidak_terdefinisi_dalam_dokumen_OpenOffice/LibreOffice_terkini_anda.
-Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=Berkas_gaya_anda_menspesifikasi_format_paragraf_'%0',_yang_tidak_terdefinisi_dalam_dokumen_OpenOffice/LibreOffice_terkini_anda.
+Set\ priority\ to\ high=Menjadikan prioritas tinggi
+Set\ priority\ to\ low=Menjadikan prioritas rendah
+Set\ priority\ to\ medium=Menjadikan prioritas menengah
+Show\ priority=Tampilkan prioritas
+Show\ quality=Tampilkan kualitas
+Show\ rank=Tampilkan pangkat
+Show\ relevance=Tampilkan relevansi
+Synchronize\ with\ keywords=Sinkronkan dengan katakunci
+Synchronized\ special\ fields\ based\ on\ keywords=Bidang khusus disinkronkan berdasar katakunci
+Toggle\ relevance=Gunakan relevansi
+Toggle\ quality\ assured=
+Toggle\ print\ status=
+Update\ keywords=Perbarui katakunci
+Write\ values\ of\ special\ fields\ as\ separate\ fields\ to\ BibTeX=Tulis isi bidang khusus sebagai bidang terpisah ke BibTeX
+You\ have\ changed\ settings\ for\ special\ fields.=Anda telah merubah pengaturan bidang khusus.
+%0\ entries\ found.\ To\ reduce\ server\ load,\ only\ %1\ will\ be\ downloaded.=%0 entri ditemukan. Untuk mengurangi beban server, hanya %1 akan dimuatturun.
+A\ string\ with\ that\ label\ already\ exists=String dengan label tadi sudah ada
+Connection\ to\ OpenOffice/LibreOffice\ has\ been\ lost.\ Please\ make\ sure\ OpenOffice/LibreOffice\ is\ running,\ and\ try\ to\ reconnect.=Sambungan ke OpenOffice/LibreOffice terlepas. Pastikan OpenOffice/LibreOffice dijalankan, dan coba menyambung sekali lagi.
+JabRef\ will\ send\ at\ least\ one\ request\ per\ entry\ to\ a\ publisher.=
+Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=Koreksi entri dan buka editor penunjuk/pengedit sumber sekali lagi.
+Could\ not\ connect\ to\ a\ running\ gnuserv\ process.\ Make\ sure\ that\ Emacs\ or\ XEmacs\ is\ running,<BR>and\ that\ the\ server\ has\ been\ started\ (by\ running\ the\ command\ 'server-start'/'gnuserv-start').=Tidak bisa menyambung ke proses gnuserv yang sudah dijalankan. Pastikan Emacs atau XEmacs<br>dan server sudah dijalankan (dengan perintah 'server-start'/'gnuserv-start')
+Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=Tidak bisa menyambung dengan OpenOffice/LibreOffice.
+Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=Pastikan OpenOffice/LibreOffice diinstal dengan dukungan Java.
+If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=Kalau menyambung secara manual, pastikan lokasi program dan pustaka.
+Error\ message\:=Pesan kesalahan:
+If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=
+Import\ metadata\ from\ PDF=Impor metadata dari PDF
+Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=Tidak tersambung dengan dokumen Writer. Pastikan salah satu dokumen terbuka dan gunakan tombol 'Select Writer document' untuk menyambung dengan dokumen itu.
+Removed\ all\ subgroups\ of\ group\ "%0".=Semua anak grup dari grup "%0" dihapus.
+To\ disable\ the\ memory\ stick\ mode\ rename\ or\ remove\ the\ jabref.xml\ file\ in\ the\ same\ folder\ as\ JabRef.=Untuk mengtidakaktifkan mode pena simpan ubah atau hapus berkas jabref.xml dalam direktori yang sama dengan JabRef.
+Unable\ to\ connect.\ One\ possible\ reason\ is\ that\ JabRef\ and\ OpenOffice/LibreOffice\ are\ not\ both\ running\ in\ either\ 32\ bit\ mode\ or\ 64\ bit\ mode.=
+Use\ the\ following\ delimiter\ character(s)\:=Gunakan karakter pembatas berikut:
+When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\ prefer\ the\ BIB\ file\ location\ rather\ than\ the\ file\ directory\ set\ above=
+Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Berkas gaya anda menspesifikasi format karakter '%0', yang tidak terdefinisi dalam dokumen OpenOffice/LibreOffice terkini anda.
+Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Berkas gaya anda menspesifikasi format paragraf '%0', yang tidak terdefinisi dalam dokumen OpenOffice/LibreOffice terkini anda.
 
-Searching...=Sedang_mencari...
-You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?=Anda_memilih_lebih_dari_%0_entri._Sejumlah_situs_web_akan_memblokir_anda_kalau_melakukan_terlalu_banyak_pemuatturunan_dengan_cepat._Apa_mau_teruskan?
-Confirm_selection=Mengkonfirmasi_pilihan
-Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case=
-Import_conversions=Impor_konversi
-Please_enter_a_search_string=Tuliskan_string_pencarian
-Please_open_or_start_a_new_library_before_searching=Buka_atau_jalankan_basisdata_yang_baru_sebelum_mencari
+Searching...=Sedang mencari...
+You\ have\ selected\ more\ than\ %0\ entries\ for\ download.\ Some\ web\ sites\ might\ block\ you\ if\ you\ make\ too\ many\ rapid\ downloads.\ Do\ you\ want\ to\ continue?=Anda memilih lebih dari %0 entri. Sejumlah situs web akan memblokir anda kalau melakukan terlalu banyak pemuatturunan dengan cepat. Apa mau teruskan?
+Confirm\ selection=Mengkonfirmasi pilihan
+Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=
+Import\ conversions=Impor konversi
+Please\ enter\ a\ search\ string=Tuliskan string pencarian
+Please\ open\ or\ start\ a\ new\ library\ before\ searching=Buka atau jalankan basisdata yang baru sebelum mencari
 
-Canceled_merging_entries=Penggabungan_entri_dibatalkan
+Canceled\ merging\ entries=Penggabungan entri dibatalkan
 
-Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search=
-Merge_entries=Gabung_entri
-Merged_entries=
-Merged_entry=
+Format\ units\ by\ adding\ non-breaking\ separators\ and\ keeping\ the\ correct\ case\ on\ search=
+Merge\ entries=Gabung entri
+Merged\ entries=
+Merged\ entry=
 None=Kosong
 Parse=Urai
 Result=Hasil
-Show_DOI_first=Tampilkan_DOI_dulu
-Show_URL_first=Tampilkan_URL_dulu
-Use_Emacs_key_bindings=
-You_have_to_choose_exactly_two_entries_to_merge.=Anda_harus_memilih_dua_entri_untuk_digabung.
+Show\ DOI\ first=Tampilkan DOI dulu
+Show\ URL\ first=Tampilkan URL dulu
+Use\ Emacs\ key\ bindings=
+You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=Anda harus memilih dua entri untuk digabung.
 
-Update_timestamp_on_modification=
-All_key_bindings_will_be_reset_to_their_defaults.=
+Update\ timestamp\ on\ modification=
+All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=
 
-Automatically_set_file_links=Buat_tautan_berkas_secara_otomatis.
-Resetting_all_key_bindings=
-Hostname=Nama_host
-Invalid_setting=Pengaturan_tidak_sah
+Automatically\ set\ file\ links=Buat tautan berkas secara otomatis.
+Resetting\ all\ key\ bindings=
+Hostname=Nama host
+Invalid\ setting=Pengaturan tidak sah
 Network=Jaringan
-Please_specify_both_hostname_and_port=Silahkan_nyatakan_nama_host_dan_port
-Please_specify_both_username_and_password=Silahkan_menulis_nama_pengguna_dan_kata_sandi
+Please\ specify\ both\ hostname\ and\ port=Silahkan nyatakan nama host dan port
+Please\ specify\ both\ username\ and\ password=Silahkan menulis nama pengguna dan kata sandi
 
-Use_custom_proxy_configuration=Gunakan_konfigurasi_proxy_suaian
-Proxy_requires_authentication=Proxy_memerlukan_otentikasi
-Attention\:_Password_is_stored_in_plain_text\!=Perhatian\:_Kata_sandi_disimpan_sebagai_teks_biasa\!
-Clear_connection_settings=Bersihkan_pengaturan_koneksi
-Cleared_connection_settings.=Pengaturan_koneksi_dibersihkan.
+Use\ custom\ proxy\ configuration=Gunakan konfigurasi proxy suaian
+Proxy\ requires\ authentication=Proxy memerlukan otentikasi
+Attention\:\ Password\ is\ stored\ in\ plain\ text\!=Perhatian: Kata sandi disimpan sebagai teks biasa!
+Clear\ connection\ settings=Bersihkan pengaturan koneksi
+Cleared\ connection\ settings.=Pengaturan koneksi dibersihkan.
 
-Rebind_C-a,_too=
-Rebind_C-f,_too=
+Rebind\ C-a,\ too=
+Rebind\ C-f,\ too=
 
-Open_folder=Buka_direktori
-Searches_for_unlinked_PDF_files_on_the_file_system=Cari_berkas_PDF_yang_tidak_bertautan_dalam_sistem_berkas
-Export_entries_ordered_as_specified=
-Export_sort_order=Ekspor_urutan_penyortiran
-Export_sorting=Ekspor_penyortiran
-Newline_separator=Pembatas_baris_yang_baru
+Open\ folder=Buka direktori
+Searches\ for\ unlinked\ PDF\ files\ on\ the\ file\ system=Cari berkas PDF yang tidak bertautan dalam sistem berkas
+Export\ entries\ ordered\ as\ specified=
+Export\ sort\ order=Ekspor urutan penyortiran
+Export\ sorting=Ekspor penyortiran
+Newline\ separator=Pembatas baris yang baru
 
-Save_entries_ordered_as_specified=
-Save_sort_order=Simpan_urutan_penyortiran
-Show_extra_columns=Tampilkan_kolom_ekstra
-Parsing_error=Kesalahan_penguraian
-illegal_backslash_expression=Ekspresi_tanda_garis_miring_terbalik_tidak_sah
+Save\ entries\ ordered\ as\ specified=
+Save\ sort\ order=Simpan urutan penyortiran
+Show\ extra\ columns=Tampilkan kolom ekstra
+Parsing\ error=Kesalahan penguraian
+illegal\ backslash\ expression=Ekspresi tanda garis miring terbalik tidak sah
 
-Move_to_group=Pindah_ke_grup
+Move\ to\ group=Pindah ke grup
 
-Clear_read_status=Bersihkan_status_pembacaan
-Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')=
-Could_not_apply_changes.=Tidak_bisa_terapkan_perubahan.
-Deprecated_fields=
-Hide/show_toolbar=Sembunyikan/Tampilkan_toolbar
-No_read_status_information=Tidak_ada_informasi_status_pembacaan
+Clear\ read\ status=Bersihkan status pembacaan
+Convert\ to\ biblatex\ format\ (for\ example,\ move\ the\ value\ of\ the\ 'journal'\ field\ to\ 'journaltitle')=
+Could\ not\ apply\ changes.=Tidak bisa terapkan perubahan.
+Deprecated\ fields=
+Hide/show\ toolbar=Sembunyikan/Tampilkan toolbar
+No\ read\ status\ information=Tidak ada informasi status pembacaan
 Printed=Dicetak
-Read_status=Status_pembacaan
-Read_status_read=Status_pembacaan_dibaca
-Read_status_skimmed=
-Save_selected_as_plain_BibTeX...=Simpan_pilihan_sebagai_BibTeX_teks_biasa
-Set_read_status_to_read=Menjadikan_status_pembacaan_dibaca
-Set_read_status_to_skimmed=
-Show_deprecated_BibTeX_fields=
+Read\ status=Status pembacaan
+Read\ status\ read=Status pembacaan dibaca
+Read\ status\ skimmed=
+Save\ selected\ as\ plain\ BibTeX...=Simpan pilihan sebagai BibTeX teks biasa
+Set\ read\ status\ to\ read=Menjadikan status pembacaan dibaca
+Set\ read\ status\ to\ skimmed=
+Show\ deprecated\ BibTeX\ fields=
 
-Show_gridlines=Tampilkan_garis_kisi
-Show_printed_status=Tampilkan_status_pencetakan
-Show_read_status=Tampilkan_status_pembacaan
-Table_row_height_padding=Lapisan_tinggi_baris_tabel
+Show\ gridlines=Tampilkan garis kisi
+Show\ printed\ status=Tampilkan status pencetakan
+Show\ read\ status=Tampilkan status pembacaan
+Table\ row\ height\ padding=Lapisan tinggi baris tabel
 
-Marked_selected_entry=Entri_pilihan_ditandai
-Marked_all_%0_selected_entries=Semua_%0_entri_pilihan_ditandai
-Unmarked_selected_entry=Tanda_entri_pilihan_dihilangkan
-Unmarked_all_%0_selected_entries=Tanda_semua_%0_entri_pilihan_dihilangkan
+Marked\ selected\ entry=Entri pilihan ditandai
+Marked\ all\ %0\ selected\ entries=Semua %0 entri pilihan ditandai
+Unmarked\ selected\ entry=Tanda entri pilihan dihilangkan
+Unmarked\ all\ %0\ selected\ entries=Tanda semua %0 entri pilihan dihilangkan
 
 
-Unmarked_all_entries=Tanda_semua_entri_dihilangkan
+Unmarked\ all\ entries=Tanda semua entri dihilangkan
 
-Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.=Penampilan_yang_dimintai_tidak_bisa_ditemukan._Karena_begitu,_penampilan_bawaan_akan_digunakan.
+Unable\ to\ find\ the\ requested\ look\ and\ feel\ and\ thus\ the\ default\ one\ is\ used.=Penampilan yang dimintai tidak bisa ditemukan. Karena begitu, penampilan bawaan akan digunakan.
 
-Opens_JabRef's_GitHub_page=Buka_halaman_JabRef_di_GitHub
-Could_not_open_browser.=Penjelajah_tidak_bisa_dibuka.
-Please_open_%0_manually.=
-The_link_has_been_copied_to_the_clipboard.=
+Opens\ JabRef's\ GitHub\ page=Buka halaman JabRef di GitHub
+Could\ not\ open\ browser.=Penjelajah tidak bisa dibuka.
+Please\ open\ %0\ manually.=
+The\ link\ has\ been\ copied\ to\ the\ clipboard.=
 
-Open_%0_file=Buka_berkas_%0
+Open\ %0\ file=Buka berkas %0
 
-Cannot_delete_file=Tidak_bisa_menghapus_berkas
-File_permission_error=Kesalahan_hak_akses_berkas
-Push_to_%0=Kirim_pilihan_ke_%0
-Path_to_%0=Lokasi_%0
+Cannot\ delete\ file=Tidak bisa menghapus berkas
+File\ permission\ error=Kesalahan hak akses berkas
+Push\ to\ %0=Kirim pilihan ke %0
+Path\ to\ %0=Lokasi %0
 Convert=
-Normalize_to_BibTeX_name_format=
-Help_on_Name_Formatting=
+Normalize\ to\ BibTeX\ name\ format=
+Help\ on\ Name\ Formatting=
 
-Add_new_file_type=Tambahkan_tipe_berkas_yang_baru
+Add\ new\ file\ type=Tambahkan tipe berkas yang baru
 
-Left_entry=
-Right_entry=
+Left\ entry=
+Right\ entry=
 Use=
-Original_entry=Entri_asli
-Replace_original_entry=Ganti_entri_asli
-No_information_added=Tidak_ada_informasi_yang_ditambahkan
-Select_at_least_one_entry_to_manage_keywords.=Pilih_paling_sedikit_sebuah_entri_untuk_mengatur_katakunci.
-OpenDocument_text=Teks_OpenDocument
-OpenDocument_spreadsheet=Lembatang_lajur_OpenDocument
-OpenDocument_presentation=Presentasi_Open_Document
-%0_image=
-Added_entry=Entri_ditambahkan
-Modified_entry=
-Deleted_entry=Entri_dihapus
-Modified_groups_tree=
-Removed_all_groups=Semua_kelompok_dihapus
-Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.=
-Select_export_format=Pilih_format_ekspor
-Return_to_JabRef=Kembali_ke_JabRef
-Please_move_the_file_manually_and_link_in_place.=Silahkan_memindah_berkas_secara_manual_dan_menautkan_tempatnya.
-Could_not_connect_to_%0=Tidak_bisa_menghubungi_%0
-Warning\:_%0_out_of_%1_entries_have_undefined_title.=
-Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.=Peringatan\:_%0_dari_%1_entri_ada_kunci_BibTeX_yang_tidak_terdefinisi.
+Original\ entry=Entri asli
+Replace\ original\ entry=Ganti entri asli
+No\ information\ added=Tidak ada informasi yang ditambahkan
+Select\ at\ least\ one\ entry\ to\ manage\ keywords.=Pilih paling sedikit sebuah entri untuk mengatur katakunci.
+OpenDocument\ text=Teks OpenDocument
+OpenDocument\ spreadsheet=Lembatang lajur OpenDocument
+OpenDocument\ presentation=Presentasi Open Document
+%0\ image=
+Added\ entry=Entri ditambahkan
+Modified\ entry=
+Deleted\ entry=Entri dihapus
+Modified\ groups\ tree=
+Removed\ all\ groups=Semua kelompok dihapus
+Accepting\ the\ change\ replaces\ the\ complete\ groups\ tree\ with\ the\ externally\ modified\ groups\ tree.=
+Select\ export\ format=Pilih format ekspor
+Return\ to\ JabRef=Kembali ke JabRef
+Please\ move\ the\ file\ manually\ and\ link\ in\ place.=Silahkan memindah berkas secara manual dan menautkan tempatnya.
+Could\ not\ connect\ to\ %0=Tidak bisa menghubungi %0
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ title.=
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ BibTeX\ key.=Peringatan: %0 dari %1 entri ada kunci BibTeX yang tidak terdefinisi.
 occurrence=
-Added_new_'%0'_entry.=Entri_yang_baru_'%0'_ditambahkan.
-Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?=
-Changed_type_to_'%0'_for=Merubah_tipe_ke_'%0'_untuk
-Really_delete_the_selected_entry?=Apa_benar-benar_mau_menghapus_entri_pilihan?
-Really_delete_the_%0_selected_entries?=Apa_benar-benar_mau_menghapus_%0_entri_yang_dipilih?
-Keep_merged_entry_only=
-Keep_left=
-Keep_right=
-Old_entry=Entri_yang_tua
-From_import=Dari_impor
-No_problems_found.=Tidak_menemukan_kesulitan.
-%0_problem(s)_found=%0_kesalahan_ditemukan
-Save_changes=Simpan_perubahan
-Discard_changes=Perubahan_dibuang
-Library_'%0'_has_changed.=Basisdata_%0_telah_berubah.
-Print_entry_preview=Cetak_pratinjau_entri
-Copy_title=
-Copy_\\cite{BibTeX_key}=Salin_\\cite{kunci_BibTeX}
-Copy_BibTeX_key_and_title=Salin_kunci_BibTeX_dan_judul
-File_rename_failed_for_%0_entries.=Perubahan_nama_berkas_gagal_untuk_%0_entri.
-Merged_BibTeX_source_code=
-Invalid_DOI\:_'%0'.=DOI_salah\:_'%0'.
-should_start_with_a_name=harus_bermula_dengan_nama
-should_end_with_a_name=harus_berakhiran_nama
-unexpected_closing_curly_bracket=
-unexpected_opening_curly_bracket=
-capital_letters_are_not_masked_using_curly_brackets_{}=
-should_contain_a_four_digit_number=harus_berisi_nomor_dengan_empat_angka
-should_contain_a_valid_page_number_range=
+Added\ new\ '%0'\ entry.=Entri yang baru '%0' ditambahkan.
+Multiple\ entries\ selected.\ Do\ you\ want\ to\ change\ the\ type\ of\ all\ these\ to\ '%0'?=
+Changed\ type\ to\ '%0'\ for=Merubah tipe ke '%0' untuk
+Really\ delete\ the\ selected\ entry?=Apa benar-benar mau menghapus entri pilihan?
+Really\ delete\ the\ %0\ selected\ entries?=Apa benar-benar mau menghapus %0 entri yang dipilih?
+Keep\ merged\ entry\ only=
+Keep\ left=
+Keep\ right=
+Old\ entry=Entri yang tua
+From\ import=Dari impor
+No\ problems\ found.=Tidak menemukan kesulitan.
+%0\ problem(s)\ found=%0 kesalahan ditemukan
+Save\ changes=Simpan perubahan
+Discard\ changes=Perubahan dibuang
+Library\ '%0'\ has\ changed.=Basisdata %0 telah berubah.
+Print\ entry\ preview=Cetak pratinjau entri
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=Salin \\cite{kunci BibTeX}
+Copy\ BibTeX\ key\ and\ title=Salin kunci BibTeX dan judul
+File\ rename\ failed\ for\ %0\ entries.=Perubahan nama berkas gagal untuk %0 entri.
+Merged\ BibTeX\ source\ code=
+Invalid\ DOI\:\ '%0'.=DOI salah: '%0'.
+should\ start\ with\ a\ name=harus bermula dengan nama
+should\ end\ with\ a\ name=harus berakhiran nama
+unexpected\ closing\ curly\ bracket=
+unexpected\ opening\ curly\ bracket=
+capital\ letters\ are\ not\ masked\ using\ curly\ brackets\ {}=
+should\ contain\ a\ four\ digit\ number=harus berisi nomor dengan empat angka
+should\ contain\ a\ valid\ page\ number\ range=
 Filled=Dipenuhi
-Field_is_missing=Tidak_ada_bidang
-Search_%0=Pencarian_%0
+Field\ is\ missing=Tidak ada bidang
+Search\ %0=Pencarian %0
 
-Search_results_in_all_libraries_for_%0=Hasil_pencarian_untuk_%0_dalam_semua_basisdata
-Search_results_in_library_%0_for_%1=Hasil_pencarian_untuk_%0_dalam_basisdata_%1
-Search_globally=Cari_secara_global
-No_results_found.=Tidak_menemukan_hasil_pencarian.
-Found_%0_results.=Menemukan_%0_hasil_pencarian.
-plain_text=teks_biasa
-This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>=
-This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>=
-This_search_contains_entries_in_which=
+Search\ results\ in\ all\ libraries\ for\ %0=Hasil pencarian untuk %0 dalam semua basisdata
+Search\ results\ in\ library\ %0\ for\ %1=Hasil pencarian untuk %0 dalam basisdata %1
+Search\ globally=Cari secara global
+No\ results\ found.=Tidak menemukan hasil pencarian.
+Found\ %0\ results.=Menemukan %0 hasil pencarian.
+plain\ text=teks biasa
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ regular\ expression\ <b>%0</b>=
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ term\ <b>%0</b>=
+This\ search\ contains\ entries\ in\ which=
 
-Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.=
-JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>=
-This_library_uses_outdated_file_links.=
+Unable\ to\ autodetect\ OpenOffice/LibreOffice\ installation.\ Please\ choose\ the\ installation\ directory\ manually.=
+JabRef\ no\ longer\ supports\ 'ps'\ or\ 'pdf'\ fields.<br>File\ links\ are\ now\ stored\ in\ the\ 'file'\ field\ and\ files\ are\ stored\ in\ an\ external\ file\ directory.<br>To\ make\ use\ of\ this\ feature,\ JabRef\ needs\ to\ upgrade\ file\ links.<br><br>=
+This\ library\ uses\ outdated\ file\ links.=
 
-Clear_search=Bersihkan_pencarian
-Close_library=Tutup_basisdata
-Close_entry_editor=Tutup_penyunting_entri
-Decrease_table_font_size=Kurangi_ukuran_huruf_tabel
-Entry_editor,_next_entry=Penyunting_entri,_entri_depan
-Entry_editor,_next_panel=Penyunting_entri,_panel_depan
-Entry_editor,_next_panel_2=
-Entry_editor,_previous_entry=Penyunting_entri,_entri_lalu
-Entry_editor,_previous_panel=Penyunting_entri,_panel_lalu
-Entry_editor,_previous_panel_2=
-File_list_editor,_move_entry_down=Penyunting_daftar_berkas,_pindah_entri_kebawah
-File_list_editor,_move_entry_up=Penyunting_daftar_berkas,_pindah_entri_keatas
-Focus_entry_table=
-Import_into_current_library=Impor_ke_basisdata_sekarang
-Import_into_new_library=Impor_ke_basisdata_yang_baru
-Increase_table_font_size=Tingkatkan_ukuran_huruf_tabel
-New_article=Artikel_baru
-New_book=Buku_baru
-New_entry=Entri_baru
-New_from_plain_text=Baru_dari_teks_biasa
-New_inbook=
-New_mastersthesis=
-New_phdthesis=
-New_proceedings=
-New_unpublished=
-Next_tab=
-Preamble_editor,_store_changes=
-Previous_tab=
-Push_to_application=
-Refresh_OpenOffice/LibreOffice=
-Resolve_duplicate_BibTeX_keys=
-Save_all=Simpan_semua
-String_dialog,_add_string=Dialog_string,_tambah_string
-String_dialog,_remove_string=Dialog_string,_hapus_string
-Synchronize_files=Sinkronkan_berkas
+Clear\ search=Bersihkan pencarian
+Close\ library=Tutup basisdata
+Close\ entry\ editor=Tutup penyunting entri
+Decrease\ table\ font\ size=Kurangi ukuran huruf tabel
+Entry\ editor,\ next\ entry=Penyunting entri, entri depan
+Entry\ editor,\ next\ panel=Penyunting entri, panel depan
+Entry\ editor,\ next\ panel\ 2=
+Entry\ editor,\ previous\ entry=Penyunting entri, entri lalu
+Entry\ editor,\ previous\ panel=Penyunting entri, panel lalu
+Entry\ editor,\ previous\ panel\ 2=
+File\ list\ editor,\ move\ entry\ down=Penyunting daftar berkas, pindah entri kebawah
+File\ list\ editor,\ move\ entry\ up=Penyunting daftar berkas, pindah entri keatas
+Focus\ entry\ table=
+Import\ into\ current\ library=Impor ke basisdata sekarang
+Import\ into\ new\ library=Impor ke basisdata yang baru
+Increase\ table\ font\ size=Tingkatkan ukuran huruf tabel
+New\ article=Artikel baru
+New\ book=Buku baru
+New\ entry=Entri baru
+New\ from\ plain\ text=Baru dari teks biasa
+New\ inbook=
+New\ mastersthesis=
+New\ phdthesis=
+New\ proceedings=
+New\ unpublished=
+Next\ tab=
+Preamble\ editor,\ store\ changes=
+Previous\ tab=
+Push\ to\ application=
+Refresh\ OpenOffice/LibreOffice=
+Resolve\ duplicate\ BibTeX\ keys=
+Save\ all=Simpan semua
+String\ dialog,\ add\ string=Dialog string, tambah string
+String\ dialog,\ remove\ string=Dialog string, hapus string
+Synchronize\ files=Sinkronkan berkas
 Unabbreviate=
-should_contain_a_protocol=
-Copy_preview=
-Automatically_setting_file_links=
-Regenerating_BibTeX_keys_according_to_metadata=
-No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys=
-Regenerate_all_keys_for_the_entries_in_a_BibTeX_file=
-Show_debug_level_messages=
-Default_bibliography_mode=Mode_bibliografi_bawaan
-New_%0_library_created.=Basisdata_baru_%0_dibuat.
-Show_only_preferences_deviating_from_their_default_value=
+should\ contain\ a\ protocol=
+Copy\ preview=
+Automatically\ setting\ file\ links=
+Regenerating\ BibTeX\ keys\ according\ to\ metadata=
+No\ meta\ data\ present\ in\ BIB\ file.\ Cannot\ regenerate\ BibTeX\ keys=
+Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=
+Show\ debug\ level\ messages=
+Default\ bibliography\ mode=Mode bibliografi bawaan
+New\ %0\ library\ created.=Basisdata baru %0 dibuat.
+Show\ only\ preferences\ deviating\ from\ their\ default\ value=
 default=bawaan
 key=kunci
 type=tipe
 value=
-Show_preferences=
-Save_actions=
-Enable_save_actions=
+Show\ preferences=
+Save\ actions=
+Enable\ save\ actions=
 
-Other_fields=Bidang_lain
-Show_remaining_fields=
+Other\ fields=Bidang lain
+Show\ remaining\ fields=
 
-link_should_refer_to_a_correct_file_path=
-abbreviation_detected=
-wrong_entry_type_as_proceedings_has_page_numbers=
-Abbreviate_journal_names=Singkatkan_nama_jurnal
+link\ should\ refer\ to\ a\ correct\ file\ path=
+abbreviation\ detected=
+wrong\ entry\ type\ as\ proceedings\ has\ page\ numbers=
+Abbreviate\ journal\ names=Singkatkan nama jurnal
 Abbreviating...=Singkatkan...
-Abbreviation_%s_for_journal_%s_already_defined.=
-Abbreviation_cannot_be_empty=
-Duplicated_Journal_Abbreviation=
-Duplicated_Journal_File=
-Error_Occurred=
-Journal_file_%s_already_added=
-Name_cannot_be_empty=
+Abbreviation\ %s\ for\ journal\ %s\ already\ defined.=
+Abbreviation\ cannot\ be\ empty=
+Duplicated\ Journal\ Abbreviation=
+Duplicated\ Journal\ File=
+Error\ Occurred=
+Journal\ file\ %s\ already\ added=
+Name\ cannot\ be\ empty=
 
-Adding_fetched_entries=Tambah_entri_ambilan
-Display_keywords_appearing_in_ALL_entries=Tampilkan_katakunci_yang_ada_dalam_semua_entri
-Display_keywords_appearing_in_ANY_entry=
-Fetching_entries_from_Inspire=
-None_of_the_selected_entries_have_titles.=
-None_of_the_selected_entries_have_BibTeX_keys.=
-Unabbreviate_journal_names=
+Adding\ fetched\ entries=Tambah entri ambilan
+Display\ keywords\ appearing\ in\ ALL\ entries=Tampilkan katakunci yang ada dalam semua entri
+Display\ keywords\ appearing\ in\ ANY\ entry=
+Fetching\ entries\ from\ Inspire=
+None\ of\ the\ selected\ entries\ have\ titles.=
+None\ of\ the\ selected\ entries\ have\ BibTeX\ keys.=
+Unabbreviate\ journal\ names=
 Unabbreviating...=
 Usage=Penggunaan
 
 
-Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.=
-Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
-Reset_preferences=
-Ill-formed_entrytype_comment_in_BIB_file=
+Adds\ {}\ brackets\ around\ acronyms,\ month\ names\ and\ countries\ to\ preserve\ their\ case.=
+Are\ you\ sure\ you\ want\ to\ reset\ all\ settings\ to\ default\ values?=
+Reset\ preferences=
+Ill-formed\ entrytype\ comment\ in\ BIB\ file=
 
-Move_linked_files_to_default_file_directory_%0=
+Move\ linked\ files\ to\ default\ file\ directory\ %0=
 
 Clipboard=
-Could_not_paste_entry_as_text\:=Entri_tidak_bisa_dimuat_sebagai_teks\:
-Do_you_still_want_to_continue?=Apa_masih_mau_meneruskan?
-This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:=
-This_could_cause_undesired_changes_to_your_entries.=
-Run_field_formatter\:=
-Table_font_size_is_%0=
-%0_import_canceled=Impor_%0_dibatalkan
-Internal_style=
-Add_style_file=Tambah_berkas_gaya
-Are_you_sure_you_want_to_remove_the_style?=
-Current_style_is_'%0'=
-Remove_style=
-Select_one_of_the_available_styles_or_add_a_style_file_from_disk.=
-You_must_select_a_valid_style_file.=Anda_harus_memilih_berkas_file_yang_sah.
+Could\ not\ paste\ entry\ as\ text\:=Entri tidak bisa dimuat sebagai teks:
+Do\ you\ still\ want\ to\ continue?=Apa masih mau meneruskan?
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=
+This\ could\ cause\ undesired\ changes\ to\ your\ entries.=
+Run\ field\ formatter\:=
+Table\ font\ size\ is\ %0=
+%0\ import\ canceled=Impor %0 dibatalkan
+Internal\ style=
+Add\ style\ file=Tambah berkas gaya
+Are\ you\ sure\ you\ want\ to\ remove\ the\ style?=
+Current\ style\ is\ '%0'=
+Remove\ style=
+Select\ one\ of\ the\ available\ styles\ or\ add\ a\ style\ file\ from\ disk.=
+You\ must\ select\ a\ valid\ style\ file.=Anda harus memilih berkas file yang sah.
 Reload=
 
 Capitalize=
-Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.=
-Capitalize_the_first_word,_changes_other_words_to_lower_case.=
-Changes_all_letters_to_lower_case.=
-Changes_all_letters_to_upper_case.=
-Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.=
-Cleans_up_LaTeX_code.=
-Converts_HTML_code_to_LaTeX_code.=
-Converts_HTML_code_to_Unicode.=
-Converts_LaTeX_encoding_to_Unicode_characters.=
-Converts_Unicode_characters_to_LaTeX_encoding.=
-Converts_ordinals_to_LaTeX_superscripts.=
-Converts_units_to_LaTeX_formatting.=
-HTML_to_LaTeX=HTML_ke_LaTeX
-LaTeX_cleanup=Pembersihan_LaTeX
-LaTeX_to_Unicode=LaTeX_ke_Unicode
-Lower_case=Huruf_kecil
-Minify_list_of_person_names=
-Normalize_date=
-Normalize_month=
-Normalize_month_to_BibTeX_standard_abbreviation.=
-Normalize_names_of_persons=
-Normalize_page_numbers=
-Normalize_pages_to_BibTeX_standard.=
-Normalizes_lists_of_persons_to_the_BibTeX_standard.=
-Normalizes_the_date_to_ISO_date_format.=
-Ordinals_to_LaTeX_superscript=
-Protect_terms=
-Remove_enclosing_braces=
-Removes_braces_encapsulating_the_complete_field_content.=
-Sentence_case=
-Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".=
-Title_case=
-Unicode_to_LaTeX=
-Units_to_LaTeX=
-Upper_case=
-Does_nothing.=
+Capitalize\ all\ words,\ but\ converts\ articles,\ prepositions,\ and\ conjunctions\ to\ lower\ case.=
+Capitalize\ the\ first\ word,\ changes\ other\ words\ to\ lower\ case.=
+Changes\ all\ letters\ to\ lower\ case.=
+Changes\ all\ letters\ to\ upper\ case.=
+Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=
+Cleans\ up\ LaTeX\ code.=
+Converts\ HTML\ code\ to\ LaTeX\ code.=
+Converts\ HTML\ code\ to\ Unicode.=
+Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=
+Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=
+Converts\ ordinals\ to\ LaTeX\ superscripts.=
+Converts\ units\ to\ LaTeX\ formatting.=
+HTML\ to\ LaTeX=HTML ke LaTeX
+LaTeX\ cleanup=Pembersihan LaTeX
+LaTeX\ to\ Unicode=LaTeX ke Unicode
+Lower\ case=Huruf kecil
+Minify\ list\ of\ person\ names=
+Normalize\ date=
+Normalize\ month=
+Normalize\ month\ to\ BibTeX\ standard\ abbreviation.=
+Normalize\ names\ of\ persons=
+Normalize\ page\ numbers=
+Normalize\ pages\ to\ BibTeX\ standard.=
+Normalizes\ lists\ of\ persons\ to\ the\ BibTeX\ standard.=
+Normalizes\ the\ date\ to\ ISO\ date\ format.=
+Ordinals\ to\ LaTeX\ superscript=
+Protect\ terms=
+Remove\ enclosing\ braces=
+Removes\ braces\ encapsulating\ the\ complete\ field\ content.=
+Sentence\ case=
+Shortens\ lists\ of\ persons\ if\ there\ are\ more\ than\ 2\ persons\ to\ "et\ al.".=
+Title\ case=
+Unicode\ to\ LaTeX=
+Units\ to\ LaTeX=
+Upper\ case=
+Does\ nothing.=
 Identity=
-Clears_the_field_completely.=
-Directory_not_found=
-Main_file_directory_not_set\!=Lokasi_berkas_utama_belum_ditentukan\!
-This_operation_requires_exactly_one_item_to_be_selected.=
-Importing_in_%0_format=
-Female_name=
-Female_names=
-Male_name=
-Male_names=
-Mixed_names=
-Neuter_name=
-Neuter_names=
+Clears\ the\ field\ completely.=
+Directory\ not\ found=
+Main\ file\ directory\ not\ set\!=Lokasi berkas utama belum ditentukan!
+This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=
+Importing\ in\ %0\ format=
+Female\ name=
+Female\ names=
+Male\ name=
+Male\ names=
+Mixed\ names=
+Neuter\ name=
+Neuter\ names=
 
-Determined_%0_for_%1_entries=
-Look_up_%0=
-Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3=
+Determined\ %0\ for\ %1\ entries=
+Look\ up\ %0=
+Looking\ up\ %0...\ -\ entry\ %1\ out\ of\ %2\ -\ found\ %3=
 
-Audio_CD=
-British_patent=
-British_patent_request=
-Candidate_thesis=
+Audio\ CD=
+British\ patent=
+British\ patent\ request=
+Candidate\ thesis=
 Collaborator=
 Column=
 Compiler=
 Continuator=
-Data_CD=
+Data\ CD=
 Editor=
-European_patent=
-European_patent_request=
+European\ patent=
+European\ patent\ request=
 Founder=
-French_patent=
-French_patent_request=
-German_patent=
-German_patent_request=
+French\ patent=
+French\ patent\ request=
+German\ patent=
+German\ patent\ request=
 Line=
-Master's_thesis=
+Master's\ thesis=
 Page=
 Paragraph=
 Patent=
-Patent_request=
-PhD_thesis=
+Patent\ request=
+PhD\ thesis=
 Redactor=
-Research_report=
+Research\ report=
 Reviser=
 Section=
 Software=
-Technical_report=
-U.S._patent=
-U.S._patent_request=
+Technical\ report=
+U.S.\ patent=
+U.S.\ patent\ request=
 Verse=
 
-change_entries_of_group=
-odd_number_of_unescaped_'\#'=
+change\ entries\ of\ group=
+odd\ number\ of\ unescaped\ '\#'=
 
-Plain_text=
-Show_diff=
+Plain\ text=
+Show\ diff=
 character=
 word=
-Show_symmetric_diff=
-Copy_Version=
+Show\ symmetric\ diff=
+Copy\ Version=
 Developers=
 Authors=
 License=
 
-HTML_encoded_character_found=
-booktitle_ends_with_'conference_on'=
+HTML\ encoded\ character\ found=
+booktitle\ ends\ with\ 'conference\ on'=
 
-All_external_files=
+All\ external\ files=
 
-OpenOffice/LibreOffice_integration=
+OpenOffice/LibreOffice\ integration=
 
-incorrect_control_digit=
-incorrect_format=
-Copied_version_to_clipboard=
+incorrect\ control\ digit=
+incorrect\ format=
+Copied\ version\ to\ clipboard=
 
-BibTeX_key=
+BibTeX\ key=
 Message=
 
 
-MathSciNet_Review=
-Reset_Bindings=
+MathSciNet\ Review=
+Reset\ Bindings=
 
-Decryption_not_supported.=
+Decryption\ not\ supported.=
 
-Cleared_'%0'_for_%1_entries=
-Set_'%0'_to_'%1'_for_%2_entries=
-Toggled_'%0'_for_%1_entries=
+Cleared\ '%0'\ for\ %1\ entries=
+Set\ '%0'\ to\ '%1'\ for\ %2\ entries=
+Toggled\ '%0'\ for\ %1\ entries=
 
-Check_for_updates=
-Download_update=
-New_version_available=
-Installed_version=
-Remind_me_later=
-Ignore_this_update=
-Could_not_connect_to_the_update_server.=
-Please_try_again_later_and/or_check_your_network_connection.=
-To_see_what_is_new_view_the_changelog.=
-A_new_version_of_JabRef_has_been_released.=
-JabRef_is_up-to-date.=
-Latest_version=
-Online_help_forum=
+Check\ for\ updates=
+Download\ update=
+New\ version\ available=
+Installed\ version=
+Remind\ me\ later=
+Ignore\ this\ update=
+Could\ not\ connect\ to\ the\ update\ server.=
+Please\ try\ again\ later\ and/or\ check\ your\ network\ connection.=
+To\ see\ what\ is\ new\ view\ the\ changelog.=
+A\ new\ version\ of\ JabRef\ has\ been\ released.=
+JabRef\ is\ up-to-date.=
+Latest\ version=
+Online\ help\ forum=
 Custom=
 
-Export_cited=
-Unable_to_generate_new_library=
+Export\ cited=
+Unable\ to\ generate\ new\ library=
 
-Open_console=
-Use_default_terminal_emulator=
-Execute_command=
-Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.=
-Executing_command_\"%0\"...=
-Error_occured_while_executing_the_command_\"%0\".=
-Reformat_ISSN=
+Open\ console=
+Use\ default\ terminal\ emulator=
+Execute\ command=
+Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=
+Executing\ command\ \"%0\"...=
+Error\ occured\ while\ executing\ the\ command\ \"%0\".=
+Reformat\ ISSN=
 
-Countries_and_territories_in_English=
-Electrical_engineering_terms=
+Countries\ and\ territories\ in\ English=
+Electrical\ engineering\ terms=
 Enabled=
-Internal_list=
-Manage_protected_terms_files=
-Months_and_weekdays_in_English=
-The_text_after_the_last_line_starting_with_\#_will_be_used=
-Add_protected_terms_file=
-Are_you_sure_you_want_to_remove_the_protected_terms_file?=
-Remove_protected_terms_file=
-Add_selected_text_to_list=
-Add_{}_around_selected_text=
-Format_field=
-New_protected_terms_file=
-change_field_%0_of_entry_%1_from_%2_to_%3=
-change_key_from_%0_to_%1=
-change_string_content_%0_to_%1=
-change_string_name_%0_to_%1=
-change_type_of_entry_%0_from_%1_to_%2=
-insert_entry_%0=
-insert_string_%0=
-remove_entry_%0=
-remove_string_%0=
+Internal\ list=
+Manage\ protected\ terms\ files=
+Months\ and\ weekdays\ in\ English=
+The\ text\ after\ the\ last\ line\ starting\ with\ \#\ will\ be\ used=
+Add\ protected\ terms\ file=
+Are\ you\ sure\ you\ want\ to\ remove\ the\ protected\ terms\ file?=
+Remove\ protected\ terms\ file=
+Add\ selected\ text\ to\ list=
+Add\ {}\ around\ selected\ text=
+Format\ field=
+New\ protected\ terms\ file=
+change\ field\ %0\ of\ entry\ %1\ from\ %2\ to\ %3=
+change\ key\ from\ %0\ to\ %1=
+change\ string\ content\ %0\ to\ %1=
+change\ string\ name\ %0\ to\ %1=
+change\ type\ of\ entry\ %0\ from\ %1\ to\ %2=
+insert\ entry\ %0=
+insert\ string\ %0=
+remove\ entry\ %0=
+remove\ string\ %0=
 undefined=
-Cannot_get_info_based_on_given_%0\:_%1=Tidak_bisa_mendapatkan_informasi_berdasar_%0\:_%1
-Get_BibTeX_data_from_%0=Dapatkan_data_BibTeX_dari_%0
-No_%0_found=
-Entry_from_%0=Entri_dari_%0
-Merge_entry_with_%0_information=Gabung_entri_dengan_informasi_%0
-Updated_entry_with_info_from_%0=Entri_diperbarui_dengan_informasi_dari_%0
+Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=Tidak bisa mendapatkan informasi berdasar %0: %1
+Get\ BibTeX\ data\ from\ %0=Dapatkan data BibTeX dari %0
+No\ %0\ found=
+Entry\ from\ %0=Entri dari %0
+Merge\ entry\ with\ %0\ information=Gabung entri dengan informasi %0
+Updated\ entry\ with\ info\ from\ %0=Entri diperbarui dengan informasi dari %0
 
-Add_existing_file=
-Create_new_list=
-Remove_list=
-Full_journal_name=
-Abbreviation_name=
+Add\ existing\ file=
+Create\ new\ list=
+Remove\ list=
+Full\ journal\ name=
+Abbreviation\ name=
 
-No_abbreviation_files_loaded=
+No\ abbreviation\ files\ loaded=
 
-Loading_built_in_lists=
+Loading\ built\ in\ lists=
 
-JabRef_built_in_list=
-IEEE_built_in_list=
+JabRef\ built\ in\ list=
+IEEE\ built\ in\ list=
 
-Event_log=
-We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.=
-Log_copied_to_clipboard.=
-Copy_Log=
-Clear_Log=
-Report_Issue=
-Issue_on_GitHub_successfully_reported.=
-Issue_report_successful=
-Your_issue_was_reported_in_your_browser.=
-The_log_and_exception_information_was_copied_to_your_clipboard.=
-Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.=
+Event\ log=
+We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef\'s\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=
+Log\ copied\ to\ clipboard.=
+Copy\ Log=
+Clear\ Log=
+Report\ Issue=
+Issue\ on\ GitHub\ successfully\ reported.=
+Issue\ report\ successful=
+Your\ issue\ was\ reported\ in\ your\ browser.=
+The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=
+Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=
 
 Connection=
 Connecting...=
@@ -2164,194 +2164,194 @@ Port=
 Library=
 User=
 Connect=Menghubungi
-Connection_error=
-Connection_to_%0_server_established.=
-Required_field_"%0"_is_empty.=
-%0_driver_not_available.=
-The_connection_to_the_server_has_been_terminated.=
-Connection_lost.=
+Connection\ error=
+Connection\ to\ %0\ server\ established.=
+Required\ field\ "%0"\ is\ empty.=
+%0\ driver\ not\ available.=
+The\ connection\ to\ the\ server\ has\ been\ terminated.=
+Connection\ lost.=
 Reconnect=
-Work_offline=
-Working_offline.=
-Update_refused.=
-Update_refused=
-Local_entry=
-Shared_entry=
-Update_could_not_be_performed_due_to_existing_change_conflicts.=
-You_are_not_working_on_the_newest_version_of_BibEntry.=
-Local_version\:_%0=
-Shared_version\:_%0=
-Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.=
-Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?=
-Shared_entry_is_no_longer_present=
-The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.=
-You_can_restore_the_entry_using_the_"Undo"_operation.=
-Remember_password?=
-You_are_already_connected_to_a_database_using_entered_connection_details.=
+Work\ offline=
+Working\ offline.=
+Update\ refused.=
+Update\ refused=
+Local\ entry=
+Shared\ entry=
+Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=
+You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=
+Local\ version\:\ %0=
+Shared\ version\:\ %0=
+Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=
+Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=
+Shared\ entry\ is\ no\ longer\ present=
+The\ BibEntry\ you\ currently\ work\ on\ has\ been\ deleted\ on\ the\ shared\ side.=
+You\ can\ restore\ the\ entry\ using\ the\ "Undo"\ operation.=
+Remember\ password?=
+You\ are\ already\ connected\ to\ a\ database\ using\ entered\ connection\ details.=
 
-Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?=
-New_technical_report=
+Cannot\ cite\ entries\ without\ BibTeX\ keys.\ Generate\ keys\ now?=
+New\ technical\ report=
 
-%0_file=
-Custom_layout_file=
-Protected_terms_file=
-Style_file=
+%0\ file=
+Custom\ layout\ file=
+Protected\ terms\ file=
+Style\ file=
 
-Open_OpenOffice/LibreOffice_connection=
-You_must_enter_at_least_one_field_name=
-Non-ASCII_encoded_character_found=
-Toggle_web_search_interface=
-Background_color_for_resolved_fields=
-Color_code_for_resolved_fields=
-%0_files_found=
-%0_of_%1=
-One_file_found=
-The_import_finished_with_warnings\:=
-There_was_one_file_that_could_not_be_imported.=
-There_were_%0_files_which_could_not_be_imported.=
+Open\ OpenOffice/LibreOffice\ connection=
+You\ must\ enter\ at\ least\ one\ field\ name=
+Non-ASCII\ encoded\ character\ found=
+Toggle\ web\ search\ interface=
+Background\ color\ for\ resolved\ fields=
+Color\ code\ for\ resolved\ fields=
+%0\ files\ found=
+%0\ of\ %1=
+One\ file\ found=
+The\ import\ finished\ with\ warnings\:=
+There\ was\ one\ file\ that\ could\ not\ be\ imported.=
+There\ were\ %0\ files\ which\ could\ not\ be\ imported.=
 
-Migration_help_information=
-Entered_database_has_obsolete_structure_and_is_no_longer_supported.=
-However,_a_new_database_was_created_alongside_the_pre-3.6_one.=
-Click_here_to_learn_about_the_migration_of_pre-3.6_databases.=
-Opens_JabRef's_Facebook_page=
-Opens_JabRef's_blog=
-Opens_JabRef's_website=
-Opens_a_link_where_the_current_development_version_can_be_downloaded=
-See_what_has_been_changed_in_the_JabRef_versions=
-Referenced_BibTeX_key_does_not_exist=
-Finished_downloading_full_text_document_for_entry_%0.=
-Full_text_document_download_failed_for_entry_%0.=
-Look_up_full_text_documents=
-You_are_about_to_look_up_full_text_documents_for_%0_entries.=
-last_four_nonpunctuation_characters_should_be_numerals=
+Migration\ help\ information=
+Entered\ database\ has\ obsolete\ structure\ and\ is\ no\ longer\ supported.=
+However,\ a\ new\ database\ was\ created\ alongside\ the\ pre-3.6\ one.=
+Click\ here\ to\ learn\ about\ the\ migration\ of\ pre-3.6\ databases.=
+Opens\ JabRef's\ Facebook\ page=
+Opens\ JabRef's\ blog=
+Opens\ JabRef's\ website=
+Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=
+See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=
+Referenced\ BibTeX\ key\ does\ not\ exist=
+Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=
+Full\ text\ document\ download\ failed\ for\ entry\ %0.=
+Look\ up\ full\ text\ documents=
+You\ are\ about\ to\ look\ up\ full\ text\ documents\ for\ %0\ entries.=
+last\ four\ nonpunctuation\ characters\ should\ be\ numerals=
 
 Author=
 Date=
-File_annotations=
-Show_file_annotations=
-Adobe_Acrobat_Reader=
-Sumatra_Reader=
+File\ annotations=
+Show\ file\ annotations=
+Adobe\ Acrobat\ Reader=
+Sumatra\ Reader=
 shared=
-should_contain_an_integer_or_a_literal=
-should_have_the_first_letter_capitalized=
+should\ contain\ an\ integer\ or\ a\ literal=
+should\ have\ the\ first\ letter\ capitalized=
 Tools=
-What\'s_new_in_this_version?=
-Want_to_help?=
-Make_a_donation=
-get_involved=
-Used_libraries=
-Existing_file=Berkas_yang_ada
+What\'s\ new\ in\ this\ version?=
+Want\ to\ help?=
+Make\ a\ donation=
+get\ involved=
+Used\ libraries=
+Existing\ file=Berkas yang ada
 
 ID=
-ID_type=
-ID-based_entry_generator=
-Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+ID\ type=
+ID-based\ entry\ generator=
+Fetcher\ '%0'\ did\ not\ find\ an\ entry\ for\ id\ '%1'.=
 
-Select_first_entry=
-Select_last_entry=
+Select\ first\ entry=
+Select\ last\ entry=
 
-Invalid_ISBN\:_'%0'.=
-should_be_an_integer_or_normalized=
-should_be_normalized=
+Invalid\ ISBN\:\ '%0'.=
+should\ be\ an\ integer\ or\ normalized=
+should\ be\ normalized=
 
-Empty_search_ID=
-The_given_search_ID_was_empty.=
-Copy_BibTeX_key_and_link=
-empty_BibTeX_key=
-biblatex_field_only=
+Empty\ search\ ID=
+The\ given\ search\ ID\ was\ empty.=
+Copy\ BibTeX\ key\ and\ link=
+empty\ BibTeX\ key=
+biblatex\ field\ only=
 
-Error_while_generating_fetch_URL=
-Error_while_parsing_ID_list=
-Unable_to_get_PubMed_IDs=
-Backup_found=
-A_backup_file_for_'%0'_was_found.=
-This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.=
-Do_you_want_to_recover_the_library_from_the_backup_file?=
-Firstname_Lastname=
+Error\ while\ generating\ fetch\ URL=
+Error\ while\ parsing\ ID\ list=
+Unable\ to\ get\ PubMed\ IDs=
+Backup\ found=
+A\ backup\ file\ for\ '%0'\ was\ found.=
+This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=
+Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=
+Firstname\ Lastname=
 
-Recommended_for_%0=
-Show_'Related_Articles'_tab=
-This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
+Recommended\ for\ %0=
+Show\ 'Related\ Articles'\ tab=
+This\ might\ be\ caused\ by\ reaching\ the\ traffic\ limitation\ of\ Google\ Scholar\ (see\ 'Help'\ for\ details).=
 
-Could_not_open_website.=
-Problem_downloading_from_%1=
+Could\ not\ open\ website.=
+Problem\ downloading\ from\ %1=
 
-File_directory_pattern=
-Update_with_bibliographic_information_from_the_web=
+File\ directory\ pattern=
+Update\ with\ bibliographic\ information\ from\ the\ web=
 
-Could_not_find_any_bibliographic_information.=
-BibTeX_key_deviates_from_generated_key=
-DOI_%0_is_invalid=
+Could\ not\ find\ any\ bibliographic\ information.=
+BibTeX\ key\ deviates\ from\ generated\ key=
+DOI\ %0\ is\ invalid=
 
-Select_all_customized_types_to_be_stored_in_local_preferences=
-Currently_unknown=
-Different_customization,_current_settings_will_be_overwritten=
+Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences=
+Currently\ unknown=
+Different\ customization,\ current\ settings\ will\ be\ overwritten=
 
-Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX=
-Jump_to_entry=
+Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=
+Jump\ to\ entry=
 
-Copied_%0_citations.=
+Copied\ %0\ citations.=
 Copying...=
 
-journal_not_found_in_abbreviation_list=
-Unhandled_exception_occurred.=
+journal\ not\ found\ in\ abbreviation\ list=
+Unhandled\ exception\ occurred.=
 
-strings_included=
-Color_for_disabled_icons=
-Color_for_enabled_icons=
-Size_of_large_icons=
-Size_of_small_icons=
-Default_table_font_size=
-Escape_underscores=
+strings\ included=
+Color\ for\ disabled\ icons=
+Color\ for\ enabled\ icons=
+Size\ of\ large\ icons=
+Size\ of\ small\ icons=
+Default\ table\ font\ size=
+Escape\ underscores=
 Color=
-Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=
-Fit_width=
-Fit_a_single_page=
-Zoom_in=
-Zoom_out=
-Previous_page=
-Next_page=
-Document_viewer=
+Please\ also\ add\ all\ steps\ to\ reproduce\ this\ issue,\ if\ possible.=
+Fit\ width=
+Fit\ a\ single\ page=
+Zoom\ in=
+Zoom\ out=
+Previous\ page=
+Next\ page=
+Document\ viewer=
 Live=
 Locked=
-Show_document_viewer=
-Show_the_document_of_the_currently_selected_entry.=
-Show_this_document_until_unlocked.=
-Set_current_user_name_as_owner.=
+Show\ document\ viewer=
+Show\ the\ document\ of\ the\ currently\ selected\ entry.=
+Show\ this\ document\ until\ unlocked.=
+Set\ current\ user\ name\ as\ owner.=
 
-Sort_all_subgroups_(recursively)=
-Collect_and_share_telemetry_data_to_help_improve_JabRef.=
-Don't_share=
-Share_anonymous_statistics=
-Telemetry\:_Help_make_JabRef_better=
-To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.=
-This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?=
-Names_are_not_in_the_standard_%0_format.=
+Sort\ all\ subgroups\ (recursively)=
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=
+Don't\ share=
+Share\ anonymous\ statistics=
+Telemetry\:\ Help\ make\ JabRef\ better=
+To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ statistics\ on\ the\ features\ you\ use.\ We\ will\ only\ record\ what\ features\ you\ access\ and\ how\ often\ you\ do\ it.\ We\ will\ neither\ collect\ any\ personal\ data\ nor\ the\ content\ of\ bibliographic\ items.\ If\ you\ choose\ to\ allow\ data\ collection,\ you\ can\ later\ disable\ it\ via\ Options\ ->\ Preferences\ ->\ General.=
+This\ file\ was\ found\ automatically.\ Do\ you\ want\ to\ link\ it\ to\ this\ entry?=
+Names\ are\ not\ in\ the\ standard\ %0\ format.=
 
-Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.=
-Delete_'%0'=
-Delete_from_disk=
-Remove_from_entry=
-The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.=
-There_exists_already_a_group_with_the_same_name.=
+Delete\ the\ selected\ file\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ file\ permanently\ from\ disk.=
+Delete\ '%0'=
+Delete\ from\ disk=
+Remove\ from\ entry=
+The\ group\ name\ contains\ the\ keyword\ separator\ "%0"\ and\ thus\ probably\ does\ not\ work\ as\ expected.=
+There\ exists\ already\ a\ group\ with\ the\ same\ name.=
 
-Copy_linked_files_to_folder...=
-Copied_file_successfully=
-Copying_files...=
-Copying_file_%0_of_entry_%1=
-Finished_copying=
-Could_not_copy_file=
-Copied_%0_files_of_%1_sucessfully_to_%2=
-Rename_failed=
-JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.=
-Show_console_output_(only_necessary_when_the_launcher_is_used)=
+Copy\ linked\ files\ to\ folder...=
+Copied\ file\ successfully=
+Copying\ files...=
+Copying\ file\ %0\ of\ entry\ %1=
+Finished\ copying=
+Could\ not\ copy\ file=
+Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=
+Rename\ failed=
+JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=
+Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=
 
-Remove_line_breaks=
-Removes_all_line_breaks_in_the_field_content.=
-Checking_integrity...=
+Remove\ line\ breaks=
+Removes\ all\ line\ breaks\ in\ the\ field\ content.=
+Checking\ integrity...=
 
-Remove_hyphenated_line_breaks=
-Removes_all_hyphenated_line_breaks_in_the_field_content.=
-Note_that_currently,_JabRef_does_not_run_with_Java_9.=
-Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.=
+Remove\ hyphenated\ line\ breaks=
+Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=
+Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=
+Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -1,8 +1,3 @@
-
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 mengandung Ekspresi Reguler <b>%1</b>
 
 %0\ contains\ the\ term\ <b>%1</b>=% mengandung istilah <b>%1</b>

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -3,156 +3,156 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-%0_contains_the_regular_expression_<b>%1</b>=%0_contiene_l'espressione_regolare_<b>%1</b>
+%0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 contiene l'espressione regolare <b>%1</b>
 
-%0_contains_the_term_<b>%1</b>=%0_contiene_il_termine_<b>%1</b>
+%0\ contains\ the\ term\ <b>%1</b>=%0 contiene il termine <b>%1</b>
 
-%0_doesn't_contain_the_regular_expression_<b>%1</b>=%0_non_contiene_l'espressione_regolare_<b>%1</b>
+%0\ doesn't\ contain\ the\ regular\ expression\ <b>%1</b>=%0 non contiene l'espressione regolare <b>%1</b>
 
-%0_doesn't_contain_the_term_<b>%1</b>=%0_non_contiene_il_termine_<b>%1</b>
+%0\ doesn't\ contain\ the\ term\ <b>%1</b>=%0 non contiene il termine <b>%1</b>
 
-%0_export_successful=%0_esportazioni_riuscite
+%0\ export\ successful=%0 esportazioni riuscite
 
-%0_matches_the_regular_expression_<b>%1</b>=%0_corrisponde_all'espressione_regolare_<b>%1</b>
+%0\ matches\ the\ regular\ expression\ <b>%1</b>=%0 corrisponde all'espressione regolare <b>%1</b>
 
-%0_matches_the_term_<b>%1</b>=%0_corrisponde_al_termine_<b>%1</b>
+%0\ matches\ the\ term\ <b>%1</b>=%0 corrisponde al termine <b>%1</b>
 
-<field_name>=<nome_del_campo>
-<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>=<HTML>Non_è_stato_trovato_il_file_'%0'_<BR>collegato_alla_voce_'%1'</HTML>
+<field\ name>=<nome del campo>
+<HTML>Could\ not\ find\ file\ '%0'<BR>linked\ from\ entry\ '%1'</HTML>=<HTML>Non è stato trovato il file '%0' <BR>collegato alla voce '%1'</HTML>
 
 <select>=<seleziona>
 
-<select_word>=<select_word>
-Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)=Abbrevia_i_nomi_dei_giornali_delle_voci_selezionate_(abbreviazioni_ISO)
-Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)=Abbrevia_i_nomi_dei_giornali_delle_voci_selezionate_(abbreviazioni_MEDLINE)
+<select\ word>=<select word>
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (ISO\ abbreviation)=Abbrevia i nomi dei giornali delle voci selezionate (abbreviazioni ISO)
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (MEDLINE\ abbreviation)=Abbrevia i nomi dei giornali delle voci selezionate (abbreviazioni MEDLINE)
 
-Abbreviate_names=Abbrevia_i_nomi
-Abbreviated_%0_journal_names.=%0_nomi_di_riviste_abbreviati.
+Abbreviate\ names=Abbrevia i nomi
+Abbreviated\ %0\ journal\ names.=%0 nomi di riviste abbreviati.
 
 Abbreviation=Abbreviazione
 
-About_JabRef=Informazioni_su_JabRef
+About\ JabRef=Informazioni su JabRef
 
 Abstract=Sommario
 
 Accept=Accetta
 
-Accept_change=Accetta_la_modifica
+Accept\ change=Accetta la modifica
 
 Action=Azione
 
-What_is_Mr._DLib?=Cos'è_Mr._Dlib?
+What\ is\ Mr.\ DLib?=Cos'è Mr. Dlib?
 
 Add=Aggiungi
 
-Add_a_(compiled)_custom_Importer_class_from_a_class_path.=Aggiungi_una_classe_Importer_personalizzata_(compilata)_da_un_percorso.
-The_path_need_not_be_on_the_classpath_of_JabRef.=Il_percorso_non_deve_necessariamente_essere_nel_classpath_di_JabRef.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=Aggiungi una classe Importer personalizzata (compilata) da un percorso.
+The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=Il percorso non deve necessariamente essere nel classpath di JabRef.
 
-Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=Aggiungi_una_classe_Importer_personalizzata_(compilata)_da_un_archivio_ZIP.
-The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=L'archivio_ZIP_non_deve_necessariamente_essere_nel_classpath_di_JabRef.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=Aggiungi una classe Importer personalizzata (compilata) da un archivio ZIP.
+The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=L'archivio ZIP non deve necessariamente essere nel classpath di JabRef.
 
-Add_a_regular_expression_for_the_key_pattern.=Aggiungi_una_espressione_regolare_per_il_modello_di_chiave.
+Add\ a\ regular\ expression\ for\ the\ key\ pattern.=Aggiungi una espressione regolare per il modello di chiave.
 
-Add_selected_entries_to_this_group=Aggiungi_le_voci_selezionate_a_questo_gruppo
+Add\ selected\ entries\ to\ this\ group=Aggiungi le voci selezionate a questo gruppo
 
-Add_from_folder=Aggiungi_da_una_cartella
+Add\ from\ folder=Aggiungi da una cartella
 
-Add_from_JAR=Aggiungi_da_un_file_JAR
+Add\ from\ JAR=Aggiungi da un file JAR
 
-add_group=aggiungi_un_gruppo
+add\ group=aggiungi un gruppo
 
-Add_new=Aggiungi_nuovo
+Add\ new=Aggiungi nuovo
 
-Add_subgroup=Aggiungi_un_sottogruppo
+Add\ subgroup=Aggiungi un sottogruppo
 
-Add_to_group=Aggiungi_al_gruppo
+Add\ to\ group=Aggiungi al gruppo
 
-Added_group_"%0".=Aggiunto_gruppo_"%0".
+Added\ group\ "%0".=Aggiunto gruppo "%0".
 
-Added_missing_braces.=
+Added\ missing\ braces.=
 
-Added_new=Aggiunto_nuovo
+Added\ new=Aggiunto nuovo
 
-Added_string=Aggiunta_stringa
+Added\ string=Aggiunta stringa
 
-Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.=Inoltre,_le_voci_il_cui_campo_<b>%0</b>_non_contiene_<b>%1</b>_possono_essere_assegnate_manualmente_a_questo_gruppo_selezionandole_e_utilizzando_il_menu_contestuale_o_il_"drag-and-drop"._Questo_processo_aggiunge_il_termine_<b>%1</b>_al_campo_<b>%0</b>_di_ciascuna_voce._Le_voci_possono_essere_rimosse_manualmente_da_questo_gruppo_selezionandole_e_utilizzando_il_menu_contestuale._Questo_processo_elimina_il_termine__<b>%1</b>_dal_campo_<b>%0</b>_di_ciascuna_voce.
+Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ can\ be\ assigned\ manually\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ This\ process\ adds\ the\ term\ <b>%1</b>\ to\ each\ entry's\ <b>%0</b>\ field.\ Entries\ can\ be\ removed\ manually\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.\ This\ process\ removes\ the\ term\ <b>%1</b>\ from\ each\ entry's\ <b>%0</b>\ field.=Inoltre, le voci il cui campo <b>%0</b> non contiene <b>%1</b> possono essere assegnate manualmente a questo gruppo selezionandole e utilizzando il menu contestuale o il "drag-and-drop". Questo processo aggiunge il termine <b>%1</b> al campo <b>%0</b> di ciascuna voce. Le voci possono essere rimosse manualmente da questo gruppo selezionandole e utilizzando il menu contestuale. Questo processo elimina il termine  <b>%1</b> dal campo <b>%0</b> di ciascuna voce.
 
 Advanced=Avanzate
-All_entries=Tutte_le_voci
-All_entries_of_this_type_will_be_declared_typeless._Continue?=Tutte_le_voci_di_questo_tipo_saranno_definite_'senza_tipo'._Continuare?
+All\ entries=Tutte le voci
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=Tutte le voci di questo tipo saranno definite 'senza tipo'. Continuare?
 
-All_fields=Tutti_i_campi
+All\ fields=Tutti i campi
 
-Always_reformat_BIB_file_on_save_and_export=Riformatta_sempre_il_file_BIB_quando_salvi_o_esporti
+Always\ reformat\ BIB\ file\ on\ save\ and\ export=Riformatta sempre il file BIB quando salvi o esporti
 
-A_SAX_exception_occurred_while_parsing_'%0'\:=Eccezione_SAX_durante_l'analisi_di_'%0'\:
+A\ SAX\ exception\ occurred\ while\ parsing\ '%0'\:=Eccezione SAX durante l'analisi di '%0':
 
 and=e
-and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.=e_la_classe_deve_essere_nel_tuo_"classpath"_al_successivo_avvio_di_JabRef.
+and\ the\ class\ must\ be\ available\ in\ your\ classpath\ next\ time\ you\ start\ JabRef.=e la classe deve essere nel tuo "classpath" al successivo avvio di JabRef.
 
-any_field_that_matches_the_regular_expression_<b>%0</b>=qualsiasi_campo_che_corrisponda_all'espressione_regolare_<b>%0</b>
+any\ field\ that\ matches\ the\ regular\ expression\ <b>%0</b>=qualsiasi campo che corrisponda all'espressione regolare <b>%0</b>
 
 Appearance=Aspetto
 
 Append=Accoda
-Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library=Accoda_il_contenuto_di_una_libreria_BibTeX_alla_libreria_corrente
+Append\ contents\ from\ a\ BibTeX\ library\ into\ the\ currently\ viewed\ library=Accoda il contenuto di una libreria BibTeX alla libreria corrente
 
-Append_library=Accoda_libreria
+Append\ library=Accoda libreria
 
-Append_the_selected_text_to_BibTeX_field=Accoda_il_testo_selezionato_alla_chiave_BibTeX
+Append\ the\ selected\ text\ to\ BibTeX\ field=Accoda il testo selezionato alla chiave BibTeX
 Application=Applicazione
 
 Apply=Applica
 
-Arguments_passed_on_to_running_JabRef_instance._Shutting_down.=Argomenti_passati_all'istanza_attiva_di_JabRef._Chiusura_in_corso.
+Arguments\ passed\ on\ to\ running\ JabRef\ instance.\ Shutting\ down.=Argomenti passati all'istanza attiva di JabRef. Chiusura in corso.
 
-Assign_new_file=Assegna_un_nuovo_file
+Assign\ new\ file=Assegna un nuovo file
 
-Assign_the_original_group's_entries_to_this_group?=Assegnare_le_voci_originali_del_gruppo_a_questo_gruppo?
+Assign\ the\ original\ group's\ entries\ to\ this\ group?=Assegnare le voci originali del gruppo a questo gruppo?
 
-Assigned_%0_entries_to_group_"%1".=Assegnate_%0_voci_al_gruppo_"%1".
+Assigned\ %0\ entries\ to\ group\ "%1".=Assegnate %0 voci al gruppo "%1".
 
-Assigned_1_entry_to_group_"%0".=Una_voce_assegnata_al_gruppo_"%0".
+Assigned\ 1\ entry\ to\ group\ "%0".=Una voce assegnata al gruppo "%0".
 
-Attach_URL=Allega_URL
+Attach\ URL=Allega URL
 
-Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.=Tentativo_di_definire_automaticamente_collegamenti_a_file_per_le_tue_voci._La_definizione_avviene_automaticamente_se_un_file_nella_cartella_file_o_sottocartella<BR>ha_lo_stesso_nome_della_chiave_di_una_voce_BibTeX,_a_meno_dell'estensione.
+Attempt\ to\ automatically\ set\ file\ links\ for\ your\ entries.\ Automatically\ setting\ works\ if\ a\ file\ in\ your\ file\ directory<BR>or\ a\ subdirectory\ is\ named\ identically\ to\ an\ entry's\ BibTeX\ key,\ plus\ extension.=Tentativo di definire automaticamente collegamenti a file per le tue voci. La definizione avviene automaticamente se un file nella cartella file o sottocartella<BR>ha lo stesso nome della chiave di una voce BibTeX, a meno dell'estensione.
 
-Autodetect_format=Rivelamento_automatico_del_formato
+Autodetect\ format=Rivelamento automatico del formato
 
-Autogenerate_BibTeX_keys=Generazione_automatica_delle_chiavi_BibTeX
+Autogenerate\ BibTeX\ keys=Generazione automatica delle chiavi BibTeX
 
-Autolink_files_with_names_starting_with_the_BibTeX_key=Collegare_automaticamente_i_file_con_nomi_che_iniziano_con_la_chiave_BibTeX
+Autolink\ files\ with\ names\ starting\ with\ the\ BibTeX\ key=Collegare automaticamente i file con nomi che iniziano con la chiave BibTeX
 
-Autolink_only_files_that_match_the_BibTeX_key=Collegare_automaticamente_solo_i_file_con_nome_corrispondente_alla_chiave_BibTeX
+Autolink\ only\ files\ that\ match\ the\ BibTeX\ key=Collegare automaticamente solo i file con nome corrispondente alla chiave BibTeX
 
-Automatically_create_groups=Crea_automaticamente_i_gruppi
+Automatically\ create\ groups=Crea automaticamente i gruppi
 
-Automatically_remove_exact_duplicates=Rimuovi_automaticamente_i_duplicati_esatti
+Automatically\ remove\ exact\ duplicates=Rimuovi automaticamente i duplicati esatti
 
-Allow_overwriting_existing_links.=Consenti_la_sovrascrittura_dei_collegamenti_esistenti.
+Allow\ overwriting\ existing\ links.=Consenti la sovrascrittura dei collegamenti esistenti.
 
-Do_not_overwrite_existing_links.=Non_consentire_la_sovrascrittura_dei_collegamenti_esistenti.
+Do\ not\ overwrite\ existing\ links.=Non consentire la sovrascrittura dei collegamenti esistenti.
 
-AUX_file_import=Importa_file_AUX
+AUX\ file\ import=Importa file AUX
 
-Available_export_formats=Formati_di_esportazione_disponibili
+Available\ export\ formats=Formati di esportazione disponibili
 
-Available_BibTeX_fields=Campi_BibTeX_disponibili
+Available\ BibTeX\ fields=Campi BibTeX disponibili
 
-Available_import_formats=Formati_di_importazione_disponibili
+Available\ import\ formats=Formati di importazione disponibili
 
-Background_color_for_optional_fields=Colore_di_sfondo_per_i_campi_facoltativi
+Background\ color\ for\ optional\ fields=Colore di sfondo per i campi facoltativi
 
-Background_color_for_required_fields=Colore_di_sfondo_per_i_campi_obbligatori
+Background\ color\ for\ required\ fields=Colore di sfondo per i campi obbligatori
 
-Backup_old_file_when_saving=Fai_una_copia_di_backup_del_vecchio_file_quando_viene_salvato
+Backup\ old\ file\ when\ saving=Fai una copia di backup del vecchio file quando viene salvato
 
-BibTeX_key_is_unique.=La_chiave_BibTeX_è_unica.
+BibTeX\ key\ is\ unique.=La chiave BibTeX è unica.
 
-%0_source=Sorgente_%0
+%0\ source=Sorgente %0
 
-Broken_link=Collegamento_interrotto
+Broken\ link=Collegamento interrotto
 
 Browse=Sfoglia
 
@@ -160,321 +160,321 @@ by=da
 
 Cancel=Annulla
 
-Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?=Le_voci_non_possono_essere_inserite_in_un_gruppo_se_prive_di_chiave._Generare_le_chiavi_ora?
+Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=Le voci non possono essere inserite in un gruppo se prive di chiave. Generare le chiavi ora?
 
-Cannot_merge_this_change=Questa_modifica_non__può_essere_incorporata
+Cannot\ merge\ this\ change=Questa modifica non  può essere incorporata
 
-case_insensitive=non_distingue_maiuscole_e_minuscole
+case\ insensitive=non distingue maiuscole e minuscole
 
-case_sensitive=distingue_maiuscole_e_minuscole
+case\ sensitive=distingue maiuscole e minuscole
 
-Case_sensitive=Distingue_maiuscole_e_minuscole
+Case\ sensitive=Distingue maiuscole e minuscole
 
-change_assignment_of_entries=modifica_l'assegnazione_delle_voci
+change\ assignment\ of\ entries=modifica l'assegnazione delle voci
 
-Change_case=Inverti_maiuscolo/minuscolo
+Change\ case=Inverti maiuscolo/minuscolo
 
-Change_entry_type=Cambia_tipo_di_voce
-Change_file_type=Cambia_il_tipo_di_file
+Change\ entry\ type=Cambia tipo di voce
+Change\ file\ type=Cambia il tipo di file
 
 
-Change_of_Grouping_Method=Cambia_Metodo_di_Raggruppamento
+Change\ of\ Grouping\ Method=Cambia Metodo di Raggruppamento
 
-change_preamble=modifica_il_preambolo
+change\ preamble=modifica il preambolo
 
-Change_table_column_and_General_fields_settings_to_use_the_new_feature=Modifica_le_colonne_della_tabella_e_le_impostazioni_dei_campi_generali_per_utilizzare_la_nuova_funzione
+Change\ table\ column\ and\ General\ fields\ settings\ to\ use\ the\ new\ feature=Modifica le colonne della tabella e le impostazioni dei campi generali per utilizzare la nuova funzione
 
-Changed_language_settings=Parametri_della_lingua_modificati
+Changed\ language\ settings=Parametri della lingua modificati
 
-Changed_preamble=Preambolo_modificato
+Changed\ preamble=Preambolo modificato
 
-Check_existing_file_links=Verificare_i_collegamenti_a_file_esistenti
+Check\ existing\ file\ links=Verificare i collegamenti a file esistenti
 
-Check_links=Verifica_i_collegamenti
+Check\ links=Verifica i collegamenti
 
-Cite_command=Comando_Cite
+Cite\ command=Comando Cite
 
-Class_name=Nome_della_classe
+Class\ name=Nome della classe
 
 Clear=Svuota
 
-Clear_fields=Annulla_i_campi
+Clear\ fields=Annulla i campi
 
 Close=Chiudi
-Close_others=Chiudi_gli_altri
-Close_all=Chiudi_tutti
+Close\ others=Chiudi gli altri
+Close\ all=Chiudi tutti
 
-Close_dialog=Chiudi_la_finestra_di_dialogo
+Close\ dialog=Chiudi la finestra di dialogo
 
-Close_the_current_library=Chiudi_la_libreria_corrente
+Close\ the\ current\ library=Chiudi la libreria corrente
 
-Close_window=Chiudi_la_finestra
+Close\ window=Chiudi la finestra
 
-Closed_library=Libreria_chiusa
+Closed\ library=Libreria chiusa
 
-Color_codes_for_required_and_optional_fields=Codifica_a_colori_per_campi_obbligatori_e_opzionali
+Color\ codes\ for\ required\ and\ optional\ fields=Codifica a colori per campi obbligatori e opzionali
 
-Color_for_marking_incomplete_entries=Colore_per_contrassegnare_voci_incomplete
+Color\ for\ marking\ incomplete\ entries=Colore per contrassegnare voci incomplete
 
-Column_width=Larghezza_della_colonna
+Column\ width=Larghezza della colonna
 
-Command_line_id=Identificativo_della_riga_di_comando
+Command\ line\ id=Identificativo della riga di comando
 
 
-Contained_in=Contenuto_in
+Contained\ in=Contenuto in
 
 Content=Contenuto
 
 Copied=Copiato
 
-Copied_cell_contents=Contenuto_delle_celle_copiato
+Copied\ cell\ contents=Contenuto delle celle copiato
 
-Copied_title=Titolo_copiato
+Copied\ title=Titolo copiato
 
-Copied_key=Chiave_BibTeX_copiata
+Copied\ key=Chiave BibTeX copiata
 
-Copied_titles=Titoli_copiati
+Copied\ titles=Titoli copiati
 
-Copied_keys=Chiavi_BibTeX_copiate
+Copied\ keys=Chiavi BibTeX copiate
 
 Copy=Copia
 
-Copy_BibTeX_key=Copia_chiave_BibTeX
-Copy_file_to_file_directory=Copia_il_file_nella_cartella_dei_file
+Copy\ BibTeX\ key=Copia chiave BibTeX
+Copy\ file\ to\ file\ directory=Copia il file nella cartella dei file
 
-Copy_to_clipboard=Copia_negli_appunti
+Copy\ to\ clipboard=Copia negli appunti
 
-Could_not_call_executable=Non_è_possibile_effetuare_la_chiamata_dell'eseguibile
-Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.=Impossibile_stabilire_la_connessione_al_server_Vim.<BR>Assicurarsi_che_Vim_sia_in_esecuzione_con_il_nome_di_server_corretto.
+Could\ not\ call\ executable=Non è possibile effetuare la chiamata dell'eseguibile
+Could\ not\ connect\ to\ Vim\ server.\ Make\ sure\ that\ Vim\ is\ running<BR>with\ correct\ server\ name.=Impossibile stabilire la connessione al server Vim.<BR>Assicurarsi che Vim sia in esecuzione con il nome di server corretto.
 
-Could_not_export_file=Impossibile_esportare_il_file
+Could\ not\ export\ file=Impossibile esportare il file
 
-Could_not_export_preferences=Impossibile_esportare_le_preferenze
+Could\ not\ export\ preferences=Impossibile esportare le preferenze
 
-Could_not_find_a_suitable_import_format.=Impossibile_trovare_un_formato_di_importazione_adeguato
-Could_not_import_preferences=Impossibile_importare_le_preferenze
+Could\ not\ find\ a\ suitable\ import\ format.=Impossibile trovare un formato di importazione adeguato
+Could\ not\ import\ preferences=Impossibile importare le preferenze
 
-Could_not_instantiate_%0=Impossibile_istanziare_%0
-Could_not_instantiate_%0_%1=Impossibile_istanziare_%0_%1
-Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?=Impossibile_istanziare_%0._Verificare_il_"package_path".
-Could_not_open_link=Impossibile_aprire_il_collegamento
+Could\ not\ instantiate\ %0=Impossibile istanziare %0
+Could\ not\ instantiate\ %0\ %1=Impossibile istanziare %0 %1
+Could\ not\ instantiate\ %0.\ Have\ you\ chosen\ the\ correct\ package\ path?=Impossibile istanziare %0. Verificare il "package path".
+Could\ not\ open\ link=Impossibile aprire il collegamento
 
-Could_not_print_preview=Impossibile_visualizzare_l'anteprima_di_stampa
+Could\ not\ print\ preview=Impossibile visualizzare l'anteprima di stampa
 
-Could_not_run_the_'vim'_program.=Impossibile_eseguire_il_programma_'vim'.
+Could\ not\ run\ the\ 'vim'\ program.=Impossibile eseguire il programma 'vim'.
 
-Could_not_save_file.=Impossibile_salvare_il_file.
-Character_encoding_'%0'_is_not_supported.=La_codifica_dei_caratteri_'%0'_non_è_supportata.
+Could\ not\ save\ file.=Impossibile salvare il file.
+Character\ encoding\ '%0'\ is\ not\ supported.=La codifica dei caratteri '%0' non è supportata.
 
-crossreferenced_entries_included=Incluse_le_voci_con_riferimenti_incrociati
+crossreferenced\ entries\ included=Incluse le voci con riferimenti incrociati
 
-Current_content=Contenuto_corrente
+Current\ content=Contenuto corrente
 
-Current_value=Valore_corrente
+Current\ value=Valore corrente
 
-Custom_entry_types=Tipi_di_voce_personalizzati
+Custom\ entry\ types=Tipi di voce personalizzati
 
-Custom_entry_types_found_in_file=Tipi_di_voce_personalizzati_trovati_nel_file
+Custom\ entry\ types\ found\ in\ file=Tipi di voce personalizzati trovati nel file
 
-Customize_entry_types=Personalizza_tipi_di_voce
+Customize\ entry\ types=Personalizza tipi di voce
 
-Customize_key_bindings=Personalizza_combinazioni_di_tasti
+Customize\ key\ bindings=Personalizza combinazioni di tasti
 
 Cut=Taglia
 
-cut_entries=taglia_voci
+cut\ entries=taglia voci
 
-cut_entry=taglia_voce
+cut\ entry=taglia voce
 
 
-Library_encoding=Codifica_libreria
+Library\ encoding=Codifica libreria
 
-Library_properties=Proprietà_della_libreria
+Library\ properties=Proprietà della libreria
 
-Library_type=Tipo_di_libreria
+Library\ type=Tipo di libreria
 
-Date_format=Formato_data
+Date\ format=Formato data
 
 Default=Predefinito
 
-Default_encoding=Codifica_predefinita
+Default\ encoding=Codifica predefinita
 
-Default_grouping_field=Campo_di_raggruppamento_predefinito
+Default\ grouping\ field=Campo di raggruppamento predefinito
 
-Default_look_and_feel="Look-and-Feel"_predefinito
+Default\ look\ and\ feel="Look-and-Feel" predefinito
 
-Default_pattern=Modello_predefinito
+Default\ pattern=Modello predefinito
 
-Default_sort_criteria=Criterio_di_ordinamento_predefinito
-Define_'%0'=Definisci_'%0'
+Default\ sort\ criteria=Criterio di ordinamento predefinito
+Define\ '%0'=Definisci '%0'
 
 Delete=Cancella
 
-Delete_custom_format=Cancella_i_formati_personalizzati
+Delete\ custom\ format=Cancella i formati personalizzati
 
-delete_entries=cancella_le_voci
+delete\ entries=cancella le voci
 
-Delete_entry=Cancella_la_voce
+Delete\ entry=Cancella la voce
 
-delete_entry=cancella_la_voce
+delete\ entry=cancella la voce
 
-Delete_multiple_entries=Cancella_più_voci
+Delete\ multiple\ entries=Cancella più voci
 
-Delete_rows=Cancella_voci
+Delete\ rows=Cancella voci
 
-Delete_strings=Cancella_stringhe
+Delete\ strings=Cancella stringhe
 
 Deleted=Cancellato
 
-Permanently_delete_local_file=Cancella_file_locale
+Permanently\ delete\ local\ file=Cancella file locale
 
-Delimit_fields_with_semicolon,_ex.=Campi_delimitati_da_punto_e_virgola,_ex.
+Delimit\ fields\ with\ semicolon,\ ex.=Campi delimitati da punto e virgola, ex.
 
 Descending=Discendente
 
 Description=Descrizione
 
-Deselect_all=Deseleziona_tutto
-Deselect_all_duplicates=Deseleziona_tutti_i_duplicati
+Deselect\ all=Deseleziona tutto
+Deselect\ all\ duplicates=Deseleziona tutti i duplicati
 
-Disable_this_confirmation_dialog=Disabilita_la_richiesta_di_conferma
+Disable\ this\ confirmation\ dialog=Disabilita la richiesta di conferma
 
-Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.=Mostra_tutte_le_voci_appartenenti_a_uno_o_più_gruppi_tra_quelli_selezionati.
+Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups.=Mostra tutte le voci appartenenti a uno o più gruppi tra quelli selezionati.
 
-Display_all_error_messages=Mostra_tutti_i_messaggi_di_errore
+Display\ all\ error\ messages=Mostra tutti i messaggi di errore
 
-Display_help_on_command_line_options=Mostra_l'aiuto_sulle_opzioni_della_riga_di_comando
+Display\ help\ on\ command\ line\ options=Mostra l'aiuto sulle opzioni della riga di comando
 
-Display_only_entries_belonging_to_all_selected_groups.=Mostra_solo_le_voci_appartenenti_a_tutti_i_gruppi_selezionati.
-Display_version=Versione
+Display\ only\ entries\ belonging\ to\ all\ selected\ groups.=Mostra solo le voci appartenenti a tutti i gruppi selezionati.
+Display\ version=Versione
 
-Do_not_abbreviate_names=Non_abbreviare_i_nomi
+Do\ not\ abbreviate\ names=Non abbreviare i nomi
 
-Do_not_automatically_set=Non_effettuare_definizioni_automatiche
+Do\ not\ automatically\ set=Non effettuare definizioni automatiche
 
-Do_not_import_entry=Non_importare_la_voce
+Do\ not\ import\ entry=Non importare la voce
 
-Do_not_open_any_files_at_startup=Non_aprire_nessun_file_all'avvio
+Do\ not\ open\ any\ files\ at\ startup=Non aprire nessun file all'avvio
 
-Do_not_overwrite_existing_keys=Non_sovrascrivere_chiavi_esistenti
-Do_not_show_these_options_in_the_future=Non_mostrare_queste_opzioni_in_futuro
+Do\ not\ overwrite\ existing\ keys=Non sovrascrivere chiavi esistenti
+Do\ not\ show\ these\ options\ in\ the\ future=Non mostrare queste opzioni in futuro
 
-Do_not_wrap_the_following_fields_when_saving=Non_mandare_a_capo_i_campi_seguenti_salvando_il_file
-Do_not_write_the_following_fields_to_XMP_Metadata\:=Non_scrivere_i_dati_dei_campi_seguenti_nei_metadati_XMP\:
+Do\ not\ wrap\ the\ following\ fields\ when\ saving=Non mandare a capo i campi seguenti salvando il file
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Non scrivere i dati dei campi seguenti nei metadati XMP:
 
-Do_you_want_JabRef_to_do_the_following_operations?=Vuoi_che_JabRef_esegua_le_operazioni_seguenti?
+Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Vuoi che JabRef esegua le operazioni seguenti?
 
-Donate_to_JabRef=Fai_una_donazione_a_JabRef
+Donate\ to\ JabRef=Fai una donazione a JabRef
 
 Down=Giù
 
-Download_file=Scarica_il_file
+Download\ file=Scarica il file
 
-Downloading...=Download_in_corso...
+Downloading...=Download in corso...
 
-Drop_%0=Rilascia_%0
+Drop\ %0=Rilascia %0
 
-duplicate_removal=rimozione_di_doppioni
+duplicate\ removal=rimozione di doppioni
 
-Duplicate_string_name=Nome_di_stringa_duplicato
+Duplicate\ string\ name=Nome di stringa duplicato
 
-Duplicates_found=Trovati_doppioni
+Duplicates\ found=Trovati doppioni
 
-Dynamic_groups=Gruppi_dinamici
+Dynamic\ groups=Gruppi dinamici
 
-Dynamically_group_entries_by_a_free-form_search_expression=Raggruppa_dinamicamente_le_voci_utilizzando_una_espressione_di_ricerca_in_formato_libero
+Dynamically\ group\ entries\ by\ a\ free-form\ search\ expression=Raggruppa dinamicamente le voci utilizzando una espressione di ricerca in formato libero
 
-Dynamically_group_entries_by_searching_a_field_for_a_keyword=Raggruppa_dinamicamente_le_voci_ricercando_una_parola_chiave_in_un_campo
+Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=Raggruppa dinamicamente le voci ricercando una parola chiave in un campo
 
-Each_line_must_be_on_the_following_form=Ciascuna_linea_deve_essere_nel_formato_seguente
+Each\ line\ must\ be\ on\ the\ following\ form=Ciascuna linea deve essere nel formato seguente
 
 Edit=Modifica
 
-Edit_custom_export=Modifica_l'esportazione_personalizzata
-Edit_entry=Modifica_voce
-Save_file=Modifica_il_collegamento_al_file
-Edit_file_type=Modifica_il_tipo_di_file
+Edit\ custom\ export=Modifica l'esportazione personalizzata
+Edit\ entry=Modifica voce
+Save\ file=Modifica il collegamento al file
+Edit\ file\ type=Modifica il tipo di file
 
-Edit_group=Modifica_il_gruppo
+Edit\ group=Modifica il gruppo
 
 
-Edit_preamble=Modifica_il_preambolo
-Edit_strings=Modifica_le_stringhe
-Editor_options=Opzioni_dell'editor
+Edit\ preamble=Modifica il preambolo
+Edit\ strings=Modifica le stringhe
+Editor\ options=Opzioni dell'editor
 
-Empty_BibTeX_key=Chiave_BibTeX_vuota
+Empty\ BibTeX\ key=Chiave BibTeX vuota
 
-Grouping_may_not_work_for_this_entry.=La_gestione_dei_gruppi_potrebbe_non_funzionare_per_questa_voce.
+Grouping\ may\ not\ work\ for\ this\ entry.=La gestione dei gruppi potrebbe non funzionare per questa voce.
 
-empty_library=libreria_vuota
-Enable_word/name_autocompletion=Abilita_autocompletamento_di_parole/nomi
+empty\ library=libreria vuota
+Enable\ word/name\ autocompletion=Abilita autocompletamento di parole/nomi
 
-Enter_URL=Immettere_l'URL
+Enter\ URL=Immettere l'URL
 
-Enter_URL_to_download=Immettere_l'URL_da_scaricare
+Enter\ URL\ to\ download=Immettere l'URL da scaricare
 
 entries=voci
 
-Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.=Le_voci_non_possono_essere_inserite_o_rimosse_manualmente_da_questo_gruppo.
+Entries\ cannot\ be\ manually\ assigned\ to\ or\ removed\ from\ this\ group.=Le voci non possono essere inserite o rimosse manualmente da questo gruppo.
 
-Entries_exported_to_clipboard=Voci_esportate_negli_appunti
+Entries\ exported\ to\ clipboard=Voci esportate negli appunti
 
 
 entry=voce
 
-Entry_editor=Modifica_voci
+Entry\ editor=Modifica voci
 
-Entry_preview=Anteprima_della_voce
+Entry\ preview=Anteprima della voce
 
-Entry_table=Tabella_delle_voci
+Entry\ table=Tabella delle voci
 
-Entry_table_columns=Colonne_della_tabella_delle_voci
+Entry\ table\ columns=Colonne della tabella delle voci
 
-Entry_type=Tipo_di_voce
+Entry\ type=Tipo di voce
 
-Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters=I_nomi_dei_tipi_di_voce_non_possono_contenere_spazi_o_i_caratteri_seguenti
+Entry\ type\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=I nomi dei tipi di voce non possono contenere spazi o i caratteri seguenti
 
-Entry_types=Tipi_di_voce
+Entry\ types=Tipi di voce
 
 Error=Errore
-Error_exporting_to_clipboard=Errore_durante_l'esportazione_negli_appunti
+Error\ exporting\ to\ clipboard=Errore durante l'esportazione negli appunti
 
-Error_occurred_when_parsing_entry=Errore_durante_l'elaborazione_della_voce
+Error\ occurred\ when\ parsing\ entry=Errore durante l'elaborazione della voce
 
-Error_opening_file=Errore_all'apertura_del_file
+Error\ opening\ file=Errore all'apertura del file
 
-Error_setting_field=Errore_nell'impostazione_del_campo
+Error\ setting\ field=Errore nell'impostazione del campo
 
-Error_while_writing=Errore_durante_la_scrittura
-Error_writing_to_%0_file(s).=Errore_di_scrittura_di_%0_file.
+Error\ while\ writing=Errore durante la scrittura
+Error\ writing\ to\ %0\ file(s).=Errore di scrittura di %0 file.
 
 
 
-'%0'_exists._Overwrite_file?='%0'_esiste._Sovrascrivere_il_file?
-Overwrite_file?=Sovrascrivere_il_file?
+'%0'\ exists.\ Overwrite\ file?='%0' esiste. Sovrascrivere il file?
+Overwrite\ file?=Sovrascrivere il file?
 
 Export=Esporta
 
-Export_name=Esporta_nome
+Export\ name=Esporta nome
 
-Export_preferences=Esporta_preferenze
+Export\ preferences=Esporta preferenze
 
-Export_preferences_to_file=Esporta_preferenze_in_un_file
+Export\ preferences\ to\ file=Esporta preferenze in un file
 
-Export_properties=Esporta_proprietà
+Export\ properties=Esporta proprietà
 
-Export_to_clipboard=Esporta_negli_appunti
+Export\ to\ clipboard=Esporta negli appunti
 
-Exporting=Esportazione_in_corso
+Exporting=Esportazione in corso
 Extension=Estensione
 
-External_changes=Modifiche_esterne
+External\ changes=Modifiche esterne
 
-External_file_links=Collegamenti_a_file_esterni
+External\ file\ links=Collegamenti a file esterni
 
-External_programs=Programmi_esterni
+External\ programs=Programmi esterni
 
-External_viewer_called=Chiamata_a_visualizzatore_esterno
+External\ viewer\ called=Chiamata a visualizzatore esterno
 
 Fetch=Recupera
 
@@ -482,660 +482,660 @@ Field=Campo
 
 field=campo
 
-Field_name=Nome_del_campo
-Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters=I_nomi_dei_campi_non_possono_contenere_spazi_o_i_caratteri_seguenti
+Field\ name=Nome del campo
+Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=I nomi dei campi non possono contenere spazi o i caratteri seguenti
 
-Field_to_filter=Campi_da_filtrare
+Field\ to\ filter=Campi da filtrare
 
-Field_to_group_by=Campo_di_raggruppamento
+Field\ to\ group\ by=Campo di raggruppamento
 
 File=File
 
 file=file
-File_'%0'_is_already_open.=Il_file_'%0'__è_già_aperto.
+File\ '%0'\ is\ already\ open.=Il file '%0'  è già aperto.
 
-File_changed=File_modificato
-File_directory_is_'%0'\:=La_cartella_dei_file_è_'%0'\:
+File\ changed=File modificato
+File\ directory\ is\ '%0'\:=La cartella dei file è '%0':
 
-File_directory_is_not_set_or_does_not_exist\!=La_cartella_dei_file_non_è_impostata_o_non_esiste\!
+File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=La cartella dei file non è impostata o non esiste!
 
-File_exists=Il_file_esiste
+File\ exists=Il file esiste
 
-File_has_been_updated_externally._What_do_you_want_to_do?=Il_file_è_stato_aggiornato_da_un'applicazione_esterna._Cosa_vuoi_fare?
+File\ has\ been\ updated\ externally.\ What\ do\ you\ want\ to\ do?=Il file è stato aggiornato da un'applicazione esterna. Cosa vuoi fare?
 
-File_not_found=File_non_trovato
-File_type=Tipo_di_file
+File\ not\ found=File non trovato
+File\ type=Tipo di file
 
-File_updated_externally=File_aggiornato_esternamente
+File\ updated\ externally=File aggiornato esternamente
 
-filename=nome_del_file
+filename=nome del file
 
-Filename=Nome_del_file
+Filename=Nome del file
 
-Files_opened=File_aperti
+Files\ opened=File aperti
 
 Filter=Filtro
 
-Filter_All=Filtra_tutto
+Filter\ All=Filtra tutto
 
-Filter_None=Filtra_nulla
+Filter\ None=Filtra nulla
 
-Finished_automatically_setting_external_links.=Impostazione_automatica_dei_collegamenti_esterni_terminata.
+Finished\ automatically\ setting\ external\ links.=Impostazione automatica dei collegamenti esterni terminata.
 
-Finished_synchronizing_file_links._Entries_changed\:_%0.=Sincronizzazione_di_collegamenti_a_file:_Voci_cambiate\:_%0.
-Finished_writing_XMP-metadata._Wrote_to_%0_file(s).=Scrittura_dei_metadati_XMP_terminata._Scrittura_eseguita_su_%0_file.
-Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).=Terminata_la_scrittura_di_metadati_XMP_per_%0_file_(%1_saltati,_%2_errori).
+Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Sincronizzazione di collegamenti a file: Voci cambiate: %0.
+Finished\ writing\ XMP-metadata.\ Wrote\ to\ %0\ file(s).=Scrittura dei metadati XMP terminata. Scrittura eseguita su %0 file.
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Terminata la scrittura di metadati XMP per %0 file (%1 saltati, %2 errori).
 
-First_select_the_entries_you_want_keys_to_be_generated_for.=Selezionare_dapprima_le_voci_per_le_quali_si_vogliono_generare_le_chiavi.
+First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Selezionare dapprima le voci per le quali si vogliono generare le chiavi.
 
-Fit_table_horizontally_on_screen=Adatta_la_tabella_allo_schermo_orizontalmente
+Fit\ table\ horizontally\ on\ screen=Adatta la tabella allo schermo orizontalmente
 
 Float=Galleggiante
-Float_marked_entries=Voci_evidenziate_sempre_in_alto
+Float\ marked\ entries=Voci evidenziate sempre in alto
 
-Font_family=Famiglia_di_font
+Font\ family=Famiglia di font
 
-Font_preview=Anteprima_font
+Font\ preview=Anteprima font
 
-Font_size=Dimensione_font
+Font\ size=Dimensione font
 
-Font_style=Stile_font
+Font\ style=Stile font
 
-Font_selection=Selettore_dei_font
+Font\ selection=Selettore dei font
 
 for=per
 
-Format_of_author_and_editor_names=Formato_dei_nomi_di_autori_e_curatori
-Format_string=Stringa_di_formattazione
+Format\ of\ author\ and\ editor\ names=Formato dei nomi di autori e curatori
+Format\ string=Stringa di formattazione
 
-Format_used=Formato_utilizzato
-Formatter_name=Nome_della_formattazione
+Format\ used=Formato utilizzato
+Formatter\ name=Nome della formattazione
 
-found_in_AUX_file=trovate_nel_file_AUX
+found\ in\ AUX\ file=trovate nel file AUX
 
-Full_name=Nome_completo
+Full\ name=Nome completo
 
 General=Generale
 
-General_fields=Campi_generali
+General\ fields=Campi generali
 
 Generate=Genera
 
-Generate_BibTeX_key=Genera_la_chiave_BibTeX
+Generate\ BibTeX\ key=Genera la chiave BibTeX
 
-Generate_keys=Genera_le_chiavi
+Generate\ keys=Genera le chiavi
 
-Generate_keys_before_saving_(for_entries_without_a_key)=Genera_le_chiavi_prima_di_salvare_(per_le_voci_senza_chiave)
-Generate_keys_for_imported_entries=Genera_chiavi_per_le_voci_importate
+Generate\ keys\ before\ saving\ (for\ entries\ without\ a\ key)=Genera le chiavi prima di salvare (per le voci senza chiave)
+Generate\ keys\ for\ imported\ entries=Genera chiavi per le voci importate
 
-Generate_now=Genera_ora
+Generate\ now=Genera ora
 
-Generated_BibTeX_key_for=Generata_la_chiave_BibTeX_per
+Generated\ BibTeX\ key\ for=Generata la chiave BibTeX per
 
-Generating_BibTeX_key_for=Generazione_in_corso_della_chiave_BibTeX_per
-Get_fulltext=Prendi_testo_completo
+Generating\ BibTeX\ key\ for=Generazione in corso della chiave BibTeX per
+Get\ fulltext=Prendi testo completo
 
-Gray_out_non-hits=Disattiva_le_voci_non_corrispondenti
+Gray\ out\ non-hits=Disattiva le voci non corrispondenti
 
 Groups=Gruppi
 
-Have_you_chosen_the_correct_package_path?=Il_classpath_è_corretto?
+Have\ you\ chosen\ the\ correct\ package\ path?=Il classpath è corretto?
 
 Help=Aiuto
 
-Help_on_key_patterns=Aiuto_sulla_composizione_delle_chiavi
-Help_on_regular_expression_search=Aiuto_sulla_ricerca_di_un'espressione_regolare
+Help\ on\ key\ patterns=Aiuto sulla composizione delle chiavi
+Help\ on\ regular\ expression\ search=Aiuto sulla ricerca di un'espressione regolare
 
-Hide_non-hits=Nascondi_le_voci_non_corrispondenti
+Hide\ non-hits=Nascondi le voci non corrispondenti
 
-Hierarchical_context=Contesto_gerarchico
+Hierarchical\ context=Contesto gerarchico
 
 Highlight=Evidenzia
 Marking=Contrassegno
 Underline=Sottolinea
-Empty_Highlight=Evidenziazione_vuota
-Empty_Marking=Contrassegno_vuoto
-Empty_Underline=Sottolineatura_vuota
-The_marked_area_does_not_contain_any_legible_text!=L'area_marcata_non_contiene_alcun_testo_leggibile!
+Empty\ Highlight=Evidenziazione vuota
+Empty\ Marking=Contrassegno vuoto
+Empty\ Underline=Sottolineatura vuota
+The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=L'area marcata non contiene alcun testo leggibile!
 
-Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>=Suggerimento\:_Per_ricercare_in_un_campo_specifico_digitare,_per_esempio\:<p><tt>author\=smith_and_title\=electrical</tt>
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Suggerimento: Per ricercare in un campo specifico digitare, per esempio:<p><tt>author=smith and title=electrical</tt>
 
-HTML_table=Tabella_HTML
-HTML_table_(with_Abstract_&_BibTeX)=Tabella_HTML_(con_Sommario_e_BibTeX)
+HTML\ table=Tabella HTML
+HTML\ table\ (with\ Abstract\ &\ BibTeX)=Tabella HTML (con Sommario e BibTeX)
 Icon=Icona
 
 Ignore=Ignora
 
 Import=Importa
 
-Import_and_keep_old_entry=Importa_e_mantieni_le_vecchie_voci
+Import\ and\ keep\ old\ entry=Importa e mantieni le vecchie voci
 
-Import_and_remove_old_entry=Importa_e_rimuovi_le_vecchie_voci
+Import\ and\ remove\ old\ entry=Importa e rimuovi le vecchie voci
 
-Import_entries=Importa_voci
+Import\ entries=Importa voci
 
-Import_failed=Importazione_fallita
+Import\ failed=Importazione fallita
 
-Import_file=Importa_file
+Import\ file=Importa file
 
-Import_group_definitions=Importa_definizioni_di_gruppo
+Import\ group\ definitions=Importa definizioni di gruppo
 
-Import_name=Importa_nome
+Import\ name=Importa nome
 
-Import_preferences=Importa_preferenze
+Import\ preferences=Importa preferenze
 
-Import_preferences_from_file=Importa_preferenze_da_un_file
+Import\ preferences\ from\ file=Importa preferenze da un file
 
-Import_strings=Importa_stringhe
+Import\ strings=Importa stringhe
 
-Import_to_open_tab=Importa_nella_scheda_aperta
+Import\ to\ open\ tab=Importa nella scheda aperta
 
-Import_word_selector_definitions=Importa_le_definizioni_per_la_selezione_di_parole
+Import\ word\ selector\ definitions=Importa le definizioni per la selezione di parole
 
-Imported_entries=Voci_importate
+Imported\ entries=Voci importate
 
-Imported_from_library=Importato_dalla_libreria
+Imported\ from\ library=Importato dalla libreria
 
-Importer_class=Classe_Importer
+Importer\ class=Classe Importer
 
-Importing=Importazione_in_corso
+Importing=Importazione in corso
 
-Importing_in_unknown_format=Importazione_in_formato_sconosciuto
+Importing\ in\ unknown\ format=Importazione in formato sconosciuto
 
-Include_abstracts=Includi_il_sommario
-Include_entries=Includi_voci
+Include\ abstracts=Includi il sommario
+Include\ entries=Includi voci
 
-Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups=Includi_i_sottogruppi\:_Quando_selezionato,_mostra_le_voci_contenute_in_questo_gruppo_e_nei_suoi_sottogruppi
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=Includi i sottogruppi: Quando selezionato, mostra le voci contenute in questo gruppo e nei suoi sottogruppi
 
-Independent_group\:_When_selected,_view_only_this_group's_entries=Gruppo_indipendente\:_Quando_selezionato,_mostra_solo_le_voci_di_questo_gruppo
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=Gruppo indipendente: Quando selezionato, mostra solo le voci di questo gruppo
 
-Work_options=Attribuzione_dei_campi
+Work\ options=Attribuzione dei campi
 
 Insert=Inserisci
 
-Insert_rows=Inserisci_righe
+Insert\ rows=Inserisci righe
 
 Intersection=Intersezione
 
-Invalid_BibTeX_key=Chiave_BibTeX_non_valida
+Invalid\ BibTeX\ key=Chiave BibTeX non valida
 
-Invalid_date_format=Formato_data_non_valido
+Invalid\ date\ format=Formato data non valido
 
-Invalid_URL=URL_non_valido
+Invalid\ URL=URL non valido
 
-Online_help=Help_online
+Online\ help=Help online
 
-JabRef_preferences=Preferenze_JabRef
+JabRef\ preferences=Preferenze JabRef
 
 Join=Unisci
 
-Joins_selected_keywords_and_deletes_selected_keywords.=Unisce_le_keyword_selezionate_e_cancella_le_keyword_selezionate.
+Joins\ selected\ keywords\ and\ deletes\ selected\ keywords.=Unisce le keyword selezionate e cancella le keyword selezionate.
 
-Journal_abbreviations=Abbreviazioni_riviste
+Journal\ abbreviations=Abbreviazioni riviste
 
 Keep=Mantieni
 
-Keep_both=Mantieni_entrambi
+Keep\ both=Mantieni entrambi
 
-Key_bindings=Combinazioni_di_tasti
+Key\ bindings=Combinazioni di tasti
 
-Key_bindings_changed=Combinazioni_di_tasti_modificate
+Key\ bindings\ changed=Combinazioni di tasti modificate
 
-Key_generator_settings=Impostazioni_per_la_generazione_delle_chiavi
+Key\ generator\ settings=Impostazioni per la generazione delle chiavi
 
-Key_pattern=Modello_delle_chiavi
+Key\ pattern=Modello delle chiavi
 
-keys_in_library=Chiavi_nella_libreria
+keys\ in\ library=Chiavi nella libreria
 
-Keyword=Parola_Chiave
+Keyword=Parola Chiave
 
 Label=Etichetta
 
 Language=Lingua
 
-Last_modified=Ultimo_modificato
+Last\ modified=Ultimo modificato
 
-LaTeX_AUX_file=File_AUX_LaTeX
-Leave_file_in_its_current_directory=Lascia_il_file_nella_cartella_corrente
+LaTeX\ AUX\ file=File AUX LaTeX
+Leave\ file\ in\ its\ current\ directory=Lascia il file nella cartella corrente
 
 Left=Sinistra
 Level=Livello
 
-Limit_to_fields=Restrizioni_ai_campi
+Limit\ to\ fields=Restrizioni ai campi
 
-Limit_to_selected_entries=Restrizioni_alle_voci_selezionate
+Limit\ to\ selected\ entries=Restrizioni alle voci selezionate
 
 Link=Collegamento
-Link_local_file=Collegamento_al_file_locale
-Link_to_file_%0=Collegamento_al_file_%0
+Link\ local\ file=Collegamento al file locale
+Link\ to\ file\ %0=Collegamento al file %0
 
-Listen_for_remote_operation_on_port=Porta_in_ascolto_per_operazioni_remote
-Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)=Carica_e_salva_le_preferenze_da/in_jabref.xml_all'avvio_(modalità_chiavetta_di_memoria)
+Listen\ for\ remote\ operation\ on\ port=Porta in ascolto per operazioni remote
+Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=Carica e salva le preferenze da/in jabref.xml all'avvio (modalità chiavetta di memoria)
 
-Look_and_feel=Aspetto
-Main_file_directory=Cartella_dei_file_principale
+Look\ and\ feel=Aspetto
+Main\ file\ directory=Cartella dei file principale
 
-Main_layout_file=File_di_layout_principale
+Main\ layout\ file=File di layout principale
 
-Manage_custom_exports=Gestione_delle_esportazioni_personalizzate
+Manage\ custom\ exports=Gestione delle esportazioni personalizzate
 
-Manage_custom_imports=Gestione_delle_importazioni_personalizzate
-Manage_external_file_types=Gestione_dei_tipi_di_file_esterni
+Manage\ custom\ imports=Gestione delle importazioni personalizzate
+Manage\ external\ file\ types=Gestione dei tipi di file esterni
 
-Mark_entries=Contrassegna_voci
+Mark\ entries=Contrassegna voci
 
-Mark_entry=Contrassegna_voce
+Mark\ entry=Contrassegna voce
 
-Mark_new_entries_with_addition_date=Contrassegna_le_nuove_voci_con_la_data_di_inserimento
+Mark\ new\ entries\ with\ addition\ date=Contrassegna le nuove voci con la data di inserimento
 
-Mark_new_entries_with_owner_name=Contrassegna_le_nuove_voci_con_il_nome_del_proprietario
+Mark\ new\ entries\ with\ owner\ name=Contrassegna le nuove voci con il nome del proprietario
 
-Memory_stick_mode=Modalità_chiavetta_di_memoria
+Memory\ stick\ mode=Modalità chiavetta di memoria
 
-Menu_and_label_font_size=Dimensione_del_font_di_menu_ed_etichette
+Menu\ and\ label\ font\ size=Dimensione del font di menu ed etichette
 
-Merged_external_changes=Modifiche_esterne_incorporate
+Merged\ external\ changes=Modifiche esterne incorporate
 
 Messages=Messaggi
 
-Modification_of_field=Modifica_del_campo
+Modification\ of\ field=Modifica del campo
 
-Modified_group_"%0".=Gruppo_"%0"_modificato.
+Modified\ group\ "%0".=Gruppo "%0" modificato.
 
-Modified_groups=Gruppi_modificati
+Modified\ groups=Gruppi modificati
 
-Modified_string=Stringa_modificata
+Modified\ string=Stringa modificata
 
 Modify=Modifica
 
-modify_group=modifica_gruppo
+modify\ group=modifica gruppo
 
-Move_down=Sposta_in_giù
+Move\ down=Sposta in giù
 
-Move_external_links_to_'file'_field=Sposta_i_collegamenti_esterni_nel_campo_'file'
+Move\ external\ links\ to\ 'file'\ field=Sposta i collegamenti esterni nel campo 'file'
 
-move_group=sposta_gruppo
+move\ group=sposta gruppo
 
-Move_up=Sposta_in_su
+Move\ up=Sposta in su
 
-Moved_group_"%0".=Spostato_gruppo_"%0".
+Moved\ group\ "%0".=Spostato gruppo "%0".
 
 Name=Nome
-Name_formatter=Formattazione_dei_nomi
+Name\ formatter=Formattazione dei nomi
 
-Natbib_style=Stile_Natbib
+Natbib\ style=Stile Natbib
 
-nested_AUX_files=File_AUX_nidificati
+nested\ AUX\ files=File AUX nidificati
 
 New=Nuovo
 
 new=nuovo
 
-New_BibTeX_entry=Nuova_voce_BibTeX
+New\ BibTeX\ entry=Nuova voce BibTeX
 
-New_BibTeX_sublibrary=Nuova_sottolibreria_BibTeX
+New\ BibTeX\ sublibrary=Nuova sottolibreria BibTeX
 
-New_content=Nuovo_contenuto
+New\ content=Nuovo contenuto
 
-New_library_created.=Nuovo_libreria_creata
-New_%0_library=Nuova_libreria_%0
-New_field_value=Nuovo_valore_del_campo
+New\ library\ created.=Nuovo libreria creata
+New\ %0\ library=Nuova libreria %0
+New\ field\ value=Nuovo valore del campo
 
-New_group=Nuovo_gruppo
+New\ group=Nuovo gruppo
 
-New_string=Nuova_stringa
+New\ string=Nuova stringa
 
-Next_entry=Voce_successiva
+Next\ entry=Voce successiva
 
-No_actual_changes_found.=Nessun_cambiamento_trovato.
+No\ actual\ changes\ found.=Nessun cambiamento trovato.
 
-no_base-BibTeX-file_specified=nessuna_libreria_BibTeX_specificata
+no\ base-BibTeX-file\ specified=nessuna libreria BibTeX specificata
 
-no_library_generated=nessuna_libreria_creata
+no\ library\ generated=nessuna libreria creata
 
-No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.=Nessuna_voce_trovata._Verificare_che_si_stia_utilizzando_il_filtro_di_importazione_appropriato.
+No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=Nessuna voce trovata. Verificare che si stia utilizzando il filtro di importazione appropriato.
 
 
-No_entries_found_for_the_search_string_'%0'=Nessuna_voce_trovata_in_base_alla_stringa_di_ricerca_'%0'
+No\ entries\ found\ for\ the\ search\ string\ '%0'=Nessuna voce trovata in base alla stringa di ricerca '%0'
 
-No_entries_imported.=Nessuna_voce_importata
+No\ entries\ imported.=Nessuna voce importata
 
-No_files_found.=Nessun_file_trovato.
+No\ files\ found.=Nessun file trovato.
 
-No_GUI._Only_process_command_line_options.=Senza_interfaccia_grafica._Elaborate_solo_le_opzioni_della_riga_di_comando.
+No\ GUI.\ Only\ process\ command\ line\ options.=Senza interfaccia grafica. Elaborate solo le opzioni della riga di comando.
 
-No_journal_names_could_be_abbreviated.=Nessun_nome_di_rivista_può_essere_abbreviato.
+No\ journal\ names\ could\ be\ abbreviated.=Nessun nome di rivista può essere abbreviato.
 
-No_journal_names_could_be_unabbreviated.=Nessuna_abbreviazione_di_rivista_può_essere_estesa.
-No_PDF_linked=Nessun_file_PDF_collegato
+No\ journal\ names\ could\ be\ unabbreviated.=Nessuna abbreviazione di rivista può essere estesa.
+No\ PDF\ linked=Nessun file PDF collegato
 
-Open_PDF=Apri_PDF
+Open\ PDF=Apri PDF
 
-No_URL_defined=Nessun_URL_trovato
+No\ URL\ defined=Nessun URL trovato
 not=non
 
-not_found=non_trovato
+not\ found=non trovato
 
-Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,=Nota\:_è_necessario_specificare_il_nome_di_classe_completo_per_il_"Look-and-Feel",
+Note\ that\ you\ must\ specify\ the\ fully\ qualified\ class\ name\ for\ the\ look\ and\ feel,=Nota: è necessario specificare il nome di classe completo per il "Look-and-Feel",
 
-Nothing_to_redo=Niente_da_ripetere
+Nothing\ to\ redo=Niente da ripetere
 
-Nothing_to_undo=Niente_da_annullare
+Nothing\ to\ undo=Niente da annullare
 
 occurrences=ricorrenze
 
 OK=OK
-One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Uno_o_più_collegamenti_a_file_sono_del_tipo_'%0',_non_definito._Come_procedere?
+One\ or\ more\ file\ links\ are\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Uno o più collegamenti a file sono del tipo '%0', non definito. Come procedere?
 
-One_or_more_keys_will_be_overwritten._Continue?=Una_o_più_chiavi_saranno_sovrascritte._Continuare?
+One\ or\ more\ keys\ will\ be\ overwritten.\ Continue?=Una o più chiavi saranno sovrascritte. Continuare?
 
 
 Open=Apri
 
-Open_BibTeX_library=Apri_libreria_BibTeX
+Open\ BibTeX\ library=Apri libreria BibTeX
 
-Open_library=Apri_libreria
+Open\ library=Apri libreria
 
-Open_editor_when_a_new_entry_is_created=Apri_per_modifiche_quando_una_nuova_voce_viene_creata
+Open\ editor\ when\ a\ new\ entry\ is\ created=Apri per modifiche quando una nuova voce viene creata
 
-Open_file=Apri_file
+Open\ file=Apri file
 
-Open_last_edited_libraries_at_startup=All'avvio_apri_le_librerie_aperte_nella_sessione_precedente
+Open\ last\ edited\ libraries\ at\ startup=All'avvio apri le librerie aperte nella sessione precedente
 
-Connect_to_shared_database=Apri_archivio_condiviso
+Connect\ to\ shared\ database=Apri archivio condiviso
 
-Open_terminal_here=Apri_un_terminale_qui
+Open\ terminal\ here=Apri un terminale qui
 
-Open_URL_or_DOI=Apri_URL_o_DOI
+Open\ URL\ or\ DOI=Apri URL o DOI
 
-Opened_library=Libreria_aperta
+Opened\ library=Libreria aperta
 
-Opening=Apertura_in_corso
+Opening=Apertura in corso
 
-Opening_preferences...=Apertura_delle_preferenze_in_corso...
+Opening\ preferences...=Apertura delle preferenze in corso...
 
-Operation_canceled.=Operazione_annullata.
-Operation_not_supported=Operazione_non_supportata
+Operation\ canceled.=Operazione annullata.
+Operation\ not\ supported=Operazione non supportata
 
-Optional_fields=Campi_opzionali
+Optional\ fields=Campi opzionali
 
 Options=Opzioni
 
 or=o
 
-Output_or_export_file=File_di_salvataggio_o_esportazione
+Output\ or\ export\ file=File di salvataggio o esportazione
 
 Override=Sovrascrivi
 
-Override_default_file_directories=Alternative_alle_cartelle_di_file_predefinite
+Override\ default\ file\ directories=Alternative alle cartelle di file predefinite
 
-Override_default_font_settings=Ignora_le_impostazioni_dei_font_predefinite
+Override\ default\ font\ settings=Ignora le impostazioni dei font predefinite
 
-Override_the_BibTeX_field_by_the_selected_text=Sovrascrivi_la_chiave_BibTeX_con_il_testo_selezionato
+Override\ the\ BibTeX\ field\ by\ the\ selected\ text=Sovrascrivi la chiave BibTeX con il testo selezionato
 
 
 Overwrite=Sovrascrivi
-Overwrite_existing_field_values=Sovrascrivi_i_valori_esistenti_del_campo
+Overwrite\ existing\ field\ values=Sovrascrivi i valori esistenti del campo
 
-Overwrite_keys=Sovrascrivi_chiavi
+Overwrite\ keys=Sovrascrivi chiavi
 
-pairs_processed=coppie_elaborate
+pairs\ processed=coppie elaborate
 Password=Password
 
 Paste=Incolla
 
-paste_entries=incolla_voci
+paste\ entries=incolla voci
 
-paste_entry=incolla_voce
-Paste_from_clipboard=Incolla_dagli_appunti
+paste\ entry=incolla voce
+Paste\ from\ clipboard=Incolla dagli appunti
 
 Pasted=Incollato
 
-Path_to_%0_not_defined=Percorso_per_%0_non_definito
+Path\ to\ %0\ not\ defined=Percorso per %0 non definito
 
-Path_to_LyX_pipe=Percorso_per_la_pipe_LyX
+Path\ to\ LyX\ pipe=Percorso per la pipe LyX
 
-PDF_does_not_exist=Il_file_PDF_non_esiste
+PDF\ does\ not\ exist=Il file PDF non esiste
 
-File_has_no_attached_annotations=Il_file_non_ha_annotazioni_allegate
+File\ has\ no\ attached\ annotations=Il file non ha annotazioni allegate
 
-Plain_text_import=Importazione_da_solo_testo
+Plain\ text\ import=Importazione da solo testo
 
-Please_enter_a_name_for_the_group.=Immettere_un_nome_per_il_gruppo
+Please\ enter\ a\ name\ for\ the\ group.=Immettere un nome per il gruppo
 
-Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>=Immettere_un_termine_di_ricerca._Per_esempio,_per_ricercare_in_tutti_i_campi_<b>Smith</b>,_imettere\:<p><tt>smith</tt><p>_Per_ricercare_nel_campo_<b>Author</b>_il_termine_<b>Smith</b>_e_nel_campo_<b>Title</b>_il_termine_<b>electrical</b>,_immettere\:<p><tt>author\=smith_and_title\=electrical</tt>
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Immettere un termine di ricerca. Per esempio, per ricercare in tutti i campi <b>Smith</b>, imettere:<p><tt>smith</tt><p> Per ricercare nel campo <b>Author</b> il termine <b>Smith</b> e nel campo <b>Title</b> il termine <b>electrical</b>, immettere:<p><tt>author=smith and title=electrical</tt>
 
-Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=Immettere_il_cmpo_di_ricerca_(es._<b>keywords</b>)_e_la_parola_chiave_da_ricercare_(es._<b>electrical</b>).
+Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=Immettere il cmpo di ricerca (es. <b>keywords</b>) e la parola chiave da ricercare (es. <b>electrical</b>).
 
-Please_enter_the_string's_label=Immettere_l'etichetta_della_stringa
+Please\ enter\ the\ string's\ label=Immettere l'etichetta della stringa
 
-Please_select_an_importer.=Selezionare_un_filtro_di_importazione.
+Please\ select\ an\ importer.=Selezionare un filtro di importazione.
 
-Possible_duplicate_entries=Voci_potenzialmente_duplicate
+Possible\ duplicate\ entries=Voci potenzialmente duplicate
 
-Possible_duplicate_of_existing_entry._Click_to_resolve.=Possibile_duplicazione_di_una_voce_esistente._Cliccare_per_effettuare_la_verifica.
+Possible\ duplicate\ of\ existing\ entry.\ Click\ to\ resolve.=Possibile duplicazione di una voce esistente. Cliccare per effettuare la verifica.
 
 Preamble=Preambolo
 
 Preferences=Preferenze
 
-Preferences_recorded.=Preferenze_registrate.
+Preferences\ recorded.=Preferenze registrate.
 
 Preview=Anteprima
-Citation_Style=Stile_delle_citazioni
-Current_Preview=Anteprima_di_stampa_corrente
-Cannot_generate_preview_based_on_selected_citation_style.=Non_posso_generare_un'anteprima_usando_lo_stile_delle_citazioni_scelto.
-Bad_character_inside_entry=Carattere_errato_nella_voce
-Error_while_generating_citation_style=Errore_durante_la_generazione_dello_stile_di_citazione
-Preview_style_changed_to\:_%0=Stile_di_anteprima_modificato_in\:_%0
-Next_preview_layout=Prossimo_layout_di_anteprima
-Previous_preview_layout=Successivo_layout_di_anteprima
+Citation\ Style=Stile delle citazioni
+Current\ Preview=Anteprima di stampa corrente
+Cannot\ generate\ preview\ based\ on\ selected\ citation\ style.=Non posso generare un'anteprima usando lo stile delle citazioni scelto.
+Bad\ character\ inside\ entry=Carattere errato nella voce
+Error\ while\ generating\ citation\ style=Errore durante la generazione dello stile di citazione
+Preview\ style\ changed\ to\:\ %0=Stile di anteprima modificato in: %0
+Next\ preview\ layout=Prossimo layout di anteprima
+Previous\ preview\ layout=Successivo layout di anteprima
 
-Previous_entry=Voce_precedente
+Previous\ entry=Voce precedente
 
-Primary_sort_criterion=Criterio_di_ordinamento_principale
-Problem_with_parsing_entry=Problema_di_analisi_di_una_voce
-Processing_%0=Elaborazione_di_%0
-Pull_changes_from_shared_database=Estrai_modifiche_dal'archivio_condiviso
+Primary\ sort\ criterion=Criterio di ordinamento principale
+Problem\ with\ parsing\ entry=Problema di analisi di una voce
+Processing\ %0=Elaborazione di %0
+Pull\ changes\ from\ shared\ database=Estrai modifiche dal'archivio condiviso
 
-Pushed_citations_to_%0=Citazioni_inviate_a_%0
+Pushed\ citations\ to\ %0=Citazioni inviate a %0
 
-Quit_JabRef=Chiudi_JabRef
+Quit\ JabRef=Chiudi JabRef
 
-Quit_synchronization=Chiudi_sincronizzazione
+Quit\ synchronization=Chiudi sincronizzazione
 
-Raw_source=Solo_testo
+Raw\ source=Solo testo
 
-Rearrange_tabs_alphabetically_by_title=Ordina_alfabeticamente_le_schede
+Rearrange\ tabs\ alphabetically\ by\ title=Ordina alfabeticamente le schede
 
 Redo=Ripeti
 
-Reference_library=Libreria_di_riferimenti
+Reference\ library=Libreria di riferimenti
 
-%0_references_found._Number_of_references_to_fetch?=Riferimenti_trovati\:_%0._Numero_di_riferimenti_da_recuperare?
+%0\ references\ found.\ Number\ of\ references\ to\ fetch?=Riferimenti trovati: %0. Numero di riferimenti da recuperare?
 
-Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Perfeziona_il_super-gruppo\:_Quando_selezionato,_mostra_le_voci_contenute_sia_in_questo_gruppo_sia_nel_suo_super-gruppo
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=Perfeziona il super-gruppo: Quando selezionato, mostra le voci contenute sia in questo gruppo sia nel suo super-gruppo
 
-regular_expression=Espressione_regolare
+regular\ expression=Espressione regolare
 
-Related_articles=Articoli_correlati
+Related\ articles=Articoli correlati
 
-Remote_operation=Accesso_remoto
+Remote\ operation=Accesso remoto
 
-Remote_server_port=Porta_del_server_remoto
+Remote\ server\ port=Porta del server remoto
 
 Remove=Rimuovi
 
-Remove_subgroups=Rimuovi_tutti_i_sottogruppi
+Remove\ subgroups=Rimuovi tutti i sottogruppi
 
-Remove_all_subgroups_of_"%0"?=Rimuovere_tutti_i_sottogruppi_di_"%0"?
+Remove\ all\ subgroups\ of\ "%0"?=Rimuovere tutti i sottogruppi di "%0"?
 
-Remove_entry_from_import=Rimuovi_la_voce_dall'importazione
+Remove\ entry\ from\ import=Rimuovi la voce dall'importazione
 
-Remove_selected_entries_from_this_group=Rimuovi_da_questo_gruppo_le_voci_selezionate
+Remove\ selected\ entries\ from\ this\ group=Rimuovi da questo gruppo le voci selezionate
 
-Remove_entry_type=Rimuovi_il_tipo_di_voce
+Remove\ entry\ type=Rimuovi il tipo di voce
 
-Remove_from_group=Rimuovi_dal_gruppo
+Remove\ from\ group=Rimuovi dal gruppo
 
-Remove_group=Rimuovi_gruppo
+Remove\ group=Rimuovi gruppo
 
-Remove_group,_keep_subgroups=Rimuovi_gruppo,_mantieni_i_sottogruppi
+Remove\ group,\ keep\ subgroups=Rimuovi gruppo, mantieni i sottogruppi
 
-Remove_group_"%0"?=Rimuovere_il_gruppo_"%0"?
+Remove\ group\ "%0"?=Rimuovere il gruppo "%0"?
 
-Remove_group_"%0"_and_its_subgroups?=Rimuovere_il_gruppo_"%0"_ed_i_suoi_sottogruppi?
+Remove\ group\ "%0"\ and\ its\ subgroups?=Rimuovere il gruppo "%0" ed i suoi sottogruppi?
 
-remove_group_(keep_subgroups)=rimuovi_gruppo_(mantieni_i_sottogruppi)
+remove\ group\ (keep\ subgroups)=rimuovi gruppo (mantieni i sottogruppi)
 
-remove_group_and_subgroups=rimuovi_gruppo_e_sottogruppi
+remove\ group\ and\ subgroups=rimuovi gruppo e sottogruppi
 
-Remove_group_and_subgroups=Rimuovi_gruppo_e_sottogruppi
+Remove\ group\ and\ subgroups=Rimuovi gruppo e sottogruppi
 
-Remove_link=Rimuovere_il_collegamento
+Remove\ link=Rimuovere il collegamento
 
-Remove_old_entry=Rimuovi_vecchia_voce
+Remove\ old\ entry=Rimuovi vecchia voce
 
-Remove_selected_strings=Rimuovi_le_stringhe_selezionate
+Remove\ selected\ strings=Rimuovi le stringhe selezionate
 
-Removed_group_"%0".=Rimosso_gruppo_"%0".
+Removed\ group\ "%0".=Rimosso gruppo "%0".
 
-Removed_group_"%0"_and_its_subgroups.=Rimosso_gruppo_"%0"_e_suoi_sottogruppi.
+Removed\ group\ "%0"\ and\ its\ subgroups.=Rimosso gruppo "%0" e suoi sottogruppi.
 
-Removed_string=Stringa_rimossa
+Removed\ string=Stringa rimossa
 
-Renamed_string=Stringa_rinominata
+Renamed\ string=Stringa rinominata
 
 Replace=Sostituisci
 
-Replace_(regular_expression)=Sostituisci_(espressione_regolare)
+Replace\ (regular\ expression)=Sostituisci (espressione regolare)
 
-Replace_string=Sostituisci_stringa
+Replace\ string=Sostituisci stringa
 
-Replace_with=Sostituisci_con
+Replace\ with=Sostituisci con
 
 Replaced=Sostituito
 
-Required_fields=Campo_obbligatorio
+Required\ fields=Campo obbligatorio
 
-Reset_all=Reimposta_tutto
+Reset\ all=Reimposta tutto
 
-Resolve_strings_for_all_fields_except=Risolve_le_stringhe_per_tutti_i_campi_tranne
-Resolve_strings_for_standard_BibTeX_fields_only=Risolve_le_stringhe_solo_per_i_campi_BibTeX_standard
+Resolve\ strings\ for\ all\ fields\ except=Risolve le stringhe per tutti i campi tranne
+Resolve\ strings\ for\ standard\ BibTeX\ fields\ only=Risolve le stringhe solo per i campi BibTeX standard
 
 resolved=risolto
 
 Review=Rivedi
 
-Review_changes=Rivedi_le_modifiche
+Review\ changes=Rivedi le modifiche
 
 Right=Destra
 
 Save=Salva
-Save_all_finished.=Terminato_il_salvataggio_globale.
+Save\ all\ finished.=Terminato il salvataggio globale.
 
-Save_all_open_libraries=Salva_tutte_le_librerie_aperte
+Save\ all\ open\ libraries=Salva tutte le librerie aperte
 
-Save_before_closing=Salva_prima_di_chiudere
+Save\ before\ closing=Salva prima di chiudere
 
-Save_library=Salva_la_libreria
-Save_library_as...=Salva_la_libreria_come...
+Save\ library=Salva la libreria
+Save\ library\ as...=Salva la libreria come...
 
-Save_entries_in_their_original_order=Salva_le_voci_nel_loro_ordine_originale
+Save\ entries\ in\ their\ original\ order=Salva le voci nel loro ordine originale
 
-Save_failed=Salvataggio_fallito
+Save\ failed=Salvataggio fallito
 
-Save_failed_during_backup_creation=Salvataggio_fallito_durante_la_creazione_della_copia_di_backup
+Save\ failed\ during\ backup\ creation=Salvataggio fallito durante la creazione della copia di backup
 
-Save_selected_as...=Salva_la_selezione_come...
+Save\ selected\ as...=Salva la selezione come...
 
-Saved_library=Libreria_salvata
+Saved\ library=Libreria salvata
 
-Saved_selected_to_'%0'.=Salvata_la_selezione_in_'%0'.
+Saved\ selected\ to\ '%0'.=Salvata la selezione in '%0'.
 
-Saving=Salvataggio_in_corso
-Saving_all_libraries...=Salvataggio_di_tutte_le_librerie...
+Saving=Salvataggio in corso
+Saving\ all\ libraries...=Salvataggio di tutte le librerie...
 
-Saving_library=Salvataggio_delle_librerie_in_corso
+Saving\ library=Salvataggio delle librerie in corso
 
 Search=Ricerca
 
-Search_expression=Espressione_di_ricerca
+Search\ expression=Espressione di ricerca
 
-Search_for=Ricerca
+Search\ for=Ricerca
 
-Searching_for_duplicates...=Ricerca_di_duplicati_in_corso...
+Searching\ for\ duplicates...=Ricerca di duplicati in corso...
 
-Searching_for_files=Ricerca_dei_file
+Searching\ for\ files=Ricerca dei file
 
-Secondary_sort_criterion=Criterio_di_ordinamento_secondario
+Secondary\ sort\ criterion=Criterio di ordinamento secondario
 
-Select_all=Seleziona_tutto
+Select\ all=Seleziona tutto
 
-Select_encoding=Seleziona_la_codifica
+Select\ encoding=Seleziona la codifica
 
-Select_entry_type=Seleziona_un_tipo_di_voce
-Select_external_application=Seleziona_un'applicazione_esterna
+Select\ entry\ type=Seleziona un tipo di voce
+Select\ external\ application=Seleziona un'applicazione esterna
 
-Select_file_from_ZIP-archive=Seleziona_un_file_da_un_archivio_ZIP
+Select\ file\ from\ ZIP-archive=Seleziona un file da un archivio ZIP
 
-Select_the_tree_nodes_to_view_and_accept_or_reject_changes=Selezionare_i_nodi_dell'albero_per_vedere_ed_accettare_o_rifiutare_le_modifiche
-Selected_entries=Voci_selezionate
-Set_field=Imposta_il_campo
-Set_fields=Imposta_i_campi
+Select\ the\ tree\ nodes\ to\ view\ and\ accept\ or\ reject\ changes=Selezionare i nodi dell'albero per vedere ed accettare o rifiutare le modifiche
+Selected\ entries=Voci selezionate
+Set\ field=Imposta il campo
+Set\ fields=Imposta i campi
 
-Set_general_fields=Definisci_i_campi_generali
-Set_main_external_file_directory=Impostare_la_cartella_principale_dei_file_esterni
+Set\ general\ fields=Definisci i campi generali
+Set\ main\ external\ file\ directory=Impostare la cartella principale dei file esterni
 
-Set_table_font=Definisci_i_font_della_tabella
+Set\ table\ font=Definisci i font della tabella
 
 Settings=Parametri
 
 Shortcut=Scorciatoia
 
-Show/edit_%0_source=Mostra/Modifica_codice_sorgente_%0
+Show/edit\ %0\ source=Mostra/Modifica codice sorgente %0
 
-Show_'Firstname_Lastname'=Mostra_'Nome_Cognome'
+Show\ 'Firstname\ Lastname'=Mostra 'Nome Cognome'
 
-Show_'Lastname,_Firstname'=Mostra_'Cognome,_Nome'
+Show\ 'Lastname,\ Firstname'=Mostra 'Cognome, Nome'
 
-Show_BibTeX_source_by_default=Mostra_il_codice_sorgente_BibTeX_per_impostazione_predefinita
+Show\ BibTeX\ source\ by\ default=Mostra il codice sorgente BibTeX per impostazione predefinita
 
-Show_confirmation_dialog_when_deleting_entries=Chiedere_conferma_della_cancellazione_di_una_voce
+Show\ confirmation\ dialog\ when\ deleting\ entries=Chiedere conferma della cancellazione di una voce
 
-Show_description=Mostra_descrizione
+Show\ description=Mostra descrizione
 
-Show_file_column=Visualizza_la_colonna_File
+Show\ file\ column=Visualizza la colonna File
 
-Show_last_names_only=Mostra_solo_i_cognomi
+Show\ last\ names\ only=Mostra solo i cognomi
 
-Show_names_unchanged=Mostra_i_nomi_immodificati
+Show\ names\ unchanged=Mostra i nomi immodificati
 
-Show_optional_fields=Mostra_i_campi_opzionali
+Show\ optional\ fields=Mostra i campi opzionali
 
-Show_required_fields=Mostra_i_campi_obbligatori
+Show\ required\ fields=Mostra i campi obbligatori
 
-Show_URL/DOI_column=Mostra_colonna_URL/DOI
+Show\ URL/DOI\ column=Mostra colonna URL/DOI
 
-Simple_HTML=HTML_semplice
+Simple\ HTML=HTML semplice
 
 Size=Dimensione
 
-Skipped_-_No_PDF_linked=Saltato_-_Nessun_file_PDF_collegato
-Skipped_-_PDF_does_not_exist=Saltato_-_Il_file_PDF_non_esiste
+Skipped\ -\ No\ PDF\ linked=Saltato - Nessun file PDF collegato
+Skipped\ -\ PDF\ does\ not\ exist=Saltato - Il file PDF non esiste
 
-Skipped_entry.=Voce_saltata
+Skipped\ entry.=Voce saltata
 
-Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.=
+Some\ appearance\ settings\ you\ changed\ require\ to\ restart\ JabRef\ to\ come\ into\ effect.=
 
-source_edit=modifica_sorgente
-Special_name_formatters=Formattazioni_speciali_dei_nomi
+source\ edit=modifica sorgente
+Special\ name\ formatters=Formattazioni speciali dei nomi
 
-Special_table_columns=Colonne_di_tabella_speciali
+Special\ table\ columns=Colonne di tabella speciali
 
-Starting_import=Inizio_importazione
+Starting\ import=Inizio importazione
 
-Statically_group_entries_by_manual_assignment=Raggruppa_manualmente_le_voci
+Statically\ group\ entries\ by\ manual\ assignment=Raggruppa manualmente le voci
 
 Status=Stato
 
@@ -1143,1019 +1143,1019 @@ Stop=Arresta
 
 Strings=Stringa
 
-Strings_for_library=Stringhe_per_la_libreria
+Strings\ for\ library=Stringhe per la libreria
 
-Sublibrary_from_AUX=Sottolibreria_da_file_LaTeX_AUX
+Sublibrary\ from\ AUX=Sottolibreria da file LaTeX AUX
 
-Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.=Alterna_nomi_completi_e_nomi_abbreviati_per_le_riviste_delle_quali_è_noto_il_nome.
+Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=Alterna nomi completi e nomi abbreviati per le riviste delle quali è noto il nome.
 
-Synchronize_file_links=Sincronizza_il_collegamento_ai_file
+Synchronize\ file\ links=Sincronizza il collegamento ai file
 
-Synchronizing_file_links...=Sincronizzazione_di_file_collegamenti_in_corso...
+Synchronizing\ file\ links...=Sincronizzazione di file collegamenti in corso...
 
-Table_appearance=Aspetto_della_tabella
+Table\ appearance=Aspetto della tabella
 
-Table_background_color=Colore_di_sfondo_della_tabella
+Table\ background\ color=Colore di sfondo della tabella
 
-Table_grid_color=Colore_della_griglia_della_tabella
+Table\ grid\ color=Colore della griglia della tabella
 
-Table_text_color=Colore_del_testo_della_tabella
+Table\ text\ color=Colore del testo della tabella
 
-Tabname=Nome_della_scheda
-Target_file_cannot_be_a_directory.=L'oggetto_deve_essere_un_file,_non_una_cartella.
+Tabname=Nome della scheda
+Target\ file\ cannot\ be\ a\ directory.=L'oggetto deve essere un file, non una cartella.
 
-Tertiary_sort_criterion=Criterio_di_ordinamento_terziario
+Tertiary\ sort\ criterion=Criterio di ordinamento terziario
 
 Test=Test
 
-paste_text_here=Area_di_inserimento_testo
+paste\ text\ here=Area di inserimento testo
 
-The_chosen_date_format_for_new_entries_is_not_valid=Il_formato_di_data_scelto_per_le_nuove_voci_non_è_valido
+The\ chosen\ date\ format\ for\ new\ entries\ is\ not\ valid=Il formato di data scelto per le nuove voci non è valido
 
-The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:=La_codifica_scelta_'%0'_non_può_codificare_i_caratteri_seguenti\:
+The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=La codifica scelta '%0' non può codificare i caratteri seguenti:
 
 
-the_field_<b>%0</b>=il_campo_<b>%0</b>
+the\ field\ <b>%0</b>=il campo <b>%0</b>
 
-The_file<BR>'%0'<BR>has_been_modified<BR>externally\!=Il_file_<BR>'%0'<BR>_è_stato_modificato_da_un'applicazione_esterna
+The\ file<BR>'%0'<BR>has\ been\ modified<BR>externally\!=Il file <BR>'%0'<BR> è stato modificato da un'applicazione esterna
 
-The_group_"%0"_already_contains_the_selection.=Il_gruppo_"%0"_contiene_già_la_selezione.
+The\ group\ "%0"\ already\ contains\ the\ selection.=Il gruppo "%0" contiene già la selezione.
 
-The_label_of_the_string_cannot_be_a_number.=L'etichetta_della_stringa_non_può_essere_un_numero.
+The\ label\ of\ the\ string\ cannot\ be\ a\ number.=L'etichetta della stringa non può essere un numero.
 
-The_label_of_the_string_cannot_contain_spaces.=L'etichetta_della_stringa_non_può_contenere_spazi.
+The\ label\ of\ the\ string\ cannot\ contain\ spaces.=L'etichetta della stringa non può contenere spazi.
 
-The_label_of_the_string_cannot_contain_the_'\#'_character.=L'etichetta_della_stringa_non_può_contenere_il_carattere_'\#'
+The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=L'etichetta della stringa non può contenere il carattere '#'
 
-The_output_option_depends_on_a_valid_import_option.=L'opzione_di_output_dipende_da_una_opzione_di_importazione_valida.
-The_PDF_contains_one_or_several_BibTeX-records.=Il_file_PDF_contiene_uno_o_più_record_BibTeX.
-Do_you_want_to_import_these_as_new_entries_into_the_current_library?=Vuoi_importarli_come_nuove_voci_nella_libreria_corrente?
+The\ output\ option\ depends\ on\ a\ valid\ import\ option.=L'opzione di output dipende da una opzione di importazione valida.
+The\ PDF\ contains\ one\ or\ several\ BibTeX-records.=Il file PDF contiene uno o più record BibTeX.
+Do\ you\ want\ to\ import\ these\ as\ new\ entries\ into\ the\ current\ library?=Vuoi importarli come nuove voci nella libreria corrente?
 
-The_regular_expression_<b>%0</b>_is_invalid\:=L'espressione_regolare_<b>%0</b>_non_è_valida\:
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=L'espressione regolare <b>%0</b> non è valida:
 
-The_search_is_case_insensitive.=La_ricerca_non_distingue_maiuscole_e_minuscole.
+The\ search\ is\ case\ insensitive.=La ricerca non distingue maiuscole e minuscole.
 
-The_search_is_case_sensitive.=La_ricerca_distingue_maiuscole_e_minuscole.
+The\ search\ is\ case\ sensitive.=La ricerca distingue maiuscole e minuscole.
 
-The_string_has_been_removed_locally=La_stringa_è_stata_rimossa_localmente
+The\ string\ has\ been\ removed\ locally=La stringa è stata rimossa localmente
 
-There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?=Ci_sono_dei_potenziali_duplicati_(contrassegnati_con_una_icona_'D')_che_non_possono_essere_risolti._Continuare?
+There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=Ci sono dei potenziali duplicati (contrassegnati con una icona 'D') che non possono essere risolti. Continuare?
 
-This_entry_has_no_BibTeX_key._Generate_key_now?=Questa_voce_è_priva_di_una_chiave_BibTeX._Generarla_ora?
+This\ entry\ has\ no\ BibTeX\ key.\ Generate\ key\ now?=Questa voce è priva di una chiave BibTeX. Generarla ora?
 
-This_entry_is_incomplete=La_voce_è_incompleta
+This\ entry\ is\ incomplete=La voce è incompleta
 
-This_entry_type_cannot_be_removed.=Questo_tipo_di_voce_non_può_essere_eliminato.
+This\ entry\ type\ cannot\ be\ removed.=Questo tipo di voce non può essere eliminato.
 
-This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Questo_collegamento_è_di_tipo_'%0',_ancora_indefinito._Cosa_vuoi_fare?
+This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Questo collegamento è di tipo '%0', ancora indefinito. Cosa vuoi fare?
 
-This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.=Questo_gruppo_contiene_voci_assegnate_manualmente._Altre_voci_possono_essere_assegnate_a_questo_gruppo_selezionandole_e_utilizzando_il_menu_contestuale_oppure_trascinandole_nel_gruppo._Le_voci_possono_essere_rimosse_dal_gruppo_selezionandole_e_utilizzando_il_menu_contestuale.
+This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=Questo gruppo contiene voci assegnate manualmente. Altre voci possono essere assegnate a questo gruppo selezionandole e utilizzando il menu contestuale oppure trascinandole nel gruppo. Le voci possono essere rimosse dal gruppo selezionandole e utilizzando il menu contestuale.
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>=Questo_gruppo_contiene_voci_in_cui_il_campo_<b>%0</b>__contiene_la_keyword_<b>%1</b>
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Questo gruppo contiene voci in cui il campo <b>%0</b>  contiene la keyword <b>%1</b>
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>=Questo_gruppo_contiene_voci_in_cui_il_campo_<b>%0</b>__contiene_l'espressione_regolare_<b>%1</b>
-This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.=Per_ciascuno_dei_file_collegamenti,_JabRef_verificherà_l'esistenza_del_file.<BR>In_caso_negativo_proporrà_delle_opzioni_per_la_risoluzione_del_problema.
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Questo gruppo contiene voci in cui il campo <b>%0</b>  contiene l'espressione regolare <b>%1</b>
+This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=Per ciascuno dei file collegamenti, JabRef verificherà l'esistenza del file.<BR>In caso negativo proporrà delle opzioni per la risoluzione del problema.
 
-This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.=Per_questa_operazione_è_necessario_che_tutte_le_voci_selezionate_abbiano_la_chiave_BibTeX_definita
+This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=Per questa operazione è necessario che tutte le voci selezionate abbiano la chiave BibTeX definita
 
-This_operation_requires_one_or_more_entries_to_be_selected.=Per_questa_operazione_una_o_più_voci_devono_essere_selezionate
+This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=Per questa operazione una o più voci devono essere selezionate
 
-Toggle_entry_preview=Mostra/Nascondi_l'anteprima
-Toggle_groups_interface=Mostra/Nascondi_l'interfaccia_dei_gruppi
-Try_different_encoding=Prova_codifiche_differenti
+Toggle\ entry\ preview=Mostra/Nascondi l'anteprima
+Toggle\ groups\ interface=Mostra/Nascondi l'interfaccia dei gruppi
+Try\ different\ encoding=Prova codifiche differenti
 
-Unabbreviate_journal_names_of_the_selected_entries=Mostra_il_nome_completo_delle_riviste_per_le_voci_selezionate
-Unabbreviated_%0_journal_names.=%0_nomi_di_riviste_per_esteso.
+Unabbreviate\ journal\ names\ of\ the\ selected\ entries=Mostra il nome completo delle riviste per le voci selezionate
+Unabbreviated\ %0\ journal\ names.=%0 nomi di riviste per esteso.
 
-Unable_to_open_file.=Impossibile_aprire_il_file
-Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.=Impossibile_aprire_il_collegamento._L'applicazione_'%0'_associata_con_il_tipo_di_file_'%1'_non_può_essere_aperta.
-unable_to_write_to=Impossibile_scrivere_su
-Undefined_file_type=Tipo_di_file_non_definito
+Unable\ to\ open\ file.=Impossibile aprire il file
+Unable\ to\ open\ link.\ The\ application\ '%0'\ associated\ with\ the\ file\ type\ '%1'\ could\ not\ be\ called.=Impossibile aprire il collegamento. L'applicazione '%0' associata con il tipo di file '%1' non può essere aperta.
+unable\ to\ write\ to=Impossibile scrivere su
+Undefined\ file\ type=Tipo di file non definito
 
 Undo=Annulla
 
 Union=Unione
 
-Unknown_BibTeX_entries=Voci_BibTeX_sconosciute
+Unknown\ BibTeX\ entries=Voci BibTeX sconosciute
 
-unknown_edit=modifica_sconosciuta
+unknown\ edit=modifica sconosciuta
 
-Unknown_export_format=Formato_di_esportazione_sconosciuto
+Unknown\ export\ format=Formato di esportazione sconosciuto
 
-Unmark_all=Rimuovi_tutti_i_contrassegni
+Unmark\ all=Rimuovi tutti i contrassegni
 
-Unmark_entries=Rimuovi_i_contrassegni_dalle_voci
+Unmark\ entries=Rimuovi i contrassegni dalle voci
 
-Unmark_entry=Rimuovi_il_contrassegno_dalla_voce
+Unmark\ entry=Rimuovi il contrassegno dalla voce
 
-untitled=senza_titolo
+untitled=senza titolo
 
 Up=Su
 
-Update_to_current_column_widths=Aggiorna_la_larghezza_delle_colonne_ai_valori_correnti
+Update\ to\ current\ column\ widths=Aggiorna la larghezza delle colonne ai valori correnti
 
-Updated_group_selection=Selezione_di_gruppo_aggiornata
-Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.=Aggiornare_i_collegamenti_esterni_PDF/PS_per_utilizzare_il_campo_'%0'.
-Upgrade_file=Aggiornamento_del_file
-Upgrade_old_external_file_links_to_use_the_new_feature=Aggiornare_i_vecchi_collegamenti_ai_file_esterni_per_utilizzare_la_nuova_funzione
+Updated\ group\ selection=Selezione di gruppo aggiornata
+Upgrade\ external\ PDF/PS\ links\ to\ use\ the\ '%0'\ field.=Aggiornare i collegamenti esterni PDF/PS per utilizzare il campo '%0'.
+Upgrade\ file=Aggiornamento del file
+Upgrade\ old\ external\ file\ links\ to\ use\ the\ new\ feature=Aggiornare i vecchi collegamenti ai file esterni per utilizzare la nuova funzione
 
 usage=uso
-Use_autocompletion_for_the_following_fields=Usa_l'autocompletamento_per_i_seguenti_campi
+Use\ autocompletion\ for\ the\ following\ fields=Usa l'autocompletamento per i seguenti campi
 
-Use_other_look_and_feel=Usa_un_altro_"Look-and-Feel"
-Tweak_font_rendering_for_entry_editor_on_Linux=
-Use_regular_expression_search=Ricerca_l'espressione_regolare
+Use\ other\ look\ and\ feel=Usa un altro "Look-and-Feel"
+Tweak\ font\ rendering\ for\ entry\ editor\ on\ Linux=
+Use\ regular\ expression\ search=Ricerca l'espressione regolare
 
 Username=Username
 
-Value_cleared_externally=Valore_cancellato_esternamente
+Value\ cleared\ externally=Valore cancellato esternamente
 
-Value_set_externally=Valore_impostato_esternamente
+Value\ set\ externally=Valore impostato esternamente
 
-verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid=verifica_che_LyX_sia_in_esecuzione_e_che_la_lyxpipe_sia_valida
+verify\ that\ LyX\ is\ running\ and\ that\ the\ lyxpipe\ is\ valid=verifica che LyX sia in esecuzione e che la lyxpipe sia valida
 
 View=Visualizza
-Vim_server_name=Nome_del_server_Vim
+Vim\ server\ name=Nome del server Vim
 
-Waiting_for_ArXiv...=In_attesa_di_ArXiv...
+Waiting\ for\ ArXiv...=In attesa di ArXiv...
 
-Warn_about_unresolved_duplicates_when_closing_inspection_window=Avverti_della_presenza_di_doppioni_non_risolti_alla_chiusura_della_finestra_di_ispezione
+Warn\ about\ unresolved\ duplicates\ when\ closing\ inspection\ window=Avverti della presenza di doppioni non risolti alla chiusura della finestra di ispezione
 
-Warn_before_overwriting_existing_keys=Avverti_prima_di_sovrascrivere_chiavi_esistenti
+Warn\ before\ overwriting\ existing\ keys=Avverti prima di sovrascrivere chiavi esistenti
 
 Warning=Avvertimento
 
 Warnings=Avvertimenti
 
-web_link=collegamenti_Internet
+web\ link=collegamenti Internet
 
-What_do_you_want_to_do?=Cosa_vuoi_fare?
+What\ do\ you\ want\ to\ do?=Cosa vuoi fare?
 
-When_adding/removing_keywords,_separate_them_by=All'aggiunta/rimozione_di_keyword_separarle_con
-Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.=Scrive_i_metadati_XMP_nei_file_PDF_collegati_alle_voci_selezionate
+When\ adding/removing\ keywords,\ separate\ them\ by=All'aggiunta/rimozione di keyword separarle con
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Scrive i metadati XMP nei file PDF collegati alle voci selezionate
 
 with=con
 
-Write_BibTeXEntry_as_XMP-metadata_to_PDF.=Scrivi_voce_BibTeX_come_metadati_XMP_in_un_file_PDF.
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Scrivi voce BibTeX come metadati XMP in un file PDF.
 
-Write_XMP=Scrivi_XMP
-Write_XMP-metadata=Scrivi_i_metadati_XMP
-Write_XMP-metadata_for_all_PDFs_in_current_library?=Scrivere_i_metadati_XMP_per_tutti_i_file_PDF_della_libreria_corrente?
-Writing_XMP-metadata...=Scrittura_dei_metadati_XMP...
-Writing_XMP-metadata_for_selected_entries...=Scrittura_dei_metadati_XMP_per_le_voci_selezionate
+Write\ XMP=Scrivi XMP
+Write\ XMP-metadata=Scrivi i metadati XMP
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Scrivere i metadati XMP per tutti i file PDF della libreria corrente?
+Writing\ XMP-metadata...=Scrittura dei metadati XMP...
+Writing\ XMP-metadata\ for\ selected\ entries...=Scrittura dei metadati XMP per le voci selezionate
 
-Wrote_XMP-metadata=Metadati_XMP_scritti
+Wrote\ XMP-metadata=Metadati XMP scritti
 
-XMP-annotated_PDF=PDF_con_annotazioni_XMP
-XMP_export_privacy_settings=Impostazioni_per_la_riservatezza_dei_dati_XMP_esportati
-XMP-metadata=Metadati_XMP
-XMP-metadata_found_in_PDF\:_%0=Metadati_XMP_trovati_nel_file_PDF\:_%0
-You_must_restart_JabRef_for_this_to_come_into_effect.=Riavviare_JabRef_per_rendere_effettiva_la_modifica.
-You_have_changed_the_language_setting.=La_lingua_è_stata_modificata.
-You_have_entered_an_invalid_search_'%0'.=È_stata_inserita_una_ricerca_non_valida_'%0'.
+XMP-annotated\ PDF=PDF con annotazioni XMP
+XMP\ export\ privacy\ settings=Impostazioni per la riservatezza dei dati XMP esportati
+XMP-metadata=Metadati XMP
+XMP-metadata\ found\ in\ PDF\:\ %0=Metadati XMP trovati nel file PDF: %0
+You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Riavviare JabRef per rendere effettiva la modifica.
+You\ have\ changed\ the\ language\ setting.=La lingua è stata modificata.
+You\ have\ entered\ an\ invalid\ search\ '%0'.=È stata inserita una ricerca non valida '%0'.
 
-You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.=Riavviare_JabRef_per_rendere_operative_le_nuove_assegnazioni_di_tasti.
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Riavviare JabRef per rendere operative le nuove assegnazioni di tasti.
 
-Your_new_key_bindings_have_been_stored.=La_nuova_assegnazione_di_tasti_è_stata_salvata.
+Your\ new\ key\ bindings\ have\ been\ stored.=La nuova assegnazione di tasti è stata salvata.
 
-The_following_fetchers_are_available\:=Le_utilità_di_ricerca_seguenti_sono_disponibili\:
-Could_not_find_fetcher_'%0'=Impossibile_trovare_l'utilità_di_ricerca_'%0'
-Running_query_'%0'_with_fetcher_'%1'.=Esecuzione_della_query_'%0'_con_l'utilità_di_ricerca_'%1'.
-Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.=La_query_'%0'_con_l'utilità_di_ricerca_'%1'_non_ha_prodotto_alcun_risultato.
+The\ following\ fetchers\ are\ available\:=Le utilità di ricerca seguenti sono disponibili:
+Could\ not\ find\ fetcher\ '%0'=Impossibile trovare l'utilità di ricerca '%0'
+Running\ query\ '%0'\ with\ fetcher\ '%1'.=Esecuzione della query '%0' con l'utilità di ricerca '%1'.
+Query\ '%0'\ with\ fetcher\ '%1'\ did\ not\ return\ any\ results.=La query '%0' con l'utilità di ricerca '%1' non ha prodotto alcun risultato.
 
-Move_file=Sposta_file
-Rename_file=Rinomina_il_file
+Move\ file=Sposta file
+Rename\ file=Rinomina il file
 
-Move_file_failed=Spostamento_del_file_fallito
-Could_not_move_file_'%0'.=Impossibile_spostare_il_file_'%0'.
-Could_not_find_file_'%0'.=Impossibile_trovare_il_file_'%0'.
-Number_of_entries_successfully_imported=Numero_di_voci_importate_con_successo
-Import_canceled_by_user=Importazione_interrotta_dall'utente
-Progress\:_%0_of_%1=Stato_d'avanzamento\:_%0_di_%1
-Error_while_fetching_from_%0=Errore_durante_la_ricerca_%0
+Move\ file\ failed=Spostamento del file fallito
+Could\ not\ move\ file\ '%0'.=Impossibile spostare il file '%0'.
+Could\ not\ find\ file\ '%0'.=Impossibile trovare il file '%0'.
+Number\ of\ entries\ successfully\ imported=Numero di voci importate con successo
+Import\ canceled\ by\ user=Importazione interrotta dall'utente
+Progress\:\ %0\ of\ %1=Stato d'avanzamento: %0 di %1
+Error\ while\ fetching\ from\ %0=Errore durante la ricerca %0
 
-Please_enter_a_valid_number=Inserire_un_numero_valido
-Show_search_results_in_a_window=Mostra_i_risultati_della_ricerca_in_una_finestra
-Show_global_search_results_in_a_window=Mostra_i_risultati_della_ricerca_globale_in_una_finestra
-Search_in_all_open_libraries=Cerca_in_tutte_le_librerie_aperte
-Move_file_to_file_directory?=Spostare_i_file_nella_cartella_dei_file_principale?
+Please\ enter\ a\ valid\ number=Inserire un numero valido
+Show\ search\ results\ in\ a\ window=Mostra i risultati della ricerca in una finestra
+Show\ global\ search\ results\ in\ a\ window=Mostra i risultati della ricerca globale in una finestra
+Search\ in\ all\ open\ libraries=Cerca in tutte le librerie aperte
+Move\ file\ to\ file\ directory?=Spostare i file nella cartella dei file principale?
 
-Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.=La_libreria_è_protetta._Le_modifiche_esterne_devono_evvere_state_riviste_prima_di_poter_salvare.
-Protected_library=Libreria_protetta
-Refuse_to_save_the_library_before_external_changes_have_been_reviewed.=Rifiuta_di_salvare_la_libreria_prima_che_le_modifiche_esterne_siano_state_riviste.
-Library_protection=Protezione_della_libreria
-Unable_to_save_library=Impossibile_salvare_la_libreria
+Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=La libreria è protetta. Le modifiche esterne devono evvere state riviste prima di poter salvare.
+Protected\ library=Libreria protetta
+Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=Rifiuta di salvare la libreria prima che le modifiche esterne siano state riviste.
+Library\ protection=Protezione della libreria
+Unable\ to\ save\ library=Impossibile salvare la libreria
 
-BibTeX_key_generator=Generatore_di_chiavi_BibTeX
-Unable_to_open_link.=Impossibile_aprire_il_collegamento.
-Move_the_keyboard_focus_to_the_entry_table=Sposta_il_cursore_nella_tabella_delle_voci
-MIME_type=Tipo_MIME
+BibTeX\ key\ generator=Generatore di chiavi BibTeX
+Unable\ to\ open\ link.=Impossibile aprire il collegamento.
+Move\ the\ keyboard\ focus\ to\ the\ entry\ table=Sposta il cursore nella tabella delle voci
+MIME\ type=Tipo MIME
 
-This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.=Questa_funzione_permette_l'apertura_o_l'importazione_di_nuovi_file_in_una_istanza_di_JabRef_già_aperta<BR>invece_di_aprirne_una_nuova._Per_esempio,_ciò_è_utile_quando_un_file_viene_aperto_in_JabRef<BR>da_un_browser_web.<BR>Questo_tuttavia_impedisce_di_aprire_più_sessioni_di_JabRef_contemporaneamente.
-Run_fetcher,_e.g._"--fetch\=Medline\:cancer"=Lanciare_una_ricerca,_es._"--fetch=Medline\:cancer"
+This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef<BR>instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef<br>from\ your\ web\ browser.<BR>Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=Questa funzione permette l'apertura o l'importazione di nuovi file in una istanza di JabRef già aperta<BR>invece di aprirne una nuova. Per esempio, ciò è utile quando un file viene aperto in JabRef<BR>da un browser web.<BR>Questo tuttavia impedisce di aprire più sessioni di JabRef contemporaneamente.
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=Lanciare una ricerca, es. "--fetch=Medline:cancer"
 
-The_ACM_Digital_Library=ACM_Digital_Library
+The\ ACM\ Digital\ Library=ACM Digital Library
 Reset=Reinizializza
 
-Use_IEEE_LaTeX_abbreviations=Usa_le_abbreviazioni_LaTeX_IEEE
-The_Guide_to_Computing_Literature=The_Guide_to_Computing_Literature
+Use\ IEEE\ LaTeX\ abbreviations=Usa le abbreviazioni LaTeX IEEE
+The\ Guide\ to\ Computing\ Literature=The Guide to Computing Literature
 
-When_opening_file_link,_search_for_matching_file_if_no_link_is_defined=All'apertura_di_un_collegamento_ad_un_file,_ricercare_un_file_corrispondente_se_non_ne_è_definito_uno.
-Settings_for_%0=Parametri__per_%0
-Mark_entries_imported_into_an_existing_library=Contrassegna_le_voci_importate_in_una_libreria_preesistente
-Unmark_all_entries_before_importing_new_entries_into_an_existing_library=Rimuovi_tutti_i_contrassegni_prima_di_importare_nuove_voci_in_una_libreria_preesistente
+When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=All'apertura di un collegamento ad un file, ricercare un file corrispondente se non ne è definito uno.
+Settings\ for\ %0=Parametri  per %0
+Mark\ entries\ imported\ into\ an\ existing\ library=Contrassegna le voci importate in una libreria preesistente
+Unmark\ all\ entries\ before\ importing\ new\ entries\ into\ an\ existing\ library=Rimuovi tutti i contrassegni prima di importare nuove voci in una libreria preesistente
 
 Forward=Successivo
 Back=Precedente
-Sort_the_following_fields_as_numeric_fields=Ordina_i_campi_seguenti_come_campi_numerici
-Line_%0\:_Found_corrupted_BibTeX_key.=Riga_%0\:_chiave_BibTeX_corrotta.
-Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).=Riga_%0\:_chiave_BibTeX_corrotta_(contiene_spazi).
-Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).=Riga_%0\:_chiave_BibTeX_corrotta_(virgola_mancante).
-Full_text_document_download_failed=Fallito_il_download_del_documento_citato
-Update_to_current_column_order=Salvare_l'ordine_delle_colonne_attuale
-Download_from_URL=Scarica_dall'URL
-Rename_field=Rinomina_il_campo
-Set/clear/append/rename_fields=Imposta/svuota/rinomina_i_campi
-Append_field=
-Append_to_fields=
-Rename_field_to=Rinomina_il_campo_in
-Move_contents_of_a_field_into_a_field_with_a_different_name=Sposta_il_contenuto_di_un_campo_in_un_campo_con_nome_diverso
-You_can_only_rename_one_field_at_a_time=È_possibile_rinominare_solo_un_campo_per_volta
+Sort\ the\ following\ fields\ as\ numeric\ fields=Ordina i campi seguenti come campi numerici
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=Riga %0: chiave BibTeX corrotta.
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=Riga %0: chiave BibTeX corrotta (contiene spazi).
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=Riga %0: chiave BibTeX corrotta (virgola mancante).
+Full\ text\ document\ download\ failed=Fallito il download del documento citato
+Update\ to\ current\ column\ order=Salvare l'ordine delle colonne attuale
+Download\ from\ URL=Scarica dall'URL
+Rename\ field=Rinomina il campo
+Set/clear/append/rename\ fields=Imposta/svuota/rinomina i campi
+Append\ field=
+Append\ to\ fields=
+Rename\ field\ to=Rinomina il campo in
+Move\ contents\ of\ a\ field\ into\ a\ field\ with\ a\ different\ name=Sposta il contenuto di un campo in un campo con nome diverso
+You\ can\ only\ rename\ one\ field\ at\ a\ time=È possibile rinominare solo un campo per volta
 
-Remove_all_broken_links=Rimuovere_tutti_i_collegamenti_non_validi
+Remove\ all\ broken\ links=Rimuovere tutti i collegamenti non validi
 
-Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.=Impossibile_utilizzare_la_porta_%0_per_operazioni_remote;_la_porta_potrebbe_essere_in_uso_da_parte_di_un'altra_applicazione._Provare_a_specificare_una_porta_diversa.
+Cannot\ use\ port\ %0\ for\ remote\ operation;\ another\ application\ may\ be\ using\ it.\ Try\ specifying\ another\ port.=Impossibile utilizzare la porta %0 per operazioni remote; la porta potrebbe essere in uso da parte di un'altra applicazione. Provare a specificare una porta diversa.
 
-Looking_for_full_text_document...=Ricerca_del_documento_citato
-Autosave=Salvataggio_automatico
-A_local_copy_will_be_opened.=Verrà_aperta_una_copia_locale.
-Autosave_local_libraries=Salva_automaticamente_le_librerie_locali
-Automatically_save_the_library_to=Salva_automaticamente_la_libreria_come
-Please_enter_a_valid_file_path.=Per_favore_inserisci_un_percorso_di_file_valido.
+Looking\ for\ full\ text\ document...=Ricerca del documento citato
+Autosave=Salvataggio automatico
+A\ local\ copy\ will\ be\ opened.=Verrà aperta una copia locale.
+Autosave\ local\ libraries=Salva automaticamente le librerie locali
+Automatically\ save\ the\ library\ to=Salva automaticamente la libreria come
+Please\ enter\ a\ valid\ file\ path.=Per favore inserisci un percorso di file valido.
 
 
-Export_in_current_table_sort_order=Esportare_nell'ordine_corrente_della_tabella
-Export_entries_in_their_original_order=Esportare_le_voci_nell'ordine_originale
-Error_opening_file_'%0'.=Errore_nell'apertura_del_file_'%0'.
+Export\ in\ current\ table\ sort\ order=Esportare nell'ordine corrente della tabella
+Export\ entries\ in\ their\ original\ order=Esportare le voci nell'ordine originale
+Error\ opening\ file\ '%0'.=Errore nell'apertura del file '%0'.
 
-Formatter_not_found\:_%0=Formattazione_non_trovata\:_%0
-Clear_inputarea=Svuota_l'area_di_inserimento
+Formatter\ not\ found\:\ %0=Formattazione non trovata: %0
+Clear\ inputarea=Svuota l'area di inserimento
 
-Automatically_set_file_links_for_this_entry=Definire_automaticamente_i_collegamenti_ai_file_per_questa_voce
-Could_not_save,_file_locked_by_another_JabRef_instance.=Impossibile_salvare,_il_file_è_bloccato_da_un'altra_istanza_di_JabRef.
-File_is_locked_by_another_JabRef_instance.=Il_file_è_bloccato_da_un'altra_istanza_di_JabRef.
-Do_you_want_to_override_the_file_lock?=Vuoi_ignorare_il_blocco_del_file?
-File_locked=File_bloccato
-Current_tmp_value=Variabile_"tmp"_corrente
-Metadata_change=Modifica_dei_metadati
-Changes_have_been_made_to_the_following_metadata_elements=Sono_stati_modificati_i_seguenti_elementi_dei_metadati
+Automatically\ set\ file\ links\ for\ this\ entry=Definire automaticamente i collegamenti ai file per questa voce
+Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=Impossibile salvare, il file è bloccato da un'altra istanza di JabRef.
+File\ is\ locked\ by\ another\ JabRef\ instance.=Il file è bloccato da un'altra istanza di JabRef.
+Do\ you\ want\ to\ override\ the\ file\ lock?=Vuoi ignorare il blocco del file?
+File\ locked=File bloccato
+Current\ tmp\ value=Variabile "tmp" corrente
+Metadata\ change=Modifica dei metadati
+Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=Sono stati modificati i seguenti elementi dei metadati
 
-Generate_groups_for_author_last_names=Genera_gruppi_in_base_al_cognome_dell'autore
-Generate_groups_from_keywords_in_a_BibTeX_field=Genera_gruppi_in_base_alle_parole_chiave_in_un_campo_BibTeX
-Enforce_legal_characters_in_BibTeX_keys=Imponi_l'utilizzo_dei_soli_caratteri_conformi_alla_sintassi_nelle_chiavi_BibTeX
+Generate\ groups\ for\ author\ last\ names=Genera gruppi in base al cognome dell'autore
+Generate\ groups\ from\ keywords\ in\ a\ BibTeX\ field=Genera gruppi in base alle parole chiave in un campo BibTeX
+Enforce\ legal\ characters\ in\ BibTeX\ keys=Imponi l'utilizzo dei soli caratteri conformi alla sintassi nelle chiavi BibTeX
 
-Save_without_backup?=Salvare_senza_backup?
-Unable_to_create_backup=Impossibile_creare_un_backup
-Move_file_to_file_directory=Sposta_il_file_nella_cartella_dei_file
-Rename_file_to=Rinomina_il_file_in
-<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)=<b>Tutte_le_voci</b>_(questo_gruppo_non_può_essere_modificato_o_rimosso)
-static_group=gruppo_statico
-dynamic_group=gruppo_dinamico
-refines_supergroup=ridefinisce_il_super-gruppo
-includes_subgroups=include_il_super-gruppo
+Save\ without\ backup?=Salvare senza backup?
+Unable\ to\ create\ backup=Impossibile creare un backup
+Move\ file\ to\ file\ directory=Sposta il file nella cartella dei file
+Rename\ file\ to=Rinomina il file in
+<b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=<b>Tutte le voci</b> (questo gruppo non può essere modificato o rimosso)
+static\ group=gruppo statico
+dynamic\ group=gruppo dinamico
+refines\ supergroup=ridefinisce il super-gruppo
+includes\ subgroups=include il super-gruppo
 contains=contiene
-search_expression=espressione_di_ricerca
+search\ expression=espressione di ricerca
 
-Optional_fields_2=Campi_opzionali_2
-Waiting_for_save_operation_to_finish=In_attesa_del_termine_del_salvataggio
-Resolving_duplicate_BibTeX_keys...=Risoluzione_delle_chiavi_BibTeX_duplicate...
-Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.=Terminata_la_risoluzione_delle_chiavi_BibTeX_duplicate._%0_voci_modificate.
-This_library_contains_one_or_more_duplicated_BibTeX_keys.=Questa_libreria_contiene_una_o_più_chiavi_BibTeX_duplicate.
-Do_you_want_to_resolve_duplicate_keys_now?=Vuoi_effettuare_la_risoluzione_delle_chiavi_duplicate_ora?
+Optional\ fields\ 2=Campi opzionali 2
+Waiting\ for\ save\ operation\ to\ finish=In attesa del termine del salvataggio
+Resolving\ duplicate\ BibTeX\ keys...=Risoluzione delle chiavi BibTeX duplicate...
+Finished\ resolving\ duplicate\ BibTeX\ keys.\ %0\ entries\ modified.=Terminata la risoluzione delle chiavi BibTeX duplicate. %0 voci modificate.
+This\ library\ contains\ one\ or\ more\ duplicated\ BibTeX\ keys.=Questa libreria contiene una o più chiavi BibTeX duplicate.
+Do\ you\ want\ to\ resolve\ duplicate\ keys\ now?=Vuoi effettuare la risoluzione delle chiavi duplicate ora?
 
-Find_and_remove_duplicate_BibTeX_keys=Trova_e_rimuovi_le_chiavi_BibTeX_duplicate
-Expected_syntax_for_--fetch\='<name_of_fetcher>\:<query>'=Sintassi_attesa_per_--fetch='<name_of_fetcher>\:<query>'
-Duplicate_BibTeX_key=Chiave_BibTeX_duplicata
-Import_marking_color=Colore_per_contrassegnare_le_voci_importate
-Always_add_letter_(a,_b,_...)_to_generated_keys=Aggiungi_sempre_una_lettera_(a,_b,_...)_alle_chiavi_generate
+Find\ and\ remove\ duplicate\ BibTeX\ keys=Trova e rimuovi le chiavi BibTeX duplicate
+Expected\ syntax\ for\ --fetch\='<name\ of\ fetcher>\:<query>'=Sintassi attesa per --fetch='<name of fetcher>:<query>'
+Duplicate\ BibTeX\ key=Chiave BibTeX duplicata
+Import\ marking\ color=Colore per contrassegnare le voci importate
+Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=Aggiungi sempre una lettera (a, b, ...) alle chiavi generate
 
-Ensure_unique_keys_using_letters_(a,_b,_...)=Assicura_l'unicità_delle_chiavi_con_l'uso_di_lettere_(a,_b,_...)
-Ensure_unique_keys_using_letters_(b,_c,_...)=Assicura_l'unicità_delle_chiavi_con_l'uso_di_lettere_(b,_c,_...)
-Entry_editor_active_background_color=Colore_dello_sfondo_quando_attivo_l'editor_delle_voci
-Entry_editor_background_color=Colore_dello_sfondo_dell'editor_delle_voci
-Entry_editor_font_color=Colore_del_font_dell'editor_delle_voci
-Entry_editor_invalid_field_color=Colore_del_campo_non_valido_nell'editor_delle_voci
+Ensure\ unique\ keys\ using\ letters\ (a,\ b,\ ...)=Assicura l'unicità delle chiavi con l'uso di lettere (a, b, ...)
+Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=Assicura l'unicità delle chiavi con l'uso di lettere (b, c, ...)
+Entry\ editor\ active\ background\ color=Colore dello sfondo quando attivo l'editor delle voci
+Entry\ editor\ background\ color=Colore dello sfondo dell'editor delle voci
+Entry\ editor\ font\ color=Colore del font dell'editor delle voci
+Entry\ editor\ invalid\ field\ color=Colore del campo non valido nell'editor delle voci
 
-Table_and_entry_editor_colors=Colori_della_tabella_e_dell'editor_delle_voci
+Table\ and\ entry\ editor\ colors=Colori della tabella e dell'editor delle voci
 
-General_file_directory=Cartella_dei_file_generale
-User-specific_file_directory=Cartella_dei_file_specifica_dell'utente
-Search_failed\:_illegal_search_expression=Ricerca_fallita\:_espressione_di_ricerca_illegale
-Show_ArXiv_column=Mostra_la_colonna_ArXiv
+General\ file\ directory=Cartella dei file generale
+User-specific\ file\ directory=Cartella dei file specifica dell'utente
+Search\ failed\:\ illegal\ search\ expression=Ricerca fallita: espressione di ricerca illegale
+Show\ ArXiv\ column=Mostra la colonna ArXiv
 
-You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for=È_necessario_inserire_un_intero_nell'intervallo_1025-65535_nel_campo_di_testo_per
-Automatically_open_browse_dialog_when_creating_new_file_link=Apri_automaticamente_la_finestra_di_dialogo_"Sfoglia"_quando_viene_creato_un_nuovo_collegamento_ad_un_file
-Import_metadata_from\:=Importa_i_Metadati_da\:
-Choose_the_source_for_the_metadata_import=Scegli_la_sorgente_dei_metadati_da_importare
-Create_entry_based_on_XMP-metadata=Crea_una_nuova_voce_in_base_ai_dati_XMP
-Create_blank_entry_linking_the_PDF=Crea_una_voce_vuota_collegata_al_file_PDF
-Only_attach_PDF=Allega_solo_il_file_PDF
+You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=È necessario inserire un intero nell'intervallo 1025-65535 nel campo di testo per
+Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Apri automaticamente la finestra di dialogo "Sfoglia" quando viene creato un nuovo collegamento ad un file
+Import\ metadata\ from\:=Importa i Metadati da:
+Choose\ the\ source\ for\ the\ metadata\ import=Scegli la sorgente dei metadati da importare
+Create\ entry\ based\ on\ XMP-metadata=Crea una nuova voce in base ai dati XMP
+Create\ blank\ entry\ linking\ the\ PDF=Crea una voce vuota collegata al file PDF
+Only\ attach\ PDF=Allega solo il file PDF
 Title=Titolo
-Create_new_entry=Crea_una_nuova_voce
-Update_existing_entry=Aggiorna_la_voce_esistente
-Autocomplete_names_in_'Firstname_Lastname'_format_only=Autocompletamento_dei_nomi_solo_nel_formato_'Firstname_Lastname'
-Autocomplete_names_in_'Lastname,_Firstname'_format_only=Autocompletamento_dei_nomi_solo_nel_formato_'Lastname,_Firstname'
-Autocomplete_names_in_both_formats=Autocompletamento_dei_nomi_in_entrambi_i_formati
-Marking_color_%0=Colore_di_contrassegno_%0
-The_name_'comment'_cannot_be_used_as_an_entry_type_name.=Il_nome_'comment'_non_può_essere_utilizzato_come_nome_di_tipo_di_voce.
-You_must_enter_an_integer_value_in_the_text_field_for=Inserire_un_numero_intero_nel_campo_di_testo_per
-Send_as_email=Invia_come_email
+Create\ new\ entry=Crea una nuova voce
+Update\ existing\ entry=Aggiorna la voce esistente
+Autocomplete\ names\ in\ 'Firstname\ Lastname'\ format\ only=Autocompletamento dei nomi solo nel formato 'Firstname Lastname'
+Autocomplete\ names\ in\ 'Lastname,\ Firstname'\ format\ only=Autocompletamento dei nomi solo nel formato 'Lastname, Firstname'
+Autocomplete\ names\ in\ both\ formats=Autocompletamento dei nomi in entrambi i formati
+Marking\ color\ %0=Colore di contrassegno %0
+The\ name\ 'comment'\ cannot\ be\ used\ as\ an\ entry\ type\ name.=Il nome 'comment' non può essere utilizzato come nome di tipo di voce.
+You\ must\ enter\ an\ integer\ value\ in\ the\ text\ field\ for=Inserire un numero intero nel campo di testo per
+Send\ as\ email=Invia come email
 References=Riferimenti
-Sending_of_emails=Invio_di_email
-Subject_for_sending_an_email_with_references=Oggetto_per_l'invio_di_email_con_riferimenti
-Automatically_open_folders_of_attached_files=Apri_automaticamente_le_cartelle_dei_file_allegati
-Create_entry_based_on_content=Crea_una_voce_in_base_al_contenuto
-Do_not_show_this_box_again_for_this_import=Non_mostrare_nuovamente_questo_dialogo_per_questa_importazione
-Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)=Usa_sempre_questa_modalità_di_importazione_PDF_(non_chiedere_per_ogni_importazione)
-Error_creating_email=Errore_nella_creazione_della_email
-Entries_added_to_an_email=Voci_aggiunte_ad_un'email
-exportFormat=Formato_di_esportazione
-Output_file_missing=File_di_output_mancante
-No_search_matches.=Nessuna_corrispondenza_per_la_ricerca.
-The_output_option_depends_on_a_valid_input_option.=L'opzione_di_output_dipende_da_un'opzione_di_input_valida.
-Default_import_style_for_drag_and_drop_of_PDFs=Modalità_di_importazione_predefinita_per_il_drag_and_drop_dei_file_PDF
-Default_PDF_file_link_action=Azione_predefinita_per_il_collegamento_ai_file_PDF
-Filename_format_pattern=Modello_del_formato_dei_nomi_dei_file
-Additional_parameters=Parametri_addizionali
-Cite_selected_entries_between_parenthesis=Cita_le_voci_selezionate
-Cite_selected_entries_with_in-text_citation=Cita_le_voci_selezionate_con_citazione_inclusa_nel_testo
-Cite_special=Citazione_speciale
-Extra_information_(e.g._page_number)=Informazione_aggiuntiva_(es._numero_di_pagina)
-Manage_citations=Gestione_delle_citazioni
-Problem_modifying_citation=Problema_nella_modifica_della_citazione
+Sending\ of\ emails=Invio di email
+Subject\ for\ sending\ an\ email\ with\ references=Oggetto per l'invio di email con riferimenti
+Automatically\ open\ folders\ of\ attached\ files=Apri automaticamente le cartelle dei file allegati
+Create\ entry\ based\ on\ content=Crea una voce in base al contenuto
+Do\ not\ show\ this\ box\ again\ for\ this\ import=Non mostrare nuovamente questo dialogo per questa importazione
+Always\ use\ this\ PDF\ import\ style\ (and\ do\ not\ ask\ for\ each\ import)=Usa sempre questa modalità di importazione PDF (non chiedere per ogni importazione)
+Error\ creating\ email=Errore nella creazione della email
+Entries\ added\ to\ an\ email=Voci aggiunte ad un'email
+exportFormat=Formato di esportazione
+Output\ file\ missing=File di output mancante
+No\ search\ matches.=Nessuna corrispondenza per la ricerca.
+The\ output\ option\ depends\ on\ a\ valid\ input\ option.=L'opzione di output dipende da un'opzione di input valida.
+Default\ import\ style\ for\ drag\ and\ drop\ of\ PDFs=Modalità di importazione predefinita per il drag and drop dei file PDF
+Default\ PDF\ file\ link\ action=Azione predefinita per il collegamento ai file PDF
+Filename\ format\ pattern=Modello del formato dei nomi dei file
+Additional\ parameters=Parametri addizionali
+Cite\ selected\ entries\ between\ parenthesis=Cita le voci selezionate
+Cite\ selected\ entries\ with\ in-text\ citation=Cita le voci selezionate con citazione inclusa nel testo
+Cite\ special=Citazione speciale
+Extra\ information\ (e.g.\ page\ number)=Informazione aggiuntiva (es. numero di pagina)
+Manage\ citations=Gestione delle citazioni
+Problem\ modifying\ citation=Problema nella modifica della citazione
 Citation=Citazione
-Extra_information=Informazione_aggiuntiva
-Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.=Impossibile_risolvere_la_voce_BibTeX_per_l'identificativo_di_citazione_'%0'.
-Select_style=Seleziona_stile
+Extra\ information=Informazione aggiuntiva
+Could\ not\ resolve\ BibTeX\ entry\ for\ citation\ marker\ '%0'.=Impossibile risolvere la voce BibTeX per l'identificativo di citazione '%0'.
+Select\ style=Seleziona stile
 Journals=Riviste
 Cite=Cita
-Cite_in-text=Citazione_inclusa_nel_testo
-Insert_empty_citation=Inserisci_una_citazione_vuota
-Merge_citations=Accorpa_citazioni
-Manual_connect=Connessione_manuale
-Select_Writer_document=Selezionare_il_documento_Writer
-Sync_OpenOffice/LibreOffice_bibliography=Sincronizza_la_bibliografia_OpenOffice/LibreOffice
-Select_which_open_Writer_document_to_work_on=Selezionare_il_documento_Writer_aperto_su_cui_lavorare
-Connected_to_document=Connesso_al_documento
-Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)=Inserire_una_citazione_senza_testo_(la_voce_comparirà_nella_lista_dei_riferimenti)
-Cite_selected_entries_with_extra_information=Cita_le_voci_selezionate_con_informazioni_aggiuntive
-Ensure_that_the_bibliography_is_up-to-date=Assicura_che_la_bibliografia_sia_aggiornata
-Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.=Il_tuo_documento_OpenOffice/LibreOffice_fa_riferimento_alla_chiave_BibTeX_'%0',_non_presente_nella_libreria_corrente.
-Unable_to_synchronize_bibliography=Impossiblile_sincronizzare_la_bibliografia
-Combine_pairs_of_citations_that_are_separated_by_spaces_only=Combina_le_coppie_di_citazioni_separate_solo_da_spazi
-Autodetection_failed=Autorilevamento_non_riuscito
-Connecting=Connessione_in_corso
-Please_wait...=Attendere...
-Set_connection_parameters=Imposta_i_parametri_di_connessione
-Path_to_OpenOffice/LibreOffice_directory=Percorso_per_la_cartella_OpenOffice/LibreOffice
-Path_to_OpenOffice/LibreOffice_executable=Percorso_per_il_file_eseguibile_OpenOffice/LibreOffice
-Path_to_OpenOffice/LibreOffice_library_dir=Percorso_per_la_cartella_della_libreria_OpenOffice/LibreOffice
-Connection_lost=Connessione_perduta
-The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.=Il_formato_del_paragrafo_è_controllato_dalle_proprietà_'ReferenceParagraphFormat'_o_'ReferenceHeaderParagraphFormat'_nel_file_di_stile.
-The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.=Il_formato_del_carattere_è_controllato_dalla_proprietà_della_citazione_'CitationCharacterFormat'_nel_file_di_stile.
-Automatically_sync_bibliography_when_inserting_citations=Sincronizza_automaticamente_la_bibliografia_all'inserimento_delle_citazioni
-Look_up_BibTeX_entries_in_the_active_tab_only=Ricerca_le_voci_BibTeX_solo_nella_scheda_attiva
-Look_up_BibTeX_entries_in_all_open_libraries=Ricerca_le_voci_BibTeX_in_tutte_le_librerie_aperte
-Autodetecting_paths...=Autorilevamento_dei_percorsi...
-Could_not_find_OpenOffice/LibreOffice_installation=Impossibile_trovare_l'installazione_OpenOffice/LibreOffice
-Found_more_than_one_OpenOffice/LibreOffice_executable.=Trovati_più_di_un_file_eseguibile_OpenOffice/LibreOffice.
-Please_choose_which_one_to_connect_to\:=Selezionare_quello_al_quale_connettersi\:
-Choose_OpenOffice/LibreOffice_executable=Scegliere_file_eseguibile_OpenOffice/LibreOffice
-Select_document=Selezionare_il_documento
-HTML_list=Lista_HTML
-If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting=Se_possiblile,_normalizzare_questa_lista_di_nomi_in_accordo_con_lo_standard_di_formattazione_dei_nomi_BibTeX
-Could_not_open_%0=Impossiblie_aprire_%0
-Unknown_import_format=Formato_di_importazione_sconosciuto
-Web_search=Ricerca_sul_Web
-Style_selection=Selezione_dello_stile
-No_valid_style_file_defined=Nessun_file_di_stile_valido_definito
-Choose_pattern=Sceglire_un_modello
-Use_the_BIB_file_location_as_primary_file_directory=Utilizza_la_posizione_del_file_BibTeX_come_cartella_dei_file_principale
-Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.=Impossibile_eseguire_il_programma_gnuclient/emacsclient._Assicurarsi_che_il_programma_gnuclient/emacsclient_sia_installato_e_disponibile_nel_PATH.
-OpenOffice/LibreOffice_connection=Connessione_a_OpenOffice/LibreOffice
-You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.=Selezionare_un_file_di_stile_valido_oppure_utilizzare_uno_degli_stili_predefiniti.
+Cite\ in-text=Citazione inclusa nel testo
+Insert\ empty\ citation=Inserisci una citazione vuota
+Merge\ citations=Accorpa citazioni
+Manual\ connect=Connessione manuale
+Select\ Writer\ document=Selezionare il documento Writer
+Sync\ OpenOffice/LibreOffice\ bibliography=Sincronizza la bibliografia OpenOffice/LibreOffice
+Select\ which\ open\ Writer\ document\ to\ work\ on=Selezionare il documento Writer aperto su cui lavorare
+Connected\ to\ document=Connesso al documento
+Insert\ a\ citation\ without\ text\ (the\ entry\ will\ appear\ in\ the\ reference\ list)=Inserire una citazione senza testo (la voce comparirà nella lista dei riferimenti)
+Cite\ selected\ entries\ with\ extra\ information=Cita le voci selezionate con informazioni aggiuntive
+Ensure\ that\ the\ bibliography\ is\ up-to-date=Assicura che la bibliografia sia aggiornata
+Your\ OpenOffice/LibreOffice\ document\ references\ the\ BibTeX\ key\ '%0',\ which\ could\ not\ be\ found\ in\ your\ current\ library.=Il tuo documento OpenOffice/LibreOffice fa riferimento alla chiave BibTeX '%0', non presente nella libreria corrente.
+Unable\ to\ synchronize\ bibliography=Impossiblile sincronizzare la bibliografia
+Combine\ pairs\ of\ citations\ that\ are\ separated\ by\ spaces\ only=Combina le coppie di citazioni separate solo da spazi
+Autodetection\ failed=Autorilevamento non riuscito
+Connecting=Connessione in corso
+Please\ wait...=Attendere...
+Set\ connection\ parameters=Imposta i parametri di connessione
+Path\ to\ OpenOffice/LibreOffice\ directory=Percorso per la cartella OpenOffice/LibreOffice
+Path\ to\ OpenOffice/LibreOffice\ executable=Percorso per il file eseguibile OpenOffice/LibreOffice
+Path\ to\ OpenOffice/LibreOffice\ library\ dir=Percorso per la cartella della libreria OpenOffice/LibreOffice
+Connection\ lost=Connessione perduta
+The\ paragraph\ format\ is\ controlled\ by\ the\ property\ 'ReferenceParagraphFormat'\ or\ 'ReferenceHeaderParagraphFormat'\ in\ the\ style\ file.=Il formato del paragrafo è controllato dalle proprietà 'ReferenceParagraphFormat' o 'ReferenceHeaderParagraphFormat' nel file di stile.
+The\ character\ format\ is\ controlled\ by\ the\ citation\ property\ 'CitationCharacterFormat'\ in\ the\ style\ file.=Il formato del carattere è controllato dalla proprietà della citazione 'CitationCharacterFormat' nel file di stile.
+Automatically\ sync\ bibliography\ when\ inserting\ citations=Sincronizza automaticamente la bibliografia all'inserimento delle citazioni
+Look\ up\ BibTeX\ entries\ in\ the\ active\ tab\ only=Ricerca le voci BibTeX solo nella scheda attiva
+Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=Ricerca le voci BibTeX in tutte le librerie aperte
+Autodetecting\ paths...=Autorilevamento dei percorsi...
+Could\ not\ find\ OpenOffice/LibreOffice\ installation=Impossibile trovare l'installazione OpenOffice/LibreOffice
+Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=Trovati più di un file eseguibile OpenOffice/LibreOffice.
+Please\ choose\ which\ one\ to\ connect\ to\:=Selezionare quello al quale connettersi:
+Choose\ OpenOffice/LibreOffice\ executable=Scegliere file eseguibile OpenOffice/LibreOffice
+Select\ document=Selezionare il documento
+HTML\ list=Lista HTML
+If\ possible,\ normalize\ this\ list\ of\ names\ to\ conform\ to\ standard\ BibTeX\ name\ formatting=Se possiblile, normalizzare questa lista di nomi in accordo con lo standard di formattazione dei nomi BibTeX
+Could\ not\ open\ %0=Impossiblie aprire %0
+Unknown\ import\ format=Formato di importazione sconosciuto
+Web\ search=Ricerca sul Web
+Style\ selection=Selezione dello stile
+No\ valid\ style\ file\ defined=Nessun file di stile valido definito
+Choose\ pattern=Sceglire un modello
+Use\ the\ BIB\ file\ location\ as\ primary\ file\ directory=Utilizza la posizione del file BibTeX come cartella dei file principale
+Could\ not\ run\ the\ gnuclient/emacsclient\ program.\ Make\ sure\ you\ have\ the\ emacsclient/gnuclient\ program\ installed\ and\ available\ in\ the\ PATH.=Impossibile eseguire il programma gnuclient/emacsclient. Assicurarsi che il programma gnuclient/emacsclient sia installato e disponibile nel PATH.
+OpenOffice/LibreOffice\ connection=Connessione a OpenOffice/LibreOffice
+You\ must\ select\ either\ a\ valid\ style\ file,\ or\ use\ one\ of\ the\ default\ styles.=Selezionare un file di stile valido oppure utilizzare uno degli stili predefiniti.
 
-This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.=Questo_è_un_semplice_dialogo_di_copia_e_incolla._Prima_carica_o_incolla_il_testo_nell'area_di_inserimento_di_testo.<BR>Quindi_è_possibile_selezionare_parti_del_testo_e_assegnarle_ai_campi_BibTeX.
-This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.=Questa_funzione_genera_una_nuova_libreria_basata_sulle_voci_necessarie_in_un_documento_LaTeX_esistente.
-You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.=È_necessario_selezionare_una_delle_librerie_aperte_da_cui_scegliere_le_voci,_così_come_il_file_AUX_prodotto_da_LaTeX_nel_compilare_il_documento.
+This\ is\ a\ simple\ copy\ and\ paste\ dialog.\ First\ load\ or\ paste\ some\ text\ into\ the\ text\ input\ area.<br>After\ that,\ you\ can\ mark\ text\ and\ assign\ it\ to\ a\ BibTeX\ field.=Questo è un semplice dialogo di copia e incolla. Prima carica o incolla il testo nell'area di inserimento di testo.<BR>Quindi è possibile selezionare parti del testo e assegnarle ai campi BibTeX.
+This\ feature\ generates\ a\ new\ library\ based\ on\ which\ entries\ are\ needed\ in\ an\ existing\ LaTeX\ document.=Questa funzione genera una nuova libreria basata sulle voci necessarie in un documento LaTeX esistente.
+You\ need\ to\ select\ one\ of\ your\ open\ libraries\ from\ which\ to\ choose\ entries,\ as\ well\ as\ the\ AUX\ file\ produced\ by\ LaTeX\ when\ compiling\ your\ document.=È necessario selezionare una delle librerie aperte da cui scegliere le voci, così come il file AUX prodotto da LaTeX nel compilare il documento.
 
-First_select_entries_to_clean_up.=Selezionare_le_voci_da_ripulire.
-Cleanup_entry=Ripulisci_voce
-Autogenerate_PDF_Names=Genera_automaticamente_i_nomi_dei_file_PDF
-Auto-generating_PDF-Names_does_not_support_undo._Continue?=La_generazione_automatica_dei_nomi_dei_file_PDF_non_può_essere_annullata._Continuare?
+First\ select\ entries\ to\ clean\ up.=Selezionare le voci da ripulire.
+Cleanup\ entry=Ripulisci voce
+Autogenerate\ PDF\ Names=Genera automaticamente i nomi dei file PDF
+Auto-generating\ PDF-Names\ does\ not\ support\ undo.\ Continue?=La generazione automatica dei nomi dei file PDF non può essere annullata. Continuare?
 
-Use_full_firstname_whenever_possible=Usa_nome_completo_quando_possibile
-Use_abbreviated_firstname_whenever_possible=Usa_nome_abbreviato_quando_possibile
-Use_abbreviated_and_full_firstname=Usa_nome_abbreviato_e_completo
-Autocompletion_options=Opzioni_di_autocompletamento
-Name_format_used_for_autocompletion=Formato_dei_nomi_usato_per_l'autocompletamento
-Treatment_of_first_names=Gestione_dei_nomi
-Cleanup_entries=Ripulisci_voci
-Automatically_assign_new_entry_to_selected_groups=Assegna_automaticamente_la_nuova_voce_ai_gruppi_selezionati
-%0_mode=modalità_%0
-Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix=Sposta_i_DOI_dai_campi_note_e_URL_al_campo_DOI_e_rimuovi_il_prefisso_'http'
-Make_paths_of_linked_files_relative_(if_possible)=Rendi_relativi_i_percorsi_dei_file_collegati_(se_possibile)
-Rename_PDFs_to_given_filename_format_pattern=Rinomina_i_file_PDF_secondo_il_modello_di_nome_dei_file
-Rename_only_PDFs_having_a_relative_path=Rinomina_solo_i_file_PDF_con_un_percorso_relativo
-What_would_you_like_to_clean_up?=Cosa_si_vuole_ripulire?
-Doing_a_cleanup_for_%0_entries...=Ripulitura_per_%0_voci...
-No_entry_needed_a_clean_up=Nessuna_voce_necessita_ripulitura
-One_entry_needed_a_clean_up=Una_voce_necessita_ripulitura
-%0_entries_needed_a_clean_up=%0_voci_necessitano_ripulitura
+Use\ full\ firstname\ whenever\ possible=Usa nome completo quando possibile
+Use\ abbreviated\ firstname\ whenever\ possible=Usa nome abbreviato quando possibile
+Use\ abbreviated\ and\ full\ firstname=Usa nome abbreviato e completo
+Autocompletion\ options=Opzioni di autocompletamento
+Name\ format\ used\ for\ autocompletion=Formato dei nomi usato per l'autocompletamento
+Treatment\ of\ first\ names=Gestione dei nomi
+Cleanup\ entries=Ripulisci voci
+Automatically\ assign\ new\ entry\ to\ selected\ groups=Assegna automaticamente la nuova voce ai gruppi selezionati
+%0\ mode=modalità %0
+Move\ DOIs\ from\ note\ and\ URL\ field\ to\ DOI\ field\ and\ remove\ http\ prefix=Sposta i DOI dai campi note e URL al campo DOI e rimuovi il prefisso 'http'
+Make\ paths\ of\ linked\ files\ relative\ (if\ possible)=Rendi relativi i percorsi dei file collegati (se possibile)
+Rename\ PDFs\ to\ given\ filename\ format\ pattern=Rinomina i file PDF secondo il modello di nome dei file
+Rename\ only\ PDFs\ having\ a\ relative\ path=Rinomina solo i file PDF con un percorso relativo
+What\ would\ you\ like\ to\ clean\ up?=Cosa si vuole ripulire?
+Doing\ a\ cleanup\ for\ %0\ entries...=Ripulitura per %0 voci...
+No\ entry\ needed\ a\ clean\ up=Nessuna voce necessita ripulitura
+One\ entry\ needed\ a\ clean\ up=Una voce necessita ripulitura
+%0\ entries\ needed\ a\ clean\ up=%0 voci necessitano ripulitura
 
-Remove_selected=Rimuovi_la_selezione
+Remove\ selected=Rimuovi la selezione
 
-Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.=Impossibile_analizzare_l'albero_dei_gruppi._Salvando_la_libreria_BibTeX_i_gruppi_saranno_persi.
-Attach_file=Allega_file
-Setting_all_preferences_to_default_values.=Imposta_tutte_le_preferenze_ai_valori_predefiniti.
-Resetting_preference_key_'%0'=Reimposta_la_chiave_delle_preferenze_'%0'
-Unknown_preference_key_'%0'=Chiave_delle_preferenze_sconosciuta_'%0'
-Unable_to_clear_preferences.=Impossibile_reimpostatare_le_preferenze.
+Group\ tree\ could\ not\ be\ parsed.\ If\ you\ save\ the\ BibTeX\ library,\ all\ groups\ will\ be\ lost.=Impossibile analizzare l'albero dei gruppi. Salvando la libreria BibTeX i gruppi saranno persi.
+Attach\ file=Allega file
+Setting\ all\ preferences\ to\ default\ values.=Imposta tutte le preferenze ai valori predefiniti.
+Resetting\ preference\ key\ '%0'=Reimposta la chiave delle preferenze '%0'
+Unknown\ preference\ key\ '%0'=Chiave delle preferenze sconosciuta '%0'
+Unable\ to\ clear\ preferences.=Impossibile reimpostatare le preferenze.
 
-Reset_preferences_(key1,key2,..._or_'all')=Reimposta_le_preferenze_(chiave1,chiave2,..._oppure_'all')
-Find_unlinked_files=Trovati_file_non_collegati
-Unselect_all=Deseleziona_tutto
-Expand_all=Espandi_tutto
-Collapse_all=Comprimi_tutto
-Opens_the_file_browser.=Apre_il_dialogo_di_selezione_dei_file.
-Scan_directory=Analizza_la_cartella
-Searches_the_selected_directory_for_unlinked_files.=Ricerca_nella_cartella_selezionata_file_non_collegati.
-Starts_the_import_of_BibTeX_entries.=Inizia_l'importazione_delle_voci_BibTeX
-Leave_this_dialog.=Abbandona_questo_dialogo.
-Create_directory_based_keywords=Crea_parole_chiave_in_base_al_nome_delle_cartelle
-Creates_keywords_in_created_entrys_with_directory_pathnames=Crea_parole_chiave_nelle_voci_generate_in_base_al_percorso_delle_cartelle
-Select_a_directory_where_the_search_shall_start.=Seleziona_una_cartella_dalla_quale_iniziare_la_ricerca.
-Select_file_type\:=Seleziona_il_tipo_di_file\:
-These_files_are_not_linked_in_the_active_library.=Questi_file_non_sono_collegati_nella_libreria_attiva.
-Entry_type_to_be_created\:=Tipo_di_voci_da_creare\:
-Searching_file_system...=Ricerca_nel_filesystem...
-Importing_into_Library...=Importazione_nella_libreria
-Select_directory=Seleziona_cartella
-Select_files=Seleziona_file
-BibTeX_entry_creation=Creazione_della_voce_BibTeX
-<No_selection>=<Nessuna_selezione>
-Unable_to_connect_to_FreeCite_online_service.=Impossibile_connettersi_al_servizio_online_FreeCite.
-Parse_with_FreeCite=Analizza_con_FreeCite
-The_current_BibTeX_key_will_be_overwritten._Continue?=La_chiave_BibTeX_corrente_sarà_sovrascritta._Continuare?
-Overwrite_key=Sovrascrivi_chiave
-Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator=Le_chiavi_esistenti_non_vengono_sovrascritte._Per_cambiare_questa_impostazione,_aprire_Opzioni_->_Preferenze_->_Generatore_di_chiavi_BibTeX
-How_would_you_like_to_link_to_'%0'?=Come_vuoi_collegare_a_'%0'?
-BibTeX_key_patterns=Modelli_delle_chiavi_BibTeX
-Changed_special_field_settings=Cambiate_le_impostazioni_dei_campi_speciali
-Clear_priority=Azzera_le_priorità
-Clear_rank=Azzera_la_valutazione
-Enable_special_fields=Abilita_campi_speciali
-One_star=Una_stella
-Two_stars=Due_stelle
-Three_stars=Tre_stelle
-Four_stars=Quattro_stelle
-Five_stars=Cinque_stelle
-Help_on_special_fields=Aiuto_sui_campi_speciali
-Keywords_of_selected_entries=Parole_chiave_delle_voci_selezionate
-Manage_content_selectors=Gestione_dei_selettori_dei_contenuti
-Manage_keywords=Gestione_delle_parole_chiave
-No_priority_information=Nessuna_informazione_di_priorità
-No_rank_information=Nessuna_informazione_sulla_valutazione
+Reset\ preferences\ (key1,key2,...\ or\ 'all')=Reimposta le preferenze (chiave1,chiave2,... oppure 'all')
+Find\ unlinked\ files=Trovati file non collegati
+Unselect\ all=Deseleziona tutto
+Expand\ all=Espandi tutto
+Collapse\ all=Comprimi tutto
+Opens\ the\ file\ browser.=Apre il dialogo di selezione dei file.
+Scan\ directory=Analizza la cartella
+Searches\ the\ selected\ directory\ for\ unlinked\ files.=Ricerca nella cartella selezionata file non collegati.
+Starts\ the\ import\ of\ BibTeX\ entries.=Inizia l'importazione delle voci BibTeX
+Leave\ this\ dialog.=Abbandona questo dialogo.
+Create\ directory\ based\ keywords=Crea parole chiave in base al nome delle cartelle
+Creates\ keywords\ in\ created\ entrys\ with\ directory\ pathnames=Crea parole chiave nelle voci generate in base al percorso delle cartelle
+Select\ a\ directory\ where\ the\ search\ shall\ start.=Seleziona una cartella dalla quale iniziare la ricerca.
+Select\ file\ type\:=Seleziona il tipo di file:
+These\ files\ are\ not\ linked\ in\ the\ active\ library.=Questi file non sono collegati nella libreria attiva.
+Entry\ type\ to\ be\ created\:=Tipo di voci da creare:
+Searching\ file\ system...=Ricerca nel filesystem...
+Importing\ into\ Library...=Importazione nella libreria
+Select\ directory=Seleziona cartella
+Select\ files=Seleziona file
+BibTeX\ entry\ creation=Creazione della voce BibTeX
+<No\ selection>=<Nessuna selezione>
+Unable\ to\ connect\ to\ FreeCite\ online\ service.=Impossibile connettersi al servizio online FreeCite.
+Parse\ with\ FreeCite=Analizza con FreeCite
+The\ current\ BibTeX\ key\ will\ be\ overwritten.\ Continue?=La chiave BibTeX corrente sarà sovrascritta. Continuare?
+Overwrite\ key=Sovrascrivi chiave
+Not\ overwriting\ existing\ key.\ To\ change\ this\ setting,\ open\ Options\ ->\ Prefererences\ ->\ BibTeX\ key\ generator=Le chiavi esistenti non vengono sovrascritte. Per cambiare questa impostazione, aprire Opzioni -> Preferenze -> Generatore di chiavi BibTeX
+How\ would\ you\ like\ to\ link\ to\ '%0'?=Come vuoi collegare a '%0'?
+BibTeX\ key\ patterns=Modelli delle chiavi BibTeX
+Changed\ special\ field\ settings=Cambiate le impostazioni dei campi speciali
+Clear\ priority=Azzera le priorità
+Clear\ rank=Azzera la valutazione
+Enable\ special\ fields=Abilita campi speciali
+One\ star=Una stella
+Two\ stars=Due stelle
+Three\ stars=Tre stelle
+Four\ stars=Quattro stelle
+Five\ stars=Cinque stelle
+Help\ on\ special\ fields=Aiuto sui campi speciali
+Keywords\ of\ selected\ entries=Parole chiave delle voci selezionate
+Manage\ content\ selectors=Gestione dei selettori dei contenuti
+Manage\ keywords=Gestione delle parole chiave
+No\ priority\ information=Nessuna informazione di priorità
+No\ rank\ information=Nessuna informazione sulla valutazione
 Priority=Priorità
-Priority_high=Priorità_alta
-Priority_low=Priorità_bassa
-Priority_medium=Priorità_media
+Priority\ high=Priorità alta
+Priority\ low=Priorità bassa
+Priority\ medium=Priorità media
 Quality=Qualità
 Rank=Valutazione
 Relevance=Rilevanza
-Set_priority_to_high=Assegna_priorità_alta
-Set_priority_to_low=Assegna_priorità_bassa
-Set_priority_to_medium=Assegna_priorità_media
-Show_priority=Mostra_priorità
-Show_quality=Mostra_qualità
-Show_rank=Mostra_valutazione
-Show_relevance=Mostra_rilevanza
-Synchronize_with_keywords=Sincronizza_con_le_parole_chiave
-Synchronized_special_fields_based_on_keywords=Sincronizzati_i_campi_speciali_in_base_alle_parole_chiave.
-Toggle_relevance=Mostra/Nascondi_rilevanza
-Toggle_quality_assured=Mostra/Nascondi_qualità
-Toggle_print_status=Invertito_lo_stato_di_stampa
-Update_keywords=Aggiorna_parole_chiave
-Write_values_of_special_fields_as_separate_fields_to_BibTeX=Scrivi_i_valori_dei_campi_speciali_come_campi_separati_nelle_voci_BibTeX
-You_have_changed_settings_for_special_fields.=Sono_state_modificate_le_impostazioni_per_i_campi_speciali.
-%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.=Trovate_%0_voci._Per_ridurre_il_carico_sul_server_ne_saranno_scaricate_solo_%1.
-A_string_with_that_label_already_exists=Una_stringa_con_questa_etichetta_esiste_già.
-Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.=Perduta_la_connessione_con_OpenOffice/LibreOffice._Assicurarsi_che_OpenOffice/LibreOffice_sia_in_esecuzione_e_provare_a_riconnettersi.
-JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.=JabRef_spedirà_almeno_una_richiesta_per_voce_ad_un_editore.
-Correct_the_entry,_and_reopen_editor_to_display/edit_source.=Correggi_la_voce_e_riapri_l'editor_per_mostrare/modificare_il_codice_sorgente.
-Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').=Impossibile_la_connessione_a_un_processo_gnuserv_in_esecuzione._Accertarsi_che_Emacs_o_XEmacs_siano_in_esecuzione,<BR>e_che_il_server_sia_stato_avviato_(con_il_comando_'server-start'/'gnuserv-start').
-Could_not_connect_to_running_OpenOffice/LibreOffice.=Impossibile_la_connessione_ad_OpenOffice/LibreOffice.
-Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.=Assicurarsi_che_OpenOffice/LibreOffice_sia_installato_con_supporto_per_Java.
-If_connecting_manually,_please_verify_program_and_library_paths.=Se_si_effettua_la_connessione_manualmente_verificare_i_percorsi_al_programma_e_alla_libreria.
-Error_message\:=Messaggio_di_errore\:
-If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.=Se_la_voce_incollata_o_importata_ha_il_campo_già_impostato,_sovrascrivere.
-Import_metadata_from_PDF=Importa_metadati_dal_file_PDF
-Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.=Non_connesso_ad_alcun_documento_Writer._Assicurarsi_che_un_documento_sia_aperto_e_connetterlo_con_il_bottone_"Selezionare_il_documento_Writer".
-Removed_all_subgroups_of_group_"%0".=Eliminati_tutti_i_sottogruppi_del_gruppo_"%0".
-To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.=Per_disabilitare_la_modalità_chiavetta_di_memoria_rinominare_o_cancellare_il_file_"jabref.xml"_che_si_trova_nella_cartella_di_installazione_di_JabRef.
-Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.=Impossibile_connettersi._Una_possibile_ragione_è_il_fatto_che_JabRef_e_OpenOffice/LibreOffice_non_vengono_eseguiti_nella_stessa_modalità_a_32_o_64_bit.
-Use_the_following_delimiter_character(s)\:=Usa_i_seguenti_caratteri_di_delimitazione\:
-When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above=Quando_si_scaricano_i_file_o_si_spostano_i_file_collegati,_preferire_la_posizione_del_file_BibTeX_alla_cartella_impostata_sopra.
-Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=Il_file_di_stile_specifica_il_formato_di_carattere_"%0"_che_non_è_tuttavia_definito_nel_documento_OpenOffice/LibreOffice_corrente.
-Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=Il_file_di_stile_specifica_il_formato_di_paragrafo_"%0"_che_non_è_tuttavia_definito_nel_documento_OpenOffice/LibreOffice_corrente.
+Set\ priority\ to\ high=Assegna priorità alta
+Set\ priority\ to\ low=Assegna priorità bassa
+Set\ priority\ to\ medium=Assegna priorità media
+Show\ priority=Mostra priorità
+Show\ quality=Mostra qualità
+Show\ rank=Mostra valutazione
+Show\ relevance=Mostra rilevanza
+Synchronize\ with\ keywords=Sincronizza con le parole chiave
+Synchronized\ special\ fields\ based\ on\ keywords=Sincronizzati i campi speciali in base alle parole chiave.
+Toggle\ relevance=Mostra/Nascondi rilevanza
+Toggle\ quality\ assured=Mostra/Nascondi qualità
+Toggle\ print\ status=Invertito lo stato di stampa
+Update\ keywords=Aggiorna parole chiave
+Write\ values\ of\ special\ fields\ as\ separate\ fields\ to\ BibTeX=Scrivi i valori dei campi speciali come campi separati nelle voci BibTeX
+You\ have\ changed\ settings\ for\ special\ fields.=Sono state modificate le impostazioni per i campi speciali.
+%0\ entries\ found.\ To\ reduce\ server\ load,\ only\ %1\ will\ be\ downloaded.=Trovate %0 voci. Per ridurre il carico sul server ne saranno scaricate solo %1.
+A\ string\ with\ that\ label\ already\ exists=Una stringa con questa etichetta esiste già.
+Connection\ to\ OpenOffice/LibreOffice\ has\ been\ lost.\ Please\ make\ sure\ OpenOffice/LibreOffice\ is\ running,\ and\ try\ to\ reconnect.=Perduta la connessione con OpenOffice/LibreOffice. Assicurarsi che OpenOffice/LibreOffice sia in esecuzione e provare a riconnettersi.
+JabRef\ will\ send\ at\ least\ one\ request\ per\ entry\ to\ a\ publisher.=JabRef spedirà almeno una richiesta per voce ad un editore.
+Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=Correggi la voce e riapri l'editor per mostrare/modificare il codice sorgente.
+Could\ not\ connect\ to\ a\ running\ gnuserv\ process.\ Make\ sure\ that\ Emacs\ or\ XEmacs\ is\ running,<BR>and\ that\ the\ server\ has\ been\ started\ (by\ running\ the\ command\ 'server-start'/'gnuserv-start').=Impossibile la connessione a un processo gnuserv in esecuzione. Accertarsi che Emacs o XEmacs siano in esecuzione,<BR>e che il server sia stato avviato (con il comando 'server-start'/'gnuserv-start').
+Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=Impossibile la connessione ad OpenOffice/LibreOffice.
+Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=Assicurarsi che OpenOffice/LibreOffice sia installato con supporto per Java.
+If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=Se si effettua la connessione manualmente verificare i percorsi al programma e alla libreria.
+Error\ message\:=Messaggio di errore:
+If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=Se la voce incollata o importata ha il campo già impostato, sovrascrivere.
+Import\ metadata\ from\ PDF=Importa metadati dal file PDF
+Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=Non connesso ad alcun documento Writer. Assicurarsi che un documento sia aperto e connetterlo con il bottone "Selezionare il documento Writer".
+Removed\ all\ subgroups\ of\ group\ "%0".=Eliminati tutti i sottogruppi del gruppo "%0".
+To\ disable\ the\ memory\ stick\ mode\ rename\ or\ remove\ the\ jabref.xml\ file\ in\ the\ same\ folder\ as\ JabRef.=Per disabilitare la modalità chiavetta di memoria rinominare o cancellare il file "jabref.xml" che si trova nella cartella di installazione di JabRef.
+Unable\ to\ connect.\ One\ possible\ reason\ is\ that\ JabRef\ and\ OpenOffice/LibreOffice\ are\ not\ both\ running\ in\ either\ 32\ bit\ mode\ or\ 64\ bit\ mode.=Impossibile connettersi. Una possibile ragione è il fatto che JabRef e OpenOffice/LibreOffice non vengono eseguiti nella stessa modalità a 32 o 64 bit.
+Use\ the\ following\ delimiter\ character(s)\:=Usa i seguenti caratteri di delimitazione:
+When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\ prefer\ the\ BIB\ file\ location\ rather\ than\ the\ file\ directory\ set\ above=Quando si scaricano i file o si spostano i file collegati, preferire la posizione del file BibTeX alla cartella impostata sopra.
+Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Il file di stile specifica il formato di carattere "%0" che non è tuttavia definito nel documento OpenOffice/LibreOffice corrente.
+Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Il file di stile specifica il formato di paragrafo "%0" che non è tuttavia definito nel documento OpenOffice/LibreOffice corrente.
 
-Searching...=Ricerca_in_corso...
-You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?=Sono_state_selezionate_più_di_%0_voci_da_scaricare._Alcuni_siti_potrebbero_bloccare_la_connessione_se_si_eseguono_scaricamenti_troppo_numerosi_e_rapidi._Continuare?
-Confirm_selection=Conferma_la_selezione
-Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case=Aggiungere_{}_alle_parole_del_titolo_specificate_per_mantenere_la_corretta_capitalizzazione_nella_ricerca.
-Import_conversions=Importare_le_conversioni
-Please_enter_a_search_string=Inserire_una_stringa_di_ricerca
-Please_open_or_start_a_new_library_before_searching=Aprire_o_creare_una_nuova_libreria_prima_di_effettuare_la_ricerca
+Searching...=Ricerca in corso...
+You\ have\ selected\ more\ than\ %0\ entries\ for\ download.\ Some\ web\ sites\ might\ block\ you\ if\ you\ make\ too\ many\ rapid\ downloads.\ Do\ you\ want\ to\ continue?=Sono state selezionate più di %0 voci da scaricare. Alcuni siti potrebbero bloccare la connessione se si eseguono scaricamenti troppo numerosi e rapidi. Continuare?
+Confirm\ selection=Conferma la selezione
+Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=Aggiungere {} alle parole del titolo specificate per mantenere la corretta capitalizzazione nella ricerca.
+Import\ conversions=Importare le conversioni
+Please\ enter\ a\ search\ string=Inserire una stringa di ricerca
+Please\ open\ or\ start\ a\ new\ library\ before\ searching=Aprire o creare una nuova libreria prima di effettuare la ricerca
 
-Canceled_merging_entries=Accorpamento_delle_voci_cancellato
+Canceled\ merging\ entries=Accorpamento delle voci cancellato
 
-Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search=Struttura_le_unità_aggiungendo_separatori_non_interrompibili_e_conservare_la_corretta_capitalizzazione_per_la_ricerca
-Merge_entries=Accorpa_le_voci
-Merged_entries=Accorpate_le_voci_in_una_nuova_e_mantenute_le_vecchie
-Merged_entry=Voce_accorpata
+Format\ units\ by\ adding\ non-breaking\ separators\ and\ keeping\ the\ correct\ case\ on\ search=Struttura le unità aggiungendo separatori non interrompibili e conservare la corretta capitalizzazione per la ricerca
+Merge\ entries=Accorpa le voci
+Merged\ entries=Accorpate le voci in una nuova e mantenute le vecchie
+Merged\ entry=Voce accorpata
 None=Nessuna
 Parse=Analizza
 Result=Risultato
-Show_DOI_first=Mostrare_prima_il_DOI
-Show_URL_first=Mostrare_prima_l'URL
-Use_Emacs_key_bindings=Utilizza_le_scorciatoie_di_tastiera_di_Emacs
-You_have_to_choose_exactly_two_entries_to_merge.=È_necessario_selezionare_esattamente_due_voci_da_accorpare.
+Show\ DOI\ first=Mostrare prima il DOI
+Show\ URL\ first=Mostrare prima l'URL
+Use\ Emacs\ key\ bindings=Utilizza le scorciatoie di tastiera di Emacs
+You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=È necessario selezionare esattamente due voci da accorpare.
 
-Update_timestamp_on_modification=Aggiornare_data_e_ora_a_seguito_di_una_modifica
-All_key_bindings_will_be_reset_to_their_defaults.=Tutte_le_scorciatoie_di_tastiera_saranno_reimpostate_ai_valori_predefiniti.
+Update\ timestamp\ on\ modification=Aggiornare data e ora a seguito di una modifica
+All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=Tutte le scorciatoie di tastiera saranno reimpostate ai valori predefiniti.
 
-Automatically_set_file_links=Impostazione_automatica_dei_collegamenti_ai_file
-Resetting_all_key_bindings=Reimpostazione_di_tutte_le_scorciatoie_di_tastiera
+Automatically\ set\ file\ links=Impostazione automatica dei collegamenti ai file
+Resetting\ all\ key\ bindings=Reimpostazione di tutte le scorciatoie di tastiera
 Hostname=Host
-Invalid_setting=Impostazione_non_valida
+Invalid\ setting=Impostazione non valida
 Network=Rete
-Please_specify_both_hostname_and_port=Specificare_sia_il_nome_dell'host_sia_il_numero_della_porta
-Please_specify_both_username_and_password=Specificare_sia_il_nome_utente_che_la_password
+Please\ specify\ both\ hostname\ and\ port=Specificare sia il nome dell'host sia il numero della porta
+Please\ specify\ both\ username\ and\ password=Specificare sia il nome utente che la password
 
-Use_custom_proxy_configuration=Utilizza_una_configurazione_del_proxy_personalizzata.
-Proxy_requires_authentication=Il_proxy_richiede_un'autenticazione
-Attention\:_Password_is_stored_in_plain_text\!=Attenzione\:_Password_salvata_come_testo_semplice\!
-Clear_connection_settings=Reinizializza_i_parametri_di_connessione
-Cleared_connection_settings.=Parametri_di_connessione_reinizializzati
+Use\ custom\ proxy\ configuration=Utilizza una configurazione del proxy personalizzata.
+Proxy\ requires\ authentication=Il proxy richiede un'autenticazione
+Attention\:\ Password\ is\ stored\ in\ plain\ text\!=Attenzione: Password salvata come testo semplice!
+Clear\ connection\ settings=Reinizializza i parametri di connessione
+Cleared\ connection\ settings.=Parametri di connessione reinizializzati
 
-Rebind_C-a,_too=Riassociare_anche_C-a
-Rebind_C-f,_too=Riassociare_anche_C-f
+Rebind\ C-a,\ too=Riassociare anche C-a
+Rebind\ C-f,\ too=Riassociare anche C-f
 
-Open_folder=Apri_la_cartella
-Searches_for_unlinked_PDF_files_on_the_file_system=Cerca_i_file_PDF_non_collegati_nel_filesystem
-Export_entries_ordered_as_specified=Esporta_le_voci_nell'ordine_specificato
-Export_sort_order=Esporta_il_modo_di_ordinamento
-Export_sorting=Esporta_l'ordinamento
-Newline_separator=Separatore_di_linea
+Open\ folder=Apri la cartella
+Searches\ for\ unlinked\ PDF\ files\ on\ the\ file\ system=Cerca i file PDF non collegati nel filesystem
+Export\ entries\ ordered\ as\ specified=Esporta le voci nell'ordine specificato
+Export\ sort\ order=Esporta il modo di ordinamento
+Export\ sorting=Esporta l'ordinamento
+Newline\ separator=Separatore di linea
 
-Save_entries_ordered_as_specified=Salva_le_voci_nell'ordine_specificato
-Save_sort_order=Salva_il_modo_di_ordinamento
-Show_extra_columns=Mostra_le_colonne_supplementari
-Parsing_error=Errore_di_elaborazione
-illegal_backslash_expression=Espressione_con_barra_retroversa_illegale
+Save\ entries\ ordered\ as\ specified=Salva le voci nell'ordine specificato
+Save\ sort\ order=Salva il modo di ordinamento
+Show\ extra\ columns=Mostra le colonne supplementari
+Parsing\ error=Errore di elaborazione
+illegal\ backslash\ expression=Espressione con barra retroversa illegale
 
-Move_to_group=Sposta_nel_gruppo
+Move\ to\ group=Sposta nel gruppo
 
-Clear_read_status=Annulla_lo_stato_di_lettura
-Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')=Converti_nel_formato_biblatex_(per_esempio,_sposta_il_valore_del_campo_'journal'_nel_campo_'journaltitle')
-Could_not_apply_changes.=Impossibile_applicare_le_modifiche.
-Deprecated_fields=Campi_obsoleti
-Hide/show_toolbar=Mostra/Nascondi_la_barra_degli_strumenti
-No_read_status_information=Nessuna_informazione_sullo_stato_di_lettura
+Clear\ read\ status=Annulla lo stato di lettura
+Convert\ to\ biblatex\ format\ (for\ example,\ move\ the\ value\ of\ the\ 'journal'\ field\ to\ 'journaltitle')=Converti nel formato biblatex (per esempio, sposta il valore del campo 'journal' nel campo 'journaltitle')
+Could\ not\ apply\ changes.=Impossibile applicare le modifiche.
+Deprecated\ fields=Campi obsoleti
+Hide/show\ toolbar=Mostra/Nascondi la barra degli strumenti
+No\ read\ status\ information=Nessuna informazione sullo stato di lettura
 Printed=Stampato
-Read_status=Stato_di_lettura
-Read_status_read=Stato_di_lettura\:_letto
-Read_status_skimmed=Stato_di_lettura\:_scorso
-Save_selected_as_plain_BibTeX...=Salva_la_selezione_in_formato_BibTeX_base...
-Set_read_status_to_read=Imposta_lo_stato_di_lettura_a_'letto'
-Set_read_status_to_skimmed=Imposta_lo_stato_di_lettura_a_'scorso'
-Show_deprecated_BibTeX_fields=Mostra_i_campi_BibTeX_obsoleti
+Read\ status=Stato di lettura
+Read\ status\ read=Stato di lettura: letto
+Read\ status\ skimmed=Stato di lettura: scorso
+Save\ selected\ as\ plain\ BibTeX...=Salva la selezione in formato BibTeX base...
+Set\ read\ status\ to\ read=Imposta lo stato di lettura a 'letto'
+Set\ read\ status\ to\ skimmed=Imposta lo stato di lettura a 'scorso'
+Show\ deprecated\ BibTeX\ fields=Mostra i campi BibTeX obsoleti
 
-Show_gridlines=Mostra_la_griglia
-Show_printed_status=Mostra_lo_stato_di_stampa
-Show_read_status=Mostra_lo_stato_di_lettura
-Table_row_height_padding=Altezza_delle_righe
+Show\ gridlines=Mostra la griglia
+Show\ printed\ status=Mostra lo stato di stampa
+Show\ read\ status=Mostra lo stato di lettura
+Table\ row\ height\ padding=Altezza delle righe
 
-Marked_selected_entry=Contrassegnate_le_voci_selezionate
-Marked_all_%0_selected_entries=Contrassegnate_tutte_le_'%0'_voci_selezionate
-Unmarked_selected_entry=Rimossi_i_contrassegni_dalle_voci_selezionate
-Unmarked_all_%0_selected_entries=Rimossi_i_contrassegni_da_tutte_le_'%0'_voci_selezionate
+Marked\ selected\ entry=Contrassegnate le voci selezionate
+Marked\ all\ %0\ selected\ entries=Contrassegnate tutte le '%0' voci selezionate
+Unmarked\ selected\ entry=Rimossi i contrassegni dalle voci selezionate
+Unmarked\ all\ %0\ selected\ entries=Rimossi i contrassegni da tutte le '%0' voci selezionate
 
 
-Unmarked_all_entries=Rimossi_i_contrassegni_da_tutte_voci
+Unmarked\ all\ entries=Rimossi i contrassegni da tutte voci
 
-Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.=Impossibile_trovare_il_'look_and_feel'_richiesto._Viene_utilizzato_quello_predefinito
+Unable\ to\ find\ the\ requested\ look\ and\ feel\ and\ thus\ the\ default\ one\ is\ used.=Impossibile trovare il 'look and feel' richiesto. Viene utilizzato quello predefinito
 
-Opens_JabRef's_GitHub_page=Apri_la_pagina_di_JabRef_su_GitHub
-Could_not_open_browser.=Impossibile_avviare_il_browser
-Please_open_%0_manually.=Per_favore_aprire_%0_manualmente.
-The_link_has_been_copied_to_the_clipboard.=Il_link_è_stato_copiato_negli_appunti.
+Opens\ JabRef's\ GitHub\ page=Apri la pagina di JabRef su GitHub
+Could\ not\ open\ browser.=Impossibile avviare il browser
+Please\ open\ %0\ manually.=Per favore aprire %0 manualmente.
+The\ link\ has\ been\ copied\ to\ the\ clipboard.=Il link è stato copiato negli appunti.
 
-Open_%0_file=Apri_il_file_%0
+Open\ %0\ file=Apri il file %0
 
-Cannot_delete_file=Non_posso_cancellare_il_file
-File_permission_error=Errore_nei_permessi_del_file
-Push_to_%0=Invia_a_%0
-Path_to_%0=Percorso_per_%0
+Cannot\ delete\ file=Non posso cancellare il file
+File\ permission\ error=Errore nei permessi del file
+Push\ to\ %0=Invia a %0
+Path\ to\ %0=Percorso per %0
 Convert=Converti
-Normalize_to_BibTeX_name_format=Normalizza_al_formato_di_nome_di_BibTeX
-Help_on_Name_Formatting=Aiuto_sulla_Formattazione_dei_Nomi
+Normalize\ to\ BibTeX\ name\ format=Normalizza al formato di nome di BibTeX
+Help\ on\ Name\ Formatting=Aiuto sulla Formattazione dei Nomi
 
-Add_new_file_type=Aggiungi_un_nuovo_tipo_di_file
+Add\ new\ file\ type=Aggiungi un nuovo tipo di file
 
-Left_entry=Voce_di_sinistra
-Right_entry=Voce_di_destra
+Left\ entry=Voce di sinistra
+Right\ entry=Voce di destra
 Use=Uso
-Original_entry=Voce_originale
-Replace_original_entry=Rimpiazza_il_voce_originale
-No_information_added=Non_è_stata_aggiunta_alcuna_informazione
-Select_at_least_one_entry_to_manage_keywords.=Seleziona_almeno_una_voce_per_gestire_le_parole_chiave
-OpenDocument_text=Testo_di_OpenDocument
-OpenDocument_spreadsheet=Foglio_di_calcolo_di_OpenDocument
-OpenDocument_presentation=Presentazione_di_OpenDocument
-%0_image=immagine_%0
-Added_entry=Voce_aggiunta
-Modified_entry=Voce_modificata
-Deleted_entry=Voce_cancellata
-Modified_groups_tree=Albero_dei_gruppi_modificato
-Removed_all_groups=Cancellati_tutti_i_gruppi
-Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.=Accettando_le_modifiche_si_sovrascriver_à_l'albero_dei_gruppi_con_quello_modificato_esternamente.
-Select_export_format=Selezionare_il_formato_di_esportazione
-Return_to_JabRef=Ritorna_a_JabRef
-Please_move_the_file_manually_and_link_in_place.=Per_favore_sposta_il_file_manualmente_e_collegalo_al_suo_posto.
-Could_not_connect_to_%0=Impossibile_la_connessione_a_%0
-Warning\:_%0_out_of_%1_entries_have_undefined_title.=Attenzione\:_%0_di_%1_voci_non_hanno_un_titolo_definito.
-Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.=Attenzione\:_%0_di_%1_voci_hanno_chiavi_BibTeX_non_definite.
+Original\ entry=Voce originale
+Replace\ original\ entry=Rimpiazza il voce originale
+No\ information\ added=Non è stata aggiunta alcuna informazione
+Select\ at\ least\ one\ entry\ to\ manage\ keywords.=Seleziona almeno una voce per gestire le parole chiave
+OpenDocument\ text=Testo di OpenDocument
+OpenDocument\ spreadsheet=Foglio di calcolo di OpenDocument
+OpenDocument\ presentation=Presentazione di OpenDocument
+%0\ image=immagine %0
+Added\ entry=Voce aggiunta
+Modified\ entry=Voce modificata
+Deleted\ entry=Voce cancellata
+Modified\ groups\ tree=Albero dei gruppi modificato
+Removed\ all\ groups=Cancellati tutti i gruppi
+Accepting\ the\ change\ replaces\ the\ complete\ groups\ tree\ with\ the\ externally\ modified\ groups\ tree.=Accettando le modifiche si sovrascriver à l'albero dei gruppi con quello modificato esternamente.
+Select\ export\ format=Selezionare il formato di esportazione
+Return\ to\ JabRef=Ritorna a JabRef
+Please\ move\ the\ file\ manually\ and\ link\ in\ place.=Per favore sposta il file manualmente e collegalo al suo posto.
+Could\ not\ connect\ to\ %0=Impossibile la connessione a %0
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ title.=Attenzione: %0 di %1 voci non hanno un titolo definito.
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ BibTeX\ key.=Attenzione: %0 di %1 voci hanno chiavi BibTeX non definite.
 occurrence=occorrenza
-Added_new_'%0'_entry.=Aggiunta_la_nuova_voce_'%0'.
-Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?=Selezione_multipla._Vuoi_cambiare_il_tipo_di_tutti_questi_in_'%0'?
-Changed_type_to_'%0'_for=Tipo_cambiato_in_'%0'_per
-Really_delete_the_selected_entry?=Cancellare_veramente_la_voce_selezionata?
-Really_delete_the_%0_selected_entries?=Cancellare_veramente_le_%0_voci_selezionate?
-Keep_merged_entry_only=Tieni_solo_i_voci_accorpate
-Keep_left=Tieni_quelli_di_sinistra
-Keep_right=Tieni_quelli_di_destra
-Old_entry=Voce_vecchia
-From_import=Dall'importazione
-No_problems_found.=Nessun_problema_trovato.
-%0_problem(s)_found=%0_problemi_trovati
-Save_changes=Salva_le_modifiche
-Discard_changes=Scarta_le_modifiche
-Library_'%0'_has_changed.=La_libreria_'%0'_è_stato_modificata.
-Print_entry_preview=Stampa_l'anteprima_della_voce
-Copy_title=Copia_titolo
-Copy_\\cite{BibTeX_key}=Copia_\\cite{chiave_BibTeX}
-Copy_BibTeX_key_and_title=Copia_la_chiave_BibTeX_ed_il_titolo
-File_rename_failed_for_%0_entries.=Rinominazione_dei_file_fallita_per_%0_voci.
-Merged_BibTeX_source_code=Codice_sorgente_BibTeX_accorpato
-Invalid_DOI\:_'%0'.=DOI_non_valido\:_'%0'.
-should_start_with_a_name=deve_cominciare_con_un_nome
-should_end_with_a_name=deve_finire_con_un_nome
-unexpected_closing_curly_bracket=parentesi_graffa_chiusa_inaspettata
-unexpected_opening_curly_bracket=parentesi_graffa_aperta_inaspettata
-capital_letters_are_not_masked_using_curly_brackets_{}=le_maiuscole_grandi_non_vengono_nascoste_con_le_parentesi_graffe_{}
-should_contain_a_four_digit_number=deve_contenere_un_numero_di_quattro_cifre
-should_contain_a_valid_page_number_range=deve_contenere_un_intervallo_valido_di_numeri_di_pagina
+Added\ new\ '%0'\ entry.=Aggiunta la nuova voce '%0'.
+Multiple\ entries\ selected.\ Do\ you\ want\ to\ change\ the\ type\ of\ all\ these\ to\ '%0'?=Selezione multipla. Vuoi cambiare il tipo di tutti questi in '%0'?
+Changed\ type\ to\ '%0'\ for=Tipo cambiato in '%0' per
+Really\ delete\ the\ selected\ entry?=Cancellare veramente la voce selezionata?
+Really\ delete\ the\ %0\ selected\ entries?=Cancellare veramente le %0 voci selezionate?
+Keep\ merged\ entry\ only=Tieni solo i voci accorpate
+Keep\ left=Tieni quelli di sinistra
+Keep\ right=Tieni quelli di destra
+Old\ entry=Voce vecchia
+From\ import=Dall'importazione
+No\ problems\ found.=Nessun problema trovato.
+%0\ problem(s)\ found=%0 problemi trovati
+Save\ changes=Salva le modifiche
+Discard\ changes=Scarta le modifiche
+Library\ '%0'\ has\ changed.=La libreria '%0' è stato modificata.
+Print\ entry\ preview=Stampa l'anteprima della voce
+Copy\ title=Copia titolo
+Copy\ \\cite{BibTeX\ key}=Copia \\cite{chiave BibTeX}
+Copy\ BibTeX\ key\ and\ title=Copia la chiave BibTeX ed il titolo
+File\ rename\ failed\ for\ %0\ entries.=Rinominazione dei file fallita per %0 voci.
+Merged\ BibTeX\ source\ code=Codice sorgente BibTeX accorpato
+Invalid\ DOI\:\ '%0'.=DOI non valido: '%0'.
+should\ start\ with\ a\ name=deve cominciare con un nome
+should\ end\ with\ a\ name=deve finire con un nome
+unexpected\ closing\ curly\ bracket=parentesi graffa chiusa inaspettata
+unexpected\ opening\ curly\ bracket=parentesi graffa aperta inaspettata
+capital\ letters\ are\ not\ masked\ using\ curly\ brackets\ {}=le maiuscole grandi non vengono nascoste con le parentesi graffe {}
+should\ contain\ a\ four\ digit\ number=deve contenere un numero di quattro cifre
+should\ contain\ a\ valid\ page\ number\ range=deve contenere un intervallo valido di numeri di pagina
 Filled=Riempito
-Field_is_missing=Campo_mancante
-Search_%0=Ricerca_%0
+Field\ is\ missing=Campo mancante
+Search\ %0=Ricerca %0
 
-Search_results_in_all_libraries_for_%0=Risultati_della_ricerca_di_%0_in_tutte_le_librerie
-Search_results_in_library_%0_for_%1=Risultati_della_ricerca_di_%1_nella_libreria_%0
-Search_globally=Ricerca_globale
-No_results_found.=Nessun_risultato_trovato.
-Found_%0_results.=Trovati_%0_risultati.
-plain_text=Testo_semplice
-This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>=Questa_ricerca_contiene_occorrenze_in_cui_qualsiasi_campo_contiene_l'espressione_regolare_<b>%0</b>
-This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>=Questa_ricerca_contiene_occorrenze_in_cui_qualsiasi_campo_contiene_il_termine_<b>%0</b>
-This_search_contains_entries_in_which=Questa_ricerca_contiene_occorrenze_in_cui
+Search\ results\ in\ all\ libraries\ for\ %0=Risultati della ricerca di %0 in tutte le librerie
+Search\ results\ in\ library\ %0\ for\ %1=Risultati della ricerca di %1 nella libreria %0
+Search\ globally=Ricerca globale
+No\ results\ found.=Nessun risultato trovato.
+Found\ %0\ results.=Trovati %0 risultati.
+plain\ text=Testo semplice
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ regular\ expression\ <b>%0</b>=Questa ricerca contiene occorrenze in cui qualsiasi campo contiene l'espressione regolare <b>%0</b>
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ term\ <b>%0</b>=Questa ricerca contiene occorrenze in cui qualsiasi campo contiene il termine <b>%0</b>
+This\ search\ contains\ entries\ in\ which=Questa ricerca contiene occorrenze in cui
 
-Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.=Non_sono_in_grado_di_rilevare_l'installazione_di_OpenOffice/LibreOffice._Scegliere_la_cartella_di_installazione_manualmente.
-JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>=JabRef_non_supporta_più_campi_'ps'_o_'pdf'.<br>I_link_ai_file_sono_salvati_ora_nei_campi_'file'_e_i_file_sono_salvati_in_una_cartella_esterna.<br>Per_usare_questa_funzione_JabRef_ha_bisogno_di_aggiornare_i_link_ai_file.<br><br>
-This_library_uses_outdated_file_links.=Questa_libreria_usa_vecchi_link_a_file.
+Unable\ to\ autodetect\ OpenOffice/LibreOffice\ installation.\ Please\ choose\ the\ installation\ directory\ manually.=Non sono in grado di rilevare l'installazione di OpenOffice/LibreOffice. Scegliere la cartella di installazione manualmente.
+JabRef\ no\ longer\ supports\ 'ps'\ or\ 'pdf'\ fields.<br>File\ links\ are\ now\ stored\ in\ the\ 'file'\ field\ and\ files\ are\ stored\ in\ an\ external\ file\ directory.<br>To\ make\ use\ of\ this\ feature,\ JabRef\ needs\ to\ upgrade\ file\ links.<br><br>=JabRef non supporta più campi 'ps' o 'pdf'.<br>I link ai file sono salvati ora nei campi 'file' e i file sono salvati in una cartella esterna.<br>Per usare questa funzione JabRef ha bisogno di aggiornare i link ai file.<br><br>
+This\ library\ uses\ outdated\ file\ links.=Questa libreria usa vecchi link a file.
 
-Clear_search=Cancella_la_ricerca
-Close_library=Chiudi_la_libreria
-Close_entry_editor=Chiudi_l'editor_della_voce
-Decrease_table_font_size=Decrementa_la_grandezza_del_carattere_della_tavola
-Entry_editor,_next_entry=Editor_della_voce,_voce_successiva
-Entry_editor,_next_panel=Editor_della_voce,_pannello_successivo
-Entry_editor,_next_panel_2=Editor_della_voce,_pannello_successivo_2
-Entry_editor,_previous_entry=Editor_della_voce,_voce_precedente
-Entry_editor,_previous_panel=Editor_della_voce,_pannello_precedente
-Entry_editor,_previous_panel_2=Editor_della_voce,_pannello_precedente_2
-File_list_editor,_move_entry_down=Editor_di_liste_di_file,_sposta_la_voce_in_giù
-File_list_editor,_move_entry_up=Editor_di_liste_di_file,_sposta_la_voce_in_su
-Focus_entry_table=Sposta_il_fuoco_sulla_tavola_della_voce
-Import_into_current_library=Importa_nella_libreria_corrente
-Import_into_new_library=Importa_in_una_nuova_libreriia
-Increase_table_font_size=Incremente_la_grandezza_del_carattere_della_tavola
-New_article=Nuovo_articolo
-New_book=Nuovo_libro
-New_entry=Nuova_voce
-New_from_plain_text=Nuovo_da_testo_libero
-New_inbook=Nuovo_in_libro
-New_mastersthesis=Nuova_tesi_di_master
-New_phdthesis=Nuova_tesi_di_dottorato
-New_proceedings=Nuovi_atti_di_congresso
-New_unpublished=Nuovo_non_pubblicato
-Next_tab=Scheda_successiva
-Preamble_editor,_store_changes=Editor_di_preambolo
-Previous_tab=Scheda_precedente
-Push_to_application=Manda_all'applicazione
-Refresh_OpenOffice/LibreOffice=Ricarica_OpenOffice/LibreOffice
-Resolve_duplicate_BibTeX_keys=Risolvi_duplicazione_chiavi_BibTeX
-Save_all=Salva_tutto
-String_dialog,_add_string=Dialogo_stringhe,_aggiungi_una_stringa
-String_dialog,_remove_string=Dialogo_stringhe,_cancella_una_stringa
-Synchronize_files=Sincronizza_file
-Unabbreviate=Togli_abbreviazioni
-should_contain_a_protocol=deve_contenere_un_protocollo
-Copy_preview=Copia_l'anteprima
-Automatically_setting_file_links=Seleziona_automaticamente_i_collegamenti_ai_file
-Regenerating_BibTeX_keys_according_to_metadata=Rigenera_le_chiavi_BibTeX_secondo_i_metadati
-No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys=Non_ci_sono_meta_nel_fil_BIB._Non_posso_rigenerare_le_chiavi_BibTeX
-Regenerate_all_keys_for_the_entries_in_a_BibTeX_file=Rigenera_tutte_le_chiavi_per_i_campi_di_un_file_BibTeX
-Show_debug_level_messages=Mostra_i_messaggi_del_livello_di_debug
-Default_bibliography_mode=Modalità_bibliografica_predefinita
-New_%0_library_created.=Creato_la_nuova_libreria_%0.
-Show_only_preferences_deviating_from_their_default_value=Mostra_solo_le_preferenze_diverse_dai_valori_predefiniti
+Clear\ search=Cancella la ricerca
+Close\ library=Chiudi la libreria
+Close\ entry\ editor=Chiudi l'editor della voce
+Decrease\ table\ font\ size=Decrementa la grandezza del carattere della tavola
+Entry\ editor,\ next\ entry=Editor della voce, voce successiva
+Entry\ editor,\ next\ panel=Editor della voce, pannello successivo
+Entry\ editor,\ next\ panel\ 2=Editor della voce, pannello successivo 2
+Entry\ editor,\ previous\ entry=Editor della voce, voce precedente
+Entry\ editor,\ previous\ panel=Editor della voce, pannello precedente
+Entry\ editor,\ previous\ panel\ 2=Editor della voce, pannello precedente 2
+File\ list\ editor,\ move\ entry\ down=Editor di liste di file, sposta la voce in giù
+File\ list\ editor,\ move\ entry\ up=Editor di liste di file, sposta la voce in su
+Focus\ entry\ table=Sposta il fuoco sulla tavola della voce
+Import\ into\ current\ library=Importa nella libreria corrente
+Import\ into\ new\ library=Importa in una nuova libreriia
+Increase\ table\ font\ size=Incremente la grandezza del carattere della tavola
+New\ article=Nuovo articolo
+New\ book=Nuovo libro
+New\ entry=Nuova voce
+New\ from\ plain\ text=Nuovo da testo libero
+New\ inbook=Nuovo in libro
+New\ mastersthesis=Nuova tesi di master
+New\ phdthesis=Nuova tesi di dottorato
+New\ proceedings=Nuovi atti di congresso
+New\ unpublished=Nuovo non pubblicato
+Next\ tab=Scheda successiva
+Preamble\ editor,\ store\ changes=Editor di preambolo
+Previous\ tab=Scheda precedente
+Push\ to\ application=Manda all'applicazione
+Refresh\ OpenOffice/LibreOffice=Ricarica OpenOffice/LibreOffice
+Resolve\ duplicate\ BibTeX\ keys=Risolvi duplicazione chiavi BibTeX
+Save\ all=Salva tutto
+String\ dialog,\ add\ string=Dialogo stringhe, aggiungi una stringa
+String\ dialog,\ remove\ string=Dialogo stringhe, cancella una stringa
+Synchronize\ files=Sincronizza file
+Unabbreviate=Togli abbreviazioni
+should\ contain\ a\ protocol=deve contenere un protocollo
+Copy\ preview=Copia l'anteprima
+Automatically\ setting\ file\ links=Seleziona automaticamente i collegamenti ai file
+Regenerating\ BibTeX\ keys\ according\ to\ metadata=Rigenera le chiavi BibTeX secondo i metadati
+No\ meta\ data\ present\ in\ BIB\ file.\ Cannot\ regenerate\ BibTeX\ keys=Non ci sono meta nel fil BIB. Non posso rigenerare le chiavi BibTeX
+Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=Rigenera tutte le chiavi per i campi di un file BibTeX
+Show\ debug\ level\ messages=Mostra i messaggi del livello di debug
+Default\ bibliography\ mode=Modalità bibliografica predefinita
+New\ %0\ library\ created.=Creato la nuova libreria %0.
+Show\ only\ preferences\ deviating\ from\ their\ default\ value=Mostra solo le preferenze diverse dai valori predefiniti
 default=predefinito
 key=chiave
 type=tipo
 value=valore
-Show_preferences=Mostra_preferenze
-Save_actions=Salva_azioni
-Enable_save_actions=Abilita_il_salvataggio_delle_azioni
+Show\ preferences=Mostra preferenze
+Save\ actions=Salva azioni
+Enable\ save\ actions=Abilita il salvataggio delle azioni
 
-Other_fields=Altri_campi
-Show_remaining_fields=Mostra_i_campi_rimanenti
+Other\ fields=Altri campi
+Show\ remaining\ fields=Mostra i campi rimanenti
 
-link_should_refer_to_a_correct_file_path=il_link_deve_riferirsi_ad_un_percorso_file_corretto
-abbreviation_detected=rilevata_abbreviazione
-wrong_entry_type_as_proceedings_has_page_numbers=tipo_di_voce_sbagliata_perché_ha_numeri_di_pagina
-Abbreviate_journal_names=Nomi_di_rivista_abbreviati
-Abbreviating...=Applico_le_abbreviazioni
-Abbreviation_%s_for_journal_%s_already_defined.=Abbreviazione_%s_per_la_rivista_%s_già_definita.
-Abbreviation_cannot_be_empty=L'abbreviazione_non_può_essere_vuota
-Duplicated_Journal_Abbreviation=Abbreviazione_per_rivista_duplicata
-Duplicated_Journal_File=File_per_rivista_duplicato
-Error_Occurred=C'è_stato_un_errore
-Journal_file_%s_already_added=File_per_rivista_%s_già_aggiunto
-Name_cannot_be_empty=Il_nome_non_può_essere_vuoto
+link\ should\ refer\ to\ a\ correct\ file\ path=il link deve riferirsi ad un percorso file corretto
+abbreviation\ detected=rilevata abbreviazione
+wrong\ entry\ type\ as\ proceedings\ has\ page\ numbers=tipo di voce sbagliata perché ha numeri di pagina
+Abbreviate\ journal\ names=Nomi di rivista abbreviati
+Abbreviating...=Applico le abbreviazioni
+Abbreviation\ %s\ for\ journal\ %s\ already\ defined.=Abbreviazione %s per la rivista %s già definita.
+Abbreviation\ cannot\ be\ empty=L'abbreviazione non può essere vuota
+Duplicated\ Journal\ Abbreviation=Abbreviazione per rivista duplicata
+Duplicated\ Journal\ File=File per rivista duplicato
+Error\ Occurred=C'è stato un errore
+Journal\ file\ %s\ already\ added=File per rivista %s già aggiunto
+Name\ cannot\ be\ empty=Il nome non può essere vuoto
 
-Adding_fetched_entries=Aggiungo_le_voci_estratte
-Display_keywords_appearing_in_ALL_entries=Mostra_le_parole_chiave_che_compaiono_in_TUTTI_le_voci
-Display_keywords_appearing_in_ANY_entry=Mostra_le_parole_chiave_che_compaiono_in_QUALSIASI_voce
-Fetching_entries_from_Inspire=Estrae_le_voci_da_Inspire
-None_of_the_selected_entries_have_titles.=Nessuna_delle_voci_selezionate_ha_un_titolo.
-None_of_the_selected_entries_have_BibTeX_keys.=Nessuno_delle_voci_selezionate_ha_chiavi_BibTeX.
-Unabbreviate_journal_names=Nomi_di_rivista_senza_abbreviazione
-Unabbreviating...=Elimino_le_abbreviazioni
+Adding\ fetched\ entries=Aggiungo le voci estratte
+Display\ keywords\ appearing\ in\ ALL\ entries=Mostra le parole chiave che compaiono in TUTTI le voci
+Display\ keywords\ appearing\ in\ ANY\ entry=Mostra le parole chiave che compaiono in QUALSIASI voce
+Fetching\ entries\ from\ Inspire=Estrae le voci da Inspire
+None\ of\ the\ selected\ entries\ have\ titles.=Nessuna delle voci selezionate ha un titolo.
+None\ of\ the\ selected\ entries\ have\ BibTeX\ keys.=Nessuno delle voci selezionate ha chiavi BibTeX.
+Unabbreviate\ journal\ names=Nomi di rivista senza abbreviazione
+Unabbreviating...=Elimino le abbreviazioni
 Usage=Uso
 
 
-Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.=Aggiungi_parentesi_graffe_{}_intorno_ad_acronimi,_nomi_di_mesi_e_nazioni_per_preservare_maiuscole/minuscole.
-Are_you_sure_you_want_to_reset_all_settings_to_default_values?=Sei_sicuro_di_voler_riportare_tutte_le_preferenze_ai_propri_valori_predefiniti?
-Reset_preferences=Reimposta_le_preferenze
-Ill-formed_entrytype_comment_in_BIB_file=Commento_nel_tipo_di_voce_malformato_nel_file_BIB
+Adds\ {}\ brackets\ around\ acronyms,\ month\ names\ and\ countries\ to\ preserve\ their\ case.=Aggiungi parentesi graffe {} intorno ad acronimi, nomi di mesi e nazioni per preservare maiuscole/minuscole.
+Are\ you\ sure\ you\ want\ to\ reset\ all\ settings\ to\ default\ values?=Sei sicuro di voler riportare tutte le preferenze ai propri valori predefiniti?
+Reset\ preferences=Reimposta le preferenze
+Ill-formed\ entrytype\ comment\ in\ BIB\ file=Commento nel tipo di voce malformato nel file BIB
 
-Move_linked_files_to_default_file_directory_%0=Sposta_i_collegamenti_ai_file_nella_cartella_predefinita
+Move\ linked\ files\ to\ default\ file\ directory\ %0=Sposta i collegamenti ai file nella cartella predefinita
 
 Clipboard=Appunti
-Could_not_paste_entry_as_text\:=Non_posso_incollare_la_voce_come_testo\:
-Do_you_still_want_to_continue?=Vuoi_ancora_continuare?
-This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:=Questa_azione_modificherà_i_seguenti_campi_per_almeno_una_voce_ciascuno\:
-This_could_cause_undesired_changes_to_your_entries.=Questo_potrebbe_causare_modifiche_indesiderate_alle_tue_voci.
-Run_field_formatter\:=Fa_andare_il_formattatore_di_campo\:
-Table_font_size_is_%0=La_grandezza_del_carattere_\e00e8_%0
-%0_import_canceled=Importazione_da_%0_annullata
-Internal_style=Stile_interno
-Add_style_file=Aggiungi_file_di_stile
-Are_you_sure_you_want_to_remove_the_style?=Sei_sicuro_di_voler_rimuovere_lo_stile?
-Current_style_is_'%0'=Lo_stile_corrente_è_'%0'
-Remove_style=Rimuovi_lo_stile
-Select_one_of_the_available_styles_or_add_a_style_file_from_disk.=Seleziona_uno_degli_stili_disponibili_o_aggiungi_uno_stile_dal_disco.
-You_must_select_a_valid_style_file.=Devi_selezionare_un_file_di_stile_valido.
+Could\ not\ paste\ entry\ as\ text\:=Non posso incollare la voce come testo:
+Do\ you\ still\ want\ to\ continue?=Vuoi ancora continuare?
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=Questa azione modificherà i seguenti campi per almeno una voce ciascuno:
+This\ could\ cause\ undesired\ changes\ to\ your\ entries.=Questo potrebbe causare modifiche indesiderate alle tue voci.
+Run\ field\ formatter\:=Fa andare il formattatore di campo:
+Table\ font\ size\ is\ %0=La grandezza del carattere \e00e8 %0
+%0\ import\ canceled=Importazione da %0 annullata
+Internal\ style=Stile interno
+Add\ style\ file=Aggiungi file di stile
+Are\ you\ sure\ you\ want\ to\ remove\ the\ style?=Sei sicuro di voler rimuovere lo stile?
+Current\ style\ is\ '%0'=Lo stile corrente è '%0'
+Remove\ style=Rimuovi lo stile
+Select\ one\ of\ the\ available\ styles\ or\ add\ a\ style\ file\ from\ disk.=Seleziona uno degli stili disponibili o aggiungi uno stile dal disco.
+You\ must\ select\ a\ valid\ style\ file.=Devi selezionare un file di stile valido.
 Reload=Ricarica
 
-Capitalize=Metti_in_maiuscolo_la_prima_lettera
-Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.=Metti_in_maiuscolo_la_prima_lettera_di_tutte_le_parole,_ma_converti_articoli_preposizioni_e_congiunzioni_in_minuscolo.
-Capitalize_the_first_word,_changes_other_words_to_lower_case.=Metti_in_maiuscolo_la_prima_lettera_della_prima_parola,_metti_in_minuscolo_tutte_le_altre_parole.
-Changes_all_letters_to_lower_case.=Metti_tutte_le_lettere_in_minuscolo.
-Changes_all_letters_to_upper_case.=Metti_tutte_le_lettere_in_maiuscolo.
-Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.=Metti_in_maiuscolo_la_prima_lettera_di_tutte_le_parole_e_le_altre_in_minuscolo.
-Cleans_up_LaTeX_code.=Pulisci_il_codice_LaTeX.
-Converts_HTML_code_to_LaTeX_code.=Converti_il_codice_HTML_in_LaTeX.
-Converts_HTML_code_to_Unicode.=Converti_il_codice_HTML_in_Unicode.
-Converts_LaTeX_encoding_to_Unicode_characters.=Converti_la_codice_LaTeX_in_caratteri_Unicode.
-Converts_Unicode_characters_to_LaTeX_encoding.=Converti_i_caratteri_Unicode_in_codice_LaTeX.
-Converts_ordinals_to_LaTeX_superscripts.=Converti_gli_ordinali_in_indici_alti_LaTeX.
-Converts_units_to_LaTeX_formatting.=Converti_unità_in_formattazione_LaTeX.
-HTML_to_LaTeX=Da_HTML_a_LaTeX
-LaTeX_cleanup=Pulisci_il_LaTeX
-LaTeX_to_Unicode=Da_LaTeX_a_Unicode
-Lower_case=Minuscolo
-Minify_list_of_person_names=Riduci_la_lista_di_nomi_di_persona
-Normalize_date=Normalizza_la_data
-Normalize_month=Normalizza_il_mese
-Normalize_month_to_BibTeX_standard_abbreviation.=Normalizza_il_mese_secondo_l'abbreviazione_standard_di_BibTeX.
-Normalize_names_of_persons=Normalizza_i_nomi_di_persona
-Normalize_page_numbers=Normalizza_i_numeri_di_pagina
-Normalize_pages_to_BibTeX_standard.=Normalizza_le_pagine_secondo_lo_standard_di_BibTeX.
-Normalizes_lists_of_persons_to_the_BibTeX_standard.=Normalizza_le_liste_di_persone__secondo_lo_standard_di_BibTeX.
-Normalizes_the_date_to_ISO_date_format.=Normalizza_le_date_secondo_il_formato_di_data_ISO
-Ordinals_to_LaTeX_superscript=Da_ordinali_ad_apici_LaTeX
-Protect_terms=Termini_protetti
-Remove_enclosing_braces=Rimuovi_le_parentesi_graffe_interne
-Removes_braces_encapsulating_the_complete_field_content.=Rimuovi_le_parentesi_graffe_che_incapsulano_completamente_il_contenuto_dei_campi.
-Sentence_case=Frase_maiuscola/minuscola
-Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".=Se_ci_sono_più_di_due_persone_in_una_lista,_abbrevia_in_"et_al.".
-Title_case=Titolo_maiuscolo/minuscolo
-Unicode_to_LaTeX=Da_Unicode_a_LaTeX
-Units_to_LaTeX=Da_unità_a_LaTeX
-Upper_case=Maiuscolo
-Does_nothing.=Non_fa_niente.
+Capitalize=Metti in maiuscolo la prima lettera
+Capitalize\ all\ words,\ but\ converts\ articles,\ prepositions,\ and\ conjunctions\ to\ lower\ case.=Metti in maiuscolo la prima lettera di tutte le parole, ma converti articoli preposizioni e congiunzioni in minuscolo.
+Capitalize\ the\ first\ word,\ changes\ other\ words\ to\ lower\ case.=Metti in maiuscolo la prima lettera della prima parola, metti in minuscolo tutte le altre parole.
+Changes\ all\ letters\ to\ lower\ case.=Metti tutte le lettere in minuscolo.
+Changes\ all\ letters\ to\ upper\ case.=Metti tutte le lettere in maiuscolo.
+Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=Metti in maiuscolo la prima lettera di tutte le parole e le altre in minuscolo.
+Cleans\ up\ LaTeX\ code.=Pulisci il codice LaTeX.
+Converts\ HTML\ code\ to\ LaTeX\ code.=Converti il codice HTML in LaTeX.
+Converts\ HTML\ code\ to\ Unicode.=Converti il codice HTML in Unicode.
+Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=Converti la codice LaTeX in caratteri Unicode.
+Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=Converti i caratteri Unicode in codice LaTeX.
+Converts\ ordinals\ to\ LaTeX\ superscripts.=Converti gli ordinali in indici alti LaTeX.
+Converts\ units\ to\ LaTeX\ formatting.=Converti unità in formattazione LaTeX.
+HTML\ to\ LaTeX=Da HTML a LaTeX
+LaTeX\ cleanup=Pulisci il LaTeX
+LaTeX\ to\ Unicode=Da LaTeX a Unicode
+Lower\ case=Minuscolo
+Minify\ list\ of\ person\ names=Riduci la lista di nomi di persona
+Normalize\ date=Normalizza la data
+Normalize\ month=Normalizza il mese
+Normalize\ month\ to\ BibTeX\ standard\ abbreviation.=Normalizza il mese secondo l'abbreviazione standard di BibTeX.
+Normalize\ names\ of\ persons=Normalizza i nomi di persona
+Normalize\ page\ numbers=Normalizza i numeri di pagina
+Normalize\ pages\ to\ BibTeX\ standard.=Normalizza le pagine secondo lo standard di BibTeX.
+Normalizes\ lists\ of\ persons\ to\ the\ BibTeX\ standard.=Normalizza le liste di persone  secondo lo standard di BibTeX.
+Normalizes\ the\ date\ to\ ISO\ date\ format.=Normalizza le date secondo il formato di data ISO
+Ordinals\ to\ LaTeX\ superscript=Da ordinali ad apici LaTeX
+Protect\ terms=Termini protetti
+Remove\ enclosing\ braces=Rimuovi le parentesi graffe interne
+Removes\ braces\ encapsulating\ the\ complete\ field\ content.=Rimuovi le parentesi graffe che incapsulano completamente il contenuto dei campi.
+Sentence\ case=Frase maiuscola/minuscola
+Shortens\ lists\ of\ persons\ if\ there\ are\ more\ than\ 2\ persons\ to\ "et\ al.".=Se ci sono più di due persone in una lista, abbrevia in "et al.".
+Title\ case=Titolo maiuscolo/minuscolo
+Unicode\ to\ LaTeX=Da Unicode a LaTeX
+Units\ to\ LaTeX=Da unità a LaTeX
+Upper\ case=Maiuscolo
+Does\ nothing.=Non fa niente.
 Identity=Identità
-Clears_the_field_completely.=Azzera_completamente_il_campo.
-Directory_not_found=Cartella_non_trovata
-Main_file_directory_not_set\!=Cartella_principale_non_selezionata\!
-This_operation_requires_exactly_one_item_to_be_selected.=Per_questa_operazione_devi_selezionare_esattamente_un_elemento.
-Importing_in_%0_format=Importo_nel_formato_%0
-Female_name=Nome_di_donna
-Female_names=Nomi_di_donna
-Male_name=Nome_di_uomo
-Male_names=Nomi_di_uomo
-Mixed_names=Nomi_misti
-Neuter_name=Nome_neutro
-Neuter_names=Nomi_neutri
+Clears\ the\ field\ completely.=Azzera completamente il campo.
+Directory\ not\ found=Cartella non trovata
+Main\ file\ directory\ not\ set\!=Cartella principale non selezionata!
+This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=Per questa operazione devi selezionare esattamente un elemento.
+Importing\ in\ %0\ format=Importo nel formato %0
+Female\ name=Nome di donna
+Female\ names=Nomi di donna
+Male\ name=Nome di uomo
+Male\ names=Nomi di uomo
+Mixed\ names=Nomi misti
+Neuter\ name=Nome neutro
+Neuter\ names=Nomi neutri
 
-Determined_%0_for_%1_entries=Determinate_%0_di_%1_voci
-Look_up_%0=Cerca_%0
-Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3=Cerco_%0..._-_voce_%1_di_%2_-_trovate_%3
+Determined\ %0\ for\ %1\ entries=Determinate %0 di %1 voci
+Look\ up\ %0=Cerca %0
+Looking\ up\ %0...\ -\ entry\ %1\ out\ of\ %2\ -\ found\ %3=Cerco %0... - voce %1 di %2 - trovate %3
 
-Audio_CD=CD_Audio
-British_patent=Brevetto_britannico
-British_patent_request=Richiesto_brevetto_britannico
-Candidate_thesis=Tesi_candidata
+Audio\ CD=CD Audio
+British\ patent=Brevetto britannico
+British\ patent\ request=Richiesto brevetto britannico
+Candidate\ thesis=Tesi candidata
 Collaborator=Collaboratore
 Column=Colonna
 Compiler=Compilatore
 Continuator=Continuatore
-Data_CD=CD_Dati
+Data\ CD=CD Dati
 Editor=Editore
-European_patent=Brevetto_europeo
-European_patent_request=Richiesta_di_brevetto_europeo
+European\ patent=Brevetto europeo
+European\ patent\ request=Richiesta di brevetto europeo
 Founder=Fondatore
-French_patent=Brevetto_francese
-French_patent_request=Richiesta_di_brevetto_francese
-German_patent=Brevetto_tedesco
-German_patent_request=Richesta_di_brevetto_tedesco
+French\ patent=Brevetto francese
+French\ patent\ request=Richiesta di brevetto francese
+German\ patent=Brevetto tedesco
+German\ patent\ request=Richesta di brevetto tedesco
 Line=Riga
-Master's_thesis=Tesi_di_laurea_specialistica
+Master's\ thesis=Tesi di laurea specialistica
 Page=Pagina
 Paragraph=Paragrafo
 Patent=Brevetto
-Patent_request=Richiesta_di_brevetto
-PhD_thesis=Tesi_di_dottorato
+Patent\ request=Richiesta di brevetto
+PhD\ thesis=Tesi di dottorato
 Redactor=Redattore
-Research_report=Relazione_di_ricerca
+Research\ report=Relazione di ricerca
 Reviser=Revisore
 Section=Sezione
 Software=Software
-Technical_report=Relazione_tecnica
-U.S._patent=Brevetto_U.S.
-U.S._patent_request=Richiesta_di_brevetto_U.S.
+Technical\ report=Relazione tecnica
+U.S.\ patent=Brevetto U.S.
+U.S.\ patent\ request=Richiesta di brevetto U.S.
 Verse=Verso
 
-change_entries_of_group=modifica_le_voci_del_gruppo
-odd_number_of_unescaped_'\#'=numero_dispari_di_'\#'_non_marcati
+change\ entries\ of\ group=modifica le voci del gruppo
+odd\ number\ of\ unescaped\ '\#'=numero dispari di '#' non marcati
 
-Plain_text=Testo_semplice
-Show_diff=Mostra_differenze
+Plain\ text=Testo semplice
+Show\ diff=Mostra differenze
 character=carattere
 word=parola
-Show_symmetric_diff=Mostra_differenze_simmetriche
-Copy_Version=Copia_la_versione
+Show\ symmetric\ diff=Mostra differenze simmetriche
+Copy\ Version=Copia la versione
 Developers=Sviluppatori
 Authors=Autori
 License=Licenza
 
-HTML_encoded_character_found=Trovato_un_carattere_in_codifica_HTML
-booktitle_ends_with_'conference_on'=il_titolo_del_libro_termina_con_'conferenza_su'
+HTML\ encoded\ character\ found=Trovato un carattere in codifica HTML
+booktitle\ ends\ with\ 'conference\ on'=il titolo del libro termina con 'conferenza su'
 
-All_external_files=Tutti_i_file_esterni
+All\ external\ files=Tutti i file esterni
 
-OpenOffice/LibreOffice_integration=integrazione_con_OpenOffice/LibreOffice
+OpenOffice/LibreOffice\ integration=integrazione con OpenOffice/LibreOffice
 
-incorrect_control_digit=carattere_di_controllo_non_corretto
-incorrect_format=formato_non_corretto
-Copied_version_to_clipboard=Versione_copiata_negli_appunti
+incorrect\ control\ digit=carattere di controllo non corretto
+incorrect\ format=formato non corretto
+Copied\ version\ to\ clipboard=Versione copiata negli appunti
 
-BibTeX_key=Chiave_BibTeX
+BibTeX\ key=Chiave BibTeX
 Message=Messaggio
 
 
-MathSciNet_Review=Recensione_MathSciNet
-Reset_Bindings=Annulla_scorciatoie
+MathSciNet\ Review=Recensione MathSciNet
+Reset\ Bindings=Annulla scorciatoie
 
-Decryption_not_supported.=Decrittografazione_non_supportata.
+Decryption\ not\ supported.=Decrittografazione non supportata.
 
-Cleared_'%0'_for_%1_entries=Reinizializzati_'%0'_per_%1_voce/i
-Set_'%0'_to_'%1'_for_%2_entries='%0'_impostata_a_'%1'_per_%2_voce/i
-Toggled_'%0'_for_%1_entries=Modificata_la_valutazione_di_'%0'_per_%1_voce/i
+Cleared\ '%0'\ for\ %1\ entries=Reinizializzati '%0' per %1 voce/i
+Set\ '%0'\ to\ '%1'\ for\ %2\ entries='%0' impostata a '%1' per %2 voce/i
+Toggled\ '%0'\ for\ %1\ entries=Modificata la valutazione di '%0' per %1 voce/i
 
-Check_for_updates=Ricerca_degli_aggiornamenti
-Download_update=Scarica_gli_aggiornamenti
-New_version_available=Nuova_versione_disponibile
-Installed_version=Versione_installata
-Remind_me_later=Ricordamelo_dopo
-Ignore_this_update=Ignora_questo_aggiornamento
-Could_not_connect_to_the_update_server.=Non_posso_connettermi_al_server_degli_aggiornamenti.
-Please_try_again_later_and/or_check_your_network_connection.=Prova_più_tardi_e/o_controlla_la_tua_connessione.
-To_see_what_is_new_view_the_changelog.=Per_vedere_cosa_c'è_di_nuovo_controlla_il_changelog
-A_new_version_of_JabRef_has_been_released.=È_stata_rilasciata_una_nuova_versione_di_JabRef.
-JabRef_is_up-to-date.=JabRef_è_aggiornato.
-Latest_version=Ultima_versione
-Online_help_forum=Forum_per_help_online
+Check\ for\ updates=Ricerca degli aggiornamenti
+Download\ update=Scarica gli aggiornamenti
+New\ version\ available=Nuova versione disponibile
+Installed\ version=Versione installata
+Remind\ me\ later=Ricordamelo dopo
+Ignore\ this\ update=Ignora questo aggiornamento
+Could\ not\ connect\ to\ the\ update\ server.=Non posso connettermi al server degli aggiornamenti.
+Please\ try\ again\ later\ and/or\ check\ your\ network\ connection.=Prova più tardi e/o controlla la tua connessione.
+To\ see\ what\ is\ new\ view\ the\ changelog.=Per vedere cosa c'è di nuovo controlla il changelog
+A\ new\ version\ of\ JabRef\ has\ been\ released.=È stata rilasciata una nuova versione di JabRef.
+JabRef\ is\ up-to-date.=JabRef è aggiornato.
+Latest\ version=Ultima versione
+Online\ help\ forum=Forum per help online
 Custom=Appopsito
 
-Export_cited=Esporta_citazioni
-Unable_to_generate_new_library=Impossibile_generare_la_nuova_libreria
+Export\ cited=Esporta citazioni
+Unable\ to\ generate\ new\ library=Impossibile generare la nuova libreria
 
-Open_console=Apri_la_console
-Use_default_terminal_emulator=Usa_l'emulatore_di_terminale_predefinito
-Execute_command=Esegui_il_comando
-Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.=Nota\:_Usa_il_segnaposto_%0_come_posizione_nel_file_di_libreria_aperto.
-Executing_command_\"%0\"...=Esegui_il_comando_\"%0\"
-Error_occured_while_executing_the_command_\"%0\".=È_avvenuto_un_errore_eseguendo_il_comando_\"%0\".
-Reformat_ISSN=Riformatta_ISSN
+Open\ console=Apri la console
+Use\ default\ terminal\ emulator=Usa l'emulatore di terminale predefinito
+Execute\ command=Esegui il comando
+Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=Nota: Usa il segnaposto %0 come posizione nel file di libreria aperto.
+Executing\ command\ \"%0\"...=Esegui il comando \"%0\"
+Error\ occured\ while\ executing\ the\ command\ \"%0\".=È avvenuto un errore eseguendo il comando \"%0\".
+Reformat\ ISSN=Riformatta ISSN
 
-Countries_and_territories_in_English=Paesi_e_territori_in_inglese
-Electrical_engineering_terms=Termini_di_ingegneria_elettrica
+Countries\ and\ territories\ in\ English=Paesi e territori in inglese
+Electrical\ engineering\ terms=Termini di ingegneria elettrica
 Enabled=Abilitato
-Internal_list=Lista_interna
-Manage_protected_terms_files=Gestisci_file_di_termini_protetti
-Months_and_weekdays_in_English=Mesi_e_giorni_in_inglese
-The_text_after_the_last_line_starting_with_\#_will_be_used=Verrà_usato_il_testo_dopo_l'ultima_riga_che_comincia_con_\#
-Add_protected_terms_file=Aggiungi_un_file_di_termini_protetti
-Are_you_sure_you_want_to_remove_the_protected_terms_file?=Sei_sicuro_di_voler_rimuovere_il_file_di_termini_protetti?
-Remove_protected_terms_file=Rimuovi_il_file_di_termini_protetti
-Add_selected_text_to_list=Aggiungi_il_testo_selezionato_alla_lista
-Add_{}_around_selected_text=Aggiungi_{}_intorno_al_testo_selezionato
-Format_field=Campo_di_formattazione
-New_protected_terms_file=Nuovo_file_di_termini_protetti
-change_field_%0_of_entry_%1_from_%2_to_%3=modifica_il_campo_%0_della_voce_%1_da_%2_a_%3
-change_key_from_%0_to_%1=modifica_la_chiave_da_%0_a_%1
-change_string_content_%0_to_%1=modifica_il_contenuto_della_stringa_da_%0_a_%1
-change_string_name_%0_to_%1=modifica_il_nome_della_stringa_da_%0_a_%1
-change_type_of_entry_%0_from_%1_to_%2=modifica_il_tipo_della_voce_%0_da_%1_a_%2
-insert_entry_%0=inserisci_la_voce_%0
-insert_string_%0=inserisci_la_stringa_%0
-remove_entry_%0=rimuovi_la_voce_%0
-remove_string_%0=rimuovi_la_stringa_%0
-undefined=non_definito
-Cannot_get_info_based_on_given_%0\:_%1=Non_trovo_informazioni_in_base_alla_data_%0\:_%1
-Get_BibTeX_data_from_%0=Preleva_i_dati_BibTeX_da_%0
-No_%0_found=Nessun_%0_trovato
-Entry_from_%0=Voce_da_%0
-Merge_entry_with_%0_information=Accorpa_la_voce_con_l'informazione_%0
-Updated_entry_with_info_from_%0=Aggiornata_la_voce_con_l'informazione_da_%0
+Internal\ list=Lista interna
+Manage\ protected\ terms\ files=Gestisci file di termini protetti
+Months\ and\ weekdays\ in\ English=Mesi e giorni in inglese
+The\ text\ after\ the\ last\ line\ starting\ with\ \#\ will\ be\ used=Verrà usato il testo dopo l'ultima riga che comincia con #
+Add\ protected\ terms\ file=Aggiungi un file di termini protetti
+Are\ you\ sure\ you\ want\ to\ remove\ the\ protected\ terms\ file?=Sei sicuro di voler rimuovere il file di termini protetti?
+Remove\ protected\ terms\ file=Rimuovi il file di termini protetti
+Add\ selected\ text\ to\ list=Aggiungi il testo selezionato alla lista
+Add\ {}\ around\ selected\ text=Aggiungi {} intorno al testo selezionato
+Format\ field=Campo di formattazione
+New\ protected\ terms\ file=Nuovo file di termini protetti
+change\ field\ %0\ of\ entry\ %1\ from\ %2\ to\ %3=modifica il campo %0 della voce %1 da %2 a %3
+change\ key\ from\ %0\ to\ %1=modifica la chiave da %0 a %1
+change\ string\ content\ %0\ to\ %1=modifica il contenuto della stringa da %0 a %1
+change\ string\ name\ %0\ to\ %1=modifica il nome della stringa da %0 a %1
+change\ type\ of\ entry\ %0\ from\ %1\ to\ %2=modifica il tipo della voce %0 da %1 a %2
+insert\ entry\ %0=inserisci la voce %0
+insert\ string\ %0=inserisci la stringa %0
+remove\ entry\ %0=rimuovi la voce %0
+remove\ string\ %0=rimuovi la stringa %0
+undefined=non definito
+Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=Non trovo informazioni in base alla data %0: %1
+Get\ BibTeX\ data\ from\ %0=Preleva i dati BibTeX da %0
+No\ %0\ found=Nessun %0 trovato
+Entry\ from\ %0=Voce da %0
+Merge\ entry\ with\ %0\ information=Accorpa la voce con l'informazione %0
+Updated\ entry\ with\ info\ from\ %0=Aggiornata la voce con l'informazione da %0
 
-Add_existing_file=Aggiungi_file_esistente
-Create_new_list=Crea_una_nuova_lista
-Remove_list=Rimuovi_la_lista
-Full_journal_name=Nome_completo_della_rivista
-Abbreviation_name=Nome_abbreviato
+Add\ existing\ file=Aggiungi file esistente
+Create\ new\ list=Crea una nuova lista
+Remove\ list=Rimuovi la lista
+Full\ journal\ name=Nome completo della rivista
+Abbreviation\ name=Nome abbreviato
 
-No_abbreviation_files_loaded=Nessun_file_di_abbreviazioni_caricato
+No\ abbreviation\ files\ loaded=Nessun file di abbreviazioni caricato
 
-Loading_built_in_lists=Caricamento_liste_predefinite
+Loading\ built\ in\ lists=Caricamento liste predefinite
 
-JabRef_built_in_list=Liste_predefinite_di_JabRef
-IEEE_built_in_list=Liste_predefinite_di_IEEE
+JabRef\ built\ in\ list=Liste predefinite di JabRef
+IEEE\ built\ in\ list=Liste predefinite di IEEE
 
-Event_log=Log_degli_eventi
-We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.=Ora_ti_daremo_un'idea_del_funzionamento_interno_di_JabRef._Questa_informazione_potrà_essere_utile_per_diagnosticare_la_causa_originale_del_problema._Per_favore,_sentitevi_liberi_di_informare_gli_sviluppatori_di_qualsiasi_problema.
-Log_copied_to_clipboard.=Log_copiato_negli_appunti.
-Copy_Log=Copia_il_log
-Clear_Log=Cancello_il_log
-Report_Issue=Segnala_il_problema
-Issue_on_GitHub_successfully_reported.=Problema_di_GitHub_segnalato_con_successo.
-Issue_report_successful=Segnalazione_del_problema_avvenuta_con_successo
-Your_issue_was_reported_in_your_browser.=Il_problema_è_stato_segnalato_nel_browser.
-The_log_and_exception_information_was_copied_to_your_clipboard.=Il_log_e_le_informazioni_dell'eccezione_sono_stati_copiati_negli_appunti.
-Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.=Per_favore,_incolla_questa_informazione_(con_Ctrl+V)_nella_descrizione_del_problema.
+Event\ log=Log degli eventi
+We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef\'s\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=Ora ti daremo un'idea del funzionamento interno di JabRef. Questa informazione potrà essere utile per diagnosticare la causa originale del problema. Per favore, sentitevi liberi di informare gli sviluppatori di qualsiasi problema.
+Log\ copied\ to\ clipboard.=Log copiato negli appunti.
+Copy\ Log=Copia il log
+Clear\ Log=Cancello il log
+Report\ Issue=Segnala il problema
+Issue\ on\ GitHub\ successfully\ reported.=Problema di GitHub segnalato con successo.
+Issue\ report\ successful=Segnalazione del problema avvenuta con successo
+Your\ issue\ was\ reported\ in\ your\ browser.=Il problema è stato segnalato nel browser.
+The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=Il log e le informazioni dell'eccezione sono stati copiati negli appunti.
+Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=Per favore, incolla questa informazione (con Ctrl+V) nella descrizione del problema.
 
 Connection=Connessione
 Connecting...=Connetto...
@@ -2164,194 +2164,194 @@ Port=Porta
 Library=Libreria
 User=Utente
 Connect=Connetto
-Connection_error=Errore_di_connessione
-Connection_to_%0_server_established.=Connessione_al_server_%0_stabilita.
-Required_field_"%0"_is_empty.=Il_campo_obbligatorio_"%0"_è_vuoto.
-%0_driver_not_available.=Driver_%0_non_disponibile.
-The_connection_to_the_server_has_been_terminated.=La_connessione_al_server_è_stata_interrotta.
-Connection_lost.=Connessione_perduta.
+Connection\ error=Errore di connessione
+Connection\ to\ %0\ server\ established.=Connessione al server %0 stabilita.
+Required\ field\ "%0"\ is\ empty.=Il campo obbligatorio "%0" è vuoto.
+%0\ driver\ not\ available.=Driver %0 non disponibile.
+The\ connection\ to\ the\ server\ has\ been\ terminated.=La connessione al server è stata interrotta.
+Connection\ lost.=Connessione perduta.
 Reconnect=Riconnetto
-Work_offline=Lavora_senza_connessione
-Working_offline.=Senza_connessione.
-Update_refused.=Aggiornamento_rifiutato.
-Update_refused=Aggiornamento_rifiutato
-Local_entry=Voce_locale
-Shared_entry=Voce_condivisa
-Update_could_not_be_performed_due_to_existing_change_conflicts.=L'aggiornamento_non_è_stato_possibile_a_causa_di_un_conflitto_tra_modifiche.
-You_are_not_working_on_the_newest_version_of_BibEntry.=Non_stai_usando_la_versione_più_recente_di_BibEntry.
-Local_version\:_%0=Versione_locale\:_%0
-Shared_version\:_%0=Versione_condivisa\:_%0
-Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.=Accorpa_la_voce_condivisa_con_la_tua_e_premi_"Accorpa_voci"_per_risolvere_questo_problema.
-Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?=Cancellare_questa_operazione_lascerà_le_modifiche_non_sincronizzate._Cancella_comunque?
-Shared_entry_is_no_longer_present=La_voce_condivisa_non_è_più_presente
-The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.=La_BibEntry_su_cui_stai_lavorando_è_stata_cancellata_dalla_parte_che_l'ha_condivisa.
-You_can_restore_the_entry_using_the_"Undo"_operation.=Puoi_ripristinare_la_voce_usando_l'"Undo".
-Remember_password?=Devo_ricordare_la_password?
-You_are_already_connected_to_a_database_using_entered_connection_details.=Sei_già_connesso_ad_una_libreria_con_i_dettagli_di_connessione_specificati.
+Work\ offline=Lavora senza connessione
+Working\ offline.=Senza connessione.
+Update\ refused.=Aggiornamento rifiutato.
+Update\ refused=Aggiornamento rifiutato
+Local\ entry=Voce locale
+Shared\ entry=Voce condivisa
+Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=L'aggiornamento non è stato possibile a causa di un conflitto tra modifiche.
+You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=Non stai usando la versione più recente di BibEntry.
+Local\ version\:\ %0=Versione locale: %0
+Shared\ version\:\ %0=Versione condivisa: %0
+Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=Accorpa la voce condivisa con la tua e premi "Accorpa voci" per risolvere questo problema.
+Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=Cancellare questa operazione lascerà le modifiche non sincronizzate. Cancella comunque?
+Shared\ entry\ is\ no\ longer\ present=La voce condivisa non è più presente
+The\ BibEntry\ you\ currently\ work\ on\ has\ been\ deleted\ on\ the\ shared\ side.=La BibEntry su cui stai lavorando è stata cancellata dalla parte che l'ha condivisa.
+You\ can\ restore\ the\ entry\ using\ the\ "Undo"\ operation.=Puoi ripristinare la voce usando l'"Undo".
+Remember\ password?=Devo ricordare la password?
+You\ are\ already\ connected\ to\ a\ database\ using\ entered\ connection\ details.=Sei già connesso ad una libreria con i dettagli di connessione specificati.
 
-Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?=Non_posso_citare_voci_senza_chiavi_BibTeX._Le_genero_ora?
-New_technical_report=Nuovo_rapporto_tecnico
+Cannot\ cite\ entries\ without\ BibTeX\ keys.\ Generate\ keys\ now?=Non posso citare voci senza chiavi BibTeX. Le genero ora?
+New\ technical\ report=Nuovo rapporto tecnico
 
-%0_file=file_%0
-Custom_layout_file=File_di_layout_apposito
-Protected_terms_file=File_di_termini_protetti
-Style_file=File_stile
+%0\ file=file %0
+Custom\ layout\ file=File di layout apposito
+Protected\ terms\ file=File di termini protetti
+Style\ file=File stile
 
-Open_OpenOffice/LibreOffice_connection=Apri_connessione_OpenOffice/LibreOffice
-You_must_enter_at_least_one_field_name=Devi_inserire_almeno_il_nome_di_un_campo
-Non-ASCII_encoded_character_found=Trovato_un_carattere_non_codificato_ASCII
-Toggle_web_search_interface=Inverti_la_selezione_dell'interfaccia_di_ricerca_web
-Background_color_for_resolved_fields=Colore_di_sfondo_per_i_campi_risolti
-Color_code_for_resolved_fields=Codice_di_colore_per_i_campi_risolti
-%0_files_found=Trovati_%0_file
-%0_of_%1=%0_di_%1
-One_file_found=Trovato_un_file
-The_import_finished_with_warnings\:=L'importazione_è_terminata_con_degli_avvisi\:
-There_was_one_file_that_could_not_be_imported.=Un_file_non_è_stato_importato.
-There_were_%0_files_which_could_not_be_imported.=%0_file_non_sono_stati_importati.
+Open\ OpenOffice/LibreOffice\ connection=Apri connessione OpenOffice/LibreOffice
+You\ must\ enter\ at\ least\ one\ field\ name=Devi inserire almeno il nome di un campo
+Non-ASCII\ encoded\ character\ found=Trovato un carattere non codificato ASCII
+Toggle\ web\ search\ interface=Inverti la selezione dell'interfaccia di ricerca web
+Background\ color\ for\ resolved\ fields=Colore di sfondo per i campi risolti
+Color\ code\ for\ resolved\ fields=Codice di colore per i campi risolti
+%0\ files\ found=Trovati %0 file
+%0\ of\ %1=%0 di %1
+One\ file\ found=Trovato un file
+The\ import\ finished\ with\ warnings\:=L'importazione è terminata con degli avvisi:
+There\ was\ one\ file\ that\ could\ not\ be\ imported.=Un file non è stato importato.
+There\ were\ %0\ files\ which\ could\ not\ be\ imported.=%0 file non sono stati importati.
 
-Migration_help_information=Informazioni_per_la_migrazione
-Entered_database_has_obsolete_structure_and_is_no_longer_supported.=La_libreria_selezionata_ha_una_struttura_obsoleta_e_non_è_più_supportata.
-However,_a_new_database_was_created_alongside_the_pre-3.6_one.=Tuttavia_è_stata_creata_una_nuova_libreria_oltre_a_quello_pre-3.6.
-Click_here_to_learn_about_the_migration_of_pre-3.6_databases.=Clicca_qui_per_informazioni_sulla_migrazione_di_librerie_pre-3.6
-Opens_JabRef's_Facebook_page=Apri_la_pagina_Facebook_di_JabRef
-Opens_JabRef's_blog=Apri_il_blog_di_JabRef
-Opens_JabRef's_website=Apri_il_sito_web_di_JabRef
-Opens_a_link_where_the_current_development_version_can_be_downloaded=Apri_un_collegamento_da_cui_scaricare_la_versione_di_sviluppo
-See_what_has_been_changed_in_the_JabRef_versions=Vedi_cosa_è_cambiato_tra_le_versioni_di_JabRef
-Referenced_BibTeX_key_does_not_exist=La_chiave_BibTeX_a_cui_ci_si_riferisce_non_esiste
-Finished_downloading_full_text_document_for_entry_%0.=Lo_scaricamento_del_testo_completo_del_documento_della_voce_%0_è_terminato.
-Full_text_document_download_failed_for_entry_%0.=Lo_scaricamento_del_testo_completo_del_documento_della_voce_%0_è_fallito
-Look_up_full_text_documents=Cerca_documenti_completi
-You_are_about_to_look_up_full_text_documents_for_%0_entries.=Stai_per_cercare_documenti_completi_per_la_voce_%0.
-last_four_nonpunctuation_characters_should_be_numerals=gli_ultimi_quattro_caratteri_non_di_interpunzione_devono_essere_dei_numerali
+Migration\ help\ information=Informazioni per la migrazione
+Entered\ database\ has\ obsolete\ structure\ and\ is\ no\ longer\ supported.=La libreria selezionata ha una struttura obsoleta e non è più supportata.
+However,\ a\ new\ database\ was\ created\ alongside\ the\ pre-3.6\ one.=Tuttavia è stata creata una nuova libreria oltre a quello pre-3.6.
+Click\ here\ to\ learn\ about\ the\ migration\ of\ pre-3.6\ databases.=Clicca qui per informazioni sulla migrazione di librerie pre-3.6
+Opens\ JabRef's\ Facebook\ page=Apri la pagina Facebook di JabRef
+Opens\ JabRef's\ blog=Apri il blog di JabRef
+Opens\ JabRef's\ website=Apri il sito web di JabRef
+Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=Apri un collegamento da cui scaricare la versione di sviluppo
+See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=Vedi cosa è cambiato tra le versioni di JabRef
+Referenced\ BibTeX\ key\ does\ not\ exist=La chiave BibTeX a cui ci si riferisce non esiste
+Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=Lo scaricamento del testo completo del documento della voce %0 è terminato.
+Full\ text\ document\ download\ failed\ for\ entry\ %0.=Lo scaricamento del testo completo del documento della voce %0 è fallito
+Look\ up\ full\ text\ documents=Cerca documenti completi
+You\ are\ about\ to\ look\ up\ full\ text\ documents\ for\ %0\ entries.=Stai per cercare documenti completi per la voce %0.
+last\ four\ nonpunctuation\ characters\ should\ be\ numerals=gli ultimi quattro caratteri non di interpunzione devono essere dei numerali
 
 Author=Autore
 Date=Data
-File_annotations=File_di_annotazioni
-Show_file_annotations=Mostra_il_file_delle_annotazioni
-Adobe_Acrobat_Reader=Adobe_Acrobat_Reader
-Sumatra_Reader=Sumatra_Reader
+File\ annotations=File di annotazioni
+Show\ file\ annotations=Mostra il file delle annotazioni
+Adobe\ Acrobat\ Reader=Adobe Acrobat Reader
+Sumatra\ Reader=Sumatra Reader
 shared=condiviso
-should_contain_an_integer_or_a_literal=deve_contenere_almeno_un_intero_o_una_lettera
-should_have_the_first_letter_capitalized=la_prima_lettera_deve_essere_maiuscola
+should\ contain\ an\ integer\ or\ a\ literal=deve contenere almeno un intero o una lettera
+should\ have\ the\ first\ letter\ capitalized=la prima lettera deve essere maiuscola
 Tools=Strumenti
-What\'s_new_in_this_version?=Cosa_c\'è_di_nuovo_in_questa_versione?
-Want_to_help?=Ti_serve_aiuto?
-Make_a_donation=Fai_una_donazione
-get_involved=collabora_con_noi
-Used_libraries=Librerie_usate
-Existing_file=File_esistente
+What\'s\ new\ in\ this\ version?=Cosa c\'è di nuovo in questa versione?
+Want\ to\ help?=Ti serve aiuto?
+Make\ a\ donation=Fai una donazione
+get\ involved=collabora con noi
+Used\ libraries=Librerie usate
+Existing\ file=File esistente
 
 ID=ID
-ID_type=Tipo_di_ID
-ID-based_entry_generator=Generatore_di_voci_basato_su_ID
-Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=Il_collettore_'%0'_non_ha_trovato_una_voce_per_l'id_'%1'
+ID\ type=Tipo di ID
+ID-based\ entry\ generator=Generatore di voci basato su ID
+Fetcher\ '%0'\ did\ not\ find\ an\ entry\ for\ id\ '%1'.=Il collettore '%0' non ha trovato una voce per l'id '%1'
 
-Select_first_entry=Seleziona_la_prima_voce
-Select_last_entry=Seleziona_l'ultima_voce
+Select\ first\ entry=Seleziona la prima voce
+Select\ last\ entry=Seleziona l'ultima voce
 
-Invalid_ISBN\:_'%0'.=ISBN_invalido\:'%0'
-should_be_an_integer_or_normalized=dovrebbe_essere_un_intero_o_normalizzato
-should_be_normalized=dovrebbe_essere_normalizzato
+Invalid\ ISBN\:\ '%0'.=ISBN invalido:'%0'
+should\ be\ an\ integer\ or\ normalized=dovrebbe essere un intero o normalizzato
+should\ be\ normalized=dovrebbe essere normalizzato
 
-Empty_search_ID=ID_della_ricerca_vuoto
-The_given_search_ID_was_empty.=L'ID_della_ricerca_usato_era_vuoto.
-Copy_BibTeX_key_and_link=Copia_la_chiave_e_il_link_BibTeX
-empty_BibTeX_key=chiave_BibTeX_vuota
-biblatex_field_only=campo_solo_biblatex
+Empty\ search\ ID=ID della ricerca vuoto
+The\ given\ search\ ID\ was\ empty.=L'ID della ricerca usato era vuoto.
+Copy\ BibTeX\ key\ and\ link=Copia la chiave e il link BibTeX
+empty\ BibTeX\ key=chiave BibTeX vuota
+biblatex\ field\ only=campo solo biblatex
 
-Error_while_generating_fetch_URL=Errore_generando_l'URL_per_l'estrazione
-Error_while_parsing_ID_list=Errore_analizzando_la_lista_di_ID
-Unable_to_get_PubMed_IDs=Impossibile_prelevare_gli_ID_di_PubMed
-Backup_found=Trovato_il_backup
-A_backup_file_for_'%0'_was_found.=Non_ho_trovato_un_file_di_backup_per_'%0'
-This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.=Questo_può_significare_che_HabRef_non_si_è_chiuso_correttamente_l'ultima_volta_che_il_file_è_stato_usato.
-Do_you_want_to_recover_the_library_from_the_backup_file?=Vuoi_recuperare_l'archivio_dal_file_di_backup?
-Firstname_Lastname=Nome_Cognome
+Error\ while\ generating\ fetch\ URL=Errore generando l'URL per l'estrazione
+Error\ while\ parsing\ ID\ list=Errore analizzando la lista di ID
+Unable\ to\ get\ PubMed\ IDs=Impossibile prelevare gli ID di PubMed
+Backup\ found=Trovato il backup
+A\ backup\ file\ for\ '%0'\ was\ found.=Non ho trovato un file di backup per '%0'
+This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Questo può significare che HabRef non si è chiuso correttamente l'ultima volta che il file è stato usato.
+Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Vuoi recuperare l'archivio dal file di backup?
+Firstname\ Lastname=Nome Cognome
 
-Recommended_for_%0=Raccomandato_per_%0
-Show_'Related_Articles'_tab=Mostra_il_tab_'Articoli_Correlati'
-This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=Questo_può_essere_dovuto_al_raggiungimento_del_limite_di_traffico_di_Google_Scholar_(vedi_'Aiuto'_per_i_dettagli).
+Recommended\ for\ %0=Raccomandato per %0
+Show\ 'Related\ Articles'\ tab=Mostra il tab 'Articoli Correlati'
+This\ might\ be\ caused\ by\ reaching\ the\ traffic\ limitation\ of\ Google\ Scholar\ (see\ 'Help'\ for\ details).=Questo può essere dovuto al raggiungimento del limite di traffico di Google Scholar (vedi 'Aiuto' per i dettagli).
 
-Could_not_open_website.=Non_posso_aprire_il_sito_web.
-Problem_downloading_from_%1=Problema_scaricando_da_%1
+Could\ not\ open\ website.=Non posso aprire il sito web.
+Problem\ downloading\ from\ %1=Problema scaricando da %1
 
-File_directory_pattern=Modello_della_cartella_dei_file
-Update_with_bibliographic_information_from_the_web=Aggiorna_con_informazioni_bibliografiche_dal_web
+File\ directory\ pattern=Modello della cartella dei file
+Update\ with\ bibliographic\ information\ from\ the\ web=Aggiorna con informazioni bibliografiche dal web
 
-Could_not_find_any_bibliographic_information.=Non_ho_trovato_informazioni_bibliografiche.
-BibTeX_key_deviates_from_generated_key=Chiave_BibTeX_diversa_dalla_chiave_generata
-DOI_%0_is_invalid=DOI_%0_non_valido
+Could\ not\ find\ any\ bibliographic\ information.=Non ho trovato informazioni bibliografiche.
+BibTeX\ key\ deviates\ from\ generated\ key=Chiave BibTeX diversa dalla chiave generata
+DOI\ %0\ is\ invalid=DOI %0 non valido
 
-Select_all_customized_types_to_be_stored_in_local_preferences=Seleziona_tutti_i_tipi_personalizzati_da_registrare_nelle_preferenze_locali
-Currently_unknown=Attualmente_sconosciuto
-Different_customization,_current_settings_will_be_overwritten=Personalizzazione_differente,_i_parametri_correnti_saranno_sovrascritti
+Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences=Seleziona tutti i tipi personalizzati da registrare nelle preferenze locali
+Currently\ unknown=Attualmente sconosciuto
+Different\ customization,\ current\ settings\ will\ be\ overwritten=Personalizzazione differente, i parametri correnti saranno sovrascritti
 
-Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX=Il_tipo_di_voce_%0_è_definita_per_Biblatex_ma_non_per_BibTeX
-Jump_to_entry=Salta_alla_voce
+Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=Il tipo di voce %0 è definita per Biblatex ma non per BibTeX
+Jump\ to\ entry=Salta alla voce
 
-Copied_%0_citations.=Copiate_%0_citazioni.
+Copied\ %0\ citations.=Copiate %0 citazioni.
 Copying...=Copia...
 
-journal_not_found_in_abbreviation_list=rivista_non_trovata_nella_lista_delle_abbreviazioni
-Unhandled_exception_occurred.=È_avvenuta_un\'eccezione_non_gestita.
+journal\ not\ found\ in\ abbreviation\ list=rivista non trovata nella lista delle abbreviazioni
+Unhandled\ exception\ occurred.=È avvenuta un\'eccezione non gestita.
 
-strings_included=stringhe_incluse
-Color_for_disabled_icons=Colore_per_le_icone_disabilitate
-Color_for_enabled_icons=Colore_per_le_icone_abilitate
-Size_of_large_icons=Dimensione_delle_icone_grandi
-Size_of_small_icons=Dimensione_delle_icone_piccole
-Default_table_font_size=Grandezza_predefinita_per_i_font_delle_tavole
-Escape_underscores=Marca_i_caratteri_di_sottolineatura
+strings\ included=stringhe incluse
+Color\ for\ disabled\ icons=Colore per le icone disabilitate
+Color\ for\ enabled\ icons=Colore per le icone abilitate
+Size\ of\ large\ icons=Dimensione delle icone grandi
+Size\ of\ small\ icons=Dimensione delle icone piccole
+Default\ table\ font\ size=Grandezza predefinita per i font delle tavole
+Escape\ underscores=Marca i caratteri di sottolineatura
 Color=Colore
-Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=Per_favore_aggiungi_anche_tutti_i_passi_per_riprodurre_questo_problema,_se_possibile.
-Fit_width=Adatta_alla_larghezza
-Fit_a_single_page=Adatta_a_pagina_singola
-Zoom_in=Ingrandisci
-Zoom_out=Rimpicciolisci
-Previous_page=Pagina_precedente
-Next_page=Pagina_successiva
-Document_viewer=Visualizzatore_del_documento
+Please\ also\ add\ all\ steps\ to\ reproduce\ this\ issue,\ if\ possible.=Per favore aggiungi anche tutti i passi per riprodurre questo problema, se possibile.
+Fit\ width=Adatta alla larghezza
+Fit\ a\ single\ page=Adatta a pagina singola
+Zoom\ in=Ingrandisci
+Zoom\ out=Rimpicciolisci
+Previous\ page=Pagina precedente
+Next\ page=Pagina successiva
+Document\ viewer=Visualizzatore del documento
 Live=Attivo
 Locked=bloccato
-Show_document_viewer=Mostra_il_visualizzatore_del_documento
-Show_the_document_of_the_currently_selected_entry.=Mostra_il_documento_della_voce_attualmente_selezionata.
-Show_this_document_until_unlocked.=Mostra_questo_documento_finché_non_viene_sbloccato.
-Set_current_user_name_as_owner.=Imposta_il_nome_dell'utente_corrente_come_proprietario.
+Show\ document\ viewer=Mostra il visualizzatore del documento
+Show\ the\ document\ of\ the\ currently\ selected\ entry.=Mostra il documento della voce attualmente selezionata.
+Show\ this\ document\ until\ unlocked.=Mostra questo documento finché non viene sbloccato.
+Set\ current\ user\ name\ as\ owner.=Imposta il nome dell'utente corrente come proprietario.
 
-Sort_all_subgroups_(recursively)=Ordina_tutti_i_sottogruppi_(ricorsivamente)
-Collect_and_share_telemetry_data_to_help_improve_JabRef.=Registra_e_condividi_i_dati_di_telemetria_per_aiutare_a_migliorare_JabRef.
-Don't_share=Non_condividere
-Share_anonymous_statistics=Condividi_statistiche_anonime
-Telemetry\:_Help_make_JabRef_better=Telemetria\:_Aiuta_a_migliorare_JabRef
-To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.=Per_migliorare_l'esperienza_utente,_vorremmo_raccogliere_delle_statistiche_anonime_sulle_funzioni_che_usi._Registreremo_solo_quali_funzioni_accedi_e_quanto_spesso._Non_registreremo_dati_personali_né_il_contenuto_delle_voci_bibliografiche._Se_scegli_di_permettere_la_raccolta_dei_dati,_potrai_disabilitarla_successivamente_da_Opzioni_->_Preferenze_->_Generale.
-This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?=Questo_file_è_stato_trovato_automaticamente._Vuoi_collegarlo_a_questa_voce?
-Names_are_not_in_the_standard_%0_format.=I_nomi_non_sono_nel_formato_standard_%0.
+Sort\ all\ subgroups\ (recursively)=Ordina tutti i sottogruppi (ricorsivamente)
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=Registra e condividi i dati di telemetria per aiutare a migliorare JabRef.
+Don't\ share=Non condividere
+Share\ anonymous\ statistics=Condividi statistiche anonime
+Telemetry\:\ Help\ make\ JabRef\ better=Telemetria: Aiuta a migliorare JabRef
+To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ statistics\ on\ the\ features\ you\ use.\ We\ will\ only\ record\ what\ features\ you\ access\ and\ how\ often\ you\ do\ it.\ We\ will\ neither\ collect\ any\ personal\ data\ nor\ the\ content\ of\ bibliographic\ items.\ If\ you\ choose\ to\ allow\ data\ collection,\ you\ can\ later\ disable\ it\ via\ Options\ ->\ Preferences\ ->\ General.=Per migliorare l'esperienza utente, vorremmo raccogliere delle statistiche anonime sulle funzioni che usi. Registreremo solo quali funzioni accedi e quanto spesso. Non registreremo dati personali né il contenuto delle voci bibliografiche. Se scegli di permettere la raccolta dei dati, potrai disabilitarla successivamente da Opzioni -> Preferenze -> Generale.
+This\ file\ was\ found\ automatically.\ Do\ you\ want\ to\ link\ it\ to\ this\ entry?=Questo file è stato trovato automaticamente. Vuoi collegarlo a questa voce?
+Names\ are\ not\ in\ the\ standard\ %0\ format.=I nomi non sono nel formato standard %0.
 
-Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.=Cancello_permanentemente_i_file_selezionati_dal_disco,_o_rimuovo_solo_il_file_dalla_voce?_Premendo_Cancella_il_file_verrà_cancellato_permanentemente_dal_disco.
-Delete_'%0'=Cancella_'%0'
-Delete_from_disk=Cancella_dal_disco
-Remove_from_entry=Rimuovi_dalla_voce
-The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.=Il_nome_di_gruppo_contiene_il_separatore_di_keyword_"%0"_e_quindi_probabilmente_non_funziona_come_ci_si_aspetta.
-There_exists_already_a_group_with_the_same_name.=Esiste_già_almeno_un_gruppo_con_lo_stesso_nome.
+Delete\ the\ selected\ file\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ file\ permanently\ from\ disk.=Cancello permanentemente i file selezionati dal disco, o rimuovo solo il file dalla voce? Premendo Cancella il file verrà cancellato permanentemente dal disco.
+Delete\ '%0'=Cancella '%0'
+Delete\ from\ disk=Cancella dal disco
+Remove\ from\ entry=Rimuovi dalla voce
+The\ group\ name\ contains\ the\ keyword\ separator\ "%0"\ and\ thus\ probably\ does\ not\ work\ as\ expected.=Il nome di gruppo contiene il separatore di keyword "%0" e quindi probabilmente non funziona come ci si aspetta.
+There\ exists\ already\ a\ group\ with\ the\ same\ name.=Esiste già almeno un gruppo con lo stesso nome.
 
-Copy_linked_files_to_folder...=
-Copied_file_successfully=
-Copying_files...=
-Copying_file_%0_of_entry_%1=
-Finished_copying=
-Could_not_copy_file=
-Copied_%0_files_of_%1_sucessfully_to_%2=
-Rename_failed=
-JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.=
-Show_console_output_(only_necessary_when_the_launcher_is_used)=
+Copy\ linked\ files\ to\ folder...=
+Copied\ file\ successfully=
+Copying\ files...=
+Copying\ file\ %0\ of\ entry\ %1=
+Finished\ copying=
+Could\ not\ copy\ file=
+Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=
+Rename\ failed=
+JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=
+Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=
 
-Remove_line_breaks=
-Removes_all_line_breaks_in_the_field_content.=
-Checking_integrity...=
+Remove\ line\ breaks=
+Removes\ all\ line\ breaks\ in\ the\ field\ content.=
+Checking\ integrity...=
 
-Remove_hyphenated_line_breaks=
-Removes_all_hyphenated_line_breaks_in_the_field_content.=
-Note_that_currently,_JabRef_does_not_run_with_Java_9.=
-Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.=
+Remove\ hyphenated\ line\ breaks=
+Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=
+Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=
+Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -1,8 +1,3 @@
-
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 contiene l'espressione regolare <b>%1</b>
 
 %0\ contains\ the\ term\ <b>%1</b>=%0 contiene il termine <b>%1</b>

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -3,156 +3,156 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-%0_contains_the_regular_expression_<b>%1</b>=%0には，正規表現<b>%1</b>が含まれています
+%0\ contains\ the\ regular\ expression\ <b>%1</b>=%0には，正規表現<b>%1</b>が含まれています
 
-%0_contains_the_term_<b>%1</b>=%0には，用語<b>%1</b>が含まれています
+%0\ contains\ the\ term\ <b>%1</b>=%0には，用語<b>%1</b>が含まれています
 
-%0_doesn't_contain_the_regular_expression_<b>%1</b>=%0には，正規表現<b>%1</b>が含まれていません
+%0\ doesn't\ contain\ the\ regular\ expression\ <b>%1</b>=%0には，正規表現<b>%1</b>が含まれていません
 
-%0_doesn't_contain_the_term_<b>%1</b>=%0には，用語<b>%1</b>が含まれていません
+%0\ doesn't\ contain\ the\ term\ <b>%1</b>=%0には，用語<b>%1</b>が含まれていません
 
-%0_export_successful=%0個の書き出しに成功しました
+%0\ export\ successful=%0個の書き出しに成功しました
 
-%0_matches_the_regular_expression_<b>%1</b>=%0は正規表現<b>%1</b>に一致します
+%0\ matches\ the\ regular\ expression\ <b>%1</b>=%0は正規表現<b>%1</b>に一致します
 
-%0_matches_the_term_<b>%1</b>=%0は項目<b>%1</b>に一致します
+%0\ matches\ the\ term\ <b>%1</b>=%0は項目<b>%1</b>に一致します
 
-<field_name>=<フィールド名>
-<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>=<HTML>項目「%1」からリンクされているファイル<BR>「%0」を見つけることができませんでした</HTML>
+<field\ name>=<フィールド名>
+<HTML>Could\ not\ find\ file\ '%0'<BR>linked\ from\ entry\ '%1'</HTML>=<HTML>項目「%1」からリンクされているファイル<BR>「%0」を見つけることができませんでした</HTML>
 
 <select>=<選択してください>
 
-<select_word>=<単語を選択してください>
-Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)=選択項目の学術誌名を短縮形にします（ISO式短縮形）
-Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)=選択項目の学術誌名を短縮形にします（MEDLINE式短縮形）
+<select\ word>=<単語を選択してください>
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (ISO\ abbreviation)=選択項目の学術誌名を短縮形にします（ISO式短縮形）
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (MEDLINE\ abbreviation)=選択項目の学術誌名を短縮形にします（MEDLINE式短縮形）
 
-Abbreviate_names=名前を短縮形に
-Abbreviated_%0_journal_names.=%0個の誌名を略語化しました．
+Abbreviate\ names=名前を短縮形に
+Abbreviated\ %0\ journal\ names.=%0個の誌名を略語化しました．
 
 Abbreviation=短縮形
 
-About_JabRef=JabRefについて
+About\ JabRef=JabRefについて
 
 Abstract=概要
 
 Accept=受け付ける
 
-Accept_change=変更を受け付ける
+Accept\ change=変更を受け付ける
 
 Action=動作
 
-What_is_Mr._DLib?=Mr._DLibってなにですか？
+What\ is\ Mr.\ DLib?=Mr. DLibってなにですか？
 
 Add=追加
 
-Add_a_(compiled)_custom_Importer_class_from_a_class_path.=(コンパイルした)ユーザー定義ImportFormatクラスをクラスパスから追加します．
-The_path_need_not_be_on_the_classpath_of_JabRef.=このパスは，JabRefのクラスパスにあるとは限りません．
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=(コンパイルした)ユーザー定義ImportFormatクラスをクラスパスから追加します．
+The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=このパスは，JabRefのクラスパスにあるとは限りません．
 
-Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=(コンパイルした)ユーザー定義ImportFormatクラスをZIP書庫から追加します．
-The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=このZIP書庫は，JabRefのクラスパスにあるとは限りません．
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=(コンパイルした)ユーザー定義ImportFormatクラスをZIP書庫から追加します．
+The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=このZIP書庫は，JabRefのクラスパスにあるとは限りません．
 
-Add_a_regular_expression_for_the_key_pattern.=鍵パターンに正規表現を追加します．
+Add\ a\ regular\ expression\ for\ the\ key\ pattern.=鍵パターンに正規表現を追加します．
 
-Add_selected_entries_to_this_group=選択項目をこのグループに追加
+Add\ selected\ entries\ to\ this\ group=選択項目をこのグループに追加
 
-Add_from_folder=フォルダから追加
+Add\ from\ folder=フォルダから追加
 
-Add_from_JAR=jarから追加
+Add\ from\ JAR=jarから追加
 
-add_group=グループを追加
+add\ group=グループを追加
 
-Add_new=新規追加
+Add\ new=新規追加
 
-Add_subgroup=下層グループを追加
+Add\ subgroup=下層グループを追加
 
-Add_to_group=グループに追加
+Add\ to\ group=グループに追加
 
-Added_group_"%0".=グループ「%0」を追加しました．
+Added\ group\ "%0".=グループ「%0」を追加しました．
 
-Added_missing_braces.=
+Added\ missing\ braces.=
 
-Added_new=新規に追加しました
+Added\ new=新規に追加しました
 
-Added_string=文字列を追加しました
+Added\ string=文字列を追加しました
 
-Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.=さらに，<b>%0</b>フィールドに<b>%1</b>が含まれていない項目は，選択してからドラッグアンドドロップをするかコンテクストメニューを使うことで，手動でこのグループに割り当てることができます．こうすることによって，各項目の<b>%0</b>フィールドに用語<b>%1</b>が追加されます．
+Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ can\ be\ assigned\ manually\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ This\ process\ adds\ the\ term\ <b>%1</b>\ to\ each\ entry's\ <b>%0</b>\ field.\ Entries\ can\ be\ removed\ manually\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.\ This\ process\ removes\ the\ term\ <b>%1</b>\ from\ each\ entry's\ <b>%0</b>\ field.=さらに，<b>%0</b>フィールドに<b>%1</b>が含まれていない項目は，選択してからドラッグアンドドロップをするかコンテクストメニューを使うことで，手動でこのグループに割り当てることができます．こうすることによって，各項目の<b>%0</b>フィールドに用語<b>%1</b>が追加されます．
 
 Advanced=詳細設定
-All_entries=全項目
-All_entries_of_this_type_will_be_declared_typeless._Continue?=この型の項目はすべて型なしと宣言されます．続けますか？
+All\ entries=全項目
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=この型の項目はすべて型なしと宣言されます．続けますか？
 
-All_fields=全フィールド
+All\ fields=全フィールド
 
-Always_reformat_BIB_file_on_save_and_export=保存・書出の際，つねにBIBファイルを再整形する
+Always\ reformat\ BIB\ file\ on\ save\ and\ export=保存・書出の際，つねにBIBファイルを再整形する
 
-A_SAX_exception_occurred_while_parsing_'%0'\:=「%0」を解析中にSAX例外エラーが発生しました：
+A\ SAX\ exception\ occurred\ while\ parsing\ '%0'\:=「%0」を解析中にSAX例外エラーが発生しました：
 
 and=および
-and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.=また，次回JabRefを起動したときに，お使いのクラスパス中でクラスが利用可能になっていなくてはなりません．
+and\ the\ class\ must\ be\ available\ in\ your\ classpath\ next\ time\ you\ start\ JabRef.=また，次回JabRefを起動したときに，お使いのクラスパス中でクラスが利用可能になっていなくてはなりません．
 
-any_field_that_matches_the_regular_expression_<b>%0</b>=正規表現<b>%0</b>に一致するフィールドすべて
+any\ field\ that\ matches\ the\ regular\ expression\ <b>%0</b>=正規表現<b>%0</b>に一致するフィールドすべて
 
 Appearance=外観
 
 Append=追加
-Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library=BibTeXデータベースから，現在表示しているデータベースに内容を追加する
+Append\ contents\ from\ a\ BibTeX\ library\ into\ the\ currently\ viewed\ library=BibTeXデータベースから，現在表示しているデータベースに内容を追加する
 
-Append_library=データベースを追加
+Append\ library=データベースを追加
 
-Append_the_selected_text_to_BibTeX_field=選択したテキストをBibTeX鍵に追加
+Append\ the\ selected\ text\ to\ BibTeX\ field=選択したテキストをBibTeX鍵に追加
 Application=アプリケーション
 
 Apply=適用
 
-Arguments_passed_on_to_running_JabRef_instance._Shutting_down.=引数は実行中のJabRefインスタンスに渡されました．終了します．
+Arguments\ passed\ on\ to\ running\ JabRef\ instance.\ Shutting\ down.=引数は実行中のJabRefインスタンスに渡されました．終了します．
 
-Assign_new_file=新規ファイルを割り当て
+Assign\ new\ file=新規ファイルを割り当て
 
-Assign_the_original_group's_entries_to_this_group?=元のグループの項目をこのグループに割り当てますか？
+Assign\ the\ original\ group's\ entries\ to\ this\ group?=元のグループの項目をこのグループに割り当てますか？
 
-Assigned_%0_entries_to_group_"%1".=%0項目をグループ「%1」に割り当てました．
+Assigned\ %0\ entries\ to\ group\ "%1".=%0項目をグループ「%1」に割り当てました．
 
-Assigned_1_entry_to_group_"%0".=1項目をグループ「%1」に割り当てました．
+Assigned\ 1\ entry\ to\ group\ "%0".=1項目をグループ「%1」に割り当てました．
 
-Attach_URL=URLを添付
+Attach\ URL=URLを添付
 
-Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.=これは，使用中の項目のファイルリンクを自動設定します．自動設定は，ファイルディレクトリないし下層ディレクトリの<BR>ファイルが，項目のBibTeX鍵と同一名＋拡張子として命名されているときのみ，機能します．
+Attempt\ to\ automatically\ set\ file\ links\ for\ your\ entries.\ Automatically\ setting\ works\ if\ a\ file\ in\ your\ file\ directory<BR>or\ a\ subdirectory\ is\ named\ identically\ to\ an\ entry's\ BibTeX\ key,\ plus\ extension.=これは，使用中の項目のファイルリンクを自動設定します．自動設定は，ファイルディレクトリないし下層ディレクトリの<BR>ファイルが，項目のBibTeX鍵と同一名＋拡張子として命名されているときのみ，機能します．
 
-Autodetect_format=書式を自動検出
+Autodetect\ format=書式を自動検出
 
-Autogenerate_BibTeX_keys=BibTeX鍵を自動生成
+Autogenerate\ BibTeX\ keys=BibTeX鍵を自動生成
 
-Autolink_files_with_names_starting_with_the_BibTeX_key=BibTeX鍵で始まるファイル名を持つファイルを自動リンク
+Autolink\ files\ with\ names\ starting\ with\ the\ BibTeX\ key=BibTeX鍵で始まるファイル名を持つファイルを自動リンク
 
-Autolink_only_files_that_match_the_BibTeX_key=BibTeX鍵に一致するファイルのみを自動リンク
+Autolink\ only\ files\ that\ match\ the\ BibTeX\ key=BibTeX鍵に一致するファイルのみを自動リンク
 
-Automatically_create_groups=グループを自動生成
+Automatically\ create\ groups=グループを自動生成
 
-Automatically_remove_exact_duplicates=完全に同一な重複を自動削除
+Automatically\ remove\ exact\ duplicates=完全に同一な重複を自動削除
 
-Allow_overwriting_existing_links.=既存リンクの上書きを許可する．
+Allow\ overwriting\ existing\ links.=既存リンクの上書きを許可する．
 
-Do_not_overwrite_existing_links.=既存リンクは上書きしない．
+Do\ not\ overwrite\ existing\ links.=既存リンクは上書きしない．
 
-AUX_file_import=AUXファイルの読み込み
+AUX\ file\ import=AUXファイルの読み込み
 
-Available_export_formats=使用できる書き出し書式
+Available\ export\ formats=使用できる書き出し書式
 
-Available_BibTeX_fields=使用できるBibTeXフィールド
+Available\ BibTeX\ fields=使用できるBibTeXフィールド
 
-Available_import_formats=使用できる読み込み書式
+Available\ import\ formats=使用できる読み込み書式
 
-Background_color_for_optional_fields=非必須項目の背景色
+Background\ color\ for\ optional\ fields=非必須項目の背景色
 
-Background_color_for_required_fields=必須項目の背景色
+Background\ color\ for\ required\ fields=必須項目の背景色
 
-Backup_old_file_when_saving=保存時に旧ファイルをバックアップ
+Backup\ old\ file\ when\ saving=保存時に旧ファイルをバックアップ
 
-BibTeX_key_is_unique.=BibTeX鍵は一意です．
+BibTeX\ key\ is\ unique.=BibTeX鍵は一意です．
 
-%0_source=%0ソース
+%0\ source=%0ソース
 
-Broken_link=壊れたリンク
+Broken\ link=壊れたリンク
 
 Browse=一覧
 
@@ -160,321 +160,321 @@ by=置換文字列
 
 Cancel=取消
 
-Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?=鍵を生成しなければ項目をグループに追加することはできません．ここで鍵を生成しますか？
+Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=鍵を生成しなければ項目をグループに追加することはできません．ここで鍵を生成しますか？
 
-Cannot_merge_this_change=この変更を統合することができません
+Cannot\ merge\ this\ change=この変更を統合することができません
 
-case_insensitive=大小文字を区別しない
+case\ insensitive=大小文字を区別しない
 
-case_sensitive=大小文字を区別
+case\ sensitive=大小文字を区別
 
-Case_sensitive=大小文字を区別
+Case\ sensitive=大小文字を区別
 
-change_assignment_of_entries=項目の割り当てを変更
+change\ assignment\ of\ entries=項目の割り当てを変更
 
-Change_case=大小文字を切り替え
+Change\ case=大小文字を切り替え
 
-Change_entry_type=項目型を変更
-Change_file_type=ファイル型を変更
+Change\ entry\ type=項目型を変更
+Change\ file\ type=ファイル型を変更
 
 
-Change_of_Grouping_Method=グループ法を変更
+Change\ of\ Grouping\ Method=グループ法を変更
 
-change_preamble=プリアンブルを変更
+change\ preamble=プリアンブルを変更
 
-Change_table_column_and_General_fields_settings_to_use_the_new_feature=新しい機能を用いるために，表列と汎用フィールドの設定を変更
+Change\ table\ column\ and\ General\ fields\ settings\ to\ use\ the\ new\ feature=新しい機能を用いるために，表列と汎用フィールドの設定を変更
 
-Changed_language_settings=言語設定を変更しました
+Changed\ language\ settings=言語設定を変更しました
 
-Changed_preamble=プリアンブルを変更しました
+Changed\ preamble=プリアンブルを変更しました
 
-Check_existing_file_links=既存のファイルリンクを確認
+Check\ existing\ file\ links=既存のファイルリンクを確認
 
-Check_links=リンクを確認
+Check\ links=リンクを確認
 
-Cite_command=Citeコマンド
+Cite\ command=Citeコマンド
 
-Class_name=クラス名
+Class\ name=クラス名
 
 Clear=消去
 
-Clear_fields=フィールドを消去
+Clear\ fields=フィールドを消去
 
 Close=閉じる
-Close_others=他を閉じる
-Close_all=すべて閉じる
+Close\ others=他を閉じる
+Close\ all=すべて閉じる
 
-Close_dialog=ダイアログを閉じる
+Close\ dialog=ダイアログを閉じる
 
-Close_the_current_library=現在のデータベースを閉じる
+Close\ the\ current\ library=現在のデータベースを閉じる
 
-Close_window=ウィンドウを閉じる
+Close\ window=ウィンドウを閉じる
 
-Closed_library=データベースを閉じました
+Closed\ library=データベースを閉じました
 
-Color_codes_for_required_and_optional_fields=必須フィールドと非必須フィールドのコードに着色
+Color\ codes\ for\ required\ and\ optional\ fields=必須フィールドと非必須フィールドのコードに着色
 
-Color_for_marking_incomplete_entries=不完全な項目を標識するのに使用する色
+Color\ for\ marking\ incomplete\ entries=不完全な項目を標識するのに使用する色
 
-Column_width=列幅
+Column\ width=列幅
 
-Command_line_id=コマンドラインID
+Command\ line\ id=コマンドラインID
 
 
-Contained_in=所在
+Contained\ in=所在
 
 Content=内容
 
 Copied=コピーしました
 
-Copied_cell_contents=セルの内容をコピーしました
+Copied\ cell\ contents=セルの内容をコピーしました
 
-Copied_title=タイトルをコピーしました
+Copied\ title=タイトルをコピーしました
 
-Copied_key=鍵をコピーしました
+Copied\ key=鍵をコピーしました
 
-Copied_titles=タイトルをコピーしました
+Copied\ titles=タイトルをコピーしました
 
-Copied_keys=鍵をコピーしました
+Copied\ keys=鍵をコピーしました
 
 Copy=コピー
 
-Copy_BibTeX_key=BibTeX鍵をコピー
-Copy_file_to_file_directory=ファイルをファイルディレクトリにコピーします．
+Copy\ BibTeX\ key=BibTeX鍵をコピー
+Copy\ file\ to\ file\ directory=ファイルをファイルディレクトリにコピーします．
 
-Copy_to_clipboard=クリップボードにコピーします．
+Copy\ to\ clipboard=クリップボードにコピーします．
 
-Could_not_call_executable=実行ファイルを呼び出せませんでした
-Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.=Vimサーバーに接続することができませんでした．Vimが正しいサーバー名で実行されていることを確認してください．
+Could\ not\ call\ executable=実行ファイルを呼び出せませんでした
+Could\ not\ connect\ to\ Vim\ server.\ Make\ sure\ that\ Vim\ is\ running<BR>with\ correct\ server\ name.=Vimサーバーに接続することができませんでした．Vimが正しいサーバー名で実行されていることを確認してください．
 
-Could_not_export_file=ファイルを書き出せませんでした
+Could\ not\ export\ file=ファイルを書き出せませんでした
 
-Could_not_export_preferences=設定を書き出せませんでした
+Could\ not\ export\ preferences=設定を書き出せませんでした
 
-Could_not_find_a_suitable_import_format.=適切な読み込み書式を見つけられませんでした．
-Could_not_import_preferences=設定を読み込めませんでした
+Could\ not\ find\ a\ suitable\ import\ format.=適切な読み込み書式を見つけられませんでした．
+Could\ not\ import\ preferences=設定を読み込めませんでした
 
-Could_not_instantiate_%0=%0にインスタンス化できませんでした
-Could_not_instantiate_%0_%1=%0_%1にインスタンス化できませんでした
-Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?=%0にインスタンス化できませんでした．正しいパッケージパスを選択しましたか？
-Could_not_open_link=リンクを開けませんでした
+Could\ not\ instantiate\ %0=%0にインスタンス化できませんでした
+Could\ not\ instantiate\ %0\ %1=%0 %1にインスタンス化できませんでした
+Could\ not\ instantiate\ %0.\ Have\ you\ chosen\ the\ correct\ package\ path?=%0にインスタンス化できませんでした．正しいパッケージパスを選択しましたか？
+Could\ not\ open\ link=リンクを開けませんでした
 
-Could_not_print_preview=プレビューを印刷できませんでした
+Could\ not\ print\ preview=プレビューを印刷できませんでした
 
-Could_not_run_the_'vim'_program.=「vim」プログラムを実行できませんでした．
+Could\ not\ run\ the\ 'vim'\ program.=「vim」プログラムを実行できませんでした．
 
-Could_not_save_file.=ファイルを保存できませんでした
-Character_encoding_'%0'_is_not_supported.=．文字エンコーディング「%0」はサポートされていません．
+Could\ not\ save\ file.=ファイルを保存できませんでした
+Character\ encoding\ '%0'\ is\ not\ supported.=．文字エンコーディング「%0」はサポートされていません．
 
-crossreferenced_entries_included=相互参照している項目を取り込みました
+crossreferenced\ entries\ included=相互参照している項目を取り込みました
 
-Current_content=現在の内容
+Current\ content=現在の内容
 
-Current_value=現在値
+Current\ value=現在値
 
-Custom_entry_types=ユーザー項目型
+Custom\ entry\ types=ユーザー項目型
 
-Custom_entry_types_found_in_file=ユーザー項目型がファイル中に見つかりました
+Custom\ entry\ types\ found\ in\ file=ユーザー項目型がファイル中に見つかりました
 
-Customize_entry_types=項目型の編集
+Customize\ entry\ types=項目型の編集
 
-Customize_key_bindings=キー割当の編集
+Customize\ key\ bindings=キー割当の編集
 
 Cut=切り取り
 
-cut_entries=項目を切り取り
+cut\ entries=項目を切り取り
 
-cut_entry=項目を切り取り
+cut\ entry=項目を切り取り
 
 
-Library_encoding=データベースのエンコーディング
+Library\ encoding=データベースのエンコーディング
 
-Library_properties=データベース特性
+Library\ properties=データベース特性
 
-Library_type=データベース型
+Library\ type=データベース型
 
-Date_format=日付書式
+Date\ format=日付書式
 
 Default=既定値
 
-Default_encoding=既定エンコーディング
+Default\ encoding=既定エンコーディング
 
-Default_grouping_field=既定のグループ化フィールド
+Default\ grouping\ field=既定のグループ化フィールド
 
-Default_look_and_feel=既定の操作性
+Default\ look\ and\ feel=既定の操作性
 
-Default_pattern=既定パターン
+Default\ pattern=既定パターン
 
-Default_sort_criteria=既定の整序基準
-Define_'%0'=「'%0」を定義
+Default\ sort\ criteria=既定の整序基準
+Define\ '%0'=「'%0」を定義
 
 Delete=削除
 
-Delete_custom_format=ユーザー形式を削除
+Delete\ custom\ format=ユーザー形式を削除
 
-delete_entries=項目を削除
+delete\ entries=項目を削除
 
-Delete_entry=項目を削除
+Delete\ entry=項目を削除
 
-delete_entry=項目を削除
+delete\ entry=項目を削除
 
-Delete_multiple_entries=複数項目を削除
+Delete\ multiple\ entries=複数項目を削除
 
-Delete_rows=行を削除
+Delete\ rows=行を削除
 
-Delete_strings=文字列を削除
+Delete\ strings=文字列を削除
 
 Deleted=削除しました
 
-Permanently_delete_local_file=ローカルファイルを削除
+Permanently\ delete\ local\ file=ローカルファイルを削除
 
-Delimit_fields_with_semicolon,_ex.=各フィールドをセミコロンで区切ってください．例)
+Delimit\ fields\ with\ semicolon,\ ex.=各フィールドをセミコロンで区切ってください．例)
 
 Descending=降順
 
 Description=説明
 
-Deselect_all=すべて選択解除
-Deselect_all_duplicates=重複をすべて削除
+Deselect\ all=すべて選択解除
+Deselect\ all\ duplicates=重複をすべて削除
 
-Disable_this_confirmation_dialog=この確認ダイアログをもう表示しない
+Disable\ this\ confirmation\ dialog=この確認ダイアログをもう表示しない
 
-Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.=選択したグループの一つ以上に属する項目をすべて表示する．
+Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups.=選択したグループの一つ以上に属する項目をすべて表示する．
 
-Display_all_error_messages=全エラーメッセージを表示
+Display\ all\ error\ messages=全エラーメッセージを表示
 
-Display_help_on_command_line_options=コマンドラインオプションに関するヘルプを表示
+Display\ help\ on\ command\ line\ options=コマンドラインオプションに関するヘルプを表示
 
-Display_only_entries_belonging_to_all_selected_groups.=選択したグループ全てに属する項目のみ表示する．
-Display_version=バージョンを表示
+Display\ only\ entries\ belonging\ to\ all\ selected\ groups.=選択したグループ全てに属する項目のみ表示する．
+Display\ version=バージョンを表示
 
-Do_not_abbreviate_names=名前を略さない
+Do\ not\ abbreviate\ names=名前を略さない
 
-Do_not_automatically_set=自動設定しない
+Do\ not\ automatically\ set=自動設定しない
 
-Do_not_import_entry=項目を読み込まない
+Do\ not\ import\ entry=項目を読み込まない
 
-Do_not_open_any_files_at_startup=起動時にファイルを開かない
+Do\ not\ open\ any\ files\ at\ startup=起動時にファイルを開かない
 
-Do_not_overwrite_existing_keys=既存の鍵は上書きしない
-Do_not_show_these_options_in_the_future=これらのオプションはもう表示しない
+Do\ not\ overwrite\ existing\ keys=既存の鍵は上書きしない
+Do\ not\ show\ these\ options\ in\ the\ future=これらのオプションはもう表示しない
 
-Do_not_wrap_the_following_fields_when_saving=以下のフィールドは保存時に改行しない
-Do_not_write_the_following_fields_to_XMP_Metadata\:=以下のフィールドはXMPメタデータに書き込まない：
+Do\ not\ wrap\ the\ following\ fields\ when\ saving=以下のフィールドは保存時に改行しない
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=以下のフィールドはXMPメタデータに書き込まない：
 
-Do_you_want_JabRef_to_do_the_following_operations?=JabRefに以下の操作をさせますか？
+Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=JabRefに以下の操作をさせますか？
 
-Donate_to_JabRef=JabRefに寄付する
+Donate\ to\ JabRef=JabRefに寄付する
 
 Down=下
 
-Download_file=ファイルをダウンロード
+Download\ file=ファイルをダウンロード
 
 Downloading...=ダウンロード中です…
 
-Drop_%0=%0をドロップ
+Drop\ %0=%0をドロップ
 
-duplicate_removal=重複を削除
+duplicate\ removal=重複を削除
 
-Duplicate_string_name=重複した文字列名
+Duplicate\ string\ name=重複した文字列名
 
-Duplicates_found=重複が見つかりました
+Duplicates\ found=重複が見つかりました
 
-Dynamic_groups=動的グループ
+Dynamic\ groups=動的グループ
 
-Dynamically_group_entries_by_a_free-form_search_expression=自由型検索表現で動的にグループ化
+Dynamically\ group\ entries\ by\ a\ free-form\ search\ expression=自由型検索表現で動的にグループ化
 
-Dynamically_group_entries_by_searching_a_field_for_a_keyword=フィールド中のキーワードを検索して動的にグループ化
+Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=フィールド中のキーワードを検索して動的にグループ化
 
-Each_line_must_be_on_the_following_form=各行は以下の形でなくてはなりません
+Each\ line\ must\ be\ on\ the\ following\ form=各行は以下の形でなくてはなりません
 
 Edit=編集
 
-Edit_custom_export=ユーザー書出を編集
-Edit_entry=項目を編集
-Save_file=ファイルリンクを編集
-Edit_file_type=ファイル型を編集
+Edit\ custom\ export=ユーザー書出を編集
+Edit\ entry=項目を編集
+Save\ file=ファイルリンクを編集
+Edit\ file\ type=ファイル型を編集
 
-Edit_group=グループを編集
+Edit\ group=グループを編集
 
 
-Edit_preamble=プリアンブルを編集
-Edit_strings=文字列を編集
-Editor_options=エディタオプション
+Edit\ preamble=プリアンブルを編集
+Edit\ strings=文字列を編集
+Editor\ options=エディタオプション
 
-Empty_BibTeX_key=BibTeX鍵を空にする
+Empty\ BibTeX\ key=BibTeX鍵を空にする
 
-Grouping_may_not_work_for_this_entry.=この項目に対するグループ化は動作しないかもしれません
+Grouping\ may\ not\ work\ for\ this\ entry.=この項目に対するグループ化は動作しないかもしれません
 
-empty_library=データベースは空です
-Enable_word/name_autocompletion=単語と名称の自動補完を有効にする
+empty\ library=データベースは空です
+Enable\ word/name\ autocompletion=単語と名称の自動補完を有効にする
 
-Enter_URL=URLを入力してください
+Enter\ URL=URLを入力してください
 
-Enter_URL_to_download=ダウンロードするURLを入力してください
+Enter\ URL\ to\ download=ダウンロードするURLを入力してください
 
 entries=項目
 
-Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.=項目を手動でこのグループへ割り当てたり，このグループから削除したりすることができません．
+Entries\ cannot\ be\ manually\ assigned\ to\ or\ removed\ from\ this\ group.=項目を手動でこのグループへ割り当てたり，このグループから削除したりすることができません．
 
-Entries_exported_to_clipboard=項目をクリップボードに書き出しました
+Entries\ exported\ to\ clipboard=項目をクリップボードに書き出しました
 
 
 entry=項目
 
-Entry_editor=項目エディタ
+Entry\ editor=項目エディタ
 
-Entry_preview=項目プレビュー
+Entry\ preview=項目プレビュー
 
-Entry_table=項目表
+Entry\ table=項目表
 
-Entry_table_columns=項目表の列
+Entry\ table\ columns=項目表の列
 
-Entry_type=項目型
+Entry\ type=項目型
 
-Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters=項目型名には，スペースや以下の文字が含まれてはなりません
+Entry\ type\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=項目型名には，スペースや以下の文字が含まれてはなりません
 
-Entry_types=項目型
+Entry\ types=項目型
 
 Error=エラー
-Error_exporting_to_clipboard=クリップボード書き出し中にエラー発生
+Error\ exporting\ to\ clipboard=クリップボード書き出し中にエラー発生
 
-Error_occurred_when_parsing_entry=項目を解析中にエラーが発生
+Error\ occurred\ when\ parsing\ entry=項目を解析中にエラーが発生
 
-Error_opening_file=ファイルを開く際にエラー発生
+Error\ opening\ file=ファイルを開く際にエラー発生
 
-Error_setting_field=フィールド設定時にエラー発生
+Error\ setting\ field=フィールド設定時にエラー発生
 
-Error_while_writing=書き込み中にエラー発生
-Error_writing_to_%0_file(s).=%0ファイルを書き込み中にエラー発生
+Error\ while\ writing=書き込み中にエラー発生
+Error\ writing\ to\ %0\ file(s).=%0ファイルを書き込み中にエラー発生
 
 
 
-'%0'_exists._Overwrite_file?='%0'_は存在します．ファイルを上書きしますか？
-Overwrite_file?=ファイルを上書きしますか？
+'%0'\ exists.\ Overwrite\ file?='%0' は存在します．ファイルを上書きしますか？
+Overwrite\ file?=ファイルを上書きしますか？
 
 Export=書き出す
 
-Export_name=書出名
+Export\ name=書出名
 
-Export_preferences=設定を書き出す
+Export\ preferences=設定を書き出す
 
-Export_preferences_to_file=設定をファイルに書き出す
+Export\ preferences\ to\ file=設定をファイルに書き出す
 
-Export_properties=特性を書き出す
+Export\ properties=特性を書き出す
 
-Export_to_clipboard=クリップボードに書き出す
+Export\ to\ clipboard=クリップボードに書き出す
 
 Exporting=書き出し中
 Extension=拡張子
 
-External_changes=外部の変更
+External\ changes=外部の変更
 
-External_file_links=外部ファイルリンク
+External\ file\ links=外部ファイルリンク
 
-External_programs=外部プログラム
+External\ programs=外部プログラム
 
-External_viewer_called=外部ビューアが呼び出されました
+External\ viewer\ called=外部ビューアが呼び出されました
 
 Fetch=取得
 
@@ -482,210 +482,210 @@ Field=フィールド
 
 field=フィールド
 
-Field_name=フィールド名
-Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters=フィールド名には，スペースや以下の文字を使うことはできません
+Field\ name=フィールド名
+Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=フィールド名には，スペースや以下の文字を使うことはできません
 
-Field_to_filter=フィルタを掛けるフィールド
+Field\ to\ filter=フィルタを掛けるフィールド
 
-Field_to_group_by=グループ化するフィールド
+Field\ to\ group\ by=グループ化するフィールド
 
 File=ファイル
 
 file=ファイル
-File_'%0'_is_already_open.=ファイル「%0」は既に開かれています．
+File\ '%0'\ is\ already\ open.=ファイル「%0」は既に開かれています．
 
-File_changed=ファイルが変更されました
-File_directory_is_'%0'\:=ファイルディレクトリは「%0」です：
+File\ changed=ファイルが変更されました
+File\ directory\ is\ '%0'\:=ファイルディレクトリは「%0」です：
 
-File_directory_is_not_set_or_does_not_exist\!=ファイルディレクトリが設定されていないか存在しません！
+File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=ファイルディレクトリが設定されていないか存在しません！
 
-File_exists=ファイルが存在します
+File\ exists=ファイルが存在します
 
-File_has_been_updated_externally._What_do_you_want_to_do?=ファイルが外部から更新されました．どうしますか？
+File\ has\ been\ updated\ externally.\ What\ do\ you\ want\ to\ do?=ファイルが外部から更新されました．どうしますか？
 
-File_not_found=ファイルが見つかりませんでした
-File_type=ファイル型
+File\ not\ found=ファイルが見つかりませんでした
+File\ type=ファイル型
 
-File_updated_externally=ファイルが外部から更新されました
+File\ updated\ externally=ファイルが外部から更新されました
 
 filename=ファイル名
 
 Filename=ファイル名
 
-Files_opened=ファイルは開かれています
+Files\ opened=ファイルは開かれています
 
 Filter=フィルタ
 
-Filter_All=全てをフィルタ
+Filter\ All=全てをフィルタ
 
-Filter_None=フィルタを外す
+Filter\ None=フィルタを外す
 
-Finished_automatically_setting_external_links.=外部リンクの自動設定が終了しました
+Finished\ automatically\ setting\ external\ links.=外部リンクの自動設定が終了しました
 
-Finished_synchronizing_file_links._Entries_changed\:_%0.=ファイルリンクの同期し終えました．変更された項目：%0．
-Finished_writing_XMP-metadata._Wrote_to_%0_file(s).=XMPメタデータを書き込み終わりました．%0ファイルに書き込みました．
-Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).=XMPを%0ファイルに書き込み終わりました（%1スキップ・%2エラー）．
+Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=ファイルリンクの同期し終えました．変更された項目：%0．
+Finished\ writing\ XMP-metadata.\ Wrote\ to\ %0\ file(s).=XMPメタデータを書き込み終わりました．%0ファイルに書き込みました．
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=XMPを%0ファイルに書き込み終わりました（%1スキップ・%2エラー）．
 
-First_select_the_entries_you_want_keys_to_be_generated_for.=鍵を生成させたい項目をまず選択してください．
+First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=鍵を生成させたい項目をまず選択してください．
 
-Fit_table_horizontally_on_screen=表を画面上の水平方向に合わせて表示
+Fit\ table\ horizontally\ on\ screen=表を画面上の水平方向に合わせて表示
 
 Float=上部に表示
-Float_marked_entries=標識を付けた項目を上部へ
+Float\ marked\ entries=標識を付けた項目を上部へ
 
-Font_family=フォント族
+Font\ family=フォント族
 
-Font_preview=フォントプレビュー
+Font\ preview=フォントプレビュー
 
-Font_size=フォント寸法
+Font\ size=フォント寸法
 
-Font_style=フォント様式
+Font\ style=フォント様式
 
-Font_selection=フォントの選択
+Font\ selection=フォントの選択
 
 for=；対象：
 
-Format_of_author_and_editor_names=著者名と編集者名の書式
-Format_string=整形文字列
+Format\ of\ author\ and\ editor\ names=著者名と編集者名の書式
+Format\ string=整形文字列
 
-Format_used=使用されている書式
-Formatter_name=整形定義の名称
+Format\ used=使用されている書式
+Formatter\ name=整形定義の名称
 
-found_in_AUX_file=AUXファイルを検出
+found\ in\ AUX\ file=AUXファイルを検出
 
-Full_name=完全な名称
+Full\ name=完全な名称
 
 General=一般
 
-General_fields=汎用フィールド
+General\ fields=汎用フィールド
 
 Generate=生成
 
-Generate_BibTeX_key=BibTeX鍵を生成
+Generate\ BibTeX\ key=BibTeX鍵を生成
 
-Generate_keys=鍵を生成
+Generate\ keys=鍵を生成
 
-Generate_keys_before_saving_(for_entries_without_a_key)=保存前に鍵を生成（鍵のない項目に対して）
-Generate_keys_for_imported_entries=読み込んだ項目に鍵を生成
+Generate\ keys\ before\ saving\ (for\ entries\ without\ a\ key)=保存前に鍵を生成（鍵のない項目に対して）
+Generate\ keys\ for\ imported\ entries=読み込んだ項目に鍵を生成
 
-Generate_now=いま生成する
+Generate\ now=いま生成する
 
-Generated_BibTeX_key_for=以下の項目のBibTeX鍵を生成しました：
+Generated\ BibTeX\ key\ for=以下の項目のBibTeX鍵を生成しました：
 
-Generating_BibTeX_key_for=以下の項目のBibTeX鍵を生成しています：
-Get_fulltext=フルテキストを得る
+Generating\ BibTeX\ key\ for=以下の項目のBibTeX鍵を生成しています：
+Get\ fulltext=フルテキストを得る
 
-Gray_out_non-hits=合致しないものを淡色化
+Gray\ out\ non-hits=合致しないものを淡色化
 
 Groups=グループ
 
-Have_you_chosen_the_correct_package_path?=正しいパッケージパスを選択しましたか？
+Have\ you\ chosen\ the\ correct\ package\ path?=正しいパッケージパスを選択しましたか？
 
 Help=ヘルプ
 
-Help_on_key_patterns=キーパターンに関するヘルプ
-Help_on_regular_expression_search=正規表現検索に関するヘルプ
+Help\ on\ key\ patterns=キーパターンに関するヘルプ
+Help\ on\ regular\ expression\ search=正規表現検索に関するヘルプ
 
-Hide_non-hits=合致しないものを非表示
+Hide\ non-hits=合致しないものを非表示
 
-Hierarchical_context=階層コンテクスト
+Hierarchical\ context=階層コンテクスト
 
 Highlight=着色
 Marking=標識
 Underline=下線
-Empty_Highlight=着色を取り除く
-Empty_Marking=標識を取り除く
-Empty_Underline=下線を取り除く
-The_marked_area_does_not_contain_any_legible_text!=標識した領域に文が含まれていません！
+Empty\ Highlight=着色を取り除く
+Empty\ Marking=標識を取り除く
+Empty\ Underline=下線を取り除く
+The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=標識した領域に文が含まれていません！
 
-Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>=ヒント：特定のフィールドのみを検索するには，たとえば：<p><tt>author\=smith_and_title\=electrical</tt>と入力してください
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=ヒント：特定のフィールドのみを検索するには，たとえば：<p><tt>author=smith and title=electrical</tt>と入力してください
 
-HTML_table=HTMLテーブル
-HTML_table_(with_Abstract_&_BibTeX)=HTMLテーブル（Abstract及びBibTeX付き）
+HTML\ table=HTMLテーブル
+HTML\ table\ (with\ Abstract\ &\ BibTeX)=HTMLテーブル（Abstract及びBibTeX付き）
 Icon=アイコン
 
 Ignore=無視
 
 Import=読み込み
 
-Import_and_keep_old_entry=読み込みを行い，旧項目は維持
+Import\ and\ keep\ old\ entry=読み込みを行い，旧項目は維持
 
-Import_and_remove_old_entry=読み込みを行い，旧項目は削除
+Import\ and\ remove\ old\ entry=読み込みを行い，旧項目は削除
 
-Import_entries=項目の読み込み
+Import\ entries=項目の読み込み
 
-Import_failed=読み込みに失敗しました
+Import\ failed=読み込みに失敗しました
 
-Import_file=ファイルを読み込み
+Import\ file=ファイルを読み込み
 
-Import_group_definitions=グループ定義を読み込み
+Import\ group\ definitions=グループ定義を読み込み
 
-Import_name=読込名
+Import\ name=読込名
 
-Import_preferences=設定を読み込む
+Import\ preferences=設定を読み込む
 
-Import_preferences_from_file=ファイルから設定を読み込み
+Import\ preferences\ from\ file=ファイルから設定を読み込み
 
-Import_strings=文字列を読み込み
+Import\ strings=文字列を読み込み
 
-Import_to_open_tab=読み込んでタブを開く
+Import\ to\ open\ tab=読み込んでタブを開く
 
-Import_word_selector_definitions=単語選択メニューの定義を読み込み
+Import\ word\ selector\ definitions=単語選択メニューの定義を読み込み
 
-Imported_entries=項目を読み込みました
+Imported\ entries=項目を読み込みました
 
-Imported_from_library=データベースから読み込みました
+Imported\ from\ library=データベースから読み込みました
 
-Importer_class=Importerクラス
+Importer\ class=Importerクラス
 
 Importing=読み込んでいます
 
-Importing_in_unknown_format=未知の書式で読み込んでいます
+Importing\ in\ unknown\ format=未知の書式で読み込んでいます
 
-Include_abstracts=概要を取り込む
-Include_entries=項目を含める
+Include\ abstracts=概要を取り込む
+Include\ entries=項目を含める
 
-Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups=下層グループの取り込み：このグループやその配下の下層グループに含まれている項目を表示
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=下層グループの取り込み：このグループやその配下の下層グループに含まれている項目を表示
 
-Independent_group\:_When_selected,_view_only_this_group's_entries=独立グループ：このグループの項目のみを表示
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=独立グループ：このグループの項目のみを表示
 
-Work_options=作業オプション
+Work\ options=作業オプション
 
 Insert=挿入
 
-Insert_rows=行を挿入
+Insert\ rows=行を挿入
 
 Intersection=論理積
 
-Invalid_BibTeX_key=無効なBibTeX鍵です
+Invalid\ BibTeX\ key=無効なBibTeX鍵です
 
-Invalid_date_format=無効な日付書式です
+Invalid\ date\ format=無効な日付書式です
 
-Invalid_URL=無効なURLです
+Invalid\ URL=無効なURLです
 
-Online_help=オンラインヘルプ
+Online\ help=オンラインヘルプ
 
-JabRef_preferences=JabRefの設定
+JabRef\ preferences=JabRefの設定
 
 Join=結合
 
-Joins_selected_keywords_and_deletes_selected_keywords.=選択したキーワードを結合して削除します．
+Joins\ selected\ keywords\ and\ deletes\ selected\ keywords.=選択したキーワードを結合して削除します．
 
-Journal_abbreviations=誌名短縮形
+Journal\ abbreviations=誌名短縮形
 
 Keep=維持
 
-Keep_both=両側を維持
+Keep\ both=両側を維持
 
-Key_bindings=キー割当
+Key\ bindings=キー割当
 
-Key_bindings_changed=キー割当が変更されました
+Key\ bindings\ changed=キー割当が変更されました
 
-Key_generator_settings=鍵生成ツールの設定
+Key\ generator\ settings=鍵生成ツールの設定
 
-Key_pattern=キーパターン
+Key\ pattern=キーパターン
 
-keys_in_library=データベース中の鍵
+keys\ in\ library=データベース中の鍵
 
 Keyword=キーワード
 
@@ -693,449 +693,449 @@ Label=ラベル
 
 Language=言語
 
-Last_modified=最終修正日時
+Last\ modified=最終修正日時
 
-LaTeX_AUX_file=LaTeX_AUXファイル
-Leave_file_in_its_current_directory=ファイルを現ディレクトリに残す
+LaTeX\ AUX\ file=LaTeX AUXファイル
+Leave\ file\ in\ its\ current\ directory=ファイルを現ディレクトリに残す
 
 Left=左側
 Level=レベル
 
-Limit_to_fields=以下のフィールドに制限
+Limit\ to\ fields=以下のフィールドに制限
 
-Limit_to_selected_entries=選択項目に制限
+Limit\ to\ selected\ entries=選択項目に制限
 
 Link=リンク
-Link_local_file=ローカルファイルをリンク
-Link_to_file_%0=ファイル%0へのリンク
+Link\ local\ file=ローカルファイルをリンク
+Link\ to\ file\ %0=ファイル%0へのリンク
 
-Listen_for_remote_operation_on_port=以下のポートでリモート操作を待ち受ける
-Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)=起動時にjabref.xmlの読み込みと保存を行う（メモリースティックモード）
+Listen\ for\ remote\ operation\ on\ port=以下のポートでリモート操作を待ち受ける
+Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=起動時にjabref.xmlの読み込みと保存を行う（メモリースティックモード）
 
-Look_and_feel=操作性
-Main_file_directory=基本ファイルディレクトリ
+Look\ and\ feel=操作性
+Main\ file\ directory=基本ファイルディレクトリ
 
-Main_layout_file=基本レイアウトファイル
+Main\ layout\ file=基本レイアウトファイル
 
-Manage_custom_exports=ユーザー書出の管理
+Manage\ custom\ exports=ユーザー書出の管理
 
-Manage_custom_imports=ユーザー読込の管理
-Manage_external_file_types=外部ファイル型の管理
+Manage\ custom\ imports=ユーザー読込の管理
+Manage\ external\ file\ types=外部ファイル型の管理
 
-Mark_entries=項目を標識
+Mark\ entries=項目を標識
 
-Mark_entry=項目を標識
+Mark\ entry=項目を標識
 
-Mark_new_entries_with_addition_date=新規項目に追加の日付を記載
+Mark\ new\ entries\ with\ addition\ date=新規項目に追加の日付を記載
 
-Mark_new_entries_with_owner_name=新規項目にオーナー名を記載
+Mark\ new\ entries\ with\ owner\ name=新規項目にオーナー名を記載
 
-Memory_stick_mode=メモリースティックモード
+Memory\ stick\ mode=メモリースティックモード
 
-Menu_and_label_font_size=メニューとラベルのフォント寸法
+Menu\ and\ label\ font\ size=メニューとラベルのフォント寸法
 
-Merged_external_changes=外部からの変更を統合しました
+Merged\ external\ changes=外部からの変更を統合しました
 
 Messages=メッセージ
 
-Modification_of_field=フィールドの修正
+Modification\ of\ field=フィールドの修正
 
-Modified_group_"%0".=グループ「%0」を修正しました．
+Modified\ group\ "%0".=グループ「%0」を修正しました．
 
-Modified_groups=グループを修正しました
+Modified\ groups=グループを修正しました
 
-Modified_string=文字列を修正しました
+Modified\ string=文字列を修正しました
 
 Modify=修正
 
-modify_group=グループを修正
+modify\ group=グループを修正
 
-Move_down=下げる
+Move\ down=下げる
 
-Move_external_links_to_'file'_field=外部リンクを「ファイル」フィールドに移動
+Move\ external\ links\ to\ 'file'\ field=外部リンクを「ファイル」フィールドに移動
 
-move_group=グループを移動
+move\ group=グループを移動
 
-Move_up=上げる
+Move\ up=上げる
 
-Moved_group_"%0".=グループ「%0」を移動しました．
+Moved\ group\ "%0".=グループ「%0」を移動しました．
 
 Name=名称
-Name_formatter=名前の整形
+Name\ formatter=名前の整形
 
-Natbib_style=Natbib様式
+Natbib\ style=Natbib様式
 
-nested_AUX_files=入れ子になっているAUXファイル
+nested\ AUX\ files=入れ子になっているAUXファイル
 
 New=新規
 
 new=新規
 
-New_BibTeX_entry=新規BibTeX項目
+New\ BibTeX\ entry=新規BibTeX項目
 
-New_BibTeX_sublibrary=新規BibTeX副データベース
+New\ BibTeX\ sublibrary=新規BibTeX副データベース
 
-New_content=新規内容
+New\ content=新規内容
 
-New_library_created.=新規データベースが作成されました．
-New_%0_library=新規%0データベース
-New_field_value=新規フィールド値
+New\ library\ created.=新規データベースが作成されました．
+New\ %0\ library=新規%0データベース
+New\ field\ value=新規フィールド値
 
-New_group=新規グループ
+New\ group=新規グループ
 
-New_string=新規文字列
+New\ string=新規文字列
 
-Next_entry=次の項目
+Next\ entry=次の項目
 
-No_actual_changes_found.=実際に変更されているところは見つかりませんでした．
+No\ actual\ changes\ found.=実際に変更されているところは見つかりませんでした．
 
-no_base-BibTeX-file_specified=ベースとなるBibTeXファイルが指定されていません
+no\ base-BibTeX-file\ specified=ベースとなるBibTeXファイルが指定されていません
 
-no_library_generated=データベースは生成されませんでした
+no\ library\ generated=データベースは生成されませんでした
 
-No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.=項目が見つかりませんでした．正しい読み込みフィルタを使用していることを確認してください．
+No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=項目が見つかりませんでした．正しい読み込みフィルタを使用していることを確認してください．
 
 
-No_entries_found_for_the_search_string_'%0'=検索文字列「%0」に一致する項目が見つかりませんでした．
+No\ entries\ found\ for\ the\ search\ string\ '%0'=検索文字列「%0」に一致する項目が見つかりませんでした．
 
-No_entries_imported.=項目は読み込まれませんでした．
+No\ entries\ imported.=項目は読み込まれませんでした．
 
-No_files_found.=ファイルがみつかりません．
+No\ files\ found.=ファイルがみつかりません．
 
-No_GUI._Only_process_command_line_options.=GUIがありません．コマンドラインオプションのみ処理します．
+No\ GUI.\ Only\ process\ command\ line\ options.=GUIがありません．コマンドラインオプションのみ処理します．
 
-No_journal_names_could_be_abbreviated.=学術誌名を短縮形にすることができませんでした．
+No\ journal\ names\ could\ be\ abbreviated.=学術誌名を短縮形にすることができませんでした．
 
-No_journal_names_could_be_unabbreviated.=学術誌名を非短縮形にすることができませんでした．
-No_PDF_linked=PDFはリンクされていません
+No\ journal\ names\ could\ be\ unabbreviated.=学術誌名を非短縮形にすることができませんでした．
+No\ PDF\ linked=PDFはリンクされていません
 
-Open_PDF=PDFを開く
+Open\ PDF=PDFを開く
 
-No_URL_defined=URLは定義されていません
+No\ URL\ defined=URLは定義されていません
 not=not
 
-not_found=見つかりません
+not\ found=見つかりません
 
-Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,=操作性(look&feel)には，完全に有効なクラス名を指定しなくてはならないことに注意してください．
+Note\ that\ you\ must\ specify\ the\ fully\ qualified\ class\ name\ for\ the\ look\ and\ feel,=操作性(look&feel)には，完全に有効なクラス名を指定しなくてはならないことに注意してください．
 
-Nothing_to_redo=繰り返すべきものがありません
+Nothing\ to\ redo=繰り返すべきものがありません
 
-Nothing_to_undo=取り消すべきものがありません
+Nothing\ to\ undo=取り消すべきものがありません
 
 occurrences=個
 
 OK=OK
-One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=一つないしそれ以上のファイルリンクが，未定義の「%0」となっています．どうしますか？
+One\ or\ more\ file\ links\ are\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=一つないしそれ以上のファイルリンクが，未定義の「%0」となっています．どうしますか？
 
-One_or_more_keys_will_be_overwritten._Continue?=一つないしそれ以上の鍵が上書きされます．続けますか？
+One\ or\ more\ keys\ will\ be\ overwritten.\ Continue?=一つないしそれ以上の鍵が上書きされます．続けますか？
 
 
 Open=開く
 
-Open_BibTeX_library=BibTeXデータベースを開く
+Open\ BibTeX\ library=BibTeXデータベースを開く
 
-Open_library=データベースを開く
+Open\ library=データベースを開く
 
-Open_editor_when_a_new_entry_is_created=新規項目を生成した際にエディタを開く
+Open\ editor\ when\ a\ new\ entry\ is\ created=新規項目を生成した際にエディタを開く
 
-Open_file=ファイルを開く
+Open\ file=ファイルを開く
 
-Open_last_edited_libraries_at_startup=起動時に最後に編集していたデータベースを開く
+Open\ last\ edited\ libraries\ at\ startup=起動時に最後に編集していたデータベースを開く
 
-Connect_to_shared_database=共有データベースに接続
+Connect\ to\ shared\ database=共有データベースに接続
 
-Open_terminal_here=ここで端末を開く
+Open\ terminal\ here=ここで端末を開く
 
-Open_URL_or_DOI=URLまたはDOIを開く
+Open\ URL\ or\ DOI=URLまたはDOIを開く
 
-Opened_library=データベースを開きました
+Opened\ library=データベースを開きました
 
 Opening=開いています
 
-Opening_preferences...=設定を開いています...
+Opening\ preferences...=設定を開いています...
 
-Operation_canceled.=操作は取り消されました．
-Operation_not_supported=操作がサポートされていません
+Operation\ canceled.=操作は取り消されました．
+Operation\ not\ supported=操作がサポートされていません
 
-Optional_fields=非必須フィールド
+Optional\ fields=非必須フィールド
 
 Options=オプション
 
 or=or
 
-Output_or_export_file=ファイルを出力するか書き出す
+Output\ or\ export\ file=ファイルを出力するか書き出す
 
 Override=上書き
 
-Override_default_file_directories=ファイルディレクトリ既定値の上書き
+Override\ default\ file\ directories=ファイルディレクトリ既定値の上書き
 
-Override_default_font_settings=既定フォント設定を上書き
+Override\ default\ font\ settings=既定フォント設定を上書き
 
-Override_the_BibTeX_field_by_the_selected_text=BibTeX鍵を選択した文字列で上書き
+Override\ the\ BibTeX\ field\ by\ the\ selected\ text=BibTeX鍵を選択した文字列で上書き
 
 
 Overwrite=上書き
-Overwrite_existing_field_values=既存のフィールド値を上書き
+Overwrite\ existing\ field\ values=既存のフィールド値を上書き
 
-Overwrite_keys=鍵の上書き
+Overwrite\ keys=鍵の上書き
 
-pairs_processed=対が処理されました
+pairs\ processed=対が処理されました
 Password=パスワード
 
 Paste=貼り付け
 
-paste_entries=項目を貼り付け
+paste\ entries=項目を貼り付け
 
-paste_entry=項目を貼り付け
-Paste_from_clipboard=クリップボードから貼り付け
+paste\ entry=項目を貼り付け
+Paste\ from\ clipboard=クリップボードから貼り付け
 
 Pasted=貼り付けました
 
-Path_to_%0_not_defined=%0へのパスは定義されていません
+Path\ to\ %0\ not\ defined=%0へのパスは定義されていません
 
-Path_to_LyX_pipe=LyXパイプへのパス
+Path\ to\ LyX\ pipe=LyXパイプへのパス
 
-PDF_does_not_exist=PDFが存在しません
+PDF\ does\ not\ exist=PDFが存在しません
 
-File_has_no_attached_annotations=ファイルには註釈が付けられていません
+File\ has\ no\ attached\ annotations=ファイルには註釈が付けられていません
 
-Plain_text_import=平文読み込み
+Plain\ text\ import=平文読み込み
 
-Please_enter_a_name_for_the_group.=このグループ用の名称を入力してください．
+Please\ enter\ a\ name\ for\ the\ group.=このグループ用の名称を入力してください．
 
-Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>=検索項目を入力してください．たとえば，<b>Smith</b>のすべての項目を検索するには，<p><tt>smith</tt><p>と入力してください．<b>Author</b>フィールドで<b>Smith</b>，かつ<b>Title</b>フィールドで<b>electrical</b>を検索したい場合には，<p><tt>author\=smith_and_title\=electrical</tt>と入力してください．
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=検索項目を入力してください．たとえば，<b>Smith</b>のすべての項目を検索するには，<p><tt>smith</tt><p>と入力してください．<b>Author</b>フィールドで<b>Smith</b>，かつ<b>Title</b>フィールドで<b>electrical</b>を検索したい場合には，<p><tt>author=smith and title=electrical</tt>と入力してください．
 
-Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=検索するフィールド（例：<b>keywords</b>）とそのフィールド内で検索したいキーワード（例：<b>electrical</b>）を入力してください．
+Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=検索するフィールド（例：<b>keywords</b>）とそのフィールド内で検索したいキーワード（例：<b>electrical</b>）を入力してください．
 
-Please_enter_the_string's_label=文字列のラベルを入力してください．
+Please\ enter\ the\ string's\ label=文字列のラベルを入力してください．
 
-Please_select_an_importer.=読込を選択してください．
+Please\ select\ an\ importer.=読込を選択してください．
 
-Possible_duplicate_entries=重複の可能性のある項目
+Possible\ duplicate\ entries=重複の可能性のある項目
 
-Possible_duplicate_of_existing_entry._Click_to_resolve.=既存項目と重複している可能性があります．解消するにはクリックしてください．
+Possible\ duplicate\ of\ existing\ entry.\ Click\ to\ resolve.=既存項目と重複している可能性があります．解消するにはクリックしてください．
 
 Preamble=プリアンブル
 
 Preferences=設定
 
-Preferences_recorded.=設定が記録されました．
+Preferences\ recorded.=設定が記録されました．
 
 Preview=プレビュー
-Citation_Style=引用様式
-Current_Preview=現在のプレビュー
-Cannot_generate_preview_based_on_selected_citation_style.=選択された引用様式に沿ってプレビューを生成することができませんでした．
-Bad_character_inside_entry=項目中に不適切な文字
-Error_while_generating_citation_style=引用様式を生成中にエラー発生
-Preview_style_changed_to\:_%0=プレビュー様式が_%0_に変更されました
-Next_preview_layout=次のプレビュー様式
-Previous_preview_layout=前のプレビュー様式
+Citation\ Style=引用様式
+Current\ Preview=現在のプレビュー
+Cannot\ generate\ preview\ based\ on\ selected\ citation\ style.=選択された引用様式に沿ってプレビューを生成することができませんでした．
+Bad\ character\ inside\ entry=項目中に不適切な文字
+Error\ while\ generating\ citation\ style=引用様式を生成中にエラー発生
+Preview\ style\ changed\ to\:\ %0=プレビュー様式が %0 に変更されました
+Next\ preview\ layout=次のプレビュー様式
+Previous\ preview\ layout=前のプレビュー様式
 
-Previous_entry=前の項目
+Previous\ entry=前の項目
 
-Primary_sort_criterion=第一整序基準
-Problem_with_parsing_entry=項目を解析中に問題が発生しました
-Processing_%0=%0を処理中です
-Pull_changes_from_shared_database=共有データベースから変更点を取得
+Primary\ sort\ criterion=第一整序基準
+Problem\ with\ parsing\ entry=項目を解析中に問題が発生しました
+Processing\ %0=%0を処理中です
+Pull\ changes\ from\ shared\ database=共有データベースから変更点を取得
 
-Pushed_citations_to_%0=引用を%0に送り込みました
+Pushed\ citations\ to\ %0=引用を%0に送り込みました
 
-Quit_JabRef=JabRefを終了
+Quit\ JabRef=JabRefを終了
 
-Quit_synchronization=動機を終了する
+Quit\ synchronization=動機を終了する
 
-Raw_source=元のソース
+Raw\ source=元のソース
 
-Rearrange_tabs_alphabetically_by_title=タブをタイトルでアルファベット順に整序
+Rearrange\ tabs\ alphabetically\ by\ title=タブをタイトルでアルファベット順に整序
 
 Redo=繰り返し
 
-Reference_library=参照データベース
+Reference\ library=参照データベース
 
-%0_references_found._Number_of_references_to_fetch?=%0個の参照を検出しました．いくつの参照を取得しますか？
+%0\ references\ found.\ Number\ of\ references\ to\ fetch?=%0個の参照を検出しました．いくつの参照を取得しますか？
 
-Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=上層グループの絞り込み：このグループとその上層グループの両方に含まれている項目を表示
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=上層グループの絞り込み：このグループとその上層グループの両方に含まれている項目を表示
 
-regular_expression=正規表現
+regular\ expression=正規表現
 
-Related_articles=関連文献
+Related\ articles=関連文献
 
-Remote_operation=リモート操作
+Remote\ operation=リモート操作
 
-Remote_server_port=リモートサーバーのポート
+Remote\ server\ port=リモートサーバーのポート
 
 Remove=削除
 
-Remove_subgroups=下層グループを削除
+Remove\ subgroups=下層グループを削除
 
-Remove_all_subgroups_of_"%0"?=「%0」の下層グループをすべて削除しますか？
+Remove\ all\ subgroups\ of\ "%0"?=「%0」の下層グループをすべて削除しますか？
 
-Remove_entry_from_import=読み込み分から項目を削除
+Remove\ entry\ from\ import=読み込み分から項目を削除
 
-Remove_selected_entries_from_this_group=このグループから選択項目を削除
+Remove\ selected\ entries\ from\ this\ group=このグループから選択項目を削除
 
-Remove_entry_type=項目型を削除
+Remove\ entry\ type=項目型を削除
 
-Remove_from_group=グループから削除
+Remove\ from\ group=グループから削除
 
-Remove_group=グループを削除
+Remove\ group=グループを削除
 
-Remove_group,_keep_subgroups=グループを削除し，下層グループは維持
+Remove\ group,\ keep\ subgroups=グループを削除し，下層グループは維持
 
-Remove_group_"%0"?=グループ「%0」を削除しますか？
+Remove\ group\ "%0"?=グループ「%0」を削除しますか？
 
-Remove_group_"%0"_and_its_subgroups?=グループ「%0」とその下層グループを削除しますか？
+Remove\ group\ "%0"\ and\ its\ subgroups?=グループ「%0」とその下層グループを削除しますか？
 
-remove_group_(keep_subgroups)=グループを削除（下層グループは維持）
+remove\ group\ (keep\ subgroups)=グループを削除（下層グループは維持）
 
-remove_group_and_subgroups=グループと下層グループを削除
+remove\ group\ and\ subgroups=グループと下層グループを削除
 
-Remove_group_and_subgroups=グループと下層グループを削除
+Remove\ group\ and\ subgroups=グループと下層グループを削除
 
-Remove_link=リンクを削除
+Remove\ link=リンクを削除
 
-Remove_old_entry=旧項目を削除
+Remove\ old\ entry=旧項目を削除
 
-Remove_selected_strings=選択した文字列を削除する
+Remove\ selected\ strings=選択した文字列を削除する
 
-Removed_group_"%0".=グループ「%0」を削除しました．
+Removed\ group\ "%0".=グループ「%0」を削除しました．
 
-Removed_group_"%0"_and_its_subgroups.=グループ「%0」とその下層グループを削除しました．
+Removed\ group\ "%0"\ and\ its\ subgroups.=グループ「%0」とその下層グループを削除しました．
 
-Removed_string=文字列を削除しました
+Removed\ string=文字列を削除しました
 
-Renamed_string=文字列を改名しました
+Renamed\ string=文字列を改名しました
 
 Replace=置換
 
-Replace_(regular_expression)=置換対象（正規表現）
+Replace\ (regular\ expression)=置換対象（正規表現）
 
-Replace_string=文字列の置換
+Replace\ string=文字列の置換
 
-Replace_with=置換文字列
+Replace\ with=置換文字列
 
 Replaced=置換しました
 
-Required_fields=必須フィールド
+Required\ fields=必須フィールド
 
-Reset_all=すべてリセット
+Reset\ all=すべてリセット
 
-Resolve_strings_for_all_fields_except=文字列を以下を除いた全フィールドで展開する
-Resolve_strings_for_standard_BibTeX_fields_only=文字列をBibTeX標準フィールドでのみ展開する
+Resolve\ strings\ for\ all\ fields\ except=文字列を以下を除いた全フィールドで展開する
+Resolve\ strings\ for\ standard\ BibTeX\ fields\ only=文字列をBibTeX標準フィールドでのみ展開する
 
 resolved=解消しました
 
 Review=論評
 
-Review_changes=変更を検査する
+Review\ changes=変更を検査する
 
 Right=右側
 
 Save=保存
-Save_all_finished.=保存がすべて終わりました．
+Save\ all\ finished.=保存がすべて終わりました．
 
-Save_all_open_libraries=すべての開かれているデータベースを保存
+Save\ all\ open\ libraries=すべての開かれているデータベースを保存
 
-Save_before_closing=閉じる前に保存
+Save\ before\ closing=閉じる前に保存
 
-Save_library=データベースを保存
-Save_library_as...=データベースに名前を付けて保存...
+Save\ library=データベースを保存
+Save\ library\ as...=データベースに名前を付けて保存...
 
-Save_entries_in_their_original_order=項目をオリジナルの順序で保存
+Save\ entries\ in\ their\ original\ order=項目をオリジナルの順序で保存
 
-Save_failed=保存に失敗
+Save\ failed=保存に失敗
 
-Save_failed_during_backup_creation=バックアップ作成中に保存に失敗
+Save\ failed\ during\ backup\ creation=バックアップ作成中に保存に失敗
 
-Save_selected_as...=選択部に名前を付けて保存...
+Save\ selected\ as...=選択部に名前を付けて保存...
 
-Saved_library=データベースを保存しました
+Saved\ library=データベースを保存しました
 
-Saved_selected_to_'%0'.=選択部を以下に保存しました：'%0'
+Saved\ selected\ to\ '%0'.=選択部を以下に保存しました：'%0'
 
 Saving=保存しています
-Saving_all_libraries...=データベースをすべて保存しています...
+Saving\ all\ libraries...=データベースをすべて保存しています...
 
-Saving_library=データベースを保存しています
+Saving\ library=データベースを保存しています
 
 Search=検索
 
-Search_expression=検索表現
+Search\ expression=検索表現
 
-Search_for=検索対象
+Search\ for=検索対象
 
-Searching_for_duplicates...=重複を検索しています...
+Searching\ for\ duplicates...=重複を検索しています...
 
-Searching_for_files=ファイルを検索しています
+Searching\ for\ files=ファイルを検索しています
 
-Secondary_sort_criterion=第二整序基準
+Secondary\ sort\ criterion=第二整序基準
 
-Select_all=すべて選択
+Select\ all=すべて選択
 
-Select_encoding=エンコーディングを選択
+Select\ encoding=エンコーディングを選択
 
-Select_entry_type=項目型を選択してください
-Select_external_application=外部アプリケーションを選択
+Select\ entry\ type=項目型を選択してください
+Select\ external\ application=外部アプリケーションを選択
 
-Select_file_from_ZIP-archive=ZIP書庫からファイルを選択してください
+Select\ file\ from\ ZIP-archive=ZIP書庫からファイルを選択してください
 
-Select_the_tree_nodes_to_view_and_accept_or_reject_changes=ツリーノードを選択して表示させ，変更を受諾ないし拒否してください
-Selected_entries=選択した項目
-Set_field=フィールドを設定
-Set_fields=フィールドを設定
+Select\ the\ tree\ nodes\ to\ view\ and\ accept\ or\ reject\ changes=ツリーノードを選択して表示させ，変更を受諾ないし拒否してください
+Selected\ entries=選択した項目
+Set\ field=フィールドを設定
+Set\ fields=フィールドを設定
 
-Set_general_fields=汎用フィールドを設定
-Set_main_external_file_directory=主幹外部ファイルディレクトリを設定してください
+Set\ general\ fields=汎用フィールドを設定
+Set\ main\ external\ file\ directory=主幹外部ファイルディレクトリを設定してください
 
-Set_table_font=表フォントを設定
+Set\ table\ font=表フォントを設定
 
 Settings=設定
 
 Shortcut=ショートカット
 
-Show/edit_%0_source=%0ソースを表示・編集
+Show/edit\ %0\ source=%0ソースを表示・編集
 
-Show_'Firstname_Lastname'=「名_姓」と表示
+Show\ 'Firstname\ Lastname'=「名 姓」と表示
 
-Show_'Lastname,_Firstname'=「姓,_名」と表示
+Show\ 'Lastname,\ Firstname'=「姓, 名」と表示
 
-Show_BibTeX_source_by_default=既定でBibTeXソースを表示
+Show\ BibTeX\ source\ by\ default=既定でBibTeXソースを表示
 
-Show_confirmation_dialog_when_deleting_entries=項目を削除する際に確認ダイアログを表示
+Show\ confirmation\ dialog\ when\ deleting\ entries=項目を削除する際に確認ダイアログを表示
 
-Show_description=説明を表示
+Show\ description=説明を表示
 
-Show_file_column=ファイル列を表示
+Show\ file\ column=ファイル列を表示
 
-Show_last_names_only=姓のみを表示する
+Show\ last\ names\ only=姓のみを表示する
 
-Show_names_unchanged=氏名をそのまま表示
+Show\ names\ unchanged=氏名をそのまま表示
 
-Show_optional_fields=非必須フィールドを表示
+Show\ optional\ fields=非必須フィールドを表示
 
-Show_required_fields=必須フィールドを表示
+Show\ required\ fields=必須フィールドを表示
 
-Show_URL/DOI_column=URL/DOI列を表示
+Show\ URL/DOI\ column=URL/DOI列を表示
 
-Simple_HTML=単純なHTML
+Simple\ HTML=単純なHTML
 
 Size=サイズ
 
-Skipped_-_No_PDF_linked=跳ばしました_-_PDFがリンクされていません
-Skipped_-_PDF_does_not_exist=跳ばしました_-_PDFが存在しません
+Skipped\ -\ No\ PDF\ linked=跳ばしました - PDFがリンクされていません
+Skipped\ -\ PDF\ does\ not\ exist=跳ばしました - PDFが存在しません
 
-Skipped_entry.=項目を跳ばしました．
+Skipped\ entry.=項目を跳ばしました．
 
-Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.=
+Some\ appearance\ settings\ you\ changed\ require\ to\ restart\ JabRef\ to\ come\ into\ effect.=
 
-source_edit=ソースの編集
-Special_name_formatters=名前の整形の定義
+source\ edit=ソースの編集
+Special\ name\ formatters=名前の整形の定義
 
-Special_table_columns=特殊な表列
+Special\ table\ columns=特殊な表列
 
-Starting_import=読み込みを開始
+Starting\ import=読み込みを開始
 
-Statically_group_entries_by_manual_assignment=手動割り当てによって静的に項目をグループ化
+Statically\ group\ entries\ by\ manual\ assignment=手動割り当てによって静的に項目をグループ化
 
 Status=状態
 
@@ -1143,1019 +1143,1019 @@ Stop=停止
 
 Strings=文字列
 
-Strings_for_library=右のデータベースで用いる文字列
+Strings\ for\ library=右のデータベースで用いる文字列
 
-Sublibrary_from_AUX=AUXからの部分データベース
+Sublibrary\ from\ AUX=AUXからの部分データベース
 
-Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.=学術誌名が既知の場合は，完全な学術誌名と短縮形を切り替える．
+Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=学術誌名が既知の場合は，完全な学術誌名と短縮形を切り替える．
 
-Synchronize_file_links=ファイルリンクの同期
+Synchronize\ file\ links=ファイルリンクの同期
 
-Synchronizing_file_links...=ファイルリンクの同期...
+Synchronizing\ file\ links...=ファイルリンクの同期...
 
-Table_appearance=表の外観
+Table\ appearance=表の外観
 
-Table_background_color=表の背景色
+Table\ background\ color=表の背景色
 
-Table_grid_color=表の罫線色
+Table\ grid\ color=表の罫線色
 
-Table_text_color=表の文字色
+Table\ text\ color=表の文字色
 
 Tabname=タブ名
-Target_file_cannot_be_a_directory.=ターゲットファイルはディレクトリであってはなりません．
+Target\ file\ cannot\ be\ a\ directory.=ターゲットファイルはディレクトリであってはなりません．
 
-Tertiary_sort_criterion=第三整序基準
+Tertiary\ sort\ criterion=第三整序基準
 
 Test=確認
 
-paste_text_here=テキストをここに貼り付けてください
+paste\ text\ here=テキストをここに貼り付けてください
 
-The_chosen_date_format_for_new_entries_is_not_valid=新規項目に選択した日付書式は有効ではありません
+The\ chosen\ date\ format\ for\ new\ entries\ is\ not\ valid=新規項目に選択した日付書式は有効ではありません
 
-The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:=選択したエンコーディング「%0」は，以下の文字をエンコードすることができませんでした：
+The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=選択したエンコーディング「%0」は，以下の文字をエンコードすることができませんでした：
 
 
-the_field_<b>%0</b>=フィールド<b>%0</b>
+the\ field\ <b>%0</b>=フィールド<b>%0</b>
 
-The_file<BR>'%0'<BR>has_been_modified<BR>externally\!=ファイル<BR>'%0'<BR>は外部から<BR>修正されました！
+The\ file<BR>'%0'<BR>has\ been\ modified<BR>externally\!=ファイル<BR>'%0'<BR>は外部から<BR>修正されました！
 
-The_group_"%0"_already_contains_the_selection.=グループ「%0」には既に選択したものが含まれています．
+The\ group\ "%0"\ already\ contains\ the\ selection.=グループ「%0」には既に選択したものが含まれています．
 
-The_label_of_the_string_cannot_be_a_number.=文字列のラベルは数字であってはなりません．
+The\ label\ of\ the\ string\ cannot\ be\ a\ number.=文字列のラベルは数字であってはなりません．
 
-The_label_of_the_string_cannot_contain_spaces.=文字列のラベルにはスペースを入れてはなりません．
+The\ label\ of\ the\ string\ cannot\ contain\ spaces.=文字列のラベルにはスペースを入れてはなりません．
 
-The_label_of_the_string_cannot_contain_the_'\#'_character.=文字列のラベルには「\#」文字を入れてはなりません．
+The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=文字列のラベルには「#」文字を入れてはなりません．
 
-The_output_option_depends_on_a_valid_import_option.=この出力オプションは，有効な読み込みオプションに依存します．
-The_PDF_contains_one_or_several_BibTeX-records.=このPDFは，BibTeXレコードを含んでいます．
-Do_you_want_to_import_these_as_new_entries_into_the_current_library?=これらを，現在のデータベースに新規項目として読み込みますか？
+The\ output\ option\ depends\ on\ a\ valid\ import\ option.=この出力オプションは，有効な読み込みオプションに依存します．
+The\ PDF\ contains\ one\ or\ several\ BibTeX-records.=このPDFは，BibTeXレコードを含んでいます．
+Do\ you\ want\ to\ import\ these\ as\ new\ entries\ into\ the\ current\ library?=これらを，現在のデータベースに新規項目として読み込みますか？
 
-The_regular_expression_<b>%0</b>_is_invalid\:=正規表現<b>%0</b>は無効です：
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=正規表現<b>%0</b>は無効です：
 
-The_search_is_case_insensitive.=検索は大小文字を区別しません．
+The\ search\ is\ case\ insensitive.=検索は大小文字を区別しません．
 
-The_search_is_case_sensitive.=検索は大小文字を区別します．
+The\ search\ is\ case\ sensitive.=検索は大小文字を区別します．
 
-The_string_has_been_removed_locally=文字列はローカルで削除されました
+The\ string\ has\ been\ removed\ locally=文字列はローカルで削除されました
 
-There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?=解消されていない重複と思われるものが存在します（「D」アイコンで標識されています）．先に進みますか？
+There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=解消されていない重複と思われるものが存在します（「D」アイコンで標識されています）．先に進みますか？
 
-This_entry_has_no_BibTeX_key._Generate_key_now?=この項目にはBibTeX鍵がありません．いま生成しますか？
+This\ entry\ has\ no\ BibTeX\ key.\ Generate\ key\ now?=この項目にはBibTeX鍵がありません．いま生成しますか？
 
-This_entry_is_incomplete=この項目は不完全です
+This\ entry\ is\ incomplete=この項目は不完全です
 
-This_entry_type_cannot_be_removed.=この項目型は解消できません．
+This\ entry\ type\ cannot\ be\ removed.=この項目型は解消できません．
 
-This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=この外部リンクは「%0」型ですが，これは定義されていません．どうしますか？
+This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=この外部リンクは「%0」型ですが，これは定義されていません．どうしますか？
 
-This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.=このグループは，手動割り当てによる項目を含んでいます．項目を選択して，ドラッグアンドドロップを行うかコンテクストメニューを使うかすれば，このグループに項目を割り当てることができます．項目を選択してコンテクストメニューを使えば，項目を削除することができます．
+This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=このグループは，手動割り当てによる項目を含んでいます．項目を選択して，ドラッグアンドドロップを行うかコンテクストメニューを使うかすれば，このグループに項目を割り当てることができます．項目を選択してコンテクストメニューを使えば，項目を削除することができます．
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>=このグループには，<b>%0</b>フィールドにキーワード<b>%1</b>を含んでいる項目があります
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=このグループには，<b>%0</b>フィールドにキーワード<b>%1</b>を含んでいる項目があります
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>=このグループには，<b>%0</b>フィールドに正規表現<b>%1</b>を含んでいる項目があります
-This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.=これを有効にすると，JabRefは各ファイルリンクを調べ，ファイルが存在するかどうか確認します．<BR>もし存在しなければ，問題を解決する選択肢を提供します．
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=このグループには，<b>%0</b>フィールドに正規表現<b>%1</b>を含んでいる項目があります
+This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=これを有効にすると，JabRefは各ファイルリンクを調べ，ファイルが存在するかどうか確認します．<BR>もし存在しなければ，問題を解決する選択肢を提供します．
 
-This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.=この操作を行うには，選択された全項目にBibTeX鍵が定義されている必要があります．
+This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=この操作を行うには，選択された全項目にBibTeX鍵が定義されている必要があります．
 
-This_operation_requires_one_or_more_entries_to_be_selected.=この操作を行うには，1つ以上の項目が選択されている必要があります．
+This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=この操作を行うには，1つ以上の項目が選択されている必要があります．
 
-Toggle_entry_preview=項目プレビューを入切
-Toggle_groups_interface=グループ制御面を入切
-Try_different_encoding=別のエンコーディングを試す
+Toggle\ entry\ preview=項目プレビューを入切
+Toggle\ groups\ interface=グループ制御面を入切
+Try\ different\ encoding=別のエンコーディングを試す
 
-Unabbreviate_journal_names_of_the_selected_entries=選択した項目の誌名を非短縮形にする
-Unabbreviated_%0_journal_names.=%0個の誌名を非短縮形にしました
+Unabbreviate\ journal\ names\ of\ the\ selected\ entries=選択した項目の誌名を非短縮形にする
+Unabbreviated\ %0\ journal\ names.=%0個の誌名を非短縮形にしました
 
-Unable_to_open_file.=ファイルを開くことができませんでした．
-Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.=リンクを開くことができませんでした．ファイル型「%1」に関連付けられているアプリケーション「%0」を呼び出すことができませんでした．
-unable_to_write_to=以下に書き込むことができませんでした：
-Undefined_file_type=定義されていないファイル型
+Unable\ to\ open\ file.=ファイルを開くことができませんでした．
+Unable\ to\ open\ link.\ The\ application\ '%0'\ associated\ with\ the\ file\ type\ '%1'\ could\ not\ be\ called.=リンクを開くことができませんでした．ファイル型「%1」に関連付けられているアプリケーション「%0」を呼び出すことができませんでした．
+unable\ to\ write\ to=以下に書き込むことができませんでした：
+Undefined\ file\ type=定義されていないファイル型
 
 Undo=取り消し
 
 Union=論理和
 
-Unknown_BibTeX_entries=認識されなかったBibTeX項目
+Unknown\ BibTeX\ entries=認識されなかったBibTeX項目
 
-unknown_edit=知らない編集
+unknown\ edit=知らない編集
 
-Unknown_export_format=知らない書き出し書式です
+Unknown\ export\ format=知らない書き出し書式です
 
-Unmark_all=すべての標識を解除
+Unmark\ all=すべての標識を解除
 
-Unmark_entries=項目の標識を外す
+Unmark\ entries=項目の標識を外す
 
-Unmark_entry=項目の標識を外す
+Unmark\ entry=項目の標識を外す
 
 untitled=タイトルなし
 
 Up=上
 
-Update_to_current_column_widths=現在の列幅に更新
+Update\ to\ current\ column\ widths=現在の列幅に更新
 
-Updated_group_selection=グループ選択を更新しました
-Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.=外部PDF/PSリンクを「%0」フィールドを使用するように更新
-Upgrade_file=ファイルを更新
-Upgrade_old_external_file_links_to_use_the_new_feature=古い外部ファイルリンクを新機能を利用するように更新
+Updated\ group\ selection=グループ選択を更新しました
+Upgrade\ external\ PDF/PS\ links\ to\ use\ the\ '%0'\ field.=外部PDF/PSリンクを「%0」フィールドを使用するように更新
+Upgrade\ file=ファイルを更新
+Upgrade\ old\ external\ file\ links\ to\ use\ the\ new\ feature=古い外部ファイルリンクを新機能を利用するように更新
 
 usage=使用法
-Use_autocompletion_for_the_following_fields=右記のフィールドで自動補完を使用
+Use\ autocompletion\ for\ the\ following\ fields=右記のフィールドで自動補完を使用
 
-Use_other_look_and_feel=別の操作性を使用する
-Tweak_font_rendering_for_entry_editor_on_Linux=
-Use_regular_expression_search=正規表現検索を使用
+Use\ other\ look\ and\ feel=別の操作性を使用する
+Tweak\ font\ rendering\ for\ entry\ editor\ on\ Linux=
+Use\ regular\ expression\ search=正規表現検索を使用
 
 Username=ユーザー名
 
-Value_cleared_externally=外部から値が消去されました
+Value\ cleared\ externally=外部から値が消去されました
 
-Value_set_externally=外部から値が設定されました
+Value\ set\ externally=外部から値が設定されました
 
-verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid=LyXが実行されていて，lyxpipeが有効となっていることを確認してください
+verify\ that\ LyX\ is\ running\ and\ that\ the\ lyxpipe\ is\ valid=LyXが実行されていて，lyxpipeが有効となっていることを確認してください
 
 View=表示
-Vim_server_name=Vimサーバー名
+Vim\ server\ name=Vimサーバー名
 
-Waiting_for_ArXiv...=ArXivの応答を待っています...
+Waiting\ for\ ArXiv...=ArXivの応答を待っています...
 
-Warn_about_unresolved_duplicates_when_closing_inspection_window=精査ウィンドウを閉じる際に解消されていない重複項目に対して警告する
+Warn\ about\ unresolved\ duplicates\ when\ closing\ inspection\ window=精査ウィンドウを閉じる際に解消されていない重複項目に対して警告する
 
-Warn_before_overwriting_existing_keys=既存の鍵を上書きする前に警告
+Warn\ before\ overwriting\ existing\ keys=既存の鍵を上書きする前に警告
 
 Warning=警告
 
 Warnings=警告
 
-web_link=ウェブリンク
+web\ link=ウェブリンク
 
-What_do_you_want_to_do?=どうしますか？
+What\ do\ you\ want\ to\ do?=どうしますか？
 
-When_adding/removing_keywords,_separate_them_by=キーワードを追加・削除する際，それらを以下の文字で区切る
-Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.=選択した項目からリンクされているPDFにXMPメタデータを書き込みます．
+When\ adding/removing\ keywords,\ separate\ them\ by=キーワードを追加・削除する際，それらを以下の文字で区切る
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=選択した項目からリンクされているPDFにXMPメタデータを書き込みます．
 
 with=with
 
-Write_BibTeXEntry_as_XMP-metadata_to_PDF.=PDFにBibTeX項目をXMPメタデータとして書き込む．
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=PDFにBibTeX項目をXMPメタデータとして書き込む．
 
-Write_XMP=XMPを書き込む
-Write_XMP-metadata=XMPメタデータを書き込む
-Write_XMP-metadata_for_all_PDFs_in_current_library?=現データベースの全PDFにXMPメタデータを書き込みますか？
-Writing_XMP-metadata...=XMPメタデータを書き込んでいます...
-Writing_XMP-metadata_for_selected_entries...=選択した項目にXMPメタデータを書き込んでいます...
+Write\ XMP=XMPを書き込む
+Write\ XMP-metadata=XMPメタデータを書き込む
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=現データベースの全PDFにXMPメタデータを書き込みますか？
+Writing\ XMP-metadata...=XMPメタデータを書き込んでいます...
+Writing\ XMP-metadata\ for\ selected\ entries...=選択した項目にXMPメタデータを書き込んでいます...
 
-Wrote_XMP-metadata=XMPメタデータを書き込みました
+Wrote\ XMP-metadata=XMPメタデータを書き込みました
 
-XMP-annotated_PDF=XMP注釈付きPDF
-XMP_export_privacy_settings=XMP書き出しのプライバシー設定
+XMP-annotated\ PDF=XMP注釈付きPDF
+XMP\ export\ privacy\ settings=XMP書き出しのプライバシー設定
 XMP-metadata=XMPメタデータ
-XMP-metadata_found_in_PDF\:_%0=PDF中にXMPメタデータを検出しました：%0
-You_must_restart_JabRef_for_this_to_come_into_effect.=これを有効にするためにはJabRefを再起動する必要があります．
-You_have_changed_the_language_setting.=言語設定が変更されました．
-You_have_entered_an_invalid_search_'%0'.=無効な検索「%0」を入力しました．
+XMP-metadata\ found\ in\ PDF\:\ %0=PDF中にXMPメタデータを検出しました：%0
+You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=これを有効にするためにはJabRefを再起動する必要があります．
+You\ have\ changed\ the\ language\ setting.=言語設定が変更されました．
+You\ have\ entered\ an\ invalid\ search\ '%0'.=無効な検索「%0」を入力しました．
 
-You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.=新しいキー割当が正しく機能するようにするためには，JabRefを再起動しなくてはなりません．
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=新しいキー割当が正しく機能するようにするためには，JabRefを再起動しなくてはなりません．
 
-Your_new_key_bindings_have_been_stored.=新しいキー割当が保管されました．
+Your\ new\ key\ bindings\ have\ been\ stored.=新しいキー割当が保管されました．
 
-The_following_fetchers_are_available\:=以下の取得子が使用できます：
-Could_not_find_fetcher_'%0'=取得子「%0」を見つけられませんでした
-Running_query_'%0'_with_fetcher_'%1'.=取得子「%1」を使用して，クエリ「%0」を実行しています．
-Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.=取得子「%1」を使用したクエリ「%0」は，結果を何も返しませんでした．
+The\ following\ fetchers\ are\ available\:=以下の取得子が使用できます：
+Could\ not\ find\ fetcher\ '%0'=取得子「%0」を見つけられませんでした
+Running\ query\ '%0'\ with\ fetcher\ '%1'.=取得子「%1」を使用して，クエリ「%0」を実行しています．
+Query\ '%0'\ with\ fetcher\ '%1'\ did\ not\ return\ any\ results.=取得子「%1」を使用したクエリ「%0」は，結果を何も返しませんでした．
 
-Move_file=ファイルを移動
-Rename_file=ファイルを改名
+Move\ file=ファイルを移動
+Rename\ file=ファイルを改名
 
-Move_file_failed=ファイルの移動に失敗
-Could_not_move_file_'%0'.=ファイルを%0移動できませんでした
-Could_not_find_file_'%0'.=ファイル「%0」を見つけられませんでした．
-Number_of_entries_successfully_imported=読み込みに成功した項目数
-Import_canceled_by_user=読み込みはユーザーによって取り消されました
-Progress\:_%0_of_%1=進捗状況：%1のうち%0
-Error_while_fetching_from_%0=%0からの取得中にエラー発生
+Move\ file\ failed=ファイルの移動に失敗
+Could\ not\ move\ file\ '%0'.=ファイルを%0移動できませんでした
+Could\ not\ find\ file\ '%0'.=ファイル「%0」を見つけられませんでした．
+Number\ of\ entries\ successfully\ imported=読み込みに成功した項目数
+Import\ canceled\ by\ user=読み込みはユーザーによって取り消されました
+Progress\:\ %0\ of\ %1=進捗状況：%1のうち%0
+Error\ while\ fetching\ from\ %0=%0からの取得中にエラー発生
 
-Please_enter_a_valid_number=有効な数値を入力してください
-Show_search_results_in_a_window=検索結果をウィンドウに表示
-Show_global_search_results_in_a_window=大域検索の結果をウィンドウに表示
-Search_in_all_open_libraries=全データベースを検索
-Move_file_to_file_directory?=ファイルをファイルディレクトリに移動しますか？
+Please\ enter\ a\ valid\ number=有効な数値を入力してください
+Show\ search\ results\ in\ a\ window=検索結果をウィンドウに表示
+Show\ global\ search\ results\ in\ a\ window=大域検索の結果をウィンドウに表示
+Search\ in\ all\ open\ libraries=全データベースを検索
+Move\ file\ to\ file\ directory?=ファイルをファイルディレクトリに移動しますか？
 
-Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.=データベースは保護されています．外部からの変更を検査しない限り，保存することができません．
-Protected_library=保護されたデータベース
-Refuse_to_save_the_library_before_external_changes_have_been_reviewed.=外部からの変更を検査するまではデータベースを保存することを拒絶する
-Library_protection=データベース保護
-Unable_to_save_library=データベースを保存することができませんでした
+Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=データベースは保護されています．外部からの変更を検査しない限り，保存することができません．
+Protected\ library=保護されたデータベース
+Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=外部からの変更を検査するまではデータベースを保存することを拒絶する
+Library\ protection=データベース保護
+Unable\ to\ save\ library=データベースを保存することができませんでした
 
-BibTeX_key_generator=BibTeX鍵の生成
-Unable_to_open_link.=リンクを開くことができませんでした．
-Move_the_keyboard_focus_to_the_entry_table=キーボードのフォーカスを項目表に移動
-MIME_type=MIME型
+BibTeX\ key\ generator=BibTeX鍵の生成
+Unable\ to\ open\ link.=リンクを開くことができませんでした．
+Move\ the\ keyboard\ focus\ to\ the\ entry\ table=キーボードのフォーカスを項目表に移動
+MIME\ type=MIME型
 
-This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.=この機能は，新規ファイルを，新しいJabRefインスタンスを開かないで，すでに実行されているインスタンスに開いたり<BR>読み込んだりするものです．たとえば，これは，ウェブブラウザからJabRefにファイルを開かせたい時に便利です．<BR>これによって，一度にJabRefのインスタンスを一つしか開けなくなることに注意してください．
-Run_fetcher,_e.g._"--fetch\=Medline\:cancer"=取得子を実行する．例：「--fetch\=Medline\:cancer」
+This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef<BR>instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef<br>from\ your\ web\ browser.<BR>Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=この機能は，新規ファイルを，新しいJabRefインスタンスを開かないで，すでに実行されているインスタンスに開いたり<BR>読み込んだりするものです．たとえば，これは，ウェブブラウザからJabRefにファイルを開かせたい時に便利です．<BR>これによって，一度にJabRefのインスタンスを一つしか開けなくなることに注意してください．
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=取得子を実行する．例：「--fetch=Medline:cancer」
 
-The_ACM_Digital_Library=ACMデジタルライブラリ
+The\ ACM\ Digital\ Library=ACMデジタルライブラリ
 Reset=リセット
 
-Use_IEEE_LaTeX_abbreviations=IEEEのLaTeX略語を使用
-The_Guide_to_Computing_Literature=The_Guide_to_Computing_Literature
+Use\ IEEE\ LaTeX\ abbreviations=IEEEのLaTeX略語を使用
+The\ Guide\ to\ Computing\ Literature=The Guide to Computing Literature
 
-When_opening_file_link,_search_for_matching_file_if_no_link_is_defined=ファイルリンクを開く際，リンクが定義されていなければ，一致するファイルを検索する
-Settings_for_%0=「%0」の設定
-Mark_entries_imported_into_an_existing_library=既存データベースに読み込んだ項目を標識する
-Unmark_all_entries_before_importing_new_entries_into_an_existing_library=既存のデータベースに新規項目を読み込む前に全項目のマークを解除する
+When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=ファイルリンクを開く際，リンクが定義されていなければ，一致するファイルを検索する
+Settings\ for\ %0=「%0」の設定
+Mark\ entries\ imported\ into\ an\ existing\ library=既存データベースに読み込んだ項目を標識する
+Unmark\ all\ entries\ before\ importing\ new\ entries\ into\ an\ existing\ library=既存のデータベースに新規項目を読み込む前に全項目のマークを解除する
 
 Forward=進む
 Back=戻る
-Sort_the_following_fields_as_numeric_fields=以下のフィールドは数値フィールドとして整序
-Line_%0\:_Found_corrupted_BibTeX_key.=%0行め：破損したBibTeX鍵を検出しました．
-Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).=%0行め：破損したBibTeX鍵を発見しました（空白が入っている）．
-Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).=%0行め：破損したBibTeX鍵を発見しました（コンマが欠落）．
-Full_text_document_download_failed=論文本体のダウンロードに失敗しました
-Update_to_current_column_order=現在の列順に更新
-Download_from_URL=URLからダウンロード
-Rename_field=フィールドを改名しました
-Set/clear/append/rename_fields=フィールドを設定/消去/名称変更
-Append_field=
-Append_to_fields=
-Rename_field_to=フィールド名を以下に変更
-Move_contents_of_a_field_into_a_field_with_a_different_name=フィールドの内容を別名のフィールドに移動する
-You_can_only_rename_one_field_at_a_time=一度に改名できるのはひとつのフィールドだけです
+Sort\ the\ following\ fields\ as\ numeric\ fields=以下のフィールドは数値フィールドとして整序
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=%0行め：破損したBibTeX鍵を検出しました．
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=%0行め：破損したBibTeX鍵を発見しました（空白が入っている）．
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=%0行め：破損したBibTeX鍵を発見しました（コンマが欠落）．
+Full\ text\ document\ download\ failed=論文本体のダウンロードに失敗しました
+Update\ to\ current\ column\ order=現在の列順に更新
+Download\ from\ URL=URLからダウンロード
+Rename\ field=フィールドを改名しました
+Set/clear/append/rename\ fields=フィールドを設定/消去/名称変更
+Append\ field=
+Append\ to\ fields=
+Rename\ field\ to=フィールド名を以下に変更
+Move\ contents\ of\ a\ field\ into\ a\ field\ with\ a\ different\ name=フィールドの内容を別名のフィールドに移動する
+You\ can\ only\ rename\ one\ field\ at\ a\ time=一度に改名できるのはひとつのフィールドだけです
 
-Remove_all_broken_links=破損したリンクをすべて削除
+Remove\ all\ broken\ links=破損したリンクをすべて削除
 
-Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.=リモート操作用に%0ポートを使用することができません．別のアプリケーションが使用している可能性があります．別のポートを指定してみてください．
+Cannot\ use\ port\ %0\ for\ remote\ operation;\ another\ application\ may\ be\ using\ it.\ Try\ specifying\ another\ port.=リモート操作用に%0ポートを使用することができません．別のアプリケーションが使用している可能性があります．別のポートを指定してみてください．
 
-Looking_for_full_text_document...=文書本体を探しています...
+Looking\ for\ full\ text\ document...=文書本体を探しています...
 Autosave=自動保存
-A_local_copy_will_be_opened.=ローカルコピーを開きます．
-Autosave_local_libraries=ローカルデータベースを自動保存
-Automatically_save_the_library_to=自動的にデータベースを右記に保存：
-Please_enter_a_valid_file_path.=有効なファイルパスを入力してください．
+A\ local\ copy\ will\ be\ opened.=ローカルコピーを開きます．
+Autosave\ local\ libraries=ローカルデータベースを自動保存
+Automatically\ save\ the\ library\ to=自動的にデータベースを右記に保存：
+Please\ enter\ a\ valid\ file\ path.=有効なファイルパスを入力してください．
 
 
-Export_in_current_table_sort_order=現在の表での整序順で書き出し
-Export_entries_in_their_original_order=項目をオリジナルの順序で書き出し
-Error_opening_file_'%0'.=ファイル「%0」を開く際にエラー発生
+Export\ in\ current\ table\ sort\ order=現在の表での整序順で書き出し
+Export\ entries\ in\ their\ original\ order=項目をオリジナルの順序で書き出し
+Error\ opening\ file\ '%0'.=ファイル「%0」を開く際にエラー発生
 
-Formatter_not_found\:_%0=整形子が見つかりません：%0
-Clear_inputarea=入力領域を一掃
+Formatter\ not\ found\:\ %0=整形子が見つかりません：%0
+Clear\ inputarea=入力領域を一掃
 
-Automatically_set_file_links_for_this_entry=この項目にファイルリンクを自動的に設定
-Could_not_save,_file_locked_by_another_JabRef_instance.=保存できませんでした．ファイルが他のJabRefインスタンスによってロックされています．
-File_is_locked_by_another_JabRef_instance.=ファイルがもうひとつのJabRefインスタンスによってロックされています．
-Do_you_want_to_override_the_file_lock?=ファイルロックを上書きしますか？
-File_locked=ファイルがロックされています
-Current_tmp_value=現在のtmp値
-Metadata_change=メタデータの変更
-Changes_have_been_made_to_the_following_metadata_elements=以下のメタデータ要素に変更を加えました
+Automatically\ set\ file\ links\ for\ this\ entry=この項目にファイルリンクを自動的に設定
+Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=保存できませんでした．ファイルが他のJabRefインスタンスによってロックされています．
+File\ is\ locked\ by\ another\ JabRef\ instance.=ファイルがもうひとつのJabRefインスタンスによってロックされています．
+Do\ you\ want\ to\ override\ the\ file\ lock?=ファイルロックを上書きしますか？
+File\ locked=ファイルがロックされています
+Current\ tmp\ value=現在のtmp値
+Metadata\ change=メタデータの変更
+Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=以下のメタデータ要素に変更を加えました
 
-Generate_groups_for_author_last_names=著者の姓でグループを生成する
-Generate_groups_from_keywords_in_a_BibTeX_field=BibTeXフィールドのキーワードからグループを生成する
-Enforce_legal_characters_in_BibTeX_keys=BibTeX鍵で規則に則った文字の使用を強制する
+Generate\ groups\ for\ author\ last\ names=著者の姓でグループを生成する
+Generate\ groups\ from\ keywords\ in\ a\ BibTeX\ field=BibTeXフィールドのキーワードからグループを生成する
+Enforce\ legal\ characters\ in\ BibTeX\ keys=BibTeX鍵で規則に則った文字の使用を強制する
 
-Save_without_backup?=バックアップを取らずに保存しますか？
-Unable_to_create_backup=バックアップを作成することができません
-Move_file_to_file_directory=ファイルをファイルディレクトリに移動
-Rename_file_to=ファイル名を以下に改名：
-<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)=<b>全項目</b>（このグループは編集したり削除したりすることはできません）
-static_group=静的グループ
-dynamic_group=動的グループ
-refines_supergroup=上層グループを絞り込む
-includes_subgroups=下層グループを含む
+Save\ without\ backup?=バックアップを取らずに保存しますか？
+Unable\ to\ create\ backup=バックアップを作成することができません
+Move\ file\ to\ file\ directory=ファイルをファイルディレクトリに移動
+Rename\ file\ to=ファイル名を以下に改名：
+<b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=<b>全項目</b>（このグループは編集したり削除したりすることはできません）
+static\ group=静的グループ
+dynamic\ group=動的グループ
+refines\ supergroup=上層グループを絞り込む
+includes\ subgroups=下層グループを含む
 contains=contains
-search_expression=検索表現
+search\ expression=検索表現
 
-Optional_fields_2=非必須フィールド2
-Waiting_for_save_operation_to_finish=保存操作が終了するのを待っています
-Resolving_duplicate_BibTeX_keys...=重複したBibTeX鍵を解決...
-Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.=重複したBibTeX鍵を解消し終わりました．%0項目を修正しました．
-This_library_contains_one_or_more_duplicated_BibTeX_keys.=このデータベースには，1つないし複数の重複したBibTeX鍵があります．
-Do_you_want_to_resolve_duplicate_keys_now?=重複した鍵を直ちに解消しますか？
+Optional\ fields\ 2=非必須フィールド2
+Waiting\ for\ save\ operation\ to\ finish=保存操作が終了するのを待っています
+Resolving\ duplicate\ BibTeX\ keys...=重複したBibTeX鍵を解決...
+Finished\ resolving\ duplicate\ BibTeX\ keys.\ %0\ entries\ modified.=重複したBibTeX鍵を解消し終わりました．%0項目を修正しました．
+This\ library\ contains\ one\ or\ more\ duplicated\ BibTeX\ keys.=このデータベースには，1つないし複数の重複したBibTeX鍵があります．
+Do\ you\ want\ to\ resolve\ duplicate\ keys\ now?=重複した鍵を直ちに解消しますか？
 
-Find_and_remove_duplicate_BibTeX_keys=重複BibTeX鍵を検出して削除
-Expected_syntax_for_--fetch\='<name_of_fetcher>\:<query>'=--fetch='<取得子名>\:<問い合わせ>'に期待される文法
-Duplicate_BibTeX_key=重複したBibTeX鍵
-Import_marking_color=読み込み標識の色
-Always_add_letter_(a,_b,_...)_to_generated_keys=鍵生成時に常に(a,_,b,_…)などの文字を付加
+Find\ and\ remove\ duplicate\ BibTeX\ keys=重複BibTeX鍵を検出して削除
+Expected\ syntax\ for\ --fetch\='<name\ of\ fetcher>\:<query>'=--fetch='<取得子名>:<問い合わせ>'に期待される文法
+Duplicate\ BibTeX\ key=重複したBibTeX鍵
+Import\ marking\ color=読み込み標識の色
+Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=鍵生成時に常に(a, ,b, …)などの文字を付加
 
-Ensure_unique_keys_using_letters_(a,_b,_...)=(a,_,b,_…)などの文字を使用して鍵が唯一であることを保証
-Ensure_unique_keys_using_letters_(b,_c,_...)=(b,_,c,_…)などの文字を使用して鍵が唯一であることを保証
-Entry_editor_active_background_color=項目エディタのアクティブ背景色
-Entry_editor_background_color=項目エディタの背景色
-Entry_editor_font_color=項目エディタのフォント色
-Entry_editor_invalid_field_color=項目エディタの無効フィールド色
+Ensure\ unique\ keys\ using\ letters\ (a,\ b,\ ...)=(a, ,b, …)などの文字を使用して鍵が唯一であることを保証
+Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=(b, ,c, …)などの文字を使用して鍵が唯一であることを保証
+Entry\ editor\ active\ background\ color=項目エディタのアクティブ背景色
+Entry\ editor\ background\ color=項目エディタの背景色
+Entry\ editor\ font\ color=項目エディタのフォント色
+Entry\ editor\ invalid\ field\ color=項目エディタの無効フィールド色
 
-Table_and_entry_editor_colors=表および項目エディタ色
+Table\ and\ entry\ editor\ colors=表および項目エディタ色
 
-General_file_directory=一般ファイルディレクトリ
-User-specific_file_directory=ユーザーファイルディレクトリ
-Search_failed\:_illegal_search_expression=検索に失敗：誤った検索表現です
-Show_ArXiv_column=ArXiv列を表示
+General\ file\ directory=一般ファイルディレクトリ
+User-specific\ file\ directory=ユーザーファイルディレクトリ
+Search\ failed\:\ illegal\ search\ expression=検索に失敗：誤った検索表現です
+Show\ ArXiv\ column=ArXiv列を表示
 
-You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for=テキストフィールドに1025〜65535の間の整数値を入力しなくてはなりません：
-Automatically_open_browse_dialog_when_creating_new_file_link=新しくファイルリンクを作成する際，自動的にブラウズダイアログを開く
-Import_metadata_from\:=右記からメタデータを読み込み：
-Choose_the_source_for_the_metadata_import=メタデータを読み込むソースを選んでください
-Create_entry_based_on_XMP-metadata=XMPデータに基づいて項目を生成
-Create_blank_entry_linking_the_PDF=PDFにリンクした空の項目を生成
-Only_attach_PDF=PDFを添付してください
+You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=テキストフィールドに1025〜65535の間の整数値を入力しなくてはなりません：
+Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=新しくファイルリンクを作成する際，自動的にブラウズダイアログを開く
+Import\ metadata\ from\:=右記からメタデータを読み込み：
+Choose\ the\ source\ for\ the\ metadata\ import=メタデータを読み込むソースを選んでください
+Create\ entry\ based\ on\ XMP-metadata=XMPデータに基づいて項目を生成
+Create\ blank\ entry\ linking\ the\ PDF=PDFにリンクした空の項目を生成
+Only\ attach\ PDF=PDFを添付してください
 Title=タイトル
-Create_new_entry=新規項目を作成
-Update_existing_entry=既存項目を更新
-Autocomplete_names_in_'Firstname_Lastname'_format_only=「名_姓」形式の名前のみ自動補完
-Autocomplete_names_in_'Lastname,_Firstname'_format_only=「姓,_名」形式の名前のみ自動補完
-Autocomplete_names_in_both_formats=両方の形式とも自動補完
-Marking_color_%0=標識色_%0
-The_name_'comment'_cannot_be_used_as_an_entry_type_name.=「comment」という名前は，項目型名としては使用することができません．
-You_must_enter_an_integer_value_in_the_text_field_for=右記のテキストフィールド中には整数値を入力しなくてはなりません：
-Send_as_email=電子メールとして送る
+Create\ new\ entry=新規項目を作成
+Update\ existing\ entry=既存項目を更新
+Autocomplete\ names\ in\ 'Firstname\ Lastname'\ format\ only=「名 姓」形式の名前のみ自動補完
+Autocomplete\ names\ in\ 'Lastname,\ Firstname'\ format\ only=「姓, 名」形式の名前のみ自動補完
+Autocomplete\ names\ in\ both\ formats=両方の形式とも自動補完
+Marking\ color\ %0=標識色 %0
+The\ name\ 'comment'\ cannot\ be\ used\ as\ an\ entry\ type\ name.=「comment」という名前は，項目型名としては使用することができません．
+You\ must\ enter\ an\ integer\ value\ in\ the\ text\ field\ for=右記のテキストフィールド中には整数値を入力しなくてはなりません：
+Send\ as\ email=電子メールとして送る
 References=書誌情報
-Sending_of_emails=電子メールの送付
-Subject_for_sending_an_email_with_references=書誌情報を添付した電子メールの件名
-Automatically_open_folders_of_attached_files=添付ファイルのフォルダを自動的に開く
-Create_entry_based_on_content=内容に基づいて項目を生成
-Do_not_show_this_box_again_for_this_import=この読み込みにはこのボックスをもう表示しない
-Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)=このPDF取込み方法を常に用いる(そして読み込み毎に尋ねない)
-Error_creating_email=電子メールを生成する際エラーが発生しました
-Entries_added_to_an_email=項目が電子メールに追加されました
+Sending\ of\ emails=電子メールの送付
+Subject\ for\ sending\ an\ email\ with\ references=書誌情報を添付した電子メールの件名
+Automatically\ open\ folders\ of\ attached\ files=添付ファイルのフォルダを自動的に開く
+Create\ entry\ based\ on\ content=内容に基づいて項目を生成
+Do\ not\ show\ this\ box\ again\ for\ this\ import=この読み込みにはこのボックスをもう表示しない
+Always\ use\ this\ PDF\ import\ style\ (and\ do\ not\ ask\ for\ each\ import)=このPDF取込み方法を常に用いる(そして読み込み毎に尋ねない)
+Error\ creating\ email=電子メールを生成する際エラーが発生しました
+Entries\ added\ to\ an\ email=項目が電子メールに追加されました
 exportFormat=exportFormat
-Output_file_missing=出力ファイルが見当たりません
-No_search_matches.=検索条件に一致するものがありませんでした．
-The_output_option_depends_on_a_valid_input_option.=出力オプションは，入力オプションのうち，有効なものに依存します．
-Default_import_style_for_drag_and_drop_of_PDFs=PDFファイルのドラッグ＆ドロップに対する読み込み方法の既定値
-Default_PDF_file_link_action=PDFファイルのリンク方法の既定値
-Filename_format_pattern=ファイル名の書式パターン
-Additional_parameters=追加のパラメーター
-Cite_selected_entries_between_parenthesis=選択した項目を引用
-Cite_selected_entries_with_in-text_citation=選択した項目を本文内の引用として引用する
-Cite_special=特殊な引用
-Extra_information_(e.g._page_number)=追加情報（例：ページ番号）
-Manage_citations=引用を管理
-Problem_modifying_citation=引用を修正するのに問題発生
+Output\ file\ missing=出力ファイルが見当たりません
+No\ search\ matches.=検索条件に一致するものがありませんでした．
+The\ output\ option\ depends\ on\ a\ valid\ input\ option.=出力オプションは，入力オプションのうち，有効なものに依存します．
+Default\ import\ style\ for\ drag\ and\ drop\ of\ PDFs=PDFファイルのドラッグ＆ドロップに対する読み込み方法の既定値
+Default\ PDF\ file\ link\ action=PDFファイルのリンク方法の既定値
+Filename\ format\ pattern=ファイル名の書式パターン
+Additional\ parameters=追加のパラメーター
+Cite\ selected\ entries\ between\ parenthesis=選択した項目を引用
+Cite\ selected\ entries\ with\ in-text\ citation=選択した項目を本文内の引用として引用する
+Cite\ special=特殊な引用
+Extra\ information\ (e.g.\ page\ number)=追加情報（例：ページ番号）
+Manage\ citations=引用を管理
+Problem\ modifying\ citation=引用を修正するのに問題発生
 Citation=引用
-Extra_information=追加情報
-Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.=引用標識「%0」に対してBibTeX項目を当てはめられませんでした．
-Select_style=様式の選択
+Extra\ information=追加情報
+Could\ not\ resolve\ BibTeX\ entry\ for\ citation\ marker\ '%0'.=引用標識「%0」に対してBibTeX項目を当てはめられませんでした．
+Select\ style=様式の選択
 Journals=学術誌
 Cite=引用
-Cite_in-text=文中への引用
-Insert_empty_citation=空の引用を挿入
-Merge_citations=引用の統合
-Manual_connect=手動接続
-Select_Writer_document=Writer文書を選択
-Sync_OpenOffice/LibreOffice_bibliography=OpenOffice/LibreOffice書誌情報を同期
-Select_which_open_Writer_document_to_work_on=作業にどのWriter文書を開くか選択してください
-Connected_to_document=文書に接続しました
-Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)=表示なしで引用を挿入（項目は参考文献一覧にのみ表示されます）
-Cite_selected_entries_with_extra_information=選択した項目を追加情報とともに引用
-Ensure_that_the_bibliography_is_up-to-date=書誌情報が最新であることを確認する
-Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.=お使いのOpenOffice/LibreOffice文書がBibTeX鍵「%0」を参照していますが，現在のデータベース中には見当たりません．
-Unable_to_synchronize_bibliography=書誌情報を同期することができませんでした
-Combine_pairs_of_citations_that_are_separated_by_spaces_only=空白で区切られている引用のペアのみを連結してください
-Autodetection_failed=自動検出に失敗しました
+Cite\ in-text=文中への引用
+Insert\ empty\ citation=空の引用を挿入
+Merge\ citations=引用の統合
+Manual\ connect=手動接続
+Select\ Writer\ document=Writer文書を選択
+Sync\ OpenOffice/LibreOffice\ bibliography=OpenOffice/LibreOffice書誌情報を同期
+Select\ which\ open\ Writer\ document\ to\ work\ on=作業にどのWriter文書を開くか選択してください
+Connected\ to\ document=文書に接続しました
+Insert\ a\ citation\ without\ text\ (the\ entry\ will\ appear\ in\ the\ reference\ list)=表示なしで引用を挿入（項目は参考文献一覧にのみ表示されます）
+Cite\ selected\ entries\ with\ extra\ information=選択した項目を追加情報とともに引用
+Ensure\ that\ the\ bibliography\ is\ up-to-date=書誌情報が最新であることを確認する
+Your\ OpenOffice/LibreOffice\ document\ references\ the\ BibTeX\ key\ '%0',\ which\ could\ not\ be\ found\ in\ your\ current\ library.=お使いのOpenOffice/LibreOffice文書がBibTeX鍵「%0」を参照していますが，現在のデータベース中には見当たりません．
+Unable\ to\ synchronize\ bibliography=書誌情報を同期することができませんでした
+Combine\ pairs\ of\ citations\ that\ are\ separated\ by\ spaces\ only=空白で区切られている引用のペアのみを連結してください
+Autodetection\ failed=自動検出に失敗しました
 Connecting=接続しています
-Please_wait...=お待ちください...
-Set_connection_parameters=接続パラメーターを指定してください
-Path_to_OpenOffice/LibreOffice_directory=OpenOffice/LibreOffice辞書へのパス
-Path_to_OpenOffice/LibreOffice_executable=OpenOffice/LibreOffice実行ファイルへのパス
-Path_to_OpenOffice/LibreOffice_library_dir=OpenOffice/LibreOfficeライブラリディレクトリへのパス
-Connection_lost=接続が失われました
-The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.=段落様式は，様式ファイル内の「ReferenceParagraphFormat」特性もしくは「ReferenceHeaderParagraphFormat」特性で制御されています．
-The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.=文字書式は，書式ファイル内の引用特性「CitationCharacterFormat」で制御されています．
-Automatically_sync_bibliography_when_inserting_citations=引用を挿入する際，書誌情報を自動的に同期
-Look_up_BibTeX_entries_in_the_active_tab_only=アクティブなタブのBibTeX項目のみを検索
-Look_up_BibTeX_entries_in_all_open_libraries=開かれているデータベースすべてのBibTeX項目を検索
-Autodetecting_paths...=パスを自動検出しています...
-Could_not_find_OpenOffice/LibreOffice_installation=導入済みのOpenOffice/LibreOfficeを検出できませんでした
-Found_more_than_one_OpenOffice/LibreOffice_executable.=実行可能なOpenOffice/LibreOfficeが2つ以上見つかりました．
-Please_choose_which_one_to_connect_to\:=どれに接続するか選んでください：
-Choose_OpenOffice/LibreOffice_executable=OpenOffice/LibreOffice実行ファイルを選択
-Select_document=文書を選択
-HTML_list=HTML一覧
-If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting=可能ならば，名称一覧を標準的なBibTeX名書式に合致するように標準化する
-Could_not_open_%0=%0を開くことができませんでした
-Unknown_import_format=未知の読み込み型です
-Web_search=ウェブ検索
-Style_selection=様式の選択
-No_valid_style_file_defined=有効な様式ファイルが定義されていません
-Choose_pattern=パターンを選択
-Use_the_BIB_file_location_as_primary_file_directory=bibファイルの場所を主要ファイルディレクトリとして使用
-Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.=gnuclient/emacsclientプログラムを実行することができませんでした．emacsclient/gnuclientプログラムが導入済みでPATH中にあることを確認してください．
-OpenOffice/LibreOffice_connection=OpenOffice/LibreOffice接続
-You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.=有効な様式ファイルを選択するか，既定様式のうち一つを用いなくてはなりません．
+Please\ wait...=お待ちください...
+Set\ connection\ parameters=接続パラメーターを指定してください
+Path\ to\ OpenOffice/LibreOffice\ directory=OpenOffice/LibreOffice辞書へのパス
+Path\ to\ OpenOffice/LibreOffice\ executable=OpenOffice/LibreOffice実行ファイルへのパス
+Path\ to\ OpenOffice/LibreOffice\ library\ dir=OpenOffice/LibreOfficeライブラリディレクトリへのパス
+Connection\ lost=接続が失われました
+The\ paragraph\ format\ is\ controlled\ by\ the\ property\ 'ReferenceParagraphFormat'\ or\ 'ReferenceHeaderParagraphFormat'\ in\ the\ style\ file.=段落様式は，様式ファイル内の「ReferenceParagraphFormat」特性もしくは「ReferenceHeaderParagraphFormat」特性で制御されています．
+The\ character\ format\ is\ controlled\ by\ the\ citation\ property\ 'CitationCharacterFormat'\ in\ the\ style\ file.=文字書式は，書式ファイル内の引用特性「CitationCharacterFormat」で制御されています．
+Automatically\ sync\ bibliography\ when\ inserting\ citations=引用を挿入する際，書誌情報を自動的に同期
+Look\ up\ BibTeX\ entries\ in\ the\ active\ tab\ only=アクティブなタブのBibTeX項目のみを検索
+Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=開かれているデータベースすべてのBibTeX項目を検索
+Autodetecting\ paths...=パスを自動検出しています...
+Could\ not\ find\ OpenOffice/LibreOffice\ installation=導入済みのOpenOffice/LibreOfficeを検出できませんでした
+Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=実行可能なOpenOffice/LibreOfficeが2つ以上見つかりました．
+Please\ choose\ which\ one\ to\ connect\ to\:=どれに接続するか選んでください：
+Choose\ OpenOffice/LibreOffice\ executable=OpenOffice/LibreOffice実行ファイルを選択
+Select\ document=文書を選択
+HTML\ list=HTML一覧
+If\ possible,\ normalize\ this\ list\ of\ names\ to\ conform\ to\ standard\ BibTeX\ name\ formatting=可能ならば，名称一覧を標準的なBibTeX名書式に合致するように標準化する
+Could\ not\ open\ %0=%0を開くことができませんでした
+Unknown\ import\ format=未知の読み込み型です
+Web\ search=ウェブ検索
+Style\ selection=様式の選択
+No\ valid\ style\ file\ defined=有効な様式ファイルが定義されていません
+Choose\ pattern=パターンを選択
+Use\ the\ BIB\ file\ location\ as\ primary\ file\ directory=bibファイルの場所を主要ファイルディレクトリとして使用
+Could\ not\ run\ the\ gnuclient/emacsclient\ program.\ Make\ sure\ you\ have\ the\ emacsclient/gnuclient\ program\ installed\ and\ available\ in\ the\ PATH.=gnuclient/emacsclientプログラムを実行することができませんでした．emacsclient/gnuclientプログラムが導入済みでPATH中にあることを確認してください．
+OpenOffice/LibreOffice\ connection=OpenOffice/LibreOffice接続
+You\ must\ select\ either\ a\ valid\ style\ file,\ or\ use\ one\ of\ the\ default\ styles.=有効な様式ファイルを選択するか，既定様式のうち一つを用いなくてはなりません．
 
-This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.=これは単純なコピー＆ペーストダイアログです．まず入力領域に文章を読み込むか貼り付けてください．<br>その後，文章を標識して，それをBibTeXフィールドに割り当てることができます．
-This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.=この機能を使うと，既存のLaTeX文書に必要とされている項目が何であるかを検出して新規データベースが作成されます．
-You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.=項目を選ぶための既に開かれているデータベースと，文書をコンパイルする際にLaTeXが生成したAUXファイルを選択する必要があります．
+This\ is\ a\ simple\ copy\ and\ paste\ dialog.\ First\ load\ or\ paste\ some\ text\ into\ the\ text\ input\ area.<br>After\ that,\ you\ can\ mark\ text\ and\ assign\ it\ to\ a\ BibTeX\ field.=これは単純なコピー＆ペーストダイアログです．まず入力領域に文章を読み込むか貼り付けてください．<br>その後，文章を標識して，それをBibTeXフィールドに割り当てることができます．
+This\ feature\ generates\ a\ new\ library\ based\ on\ which\ entries\ are\ needed\ in\ an\ existing\ LaTeX\ document.=この機能を使うと，既存のLaTeX文書に必要とされている項目が何であるかを検出して新規データベースが作成されます．
+You\ need\ to\ select\ one\ of\ your\ open\ libraries\ from\ which\ to\ choose\ entries,\ as\ well\ as\ the\ AUX\ file\ produced\ by\ LaTeX\ when\ compiling\ your\ document.=項目を選ぶための既に開かれているデータベースと，文書をコンパイルする際にLaTeXが生成したAUXファイルを選択する必要があります．
 
-First_select_entries_to_clean_up.=まず剪定する項目を選択してください．
-Cleanup_entry=項目の剪定
-Autogenerate_PDF_Names=PDF名を自動生成
-Auto-generating_PDF-Names_does_not_support_undo._Continue?=PDF名の自動生成は取り消せません．続けますか？
+First\ select\ entries\ to\ clean\ up.=まず剪定する項目を選択してください．
+Cleanup\ entry=項目の剪定
+Autogenerate\ PDF\ Names=PDF名を自動生成
+Auto-generating\ PDF-Names\ does\ not\ support\ undo.\ Continue?=PDF名の自動生成は取り消せません．続けますか？
 
-Use_full_firstname_whenever_possible=可能な場合は常に完全なファーストネームを使用
-Use_abbreviated_firstname_whenever_possible=可能な場合は常に短縮したファーストネームを使用
-Use_abbreviated_and_full_firstname=短縮したファーストネームと完全なファーストネームを両方使用
-Autocompletion_options=自動補完オプション
-Name_format_used_for_autocompletion=自動補完に使用される氏名の書式
-Treatment_of_first_names=名(first_name)の取り扱い
-Cleanup_entries=項目の剪定
-Automatically_assign_new_entry_to_selected_groups=選択したグループに新規項目を自動割り当て
-%0_mode=%0モード
-Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix=DOIをnote及びURLフィールドからDOIフィールドに移動して，http前置詞を削除
-Make_paths_of_linked_files_relative_(if_possible)=リンクファイルのパスを（可能な限り）相対パス化
-Rename_PDFs_to_given_filename_format_pattern=PDFを指定したファイル名書式パターンに改名
-Rename_only_PDFs_having_a_relative_path=相対パスを持つPDFのみを改名
-What_would_you_like_to_clean_up?=どのように剪定しますか？
-Doing_a_cleanup_for_%0_entries...=%0個の項目を剪定しています...
-No_entry_needed_a_clean_up=剪定の必要がある項目はありませんでした
-One_entry_needed_a_clean_up=1つの項目を剪定する必要がありました
-%0_entries_needed_a_clean_up=%0個の項目を剪定する必要がありました
+Use\ full\ firstname\ whenever\ possible=可能な場合は常に完全なファーストネームを使用
+Use\ abbreviated\ firstname\ whenever\ possible=可能な場合は常に短縮したファーストネームを使用
+Use\ abbreviated\ and\ full\ firstname=短縮したファーストネームと完全なファーストネームを両方使用
+Autocompletion\ options=自動補完オプション
+Name\ format\ used\ for\ autocompletion=自動補完に使用される氏名の書式
+Treatment\ of\ first\ names=名(first name)の取り扱い
+Cleanup\ entries=項目の剪定
+Automatically\ assign\ new\ entry\ to\ selected\ groups=選択したグループに新規項目を自動割り当て
+%0\ mode=%0モード
+Move\ DOIs\ from\ note\ and\ URL\ field\ to\ DOI\ field\ and\ remove\ http\ prefix=DOIをnote及びURLフィールドからDOIフィールドに移動して，http前置詞を削除
+Make\ paths\ of\ linked\ files\ relative\ (if\ possible)=リンクファイルのパスを（可能な限り）相対パス化
+Rename\ PDFs\ to\ given\ filename\ format\ pattern=PDFを指定したファイル名書式パターンに改名
+Rename\ only\ PDFs\ having\ a\ relative\ path=相対パスを持つPDFのみを改名
+What\ would\ you\ like\ to\ clean\ up?=どのように剪定しますか？
+Doing\ a\ cleanup\ for\ %0\ entries...=%0個の項目を剪定しています...
+No\ entry\ needed\ a\ clean\ up=剪定の必要がある項目はありませんでした
+One\ entry\ needed\ a\ clean\ up=1つの項目を剪定する必要がありました
+%0\ entries\ needed\ a\ clean\ up=%0個の項目を剪定する必要がありました
 
-Remove_selected=選択分を削除
+Remove\ selected=選択分を削除
 
-Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.=グループツリーを解析できませんでした．BibTeXデータベースを保存すると，グループはすべて失われます．
-Attach_file=ファイルを添付
-Setting_all_preferences_to_default_values.=すべての設定を既定値にします．
-Resetting_preference_key_'%0'=キー「%0」の設定をリセットします
-Unknown_preference_key_'%0'=キー「%0」という設定は知りません
-Unable_to_clear_preferences.=設定を消去することができませんでした．
+Group\ tree\ could\ not\ be\ parsed.\ If\ you\ save\ the\ BibTeX\ library,\ all\ groups\ will\ be\ lost.=グループツリーを解析できませんでした．BibTeXデータベースを保存すると，グループはすべて失われます．
+Attach\ file=ファイルを添付
+Setting\ all\ preferences\ to\ default\ values.=すべての設定を既定値にします．
+Resetting\ preference\ key\ '%0'=キー「%0」の設定をリセットします
+Unknown\ preference\ key\ '%0'=キー「%0」という設定は知りません
+Unable\ to\ clear\ preferences.=設定を消去することができませんでした．
 
-Reset_preferences_(key1,key2,..._or_'all')=設定をリセット(キー1・キー2…あるいは「all」)
-Find_unlinked_files=リンクされていないファイルを検索
-Unselect_all=すべての選択を解除
-Expand_all=すべて展開表示
-Collapse_all=すべて畳んで表示
-Opens_the_file_browser.=ファイルブラウザを開きます
-Scan_directory=ディレクトリを走査
-Searches_the_selected_directory_for_unlinked_files.=選択したディレクトリでリンクされていないファイルを検索
-Starts_the_import_of_BibTeX_entries.=BibTeX項目の読み込みを開始します．
-Leave_this_dialog.=このダイアログを閉じます．
-Create_directory_based_keywords=ディレクトリに基づいたキーワードを生成
-Creates_keywords_in_created_entrys_with_directory_pathnames=生成した項目のキーワードにディレクトリパス名を入れる
-Select_a_directory_where_the_search_shall_start.=検索を開始するディレクトリを選んでください．
-Select_file_type\:=ファイル型を選択：
-These_files_are_not_linked_in_the_active_library.=これらのファイルは，現在アクティブなデータベースにリンクされていません．
-Entry_type_to_be_created\:=生成する項目型：
-Searching_file_system...=ファイルシステムを検索しています...
-Importing_into_Library...=データベースに読み込んでいます...
-Select_directory=辞書を選択
-Select_files=ファイルを選択
-BibTeX_entry_creation=BibTeX項目の引用
-<No_selection>=<選択されていません>
-Unable_to_connect_to_FreeCite_online_service.=freeciteオンラインサービスに接続できませんでした．
-Parse_with_FreeCite=FreeCiteで解析
-The_current_BibTeX_key_will_be_overwritten._Continue?=現在のBibTeX鍵は上書きされます．続けますか？
-Overwrite_key=鍵を上書き
-Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator=既存の鍵を上書きしません．この設定を変更するには，オプション→設定→BibTeXキーの生成を開いてください
-How_would_you_like_to_link_to_'%0'?=「%0」へのリンクをどうしますか？
-BibTeX_key_patterns=BibTeX鍵パターン
-Changed_special_field_settings=特殊フィールドの設定が変更されました
-Clear_priority=優先度を消去
-Clear_rank=評価を消去
-Enable_special_fields=特殊フィールドを使用する
-One_star=一つ星
-Two_stars=二つ星
-Three_stars=三つ星
-Four_stars=四つ星
-Five_stars=五つ星
-Help_on_special_fields=特殊フィールドのヘルプ
-Keywords_of_selected_entries=選択した項目のキーワード
-Manage_content_selectors=内容選択子を管理
-Manage_keywords=キーワードの管理
-No_priority_information=優先度の情報がありません
-No_rank_information=評価の情報がありません
+Reset\ preferences\ (key1,key2,...\ or\ 'all')=設定をリセット(キー1・キー2…あるいは「all」)
+Find\ unlinked\ files=リンクされていないファイルを検索
+Unselect\ all=すべての選択を解除
+Expand\ all=すべて展開表示
+Collapse\ all=すべて畳んで表示
+Opens\ the\ file\ browser.=ファイルブラウザを開きます
+Scan\ directory=ディレクトリを走査
+Searches\ the\ selected\ directory\ for\ unlinked\ files.=選択したディレクトリでリンクされていないファイルを検索
+Starts\ the\ import\ of\ BibTeX\ entries.=BibTeX項目の読み込みを開始します．
+Leave\ this\ dialog.=このダイアログを閉じます．
+Create\ directory\ based\ keywords=ディレクトリに基づいたキーワードを生成
+Creates\ keywords\ in\ created\ entrys\ with\ directory\ pathnames=生成した項目のキーワードにディレクトリパス名を入れる
+Select\ a\ directory\ where\ the\ search\ shall\ start.=検索を開始するディレクトリを選んでください．
+Select\ file\ type\:=ファイル型を選択：
+These\ files\ are\ not\ linked\ in\ the\ active\ library.=これらのファイルは，現在アクティブなデータベースにリンクされていません．
+Entry\ type\ to\ be\ created\:=生成する項目型：
+Searching\ file\ system...=ファイルシステムを検索しています...
+Importing\ into\ Library...=データベースに読み込んでいます...
+Select\ directory=辞書を選択
+Select\ files=ファイルを選択
+BibTeX\ entry\ creation=BibTeX項目の引用
+<No\ selection>=<選択されていません>
+Unable\ to\ connect\ to\ FreeCite\ online\ service.=freeciteオンラインサービスに接続できませんでした．
+Parse\ with\ FreeCite=FreeCiteで解析
+The\ current\ BibTeX\ key\ will\ be\ overwritten.\ Continue?=現在のBibTeX鍵は上書きされます．続けますか？
+Overwrite\ key=鍵を上書き
+Not\ overwriting\ existing\ key.\ To\ change\ this\ setting,\ open\ Options\ ->\ Prefererences\ ->\ BibTeX\ key\ generator=既存の鍵を上書きしません．この設定を変更するには，オプション→設定→BibTeXキーの生成を開いてください
+How\ would\ you\ like\ to\ link\ to\ '%0'?=「%0」へのリンクをどうしますか？
+BibTeX\ key\ patterns=BibTeX鍵パターン
+Changed\ special\ field\ settings=特殊フィールドの設定が変更されました
+Clear\ priority=優先度を消去
+Clear\ rank=評価を消去
+Enable\ special\ fields=特殊フィールドを使用する
+One\ star=一つ星
+Two\ stars=二つ星
+Three\ stars=三つ星
+Four\ stars=四つ星
+Five\ stars=五つ星
+Help\ on\ special\ fields=特殊フィールドのヘルプ
+Keywords\ of\ selected\ entries=選択した項目のキーワード
+Manage\ content\ selectors=内容選択子を管理
+Manage\ keywords=キーワードの管理
+No\ priority\ information=優先度の情報がありません
+No\ rank\ information=評価の情報がありません
 Priority=優先度
-Priority_high=優先度高
-Priority_low=優先度中
-Priority_medium=優先度低
+Priority\ high=優先度高
+Priority\ low=優先度中
+Priority\ medium=優先度低
 Quality=品質
 Rank=評価
 Relevance=関連性
-Set_priority_to_high=優先度を高に設定
-Set_priority_to_low=優先度を低に設定
-Set_priority_to_medium=優先度を中に設定
-Show_priority=優先度を表示
-Show_quality=品質を表示
-Show_rank=評価を表示
-Show_relevance=関連性を表示
-Synchronize_with_keywords=キーワードと同期
-Synchronized_special_fields_based_on_keywords=キーワードに基づいて同期される特殊フィールド
-Toggle_relevance=関連性を入切
-Toggle_quality_assured=品質検査済みを入切
-Toggle_print_status=印刷済情報を変更
-Update_keywords=キーワードを更新
-Write_values_of_special_fields_as_separate_fields_to_BibTeX=特殊フィールドの値を独立したフィールドとしてBibTeXに書き込む
-You_have_changed_settings_for_special_fields.=特殊フィールドの設定が変更されました．
-%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.=%0個の項目が検出されました．サーバー負荷を軽減するため，%1個のみがダウンロードされます．
-A_string_with_that_label_already_exists=そのラベルを持つ文字列は既に存在しています
-Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.=OpenOffice/LibreOfficeへの接続が失われました．OpenOffice/LibreOfficeが実行されていることを確認して再接続を試みてください．
-JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.=JabRefは，項目あたり少なくとも一つのリクエストを出版社に送ります．
-Correct_the_entry,_and_reopen_editor_to_display/edit_source.=項目を修正してエディタを再度開き，ソースを表示もしくは編集してください．
-Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').=実行中のgnuservプロセスに接続できませんでした．EmacsあるいはXEmacsが実行中であることを確認し，<BR>（「server-start」または「gnuserv-start」コマンドを実行して）サーバーが起動していることてください．
-Could_not_connect_to_running_OpenOffice/LibreOffice.=実行中のOpenOffice/LibreOfficeに接続できませんでした．
-Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.=OpenOffice/LibreOfficeがJavaサポートとともに導入されていることを確認してください．
-If_connecting_manually,_please_verify_program_and_library_paths.=手動で接続しようとしている場合には，プログラムとライブラリのパスを確認してください．
-Error_message\:=エラーメッセージは以下の通り：
-If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.=既にフィールドセットのある項目を貼り付けたり読み込んだりした場合には，上書きする．
-Import_metadata_from_PDF=PDFからMetadataを読み込む
-Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.=どのWriter文書にも接続されていません．文書が開かれているか確認して，「Writer文書を選択」ボタンを押して接続してください．
-Removed_all_subgroups_of_group_"%0".=グループ「%0」の全下層グループを削除しました
-To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.=メモリースティックモードを無効にするには，JabRefと同じフォルダにあるjabref.xmlファイルを改名するか削除してください
-Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.=接続ができません．一つの可能性としては，JabRefとOpenOffice/LibreOfficeが，ともに32ビットモードか64ビットモードで実行されていないせいかもしれません．
-Use_the_following_delimiter_character(s)\:=右記の区切り文字を使用：
-When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above=ファイルをダウンロードする時やリンクしたファイルをファイルディレクトリに移動する際に，上記で設定したファイルディレクトリではなくbibファイルの場所を優先する
-Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=お使いの様式ファイルは，文字様式「%0」を指定していますが，これは，現在のOpenOffice/LibreOffice文書には定義されていません．
-Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=お使いの様式ファイルは，段落様式「%0」を指定していますが，これは，現在のOpenOffice/LibreOffice文書には定義されていません．
+Set\ priority\ to\ high=優先度を高に設定
+Set\ priority\ to\ low=優先度を低に設定
+Set\ priority\ to\ medium=優先度を中に設定
+Show\ priority=優先度を表示
+Show\ quality=品質を表示
+Show\ rank=評価を表示
+Show\ relevance=関連性を表示
+Synchronize\ with\ keywords=キーワードと同期
+Synchronized\ special\ fields\ based\ on\ keywords=キーワードに基づいて同期される特殊フィールド
+Toggle\ relevance=関連性を入切
+Toggle\ quality\ assured=品質検査済みを入切
+Toggle\ print\ status=印刷済情報を変更
+Update\ keywords=キーワードを更新
+Write\ values\ of\ special\ fields\ as\ separate\ fields\ to\ BibTeX=特殊フィールドの値を独立したフィールドとしてBibTeXに書き込む
+You\ have\ changed\ settings\ for\ special\ fields.=特殊フィールドの設定が変更されました．
+%0\ entries\ found.\ To\ reduce\ server\ load,\ only\ %1\ will\ be\ downloaded.=%0個の項目が検出されました．サーバー負荷を軽減するため，%1個のみがダウンロードされます．
+A\ string\ with\ that\ label\ already\ exists=そのラベルを持つ文字列は既に存在しています
+Connection\ to\ OpenOffice/LibreOffice\ has\ been\ lost.\ Please\ make\ sure\ OpenOffice/LibreOffice\ is\ running,\ and\ try\ to\ reconnect.=OpenOffice/LibreOfficeへの接続が失われました．OpenOffice/LibreOfficeが実行されていることを確認して再接続を試みてください．
+JabRef\ will\ send\ at\ least\ one\ request\ per\ entry\ to\ a\ publisher.=JabRefは，項目あたり少なくとも一つのリクエストを出版社に送ります．
+Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=項目を修正してエディタを再度開き，ソースを表示もしくは編集してください．
+Could\ not\ connect\ to\ a\ running\ gnuserv\ process.\ Make\ sure\ that\ Emacs\ or\ XEmacs\ is\ running,<BR>and\ that\ the\ server\ has\ been\ started\ (by\ running\ the\ command\ 'server-start'/'gnuserv-start').=実行中のgnuservプロセスに接続できませんでした．EmacsあるいはXEmacsが実行中であることを確認し，<BR>（「server-start」または「gnuserv-start」コマンドを実行して）サーバーが起動していることてください．
+Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=実行中のOpenOffice/LibreOfficeに接続できませんでした．
+Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=OpenOffice/LibreOfficeがJavaサポートとともに導入されていることを確認してください．
+If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=手動で接続しようとしている場合には，プログラムとライブラリのパスを確認してください．
+Error\ message\:=エラーメッセージは以下の通り：
+If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=既にフィールドセットのある項目を貼り付けたり読み込んだりした場合には，上書きする．
+Import\ metadata\ from\ PDF=PDFからMetadataを読み込む
+Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=どのWriter文書にも接続されていません．文書が開かれているか確認して，「Writer文書を選択」ボタンを押して接続してください．
+Removed\ all\ subgroups\ of\ group\ "%0".=グループ「%0」の全下層グループを削除しました
+To\ disable\ the\ memory\ stick\ mode\ rename\ or\ remove\ the\ jabref.xml\ file\ in\ the\ same\ folder\ as\ JabRef.=メモリースティックモードを無効にするには，JabRefと同じフォルダにあるjabref.xmlファイルを改名するか削除してください
+Unable\ to\ connect.\ One\ possible\ reason\ is\ that\ JabRef\ and\ OpenOffice/LibreOffice\ are\ not\ both\ running\ in\ either\ 32\ bit\ mode\ or\ 64\ bit\ mode.=接続ができません．一つの可能性としては，JabRefとOpenOffice/LibreOfficeが，ともに32ビットモードか64ビットモードで実行されていないせいかもしれません．
+Use\ the\ following\ delimiter\ character(s)\:=右記の区切り文字を使用：
+When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\ prefer\ the\ BIB\ file\ location\ rather\ than\ the\ file\ directory\ set\ above=ファイルをダウンロードする時やリンクしたファイルをファイルディレクトリに移動する際に，上記で設定したファイルディレクトリではなくbibファイルの場所を優先する
+Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=お使いの様式ファイルは，文字様式「%0」を指定していますが，これは，現在のOpenOffice/LibreOffice文書には定義されていません．
+Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=お使いの様式ファイルは，段落様式「%0」を指定していますが，これは，現在のOpenOffice/LibreOffice文書には定義されていません．
 
 Searching...=検索中...
-You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?=ダウンロードする項目を%0個以上選択しました．あまりに多くのダウンロードを急に行うと，其れをブロックするウェブサイトもあります．続けますか？
-Confirm_selection=選択範囲を確認
-Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case=大小文字を正しく維持するため，検索中に指定したタイトル語に{}を付け加える
-Import_conversions=読み込み時変換
-Please_enter_a_search_string=検索文字列を入力してください
-Please_open_or_start_a_new_library_before_searching=検索前にデータベースを開くか新規データベースを開始してください
+You\ have\ selected\ more\ than\ %0\ entries\ for\ download.\ Some\ web\ sites\ might\ block\ you\ if\ you\ make\ too\ many\ rapid\ downloads.\ Do\ you\ want\ to\ continue?=ダウンロードする項目を%0個以上選択しました．あまりに多くのダウンロードを急に行うと，其れをブロックするウェブサイトもあります．続けますか？
+Confirm\ selection=選択範囲を確認
+Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=大小文字を正しく維持するため，検索中に指定したタイトル語に{}を付け加える
+Import\ conversions=読み込み時変換
+Please\ enter\ a\ search\ string=検索文字列を入力してください
+Please\ open\ or\ start\ a\ new\ library\ before\ searching=検索前にデータベースを開くか新規データベースを開始してください
 
-Canceled_merging_entries=項目の統合を取り消しました
+Canceled\ merging\ entries=項目の統合を取り消しました
 
-Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search=非改行区切りを付して検索で大文字小文字が正しくなるよう単位を整形
-Merge_entries=項目の統合
-Merged_entries=項目を統合しました
-Merged_entry=統合後の項目
+Format\ units\ by\ adding\ non-breaking\ separators\ and\ keeping\ the\ correct\ case\ on\ search=非改行区切りを付して検索で大文字小文字が正しくなるよう単位を整形
+Merge\ entries=項目の統合
+Merged\ entries=項目を統合しました
+Merged\ entry=統合後の項目
 None=なし
 Parse=解析
 Result=結果
-Show_DOI_first=DOIを最初に表示
-Show_URL_first=URLを最初に表示
-Use_Emacs_key_bindings=Emacsキー割当を使用
-You_have_to_choose_exactly_two_entries_to_merge.=統合する項目を2つ選ばなくてはなりません．
+Show\ DOI\ first=DOIを最初に表示
+Show\ URL\ first=URLを最初に表示
+Use\ Emacs\ key\ bindings=Emacsキー割当を使用
+You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=統合する項目を2つ選ばなくてはなりません．
 
-Update_timestamp_on_modification=修正時にタイムスタンプを更新
-All_key_bindings_will_be_reset_to_their_defaults.=すべてのキー割当を既定値に復帰します．
+Update\ timestamp\ on\ modification=修正時にタイムスタンプを更新
+All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=すべてのキー割当を既定値に復帰します．
 
-Automatically_set_file_links=ファイルリンクを自動設定
-Resetting_all_key_bindings=キー割当をすべて復帰
+Automatically\ set\ file\ links=ファイルリンクを自動設定
+Resetting\ all\ key\ bindings=キー割当をすべて復帰
 Hostname=ホスト
-Invalid_setting=無効な設定です
+Invalid\ setting=無効な設定です
 Network=ネットワーク
-Please_specify_both_hostname_and_port=ホスト名とポートの両方を指定してください
-Please_specify_both_username_and_password=ユーザー名とパスワードをともに指定してください
+Please\ specify\ both\ hostname\ and\ port=ホスト名とポートの両方を指定してください
+Please\ specify\ both\ username\ and\ password=ユーザー名とパスワードをともに指定してください
 
-Use_custom_proxy_configuration=ユーザー定義のプロキシ設定を用いる
-Proxy_requires_authentication=プロキシには認証が必要
-Attention\:_Password_is_stored_in_plain_text\!=警告：パスワードは平文で保管されます！
-Clear_connection_settings=接続設定を消去する
-Cleared_connection_settings.=接続設定を消去しました
+Use\ custom\ proxy\ configuration=ユーザー定義のプロキシ設定を用いる
+Proxy\ requires\ authentication=プロキシには認証が必要
+Attention\:\ Password\ is\ stored\ in\ plain\ text\!=警告：パスワードは平文で保管されます！
+Clear\ connection\ settings=接続設定を消去する
+Cleared\ connection\ settings.=接続設定を消去しました
 
-Rebind_C-a,_too=C-aも割り当て直す
-Rebind_C-f,_too=C-fもバインドし直します
+Rebind\ C-a,\ too=C-aも割り当て直す
+Rebind\ C-f,\ too=C-fもバインドし直します
 
-Open_folder=フォルダを開く
-Searches_for_unlinked_PDF_files_on_the_file_system=ファイルシステム上にあるリンクされていないPDFファイルを検索する
-Export_entries_ordered_as_specified=項目を指定順に書き出し
-Export_sort_order=書き出し整序順
-Export_sorting=書き出しの整序
-Newline_separator=新規行分離子
+Open\ folder=フォルダを開く
+Searches\ for\ unlinked\ PDF\ files\ on\ the\ file\ system=ファイルシステム上にあるリンクされていないPDFファイルを検索する
+Export\ entries\ ordered\ as\ specified=項目を指定順に書き出し
+Export\ sort\ order=書き出し整序順
+Export\ sorting=書き出しの整序
+Newline\ separator=新規行分離子
 
-Save_entries_ordered_as_specified=項目を指定順に保存
-Save_sort_order=整序順を保存
-Show_extra_columns=追加列を表示
-Parsing_error=解析エラー
-illegal_backslash_expression=バックスラッシュ表現が不正です
+Save\ entries\ ordered\ as\ specified=項目を指定順に保存
+Save\ sort\ order=整序順を保存
+Show\ extra\ columns=追加列を表示
+Parsing\ error=解析エラー
+illegal\ backslash\ expression=バックスラッシュ表現が不正です
 
-Move_to_group=グループに移動
+Move\ to\ group=グループに移動
 
-Clear_read_status=既読情報を消去
-Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')=biblatex形式に変換（例：「journal」フィールドの値を「journaltitle」フィールドに移管）
-Could_not_apply_changes.=変更を適用できませんでした．
-Deprecated_fields=旧式のフィールド
-Hide/show_toolbar=ツールバーを表示/非表示
-No_read_status_information=既読情報がありません
+Clear\ read\ status=既読情報を消去
+Convert\ to\ biblatex\ format\ (for\ example,\ move\ the\ value\ of\ the\ 'journal'\ field\ to\ 'journaltitle')=biblatex形式に変換（例：「journal」フィールドの値を「journaltitle」フィールドに移管）
+Could\ not\ apply\ changes.=変更を適用できませんでした．
+Deprecated\ fields=旧式のフィールド
+Hide/show\ toolbar=ツールバーを表示/非表示
+No\ read\ status\ information=既読情報がありません
 Printed=印刷しました
-Read_status=既読情報
-Read_status_read=既読情報は既読です
-Read_status_skimmed=既読情報は斜め読み状態です
-Save_selected_as_plain_BibTeX...=選択部をplain_BibTeXとして保存...
-Set_read_status_to_read=既読情報を既読に設定
-Set_read_status_to_skimmed=既読情報を斜め読み済に設定
-Show_deprecated_BibTeX_fields=旧式のBibTeXフィールドを表示
+Read\ status=既読情報
+Read\ status\ read=既読情報は既読です
+Read\ status\ skimmed=既読情報は斜め読み状態です
+Save\ selected\ as\ plain\ BibTeX...=選択部をplain BibTeXとして保存...
+Set\ read\ status\ to\ read=既読情報を既読に設定
+Set\ read\ status\ to\ skimmed=既読情報を斜め読み済に設定
+Show\ deprecated\ BibTeX\ fields=旧式のBibTeXフィールドを表示
 
-Show_gridlines=グリッド線を表示
-Show_printed_status=印刷済情報を表示
-Show_read_status=既読情報を表示
-Table_row_height_padding=表の行高パディング
+Show\ gridlines=グリッド線を表示
+Show\ printed\ status=印刷済情報を表示
+Show\ read\ status=既読情報を表示
+Table\ row\ height\ padding=表の行高パディング
 
-Marked_selected_entry=選択した項目に標識を付けました
-Marked_all_%0_selected_entries=%0個の選択項目全てに標識を付けました
-Unmarked_selected_entry=選択項目の標識を外しました
-Unmarked_all_%0_selected_entries=%0個の選択項目全ての標識を外しました
+Marked\ selected\ entry=選択した項目に標識を付けました
+Marked\ all\ %0\ selected\ entries=%0個の選択項目全てに標識を付けました
+Unmarked\ selected\ entry=選択項目の標識を外しました
+Unmarked\ all\ %0\ selected\ entries=%0個の選択項目全ての標識を外しました
 
 
-Unmarked_all_entries=全項目の標識を外しました
+Unmarked\ all\ entries=全項目の標識を外しました
 
-Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.=要求のあった操作性設定を見つけることができなかったので，既定値を使用します．
+Unable\ to\ find\ the\ requested\ look\ and\ feel\ and\ thus\ the\ default\ one\ is\ used.=要求のあった操作性設定を見つけることができなかったので，既定値を使用します．
 
-Opens_JabRef's_GitHub_page=JabRefのGitHubページを開きます
-Could_not_open_browser.=ブラウザを開くことができませんでした．
-Please_open_%0_manually.=%0を手動で開いてください．
-The_link_has_been_copied_to_the_clipboard.=リンクがクリップボードにコピーされました．
+Opens\ JabRef's\ GitHub\ page=JabRefのGitHubページを開きます
+Could\ not\ open\ browser.=ブラウザを開くことができませんでした．
+Please\ open\ %0\ manually.=%0を手動で開いてください．
+The\ link\ has\ been\ copied\ to\ the\ clipboard.=リンクがクリップボードにコピーされました．
 
-Open_%0_file=%0個のファイルを開きます
+Open\ %0\ file=%0個のファイルを開きます
 
-Cannot_delete_file=ファイルを削除することができません
-File_permission_error=ファイルアクセス権のエラー
-Push_to_%0=%0にプッシュ
-Path_to_%0=%0へのパス
+Cannot\ delete\ file=ファイルを削除することができません
+File\ permission\ error=ファイルアクセス権のエラー
+Push\ to\ %0=%0にプッシュ
+Path\ to\ %0=%0へのパス
 Convert=変換
-Normalize_to_BibTeX_name_format=BibTeXの名前書式に標準化
-Help_on_Name_Formatting=名前の書式に関するヘルプ
+Normalize\ to\ BibTeX\ name\ format=BibTeXの名前書式に標準化
+Help\ on\ Name\ Formatting=名前の書式に関するヘルプ
 
-Add_new_file_type=新規ファイル形式を追加
+Add\ new\ file\ type=新規ファイル形式を追加
 
-Left_entry=左側の項目
-Right_entry=右側の項目
+Left\ entry=左側の項目
+Right\ entry=右側の項目
 Use=採用
-Original_entry=元の項目
-Replace_original_entry=元の項目を置き換える
-No_information_added=情報は追加されていません
-Select_at_least_one_entry_to_manage_keywords.=キーワードを操作するには少なくともひとつの項目を選択してください．
-OpenDocument_text=OpenDocument文書
-OpenDocument_spreadsheet=OpenDocument表計算
-OpenDocument_presentation=OpenDocumentプレゼンテーション
-%0_image=%0画像
-Added_entry=項目を追加しました
-Modified_entry=項目を修正しました
-Deleted_entry=項目を削除
-Modified_groups_tree=グループツリーを修正しました
-Removed_all_groups=全グループを削除しました
-Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.=変更を承認すると，外部で修正されたグループツリーで，グループツリー全体を置き換えます．
-Select_export_format=書き出し形式を選んでください
-Return_to_JabRef=JabRefに戻る
-Please_move_the_file_manually_and_link_in_place.=ファイルを手動で移動して，そこでリンクしてください．
-Could_not_connect_to_%0=%0に接続することができませんでした
-Warning\:_%0_out_of_%1_entries_have_undefined_title.=警告；%1項目中%0項目に定義されていないタイトルがあります．
-Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.=警告；%1項目中%0項目に定義されていないBibTeX鍵があります．
+Original\ entry=元の項目
+Replace\ original\ entry=元の項目を置き換える
+No\ information\ added=情報は追加されていません
+Select\ at\ least\ one\ entry\ to\ manage\ keywords.=キーワードを操作するには少なくともひとつの項目を選択してください．
+OpenDocument\ text=OpenDocument文書
+OpenDocument\ spreadsheet=OpenDocument表計算
+OpenDocument\ presentation=OpenDocumentプレゼンテーション
+%0\ image=%0画像
+Added\ entry=項目を追加しました
+Modified\ entry=項目を修正しました
+Deleted\ entry=項目を削除
+Modified\ groups\ tree=グループツリーを修正しました
+Removed\ all\ groups=全グループを削除しました
+Accepting\ the\ change\ replaces\ the\ complete\ groups\ tree\ with\ the\ externally\ modified\ groups\ tree.=変更を承認すると，外部で修正されたグループツリーで，グループツリー全体を置き換えます．
+Select\ export\ format=書き出し形式を選んでください
+Return\ to\ JabRef=JabRefに戻る
+Please\ move\ the\ file\ manually\ and\ link\ in\ place.=ファイルを手動で移動して，そこでリンクしてください．
+Could\ not\ connect\ to\ %0=%0に接続することができませんでした
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ title.=警告；%1項目中%0項目に定義されていないタイトルがあります．
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ BibTeX\ key.=警告；%1項目中%0項目に定義されていないBibTeX鍵があります．
 occurrence=個
-Added_new_'%0'_entry.=「%0」項目を新規に追加しました．
-Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?=複数の項目を選択しています．これらすべての項目の型を「%0」に変更しますか？
-Changed_type_to_'%0'_for=右記を「%0」型に変更しました：
-Really_delete_the_selected_entry?=選択した項目を本当に削除しますか？
-Really_delete_the_%0_selected_entries?=選択した%0項目を本当に削除しますか？
-Keep_merged_entry_only=統合した項目のみを維持
-Keep_left=左側を維持
-Keep_right=右側を維持
-Old_entry=旧項目
-From_import=読込より
-No_problems_found.=問題は検出されませんでした．
-%0_problem(s)_found=%0件問題を検出しました
-Save_changes=変更点を保存
-Discard_changes=変更を放棄
-Library_'%0'_has_changed.=データベース「%0」に変更が加えられました．
-Print_entry_preview=項目プレビューを印刷
-Copy_title=タイトルをコピー
-Copy_\\cite{BibTeX_key}=\\cite{BibTeX鍵}をコピー
-Copy_BibTeX_key_and_title=BibTeX鍵とタイトルをコピー
-File_rename_failed_for_%0_entries.=%0項目のファイル名変更が失敗しました．
-Merged_BibTeX_source_code=統合後のBibTeXソースコード
-Invalid_DOI\:_'%0'.=無効なDOIです：'%0'.
-should_start_with_a_name=始まりは名前でなくてはなりません
-should_end_with_a_name=終わりは名前でなくてはなりません
-unexpected_closing_curly_bracket=閉じ波かっこが余分にあります
-unexpected_opening_curly_bracket=開き波かっこが余計にあります
-capital_letters_are_not_masked_using_curly_brackets_{}=波かっこ{}では，大文字はマスクされません
-should_contain_a_four_digit_number=4桁の数字でなくてはなりません
-should_contain_a_valid_page_number_range=有効なページ数範囲でなくてはなりません
+Added\ new\ '%0'\ entry.=「%0」項目を新規に追加しました．
+Multiple\ entries\ selected.\ Do\ you\ want\ to\ change\ the\ type\ of\ all\ these\ to\ '%0'?=複数の項目を選択しています．これらすべての項目の型を「%0」に変更しますか？
+Changed\ type\ to\ '%0'\ for=右記を「%0」型に変更しました：
+Really\ delete\ the\ selected\ entry?=選択した項目を本当に削除しますか？
+Really\ delete\ the\ %0\ selected\ entries?=選択した%0項目を本当に削除しますか？
+Keep\ merged\ entry\ only=統合した項目のみを維持
+Keep\ left=左側を維持
+Keep\ right=右側を維持
+Old\ entry=旧項目
+From\ import=読込より
+No\ problems\ found.=問題は検出されませんでした．
+%0\ problem(s)\ found=%0件問題を検出しました
+Save\ changes=変更点を保存
+Discard\ changes=変更を放棄
+Library\ '%0'\ has\ changed.=データベース「%0」に変更が加えられました．
+Print\ entry\ preview=項目プレビューを印刷
+Copy\ title=タイトルをコピー
+Copy\ \\cite{BibTeX\ key}=\\cite{BibTeX鍵}をコピー
+Copy\ BibTeX\ key\ and\ title=BibTeX鍵とタイトルをコピー
+File\ rename\ failed\ for\ %0\ entries.=%0項目のファイル名変更が失敗しました．
+Merged\ BibTeX\ source\ code=統合後のBibTeXソースコード
+Invalid\ DOI\:\ '%0'.=無効なDOIです：'%0'.
+should\ start\ with\ a\ name=始まりは名前でなくてはなりません
+should\ end\ with\ a\ name=終わりは名前でなくてはなりません
+unexpected\ closing\ curly\ bracket=閉じ波かっこが余分にあります
+unexpected\ opening\ curly\ bracket=開き波かっこが余計にあります
+capital\ letters\ are\ not\ masked\ using\ curly\ brackets\ {}=波かっこ{}では，大文字はマスクされません
+should\ contain\ a\ four\ digit\ number=4桁の数字でなくてはなりません
+should\ contain\ a\ valid\ page\ number\ range=有効なページ数範囲でなくてはなりません
 Filled=書込み済
-Field_is_missing=フィールドがありません
-Search_%0=%0を検索
+Field\ is\ missing=フィールドがありません
+Search\ %0=%0を検索
 
-Search_results_in_all_libraries_for_%0=%0を全データベースで検索した結果
-Search_results_in_library_%0_for_%1=%0をデータベース%1で検索した結果
-Search_globally=大域検索
-No_results_found.=検出されませんでした．
-Found_%0_results.=%0件検出しました．
-plain_text=平文
-This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>=この検索結果は，フィールドのうちどれかに正規表現<b>%0</b>が含まれている項目を表示します．
-This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>=この検索結果は，フィールドのうちどれかに用語<b>%0</b>が含まれている項目を表示します．
-This_search_contains_entries_in_which=この検索結果は下記のものを表示；
+Search\ results\ in\ all\ libraries\ for\ %0=%0を全データベースで検索した結果
+Search\ results\ in\ library\ %0\ for\ %1=%0をデータベース%1で検索した結果
+Search\ globally=大域検索
+No\ results\ found.=検出されませんでした．
+Found\ %0\ results.=%0件検出しました．
+plain\ text=平文
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ regular\ expression\ <b>%0</b>=この検索結果は，フィールドのうちどれかに正規表現<b>%0</b>が含まれている項目を表示します．
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ term\ <b>%0</b>=この検索結果は，フィールドのうちどれかに用語<b>%0</b>が含まれている項目を表示します．
+This\ search\ contains\ entries\ in\ which=この検索結果は下記のものを表示；
 
-Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.=OpenOffice/LibreOfficeが導入済みであることを自動検出できませんでした．導入先ディレクトリを手動で選択してください．
-JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>=JabRefは「ps」「pdf」フィールドのサポートを停止しました．<br>現在，ファイルリンクは「file」フィールドに保管され，ファイルは外部のファイルディレクトリに保管されます．<br>この機能を利用するには，JabRefにファイルリンクを更新させる必要があります．<br><br>
-This_library_uses_outdated_file_links.=このデータベースは旧式のファイルリンクを使用しています．
+Unable\ to\ autodetect\ OpenOffice/LibreOffice\ installation.\ Please\ choose\ the\ installation\ directory\ manually.=OpenOffice/LibreOfficeが導入済みであることを自動検出できませんでした．導入先ディレクトリを手動で選択してください．
+JabRef\ no\ longer\ supports\ 'ps'\ or\ 'pdf'\ fields.<br>File\ links\ are\ now\ stored\ in\ the\ 'file'\ field\ and\ files\ are\ stored\ in\ an\ external\ file\ directory.<br>To\ make\ use\ of\ this\ feature,\ JabRef\ needs\ to\ upgrade\ file\ links.<br><br>=JabRefは「ps」「pdf」フィールドのサポートを停止しました．<br>現在，ファイルリンクは「file」フィールドに保管され，ファイルは外部のファイルディレクトリに保管されます．<br>この機能を利用するには，JabRefにファイルリンクを更新させる必要があります．<br><br>
+This\ library\ uses\ outdated\ file\ links.=このデータベースは旧式のファイルリンクを使用しています．
 
-Clear_search=検索を消去
-Close_library=データベースを閉じる
-Close_entry_editor=項目エディタを閉じる
-Decrease_table_font_size=表フォント寸法を減少
-Entry_editor,_next_entry=項目エディタ・次項目
-Entry_editor,_next_panel=項目エディタ・次パネル
-Entry_editor,_next_panel_2=項目エディタ・次パネル_2
-Entry_editor,_previous_entry=項目エディタ・前項目
-Entry_editor,_previous_panel=項目エディタ・前パネル
-Entry_editor,_previous_panel_2=項目エディタ・前パネル_2
-File_list_editor,_move_entry_down=ファイル一覧エディタ・項目を下に移動
-File_list_editor,_move_entry_up=ファイル一覧エディタ・項目を上に移動
-Focus_entry_table=項目表にフォーカス
-Import_into_current_library=現データベースに読み込む
-Import_into_new_library=新規データベースに読み込む
-Increase_table_font_size=表フォント寸法を増大
-New_article=新規article
-New_book=新規book
-New_entry=新規項目
-New_from_plain_text=平文から新規
-New_inbook=新規inbook
-New_mastersthesis=新規masterthesis
-New_phdthesis=新規phdthesis
-New_proceedings=新規proceedings
-New_unpublished=新規unpublished
-Next_tab=次タブ
-Preamble_editor,_store_changes=プリアンブルエディタ・変更を保存
-Previous_tab=前タブ
-Push_to_application=アプリケーションにプッシュ
-Refresh_OpenOffice/LibreOffice=OpenOffice/LibreOfficeを更新
-Resolve_duplicate_BibTeX_keys=重複BibTeX鍵を解消
-Save_all=全て保存
-String_dialog,_add_string=文字列ダイアログ・文字列を追加
-String_dialog,_remove_string=文字列ダイアログ・文字列を削除
-Synchronize_files=ファイルを同期
+Clear\ search=検索を消去
+Close\ library=データベースを閉じる
+Close\ entry\ editor=項目エディタを閉じる
+Decrease\ table\ font\ size=表フォント寸法を減少
+Entry\ editor,\ next\ entry=項目エディタ・次項目
+Entry\ editor,\ next\ panel=項目エディタ・次パネル
+Entry\ editor,\ next\ panel\ 2=項目エディタ・次パネル 2
+Entry\ editor,\ previous\ entry=項目エディタ・前項目
+Entry\ editor,\ previous\ panel=項目エディタ・前パネル
+Entry\ editor,\ previous\ panel\ 2=項目エディタ・前パネル 2
+File\ list\ editor,\ move\ entry\ down=ファイル一覧エディタ・項目を下に移動
+File\ list\ editor,\ move\ entry\ up=ファイル一覧エディタ・項目を上に移動
+Focus\ entry\ table=項目表にフォーカス
+Import\ into\ current\ library=現データベースに読み込む
+Import\ into\ new\ library=新規データベースに読み込む
+Increase\ table\ font\ size=表フォント寸法を増大
+New\ article=新規article
+New\ book=新規book
+New\ entry=新規項目
+New\ from\ plain\ text=平文から新規
+New\ inbook=新規inbook
+New\ mastersthesis=新規masterthesis
+New\ phdthesis=新規phdthesis
+New\ proceedings=新規proceedings
+New\ unpublished=新規unpublished
+Next\ tab=次タブ
+Preamble\ editor,\ store\ changes=プリアンブルエディタ・変更を保存
+Previous\ tab=前タブ
+Push\ to\ application=アプリケーションにプッシュ
+Refresh\ OpenOffice/LibreOffice=OpenOffice/LibreOfficeを更新
+Resolve\ duplicate\ BibTeX\ keys=重複BibTeX鍵を解消
+Save\ all=全て保存
+String\ dialog,\ add\ string=文字列ダイアログ・文字列を追加
+String\ dialog,\ remove\ string=文字列ダイアログ・文字列を削除
+Synchronize\ files=ファイルを同期
 Unabbreviate=非短縮形化
-should_contain_a_protocol=プロトコルを含む必要あり
-Copy_preview=プレビューをコピー
-Automatically_setting_file_links=ファイルリンクを自動的に設定
-Regenerating_BibTeX_keys_according_to_metadata=メタデータにしたがってBibTeX鍵を再生成
-No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys=bibファイルにメタデータがありません．BibTeX鍵を再生成することができません
-Regenerate_all_keys_for_the_entries_in_a_BibTeX_file=BibTeXファイル中全項目の鍵を再生成
-Show_debug_level_messages=デバッグレベルメッセージを表示
-Default_bibliography_mode=既定の書誌情報モード
-New_%0_library_created.=新規に%0個のデータベースが生成されました．
-Show_only_preferences_deviating_from_their_default_value=既定値と異なる設定のみ表示
+should\ contain\ a\ protocol=プロトコルを含む必要あり
+Copy\ preview=プレビューをコピー
+Automatically\ setting\ file\ links=ファイルリンクを自動的に設定
+Regenerating\ BibTeX\ keys\ according\ to\ metadata=メタデータにしたがってBibTeX鍵を再生成
+No\ meta\ data\ present\ in\ BIB\ file.\ Cannot\ regenerate\ BibTeX\ keys=bibファイルにメタデータがありません．BibTeX鍵を再生成することができません
+Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=BibTeXファイル中全項目の鍵を再生成
+Show\ debug\ level\ messages=デバッグレベルメッセージを表示
+Default\ bibliography\ mode=既定の書誌情報モード
+New\ %0\ library\ created.=新規に%0個のデータベースが生成されました．
+Show\ only\ preferences\ deviating\ from\ their\ default\ value=既定値と異なる設定のみ表示
 default=既定値
 key=鍵
 type=型
 value=値
-Show_preferences=設定を表示
-Save_actions=保存時動作
-Enable_save_actions=保存時動作を有効化
+Show\ preferences=設定を表示
+Save\ actions=保存時動作
+Enable\ save\ actions=保存時動作を有効化
 
-Other_fields=他のフィールド
-Show_remaining_fields=その他のフィールドを表示
+Other\ fields=他のフィールド
+Show\ remaining\ fields=その他のフィールドを表示
 
-link_should_refer_to_a_correct_file_path=リンクは正しいファイルパスを参照しなくてはなりません
-abbreviation_detected=短縮形を検出しました
-wrong_entry_type_as_proceedings_has_page_numbers=項目型の誤り：proceedingsにページ番号があります
-Abbreviate_journal_names=学術誌名を短縮形化
+link\ should\ refer\ to\ a\ correct\ file\ path=リンクは正しいファイルパスを参照しなくてはなりません
+abbreviation\ detected=短縮形を検出しました
+wrong\ entry\ type\ as\ proceedings\ has\ page\ numbers=項目型の誤り：proceedingsにページ番号があります
+Abbreviate\ journal\ names=学術誌名を短縮形化
 Abbreviating...=短縮形化中
-Abbreviation_%s_for_journal_%s_already_defined.=短縮形%sは，学術誌%s用にすでに定義されています．
-Abbreviation_cannot_be_empty=短縮形は空にはできません
-Duplicated_Journal_Abbreviation=学術誌名短縮形が重複しています
-Duplicated_Journal_File=学術誌ファイルが重複しています
-Error_Occurred=エラーが発生しました
-Journal_file_%s_already_added=がくじゅつしふぁいる%sは追加済みです
-Name_cannot_be_empty=名称は空にはできません
+Abbreviation\ %s\ for\ journal\ %s\ already\ defined.=短縮形%sは，学術誌%s用にすでに定義されています．
+Abbreviation\ cannot\ be\ empty=短縮形は空にはできません
+Duplicated\ Journal\ Abbreviation=学術誌名短縮形が重複しています
+Duplicated\ Journal\ File=学術誌ファイルが重複しています
+Error\ Occurred=エラーが発生しました
+Journal\ file\ %s\ already\ added=がくじゅつしふぁいる%sは追加済みです
+Name\ cannot\ be\ empty=名称は空にはできません
 
-Adding_fetched_entries=取得した項目を追加しています
-Display_keywords_appearing_in_ALL_entries=全ての項目に現れるキーワードを表示
-Display_keywords_appearing_in_ANY_entry=いずれかの項目に現れるキーワードを表示
-Fetching_entries_from_Inspire=Inspireから項目を取得
-None_of_the_selected_entries_have_titles.=選択した項目のいずれにもタイトルがありません．
-None_of_the_selected_entries_have_BibTeX_keys.=選択した項目のいずれにもBibTeX鍵がありません．
-Unabbreviate_journal_names=学術誌名を非短縮形化
+Adding\ fetched\ entries=取得した項目を追加しています
+Display\ keywords\ appearing\ in\ ALL\ entries=全ての項目に現れるキーワードを表示
+Display\ keywords\ appearing\ in\ ANY\ entry=いずれかの項目に現れるキーワードを表示
+Fetching\ entries\ from\ Inspire=Inspireから項目を取得
+None\ of\ the\ selected\ entries\ have\ titles.=選択した項目のいずれにもタイトルがありません．
+None\ of\ the\ selected\ entries\ have\ BibTeX\ keys.=選択した項目のいずれにもBibTeX鍵がありません．
+Unabbreviate\ journal\ names=学術誌名を非短縮形化
 Unabbreviating...=非短縮形化中...
 Usage=使用法
 
 
-Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.=大小文字が維持されるように，略語や月名，国名の前後に_{}_括弧を付します．
-Are_you_sure_you_want_to_reset_all_settings_to_default_values?=本当に全ての設定を既定値に戻しますか？
-Reset_preferences=設定をリセット
-Ill-formed_entrytype_comment_in_BIB_file=bibファイル中に誤った書式の項目型コメントがあります
+Adds\ {}\ brackets\ around\ acronyms,\ month\ names\ and\ countries\ to\ preserve\ their\ case.=大小文字が維持されるように，略語や月名，国名の前後に {} 括弧を付します．
+Are\ you\ sure\ you\ want\ to\ reset\ all\ settings\ to\ default\ values?=本当に全ての設定を既定値に戻しますか？
+Reset\ preferences=設定をリセット
+Ill-formed\ entrytype\ comment\ in\ BIB\ file=bibファイル中に誤った書式の項目型コメントがあります
 
-Move_linked_files_to_default_file_directory_%0=リンクを張られたファイルを既定ファイルディレクトリ%0に移動
+Move\ linked\ files\ to\ default\ file\ directory\ %0=リンクを張られたファイルを既定ファイルディレクトリ%0に移動
 
 Clipboard=クリップボード
-Could_not_paste_entry_as_text\:=項目をテキストとして貼り付けることができませんでした：
-Do_you_still_want_to_continue?=それでも続けますか？
-This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:=この動作は，次の各フィールドをそれぞれ少なくとも1項目以上書き換えます：
-This_could_cause_undesired_changes_to_your_entries.=これはあなたの項目に望ましくない変更を加えるおそれがあります．
-Run_field_formatter\:=フィールド整形を実行：
-Table_font_size_is_%0=表フォント寸法は%0です
-%0_import_canceled=%0からの読み込みを取り消しました
-Internal_style=内部スタイル
-Add_style_file=スタイルファイルを追加
-Are_you_sure_you_want_to_remove_the_style?=本当にこのスタイルを削除しますか？
-Current_style_is_'%0'=現在のスタイルは「%0」です
-Remove_style=スタイルを削除
-Select_one_of_the_available_styles_or_add_a_style_file_from_disk.=利用できるスタイルの一つを選択するか，ディスクからスタイルファイルを追加してください．
-You_must_select_a_valid_style_file.=有効なスタイルファイルを選択しなくてはなりません．
+Could\ not\ paste\ entry\ as\ text\:=項目をテキストとして貼り付けることができませんでした：
+Do\ you\ still\ want\ to\ continue?=それでも続けますか？
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=この動作は，次の各フィールドをそれぞれ少なくとも1項目以上書き換えます：
+This\ could\ cause\ undesired\ changes\ to\ your\ entries.=これはあなたの項目に望ましくない変更を加えるおそれがあります．
+Run\ field\ formatter\:=フィールド整形を実行：
+Table\ font\ size\ is\ %0=表フォント寸法は%0です
+%0\ import\ canceled=%0からの読み込みを取り消しました
+Internal\ style=内部スタイル
+Add\ style\ file=スタイルファイルを追加
+Are\ you\ sure\ you\ want\ to\ remove\ the\ style?=本当にこのスタイルを削除しますか？
+Current\ style\ is\ '%0'=現在のスタイルは「%0」です
+Remove\ style=スタイルを削除
+Select\ one\ of\ the\ available\ styles\ or\ add\ a\ style\ file\ from\ disk.=利用できるスタイルの一つを選択するか，ディスクからスタイルファイルを追加してください．
+You\ must\ select\ a\ valid\ style\ file.=有効なスタイルファイルを選択しなくてはなりません．
 Reload=再読み込み
 
 Capitalize=語頭大文字
-Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.=全単語の語頭を大文字化しますが，冠詞・前置詞・接続詞は小文字に変換します．
-Capitalize_the_first_word,_changes_other_words_to_lower_case.=最初の単語の語頭を大文字化しますが，他の単語は小文字に変換します．
-Changes_all_letters_to_lower_case.=全文字を小文字に変換します．
-Changes_all_letters_to_upper_case.=全文字を大文字に変換します．
-Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.=全単語の最初の文字を大文字に変換し，他の文字を小文字に変換します．
-Cleans_up_LaTeX_code.=LaTeXコードを剪定します．
-Converts_HTML_code_to_LaTeX_code.=HTMLコードをLaTeXコードに変換します．
-Converts_HTML_code_to_Unicode.=HTMLコードをUnicodeに変換します．
-Converts_LaTeX_encoding_to_Unicode_characters.=LaTeXエンコーディングをUnicode文字に変換します．
-Converts_Unicode_characters_to_LaTeX_encoding.=Unicode文字をLaTeXエンコーディングに変換します．
-Converts_ordinals_to_LaTeX_superscripts.=序数をLaTeX上付き文字に変換します．
-Converts_units_to_LaTeX_formatting.=単位をLaTeX形式に変換します．
-HTML_to_LaTeX=HTMLからLaTeXへ
-LaTeX_cleanup=LaTeXの剪定
-LaTeX_to_Unicode=LaTeXからUnicodeへ
-Lower_case=小文字
-Minify_list_of_person_names=人名一覧の圧縮
-Normalize_date=日付を標準化
-Normalize_month=月を標準化
-Normalize_month_to_BibTeX_standard_abbreviation.=月をBibTeX標準の短縮形に標準化します．
-Normalize_names_of_persons=人名を標準化
-Normalize_page_numbers=ページ番号を標準化
-Normalize_pages_to_BibTeX_standard.=ページをBibTeX標準に標準化します．
-Normalizes_lists_of_persons_to_the_BibTeX_standard.=人名一覧をBibTeX標準に標準化します．
-Normalizes_the_date_to_ISO_date_format.=日付をISO日付書式に標準化します．
-Ordinals_to_LaTeX_superscript=序数をLaTeX上付き文字に
-Protect_terms=用語を保護
-Remove_enclosing_braces=包含括弧を除去
-Removes_braces_encapsulating_the_complete_field_content.=フィールド内容全体を包含する括弧を除去します．
-Sentence_case=文の大小文字パターン
-Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".=3名以上の人名リストは「et_al.」に短縮します．
-Title_case=タイトルの大小文字パターン
-Unicode_to_LaTeX=UnicodeからLaTeXへ
-Units_to_LaTeX=単位からLaTeXへ
-Upper_case=大文字
-Does_nothing.=何もしません．
+Capitalize\ all\ words,\ but\ converts\ articles,\ prepositions,\ and\ conjunctions\ to\ lower\ case.=全単語の語頭を大文字化しますが，冠詞・前置詞・接続詞は小文字に変換します．
+Capitalize\ the\ first\ word,\ changes\ other\ words\ to\ lower\ case.=最初の単語の語頭を大文字化しますが，他の単語は小文字に変換します．
+Changes\ all\ letters\ to\ lower\ case.=全文字を小文字に変換します．
+Changes\ all\ letters\ to\ upper\ case.=全文字を大文字に変換します．
+Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=全単語の最初の文字を大文字に変換し，他の文字を小文字に変換します．
+Cleans\ up\ LaTeX\ code.=LaTeXコードを剪定します．
+Converts\ HTML\ code\ to\ LaTeX\ code.=HTMLコードをLaTeXコードに変換します．
+Converts\ HTML\ code\ to\ Unicode.=HTMLコードをUnicodeに変換します．
+Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=LaTeXエンコーディングをUnicode文字に変換します．
+Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=Unicode文字をLaTeXエンコーディングに変換します．
+Converts\ ordinals\ to\ LaTeX\ superscripts.=序数をLaTeX上付き文字に変換します．
+Converts\ units\ to\ LaTeX\ formatting.=単位をLaTeX形式に変換します．
+HTML\ to\ LaTeX=HTMLからLaTeXへ
+LaTeX\ cleanup=LaTeXの剪定
+LaTeX\ to\ Unicode=LaTeXからUnicodeへ
+Lower\ case=小文字
+Minify\ list\ of\ person\ names=人名一覧の圧縮
+Normalize\ date=日付を標準化
+Normalize\ month=月を標準化
+Normalize\ month\ to\ BibTeX\ standard\ abbreviation.=月をBibTeX標準の短縮形に標準化します．
+Normalize\ names\ of\ persons=人名を標準化
+Normalize\ page\ numbers=ページ番号を標準化
+Normalize\ pages\ to\ BibTeX\ standard.=ページをBibTeX標準に標準化します．
+Normalizes\ lists\ of\ persons\ to\ the\ BibTeX\ standard.=人名一覧をBibTeX標準に標準化します．
+Normalizes\ the\ date\ to\ ISO\ date\ format.=日付をISO日付書式に標準化します．
+Ordinals\ to\ LaTeX\ superscript=序数をLaTeX上付き文字に
+Protect\ terms=用語を保護
+Remove\ enclosing\ braces=包含括弧を除去
+Removes\ braces\ encapsulating\ the\ complete\ field\ content.=フィールド内容全体を包含する括弧を除去します．
+Sentence\ case=文の大小文字パターン
+Shortens\ lists\ of\ persons\ if\ there\ are\ more\ than\ 2\ persons\ to\ "et\ al.".=3名以上の人名リストは「et al.」に短縮します．
+Title\ case=タイトルの大小文字パターン
+Unicode\ to\ LaTeX=UnicodeからLaTeXへ
+Units\ to\ LaTeX=単位からLaTeXへ
+Upper\ case=大文字
+Does\ nothing.=何もしません．
 Identity=同一
-Clears_the_field_completely.=フィールドを完全に消去します．
-Directory_not_found=ディレクトリが検出されませんでした
-Main_file_directory_not_set\!=主幹ファイルディレクトリが設定されていません！
-This_operation_requires_exactly_one_item_to_be_selected.=この操作では，1項目のみ選択されている必要があります．
-Importing_in_%0_format=%0形式で読み込み
-Female_name=女性名
-Female_names=女性名
-Male_name=男性名
-Male_names=男性名
-Mixed_names=男女名
-Neuter_name=中性名
-Neuter_names=中性名
+Clears\ the\ field\ completely.=フィールドを完全に消去します．
+Directory\ not\ found=ディレクトリが検出されませんでした
+Main\ file\ directory\ not\ set\!=主幹ファイルディレクトリが設定されていません！
+This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=この操作では，1項目のみ選択されている必要があります．
+Importing\ in\ %0\ format=%0形式で読み込み
+Female\ name=女性名
+Female\ names=女性名
+Male\ name=男性名
+Male\ names=男性名
+Mixed\ names=男女名
+Neuter\ name=中性名
+Neuter\ names=中性名
 
-Determined_%0_for_%1_entries=%1項目のうち%0項目を確定
-Look_up_%0=%0を検索
-Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3=%0を検索中...−全%2項目中第%1項目−%3項目検出済み
+Determined\ %0\ for\ %1\ entries=%1項目のうち%0項目を確定
+Look\ up\ %0=%0を検索
+Looking\ up\ %0...\ -\ entry\ %1\ out\ of\ %2\ -\ found\ %3=%0を検索中...−全%2項目中第%1項目−%3項目検出済み
 
-Audio_CD=オーディオCD
-British_patent=イギリス特許
-British_patent_request=イギリス特許申請
-Candidate_thesis=博士申請論文
+Audio\ CD=オーディオCD
+British\ patent=イギリス特許
+British\ patent\ request=イギリス特許申請
+Candidate\ thesis=博士申請論文
 Collaborator=共著者
 Column=列
 Compiler=コンパイラ
 Continuator=継承者
-Data_CD=データCD
+Data\ CD=データCD
 Editor=編集者
-European_patent=欧州特許
-European_patent_request=欧州特許申請
+European\ patent=欧州特許
+European\ patent\ request=欧州特許申請
 Founder=設立者
-French_patent=フランス特許
-French_patent_request=フランス特許申請
-German_patent=ドイツ特許
-German_patent_request=ドイツ特許申請
+French\ patent=フランス特許
+French\ patent\ request=フランス特許申請
+German\ patent=ドイツ特許
+German\ patent\ request=ドイツ特許申請
 Line=行
-Master's_thesis=修士論文
+Master's\ thesis=修士論文
 Page=ページ
 Paragraph=段落
 Patent=特許
-Patent_request=特許申請
-PhD_thesis=博士論文
+Patent\ request=特許申請
+PhD\ thesis=博士論文
 Redactor=校閲者
-Research_report=研究レポート
+Research\ report=研究レポート
 Reviser=改訂者
 Section=節
 Software=ソフトウェア
-Technical_report=技術レポート
-U.S._patent=米国特許
-U.S._patent_request=米国特許申請
+Technical\ report=技術レポート
+U.S.\ patent=米国特許
+U.S.\ patent\ request=米国特許申請
 Verse=詩句
 
-change_entries_of_group=グループ項目を変更
-odd_number_of_unescaped_'\#'=エスケープしていない「\#」の奇数
+change\ entries\ of\ group=グループ項目を変更
+odd\ number\ of\ unescaped\ '\#'=エスケープしていない「#」の奇数
 
-Plain_text=平文
-Show_diff=差異を表示
+Plain\ text=平文
+Show\ diff=差異を表示
 character=文字
 word=単語
-Show_symmetric_diff=差異を対照表示
-Copy_Version=バージョンをコピー
+Show\ symmetric\ diff=差異を対照表示
+Copy\ Version=バージョンをコピー
 Developers=開発者
 Authors=著作者
 License=著作権
 
-HTML_encoded_character_found=HTMLエンコードされた文字が見つかりました
-booktitle_ends_with_'conference_on'=「conference_on」で終わるbooktitle
+HTML\ encoded\ character\ found=HTMLエンコードされた文字が見つかりました
+booktitle\ ends\ with\ 'conference\ on'=「conference on」で終わるbooktitle
 
-All_external_files=全外部ファイル
+All\ external\ files=全外部ファイル
 
-OpenOffice/LibreOffice_integration=OpenOffice/LibreOfficeの統合
+OpenOffice/LibreOffice\ integration=OpenOffice/LibreOfficeの統合
 
-incorrect_control_digit=誤った制御数字
-incorrect_format=誤った書式
-Copied_version_to_clipboard=クリップボードにコピーされたバージョン
+incorrect\ control\ digit=誤った制御数字
+incorrect\ format=誤った書式
+Copied\ version\ to\ clipboard=クリップボードにコピーされたバージョン
 
-BibTeX_key=BibTeX鍵
+BibTeX\ key=BibTeX鍵
 Message=メッセージ
 
 
-MathSciNet_Review=MathSciNet_Review
-Reset_Bindings=割当をリセット
+MathSciNet\ Review=MathSciNet Review
+Reset\ Bindings=割当をリセット
 
-Decryption_not_supported.=サポートされていない復号化です．
+Decryption\ not\ supported.=サポートされていない復号化です．
 
-Cleared_'%0'_for_%1_entries=%1項目から「%0」を消去しました
-Set_'%0'_to_'%1'_for_%2_entries=%2項目の「%0」を「%1」に設定しました
-Toggled_'%0'_for_%1_entries=%1項目の「%0」を切り替えました
+Cleared\ '%0'\ for\ %1\ entries=%1項目から「%0」を消去しました
+Set\ '%0'\ to\ '%1'\ for\ %2\ entries=%2項目の「%0」を「%1」に設定しました
+Toggled\ '%0'\ for\ %1\ entries=%1項目の「%0」を切り替えました
 
-Check_for_updates=更新があるかを確認
-Download_update=更新分をダウンロード
-New_version_available=新しい版があります
-Installed_version=インストールされた版
-Remind_me_later=後で通知
-Ignore_this_update=この更新は無視する
-Could_not_connect_to_the_update_server.=更新サーバーに接続できませんでした．
-Please_try_again_later_and/or_check_your_network_connection.=ネットワーク接続を確認した上で，後で再度試みてください．
-To_see_what_is_new_view_the_changelog.=変更履歴を開いて新機能を見る
-A_new_version_of_JabRef_has_been_released.=JabRefの新版がリリースされました．
-JabRef_is_up-to-date.=JabRefは最新です．
-Latest_version=最新版
-Online_help_forum=オンラインヘルプ_フォーラム
+Check\ for\ updates=更新があるかを確認
+Download\ update=更新分をダウンロード
+New\ version\ available=新しい版があります
+Installed\ version=インストールされた版
+Remind\ me\ later=後で通知
+Ignore\ this\ update=この更新は無視する
+Could\ not\ connect\ to\ the\ update\ server.=更新サーバーに接続できませんでした．
+Please\ try\ again\ later\ and/or\ check\ your\ network\ connection.=ネットワーク接続を確認した上で，後で再度試みてください．
+To\ see\ what\ is\ new\ view\ the\ changelog.=変更履歴を開いて新機能を見る
+A\ new\ version\ of\ JabRef\ has\ been\ released.=JabRefの新版がリリースされました．
+JabRef\ is\ up-to-date.=JabRefは最新です．
+Latest\ version=最新版
+Online\ help\ forum=オンラインヘルプ フォーラム
 Custom=カスタム
 
-Export_cited=引用を書き出す
-Unable_to_generate_new_library=新しいデータベースを生成することができませんでした
+Export\ cited=引用を書き出す
+Unable\ to\ generate\ new\ library=新しいデータベースを生成することができませんでした
 
-Open_console=コンソールを開く
-Use_default_terminal_emulator=既定の擬似端末を使用する
-Execute_command=コマンドを実行
-Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.=【註】開かれたデータベースの場所のプレイスホルダーに%0を使用します．
-Executing_command_\"%0\"...=コマンド「%0」を実行…
-Error_occured_while_executing_the_command_\"%0\".=コマンド「%0」を実行中にエラーが発生しました
-Reformat_ISSN=ISSNを再構成
+Open\ console=コンソールを開く
+Use\ default\ terminal\ emulator=既定の擬似端末を使用する
+Execute\ command=コマンドを実行
+Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=【註】開かれたデータベースの場所のプレイスホルダーに%0を使用します．
+Executing\ command\ \"%0\"...=コマンド「%0」を実行…
+Error\ occured\ while\ executing\ the\ command\ \"%0\".=コマンド「%0」を実行中にエラーが発生しました
+Reformat\ ISSN=ISSNを再構成
 
-Countries_and_territories_in_English=英語での国名・地域名
-Electrical_engineering_terms=電気工学用語
+Countries\ and\ territories\ in\ English=英語での国名・地域名
+Electrical\ engineering\ terms=電気工学用語
 Enabled=有効
-Internal_list=内部リスト
-Manage_protected_terms_files=予約語ファイルを管理する
-Months_and_weekdays_in_English=英語での月名と曜日名
-The_text_after_the_last_line_starting_with_\#_will_be_used=\#で始まる最後の行の後の文字列が使用されます
-Add_protected_terms_file=予約語ファイルを追加する
-Are_you_sure_you_want_to_remove_the_protected_terms_file?=本当に予約語ファイルを削除して良いですか？
-Remove_protected_terms_file=予約語ファイルを削除する
-Add_selected_text_to_list=選択した平文をリストに追加する
-Add_{}_around_selected_text=選択した平文の前後に{}を付加する
-Format_field=フィールドを整形する
-New_protected_terms_file=新規予約語ファイル
-change_field_%0_of_entry_%1_from_%2_to_%3=%2から%3までの項目%1のフィールド%0を変更する
-change_key_from_%0_to_%1=%0から%1までの鍵を変更する
-change_string_content_%0_to_%1=文字列の内容%0を%1に変更する
-change_string_name_%0_to_%1=文字列名%0を%1に変更する
-change_type_of_entry_%0_from_%1_to_%2=項目%0の型を%1から%2に変更する
-insert_entry_%0=項目%0を挿入する
-insert_string_%0=文字列%0を挿入する
-remove_entry_%0=項目%0を削除する
-remove_string_%0=文字列%0を削除する
+Internal\ list=内部リスト
+Manage\ protected\ terms\ files=予約語ファイルを管理する
+Months\ and\ weekdays\ in\ English=英語での月名と曜日名
+The\ text\ after\ the\ last\ line\ starting\ with\ \#\ will\ be\ used=#で始まる最後の行の後の文字列が使用されます
+Add\ protected\ terms\ file=予約語ファイルを追加する
+Are\ you\ sure\ you\ want\ to\ remove\ the\ protected\ terms\ file?=本当に予約語ファイルを削除して良いですか？
+Remove\ protected\ terms\ file=予約語ファイルを削除する
+Add\ selected\ text\ to\ list=選択した平文をリストに追加する
+Add\ {}\ around\ selected\ text=選択した平文の前後に{}を付加する
+Format\ field=フィールドを整形する
+New\ protected\ terms\ file=新規予約語ファイル
+change\ field\ %0\ of\ entry\ %1\ from\ %2\ to\ %3=%2から%3までの項目%1のフィールド%0を変更する
+change\ key\ from\ %0\ to\ %1=%0から%1までの鍵を変更する
+change\ string\ content\ %0\ to\ %1=文字列の内容%0を%1に変更する
+change\ string\ name\ %0\ to\ %1=文字列名%0を%1に変更する
+change\ type\ of\ entry\ %0\ from\ %1\ to\ %2=項目%0の型を%1から%2に変更する
+insert\ entry\ %0=項目%0を挿入する
+insert\ string\ %0=文字列%0を挿入する
+remove\ entry\ %0=項目%0を削除する
+remove\ string\ %0=文字列%0を削除する
 undefined=未定義
-Cannot_get_info_based_on_given_%0\:_%1=提供された%0で情報を得ることができません：%1
-Get_BibTeX_data_from_%0=%0からBibTeXデータを取得
-No_%0_found=%0が見つかりませんでした
-Entry_from_%0=%0からの項目
-Merge_entry_with_%0_information=項目を%0情報と統合
-Updated_entry_with_info_from_%0=%0からの情報で項目を更新しました
+Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=提供された%0で情報を得ることができません：%1
+Get\ BibTeX\ data\ from\ %0=%0からBibTeXデータを取得
+No\ %0\ found=%0が見つかりませんでした
+Entry\ from\ %0=%0からの項目
+Merge\ entry\ with\ %0\ information=項目を%0情報と統合
+Updated\ entry\ with\ info\ from\ %0=%0からの情報で項目を更新しました
 
-Add_existing_file=既存ファイルを追加
-Create_new_list=新規リストを生成
-Remove_list=リストを削除
-Full_journal_name=正式誌名
-Abbreviation_name=短縮誌名
+Add\ existing\ file=既存ファイルを追加
+Create\ new\ list=新規リストを生成
+Remove\ list=リストを削除
+Full\ journal\ name=正式誌名
+Abbreviation\ name=短縮誌名
 
-No_abbreviation_files_loaded=短縮名ファイルが読み込まれていません
+No\ abbreviation\ files\ loaded=短縮名ファイルが読み込まれていません
 
-Loading_built_in_lists=組込リストを読み込んでいます
+Loading\ built\ in\ lists=組込リストを読み込んでいます
 
-JabRef_built_in_list=JabRef組込リスト
-IEEE_built_in_list=IEEE組込リスト
+JabRef\ built\ in\ list=JabRef組込リスト
+IEEE\ built\ in\ list=IEEE組込リスト
 
-Event_log=イベントログ
-We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.=これからJabRef内部の内部動作についての情報を提供します．この情報は，問題の根本原因を診断するために役立つことがあります．お気軽に問題を開発者に相談してください．
-Log_copied_to_clipboard.=ログがクリップボードにコピーされました．
-Copy_Log=ログをコピー
-Clear_Log=ログを消去
-Report_Issue=問題を報告
-Issue_on_GitHub_successfully_reported.=問題がGitHubに正しく報告されました．
-Issue_report_successful=成功裏に問題が報告されました
-Your_issue_was_reported_in_your_browser.=あなたの問題はブラウザ中に報告されました．
-The_log_and_exception_information_was_copied_to_your_clipboard.=ログと例外情報がクリップボードにコピーされました．
-Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.=この情報を問題の記述部に（Ctrl+Vを使って）貼り付けてください．
+Event\ log=イベントログ
+We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef\'s\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=これからJabRef内部の内部動作についての情報を提供します．この情報は，問題の根本原因を診断するために役立つことがあります．お気軽に問題を開発者に相談してください．
+Log\ copied\ to\ clipboard.=ログがクリップボードにコピーされました．
+Copy\ Log=ログをコピー
+Clear\ Log=ログを消去
+Report\ Issue=問題を報告
+Issue\ on\ GitHub\ successfully\ reported.=問題がGitHubに正しく報告されました．
+Issue\ report\ successful=成功裏に問題が報告されました
+Your\ issue\ was\ reported\ in\ your\ browser.=あなたの問題はブラウザ中に報告されました．
+The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=ログと例外情報がクリップボードにコピーされました．
+Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=この情報を問題の記述部に（Ctrl+Vを使って）貼り付けてください．
 
 Connection=接続
 Connecting...=接続中...
@@ -2164,194 +2164,194 @@ Port=ポート
 Library=データベース
 User=ユーザー
 Connect=接続
-Connection_error=接続エラー
-Connection_to_%0_server_established.=%0サーバーへの接続が確立されました．
-Required_field_"%0"_is_empty.=必須フィールド「%0」が空です．
-%0_driver_not_available.=%0ドライバが利用できません．
-The_connection_to_the_server_has_been_terminated.=サーバーへの接続が絶たれました．
-Connection_lost.=接続を喪失しました．
+Connection\ error=接続エラー
+Connection\ to\ %0\ server\ established.=%0サーバーへの接続が確立されました．
+Required\ field\ "%0"\ is\ empty.=必須フィールド「%0」が空です．
+%0\ driver\ not\ available.=%0ドライバが利用できません．
+The\ connection\ to\ the\ server\ has\ been\ terminated.=サーバーへの接続が絶たれました．
+Connection\ lost.=接続を喪失しました．
 Reconnect=再接続
-Work_offline=オフラインで作業
-Working_offline.=オフラインで作業しています．
-Update_refused.=更新が拒否されました．
-Update_refused=更新拒否
-Local_entry=ローカルの項目
-Shared_entry=共有項目
-Update_could_not_be_performed_due_to_existing_change_conflicts.=既存変更点の衝突により更新は実行できませんでした．
-You_are_not_working_on_the_newest_version_of_BibEntry.=現在，BibEntryの最新版で作業中ではありません．
-Local_version\:_%0=ローカルのバージョン：%0
-Shared_version\:_%0=共有のバージョン：%0
-Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.=この問題を解決するには，共有項目をローカル項目と統合して「項目を統合」ボタンを押してください．
-Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?=この操作を取り消してしまうと，変更点が同期されないまま残ってしまいます．それでも取り消しますか？
-Shared_entry_is_no_longer_present=共有項目がすでに存在しません
-The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.=現在作業しているBibEntryが共有側で削除されています．
-You_can_restore_the_entry_using_the_"Undo"_operation.=「取り消し」操作を行って項目を復活させることができます．
-Remember_password?=パスワードを記憶しますか？
-You_are_already_connected_to_a_database_using_entered_connection_details.=入力済みの接続詳細情報を使って，データベースにすでに接続されています．
+Work\ offline=オフラインで作業
+Working\ offline.=オフラインで作業しています．
+Update\ refused.=更新が拒否されました．
+Update\ refused=更新拒否
+Local\ entry=ローカルの項目
+Shared\ entry=共有項目
+Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=既存変更点の衝突により更新は実行できませんでした．
+You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=現在，BibEntryの最新版で作業中ではありません．
+Local\ version\:\ %0=ローカルのバージョン：%0
+Shared\ version\:\ %0=共有のバージョン：%0
+Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=この問題を解決するには，共有項目をローカル項目と統合して「項目を統合」ボタンを押してください．
+Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=この操作を取り消してしまうと，変更点が同期されないまま残ってしまいます．それでも取り消しますか？
+Shared\ entry\ is\ no\ longer\ present=共有項目がすでに存在しません
+The\ BibEntry\ you\ currently\ work\ on\ has\ been\ deleted\ on\ the\ shared\ side.=現在作業しているBibEntryが共有側で削除されています．
+You\ can\ restore\ the\ entry\ using\ the\ "Undo"\ operation.=「取り消し」操作を行って項目を復活させることができます．
+Remember\ password?=パスワードを記憶しますか？
+You\ are\ already\ connected\ to\ a\ database\ using\ entered\ connection\ details.=入力済みの接続詳細情報を使って，データベースにすでに接続されています．
 
-Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?=BibTeX鍵がないと，項目を引用することができません．ここで鍵を生成しますか？
-New_technical_report=新規technical_report
+Cannot\ cite\ entries\ without\ BibTeX\ keys.\ Generate\ keys\ now?=BibTeX鍵がないと，項目を引用することができません．ここで鍵を生成しますか？
+New\ technical\ report=新規technical report
 
-%0_file=%0ファイル
-Custom_layout_file=カスタムレイアウトファイル
-Protected_terms_file=予約語ファイル
-Style_file=スタイルファイル
+%0\ file=%0ファイル
+Custom\ layout\ file=カスタムレイアウトファイル
+Protected\ terms\ file=予約語ファイル
+Style\ file=スタイルファイル
 
-Open_OpenOffice/LibreOffice_connection=OpenOffice/LibreOffice接続を開く
-You_must_enter_at_least_one_field_name=少なくとも一つのフィールド名を入力する必要があります
-Non-ASCII_encoded_character_found=ASCIIエンコードでない文字が検出されました
-Toggle_web_search_interface=ウェブ検索インタフェースを入切
-Background_color_for_resolved_fields=解決したフィールドの背景色
-Color_code_for_resolved_fields=解決したフィールドの色コード
-%0_files_found=%0個のファイルが見つかりました
-%0_of_%1=%1のうちの%0
-One_file_found=1個のファイルが見つかりました
-The_import_finished_with_warnings\:=右記の警告とともに読み込みが終了しました：
-There_was_one_file_that_could_not_be_imported.=読み込みのできなかったファイルが一つありました．
-There_were_%0_files_which_could_not_be_imported.=読み込みのできなかったファイルが%0個ありました．
+Open\ OpenOffice/LibreOffice\ connection=OpenOffice/LibreOffice接続を開く
+You\ must\ enter\ at\ least\ one\ field\ name=少なくとも一つのフィールド名を入力する必要があります
+Non-ASCII\ encoded\ character\ found=ASCIIエンコードでない文字が検出されました
+Toggle\ web\ search\ interface=ウェブ検索インタフェースを入切
+Background\ color\ for\ resolved\ fields=解決したフィールドの背景色
+Color\ code\ for\ resolved\ fields=解決したフィールドの色コード
+%0\ files\ found=%0個のファイルが見つかりました
+%0\ of\ %1=%1のうちの%0
+One\ file\ found=1個のファイルが見つかりました
+The\ import\ finished\ with\ warnings\:=右記の警告とともに読み込みが終了しました：
+There\ was\ one\ file\ that\ could\ not\ be\ imported.=読み込みのできなかったファイルが一つありました．
+There\ were\ %0\ files\ which\ could\ not\ be\ imported.=読み込みのできなかったファイルが%0個ありました．
 
-Migration_help_information=移出入ヘルプ情報
-Entered_database_has_obsolete_structure_and_is_no_longer_supported.=入力されたデータベースは旧式の構造を持っていて，もうサポートされていません．
-However,_a_new_database_was_created_alongside_the_pre-3.6_one.=しかしながら，pre-3.6データベースに従って，新しいデータベースが生成されました．
-Click_here_to_learn_about_the_migration_of_pre-3.6_databases.=pre-3.6データベースの移出入について知るには，ここをクリックしてください．
-Opens_JabRef's_Facebook_page=JabRefのFacebookページを開きます
-Opens_JabRef's_blog=JabRefのブログを開きます
-Opens_JabRef's_website=JabRefのウェブサイトを開きます
-Opens_a_link_where_the_current_development_version_can_be_downloaded=現行開発版をダウンロードできる場所へのリンクを開きます
-See_what_has_been_changed_in_the_JabRef_versions=JabRefの各版における変更点を見ます
-Referenced_BibTeX_key_does_not_exist=参照されたBibTeX鍵は存在しません
-Finished_downloading_full_text_document_for_entry_%0.=項目%0の文書本体のダウンロードが終了しました．
-Full_text_document_download_failed_for_entry_%0.=項目%0の文書本体のダウンロードに失敗しました．
-Look_up_full_text_documents=文書本体を見る
-You_are_about_to_look_up_full_text_documents_for_%0_entries.=%0項目の文書本体を見ようとしています．
-last_four_nonpunctuation_characters_should_be_numerals=句読点を含まない最後の4文字は数字でなくてはなりません
+Migration\ help\ information=移出入ヘルプ情報
+Entered\ database\ has\ obsolete\ structure\ and\ is\ no\ longer\ supported.=入力されたデータベースは旧式の構造を持っていて，もうサポートされていません．
+However,\ a\ new\ database\ was\ created\ alongside\ the\ pre-3.6\ one.=しかしながら，pre-3.6データベースに従って，新しいデータベースが生成されました．
+Click\ here\ to\ learn\ about\ the\ migration\ of\ pre-3.6\ databases.=pre-3.6データベースの移出入について知るには，ここをクリックしてください．
+Opens\ JabRef's\ Facebook\ page=JabRefのFacebookページを開きます
+Opens\ JabRef's\ blog=JabRefのブログを開きます
+Opens\ JabRef's\ website=JabRefのウェブサイトを開きます
+Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=現行開発版をダウンロードできる場所へのリンクを開きます
+See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=JabRefの各版における変更点を見ます
+Referenced\ BibTeX\ key\ does\ not\ exist=参照されたBibTeX鍵は存在しません
+Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=項目%0の文書本体のダウンロードが終了しました．
+Full\ text\ document\ download\ failed\ for\ entry\ %0.=項目%0の文書本体のダウンロードに失敗しました．
+Look\ up\ full\ text\ documents=文書本体を見る
+You\ are\ about\ to\ look\ up\ full\ text\ documents\ for\ %0\ entries.=%0項目の文書本体を見ようとしています．
+last\ four\ nonpunctuation\ characters\ should\ be\ numerals=句読点を含まない最後の4文字は数字でなくてはなりません
 
 Author=著者
 Date=日付
-File_annotations=ファイル註釈
-Show_file_annotations=ファイル註釈を表示
-Adobe_Acrobat_Reader=Adobe_Acrobat_Reader
-Sumatra_Reader=Sumatra_Reader
+File\ annotations=ファイル註釈
+Show\ file\ annotations=ファイル註釈を表示
+Adobe\ Acrobat\ Reader=Adobe Acrobat Reader
+Sumatra\ Reader=Sumatra Reader
 shared=共有中
-should_contain_an_integer_or_a_literal=整数または文字を含んでいなくてはなりません
-should_have_the_first_letter_capitalized=最初の文字を大文字にしなくてはなりません
+should\ contain\ an\ integer\ or\ a\ literal=整数または文字を含んでいなくてはなりません
+should\ have\ the\ first\ letter\ capitalized=最初の文字を大文字にしなくてはなりません
 Tools=ツール
-What\'s_new_in_this_version?=このバージョンの新しいところは？
-Want_to_help?=手助けが必要ですか？
-Make_a_donation=寄付をするには
-get_involved=参加するには
-Used_libraries=使用ライブラリ
-Existing_file=既存ファイル
+What\'s\ new\ in\ this\ version?=このバージョンの新しいところは？
+Want\ to\ help?=手助けが必要ですか？
+Make\ a\ donation=寄付をするには
+get\ involved=参加するには
+Used\ libraries=使用ライブラリ
+Existing\ file=既存ファイル
 
 ID=ID
-ID_type=ID型
-ID-based_entry_generator=IDから項目を生成
-Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=取得子「%0」は，IDが「%1」の項目を見つけられませんでした．
+ID\ type=ID型
+ID-based\ entry\ generator=IDから項目を生成
+Fetcher\ '%0'\ did\ not\ find\ an\ entry\ for\ id\ '%1'.=取得子「%0」は，IDが「%1」の項目を見つけられませんでした．
 
-Select_first_entry=最初の項目を選択
-Select_last_entry=最後の項目を選択
+Select\ first\ entry=最初の項目を選択
+Select\ last\ entry=最後の項目を選択
 
-Invalid_ISBN\:_'%0'.=ISBN「%0」は無効です．
-should_be_an_integer_or_normalized=標準化されたものか整数でなくてはなりません
-should_be_normalized=標準化されたものでなくてはなりません
+Invalid\ ISBN\:\ '%0'.=ISBN「%0」は無効です．
+should\ be\ an\ integer\ or\ normalized=標準化されたものか整数でなくてはなりません
+should\ be\ normalized=標準化されたものでなくてはなりません
 
-Empty_search_ID=検索IDが空
-The_given_search_ID_was_empty.=提示された検索IDが空です．
-Copy_BibTeX_key_and_link=BibTeX鍵とリンクをコピー
-empty_BibTeX_key=空のBibTeX鍵
-biblatex_field_only=biblatexフィールドのみ
+Empty\ search\ ID=検索IDが空
+The\ given\ search\ ID\ was\ empty.=提示された検索IDが空です．
+Copy\ BibTeX\ key\ and\ link=BibTeX鍵とリンクをコピー
+empty\ BibTeX\ key=空のBibTeX鍵
+biblatex\ field\ only=biblatexフィールドのみ
 
-Error_while_generating_fetch_URL=取得URLを生成中にエラー発生
-Error_while_parsing_ID_list=ID一覧を解析中にエラー発生
-Unable_to_get_PubMed_IDs=PubMed_IDを取得することができませんでした
-Backup_found=バックアップを検出
-A_backup_file_for_'%0'_was_found.=「%0」のバックアップファイルを検出しました．
-This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.=これは，このファイルが最後に使用された際にJabRefが正常に終了しなかったことを意味している可能性があります．
-Do_you_want_to_recover_the_library_from_the_backup_file?=データベースをバックアップファイルから復活させますか？
-Firstname_Lastname=名_姓
+Error\ while\ generating\ fetch\ URL=取得URLを生成中にエラー発生
+Error\ while\ parsing\ ID\ list=ID一覧を解析中にエラー発生
+Unable\ to\ get\ PubMed\ IDs=PubMed IDを取得することができませんでした
+Backup\ found=バックアップを検出
+A\ backup\ file\ for\ '%0'\ was\ found.=「%0」のバックアップファイルを検出しました．
+This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=これは，このファイルが最後に使用された際にJabRefが正常に終了しなかったことを意味している可能性があります．
+Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=データベースをバックアップファイルから復活させますか？
+Firstname\ Lastname=名 姓
 
-Recommended_for_%0=%0に対する推奨
-Show_'Related_Articles'_tab=「関連文献」タブを表示
-This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=これはGoogle_Scholarのトラフィック上限に達したせいかもしれません（詳細は「ヘルプ」を参照）．
+Recommended\ for\ %0=%0に対する推奨
+Show\ 'Related\ Articles'\ tab=「関連文献」タブを表示
+This\ might\ be\ caused\ by\ reaching\ the\ traffic\ limitation\ of\ Google\ Scholar\ (see\ 'Help'\ for\ details).=これはGoogle Scholarのトラフィック上限に達したせいかもしれません（詳細は「ヘルプ」を参照）．
 
-Could_not_open_website.=ウェブサイトを開けませんでした．
-Problem_downloading_from_%1=%1からのダウンロードに問題発生
+Could\ not\ open\ website.=ウェブサイトを開けませんでした．
+Problem\ downloading\ from\ %1=%1からのダウンロードに問題発生
 
-File_directory_pattern=ファイルディレクトリのパターン
-Update_with_bibliographic_information_from_the_web=ウェブからの文献情報を使用して更新
+File\ directory\ pattern=ファイルディレクトリのパターン
+Update\ with\ bibliographic\ information\ from\ the\ web=ウェブからの文献情報を使用して更新
 
-Could_not_find_any_bibliographic_information.=文献情報を見つけることができませんでした．
-BibTeX_key_deviates_from_generated_key=BibTeX鍵は生成された鍵と異なります
-DOI_%0_is_invalid=DOI_%0は有効ではありません
+Could\ not\ find\ any\ bibliographic\ information.=文献情報を見つけることができませんでした．
+BibTeX\ key\ deviates\ from\ generated\ key=BibTeX鍵は生成された鍵と異なります
+DOI\ %0\ is\ invalid=DOI %0は有効ではありません
 
-Select_all_customized_types_to_be_stored_in_local_preferences=ローカル設定に保管されるカスタム型を全て選択
-Currently_unknown=現時点では未知
-Different_customization,_current_settings_will_be_overwritten=異なる設定：現在の設定は上書きされます
+Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences=ローカル設定に保管されるカスタム型を全て選択
+Currently\ unknown=現時点では未知
+Different\ customization,\ current\ settings\ will\ be\ overwritten=異なる設定：現在の設定は上書きされます
 
-Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX=項目型%0はBiblatexにのみ定義されていてBibTeXでは使えません
-Jump_to_entry=項目へジャンプ
+Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=項目型%0はBiblatexにのみ定義されていてBibTeXでは使えません
+Jump\ to\ entry=項目へジャンプ
 
-Copied_%0_citations.=%0個の引用をコピーしました
+Copied\ %0\ citations.=%0個の引用をコピーしました
 Copying...=コピーしています...
 
-journal_not_found_in_abbreviation_list=短縮名リストにない学術誌
-Unhandled_exception_occurred.=取り扱えない例外が発生しました．
+journal\ not\ found\ in\ abbreviation\ list=短縮名リストにない学術誌
+Unhandled\ exception\ occurred.=取り扱えない例外が発生しました．
 
-strings_included=インクルードした文字列
-Color_for_disabled_icons=無効なアイコンの色
-Color_for_enabled_icons=有効なアイコンの色
-Size_of_large_icons=大アイコンの大きさ
-Size_of_small_icons=小アイコンの大きさ
-Default_table_font_size=テーブルフォントの既定寸法
-Escape_underscores=アンダースコアをエスケープ
+strings\ included=インクルードした文字列
+Color\ for\ disabled\ icons=無効なアイコンの色
+Color\ for\ enabled\ icons=有効なアイコンの色
+Size\ of\ large\ icons=大アイコンの大きさ
+Size\ of\ small\ icons=小アイコンの大きさ
+Default\ table\ font\ size=テーブルフォントの既定寸法
+Escape\ underscores=アンダースコアをエスケープ
 Color=色
-Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=可能ならば，この問題を再現するための全手順も書いておいてください．
-Fit_width=幅に合わせる
-Fit_a_single_page=ページ全体に合わせる
-Zoom_in=拡大
-Zoom_out=縮小
-Previous_page=前ページ
-Next_page=次ページ
-Document_viewer=文書ビューア
+Please\ also\ add\ all\ steps\ to\ reproduce\ this\ issue,\ if\ possible.=可能ならば，この問題を再現するための全手順も書いておいてください．
+Fit\ width=幅に合わせる
+Fit\ a\ single\ page=ページ全体に合わせる
+Zoom\ in=拡大
+Zoom\ out=縮小
+Previous\ page=前ページ
+Next\ page=次ページ
+Document\ viewer=文書ビューア
 Live=ライブ
 Locked=ロック済
-Show_document_viewer=文書ビューアを表示
-Show_the_document_of_the_currently_selected_entry.=現在選択されている項目の文書を表示する．
-Show_this_document_until_unlocked.=ロック解除までこの文書を表示
-Set_current_user_name_as_owner.=現在のユーザー名を所有者に設定する．
+Show\ document\ viewer=文書ビューアを表示
+Show\ the\ document\ of\ the\ currently\ selected\ entry.=現在選択されている項目の文書を表示する．
+Show\ this\ document\ until\ unlocked.=ロック解除までこの文書を表示
+Set\ current\ user\ name\ as\ owner.=現在のユーザー名を所有者に設定する．
 
-Sort_all_subgroups_(recursively)=全下層グループを（再帰的に）整序
-Collect_and_share_telemetry_data_to_help_improve_JabRef.=JabRefの改良を手助けするために遠隔計測データを収集・共有する
-Don't_share=共有しない
-Share_anonymous_statistics=匿名統計を共有
-Telemetry\:_Help_make_JabRef_better=遠隔計測：JabRefの改善に貢献
-To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.=ユーザー・エクスペリエンスを改善するために，あなたが使用する機能の匿名統計を収集したいと考えています．あなたがどの機能にアクセスし，それをどれくらい頻繁に使ったかのみを記録します．個人的データや文献項目の内容は収集しません．データ収集を許可した場合でも，オプション→設定→一般から後で無効にすることができます．
-This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?=このファイルは自動的に検出されました．ファイルをこの項目にリンクしますか？
-Names_are_not_in_the_standard_%0_format.=名称が%0標準形式ではありません．
+Sort\ all\ subgroups\ (recursively)=全下層グループを（再帰的に）整序
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=JabRefの改良を手助けするために遠隔計測データを収集・共有する
+Don't\ share=共有しない
+Share\ anonymous\ statistics=匿名統計を共有
+Telemetry\:\ Help\ make\ JabRef\ better=遠隔計測：JabRefの改善に貢献
+To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ statistics\ on\ the\ features\ you\ use.\ We\ will\ only\ record\ what\ features\ you\ access\ and\ how\ often\ you\ do\ it.\ We\ will\ neither\ collect\ any\ personal\ data\ nor\ the\ content\ of\ bibliographic\ items.\ If\ you\ choose\ to\ allow\ data\ collection,\ you\ can\ later\ disable\ it\ via\ Options\ ->\ Preferences\ ->\ General.=ユーザー・エクスペリエンスを改善するために，あなたが使用する機能の匿名統計を収集したいと考えています．あなたがどの機能にアクセスし，それをどれくらい頻繁に使ったかのみを記録します．個人的データや文献項目の内容は収集しません．データ収集を許可した場合でも，オプション→設定→一般から後で無効にすることができます．
+This\ file\ was\ found\ automatically.\ Do\ you\ want\ to\ link\ it\ to\ this\ entry?=このファイルは自動的に検出されました．ファイルをこの項目にリンクしますか？
+Names\ are\ not\ in\ the\ standard\ %0\ format.=名称が%0標準形式ではありません．
 
-Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.=選択したファイルをディスクから永久に削除しますか，それとも項目からファイルを除去するだけにしますか？削除を押すとディスクからファイルを永久に削除することになります．
-Delete_'%0'=「%0」を削除
-Delete_from_disk=ディスクから削除
-Remove_from_entry=項目から除去
-The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.=グループ名にキーワード区切りの「%0」が含まれているので，想定通りにはおそらく動作しません．
-There_exists_already_a_group_with_the_same_name.=同じ名称のグループがすでに存在します．
+Delete\ the\ selected\ file\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ file\ permanently\ from\ disk.=選択したファイルをディスクから永久に削除しますか，それとも項目からファイルを除去するだけにしますか？削除を押すとディスクからファイルを永久に削除することになります．
+Delete\ '%0'=「%0」を削除
+Delete\ from\ disk=ディスクから削除
+Remove\ from\ entry=項目から除去
+The\ group\ name\ contains\ the\ keyword\ separator\ "%0"\ and\ thus\ probably\ does\ not\ work\ as\ expected.=グループ名にキーワード区切りの「%0」が含まれているので，想定通りにはおそらく動作しません．
+There\ exists\ already\ a\ group\ with\ the\ same\ name.=同じ名称のグループがすでに存在します．
 
-Copy_linked_files_to_folder...=
-Copied_file_successfully=
-Copying_files...=Copying_files...
-Copying_file_%0_of_entry_%1=
-Finished_copying=Finished_copying
-Could_not_copy_file=Could_not_copy_file
-Copied_%0_files_of_%1_sucessfully_to_%2=
-Rename_failed=
-JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.=
-Show_console_output_(only_necessary_when_the_launcher_is_used)=
+Copy\ linked\ files\ to\ folder...=
+Copied\ file\ successfully=
+Copying\ files...=Copying files...
+Copying\ file\ %0\ of\ entry\ %1=
+Finished\ copying=Finished copying
+Could\ not\ copy\ file=Could not copy file
+Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=
+Rename\ failed=
+JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=
+Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=
 
-Remove_line_breaks=
-Removes_all_line_breaks_in_the_field_content.=
-Checking_integrity...=
+Remove\ line\ breaks=
+Removes\ all\ line\ breaks\ in\ the\ field\ content.=
+Checking\ integrity...=
 
-Remove_hyphenated_line_breaks=
-Removes_all_hyphenated_line_breaks_in_the_field_content.=
-Note_that_currently,_JabRef_does_not_run_with_Java_9.=
-Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.=
+Remove\ hyphenated\ line\ breaks=
+Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=
+Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=
+Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -1,8 +1,3 @@
-
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=%0には，正規表現<b>%1</b>が含まれています
 
 %0\ contains\ the\ term\ <b>%1</b>=%0には，用語<b>%1</b>が含まれています

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -52,7 +52,7 @@ Add\ selected\ entries\ to\ this\ group=
 
 Add\ from\ folder=Voeg toe uit map
 
-Add\ from\ JAR= Voeg toe uit JAR
+Add\ from\ JAR=Voeg toe uit JAR
 
 add\ group=groep toevoegen
 

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -1,8 +1,3 @@
-
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 bevat de regular expression <b>%1</b>
 
 %0\ contains\ the\ term\ <b>%1</b>=%0 bevat de term <b>%1</b>

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -3,156 +3,156 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-%0_contains_the_regular_expression_<b>%1</b>=%0_bevat_de_regular_expression_<b>%1</b>
+%0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 bevat de regular expression <b>%1</b>
 
-%0_contains_the_term_<b>%1</b>=%0_bevat_de_term_<b>%1</b>
+%0\ contains\ the\ term\ <b>%1</b>=%0 bevat de term <b>%1</b>
 
-%0_doesn't_contain_the_regular_expression_<b>%1</b>=%0_bevat_de_regular_expression_<b>%1</b>_niet
+%0\ doesn't\ contain\ the\ regular\ expression\ <b>%1</b>=%0 bevat de regular expression <b>%1</b> niet
 
-%0_doesn't_contain_the_term_<b>%1</b>=%0_bevat_de_term_<b>%1</b>_niet
+%0\ doesn't\ contain\ the\ term\ <b>%1</b>=%0 bevat de term <b>%1</b> niet
 
-%0_export_successful=
+%0\ export\ successful=
 
-%0_matches_the_regular_expression_<b>%1</b>=%0_komt_overeen_met_de_regular_expression_<b>%1</b>
+%0\ matches\ the\ regular\ expression\ <b>%1</b>=%0 komt overeen met de regular expression <b>%1</b>
 
-%0_matches_the_term_<b>%1</b>=%0_komt_overeen_met_de_term_<b>%1</b>
+%0\ matches\ the\ term\ <b>%1</b>=%0 komt overeen met de term <b>%1</b>
 
-<field_name>=<veldnaam>
-<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>=
+<field\ name>=<veldnaam>
+<HTML>Could\ not\ find\ file\ '%0'<BR>linked\ from\ entry\ '%1'</HTML>=
 
 <select>=<selecteer>
 
-<select_word>=<selecteer_woord>
-Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)=Kort_tijdschriftennamen_met_de_geselecteerde_entries_af_(ISO_afkorting)
-Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)=Kort_tijdschriftennamen_met_de_geselecteerde_entries_af_(MEDLINE_afkorting)
+<select\ word>=<selecteer woord>
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (ISO\ abbreviation)=Kort tijdschriftennamen met de geselecteerde entries af (ISO afkorting)
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (MEDLINE\ abbreviation)=Kort tijdschriftennamen met de geselecteerde entries af (MEDLINE afkorting)
 
-Abbreviate_names=Namen_afkorten
-Abbreviated_%0_journal_names.=Afgekorte_tijdschrift_namen
+Abbreviate\ names=Namen afkorten
+Abbreviated\ %0\ journal\ names.=Afgekorte tijdschrift namen
 
 Abbreviation=Afkorting
 
-About_JabRef=Over_JabRef
+About\ JabRef=Over JabRef
 
 Abstract=Abstract
 
 Accept=Aanvaarden
 
-Accept_change=Veranderingen_aanvaarden
+Accept\ change=Veranderingen aanvaarden
 
 Action=Actie
 
-What_is_Mr._DLib?=
+What\ is\ Mr.\ DLib?=
 
 Add=Toevoegen
 
-Add_a_(compiled)_custom_Importer_class_from_a_class_path.=Voeg_een_(gecompileerde)_externe_Importer_klasse_van_een_class_path_toe.
-The_path_need_not_be_on_the_classpath_of_JabRef.=Het_pad_moet_niet_in_het_classpath_van_JabRef_staan.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=Voeg een (gecompileerde) externe Importer klasse van een class path toe.
+The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=Het pad moet niet in het classpath van JabRef staan.
 
-Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=Voeg_een_(gecompileerde)_externe_Importer_klasse_van_een_ZIP-archief_toe.
-The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=Het_pad_moet_niet_in_het_classpath_van_JabRef_staan.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=Voeg een (gecompileerde) externe Importer klasse van een ZIP-archief toe.
+The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=Het pad moet niet in het classpath van JabRef staan.
 
-Add_a_regular_expression_for_the_key_pattern.=
+Add\ a\ regular\ expression\ for\ the\ key\ pattern.=
 
-Add_selected_entries_to_this_group=
+Add\ selected\ entries\ to\ this\ group=
 
-Add_from_folder=Voeg_toe_uit_map
+Add\ from\ folder=Voeg toe uit map
 
-Add_from_JAR=_Voeg_toe_uit_JAR
+Add\ from\ JAR= Voeg toe uit JAR
 
-add_group=groep_toevoegen
+add\ group=groep toevoegen
 
-Add_new=Voeg_nieuw_toe
+Add\ new=Voeg nieuw toe
 
-Add_subgroup=Voeg_subgroep_toe
+Add\ subgroup=Voeg subgroep toe
 
-Add_to_group=Voeg_toe_aan_groep
+Add\ to\ group=Voeg toe aan groep
 
-Added_group_"%0".=Toegevoegde_groep_"%0".
+Added\ group\ "%0".=Toegevoegde groep "%0".
 
-Added_missing_braces.=
+Added\ missing\ braces.=
 
-Added_new=Nieuwe_toegevoegd
+Added\ new=Nieuwe toegevoegd
 
-Added_string=Toegevoegde_constante
+Added\ string=Toegevoegde constante
 
-Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.=Bijkomstig,_entries_waarvan_het_<b>%0</b>_veld_niet_<b>%1</b>_bevatten_kunnen_manueel_toegekend_worden_aan_deze_groep_door_ze_te_selecteren_gebruik_makend_van_"drag_and_drop"_of_het_contextmenu._Dit_proces_voegt_de_term_<b>%1</b>_aan_het_<b>%0</b>_veld_van_elke_entry_toe._Entries_kunnen_manueel_verwijderd_worden_van_deze_groep_door_ze_te_selecteren_gebruik_makend_van_het_contextmenu._Dit_proces_verwijdert_de_term_van_het_<b>%0</b>_veld_van_elke_entry.
+Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ can\ be\ assigned\ manually\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ This\ process\ adds\ the\ term\ <b>%1</b>\ to\ each\ entry's\ <b>%0</b>\ field.\ Entries\ can\ be\ removed\ manually\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.\ This\ process\ removes\ the\ term\ <b>%1</b>\ from\ each\ entry's\ <b>%0</b>\ field.=Bijkomstig, entries waarvan het <b>%0</b> veld niet <b>%1</b> bevatten kunnen manueel toegekend worden aan deze groep door ze te selecteren gebruik makend van "drag and drop" of het contextmenu. Dit proces voegt de term <b>%1</b> aan het <b>%0</b> veld van elke entry toe. Entries kunnen manueel verwijderd worden van deze groep door ze te selecteren gebruik makend van het contextmenu. Dit proces verwijdert de term van het <b>%0</b> veld van elke entry.
 
 Advanced=Geavanceerd
-All_entries=Alle_entries
-All_entries_of_this_type_will_be_declared_typeless._Continue?=
+All\ entries=Alle entries
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=
 
-All_fields=Alle_velden
+All\ fields=Alle velden
 
-Always_reformat_BIB_file_on_save_and_export=
+Always\ reformat\ BIB\ file\ on\ save\ and\ export=
 
-A_SAX_exception_occurred_while_parsing_'%0'\:=
+A\ SAX\ exception\ occurred\ while\ parsing\ '%0'\:=
 
 and=en
-and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.=en_de_klasse_moet_beschikbaar_zijn_in_uw_classpath_de_volgende_keer_wanneer_u_JabRef_opstart
+and\ the\ class\ must\ be\ available\ in\ your\ classpath\ next\ time\ you\ start\ JabRef.=en de klasse moet beschikbaar zijn in uw classpath de volgende keer wanneer u JabRef opstart
 
-any_field_that_matches_the_regular_expression_<b>%0</b>=elk_veld_dat_overeenkomt_met_de_regular_expression_<b>%0</b>
+any\ field\ that\ matches\ the\ regular\ expression\ <b>%0</b>=elk veld dat overeenkomt met de regular expression <b>%0</b>
 
 Appearance=Uiterlijk
 
 Append=Bijvoegen
-Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library=Voeg_de_inhoud_van_een_BibTeX_library_in_de_huidige_weergegeven_library_toe
+Append\ contents\ from\ a\ BibTeX\ library\ into\ the\ currently\ viewed\ library=Voeg de inhoud van een BibTeX library in de huidige weergegeven library toe
 
-Append_library=Library_invoegen
+Append\ library=Library invoegen
 
-Append_the_selected_text_to_BibTeX_field=Voeg_de_geselecteerde_tekst_toe_aan_BibTeX-sleutel
+Append\ the\ selected\ text\ to\ BibTeX\ field=Voeg de geselecteerde tekst toe aan BibTeX-sleutel
 Application=Programma
 
 Apply=Toepassen
 
-Arguments_passed_on_to_running_JabRef_instance._Shutting_down.=Argumenten_doorgegeven_aan_de_draaiende_JabRef_instantie._Wordt_nu_afgesloten.
+Arguments\ passed\ on\ to\ running\ JabRef\ instance.\ Shutting\ down.=Argumenten doorgegeven aan de draaiende JabRef instantie. Wordt nu afgesloten.
 
-Assign_new_file=Ken_nieuw_bestand_toe
+Assign\ new\ file=Ken nieuw bestand toe
 
-Assign_the_original_group's_entries_to_this_group?=De_entries_van_de_originele_groep_aan_deze_groep_toekennen?
+Assign\ the\ original\ group's\ entries\ to\ this\ group?=De entries van de originele groep aan deze groep toekennen?
 
-Assigned_%0_entries_to_group_"%1".=%0_entries_aan_groep_"%1"_toegekend
+Assigned\ %0\ entries\ to\ group\ "%1".=%0 entries aan groep "%1" toegekend
 
-Assigned_1_entry_to_group_"%0".=1_entry_aan_groep_"%0"_toegekend
+Assigned\ 1\ entry\ to\ group\ "%0".=1 entry aan groep "%0" toegekend
 
-Attach_URL=URL_bijvoegen
+Attach\ URL=URL bijvoegen
 
-Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.=Poging_om_bestand_snelkoppelingen_voor_jouw_entries_automatisch_in_te_stellen._Automatisch_instellen_werkt_als_een_bestand_in_jouw_bestand_map_of_een_submap<BR>een_identieke_naam_heeft_als_een_BibTeX-sleutel_van_een_entry,_plus_extensie.
+Attempt\ to\ automatically\ set\ file\ links\ for\ your\ entries.\ Automatically\ setting\ works\ if\ a\ file\ in\ your\ file\ directory<BR>or\ a\ subdirectory\ is\ named\ identically\ to\ an\ entry's\ BibTeX\ key,\ plus\ extension.=Poging om bestand snelkoppelingen voor jouw entries automatisch in te stellen. Automatisch instellen werkt als een bestand in jouw bestand map of een submap<BR>een identieke naam heeft als een BibTeX-sleutel van een entry, plus extensie.
 
-Autodetect_format=Formaat_automatisch_detecteren
+Autodetect\ format=Formaat automatisch detecteren
 
-Autogenerate_BibTeX_keys=BibTeX-sleutels_automatisch_genereren
+Autogenerate\ BibTeX\ keys=BibTeX-sleutels automatisch genereren
 
-Autolink_files_with_names_starting_with_the_BibTeX_key=
+Autolink\ files\ with\ names\ starting\ with\ the\ BibTeX\ key=
 
-Autolink_only_files_that_match_the_BibTeX_key=
+Autolink\ only\ files\ that\ match\ the\ BibTeX\ key=
 
-Automatically_create_groups=Groepen_automatisch_aanmaken
+Automatically\ create\ groups=Groepen automatisch aanmaken
 
-Automatically_remove_exact_duplicates=Automatisch_exacte_kopie\u00ebn_verwijderen
+Automatically\ remove\ exact\ duplicates=Automatisch exacte kopie\u00ebn verwijderen
 
-Allow_overwriting_existing_links.=Overschrijven_van_bestaande_snelkoppelingen_toestaan.
+Allow\ overwriting\ existing\ links.=Overschrijven van bestaande snelkoppelingen toestaan.
 
-Do_not_overwrite_existing_links.=Overschrijven_van_bestaande_snelkoppelingen_niet_toestaan.
+Do\ not\ overwrite\ existing\ links.=Overschrijven van bestaande snelkoppelingen niet toestaan.
 
-AUX_file_import=AUX_bestand_importeren
+AUX\ file\ import=AUX bestand importeren
 
-Available_export_formats=Beschikbare_exporteer_formaten
+Available\ export\ formats=Beschikbare exporteer formaten
 
-Available_BibTeX_fields=Beschikbare_velden
+Available\ BibTeX\ fields=Beschikbare velden
 
-Available_import_formats=Beschikbare_importeer_formaten
+Available\ import\ formats=Beschikbare importeer formaten
 
-Background_color_for_optional_fields=Achtergrondkleur_voor_optionele_velden
+Background\ color\ for\ optional\ fields=Achtergrondkleur voor optionele velden
 
-Background_color_for_required_fields=Achtergrondkleur_voor_vereiste_velden
+Background\ color\ for\ required\ fields=Achtergrondkleur voor vereiste velden
 
-Backup_old_file_when_saving=Maak_reservekopie_van_oud_bestand_bij_het_opslaan
+Backup\ old\ file\ when\ saving=Maak reservekopie van oud bestand bij het opslaan
 
-BibTeX_key_is_unique.=BibTeX-sleutel_is_uniek
+BibTeX\ key\ is\ unique.=BibTeX-sleutel is uniek
 
-%0_source=%0-broncode
+%0\ source=%0-broncode
 
-Broken_link=
+Broken\ link=
 
 Browse=Bladeren
 
@@ -160,321 +160,321 @@ by=door
 
 Cancel=Annuleren
 
-Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?=Kan_entries_niet_aan_de_groep_toevoegen_zonder_sleutels_te_genereren._Sleutels_nu_genereren?
+Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=Kan entries niet aan de groep toevoegen zonder sleutels te genereren. Sleutels nu genereren?
 
-Cannot_merge_this_change=Kan_deze_verandering_niet_samenvoegen
+Cannot\ merge\ this\ change=Kan deze verandering niet samenvoegen
 
-case_insensitive=hoofdletter_ongevoelig
+case\ insensitive=hoofdletter ongevoelig
 
-case_sensitive=hoofdletter_gevoelig
+case\ sensitive=hoofdletter gevoelig
 
-Case_sensitive=Hoofdletter_gevoelig
+Case\ sensitive=Hoofdletter gevoelig
 
-change_assignment_of_entries=verandering_toekenning_van_entries
+change\ assignment\ of\ entries=verandering toekenning van entries
 
-Change_case=Verander_geval
+Change\ case=Verander geval
 
-Change_entry_type=Wijzig_entry_type
-Change_file_type=Wijzig_bestandstype
+Change\ entry\ type=Wijzig entry type
+Change\ file\ type=Wijzig bestandstype
 
 
-Change_of_Grouping_Method=Wijzig_groepering_methode
+Change\ of\ Grouping\ Method=Wijzig groepering methode
 
-change_preamble=wijzig_inleiding
+change\ preamble=wijzig inleiding
 
-Change_table_column_and_General_fields_settings_to_use_the_new_feature=
+Change\ table\ column\ and\ General\ fields\ settings\ to\ use\ the\ new\ feature=
 
-Changed_language_settings=Gewijzigde_taal_instellingen
+Changed\ language\ settings=Gewijzigde taal instellingen
 
-Changed_preamble=Gewijzigde_inleiding
+Changed\ preamble=Gewijzigde inleiding
 
-Check_existing_file_links=Controleer_bestaande_bestand_snelkoppelingen
+Check\ existing\ file\ links=Controleer bestaande bestand snelkoppelingen
 
-Check_links=Controleer_snelkoppelingen
+Check\ links=Controleer snelkoppelingen
 
-Cite_command=
+Cite\ command=
 
-Class_name=Klassenaam
+Class\ name=Klassenaam
 
 Clear=Wissen
 
-Clear_fields=Velden_wissen
+Clear\ fields=Velden wissen
 
 Close=Sluiten
-Close_others=
-Close_all=
+Close\ others=
+Close\ all=
 
-Close_dialog=Sluit_dialoog
+Close\ dialog=Sluit dialoog
 
-Close_the_current_library=Sluit_de_huidige_library
+Close\ the\ current\ library=Sluit de huidige library
 
-Close_window=Sluit_venster
+Close\ window=Sluit venster
 
-Closed_library=Sluit_library
+Closed\ library=Sluit library
 
-Color_codes_for_required_and_optional_fields=Kleurcodes_voor_vereiste_en_optionele_velden
+Color\ codes\ for\ required\ and\ optional\ fields=Kleurcodes voor vereiste en optionele velden
 
-Color_for_marking_incomplete_entries=Kleur_om_onvolledige_entries_te_markeren
+Color\ for\ marking\ incomplete\ entries=Kleur om onvolledige entries te markeren
 
-Column_width=Kolombreedte
+Column\ width=Kolombreedte
 
-Command_line_id=Commandoregel_id
+Command\ line\ id=Commandoregel id
 
 
-Contained_in=bevat_in
+Contained\ in=bevat in
 
 Content=Inhoud
 
 Copied=Gekopieerd
 
-Copied_cell_contents=Gekopieerde_cel_inhoud
+Copied\ cell\ contents=Gekopieerde cel inhoud
 
-Copied_title=
+Copied\ title=
 
-Copied_key=Gekopieerde_BibTeX-sleutel
+Copied\ key=Gekopieerde BibTeX-sleutel
 
-Copied_titles=
+Copied\ titles=
 
-Copied_keys=Gekopieerde_BibTeX-sleutels
+Copied\ keys=Gekopieerde BibTeX-sleutels
 
 Copy=Kopi\u00ebren
 
-Copy_BibTeX_key=Kopieer_BibTeX-sleutel
-Copy_file_to_file_directory=
+Copy\ BibTeX\ key=Kopieer BibTeX-sleutel
+Copy\ file\ to\ file\ directory=
 
-Copy_to_clipboard=
+Copy\ to\ clipboard=
 
-Could_not_call_executable=Kon_executable_niet_oproepen
-Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.=
+Could\ not\ call\ executable=Kon executable niet oproepen
+Could\ not\ connect\ to\ Vim\ server.\ Make\ sure\ that\ Vim\ is\ running<BR>with\ correct\ server\ name.=
 
-Could_not_export_file=Kon_bestand_niet_exporteren
+Could\ not\ export\ file=Kon bestand niet exporteren
 
-Could_not_export_preferences=Kon_instellingen_niet_exporteren
+Could\ not\ export\ preferences=Kon instellingen niet exporteren
 
-Could_not_find_a_suitable_import_format.=Kon_geen_geschikt_importeer_formaat_vinden.
-Could_not_import_preferences=Kon_instellingen_niet_importeren
+Could\ not\ find\ a\ suitable\ import\ format.=Kon geen geschikt importeer formaat vinden.
+Could\ not\ import\ preferences=Kon instellingen niet importeren
 
-Could_not_instantiate_%0=Kon_geen_instantie_van_%0_aanmaken
-Could_not_instantiate_%0_%1=Kon_geen_instantie_van_%0_%1_aanmaken
-Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?=Kon_geen_instantie_van_%0_aanmaken._Heeft_u_het_correcte_pakket_pad_gekozen?
-Could_not_open_link=
+Could\ not\ instantiate\ %0=Kon geen instantie van %0 aanmaken
+Could\ not\ instantiate\ %0\ %1=Kon geen instantie van %0 %1 aanmaken
+Could\ not\ instantiate\ %0.\ Have\ you\ chosen\ the\ correct\ package\ path?=Kon geen instantie van %0 aanmaken. Heeft u het correcte pakket pad gekozen?
+Could\ not\ open\ link=
 
-Could_not_print_preview=
+Could\ not\ print\ preview=
 
-Could_not_run_the_'vim'_program.=
+Could\ not\ run\ the\ 'vim'\ program.=
 
-Could_not_save_file.=Kon_het_bestand_niet_opslaan.
-Character_encoding_'%0'_is_not_supported.=
+Could\ not\ save\ file.=Kon het bestand niet opslaan.
+Character\ encoding\ '%0'\ is\ not\ supported.=
 
-crossreferenced_entries_included=inclusief_kruisgerefereerde_entries
+crossreferenced\ entries\ included=inclusief kruisgerefereerde entries
 
-Current_content=Huidige_inhoud
+Current\ content=Huidige inhoud
 
-Current_value=Huidige_waarde
+Current\ value=Huidige waarde
 
-Custom_entry_types=Externe_entry_types
+Custom\ entry\ types=Externe entry types
 
-Custom_entry_types_found_in_file=Externe_entry_types_gevonden_in_bestand
+Custom\ entry\ types\ found\ in\ file=Externe entry types gevonden in bestand
 
-Customize_entry_types=Entry_types_aanpassen
+Customize\ entry\ types=Entry types aanpassen
 
-Customize_key_bindings=Toetsentoekenningen_aanpassen
+Customize\ key\ bindings=Toetsentoekenningen aanpassen
 
 Cut=Knippen
 
-cut_entries=entries_knippen
+cut\ entries=entries knippen
 
-cut_entry=entry_knippen
+cut\ entry=entry knippen
 
 
-Library_encoding=Library_encodering
+Library\ encoding=Library encodering
 
-Library_properties=Library_eigenschappen
+Library\ properties=Library eigenschappen
 
-Library_type=
+Library\ type=
 
-Date_format=Datum_formaat
+Date\ format=Datum formaat
 
 Default=Standaard
 
-Default_encoding=Standaard_encodering
+Default\ encoding=Standaard encodering
 
-Default_grouping_field=Standaard_groeperingsveld
+Default\ grouping\ field=Standaard groeperingsveld
 
-Default_look_and_feel=Standaard_"look_and_feel"
+Default\ look\ and\ feel=Standaard "look and feel"
 
-Default_pattern=Standaard_patroon
+Default\ pattern=Standaard patroon
 
-Default_sort_criteria=Standaard_sorteercriteria
-Define_'%0'=
+Default\ sort\ criteria=Standaard sorteercriteria
+Define\ '%0'=
 
 Delete=Verwijderen
 
-Delete_custom_format=Verwijder_aangepast_formaat
+Delete\ custom\ format=Verwijder aangepast formaat
 
-delete_entries=verwijder_entries
+delete\ entries=verwijder entries
 
-Delete_entry=Verwijder_entry
+Delete\ entry=Verwijder entry
 
-delete_entry=verwijder_entry
+delete\ entry=verwijder entry
 
-Delete_multiple_entries=Verwijder_meerdere_entries
+Delete\ multiple\ entries=Verwijder meerdere entries
 
-Delete_rows=Verwijder_rijen
+Delete\ rows=Verwijder rijen
 
-Delete_strings=Verwijder_constanten
+Delete\ strings=Verwijder constanten
 
 Deleted=Verwijderd
 
-Permanently_delete_local_file=
+Permanently\ delete\ local\ file=
 
-Delimit_fields_with_semicolon,_ex.=Scheid_velden_met_puntkomma,_bv.
+Delimit\ fields\ with\ semicolon,\ ex.=Scheid velden met puntkomma, bv.
 
 Descending=Afdalend
 
 Description=Beschrijving
 
-Deselect_all=Alle_selecties_ongedaan_maken
-Deselect_all_duplicates=
+Deselect\ all=Alle selecties ongedaan maken
+Deselect\ all\ duplicates=
 
-Disable_this_confirmation_dialog=Maak_deze_bevestigingsdialoog_onbeschikbaar
+Disable\ this\ confirmation\ dialog=Maak deze bevestigingsdialoog onbeschikbaar
 
-Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.=Toon_alle_entries_die_bij_een_of_meerdere_van_de_geselecteerde_groepen_behoren.
+Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups.=Toon alle entries die bij een of meerdere van de geselecteerde groepen behoren.
 
-Display_all_error_messages=Toon_alle_foutmeldingen
+Display\ all\ error\ messages=Toon alle foutmeldingen
 
-Display_help_on_command_line_options=Toon_help_over_commandline_opties
+Display\ help\ on\ command\ line\ options=Toon help over commandline opties
 
-Display_only_entries_belonging_to_all_selected_groups.=Toon_alleen_entries_die_tot_alle_geselecteerde_groepen_behoren.
-Display_version=Display_versie
+Display\ only\ entries\ belonging\ to\ all\ selected\ groups.=Toon alleen entries die tot alle geselecteerde groepen behoren.
+Display\ version=Display versie
 
-Do_not_abbreviate_names=Namen_niet_afkorten
+Do\ not\ abbreviate\ names=Namen niet afkorten
 
-Do_not_automatically_set=Niet_automatisch_instellen
+Do\ not\ automatically\ set=Niet automatisch instellen
 
-Do_not_import_entry=Entry_niet_importeren
+Do\ not\ import\ entry=Entry niet importeren
 
-Do_not_open_any_files_at_startup=Geen_bestanden_openen_bij_het_opstarten
+Do\ not\ open\ any\ files\ at\ startup=Geen bestanden openen bij het opstarten
 
-Do_not_overwrite_existing_keys=Bestaande_BibTeX-sleutels_niet_overschrijven
-Do_not_show_these_options_in_the_future=
+Do\ not\ overwrite\ existing\ keys=Bestaande BibTeX-sleutels niet overschrijven
+Do\ not\ show\ these\ options\ in\ the\ future=
 
-Do_not_wrap_the_following_fields_when_saving=De_volgende_velden_niet_bij_het_opslaan_afbreken
-Do_not_write_the_following_fields_to_XMP_Metadata\:=
+Do\ not\ wrap\ the\ following\ fields\ when\ saving=De volgende velden niet bij het opslaan afbreken
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=
 
-Do_you_want_JabRef_to_do_the_following_operations?=
+Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=
 
-Donate_to_JabRef=
+Donate\ to\ JabRef=
 
 Down=Omlaag
 
-Download_file=Download_bestand
+Download\ file=Download bestand
 
 Downloading...=Downloading...
 
-Drop_%0=
+Drop\ %0=
 
-duplicate_removal=dubbels_verwijderen
+duplicate\ removal=dubbels verwijderen
 
-Duplicate_string_name=Dubbele_constante_naam
+Duplicate\ string\ name=Dubbele constante naam
 
-Duplicates_found=Dubbels_gevonden
+Duplicates\ found=Dubbels gevonden
 
-Dynamic_groups=Dynamische_groepen
+Dynamic\ groups=Dynamische groepen
 
-Dynamically_group_entries_by_a_free-form_search_expression=Dynamisch_entries_groeperen_door_een_"free-form"_zoek_expressie
+Dynamically\ group\ entries\ by\ a\ free-form\ search\ expression=Dynamisch entries groeperen door een "free-form" zoek expressie
 
-Dynamically_group_entries_by_searching_a_field_for_a_keyword=Dynamisch_entries_groeperen_door_een_veld_te_zoeken_via_een_sleutelwoord
+Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=Dynamisch entries groeperen door een veld te zoeken via een sleutelwoord
 
-Each_line_must_be_on_the_following_form=Elke_regel_moet_in_de_volgende_vorm_zijn
+Each\ line\ must\ be\ on\ the\ following\ form=Elke regel moet in de volgende vorm zijn
 
 Edit=Bewerken
 
-Edit_custom_export=Externe_exportfilter_bewerken
-Edit_entry=Entry_bewerken
-Save_file=
-Edit_file_type=
+Edit\ custom\ export=Externe exportfilter bewerken
+Edit\ entry=Entry bewerken
+Save\ file=
+Edit\ file\ type=
 
-Edit_group=Groep_bewerken
+Edit\ group=Groep bewerken
 
 
-Edit_preamble=Inleiding_bewerken
-Edit_strings=Constanten_bewerken
-Editor_options=
+Edit\ preamble=Inleiding bewerken
+Edit\ strings=Constanten bewerken
+Editor\ options=
 
-Empty_BibTeX_key=Lege_BibTeX-sleutel
+Empty\ BibTeX\ key=Lege BibTeX-sleutel
 
-Grouping_may_not_work_for_this_entry.=Groepering_kan_misschien_niet_werken_voor_deze_entry.
+Grouping\ may\ not\ work\ for\ this\ entry.=Groepering kan misschien niet werken voor deze entry.
 
-empty_library=lege_library
-Enable_word/name_autocompletion=
+empty\ library=lege library
+Enable\ word/name\ autocompletion=
 
-Enter_URL=URL_ingeven
+Enter\ URL=URL ingeven
 
-Enter_URL_to_download=Geef_URL_om_te_downloaden_in
+Enter\ URL\ to\ download=Geef URL om te downloaden in
 
 entries=entries
 
-Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.=Entries_kunnen_niet_manueel_toegekend_of_verwijderd_worden_van_deze_groep.
+Entries\ cannot\ be\ manually\ assigned\ to\ or\ removed\ from\ this\ group.=Entries kunnen niet manueel toegekend of verwijderd worden van deze groep.
 
-Entries_exported_to_clipboard=Entries_ge\u00ebxporteerd_naar_het_klembord
+Entries\ exported\ to\ clipboard=Entries ge\u00ebxporteerd naar het klembord
 
 
 entry=entry
 
-Entry_editor=Entry_editor
+Entry\ editor=Entry editor
 
-Entry_preview=Entry_voorbeeld
+Entry\ preview=Entry voorbeeld
 
-Entry_table=Entry_tabel
+Entry\ table=Entry tabel
 
-Entry_table_columns=Entry_tabelkolommen
+Entry\ table\ columns=Entry tabelkolommen
 
-Entry_type=Entry_type
+Entry\ type=Entry type
 
-Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Entry_typenamen_mogen_geen_witruimtes_of_de_volgende_tekens_bevatten
+Entry\ type\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Entry typenamen mogen geen witruimtes of de volgende tekens bevatten
 
-Entry_types=Entrytypes
+Entry\ types=Entrytypes
 
 Error=Foutmelding
-Error_exporting_to_clipboard=
+Error\ exporting\ to\ clipboard=
 
-Error_occurred_when_parsing_entry=Foutmelding_bij_het_ontleden_van_de_entry
+Error\ occurred\ when\ parsing\ entry=Foutmelding bij het ontleden van de entry
 
-Error_opening_file=Foutmelding_bij_het_openen_van_het_bestand
+Error\ opening\ file=Foutmelding bij het openen van het bestand
 
-Error_setting_field=Foutmelding_bij_het_instellen_van_het_veld
+Error\ setting\ field=Foutmelding bij het instellen van het veld
 
-Error_while_writing=Foutmelding_bij_het_schrijven
-Error_writing_to_%0_file(s).=
+Error\ while\ writing=Foutmelding bij het schrijven
+Error\ writing\ to\ %0\ file(s).=
 
 
 
-'%0'_exists._Overwrite_file?='%0'_bestaat_reeds._Bestand_overschrijven?
-Overwrite_file?=Bestand_overschrijven?
+'%0'\ exists.\ Overwrite\ file?='%0' bestaat reeds. Bestand overschrijven?
+Overwrite\ file?=Bestand overschrijven?
 
 Export=Exporteren
 
-Export_name=Naam_exporteren
+Export\ name=Naam exporteren
 
-Export_preferences=Instellingen_exporteren
+Export\ preferences=Instellingen exporteren
 
-Export_preferences_to_file=Instellingen_exporteren_naar_bestand
+Export\ preferences\ to\ file=Instellingen exporteren naar bestand
 
-Export_properties=Eigenschappen_exporteren
+Export\ properties=Eigenschappen exporteren
 
-Export_to_clipboard=Exporteer_naar_klembord
+Export\ to\ clipboard=Exporteer naar klembord
 
 Exporting=Exporteren...
 Extension=
 
-External_changes=Externe_wijzigingen
+External\ changes=Externe wijzigingen
 
-External_file_links=
+External\ file\ links=
 
-External_programs=Externe_programma's
+External\ programs=Externe programma's
 
-External_viewer_called=Externe_viewer_opgeroepen
+External\ viewer\ called=Externe viewer opgeroepen
 
 Fetch=Ophalen
 
@@ -482,210 +482,210 @@ Field=Veld
 
 field=veld
 
-Field_name=Veldnaam
-Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters=
+Field\ name=Veldnaam
+Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=
 
-Field_to_filter=
+Field\ to\ filter=
 
-Field_to_group_by=Veld_te_groeperen_op
+Field\ to\ group\ by=Veld te groeperen op
 
 File=Bestand
 
 file=bestand
-File_'%0'_is_already_open.=
+File\ '%0'\ is\ already\ open.=
 
-File_changed=Bestand_veranderd
-File_directory_is_'%0'\:=
+File\ changed=Bestand veranderd
+File\ directory\ is\ '%0'\:=
 
-File_directory_is_not_set_or_does_not_exist\!=
+File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=
 
-File_exists=Bestand_bestaat
+File\ exists=Bestand bestaat
 
-File_has_been_updated_externally._What_do_you_want_to_do?=
+File\ has\ been\ updated\ externally.\ What\ do\ you\ want\ to\ do?=
 
-File_not_found=Bestand_niet_gevonden
-File_type=
+File\ not\ found=Bestand niet gevonden
+File\ type=
 
-File_updated_externally=Bestand_extern_geupdate
+File\ updated\ externally=Bestand extern geupdate
 
 filename=bestandsnaam
 
 Filename=
 
-Files_opened=Bestanden_geopend
+Files\ opened=Bestanden geopend
 
 Filter=Filter
 
-Filter_All=
+Filter\ All=
 
-Filter_None=
+Filter\ None=
 
-Finished_automatically_setting_external_links.=
+Finished\ automatically\ setting\ external\ links.=
 
-Finished_synchronizing_file_links._Entries_changed\:_%0.=Synchroniseren_van_bestand_snelkoppelingen_voltooid._Aantal_veranderde_entries\:_%0.
-Finished_writing_XMP-metadata._Wrote_to_%0_file(s).=
-Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).=XMP_schrijven_voor_%0_bestand_voltooid_(%1_overgeslagen,_%2_fouten).
+Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Synchroniseren van bestand snelkoppelingen voltooid. Aantal veranderde entries: %0.
+Finished\ writing\ XMP-metadata.\ Wrote\ to\ %0\ file(s).=
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=XMP schrijven voor %0 bestand voltooid (%1 overgeslagen, %2 fouten).
 
-First_select_the_entries_you_want_keys_to_be_generated_for.=Selecteer_eerst_de_entries_waarvoor_u_sleutels_wilt_genereren.
+First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Selecteer eerst de entries waarvoor u sleutels wilt genereren.
 
-Fit_table_horizontally_on_screen=Pas_tabel_horizontaal_aan_op_het_scherm
+Fit\ table\ horizontally\ on\ screen=Pas tabel horizontaal aan op het scherm
 
 Float=Float
-Float_marked_entries=Gemarkeerde_entries_bovenaan_tonen
+Float\ marked\ entries=Gemarkeerde entries bovenaan tonen
 
-Font_family=Lettertype_Type
+Font\ family=Lettertype Type
 
-Font_preview=Lettertype_Voorbeeld
+Font\ preview=Lettertype Voorbeeld
 
-Font_size=Lettertype_Grootte
+Font\ size=Lettertype Grootte
 
-Font_style=Lettertype_Stijl
+Font\ style=Lettertype Stijl
 
-Font_selection=Lettertype_selecteren
+Font\ selection=Lettertype selecteren
 
 for=voor
 
-Format_of_author_and_editor_names=Formaat_van_de_auteur-_en_editornamen
-Format_string=
+Format\ of\ author\ and\ editor\ names=Formaat van de auteur- en editornamen
+Format\ string=
 
-Format_used=Formaat_gebruikt
-Formatter_name=
+Format\ used=Formaat gebruikt
+Formatter\ name=
 
-found_in_AUX_file=gevonden_in_AUX_bestand
+found\ in\ AUX\ file=gevonden in AUX bestand
 
-Full_name=Volledige_naam
+Full\ name=Volledige naam
 
 General=Algemeen
 
-General_fields=Algemene_velden
+General\ fields=Algemene velden
 
 Generate=Genereren
 
-Generate_BibTeX_key=Genereer_BibTeX-sleutel
+Generate\ BibTeX\ key=Genereer BibTeX-sleutel
 
-Generate_keys=Genereer_sleutels
+Generate\ keys=Genereer sleutels
 
-Generate_keys_before_saving_(for_entries_without_a_key)=Genereer_sleutels_voor_het_opslaan_(voor_entries_zonder_een_sleutel)
-Generate_keys_for_imported_entries=
+Generate\ keys\ before\ saving\ (for\ entries\ without\ a\ key)=Genereer sleutels voor het opslaan (voor entries zonder een sleutel)
+Generate\ keys\ for\ imported\ entries=
 
-Generate_now=Genereer_nu
+Generate\ now=Genereer nu
 
-Generated_BibTeX_key_for=Gegenereerde_BibTeX-sleutel_voor
+Generated\ BibTeX\ key\ for=Gegenereerde BibTeX-sleutel voor
 
-Generating_BibTeX_key_for=BibTeX-sleutel_aan_het_genereren_voor
-Get_fulltext=
+Generating\ BibTeX\ key\ for=BibTeX-sleutel aan het genereren voor
+Get\ fulltext=
 
-Gray_out_non-hits=Maak_niet_gevonden_items_grijs
+Gray\ out\ non-hits=Maak niet gevonden items grijs
 
 Groups=Groepen
 
-Have_you_chosen_the_correct_package_path?=Heeft_u_het_correcte_pakket_pad_gekozen?
+Have\ you\ chosen\ the\ correct\ package\ path?=Heeft u het correcte pakket pad gekozen?
 
 Help=Help
 
-Help_on_key_patterns=Help_over_sleutelpatronen
-Help_on_regular_expression_search=Help_over_Regular_Expression_Zoekopdracht
+Help\ on\ key\ patterns=Help over sleutelpatronen
+Help\ on\ regular\ expression\ search=Help over Regular Expression Zoekopdracht
 
-Hide_non-hits=Verberg_niet_gevonden_objecten
+Hide\ non-hits=Verberg niet gevonden objecten
 
-Hierarchical_context=Hi\u00ebrarchische_context
+Hierarchical\ context=Hi\u00ebrarchische context
 
 Highlight=Markeren
 Marking=
 Underline=
-Empty_Highlight=
-Empty_Marking=
-Empty_Underline=
-The_marked_area_does_not_contain_any_legible_text!=
+Empty\ Highlight=
+Empty\ Marking=
+Empty\ Underline=
+The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=
 
-Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>=Hint\:_Om_specifieke_velden_alleen_te_zoeken,_geef_bijvoorbeeld_in\:<p><tt>auteur\=smith_en_titel\=electrical</tt>
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Hint: Om specifieke velden alleen te zoeken, geef bijvoorbeeld in:<p><tt>auteur=smith en titel=electrical</tt>
 
-HTML_table=HTML_tabel
-HTML_table_(with_Abstract_&_BibTeX)=HTML_tabel_(met_Abstract_&_BibTeX)
+HTML\ table=HTML tabel
+HTML\ table\ (with\ Abstract\ &\ BibTeX)=HTML tabel (met Abstract & BibTeX)
 Icon=
 
 Ignore=Negeren
 
 Import=Importeren
 
-Import_and_keep_old_entry=Importeren_en_oude_entry_behouden
+Import\ and\ keep\ old\ entry=Importeren en oude entry behouden
 
-Import_and_remove_old_entry=Importeren_en_oude_entry_verwijderen
+Import\ and\ remove\ old\ entry=Importeren en oude entry verwijderen
 
-Import_entries=Importeer_entries
+Import\ entries=Importeer entries
 
-Import_failed=Importering_mislukt
+Import\ failed=Importering mislukt
 
-Import_file=Importeer_bestand
+Import\ file=Importeer bestand
 
-Import_group_definitions=Importeer_groep_definities
+Import\ group\ definitions=Importeer groep definities
 
-Import_name=Importeer_naam
+Import\ name=Importeer naam
 
-Import_preferences=Instellingen_importeren
+Import\ preferences=Instellingen importeren
 
-Import_preferences_from_file=Importeer_instellingen_van_bestand
+Import\ preferences\ from\ file=Importeer instellingen van bestand
 
-Import_strings=Importeer_constanten
+Import\ strings=Importeer constanten
 
-Import_to_open_tab=Importeer_naar_open_tabblad
+Import\ to\ open\ tab=Importeer naar open tabblad
 
-Import_word_selector_definitions=Importeer_woordselecteerder_definities
+Import\ word\ selector\ definitions=Importeer woordselecteerder definities
 
-Imported_entries=Ge\u00efmporteerde_entries
+Imported\ entries=Ge\u00efmporteerde entries
 
-Imported_from_library=Ge\u00efmporteerd_van_library
+Imported\ from\ library=Ge\u00efmporteerd van library
 
-Importer_class=Importer_Klasse
+Importer\ class=Importer Klasse
 
-Importing=Aan_het_importeren
+Importing=Aan het importeren
 
-Importing_in_unknown_format=Aan_het_Importeren_in_onbekend_formaat
+Importing\ in\ unknown\ format=Aan het Importeren in onbekend formaat
 
-Include_abstracts=Abstracts_insluiten
-Include_entries=Entries_insluiten
+Include\ abstracts=Abstracts insluiten
+Include\ entries=Entries insluiten
 
-Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups=Subgroepen_insluiten\:_Wanneer_geselecteerd,_toon_entries_in_deze_groep_of_in_zijn_subgroepen
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=Subgroepen insluiten: Wanneer geselecteerd, toon entries in deze groep of in zijn subgroepen
 
-Independent_group\:_When_selected,_view_only_this_group's_entries=Onafhankelijke_groep\:_Wanneer_geselecteerd,_toon_enkel_de_entries_van_deze_groep
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=Onafhankelijke groep: Wanneer geselecteerd, toon enkel de entries van deze groep
 
-Work_options=
+Work\ options=
 
 Insert=Invoegen
 
-Insert_rows=Rijen_invoegen
+Insert\ rows=Rijen invoegen
 
 Intersection=Doorsnede
 
-Invalid_BibTeX_key=Ongeldige_BibTeX-sleutel
+Invalid\ BibTeX\ key=Ongeldige BibTeX-sleutel
 
-Invalid_date_format=Ongeldig_datumformaat
+Invalid\ date\ format=Ongeldig datumformaat
 
-Invalid_URL=Ongeldige_URL
+Invalid\ URL=Ongeldige URL
 
-Online_help=
+Online\ help=
 
-JabRef_preferences=JabRef_instellingen
+JabRef\ preferences=JabRef instellingen
 
 Join=
 
-Joins_selected_keywords_and_deletes_selected_keywords.=
+Joins\ selected\ keywords\ and\ deletes\ selected\ keywords.=
 
-Journal_abbreviations=Tijdschrift_afkortingen
+Journal\ abbreviations=Tijdschrift afkortingen
 
 Keep=Behouden
 
-Keep_both=Beide_behouden
+Keep\ both=Beide behouden
 
-Key_bindings=Sleutel_koppelingen
+Key\ bindings=Sleutel koppelingen
 
-Key_bindings_changed=Sleutel_koppelingen_gewijzigd
+Key\ bindings\ changed=Sleutel koppelingen gewijzigd
 
-Key_generator_settings=Sleutelgenerator_instellingen
+Key\ generator\ settings=Sleutelgenerator instellingen
 
-Key_pattern=Sleutelpatroon
+Key\ pattern=Sleutelpatroon
 
-keys_in_library=sleutels_in_library
+keys\ in\ library=sleutels in library
 
 Keyword=Sleutelwoord
 
@@ -693,449 +693,449 @@ Label=Label
 
 Language=Taal
 
-Last_modified=Laatst_gewijzigd
+Last\ modified=Laatst gewijzigd
 
-LaTeX_AUX_file=LaTeX_AUX-bestand
-Leave_file_in_its_current_directory=
+LaTeX\ AUX\ file=LaTeX AUX-bestand
+Leave\ file\ in\ its\ current\ directory=
 
 Left=Links
 Level=
 
-Limit_to_fields=De_volgende_velden_begrenzen
+Limit\ to\ fields=De volgende velden begrenzen
 
-Limit_to_selected_entries=De_volgende_geselecteerde_entries_begrenzen
+Limit\ to\ selected\ entries=De volgende geselecteerde entries begrenzen
 
 Link=
-Link_local_file=
-Link_to_file_%0=
+Link\ local\ file=
+Link\ to\ file\ %0=
 
-Listen_for_remote_operation_on_port=Luister_naar_operatie_vanop_afstand_op_poort
-Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)=
+Listen\ for\ remote\ operation\ on\ port=Luister naar operatie vanop afstand op poort
+Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=
 
-Look_and_feel="Look_and_feel"
-Main_file_directory=
+Look\ and\ feel="Look and feel"
+Main\ file\ directory=
 
-Main_layout_file=Hoofd_layoutbestand
+Main\ layout\ file=Hoofd layoutbestand
 
-Manage_custom_exports=Beheer_externe_exportfilters
+Manage\ custom\ exports=Beheer externe exportfilters
 
-Manage_custom_imports=Beheer_externe_importfilters
-Manage_external_file_types=
+Manage\ custom\ imports=Beheer externe importfilters
+Manage\ external\ file\ types=
 
-Mark_entries=Markeer_entries
+Mark\ entries=Markeer entries
 
-Mark_entry=Markeer_entry
+Mark\ entry=Markeer entry
 
-Mark_new_entries_with_addition_date=Markeer_nieuwe_entries_met_datum_van_toevoeging
+Mark\ new\ entries\ with\ addition\ date=Markeer nieuwe entries met datum van toevoeging
 
-Mark_new_entries_with_owner_name=Markeer_nieuwe_entries_met_naam_van_eigenaar
+Mark\ new\ entries\ with\ owner\ name=Markeer nieuwe entries met naam van eigenaar
 
-Memory_stick_mode=
+Memory\ stick\ mode=
 
-Menu_and_label_font_size=Menu_en_label_lettertypegrootte
+Menu\ and\ label\ font\ size=Menu en label lettertypegrootte
 
-Merged_external_changes=Voeg_externe_veranderingen_samen
+Merged\ external\ changes=Voeg externe veranderingen samen
 
 Messages=Berichten
 
-Modification_of_field=Wijziging_van_veld
+Modification\ of\ field=Wijziging van veld
 
-Modified_group_"%0".=Gewijzigde_groep_"%0".
+Modified\ group\ "%0".=Gewijzigde groep "%0".
 
-Modified_groups=Gewijzigde_groepen
+Modified\ groups=Gewijzigde groepen
 
-Modified_string=Gewijzigde_constante
+Modified\ string=Gewijzigde constante
 
 Modify=Wijzigen
 
-modify_group=wijzig_groep
+modify\ group=wijzig groep
 
-Move_down=Verplaats_naar_beneden
+Move\ down=Verplaats naar beneden
 
-Move_external_links_to_'file'_field=
+Move\ external\ links\ to\ 'file'\ field=
 
-move_group=verplaats_groep
+move\ group=verplaats groep
 
-Move_up=Verplaats_naar_boven
+Move\ up=Verplaats naar boven
 
-Moved_group_"%0".=Verplaatste_Groep_"%0".
+Moved\ group\ "%0".=Verplaatste Groep "%0".
 
 Name=Naam
-Name_formatter=
+Name\ formatter=
 
-Natbib_style=Natbib_stijl
+Natbib\ style=Natbib stijl
 
-nested_AUX_files=geneste_AUX_bestanden
+nested\ AUX\ files=geneste AUX bestanden
 
 New=Nieuw
 
 new=nieuw
 
-New_BibTeX_entry=Nieuwe_BibTeX-entry
+New\ BibTeX\ entry=Nieuwe BibTeX-entry
 
-New_BibTeX_sublibrary=Nieuwe_BibTeX_sublibrary
+New\ BibTeX\ sublibrary=Nieuwe BibTeX sublibrary
 
-New_content=Nieuwe_inhoud
+New\ content=Nieuwe inhoud
 
-New_library_created.=Nieuwe_library_aangemaakt.
-New_%0_library=
-New_field_value=Nieuwe_veld_waarde
+New\ library\ created.=Nieuwe library aangemaakt.
+New\ %0\ library=
+New\ field\ value=Nieuwe veld waarde
 
-New_group=Nieuwe_groep
+New\ group=Nieuwe groep
 
-New_string=Nieuwe_constante
+New\ string=Nieuwe constante
 
-Next_entry=Volgende_entry
+Next\ entry=Volgende entry
 
-No_actual_changes_found.=Geen_actuele_veranderingen_gevonden.
+No\ actual\ changes\ found.=Geen actuele veranderingen gevonden.
 
-no_base-BibTeX-file_specified=Geen_basis_BibTeX-bestand_gespecifieerd
+no\ base-BibTeX-file\ specified=Geen basis BibTeX-bestand gespecifieerd
 
-no_library_generated=Geen_library_gegenereerd
+no\ library\ generated=Geen library gegenereerd
 
-No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.=Geen_entries_gevonden._Zorg_er_a.u.b._voor_dat_u_de_juiste_importfilter_gebruikt.
+No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=Geen entries gevonden. Zorg er a.u.b. voor dat u de juiste importfilter gebruikt.
 
 
-No_entries_found_for_the_search_string_'%0'=
+No\ entries\ found\ for\ the\ search\ string\ '%0'=
 
-No_entries_imported.=Geen_entries_ge\u00efmporteerd.
+No\ entries\ imported.=Geen entries ge\u00efmporteerd.
 
-No_files_found.=
+No\ files\ found.=
 
-No_GUI._Only_process_command_line_options.=Geen_GUI._Alleen_proces_commandoregel_opties.
+No\ GUI.\ Only\ process\ command\ line\ options.=Geen GUI. Alleen proces commandoregel opties.
 
-No_journal_names_could_be_abbreviated.=Er_konden_geen_tijdschrift_namen_afgekort_worden.
+No\ journal\ names\ could\ be\ abbreviated.=Er konden geen tijdschrift namen afgekort worden.
 
-No_journal_names_could_be_unabbreviated.=Geen_afkortingen_van_tijdschrift_namen_konden_ongedaan_gemaakt_worden.
-No_PDF_linked=
+No\ journal\ names\ could\ be\ unabbreviated.=Geen afkortingen van tijdschrift namen konden ongedaan gemaakt worden.
+No\ PDF\ linked=
 
-Open_PDF=
+Open\ PDF=
 
-No_URL_defined=Geen_URL_gedefinieerd
+No\ URL\ defined=Geen URL gedefinieerd
 not=niet
 
-not_found=niet_gevonden
+not\ found=niet gevonden
 
-Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,=Merk_op_dat_u_de_volledig_gekwalificeerde_klassenaam_voor_de_"look_and_feel"_moet_specificeren,
+Note\ that\ you\ must\ specify\ the\ fully\ qualified\ class\ name\ for\ the\ look\ and\ feel,=Merk op dat u de volledig gekwalificeerde klassenaam voor de "look and feel" moet specificeren,
 
-Nothing_to_redo=Niets_om_te_herstellen
+Nothing\ to\ redo=Niets om te herstellen
 
-Nothing_to_undo=Niets_om_ongedaan_te_maken
+Nothing\ to\ undo=Niets om ongedaan te maken
 
 occurrences=voorkomens
 
 OK=OK
-One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=
+One\ or\ more\ file\ links\ are\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=
 
-One_or_more_keys_will_be_overwritten._Continue?=E\u00e9n_of_meerdere_sleutels_zullen_overschreven_worden._Verder_gaan?
+One\ or\ more\ keys\ will\ be\ overwritten.\ Continue?=E\u00e9n of meerdere sleutels zullen overschreven worden. Verder gaan?
 
 
 Open=Openen
 
-Open_BibTeX_library=Open_BibTeX-library
+Open\ BibTeX\ library=Open BibTeX-library
 
-Open_library=Open_library
+Open\ library=Open library
 
-Open_editor_when_a_new_entry_is_created=Open_editor_wanneer_een_nieuwe_entry_aangemaakt_werd
+Open\ editor\ when\ a\ new\ entry\ is\ created=Open editor wanneer een nieuwe entry aangemaakt werd
 
-Open_file=Open_bestand
+Open\ file=Open bestand
 
-Open_last_edited_libraries_at_startup=Open_laatst_aangepaste_libraries_bij_het_opstarten
+Open\ last\ edited\ libraries\ at\ startup=Open laatst aangepaste libraries bij het opstarten
 
-Connect_to_shared_database=
+Connect\ to\ shared\ database=
 
-Open_terminal_here=
+Open\ terminal\ here=
 
-Open_URL_or_DOI=Open_URL_of_DOI
+Open\ URL\ or\ DOI=Open URL of DOI
 
-Opened_library=Geopende_library
+Opened\ library=Geopende library
 
-Opening=Aan_het_openen
+Opening=Aan het openen
 
-Opening_preferences...=Instellingen_aan_het_openen
+Opening\ preferences...=Instellingen aan het openen
 
-Operation_canceled.=Operatie_geannuleerd.
-Operation_not_supported=
+Operation\ canceled.=Operatie geannuleerd.
+Operation\ not\ supported=
 
-Optional_fields=Optionele_velden
+Optional\ fields=Optionele velden
 
 Options=Opties
 
 or=of
 
-Output_or_export_file=Geef_uitvoer_of_exporteer_bestand
+Output\ or\ export\ file=Geef uitvoer of exporteer bestand
 
 Override=Wijzigen
 
-Override_default_file_directories=Wijzig_standaard_bestandsmappen
+Override\ default\ file\ directories=Wijzig standaard bestandsmappen
 
-Override_default_font_settings=Wijzig_standaard_lettertypeinstellingen
+Override\ default\ font\ settings=Wijzig standaard lettertypeinstellingen
 
-Override_the_BibTeX_field_by_the_selected_text=Wijzig_de_BibTeX-sleutel_door_de_geselecteerde_tekst
+Override\ the\ BibTeX\ field\ by\ the\ selected\ text=Wijzig de BibTeX-sleutel door de geselecteerde tekst
 
 
 Overwrite=
-Overwrite_existing_field_values=Overschrijf_bestaande_veld_waarden
+Overwrite\ existing\ field\ values=Overschrijf bestaande veld waarden
 
-Overwrite_keys=Overschrijf_sleutels
+Overwrite\ keys=Overschrijf sleutels
 
-pairs_processed=paren_verwerkt
+pairs\ processed=paren verwerkt
 Password=
 
 Paste=Plakken
 
-paste_entries=plak_entries
+paste\ entries=plak entries
 
-paste_entry=plak_entry
-Paste_from_clipboard=
+paste\ entry=plak entry
+Paste\ from\ clipboard=
 
 Pasted=Geplakt
 
-Path_to_%0_not_defined=
+Path\ to\ %0\ not\ defined=
 
-Path_to_LyX_pipe=Pad_naar_LyX-pipe
+Path\ to\ LyX\ pipe=Pad naar LyX-pipe
 
-PDF_does_not_exist=
+PDF\ does\ not\ exist=
 
-File_has_no_attached_annotations=
+File\ has\ no\ attached\ annotations=
 
-Plain_text_import=Onopgemaakte_tekst_importeren
+Plain\ text\ import=Onopgemaakte tekst importeren
 
-Please_enter_a_name_for_the_group.=Geef_a.u.b._een_naam_voor_de_groep.
+Please\ enter\ a\ name\ for\ the\ group.=Geef a.u.b. een naam voor de groep.
 
-Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>=Geef_a.u.b._een_zoekterm._Bijvoorbeeld,_om_alle_velden_te_doorzoeken_naar_<b>Smith</b>,_geef_in\:\:<p><tt>smith</tt><p>Om_het_veld_<b>Author</b>_te_doorzoeken_naar_<b>Smith</b>_en_het_veld_<b>Title</b>_naar_<b>electrical</b>,_geef_in\:\:<p><tt>author\=smith_and_title\=electrical</tt>
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Geef a.u.b. een zoekterm. Bijvoorbeeld, om alle velden te doorzoeken naar <b>Smith</b>, geef in::<p><tt>smith</tt><p>Om het veld <b>Author</b> te doorzoeken naar <b>Smith</b> en het veld <b>Title</b> naar <b>electrical</b>, geef in::<p><tt>author=smith and title=electrical</tt>
 
-Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=Geef_a.u.b._het_veld_om_te_doorzoeken_(bv._<b>keywords</b>)_en_het_sleutelword_om_naar_te_zoeken_(bv._<b>electrical</b>).
+Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=Geef a.u.b. het veld om te doorzoeken (bv. <b>keywords</b>) en het sleutelword om naar te zoeken (bv. <b>electrical</b>).
 
-Please_enter_the_string's_label=Geef_a.u.b._het_label_van_de_constante_in
+Please\ enter\ the\ string's\ label=Geef a.u.b. het label van de constante in
 
-Please_select_an_importer.=Selecteer_a.u.b._een_importer.
+Please\ select\ an\ importer.=Selecteer a.u.b. een importer.
 
-Possible_duplicate_entries=Mogelijke_dubbele_entries
+Possible\ duplicate\ entries=Mogelijke dubbele entries
 
-Possible_duplicate_of_existing_entry._Click_to_resolve.=Mogelijk_duplicaat_van_bestaande_entry.
+Possible\ duplicate\ of\ existing\ entry.\ Click\ to\ resolve.=Mogelijk duplicaat van bestaande entry.
 
 Preamble=Inleiding
 
 Preferences=Instellingen
 
-Preferences_recorded.=Instellingen_opgeslagen.
+Preferences\ recorded.=Instellingen opgeslagen.
 
 Preview=Voorbeeld
-Citation_Style=
-Current_Preview=
-Cannot_generate_preview_based_on_selected_citation_style.=
-Bad_character_inside_entry=
-Error_while_generating_citation_style=
-Preview_style_changed_to\:_%0=
-Next_preview_layout=
-Previous_preview_layout=
+Citation\ Style=
+Current\ Preview=
+Cannot\ generate\ preview\ based\ on\ selected\ citation\ style.=
+Bad\ character\ inside\ entry=
+Error\ while\ generating\ citation\ style=
+Preview\ style\ changed\ to\:\ %0=
+Next\ preview\ layout=
+Previous\ preview\ layout=
 
-Previous_entry=Vorige_entry
+Previous\ entry=Vorige entry
 
-Primary_sort_criterion=Primair_sorteercriterium
-Problem_with_parsing_entry=Probleem_met_entry_ontleding
-Processing_%0=
-Pull_changes_from_shared_database=
+Primary\ sort\ criterion=Primair sorteercriterium
+Problem\ with\ parsing\ entry=Probleem met entry ontleding
+Processing\ %0=
+Pull\ changes\ from\ shared\ database=
 
-Pushed_citations_to_%0=
+Pushed\ citations\ to\ %0=
 
-Quit_JabRef=JabRef_afsluiten
+Quit\ JabRef=JabRef afsluiten
 
-Quit_synchronization=Synchronisatie_afsluiten
+Quit\ synchronization=Synchronisatie afsluiten
 
-Raw_source=Ruwe_bron
+Raw\ source=Ruwe bron
 
-Rearrange_tabs_alphabetically_by_title=Rangschik_tabbladen_alfabetisch_op_titel
+Rearrange\ tabs\ alphabetically\ by\ title=Rangschik tabbladen alfabetisch op titel
 
 Redo=Herstellen
 
-Reference_library=Referentie_library
+Reference\ library=Referentie library
 
-%0_references_found._Number_of_references_to_fetch?=Referenties_gevonden\:_%0._Aantal_referenties_om_op_te_halen?
+%0\ references\ found.\ Number\ of\ references\ to\ fetch?=Referenties gevonden: %0. Aantal referenties om op te halen?
 
-Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Verfijn_supergroep\:_Wanneer_geselecteerd,_toon_de_entries_die_in_deze_groep_en_zijn_supergroep_zitten
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=Verfijn supergroep: Wanneer geselecteerd, toon de entries die in deze groep en zijn supergroep zitten
 
-regular_expression=Regular_Expression
+regular\ expression=Regular Expression
 
-Related_articles=
+Related\ articles=
 
-Remote_operation=Externe_operatie
+Remote\ operation=Externe operatie
 
-Remote_server_port=Externe_server_poort
+Remote\ server\ port=Externe server poort
 
 Remove=Verwijderen
 
-Remove_subgroups=Verwijder_alle_subgroepen
+Remove\ subgroups=Verwijder alle subgroepen
 
-Remove_all_subgroups_of_"%0"?=Alle_subgroepen_van_"%0"_verwijderen?
+Remove\ all\ subgroups\ of\ "%0"?=Alle subgroepen van "%0" verwijderen?
 
-Remove_entry_from_import=Verwijder_entry_uit_importering
+Remove\ entry\ from\ import=Verwijder entry uit importering
 
-Remove_selected_entries_from_this_group=
+Remove\ selected\ entries\ from\ this\ group=
 
-Remove_entry_type=Verwijder_entry_type
+Remove\ entry\ type=Verwijder entry type
 
-Remove_from_group=Verwijder_uit_groep
+Remove\ from\ group=Verwijder uit groep
 
-Remove_group=Verwijder_groep
+Remove\ group=Verwijder groep
 
-Remove_group,_keep_subgroups=Verwijder_groep,_behoud_subgroepen
+Remove\ group,\ keep\ subgroups=Verwijder groep, behoud subgroepen
 
-Remove_group_"%0"?=Verwijder_groep_"%0"?
+Remove\ group\ "%0"?=Verwijder groep "%0"?
 
-Remove_group_"%0"_and_its_subgroups?=Verwijder_groep_"%0"_en_zijn_subgroepen?
+Remove\ group\ "%0"\ and\ its\ subgroups?=Verwijder groep "%0" en zijn subgroepen?
 
-remove_group_(keep_subgroups)=verwijder_groep_(behoud_subgroepen)
+remove\ group\ (keep\ subgroups)=verwijder groep (behoud subgroepen)
 
-remove_group_and_subgroups=verwijder_groep_en_subgroepen
+remove\ group\ and\ subgroups=verwijder groep en subgroepen
 
-Remove_group_and_subgroups=Verwijder_groep_en_subgroepen
+Remove\ group\ and\ subgroups=Verwijder groep en subgroepen
 
-Remove_link=
+Remove\ link=
 
-Remove_old_entry=Verwijder_oude_entry
+Remove\ old\ entry=Verwijder oude entry
 
-Remove_selected_strings=Verwijder_geselecteerde_entries
+Remove\ selected\ strings=Verwijder geselecteerde entries
 
-Removed_group_"%0".=Groep_"%0"_verwijderd.
+Removed\ group\ "%0".=Groep "%0" verwijderd.
 
-Removed_group_"%0"_and_its_subgroups.=Groep_"%0"_en_zijn_subgroepen_verwijderd.
+Removed\ group\ "%0"\ and\ its\ subgroups.=Groep "%0" en zijn subgroepen verwijderd.
 
-Removed_string=Constante_verwijderd
+Removed\ string=Constante verwijderd
 
-Renamed_string=Constante_hernoemd
+Renamed\ string=Constante hernoemd
 
 Replace=
 
-Replace_(regular_expression)=Vervang_(regular_expression)
+Replace\ (regular\ expression)=Vervang (regular expression)
 
-Replace_string=Tekst_vervangen
+Replace\ string=Tekst vervangen
 
-Replace_with=Vervang_door
+Replace\ with=Vervang door
 
 Replaced=Vervangen
 
-Required_fields=Vereiste_velden
+Required\ fields=Vereiste velden
 
-Reset_all=Herstel_alles
+Reset\ all=Herstel alles
 
-Resolve_strings_for_all_fields_except=
-Resolve_strings_for_standard_BibTeX_fields_only=
+Resolve\ strings\ for\ all\ fields\ except=
+Resolve\ strings\ for\ standard\ BibTeX\ fields\ only=
 
 resolved=opgelost
 
 Review=Recensie
 
-Review_changes=Bekijk_veranderingen
+Review\ changes=Bekijk veranderingen
 
 Right=Rechts
 
 Save=Opslaan
-Save_all_finished.=
+Save\ all\ finished.=
 
-Save_all_open_libraries=
+Save\ all\ open\ libraries=
 
-Save_before_closing=Opslaan_voor_afsluiten
+Save\ before\ closing=Opslaan voor afsluiten
 
-Save_library=Library_opslaan
-Save_library_as...=Library_opslaan_als_...
+Save\ library=Library opslaan
+Save\ library\ as...=Library opslaan als ...
 
-Save_entries_in_their_original_order=Sla_entries_in_hun_originele_volgorde_op
+Save\ entries\ in\ their\ original\ order=Sla entries in hun originele volgorde op
 
-Save_failed=Opslaan_mislukt
+Save\ failed=Opslaan mislukt
 
-Save_failed_during_backup_creation=Opslaan_mislukt_tijdens_creatie_van_backup
+Save\ failed\ during\ backup\ creation=Opslaan mislukt tijdens creatie van backup
 
-Save_selected_as...=Sla_geselecteerde_op_als_...
+Save\ selected\ as...=Sla geselecteerde op als ...
 
-Saved_library=Library_opgeslagen
+Saved\ library=Library opgeslagen
 
-Saved_selected_to_'%0'.=Geselecteerde_opgeslagen_naar_'%0'.
+Saved\ selected\ to\ '%0'.=Geselecteerde opgeslagen naar '%0'.
 
-Saving=Aan_het_opslaan
-Saving_all_libraries...=
+Saving=Aan het opslaan
+Saving\ all\ libraries...=
 
-Saving_library=Library_aan_het_opslaan
+Saving\ library=Library aan het opslaan
 
 Search=Zoeken
 
-Search_expression=Zoek_expressie
+Search\ expression=Zoek expressie
 
-Search_for=Zoek_naar
+Search\ for=Zoek naar
 
-Searching_for_duplicates...=Aan_het_zoeken_naar_dubbels
+Searching\ for\ duplicates...=Aan het zoeken naar dubbels
 
-Searching_for_files=
+Searching\ for\ files=
 
-Secondary_sort_criterion=Secundair_sorteercriterium
+Secondary\ sort\ criterion=Secundair sorteercriterium
 
-Select_all=Alles_selecteren
+Select\ all=Alles selecteren
 
-Select_encoding=Selecteer_encodering
+Select\ encoding=Selecteer encodering
 
-Select_entry_type=Selecteer_entry_type
-Select_external_application=Selecteer_externe_applicatie
+Select\ entry\ type=Selecteer entry type
+Select\ external\ application=Selecteer externe applicatie
 
-Select_file_from_ZIP-archive=Selecteer_bestand_van_ZIP-archief
+Select\ file\ from\ ZIP-archive=Selecteer bestand van ZIP-archief
 
-Select_the_tree_nodes_to_view_and_accept_or_reject_changes=Selecteer_de_boom_knopen_om_veranderingen_te_tonen_en_te_accepteren_of_afwijzen
-Selected_entries=Geselecteerde_entries
-Set_field=Veld_instellen
-Set_fields=Velden_instellen
+Select\ the\ tree\ nodes\ to\ view\ and\ accept\ or\ reject\ changes=Selecteer de boom knopen om veranderingen te tonen en te accepteren of afwijzen
+Selected\ entries=Geselecteerde entries
+Set\ field=Veld instellen
+Set\ fields=Velden instellen
 
-Set_general_fields=Algemene_velden_instellen
-Set_main_external_file_directory=
+Set\ general\ fields=Algemene velden instellen
+Set\ main\ external\ file\ directory=
 
-Set_table_font=Tabel_lettertype_instellen
+Set\ table\ font=Tabel lettertype instellen
 
 Settings=Instellingen
 
 Shortcut=Snelkoppeling
 
-Show/edit_%0_source=Toon/bewerk_%0-broncode
+Show/edit\ %0\ source=Toon/bewerk %0-broncode
 
-Show_'Firstname_Lastname'=Toon_'Voornaam_Familienaam'
+Show\ 'Firstname\ Lastname'=Toon 'Voornaam Familienaam'
 
-Show_'Lastname,_Firstname'=Toon_'Familienaam,_Voornaam'
+Show\ 'Lastname,\ Firstname'=Toon 'Familienaam, Voornaam'
 
-Show_BibTeX_source_by_default=Toon_standaard_BibTeX-broncode
+Show\ BibTeX\ source\ by\ default=Toon standaard BibTeX-broncode
 
-Show_confirmation_dialog_when_deleting_entries=Toon_bevestigingsdialoog_bij_verwijderen_van_entries
+Show\ confirmation\ dialog\ when\ deleting\ entries=Toon bevestigingsdialoog bij verwijderen van entries
 
-Show_description=Toon_beschrijving
+Show\ description=Toon beschrijving
 
-Show_file_column=
+Show\ file\ column=
 
-Show_last_names_only=Toon_enkel_laatste_namen
+Show\ last\ names\ only=Toon enkel laatste namen
 
-Show_names_unchanged=Toon_namen_onveranderd
+Show\ names\ unchanged=Toon namen onveranderd
 
-Show_optional_fields=Toon_optionele_velden
+Show\ optional\ fields=Toon optionele velden
 
-Show_required_fields=Toon_vereiste_velden
+Show\ required\ fields=Toon vereiste velden
 
-Show_URL/DOI_column=Toon_URL/DOI-kolom
+Show\ URL/DOI\ column=Toon URL/DOI-kolom
 
-Simple_HTML=Eenvoudige_HTML
+Simple\ HTML=Eenvoudige HTML
 
 Size=Grootte
 
-Skipped_-_No_PDF_linked=Overgeslagen_-_Geen_PDF_gelinkt
-Skipped_-_PDF_does_not_exist=Overgeslagen_-_PDF_bestaat_niet
+Skipped\ -\ No\ PDF\ linked=Overgeslagen - Geen PDF gelinkt
+Skipped\ -\ PDF\ does\ not\ exist=Overgeslagen - PDF bestaat niet
 
-Skipped_entry.=Overgeslagen_entry.
+Skipped\ entry.=Overgeslagen entry.
 
-Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.=
+Some\ appearance\ settings\ you\ changed\ require\ to\ restart\ JabRef\ to\ come\ into\ effect.=
 
-source_edit=broncode_aanpassen
-Special_name_formatters=
+source\ edit=broncode aanpassen
+Special\ name\ formatters=
 
-Special_table_columns=Speciale_tabelkolommen
+Special\ table\ columns=Speciale tabelkolommen
 
-Starting_import=Importeren_aan_het_starten
+Starting\ import=Importeren aan het starten
 
-Statically_group_entries_by_manual_assignment=Groepeer_entries_statisch_door_manuele_toekenning
+Statically\ group\ entries\ by\ manual\ assignment=Groepeer entries statisch door manuele toekenning
 
 Status=Status
 
@@ -1143,1019 +1143,1019 @@ Stop=Stop
 
 Strings=Constanten
 
-Strings_for_library=Constanten_voor_library
+Strings\ for\ library=Constanten voor library
 
-Sublibrary_from_AUX=Sublibrary_van_AUX
+Sublibrary\ from\ AUX=Sublibrary van AUX
 
-Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.=Schakelt_tussen_volledige_en_afgekorte_tijdschriftnaam_als_het_tijdschrift_gekend_is.
+Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=Schakelt tussen volledige en afgekorte tijdschriftnaam als het tijdschrift gekend is.
 
-Synchronize_file_links=
+Synchronize\ file\ links=
 
-Synchronizing_file_links...=Bestand_snelkoppelingen_aan_het_synchroniseren
+Synchronizing\ file\ links...=Bestand snelkoppelingen aan het synchroniseren
 
-Table_appearance=Tabel_uiterlijk
+Table\ appearance=Tabel uiterlijk
 
-Table_background_color=Tabel_achtergrondkleur
+Table\ background\ color=Tabel achtergrondkleur
 
-Table_grid_color=Tabel_roosterkleur
+Table\ grid\ color=Tabel roosterkleur
 
-Table_text_color=Tabel_tekstkleur
+Table\ text\ color=Tabel tekstkleur
 
-Tabname=Tabblad_naam
-Target_file_cannot_be_a_directory.=
+Tabname=Tabblad naam
+Target\ file\ cannot\ be\ a\ directory.=
 
-Tertiary_sort_criterion=Tertiair_sorteercriterium
+Tertiary\ sort\ criterion=Tertiair sorteercriterium
 
 Test=Test
 
-paste_text_here=Tekst_Invoer_Gebied
+paste\ text\ here=Tekst Invoer Gebied
 
-The_chosen_date_format_for_new_entries_is_not_valid=Het_gekozen_datumformaat_voor_nieuwe_entries_is_niet_geldig
+The\ chosen\ date\ format\ for\ new\ entries\ is\ not\ valid=Het gekozen datumformaat voor nieuwe entries is niet geldig
 
-The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:=
+The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=
 
 
-the_field_<b>%0</b>=het_veld_<b>%0</b>
+the\ field\ <b>%0</b>=het veld <b>%0</b>
 
-The_file<BR>'%0'<BR>has_been_modified<BR>externally\!=Het_bestand<BR>'%0'<BR>werd_extern_gewijzigd\!
+The\ file<BR>'%0'<BR>has\ been\ modified<BR>externally\!=Het bestand<BR>'%0'<BR>werd extern gewijzigd!
 
-The_group_"%0"_already_contains_the_selection.=De_groep_"%0"_bevat_reeds_de_selectie.
+The\ group\ "%0"\ already\ contains\ the\ selection.=De groep "%0" bevat reeds de selectie.
 
-The_label_of_the_string_cannot_be_a_number.=Het_label_van_een_constante_mag_geen_nummer_zijn.
+The\ label\ of\ the\ string\ cannot\ be\ a\ number.=Het label van een constante mag geen nummer zijn.
 
-The_label_of_the_string_cannot_contain_spaces.=Het_label_van_een_constante_mag_geen_spaties_bevatten.
+The\ label\ of\ the\ string\ cannot\ contain\ spaces.=Het label van een constante mag geen spaties bevatten.
 
-The_label_of_the_string_cannot_contain_the_'\#'_character.=Het_label_van_een_constante_mag_het_'\#'_teken_niet_bevatten.
+The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=Het label van een constante mag het '#' teken niet bevatten.
 
-The_output_option_depends_on_a_valid_import_option.=De_uitvoeroptie_is_afhankelijk_van_een_geldige_importeeroptie.
-The_PDF_contains_one_or_several_BibTeX-records.=
-Do_you_want_to_import_these_as_new_entries_into_the_current_library?=
+The\ output\ option\ depends\ on\ a\ valid\ import\ option.=De uitvoeroptie is afhankelijk van een geldige importeeroptie.
+The\ PDF\ contains\ one\ or\ several\ BibTeX-records.=
+Do\ you\ want\ to\ import\ these\ as\ new\ entries\ into\ the\ current\ library?=
 
-The_regular_expression_<b>%0</b>_is_invalid\:=De_regular_expression_<b>%0</b>_is_ongeldig\:
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=De regular expression <b>%0</b> is ongeldig:
 
-The_search_is_case_insensitive.=De_zoekopdracht_is_hoofdletterongevoelig.
+The\ search\ is\ case\ insensitive.=De zoekopdracht is hoofdletterongevoelig.
 
-The_search_is_case_sensitive.=De_zoekopdracht_is_hoofdlettergevoelig.
+The\ search\ is\ case\ sensitive.=De zoekopdracht is hoofdlettergevoelig.
 
-The_string_has_been_removed_locally=De_constante_werd_lokaal_verwijderd
+The\ string\ has\ been\ removed\ locally=De constante werd lokaal verwijderd
 
-There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?=Er_zijn_mogelijke_dubbels_(aangeduid_met_een_icoon)_die_nog_niet_opgelost_werden._Verdergaan?
+There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=Er zijn mogelijke dubbels (aangeduid met een icoon) die nog niet opgelost werden. Verdergaan?
 
-This_entry_has_no_BibTeX_key._Generate_key_now?=
+This\ entry\ has\ no\ BibTeX\ key.\ Generate\ key\ now?=
 
-This_entry_is_incomplete=Deze_entry_is_onvolledig
+This\ entry\ is\ incomplete=Deze entry is onvolledig
 
-This_entry_type_cannot_be_removed.=Dit_entry_type_kan_niet_verwijderd_worden.
+This\ entry\ type\ cannot\ be\ removed.=Dit entry type kan niet verwijderd worden.
 
-This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=
+This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=
 
-This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.=Deze_groep_bevat_entries_gebaseerd_op_manuele_toekenning._Entries_kunnen_aan_deze_groep_toegekend_worden_door_ze_te_selecteren_en_hierna_ofwel_"drag_and_drop"_of_het_contextmenu_te_gebruiken._Entries_kunnen_uit_deze_groep_verwijderd_worden_door_ze_te_selecteren_via_het_contextmenu.
+This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=Deze groep bevat entries gebaseerd op manuele toekenning. Entries kunnen aan deze groep toegekend worden door ze te selecteren en hierna ofwel "drag and drop" of het contextmenu te gebruiken. Entries kunnen uit deze groep verwijderd worden door ze te selecteren via het contextmenu.
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>=Deze_groep_bevat_entries_waarin_het_<b>%0</b>_veld_het_sleutelwoord_<b>%1</b>_bevat
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Deze groep bevat entries waarin het <b>%0</b> veld het sleutelwoord <b>%1</b> bevat
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>=Deze_groep_bevat_entries_waarin_het_<b>%0</b>_veld_de_regular_expression_<b>%1</b>_bevat
-This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.=Dit_zorgt_ervoor_dat_JabRef_elke_bestand_snelkoppeling_op_zoekt_en_controleert_of_het_bestand_bestaat._Indien_dit_niet_het_geval_is,_zullen_u_opties_gegeven_worden<BR>om_het_probleem_op_te_lossen.
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Deze groep bevat entries waarin het <b>%0</b> veld de regular expression <b>%1</b> bevat
+This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=Dit zorgt ervoor dat JabRef elke bestand snelkoppeling op zoekt en controleert of het bestand bestaat. Indien dit niet het geval is, zullen u opties gegeven worden<BR>om het probleem op te lossen.
 
-This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.=Deze_operatie_vereist_dat_alle_geselecteerde_entries_BibTeX-sleutels_gedefinieerd_hebben.
+This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=Deze operatie vereist dat alle geselecteerde entries BibTeX-sleutels gedefinieerd hebben.
 
-This_operation_requires_one_or_more_entries_to_be_selected.=Deze_operatie_vereist_dat_een_of_meer_entries_geselecteerd_zijn.
+This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=Deze operatie vereist dat een of meer entries geselecteerd zijn.
 
-Toggle_entry_preview=Toon_entry_voorbeeld
-Toggle_groups_interface=Toon_groepenvenster
-Try_different_encoding=Probeer_een_andere_encodering
+Toggle\ entry\ preview=Toon entry voorbeeld
+Toggle\ groups\ interface=Toon groepenvenster
+Try\ different\ encoding=Probeer een andere encodering
 
-Unabbreviate_journal_names_of_the_selected_entries=Maak_afkortingen_van_tijdschriftnamen_van_geselecteerde_entries_ongedaan
-Unabbreviated_%0_journal_names.=
+Unabbreviate\ journal\ names\ of\ the\ selected\ entries=Maak afkortingen van tijdschriftnamen van geselecteerde entries ongedaan
+Unabbreviated\ %0\ journal\ names.=
 
-Unable_to_open_file.=
-Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.=
-unable_to_write_to=kan_niet_schrijven_naar
-Undefined_file_type=
+Unable\ to\ open\ file.=
+Unable\ to\ open\ link.\ The\ application\ '%0'\ associated\ with\ the\ file\ type\ '%1'\ could\ not\ be\ called.=
+unable\ to\ write\ to=kan niet schrijven naar
+Undefined\ file\ type=
 
-Undo=Ongedaan_maken
+Undo=Ongedaan maken
 
 Union=Unie
 
-Unknown_BibTeX_entries=Onbekende_BibTeX-entries
+Unknown\ BibTeX\ entries=Onbekende BibTeX-entries
 
-unknown_edit=onbekende_aanpassing
+unknown\ edit=onbekende aanpassing
 
-Unknown_export_format=Onbekend_exporteerformaat
+Unknown\ export\ format=Onbekend exporteerformaat
 
-Unmark_all=Alle_markeringen_ongedaan_maken
+Unmark\ all=Alle markeringen ongedaan maken
 
-Unmark_entries=Alle_markeringen_van_entries_ongedaan_maken
+Unmark\ entries=Alle markeringen van entries ongedaan maken
 
-Unmark_entry=Markering_van_entry_ongedaan_maken
+Unmark\ entry=Markering van entry ongedaan maken
 
 untitled=naamloos
 
 Up=Omhoog
 
-Update_to_current_column_widths=Update_naar_huidige_kolombreedtes
+Update\ to\ current\ column\ widths=Update naar huidige kolombreedtes
 
-Updated_group_selection=Groep_selectie_geupdate
-Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.=
-Upgrade_file=
-Upgrade_old_external_file_links_to_use_the_new_feature=
+Updated\ group\ selection=Groep selectie geupdate
+Upgrade\ external\ PDF/PS\ links\ to\ use\ the\ '%0'\ field.=
+Upgrade\ file=
+Upgrade\ old\ external\ file\ links\ to\ use\ the\ new\ feature=
 
 usage=gebruik
-Use_autocompletion_for_the_following_fields=
+Use\ autocompletion\ for\ the\ following\ fields=
 
-Use_other_look_and_feel=Gebruik_andere_"look_and_feel"
-Tweak_font_rendering_for_entry_editor_on_Linux=
-Use_regular_expression_search=Gebruik_Regular_Expression_Zoekopdracht
+Use\ other\ look\ and\ feel=Gebruik andere "look and feel"
+Tweak\ font\ rendering\ for\ entry\ editor\ on\ Linux=
+Use\ regular\ expression\ search=Gebruik Regular Expression Zoekopdracht
 
 Username=
 
-Value_cleared_externally=Waarde_extern_gewist
+Value\ cleared\ externally=Waarde extern gewist
 
-Value_set_externally=Waarde_extern_ingesteld
+Value\ set\ externally=Waarde extern ingesteld
 
-verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid=verifieer_dat_LyX_draait_en_dat_de_lyxpipe_geldig_is
+verify\ that\ LyX\ is\ running\ and\ that\ the\ lyxpipe\ is\ valid=verifieer dat LyX draait en dat de lyxpipe geldig is
 
 View=Beeld
-Vim_server_name=
+Vim\ server\ name=
 
-Waiting_for_ArXiv...=
+Waiting\ for\ ArXiv...=
 
-Warn_about_unresolved_duplicates_when_closing_inspection_window=Waarschuw_bij_onopgeloste_dubbels_bij_het_sluiten_van_het_inspectievenster
+Warn\ about\ unresolved\ duplicates\ when\ closing\ inspection\ window=Waarschuw bij onopgeloste dubbels bij het sluiten van het inspectievenster
 
-Warn_before_overwriting_existing_keys=Waarschuwing_v\u00f3\u00f3r_het_overschrijven_van_bestaande_sleutels
+Warn\ before\ overwriting\ existing\ keys=Waarschuwing v\u00f3\u00f3r het overschrijven van bestaande sleutels
 
 Warning=Waarschuwing
 
 Warnings=Waarschuwingen
 
-web_link=web-link
+web\ link=web-link
 
-What_do_you_want_to_do?=Wat_wilt_u_doen?
+What\ do\ you\ want\ to\ do?=Wat wilt u doen?
 
-When_adding/removing_keywords,_separate_them_by=Wanneer_u_sleutelwoorden_toevoegt/verwijdert,_scheid_ze_dan_door
-Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.=Zal_XMP_metadata_naar_de_PDFs_gelinkt_vanuit_geselecteerde_entries_schrijven.
+When\ adding/removing\ keywords,\ separate\ them\ by=Wanneer u sleutelwoorden toevoegt/verwijdert, scheid ze dan door
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Zal XMP metadata naar de PDFs gelinkt vanuit geselecteerde entries schrijven.
 
 with=met
 
-Write_BibTeXEntry_as_XMP-metadata_to_PDF.=Schrijf_BibTeX-entry_als_XMP-metadata_naar_PDF.
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Schrijf BibTeX-entry als XMP-metadata naar PDF.
 
-Write_XMP=Schrijf_XMP
-Write_XMP-metadata=
-Write_XMP-metadata_for_all_PDFs_in_current_library?=
-Writing_XMP-metadata...=XMP_metadata_aan_het_schrijven...
-Writing_XMP-metadata_for_selected_entries...=XMP_metadata_voor_geselecteerde_entries_aan_het_schrijven...
+Write\ XMP=Schrijf XMP
+Write\ XMP-metadata=
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=
+Writing\ XMP-metadata...=XMP metadata aan het schrijven...
+Writing\ XMP-metadata\ for\ selected\ entries...=XMP metadata voor geselecteerde entries aan het schrijven...
 
-Wrote_XMP-metadata=
+Wrote\ XMP-metadata=
 
-XMP-annotated_PDF=XMP_geannoteerde_PDF
-XMP_export_privacy_settings=
-XMP-metadata=XMP_metadata
-XMP-metadata_found_in_PDF\:_%0=
-You_must_restart_JabRef_for_this_to_come_into_effect.=U_moet_JabRef_herstarten_om_dit_toe_te_passen.
-You_have_changed_the_language_setting.=U_heeft_de_taalinstelling_veranderd.
-You_have_entered_an_invalid_search_'%0'.=
+XMP-annotated\ PDF=XMP geannoteerde PDF
+XMP\ export\ privacy\ settings=
+XMP-metadata=XMP metadata
+XMP-metadata\ found\ in\ PDF\:\ %0=
+You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=U moet JabRef herstarten om dit toe te passen.
+You\ have\ changed\ the\ language\ setting.=U heeft de taalinstelling veranderd.
+You\ have\ entered\ an\ invalid\ search\ '%0'.=
 
-You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.=U_moet_JabRef_herstarten_zodat_de_nieuwe_sneltoetsen_correct_kunnen_werken.
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=U moet JabRef herstarten zodat de nieuwe sneltoetsen correct kunnen werken.
 
-Your_new_key_bindings_have_been_stored.=Uw_nieuwe_sneltoetsen_zijn_opgeslagen.
+Your\ new\ key\ bindings\ have\ been\ stored.=Uw nieuwe sneltoetsen zijn opgeslagen.
 
-The_following_fetchers_are_available\:=
-Could_not_find_fetcher_'%0'=
-Running_query_'%0'_with_fetcher_'%1'.=
-Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.=
+The\ following\ fetchers\ are\ available\:=
+Could\ not\ find\ fetcher\ '%0'=
+Running\ query\ '%0'\ with\ fetcher\ '%1'.=
+Query\ '%0'\ with\ fetcher\ '%1'\ did\ not\ return\ any\ results.=
 
-Move_file=
-Rename_file=
+Move\ file=
+Rename\ file=
 
-Move_file_failed=
-Could_not_move_file_'%0'.=
-Could_not_find_file_'%0'.=
-Number_of_entries_successfully_imported=
-Import_canceled_by_user=
-Progress\:_%0_of_%1=
-Error_while_fetching_from_%0=
+Move\ file\ failed=
+Could\ not\ move\ file\ '%0'.=
+Could\ not\ find\ file\ '%0'.=
+Number\ of\ entries\ successfully\ imported=
+Import\ canceled\ by\ user=
+Progress\:\ %0\ of\ %1=
+Error\ while\ fetching\ from\ %0=
 
-Please_enter_a_valid_number=
-Show_search_results_in_a_window=
-Show_global_search_results_in_a_window=
-Search_in_all_open_libraries=
-Move_file_to_file_directory?=
+Please\ enter\ a\ valid\ number=
+Show\ search\ results\ in\ a\ window=
+Show\ global\ search\ results\ in\ a\ window=
+Search\ in\ all\ open\ libraries=
+Move\ file\ to\ file\ directory?=
 
-Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.=
-Protected_library=
-Refuse_to_save_the_library_before_external_changes_have_been_reviewed.=
-Library_protection=
-Unable_to_save_library=
+Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=
+Protected\ library=
+Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=
+Library\ protection=
+Unable\ to\ save\ library=
 
-BibTeX_key_generator=
-Unable_to_open_link.=
-Move_the_keyboard_focus_to_the_entry_table=
-MIME_type=
+BibTeX\ key\ generator=
+Unable\ to\ open\ link.=
+Move\ the\ keyboard\ focus\ to\ the\ entry\ table=
+MIME\ type=
 
-This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.=
-Run_fetcher,_e.g._"--fetch\=Medline\:cancer"=
+This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef<BR>instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef<br>from\ your\ web\ browser.<BR>Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=
 
-The_ACM_Digital_Library=
+The\ ACM\ Digital\ Library=
 Reset=
 
-Use_IEEE_LaTeX_abbreviations=
-The_Guide_to_Computing_Literature=
+Use\ IEEE\ LaTeX\ abbreviations=
+The\ Guide\ to\ Computing\ Literature=
 
-When_opening_file_link,_search_for_matching_file_if_no_link_is_defined=
-Settings_for_%0=
-Mark_entries_imported_into_an_existing_library=
-Unmark_all_entries_before_importing_new_entries_into_an_existing_library=
+When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=
+Settings\ for\ %0=
+Mark\ entries\ imported\ into\ an\ existing\ library=
+Unmark\ all\ entries\ before\ importing\ new\ entries\ into\ an\ existing\ library=
 
 Forward=
 Back=
-Sort_the_following_fields_as_numeric_fields=
-Line_%0\:_Found_corrupted_BibTeX_key.=
-Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).=
-Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).=
-Full_text_document_download_failed=
-Update_to_current_column_order=
-Download_from_URL=
-Rename_field=
-Set/clear/append/rename_fields=Instellen/wissen/hernoemen_van_velden
-Append_field=
-Append_to_fields=
-Rename_field_to=
-Move_contents_of_a_field_into_a_field_with_a_different_name=
-You_can_only_rename_one_field_at_a_time=
+Sort\ the\ following\ fields\ as\ numeric\ fields=
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=
+Full\ text\ document\ download\ failed=
+Update\ to\ current\ column\ order=
+Download\ from\ URL=
+Rename\ field=
+Set/clear/append/rename\ fields=Instellen/wissen/hernoemen van velden
+Append\ field=
+Append\ to\ fields=
+Rename\ field\ to=
+Move\ contents\ of\ a\ field\ into\ a\ field\ with\ a\ different\ name=
+You\ can\ only\ rename\ one\ field\ at\ a\ time=
 
-Remove_all_broken_links=
+Remove\ all\ broken\ links=
 
-Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.=
+Cannot\ use\ port\ %0\ for\ remote\ operation;\ another\ application\ may\ be\ using\ it.\ Try\ specifying\ another\ port.=
 
-Looking_for_full_text_document...=
+Looking\ for\ full\ text\ document...=
 Autosave=
-A_local_copy_will_be_opened.=
-Autosave_local_libraries=
-Automatically_save_the_library_to=
-Please_enter_a_valid_file_path.=
+A\ local\ copy\ will\ be\ opened.=
+Autosave\ local\ libraries=
+Automatically\ save\ the\ library\ to=
+Please\ enter\ a\ valid\ file\ path.=
 
 
-Export_in_current_table_sort_order=
-Export_entries_in_their_original_order=
-Error_opening_file_'%0'.=
+Export\ in\ current\ table\ sort\ order=
+Export\ entries\ in\ their\ original\ order=
+Error\ opening\ file\ '%0'.=
 
-Formatter_not_found\:_%0=
-Clear_inputarea=
+Formatter\ not\ found\:\ %0=
+Clear\ inputarea=
 
-Automatically_set_file_links_for_this_entry=
-Could_not_save,_file_locked_by_another_JabRef_instance.=
-File_is_locked_by_another_JabRef_instance.=
-Do_you_want_to_override_the_file_lock?=
-File_locked=
-Current_tmp_value=
-Metadata_change=
-Changes_have_been_made_to_the_following_metadata_elements=
+Automatically\ set\ file\ links\ for\ this\ entry=
+Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=
+File\ is\ locked\ by\ another\ JabRef\ instance.=
+Do\ you\ want\ to\ override\ the\ file\ lock?=
+File\ locked=
+Current\ tmp\ value=
+Metadata\ change=
+Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=
 
-Generate_groups_for_author_last_names=
-Generate_groups_from_keywords_in_a_BibTeX_field=
-Enforce_legal_characters_in_BibTeX_keys=
+Generate\ groups\ for\ author\ last\ names=
+Generate\ groups\ from\ keywords\ in\ a\ BibTeX\ field=
+Enforce\ legal\ characters\ in\ BibTeX\ keys=
 
-Save_without_backup?=
-Unable_to_create_backup=
-Move_file_to_file_directory=
-Rename_file_to=
-<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)=
-static_group=
-dynamic_group=
-refines_supergroup=
-includes_subgroups=
+Save\ without\ backup?=
+Unable\ to\ create\ backup=
+Move\ file\ to\ file\ directory=
+Rename\ file\ to=
+<b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=
+static\ group=
+dynamic\ group=
+refines\ supergroup=
+includes\ subgroups=
 contains=
-search_expression=
+search\ expression=
 
-Optional_fields_2=
-Waiting_for_save_operation_to_finish=
-Resolving_duplicate_BibTeX_keys...=
-Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.=
-This_library_contains_one_or_more_duplicated_BibTeX_keys.=
-Do_you_want_to_resolve_duplicate_keys_now?=
+Optional\ fields\ 2=
+Waiting\ for\ save\ operation\ to\ finish=
+Resolving\ duplicate\ BibTeX\ keys...=
+Finished\ resolving\ duplicate\ BibTeX\ keys.\ %0\ entries\ modified.=
+This\ library\ contains\ one\ or\ more\ duplicated\ BibTeX\ keys.=
+Do\ you\ want\ to\ resolve\ duplicate\ keys\ now?=
 
-Find_and_remove_duplicate_BibTeX_keys=
-Expected_syntax_for_--fetch\='<name_of_fetcher>\:<query>'=
-Duplicate_BibTeX_key=
-Import_marking_color=
-Always_add_letter_(a,_b,_...)_to_generated_keys=
+Find\ and\ remove\ duplicate\ BibTeX\ keys=
+Expected\ syntax\ for\ --fetch\='<name\ of\ fetcher>\:<query>'=
+Duplicate\ BibTeX\ key=
+Import\ marking\ color=
+Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=
 
-Ensure_unique_keys_using_letters_(a,_b,_...)=
-Ensure_unique_keys_using_letters_(b,_c,_...)=
-Entry_editor_active_background_color=
-Entry_editor_background_color=
-Entry_editor_font_color=
-Entry_editor_invalid_field_color=
+Ensure\ unique\ keys\ using\ letters\ (a,\ b,\ ...)=
+Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=
+Entry\ editor\ active\ background\ color=
+Entry\ editor\ background\ color=
+Entry\ editor\ font\ color=
+Entry\ editor\ invalid\ field\ color=
 
-Table_and_entry_editor_colors=
+Table\ and\ entry\ editor\ colors=
 
-General_file_directory=
-User-specific_file_directory=
-Search_failed\:_illegal_search_expression=
-Show_ArXiv_column=
+General\ file\ directory=
+User-specific\ file\ directory=
+Search\ failed\:\ illegal\ search\ expression=
+Show\ ArXiv\ column=
 
-You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for=
-Automatically_open_browse_dialog_when_creating_new_file_link=
-Import_metadata_from\:=
-Choose_the_source_for_the_metadata_import=
-Create_entry_based_on_XMP-metadata=
-Create_blank_entry_linking_the_PDF=
-Only_attach_PDF=
+You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=
+Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=
+Import\ metadata\ from\:=
+Choose\ the\ source\ for\ the\ metadata\ import=
+Create\ entry\ based\ on\ XMP-metadata=
+Create\ blank\ entry\ linking\ the\ PDF=
+Only\ attach\ PDF=
 Title=
-Create_new_entry=
-Update_existing_entry=
-Autocomplete_names_in_'Firstname_Lastname'_format_only=
-Autocomplete_names_in_'Lastname,_Firstname'_format_only=
-Autocomplete_names_in_both_formats=
-Marking_color_%0=
-The_name_'comment'_cannot_be_used_as_an_entry_type_name.=
-You_must_enter_an_integer_value_in_the_text_field_for=
-Send_as_email=
+Create\ new\ entry=
+Update\ existing\ entry=
+Autocomplete\ names\ in\ 'Firstname\ Lastname'\ format\ only=
+Autocomplete\ names\ in\ 'Lastname,\ Firstname'\ format\ only=
+Autocomplete\ names\ in\ both\ formats=
+Marking\ color\ %0=
+The\ name\ 'comment'\ cannot\ be\ used\ as\ an\ entry\ type\ name.=
+You\ must\ enter\ an\ integer\ value\ in\ the\ text\ field\ for=
+Send\ as\ email=
 References=
-Sending_of_emails=
-Subject_for_sending_an_email_with_references=
-Automatically_open_folders_of_attached_files=
-Create_entry_based_on_content=
-Do_not_show_this_box_again_for_this_import=
-Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)=
-Error_creating_email=
-Entries_added_to_an_email=
+Sending\ of\ emails=
+Subject\ for\ sending\ an\ email\ with\ references=
+Automatically\ open\ folders\ of\ attached\ files=
+Create\ entry\ based\ on\ content=
+Do\ not\ show\ this\ box\ again\ for\ this\ import=
+Always\ use\ this\ PDF\ import\ style\ (and\ do\ not\ ask\ for\ each\ import)=
+Error\ creating\ email=
+Entries\ added\ to\ an\ email=
 exportFormat=
-Output_file_missing=
-No_search_matches.=
-The_output_option_depends_on_a_valid_input_option.=
-Default_import_style_for_drag_and_drop_of_PDFs=
-Default_PDF_file_link_action=
-Filename_format_pattern=
-Additional_parameters=
-Cite_selected_entries_between_parenthesis=
-Cite_selected_entries_with_in-text_citation=
-Cite_special=
-Extra_information_(e.g._page_number)=
-Manage_citations=
-Problem_modifying_citation=
+Output\ file\ missing=
+No\ search\ matches.=
+The\ output\ option\ depends\ on\ a\ valid\ input\ option.=
+Default\ import\ style\ for\ drag\ and\ drop\ of\ PDFs=
+Default\ PDF\ file\ link\ action=
+Filename\ format\ pattern=
+Additional\ parameters=
+Cite\ selected\ entries\ between\ parenthesis=
+Cite\ selected\ entries\ with\ in-text\ citation=
+Cite\ special=
+Extra\ information\ (e.g.\ page\ number)=
+Manage\ citations=
+Problem\ modifying\ citation=
 Citation=
-Extra_information=
-Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.=
-Select_style=
+Extra\ information=
+Could\ not\ resolve\ BibTeX\ entry\ for\ citation\ marker\ '%0'.=
+Select\ style=
 Journals=
 Cite=
-Cite_in-text=
-Insert_empty_citation=
-Merge_citations=
-Manual_connect=
-Select_Writer_document=
-Sync_OpenOffice/LibreOffice_bibliography=
-Select_which_open_Writer_document_to_work_on=
-Connected_to_document=
-Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)=
-Cite_selected_entries_with_extra_information=
-Ensure_that_the_bibliography_is_up-to-date=
-Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.=
-Unable_to_synchronize_bibliography=
-Combine_pairs_of_citations_that_are_separated_by_spaces_only=
-Autodetection_failed=
+Cite\ in-text=
+Insert\ empty\ citation=
+Merge\ citations=
+Manual\ connect=
+Select\ Writer\ document=
+Sync\ OpenOffice/LibreOffice\ bibliography=
+Select\ which\ open\ Writer\ document\ to\ work\ on=
+Connected\ to\ document=
+Insert\ a\ citation\ without\ text\ (the\ entry\ will\ appear\ in\ the\ reference\ list)=
+Cite\ selected\ entries\ with\ extra\ information=
+Ensure\ that\ the\ bibliography\ is\ up-to-date=
+Your\ OpenOffice/LibreOffice\ document\ references\ the\ BibTeX\ key\ '%0',\ which\ could\ not\ be\ found\ in\ your\ current\ library.=
+Unable\ to\ synchronize\ bibliography=
+Combine\ pairs\ of\ citations\ that\ are\ separated\ by\ spaces\ only=
+Autodetection\ failed=
 Connecting=
-Please_wait...=
-Set_connection_parameters=
-Path_to_OpenOffice/LibreOffice_directory=
-Path_to_OpenOffice/LibreOffice_executable=
-Path_to_OpenOffice/LibreOffice_library_dir=
-Connection_lost=
-The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.=
-The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.=
-Automatically_sync_bibliography_when_inserting_citations=
-Look_up_BibTeX_entries_in_the_active_tab_only=
-Look_up_BibTeX_entries_in_all_open_libraries=
-Autodetecting_paths...=
-Could_not_find_OpenOffice/LibreOffice_installation=
-Found_more_than_one_OpenOffice/LibreOffice_executable.=
-Please_choose_which_one_to_connect_to\:=
-Choose_OpenOffice/LibreOffice_executable=
-Select_document=
-HTML_list=
-If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting=
-Could_not_open_%0=
-Unknown_import_format=
-Web_search=
-Style_selection=
-No_valid_style_file_defined=
-Choose_pattern=
-Use_the_BIB_file_location_as_primary_file_directory=
-Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.=
-OpenOffice/LibreOffice_connection=
-You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.=
+Please\ wait...=
+Set\ connection\ parameters=
+Path\ to\ OpenOffice/LibreOffice\ directory=
+Path\ to\ OpenOffice/LibreOffice\ executable=
+Path\ to\ OpenOffice/LibreOffice\ library\ dir=
+Connection\ lost=
+The\ paragraph\ format\ is\ controlled\ by\ the\ property\ 'ReferenceParagraphFormat'\ or\ 'ReferenceHeaderParagraphFormat'\ in\ the\ style\ file.=
+The\ character\ format\ is\ controlled\ by\ the\ citation\ property\ 'CitationCharacterFormat'\ in\ the\ style\ file.=
+Automatically\ sync\ bibliography\ when\ inserting\ citations=
+Look\ up\ BibTeX\ entries\ in\ the\ active\ tab\ only=
+Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=
+Autodetecting\ paths...=
+Could\ not\ find\ OpenOffice/LibreOffice\ installation=
+Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=
+Please\ choose\ which\ one\ to\ connect\ to\:=
+Choose\ OpenOffice/LibreOffice\ executable=
+Select\ document=
+HTML\ list=
+If\ possible,\ normalize\ this\ list\ of\ names\ to\ conform\ to\ standard\ BibTeX\ name\ formatting=
+Could\ not\ open\ %0=
+Unknown\ import\ format=
+Web\ search=
+Style\ selection=
+No\ valid\ style\ file\ defined=
+Choose\ pattern=
+Use\ the\ BIB\ file\ location\ as\ primary\ file\ directory=
+Could\ not\ run\ the\ gnuclient/emacsclient\ program.\ Make\ sure\ you\ have\ the\ emacsclient/gnuclient\ program\ installed\ and\ available\ in\ the\ PATH.=
+OpenOffice/LibreOffice\ connection=
+You\ must\ select\ either\ a\ valid\ style\ file,\ or\ use\ one\ of\ the\ default\ styles.=
 
-This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.=
-This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.=
-You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.=
+This\ is\ a\ simple\ copy\ and\ paste\ dialog.\ First\ load\ or\ paste\ some\ text\ into\ the\ text\ input\ area.<br>After\ that,\ you\ can\ mark\ text\ and\ assign\ it\ to\ a\ BibTeX\ field.=
+This\ feature\ generates\ a\ new\ library\ based\ on\ which\ entries\ are\ needed\ in\ an\ existing\ LaTeX\ document.=
+You\ need\ to\ select\ one\ of\ your\ open\ libraries\ from\ which\ to\ choose\ entries,\ as\ well\ as\ the\ AUX\ file\ produced\ by\ LaTeX\ when\ compiling\ your\ document.=
 
-First_select_entries_to_clean_up.=
-Cleanup_entry=
-Autogenerate_PDF_Names=
-Auto-generating_PDF-Names_does_not_support_undo._Continue?=
+First\ select\ entries\ to\ clean\ up.=
+Cleanup\ entry=
+Autogenerate\ PDF\ Names=
+Auto-generating\ PDF-Names\ does\ not\ support\ undo.\ Continue?=
 
-Use_full_firstname_whenever_possible=
-Use_abbreviated_firstname_whenever_possible=
-Use_abbreviated_and_full_firstname=
-Autocompletion_options=
-Name_format_used_for_autocompletion=
-Treatment_of_first_names=
-Cleanup_entries=
-Automatically_assign_new_entry_to_selected_groups=
-%0_mode=
-Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix=
-Make_paths_of_linked_files_relative_(if_possible)=
-Rename_PDFs_to_given_filename_format_pattern=
-Rename_only_PDFs_having_a_relative_path=
-What_would_you_like_to_clean_up?=
-Doing_a_cleanup_for_%0_entries...=
-No_entry_needed_a_clean_up=
-One_entry_needed_a_clean_up=
-%0_entries_needed_a_clean_up=
+Use\ full\ firstname\ whenever\ possible=
+Use\ abbreviated\ firstname\ whenever\ possible=
+Use\ abbreviated\ and\ full\ firstname=
+Autocompletion\ options=
+Name\ format\ used\ for\ autocompletion=
+Treatment\ of\ first\ names=
+Cleanup\ entries=
+Automatically\ assign\ new\ entry\ to\ selected\ groups=
+%0\ mode=
+Move\ DOIs\ from\ note\ and\ URL\ field\ to\ DOI\ field\ and\ remove\ http\ prefix=
+Make\ paths\ of\ linked\ files\ relative\ (if\ possible)=
+Rename\ PDFs\ to\ given\ filename\ format\ pattern=
+Rename\ only\ PDFs\ having\ a\ relative\ path=
+What\ would\ you\ like\ to\ clean\ up?=
+Doing\ a\ cleanup\ for\ %0\ entries...=
+No\ entry\ needed\ a\ clean\ up=
+One\ entry\ needed\ a\ clean\ up=
+%0\ entries\ needed\ a\ clean\ up=
 
-Remove_selected=
+Remove\ selected=
 
-Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.=
-Attach_file=
-Setting_all_preferences_to_default_values.=
-Resetting_preference_key_'%0'=
-Unknown_preference_key_'%0'=
-Unable_to_clear_preferences.=
+Group\ tree\ could\ not\ be\ parsed.\ If\ you\ save\ the\ BibTeX\ library,\ all\ groups\ will\ be\ lost.=
+Attach\ file=
+Setting\ all\ preferences\ to\ default\ values.=
+Resetting\ preference\ key\ '%0'=
+Unknown\ preference\ key\ '%0'=
+Unable\ to\ clear\ preferences.=
 
-Reset_preferences_(key1,key2,..._or_'all')=
-Find_unlinked_files=
-Unselect_all=
-Expand_all=
-Collapse_all=
-Opens_the_file_browser.=
-Scan_directory=
-Searches_the_selected_directory_for_unlinked_files.=
-Starts_the_import_of_BibTeX_entries.=
-Leave_this_dialog.=
-Create_directory_based_keywords=
-Creates_keywords_in_created_entrys_with_directory_pathnames=
-Select_a_directory_where_the_search_shall_start.=
-Select_file_type\:=
-These_files_are_not_linked_in_the_active_library.=
-Entry_type_to_be_created\:=
-Searching_file_system...=
-Importing_into_Library...=
-Select_directory=
-Select_files=
-BibTeX_entry_creation=
-<No_selection>=
-Unable_to_connect_to_FreeCite_online_service.=
-Parse_with_FreeCite=
-The_current_BibTeX_key_will_be_overwritten._Continue?=
-Overwrite_key=
-Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator=
-How_would_you_like_to_link_to_'%0'?=
-BibTeX_key_patterns=
-Changed_special_field_settings=
-Clear_priority=
-Clear_rank=
-Enable_special_fields=
-One_star=
-Two_stars=
-Three_stars=
-Four_stars=
-Five_stars=
-Help_on_special_fields=
-Keywords_of_selected_entries=
-Manage_content_selectors=
-Manage_keywords=
-No_priority_information=
-No_rank_information=
+Reset\ preferences\ (key1,key2,...\ or\ 'all')=
+Find\ unlinked\ files=
+Unselect\ all=
+Expand\ all=
+Collapse\ all=
+Opens\ the\ file\ browser.=
+Scan\ directory=
+Searches\ the\ selected\ directory\ for\ unlinked\ files.=
+Starts\ the\ import\ of\ BibTeX\ entries.=
+Leave\ this\ dialog.=
+Create\ directory\ based\ keywords=
+Creates\ keywords\ in\ created\ entrys\ with\ directory\ pathnames=
+Select\ a\ directory\ where\ the\ search\ shall\ start.=
+Select\ file\ type\:=
+These\ files\ are\ not\ linked\ in\ the\ active\ library.=
+Entry\ type\ to\ be\ created\:=
+Searching\ file\ system...=
+Importing\ into\ Library...=
+Select\ directory=
+Select\ files=
+BibTeX\ entry\ creation=
+<No\ selection>=
+Unable\ to\ connect\ to\ FreeCite\ online\ service.=
+Parse\ with\ FreeCite=
+The\ current\ BibTeX\ key\ will\ be\ overwritten.\ Continue?=
+Overwrite\ key=
+Not\ overwriting\ existing\ key.\ To\ change\ this\ setting,\ open\ Options\ ->\ Prefererences\ ->\ BibTeX\ key\ generator=
+How\ would\ you\ like\ to\ link\ to\ '%0'?=
+BibTeX\ key\ patterns=
+Changed\ special\ field\ settings=
+Clear\ priority=
+Clear\ rank=
+Enable\ special\ fields=
+One\ star=
+Two\ stars=
+Three\ stars=
+Four\ stars=
+Five\ stars=
+Help\ on\ special\ fields=
+Keywords\ of\ selected\ entries=
+Manage\ content\ selectors=
+Manage\ keywords=
+No\ priority\ information=
+No\ rank\ information=
 Priority=
-Priority_high=
-Priority_low=
-Priority_medium=
+Priority\ high=
+Priority\ low=
+Priority\ medium=
 Quality=
 Rank=
 Relevance=
-Set_priority_to_high=
-Set_priority_to_low=
-Set_priority_to_medium=
-Show_priority=
-Show_quality=
-Show_rank=
-Show_relevance=
-Synchronize_with_keywords=
-Synchronized_special_fields_based_on_keywords=
-Toggle_relevance=
-Toggle_quality_assured=
-Toggle_print_status=
-Update_keywords=
-Write_values_of_special_fields_as_separate_fields_to_BibTeX=
-You_have_changed_settings_for_special_fields.=
-%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.=
-A_string_with_that_label_already_exists=
-Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.=
-JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.=
-Correct_the_entry,_and_reopen_editor_to_display/edit_source.=
-Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').=
-Could_not_connect_to_running_OpenOffice/LibreOffice.=
-Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.=
-If_connecting_manually,_please_verify_program_and_library_paths.=
-Error_message\:=
-If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.=
-Import_metadata_from_PDF=
-Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.=
-Removed_all_subgroups_of_group_"%0".=
-To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.=
-Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.=
-Use_the_following_delimiter_character(s)\:=
-When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above=
-Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=
-Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=
+Set\ priority\ to\ high=
+Set\ priority\ to\ low=
+Set\ priority\ to\ medium=
+Show\ priority=
+Show\ quality=
+Show\ rank=
+Show\ relevance=
+Synchronize\ with\ keywords=
+Synchronized\ special\ fields\ based\ on\ keywords=
+Toggle\ relevance=
+Toggle\ quality\ assured=
+Toggle\ print\ status=
+Update\ keywords=
+Write\ values\ of\ special\ fields\ as\ separate\ fields\ to\ BibTeX=
+You\ have\ changed\ settings\ for\ special\ fields.=
+%0\ entries\ found.\ To\ reduce\ server\ load,\ only\ %1\ will\ be\ downloaded.=
+A\ string\ with\ that\ label\ already\ exists=
+Connection\ to\ OpenOffice/LibreOffice\ has\ been\ lost.\ Please\ make\ sure\ OpenOffice/LibreOffice\ is\ running,\ and\ try\ to\ reconnect.=
+JabRef\ will\ send\ at\ least\ one\ request\ per\ entry\ to\ a\ publisher.=
+Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=
+Could\ not\ connect\ to\ a\ running\ gnuserv\ process.\ Make\ sure\ that\ Emacs\ or\ XEmacs\ is\ running,<BR>and\ that\ the\ server\ has\ been\ started\ (by\ running\ the\ command\ 'server-start'/'gnuserv-start').=
+Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=
+Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=
+If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=
+Error\ message\:=
+If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=
+Import\ metadata\ from\ PDF=
+Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=
+Removed\ all\ subgroups\ of\ group\ "%0".=
+To\ disable\ the\ memory\ stick\ mode\ rename\ or\ remove\ the\ jabref.xml\ file\ in\ the\ same\ folder\ as\ JabRef.=
+Unable\ to\ connect.\ One\ possible\ reason\ is\ that\ JabRef\ and\ OpenOffice/LibreOffice\ are\ not\ both\ running\ in\ either\ 32\ bit\ mode\ or\ 64\ bit\ mode.=
+Use\ the\ following\ delimiter\ character(s)\:=
+When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\ prefer\ the\ BIB\ file\ location\ rather\ than\ the\ file\ directory\ set\ above=
+Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=
+Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=
 
 Searching...=
-You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?=
-Confirm_selection=
-Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case=
-Import_conversions=
-Please_enter_a_search_string=
-Please_open_or_start_a_new_library_before_searching=
+You\ have\ selected\ more\ than\ %0\ entries\ for\ download.\ Some\ web\ sites\ might\ block\ you\ if\ you\ make\ too\ many\ rapid\ downloads.\ Do\ you\ want\ to\ continue?=
+Confirm\ selection=
+Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=
+Import\ conversions=
+Please\ enter\ a\ search\ string=
+Please\ open\ or\ start\ a\ new\ library\ before\ searching=
 
-Canceled_merging_entries=
+Canceled\ merging\ entries=
 
-Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search=
-Merge_entries=
-Merged_entries=
-Merged_entry=
+Format\ units\ by\ adding\ non-breaking\ separators\ and\ keeping\ the\ correct\ case\ on\ search=
+Merge\ entries=
+Merged\ entries=
+Merged\ entry=
 None=
 Parse=
 Result=
-Show_DOI_first=
-Show_URL_first=
-Use_Emacs_key_bindings=
-You_have_to_choose_exactly_two_entries_to_merge.=
+Show\ DOI\ first=
+Show\ URL\ first=
+Use\ Emacs\ key\ bindings=
+You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=
 
-Update_timestamp_on_modification=
-All_key_bindings_will_be_reset_to_their_defaults.=
+Update\ timestamp\ on\ modification=
+All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=
 
-Automatically_set_file_links=
-Resetting_all_key_bindings=
+Automatically\ set\ file\ links=
+Resetting\ all\ key\ bindings=
 Hostname=
-Invalid_setting=
+Invalid\ setting=
 Network=Netwerk
-Please_specify_both_hostname_and_port=
-Please_specify_both_username_and_password=
+Please\ specify\ both\ hostname\ and\ port=
+Please\ specify\ both\ username\ and\ password=
 
-Use_custom_proxy_configuration=
-Proxy_requires_authentication=
-Attention\:_Password_is_stored_in_plain_text\!=
-Clear_connection_settings=
-Cleared_connection_settings.=
+Use\ custom\ proxy\ configuration=
+Proxy\ requires\ authentication=
+Attention\:\ Password\ is\ stored\ in\ plain\ text\!=
+Clear\ connection\ settings=
+Cleared\ connection\ settings.=
 
-Rebind_C-a,_too=
-Rebind_C-f,_too=
+Rebind\ C-a,\ too=
+Rebind\ C-f,\ too=
 
-Open_folder=Open_map
-Searches_for_unlinked_PDF_files_on_the_file_system=
-Export_entries_ordered_as_specified=
-Export_sort_order=
-Export_sorting=
-Newline_separator=
+Open\ folder=Open map
+Searches\ for\ unlinked\ PDF\ files\ on\ the\ file\ system=
+Export\ entries\ ordered\ as\ specified=
+Export\ sort\ order=
+Export\ sorting=
+Newline\ separator=
 
-Save_entries_ordered_as_specified=
-Save_sort_order=
-Show_extra_columns=
-Parsing_error=
-illegal_backslash_expression=
+Save\ entries\ ordered\ as\ specified=
+Save\ sort\ order=
+Show\ extra\ columns=
+Parsing\ error=
+illegal\ backslash\ expression=
 
-Move_to_group=
+Move\ to\ group=
 
-Clear_read_status=
-Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')=
-Could_not_apply_changes.=
-Deprecated_fields=
-Hide/show_toolbar=
-No_read_status_information=
+Clear\ read\ status=
+Convert\ to\ biblatex\ format\ (for\ example,\ move\ the\ value\ of\ the\ 'journal'\ field\ to\ 'journaltitle')=
+Could\ not\ apply\ changes.=
+Deprecated\ fields=
+Hide/show\ toolbar=
+No\ read\ status\ information=
 Printed=
-Read_status=
-Read_status_read=
-Read_status_skimmed=
-Save_selected_as_plain_BibTeX...=
-Set_read_status_to_read=
-Set_read_status_to_skimmed=
-Show_deprecated_BibTeX_fields=
+Read\ status=
+Read\ status\ read=
+Read\ status\ skimmed=
+Save\ selected\ as\ plain\ BibTeX...=
+Set\ read\ status\ to\ read=
+Set\ read\ status\ to\ skimmed=
+Show\ deprecated\ BibTeX\ fields=
 
-Show_gridlines=
-Show_printed_status=
-Show_read_status=
-Table_row_height_padding=
+Show\ gridlines=
+Show\ printed\ status=
+Show\ read\ status=
+Table\ row\ height\ padding=
 
-Marked_selected_entry=
-Marked_all_%0_selected_entries=
-Unmarked_selected_entry=
-Unmarked_all_%0_selected_entries=
+Marked\ selected\ entry=
+Marked\ all\ %0\ selected\ entries=
+Unmarked\ selected\ entry=
+Unmarked\ all\ %0\ selected\ entries=
 
 
-Unmarked_all_entries=
+Unmarked\ all\ entries=
 
-Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.=
+Unable\ to\ find\ the\ requested\ look\ and\ feel\ and\ thus\ the\ default\ one\ is\ used.=
 
-Opens_JabRef's_GitHub_page=
-Could_not_open_browser.=
-Please_open_%0_manually.=
-The_link_has_been_copied_to_the_clipboard.=
+Opens\ JabRef's\ GitHub\ page=
+Could\ not\ open\ browser.=
+Please\ open\ %0\ manually.=
+The\ link\ has\ been\ copied\ to\ the\ clipboard.=
 
-Open_%0_file=
+Open\ %0\ file=
 
-Cannot_delete_file=
-File_permission_error=
-Push_to_%0=Stuur_selectie_naar_%0
-Path_to_%0=
+Cannot\ delete\ file=
+File\ permission\ error=
+Push\ to\ %0=Stuur selectie naar %0
+Path\ to\ %0=
 Convert=
-Normalize_to_BibTeX_name_format=
-Help_on_Name_Formatting=
+Normalize\ to\ BibTeX\ name\ format=
+Help\ on\ Name\ Formatting=
 
-Add_new_file_type=
+Add\ new\ file\ type=
 
-Left_entry=
-Right_entry=
+Left\ entry=
+Right\ entry=
 Use=
-Original_entry=
-Replace_original_entry=
-No_information_added=
-Select_at_least_one_entry_to_manage_keywords.=
-OpenDocument_text=
-OpenDocument_spreadsheet=
-OpenDocument_presentation=
-%0_image=
-Added_entry=
-Modified_entry=
-Deleted_entry=
-Modified_groups_tree=
-Removed_all_groups=
-Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.=
-Select_export_format=
-Return_to_JabRef=
-Please_move_the_file_manually_and_link_in_place.=
-Could_not_connect_to_%0=
-Warning\:_%0_out_of_%1_entries_have_undefined_title.=
-Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.=
+Original\ entry=
+Replace\ original\ entry=
+No\ information\ added=
+Select\ at\ least\ one\ entry\ to\ manage\ keywords.=
+OpenDocument\ text=
+OpenDocument\ spreadsheet=
+OpenDocument\ presentation=
+%0\ image=
+Added\ entry=
+Modified\ entry=
+Deleted\ entry=
+Modified\ groups\ tree=
+Removed\ all\ groups=
+Accepting\ the\ change\ replaces\ the\ complete\ groups\ tree\ with\ the\ externally\ modified\ groups\ tree.=
+Select\ export\ format=
+Return\ to\ JabRef=
+Please\ move\ the\ file\ manually\ and\ link\ in\ place.=
+Could\ not\ connect\ to\ %0=
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ title.=
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ BibTeX\ key.=
 occurrence=
-Added_new_'%0'_entry.=
-Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?=
-Changed_type_to_'%0'_for=Type_gewijzigd_naar_'%0'_voor
-Really_delete_the_selected_entry?=
-Really_delete_the_%0_selected_entries?=
-Keep_merged_entry_only=
-Keep_left=
-Keep_right=
-Old_entry=
-From_import=
-No_problems_found.=
-%0_problem(s)_found=
-Save_changes=
-Discard_changes=
-Library_'%0'_has_changed.=
-Print_entry_preview=
-Copy_title=
-Copy_\\cite{BibTeX_key}=Kopieer_\\cite{BibTeX-sleutel}
-Copy_BibTeX_key_and_title=Kopieer_BibTeX_sleutel_en_titel
-File_rename_failed_for_%0_entries.=
-Merged_BibTeX_source_code=
-Invalid_DOI\:_'%0'.=Ongeldig_DOI\:_'%0'.
-should_start_with_a_name=
-should_end_with_a_name=
-unexpected_closing_curly_bracket=
-unexpected_opening_curly_bracket=
-capital_letters_are_not_masked_using_curly_brackets_{}=
-should_contain_a_four_digit_number=
-should_contain_a_valid_page_number_range=
+Added\ new\ '%0'\ entry.=
+Multiple\ entries\ selected.\ Do\ you\ want\ to\ change\ the\ type\ of\ all\ these\ to\ '%0'?=
+Changed\ type\ to\ '%0'\ for=Type gewijzigd naar '%0' voor
+Really\ delete\ the\ selected\ entry?=
+Really\ delete\ the\ %0\ selected\ entries?=
+Keep\ merged\ entry\ only=
+Keep\ left=
+Keep\ right=
+Old\ entry=
+From\ import=
+No\ problems\ found.=
+%0\ problem(s)\ found=
+Save\ changes=
+Discard\ changes=
+Library\ '%0'\ has\ changed.=
+Print\ entry\ preview=
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=Kopieer \\cite{BibTeX-sleutel}
+Copy\ BibTeX\ key\ and\ title=Kopieer BibTeX sleutel en titel
+File\ rename\ failed\ for\ %0\ entries.=
+Merged\ BibTeX\ source\ code=
+Invalid\ DOI\:\ '%0'.=Ongeldig DOI: '%0'.
+should\ start\ with\ a\ name=
+should\ end\ with\ a\ name=
+unexpected\ closing\ curly\ bracket=
+unexpected\ opening\ curly\ bracket=
+capital\ letters\ are\ not\ masked\ using\ curly\ brackets\ {}=
+should\ contain\ a\ four\ digit\ number=
+should\ contain\ a\ valid\ page\ number\ range=
 Filled=
-Field_is_missing=
-Search_%0=Zoek_%0
+Field\ is\ missing=
+Search\ %0=Zoek %0
 
-Search_results_in_all_libraries_for_%0=
-Search_results_in_library_%0_for_%1=
-Search_globally=
-No_results_found.=
-Found_%0_results.=
-plain_text=
-This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>=
-This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>=
-This_search_contains_entries_in_which=
+Search\ results\ in\ all\ libraries\ for\ %0=
+Search\ results\ in\ library\ %0\ for\ %1=
+Search\ globally=
+No\ results\ found.=
+Found\ %0\ results.=
+plain\ text=
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ regular\ expression\ <b>%0</b>=
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ term\ <b>%0</b>=
+This\ search\ contains\ entries\ in\ which=
 
-Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.=
-JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>=
-This_library_uses_outdated_file_links.=
+Unable\ to\ autodetect\ OpenOffice/LibreOffice\ installation.\ Please\ choose\ the\ installation\ directory\ manually.=
+JabRef\ no\ longer\ supports\ 'ps'\ or\ 'pdf'\ fields.<br>File\ links\ are\ now\ stored\ in\ the\ 'file'\ field\ and\ files\ are\ stored\ in\ an\ external\ file\ directory.<br>To\ make\ use\ of\ this\ feature,\ JabRef\ needs\ to\ upgrade\ file\ links.<br><br>=
+This\ library\ uses\ outdated\ file\ links.=
 
-Clear_search=
-Close_library=
-Close_entry_editor=
-Decrease_table_font_size=
-Entry_editor,_next_entry=
-Entry_editor,_next_panel=
-Entry_editor,_next_panel_2=
-Entry_editor,_previous_entry=
-Entry_editor,_previous_panel=
-Entry_editor,_previous_panel_2=
-File_list_editor,_move_entry_down=
-File_list_editor,_move_entry_up=
-Focus_entry_table=
-Import_into_current_library=
-Import_into_new_library=
-Increase_table_font_size=
-New_article=
-New_book=
-New_entry=
-New_from_plain_text=
-New_inbook=
-New_mastersthesis=
-New_phdthesis=
-New_proceedings=
-New_unpublished=
-Next_tab=
-Preamble_editor,_store_changes=
-Previous_tab=
-Push_to_application=
-Refresh_OpenOffice/LibreOffice=
-Resolve_duplicate_BibTeX_keys=
-Save_all=
-String_dialog,_add_string=
-String_dialog,_remove_string=
-Synchronize_files=
+Clear\ search=
+Close\ library=
+Close\ entry\ editor=
+Decrease\ table\ font\ size=
+Entry\ editor,\ next\ entry=
+Entry\ editor,\ next\ panel=
+Entry\ editor,\ next\ panel\ 2=
+Entry\ editor,\ previous\ entry=
+Entry\ editor,\ previous\ panel=
+Entry\ editor,\ previous\ panel\ 2=
+File\ list\ editor,\ move\ entry\ down=
+File\ list\ editor,\ move\ entry\ up=
+Focus\ entry\ table=
+Import\ into\ current\ library=
+Import\ into\ new\ library=
+Increase\ table\ font\ size=
+New\ article=
+New\ book=
+New\ entry=
+New\ from\ plain\ text=
+New\ inbook=
+New\ mastersthesis=
+New\ phdthesis=
+New\ proceedings=
+New\ unpublished=
+Next\ tab=
+Preamble\ editor,\ store\ changes=
+Previous\ tab=
+Push\ to\ application=
+Refresh\ OpenOffice/LibreOffice=
+Resolve\ duplicate\ BibTeX\ keys=
+Save\ all=
+String\ dialog,\ add\ string=
+String\ dialog,\ remove\ string=
+Synchronize\ files=
 Unabbreviate=
-should_contain_a_protocol=
-Copy_preview=
-Automatically_setting_file_links=
-Regenerating_BibTeX_keys_according_to_metadata=
-No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys=
-Regenerate_all_keys_for_the_entries_in_a_BibTeX_file=
-Show_debug_level_messages=
-Default_bibliography_mode=
-New_%0_library_created.=
-Show_only_preferences_deviating_from_their_default_value=
+should\ contain\ a\ protocol=
+Copy\ preview=
+Automatically\ setting\ file\ links=
+Regenerating\ BibTeX\ keys\ according\ to\ metadata=
+No\ meta\ data\ present\ in\ BIB\ file.\ Cannot\ regenerate\ BibTeX\ keys=
+Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=
+Show\ debug\ level\ messages=
+Default\ bibliography\ mode=
+New\ %0\ library\ created.=
+Show\ only\ preferences\ deviating\ from\ their\ default\ value=
 default=
 key=
 type=
 value=
-Show_preferences=
-Save_actions=
-Enable_save_actions=
+Show\ preferences=
+Save\ actions=
+Enable\ save\ actions=
 
-Other_fields=
-Show_remaining_fields=
+Other\ fields=
+Show\ remaining\ fields=
 
-link_should_refer_to_a_correct_file_path=
-abbreviation_detected=
-wrong_entry_type_as_proceedings_has_page_numbers=
-Abbreviate_journal_names=
+link\ should\ refer\ to\ a\ correct\ file\ path=
+abbreviation\ detected=
+wrong\ entry\ type\ as\ proceedings\ has\ page\ numbers=
+Abbreviate\ journal\ names=
 Abbreviating...=
-Abbreviation_%s_for_journal_%s_already_defined.=
-Abbreviation_cannot_be_empty=
-Duplicated_Journal_Abbreviation=
-Duplicated_Journal_File=
-Error_Occurred=
-Journal_file_%s_already_added=
-Name_cannot_be_empty=
+Abbreviation\ %s\ for\ journal\ %s\ already\ defined.=
+Abbreviation\ cannot\ be\ empty=
+Duplicated\ Journal\ Abbreviation=
+Duplicated\ Journal\ File=
+Error\ Occurred=
+Journal\ file\ %s\ already\ added=
+Name\ cannot\ be\ empty=
 
-Adding_fetched_entries=
-Display_keywords_appearing_in_ALL_entries=
-Display_keywords_appearing_in_ANY_entry=
-Fetching_entries_from_Inspire=
-None_of_the_selected_entries_have_titles.=
-None_of_the_selected_entries_have_BibTeX_keys.=
-Unabbreviate_journal_names=
+Adding\ fetched\ entries=
+Display\ keywords\ appearing\ in\ ALL\ entries=
+Display\ keywords\ appearing\ in\ ANY\ entry=
+Fetching\ entries\ from\ Inspire=
+None\ of\ the\ selected\ entries\ have\ titles.=
+None\ of\ the\ selected\ entries\ have\ BibTeX\ keys.=
+Unabbreviate\ journal\ names=
 Unabbreviating...=
 Usage=
 
 
-Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.=
-Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
-Reset_preferences=
-Ill-formed_entrytype_comment_in_BIB_file=
+Adds\ {}\ brackets\ around\ acronyms,\ month\ names\ and\ countries\ to\ preserve\ their\ case.=
+Are\ you\ sure\ you\ want\ to\ reset\ all\ settings\ to\ default\ values?=
+Reset\ preferences=
+Ill-formed\ entrytype\ comment\ in\ BIB\ file=
 
-Move_linked_files_to_default_file_directory_%0=
+Move\ linked\ files\ to\ default\ file\ directory\ %0=
 
 Clipboard=
-Could_not_paste_entry_as_text\:=
-Do_you_still_want_to_continue?=
-This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:=
-This_could_cause_undesired_changes_to_your_entries.=
-Run_field_formatter\:=
-Table_font_size_is_%0=
-%0_import_canceled=
-Internal_style=
-Add_style_file=
-Are_you_sure_you_want_to_remove_the_style?=
-Current_style_is_'%0'=
-Remove_style=
-Select_one_of_the_available_styles_or_add_a_style_file_from_disk.=
-You_must_select_a_valid_style_file.=
+Could\ not\ paste\ entry\ as\ text\:=
+Do\ you\ still\ want\ to\ continue?=
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=
+This\ could\ cause\ undesired\ changes\ to\ your\ entries.=
+Run\ field\ formatter\:=
+Table\ font\ size\ is\ %0=
+%0\ import\ canceled=
+Internal\ style=
+Add\ style\ file=
+Are\ you\ sure\ you\ want\ to\ remove\ the\ style?=
+Current\ style\ is\ '%0'=
+Remove\ style=
+Select\ one\ of\ the\ available\ styles\ or\ add\ a\ style\ file\ from\ disk.=
+You\ must\ select\ a\ valid\ style\ file.=
 Reload=
 
 Capitalize=
-Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.=
-Capitalize_the_first_word,_changes_other_words_to_lower_case.=
-Changes_all_letters_to_lower_case.=
-Changes_all_letters_to_upper_case.=
-Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.=
-Cleans_up_LaTeX_code.=
-Converts_HTML_code_to_LaTeX_code.=
-Converts_HTML_code_to_Unicode.=
-Converts_LaTeX_encoding_to_Unicode_characters.=
-Converts_Unicode_characters_to_LaTeX_encoding.=
-Converts_ordinals_to_LaTeX_superscripts.=
-Converts_units_to_LaTeX_formatting.=
-HTML_to_LaTeX=
-LaTeX_cleanup=
-LaTeX_to_Unicode=
-Lower_case=
-Minify_list_of_person_names=
-Normalize_date=
-Normalize_month=
-Normalize_month_to_BibTeX_standard_abbreviation.=
-Normalize_names_of_persons=
-Normalize_page_numbers=
-Normalize_pages_to_BibTeX_standard.=
-Normalizes_lists_of_persons_to_the_BibTeX_standard.=
-Normalizes_the_date_to_ISO_date_format.=
-Ordinals_to_LaTeX_superscript=
-Protect_terms=
-Remove_enclosing_braces=
-Removes_braces_encapsulating_the_complete_field_content.=
-Sentence_case=
-Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".=
-Title_case=
-Unicode_to_LaTeX=
-Units_to_LaTeX=
-Upper_case=
-Does_nothing.=
+Capitalize\ all\ words,\ but\ converts\ articles,\ prepositions,\ and\ conjunctions\ to\ lower\ case.=
+Capitalize\ the\ first\ word,\ changes\ other\ words\ to\ lower\ case.=
+Changes\ all\ letters\ to\ lower\ case.=
+Changes\ all\ letters\ to\ upper\ case.=
+Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=
+Cleans\ up\ LaTeX\ code.=
+Converts\ HTML\ code\ to\ LaTeX\ code.=
+Converts\ HTML\ code\ to\ Unicode.=
+Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=
+Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=
+Converts\ ordinals\ to\ LaTeX\ superscripts.=
+Converts\ units\ to\ LaTeX\ formatting.=
+HTML\ to\ LaTeX=
+LaTeX\ cleanup=
+LaTeX\ to\ Unicode=
+Lower\ case=
+Minify\ list\ of\ person\ names=
+Normalize\ date=
+Normalize\ month=
+Normalize\ month\ to\ BibTeX\ standard\ abbreviation.=
+Normalize\ names\ of\ persons=
+Normalize\ page\ numbers=
+Normalize\ pages\ to\ BibTeX\ standard.=
+Normalizes\ lists\ of\ persons\ to\ the\ BibTeX\ standard.=
+Normalizes\ the\ date\ to\ ISO\ date\ format.=
+Ordinals\ to\ LaTeX\ superscript=
+Protect\ terms=
+Remove\ enclosing\ braces=
+Removes\ braces\ encapsulating\ the\ complete\ field\ content.=
+Sentence\ case=
+Shortens\ lists\ of\ persons\ if\ there\ are\ more\ than\ 2\ persons\ to\ "et\ al.".=
+Title\ case=
+Unicode\ to\ LaTeX=
+Units\ to\ LaTeX=
+Upper\ case=
+Does\ nothing.=
 Identity=
-Clears_the_field_completely.=
-Directory_not_found=
-Main_file_directory_not_set\!=
-This_operation_requires_exactly_one_item_to_be_selected.=
-Importing_in_%0_format=
-Female_name=
-Female_names=
-Male_name=
-Male_names=
-Mixed_names=
-Neuter_name=
-Neuter_names=
+Clears\ the\ field\ completely.=
+Directory\ not\ found=
+Main\ file\ directory\ not\ set\!=
+This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=
+Importing\ in\ %0\ format=
+Female\ name=
+Female\ names=
+Male\ name=
+Male\ names=
+Mixed\ names=
+Neuter\ name=
+Neuter\ names=
 
-Determined_%0_for_%1_entries=
-Look_up_%0=
-Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3=
+Determined\ %0\ for\ %1\ entries=
+Look\ up\ %0=
+Looking\ up\ %0...\ -\ entry\ %1\ out\ of\ %2\ -\ found\ %3=
 
-Audio_CD=
-British_patent=
-British_patent_request=
-Candidate_thesis=
+Audio\ CD=
+British\ patent=
+British\ patent\ request=
+Candidate\ thesis=
 Collaborator=
 Column=
 Compiler=
 Continuator=
-Data_CD=
+Data\ CD=
 Editor=
-European_patent=
-European_patent_request=
+European\ patent=
+European\ patent\ request=
 Founder=
-French_patent=
-French_patent_request=
-German_patent=
-German_patent_request=
+French\ patent=
+French\ patent\ request=
+German\ patent=
+German\ patent\ request=
 Line=
-Master's_thesis=
+Master's\ thesis=
 Page=
 Paragraph=
 Patent=
-Patent_request=
-PhD_thesis=
+Patent\ request=
+PhD\ thesis=
 Redactor=
-Research_report=
+Research\ report=
 Reviser=
 Section=
 Software=
-Technical_report=
-U.S._patent=
-U.S._patent_request=
+Technical\ report=
+U.S.\ patent=
+U.S.\ patent\ request=
 Verse=
 
-change_entries_of_group=
-odd_number_of_unescaped_'\#'=
+change\ entries\ of\ group=
+odd\ number\ of\ unescaped\ '\#'=
 
-Plain_text=
-Show_diff=
+Plain\ text=
+Show\ diff=
 character=
 word=
-Show_symmetric_diff=
-Copy_Version=
+Show\ symmetric\ diff=
+Copy\ Version=
 Developers=
 Authors=
 License=
 
-HTML_encoded_character_found=
-booktitle_ends_with_'conference_on'=
+HTML\ encoded\ character\ found=
+booktitle\ ends\ with\ 'conference\ on'=
 
-All_external_files=
+All\ external\ files=
 
-OpenOffice/LibreOffice_integration=
+OpenOffice/LibreOffice\ integration=
 
-incorrect_control_digit=
-incorrect_format=
-Copied_version_to_clipboard=
+incorrect\ control\ digit=
+incorrect\ format=
+Copied\ version\ to\ clipboard=
 
-BibTeX_key=
+BibTeX\ key=
 Message=
 
 
-MathSciNet_Review=
-Reset_Bindings=
+MathSciNet\ Review=
+Reset\ Bindings=
 
-Decryption_not_supported.=
+Decryption\ not\ supported.=
 
-Cleared_'%0'_for_%1_entries=
-Set_'%0'_to_'%1'_for_%2_entries=
-Toggled_'%0'_for_%1_entries=
+Cleared\ '%0'\ for\ %1\ entries=
+Set\ '%0'\ to\ '%1'\ for\ %2\ entries=
+Toggled\ '%0'\ for\ %1\ entries=
 
-Check_for_updates=
-Download_update=
-New_version_available=
-Installed_version=
-Remind_me_later=
-Ignore_this_update=
-Could_not_connect_to_the_update_server.=
-Please_try_again_later_and/or_check_your_network_connection.=
-To_see_what_is_new_view_the_changelog.=
-A_new_version_of_JabRef_has_been_released.=
-JabRef_is_up-to-date.=
-Latest_version=
-Online_help_forum=
+Check\ for\ updates=
+Download\ update=
+New\ version\ available=
+Installed\ version=
+Remind\ me\ later=
+Ignore\ this\ update=
+Could\ not\ connect\ to\ the\ update\ server.=
+Please\ try\ again\ later\ and/or\ check\ your\ network\ connection.=
+To\ see\ what\ is\ new\ view\ the\ changelog.=
+A\ new\ version\ of\ JabRef\ has\ been\ released.=
+JabRef\ is\ up-to-date.=
+Latest\ version=
+Online\ help\ forum=
 Custom=
 
-Export_cited=
-Unable_to_generate_new_library=
+Export\ cited=
+Unable\ to\ generate\ new\ library=
 
-Open_console=
-Use_default_terminal_emulator=
-Execute_command=
-Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.=
-Executing_command_\"%0\"...=
-Error_occured_while_executing_the_command_\"%0\".=
-Reformat_ISSN=
+Open\ console=
+Use\ default\ terminal\ emulator=
+Execute\ command=
+Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=
+Executing\ command\ \"%0\"...=
+Error\ occured\ while\ executing\ the\ command\ \"%0\".=
+Reformat\ ISSN=
 
-Countries_and_territories_in_English=
-Electrical_engineering_terms=
+Countries\ and\ territories\ in\ English=
+Electrical\ engineering\ terms=
 Enabled=
-Internal_list=
-Manage_protected_terms_files=
-Months_and_weekdays_in_English=
-The_text_after_the_last_line_starting_with_\#_will_be_used=
-Add_protected_terms_file=
-Are_you_sure_you_want_to_remove_the_protected_terms_file?=
-Remove_protected_terms_file=
-Add_selected_text_to_list=
-Add_{}_around_selected_text=
-Format_field=
-New_protected_terms_file=
-change_field_%0_of_entry_%1_from_%2_to_%3=
-change_key_from_%0_to_%1=
-change_string_content_%0_to_%1=
-change_string_name_%0_to_%1=
-change_type_of_entry_%0_from_%1_to_%2=
-insert_entry_%0=
-insert_string_%0=
-remove_entry_%0=
-remove_string_%0=
+Internal\ list=
+Manage\ protected\ terms\ files=
+Months\ and\ weekdays\ in\ English=
+The\ text\ after\ the\ last\ line\ starting\ with\ \#\ will\ be\ used=
+Add\ protected\ terms\ file=
+Are\ you\ sure\ you\ want\ to\ remove\ the\ protected\ terms\ file?=
+Remove\ protected\ terms\ file=
+Add\ selected\ text\ to\ list=
+Add\ {}\ around\ selected\ text=
+Format\ field=
+New\ protected\ terms\ file=
+change\ field\ %0\ of\ entry\ %1\ from\ %2\ to\ %3=
+change\ key\ from\ %0\ to\ %1=
+change\ string\ content\ %0\ to\ %1=
+change\ string\ name\ %0\ to\ %1=
+change\ type\ of\ entry\ %0\ from\ %1\ to\ %2=
+insert\ entry\ %0=
+insert\ string\ %0=
+remove\ entry\ %0=
+remove\ string\ %0=
 undefined=
-Cannot_get_info_based_on_given_%0\:_%1=
-Get_BibTeX_data_from_%0=
-No_%0_found=
-Entry_from_%0=
-Merge_entry_with_%0_information=
-Updated_entry_with_info_from_%0=
+Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=
+Get\ BibTeX\ data\ from\ %0=
+No\ %0\ found=
+Entry\ from\ %0=
+Merge\ entry\ with\ %0\ information=
+Updated\ entry\ with\ info\ from\ %0=
 
-Add_existing_file=
-Create_new_list=
-Remove_list=
-Full_journal_name=
-Abbreviation_name=
+Add\ existing\ file=
+Create\ new\ list=
+Remove\ list=
+Full\ journal\ name=
+Abbreviation\ name=
 
-No_abbreviation_files_loaded=
+No\ abbreviation\ files\ loaded=
 
-Loading_built_in_lists=
+Loading\ built\ in\ lists=
 
-JabRef_built_in_list=
-IEEE_built_in_list=
+JabRef\ built\ in\ list=
+IEEE\ built\ in\ list=
 
-Event_log=
-We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.=
-Log_copied_to_clipboard.=
-Copy_Log=
-Clear_Log=
-Report_Issue=
-Issue_on_GitHub_successfully_reported.=
-Issue_report_successful=
-Your_issue_was_reported_in_your_browser.=
-The_log_and_exception_information_was_copied_to_your_clipboard.=
-Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.=
+Event\ log=
+We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef\'s\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=
+Log\ copied\ to\ clipboard.=
+Copy\ Log=
+Clear\ Log=
+Report\ Issue=
+Issue\ on\ GitHub\ successfully\ reported.=
+Issue\ report\ successful=
+Your\ issue\ was\ reported\ in\ your\ browser.=
+The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=
+Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=
 
 Connection=
 Connecting...=
@@ -2164,194 +2164,194 @@ Port=Poort
 Library=
 User=
 Connect=Verbinden
-Connection_error=
-Connection_to_%0_server_established.=
-Required_field_"%0"_is_empty.=
-%0_driver_not_available.=
-The_connection_to_the_server_has_been_terminated.=
-Connection_lost.=
+Connection\ error=
+Connection\ to\ %0\ server\ established.=
+Required\ field\ "%0"\ is\ empty.=
+%0\ driver\ not\ available.=
+The\ connection\ to\ the\ server\ has\ been\ terminated.=
+Connection\ lost.=
 Reconnect=
-Work_offline=
-Working_offline.=
-Update_refused.=
-Update_refused=
-Local_entry=
-Shared_entry=
-Update_could_not_be_performed_due_to_existing_change_conflicts.=
-You_are_not_working_on_the_newest_version_of_BibEntry.=
-Local_version\:_%0=
-Shared_version\:_%0=
-Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.=
-Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?=
-Shared_entry_is_no_longer_present=
-The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.=
-You_can_restore_the_entry_using_the_"Undo"_operation.=
-Remember_password?=
-You_are_already_connected_to_a_database_using_entered_connection_details.=
+Work\ offline=
+Working\ offline.=
+Update\ refused.=
+Update\ refused=
+Local\ entry=
+Shared\ entry=
+Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=
+You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=
+Local\ version\:\ %0=
+Shared\ version\:\ %0=
+Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=
+Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=
+Shared\ entry\ is\ no\ longer\ present=
+The\ BibEntry\ you\ currently\ work\ on\ has\ been\ deleted\ on\ the\ shared\ side.=
+You\ can\ restore\ the\ entry\ using\ the\ "Undo"\ operation.=
+Remember\ password?=
+You\ are\ already\ connected\ to\ a\ database\ using\ entered\ connection\ details.=
 
-Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?=
-New_technical_report=
+Cannot\ cite\ entries\ without\ BibTeX\ keys.\ Generate\ keys\ now?=
+New\ technical\ report=
 
-%0_file=
-Custom_layout_file=
-Protected_terms_file=
-Style_file=
+%0\ file=
+Custom\ layout\ file=
+Protected\ terms\ file=
+Style\ file=
 
-Open_OpenOffice/LibreOffice_connection=
-You_must_enter_at_least_one_field_name=
-Non-ASCII_encoded_character_found=
-Toggle_web_search_interface=
-Background_color_for_resolved_fields=
-Color_code_for_resolved_fields=
-%0_files_found=
-%0_of_%1=
-One_file_found=
-The_import_finished_with_warnings\:=
-There_was_one_file_that_could_not_be_imported.=
-There_were_%0_files_which_could_not_be_imported.=
+Open\ OpenOffice/LibreOffice\ connection=
+You\ must\ enter\ at\ least\ one\ field\ name=
+Non-ASCII\ encoded\ character\ found=
+Toggle\ web\ search\ interface=
+Background\ color\ for\ resolved\ fields=
+Color\ code\ for\ resolved\ fields=
+%0\ files\ found=
+%0\ of\ %1=
+One\ file\ found=
+The\ import\ finished\ with\ warnings\:=
+There\ was\ one\ file\ that\ could\ not\ be\ imported.=
+There\ were\ %0\ files\ which\ could\ not\ be\ imported.=
 
-Migration_help_information=
-Entered_database_has_obsolete_structure_and_is_no_longer_supported.=
-However,_a_new_database_was_created_alongside_the_pre-3.6_one.=
-Click_here_to_learn_about_the_migration_of_pre-3.6_databases.=
-Opens_JabRef's_Facebook_page=
-Opens_JabRef's_blog=
-Opens_JabRef's_website=
-Opens_a_link_where_the_current_development_version_can_be_downloaded=
-See_what_has_been_changed_in_the_JabRef_versions=
-Referenced_BibTeX_key_does_not_exist=
-Finished_downloading_full_text_document_for_entry_%0.=
-Full_text_document_download_failed_for_entry_%0.=
-Look_up_full_text_documents=
-You_are_about_to_look_up_full_text_documents_for_%0_entries.=
-last_four_nonpunctuation_characters_should_be_numerals=
+Migration\ help\ information=
+Entered\ database\ has\ obsolete\ structure\ and\ is\ no\ longer\ supported.=
+However,\ a\ new\ database\ was\ created\ alongside\ the\ pre-3.6\ one.=
+Click\ here\ to\ learn\ about\ the\ migration\ of\ pre-3.6\ databases.=
+Opens\ JabRef's\ Facebook\ page=
+Opens\ JabRef's\ blog=
+Opens\ JabRef's\ website=
+Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=
+See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=
+Referenced\ BibTeX\ key\ does\ not\ exist=
+Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=
+Full\ text\ document\ download\ failed\ for\ entry\ %0.=
+Look\ up\ full\ text\ documents=
+You\ are\ about\ to\ look\ up\ full\ text\ documents\ for\ %0\ entries.=
+last\ four\ nonpunctuation\ characters\ should\ be\ numerals=
 
 Author=
 Date=
-File_annotations=
-Show_file_annotations=
-Adobe_Acrobat_Reader=
-Sumatra_Reader=
+File\ annotations=
+Show\ file\ annotations=
+Adobe\ Acrobat\ Reader=
+Sumatra\ Reader=
 shared=
-should_contain_an_integer_or_a_literal=
-should_have_the_first_letter_capitalized=
+should\ contain\ an\ integer\ or\ a\ literal=
+should\ have\ the\ first\ letter\ capitalized=
 Tools=
-What\'s_new_in_this_version?=
-Want_to_help?=
-Make_a_donation=
-get_involved=
-Used_libraries=
-Existing_file=
+What\'s\ new\ in\ this\ version?=
+Want\ to\ help?=
+Make\ a\ donation=
+get\ involved=
+Used\ libraries=
+Existing\ file=
 
 ID=
-ID_type=
-ID-based_entry_generator=
-Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+ID\ type=
+ID-based\ entry\ generator=
+Fetcher\ '%0'\ did\ not\ find\ an\ entry\ for\ id\ '%1'.=
 
-Select_first_entry=
-Select_last_entry=
+Select\ first\ entry=
+Select\ last\ entry=
 
-Invalid_ISBN\:_'%0'.=
-should_be_an_integer_or_normalized=
-should_be_normalized=
+Invalid\ ISBN\:\ '%0'.=
+should\ be\ an\ integer\ or\ normalized=
+should\ be\ normalized=
 
-Empty_search_ID=
-The_given_search_ID_was_empty.=
-Copy_BibTeX_key_and_link=
-empty_BibTeX_key=
-biblatex_field_only=
+Empty\ search\ ID=
+The\ given\ search\ ID\ was\ empty.=
+Copy\ BibTeX\ key\ and\ link=
+empty\ BibTeX\ key=
+biblatex\ field\ only=
 
-Error_while_generating_fetch_URL=
-Error_while_parsing_ID_list=
-Unable_to_get_PubMed_IDs=
-Backup_found=
-A_backup_file_for_'%0'_was_found.=
-This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.=
-Do_you_want_to_recover_the_library_from_the_backup_file?=
-Firstname_Lastname=
+Error\ while\ generating\ fetch\ URL=
+Error\ while\ parsing\ ID\ list=
+Unable\ to\ get\ PubMed\ IDs=
+Backup\ found=
+A\ backup\ file\ for\ '%0'\ was\ found.=
+This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=
+Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=
+Firstname\ Lastname=
 
-Recommended_for_%0=
-Show_'Related_Articles'_tab=
-This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
+Recommended\ for\ %0=
+Show\ 'Related\ Articles'\ tab=
+This\ might\ be\ caused\ by\ reaching\ the\ traffic\ limitation\ of\ Google\ Scholar\ (see\ 'Help'\ for\ details).=
 
-Could_not_open_website.=
-Problem_downloading_from_%1=
+Could\ not\ open\ website.=
+Problem\ downloading\ from\ %1=
 
-File_directory_pattern=
-Update_with_bibliographic_information_from_the_web=
+File\ directory\ pattern=
+Update\ with\ bibliographic\ information\ from\ the\ web=
 
-Could_not_find_any_bibliographic_information.=
-BibTeX_key_deviates_from_generated_key=
-DOI_%0_is_invalid=
+Could\ not\ find\ any\ bibliographic\ information.=
+BibTeX\ key\ deviates\ from\ generated\ key=
+DOI\ %0\ is\ invalid=
 
-Select_all_customized_types_to_be_stored_in_local_preferences=
-Currently_unknown=
-Different_customization,_current_settings_will_be_overwritten=
+Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences=
+Currently\ unknown=
+Different\ customization,\ current\ settings\ will\ be\ overwritten=
 
-Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX=
-Jump_to_entry=
+Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=
+Jump\ to\ entry=
 
-Copied_%0_citations.=
+Copied\ %0\ citations.=
 Copying...=
 
-journal_not_found_in_abbreviation_list=
-Unhandled_exception_occurred.=
+journal\ not\ found\ in\ abbreviation\ list=
+Unhandled\ exception\ occurred.=
 
-strings_included=
-Color_for_disabled_icons=
-Color_for_enabled_icons=
-Size_of_large_icons=
-Size_of_small_icons=
-Default_table_font_size=
-Escape_underscores=
+strings\ included=
+Color\ for\ disabled\ icons=
+Color\ for\ enabled\ icons=
+Size\ of\ large\ icons=
+Size\ of\ small\ icons=
+Default\ table\ font\ size=
+Escape\ underscores=
 Color=
-Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=
-Fit_width=
-Fit_a_single_page=
-Zoom_in=
-Zoom_out=
-Previous_page=
-Next_page=
-Document_viewer=
+Please\ also\ add\ all\ steps\ to\ reproduce\ this\ issue,\ if\ possible.=
+Fit\ width=
+Fit\ a\ single\ page=
+Zoom\ in=
+Zoom\ out=
+Previous\ page=
+Next\ page=
+Document\ viewer=
 Live=
 Locked=
-Show_document_viewer=
-Show_the_document_of_the_currently_selected_entry.=
-Show_this_document_until_unlocked.=
-Set_current_user_name_as_owner.=
+Show\ document\ viewer=
+Show\ the\ document\ of\ the\ currently\ selected\ entry.=
+Show\ this\ document\ until\ unlocked.=
+Set\ current\ user\ name\ as\ owner.=
 
-Sort_all_subgroups_(recursively)=
-Collect_and_share_telemetry_data_to_help_improve_JabRef.=
-Don't_share=
-Share_anonymous_statistics=
-Telemetry\:_Help_make_JabRef_better=
-To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.=
-This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?=
-Names_are_not_in_the_standard_%0_format.=
+Sort\ all\ subgroups\ (recursively)=
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=
+Don't\ share=
+Share\ anonymous\ statistics=
+Telemetry\:\ Help\ make\ JabRef\ better=
+To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ statistics\ on\ the\ features\ you\ use.\ We\ will\ only\ record\ what\ features\ you\ access\ and\ how\ often\ you\ do\ it.\ We\ will\ neither\ collect\ any\ personal\ data\ nor\ the\ content\ of\ bibliographic\ items.\ If\ you\ choose\ to\ allow\ data\ collection,\ you\ can\ later\ disable\ it\ via\ Options\ ->\ Preferences\ ->\ General.=
+This\ file\ was\ found\ automatically.\ Do\ you\ want\ to\ link\ it\ to\ this\ entry?=
+Names\ are\ not\ in\ the\ standard\ %0\ format.=
 
-Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.=
-Delete_'%0'=
-Delete_from_disk=
-Remove_from_entry=
-The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.=
-There_exists_already_a_group_with_the_same_name.=
+Delete\ the\ selected\ file\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ file\ permanently\ from\ disk.=
+Delete\ '%0'=
+Delete\ from\ disk=
+Remove\ from\ entry=
+The\ group\ name\ contains\ the\ keyword\ separator\ "%0"\ and\ thus\ probably\ does\ not\ work\ as\ expected.=
+There\ exists\ already\ a\ group\ with\ the\ same\ name.=
 
-Copy_linked_files_to_folder...=
-Copied_file_successfully=
-Copying_files...=
-Copying_file_%0_of_entry_%1=
-Finished_copying=
-Could_not_copy_file=
-Copied_%0_files_of_%1_sucessfully_to_%2=
-Rename_failed=
-JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.=
-Show_console_output_(only_necessary_when_the_launcher_is_used)=
+Copy\ linked\ files\ to\ folder...=
+Copied\ file\ successfully=
+Copying\ files...=
+Copying\ file\ %0\ of\ entry\ %1=
+Finished\ copying=
+Could\ not\ copy\ file=
+Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=
+Rename\ failed=
+JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=
+Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=
 
-Remove_line_breaks=
-Removes_all_line_breaks_in_the_field_content.=
-Checking_integrity...=
+Remove\ line\ breaks=
+Removes\ all\ line\ breaks\ in\ the\ field\ content.=
+Checking\ integrity...=
 
-Remove_hyphenated_line_breaks=
-Removes_all_hyphenated_line_breaks_in_the_field_content.=
-Note_that_currently,_JabRef_does_not_run_with_Java_9.=
-Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.=
+Remove\ hyphenated\ line\ breaks=
+Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=
+Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=
+Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -3,478 +3,478 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-%0_contains_the_regular_expression_<b>%1</b>=%0_inneholder_regul\u00e6ruttrykket_<b>%1</b>
+%0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 inneholder regul\u00e6ruttrykket <b>%1</b>
 
-%0_contains_the_term_<b>%1</b>=%0_inneholder_uttrykket_<b>%1</b>
+%0\ contains\ the\ term\ <b>%1</b>=%0 inneholder uttrykket <b>%1</b>
 
-%0_doesn't_contain_the_regular_expression_<b>%1</b>=%0_inneholder_ikke_regul\u00e6ruttrykket_<b>%1</b>
+%0\ doesn't\ contain\ the\ regular\ expression\ <b>%1</b>=%0 inneholder ikke regul\u00e6ruttrykket <b>%1</b>
 
-%0_doesn't_contain_the_term_<b>%1</b>=%0_inneholder_ikke_uttrykket_<b>%1</b>
+%0\ doesn't\ contain\ the\ term\ <b>%1</b>=%0 inneholder ikke uttrykket <b>%1</b>
 
-%0_export_successful=%0-eksport_lyktes
+%0\ export\ successful=%0-eksport lyktes
 
-%0_matches_the_regular_expression_<b>%1</b>=%0_matcher_regul\u00e6ruttrykket_<b>%1</b>
+%0\ matches\ the\ regular\ expression\ <b>%1</b>=%0 matcher regul\u00e6ruttrykket <b>%1</b>
 
-%0_matches_the_term_<b>%1</b>=%0_matcher_uttrykket_<b>%1</b>
+%0\ matches\ the\ term\ <b>%1</b>=%0 matcher uttrykket <b>%1</b>
 
-<field_name>=<feltnavn>
-<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>=<HTML>Kunne_ikke_finne_filen_'%0'<BR>linket_fra_enheten_'%1'</HTML>
+<field\ name>=<feltnavn>
+<HTML>Could\ not\ find\ file\ '%0'<BR>linked\ from\ entry\ '%1'</HTML>=<HTML>Kunne ikke finne filen '%0'<BR>linket fra enheten '%1'</HTML>
 
 <select>=<velg>
 
-<select_word>=<velg_ord>
-Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)=Forkort_journalnavn_for_de_valgte_enhetene_(ISO-forkortelse)
-Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)=Forkort_journalnavn_for_de_valgte_enhetene_(MEDLINE-forkortelse)
+<select\ word>=<velg ord>
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (ISO\ abbreviation)=Forkort journalnavn for de valgte enhetene (ISO-forkortelse)
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (MEDLINE\ abbreviation)=Forkort journalnavn for de valgte enhetene (MEDLINE-forkortelse)
 
-Abbreviate_names=Forkort_navn
-Abbreviated_%0_journal_names.=Fortkortet_%0_journalnavn.
+Abbreviate\ names=Forkort navn
+Abbreviated\ %0\ journal\ names.=Fortkortet %0 journalnavn.
 
 Abbreviation=Forkortelse
 
-About_JabRef=Om_JabRef
+About\ JabRef=Om JabRef
 
 Abstract=Sammendrag
 
 Accept=Aksepter
 
-Accept_change=Aksepter_endring
+Accept\ change=Aksepter endring
 
 Action=Aksjon
 
-What_is_Mr._DLib?=
+What\ is\ Mr.\ DLib?=
 
-Add=Legg_til
+Add=Legg til
 
-Add_a_(compiled)_custom_Importer_class_from_a_class_path.=Legg_til_en_(kompilert)_egendefinert_Importer-klasse_fra_en_classpath.
-The_path_need_not_be_on_the_classpath_of_JabRef.=Stien_trenger_ikke_\u00e5_v\u00e6re_p\u00e5_JabRefs_classpath.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=Legg til en (kompilert) egendefinert Importer-klasse fra en classpath.
+The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=Stien trenger ikke \u00e5 v\u00e6re p\u00e5 JabRefs classpath.
 
-Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=Legg_til_en_(kompilert)_egendefinert_Importer-klasse_fra_en_zip-fil.
-The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=ZIP-filen_trenger_ikke_\u00e5_v\u00e6re_p\u00e5_JabRefs_classpath.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=Legg til en (kompilert) egendefinert Importer-klasse fra en zip-fil.
+The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=ZIP-filen trenger ikke \u00e5 v\u00e6re p\u00e5 JabRefs classpath.
 
-Add_a_regular_expression_for_the_key_pattern.=
+Add\ a\ regular\ expression\ for\ the\ key\ pattern.=
 
-Add_selected_entries_to_this_group=
+Add\ selected\ entries\ to\ this\ group=
 
-Add_from_folder=Legg_til_fra_mappe
+Add\ from\ folder=Legg til fra mappe
 
-Add_from_JAR=Legg_til_fra_JAR-fil
+Add\ from\ JAR=Legg til fra JAR-fil
 
-add_group=legg_til_gruppe
+add\ group=legg til gruppe
 
-Add_new=Legg_til_ny
+Add\ new=Legg til ny
 
-Add_subgroup=Legg_til_undergruppe
+Add\ subgroup=Legg til undergruppe
 
-Add_to_group=Legg_til_i_gruppe
+Add\ to\ group=Legg til i gruppe
 
-Added_group_"%0".=La_til_gruppe_"%0".
+Added\ group\ "%0".=La til gruppe "%0".
 
-Added_missing_braces.=
+Added\ missing\ braces.=
 
-Added_new=La_til_ny
+Added\ new=La til ny
 
-Added_string=La_til_streng
+Added\ string=La til streng
 
-Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.=Dessuten,_enheter_hvis_<b>%0</b>-felt_ikke_inneholder_<b>%1</b>_kan_legges_manuelt_til_denne_gruppen_ved_\u00e5_velge_dem,_og_enten_dra_dem_over_eller_bruke_kontekstmenyen._Denne_prosessen_legger_til_uttrykket_<b>%1</b>_til_hver_av_enhetenes_<b>%0</b>-felt._Enheter_kan_fjernes_manuelt_fra_denne_gruppen_ved_\u00e5_velge_dem_og_deretter_bruke_kontekstmenyen._Denne_prosessen_fjerner_uttrykket_<b>%1</b>_fra_hver_av_enhetenes_<b>%0</b>-felt.
+Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ can\ be\ assigned\ manually\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ This\ process\ adds\ the\ term\ <b>%1</b>\ to\ each\ entry's\ <b>%0</b>\ field.\ Entries\ can\ be\ removed\ manually\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.\ This\ process\ removes\ the\ term\ <b>%1</b>\ from\ each\ entry's\ <b>%0</b>\ field.=Dessuten, enheter hvis <b>%0</b>-felt ikke inneholder <b>%1</b> kan legges manuelt til denne gruppen ved \u00e5 velge dem, og enten dra dem over eller bruke kontekstmenyen. Denne prosessen legger til uttrykket <b>%1</b> til hver av enhetenes <b>%0</b>-felt. Enheter kan fjernes manuelt fra denne gruppen ved \u00e5 velge dem og deretter bruke kontekstmenyen. Denne prosessen fjerner uttrykket <b>%1</b> fra hver av enhetenes <b>%0</b>-felt.
 
 Advanced=Avansert
-All_entries=Alle_enheter
-All_entries_of_this_type_will_be_declared_typeless._Continue?=Alle_enhetene_av_denne_typen_vil_bli_klassifisert_som_typel\u00f8se._Fortsette?
+All\ entries=Alle enheter
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=Alle enhetene av denne typen vil bli klassifisert som typel\u00f8se. Fortsette?
 
-All_fields=Alle_felter
+All\ fields=Alle felter
 
-Always_reformat_BIB_file_on_save_and_export=
+Always\ reformat\ BIB\ file\ on\ save\ and\ export=
 
-A_SAX_exception_occurred_while_parsing_'%0'\:=En_SAXException_forekom_ved_lesing_av_'%0'\:
+A\ SAX\ exception\ occurred\ while\ parsing\ '%0'\:=En SAXException forekom ved lesing av '%0':
 
 and=og
-and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.=og_klassen_m\u00e5_v\u00e6re_tilgjengelig_i_CLASSPATH_neste_gang_du_starter_JabRef.
+and\ the\ class\ must\ be\ available\ in\ your\ classpath\ next\ time\ you\ start\ JabRef.=og klassen m\u00e5 v\u00e6re tilgjengelig i CLASSPATH neste gang du starter JabRef.
 
-any_field_that_matches_the_regular_expression_<b>%0</b>=ethvert_felt_som_matcher_regul\u00e6ruttrykket_<b>%0</b>
+any\ field\ that\ matches\ the\ regular\ expression\ <b>%0</b>=ethvert felt som matcher regul\u00e6ruttrykket <b>%0</b>
 
 Appearance=Utseende
 
-Append=Legg_til
-Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library=Legg_til_innhold_fra_en_BibTeX-library_i_den_\u00e5pne_library
+Append=Legg til
+Append\ contents\ from\ a\ BibTeX\ library\ into\ the\ currently\ viewed\ library=Legg til innhold fra en BibTeX-library i den \u00e5pne library
 
-Append_library=Append_library
+Append\ library=Append library
 
-Append_the_selected_text_to_BibTeX_field=Legg_til_den_valgte_teksten_til_BibTeX-n\u00f8kkelen
+Append\ the\ selected\ text\ to\ BibTeX\ field=Legg til den valgte teksten til BibTeX-n\u00f8kkelen
 Application=Applikasjon
 
 Apply=Utf\u00f8r
 
-Arguments_passed_on_to_running_JabRef_instance._Shutting_down.=Argumentene_sendt_til_allerede_aktiv_JabRef-instans._Avslutter.
+Arguments\ passed\ on\ to\ running\ JabRef\ instance.\ Shutting\ down.=Argumentene sendt til allerede aktiv JabRef-instans. Avslutter.
 
-Assign_new_file=Tilordne_ny_fil
+Assign\ new\ file=Tilordne ny fil
 
-Assign_the_original_group's_entries_to_this_group?=Legg_den_opprinnelige_gruppens_enheter_til_denne_gruppen?
+Assign\ the\ original\ group's\ entries\ to\ this\ group?=Legg den opprinnelige gruppens enheter til denne gruppen?
 
-Assigned_%0_entries_to_group_"%1".=La_til_%0_enheter_til_gruppen_"%1".
+Assigned\ %0\ entries\ to\ group\ "%1".=La til %0 enheter til gruppen "%1".
 
-Assigned_1_entry_to_group_"%0".=La_til_1_enhet_til_gruppen_"%0".
+Assigned\ 1\ entry\ to\ group\ "%0".=La til 1 enhet til gruppen "%0".
 
-Attach_URL=Tilordne_URL
+Attach\ URL=Tilordne URL
 
-Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.=Pr\u00f8v_\u00e5_sette_fil-linker_automatisk_for_dine_enheter._Dette_virker_dersom_en_fil_i_fil-katalogen_din_eller_en_underkatalog<BR>har_navn_likt_en_enhets_BibTeX-n\u00f8kkel,_pluss_etternavn.
+Attempt\ to\ automatically\ set\ file\ links\ for\ your\ entries.\ Automatically\ setting\ works\ if\ a\ file\ in\ your\ file\ directory<BR>or\ a\ subdirectory\ is\ named\ identically\ to\ an\ entry's\ BibTeX\ key,\ plus\ extension.=Pr\u00f8v \u00e5 sette fil-linker automatisk for dine enheter. Dette virker dersom en fil i fil-katalogen din eller en underkatalog<BR>har navn likt en enhets BibTeX-n\u00f8kkel, pluss etternavn.
 
-Autodetect_format=Autodetekter_format
+Autodetect\ format=Autodetekter format
 
-Autogenerate_BibTeX_keys=Autogenerer_BibTeX-n\u00f8kler
+Autogenerate\ BibTeX\ keys=Autogenerer BibTeX-n\u00f8kler
 
-Autolink_files_with_names_starting_with_the_BibTeX_key=Autolink_filer_med_navn_som_starter_med_BibTeX-n\u00f8kkelen
+Autolink\ files\ with\ names\ starting\ with\ the\ BibTeX\ key=Autolink filer med navn som starter med BibTeX-n\u00f8kkelen
 
-Autolink_only_files_that_match_the_BibTeX_key=Autolink_bare_filer_med_navn_som_samsvarer_med_BibTeX-n\u00f8kkelen
+Autolink\ only\ files\ that\ match\ the\ BibTeX\ key=Autolink bare filer med navn som samsvarer med BibTeX-n\u00f8kkelen
 
-Automatically_create_groups=Generer_grupper_automatisk
+Automatically\ create\ groups=Generer grupper automatisk
 
-Automatically_remove_exact_duplicates=Fjern_eksakte_duplikater_automatisk
+Automatically\ remove\ exact\ duplicates=Fjern eksakte duplikater automatisk
 
-Allow_overwriting_existing_links.=Tillat_overskriving_av_eksisterende_linker.
+Allow\ overwriting\ existing\ links.=Tillat overskriving av eksisterende linker.
 
-Do_not_overwrite_existing_links.=Skriv_ikke_over_eksisterende_linker.
+Do\ not\ overwrite\ existing\ links.=Skriv ikke over eksisterende linker.
 
-AUX_file_import=AUX-fil_import
+AUX\ file\ import=AUX-fil import
 
-Available_export_formats=Tilgjengelige_eksportformater
+Available\ export\ formats=Tilgjengelige eksportformater
 
-Available_BibTeX_fields=Tilgjengelige_felter
+Available\ BibTeX\ fields=Tilgjengelige felter
 
-Available_import_formats=Tilgjengelige_importformater
+Available\ import\ formats=Tilgjengelige importformater
 
-Background_color_for_optional_fields=Bakgrunnsfarge_for_valgfrie_felter
+Background\ color\ for\ optional\ fields=Bakgrunnsfarge for valgfrie felter
 
-Background_color_for_required_fields=Bakgrunnsfarge_for_n\u00f8dvendige_felter
+Background\ color\ for\ required\ fields=Bakgrunnsfarge for n\u00f8dvendige felter
 
-Backup_old_file_when_saving=Lag_sikkerhetskopi_ved_lagring
+Backup\ old\ file\ when\ saving=Lag sikkerhetskopi ved lagring
 
-BibTeX_key_is_unique.=BibTeX-n\u00f8kkelen_er_unik
+BibTeX\ key\ is\ unique.=BibTeX-n\u00f8kkelen er unik
 
-%0_source=%0-kilde
+%0\ source=%0-kilde
 
-Broken_link=Ugyldig_link
+Broken\ link=Ugyldig link
 
-Browse=Bla_gjennom
+Browse=Bla gjennom
 
 by=med
 
 Cancel=Avbryt
 
-Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?=Kan_ikke_legge_til_enheter_til_en_gruppe_uten_\u00e5_generere_n\u00f8kler._Vil_du_generer_n\u00f8kler_n\u00e5?
+Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=Kan ikke legge til enheter til en gruppe uten \u00e5 generere n\u00f8kler. Vil du generer n\u00f8kler n\u00e5?
 
-Cannot_merge_this_change=Kan_ikke_inkorporere_denne_endringen
+Cannot\ merge\ this\ change=Kan ikke inkorporere denne endringen
 
-case_insensitive=skiller_ikke_mellom_store_og_sm\u00e5_bokstaver
+case\ insensitive=skiller ikke mellom store og sm\u00e5 bokstaver
 
-case_sensitive=skiller_mellom_store_og_sm\u00e5_bokstaver
+case\ sensitive=skiller mellom store og sm\u00e5 bokstaver
 
-Case_sensitive=Skill_store_og_sm\u00e5_bokstaver
+Case\ sensitive=Skill store og sm\u00e5 bokstaver
 
-change_assignment_of_entries=endre_tilordning_av_enheter
+change\ assignment\ of\ entries=endre tilordning av enheter
 
-Change_case=Endre_store/sm\u00e5_bokstaver
+Change\ case=Endre store/sm\u00e5 bokstaver
 
-Change_entry_type=Endre_enhetstype
-Change_file_type=Endre_filtype
+Change\ entry\ type=Endre enhetstype
+Change\ file\ type=Endre filtype
 
 
-Change_of_Grouping_Method=Endre_grupperingsm\u00e5te
+Change\ of\ Grouping\ Method=Endre grupperingsm\u00e5te
 
-change_preamble=endre_'preamble'
+change\ preamble=endre 'preamble'
 
-Change_table_column_and_General_fields_settings_to_use_the_new_feature=Endre_oppsett_for_tabellkollonner_og_generelle_felter_for_\u00e5_ta_i_bruk_den_nye_funksjonen
+Change\ table\ column\ and\ General\ fields\ settings\ to\ use\ the\ new\ feature=Endre oppsett for tabellkollonner og generelle felter for \u00e5 ta i bruk den nye funksjonen
 
-Changed_language_settings=Endret_spr\u00e5koppsett
+Changed\ language\ settings=Endret spr\u00e5koppsett
 
-Changed_preamble=Endret_preamble
+Changed\ preamble=Endret preamble
 
-Check_existing_file_links=Sjekk_eksisterende_fil-linker
+Check\ existing\ file\ links=Sjekk eksisterende fil-linker
 
-Check_links=Sjekk_eksterne_linker
+Check\ links=Sjekk eksterne linker
 
-Cite_command=Siteringskommando
+Cite\ command=Siteringskommando
 
-Class_name=Klassenavn
+Class\ name=Klassenavn
 
 Clear=Opphev
 
-Clear_fields=Slett_felter
+Clear\ fields=Slett felter
 
 Close=Lukk
-Close_others=
-Close_all=
+Close\ others=
+Close\ all=
 
-Close_dialog=Lukk_dialog
+Close\ dialog=Lukk dialog
 
-Close_the_current_library=Lukk_denne_libraryn
+Close\ the\ current\ library=Lukk denne libraryn
 
-Close_window=Lukk_vindu
+Close\ window=Lukk vindu
 
-Closed_library=Lukket_library
+Closed\ library=Lukket library
 
-Color_codes_for_required_and_optional_fields=Fargekoder_for_n\u00f8dvendige_og_valgfrie_felter
+Color\ codes\ for\ required\ and\ optional\ fields=Fargekoder for n\u00f8dvendige og valgfrie felter
 
-Color_for_marking_incomplete_entries=Farge_for_markering_av_ufullstendige_enheter
+Color\ for\ marking\ incomplete\ entries=Farge for markering av ufullstendige enheter
 
-Column_width=Kolonnebredde
+Column\ width=Kolonnebredde
 
-Command_line_id=Kommandolinje-id
+Command\ line\ id=Kommandolinje-id
 
 
-Contained_in=Inneholdt_i
+Contained\ in=Inneholdt i
 
 Content=Innhold
 
 Copied=Kopierte
 
-Copied_cell_contents=Kopierte_innhold_av_cellen
+Copied\ cell\ contents=Kopierte innhold av cellen
 
-Copied_title=
+Copied\ title=
 
-Copied_key=Kopierte_n\u00f8kkel
+Copied\ key=Kopierte n\u00f8kkel
 
-Copied_titles=
+Copied\ titles=
 
-Copied_keys=Kopierte_n\u00f8kler
+Copied\ keys=Kopierte n\u00f8kler
 
 Copy=Kopier
 
-Copy_BibTeX_key=Kopier_BibTeX-n\u00f8kkel
-Copy_file_to_file_directory=Kopier_fil_til_filkatalog
+Copy\ BibTeX\ key=Kopier BibTeX-n\u00f8kkel
+Copy\ file\ to\ file\ directory=Kopier fil til filkatalog
 
-Copy_to_clipboard=Kopier_til_utklippstavle
+Copy\ to\ clipboard=Kopier til utklippstavle
 
-Could_not_call_executable=Kunne_ikke_kalle_programfilen
-Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.=Kunne_ikke_koble_til_Vim-server._Sjekk_at_Vim_kj\u00f8rer<BR>med_riktig_servernavn.
+Could\ not\ call\ executable=Kunne ikke kalle programfilen
+Could\ not\ connect\ to\ Vim\ server.\ Make\ sure\ that\ Vim\ is\ running<BR>with\ correct\ server\ name.=Kunne ikke koble til Vim-server. Sjekk at Vim kj\u00f8rer<BR>med riktig servernavn.
 
-Could_not_export_file=Kunne_ikke_eksportere
+Could\ not\ export\ file=Kunne ikke eksportere
 
-Could_not_export_preferences=Kunne_ikke_eksportere_innstillinger
+Could\ not\ export\ preferences=Kunne ikke eksportere innstillinger
 
-Could_not_find_a_suitable_import_format.=Fant_ikke_noe_passende_importformat.
-Could_not_import_preferences=Kunne_ikke_importere_innstillinger
+Could\ not\ find\ a\ suitable\ import\ format.=Fant ikke noe passende importformat.
+Could\ not\ import\ preferences=Kunne ikke importere innstillinger
 
-Could_not_instantiate_%0=Kunne_ikke_instansiere_%0
-Could_not_instantiate_%0_%1=Kunne_ikke_instansiere_%0_%1
-Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?=Kunne_ikke_instansiere_%0._Har_du_valgt_riktig_katalog?
-Could_not_open_link=Kunne_ikke_\u00e5pne_link
+Could\ not\ instantiate\ %0=Kunne ikke instansiere %0
+Could\ not\ instantiate\ %0\ %1=Kunne ikke instansiere %0 %1
+Could\ not\ instantiate\ %0.\ Have\ you\ chosen\ the\ correct\ package\ path?=Kunne ikke instansiere %0. Har du valgt riktig katalog?
+Could\ not\ open\ link=Kunne ikke \u00e5pne link
 
-Could_not_print_preview=Kunne_ikke_skrive_ut_forh\u00e5ndsvisningen
+Could\ not\ print\ preview=Kunne ikke skrive ut forh\u00e5ndsvisningen
 
-Could_not_run_the_'vim'_program.=Kunne_ikke_kj\u00f8re_'vim'-programmet
+Could\ not\ run\ the\ 'vim'\ program.=Kunne ikke kj\u00f8re 'vim'-programmet
 
-Could_not_save_file.=
-Character_encoding_'%0'_is_not_supported.=Tegnkodingen_'%0'_er_ikke_st\u00f8ttet.
+Could\ not\ save\ file.=
+Character\ encoding\ '%0'\ is\ not\ supported.=Tegnkodingen '%0' er ikke st\u00f8ttet.
 
-crossreferenced_entries_included=refererte_enheter_inkludert
+crossreferenced\ entries\ included=refererte enheter inkludert
 
-Current_content=N\u00e5v\u00e6rende_innhold
+Current\ content=N\u00e5v\u00e6rende innhold
 
-Current_value=N\u00e5v\u00e6rende_verdi
+Current\ value=N\u00e5v\u00e6rende verdi
 
-Custom_entry_types=Egendefinerte_enhetstyper
+Custom\ entry\ types=Egendefinerte enhetstyper
 
-Custom_entry_types_found_in_file=Fant_egendefinerte_enhetstyper_i_filen
+Custom\ entry\ types\ found\ in\ file=Fant egendefinerte enhetstyper i filen
 
-Customize_entry_types=Tilpass_enhetstyper
+Customize\ entry\ types=Tilpass enhetstyper
 
-Customize_key_bindings=Sett_opp_hurtigtaster
+Customize\ key\ bindings=Sett opp hurtigtaster
 
-Cut=Klipp_ut
+Cut=Klipp ut
 
-cut_entries=klippet_ut
+cut\ entries=klippet ut
 
-cut_entry=klipp_ut_enhet
+cut\ entry=klipp ut enhet
 
 
-Library_encoding=Tegnkoding_for_library
+Library\ encoding=Tegnkoding for library
 
-Library_properties=Libraryegenskaper
+Library\ properties=Libraryegenskaper
 
-Library_type=
+Library\ type=
 
-Date_format=Datoformat
+Date\ format=Datoformat
 
 Default=Tilbakestill
 
-Default_encoding=Standard_koding
+Default\ encoding=Standard koding
 
-Default_grouping_field=Standardfelt_for_gruppering
+Default\ grouping\ field=Standardfelt for gruppering
 
-Default_look_and_feel=Standard_utseende
+Default\ look\ and\ feel=Standard utseende
 
-Default_pattern=Default_pattern
+Default\ pattern=Default pattern
 
-Default_sort_criteria=Standard_sorteringskriteria
-Define_'%0'=Definer_'%0'
+Default\ sort\ criteria=Standard sorteringskriteria
+Define\ '%0'=Definer '%0'
 
 Delete=Slett
 
-Delete_custom_format=Slett_tilpasset_type
+Delete\ custom\ format=Slett tilpasset type
 
-delete_entries=slett_enheter
+delete\ entries=slett enheter
 
-Delete_entry=Slett_enhet
+Delete\ entry=Slett enhet
 
-delete_entry=slett_enhet
+delete\ entry=slett enhet
 
-Delete_multiple_entries=Slett_flere_enheter
+Delete\ multiple\ entries=Slett flere enheter
 
-Delete_rows=Slett_rader
+Delete\ rows=Slett rader
 
-Delete_strings=Slett_strenger
+Delete\ strings=Slett strenger
 
 Deleted=Slettet
 
-Permanently_delete_local_file=
+Permanently\ delete\ local\ file=
 
-Delimit_fields_with_semicolon,_ex.=Avgrens_felter_med_semikolon,_f.eks.
+Delimit\ fields\ with\ semicolon,\ ex.=Avgrens felter med semikolon, f.eks.
 
 Descending=Synkende
 
 Description=Beskrivelse
 
-Deselect_all=Velg_ingen
-Deselect_all_duplicates=Velg_bort_alle_duplikater
+Deselect\ all=Velg ingen
+Deselect\ all\ duplicates=Velg bort alle duplikater
 
-Disable_this_confirmation_dialog=Deaktiver_denne_kontrolldialogen
+Disable\ this\ confirmation\ dialog=Deaktiver denne kontrolldialogen
 
-Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.=Vis_alle_enheter_inneholdt_i_minst_en_av_de_valgte_gruppene.
+Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups.=Vis alle enheter inneholdt i minst en av de valgte gruppene.
 
-Display_all_error_messages=Vis_alle_feilmeldinger
+Display\ all\ error\ messages=Vis alle feilmeldinger
 
-Display_help_on_command_line_options=Vis_kommandolinjehjelp
+Display\ help\ on\ command\ line\ options=Vis kommandolinjehjelp
 
-Display_only_entries_belonging_to_all_selected_groups.=Vis_kun_enheter_inneholdt_i_alle_valgte_grupper.
-Display_version=Vis_versjonsnummer
+Display\ only\ entries\ belonging\ to\ all\ selected\ groups.=Vis kun enheter inneholdt i alle valgte grupper.
+Display\ version=Vis versjonsnummer
 
-Do_not_abbreviate_names=Ikke_forkort_navn
+Do\ not\ abbreviate\ names=Ikke forkort navn
 
-Do_not_automatically_set=Ikke_sett_linker_automatisk
+Do\ not\ automatically\ set=Ikke sett linker automatisk
 
-Do_not_import_entry=Ikke_importer_enhet
+Do\ not\ import\ entry=Ikke importer enhet
 
-Do_not_open_any_files_at_startup=\u00c5pne_ingen_filer_ved_oppstart
+Do\ not\ open\ any\ files\ at\ startup=\u00c5pne ingen filer ved oppstart
 
-Do_not_overwrite_existing_keys=Ikke_skriv_over_eksisterende_n\u00f8kler
-Do_not_show_these_options_in_the_future=Ikke_vis_disse_valgene_igjen
+Do\ not\ overwrite\ existing\ keys=Ikke skriv over eksisterende n\u00f8kler
+Do\ not\ show\ these\ options\ in\ the\ future=Ikke vis disse valgene igjen
 
-Do_not_wrap_the_following_fields_when_saving=Ikke_introduser_linjeskift_i_f\u00f8lgende_felter_ved_lagring
-Do_not_write_the_following_fields_to_XMP_Metadata\:=Ikke_skriv_de_f\u00f8lgende_feltene_til_XMP-metadata\:
+Do\ not\ wrap\ the\ following\ fields\ when\ saving=Ikke introduser linjeskift i f\u00f8lgende felter ved lagring
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Ikke skriv de f\u00f8lgende feltene til XMP-metadata:
 
-Do_you_want_JabRef_to_do_the_following_operations?=Vil_du_at_JabRef_skal_gj\u00f8re_de_f\u00f8lgende_operasjonene?
+Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Vil du at JabRef skal gj\u00f8re de f\u00f8lgende operasjonene?
 
-Donate_to_JabRef=
+Donate\ to\ JabRef=
 
 Down=Ned
 
-Download_file=Last_ned_fil
+Download\ file=Last ned fil
 
-Downloading...=Laster_ned...
+Downloading...=Laster ned...
 
-Drop_%0=Slipp_%0
+Drop\ %0=Slipp %0
 
-duplicate_removal=fjerning_av_duplikater
+duplicate\ removal=fjerning av duplikater
 
-Duplicate_string_name=Ikke_unikt_navn_p\u00e5_streng
+Duplicate\ string\ name=Ikke unikt navn p\u00e5 streng
 
-Duplicates_found=Duplikater_funnet
+Duplicates\ found=Duplikater funnet
 
-Dynamic_groups=Dynamiske_grupper
+Dynamic\ groups=Dynamiske grupper
 
-Dynamically_group_entries_by_a_free-form_search_expression=Grupper_enheter_dynamisk_ved_hjelp_av_et_standard_s\u00f8keuttrykk
+Dynamically\ group\ entries\ by\ a\ free-form\ search\ expression=Grupper enheter dynamisk ved hjelp av et standard s\u00f8keuttrykk
 
-Dynamically_group_entries_by_searching_a_field_for_a_keyword=Grupper_enheter_dynamisk_ved_\u00e5_s\u00f8ke_etter_n\u00f8kkelord_i_et_felt
+Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=Grupper enheter dynamisk ved \u00e5 s\u00f8ke etter n\u00f8kkelord i et felt
 
-Each_line_must_be_on_the_following_form=Hver_av_linjene_m\u00e5_v\u00e6re_p\u00e5_den_f\u00f8lgende_formen
+Each\ line\ must\ be\ on\ the\ following\ form=Hver av linjene m\u00e5 v\u00e6re p\u00e5 den f\u00f8lgende formen
 
 Edit=Rediger
 
-Edit_custom_export=Rediger_eksternt_eksportfilter
-Edit_entry=Rediger_enhet
-Save_file=Rediger_link
-Edit_file_type=Rediger_filtype
+Edit\ custom\ export=Rediger eksternt eksportfilter
+Edit\ entry=Rediger enhet
+Save\ file=Rediger link
+Edit\ file\ type=Rediger filtype
 
-Edit_group=Rediger_gruppe
+Edit\ group=Rediger gruppe
 
 
-Edit_preamble=Rediger_'preamble'
-Edit_strings=Rediger_strenger
-Editor_options=Alternativer_for_redigering
+Edit\ preamble=Rediger 'preamble'
+Edit\ strings=Rediger strenger
+Editor\ options=Alternativer for redigering
 
-Empty_BibTeX_key=Tom_BibTeX-n\u00f8kkel
+Empty\ BibTeX\ key=Tom BibTeX-n\u00f8kkel
 
-Grouping_may_not_work_for_this_entry.=Gruppering_kan_feile_for_denne_enheten.
+Grouping\ may\ not\ work\ for\ this\ entry.=Gruppering kan feile for denne enheten.
 
-empty_library=tom_library
-Enable_word/name_autocompletion=Aktiver_autokomplettering_av_navn/ord
+empty\ library=tom library
+Enable\ word/name\ autocompletion=Aktiver autokomplettering av navn/ord
 
-Enter_URL=Skriv_inn_URL
+Enter\ URL=Skriv inn URL
 
-Enter_URL_to_download=Skriv_inn_URL_som_skal_lastes_ned
+Enter\ URL\ to\ download=Skriv inn URL som skal lastes ned
 
 entries=enheter
 
-Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.=Enheter_kan_ikke_manuelt_legges_til_i_eller_fjernes_fra_denne_gruppen.
+Entries\ cannot\ be\ manually\ assigned\ to\ or\ removed\ from\ this\ group.=Enheter kan ikke manuelt legges til i eller fjernes fra denne gruppen.
 
-Entries_exported_to_clipboard=Enheter_eksportert_til_utklippstavle
+Entries\ exported\ to\ clipboard=Enheter eksportert til utklippstavle
 
 
 entry=enhet
 
-Entry_editor=Enhetsskjema
+Entry\ editor=Enhetsskjema
 
-Entry_preview=Forh\u00e5ndsvisning
+Entry\ preview=Forh\u00e5ndsvisning
 
-Entry_table=Hovedtabell
+Entry\ table=Hovedtabell
 
-Entry_table_columns=Tabellkolonner
+Entry\ table\ columns=Tabellkolonner
 
-Entry_type=Enhetstype
+Entry\ type=Enhetstype
 
-Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Navn_p\u00e5_typer_kan_ikke_inneholde_opperom_eller_noen_av_de_f\u00f8lgende_tegnene
+Entry\ type\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Navn p\u00e5 typer kan ikke inneholde opperom eller noen av de f\u00f8lgende tegnene
 
-Entry_types=Enhetstyper
+Entry\ types=Enhetstyper
 
 Error=Feil
-Error_exporting_to_clipboard=Feil_ved_eksport_til_utklippstavle
+Error\ exporting\ to\ clipboard=Feil ved eksport til utklippstavle
 
-Error_occurred_when_parsing_entry=En_feil_oppsto_ved_lesing_av_enhet
+Error\ occurred\ when\ parsing\ entry=En feil oppsto ved lesing av enhet
 
-Error_opening_file=Feil_ved_\u00e5pning_av_fil
+Error\ opening\ file=Feil ved \u00e5pning av fil
 
-Error_setting_field=Problem_med_\u00e5_sette_felt
+Error\ setting\ field=Problem med \u00e5 sette felt
 
-Error_while_writing=En_feil_oppsto_ved_skriving
-Error_writing_to_%0_file(s).=Feil_ved_skriving_til_%0_fil(er).
+Error\ while\ writing=En feil oppsto ved skriving
+Error\ writing\ to\ %0\ file(s).=Feil ved skriving til %0 fil(er).
 
 
 
-'%0'_exists._Overwrite_file?='%0'_eksisterer._Erstatt_filen?
-Overwrite_file?=Erstatt_filen?
+'%0'\ exists.\ Overwrite\ file?='%0' eksisterer. Erstatt filen?
+Overwrite\ file?=Erstatt filen?
 
 Export=Eksporter
 
-Export_name=Navn_p\u00e5_filter
+Export\ name=Navn p\u00e5 filter
 
-Export_preferences=Eksporter_innstillinger
+Export\ preferences=Eksporter innstillinger
 
-Export_preferences_to_file=Eksporter_innstillinger_til_fil
+Export\ preferences\ to\ file=Eksporter innstillinger til fil
 
-Export_properties=Egenskaper_for_eksportfilter
+Export\ properties=Egenskaper for eksportfilter
 
-Export_to_clipboard=Eksporter_til_utklippstavle
+Export\ to\ clipboard=Eksporter til utklippstavle
 
 Exporting=Eksporterer
 Extension=Etternavn
 
-External_changes=Eksterne_endringer
+External\ changes=Eksterne endringer
 
-External_file_links=Eksterne_linker
+External\ file\ links=Eksterne linker
 
-External_programs=Eksterne_programmer
+External\ programs=Eksterne programmer
 
-External_viewer_called=Eksternt_program_kalt_opp
+External\ viewer\ called=Eksternt program kalt opp
 
 Fetch=Hent
 
@@ -482,210 +482,210 @@ Field=Felt
 
 field=felt
 
-Field_name=Feltnavn
-Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Feltnavn_kan_ikke_inneholde_opperom_eller_de_f\u00f8lgende_tegnene
+Field\ name=Feltnavn
+Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Feltnavn kan ikke inneholde opperom eller de f\u00f8lgende tegnene
 
-Field_to_filter=Felt_som_skal_filtreres
+Field\ to\ filter=Felt som skal filtreres
 
-Field_to_group_by=Grupperingsfelt
+Field\ to\ group\ by=Grupperingsfelt
 
 File=Fil
 
 file=fil
-File_'%0'_is_already_open.=Filen_'%0'_er_allerede_\u00e5pen.
+File\ '%0'\ is\ already\ open.=Filen '%0' er allerede \u00e5pen.
 
-File_changed=Endret_fil
-File_directory_is_'%0'\:=Filkatalogen_er_'%0'\:
+File\ changed=Endret fil
+File\ directory\ is\ '%0'\:=Filkatalogen er '%0':
 
-File_directory_is_not_set_or_does_not_exist\!=Filkatalogen_er_ikke_satt_eller_eksisterer_ikke\!
+File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=Filkatalogen er ikke satt eller eksisterer ikke!
 
-File_exists=Filen_eksisterer
+File\ exists=Filen eksisterer
 
-File_has_been_updated_externally._What_do_you_want_to_do?=Filen_har_blitt_endret_eksternt._Hva_vil_du_gj\u00f8re?
+File\ has\ been\ updated\ externally.\ What\ do\ you\ want\ to\ do?=Filen har blitt endret eksternt. Hva vil du gj\u00f8re?
 
-File_not_found=Fant_ikke_filen
-File_type=Filtype
+File\ not\ found=Fant ikke filen
+File\ type=Filtype
 
-File_updated_externally=Filen_har_blitt_endret_eksternt
+File\ updated\ externally=Filen har blitt endret eksternt
 
 filename=filnavn
 
 Filename=
 
-Files_opened=Filer_\u00e5pnet
+Files\ opened=Filer \u00e5pnet
 
 Filter=Filter
 
-Filter_All=
+Filter\ All=
 
-Filter_None=
+Filter\ None=
 
-Finished_automatically_setting_external_links.=Fullf\u00f8rte_automatisk_setting_av_eksterne_linker.
+Finished\ automatically\ setting\ external\ links.=Fullf\u00f8rte automatisk setting av eksterne linker.
 
-Finished_synchronizing_file_links._Entries_changed\:_%0.=Fullf\u00f8rte_synkronisering_av_fil-linker._Enheter_endret\:_%0.
-Finished_writing_XMP-metadata._Wrote_to_%0_file(s).=Fullf\u00f8rte_skriving_av_XMP-metadata._Skrev_til_%0_fil(er).
-Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).=Fullf\u00f8rte_skriving_av_XMP-data_for_%0_fil(er)_(hoppet_over_%1,_%2_mislyktes).
+Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Fullf\u00f8rte synkronisering av fil-linker. Enheter endret: %0.
+Finished\ writing\ XMP-metadata.\ Wrote\ to\ %0\ file(s).=Fullf\u00f8rte skriving av XMP-metadata. Skrev til %0 fil(er).
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Fullf\u00f8rte skriving av XMP-data for %0 fil(er) (hoppet over %1, %2 mislyktes).
 
-First_select_the_entries_you_want_keys_to_be_generated_for.=Velg_f\u00f8rst_hvilke_enheter_du_vil_generere_n\u00f8kler_for.
+First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Velg f\u00f8rst hvilke enheter du vil generere n\u00f8kler for.
 
-Fit_table_horizontally_on_screen=Tilpass_tabellbredden_horisontalt
+Fit\ table\ horizontally\ on\ screen=Tilpass tabellbredden horisontalt
 
 Float=Flyt
-Float_marked_entries=Sorter_merkede_enheter_\u00f8verst
+Float\ marked\ entries=Sorter merkede enheter \u00f8verst
 
-Font_family=Familie
+Font\ family=Familie
 
-Font_preview=Forh\u00e5ndsvisning
+Font\ preview=Forh\u00e5ndsvisning
 
-Font_size=St\u00f8rrelse
+Font\ size=St\u00f8rrelse
 
-Font_style=Stil
+Font\ style=Stil
 
-Font_selection=Fontvelger
+Font\ selection=Fontvelger
 
 for=for
 
-Format_of_author_and_editor_names=Formatering_av_forfatter-_og_redakt\u00f8rnavn
-Format_string=Formatstreng
+Format\ of\ author\ and\ editor\ names=Formatering av forfatter- og redakt\u00f8rnavn
+Format\ string=Formatstreng
 
-Format_used=Format_brukt
-Formatter_name=Navn_p\u00e5_formaterer
+Format\ used=Format brukt
+Formatter\ name=Navn p\u00e5 formaterer
 
-found_in_AUX_file=funnet_i_AUX-fil
+found\ in\ AUX\ file=funnet i AUX-fil
 
-Full_name=Fullt_navn
+Full\ name=Fullt navn
 
 General=Generelt
 
-General_fields=Generelle_felter
+General\ fields=Generelle felter
 
 Generate=Generer
 
-Generate_BibTeX_key=Generere_BibTeX-n\u00f8kkel
+Generate\ BibTeX\ key=Generere BibTeX-n\u00f8kkel
 
-Generate_keys=Generer_n\u00f8kler
+Generate\ keys=Generer n\u00f8kler
 
-Generate_keys_before_saving_(for_entries_without_a_key)=Generer_n\u00f8kler_f\u00f8r_lagring_(for_enheter_uten_n\u00f8kkel))
-Generate_keys_for_imported_entries=Generer_n\u00f8kler_automatisk_for_importerte_enheter
+Generate\ keys\ before\ saving\ (for\ entries\ without\ a\ key)=Generer n\u00f8kler f\u00f8r lagring (for enheter uten n\u00f8kkel))
+Generate\ keys\ for\ imported\ entries=Generer n\u00f8kler automatisk for importerte enheter
 
-Generate_now=Generer_n\u00e5
+Generate\ now=Generer n\u00e5
 
-Generated_BibTeX_key_for=Genererte_BibTeX-n\u00f8kkel_for
+Generated\ BibTeX\ key\ for=Genererte BibTeX-n\u00f8kkel for
 
-Generating_BibTeX_key_for=Genererer_BibTeX-n\u00f8kkel_for
-Get_fulltext=
+Generating\ BibTeX\ key\ for=Genererer BibTeX-n\u00f8kkel for
+Get\ fulltext=
 
-Gray_out_non-hits=Vis_ikke-treff_i-gr\u00e5tt
+Gray\ out\ non-hits=Vis ikke-treff i-gr\u00e5tt
 
 Groups=Gruppering
 
-Have_you_chosen_the_correct_package_path?=Har_du_valgt_riktig_pakkenavn?
+Have\ you\ chosen\ the\ correct\ package\ path?=Har du valgt riktig pakkenavn?
 
 Help=Hjelp
 
-Help_on_key_patterns=Hjelp_om_n\u00f8kkelgenerering
-Help_on_regular_expression_search=Hjelp_for_s\u00f8k_med_regul\u00e6ruttrykk
+Help\ on\ key\ patterns=Hjelp om n\u00f8kkelgenerering
+Help\ on\ regular\ expression\ search=Hjelp for s\u00f8k med regul\u00e6ruttrykk
 
-Hide_non-hits=Skjul_ikke-treff
+Hide\ non-hits=Skjul ikke-treff
 
-Hierarchical_context=Gruppehierarki
+Hierarchical\ context=Gruppehierarki
 
 Highlight=Uthev
 Marking=
 Underline=
-Empty_Highlight=
-Empty_Marking=
-Empty_Underline=
-The_marked_area_does_not_contain_any_legible_text!=
+Empty\ Highlight=
+Empty\ Marking=
+Empty\ Underline=
+The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=
 
-Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>=Hint\:_For_bare_\u00e5_s\u00f8ke_i_spesifikke_felt,_skriv_f._eks.\:<p><tt>author\=smith_and_title\=electrical</tt>
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Hint: For bare \u00e5 s\u00f8ke i spesifikke felt, skriv f. eks.:<p><tt>author=smith and title=electrical</tt>
 
-HTML_table=HTML-tabell
-HTML_table_(with_Abstract_&_BibTeX)=HTML-tabell_(med_Abstract_&_BibTeX)
+HTML\ table=HTML-tabell
+HTML\ table\ (with\ Abstract\ &\ BibTeX)=HTML-tabell (med Abstract & BibTeX)
 Icon=Ikon
 
 Ignore=Ignorer
 
 Import=Importer
 
-Import_and_keep_old_entry=Importer_og_behold_den_gamle_enheten
+Import\ and\ keep\ old\ entry=Importer og behold den gamle enheten
 
-Import_and_remove_old_entry=Importer_og_fjern_den_gamle_enheten
+Import\ and\ remove\ old\ entry=Importer og fjern den gamle enheten
 
-Import_entries=Importer_enheter
+Import\ entries=Importer enheter
 
-Import_failed=Import_mislyktes
+Import\ failed=Import mislyktes
 
-Import_file=Importer_fil
+Import\ file=Importer fil
 
-Import_group_definitions=Importer_gruppedefinisjoner
+Import\ group\ definitions=Importer gruppedefinisjoner
 
-Import_name=Navn_p\u00e5_import
+Import\ name=Navn p\u00e5 import
 
-Import_preferences=Importer_innstillinger
+Import\ preferences=Importer innstillinger
 
-Import_preferences_from_file=Importer_innstillinger_fra_fil
+Import\ preferences\ from\ file=Importer innstillinger fra fil
 
-Import_strings=Importer_strenger
+Import\ strings=Importer strenger
 
-Import_to_open_tab=Importer_til_\u00e5pen_tab
+Import\ to\ open\ tab=Importer til \u00e5pen tab
 
-Import_word_selector_definitions=Importer_definisjoner_for_hurtigvelgere
+Import\ word\ selector\ definitions=Importer definisjoner for hurtigvelgere
 
-Imported_entries=Importerte_enheter
+Imported\ entries=Importerte enheter
 
-Imported_from_library=Importerte_fra_libraryn
+Imported\ from\ library=Importerte fra libraryn
 
-Importer_class=Importer-klasse
+Importer\ class=Importer-klasse
 
 Importing=Importerer
 
-Importing_in_unknown_format=Importerer_ukjent_format
+Importing\ in\ unknown\ format=Importerer ukjent format
 
-Include_abstracts=Inkluder_sammendrag
-Include_entries=Inkluder_enheter
+Include\ abstracts=Inkluder sammendrag
+Include\ entries=Inkluder enheter
 
-Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups=Inkluder_undergrupper\:_Vis_enheter_inneholdt_i_denne_gruppen_eller_en_undergruppe
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=Inkluder undergrupper: Vis enheter inneholdt i denne gruppen eller en undergruppe
 
-Independent_group\:_When_selected,_view_only_this_group's_entries=Uavhengig_gruppe\:_Vis_bare_denne_gruppens_enheter
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=Uavhengig gruppe: Vis bare denne gruppens enheter
 
-Work_options=
+Work\ options=
 
-Insert=Legg_til
+Insert=Legg til
 
-Insert_rows=Legg_til_rader
+Insert\ rows=Legg til rader
 
 Intersection=Snitt
 
-Invalid_BibTeX_key=Ugyldig_BibTeX-n\u00f8kkel
+Invalid\ BibTeX\ key=Ugyldig BibTeX-n\u00f8kkel
 
-Invalid_date_format=Ugyldig_datoformat
+Invalid\ date\ format=Ugyldig datoformat
 
-Invalid_URL=Ugyldig_URL
+Invalid\ URL=Ugyldig URL
 
-Online_help=
+Online\ help=
 
-JabRef_preferences=JabRef-oppsett
+JabRef\ preferences=JabRef-oppsett
 
 Join=
 
-Joins_selected_keywords_and_deletes_selected_keywords.=
+Joins\ selected\ keywords\ and\ deletes\ selected\ keywords.=
 
-Journal_abbreviations=Journalforkortelser
+Journal\ abbreviations=Journalforkortelser
 
 Keep=Behold
 
-Keep_both=Behold_begge
+Keep\ both=Behold begge
 
-Key_bindings=Hurtigtaster
+Key\ bindings=Hurtigtaster
 
-Key_bindings_changed=Hurtigtaster_endret
+Key\ bindings\ changed=Hurtigtaster endret
 
-Key_generator_settings=Innstillinger_for_n\u00f8kkelgenerering
+Key\ generator\ settings=Innstillinger for n\u00f8kkelgenerering
 
-Key_pattern=M\u00f8nster
+Key\ pattern=M\u00f8nster
 
-keys_in_library=n\u00f8kler_i_libraryn
+keys\ in\ library=n\u00f8kler i libraryn
 
 Keyword=N\u00f8kkelord
 
@@ -693,449 +693,449 @@ Label=Navn
 
 Language=Spr\u00e5k
 
-Last_modified=Sist_endret
+Last\ modified=Sist endret
 
-LaTeX_AUX_file=LaTeX_AUX-fil
-Leave_file_in_its_current_directory=La_filen_ligge_i_katalogen_den_ligger_i_n\u00e5
+LaTeX\ AUX\ file=LaTeX AUX-fil
+Leave\ file\ in\ its\ current\ directory=La filen ligge i katalogen den ligger i n\u00e5
 
 Left=Venstre
 Level=
 
-Limit_to_fields=Begrens_til_f\u00f8lgende_felter
+Limit\ to\ fields=Begrens til f\u00f8lgende felter
 
-Limit_to_selected_entries=Begrens_til_valgte_enheter
+Limit\ to\ selected\ entries=Begrens til valgte enheter
 
 Link=Link
-Link_local_file=Link_til_lokal_fil
-Link_to_file_%0=Link_til_filen_%0
+Link\ local\ file=Link til lokal fil
+Link\ to\ file\ %0=Link til filen %0
 
-Listen_for_remote_operation_on_port=Lytt_etter_fjernoperasjoner_p\u00c3\u00a5_port
-Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)=Hent_og_lagre_innstillinger_fra/til_jabef.xml_ved_oppstart_(minnepinne-modus)
+Listen\ for\ remote\ operation\ on\ port=Lytt etter fjernoperasjoner p\u00c3\u00a5 port
+Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=Hent og lagre innstillinger fra/til jabef.xml ved oppstart (minnepinne-modus)
 
-Look_and_feel=Utseende
-Main_file_directory=Hovedkatalog_for_filer
+Look\ and\ feel=Utseende
+Main\ file\ directory=Hovedkatalog for filer
 
-Main_layout_file=Hoved-layoutfil
+Main\ layout\ file=Hoved-layoutfil
 
-Manage_custom_exports=Sett_opp_eksterne_eksportfiltre
+Manage\ custom\ exports=Sett opp eksterne eksportfiltre
 
-Manage_custom_imports=Sett_opp_eksterne_importfiltre
-Manage_external_file_types=Sett_opp_eksterne_filtyper
+Manage\ custom\ imports=Sett opp eksterne importfiltre
+Manage\ external\ file\ types=Sett opp eksterne filtyper
 
-Mark_entries=Merk_enheter
+Mark\ entries=Merk enheter
 
-Mark_entry=Merk_enhet
+Mark\ entry=Merk enhet
 
-Mark_new_entries_with_addition_date=Merk_nye_enheter_med_dato
+Mark\ new\ entries\ with\ addition\ date=Merk nye enheter med dato
 
-Mark_new_entries_with_owner_name=Merk_nye_enheter_med_navn_p\u00e5_eier
+Mark\ new\ entries\ with\ owner\ name=Merk nye enheter med navn p\u00e5 eier
 
-Memory_stick_mode=Minnepinne-modus
+Memory\ stick\ mode=Minnepinne-modus
 
-Menu_and_label_font_size=St\u00f8rrelse_av_menyfonter
+Menu\ and\ label\ font\ size=St\u00f8rrelse av menyfonter
 
-Merged_external_changes=Inkorporerte_eksterne_endringer
+Merged\ external\ changes=Inkorporerte eksterne endringer
 
 Messages=Meldinger
 
-Modification_of_field=Endring_av_felt
+Modification\ of\ field=Endring av felt
 
-Modified_group_"%0".=Endret_gruppen_"%0".
+Modified\ group\ "%0".=Endret gruppen "%0".
 
-Modified_groups=Endrede_grupper
+Modified\ groups=Endrede grupper
 
-Modified_string=Endret_streng
+Modified\ string=Endret streng
 
 Modify=Endre
 
-modify_group=endre_gruppe
+modify\ group=endre gruppe
 
-Move_down=Flytt_ned
+Move\ down=Flytt ned
 
-Move_external_links_to_'file'_field=Flytt_eksterne_linker_til_'file'-feltet
+Move\ external\ links\ to\ 'file'\ field=Flytt eksterne linker til 'file'-feltet
 
-move_group=flytt_gruppe
+move\ group=flytt gruppe
 
-Move_up=Flytt_opp
+Move\ up=Flytt opp
 
-Moved_group_"%0".=Flyttet_gruppen_"%0".
+Moved\ group\ "%0".=Flyttet gruppen "%0".
 
 Name=Navn
-Name_formatter=Navneformaterer
+Name\ formatter=Navneformaterer
 
-Natbib_style=Natbib-stil
+Natbib\ style=Natbib-stil
 
-nested_AUX_files=n\u00f8stede_AUX-filer
+nested\ AUX\ files=n\u00f8stede AUX-filer
 
 New=Ny
 
 new=ny
 
-New_BibTeX_entry=Ny_BibTeX-enhet
+New\ BibTeX\ entry=Ny BibTeX-enhet
 
-New_BibTeX_sublibrary=Ny_BibTeX-dellibrary
+New\ BibTeX\ sublibrary=Ny BibTeX-dellibrary
 
-New_content=Nytt_innhold
+New\ content=Nytt innhold
 
-New_library_created.=Opprettet_ny_library.
-New_%0_library=
-New_field_value=Ny_verdi
+New\ library\ created.=Opprettet ny library.
+New\ %0\ library=
+New\ field\ value=Ny verdi
 
-New_group=Ny_gruppe
+New\ group=Ny gruppe
 
-New_string=Ny_streng
+New\ string=Ny streng
 
-Next_entry=Neste_enhet
+Next\ entry=Neste enhet
 
-No_actual_changes_found.=Ingen_reelle_endringer_funnet.
+No\ actual\ changes\ found.=Ingen reelle endringer funnet.
 
-no_base-BibTeX-file_specified=ingen_basis-BibTeXfil_spesifisert
+no\ base-BibTeX-file\ specified=ingen basis-BibTeXfil spesifisert
 
-no_library_generated=ingen_library_generert
+no\ library\ generated=ingen library generert
 
-No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.=Ingen_enheter_funnet._Kontroller_at_du_bruker_riktig_importfilter.
+No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=Ingen enheter funnet. Kontroller at du bruker riktig importfilter.
 
 
-No_entries_found_for_the_search_string_'%0'=Fant_ingen_enheter_for_s\u00f8keteksten_'%0'
+No\ entries\ found\ for\ the\ search\ string\ '%0'=Fant ingen enheter for s\u00f8keteksten '%0'
 
-No_entries_imported.=Ingen_enheter_importert.
+No\ entries\ imported.=Ingen enheter importert.
 
-No_files_found.=Ingen_filer_funnet.
+No\ files\ found.=Ingen filer funnet.
 
-No_GUI._Only_process_command_line_options.=Ingen_GUI._Bare_behandle_kommandolinjevalg.
+No\ GUI.\ Only\ process\ command\ line\ options.=Ingen GUI. Bare behandle kommandolinjevalg.
 
-No_journal_names_could_be_abbreviated.=Ingen_journalnavn_kunne_forkortes.
+No\ journal\ names\ could\ be\ abbreviated.=Ingen journalnavn kunne forkortes.
 
-No_journal_names_could_be_unabbreviated.=Ingen_journalnavn_kunne_ekspanderes.
-No_PDF_linked=Ingen_PDF_linket
+No\ journal\ names\ could\ be\ unabbreviated.=Ingen journalnavn kunne ekspanderes.
+No\ PDF\ linked=Ingen PDF linket
 
-Open_PDF=
+Open\ PDF=
 
-No_URL_defined=Ingen_url_er_definert
+No\ URL\ defined=Ingen url er definert
 not=ikke
 
-not_found=ikke_funnet
+not\ found=ikke funnet
 
-Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,=Merk_at_du_m\u00e5_spesifisere_det_fullstendige_klassenavnet_for_utseendet,
+Note\ that\ you\ must\ specify\ the\ fully\ qualified\ class\ name\ for\ the\ look\ and\ feel,=Merk at du m\u00e5 spesifisere det fullstendige klassenavnet for utseendet,
 
-Nothing_to_redo=Ingenting_\u00e5_gjenta
+Nothing\ to\ redo=Ingenting \u00e5 gjenta
 
-Nothing_to_undo=Ingenting_\u00e5_angre
+Nothing\ to\ undo=Ingenting \u00e5 angre
 
 occurrences=treff
 
 OK=OK
-One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=En_eller_flere_linker_er_av_typen_'%0'_som_er_udefinert._Hva_vil_du_gj\u00f8re?
+One\ or\ more\ file\ links\ are\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=En eller flere linker er av typen '%0' som er udefinert. Hva vil du gj\u00f8re?
 
-One_or_more_keys_will_be_overwritten._Continue?=En_eller_flere_n\u00f8kler_vil_bli_skrevet_over._Fortsett?
+One\ or\ more\ keys\ will\ be\ overwritten.\ Continue?=En eller flere n\u00f8kler vil bli skrevet over. Fortsett?
 
 
 Open=\u00c5pne
 
-Open_BibTeX_library=\u00c5pne_BibTeX-library
+Open\ BibTeX\ library=\u00c5pne BibTeX-library
 
-Open_library=\u00c5pne_library
+Open\ library=\u00c5pne library
 
-Open_editor_when_a_new_entry_is_created=Start_redigering_n\u00e5r_en_ny_enhet_opprettes
+Open\ editor\ when\ a\ new\ entry\ is\ created=Start redigering n\u00e5r en ny enhet opprettes
 
-Open_file=\u00c5pne_fil
+Open\ file=\u00c5pne fil
 
-Open_last_edited_libraries_at_startup=\u00c5pne_sist_viste_libraryr_ved_oppstart
+Open\ last\ edited\ libraries\ at\ startup=\u00c5pne sist viste libraryr ved oppstart
 
-Connect_to_shared_database=
+Connect\ to\ shared\ database=
 
-Open_terminal_here=
+Open\ terminal\ here=
 
-Open_URL_or_DOI=\u00c5pne_URL_eller_DOI
+Open\ URL\ or\ DOI=\u00c5pne URL eller DOI
 
-Opened_library=\u00c5pnet_library
+Opened\ library=\u00c5pnet library
 
 Opening=\u00c5pner
 
-Opening_preferences...=\u00c5pner_innstillinger...
+Opening\ preferences...=\u00c5pner innstillinger...
 
-Operation_canceled.=Operasjonen_avbrutt.
-Operation_not_supported=Operasjonen_er_ikke_st\u00f8ttet
+Operation\ canceled.=Operasjonen avbrutt.
+Operation\ not\ supported=Operasjonen er ikke st\u00f8ttet
 
-Optional_fields=Valgfrie_felter
+Optional\ fields=Valgfrie felter
 
 Options=Valg
 
 or=eller
 
-Output_or_export_file=Lagre_eller_eksporter_fil
+Output\ or\ export\ file=Lagre eller eksporter fil
 
-Override=Skriv_over
+Override=Skriv over
 
-Override_default_file_directories=Overstyr_hovekataloger_for_filer
+Override\ default\ file\ directories=Overstyr hovekataloger for filer
 
-Override_default_font_settings=Overstyr_standardfonter
+Override\ default\ font\ settings=Overstyr standardfonter
 
-Override_the_BibTeX_field_by_the_selected_text=Overskriv_BibTeX-n\u00f8kkelen_med_den_valgte_teksten
+Override\ the\ BibTeX\ field\ by\ the\ selected\ text=Overskriv BibTeX-n\u00f8kkelen med den valgte teksten
 
 
-Overwrite=Skriv_over
-Overwrite_existing_field_values=Skriv_over_eksisterende_verdier
+Overwrite=Skriv over
+Overwrite\ existing\ field\ values=Skriv over eksisterende verdier
 
-Overwrite_keys=Skriv_over_n\u00f8kler
+Overwrite\ keys=Skriv over n\u00f8kler
 
-pairs_processed=par_revidert
+pairs\ processed=par revidert
 Password=Passord
 
-Paste=Lim_inn
+Paste=Lim inn
 
-paste_entries=lim_inn
+paste\ entries=lim inn
 
-paste_entry=lim_inn
-Paste_from_clipboard=Lim_inn_fra_utklippstavle
+paste\ entry=lim inn
+Paste\ from\ clipboard=Lim inn fra utklippstavle
 
-Pasted=Limte_inn
+Pasted=Limte inn
 
-Path_to_%0_not_defined=Sti_til_%0_ikke_definert
+Path\ to\ %0\ not\ defined=Sti til %0 ikke definert
 
-Path_to_LyX_pipe=Sti_til_LyX-pipe
+Path\ to\ LyX\ pipe=Sti til LyX-pipe
 
-PDF_does_not_exist=PDF-filen_finnes_ikke
+PDF\ does\ not\ exist=PDF-filen finnes ikke
 
-File_has_no_attached_annotations=
+File\ has\ no\ attached\ annotations=
 
-Plain_text_import=Import_fra_ren_tekst
+Plain\ text\ import=Import fra ren tekst
 
-Please_enter_a_name_for_the_group.=Skriv_inn_et_navn_for_gruppen.
+Please\ enter\ a\ name\ for\ the\ group.=Skriv inn et navn for gruppen.
 
-Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>=Skriv_inn_et_s\u00f8kebegrep._For_eksempel,_for_\u00e5_s\u00f8ke_i_alle_felter_etter_<b>Olsen</b>,_skriv\:<p><tt>olsen</tt><p>For_\u00e5_s\u00f8ke_i_<b>Author</b>-feltet_etter_<b>Olsen</b>_og_i_<b>Title</b>-feltet_etter_<b>electrical</b>,_skriv\:<p><tt>author\=olsen_and_title\=electrical</tt>
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Skriv inn et s\u00f8kebegrep. For eksempel, for \u00e5 s\u00f8ke i alle felter etter <b>Olsen</b>, skriv:<p><tt>olsen</tt><p>For \u00e5 s\u00f8ke i <b>Author</b>-feltet etter <b>Olsen</b> og i <b>Title</b>-feltet etter <b>electrical</b>, skriv:<p><tt>author=olsen and title=electrical</tt>
 
-Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=Vennligst_skriv_inn_feltet_som_skal_s\u00f8kes_i_(f.eks._<b>keywords</b>)_og_n\u00f8kkelordet_\u00e5_s\u00f8ke_etter_(f._eks._<b>electrical</b>).
+Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=Vennligst skriv inn feltet som skal s\u00f8kes i (f.eks. <b>keywords</b>) og n\u00f8kkelordet \u00e5 s\u00f8ke etter (f. eks. <b>electrical</b>).
 
-Please_enter_the_string's_label=Skriv_inn_et_navn_for_strengen
+Please\ enter\ the\ string's\ label=Skriv inn et navn for strengen
 
-Please_select_an_importer.=Velg_et_importfilter.
+Please\ select\ an\ importer.=Velg et importfilter.
 
-Possible_duplicate_entries=Mulige_duplikater
+Possible\ duplicate\ entries=Mulige duplikater
 
-Possible_duplicate_of_existing_entry._Click_to_resolve.=Mulig_duplikat_av_eksisterende_enhet._Klikk_for_\u00e5_h\u00e5ndtere.
+Possible\ duplicate\ of\ existing\ entry.\ Click\ to\ resolve.=Mulig duplikat av eksisterende enhet. Klikk for \u00e5 h\u00e5ndtere.
 
 Preamble=Preamble
 
 Preferences=Oppsett
 
-Preferences_recorded.=Lagret_oppsett.
+Preferences\ recorded.=Lagret oppsett.
 
 Preview=Forh\u00e5ndsvisning
-Citation_Style=
-Current_Preview=
-Cannot_generate_preview_based_on_selected_citation_style.=
-Bad_character_inside_entry=
-Error_while_generating_citation_style=
-Preview_style_changed_to\:_%0=
-Next_preview_layout=
-Previous_preview_layout=
+Citation\ Style=
+Current\ Preview=
+Cannot\ generate\ preview\ based\ on\ selected\ citation\ style.=
+Bad\ character\ inside\ entry=
+Error\ while\ generating\ citation\ style=
+Preview\ style\ changed\ to\:\ %0=
+Next\ preview\ layout=
+Previous\ preview\ layout=
 
-Previous_entry=Forrige_enhet
+Previous\ entry=Forrige enhet
 
-Primary_sort_criterion=Prim\u00e6rt_sorteringskriterium
-Problem_with_parsing_entry=Problem_med_\u00e5_lese_enhet
-Processing_%0=Arbeider_%0
-Pull_changes_from_shared_database=
+Primary\ sort\ criterion=Prim\u00e6rt sorteringskriterium
+Problem\ with\ parsing\ entry=Problem med \u00e5 lese enhet
+Processing\ %0=Arbeider %0
+Pull\ changes\ from\ shared\ database=
 
-Pushed_citations_to_%0=Sendte_enheter_til_%0
+Pushed\ citations\ to\ %0=Sendte enheter til %0
 
-Quit_JabRef=Avslutt_JabRef
+Quit\ JabRef=Avslutt JabRef
 
-Quit_synchronization=Avslutt_synkronisering
+Quit\ synchronization=Avslutt synkronisering
 
-Raw_source=Kilde
+Raw\ source=Kilde
 
-Rearrange_tabs_alphabetically_by_title=Rearranger_libraryne_alfabetisk_etter_navn
+Rearrange\ tabs\ alphabetically\ by\ title=Rearranger libraryne alfabetisk etter navn
 
 Redo=Gjenta
 
-Reference_library=Referanselibrary
+Reference\ library=Referanselibrary
 
-%0_references_found._Number_of_references_to_fetch?=Referanser_funnet\:_%0._Antall_referanser_som_skal_hentes?
+%0\ references\ found.\ Number\ of\ references\ to\ fetch?=Referanser funnet: %0. Antall referanser som skal hentes?
 
-Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Undergruppe\:_Vis_enheter_innehold_b\u00e5de_i_denne_gruppen_og_gruppen_over
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=Undergruppe: Vis enheter innehold b\u00e5de i denne gruppen og gruppen over
 
-regular_expression=Regul\u00e6ruttrykk
+regular\ expression=Regul\u00e6ruttrykk
 
-Related_articles=
+Related\ articles=
 
-Remote_operation=Fjernstyring
+Remote\ operation=Fjernstyring
 
-Remote_server_port=Port_for_fjernstyring
+Remote\ server\ port=Port for fjernstyring
 
 Remove=Fjern
 
-Remove_subgroups=Fjern_undergrupper
+Remove\ subgroups=Fjern undergrupper
 
-Remove_all_subgroups_of_"%0"?=Remove_all_subgroups_of_"%0"?
+Remove\ all\ subgroups\ of\ "%0"?=Remove all subgroups of "%0"?
 
-Remove_entry_from_import=Fjern_enhet_fra_import
+Remove\ entry\ from\ import=Fjern enhet fra import
 
-Remove_selected_entries_from_this_group=
+Remove\ selected\ entries\ from\ this\ group=
 
-Remove_entry_type=Slett_enhetstype
+Remove\ entry\ type=Slett enhetstype
 
-Remove_from_group=Fjern_fra_gruppe
+Remove\ from\ group=Fjern fra gruppe
 
-Remove_group=Fjern_gruppe
+Remove\ group=Fjern gruppe
 
-Remove_group,_keep_subgroups=Fjern_gruppe,_behold_undergrupper
+Remove\ group,\ keep\ subgroups=Fjern gruppe, behold undergrupper
 
-Remove_group_"%0"?=Fjern_gruppen_"%0"?
+Remove\ group\ "%0"?=Fjern gruppen "%0"?
 
-Remove_group_"%0"_and_its_subgroups?=Fjern_gruppen_"%0"_og_dens_undergrupper?
+Remove\ group\ "%0"\ and\ its\ subgroups?=Fjern gruppen "%0" og dens undergrupper?
 
-remove_group_(keep_subgroups)=fjern_gruppe_(behold_undergrupper)
+remove\ group\ (keep\ subgroups)=fjern gruppe (behold undergrupper)
 
-remove_group_and_subgroups=fjern_gruppe_og_undergrupper
+remove\ group\ and\ subgroups=fjern gruppe og undergrupper
 
-Remove_group_and_subgroups=Fjern_gruppe_og_undergrupper
+Remove\ group\ and\ subgroups=Fjern gruppe og undergrupper
 
-Remove_link=Slett_link
+Remove\ link=Slett link
 
-Remove_old_entry=Fjern_gammel_enhet
+Remove\ old\ entry=Fjern gammel enhet
 
-Remove_selected_strings=Slett_valgte_strenger
+Remove\ selected\ strings=Slett valgte strenger
 
-Removed_group_"%0".=Fjernet_gruppen_"%0"
+Removed\ group\ "%0".=Fjernet gruppen "%0"
 
-Removed_group_"%0"_and_its_subgroups.=Fjernet_gruppen_"%0"_og_dens_undergrupper
+Removed\ group\ "%0"\ and\ its\ subgroups.=Fjernet gruppen "%0" og dens undergrupper
 
-Removed_string=Fjernet_streng
+Removed\ string=Fjernet streng
 
-Renamed_string=Endret_navn_p\u00e5_streng
+Renamed\ string=Endret navn p\u00e5 streng
 
 Replace=
 
-Replace_(regular_expression)=Erstatt_(regul\u00e6ruttrykk)
+Replace\ (regular\ expression)=Erstatt (regul\u00e6ruttrykk)
 
-Replace_string=Erstatt_streng
+Replace\ string=Erstatt streng
 
-Replace_with=Erstatt_med
+Replace\ with=Erstatt med
 
 Replaced=Erstattet
 
-Required_fields=N\u00f8dvendige_felter
+Required\ fields=N\u00f8dvendige felter
 
-Reset_all=Tilbakestill_alle
+Reset\ all=Tilbakestill alle
 
-Resolve_strings_for_all_fields_except=Sl\u00e5_opp_strenger_for_alle_felter_unntatt
-Resolve_strings_for_standard_BibTeX_fields_only=Sl\u00e5_opp_strenger_kun_for_standard_BibTeX-felter
+Resolve\ strings\ for\ all\ fields\ except=Sl\u00e5 opp strenger for alle felter unntatt
+Resolve\ strings\ for\ standard\ BibTeX\ fields\ only=Sl\u00e5 opp strenger kun for standard BibTeX-felter
 
-resolved=tatt_h\u00e5nd_om
+resolved=tatt h\u00e5nd om
 
 Review=Kommentarer
 
-Review_changes=Se_over_endringer
+Review\ changes=Se over endringer
 
 Right=H\u00f8yre
 
 Save=Lagre
-Save_all_finished.=Fullf\u00f8rte_lagring_av_alle_libraryr
+Save\ all\ finished.=Fullf\u00f8rte lagring av alle libraryr
 
-Save_all_open_libraries=Lagre_alle_\u00e5pne_libraryr
+Save\ all\ open\ libraries=Lagre alle \u00e5pne libraryr
 
-Save_before_closing=Lagre_f\u00f8r_libraryn_lukkes
+Save\ before\ closing=Lagre f\u00f8r libraryn lukkes
 
-Save_library=Lagre_library
-Save_library_as...=Lagre_library_som_...
+Save\ library=Lagre library
+Save\ library\ as...=Lagre library som ...
 
-Save_entries_in_their_original_order=Lagre_enheter_i_opprinnelig_rekkef\u00f8lge
+Save\ entries\ in\ their\ original\ order=Lagre enheter i opprinnelig rekkef\u00f8lge
 
-Save_failed=Lagring_mislyktes
+Save\ failed=Lagring mislyktes
 
-Save_failed_during_backup_creation=Lagring_mislyktes_ved_opprettelse_av_sikkerhetskopi
+Save\ failed\ during\ backup\ creation=Lagring mislyktes ved opprettelse av sikkerhetskopi
 
-Save_selected_as...=Lagre_valgte_som_...
+Save\ selected\ as...=Lagre valgte som ...
 
-Saved_library=Lagret_library
+Saved\ library=Lagret library
 
-Saved_selected_to_'%0'.=Lagret_valgte_i_'%0'.
+Saved\ selected\ to\ '%0'.=Lagret valgte i '%0'.
 
 Saving=Lagrer
-Saving_all_libraries...=Lagrer_alle_libraryr...
+Saving\ all\ libraries...=Lagrer alle libraryr...
 
-Saving_library=Lagrer_library
+Saving\ library=Lagrer library
 
 Search=S\u00f8k
 
-Search_expression=S\u00f8keuttrykk
+Search\ expression=S\u00f8keuttrykk
 
-Search_for=S\u00f8k_etter
+Search\ for=S\u00f8k etter
 
-Searching_for_duplicates...=S\u00f8ker_etter_duplikater...
+Searching\ for\ duplicates...=S\u00f8ker etter duplikater...
 
-Searching_for_files=S\u00f8ker_etter_filer
+Searching\ for\ files=S\u00f8ker etter filer
 
-Secondary_sort_criterion=Andre_sorteringskriterium
+Secondary\ sort\ criterion=Andre sorteringskriterium
 
-Select_all=Velg_alle
+Select\ all=Velg alle
 
-Select_encoding=Velg_koding
+Select\ encoding=Velg koding
 
-Select_entry_type=Velg_enhetstype
-Select_external_application=Velg_ekstern_applikasjon
+Select\ entry\ type=Velg enhetstype
+Select\ external\ application=Velg ekstern applikasjon
 
-Select_file_from_ZIP-archive=Velg_fil_fra_ZIP-fil
+Select\ file\ from\ ZIP-archive=Velg fil fra ZIP-fil
 
-Select_the_tree_nodes_to_view_and_accept_or_reject_changes=Velg_trenodene_for_\u00e5_inspisere_og_akseptere_eller_avsl\u00e5_endringer
-Selected_entries=Valgte_enheter
-Set_field=Sett_felt
-Set_fields=Sett_felter
+Select\ the\ tree\ nodes\ to\ view\ and\ accept\ or\ reject\ changes=Velg trenodene for \u00e5 inspisere og akseptere eller avsl\u00e5 endringer
+Selected\ entries=Valgte enheter
+Set\ field=Sett felt
+Set\ fields=Sett felter
 
-Set_general_fields=Tilpass_generelle_felter
-Set_main_external_file_directory=Sett_hovedkatalog_for_eksterne_linker
+Set\ general\ fields=Tilpass generelle felter
+Set\ main\ external\ file\ directory=Sett hovedkatalog for eksterne linker
 
-Set_table_font=Velg_tabellfont
+Set\ table\ font=Velg tabellfont
 
 Settings=Innstillinger
 
 Shortcut=Snarvei
 
-Show/edit_%0_source=Vis/rediger_%0-kilde
+Show/edit\ %0\ source=Vis/rediger %0-kilde
 
-Show_'Firstname_Lastname'=Vis_'Fornavn_Etternavn'
+Show\ 'Firstname\ Lastname'=Vis 'Fornavn Etternavn'
 
-Show_'Lastname,_Firstname'=Vis_'Etternavn,_Fornavn'
+Show\ 'Lastname,\ Firstname'=Vis 'Etternavn, Fornavn'
 
-Show_BibTeX_source_by_default=Vis_BibTeX-kode_som_standard
+Show\ BibTeX\ source\ by\ default=Vis BibTeX-kode som standard
 
-Show_confirmation_dialog_when_deleting_entries=Vis_dialog_for_\u00e5_bekrefte_sletting_av_enheter
+Show\ confirmation\ dialog\ when\ deleting\ entries=Vis dialog for \u00e5 bekrefte sletting av enheter
 
-Show_description=Vis_beskrivelse
+Show\ description=Vis beskrivelse
 
-Show_file_column=Vis_'file'-kolonne
+Show\ file\ column=Vis 'file'-kolonne
 
-Show_last_names_only=Vis_bare_etternavn
+Show\ last\ names\ only=Vis bare etternavn
 
-Show_names_unchanged=Vis_navn_uforandret
+Show\ names\ unchanged=Vis navn uforandret
 
-Show_optional_fields=Vis_valgfrie_felter
+Show\ optional\ fields=Vis valgfrie felter
 
-Show_required_fields=Vis_n\u00f8dvendige_felter
+Show\ required\ fields=Vis n\u00f8dvendige felter
 
-Show_URL/DOI_column=Vis_URL/DOI-kolonne
+Show\ URL/DOI\ column=Vis URL/DOI-kolonne
 
-Simple_HTML=Enkel_HTML
+Simple\ HTML=Enkel HTML
 
 Size=St\u00f8rrelse
 
-Skipped_-_No_PDF_linked=Hoppet_over_-_ingen_PDF-fil_linket
-Skipped_-_PDF_does_not_exist=Hoppet_over_-_PDF-filen_finnes_ikke
+Skipped\ -\ No\ PDF\ linked=Hoppet over - ingen PDF-fil linket
+Skipped\ -\ PDF\ does\ not\ exist=Hoppet over - PDF-filen finnes ikke
 
-Skipped_entry.=Hoppet_over_enhet.
+Skipped\ entry.=Hoppet over enhet.
 
-Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.=
+Some\ appearance\ settings\ you\ changed\ require\ to\ restart\ JabRef\ to\ come\ into\ effect.=
 
-source_edit=redigering_av_kilde
-Special_name_formatters=Spesielle_navneformaterere
+source\ edit=redigering av kilde
+Special\ name\ formatters=Spesielle navneformaterere
 
-Special_table_columns=Spesielle_kolonner
+Special\ table\ columns=Spesielle kolonner
 
-Starting_import=Starter_import
+Starting\ import=Starter import
 
-Statically_group_entries_by_manual_assignment=Grupper_enheter_statisk_ved_manuell_tildeling
+Statically\ group\ entries\ by\ manual\ assignment=Grupper enheter statisk ved manuell tildeling
 
 Status=Status
 
@@ -1143,1019 +1143,1019 @@ Stop=Stopp
 
 Strings=Strenger
 
-Strings_for_library=Strenger_for_library
+Strings\ for\ library=Strenger for library
 
-Sublibrary_from_AUX=Dellibrary_fra_AUX-fil
+Sublibrary\ from\ AUX=Dellibrary fra AUX-fil
 
-Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.=Bytter_mellom_fullt_og_forkortet_journalnavn_dersom_navnet_er_kjent.
+Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=Bytter mellom fullt og forkortet journalnavn dersom navnet er kjent.
 
-Synchronize_file_links=Synkroniser_eksterne_linker
+Synchronize\ file\ links=Synkroniser eksterne linker
 
-Synchronizing_file_links...=Synkroniserer_fil-linker...
+Synchronizing\ file\ links...=Synkroniserer fil-linker...
 
-Table_appearance=Tabelloppsett
+Table\ appearance=Tabelloppsett
 
-Table_background_color=Bakgrunnsfarge_for_tabell
+Table\ background\ color=Bakgrunnsfarge for tabell
 
-Table_grid_color=Farge_p\u00e5_linjer_i_tabell
+Table\ grid\ color=Farge p\u00e5 linjer i tabell
 
-Table_text_color=Tekstfarge_i_tabell
+Table\ text\ color=Tekstfarge i tabell
 
 Tabname=Tabnavn
-Target_file_cannot_be_a_directory.=M\u00e5lfilen_kan_ikke_v\u00e6re_en_katalog.
+Target\ file\ cannot\ be\ a\ directory.=M\u00e5lfilen kan ikke v\u00e6re en katalog.
 
-Tertiary_sort_criterion=Tredje_sorteringskriterium
+Tertiary\ sort\ criterion=Tredje sorteringskriterium
 
 Test=Test
 
-paste_text_here=Inndatafelt
+paste\ text\ here=Inndatafelt
 
-The_chosen_date_format_for_new_entries_is_not_valid=Det_valgte_datoformatet_er_ugyldig
+The\ chosen\ date\ format\ for\ new\ entries\ is\ not\ valid=Det valgte datoformatet er ugyldig
 
-The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:=Den_valgte_tegnkodingen_'%0'_kunne_ikke_kode_f\u00f8lgende_tegn\:
+The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=Den valgte tegnkodingen '%0' kunne ikke kode f\u00f8lgende tegn:
 
 
-the_field_<b>%0</b>=feltet_<b>%0</b>
+the\ field\ <b>%0</b>=feltet <b>%0</b>
 
-The_file<BR>'%0'<BR>has_been_modified<BR>externally\!=Filen<BR>'%0'<BR>har_blitt_endret<BR>eksternt\!
+The\ file<BR>'%0'<BR>has\ been\ modified<BR>externally\!=Filen<BR>'%0'<BR>har blitt endret<BR>eksternt!
 
-The_group_"%0"_already_contains_the_selection.=Gruppen_"%0"_inneholder_allerede_de_valgte_enhetene.
+The\ group\ "%0"\ already\ contains\ the\ selection.=Gruppen "%0" inneholder allerede de valgte enhetene.
 
-The_label_of_the_string_cannot_be_a_number.=Navnet_p\u00e5_strengen_kan_ikke_v\u00e6re_et_tall.
+The\ label\ of\ the\ string\ cannot\ be\ a\ number.=Navnet p\u00e5 strengen kan ikke v\u00e6re et tall.
 
-The_label_of_the_string_cannot_contain_spaces.=Navnet_p\u00e5_strengen_kan_ikke_inneholde_mellomrom.
+The\ label\ of\ the\ string\ cannot\ contain\ spaces.=Navnet p\u00e5 strengen kan ikke inneholde mellomrom.
 
-The_label_of_the_string_cannot_contain_the_'\#'_character.=Navnet_p\u00e5_strengen_kan_ikke_inneholde_tegnet_'\#'.
+The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=Navnet p\u00e5 strengen kan ikke inneholde tegnet '#'.
 
-The_output_option_depends_on_a_valid_import_option.=Lagre-operasjonen_er_avhengig_av_en_gyldig_import-operasjon.
-The_PDF_contains_one_or_several_BibTeX-records.=PDF-filen_inneholder_en_eller_flere_BibTeX-enheter.
-Do_you_want_to_import_these_as_new_entries_into_the_current_library?=Vil_du_importere_disse_som_nye_enheter_i_den_\u00e5pne_libraryn?
+The\ output\ option\ depends\ on\ a\ valid\ import\ option.=Lagre-operasjonen er avhengig av en gyldig import-operasjon.
+The\ PDF\ contains\ one\ or\ several\ BibTeX-records.=PDF-filen inneholder en eller flere BibTeX-enheter.
+Do\ you\ want\ to\ import\ these\ as\ new\ entries\ into\ the\ current\ library?=Vil du importere disse som nye enheter i den \u00e5pne libraryn?
 
-The_regular_expression_<b>%0</b>_is_invalid\:=Regul\u00e6ruttrykket_<b>%0</b>_er_ugyldig\:
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=Regul\u00e6ruttrykket <b>%0</b> er ugyldig:
 
-The_search_is_case_insensitive.=S\u00f8ket_skiller_ikke_mellom_store_og_sm\u00e5_bokstaver.
+The\ search\ is\ case\ insensitive.=S\u00f8ket skiller ikke mellom store og sm\u00e5 bokstaver.
 
-The_search_is_case_sensitive.=S\u00f8ket_skiller_mellom_store_og_sm\u00e5_bokstaver.
+The\ search\ is\ case\ sensitive.=S\u00f8ket skiller mellom store og sm\u00e5 bokstaver.
 
-The_string_has_been_removed_locally=Strengen_har_blitt_slettet_lokalt
+The\ string\ has\ been\ removed\ locally=Strengen har blitt slettet lokalt
 
-There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?=Det_finnes_mulige_duplikater_(merket_med_et_ikon)_som_ikke_har_blitt_h\u00e5ndtert._Fortsette?
+There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=Det finnes mulige duplikater (merket med et ikon) som ikke har blitt h\u00e5ndtert. Fortsette?
 
-This_entry_has_no_BibTeX_key._Generate_key_now?=Denne_enheten_har_ingen_BibTeX-n\u00f8kkel._Generer_n\u00f8kkel_n\u00e5?
+This\ entry\ has\ no\ BibTeX\ key.\ Generate\ key\ now?=Denne enheten har ingen BibTeX-n\u00f8kkel. Generer n\u00f8kkel n\u00e5?
 
-This_entry_is_incomplete=Denne_enheten_er_ufullstendig
+This\ entry\ is\ incomplete=Denne enheten er ufullstendig
 
-This_entry_type_cannot_be_removed.=Denne_enhetstypen_kan_ikke_slettes.
+This\ entry\ type\ cannot\ be\ removed.=Denne enhetstypen kan ikke slettes.
 
-This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Denne_eksterne_linken_er_av_typen_'%0'_som_er_udefinert._Hva_vil_du_gj\u00f8re?
+This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Denne eksterne linken er av typen '%0' som er udefinert. Hva vil du gj\u00f8re?
 
-This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.=Denne_gruppen_inneholder_enheter_basert_p\u00e5_manuell_tilordning._Enheter_kan_tilordnes_til_denne_gruppen_ved_\u00e5_velge_dem_og_deretter_trekke_dem_over_til_gruppen,_eller_ved_hjelp_av_h\u00f8yreklikkmenyen.
+This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=Denne gruppen inneholder enheter basert p\u00e5 manuell tilordning. Enheter kan tilordnes til denne gruppen ved \u00e5 velge dem og deretter trekke dem over til gruppen, eller ved hjelp av h\u00f8yreklikkmenyen.
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>=Denne_gruppen_inneholder_enheter_hvis_<b>%0</b>-felt_inneholder_n\u00f8kkelordet_<b>%1</b>
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Denne gruppen inneholder enheter hvis <b>%0</b>-felt inneholder n\u00f8kkelordet <b>%1</b>
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>=Denne_gruppen_inneholder_enheter_hvis_<b>%0</b>-felt_stemmer_med_regul\u00e6ruttrykket_<b>%1</b>
-This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.=Dette_f\u00e5r_JabRef_til_\u00e5_unders\u00f8ke_hver_av_fil-linkene,_og_sjekke_om_filen_eksisterer._Hvis_ikke_vil_du_bli_gitt_valg<BR>for_\u00e5_l\u00f8se_problemet.
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Denne gruppen inneholder enheter hvis <b>%0</b>-felt stemmer med regul\u00e6ruttrykket <b>%1</b>
+This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=Dette f\u00e5r JabRef til \u00e5 unders\u00f8ke hver av fil-linkene, og sjekke om filen eksisterer. Hvis ikke vil du bli gitt valg<BR>for \u00e5 l\u00f8se problemet.
 
-This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.=Denne_operasjonen_krever_at_alle_valgte_enheter_har_definerte_BibTeX-n\u00f8kler.
+This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=Denne operasjonen krever at alle valgte enheter har definerte BibTeX-n\u00f8kler.
 
-This_operation_requires_one_or_more_entries_to_be_selected.=Denne_operasjonen_krever_at_en_eller_flere_enheter_er_valgt.
+This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=Denne operasjonen krever at en eller flere enheter er valgt.
 
-Toggle_entry_preview=Vis/skjul_forh\u00e5ndsvisning
-Toggle_groups_interface=Vis/skjul_grupperingskontroll
-Try_different_encoding=Pr\u00f8v_en_annen_tegnkoding
+Toggle\ entry\ preview=Vis/skjul forh\u00e5ndsvisning
+Toggle\ groups\ interface=Vis/skjul grupperingskontroll
+Try\ different\ encoding=Pr\u00f8v en annen tegnkoding
 
-Unabbreviate_journal_names_of_the_selected_entries=Ekspander_journalnavn_for_de_valgte_enhetene
-Unabbreviated_%0_journal_names.=Ekspanderte_%0_journalnavn.
+Unabbreviate\ journal\ names\ of\ the\ selected\ entries=Ekspander journalnavn for de valgte enhetene
+Unabbreviated\ %0\ journal\ names.=Ekspanderte %0 journalnavn.
 
-Unable_to_open_file.=Kan_ikke_\u00e5pne_fil.
-Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.=Kan_ikke_\u00e5pne_link._Applikasjonen_'%0'_assosiert_med_filtypen_'%1'_kunne_ikke_kalles.
-unable_to_write_to=kunne_ikke_skrive_til
-Undefined_file_type=Udefinert_filtype
+Unable\ to\ open\ file.=Kan ikke \u00e5pne fil.
+Unable\ to\ open\ link.\ The\ application\ '%0'\ associated\ with\ the\ file\ type\ '%1'\ could\ not\ be\ called.=Kan ikke \u00e5pne link. Applikasjonen '%0' assosiert med filtypen '%1' kunne ikke kalles.
+unable\ to\ write\ to=kunne ikke skrive til
+Undefined\ file\ type=Udefinert filtype
 
 Undo=Angre
 
 Union=Union
 
-Unknown_BibTeX_entries=Ukjente_BibTeX-enheter
+Unknown\ BibTeX\ entries=Ukjente BibTeX-enheter
 
-unknown_edit=ukjent_endring
+unknown\ edit=ukjent endring
 
-Unknown_export_format=Ukjent_eksportformat
+Unknown\ export\ format=Ukjent eksportformat
 
-Unmark_all=Fjern_merking_fra_alle
+Unmark\ all=Fjern merking fra alle
 
-Unmark_entries=Fjern_merking
+Unmark\ entries=Fjern merking
 
-Unmark_entry=Fjern_merking
+Unmark\ entry=Fjern merking
 
-untitled=uten_navn
+untitled=uten navn
 
 Up=Opp
 
-Update_to_current_column_widths=Bruk_n\u00e5v\u00e6rende_kolonnebredder
+Update\ to\ current\ column\ widths=Bruk n\u00e5v\u00e6rende kolonnebredder
 
-Updated_group_selection=Updated_group_selection
-Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.=Oppgrader_eksterne_PDF-_og_PS-linker_til_\u00e5_bruke_'%0'-feltet.
-Upgrade_file=Oppgrader_fil
-Upgrade_old_external_file_links_to_use_the_new_feature=Oppgrader_gamle_eksterne_linker_for_\u00e5_bruke_den_nye_funksjonen
+Updated\ group\ selection=Updated group selection
+Upgrade\ external\ PDF/PS\ links\ to\ use\ the\ '%0'\ field.=Oppgrader eksterne PDF- og PS-linker til \u00e5 bruke '%0'-feltet.
+Upgrade\ file=Oppgrader fil
+Upgrade\ old\ external\ file\ links\ to\ use\ the\ new\ feature=Oppgrader gamle eksterne linker for \u00e5 bruke den nye funksjonen
 
 usage=bruk
-Use_autocompletion_for_the_following_fields=Bruk_autokomplettering_for_f\u00f8lgende_felter
+Use\ autocompletion\ for\ the\ following\ fields=Bruk autokomplettering for f\u00f8lgende felter
 
-Use_other_look_and_feel=Bruk_annet_utseende
-Tweak_font_rendering_for_entry_editor_on_Linux=
-Use_regular_expression_search=S\u00f8k_med_regul\u00e6ruttrykk
+Use\ other\ look\ and\ feel=Bruk annet utseende
+Tweak\ font\ rendering\ for\ entry\ editor\ on\ Linux=
+Use\ regular\ expression\ search=S\u00f8k med regul\u00e6ruttrykk
 
 Username=Brukernavn
 
-Value_cleared_externally=Verdien_slettet_eksternt
+Value\ cleared\ externally=Verdien slettet eksternt
 
-Value_set_externally=Verdi_satt_eksternt
+Value\ set\ externally=Verdi satt eksternt
 
-verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid=kontroller_at_LyX_kj\u00f8rer,_og_at_den_angitte_lyxpipe_stemmer
+verify\ that\ LyX\ is\ running\ and\ that\ the\ lyxpipe\ is\ valid=kontroller at LyX kj\u00f8rer, og at den angitte lyxpipe stemmer
 
 View=Vis
-Vim_server_name=Navn_p\u00e5_Vim-server
+Vim\ server\ name=Navn p\u00e5 Vim-server
 
-Waiting_for_ArXiv...=Venter_p\u00e5_ArXiv
+Waiting\ for\ ArXiv...=Venter p\u00e5 ArXiv
 
-Warn_about_unresolved_duplicates_when_closing_inspection_window=Advar_om_duplikater_som_ikke_er_blitt_h\u00e5ndtert_n\u00e5r_inspeksjonsvinduet_lukkes
+Warn\ about\ unresolved\ duplicates\ when\ closing\ inspection\ window=Advar om duplikater som ikke er blitt h\u00e5ndtert n\u00e5r inspeksjonsvinduet lukkes
 
-Warn_before_overwriting_existing_keys=Gi_advarsel_f\u00f8r_eksisterende_n\u00f8kler_skrives_over
+Warn\ before\ overwriting\ existing\ keys=Gi advarsel f\u00f8r eksisterende n\u00f8kler skrives over
 
 Warning=Advarsel
 
 Warnings=Advarsler
 
-web_link=link
+web\ link=link
 
-What_do_you_want_to_do?=Hva_vil_du_gj\u00f8re?
+What\ do\ you\ want\ to\ do?=Hva vil du gj\u00f8re?
 
-When_adding/removing_keywords,_separate_them_by=N\u00e5r_n\u00f8kkelord_legges_til_eller_fjernes_skill_dem_med
-Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.=Vil_skrive_XMP-metadata_til_PDFene_linket_fra_de_valgte_enhetene.
+When\ adding/removing\ keywords,\ separate\ them\ by=N\u00e5r n\u00f8kkelord legges til eller fjernes skill dem med
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Vil skrive XMP-metadata til PDFene linket fra de valgte enhetene.
 
 with=med
 
-Write_BibTeXEntry_as_XMP-metadata_to_PDF.=Skriv_BibTeX-enheten_som_XMP-metadata_til_PDF.
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Skriv BibTeX-enheten som XMP-metadata til PDF.
 
-Write_XMP=Skriv_XMP
-Write_XMP-metadata=Skriv_XMP-metadata
-Write_XMP-metadata_for_all_PDFs_in_current_library?=Skriv_XMP-metadata_for_alle_PDFer_i_denne_libraryn?
-Writing_XMP-metadata...=Skriver_XMP-metadata...
-Writing_XMP-metadata_for_selected_entries...=Skriver_XMP-metadata_for_de_valgte_enhetene...
+Write\ XMP=Skriv XMP
+Write\ XMP-metadata=Skriv XMP-metadata
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Skriv XMP-metadata for alle PDFer i denne libraryn?
+Writing\ XMP-metadata...=Skriver XMP-metadata...
+Writing\ XMP-metadata\ for\ selected\ entries...=Skriver XMP-metadata for de valgte enhetene...
 
-Wrote_XMP-metadata=Skrev_XMP-metadata
+Wrote\ XMP-metadata=Skrev XMP-metadata
 
-XMP-annotated_PDF=XMP-annotert_PDF
-XMP_export_privacy_settings=Innstillinger_for_XMP-eksport
+XMP-annotated\ PDF=XMP-annotert PDF
+XMP\ export\ privacy\ settings=Innstillinger for XMP-eksport
 XMP-metadata=XMP-metadata
-XMP-metadata_found_in_PDF\:_%0=XMP-metadata_funnet_i_PDF\:_%0
-You_must_restart_JabRef_for_this_to_come_into_effect.=Du_m\u00e5_starte_JabRef_p\u00e5_nytt_for_at_dette_skal_tre_i_kraft.
-You_have_changed_the_language_setting.=Du_har_valgt_et_nytt_spr\u00e5k.
-You_have_entered_an_invalid_search_'%0'.=Ugyldig_s\u00f8keuttrykk_'%0'.
+XMP-metadata\ found\ in\ PDF\:\ %0=XMP-metadata funnet i PDF: %0
+You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Du m\u00e5 starte JabRef p\u00e5 nytt for at dette skal tre i kraft.
+You\ have\ changed\ the\ language\ setting.=Du har valgt et nytt spr\u00e5k.
+You\ have\ entered\ an\ invalid\ search\ '%0'.=Ugyldig s\u00f8keuttrykk '%0'.
 
-You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.=Du_m\u00e5_starte_JabRef_p\u00e5_nytt_for_at_de_nye_hurtigtastene_skal_fungere.
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Du m\u00e5 starte JabRef p\u00e5 nytt for at de nye hurtigtastene skal fungere.
 
-Your_new_key_bindings_have_been_stored.=Dine_nye_hurtigtaster_har_blitt_lagret.
+Your\ new\ key\ bindings\ have\ been\ stored.=Dine nye hurtigtaster har blitt lagret.
 
-The_following_fetchers_are_available\:=De_f\u00f8lgende_nedlasterne_er_tilgjengelige\:
-Could_not_find_fetcher_'%0'=Kunne_ikke_finne_nedlasteren_'%0'
-Running_query_'%0'_with_fetcher_'%1'.=Utf\u00f8rer_s\u00f8k_'%0'_med_nedlaster_'%1'.
-Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.=S\u00f8ket_'%0'_med_nedlaster_'%1'_ga_ingen_resultater.
+The\ following\ fetchers\ are\ available\:=De f\u00f8lgende nedlasterne er tilgjengelige:
+Could\ not\ find\ fetcher\ '%0'=Kunne ikke finne nedlasteren '%0'
+Running\ query\ '%0'\ with\ fetcher\ '%1'.=Utf\u00f8rer s\u00f8k '%0' med nedlaster '%1'.
+Query\ '%0'\ with\ fetcher\ '%1'\ did\ not\ return\ any\ results.=S\u00f8ket '%0' med nedlaster '%1' ga ingen resultater.
 
-Move_file=Flytt_fil
-Rename_file=endre_navn_p\u00e5_fil
+Move\ file=Flytt fil
+Rename\ file=endre navn p\u00e5 fil
 
-Move_file_failed=Flytting_av_fil_mislyktes
-Could_not_move_file_'%0'.=Kunne_ikke_flytte_filen_'%0'.
-Could_not_find_file_'%0'.=Kunne_ikke_finne_filen_'%0'.
-Number_of_entries_successfully_imported=Antall_enheter_importert
-Import_canceled_by_user=Import_avbrutt_av_bruker
-Progress\:_%0_of_%1=Framdrift\:_%0_av_%1
-Error_while_fetching_from_%0=Feil_ved_henting_fra_%0
+Move\ file\ failed=Flytting av fil mislyktes
+Could\ not\ move\ file\ '%0'.=Kunne ikke flytte filen '%0'.
+Could\ not\ find\ file\ '%0'.=Kunne ikke finne filen '%0'.
+Number\ of\ entries\ successfully\ imported=Antall enheter importert
+Import\ canceled\ by\ user=Import avbrutt av bruker
+Progress\:\ %0\ of\ %1=Framdrift: %0 av %1
+Error\ while\ fetching\ from\ %0=Feil ved henting fra %0
 
-Please_enter_a_valid_number=Vennligst_skriv_inn_et_gyldig_tall
-Show_search_results_in_a_window=Vis_s\u00f8keresultatene_i_et_vundu
-Show_global_search_results_in_a_window=
-Search_in_all_open_libraries=
-Move_file_to_file_directory?=Flytt_filen_til_hovedkatalogen_for_filer?
+Please\ enter\ a\ valid\ number=Vennligst skriv inn et gyldig tall
+Show\ search\ results\ in\ a\ window=Vis s\u00f8keresultatene i et vundu
+Show\ global\ search\ results\ in\ a\ window=
+Search\ in\ all\ open\ libraries=
+Move\ file\ to\ file\ directory?=Flytt filen til hovedkatalogen for filer?
 
-Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.=Libraryn_er_beskyttet._Kan_ikke_lagre_f\u00f8r_eksterne_endringer_har_blitt_gjennomg\u00e5tt.
-Protected_library=Beskyttet_library
-Refuse_to_save_the_library_before_external_changes_have_been_reviewed.=Nekt_\u00e5_lagre_libraryn_f\u00f8r_eksterne_endringer_har_blitt_gjennomg\u00e5tt.
-Library_protection=Librarybeskyttelse
-Unable_to_save_library=Kan_ikke_lagre_libraryn
+Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=Libraryn er beskyttet. Kan ikke lagre f\u00f8r eksterne endringer har blitt gjennomg\u00e5tt.
+Protected\ library=Beskyttet library
+Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=Nekt \u00e5 lagre libraryn f\u00f8r eksterne endringer har blitt gjennomg\u00e5tt.
+Library\ protection=Librarybeskyttelse
+Unable\ to\ save\ library=Kan ikke lagre libraryn
 
-BibTeX_key_generator=BibTeX-n\u00f8kkelgenerator
-Unable_to_open_link.=Kan_ikke_\u00e5pne_link.
-Move_the_keyboard_focus_to_the_entry_table=Flytt_fokus_til_hovedtabellen
-MIME_type=MIME-type
+BibTeX\ key\ generator=BibTeX-n\u00f8kkelgenerator
+Unable\ to\ open\ link.=Kan ikke \u00e5pne link.
+Move\ the\ keyboard\ focus\ to\ the\ entry\ table=Flytt fokus til hovedtabellen
+MIME\ type=MIME-type
 
-This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.=Denne_funksjonen_lar_deg_\u00e5pne_eller_importere_nye_filer_til_en_allerede_kj\u00f8rende_instans_av_JabRef<br>fra_nettleseren_din.<br>Merk_at_dette_vil_hindre_deg_i_\u00e5_kj\u00f8re_mer_enn_en_instans_av_JabRef_av_gangen.
-Run_fetcher,_e.g._"--fetch\=Medline\:cancer"=
+This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef<BR>instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef<br>from\ your\ web\ browser.<BR>Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=Denne funksjonen lar deg \u00e5pne eller importere nye filer til en allerede kj\u00f8rende instans av JabRef<br>fra nettleseren din.<br>Merk at dette vil hindre deg i \u00e5 kj\u00f8re mer enn en instans av JabRef av gangen.
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=
 
-The_ACM_Digital_Library=ACM_Digital_Library
+The\ ACM\ Digital\ Library=ACM Digital Library
 Reset=Resett
 
-Use_IEEE_LaTeX_abbreviations=Bruk_IEEE-LaTeX-forkortelser
-The_Guide_to_Computing_Literature=The_Guide_to_Computing_Literature
+Use\ IEEE\ LaTeX\ abbreviations=Bruk IEEE-LaTeX-forkortelser
+The\ Guide\ to\ Computing\ Literature=The Guide to Computing Literature
 
-When_opening_file_link,_search_for_matching_file_if_no_link_is_defined=Ved_\u00e5pning_av_linke,_s\u00b8k_etter_matchende_fil_hvis_ingen_er_definert
-Settings_for_%0=Innstillinger_for_%0
-Mark_entries_imported_into_an_existing_library=Merk_enheter_som_importeres_til_en_eksisterende_library
-Unmark_all_entries_before_importing_new_entries_into_an_existing_library=Fjern_merking_fra_alle_merkede_enheter_f\u00b8r_nye_importeres
+When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=Ved \u00e5pning av linke, s\u00b8k etter matchende fil hvis ingen er definert
+Settings\ for\ %0=Innstillinger for %0
+Mark\ entries\ imported\ into\ an\ existing\ library=Merk enheter som importeres til en eksisterende library
+Unmark\ all\ entries\ before\ importing\ new\ entries\ into\ an\ existing\ library=Fjern merking fra alle merkede enheter f\u00b8r nye importeres
 
 Forward=Fram
 Back=Tilbake
-Sort_the_following_fields_as_numeric_fields=Sorter_de_f\u00c3\u00b8lgende_feltene_som_tall
-Line_%0\:_Found_corrupted_BibTeX_key.=Linje_%0\:_Fant_ugyldig_BibTeX-n\u00b8kkel.
-Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).=Linje_%0\:_Fant_ugyldig_BibTeX-n\u00b8kkel_(inneholder_mellomrom).
-Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).=Linje_%0\:_Fant_ugyldig_BibTeX-n\u00b8kkel_(manglende_komma).
-Full_text_document_download_failed=Kunne_ikke_laste_ned_fulltekstdokument
-Update_to_current_column_order=Oppdater_til_n\u00e5v\u00e6rende_rekkef\u00b8lge_p\u00e5_kolonner
-Download_from_URL=
-Rename_field=Endre_navn_p\u00e5_felt
-Set/clear/append/rename_fields=Sett/slett/endre_navn_p\u00e5_felt
-Append_field=
-Append_to_fields=
-Rename_field_to=Endre_navn_p\u00e5_felt_til
-Move_contents_of_a_field_into_a_field_with_a_different_name=Flytt_innholdet_i_et_felt_til_et_annet_felt
-You_can_only_rename_one_field_at_a_time=Du_kan_bare_endre_navn_p\u00e5_ett_felt_av_gangen
+Sort\ the\ following\ fields\ as\ numeric\ fields=Sorter de f\u00c3\u00b8lgende feltene som tall
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=Linje %0: Fant ugyldig BibTeX-n\u00b8kkel.
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=Linje %0: Fant ugyldig BibTeX-n\u00b8kkel (inneholder mellomrom).
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=Linje %0: Fant ugyldig BibTeX-n\u00b8kkel (manglende komma).
+Full\ text\ document\ download\ failed=Kunne ikke laste ned fulltekstdokument
+Update\ to\ current\ column\ order=Oppdater til n\u00e5v\u00e6rende rekkef\u00b8lge p\u00e5 kolonner
+Download\ from\ URL=
+Rename\ field=Endre navn p\u00e5 felt
+Set/clear/append/rename\ fields=Sett/slett/endre navn p\u00e5 felt
+Append\ field=
+Append\ to\ fields=
+Rename\ field\ to=Endre navn p\u00e5 felt til
+Move\ contents\ of\ a\ field\ into\ a\ field\ with\ a\ different\ name=Flytt innholdet i et felt til et annet felt
+You\ can\ only\ rename\ one\ field\ at\ a\ time=Du kan bare endre navn p\u00e5 ett felt av gangen
 
-Remove_all_broken_links=Fjern_alle_ugyldige_linker
+Remove\ all\ broken\ links=Fjern alle ugyldige linker
 
-Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.=Kan_ikke_bruke_port_%0_for_fjernstyring;_den_kan_v\u00e6re_i_bruk_av_et_annet_program._Pr\u00b8v_\u00e5_spesifisere_en_annen_port.
+Cannot\ use\ port\ %0\ for\ remote\ operation;\ another\ application\ may\ be\ using\ it.\ Try\ specifying\ another\ port.=Kan ikke bruke port %0 for fjernstyring; den kan v\u00e6re i bruk av et annet program. Pr\u00b8v \u00e5 spesifisere en annen port.
 
-Looking_for_full_text_document...=Ser_etter_fulltekstdokument...
+Looking\ for\ full\ text\ document...=Ser etter fulltekstdokument...
 Autosave=Autolagring
-A_local_copy_will_be_opened.=
-Autosave_local_libraries=
-Automatically_save_the_library_to=
-Please_enter_a_valid_file_path.=
+A\ local\ copy\ will\ be\ opened.=
+Autosave\ local\ libraries=
+Automatically\ save\ the\ library\ to=
+Please\ enter\ a\ valid\ file\ path.=
 
 
-Export_in_current_table_sort_order=Eksporter_i_n\u00e5v\u00e6rende_sortering
-Export_entries_in_their_original_order=Eksporter_enheter_i_deres_opprinnelige_rekkef\u00b8lge
-Error_opening_file_'%0'.=Feil_ved_\u00e5pning_av_filen_'%0'.
+Export\ in\ current\ table\ sort\ order=Eksporter i n\u00e5v\u00e6rende sortering
+Export\ entries\ in\ their\ original\ order=Eksporter enheter i deres opprinnelige rekkef\u00b8lge
+Error\ opening\ file\ '%0'.=Feil ved \u00e5pning av filen '%0'.
 
-Formatter_not_found\:_%0=Fant_ikke_formaterer\:_%0
-Clear_inputarea=T\u00b8m_inputfelt
+Formatter\ not\ found\:\ %0=Fant ikke formaterer: %0
+Clear\ inputarea=T\u00b8m inputfelt
 
-Automatically_set_file_links_for_this_entry=Set_fillinker_for_denne_enheten_automatisk
-Could_not_save,_file_locked_by_another_JabRef_instance.=Kunne_ikke_lagre,_filen_er_l\u00e5st_av_en_annen_instans_av_JabRef.
-File_is_locked_by_another_JabRef_instance.=Filen_er_l\u00e5st_av_en_annen_instans_av_JabRef.
-Do_you_want_to_override_the_file_lock?=Vil_du_overstyre_fill\u00e5sen?
-File_locked=Filen_er_l\u00e5st
-Current_tmp_value=N\u00e5v\u00e6rende_tmp-verdi
-Metadata_change=Endring_av_metadata
-Changes_have_been_made_to_the_following_metadata_elements=Endringer_er_gjort_for_de_f\u00b8lgende_metadata-elementene
+Automatically\ set\ file\ links\ for\ this\ entry=Set fillinker for denne enheten automatisk
+Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=Kunne ikke lagre, filen er l\u00e5st av en annen instans av JabRef.
+File\ is\ locked\ by\ another\ JabRef\ instance.=Filen er l\u00e5st av en annen instans av JabRef.
+Do\ you\ want\ to\ override\ the\ file\ lock?=Vil du overstyre fill\u00e5sen?
+File\ locked=Filen er l\u00e5st
+Current\ tmp\ value=N\u00e5v\u00e6rende tmp-verdi
+Metadata\ change=Endring av metadata
+Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=Endringer er gjort for de f\u00b8lgende metadata-elementene
 
-Generate_groups_for_author_last_names=Generer_grupper_for_etternavn_fra_author-feltet
-Generate_groups_from_keywords_in_a_BibTeX_field=Generer_grupper_fra_n\u00b8kkelord_i_et_BibTeX-felt
-Enforce_legal_characters_in_BibTeX_keys=Forby_tegn_i_BibTeX-n\u00b8kler_som_ikke_aksepteres_av_BibTeX
+Generate\ groups\ for\ author\ last\ names=Generer grupper for etternavn fra author-feltet
+Generate\ groups\ from\ keywords\ in\ a\ BibTeX\ field=Generer grupper fra n\u00b8kkelord i et BibTeX-felt
+Enforce\ legal\ characters\ in\ BibTeX\ keys=Forby tegn i BibTeX-n\u00b8kler som ikke aksepteres av BibTeX
 
-Save_without_backup?=Lagre_uten_backup?
-Unable_to_create_backup=Kan_ikke_lagre_backup?
-Move_file_to_file_directory=Flytt_fil_til_filkatalog
-Rename_file_to=Endre_navn_p\u00e5_fil_til
-<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)=<b>Alle_enheter</b>_(denne_gruppen_kan_ikke_endres_eller_slettes)
-static_group=statisk_gruppe
-dynamic_group=dynamisk_gruppe
-refines_supergroup=subset_av_gruppen_over
-includes_subgroups=inkluderer_gruppen_over
+Save\ without\ backup?=Lagre uten backup?
+Unable\ to\ create\ backup=Kan ikke lagre backup?
+Move\ file\ to\ file\ directory=Flytt fil til filkatalog
+Rename\ file\ to=Endre navn p\u00e5 fil til
+<b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=<b>Alle enheter</b> (denne gruppen kan ikke endres eller slettes)
+static\ group=statisk gruppe
+dynamic\ group=dynamisk gruppe
+refines\ supergroup=subset av gruppen over
+includes\ subgroups=inkluderer gruppen over
 contains=inneholder
-search_expression=s\u00b8keutryk
+search\ expression=s\u00b8keutryk
 
-Optional_fields_2=Valgfrie_felter_2
-Waiting_for_save_operation_to_finish=Venter_p\u00e5_lagringsoperasjon
-Resolving_duplicate_BibTeX_keys...=S\u00f8k_etter_dupliserte_BibTeX-n\u00f8kler
-Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.=Fullf\u00f8rte_s\u00f8k_etter_dupliserte_BibTeX-n\u00f8kler._%0_enheter_endret.
-This_library_contains_one_or_more_duplicated_BibTeX_keys.=Denne_library_inneholder_en_eller_flere_dupliserte_BibTeX-n\u00f8kler
-Do_you_want_to_resolve_duplicate_keys_now?=Vil_du_ordne_opp_i_dupliserte_n\u00f8kler_n\u00e5?
+Optional\ fields\ 2=Valgfrie felter 2
+Waiting\ for\ save\ operation\ to\ finish=Venter p\u00e5 lagringsoperasjon
+Resolving\ duplicate\ BibTeX\ keys...=S\u00f8k etter dupliserte BibTeX-n\u00f8kler
+Finished\ resolving\ duplicate\ BibTeX\ keys.\ %0\ entries\ modified.=Fullf\u00f8rte s\u00f8k etter dupliserte BibTeX-n\u00f8kler. %0 enheter endret.
+This\ library\ contains\ one\ or\ more\ duplicated\ BibTeX\ keys.=Denne library inneholder en eller flere dupliserte BibTeX-n\u00f8kler
+Do\ you\ want\ to\ resolve\ duplicate\ keys\ now?=Vil du ordne opp i dupliserte n\u00f8kler n\u00e5?
 
-Find_and_remove_duplicate_BibTeX_keys=Finn_og_fjern_dupliserte_BibTeX-n\u00f8kler
-Expected_syntax_for_--fetch\='<name_of_fetcher>\:<query>'=
-Duplicate_BibTeX_key=Duplisert_BibTeX-n\u00f8kkel
-Import_marking_color=Farge_som_markerer_importerte_enheter
-Always_add_letter_(a,_b,_...)_to_generated_keys=Legg_alltid_til_en_bokstav_(a,_b,_...)_til_genererte_n\u00f8kler
+Find\ and\ remove\ duplicate\ BibTeX\ keys=Finn og fjern dupliserte BibTeX-n\u00f8kler
+Expected\ syntax\ for\ --fetch\='<name\ of\ fetcher>\:<query>'=
+Duplicate\ BibTeX\ key=Duplisert BibTeX-n\u00f8kkel
+Import\ marking\ color=Farge som markerer importerte enheter
+Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=Legg alltid til en bokstav (a, b, ...) til genererte n\u00f8kler
 
-Ensure_unique_keys_using_letters_(a,_b,_...)=Sikre_unike_n\u00f8kler_ved_bruk_av_bokstaver_(a,_b,_...)
-Ensure_unique_keys_using_letters_(b,_c,_...)=Sikre_unike_n\u00f8kler_ved_bruk_av_bokstaver_(b,_c,_...)
-Entry_editor_active_background_color=Bakgrunnsfarge_for_aktivt_felt_i_enhetsskjema
-Entry_editor_background_color=Bakgrunnsfarge_i_enhetsskjema
-Entry_editor_font_color=Tekstfarge_i_enhetsskjema
-Entry_editor_invalid_field_color=Bakgrunnsfarge_for_ugyldige_felt_i_enhetsskjema
+Ensure\ unique\ keys\ using\ letters\ (a,\ b,\ ...)=Sikre unike n\u00f8kler ved bruk av bokstaver (a, b, ...)
+Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=Sikre unike n\u00f8kler ved bruk av bokstaver (b, c, ...)
+Entry\ editor\ active\ background\ color=Bakgrunnsfarge for aktivt felt i enhetsskjema
+Entry\ editor\ background\ color=Bakgrunnsfarge i enhetsskjema
+Entry\ editor\ font\ color=Tekstfarge i enhetsskjema
+Entry\ editor\ invalid\ field\ color=Bakgrunnsfarge for ugyldige felt i enhetsskjema
 
-Table_and_entry_editor_colors=Farger_i_tabell_og_enhetsskjema
+Table\ and\ entry\ editor\ colors=Farger i tabell og enhetsskjema
 
-General_file_directory=Standard_filkatalog
-User-specific_file_directory=Brukerdefinert_filkatalog
-Search_failed\:_illegal_search_expression=Kunne_ikke_s\u00f8ke\:_feil_i_s\u00f8keuttrykk
-Show_ArXiv_column=Vis_ArXiv-kolonne
+General\ file\ directory=Standard filkatalog
+User-specific\ file\ directory=Brukerdefinert filkatalog
+Search\ failed\:\ illegal\ search\ expression=Kunne ikke s\u00f8ke: feil i s\u00f8keuttrykk
+Show\ ArXiv\ column=Vis ArXiv-kolonne
 
-You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for=Du_m\u00e5_velge_en_heltallsverdi_i_intervallet_1025-65535_i_feltet_for
-Automatically_open_browse_dialog_when_creating_new_file_link=\u00c5pne_fildialog_automatisk_n\u00e5r_ny_link_opprettes
-Import_metadata_from\:=Importer_metadata_fra\:
-Choose_the_source_for_the_metadata_import=Velg_kilde_for_import_av_metadata
-Create_entry_based_on_XMP-metadata=Lag_enhet_basert_p\u00e5_XMP-data
-Create_blank_entry_linking_the_PDF=Lag_blank_enhet_med_lenke_til_PDF
-Only_attach_PDF=Bare_lenk_til_PDF
+You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=Du m\u00e5 velge en heltallsverdi i intervallet 1025-65535 i feltet for
+Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=\u00c5pne fildialog automatisk n\u00e5r ny link opprettes
+Import\ metadata\ from\:=Importer metadata fra:
+Choose\ the\ source\ for\ the\ metadata\ import=Velg kilde for import av metadata
+Create\ entry\ based\ on\ XMP-metadata=Lag enhet basert p\u00e5 XMP-data
+Create\ blank\ entry\ linking\ the\ PDF=Lag blank enhet med lenke til PDF
+Only\ attach\ PDF=Bare lenk til PDF
 Title=Tittel
-Create_new_entry=Lag_ny_enhet
-Update_existing_entry=Oppdater_eksisterende_enhet
-Autocomplete_names_in_'Firstname_Lastname'_format_only=Autokompletter_navn_i_'Fornavn_Etternavn'-format
-Autocomplete_names_in_'Lastname,_Firstname'_format_only=Autokompletter_navn_i_'Etternavn,_Fornavn'-format
-Autocomplete_names_in_both_formats=Autokompletter_navn_i_begge_format
-Marking_color_%0=Markeringsfarge_%0
-The_name_'comment'_cannot_be_used_as_an_entry_type_name.=Navnet_'comment'_kan_ikke_brukes_som_navn_p\u00e5_en_enhetstype
-You_must_enter_an_integer_value_in_the_text_field_for=Du_m\u00e5_skrive_inn_en_heltallverdi_i_tekstfeltet_for
-Send_as_email=Send_som_e-post
+Create\ new\ entry=Lag ny enhet
+Update\ existing\ entry=Oppdater eksisterende enhet
+Autocomplete\ names\ in\ 'Firstname\ Lastname'\ format\ only=Autokompletter navn i 'Fornavn Etternavn'-format
+Autocomplete\ names\ in\ 'Lastname,\ Firstname'\ format\ only=Autokompletter navn i 'Etternavn, Fornavn'-format
+Autocomplete\ names\ in\ both\ formats=Autokompletter navn i begge format
+Marking\ color\ %0=Markeringsfarge %0
+The\ name\ 'comment'\ cannot\ be\ used\ as\ an\ entry\ type\ name.=Navnet 'comment' kan ikke brukes som navn p\u00e5 en enhetstype
+You\ must\ enter\ an\ integer\ value\ in\ the\ text\ field\ for=Du m\u00e5 skrive inn en heltallverdi i tekstfeltet for
+Send\ as\ email=Send som e-post
 References=Referanser
-Sending_of_emails=Sending_av_e-post
-Subject_for_sending_an_email_with_references=Emne_for_sending_av_e-post_med_referanser
-Automatically_open_folders_of_attached_files=\u00c5pne_automatisk_mapper_for_vedlegg
-Create_entry_based_on_content=Opprett_enhet_basert_p\u00e5_innhold
-Do_not_show_this_box_again_for_this_import=Ikke_vis_denne_dialogboksen_igjen_for_denne_importen
-Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)=Alltid_bruk_denne_PDF-importmetoden_(ikke_sp\u00f8r_for_hver_enkelt_import)
-Error_creating_email=Feil_ved_opprettelse_av_e-post
-Entries_added_to_an_email=Enheter_lagt_til_en_e-post
+Sending\ of\ emails=Sending av e-post
+Subject\ for\ sending\ an\ email\ with\ references=Emne for sending av e-post med referanser
+Automatically\ open\ folders\ of\ attached\ files=\u00c5pne automatisk mapper for vedlegg
+Create\ entry\ based\ on\ content=Opprett enhet basert p\u00e5 innhold
+Do\ not\ show\ this\ box\ again\ for\ this\ import=Ikke vis denne dialogboksen igjen for denne importen
+Always\ use\ this\ PDF\ import\ style\ (and\ do\ not\ ask\ for\ each\ import)=Alltid bruk denne PDF-importmetoden (ikke sp\u00f8r for hver enkelt import)
+Error\ creating\ email=Feil ved opprettelse av e-post
+Entries\ added\ to\ an\ email=Enheter lagt til en e-post
 exportFormat=Eksportformat
-Output_file_missing=Utfil_mangler
-No_search_matches.=Ingen_s\u00f8keresultater
-The_output_option_depends_on_a_valid_input_option.=Output-innstillingen_krever_en_gyldig_input-innstilling
-Default_import_style_for_drag_and_drop_of_PDFs=Standard_importmetode_for_PDF-filer
-Default_PDF_file_link_action=Standardaksjon_for_PDF-fillinker
-Filename_format_pattern=M\u00f8nster_for_filnavn
-Additional_parameters=Ytterligere_parametre
-Cite_selected_entries_between_parenthesis=Referer_valgte_enheter
-Cite_selected_entries_with_in-text_citation=Referer_valgte_enheter_med_referanse_i_teksten
-Cite_special=Referanse_med_ekstra_informasjon
-Extra_information_(e.g._page_number)=Ekstra_informasjon_(f.eks._sidenummer)
-Manage_citations=Administrer_referanser
-Problem_modifying_citation=Det_oppsto_et_problem_ved_endring_av_referansen
+Output\ file\ missing=Utfil mangler
+No\ search\ matches.=Ingen s\u00f8keresultater
+The\ output\ option\ depends\ on\ a\ valid\ input\ option.=Output-innstillingen krever en gyldig input-innstilling
+Default\ import\ style\ for\ drag\ and\ drop\ of\ PDFs=Standard importmetode for PDF-filer
+Default\ PDF\ file\ link\ action=Standardaksjon for PDF-fillinker
+Filename\ format\ pattern=M\u00f8nster for filnavn
+Additional\ parameters=Ytterligere parametre
+Cite\ selected\ entries\ between\ parenthesis=Referer valgte enheter
+Cite\ selected\ entries\ with\ in-text\ citation=Referer valgte enheter med referanse i teksten
+Cite\ special=Referanse med ekstra informasjon
+Extra\ information\ (e.g.\ page\ number)=Ekstra informasjon (f.eks. sidenummer)
+Manage\ citations=Administrer referanser
+Problem\ modifying\ citation=Det oppsto et problem ved endring av referansen
 Citation=Referanse
-Extra_information=Ekstra_informasjon
-Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.=Kunne_ikke_finne_BibTeX-enhet_for_referansen_'%0'.
-Select_style=Velg_stil
+Extra\ information=Ekstra informasjon
+Could\ not\ resolve\ BibTeX\ entry\ for\ citation\ marker\ '%0'.=Kunne ikke finne BibTeX-enhet for referansen '%0'.
+Select\ style=Velg stil
 Journals=Tidsskrifter
 Cite=Referer
-Cite_in-text=Referer_i_teksten
-Insert_empty_citation=Sett_in_tom_referanse
-Merge_citations=Sl\u00e5_sammen_referanser
-Manual_connect=Manuell_tilkobling
-Select_Writer_document=Velg_Writer-dokument
-Sync_OpenOffice/LibreOffice_bibliography=Synkroniser_OpenOffice/LibreOffice-bibliografi
-Select_which_open_Writer_document_to_work_on=Velg_hvilket_\u00e5pent_Writer-dokument_du_vil_jobbe_med
-Connected_to_document=Koblet_til_dokument
-Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)=Sett_inn_en_referanse_uten_tekst_(enheten_vil_bli_med_i_referanselisten)
-Cite_selected_entries_with_extra_information=Referer_valgte_enheter_med_ekstra_informasjon
-Ensure_that_the_bibliography_is_up-to-date=S\u00f8rg_for_at_bibliografien_er_oppdatert
-Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.=OpenOffice/LibreOffice-dokumentet_referer_til_BibTeX-n\u00f8kkelen_'%0',_som_ikke_finnes_i_din_aktuelle_library.
-Unable_to_synchronize_bibliography=Kunne_ikke_synkronisere_bibliografien
-Combine_pairs_of_citations_that_are_separated_by_spaces_only=Sl\u00e5_sammen_par_av_referanser_som_bare_er_adskilt_av_mellomrom
-Autodetection_failed=Autodeteksjon_mislyktes
-Connecting=Kobler_til
-Please_wait...=Vennligst_vent...
-Set_connection_parameters=Sett_opp_tilkoblingsparametre
-Path_to_OpenOffice/LibreOffice_directory=Sti_til_OpenOffice/LibreOffice-katalog
-Path_to_OpenOffice/LibreOffice_executable=Sti_til_OpenOffice/LibreOffice-startfil
-Path_to_OpenOffice/LibreOffice_library_dir=Sti_til_OpenOffice/LibreOffice-bibliotekkatalog
-Connection_lost=Mistet_forbindelsen
-The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.=Dette_avsnittsformatet_styres_av_innstillingen_'ReferenceParagraphFormat'_eller_'ReferenceHeaderParagraphFormat'_i_stilfilen.
-The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.=Tegnformatet_styres_av_referanseinnstillingen_'CitationCharacterFormat'_i_stilfilen.
-Automatically_sync_bibliography_when_inserting_citations=Sykroniser_automatisk_bibliografien_n\u00e5r_nye_referanser_legges_til
-Look_up_BibTeX_entries_in_the_active_tab_only=Se_etter_BibTeX-enheter_bare_i_den_aktive_libraryn
-Look_up_BibTeX_entries_in_all_open_libraries=Se_etter_BibTeX-enheter_i_alle_\u00e5pne_libraryr
-Autodetecting_paths...=Autodetekterer_kataloger
-Could_not_find_OpenOffice/LibreOffice_installation=Kunne_ikke_finne_OpenOffice/LibreOffice-installasjonen
-Found_more_than_one_OpenOffice/LibreOffice_executable.=Fant_mer_enn_en_OpenOffice/LibreOffice-startfil.
-Please_choose_which_one_to_connect_to\:=Vennligst_velg_hvilken_du_vil_koble_til\:
-Choose_OpenOffice/LibreOffice_executable=Velg_OpenOffice/LibreOffice-startfil
-Select_document=Velg_dokument
-HTML_list=HTML-liste
-If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting=Om_mulig,_normaliser_denne_navnelisten_til_standard_BibTeX-navneformatering
-Could_not_open_%0=Kunne_ikke_\u00e5pne_%0
-Unknown_import_format=Ukjent_importformat
-Web_search=Webs\u00f8k
-Style_selection=Valg_av_stil
-No_valid_style_file_defined=Ingen_gyldig_stilfil_definert
-Choose_pattern=Velg_m\u00f8nster
-Use_the_BIB_file_location_as_primary_file_directory=Bruk_plasseringen_av_BIB-filen_som_standard_filkatalog
-Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.=Kunne_ikke_kalle_gnuclient/emacsclient._Sjekk_at_du_har_programmet_installert_og_tilgjengelig_i_PATH.
-OpenOffice/LibreOffice_connection=Kobling_til_OpenOffice/LibreOffice
-You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.=Du_m\u00e5_enten_velge_en_gyldig_stilfil_eller_bruke_en_av_standardstilene.
+Cite\ in-text=Referer i teksten
+Insert\ empty\ citation=Sett in tom referanse
+Merge\ citations=Sl\u00e5 sammen referanser
+Manual\ connect=Manuell tilkobling
+Select\ Writer\ document=Velg Writer-dokument
+Sync\ OpenOffice/LibreOffice\ bibliography=Synkroniser OpenOffice/LibreOffice-bibliografi
+Select\ which\ open\ Writer\ document\ to\ work\ on=Velg hvilket \u00e5pent Writer-dokument du vil jobbe med
+Connected\ to\ document=Koblet til dokument
+Insert\ a\ citation\ without\ text\ (the\ entry\ will\ appear\ in\ the\ reference\ list)=Sett inn en referanse uten tekst (enheten vil bli med i referanselisten)
+Cite\ selected\ entries\ with\ extra\ information=Referer valgte enheter med ekstra informasjon
+Ensure\ that\ the\ bibliography\ is\ up-to-date=S\u00f8rg for at bibliografien er oppdatert
+Your\ OpenOffice/LibreOffice\ document\ references\ the\ BibTeX\ key\ '%0',\ which\ could\ not\ be\ found\ in\ your\ current\ library.=OpenOffice/LibreOffice-dokumentet referer til BibTeX-n\u00f8kkelen '%0', som ikke finnes i din aktuelle library.
+Unable\ to\ synchronize\ bibliography=Kunne ikke synkronisere bibliografien
+Combine\ pairs\ of\ citations\ that\ are\ separated\ by\ spaces\ only=Sl\u00e5 sammen par av referanser som bare er adskilt av mellomrom
+Autodetection\ failed=Autodeteksjon mislyktes
+Connecting=Kobler til
+Please\ wait...=Vennligst vent...
+Set\ connection\ parameters=Sett opp tilkoblingsparametre
+Path\ to\ OpenOffice/LibreOffice\ directory=Sti til OpenOffice/LibreOffice-katalog
+Path\ to\ OpenOffice/LibreOffice\ executable=Sti til OpenOffice/LibreOffice-startfil
+Path\ to\ OpenOffice/LibreOffice\ library\ dir=Sti til OpenOffice/LibreOffice-bibliotekkatalog
+Connection\ lost=Mistet forbindelsen
+The\ paragraph\ format\ is\ controlled\ by\ the\ property\ 'ReferenceParagraphFormat'\ or\ 'ReferenceHeaderParagraphFormat'\ in\ the\ style\ file.=Dette avsnittsformatet styres av innstillingen 'ReferenceParagraphFormat' eller 'ReferenceHeaderParagraphFormat' i stilfilen.
+The\ character\ format\ is\ controlled\ by\ the\ citation\ property\ 'CitationCharacterFormat'\ in\ the\ style\ file.=Tegnformatet styres av referanseinnstillingen 'CitationCharacterFormat' i stilfilen.
+Automatically\ sync\ bibliography\ when\ inserting\ citations=Sykroniser automatisk bibliografien n\u00e5r nye referanser legges til
+Look\ up\ BibTeX\ entries\ in\ the\ active\ tab\ only=Se etter BibTeX-enheter bare i den aktive libraryn
+Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=Se etter BibTeX-enheter i alle \u00e5pne libraryr
+Autodetecting\ paths...=Autodetekterer kataloger
+Could\ not\ find\ OpenOffice/LibreOffice\ installation=Kunne ikke finne OpenOffice/LibreOffice-installasjonen
+Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=Fant mer enn en OpenOffice/LibreOffice-startfil.
+Please\ choose\ which\ one\ to\ connect\ to\:=Vennligst velg hvilken du vil koble til:
+Choose\ OpenOffice/LibreOffice\ executable=Velg OpenOffice/LibreOffice-startfil
+Select\ document=Velg dokument
+HTML\ list=HTML-liste
+If\ possible,\ normalize\ this\ list\ of\ names\ to\ conform\ to\ standard\ BibTeX\ name\ formatting=Om mulig, normaliser denne navnelisten til standard BibTeX-navneformatering
+Could\ not\ open\ %0=Kunne ikke \u00e5pne %0
+Unknown\ import\ format=Ukjent importformat
+Web\ search=Webs\u00f8k
+Style\ selection=Valg av stil
+No\ valid\ style\ file\ defined=Ingen gyldig stilfil definert
+Choose\ pattern=Velg m\u00f8nster
+Use\ the\ BIB\ file\ location\ as\ primary\ file\ directory=Bruk plasseringen av BIB-filen som standard filkatalog
+Could\ not\ run\ the\ gnuclient/emacsclient\ program.\ Make\ sure\ you\ have\ the\ emacsclient/gnuclient\ program\ installed\ and\ available\ in\ the\ PATH.=Kunne ikke kalle gnuclient/emacsclient. Sjekk at du har programmet installert og tilgjengelig i PATH.
+OpenOffice/LibreOffice\ connection=Kobling til OpenOffice/LibreOffice
+You\ must\ select\ either\ a\ valid\ style\ file,\ or\ use\ one\ of\ the\ default\ styles.=Du m\u00e5 enten velge en gyldig stilfil eller bruke en av standardstilene.
 
-This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.=Dette_er_et_enkelt_klipp-og-lim-vindu._F\u00f8rst_last_inn_eller_lim_inn_tekst_i_tekstfeltet.<br>Deretter_kan_du_merke_tekst_og_tilordne_den_til_BibTeX-felter.
-This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.=Denne_funksjonen_genererer_en_ny_library_basert_p\u00e5_hvilke_enheter_som_trengs_i_et_eksisterende_LaTeX-dokument.
-You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.=Du_m\u00e5_velge_en_av_de_\u00e5pne_libraryne_hvor_enheter_skal_hentes_fra,_i_tillegg_til_AUX-filen_generert_av_LaTeX_n\u00e5r_dokumentet_kompileres.
+This\ is\ a\ simple\ copy\ and\ paste\ dialog.\ First\ load\ or\ paste\ some\ text\ into\ the\ text\ input\ area.<br>After\ that,\ you\ can\ mark\ text\ and\ assign\ it\ to\ a\ BibTeX\ field.=Dette er et enkelt klipp-og-lim-vindu. F\u00f8rst last inn eller lim inn tekst i tekstfeltet.<br>Deretter kan du merke tekst og tilordne den til BibTeX-felter.
+This\ feature\ generates\ a\ new\ library\ based\ on\ which\ entries\ are\ needed\ in\ an\ existing\ LaTeX\ document.=Denne funksjonen genererer en ny library basert p\u00e5 hvilke enheter som trengs i et eksisterende LaTeX-dokument.
+You\ need\ to\ select\ one\ of\ your\ open\ libraries\ from\ which\ to\ choose\ entries,\ as\ well\ as\ the\ AUX\ file\ produced\ by\ LaTeX\ when\ compiling\ your\ document.=Du m\u00e5 velge en av de \u00e5pne libraryne hvor enheter skal hentes fra, i tillegg til AUX-filen generert av LaTeX n\u00e5r dokumentet kompileres.
 
-First_select_entries_to_clean_up.=
-Cleanup_entry=
-Autogenerate_PDF_Names=
-Auto-generating_PDF-Names_does_not_support_undo._Continue?=
+First\ select\ entries\ to\ clean\ up.=
+Cleanup\ entry=
+Autogenerate\ PDF\ Names=
+Auto-generating\ PDF-Names\ does\ not\ support\ undo.\ Continue?=
 
-Use_full_firstname_whenever_possible=
-Use_abbreviated_firstname_whenever_possible=
-Use_abbreviated_and_full_firstname=
-Autocompletion_options=
-Name_format_used_for_autocompletion=
-Treatment_of_first_names=
-Cleanup_entries=
-Automatically_assign_new_entry_to_selected_groups=Tilordne_automatisk_nye_enheter_til_valgte_grupper
-%0_mode=%0-modus
-Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix=
-Make_paths_of_linked_files_relative_(if_possible)=
-Rename_PDFs_to_given_filename_format_pattern=
-Rename_only_PDFs_having_a_relative_path=
-What_would_you_like_to_clean_up?=
-Doing_a_cleanup_for_%0_entries...=
-No_entry_needed_a_clean_up=
-One_entry_needed_a_clean_up=
-%0_entries_needed_a_clean_up=
+Use\ full\ firstname\ whenever\ possible=
+Use\ abbreviated\ firstname\ whenever\ possible=
+Use\ abbreviated\ and\ full\ firstname=
+Autocompletion\ options=
+Name\ format\ used\ for\ autocompletion=
+Treatment\ of\ first\ names=
+Cleanup\ entries=
+Automatically\ assign\ new\ entry\ to\ selected\ groups=Tilordne automatisk nye enheter til valgte grupper
+%0\ mode=%0-modus
+Move\ DOIs\ from\ note\ and\ URL\ field\ to\ DOI\ field\ and\ remove\ http\ prefix=
+Make\ paths\ of\ linked\ files\ relative\ (if\ possible)=
+Rename\ PDFs\ to\ given\ filename\ format\ pattern=
+Rename\ only\ PDFs\ having\ a\ relative\ path=
+What\ would\ you\ like\ to\ clean\ up?=
+Doing\ a\ cleanup\ for\ %0\ entries...=
+No\ entry\ needed\ a\ clean\ up=
+One\ entry\ needed\ a\ clean\ up=
+%0\ entries\ needed\ a\ clean\ up=
 
-Remove_selected=Fjern_merkede
+Remove\ selected=Fjern merkede
 
-Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.=
-Attach_file=
-Setting_all_preferences_to_default_values.=
-Resetting_preference_key_'%0'=
-Unknown_preference_key_'%0'=
-Unable_to_clear_preferences.=
+Group\ tree\ could\ not\ be\ parsed.\ If\ you\ save\ the\ BibTeX\ library,\ all\ groups\ will\ be\ lost.=
+Attach\ file=
+Setting\ all\ preferences\ to\ default\ values.=
+Resetting\ preference\ key\ '%0'=
+Unknown\ preference\ key\ '%0'=
+Unable\ to\ clear\ preferences.=
 
-Reset_preferences_(key1,key2,..._or_'all')=
-Find_unlinked_files=
-Unselect_all=
-Expand_all=
-Collapse_all=
-Opens_the_file_browser.=
-Scan_directory=
-Searches_the_selected_directory_for_unlinked_files.=
-Starts_the_import_of_BibTeX_entries.=
-Leave_this_dialog.=
-Create_directory_based_keywords=
-Creates_keywords_in_created_entrys_with_directory_pathnames=
-Select_a_directory_where_the_search_shall_start.=
-Select_file_type\:=
-These_files_are_not_linked_in_the_active_library.=
-Entry_type_to_be_created\:=
-Searching_file_system...=
-Importing_into_Library...=
-Select_directory=
-Select_files=
-BibTeX_entry_creation=
-<No_selection>=
-Unable_to_connect_to_FreeCite_online_service.=
-Parse_with_FreeCite=
-The_current_BibTeX_key_will_be_overwritten._Continue?=
-Overwrite_key=
-Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator=
-How_would_you_like_to_link_to_'%0'?=
-BibTeX_key_patterns=
-Changed_special_field_settings=
-Clear_priority=
-Clear_rank=
-Enable_special_fields=
-One_star=
-Two_stars=
-Three_stars=
-Four_stars=
-Five_stars=
-Help_on_special_fields=
-Keywords_of_selected_entries=
-Manage_content_selectors=
-Manage_keywords=
-No_priority_information=
-No_rank_information=
+Reset\ preferences\ (key1,key2,...\ or\ 'all')=
+Find\ unlinked\ files=
+Unselect\ all=
+Expand\ all=
+Collapse\ all=
+Opens\ the\ file\ browser.=
+Scan\ directory=
+Searches\ the\ selected\ directory\ for\ unlinked\ files.=
+Starts\ the\ import\ of\ BibTeX\ entries.=
+Leave\ this\ dialog.=
+Create\ directory\ based\ keywords=
+Creates\ keywords\ in\ created\ entrys\ with\ directory\ pathnames=
+Select\ a\ directory\ where\ the\ search\ shall\ start.=
+Select\ file\ type\:=
+These\ files\ are\ not\ linked\ in\ the\ active\ library.=
+Entry\ type\ to\ be\ created\:=
+Searching\ file\ system...=
+Importing\ into\ Library...=
+Select\ directory=
+Select\ files=
+BibTeX\ entry\ creation=
+<No\ selection>=
+Unable\ to\ connect\ to\ FreeCite\ online\ service.=
+Parse\ with\ FreeCite=
+The\ current\ BibTeX\ key\ will\ be\ overwritten.\ Continue?=
+Overwrite\ key=
+Not\ overwriting\ existing\ key.\ To\ change\ this\ setting,\ open\ Options\ ->\ Prefererences\ ->\ BibTeX\ key\ generator=
+How\ would\ you\ like\ to\ link\ to\ '%0'?=
+BibTeX\ key\ patterns=
+Changed\ special\ field\ settings=
+Clear\ priority=
+Clear\ rank=
+Enable\ special\ fields=
+One\ star=
+Two\ stars=
+Three\ stars=
+Four\ stars=
+Five\ stars=
+Help\ on\ special\ fields=
+Keywords\ of\ selected\ entries=
+Manage\ content\ selectors=
+Manage\ keywords=
+No\ priority\ information=
+No\ rank\ information=
 Priority=
-Priority_high=
-Priority_low=
-Priority_medium=
+Priority\ high=
+Priority\ low=
+Priority\ medium=
 Quality=
 Rank=
 Relevance=
-Set_priority_to_high=
-Set_priority_to_low=
-Set_priority_to_medium=
-Show_priority=
-Show_quality=
-Show_rank=
-Show_relevance=
-Synchronize_with_keywords=
-Synchronized_special_fields_based_on_keywords=
-Toggle_relevance=
-Toggle_quality_assured=
-Toggle_print_status=
-Update_keywords=
-Write_values_of_special_fields_as_separate_fields_to_BibTeX=
-You_have_changed_settings_for_special_fields.=
-%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.=
-A_string_with_that_label_already_exists=Det_finnes_allerede_en_streng_med_det_navnet
-Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.=
-JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.=
-Correct_the_entry,_and_reopen_editor_to_display/edit_source.=
-Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').=
-Could_not_connect_to_running_OpenOffice/LibreOffice.=
-Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.=
-If_connecting_manually,_please_verify_program_and_library_paths.=
-Error_message\:=
-If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.=
-Import_metadata_from_PDF=
-Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.=
-Removed_all_subgroups_of_group_"%0".=
-To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.=
-Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.=
-Use_the_following_delimiter_character(s)\:=
-When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above=
-Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=
-Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=
+Set\ priority\ to\ high=
+Set\ priority\ to\ low=
+Set\ priority\ to\ medium=
+Show\ priority=
+Show\ quality=
+Show\ rank=
+Show\ relevance=
+Synchronize\ with\ keywords=
+Synchronized\ special\ fields\ based\ on\ keywords=
+Toggle\ relevance=
+Toggle\ quality\ assured=
+Toggle\ print\ status=
+Update\ keywords=
+Write\ values\ of\ special\ fields\ as\ separate\ fields\ to\ BibTeX=
+You\ have\ changed\ settings\ for\ special\ fields.=
+%0\ entries\ found.\ To\ reduce\ server\ load,\ only\ %1\ will\ be\ downloaded.=
+A\ string\ with\ that\ label\ already\ exists=Det finnes allerede en streng med det navnet
+Connection\ to\ OpenOffice/LibreOffice\ has\ been\ lost.\ Please\ make\ sure\ OpenOffice/LibreOffice\ is\ running,\ and\ try\ to\ reconnect.=
+JabRef\ will\ send\ at\ least\ one\ request\ per\ entry\ to\ a\ publisher.=
+Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=
+Could\ not\ connect\ to\ a\ running\ gnuserv\ process.\ Make\ sure\ that\ Emacs\ or\ XEmacs\ is\ running,<BR>and\ that\ the\ server\ has\ been\ started\ (by\ running\ the\ command\ 'server-start'/'gnuserv-start').=
+Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=
+Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=
+If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=
+Error\ message\:=
+If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=
+Import\ metadata\ from\ PDF=
+Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=
+Removed\ all\ subgroups\ of\ group\ "%0".=
+To\ disable\ the\ memory\ stick\ mode\ rename\ or\ remove\ the\ jabref.xml\ file\ in\ the\ same\ folder\ as\ JabRef.=
+Unable\ to\ connect.\ One\ possible\ reason\ is\ that\ JabRef\ and\ OpenOffice/LibreOffice\ are\ not\ both\ running\ in\ either\ 32\ bit\ mode\ or\ 64\ bit\ mode.=
+Use\ the\ following\ delimiter\ character(s)\:=
+When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\ prefer\ the\ BIB\ file\ location\ rather\ than\ the\ file\ directory\ set\ above=
+Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=
+Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=
 
 Searching...=
-You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?=
-Confirm_selection=
-Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case=
-Import_conversions=
-Please_enter_a_search_string=
-Please_open_or_start_a_new_library_before_searching=
+You\ have\ selected\ more\ than\ %0\ entries\ for\ download.\ Some\ web\ sites\ might\ block\ you\ if\ you\ make\ too\ many\ rapid\ downloads.\ Do\ you\ want\ to\ continue?=
+Confirm\ selection=
+Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=
+Import\ conversions=
+Please\ enter\ a\ search\ string=
+Please\ open\ or\ start\ a\ new\ library\ before\ searching=
 
-Canceled_merging_entries=
+Canceled\ merging\ entries=
 
-Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search=
-Merge_entries=
-Merged_entries=
-Merged_entry=
+Format\ units\ by\ adding\ non-breaking\ separators\ and\ keeping\ the\ correct\ case\ on\ search=
+Merge\ entries=
+Merged\ entries=
+Merged\ entry=
 None=
 Parse=
 Result=
-Show_DOI_first=
-Show_URL_first=
-Use_Emacs_key_bindings=
-You_have_to_choose_exactly_two_entries_to_merge.=
+Show\ DOI\ first=
+Show\ URL\ first=
+Use\ Emacs\ key\ bindings=
+You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=
 
-Update_timestamp_on_modification=
-All_key_bindings_will_be_reset_to_their_defaults.=
+Update\ timestamp\ on\ modification=
+All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=
 
-Automatically_set_file_links=
-Resetting_all_key_bindings=
+Automatically\ set\ file\ links=
+Resetting\ all\ key\ bindings=
 Hostname=
-Invalid_setting=
+Invalid\ setting=
 Network=
-Please_specify_both_hostname_and_port=
-Please_specify_both_username_and_password=
+Please\ specify\ both\ hostname\ and\ port=
+Please\ specify\ both\ username\ and\ password=
 
-Use_custom_proxy_configuration=
-Proxy_requires_authentication=
-Attention\:_Password_is_stored_in_plain_text\!=
-Clear_connection_settings=
-Cleared_connection_settings.=
+Use\ custom\ proxy\ configuration=
+Proxy\ requires\ authentication=
+Attention\:\ Password\ is\ stored\ in\ plain\ text\!=
+Clear\ connection\ settings=
+Cleared\ connection\ settings.=
 
-Rebind_C-a,_too=
-Rebind_C-f,_too=
+Rebind\ C-a,\ too=
+Rebind\ C-f,\ too=
 
-Open_folder=
-Searches_for_unlinked_PDF_files_on_the_file_system=
-Export_entries_ordered_as_specified=
-Export_sort_order=
-Export_sorting=
-Newline_separator=
+Open\ folder=
+Searches\ for\ unlinked\ PDF\ files\ on\ the\ file\ system=
+Export\ entries\ ordered\ as\ specified=
+Export\ sort\ order=
+Export\ sorting=
+Newline\ separator=
 
-Save_entries_ordered_as_specified=
-Save_sort_order=
-Show_extra_columns=
-Parsing_error=
-illegal_backslash_expression=
+Save\ entries\ ordered\ as\ specified=
+Save\ sort\ order=
+Show\ extra\ columns=
+Parsing\ error=
+illegal\ backslash\ expression=
 
-Move_to_group=
+Move\ to\ group=
 
-Clear_read_status=
-Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')=
-Could_not_apply_changes.=
-Deprecated_fields=
-Hide/show_toolbar=
-No_read_status_information=
+Clear\ read\ status=
+Convert\ to\ biblatex\ format\ (for\ example,\ move\ the\ value\ of\ the\ 'journal'\ field\ to\ 'journaltitle')=
+Could\ not\ apply\ changes.=
+Deprecated\ fields=
+Hide/show\ toolbar=
+No\ read\ status\ information=
 Printed=
-Read_status=
-Read_status_read=
-Read_status_skimmed=
-Save_selected_as_plain_BibTeX...=
-Set_read_status_to_read=
-Set_read_status_to_skimmed=
-Show_deprecated_BibTeX_fields=
+Read\ status=
+Read\ status\ read=
+Read\ status\ skimmed=
+Save\ selected\ as\ plain\ BibTeX...=
+Set\ read\ status\ to\ read=
+Set\ read\ status\ to\ skimmed=
+Show\ deprecated\ BibTeX\ fields=
 
-Show_gridlines=
-Show_printed_status=
-Show_read_status=
-Table_row_height_padding=
+Show\ gridlines=
+Show\ printed\ status=
+Show\ read\ status=
+Table\ row\ height\ padding=
 
-Marked_selected_entry=
-Marked_all_%0_selected_entries=
-Unmarked_selected_entry=
-Unmarked_all_%0_selected_entries=
+Marked\ selected\ entry=
+Marked\ all\ %0\ selected\ entries=
+Unmarked\ selected\ entry=
+Unmarked\ all\ %0\ selected\ entries=
 
 
-Unmarked_all_entries=
+Unmarked\ all\ entries=
 
-Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.=
+Unable\ to\ find\ the\ requested\ look\ and\ feel\ and\ thus\ the\ default\ one\ is\ used.=
 
-Opens_JabRef's_GitHub_page=
-Could_not_open_browser.=
-Please_open_%0_manually.=
-The_link_has_been_copied_to_the_clipboard.=
+Opens\ JabRef's\ GitHub\ page=
+Could\ not\ open\ browser.=
+Please\ open\ %0\ manually.=
+The\ link\ has\ been\ copied\ to\ the\ clipboard.=
 
-Open_%0_file=
+Open\ %0\ file=
 
-Cannot_delete_file=
-File_permission_error=
-Push_to_%0=Send_til_%0
-Path_to_%0=Sti_til_%0
+Cannot\ delete\ file=
+File\ permission\ error=
+Push\ to\ %0=Send til %0
+Path\ to\ %0=Sti til %0
 Convert=
-Normalize_to_BibTeX_name_format=
-Help_on_Name_Formatting=
+Normalize\ to\ BibTeX\ name\ format=
+Help\ on\ Name\ Formatting=
 
-Add_new_file_type=
+Add\ new\ file\ type=
 
-Left_entry=
-Right_entry=
+Left\ entry=
+Right\ entry=
 Use=
-Original_entry=
-Replace_original_entry=
-No_information_added=
-Select_at_least_one_entry_to_manage_keywords.=
-OpenDocument_text=
-OpenDocument_spreadsheet=
-OpenDocument_presentation=
-%0_image=
-Added_entry=
-Modified_entry=
-Deleted_entry=
-Modified_groups_tree=
-Removed_all_groups=
-Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.=
-Select_export_format=
-Return_to_JabRef=
-Please_move_the_file_manually_and_link_in_place.=
-Could_not_connect_to_%0=Kunne_ikke_koble_til_%0
-Warning\:_%0_out_of_%1_entries_have_undefined_title.=
-Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.=
+Original\ entry=
+Replace\ original\ entry=
+No\ information\ added=
+Select\ at\ least\ one\ entry\ to\ manage\ keywords.=
+OpenDocument\ text=
+OpenDocument\ spreadsheet=
+OpenDocument\ presentation=
+%0\ image=
+Added\ entry=
+Modified\ entry=
+Deleted\ entry=
+Modified\ groups\ tree=
+Removed\ all\ groups=
+Accepting\ the\ change\ replaces\ the\ complete\ groups\ tree\ with\ the\ externally\ modified\ groups\ tree.=
+Select\ export\ format=
+Return\ to\ JabRef=
+Please\ move\ the\ file\ manually\ and\ link\ in\ place.=
+Could\ not\ connect\ to\ %0=Kunne ikke koble til %0
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ title.=
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ BibTeX\ key.=
 occurrence=
-Added_new_'%0'_entry.=
-Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?=
-Changed_type_to_'%0'_for=Endret_type_til_'%0'_for
-Really_delete_the_selected_entry?=
-Really_delete_the_%0_selected_entries?=
-Keep_merged_entry_only=
-Keep_left=
-Keep_right=
-Old_entry=
-From_import=
-No_problems_found.=
-%0_problem(s)_found=
-Save_changes=
-Discard_changes=
-Library_'%0'_has_changed.=
-Print_entry_preview=
-Copy_title=
-Copy_\\cite{BibTeX_key}=Kopier_\\cite{BibTeX-n\u00f8kkel}
-Copy_BibTeX_key_and_title=Kopier_BibTeX-n\u00f8kkel_og_tittel
-File_rename_failed_for_%0_entries.=
-Merged_BibTeX_source_code=
-Invalid_DOI\:_'%0'.=Ugyldig_DOI\:_'%0'.
-should_start_with_a_name=
-should_end_with_a_name=
-unexpected_closing_curly_bracket=
-unexpected_opening_curly_bracket=
-capital_letters_are_not_masked_using_curly_brackets_{}=
-should_contain_a_four_digit_number=
-should_contain_a_valid_page_number_range=
+Added\ new\ '%0'\ entry.=
+Multiple\ entries\ selected.\ Do\ you\ want\ to\ change\ the\ type\ of\ all\ these\ to\ '%0'?=
+Changed\ type\ to\ '%0'\ for=Endret type til '%0' for
+Really\ delete\ the\ selected\ entry?=
+Really\ delete\ the\ %0\ selected\ entries?=
+Keep\ merged\ entry\ only=
+Keep\ left=
+Keep\ right=
+Old\ entry=
+From\ import=
+No\ problems\ found.=
+%0\ problem(s)\ found=
+Save\ changes=
+Discard\ changes=
+Library\ '%0'\ has\ changed.=
+Print\ entry\ preview=
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=Kopier \\cite{BibTeX-n\u00f8kkel}
+Copy\ BibTeX\ key\ and\ title=Kopier BibTeX-n\u00f8kkel og tittel
+File\ rename\ failed\ for\ %0\ entries.=
+Merged\ BibTeX\ source\ code=
+Invalid\ DOI\:\ '%0'.=Ugyldig DOI: '%0'.
+should\ start\ with\ a\ name=
+should\ end\ with\ a\ name=
+unexpected\ closing\ curly\ bracket=
+unexpected\ opening\ curly\ bracket=
+capital\ letters\ are\ not\ masked\ using\ curly\ brackets\ {}=
+should\ contain\ a\ four\ digit\ number=
+should\ contain\ a\ valid\ page\ number\ range=
 Filled=
-Field_is_missing=
-Search_%0=S\u00f8l_%0
+Field\ is\ missing=
+Search\ %0=S\u00f8l %0
 
-Search_results_in_all_libraries_for_%0=
-Search_results_in_library_%0_for_%1=
-Search_globally=
-No_results_found.=
-Found_%0_results.=
-plain_text=
-This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>=
-This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>=
-This_search_contains_entries_in_which=
+Search\ results\ in\ all\ libraries\ for\ %0=
+Search\ results\ in\ library\ %0\ for\ %1=
+Search\ globally=
+No\ results\ found.=
+Found\ %0\ results.=
+plain\ text=
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ regular\ expression\ <b>%0</b>=
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ term\ <b>%0</b>=
+This\ search\ contains\ entries\ in\ which=
 
-Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.=
-JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>=
-This_library_uses_outdated_file_links.=
+Unable\ to\ autodetect\ OpenOffice/LibreOffice\ installation.\ Please\ choose\ the\ installation\ directory\ manually.=
+JabRef\ no\ longer\ supports\ 'ps'\ or\ 'pdf'\ fields.<br>File\ links\ are\ now\ stored\ in\ the\ 'file'\ field\ and\ files\ are\ stored\ in\ an\ external\ file\ directory.<br>To\ make\ use\ of\ this\ feature,\ JabRef\ needs\ to\ upgrade\ file\ links.<br><br>=
+This\ library\ uses\ outdated\ file\ links.=
 
-Clear_search=
-Close_library=
-Close_entry_editor=
-Decrease_table_font_size=
-Entry_editor,_next_entry=
-Entry_editor,_next_panel=
-Entry_editor,_next_panel_2=
-Entry_editor,_previous_entry=
-Entry_editor,_previous_panel=
-Entry_editor,_previous_panel_2=
-File_list_editor,_move_entry_down=
-File_list_editor,_move_entry_up=
-Focus_entry_table=
-Import_into_current_library=
-Import_into_new_library=
-Increase_table_font_size=
-New_article=
-New_book=
-New_entry=
-New_from_plain_text=
-New_inbook=
-New_mastersthesis=
-New_phdthesis=
-New_proceedings=
-New_unpublished=
-Next_tab=
-Preamble_editor,_store_changes=
-Previous_tab=
-Push_to_application=
-Refresh_OpenOffice/LibreOffice=
-Resolve_duplicate_BibTeX_keys=
-Save_all=
-String_dialog,_add_string=
-String_dialog,_remove_string=
-Synchronize_files=
+Clear\ search=
+Close\ library=
+Close\ entry\ editor=
+Decrease\ table\ font\ size=
+Entry\ editor,\ next\ entry=
+Entry\ editor,\ next\ panel=
+Entry\ editor,\ next\ panel\ 2=
+Entry\ editor,\ previous\ entry=
+Entry\ editor,\ previous\ panel=
+Entry\ editor,\ previous\ panel\ 2=
+File\ list\ editor,\ move\ entry\ down=
+File\ list\ editor,\ move\ entry\ up=
+Focus\ entry\ table=
+Import\ into\ current\ library=
+Import\ into\ new\ library=
+Increase\ table\ font\ size=
+New\ article=
+New\ book=
+New\ entry=
+New\ from\ plain\ text=
+New\ inbook=
+New\ mastersthesis=
+New\ phdthesis=
+New\ proceedings=
+New\ unpublished=
+Next\ tab=
+Preamble\ editor,\ store\ changes=
+Previous\ tab=
+Push\ to\ application=
+Refresh\ OpenOffice/LibreOffice=
+Resolve\ duplicate\ BibTeX\ keys=
+Save\ all=
+String\ dialog,\ add\ string=
+String\ dialog,\ remove\ string=
+Synchronize\ files=
 Unabbreviate=
-should_contain_a_protocol=
-Copy_preview=
-Automatically_setting_file_links=
-Regenerating_BibTeX_keys_according_to_metadata=
-No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys=
-Regenerate_all_keys_for_the_entries_in_a_BibTeX_file=
-Show_debug_level_messages=
-Default_bibliography_mode=
-New_%0_library_created.=
-Show_only_preferences_deviating_from_their_default_value=
+should\ contain\ a\ protocol=
+Copy\ preview=
+Automatically\ setting\ file\ links=
+Regenerating\ BibTeX\ keys\ according\ to\ metadata=
+No\ meta\ data\ present\ in\ BIB\ file.\ Cannot\ regenerate\ BibTeX\ keys=
+Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=
+Show\ debug\ level\ messages=
+Default\ bibliography\ mode=
+New\ %0\ library\ created.=
+Show\ only\ preferences\ deviating\ from\ their\ default\ value=
 default=
 key=
 type=
 value=
-Show_preferences=
-Save_actions=
-Enable_save_actions=
+Show\ preferences=
+Save\ actions=
+Enable\ save\ actions=
 
-Other_fields=
-Show_remaining_fields=
+Other\ fields=
+Show\ remaining\ fields=
 
-link_should_refer_to_a_correct_file_path=
-abbreviation_detected=
-wrong_entry_type_as_proceedings_has_page_numbers=
-Abbreviate_journal_names=
+link\ should\ refer\ to\ a\ correct\ file\ path=
+abbreviation\ detected=
+wrong\ entry\ type\ as\ proceedings\ has\ page\ numbers=
+Abbreviate\ journal\ names=
 Abbreviating...=
-Abbreviation_%s_for_journal_%s_already_defined.=
-Abbreviation_cannot_be_empty=
-Duplicated_Journal_Abbreviation=
-Duplicated_Journal_File=
-Error_Occurred=
-Journal_file_%s_already_added=
-Name_cannot_be_empty=
+Abbreviation\ %s\ for\ journal\ %s\ already\ defined.=
+Abbreviation\ cannot\ be\ empty=
+Duplicated\ Journal\ Abbreviation=
+Duplicated\ Journal\ File=
+Error\ Occurred=
+Journal\ file\ %s\ already\ added=
+Name\ cannot\ be\ empty=
 
-Adding_fetched_entries=
-Display_keywords_appearing_in_ALL_entries=
-Display_keywords_appearing_in_ANY_entry=
-Fetching_entries_from_Inspire=
-None_of_the_selected_entries_have_titles.=
-None_of_the_selected_entries_have_BibTeX_keys.=
-Unabbreviate_journal_names=
+Adding\ fetched\ entries=
+Display\ keywords\ appearing\ in\ ALL\ entries=
+Display\ keywords\ appearing\ in\ ANY\ entry=
+Fetching\ entries\ from\ Inspire=
+None\ of\ the\ selected\ entries\ have\ titles.=
+None\ of\ the\ selected\ entries\ have\ BibTeX\ keys.=
+Unabbreviate\ journal\ names=
 Unabbreviating...=
 Usage=
 
 
-Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.=
-Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
-Reset_preferences=
-Ill-formed_entrytype_comment_in_BIB_file=
+Adds\ {}\ brackets\ around\ acronyms,\ month\ names\ and\ countries\ to\ preserve\ their\ case.=
+Are\ you\ sure\ you\ want\ to\ reset\ all\ settings\ to\ default\ values?=
+Reset\ preferences=
+Ill-formed\ entrytype\ comment\ in\ BIB\ file=
 
-Move_linked_files_to_default_file_directory_%0=
+Move\ linked\ files\ to\ default\ file\ directory\ %0=
 
 Clipboard=
-Could_not_paste_entry_as_text\:=
-Do_you_still_want_to_continue?=
-This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:=
-This_could_cause_undesired_changes_to_your_entries.=
-Run_field_formatter\:=
-Table_font_size_is_%0=
-%0_import_canceled=%0-import_kansellert
-Internal_style=
-Add_style_file=
-Are_you_sure_you_want_to_remove_the_style?=
-Current_style_is_'%0'=
-Remove_style=
-Select_one_of_the_available_styles_or_add_a_style_file_from_disk.=
-You_must_select_a_valid_style_file.=
+Could\ not\ paste\ entry\ as\ text\:=
+Do\ you\ still\ want\ to\ continue?=
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=
+This\ could\ cause\ undesired\ changes\ to\ your\ entries.=
+Run\ field\ formatter\:=
+Table\ font\ size\ is\ %0=
+%0\ import\ canceled=%0-import kansellert
+Internal\ style=
+Add\ style\ file=
+Are\ you\ sure\ you\ want\ to\ remove\ the\ style?=
+Current\ style\ is\ '%0'=
+Remove\ style=
+Select\ one\ of\ the\ available\ styles\ or\ add\ a\ style\ file\ from\ disk.=
+You\ must\ select\ a\ valid\ style\ file.=
 Reload=
 
 Capitalize=
-Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.=
-Capitalize_the_first_word,_changes_other_words_to_lower_case.=
-Changes_all_letters_to_lower_case.=
-Changes_all_letters_to_upper_case.=
-Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.=
-Cleans_up_LaTeX_code.=
-Converts_HTML_code_to_LaTeX_code.=
-Converts_HTML_code_to_Unicode.=
-Converts_LaTeX_encoding_to_Unicode_characters.=
-Converts_Unicode_characters_to_LaTeX_encoding.=
-Converts_ordinals_to_LaTeX_superscripts.=
-Converts_units_to_LaTeX_formatting.=
-HTML_to_LaTeX=
-LaTeX_cleanup=
-LaTeX_to_Unicode=
-Lower_case=
-Minify_list_of_person_names=
-Normalize_date=
-Normalize_month=
-Normalize_month_to_BibTeX_standard_abbreviation.=
-Normalize_names_of_persons=
-Normalize_page_numbers=
-Normalize_pages_to_BibTeX_standard.=
-Normalizes_lists_of_persons_to_the_BibTeX_standard.=
-Normalizes_the_date_to_ISO_date_format.=
-Ordinals_to_LaTeX_superscript=
-Protect_terms=
-Remove_enclosing_braces=
-Removes_braces_encapsulating_the_complete_field_content.=
-Sentence_case=
-Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".=
-Title_case=
-Unicode_to_LaTeX=
-Units_to_LaTeX=
-Upper_case=
-Does_nothing.=
+Capitalize\ all\ words,\ but\ converts\ articles,\ prepositions,\ and\ conjunctions\ to\ lower\ case.=
+Capitalize\ the\ first\ word,\ changes\ other\ words\ to\ lower\ case.=
+Changes\ all\ letters\ to\ lower\ case.=
+Changes\ all\ letters\ to\ upper\ case.=
+Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=
+Cleans\ up\ LaTeX\ code.=
+Converts\ HTML\ code\ to\ LaTeX\ code.=
+Converts\ HTML\ code\ to\ Unicode.=
+Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=
+Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=
+Converts\ ordinals\ to\ LaTeX\ superscripts.=
+Converts\ units\ to\ LaTeX\ formatting.=
+HTML\ to\ LaTeX=
+LaTeX\ cleanup=
+LaTeX\ to\ Unicode=
+Lower\ case=
+Minify\ list\ of\ person\ names=
+Normalize\ date=
+Normalize\ month=
+Normalize\ month\ to\ BibTeX\ standard\ abbreviation.=
+Normalize\ names\ of\ persons=
+Normalize\ page\ numbers=
+Normalize\ pages\ to\ BibTeX\ standard.=
+Normalizes\ lists\ of\ persons\ to\ the\ BibTeX\ standard.=
+Normalizes\ the\ date\ to\ ISO\ date\ format.=
+Ordinals\ to\ LaTeX\ superscript=
+Protect\ terms=
+Remove\ enclosing\ braces=
+Removes\ braces\ encapsulating\ the\ complete\ field\ content.=
+Sentence\ case=
+Shortens\ lists\ of\ persons\ if\ there\ are\ more\ than\ 2\ persons\ to\ "et\ al.".=
+Title\ case=
+Unicode\ to\ LaTeX=
+Units\ to\ LaTeX=
+Upper\ case=
+Does\ nothing.=
 Identity=
-Clears_the_field_completely.=
-Directory_not_found=
-Main_file_directory_not_set\!=
-This_operation_requires_exactly_one_item_to_be_selected.=
-Importing_in_%0_format=
-Female_name=
-Female_names=
-Male_name=
-Male_names=
-Mixed_names=
-Neuter_name=
-Neuter_names=
+Clears\ the\ field\ completely.=
+Directory\ not\ found=
+Main\ file\ directory\ not\ set\!=
+This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=
+Importing\ in\ %0\ format=
+Female\ name=
+Female\ names=
+Male\ name=
+Male\ names=
+Mixed\ names=
+Neuter\ name=
+Neuter\ names=
 
-Determined_%0_for_%1_entries=
-Look_up_%0=
-Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3=
+Determined\ %0\ for\ %1\ entries=
+Look\ up\ %0=
+Looking\ up\ %0...\ -\ entry\ %1\ out\ of\ %2\ -\ found\ %3=
 
-Audio_CD=
-British_patent=
-British_patent_request=
-Candidate_thesis=
+Audio\ CD=
+British\ patent=
+British\ patent\ request=
+Candidate\ thesis=
 Collaborator=
 Column=
 Compiler=
 Continuator=
-Data_CD=
+Data\ CD=
 Editor=
-European_patent=
-European_patent_request=
+European\ patent=
+European\ patent\ request=
 Founder=
-French_patent=
-French_patent_request=
-German_patent=
-German_patent_request=
+French\ patent=
+French\ patent\ request=
+German\ patent=
+German\ patent\ request=
 Line=
-Master's_thesis=
+Master's\ thesis=
 Page=
 Paragraph=
 Patent=
-Patent_request=
-PhD_thesis=
+Patent\ request=
+PhD\ thesis=
 Redactor=
-Research_report=
+Research\ report=
 Reviser=
 Section=
 Software=
-Technical_report=
-U.S._patent=
-U.S._patent_request=
+Technical\ report=
+U.S.\ patent=
+U.S.\ patent\ request=
 Verse=
 
-change_entries_of_group=
-odd_number_of_unescaped_'\#'=
+change\ entries\ of\ group=
+odd\ number\ of\ unescaped\ '\#'=
 
-Plain_text=
-Show_diff=
+Plain\ text=
+Show\ diff=
 character=
 word=
-Show_symmetric_diff=
-Copy_Version=
+Show\ symmetric\ diff=
+Copy\ Version=
 Developers=
 Authors=
 License=
 
-HTML_encoded_character_found=
-booktitle_ends_with_'conference_on'=
+HTML\ encoded\ character\ found=
+booktitle\ ends\ with\ 'conference\ on'=
 
-All_external_files=
+All\ external\ files=
 
-OpenOffice/LibreOffice_integration=
+OpenOffice/LibreOffice\ integration=
 
-incorrect_control_digit=
-incorrect_format=
-Copied_version_to_clipboard=
+incorrect\ control\ digit=
+incorrect\ format=
+Copied\ version\ to\ clipboard=
 
-BibTeX_key=
+BibTeX\ key=
 Message=
 
 
-MathSciNet_Review=
-Reset_Bindings=
+MathSciNet\ Review=
+Reset\ Bindings=
 
-Decryption_not_supported.=
+Decryption\ not\ supported.=
 
-Cleared_'%0'_for_%1_entries=
-Set_'%0'_to_'%1'_for_%2_entries=
-Toggled_'%0'_for_%1_entries=
+Cleared\ '%0'\ for\ %1\ entries=
+Set\ '%0'\ to\ '%1'\ for\ %2\ entries=
+Toggled\ '%0'\ for\ %1\ entries=
 
-Check_for_updates=
-Download_update=
-New_version_available=
-Installed_version=
-Remind_me_later=
-Ignore_this_update=
-Could_not_connect_to_the_update_server.=
-Please_try_again_later_and/or_check_your_network_connection.=
-To_see_what_is_new_view_the_changelog.=
-A_new_version_of_JabRef_has_been_released.=
-JabRef_is_up-to-date.=
-Latest_version=
-Online_help_forum=
+Check\ for\ updates=
+Download\ update=
+New\ version\ available=
+Installed\ version=
+Remind\ me\ later=
+Ignore\ this\ update=
+Could\ not\ connect\ to\ the\ update\ server.=
+Please\ try\ again\ later\ and/or\ check\ your\ network\ connection.=
+To\ see\ what\ is\ new\ view\ the\ changelog.=
+A\ new\ version\ of\ JabRef\ has\ been\ released.=
+JabRef\ is\ up-to-date.=
+Latest\ version=
+Online\ help\ forum=
 Custom=
 
-Export_cited=
-Unable_to_generate_new_library=
+Export\ cited=
+Unable\ to\ generate\ new\ library=
 
-Open_console=
-Use_default_terminal_emulator=
-Execute_command=
-Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.=
-Executing_command_\"%0\"...=
-Error_occured_while_executing_the_command_\"%0\".=
-Reformat_ISSN=
+Open\ console=
+Use\ default\ terminal\ emulator=
+Execute\ command=
+Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=
+Executing\ command\ \"%0\"...=
+Error\ occured\ while\ executing\ the\ command\ \"%0\".=
+Reformat\ ISSN=
 
-Countries_and_territories_in_English=
-Electrical_engineering_terms=
+Countries\ and\ territories\ in\ English=
+Electrical\ engineering\ terms=
 Enabled=
-Internal_list=
-Manage_protected_terms_files=
-Months_and_weekdays_in_English=
-The_text_after_the_last_line_starting_with_\#_will_be_used=
-Add_protected_terms_file=
-Are_you_sure_you_want_to_remove_the_protected_terms_file?=
-Remove_protected_terms_file=
-Add_selected_text_to_list=
-Add_{}_around_selected_text=
-Format_field=
-New_protected_terms_file=
-change_field_%0_of_entry_%1_from_%2_to_%3=
-change_key_from_%0_to_%1=
-change_string_content_%0_to_%1=
-change_string_name_%0_to_%1=
-change_type_of_entry_%0_from_%1_to_%2=
-insert_entry_%0=
-insert_string_%0=
-remove_entry_%0=
-remove_string_%0=
+Internal\ list=
+Manage\ protected\ terms\ files=
+Months\ and\ weekdays\ in\ English=
+The\ text\ after\ the\ last\ line\ starting\ with\ \#\ will\ be\ used=
+Add\ protected\ terms\ file=
+Are\ you\ sure\ you\ want\ to\ remove\ the\ protected\ terms\ file?=
+Remove\ protected\ terms\ file=
+Add\ selected\ text\ to\ list=
+Add\ {}\ around\ selected\ text=
+Format\ field=
+New\ protected\ terms\ file=
+change\ field\ %0\ of\ entry\ %1\ from\ %2\ to\ %3=
+change\ key\ from\ %0\ to\ %1=
+change\ string\ content\ %0\ to\ %1=
+change\ string\ name\ %0\ to\ %1=
+change\ type\ of\ entry\ %0\ from\ %1\ to\ %2=
+insert\ entry\ %0=
+insert\ string\ %0=
+remove\ entry\ %0=
+remove\ string\ %0=
 undefined=
-Cannot_get_info_based_on_given_%0\:_%1=
-Get_BibTeX_data_from_%0=
-No_%0_found=
-Entry_from_%0=
-Merge_entry_with_%0_information=
-Updated_entry_with_info_from_%0=
+Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=
+Get\ BibTeX\ data\ from\ %0=
+No\ %0\ found=
+Entry\ from\ %0=
+Merge\ entry\ with\ %0\ information=
+Updated\ entry\ with\ info\ from\ %0=
 
-Add_existing_file=
-Create_new_list=
-Remove_list=
-Full_journal_name=
-Abbreviation_name=
+Add\ existing\ file=
+Create\ new\ list=
+Remove\ list=
+Full\ journal\ name=
+Abbreviation\ name=
 
-No_abbreviation_files_loaded=
+No\ abbreviation\ files\ loaded=
 
-Loading_built_in_lists=
+Loading\ built\ in\ lists=
 
-JabRef_built_in_list=
-IEEE_built_in_list=
+JabRef\ built\ in\ list=
+IEEE\ built\ in\ list=
 
-Event_log=
-We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.=
-Log_copied_to_clipboard.=
-Copy_Log=
-Clear_Log=
-Report_Issue=
-Issue_on_GitHub_successfully_reported.=
-Issue_report_successful=
-Your_issue_was_reported_in_your_browser.=
-The_log_and_exception_information_was_copied_to_your_clipboard.=
-Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.=
+Event\ log=
+We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef\'s\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=
+Log\ copied\ to\ clipboard.=
+Copy\ Log=
+Clear\ Log=
+Report\ Issue=
+Issue\ on\ GitHub\ successfully\ reported.=
+Issue\ report\ successful=
+Your\ issue\ was\ reported\ in\ your\ browser.=
+The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=
+Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=
 
 Connection=
 Connecting...=
@@ -2163,195 +2163,195 @@ Host=
 Port=
 Library=
 User=
-Connect=Koble_til
-Connection_error=
-Connection_to_%0_server_established.=
-Required_field_"%0"_is_empty.=
-%0_driver_not_available.=
-The_connection_to_the_server_has_been_terminated.=
-Connection_lost.=
+Connect=Koble til
+Connection\ error=
+Connection\ to\ %0\ server\ established.=
+Required\ field\ "%0"\ is\ empty.=
+%0\ driver\ not\ available.=
+The\ connection\ to\ the\ server\ has\ been\ terminated.=
+Connection\ lost.=
 Reconnect=
-Work_offline=
-Working_offline.=
-Update_refused.=
-Update_refused=
-Local_entry=
-Shared_entry=
-Update_could_not_be_performed_due_to_existing_change_conflicts.=
-You_are_not_working_on_the_newest_version_of_BibEntry.=
-Local_version\:_%0=
-Shared_version\:_%0=
-Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.=
-Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?=
-Shared_entry_is_no_longer_present=
-The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.=
-You_can_restore_the_entry_using_the_"Undo"_operation.=
-Remember_password?=
-You_are_already_connected_to_a_database_using_entered_connection_details.=
+Work\ offline=
+Working\ offline.=
+Update\ refused.=
+Update\ refused=
+Local\ entry=
+Shared\ entry=
+Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=
+You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=
+Local\ version\:\ %0=
+Shared\ version\:\ %0=
+Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=
+Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=
+Shared\ entry\ is\ no\ longer\ present=
+The\ BibEntry\ you\ currently\ work\ on\ has\ been\ deleted\ on\ the\ shared\ side.=
+You\ can\ restore\ the\ entry\ using\ the\ "Undo"\ operation.=
+Remember\ password?=
+You\ are\ already\ connected\ to\ a\ database\ using\ entered\ connection\ details.=
 
-Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?=
-New_technical_report=
+Cannot\ cite\ entries\ without\ BibTeX\ keys.\ Generate\ keys\ now?=
+New\ technical\ report=
 
-%0_file=
-Custom_layout_file=
-Protected_terms_file=
-Style_file=
+%0\ file=
+Custom\ layout\ file=
+Protected\ terms\ file=
+Style\ file=
 
-Open_OpenOffice/LibreOffice_connection=
-You_must_enter_at_least_one_field_name=
-Non-ASCII_encoded_character_found=
-Toggle_web_search_interface=
-Background_color_for_resolved_fields=
-Color_code_for_resolved_fields=
-%0_files_found=
-%0_of_%1=
-One_file_found=
-The_import_finished_with_warnings\:=
-There_was_one_file_that_could_not_be_imported.=
-There_were_%0_files_which_could_not_be_imported.=
+Open\ OpenOffice/LibreOffice\ connection=
+You\ must\ enter\ at\ least\ one\ field\ name=
+Non-ASCII\ encoded\ character\ found=
+Toggle\ web\ search\ interface=
+Background\ color\ for\ resolved\ fields=
+Color\ code\ for\ resolved\ fields=
+%0\ files\ found=
+%0\ of\ %1=
+One\ file\ found=
+The\ import\ finished\ with\ warnings\:=
+There\ was\ one\ file\ that\ could\ not\ be\ imported.=
+There\ were\ %0\ files\ which\ could\ not\ be\ imported.=
 
-Migration_help_information=
-Entered_database_has_obsolete_structure_and_is_no_longer_supported.=
-However,_a_new_database_was_created_alongside_the_pre-3.6_one.=
-Click_here_to_learn_about_the_migration_of_pre-3.6_databases.=
-Opens_JabRef's_Facebook_page=
-Opens_JabRef's_blog=
-Opens_JabRef's_website=
-Opens_a_link_where_the_current_development_version_can_be_downloaded=
-See_what_has_been_changed_in_the_JabRef_versions=
-Referenced_BibTeX_key_does_not_exist=
-Finished_downloading_full_text_document_for_entry_%0.=
-Full_text_document_download_failed_for_entry_%0.=
-Look_up_full_text_documents=
-You_are_about_to_look_up_full_text_documents_for_%0_entries.=
-last_four_nonpunctuation_characters_should_be_numerals=
+Migration\ help\ information=
+Entered\ database\ has\ obsolete\ structure\ and\ is\ no\ longer\ supported.=
+However,\ a\ new\ database\ was\ created\ alongside\ the\ pre-3.6\ one.=
+Click\ here\ to\ learn\ about\ the\ migration\ of\ pre-3.6\ databases.=
+Opens\ JabRef's\ Facebook\ page=
+Opens\ JabRef's\ blog=
+Opens\ JabRef's\ website=
+Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=
+See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=
+Referenced\ BibTeX\ key\ does\ not\ exist=
+Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=
+Full\ text\ document\ download\ failed\ for\ entry\ %0.=
+Look\ up\ full\ text\ documents=
+You\ are\ about\ to\ look\ up\ full\ text\ documents\ for\ %0\ entries.=
+last\ four\ nonpunctuation\ characters\ should\ be\ numerals=
 
 Author=
 Date=
-File_annotations=
-Show_file_annotations=
-Adobe_Acrobat_Reader=
-Sumatra_Reader=
+File\ annotations=
+Show\ file\ annotations=
+Adobe\ Acrobat\ Reader=
+Sumatra\ Reader=
 shared=
-should_contain_an_integer_or_a_literal=
-should_have_the_first_letter_capitalized=
+should\ contain\ an\ integer\ or\ a\ literal=
+should\ have\ the\ first\ letter\ capitalized=
 Tools=
-What\'s_new_in_this_version?=
-Want_to_help?=
-Make_a_donation=
-get_involved=
-Used_libraries=
-Existing_file=
+What\'s\ new\ in\ this\ version?=
+Want\ to\ help?=
+Make\ a\ donation=
+get\ involved=
+Used\ libraries=
+Existing\ file=
 
 ID=
-ID_type=
-ID-based_entry_generator=
-Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+ID\ type=
+ID-based\ entry\ generator=
+Fetcher\ '%0'\ did\ not\ find\ an\ entry\ for\ id\ '%1'.=
 
-Select_first_entry=
-Select_last_entry=
+Select\ first\ entry=
+Select\ last\ entry=
 
-Invalid_ISBN\:_'%0'.=
-should_be_an_integer_or_normalized=
-should_be_normalized=
+Invalid\ ISBN\:\ '%0'.=
+should\ be\ an\ integer\ or\ normalized=
+should\ be\ normalized=
 
-Empty_search_ID=
-The_given_search_ID_was_empty.=
-Copy_BibTeX_key_and_link=
-empty_BibTeX_key=
-biblatex_field_only=
+Empty\ search\ ID=
+The\ given\ search\ ID\ was\ empty.=
+Copy\ BibTeX\ key\ and\ link=
+empty\ BibTeX\ key=
+biblatex\ field\ only=
 
-Error_while_generating_fetch_URL=
-Error_while_parsing_ID_list=
-Unable_to_get_PubMed_IDs=
-Backup_found=
-A_backup_file_for_'%0'_was_found.=
-This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.=
-Do_you_want_to_recover_the_library_from_the_backup_file?=
-Firstname_Lastname=
+Error\ while\ generating\ fetch\ URL=
+Error\ while\ parsing\ ID\ list=
+Unable\ to\ get\ PubMed\ IDs=
+Backup\ found=
+A\ backup\ file\ for\ '%0'\ was\ found.=
+This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=
+Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=
+Firstname\ Lastname=
 
-Recommended_for_%0=
-Show_'Related_Articles'_tab=
-This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
+Recommended\ for\ %0=
+Show\ 'Related\ Articles'\ tab=
+This\ might\ be\ caused\ by\ reaching\ the\ traffic\ limitation\ of\ Google\ Scholar\ (see\ 'Help'\ for\ details).=
 
-Could_not_open_website.=
-Problem_downloading_from_%1=
+Could\ not\ open\ website.=
+Problem\ downloading\ from\ %1=
 
-File_directory_pattern=
-Update_with_bibliographic_information_from_the_web=
+File\ directory\ pattern=
+Update\ with\ bibliographic\ information\ from\ the\ web=
 
-Could_not_find_any_bibliographic_information.=
-BibTeX_key_deviates_from_generated_key=
-DOI_%0_is_invalid=
+Could\ not\ find\ any\ bibliographic\ information.=
+BibTeX\ key\ deviates\ from\ generated\ key=
+DOI\ %0\ is\ invalid=
 
-Select_all_customized_types_to_be_stored_in_local_preferences=
-Currently_unknown=
-Different_customization,_current_settings_will_be_overwritten=
+Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences=
+Currently\ unknown=
+Different\ customization,\ current\ settings\ will\ be\ overwritten=
 
-Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX=
-Jump_to_entry=
+Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=
+Jump\ to\ entry=
 
-Copied_%0_citations.=
+Copied\ %0\ citations.=
 Copying...=
 
-journal_not_found_in_abbreviation_list=
-Unhandled_exception_occurred.=
+journal\ not\ found\ in\ abbreviation\ list=
+Unhandled\ exception\ occurred.=
 
-strings_included=
-Color_for_disabled_icons=
-Color_for_enabled_icons=
-Size_of_large_icons=
-Size_of_small_icons=
-Default_table_font_size=
-Escape_underscores=
+strings\ included=
+Color\ for\ disabled\ icons=
+Color\ for\ enabled\ icons=
+Size\ of\ large\ icons=
+Size\ of\ small\ icons=
+Default\ table\ font\ size=
+Escape\ underscores=
 Color=
-Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=
-Fit_width=
-Fit_a_single_page=
-Zoom_in=
-Zoom_out=
-Previous_page=
-Next_page=
-Document_viewer=
+Please\ also\ add\ all\ steps\ to\ reproduce\ this\ issue,\ if\ possible.=
+Fit\ width=
+Fit\ a\ single\ page=
+Zoom\ in=
+Zoom\ out=
+Previous\ page=
+Next\ page=
+Document\ viewer=
 Live=
 Locked=
-Show_document_viewer=
-Show_the_document_of_the_currently_selected_entry.=
-Show_this_document_until_unlocked.=
-Set_current_user_name_as_owner.=
+Show\ document\ viewer=
+Show\ the\ document\ of\ the\ currently\ selected\ entry.=
+Show\ this\ document\ until\ unlocked.=
+Set\ current\ user\ name\ as\ owner.=
 
-Sort_all_subgroups_(recursively)=
-Collect_and_share_telemetry_data_to_help_improve_JabRef.=
-Don't_share=
-Share_anonymous_statistics=
-Telemetry\:_Help_make_JabRef_better=
-To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.=
-This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?=
-Names_are_not_in_the_standard_%0_format.=
+Sort\ all\ subgroups\ (recursively)=
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=
+Don't\ share=
+Share\ anonymous\ statistics=
+Telemetry\:\ Help\ make\ JabRef\ better=
+To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ statistics\ on\ the\ features\ you\ use.\ We\ will\ only\ record\ what\ features\ you\ access\ and\ how\ often\ you\ do\ it.\ We\ will\ neither\ collect\ any\ personal\ data\ nor\ the\ content\ of\ bibliographic\ items.\ If\ you\ choose\ to\ allow\ data\ collection,\ you\ can\ later\ disable\ it\ via\ Options\ ->\ Preferences\ ->\ General.=
+This\ file\ was\ found\ automatically.\ Do\ you\ want\ to\ link\ it\ to\ this\ entry?=
+Names\ are\ not\ in\ the\ standard\ %0\ format.=
 
-Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.=
-Delete_'%0'=
-Delete_from_disk=
-Remove_from_entry=
-The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.=
-There_exists_already_a_group_with_the_same_name.=
+Delete\ the\ selected\ file\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ file\ permanently\ from\ disk.=
+Delete\ '%0'=
+Delete\ from\ disk=
+Remove\ from\ entry=
+The\ group\ name\ contains\ the\ keyword\ separator\ "%0"\ and\ thus\ probably\ does\ not\ work\ as\ expected.=
+There\ exists\ already\ a\ group\ with\ the\ same\ name.=
 
-Copy_linked_files_to_folder...=
-Copied_file_successfully=
-Copying_files...=
-Copying_file_%0_of_entry_%1=
-Finished_copying=
-Could_not_copy_file=
-Copied_%0_files_of_%1_sucessfully_to_%2=
-Rename_failed=
-JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.=
-Show_console_output_(only_necessary_when_the_launcher_is_used)=
+Copy\ linked\ files\ to\ folder...=
+Copied\ file\ successfully=
+Copying\ files...=
+Copying\ file\ %0\ of\ entry\ %1=
+Finished\ copying=
+Could\ not\ copy\ file=
+Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=
+Rename\ failed=
+JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=
+Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=
 
-Remove_line_breaks=
-Removes_all_line_breaks_in_the_field_content.=
-Checking_integrity...=
+Remove\ line\ breaks=
+Removes\ all\ line\ breaks\ in\ the\ field\ content.=
+Checking\ integrity...=
 
-Remove_hyphenated_line_breaks=
-Removes_all_hyphenated_line_breaks_in_the_field_content.=
-Note_that_currently,_JabRef_does_not_run_with_Java_9.=
-Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.=
+Remove\ hyphenated\ line\ breaks=
+Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=
+Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=
+Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -1,8 +1,3 @@
-
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 inneholder regul\u00e6ruttrykket <b>%1</b>
 
 %0\ contains\ the\ term\ <b>%1</b>=%0 inneholder uttrykket <b>%1</b>

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -1309,7 +1309,7 @@ You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Você deve reinic
 You\ have\ changed\ the\ language\ setting.=Você configurou a configuração de idioma.
 You\ have\ entered\ an\ invalid\ search\ '%0'.=Você digitou um termo de busca inválido '%0'.
 
-You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.= O JabRef precisa ser reiniciado para que as novas atribuições de chave funcionem corretamente.
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=O JabRef precisa ser reiniciado para que as novas atribuições de chave funcionem corretamente.
 
 Your\ new\ key\ bindings\ have\ been\ stored.=Suas novas atribuições de chave foram armazenadas.
 

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -1,8 +1,3 @@
-
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 contém a Expressão Regular <b>%1</b>
 
 %0\ contains\ the\ term\ <b>%1</b>=%0 contém o termo <b>%1</b>

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -3,156 +3,156 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-%0_contains_the_regular_expression_<b>%1</b>=%0_contém_a_Expressão_Regular_<b>%1</b>
+%0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 contém a Expressão Regular <b>%1</b>
 
-%0_contains_the_term_<b>%1</b>=%0_contém_o_termo_<b>%1</b>
+%0\ contains\ the\ term\ <b>%1</b>=%0 contém o termo <b>%1</b>
 
-%0_doesn't_contain_the_regular_expression_<b>%1</b>=%0_não_contém_a_Expressão_Regular_<b>%1</b>
+%0\ doesn't\ contain\ the\ regular\ expression\ <b>%1</b>=%0 não contém a Expressão Regular <b>%1</b>
 
-%0_doesn't_contain_the_term_<b>%1</b>=%0_não_contém_o_termo_<b>%1</b>
+%0\ doesn't\ contain\ the\ term\ <b>%1</b>=%0 não contém o termo <b>%1</b>
 
-%0_export_successful=%0_exportado_com_sucesso
+%0\ export\ successful=%0 exportado com sucesso
 
-%0_matches_the_regular_expression_<b>%1</b>=%0_encontrada_a_expressão_regular_<b>%1</b>
+%0\ matches\ the\ regular\ expression\ <b>%1</b>=%0 encontrada a expressão regular <b>%1</b>
 
-%0_matches_the_term_<b>%1</b>=%0_encontrado_o_termo_<b>%1</b>
+%0\ matches\ the\ term\ <b>%1</b>=%0 encontrado o termo <b>%1</b>
 
-<field_name>=<nome_do_campo>
-<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>=<HTML>Não_foi_possível_encontrar_o_arquivo_'%0'<BR>a_partir_da_referência_'%1'</HTML>
+<field\ name>=<nome do campo>
+<HTML>Could\ not\ find\ file\ '%0'<BR>linked\ from\ entry\ '%1'</HTML>=<HTML>Não foi possível encontrar o arquivo '%0'<BR>a partir da referência '%1'</HTML>
 
 <select>=<selecionar>
 
-<select_word>=<selecionar_palavra>
-Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)=Abreviar_nomes_de_periódicos_das_referências_selecionadas_(abreviação_ISO)
-Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)=Abreviar_nomes_de_periódicos_das_referências_selecionadas_(abreviação_MEDLINE)
+<select\ word>=<selecionar palavra>
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (ISO\ abbreviation)=Abreviar nomes de periódicos das referências selecionadas (abreviação ISO)
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (MEDLINE\ abbreviation)=Abreviar nomes de periódicos das referências selecionadas (abreviação MEDLINE)
 
-Abbreviate_names=Abreviar_nomes
-Abbreviated_%0_journal_names.=%0_nomes_de_periódicos_foram_abreviados.
+Abbreviate\ names=Abreviar nomes
+Abbreviated\ %0\ journal\ names.=%0 nomes de periódicos foram abreviados.
 
 Abbreviation=Abreviação
 
-About_JabRef=Sobre_JabRef
+About\ JabRef=Sobre JabRef
 
 Abstract=Resumo
 
 Accept=Aceitar
 
-Accept_change=Aceitar_modificação
+Accept\ change=Aceitar modificação
 
 Action=Ação
 
-What_is_Mr._DLib?=
+What\ is\ Mr.\ DLib?=
 
 Add=Adicionar
 
-Add_a_(compiled)_custom_Importer_class_from_a_class_path.=Adicionar_uma_classe_Importer_customizada_(compilada)_a_partir_de_um_classpath.
-The_path_need_not_be_on_the_classpath_of_JabRef.=O_caminho_não_precisa_estar_no_classpath_do_JabRef.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=Adicionar uma classe Importer customizada (compilada) a partir de um classpath.
+The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=O caminho não precisa estar no classpath do JabRef.
 
-Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=Adicionar_uma_classe_Importer_customizada_(compilada)_a_partir_de_um_arquivo_zip.
-The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=O_arquivo_zip_não_precisa_estar_no_classpath_do_JabRef.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=Adicionar uma classe Importer customizada (compilada) a partir de um arquivo zip.
+The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=O arquivo zip não precisa estar no classpath do JabRef.
 
-Add_a_regular_expression_for_the_key_pattern.=
+Add\ a\ regular\ expression\ for\ the\ key\ pattern.=
 
-Add_selected_entries_to_this_group=
+Add\ selected\ entries\ to\ this\ group=
 
-Add_from_folder=Adicionar_a_partir_de_uma_pasta
+Add\ from\ folder=Adicionar a partir de uma pasta
 
-Add_from_JAR=Adicionar_a_partir_de_um_JAR
+Add\ from\ JAR=Adicionar a partir de um JAR
 
-add_group=adicionar_grupo
+add\ group=adicionar grupo
 
-Add_new=Adicionar_novo
+Add\ new=Adicionar novo
 
-Add_subgroup=Adicionar_subgrupo
+Add\ subgroup=Adicionar subgrupo
 
-Add_to_group=Adicionar_ao_grupo
+Add\ to\ group=Adicionar ao grupo
 
-Added_group_"%0".=O_grupo_"%0"_foi_adicionado.
+Added\ group\ "%0".=O grupo "%0" foi adicionado.
 
-Added_missing_braces.=
+Added\ missing\ braces.=
 
-Added_new=Adicionado_novo
+Added\ new=Adicionado novo
 
-Added_string=Adicionada_string
+Added\ string=Adicionada string
 
-Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.=Adicionalmente,_as_referências_cujo_campo_<b>%0</b>não_contem_<b>%1</b>_podem_ser_atribuídos_a_este_grupo_manualmente,_selecionandos-as_e_depois_arrastando_e_soltando_no_menu_de_contexto._Este_processo_inclui_o_termo_<b>%1</b>_para_cada_referência_<b>%0</b>._Referências_podem_ser_removidas_manualmente_deste_grupo_selecionando-as_utilizando_o_menu_de_contexto._O_processo_remove_o_termo_<b>%1</b>_de_cada_referência_<b>%0</b>.
+Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ can\ be\ assigned\ manually\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ This\ process\ adds\ the\ term\ <b>%1</b>\ to\ each\ entry's\ <b>%0</b>\ field.\ Entries\ can\ be\ removed\ manually\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.\ This\ process\ removes\ the\ term\ <b>%1</b>\ from\ each\ entry's\ <b>%0</b>\ field.=Adicionalmente, as referências cujo campo <b>%0</b>não contem <b>%1</b> podem ser atribuídos a este grupo manualmente, selecionandos-as e depois arrastando e soltando no menu de contexto. Este processo inclui o termo <b>%1</b> para cada referência <b>%0</b>. Referências podem ser removidas manualmente deste grupo selecionando-as utilizando o menu de contexto. O processo remove o termo <b>%1</b> de cada referência <b>%0</b>.
 
 Advanced=Avançado
-All_entries=Todas_as_referências
-All_entries_of_this_type_will_be_declared_typeless._Continue?=Todas_as_referências_serão_consideradas_sem_tipo._Continuar?
+All\ entries=Todas as referências
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=Todas as referências serão consideradas sem tipo. Continuar?
 
-All_fields=Todos_os_campos
+All\ fields=Todos os campos
 
-Always_reformat_BIB_file_on_save_and_export=
+Always\ reformat\ BIB\ file\ on\ save\ and\ export=
 
-A_SAX_exception_occurred_while_parsing_'%0'\:=Uma_exceção_ocorreu_durante_a_análise_de_'%0'
+A\ SAX\ exception\ occurred\ while\ parsing\ '%0'\:=Uma exceção ocorreu durante a análise de '%0'
 
 and=e
-and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.=e_a_classe_deve_estar_disponível_em_seu_classpath_na_próxima_vez_que_você_iniciar_o_JabRef.
+and\ the\ class\ must\ be\ available\ in\ your\ classpath\ next\ time\ you\ start\ JabRef.=e a classe deve estar disponível em seu classpath na próxima vez que você iniciar o JabRef.
 
-any_field_that_matches_the_regular_expression_<b>%0</b>=qualquer_campo_que_corresponde_a_expressão_regular_<b>%0</b>
+any\ field\ that\ matches\ the\ regular\ expression\ <b>%0</b>=qualquer campo que corresponde a expressão regular <b>%0</b>
 
 Appearance=Aparência
 
 Append=Anexar
-Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library=Anexar_o_conteúdo_de_uma_base_de_dados_BibTeX_à_base_de_dados_atual
+Append\ contents\ from\ a\ BibTeX\ library\ into\ the\ currently\ viewed\ library=Anexar o conteúdo de uma base de dados BibTeX à base de dados atual
 
-Append_library=Anexar_base_de_dados
+Append\ library=Anexar base de dados
 
-Append_the_selected_text_to_BibTeX_field=Anexar_o_texto_selecionado_à_chave_BibTeX
+Append\ the\ selected\ text\ to\ BibTeX\ field=Anexar o texto selecionado à chave BibTeX
 Application=Aplicação
 
 Apply=Aplicar
 
-Arguments_passed_on_to_running_JabRef_instance._Shutting_down.=Parâmetros_passados_ao_JabRef_em_execução._Encerrando_o_programa.
+Arguments\ passed\ on\ to\ running\ JabRef\ instance.\ Shutting\ down.=Parâmetros passados ao JabRef em execução. Encerrando o programa.
 
-Assign_new_file=Associar_novo_arquivo
+Assign\ new\ file=Associar novo arquivo
 
-Assign_the_original_group's_entries_to_this_group?=Atribuir_as_referênciass_originais_do_grupo_à_este_grupo?
+Assign\ the\ original\ group's\ entries\ to\ this\ group?=Atribuir as referênciass originais do grupo à este grupo?
 
-Assigned_%0_entries_to_group_"%1".=%0_referências_atribuídas_ao_grupo_"%1"
+Assigned\ %0\ entries\ to\ group\ "%1".=%0 referências atribuídas ao grupo "%1"
 
-Assigned_1_entry_to_group_"%0".=1_referência_atribuído_ao_grupo_"%0"
+Assigned\ 1\ entry\ to\ group\ "%0".=1 referência atribuído ao grupo "%0"
 
-Attach_URL=Anexar_a_URL
+Attach\ URL=Anexar a URL
 
-Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.=Tentativa_de_definir_automaticamente_links_de_arquivos_para_suas_referências._A_definição_automática_funciona_se_um_arquivo_em_seu_diretório_arquivo_ou_um_subdiretório<BR>tem_o_mesmo_nome_de_uma_chave_BibTeX_de_uma_referência,_mais_sua_extensão.
+Attempt\ to\ automatically\ set\ file\ links\ for\ your\ entries.\ Automatically\ setting\ works\ if\ a\ file\ in\ your\ file\ directory<BR>or\ a\ subdirectory\ is\ named\ identically\ to\ an\ entry's\ BibTeX\ key,\ plus\ extension.=Tentativa de definir automaticamente links de arquivos para suas referências. A definição automática funciona se um arquivo em seu diretório arquivo ou um subdiretório<BR>tem o mesmo nome de uma chave BibTeX de uma referência, mais sua extensão.
 
-Autodetect_format=Detecção_automática_de_formato
+Autodetect\ format=Detecção automática de formato
 
-Autogenerate_BibTeX_keys=Geração_automática_de_chaves_BibTeX
+Autogenerate\ BibTeX\ keys=Geração automática de chaves BibTeX
 
-Autolink_files_with_names_starting_with_the_BibTeX_key=Criar_links_automaticamente_arquivos_com_nomes_iniciando_pela_chave_BibTeX
+Autolink\ files\ with\ names\ starting\ with\ the\ BibTeX\ key=Criar links automaticamente arquivos com nomes iniciando pela chave BibTeX
 
-Autolink_only_files_that_match_the_BibTeX_key=Criar_links_automaticamente_somente_os_arquivos_que_correspondem_à_chave_BibTeX
+Autolink\ only\ files\ that\ match\ the\ BibTeX\ key=Criar links automaticamente somente os arquivos que correspondem à chave BibTeX
 
-Automatically_create_groups=Criar_grupos_automaticamente
+Automatically\ create\ groups=Criar grupos automaticamente
 
-Automatically_remove_exact_duplicates=Remover_automaticamente_duplicatas_exatas
+Automatically\ remove\ exact\ duplicates=Remover automaticamente duplicatas exatas
 
-Allow_overwriting_existing_links.=Sobrescrever_links_existentes.
+Allow\ overwriting\ existing\ links.=Sobrescrever links existentes.
 
-Do_not_overwrite_existing_links.=Não_sobrescrever_links_existentes.
+Do\ not\ overwrite\ existing\ links.=Não sobrescrever links existentes.
 
-AUX_file_import=Importação_de_arquivos_AUX
+AUX\ file\ import=Importação de arquivos AUX
 
-Available_export_formats=Formatos_de_exportação_disponíveis
+Available\ export\ formats=Formatos de exportação disponíveis
 
-Available_BibTeX_fields=Campos_disponíveis
+Available\ BibTeX\ fields=Campos disponíveis
 
-Available_import_formats=Formatos_de_importação_disponíveis
+Available\ import\ formats=Formatos de importação disponíveis
 
-Background_color_for_optional_fields=Cor_de_fundo_para_campos_opcionais
+Background\ color\ for\ optional\ fields=Cor de fundo para campos opcionais
 
-Background_color_for_required_fields=Cor_de_fundo_para_campos_obrigatórios
+Background\ color\ for\ required\ fields=Cor de fundo para campos obrigatórios
 
-Backup_old_file_when_saving=Criar_uma_cópia_de_segurança_do_arquivo_antigo_quando_salvar
+Backup\ old\ file\ when\ saving=Criar uma cópia de segurança do arquivo antigo quando salvar
 
-BibTeX_key_is_unique.=A_chave_BibTeX_é_única.
+BibTeX\ key\ is\ unique.=A chave BibTeX é única.
 
-%0_source=Fonte_%0
+%0\ source=Fonte %0
 
-Broken_link=Link_quebrado
+Broken\ link=Link quebrado
 
 Browse=Explorar
 
@@ -160,321 +160,321 @@ by=por
 
 Cancel=Cancelar
 
-Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?=Não_é_possível_adicionar_referências_ao_grupo_sem_gerar_as_chaves._Gerar_as_chaves_agora?
+Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=Não é possível adicionar referências ao grupo sem gerar as chaves. Gerar as chaves agora?
 
-Cannot_merge_this_change=Não_é_possível_mesclar_esta_mudança.
+Cannot\ merge\ this\ change=Não é possível mesclar esta mudança.
 
-case_insensitive=Insensível_ao_caso
+case\ insensitive=Insensível ao caso
 
-case_sensitive=sensível_ao_caso
+case\ sensitive=sensível ao caso
 
-Case_sensitive=Sensível_ao_caso
+Case\ sensitive=Sensível ao caso
 
-change_assignment_of_entries=Alterar_atribuição_de_referências
+change\ assignment\ of\ entries=Alterar atribuição de referências
 
-Change_case=Modificar_caso
+Change\ case=Modificar caso
 
-Change_entry_type=Modificar_tipo_de_referência
-Change_file_type=Modificar_tipo_do_arquivo
+Change\ entry\ type=Modificar tipo de referência
+Change\ file\ type=Modificar tipo do arquivo
 
 
-Change_of_Grouping_Method=Modificar_método_de_agrupamento
+Change\ of\ Grouping\ Method=Modificar método de agrupamento
 
-change_preamble=modificar_preâmbulo
+change\ preamble=modificar preâmbulo
 
-Change_table_column_and_General_fields_settings_to_use_the_new_feature=Modificar_coluna_da_tabela_e_configurações_gerais_do_campo_para_utilizar_a_nova_funcionalidade
+Change\ table\ column\ and\ General\ fields\ settings\ to\ use\ the\ new\ feature=Modificar coluna da tabela e configurações gerais do campo para utilizar a nova funcionalidade
 
-Changed_language_settings=Configurações_de_idioma_modificadas
+Changed\ language\ settings=Configurações de idioma modificadas
 
-Changed_preamble=Preâmbulo_modificado
+Changed\ preamble=Preâmbulo modificado
 
-Check_existing_file_links=Verificar_links_de_arquivos_existentes
+Check\ existing\ file\ links=Verificar links de arquivos existentes
 
-Check_links=Verificar_links
+Check\ links=Verificar links
 
-Cite_command=Comando_citar
+Cite\ command=Comando citar
 
-Class_name=Nome_da_classe
+Class\ name=Nome da classe
 
 Clear=Limpar
 
-Clear_fields=Limpar_campos
+Clear\ fields=Limpar campos
 
 Close=Fechar
-Close_others=Fechar_os_outros
-Close_all=Fechar_todos
+Close\ others=Fechar os outros
+Close\ all=Fechar todos
 
-Close_dialog=Fechar_janela_de_diálogo
+Close\ dialog=Fechar janela de diálogo
 
-Close_the_current_library=Fechar_a_base_de_dados_atual
+Close\ the\ current\ library=Fechar a base de dados atual
 
-Close_window=Fechar_Janela
+Close\ window=Fechar Janela
 
-Closed_library=Base_de_dados_fechada
+Closed\ library=Base de dados fechada
 
-Color_codes_for_required_and_optional_fields=Códigos_de_cores_para_campos_obrigatórios_e_opcionais
+Color\ codes\ for\ required\ and\ optional\ fields=Códigos de cores para campos obrigatórios e opcionais
 
-Color_for_marking_incomplete_entries=Cores_para_marcar_referências_incompletas
+Color\ for\ marking\ incomplete\ entries=Cores para marcar referências incompletas
 
-Column_width=Largura_da_coluna
+Column\ width=Largura da coluna
 
-Command_line_id=ID_da_linha_de_comando
+Command\ line\ id=ID da linha de comando
 
 
-Contained_in=Contido_em
+Contained\ in=Contido em
 
 Content=Conteúdo
 
 Copied=Copiado
 
-Copied_cell_contents=Conteúdos_da_célula_copiados
+Copied\ cell\ contents=Conteúdos da célula copiados
 
-Copied_title=
+Copied\ title=
 
-Copied_key=Chave_BibTeX_copiada
+Copied\ key=Chave BibTeX copiada
 
-Copied_titles=
+Copied\ titles=
 
-Copied_keys=Chaves_BibTeX_copiadas
+Copied\ keys=Chaves BibTeX copiadas
 
 Copy=Copiar
 
-Copy_BibTeX_key=Copiar_chave_BibTeX
-Copy_file_to_file_directory=Copiar_arquivo_para_o_diretório_de_arquivos
+Copy\ BibTeX\ key=Copiar chave BibTeX
+Copy\ file\ to\ file\ directory=Copiar arquivo para o diretório de arquivos
 
-Copy_to_clipboard=Copiar_para_a_área_de_transferência
+Copy\ to\ clipboard=Copiar para a área de transferência
 
-Could_not_call_executable=Não_é_possível_chamar_o_executável
-Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.=Não_foi_possível_conectar_ao_servidor_Vim._Certifique-se_que_o_Vim_está_sendo_executado<br>_com_o_nome_de_servidor_correto.
+Could\ not\ call\ executable=Não é possível chamar o executável
+Could\ not\ connect\ to\ Vim\ server.\ Make\ sure\ that\ Vim\ is\ running<BR>with\ correct\ server\ name.=Não foi possível conectar ao servidor Vim. Certifique-se que o Vim está sendo executado<br> com o nome de servidor correto.
 
-Could_not_export_file=Não_foi_possível_exportar_os_arquivos
+Could\ not\ export\ file=Não foi possível exportar os arquivos
 
-Could_not_export_preferences=Não_foi_possível_exportar_as_preferências
+Could\ not\ export\ preferences=Não foi possível exportar as preferências
 
-Could_not_find_a_suitable_import_format.=Não_foi_possível_encontrar_um_formato_de_importação_compatível.
-Could_not_import_preferences=Não_foi_possível_importar_as_preferências
+Could\ not\ find\ a\ suitable\ import\ format.=Não foi possível encontrar um formato de importação compatível.
+Could\ not\ import\ preferences=Não foi possível importar as preferências
 
-Could_not_instantiate_%0=Não_foi_possível_instanciar_%0
-Could_not_instantiate_%0_%1=Não_foi_possível_instanciar_%0_%1
-Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?=Não_foi_possível_instanciar_%0._Você_escolheu_o_caminho_correto_do_pacote?
-Could_not_open_link=Não_foi_possível_abrir_o_link
+Could\ not\ instantiate\ %0=Não foi possível instanciar %0
+Could\ not\ instantiate\ %0\ %1=Não foi possível instanciar %0 %1
+Could\ not\ instantiate\ %0.\ Have\ you\ chosen\ the\ correct\ package\ path?=Não foi possível instanciar %0. Você escolheu o caminho correto do pacote?
+Could\ not\ open\ link=Não foi possível abrir o link
 
-Could_not_print_preview=Não_foi_possível_imprimir_a_previsualização
+Could\ not\ print\ preview=Não foi possível imprimir a previsualização
 
-Could_not_run_the_'vim'_program.=Não_foi_possível_executar_o_programa_'vim'.
+Could\ not\ run\ the\ 'vim'\ program.=Não foi possível executar o programa 'vim'.
 
-Could_not_save_file.=Não_foi_possível_salvar_o_arquivo.
-Character_encoding_'%0'_is_not_supported.=A_codificação_de_caracteres_'%0'_não_é_suportada.
+Could\ not\ save\ file.=Não foi possível salvar o arquivo.
+Character\ encoding\ '%0'\ is\ not\ supported.=A codificação de caracteres '%0' não é suportada.
 
-crossreferenced_entries_included=Registros_com_referências_cruzadas_incluídos
+crossreferenced\ entries\ included=Registros com referências cruzadas incluídos
 
-Current_content=Conteúdo_atual
+Current\ content=Conteúdo atual
 
-Current_value=Valor_atual
+Current\ value=Valor atual
 
-Custom_entry_types=Tipos_de_referências_personalizados
+Custom\ entry\ types=Tipos de referências personalizados
 
-Custom_entry_types_found_in_file=Tipos_de_referências_personalizadas_encontradas_no_arquivo
+Custom\ entry\ types\ found\ in\ file=Tipos de referências personalizadas encontradas no arquivo
 
-Customize_entry_types=Personalizar_tipos_de_referências
+Customize\ entry\ types=Personalizar tipos de referências
 
-Customize_key_bindings=Personalizar_combinações_de_teclas
+Customize\ key\ bindings=Personalizar combinações de teclas
 
 Cut=Recortar
 
-cut_entries=Recortar_referências
+cut\ entries=Recortar referências
 
-cut_entry=Recortar_referência
+cut\ entry=Recortar referência
 
 
-Library_encoding=Codificação_da_base_de_dados
+Library\ encoding=Codificação da base de dados
 
-Library_properties=Propriedades_da_base_de_dados
+Library\ properties=Propriedades da base de dados
 
-Library_type=
+Library\ type=
 
-Date_format=Formato_de_data
+Date\ format=Formato de data
 
 Default=Padrão
 
-Default_encoding=Codificação_padrão
+Default\ encoding=Codificação padrão
 
-Default_grouping_field=Agrupamento_de_campo_padrão
+Default\ grouping\ field=Agrupamento de campo padrão
 
-Default_look_and_feel=Aparência_padrão
+Default\ look\ and\ feel=Aparência padrão
 
-Default_pattern=Ppadrão_predefinido
+Default\ pattern=Ppadrão predefinido
 
-Default_sort_criteria=Critério_de_ordenação_padrão
-Define_'%0'=Definir_'%0'
+Default\ sort\ criteria=Critério de ordenação padrão
+Define\ '%0'=Definir '%0'
 
 Delete=Remover
 
-Delete_custom_format=Remover_formato_personalizado
+Delete\ custom\ format=Remover formato personalizado
 
-delete_entries=remover_referências
+delete\ entries=remover referências
 
-Delete_entry=Remover_referência
+Delete\ entry=Remover referência
 
-delete_entry=remover_referência
+delete\ entry=remover referência
 
-Delete_multiple_entries=Remover_múltiplos_referências
+Delete\ multiple\ entries=Remover múltiplos referências
 
-Delete_rows=Remover_linhas
+Delete\ rows=Remover linhas
 
-Delete_strings=Remover_strings
+Delete\ strings=Remover strings
 
 Deleted=Removido
 
-Permanently_delete_local_file=Remover_arquivo_local
+Permanently\ delete\ local\ file=Remover arquivo local
 
-Delimit_fields_with_semicolon,_ex.=Delimitar_campos_com_ponto_e_vírgula,_ex.
+Delimit\ fields\ with\ semicolon,\ ex.=Delimitar campos com ponto e vírgula, ex.
 
 Descending=Descendente
 
 Description=Descrição
 
-Deselect_all=Desmarcar_todos
-Deselect_all_duplicates=Desmarcar_todas_as_duplicatas
+Deselect\ all=Desmarcar todos
+Deselect\ all\ duplicates=Desmarcar todas as duplicatas
 
-Disable_this_confirmation_dialog=Desativar_este_janela_de_confirmação
+Disable\ this\ confirmation\ dialog=Desativar este janela de confirmação
 
-Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.=Exibir_todas_as_referências_pertencentes_a_um_ou_mais_grupos_selecionados.
+Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups.=Exibir todas as referências pertencentes a um ou mais grupos selecionados.
 
-Display_all_error_messages=Exibir_todas_as_mensagens_de_erro
+Display\ all\ error\ messages=Exibir todas as mensagens de erro
 
-Display_help_on_command_line_options=Exibir_ajuda_para_opções_de_linha_de_comando
+Display\ help\ on\ command\ line\ options=Exibir ajuda para opções de linha de comando
 
-Display_only_entries_belonging_to_all_selected_groups.=Exibir_apenas_referências_pertencentes_aos_grupos_selecionados.
-Display_version=Exibir_versão
+Display\ only\ entries\ belonging\ to\ all\ selected\ groups.=Exibir apenas referências pertencentes aos grupos selecionados.
+Display\ version=Exibir versão
 
-Do_not_abbreviate_names=Não_abreviar_nomes
+Do\ not\ abbreviate\ names=Não abreviar nomes
 
-Do_not_automatically_set=Não_definir_automaticamente
+Do\ not\ automatically\ set=Não definir automaticamente
 
-Do_not_import_entry=Não_importar_a_referência
+Do\ not\ import\ entry=Não importar a referência
 
-Do_not_open_any_files_at_startup=Não_abrir_arquivos_ao_iniciar
+Do\ not\ open\ any\ files\ at\ startup=Não abrir arquivos ao iniciar
 
-Do_not_overwrite_existing_keys=Não_sobrescrever_chaves_existentes
-Do_not_show_these_options_in_the_future=Não_exibir_estas_opções_no_futuro
+Do\ not\ overwrite\ existing\ keys=Não sobrescrever chaves existentes
+Do\ not\ show\ these\ options\ in\ the\ future=Não exibir estas opções no futuro
 
-Do_not_wrap_the_following_fields_when_saving=Não_agregar_os_seguintes_campos_ao_salvar
-Do_not_write_the_following_fields_to_XMP_Metadata\:=Não_escrever_os_seguintes_campos_para_metadados_XMP\:
+Do\ not\ wrap\ the\ following\ fields\ when\ saving=Não agregar os seguintes campos ao salvar
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Não escrever os seguintes campos para metadados XMP:
 
-Do_you_want_JabRef_to_do_the_following_operations?=Você_deseja_que_o_JabRef_realize_as_seguintes_operações?
+Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Você deseja que o JabRef realize as seguintes operações?
 
-Donate_to_JabRef=
+Donate\ to\ JabRef=
 
 Down=Abaixo
 
-Download_file=Download_do_arquivo
+Download\ file=Download do arquivo
 
-Downloading...=Download_em_curso...
+Downloading...=Download em curso...
 
-Drop_%0=Soltar_%0
+Drop\ %0=Soltar %0
 
-duplicate_removal=remoção_de_duplicatas
+duplicate\ removal=remoção de duplicatas
 
-Duplicate_string_name=Duplicar_nome_da_string
+Duplicate\ string\ name=Duplicar nome da string
 
-Duplicates_found=Duplicatas_encontradas
+Duplicates\ found=Duplicatas encontradas
 
-Dynamic_groups=Grupos_dinâmicos
+Dynamic\ groups=Grupos dinâmicos
 
-Dynamically_group_entries_by_a_free-form_search_expression=Agrupar_referências_dinamicamente_utilizando_uma_expressão_de_busca_em_forma_livre
+Dynamically\ group\ entries\ by\ a\ free-form\ search\ expression=Agrupar referências dinamicamente utilizando uma expressão de busca em forma livre
 
-Dynamically_group_entries_by_searching_a_field_for_a_keyword=Agrupar_referências_dinamicamente_selecionando_um_campo_ou_palavra-chave
+Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=Agrupar referências dinamicamente selecionando um campo ou palavra-chave
 
-Each_line_must_be_on_the_following_form=Cada_linha_deve_posuir_o_seguinte_formato
+Each\ line\ must\ be\ on\ the\ following\ form=Cada linha deve posuir o seguinte formato
 
 Edit=Editar
 
-Edit_custom_export=Editar_exportação_personalizada
-Edit_entry=Editar_referência
-Save_file=Editar_link_do_arquivo
-Edit_file_type=Editar_tipo_de_arquivo
+Edit\ custom\ export=Editar exportação personalizada
+Edit\ entry=Editar referência
+Save\ file=Editar link do arquivo
+Edit\ file\ type=Editar tipo de arquivo
 
-Edit_group=Editar_grupo
+Edit\ group=Editar grupo
 
 
-Edit_preamble=Editar_preâmbulo
-Edit_strings=Editar_strings
-Editor_options=Opções_do_editor
+Edit\ preamble=Editar preâmbulo
+Edit\ strings=Editar strings
+Editor\ options=Opções do editor
 
-Empty_BibTeX_key=Chave_BibTeX_vazia
+Empty\ BibTeX\ key=Chave BibTeX vazia
 
-Grouping_may_not_work_for_this_entry.=O_agrupamento_pode_não_funcionar_para_esta_referência.
+Grouping\ may\ not\ work\ for\ this\ entry.=O agrupamento pode não funcionar para esta referência.
 
-empty_library=base_de_dados_vazio
-Enable_word/name_autocompletion=Ativar_auto_completar_para_palavras/nomes
+empty\ library=base de dados vazio
+Enable\ word/name\ autocompletion=Ativar auto completar para palavras/nomes
 
-Enter_URL=Digite_a_URL
+Enter\ URL=Digite a URL
 
-Enter_URL_to_download=Digite_a_URl_para_download
+Enter\ URL\ to\ download=Digite a URl para download
 
 entries=referências
 
-Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.=As_referências_não_podem_ser_manualmente_atribuídas_ou_removidas_deste_grupo.
+Entries\ cannot\ be\ manually\ assigned\ to\ or\ removed\ from\ this\ group.=As referências não podem ser manualmente atribuídas ou removidas deste grupo.
 
-Entries_exported_to_clipboard=Referências_exportadas_para_a_área_de_transferência
+Entries\ exported\ to\ clipboard=Referências exportadas para a área de transferência
 
 
 entry=referência
 
-Entry_editor=Editor_de_referência
+Entry\ editor=Editor de referência
 
-Entry_preview=Previsualização_da_referência
+Entry\ preview=Previsualização da referência
 
-Entry_table=Tabela_de_referências
+Entry\ table=Tabela de referências
 
-Entry_table_columns=Colunas_da_tabela_de_referências
+Entry\ table\ columns=Colunas da tabela de referências
 
-Entry_type=Tipo_de_referência
+Entry\ type=Tipo de referência
 
-Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Os_nomes_dos_tipos_de_referência_não_devem_possuir_espaços_em_branco_ou_os_seguintes_caracteres
+Entry\ type\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Os nomes dos tipos de referência não devem possuir espaços em branco ou os seguintes caracteres
 
-Entry_types=Tipos_de_referência
+Entry\ types=Tipos de referência
 
 Error=Erro
-Error_exporting_to_clipboard=Erro_ao_exportar_para_a_área_de_transferência
+Error\ exporting\ to\ clipboard=Erro ao exportar para a área de transferência
 
-Error_occurred_when_parsing_entry=Ocorreu_um_erro_ao_analisar_a_referência
+Error\ occurred\ when\ parsing\ entry=Ocorreu um erro ao analisar a referência
 
-Error_opening_file=Erro_ao_abrir_o_arquivo
+Error\ opening\ file=Erro ao abrir o arquivo
 
-Error_setting_field=Erro_ao_confgurar_campo
+Error\ setting\ field=Erro ao confgurar campo
 
-Error_while_writing=Erro_durante_a_escrita
-Error_writing_to_%0_file(s).=Erro_ao_escrever_para_%0_arquivos.
+Error\ while\ writing=Erro durante a escrita
+Error\ writing\ to\ %0\ file(s).=Erro ao escrever para %0 arquivos.
 
 
 
-'%0'_exists._Overwrite_file?='%0'_existe._Sobrescrever_o_arquivo?
-Overwrite_file?=Sobrescrever_o_arquivo??
+'%0'\ exists.\ Overwrite\ file?='%0' existe. Sobrescrever o arquivo?
+Overwrite\ file?=Sobrescrever o arquivo??
 
 Export=Exportar
 
-Export_name=Exportar_nome
+Export\ name=Exportar nome
 
-Export_preferences=Exportar_preferências
+Export\ preferences=Exportar preferências
 
-Export_preferences_to_file=Exportar_preferências_do_arquivo
+Export\ preferences\ to\ file=Exportar preferências do arquivo
 
-Export_properties=Propriedades_de_exportação
+Export\ properties=Propriedades de exportação
 
-Export_to_clipboard=Exportar_para_a_área_de_transferência
+Export\ to\ clipboard=Exportar para a área de transferência
 
 Exporting=Exportando
 Extension=Extensão
 
-External_changes=Modificações_externas
+External\ changes=Modificações externas
 
-External_file_links=Links_de_arquivos_externos
+External\ file\ links=Links de arquivos externos
 
-External_programs=Programas_externos
+External\ programs=Programas externos
 
-External_viewer_called=Visualizador_externo_chamado
+External\ viewer\ called=Visualizador externo chamado
 
 Fetch=Recuperar
 
@@ -482,210 +482,210 @@ Field=Campo
 
 field=campo
 
-Field_name=Nome_do_campo
-Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters=O_nome_dos_campos_não_devem_possuir_espaços_em_branco_ou_os_seguintes_caracteres
+Field\ name=Nome do campo
+Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=O nome dos campos não devem possuir espaços em branco ou os seguintes caracteres
 
-Field_to_filter=Campos_a_serem_filtrados
+Field\ to\ filter=Campos a serem filtrados
 
-Field_to_group_by=Campos_como_critério_de_agrupamento
+Field\ to\ group\ by=Campos como critério de agrupamento
 
 File=Arquivo
 
 file=arquivo
-File_'%0'_is_already_open.=O_arquivo_'%0'_já_está_aberto.
+File\ '%0'\ is\ already\ open.=O arquivo '%0' já está aberto.
 
-File_changed=Arquivo_modificado
-File_directory_is_'%0'\:=O_diretório_do_arquivo_é_'%0'\:
+File\ changed=Arquivo modificado
+File\ directory\ is\ '%0'\:=O diretório do arquivo é '%0':
 
-File_directory_is_not_set_or_does_not_exist\!=O_diretório_do_arquivo_não_foi_condiguração_ou_não_existe\!
+File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=O diretório do arquivo não foi condiguração ou não existe!
 
-File_exists=O_arquivo_existe
+File\ exists=O arquivo existe
 
-File_has_been_updated_externally._What_do_you_want_to_do?=O_arquivo_foi_atualizado_externamente._O_que_você_deseja_fazer?
+File\ has\ been\ updated\ externally.\ What\ do\ you\ want\ to\ do?=O arquivo foi atualizado externamente. O que você deseja fazer?
 
-File_not_found=Arquivo_não_encontrado
-File_type=Tipo_de_arquivo
+File\ not\ found=Arquivo não encontrado
+File\ type=Tipo de arquivo
 
-File_updated_externally=Arquivo_atualizado_externamente
+File\ updated\ externally=Arquivo atualizado externamente
 
-filename=nome_do_arquivo
+filename=nome do arquivo
 
 Filename=
 
-Files_opened=Arquivos_abertos
+Files\ opened=Arquivos abertos
 
 Filter=Filtro
 
-Filter_All=
+Filter\ All=
 
-Filter_None=
+Filter\ None=
 
-Finished_automatically_setting_external_links.=A_definição_automática_de_links_externos_foi_finalizada.
+Finished\ automatically\ setting\ external\ links.=A definição automática de links externos foi finalizada.
 
-Finished_synchronizing_file_links._Entries_changed\:_%0.=A_sincronização_de_arquivo_links_foi_finalizada._Referências_modificadas\:_%0.
-Finished_writing_XMP-metadata._Wrote_to_%0_file(s).=A_escrita_de_metadados_XMP_terminou._Escrita_realizada_para_%0_arquivo(s).
-Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).=A_escrita_de_metadados_XMP_para_o_arquivo_%0_terminou_(%1_ignorado,_%2_erros).
+Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=A sincronização de arquivo links foi finalizada. Referências modificadas: %0.
+Finished\ writing\ XMP-metadata.\ Wrote\ to\ %0\ file(s).=A escrita de metadados XMP terminou. Escrita realizada para %0 arquivo(s).
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=A escrita de metadados XMP para o arquivo %0 terminou (%1 ignorado, %2 erros).
 
-First_select_the_entries_you_want_keys_to_be_generated_for.=Primeiro_selecione_as_referências_para_as_quais_você_deseja_ter_chaves_geradas.
+First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Primeiro selecione as referências para as quais você deseja ter chaves geradas.
 
-Fit_table_horizontally_on_screen=Ajustar_tabela_horizontalmente_na_tela
+Fit\ table\ horizontally\ on\ screen=Ajustar tabela horizontalmente na tela
 
-Float=Manter_no_topo
-Float_marked_entries=Flutuar_referências_marcadas
+Float=Manter no topo
+Float\ marked\ entries=Flutuar referências marcadas
 
-Font_family=Família_da_fonte
+Font\ family=Família da fonte
 
-Font_preview=Previsualização_da_fonte
+Font\ preview=Previsualização da fonte
 
-Font_size=Tamanho_da_fonte
+Font\ size=Tamanho da fonte
 
-Font_style=Estilo_de_fonte
+Font\ style=Estilo de fonte
 
-Font_selection=Font_selection
+Font\ selection=Font selection
 
 for=para
 
-Format_of_author_and_editor_names=Formato_dos_nomes_do_autor_e_editor
-Format_string=Formato_de_string
+Format\ of\ author\ and\ editor\ names=Formato dos nomes do autor e editor
+Format\ string=Formato de string
 
-Format_used=Formato_utilizado
-Formatter_name=Nome_do_formatador
+Format\ used=Formato utilizado
+Formatter\ name=Nome do formatador
 
-found_in_AUX_file=encontrado_em_arquivo_AUX
+found\ in\ AUX\ file=encontrado em arquivo AUX
 
-Full_name=Nome_completo
+Full\ name=Nome completo
 
 General=Geral
 
-General_fields=Campos_gerais
+General\ fields=Campos gerais
 
 Generate=Gerar
 
-Generate_BibTeX_key=Gerar_chave_BibTeX
+Generate\ BibTeX\ key=Gerar chave BibTeX
 
-Generate_keys=Gerar_chaves
+Generate\ keys=Gerar chaves
 
-Generate_keys_before_saving_(for_entries_without_a_key)=Gerar_chaves_antes_de_salvar
-Generate_keys_for_imported_entries=Gerar_chaves_para_referências_importadas
+Generate\ keys\ before\ saving\ (for\ entries\ without\ a\ key)=Gerar chaves antes de salvar
+Generate\ keys\ for\ imported\ entries=Gerar chaves para referências importadas
 
-Generate_now=Gerar_agora
+Generate\ now=Gerar agora
 
-Generated_BibTeX_key_for=Chave_BibTeX_gerada_para
+Generated\ BibTeX\ key\ for=Chave BibTeX gerada para
 
-Generating_BibTeX_key_for=Gerando_chave_BibTeX_para
-Get_fulltext=
+Generating\ BibTeX\ key\ for=Gerando chave BibTeX para
+Get\ fulltext=
 
-Gray_out_non-hits=Esmaecer_referências_não_encontradas
+Gray\ out\ non-hits=Esmaecer referências não encontradas
 
 Groups=Grupos
 
-Have_you_chosen_the_correct_package_path?=Você_escolheu_o_caminho_de_pacote_correto?
+Have\ you\ chosen\ the\ correct\ package\ path?=Você escolheu o caminho de pacote correto?
 
 Help=Ajuda
 
-Help_on_key_patterns=Ajuda_sobre_modelos_de_chave
-Help_on_regular_expression_search=Ajuda_sobre_busca_por_expressão_regular
+Help\ on\ key\ patterns=Ajuda sobre modelos de chave
+Help\ on\ regular\ expression\ search=Ajuda sobre busca por expressão regular
 
-Hide_non-hits=Ocultar_referências_não_encontradas
+Hide\ non-hits=Ocultar referências não encontradas
 
-Hierarchical_context=Contexo_hierárquico
+Hierarchical\ context=Contexo hierárquico
 
 Highlight=Destacar
 Marking=
 Underline=
-Empty_Highlight=
-Empty_Marking=
-Empty_Underline=
-The_marked_area_does_not_contain_any_legible_text!=
+Empty\ Highlight=
+Empty\ Marking=
+Empty\ Underline=
+The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=
 
-Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>=Dica\:_Para_procurar_apenas_campos_específicos,_digite_por_exemplo\:<p><tt>author\=smith_and_title\=electrical</tt>
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Dica: Para procurar apenas campos específicos, digite por exemplo:<p><tt>author=smith and title=electrical</tt>
 
-HTML_table=Tabela_HTML
-HTML_table_(with_Abstract_&_BibTeX)=Tabela_HTML_(_com_resumo_(abstract)_&_BibTeX)
+HTML\ table=Tabela HTML
+HTML\ table\ (with\ Abstract\ &\ BibTeX)=Tabela HTML ( com resumo (abstract) & BibTeX)
 Icon=Ícone
 
 Ignore=Ignorar
 
 Import=Importar
 
-Import_and_keep_old_entry=Importar_e_manter_referências_antigas
+Import\ and\ keep\ old\ entry=Importar e manter referências antigas
 
-Import_and_remove_old_entry=Importar_e_remover_referências_antigas
+Import\ and\ remove\ old\ entry=Importar e remover referências antigas
 
-Import_entries=Importar_referências
+Import\ entries=Importar referências
 
-Import_failed=A_importação_falhou
+Import\ failed=A importação falhou
 
-Import_file=Importar_arquivo
+Import\ file=Importar arquivo
 
-Import_group_definitions=Importar_definições_de_grupo
+Import\ group\ definitions=Importar definições de grupo
 
-Import_name=Importar_o_nome
+Import\ name=Importar o nome
 
-Import_preferences=Importar_preferências
+Import\ preferences=Importar preferências
 
-Import_preferences_from_file=Importar_preferências_a_partir_de_um_arquivo
+Import\ preferences\ from\ file=Importar preferências a partir de um arquivo
 
-Import_strings=Importar_strings
+Import\ strings=Importar strings
 
-Import_to_open_tab=Importar_para_abrir_aba
+Import\ to\ open\ tab=Importar para abrir aba
 
-Import_word_selector_definitions=Importar_definições_de_seleção_de_palavra
+Import\ word\ selector\ definitions=Importar definições de seleção de palavra
 
-Imported_entries=Referências_importadas
+Imported\ entries=Referências importadas
 
-Imported_from_library=Importado_a_partir_da_base_de_dados
+Imported\ from\ library=Importado a partir da base de dados
 
-Importer_class=Classe_Importer
+Importer\ class=Classe Importer
 
 Importing=Importando
 
-Importing_in_unknown_format=Importando_em_formato_desconhecido
+Importing\ in\ unknown\ format=Importando em formato desconhecido
 
-Include_abstracts=Incluir_resumos
-Include_entries=Incluir_referências
+Include\ abstracts=Incluir resumos
+Include\ entries=Incluir referências
 
-Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups=Incluir_subgrupos\:_Quando_selecionado,_visualizar_referências_contidas_neste_grupo_ou_em_seus_subgrupos
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=Incluir subgrupos: Quando selecionado, visualizar referências contidas neste grupo ou em seus subgrupos
 
-Independent_group\:_When_selected,_view_only_this_group's_entries=Grupo_independente\:_Quando_selecionado,_mostra_apenas_as_referências_deste_grupo
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=Grupo independente: Quando selecionado, mostra apenas as referências deste grupo
 
-Work_options=Atribuição_do_campo
+Work\ options=Atribuição do campo
 
 Insert=Inserir
 
-Insert_rows=Inseir_linhas
+Insert\ rows=Inseir linhas
 
 Intersection=Interseção
 
-Invalid_BibTeX_key=Chave_BibTeX_inválida
+Invalid\ BibTeX\ key=Chave BibTeX inválida
 
-Invalid_date_format=Formato_de_data_inválido
+Invalid\ date\ format=Formato de data inválido
 
-Invalid_URL=URL_inválida
+Invalid\ URL=URL inválida
 
-Online_help=
+Online\ help=
 
-JabRef_preferences=Preferências_do_JabRef
+JabRef\ preferences=Preferências do JabRef
 
 Join=
 
-Joins_selected_keywords_and_deletes_selected_keywords.=
+Joins\ selected\ keywords\ and\ deletes\ selected\ keywords.=
 
-Journal_abbreviations=Abreviações_de_periódico
+Journal\ abbreviations=Abreviações de periódico
 
 Keep=Manter
 
-Keep_both=Manter_ambos
+Keep\ both=Manter ambos
 
-Key_bindings=Combinações_de_tecla
+Key\ bindings=Combinações de tecla
 
-Key_bindings_changed=Combinações_de_teclas_modificadas
+Key\ bindings\ changed=Combinações de teclas modificadas
 
-Key_generator_settings=Configurações_do_gerador_de_chaves
+Key\ generator\ settings=Configurações do gerador de chaves
 
-Key_pattern=Padrão_de_chave
+Key\ pattern=Padrão de chave
 
-keys_in_library=chaves_na_base_de_dados
+keys\ in\ library=chaves na base de dados
 
 Keyword=Palavra-chave
 
@@ -693,449 +693,449 @@ Label=Rótulo
 
 Language=Idioma
 
-Last_modified=Última_modificação
+Last\ modified=Última modificação
 
-LaTeX_AUX_file=Arquivo_LaTeX_AUX
-Leave_file_in_its_current_directory=Manter_arquivos_em_seu_diretório_atual
+LaTeX\ AUX\ file=Arquivo LaTeX AUX
+Leave\ file\ in\ its\ current\ directory=Manter arquivos em seu diretório atual
 
 Left=Esquerdo(a)
 Level=
 
-Limit_to_fields=Limitar_aos_campos
+Limit\ to\ fields=Limitar aos campos
 
-Limit_to_selected_entries=Limitar_às_referência_selecionadas
+Limit\ to\ selected\ entries=Limitar às referência selecionadas
 
 Link=Linkar
-Link_local_file=Link_arquivo_local
-Link_to_file_%0=Link_para_o_arquivo_%0
+Link\ local\ file=Link arquivo local
+Link\ to\ file\ %0=Link para o arquivo %0
 
-Listen_for_remote_operation_on_port=Escutar_operações_remotas_na_porta
-Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)=Carregar_e_salvar_preferências_a_partir_de/para_jabref.xml_ao_iniciar_(modo_cartão_de_memória)
+Listen\ for\ remote\ operation\ on\ port=Escutar operações remotas na porta
+Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=Carregar e salvar preferências a partir de/para jabref.xml ao iniciar (modo cartão de memória)
 
-Look_and_feel=Aparência
-Main_file_directory=Diretório_de_arquivos_principal
+Look\ and\ feel=Aparência
+Main\ file\ directory=Diretório de arquivos principal
 
-Main_layout_file=Arquivo_de_leiaute_principal
+Main\ layout\ file=Arquivo de leiaute principal
 
-Manage_custom_exports=Gerenciar_exportações_personalizadas
+Manage\ custom\ exports=Gerenciar exportações personalizadas
 
-Manage_custom_imports=Gerenciar_importações_personalizadas
-Manage_external_file_types=Gerenciar_tipos_de_arquivo_externos
+Manage\ custom\ imports=Gerenciar importações personalizadas
+Manage\ external\ file\ types=Gerenciar tipos de arquivo externos
 
-Mark_entries=Marcar_referências
+Mark\ entries=Marcar referências
 
-Mark_entry=Marcar_referências
+Mark\ entry=Marcar referências
 
-Mark_new_entries_with_addition_date=Marcar_novas_referências_com_a_data_de_criação
+Mark\ new\ entries\ with\ addition\ date=Marcar novas referências com a data de criação
 
-Mark_new_entries_with_owner_name=Marcar_novas_referências_com_o_nome_do_usuário
+Mark\ new\ entries\ with\ owner\ name=Marcar novas referências com o nome do usuário
 
-Memory_stick_mode=Modo_cartão_de_memória
+Memory\ stick\ mode=Modo cartão de memória
 
-Menu_and_label_font_size=Tamanho_da_fonte_do_menu_e_dos_rótulo
+Menu\ and\ label\ font\ size=Tamanho da fonte do menu e dos rótulo
 
-Merged_external_changes=Mudanças_externas_mescladas
+Merged\ external\ changes=Mudanças externas mescladas
 
 Messages=Mensagens
 
-Modification_of_field=Modificação_do_campo
+Modification\ of\ field=Modificação do campo
 
-Modified_group_"%0".=Grupo_"%0"_modificado
+Modified\ group\ "%0".=Grupo "%0" modificado
 
-Modified_groups=Grupos_modificados
+Modified\ groups=Grupos modificados
 
-Modified_string=String_modificada
+Modified\ string=String modificada
 
 Modify=Modificar
 
-modify_group=Modificar_grupo
+modify\ group=Modificar grupo
 
-Move_down=Mover_para_baixo
+Move\ down=Mover para baixo
 
-Move_external_links_to_'file'_field=Mover_links_externos_para_o_campo_'arquivo'
+Move\ external\ links\ to\ 'file'\ field=Mover links externos para o campo 'arquivo'
 
-move_group=mover_grupo
+move\ group=mover grupo
 
-Move_up=Mover_para_cima
+Move\ up=Mover para cima
 
-Moved_group_"%0".=Grupo_"%0"_movido
+Moved\ group\ "%0".=Grupo "%0" movido
 
 Name=Nome
-Name_formatter=Formatador_de_nomes
+Name\ formatter=Formatador de nomes
 
-Natbib_style=Estilo_Natbib
+Natbib\ style=Estilo Natbib
 
-nested_AUX_files=arquivos_AUXiliares_aninhados
+nested\ AUX\ files=arquivos AUXiliares aninhados
 
 New=Novo
 
 new=novo
 
-New_BibTeX_entry=Nova_referência_BibTeX
+New\ BibTeX\ entry=Nova referência BibTeX
 
-New_BibTeX_sublibrary=Nova_sub-base_de_dados_BibTeX
+New\ BibTeX\ sublibrary=Nova sub-base de dados BibTeX
 
-New_content=Novo_conteúdo
+New\ content=Novo conteúdo
 
-New_library_created.=Nova_base_de_dados_criada
-New_%0_library=%0_novas_bases_de_dados
-New_field_value=Novo_valor_de_campo
+New\ library\ created.=Nova base de dados criada
+New\ %0\ library=%0 novas bases de dados
+New\ field\ value=Novo valor de campo
 
-New_group=Novo_grupo
+New\ group=Novo grupo
 
-New_string=Nova_string
+New\ string=Nova string
 
-Next_entry=Próxima_referência
+Next\ entry=Próxima referência
 
-No_actual_changes_found.=Nenhuma_mudança_atual_encontrada.
+No\ actual\ changes\ found.=Nenhuma mudança atual encontrada.
 
-no_base-BibTeX-file_specified=nenhum_arquivo_BibTeX_de_base_especificado
+no\ base-BibTeX-file\ specified=nenhum arquivo BibTeX de base especificado
 
-no_library_generated=Nenhuma_base_de_dados_gerada
+no\ library\ generated=Nenhuma base de dados gerada
 
-No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.=Nenhuma_referência_encontrada._Por_favor,_certifique-se_que_você_está_utilizando_o_filtro_de_importação_correto.
+No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=Nenhuma referência encontrada. Por favor, certifique-se que você está utilizando o filtro de importação correto.
 
 
-No_entries_found_for_the_search_string_'%0'=Nenhuma_referência_encontrada_para_a_string_pesquisada_'%0'
+No\ entries\ found\ for\ the\ search\ string\ '%0'=Nenhuma referência encontrada para a string pesquisada '%0'
 
-No_entries_imported.=Nenhuma_referência_importada.
+No\ entries\ imported.=Nenhuma referência importada.
 
-No_files_found.=Nenhum_arquivo_encontrado.
+No\ files\ found.=Nenhum arquivo encontrado.
 
-No_GUI._Only_process_command_line_options.=Nenhuma_interface_gráfica._Apenas_processar_opções_de_comandos_de_linha.
+No\ GUI.\ Only\ process\ command\ line\ options.=Nenhuma interface gráfica. Apenas processar opções de comandos de linha.
 
-No_journal_names_could_be_abbreviated.=Nenhum_nome_de_periódico_pôde_ser_abreviado.
+No\ journal\ names\ could\ be\ abbreviated.=Nenhum nome de periódico pôde ser abreviado.
 
-No_journal_names_could_be_unabbreviated.=Nenhum_nome_de_periódico_pôde_ser_desabreviado.
-No_PDF_linked=Nenhum_PDF_linkado
+No\ journal\ names\ could\ be\ unabbreviated.=Nenhum nome de periódico pôde ser desabreviado.
+No\ PDF\ linked=Nenhum PDF linkado
 
-Open_PDF=
+Open\ PDF=
 
-No_URL_defined=Nenhuma_URL_definida
+No\ URL\ defined=Nenhuma URL definida
 not=não
 
-not_found=não_encontrado
+not\ found=não encontrado
 
-Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,=Note_que_você_deve_especificar_completamente_o_nome_de_classe_da_aparência,
+Note\ that\ you\ must\ specify\ the\ fully\ qualified\ class\ name\ for\ the\ look\ and\ feel,=Note que você deve especificar completamente o nome de classe da aparência,
 
-Nothing_to_redo=Nada_para_refazer
+Nothing\ to\ redo=Nada para refazer
 
-Nothing_to_undo=Nada_para_desfazer
+Nothing\ to\ undo=Nada para desfazer
 
 occurrences=ocorrências
 
 OK=Ok
-One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Um_ou_mais_links_de_arquivos_são_do_tipo_'%0',_que_não_está_definido._O_que_você_deseja_fazer?
+One\ or\ more\ file\ links\ are\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Um ou mais links de arquivos são do tipo '%0', que não está definido. O que você deseja fazer?
 
-One_or_more_keys_will_be_overwritten._Continue?=Uma_ou_mais_chaves_serão_sobrescritas._Continuar?
+One\ or\ more\ keys\ will\ be\ overwritten.\ Continue?=Uma ou mais chaves serão sobrescritas. Continuar?
 
 
 Open=Abrir
 
-Open_BibTeX_library=Abrir_base_de_dados_BibTeX
+Open\ BibTeX\ library=Abrir base de dados BibTeX
 
-Open_library=Abrir_base_de_dados
+Open\ library=Abrir base de dados
 
-Open_editor_when_a_new_entry_is_created=Abrir_o_editor_quando_uma_nova_referência_é_criada
+Open\ editor\ when\ a\ new\ entry\ is\ created=Abrir o editor quando uma nova referência é criada
 
-Open_file=Abrir_arquivo
+Open\ file=Abrir arquivo
 
-Open_last_edited_libraries_at_startup=Abrir_as_últimas_base_de_dados_editadas_ao_iniciar
+Open\ last\ edited\ libraries\ at\ startup=Abrir as últimas base de dados editadas ao iniciar
 
-Connect_to_shared_database=
+Connect\ to\ shared\ database=
 
-Open_terminal_here=
+Open\ terminal\ here=
 
-Open_URL_or_DOI=Abrir_URL_ou_DOI
+Open\ URL\ or\ DOI=Abrir URL ou DOI
 
-Opened_library=Base_de_dados_aberta
+Opened\ library=Base de dados aberta
 
 Opening=Abrindo
 
-Opening_preferences...=Abrindo_preferências
+Opening\ preferences...=Abrindo preferências
 
-Operation_canceled.=Operação_cancelada.
-Operation_not_supported=Operação_não_suportada
+Operation\ canceled.=Operação cancelada.
+Operation\ not\ supported=Operação não suportada
 
-Optional_fields=Campos_opcionais
+Optional\ fields=Campos opcionais
 
 Options=Opções
 
 or=ou
 
-Output_or_export_file=Saída_ou_arquivo_de_exportação
+Output\ or\ export\ file=Saída ou arquivo de exportação
 
 Override=Substituir
 
-Override_default_file_directories=Substituir_os_diretórios_de_arquivo_padrão
+Override\ default\ file\ directories=Substituir os diretórios de arquivo padrão
 
-Override_default_font_settings=Substituir_configurações_de_fonte_padrão
+Override\ default\ font\ settings=Substituir configurações de fonte padrão
 
-Override_the_BibTeX_field_by_the_selected_text=Substituir_a_chave_BibTeX_pelo_texto_selecionado
+Override\ the\ BibTeX\ field\ by\ the\ selected\ text=Substituir a chave BibTeX pelo texto selecionado
 
 
 Overwrite=Sobrescrever
-Overwrite_existing_field_values=Sobrescrever_valores_de_campo_existentes
+Overwrite\ existing\ field\ values=Sobrescrever valores de campo existentes
 
-Overwrite_keys=Sobrescrever_chaves
+Overwrite\ keys=Sobrescrever chaves
 
-pairs_processed=pares_processados
+pairs\ processed=pares processados
 Password=Senha
 
 Paste=Colar
 
-paste_entries=colar_referências
+paste\ entries=colar referências
 
-paste_entry=colar_referência
-Paste_from_clipboard=Colar_a_partir_da_área_de_transferência
+paste\ entry=colar referência
+Paste\ from\ clipboard=Colar a partir da área de transferência
 
 Pasted=Colado
 
-Path_to_%0_not_defined=Caminho_para_%0_não_definido
+Path\ to\ %0\ not\ defined=Caminho para %0 não definido
 
-Path_to_LyX_pipe=Caminho_para_o_canal_de_transmissão_LyX
+Path\ to\ LyX\ pipe=Caminho para o canal de transmissão LyX
 
-PDF_does_not_exist=O_PDF_não_existe
+PDF\ does\ not\ exist=O PDF não existe
 
-File_has_no_attached_annotations=
+File\ has\ no\ attached\ annotations=
 
-Plain_text_import=Importação_de_texto_puro
+Plain\ text\ import=Importação de texto puro
 
-Please_enter_a_name_for_the_group.=Por_favor,_digite_um_nome_para_o_grupo.
+Please\ enter\ a\ name\ for\ the\ group.=Por favor, digite um nome para o grupo.
 
-Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>=Por_favor_digite_um_termo_de_pesquisa._Por_exemplo,_para_pesquisar_todos_os_campos_por_<b>Smith</b>,_digite_\:<p><tt>smith</tt><p>Para_pesquisar_no_campo_<b>Author</b>_por_<b>Smith</b>_e_no_campo_<b>Title</b>_por_<b>electrical</b>,_digite\:<p><tt>author\=smith_and_title\=electrical</tt>
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Por favor digite um termo de pesquisa. Por exemplo, para pesquisar todos os campos por <b>Smith</b>, digite :<p><tt>smith</tt><p>Para pesquisar no campo <b>Author</b> por <b>Smith</b> e no campo <b>Title</b> por <b>electrical</b>, digite:<p><tt>author=smith and title=electrical</tt>
 
-Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=Por_favor,_digite_o_campo_a_ser_pesquisado_(e.g._<b>palavras-chave</b>)_e_a_palavra-chave_de_pesquisa_(e.g._<b>elétrico</b>).
+Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=Por favor, digite o campo a ser pesquisado (e.g. <b>palavras-chave</b>) e a palavra-chave de pesquisa (e.g. <b>elétrico</b>).
 
-Please_enter_the_string's_label=Por_favor,_digite_o_rótulo_da_string
+Please\ enter\ the\ string's\ label=Por favor, digite o rótulo da string
 
-Please_select_an_importer.=Por_favor,_selecione_um_importador.
+Please\ select\ an\ importer.=Por favor, selecione um importador.
 
-Possible_duplicate_entries=Possíveis_referências_duplicadas
+Possible\ duplicate\ entries=Possíveis referências duplicadas
 
-Possible_duplicate_of_existing_entry._Click_to_resolve.=Possível_duplicata_de_referência_existente._Clique_para_resolver.
+Possible\ duplicate\ of\ existing\ entry.\ Click\ to\ resolve.=Possível duplicata de referência existente. Clique para resolver.
 
 Preamble=Preâmbulo
 
 Preferences=Preferências
 
-Preferences_recorded.=Preferências_salvas.
+Preferences\ recorded.=Preferências salvas.
 
 Preview=Previsualização
-Citation_Style=
-Current_Preview=
-Cannot_generate_preview_based_on_selected_citation_style.=
-Bad_character_inside_entry=
-Error_while_generating_citation_style=
-Preview_style_changed_to\:_%0=
-Next_preview_layout=
-Previous_preview_layout=
+Citation\ Style=
+Current\ Preview=
+Cannot\ generate\ preview\ based\ on\ selected\ citation\ style.=
+Bad\ character\ inside\ entry=
+Error\ while\ generating\ citation\ style=
+Preview\ style\ changed\ to\:\ %0=
+Next\ preview\ layout=
+Previous\ preview\ layout=
 
-Previous_entry=Referência_anterior
+Previous\ entry=Referência anterior
 
-Primary_sort_criterion=Critério_de_ordenação_primário
-Problem_with_parsing_entry=Problema_ao_analisar_a_referência
-Processing_%0=Processando_%0
-Pull_changes_from_shared_database=
+Primary\ sort\ criterion=Critério de ordenação primário
+Problem\ with\ parsing\ entry=Problema ao analisar a referência
+Processing\ %0=Processando %0
+Pull\ changes\ from\ shared\ database=
 
-Pushed_citations_to_%0=Citações_enviadas_para_%0
+Pushed\ citations\ to\ %0=Citações enviadas para %0
 
-Quit_JabRef=Sair_do_JabRef
+Quit\ JabRef=Sair do JabRef
 
-Quit_synchronization=Sair_da_sincronização
+Quit\ synchronization=Sair da sincronização
 
-Raw_source=Fonte_primária
+Raw\ source=Fonte primária
 
-Rearrange_tabs_alphabetically_by_title=Rearranjar_abas_alfabeticamente_por_título
+Rearrange\ tabs\ alphabetically\ by\ title=Rearranjar abas alfabeticamente por título
 
 Redo=Refazer
 
-Reference_library=Base_de_dados_de_referência
+Reference\ library=Base de dados de referência
 
-%0_references_found._Number_of_references_to_fetch?=Referências_encontradas\:_%0._Números_de_referências_para_recuperar?
+%0\ references\ found.\ Number\ of\ references\ to\ fetch?=Referências encontradas: %0. Números de referências para recuperar?
 
-Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Refinar_supergrupo\:_Quando_selecionado,_visualiza_referências_contidas_em_ambos_os_grupos_e_seu_supergrupo.
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=Refinar supergrupo: Quando selecionado, visualiza referências contidas em ambos os grupos e seu supergrupo.
 
-regular_expression=Expressão_regular
+regular\ expression=Expressão regular
 
-Related_articles=
+Related\ articles=
 
-Remote_operation=Operação_remota
+Remote\ operation=Operação remota
 
-Remote_server_port=Remover_porta_do_servidor
+Remote\ server\ port=Remover porta do servidor
 
 Remove=Remover
 
-Remove_subgroups=Remover_todos_os_subgrupos
+Remove\ subgroups=Remover todos os subgrupos
 
-Remove_all_subgroups_of_"%0"?=Remover_todos_os_subgrupos_de_"%0"?
+Remove\ all\ subgroups\ of\ "%0"?=Remover todos os subgrupos de "%0"?
 
-Remove_entry_from_import=Remover_referência_da_importação
+Remove\ entry\ from\ import=Remover referência da importação
 
-Remove_selected_entries_from_this_group=
+Remove\ selected\ entries\ from\ this\ group=
 
-Remove_entry_type=remover_tipo_de_referência
+Remove\ entry\ type=remover tipo de referência
 
-Remove_from_group=Remover_do_grupo
+Remove\ from\ group=Remover do grupo
 
-Remove_group=Remover_grupo
+Remove\ group=Remover grupo
 
-Remove_group,_keep_subgroups=Remover_grupo,_manter_subgrupos
+Remove\ group,\ keep\ subgroups=Remover grupo, manter subgrupos
 
-Remove_group_"%0"?=Remover_grupo_"%0"?
+Remove\ group\ "%0"?=Remover grupo "%0"?
 
-Remove_group_"%0"_and_its_subgroups?=Remover_grupo_"%0"_e_seus_subgrupos?
+Remove\ group\ "%0"\ and\ its\ subgroups?=Remover grupo "%0" e seus subgrupos?
 
-remove_group_(keep_subgroups)=remover_grupo_(manter_subgrupos)
+remove\ group\ (keep\ subgroups)=remover grupo (manter subgrupos)
 
-remove_group_and_subgroups=remover_grupos_e_subgrupos
+remove\ group\ and\ subgroups=remover grupos e subgrupos
 
-Remove_group_and_subgroups=Remover_grupos_e_subgrupos
+Remove\ group\ and\ subgroups=Remover grupos e subgrupos
 
-Remove_link=Remover_link
+Remove\ link=Remover link
 
-Remove_old_entry=Remover_referência_antiga
+Remove\ old\ entry=Remover referência antiga
 
-Remove_selected_strings=Remover_string_selecionadas
+Remove\ selected\ strings=Remover string selecionadas
 
-Removed_group_"%0".=Grupo_"%0"_removido.
+Removed\ group\ "%0".=Grupo "%0" removido.
 
-Removed_group_"%0"_and_its_subgroups.=Grupo_"%0"_e_seus_subgrupos_removidos.
+Removed\ group\ "%0"\ and\ its\ subgroups.=Grupo "%0" e seus subgrupos removidos.
 
-Removed_string=String_removida
+Removed\ string=String removida
 
-Renamed_string=String_renomeada
+Renamed\ string=String renomeada
 
 Replace=
 
-Replace_(regular_expression)=Substituir_(expressão_regular)
+Replace\ (regular\ expression)=Substituir (expressão regular)
 
-Replace_string=Substituir_string
+Replace\ string=Substituir string
 
-Replace_with=Substituir_por
+Replace\ with=Substituir por
 
 Replaced=Substituído
 
-Required_fields=Campos_obrigatórios
+Required\ fields=Campos obrigatórios
 
-Reset_all=Resetar_todos
+Reset\ all=Resetar todos
 
-Resolve_strings_for_all_fields_except=Resolver_strings_para_todos_os_campos_exceto
-Resolve_strings_for_standard_BibTeX_fields_only=Resolver_strings_apenas_para_campos_BibTeX_padrões
+Resolve\ strings\ for\ all\ fields\ except=Resolver strings para todos os campos exceto
+Resolve\ strings\ for\ standard\ BibTeX\ fields\ only=Resolver strings apenas para campos BibTeX padrões
 
 resolved=resolvido
 
 Review=Revisar
 
-Review_changes=Revisar_mudanças
+Review\ changes=Revisar mudanças
 
 Right=Direito
 
 Save=Salvar
-Save_all_finished.=Salvar_todos_os_concluídos.
+Save\ all\ finished.=Salvar todos os concluídos.
 
-Save_all_open_libraries=Salvar_todas_as_preferências
+Save\ all\ open\ libraries=Salvar todas as preferências
 
-Save_before_closing=Salvar_antes_de_fechar
+Save\ before\ closing=Salvar antes de fechar
 
-Save_library=Salvar_base_de_dados
-Save_library_as...=Salvar_base_de_dados_como...
+Save\ library=Salvar base de dados
+Save\ library\ as...=Salvar base de dados como...
 
-Save_entries_in_their_original_order=Referências_salvas_em_sua_ordem_original
+Save\ entries\ in\ their\ original\ order=Referências salvas em sua ordem original
 
-Save_failed=Falha_ao_salvar
+Save\ failed=Falha ao salvar
 
-Save_failed_during_backup_creation=Falha_ao_salvar_durante_a_criação_do_backup
+Save\ failed\ during\ backup\ creation=Falha ao salvar durante a criação do backup
 
-Save_selected_as...=Salvar_selecionados_como...
+Save\ selected\ as...=Salvar selecionados como...
 
-Saved_library=Base_de_dados_salva
+Saved\ library=Base de dados salva
 
-Saved_selected_to_'%0'.=Seleção_salva_para_'%0'.
+Saved\ selected\ to\ '%0'.=Seleção salva para '%0'.
 
 Saving=Salvando...
-Saving_all_libraries...=Salvando_todas_as_bases_de_dados...
+Saving\ all\ libraries...=Salvando todas as bases de dados...
 
-Saving_library=Salvando_base_de_dados...
+Saving\ library=Salvando base de dados...
 
 Search=Pesquisar
 
-Search_expression=Pesquisar_expressão
+Search\ expression=Pesquisar expressão
 
-Search_for=Pesquisar_por
+Search\ for=Pesquisar por
 
-Searching_for_duplicates...=Procurando_por_duplicatas...
+Searching\ for\ duplicates...=Procurando por duplicatas...
 
-Searching_for_files=Procurando_por_arquivos...
+Searching\ for\ files=Procurando por arquivos...
 
-Secondary_sort_criterion=Critério_de_ordenação_secundário
+Secondary\ sort\ criterion=Critério de ordenação secundário
 
-Select_all=Selecionar_tudo
+Select\ all=Selecionar tudo
 
-Select_encoding=Selecionar_codificação
+Select\ encoding=Selecionar codificação
 
-Select_entry_type=Selecionar_tipo_de_referência
-Select_external_application=Selecionar_aplicação_externa
+Select\ entry\ type=Selecionar tipo de referência
+Select\ external\ application=Selecionar aplicação externa
 
-Select_file_from_ZIP-archive=Selecionar_arquivo_a_partir_de_um_arquivo_ZIP
+Select\ file\ from\ ZIP-archive=Selecionar arquivo a partir de um arquivo ZIP
 
-Select_the_tree_nodes_to_view_and_accept_or_reject_changes=Selecione_os_nós_da_árvore_para_visualizar_e_aceitar_ou_rejeitar_mudanças
-Selected_entries=Referências_selecionadas
-Set_field=Configurar_campo
-Set_fields=Configurar_campos
+Select\ the\ tree\ nodes\ to\ view\ and\ accept\ or\ reject\ changes=Selecione os nós da árvore para visualizar e aceitar ou rejeitar mudanças
+Selected\ entries=Referências selecionadas
+Set\ field=Configurar campo
+Set\ fields=Configurar campos
 
-Set_general_fields=Definir_campos_gerais
-Set_main_external_file_directory=Definir_diretório_principal_de_arquivo_externo
+Set\ general\ fields=Definir campos gerais
+Set\ main\ external\ file\ directory=Definir diretório principal de arquivo externo
 
-Set_table_font=Definir_fonte_da_tabela
+Set\ table\ font=Definir fonte da tabela
 
 Settings=Configurações
 
 Shortcut=Atalho
 
-Show/edit_%0_source=Exibir/editar_fonte_%0
+Show/edit\ %0\ source=Exibir/editar fonte %0
 
-Show_'Firstname_Lastname'=Exibir_'Nome,_Sobrenome'
+Show\ 'Firstname\ Lastname'=Exibir 'Nome, Sobrenome'
 
-Show_'Lastname,_Firstname'=Exibir_'Sobrenome,_Nome'
+Show\ 'Lastname,\ Firstname'=Exibir 'Sobrenome, Nome'
 
-Show_BibTeX_source_by_default=Exibir_o_fonte_BibTeX_por_padrão
+Show\ BibTeX\ source\ by\ default=Exibir o fonte BibTeX por padrão
 
-Show_confirmation_dialog_when_deleting_entries=Exibir_diálogo_de_confirmação_ao_remover_referências
+Show\ confirmation\ dialog\ when\ deleting\ entries=Exibir diálogo de confirmação ao remover referências
 
-Show_description=Exibir_descrição
+Show\ description=Exibir descrição
 
-Show_file_column=Exibir_coluna_de_arquivo
+Show\ file\ column=Exibir coluna de arquivo
 
-Show_last_names_only=Exibir_apenas_últimos_nomes
+Show\ last\ names\ only=Exibir apenas últimos nomes
 
-Show_names_unchanged=Exibir_nomes_não_modificados
+Show\ names\ unchanged=Exibir nomes não modificados
 
-Show_optional_fields=Exibir_campos_opcionais
+Show\ optional\ fields=Exibir campos opcionais
 
-Show_required_fields=Exibir_campos_obrigatórios
+Show\ required\ fields=Exibir campos obrigatórios
 
-Show_URL/DOI_column=Exibir_coluna_URL/DOI
+Show\ URL/DOI\ column=Exibir coluna URL/DOI
 
-Simple_HTML=HTML_simples
+Simple\ HTML=HTML simples
 
 Size=Tamanho
 
-Skipped_-_No_PDF_linked=Omitido_-_Nenhum_PDF_linkado
-Skipped_-_PDF_does_not_exist=Omitido_-_O_PDF_não_existe
+Skipped\ -\ No\ PDF\ linked=Omitido - Nenhum PDF linkado
+Skipped\ -\ PDF\ does\ not\ exist=Omitido - O PDF não existe
 
-Skipped_entry.=Referência_omitida.
+Skipped\ entry.=Referência omitida.
 
-Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.=
+Some\ appearance\ settings\ you\ changed\ require\ to\ restart\ JabRef\ to\ come\ into\ effect.=
 
-source_edit=edição_de_fonte
-Special_name_formatters=Formatadores_de_nome_espepciais
+source\ edit=edição de fonte
+Special\ name\ formatters=Formatadores de nome espepciais
 
-Special_table_columns=Colunas_de_tabela_especiais
+Special\ table\ columns=Colunas de tabela especiais
 
-Starting_import=Iniciando_importação
+Starting\ import=Iniciando importação
 
-Statically_group_entries_by_manual_assignment=Agrupar_referências_manualmente
+Statically\ group\ entries\ by\ manual\ assignment=Agrupar referências manualmente
 
 Status=Status
 
@@ -1143,1019 +1143,1019 @@ Stop=Parar
 
 Strings=Strings
 
-Strings_for_library=Strings_para_a_base_de_dados
+Strings\ for\ library=Strings para a base de dados
 
-Sublibrary_from_AUX=Sub-base_de_dados_a_partir_do_LaTeX_AUX
+Sublibrary\ from\ AUX=Sub-base de dados a partir do LaTeX AUX
 
-Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.=Alterna_entre_nomes_de_periódicos_abreviados_e_completos_se_o_nome_do_periódico_é_conhecido.
+Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=Alterna entre nomes de periódicos abreviados e completos se o nome do periódico é conhecido.
 
-Synchronize_file_links=Sincronizar_links_de_arquivos
+Synchronize\ file\ links=Sincronizar links de arquivos
 
-Synchronizing_file_links...=Sincronizando_links_de_arquivos.
+Synchronizing\ file\ links...=Sincronizando links de arquivos.
 
-Table_appearance=Aparência_da_tabela
+Table\ appearance=Aparência da tabela
 
-Table_background_color=Cor_de_fundo_da_tabela
+Table\ background\ color=Cor de fundo da tabela
 
-Table_grid_color=Cor_do_grade_da_tabela
+Table\ grid\ color=Cor do grade da tabela
 
-Table_text_color=Cor_do_texto_da_tabela
+Table\ text\ color=Cor do texto da tabela
 
-Tabname=Nome_da_aba
-Target_file_cannot_be_a_directory.=O_arquivo_destino_não_pode_ser_um_diretório
+Tabname=Nome da aba
+Target\ file\ cannot\ be\ a\ directory.=O arquivo destino não pode ser um diretório
 
-Tertiary_sort_criterion=Critério_de_ordenação_terciário
+Tertiary\ sort\ criterion=Critério de ordenação terciário
 
 Test=Teste
 
-paste_text_here=Area_de_inserção_de_texto
+paste\ text\ here=Area de inserção de texto
 
-The_chosen_date_format_for_new_entries_is_not_valid=O_formato_de_data_escolhido_não_é_válido
+The\ chosen\ date\ format\ for\ new\ entries\ is\ not\ valid=O formato de data escolhido não é válido
 
-The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:=A_codificação_'%0'_não_pode_codificar_os_seguintes_caracteres\:
+The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=A codificação '%0' não pode codificar os seguintes caracteres:
 
 
-the_field_<b>%0</b>=o_campo_<b>%0</b>
+the\ field\ <b>%0</b>=o campo <b>%0</b>
 
-The_file<BR>'%0'<BR>has_been_modified<BR>externally\!=O_arquivo<BR>'%0'<BR>foi_modificado<BR>externamente\!
+The\ file<BR>'%0'<BR>has\ been\ modified<BR>externally\!=O arquivo<BR>'%0'<BR>foi modificado<BR>externamente!
 
-The_group_"%0"_already_contains_the_selection.=O_grupo_"%0"_já_contém_a_seleção.
+The\ group\ "%0"\ already\ contains\ the\ selection.=O grupo "%0" já contém a seleção.
 
-The_label_of_the_string_cannot_be_a_number.=O_rótulo_da_string_não_pode_ser_um_número.
+The\ label\ of\ the\ string\ cannot\ be\ a\ number.=O rótulo da string não pode ser um número.
 
-The_label_of_the_string_cannot_contain_spaces.=O_rótulo_da_string_não_pode_conter_espaços.
+The\ label\ of\ the\ string\ cannot\ contain\ spaces.=O rótulo da string não pode conter espaços.
 
-The_label_of_the_string_cannot_contain_the_'\#'_character.=O_rótulo_da_string_não_pode_conter_o_caracter_'\#'.
+The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=O rótulo da string não pode conter o caracter '#'.
 
-The_output_option_depends_on_a_valid_import_option.=A_opção_de_output_depende_de_uma_opção_de_importação_válida.
-The_PDF_contains_one_or_several_BibTeX-records.=O_PDF_contém_um_ou_mais_referências_BibTeX.
-Do_you_want_to_import_these_as_new_entries_into_the_current_library?=Você_quer_importar_as_novas_referências_para_a_base_de_dados_atual?
+The\ output\ option\ depends\ on\ a\ valid\ import\ option.=A opção de output depende de uma opção de importação válida.
+The\ PDF\ contains\ one\ or\ several\ BibTeX-records.=O PDF contém um ou mais referências BibTeX.
+Do\ you\ want\ to\ import\ these\ as\ new\ entries\ into\ the\ current\ library?=Você quer importar as novas referências para a base de dados atual?
 
-The_regular_expression_<b>%0</b>_is_invalid\:=A_expressão_regular_<b>%0</b>_é_inválida\:
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=A expressão regular <b>%0</b> é inválida:
 
-The_search_is_case_insensitive.=A_busca_não_é_sensível_ao_caso.
+The\ search\ is\ case\ insensitive.=A busca não é sensível ao caso.
 
-The_search_is_case_sensitive.=A_busca_é_sensível_ao_caso.
+The\ search\ is\ case\ sensitive.=A busca é sensível ao caso.
 
-The_string_has_been_removed_locally=Esta_string_foi_removida_localmente
+The\ string\ has\ been\ removed\ locally=Esta string foi removida localmente
 
-There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?=Existem_possíveis_duplicatadas_(marcadas_com_um_ícone)_que_não_foram_resolvidas._Continuar?
+There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=Existem possíveis duplicatadas (marcadas com um ícone) que não foram resolvidas. Continuar?
 
-This_entry_has_no_BibTeX_key._Generate_key_now?=Esta_referência_não_possui_chave_BibTeX._Deseja_gerar_uma_chave?
+This\ entry\ has\ no\ BibTeX\ key.\ Generate\ key\ now?=Esta referência não possui chave BibTeX. Deseja gerar uma chave?
 
-This_entry_is_incomplete=Esta_referência_está_incompleta
+This\ entry\ is\ incomplete=Esta referência está incompleta
 
-This_entry_type_cannot_be_removed.=Este_tipo_de_referência_não_pode_ser_removida.
+This\ entry\ type\ cannot\ be\ removed.=Este tipo de referência não pode ser removida.
 
-This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Este_link_externo_é_do_tipo_'%0',_o_qual_não_está_definido._O_que_você_deseja_fazer?
+This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Este link externo é do tipo '%0', o qual não está definido. O que você deseja fazer?
 
-This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.=Este_grupo_contém_referências_baseadas_em_associações_manuais._Referências_pode_ser_associadas_para_este_grupo_selecionando-as_e_então_usando_arrastar_e_soltar_ou_o_menu_de_contexto._Referências_podem_ser_removidas_deste_grupo_selecionando-as_e_então_usando_o_menu_de_contexto.
+This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=Este grupo contém referências baseadas em associações manuais. Referências pode ser associadas para este grupo selecionando-as e então usando arrastar e soltar ou o menu de contexto. Referências podem ser removidas deste grupo selecionando-as e então usando o menu de contexto.
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>=Este_grupo_contém_referências_cujo_campo_<b>%0</b>_contém_a_palavra-chave_<b>%1</b>
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Este grupo contém referências cujo campo <b>%0</b> contém a palavra-chave <b>%1</b>
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>=Este_grupo_contém_referências_cujo_campo_<b>%0</b>_contém_a_expressão_regular_<b>%1</b>
-This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.=Isto_faz_com_que_o_JabRed_busque_cada_link_de_arquivos_e_verifique_se_o_arquivo_existe._Caso_não_exista,_serão_exibidas_opções<BR>_para_resolver_o_problema.
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Este grupo contém referências cujo campo <b>%0</b> contém a expressão regular <b>%1</b>
+This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=Isto faz com que o JabRed busque cada link de arquivos e verifique se o arquivo existe. Caso não exista, serão exibidas opções<BR> para resolver o problema.
 
-This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.=Esta_operação_requer_que_todas_as_referências_selecionadas_tenham_chaves_BibTeX_definidas.
+This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=Esta operação requer que todas as referências selecionadas tenham chaves BibTeX definidas.
 
-This_operation_requires_one_or_more_entries_to_be_selected.=Esta_operação_exige_que_uma_ou_mais_referências_sejam_selecionadas
+This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=Esta operação exige que uma ou mais referências sejam selecionadas
 
-Toggle_entry_preview=Habilitar/Desabilitar_previsualização_da_referência
-Toggle_groups_interface=Habilitar/Desabilitar_interface_de_grupos
-Try_different_encoding=Tente_uma_codificação_diferente
+Toggle\ entry\ preview=Habilitar/Desabilitar previsualização da referência
+Toggle\ groups\ interface=Habilitar/Desabilitar interface de grupos
+Try\ different\ encoding=Tente uma codificação diferente
 
-Unabbreviate_journal_names_of_the_selected_entries=Reverter_abreviações_dos_nomes_de_periódicos_das_referências_selecionadas
-Unabbreviated_%0_journal_names.=Revertidas_abreviações_de_%0_nomes_de_periódicos.
+Unabbreviate\ journal\ names\ of\ the\ selected\ entries=Reverter abreviações dos nomes de periódicos das referências selecionadas
+Unabbreviated\ %0\ journal\ names.=Revertidas abreviações de %0 nomes de periódicos.
 
-Unable_to_open_file.=Não_foi_possível_abrir_o_arquivo.
-Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.=Não_foi_possível_abrir_o_link._A_aplicaçaõ_'%0'_associada_com_o_tipo_de_arquivo_'%1'_não_pôde_ser_chamada.
-unable_to_write_to=não_foi_possível_escrever_para
-Undefined_file_type=Tipo_de_arquivo_indefinido
+Unable\ to\ open\ file.=Não foi possível abrir o arquivo.
+Unable\ to\ open\ link.\ The\ application\ '%0'\ associated\ with\ the\ file\ type\ '%1'\ could\ not\ be\ called.=Não foi possível abrir o link. A aplicaçaõ '%0' associada com o tipo de arquivo '%1' não pôde ser chamada.
+unable\ to\ write\ to=não foi possível escrever para
+Undefined\ file\ type=Tipo de arquivo indefinido
 
 Undo=Desfazer
 
 Union=União
 
-Unknown_BibTeX_entries=Referências_BibTeX_desconhecidas
+Unknown\ BibTeX\ entries=Referências BibTeX desconhecidas
 
-unknown_edit=edição_desconhecida
+unknown\ edit=edição desconhecida
 
-Unknown_export_format=Formato_de_exportação_desconhecido
+Unknown\ export\ format=Formato de exportação desconhecido
 
-Unmark_all=Desmarcar_todos
+Unmark\ all=Desmarcar todos
 
-Unmark_entries=Desmarcar_referências
+Unmark\ entries=Desmarcar referências
 
-Unmark_entry=Desmarcar_referência
+Unmark\ entry=Desmarcar referência
 
-untitled=Sem_título
+untitled=Sem título
 
 Up=Acima
 
-Update_to_current_column_widths=Atualizar_para_a_largura_de_coluna_atual
+Update\ to\ current\ column\ widths=Atualizar para a largura de coluna atual
 
-Updated_group_selection=Seleção_de_grupo_atualizada
-Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.=Atualizar_links_PDF/PS_externos_para_utilizar_o_campo_'%0'
-Upgrade_file=Atualizar_arquivo
-Upgrade_old_external_file_links_to_use_the_new_feature=Atualize_os_links_de_arquivos_externos_para_utilizar_o_novo_recurso
+Updated\ group\ selection=Seleção de grupo atualizada
+Upgrade\ external\ PDF/PS\ links\ to\ use\ the\ '%0'\ field.=Atualizar links PDF/PS externos para utilizar o campo '%0'
+Upgrade\ file=Atualizar arquivo
+Upgrade\ old\ external\ file\ links\ to\ use\ the\ new\ feature=Atualize os links de arquivos externos para utilizar o novo recurso
 
 usage=utilização
-Use_autocompletion_for_the_following_fields=Utilizar_o_autocompletar_para_os_seguintes_campos
+Use\ autocompletion\ for\ the\ following\ fields=Utilizar o autocompletar para os seguintes campos
 
-Use_other_look_and_feel=Utilizar_uma_outra_aparência
-Tweak_font_rendering_for_entry_editor_on_Linux=
-Use_regular_expression_search=Utilizar_pesquisa_por_expressão_regular
+Use\ other\ look\ and\ feel=Utilizar uma outra aparência
+Tweak\ font\ rendering\ for\ entry\ editor\ on\ Linux=
+Use\ regular\ expression\ search=Utilizar pesquisa por expressão regular
 
-Username=Nome_de_usuário
+Username=Nome de usuário
 
-Value_cleared_externally=Valor_apagado_externamente
+Value\ cleared\ externally=Valor apagado externamente
 
-Value_set_externally=Valor_definido_externamente
+Value\ set\ externally=Valor definido externamente
 
-verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid=verifique_que_o_LyX_está_sendo_executado_e_que_o_lyxpipe_é_válido
+verify\ that\ LyX\ is\ running\ and\ that\ the\ lyxpipe\ is\ valid=verifique que o LyX está sendo executado e que o lyxpipe é válido
 
 View=Visualizar
-Vim_server_name=Nome_do_servidor_Vim
+Vim\ server\ name=Nome do servidor Vim
 
-Waiting_for_ArXiv...=Aguardando_por_ArXiv...
+Waiting\ for\ ArXiv...=Aguardando por ArXiv...
 
-Warn_about_unresolved_duplicates_when_closing_inspection_window=Alertar_sobre_duplicatas_não_resolvidas_ao_fechar_a_janela_de_inspeção
+Warn\ about\ unresolved\ duplicates\ when\ closing\ inspection\ window=Alertar sobre duplicatas não resolvidas ao fechar a janela de inspeção
 
-Warn_before_overwriting_existing_keys=Alertar_ao_sobrescrever_chaves_existentes
+Warn\ before\ overwriting\ existing\ keys=Alertar ao sobrescrever chaves existentes
 
 Warning=Alerta
 
 Warnings=Alertas
 
-web_link=link_web
+web\ link=link web
 
-What_do_you_want_to_do?=O_que_você_deseja_fazer?
+What\ do\ you\ want\ to\ do?=O que você deseja fazer?
 
-When_adding/removing_keywords,_separate_them_by=Ao_adicionar/remover_palavras-cave,_separá-las_por
-Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.=Irá_escrever_todos_os_metadados_XMP_para_os_PDF_linkados_a_partir_das_referências_selecionadas.
+When\ adding/removing\ keywords,\ separate\ them\ by=Ao adicionar/remover palavras-cave, separá-las por
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Irá escrever todos os metadados XMP para os PDF linkados a partir das referências selecionadas.
 
 with=com
 
-Write_BibTeXEntry_as_XMP-metadata_to_PDF.=Escrever_BibTeXEntry_como_um_metadado_XMP_para_o_PDF.
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Escrever BibTeXEntry como um metadado XMP para o PDF.
 
-Write_XMP=Escrever_XMP
-Write_XMP-metadata=Escrever_metadados_XMP
-Write_XMP-metadata_for_all_PDFs_in_current_library?=Escrever_metadados_XMP_para_todos_os_PDF's_no_banco_de_dados_atual?
-Writing_XMP-metadata...=Escrevendo_metadados_XMP...
-Writing_XMP-metadata_for_selected_entries...=Escrevendo_metadados_XMP_para_as_referências_selecionadas...
+Write\ XMP=Escrever XMP
+Write\ XMP-metadata=Escrever metadados XMP
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Escrever metadados XMP para todos os PDF's no banco de dados atual?
+Writing\ XMP-metadata...=Escrevendo metadados XMP...
+Writing\ XMP-metadata\ for\ selected\ entries...=Escrevendo metadados XMP para as referências selecionadas...
 
-Wrote_XMP-metadata=Metadados_XMP_escritos
+Wrote\ XMP-metadata=Metadados XMP escritos
 
-XMP-annotated_PDF=PDF_com_anotações_XMP
-XMP_export_privacy_settings=Configurações_de_privacidade_para_a_exportação_XMP
-XMP-metadata=Metaddos_XMP
-XMP-metadata_found_in_PDF\:_%0=Metadados_XMP_encontrados_no_PDF\:_%0
-You_must_restart_JabRef_for_this_to_come_into_effect.=Você_deve_reiniciar_o_JabRef_para_a_alteração_tenha_efeito.
-You_have_changed_the_language_setting.=Você_configurou_a_configuração_de_idioma.
-You_have_entered_an_invalid_search_'%0'.=Você_digitou_um_termo_de_busca_inválido_'%0'.
+XMP-annotated\ PDF=PDF com anotações XMP
+XMP\ export\ privacy\ settings=Configurações de privacidade para a exportação XMP
+XMP-metadata=Metaddos XMP
+XMP-metadata\ found\ in\ PDF\:\ %0=Metadados XMP encontrados no PDF: %0
+You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Você deve reiniciar o JabRef para a alteração tenha efeito.
+You\ have\ changed\ the\ language\ setting.=Você configurou a configuração de idioma.
+You\ have\ entered\ an\ invalid\ search\ '%0'.=Você digitou um termo de busca inválido '%0'.
 
-You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.=_O_JabRef_precisa_ser_reiniciado_para_que_as_novas_atribuições_de_chave_funcionem_corretamente.
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.= O JabRef precisa ser reiniciado para que as novas atribuições de chave funcionem corretamente.
 
-Your_new_key_bindings_have_been_stored.=Suas_novas_atribuições_de_chave_foram_armazenadas.
+Your\ new\ key\ bindings\ have\ been\ stored.=Suas novas atribuições de chave foram armazenadas.
 
-The_following_fetchers_are_available\:=As_seguintes_ferramentas_de_pesquisa_estão_disponíveis\:
-Could_not_find_fetcher_'%0'=Não_foi_possível_encontrar_a_ferramenta_de_pesquisa_'%0'
-Running_query_'%0'_with_fetcher_'%1'.=Executando_consulta_'%0'_com_ferramenta_de_pesquisa_'%1'.
-Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.=Consulta_'%0'_com_ferramenta_de_pesquisa_'%1'_não_retornou_resultados.
+The\ following\ fetchers\ are\ available\:=As seguintes ferramentas de pesquisa estão disponíveis:
+Could\ not\ find\ fetcher\ '%0'=Não foi possível encontrar a ferramenta de pesquisa '%0'
+Running\ query\ '%0'\ with\ fetcher\ '%1'.=Executando consulta '%0' com ferramenta de pesquisa '%1'.
+Query\ '%0'\ with\ fetcher\ '%1'\ did\ not\ return\ any\ results.=Consulta '%0' com ferramenta de pesquisa '%1' não retornou resultados.
 
-Move_file=Mover_arquivo
-Rename_file=Renomear_arquivo
+Move\ file=Mover arquivo
+Rename\ file=Renomear arquivo
 
-Move_file_failed=Movimentação_do_arquivo_falhou
-Could_not_move_file_'%0'.=Não_foi_possível_mover_o_arquivo_'%0'.
-Could_not_find_file_'%0'.=Não_foi_possível_encontrar_o_arquivo_'%0'.
-Number_of_entries_successfully_imported=Número_de_referências_importadas_com_sucesso
-Import_canceled_by_user=Importação_cancelada_pelo_usuário
-Progress\:_%0_of_%1=Progresso\:_%0_de_%1
-Error_while_fetching_from_%0=Erro_ao_recuperar_do_%0
+Move\ file\ failed=Movimentação do arquivo falhou
+Could\ not\ move\ file\ '%0'.=Não foi possível mover o arquivo '%0'.
+Could\ not\ find\ file\ '%0'.=Não foi possível encontrar o arquivo '%0'.
+Number\ of\ entries\ successfully\ imported=Número de referências importadas com sucesso
+Import\ canceled\ by\ user=Importação cancelada pelo usuário
+Progress\:\ %0\ of\ %1=Progresso: %0 de %1
+Error\ while\ fetching\ from\ %0=Erro ao recuperar do %0
 
-Please_enter_a_valid_number=Por_favor,_digite_um_número_válido
-Show_search_results_in_a_window=Exibir_resultados_de_busca_em_uma_janela
-Show_global_search_results_in_a_window=
-Search_in_all_open_libraries=
-Move_file_to_file_directory?=Mover_arquivo_para_o_diretório_de_arquivos?
+Please\ enter\ a\ valid\ number=Por favor, digite um número válido
+Show\ search\ results\ in\ a\ window=Exibir resultados de busca em uma janela
+Show\ global\ search\ results\ in\ a\ window=
+Search\ in\ all\ open\ libraries=
+Move\ file\ to\ file\ directory?=Mover arquivo para o diretório de arquivos?
 
-Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.=A_base_de_dados_está_protegida._Não_é_possível_salvar_antes_que_mudanças_externas_sejam_revisadas.
-Protected_library=Base_de_dados_protegida
-Refuse_to_save_the_library_before_external_changes_have_been_reviewed.=Recusa_em_salvar_a_base_de_dados_antes_de_mudanças_externas_serem_revisadas.
-Library_protection=Proteção_da_base_de_dados
-Unable_to_save_library=Não_foi_possível_salvar_a_base_de_dados
+Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=A base de dados está protegida. Não é possível salvar antes que mudanças externas sejam revisadas.
+Protected\ library=Base de dados protegida
+Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=Recusa em salvar a base de dados antes de mudanças externas serem revisadas.
+Library\ protection=Proteção da base de dados
+Unable\ to\ save\ library=Não foi possível salvar a base de dados
 
-BibTeX_key_generator=Gerador_de_chaves_BibTeX
-Unable_to_open_link.=Não_foi_possível_abrir_link.
-Move_the_keyboard_focus_to_the_entry_table=Mover_o_foco_do_teclado_para_a_tabela_de_referências
-MIME_type=MIME_type
+BibTeX\ key\ generator=Gerador de chaves BibTeX
+Unable\ to\ open\ link.=Não foi possível abrir link.
+Move\ the\ keyboard\ focus\ to\ the\ entry\ table=Mover o foco do teclado para a tabela de referências
+MIME\ type=MIME type
 
-This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.=Esta_funcionalidade_permite_que_novos_arquivos_sejam_abertos_ou_importados_para_uma_instância_do_JabRef_já_aberta<br>_ao_invés_de_abrir_uma_nova_instância._Por_exemplo,_isto_é_útil_quando_você_abre_um_arquivo_no_JabRef<br>_a_partir_de_ser_navegador_web.<BR>_Note_que_isto_irá_previnir_que_você_execute_uma_ou_mais_instâncias_do_JabRef_ao_mesmo_tempo.
-Run_fetcher,_e.g._"--fetch\=Medline\:cancer"=Executar_Pesquisar_,_e.g.,_"--fetch\=Medline\:cancer"
+This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef<BR>instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef<br>from\ your\ web\ browser.<BR>Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=Esta funcionalidade permite que novos arquivos sejam abertos ou importados para uma instância do JabRef já aberta<br> ao invés de abrir uma nova instância. Por exemplo, isto é útil quando você abre um arquivo no JabRef<br> a partir de ser navegador web.<BR> Note que isto irá previnir que você execute uma ou mais instâncias do JabRef ao mesmo tempo.
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=Executar Pesquisar , e.g., "--fetch=Medline:cancer"
 
-The_ACM_Digital_Library=A_Biblioteca_Digital_ACM
+The\ ACM\ Digital\ Library=A Biblioteca Digital ACM
 Reset=Redefinir
 
-Use_IEEE_LaTeX_abbreviations=Utilizar_abreviações_LaTeX_IEEE
-The_Guide_to_Computing_Literature=O_Guia_da_Literatura_em_Computação
+Use\ IEEE\ LaTeX\ abbreviations=Utilizar abreviações LaTeX IEEE
+The\ Guide\ to\ Computing\ Literature=O Guia da Literatura em Computação
 
-When_opening_file_link,_search_for_matching_file_if_no_link_is_defined=Ao_abrir_o_link_do_arquivo,_procurar_por_arquivo_correspondente_se_nenhum_link_está_definido
-Settings_for_%0=Configurações_para_%0
-Mark_entries_imported_into_an_existing_library=Marcar_referências_importadas_para_uma_nova_base_de_dados_existente
-Unmark_all_entries_before_importing_new_entries_into_an_existing_library=Desmarcar_todas_as_referências_antes_de_importar_novas_referências_para_uma_base_de_dados_existente
+When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=Ao abrir o link do arquivo, procurar por arquivo correspondente se nenhum link está definido
+Settings\ for\ %0=Configurações para %0
+Mark\ entries\ imported\ into\ an\ existing\ library=Marcar referências importadas para uma nova base de dados existente
+Unmark\ all\ entries\ before\ importing\ new\ entries\ into\ an\ existing\ library=Desmarcar todas as referências antes de importar novas referências para uma base de dados existente
 
 Forward=Avançar
 Back=Voltar
-Sort_the_following_fields_as_numeric_fields=Ordenar_os_seguintes_campos_como_campos_numéricos
-Line_%0\:_Found_corrupted_BibTeX_key.=Linha_%0\:_Chave_BibTeX_corrompida_encontrada.
-Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).=Linha_%0\:_Chave_BibTeX_corrompida_encontrada_(contém_espaços_em_branco).
-Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).=Linha_%0\:_Chave_BibTeX_corrompida_encontrada_(vírgula_faltando).
-Full_text_document_download_failed=O_download_do_artigo_completo_falhou
-Update_to_current_column_order=Atualizar_para_ordenação_de_coluna_atual
-Download_from_URL=
-Rename_field=Renomear_campo
-Set/clear/append/rename_fields=Definir/limpar/renomear_campos
-Append_field=
-Append_to_fields=
-Rename_field_to=Renomear_campo_para
-Move_contents_of_a_field_into_a_field_with_a_different_name=Mover_conteúdo_de_um_campo_para_um_campo_com_nome_diferente
-You_can_only_rename_one_field_at_a_time=Você_pode_renomear_apenas_um_campo_por_vez
+Sort\ the\ following\ fields\ as\ numeric\ fields=Ordenar os seguintes campos como campos numéricos
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=Linha %0: Chave BibTeX corrompida encontrada.
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=Linha %0: Chave BibTeX corrompida encontrada (contém espaços em branco).
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=Linha %0: Chave BibTeX corrompida encontrada (vírgula faltando).
+Full\ text\ document\ download\ failed=O download do artigo completo falhou
+Update\ to\ current\ column\ order=Atualizar para ordenação de coluna atual
+Download\ from\ URL=
+Rename\ field=Renomear campo
+Set/clear/append/rename\ fields=Definir/limpar/renomear campos
+Append\ field=
+Append\ to\ fields=
+Rename\ field\ to=Renomear campo para
+Move\ contents\ of\ a\ field\ into\ a\ field\ with\ a\ different\ name=Mover conteúdo de um campo para um campo com nome diferente
+You\ can\ only\ rename\ one\ field\ at\ a\ time=Você pode renomear apenas um campo por vez
 
-Remove_all_broken_links=Remover_todos_os_links_inválidos
+Remove\ all\ broken\ links=Remover todos os links inválidos
 
-Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.=Não_é_possível_utilizar_a_porta_%0_para_operação_remota;_outra_aplicação_pode_estar_usando-a._Tente_utilizar_uma_outra_porta.
+Cannot\ use\ port\ %0\ for\ remote\ operation;\ another\ application\ may\ be\ using\ it.\ Try\ specifying\ another\ port.=Não é possível utilizar a porta %0 para operação remota; outra aplicação pode estar usando-a. Tente utilizar uma outra porta.
 
-Looking_for_full_text_document...=Pesquisando_por_documento_completo...
-Autosave=Salvar_automaticamente
-A_local_copy_will_be_opened.=Uma_cópia_local_será_aberta.
-Autosave_local_libraries=Salvar_biblioteca_local_automaticamente
-Automatically_save_the_library_to=Salvar_a_biblioteca_local_automaticamente_em
-Please_enter_a_valid_file_path.=Por_favor_entre_um_caminho_válido
+Looking\ for\ full\ text\ document...=Pesquisando por documento completo...
+Autosave=Salvar automaticamente
+A\ local\ copy\ will\ be\ opened.=Uma cópia local será aberta.
+Autosave\ local\ libraries=Salvar biblioteca local automaticamente
+Automatically\ save\ the\ library\ to=Salvar a biblioteca local automaticamente em
+Please\ enter\ a\ valid\ file\ path.=Por favor entre um caminho válido
 
 
-Export_in_current_table_sort_order=Exportar_na_ordenação_atual_da_tabela
-Export_entries_in_their_original_order=Exportar_referências_em_sua_ordem_original
-Error_opening_file_'%0'.=Erro_ao_abrir_arquivo_'%0'.
+Export\ in\ current\ table\ sort\ order=Exportar na ordenação atual da tabela
+Export\ entries\ in\ their\ original\ order=Exportar referências em sua ordem original
+Error\ opening\ file\ '%0'.=Erro ao abrir arquivo '%0'.
 
-Formatter_not_found\:_%0=Formatador_não_encontrado\:_%0
-Clear_inputarea=Limpar_área_de_entrada
+Formatter\ not\ found\:\ %0=Formatador não encontrado: %0
+Clear\ inputarea=Limpar área de entrada
 
-Automatically_set_file_links_for_this_entry=Links_de_arquivos_automaticamente_definidos_para_esta_referência.
-Could_not_save,_file_locked_by_another_JabRef_instance.=Não_foi_possível_salvar,_o_arquivo_está_bloqueado_por_outra_instância_JabRef.
-File_is_locked_by_another_JabRef_instance.=O_arquivo_está_bloqueado_por_outra_instância_JabRef.
-Do_you_want_to_override_the_file_lock?=Deseja_substituir_o_bloqueio_do_arquivo?
-File_locked=Arquivo_bloqueado
-Current_tmp_value=Valor_tmp_atual
-Metadata_change=Mudança_de_metadados
-Changes_have_been_made_to_the_following_metadata_elements=Mudanças_foram_realizadas_nos_seguintes_elementos_de_metadados
+Automatically\ set\ file\ links\ for\ this\ entry=Links de arquivos automaticamente definidos para esta referência.
+Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=Não foi possível salvar, o arquivo está bloqueado por outra instância JabRef.
+File\ is\ locked\ by\ another\ JabRef\ instance.=O arquivo está bloqueado por outra instância JabRef.
+Do\ you\ want\ to\ override\ the\ file\ lock?=Deseja substituir o bloqueio do arquivo?
+File\ locked=Arquivo bloqueado
+Current\ tmp\ value=Valor tmp atual
+Metadata\ change=Mudança de metadados
+Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=Mudanças foram realizadas nos seguintes elementos de metadados
 
-Generate_groups_for_author_last_names=Gerar_grupos_a_partir_dos_últimos_nomes_dos_autores
-Generate_groups_from_keywords_in_a_BibTeX_field=Gerar_grupos_a_partir_de_palavras_chaves_em_um_campo_BibTeX
-Enforce_legal_characters_in_BibTeX_keys=Forçar_caracteres_permitidos_em_chaves_BibTeX
+Generate\ groups\ for\ author\ last\ names=Gerar grupos a partir dos últimos nomes dos autores
+Generate\ groups\ from\ keywords\ in\ a\ BibTeX\ field=Gerar grupos a partir de palavras chaves em um campo BibTeX
+Enforce\ legal\ characters\ in\ BibTeX\ keys=Forçar caracteres permitidos em chaves BibTeX
 
-Save_without_backup?=Salvar_sem_backup?
-Unable_to_create_backup=Não_foi_possível_criar_o_backup
-Move_file_to_file_directory=Mover_arquivo_para_diretório_de_arquivo
-Rename_file_to=Renomear_arquivo_para
-<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)=<b>Todas_as_referências</b>_(este_grupo_não_pode_ser_editado_ou_removido)
-static_group=grupo_estático
-dynamic_group=grupo_dinâmico
-refines_supergroup=redefine_o_supergrupo
-includes_subgroups=incluir_subgrupos
+Save\ without\ backup?=Salvar sem backup?
+Unable\ to\ create\ backup=Não foi possível criar o backup
+Move\ file\ to\ file\ directory=Mover arquivo para diretório de arquivo
+Rename\ file\ to=Renomear arquivo para
+<b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=<b>Todas as referências</b> (este grupo não pode ser editado ou removido)
+static\ group=grupo estático
+dynamic\ group=grupo dinâmico
+refines\ supergroup=redefine o supergrupo
+includes\ subgroups=incluir subgrupos
 contains=contém
-search_expression=expressão_de_pesquisa
+search\ expression=expressão de pesquisa
 
-Optional_fields_2=Campos_opcionais_2
-Waiting_for_save_operation_to_finish=Aguardando_a_operação_de_salvamento_ser_finalizada
-Resolving_duplicate_BibTeX_keys...=Resolvendo_chaves_BibTeX_duplicadas...
-Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.=Resolução_de_chaves_BibTeX_duplicadas_finalizada._%0_referências_foram_modificadas.
-This_library_contains_one_or_more_duplicated_BibTeX_keys.=Esta_base_de_dados_contém_uma_ou_mais_chaves_BibTeX_duplicadas.
-Do_you_want_to_resolve_duplicate_keys_now?=Deseja_resolver_chaves_duplicadas_agora?
+Optional\ fields\ 2=Campos opcionais 2
+Waiting\ for\ save\ operation\ to\ finish=Aguardando a operação de salvamento ser finalizada
+Resolving\ duplicate\ BibTeX\ keys...=Resolvendo chaves BibTeX duplicadas...
+Finished\ resolving\ duplicate\ BibTeX\ keys.\ %0\ entries\ modified.=Resolução de chaves BibTeX duplicadas finalizada. %0 referências foram modificadas.
+This\ library\ contains\ one\ or\ more\ duplicated\ BibTeX\ keys.=Esta base de dados contém uma ou mais chaves BibTeX duplicadas.
+Do\ you\ want\ to\ resolve\ duplicate\ keys\ now?=Deseja resolver chaves duplicadas agora?
 
-Find_and_remove_duplicate_BibTeX_keys=Encontrar_e_remover_chaves_BibTeX_duplicadas
-Expected_syntax_for_--fetch\='<name_of_fetcher>\:<query>'=Sintaxe_esperada_para_--fetch='<name_of_fetcher>\:<query>'
-Duplicate_BibTeX_key=Duplicar_chave_BibTeX
-Import_marking_color=Importar_cores_de_marcação
-Always_add_letter_(a,_b,_...)_to_generated_keys=Sempre_adicionar_uma_letra_(a,_b,_...)às_chaves_geradas
+Find\ and\ remove\ duplicate\ BibTeX\ keys=Encontrar e remover chaves BibTeX duplicadas
+Expected\ syntax\ for\ --fetch\='<name\ of\ fetcher>\:<query>'=Sintaxe esperada para --fetch='<name of fetcher>:<query>'
+Duplicate\ BibTeX\ key=Duplicar chave BibTeX
+Import\ marking\ color=Importar cores de marcação
+Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=Sempre adicionar uma letra (a, b, ...)às chaves geradas
 
-Ensure_unique_keys_using_letters_(a,_b,_...)=Garantir_chaves_únicas_utilizando_letras_(a,_b,_...)
-Ensure_unique_keys_using_letters_(b,_c,_...)=Garantir_chaves_únicas_utilizando_letras_(b,_c,_...)
-Entry_editor_active_background_color=Editor_de_referências
-Entry_editor_background_color=Cor_de_fundo_do_editor_de_referências
-Entry_editor_font_color=Cor_da_fonte_do_editor_de_referências
-Entry_editor_invalid_field_color=Cor_de_campo_inválido_do_editor_de_referências
+Ensure\ unique\ keys\ using\ letters\ (a,\ b,\ ...)=Garantir chaves únicas utilizando letras (a, b, ...)
+Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=Garantir chaves únicas utilizando letras (b, c, ...)
+Entry\ editor\ active\ background\ color=Editor de referências
+Entry\ editor\ background\ color=Cor de fundo do editor de referências
+Entry\ editor\ font\ color=Cor da fonte do editor de referências
+Entry\ editor\ invalid\ field\ color=Cor de campo inválido do editor de referências
 
-Table_and_entry_editor_colors=Cores_do_editor_de_tabela_e_referências
+Table\ and\ entry\ editor\ colors=Cores do editor de tabela e referências
 
-General_file_directory=Diretório_geral_de_arquivos
-User-specific_file_directory=Diretório_de_arquivo_específico_do_usuário
-Search_failed\:_illegal_search_expression=A_pesquisa_falhou\:_expressão_de_pesquisa_ilegal
-Show_ArXiv_column=Exibir_coluna_ArXiv
+General\ file\ directory=Diretório geral de arquivos
+User-specific\ file\ directory=Diretório de arquivo específico do usuário
+Search\ failed\:\ illegal\ search\ expression=A pesquisa falhou: expressão de pesquisa ilegal
+Show\ ArXiv\ column=Exibir coluna ArXiv
 
-You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for=Você_deve_digitar_um_valor_inteiro_entre_1025_e_65535_no_campo_de_texto_para
-Automatically_open_browse_dialog_when_creating_new_file_link=Abrir_janela_de_diálogo_automaticamente_ao_criar_um_novo_link_de_arquivo
-Import_metadata_from\:=Importar_metadados_a_partir_de\:
-Choose_the_source_for_the_metadata_import=Escolher_a_fonte_para_a_importação_de_metadados
-Create_entry_based_on_XMP-metadata=Criar_referência_baseada_em_dados_XMP
-Create_blank_entry_linking_the_PDF=Criar_referência_em_branco_linkando_o_PDF
-Only_attach_PDF=Anexar_apenas_PDF
+You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=Você deve digitar um valor inteiro entre 1025 e 65535 no campo de texto para
+Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Abrir janela de diálogo automaticamente ao criar um novo link de arquivo
+Import\ metadata\ from\:=Importar metadados a partir de:
+Choose\ the\ source\ for\ the\ metadata\ import=Escolher a fonte para a importação de metadados
+Create\ entry\ based\ on\ XMP-metadata=Criar referência baseada em dados XMP
+Create\ blank\ entry\ linking\ the\ PDF=Criar referência em branco linkando o PDF
+Only\ attach\ PDF=Anexar apenas PDF
 Title=Título
-Create_new_entry=Criar_nova_referência
-Update_existing_entry=Atualizar_referência_existente
-Autocomplete_names_in_'Firstname_Lastname'_format_only=Autocompletar_nome_em_um_formato_'Nome,_Sobrenome'_apenas
-Autocomplete_names_in_'Lastname,_Firstname'_format_only=Autocompletar_nomes_em_um_formato_'Sobrenome,_Nome'_apenas
-Autocomplete_names_in_both_formats=Autocompletar_nomes_em_ambos_os_formatos
-Marking_color_%0=Cor_de_marcação_%0
-The_name_'comment'_cannot_be_used_as_an_entry_type_name.=O_nome_'comment'_não_pode_ser_utilizado_como_um_nome_de_tipo_de_referência.
-You_must_enter_an_integer_value_in_the_text_field_for=Você_deve_digitar_um_valor_inteiro_no_campo_de_texto_para
-Send_as_email=Enviar_como_email
+Create\ new\ entry=Criar nova referência
+Update\ existing\ entry=Atualizar referência existente
+Autocomplete\ names\ in\ 'Firstname\ Lastname'\ format\ only=Autocompletar nome em um formato 'Nome, Sobrenome' apenas
+Autocomplete\ names\ in\ 'Lastname,\ Firstname'\ format\ only=Autocompletar nomes em um formato 'Sobrenome, Nome' apenas
+Autocomplete\ names\ in\ both\ formats=Autocompletar nomes em ambos os formatos
+Marking\ color\ %0=Cor de marcação %0
+The\ name\ 'comment'\ cannot\ be\ used\ as\ an\ entry\ type\ name.=O nome 'comment' não pode ser utilizado como um nome de tipo de referência.
+You\ must\ enter\ an\ integer\ value\ in\ the\ text\ field\ for=Você deve digitar um valor inteiro no campo de texto para
+Send\ as\ email=Enviar como email
 References=Referências
-Sending_of_emails=Envio_de_emails
-Subject_for_sending_an_email_with_references=Assunto_para_enviar_um_email_com_referências
-Automatically_open_folders_of_attached_files=Abrir_pastas_de_arquivos_anexados_automaticamente
-Create_entry_based_on_content=Criar_referência_baseada_no_conteúdo
-Do_not_show_this_box_again_for_this_import=Não_exibir_esta_caixa_de_diálogo_novamente_para_esta_importação
-Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)=Sempre_utilizar_este_estilo_de_importação_de_PDF_(e_não_pergunte_a_cada_importação)
-Error_creating_email=Erro_ao_criar_email
-Entries_added_to_an_email=referências_adicionadas_para_um_email
+Sending\ of\ emails=Envio de emails
+Subject\ for\ sending\ an\ email\ with\ references=Assunto para enviar um email com referências
+Automatically\ open\ folders\ of\ attached\ files=Abrir pastas de arquivos anexados automaticamente
+Create\ entry\ based\ on\ content=Criar referência baseada no conteúdo
+Do\ not\ show\ this\ box\ again\ for\ this\ import=Não exibir esta caixa de diálogo novamente para esta importação
+Always\ use\ this\ PDF\ import\ style\ (and\ do\ not\ ask\ for\ each\ import)=Sempre utilizar este estilo de importação de PDF (e não pergunte a cada importação)
+Error\ creating\ email=Erro ao criar email
+Entries\ added\ to\ an\ email=referências adicionadas para um email
 exportFormat=exportFormat
-Output_file_missing=Arquivo_de_saída_não_encontrado.
-No_search_matches.=Sem_correspondências.
-The_output_option_depends_on_a_valid_input_option.=A_opção_padrão_depende_de_uma_opção_de_referência_válida.
-Default_import_style_for_drag_and_drop_of_PDFs=Estilo_de_importação_padrão_para_Arrastar_e_Soltar_de_PDFs
-Default_PDF_file_link_action=Ação_de_link_de_arquivo_PDF_padrão
-Filename_format_pattern=Modelo_de_formato_de_nome_de_arquivo
-Additional_parameters=Parâmetros_adicionais
-Cite_selected_entries_between_parenthesis=Citar_referências_selecionadas
-Cite_selected_entries_with_in-text_citation=Citar_referências_selecionadas_com_citação_no_texto
-Cite_special=Citar_especial
-Extra_information_(e.g._page_number)=Informação_adicional_(e.g.)_número_de_páginas)
-Manage_citations=Gerenciar_citações
-Problem_modifying_citation=Problema_ao_modificar_citação
+Output\ file\ missing=Arquivo de saída não encontrado.
+No\ search\ matches.=Sem correspondências.
+The\ output\ option\ depends\ on\ a\ valid\ input\ option.=A opção padrão depende de uma opção de referência válida.
+Default\ import\ style\ for\ drag\ and\ drop\ of\ PDFs=Estilo de importação padrão para Arrastar e Soltar de PDFs
+Default\ PDF\ file\ link\ action=Ação de link de arquivo PDF padrão
+Filename\ format\ pattern=Modelo de formato de nome de arquivo
+Additional\ parameters=Parâmetros adicionais
+Cite\ selected\ entries\ between\ parenthesis=Citar referências selecionadas
+Cite\ selected\ entries\ with\ in-text\ citation=Citar referências selecionadas com citação no texto
+Cite\ special=Citar especial
+Extra\ information\ (e.g.\ page\ number)=Informação adicional (e.g.) número de páginas)
+Manage\ citations=Gerenciar citações
+Problem\ modifying\ citation=Problema ao modificar citação
 Citation=Citação
-Extra_information=Informação_adicional
-Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.=Não_foi_possível_resolver_a_referência_BibTeX_para_o_marcador_de_citação_'%0'.
-Select_style=Selecionar_estilo
+Extra\ information=Informação adicional
+Could\ not\ resolve\ BibTeX\ entry\ for\ citation\ marker\ '%0'.=Não foi possível resolver a referência BibTeX para o marcador de citação '%0'.
+Select\ style=Selecionar estilo
 Journals=Periódicos
 Cite=Citar
-Cite_in-text=Citar_no_texto
-Insert_empty_citation=Inserir_citação_vazia
-Merge_citations=Unir_citações
-Manual_connect=Conexão_manual
-Select_Writer_document=Selecionar_documento_Writer
-Sync_OpenOffice/LibreOffice_bibliography=Sincronizar_bibliografia_OpenOffice/LibreOffice
-Select_which_open_Writer_document_to_work_on=Selecionar_o_documento_Writer_aberto_a_se_trabalhar
-Connected_to_document=Conectado_ao_documento
-Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)=Inserir_uma_citação_sem_texto_(a_referência_aparecerá_na_lista_de_referências)
-Cite_selected_entries_with_extra_information=Citar_as_referências_selecionadas_com_informações_adicionais
-Ensure_that_the_bibliography_is_up-to-date=Certifique-se_que_a_bibliografia_está_atualizada
-Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.=Seu_documento_do_OpenOffice/LibreOffice_referencia_a_chave_BibTeX_'%0',_que_não_foi_encontrada_em_nossa_base_de_dados.
-Unable_to_synchronize_bibliography=Não_foi_possível_sincronizar_a_bibliografia
-Combine_pairs_of_citations_that_are_separated_by_spaces_only=Combinar_pares_de_citações_que_são_separados_apenas_por_espaços
-Autodetection_failed=Falha_na_detecção_automática
+Cite\ in-text=Citar no texto
+Insert\ empty\ citation=Inserir citação vazia
+Merge\ citations=Unir citações
+Manual\ connect=Conexão manual
+Select\ Writer\ document=Selecionar documento Writer
+Sync\ OpenOffice/LibreOffice\ bibliography=Sincronizar bibliografia OpenOffice/LibreOffice
+Select\ which\ open\ Writer\ document\ to\ work\ on=Selecionar o documento Writer aberto a se trabalhar
+Connected\ to\ document=Conectado ao documento
+Insert\ a\ citation\ without\ text\ (the\ entry\ will\ appear\ in\ the\ reference\ list)=Inserir uma citação sem texto (a referência aparecerá na lista de referências)
+Cite\ selected\ entries\ with\ extra\ information=Citar as referências selecionadas com informações adicionais
+Ensure\ that\ the\ bibliography\ is\ up-to-date=Certifique-se que a bibliografia está atualizada
+Your\ OpenOffice/LibreOffice\ document\ references\ the\ BibTeX\ key\ '%0',\ which\ could\ not\ be\ found\ in\ your\ current\ library.=Seu documento do OpenOffice/LibreOffice referencia a chave BibTeX '%0', que não foi encontrada em nossa base de dados.
+Unable\ to\ synchronize\ bibliography=Não foi possível sincronizar a bibliografia
+Combine\ pairs\ of\ citations\ that\ are\ separated\ by\ spaces\ only=Combinar pares de citações que são separados apenas por espaços
+Autodetection\ failed=Falha na detecção automática
 Connecting=Conectando
-Please_wait...=Por_favor,_aguarde...
-Set_connection_parameters=Definir_parâmetros_de_conexão
-Path_to_OpenOffice/LibreOffice_directory=Caminho_para_o_diretório_OpenOffice/LibreOffice
-Path_to_OpenOffice/LibreOffice_executable=Caminho_para_o_executável_do_OpenOffice/LibreOffice
-Path_to_OpenOffice/LibreOffice_library_dir=Camino_para_diretório_de_bibliotecas_do_OpenOffice/LibreOffice
-Connection_lost=Conexão_perdida
-The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.=O_formato_de_parágrafo_é_controlado_pela_propriedade_'ReferenceParagraphFormat'_ou_Reference_HeaderParagraphFormat'_no_arquivo_de_estilos.
-The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.=O_formato_do_caracter_é_controlado_pela_propriedade_de_citação_'CitationCharacterFormat'_no_arquivo_de_estilos.
-Automatically_sync_bibliography_when_inserting_citations=Sincronizar_bibliografia_automaticamente_ao_inserir_citações
-Look_up_BibTeX_entries_in_the_active_tab_only=Pesquisar_por_referências_BibTeX_apenas_na_aba_ativa
-Look_up_BibTeX_entries_in_all_open_libraries=Pesquisar_referências_BibTeX_em_todas_as_bases_de_dados_abertas
-Autodetecting_paths...=Detectando_automaticamente_caminhos...
-Could_not_find_OpenOffice/LibreOffice_installation=Não_foi_possível_encontrar_uma_instalação_do_OpenOffice/LibreOffice
-Found_more_than_one_OpenOffice/LibreOffice_executable.=Um_ou_mais_executáveis_OpenOffice/LibreOffice_encontrados.
-Please_choose_which_one_to_connect_to\:=Por_favor,_escolha_um_deles_para_conectar-se\:
-Choose_OpenOffice/LibreOffice_executable=Escolher_um_executável_OpenOffice/LibreOffice
-Select_document=Selecionar_documento
-HTML_list=Lista_HTML
-If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting=Se_possível,_normalize_esta_lista_de_nomes_conforme_à_formação_de_nomes_BibTeX_padrão
-Could_not_open_%0=Não_foi_possível_abrir_%0
-Unknown_import_format=Formato_de_importação_desconhecido
-Web_search=Pesquisa_na_Web
-Style_selection=Seleção_de_estilo
-No_valid_style_file_defined=Nenhum_estilo_válido_definido
-Choose_pattern=Escolher_modelo
-Use_the_BIB_file_location_as_primary_file_directory=Utilizar_o_local_do_arquivo_BIB_como_diretório_de_arquivo_principal
-Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.=Não_foi_possível_executar_o_programa_gnuclient/emacsclient._Certifique-se_que_você_tem_o_programa_gnucliente/emacscliente_instalado_e_descrito_na_variável_de_ambiente_PATH.
-OpenOffice/LibreOffice_connection=Conexão_OpenOffice/LibreOffice
-You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.=Você_deve_selecionar_um_arquivo_de_estilo_válido_ou_utilizar_um_dos_estilos_padrão.
+Please\ wait...=Por favor, aguarde...
+Set\ connection\ parameters=Definir parâmetros de conexão
+Path\ to\ OpenOffice/LibreOffice\ directory=Caminho para o diretório OpenOffice/LibreOffice
+Path\ to\ OpenOffice/LibreOffice\ executable=Caminho para o executável do OpenOffice/LibreOffice
+Path\ to\ OpenOffice/LibreOffice\ library\ dir=Camino para diretório de bibliotecas do OpenOffice/LibreOffice
+Connection\ lost=Conexão perdida
+The\ paragraph\ format\ is\ controlled\ by\ the\ property\ 'ReferenceParagraphFormat'\ or\ 'ReferenceHeaderParagraphFormat'\ in\ the\ style\ file.=O formato de parágrafo é controlado pela propriedade 'ReferenceParagraphFormat' ou Reference HeaderParagraphFormat' no arquivo de estilos.
+The\ character\ format\ is\ controlled\ by\ the\ citation\ property\ 'CitationCharacterFormat'\ in\ the\ style\ file.=O formato do caracter é controlado pela propriedade de citação 'CitationCharacterFormat' no arquivo de estilos.
+Automatically\ sync\ bibliography\ when\ inserting\ citations=Sincronizar bibliografia automaticamente ao inserir citações
+Look\ up\ BibTeX\ entries\ in\ the\ active\ tab\ only=Pesquisar por referências BibTeX apenas na aba ativa
+Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=Pesquisar referências BibTeX em todas as bases de dados abertas
+Autodetecting\ paths...=Detectando automaticamente caminhos...
+Could\ not\ find\ OpenOffice/LibreOffice\ installation=Não foi possível encontrar uma instalação do OpenOffice/LibreOffice
+Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=Um ou mais executáveis OpenOffice/LibreOffice encontrados.
+Please\ choose\ which\ one\ to\ connect\ to\:=Por favor, escolha um deles para conectar-se:
+Choose\ OpenOffice/LibreOffice\ executable=Escolher um executável OpenOffice/LibreOffice
+Select\ document=Selecionar documento
+HTML\ list=Lista HTML
+If\ possible,\ normalize\ this\ list\ of\ names\ to\ conform\ to\ standard\ BibTeX\ name\ formatting=Se possível, normalize esta lista de nomes conforme à formação de nomes BibTeX padrão
+Could\ not\ open\ %0=Não foi possível abrir %0
+Unknown\ import\ format=Formato de importação desconhecido
+Web\ search=Pesquisa na Web
+Style\ selection=Seleção de estilo
+No\ valid\ style\ file\ defined=Nenhum estilo válido definido
+Choose\ pattern=Escolher modelo
+Use\ the\ BIB\ file\ location\ as\ primary\ file\ directory=Utilizar o local do arquivo BIB como diretório de arquivo principal
+Could\ not\ run\ the\ gnuclient/emacsclient\ program.\ Make\ sure\ you\ have\ the\ emacsclient/gnuclient\ program\ installed\ and\ available\ in\ the\ PATH.=Não foi possível executar o programa gnuclient/emacsclient. Certifique-se que você tem o programa gnucliente/emacscliente instalado e descrito na variável de ambiente PATH.
+OpenOffice/LibreOffice\ connection=Conexão OpenOffice/LibreOffice
+You\ must\ select\ either\ a\ valid\ style\ file,\ or\ use\ one\ of\ the\ default\ styles.=Você deve selecionar um arquivo de estilo válido ou utilizar um dos estilos padrão.
 
-This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.=Esta_é_uma_simples_janela_de_diálogo_Copiar_e_Colar._Primeiro_carregue_ou_cole_algum_texto_na_área_de_inserção_de_texto.<br>Em_seguida,_você_pode_marcar_o_texto_e_designá-lo_a_um_campo_BibTeX.
-This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.=Esta_funcionalidade_gera_uma_nova_base_de_dados_na_qual_as_referências_são_necessárias_em_um_documento_LaTex_existente
-You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.=Você_precisa_selecionar_uma_das_bases_de_dados_abertas_a_partir_da_qual_serão_selecionadas_as_referências,_bem_como_um_arquivo_AUX_produzido_pela_compilação_do_seu_arquivo_LaTex.
+This\ is\ a\ simple\ copy\ and\ paste\ dialog.\ First\ load\ or\ paste\ some\ text\ into\ the\ text\ input\ area.<br>After\ that,\ you\ can\ mark\ text\ and\ assign\ it\ to\ a\ BibTeX\ field.=Esta é uma simples janela de diálogo Copiar e Colar. Primeiro carregue ou cole algum texto na área de inserção de texto.<br>Em seguida, você pode marcar o texto e designá-lo a um campo BibTeX.
+This\ feature\ generates\ a\ new\ library\ based\ on\ which\ entries\ are\ needed\ in\ an\ existing\ LaTeX\ document.=Esta funcionalidade gera uma nova base de dados na qual as referências são necessárias em um documento LaTex existente
+You\ need\ to\ select\ one\ of\ your\ open\ libraries\ from\ which\ to\ choose\ entries,\ as\ well\ as\ the\ AUX\ file\ produced\ by\ LaTeX\ when\ compiling\ your\ document.=Você precisa selecionar uma das bases de dados abertas a partir da qual serão selecionadas as referências, bem como um arquivo AUX produzido pela compilação do seu arquivo LaTex.
 
-First_select_entries_to_clean_up.=Selecione_as_entradas_a_limpar
-Cleanup_entry=Limpar_referência
-Autogenerate_PDF_Names=Gerar_nomes_dos_PDFs_automaticamente
-Auto-generating_PDF-Names_does_not_support_undo._Continue?=Não_será_possível_desfazer_a_auto_geração_de_nomes_de_PDFs._Continuar_mesmo_assim?
+First\ select\ entries\ to\ clean\ up.=Selecione as entradas a limpar
+Cleanup\ entry=Limpar referência
+Autogenerate\ PDF\ Names=Gerar nomes dos PDFs automaticamente
+Auto-generating\ PDF-Names\ does\ not\ support\ undo.\ Continue?=Não será possível desfazer a auto geração de nomes de PDFs. Continuar mesmo assim?
 
-Use_full_firstname_whenever_possible=Usar_primeiro_nome_inteiro_sempre_que_possível
-Use_abbreviated_firstname_whenever_possible=Usar_primeiro_nome_abreviado_sempre_que_possível
-Use_abbreviated_and_full_firstname=Usar_primeiro_nome_abreviado_e_inteiro
-Autocompletion_options=Opções_de_autocompletar
-Name_format_used_for_autocompletion=Formato_de_nome_usado_para_autocompletar
-Treatment_of_first_names=Tratamento_dos_primeiros_nomes
-Cleanup_entries=Limpar_entradas
-Automatically_assign_new_entry_to_selected_groups=Designar_automaticamente_novas_referências_para_os_grupos_selecionados
-%0_mode=Modo_%0
-Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix=Mover_DOIs_dos_campos_note_e_URL_para_o_campo_DOI_e_remover_o_prefixo_http
-Make_paths_of_linked_files_relative_(if_possible)=Tornar_os_caminhos_dos_arquivos_relativos_(se_possível)
-Rename_PDFs_to_given_filename_format_pattern=Renomear_PDFs_para_o_padrão_de_nome_definido
-Rename_only_PDFs_having_a_relative_path=Renomear_apenas_os_PDFs_que_tem_caminho_relativo
-What_would_you_like_to_clean_up?=O_que_você_deseja_limpar?
-Doing_a_cleanup_for_%0_entries...=Limpando_%0_entradas...
-No_entry_needed_a_clean_up=Nenhuma_referência_precisou_de_limpeza
-One_entry_needed_a_clean_up=Uma_referência_necessitou_limpeza
-%0_entries_needed_a_clean_up=%0_entradas_necessitaram_limpeza
+Use\ full\ firstname\ whenever\ possible=Usar primeiro nome inteiro sempre que possível
+Use\ abbreviated\ firstname\ whenever\ possible=Usar primeiro nome abreviado sempre que possível
+Use\ abbreviated\ and\ full\ firstname=Usar primeiro nome abreviado e inteiro
+Autocompletion\ options=Opções de autocompletar
+Name\ format\ used\ for\ autocompletion=Formato de nome usado para autocompletar
+Treatment\ of\ first\ names=Tratamento dos primeiros nomes
+Cleanup\ entries=Limpar entradas
+Automatically\ assign\ new\ entry\ to\ selected\ groups=Designar automaticamente novas referências para os grupos selecionados
+%0\ mode=Modo %0
+Move\ DOIs\ from\ note\ and\ URL\ field\ to\ DOI\ field\ and\ remove\ http\ prefix=Mover DOIs dos campos note e URL para o campo DOI e remover o prefixo http
+Make\ paths\ of\ linked\ files\ relative\ (if\ possible)=Tornar os caminhos dos arquivos relativos (se possível)
+Rename\ PDFs\ to\ given\ filename\ format\ pattern=Renomear PDFs para o padrão de nome definido
+Rename\ only\ PDFs\ having\ a\ relative\ path=Renomear apenas os PDFs que tem caminho relativo
+What\ would\ you\ like\ to\ clean\ up?=O que você deseja limpar?
+Doing\ a\ cleanup\ for\ %0\ entries...=Limpando %0 entradas...
+No\ entry\ needed\ a\ clean\ up=Nenhuma referência precisou de limpeza
+One\ entry\ needed\ a\ clean\ up=Uma referência necessitou limpeza
+%0\ entries\ needed\ a\ clean\ up=%0 entradas necessitaram limpeza
 
-Remove_selected=Remover_Selecionados
+Remove\ selected=Remover Selecionados
 
-Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.=Árvore_de_agrupamento_não_pode_ser_interpretada._Se_você_salvar_sua_base_de_dados_BibTeX,_todos_os_grupos_serão_perdidos
-Attach_file=Anexar_arquivo
-Setting_all_preferences_to_default_values.=Definindo_todas_as_preferências_para_os_valores_padrão
-Resetting_preference_key_'%0'=Redefinindo_preferência_'%0'
-Unknown_preference_key_'%0'=Preferência_desconhecida_'%0"
-Unable_to_clear_preferences.=Não_foi_possível_limpar_as_preferências
+Group\ tree\ could\ not\ be\ parsed.\ If\ you\ save\ the\ BibTeX\ library,\ all\ groups\ will\ be\ lost.=Árvore de agrupamento não pode ser interpretada. Se você salvar sua base de dados BibTeX, todos os grupos serão perdidos
+Attach\ file=Anexar arquivo
+Setting\ all\ preferences\ to\ default\ values.=Definindo todas as preferências para os valores padrão
+Resetting\ preference\ key\ '%0'=Redefinindo preferência '%0'
+Unknown\ preference\ key\ '%0'=Preferência desconhecida '%0"
+Unable\ to\ clear\ preferences.=Não foi possível limpar as preferências
 
-Reset_preferences_(key1,key2,..._or_'all')=Redefinir_preferências_(key1,key2,..._ou_todas)
-Find_unlinked_files=Encontrar_arquivos_não_referenciados
-Unselect_all=Desmarcar_todas
-Expand_all=Expandir_todos
-Collapse_all=Reduzir_todos
-Opens_the_file_browser.=Abrir_o_gerenciador_de_arquivos
-Scan_directory=Varrer_diretório
-Searches_the_selected_directory_for_unlinked_files.=Buscar_arquivos_não_referenciados_no_diretório_selecionado
-Starts_the_import_of_BibTeX_entries.=Iniciar_a_importação_de_entradas_BibTeX
-Leave_this_dialog.=Deixar_esse_diálogo.
-Create_directory_based_keywords=Criar_diretórios_baseados_em_palavras-chave
-Creates_keywords_in_created_entrys_with_directory_pathnames=Criar_palavras-chave_nas_referências_criadas_com_caminhos_de_diretórios
-Select_a_directory_where_the_search_shall_start.=Selecione_um_diretório_em_que_a_busca_deve_começar
-Select_file_type\:=Selecione_o_arquivo
-These_files_are_not_linked_in_the_active_library.=Esses_arquivos_não_são_referenciados_na_base_de_dados_ativa
-Entry_type_to_be_created\:=Tipo_de_referência_a_ser_criada
-Searching_file_system...=Buscando_sistema_de_arquivo...
-Importing_into_Library...=Importando_na_base_de_dados
-Select_directory=Selecionar_diretório
-Select_files=Selecionar_arquivos
-BibTeX_entry_creation=Criação_de_referência_BibTeX
-<No_selection>=<Sem_seleção>
-Unable_to_connect_to_FreeCite_online_service.=Não_foi_possível_conectar_ao_serviço_FreeCite
-Parse_with_FreeCite=Interpretar_com_FreeCite
-The_current_BibTeX_key_will_be_overwritten._Continue?=A_chave_BibTeX_atual_será_sobrescrita._Continuar_mesmo_assim?
-Overwrite_key=Sobrescrever_chave
-Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator=Chave_existente_NÃO_foi_sobrescrita._Para_mudar_essa_configuração_abra_Opções_->_Preferências_->_Gerador_de_chaves_BibTeX
-How_would_you_like_to_link_to_'%0'?=Como_deseja_ligar_ao_'%0'?
-BibTeX_key_patterns=Padrões_de_chaves_BibTeX
-Changed_special_field_settings=Preferências_de_campos_especiais_alteradas
-Clear_priority=Limpar_prioridades
-Clear_rank=Limpar_classificação
-Enable_special_fields=Habilitar_campos_especiais
-One_star=Uma_estrela
-Two_stars=Duas_estrelas
-Three_stars=Três_estrelas
-Four_stars=Quatro_estrelas
-Five_stars=Cinco_estrelas
-Help_on_special_fields=Ajuda_com_campos_especiais
-Keywords_of_selected_entries=Palavras-chave_das_entradas_selecionadas
-Manage_content_selectors=Gerenciar_seletores_de_conteúdo
-Manage_keywords=Gerenciar_palavras-chave
-No_priority_information=Sem_informações_de_prioridade
-No_rank_information=Sem_informações_de_classificação
+Reset\ preferences\ (key1,key2,...\ or\ 'all')=Redefinir preferências (key1,key2,... ou todas)
+Find\ unlinked\ files=Encontrar arquivos não referenciados
+Unselect\ all=Desmarcar todas
+Expand\ all=Expandir todos
+Collapse\ all=Reduzir todos
+Opens\ the\ file\ browser.=Abrir o gerenciador de arquivos
+Scan\ directory=Varrer diretório
+Searches\ the\ selected\ directory\ for\ unlinked\ files.=Buscar arquivos não referenciados no diretório selecionado
+Starts\ the\ import\ of\ BibTeX\ entries.=Iniciar a importação de entradas BibTeX
+Leave\ this\ dialog.=Deixar esse diálogo.
+Create\ directory\ based\ keywords=Criar diretórios baseados em palavras-chave
+Creates\ keywords\ in\ created\ entrys\ with\ directory\ pathnames=Criar palavras-chave nas referências criadas com caminhos de diretórios
+Select\ a\ directory\ where\ the\ search\ shall\ start.=Selecione um diretório em que a busca deve começar
+Select\ file\ type\:=Selecione o arquivo
+These\ files\ are\ not\ linked\ in\ the\ active\ library.=Esses arquivos não são referenciados na base de dados ativa
+Entry\ type\ to\ be\ created\:=Tipo de referência a ser criada
+Searching\ file\ system...=Buscando sistema de arquivo...
+Importing\ into\ Library...=Importando na base de dados
+Select\ directory=Selecionar diretório
+Select\ files=Selecionar arquivos
+BibTeX\ entry\ creation=Criação de referência BibTeX
+<No\ selection>=<Sem seleção>
+Unable\ to\ connect\ to\ FreeCite\ online\ service.=Não foi possível conectar ao serviço FreeCite
+Parse\ with\ FreeCite=Interpretar com FreeCite
+The\ current\ BibTeX\ key\ will\ be\ overwritten.\ Continue?=A chave BibTeX atual será sobrescrita. Continuar mesmo assim?
+Overwrite\ key=Sobrescrever chave
+Not\ overwriting\ existing\ key.\ To\ change\ this\ setting,\ open\ Options\ ->\ Prefererences\ ->\ BibTeX\ key\ generator=Chave existente NÃO foi sobrescrita. Para mudar essa configuração abra Opções -> Preferências -> Gerador de chaves BibTeX
+How\ would\ you\ like\ to\ link\ to\ '%0'?=Como deseja ligar ao '%0'?
+BibTeX\ key\ patterns=Padrões de chaves BibTeX
+Changed\ special\ field\ settings=Preferências de campos especiais alteradas
+Clear\ priority=Limpar prioridades
+Clear\ rank=Limpar classificação
+Enable\ special\ fields=Habilitar campos especiais
+One\ star=Uma estrela
+Two\ stars=Duas estrelas
+Three\ stars=Três estrelas
+Four\ stars=Quatro estrelas
+Five\ stars=Cinco estrelas
+Help\ on\ special\ fields=Ajuda com campos especiais
+Keywords\ of\ selected\ entries=Palavras-chave das entradas selecionadas
+Manage\ content\ selectors=Gerenciar seletores de conteúdo
+Manage\ keywords=Gerenciar palavras-chave
+No\ priority\ information=Sem informações de prioridade
+No\ rank\ information=Sem informações de classificação
 Priority=Prioridade
-Priority_high=Alta_prioridade
-Priority_low=Baixa_prioridade
-Priority_medium=Média_prioridade
+Priority\ high=Alta prioridade
+Priority\ low=Baixa prioridade
+Priority\ medium=Média prioridade
 Quality=Qualidade
 Rank=Classificação
 Relevance=Relevância
-Set_priority_to_high=Definir_prioridade_como_alta
-Set_priority_to_low=Definir_prioridade_como_baixa
-Set_priority_to_medium=Definir_prioridade_como_média
-Show_priority=Mostrar_prioridade
-Show_quality=Mostrar_qualidade
-Show_rank=Mostrar_classificação(estrelas)
-Show_relevance=Mostrar_relevância
-Synchronize_with_keywords=Sincronizar_com_palavras-chave
-Synchronized_special_fields_based_on_keywords=Campos_especiais_sincronizados_com_base_nas_palavras-chave
-Toggle_relevance=Alternar_relevância
-Toggle_quality_assured=Alteranar_qualidade_garantida
-Toggle_print_status=Status_de_leitura_alternado
-Update_keywords=Atualizar_palavras-chave
-Write_values_of_special_fields_as_separate_fields_to_BibTeX=Escrever_valores_dos_campos_especiais_como_campos_separados_do_BibTeX
-You_have_changed_settings_for_special_fields.=Você_alterou_as_configurações_de_campos_especiais
-%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.=%0_entradas_encontradas._Para_reduzir_a_carga_do_servidor,_apenas_%1_serão_baixados.
-A_string_with_that_label_already_exists=Uma_string_com_esse_label_já_existe
-Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.=Conexão_com_o_OpenOffice/LibreOffice_foi_perdida._Por_favor_certifique-se_de_que_o_OpenOffice/LibreOffice_está_rodando,_e_tente_reconectar
-JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.=
-Correct_the_entry,_and_reopen_editor_to_display/edit_source.=Corrija_a_referência,_e_abra_o_editor_novamente_para_mostrar/editar_o_fonte
-Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').=Não_foi_possível_conectar_a_um_processo_gnuserv._Assegure-se_de_que_o_Emacs_ou_XEmacs_está_rodando,<BR>e_que_o_servidor_foi_iniciado_(por_meio_do_comando_'server-start1/'gnu-serv-start').
-Could_not_connect_to_running_OpenOffice/LibreOffice.=Não_foi_possível_conectar_ao_OpenOffice/LibreOffice.
-Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.=Assegure-se_que_o_OpenOffice/LibreOffice_está_instalado_com_suporte_Java.
-If_connecting_manually,_please_verify_program_and_library_paths.=Se_estiver_conectando_manualmente,_por_favor_verifique_o_caminho_do_programa_e_da_biblioteca.
-Error_message\:=Mensagem_de_erro\:
-If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.=Se_a_referência_colada_ou_importada_já_possuir_o_campo_definido,_sobrescrever.
-Import_metadata_from_PDF=Importar_Metadados_do_PDF
-Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.=Não_conectado_a_nenhum_documento_do_Writer._Por_favor_assegure-se_de_que_um_documento_está_aberto,_e_use_o_botão_'Selecionar_documento_do_Writer'_para_conectar_a_ele.
-Removed_all_subgroups_of_group_"%0".=Todos_os_subgrupos_do_grupo_"%0"_foram_removidos.
-To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.=Para_desabilitar_o_modo_memory_stick_renomeie_ou_remova_o_arquivo_jabref.xml_no_mesmo_diretório_que_o_JabRef
-Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.=Não_possível_conectar._Uma_possível_razão_é_que_o_JabRef_e_o_OpenOffice/LibreOffice_não_estão_rodando_no_mesmo_modo\:_32_bits_ou_64_bits.
-Use_the_following_delimiter_character(s)\:=Use_o(s)_seguinte(s)_caracter(es)_delimitador(es)\:
-When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above=Quand_estiver_baixando_arquivos,_ou_mesmo_movendo_arquivos_ao_diretório,_dê_preferência_ao_local_onde_está_o_seu_arquivo_bib.
-Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=Seu_arquivo_de_estilo_especifica_o_formato_de_caracter_'%0',_que_não_está_definido_no_seu_documento_OpenOffice/LibreOffice_atual
-Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=Seu_arquivo_de_estilo_especifica_o_formato_de_parágrafo_'%0',_que_não_está_definido_no_seu_documento_OpenOffice/LibreOffice_atual
+Set\ priority\ to\ high=Definir prioridade como alta
+Set\ priority\ to\ low=Definir prioridade como baixa
+Set\ priority\ to\ medium=Definir prioridade como média
+Show\ priority=Mostrar prioridade
+Show\ quality=Mostrar qualidade
+Show\ rank=Mostrar classificação(estrelas)
+Show\ relevance=Mostrar relevância
+Synchronize\ with\ keywords=Sincronizar com palavras-chave
+Synchronized\ special\ fields\ based\ on\ keywords=Campos especiais sincronizados com base nas palavras-chave
+Toggle\ relevance=Alternar relevância
+Toggle\ quality\ assured=Alteranar qualidade garantida
+Toggle\ print\ status=Status de leitura alternado
+Update\ keywords=Atualizar palavras-chave
+Write\ values\ of\ special\ fields\ as\ separate\ fields\ to\ BibTeX=Escrever valores dos campos especiais como campos separados do BibTeX
+You\ have\ changed\ settings\ for\ special\ fields.=Você alterou as configurações de campos especiais
+%0\ entries\ found.\ To\ reduce\ server\ load,\ only\ %1\ will\ be\ downloaded.=%0 entradas encontradas. Para reduzir a carga do servidor, apenas %1 serão baixados.
+A\ string\ with\ that\ label\ already\ exists=Uma string com esse label já existe
+Connection\ to\ OpenOffice/LibreOffice\ has\ been\ lost.\ Please\ make\ sure\ OpenOffice/LibreOffice\ is\ running,\ and\ try\ to\ reconnect.=Conexão com o OpenOffice/LibreOffice foi perdida. Por favor certifique-se de que o OpenOffice/LibreOffice está rodando, e tente reconectar
+JabRef\ will\ send\ at\ least\ one\ request\ per\ entry\ to\ a\ publisher.=
+Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=Corrija a referência, e abra o editor novamente para mostrar/editar o fonte
+Could\ not\ connect\ to\ a\ running\ gnuserv\ process.\ Make\ sure\ that\ Emacs\ or\ XEmacs\ is\ running,<BR>and\ that\ the\ server\ has\ been\ started\ (by\ running\ the\ command\ 'server-start'/'gnuserv-start').=Não foi possível conectar a um processo gnuserv. Assegure-se de que o Emacs ou XEmacs está rodando,<BR>e que o servidor foi iniciado (por meio do comando 'server-start1/'gnu-serv-start').
+Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=Não foi possível conectar ao OpenOffice/LibreOffice.
+Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=Assegure-se que o OpenOffice/LibreOffice está instalado com suporte Java.
+If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=Se estiver conectando manualmente, por favor verifique o caminho do programa e da biblioteca.
+Error\ message\:=Mensagem de erro:
+If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=Se a referência colada ou importada já possuir o campo definido, sobrescrever.
+Import\ metadata\ from\ PDF=Importar Metadados do PDF
+Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=Não conectado a nenhum documento do Writer. Por favor assegure-se de que um documento está aberto, e use o botão 'Selecionar documento do Writer' para conectar a ele.
+Removed\ all\ subgroups\ of\ group\ "%0".=Todos os subgrupos do grupo "%0" foram removidos.
+To\ disable\ the\ memory\ stick\ mode\ rename\ or\ remove\ the\ jabref.xml\ file\ in\ the\ same\ folder\ as\ JabRef.=Para desabilitar o modo memory stick renomeie ou remova o arquivo jabref.xml no mesmo diretório que o JabRef
+Unable\ to\ connect.\ One\ possible\ reason\ is\ that\ JabRef\ and\ OpenOffice/LibreOffice\ are\ not\ both\ running\ in\ either\ 32\ bit\ mode\ or\ 64\ bit\ mode.=Não possível conectar. Uma possível razão é que o JabRef e o OpenOffice/LibreOffice não estão rodando no mesmo modo: 32 bits ou 64 bits.
+Use\ the\ following\ delimiter\ character(s)\:=Use o(s) seguinte(s) caracter(es) delimitador(es):
+When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\ prefer\ the\ BIB\ file\ location\ rather\ than\ the\ file\ directory\ set\ above=Quand estiver baixando arquivos, ou mesmo movendo arquivos ao diretório, dê preferência ao local onde está o seu arquivo bib.
+Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Seu arquivo de estilo especifica o formato de caracter '%0', que não está definido no seu documento OpenOffice/LibreOffice atual
+Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Seu arquivo de estilo especifica o formato de parágrafo '%0', que não está definido no seu documento OpenOffice/LibreOffice atual
 
 Searching...=Buscando...
-You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?=Você_selecionou_mais_de_%0_entradas_para_download._Alguns_sites_podem_bloquear_seu_acesso_se_você_fizer_muitos_downloads_num_período_curto_de_tempo._Deseja_continuar_mesmo_assim?
-Confirm_selection=Confirmar_seleção
-Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case=Adicione_{}_às_palavras_do_título_na_busca_para_manter_maiúsculas_minúsculas
-Import_conversions=Importar_conversões
-Please_enter_a_search_string=Favor_digitar_uma_string_de_busca
-Please_open_or_start_a_new_library_before_searching=Por_favor,_abra_ou_inicie_uma_base_de_dados_antes_de_realizar_a_busca
+You\ have\ selected\ more\ than\ %0\ entries\ for\ download.\ Some\ web\ sites\ might\ block\ you\ if\ you\ make\ too\ many\ rapid\ downloads.\ Do\ you\ want\ to\ continue?=Você selecionou mais de %0 entradas para download. Alguns sites podem bloquear seu acesso se você fizer muitos downloads num período curto de tempo. Deseja continuar mesmo assim?
+Confirm\ selection=Confirmar seleção
+Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=Adicione {} às palavras do título na busca para manter maiúsculas minúsculas
+Import\ conversions=Importar conversões
+Please\ enter\ a\ search\ string=Favor digitar uma string de busca
+Please\ open\ or\ start\ a\ new\ library\ before\ searching=Por favor, abra ou inicie uma base de dados antes de realizar a busca
 
-Canceled_merging_entries=União_das_referências_cancelada
+Canceled\ merging\ entries=União das referências cancelada
 
-Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search=Formatar_unidades_adicionando_separadores_sem_quebras_e_manter_maiúsculas_e_minúsculas_na_busca
-Merge_entries=Mesclar_referências
-Merged_entries=Mesclou_referências_em_uma_nova_e_manteve_a_antiga
-Merged_entry=Referência_mesclada
+Format\ units\ by\ adding\ non-breaking\ separators\ and\ keeping\ the\ correct\ case\ on\ search=Formatar unidades adicionando separadores sem quebras e manter maiúsculas e minúsculas na busca
+Merge\ entries=Mesclar referências
+Merged\ entries=Mesclou referências em uma nova e manteve a antiga
+Merged\ entry=Referência mesclada
 None=None
 Parse=Interpretar
 Result=Resultado
-Show_DOI_first=Mostrar_DOI_antes
-Show_URL_first=Mostrar_URL_antes
-Use_Emacs_key_bindings=Usar_combinações_de_teclas_do_Emacs
-You_have_to_choose_exactly_two_entries_to_merge.=Você_deve_escolher_exatamente_duas_referências_para_mesclar
+Show\ DOI\ first=Mostrar DOI antes
+Show\ URL\ first=Mostrar URL antes
+Use\ Emacs\ key\ bindings=Usar combinações de teclas do Emacs
+You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=Você deve escolher exatamente duas referências para mesclar
 
-Update_timestamp_on_modification=Atualizar_timestamp_na_modificação
-All_key_bindings_will_be_reset_to_their_defaults.=Todas_as_teclas_de_atalho_serão_reconfiguradas_para_seus_valores_padrão.
+Update\ timestamp\ on\ modification=Atualizar timestamp na modificação
+All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=Todas as teclas de atalho serão reconfiguradas para seus valores padrão.
 
-Automatically_set_file_links=Definir_links_para_os_arquivos_automaticamente
-Resetting_all_key_bindings=Redefinindo_todas_as_teclas_de_atalho
+Automatically\ set\ file\ links=Definir links para os arquivos automaticamente
+Resetting\ all\ key\ bindings=Redefinindo todas as teclas de atalho
 Hostname=Host
-Invalid_setting=Configuração_Inválida
+Invalid\ setting=Configuração Inválida
 Network=Rede
-Please_specify_both_hostname_and_port=Por_favor,_especifique_o_hostname_e_a_porta
-Please_specify_both_username_and_password=
+Please\ specify\ both\ hostname\ and\ port=Por favor, especifique o hostname e a porta
+Please\ specify\ both\ username\ and\ password=
 
-Use_custom_proxy_configuration=Usar_configurações_personalizadas_de_proxy
-Proxy_requires_authentication=
-Attention\:_Password_is_stored_in_plain_text\!=
-Clear_connection_settings=Limpar_configurações_da_conexão
-Cleared_connection_settings.=Configurações_de_conexão_foram_limpas.
+Use\ custom\ proxy\ configuration=Usar configurações personalizadas de proxy
+Proxy\ requires\ authentication=
+Attention\:\ Password\ is\ stored\ in\ plain\ text\!=
+Clear\ connection\ settings=Limpar configurações da conexão
+Cleared\ connection\ settings.=Configurações de conexão foram limpas.
 
-Rebind_C-a,_too=Recombinar_C-a_também
-Rebind_C-f,_too=Recombinar_C-f_também
+Rebind\ C-a,\ too=Recombinar C-a também
+Rebind\ C-f,\ too=Recombinar C-f também
 
-Open_folder=Abrir_pasta
-Searches_for_unlinked_PDF_files_on_the_file_system=Busca_por_arquivos_PDF_não_referenciados_no_sistema_de_arquivos
-Export_entries_ordered_as_specified=Exportar_entradas_como_especificado
-Export_sort_order=Exportar_ordenação
-Export_sorting=
-Newline_separator=Separador_de_quebra_de_linha
+Open\ folder=Abrir pasta
+Searches\ for\ unlinked\ PDF\ files\ on\ the\ file\ system=Busca por arquivos PDF não referenciados no sistema de arquivos
+Export\ entries\ ordered\ as\ specified=Exportar entradas como especificado
+Export\ sort\ order=Exportar ordenação
+Export\ sorting=
+Newline\ separator=Separador de quebra de linha
 
-Save_entries_ordered_as_specified=Salvar_entradas_como_especificado
-Save_sort_order=Salvar_ordenação
-Show_extra_columns=Mostrar_colunas_extra
-Parsing_error=Erro_de_interpretação
-illegal_backslash_expression=Expressã_ilegal_com_contrabarra
+Save\ entries\ ordered\ as\ specified=Salvar entradas como especificado
+Save\ sort\ order=Salvar ordenação
+Show\ extra\ columns=Mostrar colunas extra
+Parsing\ error=Erro de interpretação
+illegal\ backslash\ expression=Expressã ilegal com contrabarra
 
-Move_to_group=Mover_para_grupo
+Move\ to\ group=Mover para grupo
 
-Clear_read_status=Limpar_status_de_leitura
-Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')=Converter_para_o_formato_Biblatex_(por_exemplo,_mude_o_valor_do_campo_'journal'_para_'journaltitle')
-Could_not_apply_changes.=Não_foi_possível_realizar_as_mudanças.
-Deprecated_fields=Campo_em_desuso
-Hide/show_toolbar=Mostrar/esconder_barra_de_ferramentas
-No_read_status_information=Sem_informação_sobre_status_da_leitura
+Clear\ read\ status=Limpar status de leitura
+Convert\ to\ biblatex\ format\ (for\ example,\ move\ the\ value\ of\ the\ 'journal'\ field\ to\ 'journaltitle')=Converter para o formato Biblatex (por exemplo, mude o valor do campo 'journal' para 'journaltitle')
+Could\ not\ apply\ changes.=Não foi possível realizar as mudanças.
+Deprecated\ fields=Campo em desuso
+Hide/show\ toolbar=Mostrar/esconder barra de ferramentas
+No\ read\ status\ information=Sem informação sobre status da leitura
 Printed=Impresso
-Read_status=Status_da_leitura
-Read_status_read=Status_de_leitura_lido
-Read_status_skimmed=Status_de_leitura_folheado
-Save_selected_as_plain_BibTeX...=Salvar_selecionado_como_BibTeX_simples
-Set_read_status_to_read=Definir_como_Lido
-Set_read_status_to_skimmed=Definir_como_Folheado
-Show_deprecated_BibTeX_fields=Mostrar_campos_BibTeX_em_desuso
+Read\ status=Status da leitura
+Read\ status\ read=Status de leitura lido
+Read\ status\ skimmed=Status de leitura folheado
+Save\ selected\ as\ plain\ BibTeX...=Salvar selecionado como BibTeX simples
+Set\ read\ status\ to\ read=Definir como Lido
+Set\ read\ status\ to\ skimmed=Definir como Folheado
+Show\ deprecated\ BibTeX\ fields=Mostrar campos BibTeX em desuso
 
-Show_gridlines=Mostrar_linhas_de_grade
-Show_printed_status=Mostrar_status_de_impressão
-Show_read_status=Mostrar_status_da_leitura
-Table_row_height_padding=Preenchimento_(padding)_da_altura_das_linhas_da_tabela
+Show\ gridlines=Mostrar linhas de grade
+Show\ printed\ status=Mostrar status de impressão
+Show\ read\ status=Mostrar status da leitura
+Table\ row\ height\ padding=Preenchimento (padding) da altura das linhas da tabela
 
-Marked_selected_entry=Registro_selecionado_marcado
-Marked_all_%0_selected_entries=Marcadas_todos_os_%0_registros
-Unmarked_selected_entry=Registro_selecionado_desmarcado
-Unmarked_all_%0_selected_entries=Desmarcados_todos_os_%0_registros
+Marked\ selected\ entry=Registro selecionado marcado
+Marked\ all\ %0\ selected\ entries=Marcadas todos os %0 registros
+Unmarked\ selected\ entry=Registro selecionado desmarcado
+Unmarked\ all\ %0\ selected\ entries=Desmarcados todos os %0 registros
 
 
-Unmarked_all_entries=Todos_os_registros_desmarcados
+Unmarked\ all\ entries=Todos os registros desmarcados
 
-Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.=Não_foi_possivel_encontrar_o_look_and_feel_selecionado,_o_look_and_feel_padrão_sera_usado.
+Unable\ to\ find\ the\ requested\ look\ and\ feel\ and\ thus\ the\ default\ one\ is\ used.=Não foi possivel encontrar o look and feel selecionado, o look and feel padrão sera usado.
 
-Opens_JabRef's_GitHub_page=Abrir_a_página_do_JabRef_no_GitHub
-Could_not_open_browser.=Não_foi_possível_abrir_o_navegador.
-Please_open_%0_manually.=Por_favor_abra_%0_manualmente.
-The_link_has_been_copied_to_the_clipboard.=O_link_foi_copiado_para_a_área_de_transferência
+Opens\ JabRef's\ GitHub\ page=Abrir a página do JabRef no GitHub
+Could\ not\ open\ browser.=Não foi possível abrir o navegador.
+Please\ open\ %0\ manually.=Por favor abra %0 manualmente.
+The\ link\ has\ been\ copied\ to\ the\ clipboard.=O link foi copiado para a área de transferência
 
-Open_%0_file=Abrir_%0_arquivo
+Open\ %0\ file=Abrir %0 arquivo
 
-Cannot_delete_file=Impossível_remover_arquivo
-File_permission_error=Erro_de_permissão_de_arquivo
-Push_to_%0=Mover_para_%0
-Path_to_%0=Caminho_para_%0
+Cannot\ delete\ file=Impossível remover arquivo
+File\ permission\ error=Erro de permissão de arquivo
+Push\ to\ %0=Mover para %0
+Path\ to\ %0=Caminho para %0
 Convert=Converter
-Normalize_to_BibTeX_name_format=Normalizar_para_o_formato_de_nome_do_BibTeX
-Help_on_Name_Formatting=Ajuda_na_formatação_do_nome
+Normalize\ to\ BibTeX\ name\ format=Normalizar para o formato de nome do BibTeX
+Help\ on\ Name\ Formatting=Ajuda na formatação do nome
 
-Add_new_file_type=Adicionar_novo_tipo_de_arquivo
+Add\ new\ file\ type=Adicionar novo tipo de arquivo
 
-Left_entry=Referência_da_esquerda
-Right_entry=Referência_da_direita
+Left\ entry=Referência da esquerda
+Right\ entry=Referência da direita
 Use=Usar
-Original_entry=Referência_original
-Replace_original_entry=Substituir_referência_original
-No_information_added=Nenhuma_informação_foi_adicionada
-Select_at_least_one_entry_to_manage_keywords.=Selecione_pelo_menos_uma_entrada_para_gerenciar_as_chaves.
-OpenDocument_text=Texto_OpenDocument
-OpenDocument_spreadsheet=Planilha_OpenDocument
-OpenDocument_presentation=Apresentação_OpenDocument
-%0_image=Imagem_%0
-Added_entry=Referência_adicionada
-Modified_entry=Referência_modificada
-Deleted_entry=Referência_removida
-Modified_groups_tree=Árvore_de_grupos_alterada
-Removed_all_groups=Todos_os_grupos_removidos
-Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.=Ao_aceitar_as_alterações_toda_a_árvore_de_grupos_será_substituda_pela_árvore_de_grupos_modificada_externamente.
-Select_export_format=Selecione_o_formato_de_Exportação
-Return_to_JabRef=Retornar_ao_JabRef
-Please_move_the_file_manually_and_link_in_place.=Por_favor_mova_o_arquivo_manualmente_e_crie_o_link.
-Could_not_connect_to_%0=Não_foi_possível_conectar_a_%0
-Warning\:_%0_out_of_%1_entries_have_undefined_title.=Alerta\:_%0_de_%1_referências_não_tem_título_definido.
-Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.=Alerta\:_%0_de_%1_referências_não_tem_chave_definida.
+Original\ entry=Referência original
+Replace\ original\ entry=Substituir referência original
+No\ information\ added=Nenhuma informação foi adicionada
+Select\ at\ least\ one\ entry\ to\ manage\ keywords.=Selecione pelo menos uma entrada para gerenciar as chaves.
+OpenDocument\ text=Texto OpenDocument
+OpenDocument\ spreadsheet=Planilha OpenDocument
+OpenDocument\ presentation=Apresentação OpenDocument
+%0\ image=Imagem %0
+Added\ entry=Referência adicionada
+Modified\ entry=Referência modificada
+Deleted\ entry=Referência removida
+Modified\ groups\ tree=Árvore de grupos alterada
+Removed\ all\ groups=Todos os grupos removidos
+Accepting\ the\ change\ replaces\ the\ complete\ groups\ tree\ with\ the\ externally\ modified\ groups\ tree.=Ao aceitar as alterações toda a árvore de grupos será substituda pela árvore de grupos modificada externamente.
+Select\ export\ format=Selecione o formato de Exportação
+Return\ to\ JabRef=Retornar ao JabRef
+Please\ move\ the\ file\ manually\ and\ link\ in\ place.=Por favor mova o arquivo manualmente e crie o link.
+Could\ not\ connect\ to\ %0=Não foi possível conectar a %0
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ title.=Alerta: %0 de %1 referências não tem título definido.
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ BibTeX\ key.=Alerta: %0 de %1 referências não tem chave definida.
 occurrence=ocorrência
-Added_new_'%0'_entry.=%0_novas_referências_adicionadas
-Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?=Múltiplas_referências_selecionadas._Deseja_alterar_o_tipo_de_todas?
-Changed_type_to_'%0'_for=Tipo_modificado_para_'%0'_para
-Really_delete_the_selected_entry?=Você_realmente_deseja_remover_a_referência_selecionada?
-Really_delete_the_%0_selected_entries?=Você_realmente_deseja_remover_as_%0_referências_selecionadas?
-Keep_merged_entry_only=Manter_a_referência_combinada_apenas
-Keep_left=Manter_a_da_direita
-Keep_right=Manter_a_da_esquerda
-Old_entry=Referência_antiga
-From_import=Da_importação
-No_problems_found.=Nenhum_problema_encontrado.
-%0_problem(s)_found=%0_problema\(s\)_encontrado\(s\)
-Save_changes=Salvar_mudanças.
-Discard_changes=Descartar_mudanças
-Library_'%0'_has_changed.=Base_de_dados_'%0'_mudou.
-Print_entry_preview=Imprimir_preview_da_referência
-Copy_title=Copiar_título
-Copy_\\cite{BibTeX_key}=Copiar_como_\\cite{chave_BibTeX}
-Copy_BibTeX_key_and_title=Copiar_chave_BibTeX_e_título
-File_rename_failed_for_%0_entries.=Renomeação_de_arquivo_falho_para_%0_referências
-Merged_BibTeX_source_code=Código_BibTex_combinado
-Invalid_DOI\:_'%0'.=DOI_inválida\:_'%0'.
-should_start_with_a_name=deve_iniciar_com_um_nome
-should_end_with_a_name=deve_terminar_com_um_nome
-unexpected_closing_curly_bracket=fechamento_de_chaves_inesperado_}
-unexpected_opening_curly_bracket=abertura_de_chaves_inesperada_{
-capital_letters_are_not_masked_using_curly_brackets_{}=letras_maiúsculas_não_são_masked_utilizando_chaves_{}
-should_contain_a_four_digit_number=deve_conter_um_número_de_quatro_dígitos
-should_contain_a_valid_page_number_range=deve_conter_números_de_página_válidos
+Added\ new\ '%0'\ entry.=%0 novas referências adicionadas
+Multiple\ entries\ selected.\ Do\ you\ want\ to\ change\ the\ type\ of\ all\ these\ to\ '%0'?=Múltiplas referências selecionadas. Deseja alterar o tipo de todas?
+Changed\ type\ to\ '%0'\ for=Tipo modificado para '%0' para
+Really\ delete\ the\ selected\ entry?=Você realmente deseja remover a referência selecionada?
+Really\ delete\ the\ %0\ selected\ entries?=Você realmente deseja remover as %0 referências selecionadas?
+Keep\ merged\ entry\ only=Manter a referência combinada apenas
+Keep\ left=Manter a da direita
+Keep\ right=Manter a da esquerda
+Old\ entry=Referência antiga
+From\ import=Da importação
+No\ problems\ found.=Nenhum problema encontrado.
+%0\ problem(s)\ found=%0 problema\(s\) encontrado\(s\)
+Save\ changes=Salvar mudanças.
+Discard\ changes=Descartar mudanças
+Library\ '%0'\ has\ changed.=Base de dados '%0' mudou.
+Print\ entry\ preview=Imprimir preview da referência
+Copy\ title=Copiar título
+Copy\ \\cite{BibTeX\ key}=Copiar como \\cite{chave BibTeX}
+Copy\ BibTeX\ key\ and\ title=Copiar chave BibTeX e título
+File\ rename\ failed\ for\ %0\ entries.=Renomeação de arquivo falho para %0 referências
+Merged\ BibTeX\ source\ code=Código BibTex combinado
+Invalid\ DOI\:\ '%0'.=DOI inválida: '%0'.
+should\ start\ with\ a\ name=deve iniciar com um nome
+should\ end\ with\ a\ name=deve terminar com um nome
+unexpected\ closing\ curly\ bracket=fechamento de chaves inesperado }
+unexpected\ opening\ curly\ bracket=abertura de chaves inesperada {
+capital\ letters\ are\ not\ masked\ using\ curly\ brackets\ {}=letras maiúsculas não são masked utilizando chaves {}
+should\ contain\ a\ four\ digit\ number=deve conter um número de quatro dígitos
+should\ contain\ a\ valid\ page\ number\ range=deve conter números de página válidos
 Filled=Preenchido
-Field_is_missing=Campo_está_faltando
-Search_%0=Pesquisar_na_%0
+Field\ is\ missing=Campo está faltando
+Search\ %0=Pesquisar na %0
 
-Search_results_in_all_libraries_for_%0=
-Search_results_in_library_%0_for_%1=
-Search_globally=
-No_results_found.=Nenhum_resultado_encontrado.
-Found_%0_results.=Encontrados_%0_resultados.
-plain_text=
-This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>=
-This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>=
-This_search_contains_entries_in_which=
+Search\ results\ in\ all\ libraries\ for\ %0=
+Search\ results\ in\ library\ %0\ for\ %1=
+Search\ globally=
+No\ results\ found.=Nenhum resultado encontrado.
+Found\ %0\ results.=Encontrados %0 resultados.
+plain\ text=
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ regular\ expression\ <b>%0</b>=
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ term\ <b>%0</b>=
+This\ search\ contains\ entries\ in\ which=
 
-Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.=
-JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>=
-This_library_uses_outdated_file_links.=
+Unable\ to\ autodetect\ OpenOffice/LibreOffice\ installation.\ Please\ choose\ the\ installation\ directory\ manually.=
+JabRef\ no\ longer\ supports\ 'ps'\ or\ 'pdf'\ fields.<br>File\ links\ are\ now\ stored\ in\ the\ 'file'\ field\ and\ files\ are\ stored\ in\ an\ external\ file\ directory.<br>To\ make\ use\ of\ this\ feature,\ JabRef\ needs\ to\ upgrade\ file\ links.<br><br>=
+This\ library\ uses\ outdated\ file\ links.=
 
-Clear_search=Limpar_busca
-Close_library=Fechar_base_de_dados
-Close_entry_editor=
-Decrease_table_font_size=
-Entry_editor,_next_entry=
-Entry_editor,_next_panel=
-Entry_editor,_next_panel_2=
-Entry_editor,_previous_entry=
-Entry_editor,_previous_panel=
-Entry_editor,_previous_panel_2=
-File_list_editor,_move_entry_down=
-File_list_editor,_move_entry_up=
-Focus_entry_table=
-Import_into_current_library=
-Import_into_new_library=
-Increase_table_font_size=
-New_article=Novo_artigo
-New_book=Novo_livro
-New_entry=Nova_referência
-New_from_plain_text=
-New_inbook=
-New_mastersthesis=
-New_phdthesis=
-New_proceedings=
-New_unpublished=
-Next_tab=
-Preamble_editor,_store_changes=
-Previous_tab=
-Push_to_application=
-Refresh_OpenOffice/LibreOffice=
-Resolve_duplicate_BibTeX_keys=
-Save_all=Salvar_todos
-String_dialog,_add_string=
-String_dialog,_remove_string=
-Synchronize_files=Sincronizar_arquivos
-Unabbreviate=Reverter_abreviações
-should_contain_a_protocol=
-Copy_preview=
-Automatically_setting_file_links=
-Regenerating_BibTeX_keys_according_to_metadata=
-No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys=
-Regenerate_all_keys_for_the_entries_in_a_BibTeX_file=
-Show_debug_level_messages=
-Default_bibliography_mode=
-New_%0_library_created.=%0_novas_bases_de_dados_foram_criadas.
-Show_only_preferences_deviating_from_their_default_value=
+Clear\ search=Limpar busca
+Close\ library=Fechar base de dados
+Close\ entry\ editor=
+Decrease\ table\ font\ size=
+Entry\ editor,\ next\ entry=
+Entry\ editor,\ next\ panel=
+Entry\ editor,\ next\ panel\ 2=
+Entry\ editor,\ previous\ entry=
+Entry\ editor,\ previous\ panel=
+Entry\ editor,\ previous\ panel\ 2=
+File\ list\ editor,\ move\ entry\ down=
+File\ list\ editor,\ move\ entry\ up=
+Focus\ entry\ table=
+Import\ into\ current\ library=
+Import\ into\ new\ library=
+Increase\ table\ font\ size=
+New\ article=Novo artigo
+New\ book=Novo livro
+New\ entry=Nova referência
+New\ from\ plain\ text=
+New\ inbook=
+New\ mastersthesis=
+New\ phdthesis=
+New\ proceedings=
+New\ unpublished=
+Next\ tab=
+Preamble\ editor,\ store\ changes=
+Previous\ tab=
+Push\ to\ application=
+Refresh\ OpenOffice/LibreOffice=
+Resolve\ duplicate\ BibTeX\ keys=
+Save\ all=Salvar todos
+String\ dialog,\ add\ string=
+String\ dialog,\ remove\ string=
+Synchronize\ files=Sincronizar arquivos
+Unabbreviate=Reverter abreviações
+should\ contain\ a\ protocol=
+Copy\ preview=
+Automatically\ setting\ file\ links=
+Regenerating\ BibTeX\ keys\ according\ to\ metadata=
+No\ meta\ data\ present\ in\ BIB\ file.\ Cannot\ regenerate\ BibTeX\ keys=
+Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=
+Show\ debug\ level\ messages=
+Default\ bibliography\ mode=
+New\ %0\ library\ created.=%0 novas bases de dados foram criadas.
+Show\ only\ preferences\ deviating\ from\ their\ default\ value=
 default=padrão
 key=chave
 type=tipo
 value=valor
-Show_preferences=Mostrar_preferências
-Save_actions=Salvar_ações
-Enable_save_actions=Habilitar_salvar_ações
+Show\ preferences=Mostrar preferências
+Save\ actions=Salvar ações
+Enable\ save\ actions=Habilitar salvar ações
 
-Other_fields=Outros_campos
-Show_remaining_fields=Mostrar_campos_restantes
+Other\ fields=Outros campos
+Show\ remaining\ fields=Mostrar campos restantes
 
-link_should_refer_to_a_correct_file_path=
-abbreviation_detected=abreviação_detectada
-wrong_entry_type_as_proceedings_has_page_numbers=
-Abbreviate_journal_names=Abreviar_nomes_de_periódicos
+link\ should\ refer\ to\ a\ correct\ file\ path=
+abbreviation\ detected=abreviação detectada
+wrong\ entry\ type\ as\ proceedings\ has\ page\ numbers=
+Abbreviate\ journal\ names=Abreviar nomes de periódicos
 Abbreviating...=Abreviando...
-Abbreviation_%s_for_journal_%s_already_defined.=
-Abbreviation_cannot_be_empty=
-Duplicated_Journal_Abbreviation=
-Duplicated_Journal_File=
-Error_Occurred=
-Journal_file_%s_already_added=
-Name_cannot_be_empty=
+Abbreviation\ %s\ for\ journal\ %s\ already\ defined.=
+Abbreviation\ cannot\ be\ empty=
+Duplicated\ Journal\ Abbreviation=
+Duplicated\ Journal\ File=
+Error\ Occurred=
+Journal\ file\ %s\ already\ added=
+Name\ cannot\ be\ empty=
 
-Adding_fetched_entries=Adicionando_referências_recuperadas
-Display_keywords_appearing_in_ALL_entries=
-Display_keywords_appearing_in_ANY_entry=
-Fetching_entries_from_Inspire=
-None_of_the_selected_entries_have_titles.=
-None_of_the_selected_entries_have_BibTeX_keys.=
-Unabbreviate_journal_names=Reverter_Abreviar_nomes_de_periódicos
-Unabbreviating...=Revertendo_abreviação
+Adding\ fetched\ entries=Adicionando referências recuperadas
+Display\ keywords\ appearing\ in\ ALL\ entries=
+Display\ keywords\ appearing\ in\ ANY\ entry=
+Fetching\ entries\ from\ Inspire=
+None\ of\ the\ selected\ entries\ have\ titles.=
+None\ of\ the\ selected\ entries\ have\ BibTeX\ keys.=
+Unabbreviate\ journal\ names=Reverter Abreviar nomes de periódicos
+Unabbreviating...=Revertendo abreviação
 Usage=Utilização
 
 
-Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.=
-Are_you_sure_you_want_to_reset_all_settings_to_default_values?=Você_tem_certeza_que_deseja_redefinir_todas_as_configurações_para_valores_padrão?
-Reset_preferences=Redefinir_preferências
-Ill-formed_entrytype_comment_in_BIB_file=
+Adds\ {}\ brackets\ around\ acronyms,\ month\ names\ and\ countries\ to\ preserve\ their\ case.=
+Are\ you\ sure\ you\ want\ to\ reset\ all\ settings\ to\ default\ values?=Você tem certeza que deseja redefinir todas as configurações para valores padrão?
+Reset\ preferences=Redefinir preferências
+Ill-formed\ entrytype\ comment\ in\ BIB\ file=
 
-Move_linked_files_to_default_file_directory_%0=
+Move\ linked\ files\ to\ default\ file\ directory\ %0=
 
-Clipboard=Área_de_transferência
-Could_not_paste_entry_as_text\:=
-Do_you_still_want_to_continue?=
-This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:=
-This_could_cause_undesired_changes_to_your_entries.=
-Run_field_formatter\:=
-Table_font_size_is_%0=
-%0_import_canceled=Importação_a_partir_do_%0_cancelada
-Internal_style=
-Add_style_file=
-Are_you_sure_you_want_to_remove_the_style?=
-Current_style_is_'%0'=
-Remove_style=
-Select_one_of_the_available_styles_or_add_a_style_file_from_disk.=
-You_must_select_a_valid_style_file.=
+Clipboard=Área de transferência
+Could\ not\ paste\ entry\ as\ text\:=
+Do\ you\ still\ want\ to\ continue?=
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=
+This\ could\ cause\ undesired\ changes\ to\ your\ entries.=
+Run\ field\ formatter\:=
+Table\ font\ size\ is\ %0=
+%0\ import\ canceled=Importação a partir do %0 cancelada
+Internal\ style=
+Add\ style\ file=
+Are\ you\ sure\ you\ want\ to\ remove\ the\ style?=
+Current\ style\ is\ '%0'=
+Remove\ style=
+Select\ one\ of\ the\ available\ styles\ or\ add\ a\ style\ file\ from\ disk.=
+You\ must\ select\ a\ valid\ style\ file.=
 Reload=
 
 Capitalize=
-Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.=
-Capitalize_the_first_word,_changes_other_words_to_lower_case.=
-Changes_all_letters_to_lower_case.=
-Changes_all_letters_to_upper_case.=
-Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.=
-Cleans_up_LaTeX_code.=
-Converts_HTML_code_to_LaTeX_code.=
-Converts_HTML_code_to_Unicode.=
-Converts_LaTeX_encoding_to_Unicode_characters.=
-Converts_Unicode_characters_to_LaTeX_encoding.=
-Converts_ordinals_to_LaTeX_superscripts.=
-Converts_units_to_LaTeX_formatting.=
-HTML_to_LaTeX=
-LaTeX_cleanup=
-LaTeX_to_Unicode=
-Lower_case=
-Minify_list_of_person_names=
-Normalize_date=
-Normalize_month=
-Normalize_month_to_BibTeX_standard_abbreviation.=
-Normalize_names_of_persons=
-Normalize_page_numbers=
-Normalize_pages_to_BibTeX_standard.=
-Normalizes_lists_of_persons_to_the_BibTeX_standard.=
-Normalizes_the_date_to_ISO_date_format.=
-Ordinals_to_LaTeX_superscript=
-Protect_terms=
-Remove_enclosing_braces=
-Removes_braces_encapsulating_the_complete_field_content.=
-Sentence_case=
-Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".=
-Title_case=
-Unicode_to_LaTeX=
-Units_to_LaTeX=
-Upper_case=
-Does_nothing.=
+Capitalize\ all\ words,\ but\ converts\ articles,\ prepositions,\ and\ conjunctions\ to\ lower\ case.=
+Capitalize\ the\ first\ word,\ changes\ other\ words\ to\ lower\ case.=
+Changes\ all\ letters\ to\ lower\ case.=
+Changes\ all\ letters\ to\ upper\ case.=
+Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=
+Cleans\ up\ LaTeX\ code.=
+Converts\ HTML\ code\ to\ LaTeX\ code.=
+Converts\ HTML\ code\ to\ Unicode.=
+Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=
+Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=
+Converts\ ordinals\ to\ LaTeX\ superscripts.=
+Converts\ units\ to\ LaTeX\ formatting.=
+HTML\ to\ LaTeX=
+LaTeX\ cleanup=
+LaTeX\ to\ Unicode=
+Lower\ case=
+Minify\ list\ of\ person\ names=
+Normalize\ date=
+Normalize\ month=
+Normalize\ month\ to\ BibTeX\ standard\ abbreviation.=
+Normalize\ names\ of\ persons=
+Normalize\ page\ numbers=
+Normalize\ pages\ to\ BibTeX\ standard.=
+Normalizes\ lists\ of\ persons\ to\ the\ BibTeX\ standard.=
+Normalizes\ the\ date\ to\ ISO\ date\ format.=
+Ordinals\ to\ LaTeX\ superscript=
+Protect\ terms=
+Remove\ enclosing\ braces=
+Removes\ braces\ encapsulating\ the\ complete\ field\ content.=
+Sentence\ case=
+Shortens\ lists\ of\ persons\ if\ there\ are\ more\ than\ 2\ persons\ to\ "et\ al.".=
+Title\ case=
+Unicode\ to\ LaTeX=
+Units\ to\ LaTeX=
+Upper\ case=
+Does\ nothing.=
 Identity=
-Clears_the_field_completely.=
-Directory_not_found=
-Main_file_directory_not_set\!=
-This_operation_requires_exactly_one_item_to_be_selected.=
-Importing_in_%0_format=
-Female_name=
-Female_names=
-Male_name=
-Male_names=
-Mixed_names=
-Neuter_name=
-Neuter_names=
+Clears\ the\ field\ completely.=
+Directory\ not\ found=
+Main\ file\ directory\ not\ set\!=
+This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=
+Importing\ in\ %0\ format=
+Female\ name=
+Female\ names=
+Male\ name=
+Male\ names=
+Mixed\ names=
+Neuter\ name=
+Neuter\ names=
 
-Determined_%0_for_%1_entries=
-Look_up_%0=
-Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3=
+Determined\ %0\ for\ %1\ entries=
+Look\ up\ %0=
+Looking\ up\ %0...\ -\ entry\ %1\ out\ of\ %2\ -\ found\ %3=
 
-Audio_CD=
-British_patent=
-British_patent_request=
-Candidate_thesis=
+Audio\ CD=
+British\ patent=
+British\ patent\ request=
+Candidate\ thesis=
 Collaborator=
 Column=
 Compiler=
 Continuator=
-Data_CD=
+Data\ CD=
 Editor=
-European_patent=
-European_patent_request=
+European\ patent=
+European\ patent\ request=
 Founder=
-French_patent=
-French_patent_request=
-German_patent=
-German_patent_request=
+French\ patent=
+French\ patent\ request=
+German\ patent=
+German\ patent\ request=
 Line=
-Master's_thesis=
+Master's\ thesis=
 Page=
 Paragraph=
 Patent=
-Patent_request=
-PhD_thesis=
+Patent\ request=
+PhD\ thesis=
 Redactor=
-Research_report=
+Research\ report=
 Reviser=
 Section=
 Software=
-Technical_report=
-U.S._patent=
-U.S._patent_request=
+Technical\ report=
+U.S.\ patent=
+U.S.\ patent\ request=
 Verse=
 
-change_entries_of_group=
-odd_number_of_unescaped_'\#'=
+change\ entries\ of\ group=
+odd\ number\ of\ unescaped\ '\#'=
 
-Plain_text=
-Show_diff=
+Plain\ text=
+Show\ diff=
 character=
 word=
-Show_symmetric_diff=
-Copy_Version=
+Show\ symmetric\ diff=
+Copy\ Version=
 Developers=
 Authors=
 License=
 
-HTML_encoded_character_found=
-booktitle_ends_with_'conference_on'=
+HTML\ encoded\ character\ found=
+booktitle\ ends\ with\ 'conference\ on'=
 
-All_external_files=
+All\ external\ files=
 
-OpenOffice/LibreOffice_integration=
+OpenOffice/LibreOffice\ integration=
 
-incorrect_control_digit=
-incorrect_format=
-Copied_version_to_clipboard=
+incorrect\ control\ digit=
+incorrect\ format=
+Copied\ version\ to\ clipboard=
 
-BibTeX_key=
+BibTeX\ key=
 Message=
 
 
-MathSciNet_Review=
-Reset_Bindings=
+MathSciNet\ Review=
+Reset\ Bindings=
 
-Decryption_not_supported.=
+Decryption\ not\ supported.=
 
-Cleared_'%0'_for_%1_entries=
-Set_'%0'_to_'%1'_for_%2_entries=Definir_'%0'_'%1'_para_%2_registros
-Toggled_'%0'_for_%1_entries=
+Cleared\ '%0'\ for\ %1\ entries=
+Set\ '%0'\ to\ '%1'\ for\ %2\ entries=Definir '%0' '%1' para %2 registros
+Toggled\ '%0'\ for\ %1\ entries=
 
-Check_for_updates=
-Download_update=
-New_version_available=
-Installed_version=
-Remind_me_later=
-Ignore_this_update=
-Could_not_connect_to_the_update_server.=
-Please_try_again_later_and/or_check_your_network_connection.=
-To_see_what_is_new_view_the_changelog.=
-A_new_version_of_JabRef_has_been_released.=
-JabRef_is_up-to-date.=
-Latest_version=
-Online_help_forum=
+Check\ for\ updates=
+Download\ update=
+New\ version\ available=
+Installed\ version=
+Remind\ me\ later=
+Ignore\ this\ update=
+Could\ not\ connect\ to\ the\ update\ server.=
+Please\ try\ again\ later\ and/or\ check\ your\ network\ connection.=
+To\ see\ what\ is\ new\ view\ the\ changelog.=
+A\ new\ version\ of\ JabRef\ has\ been\ released.=
+JabRef\ is\ up-to-date.=
+Latest\ version=
+Online\ help\ forum=
 Custom=
 
-Export_cited=
-Unable_to_generate_new_library=
+Export\ cited=
+Unable\ to\ generate\ new\ library=
 
-Open_console=
-Use_default_terminal_emulator=
-Execute_command=
-Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.=
-Executing_command_\"%0\"...=
-Error_occured_while_executing_the_command_\"%0\".=
-Reformat_ISSN=
+Open\ console=
+Use\ default\ terminal\ emulator=
+Execute\ command=
+Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=
+Executing\ command\ \"%0\"...=
+Error\ occured\ while\ executing\ the\ command\ \"%0\".=
+Reformat\ ISSN=
 
-Countries_and_territories_in_English=
-Electrical_engineering_terms=
+Countries\ and\ territories\ in\ English=
+Electrical\ engineering\ terms=
 Enabled=
-Internal_list=
-Manage_protected_terms_files=
-Months_and_weekdays_in_English=
-The_text_after_the_last_line_starting_with_\#_will_be_used=
-Add_protected_terms_file=
-Are_you_sure_you_want_to_remove_the_protected_terms_file?=
-Remove_protected_terms_file=
-Add_selected_text_to_list=
-Add_{}_around_selected_text=
-Format_field=
-New_protected_terms_file=
-change_field_%0_of_entry_%1_from_%2_to_%3=
-change_key_from_%0_to_%1=
-change_string_content_%0_to_%1=
-change_string_name_%0_to_%1=
-change_type_of_entry_%0_from_%1_to_%2=
-insert_entry_%0=
-insert_string_%0=
-remove_entry_%0=
-remove_string_%0=
+Internal\ list=
+Manage\ protected\ terms\ files=
+Months\ and\ weekdays\ in\ English=
+The\ text\ after\ the\ last\ line\ starting\ with\ \#\ will\ be\ used=
+Add\ protected\ terms\ file=
+Are\ you\ sure\ you\ want\ to\ remove\ the\ protected\ terms\ file?=
+Remove\ protected\ terms\ file=
+Add\ selected\ text\ to\ list=
+Add\ {}\ around\ selected\ text=
+Format\ field=
+New\ protected\ terms\ file=
+change\ field\ %0\ of\ entry\ %1\ from\ %2\ to\ %3=
+change\ key\ from\ %0\ to\ %1=
+change\ string\ content\ %0\ to\ %1=
+change\ string\ name\ %0\ to\ %1=
+change\ type\ of\ entry\ %0\ from\ %1\ to\ %2=
+insert\ entry\ %0=
+insert\ string\ %0=
+remove\ entry\ %0=
+remove\ string\ %0=
 undefined=
-Cannot_get_info_based_on_given_%0\:_%1=
-Get_BibTeX_data_from_%0=
-No_%0_found=
-Entry_from_%0=
-Merge_entry_with_%0_information=
-Updated_entry_with_info_from_%0=
+Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=
+Get\ BibTeX\ data\ from\ %0=
+No\ %0\ found=
+Entry\ from\ %0=
+Merge\ entry\ with\ %0\ information=
+Updated\ entry\ with\ info\ from\ %0=
 
-Add_existing_file=
-Create_new_list=
-Remove_list=
-Full_journal_name=
-Abbreviation_name=
+Add\ existing\ file=
+Create\ new\ list=
+Remove\ list=
+Full\ journal\ name=
+Abbreviation\ name=
 
-No_abbreviation_files_loaded=
+No\ abbreviation\ files\ loaded=
 
-Loading_built_in_lists=
+Loading\ built\ in\ lists=
 
-JabRef_built_in_list=
-IEEE_built_in_list=
+JabRef\ built\ in\ list=
+IEEE\ built\ in\ list=
 
-Event_log=
-We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.=
-Log_copied_to_clipboard.=
-Copy_Log=
-Clear_Log=
-Report_Issue=
-Issue_on_GitHub_successfully_reported.=
-Issue_report_successful=
-Your_issue_was_reported_in_your_browser.=
-The_log_and_exception_information_was_copied_to_your_clipboard.=
-Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.=
+Event\ log=
+We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef\'s\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=
+Log\ copied\ to\ clipboard.=
+Copy\ Log=
+Clear\ Log=
+Report\ Issue=
+Issue\ on\ GitHub\ successfully\ reported.=
+Issue\ report\ successful=
+Your\ issue\ was\ reported\ in\ your\ browser.=
+The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=
+Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=
 
 Connection=
 Connecting...=
@@ -2164,194 +2164,194 @@ Port=
 Library=
 User=
 Connect=Conectar
-Connection_error=
-Connection_to_%0_server_established.=
-Required_field_"%0"_is_empty.=
-%0_driver_not_available.=
-The_connection_to_the_server_has_been_terminated.=
-Connection_lost.=
+Connection\ error=
+Connection\ to\ %0\ server\ established.=
+Required\ field\ "%0"\ is\ empty.=
+%0\ driver\ not\ available.=
+The\ connection\ to\ the\ server\ has\ been\ terminated.=
+Connection\ lost.=
 Reconnect=
-Work_offline=
-Working_offline.=
-Update_refused.=
-Update_refused=
-Local_entry=
-Shared_entry=
-Update_could_not_be_performed_due_to_existing_change_conflicts.=
-You_are_not_working_on_the_newest_version_of_BibEntry.=
-Local_version\:_%0=
-Shared_version\:_%0=
-Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.=
-Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?=
-Shared_entry_is_no_longer_present=
-The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.=
-You_can_restore_the_entry_using_the_"Undo"_operation.=
-Remember_password?=
-You_are_already_connected_to_a_database_using_entered_connection_details.=
+Work\ offline=
+Working\ offline.=
+Update\ refused.=
+Update\ refused=
+Local\ entry=
+Shared\ entry=
+Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=
+You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=
+Local\ version\:\ %0=
+Shared\ version\:\ %0=
+Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=
+Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=
+Shared\ entry\ is\ no\ longer\ present=
+The\ BibEntry\ you\ currently\ work\ on\ has\ been\ deleted\ on\ the\ shared\ side.=
+You\ can\ restore\ the\ entry\ using\ the\ "Undo"\ operation.=
+Remember\ password?=
+You\ are\ already\ connected\ to\ a\ database\ using\ entered\ connection\ details.=
 
-Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?=
-New_technical_report=
+Cannot\ cite\ entries\ without\ BibTeX\ keys.\ Generate\ keys\ now?=
+New\ technical\ report=
 
-%0_file=
-Custom_layout_file=
-Protected_terms_file=
-Style_file=
+%0\ file=
+Custom\ layout\ file=
+Protected\ terms\ file=
+Style\ file=
 
-Open_OpenOffice/LibreOffice_connection=
-You_must_enter_at_least_one_field_name=
-Non-ASCII_encoded_character_found=
-Toggle_web_search_interface=
-Background_color_for_resolved_fields=
-Color_code_for_resolved_fields=
-%0_files_found=
-%0_of_%1=
-One_file_found=
-The_import_finished_with_warnings\:=
-There_was_one_file_that_could_not_be_imported.=
-There_were_%0_files_which_could_not_be_imported.=
+Open\ OpenOffice/LibreOffice\ connection=
+You\ must\ enter\ at\ least\ one\ field\ name=
+Non-ASCII\ encoded\ character\ found=
+Toggle\ web\ search\ interface=
+Background\ color\ for\ resolved\ fields=
+Color\ code\ for\ resolved\ fields=
+%0\ files\ found=
+%0\ of\ %1=
+One\ file\ found=
+The\ import\ finished\ with\ warnings\:=
+There\ was\ one\ file\ that\ could\ not\ be\ imported.=
+There\ were\ %0\ files\ which\ could\ not\ be\ imported.=
 
-Migration_help_information=
-Entered_database_has_obsolete_structure_and_is_no_longer_supported.=
-However,_a_new_database_was_created_alongside_the_pre-3.6_one.=
-Click_here_to_learn_about_the_migration_of_pre-3.6_databases.=
-Opens_JabRef's_Facebook_page=
-Opens_JabRef's_blog=
-Opens_JabRef's_website=
-Opens_a_link_where_the_current_development_version_can_be_downloaded=
-See_what_has_been_changed_in_the_JabRef_versions=
-Referenced_BibTeX_key_does_not_exist=
-Finished_downloading_full_text_document_for_entry_%0.=
-Full_text_document_download_failed_for_entry_%0.=
-Look_up_full_text_documents=
-You_are_about_to_look_up_full_text_documents_for_%0_entries.=
-last_four_nonpunctuation_characters_should_be_numerals=
+Migration\ help\ information=
+Entered\ database\ has\ obsolete\ structure\ and\ is\ no\ longer\ supported.=
+However,\ a\ new\ database\ was\ created\ alongside\ the\ pre-3.6\ one.=
+Click\ here\ to\ learn\ about\ the\ migration\ of\ pre-3.6\ databases.=
+Opens\ JabRef's\ Facebook\ page=
+Opens\ JabRef's\ blog=
+Opens\ JabRef's\ website=
+Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=
+See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=
+Referenced\ BibTeX\ key\ does\ not\ exist=
+Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=
+Full\ text\ document\ download\ failed\ for\ entry\ %0.=
+Look\ up\ full\ text\ documents=
+You\ are\ about\ to\ look\ up\ full\ text\ documents\ for\ %0\ entries.=
+last\ four\ nonpunctuation\ characters\ should\ be\ numerals=
 
 Author=
 Date=
-File_annotations=
-Show_file_annotations=
-Adobe_Acrobat_Reader=
-Sumatra_Reader=
+File\ annotations=
+Show\ file\ annotations=
+Adobe\ Acrobat\ Reader=
+Sumatra\ Reader=
 shared=
-should_contain_an_integer_or_a_literal=
-should_have_the_first_letter_capitalized=
+should\ contain\ an\ integer\ or\ a\ literal=
+should\ have\ the\ first\ letter\ capitalized=
 Tools=
-What\'s_new_in_this_version?=
-Want_to_help?=
-Make_a_donation=
-get_involved=
-Used_libraries=
-Existing_file=Arquivo_existente
+What\'s\ new\ in\ this\ version?=
+Want\ to\ help?=
+Make\ a\ donation=
+get\ involved=
+Used\ libraries=
+Existing\ file=Arquivo existente
 
 ID=
-ID_type=
-ID-based_entry_generator=
-Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+ID\ type=
+ID-based\ entry\ generator=
+Fetcher\ '%0'\ did\ not\ find\ an\ entry\ for\ id\ '%1'.=
 
-Select_first_entry=
-Select_last_entry=
+Select\ first\ entry=
+Select\ last\ entry=
 
-Invalid_ISBN\:_'%0'.=
-should_be_an_integer_or_normalized=
-should_be_normalized=
+Invalid\ ISBN\:\ '%0'.=
+should\ be\ an\ integer\ or\ normalized=
+should\ be\ normalized=
 
-Empty_search_ID=
-The_given_search_ID_was_empty.=
-Copy_BibTeX_key_and_link=
-empty_BibTeX_key=
-biblatex_field_only=
+Empty\ search\ ID=
+The\ given\ search\ ID\ was\ empty.=
+Copy\ BibTeX\ key\ and\ link=
+empty\ BibTeX\ key=
+biblatex\ field\ only=
 
-Error_while_generating_fetch_URL=
-Error_while_parsing_ID_list=
-Unable_to_get_PubMed_IDs=
-Backup_found=
-A_backup_file_for_'%0'_was_found.=
-This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.=
-Do_you_want_to_recover_the_library_from_the_backup_file?=
-Firstname_Lastname=
+Error\ while\ generating\ fetch\ URL=
+Error\ while\ parsing\ ID\ list=
+Unable\ to\ get\ PubMed\ IDs=
+Backup\ found=
+A\ backup\ file\ for\ '%0'\ was\ found.=
+This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=
+Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=
+Firstname\ Lastname=
 
-Recommended_for_%0=
-Show_'Related_Articles'_tab=
-This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
+Recommended\ for\ %0=
+Show\ 'Related\ Articles'\ tab=
+This\ might\ be\ caused\ by\ reaching\ the\ traffic\ limitation\ of\ Google\ Scholar\ (see\ 'Help'\ for\ details).=
 
-Could_not_open_website.=
-Problem_downloading_from_%1=
+Could\ not\ open\ website.=
+Problem\ downloading\ from\ %1=
 
-File_directory_pattern=
-Update_with_bibliographic_information_from_the_web=
+File\ directory\ pattern=
+Update\ with\ bibliographic\ information\ from\ the\ web=
 
-Could_not_find_any_bibliographic_information.=
-BibTeX_key_deviates_from_generated_key=
-DOI_%0_is_invalid=
+Could\ not\ find\ any\ bibliographic\ information.=
+BibTeX\ key\ deviates\ from\ generated\ key=
+DOI\ %0\ is\ invalid=
 
-Select_all_customized_types_to_be_stored_in_local_preferences=
-Currently_unknown=
-Different_customization,_current_settings_will_be_overwritten=
+Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences=
+Currently\ unknown=
+Different\ customization,\ current\ settings\ will\ be\ overwritten=
 
-Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX=
-Jump_to_entry=
+Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=
+Jump\ to\ entry=
 
-Copied_%0_citations.=
+Copied\ %0\ citations.=
 Copying...=
 
-journal_not_found_in_abbreviation_list=
-Unhandled_exception_occurred.=
+journal\ not\ found\ in\ abbreviation\ list=
+Unhandled\ exception\ occurred.=
 
-strings_included=
-Color_for_disabled_icons=
-Color_for_enabled_icons=
-Size_of_large_icons=
-Size_of_small_icons=
-Default_table_font_size=
-Escape_underscores=
+strings\ included=
+Color\ for\ disabled\ icons=
+Color\ for\ enabled\ icons=
+Size\ of\ large\ icons=
+Size\ of\ small\ icons=
+Default\ table\ font\ size=
+Escape\ underscores=
 Color=
-Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=
-Fit_width=
-Fit_a_single_page=
-Zoom_in=
-Zoom_out=
-Previous_page=
-Next_page=
-Document_viewer=
+Please\ also\ add\ all\ steps\ to\ reproduce\ this\ issue,\ if\ possible.=
+Fit\ width=
+Fit\ a\ single\ page=
+Zoom\ in=
+Zoom\ out=
+Previous\ page=
+Next\ page=
+Document\ viewer=
 Live=
 Locked=
-Show_document_viewer=
-Show_the_document_of_the_currently_selected_entry.=
-Show_this_document_until_unlocked.=
-Set_current_user_name_as_owner.=
+Show\ document\ viewer=
+Show\ the\ document\ of\ the\ currently\ selected\ entry.=
+Show\ this\ document\ until\ unlocked.=
+Set\ current\ user\ name\ as\ owner.=
 
-Sort_all_subgroups_(recursively)=
-Collect_and_share_telemetry_data_to_help_improve_JabRef.=
-Don't_share=
-Share_anonymous_statistics=
-Telemetry\:_Help_make_JabRef_better=
-To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.=
-This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?=
-Names_are_not_in_the_standard_%0_format.=
+Sort\ all\ subgroups\ (recursively)=
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=
+Don't\ share=
+Share\ anonymous\ statistics=
+Telemetry\:\ Help\ make\ JabRef\ better=
+To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ statistics\ on\ the\ features\ you\ use.\ We\ will\ only\ record\ what\ features\ you\ access\ and\ how\ often\ you\ do\ it.\ We\ will\ neither\ collect\ any\ personal\ data\ nor\ the\ content\ of\ bibliographic\ items.\ If\ you\ choose\ to\ allow\ data\ collection,\ you\ can\ later\ disable\ it\ via\ Options\ ->\ Preferences\ ->\ General.=
+This\ file\ was\ found\ automatically.\ Do\ you\ want\ to\ link\ it\ to\ this\ entry?=
+Names\ are\ not\ in\ the\ standard\ %0\ format.=
 
-Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.=
-Delete_'%0'=
-Delete_from_disk=
-Remove_from_entry=
-The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.=
-There_exists_already_a_group_with_the_same_name.=
+Delete\ the\ selected\ file\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ file\ permanently\ from\ disk.=
+Delete\ '%0'=
+Delete\ from\ disk=
+Remove\ from\ entry=
+The\ group\ name\ contains\ the\ keyword\ separator\ "%0"\ and\ thus\ probably\ does\ not\ work\ as\ expected.=
+There\ exists\ already\ a\ group\ with\ the\ same\ name.=
 
-Copy_linked_files_to_folder...=
-Copied_file_successfully=
-Copying_files...=
-Copying_file_%0_of_entry_%1=
-Finished_copying=
-Could_not_copy_file=
-Copied_%0_files_of_%1_sucessfully_to_%2=
-Rename_failed=
-JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.=
-Show_console_output_(only_necessary_when_the_launcher_is_used)=
+Copy\ linked\ files\ to\ folder...=
+Copied\ file\ successfully=
+Copying\ files...=
+Copying\ file\ %0\ of\ entry\ %1=
+Finished\ copying=
+Could\ not\ copy\ file=
+Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=
+Rename\ failed=
+JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=
+Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=
 
-Remove_line_breaks=
-Removes_all_line_breaks_in_the_field_content.=
-Checking_integrity...=
+Remove\ line\ breaks=
+Removes\ all\ line\ breaks\ in\ the\ field\ content.=
+Checking\ integrity...=
 
-Remove_hyphenated_line_breaks=
-Removes_all_hyphenated_line_breaks_in_the_field_content.=
-Note_that_currently,_JabRef_does_not_run_with_Java_9.=
-Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.=
+Remove\ hyphenated\ line\ breaks=
+Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=
+Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=
+Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -1206,9 +1206,9 @@ This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\
 
 This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=Группа содержит записи, на основе назначений вручную. Чтобы назначить запись этой группе, выберите запись и перетащите ее в группу или выберите команду контекстного меню. Чтобы удалить запись из этой группы, выделите запись и выберите команду контекстного меню.
 
-This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Группа содержит записи, в которых поле <b>%0</b> содержит ключевое слово <b>%1</b> 
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Группа содержит записи, в которых поле <b>%0</b> содержит ключевое слово <b>%1</b>
 
-This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Группа содержит записи, в которых поле <b>%0</b> содержит регулярное выражение <b>%1</b> 
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Группа содержит записи, в которых поле <b>%0</b> содержит регулярное выражение <b>%1</b>
 This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=При этом JabRef произведет поиск всех ссылок файл с проверкой наличия файла. В противном случае будет выведен запрос<BR>на разрешение проблемы.
 
 This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=Для этой операции необходимо определение ключей BibTeX всех выбранных записей.

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -3,156 +3,156 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-%0_contains_the_regular_expression_<b>%1</b>=%0_содержит_регулярное_выражение_<b>%1</b>
+%0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 содержит регулярное выражение <b>%1</b>
 
-%0_contains_the_term_<b>%1</b>=%0_содержит_условие_<b>%1</b>
+%0\ contains\ the\ term\ <b>%1</b>=%0 содержит условие <b>%1</b>
 
-%0_doesn't_contain_the_regular_expression_<b>%1</b>=%0_не_содержит_регулярного_выражения_<b>%1</b>
+%0\ doesn't\ contain\ the\ regular\ expression\ <b>%1</b>=%0 не содержит регулярного выражения <b>%1</b>
 
-%0_doesn't_contain_the_term_<b>%1</b>=%0_не_содержит_условия_<b>%1</b>
+%0\ doesn't\ contain\ the\ term\ <b>%1</b>=%0 не содержит условия <b>%1</b>
 
-%0_export_successful=%0_успешно_экспортировано
+%0\ export\ successful=%0 успешно экспортировано
 
-%0_matches_the_regular_expression_<b>%1</b>=%0_соответствует_регулярному_выражению_<b>%1</b>
+%0\ matches\ the\ regular\ expression\ <b>%1</b>=%0 соответствует регулярному выражению <b>%1</b>
 
-%0_matches_the_term_<b>%1</b>=%0_соответствует_условию_<b>%1</b>
+%0\ matches\ the\ term\ <b>%1</b>=%0 соответствует условию <b>%1</b>
 
-<field_name>=<имя_поля>
-<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>=<HTML>Не_обнаружен_файл_'%0'<BR>по_ссылке_из_записи_'%1'</HTML>
+<field\ name>=<имя поля>
+<HTML>Could\ not\ find\ file\ '%0'<BR>linked\ from\ entry\ '%1'</HTML>=<HTML>Не обнаружен файл '%0'<BR>по ссылке из записи '%1'</HTML>
 
 <select>=<выбрать>
 
-<select_word>=<выбрать_слово>
-Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)=Сокращения_названий_журналов_для_выбранных_записей_(аббр._ISO)
-Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)=Сокращения_названий_журналов_для_выбранных_записей_(аббр._MEDLINE)
+<select\ word>=<выбрать слово>
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (ISO\ abbreviation)=Сокращения названий журналов для выбранных записей (аббр. ISO)
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (MEDLINE\ abbreviation)=Сокращения названий журналов для выбранных записей (аббр. MEDLINE)
 
-Abbreviate_names=Сокращения_названий
-Abbreviated_%0_journal_names.=Сокращения_для_%0_названий_журналов.
+Abbreviate\ names=Сокращения названий
+Abbreviated\ %0\ journal\ names.=Сокращения для %0 названий журналов.
 
 Abbreviation=Сокращение
 
-About_JabRef=О_программе_JabRef
+About\ JabRef=О программе JabRef
 
 Abstract=Резюме
 
 Accept=Принять
 
-Accept_change=Принять_изменение
+Accept\ change=Принять изменение
 
 Action=Действие
 
-What_is_Mr._DLib?=
+What\ is\ Mr.\ DLib?=
 
 Add=Добавить
 
-Add_a_(compiled)_custom_Importer_class_from_a_class_path.=Добавить_(скомпил.)_пользовательский_класс_Importer_из_пути_класса.
-The_path_need_not_be_on_the_classpath_of_JabRef.=Путь_может_не_совпадать_с_путем_классов_JabRef.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=Добавить (скомпил.) пользовательский класс Importer из пути класса.
+The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=Путь может не совпадать с путем классов JabRef.
 
-Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=Добавить_(скомпил.)_пользовательский_класс_Importer_из_ZIP-архива.
-The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=ZIP-архив_может_не_совпадать_с_путем_классов_JabRef.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=Добавить (скомпил.) пользовательский класс Importer из ZIP-архива.
+The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=ZIP-архив может не совпадать с путем классов JabRef.
 
-Add_a_regular_expression_for_the_key_pattern.=
+Add\ a\ regular\ expression\ for\ the\ key\ pattern.=
 
-Add_selected_entries_to_this_group=
+Add\ selected\ entries\ to\ this\ group=
 
-Add_from_folder=Добавить_из_папки
+Add\ from\ folder=Добавить из папки
 
-Add_from_JAR=Добавить_из_JAR
+Add\ from\ JAR=Добавить из JAR
 
-add_group=добавить_группу
+add\ group=добавить группу
 
-Add_new=Добавить_новую
+Add\ new=Добавить новую
 
-Add_subgroup=Добавить_подгруппу
+Add\ subgroup=Добавить подгруппу
 
-Add_to_group=Добавить_в_группу
+Add\ to\ group=Добавить в группу
 
-Added_group_"%0".=Группа_"%0"_добавлена.
+Added\ group\ "%0".=Группа "%0" добавлена.
 
-Added_missing_braces.=
+Added\ missing\ braces.=
 
-Added_new=Добавлена_новая
+Added\ new=Добавлена новая
 
-Added_string=Строка_добавлена
+Added\ string=Строка добавлена
 
-Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.=Кроме_того,_записи,_в_которых_поле_<b>%0</b>_не_содержит_<b>%1</b>_могут_быть_назначены_этой_группе_вручную_путем_их_выбора_и_перетаскивания_в_группу_или_с_помощью_команды_контекстного_меню._В_этом_случае_условие<b>%1</b>_будет_добавлено_к_полю_<b>%0</b>_каждой_записи._Чтобы_вручную_удалить_записи_из_этой_группы,_выберите_записи_и_примените_команду_контекстного_меню._В_этом_случае_условие_<b>%1</b>_будет_удалено_из_поля_<b>%0</b>_каждой_записи.
+Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ can\ be\ assigned\ manually\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ This\ process\ adds\ the\ term\ <b>%1</b>\ to\ each\ entry's\ <b>%0</b>\ field.\ Entries\ can\ be\ removed\ manually\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.\ This\ process\ removes\ the\ term\ <b>%1</b>\ from\ each\ entry's\ <b>%0</b>\ field.=Кроме того, записи, в которых поле <b>%0</b> не содержит <b>%1</b> могут быть назначены этой группе вручную путем их выбора и перетаскивания в группу или с помощью команды контекстного меню. В этом случае условие<b>%1</b> будет добавлено к полю <b>%0</b> каждой записи. Чтобы вручную удалить записи из этой группы, выберите записи и примените команду контекстного меню. В этом случае условие <b>%1</b> будет удалено из поля <b>%0</b> каждой записи.
 
 Advanced=Расширенные
-All_entries=Все_записи
-All_entries_of_this_type_will_be_declared_typeless._Continue?=Все_записи_этого_типа_будут_объявлены_записями_'без_типа'._Продолжть?
+All\ entries=Все записи
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=Все записи этого типа будут объявлены записями 'без типа'. Продолжть?
 
-All_fields=Все_поля
+All\ fields=Все поля
 
-Always_reformat_BIB_file_on_save_and_export=Всегда_преобразовывать_формат_файла_BIB_при_сохранении_и_экспорте
+Always\ reformat\ BIB\ file\ on\ save\ and\ export=Всегда преобразовывать формат файла BIB при сохранении и экспорте
 
-A_SAX_exception_occurred_while_parsing_'%0'\:=Исключение_SAX_при_анализе_'%0'\:
+A\ SAX\ exception\ occurred\ while\ parsing\ '%0'\:=Исключение SAX при анализе '%0':
 
 and=и
-and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.=и_класс_должен_быть_доступен_в_пути_класса_при_следующем_запуске_JabRef.
+and\ the\ class\ must\ be\ available\ in\ your\ classpath\ next\ time\ you\ start\ JabRef.=и класс должен быть доступен в пути класса при следующем запуске JabRef.
 
-any_field_that_matches_the_regular_expression_<b>%0</b>=любое_поле,_соответствующее_регулярному_выражению_<b>%0</b>
+any\ field\ that\ matches\ the\ regular\ expression\ <b>%0</b>=любое поле, соответствующее регулярному выражению <b>%0</b>
 
 Appearance=Представление
 
 Append=Добавить
-Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library=Добавить_содержимое_БД_BibTeX_к_БД_текущего_просмотра
+Append\ contents\ from\ a\ BibTeX\ library\ into\ the\ currently\ viewed\ library=Добавить содержимое БД BibTeX к БД текущего просмотра
 
-Append_library=Добавить_БД
+Append\ library=Добавить БД
 
-Append_the_selected_text_to_BibTeX_field=Подключить_выбранный_текст_к_ключу_BibTeX
+Append\ the\ selected\ text\ to\ BibTeX\ field=Подключить выбранный текст к ключу BibTeX
 Application=Приложение
 
 Apply=Применить
 
-Arguments_passed_on_to_running_JabRef_instance._Shutting_down.=Аргументы_переданы_в_запущенный_экземпляр_JabRef._Отключение.
+Arguments\ passed\ on\ to\ running\ JabRef\ instance.\ Shutting\ down.=Аргументы переданы в запущенный экземпляр JabRef. Отключение.
 
-Assign_new_file=Назначить_новый_файл
+Assign\ new\ file=Назначить новый файл
 
-Assign_the_original_group's_entries_to_this_group?=Назначить_исходные_записи_группы_этой_группе?
+Assign\ the\ original\ group's\ entries\ to\ this\ group?=Назначить исходные записи группы этой группе?
 
-Assigned_%0_entries_to_group_"%1".=%0_записей_назначено_группе_"%1".
+Assigned\ %0\ entries\ to\ group\ "%1".=%0 записей назначено группе "%1".
 
-Assigned_1_entry_to_group_"%0".=Назначена_1_запись_группе_"%0".
+Assigned\ 1\ entry\ to\ group\ "%0".=Назначена 1 запись группе "%0".
 
-Attach_URL=Добавить_URL-адрес
+Attach\ URL=Добавить URL-адрес
 
-Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.=Попытка_автоопределения_ссылок_файл_для_записей._Автоопределение_возможно_если_файл_находящийся_в_каталоге_файлов_файл_или_его_подкаталоге<BR>имеет_имя,_идентичное_имени_ключа_BibTeX_для_записи,_с_соответствующим_разрешением.
+Attempt\ to\ automatically\ set\ file\ links\ for\ your\ entries.\ Automatically\ setting\ works\ if\ a\ file\ in\ your\ file\ directory<BR>or\ a\ subdirectory\ is\ named\ identically\ to\ an\ entry's\ BibTeX\ key,\ plus\ extension.=Попытка автоопределения ссылок файл для записей. Автоопределение возможно если файл находящийся в каталоге файлов файл или его подкаталоге<BR>имеет имя, идентичное имени ключа BibTeX для записи, с соответствующим разрешением.
 
-Autodetect_format=Автоопределение_формата
+Autodetect\ format=Автоопределение формата
 
-Autogenerate_BibTeX_keys=Автосоздание_ключей_BibTeX
+Autogenerate\ BibTeX\ keys=Автосоздание ключей BibTeX
 
-Autolink_files_with_names_starting_with_the_BibTeX_key=Автоматическая_привязка_файлов_с_именами,_начинающимися_с_ключа_BibTeX
+Autolink\ files\ with\ names\ starting\ with\ the\ BibTeX\ key=Автоматическая привязка файлов с именами, начинающимися с ключа BibTeX
 
-Autolink_only_files_that_match_the_BibTeX_key=Автоматическая_привязка_только_файлов_с_соответствием_ключу_BibTeX
+Autolink\ only\ files\ that\ match\ the\ BibTeX\ key=Автоматическая привязка только файлов с соответствием ключу BibTeX
 
-Automatically_create_groups=Автоматическое_создание_групп
+Automatically\ create\ groups=Автоматическое создание групп
 
-Automatically_remove_exact_duplicates=Автоматически_удалять_полные_дубликаты
+Automatically\ remove\ exact\ duplicates=Автоматически удалять полные дубликаты
 
-Allow_overwriting_existing_links.=Разрешить_перезапись_текущих_ссылок.
+Allow\ overwriting\ existing\ links.=Разрешить перезапись текущих ссылок.
 
-Do_not_overwrite_existing_links.=Не_перезаписывать_текущие_ссылки.
+Do\ not\ overwrite\ existing\ links.=Не перезаписывать текущие ссылки.
 
-AUX_file_import=Импорт_файла_AUX
+AUX\ file\ import=Импорт файла AUX
 
-Available_export_formats=Доступные_форматы_экспорта
+Available\ export\ formats=Доступные форматы экспорта
 
-Available_BibTeX_fields=Разрешенные_поля_BibTeX
+Available\ BibTeX\ fields=Разрешенные поля BibTeX
 
-Available_import_formats=Доступные_форматы_импорта
+Available\ import\ formats=Доступные форматы импорта
 
-Background_color_for_optional_fields=Цвет_фона_дополнительных_полей
+Background\ color\ for\ optional\ fields=Цвет фона дополнительных полей
 
-Background_color_for_required_fields=Цвет_фона_обязательных_полей
+Background\ color\ for\ required\ fields=Цвет фона обязательных полей
 
-Backup_old_file_when_saving=Создание_резервной_копии_старого_файла_при_сохранении
+Backup\ old\ file\ when\ saving=Создание резервной копии старого файла при сохранении
 
-BibTeX_key_is_unique.=Ключ_BibTeX_является_уникальным.
+BibTeX\ key\ is\ unique.=Ключ BibTeX является уникальным.
 
-%0_source=Источник_%0
+%0\ source=Источник %0
 
-Broken_link=Ссылка_с_ошибкой
+Broken\ link=Ссылка с ошибкой
 
 Browse=Обзор
 
@@ -160,321 +160,321 @@ by=по
 
 Cancel=Отмена
 
-Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?=Невозможно_добавить_записи_в_группу_без_создания_ключей._Создать_ключи?
+Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=Невозможно добавить записи в группу без создания ключей. Создать ключи?
 
-Cannot_merge_this_change=Невозможно_выполнить_объединение_для_этого_изменения
+Cannot\ merge\ this\ change=Невозможно выполнить объединение для этого изменения
 
-case_insensitive=без_учета_регистра
+case\ insensitive=без учета регистра
 
-case_sensitive=с_учетом_регистра
+case\ sensitive=с учетом регистра
 
-Case_sensitive=С_учетом_регистра
+Case\ sensitive=С учетом регистра
 
-change_assignment_of_entries=изменить_назначение_для_записей
+change\ assignment\ of\ entries=изменить назначение для записей
 
-Change_case=Изменить_регистр
+Change\ case=Изменить регистр
 
-Change_entry_type=Изменить_тип_записи
-Change_file_type=Изменить_тип_файла
+Change\ entry\ type=Изменить тип записи
+Change\ file\ type=Изменить тип файла
 
 
-Change_of_Grouping_Method=Изменить_метод_группировки
+Change\ of\ Grouping\ Method=Изменить метод группировки
 
-change_preamble=изменить_преамбулу
+change\ preamble=изменить преамбулу
 
-Change_table_column_and_General_fields_settings_to_use_the_new_feature=Измените_столбец_таблицы_и_общие_настройки_полей_для_использования_новых_свойств
+Change\ table\ column\ and\ General\ fields\ settings\ to\ use\ the\ new\ feature=Измените столбец таблицы и общие настройки полей для использования новых свойств
 
-Changed_language_settings=Измененные_настройки_языка
+Changed\ language\ settings=Измененные настройки языка
 
-Changed_preamble=Измененная_преамбула
+Changed\ preamble=Измененная преамбула
 
-Check_existing_file_links=Проверить_текущие_ссылки_файл
+Check\ existing\ file\ links=Проверить текущие ссылки файл
 
-Check_links=Проверить_ссылки
+Check\ links=Проверить ссылки
 
-Cite_command=Команда_цитирования
+Cite\ command=Команда цитирования
 
-Class_name=Имя_класса
+Class\ name=Имя класса
 
 Clear=Очистить
 
-Clear_fields=Очистить_поля
+Clear\ fields=Очистить поля
 
 Close=Закрыть
-Close_others=Закрыть_другие
-Close_all=Закрыть_все
+Close\ others=Закрыть другие
+Close\ all=Закрыть все
 
-Close_dialog=Закрыть_диалоговое_окно
+Close\ dialog=Закрыть диалоговое окно
 
-Close_the_current_library=Закрыть_текущую_БД
+Close\ the\ current\ library=Закрыть текущую БД
 
-Close_window=Закрыть_окно
+Close\ window=Закрыть окно
 
-Closed_library=Закрытая_БД
+Closed\ library=Закрытая БД
 
-Color_codes_for_required_and_optional_fields=Цветовые_коды_обязательных_и_дополнительных_полей
+Color\ codes\ for\ required\ and\ optional\ fields=Цветовые коды обязательных и дополнительных полей
 
-Color_for_marking_incomplete_entries=Цвет_маркировки_неполных_записей
+Color\ for\ marking\ incomplete\ entries=Цвет маркировки неполных записей
 
-Column_width=Ширина_столбца
+Column\ width=Ширина столбца
 
-Command_line_id=Ид._командной_строки
+Command\ line\ id=Ид. командной строки
 
 
-Contained_in=Содержится_в
+Contained\ in=Содержится в
 
 Content=Содержимое
 
 Copied=Скопированное
 
-Copied_cell_contents=Скопированное_содержимое_ячеек
+Copied\ cell\ contents=Скопированное содержимое ячеек
 
-Copied_title=
+Copied\ title=
 
-Copied_key=Скопированный_ключ
+Copied\ key=Скопированный ключ
 
-Copied_titles=
+Copied\ titles=
 
-Copied_keys=Скопированные_ключи
+Copied\ keys=Скопированные ключи
 
 Copy=Копировать
 
-Copy_BibTeX_key=Копировать_ключ_BibTeX
-Copy_file_to_file_directory=Копировать_файл_в_каталог
+Copy\ BibTeX\ key=Копировать ключ BibTeX
+Copy\ file\ to\ file\ directory=Копировать файл в каталог
 
-Copy_to_clipboard=Копировать_в_буфер_обмена
+Copy\ to\ clipboard=Копировать в буфер обмена
 
-Could_not_call_executable=Не_удалось_вызвать_исполняемый_файл
-Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.=Не_удалось_подключиться_к_серверу_Vim._Убедитесь,_что_приложение_Vim_запущено<BR>,и_имя_сервера_указано_правильно.
+Could\ not\ call\ executable=Не удалось вызвать исполняемый файл
+Could\ not\ connect\ to\ Vim\ server.\ Make\ sure\ that\ Vim\ is\ running<BR>with\ correct\ server\ name.=Не удалось подключиться к серверу Vim. Убедитесь, что приложение Vim запущено<BR>,и имя сервера указано правильно.
 
-Could_not_export_file=Не_удалось_экспортировать_файл
+Could\ not\ export\ file=Не удалось экспортировать файл
 
-Could_not_export_preferences=Не_удалось_экспортировать_пользовательские_настройки
+Could\ not\ export\ preferences=Не удалось экспортировать пользовательские настройки
 
-Could_not_find_a_suitable_import_format.=Не_удалось_найти_подходящий_формат_импорта.
-Could_not_import_preferences=Не_удалось_импортировать_пользовательские_настройки
+Could\ not\ find\ a\ suitable\ import\ format.=Не удалось найти подходящий формат импорта.
+Could\ not\ import\ preferences=Не удалось импортировать пользовательские настройки
 
-Could_not_instantiate_%0=Не_удалось_создать_экземпляр_%0
-Could_not_instantiate_%0_%1=Не_удалось_создать_экземпляр_%0_%1
-Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?=Не_удалось_создать_экземпляр_%0._Проверьте_правильность_пути_пакета.
-Could_not_open_link=Не_удалось_открыть_ссылку
+Could\ not\ instantiate\ %0=Не удалось создать экземпляр %0
+Could\ not\ instantiate\ %0\ %1=Не удалось создать экземпляр %0 %1
+Could\ not\ instantiate\ %0.\ Have\ you\ chosen\ the\ correct\ package\ path?=Не удалось создать экземпляр %0. Проверьте правильность пути пакета.
+Could\ not\ open\ link=Не удалось открыть ссылку
 
-Could_not_print_preview=Не_удалось_напечатать_предпросмотр
+Could\ not\ print\ preview=Не удалось напечатать предпросмотр
 
-Could_not_run_the_'vim'_program.=Не_удалось_запустить_приложение_'Vim'.
+Could\ not\ run\ the\ 'vim'\ program.=Не удалось запустить приложение 'Vim'.
 
-Could_not_save_file.=Не_удалось_сохранить_файл.
-Character_encoding_'%0'_is_not_supported.=Кодировка_'%0'_не_поддерживается.
+Could\ not\ save\ file.=Не удалось сохранить файл.
+Character\ encoding\ '%0'\ is\ not\ supported.=Кодировка '%0' не поддерживается.
 
-crossreferenced_entries_included=записи_с_перекрестными_ссылками
+crossreferenced\ entries\ included=записи с перекрестными ссылками
 
-Current_content=Текущее_содержимое
+Current\ content=Текущее содержимое
 
-Current_value=Текущее_значение
+Current\ value=Текущее значение
 
-Custom_entry_types=Пользовательские_типы_записей
+Custom\ entry\ types=Пользовательские типы записей
 
-Custom_entry_types_found_in_file=В_файле_обнаружены_пользовательские_типы_записей
+Custom\ entry\ types\ found\ in\ file=В файле обнаружены пользовательские типы записей
 
-Customize_entry_types=Настроить_типы_записей
+Customize\ entry\ types=Настроить типы записей
 
-Customize_key_bindings=Настройка_назначений_функциональных_клавиш
+Customize\ key\ bindings=Настройка назначений функциональных клавиш
 
 Cut=Вырезать
 
-cut_entries=вырезать_записи
+cut\ entries=вырезать записи
 
-cut_entry=вырезать_запись
+cut\ entry=вырезать запись
 
 
-Library_encoding=Кодировка_БД
+Library\ encoding=Кодировка БД
 
-Library_properties=Свойства_БД
+Library\ properties=Свойства БД
 
-Library_type=Тип_БД
+Library\ type=Тип БД
 
-Date_format=Формат_БД
+Date\ format=Формат БД
 
-Default=По_умолчанию
+Default=По умолчанию
 
-Default_encoding=Кодировка_по_умолчанию
+Default\ encoding=Кодировка по умолчанию
 
-Default_grouping_field=Поле_группировки_по_умолчанию
+Default\ grouping\ field=Поле группировки по умолчанию
 
-Default_look_and_feel=Интерфейс_по_умолчанию
+Default\ look\ and\ feel=Интерфейс по умолчанию
 
-Default_pattern=Шаблон_по_умолчанию
+Default\ pattern=Шаблон по умолчанию
 
-Default_sort_criteria=Критерий_сортировки_по_умолчанию
-Define_'%0'=Определить_'%0'
+Default\ sort\ criteria=Критерий сортировки по умолчанию
+Define\ '%0'=Определить '%0'
 
 Delete=Удалить
 
-Delete_custom_format=Удалить_пользовательский_формат
+Delete\ custom\ format=Удалить пользовательский формат
 
-delete_entries=удалить_записи
+delete\ entries=удалить записи
 
-Delete_entry=Удалить_запись
+Delete\ entry=Удалить запись
 
-delete_entry=удалить_запись
+delete\ entry=удалить запись
 
-Delete_multiple_entries=Удалить_несколько_записей
+Delete\ multiple\ entries=Удалить несколько записей
 
-Delete_rows=Удалить_ряды
+Delete\ rows=Удалить ряды
 
-Delete_strings=Удалить_строки
+Delete\ strings=Удалить строки
 
 Deleted=Удалено
 
-Permanently_delete_local_file=Удалить_локальный_файл
+Permanently\ delete\ local\ file=Удалить локальный файл
 
-Delimit_fields_with_semicolon,_ex.=Разделитель_для_полей\:_точка_с_запятой,_напр.\:
+Delimit\ fields\ with\ semicolon,\ ex.=Разделитель для полей: точка с запятой, напр.:
 
-Descending=В_порядке_убывания
+Descending=В порядке убывания
 
 Description=Описание
 
-Deselect_all=Отменить_выбор_всех
-Deselect_all_duplicates=Отменить_выбор_всех_дубликатов
+Deselect\ all=Отменить выбор всех
+Deselect\ all\ duplicates=Отменить выбор всех дубликатов
 
-Disable_this_confirmation_dialog=Отключить_это_диалоговое_окно_подтверждения
+Disable\ this\ confirmation\ dialog=Отключить это диалоговое окно подтверждения
 
-Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.=Отображать_все_записи,_принадлежащие_более_чем_одной_из_выбранных_групп.
+Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups.=Отображать все записи, принадлежащие более чем одной из выбранных групп.
 
-Display_all_error_messages=Отображать_все_сообщения_об_ошибках
+Display\ all\ error\ messages=Отображать все сообщения об ошибках
 
-Display_help_on_command_line_options=Отображать_справку_по_параметрам_командной_строки
+Display\ help\ on\ command\ line\ options=Отображать справку по параметрам командной строки
 
-Display_only_entries_belonging_to_all_selected_groups.=Отображать_только_записи,_принадлежащие_всем_выбранным_группам.
-Display_version=Отобразить_сведения_о_версии
+Display\ only\ entries\ belonging\ to\ all\ selected\ groups.=Отображать только записи, принадлежащие всем выбранным группам.
+Display\ version=Отобразить сведения о версии
 
-Do_not_abbreviate_names=Не_сокращать_названия
+Do\ not\ abbreviate\ names=Не сокращать названия
 
-Do_not_automatically_set=Без_автоопределения
+Do\ not\ automatically\ set=Без автоопределения
 
-Do_not_import_entry=Не_импортировать_запись
+Do\ not\ import\ entry=Не импортировать запись
 
-Do_not_open_any_files_at_startup=Не_открывать_файлы_при_запуске
+Do\ not\ open\ any\ files\ at\ startup=Не открывать файлы при запуске
 
-Do_not_overwrite_existing_keys=Не_перезаписывать_существующие_ключи
-Do_not_show_these_options_in_the_future=Не_показывать_эти_параметры_в_дальнейшем
+Do\ not\ overwrite\ existing\ keys=Не перезаписывать существующие ключи
+Do\ not\ show\ these\ options\ in\ the\ future=Не показывать эти параметры в дальнейшем
 
-Do_not_wrap_the_following_fields_when_saving=Не_сворачивать_следующие_поля_при_сохранении
-Do_not_write_the_following_fields_to_XMP_Metadata\:=Не_записывать_следующие_поля_в_метаданные_XMP\:
+Do\ not\ wrap\ the\ following\ fields\ when\ saving=Не сворачивать следующие поля при сохранении
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Не записывать следующие поля в метаданные XMP:
 
-Do_you_want_JabRef_to_do_the_following_operations?=Приложение_JabRef_выполнит_следующие_операции._Продолжить?
+Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Приложение JabRef выполнит следующие операции. Продолжить?
 
-Donate_to_JabRef=Поддержать_JabRef
+Donate\ to\ JabRef=Поддержать JabRef
 
 Down=Вниз
 
-Download_file=Загрузить_файл
+Download\ file=Загрузить файл
 
-Downloading...=Выполняется_загрузка...
+Downloading...=Выполняется загрузка...
 
-Drop_%0=Отброшено\:_%0
+Drop\ %0=Отброшено: %0
 
-duplicate_removal=удаление_дубликатов
+duplicate\ removal=удаление дубликатов
 
-Duplicate_string_name=Дубликат_имени_строки
+Duplicate\ string\ name=Дубликат имени строки
 
-Duplicates_found=Найдены_дубликаты
+Duplicates\ found=Найдены дубликаты
 
-Dynamic_groups=Динамические_группы
+Dynamic\ groups=Динамические группы
 
-Dynamically_group_entries_by_a_free-form_search_expression=Динамическая_группировка_записей_по_произвольному_условию_поиска
+Dynamically\ group\ entries\ by\ a\ free-form\ search\ expression=Динамическая группировка записей по произвольному условию поиска
 
-Dynamically_group_entries_by_searching_a_field_for_a_keyword=Динамическая_группировка_записей_по_поиску_ключегого_слова_в_поле
+Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=Динамическая группировка записей по поиску ключегого слова в поле
 
-Each_line_must_be_on_the_following_form=Каждая_строка_должна_иметь_следующую_форму
+Each\ line\ must\ be\ on\ the\ following\ form=Каждая строка должна иметь следующую форму
 
 Edit=Изменить
 
-Edit_custom_export=Изменить_пользовательский_экспорт
-Edit_entry=Изменить_запись
-Save_file=Изменить_ссылку_на_файл
-Edit_file_type=Изменить_тип_файла
+Edit\ custom\ export=Изменить пользовательский экспорт
+Edit\ entry=Изменить запись
+Save\ file=Изменить ссылку на файл
+Edit\ file\ type=Изменить тип файла
 
-Edit_group=Изменить_группу
+Edit\ group=Изменить группу
 
 
-Edit_preamble=Изменить_преамбулу
-Edit_strings=Изменить_строки
-Editor_options=Параметры_редактора
+Edit\ preamble=Изменить преамбулу
+Edit\ strings=Изменить строки
+Editor\ options=Параметры редактора
 
-Empty_BibTeX_key=Пустой_ключ_BibTeX
+Empty\ BibTeX\ key=Пустой ключ BibTeX
 
-Grouping_may_not_work_for_this_entry.=Возможна_ошибка_группировки_для_этой_записи.
+Grouping\ may\ not\ work\ for\ this\ entry.=Возможна ошибка группировки для этой записи.
 
-empty_library=пустая_база_данных
-Enable_word/name_autocompletion=Включить_автозавершение_для_слов/названий
+empty\ library=пустая база данных
+Enable\ word/name\ autocompletion=Включить автозавершение для слов/названий
 
-Enter_URL=Ввод_URL-адреса
+Enter\ URL=Ввод URL-адреса
 
-Enter_URL_to_download=Ввод_URL-адреса_загрузки
+Enter\ URL\ to\ download=Ввод URL-адреса загрузки
 
 entries=записи
 
-Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.=Невозможно_назначить/удалить_записи_этой_группы_вручную.
+Entries\ cannot\ be\ manually\ assigned\ to\ or\ removed\ from\ this\ group.=Невозможно назначить/удалить записи этой группы вручную.
 
-Entries_exported_to_clipboard=Записи_экспортированы_в_буфер_обмена
+Entries\ exported\ to\ clipboard=Записи экспортированы в буфер обмена
 
 
 entry=запись
 
-Entry_editor=Редактор_записей
+Entry\ editor=Редактор записей
 
-Entry_preview=Предварительный_просмотр_записи
+Entry\ preview=Предварительный просмотр записи
 
-Entry_table=Таблица_записей
+Entry\ table=Таблица записей
 
-Entry_table_columns=Столбцы_таблицы_записей
+Entry\ table\ columns=Столбцы таблицы записей
 
-Entry_type=Тип_записи
+Entry\ type=Тип записи
 
-Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Имена_типов_записей_не_должны_содержать_пробелов_или_следующих_знаков
+Entry\ type\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Имена типов записей не должны содержать пробелов или следующих знаков
 
-Entry_types=Типы_записей
+Entry\ types=Типы записей
 
 Error=Ошибка
-Error_exporting_to_clipboard=Ошибка_экспорта_в_буфер_обмена
+Error\ exporting\ to\ clipboard=Ошибка экспорта в буфер обмена
 
-Error_occurred_when_parsing_entry=Ошибка_анализа_записи
+Error\ occurred\ when\ parsing\ entry=Ошибка анализа записи
 
-Error_opening_file=Ошибка_при_открытии_файла
+Error\ opening\ file=Ошибка при открытии файла
 
-Error_setting_field=Ошибка_конфигурации_поля
+Error\ setting\ field=Ошибка конфигурации поля
 
-Error_while_writing=Ошибка_при_записи
-Error_writing_to_%0_file(s).=Ошибка_при_записи_в_файл(ы)_%0.
+Error\ while\ writing=Ошибка при записи
+Error\ writing\ to\ %0\ file(s).=Ошибка при записи в файл(ы) %0.
 
 
 
-'%0'_exists._Overwrite_file?='%0'_существует._Перезаписать_файл?
-Overwrite_file?=Перезаписать_файл?
+'%0'\ exists.\ Overwrite\ file?='%0' существует. Перезаписать файл?
+Overwrite\ file?=Перезаписать файл?
 
 Export=Экспорт
 
-Export_name=Имя_экспорта
+Export\ name=Имя экспорта
 
-Export_preferences=Экспорт_пользовательских_настроек
+Export\ preferences=Экспорт пользовательских настроек
 
-Export_preferences_to_file=Экспорт_пользовательских_настроек_в_файл
+Export\ preferences\ to\ file=Экспорт пользовательских настроек в файл
 
-Export_properties=Экспорт_свойств
+Export\ properties=Экспорт свойств
 
-Export_to_clipboard=Экспорт_в_буфер_обмена
+Export\ to\ clipboard=Экспорт в буфер обмена
 
-Exporting=Выполняется_экспорт
+Exporting=Выполняется экспорт
 Extension=Расширение
 
-External_changes=Внешние_изменения
+External\ changes=Внешние изменения
 
-External_file_links=Ссылки_на_внешние_файлы
+External\ file\ links=Ссылки на внешние файлы
 
-External_programs=Внешние_программы
+External\ programs=Внешние программы
 
-External_viewer_called=Вызов_внешней_программы_просмотра
+External\ viewer\ called=Вызов внешней программы просмотра
 
 Fetch=Выборка
 
@@ -482,660 +482,660 @@ Field=Поле
 
 field=поле
 
-Field_name=Имя_поля
-Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Имена_полей_не_должны_содержать_пробелов_или_следующих_знаков
+Field\ name=Имя поля
+Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Имена полей не должны содержать пробелов или следующих знаков
 
-Field_to_filter=Поле_для_фильтра
+Field\ to\ filter=Поле для фильтра
 
-Field_to_group_by=Поле_для_группировки
+Field\ to\ group\ by=Поле для группировки
 
 File=Файл
 
 file=файл
-File_'%0'_is_already_open.=Файл_'%0'_уже_открыт.
+File\ '%0'\ is\ already\ open.=Файл '%0' уже открыт.
 
-File_changed=Файл_изменен
-File_directory_is_'%0'\:=Каталог_файлов_-_'%0'\:
+File\ changed=Файл изменен
+File\ directory\ is\ '%0'\:=Каталог файлов - '%0':
 
-File_directory_is_not_set_or_does_not_exist\!=Каталог_файлов_не_задан_или_не_существует.
+File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=Каталог файлов не задан или не существует.
 
-File_exists=Файл_существует
+File\ exists=Файл существует
 
-File_has_been_updated_externally._What_do_you_want_to_do?=Файл_изменен_внешними_средствами._Выберите_дальнейшие_действия.
+File\ has\ been\ updated\ externally.\ What\ do\ you\ want\ to\ do?=Файл изменен внешними средствами. Выберите дальнейшие действия.
 
-File_not_found=Файл_не_найден
-File_type=Тип_файла
+File\ not\ found=Файл не найден
+File\ type=Тип файла
 
-File_updated_externally=Файл_изменен_внешними_средствами
+File\ updated\ externally=Файл изменен внешними средствами
 
-filename=имя_файла
+filename=имя файла
 
 Filename=
 
-Files_opened=Открытые_файлы
+Files\ opened=Открытые файлы
 
 Filter=Фильтр
 
-Filter_All=
+Filter\ All=
 
-Filter_None=
+Filter\ None=
 
-Finished_automatically_setting_external_links.=Автоопределение_внешних_ссылок_выполнено.
+Finished\ automatically\ setting\ external\ links.=Автоопределение внешних ссылок выполнено.
 
-Finished_synchronizing_file_links._Entries_changed\:_%0.=Синхронизация_ссылок_файл_выполнена._Записей_с_изменениями\:_%0.
-Finished_writing_XMP-metadata._Wrote_to_%0_file(s).=Запись_метаданных_XMP_выполнена._Файлов_с_записями:_%0.
-Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).=Запись_XMP_в_%0_файл(ов)_выполнена_(пропущено:_%1_,с_ошибками:_%2).
+Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Синхронизация ссылок файл выполнена. Записей с изменениями: %0.
+Finished\ writing\ XMP-metadata.\ Wrote\ to\ %0\ file(s).=Запись метаданных XMP выполнена. Файлов с записями: %0.
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Запись XMP в %0 файл(ов) выполнена (пропущено: %1 ,с ошибками: %2).
 
-First_select_the_entries_you_want_keys_to_be_generated_for.=Сначала_выберите_записи,_для_которых_следует_создать_ключи.
+First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Сначала выберите записи, для которых следует создать ключи.
 
-Fit_table_horizontally_on_screen=Разместить_горизонтально_на_экране
+Fit\ table\ horizontally\ on\ screen=Разместить горизонтально на экране
 
 Float=Нефиксированные
-Float_marked_entries=Записи_с_метками_как_нефиксированные
+Float\ marked\ entries=Записи с метками как нефиксированные
 
-Font_family=Гарнитура_шрифта
+Font\ family=Гарнитура шрифта
 
-Font_preview=Предварительный_просмотр_шрифта
+Font\ preview=Предварительный просмотр шрифта
 
-Font_size=Кегль
+Font\ size=Кегль
 
-Font_style=Начертание_шрифта
+Font\ style=Начертание шрифта
 
-Font_selection=Выбор_шрифта
+Font\ selection=Выбор шрифта
 
 for=для
 
-Format_of_author_and_editor_names=Формат_имени_автора/редактора
-Format_string=Форматировать_строку
+Format\ of\ author\ and\ editor\ names=Формат имени автора/редактора
+Format\ string=Форматировать строку
 
-Format_used=Используемый_формат
-Formatter_name=Имя_программы_форматирования
+Format\ used=Используемый формат
+Formatter\ name=Имя программы форматирования
 
-found_in_AUX_file=найдено_в_файле_AUX
+found\ in\ AUX\ file=найдено в файле AUX
 
-Full_name=Полное_имя
+Full\ name=Полное имя
 
 General=Общие
 
-General_fields=Общие_поля
+General\ fields=Общие поля
 
 Generate=Создать
 
-Generate_BibTeX_key=Создать_ключ_BibTeX
+Generate\ BibTeX\ key=Создать ключ BibTeX
 
-Generate_keys=Создать_ключи
+Generate\ keys=Создать ключи
 
-Generate_keys_before_saving_(for_entries_without_a_key)=Создать_ключи_перед_сохранением_(для_записей_без_ключей)
-Generate_keys_for_imported_entries=Создать_ключи_для_импортируемых_записей
+Generate\ keys\ before\ saving\ (for\ entries\ without\ a\ key)=Создать ключи перед сохранением (для записей без ключей)
+Generate\ keys\ for\ imported\ entries=Создать ключи для импортируемых записей
 
-Generate_now=Создать_сейчас
+Generate\ now=Создать сейчас
 
-Generated_BibTeX_key_for=Создать_ключ_BibTeX_для
+Generated\ BibTeX\ key\ for=Создать ключ BibTeX для
 
-Generating_BibTeX_key_for=Создание_ключа_BibTeX_для
-Get_fulltext=Получить_весь_текст
+Generating\ BibTeX\ key\ for=Создание ключа BibTeX для
+Get\ fulltext=Получить весь текст
 
-Gray_out_non-hits=Деактивировать_неподходящие
+Gray\ out\ non-hits=Деактивировать неподходящие
 
 Groups=Группы
 
-Have_you_chosen_the_correct_package_path?=Проверьте_правильность_пути_пакета.
+Have\ you\ chosen\ the\ correct\ package\ path?=Проверьте правильность пути пакета.
 
 Help=Справка
 
-Help_on_key_patterns=Справка_по_шаблонам_ключей
-Help_on_regular_expression_search=Справка_по_поиску_с_помощью_регулярных_выражений
+Help\ on\ key\ patterns=Справка по шаблонам ключей
+Help\ on\ regular\ expression\ search=Справка по поиску с помощью регулярных выражений
 
-Hide_non-hits=Скрыть_неподходящие
+Hide\ non-hits=Скрыть неподходящие
 
-Hierarchical_context=Иерархический_контекст
+Hierarchical\ context=Иерархический контекст
 
 Highlight=Выделение
 Marking=
 Underline=
-Empty_Highlight=
-Empty_Marking=
-Empty_Underline=
-The_marked_area_does_not_contain_any_legible_text!=
+Empty\ Highlight=
+Empty\ Marking=
+Empty\ Underline=
+The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=
 
-Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>=Подсказка\:_Для_поиска_только_по_определенным_полям,_напр.\:<p><tt>автор\=smith_и_заглавие\=electrical</tt>
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Подсказка: Для поиска только по определенным полям, напр.:<p><tt>автор=smith и заглавие=electrical</tt>
 
-HTML_table=Таблица_HTML
-HTML_table_(with_Abstract_&_BibTeX)=Таблица_HTML_(с_резюме_&_BibTeX)
+HTML\ table=Таблица HTML
+HTML\ table\ (with\ Abstract\ &\ BibTeX)=Таблица HTML (с резюме & BibTeX)
 Icon=Значок
 
 Ignore=Пропуск
 
 Import=Импорт
 
-Import_and_keep_old_entry=Импорт_с_сохранением_старой_записи
+Import\ and\ keep\ old\ entry=Импорт с сохранением старой записи
 
-Import_and_remove_old_entry=Импорт_с_удалением_старой_записи
+Import\ and\ remove\ old\ entry=Импорт с удалением старой записи
 
-Import_entries=Импорт_записей
+Import\ entries=Импорт записей
 
-Import_failed=Ошибка_импорта
+Import\ failed=Ошибка импорта
 
-Import_file=Импорт_файла
+Import\ file=Импорт файла
 
-Import_group_definitions=Импорт_определений_групп
+Import\ group\ definitions=Импорт определений групп
 
-Import_name=Имя_импорта
+Import\ name=Имя импорта
 
-Import_preferences=Импорт_пользовательских_настроек
+Import\ preferences=Импорт пользовательских настроек
 
-Import_preferences_from_file=Импорт_пользовательских_настроек_из_файла
+Import\ preferences\ from\ file=Импорт пользовательских настроек из файла
 
-Import_strings=Импорт_строк
+Import\ strings=Импорт строк
 
-Import_to_open_tab=Импорт_в_открытую_вкладку
+Import\ to\ open\ tab=Импорт в открытую вкладку
 
-Import_word_selector_definitions=Импорт_определений_выбора_слов
+Import\ word\ selector\ definitions=Импорт определений выбора слов
 
-Imported_entries=Импортированные_записи
+Imported\ entries=Импортированные записи
 
-Imported_from_library=Импортировано_из_БД
+Imported\ from\ library=Импортировано из БД
 
-Importer_class=Класс_Importer
+Importer\ class=Класс Importer
 
 Importing=Импорт
 
-Importing_in_unknown_format=Импорт_неизвестного_формата
+Importing\ in\ unknown\ format=Импорт неизвестного формата
 
-Include_abstracts=Включить_конспект
-Include_entries=Включить_записи
+Include\ abstracts=Включить конспект
+Include\ entries=Включить записи
 
-Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups=Включить_подгруппы\:_Просмотр_записей,_содержащихся_в_этой_группе_или_ее_подгруппах_(если_выбрано)
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=Включить подгруппы: Просмотр записей, содержащихся в этой группе или ее подгруппах (если выбрано)
 
-Independent_group\:_When_selected,_view_only_this_group's_entries=Независимая_группа\:_Просмотр_записей_только_этой_группы_(если_выбрано)
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=Независимая группа: Просмотр записей только этой группы (если выбрано)
 
-Work_options=Рабочие_параметры
+Work\ options=Рабочие параметры
 
 Insert=Вставить
 
-Insert_rows=Вставить_строки
+Insert\ rows=Вставить строки
 
 Intersection=Пересечение
 
-Invalid_BibTeX_key=Недопустимый_ключ_BibTeX
+Invalid\ BibTeX\ key=Недопустимый ключ BibTeX
 
-Invalid_date_format=Недопустимый_формат_даты
+Invalid\ date\ format=Недопустимый формат даты
 
-Invalid_URL=Недопустимый_URL-адрес
+Invalid\ URL=Недопустимый URL-адрес
 
-Online_help=Онлайн-справка
+Online\ help=Онлайн-справка
 
-JabRef_preferences=Пользовательские_настройки_JabRef
+JabRef\ preferences=Пользовательские настройки JabRef
 
 Join=
 
-Joins_selected_keywords_and_deletes_selected_keywords.=
+Joins\ selected\ keywords\ and\ deletes\ selected\ keywords.=
 
-Journal_abbreviations=Сокращения_для_журналов
+Journal\ abbreviations=Сокращения для журналов
 
 Keep=Оставить
 
-Keep_both=Оставить_оба
+Keep\ both=Оставить оба
 
-Key_bindings=Функциональные_клавиши
+Key\ bindings=Функциональные клавиши
 
-Key_bindings_changed=Назначения_функциональных_клавиш_изменены
+Key\ bindings\ changed=Назначения функциональных клавиш изменены
 
-Key_generator_settings=Настройки_создания_ключей
+Key\ generator\ settings=Настройки создания ключей
 
-Key_pattern=Шаблон_ключа
+Key\ pattern=Шаблон ключа
 
-keys_in_library=ключи_в_базе_данных
+keys\ in\ library=ключи в базе данных
 
-Keyword=Ключевое_слово
+Keyword=Ключевое слово
 
 Label=Метка
 
 Language=Язык
 
-Last_modified=Последнее_изменение
+Last\ modified=Последнее изменение
 
-LaTeX_AUX_file=Файл_AUX_для_LaTeX
-Leave_file_in_its_current_directory=Сохранить_файл_в_текущем_каталоге
+LaTeX\ AUX\ file=Файл AUX для LaTeX
+Leave\ file\ in\ its\ current\ directory=Сохранить файл в текущем каталоге
 
 Left=Левый
 Level=Уровень
 
-Limit_to_fields=Ограничение_для_полей
+Limit\ to\ fields=Ограничение для полей
 
-Limit_to_selected_entries=Ограничение_для_выбранных_записей
+Limit\ to\ selected\ entries=Ограничение для выбранных записей
 
 Link=Ссылка
-Link_local_file=Ссылка_на_локальный_файл
-Link_to_file_%0=Ссылка_на_файл_%0
+Link\ local\ file=Ссылка на локальный файл
+Link\ to\ file\ %0=Ссылка на файл %0
 
-Listen_for_remote_operation_on_port=Прослушивать_удаленные_подключения_для_порта
-Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)=Загрузка_или_сохранение_пользовательских_настроек_из/в_файл_jabref.xml_при_запуске_(режим_флеш-памяти)
+Listen\ for\ remote\ operation\ on\ port=Прослушивать удаленные подключения для порта
+Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=Загрузка или сохранение пользовательских настроек из/в файл jabref.xml при запуске (режим флеш-памяти)
 
-Look_and_feel=Интерфейс
-Main_file_directory=Основной_каталог_файлов
+Look\ and\ feel=Интерфейс
+Main\ file\ directory=Основной каталог файлов
 
-Main_layout_file=Главный_файл_макета
+Main\ layout\ file=Главный файл макета
 
-Manage_custom_exports=Управление_пользовательским_экспортом
+Manage\ custom\ exports=Управление пользовательским экспортом
 
-Manage_custom_imports=Управление_пользовательским_импортом
-Manage_external_file_types=Управление_внешними_типами_файлов
+Manage\ custom\ imports=Управление пользовательским импортом
+Manage\ external\ file\ types=Управление внешними типами файлов
 
-Mark_entries=Метки_записей
+Mark\ entries=Метки записей
 
-Mark_entry=Метка_записи
+Mark\ entry=Метка записи
 
-Mark_new_entries_with_addition_date=Метка_даты_добавления_для_новых_записей
+Mark\ new\ entries\ with\ addition\ date=Метка даты добавления для новых записей
 
-Mark_new_entries_with_owner_name=Метка_имени_владельца_для_новых_записей
+Mark\ new\ entries\ with\ owner\ name=Метка имени владельца для новых записей
 
-Memory_stick_mode=Режим_флеш-памяти
+Memory\ stick\ mode=Режим флеш-памяти
 
-Menu_and_label_font_size=Кегль_меню_и_подписи
+Menu\ and\ label\ font\ size=Кегль меню и подписи
 
-Merged_external_changes=Внешние_изменения_с_объединением
+Merged\ external\ changes=Внешние изменения с объединением
 
 Messages=Сообщения
 
-Modification_of_field=Модификация_поля
+Modification\ of\ field=Модификация поля
 
-Modified_group_"%0".=Модифицированная_группа_"%0".
+Modified\ group\ "%0".=Модифицированная группа "%0".
 
-Modified_groups=Модифицированные_группы
+Modified\ groups=Модифицированные группы
 
-Modified_string=Модифицированная_строка
+Modified\ string=Модифицированная строка
 
 Modify=Модифицировать
 
-modify_group=модифицировать_группу
+modify\ group=модифицировать группу
 
-Move_down=Переместить_вниз
+Move\ down=Переместить вниз
 
-Move_external_links_to_'file'_field=Переместить_внешние_ссылки_в_поле_'файл'
+Move\ external\ links\ to\ 'file'\ field=Переместить внешние ссылки в поле 'файл'
 
-move_group=переместить_группу
+move\ group=переместить группу
 
-Move_up=Переместить_вверх
+Move\ up=Переместить вверх
 
-Moved_group_"%0".=Перемещенная_группа_"%0".
+Moved\ group\ "%0".=Перемещенная группа "%0".
 
 Name=Имя
-Name_formatter=Программа_форматирования_имени
+Name\ formatter=Программа форматирования имени
 
-Natbib_style=Стиль_Natbib
+Natbib\ style=Стиль Natbib
 
-nested_AUX_files=родственный_файл_AUX
+nested\ AUX\ files=родственный файл AUX
 
 New=Создать
 
 new=создать
 
-New_BibTeX_entry=Создать_запись_BibTeX
+New\ BibTeX\ entry=Создать запись BibTeX
 
-New_BibTeX_sublibrary=Создать_подчиненную_БД_BibTeX
+New\ BibTeX\ sublibrary=Создать подчиненную БД BibTeX
 
-New_content=Создать_контент
+New\ content=Создать контент
 
-New_library_created.=Создана_новая_БД.
-New_%0_library=Создать_БД_%0
-New_field_value=Создать_значение_поля
+New\ library\ created.=Создана новая БД.
+New\ %0\ library=Создать БД %0
+New\ field\ value=Создать значение поля
 
-New_group=Создать_группу
+New\ group=Создать группу
 
-New_string=Создать_строку
+New\ string=Создать строку
 
-Next_entry=Следующая_запись
+Next\ entry=Следующая запись
 
-No_actual_changes_found.=Изменений_не_найдено.
+No\ actual\ changes\ found.=Изменений не найдено.
 
-no_base-BibTeX-file_specified=не_указан_базовый_файл_BibTeX
+no\ base-BibTeX-file\ specified=не указан базовый файл BibTeX
 
-no_library_generated=БД_не_создана
+no\ library\ generated=БД не создана
 
-No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.=Записи_не_найдены._Убедитесь,_что_используется_правильный_фильтр_импорта.
+No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=Записи не найдены. Убедитесь, что используется правильный фильтр импорта.
 
 
-No_entries_found_for_the_search_string_'%0'=Не_найдены_записи_для_строки_поиска_'%0'
+No\ entries\ found\ for\ the\ search\ string\ '%0'=Не найдены записи для строки поиска '%0'
 
-No_entries_imported.=Записи_не_импортированы.
+No\ entries\ imported.=Записи не импортированы.
 
-No_files_found.=Файлы_не_найдены.
+No\ files\ found.=Файлы не найдены.
 
-No_GUI._Only_process_command_line_options.=Без_ИП._Обработка_только_с_использованием_командной_строки.
+No\ GUI.\ Only\ process\ command\ line\ options.=Без ИП. Обработка только с использованием командной строки.
 
-No_journal_names_could_be_abbreviated.=Названия_журналов_не_могут_быть_сокращены.
+No\ journal\ names\ could\ be\ abbreviated.=Названия журналов не могут быть сокращены.
 
-No_journal_names_could_be_unabbreviated.=Названия_журналов_не_могут_быть_развернуты.
-No_PDF_linked=Без_ссылок_на_PDF
+No\ journal\ names\ could\ be\ unabbreviated.=Названия журналов не могут быть развернуты.
+No\ PDF\ linked=Без ссылок на PDF
 
-Open_PDF=
+Open\ PDF=
 
-No_URL_defined=URL-адрес_не_определен
+No\ URL\ defined=URL-адрес не определен
 not=не
 
-not_found=не_найдено
+not\ found=не найдено
 
-Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,=Обратите_внимание,_что_следует_указать_полностью_квалифицированное_имя_класса_для_интерфейса,
+Note\ that\ you\ must\ specify\ the\ fully\ qualified\ class\ name\ for\ the\ look\ and\ feel,=Обратите внимание, что следует указать полностью квалифицированное имя класса для интерфейса,
 
-Nothing_to_redo=Нет_действий_для_повтора
+Nothing\ to\ redo=Нет действий для повтора
 
-Nothing_to_undo=Нет_действий_для_отмены
+Nothing\ to\ undo=Нет действий для отмены
 
 occurrences=встречаемость
 
 OK=OK
-One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Один_или_несколько_файлов_имеют_не_определенный_тип_'%0'._Выберите_дальнейшие_действия.
+One\ or\ more\ file\ links\ are\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Один или несколько файлов имеют не определенный тип '%0'. Выберите дальнейшие действия.
 
-One_or_more_keys_will_be_overwritten._Continue?=Один_или_несколько_ключей_будут_перезаписаны._Продолжить?
+One\ or\ more\ keys\ will\ be\ overwritten.\ Continue?=Один или несколько ключей будут перезаписаны. Продолжить?
 
 
 Open=Открыть
 
-Open_BibTeX_library=Открыть_БД_BibTeX
+Open\ BibTeX\ library=Открыть БД BibTeX
 
-Open_library=Открыть_БД
+Open\ library=Открыть БД
 
-Open_editor_when_a_new_entry_is_created=Открыть_редактор_при_создании_новой_записи
+Open\ editor\ when\ a\ new\ entry\ is\ created=Открыть редактор при создании новой записи
 
-Open_file=Открыть_файл
+Open\ file=Открыть файл
 
-Open_last_edited_libraries_at_startup=Открыть_БД_с_последним_временем_редактирования_при_запуске
+Open\ last\ edited\ libraries\ at\ startup=Открыть БД с последним временем редактирования при запуске
 
-Connect_to_shared_database=
+Connect\ to\ shared\ database=
 
-Open_terminal_here=Открыть_терминал_в_текущей_директории
+Open\ terminal\ here=Открыть терминал в текущей директории
 
-Open_URL_or_DOI=Открыть_URL-адрес_или_DOI
+Open\ URL\ or\ DOI=Открыть URL-адрес или DOI
 
-Opened_library=Открытая_БД
+Opened\ library=Открытая БД
 
-Opening=Выполняется_открытие
+Opening=Выполняется открытие
 
-Opening_preferences...=Выполняется_загрузка_пользовательских_настроек...
+Opening\ preferences...=Выполняется загрузка пользовательских настроек...
 
-Operation_canceled.=Операция_отменена.
-Operation_not_supported=Операция_не_поддерживается
+Operation\ canceled.=Операция отменена.
+Operation\ not\ supported=Операция не поддерживается
 
-Optional_fields=Дополнительные_поля
+Optional\ fields=Дополнительные поля
 
 Options=Параметры
 
 or=или
 
-Output_or_export_file=Вывод_или_экспорт_файла
+Output\ or\ export\ file=Вывод или экспорт файла
 
 Override=Переопределить
 
-Override_default_file_directories=Переопределить_каталоги_файлов,_заданные_по_умолчанию
+Override\ default\ file\ directories=Переопределить каталоги файлов, заданные по умолчанию
 
-Override_default_font_settings=Переопределить_настройки_шрифта,_заданные_по_умолчанию
+Override\ default\ font\ settings=Переопределить настройки шрифта, заданные по умолчанию
 
-Override_the_BibTeX_field_by_the_selected_text=заменить_ключ_BibTeX_на_выделенный_текст
+Override\ the\ BibTeX\ field\ by\ the\ selected\ text=заменить ключ BibTeX на выделенный текст
 
 
 Overwrite=Перезаписать
-Overwrite_existing_field_values=Перезаписать_текущие_значения_полей
+Overwrite\ existing\ field\ values=Перезаписать текущие значения полей
 
-Overwrite_keys=Перезаписать_ключи
+Overwrite\ keys=Перезаписать ключи
 
-pairs_processed=обработанные_пары
+pairs\ processed=обработанные пары
 Password=Пароль
 
 Paste=Вставить
 
-paste_entries=вставить_записи
+paste\ entries=вставить записи
 
-paste_entry=вставить_запись
-Paste_from_clipboard=Вставить_из_буфера_обмена
+paste\ entry=вставить запись
+Paste\ from\ clipboard=Вставить из буфера обмена
 
 Pasted=Вставлено
 
-Path_to_%0_not_defined=Не_задан_путь_к_%0
+Path\ to\ %0\ not\ defined=Не задан путь к %0
 
-Path_to_LyX_pipe=Путь_к_каналу_LyX
+Path\ to\ LyX\ pipe=Путь к каналу LyX
 
-PDF_does_not_exist=PDF_не_существует
+PDF\ does\ not\ exist=PDF не существует
 
-File_has_no_attached_annotations=
+File\ has\ no\ attached\ annotations=
 
-Plain_text_import=Импорт_неформатированного_текста
+Plain\ text\ import=Импорт неформатированного текста
 
-Please_enter_a_name_for_the_group.=Введите_имя_для_группы.
+Please\ enter\ a\ name\ for\ the\ group.=Введите имя для группы.
 
-Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>=Введите_условие_поиска._Например,_для_поиска_всех_полей_со_значением_<b>Smith</b>,_введите\:<p><tt>smith</tt><p>Для_поиска_в_поле_<b>Автор</b>_значения_<b>Smith</b>_а_в_поле_<b>Заглавие</b>_значения_<b>electrical</b>,_введите\:<p><tt>автор\=smith_и_заглавие\=electrical</tt>
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Введите условие поиска. Например, для поиска всех полей со значением <b>Smith</b>, введите:<p><tt>smith</tt><p>Для поиска в поле <b>Автор</b> значения <b>Smith</b> а в поле <b>Заглавие</b> значения <b>electrical</b>, введите:<p><tt>автор=smith и заглавие=electrical</tt>
 
-Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=Введите_поле_для_поиска_(напр.,_<b>ключевые_слова</b>)_и_ключевое_слово_для_поиска_(напр.,_<b>electrical</b>).
+Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=Введите поле для поиска (напр., <b>ключевые слова</b>) и ключевое слово для поиска (напр., <b>electrical</b>).
 
-Please_enter_the_string's_label=Введите_подпись_для_строки
+Please\ enter\ the\ string's\ label=Введите подпись для строки
 
-Please_select_an_importer.=Выберите_фильтр_импорта.
+Please\ select\ an\ importer.=Выберите фильтр импорта.
 
-Possible_duplicate_entries=Возможные_дубликаты_записей
+Possible\ duplicate\ entries=Возможные дубликаты записей
 
-Possible_duplicate_of_existing_entry._Click_to_resolve.=Возможный_дубликат_существующей_записи._Щелкните_для_разрешения.
+Possible\ duplicate\ of\ existing\ entry.\ Click\ to\ resolve.=Возможный дубликат существующей записи. Щелкните для разрешения.
 
 Preamble=Преамбула
 
-Preferences=Пользовательские_настройки
+Preferences=Пользовательские настройки
 
-Preferences_recorded.=Пользовательские_настройки_записаны.
+Preferences\ recorded.=Пользовательские настройки записаны.
 
-Preview=Предварительный_просмотр
-Citation_Style=
-Current_Preview=
-Cannot_generate_preview_based_on_selected_citation_style.=
-Bad_character_inside_entry=
-Error_while_generating_citation_style=
-Preview_style_changed_to\:_%0=
-Next_preview_layout=
-Previous_preview_layout=
+Preview=Предварительный просмотр
+Citation\ Style=
+Current\ Preview=
+Cannot\ generate\ preview\ based\ on\ selected\ citation\ style.=
+Bad\ character\ inside\ entry=
+Error\ while\ generating\ citation\ style=
+Preview\ style\ changed\ to\:\ %0=
+Next\ preview\ layout=
+Previous\ preview\ layout=
 
-Previous_entry=Предыдущая_запись
+Previous\ entry=Предыдущая запись
 
-Primary_sort_criterion=Первичный_критерий_сортировки
-Problem_with_parsing_entry=Ошибка_анализа_записи
-Processing_%0=Выполняется_обработка_%0
-Pull_changes_from_shared_database=Загрузить_изменения_из_БД_с_общим_доступом
+Primary\ sort\ criterion=Первичный критерий сортировки
+Problem\ with\ parsing\ entry=Ошибка анализа записи
+Processing\ %0=Выполняется обработка %0
+Pull\ changes\ from\ shared\ database=Загрузить изменения из БД с общим доступом
 
-Pushed_citations_to_%0=Цитаты_переданы_в_%0
+Pushed\ citations\ to\ %0=Цитаты переданы в %0
 
-Quit_JabRef=Выход_из_JabRef
+Quit\ JabRef=Выход из JabRef
 
-Quit_synchronization=Завершить_синхронизацию
+Quit\ synchronization=Завершить синхронизацию
 
-Raw_source=Необработанный_источник
+Raw\ source=Необработанный источник
 
-Rearrange_tabs_alphabetically_by_title=Переупорядочить_вкладки_в_алфавитном_порядке_по_заголовку
+Rearrange\ tabs\ alphabetically\ by\ title=Переупорядочить вкладки в алфавитном порядке по заголовку
 
 Redo=Повторить
 
-Reference_library=БД_для_ссылки
+Reference\ library=БД для ссылки
 
-%0_references_found._Number_of_references_to_fetch?=Найдены_ссылки\:_%0._Число_ссылок_для_выборки?
+%0\ references\ found.\ Number\ of\ references\ to\ fetch?=Найдены ссылки: %0. Число ссылок для выборки?
 
-Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Детализировать_супергруппу\:_Просмотр_записей,_содержащихся_в_группе_и_ее_супергруппе_(если_выбрано)
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=Детализировать супергруппу: Просмотр записей, содержащихся в группе и ее супергруппе (если выбрано)
 
-regular_expression=Регулярное_выражение
+regular\ expression=Регулярное выражение
 
-Related_articles=
+Related\ articles=
 
-Remote_operation=Операции_удаленного_подключения
+Remote\ operation=Операции удаленного подключения
 
-Remote_server_port=Порт_сервера_удаленного_подключения
+Remote\ server\ port=Порт сервера удаленного подключения
 
 Remove=Удалить
 
-Remove_subgroups=Удалить_подгруппы
+Remove\ subgroups=Удалить подгруппы
 
-Remove_all_subgroups_of_"%0"?=Удалить_все_подгруппы_"%0"?
+Remove\ all\ subgroups\ of\ "%0"?=Удалить все подгруппы "%0"?
 
-Remove_entry_from_import=Удалить_запись_из_импортируемых
+Remove\ entry\ from\ import=Удалить запись из импортируемых
 
-Remove_selected_entries_from_this_group=
+Remove\ selected\ entries\ from\ this\ group=
 
-Remove_entry_type=Удалить_тип_записи
+Remove\ entry\ type=Удалить тип записи
 
-Remove_from_group=Удалить_из_группы
+Remove\ from\ group=Удалить из группы
 
-Remove_group=Удалить_группу
+Remove\ group=Удалить группу
 
-Remove_group,_keep_subgroups=Удалить_группу,_оставить_подгруппы
+Remove\ group,\ keep\ subgroups=Удалить группу, оставить подгруппы
 
-Remove_group_"%0"?=Удалить_группу_"%0"?
+Remove\ group\ "%0"?=Удалить группу "%0"?
 
-Remove_group_"%0"_and_its_subgroups?=Удалить_группу_"%0"_и_ее_подгруппы?
+Remove\ group\ "%0"\ and\ its\ subgroups?=Удалить группу "%0" и ее подгруппы?
 
-remove_group_(keep_subgroups)=удалить_группу_(оставить_подгруппы)
+remove\ group\ (keep\ subgroups)=удалить группу (оставить подгруппы)
 
-remove_group_and_subgroups=удалить_группу_и_подгруппы
+remove\ group\ and\ subgroups=удалить группу и подгруппы
 
-Remove_group_and_subgroups=Удалить_группу_и_подгруппы
+Remove\ group\ and\ subgroups=Удалить группу и подгруппы
 
-Remove_link=Удалить_ссылку
+Remove\ link=Удалить ссылку
 
-Remove_old_entry=Удалить_старую_запись
+Remove\ old\ entry=Удалить старую запись
 
-Remove_selected_strings=Удалить_выбранные_строки
+Remove\ selected\ strings=Удалить выбранные строки
 
-Removed_group_"%0".=Группа_"%0"_удалена.
+Removed\ group\ "%0".=Группа "%0" удалена.
 
-Removed_group_"%0"_and_its_subgroups.=Группа_"%0"_и_ее_подгруппы_удалены.
+Removed\ group\ "%0"\ and\ its\ subgroups.=Группа "%0" и ее подгруппы удалены.
 
-Removed_string=Строка_удалена
+Removed\ string=Строка удалена
 
-Renamed_string=Строка_переименована
+Renamed\ string=Строка переименована
 
 Replace=
 
-Replace_(regular_expression)=Заменить_(регулярное_выражение)
+Replace\ (regular\ expression)=Заменить (регулярное выражение)
 
-Replace_string=Заменить_строку
+Replace\ string=Заменить строку
 
-Replace_with=Заменить_на
+Replace\ with=Заменить на
 
 Replaced=Заменено
 
-Required_fields=Обязательные_поля
+Required\ fields=Обязательные поля
 
-Reset_all=Отменить_все_изменения
+Reset\ all=Отменить все изменения
 
-Resolve_strings_for_all_fields_except=Разрешение_для_строк_всех_полей,_кроме
-Resolve_strings_for_standard_BibTeX_fields_only=Разрешение_для_строк_только_стандартных_полей_BibTeX
+Resolve\ strings\ for\ all\ fields\ except=Разрешение для строк всех полей, кроме
+Resolve\ strings\ for\ standard\ BibTeX\ fields\ only=Разрешение для строк только стандартных полей BibTeX
 
 resolved=разрешено
 
 Review=Просмотр
 
-Review_changes=Просмотр_изменений
+Review\ changes=Просмотр изменений
 
 Right=Справа
 
 Save=Сохранить
-Save_all_finished.=Сохранить_все_завершенные.
+Save\ all\ finished.=Сохранить все завершенные.
 
-Save_all_open_libraries=Сохранить_все_открытые_БД
+Save\ all\ open\ libraries=Сохранить все открытые БД
 
-Save_before_closing=Сохранить_перед_закрытием
+Save\ before\ closing=Сохранить перед закрытием
 
-Save_library=Сохранить_БД
-Save_library_as...=Сохранить_БД_как...
+Save\ library=Сохранить БД
+Save\ library\ as...=Сохранить БД как...
 
-Save_entries_in_their_original_order=Сохранить_записи_в_исходном_порядке
+Save\ entries\ in\ their\ original\ order=Сохранить записи в исходном порядке
 
-Save_failed=Ошибка_сохранения
+Save\ failed=Ошибка сохранения
 
-Save_failed_during_backup_creation=Ошибка_сохранения_при_создании_резервной_копии
+Save\ failed\ during\ backup\ creation=Ошибка сохранения при создании резервной копии
 
-Save_selected_as...=Сохранить_выбранное_как...
+Save\ selected\ as...=Сохранить выбранное как...
 
-Saved_library=БД_сохранена
+Saved\ library=БД сохранена
 
-Saved_selected_to_'%0'.=Сохранить_выбранное_в_'%0'.
+Saved\ selected\ to\ '%0'.=Сохранить выбранное в '%0'.
 
-Saving=Выполняется_сохранение
-Saving_all_libraries...=Выполняется_сохранение_всех_БД...
+Saving=Выполняется сохранение
+Saving\ all\ libraries...=Выполняется сохранение всех БД...
 
-Saving_library=Выполняется_сохранение_БД
+Saving\ library=Выполняется сохранение БД
 
 Search=Поиск
 
-Search_expression=Выражение_для_поиска
+Search\ expression=Выражение для поиска
 
-Search_for=Поиск
+Search\ for=Поиск
 
-Searching_for_duplicates...=Выполняется_поиск_дубликатов...
+Searching\ for\ duplicates...=Выполняется поиск дубликатов...
 
-Searching_for_files=Выполняется_поиск_файлов...
+Searching\ for\ files=Выполняется поиск файлов...
 
-Secondary_sort_criterion=Вторичный_критерий_сортировки
+Secondary\ sort\ criterion=Вторичный критерий сортировки
 
-Select_all=Выбрать_все
+Select\ all=Выбрать все
 
-Select_encoding=Выбрать_кодировку
+Select\ encoding=Выбрать кодировку
 
-Select_entry_type=Выбрать_тип_записи
-Select_external_application=Выбрать_внешнее_приложение
+Select\ entry\ type=Выбрать тип записи
+Select\ external\ application=Выбрать внешнее приложение
 
-Select_file_from_ZIP-archive=Выбрать_файл_из_ZIP-архива
+Select\ file\ from\ ZIP-archive=Выбрать файл из ZIP-архива
 
-Select_the_tree_nodes_to_view_and_accept_or_reject_changes=Выбрать_узлы_дерева_для_просмотра_и_применения/отклонения_изменений
-Selected_entries=Записи_выбраны
-Set_field=Настройка_поля
-Set_fields=Настройка_полей
+Select\ the\ tree\ nodes\ to\ view\ and\ accept\ or\ reject\ changes=Выбрать узлы дерева для просмотра и применения/отклонения изменений
+Selected\ entries=Записи выбраны
+Set\ field=Настройка поля
+Set\ fields=Настройка полей
 
-Set_general_fields=Настройка_общих_полей
-Set_main_external_file_directory=Задать_основной_файловый_каталог_внешних_файлов
+Set\ general\ fields=Настройка общих полей
+Set\ main\ external\ file\ directory=Задать основной файловый каталог внешних файлов
 
-Set_table_font=Настройка_шрифта_таблицы
+Set\ table\ font=Настройка шрифта таблицы
 
 Settings=Параметры
 
 Shortcut=Ярлык
 
-Show/edit_%0_source=Показать/изменить_источник_%0
+Show/edit\ %0\ source=Показать/изменить источник %0
 
-Show_'Firstname_Lastname'=Порядок_вывода_'Имя_Фамилия'
+Show\ 'Firstname\ Lastname'=Порядок вывода 'Имя Фамилия'
 
-Show_'Lastname,_Firstname'=Порядок_вывода_'Фамилия,_Имя'
+Show\ 'Lastname,\ Firstname'=Порядок вывода 'Фамилия, Имя'
 
-Show_BibTeX_source_by_default=Показать_источник_BibTeX_по_умолчанию
+Show\ BibTeX\ source\ by\ default=Показать источник BibTeX по умолчанию
 
-Show_confirmation_dialog_when_deleting_entries=Запрос_подтверждения_при_удалении_записей
+Show\ confirmation\ dialog\ when\ deleting\ entries=Запрос подтверждения при удалении записей
 
-Show_description=Показать_описание
+Show\ description=Показать описание
 
-Show_file_column=Показать_столбец_Файл
+Show\ file\ column=Показать столбец Файл
 
-Show_last_names_only=Показать_только_фамилии
+Show\ last\ names\ only=Показать только фамилии
 
-Show_names_unchanged=Показать_имена_без_изменений
+Show\ names\ unchanged=Показать имена без изменений
 
-Show_optional_fields=Показать_дополнительные_поля
+Show\ optional\ fields=Показать дополнительные поля
 
-Show_required_fields=Показать_обязательные_поля
+Show\ required\ fields=Показать обязательные поля
 
-Show_URL/DOI_column=Показать_столбец_URL/DOI
+Show\ URL/DOI\ column=Показать столбец URL/DOI
 
-Simple_HTML=HTML_(простой)
+Simple\ HTML=HTML (простой)
 
 Size=Размер
 
-Skipped_-_No_PDF_linked=Пропущено_-_Без_ссылок_на_PDF
-Skipped_-_PDF_does_not_exist=Пропущено_-_PDF_не_существует
+Skipped\ -\ No\ PDF\ linked=Пропущено - Без ссылок на PDF
+Skipped\ -\ PDF\ does\ not\ exist=Пропущено - PDF не существует
 
-Skipped_entry.=Запись_пропущена.
+Skipped\ entry.=Запись пропущена.
 
-Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.=
+Some\ appearance\ settings\ you\ changed\ require\ to\ restart\ JabRef\ to\ come\ into\ effect.=
 
-source_edit=изменение_источника
-Special_name_formatters=Особые_программы_форматирования_имени
+source\ edit=изменение источника
+Special\ name\ formatters=Особые программы форматирования имени
 
-Special_table_columns=Особые_столбцы_таблицы
+Special\ table\ columns=Особые столбцы таблицы
 
-Starting_import=Запустить_импорт
+Starting\ import=Запустить импорт
 
-Statically_group_entries_by_manual_assignment=Фиксированная_группировка_записей_назначением_вручную
+Statically\ group\ entries\ by\ manual\ assignment=Фиксированная группировка записей назначением вручную
 
 Status=Статус
 
@@ -1143,1215 +1143,1215 @@ Stop=Остановить
 
 Strings=Строки
 
-Strings_for_library=Строки_БД
+Strings\ for\ library=Строки БД
 
-Sublibrary_from_AUX=Подчиненная_БД_из_AUX
+Sublibrary\ from\ AUX=Подчиненная БД из AUX
 
-Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.=Переключение_полного/сокращенного_имени_журнала_для_известных_имен_журналов.
+Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=Переключение полного/сокращенного имени журнала для известных имен журналов.
 
-Synchronize_file_links=Синхронизировать_ссылки_на_файлы
+Synchronize\ file\ links=Синхронизировать ссылки на файлы
 
-Synchronizing_file_links...=Выполняется_синхронизация_ссылок_файл...
+Synchronizing\ file\ links...=Выполняется синхронизация ссылок файл...
 
-Table_appearance=Представление_таблицы
+Table\ appearance=Представление таблицы
 
-Table_background_color=Цвет_фона_таблицы
+Table\ background\ color=Цвет фона таблицы
 
-Table_grid_color=Цвет_сетки_таблицы
+Table\ grid\ color=Цвет сетки таблицы
 
-Table_text_color=Цвет_текста_таблицы
+Table\ text\ color=Цвет текста таблицы
 
-Tabname=Имя_вкладки
-Target_file_cannot_be_a_directory.=Невозможно_указать_каталог_файлов_в_качестве_целевого_файла.
+Tabname=Имя вкладки
+Target\ file\ cannot\ be\ a\ directory.=Невозможно указать каталог файлов в качестве целевого файла.
 
-Tertiary_sort_criterion=Третичный_критерий_сортировки
+Tertiary\ sort\ criterion=Третичный критерий сортировки
 
 Test=Тест
 
-paste_text_here=место_вставки_текста
+paste\ text\ here=место вставки текста
 
-The_chosen_date_format_for_new_entries_is_not_valid=Выбранный_формат_даты_для_новых_записей_недопустим
+The\ chosen\ date\ format\ for\ new\ entries\ is\ not\ valid=Выбранный формат даты для новых записей недопустим
 
-The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:=В_выбранной_кодировке_'%0'_невозможно_прочитать_следующие_символы\:
+The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=В выбранной кодировке '%0' невозможно прочитать следующие символы:
 
 
-the_field_<b>%0</b>=поле_<b>%0</b>
+the\ field\ <b>%0</b>=поле <b>%0</b>
 
-The_file<BR>'%0'<BR>has_been_modified<BR>externally\!=Файл_<BR>'%0'<BR>изменен<BR>внешними_средствами\!
+The\ file<BR>'%0'<BR>has\ been\ modified<BR>externally\!=Файл <BR>'%0'<BR>изменен<BR>внешними средствами!
 
-The_group_"%0"_already_contains_the_selection.=Группа_"%0"_уже_содержит_выбранное.
+The\ group\ "%0"\ already\ contains\ the\ selection.=Группа "%0" уже содержит выбранное.
 
-The_label_of_the_string_cannot_be_a_number.=Метка_строки_не_может_быть_числом.
+The\ label\ of\ the\ string\ cannot\ be\ a\ number.=Метка строки не может быть числом.
 
-The_label_of_the_string_cannot_contain_spaces.=Метка_строки_не_может_содержать_пробелов.
+The\ label\ of\ the\ string\ cannot\ contain\ spaces.=Метка строки не может содержать пробелов.
 
-The_label_of_the_string_cannot_contain_the_'\#'_character.=Метка_строки_не_может_содержать_символ_'\#'.
+The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=Метка строки не может содержать символ '#'.
 
-The_output_option_depends_on_a_valid_import_option.=Параметры_вывода_зависят_от_допустимых_параметров_импорта.
-The_PDF_contains_one_or_several_BibTeX-records.=PDF_содержит_одну_или_несколько_записей_BibTeX.
-Do_you_want_to_import_these_as_new_entries_into_the_current_library?=Выполнить_их_импорт_в_текущую_БД_в_виде_новых_записей?
+The\ output\ option\ depends\ on\ a\ valid\ import\ option.=Параметры вывода зависят от допустимых параметров импорта.
+The\ PDF\ contains\ one\ or\ several\ BibTeX-records.=PDF содержит одну или несколько записей BibTeX.
+Do\ you\ want\ to\ import\ these\ as\ new\ entries\ into\ the\ current\ library?=Выполнить их импорт в текущую БД в виде новых записей?
 
-The_regular_expression_<b>%0</b>_is_invalid\:=Регулярное_выражение_<b>%0</b>_недопустимо\:
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=Регулярное выражение <b>%0</b> недопустимо:
 
-The_search_is_case_insensitive.=Поиск_без_учета_регистра.
+The\ search\ is\ case\ insensitive.=Поиск без учета регистра.
 
-The_search_is_case_sensitive.=Поиск_с_учетом_регистра.
+The\ search\ is\ case\ sensitive.=Поиск с учетом регистра.
 
-The_string_has_been_removed_locally=Строка_удалена_локально
+The\ string\ has\ been\ removed\ locally=Строка удалена локально
 
-There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?=Возможно_наличие_неразрешенных_дубликатов_(отмечены_знаком)._Продолжить?
+There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=Возможно наличие неразрешенных дубликатов (отмечены знаком). Продолжить?
 
-This_entry_has_no_BibTeX_key._Generate_key_now?=Отсутствует_ключ_BibTeX_для_записи._Создать_ключ_сейчас?
+This\ entry\ has\ no\ BibTeX\ key.\ Generate\ key\ now?=Отсутствует ключ BibTeX для записи. Создать ключ сейчас?
 
-This_entry_is_incomplete=Это_неполная_запись
+This\ entry\ is\ incomplete=Это неполная запись
 
-This_entry_type_cannot_be_removed.=Невозможно_удалить_этот_тип_записи.
+This\ entry\ type\ cannot\ be\ removed.=Невозможно удалить этот тип записи.
 
-This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Внешняя_ссылка_не_определенного_типа_'%0'._Выберите_дальнейшие_действия.
+This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Внешняя ссылка не определенного типа '%0'. Выберите дальнейшие действия.
 
-This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.=Группа_содержит_записи,_на_основе_назначений_вручную._Чтобы_назначить_запись_этой_группе,_выберите_запись_и_перетащите_ее_в_группу_или_выберите_команду_контекстного_меню._Чтобы_удалить_запись_из_этой_группы,_выделите_запись_и_выберите_команду_контекстного_меню.
+This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=Группа содержит записи, на основе назначений вручную. Чтобы назначить запись этой группе, выберите запись и перетащите ее в группу или выберите команду контекстного меню. Чтобы удалить запись из этой группы, выделите запись и выберите команду контекстного меню.
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>=Группа_содержит_записи,_в_которых_поле_<b>%0</b>_содержит_ключевое_слово_<b>%1</b>_
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Группа содержит записи, в которых поле <b>%0</b> содержит ключевое слово <b>%1</b> 
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>=Группа_содержит_записи,_в_которых_поле_<b>%0</b>_содержит_регулярное_выражение_<b>%1</b>_
-This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.=При_этом_JabRef_произведет_поиск_всех_ссылок_файл_с_проверкой_наличия_файла._В_противном_случае_будет_выведен_запрос<BR>на_разрешение_проблемы.
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Группа содержит записи, в которых поле <b>%0</b> содержит регулярное выражение <b>%1</b> 
+This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=При этом JabRef произведет поиск всех ссылок файл с проверкой наличия файла. В противном случае будет выведен запрос<BR>на разрешение проблемы.
 
-This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.=Для_этой_операции_необходимо_определение_ключей_BibTeX_всех_выбранных_записей.
+This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=Для этой операции необходимо определение ключей BibTeX всех выбранных записей.
 
-This_operation_requires_one_or_more_entries_to_be_selected.=Для_этой_операции_необходимо_выбрать_одну_или_несколько_записей.
+This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=Для этой операции необходимо выбрать одну или несколько записей.
 
-Toggle_entry_preview=Показать/скрыть_просмотр_записи
-Toggle_groups_interface=Показать/скрыть_интерфейс_групп
-Try_different_encoding=Используйте_другую_кодировку
+Toggle\ entry\ preview=Показать/скрыть просмотр записи
+Toggle\ groups\ interface=Показать/скрыть интерфейс групп
+Try\ different\ encoding=Используйте другую кодировку
 
-Unabbreviate_journal_names_of_the_selected_entries=Развернуть_названия_журналов_для_выбранных_записей
-Unabbreviated_%0_journal_names.=Развернуты_названия_журналов_для_%0.
+Unabbreviate\ journal\ names\ of\ the\ selected\ entries=Развернуть названия журналов для выбранных записей
+Unabbreviated\ %0\ journal\ names.=Развернуты названия журналов для %0.
 
-Unable_to_open_file.=Не_удалось_открыть_файл.
-Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.=Не_удалось_перейти_по_ссылке._Ошибка_вызова_приложения_'%0'_связанного_с_типом_'%1'.
-unable_to_write_to=ошибка_записи_в
-Undefined_file_type=Тип_файла_не_определен
+Unable\ to\ open\ file.=Не удалось открыть файл.
+Unable\ to\ open\ link.\ The\ application\ '%0'\ associated\ with\ the\ file\ type\ '%1'\ could\ not\ be\ called.=Не удалось перейти по ссылке. Ошибка вызова приложения '%0' связанного с типом '%1'.
+unable\ to\ write\ to=ошибка записи в
+Undefined\ file\ type=Тип файла не определен
 
 Undo=Отмена
 
 Union=Объединение
 
-Unknown_BibTeX_entries=Неизвестные_записи_BibTeX
+Unknown\ BibTeX\ entries=Неизвестные записи BibTeX
 
-unknown_edit=неизвестное_изменение
+unknown\ edit=неизвестное изменение
 
-Unknown_export_format=Неизвестный_формат_экспорта
+Unknown\ export\ format=Неизвестный формат экспорта
 
-Unmark_all=Снять_все_метки
+Unmark\ all=Снять все метки
 
-Unmark_entries=Снять_метки_записей
+Unmark\ entries=Снять метки записей
 
-Unmark_entry=Снять_метку_записи
+Unmark\ entry=Снять метку записи
 
-untitled=без_заглавия
+untitled=без заглавия
 
 Up=Вверх
 
-Update_to_current_column_widths=Сохранить_текущую_ширину_столбца
+Update\ to\ current\ column\ widths=Сохранить текущую ширину столбца
 
-Updated_group_selection=Выбор_группы_изменен
-Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.=Обновить_ссылки_на_внешние_PDF/PS_для_использования_в_поле_'%0'.
-Upgrade_file=Обновить_файл
-Upgrade_old_external_file_links_to_use_the_new_feature=Обновить_старые_ссылки_на_внешние_файлы_для_использования_новых_функций
+Updated\ group\ selection=Выбор группы изменен
+Upgrade\ external\ PDF/PS\ links\ to\ use\ the\ '%0'\ field.=Обновить ссылки на внешние PDF/PS для использования в поле '%0'.
+Upgrade\ file=Обновить файл
+Upgrade\ old\ external\ file\ links\ to\ use\ the\ new\ feature=Обновить старые ссылки на внешние файлы для использования новых функций
 
 usage=использование
-Use_autocompletion_for_the_following_fields=Автозавершение_для_следующих_полей
+Use\ autocompletion\ for\ the\ following\ fields=Автозавершение для следующих полей
 
-Use_other_look_and_feel=Использовать_другой_интерфейс
-Tweak_font_rendering_for_entry_editor_on_Linux=
-Use_regular_expression_search=Поиск_с_использованием_регулярных_выражений
+Use\ other\ look\ and\ feel=Использовать другой интерфейс
+Tweak\ font\ rendering\ for\ entry\ editor\ on\ Linux=
+Use\ regular\ expression\ search=Поиск с использованием регулярных выражений
 
-Username=Имя_пользователя
+Username=Имя пользователя
 
-Value_cleared_externally=Значение_создано_внешними_средствами
+Value\ cleared\ externally=Значение создано внешними средствами
 
-Value_set_externally=Значение_задано_внешними_средствами
+Value\ set\ externally=Значение задано внешними средствами
 
-verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid=убедитесь,_что_приложение_LyX_запущено,_и_указано_допустимое_значение_канала_LyX
+verify\ that\ LyX\ is\ running\ and\ that\ the\ lyxpipe\ is\ valid=убедитесь, что приложение LyX запущено, и указано допустимое значение канала LyX
 
 View=Вид
-Vim_server_name=Имя_сервера_Vim
+Vim\ server\ name=Имя сервера Vim
 
-Waiting_for_ArXiv...=Ожидание_ArXiv...
+Waiting\ for\ ArXiv...=Ожидание ArXiv...
 
-Warn_about_unresolved_duplicates_when_closing_inspection_window=Выдать_предупреждение_о_неразрешенных_дубликатах_при_закрытии_окна_контроля
+Warn\ about\ unresolved\ duplicates\ when\ closing\ inspection\ window=Выдать предупреждение о неразрешенных дубликатах при закрытии окна контроля
 
-Warn_before_overwriting_existing_keys=Выдать_предупреждение_при_перезаписи_текущих_ключей
+Warn\ before\ overwriting\ existing\ keys=Выдать предупреждение при перезаписи текущих ключей
 
 Warning=Предупреждение
 
 Warnings=Предупреждения
 
-web_link=веб-ссылки
+web\ link=веб-ссылки
 
-What_do_you_want_to_do?=Выберите_действие_для_продолжения.
+What\ do\ you\ want\ to\ do?=Выберите действие для продолжения.
 
-When_adding/removing_keywords,_separate_them_by=При_добавлении/удалении_ключевых_слов_разделять_их_с_помощью
-Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.=Будет_выполнена_запись_метаданных_XMP_в_PDF_со_ссылками_из_выбранных_записей.
+When\ adding/removing\ keywords,\ separate\ them\ by=При добавлении/удалении ключевых слов разделять их с помощью
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Будет выполнена запись метаданных XMP в PDF со ссылками из выбранных записей.
 
 with=с
 
-Write_BibTeXEntry_as_XMP-metadata_to_PDF.=Запись_значения_записи_BibTeX_как_метаданных_XMP_в_PDF.
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Запись значения записи BibTeX как метаданных XMP в PDF.
 
-Write_XMP=Запись_XMP
-Write_XMP-metadata=Запись_метаданных_XMP
-Write_XMP-metadata_for_all_PDFs_in_current_library?=Выполнить_запись_метаданных_XMP_для_всех_PDF_текущей_БД?
-Writing_XMP-metadata...=Выполняется_запись_метаданных_XMP...
-Writing_XMP-metadata_for_selected_entries...=Выполняется_запись_метаданных_XMPдля_выбранных_записей...
+Write\ XMP=Запись XMP
+Write\ XMP-metadata=Запись метаданных XMP
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Выполнить запись метаданных XMP для всех PDF текущей БД?
+Writing\ XMP-metadata...=Выполняется запись метаданных XMP...
+Writing\ XMP-metadata\ for\ selected\ entries...=Выполняется запись метаданных XMPдля выбранных записей...
 
-Wrote_XMP-metadata=Метаданные_XMP_записаны
+Wrote\ XMP-metadata=Метаданные XMP записаны
 
-XMP-annotated_PDF=PDF_с_аннотациями_XMP
-XMP_export_privacy_settings=Настройки_защиты_экспорта_XMP
-XMP-metadata=Метаданные_XMP
-XMP-metadata_found_in_PDF\:_%0=Найдены_метаданные_XMP_в_PDF\:_%0
-You_must_restart_JabRef_for_this_to_come_into_effect.=Для_применения_изменений_необходимо_перезапустить_JabRef.
-You_have_changed_the_language_setting.=Настройки_языка_изменены_пользователем.
-You_have_entered_an_invalid_search_'%0'.=Указано_недопустимое_значение_для_поиска_'%0'.
+XMP-annotated\ PDF=PDF с аннотациями XMP
+XMP\ export\ privacy\ settings=Настройки защиты экспорта XMP
+XMP-metadata=Метаданные XMP
+XMP-metadata\ found\ in\ PDF\:\ %0=Найдены метаданные XMP в PDF: %0
+You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Для применения изменений необходимо перезапустить JabRef.
+You\ have\ changed\ the\ language\ setting.=Настройки языка изменены пользователем.
+You\ have\ entered\ an\ invalid\ search\ '%0'.=Указано недопустимое значение для поиска '%0'.
 
-You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.=Для_правильной_работы_новых_назначений_функциональных_клавиш_необходимо_перезапустить_JabRef.
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Для правильной работы новых назначений функциональных клавиш необходимо перезапустить JabRef.
 
-Your_new_key_bindings_have_been_stored.=Новые_назначения_функциональных_клавиш_сохранены.
+Your\ new\ key\ bindings\ have\ been\ stored.=Новые назначения функциональных клавиш сохранены.
 
-The_following_fetchers_are_available\:=Доступны_следующие_инструменты_выборки\:
-Could_not_find_fetcher_'%0'=Не_удалось_найти_инструмент_выборки_'%0'
-Running_query_'%0'_with_fetcher_'%1'.=Выполняется_запрос_'%0'_для_инструмента_выборки_'%1'.
-Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.=Не_найдено_результатов_запроса_'%0'_для_инструмента_выборки_'%1'.
+The\ following\ fetchers\ are\ available\:=Доступны следующие инструменты выборки:
+Could\ not\ find\ fetcher\ '%0'=Не удалось найти инструмент выборки '%0'
+Running\ query\ '%0'\ with\ fetcher\ '%1'.=Выполняется запрос '%0' для инструмента выборки '%1'.
+Query\ '%0'\ with\ fetcher\ '%1'\ did\ not\ return\ any\ results.=Не найдено результатов запроса '%0' для инструмента выборки '%1'.
 
-Move_file=Переместить_файл
-Rename_file=Ппереименовать_файл
+Move\ file=Переместить файл
+Rename\ file=Ппереименовать файл
 
-Move_file_failed=Ошибка_перемещения_файла
-Could_not_move_file_'%0'.=Не_удалось_переместить_файл_'%0'.
-Could_not_find_file_'%0'.=Не_удалось_найти_файл_'%0'.
-Number_of_entries_successfully_imported=Число_успешно_импортированных_записей
-Import_canceled_by_user=Импорт_отменен_пользователем
-Progress\:_%0_of_%1=Выполнено\:_%0_из_%1
-Error_while_fetching_from_%0=Ошибка_выполнения_выборки_%0
+Move\ file\ failed=Ошибка перемещения файла
+Could\ not\ move\ file\ '%0'.=Не удалось переместить файл '%0'.
+Could\ not\ find\ file\ '%0'.=Не удалось найти файл '%0'.
+Number\ of\ entries\ successfully\ imported=Число успешно импортированных записей
+Import\ canceled\ by\ user=Импорт отменен пользователем
+Progress\:\ %0\ of\ %1=Выполнено: %0 из %1
+Error\ while\ fetching\ from\ %0=Ошибка выполнения выборки %0
 
-Please_enter_a_valid_number=Введите_допустимое_число
-Show_search_results_in_a_window=Показать_результаты_в_окне
-Show_global_search_results_in_a_window=
-Search_in_all_open_libraries=Поиск_во_всех_открытых_БД
-Move_file_to_file_directory?=Файл_будет_перемещен_в_каталог_файлов._Продолжить?
+Please\ enter\ a\ valid\ number=Введите допустимое число
+Show\ search\ results\ in\ a\ window=Показать результаты в окне
+Show\ global\ search\ results\ in\ a\ window=
+Search\ in\ all\ open\ libraries=Поиск во всех открытых БД
+Move\ file\ to\ file\ directory?=Файл будет перемещен в каталог файлов. Продолжить?
 
-Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.=Защищенная_БД._Невозможно_сохранить_без_просмотра_внешних_изменений.
-Protected_library=Защищенная_БД
-Refuse_to_save_the_library_before_external_changes_have_been_reviewed.=Невозможно_сохранить_БД_без_просмотра_внешних_изменений.
-Library_protection=Защита_БД
-Unable_to_save_library=Не_удалось_сохранить_БД
+Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=Защищенная БД. Невозможно сохранить без просмотра внешних изменений.
+Protected\ library=Защищенная БД
+Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=Невозможно сохранить БД без просмотра внешних изменений.
+Library\ protection=Защита БД
+Unable\ to\ save\ library=Не удалось сохранить БД
 
-BibTeX_key_generator=Генератор_ключей_BibTeX
-Unable_to_open_link.=Не_удалось_перейти_по_ссылке.
-Move_the_keyboard_focus_to_the_entry_table=Переместить_курсор_в_таблицу_записей
-MIME_type=MIME-тип
+BibTeX\ key\ generator=Генератор ключей BibTeX
+Unable\ to\ open\ link.=Не удалось перейти по ссылке.
+Move\ the\ keyboard\ focus\ to\ the\ entry\ table=Переместить курсор в таблицу записей
+MIME\ type=MIME-тип
 
-This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.=Эта_функция_позволяет_открывать_или_импортировать_файлы_в_работающий_экземпляр_JabRef<BR>без_запуска_нового_экземпляра_приложения._Например,_при_передаче_файла_в_JabRef<br>из_веб-браузера.<BR>Обратите_внимание,_что_эта_функция_позволяет_не_запускать_несколько_экземпляров_JabRef_одновременно.
-Run_fetcher,_e.g._"--fetch\=Medline\:cancer"=Запуск_инструмента_выборки,_напр.\:_"--fetch\=Medline\:cancer"
+This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef<BR>instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef<br>from\ your\ web\ browser.<BR>Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=Эта функция позволяет открывать или импортировать файлы в работающий экземпляр JabRef<BR>без запуска нового экземпляра приложения. Например, при передаче файла в JabRef<br>из веб-браузера.<BR>Обратите внимание, что эта функция позволяет не запускать несколько экземпляров JabRef одновременно.
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=Запуск инструмента выборки, напр.: "--fetch=Medline:cancer"
 
-The_ACM_Digital_Library=Цифровая_библиотека_ACM
+The\ ACM\ Digital\ Library=Цифровая библиотека ACM
 Reset=Инициализировать
 
-Use_IEEE_LaTeX_abbreviations=Использовать_сокращения_LaTeX_для_IEEE
-The_Guide_to_Computing_Literature=ACM_-_Каталог_публикаций_по_информатике_и_ВТ
+Use\ IEEE\ LaTeX\ abbreviations=Использовать сокращения LaTeX для IEEE
+The\ Guide\ to\ Computing\ Literature=ACM - Каталог публикаций по информатике и ВТ
 
-When_opening_file_link,_search_for_matching_file_if_no_link_is_defined=При_переходе_по_ссылке_выполнять_поиск_соответствующего_файла,_если_ссылка_не_определена
-Settings_for_%0=Настройки_для_%0
-Mark_entries_imported_into_an_existing_library=Пометить_записи,_импортированные_в_текущую_БД
-Unmark_all_entries_before_importing_new_entries_into_an_existing_library=Снять_метки_всех_записей_перед_выполнением_импорта_новых_записей_в_существующую_БД
+When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=При переходе по ссылке выполнять поиск соответствующего файла, если ссылка не определена
+Settings\ for\ %0=Настройки для %0
+Mark\ entries\ imported\ into\ an\ existing\ library=Пометить записи, импортированные в текущую БД
+Unmark\ all\ entries\ before\ importing\ new\ entries\ into\ an\ existing\ library=Снять метки всех записей перед выполнением импорта новых записей в существующую БД
 
 Forward=Вперед
 Back=Назад
-Sort_the_following_fields_as_numeric_fields=Сортировать_следующие_поля_как_числовые
-Line_%0\:_Found_corrupted_BibTeX_key.=Строка_%0\:_Найден_поврежденный_ключ_BibTeX.
-Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).=Строка_%0\:_Найден_поврежденный_ключ_BibTeX_(содержит_пробелы)
-Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).=Строка_%0\:_Найден_поврежденный_ключ_BibTeX_(пропущена_запятая)
-Full_text_document_download_failed=Ошибка_загрузки_цитируемой_статьи
-Update_to_current_column_order=Сохранить_текущий_порядок_столбцов
-Download_from_URL=Загрузить_из_URL-адреса
-Rename_field=Переименовать_поле
-Set/clear/append/rename_fields=Задать/очистить/переименовать_поля
-Append_field=
-Append_to_fields=
-Rename_field_to=Переименовать_поле_в
-Move_contents_of_a_field_into_a_field_with_a_different_name=Переместить_содержимое_поля_в_поле_с_другим_именем
-You_can_only_rename_one_field_at_a_time=Возможно_переименовать_только_одно_поле_одновременно
+Sort\ the\ following\ fields\ as\ numeric\ fields=Сортировать следующие поля как числовые
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=Строка %0: Найден поврежденный ключ BibTeX.
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=Строка %0: Найден поврежденный ключ BibTeX (содержит пробелы)
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=Строка %0: Найден поврежденный ключ BibTeX (пропущена запятая)
+Full\ text\ document\ download\ failed=Ошибка загрузки цитируемой статьи
+Update\ to\ current\ column\ order=Сохранить текущий порядок столбцов
+Download\ from\ URL=Загрузить из URL-адреса
+Rename\ field=Переименовать поле
+Set/clear/append/rename\ fields=Задать/очистить/переименовать поля
+Append\ field=
+Append\ to\ fields=
+Rename\ field\ to=Переименовать поле в
+Move\ contents\ of\ a\ field\ into\ a\ field\ with\ a\ different\ name=Переместить содержимое поля в поле с другим именем
+You\ can\ only\ rename\ one\ field\ at\ a\ time=Возможно переименовать только одно поле одновременно
 
-Remove_all_broken_links=Удалить_все_ссылки_с_ошибками
+Remove\ all\ broken\ links=Удалить все ссылки с ошибками
 
-Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.=Невозможно_использовать_порт_%0_для_удаленного_подключения;_another_application_may_be_using_it._Try_specifying_another_port.
+Cannot\ use\ port\ %0\ for\ remote\ operation;\ another\ application\ may\ be\ using\ it.\ Try\ specifying\ another\ port.=Невозможно использовать порт %0 для удаленного подключения; another application may be using it. Try specifying another port.
 
-Looking_for_full_text_document...=Поиск_цитируемого_документа...
+Looking\ for\ full\ text\ document...=Поиск цитируемого документа...
 Autosave=Автосохранение
-A_local_copy_will_be_opened.=
-Autosave_local_libraries=
-Automatically_save_the_library_to=
-Please_enter_a_valid_file_path.=
+A\ local\ copy\ will\ be\ opened.=
+Autosave\ local\ libraries=
+Automatically\ save\ the\ library\ to=
+Please\ enter\ a\ valid\ file\ path.=
 
 
-Export_in_current_table_sort_order=Экспорт_в_текущем_порядке_сортировки_таблицы
-Export_entries_in_their_original_order=Экспорт_записей_в_исходном_порядке
-Error_opening_file_'%0'.=Ошибка_при_открытии_файла_'%0'.
+Export\ in\ current\ table\ sort\ order=Экспорт в текущем порядке сортировки таблицы
+Export\ entries\ in\ their\ original\ order=Экспорт записей в исходном порядке
+Error\ opening\ file\ '%0'.=Ошибка при открытии файла '%0'.
 
-Formatter_not_found\:_%0=Не_найдена_программа_форматирования\:_%0
-Clear_inputarea=Очистить_область_ввода
+Formatter\ not\ found\:\ %0=Не найдена программа форматирования: %0
+Clear\ inputarea=Очистить область ввода
 
-Automatically_set_file_links_for_this_entry=Автоуказание_ссылок_на_файлы_для_этой_записи
-Could_not_save,_file_locked_by_another_JabRef_instance.=Сохранение_не_удалось,_файл_заблокирован_другим_экземпляром_JabRef.
-File_is_locked_by_another_JabRef_instance.=Файл_заблокирован_другим_экземпляром_JabRef.
-Do_you_want_to_override_the_file_lock?=Блокировка_файла_будет_переопределена._Продолжить?
-File_locked=Файл_заблокирован
-Current_tmp_value=Текущее_значение_TMP
-Metadata_change=Изменение_метаданных
-Changes_have_been_made_to_the_following_metadata_elements=Произведены_изменения_для_следующих_элементов_метаданных
+Automatically\ set\ file\ links\ for\ this\ entry=Автоуказание ссылок на файлы для этой записи
+Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=Сохранение не удалось, файл заблокирован другим экземпляром JabRef.
+File\ is\ locked\ by\ another\ JabRef\ instance.=Файл заблокирован другим экземпляром JabRef.
+Do\ you\ want\ to\ override\ the\ file\ lock?=Блокировка файла будет переопределена. Продолжить?
+File\ locked=Файл заблокирован
+Current\ tmp\ value=Текущее значение TMP
+Metadata\ change=Изменение метаданных
+Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=Произведены изменения для следующих элементов метаданных
 
-Generate_groups_for_author_last_names=Создание_групп_для_фамилий_авторов
-Generate_groups_from_keywords_in_a_BibTeX_field=Создание_групп_из_ключевых_слов_в_поле_BibTeX
-Enforce_legal_characters_in_BibTeX_keys=Принудительное_использование_допустимого_набора_символов_в_ключах_BibTeX
+Generate\ groups\ for\ author\ last\ names=Создание групп для фамилий авторов
+Generate\ groups\ from\ keywords\ in\ a\ BibTeX\ field=Создание групп из ключевых слов в поле BibTeX
+Enforce\ legal\ characters\ in\ BibTeX\ keys=Принудительное использование допустимого набора символов в ключах BibTeX
 
-Save_without_backup?=Выполнить_сохранение_без_создания_резервной_копии?
-Unable_to_create_backup=Не_удалось_создать_резервную_копию
-Move_file_to_file_directory=Переместить_файл_в_каталог_файлов
-Rename_file_to=Переименовать_файл_в
-<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)=<b>Все_записи</b>_(невозможно_изменить_или_удалить_эту_группу)
-static_group=фиксированная_группа
-dynamic_group=динамическая_группа
-refines_supergroup=детализация_супергруппы
-includes_subgroups=включает_подгруппы
+Save\ without\ backup?=Выполнить сохранение без создания резервной копии?
+Unable\ to\ create\ backup=Не удалось создать резервную копию
+Move\ file\ to\ file\ directory=Переместить файл в каталог файлов
+Rename\ file\ to=Переименовать файл в
+<b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=<b>Все записи</b> (невозможно изменить или удалить эту группу)
+static\ group=фиксированная группа
+dynamic\ group=динамическая группа
+refines\ supergroup=детализация супергруппы
+includes\ subgroups=включает подгруппы
 contains=содержит
-search_expression=выражение_для_поиска
+search\ expression=выражение для поиска
 
-Optional_fields_2=Дополнительные_поля_2
-Waiting_for_save_operation_to_finish=Ожидается_завершение_операции_сохранения
-Resolving_duplicate_BibTeX_keys...=Выполняется_разрешение_дубликатов_ключей_BibTeX...
-Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.=Разрешение_дубликатов_ключей_BibTeX_выполнено._Записей_изменено\:_%0
-This_library_contains_one_or_more_duplicated_BibTeX_keys.=В_этой_БД_содержится_один_или_несколько_дубликатов_ключей_BibTeX.
-Do_you_want_to_resolve_duplicate_keys_now?=Выполнить_разрешение_дубликатов_ключей_сейчас?
+Optional\ fields\ 2=Дополнительные поля 2
+Waiting\ for\ save\ operation\ to\ finish=Ожидается завершение операции сохранения
+Resolving\ duplicate\ BibTeX\ keys...=Выполняется разрешение дубликатов ключей BibTeX...
+Finished\ resolving\ duplicate\ BibTeX\ keys.\ %0\ entries\ modified.=Разрешение дубликатов ключей BibTeX выполнено. Записей изменено: %0
+This\ library\ contains\ one\ or\ more\ duplicated\ BibTeX\ keys.=В этой БД содержится один или несколько дубликатов ключей BibTeX.
+Do\ you\ want\ to\ resolve\ duplicate\ keys\ now?=Выполнить разрешение дубликатов ключей сейчас?
 
-Find_and_remove_duplicate_BibTeX_keys=Найти_и_удалить_дубликаты_ключей_BibTeX
-Expected_syntax_for_--fetch\='<name_of_fetcher>\:<query>'=Стандартный_синтаксис_--fetch\='<имя_инструмента>\:<запрос>'
-Duplicate_BibTeX_key=Дубликат_ключа_BibTeX
-Import_marking_color=Импорт_цвета_метки
-Always_add_letter_(a,_b,_...)_to_generated_keys=Всегда_добавлять_букву_(a,_b,_...)_к_созданным_ключам
+Find\ and\ remove\ duplicate\ BibTeX\ keys=Найти и удалить дубликаты ключей BibTeX
+Expected\ syntax\ for\ --fetch\='<name\ of\ fetcher>\:<query>'=Стандартный синтаксис --fetch='<имя инструмента>:<запрос>'
+Duplicate\ BibTeX\ key=Дубликат ключа BibTeX
+Import\ marking\ color=Импорт цвета метки
+Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=Всегда добавлять букву (a, b, ...) к созданным ключам
 
-Ensure_unique_keys_using_letters_(a,_b,_...)=Проверка_уникальности_ключа_по_литере_(a,_b,_...)
-Ensure_unique_keys_using_letters_(b,_c,_...)=Проверка_уникальности_ключа_по_литере_(b_c,_...)
-Entry_editor_active_background_color=Редактор_записей\:_цвет_фона_активной_записи
-Entry_editor_background_color=Редактор_записей\:_цвет_фона
-Entry_editor_font_color=Редактор_записей\:_цвет_шрифта
-Entry_editor_invalid_field_color=Редактор_записей\:_цвет_недопустимого_поля
+Ensure\ unique\ keys\ using\ letters\ (a,\ b,\ ...)=Проверка уникальности ключа по литере (a, b, ...)
+Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=Проверка уникальности ключа по литере (b c, ...)
+Entry\ editor\ active\ background\ color=Редактор записей: цвет фона активной записи
+Entry\ editor\ background\ color=Редактор записей: цвет фона
+Entry\ editor\ font\ color=Редактор записей: цвет шрифта
+Entry\ editor\ invalid\ field\ color=Редактор записей: цвет недопустимого поля
 
-Table_and_entry_editor_colors=Цвета_таблицы_и_редактора_записей
+Table\ and\ entry\ editor\ colors=Цвета таблицы и редактора записей
 
-General_file_directory=Общий_каталог_файлов
-User-specific_file_directory=Пользовательский_каталог_файлов
-Search_failed\:_illegal_search_expression=Ошибка_поиска\:_недопустимое_выражение_для_поиска
-Show_ArXiv_column=Показать_столбец_ArXiv
+General\ file\ directory=Общий каталог файлов
+User-specific\ file\ directory=Пользовательский каталог файлов
+Search\ failed\:\ illegal\ search\ expression=Ошибка поиска: недопустимое выражение для поиска
+Show\ ArXiv\ column=Показать столбец ArXiv
 
-You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for=Необходимо_ввести_целое_число_из_интервала_1025-65535_в_текстовое_поле_для
-Automatically_open_browse_dialog_when_creating_new_file_link=Автоматически_открывать_диалоговое_окно_обзора_при_создании_новой_ссылки_на_файл
-Import_metadata_from\:=Импорт_метаданных_из\:
-Choose_the_source_for_the_metadata_import=Выбрать_источник_для_импорта_метаданных
-Create_entry_based_on_XMP-metadata=Создание_записи_на_основе_данных_XMP
-Create_blank_entry_linking_the_PDF=Создание_пустой_записи_со_ссылкой_на_PDF
-Only_attach_PDF=Приложить_только_PDF
+You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=Необходимо ввести целое число из интервала 1025-65535 в текстовое поле для
+Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Автоматически открывать диалоговое окно обзора при создании новой ссылки на файл
+Import\ metadata\ from\:=Импорт метаданных из:
+Choose\ the\ source\ for\ the\ metadata\ import=Выбрать источник для импорта метаданных
+Create\ entry\ based\ on\ XMP-metadata=Создание записи на основе данных XMP
+Create\ blank\ entry\ linking\ the\ PDF=Создание пустой записи со ссылкой на PDF
+Only\ attach\ PDF=Приложить только PDF
 Title=Заглавие
-Create_new_entry=Создание_новой_записи
-Update_existing_entry=Изменение_существующей_записи
-Autocomplete_names_in_'Firstname_Lastname'_format_only=Автозавершение_имен_только_для_формата_'Имя_Фамилия'
-Autocomplete_names_in_'Lastname,_Firstname'_format_only=Автозавершение_имен_только_для_формата_'Фамилия,_Имя'
-Autocomplete_names_in_both_formats=Автозавершение_имен_в_обоих_форматах
-Marking_color_%0=Цвет_метки_%0
-The_name_'comment'_cannot_be_used_as_an_entry_type_name.=Имя_'комментарий'_не_может_использоваться_как_имя_типа_записи.
-You_must_enter_an_integer_value_in_the_text_field_for=Необходимо_ввести_целое_число_в_текстовое_поле_для
-Send_as_email=Отправить_по_эл.почте
+Create\ new\ entry=Создание новой записи
+Update\ existing\ entry=Изменение существующей записи
+Autocomplete\ names\ in\ 'Firstname\ Lastname'\ format\ only=Автозавершение имен только для формата 'Имя Фамилия'
+Autocomplete\ names\ in\ 'Lastname,\ Firstname'\ format\ only=Автозавершение имен только для формата 'Фамилия, Имя'
+Autocomplete\ names\ in\ both\ formats=Автозавершение имен в обоих форматах
+Marking\ color\ %0=Цвет метки %0
+The\ name\ 'comment'\ cannot\ be\ used\ as\ an\ entry\ type\ name.=Имя 'комментарий' не может использоваться как имя типа записи.
+You\ must\ enter\ an\ integer\ value\ in\ the\ text\ field\ for=Необходимо ввести целое число в текстовое поле для
+Send\ as\ email=Отправить по эл.почте
 References=Ссылки
-Sending_of_emails=Выполняется_отправка_эл.почты
-Subject_for_sending_an_email_with_references=Тема_письма_эл.почты_со_ссылками
-Automatically_open_folders_of_attached_files=Автоматически_открывать_папки_для_приложенных_файлов
-Create_entry_based_on_content=Создать_запись_на_основе_содержимого
-Do_not_show_this_box_again_for_this_import=Не_показывать_это_окно_в_дальнейшем_для_данного_импорта
-Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)=Всегда_использовать_этот_стиль_импорта_PDF_(не_спрашивать_при_последующем_импорте)
-Error_creating_email=Ошибка_при_создании_сообщения_эл.почты
-Entries_added_to_an_email=Записи,_добавленные_в_сообщение_эл.почты
-exportFormat=Формат_экспорта
-Output_file_missing=Отсутствует_файл_вывода
-No_search_matches.=Нет_совпадений_для_поиска.
-The_output_option_depends_on_a_valid_input_option.=Параметры_вывода_зависят_от_допустимых_параметров_ввода.
-Default_import_style_for_drag_and_drop_of_PDFs=Стиль_импорта_по_умолчанию_для_режима_перетаскивания_PDF
-Default_PDF_file_link_action=Действие_для_ссылки_на_файл_PDF_по_умолчанию
-Filename_format_pattern=Шаблон_формата_имени_файла
-Additional_parameters=Дополнительные_параметры
-Cite_selected_entries_between_parenthesis=Цитаты_в_круглых_скобках_для_выбранных_записей
-Cite_selected_entries_with_in-text_citation=Цитаты_в_угловых_скобках_для_выбранных_записей
-Cite_special=Особое_цитирование
-Extra_information_(e.g._page_number)=Дополнительные_сведения_(напр.,_номер_страницы)
-Manage_citations=Управление_цитированием
-Problem_modifying_citation=Ошибка_при_модификации_цитаты
+Sending\ of\ emails=Выполняется отправка эл.почты
+Subject\ for\ sending\ an\ email\ with\ references=Тема письма эл.почты со ссылками
+Automatically\ open\ folders\ of\ attached\ files=Автоматически открывать папки для приложенных файлов
+Create\ entry\ based\ on\ content=Создать запись на основе содержимого
+Do\ not\ show\ this\ box\ again\ for\ this\ import=Не показывать это окно в дальнейшем для данного импорта
+Always\ use\ this\ PDF\ import\ style\ (and\ do\ not\ ask\ for\ each\ import)=Всегда использовать этот стиль импорта PDF (не спрашивать при последующем импорте)
+Error\ creating\ email=Ошибка при создании сообщения эл.почты
+Entries\ added\ to\ an\ email=Записи, добавленные в сообщение эл.почты
+exportFormat=Формат экспорта
+Output\ file\ missing=Отсутствует файл вывода
+No\ search\ matches.=Нет совпадений для поиска.
+The\ output\ option\ depends\ on\ a\ valid\ input\ option.=Параметры вывода зависят от допустимых параметров ввода.
+Default\ import\ style\ for\ drag\ and\ drop\ of\ PDFs=Стиль импорта по умолчанию для режима перетаскивания PDF
+Default\ PDF\ file\ link\ action=Действие для ссылки на файл PDF по умолчанию
+Filename\ format\ pattern=Шаблон формата имени файла
+Additional\ parameters=Дополнительные параметры
+Cite\ selected\ entries\ between\ parenthesis=Цитаты в круглых скобках для выбранных записей
+Cite\ selected\ entries\ with\ in-text\ citation=Цитаты в угловых скобках для выбранных записей
+Cite\ special=Особое цитирование
+Extra\ information\ (e.g.\ page\ number)=Дополнительные сведения (напр., номер страницы)
+Manage\ citations=Управление цитированием
+Problem\ modifying\ citation=Ошибка при модификации цитаты
 Citation=Цитата
-Extra_information=Дополнительные_сведения
-Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.=Не_удалось_разрешить_записи_BibTeX_для_метки_цитаты_'%0'.
-Select_style=Выбор_стиля
+Extra\ information=Дополнительные сведения
+Could\ not\ resolve\ BibTeX\ entry\ for\ citation\ marker\ '%0'.=Не удалось разрешить записи BibTeX для метки цитаты '%0'.
+Select\ style=Выбор стиля
 Journals=Журналы
-Cite=Цитировать_(в_круглых_скобках)
-Cite_in-text=Цитировать_(в_угловых_скобках)
-Insert_empty_citation=Вставка_пустой_цитаты
-Merge_citations=Объединение_цитат
-Manual_connect=Исправление_вручную
-Select_Writer_document=Выбор_документа_OpenOffice/LibreOffice_Writer
-Sync_OpenOffice/LibreOffice_bibliography=Синхронизация_библиографии_OpenOffice/LibreOffice
-Select_which_open_Writer_document_to_work_on=Выберите_открытый_документ_OpenOffice/LibreOffice_Writer_для_работы
-Connected_to_document=Подключено_к_документу
-Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)=Вставка_цитаты_без_текста_(запись_отображается_в_списке_ссылок)
-Cite_selected_entries_with_extra_information=Цитировать_выбранные_записи_с_дополнительными_сведениями
-Ensure_that_the_bibliography_is_up-to-date=Проверьте_актуальность_библиографии
-Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.=Документ_OpenOffice/LibreOffice_ссылается_на_ключ_BibTeX_'%0',_который_не_удалось_найти_в_текущей_БД.
-Unable_to_synchronize_bibliography=Не_удалось_выполнить_синхронизацию_библиографии
-Combine_pairs_of_citations_that_are_separated_by_spaces_only=Объединить_пары_цитат,_разделенные_только_пробелом
-Autodetection_failed=Ошибка_автоопределения
-Connecting=Выполняется_подключение
-Please_wait...=Подождите...
-Set_connection_parameters=Настройка_параметров_подключения
-Path_to_OpenOffice/LibreOffice_directory=Путь_к_каталогу_файлов_OpenOffice/LibreOffice
-Path_to_OpenOffice/LibreOffice_executable=Путь_к_приложениям_OpenOffice/LibreOffice
-Path_to_OpenOffice/LibreOffice_library_dir=Путь_к_каталогу_библиотеки_OpenOffice/LibreOffice
-Connection_lost=Соединение_прервано
-The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.=Формат_абзаца_задается_с_помощью_свойства_'ReferenceParagraphFormat'_или_'ReferenceHeaderParagraphFormat'_в_файле_стиля.
-The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.=Формат_символа_задается_с_помощью_свойства_цитаты_'CitationCharacterFormat'_в_файле_стиля.
-Automatically_sync_bibliography_when_inserting_citations=Автоматически_синхронизировать_библиографию_при_вставке_цитат
-Look_up_BibTeX_entries_in_the_active_tab_only=Поиск_записей_BibTeX_только_в_активной_вкладке
-Look_up_BibTeX_entries_in_all_open_libraries=Поиск_записей_BibTeX_во_всех_открытых_БД
-Autodetecting_paths...=Выполняется_автоопределение_путей...
-Could_not_find_OpenOffice/LibreOffice_installation=Не_удалось_найти_установленное_приложение_OpenOffice/LibreOffice
-Found_more_than_one_OpenOffice/LibreOffice_executable.=Найдено_несколько_приложений_OpenOffice/LibreOffice.
-Please_choose_which_one_to_connect_to\:=Укажите_одно_для_подключения\:
-Choose_OpenOffice/LibreOffice_executable=Выбор_приложения_OpenOffice/LibreOffice
-Select_document=Выбрать_документ
-HTML_list=Список_HTML
-If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting=Если_возможно,_приведите_список_имен_в_соответствие_со_стандартным_форматированием_имен_BibTeX
-Could_not_open_%0=Не_удалось_открыть_%0
-Unknown_import_format=Неизвестный_формат_импорта
-Web_search=Веб-поиск
-Style_selection=Выбор_стиля
-No_valid_style_file_defined=Не_определен_допустимый_файл_стиля
-Choose_pattern=Выбор_шаблона
-Use_the_BIB_file_location_as_primary_file_directory=Использовать_расположение_файла_BIB_как_основной_каталог_файлов
-Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.=Не_удалось_запустить_приложение_gnuclient/emacsclient._Убедитесь,_что_приложение_gnuclient/emacsclient_установлено_и_доступно_по_указанному_пути_PATH.
-OpenOffice/LibreOffice_connection=Подключение_к_OpenOffice/LibreOffice
-You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.=Необходимо_использовать_допустимый_файл_стиля_или_один_из_стилей_по_умолчанию.
+Cite=Цитировать (в круглых скобках)
+Cite\ in-text=Цитировать (в угловых скобках)
+Insert\ empty\ citation=Вставка пустой цитаты
+Merge\ citations=Объединение цитат
+Manual\ connect=Исправление вручную
+Select\ Writer\ document=Выбор документа OpenOffice/LibreOffice Writer
+Sync\ OpenOffice/LibreOffice\ bibliography=Синхронизация библиографии OpenOffice/LibreOffice
+Select\ which\ open\ Writer\ document\ to\ work\ on=Выберите открытый документ OpenOffice/LibreOffice Writer для работы
+Connected\ to\ document=Подключено к документу
+Insert\ a\ citation\ without\ text\ (the\ entry\ will\ appear\ in\ the\ reference\ list)=Вставка цитаты без текста (запись отображается в списке ссылок)
+Cite\ selected\ entries\ with\ extra\ information=Цитировать выбранные записи с дополнительными сведениями
+Ensure\ that\ the\ bibliography\ is\ up-to-date=Проверьте актуальность библиографии
+Your\ OpenOffice/LibreOffice\ document\ references\ the\ BibTeX\ key\ '%0',\ which\ could\ not\ be\ found\ in\ your\ current\ library.=Документ OpenOffice/LibreOffice ссылается на ключ BibTeX '%0', который не удалось найти в текущей БД.
+Unable\ to\ synchronize\ bibliography=Не удалось выполнить синхронизацию библиографии
+Combine\ pairs\ of\ citations\ that\ are\ separated\ by\ spaces\ only=Объединить пары цитат, разделенные только пробелом
+Autodetection\ failed=Ошибка автоопределения
+Connecting=Выполняется подключение
+Please\ wait...=Подождите...
+Set\ connection\ parameters=Настройка параметров подключения
+Path\ to\ OpenOffice/LibreOffice\ directory=Путь к каталогу файлов OpenOffice/LibreOffice
+Path\ to\ OpenOffice/LibreOffice\ executable=Путь к приложениям OpenOffice/LibreOffice
+Path\ to\ OpenOffice/LibreOffice\ library\ dir=Путь к каталогу библиотеки OpenOffice/LibreOffice
+Connection\ lost=Соединение прервано
+The\ paragraph\ format\ is\ controlled\ by\ the\ property\ 'ReferenceParagraphFormat'\ or\ 'ReferenceHeaderParagraphFormat'\ in\ the\ style\ file.=Формат абзаца задается с помощью свойства 'ReferenceParagraphFormat' или 'ReferenceHeaderParagraphFormat' в файле стиля.
+The\ character\ format\ is\ controlled\ by\ the\ citation\ property\ 'CitationCharacterFormat'\ in\ the\ style\ file.=Формат символа задается с помощью свойства цитаты 'CitationCharacterFormat' в файле стиля.
+Automatically\ sync\ bibliography\ when\ inserting\ citations=Автоматически синхронизировать библиографию при вставке цитат
+Look\ up\ BibTeX\ entries\ in\ the\ active\ tab\ only=Поиск записей BibTeX только в активной вкладке
+Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=Поиск записей BibTeX во всех открытых БД
+Autodetecting\ paths...=Выполняется автоопределение путей...
+Could\ not\ find\ OpenOffice/LibreOffice\ installation=Не удалось найти установленное приложение OpenOffice/LibreOffice
+Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=Найдено несколько приложений OpenOffice/LibreOffice.
+Please\ choose\ which\ one\ to\ connect\ to\:=Укажите одно для подключения:
+Choose\ OpenOffice/LibreOffice\ executable=Выбор приложения OpenOffice/LibreOffice
+Select\ document=Выбрать документ
+HTML\ list=Список HTML
+If\ possible,\ normalize\ this\ list\ of\ names\ to\ conform\ to\ standard\ BibTeX\ name\ formatting=Если возможно, приведите список имен в соответствие со стандартным форматированием имен BibTeX
+Could\ not\ open\ %0=Не удалось открыть %0
+Unknown\ import\ format=Неизвестный формат импорта
+Web\ search=Веб-поиск
+Style\ selection=Выбор стиля
+No\ valid\ style\ file\ defined=Не определен допустимый файл стиля
+Choose\ pattern=Выбор шаблона
+Use\ the\ BIB\ file\ location\ as\ primary\ file\ directory=Использовать расположение файла BIB как основной каталог файлов
+Could\ not\ run\ the\ gnuclient/emacsclient\ program.\ Make\ sure\ you\ have\ the\ emacsclient/gnuclient\ program\ installed\ and\ available\ in\ the\ PATH.=Не удалось запустить приложение gnuclient/emacsclient. Убедитесь, что приложение gnuclient/emacsclient установлено и доступно по указанному пути PATH.
+OpenOffice/LibreOffice\ connection=Подключение к OpenOffice/LibreOffice
+You\ must\ select\ either\ a\ valid\ style\ file,\ or\ use\ one\ of\ the\ default\ styles.=Необходимо использовать допустимый файл стиля или один из стилей по умолчанию.
 
-This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.=Это_простое_окно_копирования/вставки._Сначала_загрузите_или_вставьте_текст_в_область_ввода.<br>После_этого_вы_можете_пометить_текст_и_назначить_его_полю_BibTeX.
-This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.=С_помощью_данной_функции_создается_новая_БД_на_основе_обязательных_записей_существующего_документа_LaTeX.
-You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.=Необходимо_указать_одну_из_открытых_БД,_из_которой_выбираются_записи,_и_файл_AUX,_полученный_в_LaTeX_при_компиляции_документа.
+This\ is\ a\ simple\ copy\ and\ paste\ dialog.\ First\ load\ or\ paste\ some\ text\ into\ the\ text\ input\ area.<br>After\ that,\ you\ can\ mark\ text\ and\ assign\ it\ to\ a\ BibTeX\ field.=Это простое окно копирования/вставки. Сначала загрузите или вставьте текст в область ввода.<br>После этого вы можете пометить текст и назначить его полю BibTeX.
+This\ feature\ generates\ a\ new\ library\ based\ on\ which\ entries\ are\ needed\ in\ an\ existing\ LaTeX\ document.=С помощью данной функции создается новая БД на основе обязательных записей существующего документа LaTeX.
+You\ need\ to\ select\ one\ of\ your\ open\ libraries\ from\ which\ to\ choose\ entries,\ as\ well\ as\ the\ AUX\ file\ produced\ by\ LaTeX\ when\ compiling\ your\ document.=Необходимо указать одну из открытых БД, из которой выбираются записи, и файл AUX, полученный в LaTeX при компиляции документа.
 
-First_select_entries_to_clean_up.=Необходимо_сначала_выбрать_записи_для_очистки.
-Cleanup_entry=Очистка_записей
-Autogenerate_PDF_Names=Автосоздание_имен_PDF
-Auto-generating_PDF-Names_does_not_support_undo._Continue?=Операция_отмены-не_поддерживается_для_автосоздания_имен_PDF._Продолжить?
+First\ select\ entries\ to\ clean\ up.=Необходимо сначала выбрать записи для очистки.
+Cleanup\ entry=Очистка записей
+Autogenerate\ PDF\ Names=Автосоздание имен PDF
+Auto-generating\ PDF-Names\ does\ not\ support\ undo.\ Continue?=Операция отмены-не поддерживается для автосоздания имен PDF. Продолжить?
 
-Use_full_firstname_whenever_possible=Использовать_полное_имя_(если_возможно)
-Use_abbreviated_firstname_whenever_possible=Использовать_сокращенное_имя_(если_возможно)
-Use_abbreviated_and_full_firstname=Использовать_сокращенное_и_полное_имя
-Autocompletion_options=Параметры_автозавершения
-Name_format_used_for_autocompletion=Формат_имени_для_автозавершения
-Treatment_of_first_names=Способ_обработки_имен
-Cleanup_entries=Очистить_записи
-Automatically_assign_new_entry_to_selected_groups=Автоматически_назначать_новую_запись_выбранным_группам
-%0_mode=Режим_%0
-Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix=Перемещать_DOI_из_поля_примечания_и_URL-адреса_в_поле_DOI_и_удалять_префикс_http
-Make_paths_of_linked_files_relative_(if_possible)=Создавать_относительные_пути_для_связанных_файлов_(если_возможно)
-Rename_PDFs_to_given_filename_format_pattern=Переименовать_PDF_в_соответствии_с_указанным_шаблоном_формата_имени
-Rename_only_PDFs_having_a_relative_path=Переименовать_только_PDF_с_относительными_путями
-What_would_you_like_to_clean_up?=Выберите_объекты_для_очистки.
-Doing_a_cleanup_for_%0_entries...=Выполняется_очистка_для_%0_записей...
-No_entry_needed_a_clean_up=Нет_записей_для_очистки
-One_entry_needed_a_clean_up=Необходима_очистка_для_одной_записи
-%0_entries_needed_a_clean_up=Необходима_очистка_для_%0_записей
+Use\ full\ firstname\ whenever\ possible=Использовать полное имя (если возможно)
+Use\ abbreviated\ firstname\ whenever\ possible=Использовать сокращенное имя (если возможно)
+Use\ abbreviated\ and\ full\ firstname=Использовать сокращенное и полное имя
+Autocompletion\ options=Параметры автозавершения
+Name\ format\ used\ for\ autocompletion=Формат имени для автозавершения
+Treatment\ of\ first\ names=Способ обработки имен
+Cleanup\ entries=Очистить записи
+Automatically\ assign\ new\ entry\ to\ selected\ groups=Автоматически назначать новую запись выбранным группам
+%0\ mode=Режим %0
+Move\ DOIs\ from\ note\ and\ URL\ field\ to\ DOI\ field\ and\ remove\ http\ prefix=Перемещать DOI из поля примечания и URL-адреса в поле DOI и удалять префикс http
+Make\ paths\ of\ linked\ files\ relative\ (if\ possible)=Создавать относительные пути для связанных файлов (если возможно)
+Rename\ PDFs\ to\ given\ filename\ format\ pattern=Переименовать PDF в соответствии с указанным шаблоном формата имени
+Rename\ only\ PDFs\ having\ a\ relative\ path=Переименовать только PDF с относительными путями
+What\ would\ you\ like\ to\ clean\ up?=Выберите объекты для очистки.
+Doing\ a\ cleanup\ for\ %0\ entries...=Выполняется очистка для %0 записей...
+No\ entry\ needed\ a\ clean\ up=Нет записей для очистки
+One\ entry\ needed\ a\ clean\ up=Необходима очистка для одной записи
+%0\ entries\ needed\ a\ clean\ up=Необходима очистка для %0 записей
 
-Remove_selected=Удалить_выбранное
+Remove\ selected=Удалить выбранное
 
-Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.=Не_удалось_проанализировать_дерево_групп._При_сохранении_БД_BibTeX_все_группы_будут_утеряны.
-Attach_file=Приложить_файл
-Setting_all_preferences_to_default_values.=Инициализация_пользовательских_настроек_к_значениям_по_умолчанию.
-Resetting_preference_key_'%0'=Сброс_ключа_пользовательских_настроек_'%0'
-Unknown_preference_key_'%0'=Неизвестный_ключ_пользовательских_настроек_'%0'
-Unable_to_clear_preferences.=Не_удалось_очистить_пользовательские_настройки.
+Group\ tree\ could\ not\ be\ parsed.\ If\ you\ save\ the\ BibTeX\ library,\ all\ groups\ will\ be\ lost.=Не удалось проанализировать дерево групп. При сохранении БД BibTeX все группы будут утеряны.
+Attach\ file=Приложить файл
+Setting\ all\ preferences\ to\ default\ values.=Инициализация пользовательских настроек к значениям по умолчанию.
+Resetting\ preference\ key\ '%0'=Сброс ключа пользовательских настроек '%0'
+Unknown\ preference\ key\ '%0'=Неизвестный ключ пользовательских настроек '%0'
+Unable\ to\ clear\ preferences.=Не удалось очистить пользовательские настройки.
 
-Reset_preferences_(key1,key2,..._or_'all')=Сброс_пользовательских_настроек_(ключ1,_ключ2,..._или_'все')
-Find_unlinked_files=Поиск_несвязанных_файлов
-Unselect_all=Отменить_выбор_всех
-Expand_all=Развернуть_все
-Collapse_all=Свернуть_все
-Opens_the_file_browser.=Открывает_окно_обзора_файлов.
-Scan_directory=Сканировать_каталог_файлов
-Searches_the_selected_directory_for_unlinked_files.=Выполняет_поиск_несвязанных_файлов_в_выбранном_каталоге_файлов.
-Starts_the_import_of_BibTeX_entries.=Начинает_импорт_записей_BibTeX.
-Leave_this_dialog.=Выйти_из_диалогового_окна.
-Create_directory_based_keywords=Создать_ключевые_слова_на_основе_каталога_файлов
-Creates_keywords_in_created_entrys_with_directory_pathnames=Создает_ключевые_слова_для_созданных_записей_с_путями_каталога_файлов
-Select_a_directory_where_the_search_shall_start.=Выбирает_каталог_файлов_для_начала_поиска.
-Select_file_type\:=Выбор_типа_файла\:
-These_files_are_not_linked_in_the_active_library.=Эти_файлы_не_связаны_в_активной_БД.
-Entry_type_to_be_created\:=Создаваемый_тип_записи\:
-Searching_file_system...=Выполняется_поиск_в_файловой_системе...
-Importing_into_Library...=Выполняется_импорт_в_БД...
-Select_directory=Выбрать_каталог_файлов
-Select_files=Выбрать_файлы
-BibTeX_entry_creation=Создание_записи_BibTeX
-<No_selection>=<Не_выбрано>
-Unable_to_connect_to_FreeCite_online_service.=Не_удалось_подключиться_к_он-лайн_службе_FreeCite.
-Parse_with_FreeCite=Анализ_с_помощью_FreeCite
-The_current_BibTeX_key_will_be_overwritten._Continue?=Текущий_ключ_BibTeX_будет_перезаписан._Продолжить?
-Overwrite_key=Перезаписать_ключ
-Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator=Без_перезаписи_текущего_ключа._Для_изменения_настроек\:_Параметры_->_Параметры_пользователя_->_Создание_ключа_BibTeX
-How_would_you_like_to_link_to_'%0'?=Выберите_тип_ссылки_для_'%0'.
-BibTeX_key_patterns=Шаблоны_ключа_BibTeX
-Changed_special_field_settings=Настройки_полей_особых_отметок_изменены
-Clear_priority=Очистить_значения_приоритета
-Clear_rank=Очистить_значения_ранга
-Enable_special_fields=Разрешить_поля_особых_отметок
-One_star=Одна_звезда
-Two_stars=Две_звезды
-Three_stars=Три_звезды
-Four_stars=Четыре_звезды
-Five_stars=Пять_звезд
-Help_on_special_fields=Справка_для_полей_особых_отметок
-Keywords_of_selected_entries=Ключевые_слова_для_выбранных_записей
-Manage_content_selectors=Управление_выбором_содержимого
-Manage_keywords=Управление_ключевыми_словами
-No_priority_information=Без_данных_о_приоритете
-No_rank_information=Без_данных_о_ранге
+Reset\ preferences\ (key1,key2,...\ or\ 'all')=Сброс пользовательских настроек (ключ1, ключ2,... или 'все')
+Find\ unlinked\ files=Поиск несвязанных файлов
+Unselect\ all=Отменить выбор всех
+Expand\ all=Развернуть все
+Collapse\ all=Свернуть все
+Opens\ the\ file\ browser.=Открывает окно обзора файлов.
+Scan\ directory=Сканировать каталог файлов
+Searches\ the\ selected\ directory\ for\ unlinked\ files.=Выполняет поиск несвязанных файлов в выбранном каталоге файлов.
+Starts\ the\ import\ of\ BibTeX\ entries.=Начинает импорт записей BibTeX.
+Leave\ this\ dialog.=Выйти из диалогового окна.
+Create\ directory\ based\ keywords=Создать ключевые слова на основе каталога файлов
+Creates\ keywords\ in\ created\ entrys\ with\ directory\ pathnames=Создает ключевые слова для созданных записей с путями каталога файлов
+Select\ a\ directory\ where\ the\ search\ shall\ start.=Выбирает каталог файлов для начала поиска.
+Select\ file\ type\:=Выбор типа файла:
+These\ files\ are\ not\ linked\ in\ the\ active\ library.=Эти файлы не связаны в активной БД.
+Entry\ type\ to\ be\ created\:=Создаваемый тип записи:
+Searching\ file\ system...=Выполняется поиск в файловой системе...
+Importing\ into\ Library...=Выполняется импорт в БД...
+Select\ directory=Выбрать каталог файлов
+Select\ files=Выбрать файлы
+BibTeX\ entry\ creation=Создание записи BibTeX
+<No\ selection>=<Не выбрано>
+Unable\ to\ connect\ to\ FreeCite\ online\ service.=Не удалось подключиться к он-лайн службе FreeCite.
+Parse\ with\ FreeCite=Анализ с помощью FreeCite
+The\ current\ BibTeX\ key\ will\ be\ overwritten.\ Continue?=Текущий ключ BibTeX будет перезаписан. Продолжить?
+Overwrite\ key=Перезаписать ключ
+Not\ overwriting\ existing\ key.\ To\ change\ this\ setting,\ open\ Options\ ->\ Prefererences\ ->\ BibTeX\ key\ generator=Без перезаписи текущего ключа. Для изменения настроек: Параметры -> Параметры пользователя -> Создание ключа BibTeX
+How\ would\ you\ like\ to\ link\ to\ '%0'?=Выберите тип ссылки для '%0'.
+BibTeX\ key\ patterns=Шаблоны ключа BibTeX
+Changed\ special\ field\ settings=Настройки полей особых отметок изменены
+Clear\ priority=Очистить значения приоритета
+Clear\ rank=Очистить значения ранга
+Enable\ special\ fields=Разрешить поля особых отметок
+One\ star=Одна звезда
+Two\ stars=Две звезды
+Three\ stars=Три звезды
+Four\ stars=Четыре звезды
+Five\ stars=Пять звезд
+Help\ on\ special\ fields=Справка для полей особых отметок
+Keywords\ of\ selected\ entries=Ключевые слова для выбранных записей
+Manage\ content\ selectors=Управление выбором содержимого
+Manage\ keywords=Управление ключевыми словами
+No\ priority\ information=Без данных о приоритете
+No\ rank\ information=Без данных о ранге
 Priority=Приоритет
-Priority_high=Высокий_приоритет
-Priority_low=Низкий_приоритет
-Priority_medium=Средний_приоритет
+Priority\ high=Высокий приоритет
+Priority\ low=Низкий приоритет
+Priority\ medium=Средний приоритет
 Quality=Качество
 Rank=Ранг
 Relevance=Релевантность
-Set_priority_to_high=Установить_высокий_приоритет
-Set_priority_to_low=Установить_низкий_приоритет
-Set_priority_to_medium=Установить_средний_приоритет
-Show_priority=Показать_значения_приоритета
-Show_quality=Показать_значения_качества
-Show_rank=Показать_значения_ранга
-Show_relevance=Показать_значения_релевантности
-Synchronize_with_keywords=Синхронизировать_с_ключевыми_словами
-Synchronized_special_fields_based_on_keywords=Поля_особых_отметок_синхронизированы_на_основе_ключевых_слов
-Toggle_relevance=Показать/скрыть_релевантность
-Toggle_quality_assured=Прказать/скрыть_проверку_контроля_качества
-Toggle_print_status=Изменить_статус_'печать'
-Update_keywords=Изменить_ключевые_слова
-Write_values_of_special_fields_as_separate_fields_to_BibTeX=Записать_значения_полей_особых_отметок_в_отдельные_поля_BibTeX
-You_have_changed_settings_for_special_fields.=Настройки_полей_особых_отметок_изменены_пользователем.
-%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.=Найдено_записей\:_%0._Для_снижения_нагрузки_сервера,_будет_загружено_записей\:_%1.
-A_string_with_that_label_already_exists=Строка_с_такой_меткой_уже_существует
-Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.=Соединение_с_OpenOffice/LibreOffice_прервано._Убедитесь,_что_приложение_OpenOffice/LibreOffice_запущено_и_повторите_соединение.
-JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.=
-Correct_the_entry,_and_reopen_editor_to_display/edit_source.=Исправить_запись_и_повторно_открыть_редактор_для_отображения/изменения_исходника.
-Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').=Не_удалось_подключиться_к_запущенному_процессу_gnuserv._Убедитесь,_что_приложение_Emacs_или_XEmacs<BR>и_сервер_запущены(с_помощью_команды_'server-start'/'gnuserv-start').
-Could_not_connect_to_running_OpenOffice/LibreOffice.=Не_удалось_подключиться_к_работающему_приложению_OpenOffice/LibreOffice.
-Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.=Убедитесь,_что_установлен_OpenOffice/LibreOffice_с_поддержкой_Java.
-If_connecting_manually,_please_verify_program_and_library_paths.=При_подключении_вручную,_проверьте_правильность_путей_для_приложения_и_библиотеки.
-Error_message\:=Сообщение_об_ошибке\:
-If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.=Перезаписать,_если_поле_для_вставленной_или_импортированной_записи_уже_задано.
-Import_metadata_from_PDF=Импорт_метаданных_из_PDF
-Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.=Отсутствует_подключение_к_документу_Writer._Убедитесь,_что_документ_открыт_и_нажмите_кнопку_'Выбрать_документ_Writer'_для_подключения.
-Removed_all_subgroups_of_group_"%0".=Все_подгруппы_группы_"%0"_удалены.
-To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.=Для_отключения_режима_флеш-памяти_переименуйте_или_удалите_файл_jabref.xml_в_каталоге_JabRef.
-Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.=Не_удалось_выполнить_подключение._Возможная_причина\:_JabRef_и_OpenOffice/LibreOffice_не_запущены_в_режиме_32-х_или_64-х_битного_приложения.
-Use_the_following_delimiter_character(s)\:=Используйте_следующие_символы-разделители\:
-When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above=При_загрузке_файлов_или_перемещении_связанных_файлов_в_каталог_файлов_желательно_использовать_каталог_расположения_файла_bib,_а_не_вышеуказанный_каталог
-Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=В_пользовательском_файле_стиля_указан_формат_знака_'%0',_не_определенный_в_текущем_документе_OpenOffice/LibreOffice.
-Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=В_пользовательском_файле_стиля_указан_формат_абзаца_'%0',_не_определенный_в_текущем_документе_OpenOffice/LibreOffice.
+Set\ priority\ to\ high=Установить высокий приоритет
+Set\ priority\ to\ low=Установить низкий приоритет
+Set\ priority\ to\ medium=Установить средний приоритет
+Show\ priority=Показать значения приоритета
+Show\ quality=Показать значения качества
+Show\ rank=Показать значения ранга
+Show\ relevance=Показать значения релевантности
+Synchronize\ with\ keywords=Синхронизировать с ключевыми словами
+Synchronized\ special\ fields\ based\ on\ keywords=Поля особых отметок синхронизированы на основе ключевых слов
+Toggle\ relevance=Показать/скрыть релевантность
+Toggle\ quality\ assured=Прказать/скрыть проверку контроля качества
+Toggle\ print\ status=Изменить статус 'печать'
+Update\ keywords=Изменить ключевые слова
+Write\ values\ of\ special\ fields\ as\ separate\ fields\ to\ BibTeX=Записать значения полей особых отметок в отдельные поля BibTeX
+You\ have\ changed\ settings\ for\ special\ fields.=Настройки полей особых отметок изменены пользователем.
+%0\ entries\ found.\ To\ reduce\ server\ load,\ only\ %1\ will\ be\ downloaded.=Найдено записей: %0. Для снижения нагрузки сервера, будет загружено записей: %1.
+A\ string\ with\ that\ label\ already\ exists=Строка с такой меткой уже существует
+Connection\ to\ OpenOffice/LibreOffice\ has\ been\ lost.\ Please\ make\ sure\ OpenOffice/LibreOffice\ is\ running,\ and\ try\ to\ reconnect.=Соединение с OpenOffice/LibreOffice прервано. Убедитесь, что приложение OpenOffice/LibreOffice запущено и повторите соединение.
+JabRef\ will\ send\ at\ least\ one\ request\ per\ entry\ to\ a\ publisher.=
+Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=Исправить запись и повторно открыть редактор для отображения/изменения исходника.
+Could\ not\ connect\ to\ a\ running\ gnuserv\ process.\ Make\ sure\ that\ Emacs\ or\ XEmacs\ is\ running,<BR>and\ that\ the\ server\ has\ been\ started\ (by\ running\ the\ command\ 'server-start'/'gnuserv-start').=Не удалось подключиться к запущенному процессу gnuserv. Убедитесь, что приложение Emacs или XEmacs<BR>и сервер запущены(с помощью команды 'server-start'/'gnuserv-start').
+Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=Не удалось подключиться к работающему приложению OpenOffice/LibreOffice.
+Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=Убедитесь, что установлен OpenOffice/LibreOffice с поддержкой Java.
+If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=При подключении вручную, проверьте правильность путей для приложения и библиотеки.
+Error\ message\:=Сообщение об ошибке:
+If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=Перезаписать, если поле для вставленной или импортированной записи уже задано.
+Import\ metadata\ from\ PDF=Импорт метаданных из PDF
+Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=Отсутствует подключение к документу Writer. Убедитесь, что документ открыт и нажмите кнопку 'Выбрать документ Writer' для подключения.
+Removed\ all\ subgroups\ of\ group\ "%0".=Все подгруппы группы "%0" удалены.
+To\ disable\ the\ memory\ stick\ mode\ rename\ or\ remove\ the\ jabref.xml\ file\ in\ the\ same\ folder\ as\ JabRef.=Для отключения режима флеш-памяти переименуйте или удалите файл jabref.xml в каталоге JabRef.
+Unable\ to\ connect.\ One\ possible\ reason\ is\ that\ JabRef\ and\ OpenOffice/LibreOffice\ are\ not\ both\ running\ in\ either\ 32\ bit\ mode\ or\ 64\ bit\ mode.=Не удалось выполнить подключение. Возможная причина: JabRef и OpenOffice/LibreOffice не запущены в режиме 32-х или 64-х битного приложения.
+Use\ the\ following\ delimiter\ character(s)\:=Используйте следующие символы-разделители:
+When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\ prefer\ the\ BIB\ file\ location\ rather\ than\ the\ file\ directory\ set\ above=При загрузке файлов или перемещении связанных файлов в каталог файлов желательно использовать каталог расположения файла bib, а не вышеуказанный каталог
+Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=В пользовательском файле стиля указан формат знака '%0', не определенный в текущем документе OpenOffice/LibreOffice.
+Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=В пользовательском файле стиля указан формат абзаца '%0', не определенный в текущем документе OpenOffice/LibreOffice.
 
-Searching...=Выполняется_поиск...
-You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?=Выбрано_более_%0_записей_для_загрузки._Возможна_блокировка_пользователя_некоторыми_веб-сайтами_при_большом_числе_быстрых_загрузок._Продолжить?
-Confirm_selection=Подтвердить_выбор
-Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case=Добавлять_{}_к_указанным_заглавным_словам_при_поиске_для_соблюдения_правильности_регистра
-Import_conversions=Импорт_преобразований
-Please_enter_a_search_string=Введите_строку_для_поиска
-Please_open_or_start_a_new_library_before_searching=Для_начала_поиска_откройте_существующую_БД_или_создайте_новую_БД
+Searching...=Выполняется поиск...
+You\ have\ selected\ more\ than\ %0\ entries\ for\ download.\ Some\ web\ sites\ might\ block\ you\ if\ you\ make\ too\ many\ rapid\ downloads.\ Do\ you\ want\ to\ continue?=Выбрано более %0 записей для загрузки. Возможна блокировка пользователя некоторыми веб-сайтами при большом числе быстрых загрузок. Продолжить?
+Confirm\ selection=Подтвердить выбор
+Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=Добавлять {} к указанным заглавным словам при поиске для соблюдения правильности регистра
+Import\ conversions=Импорт преобразований
+Please\ enter\ a\ search\ string=Введите строку для поиска
+Please\ open\ or\ start\ a\ new\ library\ before\ searching=Для начала поиска откройте существующую БД или создайте новую БД
 
-Canceled_merging_entries=Слияние_записей_отменено
+Canceled\ merging\ entries=Слияние записей отменено
 
-Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search=Форматирование_единиц_с_помощью_неразрывных_символов-разделителей_с_сохранением_правильного_регистра_при_поиске
-Merge_entries=Объединение_записей
-Merged_entries=Записи_с_объединением_в_новую_и_сохранением_старой
-Merged_entry=Запись_с_объединением
-None=Ни_одной
+Format\ units\ by\ adding\ non-breaking\ separators\ and\ keeping\ the\ correct\ case\ on\ search=Форматирование единиц с помощью неразрывных символов-разделителей с сохранением правильного регистра при поиске
+Merge\ entries=Объединение записей
+Merged\ entries=Записи с объединением в новую и сохранением старой
+Merged\ entry=Запись с объединением
+None=Ни одной
 Parse=Анализ
 Result=Результат
-Show_DOI_first=Показать_сначала_DOI
-Show_URL_first=Показать_сначала_URL
-Use_Emacs_key_bindings=Использовать_назначения_функциональных_клавиш_Emacs
-You_have_to_choose_exactly_two_entries_to_merge.=Для_слияния_необходимо_выбрать_строго_две_записи.
+Show\ DOI\ first=Показать сначала DOI
+Show\ URL\ first=Показать сначала URL
+Use\ Emacs\ key\ bindings=Использовать назначения функциональных клавиш Emacs
+You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=Для слияния необходимо выбрать строго две записи.
 
-Update_timestamp_on_modification=Обновить_метку_времени_при_изменении
-All_key_bindings_will_be_reset_to_their_defaults.=Все_назначения_функциональных_клавиш_будут_сброшены_к_значениям_по_умолчанию.
+Update\ timestamp\ on\ modification=Обновить метку времени при изменении
+All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=Все назначения функциональных клавиш будут сброшены к значениям по умолчанию.
 
-Automatically_set_file_links=Автоуказание_ссылок_на_файлы
-Resetting_all_key_bindings=Сброс_назначений_функциональных_клавиш
+Automatically\ set\ file\ links=Автоуказание ссылок на файлы
+Resetting\ all\ key\ bindings=Сброс назначений функциональных клавиш
 Hostname=Хост
-Invalid_setting=Недопустимые_параметры
+Invalid\ setting=Недопустимые параметры
 Network=Сеть
-Please_specify_both_hostname_and_port=Укажите_имя_хоста_и_порт
-Please_specify_both_username_and_password=Укажите_имя_пользователя_и_пароль
+Please\ specify\ both\ hostname\ and\ port=Укажите имя хоста и порт
+Please\ specify\ both\ username\ and\ password=Укажите имя пользователя и пароль
 
-Use_custom_proxy_configuration=Использовать_пользовательские_настройки_прокси-сервера
-Proxy_requires_authentication=Для_прокси-сервера_требуется_авторизация
-Attention\:_Password_is_stored_in_plain_text\!=Внимание._Пароль_сохранен_в_виде_простого_текста.
-Clear_connection_settings=Удалить_настройки_подключения
-Cleared_connection_settings.=Настройки_подключения_удалены.
+Use\ custom\ proxy\ configuration=Использовать пользовательские настройки прокси-сервера
+Proxy\ requires\ authentication=Для прокси-сервера требуется авторизация
+Attention\:\ Password\ is\ stored\ in\ plain\ text\!=Внимание. Пароль сохранен в виде простого текста.
+Clear\ connection\ settings=Удалить настройки подключения
+Cleared\ connection\ settings.=Настройки подключения удалены.
 
-Rebind_C-a,_too=Переназначить_также_C-a
-Rebind_C-f,_too=Переназначить_также_C-f
+Rebind\ C-a,\ too=Переназначить также C-a
+Rebind\ C-f,\ too=Переназначить также C-f
 
-Open_folder=Открыть_папку
-Searches_for_unlinked_PDF_files_on_the_file_system=Выполняет_поиск_несвязанных_файлов_PDF_в_файловой_системе
-Export_entries_ordered_as_specified=Экспорт_записей_в_указанном_порядке
-Export_sort_order=Экспорт_в_порядке_сортировки
-Export_sorting=Сортировка_при_экспорте
-Newline_separator=Разделитель_для_новой_строки
+Open\ folder=Открыть папку
+Searches\ for\ unlinked\ PDF\ files\ on\ the\ file\ system=Выполняет поиск несвязанных файлов PDF в файловой системе
+Export\ entries\ ordered\ as\ specified=Экспорт записей в указанном порядке
+Export\ sort\ order=Экспорт в порядке сортировки
+Export\ sorting=Сортировка при экспорте
+Newline\ separator=Разделитель для новой строки
 
-Save_entries_ordered_as_specified=Сохранить_записи_в_указанном_порядке
-Save_sort_order=Сохранить_порядок_сортировки
-Show_extra_columns=Показывать_столбцы_доп.сведений
-Parsing_error=Ошибка_анализа
-illegal_backslash_expression=недопустимое_выражение_с_обратной_косой_чертой
+Save\ entries\ ordered\ as\ specified=Сохранить записи в указанном порядке
+Save\ sort\ order=Сохранить порядок сортировки
+Show\ extra\ columns=Показывать столбцы доп.сведений
+Parsing\ error=Ошибка анализа
+illegal\ backslash\ expression=недопустимое выражение с обратной косой чертой
 
-Move_to_group=Переместить_в_группу
+Move\ to\ group=Переместить в группу
 
-Clear_read_status=Очистить_статус_"для_чтения"
-Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')=Преобразовать_в_формат_biblatex_(например,_переместить_значение_из_поля_'journal'_в_'journaltitle')
-Could_not_apply_changes.=Не_удалось_применить_изменения.
-Deprecated_fields=Устаревшие_поля
-Hide/show_toolbar=Показать/скрыть_панель_инструментов
-No_read_status_information=Без_сведений_статуса_"чтение"
+Clear\ read\ status=Очистить статус "для чтения"
+Convert\ to\ biblatex\ format\ (for\ example,\ move\ the\ value\ of\ the\ 'journal'\ field\ to\ 'journaltitle')=Преобразовать в формат biblatex (например, переместить значение из поля 'journal' в 'journaltitle')
+Could\ not\ apply\ changes.=Не удалось применить изменения.
+Deprecated\ fields=Устаревшие поля
+Hide/show\ toolbar=Показать/скрыть панель инструментов
+No\ read\ status\ information=Без сведений статуса "чтение"
 Printed=Напечатано
-Read_status=Статус_'чтение'
-Read_status_read=Статус_чтения_\:_'чтение'
-Read_status_skimmed=Статус_чтения_\:_'просмотр'
-Save_selected_as_plain_BibTeX...=Сохранить_выбранное_как_неформатированный_BibTeX...
-Set_read_status_to_read=Установить_статус_чтения_\:_'чтение'
-Set_read_status_to_skimmed=Установить_статус_чтения_\:_'просмотр'
-Show_deprecated_BibTeX_fields=Показать_устаревшие_поля_BibTeX
+Read\ status=Статус 'чтение'
+Read\ status\ read=Статус чтения : 'чтение'
+Read\ status\ skimmed=Статус чтения : 'просмотр'
+Save\ selected\ as\ plain\ BibTeX...=Сохранить выбранное как неформатированный BibTeX...
+Set\ read\ status\ to\ read=Установить статус чтения : 'чтение'
+Set\ read\ status\ to\ skimmed=Установить статус чтения : 'просмотр'
+Show\ deprecated\ BibTeX\ fields=Показать устаревшие поля BibTeX
 
-Show_gridlines=Показать_сетку
-Show_printed_status=Показать_статус_'печать'
-Show_read_status=Показать_статус_'чтение'
-Table_row_height_padding=Отступ_по_высоте_для_строки_таблицы
+Show\ gridlines=Показать сетку
+Show\ printed\ status=Показать статус 'печать'
+Show\ read\ status=Показать статус 'чтение'
+Table\ row\ height\ padding=Отступ по высоте для строки таблицы
 
-Marked_selected_entry=Отмечены_выбранные_записи
-Marked_all_%0_selected_entries=Отмечены_все_%0_выбранные_записи
-Unmarked_selected_entry=Отмена_отметки_выбранных_записей
-Unmarked_all_%0_selected_entries=Отмена_отметки_всех_%0_выбранных_записей
+Marked\ selected\ entry=Отмечены выбранные записи
+Marked\ all\ %0\ selected\ entries=Отмечены все %0 выбранные записи
+Unmarked\ selected\ entry=Отмена отметки выбранных записей
+Unmarked\ all\ %0\ selected\ entries=Отмена отметки всех %0 выбранных записей
 
 
-Unmarked_all_entries=Отмена_отметки_всех_записей
+Unmarked\ all\ entries=Отмена отметки всех записей
 
-Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.=Не_удалось_найти_запрошенное_представление._Используется_представление_по_умолчанию.
+Unable\ to\ find\ the\ requested\ look\ and\ feel\ and\ thus\ the\ default\ one\ is\ used.=Не удалось найти запрошенное представление. Используется представление по умолчанию.
 
-Opens_JabRef's_GitHub_page=Открыть_страницу_JabRef_на_GitHub
-Could_not_open_browser.=Не_удалось_открыть_браузер.
-Please_open_%0_manually.=Откройте_%0_вручную.
-The_link_has_been_copied_to_the_clipboard.=Ссылка_скопирована_в_буфер_обмена.
+Opens\ JabRef's\ GitHub\ page=Открыть страницу JabRef на GitHub
+Could\ not\ open\ browser.=Не удалось открыть браузер.
+Please\ open\ %0\ manually.=Откройте %0 вручную.
+The\ link\ has\ been\ copied\ to\ the\ clipboard.=Ссылка скопирована в буфер обмена.
 
-Open_%0_file=Открыть_файл_%0
+Open\ %0\ file=Открыть файл %0
 
-Cannot_delete_file=Невозможно_удалить_файл
-File_permission_error=Ошибка_прав_доступа_для_файла
-Push_to_%0=Передать_в_%0
-Path_to_%0=Путь_к_%0
+Cannot\ delete\ file=Невозможно удалить файл
+File\ permission\ error=Ошибка прав доступа для файла
+Push\ to\ %0=Передать в %0
+Path\ to\ %0=Путь к %0
 Convert=Преобразовать
-Normalize_to_BibTeX_name_format=Нормализовать_в_формат_имени_BibTeX
-Help_on_Name_Formatting=Справка_по_форматированию_имен
+Normalize\ to\ BibTeX\ name\ format=Нормализовать в формат имени BibTeX
+Help\ on\ Name\ Formatting=Справка по форматированию имен
 
-Add_new_file_type=Добавить_новый_тип_файлов
+Add\ new\ file\ type=Добавить новый тип файлов
 
-Left_entry=Запись_слева
-Right_entry=Запись_справа
+Left\ entry=Запись слева
+Right\ entry=Запись справа
 Use=Использовать
-Original_entry=Исходная_запись
-Replace_original_entry=Заменить_исходную_запись
-No_information_added=Сведения_не_добавлены
-Select_at_least_one_entry_to_manage_keywords.=Выберите_минимум_одну_запись_для_управления_ключевыми_словами.
-OpenDocument_text=Текст_OpenDocument
-OpenDocument_spreadsheet=Таблица_OpenDocument
-OpenDocument_presentation=Презентация_OpenDocument
-%0_image=Изображение_%0
-Added_entry=Добавленная_запись
-Modified_entry=Модифицированная_запись
-Deleted_entry=Удаленная_запись
-Modified_groups_tree=Модифицированное_дерево_групп
-Removed_all_groups=Удаление_всех_групп
-Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.=При_принятии_данного_изменения_все_дерево_групп_будет_заменено_на_дерево_групп_с_внешними_изменениями.
-Select_export_format=Выбрать_формат_экспорта
-Return_to_JabRef=Вернуться_в_JabRef
-Please_move_the_file_manually_and_link_in_place.=Переместите_файл_вручную_и_укажите_локальную_ссылку.
-Could_not_connect_to_%0=Не_удалось_подключиться_к_серверу_%0
-Warning\:_%0_out_of_%1_entries_have_undefined_title.=
-Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.=Предупреждение._Для_%0_из_%1_записей_не_определен_ключ_BibTeX.
+Original\ entry=Исходная запись
+Replace\ original\ entry=Заменить исходную запись
+No\ information\ added=Сведения не добавлены
+Select\ at\ least\ one\ entry\ to\ manage\ keywords.=Выберите минимум одну запись для управления ключевыми словами.
+OpenDocument\ text=Текст OpenDocument
+OpenDocument\ spreadsheet=Таблица OpenDocument
+OpenDocument\ presentation=Презентация OpenDocument
+%0\ image=Изображение %0
+Added\ entry=Добавленная запись
+Modified\ entry=Модифицированная запись
+Deleted\ entry=Удаленная запись
+Modified\ groups\ tree=Модифицированное дерево групп
+Removed\ all\ groups=Удаление всех групп
+Accepting\ the\ change\ replaces\ the\ complete\ groups\ tree\ with\ the\ externally\ modified\ groups\ tree.=При принятии данного изменения все дерево групп будет заменено на дерево групп с внешними изменениями.
+Select\ export\ format=Выбрать формат экспорта
+Return\ to\ JabRef=Вернуться в JabRef
+Please\ move\ the\ file\ manually\ and\ link\ in\ place.=Переместите файл вручную и укажите локальную ссылку.
+Could\ not\ connect\ to\ %0=Не удалось подключиться к серверу %0
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ title.=
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ BibTeX\ key.=Предупреждение. Для %0 из %1 записей не определен ключ BibTeX.
 occurrence=вхождения
-Added_new_'%0'_entry.=Добавлена_новая_запись_'%0'.
-Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?=Выбрано_несколько_записей._Изменить_тип_всех_этих_записей_на_'%0'?
-Changed_type_to_'%0'_for=Тип_с_изменением_на_'%0'_для
-Really_delete_the_selected_entry?=Подтвердите_удаление_выбранной_записи.
-Really_delete_the_%0_selected_entries?=Подтвердите_удаление_выбранных_%0_записей.
-Keep_merged_entry_only=Сохранить_только_объединенные_записи
-Keep_left=Сохранить_слева
-Keep_right=Сохранить_справа
-Old_entry=Старая_запись
-From_import=Из_импорта
-No_problems_found.=Ошибки_не_найдены.
-%0_problem(s)_found=Найдено_ошибок_:_%0
-Save_changes=Сохранить_изменения
-Discard_changes=Отменить_изменения
-Library_'%0'_has_changed.=БД_'%0'_изменена.
-Print_entry_preview=Предварительный_просмотр_записи_для_печати
-Copy_title=
-Copy_\\cite{BibTeX_key}=Копировать_\\цитировать{ключ_BibTeX}
-Copy_BibTeX_key_and_title=Копировать_ключ_и_заголовок_BibTeX
-File_rename_failed_for_%0_entries.=Ошибка_переименования_файла_для_%0_записи.
-Merged_BibTeX_source_code=Объединенный_исходный_код_BibTeX
-Invalid_DOI\:_'%0'.=Недопустимый_DOI-адрес\:_'%0'.
-should_start_with_a_name=должно_начинаться_с_имени
-should_end_with_a_name=должно_заканчиваться_именем
-unexpected_closing_curly_bracket=непредвиденная_закрывающая_фигурная_скобка
-unexpected_opening_curly_bracket=непредвиденная_открывающая_фигурная_скобка
-capital_letters_are_not_masked_using_curly_brackets_{}=Прописные_не_помечены_с_помощью_фигурных_скобок_{}
-should_contain_a_four_digit_number=должно_содержать_четырехзначное_число
-should_contain_a_valid_page_number_range=должно_содержать_допустимый_диапазон_номеров_страниц
+Added\ new\ '%0'\ entry.=Добавлена новая запись '%0'.
+Multiple\ entries\ selected.\ Do\ you\ want\ to\ change\ the\ type\ of\ all\ these\ to\ '%0'?=Выбрано несколько записей. Изменить тип всех этих записей на '%0'?
+Changed\ type\ to\ '%0'\ for=Тип с изменением на '%0' для
+Really\ delete\ the\ selected\ entry?=Подтвердите удаление выбранной записи.
+Really\ delete\ the\ %0\ selected\ entries?=Подтвердите удаление выбранных %0 записей.
+Keep\ merged\ entry\ only=Сохранить только объединенные записи
+Keep\ left=Сохранить слева
+Keep\ right=Сохранить справа
+Old\ entry=Старая запись
+From\ import=Из импорта
+No\ problems\ found.=Ошибки не найдены.
+%0\ problem(s)\ found=Найдено ошибок : %0
+Save\ changes=Сохранить изменения
+Discard\ changes=Отменить изменения
+Library\ '%0'\ has\ changed.=БД '%0' изменена.
+Print\ entry\ preview=Предварительный просмотр записи для печати
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=Копировать \\цитировать{ключ BibTeX}
+Copy\ BibTeX\ key\ and\ title=Копировать ключ и заголовок BibTeX
+File\ rename\ failed\ for\ %0\ entries.=Ошибка переименования файла для %0 записи.
+Merged\ BibTeX\ source\ code=Объединенный исходный код BibTeX
+Invalid\ DOI\:\ '%0'.=Недопустимый DOI-адрес: '%0'.
+should\ start\ with\ a\ name=должно начинаться с имени
+should\ end\ with\ a\ name=должно заканчиваться именем
+unexpected\ closing\ curly\ bracket=непредвиденная закрывающая фигурная скобка
+unexpected\ opening\ curly\ bracket=непредвиденная открывающая фигурная скобка
+capital\ letters\ are\ not\ masked\ using\ curly\ brackets\ {}=Прописные не помечены с помощью фигурных скобок {}
+should\ contain\ a\ four\ digit\ number=должно содержать четырехзначное число
+should\ contain\ a\ valid\ page\ number\ range=должно содержать допустимый диапазон номеров страниц
 Filled=Заполнено
-Field_is_missing=Отсутствует_поле
-Search_%0=Поиск_%0
+Field\ is\ missing=Отсутствует поле
+Search\ %0=Поиск %0
 
-Search_results_in_all_libraries_for_%0=Результаты_поиска_во_всех_БД_для_%0
-Search_results_in_library_%0_for_%1=Результаты_поиска_в_БД_%0_для_%1
-Search_globally=Глобальный_поиск
-No_results_found.=Результаты_не_найдены.
-Found_%0_results.=Найдено_%0_результатов.
-plain_text=обычный_текст
-This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>=Поиск_содержит_записи,_в_которых_любое_поле_содержит_регулярное_выражение_<b>%0</b>
-This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>=Поиск_содержит_записи,_в_которых_любое_поле_содержит_условие_<b>%0</b>
-This_search_contains_entries_in_which=Поиск_содержит_записи,_в_которых
+Search\ results\ in\ all\ libraries\ for\ %0=Результаты поиска во всех БД для %0
+Search\ results\ in\ library\ %0\ for\ %1=Результаты поиска в БД %0 для %1
+Search\ globally=Глобальный поиск
+No\ results\ found.=Результаты не найдены.
+Found\ %0\ results.=Найдено %0 результатов.
+plain\ text=обычный текст
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ regular\ expression\ <b>%0</b>=Поиск содержит записи, в которых любое поле содержит регулярное выражение <b>%0</b>
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ term\ <b>%0</b>=Поиск содержит записи, в которых любое поле содержит условие <b>%0</b>
+This\ search\ contains\ entries\ in\ which=Поиск содержит записи, в которых
 
-Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.=Не_удалось_выполнить_автоопределение_установки_OpenOffice/LibreOffice._Укажите_каталог_установки_вручную.
-JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>=Поддержка_полей_'ps'_или_'pdf'_в_JabRef_отключена.<br>Теперь_ссылки_на_файлы_сохраняются_в_поле_'file',_а_файлы_хранятся_во_внешнем_каталоге_файлов.<br>Для_использования_этих_возможностей_необходимо_обновить_ссылки_на_файлы_в_JabRef.<br><br>
-This_library_uses_outdated_file_links.=Эта_БД_использует_устаревшие_ссылки_на_файлы.
+Unable\ to\ autodetect\ OpenOffice/LibreOffice\ installation.\ Please\ choose\ the\ installation\ directory\ manually.=Не удалось выполнить автоопределение установки OpenOffice/LibreOffice. Укажите каталог установки вручную.
+JabRef\ no\ longer\ supports\ 'ps'\ or\ 'pdf'\ fields.<br>File\ links\ are\ now\ stored\ in\ the\ 'file'\ field\ and\ files\ are\ stored\ in\ an\ external\ file\ directory.<br>To\ make\ use\ of\ this\ feature,\ JabRef\ needs\ to\ upgrade\ file\ links.<br><br>=Поддержка полей 'ps' или 'pdf' в JabRef отключена.<br>Теперь ссылки на файлы сохраняются в поле 'file', а файлы хранятся во внешнем каталоге файлов.<br>Для использования этих возможностей необходимо обновить ссылки на файлы в JabRef.<br><br>
+This\ library\ uses\ outdated\ file\ links.=Эта БД использует устаревшие ссылки на файлы.
 
-Clear_search=Очистить_поиск
-Close_library=Закрыть_БД
-Close_entry_editor=Закрыть_редактор_записей
-Decrease_table_font_size=Уменьшить_шрифт_в_таблице
-Entry_editor,_next_entry=Редактор_записей,_следующая_запись
-Entry_editor,_next_panel=Редактор_записей,_следующая_панель
-Entry_editor,_next_panel_2=Редактор_записей,_следующая_панель_2
-Entry_editor,_previous_entry=Редактор_записей,_предыдущая_запись
-Entry_editor,_previous_panel=Редактор_записей,_предыдущая_панель
-Entry_editor,_previous_panel_2=Редактор_записей,_предыдущая_панель_2
-File_list_editor,_move_entry_down=Редактор_списка_файлов,_переместить_запись_вниз
-File_list_editor,_move_entry_up=Редактор_списка_файлов,_переместить_запись_вверх
-Focus_entry_table=Поместить_курсор_в_таблицу_записей
-Import_into_current_library=Импорт_в_текущую_БД
-Import_into_new_library=Импорт_в_новую_БД
-Increase_table_font_size=Увеличить_шрифт_в_таблице
-New_article=Создать_статью
-New_book=Создать_книгу
-New_entry=Создать_запись
-New_from_plain_text=Создать_из_неформатированного_текста
-New_inbook=Новая_часть_книги_(inbook)
-New_mastersthesis=Новая_магистерская_дисс.
-New_phdthesis=Новая_докторская_дисс.
-New_proceedings=Новые_протоколы
-New_unpublished=Новое_неопубликованное
-Next_tab=Следующая_вкладка
-Preamble_editor,_store_changes=Редактор_преамбул,_сохранить_изменения
-Previous_tab=Предыдущая_вкладка
-Push_to_application=Передать_в_приложение
-Refresh_OpenOffice/LibreOffice=Обновить_OpenOffice/LibreOffice
-Resolve_duplicate_BibTeX_keys=Разрешение_дубликатов_ключей_BibTeX
-Save_all=Сохранить_все
-String_dialog,_add_string=Диалоговое_окно_строк,_добавить_строку
-String_dialog,_remove_string=Диалоговое_окно_строк,_удалить_строку
-Synchronize_files=Синхронизировать_файлы
-Unabbreviate=Отменить_сокращения
-should_contain_a_protocol=должно_содержать_протокол
-Copy_preview=Копировать_предварительный_просмотр
-Automatically_setting_file_links=Автоуказание_ссылок_на_файлы
-Regenerating_BibTeX_keys_according_to_metadata=Восстановление_ключей_BibTeX_на_основе_метаданных
-No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys=В_файле_BIB_отсутствуют_метаданные._Восстановление_ключей_BibTeX_невозможно.
-Regenerate_all_keys_for_the_entries_in_a_BibTeX_file=Восстановление_всех_ключей_для_записей_в_файле_BibTeX
-Show_debug_level_messages=Показать_сообщения_об_отладке
-Default_bibliography_mode=Режим_библиографии_по_умолчанию
-New_%0_library_created.=Создана_новая_БД_%0.
-Show_only_preferences_deviating_from_their_default_value=Показать_только_пользовательские_настройки,_отличающиеся_от_значений_по_умолчанию
-default=по_умолчанию
+Clear\ search=Очистить поиск
+Close\ library=Закрыть БД
+Close\ entry\ editor=Закрыть редактор записей
+Decrease\ table\ font\ size=Уменьшить шрифт в таблице
+Entry\ editor,\ next\ entry=Редактор записей, следующая запись
+Entry\ editor,\ next\ panel=Редактор записей, следующая панель
+Entry\ editor,\ next\ panel\ 2=Редактор записей, следующая панель 2
+Entry\ editor,\ previous\ entry=Редактор записей, предыдущая запись
+Entry\ editor,\ previous\ panel=Редактор записей, предыдущая панель
+Entry\ editor,\ previous\ panel\ 2=Редактор записей, предыдущая панель 2
+File\ list\ editor,\ move\ entry\ down=Редактор списка файлов, переместить запись вниз
+File\ list\ editor,\ move\ entry\ up=Редактор списка файлов, переместить запись вверх
+Focus\ entry\ table=Поместить курсор в таблицу записей
+Import\ into\ current\ library=Импорт в текущую БД
+Import\ into\ new\ library=Импорт в новую БД
+Increase\ table\ font\ size=Увеличить шрифт в таблице
+New\ article=Создать статью
+New\ book=Создать книгу
+New\ entry=Создать запись
+New\ from\ plain\ text=Создать из неформатированного текста
+New\ inbook=Новая часть книги (inbook)
+New\ mastersthesis=Новая магистерская дисс.
+New\ phdthesis=Новая докторская дисс.
+New\ proceedings=Новые протоколы
+New\ unpublished=Новое неопубликованное
+Next\ tab=Следующая вкладка
+Preamble\ editor,\ store\ changes=Редактор преамбул, сохранить изменения
+Previous\ tab=Предыдущая вкладка
+Push\ to\ application=Передать в приложение
+Refresh\ OpenOffice/LibreOffice=Обновить OpenOffice/LibreOffice
+Resolve\ duplicate\ BibTeX\ keys=Разрешение дубликатов ключей BibTeX
+Save\ all=Сохранить все
+String\ dialog,\ add\ string=Диалоговое окно строк, добавить строку
+String\ dialog,\ remove\ string=Диалоговое окно строк, удалить строку
+Synchronize\ files=Синхронизировать файлы
+Unabbreviate=Отменить сокращения
+should\ contain\ a\ protocol=должно содержать протокол
+Copy\ preview=Копировать предварительный просмотр
+Automatically\ setting\ file\ links=Автоуказание ссылок на файлы
+Regenerating\ BibTeX\ keys\ according\ to\ metadata=Восстановление ключей BibTeX на основе метаданных
+No\ meta\ data\ present\ in\ BIB\ file.\ Cannot\ regenerate\ BibTeX\ keys=В файле BIB отсутствуют метаданные. Восстановление ключей BibTeX невозможно.
+Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=Восстановление всех ключей для записей в файле BibTeX
+Show\ debug\ level\ messages=Показать сообщения об отладке
+Default\ bibliography\ mode=Режим библиографии по умолчанию
+New\ %0\ library\ created.=Создана новая БД %0.
+Show\ only\ preferences\ deviating\ from\ their\ default\ value=Показать только пользовательские настройки, отличающиеся от значений по умолчанию
+default=по умолчанию
 key=ключ
 type=тип
 value=значение
-Show_preferences=Показать_пользовательские_настройки
-Save_actions=Действия_при_сохранении
-Enable_save_actions=Включить_действия_при_сохранении
+Show\ preferences=Показать пользовательские настройки
+Save\ actions=Действия при сохранении
+Enable\ save\ actions=Включить действия при сохранении
 
-Other_fields=Прочие_поля
-Show_remaining_fields=Показать_оставшиеся_поля
+Other\ fields=Прочие поля
+Show\ remaining\ fields=Показать оставшиеся поля
 
-link_should_refer_to_a_correct_file_path=Ссылка_должна_указывать_на_корректный_путь_к_файлу
-abbreviation_detected=обнаружены_сокращения
-wrong_entry_type_as_proceedings_has_page_numbers=неверный_тип_записи,_так_как_протоколы_имеют_номера_страниц
-Abbreviate_journal_names=Сокращения_названий_журналов
-Abbreviating...=Создание_сокращений...
-Abbreviation_%s_for_journal_%s_already_defined.=
-Abbreviation_cannot_be_empty=
-Duplicated_Journal_Abbreviation=
-Duplicated_Journal_File=
-Error_Occurred=
-Journal_file_%s_already_added=
-Name_cannot_be_empty=
+link\ should\ refer\ to\ a\ correct\ file\ path=Ссылка должна указывать на корректный путь к файлу
+abbreviation\ detected=обнаружены сокращения
+wrong\ entry\ type\ as\ proceedings\ has\ page\ numbers=неверный тип записи, так как протоколы имеют номера страниц
+Abbreviate\ journal\ names=Сокращения названий журналов
+Abbreviating...=Создание сокращений...
+Abbreviation\ %s\ for\ journal\ %s\ already\ defined.=
+Abbreviation\ cannot\ be\ empty=
+Duplicated\ Journal\ Abbreviation=
+Duplicated\ Journal\ File=
+Error\ Occurred=
+Journal\ file\ %s\ already\ added=
+Name\ cannot\ be\ empty=
 
-Adding_fetched_entries=Добавление_записей_из_выборки
-Display_keywords_appearing_in_ALL_entries=Отображение_ключевых_слов,_относящихся_ко_ВСЕМ_записям
-Display_keywords_appearing_in_ANY_entry=Отображение_ключевых_слов,_относящихся_к_КАКОЙ-ЛИБО_записи
-Fetching_entries_from_Inspire=Выборка_записей_из_Inspire
-None_of_the_selected_entries_have_titles.=
-None_of_the_selected_entries_have_BibTeX_keys.=Для_выбранных_записей_отсутствуют_ключи_BibTeX.
-Unabbreviate_journal_names=Полные_названия_журналов
-Unabbreviating...=Отмена_сокращений...
+Adding\ fetched\ entries=Добавление записей из выборки
+Display\ keywords\ appearing\ in\ ALL\ entries=Отображение ключевых слов, относящихся ко ВСЕМ записям
+Display\ keywords\ appearing\ in\ ANY\ entry=Отображение ключевых слов, относящихся к КАКОЙ-ЛИБО записи
+Fetching\ entries\ from\ Inspire=Выборка записей из Inspire
+None\ of\ the\ selected\ entries\ have\ titles.=
+None\ of\ the\ selected\ entries\ have\ BibTeX\ keys.=Для выбранных записей отсутствуют ключи BibTeX.
+Unabbreviate\ journal\ names=Полные названия журналов
+Unabbreviating...=Отмена сокращений...
 Usage=Использование
 
 
-Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.=Пометка_{}_скобками_акронимов,_названий_месяцев_и_стран_для_соблюдения_регистра_их_написания.
-Are_you_sure_you_want_to_reset_all_settings_to_default_values?=Подтвердите_сброс_всех_настроек_на_значения_по_умолчанию.
-Reset_preferences=Сброс_пользовательских_настроек
-Ill-formed_entrytype_comment_in_BIB_file=Неверный_формат_комментария_для_типа_записи_в_файле_BIB
+Adds\ {}\ brackets\ around\ acronyms,\ month\ names\ and\ countries\ to\ preserve\ their\ case.=Пометка {} скобками акронимов, названий месяцев и стран для соблюдения регистра их написания.
+Are\ you\ sure\ you\ want\ to\ reset\ all\ settings\ to\ default\ values?=Подтвердите сброс всех настроек на значения по умолчанию.
+Reset\ preferences=Сброс пользовательских настроек
+Ill-formed\ entrytype\ comment\ in\ BIB\ file=Неверный формат комментария для типа записи в файле BIB
 
-Move_linked_files_to_default_file_directory_%0=Переместить_связанные_файлы_в_каталог_файлов_по_умолчанию_%0
+Move\ linked\ files\ to\ default\ file\ directory\ %0=Переместить связанные файлы в каталог файлов по умолчанию %0
 
-Clipboard=Буфер_обмена
-Could_not_paste_entry_as_text\:=Не_удалось_вставить_запись_как_текст:
-Do_you_still_want_to_continue?=Продолжить?
-This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:=Это_действие_изменит_минимум_одну_запись_в_каждом_из_следующих_полей:
-This_could_cause_undesired_changes_to_your_entries.=Это_может_привести_к_нежелательным_изменениям_ваших_записей.
-Run_field_formatter\:=Запуск_средства_форматирования_полей:
-Table_font_size_is_%0=Размер_шрифта_в_таблице:_%0
-%0_import_canceled=Импорт_%0_отменен
-Internal_style=Встроенный_стиль
-Add_style_file=Добавить_файл_стиля
-Are_you_sure_you_want_to_remove_the_style?=Подтвердите_удаление_стиля.
-Current_style_is_'%0'=Текущий_стиль:_'%0'
-Remove_style=Удалить_стиль
-Select_one_of_the_available_styles_or_add_a_style_file_from_disk.=Выберите_один_из_доступных_стилей_или_добавьте_файл_стиля_с_диска.
-You_must_select_a_valid_style_file.=Необходимо_выбрать_допустимый_файл_стиля.
+Clipboard=Буфер обмена
+Could\ not\ paste\ entry\ as\ text\:=Не удалось вставить запись как текст:
+Do\ you\ still\ want\ to\ continue?=Продолжить?
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=Это действие изменит минимум одну запись в каждом из следующих полей:
+This\ could\ cause\ undesired\ changes\ to\ your\ entries.=Это может привести к нежелательным изменениям ваших записей.
+Run\ field\ formatter\:=Запуск средства форматирования полей:
+Table\ font\ size\ is\ %0=Размер шрифта в таблице: %0
+%0\ import\ canceled=Импорт %0 отменен
+Internal\ style=Встроенный стиль
+Add\ style\ file=Добавить файл стиля
+Are\ you\ sure\ you\ want\ to\ remove\ the\ style?=Подтвердите удаление стиля.
+Current\ style\ is\ '%0'=Текущий стиль: '%0'
+Remove\ style=Удалить стиль
+Select\ one\ of\ the\ available\ styles\ or\ add\ a\ style\ file\ from\ disk.=Выберите один из доступных стилей или добавьте файл стиля с диска.
+You\ must\ select\ a\ valid\ style\ file.=Необходимо выбрать допустимый файл стиля.
 Reload=Перезагрузка
 
 Capitalize=Капитализация
-Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.=Капитализировать_все_слова,_написание_артиклей,_предлогов_и_союзов_строчными.
-Capitalize_the_first_word,_changes_other_words_to_lower_case.=Капитализация_первого_слова,_остальные_слова_пишутся_строчными.
-Changes_all_letters_to_lower_case.=Изменение_регистра_всех_знаков_на_нижний.
-Changes_all_letters_to_upper_case.=Изменение_регистра_всех_знаков_на_верхний.
-Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.=Изменение_первой_буквы_всех_слов_на_прописные,_остальные_знаки_пишутся_строчными.
-Cleans_up_LaTeX_code.=Очистка_кода_LaTeX.
-Converts_HTML_code_to_LaTeX_code.=Преобразование_кода_HTML_в_код_LaTeX.
-Converts_HTML_code_to_Unicode.=Преобразование_кода_HTML_в_Юникод.
-Converts_LaTeX_encoding_to_Unicode_characters.=Преобразование_кодировки_LaTeX_в_символы_Юникода.
-Converts_Unicode_characters_to_LaTeX_encoding.=Преобразование_символов_Юникода_в_кодировку_LaTeX.
-Converts_ordinals_to_LaTeX_superscripts.=Преобразование_порядковых_числительных_в_надстрочник_LaTeX.
-Converts_units_to_LaTeX_formatting.=Преобразование_единиц_в_формат_LaTeX.
-HTML_to_LaTeX=HTML_в_LaTeX
-LaTeX_cleanup=Очистка_LaTeX
-LaTeX_to_Unicode=LaTeX_в_Юникод
-Lower_case=Строчные
-Minify_list_of_person_names=Сокращение_списка_имен_лиц
-Normalize_date=Нормализовать_дату
-Normalize_month=Нормализовать_месяц
-Normalize_month_to_BibTeX_standard_abbreviation.=Нормализовать_месяц_по_стандартному_сокращению_BibTeX
-Normalize_names_of_persons=Нормализовать_личные_имена
-Normalize_page_numbers=Нормализовать_номера_страниц
-Normalize_pages_to_BibTeX_standard.=Нормализовать_страницы_по_стандарту_BibTeX.
-Normalizes_lists_of_persons_to_the_BibTeX_standard.=Нормализовать_список_лиц_по_стандарту_BibTeX.
-Normalizes_the_date_to_ISO_date_format.=Нормализовать_дату_по_формату_дат_ISO.
-Ordinals_to_LaTeX_superscript=Порядковые_числительные_в_надстрочник_LaTeX
-Protect_terms=Защита_терминов
-Remove_enclosing_braces=Удалить_окружающие_скобки
-Removes_braces_encapsulating_the_complete_field_content.=Удаление_скобок,_заключающих_все_содержимое_поля.
-Sentence_case=Как_в_предложении
-Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".=Сокращение_списка_лиц,_если_существует_более_2_лиц_для_\"et_al.\".
-Title_case=Заглавные
-Unicode_to_LaTeX=Юникод_в_LaTeX
-Units_to_LaTeX=Единицы_в_LaTeX
-Upper_case=Прописные
-Does_nothing.=Не_выполнять_действий.
+Capitalize\ all\ words,\ but\ converts\ articles,\ prepositions,\ and\ conjunctions\ to\ lower\ case.=Капитализировать все слова, написание артиклей, предлогов и союзов строчными.
+Capitalize\ the\ first\ word,\ changes\ other\ words\ to\ lower\ case.=Капитализация первого слова, остальные слова пишутся строчными.
+Changes\ all\ letters\ to\ lower\ case.=Изменение регистра всех знаков на нижний.
+Changes\ all\ letters\ to\ upper\ case.=Изменение регистра всех знаков на верхний.
+Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=Изменение первой буквы всех слов на прописные, остальные знаки пишутся строчными.
+Cleans\ up\ LaTeX\ code.=Очистка кода LaTeX.
+Converts\ HTML\ code\ to\ LaTeX\ code.=Преобразование кода HTML в код LaTeX.
+Converts\ HTML\ code\ to\ Unicode.=Преобразование кода HTML в Юникод.
+Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=Преобразование кодировки LaTeX в символы Юникода.
+Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=Преобразование символов Юникода в кодировку LaTeX.
+Converts\ ordinals\ to\ LaTeX\ superscripts.=Преобразование порядковых числительных в надстрочник LaTeX.
+Converts\ units\ to\ LaTeX\ formatting.=Преобразование единиц в формат LaTeX.
+HTML\ to\ LaTeX=HTML в LaTeX
+LaTeX\ cleanup=Очистка LaTeX
+LaTeX\ to\ Unicode=LaTeX в Юникод
+Lower\ case=Строчные
+Minify\ list\ of\ person\ names=Сокращение списка имен лиц
+Normalize\ date=Нормализовать дату
+Normalize\ month=Нормализовать месяц
+Normalize\ month\ to\ BibTeX\ standard\ abbreviation.=Нормализовать месяц по стандартному сокращению BibTeX
+Normalize\ names\ of\ persons=Нормализовать личные имена
+Normalize\ page\ numbers=Нормализовать номера страниц
+Normalize\ pages\ to\ BibTeX\ standard.=Нормализовать страницы по стандарту BibTeX.
+Normalizes\ lists\ of\ persons\ to\ the\ BibTeX\ standard.=Нормализовать список лиц по стандарту BibTeX.
+Normalizes\ the\ date\ to\ ISO\ date\ format.=Нормализовать дату по формату дат ISO.
+Ordinals\ to\ LaTeX\ superscript=Порядковые числительные в надстрочник LaTeX
+Protect\ terms=Защита терминов
+Remove\ enclosing\ braces=Удалить окружающие скобки
+Removes\ braces\ encapsulating\ the\ complete\ field\ content.=Удаление скобок, заключающих все содержимое поля.
+Sentence\ case=Как в предложении
+Shortens\ lists\ of\ persons\ if\ there\ are\ more\ than\ 2\ persons\ to\ "et\ al.".=Сокращение списка лиц, если существует более 2 лиц для \"et al.\".
+Title\ case=Заглавные
+Unicode\ to\ LaTeX=Юникод в LaTeX
+Units\ to\ LaTeX=Единицы в LaTeX
+Upper\ case=Прописные
+Does\ nothing.=Не выполнять действий.
 Identity=Идентичность
-Clears_the_field_completely.=Полная_очистка_поля.
-Directory_not_found=Каталог_не_найден
-Main_file_directory_not_set\!=Не_указан_основной_каталог_файлов!
-This_operation_requires_exactly_one_item_to_be_selected.=Для_этой_операции_необходимо_выбрать_только_одну_запись.
-Importing_in_%0_format=Импорт_в_формате_%0
-Female_name=Имя_женского_рода
-Female_names=Имена_женского_рода
-Male_name=Имя_мужского_рода
-Male_names=Имена_мужского_рода
-Mixed_names=Смешанные_имена
-Neuter_name=Имя_среднего_рода
-Neuter_names=Имена_среднего_рода
+Clears\ the\ field\ completely.=Полная очистка поля.
+Directory\ not\ found=Каталог не найден
+Main\ file\ directory\ not\ set\!=Не указан основной каталог файлов!
+This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=Для этой операции необходимо выбрать только одну запись.
+Importing\ in\ %0\ format=Импорт в формате %0
+Female\ name=Имя женского рода
+Female\ names=Имена женского рода
+Male\ name=Имя мужского рода
+Male\ names=Имена мужского рода
+Mixed\ names=Смешанные имена
+Neuter\ name=Имя среднего рода
+Neuter\ names=Имена среднего рода
 
-Determined_%0_for_%1_entries=
-Look_up_%0=
-Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3=
+Determined\ %0\ for\ %1\ entries=
+Look\ up\ %0=
+Looking\ up\ %0...\ -\ entry\ %1\ out\ of\ %2\ -\ found\ %3=
 
-Audio_CD=Аудио_CD
-British_patent=Патент_(Британия)
-British_patent_request=Запрос_патента_(Британия)
-Candidate_thesis=Кандидатская_диссертация
+Audio\ CD=Аудио CD
+British\ patent=Патент (Британия)
+British\ patent\ request=Запрос патента (Британия)
+Candidate\ thesis=Кандидатская диссертация
 Collaborator=Участник
 Column=Столбец
 Compiler=Составитель
 Continuator=Продолжатель
-Data_CD=CD_с_данными
+Data\ CD=CD с данными
 Editor=Редактор
-European_patent=Патент_(Европа)
-European_patent_request=Запрос_патента_(Европа)
+European\ patent=Патент (Европа)
+European\ patent\ request=Запрос патента (Европа)
 Founder=Основатель
-French_patent=Патент_(Франция)
-French_patent_request=Запрос_патента_(Франция)
-German_patent=Патент_(Германия)
-German_patent_request=Запрос_патента_(Германия)
+French\ patent=Патент (Франция)
+French\ patent\ request=Запрос патента (Франция)
+German\ patent=Патент (Германия)
+German\ patent\ request=Запрос патента (Германия)
 Line=Строка
-Master's_thesis=Магистерская_диссертация
+Master's\ thesis=Магистерская диссертация
 Page=Страница
 Paragraph=Параграф
 Patent=Патент
-Patent_request=Запрос_патента
-PhD_thesis=Докторская_диссертация
+Patent\ request=Запрос патента
+PhD\ thesis=Докторская диссертация
 Redactor=Редактор-составитель
-Research_report=Отчет_о_НИР
+Research\ report=Отчет о НИР
 Reviser=Корректор
 Section=Раздел
-Software=Программное_обеспечение
-Technical_report=Технический_отчет
-U.S._patent=Патент_(США)
-U.S._patent_request=Запрос_патента_(США)
+Software=Программное обеспечение
+Technical\ report=Технический отчет
+U.S.\ patent=Патент (США)
+U.S.\ patent\ request=Запрос патента (США)
 Verse=Стихотворение
 
-change_entries_of_group=изменить_записи_в_группе
-odd_number_of_unescaped_'\#'=нечетное_число_несброшенных_'#'
+change\ entries\ of\ group=изменить записи в группе
+odd\ number\ of\ unescaped\ '\#'=нечетное число несброшенных '#'
 
-Plain_text=Обычный_текст
-Show_diff=Показать_разницу
+Plain\ text=Обычный текст
+Show\ diff=Показать разницу
 character=знак
 word=слово
-Show_symmetric_diff=Показать_симметрическую_разность
-Copy_Version=
+Show\ symmetric\ diff=Показать симметрическую разность
+Copy\ Version=
 Developers=
 Authors=
 License=
 
-HTML_encoded_character_found=Обнаружен_символ_в_кодировке_HTML
-booktitle_ends_with_'conference_on'=заголовок_книги_оканчивается_на_'conference_on'_('конференция_по')
+HTML\ encoded\ character\ found=Обнаружен символ в кодировке HTML
+booktitle\ ends\ with\ 'conference\ on'=заголовок книги оканчивается на 'conference on' ('конференция по')
 
-All_external_files=Все_внешние_файлы
+All\ external\ files=Все внешние файлы
 
-OpenOffice/LibreOffice_integration=Интеграция_с_OpenOffice/LibreOffice
+OpenOffice/LibreOffice\ integration=Интеграция с OpenOffice/LibreOffice
 
-incorrect_control_digit=неверное_контрольное_число
-incorrect_format=неверный_формат
-Copied_version_to_clipboard=Версия,_скопированная_в_буфер_обмена
+incorrect\ control\ digit=неверное контрольное число
+incorrect\ format=неверный формат
+Copied\ version\ to\ clipboard=Версия, скопированная в буфер обмена
 
-BibTeX_key=Ключ_BibTeX
+BibTeX\ key=Ключ BibTeX
 Message=Сообщение
 
 
-MathSciNet_Review=
-Reset_Bindings=
+MathSciNet\ Review=
+Reset\ Bindings=
 
-Decryption_not_supported.=Дешифрование_не_поддерживается
+Decryption\ not\ supported.=Дешифрование не поддерживается
 
-Cleared_'%0'_for_%1_entries=Очищено_'%0'_для_%1_записей
-Set_'%0'_to_'%1'_for_%2_entries=Установить_'%0'_'%1'_для_%2_записей
-Toggled_'%0'_for_%1_entries=Изменение_'%0'_для_%1_записей
+Cleared\ '%0'\ for\ %1\ entries=Очищено '%0' для %1 записей
+Set\ '%0'\ to\ '%1'\ for\ %2\ entries=Установить '%0' '%1' для %2 записей
+Toggled\ '%0'\ for\ %1\ entries=Изменение '%0' для %1 записей
 
-Check_for_updates=Проверить_обновления
-Download_update=Загрузить_обновления
-New_version_available=Доступна_новая_версия
-Installed_version=Установленная_версия
-Remind_me_later=Напомнить_позже
-Ignore_this_update=Игнорировать_это_обновление
-Could_not_connect_to_the_update_server.=Не_удалось_подключиться_к_серверу_обновлений.
-Please_try_again_later_and/or_check_your_network_connection.=Повторите_попытку_позже_и/или_проверьте_настройки_сетевого_подключения.
-To_see_what_is_new_view_the_changelog.=Для_просмотра_сведений_об_изменениях_см._журнал_изменений.
-A_new_version_of_JabRef_has_been_released.=Выпущена_новая_версия_JabRef.
-JabRef_is_up-to-date.=Установлена_актуальная_версия_JabRef.
-Latest_version=Последняя_версия
-Online_help_forum=Форум_онлайн-поддержки
-Custom=Определено_пользователем
+Check\ for\ updates=Проверить обновления
+Download\ update=Загрузить обновления
+New\ version\ available=Доступна новая версия
+Installed\ version=Установленная версия
+Remind\ me\ later=Напомнить позже
+Ignore\ this\ update=Игнорировать это обновление
+Could\ not\ connect\ to\ the\ update\ server.=Не удалось подключиться к серверу обновлений.
+Please\ try\ again\ later\ and/or\ check\ your\ network\ connection.=Повторите попытку позже и/или проверьте настройки сетевого подключения.
+To\ see\ what\ is\ new\ view\ the\ changelog.=Для просмотра сведений об изменениях см. журнал изменений.
+A\ new\ version\ of\ JabRef\ has\ been\ released.=Выпущена новая версия JabRef.
+JabRef\ is\ up-to-date.=Установлена актуальная версия JabRef.
+Latest\ version=Последняя версия
+Online\ help\ forum=Форум онлайн-поддержки
+Custom=Определено пользователем
 
-Export_cited=Экспорт_цитированного
-Unable_to_generate_new_library=Не_удалось_создать_новую_БД
+Export\ cited=Экспорт цитированного
+Unable\ to\ generate\ new\ library=Не удалось создать новую БД
 
-Open_console=Открыть_консоль
-Use_default_terminal_emulator=Использовать_эмуляцию_терминала_по_умолчанию
-Execute_command=Выполнить_команду
-Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.=Примечание._Используйте_подстановочный_знак_%0_для_указания_расположения_открытой_БД.
-Executing_command_\"%0\"...=Выполнение_команды_\"%0\"...
-Error_occured_while_executing_the_command_\"%0\".=Ошибка_при_выполнении_команды_\"%0\".
-Reformat_ISSN=Переформатировать_ISSN
+Open\ console=Открыть консоль
+Use\ default\ terminal\ emulator=Использовать эмуляцию терминала по умолчанию
+Execute\ command=Выполнить команду
+Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=Примечание. Используйте подстановочный знак %0 для указания расположения открытой БД.
+Executing\ command\ \"%0\"...=Выполнение команды \"%0\"...
+Error\ occured\ while\ executing\ the\ command\ \"%0\".=Ошибка при выполнении команды \"%0\".
+Reformat\ ISSN=Переформатировать ISSN
 
-Countries_and_territories_in_English=Страны_и_территории_на_английском
-Electrical_engineering_terms=Термины_электротехники
+Countries\ and\ territories\ in\ English=Страны и территории на английском
+Electrical\ engineering\ terms=Термины электротехники
 Enabled=Включено
-Internal_list=Встроенный_список
-Manage_protected_terms_files=Управление_файлами_защищенных_терминов
-Months_and_weekdays_in_English=Месяцы_и_рабочие_дни_на_английском
-The_text_after_the_last_line_starting_with_\#_will_be_used=Будет_использован_текст_после_последней_строки,_начинающейся_с_#
-Add_protected_terms_file=Добавить_файл_с_защищенными_терминами
-Are_you_sure_you_want_to_remove_the_protected_terms_file?=Файл_с_защищенными_терминами_будет_удален._Продолжить?
-Remove_protected_terms_file=Удалить_файл_с_защищенными_терминами
-Add_selected_text_to_list=Добавить_выбранный_текст_в_список
-Add_{}_around_selected_text=Поместить_выбранный_текст_в_{}
-Format_field=Форматировать_поле
-New_protected_terms_file=Создать_файл_с_защищенными_терминами
-change_field_%0_of_entry_%1_from_%2_to_%3=изменить_поле_%0_записи_%1_с_%2_на_%3
-change_key_from_%0_to_%1=изменить_ключ_с_%0_на_%1
-change_string_content_%0_to_%1=изменить_содержимое_строки_%0_на_%1
-change_string_name_%0_to_%1=изменить_имя_строки_%0_на_%1
-change_type_of_entry_%0_from_%1_to_%2=изменить_тип_записи_%0_с_%1_на_%2
-insert_entry_%0=вставить_запись_%0
-insert_string_%0=вставить_строку_%0
-remove_entry_%0=удалить_запись_%0
-remove_string_%0=удалить_строку_%0
-undefined=не_определено
-Cannot_get_info_based_on_given_%0\:_%1=Не_удалось_получить_сведения_на_основе_заданного_%0:_%1
-Get_BibTeX_data_from_%0=Получение_данных_BibTeX_из_%0
-No_%0_found=Не_найдены_%0
-Entry_from_%0=Запись_из_%0
-Merge_entry_with_%0_information=Объединение_записи_со_сведениями_%0
-Updated_entry_with_info_from_%0=Обновленная_запись_со_сведениями_из_%0
+Internal\ list=Встроенный список
+Manage\ protected\ terms\ files=Управление файлами защищенных терминов
+Months\ and\ weekdays\ in\ English=Месяцы и рабочие дни на английском
+The\ text\ after\ the\ last\ line\ starting\ with\ \#\ will\ be\ used=Будет использован текст после последней строки, начинающейся с #
+Add\ protected\ terms\ file=Добавить файл с защищенными терминами
+Are\ you\ sure\ you\ want\ to\ remove\ the\ protected\ terms\ file?=Файл с защищенными терминами будет удален. Продолжить?
+Remove\ protected\ terms\ file=Удалить файл с защищенными терминами
+Add\ selected\ text\ to\ list=Добавить выбранный текст в список
+Add\ {}\ around\ selected\ text=Поместить выбранный текст в {}
+Format\ field=Форматировать поле
+New\ protected\ terms\ file=Создать файл с защищенными терминами
+change\ field\ %0\ of\ entry\ %1\ from\ %2\ to\ %3=изменить поле %0 записи %1 с %2 на %3
+change\ key\ from\ %0\ to\ %1=изменить ключ с %0 на %1
+change\ string\ content\ %0\ to\ %1=изменить содержимое строки %0 на %1
+change\ string\ name\ %0\ to\ %1=изменить имя строки %0 на %1
+change\ type\ of\ entry\ %0\ from\ %1\ to\ %2=изменить тип записи %0 с %1 на %2
+insert\ entry\ %0=вставить запись %0
+insert\ string\ %0=вставить строку %0
+remove\ entry\ %0=удалить запись %0
+remove\ string\ %0=удалить строку %0
+undefined=не определено
+Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=Не удалось получить сведения на основе заданного %0: %1
+Get\ BibTeX\ data\ from\ %0=Получение данных BibTeX из %0
+No\ %0\ found=Не найдены %0
+Entry\ from\ %0=Запись из %0
+Merge\ entry\ with\ %0\ information=Объединение записи со сведениями %0
+Updated\ entry\ with\ info\ from\ %0=Обновленная запись со сведениями из %0
 
-Add_existing_file=
-Create_new_list=
-Remove_list=
-Full_journal_name=
-Abbreviation_name=
+Add\ existing\ file=
+Create\ new\ list=
+Remove\ list=
+Full\ journal\ name=
+Abbreviation\ name=
 
-No_abbreviation_files_loaded=
+No\ abbreviation\ files\ loaded=
 
-Loading_built_in_lists=
+Loading\ built\ in\ lists=
 
-JabRef_built_in_list=
-IEEE_built_in_list=
+JabRef\ built\ in\ list=
+IEEE\ built\ in\ list=
 
-Event_log=
-We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.=
-Log_copied_to_clipboard.=
-Copy_Log=
-Clear_Log=
-Report_Issue=
-Issue_on_GitHub_successfully_reported.=
-Issue_report_successful=
-Your_issue_was_reported_in_your_browser.=
-The_log_and_exception_information_was_copied_to_your_clipboard.=
-Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.=
+Event\ log=
+We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef\'s\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=
+Log\ copied\ to\ clipboard.=
+Copy\ Log=
+Clear\ Log=
+Report\ Issue=
+Issue\ on\ GitHub\ successfully\ reported.=
+Issue\ report\ successful=
+Your\ issue\ was\ reported\ in\ your\ browser.=
+The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=
+Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=
 
 Connection=Подключение
 Connecting...=
 Host=Хост
 Port=Порт
-Library=База_данных
+Library=База данных
 User=Пользователь
 Connect=Подключение
-Connection_error=Ошибка_подключения
-Connection_to_%0_server_established.=Соединение_с_сервером_%0_установлено.
-Required_field_"%0"_is_empty.=Не_заполнено_обязательное_поле_\"%0\".
-%0_driver_not_available.=Драйвер_%0_недоступен.
-The_connection_to_the_server_has_been_terminated.=Соединение_с_сервером_было_прервано.
-Connection_lost.=Соединение_прервано.
-Reconnect=Повторное_подключение
-Work_offline=Работать_автономно
-Working_offline.=Работа_в_автономном_режиме.
-Update_refused.=Обновление_отклонено.
-Update_refused=Обновление_отклонено
-Local_entry=Локальная_запись
-Shared_entry=Запись_с_общим_доступом
-Update_could_not_be_performed_due_to_existing_change_conflicts.=Не_удалось_выполнить_обновление_из-за_существующих_конфликтов_изменений.
-You_are_not_working_on_the_newest_version_of_BibEntry.=Вы_используете_не_самую_последнюю_версию_BibEntry.
-Local_version\:_%0=Локальная_версия:_%0
-Shared_version\:_%0=Версия_с_общим_доступом:_%0
-Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.=Объедините_запись_с_общим_доступом_и_вашу_запись,_а_затем_нажмите_\"Объединение_записей\"_для_разрешения_этой_проблемы.
-Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?=При_отмене_этой_операции_ваши_изменения_не_будут_синхронизированы._Отменить_операцию?
-Shared_entry_is_no_longer_present=
-The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.=Текущая_рабочая_запись_BibEntry_удалена_на_стороне_общего_доступа.
-You_can_restore_the_entry_using_the_"Undo"_operation.=
-Remember_password?=
-You_are_already_connected_to_a_database_using_entered_connection_details.=
+Connection\ error=Ошибка подключения
+Connection\ to\ %0\ server\ established.=Соединение с сервером %0 установлено.
+Required\ field\ "%0"\ is\ empty.=Не заполнено обязательное поле \"%0\".
+%0\ driver\ not\ available.=Драйвер %0 недоступен.
+The\ connection\ to\ the\ server\ has\ been\ terminated.=Соединение с сервером было прервано.
+Connection\ lost.=Соединение прервано.
+Reconnect=Повторное подключение
+Work\ offline=Работать автономно
+Working\ offline.=Работа в автономном режиме.
+Update\ refused.=Обновление отклонено.
+Update\ refused=Обновление отклонено
+Local\ entry=Локальная запись
+Shared\ entry=Запись с общим доступом
+Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=Не удалось выполнить обновление из-за существующих конфликтов изменений.
+You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=Вы используете не самую последнюю версию BibEntry.
+Local\ version\:\ %0=Локальная версия: %0
+Shared\ version\:\ %0=Версия с общим доступом: %0
+Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=Объедините запись с общим доступом и вашу запись, а затем нажмите \"Объединение записей\" для разрешения этой проблемы.
+Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=При отмене этой операции ваши изменения не будут синхронизированы. Отменить операцию?
+Shared\ entry\ is\ no\ longer\ present=
+The\ BibEntry\ you\ currently\ work\ on\ has\ been\ deleted\ on\ the\ shared\ side.=Текущая рабочая запись BibEntry удалена на стороне общего доступа.
+You\ can\ restore\ the\ entry\ using\ the\ "Undo"\ operation.=
+Remember\ password?=
+You\ are\ already\ connected\ to\ a\ database\ using\ entered\ connection\ details.=
 
-Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?=Цитирование_записей_без_ключей_BibTeX_невозможно._Создать_ключи_сейчас?
-New_technical_report=
+Cannot\ cite\ entries\ without\ BibTeX\ keys.\ Generate\ keys\ now?=Цитирование записей без ключей BibTeX невозможно. Создать ключи сейчас?
+New\ technical\ report=
 
-%0_file=Файл_%0
-Custom_layout_file=Файл_макета_пользователя
-Protected_terms_file=Файл_с_защищенными_терминами
-Style_file=Файл_стиля
+%0\ file=Файл %0
+Custom\ layout\ file=Файл макета пользователя
+Protected\ terms\ file=Файл с защищенными терминами
+Style\ file=Файл стиля
 
-Open_OpenOffice/LibreOffice_connection=Установить_подключение_к_Open_OpenOffice/LibreOffice
-You_must_enter_at_least_one_field_name=Необходимо_ввести_минимум_одно_имя_поля
-Non-ASCII_encoded_character_found=Обнаружен_символ_не_в_кодировке_ASCII
-Toggle_web_search_interface=Переключение_интерфейса_веб-поиска
-Background_color_for_resolved_fields=Цвет_фона_для_полей_c_разрешенными_ошибками
-Color_code_for_resolved_fields=Цветовой_код_для_полей_с_разрешенными_ошибками
-%0_files_found=Найдено_файлов:_%0
-%0_of_%1=%0_из_%1
-One_file_found=Найден_один_файл
-The_import_finished_with_warnings\:=Импорт_завершен_с_предупреждениями:
-There_was_one_file_that_could_not_be_imported.=Существует_один_файл,_который_не_удалось_импортировать.
-There_were_%0_files_which_could_not_be_imported.=Существует_%0_файлов,_которые_не_удалось_импортировать.
+Open\ OpenOffice/LibreOffice\ connection=Установить подключение к Open OpenOffice/LibreOffice
+You\ must\ enter\ at\ least\ one\ field\ name=Необходимо ввести минимум одно имя поля
+Non-ASCII\ encoded\ character\ found=Обнаружен символ не в кодировке ASCII
+Toggle\ web\ search\ interface=Переключение интерфейса веб-поиска
+Background\ color\ for\ resolved\ fields=Цвет фона для полей c разрешенными ошибками
+Color\ code\ for\ resolved\ fields=Цветовой код для полей с разрешенными ошибками
+%0\ files\ found=Найдено файлов: %0
+%0\ of\ %1=%0 из %1
+One\ file\ found=Найден один файл
+The\ import\ finished\ with\ warnings\:=Импорт завершен с предупреждениями:
+There\ was\ one\ file\ that\ could\ not\ be\ imported.=Существует один файл, который не удалось импортировать.
+There\ were\ %0\ files\ which\ could\ not\ be\ imported.=Существует %0 файлов, которые не удалось импортировать.
 
-Migration_help_information=
-Entered_database_has_obsolete_structure_and_is_no_longer_supported.=
-However,_a_new_database_was_created_alongside_the_pre-3.6_one.=
-Click_here_to_learn_about_the_migration_of_pre-3.6_databases.=
-Opens_JabRef's_Facebook_page=
-Opens_JabRef's_blog=
-Opens_JabRef's_website=
-Opens_a_link_where_the_current_development_version_can_be_downloaded=
-See_what_has_been_changed_in_the_JabRef_versions=
-Referenced_BibTeX_key_does_not_exist=
-Finished_downloading_full_text_document_for_entry_%0.=
-Full_text_document_download_failed_for_entry_%0.=
-Look_up_full_text_documents=
-You_are_about_to_look_up_full_text_documents_for_%0_entries.=
-last_four_nonpunctuation_characters_should_be_numerals=
+Migration\ help\ information=
+Entered\ database\ has\ obsolete\ structure\ and\ is\ no\ longer\ supported.=
+However,\ a\ new\ database\ was\ created\ alongside\ the\ pre-3.6\ one.=
+Click\ here\ to\ learn\ about\ the\ migration\ of\ pre-3.6\ databases.=
+Opens\ JabRef's\ Facebook\ page=
+Opens\ JabRef's\ blog=
+Opens\ JabRef's\ website=
+Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=
+See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=
+Referenced\ BibTeX\ key\ does\ not\ exist=
+Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=
+Full\ text\ document\ download\ failed\ for\ entry\ %0.=
+Look\ up\ full\ text\ documents=
+You\ are\ about\ to\ look\ up\ full\ text\ documents\ for\ %0\ entries.=
+last\ four\ nonpunctuation\ characters\ should\ be\ numerals=
 
 Author=
 Date=
-File_annotations=
-Show_file_annotations=
-Adobe_Acrobat_Reader=
-Sumatra_Reader=
+File\ annotations=
+Show\ file\ annotations=
+Adobe\ Acrobat\ Reader=
+Sumatra\ Reader=
 shared=
-should_contain_an_integer_or_a_literal=
-should_have_the_first_letter_capitalized=
+should\ contain\ an\ integer\ or\ a\ literal=
+should\ have\ the\ first\ letter\ capitalized=
 Tools=
-What\'s_new_in_this_version?=
-Want_to_help?=
-Make_a_donation=
-get_involved=
-Used_libraries=
-Existing_file=
+What\'s\ new\ in\ this\ version?=
+Want\ to\ help?=
+Make\ a\ donation=
+get\ involved=
+Used\ libraries=
+Existing\ file=
 
 ID=
-ID_type=
-ID-based_entry_generator=
-Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+ID\ type=
+ID-based\ entry\ generator=
+Fetcher\ '%0'\ did\ not\ find\ an\ entry\ for\ id\ '%1'.=
 
-Select_first_entry=
-Select_last_entry=
+Select\ first\ entry=
+Select\ last\ entry=
 
-Invalid_ISBN\:_'%0'.=
-should_be_an_integer_or_normalized=
-should_be_normalized=
+Invalid\ ISBN\:\ '%0'.=
+should\ be\ an\ integer\ or\ normalized=
+should\ be\ normalized=
 
-Empty_search_ID=
-The_given_search_ID_was_empty.=
-Copy_BibTeX_key_and_link=
-empty_BibTeX_key=
-biblatex_field_only=
+Empty\ search\ ID=
+The\ given\ search\ ID\ was\ empty.=
+Copy\ BibTeX\ key\ and\ link=
+empty\ BibTeX\ key=
+biblatex\ field\ only=
 
-Error_while_generating_fetch_URL=
-Error_while_parsing_ID_list=
-Unable_to_get_PubMed_IDs=
-Backup_found=
-A_backup_file_for_'%0'_was_found.=
-This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.=
-Do_you_want_to_recover_the_library_from_the_backup_file?=
-Firstname_Lastname=
+Error\ while\ generating\ fetch\ URL=
+Error\ while\ parsing\ ID\ list=
+Unable\ to\ get\ PubMed\ IDs=
+Backup\ found=
+A\ backup\ file\ for\ '%0'\ was\ found.=
+This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=
+Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=
+Firstname\ Lastname=
 
-Recommended_for_%0=
-Show_'Related_Articles'_tab=
-This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
+Recommended\ for\ %0=
+Show\ 'Related\ Articles'\ tab=
+This\ might\ be\ caused\ by\ reaching\ the\ traffic\ limitation\ of\ Google\ Scholar\ (see\ 'Help'\ for\ details).=
 
-Could_not_open_website.=
-Problem_downloading_from_%1=
+Could\ not\ open\ website.=
+Problem\ downloading\ from\ %1=
 
-File_directory_pattern=
-Update_with_bibliographic_information_from_the_web=
+File\ directory\ pattern=
+Update\ with\ bibliographic\ information\ from\ the\ web=
 
-Could_not_find_any_bibliographic_information.=
-BibTeX_key_deviates_from_generated_key=
-DOI_%0_is_invalid=
+Could\ not\ find\ any\ bibliographic\ information.=
+BibTeX\ key\ deviates\ from\ generated\ key=
+DOI\ %0\ is\ invalid=
 
-Select_all_customized_types_to_be_stored_in_local_preferences=
-Currently_unknown=
-Different_customization,_current_settings_will_be_overwritten=
+Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences=
+Currently\ unknown=
+Different\ customization,\ current\ settings\ will\ be\ overwritten=
 
-Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX=
-Jump_to_entry=
+Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=
+Jump\ to\ entry=
 
-Copied_%0_citations.=
+Copied\ %0\ citations.=
 Copying...=
 
-journal_not_found_in_abbreviation_list=
-Unhandled_exception_occurred.=
+journal\ not\ found\ in\ abbreviation\ list=
+Unhandled\ exception\ occurred.=
 
-strings_included=
-Color_for_disabled_icons=
-Color_for_enabled_icons=
-Size_of_large_icons=
-Size_of_small_icons=
-Default_table_font_size=
-Escape_underscores=
+strings\ included=
+Color\ for\ disabled\ icons=
+Color\ for\ enabled\ icons=
+Size\ of\ large\ icons=
+Size\ of\ small\ icons=
+Default\ table\ font\ size=
+Escape\ underscores=
 Color=
-Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=
-Fit_width=
-Fit_a_single_page=
-Zoom_in=
-Zoom_out=
-Previous_page=
-Next_page=
-Document_viewer=
+Please\ also\ add\ all\ steps\ to\ reproduce\ this\ issue,\ if\ possible.=
+Fit\ width=
+Fit\ a\ single\ page=
+Zoom\ in=
+Zoom\ out=
+Previous\ page=
+Next\ page=
+Document\ viewer=
 Live=
 Locked=
-Show_document_viewer=
-Show_the_document_of_the_currently_selected_entry.=
-Show_this_document_until_unlocked.=
-Set_current_user_name_as_owner.=
+Show\ document\ viewer=
+Show\ the\ document\ of\ the\ currently\ selected\ entry.=
+Show\ this\ document\ until\ unlocked.=
+Set\ current\ user\ name\ as\ owner.=
 
-Sort_all_subgroups_(recursively)=
-Collect_and_share_telemetry_data_to_help_improve_JabRef.=
-Don't_share=
-Share_anonymous_statistics=
-Telemetry\:_Help_make_JabRef_better=
-To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.=
-This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?=
-Names_are_not_in_the_standard_%0_format.=
+Sort\ all\ subgroups\ (recursively)=
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=
+Don't\ share=
+Share\ anonymous\ statistics=
+Telemetry\:\ Help\ make\ JabRef\ better=
+To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ statistics\ on\ the\ features\ you\ use.\ We\ will\ only\ record\ what\ features\ you\ access\ and\ how\ often\ you\ do\ it.\ We\ will\ neither\ collect\ any\ personal\ data\ nor\ the\ content\ of\ bibliographic\ items.\ If\ you\ choose\ to\ allow\ data\ collection,\ you\ can\ later\ disable\ it\ via\ Options\ ->\ Preferences\ ->\ General.=
+This\ file\ was\ found\ automatically.\ Do\ you\ want\ to\ link\ it\ to\ this\ entry?=
+Names\ are\ not\ in\ the\ standard\ %0\ format.=
 
-Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.=
-Delete_'%0'=
-Delete_from_disk=
-Remove_from_entry=
-The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.=
-There_exists_already_a_group_with_the_same_name.=
+Delete\ the\ selected\ file\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ file\ permanently\ from\ disk.=
+Delete\ '%0'=
+Delete\ from\ disk=
+Remove\ from\ entry=
+The\ group\ name\ contains\ the\ keyword\ separator\ "%0"\ and\ thus\ probably\ does\ not\ work\ as\ expected.=
+There\ exists\ already\ a\ group\ with\ the\ same\ name.=
 
-Copy_linked_files_to_folder...=
-Copied_file_successfully=
-Copying_files...=
-Copying_file_%0_of_entry_%1=
-Finished_copying=
-Could_not_copy_file=
-Copied_%0_files_of_%1_sucessfully_to_%2=
-Rename_failed=
-JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.=
-Show_console_output_(only_necessary_when_the_launcher_is_used)=
+Copy\ linked\ files\ to\ folder...=
+Copied\ file\ successfully=
+Copying\ files...=
+Copying\ file\ %0\ of\ entry\ %1=
+Finished\ copying=
+Could\ not\ copy\ file=
+Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=
+Rename\ failed=
+JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=
+Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=
 
-Remove_line_breaks=
-Removes_all_line_breaks_in_the_field_content.=
-Checking_integrity...=
+Remove\ line\ breaks=
+Removes\ all\ line\ breaks\ in\ the\ field\ content.=
+Checking\ integrity...=
 
-Remove_hyphenated_line_breaks=
-Removes_all_hyphenated_line_breaks_in_the_field_content.=
-Note_that_currently,_JabRef_does_not_run_with_Java_9.=
-Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.=
+Remove\ hyphenated\ line\ breaks=
+Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=
+Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=
+Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -1,8 +1,3 @@
-
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 содержит регулярное выражение <b>%1</b>
 
 %0\ contains\ the\ term\ <b>%1</b>=%0 содержит условие <b>%1</b>

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -1,8 +1,3 @@
-
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 innehåller det reguljära uttrycket <b>%1</b>
 
 %0\ contains\ the\ term\ <b>%1</b>=%0 innehåller termen <b>%1</b>

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -1990,8 +1990,8 @@ Importing\ in\ %0\ format=Importerar i %0-format
 Female\ name=Ett kvinnonamn
 Female\ names=Flera kvinnonamn
 Male\ name=Ett mansnamn
-Male\ names= Flera mansnamn
-Mixed\ names= Blandade namn
+Male\ names=Flera mansnamn
+Mixed\ names=Blandade namn
 Neuter\ name=Ett neutrumnamn
 Neuter\ names=Flera neutrumnamn
 

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -3,156 +3,156 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-%0_contains_the_regular_expression_<b>%1</b>=%0_innehåller_det_reguljära_uttrycket_<b>%1</b>
+%0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 innehåller det reguljära uttrycket <b>%1</b>
 
-%0_contains_the_term_<b>%1</b>=%0_innehåller_termen_<b>%1</b>
+%0\ contains\ the\ term\ <b>%1</b>=%0 innehåller termen <b>%1</b>
 
-%0_doesn't_contain_the_regular_expression_<b>%1</b>=%0_innehåller_inte_det_reguljära_uttrycket_<b>%1</b>
+%0\ doesn't\ contain\ the\ regular\ expression\ <b>%1</b>=%0 innehåller inte det reguljära uttrycket <b>%1</b>
 
-%0_doesn't_contain_the_term_<b>%1</b>=%0_innehåller_inte_termen_<b>%1</b>
+%0\ doesn't\ contain\ the\ term\ <b>%1</b>=%0 innehåller inte termen <b>%1</b>
 
-%0_export_successful=%0-export_lyckades
+%0\ export\ successful=%0-export lyckades
 
-%0_matches_the_regular_expression_<b>%1</b>=%0_matchar_det_reguljära_uttrycket_<b>%1</b>
+%0\ matches\ the\ regular\ expression\ <b>%1</b>=%0 matchar det reguljära uttrycket <b>%1</b>
 
-%0_matches_the_term_<b>%1</b>=%0_matchar_termen_<b>%1</b>
+%0\ matches\ the\ term\ <b>%1</b>=%0 matchar termen <b>%1</b>
 
-<field_name>=<fältnamn>
-<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>=<HTML>Hittar_inte_filen_'%0'<BR>som_länkas_från_posten_'%1'</HTML>
+<field\ name>=<fältnamn>
+<HTML>Could\ not\ find\ file\ '%0'<BR>linked\ from\ entry\ '%1'</HTML>=<HTML>Hittar inte filen '%0'<BR>som länkas från posten '%1'</HTML>
 
 <select>=<välj>
 
-<select_word>=<välj_ord>
-Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)=Förkorta_tidskriftsnamnen_för_valda_poster_(ISO-förkortningar)
-Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)=Förkorta_tidskriftsnamnen_för_valda_poster_(MEDLINE-förkortningar)
+<select\ word>=<välj ord>
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (ISO\ abbreviation)=Förkorta tidskriftsnamnen för valda poster (ISO-förkortningar)
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (MEDLINE\ abbreviation)=Förkorta tidskriftsnamnen för valda poster (MEDLINE-förkortningar)
 
-Abbreviate_names=Förkorta_namn
-Abbreviated_%0_journal_names.=Förkortade_%0_tidskriftsnamn.
+Abbreviate\ names=Förkorta namn
+Abbreviated\ %0\ journal\ names.=Förkortade %0 tidskriftsnamn.
 
 Abbreviation=Förkortning
 
-About_JabRef=Om_JabRef
+About\ JabRef=Om JabRef
 
 Abstract=Sammanfattning
 
 Accept=Acceptera
 
-Accept_change=Acceptera_ändring
+Accept\ change=Acceptera ändring
 
 Action=Händelse
 
-What_is_Mr._DLib?=
+What\ is\ Mr.\ DLib?=
 
-Add=Lägg_till
+Add=Lägg till
 
-Add_a_(compiled)_custom_Importer_class_from_a_class_path.=Lägg_till_en_(kompilerad)_Importer-klass_från_en_sökväg_till_en_klass.
-The_path_need_not_be_on_the_classpath_of_JabRef.=
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=Lägg till en (kompilerad) Importer-klass från en sökväg till en klass.
+The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=
 
-Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=Lägg_till_en_(kompilerad)_Importer-klass_från_en_zip-fil.
-The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=Lägg till en (kompilerad) Importer-klass från en zip-fil.
+The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=
 
-Add_a_regular_expression_for_the_key_pattern.=
+Add\ a\ regular\ expression\ for\ the\ key\ pattern.=
 
-Add_selected_entries_to_this_group=
+Add\ selected\ entries\ to\ this\ group=
 
-Add_from_folder=Lägg_till_från_mapp
+Add\ from\ folder=Lägg till från mapp
 
-Add_from_JAR=Lägg_till_från_JAR-fil
+Add\ from\ JAR=Lägg till från JAR-fil
 
-add_group=lägg_till_grupp
+add\ group=lägg till grupp
 
-Add_new=Lägg_till_ny
+Add\ new=Lägg till ny
 
-Add_subgroup=Lägg_till_undergrupp
+Add\ subgroup=Lägg till undergrupp
 
-Add_to_group=Lägg_till_i_grupp
+Add\ to\ group=Lägg till i grupp
 
-Added_group_"%0".=Lade_till_gruppen_"%0".
+Added\ group\ "%0".=Lade till gruppen "%0".
 
-Added_missing_braces.=
+Added\ missing\ braces.=
 
-Added_new=Lade_till_ny
+Added\ new=Lade till ny
 
-Added_string=Lade_till_sträng
+Added\ string=Lade till sträng
 
-Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.=
+Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ can\ be\ assigned\ manually\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ This\ process\ adds\ the\ term\ <b>%1</b>\ to\ each\ entry's\ <b>%0</b>\ field.\ Entries\ can\ be\ removed\ manually\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.\ This\ process\ removes\ the\ term\ <b>%1</b>\ from\ each\ entry's\ <b>%0</b>\ field.=
 
 Advanced=Avancerad
-All_entries=Alla_poster
-All_entries_of_this_type_will_be_declared_typeless._Continue?=Alla_poster_av_denna_typ_kommer_att_bli_typlösa._Fortsätt?
+All\ entries=Alla poster
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=Alla poster av denna typ kommer att bli typlösa. Fortsätt?
 
-All_fields=Alla_fält
+All\ fields=Alla fält
 
-Always_reformat_BIB_file_on_save_and_export=Formattera_alltid_om_BIB-filen_vid_när_den_sparas_eller_exporteras
+Always\ reformat\ BIB\ file\ on\ save\ and\ export=Formattera alltid om BIB-filen vid när den sparas eller exporteras
 
-A_SAX_exception_occurred_while_parsing_'%0'\:=Ett_SAX-undantag_inträffade_när_'%0'_tolkades\:
+A\ SAX\ exception\ occurred\ while\ parsing\ '%0'\:=Ett SAX-undantag inträffade när '%0' tolkades:
 
 and=och
-and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.=och_klassen_måste_finnas_i_din_sökväg_för_klasser_nästa_gång_du_startar_JabRef.
+and\ the\ class\ must\ be\ available\ in\ your\ classpath\ next\ time\ you\ start\ JabRef.=och klassen måste finnas i din sökväg för klasser nästa gång du startar JabRef.
 
-any_field_that_matches_the_regular_expression_<b>%0</b>=något_fält_som_matchar_det_reguljära_uttrycket_<b>%0</b>
+any\ field\ that\ matches\ the\ regular\ expression\ <b>%0</b>=något fält som matchar det reguljära uttrycket <b>%0</b>
 
 Appearance=Utseende
 
-Append=Lägg_till
-Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library=Lägg_till_innehåll_från_en_BibTeX-databas_till_den_nu_aktiva_libraryn
+Append=Lägg till
+Append\ contents\ from\ a\ BibTeX\ library\ into\ the\ currently\ viewed\ library=Lägg till innehåll från en BibTeX-databas till den nu aktiva libraryn
 
-Append_library=Lägg_till_databas
+Append\ library=Lägg till databas
 
-Append_the_selected_text_to_BibTeX_field=Lägg_till_vald_text_till_BibTeX-nyckeln
+Append\ the\ selected\ text\ to\ BibTeX\ field=Lägg till vald text till BibTeX-nyckeln
 Application=Program
 
 Apply=Tillämpa
 
-Arguments_passed_on_to_running_JabRef_instance._Shutting_down.=Argumenten_skickades_till_JabRef-instansen_som_redan_kördes._Stänger_ned.
+Arguments\ passed\ on\ to\ running\ JabRef\ instance.\ Shutting\ down.=Argumenten skickades till JabRef-instansen som redan kördes. Stänger ned.
 
-Assign_new_file=Tilldela_ny_fil
+Assign\ new\ file=Tilldela ny fil
 
-Assign_the_original_group's_entries_to_this_group?=Tilldela_den_ursprungliga_gruppens_poster_till_denna_grupp?
+Assign\ the\ original\ group's\ entries\ to\ this\ group?=Tilldela den ursprungliga gruppens poster till denna grupp?
 
-Assigned_%0_entries_to_group_"%1".=Tilldelade_%0_poster_till_gruppen_"%1".
+Assigned\ %0\ entries\ to\ group\ "%1".=Tilldelade %0 poster till gruppen "%1".
 
-Assigned_1_entry_to_group_"%0".=Tilldelade_en_post_till_gruppen_"%0".
+Assigned\ 1\ entry\ to\ group\ "%0".=Tilldelade en post till gruppen "%0".
 
-Attach_URL=Lägg_till_URL
+Attach\ URL=Lägg till URL
 
-Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.=
+Attempt\ to\ automatically\ set\ file\ links\ for\ your\ entries.\ Automatically\ setting\ works\ if\ a\ file\ in\ your\ file\ directory<BR>or\ a\ subdirectory\ is\ named\ identically\ to\ an\ entry's\ BibTeX\ key,\ plus\ extension.=
 
-Autodetect_format=Bestäm_format_automatiskt
+Autodetect\ format=Bestäm format automatiskt
 
-Autogenerate_BibTeX_keys=Generera_BibTeX-nycklar_automatiskt
+Autogenerate\ BibTeX\ keys=Generera BibTeX-nycklar automatiskt
 
-Autolink_files_with_names_starting_with_the_BibTeX_key=Länka_filer_vars_namn_börjar_med_BibTeX-nyckeln_automatiskt
+Autolink\ files\ with\ names\ starting\ with\ the\ BibTeX\ key=Länka filer vars namn börjar med BibTeX-nyckeln automatiskt
 
-Autolink_only_files_that_match_the_BibTeX_key=Länka_bara_filer_vars_namn_är_BibTeX-nyckeln_automatiskt
+Autolink\ only\ files\ that\ match\ the\ BibTeX\ key=Länka bara filer vars namn är BibTeX-nyckeln automatiskt
 
-Automatically_create_groups=Skapa_grupper_automatiskt
+Automatically\ create\ groups=Skapa grupper automatiskt
 
-Automatically_remove_exact_duplicates=Ta_bort_exakta_dubbletter_automatiskt
+Automatically\ remove\ exact\ duplicates=Ta bort exakta dubbletter automatiskt
 
-Allow_overwriting_existing_links.=Tillåt_att_befintliga_länkar_skrivs_över.
+Allow\ overwriting\ existing\ links.=Tillåt att befintliga länkar skrivs över.
 
-Do_not_overwrite_existing_links.=Skriv_inte_över_befintliga_länkar.
+Do\ not\ overwrite\ existing\ links.=Skriv inte över befintliga länkar.
 
-AUX_file_import=Import_från_AUX-fil
+AUX\ file\ import=Import från AUX-fil
 
-Available_export_formats=Tillgängliga_format_för_export
+Available\ export\ formats=Tillgängliga format för export
 
-Available_BibTeX_fields=Tillgängliga_BibTeX-fält
+Available\ BibTeX\ fields=Tillgängliga BibTeX-fält
 
-Available_import_formats=Tillgängliga_format_för_import
+Available\ import\ formats=Tillgängliga format för import
 
-Background_color_for_optional_fields=Bakgrundsfärg_för_valfria_fält
+Background\ color\ for\ optional\ fields=Bakgrundsfärg för valfria fält
 
-Background_color_for_required_fields=Bakgrundsfärg_för_obligatoriska_fält
+Background\ color\ for\ required\ fields=Bakgrundsfärg för obligatoriska fält
 
-Backup_old_file_when_saving=Skapa_en_säkerhetskopia_av_den_gamla_filen_vid_sparning
+Backup\ old\ file\ when\ saving=Skapa en säkerhetskopia av den gamla filen vid sparning
 
-BibTeX_key_is_unique.=BibTeX-nyckeln_är_unik.
+BibTeX\ key\ is\ unique.=BibTeX-nyckeln är unik.
 
-%0_source=%0_källkod
+%0\ source=%0 källkod
 
-Broken_link=Trasig_länk
+Broken\ link=Trasig länk
 
 Browse=Bläddra
 
@@ -160,321 +160,321 @@ by=med
 
 Cancel=Avbryt
 
-Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?=Kan_inte_lägga_till_poster_till_grupp_utan_att_generera_nycklar._Generera_nycklar_nu?
+Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=Kan inte lägga till poster till grupp utan att generera nycklar. Generera nycklar nu?
 
-Cannot_merge_this_change=Kan_inte_införa_den_här_ändringen
+Cannot\ merge\ this\ change=Kan inte införa den här ändringen
 
-case_insensitive=ej_skiftlägeskänsligt
+case\ insensitive=ej skiftlägeskänsligt
 
-case_sensitive=skiftlägeskänsligt
+case\ sensitive=skiftlägeskänsligt
 
-Case_sensitive=Shiftlägeskänlig
+Case\ sensitive=Shiftlägeskänlig
 
-change_assignment_of_entries=ändra_tilldelning_av_poster
+change\ assignment\ of\ entries=ändra tilldelning av poster
 
-Change_case=Ändra_shiftläge
+Change\ case=Ändra shiftläge
 
-Change_entry_type=Ändra_posttyp
-Change_file_type=Ändra_filtyp
+Change\ entry\ type=Ändra posttyp
+Change\ file\ type=Ändra filtyp
 
 
-Change_of_Grouping_Method=
+Change\ of\ Grouping\ Method=
 
-change_preamble=ändra_preamble
+change\ preamble=ändra preamble
 
-Change_table_column_and_General_fields_settings_to_use_the_new_feature=
+Change\ table\ column\ and\ General\ fields\ settings\ to\ use\ the\ new\ feature=
 
-Changed_language_settings=Ändra_språkinställningar
+Changed\ language\ settings=Ändra språkinställningar
 
-Changed_preamble=Ändrade_preamble
+Changed\ preamble=Ändrade preamble
 
-Check_existing_file_links=Kontrollera_befintliga_fillänkar
+Check\ existing\ file\ links=Kontrollera befintliga fillänkar
 
-Check_links=Kontrollera_länkar
+Check\ links=Kontrollera länkar
 
-Cite_command=Citeringskommando
+Cite\ command=Citeringskommando
 
-Class_name=Klassnamn
+Class\ name=Klassnamn
 
 Clear=Rensa
 
-Clear_fields=Rensa_fält
+Clear\ fields=Rensa fält
 
 Close=Stäng
-Close_others=Stäng_andra
-Close_all=Stäng_alla
+Close\ others=Stäng andra
+Close\ all=Stäng alla
 
-Close_dialog=Stäng_dialog
+Close\ dialog=Stäng dialog
 
-Close_the_current_library=Stäng_aktuell_databas
+Close\ the\ current\ library=Stäng aktuell databas
 
-Close_window=Stäng_fönster
+Close\ window=Stäng fönster
 
-Closed_library=Stängde_libraryn
+Closed\ library=Stängde libraryn
 
-Color_codes_for_required_and_optional_fields=Färgkodning_av_obligatoriska_och_valfria_fält
+Color\ codes\ for\ required\ and\ optional\ fields=Färgkodning av obligatoriska och valfria fält
 
-Color_for_marking_incomplete_entries=Färg_för_markering_av_ofullständiga_poster
+Color\ for\ marking\ incomplete\ entries=Färg för markering av ofullständiga poster
 
-Column_width=Kolumnbredd
+Column\ width=Kolumnbredd
 
-Command_line_id=Kommandorads-id
+Command\ line\ id=Kommandorads-id
 
 
-Contained_in=Finns_i
+Contained\ in=Finns i
 
 Content=Innehåll
 
 Copied=Kopierade
 
-Copied_cell_contents=Kopierade_cellinnehåll
+Copied\ cell\ contents=Kopierade cellinnehåll
 
-Copied_title=
+Copied\ title=
 
-Copied_key=Kopierade_nyckel
+Copied\ key=Kopierade nyckel
 
-Copied_titles=
+Copied\ titles=
 
-Copied_keys=Kopierade_nycklar
+Copied\ keys=Kopierade nycklar
 
 Copy=Kopiera
 
-Copy_BibTeX_key=Kopiera_BibTeX-nyckel
-Copy_file_to_file_directory=Kopiera_fil_till_filmappen
+Copy\ BibTeX\ key=Kopiera BibTeX-nyckel
+Copy\ file\ to\ file\ directory=Kopiera fil till filmappen
 
-Copy_to_clipboard=Kopiera_till_urklipp
+Copy\ to\ clipboard=Kopiera till urklipp
 
-Could_not_call_executable=Kunde_inte_anropa_program
-Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.=Kunde_inte_ansluta_till_Vim-servern._Se_till_att_Vim_körs_med_rätt_servernamn.
+Could\ not\ call\ executable=Kunde inte anropa program
+Could\ not\ connect\ to\ Vim\ server.\ Make\ sure\ that\ Vim\ is\ running<BR>with\ correct\ server\ name.=Kunde inte ansluta till Vim-servern. Se till att Vim körs med rätt servernamn.
 
-Could_not_export_file=Kunde_inte_exportera_filen
+Could\ not\ export\ file=Kunde inte exportera filen
 
-Could_not_export_preferences=Kunde_inte_exportera_inställningar
+Could\ not\ export\ preferences=Kunde inte exportera inställningar
 
-Could_not_find_a_suitable_import_format.=Kunde_inte_hitta_ett_lämpligt_importformat.
-Could_not_import_preferences=Kunde_inte_importera_inställningar
+Could\ not\ find\ a\ suitable\ import\ format.=Kunde inte hitta ett lämpligt importformat.
+Could\ not\ import\ preferences=Kunde inte importera inställningar
 
-Could_not_instantiate_%0=Kunde_inte_instansiera_%0
-Could_not_instantiate_%0_%1=Kunde_inte_instansiera_%0_%1
-Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?=Kunde_inte_instansiera_%0._Har_du_valt_rätt_sökväg?
-Could_not_open_link=Kunde_inte_öppna_länk
+Could\ not\ instantiate\ %0=Kunde inte instansiera %0
+Could\ not\ instantiate\ %0\ %1=Kunde inte instansiera %0 %1
+Could\ not\ instantiate\ %0.\ Have\ you\ chosen\ the\ correct\ package\ path?=Kunde inte instansiera %0. Har du valt rätt sökväg?
+Could\ not\ open\ link=Kunde inte öppna länk
 
-Could_not_print_preview=Kunde_inte_skriva_ut_postvisning
+Could\ not\ print\ preview=Kunde inte skriva ut postvisning
 
-Could_not_run_the_'vim'_program.=Kunde_inte_köra_'vim'.
+Could\ not\ run\ the\ 'vim'\ program.=Kunde inte köra 'vim'.
 
-Could_not_save_file.=Kunde_inte_spara_fil.
-Character_encoding_'%0'_is_not_supported.=Teckenkodningen_'%0'_stöds_inte.
+Could\ not\ save\ file.=Kunde inte spara fil.
+Character\ encoding\ '%0'\ is\ not\ supported.=Teckenkodningen '%0' stöds inte.
 
-crossreferenced_entries_included=korsrefererade_poster_inkluderade
+crossreferenced\ entries\ included=korsrefererade poster inkluderade
 
-Current_content=Nuvarande_innehåll
+Current\ content=Nuvarande innehåll
 
-Current_value=Nuvarande_värde
+Current\ value=Nuvarande värde
 
-Custom_entry_types=Anpassade_posttyper
+Custom\ entry\ types=Anpassade posttyper
 
-Custom_entry_types_found_in_file=Anpassade_posttyper_hittades_i_fil
+Custom\ entry\ types\ found\ in\ file=Anpassade posttyper hittades i fil
 
-Customize_entry_types=Anpassa_posttyper
+Customize\ entry\ types=Anpassa posttyper
 
-Customize_key_bindings=Anpassa_tangentbordsbindningar
+Customize\ key\ bindings=Anpassa tangentbordsbindningar
 
 Cut=Klipp
 
-cut_entries=klipp_ut_poster
+cut\ entries=klipp ut poster
 
-cut_entry=klipp_ut_post
+cut\ entry=klipp ut post
 
 
-Library_encoding=Teckenkodning_för_databas
+Library\ encoding=Teckenkodning för databas
 
-Library_properties=Librarygenskaper
+Library\ properties=Librarygenskaper
 
-Library_type=Databastyp
+Library\ type=Databastyp
 
-Date_format=Datumformat
+Date\ format=Datumformat
 
 Default=Standard
 
-Default_encoding=Standardteckenkodning
+Default\ encoding=Standardteckenkodning
 
-Default_grouping_field=Standardfält_för_gruppering
+Default\ grouping\ field=Standardfält för gruppering
 
-Default_look_and_feel=Standard-'look-and-feel'
+Default\ look\ and\ feel=Standard-'look-and-feel'
 
-Default_pattern=Standardmönster
+Default\ pattern=Standardmönster
 
-Default_sort_criteria=Standardsortering
-Define_'%0'=Definiera_'%0'
+Default\ sort\ criteria=Standardsortering
+Define\ '%0'=Definiera '%0'
 
 Delete=Radera
 
-Delete_custom_format=Radera_eget_format
+Delete\ custom\ format=Radera eget format
 
-delete_entries=radera_poster
+delete\ entries=radera poster
 
-Delete_entry=Radera_post
+Delete\ entry=Radera post
 
-delete_entry=radera_post
+delete\ entry=radera post
 
-Delete_multiple_entries=Radera_flera_poster
+Delete\ multiple\ entries=Radera flera poster
 
-Delete_rows=Radera_rader
+Delete\ rows=Radera rader
 
-Delete_strings=Radera_strängar
+Delete\ strings=Radera strängar
 
 Deleted=Raderade
 
-Permanently_delete_local_file=Radera_lokal_fil
+Permanently\ delete\ local\ file=Radera lokal fil
 
-Delimit_fields_with_semicolon,_ex.=Avgränsa_fält_med_semikolon,_t.ex.
+Delimit\ fields\ with\ semicolon,\ ex.=Avgränsa fält med semikolon, t.ex.
 
 Descending=Fallande
 
 Description=Beskrivning
 
-Deselect_all=
-Deselect_all_duplicates=
+Deselect\ all=
+Deselect\ all\ duplicates=
 
-Disable_this_confirmation_dialog=Avaktivera_denna_bekräftelsedialog
+Disable\ this\ confirmation\ dialog=Avaktivera denna bekräftelsedialog
 
-Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.=Visa_alla_poster_som_ingår_i_en_eller_flera_valda_grupper.
+Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups.=Visa alla poster som ingår i en eller flera valda grupper.
 
-Display_all_error_messages=Visa_alla_felmeddelanden
+Display\ all\ error\ messages=Visa alla felmeddelanden
 
-Display_help_on_command_line_options=Visa_hjälp_för_kommandoradsalternativ
+Display\ help\ on\ command\ line\ options=Visa hjälp för kommandoradsalternativ
 
-Display_only_entries_belonging_to_all_selected_groups.=Visa_bara_poster_som_ingår_i_alla_valda_grupper.
-Display_version=Visa_version
+Display\ only\ entries\ belonging\ to\ all\ selected\ groups.=Visa bara poster som ingår i alla valda grupper.
+Display\ version=Visa version
 
-Do_not_abbreviate_names=Förkorta_ej_namn
+Do\ not\ abbreviate\ names=Förkorta ej namn
 
-Do_not_automatically_set=Sätt_ej_automatiskt
+Do\ not\ automatically\ set=Sätt ej automatiskt
 
-Do_not_import_entry=Importera_inte_post
+Do\ not\ import\ entry=Importera inte post
 
-Do_not_open_any_files_at_startup=Öppna_inga_filer_vid_uppstart
+Do\ not\ open\ any\ files\ at\ startup=Öppna inga filer vid uppstart
 
-Do_not_overwrite_existing_keys=Skriv_inte_över_befintliga_nycklar
-Do_not_show_these_options_in_the_future=Visa_inte_dessa_alternativ_igen
+Do\ not\ overwrite\ existing\ keys=Skriv inte över befintliga nycklar
+Do\ not\ show\ these\ options\ in\ the\ future=Visa inte dessa alternativ igen
 
-Do_not_wrap_the_following_fields_when_saving=Radbryt_inte_följande_fält_vid_sparning
-Do_not_write_the_following_fields_to_XMP_Metadata\:=Vill_du_skriva_följande_fält_till_XMP-metadata?
+Do\ not\ wrap\ the\ following\ fields\ when\ saving=Radbryt inte följande fält vid sparning
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Vill du skriva följande fält till XMP-metadata?
 
-Do_you_want_JabRef_to_do_the_following_operations?=Vill_du_att_JabRef_ska_göra_följande?
+Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Vill du att JabRef ska göra följande?
 
-Donate_to_JabRef=Donera_till_JabRef
+Donate\ to\ JabRef=Donera till JabRef
 
 Down=Nedåt
 
-Download_file=Ladda_ned_fil
+Download\ file=Ladda ned fil
 
-Downloading...=Laddar_ned...
+Downloading...=Laddar ned...
 
-Drop_%0=Släpp_%0
+Drop\ %0=Släpp %0
 
-duplicate_removal=ta_bort_dubbletter
+duplicate\ removal=ta bort dubbletter
 
-Duplicate_string_name=Dubblerat_strängnamn
+Duplicate\ string\ name=Dubblerat strängnamn
 
-Duplicates_found=Dubbletter_hittades
+Duplicates\ found=Dubbletter hittades
 
-Dynamic_groups=Dynamiska_grupper
+Dynamic\ groups=Dynamiska grupper
 
-Dynamically_group_entries_by_a_free-form_search_expression=
+Dynamically\ group\ entries\ by\ a\ free-form\ search\ expression=
 
-Dynamically_group_entries_by_searching_a_field_for_a_keyword=
+Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=
 
-Each_line_must_be_on_the_following_form=Varje_rad_måste_vara_på_följande_form
+Each\ line\ must\ be\ on\ the\ following\ form=Varje rad måste vara på följande form
 
 Edit=Editera
 
-Edit_custom_export=Ändra_egen_exporterare
-Edit_entry=Ändra_post
-Save_file=Spara_fil
-Edit_file_type=Ändra_filtyp
+Edit\ custom\ export=Ändra egen exporterare
+Edit\ entry=Ändra post
+Save\ file=Spara fil
+Edit\ file\ type=Ändra filtyp
 
-Edit_group=Ändra_grupp
+Edit\ group=Ändra grupp
 
 
-Edit_preamble=Ändra_preamble
-Edit_strings=Ändra_strängar
-Editor_options=Editoralternativ
+Edit\ preamble=Ändra preamble
+Edit\ strings=Ändra strängar
+Editor\ options=Editoralternativ
 
-Empty_BibTeX_key=Tom_BibTeX-nyckel
+Empty\ BibTeX\ key=Tom BibTeX-nyckel
 
-Grouping_may_not_work_for_this_entry.=Grupper_kanske_inte_fungerar_för_denna_post.
+Grouping\ may\ not\ work\ for\ this\ entry.=Grupper kanske inte fungerar för denna post.
 
-empty_library=tom_databas
-Enable_word/name_autocompletion=Aktivera_automatisk_komplettering_av_ord/namn
+empty\ library=tom databas
+Enable\ word/name\ autocompletion=Aktivera automatisk komplettering av ord/namn
 
-Enter_URL=Ange_URL
+Enter\ URL=Ange URL
 
-Enter_URL_to_download=Ange_URL_att_ladda_ned
+Enter\ URL\ to\ download=Ange URL att ladda ned
 
 entries=poster
 
-Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.=Poster_kan_inte_manuellt_tilldelas_eller_tas_bort_från_denna_grupp.
+Entries\ cannot\ be\ manually\ assigned\ to\ or\ removed\ from\ this\ group.=Poster kan inte manuellt tilldelas eller tas bort från denna grupp.
 
-Entries_exported_to_clipboard=Poster_exporterades_till_urklipp
+Entries\ exported\ to\ clipboard=Poster exporterades till urklipp
 
 
 entry=post
 
-Entry_editor=Posteditor
+Entry\ editor=Posteditor
 
-Entry_preview=Postvisning
+Entry\ preview=Postvisning
 
-Entry_table=Tabell
+Entry\ table=Tabell
 
-Entry_table_columns=Tabellkolumner
+Entry\ table\ columns=Tabellkolumner
 
-Entry_type=Posttyp
+Entry\ type=Posttyp
 
-Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters=
+Entry\ type\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=
 
-Entry_types=Posttyper
+Entry\ types=Posttyper
 
 Error=Fel
-Error_exporting_to_clipboard=Fel_vid_export_till_urklipp
+Error\ exporting\ to\ clipboard=Fel vid export till urklipp
 
-Error_occurred_when_parsing_entry=Fel_vid_inläsning_av_post
+Error\ occurred\ when\ parsing\ entry=Fel vid inläsning av post
 
-Error_opening_file=Fel_vid_öppning_av_fil
+Error\ opening\ file=Fel vid öppning av fil
 
-Error_setting_field=
+Error\ setting\ field=
 
-Error_while_writing=Fel_vid_skrivning
-Error_writing_to_%0_file(s).=Fel_vid_skrivning_till_%0_fil(er).
+Error\ while\ writing=Fel vid skrivning
+Error\ writing\ to\ %0\ file(s).=Fel vid skrivning till %0 fil(er).
 
 
 
-'%0'_exists._Overwrite_file?='%0'_finns_redan._Skriv_över_filen?
-Overwrite_file?=Skriva_över_fil?
+'%0'\ exists.\ Overwrite\ file?='%0' finns redan. Skriv över filen?
+Overwrite\ file?=Skriva över fil?
 
 Export=Exportera
 
-Export_name=Exportnamn
+Export\ name=Exportnamn
 
-Export_preferences=Exportera_inställningar
+Export\ preferences=Exportera inställningar
 
-Export_preferences_to_file=Exportera_inställningar_till_fil
+Export\ preferences\ to\ file=Exportera inställningar till fil
 
-Export_properties=Exportera_egenskaper
+Export\ properties=Exportera egenskaper
 
-Export_to_clipboard=Exportera_till_utklipp
+Export\ to\ clipboard=Exportera till utklipp
 
 Exporting=Exporterar
 Extension=Filändelse
 
-External_changes=Externa_ändringar
+External\ changes=Externa ändringar
 
-External_file_links=Externa_fillänkar
+External\ file\ links=Externa fillänkar
 
-External_programs=Externa_program
+External\ programs=Externa program
 
-External_viewer_called=Öppnar_i_externt_program
+External\ viewer\ called=Öppnar i externt program
 
 Fetch=Hämta
 
@@ -482,210 +482,210 @@ Field=Fält
 
 field=fält
 
-Field_name=Fältnamn
-Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters=
+Field\ name=Fältnamn
+Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=
 
-Field_to_filter=Fält_att_filtrera
+Field\ to\ filter=Fält att filtrera
 
-Field_to_group_by=Fält_att_använda_för_gruppering
+Field\ to\ group\ by=Fält att använda för gruppering
 
 File=Fil
 
 file=fil
-File_'%0'_is_already_open.=Filen_'%0'_är_redan_öppen.
+File\ '%0'\ is\ already\ open.=Filen '%0' är redan öppen.
 
-File_changed=Fil_ändrad
-File_directory_is_'%0'\:=Filmapp_är_'%0'\:
+File\ changed=Fil ändrad
+File\ directory\ is\ '%0'\:=Filmapp är '%0':
 
-File_directory_is_not_set_or_does_not_exist\!=Filmapp_är_inte_satt_eller_existerar_inte\!
+File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=Filmapp är inte satt eller existerar inte!
 
-File_exists=Filen_finns_redan
+File\ exists=Filen finns redan
 
-File_has_been_updated_externally._What_do_you_want_to_do?=Fil_har_ändrats_utanför_JabRef._Vad_vill_du_göra?
+File\ has\ been\ updated\ externally.\ What\ do\ you\ want\ to\ do?=Fil har ändrats utanför JabRef. Vad vill du göra?
 
-File_not_found=Hittar_ej_filen
-File_type=Filtyp
+File\ not\ found=Hittar ej filen
+File\ type=Filtyp
 
-File_updated_externally=Filen_uppdaterad_utanför_JabRef
+File\ updated\ externally=Filen uppdaterad utanför JabRef
 
 filename=filnamn
 
 Filename=
 
-Files_opened=Filer_öppnade
+Files\ opened=Filer öppnade
 
 Filter=Filtrera
 
-Filter_All=
+Filter\ All=
 
-Filter_None=
+Filter\ None=
 
-Finished_automatically_setting_external_links.=
+Finished\ automatically\ setting\ external\ links.=
 
-Finished_synchronizing_file_links._Entries_changed\:_%0.=Synkronisering_av_fillänkar_avslutad._Ändrade_poster\:_%0.
-Finished_writing_XMP-metadata._Wrote_to_%0_file(s).=Skrivning_av_XMP-metadata_avslutad._Skrev_till_%0_fil(er).
-Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).=
+Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Synkronisering av fillänkar avslutad. Ändrade poster: %0.
+Finished\ writing\ XMP-metadata.\ Wrote\ to\ %0\ file(s).=Skrivning av XMP-metadata avslutad. Skrev till %0 fil(er).
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=
 
-First_select_the_entries_you_want_keys_to_be_generated_for.=Välj_först_de_poster_du_vill_generera_nycklar_för.
+First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Välj först de poster du vill generera nycklar för.
 
-Fit_table_horizontally_on_screen=
+Fit\ table\ horizontally\ on\ screen=
 
-Float=Visa_först
-Float_marked_entries=Visa_märkta_poster_först
+Float=Visa först
+Float\ marked\ entries=Visa märkta poster först
 
-Font_family=Typsnittsfamilj
+Font\ family=Typsnittsfamilj
 
-Font_preview=Typsnittsexempel
+Font\ preview=Typsnittsexempel
 
-Font_size=Typsnittsstorlek
+Font\ size=Typsnittsstorlek
 
-Font_style=Typsnittsstil
+Font\ style=Typsnittsstil
 
-Font_selection=Typsnittsväljare
+Font\ selection=Typsnittsväljare
 
 for=för
 
-Format_of_author_and_editor_names=Format_för_författar-_och_redaktörsnamn
-Format_string=Formatsträng
+Format\ of\ author\ and\ editor\ names=Format för författar- och redaktörsnamn
+Format\ string=Formatsträng
 
-Format_used=Använt_format
-Formatter_name=Formatnamn
+Format\ used=Använt format
+Formatter\ name=Formatnamn
 
-found_in_AUX_file=hittades_i_AUX-fil
+found\ in\ AUX\ file=hittades i AUX-fil
 
-Full_name=
+Full\ name=
 
 General=Generellt
 
-General_fields=Generella_fält
+General\ fields=Generella fält
 
 Generate=Generera
 
-Generate_BibTeX_key=Generera_BibTeX-nyckel
+Generate\ BibTeX\ key=Generera BibTeX-nyckel
 
-Generate_keys=Generera_nycklar
+Generate\ keys=Generera nycklar
 
-Generate_keys_before_saving_(for_entries_without_a_key)=Generera_nycklar_innan_sparning_(för_poster_utan_nyckel)
-Generate_keys_for_imported_entries=Generera_nycklar_för_importerade_poster
+Generate\ keys\ before\ saving\ (for\ entries\ without\ a\ key)=Generera nycklar innan sparning (för poster utan nyckel)
+Generate\ keys\ for\ imported\ entries=Generera nycklar för importerade poster
 
-Generate_now=Generera_nu
+Generate\ now=Generera nu
 
-Generated_BibTeX_key_for=Genererade_BibTeX-nycklar_för
+Generated\ BibTeX\ key\ for=Genererade BibTeX-nycklar för
 
-Generating_BibTeX_key_for=Genererar_BibTeX-nycklar_för
-Get_fulltext=Hämta_dokument
+Generating\ BibTeX\ key\ for=Genererar BibTeX-nycklar för
+Get\ fulltext=Hämta dokument
 
-Gray_out_non-hits=Skugga_icke-träffar
+Gray\ out\ non-hits=Skugga icke-träffar
 
 Groups=Grupper
 
-Have_you_chosen_the_correct_package_path?=Har_du_valt_rätt_sökväg_till_paketet?
+Have\ you\ chosen\ the\ correct\ package\ path?=Har du valt rätt sökväg till paketet?
 
 Help=Hjälp
 
-Help_on_key_patterns=Hjälp_för_nyckelmönster
-Help_on_regular_expression_search=Hjälp_för_sökning_med_reguljära_uttryck
+Help\ on\ key\ patterns=Hjälp för nyckelmönster
+Help\ on\ regular\ expression\ search=Hjälp för sökning med reguljära uttryck
 
-Hide_non-hits=Dölj_icke-träffar
+Hide\ non-hits=Dölj icke-träffar
 
-Hierarchical_context=Hierarkiskt_sammanhang
+Hierarchical\ context=Hierarkiskt sammanhang
 
 Highlight=Framhäv
 Marking=
 Underline=
-Empty_Highlight=
-Empty_Marking=
-Empty_Underline=
-The_marked_area_does_not_contain_any_legible_text!=
+Empty\ Highlight=
+Empty\ Marking=
+Empty\ Underline=
+The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=
 
-Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>=Tips\:_För_att_söka_i_specifika_fält,_skriv_t.ex.\:<p><tt>author\=smith_and_title\=electrical</tt>
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Tips: För att söka i specifika fält, skriv t.ex.:<p><tt>author=smith and title=electrical</tt>
 
-HTML_table=HTML-tabell
-HTML_table_(with_Abstract_&_BibTeX)=HTML-tabell_(med_sammanfattning_och_BibTeX-post)
+HTML\ table=HTML-tabell
+HTML\ table\ (with\ Abstract\ &\ BibTeX)=HTML-tabell (med sammanfattning och BibTeX-post)
 Icon=Ikon
 
 Ignore=Ignorera
 
 Import=Importera
 
-Import_and_keep_old_entry=Importera_och_behåll_gammal_post
+Import\ and\ keep\ old\ entry=Importera och behåll gammal post
 
-Import_and_remove_old_entry=Importera_och_ta_bort_gammal_post
+Import\ and\ remove\ old\ entry=Importera och ta bort gammal post
 
-Import_entries=Importera_poster
+Import\ entries=Importera poster
 
-Import_failed=Importen_misslyckades
+Import\ failed=Importen misslyckades
 
-Import_file=Importera_fil
+Import\ file=Importera fil
 
-Import_group_definitions=Importera_gruppdefinitioner
+Import\ group\ definitions=Importera gruppdefinitioner
 
-Import_name=Importnamn
+Import\ name=Importnamn
 
-Import_preferences=Importera_inställningar
+Import\ preferences=Importera inställningar
 
-Import_preferences_from_file=Importera_inställningar_från_fil
+Import\ preferences\ from\ file=Importera inställningar från fil
 
-Import_strings=Importera_strängar
+Import\ strings=Importera strängar
 
-Import_to_open_tab=Importera_till_öppen_flik
+Import\ to\ open\ tab=Importera till öppen flik
 
-Import_word_selector_definitions=
+Import\ word\ selector\ definitions=
 
-Imported_entries=Importerade_poster
+Imported\ entries=Importerade poster
 
-Imported_from_library=Importerade_från_databas
+Imported\ from\ library=Importerade från databas
 
-Importer_class=Importer-klass
+Importer\ class=Importer-klass
 
 Importing=Importerar
 
-Importing_in_unknown_format=Importerar_i_okänt_format
+Importing\ in\ unknown\ format=Importerar i okänt format
 
-Include_abstracts=Inkludera_sammanfattning
-Include_entries=Inkludera_poster
+Include\ abstracts=Inkludera sammanfattning
+Include\ entries=Inkludera poster
 
-Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups=
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=
 
-Independent_group\:_When_selected,_view_only_this_group's_entries=
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=
 
-Work_options=
+Work\ options=
 
 Insert=Infoga
 
-Insert_rows=Infoga_rader
+Insert\ rows=Infoga rader
 
 Intersection=Snitt
 
-Invalid_BibTeX_key=Ogiltig_BibTeX-nyckel
+Invalid\ BibTeX\ key=Ogiltig BibTeX-nyckel
 
-Invalid_date_format=Ogiltigt_datumformat
+Invalid\ date\ format=Ogiltigt datumformat
 
-Invalid_URL=Ogiltig_URL
+Invalid\ URL=Ogiltig URL
 
-Online_help=Onlinehjälp
+Online\ help=Onlinehjälp
 
-JabRef_preferences=Inställningar_för_JabRef
+JabRef\ preferences=Inställningar för JabRef
 
 Join=
 
-Joins_selected_keywords_and_deletes_selected_keywords.=
+Joins\ selected\ keywords\ and\ deletes\ selected\ keywords.=
 
-Journal_abbreviations=Tidskriftsförkortningar
+Journal\ abbreviations=Tidskriftsförkortningar
 
 Keep=Behåll
 
-Keep_both=Behåll_bägge
+Keep\ both=Behåll bägge
 
-Key_bindings=Tangentbordsbindningar
+Key\ bindings=Tangentbordsbindningar
 
-Key_bindings_changed=Tangentbordsbindningar_ändrades
+Key\ bindings\ changed=Tangentbordsbindningar ändrades
 
-Key_generator_settings=Nyckelgeneratorinställningar
+Key\ generator\ settings=Nyckelgeneratorinställningar
 
-Key_pattern=Nyckelmönster
+Key\ pattern=Nyckelmönster
 
-keys_in_library=nycklar_i_databas
+keys\ in\ library=nycklar i databas
 
 Keyword=Nyckelord
 
@@ -693,449 +693,449 @@ Label=
 
 Language=Språk
 
-Last_modified=Senast_ändrad
+Last\ modified=Senast ändrad
 
-LaTeX_AUX_file=LaTeX_AUX-fil
-Leave_file_in_its_current_directory=Lämna_filen_i_nuvarande_mapp
+LaTeX\ AUX\ file=LaTeX AUX-fil
+Leave\ file\ in\ its\ current\ directory=Lämna filen i nuvarande mapp
 
 Left=Vänster
 Level=Nivå
 
-Limit_to_fields=Begränsa_till_fält
+Limit\ to\ fields=Begränsa till fält
 
-Limit_to_selected_entries=Begränsa_till_valda_poster
+Limit\ to\ selected\ entries=Begränsa till valda poster
 
 Link=Länk
-Link_local_file=Länka_till_lokal_fil
-Link_to_file_%0=Länka_till_fil_%0
+Link\ local\ file=Länka till lokal fil
+Link\ to\ file\ %0=Länka till fil %0
 
-Listen_for_remote_operation_on_port=Lyssna_efter_fjärrstyrning_på_port
-Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)=
+Listen\ for\ remote\ operation\ on\ port=Lyssna efter fjärrstyrning på port
+Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=
 
-Look_and_feel='Look-and-feel'
-Main_file_directory=Huvudmapp_för_filer
+Look\ and\ feel='Look-and-feel'
+Main\ file\ directory=Huvudmapp för filer
 
-Main_layout_file=Huvudfil_för_layout
+Main\ layout\ file=Huvudfil för layout
 
-Manage_custom_exports=Hantera_egna_exporterare
+Manage\ custom\ exports=Hantera egna exporterare
 
-Manage_custom_imports=Hantera_egna_importerare
-Manage_external_file_types=Hantera_externa_filetyper
+Manage\ custom\ imports=Hantera egna importerare
+Manage\ external\ file\ types=Hantera externa filetyper
 
-Mark_entries=Markera_poster
+Mark\ entries=Markera poster
 
-Mark_entry=Markera_post
+Mark\ entry=Markera post
 
-Mark_new_entries_with_addition_date=Märk_nya_poster_med_datum_de_lades_till
+Mark\ new\ entries\ with\ addition\ date=Märk nya poster med datum de lades till
 
-Mark_new_entries_with_owner_name=Märk_nya_poster_med_ägarnamn
+Mark\ new\ entries\ with\ owner\ name=Märk nya poster med ägarnamn
 
-Memory_stick_mode=
+Memory\ stick\ mode=
 
-Menu_and_label_font_size=
+Menu\ and\ label\ font\ size=
 
-Merged_external_changes=
+Merged\ external\ changes=
 
 Messages=Meddelanden
 
-Modification_of_field=Ändring_i_fält
+Modification\ of\ field=Ändring i fält
 
-Modified_group_"%0".=Modifierade_grupp_"%0".
+Modified\ group\ "%0".=Modifierade grupp "%0".
 
-Modified_groups=Modifierade_grupper
+Modified\ groups=Modifierade grupper
 
-Modified_string=Ändrad_sträng
+Modified\ string=Ändrad sträng
 
 Modify=Ändra
 
-modify_group=ändra_grupp
+modify\ group=ändra grupp
 
-Move_down=Flytta_nedåt
+Move\ down=Flytta nedåt
 
-Move_external_links_to_'file'_field=Flytta_externa_länkar_till_'file'-fältet
+Move\ external\ links\ to\ 'file'\ field=Flytta externa länkar till 'file'-fältet
 
-move_group=flytta_grupp
+move\ group=flytta grupp
 
-Move_up=Flytta_uppåt
+Move\ up=Flytta uppåt
 
-Moved_group_"%0".=Flyttade_grupp_"%0"
+Moved\ group\ "%0".=Flyttade grupp "%0"
 
 Name=Namn
-Name_formatter=Namnformattering
+Name\ formatter=Namnformattering
 
-Natbib_style=Natbib-stil
+Natbib\ style=Natbib-stil
 
-nested_AUX_files=nästlade_AUX-filer
+nested\ AUX\ files=nästlade AUX-filer
 
 New=Ny
 
 new=ny
 
-New_BibTeX_entry=Ny_BibTeX-post
+New\ BibTeX\ entry=Ny BibTeX-post
 
-New_BibTeX_sublibrary=
+New\ BibTeX\ sublibrary=
 
-New_content=
+New\ content=
 
-New_library_created.=Skapade_ny_databas.
-New_%0_library=Ny_%0-databas
-New_field_value=Nytt_fältvärde
+New\ library\ created.=Skapade ny databas.
+New\ %0\ library=Ny %0-databas
+New\ field\ value=Nytt fältvärde
 
-New_group=Ny_grupp
+New\ group=Ny grupp
 
-New_string=Ny_sträng
+New\ string=Ny sträng
 
-Next_entry=Nästa_post
+Next\ entry=Nästa post
 
-No_actual_changes_found.=
+No\ actual\ changes\ found.=
 
-no_base-BibTeX-file_specified=
+no\ base-BibTeX-file\ specified=
 
-no_library_generated=ingen_databas_genererades
+no\ library\ generated=ingen databas genererades
 
-No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.=
+No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=
 
 
-No_entries_found_for_the_search_string_'%0'=Inga_poster_hittades_för_söksträngen_'%0'
+No\ entries\ found\ for\ the\ search\ string\ '%0'=Inga poster hittades för söksträngen '%0'
 
-No_entries_imported.=Inga_poster_importerades.
+No\ entries\ imported.=Inga poster importerades.
 
-No_files_found.=Inga_filer_hittades.
+No\ files\ found.=Inga filer hittades.
 
-No_GUI._Only_process_command_line_options.=
+No\ GUI.\ Only\ process\ command\ line\ options.=
 
-No_journal_names_could_be_abbreviated.=Inga_tidskriftsnamn_kunde_förkortas.
+No\ journal\ names\ could\ be\ abbreviated.=Inga tidskriftsnamn kunde förkortas.
 
-No_journal_names_could_be_unabbreviated.=Inga_tidskriftsnamn_kunde_expanderas.
-No_PDF_linked=Ingen_PDF_är_länkad
+No\ journal\ names\ could\ be\ unabbreviated.=Inga tidskriftsnamn kunde expanderas.
+No\ PDF\ linked=Ingen PDF är länkad
 
-Open_PDF=
+Open\ PDF=
 
-No_URL_defined=Ingen_URL_angiven
+No\ URL\ defined=Ingen URL angiven
 not=inte
 
-not_found=hittades_inte
+not\ found=hittades inte
 
-Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,=
+Note\ that\ you\ must\ specify\ the\ fully\ qualified\ class\ name\ for\ the\ look\ and\ feel,=
 
-Nothing_to_redo=Inget_att_göra_om.
+Nothing\ to\ redo=Inget att göra om.
 
-Nothing_to_undo=Inget_att_ångra.
+Nothing\ to\ undo=Inget att ångra.
 
 occurrences=förekomster
 
 OK=OK
-One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=
+One\ or\ more\ file\ links\ are\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=
 
-One_or_more_keys_will_be_overwritten._Continue?=En_eller_flera_BibTeX-nycklar_kommer_skrivas_över._Fortsätt?
+One\ or\ more\ keys\ will\ be\ overwritten.\ Continue?=En eller flera BibTeX-nycklar kommer skrivas över. Fortsätt?
 
 
 Open=Öppna
 
-Open_BibTeX_library=Öppna_BibTeX-databas
+Open\ BibTeX\ library=Öppna BibTeX-databas
 
-Open_library=Öppna_databas
+Open\ library=Öppna databas
 
-Open_editor_when_a_new_entry_is_created=Öppna_posteditorn_när_en_ny_post_skapats
+Open\ editor\ when\ a\ new\ entry\ is\ created=Öppna posteditorn när en ny post skapats
 
-Open_file=Öppna_fil
+Open\ file=Öppna fil
 
-Open_last_edited_libraries_at_startup=Öppna_senast_använda_libraryr_vid_uppstart
+Open\ last\ edited\ libraries\ at\ startup=Öppna senast använda libraryr vid uppstart
 
-Connect_to_shared_database=Öppna_delad_databas
+Connect\ to\ shared\ database=Öppna delad databas
 
-Open_terminal_here=Öppna_skalfönster_här
+Open\ terminal\ here=Öppna skalfönster här
 
-Open_URL_or_DOI=Öppna_URL_eller_DOI
+Open\ URL\ or\ DOI=Öppna URL eller DOI
 
-Opened_library=Öppnade_databas
+Opened\ library=Öppnade databas
 
 Opening=Öppnar
 
-Opening_preferences...=Öppnar_inställningar...
+Opening\ preferences...=Öppnar inställningar...
 
-Operation_canceled.=Operationen_avbruten.
-Operation_not_supported=Operationen_stöds_ej
+Operation\ canceled.=Operationen avbruten.
+Operation\ not\ supported=Operationen stöds ej
 
-Optional_fields=Valfria_fält
+Optional\ fields=Valfria fält
 
 Options=Alternativ
 
 or=eller
 
-Output_or_export_file=
+Output\ or\ export\ file=
 
 Override=Ignorera
 
-Override_default_file_directories=Ignorerar_normala_filmappar
+Override\ default\ file\ directories=Ignorerar normala filmappar
 
-Override_default_font_settings=Ignorera_normala_typsnittsinställningar
+Override\ default\ font\ settings=Ignorera normala typsnittsinställningar
 
-Override_the_BibTeX_field_by_the_selected_text=
+Override\ the\ BibTeX\ field\ by\ the\ selected\ text=
 
 
-Overwrite=Skriv_över
-Overwrite_existing_field_values=Skriv_över_befintligt_fältinnehåll
+Overwrite=Skriv över
+Overwrite\ existing\ field\ values=Skriv över befintligt fältinnehåll
 
-Overwrite_keys=Skriv_över_nycklar
+Overwrite\ keys=Skriv över nycklar
 
-pairs_processed=par_processade
+pairs\ processed=par processade
 Password=Lösenord
 
-Paste=Klistra_in
+Paste=Klistra in
 
-paste_entries=klistra_in_poster
+paste\ entries=klistra in poster
 
-paste_entry=klistra_in_post
-Paste_from_clipboard=Klistra_in_från_urklipp
+paste\ entry=klistra in post
+Paste\ from\ clipboard=Klistra in från urklipp
 
-Pasted=Klistrade_in
+Pasted=Klistrade in
 
-Path_to_%0_not_defined=Sökväg_till_%0_är_inte_angiven
+Path\ to\ %0\ not\ defined=Sökväg till %0 är inte angiven
 
-Path_to_LyX_pipe=Sökväg_till_LyX-pipe
+Path\ to\ LyX\ pipe=Sökväg till LyX-pipe
 
-PDF_does_not_exist=PDF_finns_inte
+PDF\ does\ not\ exist=PDF finns inte
 
-File_has_no_attached_annotations=
+File\ has\ no\ attached\ annotations=
 
-Plain_text_import=
+Plain\ text\ import=
 
-Please_enter_a_name_for_the_group.=Ange_ett_namn_för_gruppen.
+Please\ enter\ a\ name\ for\ the\ group.=Ange ett namn för gruppen.
 
-Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>=
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=
 
-Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=Ange_fält_att_söka_i_(t._ex._<b>keywords</b>)_och_termen_att_söka_efter_i_det_(t._ex._<b>electrical</b>).
+Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=Ange fält att söka i (t. ex. <b>keywords</b>) och termen att söka efter i det (t. ex. <b>electrical</b>).
 
-Please_enter_the_string's_label=Ange_namnet_på_strängen
+Please\ enter\ the\ string's\ label=Ange namnet på strängen
 
-Please_select_an_importer.=
+Please\ select\ an\ importer.=
 
-Possible_duplicate_entries=Möjliga_dubbletter
+Possible\ duplicate\ entries=Möjliga dubbletter
 
-Possible_duplicate_of_existing_entry._Click_to_resolve.=Möjlig_dubblett_av_befintlig_post._Klicka_för_att_reda_ut.
+Possible\ duplicate\ of\ existing\ entry.\ Click\ to\ resolve.=Möjlig dubblett av befintlig post. Klicka för att reda ut.
 
 Preamble=Preamble
 
 Preferences=Inställningar
 
-Preferences_recorded.=Inställningar_sparade.
+Preferences\ recorded.=Inställningar sparade.
 
 Preview=Postvisning
-Citation_Style=
-Current_Preview=
-Cannot_generate_preview_based_on_selected_citation_style.=
-Bad_character_inside_entry=
-Error_while_generating_citation_style=
-Preview_style_changed_to\:_%0=
-Next_preview_layout=
-Previous_preview_layout=
+Citation\ Style=
+Current\ Preview=
+Cannot\ generate\ preview\ based\ on\ selected\ citation\ style.=
+Bad\ character\ inside\ entry=
+Error\ while\ generating\ citation\ style=
+Preview\ style\ changed\ to\:\ %0=
+Next\ preview\ layout=
+Previous\ preview\ layout=
 
-Previous_entry=Föregående_post
+Previous\ entry=Föregående post
 
-Primary_sort_criterion=Första_sorteringskriteriet
-Problem_with_parsing_entry=Problem_att_tolka_post
-Processing_%0=Behandlar_%0
-Pull_changes_from_shared_database=Hämta_ändringar_från_delad_databas
+Primary\ sort\ criterion=Första sorteringskriteriet
+Problem\ with\ parsing\ entry=Problem att tolka post
+Processing\ %0=Behandlar %0
+Pull\ changes\ from\ shared\ database=Hämta ändringar från delad databas
 
-Pushed_citations_to_%0=Infogade_citeringar_i_%0
+Pushed\ citations\ to\ %0=Infogade citeringar i %0
 
-Quit_JabRef=Avsluta_JabRef
+Quit\ JabRef=Avsluta JabRef
 
-Quit_synchronization=Avsluta_synkronisering
+Quit\ synchronization=Avsluta synkronisering
 
-Raw_source=Rå_källkod
+Raw\ source=Rå källkod
 
-Rearrange_tabs_alphabetically_by_title=Sortera_flikar_i_alfabetisk_ordning
+Rearrange\ tabs\ alphabetically\ by\ title=Sortera flikar i alfabetisk ordning
 
-Redo=Gör_igen
+Redo=Gör igen
 
-Reference_library=Referensdatabas
+Reference\ library=Referensdatabas
 
-%0_references_found._Number_of_references_to_fetch?=Referenser_hittade\:_%0._Antal_referenser_som_ska_hämtas?
+%0\ references\ found.\ Number\ of\ references\ to\ fetch?=Referenser hittade: %0. Antal referenser som ska hämtas?
 
-Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=
 
-regular_expression=reguljärt_uttryck
+regular\ expression=reguljärt uttryck
 
-Related_articles=
+Related\ articles=
 
-Remote_operation=Fjärrstyrning
+Remote\ operation=Fjärrstyrning
 
-Remote_server_port=Port_på_fjärrserver
+Remote\ server\ port=Port på fjärrserver
 
-Remove=Ta_bort
+Remove=Ta bort
 
-Remove_subgroups=Ta_bort_undergrupper
+Remove\ subgroups=Ta bort undergrupper
 
-Remove_all_subgroups_of_"%0"?=Ta_bort_alla_undergrupper_till_"%0"?
+Remove\ all\ subgroups\ of\ "%0"?=Ta bort alla undergrupper till "%0"?
 
-Remove_entry_from_import=Ta_bort_post_från_import
+Remove\ entry\ from\ import=Ta bort post från import
 
-Remove_selected_entries_from_this_group=
+Remove\ selected\ entries\ from\ this\ group=
 
-Remove_entry_type=Ta_bort_posttyp
+Remove\ entry\ type=Ta bort posttyp
 
-Remove_from_group=Ta_bort_från_grupp
+Remove\ from\ group=Ta bort från grupp
 
-Remove_group=Ta_bort_grupp
+Remove\ group=Ta bort grupp
 
-Remove_group,_keep_subgroups=Ta_bort_grupp,_behåll_undergrupper
+Remove\ group,\ keep\ subgroups=Ta bort grupp, behåll undergrupper
 
-Remove_group_"%0"?=Ta_bort_gruppen_"%0"?
+Remove\ group\ "%0"?=Ta bort gruppen "%0"?
 
-Remove_group_"%0"_and_its_subgroups?=Ta_bort_gruppen_"%0"_och_dess_undergrupper?
+Remove\ group\ "%0"\ and\ its\ subgroups?=Ta bort gruppen "%0" och dess undergrupper?
 
-remove_group_(keep_subgroups)=ta_bort_grupp_(behåll_undergrupper)
+remove\ group\ (keep\ subgroups)=ta bort grupp (behåll undergrupper)
 
-remove_group_and_subgroups=ta_bort_grupp_och_undergrupper
+remove\ group\ and\ subgroups=ta bort grupp och undergrupper
 
-Remove_group_and_subgroups=Ta_bort_grupp_och_dess_undergrupper
+Remove\ group\ and\ subgroups=Ta bort grupp och dess undergrupper
 
-Remove_link=Ta_bort_länk
+Remove\ link=Ta bort länk
 
-Remove_old_entry=Ta_bort_gammal_post
+Remove\ old\ entry=Ta bort gammal post
 
-Remove_selected_strings=Ta_bort_valda_strängar
+Remove\ selected\ strings=Ta bort valda strängar
 
-Removed_group_"%0".=Tog_bort_gruppen_"%0".
+Removed\ group\ "%0".=Tog bort gruppen "%0".
 
-Removed_group_"%0"_and_its_subgroups.=Tog_bort_gruppen_"%0"_och_dess_undergrupper.
+Removed\ group\ "%0"\ and\ its\ subgroups.=Tog bort gruppen "%0" och dess undergrupper.
 
-Removed_string=Tog_bort_sträng
+Removed\ string=Tog bort sträng
 
-Renamed_string=Bytte_namn_på_sträng
+Renamed\ string=Bytte namn på sträng
 
 Replace=
 
-Replace_(regular_expression)=Ersätt_(reguljärt_uttryck)
+Replace\ (regular\ expression)=Ersätt (reguljärt uttryck)
 
-Replace_string=Ersätt_sträng
+Replace\ string=Ersätt sträng
 
-Replace_with=Ersätt_med
+Replace\ with=Ersätt med
 
 Replaced=Ersatte
 
-Required_fields=Obligatoriska_fält
+Required\ fields=Obligatoriska fält
 
-Reset_all=Återställ_alla
+Reset\ all=Återställ alla
 
-Resolve_strings_for_all_fields_except=Ersätt_strängar_för_alla_fält_utom
-Resolve_strings_for_standard_BibTeX_fields_only=Ersätt_bara_strängar_för_de_vanliga_BibTeX-fälten
+Resolve\ strings\ for\ all\ fields\ except=Ersätt strängar för alla fält utom
+Resolve\ strings\ for\ standard\ BibTeX\ fields\ only=Ersätt bara strängar för de vanliga BibTeX-fälten
 
 resolved=
 
 Review=
 
-Review_changes=Kontrollera_ändringar
+Review\ changes=Kontrollera ändringar
 
 Right=Höger
 
 Save=Spara
-Save_all_finished.=Alla_har_sparats.
+Save\ all\ finished.=Alla har sparats.
 
-Save_all_open_libraries=Spara_alla_öppna_libraryr
+Save\ all\ open\ libraries=Spara alla öppna libraryr
 
-Save_before_closing=Spara_innan_stängning
+Save\ before\ closing=Spara innan stängning
 
-Save_library=Spara_databas
-Save_library_as...=Spara_databas_som_...
+Save\ library=Spara databas
+Save\ library\ as...=Spara databas som ...
 
-Save_entries_in_their_original_order=Spara_poster_i_ursprunglig_ordning
+Save\ entries\ in\ their\ original\ order=Spara poster i ursprunglig ordning
 
-Save_failed=Sparningen_misslyckades
+Save\ failed=Sparningen misslyckades
 
-Save_failed_during_backup_creation=Sparningen_misslyckades_när_säkerhetskopian_skulle_skapas
+Save\ failed\ during\ backup\ creation=Sparningen misslyckades när säkerhetskopian skulle skapas
 
-Save_selected_as...=Spara_valda_som_...
+Save\ selected\ as...=Spara valda som ...
 
-Saved_library=Sparade_databas
+Saved\ library=Sparade databas
 
-Saved_selected_to_'%0'.=Sparade_valda_till_'%0'.
+Saved\ selected\ to\ '%0'.=Sparade valda till '%0'.
 
 Saving=Sparar
-Saving_all_libraries...=Sparar_alla_libraryr...
+Saving\ all\ libraries...=Sparar alla libraryr...
 
-Saving_library=Sparar_databas
+Saving\ library=Sparar databas
 
 Search=Sök
 
-Search_expression=Sökuttryck
+Search\ expression=Sökuttryck
 
-Search_for=Sök_efter
+Search\ for=Sök efter
 
-Searching_for_duplicates...=Söker_efter_dubbletter...
+Searching\ for\ duplicates...=Söker efter dubbletter...
 
-Searching_for_files=Söker_efter_filer
+Searching\ for\ files=Söker efter filer
 
-Secondary_sort_criterion=Andra_sorteringskriteriet
+Secondary\ sort\ criterion=Andra sorteringskriteriet
 
-Select_all=Välj_alla
+Select\ all=Välj alla
 
-Select_encoding=Välj_teckenkodning
+Select\ encoding=Välj teckenkodning
 
-Select_entry_type=Välj_posttyp
-Select_external_application=Välj_program
+Select\ entry\ type=Välj posttyp
+Select\ external\ application=Välj program
 
-Select_file_from_ZIP-archive=Välj_fil_från_ZIP-arkiv
+Select\ file\ from\ ZIP-archive=Välj fil från ZIP-arkiv
 
-Select_the_tree_nodes_to_view_and_accept_or_reject_changes=
-Selected_entries=Valda_poster
-Set_field=Sätt_fält
-Set_fields=Sätt_fält
+Select\ the\ tree\ nodes\ to\ view\ and\ accept\ or\ reject\ changes=
+Selected\ entries=Valda poster
+Set\ field=Sätt fält
+Set\ fields=Sätt fält
 
-Set_general_fields=Sätt_generella_fält
-Set_main_external_file_directory=Välj_huvudmapp_för_filer
+Set\ general\ fields=Sätt generella fält
+Set\ main\ external\ file\ directory=Välj huvudmapp för filer
 
-Set_table_font=Sätt_tabelltypsnitt
+Set\ table\ font=Sätt tabelltypsnitt
 
 Settings=Alternativ
 
 Shortcut=Genväg
 
-Show/edit_%0_source=Visa/Ändra_%0-källkod
+Show/edit\ %0\ source=Visa/Ändra %0-källkod
 
-Show_'Firstname_Lastname'=Visa_som_'Förnamn_Efternamn'
+Show\ 'Firstname\ Lastname'=Visa som 'Förnamn Efternamn'
 
-Show_'Lastname,_Firstname'=Visa_som_'Efternamn,_Förnamn'
+Show\ 'Lastname,\ Firstname'=Visa som 'Efternamn, Förnamn'
 
-Show_BibTeX_source_by_default=Visa_BibTeX-källkod_som_standard
+Show\ BibTeX\ source\ by\ default=Visa BibTeX-källkod som standard
 
-Show_confirmation_dialog_when_deleting_entries=Visa_bekräftelseruta_när_poster_raderas
+Show\ confirmation\ dialog\ when\ deleting\ entries=Visa bekräftelseruta när poster raderas
 
-Show_description=Visa_beskrivning
+Show\ description=Visa beskrivning
 
-Show_file_column=Visa_filkolumn
+Show\ file\ column=Visa filkolumn
 
-Show_last_names_only=Visa_bara_efternamn
+Show\ last\ names\ only=Visa bara efternamn
 
-Show_names_unchanged=Visa_namnen_som_de_är
+Show\ names\ unchanged=Visa namnen som de är
 
-Show_optional_fields=Visa_valfria_fält
+Show\ optional\ fields=Visa valfria fält
 
-Show_required_fields=Visa_obligatoriska_fält
+Show\ required\ fields=Visa obligatoriska fält
 
-Show_URL/DOI_column=Visa_URL/DOI-kolumn
+Show\ URL/DOI\ column=Visa URL/DOI-kolumn
 
-Simple_HTML=Enkel_HTML
+Simple\ HTML=Enkel HTML
 
 Size=Storlek
 
-Skipped_-_No_PDF_linked=Hoppade_över_-_Ingen_PDF_länkad
-Skipped_-_PDF_does_not_exist=Hoppade_över_-_PDF_fanns_ej
+Skipped\ -\ No\ PDF\ linked=Hoppade över - Ingen PDF länkad
+Skipped\ -\ PDF\ does\ not\ exist=Hoppade över - PDF fanns ej
 
-Skipped_entry.=Hoppade_över_post.
+Skipped\ entry.=Hoppade över post.
 
-Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.=
+Some\ appearance\ settings\ you\ changed\ require\ to\ restart\ JabRef\ to\ come\ into\ effect.=
 
-source_edit=ändring_av_källkod
-Special_name_formatters=Speciella_format_för_namn
+source\ edit=ändring av källkod
+Special\ name\ formatters=Speciella format för namn
 
-Special_table_columns=Speciella_kolumner
+Special\ table\ columns=Speciella kolumner
 
-Starting_import=Börjar_importera
+Starting\ import=Börjar importera
 
-Statically_group_entries_by_manual_assignment=
+Statically\ group\ entries\ by\ manual\ assignment=
 
 Status=Status
 
@@ -1143,1019 +1143,1019 @@ Stop=Stanna
 
 Strings=Strängar
 
-Strings_for_library=Strängar_för_libraryn
+Strings\ for\ library=Strängar för libraryn
 
-Sublibrary_from_AUX=Databas_baserad_på_AUX-fil
+Sublibrary\ from\ AUX=Databas baserad på AUX-fil
 
-Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.=Växlar_mellan_fullt_och_förkortat_tidskiftsnamn_om_tidskriften_är_känd.
+Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=Växlar mellan fullt och förkortat tidskiftsnamn om tidskriften är känd.
 
-Synchronize_file_links=Synkronisera_fillänkar
+Synchronize\ file\ links=Synkronisera fillänkar
 
-Synchronizing_file_links...=Synkroniserar_fillänkar...
+Synchronizing\ file\ links...=Synkroniserar fillänkar...
 
-Table_appearance=Tabellutseende
+Table\ appearance=Tabellutseende
 
-Table_background_color=Bakgrundsfärg_för_tabellen
+Table\ background\ color=Bakgrundsfärg för tabellen
 
-Table_grid_color=Rutnätsfärg_för_tabellen
+Table\ grid\ color=Rutnätsfärg för tabellen
 
-Table_text_color=Textfärg_för_tabellen
+Table\ text\ color=Textfärg för tabellen
 
 Tabname=Fliknamn
-Target_file_cannot_be_a_directory.=Målfilen_kan_inte_vara_en_mapp.
+Target\ file\ cannot\ be\ a\ directory.=Målfilen kan inte vara en mapp.
 
-Tertiary_sort_criterion=Tredje_sorteringskriteriet
+Tertiary\ sort\ criterion=Tredje sorteringskriteriet
 
 Test=Testa
 
-paste_text_here=klistra_in_text_här
+paste\ text\ here=klistra in text här
 
-The_chosen_date_format_for_new_entries_is_not_valid=Det_valda_datumformatet_för_nya_poster_är_inte_giltigt
+The\ chosen\ date\ format\ for\ new\ entries\ is\ not\ valid=Det valda datumformatet för nya poster är inte giltigt
 
-The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:=Den_valde_teckenkodningen_'%0'_kan_inte_representera_följande_tecken
+The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=Den valde teckenkodningen '%0' kan inte representera följande tecken
 
 
-the_field_<b>%0</b>=fältet_<b>%0</b>
+the\ field\ <b>%0</b>=fältet <b>%0</b>
 
-The_file<BR>'%0'<BR>has_been_modified<BR>externally\!=Filen_<b>'%0'</b>_har_ändrats_utanför_JabRef\!
+The\ file<BR>'%0'<BR>has\ been\ modified<BR>externally\!=Filen <b>'%0'</b> har ändrats utanför JabRef!
 
-The_group_"%0"_already_contains_the_selection.=Gruppen_"%0"_innehåller_redan_de_valda_posterna.
+The\ group\ "%0"\ already\ contains\ the\ selection.=Gruppen "%0" innehåller redan de valda posterna.
 
-The_label_of_the_string_cannot_be_a_number.=Strängnamnet_kan_inte_vara_ett_tal.
+The\ label\ of\ the\ string\ cannot\ be\ a\ number.=Strängnamnet kan inte vara ett tal.
 
-The_label_of_the_string_cannot_contain_spaces.=Strängnamnet_kan_inte_innehålla_mellanslag.
+The\ label\ of\ the\ string\ cannot\ contain\ spaces.=Strängnamnet kan inte innehålla mellanslag.
 
-The_label_of_the_string_cannot_contain_the_'\#'_character.=Strängnamnet_kan_inte_innehålla_tecknet_'\#'.
+The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=Strängnamnet kan inte innehålla tecknet '#'.
 
-The_output_option_depends_on_a_valid_import_option.=
-The_PDF_contains_one_or_several_BibTeX-records.=PDFen_innehåller_en_eller_flera_BibTeX-poster.
-Do_you_want_to_import_these_as_new_entries_into_the_current_library?=Vill_du_importera_dessa_som_nya_poster_i_den_befintliga_libraryn?
+The\ output\ option\ depends\ on\ a\ valid\ import\ option.=
+The\ PDF\ contains\ one\ or\ several\ BibTeX-records.=PDFen innehåller en eller flera BibTeX-poster.
+Do\ you\ want\ to\ import\ these\ as\ new\ entries\ into\ the\ current\ library?=Vill du importera dessa som nya poster i den befintliga libraryn?
 
-The_regular_expression_<b>%0</b>_is_invalid\:=Det_reguljära_uttycket_<b>%0</b>_är_ogiltigt\:
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=Det reguljära uttycket <b>%0</b> är ogiltigt:
 
-The_search_is_case_insensitive.=Sökningen_är_inte_skiftlägeskänslig.
+The\ search\ is\ case\ insensitive.=Sökningen är inte skiftlägeskänslig.
 
-The_search_is_case_sensitive.=Sökningen_är_skiftlägeskänslig.
+The\ search\ is\ case\ sensitive.=Sökningen är skiftlägeskänslig.
 
-The_string_has_been_removed_locally=Strängen_har_tagit_bort_lokalt
+The\ string\ has\ been\ removed\ locally=Strängen har tagit bort lokalt
 
-There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?=
+There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=
 
-This_entry_has_no_BibTeX_key._Generate_key_now?=Denna_post_har_ingen_BibTeX-nyckel._Generera_en_nu?
+This\ entry\ has\ no\ BibTeX\ key.\ Generate\ key\ now?=Denna post har ingen BibTeX-nyckel. Generera en nu?
 
-This_entry_is_incomplete=Denna_post_är_ej_komplett
+This\ entry\ is\ incomplete=Denna post är ej komplett
 
-This_entry_type_cannot_be_removed.=Denna_posttyp_kan_inte_tas_bort.
+This\ entry\ type\ cannot\ be\ removed.=Denna posttyp kan inte tas bort.
 
-This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Den_här_externa_länken_är_av_typen_'%0',_som_är_odefinierad._Vad_vill_du_göra?
+This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Den här externa länken är av typen '%0', som är odefinierad. Vad vill du göra?
 
-This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.=
+This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>=Denna_grupp_innehåller_poster_där_fältet_<b>%0</b>_innehåller_nyckelordet_<b>%1</b>
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Denna grupp innehåller poster där fältet <b>%0</b> innehåller nyckelordet <b>%1</b>
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>=Denna_grupp_innehåller_poster_där_fältet_<b>%0</b>_innehåller_det_reguljära_uttrycket_<b>%1</b>
-This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.=
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Denna grupp innehåller poster där fältet <b>%0</b> innehåller det reguljära uttrycket <b>%1</b>
+This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=
 
-This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.=Denna_operationen_kräver_att_alla_valda_poster_har_en_BibTeX-nyckel.
+This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=Denna operationen kräver att alla valda poster har en BibTeX-nyckel.
 
-This_operation_requires_one_or_more_entries_to_be_selected.=Den_här_operationen_kräver_att_en_eller_flera_poster_är_valda.
+This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=Den här operationen kräver att en eller flera poster är valda.
 
-Toggle_entry_preview=Växla_postvisning
-Toggle_groups_interface=Växla_grupphantering
-Try_different_encoding=Prova_en_annan_teckenkodning
+Toggle\ entry\ preview=Växla postvisning
+Toggle\ groups\ interface=Växla grupphantering
+Try\ different\ encoding=Prova en annan teckenkodning
 
-Unabbreviate_journal_names_of_the_selected_entries=Expandera_förkortade_tidskriftsnamn_för_de_valda_posterna
-Unabbreviated_%0_journal_names.=Expanderade_%0_förkortade_tidskriftsnamn.
+Unabbreviate\ journal\ names\ of\ the\ selected\ entries=Expandera förkortade tidskriftsnamn för de valda posterna
+Unabbreviated\ %0\ journal\ names.=Expanderade %0 förkortade tidskriftsnamn.
 
-Unable_to_open_file.=Kan_inte_öppna_fil.
-Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.=Kan_inte_öppna_länk._Programmet_'%0'_som_är_satt_för_filtypen_'%1'_kunde_inte_anropas.
-unable_to_write_to=kan_inte_skriva_till
-Undefined_file_type=Odefinierad_filtyp
+Unable\ to\ open\ file.=Kan inte öppna fil.
+Unable\ to\ open\ link.\ The\ application\ '%0'\ associated\ with\ the\ file\ type\ '%1'\ could\ not\ be\ called.=Kan inte öppna länk. Programmet '%0' som är satt för filtypen '%1' kunde inte anropas.
+unable\ to\ write\ to=kan inte skriva till
+Undefined\ file\ type=Odefinierad filtyp
 
 Undo=Ångra
 
 Union=Union
 
-Unknown_BibTeX_entries=Okända_BibTeX-poster
+Unknown\ BibTeX\ entries=Okända BibTeX-poster
 
-unknown_edit=okänd_ändring
+unknown\ edit=okänd ändring
 
-Unknown_export_format=Okänt_exportformat
+Unknown\ export\ format=Okänt exportformat
 
-Unmark_all=Avmarkera_alla
+Unmark\ all=Avmarkera alla
 
-Unmark_entries=Avmarkera_poster
+Unmark\ entries=Avmarkera poster
 
-Unmark_entry=Avmarkera_post
+Unmark\ entry=Avmarkera post
 
 untitled=namnlös
 
 Up=Uppåt
 
-Update_to_current_column_widths=Uppdatera_till_aktuella_kolumnbredder
+Update\ to\ current\ column\ widths=Uppdatera till aktuella kolumnbredder
 
-Updated_group_selection=
-Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.=Uppgradera_PDF/PS-länkar_att_använda_'%0'-fältet.
-Upgrade_file=Uppgradera_fil
-Upgrade_old_external_file_links_to_use_the_new_feature=
+Updated\ group\ selection=
+Upgrade\ external\ PDF/PS\ links\ to\ use\ the\ '%0'\ field.=Uppgradera PDF/PS-länkar att använda '%0'-fältet.
+Upgrade\ file=Uppgradera fil
+Upgrade\ old\ external\ file\ links\ to\ use\ the\ new\ feature=
 
 usage=användning
-Use_autocompletion_for_the_following_fields=Använd_automatisk_komplettering_för_följande_fält
+Use\ autocompletion\ for\ the\ following\ fields=Använd automatisk komplettering för följande fält
 
-Use_other_look_and_feel=Använd_annan_'look-and-feel'
-Tweak_font_rendering_for_entry_editor_on_Linux=
-Use_regular_expression_search=Använd_sökning_med_reguljära_uttryck
+Use\ other\ look\ and\ feel=Använd annan 'look-and-feel'
+Tweak\ font\ rendering\ for\ entry\ editor\ on\ Linux=
+Use\ regular\ expression\ search=Använd sökning med reguljära uttryck
 
 Username=Användarnamn
 
-Value_cleared_externally=Värdet_raderades_utanför_JabRef
+Value\ cleared\ externally=Värdet raderades utanför JabRef
 
-Value_set_externally=Värdet_sattes_utanför_JabRef
+Value\ set\ externally=Värdet sattes utanför JabRef
 
-verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid=kontrollera_att_LyX_körs_och_att_lyxpipe_är_korrekt
+verify\ that\ LyX\ is\ running\ and\ that\ the\ lyxpipe\ is\ valid=kontrollera att LyX körs och att lyxpipe är korrekt
 
 View=Visa
-Vim_server_name=Vim-servernamn
+Vim\ server\ name=Vim-servernamn
 
-Waiting_for_ArXiv...=Väntar_på_ArXiv...
+Waiting\ for\ ArXiv...=Väntar på ArXiv...
 
-Warn_about_unresolved_duplicates_when_closing_inspection_window=
+Warn\ about\ unresolved\ duplicates\ when\ closing\ inspection\ window=
 
-Warn_before_overwriting_existing_keys=Varna_innan_befintliga_nycklar_skrivs_över
+Warn\ before\ overwriting\ existing\ keys=Varna innan befintliga nycklar skrivs över
 
 Warning=Varning
 
 Warnings=Varningar
 
-web_link=weblänk
+web\ link=weblänk
 
-What_do_you_want_to_do?=Vad_vill_du_göra?
+What\ do\ you\ want\ to\ do?=Vad vill du göra?
 
-When_adding/removing_keywords,_separate_them_by=När_nyckelord_läggs_till/tas_bort,_separera_dem_med
-Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.=Kommer_skriva_XMP-metadata_till_PDFer_länkade_från_valda_poster.
+When\ adding/removing\ keywords,\ separate\ them\ by=När nyckelord läggs till/tas bort, separera dem med
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Kommer skriva XMP-metadata till PDFer länkade från valda poster.
 
 with=med
 
-Write_BibTeXEntry_as_XMP-metadata_to_PDF.=Skriv_BibTeX-posten_som_XMP-metadata_i_PDF.
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Skriv BibTeX-posten som XMP-metadata i PDF.
 
-Write_XMP=Skriv_XMP
-Write_XMP-metadata=Skriv_XMP-metadata
-Write_XMP-metadata_for_all_PDFs_in_current_library?=Skriv_XMP-metadata_för_alla_PDFer_i_aktuell_databas?
-Writing_XMP-metadata...=Skriver_XMP-metadata...
-Writing_XMP-metadata_for_selected_entries...=Skriver_XMP-metadata_för_valda_poster...
+Write\ XMP=Skriv XMP
+Write\ XMP-metadata=Skriv XMP-metadata
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Skriv XMP-metadata för alla PDFer i aktuell databas?
+Writing\ XMP-metadata...=Skriver XMP-metadata...
+Writing\ XMP-metadata\ for\ selected\ entries...=Skriver XMP-metadata för valda poster...
 
-Wrote_XMP-metadata=Skrev_XMP-metadata
+Wrote\ XMP-metadata=Skrev XMP-metadata
 
-XMP-annotated_PDF=
-XMP_export_privacy_settings=
+XMP-annotated\ PDF=
+XMP\ export\ privacy\ settings=
 XMP-metadata=XMP-metadata
-XMP-metadata_found_in_PDF\:_%0=XMP-metadata_funnen_i_PDF\:_%0
-You_must_restart_JabRef_for_this_to_come_into_effect.=Du_måste_starta_om_JabRef_för_att_ändringen_ska_slå_igenom.
-You_have_changed_the_language_setting.=Du_har_ändrat_språkinställningarna.
-You_have_entered_an_invalid_search_'%0'.=Du_har_angett_en_ogiltig_sökning_'%0'.
+XMP-metadata\ found\ in\ PDF\:\ %0=XMP-metadata funnen i PDF: %0
+You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Du måste starta om JabRef för att ändringen ska slå igenom.
+You\ have\ changed\ the\ language\ setting.=Du har ändrat språkinställningarna.
+You\ have\ entered\ an\ invalid\ search\ '%0'.=Du har angett en ogiltig sökning '%0'.
 
-You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.=Du_måste_starta_om_JabRef_för_att_tangentbordsbindningarna_ska_fungera_ordentligt.
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Du måste starta om JabRef för att tangentbordsbindningarna ska fungera ordentligt.
 
-Your_new_key_bindings_have_been_stored.=Dina_nya_tangentbordsbindningar_har_lagrats
+Your\ new\ key\ bindings\ have\ been\ stored.=Dina nya tangentbordsbindningar har lagrats
 
-The_following_fetchers_are_available\:=
-Could_not_find_fetcher_'%0'=Kunde_inte_hitta_hämtaren_'%0'
-Running_query_'%0'_with_fetcher_'%1'.=
-Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.=
+The\ following\ fetchers\ are\ available\:=
+Could\ not\ find\ fetcher\ '%0'=Kunde inte hitta hämtaren '%0'
+Running\ query\ '%0'\ with\ fetcher\ '%1'.=
+Query\ '%0'\ with\ fetcher\ '%1'\ did\ not\ return\ any\ results.=
 
-Move_file=Flytta_fil
-Rename_file=Döp_om_fil
+Move\ file=Flytta fil
+Rename\ file=Döp om fil
 
-Move_file_failed=Gick_inte_att_flytta_fil
-Could_not_move_file_'%0'.=Kunde_inte_flytta_filen_'%0'
-Could_not_find_file_'%0'.=Kunde_inte_hitta_filen_'%0'.
-Number_of_entries_successfully_imported=Antal_poster_som_lyckades_importeras
-Import_canceled_by_user=Import_avbröts_av_användare
-Progress\:_%0_of_%1=Händelseförlopp\:_%0_av_%1
-Error_while_fetching_from_%0=Fel_vid_hämtning_från_%0
+Move\ file\ failed=Gick inte att flytta fil
+Could\ not\ move\ file\ '%0'.=Kunde inte flytta filen '%0'
+Could\ not\ find\ file\ '%0'.=Kunde inte hitta filen '%0'.
+Number\ of\ entries\ successfully\ imported=Antal poster som lyckades importeras
+Import\ canceled\ by\ user=Import avbröts av användare
+Progress\:\ %0\ of\ %1=Händelseförlopp: %0 av %1
+Error\ while\ fetching\ from\ %0=Fel vid hämtning från %0
 
-Please_enter_a_valid_number=Ange_ett_giltigt_tal
-Show_search_results_in_a_window=Visa_sökresultaten_i_ett_fönster
-Show_global_search_results_in_a_window=
-Search_in_all_open_libraries=
-Move_file_to_file_directory?=Flytta_fil_till_filmapp?
+Please\ enter\ a\ valid\ number=Ange ett giltigt tal
+Show\ search\ results\ in\ a\ window=Visa sökresultaten i ett fönster
+Show\ global\ search\ results\ in\ a\ window=
+Search\ in\ all\ open\ libraries=
+Move\ file\ to\ file\ directory?=Flytta fil till filmapp?
 
-Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.=Libraryn_är_skyddad._Kan_inte_spara_innan_externa_ändringar_är_kontrollerade.
-Protected_library=Skyddad_databas
-Refuse_to_save_the_library_before_external_changes_have_been_reviewed.=Vägra_att_spara_libraryn_innan_externa_ändringar_har_kontrollerats.
-Library_protection=Databasskydd
-Unable_to_save_library=Kan_inte_spara_databas
+Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=Libraryn är skyddad. Kan inte spara innan externa ändringar är kontrollerade.
+Protected\ library=Skyddad databas
+Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=Vägra att spara libraryn innan externa ändringar har kontrollerats.
+Library\ protection=Databasskydd
+Unable\ to\ save\ library=Kan inte spara databas
 
-BibTeX_key_generator=BibTeX-nyckelgenerator
-Unable_to_open_link.=Kan_inte_öppna_länk.
-Move_the_keyboard_focus_to_the_entry_table=Flytta_tangentbordsfokus_till_tabellen
-MIME_type=MIME-typ
+BibTeX\ key\ generator=BibTeX-nyckelgenerator
+Unable\ to\ open\ link.=Kan inte öppna länk.
+Move\ the\ keyboard\ focus\ to\ the\ entry\ table=Flytta tangentbordsfokus till tabellen
+MIME\ type=MIME-typ
 
-This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.=
-Run_fetcher,_e.g._"--fetch\=Medline\:cancer"=
+This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef<BR>instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef<br>from\ your\ web\ browser.<BR>Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=
 
-The_ACM_Digital_Library=ACMs_digitala_bibliotek
+The\ ACM\ Digital\ Library=ACMs digitala bibliotek
 Reset=Återställ
 
-Use_IEEE_LaTeX_abbreviations=Använd_IEEE_LaTeX-förkortningar
-The_Guide_to_Computing_Literature=
+Use\ IEEE\ LaTeX\ abbreviations=Använd IEEE LaTeX-förkortningar
+The\ Guide\ to\ Computing\ Literature=
 
-When_opening_file_link,_search_for_matching_file_if_no_link_is_defined=
-Settings_for_%0=Alternativ_för_%0
-Mark_entries_imported_into_an_existing_library=Markera_poster_som_importeras_till_en_befintlig_databas
-Unmark_all_entries_before_importing_new_entries_into_an_existing_library=Avmarkera_alla_poster_innan_nya_importeras_till_en_befintlig_databas
+When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=
+Settings\ for\ %0=Alternativ för %0
+Mark\ entries\ imported\ into\ an\ existing\ library=Markera poster som importeras till en befintlig databas
+Unmark\ all\ entries\ before\ importing\ new\ entries\ into\ an\ existing\ library=Avmarkera alla poster innan nya importeras till en befintlig databas
 
 Forward=Framåt
 Back=Bakåt
-Sort_the_following_fields_as_numeric_fields=Sortera_följande_fält_som_tal
-Line_%0\:_Found_corrupted_BibTeX_key.=Rad_%0\:_Hittade_felaktig_BibTeX-nyckel.
-Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).=
-Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).=Rad_%0\:_Hittade_felaktig_BibTeX-nyckel_(kommatecken_saknas).
-Full_text_document_download_failed=Gick_inte_att_ladda_ned_dokument.
-Update_to_current_column_order=Uppdatera_till_aktuell_kolumnordning
-Download_from_URL=Ladda_ned_från_URL
-Rename_field=Byt_namn_på_fält
-Set/clear/append/rename_fields=Sätt/rensa/byt_namn_på_fält
-Append_field=
-Append_to_fields=
-Rename_field_to=Byt_namn_på_fält_till
-Move_contents_of_a_field_into_a_field_with_a_different_name=Flytta_innehållet_i_ett_fält_till_ett_fält_med_ett_annat_namn
-You_can_only_rename_one_field_at_a_time=Du_kan_bara_döpa_om_en_fil_i_taget
+Sort\ the\ following\ fields\ as\ numeric\ fields=Sortera följande fält som tal
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=Rad %0: Hittade felaktig BibTeX-nyckel.
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=Rad %0: Hittade felaktig BibTeX-nyckel (kommatecken saknas).
+Full\ text\ document\ download\ failed=Gick inte att ladda ned dokument.
+Update\ to\ current\ column\ order=Uppdatera till aktuell kolumnordning
+Download\ from\ URL=Ladda ned från URL
+Rename\ field=Byt namn på fält
+Set/clear/append/rename\ fields=Sätt/rensa/byt namn på fält
+Append\ field=
+Append\ to\ fields=
+Rename\ field\ to=Byt namn på fält till
+Move\ contents\ of\ a\ field\ into\ a\ field\ with\ a\ different\ name=Flytta innehållet i ett fält till ett fält med ett annat namn
+You\ can\ only\ rename\ one\ field\ at\ a\ time=Du kan bara döpa om en fil i taget
 
-Remove_all_broken_links=Ta_bort_alla_trasiga_länkar
+Remove\ all\ broken\ links=Ta bort alla trasiga länkar
 
-Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.=Kan_inte_använda_port_"%0"_för_fjärråtkomst;_ett_annat_program_kanske_använder_den._Försök_med_en_annan_port.
+Cannot\ use\ port\ %0\ for\ remote\ operation;\ another\ application\ may\ be\ using\ it.\ Try\ specifying\ another\ port.=Kan inte använda port "%0" för fjärråtkomst; ett annat program kanske använder den. Försök med en annan port.
 
-Looking_for_full_text_document...=Letar_efter_dokument...
-Autosave=Automatisk_sparning
-A_local_copy_will_be_opened.=
-Autosave_local_libraries=
-Automatically_save_the_library_to=
-Please_enter_a_valid_file_path.=
+Looking\ for\ full\ text\ document...=Letar efter dokument...
+Autosave=Automatisk sparning
+A\ local\ copy\ will\ be\ opened.=
+Autosave\ local\ libraries=
+Automatically\ save\ the\ library\ to=
+Please\ enter\ a\ valid\ file\ path.=
 
 
-Export_in_current_table_sort_order=Exportera_poster_enligt_nuvarande_sortering
-Export_entries_in_their_original_order=Exportera_poster_i_den_ursprungliga_ordningen
-Error_opening_file_'%0'.=Fel_vid_öppning_av_fil_'%0'.
+Export\ in\ current\ table\ sort\ order=Exportera poster enligt nuvarande sortering
+Export\ entries\ in\ their\ original\ order=Exportera poster i den ursprungliga ordningen
+Error\ opening\ file\ '%0'.=Fel vid öppning av fil '%0'.
 
-Formatter_not_found\:_%0=Hittade_ej_formatterare\:_%0
-Clear_inputarea=Rensa_inmatningsområdet
+Formatter\ not\ found\:\ %0=Hittade ej formatterare: %0
+Clear\ inputarea=Rensa inmatningsområdet
 
-Automatically_set_file_links_for_this_entry=Skapa_fillänkar_automatiskt_för_denna_post
-Could_not_save,_file_locked_by_another_JabRef_instance.=Kunde_inte_spara._Filen_låst_av_en_annan_JabRef-instans.
-File_is_locked_by_another_JabRef_instance.=Filen_är_låst_av_en_annan_JabRef-instans.
-Do_you_want_to_override_the_file_lock?=
-File_locked=Filen_är_låst
-Current_tmp_value=Nuvarande_temporära_värde
-Metadata_change=Ändring_i_metadata
-Changes_have_been_made_to_the_following_metadata_elements=Ändringar_har_gjorts_i_följande_metadata-element
+Automatically\ set\ file\ links\ for\ this\ entry=Skapa fillänkar automatiskt för denna post
+Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=Kunde inte spara. Filen låst av en annan JabRef-instans.
+File\ is\ locked\ by\ another\ JabRef\ instance.=Filen är låst av en annan JabRef-instans.
+Do\ you\ want\ to\ override\ the\ file\ lock?=
+File\ locked=Filen är låst
+Current\ tmp\ value=Nuvarande temporära värde
+Metadata\ change=Ändring i metadata
+Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=Ändringar har gjorts i följande metadata-element
 
-Generate_groups_for_author_last_names=Generera_grupper_baserat_på_författarefternamn
-Generate_groups_from_keywords_in_a_BibTeX_field=Generera_grupper_baserat_på_nyckelord_i_ett_fält
-Enforce_legal_characters_in_BibTeX_keys=Framtvinga_giltiga_tecken_i_BibTeX-nycklar
+Generate\ groups\ for\ author\ last\ names=Generera grupper baserat på författarefternamn
+Generate\ groups\ from\ keywords\ in\ a\ BibTeX\ field=Generera grupper baserat på nyckelord i ett fält
+Enforce\ legal\ characters\ in\ BibTeX\ keys=Framtvinga giltiga tecken i BibTeX-nycklar
 
-Save_without_backup?=Spara_utan_att_göra_backup?
-Unable_to_create_backup=Kan_inte_skapa_säkerhetskopia
-Move_file_to_file_directory=Flytta_fil_till_filmapp
-Rename_file_to=Byt_namn_på_fil_till
-<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)=<b>Alla_poster</b>_(den_här_gruppen_kan_inte_ändras_eller_tas_bort)
-static_group=statisk_grupp
-dynamic_group=dynamisk_grupp
-refines_supergroup=
-includes_subgroups=inkluderar_undergrupper
+Save\ without\ backup?=Spara utan att göra backup?
+Unable\ to\ create\ backup=Kan inte skapa säkerhetskopia
+Move\ file\ to\ file\ directory=Flytta fil till filmapp
+Rename\ file\ to=Byt namn på fil till
+<b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=<b>Alla poster</b> (den här gruppen kan inte ändras eller tas bort)
+static\ group=statisk grupp
+dynamic\ group=dynamisk grupp
+refines\ supergroup=
+includes\ subgroups=inkluderar undergrupper
 contains=innehåller
-search_expression=sökuttryck
+search\ expression=sökuttryck
 
-Optional_fields_2=Valfria_fält_2
-Waiting_for_save_operation_to_finish=Väntar_på_att_sparningen_ska_bli_färdig
-Resolving_duplicate_BibTeX_keys...=
-Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.=
-This_library_contains_one_or_more_duplicated_BibTeX_keys.=Denna_databas_innehåller_en_eller_flera_BibTeX-nyckeldubbletter.
-Do_you_want_to_resolve_duplicate_keys_now?=Vill_du_hantera_dubblerade_nycklar_nu?
+Optional\ fields\ 2=Valfria fält 2
+Waiting\ for\ save\ operation\ to\ finish=Väntar på att sparningen ska bli färdig
+Resolving\ duplicate\ BibTeX\ keys...=
+Finished\ resolving\ duplicate\ BibTeX\ keys.\ %0\ entries\ modified.=
+This\ library\ contains\ one\ or\ more\ duplicated\ BibTeX\ keys.=Denna databas innehåller en eller flera BibTeX-nyckeldubbletter.
+Do\ you\ want\ to\ resolve\ duplicate\ keys\ now?=Vill du hantera dubblerade nycklar nu?
 
-Find_and_remove_duplicate_BibTeX_keys=Hitta_och_ta_bort_duplicerade_BibTeX-nycklar
-Expected_syntax_for_--fetch\='<name_of_fetcher>\:<query>'=
-Duplicate_BibTeX_key=Dubblerad_BibTeX-nyckel
-Import_marking_color=Färg_för_importerade_poster
-Always_add_letter_(a,_b,_...)_to_generated_keys=Lägg_alltid_till_en_bokstav_(a,_b_...)_på_genererade_nycklar
+Find\ and\ remove\ duplicate\ BibTeX\ keys=Hitta och ta bort duplicerade BibTeX-nycklar
+Expected\ syntax\ for\ --fetch\='<name\ of\ fetcher>\:<query>'=
+Duplicate\ BibTeX\ key=Dubblerad BibTeX-nyckel
+Import\ marking\ color=Färg för importerade poster
+Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=Lägg alltid till en bokstav (a, b ...) på genererade nycklar
 
-Ensure_unique_keys_using_letters_(a,_b,_...)=Garantera_unika_nycklar_med_bokstäver_(a,_b,_...)
-Ensure_unique_keys_using_letters_(b,_c,_...)=Garantera_unika_nycklar_med_bokstäver_(b,_c,_...)
-Entry_editor_active_background_color=Bakgrundfärg_för_aktiv_post_i_posteditor
-Entry_editor_background_color=Bakgrundfärg_för_posteditor
-Entry_editor_font_color=Typsnittfärg_för_posteditor
-Entry_editor_invalid_field_color=Färg_för_ogiltiga_fält_i_posteditor
+Ensure\ unique\ keys\ using\ letters\ (a,\ b,\ ...)=Garantera unika nycklar med bokstäver (a, b, ...)
+Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=Garantera unika nycklar med bokstäver (b, c, ...)
+Entry\ editor\ active\ background\ color=Bakgrundfärg för aktiv post i posteditor
+Entry\ editor\ background\ color=Bakgrundfärg för posteditor
+Entry\ editor\ font\ color=Typsnittfärg för posteditor
+Entry\ editor\ invalid\ field\ color=Färg för ogiltiga fält i posteditor
 
-Table_and_entry_editor_colors=Färger_för_tabell_och_posteditor
+Table\ and\ entry\ editor\ colors=Färger för tabell och posteditor
 
-General_file_directory=Generell_filmapp
-User-specific_file_directory=Användarspecifik_filmapp
-Search_failed\:_illegal_search_expression=Sökning_misslyckades\:_ogiltigt_sökuttryck
-Show_ArXiv_column=Visa_ArXiv-kolumn
+General\ file\ directory=Generell filmapp
+User-specific\ file\ directory=Användarspecifik filmapp
+Search\ failed\:\ illegal\ search\ expression=Sökning misslyckades: ogiltigt sökuttryck
+Show\ ArXiv\ column=Visa ArXiv-kolumn
 
-You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for=Du_måste_ange_ett_heltal_i_området_1025-65536_i_fältet_för
-Automatically_open_browse_dialog_when_creating_new_file_link=Öppna_fildialog_automatiskt_när_ny_fillänk_skapas
-Import_metadata_from\:=Importera_metadata_från\:
-Choose_the_source_for_the_metadata_import=Välj_källa_för_metadata-import
-Create_entry_based_on_XMP-metadata=Skapa_post_baserat_på_XMP-data
-Create_blank_entry_linking_the_PDF=Skapa_tom_post_som_länkar_till_PDF\:en
-Only_attach_PDF=Lägg_bara_till_PDF
+You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=Du måste ange ett heltal i området 1025-65536 i fältet för
+Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Öppna fildialog automatiskt när ny fillänk skapas
+Import\ metadata\ from\:=Importera metadata från:
+Choose\ the\ source\ for\ the\ metadata\ import=Välj källa för metadata-import
+Create\ entry\ based\ on\ XMP-metadata=Skapa post baserat på XMP-data
+Create\ blank\ entry\ linking\ the\ PDF=Skapa tom post som länkar till PDF:en
+Only\ attach\ PDF=Lägg bara till PDF
 Title=Titel
-Create_new_entry=Skapa_ny_post
-Update_existing_entry=Uppdatera_befintlig_post
-Autocomplete_names_in_'Firstname_Lastname'_format_only=Komplettera_enbart_namn_i_'Förnamn_Efternamn'-format
-Autocomplete_names_in_'Lastname,_Firstname'_format_only=Komplettera_enbart_namn_i_'Efternamn,_Förnamn'-format
-Autocomplete_names_in_both_formats=Komplettera_namn_automatiskt_i_bägge_formaten
-Marking_color_%0=Markeringsfärg_%0
-The_name_'comment'_cannot_be_used_as_an_entry_type_name.=En_posttyp_kan_inte_döpas_till_'comment'.
-You_must_enter_an_integer_value_in_the_text_field_for=Du_måste_ange_ett_heltal_i_fältet_för
-Send_as_email=Skicka_som_epost
+Create\ new\ entry=Skapa ny post
+Update\ existing\ entry=Uppdatera befintlig post
+Autocomplete\ names\ in\ 'Firstname\ Lastname'\ format\ only=Komplettera enbart namn i 'Förnamn Efternamn'-format
+Autocomplete\ names\ in\ 'Lastname,\ Firstname'\ format\ only=Komplettera enbart namn i 'Efternamn, Förnamn'-format
+Autocomplete\ names\ in\ both\ formats=Komplettera namn automatiskt i bägge formaten
+Marking\ color\ %0=Markeringsfärg %0
+The\ name\ 'comment'\ cannot\ be\ used\ as\ an\ entry\ type\ name.=En posttyp kan inte döpas till 'comment'.
+You\ must\ enter\ an\ integer\ value\ in\ the\ text\ field\ for=Du måste ange ett heltal i fältet för
+Send\ as\ email=Skicka som epost
 References=Referenser
-Sending_of_emails=Skicka_epost
-Subject_for_sending_an_email_with_references=Ämne_för_epost_med_referenser
-Automatically_open_folders_of_attached_files=Öppna_automatiskt_mappar_där_filer_som_ska_skickas_med_finns
-Create_entry_based_on_content=Skapa_post_baserat_på_innehåll
-Do_not_show_this_box_again_for_this_import=Visa_inte_denna_ruta_igen_för_den_här_importen
-Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)=Använd_alltid_detta_vid_import_av_PDF_(och_fråga_inte_för_varje_fil)
-Error_creating_email=Fel_vid_skapande_av_epost
-Entries_added_to_an_email=Poster_lades_till_ett_epostmeddelande
+Sending\ of\ emails=Skicka epost
+Subject\ for\ sending\ an\ email\ with\ references=Ämne för epost med referenser
+Automatically\ open\ folders\ of\ attached\ files=Öppna automatiskt mappar där filer som ska skickas med finns
+Create\ entry\ based\ on\ content=Skapa post baserat på innehåll
+Do\ not\ show\ this\ box\ again\ for\ this\ import=Visa inte denna ruta igen för den här importen
+Always\ use\ this\ PDF\ import\ style\ (and\ do\ not\ ask\ for\ each\ import)=Använd alltid detta vid import av PDF (och fråga inte för varje fil)
+Error\ creating\ email=Fel vid skapande av epost
+Entries\ added\ to\ an\ email=Poster lades till ett epostmeddelande
 exportFormat=exportformat
-Output_file_missing=
-No_search_matches.=Sökningen_matchade_inget.
-The_output_option_depends_on_a_valid_input_option.=
-Default_import_style_for_drag_and_drop_of_PDFs=
-Default_PDF_file_link_action=Standardhändelse_för_PDF-fil
-Filename_format_pattern=Filnamnsmönster
-Additional_parameters=Ytterligare_parametrar
-Cite_selected_entries_between_parenthesis=Referera_till_valda_poster_inom_paranteser
-Cite_selected_entries_with_in-text_citation=Referera_till_valda_poster_i_löpande_text
-Cite_special=Specialcitering
-Extra_information_(e.g._page_number)=Extrainformation_(t._ex._sidnummer)
-Manage_citations=Hantera_citeringar
-Problem_modifying_citation=Problem_att_modifiera_citering
+Output\ file\ missing=
+No\ search\ matches.=Sökningen matchade inget.
+The\ output\ option\ depends\ on\ a\ valid\ input\ option.=
+Default\ import\ style\ for\ drag\ and\ drop\ of\ PDFs=
+Default\ PDF\ file\ link\ action=Standardhändelse för PDF-fil
+Filename\ format\ pattern=Filnamnsmönster
+Additional\ parameters=Ytterligare parametrar
+Cite\ selected\ entries\ between\ parenthesis=Referera till valda poster inom paranteser
+Cite\ selected\ entries\ with\ in-text\ citation=Referera till valda poster i löpande text
+Cite\ special=Specialcitering
+Extra\ information\ (e.g.\ page\ number)=Extrainformation (t. ex. sidnummer)
+Manage\ citations=Hantera citeringar
+Problem\ modifying\ citation=Problem att modifiera citering
 Citation=Citering
-Extra_information=Extrainformation
-Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.=Kunde_inte_hitta_en_BibTeX-post_för_referensmarkören_'%0'.
-Select_style=Välj_stil
+Extra\ information=Extrainformation
+Could\ not\ resolve\ BibTeX\ entry\ for\ citation\ marker\ '%0'.=Kunde inte hitta en BibTeX-post för referensmarkören '%0'.
+Select\ style=Välj stil
 Journals=Tidskrifter
 Cite=Referera
-Cite_in-text=Referera_i_löpande_text
-Insert_empty_citation=Infoga_tom_citering
-Merge_citations=Slå_ihop_citeringar
-Manual_connect=Anslut_manuellt
-Select_Writer_document=Välj_Writer-dokument
-Sync_OpenOffice/LibreOffice_bibliography=Synka_OpenOffic/LibreOffice-bibliografi
-Select_which_open_Writer_document_to_work_on=Välj_vilket_öppet_Writer-dokument_som_ska_användas
-Connected_to_document=Ansluten_till_dokument
-Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)=Infoga_en_citering_utan_text_(posten_kommer_visas_i_referenslistan)
-Cite_selected_entries_with_extra_information=Referera_till_valda_poster_och_lägg_till_extra_information
-Ensure_that_the_bibliography_is_up-to-date=Se_till_att_bibliografin_är_uppdaterad
-Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.=Ditt_OpenOffice/LibreOffice-dokument_refererar_till_BibTeX-nyckeln_'%0',_som_inte_kan_hittas_i_din_aktuella_databas.
-Unable_to_synchronize_bibliography=Kan_inte_synkronisera_bibliografi
-Combine_pairs_of_citations_that_are_separated_by_spaces_only=Slå_ihop_citeringar_som_bara_separareras_av_mellanslag
-Autodetection_failed=Kunde_inte_detektera_sökvägar
+Cite\ in-text=Referera i löpande text
+Insert\ empty\ citation=Infoga tom citering
+Merge\ citations=Slå ihop citeringar
+Manual\ connect=Anslut manuellt
+Select\ Writer\ document=Välj Writer-dokument
+Sync\ OpenOffice/LibreOffice\ bibliography=Synka OpenOffic/LibreOffice-bibliografi
+Select\ which\ open\ Writer\ document\ to\ work\ on=Välj vilket öppet Writer-dokument som ska användas
+Connected\ to\ document=Ansluten till dokument
+Insert\ a\ citation\ without\ text\ (the\ entry\ will\ appear\ in\ the\ reference\ list)=Infoga en citering utan text (posten kommer visas i referenslistan)
+Cite\ selected\ entries\ with\ extra\ information=Referera till valda poster och lägg till extra information
+Ensure\ that\ the\ bibliography\ is\ up-to-date=Se till att bibliografin är uppdaterad
+Your\ OpenOffice/LibreOffice\ document\ references\ the\ BibTeX\ key\ '%0',\ which\ could\ not\ be\ found\ in\ your\ current\ library.=Ditt OpenOffice/LibreOffice-dokument refererar till BibTeX-nyckeln '%0', som inte kan hittas i din aktuella databas.
+Unable\ to\ synchronize\ bibliography=Kan inte synkronisera bibliografi
+Combine\ pairs\ of\ citations\ that\ are\ separated\ by\ spaces\ only=Slå ihop citeringar som bara separareras av mellanslag
+Autodetection\ failed=Kunde inte detektera sökvägar
 Connecting=Ansluter
-Please_wait...=Vänta...
-Set_connection_parameters=Sätt_anslutningsinställningar
-Path_to_OpenOffice/LibreOffice_directory=Sökväg_till_OpenOffice/LibreOffice-mapp
-Path_to_OpenOffice/LibreOffice_executable=Sökväg_till_OpenOffice/LibreOffice-program
-Path_to_OpenOffice/LibreOffice_library_dir=
-Connection_lost=Tappade_anslutning
-The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.=
-The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.=
-Automatically_sync_bibliography_when_inserting_citations=Synkronisera_bibliografin_automatiskt_när_citeringar_infogas
-Look_up_BibTeX_entries_in_the_active_tab_only=Leta_bara_efter_BibTeX-poster_i_aktiv_flik
-Look_up_BibTeX_entries_in_all_open_libraries=Leta_efter_BibTeX-poster_i_alla_öppna_libraryr
-Autodetecting_paths...=Detekterar_sökvägar...
-Could_not_find_OpenOffice/LibreOffice_installation=Kunde_inte_hitta_någon_OpenOffice/LibreOffice-installation
-Found_more_than_one_OpenOffice/LibreOffice_executable.=Hittade_mer_än_ett_OpenOffice/LibreOffice-program.
-Please_choose_which_one_to_connect_to\:=Välj_det_du_vill_ansluta_till\:
-Choose_OpenOffice/LibreOffice_executable=Välj_OpenOffice/LibreOffice-program
-Select_document=Välj_dokument
-HTML_list=HTML-lista
-If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting=
-Could_not_open_%0=Kunde_inte_öppna_%0
-Unknown_import_format=Okänt_importformat
-Web_search=Websökning
-Style_selection=Stilval
-No_valid_style_file_defined=Ingen_giltig_stilfil_definierad
-Choose_pattern=Välj_mönster
-Use_the_BIB_file_location_as_primary_file_directory=Använd_BIB-filens_plats_som_primär_filmapp
-Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.=
-OpenOffice/LibreOffice_connection=OpenOffice/LibreOffice-anslutning
-You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.=Du_måste_antingen_välja_en_giltig_stilfil_eller_använda_en_av_standardstilarna.
+Please\ wait...=Vänta...
+Set\ connection\ parameters=Sätt anslutningsinställningar
+Path\ to\ OpenOffice/LibreOffice\ directory=Sökväg till OpenOffice/LibreOffice-mapp
+Path\ to\ OpenOffice/LibreOffice\ executable=Sökväg till OpenOffice/LibreOffice-program
+Path\ to\ OpenOffice/LibreOffice\ library\ dir=
+Connection\ lost=Tappade anslutning
+The\ paragraph\ format\ is\ controlled\ by\ the\ property\ 'ReferenceParagraphFormat'\ or\ 'ReferenceHeaderParagraphFormat'\ in\ the\ style\ file.=
+The\ character\ format\ is\ controlled\ by\ the\ citation\ property\ 'CitationCharacterFormat'\ in\ the\ style\ file.=
+Automatically\ sync\ bibliography\ when\ inserting\ citations=Synkronisera bibliografin automatiskt när citeringar infogas
+Look\ up\ BibTeX\ entries\ in\ the\ active\ tab\ only=Leta bara efter BibTeX-poster i aktiv flik
+Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=Leta efter BibTeX-poster i alla öppna libraryr
+Autodetecting\ paths...=Detekterar sökvägar...
+Could\ not\ find\ OpenOffice/LibreOffice\ installation=Kunde inte hitta någon OpenOffice/LibreOffice-installation
+Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=Hittade mer än ett OpenOffice/LibreOffice-program.
+Please\ choose\ which\ one\ to\ connect\ to\:=Välj det du vill ansluta till:
+Choose\ OpenOffice/LibreOffice\ executable=Välj OpenOffice/LibreOffice-program
+Select\ document=Välj dokument
+HTML\ list=HTML-lista
+If\ possible,\ normalize\ this\ list\ of\ names\ to\ conform\ to\ standard\ BibTeX\ name\ formatting=
+Could\ not\ open\ %0=Kunde inte öppna %0
+Unknown\ import\ format=Okänt importformat
+Web\ search=Websökning
+Style\ selection=Stilval
+No\ valid\ style\ file\ defined=Ingen giltig stilfil definierad
+Choose\ pattern=Välj mönster
+Use\ the\ BIB\ file\ location\ as\ primary\ file\ directory=Använd BIB-filens plats som primär filmapp
+Could\ not\ run\ the\ gnuclient/emacsclient\ program.\ Make\ sure\ you\ have\ the\ emacsclient/gnuclient\ program\ installed\ and\ available\ in\ the\ PATH.=
+OpenOffice/LibreOffice\ connection=OpenOffice/LibreOffice-anslutning
+You\ must\ select\ either\ a\ valid\ style\ file,\ or\ use\ one\ of\ the\ default\ styles.=Du måste antingen välja en giltig stilfil eller använda en av standardstilarna.
 
-This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.=
-This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.=
-You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.=
+This\ is\ a\ simple\ copy\ and\ paste\ dialog.\ First\ load\ or\ paste\ some\ text\ into\ the\ text\ input\ area.<br>After\ that,\ you\ can\ mark\ text\ and\ assign\ it\ to\ a\ BibTeX\ field.=
+This\ feature\ generates\ a\ new\ library\ based\ on\ which\ entries\ are\ needed\ in\ an\ existing\ LaTeX\ document.=
+You\ need\ to\ select\ one\ of\ your\ open\ libraries\ from\ which\ to\ choose\ entries,\ as\ well\ as\ the\ AUX\ file\ produced\ by\ LaTeX\ when\ compiling\ your\ document.=
 
-First_select_entries_to_clean_up.=Välj_först_de_poster_som_du_vill_städa_upp.
-Cleanup_entry=Städa_upp_post
-Autogenerate_PDF_Names=Generera_PDF-namn_automatiskt
-Auto-generating_PDF-Names_does_not_support_undo._Continue?=Du_kan_inte_ångra_automatisk_generering_av_PDF-namn._Fortsätt?
+First\ select\ entries\ to\ clean\ up.=Välj först de poster som du vill städa upp.
+Cleanup\ entry=Städa upp post
+Autogenerate\ PDF\ Names=Generera PDF-namn automatiskt
+Auto-generating\ PDF-Names\ does\ not\ support\ undo.\ Continue?=Du kan inte ångra automatisk generering av PDF-namn. Fortsätt?
 
-Use_full_firstname_whenever_possible=Använd_hela_förnamnet_om_möjligt
-Use_abbreviated_firstname_whenever_possible=Använd_om_möjligt_förkortade_förnamn
-Use_abbreviated_and_full_firstname=Använd_förkortade_och_hela_förnamn
-Autocompletion_options=Inställningar_för_automatisk_komplettering
-Name_format_used_for_autocompletion=Namnformat_för_automatisk_komplettering
-Treatment_of_first_names=Hantering_av_förnamn
-Cleanup_entries=Städa_upp_poster
-Automatically_assign_new_entry_to_selected_groups=Tilldela_automatiskt_nya_poster_till_valda_grupper
-%0_mode=%0-läge
-Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix=Flytta_DOIs_från_'note'-_och_'URL'-fälten_till_'DOI'-fältet_samt_ta_bort_http-prefix
-Make_paths_of_linked_files_relative_(if_possible)=Gör_sökvägen_till_länkade_filer_relativ_(om_möjligt)
-Rename_PDFs_to_given_filename_format_pattern=
-Rename_only_PDFs_having_a_relative_path=
-What_would_you_like_to_clean_up?=Vad_vill_du_städa_upp?
-Doing_a_cleanup_for_%0_entries...=Städar_upp_%0_poster
-No_entry_needed_a_clean_up=Ingen_post_behövde_städas_upp
-One_entry_needed_a_clean_up=En_post_behövde_städas_upp
-%0_entries_needed_a_clean_up=%0_poster_behövde_städas_upp
+Use\ full\ firstname\ whenever\ possible=Använd hela förnamnet om möjligt
+Use\ abbreviated\ firstname\ whenever\ possible=Använd om möjligt förkortade förnamn
+Use\ abbreviated\ and\ full\ firstname=Använd förkortade och hela förnamn
+Autocompletion\ options=Inställningar för automatisk komplettering
+Name\ format\ used\ for\ autocompletion=Namnformat för automatisk komplettering
+Treatment\ of\ first\ names=Hantering av förnamn
+Cleanup\ entries=Städa upp poster
+Automatically\ assign\ new\ entry\ to\ selected\ groups=Tilldela automatiskt nya poster till valda grupper
+%0\ mode=%0-läge
+Move\ DOIs\ from\ note\ and\ URL\ field\ to\ DOI\ field\ and\ remove\ http\ prefix=Flytta DOIs från 'note'- och 'URL'-fälten till 'DOI'-fältet samt ta bort http-prefix
+Make\ paths\ of\ linked\ files\ relative\ (if\ possible)=Gör sökvägen till länkade filer relativ (om möjligt)
+Rename\ PDFs\ to\ given\ filename\ format\ pattern=
+Rename\ only\ PDFs\ having\ a\ relative\ path=
+What\ would\ you\ like\ to\ clean\ up?=Vad vill du städa upp?
+Doing\ a\ cleanup\ for\ %0\ entries...=Städar upp %0 poster
+No\ entry\ needed\ a\ clean\ up=Ingen post behövde städas upp
+One\ entry\ needed\ a\ clean\ up=En post behövde städas upp
+%0\ entries\ needed\ a\ clean\ up=%0 poster behövde städas upp
 
-Remove_selected=Ta_bort_valda
+Remove\ selected=Ta bort valda
 
-Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.=Gruppträdet_kunde_inte_läsas_in._Om_du_sparar_din_databas_kommer_alla_grupper_att_förloras.
-Attach_file=Lägg_till_fil
-Setting_all_preferences_to_default_values.=Återställer_alla_inställningar_till_standardvärden
-Resetting_preference_key_'%0'=Återställer_inställningsvärde_'%0'
-Unknown_preference_key_'%0'=Okänd_inställning_'%0'
-Unable_to_clear_preferences.=Kan_inte_rensa_inställningar.
+Group\ tree\ could\ not\ be\ parsed.\ If\ you\ save\ the\ BibTeX\ library,\ all\ groups\ will\ be\ lost.=Gruppträdet kunde inte läsas in. Om du sparar din databas kommer alla grupper att förloras.
+Attach\ file=Lägg till fil
+Setting\ all\ preferences\ to\ default\ values.=Återställer alla inställningar till standardvärden
+Resetting\ preference\ key\ '%0'=Återställer inställningsvärde '%0'
+Unknown\ preference\ key\ '%0'=Okänd inställning '%0'
+Unable\ to\ clear\ preferences.=Kan inte rensa inställningar.
 
-Reset_preferences_(key1,key2,..._or_'all')=Återställ_inställningar_(nyckel1,nyckel2,..._eller_'all')
-Find_unlinked_files=Hitta_olänkade_filer
-Unselect_all=
-Expand_all=Expandera_alla
-Collapse_all=Fäll_ihop_alla
-Opens_the_file_browser.=Öppnar_filbläddraren
-Scan_directory=Sök_igenom_mapp
-Searches_the_selected_directory_for_unlinked_files.=Söker_i_den_valda_mappen_efter_filer_som_ej_är_länkade_i_libraryn
-Starts_the_import_of_BibTeX_entries.=Börjar_importen_av_BibTeX-poster.
-Leave_this_dialog.=Lämna_denna_dialog.
-Create_directory_based_keywords=Skapa_nyckelord_baserade_på_mapp
-Creates_keywords_in_created_entrys_with_directory_pathnames=Skapar_nyckelord_med_sökvägen_till_mappen_i_de_skapade_posterna
-Select_a_directory_where_the_search_shall_start.=Välj_en_mapp_där_sökningen_ska_börja.
-Select_file_type\:=Välj_filtyp\:
-These_files_are_not_linked_in_the_active_library.=Dessa_filerna_är_inte_länkade_i_den_aktiva_libraryn.
-Entry_type_to_be_created\:=Posttyper_som_kommer_att_skapas\:
-Searching_file_system...=Söker_på_filsystemet...
-Importing_into_Library...=Importerar_till_databas...
-Select_directory=Välj_mapp
-Select_files=Välj_filer
-BibTeX_entry_creation=Skapande_av_BibTeX-poster
-<No_selection>=<Inget_val>
-Unable_to_connect_to_FreeCite_online_service.=
-Parse_with_FreeCite=
-The_current_BibTeX_key_will_be_overwritten._Continue?=Den_aktuella_BibTeX-nyckeln_kommer_att_skrivas_över._Fortsätt?
-Overwrite_key=Skriv_över_nyckel
-Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator=
-How_would_you_like_to_link_to_'%0'?=Hur_vill_du_länka_till_'%0'?
-BibTeX_key_patterns=BibTeX-nyckelmönster
-Changed_special_field_settings=Ändrade_inställningar_för_specialfält
-Clear_priority=Rensa_prioritet
-Clear_rank=Rensa_ranking
-Enable_special_fields=Aktivera_specialfält
-One_star=En_stjärna
-Two_stars=Två_stjärnor
-Three_stars=Tre_stjärnor
-Four_stars=Fyra_stjärnor
-Five_stars=Fem_stjärnor
-Help_on_special_fields=Hjälp_för_specialfält
-Keywords_of_selected_entries=Nyckelord_för_valda_poster
-Manage_content_selectors=Hantera_innehållsväljare
-Manage_keywords=Hantera_nyckelord
-No_priority_information=Ingen_prioritetsinformation
-No_rank_information=Ingen_rankinginformation
+Reset\ preferences\ (key1,key2,...\ or\ 'all')=Återställ inställningar (nyckel1,nyckel2,... eller 'all')
+Find\ unlinked\ files=Hitta olänkade filer
+Unselect\ all=
+Expand\ all=Expandera alla
+Collapse\ all=Fäll ihop alla
+Opens\ the\ file\ browser.=Öppnar filbläddraren
+Scan\ directory=Sök igenom mapp
+Searches\ the\ selected\ directory\ for\ unlinked\ files.=Söker i den valda mappen efter filer som ej är länkade i libraryn
+Starts\ the\ import\ of\ BibTeX\ entries.=Börjar importen av BibTeX-poster.
+Leave\ this\ dialog.=Lämna denna dialog.
+Create\ directory\ based\ keywords=Skapa nyckelord baserade på mapp
+Creates\ keywords\ in\ created\ entrys\ with\ directory\ pathnames=Skapar nyckelord med sökvägen till mappen i de skapade posterna
+Select\ a\ directory\ where\ the\ search\ shall\ start.=Välj en mapp där sökningen ska börja.
+Select\ file\ type\:=Välj filtyp:
+These\ files\ are\ not\ linked\ in\ the\ active\ library.=Dessa filerna är inte länkade i den aktiva libraryn.
+Entry\ type\ to\ be\ created\:=Posttyper som kommer att skapas:
+Searching\ file\ system...=Söker på filsystemet...
+Importing\ into\ Library...=Importerar till databas...
+Select\ directory=Välj mapp
+Select\ files=Välj filer
+BibTeX\ entry\ creation=Skapande av BibTeX-poster
+<No\ selection>=<Inget val>
+Unable\ to\ connect\ to\ FreeCite\ online\ service.=
+Parse\ with\ FreeCite=
+The\ current\ BibTeX\ key\ will\ be\ overwritten.\ Continue?=Den aktuella BibTeX-nyckeln kommer att skrivas över. Fortsätt?
+Overwrite\ key=Skriv över nyckel
+Not\ overwriting\ existing\ key.\ To\ change\ this\ setting,\ open\ Options\ ->\ Prefererences\ ->\ BibTeX\ key\ generator=
+How\ would\ you\ like\ to\ link\ to\ '%0'?=Hur vill du länka till '%0'?
+BibTeX\ key\ patterns=BibTeX-nyckelmönster
+Changed\ special\ field\ settings=Ändrade inställningar för specialfält
+Clear\ priority=Rensa prioritet
+Clear\ rank=Rensa ranking
+Enable\ special\ fields=Aktivera specialfält
+One\ star=En stjärna
+Two\ stars=Två stjärnor
+Three\ stars=Tre stjärnor
+Four\ stars=Fyra stjärnor
+Five\ stars=Fem stjärnor
+Help\ on\ special\ fields=Hjälp för specialfält
+Keywords\ of\ selected\ entries=Nyckelord för valda poster
+Manage\ content\ selectors=Hantera innehållsväljare
+Manage\ keywords=Hantera nyckelord
+No\ priority\ information=Ingen prioritetsinformation
+No\ rank\ information=Ingen rankinginformation
 Priority=Prioritet
-Priority_high=Hög_prioritet
-Priority_low=Låg_prioritet
-Priority_medium=Medel_prioritet
+Priority\ high=Hög prioritet
+Priority\ low=Låg prioritet
+Priority\ medium=Medel prioritet
 Quality=Kvalitet
 Rank=Ranking
 Relevance=Relevans
-Set_priority_to_high=Sätt_prioritet_till_hög
-Set_priority_to_low=Sätt_prioritet_till_låg
-Set_priority_to_medium=Sätt_prioritet_till_medel
-Show_priority=Visa_prioritet
-Show_quality=Visa_kvalitet
-Show_rank=Visa_ranking
-Show_relevance=Visa_relevans
-Synchronize_with_keywords=Synkronisera_med_nyckelord
-Synchronized_special_fields_based_on_keywords=Synkronisera_specialfält_med_hjälp_av_nyckelord
-Toggle_relevance=Växla_relevans
-Toggle_quality_assured=Växla_kvalitetssäkring
-Toggle_print_status=Växla_utskriftsstatus
-Update_keywords=Uppdatera_nyckelord
-Write_values_of_special_fields_as_separate_fields_to_BibTeX=
-You_have_changed_settings_for_special_fields.=Du_har_ändrat_inställningarna_för_specialfält.
-%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.=%0_poster_hittades._För_att_minska_lasten_på_servern_kommer_bara_%1_att_laddas_ned.
-A_string_with_that_label_already_exists=En_sträng_med_det_namnet_finns_redan
-Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.=Anslutningen_till_OpenOffice/LibreOffice_försvann._Se_till_att_OpenOffice/LibreOffice_körs_och_anslut_på_nytt.
-JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.=JabRef_ska_sända_minst_en_begäran_för_varje_post_till_en_förläggare.
-Correct_the_entry,_and_reopen_editor_to_display/edit_source.=
-Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').=
-Could_not_connect_to_running_OpenOffice/LibreOffice.=Kunde_inte_ansluta_till_OpenOffice/LibreOffice.
-Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.=Kontrollera_att_du_har_installerat_OpenOffice/LibreOffice_med_Java-stöd.
-If_connecting_manually,_please_verify_program_and_library_paths.=Om_du_ansluter_manuellt,_kontrollera_sökvägar_till_program_och_bibliotek.
-Error_message\:=Felmeddelande\:
-If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.=
-Import_metadata_from_PDF=Importera_metadata_från_PDF
-Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.=
-Removed_all_subgroups_of_group_"%0".=Tog_bort_alla_undergrupper_för_gruppen_"%0".
-To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.=
-Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.=
-Use_the_following_delimiter_character(s)\:=Använd_följande_bokstäver_som_avgränsare\:
-When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above=
-Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=Din_stilfil_anger_bokstavsformatet_'%0',_som_är_odefinierat_i_ditt_nuvarande_OpenOffice/LibreOffice-dokument.
-Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=Din_stilfil_anger_styckesformatet_'%0',_som_är_odefinierat_i_ditt_nuvarande_OpenOffice/LibreOffice-dokument.
+Set\ priority\ to\ high=Sätt prioritet till hög
+Set\ priority\ to\ low=Sätt prioritet till låg
+Set\ priority\ to\ medium=Sätt prioritet till medel
+Show\ priority=Visa prioritet
+Show\ quality=Visa kvalitet
+Show\ rank=Visa ranking
+Show\ relevance=Visa relevans
+Synchronize\ with\ keywords=Synkronisera med nyckelord
+Synchronized\ special\ fields\ based\ on\ keywords=Synkronisera specialfält med hjälp av nyckelord
+Toggle\ relevance=Växla relevans
+Toggle\ quality\ assured=Växla kvalitetssäkring
+Toggle\ print\ status=Växla utskriftsstatus
+Update\ keywords=Uppdatera nyckelord
+Write\ values\ of\ special\ fields\ as\ separate\ fields\ to\ BibTeX=
+You\ have\ changed\ settings\ for\ special\ fields.=Du har ändrat inställningarna för specialfält.
+%0\ entries\ found.\ To\ reduce\ server\ load,\ only\ %1\ will\ be\ downloaded.=%0 poster hittades. För att minska lasten på servern kommer bara %1 att laddas ned.
+A\ string\ with\ that\ label\ already\ exists=En sträng med det namnet finns redan
+Connection\ to\ OpenOffice/LibreOffice\ has\ been\ lost.\ Please\ make\ sure\ OpenOffice/LibreOffice\ is\ running,\ and\ try\ to\ reconnect.=Anslutningen till OpenOffice/LibreOffice försvann. Se till att OpenOffice/LibreOffice körs och anslut på nytt.
+JabRef\ will\ send\ at\ least\ one\ request\ per\ entry\ to\ a\ publisher.=JabRef ska sända minst en begäran för varje post till en förläggare.
+Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=
+Could\ not\ connect\ to\ a\ running\ gnuserv\ process.\ Make\ sure\ that\ Emacs\ or\ XEmacs\ is\ running,<BR>and\ that\ the\ server\ has\ been\ started\ (by\ running\ the\ command\ 'server-start'/'gnuserv-start').=
+Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=Kunde inte ansluta till OpenOffice/LibreOffice.
+Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=Kontrollera att du har installerat OpenOffice/LibreOffice med Java-stöd.
+If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=Om du ansluter manuellt, kontrollera sökvägar till program och bibliotek.
+Error\ message\:=Felmeddelande:
+If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=
+Import\ metadata\ from\ PDF=Importera metadata från PDF
+Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=
+Removed\ all\ subgroups\ of\ group\ "%0".=Tog bort alla undergrupper för gruppen "%0".
+To\ disable\ the\ memory\ stick\ mode\ rename\ or\ remove\ the\ jabref.xml\ file\ in\ the\ same\ folder\ as\ JabRef.=
+Unable\ to\ connect.\ One\ possible\ reason\ is\ that\ JabRef\ and\ OpenOffice/LibreOffice\ are\ not\ both\ running\ in\ either\ 32\ bit\ mode\ or\ 64\ bit\ mode.=
+Use\ the\ following\ delimiter\ character(s)\:=Använd följande bokstäver som avgränsare:
+When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\ prefer\ the\ BIB\ file\ location\ rather\ than\ the\ file\ directory\ set\ above=
+Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Din stilfil anger bokstavsformatet '%0', som är odefinierat i ditt nuvarande OpenOffice/LibreOffice-dokument.
+Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Din stilfil anger styckesformatet '%0', som är odefinierat i ditt nuvarande OpenOffice/LibreOffice-dokument.
 
 Searching...=Söker...
-You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?=
-Confirm_selection=Bekräfta_val
-Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case=Lägg_till_{}_runt_skyddade_ord_i_titeln_för_att_bevara_skiftläget_vid_sökning
-Import_conversions=Konverteringar_vid_import
-Please_enter_a_search_string=Ange_en_söksträng
-Please_open_or_start_a_new_library_before_searching=Öppna_eller_skapa_en_ny_databas_innan_sökning.
+You\ have\ selected\ more\ than\ %0\ entries\ for\ download.\ Some\ web\ sites\ might\ block\ you\ if\ you\ make\ too\ many\ rapid\ downloads.\ Do\ you\ want\ to\ continue?=
+Confirm\ selection=Bekräfta val
+Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=Lägg till {} runt skyddade ord i titeln för att bevara skiftläget vid sökning
+Import\ conversions=Konverteringar vid import
+Please\ enter\ a\ search\ string=Ange en söksträng
+Please\ open\ or\ start\ a\ new\ library\ before\ searching=Öppna eller skapa en ny databas innan sökning.
 
-Canceled_merging_entries=Avbröt_sammanslagning_av_poster
+Canceled\ merging\ entries=Avbröt sammanslagning av poster
 
-Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search=
-Merge_entries=Kombinera_poster
-Merged_entries=Kombinerade_poster
-Merged_entry=Kombinerad_post
+Format\ units\ by\ adding\ non-breaking\ separators\ and\ keeping\ the\ correct\ case\ on\ search=
+Merge\ entries=Kombinera poster
+Merged\ entries=Kombinerade poster
+Merged\ entry=Kombinerad post
 None=
 Parse=
 Result=Resultat
-Show_DOI_first=Visa_DOI_först
-Show_URL_first=Visa_URL_först
-Use_Emacs_key_bindings=Använd_tangentbordsbindningar_som_i_Emacs
-You_have_to_choose_exactly_two_entries_to_merge.=Du_måste_välja_exakt_två_poster_att_slå_samman.
+Show\ DOI\ first=Visa DOI först
+Show\ URL\ first=Visa URL först
+Use\ Emacs\ key\ bindings=Använd tangentbordsbindningar som i Emacs
+You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=Du måste välja exakt två poster att slå samman.
 
-Update_timestamp_on_modification=Uppdatera_tidsstämpeln_efter_ändring
-All_key_bindings_will_be_reset_to_their_defaults.=Alla_tangentbordsbindingar_kommer_att_återställas_till_standardvärden.
+Update\ timestamp\ on\ modification=Uppdatera tidsstämpeln efter ändring
+All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=Alla tangentbordsbindingar kommer att återställas till standardvärden.
 
-Automatically_set_file_links=Skapa_fillänkar_automatiskt
-Resetting_all_key_bindings=Återställer_alla_tangentbordsbindningar
+Automatically\ set\ file\ links=Skapa fillänkar automatiskt
+Resetting\ all\ key\ bindings=Återställer alla tangentbordsbindningar
 Hostname=Värd
-Invalid_setting=Ogiltig_inställning
+Invalid\ setting=Ogiltig inställning
 Network=Nätverk
-Please_specify_both_hostname_and_port=Ange_både_värdnamn_och_port
-Please_specify_both_username_and_password=Ange_både_användarnamn_och_lösenord
+Please\ specify\ both\ hostname\ and\ port=Ange både värdnamn och port
+Please\ specify\ both\ username\ and\ password=Ange både användarnamn och lösenord
 
-Use_custom_proxy_configuration=Använd_egen_proxykonfiguration
-Proxy_requires_authentication=Proxyn_kräver_autentisering
-Attention\:_Password_is_stored_in_plain_text\!=OBS\!_Lösenordet_sparas_i_klartext\!
-Clear_connection_settings=Rensa_anslutningsinställningar
-Cleared_connection_settings.=Rensade_anslutningsinställningar.
+Use\ custom\ proxy\ configuration=Använd egen proxykonfiguration
+Proxy\ requires\ authentication=Proxyn kräver autentisering
+Attention\:\ Password\ is\ stored\ in\ plain\ text\!=OBS! Lösenordet sparas i klartext!
+Clear\ connection\ settings=Rensa anslutningsinställningar
+Cleared\ connection\ settings.=Rensade anslutningsinställningar.
 
-Rebind_C-a,_too=
-Rebind_C-f,_too=
+Rebind\ C-a,\ too=
+Rebind\ C-f,\ too=
 
-Open_folder=Öppna_mapp
-Searches_for_unlinked_PDF_files_on_the_file_system=Letar_efter_olänkade_PDF-filer_på_filsystemet
-Export_entries_ordered_as_specified=Exportera_poster_enligt_inställningar
-Export_sort_order=Soteringsordning_vid_export
-Export_sorting=Sortering_vid_export
-Newline_separator=Radbrytningstecken
+Open\ folder=Öppna mapp
+Searches\ for\ unlinked\ PDF\ files\ on\ the\ file\ system=Letar efter olänkade PDF-filer på filsystemet
+Export\ entries\ ordered\ as\ specified=Exportera poster enligt inställningar
+Export\ sort\ order=Soteringsordning vid export
+Export\ sorting=Sortering vid export
+Newline\ separator=Radbrytningstecken
 
-Save_entries_ordered_as_specified=Spara_poster_som_angivet
-Save_sort_order=
-Show_extra_columns=Visa_extrakolumner
-Parsing_error=
-illegal_backslash_expression=
+Save\ entries\ ordered\ as\ specified=Spara poster som angivet
+Save\ sort\ order=
+Show\ extra\ columns=Visa extrakolumner
+Parsing\ error=
+illegal\ backslash\ expression=
 
-Move_to_group=Flytta_till_grupp
+Move\ to\ group=Flytta till grupp
 
-Clear_read_status=Rensa_lässtatus
-Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')=Konvertera_till_biblatex-format_(t._ex._genom_att_flytta_data_från_'journal'-fältet_till_'journaltitle'-fältet)
-Could_not_apply_changes.=Kunde_inte_tillämpa_inte_ändringar.
-Deprecated_fields=
-Hide/show_toolbar=Dölj/visa_verktygslist
-No_read_status_information=Ingen_information_om_lässtatus
+Clear\ read\ status=Rensa lässtatus
+Convert\ to\ biblatex\ format\ (for\ example,\ move\ the\ value\ of\ the\ 'journal'\ field\ to\ 'journaltitle')=Konvertera till biblatex-format (t. ex. genom att flytta data från 'journal'-fältet till 'journaltitle'-fältet)
+Could\ not\ apply\ changes.=Kunde inte tillämpa inte ändringar.
+Deprecated\ fields=
+Hide/show\ toolbar=Dölj/visa verktygslist
+No\ read\ status\ information=Ingen information om lässtatus
 Printed=Utskriven
-Read_status=Lässtatus
-Read_status_read=Läst
-Read_status_skimmed=Skummat
-Save_selected_as_plain_BibTeX...=Spara_valda_som_enkel_BibTeX...
-Set_read_status_to_read=Sätt_lässtatus_till_läst
-Set_read_status_to_skimmed=Sätt_lässtatus_till_skummat
-Show_deprecated_BibTeX_fields=
+Read\ status=Lässtatus
+Read\ status\ read=Läst
+Read\ status\ skimmed=Skummat
+Save\ selected\ as\ plain\ BibTeX...=Spara valda som enkel BibTeX...
+Set\ read\ status\ to\ read=Sätt lässtatus till läst
+Set\ read\ status\ to\ skimmed=Sätt lässtatus till skummat
+Show\ deprecated\ BibTeX\ fields=
 
-Show_gridlines=Visa_rutnät
-Show_printed_status=Visa_utskriftsstatus
-Show_read_status=Visa_lässtatus
-Table_row_height_padding=Extra_höjd_på_tabellrader
+Show\ gridlines=Visa rutnät
+Show\ printed\ status=Visa utskriftsstatus
+Show\ read\ status=Visa lässtatus
+Table\ row\ height\ padding=Extra höjd på tabellrader
 
-Marked_selected_entry=Markerade_vald_post
-Marked_all_%0_selected_entries=Markerade_alla_%0_valda_poster
-Unmarked_selected_entry=Avmarkerade_valda_poster
-Unmarked_all_%0_selected_entries=Avmarkerade_alla_%0_valda_poster
+Marked\ selected\ entry=Markerade vald post
+Marked\ all\ %0\ selected\ entries=Markerade alla %0 valda poster
+Unmarked\ selected\ entry=Avmarkerade valda poster
+Unmarked\ all\ %0\ selected\ entries=Avmarkerade alla %0 valda poster
 
 
-Unmarked_all_entries=Avmarkerade_alla_poster
+Unmarked\ all\ entries=Avmarkerade alla poster
 
-Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.=
+Unable\ to\ find\ the\ requested\ look\ and\ feel\ and\ thus\ the\ default\ one\ is\ used.=
 
-Opens_JabRef's_GitHub_page=Öppnar_JabRefs_GitHub-sida
-Could_not_open_browser.=Kunde_inte_öppna_webbläsaren.
-Please_open_%0_manually.=Öppna_%0_för_hand.
-The_link_has_been_copied_to_the_clipboard.=Länken_har_kopierats_till_urklipp.
+Opens\ JabRef's\ GitHub\ page=Öppnar JabRefs GitHub-sida
+Could\ not\ open\ browser.=Kunde inte öppna webbläsaren.
+Please\ open\ %0\ manually.=Öppna %0 för hand.
+The\ link\ has\ been\ copied\ to\ the\ clipboard.=Länken har kopierats till urklipp.
 
-Open_%0_file=Öppna_%0-fil
+Open\ %0\ file=Öppna %0-fil
 
-Cannot_delete_file=Kan_inte_radera_fil
-File_permission_error=Rättighetsfel_för_fil
-Push_to_%0=Infoga_i_%0
-Path_to_%0=Sökväg_till_%0
+Cannot\ delete\ file=Kan inte radera fil
+File\ permission\ error=Rättighetsfel för fil
+Push\ to\ %0=Infoga i %0
+Path\ to\ %0=Sökväg till %0
 Convert=Konvertera
-Normalize_to_BibTeX_name_format=
-Help_on_Name_Formatting=Hjälp_för_namnformattering
+Normalize\ to\ BibTeX\ name\ format=
+Help\ on\ Name\ Formatting=Hjälp för namnformattering
 
-Add_new_file_type=Lägg_till_ny_filtyp
+Add\ new\ file\ type=Lägg till ny filtyp
 
-Left_entry=Vänster_post
-Right_entry=Höger_post
+Left\ entry=Vänster post
+Right\ entry=Höger post
 Use=Använd
-Original_entry=Ursprunglig_post
-Replace_original_entry=Ersätt_ursprunglig_post
-No_information_added=Ingen_information_tillagd
-Select_at_least_one_entry_to_manage_keywords.=Välj_åtminstone_en_post_för_att_hantera_nyckelord.
-OpenDocument_text=OpenDocument-text
-OpenDocument_spreadsheet=OpenDocument-kalkylark
-OpenDocument_presentation=OpenDocument-presentation
-%0_image=%0-bild
-Added_entry=Lade_till_post
-Modified_entry=Ändrad_post
-Deleted_entry=Raderade_post
-Modified_groups_tree=Modifierade_gruppträd
-Removed_all_groups=Tog_bort_alla_grupper
-Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.=Om_ändringarna_accepteras_så_kommer_hela_gruppträdet_att_ersättas_av_det_externt_ändrade_gruppträdet.
-Select_export_format=
-Return_to_JabRef=Återgå_till_JabRef
-Please_move_the_file_manually_and_link_in_place.=
-Could_not_connect_to_%0=Kunde_inte_ansluta_till_%0
-Warning\:_%0_out_of_%1_entries_have_undefined_title.=
-Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.=Varning\:_%0_av_%1_poster_har_odefinierade_BibTeX-nycklar.
+Original\ entry=Ursprunglig post
+Replace\ original\ entry=Ersätt ursprunglig post
+No\ information\ added=Ingen information tillagd
+Select\ at\ least\ one\ entry\ to\ manage\ keywords.=Välj åtminstone en post för att hantera nyckelord.
+OpenDocument\ text=OpenDocument-text
+OpenDocument\ spreadsheet=OpenDocument-kalkylark
+OpenDocument\ presentation=OpenDocument-presentation
+%0\ image=%0-bild
+Added\ entry=Lade till post
+Modified\ entry=Ändrad post
+Deleted\ entry=Raderade post
+Modified\ groups\ tree=Modifierade gruppträd
+Removed\ all\ groups=Tog bort alla grupper
+Accepting\ the\ change\ replaces\ the\ complete\ groups\ tree\ with\ the\ externally\ modified\ groups\ tree.=Om ändringarna accepteras så kommer hela gruppträdet att ersättas av det externt ändrade gruppträdet.
+Select\ export\ format=
+Return\ to\ JabRef=Återgå till JabRef
+Please\ move\ the\ file\ manually\ and\ link\ in\ place.=
+Could\ not\ connect\ to\ %0=Kunde inte ansluta till %0
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ title.=
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ BibTeX\ key.=Varning: %0 av %1 poster har odefinierade BibTeX-nycklar.
 occurrence=förekomst
-Added_new_'%0'_entry.=Lade_till_ny_'%0'-post.
-Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?=Flera_poster_valda._Vill_du_ändra_typen_för_alla_dessa_till_'%0'?
-Changed_type_to_'%0'_for=Ändrade_typ_till_'%0'_för
-Really_delete_the_selected_entry?=Verkligen_ta_bort_den_valda_posten?
-Really_delete_the_%0_selected_entries?=Verkligen_ta_bort_de_%0_valda_posterna?
-Keep_merged_entry_only=Behåll_bara_sammanslagen_post
-Keep_left=Behåll_vänstra
-Keep_right=Behåll_högra
-Old_entry=Gammal_post
-From_import=Från_import
-No_problems_found.=Inga_problem_hittades.
-%0_problem(s)_found=%0_problem_hittades
-Save_changes=Spara_ändringar
-Discard_changes=Ignorera_ändringar
-Library_'%0'_has_changed.=Libraryn_'%0'_har_ändrats.
-Print_entry_preview=Skriv_ut_postvisning
-Copy_title=
-Copy_\\cite{BibTeX_key}=Kopiera_\\cite{BibTeX-nyckel}
-Copy_BibTeX_key_and_title=Kopiera_BibTeX-nyckel_och_titel
-File_rename_failed_for_%0_entries.=Döpa_om_filen_misslyckades_för_%0_poster.
-Merged_BibTeX_source_code=Kombinerad_BibTeX-källkod
-Invalid_DOI\:_'%0'.=Ogiltig_DOI\:_'%0'.
-should_start_with_a_name=ska_börja_med_ett_namn
-should_end_with_a_name=ska_avslutas_med_ett_namn
-unexpected_closing_curly_bracket=oväntad_avslutande_måsvinge
-unexpected_opening_curly_bracket=oväntad_startande_måsvinge
-capital_letters_are_not_masked_using_curly_brackets_{}=stora_bokstäver_är_inte_skyddade_med_måsvingar_{}
-should_contain_a_four_digit_number=ska_innehålla_ett_fyrsiffrigt_tal
-should_contain_a_valid_page_number_range=ska_innehålla_ett_giltligt_sidintervall
+Added\ new\ '%0'\ entry.=Lade till ny '%0'-post.
+Multiple\ entries\ selected.\ Do\ you\ want\ to\ change\ the\ type\ of\ all\ these\ to\ '%0'?=Flera poster valda. Vill du ändra typen för alla dessa till '%0'?
+Changed\ type\ to\ '%0'\ for=Ändrade typ till '%0' för
+Really\ delete\ the\ selected\ entry?=Verkligen ta bort den valda posten?
+Really\ delete\ the\ %0\ selected\ entries?=Verkligen ta bort de %0 valda posterna?
+Keep\ merged\ entry\ only=Behåll bara sammanslagen post
+Keep\ left=Behåll vänstra
+Keep\ right=Behåll högra
+Old\ entry=Gammal post
+From\ import=Från import
+No\ problems\ found.=Inga problem hittades.
+%0\ problem(s)\ found=%0 problem hittades
+Save\ changes=Spara ändringar
+Discard\ changes=Ignorera ändringar
+Library\ '%0'\ has\ changed.=Libraryn '%0' har ändrats.
+Print\ entry\ preview=Skriv ut postvisning
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=Kopiera \\cite{BibTeX-nyckel}
+Copy\ BibTeX\ key\ and\ title=Kopiera BibTeX-nyckel och titel
+File\ rename\ failed\ for\ %0\ entries.=Döpa om filen misslyckades för %0 poster.
+Merged\ BibTeX\ source\ code=Kombinerad BibTeX-källkod
+Invalid\ DOI\:\ '%0'.=Ogiltig DOI: '%0'.
+should\ start\ with\ a\ name=ska börja med ett namn
+should\ end\ with\ a\ name=ska avslutas med ett namn
+unexpected\ closing\ curly\ bracket=oväntad avslutande måsvinge
+unexpected\ opening\ curly\ bracket=oväntad startande måsvinge
+capital\ letters\ are\ not\ masked\ using\ curly\ brackets\ {}=stora bokstäver är inte skyddade med måsvingar {}
+should\ contain\ a\ four\ digit\ number=ska innehålla ett fyrsiffrigt tal
+should\ contain\ a\ valid\ page\ number\ range=ska innehålla ett giltligt sidintervall
 Filled=Fyllde
-Field_is_missing=Fält_saknas
-Search_%0=Sök_%0
+Field\ is\ missing=Fält saknas
+Search\ %0=Sök %0
 
-Search_results_in_all_libraries_for_%0=Söker_efter_%0_i_alla_libraryr
-Search_results_in_library_%0_for_%1=Söker_efter_%1_i_libraryn_%0
-Search_globally=Sök_globalt
-No_results_found.=Inga_resultat_hittades.
-Found_%0_results.=Hittade_%0_resultat.
-plain_text=klartext
-This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>=Denna_sökning_innehåller_poster_där_något_fält_innehåller_det_reguljära_uttrycket_<b>%0</b>
-This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>=Denna_sökning_innehåller_poster_där_något_fält_innehåller_termen_<b>%0</b>
-This_search_contains_entries_in_which=Denna_sökning_innehåller_poster_där
+Search\ results\ in\ all\ libraries\ for\ %0=Söker efter %0 i alla libraryr
+Search\ results\ in\ library\ %0\ for\ %1=Söker efter %1 i libraryn %0
+Search\ globally=Sök globalt
+No\ results\ found.=Inga resultat hittades.
+Found\ %0\ results.=Hittade %0 resultat.
+plain\ text=klartext
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ regular\ expression\ <b>%0</b>=Denna sökning innehåller poster där något fält innehåller det reguljära uttrycket <b>%0</b>
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ term\ <b>%0</b>=Denna sökning innehåller poster där något fält innehåller termen <b>%0</b>
+This\ search\ contains\ entries\ in\ which=Denna sökning innehåller poster där
 
-Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.=Kan_inte_hitta_OpenOffice/LibreOffice._Ställ_in_sökvägar_manuellt.
-JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>=
-This_library_uses_outdated_file_links.=Denna_databas_använder_utdaterade_fillänkar.
+Unable\ to\ autodetect\ OpenOffice/LibreOffice\ installation.\ Please\ choose\ the\ installation\ directory\ manually.=Kan inte hitta OpenOffice/LibreOffice. Ställ in sökvägar manuellt.
+JabRef\ no\ longer\ supports\ 'ps'\ or\ 'pdf'\ fields.<br>File\ links\ are\ now\ stored\ in\ the\ 'file'\ field\ and\ files\ are\ stored\ in\ an\ external\ file\ directory.<br>To\ make\ use\ of\ this\ feature,\ JabRef\ needs\ to\ upgrade\ file\ links.<br><br>=
+This\ library\ uses\ outdated\ file\ links.=Denna databas använder utdaterade fillänkar.
 
-Clear_search=Rensa_sökning
-Close_library=Stäng_databas
-Close_entry_editor=Stäng_posteditor
-Decrease_table_font_size=Minska_typsnittsstorlek_för_tabellen
-Entry_editor,_next_entry=Posteditor,_nästa_post
-Entry_editor,_next_panel=Posteditor,_nästa_panel
-Entry_editor,_next_panel_2=Posteditor,_nästa_panel_2
-Entry_editor,_previous_entry=Posteditor,_föregående_post
-Entry_editor,_previous_panel=Posteditor,_föregående_panel
-Entry_editor,_previous_panel_2=Posteditor,_föregående_panel_2
-File_list_editor,_move_entry_down=
-File_list_editor,_move_entry_up=
-Focus_entry_table=Fokusera_tabellen
-Import_into_current_library=Importera_till_nuvarande_databas
-Import_into_new_library=Importera_till_ny_databas
-Increase_table_font_size=Öka_typsnittsstorlek_för_tabellen
-New_article=Ny_article-post
-New_book=Ny_book-post
-New_entry=Ny_post
-New_from_plain_text=Ny_från_text
-New_inbook=Ny_inbook-post
-New_mastersthesis=Ny_mastersthesis-post
-New_phdthesis=Ny_phdthesis-post
-New_proceedings=Ny_proceedings-post
-New_unpublished=Ny_unpublished-post
-Next_tab=Nästa_flik
-Preamble_editor,_store_changes=Preamble-editorn,_spara_ändringar
-Previous_tab=Föregående_flik
-Push_to_application=Infoga_i_program
-Refresh_OpenOffice/LibreOffice=Uppdatera_OpenOffice/LibreOffice
-Resolve_duplicate_BibTeX_keys=Hantera_BibTeX-nyckeldubbletter
-Save_all=Spara_alla
-String_dialog,_add_string=Strängdialog,_lägg_till_sträng
-String_dialog,_remove_string=Strängdialog,_ta_bort_sträng
-Synchronize_files=Synkronisera_filer
-Unabbreviate=Expandera_förkortning
-should_contain_a_protocol=ska_innehålla_ett_protokoll
-Copy_preview=Kopiera_postvisning
-Automatically_setting_file_links=Skapar_fillänkar_automatiskt
-Regenerating_BibTeX_keys_according_to_metadata=Generera_BibTeX-nycklar_enligt_metadata
-No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys=
-Regenerate_all_keys_for_the_entries_in_a_BibTeX_file=Generera_BibTeX-nycklar_för_alla_poster_i_en_BibTeX-fil
-Show_debug_level_messages=Visa_fler_felmeddelanden_för_avlusning
-Default_bibliography_mode=Standardläge_för_databas
-New_%0_library_created.=Ny_%0-databas_skapades.
-Show_only_preferences_deviating_from_their_default_value=Visa_bara_inställningar_som_skiljer_från_sitt_standardvärde
+Clear\ search=Rensa sökning
+Close\ library=Stäng databas
+Close\ entry\ editor=Stäng posteditor
+Decrease\ table\ font\ size=Minska typsnittsstorlek för tabellen
+Entry\ editor,\ next\ entry=Posteditor, nästa post
+Entry\ editor,\ next\ panel=Posteditor, nästa panel
+Entry\ editor,\ next\ panel\ 2=Posteditor, nästa panel 2
+Entry\ editor,\ previous\ entry=Posteditor, föregående post
+Entry\ editor,\ previous\ panel=Posteditor, föregående panel
+Entry\ editor,\ previous\ panel\ 2=Posteditor, föregående panel 2
+File\ list\ editor,\ move\ entry\ down=
+File\ list\ editor,\ move\ entry\ up=
+Focus\ entry\ table=Fokusera tabellen
+Import\ into\ current\ library=Importera till nuvarande databas
+Import\ into\ new\ library=Importera till ny databas
+Increase\ table\ font\ size=Öka typsnittsstorlek för tabellen
+New\ article=Ny article-post
+New\ book=Ny book-post
+New\ entry=Ny post
+New\ from\ plain\ text=Ny från text
+New\ inbook=Ny inbook-post
+New\ mastersthesis=Ny mastersthesis-post
+New\ phdthesis=Ny phdthesis-post
+New\ proceedings=Ny proceedings-post
+New\ unpublished=Ny unpublished-post
+Next\ tab=Nästa flik
+Preamble\ editor,\ store\ changes=Preamble-editorn, spara ändringar
+Previous\ tab=Föregående flik
+Push\ to\ application=Infoga i program
+Refresh\ OpenOffice/LibreOffice=Uppdatera OpenOffice/LibreOffice
+Resolve\ duplicate\ BibTeX\ keys=Hantera BibTeX-nyckeldubbletter
+Save\ all=Spara alla
+String\ dialog,\ add\ string=Strängdialog, lägg till sträng
+String\ dialog,\ remove\ string=Strängdialog, ta bort sträng
+Synchronize\ files=Synkronisera filer
+Unabbreviate=Expandera förkortning
+should\ contain\ a\ protocol=ska innehålla ett protokoll
+Copy\ preview=Kopiera postvisning
+Automatically\ setting\ file\ links=Skapar fillänkar automatiskt
+Regenerating\ BibTeX\ keys\ according\ to\ metadata=Generera BibTeX-nycklar enligt metadata
+No\ meta\ data\ present\ in\ BIB\ file.\ Cannot\ regenerate\ BibTeX\ keys=
+Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=Generera BibTeX-nycklar för alla poster i en BibTeX-fil
+Show\ debug\ level\ messages=Visa fler felmeddelanden för avlusning
+Default\ bibliography\ mode=Standardläge för databas
+New\ %0\ library\ created.=Ny %0-databas skapades.
+Show\ only\ preferences\ deviating\ from\ their\ default\ value=Visa bara inställningar som skiljer från sitt standardvärde
 default=standard
 key=nyckel
 type=typ
 value=värde
-Show_preferences=Visa_inställningar
-Save_actions=Händelser_vid_sparning
-Enable_save_actions=Aktivera_automatiska_händelser_vid_sparning
+Show\ preferences=Visa inställningar
+Save\ actions=Händelser vid sparning
+Enable\ save\ actions=Aktivera automatiska händelser vid sparning
 
-Other_fields=Andra_fält
-Show_remaining_fields=Visa_kvarvarande_fält
+Other\ fields=Andra fält
+Show\ remaining\ fields=Visa kvarvarande fält
 
-link_should_refer_to_a_correct_file_path=länken_ska_ange_en_korrekt_sökväg
-abbreviation_detected=förkortning_upptäcktes
-wrong_entry_type_as_proceedings_has_page_numbers=fel_posttyp_eftersom_proceeding_har_sidnummer
-Abbreviate_journal_names=Förkorta_tidskriftsnamn
+link\ should\ refer\ to\ a\ correct\ file\ path=länken ska ange en korrekt sökväg
+abbreviation\ detected=förkortning upptäcktes
+wrong\ entry\ type\ as\ proceedings\ has\ page\ numbers=fel posttyp eftersom proceeding har sidnummer
+Abbreviate\ journal\ names=Förkorta tidskriftsnamn
 Abbreviating...=Förkortar...
-Abbreviation_%s_for_journal_%s_already_defined.=
-Abbreviation_cannot_be_empty=
-Duplicated_Journal_Abbreviation=
-Duplicated_Journal_File=
-Error_Occurred=
-Journal_file_%s_already_added=
-Name_cannot_be_empty=
+Abbreviation\ %s\ for\ journal\ %s\ already\ defined.=
+Abbreviation\ cannot\ be\ empty=
+Duplicated\ Journal\ Abbreviation=
+Duplicated\ Journal\ File=
+Error\ Occurred=
+Journal\ file\ %s\ already\ added=
+Name\ cannot\ be\ empty=
 
-Adding_fetched_entries=Lägger_till_hämtade_poster
-Display_keywords_appearing_in_ALL_entries=Visa_nyckelord_som_finns_i_ALLA_poster
-Display_keywords_appearing_in_ANY_entry=Visa_nyckelord_som_finns_i_NÅGON_post
-Fetching_entries_from_Inspire=Hämtar_poster_från_Inspire
-None_of_the_selected_entries_have_titles.=
-None_of_the_selected_entries_have_BibTeX_keys.=Ingen_av_de_valda_posterna_har_någon_BibTeX-nyckel.
-Unabbreviate_journal_names=Expandera_förkortade_tidskriftsnamn
-Unabbreviating...=Expanderar_förkortningar...
+Adding\ fetched\ entries=Lägger till hämtade poster
+Display\ keywords\ appearing\ in\ ALL\ entries=Visa nyckelord som finns i ALLA poster
+Display\ keywords\ appearing\ in\ ANY\ entry=Visa nyckelord som finns i NÅGON post
+Fetching\ entries\ from\ Inspire=Hämtar poster från Inspire
+None\ of\ the\ selected\ entries\ have\ titles.=
+None\ of\ the\ selected\ entries\ have\ BibTeX\ keys.=Ingen av de valda posterna har någon BibTeX-nyckel.
+Unabbreviate\ journal\ names=Expandera förkortade tidskriftsnamn
+Unabbreviating...=Expanderar förkortningar...
 Usage=Användning
 
 
-Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.=
-Are_you_sure_you_want_to_reset_all_settings_to_default_values?=Är_du_säker_att_du_vill_återställa_alla_inställningar_till_standardvärden?
-Reset_preferences=Återställ_inställningar
-Ill-formed_entrytype_comment_in_BIB_file=
+Adds\ {}\ brackets\ around\ acronyms,\ month\ names\ and\ countries\ to\ preserve\ their\ case.=
+Are\ you\ sure\ you\ want\ to\ reset\ all\ settings\ to\ default\ values?=Är du säker att du vill återställa alla inställningar till standardvärden?
+Reset\ preferences=Återställ inställningar
+Ill-formed\ entrytype\ comment\ in\ BIB\ file=
 
-Move_linked_files_to_default_file_directory_%0=Flytta_länkade_filer_till_standardfilmappen_%0
+Move\ linked\ files\ to\ default\ file\ directory\ %0=Flytta länkade filer till standardfilmappen %0
 
 Clipboard=Urklipp
-Could_not_paste_entry_as_text\:=Kunde_inte_klista_in_post_so_text\:
-Do_you_still_want_to_continue?=Vill_du_fortfarande_fortsätta`?
-This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:=
-This_could_cause_undesired_changes_to_your_entries.=Detta_kan_leda_till_oönskade_effekter_för_dina_poster.
-Run_field_formatter\:=
-Table_font_size_is_%0=Typsnittstorlek_för_tabellen_är_%0
-%0_import_canceled=Import_från_%0_avbruten
-Internal_style=Intern_stil
-Add_style_file=Lägg_till_stilfil
-Are_you_sure_you_want_to_remove_the_style?=Är_du_säker_på_att_du_vill_ta_bort_stilen?
-Current_style_is_'%0'=Aktuell_stil_är_'%0'
-Remove_style=Ta_bort_stil
-Select_one_of_the_available_styles_or_add_a_style_file_from_disk.=Välj_en_av_de_tillgängliga_stilarna_eller_lägg_till_en_stilfil_från_disk.
-You_must_select_a_valid_style_file.=Du_måste_välja_en_giltig_stilfil.
-Reload=Ladda_om
+Could\ not\ paste\ entry\ as\ text\:=Kunde inte klista in post so text:
+Do\ you\ still\ want\ to\ continue?=Vill du fortfarande fortsätta`?
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=
+This\ could\ cause\ undesired\ changes\ to\ your\ entries.=Detta kan leda till oönskade effekter för dina poster.
+Run\ field\ formatter\:=
+Table\ font\ size\ is\ %0=Typsnittstorlek för tabellen är %0
+%0\ import\ canceled=Import från %0 avbruten
+Internal\ style=Intern stil
+Add\ style\ file=Lägg till stilfil
+Are\ you\ sure\ you\ want\ to\ remove\ the\ style?=Är du säker på att du vill ta bort stilen?
+Current\ style\ is\ '%0'=Aktuell stil är '%0'
+Remove\ style=Ta bort stil
+Select\ one\ of\ the\ available\ styles\ or\ add\ a\ style\ file\ from\ disk.=Välj en av de tillgängliga stilarna eller lägg till en stilfil från disk.
+You\ must\ select\ a\ valid\ style\ file.=Du måste välja en giltig stilfil.
+Reload=Ladda om
 
 Capitalize=
-Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.=
-Capitalize_the_first_word,_changes_other_words_to_lower_case.=
-Changes_all_letters_to_lower_case.=Ändrar_alla_bokstäver_till_gemener.
-Changes_all_letters_to_upper_case.=Ändrar_alla_bokstäver_till_versaler.
-Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.=
-Cleans_up_LaTeX_code.=Städar_upp_i_LaTeX-koden.
-Converts_HTML_code_to_LaTeX_code.=Konverterar_HTML-koder_till_LaTeX-kod.
-Converts_HTML_code_to_Unicode.=Konverterar_HTML-koder_till_Unicode-tecken.
-Converts_LaTeX_encoding_to_Unicode_characters.=Konverterar_Latex-koder_till_Unicode-tecken.
-Converts_Unicode_characters_to_LaTeX_encoding.=Konverterar_Unicode-tecken_till_LaTeX-kod.
-Converts_ordinals_to_LaTeX_superscripts.=Konverterar_ordningsnummer_till_LaTeX_\\superscript{}.
-Converts_units_to_LaTeX_formatting.=Formatterar_enheter_så_att_det_ser_bra_ut
-HTML_to_LaTeX=HTML_till_LaTeX
-LaTeX_cleanup=LaTeX-städning
-LaTeX_to_Unicode=LaTeX_till_Unicode
-Lower_case=Gemener
-Minify_list_of_person_names=Minimera_personlista
-Normalize_date=Normalisera_datum
-Normalize_month=Normalisera_månader
-Normalize_month_to_BibTeX_standard_abbreviation.=Nomralisera_månader_till_BibTeX-standardförkortning.
-Normalize_names_of_persons=Normalisera_personnamn
-Normalize_page_numbers=Normalisera_sidnummer
-Normalize_pages_to_BibTeX_standard.=Normaliserar_sidnummer_till_BibTeX-standard.
-Normalizes_lists_of_persons_to_the_BibTeX_standard.=Normaliserar_personnamn_till_BibTeX-standard.
-Normalizes_the_date_to_ISO_date_format.=Normaliserar_datum_till_ISO-standardformat.
-Ordinals_to_LaTeX_superscript=Ordningsnummer_till_LaTeX_\\superscript{}
-Protect_terms=Skydda_termer
-Remove_enclosing_braces=Ta_bort_inneslutande_måsvingar
-Removes_braces_encapsulating_the_complete_field_content.=Ta_bort_måsvingar_som_innesluter_hela_fältet.
-Sentence_case=
-Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".=Kortar_av_personlistor_om_det_är_fler_än_namn_till_"et_al."
-Title_case=
-Unicode_to_LaTeX=Unicode_till_LaTeX
-Units_to_LaTeX=Enheter_till_LaTeX
-Upper_case=Versaler
-Does_nothing.=Gör_ingenting.
+Capitalize\ all\ words,\ but\ converts\ articles,\ prepositions,\ and\ conjunctions\ to\ lower\ case.=
+Capitalize\ the\ first\ word,\ changes\ other\ words\ to\ lower\ case.=
+Changes\ all\ letters\ to\ lower\ case.=Ändrar alla bokstäver till gemener.
+Changes\ all\ letters\ to\ upper\ case.=Ändrar alla bokstäver till versaler.
+Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=
+Cleans\ up\ LaTeX\ code.=Städar upp i LaTeX-koden.
+Converts\ HTML\ code\ to\ LaTeX\ code.=Konverterar HTML-koder till LaTeX-kod.
+Converts\ HTML\ code\ to\ Unicode.=Konverterar HTML-koder till Unicode-tecken.
+Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=Konverterar Latex-koder till Unicode-tecken.
+Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=Konverterar Unicode-tecken till LaTeX-kod.
+Converts\ ordinals\ to\ LaTeX\ superscripts.=Konverterar ordningsnummer till LaTeX \\superscript{}.
+Converts\ units\ to\ LaTeX\ formatting.=Formatterar enheter så att det ser bra ut
+HTML\ to\ LaTeX=HTML till LaTeX
+LaTeX\ cleanup=LaTeX-städning
+LaTeX\ to\ Unicode=LaTeX till Unicode
+Lower\ case=Gemener
+Minify\ list\ of\ person\ names=Minimera personlista
+Normalize\ date=Normalisera datum
+Normalize\ month=Normalisera månader
+Normalize\ month\ to\ BibTeX\ standard\ abbreviation.=Nomralisera månader till BibTeX-standardförkortning.
+Normalize\ names\ of\ persons=Normalisera personnamn
+Normalize\ page\ numbers=Normalisera sidnummer
+Normalize\ pages\ to\ BibTeX\ standard.=Normaliserar sidnummer till BibTeX-standard.
+Normalizes\ lists\ of\ persons\ to\ the\ BibTeX\ standard.=Normaliserar personnamn till BibTeX-standard.
+Normalizes\ the\ date\ to\ ISO\ date\ format.=Normaliserar datum till ISO-standardformat.
+Ordinals\ to\ LaTeX\ superscript=Ordningsnummer till LaTeX \\superscript{}
+Protect\ terms=Skydda termer
+Remove\ enclosing\ braces=Ta bort inneslutande måsvingar
+Removes\ braces\ encapsulating\ the\ complete\ field\ content.=Ta bort måsvingar som innesluter hela fältet.
+Sentence\ case=
+Shortens\ lists\ of\ persons\ if\ there\ are\ more\ than\ 2\ persons\ to\ "et\ al.".=Kortar av personlistor om det är fler än namn till "et al."
+Title\ case=
+Unicode\ to\ LaTeX=Unicode till LaTeX
+Units\ to\ LaTeX=Enheter till LaTeX
+Upper\ case=Versaler
+Does\ nothing.=Gör ingenting.
 Identity=Identitet
-Clears_the_field_completely.=Tömmer_fältet_helt.
-Directory_not_found=Kan_ej_hitta_mapp
-Main_file_directory_not_set\!=Huvudfilmapp_ej_satt\!
-This_operation_requires_exactly_one_item_to_be_selected.=Denna_operationen_kräver_att_exakt_en_post_är_vald.
-Importing_in_%0_format=Importerar_i_%0-format
-Female_name=Ett_kvinnonamn
-Female_names=Flera_kvinnonamn
-Male_name=Ett_mansnamn
-Male_names=_Flera_mansnamn
-Mixed_names=_Blandade_namn
-Neuter_name=Ett_neutrumnamn
-Neuter_names=Flera_neutrumnamn
+Clears\ the\ field\ completely.=Tömmer fältet helt.
+Directory\ not\ found=Kan ej hitta mapp
+Main\ file\ directory\ not\ set\!=Huvudfilmapp ej satt!
+This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=Denna operationen kräver att exakt en post är vald.
+Importing\ in\ %0\ format=Importerar i %0-format
+Female\ name=Ett kvinnonamn
+Female\ names=Flera kvinnonamn
+Male\ name=Ett mansnamn
+Male\ names= Flera mansnamn
+Mixed\ names= Blandade namn
+Neuter\ name=Ett neutrumnamn
+Neuter\ names=Flera neutrumnamn
 
-Determined_%0_for_%1_entries=
-Look_up_%0=
-Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3=
+Determined\ %0\ for\ %1\ entries=
+Look\ up\ %0=
+Looking\ up\ %0...\ -\ entry\ %1\ out\ of\ %2\ -\ found\ %3=
 
-Audio_CD=Ljud-CD
-British_patent=Brittiskt_patent
-British_patent_request=Brittisk_patentansökan
-Candidate_thesis=Kandidatarbete
+Audio\ CD=Ljud-CD
+British\ patent=Brittiskt patent
+British\ patent\ request=Brittisk patentansökan
+Candidate\ thesis=Kandidatarbete
 Collaborator=Medarbetare
 Column=Kolumn
 Compiler=Sammanställare
 Continuator=Fortsättare
-Data_CD=Data-CD
+Data\ CD=Data-CD
 Editor=Redaktör
-European_patent=Europeiskt_patent
-European_patent_request=Europeisk_patentansökan
+European\ patent=Europeiskt patent
+European\ patent\ request=Europeisk patentansökan
 Founder=Grundare
-French_patent=Franskt_patent
-French_patent_request=Fransk_patentansökan
-German_patent=Tyskt_patent
-German_patent_request=Tysk_patentansökan
+French\ patent=Franskt patent
+French\ patent\ request=Fransk patentansökan
+German\ patent=Tyskt patent
+German\ patent\ request=Tysk patentansökan
 Line=Rad
-Master's_thesis=Magisteruppsats
+Master's\ thesis=Magisteruppsats
 Page=Sida
 Paragraph=Stycke
 Patent=Patent
-Patent_request=Patentansökan
-PhD_thesis=Doktorsavhandling
+Patent\ request=Patentansökan
+PhD\ thesis=Doktorsavhandling
 Redactor=
-Research_report=Forskningsrapport
+Research\ report=Forskningsrapport
 Reviser=
 Section=Del
 Software=Mjukvara
-Technical_report=Teknisk_rapport
-U.S._patent=
-U.S._patent_request=
+Technical\ report=Teknisk rapport
+U.S.\ patent=
+U.S.\ patent\ request=
 Verse=Vers
 
-change_entries_of_group=ändra_grupps_poster
-odd_number_of_unescaped_'\#'=udda_antal_'\#'-tecken
+change\ entries\ of\ group=ändra grupps poster
+odd\ number\ of\ unescaped\ '\#'=udda antal '#'-tecken
 
-Plain_text=Klartext
-Show_diff=Visa_skillnad
+Plain\ text=Klartext
+Show\ diff=Visa skillnad
 character=bokstav
 word=ord
-Show_symmetric_diff=Visa_skillnad_symmetriskt
-Copy_Version=
+Show\ symmetric\ diff=Visa skillnad symmetriskt
+Copy\ Version=
 Developers=
 Authors=
 License=
 
-HTML_encoded_character_found=HTML-kodade_tecken_hittades
-booktitle_ends_with_'conference_on'=boktiteln_slutar_med_'conference_on'
+HTML\ encoded\ character\ found=HTML-kodade tecken hittades
+booktitle\ ends\ with\ 'conference\ on'=boktiteln slutar med 'conference on'
 
-All_external_files=Alla_externa_filer
+All\ external\ files=Alla externa filer
 
-OpenOffice/LibreOffice_integration=OpenOffice/LibreOffice-integration
+OpenOffice/LibreOffice\ integration=OpenOffice/LibreOffice-integration
 
-incorrect_control_digit=felaktig_kontrollsiffra
-incorrect_format=felaktigit_format
-Copied_version_to_clipboard=Kopierade_version_till_urklipp
+incorrect\ control\ digit=felaktig kontrollsiffra
+incorrect\ format=felaktigit format
+Copied\ version\ to\ clipboard=Kopierade version till urklipp
 
-BibTeX_key=BibTeX-nyckel
+BibTeX\ key=BibTeX-nyckel
 Message=Meddelande
 
 
-MathSciNet_Review=
-Reset_Bindings=
+MathSciNet\ Review=
+Reset\ Bindings=
 
-Decryption_not_supported.=Avkryptering_stöds_ej.
+Decryption\ not\ supported.=Avkryptering stöds ej.
 
-Cleared_'%0'_for_%1_entries=Rensade_'%0'_för_%1_poster
-Set_'%0'_to_'%1'_for_%2_entries=Satta_'%0'_till_'%1'_för_%2_poster
-Toggled_'%0'_for_%1_entries=Växlade_'%0'_för_%1_poster
+Cleared\ '%0'\ for\ %1\ entries=Rensade '%0' för %1 poster
+Set\ '%0'\ to\ '%1'\ for\ %2\ entries=Satta '%0' till '%1' för %2 poster
+Toggled\ '%0'\ for\ %1\ entries=Växlade '%0' för %1 poster
 
-Check_for_updates=Sök_efter_uppdateringar
-Download_update=Ladda_ned_uppdatering
-New_version_available=Ny_version_tillgänglig
-Installed_version=Installerad_version
-Remind_me_later=Påminn_mig_senare
-Ignore_this_update=Ignorerar_den_här_uppdateringen.
-Could_not_connect_to_the_update_server.=Kunde_inte_ansluta_till_uppdateringsservern.
-Please_try_again_later_and/or_check_your_network_connection.=Försök_igen_senare_och/eller_kontrollera_din_internetuppkoppling.
-To_see_what_is_new_view_the_changelog.=För_att_få_reda_på_vad_som_är_nytt_se_ändringsloggen.
-A_new_version_of_JabRef_has_been_released.=En_ny_version_av_JabRef_har_släppts-
-JabRef_is_up-to-date.=JabRef_är_uppdaterad.
-Latest_version=Senaste_version
-Online_help_forum=Onlineforum
+Check\ for\ updates=Sök efter uppdateringar
+Download\ update=Ladda ned uppdatering
+New\ version\ available=Ny version tillgänglig
+Installed\ version=Installerad version
+Remind\ me\ later=Påminn mig senare
+Ignore\ this\ update=Ignorerar den här uppdateringen.
+Could\ not\ connect\ to\ the\ update\ server.=Kunde inte ansluta till uppdateringsservern.
+Please\ try\ again\ later\ and/or\ check\ your\ network\ connection.=Försök igen senare och/eller kontrollera din internetuppkoppling.
+To\ see\ what\ is\ new\ view\ the\ changelog.=För att få reda på vad som är nytt se ändringsloggen.
+A\ new\ version\ of\ JabRef\ has\ been\ released.=En ny version av JabRef har släppts-
+JabRef\ is\ up-to-date.=JabRef är uppdaterad.
+Latest\ version=Senaste version
+Online\ help\ forum=Onlineforum
 Custom=Egna
 
-Export_cited=Exportera_citerade
-Unable_to_generate_new_library=Kan_inte_generera_ny_databas
+Export\ cited=Exportera citerade
+Unable\ to\ generate\ new\ library=Kan inte generera ny databas
 
-Open_console=Öppna_konsoll
-Use_default_terminal_emulator=Använd_standardterminalen
-Execute_command=Kör_kommando
-Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.=Använd_%0_för_att_infoga_mappen_för_databasfilen.
-Executing_command_\"%0\"...=Kör_kommandot_\"%0\"...
-Error_occured_while_executing_the_command_\"%0\".=Fel_när_kommandot_\"%0\"_kördes.
-Reformat_ISSN=Formattera_om_ISSN
+Open\ console=Öppna konsoll
+Use\ default\ terminal\ emulator=Använd standardterminalen
+Execute\ command=Kör kommando
+Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=Använd %0 för att infoga mappen för databasfilen.
+Executing\ command\ \"%0\"...=Kör kommandot \"%0\"...
+Error\ occured\ while\ executing\ the\ command\ \"%0\".=Fel när kommandot \"%0\" kördes.
+Reformat\ ISSN=Formattera om ISSN
 
-Countries_and_territories_in_English=Länder_och_territorier_på_engelska
-Electrical_engineering_terms=Elektrotekniktermer
+Countries\ and\ territories\ in\ English=Länder och territorier på engelska
+Electrical\ engineering\ terms=Elektrotekniktermer
 Enabled=Aktiverad
-Internal_list=Intern_lista
-Manage_protected_terms_files=Hantera_filer_med_skyddade_ord
-Months_and_weekdays_in_English=Månader_och_veckodagar_på_engelska
-The_text_after_the_last_line_starting_with_\#_will_be_used=Texten_efter_sista_raden_som_startar_med_\#_kommer_användas
-Add_protected_terms_file=Lägg_till_fil_med_skyddade_ord
-Are_you_sure_you_want_to_remove_the_protected_terms_file?=Är_du_säker_på_att_du_vill_ta_bort_filen_med_skyddade_ord?
-Remove_protected_terms_file=Ta_bort_fil_med_skyddade_ord
-Add_selected_text_to_list=Lägg_till_markerad_text_till_lista
-Add_{}_around_selected_text=Lägg_till_{}_runt_markerad_text
-Format_field=Formattera_fält
-New_protected_terms_file=Ny_lista_med_skyddade_ord
-change_field_%0_of_entry_%1_from_%2_to_%3=ändra_fält_%0_för_post_%1_från_%2_till_%3
-change_key_from_%0_to_%1=ändra_nyckel_från_%0_till_%1
-change_string_content_%0_to_%1=ändra_stränginnehåll_från_%0_till_%1
-change_string_name_%0_to_%1=ändra_strängnamn_från_%0_till_%1
-change_type_of_entry_%0_from_%1_to_%2=ändra_typ_för_post_%0_från_%1_till_%2
-insert_entry_%0=infoga_post_%0
-insert_string_%0=infoga_sträng_%0
-remove_entry_%0=ta_bort_post_%0
-remove_string_%0=ta_bort_sträng_%0
+Internal\ list=Intern lista
+Manage\ protected\ terms\ files=Hantera filer med skyddade ord
+Months\ and\ weekdays\ in\ English=Månader och veckodagar på engelska
+The\ text\ after\ the\ last\ line\ starting\ with\ \#\ will\ be\ used=Texten efter sista raden som startar med # kommer användas
+Add\ protected\ terms\ file=Lägg till fil med skyddade ord
+Are\ you\ sure\ you\ want\ to\ remove\ the\ protected\ terms\ file?=Är du säker på att du vill ta bort filen med skyddade ord?
+Remove\ protected\ terms\ file=Ta bort fil med skyddade ord
+Add\ selected\ text\ to\ list=Lägg till markerad text till lista
+Add\ {}\ around\ selected\ text=Lägg till {} runt markerad text
+Format\ field=Formattera fält
+New\ protected\ terms\ file=Ny lista med skyddade ord
+change\ field\ %0\ of\ entry\ %1\ from\ %2\ to\ %3=ändra fält %0 för post %1 från %2 till %3
+change\ key\ from\ %0\ to\ %1=ändra nyckel från %0 till %1
+change\ string\ content\ %0\ to\ %1=ändra stränginnehåll från %0 till %1
+change\ string\ name\ %0\ to\ %1=ändra strängnamn från %0 till %1
+change\ type\ of\ entry\ %0\ from\ %1\ to\ %2=ändra typ för post %0 från %1 till %2
+insert\ entry\ %0=infoga post %0
+insert\ string\ %0=infoga sträng %0
+remove\ entry\ %0=ta bort post %0
+remove\ string\ %0=ta bort sträng %0
 undefined=odefinierad
-Cannot_get_info_based_on_given_%0\:_%1=Kan_inte_hämta_info_från_det_angivna_%0\:_%1
-Get_BibTeX_data_from_%0=Hämta_BibTeX-data_från_%0
-No_%0_found=Inget_%0_hittades
-Entry_from_%0=Post_från_%0
-Merge_entry_with_%0_information=Kombinera_post_med_information_från_%0
-Updated_entry_with_info_from_%0=Uppdaterade_post_med_information_från_%0
+Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=Kan inte hämta info från det angivna %0: %1
+Get\ BibTeX\ data\ from\ %0=Hämta BibTeX-data från %0
+No\ %0\ found=Inget %0 hittades
+Entry\ from\ %0=Post från %0
+Merge\ entry\ with\ %0\ information=Kombinera post med information från %0
+Updated\ entry\ with\ info\ from\ %0=Uppdaterade post med information från %0
 
-Add_existing_file=
-Create_new_list=
-Remove_list=
-Full_journal_name=
-Abbreviation_name=
+Add\ existing\ file=
+Create\ new\ list=
+Remove\ list=
+Full\ journal\ name=
+Abbreviation\ name=
 
-No_abbreviation_files_loaded=
+No\ abbreviation\ files\ loaded=
 
-Loading_built_in_lists=
+Loading\ built\ in\ lists=
 
-JabRef_built_in_list=
-IEEE_built_in_list=
+JabRef\ built\ in\ list=
+IEEE\ built\ in\ list=
 
-Event_log=
-We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.=
-Log_copied_to_clipboard.=
-Copy_Log=
-Clear_Log=
-Report_Issue=
-Issue_on_GitHub_successfully_reported.=
-Issue_report_successful=
-Your_issue_was_reported_in_your_browser.=
-The_log_and_exception_information_was_copied_to_your_clipboard.=
-Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.=
+Event\ log=
+We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef\'s\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=
+Log\ copied\ to\ clipboard.=
+Copy\ Log=
+Clear\ Log=
+Report\ Issue=
+Issue\ on\ GitHub\ successfully\ reported.=
+Issue\ report\ successful=
+Your\ issue\ was\ reported\ in\ your\ browser.=
+The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=
+Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=
 
 Connection=Anslutning
 Connecting...=Ansluter...
@@ -2164,194 +2164,194 @@ Port=Port
 Library=Databas
 User=Användare
 Connect=Anslut
-Connection_error=Anslutningsfel
-Connection_to_%0_server_established.=Anslutning_till_%0-server_skapades.
-Required_field_"%0"_is_empty.=Det_obligatoriska_fältet_"%0"_är_tomt.
-%0_driver_not_available.=
-The_connection_to_the_server_has_been_terminated.=Anslutningen_till_servern_avbröts.
-Connection_lost.=Anslutningen_förlorades.
-Reconnect=Anslut_igen
-Work_offline=Arbeta_frånkopplad
-Working_offline.=Arbetar_frånkopplad.
-Update_refused.=Uppdateringen_avvisades.
-Update_refused=Uppdateringen_avvisades
-Local_entry=Lokal_post
-Shared_entry=Delad_post
-Update_could_not_be_performed_due_to_existing_change_conflicts.=
-You_are_not_working_on_the_newest_version_of_BibEntry.=Du_arbetar_inte_med_den_senaste_versionen_av_posten.
-Local_version\:_%0=Lokal_version\:_%0
-Shared_version\:_%0=Delad_version\:_%0
-Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.=
-Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?=Om_denna_operation_avbryts_kommer_din_ändringar_ej_bli_synkroniserade._Avbryt_ändå?
-Shared_entry_is_no_longer_present=
-The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.=Posten_du_arbetar_med_har_tagits_bort_från_den_delade_libraryn.
-You_can_restore_the_entry_using_the_"Undo"_operation.=
-Remember_password?=Kom_ihåg_lösenord?
-You_are_already_connected_to_a_database_using_entered_connection_details.=
+Connection\ error=Anslutningsfel
+Connection\ to\ %0\ server\ established.=Anslutning till %0-server skapades.
+Required\ field\ "%0"\ is\ empty.=Det obligatoriska fältet "%0" är tomt.
+%0\ driver\ not\ available.=
+The\ connection\ to\ the\ server\ has\ been\ terminated.=Anslutningen till servern avbröts.
+Connection\ lost.=Anslutningen förlorades.
+Reconnect=Anslut igen
+Work\ offline=Arbeta frånkopplad
+Working\ offline.=Arbetar frånkopplad.
+Update\ refused.=Uppdateringen avvisades.
+Update\ refused=Uppdateringen avvisades
+Local\ entry=Lokal post
+Shared\ entry=Delad post
+Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=
+You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=Du arbetar inte med den senaste versionen av posten.
+Local\ version\:\ %0=Lokal version: %0
+Shared\ version\:\ %0=Delad version: %0
+Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=
+Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=Om denna operation avbryts kommer din ändringar ej bli synkroniserade. Avbryt ändå?
+Shared\ entry\ is\ no\ longer\ present=
+The\ BibEntry\ you\ currently\ work\ on\ has\ been\ deleted\ on\ the\ shared\ side.=Posten du arbetar med har tagits bort från den delade libraryn.
+You\ can\ restore\ the\ entry\ using\ the\ "Undo"\ operation.=
+Remember\ password?=Kom ihåg lösenord?
+You\ are\ already\ connected\ to\ a\ database\ using\ entered\ connection\ details.=
 
-Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?=Kan_inte_citera_poster_utan_BibTeX-nycklar._Generera_nycklar_nu?
-New_technical_report=Ny_teknisk_rapport
+Cannot\ cite\ entries\ without\ BibTeX\ keys.\ Generate\ keys\ now?=Kan inte citera poster utan BibTeX-nycklar. Generera nycklar nu?
+New\ technical\ report=Ny teknisk rapport
 
-%0_file=%0-fil
-Custom_layout_file=Egen_layoutfil
-Protected_terms_file=Fil_med_skyddade_termer
-Style_file=Stilfil_för_OpenOffice/LibreOffice
+%0\ file=%0-fil
+Custom\ layout\ file=Egen layoutfil
+Protected\ terms\ file=Fil med skyddade termer
+Style\ file=Stilfil för OpenOffice/LibreOffice
 
-Open_OpenOffice/LibreOffice_connection=Öppna_OpenOffice/LibreOffice-anslutning
-You_must_enter_at_least_one_field_name=Du_måste_ange_minst_ett_fältnamn
-Non-ASCII_encoded_character_found=Bokstäver_som_inte_är_ASCII-kodade_hittades
-Toggle_web_search_interface=Växla_webbsökning
-Background_color_for_resolved_fields=Bakgrundsfärg_för_uppslagna_fält
-Color_code_for_resolved_fields=Färgkodning_av_uppslagna_fält
-%0_files_found=%0_filer_hittades
-%0_of_%1=%0_av_%1
-One_file_found=En_fil_hittades
-The_import_finished_with_warnings\:=Importen_avslutades_med_varningar\:
-There_was_one_file_that_could_not_be_imported.=Det_fanns_en_fil_som_ej_kunde_importeras.
-There_were_%0_files_which_could_not_be_imported.=Det_fanns_%0_filer_som_ej_kunde_importeras.
+Open\ OpenOffice/LibreOffice\ connection=Öppna OpenOffice/LibreOffice-anslutning
+You\ must\ enter\ at\ least\ one\ field\ name=Du måste ange minst ett fältnamn
+Non-ASCII\ encoded\ character\ found=Bokstäver som inte är ASCII-kodade hittades
+Toggle\ web\ search\ interface=Växla webbsökning
+Background\ color\ for\ resolved\ fields=Bakgrundsfärg för uppslagna fält
+Color\ code\ for\ resolved\ fields=Färgkodning av uppslagna fält
+%0\ files\ found=%0 filer hittades
+%0\ of\ %1=%0 av %1
+One\ file\ found=En fil hittades
+The\ import\ finished\ with\ warnings\:=Importen avslutades med varningar:
+There\ was\ one\ file\ that\ could\ not\ be\ imported.=Det fanns en fil som ej kunde importeras.
+There\ were\ %0\ files\ which\ could\ not\ be\ imported.=Det fanns %0 filer som ej kunde importeras.
 
-Migration_help_information=Migrationshjälp
-Entered_database_has_obsolete_structure_and_is_no_longer_supported.=
-However,_a_new_database_was_created_alongside_the_pre-3.6_one.=
-Click_here_to_learn_about_the_migration_of_pre-3.6_databases.=Klicka_här_för_att_se_mer_information_om_migration_av_libraryr_från_innan_version_3.6.
-Opens_JabRef's_Facebook_page=Öppnar_Jabrefs_Facebooksida
-Opens_JabRef's_blog=Öppnar_Jabrefs_blogg
-Opens_JabRef's_website=Öppnar_JabRefs_hemsida
-Opens_a_link_where_the_current_development_version_can_be_downloaded=Öpnnar_en_länk_där_den_senaste_utvecklingsversionen_kan_laddas_ned
-See_what_has_been_changed_in_the_JabRef_versions=Se_vad_som_har_ändrats_i_de_olika_JabRef-versionerna
-Referenced_BibTeX_key_does_not_exist=Refererad_BibTeX-nyckel_finns_ej
-Finished_downloading_full_text_document_for_entry_%0.=
-Full_text_document_download_failed_for_entry_%0.=
-Look_up_full_text_documents=
-You_are_about_to_look_up_full_text_documents_for_%0_entries.=
-last_four_nonpunctuation_characters_should_be_numerals=
+Migration\ help\ information=Migrationshjälp
+Entered\ database\ has\ obsolete\ structure\ and\ is\ no\ longer\ supported.=
+However,\ a\ new\ database\ was\ created\ alongside\ the\ pre-3.6\ one.=
+Click\ here\ to\ learn\ about\ the\ migration\ of\ pre-3.6\ databases.=Klicka här för att se mer information om migration av libraryr från innan version 3.6.
+Opens\ JabRef's\ Facebook\ page=Öppnar Jabrefs Facebooksida
+Opens\ JabRef's\ blog=Öppnar Jabrefs blogg
+Opens\ JabRef's\ website=Öppnar JabRefs hemsida
+Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=Öpnnar en länk där den senaste utvecklingsversionen kan laddas ned
+See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=Se vad som har ändrats i de olika JabRef-versionerna
+Referenced\ BibTeX\ key\ does\ not\ exist=Refererad BibTeX-nyckel finns ej
+Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=
+Full\ text\ document\ download\ failed\ for\ entry\ %0.=
+Look\ up\ full\ text\ documents=
+You\ are\ about\ to\ look\ up\ full\ text\ documents\ for\ %0\ entries.=
+last\ four\ nonpunctuation\ characters\ should\ be\ numerals=
 
 Author=
 Date=
-File_annotations=
-Show_file_annotations=
-Adobe_Acrobat_Reader=
-Sumatra_Reader=
+File\ annotations=
+Show\ file\ annotations=
+Adobe\ Acrobat\ Reader=
+Sumatra\ Reader=
 shared=delad
-should_contain_an_integer_or_a_literal=
-should_have_the_first_letter_capitalized=
+should\ contain\ an\ integer\ or\ a\ literal=
+should\ have\ the\ first\ letter\ capitalized=
 Tools=
-What\'s_new_in_this_version?=
-Want_to_help?=
-Make_a_donation=
-get_involved=
-Used_libraries=
-Existing_file=Existerande_fil
+What\'s\ new\ in\ this\ version?=
+Want\ to\ help?=
+Make\ a\ donation=
+get\ involved=
+Used\ libraries=
+Existing\ file=Existerande fil
 
 ID=
-ID_type=
-ID-based_entry_generator=
-Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+ID\ type=
+ID-based\ entry\ generator=
+Fetcher\ '%0'\ did\ not\ find\ an\ entry\ for\ id\ '%1'.=
 
-Select_first_entry=
-Select_last_entry=
+Select\ first\ entry=
+Select\ last\ entry=
 
-Invalid_ISBN\:_'%0'.=
-should_be_an_integer_or_normalized=
-should_be_normalized=
+Invalid\ ISBN\:\ '%0'.=
+should\ be\ an\ integer\ or\ normalized=
+should\ be\ normalized=
 
-Empty_search_ID=
-The_given_search_ID_was_empty.=
-Copy_BibTeX_key_and_link=
-empty_BibTeX_key=
-biblatex_field_only=
+Empty\ search\ ID=
+The\ given\ search\ ID\ was\ empty.=
+Copy\ BibTeX\ key\ and\ link=
+empty\ BibTeX\ key=
+biblatex\ field\ only=
 
-Error_while_generating_fetch_URL=
-Error_while_parsing_ID_list=
-Unable_to_get_PubMed_IDs=
-Backup_found=
-A_backup_file_for_'%0'_was_found.=
-This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.=
-Do_you_want_to_recover_the_library_from_the_backup_file?=
-Firstname_Lastname=
+Error\ while\ generating\ fetch\ URL=
+Error\ while\ parsing\ ID\ list=
+Unable\ to\ get\ PubMed\ IDs=
+Backup\ found=
+A\ backup\ file\ for\ '%0'\ was\ found.=
+This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=
+Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=
+Firstname\ Lastname=
 
-Recommended_for_%0=
-Show_'Related_Articles'_tab=
-This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
+Recommended\ for\ %0=
+Show\ 'Related\ Articles'\ tab=
+This\ might\ be\ caused\ by\ reaching\ the\ traffic\ limitation\ of\ Google\ Scholar\ (see\ 'Help'\ for\ details).=
 
-Could_not_open_website.=
-Problem_downloading_from_%1=
+Could\ not\ open\ website.=
+Problem\ downloading\ from\ %1=
 
-File_directory_pattern=
-Update_with_bibliographic_information_from_the_web=
+File\ directory\ pattern=
+Update\ with\ bibliographic\ information\ from\ the\ web=
 
-Could_not_find_any_bibliographic_information.=
-BibTeX_key_deviates_from_generated_key=
-DOI_%0_is_invalid=
+Could\ not\ find\ any\ bibliographic\ information.=
+BibTeX\ key\ deviates\ from\ generated\ key=
+DOI\ %0\ is\ invalid=
 
-Select_all_customized_types_to_be_stored_in_local_preferences=
-Currently_unknown=
-Different_customization,_current_settings_will_be_overwritten=
+Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences=
+Currently\ unknown=
+Different\ customization,\ current\ settings\ will\ be\ overwritten=
 
-Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX=
-Jump_to_entry=
+Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=
+Jump\ to\ entry=
 
-Copied_%0_citations.=
+Copied\ %0\ citations.=
 Copying...=
 
-journal_not_found_in_abbreviation_list=
-Unhandled_exception_occurred.=
+journal\ not\ found\ in\ abbreviation\ list=
+Unhandled\ exception\ occurred.=
 
-strings_included=innehåller_strings
-Color_for_disabled_icons=
-Color_for_enabled_icons=
-Size_of_large_icons=
-Size_of_small_icons=
-Default_table_font_size=
-Escape_underscores=Maskera_understreck
+strings\ included=innehåller strings
+Color\ for\ disabled\ icons=
+Color\ for\ enabled\ icons=
+Size\ of\ large\ icons=
+Size\ of\ small\ icons=
+Default\ table\ font\ size=
+Escape\ underscores=Maskera understreck
 Color=
-Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=
-Fit_width=
-Fit_a_single_page=
-Zoom_in=
-Zoom_out=
-Previous_page=
-Next_page=
-Document_viewer=
+Please\ also\ add\ all\ steps\ to\ reproduce\ this\ issue,\ if\ possible.=
+Fit\ width=
+Fit\ a\ single\ page=
+Zoom\ in=
+Zoom\ out=
+Previous\ page=
+Next\ page=
+Document\ viewer=
 Live=
 Locked=
-Show_document_viewer=
-Show_the_document_of_the_currently_selected_entry.=
-Show_this_document_until_unlocked.=
-Set_current_user_name_as_owner.=
+Show\ document\ viewer=
+Show\ the\ document\ of\ the\ currently\ selected\ entry.=
+Show\ this\ document\ until\ unlocked.=
+Set\ current\ user\ name\ as\ owner.=
 
-Sort_all_subgroups_(recursively)=
-Collect_and_share_telemetry_data_to_help_improve_JabRef.=
-Don't_share=
-Share_anonymous_statistics=
-Telemetry\:_Help_make_JabRef_better=
-To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.=
-This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?=
-Names_are_not_in_the_standard_%0_format.=
+Sort\ all\ subgroups\ (recursively)=
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=
+Don't\ share=
+Share\ anonymous\ statistics=
+Telemetry\:\ Help\ make\ JabRef\ better=
+To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ statistics\ on\ the\ features\ you\ use.\ We\ will\ only\ record\ what\ features\ you\ access\ and\ how\ often\ you\ do\ it.\ We\ will\ neither\ collect\ any\ personal\ data\ nor\ the\ content\ of\ bibliographic\ items.\ If\ you\ choose\ to\ allow\ data\ collection,\ you\ can\ later\ disable\ it\ via\ Options\ ->\ Preferences\ ->\ General.=
+This\ file\ was\ found\ automatically.\ Do\ you\ want\ to\ link\ it\ to\ this\ entry?=
+Names\ are\ not\ in\ the\ standard\ %0\ format.=
 
-Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.=
-Delete_'%0'=
-Delete_from_disk=
-Remove_from_entry=
-The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.=
-There_exists_already_a_group_with_the_same_name.=
+Delete\ the\ selected\ file\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ file\ permanently\ from\ disk.=
+Delete\ '%0'=
+Delete\ from\ disk=
+Remove\ from\ entry=
+The\ group\ name\ contains\ the\ keyword\ separator\ "%0"\ and\ thus\ probably\ does\ not\ work\ as\ expected.=
+There\ exists\ already\ a\ group\ with\ the\ same\ name.=
 
-Copy_linked_files_to_folder...=
-Copied_file_successfully=
-Copying_files...=
-Copying_file_%0_of_entry_%1=
-Finished_copying=
-Could_not_copy_file=
-Copied_%0_files_of_%1_sucessfully_to_%2=
-Rename_failed=
-JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.=
-Show_console_output_(only_necessary_when_the_launcher_is_used)=
+Copy\ linked\ files\ to\ folder...=
+Copied\ file\ successfully=
+Copying\ files...=
+Copying\ file\ %0\ of\ entry\ %1=
+Finished\ copying=
+Could\ not\ copy\ file=
+Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=
+Rename\ failed=
+JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=
+Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=
 
-Remove_line_breaks=
-Removes_all_line_breaks_in_the_field_content.=
-Checking_integrity...=
+Remove\ line\ breaks=
+Removes\ all\ line\ breaks\ in\ the\ field\ content.=
+Checking\ integrity...=
 
-Remove_hyphenated_line_breaks=
-Removes_all_hyphenated_line_breaks_in_the_field_content.=
-Note_that_currently,_JabRef_does_not_run_with_Java_9.=
-Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.=
+Remove\ hyphenated\ line\ breaks=
+Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=
+Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=
+Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -446,7 +446,7 @@ Error\ writing\ to\ %0\ file(s).=%0 dosya(lar) yazılırken hata.
 
 
 '%0'\ exists.\ Overwrite\ file?='%0' mevcut. Dosyanın üzerine yazılsın mı?
-Overwrite\ file?= Dosyanın üzerine yazılsın mı?
+Overwrite\ file?=Dosyanın üzerine yazılsın mı?
 
 Export=Dışa aktar
 
@@ -2122,7 +2122,7 @@ remove\ string\ %0=%0 dizgesini sil
 undefined=tanımlanmamış
 Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=Verilen %0: %1'e göre bilgi alınamıyor
 Get\ BibTeX\ data\ from\ %0=%0'den BibTeX verisini al
-No\ %0\ found= %0 bulunamadi
+No\ %0\ found=%0 bulunamadi
 Entry\ from\ %0=%0'den girdi
 Merge\ entry\ with\ %0\ information=%0 bilgisiyle girdiyi birleştir
 Updated\ entry\ with\ info\ from\ %0=%0'den edinilen bilgiyle girdi güncellendi

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -1,8 +1,3 @@
-
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 şu Düzenli İfadeyi içeriyor <b>%1</b>
 
 %0\ contains\ the\ term\ <b>%1</b>=%0 şu terimi içeriyor <b>%1</b>

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -3,478 +3,478 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-%0_contains_the_regular_expression_<b>%1</b>=%0_şu_Düzenli_İfadeyi_içeriyor_<b>%1</b>
+%0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 şu Düzenli İfadeyi içeriyor <b>%1</b>
 
-%0_contains_the_term_<b>%1</b>=%0_şu_terimi_içeriyor_<b>%1</b>
+%0\ contains\ the\ term\ <b>%1</b>=%0 şu terimi içeriyor <b>%1</b>
 
-%0_doesn't_contain_the_regular_expression_<b>%1</b>=%0_şu_Düzenli_İfadeyi_içermiyor_<b>%1</b>
+%0\ doesn't\ contain\ the\ regular\ expression\ <b>%1</b>=%0 şu Düzenli İfadeyi içermiyor <b>%1</b>
 
-%0_doesn't_contain_the_term_<b>%1</b>=%0_şu_terimi_içermiyor_<b>%1</b>
+%0\ doesn't\ contain\ the\ term\ <b>%1</b>=%0 şu terimi içermiyor <b>%1</b>
 
-%0_export_successful=%0_dışa_aktarım_başarılı
+%0\ export\ successful=%0 dışa aktarım başarılı
 
-%0_matches_the_regular_expression_<b>%1</b>=%0_şu_Düzenli_İfadeyle_eşleşiyor_<b>%1</b>
+%0\ matches\ the\ regular\ expression\ <b>%1</b>=%0 şu Düzenli İfadeyle eşleşiyor <b>%1</b>
 
-%0_matches_the_term_<b>%1</b>=%0_şu_terimle_eşleşiyor_<b>%1</b>
+%0\ matches\ the\ term\ <b>%1</b>=%0 şu terimle eşleşiyor <b>%1</b>
 
-<field_name>=<alan_adı>
-<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>=<HTML>'%1'_girdisinden_bağlantılı<BR>'%0'_dosyası_bulunamadı</HTML>
+<field\ name>=<alan adı>
+<HTML>Could\ not\ find\ file\ '%0'<BR>linked\ from\ entry\ '%1'</HTML>=<HTML>'%1' girdisinden bağlantılı<BR>'%0' dosyası bulunamadı</HTML>
 
 <select>=<seç>
 
-<select_word>=<sözcük_seç>
-Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)=Seçili_girdilerin_dergi_isimlerini_kısalt_(ISO_kısaltması)
-Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)=Seçili_girdilerin_dergi_isimlerini_kısalt_(MEDLINE_kısaltması)
+<select\ word>=<sözcük seç>
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (ISO\ abbreviation)=Seçili girdilerin dergi isimlerini kısalt (ISO kısaltması)
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (MEDLINE\ abbreviation)=Seçili girdilerin dergi isimlerini kısalt (MEDLINE kısaltması)
 
-Abbreviate_names=İsimleri_kısalt
-Abbreviated_%0_journal_names.=Kısaltılmış_%0_dergi_isimleri.
+Abbreviate\ names=İsimleri kısalt
+Abbreviated\ %0\ journal\ names.=Kısaltılmış %0 dergi isimleri.
 
 Abbreviation=Kısaltma
 
-About_JabRef=JabRef_Hakkında
+About\ JabRef=JabRef Hakkında
 
 Abstract=Özet
 
-Accept=Kabul_et
+Accept=Kabul et
 
-Accept_change=Değişikliği_kabul_et
+Accept\ change=Değişikliği kabul et
 
 Action=Eylem
 
-What_is_Mr._DLib?=Bay_DLib_nedir?
+What\ is\ Mr.\ DLib?=Bay DLib nedir?
 
 Add=Ekle
 
-Add_a_(compiled)_custom_Importer_class_from_a_class_path.=Bir_sınıf_yolundan_(derlenmiş)_özel_İçeAlmaBiçemi_sınıfı_ekle.
-The_path_need_not_be_on_the_classpath_of_JabRef.=Yolun_JabRef'in_sınıf_yolunda_olması_gerekmez.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=Bir sınıf yolundan (derlenmiş) özel İçeAlmaBiçemi sınıfı ekle.
+The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=Yolun JabRef'in sınıf yolunda olması gerekmez.
 
-Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=Bir_ZIP_arşivinden_(derlenmiş)_özel_İçeAlmaBiçemi_sınıfı_ekle.
-The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=Yolun_JabRef'in_sınıf_yolunda_olması_gerekmez.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=Bir ZIP arşivinden (derlenmiş) özel İçeAlmaBiçemi sınıfı ekle.
+The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=Yolun JabRef'in sınıf yolunda olması gerekmez.
 
-Add_a_regular_expression_for_the_key_pattern.=Anahtar_kalıbı_için_bir_düzenli_ifade_ekle.
+Add\ a\ regular\ expression\ for\ the\ key\ pattern.=Anahtar kalıbı için bir düzenli ifade ekle.
 
-Add_selected_entries_to_this_group=Seçili_girdileri_bu_gruba_ekle
+Add\ selected\ entries\ to\ this\ group=Seçili girdileri bu gruba ekle
 
-Add_from_folder=Klasörden_ekle
+Add\ from\ folder=Klasörden ekle
 
-Add_from_JAR=JAR'dan_ekle
+Add\ from\ JAR=JAR'dan ekle
 
-add_group=grup_ekle
+add\ group=grup ekle
 
-Add_new=Yeni_ekle
+Add\ new=Yeni ekle
 
-Add_subgroup=Altgrup_ekle
+Add\ subgroup=Altgrup ekle
 
-Add_to_group=Gruba_ekle
+Add\ to\ group=Gruba ekle
 
-Added_group_"%0".="%0"_grubu_eklendi.
+Added\ group\ "%0".="%0" grubu eklendi.
 
-Added_missing_braces.=Eksik_olan_süslü_parantezler_eklendi.
+Added\ missing\ braces.=Eksik olan süslü parantezler eklendi.
 
-Added_new=Yeni_eklendi
+Added\ new=Yeni eklendi
 
-Added_string=Dizgi_eklendi
+Added\ string=Dizgi eklendi
 
-Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.=Ek_olarak,_<b>%0</b>_alanları_<b>%1</b>_içermeyen_girdiler_seçilip,_bu_gruba_sürükle_ve_bırak_ya_da_bağlam_menüsü_kullanılarak_elle_atanabilir._Bu_süreç_her_bir_girdinin_<b>%0</b>_alanına_<b>%1</b>_terimini_ekler._Girdiler
+Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ can\ be\ assigned\ manually\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ This\ process\ adds\ the\ term\ <b>%1</b>\ to\ each\ entry's\ <b>%0</b>\ field.\ Entries\ can\ be\ removed\ manually\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.\ This\ process\ removes\ the\ term\ <b>%1</b>\ from\ each\ entry's\ <b>%0</b>\ field.=Ek olarak, <b>%0</b> alanları <b>%1</b> içermeyen girdiler seçilip, bu gruba sürükle ve bırak ya da bağlam menüsü kullanılarak elle atanabilir. Bu süreç her bir girdinin <b>%0</b> alanına <b>%1</b> terimini ekler. Girdiler
 
 Advanced=Gelişmiş
-All_entries=Tüm_girdiler
-All_entries_of_this_type_will_be_declared_typeless._Continue?=Bu_türeden_tüm_girdiler_türsüz_olarak_bildirilecek._Devam_edilsin_mi?
+All\ entries=Tüm girdiler
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=Bu türeden tüm girdiler türsüz olarak bildirilecek. Devam edilsin mi?
 
-All_fields=Tüm_alanlar
+All\ fields=Tüm alanlar
 
-Always_reformat_BIB_file_on_save_and_export=Kaydetme_ve_dışa_aktarmada_BIB_dosyasını_her_zaman_yeniden_biçemle
+Always\ reformat\ BIB\ file\ on\ save\ and\ export=Kaydetme ve dışa aktarmada BIB dosyasını her zaman yeniden biçemle
 
-A_SAX_exception_occurred_while_parsing_'%0'\:='%0'_ayrıştırılırken_bir_SAXİstisnası_oluştu\:
+A\ SAX\ exception\ occurred\ while\ parsing\ '%0'\:='%0' ayrıştırılırken bir SAXİstisnası oluştu:
 
 and=ve
-and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.=ve_bir_dahaki_sefer_JabRef'i_başlattığınızda_sınıf_sınıf_yolunuzda_bulunmalıdır.
+and\ the\ class\ must\ be\ available\ in\ your\ classpath\ next\ time\ you\ start\ JabRef.=ve bir dahaki sefer JabRef'i başlattığınızda sınıf sınıf yolunuzda bulunmalıdır.
 
-any_field_that_matches_the_regular_expression_<b>%0</b>=<b>%0</b>_düzenli_ifadesine_uyan_herhangi_bir_alan
+any\ field\ that\ matches\ the\ regular\ expression\ <b>%0</b>=<b>%0</b> düzenli ifadesine uyan herhangi bir alan
 
 Appearance=Görünüm
 
-Append=Sonuna_ekle
-Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library=Bir_BibTeX_veritabanının_içeriğini_halen_görüntülenen_veritabanının_sonuna_ekle
+Append=Sonuna ekle
+Append\ contents\ from\ a\ BibTeX\ library\ into\ the\ currently\ viewed\ library=Bir BibTeX veritabanının içeriğini halen görüntülenen veritabanının sonuna ekle
 
-Append_library=Veritabanını_sonuna_ekle
+Append\ library=Veritabanını sonuna ekle
 
-Append_the_selected_text_to_BibTeX_field=Seçili_metni_BibTeX_anahtarının_sonuna_ekle
+Append\ the\ selected\ text\ to\ BibTeX\ field=Seçili metni BibTeX anahtarının sonuna ekle
 Application=Uygulama
 
 Apply=Uygula
 
-Arguments_passed_on_to_running_JabRef_instance._Shutting_down.=Argümanlar_çalışan_JabRef_oturumuna_aktarıldı._Kapatılıyor.
+Arguments\ passed\ on\ to\ running\ JabRef\ instance.\ Shutting\ down.=Argümanlar çalışan JabRef oturumuna aktarıldı. Kapatılıyor.
 
-Assign_new_file=Yeni_dosya_ata
+Assign\ new\ file=Yeni dosya ata
 
-Assign_the_original_group's_entries_to_this_group?=Orijinal_grubun_girdileri_bu_gruba_atansın_mı?
+Assign\ the\ original\ group's\ entries\ to\ this\ group?=Orijinal grubun girdileri bu gruba atansın mı?
 
-Assigned_%0_entries_to_group_"%1".=%0_girdi_"%1"_grubuna_atandı.
+Assigned\ %0\ entries\ to\ group\ "%1".=%0 girdi "%1" grubuna atandı.
 
-Assigned_1_entry_to_group_"%0".=Bir_girdi_"%0"_grubuna_atandı.
+Assigned\ 1\ entry\ to\ group\ "%0".=Bir girdi "%0" grubuna atandı.
 
-Attach_URL=URL_ekle
+Attach\ URL=URL ekle
 
-Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.=Girdileriniz_için_dosya_link_otokurma_girişiminde_bulunuluyor._Otokur,_eğer_dosya_dizinindeki_ya_da_bir_<BR>_altdizinindeki_dosyası_bir_BibTeX_anahtarıyla_özdeş_adlandırılmış_artı_uzantılandılılmışsa_çalışır.
+Attempt\ to\ automatically\ set\ file\ links\ for\ your\ entries.\ Automatically\ setting\ works\ if\ a\ file\ in\ your\ file\ directory<BR>or\ a\ subdirectory\ is\ named\ identically\ to\ an\ entry's\ BibTeX\ key,\ plus\ extension.=Girdileriniz için dosya link otokurma girişiminde bulunuluyor. Otokur, eğer dosya dizinindeki ya da bir <BR> altdizinindeki dosyası bir BibTeX anahtarıyla özdeş adlandırılmış artı uzantılandılılmışsa çalışır.
 
-Autodetect_format=Biçemi_otomatik_tanı
+Autodetect\ format=Biçemi otomatik tanı
 
-Autogenerate_BibTeX_keys=BibTeX_anahtarlarını_otomatik_oluştur
+Autogenerate\ BibTeX\ keys=BibTeX anahtarlarını otomatik oluştur
 
-Autolink_files_with_names_starting_with_the_BibTeX_key=Adları_BibTeX_anahtarıyla_başlayan_dosyaları_otomatik_bağla
+Autolink\ files\ with\ names\ starting\ with\ the\ BibTeX\ key=Adları BibTeX anahtarıyla başlayan dosyaları otomatik bağla
 
-Autolink_only_files_that_match_the_BibTeX_key=Yalnızca_BibTeX_anahtarıyla_eşleşen_dosyaları_otomatik_bağla
+Autolink\ only\ files\ that\ match\ the\ BibTeX\ key=Yalnızca BibTeX anahtarıyla eşleşen dosyaları otomatik bağla
 
-Automatically_create_groups=Grupları_otomatik_oluştur
+Automatically\ create\ groups=Grupları otomatik oluştur
 
-Automatically_remove_exact_duplicates=Tıpkı_çift_nüshaları_otomatik_sil
+Automatically\ remove\ exact\ duplicates=Tıpkı çift nüshaları otomatik sil
 
-Allow_overwriting_existing_links.=Mevcut_linklerin_üzerine_yazmaya_izin_ver.
+Allow\ overwriting\ existing\ links.=Mevcut linklerin üzerine yazmaya izin ver.
 
-Do_not_overwrite_existing_links.=Mevcut_linklerin_üzerine_yazma.
+Do\ not\ overwrite\ existing\ links.=Mevcut linklerin üzerine yazma.
 
-AUX_file_import=AUX_dosya_içe_aktarımı
+AUX\ file\ import=AUX dosya içe aktarımı
 
-Available_export_formats=Mevcut_dışa_aktarım_biçemleri
+Available\ export\ formats=Mevcut dışa aktarım biçemleri
 
-Available_BibTeX_fields=Mevcut_alanlar
+Available\ BibTeX\ fields=Mevcut alanlar
 
-Available_import_formats=Mevcut_içe_aktarım_biçemleri
+Available\ import\ formats=Mevcut içe aktarım biçemleri
 
-Background_color_for_optional_fields=Seçmeli_alanlar_için_arkaplan_rengi
+Background\ color\ for\ optional\ fields=Seçmeli alanlar için arkaplan rengi
 
-Background_color_for_required_fields=Zorunlu_alanlar_için_arkaplan_rengi
+Background\ color\ for\ required\ fields=Zorunlu alanlar için arkaplan rengi
 
-Backup_old_file_when_saving=Kaydederken_eski_dosyayı_yedekle
+Backup\ old\ file\ when\ saving=Kaydederken eski dosyayı yedekle
 
-BibTeX_key_is_unique.=BibTeX_anahtarı_benzersizdir.
+BibTeX\ key\ is\ unique.=BibTeX anahtarı benzersizdir.
 
-%0_source=%0_kaynağı
+%0\ source=%0 kaynağı
 
-Broken_link=Bozuk_link
+Broken\ link=Bozuk link
 
-Browse=Göz_at
+Browse=Göz at
 
 by=ile
 
 Cancel=İptal
 
-Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?=Anahtarlar_oluşturulmadan_gruba_girdiler_eklenemez._Anahtarlar_oluşturulsun_mu?
+Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=Anahtarlar oluşturulmadan gruba girdiler eklenemez. Anahtarlar oluşturulsun mu?
 
-Cannot_merge_this_change=Bu_değişiklik_birleştirilemiyor
+Cannot\ merge\ this\ change=Bu değişiklik birleştirilemiyor
 
-case_insensitive=büyük/kü.ük_harfe_duyarsız
+case\ insensitive=büyük/kü.ük harfe duyarsız
 
-case_sensitive=büyük/küçük_harfe_duyarlı
+case\ sensitive=büyük/küçük harfe duyarlı
 
-Case_sensitive=Büyük/küçük_harfe_duyarlı
+Case\ sensitive=Büyük/küçük harfe duyarlı
 
-change_assignment_of_entries=girdilerin_atanmasını_değiştir
+change\ assignment\ of\ entries=girdilerin atanmasını değiştir
 
-Change_case=Büyük/küçük_harf_değiştir
+Change\ case=Büyük/küçük harf değiştir
 
-Change_entry_type=Girdi_türünü_değiştir
-Change_file_type=Dosya_türünü_değiştir
+Change\ entry\ type=Girdi türünü değiştir
+Change\ file\ type=Dosya türünü değiştir
 
 
-Change_of_Grouping_Method=Gruplama_Yöntemi_Değişikliği
+Change\ of\ Grouping\ Method=Gruplama Yöntemi Değişikliği
 
-change_preamble=öncülü_değiştir
+change\ preamble=öncülü değiştir
 
-Change_table_column_and_General_fields_settings_to_use_the_new_feature=Yeni_özelliği_kullanmak_için_tablo_sütun_ve_Genel_alan_ayarlarını_değiştirin
+Change\ table\ column\ and\ General\ fields\ settings\ to\ use\ the\ new\ feature=Yeni özelliği kullanmak için tablo sütun ve Genel alan ayarlarını değiştirin
 
-Changed_language_settings=Dil_ayarları_değişti
+Changed\ language\ settings=Dil ayarları değişti
 
-Changed_preamble=Öncül_değişti
+Changed\ preamble=Öncül değişti
 
-Check_existing_file_links=Mevcut_dosya_linki_kontrol_ediniz
+Check\ existing\ file\ links=Mevcut dosya linki kontrol ediniz
 
-Check_links=Linkleri_kontrol_ediniz
+Check\ links=Linkleri kontrol ediniz
 
-Cite_command=Alıntı_komutu
+Cite\ command=Alıntı komutu
 
-Class_name=Sınıf_adı
+Class\ name=Sınıf adı
 
 Clear=Sil
 
-Clear_fields=Alanları_sil
+Clear\ fields=Alanları sil
 
 Close=Kapat
-Close_others=Diğerlerini_Kapat
-Close_all=Tümünü_Kapat
+Close\ others=Diğerlerini Kapat
+Close\ all=Tümünü Kapat
 
-Close_dialog=Dialoğu_kapat
+Close\ dialog=Dialoğu kapat
 
-Close_the_current_library=Güncel_veritabanını_kapat
+Close\ the\ current\ library=Güncel veritabanını kapat
 
-Close_window=Pencereyi_kapat
+Close\ window=Pencereyi kapat
 
-Closed_library=Kapalı_veritabanı
+Closed\ library=Kapalı veritabanı
 
-Color_codes_for_required_and_optional_fields=Zorunlu_ve_seçmeli_alanlar_için_renk_kodları
+Color\ codes\ for\ required\ and\ optional\ fields=Zorunlu ve seçmeli alanlar için renk kodları
 
-Color_for_marking_incomplete_entries=Tamamlanmamış_girdileri_işaretlemek_için_renk
+Color\ for\ marking\ incomplete\ entries=Tamamlanmamış girdileri işaretlemek için renk
 
-Column_width=Sütun_genişliği
+Column\ width=Sütun genişliği
 
-Command_line_id=Komut_satır_no
+Command\ line\ id=Komut satır no
 
 
-Contained_in=Şunun_içinde
+Contained\ in=Şunun içinde
 
 Content=İçerik
 
 Copied=Kopyalandı
 
-Copied_cell_contents=Hücre_içerikleri_kopyalandı
+Copied\ cell\ contents=Hücre içerikleri kopyalandı
 
-Copied_title=Kopyalanan_başlık
+Copied\ title=Kopyalanan başlık
 
-Copied_key=Kopyalanan_anahtar
+Copied\ key=Kopyalanan anahtar
 
-Copied_titles=Kopyalanan_başlıklar
+Copied\ titles=Kopyalanan başlıklar
 
-Copied_keys=Kopyalanan_anahtarlar
+Copied\ keys=Kopyalanan anahtarlar
 
 Copy=Kopyala
 
-Copy_BibTeX_key=BibTeX_anahtarını_kopyala
-Copy_file_to_file_directory=Dosyayı_dosya_dizinine_kopyala
+Copy\ BibTeX\ key=BibTeX anahtarını kopyala
+Copy\ file\ to\ file\ directory=Dosyayı dosya dizinine kopyala
 
-Copy_to_clipboard=Panoya_kopyala
+Copy\ to\ clipboard=Panoya kopyala
 
-Could_not_call_executable=Program_çağrılamıyor
-Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.=Vim_sunucusuna_bağlanılamıyor._Vim'in_doğru_sunucu_adıyla<BR>çalıştığına_emin_olun.
+Could\ not\ call\ executable=Program çağrılamıyor
+Could\ not\ connect\ to\ Vim\ server.\ Make\ sure\ that\ Vim\ is\ running<BR>with\ correct\ server\ name.=Vim sunucusuna bağlanılamıyor. Vim'in doğru sunucu adıyla<BR>çalıştığına emin olun.
 
-Could_not_export_file=Dosya_dışa_aktarılamıyor
+Could\ not\ export\ file=Dosya dışa aktarılamıyor
 
-Could_not_export_preferences=Tercihler_dışa_aktarılamıyor
+Could\ not\ export\ preferences=Tercihler dışa aktarılamıyor
 
-Could_not_find_a_suitable_import_format.=Uygun_içe_aktarım_biçemi_bulunamıyor.
-Could_not_import_preferences=Tercihler_içe_aktarılamıyor
+Could\ not\ find\ a\ suitable\ import\ format.=Uygun içe aktarım biçemi bulunamıyor.
+Could\ not\ import\ preferences=Tercihler içe aktarılamıyor
 
-Could_not_instantiate_%0=%0_somutlaştırılamıyor
-Could_not_instantiate_%0_%1=%0_%1_somutlaştırılamıyor
-Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?=%0_somutlaştırılamıyor._Doğru_paket_yolunu_seçmiş_miydiniz?
-Could_not_open_link=Link_açılamıyor
+Could\ not\ instantiate\ %0=%0 somutlaştırılamıyor
+Could\ not\ instantiate\ %0\ %1=%0 %1 somutlaştırılamıyor
+Could\ not\ instantiate\ %0.\ Have\ you\ chosen\ the\ correct\ package\ path?=%0 somutlaştırılamıyor. Doğru paket yolunu seçmiş miydiniz?
+Could\ not\ open\ link=Link açılamıyor
 
-Could_not_print_preview=Yazdırma_önizlenemiyor
+Could\ not\ print\ preview=Yazdırma önizlenemiyor
 
-Could_not_run_the_'vim'_program.='Vim'_programı_çalıştırılamıyor.
+Could\ not\ run\ the\ 'vim'\ program.='Vim' programı çalıştırılamıyor.
 
-Could_not_save_file.=Dosya_kaydedilemiyor.
-Character_encoding_'%0'_is_not_supported.='%0'_karakter_kodlaması_desteklenmiyor.
+Could\ not\ save\ file.=Dosya kaydedilemiyor.
+Character\ encoding\ '%0'\ is\ not\ supported.='%0' karakter kodlaması desteklenmiyor.
 
-crossreferenced_entries_included=çapraz_bağlantılı_girdiler_dahil_edildi
+crossreferenced\ entries\ included=çapraz bağlantılı girdiler dahil edildi
 
-Current_content=Güncel_içerik
+Current\ content=Güncel içerik
 
-Current_value=Güncel_değer
+Current\ value=Güncel değer
 
-Custom_entry_types=Özel_girdi_türleri
+Custom\ entry\ types=Özel girdi türleri
 
-Custom_entry_types_found_in_file=Dosyada_özel_girdi_türleri_bulundu
+Custom\ entry\ types\ found\ in\ file=Dosyada özel girdi türleri bulundu
 
-Customize_entry_types=Girdi_türlerini_özelleştir
+Customize\ entry\ types=Girdi türlerini özelleştir
 
-Customize_key_bindings=Tuş_bağlantılarını_özelleştir
+Customize\ key\ bindings=Tuş bağlantılarını özelleştir
 
 Cut=Kes
 
-cut_entries=girdileri_kes
+cut\ entries=girdileri kes
 
-cut_entry=girdiyi_kes
+cut\ entry=girdiyi kes
 
 
-Library_encoding=Veritabanı_kodlaması
+Library\ encoding=Veritabanı kodlaması
 
-Library_properties=Veritabanı_özellikleri
+Library\ properties=Veritabanı özellikleri
 
-Library_type=Veritabanı_türü
+Library\ type=Veritabanı türü
 
-Date_format=Tarih_biçemi
+Date\ format=Tarih biçemi
 
 Default=Öntanımlı
 
-Default_encoding=Öntanımlı_kodlama
+Default\ encoding=Öntanımlı kodlama
 
-Default_grouping_field=Öntanımlı_gruplama_alanı
+Default\ grouping\ field=Öntanımlı gruplama alanı
 
-Default_look_and_feel=Öntanımlı_görünüm_ve_tema
+Default\ look\ and\ feel=Öntanımlı görünüm ve tema
 
-Default_pattern=Öntanımlı_desen
+Default\ pattern=Öntanımlı desen
 
-Default_sort_criteria=Öntanımlı_sıralama_ölçütleri
-Define_'%0'='%0'i_tanımla
+Default\ sort\ criteria=Öntanımlı sıralama ölçütleri
+Define\ '%0'='%0'i tanımla
 
 Delete=Sil
 
-Delete_custom_format=Özel_biçemi_sil
+Delete\ custom\ format=Özel biçemi sil
 
-delete_entries=girdileri_sil
+delete\ entries=girdileri sil
 
-Delete_entry=Girdiyi_sil
+Delete\ entry=Girdiyi sil
 
-delete_entry=girdiyi_sil
+delete\ entry=girdiyi sil
 
-Delete_multiple_entries=Çok_sayıda_girdiyi_sil
+Delete\ multiple\ entries=Çok sayıda girdiyi sil
 
-Delete_rows=Satırları_sil
+Delete\ rows=Satırları sil
 
-Delete_strings=Dizgeleri_sil
+Delete\ strings=Dizgeleri sil
 
 Deleted=Silindi
 
-Permanently_delete_local_file=Yerel_dosyayı_sil
+Permanently\ delete\ local\ file=Yerel dosyayı sil
 
-Delimit_fields_with_semicolon,_ex.=Alanları_ör._noktalı_virgülle_sınırlandır
+Delimit\ fields\ with\ semicolon,\ ex.=Alanları ör. noktalı virgülle sınırlandır
 
 Descending=Azalan
 
 Description=Tarif
 
-Deselect_all=Tümünün_seçimini_kaldır
-Deselect_all_duplicates=Tüm_çift_nüshaların_seçimini_kaldır
+Deselect\ all=Tümünün seçimini kaldır
+Deselect\ all\ duplicates=Tüm çift nüshaların seçimini kaldır
 
-Disable_this_confirmation_dialog=Bu_onaylama_penceresini_etkisizleştir
+Disable\ this\ confirmation\ dialog=Bu onaylama penceresini etkisizleştir
 
-Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.=Seçili_bir_ya_da_daha_fazla_gruba_ait_tüm_girdileri_göster.
+Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups.=Seçili bir ya da daha fazla gruba ait tüm girdileri göster.
 
-Display_all_error_messages=Tüm_hata_mesajlarını_göster
+Display\ all\ error\ messages=Tüm hata mesajlarını göster
 
-Display_help_on_command_line_options=Komut_satırı_seçenekleri_hakkındaki_yardımı_göster
+Display\ help\ on\ command\ line\ options=Komut satırı seçenekleri hakkındaki yardımı göster
 
-Display_only_entries_belonging_to_all_selected_groups.=Yalnızca_seçili_tüm_gruplara_ait_girdileri_göster.
-Display_version=Sürümü_göster
+Display\ only\ entries\ belonging\ to\ all\ selected\ groups.=Yalnızca seçili tüm gruplara ait girdileri göster.
+Display\ version=Sürümü göster
 
-Do_not_abbreviate_names=İsimleri_kısaltma
+Do\ not\ abbreviate\ names=İsimleri kısaltma
 
-Do_not_automatically_set=Otomatik_kurma
+Do\ not\ automatically\ set=Otomatik kurma
 
-Do_not_import_entry=Girdiyi_içe_aktarma
+Do\ not\ import\ entry=Girdiyi içe aktarma
 
-Do_not_open_any_files_at_startup=Başlangıçta_hiçbir_dosyayı_açma
+Do\ not\ open\ any\ files\ at\ startup=Başlangıçta hiçbir dosyayı açma
 
-Do_not_overwrite_existing_keys=Mevcut_anahtarların_üzerine_yazma
-Do_not_show_these_options_in_the_future=Gelecekte_bu_seçenekleri_gösterme
+Do\ not\ overwrite\ existing\ keys=Mevcut anahtarların üzerine yazma
+Do\ not\ show\ these\ options\ in\ the\ future=Gelecekte bu seçenekleri gösterme
 
-Do_not_wrap_the_following_fields_when_saving=Kaydederken_aşağıdaki_alanları_sarmalama
-Do_not_write_the_following_fields_to_XMP_Metadata\:=Aşağıdaki_alanları_XMP_Metadata'ya_yazma\:
+Do\ not\ wrap\ the\ following\ fields\ when\ saving=Kaydederken aşağıdaki alanları sarmalama
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Aşağıdaki alanları XMP Metadata'ya yazma:
 
-Do_you_want_JabRef_to_do_the_following_operations?=JabRef'in_aşağıdaki_işlemleri_yapmasını_ister_misiniz?
+Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=JabRef'in aşağıdaki işlemleri yapmasını ister misiniz?
 
-Donate_to_JabRef=JabRef'e_bağış_yap
+Donate\ to\ JabRef=JabRef'e bağış yap
 
 Down=Aşağı
 
-Download_file=Dosya_indir
+Download\ file=Dosya indir
 
 Downloading...=İndiriliyor...
 
-Drop_%0=%0'i_bırak
+Drop\ %0=%0'i bırak
 
-duplicate_removal=çift_nüsha_silme
+duplicate\ removal=çift nüsha silme
 
-Duplicate_string_name=Çift_nüsha_dizge_adı
+Duplicate\ string\ name=Çift nüsha dizge adı
 
-Duplicates_found=Çift_nüshalar_bulundu
+Duplicates\ found=Çift nüshalar bulundu
 
-Dynamic_groups=Devingen_gruplar
+Dynamic\ groups=Devingen gruplar
 
-Dynamically_group_entries_by_a_free-form_search_expression=Serbest_form_arama_ifadesiyle_devingence_grup_girdileri
+Dynamically\ group\ entries\ by\ a\ free-form\ search\ expression=Serbest form arama ifadesiyle devingence grup girdileri
 
-Dynamically_group_entries_by_searching_a_field_for_a_keyword=Bir_alan_ya_da_anahtar_sözcük_aramayla_devingence_grup_girdileri
+Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=Bir alan ya da anahtar sözcük aramayla devingence grup girdileri
 
-Each_line_must_be_on_the_following_form=Her_satır_aşağıdaki_biçimde_olmalıdır
+Each\ line\ must\ be\ on\ the\ following\ form=Her satır aşağıdaki biçimde olmalıdır
 
 Edit=Düzenle
 
-Edit_custom_export=Özel_dışa_aktarımı_düzenle
-Edit_entry=Girdiyi_düzenle
-Save_file=Dosya_linkini_düzenle
-Edit_file_type=Dosya_türünü_düzenle
+Edit\ custom\ export=Özel dışa aktarımı düzenle
+Edit\ entry=Girdiyi düzenle
+Save\ file=Dosya linkini düzenle
+Edit\ file\ type=Dosya türünü düzenle
 
-Edit_group=Grubu_düzenle
+Edit\ group=Grubu düzenle
 
 
-Edit_preamble=Öncülü_düzenle
-Edit_strings=Dizgeleri_düzenle
-Editor_options=Düzenleyici_seçenekleri
+Edit\ preamble=Öncülü düzenle
+Edit\ strings=Dizgeleri düzenle
+Editor\ options=Düzenleyici seçenekleri
 
-Empty_BibTeX_key=Boş_BibTeX_anahtarı
+Empty\ BibTeX\ key=Boş BibTeX anahtarı
 
-Grouping_may_not_work_for_this_entry.=Bu_giriş_için_gruplama_çalışmayabilir.
+Grouping\ may\ not\ work\ for\ this\ entry.=Bu giriş için gruplama çalışmayabilir.
 
-empty_library=boş_veritabanı
-Enable_word/name_autocompletion=Sözcük/isim_ototamamlamayı_etkinleştir
+empty\ library=boş veritabanı
+Enable\ word/name\ autocompletion=Sözcük/isim ototamamlamayı etkinleştir
 
-Enter_URL=URL_gir
+Enter\ URL=URL gir
 
-Enter_URL_to_download=İndirilecek_URL'yi_girin
+Enter\ URL\ to\ download=İndirilecek URL'yi girin
 
 entries=girdiler
 
-Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.=Girdiler_elle_bu_gruptan_silinemez_ya_da_bu_gruba_eklenemez.
+Entries\ cannot\ be\ manually\ assigned\ to\ or\ removed\ from\ this\ group.=Girdiler elle bu gruptan silinemez ya da bu gruba eklenemez.
 
-Entries_exported_to_clipboard=Girdiler_panoya_aktarıldı
+Entries\ exported\ to\ clipboard=Girdiler panoya aktarıldı
 
 
 entry=girdi
 
-Entry_editor=Girdi_düzenleyici
+Entry\ editor=Girdi düzenleyici
 
-Entry_preview=Girdi_önizlemesi
+Entry\ preview=Girdi önizlemesi
 
-Entry_table=Girdi_tablosu
+Entry\ table=Girdi tablosu
 
-Entry_table_columns=Girdi_tablosu_sütunları
+Entry\ table\ columns=Girdi tablosu sütunları
 
-Entry_type=Girdi_türü
+Entry\ type=Girdi türü
 
-Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Girdi_türü_adlarının_boşluk_ya_da_aşağıdaki_karakterleri_içermesine_izin_verilmez
+Entry\ type\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Girdi türü adlarının boşluk ya da aşağıdaki karakterleri içermesine izin verilmez
 
-Entry_types=Girdi_türleri
+Entry\ types=Girdi türleri
 
 Error=Hata
-Error_exporting_to_clipboard=Panoya_aktarmada_hata
+Error\ exporting\ to\ clipboard=Panoya aktarmada hata
 
-Error_occurred_when_parsing_entry=Girdi_ayrıştırılırken_hata_oluştu
+Error\ occurred\ when\ parsing\ entry=Girdi ayrıştırılırken hata oluştu
 
-Error_opening_file=Dosya_açmada_hata
+Error\ opening\ file=Dosya açmada hata
 
-Error_setting_field=Alan_atamada_hata
+Error\ setting\ field=Alan atamada hata
 
-Error_while_writing=Yazarken_hata
-Error_writing_to_%0_file(s).=%0_dosya(lar)_yazılırken_hata.
+Error\ while\ writing=Yazarken hata
+Error\ writing\ to\ %0\ file(s).=%0 dosya(lar) yazılırken hata.
 
 
 
-'%0'_exists._Overwrite_file?='%0'_mevcut._Dosyanın_üzerine_yazılsın_mı?
-Overwrite_file?=_Dosyanın_üzerine_yazılsın_mı?
+'%0'\ exists.\ Overwrite\ file?='%0' mevcut. Dosyanın üzerine yazılsın mı?
+Overwrite\ file?= Dosyanın üzerine yazılsın mı?
 
-Export=Dışa_aktar
+Export=Dışa aktar
 
-Export_name=Adı_dışa_aktar
+Export\ name=Adı dışa aktar
 
-Export_preferences=Tercihleri_dışa_aktar
+Export\ preferences=Tercihleri dışa aktar
 
-Export_preferences_to_file=Tercihleri_dosyaya_aktar
+Export\ preferences\ to\ file=Tercihleri dosyaya aktar
 
-Export_properties=Özellikleri_dışa_aktar
+Export\ properties=Özellikleri dışa aktar
 
-Export_to_clipboard=Panoya_aktar
+Export\ to\ clipboard=Panoya aktar
 
-Exporting=Dışa_aktarılıyor
+Exporting=Dışa aktarılıyor
 Extension=Uzantı
 
-External_changes=Harici_değişiklikler
+External\ changes=Harici değişiklikler
 
-External_file_links=Harici_dosya_linkleri
+External\ file\ links=Harici dosya linkleri
 
-External_programs=Harici_programlar
+External\ programs=Harici programlar
 
-External_viewer_called=Harici_görüntüleyici_çağrıldı
+External\ viewer\ called=Harici görüntüleyici çağrıldı
 
 Fetch=Getir
 
@@ -482,660 +482,660 @@ Field=Alan
 
 field=alan
 
-Field_name=Alan_adı
-Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Alan_adlarının_boşluk_ya_da_aşağıdaki_karakterleri_içermesine_izin_verilmez
+Field\ name=Alan adı
+Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Alan adlarının boşluk ya da aşağıdaki karakterleri içermesine izin verilmez
 
-Field_to_filter=Süzülecek_alan
+Field\ to\ filter=Süzülecek alan
 
-Field_to_group_by=Gruplanacak_alan
+Field\ to\ group\ by=Gruplanacak alan
 
 File=Dosya
 
 file=dosya
-File_'%0'_is_already_open.='%0'_dosyası_zaten_açık.
+File\ '%0'\ is\ already\ open.='%0' dosyası zaten açık.
 
-File_changed=Dosya_değişti
-File_directory_is_'%0'\:=Dosya_dizini_'%0'\:
+File\ changed=Dosya değişti
+File\ directory\ is\ '%0'\:=Dosya dizini '%0':
 
-File_directory_is_not_set_or_does_not_exist\!=Dosya_dizini_kurulmadı_ya_da_mevcut_değil\!
+File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=Dosya dizini kurulmadı ya da mevcut değil!
 
-File_exists=Dosya_mevcut
+File\ exists=Dosya mevcut
 
-File_has_been_updated_externally._What_do_you_want_to_do?=Dosya_haricen_değiştirildi._Ne_yapmak_istersiniz?
+File\ has\ been\ updated\ externally.\ What\ do\ you\ want\ to\ do?=Dosya haricen değiştirildi. Ne yapmak istersiniz?
 
-File_not_found=Dosya_bulunamadı
-File_type=Dosya_türü
+File\ not\ found=Dosya bulunamadı
+File\ type=Dosya türü
 
-File_updated_externally=Dosya_haricen_güncellendi
+File\ updated\ externally=Dosya haricen güncellendi
 
-filename=dosya_adı
+filename=dosya adı
 
-Filename=Dosya_adı
+Filename=Dosya adı
 
-Files_opened=Açılmış_dosyalar
+Files\ opened=Açılmış dosyalar
 
 Filter=Süzgeç
 
-Filter_All=Hepsine_Süzgeç_Uygula
+Filter\ All=Hepsine Süzgeç Uygula
 
-Filter_None=Hiçbirine_Süzgeç_Uygulama
+Filter\ None=Hiçbirine Süzgeç Uygulama
 
-Finished_automatically_setting_external_links.=Harici_linklerin_otokurulması_bitti.
+Finished\ automatically\ setting\ external\ links.=Harici linklerin otokurulması bitti.
 
-Finished_synchronizing_file_links._Entries_changed\:_%0.=Dosya_linkin_eşzamanlaması_bitti._Değişen_girdiler\:_%0.
-Finished_writing_XMP-metadata._Wrote_to_%0_file(s).=XMP_metadata_yazımı_bitti._%0_dosyaya_yazıldı.
-Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).=%0_dosya_için_XMP_yazımı_bitti_(%1_atlandı,_%2_hata).
+Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Dosya linkin eşzamanlaması bitti. Değişen girdiler: %0.
+Finished\ writing\ XMP-metadata.\ Wrote\ to\ %0\ file(s).=XMP metadata yazımı bitti. %0 dosyaya yazıldı.
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=%0 dosya için XMP yazımı bitti (%1 atlandı, %2 hata).
 
-First_select_the_entries_you_want_keys_to_be_generated_for.=Önce_anahtar_oluşturulmasını_istediğiniz_girdileri_seçiniz.
+First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Önce anahtar oluşturulmasını istediğiniz girdileri seçiniz.
 
-Fit_table_horizontally_on_screen=Tabloyu_ekrana_yatay_sığdır
+Fit\ table\ horizontally\ on\ screen=Tabloyu ekrana yatay sığdır
 
 Float=Yüzdür
-Float_marked_entries=Yüzdür_işaretlenmiş_girdiler
+Float\ marked\ entries=Yüzdür işaretlenmiş girdiler
 
-Font_family=Yazıtipi_Ailesi
+Font\ family=Yazıtipi Ailesi
 
-Font_preview=Yazıtipi_Önizleme
+Font\ preview=Yazıtipi Önizleme
 
-Font_size=Yazıtipi_Boyutu
+Font\ size=Yazıtipi Boyutu
 
-Font_style=Yazıtipi_Stili
+Font\ style=Yazıtipi Stili
 
-Font_selection=YazıtipiSeçici
+Font\ selection=YazıtipiSeçici
 
 for=için
 
-Format_of_author_and_editor_names=Yazar_ve_düzenleyici_adları_biçemi
-Format_string=Dizgeyi_Biçimle
+Format\ of\ author\ and\ editor\ names=Yazar ve düzenleyici adları biçemi
+Format\ string=Dizgeyi Biçimle
 
-Format_used=Kullanılan_biçem
-Formatter_name=Biçimleyici_Adı
+Format\ used=Kullanılan biçem
+Formatter\ name=Biçimleyici Adı
 
-found_in_AUX_file=yardımcı_dosyada_bulundu
+found\ in\ AUX\ file=yardımcı dosyada bulundu
 
-Full_name=Tam_ad
+Full\ name=Tam ad
 
 General=Genel
 
-General_fields=Genel_alanlar
+General\ fields=Genel alanlar
 
 Generate=Oluştur
 
-Generate_BibTeX_key=BibTeX_anahtarı_oluştur
+Generate\ BibTeX\ key=BibTeX anahtarı oluştur
 
-Generate_keys=Anahtarları_oluştur
+Generate\ keys=Anahtarları oluştur
 
-Generate_keys_before_saving_(for_entries_without_a_key)=(Anahtarsız_girdiler_için)_Kaydetmeden_önce_anahtarları_oluştur
-Generate_keys_for_imported_entries=İçe_aktarılan_girdiler_için_anahtarları_oluştur
+Generate\ keys\ before\ saving\ (for\ entries\ without\ a\ key)=(Anahtarsız girdiler için) Kaydetmeden önce anahtarları oluştur
+Generate\ keys\ for\ imported\ entries=İçe aktarılan girdiler için anahtarları oluştur
 
-Generate_now=Şimdi_oluştur
+Generate\ now=Şimdi oluştur
 
-Generated_BibTeX_key_for=Şunun_için_BibTeX_anahtarı_oluşturuldu
+Generated\ BibTeX\ key\ for=Şunun için BibTeX anahtarı oluşturuldu
 
-Generating_BibTeX_key_for=Şunun_için_BibTeX_anahtarı_oluşturuluyor
-Get_fulltext=Tammetni_getir
+Generating\ BibTeX\ key\ for=Şunun için BibTeX anahtarı oluşturuluyor
+Get\ fulltext=Tammetni getir
 
-Gray_out_non-hits=İsabet_almayanları_grileştir
+Gray\ out\ non-hits=İsabet almayanları grileştir
 
 Groups=Gruplar
 
-Have_you_chosen_the_correct_package_path?=Doğru_paket_yolunu_seçtiniz_mi?
+Have\ you\ chosen\ the\ correct\ package\ path?=Doğru paket yolunu seçtiniz mi?
 
 Help=Yardım
 
-Help_on_key_patterns=Tuş_desenleri_hakkında_yardım
-Help_on_regular_expression_search=Düzenli_İfade_Arama_hakkında_yardım
+Help\ on\ key\ patterns=Tuş desenleri hakkında yardım
+Help\ on\ regular\ expression\ search=Düzenli İfade Arama hakkında yardım
 
-Hide_non-hits=İsabet_almayanları_sakla
+Hide\ non-hits=İsabet almayanları sakla
 
-Hierarchical_context=Hiyerarşik_içerik
+Hierarchical\ context=Hiyerarşik içerik
 
 Highlight=Vurgula
 Marking=İşaretleniyor
-Underline=Altını_çiz
-Empty_Highlight=Boş_vurgulama
-Empty_Marking=Boş_işaretleme
-Empty_Underline=Boş_altını_çizme
-The_marked_area_does_not_contain_any_legible_text!=İşaretlenmiş_alan_herhangi_bir_okunabilir_metin_içermiyor!
+Underline=Altını çiz
+Empty\ Highlight=Boş vurgulama
+Empty\ Marking=Boş işaretleme
+Empty\ Underline=Boş altını çizme
+The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=İşaretlenmiş alan herhangi bir okunabilir metin içermiyor!
 
-Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>=İpucu\:_Yalnızca_belirli_alanları_aramak_için,_örneğin_şunu_giriniz\:<p><tt>author\=smith_and_title\=electrical</tt>
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=İpucu: Yalnızca belirli alanları aramak için, örneğin şunu giriniz:<p><tt>author=smith and title=electrical</tt>
 
-HTML_table=HTML_tablosu
-HTML_table_(with_Abstract_&_BibTeX)=(Özet_&_BibTeX_ile)_HTML_tablosu
+HTML\ table=HTML tablosu
+HTML\ table\ (with\ Abstract\ &\ BibTeX)=(Özet & BibTeX ile) HTML tablosu
 Icon=Simge
 
 Ignore=Yoksay
 
-Import=İçe_aktar
+Import=İçe aktar
 
-Import_and_keep_old_entry=İçe_aktar_ve_eski_girdiyi_koru
+Import\ and\ keep\ old\ entry=İçe aktar ve eski girdiyi koru
 
-Import_and_remove_old_entry=Eski_girdiyi_içe_aktar_ve_sil.
+Import\ and\ remove\ old\ entry=Eski girdiyi içe aktar ve sil.
 
-Import_entries=Girdileri_içe_aktar
+Import\ entries=Girdileri içe aktar
 
-Import_failed=İçe_aktarma_başarısız
+Import\ failed=İçe aktarma başarısız
 
-Import_file=Dosya_içe_aktar
+Import\ file=Dosya içe aktar
 
-Import_group_definitions=Grup_tanımlarını_içe_aktar
+Import\ group\ definitions=Grup tanımlarını içe aktar
 
-Import_name=İsim_içe_aktar
+Import\ name=İsim içe aktar
 
-Import_preferences=İçe_aktarma_tercihleri
+Import\ preferences=İçe aktarma tercihleri
 
-Import_preferences_from_file=Dosyadan_içe_aktarma_tercihleri
+Import\ preferences\ from\ file=Dosyadan içe aktarma tercihleri
 
-Import_strings=Dizgeleri_içe_aktar
+Import\ strings=Dizgeleri içe aktar
 
-Import_to_open_tab=Sekme_açmak_için_içe_aktar
+Import\ to\ open\ tab=Sekme açmak için içe aktar
 
-Import_word_selector_definitions=Sözcük_seçici_tanımlarını_içe_aktar
+Import\ word\ selector\ definitions=Sözcük seçici tanımlarını içe aktar
 
-Imported_entries=İçe_aktarılmış_girdiler
+Imported\ entries=İçe aktarılmış girdiler
 
-Imported_from_library=Veritabanından_içe_aktarılmış
+Imported\ from\ library=Veritabanından içe aktarılmış
 
-Importer_class=Importer_sınıfı
+Importer\ class=Importer sınıfı
 
-Importing=İçe_aktarılıyor
+Importing=İçe aktarılıyor
 
-Importing_in_unknown_format=Bilinmeyen_biçemde_içe_aktarılıyor
+Importing\ in\ unknown\ format=Bilinmeyen biçemde içe aktarılıyor
 
-Include_abstracts=Özetleri_içer
-Include_entries=Alanları_içer
+Include\ abstracts=Özetleri içer
+Include\ entries=Alanları içer
 
-Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups=Altgrupları_içer\:_Seçildiğinde,_bu_grup_ya_da_altgruplarındaki_girdileri_göster
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=Altgrupları içer: Seçildiğinde, bu grup ya da altgruplarındaki girdileri göster
 
-Independent_group\:_When_selected,_view_only_this_group's_entries=Bağımsız_grup\:_Seçildiğinde,_yalnızca_bu_grubun_girdilerini_göster
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=Bağımsız grup: Seçildiğinde, yalnızca bu grubun girdilerini göster
 
-Work_options=Çalışma_seçenekleri
+Work\ options=Çalışma seçenekleri
 
 Insert=Ekle
 
-Insert_rows=Satır_ekle
+Insert\ rows=Satır ekle
 
 Intersection=Kesişim
 
-Invalid_BibTeX_key=Geçersiz_BibTeX_anahtarı
+Invalid\ BibTeX\ key=Geçersiz BibTeX anahtarı
 
-Invalid_date_format=Geçersiz_tarih_biçemi
+Invalid\ date\ format=Geçersiz tarih biçemi
 
-Invalid_URL=Geçersiz_URL
+Invalid\ URL=Geçersiz URL
 
-Online_help=Çevrimiçi_yardım
+Online\ help=Çevrimiçi yardım
 
-JabRef_preferences=JabRef_tercihler
+JabRef\ preferences=JabRef tercihler
 
 Join=Ekle
 
-Joins_selected_keywords_and_deletes_selected_keywords.=Seçili_anahtar_sözcüğü_ekler_ve_seçili_anahtar_sözcüğü_siler.
+Joins\ selected\ keywords\ and\ deletes\ selected\ keywords.=Seçili anahtar sözcüğü ekler ve seçili anahtar sözcüğü siler.
 
-Journal_abbreviations=Dergi_kısaltmaları
+Journal\ abbreviations=Dergi kısaltmaları
 
 Keep=Tut
 
-Keep_both=İkisini_de_tut
+Keep\ both=İkisini de tut
 
-Key_bindings=Anahtar_bağlantıları
+Key\ bindings=Anahtar bağlantıları
 
-Key_bindings_changed=Anahtar_bağlantıları_değişti
+Key\ bindings\ changed=Anahtar bağlantıları değişti
 
-Key_generator_settings=Anahtar_oluşturucu_ayarları
+Key\ generator\ settings=Anahtar oluşturucu ayarları
 
-Key_pattern=Anahtar_deseni
+Key\ pattern=Anahtar deseni
 
-keys_in_library=veritabanındaki_anahtarlar
+keys\ in\ library=veritabanındaki anahtarlar
 
-Keyword=Anahtar_sözcük
+Keyword=Anahtar sözcük
 
 Label=Etiket
 
 Language=Dil
 
-Last_modified=Son_değiştirme
+Last\ modified=Son değiştirme
 
-LaTeX_AUX_file=LaTex_AUX_dosyası
-Leave_file_in_its_current_directory=Dosyayı_şimdiki_dizininde_bırak
+LaTeX\ AUX\ file=LaTex AUX dosyası
+Leave\ file\ in\ its\ current\ directory=Dosyayı şimdiki dizininde bırak
 
 Left=Sol
 Level=Düzey
 
-Limit_to_fields=Alanlara_kısıtla
+Limit\ to\ fields=Alanlara kısıtla
 
-Limit_to_selected_entries=Seçili_girdilere_kısıtla
+Limit\ to\ selected\ entries=Seçili girdilere kısıtla
 
 Link=Link
-Link_local_file=Yerel_dosyayı_bağla
-Link_to_file_%0=%0_dosyasına_bağla
+Link\ local\ file=Yerel dosyayı bağla
+Link\ to\ file\ %0=%0 dosyasına bağla
 
-Listen_for_remote_operation_on_port=Bağlantı_noktasındaki_uzak_işlemi_dinle
-Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)=Başlangıçta_tercihleri_jabref.xml'den_yükle_ya_da_buraya_kaydet_(bellek_çubuğu_kipi)
+Listen\ for\ remote\ operation\ on\ port=Bağlantı noktasındaki uzak işlemi dinle
+Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=Başlangıçta tercihleri jabref.xml'den yükle ya da buraya kaydet (bellek çubuğu kipi)
 
-Look_and_feel=Görünüm_ve_tema
-Main_file_directory=Ana_dosya_dizini
+Look\ and\ feel=Görünüm ve tema
+Main\ file\ directory=Ana dosya dizini
 
-Main_layout_file=Ana_yerleşim_dosyası
+Main\ layout\ file=Ana yerleşim dosyası
 
-Manage_custom_exports=Özel_dışa_aktarımları_yönet
+Manage\ custom\ exports=Özel dışa aktarımları yönet
 
-Manage_custom_imports=Özel_içe_aktarımları_yönet
-Manage_external_file_types=Harici_dosya_türlerini_yönet
+Manage\ custom\ imports=Özel içe aktarımları yönet
+Manage\ external\ file\ types=Harici dosya türlerini yönet
 
-Mark_entries=Girdileri_işaretle
+Mark\ entries=Girdileri işaretle
 
-Mark_entry=Girdiyi_işaretle
+Mark\ entry=Girdiyi işaretle
 
-Mark_new_entries_with_addition_date=Yeni_girdileri_ekleme_tarihiyle_işaretle
+Mark\ new\ entries\ with\ addition\ date=Yeni girdileri ekleme tarihiyle işaretle
 
-Mark_new_entries_with_owner_name=Yeni_girdileri_sahip_adıyla_işaretle
+Mark\ new\ entries\ with\ owner\ name=Yeni girdileri sahip adıyla işaretle
 
-Memory_stick_mode=Bellek_Çubuğu_Kipi
+Memory\ stick\ mode=Bellek Çubuğu Kipi
 
-Menu_and_label_font_size=Menü_ve_etiket_yazı_tipi_boyutu
+Menu\ and\ label\ font\ size=Menü ve etiket yazı tipi boyutu
 
-Merged_external_changes=Harici_değişiklikler_birleştirildi
+Merged\ external\ changes=Harici değişiklikler birleştirildi
 
 Messages=Mesajlar
 
-Modification_of_field=Alanın_değişikliği
+Modification\ of\ field=Alanın değişikliği
 
-Modified_group_"%0".=Değiştirilmiş_grup_"%0".
+Modified\ group\ "%0".=Değiştirilmiş grup "%0".
 
-Modified_groups=Değiştirilmiş_gruplar
+Modified\ groups=Değiştirilmiş gruplar
 
-Modified_string=Değiştirilmiş_dizge
+Modified\ string=Değiştirilmiş dizge
 
 Modify=Değiştir
 
-modify_group=grubu_değiştir
+modify\ group=grubu değiştir
 
-Move_down=Aşağı_taşı
+Move\ down=Aşağı taşı
 
-Move_external_links_to_'file'_field=Harici_linkleri_'dosya'_alanına_taşı
+Move\ external\ links\ to\ 'file'\ field=Harici linkleri 'dosya' alanına taşı
 
-move_group=grubu_taşı
+move\ group=grubu taşı
 
-Move_up=Yukarı_taşı
+Move\ up=Yukarı taşı
 
-Moved_group_"%0".="%0"_grubu_taşındı.
+Moved\ group\ "%0".="%0" grubu taşındı.
 
 Name=Ad
-Name_formatter=Ad_biçemleyici
+Name\ formatter=Ad biçemleyici
 
-Natbib_style=Natbib_stili
+Natbib\ style=Natbib stili
 
-nested_AUX_files=içiçe_AUX_dosyaları
+nested\ AUX\ files=içiçe AUX dosyaları
 
 New=Yeni
 
 new=yeni
 
-New_BibTeX_entry=Yeni_BibTeX_girdisi
+New\ BibTeX\ entry=Yeni BibTeX girdisi
 
-New_BibTeX_sublibrary=Yeni_BibTeX_alt_veritabanı
+New\ BibTeX\ sublibrary=Yeni BibTeX alt veritabanı
 
-New_content=Yeni_içerik
+New\ content=Yeni içerik
 
-New_library_created.=Yeni_veritabanı_oluşturuldu.
-New_%0_library=Yeni_%0_veri_tabanı
-New_field_value=Yeni_alan_değeri
+New\ library\ created.=Yeni veritabanı oluşturuldu.
+New\ %0\ library=Yeni %0 veri tabanı
+New\ field\ value=Yeni alan değeri
 
-New_group=Yeni_grup
+New\ group=Yeni grup
 
-New_string=Yeni_dizge
+New\ string=Yeni dizge
 
-Next_entry=Yeni_girdi
+Next\ entry=Yeni girdi
 
-No_actual_changes_found.=Hiç_fiili_değişiklik_bulunamadı.
+No\ actual\ changes\ found.=Hiç fiili değişiklik bulunamadı.
 
-no_base-BibTeX-file_specified=temel_BibTeX_dosyası_belirtilmedi
+no\ base-BibTeX-file\ specified=temel BibTeX dosyası belirtilmedi
 
-no_library_generated=veritabanı_üretilmedi
+no\ library\ generated=veritabanı üretilmedi
 
-No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.=Girdi_bulunmadı._Lütfen_doğru_içe_aktarma_süzgecini_kullandığınızdan_emin_olun.
+No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=Girdi bulunmadı. Lütfen doğru içe aktarma süzgecini kullandığınızdan emin olun.
 
 
-No_entries_found_for_the_search_string_'%0'=Arama_dizgesi_'%0'_için_bir_girdi_bulunmadı
+No\ entries\ found\ for\ the\ search\ string\ '%0'=Arama dizgesi '%0' için bir girdi bulunmadı
 
-No_entries_imported.=Hiçbir_girdi_içe_aktarılmadı.
+No\ entries\ imported.=Hiçbir girdi içe aktarılmadı.
 
-No_files_found.=Hiçbir_dosya_bulunmadı.
+No\ files\ found.=Hiçbir dosya bulunmadı.
 
-No_GUI._Only_process_command_line_options.=Grafik_kullanıcı_arayüzü_yok._Yalnızca_komut_satırı_seçenekleri_işlenecek.
+No\ GUI.\ Only\ process\ command\ line\ options.=Grafik kullanıcı arayüzü yok. Yalnızca komut satırı seçenekleri işlenecek.
 
-No_journal_names_could_be_abbreviated.=Hiçbir_dergi_adı_kısaltılamadı.
+No\ journal\ names\ could\ be\ abbreviated.=Hiçbir dergi adı kısaltılamadı.
 
-No_journal_names_could_be_unabbreviated.=Hiçbir_dergi_adı_kısaltması_açılamadı.
-No_PDF_linked=Hiçbir_PDF_bağlanmamış
+No\ journal\ names\ could\ be\ unabbreviated.=Hiçbir dergi adı kısaltması açılamadı.
+No\ PDF\ linked=Hiçbir PDF bağlanmamış
 
-Open_PDF=DPF'i_aç
+Open\ PDF=DPF'i aç
 
-No_URL_defined=Hiç_url_tanımlanmamış
+No\ URL\ defined=Hiç url tanımlanmamış
 not=hariç
 
-not_found=bulunmadı
+not\ found=bulunmadı
 
-Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,=Görünüm_ve_temalar_için_tam_kalifiye_sınıf_adını_belirtmelisiniz,
+Note\ that\ you\ must\ specify\ the\ fully\ qualified\ class\ name\ for\ the\ look\ and\ feel,=Görünüm ve temalar için tam kalifiye sınıf adını belirtmelisiniz,
 
-Nothing_to_redo=Yinelenecek_bir_şey_yok
+Nothing\ to\ redo=Yinelenecek bir şey yok
 
-Nothing_to_undo=Geriye_alınacak_bir_şey_yok
+Nothing\ to\ undo=Geriye alınacak bir şey yok
 
-occurrences=görülme_sıklığı
+occurrences=görülme sıklığı
 
 OK=Tamam
-One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Bir_ya_da_daha_çok_link,_tanımlanmamış_'%0'_türünde._Ne_yapmak_istersiniz?
+One\ or\ more\ file\ links\ are\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Bir ya da daha çok link, tanımlanmamış '%0' türünde. Ne yapmak istersiniz?
 
-One_or_more_keys_will_be_overwritten._Continue?=Bir_ya_da_daha_çok_anahtarın_üzerine_yazılacak._Devam_edilsin_mi?
+One\ or\ more\ keys\ will\ be\ overwritten.\ Continue?=Bir ya da daha çok anahtarın üzerine yazılacak. Devam edilsin mi?
 
 
 Open=Aç
 
-Open_BibTeX_library=BibTeX_veritabanı_aç
+Open\ BibTeX\ library=BibTeX veritabanı aç
 
-Open_library=Veritabanı_aç
+Open\ library=Veritabanı aç
 
-Open_editor_when_a_new_entry_is_created=Yeni_bir_girdi_oluşturulduğunda_düzenleyiciyi_aç
+Open\ editor\ when\ a\ new\ entry\ is\ created=Yeni bir girdi oluşturulduğunda düzenleyiciyi aç
 
-Open_file=Dosya_aç
+Open\ file=Dosya aç
 
-Open_last_edited_libraries_at_startup=Açılışta_son_düzenlenmiş_veritabanlarını_aç
+Open\ last\ edited\ libraries\ at\ startup=Açılışta son düzenlenmiş veritabanlarını aç
 
-Connect_to_shared_database=Paylaşılmış_veritabanını_aç
+Connect\ to\ shared\ database=Paylaşılmış veritabanını aç
 
-Open_terminal_here=Terminali_burada_aç
+Open\ terminal\ here=Terminali burada aç
 
-Open_URL_or_DOI=URL_ya_da_DOI_aç
+Open\ URL\ or\ DOI=URL ya da DOI aç
 
-Opened_library=Açık_veritabanı
+Opened\ library=Açık veritabanı
 
 Opening=Açılıyor
 
-Opening_preferences...=Tercihler_açılıyor...
+Opening\ preferences...=Tercihler açılıyor...
 
-Operation_canceled.=İşlem_iptal_edildi.
-Operation_not_supported=İşlem_desteklenmiyor
+Operation\ canceled.=İşlem iptal edildi.
+Operation\ not\ supported=İşlem desteklenmiyor
 
-Optional_fields=Tercihe_bağlı_alanlar
+Optional\ fields=Tercihe bağlı alanlar
 
 Options=Seçenekler
 
-or=ya_da
+or=ya da
 
-Output_or_export_file=Çıktı_ya_da_dışa_aktarım_dosyası
+Output\ or\ export\ file=Çıktı ya da dışa aktarım dosyası
 
-Override=Geçersiz_kıl
+Override=Geçersiz kıl
 
-Override_default_file_directories=Öntanımlı_dosya_dizinlerini_geçersiz_kıl
+Override\ default\ file\ directories=Öntanımlı dosya dizinlerini geçersiz kıl
 
-Override_default_font_settings=Öntamınlı_yazıtipi_ayarlarını_geçersiz_kıl
+Override\ default\ font\ settings=Öntamınlı yazıtipi ayarlarını geçersiz kıl
 
-Override_the_BibTeX_field_by_the_selected_text=BibTeX_anahtarını_seçili_metinle_yenile
+Override\ the\ BibTeX\ field\ by\ the\ selected\ text=BibTeX anahtarını seçili metinle yenile
 
 
-Overwrite=Üzerine_yaz
-Overwrite_existing_field_values=Mevcut_alan_değerlerinin_üzerine_yaz
+Overwrite=Üzerine yaz
+Overwrite\ existing\ field\ values=Mevcut alan değerlerinin üzerine yaz
 
-Overwrite_keys=Anahtarların_üzerine_yaz
+Overwrite\ keys=Anahtarların üzerine yaz
 
-pairs_processed=işlenmiş_çiftler
+pairs\ processed=işlenmiş çiftler
 Password=Parola
 
 Paste=Yapıştır
 
-paste_entries=girdileri_yapıştır
+paste\ entries=girdileri yapıştır
 
-paste_entry=girdiyi_yapıştır
-Paste_from_clipboard=Panodan_yapıştır
+paste\ entry=girdiyi yapıştır
+Paste\ from\ clipboard=Panodan yapıştır
 
 Pasted=Yapıştırıldı
 
-Path_to_%0_not_defined=%0'in_yolu_tanımlanmamış
+Path\ to\ %0\ not\ defined=%0'in yolu tanımlanmamış
 
-Path_to_LyX_pipe=LyX_hattının_yolu
+Path\ to\ LyX\ pipe=LyX hattının yolu
 
-PDF_does_not_exist=PDF_mevcut_değil
+PDF\ does\ not\ exist=PDF mevcut değil
 
-File_has_no_attached_annotations=Dosyanın_eklenmiş_açıklama_notu_yok
+File\ has\ no\ attached\ annotations=Dosyanın eklenmiş açıklama notu yok
 
-Plain_text_import=Düz_metin_içe_aktarma
+Plain\ text\ import=Düz metin içe aktarma
 
-Please_enter_a_name_for_the_group.=Lütfen_grup_için_bir_isim_giriniz.
+Please\ enter\ a\ name\ for\ the\ group.=Lütfen grup için bir isim giriniz.
 
-Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>=Lütfen_bir_arama_terimi_giriniz._Örneğin,_<b>Smith</b>'i_tüm_alanlarda_aramak_için_\:<p><tt>smith</tt><p>_giriniz._<b>Smith</b>'i_<b>Author</b>_alanında,_<b>electrical</b>'ı_<b>Title</b>_alanında_aramak_için_\:<p><tt>author\=smith_and_title\=electrical</tt>_giriniz
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Lütfen bir arama terimi giriniz. Örneğin, <b>Smith</b>'i tüm alanlarda aramak için :<p><tt>smith</tt><p> giriniz. <b>Smith</b>'i <b>Author</b> alanında, <b>electrical</b>'ı <b>Title</b> alanında aramak için :<p><tt>author=smith and title=electrical</tt> giriniz
 
-Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=Lütfen_aranacak_alan_adını_(örneğin_<b>keywords</b>)_ve_aranacak_anahtar_sözcüğü_(örneğin_<b>electrical</b>)_giriniz.
+Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=Lütfen aranacak alan adını (örneğin <b>keywords</b>) ve aranacak anahtar sözcüğü (örneğin <b>electrical</b>) giriniz.
 
-Please_enter_the_string's_label=Lütfen_dizgenin_etiketini_giriniz
+Please\ enter\ the\ string's\ label=Lütfen dizgenin etiketini giriniz
 
-Please_select_an_importer.=Lütfen_bir_içe_aktarıcı_seçiniz.
+Please\ select\ an\ importer.=Lütfen bir içe aktarıcı seçiniz.
 
-Possible_duplicate_entries=Olası_çift_nüsha_girdiler
+Possible\ duplicate\ entries=Olası çift nüsha girdiler
 
-Possible_duplicate_of_existing_entry._Click_to_resolve.=Mevcut_girdinin_olası_çift_nüshası._Düzeltmek_için_tıklayınız.
+Possible\ duplicate\ of\ existing\ entry.\ Click\ to\ resolve.=Mevcut girdinin olası çift nüshası. Düzeltmek için tıklayınız.
 
 Preamble=Öncül
 
 Preferences=Tercihler
 
-Preferences_recorded.=Tercihler_kaydedildi.
+Preferences\ recorded.=Tercihler kaydedildi.
 
 Preview=Önizleme
-Citation_Style=Atıf_Stili
-Current_Preview=Mevcut_Önizleme
-Cannot_generate_preview_based_on_selected_citation_style.=Seçili_atıf_stiline_dayalı_ön_izleme_oluşturulamıyor.
-Bad_character_inside_entry=Girdi_içinde_kötü_karakter
-Error_while_generating_citation_style=Atıf_stili_oluşturulurken_hata
-Preview_style_changed_to\:_%0=Önizleme_stili_%0'a_değiştirildi
-Next_preview_layout=Sonraki_önizleme_düzeni
-Previous_preview_layout=Önceki_önizleme_düzeni
+Citation\ Style=Atıf Stili
+Current\ Preview=Mevcut Önizleme
+Cannot\ generate\ preview\ based\ on\ selected\ citation\ style.=Seçili atıf stiline dayalı ön izleme oluşturulamıyor.
+Bad\ character\ inside\ entry=Girdi içinde kötü karakter
+Error\ while\ generating\ citation\ style=Atıf stili oluşturulurken hata
+Preview\ style\ changed\ to\:\ %0=Önizleme stili %0'a değiştirildi
+Next\ preview\ layout=Sonraki önizleme düzeni
+Previous\ preview\ layout=Önceki önizleme düzeni
 
-Previous_entry=Önceki_girdi
+Previous\ entry=Önceki girdi
 
-Primary_sort_criterion=Birincil_sıralama_kriteri
-Problem_with_parsing_entry=Girdi_ayrıştırmada_sorun
-Processing_%0=İşleniyor_%0
-Pull_changes_from_shared_database=Paylaşılmış_veritabanından_değişiklikleri_çek
+Primary\ sort\ criterion=Birincil sıralama kriteri
+Problem\ with\ parsing\ entry=Girdi ayrıştırmada sorun
+Processing\ %0=İşleniyor %0
+Pull\ changes\ from\ shared\ database=Paylaşılmış veritabanından değişiklikleri çek
 
-Pushed_citations_to_%0=Atıflar_%0'a_itelendi
+Pushed\ citations\ to\ %0=Atıflar %0'a itelendi
 
-Quit_JabRef=JabRef'ten_çık
+Quit\ JabRef=JabRef'ten çık
 
-Quit_synchronization=Eşzamanlamayı_bitir
+Quit\ synchronization=Eşzamanlamayı bitir
 
-Raw_source=Ham_kaynak
+Raw\ source=Ham kaynak
 
-Rearrange_tabs_alphabetically_by_title=Sekmeleri_başlıklarıyla_alfabetik_olarak_yeniden_düzenle
+Rearrange\ tabs\ alphabetically\ by\ title=Sekmeleri başlıklarıyla alfabetik olarak yeniden düzenle
 
-Redo=Yeniden_yap
+Redo=Yeniden yap
 
-Reference_library=Başvuru_veritabanı
+Reference\ library=Başvuru veritabanı
 
-%0_references_found._Number_of_references_to_fetch?=Bulunan_başvurular\:_%0._Getirilecek_başvuru_sayısı?
+%0\ references\ found.\ Number\ of\ references\ to\ fetch?=Bulunan başvurular: %0. Getirilecek başvuru sayısı?
 
-Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Supergrubu_arıt\:_Seçildiğinde,_hem_bu_grubun,_hem_de_süpergrubunun_içerdiği_girdileri_görüntüle
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=Supergrubu arıt: Seçildiğinde, hem bu grubun, hem de süpergrubunun içerdiği girdileri görüntüle
 
-regular_expression=Düzenli_İfade
+regular\ expression=Düzenli İfade
 
-Related_articles=İlgili_makaleler
+Related\ articles=İlgili makaleler
 
-Remote_operation=Uzak_işlem
+Remote\ operation=Uzak işlem
 
-Remote_server_port=Uzak_sunucu_bağlantı_noktası
+Remote\ server\ port=Uzak sunucu bağlantı noktası
 
 Remove=Sil
 
-Remove_subgroups=Tüm_altgrupları_sil
+Remove\ subgroups=Tüm altgrupları sil
 
-Remove_all_subgroups_of_"%0"?="%0"in_tüm_altgruplarını_sil?
+Remove\ all\ subgroups\ of\ "%0"?="%0"in tüm altgruplarını sil?
 
-Remove_entry_from_import=İçe_aktarımdan_girdiyi_sil
+Remove\ entry\ from\ import=İçe aktarımdan girdiyi sil
 
-Remove_selected_entries_from_this_group=Seçili_girdileri_bu_gruptan_çıkar
+Remove\ selected\ entries\ from\ this\ group=Seçili girdileri bu gruptan çıkar
 
-Remove_entry_type=Girdi_türünü_sil
+Remove\ entry\ type=Girdi türünü sil
 
-Remove_from_group=Gruptan_sil
+Remove\ from\ group=Gruptan sil
 
-Remove_group=Grubu_sil
+Remove\ group=Grubu sil
 
-Remove_group,_keep_subgroups=Grubu_sil,_altgrupları_tut
+Remove\ group,\ keep\ subgroups=Grubu sil, altgrupları tut
 
-Remove_group_"%0"?="%0"_grubu_silinsin_mi?
+Remove\ group\ "%0"?="%0" grubu silinsin mi?
 
-Remove_group_"%0"_and_its_subgroups?="%0"_grubu_ve_altgrupları_silinsin_mi?
+Remove\ group\ "%0"\ and\ its\ subgroups?="%0" grubu ve altgrupları silinsin mi?
 
-remove_group_(keep_subgroups)=grubu_sil_(altgrupları_tut)
+remove\ group\ (keep\ subgroups)=grubu sil (altgrupları tut)
 
-remove_group_and_subgroups=grubu_ve_altgrupları_sil
+remove\ group\ and\ subgroups=grubu ve altgrupları sil
 
-Remove_group_and_subgroups=Grubu_ve_altgrupları_sil
+Remove\ group\ and\ subgroups=Grubu ve altgrupları sil
 
-Remove_link=Linki_sil
+Remove\ link=Linki sil
 
-Remove_old_entry=Eski_girdiyi_sil
+Remove\ old\ entry=Eski girdiyi sil
 
-Remove_selected_strings=Seçili_dizgeleri_sil
+Remove\ selected\ strings=Seçili dizgeleri sil
 
-Removed_group_"%0".="%0"_grubu_silindi.
+Removed\ group\ "%0".="%0" grubu silindi.
 
-Removed_group_"%0"_and_its_subgroups.="%0"_grubu_ve_altgrupları_silindi.
+Removed\ group\ "%0"\ and\ its\ subgroups.="%0" grubu ve altgrupları silindi.
 
-Removed_string=Dizge_silindi
+Removed\ string=Dizge silindi
 
-Renamed_string=Dizge_yeniden_adlandırıldı
+Renamed\ string=Dizge yeniden adlandırıldı
 
-Replace=Yerine_koy
+Replace=Yerine koy
 
-Replace_(regular_expression)=Yerine_koy_(düzenli_ifade)
+Replace\ (regular\ expression)=Yerine koy (düzenli ifade)
 
-Replace_string=Dizgenin_yerine_koy
+Replace\ string=Dizgenin yerine koy
 
-Replace_with=Şununla_değiştir
+Replace\ with=Şununla değiştir
 
 Replaced=Değiştirildi
 
-Required_fields=Zorunlu_alanlar
+Required\ fields=Zorunlu alanlar
 
-Reset_all=Tümünü_sıfırla
+Reset\ all=Tümünü sıfırla
 
-Resolve_strings_for_all_fields_except=Şu_hariç_tüm_alanların_dizgelerini_çözümle
-Resolve_strings_for_standard_BibTeX_fields_only=Yalnızca_standart_BibTeX_alan_dizgelerini_çözümle
+Resolve\ strings\ for\ all\ fields\ except=Şu hariç tüm alanların dizgelerini çözümle
+Resolve\ strings\ for\ standard\ BibTeX\ fields\ only=Yalnızca standart BibTeX alan dizgelerini çözümle
 
 resolved=çözümlendi
 
-Review=Gözden_geçir
+Review=Gözden geçir
 
-Review_changes=Değişklikleri_incele
+Review\ changes=Değişklikleri incele
 
 Right=Sağ
 
 Save=Kaydet
-Save_all_finished.=Tüm_bitenleri_kaydet.
+Save\ all\ finished.=Tüm bitenleri kaydet.
 
-Save_all_open_libraries=Tüm_açık_veritabanlarını_kaydet
+Save\ all\ open\ libraries=Tüm açık veritabanlarını kaydet
 
-Save_before_closing=Kapatmadan_önce_kaydet
+Save\ before\ closing=Kapatmadan önce kaydet
 
-Save_library=Veritabanını_kaydet
-Save_library_as...=Veritabanını_farklı_kaydet_...
+Save\ library=Veritabanını kaydet
+Save\ library\ as...=Veritabanını farklı kaydet ...
 
-Save_entries_in_their_original_order=Girdileri_orijinal_sıralarında_kaydet
+Save\ entries\ in\ their\ original\ order=Girdileri orijinal sıralarında kaydet
 
-Save_failed=Kaydetme_başarısız
+Save\ failed=Kaydetme başarısız
 
-Save_failed_during_backup_creation=Yedek_oluşturulurken_kaydetme_başarısız
+Save\ failed\ during\ backup\ creation=Yedek oluşturulurken kaydetme başarısız
 
-Save_selected_as...=Seçimi_farklı_kaydet_...
+Save\ selected\ as...=Seçimi farklı kaydet ...
 
-Saved_library=Kaydedilmiş_veritabanı
+Saved\ library=Kaydedilmiş veritabanı
 
-Saved_selected_to_'%0'.=Seçim_şuraya_kaydedildi_'%0'.
+Saved\ selected\ to\ '%0'.=Seçim şuraya kaydedildi '%0'.
 
 Saving=Kaydediliyor
-Saving_all_libraries...=Tüm_veritabanları_kaydediliyor...
+Saving\ all\ libraries...=Tüm veritabanları kaydediliyor...
 
-Saving_library=Veritabanı_kaydediliyor
+Saving\ library=Veritabanı kaydediliyor
 
 Search=Ara
 
-Search_expression=İfade_ara
+Search\ expression=İfade ara
 
-Search_for=Şunu_ara
+Search\ for=Şunu ara
 
-Searching_for_duplicates...=Çift_nüshalar_aranıyor...
+Searching\ for\ duplicates...=Çift nüshalar aranıyor...
 
-Searching_for_files=Dosyalar_aranıyor
+Searching\ for\ files=Dosyalar aranıyor
 
-Secondary_sort_criterion=İkincil_sıralama_kriteri
+Secondary\ sort\ criterion=İkincil sıralama kriteri
 
-Select_all=Tümünü_seç
+Select\ all=Tümünü seç
 
-Select_encoding=Kodlamayı_seç
+Select\ encoding=Kodlamayı seç
 
-Select_entry_type=Girdi_türünü_seç
-Select_external_application=Harici_uygulamayı_seç
+Select\ entry\ type=Girdi türünü seç
+Select\ external\ application=Harici uygulamayı seç
 
-Select_file_from_ZIP-archive=ZIP_arşivinden_dosyayı_seçiniz
+Select\ file\ from\ ZIP-archive=ZIP arşivinden dosyayı seçiniz
 
-Select_the_tree_nodes_to_view_and_accept_or_reject_changes=Değişiklikleri_görmek_ve_kabul_ya_da_reddetmek_için_ağaç_düğümlerini_seçiniz
-Selected_entries=Seçili_girdiler
-Set_field=Alanı_ata
-Set_fields=Alanları_ata
+Select\ the\ tree\ nodes\ to\ view\ and\ accept\ or\ reject\ changes=Değişiklikleri görmek ve kabul ya da reddetmek için ağaç düğümlerini seçiniz
+Selected\ entries=Seçili girdiler
+Set\ field=Alanı ata
+Set\ fields=Alanları ata
 
-Set_general_fields=Genel_alanları_ata
-Set_main_external_file_directory=Ana_harici_dosya_dizinini_ayarla
+Set\ general\ fields=Genel alanları ata
+Set\ main\ external\ file\ directory=Ana harici dosya dizinini ayarla
 
-Set_table_font=Tablo_yazıtipini_ayarla
+Set\ table\ font=Tablo yazıtipini ayarla
 
 Settings=Ayarlar
 
 Shortcut=Kısayol
 
-Show/edit_%0_source=%0_kaynağın_göster/düzenle
+Show/edit\ %0\ source=%0 kaynağın göster/düzenle
 
-Show_'Firstname_Lastname'='Ad_Soyad'_göster
+Show\ 'Firstname\ Lastname'='Ad Soyad' göster
 
-Show_'Lastname,_Firstname'='Soyad,_Ad'_göster
+Show\ 'Lastname,\ Firstname'='Soyad, Ad' göster
 
-Show_BibTeX_source_by_default=Öntanımlı_olarak_BibTeX_kaynağını_göster
+Show\ BibTeX\ source\ by\ default=Öntanımlı olarak BibTeX kaynağını göster
 
-Show_confirmation_dialog_when_deleting_entries=Girdileri_silerken_onaylama_iletişim_penceresini_göster
+Show\ confirmation\ dialog\ when\ deleting\ entries=Girdileri silerken onaylama iletişim penceresini göster
 
-Show_description=Açıklamayı_göster
+Show\ description=Açıklamayı göster
 
-Show_file_column=Dosya_sütununu_göster
+Show\ file\ column=Dosya sütununu göster
 
-Show_last_names_only=Yalnızca_soyadları_göster
+Show\ last\ names\ only=Yalnızca soyadları göster
 
-Show_names_unchanged=Adları_değiştirmeden_göster
+Show\ names\ unchanged=Adları değiştirmeden göster
 
-Show_optional_fields=Seçmeli_alanları_göster
+Show\ optional\ fields=Seçmeli alanları göster
 
-Show_required_fields=Zorunlu_alanları_göster
+Show\ required\ fields=Zorunlu alanları göster
 
-Show_URL/DOI_column=URL/DOI_sütununu_göster
+Show\ URL/DOI\ column=URL/DOI sütununu göster
 
-Simple_HTML=Basit_HTML
+Simple\ HTML=Basit HTML
 
 Size=Boyut
 
-Skipped_-_No_PDF_linked=Atlandı_-_PDF_eklenmedi
-Skipped_-_PDF_does_not_exist=Atlandı_-_PDF_mevcut_değil
+Skipped\ -\ No\ PDF\ linked=Atlandı - PDF eklenmedi
+Skipped\ -\ PDF\ does\ not\ exist=Atlandı - PDF mevcut değil
 
-Skipped_entry.=Girdi_atlandı.
+Skipped\ entry.=Girdi atlandı.
 
-Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.=
+Some\ appearance\ settings\ you\ changed\ require\ to\ restart\ JabRef\ to\ come\ into\ effect.=
 
-source_edit=kaynak_düzenle
-Special_name_formatters=Özel_Ad_Biçemleyicileri
+source\ edit=kaynak düzenle
+Special\ name\ formatters=Özel Ad Biçemleyicileri
 
-Special_table_columns=Özel_tablo_sütunları
+Special\ table\ columns=Özel tablo sütunları
 
-Starting_import=İçe_aktarım_başlatılıyor
+Starting\ import=İçe aktarım başlatılıyor
 
-Statically_group_entries_by_manual_assignment=Elle_atanmış_durağan_grup_girdileri
+Statically\ group\ entries\ by\ manual\ assignment=Elle atanmış durağan grup girdileri
 
 Status=Durum
 
@@ -1143,1215 +1143,1215 @@ Stop=Dur
 
 Strings=Dizgeler
 
-Strings_for_library=Veritabanı_için_dizgeler
+Strings\ for\ library=Veritabanı için dizgeler
 
-Sublibrary_from_AUX=Yardımcıdan_(AUX)_altveritabanı
+Sublibrary\ from\ AUX=Yardımcıdan (AUX) altveritabanı
 
-Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.=Dergi_adı_biliniyorsa_tam_ve_kısaltılmış_dergi_adı_arasında_geçiş_yapar.
+Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=Dergi adı biliniyorsa tam ve kısaltılmış dergi adı arasında geçiş yapar.
 
-Synchronize_file_links=Dosya_linklerini_eşzamanla
+Synchronize\ file\ links=Dosya linklerini eşzamanla
 
-Synchronizing_file_links...=Dosya_link_eşzamanlanıyor...
+Synchronizing\ file\ links...=Dosya link eşzamanlanıyor...
 
-Table_appearance=Tablo_görünümü
+Table\ appearance=Tablo görünümü
 
-Table_background_color=Tablo_arkaplan_rengi
+Table\ background\ color=Tablo arkaplan rengi
 
-Table_grid_color=Tablo_klavuz_çizgileri_rengi
+Table\ grid\ color=Tablo klavuz çizgileri rengi
 
-Table_text_color=Tablo_metni_rengi
+Table\ text\ color=Tablo metni rengi
 
 Tabname=Sekmeadı
-Target_file_cannot_be_a_directory.=Hedef_dosya_bir_dizin_olamaz.
+Target\ file\ cannot\ be\ a\ directory.=Hedef dosya bir dizin olamaz.
 
-Tertiary_sort_criterion=Üçüncül_sıralama_ölçütü
+Tertiary\ sort\ criterion=Üçüncül sıralama ölçütü
 
 Test=Deneme
 
-paste_text_here=Metin_Girdi_Alanı
+paste\ text\ here=Metin Girdi Alanı
 
-The_chosen_date_format_for_new_entries_is_not_valid=Yeni_girdiler_için_seçilen_tarih_biçemi_geçersiz
+The\ chosen\ date\ format\ for\ new\ entries\ is\ not\ valid=Yeni girdiler için seçilen tarih biçemi geçersiz
 
-The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:=Seçilen_'%0'_kodlaması_şu_karakterleri_kodlayamıyor\:
+The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=Seçilen '%0' kodlaması şu karakterleri kodlayamıyor:
 
 
-the_field_<b>%0</b>=alan_<b>%0</b>
+the\ field\ <b>%0</b>=alan <b>%0</b>
 
-The_file<BR>'%0'<BR>has_been_modified<BR>externally\!=Dosya<BR>'%0'<BR><BR>harici_olarak_değiştirildi\!
+The\ file<BR>'%0'<BR>has\ been\ modified<BR>externally\!=Dosya<BR>'%0'<BR><BR>harici olarak değiştirildi!
 
-The_group_"%0"_already_contains_the_selection.="%0"_grubu_seçimi_zaten_kapsıyor.
+The\ group\ "%0"\ already\ contains\ the\ selection.="%0" grubu seçimi zaten kapsıyor.
 
-The_label_of_the_string_cannot_be_a_number.=Dizgenin_etiketi_bir_numara_olamaz.
+The\ label\ of\ the\ string\ cannot\ be\ a\ number.=Dizgenin etiketi bir numara olamaz.
 
-The_label_of_the_string_cannot_contain_spaces.=Dizgenin_etiketi_boşluk_içeremez.
+The\ label\ of\ the\ string\ cannot\ contain\ spaces.=Dizgenin etiketi boşluk içeremez.
 
-The_label_of_the_string_cannot_contain_the_'\#'_character.=Dizgenin_etiketi_'\#'_karakterini_içeremez.
+The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=Dizgenin etiketi '#' karakterini içeremez.
 
-The_output_option_depends_on_a_valid_import_option.=Çıktı_seçeneği_geçerli_bir_içe_aktarım_seçeneğine_bağlıdır.
-The_PDF_contains_one_or_several_BibTeX-records.=PDF,_bir_ya_da_daha_fazla_BibTeX_kaydı_içeriyor.
-Do_you_want_to_import_these_as_new_entries_into_the_current_library?=Bunları_mevcut_veritabannına_yeni_girdiler_olarak_aktarmak_ister_misiniz?
+The\ output\ option\ depends\ on\ a\ valid\ import\ option.=Çıktı seçeneği geçerli bir içe aktarım seçeneğine bağlıdır.
+The\ PDF\ contains\ one\ or\ several\ BibTeX-records.=PDF, bir ya da daha fazla BibTeX kaydı içeriyor.
+Do\ you\ want\ to\ import\ these\ as\ new\ entries\ into\ the\ current\ library?=Bunları mevcut veritabannına yeni girdiler olarak aktarmak ister misiniz?
 
-The_regular_expression_<b>%0</b>_is_invalid\:=Düzenli_ifade_<b>%0</b>_geçersiz\:
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=Düzenli ifade <b>%0</b> geçersiz:
 
-The_search_is_case_insensitive.=Arama_büyük/küçük_harfe_duyarsız.
+The\ search\ is\ case\ insensitive.=Arama büyük/küçük harfe duyarsız.
 
-The_search_is_case_sensitive.=Arama_büyük/küçük_harfe_duyarlı.
+The\ search\ is\ case\ sensitive.=Arama büyük/küçük harfe duyarlı.
 
-The_string_has_been_removed_locally=Dizge_yerel_olarak_silindi
+The\ string\ has\ been\ removed\ locally=Dizge yerel olarak silindi
 
-There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?=Çözümlenmemiş,_olası_çift_nüshalar_mevcut_(simgesiyle_işaretlenmiş)._Devam_edilsin_mi?
+There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=Çözümlenmemiş, olası çift nüshalar mevcut (simgesiyle işaretlenmiş). Devam edilsin mi?
 
-This_entry_has_no_BibTeX_key._Generate_key_now?=Bu_girdinin_BibTeX_anahtarı_yok._Şimdi_oluşturulsun_mu?
+This\ entry\ has\ no\ BibTeX\ key.\ Generate\ key\ now?=Bu girdinin BibTeX anahtarı yok. Şimdi oluşturulsun mu?
 
-This_entry_is_incomplete=Girdi_eksik
+This\ entry\ is\ incomplete=Girdi eksik
 
-This_entry_type_cannot_be_removed.=Bu_girdi_türü_silinemiyor.
+This\ entry\ type\ cannot\ be\ removed.=Bu girdi türü silinemiyor.
 
-This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Bu_harici_link,_tanımlanmamış_'%0'_türündendir._Ne_yapmak_istersiniz?
+This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Bu harici link, tanımlanmamış '%0' türündendir. Ne yapmak istersiniz?
 
-This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.=Bu_grup,_elle_atanmış_girdiler_içeriyor._Bu_gruba_girdiler_seçilip_ya_sürükleyip_bırakarak_ya_da_fare_sağ_tıklama_menüsü_kullanılarak_eklenebilir._Bu_gruptan_girdiler_seçilip_fare_sağ_tıklama_menüsü_kullanılarak_silinebilir.
+This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=Bu grup, elle atanmış girdiler içeriyor. Bu gruba girdiler seçilip ya sürükleyip bırakarak ya da fare sağ tıklama menüsü kullanılarak eklenebilir. Bu gruptan girdiler seçilip fare sağ tıklama menüsü kullanılarak silinebilir.
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>=Bu_grup,_<b>%0</b>_alanı_<b>%1</b>_anahtar_sözcüğünü_içeren_girdileri_içerir
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Bu grup, <b>%0</b> alanı <b>%1</b> anahtar sözcüğünü içeren girdileri içerir
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>=Bu_grup,_<b>%0</b>_alanı_<b>%1</b>_düzenli_ifadesini_içeren_girdileri_içerir
-This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.=Bu,_JabRef'in_her_dosya_linki_bulup_dosyanın_var_olup_olmadığını_kontrol_etmesini_sağlar._Eğer_yoksa,_sorunu<BR>çözmek_için_seçenekler_sunulacaktır.
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Bu grup, <b>%0</b> alanı <b>%1</b> düzenli ifadesini içeren girdileri içerir
+This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=Bu, JabRef'in her dosya linki bulup dosyanın var olup olmadığını kontrol etmesini sağlar. Eğer yoksa, sorunu<BR>çözmek için seçenekler sunulacaktır.
 
-This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.=Bu_işlem,_tüm_seçili_girdilerin_tanımlı_BibTeX_anahtarlarının_olmasını_gerektirir.
+This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=Bu işlem, tüm seçili girdilerin tanımlı BibTeX anahtarlarının olmasını gerektirir.
 
-This_operation_requires_one_or_more_entries_to_be_selected.=Bu_işlem,_bir_ya_da_daha_çok_girdinin_seçili_olmasını_gerektirir.
+This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=Bu işlem, bir ya da daha çok girdinin seçili olmasını gerektirir.
 
-Toggle_entry_preview=Girdi_önizlemeyi_aç/kapat
-Toggle_groups_interface=Grup_arayüzünü_aç/kapat
-Try_different_encoding=Başka_kodlama_deneyin
+Toggle\ entry\ preview=Girdi önizlemeyi aç/kapat
+Toggle\ groups\ interface=Grup arayüzünü aç/kapat
+Try\ different\ encoding=Başka kodlama deneyin
 
-Unabbreviate_journal_names_of_the_selected_entries=Seçili_girdilerin_dergi_adlarını_kısaltma
-Unabbreviated_%0_journal_names.=%0_dergi_adı_kısaltması_kaldırıldı.
+Unabbreviate\ journal\ names\ of\ the\ selected\ entries=Seçili girdilerin dergi adlarını kısaltma
+Unabbreviated\ %0\ journal\ names.=%0 dergi adı kısaltması kaldırıldı.
 
-Unable_to_open_file.=Dosya_açılamadı.
-Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.=Link_açılamadı._'%1'_dosya_türüyle_ilişkili_'%0'_uygulaması_çağrılamadı.
-unable_to_write_to=Şuraya_yazılamadı
-Undefined_file_type=Tanımlanmamış_dosya_türü
+Unable\ to\ open\ file.=Dosya açılamadı.
+Unable\ to\ open\ link.\ The\ application\ '%0'\ associated\ with\ the\ file\ type\ '%1'\ could\ not\ be\ called.=Link açılamadı. '%1' dosya türüyle ilişkili '%0' uygulaması çağrılamadı.
+unable\ to\ write\ to=Şuraya yazılamadı
+Undefined\ file\ type=Tanımlanmamış dosya türü
 
-Undo=Geriye_al
+Undo=Geriye al
 
 Union=Bileşim
 
-Unknown_BibTeX_entries=Bilinmeyen_BibTeX_girdileri
+Unknown\ BibTeX\ entries=Bilinmeyen BibTeX girdileri
 
-unknown_edit=bilinmeyen_düzenleme
+unknown\ edit=bilinmeyen düzenleme
 
-Unknown_export_format=Bilinmeyen_dışa_aktarım_biçemi
+Unknown\ export\ format=Bilinmeyen dışa aktarım biçemi
 
-Unmark_all=Tümünün_işaretini_kaldır
+Unmark\ all=Tümünün işaretini kaldır
 
-Unmark_entries=Girdilerin_işaretini_kaldır
+Unmark\ entries=Girdilerin işaretini kaldır
 
-Unmark_entry=Girdinin_işaretini_kaldır
+Unmark\ entry=Girdinin işaretini kaldır
 
 untitled=başlıksız
 
 Up=Yukarı
 
-Update_to_current_column_widths=Mevcut_sütun_genişliklerine_güncelle
+Update\ to\ current\ column\ widths=Mevcut sütun genişliklerine güncelle
 
-Updated_group_selection=Grup_seçimi_güncellendi
-Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.=Harici_PDF/PS_linklerini_'%0'_alanını_kullanmak_üzere_yeni_sürüme_yükselt.
-Upgrade_file=Dosyayı_yeni_sürüme_yükselt
-Upgrade_old_external_file_links_to_use_the_new_feature=Eski_harici_dosya_linklerini_yeni_özelliği_kullanmak_üzere_yeni_sürüme_yükselt
+Updated\ group\ selection=Grup seçimi güncellendi
+Upgrade\ external\ PDF/PS\ links\ to\ use\ the\ '%0'\ field.=Harici PDF/PS linklerini '%0' alanını kullanmak üzere yeni sürüme yükselt.
+Upgrade\ file=Dosyayı yeni sürüme yükselt
+Upgrade\ old\ external\ file\ links\ to\ use\ the\ new\ feature=Eski harici dosya linklerini yeni özelliği kullanmak üzere yeni sürüme yükselt
 
 usage=kullanım
-Use_autocompletion_for_the_following_fields=Aşağıdaki_alanlar_için_otomatik_tamamlamayı_kullan
+Use\ autocompletion\ for\ the\ following\ fields=Aşağıdaki alanlar için otomatik tamamlamayı kullan
 
-Use_other_look_and_feel=Diğer_görünüm_ve_tema_kullan
-Tweak_font_rendering_for_entry_editor_on_Linux=
-Use_regular_expression_search=Düzenli_İfade_Aramayı_kullan
+Use\ other\ look\ and\ feel=Diğer görünüm ve tema kullan
+Tweak\ font\ rendering\ for\ entry\ editor\ on\ Linux=
+Use\ regular\ expression\ search=Düzenli İfade Aramayı kullan
 
-Username=Kullanıcı_adı
+Username=Kullanıcı adı
 
-Value_cleared_externally=Değer,_haricen_silindi
+Value\ cleared\ externally=Değer, haricen silindi
 
-Value_set_externally=Değer,_haricen_atandı
+Value\ set\ externally=Değer, haricen atandı
 
-verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid=LyX'in_çalıştığını_ve_veri_iletişim_hattının_geçerli_olduğunu_teyid_edin
+verify\ that\ LyX\ is\ running\ and\ that\ the\ lyxpipe\ is\ valid=LyX'in çalıştığını ve veri iletişim hattının geçerli olduğunu teyid edin
 
 View=Görüntüle
-Vim_server_name=Vim_Sunucu_Adı
+Vim\ server\ name=Vim Sunucu Adı
 
-Waiting_for_ArXiv...=ArXiv_bekleniyor...
+Waiting\ for\ ArXiv...=ArXiv bekleniyor...
 
-Warn_about_unresolved_duplicates_when_closing_inspection_window=İnceleme_penceresi_kapanırken_çözülmemiş_çift_nüshalar_hakkında_uyar
+Warn\ about\ unresolved\ duplicates\ when\ closing\ inspection\ window=İnceleme penceresi kapanırken çözülmemiş çift nüshalar hakkında uyar
 
-Warn_before_overwriting_existing_keys=Mevcut_anahtarların_üzerine_yazmadan_önce_uyar
+Warn\ before\ overwriting\ existing\ keys=Mevcut anahtarların üzerine yazmadan önce uyar
 
 Warning=Uyarı
 
 Warnings=Uyarılar
 
-web_link=sanaldoku_linki
+web\ link=sanaldoku linki
 
-What_do_you_want_to_do?=Ne_yapmak_istersiniz?
+What\ do\ you\ want\ to\ do?=Ne yapmak istersiniz?
 
-When_adding/removing_keywords,_separate_them_by=Anahtar_sözcük_ekler/çıkarırken,_onları_şöyle_ayırın
-Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.=Seçili_girdilerle_bağlantılı_PDFlere_XMP_metaverisi_yazılacak.
+When\ adding/removing\ keywords,\ separate\ them\ by=Anahtar sözcük ekler/çıkarırken, onları şöyle ayırın
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Seçili girdilerle bağlantılı PDFlere XMP metaverisi yazılacak.
 
 with=ile
 
-Write_BibTeXEntry_as_XMP-metadata_to_PDF.=BibTeXGirdisi'ni_PDF'ye_XMP-metaverisi_olarak_yaz.
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=BibTeXGirdisi'ni PDF'ye XMP-metaverisi olarak yaz.
 
-Write_XMP=XMP'yi_yaz
-Write_XMP-metadata=XMP-metaverisini_yaz
-Write_XMP-metadata_for_all_PDFs_in_current_library?=Mevcut_veritabanındaki_tüm_PFDlere_XMP-metaverisi_yazılsın_mı?
-Writing_XMP-metadata...=XMP_metaverisi_yazılıyor...
-Writing_XMP-metadata_for_selected_entries...=Seçili_girdiler_için_XMP_metaverisi_yazılıyor...
+Write\ XMP=XMP'yi yaz
+Write\ XMP-metadata=XMP-metaverisini yaz
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Mevcut veritabanındaki tüm PFDlere XMP-metaverisi yazılsın mı?
+Writing\ XMP-metadata...=XMP metaverisi yazılıyor...
+Writing\ XMP-metadata\ for\ selected\ entries...=Seçili girdiler için XMP metaverisi yazılıyor...
 
-Wrote_XMP-metadata=XMP-metaverisi_yazıldı
+Wrote\ XMP-metadata=XMP-metaverisi yazıldı
 
-XMP-annotated_PDF=XMP-ek_notlu_PDF
-XMP_export_privacy_settings=Gizlilik_Ayarlarını_XMP_Dışa_Aktar
-XMP-metadata=XMP_metaverisi
-XMP-metadata_found_in_PDF\:_%0=PDF'de_XMP_metaverisi_bulundu\:_%0
-You_must_restart_JabRef_for_this_to_come_into_effect.=Bunun_etkinleşmesi_için_JabRefi_yeniden_başlatmalısınız.
-You_have_changed_the_language_setting.=Dil_ayarını_değiştirdiniz.
-You_have_entered_an_invalid_search_'%0'.=Geçersiz_bir_arama_girdiniz_'%0'.
+XMP-annotated\ PDF=XMP-ek notlu PDF
+XMP\ export\ privacy\ settings=Gizlilik Ayarlarını XMP Dışa Aktar
+XMP-metadata=XMP metaverisi
+XMP-metadata\ found\ in\ PDF\:\ %0=PDF'de XMP metaverisi bulundu: %0
+You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Bunun etkinleşmesi için JabRefi yeniden başlatmalısınız.
+You\ have\ changed\ the\ language\ setting.=Dil ayarını değiştirdiniz.
+You\ have\ entered\ an\ invalid\ search\ '%0'.=Geçersiz bir arama girdiniz '%0'.
 
-You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.=Yeni_anahtar_demetlerinin_düzgün_çalışması_için_JabRef'i_yeniden_başlatmalısınız.
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Yeni anahtar demetlerinin düzgün çalışması için JabRef'i yeniden başlatmalısınız.
 
-Your_new_key_bindings_have_been_stored.=Yeni_anahtar_demetleriniz_kaydedildi.
+Your\ new\ key\ bindings\ have\ been\ stored.=Yeni anahtar demetleriniz kaydedildi.
 
-The_following_fetchers_are_available\:=Aşağıdaki_getiriciler_kullanıma_hazırdır:
-Could_not_find_fetcher_'%0'='%0'_getiricisi_bulunamadı
-Running_query_'%0'_with_fetcher_'%1'.='%0'_sorgusu_'%1'_getiricisiyle_çalıştırılıyor.
-Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.='%1'_getiricisiyle_'%0'_sorgusu_hiçbir_sonuç_döndürmedi.
+The\ following\ fetchers\ are\ available\:=Aşağıdaki getiriciler kullanıma hazırdır:
+Could\ not\ find\ fetcher\ '%0'='%0' getiricisi bulunamadı
+Running\ query\ '%0'\ with\ fetcher\ '%1'.='%0' sorgusu '%1' getiricisiyle çalıştırılıyor.
+Query\ '%0'\ with\ fetcher\ '%1'\ did\ not\ return\ any\ results.='%1' getiricisiyle '%0' sorgusu hiçbir sonuç döndürmedi.
 
-Move_file=Dosya_Taşı_adlandır
-Rename_file=Yeniden_adlandır
+Move\ file=Dosya Taşı adlandır
+Rename\ file=Yeniden adlandır
 
-Move_file_failed=Dosya_taşıma_başarısız
-Could_not_move_file_'%0'.='%0'_dosya_taşınamıyor.
-Could_not_find_file_'%0'.='%0'_dosyası_bulunamadı.
-Number_of_entries_successfully_imported=Girdi_sayısı_başarıyla_içe_aktarıldı
-Import_canceled_by_user=İçe_aktrım_kullanıcı_tarafından_iptal_edildi
-Progress\:_%0_of_%1=İlerleme:_%1'in_%0'i
-Error_while_fetching_from_%0=%0'dan_getirme_sırasında_hata
+Move\ file\ failed=Dosya taşıma başarısız
+Could\ not\ move\ file\ '%0'.='%0' dosya taşınamıyor.
+Could\ not\ find\ file\ '%0'.='%0' dosyası bulunamadı.
+Number\ of\ entries\ successfully\ imported=Girdi sayısı başarıyla içe aktarıldı
+Import\ canceled\ by\ user=İçe aktrım kullanıcı tarafından iptal edildi
+Progress\:\ %0\ of\ %1=İlerleme: %1'in %0'i
+Error\ while\ fetching\ from\ %0=%0'dan getirme sırasında hata
 
-Please_enter_a_valid_number=Lütfen_geçerli_bir_sayı_giriniz
-Show_search_results_in_a_window=Arama_sonuçlarını_bir_pencerede_göster
-Show_global_search_results_in_a_window=Küresel_arama_sonuçlarını_bir_pencerede_göster
-Search_in_all_open_libraries=Tüm_açık_veri_tabanlarında_ara
-Move_file_to_file_directory?=Dosya,_dosya_dizinine_taşınsın_mı?
+Please\ enter\ a\ valid\ number=Lütfen geçerli bir sayı giriniz
+Show\ search\ results\ in\ a\ window=Arama sonuçlarını bir pencerede göster
+Show\ global\ search\ results\ in\ a\ window=Küresel arama sonuçlarını bir pencerede göster
+Search\ in\ all\ open\ libraries=Tüm açık veri tabanlarında ara
+Move\ file\ to\ file\ directory?=Dosya, dosya dizinine taşınsın mı?
 
-Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.=Veritabanı_korunuyor._Harici_değişiklikler_gözden_geçirilene_dek_kaydedemezsiniz.
-Protected_library=Korunan_veritabanı
-Refuse_to_save_the_library_before_external_changes_have_been_reviewed.=Harici_değişiklikler_gözden_geçirilene_dek_veritabanının_kaydedilmesini_reddet.
-Library_protection=Veirtabanı_koruması
-Unable_to_save_library=Veritabanı_kaydedilemedi
+Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=Veritabanı korunuyor. Harici değişiklikler gözden geçirilene dek kaydedemezsiniz.
+Protected\ library=Korunan veritabanı
+Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=Harici değişiklikler gözden geçirilene dek veritabanının kaydedilmesini reddet.
+Library\ protection=Veirtabanı koruması
+Unable\ to\ save\ library=Veritabanı kaydedilemedi
 
-BibTeX_key_generator=BibTeX_anahtar_oluşturucusu
-Unable_to_open_link.=Bağlantı_açılamadı.
-Move_the_keyboard_focus_to_the_entry_table=Klavye_odağını_girdi_tablosuna_taşı
-MIME_type=MIME_türü
+BibTeX\ key\ generator=BibTeX anahtar oluşturucusu
+Unable\ to\ open\ link.=Bağlantı açılamadı.
+Move\ the\ keyboard\ focus\ to\ the\ entry\ table=Klavye odağını girdi tablosuna taşı
+MIME\ type=MIME türü
 
-This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.=Bu_özellik_yeni_dosyaların_yeni_bir_oturum_açmaktansa_halen_çalışmakta_olan_bir<BR>JabRef_oturumu_içine_açılması_ya_da_aktrılmasını_sağlar._Örneğin_bu,_tarayıcınızdan_bir_dosyayı<br>JabRef_içine_açtığnızda_kullanışlıdır.<BR>Bunun,_birden_fazla_JabRef_oturumunu_aynı_anda_çalıştırmanızı_önleyeceğini_not_ediniz.
-Run_fetcher,_e.g._"--fetch\=Medline\:cancer"=Getiriciyi_Çalıştır,_Örnek_"--fetch=Medline\:cancer"
+This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef<BR>instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef<br>from\ your\ web\ browser.<BR>Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=Bu özellik yeni dosyaların yeni bir oturum açmaktansa halen çalışmakta olan bir<BR>JabRef oturumu içine açılması ya da aktrılmasını sağlar. Örneğin bu, tarayıcınızdan bir dosyayı<br>JabRef içine açtığnızda kullanışlıdır.<BR>Bunun, birden fazla JabRef oturumunu aynı anda çalıştırmanızı önleyeceğini not ediniz.
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=Getiriciyi Çalıştır, Örnek "--fetch=Medline:cancer"
 
-The_ACM_Digital_Library=ACM_Sayısal_Kütüphane
+The\ ACM\ Digital\ Library=ACM Sayısal Kütüphane
 Reset=Sıfırla
 
-Use_IEEE_LaTeX_abbreviations=IEEE_LaTeX_kısaltmaları_kullanınız
-The_Guide_to_Computing_Literature=Bilgi_İşlem_Literatürü_Klavuzu
+Use\ IEEE\ LaTeX\ abbreviations=IEEE LaTeX kısaltmaları kullanınız
+The\ Guide\ to\ Computing\ Literature=Bilgi İşlem Literatürü Klavuzu
 
-When_opening_file_link,_search_for_matching_file_if_no_link_is_defined=Dosya_bağlantısını_açarken,_eğer_link_tanımlanmamışsa_eşleşen_dosyayı_ara
-Settings_for_%0=%0_için_ayarlar
-Mark_entries_imported_into_an_existing_library=Varolan_bir_veritabanına_aktarılmış_girdileri_işaretle
-Unmark_all_entries_before_importing_new_entries_into_an_existing_library=Yeni_girdileri_varolan_bir_veritabanına_aktarmadan_önce_tüm_girdilerin_işaretini_sil
+When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=Dosya bağlantısını açarken, eğer link tanımlanmamışsa eşleşen dosyayı ara
+Settings\ for\ %0=%0 için ayarlar
+Mark\ entries\ imported\ into\ an\ existing\ library=Varolan bir veritabanına aktarılmış girdileri işaretle
+Unmark\ all\ entries\ before\ importing\ new\ entries\ into\ an\ existing\ library=Yeni girdileri varolan bir veritabanına aktarmadan önce tüm girdilerin işaretini sil
 
 Forward=İleri
 Back=Geri
-Sort_the_following_fields_as_numeric_fields=Aşağıdaki_alanları_sayısal_olarak_sırala
-Line_%0\:_Found_corrupted_BibTeX_key.=Satır_%0\:_Bozulmuş_BibTeX-anahtarı_bulundu.
-Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).=Satır_%0\:_Bozulmuş_BibTeX-anahtarı_bulundu_(beyaz_boşluk_içeriyor).
-Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).=Satır_%0\:_Bozulmuş_BibTeX-anahtarı_bulundu_(virgül_kayıp).
-Full_text_document_download_failed=Tam_metin_makale_indirme_başarısız
-Update_to_current_column_order=Varolan_sütun_sırasına_güncelle
-Download_from_URL=URL'den_indir
-Rename_field=Alanın_adını_değiştir
-Set/clear/append/rename_fields=Alanları_kur/sil/yeniden_adlandır
-Append_field=
-Append_to_fields=
-Rename_field_to=Alan_adını_şuna_değiştir
-Move_contents_of_a_field_into_a_field_with_a_different_name=Alan_içeriğini_başka_isimli_bir_alanın_içine_taşı
-You_can_only_rename_one_field_at_a_time=Bir_seferde_yalnızca_bir_alanın_adını_değiştirebilirsiniz
+Sort\ the\ following\ fields\ as\ numeric\ fields=Aşağıdaki alanları sayısal olarak sırala
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=Satır %0: Bozulmuş BibTeX-anahtarı bulundu.
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=Satır %0: Bozulmuş BibTeX-anahtarı bulundu (beyaz boşluk içeriyor).
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=Satır %0: Bozulmuş BibTeX-anahtarı bulundu (virgül kayıp).
+Full\ text\ document\ download\ failed=Tam metin makale indirme başarısız
+Update\ to\ current\ column\ order=Varolan sütun sırasına güncelle
+Download\ from\ URL=URL'den indir
+Rename\ field=Alanın adını değiştir
+Set/clear/append/rename\ fields=Alanları kur/sil/yeniden adlandır
+Append\ field=
+Append\ to\ fields=
+Rename\ field\ to=Alan adını şuna değiştir
+Move\ contents\ of\ a\ field\ into\ a\ field\ with\ a\ different\ name=Alan içeriğini başka isimli bir alanın içine taşı
+You\ can\ only\ rename\ one\ field\ at\ a\ time=Bir seferde yalnızca bir alanın adını değiştirebilirsiniz
 
-Remove_all_broken_links=Tüm_bozuk_linkleri_sil
+Remove\ all\ broken\ links=Tüm bozuk linkleri sil
 
-Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.=Uzak_operasyon_için_bağlantı_noktası_%0_kullanılamıyor;_bir_başka_program_kullanıyor_olabilir._Başka_bir_bağlantı_noktası_deneyin.
+Cannot\ use\ port\ %0\ for\ remote\ operation;\ another\ application\ may\ be\ using\ it.\ Try\ specifying\ another\ port.=Uzak operasyon için bağlantı noktası %0 kullanılamıyor; bir başka program kullanıyor olabilir. Başka bir bağlantı noktası deneyin.
 
-Looking_for_full_text_document...=Tam_metin_belge_aranıyor...
-Autosave=Otomatik_kaydet
-A_local_copy_will_be_opened.=Yerel_bir_kopya_açılacak.
-Autosave_local_libraries=Yerel_kütüphaneleri_otomatik_kaydet
-Automatically_save_the_library_to=Kütüphaneyi_otomatik_olarak_şuraya_kaydet
-Please_enter_a_valid_file_path.=Lütfen_geçerli_bir_dosya_yolu_girin.
+Looking\ for\ full\ text\ document...=Tam metin belge aranıyor...
+Autosave=Otomatik kaydet
+A\ local\ copy\ will\ be\ opened.=Yerel bir kopya açılacak.
+Autosave\ local\ libraries=Yerel kütüphaneleri otomatik kaydet
+Automatically\ save\ the\ library\ to=Kütüphaneyi otomatik olarak şuraya kaydet
+Please\ enter\ a\ valid\ file\ path.=Lütfen geçerli bir dosya yolu girin.
 
 
-Export_in_current_table_sort_order=Mevcut_tablo_sıralama_düzeninde_dışa_aktar
-Export_entries_in_their_original_order=Girdileri_orijinal_sırasında_dışa_aktar
-Error_opening_file_'%0'.=Dosya_açmada_hata_'%0'.
+Export\ in\ current\ table\ sort\ order=Mevcut tablo sıralama düzeninde dışa aktar
+Export\ entries\ in\ their\ original\ order=Girdileri orijinal sırasında dışa aktar
+Error\ opening\ file\ '%0'.=Dosya açmada hata '%0'.
 
-Formatter_not_found\:_%0=Biçimleyici_bulunamadı\:_%0
-Clear_inputarea=Girdi_alanını_temizle
+Formatter\ not\ found\:\ %0=Biçimleyici bulunamadı: %0
+Clear\ inputarea=Girdi alanını temizle
 
-Automatically_set_file_links_for_this_entry=Bu_girdi_için_dosya_bağlantılarını_otomatikman_kur
-Could_not_save,_file_locked_by_another_JabRef_instance.=Kaydedilemiyor,_dosya_başka_bir_JabRef_oturumunca_kilitlenmiş.
-File_is_locked_by_another_JabRef_instance.=Dosya_başka_bir_JabRef_oturumunca_kilitlenmiş.
-Do_you_want_to_override_the_file_lock?=Dosya_kilidini_geçersiz_kılmak_ister_misiniz?
-File_locked=Dosya_kilitli
-Current_tmp_value=Mevcut_tmp_değeri
-Metadata_change=Metadata_değişikliği
-Changes_have_been_made_to_the_following_metadata_elements=Aşağıdaki_metadata_ögelerinde_değişiklik_yapıldı
+Automatically\ set\ file\ links\ for\ this\ entry=Bu girdi için dosya bağlantılarını otomatikman kur
+Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=Kaydedilemiyor, dosya başka bir JabRef oturumunca kilitlenmiş.
+File\ is\ locked\ by\ another\ JabRef\ instance.=Dosya başka bir JabRef oturumunca kilitlenmiş.
+Do\ you\ want\ to\ override\ the\ file\ lock?=Dosya kilidini geçersiz kılmak ister misiniz?
+File\ locked=Dosya kilitli
+Current\ tmp\ value=Mevcut tmp değeri
+Metadata\ change=Metadata değişikliği
+Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=Aşağıdaki metadata ögelerinde değişiklik yapıldı
 
-Generate_groups_for_author_last_names=Yazar_soyadları_için_grup_oluştur
-Generate_groups_from_keywords_in_a_BibTeX_field=Bir_BibTeX_alanındaki_anahtar_sözcüklerden_grup_oluştur
-Enforce_legal_characters_in_BibTeX_keys=BibTeX_anahtarlarında_yasal_karakterleri_zorla
+Generate\ groups\ for\ author\ last\ names=Yazar soyadları için grup oluştur
+Generate\ groups\ from\ keywords\ in\ a\ BibTeX\ field=Bir BibTeX alanındaki anahtar sözcüklerden grup oluştur
+Enforce\ legal\ characters\ in\ BibTeX\ keys=BibTeX anahtarlarında yasal karakterleri zorla
 
-Save_without_backup?=Yedeklemeden_kaydedilsin_mi?
-Unable_to_create_backup=Yedek_oluşturulamadı
-Move_file_to_file_directory=Dosyayı_dosya_dizinine_taşı
-Rename_file_to=Dosyayı_şuna_yeniden_adlandır
-<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)=<b>Tüm_Girdiler</b>_(bu_grup_silinemez_ve_düzenlenemez)
-static_group=durağan_grup
-dynamic_group=devingen_grup
-refines_supergroup=süpergrubu_rafine_eder
-includes_subgroups=altgrupları_içerir
+Save\ without\ backup?=Yedeklemeden kaydedilsin mi?
+Unable\ to\ create\ backup=Yedek oluşturulamadı
+Move\ file\ to\ file\ directory=Dosyayı dosya dizinine taşı
+Rename\ file\ to=Dosyayı şuna yeniden adlandır
+<b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=<b>Tüm Girdiler</b> (bu grup silinemez ve düzenlenemez)
+static\ group=durağan grup
+dynamic\ group=devingen grup
+refines\ supergroup=süpergrubu rafine eder
+includes\ subgroups=altgrupları içerir
 contains=içerir
-search_expression=arama_ifadesi
+search\ expression=arama ifadesi
 
-Optional_fields_2=Opsiyonel_alanlar_2
-Waiting_for_save_operation_to_finish=Kaydetme_işleminin_bitmesi_bekleniyor
-Resolving_duplicate_BibTeX_keys...=Çifte_BibTeX_anahtarları_çözümleniyor...
-Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.=Çifte_BibTeX_anahtarlarının_çözümlenmesi_bitti._%0_girdi_değiştirildi.
-This_library_contains_one_or_more_duplicated_BibTeX_keys.=Bu_veritabanı_bir_ya_da_daha_fazla_çifte_BibTeX_anahtarı_içeriyor.
-Do_you_want_to_resolve_duplicate_keys_now?=Çifte_anahtarları_şimdi_çözümlemek_ister_misiniz?
+Optional\ fields\ 2=Opsiyonel alanlar 2
+Waiting\ for\ save\ operation\ to\ finish=Kaydetme işleminin bitmesi bekleniyor
+Resolving\ duplicate\ BibTeX\ keys...=Çifte BibTeX anahtarları çözümleniyor...
+Finished\ resolving\ duplicate\ BibTeX\ keys.\ %0\ entries\ modified.=Çifte BibTeX anahtarlarının çözümlenmesi bitti. %0 girdi değiştirildi.
+This\ library\ contains\ one\ or\ more\ duplicated\ BibTeX\ keys.=Bu veritabanı bir ya da daha fazla çifte BibTeX anahtarı içeriyor.
+Do\ you\ want\ to\ resolve\ duplicate\ keys\ now?=Çifte anahtarları şimdi çözümlemek ister misiniz?
 
-Find_and_remove_duplicate_BibTeX_keys=Çifte_BibTeX_anahtarlarını_bul_ve_kaldır
-Expected_syntax_for_--fetch\='<name_of_fetcher>\:<query>'=--fetch_için_beklenen_sözdizimi_\:--fetch='<name_of_fetcher>\:<query>'
-Duplicate_BibTeX_key=Çifte_BibTeX_anahtarı
-Import_marking_color=İşaretleme_rengi_içe_al
-Always_add_letter_(a,_b,_...)_to_generated_keys=Oluşturulmuş_anahtarlara_her_zaman_harf_ekle_(a,_b_...)
+Find\ and\ remove\ duplicate\ BibTeX\ keys=Çifte BibTeX anahtarlarını bul ve kaldır
+Expected\ syntax\ for\ --fetch\='<name\ of\ fetcher>\:<query>'=--fetch için beklenen sözdizimi :--fetch='<name of fetcher>:<query>'
+Duplicate\ BibTeX\ key=Çifte BibTeX anahtarı
+Import\ marking\ color=İşaretleme rengi içe al
+Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=Oluşturulmuş anahtarlara her zaman harf ekle (a, b ...)
 
-Ensure_unique_keys_using_letters_(a,_b,_...)=Harf_kullanarak_(a,_b,_...)_anahtarların_eşsizliğini_garantile
-Ensure_unique_keys_using_letters_(b,_c,_...)=Harf_kullanarak_(b,_c,_...)_anahtarların_eşsizliğini_garantile
-Entry_editor_active_background_color=Girdi_düzenleyicisi_aktif_arkaplan_rengi
-Entry_editor_background_color=Girdi_düzenleyicisi_arkaplan_rengi
-Entry_editor_font_color=Girdi_düzenleyicisi_yazıtipi_rengi
-Entry_editor_invalid_field_color=Girdi_düzenleyicisi_geçersiz_alan_rengi
+Ensure\ unique\ keys\ using\ letters\ (a,\ b,\ ...)=Harf kullanarak (a, b, ...) anahtarların eşsizliğini garantile
+Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=Harf kullanarak (b, c, ...) anahtarların eşsizliğini garantile
+Entry\ editor\ active\ background\ color=Girdi düzenleyicisi aktif arkaplan rengi
+Entry\ editor\ background\ color=Girdi düzenleyicisi arkaplan rengi
+Entry\ editor\ font\ color=Girdi düzenleyicisi yazıtipi rengi
+Entry\ editor\ invalid\ field\ color=Girdi düzenleyicisi geçersiz alan rengi
 
-Table_and_entry_editor_colors=Tablo_ve_girdi_düzenleyicisi_renkleri
+Table\ and\ entry\ editor\ colors=Tablo ve girdi düzenleyicisi renkleri
 
-General_file_directory=Genel_dosya_dizini
-User-specific_file_directory=Kullanıcıya_özel_dosya_dizini
-Search_failed\:_illegal_search_expression=Arama_başarısız\:_uygunsuz_arama_dizgesi
-Show_ArXiv_column=ArXiv_sütununu_göster
+General\ file\ directory=Genel dosya dizini
+User-specific\ file\ directory=Kullanıcıya özel dosya dizini
+Search\ failed\:\ illegal\ search\ expression=Arama başarısız: uygunsuz arama dizgesi
+Show\ ArXiv\ column=ArXiv sütununu göster
 
-You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for=Metin_alanına_1025-65535_aralığında_bir_tamsayı_girmelisiniz
-Automatically_open_browse_dialog_when_creating_new_file_link=Yeni_dosya_bağlantısını_oluştururken_gözatma_iletişim_kutusunu_otomatikman_aç
-Import_metadata_from\:=Metaverisini_Şuradan_İçe_Aktar\:
-Choose_the_source_for_the_metadata_import=Metaverisini_içe_aktarmak_için_kaynağı_seçin
-Create_entry_based_on_XMP-metadata=XMP_verisine_dayanarak_girdi_oluştur
-Create_blank_entry_linking_the_PDF=PDF'yle_bağlantılı_olarak_boş_girdi_oluştur
-Only_attach_PDF=Yalnızca_PDF'yi_ekle
+You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=Metin alanına 1025-65535 aralığında bir tamsayı girmelisiniz
+Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Yeni dosya bağlantısını oluştururken gözatma iletişim kutusunu otomatikman aç
+Import\ metadata\ from\:=Metaverisini Şuradan İçe Aktar:
+Choose\ the\ source\ for\ the\ metadata\ import=Metaverisini içe aktarmak için kaynağı seçin
+Create\ entry\ based\ on\ XMP-metadata=XMP verisine dayanarak girdi oluştur
+Create\ blank\ entry\ linking\ the\ PDF=PDF'yle bağlantılı olarak boş girdi oluştur
+Only\ attach\ PDF=Yalnızca PDF'yi ekle
 Title=Başlık
-Create_new_entry=Yeni_Girdi_Oluştur
-Update_existing_entry=Mevcut_Girdiyi_Güncelle
-Autocomplete_names_in_'Firstname_Lastname'_format_only=İsimleri_yalnızca_'Ad_Soyad'_biçiminde_otomatik_tamamla
-Autocomplete_names_in_'Lastname,_Firstname'_format_only=İsimleri_yalnızca_'Soyad,_Ad'_biçiminde_otomatik_tamamla
-Autocomplete_names_in_both_formats=İsimleri_her_iki_biçimde_otomatik_tamamla
-Marking_color_%0=İşaretleme_rengi_%0
-The_name_'comment'_cannot_be_used_as_an_entry_type_name.='comment'_ismi_bir_girdi_türü_ismi_olarak_kullanılamaz.
-You_must_enter_an_integer_value_in_the_text_field_for=Şunun_için_metin_alanına_bir_tamsayı_girmelisiniz
-Send_as_email=Eposta_olarak_gönder
+Create\ new\ entry=Yeni Girdi Oluştur
+Update\ existing\ entry=Mevcut Girdiyi Güncelle
+Autocomplete\ names\ in\ 'Firstname\ Lastname'\ format\ only=İsimleri yalnızca 'Ad Soyad' biçiminde otomatik tamamla
+Autocomplete\ names\ in\ 'Lastname,\ Firstname'\ format\ only=İsimleri yalnızca 'Soyad, Ad' biçiminde otomatik tamamla
+Autocomplete\ names\ in\ both\ formats=İsimleri her iki biçimde otomatik tamamla
+Marking\ color\ %0=İşaretleme rengi %0
+The\ name\ 'comment'\ cannot\ be\ used\ as\ an\ entry\ type\ name.='comment' ismi bir girdi türü ismi olarak kullanılamaz.
+You\ must\ enter\ an\ integer\ value\ in\ the\ text\ field\ for=Şunun için metin alanına bir tamsayı girmelisiniz
+Send\ as\ email=Eposta olarak gönder
 References=Kaynaklar
-Sending_of_emails=Epostalar_gönderiliyor
-Subject_for_sending_an_email_with_references=Kaynaklarla_gönderilecek_bir_eposta_konusu
-Automatically_open_folders_of_attached_files=Ekli_dosyaların_klasörlerini_otomatikman_aç
-Create_entry_based_on_content=İçeriğe_bağlı_olarak_girdi_oluştur
-Do_not_show_this_box_again_for_this_import=Bu_içe_aktarım_için_bu_kutuyu_bir_daha_gösterme
-Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)=Her_zaman_bu_PDF_içe_aktarım_stilini_kullan_(ve_her_içe_aktarım_için_sorma)
-Error_creating_email=Eposta_oluşturmada_hata
-Entries_added_to_an_email=Girdiler_bir_epostaya_eklendi
+Sending\ of\ emails=Epostalar gönderiliyor
+Subject\ for\ sending\ an\ email\ with\ references=Kaynaklarla gönderilecek bir eposta konusu
+Automatically\ open\ folders\ of\ attached\ files=Ekli dosyaların klasörlerini otomatikman aç
+Create\ entry\ based\ on\ content=İçeriğe bağlı olarak girdi oluştur
+Do\ not\ show\ this\ box\ again\ for\ this\ import=Bu içe aktarım için bu kutuyu bir daha gösterme
+Always\ use\ this\ PDF\ import\ style\ (and\ do\ not\ ask\ for\ each\ import)=Her zaman bu PDF içe aktarım stilini kullan (ve her içe aktarım için sorma)
+Error\ creating\ email=Eposta oluşturmada hata
+Entries\ added\ to\ an\ email=Girdiler bir epostaya eklendi
 exportFormat=dışa-aktarımBiçimi
-Output_file_missing=Çıktı_dosyası_kayıp
-No_search_matches.=Eşleşen_arama_yok
-The_output_option_depends_on_a_valid_input_option.=Çıktı_seçeneği_geçerli_bir_girdi_seçeneğine_bağlmlıdır.
-Default_import_style_for_drag_and_drop_of_PDFs=Sürüklenip_bırakılan_PDF'lerin_öntanımlı_içe_aktarım_stili
-Default_PDF_file_link_action=Öntanımlı_PDF_dosyası_bağlantı_eylemi
-Filename_format_pattern=Dosya_adı_biçimi_deseni
-Additional_parameters=Ek_parametreler
-Cite_selected_entries_between_parenthesis=Site_seçimli_girdiler
-Cite_selected_entries_with_in-text_citation=Seçili_girdileri_metin_içi_atıflamayla_atıfla
-Cite_special=Özel_atıfla
-Extra_information_(e.g._page_number)=Ek_bilgi_(örnek\:_sayfa_numarası)
-Manage_citations=Atıfları_yönet
-Problem_modifying_citation=Alıntı_değiştirmede_sorun
+Output\ file\ missing=Çıktı dosyası kayıp
+No\ search\ matches.=Eşleşen arama yok
+The\ output\ option\ depends\ on\ a\ valid\ input\ option.=Çıktı seçeneği geçerli bir girdi seçeneğine bağlmlıdır.
+Default\ import\ style\ for\ drag\ and\ drop\ of\ PDFs=Sürüklenip bırakılan PDF'lerin öntanımlı içe aktarım stili
+Default\ PDF\ file\ link\ action=Öntanımlı PDF dosyası bağlantı eylemi
+Filename\ format\ pattern=Dosya adı biçimi deseni
+Additional\ parameters=Ek parametreler
+Cite\ selected\ entries\ between\ parenthesis=Site seçimli girdiler
+Cite\ selected\ entries\ with\ in-text\ citation=Seçili girdileri metin içi atıflamayla atıfla
+Cite\ special=Özel atıfla
+Extra\ information\ (e.g.\ page\ number)=Ek bilgi (örnek: sayfa numarası)
+Manage\ citations=Atıfları yönet
+Problem\ modifying\ citation=Alıntı değiştirmede sorun
 Citation=Atıf
-Extra_information=Ek_bilgi
-Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.=Atıf_belirteci_'%0'_için_BibTeX_girdisi_çözümlenemedi.
-Select_style=Stil_seç
+Extra\ information=Ek bilgi
+Could\ not\ resolve\ BibTeX\ entry\ for\ citation\ marker\ '%0'.=Atıf belirteci '%0' için BibTeX girdisi çözümlenemedi.
+Select\ style=Stil seç
 Journals=Dergiler
 Cite=Alıntıla
-Cite_in-text=Metin-içi_alıntıla
-Insert_empty_citation=Boş_atıf_ekle
-Merge_citations=Atıfları_birleştir
-Manual_connect=Elle_bağlan
-Select_Writer_document=Writer_belgesi_seç
-Sync_OpenOffice/LibreOffice_bibliography=Kaynakça_00_güncelle
-Select_which_open_Writer_document_to_work_on=Hangi_açık_Writer_belgesi_üzerinde_çalışılacağını_seç
-Connected_to_document=Belgeye_bağlandı
-Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)=Metinsiz_bir_atıf_seç_(girdi_kaynak_listesinde_görünecek)
-Cite_selected_entries_with_extra_information=Seçili_girdileri_ek_bilgiyle_alıntıla
-Ensure_that_the_bibliography_is_up-to-date=Kaynakçanın_güncel_olduğuna_emin_ol
-Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.=OpenOffice/LibreOffice_belgeniz_mevcut_veri_tabanında_bulunamayan_'%0'_BibTeX_anahtarını_kaynak_gösteriyor.
-Unable_to_synchronize_bibliography=Kaynakça_güncellenemiyor
-Combine_pairs_of_citations_that_are_separated_by_spaces_only=Yalnızca_boşlukla_ayrılmış_atıf_çiftlerini_birleştir
-Autodetection_failed=Otomatik_algılama_başarısız
+Cite\ in-text=Metin-içi alıntıla
+Insert\ empty\ citation=Boş atıf ekle
+Merge\ citations=Atıfları birleştir
+Manual\ connect=Elle bağlan
+Select\ Writer\ document=Writer belgesi seç
+Sync\ OpenOffice/LibreOffice\ bibliography=Kaynakça 00 güncelle
+Select\ which\ open\ Writer\ document\ to\ work\ on=Hangi açık Writer belgesi üzerinde çalışılacağını seç
+Connected\ to\ document=Belgeye bağlandı
+Insert\ a\ citation\ without\ text\ (the\ entry\ will\ appear\ in\ the\ reference\ list)=Metinsiz bir atıf seç (girdi kaynak listesinde görünecek)
+Cite\ selected\ entries\ with\ extra\ information=Seçili girdileri ek bilgiyle alıntıla
+Ensure\ that\ the\ bibliography\ is\ up-to-date=Kaynakçanın güncel olduğuna emin ol
+Your\ OpenOffice/LibreOffice\ document\ references\ the\ BibTeX\ key\ '%0',\ which\ could\ not\ be\ found\ in\ your\ current\ library.=OpenOffice/LibreOffice belgeniz mevcut veri tabanında bulunamayan '%0' BibTeX anahtarını kaynak gösteriyor.
+Unable\ to\ synchronize\ bibliography=Kaynakça güncellenemiyor
+Combine\ pairs\ of\ citations\ that\ are\ separated\ by\ spaces\ only=Yalnızca boşlukla ayrılmış atıf çiftlerini birleştir
+Autodetection\ failed=Otomatik algılama başarısız
 Connecting=Bağlanıyor
-Please_wait...=Lütfen_bekleyin...
-Set_connection_parameters=Bağlantı_parametrelerini_ayarla
-Path_to_OpenOffice/LibreOffice_directory=OpenOffice/LibreOffice_dizini_yolu
-Path_to_OpenOffice/LibreOffice_executable=OpenOffice/LibreOffice_çalıştıma_dosyası_yolu
-Path_to_OpenOffice/LibreOffice_library_dir=OpenOffice/LibreOffice_kütüphane_dizini_yolu
-Connection_lost=Bağlantı_koptu
-The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.=Paragraf_biçimi_stil_dosyasında_'KaynakParagrafBiçimi'_ya_da_'KaynakBaşlığıParagrafBiçimi'_özelliği_tarafından_kontrol_edilir.
-The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.=Karakter_biçimi_stil_dosyasında_'AtıfKarakterBiçimi'_alıntı_özelliği_tarafından_kontrol_edilir.
-Automatically_sync_bibliography_when_inserting_citations=Atıf_eklenirken_kaynakçayı_otomatikman_güncelle
-Look_up_BibTeX_entries_in_the_active_tab_only=BibTeX_girdilerini_yalnızca_etkin_sekmede_ara
-Look_up_BibTeX_entries_in_all_open_libraries=BibTeX_girdilerini_tüm_açık_veri_tabanlarında_ara
-Autodetecting_paths...=Yollar_otomatikman_algılanıyor...
-Could_not_find_OpenOffice/LibreOffice_installation=OpenOffice/LibreOffice_kurulumu_bulunamadı.
-Found_more_than_one_OpenOffice/LibreOffice_executable.=Birden_fazla_OpenOffice/LibreOffice_çalıştırma_dosyası_bulundu.
-Please_choose_which_one_to_connect_to\:=Lütfen_hangisine_bağlanılacağını_seçin\:
-Choose_OpenOffice/LibreOffice_executable=OpenOffice/LibreOffice_çalıştırma_dosyasını_seçin
-Select_document=Belge_seçin
-HTML_list=HTML_listesi
-If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting=eğer_mümkünse,_bu_isim_listesini_standart_BibTeX_isim_biçimiyle_uyumlu_olacak_şekilde_normalleştir
-Could_not_open_%0=%0_açılamıyor
-Unknown_import_format=Bilinmeyen_içe_aktarım_biçimi
-Web_search=Ağ_araması
-Style_selection=Stil_seçimi
-No_valid_style_file_defined=Geçerli_stil_dosyası_tanımlanmadı
-Choose_pattern=Desen_seçin
-Use_the_BIB_file_location_as_primary_file_directory=bib_dosyası_konumunu_birincil_dosya_dizini_olarak_kullan
-Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.=gnuclient/emacsclient_programı_çalıştırılamıyor._Emacsclient/gnuclient_programının_kurulu_olduğuna_ve_YOL'da_mevcut_olduğuna_emin_olun.
-OpenOffice/LibreOffice_connection=OpenOffice/LibreOffice_bağlantısı
-You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.=Ya_geçerli_bir_stil_dosyası_seçmeli,_ya_da_öntanımlı_stillerden_birini_kullanmalısınız.
+Please\ wait...=Lütfen bekleyin...
+Set\ connection\ parameters=Bağlantı parametrelerini ayarla
+Path\ to\ OpenOffice/LibreOffice\ directory=OpenOffice/LibreOffice dizini yolu
+Path\ to\ OpenOffice/LibreOffice\ executable=OpenOffice/LibreOffice çalıştıma dosyası yolu
+Path\ to\ OpenOffice/LibreOffice\ library\ dir=OpenOffice/LibreOffice kütüphane dizini yolu
+Connection\ lost=Bağlantı koptu
+The\ paragraph\ format\ is\ controlled\ by\ the\ property\ 'ReferenceParagraphFormat'\ or\ 'ReferenceHeaderParagraphFormat'\ in\ the\ style\ file.=Paragraf biçimi stil dosyasında 'KaynakParagrafBiçimi' ya da 'KaynakBaşlığıParagrafBiçimi' özelliği tarafından kontrol edilir.
+The\ character\ format\ is\ controlled\ by\ the\ citation\ property\ 'CitationCharacterFormat'\ in\ the\ style\ file.=Karakter biçimi stil dosyasında 'AtıfKarakterBiçimi' alıntı özelliği tarafından kontrol edilir.
+Automatically\ sync\ bibliography\ when\ inserting\ citations=Atıf eklenirken kaynakçayı otomatikman güncelle
+Look\ up\ BibTeX\ entries\ in\ the\ active\ tab\ only=BibTeX girdilerini yalnızca etkin sekmede ara
+Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=BibTeX girdilerini tüm açık veri tabanlarında ara
+Autodetecting\ paths...=Yollar otomatikman algılanıyor...
+Could\ not\ find\ OpenOffice/LibreOffice\ installation=OpenOffice/LibreOffice kurulumu bulunamadı.
+Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=Birden fazla OpenOffice/LibreOffice çalıştırma dosyası bulundu.
+Please\ choose\ which\ one\ to\ connect\ to\:=Lütfen hangisine bağlanılacağını seçin:
+Choose\ OpenOffice/LibreOffice\ executable=OpenOffice/LibreOffice çalıştırma dosyasını seçin
+Select\ document=Belge seçin
+HTML\ list=HTML listesi
+If\ possible,\ normalize\ this\ list\ of\ names\ to\ conform\ to\ standard\ BibTeX\ name\ formatting=eğer mümkünse, bu isim listesini standart BibTeX isim biçimiyle uyumlu olacak şekilde normalleştir
+Could\ not\ open\ %0=%0 açılamıyor
+Unknown\ import\ format=Bilinmeyen içe aktarım biçimi
+Web\ search=Ağ araması
+Style\ selection=Stil seçimi
+No\ valid\ style\ file\ defined=Geçerli stil dosyası tanımlanmadı
+Choose\ pattern=Desen seçin
+Use\ the\ BIB\ file\ location\ as\ primary\ file\ directory=bib dosyası konumunu birincil dosya dizini olarak kullan
+Could\ not\ run\ the\ gnuclient/emacsclient\ program.\ Make\ sure\ you\ have\ the\ emacsclient/gnuclient\ program\ installed\ and\ available\ in\ the\ PATH.=gnuclient/emacsclient programı çalıştırılamıyor. Emacsclient/gnuclient programının kurulu olduğuna ve YOL'da mevcut olduğuna emin olun.
+OpenOffice/LibreOffice\ connection=OpenOffice/LibreOffice bağlantısı
+You\ must\ select\ either\ a\ valid\ style\ file,\ or\ use\ one\ of\ the\ default\ styles.=Ya geçerli bir stil dosyası seçmeli, ya da öntanımlı stillerden birini kullanmalısınız.
 
-This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.=Bu_basit_bir_kopyala_ve_yapıştır_iletişim_kutusudur._Önce_metin_girme_alanına_bir_metin_yükleyin_ya_da_yapıştırın.<br>Daha_sonra,_metni_işaretleyip_bir_BibTeX_alanına_atayabilirsiniz.
-This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.=Bu_özellik_mevcut_bir_LaTex_belgesinde_hangi_girdilerin_gerekli_olduğuna_dayanan_yeni_bir_veritabanı_oluşturur.
-You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.=Girdilerinizi_seçmek_için_açık_veritabanlarınızdan_birini_ve_belgenizi_derlerken_LaTex'in_oluşturduğu_AUX_dosyasını_seçmelisiniz.
+This\ is\ a\ simple\ copy\ and\ paste\ dialog.\ First\ load\ or\ paste\ some\ text\ into\ the\ text\ input\ area.<br>After\ that,\ you\ can\ mark\ text\ and\ assign\ it\ to\ a\ BibTeX\ field.=Bu basit bir kopyala ve yapıştır iletişim kutusudur. Önce metin girme alanına bir metin yükleyin ya da yapıştırın.<br>Daha sonra, metni işaretleyip bir BibTeX alanına atayabilirsiniz.
+This\ feature\ generates\ a\ new\ library\ based\ on\ which\ entries\ are\ needed\ in\ an\ existing\ LaTeX\ document.=Bu özellik mevcut bir LaTex belgesinde hangi girdilerin gerekli olduğuna dayanan yeni bir veritabanı oluşturur.
+You\ need\ to\ select\ one\ of\ your\ open\ libraries\ from\ which\ to\ choose\ entries,\ as\ well\ as\ the\ AUX\ file\ produced\ by\ LaTeX\ when\ compiling\ your\ document.=Girdilerinizi seçmek için açık veritabanlarınızdan birini ve belgenizi derlerken LaTex'in oluşturduğu AUX dosyasını seçmelisiniz.
 
-First_select_entries_to_clean_up.=Öncelikle_temizlemek_istediğiniz_girdileri_seçiniz.
-Cleanup_entry=Girdiyi_temizle
-Autogenerate_PDF_Names=PFD_Adlarını_Otomatik_Oluştur
-Auto-generating_PDF-Names_does_not_support_undo._Continue?=PDF_Adlarını_otomatik_oluşturma_geri_alınamaz._Devam_edilsin_mi?
+First\ select\ entries\ to\ clean\ up.=Öncelikle temizlemek istediğiniz girdileri seçiniz.
+Cleanup\ entry=Girdiyi temizle
+Autogenerate\ PDF\ Names=PFD Adlarını Otomatik Oluştur
+Auto-generating\ PDF-Names\ does\ not\ support\ undo.\ Continue?=PDF Adlarını otomatik oluşturma geri alınamaz. Devam edilsin mi?
 
-Use_full_firstname_whenever_possible=Mümkün_oldukça_tam_ilk_ismi_kullanınız
-Use_abbreviated_firstname_whenever_possible=Mümkün_oldukça_kısaltılmış_ilk_ismi_kullanınız
-Use_abbreviated_and_full_firstname=Kısaltılmış_ve_tam_ilk_ismi_kullanınız
-Autocompletion_options=Otomatik_tamamlama_seçenekleri
-Name_format_used_for_autocompletion=Otomatik_tamamlama_için_kullanılan_isim_biçemi
-Treatment_of_first_names=İlk_isimlerin_işlenme_şekli
-Cleanup_entries=Girdileri_temizle
-Automatically_assign_new_entry_to_selected_groups=Seçili_gruplara_otomatikman_yeni_girdi_ata
-%0_mode=%0_kipi
-Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix=DOI'leri_not_ve_URL_alanlarından_DOI_alanına_taşı_ve_http_ön_ekini_kaldır
-Make_paths_of_linked_files_relative_(if_possible)=(Mümkünse)_bağlantılı_dosya_yollarını_göreceli_yapın
-Rename_PDFs_to_given_filename_format_pattern=PDF'leri_belirlenmiş_dosya_ismi_biçemi_desenine_göre_yeniden_adlandır
-Rename_only_PDFs_having_a_relative_path=Yalnızca_göreceli_yolu_olan_PDF'leri_yeniden_adlandır
-What_would_you_like_to_clean_up?=Neyi_temizlemek_istersiniz?
-Doing_a_cleanup_for_%0_entries...=%O_girdileri_için_temizlik_yapılıyor...
-No_entry_needed_a_clean_up=Hiçbir_girdiye_temizlik_gerekmedi
-One_entry_needed_a_clean_up=Bir_girdi_temizlik_gerektirdi
-%0_entries_needed_a_clean_up=%0_girdi_temizlik_gerektirdi
+Use\ full\ firstname\ whenever\ possible=Mümkün oldukça tam ilk ismi kullanınız
+Use\ abbreviated\ firstname\ whenever\ possible=Mümkün oldukça kısaltılmış ilk ismi kullanınız
+Use\ abbreviated\ and\ full\ firstname=Kısaltılmış ve tam ilk ismi kullanınız
+Autocompletion\ options=Otomatik tamamlama seçenekleri
+Name\ format\ used\ for\ autocompletion=Otomatik tamamlama için kullanılan isim biçemi
+Treatment\ of\ first\ names=İlk isimlerin işlenme şekli
+Cleanup\ entries=Girdileri temizle
+Automatically\ assign\ new\ entry\ to\ selected\ groups=Seçili gruplara otomatikman yeni girdi ata
+%0\ mode=%0 kipi
+Move\ DOIs\ from\ note\ and\ URL\ field\ to\ DOI\ field\ and\ remove\ http\ prefix=DOI'leri not ve URL alanlarından DOI alanına taşı ve http ön ekini kaldır
+Make\ paths\ of\ linked\ files\ relative\ (if\ possible)=(Mümkünse) bağlantılı dosya yollarını göreceli yapın
+Rename\ PDFs\ to\ given\ filename\ format\ pattern=PDF'leri belirlenmiş dosya ismi biçemi desenine göre yeniden adlandır
+Rename\ only\ PDFs\ having\ a\ relative\ path=Yalnızca göreceli yolu olan PDF'leri yeniden adlandır
+What\ would\ you\ like\ to\ clean\ up?=Neyi temizlemek istersiniz?
+Doing\ a\ cleanup\ for\ %0\ entries...=%O girdileri için temizlik yapılıyor...
+No\ entry\ needed\ a\ clean\ up=Hiçbir girdiye temizlik gerekmedi
+One\ entry\ needed\ a\ clean\ up=Bir girdi temizlik gerektirdi
+%0\ entries\ needed\ a\ clean\ up=%0 girdi temizlik gerektirdi
 
-Remove_selected=Seçiliyi_Sil
+Remove\ selected=Seçiliyi Sil
 
-Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.=Grup_ağacı_çözümlenemedi._Eğer_BibTeX_veri_tabanını_kaydederseniz_tüm_gruplar_yitecek.
-Attach_file=Dosya_ekle
-Setting_all_preferences_to_default_values.=Tüm_tercihler_öntanımlı_değerlere_ayarlanıyor.
-Resetting_preference_key_'%0'=Tercih_anahtarı_'%0'_yeniden_atanıyor
-Unknown_preference_key_'%0'=Bilinmeyen_tercih_anahtarı_'%0'
-Unable_to_clear_preferences.=Tercihler_silinemedi.
+Group\ tree\ could\ not\ be\ parsed.\ If\ you\ save\ the\ BibTeX\ library,\ all\ groups\ will\ be\ lost.=Grup ağacı çözümlenemedi. Eğer BibTeX veri tabanını kaydederseniz tüm gruplar yitecek.
+Attach\ file=Dosya ekle
+Setting\ all\ preferences\ to\ default\ values.=Tüm tercihler öntanımlı değerlere ayarlanıyor.
+Resetting\ preference\ key\ '%0'=Tercih anahtarı '%0' yeniden atanıyor
+Unknown\ preference\ key\ '%0'=Bilinmeyen tercih anahtarı '%0'
+Unable\ to\ clear\ preferences.=Tercihler silinemedi.
 
-Reset_preferences_(key1,key2,..._or_'all')=Tercihleri_sıfırla_(anahtar1,anahtar2,..._ya_da_'tümü')
-Find_unlinked_files=Bağlantısız_dosyaları_bul
-Unselect_all=Tüm_seçimleri_kaldır
-Expand_all=Tümünü_genişlet
-Collapse_all=Tüm_genişletmeyi_kaldır
-Opens_the_file_browser.=Dosya_göz_atıcısını_başlatır.
-Scan_directory=Dizini_tara
-Searches_the_selected_directory_for_unlinked_files.=Seçili_dizini_bağlantısız_dosyalar_için_tarar.
-Starts_the_import_of_BibTeX_entries.=BibTeX_girdilerinin_içe_aktarımı_başlatır.
-Leave_this_dialog.=Bu_iletişim_kutusunu_terket.
-Create_directory_based_keywords=Dizin_tabanlı_anahtar_sözcükler_oluştur
-Creates_keywords_in_created_entrys_with_directory_pathnames=Oluşturulan_girdilerde_dizin_yol_adlarıyla_anahtar_sözcükler_oluşturur
-Select_a_directory_where_the_search_shall_start.=Aramanın_başlayacağı_dizini_seçin.
-Select_file_type\:=Dosya_türü_seçin\:
-These_files_are_not_linked_in_the_active_library.=Bu_dosyaların_aktif_veri_tabanında_bağlantıları_yok.
-Entry_type_to_be_created\:=Oluşturulacak_girdi_türü\:
-Searching_file_system...=Dosya_sistemi_aranıyor...
-Importing_into_Library...=Veritabanına_aktarılıyor...
-Select_directory=Dizin_seç
-Select_files=Dosya_seç
-BibTeX_entry_creation=BibTeX_girdisi_oluşturma
-<No_selection>=<Seçim_yok>
-Unable_to_connect_to_FreeCite_online_service.=FreeCite_çevrimiçi_servisine_bağlanılamadı.
-Parse_with_FreeCite=FreeCite_ile_çözümle
-The_current_BibTeX_key_will_be_overwritten._Continue?=Mevcut_BibTeX_anahtarının_üzerine_yazılacak._Devam_edilsin_mi?
-Overwrite_key=Anahtarın_üzerine_yaz
-Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator=Mevcut_anahtarın_üzerine_yazılmıyor._Bu_ayarı_değiştirmek_için_Seçenekler_->_Tercihler_->_BibTeX_anahtar_oluşturucusu'nu_açın
-How_would_you_like_to_link_to_'%0'?='%0'a_nasıl_bağlantı_istersiniz?
-BibTeX_key_patterns=BibTeX_anahtar_paternleri
-Changed_special_field_settings=Değiştirilmiş_özel_alan_ayarları
-Clear_priority=Önceliği_sil
-Clear_rank=Rütbeyi_sil
-Enable_special_fields=Özle_alanları_etkinleştir
-One_star=Bir_yıldız
-Two_stars=İki_yıldız
-Three_stars=Üç_yıldız
-Four_stars=Dört_yıldız
-Five_stars=Beş_yıldız
-Help_on_special_fields=Özle_alanlar_konusunda_yardım
-Keywords_of_selected_entries=Seçili_girdilerin_anahtar_sözcükleri
-Manage_content_selectors=İçerik_seçicileri_yönet
-Manage_keywords=Anahtar_sözcükleri_yönet
-No_priority_information=Öncelik_bilgisi_yok
-No_rank_information=Rütbe_bilgisi_yok
+Reset\ preferences\ (key1,key2,...\ or\ 'all')=Tercihleri sıfırla (anahtar1,anahtar2,... ya da 'tümü')
+Find\ unlinked\ files=Bağlantısız dosyaları bul
+Unselect\ all=Tüm seçimleri kaldır
+Expand\ all=Tümünü genişlet
+Collapse\ all=Tüm genişletmeyi kaldır
+Opens\ the\ file\ browser.=Dosya göz atıcısını başlatır.
+Scan\ directory=Dizini tara
+Searches\ the\ selected\ directory\ for\ unlinked\ files.=Seçili dizini bağlantısız dosyalar için tarar.
+Starts\ the\ import\ of\ BibTeX\ entries.=BibTeX girdilerinin içe aktarımı başlatır.
+Leave\ this\ dialog.=Bu iletişim kutusunu terket.
+Create\ directory\ based\ keywords=Dizin tabanlı anahtar sözcükler oluştur
+Creates\ keywords\ in\ created\ entrys\ with\ directory\ pathnames=Oluşturulan girdilerde dizin yol adlarıyla anahtar sözcükler oluşturur
+Select\ a\ directory\ where\ the\ search\ shall\ start.=Aramanın başlayacağı dizini seçin.
+Select\ file\ type\:=Dosya türü seçin:
+These\ files\ are\ not\ linked\ in\ the\ active\ library.=Bu dosyaların aktif veri tabanında bağlantıları yok.
+Entry\ type\ to\ be\ created\:=Oluşturulacak girdi türü:
+Searching\ file\ system...=Dosya sistemi aranıyor...
+Importing\ into\ Library...=Veritabanına aktarılıyor...
+Select\ directory=Dizin seç
+Select\ files=Dosya seç
+BibTeX\ entry\ creation=BibTeX girdisi oluşturma
+<No\ selection>=<Seçim yok>
+Unable\ to\ connect\ to\ FreeCite\ online\ service.=FreeCite çevrimiçi servisine bağlanılamadı.
+Parse\ with\ FreeCite=FreeCite ile çözümle
+The\ current\ BibTeX\ key\ will\ be\ overwritten.\ Continue?=Mevcut BibTeX anahtarının üzerine yazılacak. Devam edilsin mi?
+Overwrite\ key=Anahtarın üzerine yaz
+Not\ overwriting\ existing\ key.\ To\ change\ this\ setting,\ open\ Options\ ->\ Prefererences\ ->\ BibTeX\ key\ generator=Mevcut anahtarın üzerine yazılmıyor. Bu ayarı değiştirmek için Seçenekler -> Tercihler -> BibTeX anahtar oluşturucusu'nu açın
+How\ would\ you\ like\ to\ link\ to\ '%0'?='%0'a nasıl bağlantı istersiniz?
+BibTeX\ key\ patterns=BibTeX anahtar paternleri
+Changed\ special\ field\ settings=Değiştirilmiş özel alan ayarları
+Clear\ priority=Önceliği sil
+Clear\ rank=Rütbeyi sil
+Enable\ special\ fields=Özle alanları etkinleştir
+One\ star=Bir yıldız
+Two\ stars=İki yıldız
+Three\ stars=Üç yıldız
+Four\ stars=Dört yıldız
+Five\ stars=Beş yıldız
+Help\ on\ special\ fields=Özle alanlar konusunda yardım
+Keywords\ of\ selected\ entries=Seçili girdilerin anahtar sözcükleri
+Manage\ content\ selectors=İçerik seçicileri yönet
+Manage\ keywords=Anahtar sözcükleri yönet
+No\ priority\ information=Öncelik bilgisi yok
+No\ rank\ information=Rütbe bilgisi yok
 Priority=Öncelik
-Priority_high=Öncelik_yüksek
-Priority_low=Öncelik_düşük
-Priority_medium=Öncelik_orta
+Priority\ high=Öncelik yüksek
+Priority\ low=Öncelik düşük
+Priority\ medium=Öncelik orta
 Quality=Kalite
 Rank=Rütbe
-Relevance=İlgi_düzeyi
-Set_priority_to_high=Önceliği_yükseğe_ayarla
-Set_priority_to_low=Önceliği_düşüğe_ayarla
-Set_priority_to_medium=Önceliği_ortaya_ayarla
-Show_priority=Önceliği_göster
-Show_quality=Kaliteyi_göster
-Show_rank=Rütbeyi_göster
-Show_relevance=İlgi_düzeyini_göster
-Synchronize_with_keywords=Anahtar_sözcüklerle_eşzamanla
-Synchronized_special_fields_based_on_keywords=Anahtar_sözcüklere_dayanarak_özel_alanlar_eşzamanlandı
-Toggle_relevance=İlgi_düzeyini_değiştir
-Toggle_quality_assured=Kalite_güvencesini_değiştir
-Toggle_print_status=Yazdırma_statüsünü_değiştir
-Update_keywords=Anahtar_sözcükleri_güncelle
-Write_values_of_special_fields_as_separate_fields_to_BibTeX=Özel_alan_değerlerini_BibTeX'e_ayrı_alanlar_olarak_yaz
-You_have_changed_settings_for_special_fields.=Özel_alan_ayarlarını_değiştirdiniz.
-%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.=%0_girdi_bulundu._Sunucu_yükünü_azaltmak_için_yalnızca_%1_indirilecek.
-A_string_with_that_label_already_exists=Bu_etikete_sahip_bir_dizge_zaten_mevcut
-Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.=OpenOffice/LibreOffice_bağlantısı_koptu._Lütfen_OpenOffice/LibreOffice'in_açık_olduğunu_teyid_edin,_ve_tekrar_bağlanmayı_deneyin.
-JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.=JabRef_bir_yayıncıya_en_az_bir_istem_gönderecek.
-Correct_the_entry,_and_reopen_editor_to_display/edit_source.=Girdiyi_düzeltin,_ve_kaynağı_görmek/düzenlemek_için_düzenleyiciyi_tekrar_açın.
-Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').=Öalışan_bir_gnuserv_sürecine_bağlanılamadı._Emacs_ya_da_XEmacs'ın_çalıştığına_ve<BR>sunucunun_başlatıldığına_('server-start'/'gnuserv-start'_komutu_çalıştırılarak)_emin_olun,
-Could_not_connect_to_running_OpenOffice/LibreOffice.=Çalışan_OpenOffice/LibreOffice'e_bağlanılamıyor.
-Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.=OpenOffice/LibreOffice'i_Java_desteğiyle_kurduğunuza_emin_olun.
-If_connecting_manually,_please_verify_program_and_library_paths.=Manuel_bağlanıyorsanız_program_ve_kütüphane_yollarını_kontrol_edin.
-Error_message\:=Hata_mesajı\:
-If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.=Eğer_yapıştırılmış_ya_da_içe_aktarılmış_bir_girdi_alanı_atadıysa_üzerine_yaz.
-Import_metadata_from_PDF=Metadata'yı_PDF'ten_İçe_Aktar
-Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.=Herhangi_bir_Writer_belgesine_bağlanılmadı._Lütfen_bir_belgenin_açık_olduğuna_emin_olun_ve_ona_bağlanmak_için_"Write_belgesini_seç"_düğmesini_kullanın.
-Removed_all_subgroups_of_group_"%0".=Grup_"%0"'ın_bütün_alt_grupları_silindi.
-To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.=Taşınabilir_hafıza_kartı_kipini_etkisizleştirmek_için_JabRef'le_aynı_klasördeki_jabref.xml_dosyasını_silin_ya_da_adını_değiştirin.
-Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.=Bağlanılamadı._Bir_olası_neden_JabRef_ve_OpenOffice/LibreOffice'in_birlikte_32_bit_ya_da_64_bit_kipinde_çalışmamasıdır.
-Use_the_following_delimiter_character(s)\:=Aşağıdaki_sınırlatıcı_karakter(ler)i_kullanın\:
-When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above=Dosya_indirirken_ya_da_bağlantılı_dosyaları_dosya_dizinine_taşırken,_yukarıda_atanan_dosya_dizini_yerine_BIB_dosyası_konumunu_tercih_edin
-Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=Stil_dosyanız,_mevcut_OpenOffice/LibreOffice_belgenizde_tanımlanmamış_olan_'%0'_karakter_formatını_belirtiyor.
-Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=Stil_dosyanız,_mevcut_OpenOffice/LibreOffice_belgenizde_tanımlanmamış_olan_'%0'_paragraf_formatını_belirtiyor.
+Relevance=İlgi düzeyi
+Set\ priority\ to\ high=Önceliği yükseğe ayarla
+Set\ priority\ to\ low=Önceliği düşüğe ayarla
+Set\ priority\ to\ medium=Önceliği ortaya ayarla
+Show\ priority=Önceliği göster
+Show\ quality=Kaliteyi göster
+Show\ rank=Rütbeyi göster
+Show\ relevance=İlgi düzeyini göster
+Synchronize\ with\ keywords=Anahtar sözcüklerle eşzamanla
+Synchronized\ special\ fields\ based\ on\ keywords=Anahtar sözcüklere dayanarak özel alanlar eşzamanlandı
+Toggle\ relevance=İlgi düzeyini değiştir
+Toggle\ quality\ assured=Kalite güvencesini değiştir
+Toggle\ print\ status=Yazdırma statüsünü değiştir
+Update\ keywords=Anahtar sözcükleri güncelle
+Write\ values\ of\ special\ fields\ as\ separate\ fields\ to\ BibTeX=Özel alan değerlerini BibTeX'e ayrı alanlar olarak yaz
+You\ have\ changed\ settings\ for\ special\ fields.=Özel alan ayarlarını değiştirdiniz.
+%0\ entries\ found.\ To\ reduce\ server\ load,\ only\ %1\ will\ be\ downloaded.=%0 girdi bulundu. Sunucu yükünü azaltmak için yalnızca %1 indirilecek.
+A\ string\ with\ that\ label\ already\ exists=Bu etikete sahip bir dizge zaten mevcut
+Connection\ to\ OpenOffice/LibreOffice\ has\ been\ lost.\ Please\ make\ sure\ OpenOffice/LibreOffice\ is\ running,\ and\ try\ to\ reconnect.=OpenOffice/LibreOffice bağlantısı koptu. Lütfen OpenOffice/LibreOffice'in açık olduğunu teyid edin, ve tekrar bağlanmayı deneyin.
+JabRef\ will\ send\ at\ least\ one\ request\ per\ entry\ to\ a\ publisher.=JabRef bir yayıncıya en az bir istem gönderecek.
+Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=Girdiyi düzeltin, ve kaynağı görmek/düzenlemek için düzenleyiciyi tekrar açın.
+Could\ not\ connect\ to\ a\ running\ gnuserv\ process.\ Make\ sure\ that\ Emacs\ or\ XEmacs\ is\ running,<BR>and\ that\ the\ server\ has\ been\ started\ (by\ running\ the\ command\ 'server-start'/'gnuserv-start').=Öalışan bir gnuserv sürecine bağlanılamadı. Emacs ya da XEmacs'ın çalıştığına ve<BR>sunucunun başlatıldığına ('server-start'/'gnuserv-start' komutu çalıştırılarak) emin olun,
+Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=Çalışan OpenOffice/LibreOffice'e bağlanılamıyor.
+Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=OpenOffice/LibreOffice'i Java desteğiyle kurduğunuza emin olun.
+If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=Manuel bağlanıyorsanız program ve kütüphane yollarını kontrol edin.
+Error\ message\:=Hata mesajı:
+If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=Eğer yapıştırılmış ya da içe aktarılmış bir girdi alanı atadıysa üzerine yaz.
+Import\ metadata\ from\ PDF=Metadata'yı PDF'ten İçe Aktar
+Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=Herhangi bir Writer belgesine bağlanılmadı. Lütfen bir belgenin açık olduğuna emin olun ve ona bağlanmak için "Write belgesini seç" düğmesini kullanın.
+Removed\ all\ subgroups\ of\ group\ "%0".=Grup "%0"'ın bütün alt grupları silindi.
+To\ disable\ the\ memory\ stick\ mode\ rename\ or\ remove\ the\ jabref.xml\ file\ in\ the\ same\ folder\ as\ JabRef.=Taşınabilir hafıza kartı kipini etkisizleştirmek için JabRef'le aynı klasördeki jabref.xml dosyasını silin ya da adını değiştirin.
+Unable\ to\ connect.\ One\ possible\ reason\ is\ that\ JabRef\ and\ OpenOffice/LibreOffice\ are\ not\ both\ running\ in\ either\ 32\ bit\ mode\ or\ 64\ bit\ mode.=Bağlanılamadı. Bir olası neden JabRef ve OpenOffice/LibreOffice'in birlikte 32 bit ya da 64 bit kipinde çalışmamasıdır.
+Use\ the\ following\ delimiter\ character(s)\:=Aşağıdaki sınırlatıcı karakter(ler)i kullanın:
+When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\ prefer\ the\ BIB\ file\ location\ rather\ than\ the\ file\ directory\ set\ above=Dosya indirirken ya da bağlantılı dosyaları dosya dizinine taşırken, yukarıda atanan dosya dizini yerine BIB dosyası konumunu tercih edin
+Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Stil dosyanız, mevcut OpenOffice/LibreOffice belgenizde tanımlanmamış olan '%0' karakter formatını belirtiyor.
+Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=Stil dosyanız, mevcut OpenOffice/LibreOffice belgenizde tanımlanmamış olan '%0' paragraf formatını belirtiyor.
 
 Searching...=Arıyor...
-You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?=İndirmek_için_%0'dan_fazla_girdi_seçtiniz._Çok_sayıda_hızlı_indirme_yaparsanız_bazı_web_siteleri_sizi_bloke_edebilir._Devam_etmek_istiyor_musunuz?
-Confirm_selection=Seçimi_onayla
-Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case=Aramada_doğru_küçük_büyük_harf_seçimi_için_belirli_başlık_sözcüklerine_{}_ekleyin
-Import_conversions=Dönüşümleri_içe_aktar
-Please_enter_a_search_string=Lütfen_bir_arama_dizgesi_girin
-Please_open_or_start_a_new_library_before_searching=Lütfen_aramadan_önce_bir_veri_tabanı_açın_ya_da_başlatın
+You\ have\ selected\ more\ than\ %0\ entries\ for\ download.\ Some\ web\ sites\ might\ block\ you\ if\ you\ make\ too\ many\ rapid\ downloads.\ Do\ you\ want\ to\ continue?=İndirmek için %0'dan fazla girdi seçtiniz. Çok sayıda hızlı indirme yaparsanız bazı web siteleri sizi bloke edebilir. Devam etmek istiyor musunuz?
+Confirm\ selection=Seçimi onayla
+Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=Aramada doğru küçük büyük harf seçimi için belirli başlık sözcüklerine {} ekleyin
+Import\ conversions=Dönüşümleri içe aktar
+Please\ enter\ a\ search\ string=Lütfen bir arama dizgesi girin
+Please\ open\ or\ start\ a\ new\ library\ before\ searching=Lütfen aramadan önce bir veri tabanı açın ya da başlatın
 
-Canceled_merging_entries=Girdilerin_birleştirilmesi_iptal_edildi
+Canceled\ merging\ entries=Girdilerin birleştirilmesi iptal edildi
 
-Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search=Birimleri_bölünemez_ayraçlar_ekleyerek_ve_aramadaki_büyük_küçük_harfleri_koruyarak_biçimle
-Merge_entries=Girdileri_birleştir
-Merged_entries=Girdiler_yeni_birine_birleştirildi_ve_eskiler_korundu
-Merged_entry=Birleşmiş_girdi
+Format\ units\ by\ adding\ non-breaking\ separators\ and\ keeping\ the\ correct\ case\ on\ search=Birimleri bölünemez ayraçlar ekleyerek ve aramadaki büyük küçük harfleri koruyarak biçimle
+Merge\ entries=Girdileri birleştir
+Merged\ entries=Girdiler yeni birine birleştirildi ve eskiler korundu
+Merged\ entry=Birleşmiş girdi
 None=Hiç
 Parse=Ayrıştır
 Result=Sonuç
-Show_DOI_first=Önce_DOI'yı_göster
-Show_URL_first=Önce_URL'yi_göster
-Use_Emacs_key_bindings=Emacs_tuş_bağlantılarını_kullan
-You_have_to_choose_exactly_two_entries_to_merge.=Birleştirmek_için_tam_tamına_iki_girdi_seçmelisiniz.
+Show\ DOI\ first=Önce DOI'yı göster
+Show\ URL\ first=Önce URL'yi göster
+Use\ Emacs\ key\ bindings=Emacs tuş bağlantılarını kullan
+You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=Birleştirmek için tam tamına iki girdi seçmelisiniz.
 
-Update_timestamp_on_modification=Değiştirirken_zaman_damgasını_güncelle
-All_key_bindings_will_be_reset_to_their_defaults.=Tüm_tuş_bağlantıları_öntanımlılara_dönüştürülecek.
+Update\ timestamp\ on\ modification=Değiştirirken zaman damgasını güncelle
+All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=Tüm tuş bağlantıları öntanımlılara dönüştürülecek.
 
-Automatically_set_file_links=Dosya_bağlantılarını_otomatik_olarak_kur
-Resetting_all_key_bindings=Tüm_tuş_bağlantıları_başa_döndürülüyor
+Automatically\ set\ file\ links=Dosya bağlantılarını otomatik olarak kur
+Resetting\ all\ key\ bindings=Tüm tuş bağlantıları başa döndürülüyor
 Hostname=Makine
-Invalid_setting=Geçersiz_ayar
+Invalid\ setting=Geçersiz ayar
 Network=Ağ
-Please_specify_both_hostname_and_port=Lütfen_hem_makine_adını_hem_de_bağlantı_noktasını_belirtin
-Please_specify_both_username_and_password=Lütfen_hem_kullanıcı_adı_hem_de_parolayı_belirtiniz
+Please\ specify\ both\ hostname\ and\ port=Lütfen hem makine adını hem de bağlantı noktasını belirtin
+Please\ specify\ both\ username\ and\ password=Lütfen hem kullanıcı adı hem de parolayı belirtiniz
 
-Use_custom_proxy_configuration=Özelleştirilmiş_vekil_konfigürasyonu_kullan
-Proxy_requires_authentication=Vekil_sunucu_kimlik_denetleme_gerektiriyor
-Attention\:_Password_is_stored_in_plain_text\!=Dikkat\:_Parola_salt_metin_olarak_kaydedildi\!
-Clear_connection_settings=Bağlantı_ayarlarını_sil
-Cleared_connection_settings.=Bağlantı_ayarları_silindi.
+Use\ custom\ proxy\ configuration=Özelleştirilmiş vekil konfigürasyonu kullan
+Proxy\ requires\ authentication=Vekil sunucu kimlik denetleme gerektiriyor
+Attention\:\ Password\ is\ stored\ in\ plain\ text\!=Dikkat: Parola salt metin olarak kaydedildi!
+Clear\ connection\ settings=Bağlantı ayarlarını sil
+Cleared\ connection\ settings.=Bağlantı ayarları silindi.
 
-Rebind_C-a,_too=C-a'yı_da_yeniden_bağla
-Rebind_C-f,_too=C-f'yi_de_tekrar_bağla
+Rebind\ C-a,\ too=C-a'yı da yeniden bağla
+Rebind\ C-f,\ too=C-f'yi de tekrar bağla
 
-Open_folder=Klasörü_aç
-Searches_for_unlinked_PDF_files_on_the_file_system=Dosya_sisteminde_bağlantılanmamış_PDF_dosyalarını_arar
-Export_entries_ordered_as_specified=Girdileri_belirtilen_sırada_dışa_aktar
-Export_sort_order=Sıralama_kriterlerini_dışa_aktar
-Export_sorting=Sıralamayı_dışa_aktar
-Newline_separator=Satırbaşı_ayracı
+Open\ folder=Klasörü aç
+Searches\ for\ unlinked\ PDF\ files\ on\ the\ file\ system=Dosya sisteminde bağlantılanmamış PDF dosyalarını arar
+Export\ entries\ ordered\ as\ specified=Girdileri belirtilen sırada dışa aktar
+Export\ sort\ order=Sıralama kriterlerini dışa aktar
+Export\ sorting=Sıralamayı dışa aktar
+Newline\ separator=Satırbaşı ayracı
 
-Save_entries_ordered_as_specified=Girdileri_belirtilen_sırada_kaydet
-Save_sort_order=Sıralama_kriterlerini_kaydet
-Show_extra_columns=Ekstra_sütunları_göster
-Parsing_error=Çözümleme_hatası
-illegal_backslash_expression=kuraldışı_ters_bölü_ifadesi
+Save\ entries\ ordered\ as\ specified=Girdileri belirtilen sırada kaydet
+Save\ sort\ order=Sıralama kriterlerini kaydet
+Show\ extra\ columns=Ekstra sütunları göster
+Parsing\ error=Çözümleme hatası
+illegal\ backslash\ expression=kuraldışı ters bölü ifadesi
 
-Move_to_group=gruba_taşı
+Move\ to\ group=gruba taşı
 
-Clear_read_status=Okundu_statüsünü_temizle
-Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')=Biblatex_biçemine_dönüştür_(örneğin_'journal'_alanının_değerini_'journaltitle'a_taşı)
-Could_not_apply_changes.=Değişiklikler_uygulanamadı.
-Deprecated_fields=Yürürlükten_kalkmış_alanlar
-Hide/show_toolbar=Araç_çubuğunu_gizle/göster
-No_read_status_information=Okunma_statüsü_bilgisi_yok
+Clear\ read\ status=Okundu statüsünü temizle
+Convert\ to\ biblatex\ format\ (for\ example,\ move\ the\ value\ of\ the\ 'journal'\ field\ to\ 'journaltitle')=Biblatex biçemine dönüştür (örneğin 'journal' alanının değerini 'journaltitle'a taşı)
+Could\ not\ apply\ changes.=Değişiklikler uygulanamadı.
+Deprecated\ fields=Yürürlükten kalkmış alanlar
+Hide/show\ toolbar=Araç çubuğunu gizle/göster
+No\ read\ status\ information=Okunma statüsü bilgisi yok
 Printed=Yazdırılmış
-Read_status=Okunma_statüsü
-Read_status_read=Okunma_statüsü_okunmuş
-Read_status_skimmed=Okunma_statüsü_göz_gezdirilmiş
-Save_selected_as_plain_BibTeX...=Seçimi_salt_BibTeX_olarak_kaydet...
-Set_read_status_to_read=Okunma_statüsünü_okunmuş_olarak_ata
-Set_read_status_to_skimmed=Okunma_statüsünü_göz_gezdirilmiş_olarak_ata
-Show_deprecated_BibTeX_fields=Yürürlükten_kaldırılmış_BibTeX_alanlarını_göster
+Read\ status=Okunma statüsü
+Read\ status\ read=Okunma statüsü okunmuş
+Read\ status\ skimmed=Okunma statüsü göz gezdirilmiş
+Save\ selected\ as\ plain\ BibTeX...=Seçimi salt BibTeX olarak kaydet...
+Set\ read\ status\ to\ read=Okunma statüsünü okunmuş olarak ata
+Set\ read\ status\ to\ skimmed=Okunma statüsünü göz gezdirilmiş olarak ata
+Show\ deprecated\ BibTeX\ fields=Yürürlükten kaldırılmış BibTeX alanlarını göster
 
-Show_gridlines=Izgarayı_göster
-Show_printed_status=Yazdırma_statüsünü_göster
-Show_read_status=Okunma_statüsünü_göster
-Table_row_height_padding=Tablo_satır_yüksekliği_dolgusu
+Show\ gridlines=Izgarayı göster
+Show\ printed\ status=Yazdırma statüsünü göster
+Show\ read\ status=Okunma statüsünü göster
+Table\ row\ height\ padding=Tablo satır yüksekliği dolgusu
 
-Marked_selected_entry=Seçilmiş_girdi_işaretlendi
-Marked_all_%0_selected_entries=Tüm_%0_seçilmiş_girdi_işaretlendi
-Unmarked_selected_entry=Seçilmiş_girdinin_işareti_kaldırıldı
-Unmarked_all_%0_selected_entries=Tüm_%0_seçilmiş_girdinin_işareti_kaldırıldı
+Marked\ selected\ entry=Seçilmiş girdi işaretlendi
+Marked\ all\ %0\ selected\ entries=Tüm %0 seçilmiş girdi işaretlendi
+Unmarked\ selected\ entry=Seçilmiş girdinin işareti kaldırıldı
+Unmarked\ all\ %0\ selected\ entries=Tüm %0 seçilmiş girdinin işareti kaldırıldı
 
 
-Unmarked_all_entries=Tüm_girdilerin_işareti_kaldırıldı
+Unmarked\ all\ entries=Tüm girdilerin işareti kaldırıldı
 
-Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.=Arzu_edilen_Görünüm_ve_Tema_bulunamadığından_öntanımlı_olan_kullanıldı.
+Unable\ to\ find\ the\ requested\ look\ and\ feel\ and\ thus\ the\ default\ one\ is\ used.=Arzu edilen Görünüm ve Tema bulunamadığından öntanımlı olan kullanıldı.
 
-Opens_JabRef's_GitHub_page=JabRef'in_GitHub_sayfasını_açar
-Could_not_open_browser.=Tarayıcı_açılamadı.
-Please_open_%0_manually.=Lütfen_%0'i_kendiniz_açın.
-The_link_has_been_copied_to_the_clipboard.=Bağlantı_panoya_kopyalandı.
+Opens\ JabRef's\ GitHub\ page=JabRef'in GitHub sayfasını açar
+Could\ not\ open\ browser.=Tarayıcı açılamadı.
+Please\ open\ %0\ manually.=Lütfen %0'i kendiniz açın.
+The\ link\ has\ been\ copied\ to\ the\ clipboard.=Bağlantı panoya kopyalandı.
 
-Open_%0_file=%0_dosyayı_aç
+Open\ %0\ file=%0 dosyayı aç
 
-Cannot_delete_file=Dosya_silinemiyor
-File_permission_error=Dosya_izin_hatası
-Push_to_%0=%0'e_itele
-Path_to_%0=%0_yolu
+Cannot\ delete\ file=Dosya silinemiyor
+File\ permission\ error=Dosya izin hatası
+Push\ to\ %0=%0'e itele
+Path\ to\ %0=%0 yolu
 Convert=Dönüştür
-Normalize_to_BibTeX_name_format=BibTeX_adı_biçimine_normalleştir
-Help_on_Name_Formatting=İsim_Biçimlemede_Yardım
+Normalize\ to\ BibTeX\ name\ format=BibTeX adı biçimine normalleştir
+Help\ on\ Name\ Formatting=İsim Biçimlemede Yardım
 
-Add_new_file_type=Yeni_dosya_türü_ekle
+Add\ new\ file\ type=Yeni dosya türü ekle
 
-Left_entry=Sol_girdi
-Right_entry=Sağ_girdi
+Left\ entry=Sol girdi
+Right\ entry=Sağ girdi
 Use=Kullan
-Original_entry=Orjinal_girdi
-Replace_original_entry=Orjinal_girdinin_yerine_koy
-No_information_added=Bilgi_eklenmedi
-Select_at_least_one_entry_to_manage_keywords.=Anahtar_sözcükleri_yönetmek_için_en_az_bir_girdi_seçiniz.
-OpenDocument_text=AçıkBelge_metni
-OpenDocument_spreadsheet=AçıkBelge_iş_tablosu
-OpenDocument_presentation=AçıkBelge_sunumu
-%0_image=%0_resim
-Added_entry=Eklenen_girdi
-Modified_entry=Değiştirilmiş_girdi
-Deleted_entry=Girdi_silindi
-Modified_groups_tree=Değiştirilmiş_grup_ağacı
-Removed_all_groups=Tüm_gruplar_silindi
-Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.=Değişikliği_kabul_etmek,_harici_olarak_değiştirilmiş_grup_ağacını_mevcut_grup_ağacının_tamamının_yerine_koyar.
-Select_export_format=Dışa_aktarma_biçemini_seç
-Return_to_JabRef=JabRef'e_geri_dön
-Please_move_the_file_manually_and_link_in_place.=Lütfen_dosyayı_elle_taşıyın_ve_yerinde_bağlantı_kurun.
-Could_not_connect_to_%0=%0'e_bağlanılamadı
-Warning\:_%0_out_of_%1_entries_have_undefined_title.=Uyarı\:_%1_girdiden_%0'inin_tanımlanmamış_başlığı_var.
-Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.=Uyarı\:%1_girdiden_%0'inde_tanımlanmamış_BibTeX_anahtarı_var.
+Original\ entry=Orjinal girdi
+Replace\ original\ entry=Orjinal girdinin yerine koy
+No\ information\ added=Bilgi eklenmedi
+Select\ at\ least\ one\ entry\ to\ manage\ keywords.=Anahtar sözcükleri yönetmek için en az bir girdi seçiniz.
+OpenDocument\ text=AçıkBelge metni
+OpenDocument\ spreadsheet=AçıkBelge iş tablosu
+OpenDocument\ presentation=AçıkBelge sunumu
+%0\ image=%0 resim
+Added\ entry=Eklenen girdi
+Modified\ entry=Değiştirilmiş girdi
+Deleted\ entry=Girdi silindi
+Modified\ groups\ tree=Değiştirilmiş grup ağacı
+Removed\ all\ groups=Tüm gruplar silindi
+Accepting\ the\ change\ replaces\ the\ complete\ groups\ tree\ with\ the\ externally\ modified\ groups\ tree.=Değişikliği kabul etmek, harici olarak değiştirilmiş grup ağacını mevcut grup ağacının tamamının yerine koyar.
+Select\ export\ format=Dışa aktarma biçemini seç
+Return\ to\ JabRef=JabRef'e geri dön
+Please\ move\ the\ file\ manually\ and\ link\ in\ place.=Lütfen dosyayı elle taşıyın ve yerinde bağlantı kurun.
+Could\ not\ connect\ to\ %0=%0'e bağlanılamadı
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ title.=Uyarı: %1 girdiden %0'inin tanımlanmamış başlığı var.
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ BibTeX\ key.=Uyarı:%1 girdiden %0'inde tanımlanmamış BibTeX anahtarı var.
 occurrence=görülme
-Added_new_'%0'_entry.='%0'_yebi_girdi_eklendi.
-Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?=Çok_sayıda_girdi_seçili._Tüm_bunların_türünü_'%0'e_değiştirmek_ister_misiniz?
-Changed_type_to_'%0'_for=Tür_'%0'e_değiştirildi
-Really_delete_the_selected_entry?=Gerçekten_seçili_girdi_silinsin_mi?
-Really_delete_the_%0_selected_entries?=Gerçekten_seçili_%0_girdi_silinsin_mi?
-Keep_merged_entry_only=Yalnızca_birleşik_girdiyi_tut
-Keep_left=Solu_tut
-Keep_right=Sağı_tut
-Old_entry=Eski_girdi
-From_import=İçe_almadan
-No_problems_found.=Hiçbir_sorun_bulunmadı.
-%0_problem(s)_found=%0_sorun_bulundu
-Save_changes=Değişiklikleri_kaydet
-Discard_changes=Değişiklikleri_sil
-Library_'%0'_has_changed.=Veri_tabanı_'%0'_değişti.
-Print_entry_preview=Girdi_yazdırma_önizleme
-Copy_title=Başlığı_kopyala
-Copy_\\cite{BibTeX_key}=\\cite{BibTeX_anahtarı}'nı_kopyala
-Copy_BibTeX_key_and_title=BibTeX_anahtarı_ve_başlığını_kopyala
-File_rename_failed_for_%0_entries.=%0_girdide_dosya_yeniden_adlandırma_başarısız.
-Merged_BibTeX_source_code=Birleşik_BibTeX_kaynak_kodu
-Invalid_DOI\:_'%0'.=Geçersiz_DOI\:_'%0'.
-should_start_with_a_name=bir_isimle_başlamalı
-should_end_with_a_name=bir_isimle_sonlanmalı
-unexpected_closing_curly_bracket=beklenmeyen_küme_parantezi_kapanışı
-unexpected_opening_curly_bracket=beklenmeyen_küme_parantezi_açılışı
-capital_letters_are_not_masked_using_curly_brackets_{}=küme_parantezleri_{}_kullanarak_büyük_harfler_maskelenmez
-should_contain_a_four_digit_number=dört_basamaklı_bir_numara_içermeli
-should_contain_a_valid_page_number_range=geçerli_bir_sayfa_numarası_aralığı_içermeli
+Added\ new\ '%0'\ entry.='%0' yebi girdi eklendi.
+Multiple\ entries\ selected.\ Do\ you\ want\ to\ change\ the\ type\ of\ all\ these\ to\ '%0'?=Çok sayıda girdi seçili. Tüm bunların türünü '%0'e değiştirmek ister misiniz?
+Changed\ type\ to\ '%0'\ for=Tür '%0'e değiştirildi
+Really\ delete\ the\ selected\ entry?=Gerçekten seçili girdi silinsin mi?
+Really\ delete\ the\ %0\ selected\ entries?=Gerçekten seçili %0 girdi silinsin mi?
+Keep\ merged\ entry\ only=Yalnızca birleşik girdiyi tut
+Keep\ left=Solu tut
+Keep\ right=Sağı tut
+Old\ entry=Eski girdi
+From\ import=İçe almadan
+No\ problems\ found.=Hiçbir sorun bulunmadı.
+%0\ problem(s)\ found=%0 sorun bulundu
+Save\ changes=Değişiklikleri kaydet
+Discard\ changes=Değişiklikleri sil
+Library\ '%0'\ has\ changed.=Veri tabanı '%0' değişti.
+Print\ entry\ preview=Girdi yazdırma önizleme
+Copy\ title=Başlığı kopyala
+Copy\ \\cite{BibTeX\ key}=\\cite{BibTeX anahtarı}'nı kopyala
+Copy\ BibTeX\ key\ and\ title=BibTeX anahtarı ve başlığını kopyala
+File\ rename\ failed\ for\ %0\ entries.=%0 girdide dosya yeniden adlandırma başarısız.
+Merged\ BibTeX\ source\ code=Birleşik BibTeX kaynak kodu
+Invalid\ DOI\:\ '%0'.=Geçersiz DOI: '%0'.
+should\ start\ with\ a\ name=bir isimle başlamalı
+should\ end\ with\ a\ name=bir isimle sonlanmalı
+unexpected\ closing\ curly\ bracket=beklenmeyen küme parantezi kapanışı
+unexpected\ opening\ curly\ bracket=beklenmeyen küme parantezi açılışı
+capital\ letters\ are\ not\ masked\ using\ curly\ brackets\ {}=küme parantezleri {} kullanarak büyük harfler maskelenmez
+should\ contain\ a\ four\ digit\ number=dört basamaklı bir numara içermeli
+should\ contain\ a\ valid\ page\ number\ range=geçerli bir sayfa numarası aralığı içermeli
 Filled=Dolduruldu
-Field_is_missing=Kayıp_alan
-Search_%0=%0'de_ara
+Field\ is\ missing=Kayıp alan
+Search\ %0=%0'de ara
 
-Search_results_in_all_libraries_for_%0=Sonuçları_%0_için_tüm_veritabanlarında_ara
-Search_results_in_library_%0_for_%1=Sonuçları_%1_için_%0_veritabanında_ara
-Search_globally=Küresel_ara
-No_results_found.=Hiçbir_sonuç_bulunmadı.
-Found_%0_results.=%0_sonuç_bulundu.
-plain_text=salt_metin
-This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>=Bu_arama,_<b>%0</b>_düzenli_ifadesini_içeren_herhangi_bir_alan_bulunan_girdileri_içerir
-This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>=Bu_arama,_<b>%0</b>_terimini_içeren_herhangi_bir_alan_bulunan_girdileri_içerir
-This_search_contains_entries_in_which=Bu_arama_içinde_şu_olan_girdileri_içerir
+Search\ results\ in\ all\ libraries\ for\ %0=Sonuçları %0 için tüm veritabanlarında ara
+Search\ results\ in\ library\ %0\ for\ %1=Sonuçları %1 için %0 veritabanında ara
+Search\ globally=Küresel ara
+No\ results\ found.=Hiçbir sonuç bulunmadı.
+Found\ %0\ results.=%0 sonuç bulundu.
+plain\ text=salt metin
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ regular\ expression\ <b>%0</b>=Bu arama, <b>%0</b> düzenli ifadesini içeren herhangi bir alan bulunan girdileri içerir
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ term\ <b>%0</b>=Bu arama, <b>%0</b> terimini içeren herhangi bir alan bulunan girdileri içerir
+This\ search\ contains\ entries\ in\ which=Bu arama içinde şu olan girdileri içerir
 
-Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.=OpenOffice/LibreOffice_kurulumu_otomatik_olarak_bulunamadı._Lütfen_kurulum_dizinini_kendiniz_seçiniz.
-JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>=JabRef_artık_'ps'_ya_da_'pdf!_alanlarını_desteklemiyor._<br>Dosya_bağlantıları_artık_'dosya'_alanında_ve_dosyalar_da_harici_bir_dosya_dizininde_depolanıyor.<br>Bu_özelliği_kullanabilmek_için_JabRef_dosya_bağlantılarını_yükseltmek_zorunda.<br><br>
-This_library_uses_outdated_file_links.=Bu_veri_tabanı_güncelliğini_yitirmiş_dosya_bağlantıları_kullanıyor.
+Unable\ to\ autodetect\ OpenOffice/LibreOffice\ installation.\ Please\ choose\ the\ installation\ directory\ manually.=OpenOffice/LibreOffice kurulumu otomatik olarak bulunamadı. Lütfen kurulum dizinini kendiniz seçiniz.
+JabRef\ no\ longer\ supports\ 'ps'\ or\ 'pdf'\ fields.<br>File\ links\ are\ now\ stored\ in\ the\ 'file'\ field\ and\ files\ are\ stored\ in\ an\ external\ file\ directory.<br>To\ make\ use\ of\ this\ feature,\ JabRef\ needs\ to\ upgrade\ file\ links.<br><br>=JabRef artık 'ps' ya da 'pdf! alanlarını desteklemiyor. <br>Dosya bağlantıları artık 'dosya' alanında ve dosyalar da harici bir dosya dizininde depolanıyor.<br>Bu özelliği kullanabilmek için JabRef dosya bağlantılarını yükseltmek zorunda.<br><br>
+This\ library\ uses\ outdated\ file\ links.=Bu veri tabanı güncelliğini yitirmiş dosya bağlantıları kullanıyor.
 
-Clear_search=Aramayı_temizle
-Close_library=Veri_tabanını_kapat
-Close_entry_editor=Girdi_düzenleyicisini_kapat
-Decrease_table_font_size=Tablo_yazıtipi_boyutunu_azalt
-Entry_editor,_next_entry=Girdi_düzenleyici,_sonraki_girdi
-Entry_editor,_next_panel=Girdi_düzenleyici,_sonraki_panel
-Entry_editor,_next_panel_2=Girdi_düzenleyici,_sonraki_panel_2
-Entry_editor,_previous_entry=Girdi_düzenleyici,_önceki_girdi
-Entry_editor,_previous_panel=Girdi_düzenleyici,_önceki_panel
-Entry_editor,_previous_panel_2=Girdi_düzenleyici,_önceki_panel_2
-File_list_editor,_move_entry_down=Dosya_listesi_düzenleyici,_girdiyi_aşağıya_taşı
-File_list_editor,_move_entry_up=Dosya_listesi_düzenleyici,_girdiyi_yukarıya_taşı
-Focus_entry_table=Girdi_tablosuna_odaklan
-Import_into_current_library=Mevcut_veri_tabanına_aktar
-Import_into_new_library=Yeni_veri_tabanına_aktar
-Increase_table_font_size=Tablo_yazıtipi_boyutunu_arttır
-New_article=Yeni_makale
-New_book=Yeni_kitap
-New_entry=Yeni_girdi
-New_from_plain_text=Yeni_salt_metinden
-New_inbook=Yeni_kitaptan
-New_mastersthesis=Yeni_master_tezi
-New_phdthesis=Yeni_doktora_tezi
-New_proceedings=Yeni_tutanak
-New_unpublished=Yeni_yayınlanmamış
-Next_tab=Yeni_sekme
-Preamble_editor,_store_changes=Giriş_düzenleyici,_dükkan_değişiklikleri
-Previous_tab=Önceki_sekme
-Push_to_application=Uygulamaya_itele
-Refresh_OpenOffice/LibreOffice=Tazele_00
-Resolve_duplicate_BibTeX_keys=Çift_kopyalı_BibTeX_anahtarlarını_çözümle
-Save_all=Tümünü_kaydet
-String_dialog,_add_string=Dizilim_iletişim_kutusu,_dizilim_ekle
-String_dialog,_remove_string=Dizilim_iletişim_kutusu,_dizilim_çıkar
-Synchronize_files=Dosyaları_eşzamanla
-Unabbreviate=Kısaltmayı_kaldır
-should_contain_a_protocol=bir_protokol_içermeli
-Copy_preview=Kopyalama_önizleme
-Automatically_setting_file_links=Dosya_bağlantıları_otomatik_olarak_ayarlanıyor
-Regenerating_BibTeX_keys_according_to_metadata=Üstveri_(metadata)_uyarınca_BibTeX_anahtarları_yeniden_oluşturuluyor
-No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys=Bibdosyasında_üstveri_yok._Bibtex_anahtarları_yeniden_oluşturulamıyor
-Regenerate_all_keys_for_the_entries_in_a_BibTeX_file=Bir_BibTeX_dosyasındaki_tüm_girdiler_için_tüm_anahtarları_yeniden_oluştur
-Show_debug_level_messages=Hata_ayıklama_düzeyi_mesajları_göster
-Default_bibliography_mode=Öntanımlı_bibliyografya_kipi
-New_%0_library_created.=Yeni_%0_veri_tabanı_oluşturuldu.
-Show_only_preferences_deviating_from_their_default_value=Yalnızca_öntanımlı_değerlerinden_sapan_tercihleri_göster
+Clear\ search=Aramayı temizle
+Close\ library=Veri tabanını kapat
+Close\ entry\ editor=Girdi düzenleyicisini kapat
+Decrease\ table\ font\ size=Tablo yazıtipi boyutunu azalt
+Entry\ editor,\ next\ entry=Girdi düzenleyici, sonraki girdi
+Entry\ editor,\ next\ panel=Girdi düzenleyici, sonraki panel
+Entry\ editor,\ next\ panel\ 2=Girdi düzenleyici, sonraki panel 2
+Entry\ editor,\ previous\ entry=Girdi düzenleyici, önceki girdi
+Entry\ editor,\ previous\ panel=Girdi düzenleyici, önceki panel
+Entry\ editor,\ previous\ panel\ 2=Girdi düzenleyici, önceki panel 2
+File\ list\ editor,\ move\ entry\ down=Dosya listesi düzenleyici, girdiyi aşağıya taşı
+File\ list\ editor,\ move\ entry\ up=Dosya listesi düzenleyici, girdiyi yukarıya taşı
+Focus\ entry\ table=Girdi tablosuna odaklan
+Import\ into\ current\ library=Mevcut veri tabanına aktar
+Import\ into\ new\ library=Yeni veri tabanına aktar
+Increase\ table\ font\ size=Tablo yazıtipi boyutunu arttır
+New\ article=Yeni makale
+New\ book=Yeni kitap
+New\ entry=Yeni girdi
+New\ from\ plain\ text=Yeni salt metinden
+New\ inbook=Yeni kitaptan
+New\ mastersthesis=Yeni master tezi
+New\ phdthesis=Yeni doktora tezi
+New\ proceedings=Yeni tutanak
+New\ unpublished=Yeni yayınlanmamış
+Next\ tab=Yeni sekme
+Preamble\ editor,\ store\ changes=Giriş düzenleyici, dükkan değişiklikleri
+Previous\ tab=Önceki sekme
+Push\ to\ application=Uygulamaya itele
+Refresh\ OpenOffice/LibreOffice=Tazele 00
+Resolve\ duplicate\ BibTeX\ keys=Çift kopyalı BibTeX anahtarlarını çözümle
+Save\ all=Tümünü kaydet
+String\ dialog,\ add\ string=Dizilim iletişim kutusu, dizilim ekle
+String\ dialog,\ remove\ string=Dizilim iletişim kutusu, dizilim çıkar
+Synchronize\ files=Dosyaları eşzamanla
+Unabbreviate=Kısaltmayı kaldır
+should\ contain\ a\ protocol=bir protokol içermeli
+Copy\ preview=Kopyalama önizleme
+Automatically\ setting\ file\ links=Dosya bağlantıları otomatik olarak ayarlanıyor
+Regenerating\ BibTeX\ keys\ according\ to\ metadata=Üstveri (metadata) uyarınca BibTeX anahtarları yeniden oluşturuluyor
+No\ meta\ data\ present\ in\ BIB\ file.\ Cannot\ regenerate\ BibTeX\ keys=Bibdosyasında üstveri yok. Bibtex anahtarları yeniden oluşturulamıyor
+Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=Bir BibTeX dosyasındaki tüm girdiler için tüm anahtarları yeniden oluştur
+Show\ debug\ level\ messages=Hata ayıklama düzeyi mesajları göster
+Default\ bibliography\ mode=Öntanımlı bibliyografya kipi
+New\ %0\ library\ created.=Yeni %0 veri tabanı oluşturuldu.
+Show\ only\ preferences\ deviating\ from\ their\ default\ value=Yalnızca öntanımlı değerlerinden sapan tercihleri göster
 default=öntanımlı
 key=anahtar
 type=tür
 value=değer
-Show_preferences=Tercihleri_göster
-Save_actions=Eylemleri_kaydet
-Enable_save_actions=Eylemleri_kaydetmeyi_etkinleştir
+Show\ preferences=Tercihleri göster
+Save\ actions=Eylemleri kaydet
+Enable\ save\ actions=Eylemleri kaydetmeyi etkinleştir
 
-Other_fields=Diğer_alanlar
-Show_remaining_fields=Kalan_alanları_göster
+Other\ fields=Diğer alanlar
+Show\ remaining\ fields=Kalan alanları göster
 
-link_should_refer_to_a_correct_file_path=bağlantı_doğru_bir_dosya_yolunu_işaret_etmeli
-abbreviation_detected=kısaltma_saptandı
-wrong_entry_type_as_proceedings_has_page_numbers=yanlış_girdi_türü_zira_tutanaklarda_sayfa_numarası_olur
-Abbreviate_journal_names=Dergi_adlarını_kısalt
+link\ should\ refer\ to\ a\ correct\ file\ path=bağlantı doğru bir dosya yolunu işaret etmeli
+abbreviation\ detected=kısaltma saptandı
+wrong\ entry\ type\ as\ proceedings\ has\ page\ numbers=yanlış girdi türü zira tutanaklarda sayfa numarası olur
+Abbreviate\ journal\ names=Dergi adlarını kısalt
 Abbreviating...=Kısaltılıyor...
-Abbreviation_%s_for_journal_%s_already_defined.=%2$s_dergisi_için_%1$s_kısaltması_zaten_tanımlanmış.
-Abbreviation_cannot_be_empty=Kısaltma_boş_olamaz
-Duplicated_Journal_Abbreviation=Çifte_Dergi_Kısaltması
-Duplicated_Journal_File=Çifte_Dergi_Dosyası
-Error_Occurred=Hata_Oluştu
-Journal_file_%s_already_added=%s_dergi_dosyası_zaten_eklendi
-Name_cannot_be_empty=İsim_boş_olamaz
+Abbreviation\ %s\ for\ journal\ %s\ already\ defined.=%2$s dergisi için %1$s kısaltması zaten tanımlanmış.
+Abbreviation\ cannot\ be\ empty=Kısaltma boş olamaz
+Duplicated\ Journal\ Abbreviation=Çifte Dergi Kısaltması
+Duplicated\ Journal\ File=Çifte Dergi Dosyası
+Error\ Occurred=Hata Oluştu
+Journal\ file\ %s\ already\ added=%s dergi dosyası zaten eklendi
+Name\ cannot\ be\ empty=İsim boş olamaz
 
-Adding_fetched_entries=Getirilen_girdiler_ekleniyor
-Display_keywords_appearing_in_ALL_entries=TÜM_girdilerde_görünen_anahtar_sözcükleri_göster
-Display_keywords_appearing_in_ANY_entry=HERHANGİ_BİR_girdide_görünen_anahtar_sözcükleri_göster
-Fetching_entries_from_Inspire=Girdiler_Inspire'dan_getiriliyor
-None_of_the_selected_entries_have_titles.=Seçili_girdilerin_hiç_birinde_başlık_yok.
-None_of_the_selected_entries_have_BibTeX_keys.=Seçili_girdilerin_hiçbirinde_BibTeX_anahtarı_yok.
-Unabbreviate_journal_names=Dergi_adları_kısaltmalarını_dönüştür
-Unabbreviating...=Kısaltmalar_dönüştürülüyor...
+Adding\ fetched\ entries=Getirilen girdiler ekleniyor
+Display\ keywords\ appearing\ in\ ALL\ entries=TÜM girdilerde görünen anahtar sözcükleri göster
+Display\ keywords\ appearing\ in\ ANY\ entry=HERHANGİ BİR girdide görünen anahtar sözcükleri göster
+Fetching\ entries\ from\ Inspire=Girdiler Inspire'dan getiriliyor
+None\ of\ the\ selected\ entries\ have\ titles.=Seçili girdilerin hiç birinde başlık yok.
+None\ of\ the\ selected\ entries\ have\ BibTeX\ keys.=Seçili girdilerin hiçbirinde BibTeX anahtarı yok.
+Unabbreviate\ journal\ names=Dergi adları kısaltmalarını dönüştür
+Unabbreviating...=Kısaltmalar dönüştürülüyor...
 Usage=Kullanım
 
 
-Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.=Harf_çeşidini_(büyük/küçük)_korumak_için_%lerin_içindeki_akronim,_ay_adları_ve_ülkelerin_çevresine_küme_parantezi_ekle.
-Are_you_sure_you_want_to_reset_all_settings_to_default_values?=Tüm_ayarları_öntanımlı_değerlere_dönüştürmek_istediğinizden_emin_misiniz?
-Reset_preferences=Tercihleri_sıfırla
-Ill-formed_entrytype_comment_in_BIB_file=Bib_dosyasında_kötü_biçimli_girdi_türü_yorumu
+Adds\ {}\ brackets\ around\ acronyms,\ month\ names\ and\ countries\ to\ preserve\ their\ case.=Harf çeşidini (büyük/küçük) korumak için %lerin içindeki akronim, ay adları ve ülkelerin çevresine küme parantezi ekle.
+Are\ you\ sure\ you\ want\ to\ reset\ all\ settings\ to\ default\ values?=Tüm ayarları öntanımlı değerlere dönüştürmek istediğinizden emin misiniz?
+Reset\ preferences=Tercihleri sıfırla
+Ill-formed\ entrytype\ comment\ in\ BIB\ file=Bib dosyasında kötü biçimli girdi türü yorumu
 
-Move_linked_files_to_default_file_directory_%0=Bağlantılı_dosyaları_öntanımlı_dosya_dizinine_aktar_%0
+Move\ linked\ files\ to\ default\ file\ directory\ %0=Bağlantılı dosyaları öntanımlı dosya dizinine aktar %0
 
 Clipboard=Pano
-Could_not_paste_entry_as_text\:=Girdi_metin_olarak_yapıştırılamıyor\:
-Do_you_still_want_to_continue?=Hala_devam_etmek_istiyor_musunuz?
-This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:=Bu_eylem_aşağıdaki_alanları_en_az_bir_girdide_değiştirecek\:
-This_could_cause_undesired_changes_to_your_entries.=Bu,_girdilerinizde_istenmeyen_değişikliklere_yol_açabilir.
-Run_field_formatter\:=Alan_biçimlendiriciyi_çalıştır\:
-Table_font_size_is_%0=Tablo_yazıtipi_boyutu_%0'dır
-%0_import_canceled=%0_içe_aktarımı_iptal_edildi
-Internal_style=Dahili_stil
-Add_style_file=Stil_dosyası_ekle
-Are_you_sure_you_want_to_remove_the_style?=Stili_silmek_istediğinizden_emin_misiniz?
-Current_style_is_'%0'=Mevcut_stil_'%0'dır
-Remove_style=Stili_sil
-Select_one_of_the_available_styles_or_add_a_style_file_from_disk.=Mevcut_stillerden_birini_seçin_ya_da_sürücüden_stil_dosyası_ekleyin.
-You_must_select_a_valid_style_file.=Geçerli_bir_stil_dosyası_seçmelisiniz.
-Reload=Yeniden_yükle
+Could\ not\ paste\ entry\ as\ text\:=Girdi metin olarak yapıştırılamıyor:
+Do\ you\ still\ want\ to\ continue?=Hala devam etmek istiyor musunuz?
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=Bu eylem aşağıdaki alanları en az bir girdide değiştirecek:
+This\ could\ cause\ undesired\ changes\ to\ your\ entries.=Bu, girdilerinizde istenmeyen değişikliklere yol açabilir.
+Run\ field\ formatter\:=Alan biçimlendiriciyi çalıştır:
+Table\ font\ size\ is\ %0=Tablo yazıtipi boyutu %0'dır
+%0\ import\ canceled=%0 içe aktarımı iptal edildi
+Internal\ style=Dahili stil
+Add\ style\ file=Stil dosyası ekle
+Are\ you\ sure\ you\ want\ to\ remove\ the\ style?=Stili silmek istediğinizden emin misiniz?
+Current\ style\ is\ '%0'=Mevcut stil '%0'dır
+Remove\ style=Stili sil
+Select\ one\ of\ the\ available\ styles\ or\ add\ a\ style\ file\ from\ disk.=Mevcut stillerden birini seçin ya da sürücüden stil dosyası ekleyin.
+You\ must\ select\ a\ valid\ style\ file.=Geçerli bir stil dosyası seçmelisiniz.
+Reload=Yeniden yükle
 
-Capitalize=Büyük_harfe_dönüştür
-Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.=Tüm_sözcükleri_büyük_harfe_dönüştür_ama_artikel,_edat_ve_bağlaçları_küçük_harfe_dönüştür.
-Capitalize_the_first_word,_changes_other_words_to_lower_case.=İlk_sözcüğü_büyük_harfe,_diğer_tüm_sözcükleri_küçük_harfe_deönüştür.
-Changes_all_letters_to_lower_case.=Tüm_harfleri_küçük_harfe_dönüştür.
-Changes_all_letters_to_upper_case.=Tüm_harfleri_büyük_harfe_dönüştür.
-Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.=Tüm_sözcüklerin_ilk_harfini_büyük_harfe,_diğer_tüm_harflerini_küçük_harfe_dönüştür.
-Cleans_up_LaTeX_code.=LaTeX_kodunu_temizler.
-Converts_HTML_code_to_LaTeX_code.=HTML_kodunu_LaTeX_koduna_dönüştürür.
-Converts_HTML_code_to_Unicode.=HTML_kodunu_Unicode'a_dönüştürür.
-Converts_LaTeX_encoding_to_Unicode_characters.=LaTeX_kodunu_Unicode_karakterlerine_dönüştürür.
-Converts_Unicode_characters_to_LaTeX_encoding.=Unicode_karakterlerini_LaTeX_koduna_dönüştürür.
-Converts_ordinals_to_LaTeX_superscripts.=Sıra_sayılarını_LaTeX_üstyazılarına_dönüştürür.
-Converts_units_to_LaTeX_formatting.=%lerin_içindeki_birimleri_LaTeX_koduna_dönüştürür.
-HTML_to_LaTeX=HTML'den_LaTeX'e
-LaTeX_cleanup=LaTeX_temizleme
-LaTeX_to_Unicode=LaTeX'ten_Unicode'a
-Lower_case=Küçük_harf
-Minify_list_of_person_names=Kişi_adları_listesini_küçült
-Normalize_date=Günü_normalleştir
-Normalize_month=Ayı_normalleştir
-Normalize_month_to_BibTeX_standard_abbreviation.=Ayı_BibTeX_standart_kısaltmasına_normalleştir
-Normalize_names_of_persons=Kişi_adlarını_normalleştir
-Normalize_page_numbers=Sayfa_numaralarını_normalleştir
-Normalize_pages_to_BibTeX_standard.=Sayfaları_BibTeX_standardına_normalleştir.
-Normalizes_lists_of_persons_to_the_BibTeX_standard.=Kişi_listelerini_BibTeX_standardına_normalleştirir.
-Normalizes_the_date_to_ISO_date_format.=Günü,_ISO_gün_biçemine_normalleştirir.
-Ordinals_to_LaTeX_superscript=Sıra_sayılarını_LaTeX_üstyazısına
-Protect_terms=Proje_koşulları
-Remove_enclosing_braces=Çevreleyen_küme_parantezlerini_kaldır
-Removes_braces_encapsulating_the_complete_field_content.=Tüm_alan_içeriğini_kapsayan_küme_parantezlerini_kaldırır.
-Sentence_case=Cümle_(harf)_şekli
-Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".=Kişi_listelerini,_eğer_2_kişiden_fazlaysa_"et_al."a_kısaltır.
-Title_case=Başlık_(harf)_şekli
-Unicode_to_LaTeX=Unicode'dan_LaTeX'e
-Units_to_LaTeX=Birimler'den_LaTeX'e
-Upper_case=Büyük_harf
-Does_nothing.=Hiçbir_şey_yapmaz.
+Capitalize=Büyük harfe dönüştür
+Capitalize\ all\ words,\ but\ converts\ articles,\ prepositions,\ and\ conjunctions\ to\ lower\ case.=Tüm sözcükleri büyük harfe dönüştür ama artikel, edat ve bağlaçları küçük harfe dönüştür.
+Capitalize\ the\ first\ word,\ changes\ other\ words\ to\ lower\ case.=İlk sözcüğü büyük harfe, diğer tüm sözcükleri küçük harfe deönüştür.
+Changes\ all\ letters\ to\ lower\ case.=Tüm harfleri küçük harfe dönüştür.
+Changes\ all\ letters\ to\ upper\ case.=Tüm harfleri büyük harfe dönüştür.
+Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=Tüm sözcüklerin ilk harfini büyük harfe, diğer tüm harflerini küçük harfe dönüştür.
+Cleans\ up\ LaTeX\ code.=LaTeX kodunu temizler.
+Converts\ HTML\ code\ to\ LaTeX\ code.=HTML kodunu LaTeX koduna dönüştürür.
+Converts\ HTML\ code\ to\ Unicode.=HTML kodunu Unicode'a dönüştürür.
+Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=LaTeX kodunu Unicode karakterlerine dönüştürür.
+Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=Unicode karakterlerini LaTeX koduna dönüştürür.
+Converts\ ordinals\ to\ LaTeX\ superscripts.=Sıra sayılarını LaTeX üstyazılarına dönüştürür.
+Converts\ units\ to\ LaTeX\ formatting.=%lerin içindeki birimleri LaTeX koduna dönüştürür.
+HTML\ to\ LaTeX=HTML'den LaTeX'e
+LaTeX\ cleanup=LaTeX temizleme
+LaTeX\ to\ Unicode=LaTeX'ten Unicode'a
+Lower\ case=Küçük harf
+Minify\ list\ of\ person\ names=Kişi adları listesini küçült
+Normalize\ date=Günü normalleştir
+Normalize\ month=Ayı normalleştir
+Normalize\ month\ to\ BibTeX\ standard\ abbreviation.=Ayı BibTeX standart kısaltmasına normalleştir
+Normalize\ names\ of\ persons=Kişi adlarını normalleştir
+Normalize\ page\ numbers=Sayfa numaralarını normalleştir
+Normalize\ pages\ to\ BibTeX\ standard.=Sayfaları BibTeX standardına normalleştir.
+Normalizes\ lists\ of\ persons\ to\ the\ BibTeX\ standard.=Kişi listelerini BibTeX standardına normalleştirir.
+Normalizes\ the\ date\ to\ ISO\ date\ format.=Günü, ISO gün biçemine normalleştirir.
+Ordinals\ to\ LaTeX\ superscript=Sıra sayılarını LaTeX üstyazısına
+Protect\ terms=Proje koşulları
+Remove\ enclosing\ braces=Çevreleyen küme parantezlerini kaldır
+Removes\ braces\ encapsulating\ the\ complete\ field\ content.=Tüm alan içeriğini kapsayan küme parantezlerini kaldırır.
+Sentence\ case=Cümle (harf) şekli
+Shortens\ lists\ of\ persons\ if\ there\ are\ more\ than\ 2\ persons\ to\ "et\ al.".=Kişi listelerini, eğer 2 kişiden fazlaysa "et al."a kısaltır.
+Title\ case=Başlık (harf) şekli
+Unicode\ to\ LaTeX=Unicode'dan LaTeX'e
+Units\ to\ LaTeX=Birimler'den LaTeX'e
+Upper\ case=Büyük harf
+Does\ nothing.=Hiçbir şey yapmaz.
 Identity=Kimlik
-Clears_the_field_completely.=Alanı_tamamen_temizler.
-Directory_not_found=Dizin_bulunamadı
-Main_file_directory_not_set\!=Ana_dosya_dizini_belirlenmedi\!
-This_operation_requires_exactly_one_item_to_be_selected.=Bu_işlem_tam_olarak_bir_ögenin_seçilmesini_gerektirir.
-Importing_in_%0_format=%0_biçeminde_içe_aktarılıyor
-Female_name=Dişil_ad
-Female_names=Dişil_adlar
-Male_name=Eril_ad
-Male_names=Eril_adlar
-Mixed_names=Karışık_adlar
-Neuter_name=Cinsiyetsiz_ad
-Neuter_names=Cinsiyetsiz_adlar
+Clears\ the\ field\ completely.=Alanı tamamen temizler.
+Directory\ not\ found=Dizin bulunamadı
+Main\ file\ directory\ not\ set\!=Ana dosya dizini belirlenmedi!
+This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=Bu işlem tam olarak bir ögenin seçilmesini gerektirir.
+Importing\ in\ %0\ format=%0 biçeminde içe aktarılıyor
+Female\ name=Dişil ad
+Female\ names=Dişil adlar
+Male\ name=Eril ad
+Male\ names=Eril adlar
+Mixed\ names=Karışık adlar
+Neuter\ name=Cinsiyetsiz ad
+Neuter\ names=Cinsiyetsiz adlar
 
-Determined_%0_for_%1_entries=%1_girdi_için_%0_belirlendi
-Look_up_%0=%0'ı_ara
-Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3=%0_aranıyor..._-_%2_girdiden_%1'i_-_bulunan_%3
+Determined\ %0\ for\ %1\ entries=%1 girdi için %0 belirlendi
+Look\ up\ %0=%0'ı ara
+Looking\ up\ %0...\ -\ entry\ %1\ out\ of\ %2\ -\ found\ %3=%0 aranıyor... - %2 girdiden %1'i - bulunan %3
 
-Audio_CD=Müzik_CDsi
-British_patent=İngiliz_patenti
-British_patent_request=İngiliz_patent_başvurusu
-Candidate_thesis=Aday_tezi
+Audio\ CD=Müzik CDsi
+British\ patent=İngiliz patenti
+British\ patent\ request=İngiliz patent başvurusu
+Candidate\ thesis=Aday tezi
 Collaborator=İşbirlikçi
 Column=Sütun
 Compiler=Derleyici
-Continuator=Devam_ettirici
-Data_CD=Veri_CDsi
+Continuator=Devam ettirici
+Data\ CD=Veri CDsi
 Editor=Editör
-European_patent=Avrupa_patenti
-European_patent_request=Avrupa_patent_başvurusu
+European\ patent=Avrupa patenti
+European\ patent\ request=Avrupa patent başvurusu
 Founder=Kurucu
-French_patent=Fransız_patenti
-French_patent_request=Fransız_patent_başvurusu
-German_patent=Alman_patenti
-German_patent_request=Alman_patent_başvurusu
+French\ patent=Fransız patenti
+French\ patent\ request=Fransız patent başvurusu
+German\ patent=Alman patenti
+German\ patent\ request=Alman patent başvurusu
 Line=Satır
-Master's_thesis=Master_tezi
+Master's\ thesis=Master tezi
 Page=Sayfa
 Paragraph=Paragraf
 Patent=Patent
-Patent_request=Patent_başvurusu
-PhD_thesis=Doktora_tezi
+Patent\ request=Patent başvurusu
+PhD\ thesis=Doktora tezi
 Redactor=Redaktör
-Research_report=Araştırma_raporu
+Research\ report=Araştırma raporu
 Reviser=Revizör
 Section=Bölüm
 Software=Yazılım
-Technical_report=Teknik_rapor
-U.S._patent=B.D._patenti
-U.S._patent_request=B.D._patent_başvurusu
+Technical\ report=Teknik rapor
+U.S.\ patent=B.D. patenti
+U.S.\ patent\ request=B.D. patent başvurusu
 Verse=Dize
 
-change_entries_of_group=grubun_girdilerini_değiştir
-odd_number_of_unescaped_'\#'=tek_sayılı_öncelenmemiş_'\#'
+change\ entries\ of\ group=grubun girdilerini değiştir
+odd\ number\ of\ unescaped\ '\#'=tek sayılı öncelenmemiş '#'
 
-Plain_text=Salt_metin
-Show_diff=Diff_göster
+Plain\ text=Salt metin
+Show\ diff=Diff göster
 character=karakter
 word=sözcük
-Show_symmetric_diff=Simetrik_diff_göster
-Copy_Version=Sürümü_Kopyala
+Show\ symmetric\ diff=Simetrik diff göster
+Copy\ Version=Sürümü Kopyala
 Developers=Geliştiriciler
 Authors=Yazarlar
 License=Lisans
 
-HTML_encoded_character_found=HTML_kodlu_karakter_bulundu
-booktitle_ends_with_'conference_on'=kitap_başlığı_'konudaki_konferans'_ile_bitiyor
+HTML\ encoded\ character\ found=HTML kodlu karakter bulundu
+booktitle\ ends\ with\ 'conference\ on'=kitap başlığı 'konudaki konferans' ile bitiyor
 
-All_external_files=Tüm_harici_dosyalar
+All\ external\ files=Tüm harici dosyalar
 
-OpenOffice/LibreOffice_integration=OpenOffice/LibreOffice_entegrasyonu
+OpenOffice/LibreOffice\ integration=OpenOffice/LibreOffice entegrasyonu
 
-incorrect_control_digit=yanlış_kontrol_numarası
-incorrect_format=yanlış_biçem
-Copied_version_to_clipboard=Sürüm_panoya_kopyalandı
+incorrect\ control\ digit=yanlış kontrol numarası
+incorrect\ format=yanlış biçem
+Copied\ version\ to\ clipboard=Sürüm panoya kopyalandı
 
-BibTeX_key=BibTeX_anahtarı
+BibTeX\ key=BibTeX anahtarı
 Message=Mesaj
 
 
-MathSciNet_Review=MathSciNet_Review
-Reset_Bindings=Bağlantıları_Sıfırla
+MathSciNet\ Review=MathSciNet Review
+Reset\ Bindings=Bağlantıları Sıfırla
 
-Decryption_not_supported.=Şifre_çözme_desteklenmiyor.
+Decryption\ not\ supported.=Şifre çözme desteklenmiyor.
 
-Cleared_'%0'_for_%1_entries=%1_girdi_için_%0_temizlendi
-Set_'%0'_to_'%1'_for_%2_entries=%2_girdiler_için_'%0'_'%1'a_ata
-Toggled_'%0'_for_%1_entries=%1_girdiler_için_'%0'_değiştirildi
+Cleared\ '%0'\ for\ %1\ entries=%1 girdi için %0 temizlendi
+Set\ '%0'\ to\ '%1'\ for\ %2\ entries=%2 girdiler için '%0' '%1'a ata
+Toggled\ '%0'\ for\ %1\ entries=%1 girdiler için '%0' değiştirildi
 
-Check_for_updates=Güncellemeleri_kontrol_et
-Download_update=Güncellemeyi_indir
-New_version_available=Yeni_sürüm_mevcut
-Installed_version=Kurulu_sürüm
-Remind_me_later=Daha_sonra_hatırlat
-Ignore_this_update=Bu_güncellemeyi_yoksay
-Could_not_connect_to_the_update_server.=Güncelleme_sunucusuna_bağlanılamıyor.
-Please_try_again_later_and/or_check_your_network_connection.=Lütfen_daha_sonra_deneyin_ve/veya_ağ_bağlantınızı_kontrol_edin.
-To_see_what_is_new_view_the_changelog.=Yenilikleri_görmek_için_değişiklik_kütüğüne_bakın.
-A_new_version_of_JabRef_has_been_released.=JabRef'in_yeni_bir_sürümü_yayınlandı.
-JabRef_is_up-to-date.=JabRef_güncel.
-Latest_version=En_son_sürüm
-Online_help_forum=Çevrimiçi_yardım_forumu
+Check\ for\ updates=Güncellemeleri kontrol et
+Download\ update=Güncellemeyi indir
+New\ version\ available=Yeni sürüm mevcut
+Installed\ version=Kurulu sürüm
+Remind\ me\ later=Daha sonra hatırlat
+Ignore\ this\ update=Bu güncellemeyi yoksay
+Could\ not\ connect\ to\ the\ update\ server.=Güncelleme sunucusuna bağlanılamıyor.
+Please\ try\ again\ later\ and/or\ check\ your\ network\ connection.=Lütfen daha sonra deneyin ve/veya ağ bağlantınızı kontrol edin.
+To\ see\ what\ is\ new\ view\ the\ changelog.=Yenilikleri görmek için değişiklik kütüğüne bakın.
+A\ new\ version\ of\ JabRef\ has\ been\ released.=JabRef'in yeni bir sürümü yayınlandı.
+JabRef\ is\ up-to-date.=JabRef güncel.
+Latest\ version=En son sürüm
+Online\ help\ forum=Çevrimiçi yardım forumu
 Custom=Özel
 
-Export_cited=Başvurulanları_dışa_aktar
-Unable_to_generate_new_library=Yeni_veritabanı_oluşturulamadı
+Export\ cited=Başvurulanları dışa aktar
+Unable\ to\ generate\ new\ library=Yeni veritabanı oluşturulamadı
 
-Open_console=Konsolu_aç
-Use_default_terminal_emulator=Öntanımlı_uçbirim_öykünücüsünü_kullan
-Execute_command=Komutu_çalıştır
-Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.=Not\:Açık_veritabanının_konumu_için_%0_yer_tutucusunu_kullan.
-Executing_command_\"%0\"...=\"%0\"_komutu_çalıştırılıyor...
-Error_occured_while_executing_the_command_\"%0\".=\"%0\"_komutu_çalıştırılırken_hata_oluştu.
-Reformat_ISSN=ISSN'i_yeniden_biçimlendir
+Open\ console=Konsolu aç
+Use\ default\ terminal\ emulator=Öntanımlı uçbirim öykünücüsünü kullan
+Execute\ command=Komutu çalıştır
+Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=Not:Açık veritabanının konumu için %0 yer tutucusunu kullan.
+Executing\ command\ \"%0\"...=\"%0\" komutu çalıştırılıyor...
+Error\ occured\ while\ executing\ the\ command\ \"%0\".=\"%0\" komutu çalıştırılırken hata oluştu.
+Reformat\ ISSN=ISSN'i yeniden biçimlendir
 
-Countries_and_territories_in_English=Ülke_ve_bölgeler_İngilizce
-Electrical_engineering_terms=Elektrik_mühendisliği_terimleri
+Countries\ and\ territories\ in\ English=Ülke ve bölgeler İngilizce
+Electrical\ engineering\ terms=Elektrik mühendisliği terimleri
 Enabled=Aktifleştirildi
-Internal_list=Dahili_liste
-Manage_protected_terms_files=Korunmuş_terimler_dosyasını_yönet
-Months_and_weekdays_in_English=Ay_ve_haftanın_günleri_İngilizce
-The_text_after_the_last_line_starting_with_\#_will_be_used=\#_ile_başlayan_son_satırdan_sonraki_metin_kullanılacak
-Add_protected_terms_file=Korunmuş_terimler_dosyası_ekle
-Are_you_sure_you_want_to_remove_the_protected_terms_file?=Korunmuş_terimler_dosyasını_silmek_istediğinizden_emin_misiniz?
-Remove_protected_terms_file=Korunmuş_terimler_dosyasını_sil
-Add_selected_text_to_list=Seçili_metni_listeye_ekle
-Add_{}_around_selected_text=Seçili_metnin_çevresine_{}_ekle
-Format_field=Alanı_biçimle
-New_protected_terms_file=Yeni_korunmuş_terimler_dosyası
-change_field_%0_of_entry_%1_from_%2_to_%3=%1_girdisinin_%0_alanını_%2'den_%3'e_değiştir
-change_key_from_%0_to_%1=anahtarı_%0'dan_%1'e_değiştir
-change_string_content_%0_to_%1=dizge_içeriğini_%0'dan_%1'e_değiştir
-change_string_name_%0_to_%1=dizge_adını_%0'dan_%1'e_değiştir
-change_type_of_entry_%0_from_%1_to_%2=girdi_türünü_%0'dan_%1'e_değiştir
-insert_entry_%0=%0_girdisini_ekle
-insert_string_%0=%0_dizgesini_ekle
-remove_entry_%0=%0_girdisini_sil
-remove_string_%0=%0_dizgesini_sil
+Internal\ list=Dahili liste
+Manage\ protected\ terms\ files=Korunmuş terimler dosyasını yönet
+Months\ and\ weekdays\ in\ English=Ay ve haftanın günleri İngilizce
+The\ text\ after\ the\ last\ line\ starting\ with\ \#\ will\ be\ used=# ile başlayan son satırdan sonraki metin kullanılacak
+Add\ protected\ terms\ file=Korunmuş terimler dosyası ekle
+Are\ you\ sure\ you\ want\ to\ remove\ the\ protected\ terms\ file?=Korunmuş terimler dosyasını silmek istediğinizden emin misiniz?
+Remove\ protected\ terms\ file=Korunmuş terimler dosyasını sil
+Add\ selected\ text\ to\ list=Seçili metni listeye ekle
+Add\ {}\ around\ selected\ text=Seçili metnin çevresine {} ekle
+Format\ field=Alanı biçimle
+New\ protected\ terms\ file=Yeni korunmuş terimler dosyası
+change\ field\ %0\ of\ entry\ %1\ from\ %2\ to\ %3=%1 girdisinin %0 alanını %2'den %3'e değiştir
+change\ key\ from\ %0\ to\ %1=anahtarı %0'dan %1'e değiştir
+change\ string\ content\ %0\ to\ %1=dizge içeriğini %0'dan %1'e değiştir
+change\ string\ name\ %0\ to\ %1=dizge adını %0'dan %1'e değiştir
+change\ type\ of\ entry\ %0\ from\ %1\ to\ %2=girdi türünü %0'dan %1'e değiştir
+insert\ entry\ %0=%0 girdisini ekle
+insert\ string\ %0=%0 dizgesini ekle
+remove\ entry\ %0=%0 girdisini sil
+remove\ string\ %0=%0 dizgesini sil
 undefined=tanımlanmamış
-Cannot_get_info_based_on_given_%0\:_%1=Verilen_%0\:_%1'e_göre_bilgi_alınamıyor
-Get_BibTeX_data_from_%0=%0'den_BibTeX_verisini_al
-No_%0_found=_%0_bulunamadi
-Entry_from_%0=%0'den_girdi
-Merge_entry_with_%0_information=%0_bilgisiyle_girdiyi_birleştir
-Updated_entry_with_info_from_%0=%0'den_edinilen_bilgiyle_girdi_güncellendi
+Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=Verilen %0: %1'e göre bilgi alınamıyor
+Get\ BibTeX\ data\ from\ %0=%0'den BibTeX verisini al
+No\ %0\ found= %0 bulunamadi
+Entry\ from\ %0=%0'den girdi
+Merge\ entry\ with\ %0\ information=%0 bilgisiyle girdiyi birleştir
+Updated\ entry\ with\ info\ from\ %0=%0'den edinilen bilgiyle girdi güncellendi
 
-Add_existing_file=Var_olan_dosyayı_ekle
-Create_new_list=Yeni_liste_oluştur
-Remove_list=Listeyi_sil
-Full_journal_name=Tam_dergi_adı
-Abbreviation_name=Kısaltma_adı
+Add\ existing\ file=Var olan dosyayı ekle
+Create\ new\ list=Yeni liste oluştur
+Remove\ list=Listeyi sil
+Full\ journal\ name=Tam dergi adı
+Abbreviation\ name=Kısaltma adı
 
-No_abbreviation_files_loaded=Hiç_kısaltma_dosyası_yüklenmedi
+No\ abbreviation\ files\ loaded=Hiç kısaltma dosyası yüklenmedi
 
-Loading_built_in_lists=Yerleşik_listeler_yükleniyor
+Loading\ built\ in\ lists=Yerleşik listeler yükleniyor
 
-JabRef_built_in_list=JabRef_yerleşik_listesi
-IEEE_built_in_list=IEEE_yerleşik_listesi
+JabRef\ built\ in\ list=JabRef yerleşik listesi
+IEEE\ built\ in\ list=IEEE yerleşik listesi
 
-Event_log=Olay_kayıt_dosyası
-We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.=Biz_şimdi_size_JabRef\'in_iç_çalışma_düzeneği_hakkında_içgörü_veriyoruz._Bu_bilgi_bir_sorunun_temel_nedenini_tanımada_yararlı_olabilir._Lütfen_bir_sorun_hakkında_geliştiricileri_bilgilendirmekten_çekinmeyin.
-Log_copied_to_clipboard.=Kayıt_dosyası_panoya_kopyalandı.
-Copy_Log=Kayıt_Dosyasını_Kopyala
-Clear_Log=Kayıt_Dosyasını_Temizle
-Report_Issue=Sorun_Bildir
-Issue_on_GitHub_successfully_reported.=GitHub\'daki_sorun_başarıyla_rapor_edildi.
-Issue_report_successful=Sorun_raporu_başarılı
-Your_issue_was_reported_in_your_browser.=Sorununuz_tarayıcınızda_rapor_edildi.
-The_log_and_exception_information_was_copied_to_your_clipboard.=Kayıt_dosyası_ve_istisna_bilgisi_panonuza_kopyalandı.
-Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.=Lütfen_bu_bilgiyi_sorun_tarifine_(Ctrl+V_ile)_yapıştırın.
+Event\ log=Olay kayıt dosyası
+We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef\'s\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=Biz şimdi size JabRef\'in iç çalışma düzeneği hakkında içgörü veriyoruz. Bu bilgi bir sorunun temel nedenini tanımada yararlı olabilir. Lütfen bir sorun hakkında geliştiricileri bilgilendirmekten çekinmeyin.
+Log\ copied\ to\ clipboard.=Kayıt dosyası panoya kopyalandı.
+Copy\ Log=Kayıt Dosyasını Kopyala
+Clear\ Log=Kayıt Dosyasını Temizle
+Report\ Issue=Sorun Bildir
+Issue\ on\ GitHub\ successfully\ reported.=GitHub\'daki sorun başarıyla rapor edildi.
+Issue\ report\ successful=Sorun raporu başarılı
+Your\ issue\ was\ reported\ in\ your\ browser.=Sorununuz tarayıcınızda rapor edildi.
+The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=Kayıt dosyası ve istisna bilgisi panonuza kopyalandı.
+Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=Lütfen bu bilgiyi sorun tarifine (Ctrl+V ile) yapıştırın.
 
 Connection=Bağlantı
 Connecting...=Bağlanıyor...
 Host=Makine
-Port=Bağlantı_noktası
+Port=Bağlantı noktası
 Library=Veritabanı
 User=Kullanıcı
 Connect=Bağlan
-Connection_error=Bağlantı_hatası
-Connection_to_%0_server_established.=%0_sunucusuna_bağlantı_sağlandı
-Required_field_"%0"_is_empty.=Gerekli_alan_"%0"_boş.
-%0_driver_not_available.=%0_sürücüsü_yok
-The_connection_to_the_server_has_been_terminated.=Sunucuyla_olan_bağlantı_sonlandırıldı.
-Connection_lost.=Bağlantı_koptu.
-Reconnect=Yeniden_bağlan
-Work_offline=Çevrimdışı_çalış
-Working_offline.=Çevrimdışı_çalışılıyor.
-Update_refused.=Güncelleme_reddedildi.
-Update_refused=Güncelleme_reddedildi
-Local_entry=Yerel_girdi
-Shared_entry=Paylaşılmış_girdi
-Update_could_not_be_performed_due_to_existing_change_conflicts.=Mevcut_değişiklik_çelişkileri_nedeniyle_güncelleme_yapılamadı.
-You_are_not_working_on_the_newest_version_of_BibEntry.=BibEntry'nin_en_son_sürümünde_çalışmıyorsunuz.
-Local_version\:_%0=Yerel_sürüm\:_%0
-Shared_version\:_%0=Paylaşılmış_sürüm\:_%0
-Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.=Bu_sorunu_çözmek_için_lütfen_paylaşılmış_girdiyle_sizinkini_birleştirin_ve_"Girdileri_birleştir"'e_basın.
-Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?=Bu_işlemi_iptal_etmek_değişkliklerinizi_eşzamanlanmamış_halde_bırakacak._Yine_de_iptal_edilsin_mi?
-Shared_entry_is_no_longer_present=Paylaşılmış_girdi_artık_mevcut_değil
-The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.=Üzerinde_çalıştığınız_BibEntry_paylaşılmış_tarafta_silindi.
-You_can_restore_the_entry_using_the_"Undo"_operation.="Geri_al"_işlemiyle_girdiyi_restore_edebilirsiniz.
-Remember_password?=Parola_hatırlansın_mı?
-You_are_already_connected_to_a_database_using_entered_connection_details.=Girilmiş_bağlantı_ayarlarıyla_bir_veritabanına_zaten_bağlısınız.
+Connection\ error=Bağlantı hatası
+Connection\ to\ %0\ server\ established.=%0 sunucusuna bağlantı sağlandı
+Required\ field\ "%0"\ is\ empty.=Gerekli alan "%0" boş.
+%0\ driver\ not\ available.=%0 sürücüsü yok
+The\ connection\ to\ the\ server\ has\ been\ terminated.=Sunucuyla olan bağlantı sonlandırıldı.
+Connection\ lost.=Bağlantı koptu.
+Reconnect=Yeniden bağlan
+Work\ offline=Çevrimdışı çalış
+Working\ offline.=Çevrimdışı çalışılıyor.
+Update\ refused.=Güncelleme reddedildi.
+Update\ refused=Güncelleme reddedildi
+Local\ entry=Yerel girdi
+Shared\ entry=Paylaşılmış girdi
+Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=Mevcut değişiklik çelişkileri nedeniyle güncelleme yapılamadı.
+You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=BibEntry'nin en son sürümünde çalışmıyorsunuz.
+Local\ version\:\ %0=Yerel sürüm: %0
+Shared\ version\:\ %0=Paylaşılmış sürüm: %0
+Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=Bu sorunu çözmek için lütfen paylaşılmış girdiyle sizinkini birleştirin ve "Girdileri birleştir"'e basın.
+Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=Bu işlemi iptal etmek değişkliklerinizi eşzamanlanmamış halde bırakacak. Yine de iptal edilsin mi?
+Shared\ entry\ is\ no\ longer\ present=Paylaşılmış girdi artık mevcut değil
+The\ BibEntry\ you\ currently\ work\ on\ has\ been\ deleted\ on\ the\ shared\ side.=Üzerinde çalıştığınız BibEntry paylaşılmış tarafta silindi.
+You\ can\ restore\ the\ entry\ using\ the\ "Undo"\ operation.="Geri al" işlemiyle girdiyi restore edebilirsiniz.
+Remember\ password?=Parola hatırlansın mı?
+You\ are\ already\ connected\ to\ a\ database\ using\ entered\ connection\ details.=Girilmiş bağlantı ayarlarıyla bir veritabanına zaten bağlısınız.
 
-Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?=BibTeX_anahtarları_olmadan_girdiler_alıntılanamaz._Anahtarlar_şimdi_oluşturulsun_mu?
-New_technical_report=Yeni_teknik_rapor
+Cannot\ cite\ entries\ without\ BibTeX\ keys.\ Generate\ keys\ now?=BibTeX anahtarları olmadan girdiler alıntılanamaz. Anahtarlar şimdi oluşturulsun mu?
+New\ technical\ report=Yeni teknik rapor
 
-%0_file=%0_dosyası
-Custom_layout_file=Özel_düzen_dosyası
-Protected_terms_file=Korunmuş_terimler_dosyası
-Style_file=Stil_dosyası
+%0\ file=%0 dosyası
+Custom\ layout\ file=Özel düzen dosyası
+Protected\ terms\ file=Korunmuş terimler dosyası
+Style\ file=Stil dosyası
 
-Open_OpenOffice/LibreOffice_connection=OpenOffice/LibreOffice_bağlantısı_aç
-You_must_enter_at_least_one_field_name=En_az_bir_alan_adı_girmelisiniz
-Non-ASCII_encoded_character_found=ASCII_koduyla_kodlanmamış_karakter_bulundu
-Toggle_web_search_interface=Ağ_arama_arayüzünü_değiştir
-Background_color_for_resolved_fields=Kararlaştırılmış_alanlar_için_arkaplan_rengi
-Color_code_for_resolved_fields=Kararlaştırılmış_alanlar_için_renk_kodu
-%0_files_found=%0_dosya_bulundu
-%0_of_%1=%1'in_%0'i
-One_file_found=Bir_dosya_bulundu
-The_import_finished_with_warnings\:=İçe_aktarım_uyarılarla_bitti\:
-There_was_one_file_that_could_not_be_imported.=İçe_aktarılamayan_bir_dosya_mevcuttu.
-There_were_%0_files_which_could_not_be_imported.=İçe_aktarılamayan_%0_dosya_mevcuttu.
+Open\ OpenOffice/LibreOffice\ connection=OpenOffice/LibreOffice bağlantısı aç
+You\ must\ enter\ at\ least\ one\ field\ name=En az bir alan adı girmelisiniz
+Non-ASCII\ encoded\ character\ found=ASCII koduyla kodlanmamış karakter bulundu
+Toggle\ web\ search\ interface=Ağ arama arayüzünü değiştir
+Background\ color\ for\ resolved\ fields=Kararlaştırılmış alanlar için arkaplan rengi
+Color\ code\ for\ resolved\ fields=Kararlaştırılmış alanlar için renk kodu
+%0\ files\ found=%0 dosya bulundu
+%0\ of\ %1=%1'in %0'i
+One\ file\ found=Bir dosya bulundu
+The\ import\ finished\ with\ warnings\:=İçe aktarım uyarılarla bitti:
+There\ was\ one\ file\ that\ could\ not\ be\ imported.=İçe aktarılamayan bir dosya mevcuttu.
+There\ were\ %0\ files\ which\ could\ not\ be\ imported.=İçe aktarılamayan %0 dosya mevcuttu.
 
-Migration_help_information=Gçö_yardımı_bilgisi
-Entered_database_has_obsolete_structure_and_is_no_longer_supported.=Girilen_veritanbanı_kullanılmayan_yapıya_sahip_ve_artık_desteklenmiyor.
-However,_a_new_database_was_created_alongside_the_pre-3.6_one.=Ancak,_3.6_öncesinin_yanı_sıra_yeni_bir_veritabanı_oluşturuldu.
-Click_here_to_learn_about_the_migration_of_pre-3.6_databases.=3.6_öncesi_veritabanlarının_göçünü_öğrenmek_için_burayı_tıklayın.
-Opens_JabRef's_Facebook_page=JabRef'in_Facebook_sayfasını_açar
-Opens_JabRef's_blog=JabRef'in_ağ_güncesini_açar
-Opens_JabRef's_website=JabRef'in_web_sitesini_açar
-Opens_a_link_where_the_current_development_version_can_be_downloaded=Mevcut_geliştirme_sürümünün_indirilebileceği_bir_bağlantı_açar
-See_what_has_been_changed_in_the_JabRef_versions=JabRef_sürümlerinde_nelerin_değişmiş_olduğuu_görün
-Referenced_BibTeX_key_does_not_exist=Başvurulan_BibTeX_anahtarı_mevcut_değil
-Finished_downloading_full_text_document_for_entry_%0.=%0_girdisi_için_tam_metin_belgesinin_indirilmesi_bitti.
-Full_text_document_download_failed_for_entry_%0.=%0_girdisi_için_tam_metin_belgesinin_indirilmesi_başarısız.
-Look_up_full_text_documents=Tam_netin_belgeri_ara
-You_are_about_to_look_up_full_text_documents_for_%0_entries.=%0_adet_girdi_için_tam_metin_belgeleri_aramak_üzeresiniz.
-last_four_nonpunctuation_characters_should_be_numerals=noktalama_olmayan_son_dört_karakter_rakam_olmalıdır
+Migration\ help\ information=Gçö yardımı bilgisi
+Entered\ database\ has\ obsolete\ structure\ and\ is\ no\ longer\ supported.=Girilen veritanbanı kullanılmayan yapıya sahip ve artık desteklenmiyor.
+However,\ a\ new\ database\ was\ created\ alongside\ the\ pre-3.6\ one.=Ancak, 3.6 öncesinin yanı sıra yeni bir veritabanı oluşturuldu.
+Click\ here\ to\ learn\ about\ the\ migration\ of\ pre-3.6\ databases.=3.6 öncesi veritabanlarının göçünü öğrenmek için burayı tıklayın.
+Opens\ JabRef's\ Facebook\ page=JabRef'in Facebook sayfasını açar
+Opens\ JabRef's\ blog=JabRef'in ağ güncesini açar
+Opens\ JabRef's\ website=JabRef'in web sitesini açar
+Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=Mevcut geliştirme sürümünün indirilebileceği bir bağlantı açar
+See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=JabRef sürümlerinde nelerin değişmiş olduğuu görün
+Referenced\ BibTeX\ key\ does\ not\ exist=Başvurulan BibTeX anahtarı mevcut değil
+Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=%0 girdisi için tam metin belgesinin indirilmesi bitti.
+Full\ text\ document\ download\ failed\ for\ entry\ %0.=%0 girdisi için tam metin belgesinin indirilmesi başarısız.
+Look\ up\ full\ text\ documents=Tam netin belgeri ara
+You\ are\ about\ to\ look\ up\ full\ text\ documents\ for\ %0\ entries.=%0 adet girdi için tam metin belgeleri aramak üzeresiniz.
+last\ four\ nonpunctuation\ characters\ should\ be\ numerals=noktalama olmayan son dört karakter rakam olmalıdır
 
 Author=Yazar
 Date=Tarih
-File_annotations=Dosya_açıklama_notları
-Show_file_annotations=Dosya_açıklama_notlarını_göster
-Adobe_Acrobat_Reader=Adobe_Acrobat_Okuyucu
-Sumatra_Reader=Sumatra_Okuyucu
+File\ annotations=Dosya açıklama notları
+Show\ file\ annotations=Dosya açıklama notlarını göster
+Adobe\ Acrobat\ Reader=Adobe Acrobat Okuyucu
+Sumatra\ Reader=Sumatra Okuyucu
 shared=paylaşıldı
-should_contain_an_integer_or_a_literal=bir_tamsayı_ya_da_harf_içermelidir
-should_have_the_first_letter_capitalized=İlk_harf_büyük_olmalıdır
+should\ contain\ an\ integer\ or\ a\ literal=bir tamsayı ya da harf içermelidir
+should\ have\ the\ first\ letter\ capitalized=İlk harf büyük olmalıdır
 Tools=Araçlar
-What\'s_new_in_this_version?=Bu_sürümde_neler_yeni?
-Want_to_help?=Yardım_etmek_ister_misiniz?
-Make_a_donation=Bağışta_bulun
-get_involved=katkıda_bulun
-Used_libraries=Kullanılan_kütüphaneler
-Existing_file=Varolan_dosya
+What\'s\ new\ in\ this\ version?=Bu sürümde neler yeni?
+Want\ to\ help?=Yardım etmek ister misiniz?
+Make\ a\ donation=Bağışta bulun
+get\ involved=katkıda bulun
+Used\ libraries=Kullanılan kütüphaneler
+Existing\ file=Varolan dosya
 
 ID=ID(kimlik)
-ID_type=ID_türü
-ID-based_entry_generator=ID-tabanlı_girdi_oluşturucu
-Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.='%0'_getiricisi_'%1'_kimliği_için_bir_girdi_bulamadı.
+ID\ type=ID türü
+ID-based\ entry\ generator=ID-tabanlı girdi oluşturucu
+Fetcher\ '%0'\ did\ not\ find\ an\ entry\ for\ id\ '%1'.='%0' getiricisi '%1' kimliği için bir girdi bulamadı.
 
-Select_first_entry=İlk_girdiyi_seç
-Select_last_entry=Son_girdiyi_seç
+Select\ first\ entry=İlk girdiyi seç
+Select\ last\ entry=Son girdiyi seç
 
-Invalid_ISBN\:_'%0'.=Geçersiz_ISBN\:_'%0'.
-should_be_an_integer_or_normalized=bir_tamsayı_olmalı_ya_da_normalleştirilmelidir
-should_be_normalized=normalleştirilmelidir
+Invalid\ ISBN\:\ '%0'.=Geçersiz ISBN: '%0'.
+should\ be\ an\ integer\ or\ normalized=bir tamsayı olmalı ya da normalleştirilmelidir
+should\ be\ normalized=normalleştirilmelidir
 
-Empty_search_ID=Boş_arama_IDsi
-The_given_search_ID_was_empty.=Verilen_arama_IDsi_boştu.
-Copy_BibTeX_key_and_link=BibTeX_anahtarı_ve_bağlantısını_kopyala
-empty_BibTeX_key=boş_BibTeX_anahtarı
-biblatex_field_only=Yalnızca_biblatex_alanı
+Empty\ search\ ID=Boş arama IDsi
+The\ given\ search\ ID\ was\ empty.=Verilen arama IDsi boştu.
+Copy\ BibTeX\ key\ and\ link=BibTeX anahtarı ve bağlantısını kopyala
+empty\ BibTeX\ key=boş BibTeX anahtarı
+biblatex\ field\ only=Yalnızca biblatex alanı
 
-Error_while_generating_fetch_URL=URL'den_getirme_oluşturulurken_hata
-Error_while_parsing_ID_list=ID_listesi_çözümlenirken_hata
-Unable_to_get_PubMed_IDs=PubMed_IDleri_alınamadı
-Backup_found=Yedek_bulundu
-A_backup_file_for_'%0'_was_found.='%0'_için_bir_yedek_dosyası_bulundu.
-This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.=Bu,_dosya_son_kullanıldığında_JabRef'in_temiz_kapatılmadığını_belirtiyor_olabilir.
-Do_you_want_to_recover_the_library_from_the_backup_file?=Veritabanınızı_yedek_dosyadan_kurtarmak_ister_misiniz?
-Firstname_Lastname=Ad_Soyad
+Error\ while\ generating\ fetch\ URL=URL'den getirme oluşturulurken hata
+Error\ while\ parsing\ ID\ list=ID listesi çözümlenirken hata
+Unable\ to\ get\ PubMed\ IDs=PubMed IDleri alınamadı
+Backup\ found=Yedek bulundu
+A\ backup\ file\ for\ '%0'\ was\ found.='%0' için bir yedek dosyası bulundu.
+This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Bu, dosya son kullanıldığında JabRef'in temiz kapatılmadığını belirtiyor olabilir.
+Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Veritabanınızı yedek dosyadan kurtarmak ister misiniz?
+Firstname\ Lastname=Ad Soyad
 
-Recommended_for_%0=%0_için_önerilir
-Show_'Related_Articles'_tab='İlişkili_Makaleler'_sekmesini_göster
-This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=Bu,_Google_Scholar'ın_trafik_limitine_erişmekten_dolayı_olabilir_(ayrıntılar_için_'Yardım'a_bakınız).
+Recommended\ for\ %0=%0 için önerilir
+Show\ 'Related\ Articles'\ tab='İlişkili Makaleler' sekmesini göster
+This\ might\ be\ caused\ by\ reaching\ the\ traffic\ limitation\ of\ Google\ Scholar\ (see\ 'Help'\ for\ details).=Bu, Google Scholar'ın trafik limitine erişmekten dolayı olabilir (ayrıntılar için 'Yardım'a bakınız).
 
-Could_not_open_website.=Web_sitesi_açılamadı.
-Problem_downloading_from_%1=%1'den_indirmede_sorun
+Could\ not\ open\ website.=Web sitesi açılamadı.
+Problem\ downloading\ from\ %1=%1'den indirmede sorun
 
-File_directory_pattern=Dosya_dizini_paterni
-Update_with_bibliographic_information_from_the_web=Web'deki_bibliyografya_bilgisiyle_güncelle
+File\ directory\ pattern=Dosya dizini paterni
+Update\ with\ bibliographic\ information\ from\ the\ web=Web'deki bibliyografya bilgisiyle güncelle
 
-Could_not_find_any_bibliographic_information.=Hiç_bibliyografya_bilgisi_bulunamadı.
-BibTeX_key_deviates_from_generated_key=BibTeX_anahtarı_oluşturulan_anahtardan_farklı
-DOI_%0_is_invalid=%0_DOI_geçersiz
+Could\ not\ find\ any\ bibliographic\ information.=Hiç bibliyografya bilgisi bulunamadı.
+BibTeX\ key\ deviates\ from\ generated\ key=BibTeX anahtarı oluşturulan anahtardan farklı
+DOI\ %0\ is\ invalid=%0 DOI geçersiz
 
-Select_all_customized_types_to_be_stored_in_local_preferences=Tüm_kişiselleştirilmiş_türleri_yerel_tercihlerde_sakla
-Currently_unknown=Halen_bilinmiyor
-Different_customization,_current_settings_will_be_overwritten=Farklı_kişiselleştirme,_güncel_ayarların_üzerine_yazılacak
+Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences=Tüm kişiselleştirilmiş türleri yerel tercihlerde sakla
+Currently\ unknown=Halen bilinmiyor
+Different\ customization,\ current\ settings\ will\ be\ overwritten=Farklı kişiselleştirme, güncel ayarların üzerine yazılacak
 
-Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX=%0_girdi_türü_yalnızca_Biblatex_için_tanımlanmış_BibTeX_için_değil
-Jump_to_entry=Girdiye_atla
+Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=%0 girdi türü yalnızca Biblatex için tanımlanmış BibTeX için değil
+Jump\ to\ entry=Girdiye atla
 
-Copied_%0_citations.=%0_atıf_kopyalandı.
+Copied\ %0\ citations.=%0 atıf kopyalandı.
 Copying...=Kopyalanıyor...
 
-journal_not_found_in_abbreviation_list=kısaltma_listesinde_dergi_bulunamadı
-Unhandled_exception_occurred.=İşlenmemiş_istisna_oluştu.
+journal\ not\ found\ in\ abbreviation\ list=kısaltma listesinde dergi bulunamadı
+Unhandled\ exception\ occurred.=İşlenmemiş istisna oluştu.
 
-strings_included=dizgeler_dahil_edildi
-Color_for_disabled_icons=Etkisizleştirilmiş_simgeleri_için_renk
-Color_for_enabled_icons=Etkinleştirilmiş_simgeler_için_renk
-Size_of_large_icons=Büyük_simge_boyutu
-Size_of_small_icons=Küçük_simge_boyutu
-Default_table_font_size=Öntanımlı_tablo_yazıtipi_boyutu
-Escape_underscores=Altçizgileri_öncele
+strings\ included=dizgeler dahil edildi
+Color\ for\ disabled\ icons=Etkisizleştirilmiş simgeleri için renk
+Color\ for\ enabled\ icons=Etkinleştirilmiş simgeler için renk
+Size\ of\ large\ icons=Büyük simge boyutu
+Size\ of\ small\ icons=Küçük simge boyutu
+Default\ table\ font\ size=Öntanımlı tablo yazıtipi boyutu
+Escape\ underscores=Altçizgileri öncele
 Color=Renk
-Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=Mümkünse_lütfen_bu_sorunu_yeniden_üretebilmek_için_gereken_tüm_adımları_ekleyin
-Fit_width=Genişliğe_uydur
-Fit_a_single_page=Sayfaya_uydur
-Zoom_in=Yakınlaş
-Zoom_out=Uzaklaş
-Previous_page=Önceki_sayfa
-Next_page=Sonraki_sayfa
-Document_viewer=Belge_görüntüleyici
+Please\ also\ add\ all\ steps\ to\ reproduce\ this\ issue,\ if\ possible.=Mümkünse lütfen bu sorunu yeniden üretebilmek için gereken tüm adımları ekleyin
+Fit\ width=Genişliğe uydur
+Fit\ a\ single\ page=Sayfaya uydur
+Zoom\ in=Yakınlaş
+Zoom\ out=Uzaklaş
+Previous\ page=Önceki sayfa
+Next\ page=Sonraki sayfa
+Document\ viewer=Belge görüntüleyici
 Live=Canlı
 Locked=Kilitli
-Show_document_viewer=Belge_görüntüleyiciyi_göster
-Show_the_document_of_the_currently_selected_entry.=Mevcut_seçili_girdinin_belgesini_göster.
-Show_this_document_until_unlocked.=Kilidi_açılana_dek_bu_belgeyi_göster.
-Set_current_user_name_as_owner.=Mevcut_kullanıcı_adını_sahip_olarak_ata.
+Show\ document\ viewer=Belge görüntüleyiciyi göster
+Show\ the\ document\ of\ the\ currently\ selected\ entry.=Mevcut seçili girdinin belgesini göster.
+Show\ this\ document\ until\ unlocked.=Kilidi açılana dek bu belgeyi göster.
+Set\ current\ user\ name\ as\ owner.=Mevcut kullanıcı adını sahip olarak ata.
 
-Sort_all_subgroups_(recursively)=Tüm_alt_grupları_(ardışık_olarak)_sırala
-Collect_and_share_telemetry_data_to_help_improve_JabRef.=JabRef'i_geliştirmeye_yardımcı_olmak_için_telemetri_verilerini_topla_ve_paylaş
-Don't_share=Paylaşma
-Share_anonymous_statistics=Anonim_istatistikleri_paylaş
-Telemetry\:_Help_make_JabRef_better=Telemetri\:JabRef'i_daha_iyi_yapmaya_yardım_et
-To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.=Kullanıcı_deneyimini_geliştirmek_için,_kullandığınız_özelliklerle_ilgili_anonim_istatistikleri_toplamak_istiyoruz._Yalnızca_kullandığınız_özellikleri_ve_kullanma_sıklığını_kaydedeceğiz._Kişisel_verileri_ya_da_bibliyografik_ögelerin_içeriğini_toplamayacağız._Eğer_veri_toplamaya_izin_vermeyi_seçerseniz,_bunu_daha_sonra_Seçenekler_->_Tercihler_aracılığıyla_etkisizleştirebilirsiniz_-
-This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?=Bu_dosya_otomatik_olarak_bulundu._Bu_girdiye_bağlantılamak_ister_misiniz?
-Names_are_not_in_the_standard_%0_format.=İsimler,_standart_%0_biçeminde_değil.
+Sort\ all\ subgroups\ (recursively)=Tüm alt grupları (ardışık olarak) sırala
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=JabRef'i geliştirmeye yardımcı olmak için telemetri verilerini topla ve paylaş
+Don't\ share=Paylaşma
+Share\ anonymous\ statistics=Anonim istatistikleri paylaş
+Telemetry\:\ Help\ make\ JabRef\ better=Telemetri:JabRef'i daha iyi yapmaya yardım et
+To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ statistics\ on\ the\ features\ you\ use.\ We\ will\ only\ record\ what\ features\ you\ access\ and\ how\ often\ you\ do\ it.\ We\ will\ neither\ collect\ any\ personal\ data\ nor\ the\ content\ of\ bibliographic\ items.\ If\ you\ choose\ to\ allow\ data\ collection,\ you\ can\ later\ disable\ it\ via\ Options\ ->\ Preferences\ ->\ General.=Kullanıcı deneyimini geliştirmek için, kullandığınız özelliklerle ilgili anonim istatistikleri toplamak istiyoruz. Yalnızca kullandığınız özellikleri ve kullanma sıklığını kaydedeceğiz. Kişisel verileri ya da bibliyografik ögelerin içeriğini toplamayacağız. Eğer veri toplamaya izin vermeyi seçerseniz, bunu daha sonra Seçenekler -> Tercihler aracılığıyla etkisizleştirebilirsiniz -
+This\ file\ was\ found\ automatically.\ Do\ you\ want\ to\ link\ it\ to\ this\ entry?=Bu dosya otomatik olarak bulundu. Bu girdiye bağlantılamak ister misiniz?
+Names\ are\ not\ in\ the\ standard\ %0\ format.=İsimler, standart %0 biçeminde değil.
 
-Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.=Seçili_dosyayı_diskten_kalıcı_olarak_sil,_ya_da_sadece_dosyayı_girdiden_kaldır?_Sile_basmak_dosyayı_diskten_kalıcı_olarak_silecek.
-Delete_'%0'='%0'_Sil
-Delete_from_disk=Diskten_sil
-Remove_from_entry=Girdiden_sil
-The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.=Grup_adı_anahtar_sözcük_ayracı_olan_"%0"_içeriyor_ve_bu_sebeple_muhtemelen_beklendiğini_gibi_çalışmayacak.
-There_exists_already_a_group_with_the_same_name.=Aynı_isimli_bir_grup_zaten_var.
+Delete\ the\ selected\ file\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ file\ permanently\ from\ disk.=Seçili dosyayı diskten kalıcı olarak sil, ya da sadece dosyayı girdiden kaldır? Sile basmak dosyayı diskten kalıcı olarak silecek.
+Delete\ '%0'='%0' Sil
+Delete\ from\ disk=Diskten sil
+Remove\ from\ entry=Girdiden sil
+The\ group\ name\ contains\ the\ keyword\ separator\ "%0"\ and\ thus\ probably\ does\ not\ work\ as\ expected.=Grup adı anahtar sözcük ayracı olan "%0" içeriyor ve bu sebeple muhtemelen beklendiğini gibi çalışmayacak.
+There\ exists\ already\ a\ group\ with\ the\ same\ name.=Aynı isimli bir grup zaten var.
 
-Copy_linked_files_to_folder...=
-Copied_file_successfully=
-Copying_files...=
-Copying_file_%0_of_entry_%1=
-Finished_copying=
-Could_not_copy_file=
-Copied_%0_files_of_%1_sucessfully_to_%2=
-Rename_failed=Yeniden_adlandırma_başarısız_oldu
-JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.=JabRef_dosyaya_erişemiyor_çünkü_dosya_başka_bir_süreç_tarafından_kullanılıyor.
-Show_console_output_(only_necessary_when_the_launcher_is_used)=Consol_çıktısını_göster_(sadece_başlatıcı_kullanıldığında_gereklidir)
+Copy\ linked\ files\ to\ folder...=
+Copied\ file\ successfully=
+Copying\ files...=
+Copying\ file\ %0\ of\ entry\ %1=
+Finished\ copying=
+Could\ not\ copy\ file=
+Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=
+Rename\ failed=Yeniden adlandırma başarısız oldu
+JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=JabRef dosyaya erişemiyor çünkü dosya başka bir süreç tarafından kullanılıyor.
+Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=Consol çıktısını göster (sadece başlatıcı kullanıldığında gereklidir)
 
-Remove_line_breaks=
-Removes_all_line_breaks_in_the_field_content.=
-Checking_integrity...=
+Remove\ line\ breaks=
+Removes\ all\ line\ breaks\ in\ the\ field\ content.=
+Checking\ integrity...=
 
-Remove_hyphenated_line_breaks=
-Removes_all_hyphenated_line_breaks_in_the_field_content.=
-Note_that_currently,_JabRef_does_not_run_with_Java_9.=
-Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.=
+Remove\ hyphenated\ line\ breaks=
+Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=
+Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=
+Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -43,7 +43,7 @@ Add=Thêm
 Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=Thêm một lớp ĐịnhdạngNhập tùy biến (được biên dịch) từ đường dẫn lớp.
 The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=Đường dẫn không được trùng với đường dẫn lớp của JabRef.
 
-Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=Thêm một lớp ĐịnhdạngNhập tùy biến (được biên dịch) từ một tập tin-zip. 
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=Thêm một lớp ĐịnhdạngNhập tùy biến (được biên dịch) từ một tập tin-zip.
 The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=Tập tin-zip không được trùng với đường dẫn lớp của JabRef.
 
 Add\ a\ regular\ expression\ for\ the\ key\ pattern.=
@@ -1206,9 +1206,9 @@ This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\
 
 This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=Nhóm này chứa các mục căn cứ trên phép gán thủ công. Các mục có thể được gán vào nhóm này bằng cách chọn chúng rồi dùng cách kéo thả hoặc trình đơn ngữ cảnh. Các mục có thể bị loại bỏ khỏi nhóm này bằng cách chọn chúng rồi dùng trình đơn ngữ cảnh.
 
-This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Nhóm này chứa các mục có dữ liệu <b>%0</b> chứa từ khóa <b>%1</b> 
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Nhóm này chứa các mục có dữ liệu <b>%0</b> chứa từ khóa <b>%1</b>
 
-This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Nhóm này chứa các mục có dữ liệu <b>%0</b> chứa biểu thức chính tắc <b>%1</b> 
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Nhóm này chứa các mục có dữ liệu <b>%0</b> chứa biểu thức chính tắc <b>%1</b>
 This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=Điều này khiến cho JabRef tìm từng liên kết trong tổng số tập tin và kiểm tra xem tập tin có tồn tại không. Nếu không bạn sẽ được cung cấp các tùy chọn<BR>để giải quyết trục trặc.
 
 This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=Lệnh này yêu cầu tất cả các mục được chọn phải có khóa BibTeX.
@@ -2171,7 +2171,7 @@ Working\ offline.=Đang làm việc ẩn.
 Update\ refused.=Cập nhật bị từ chối.
 Update\ refused=Cập nhật bị từ chối
 Local\ entry=Mục cục bộ
-Shared\ entry=Mục chia sẻ 
+Shared\ entry=Mục chia sẻ
 Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=Cập nhật không thể được thực hiện vì hiện đang có thay đổi xung đột.
 You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=Bạn không làm việc trên phiên bản mới nhất của BibEntry.
 Local\ version\:\ %0=Phiên bản cục bộ: %0

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -1,8 +1,3 @@
-
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 chứa biểu thức chính tắc <b>%1</b>
 
 %0\ contains\ the\ term\ <b>%1</b>=%0 chứa thuật ngữ <b>%1</b>

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -3,156 +3,156 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-%0_contains_the_regular_expression_<b>%1</b>=%0_chứa_biểu_thức_chính_tắc_<b>%1</b>
+%0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 chứa biểu thức chính tắc <b>%1</b>
 
-%0_contains_the_term_<b>%1</b>=%0_chứa_thuật_ngữ_<b>%1</b>
+%0\ contains\ the\ term\ <b>%1</b>=%0 chứa thuật ngữ <b>%1</b>
 
-%0_doesn't_contain_the_regular_expression_<b>%1</b>=%0_không_chứa_biểu_thức_chính_tắc_<b>%1</b>
+%0\ doesn't\ contain\ the\ regular\ expression\ <b>%1</b>=%0 không chứa biểu thức chính tắc <b>%1</b>
 
-%0_doesn't_contain_the_term_<b>%1</b>=%0_không_chứa_thuật_ngữ_<b>%1</b>
+%0\ doesn't\ contain\ the\ term\ <b>%1</b>=%0 không chứa thuật ngữ <b>%1</b>
 
-%0_export_successful=%0_xuất_thành_công
+%0\ export\ successful=%0 xuất thành công
 
-%0_matches_the_regular_expression_<b>%1</b>=%0_khớp_biểu_thức_chính_tắc_<b>%1</b>
+%0\ matches\ the\ regular\ expression\ <b>%1</b>=%0 khớp biểu thức chính tắc <b>%1</b>
 
-%0_matches_the_term_<b>%1</b>=%0_khớp_thuật_ngữ_<b>%1</b>
+%0\ matches\ the\ term\ <b>%1</b>=%0 khớp thuật ngữ <b>%1</b>
 
-<field_name>=<tên_trường>
-<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>=<HTML>Không_thể_tìm_thấy_tập_tin_'%0'<BR>được_liên_kết_từ_mục_'%1'</HTML>
+<field\ name>=<tên trường>
+<HTML>Could\ not\ find\ file\ '%0'<BR>linked\ from\ entry\ '%1'</HTML>=<HTML>Không thể tìm thấy tập tin '%0'<BR>được liên kết từ mục '%1'</HTML>
 
 <select>=<chọn>
 
-<select_word>=<chọn_từ>
-Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)=Viết_tắt_tên_tạp_chí_của_các_mục_được_chọn_(viết_tắt_kiểu_ISO)
-Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)=Viết_tắt_tên_tạp_chí_của_các_mục_được_chọn_(viết_tắt_kiểu_MEDLINE)
+<select\ word>=<chọn từ>
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (ISO\ abbreviation)=Viết tắt tên tạp chí của các mục được chọn (viết tắt kiểu ISO)
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (MEDLINE\ abbreviation)=Viết tắt tên tạp chí của các mục được chọn (viết tắt kiểu MEDLINE)
 
-Abbreviate_names=Viết_tắt_các_tên
-Abbreviated_%0_journal_names.=%0_tên_tạp_chí_được_viết_tắt.
+Abbreviate\ names=Viết tắt các tên
+Abbreviated\ %0\ journal\ names.=%0 tên tạp chí được viết tắt.
 
-Abbreviation=Viết_tắt
+Abbreviation=Viết tắt
 
-About_JabRef=Nói_về_JabRef
+About\ JabRef=Nói về JabRef
 
-Abstract=Tóm_tắt
+Abstract=Tóm tắt
 
-Accept=Chấp_nhận
+Accept=Chấp nhận
 
-Accept_change=Chấp_nhận_thay_đổi
+Accept\ change=Chấp nhận thay đổi
 
-Action=Hành_động
+Action=Hành động
 
-What_is_Mr._DLib?=
+What\ is\ Mr.\ DLib?=
 
 Add=Thêm
 
-Add_a_(compiled)_custom_Importer_class_from_a_class_path.=Thêm_một_lớp_ĐịnhdạngNhập_tùy_biến_(được_biên_dịch)_từ_đường_dẫn_lớp.
-The_path_need_not_be_on_the_classpath_of_JabRef.=Đường_dẫn_không_được_trùng_với_đường_dẫn_lớp_của_JabRef.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=Thêm một lớp ĐịnhdạngNhập tùy biến (được biên dịch) từ đường dẫn lớp.
+The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=Đường dẫn không được trùng với đường dẫn lớp của JabRef.
 
-Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=Thêm_một_lớp_ĐịnhdạngNhập_tùy_biến_(được_biên_dịch)_từ_một_tập_tin-zip._
-The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=Tập_tin-zip_không_được_trùng_với_đường_dẫn_lớp_của_JabRef.
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=Thêm một lớp ĐịnhdạngNhập tùy biến (được biên dịch) từ một tập tin-zip. 
+The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=Tập tin-zip không được trùng với đường dẫn lớp của JabRef.
 
-Add_a_regular_expression_for_the_key_pattern.=
+Add\ a\ regular\ expression\ for\ the\ key\ pattern.=
 
-Add_selected_entries_to_this_group=
+Add\ selected\ entries\ to\ this\ group=
 
-Add_from_folder=Thêm_từ_thư_mục
+Add\ from\ folder=Thêm từ thư mục
 
-Add_from_JAR=Thêm_từ_tập_tin_JAR
+Add\ from\ JAR=Thêm từ tập tin JAR
 
-add_group=thêm_nhóm
+add\ group=thêm nhóm
 
-Add_new=Thêm_mới
+Add\ new=Thêm mới
 
-Add_subgroup=Thêm_nhóm_con
+Add\ subgroup=Thêm nhóm con
 
-Add_to_group=Thêm_vào_nhóm
+Add\ to\ group=Thêm vào nhóm
 
-Added_group_"%0".=Nhóm_được_thêm_"%0".
+Added\ group\ "%0".=Nhóm được thêm "%0".
 
-Added_missing_braces.=
+Added\ missing\ braces.=
 
-Added_new=Mới_được_thêm
+Added\ new=Mới được thêm
 
-Added_string=Chuỗi_được_thêm
+Added\ string=Chuỗi được thêm
 
-Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.=Ngoài_ra,_những_mục_nào_có_dữ_liệu_<b>%0</b>_không_chứa_<b>%1</b>_có_thể_được_gán_thủ_công_vào_nhóm_này_bằng_cách_chọn_chúng_rồi_kéo_thả_hoặc_dùng_menu_ngữ_cảnh._Quá_trình_này_thêm_thuật_ngữ_<b>%1</b>_vào_dữ_liệu_<b>%0</b>_của_mỗi_mục._Các_mục_có_thể_được_loại_bỏ_thủ_công_khỏi_nhóm_này_bằng_cách_chọn_chúng_rồi_dùng_menu_ngữ_cảnh._Quá_trình_này_loại_bỏ_thuật_ngữ_<b>%1</b>_khỏi_dữ_liệu_<b>%0</b>_của_mỗi_mục.
+Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ can\ be\ assigned\ manually\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ This\ process\ adds\ the\ term\ <b>%1</b>\ to\ each\ entry's\ <b>%0</b>\ field.\ Entries\ can\ be\ removed\ manually\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.\ This\ process\ removes\ the\ term\ <b>%1</b>\ from\ each\ entry's\ <b>%0</b>\ field.=Ngoài ra, những mục nào có dữ liệu <b>%0</b> không chứa <b>%1</b> có thể được gán thủ công vào nhóm này bằng cách chọn chúng rồi kéo thả hoặc dùng menu ngữ cảnh. Quá trình này thêm thuật ngữ <b>%1</b> vào dữ liệu <b>%0</b> của mỗi mục. Các mục có thể được loại bỏ thủ công khỏi nhóm này bằng cách chọn chúng rồi dùng menu ngữ cảnh. Quá trình này loại bỏ thuật ngữ <b>%1</b> khỏi dữ liệu <b>%0</b> của mỗi mục.
 
-Advanced=Nâng_cao
-All_entries=Tất_cả_các_mục
-All_entries_of_this_type_will_be_declared_typeless._Continue?=Tất_cả_các_mục_thuộc_kiểu_này_sẽ_được_đổi_thành_không_có_kiểu._Tiếp_tục_không?
+Advanced=Nâng cao
+All\ entries=Tất cả các mục
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=Tất cả các mục thuộc kiểu này sẽ được đổi thành không có kiểu. Tiếp tục không?
 
-All_fields=Tất_cả_các_dữ_liệu
+All\ fields=Tất cả các dữ liệu
 
-Always_reformat_BIB_file_on_save_and_export=
+Always\ reformat\ BIB\ file\ on\ save\ and\ export=
 
-A_SAX_exception_occurred_while_parsing_'%0'\:=Một_lỗi_SAXException_xảy_ra_khi_đang_phân_tách_'%0'\:
+A\ SAX\ exception\ occurred\ while\ parsing\ '%0'\:=Một lỗi SAXException xảy ra khi đang phân tách '%0':
 
 and=và
-and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.=và_lớp_phải_có_trong_đường_dẫn_lớp_lần_sau_khi_bạn_khởi_động_JabRef.
+and\ the\ class\ must\ be\ available\ in\ your\ classpath\ next\ time\ you\ start\ JabRef.=và lớp phải có trong đường dẫn lớp lần sau khi bạn khởi động JabRef.
 
-any_field_that_matches_the_regular_expression_<b>%0</b>=bất_kỳ_dữ_liệu_nào_khớp_Biểu_thức_Chính_tắc_<b>%0</b>
+any\ field\ that\ matches\ the\ regular\ expression\ <b>%0</b>=bất kỳ dữ liệu nào khớp Biểu thức Chính tắc <b>%0</b>
 
-Appearance=Diện_mạo
+Appearance=Diện mạo
 
 Append=Nối
-Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library=Nối_nội_dung_từ_một_CSDL_BibTeX_vào_CSDL_đang_xem_hiện_tại
+Append\ contents\ from\ a\ BibTeX\ library\ into\ the\ currently\ viewed\ library=Nối nội dung từ một CSDL BibTeX vào CSDL đang xem hiện tại
 
-Append_library=Nối_CSDL
+Append\ library=Nối CSDL
 
-Append_the_selected_text_to_BibTeX_field=Nối_nội_dung_được_chọn_vào_khóa_BibTeX
-Application=Ứng_dụng
+Append\ the\ selected\ text\ to\ BibTeX\ field=Nối nội dung được chọn vào khóa BibTeX
+Application=Ứng dụng
 
-Apply=Áp_dụng
+Apply=Áp dụng
 
-Arguments_passed_on_to_running_JabRef_instance._Shutting_down.=Các_đối_số_được_truyền_cho_phiên_JabRef_đang_chạy._Đang_tắt.
+Arguments\ passed\ on\ to\ running\ JabRef\ instance.\ Shutting\ down.=Các đối số được truyền cho phiên JabRef đang chạy. Đang tắt.
 
-Assign_new_file=Gán_tập_tin_mới
+Assign\ new\ file=Gán tập tin mới
 
-Assign_the_original_group's_entries_to_this_group?=Gán_các_mục_của_nhóm_ban_đầu_vào_nhóm_này?
+Assign\ the\ original\ group's\ entries\ to\ this\ group?=Gán các mục của nhóm ban đầu vào nhóm này?
 
-Assigned_%0_entries_to_group_"%1".=Đã_gán_%0_mục_vào_nhóm_"%1".
+Assigned\ %0\ entries\ to\ group\ "%1".=Đã gán %0 mục vào nhóm "%1".
 
-Assigned_1_entry_to_group_"%0".=Đã_gán_1_mục_vào_nhóm_"%0".
+Assigned\ 1\ entry\ to\ group\ "%0".=Đã gán 1 mục vào nhóm "%0".
 
-Attach_URL=Gắn_URL
+Attach\ URL=Gắn URL
 
-Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.=Cố_gắng_thiết_lập_tự_động_tập_tin_liên_kết_vào_các_mục._Thiết_lập_tự_động_chạy_được_nếu_một_tập_tin_ở_trong_thư_mục_hoặc_thư_mục_con_tập_tin_của_bạn<BR>được_đặt_tên_giống_hệt_một_khóa_BibTeX_của_mục,_cộng_với_phần_mở_rộng.
+Attempt\ to\ automatically\ set\ file\ links\ for\ your\ entries.\ Automatically\ setting\ works\ if\ a\ file\ in\ your\ file\ directory<BR>or\ a\ subdirectory\ is\ named\ identically\ to\ an\ entry's\ BibTeX\ key,\ plus\ extension.=Cố gắng thiết lập tự động tập tin liên kết vào các mục. Thiết lập tự động chạy được nếu một tập tin ở trong thư mục hoặc thư mục con tập tin của bạn<BR>được đặt tên giống hệt một khóa BibTeX của mục, cộng với phần mở rộng.
 
-Autodetect_format=Tự_động_phát_hiện_định_dạng
+Autodetect\ format=Tự động phát hiện định dạng
 
-Autogenerate_BibTeX_keys=Tự_động_tạo_các_khóa_BibTeX
+Autogenerate\ BibTeX\ keys=Tự động tạo các khóa BibTeX
 
-Autolink_files_with_names_starting_with_the_BibTeX_key=Tự_động_liên_kết_với_các_tên_bắt_đầu_bằng_khóa_BibTeX
+Autolink\ files\ with\ names\ starting\ with\ the\ BibTeX\ key=Tự động liên kết với các tên bắt đầu bằng khóa BibTeX
 
-Autolink_only_files_that_match_the_BibTeX_key=Chỉ_tự_động_liên_kết_các_tập_tin_nào_khớp_khóa_BibTeX
+Autolink\ only\ files\ that\ match\ the\ BibTeX\ key=Chỉ tự động liên kết các tập tin nào khớp khóa BibTeX
 
-Automatically_create_groups=Tự_động_tạo_các_nhóm
+Automatically\ create\ groups=Tự động tạo các nhóm
 
-Automatically_remove_exact_duplicates=Tự_động_loại_bỏ_các_mục_trùng_nhau
+Automatically\ remove\ exact\ duplicates=Tự động loại bỏ các mục trùng nhau
 
-Allow_overwriting_existing_links.=Cho_phép_ghi_đè_các_liên_kết_hiện_có.
+Allow\ overwriting\ existing\ links.=Cho phép ghi đè các liên kết hiện có.
 
-Do_not_overwrite_existing_links.=Không_ghi_đè_các_liên_kết_hiện_có.
+Do\ not\ overwrite\ existing\ links.=Không ghi đè các liên kết hiện có.
 
-AUX_file_import=Nhập_tập_tin_AUX
+AUX\ file\ import=Nhập tập tin AUX
 
-Available_export_formats=Các_định_dạng_xuất_dùng_được
+Available\ export\ formats=Các định dạng xuất dùng được
 
-Available_BibTeX_fields=Các_dữ_liệu_BibTeX_dùng_được
+Available\ BibTeX\ fields=Các dữ liệu BibTeX dùng được
 
-Available_import_formats=Các_định_dạng_nhập_dùng_được
+Available\ import\ formats=Các định dạng nhập dùng được
 
-Background_color_for_optional_fields=Màu_nền_cho_các_dữ_liệu_tùy_chọn
+Background\ color\ for\ optional\ fields=Màu nền cho các dữ liệu tùy chọn
 
-Background_color_for_required_fields=Màu_nền_cho_các_dữ_liệu_bắt_buộc
+Background\ color\ for\ required\ fields=Màu nền cho các dữ liệu bắt buộc
 
-Backup_old_file_when_saving=Sao_lại_tập_tin_cũ_khi_lưu
+Backup\ old\ file\ when\ saving=Sao lại tập tin cũ khi lưu
 
-BibTeX_key_is_unique.=Khóa_BibTeX_không_được_trùng.
+BibTeX\ key\ is\ unique.=Khóa BibTeX không được trùng.
 
-%0_source=Nguồn_%0
+%0\ source=Nguồn %0
 
-Broken_link=Liên_kết_bị_đứt
+Broken\ link=Liên kết bị đứt
 
 Browse=Duyệt
 
@@ -160,2198 +160,2198 @@ by=theo
 
 Cancel=Hủy
 
-Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?=Không_thể_thêm_các_mục_vào_nhóm_mà_không_tạo_khóa._Có_tạo_khóa_không?
+Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=Không thể thêm các mục vào nhóm mà không tạo khóa. Có tạo khóa không?
 
-Cannot_merge_this_change=Không_thể_gộp_thay_đổi_này
+Cannot\ merge\ this\ change=Không thể gộp thay đổi này
 
-case_insensitive=không_phân_biệt_chữ_hoa/thường
+case\ insensitive=không phân biệt chữ hoa/thường
 
-case_sensitive=phân_biệt_chữ_hoa/thường
+case\ sensitive=phân biệt chữ hoa/thường
 
-Case_sensitive=Phân_biệt_chữ_hoa/thường
+Case\ sensitive=Phân biệt chữ hoa/thường
 
-change_assignment_of_entries=đổi_phép_gán_các_mục
+change\ assignment\ of\ entries=đổi phép gán các mục
 
-Change_case=Đổi_chữ_hoa/thường
+Change\ case=Đổi chữ hoa/thường
 
-Change_entry_type=Đổi_kiểu_của_mục
-Change_file_type=Đổi_kiểu_tập_tin
+Change\ entry\ type=Đổi kiểu của mục
+Change\ file\ type=Đổi kiểu tập tin
 
 
-Change_of_Grouping_Method=Đổi_Phương_pháp_Gộp_nhóm
+Change\ of\ Grouping\ Method=Đổi Phương pháp Gộp nhóm
 
-change_preamble=đổi_phần_mở_đầu
+change\ preamble=đổi phần mở đầu
 
-Change_table_column_and_General_fields_settings_to_use_the_new_feature=Đổi_cột_của_bảng_và_các_thiết_lập_dữ_liệu_tổng_quát_để_dùng_tính_chất_mới
+Change\ table\ column\ and\ General\ fields\ settings\ to\ use\ the\ new\ feature=Đổi cột của bảng và các thiết lập dữ liệu tổng quát để dùng tính chất mới
 
-Changed_language_settings=Các_thiết_lập_ngôn_ngữ_được_thay_đổi
+Changed\ language\ settings=Các thiết lập ngôn ngữ được thay đổi
 
-Changed_preamble=Phần_mở_đầu_được_thay_đổi
+Changed\ preamble=Phần mở đầu được thay đổi
 
-Check_existing_file_links=Kiểm_tra_tập_tin_liên_kết_hiện_có
+Check\ existing\ file\ links=Kiểm tra tập tin liên kết hiện có
 
-Check_links=Kiểm_tra_các_liên_kết
+Check\ links=Kiểm tra các liên kết
 
-Cite_command=Lệnh_trích_dẫn
+Cite\ command=Lệnh trích dẫn
 
-Class_name=Tên_lớp
+Class\ name=Tên lớp
 
 Clear=Xóa
 
-Clear_fields=Xóa_các_dữ_liệu
+Clear\ fields=Xóa các dữ liệu
 
 Close=Đóng
-Close_others=Đóng_các_mục_khác
-Close_all=Đóng_tất_cả
+Close\ others=Đóng các mục khác
+Close\ all=Đóng tất cả
 
-Close_dialog=Đóng_hộp_thoại
+Close\ dialog=Đóng hộp thoại
 
-Close_the_current_library=Đóng_CSDL_hiện_tại
+Close\ the\ current\ library=Đóng CSDL hiện tại
 
-Close_window=Đóng_cửa_sổ
+Close\ window=Đóng cửa sổ
 
-Closed_library=CSDL_được_đóng
+Closed\ library=CSDL được đóng
 
-Color_codes_for_required_and_optional_fields=Đánh_mã_màu_các_dữ_liệu_bắt_buộc_và_tùy_chọn
+Color\ codes\ for\ required\ and\ optional\ fields=Đánh mã màu các dữ liệu bắt buộc và tùy chọn
 
-Color_for_marking_incomplete_entries=Màu_để_đánh_dấu_các_mục_chưa_hoàn_tất
+Color\ for\ marking\ incomplete\ entries=Màu để đánh dấu các mục chưa hoàn tất
 
-Column_width=Chiều_rộng_cột
+Column\ width=Chiều rộng cột
 
-Command_line_id=Chỉ_số_(id)_của_dòng_lệnh
+Command\ line\ id=Chỉ số (id) của dòng lệnh
 
 
-Contained_in=Chứa_trong
+Contained\ in=Chứa trong
 
-Content=Nội_dung
+Content=Nội dung
 
-Copied=Được_chép
+Copied=Được chép
 
-Copied_cell_contents=Nội_dung_ô_được_chép
+Copied\ cell\ contents=Nội dung ô được chép
 
-Copied_title=
+Copied\ title=
 
-Copied_key=Khóa_được_chép
+Copied\ key=Khóa được chép
 
-Copied_titles=
+Copied\ titles=
 
-Copied_keys=Các_khóa_được_chép
+Copied\ keys=Các khóa được chép
 
 Copy=Chép
 
-Copy_BibTeX_key=Chép_khóa_BibTeX
-Copy_file_to_file_directory=Chép_tập_tin_vào_thư_mục_tập_tin
+Copy\ BibTeX\ key=Chép khóa BibTeX
+Copy\ file\ to\ file\ directory=Chép tập tin vào thư mục tập tin
 
-Copy_to_clipboard=Chép_vào_bộ_nhớ_tạm
+Copy\ to\ clipboard=Chép vào bộ nhớ tạm
 
-Could_not_call_executable=Không_thể_gọi_chương_trình
-Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.=Không_thể_kết_nối_đến_server_Vim._Hãy_đảm_bảo_rằng_Vim_đang_chạy<BR>với_tên_server_đúng.
+Could\ not\ call\ executable=Không thể gọi chương trình
+Could\ not\ connect\ to\ Vim\ server.\ Make\ sure\ that\ Vim\ is\ running<BR>with\ correct\ server\ name.=Không thể kết nối đến server Vim. Hãy đảm bảo rằng Vim đang chạy<BR>với tên server đúng.
 
-Could_not_export_file=Không_thể_xuất_tập_tin
+Could\ not\ export\ file=Không thể xuất tập tin
 
-Could_not_export_preferences=Không_thể_xuất_các_tùy_thích
+Could\ not\ export\ preferences=Không thể xuất các tùy thích
 
-Could_not_find_a_suitable_import_format.=Không_tìm_thấy_định_dạng_nhập_phù_hợp.
-Could_not_import_preferences=Không_thể_nhập_các_tùy_thích
+Could\ not\ find\ a\ suitable\ import\ format.=Không tìm thấy định dạng nhập phù hợp.
+Could\ not\ import\ preferences=Không thể nhập các tùy thích
 
-Could_not_instantiate_%0=Không_thể_tạo_đối_tượng_%0
-Could_not_instantiate_%0_%1=Không_thể_tạo_đối_tượng_%0_%1
-Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?=Không_thể_tạo_đối_tượng_%0._Bạn_đã_chọn_đường_dẫn_gói_đúng_chưa?
-Could_not_open_link=Không_thể_mở_liên_kết
+Could\ not\ instantiate\ %0=Không thể tạo đối tượng %0
+Could\ not\ instantiate\ %0\ %1=Không thể tạo đối tượng %0 %1
+Could\ not\ instantiate\ %0.\ Have\ you\ chosen\ the\ correct\ package\ path?=Không thể tạo đối tượng %0. Bạn đã chọn đường dẫn gói đúng chưa?
+Could\ not\ open\ link=Không thể mở liên kết
 
-Could_not_print_preview=Không_thể_in_phần_xem_trước
+Could\ not\ print\ preview=Không thể in phần xem trước
 
-Could_not_run_the_'vim'_program.=Không_thể_chạy_chương_trình_'vim'.
+Could\ not\ run\ the\ 'vim'\ program.=Không thể chạy chương trình 'vim'.
 
-Could_not_save_file.=Không_thể_lưu_tập_tin.
-Character_encoding_'%0'_is_not_supported.=Mã_hóa_ký_tự_'%0'_không_được_hỗ_trợ.
+Could\ not\ save\ file.=Không thể lưu tập tin.
+Character\ encoding\ '%0'\ is\ not\ supported.=Mã hóa ký tự '%0' không được hỗ trợ.
 
-crossreferenced_entries_included=các_mục_có_tham_chiếu_chéo_được_đưa_vào
+crossreferenced\ entries\ included=các mục có tham chiếu chéo được đưa vào
 
-Current_content=Nội_dung_hiện_tại
+Current\ content=Nội dung hiện tại
 
-Current_value=Giá_trị_hiện_tại
+Current\ value=Giá trị hiện tại
 
-Custom_entry_types=Kiểu_mục_tùy_chỉnh
+Custom\ entry\ types=Kiểu mục tùy chỉnh
 
-Custom_entry_types_found_in_file=Kiểu_mục_tùy_chỉnh_được_tìm_thấy_trong_tập_tin
+Custom\ entry\ types\ found\ in\ file=Kiểu mục tùy chỉnh được tìm thấy trong tập tin
 
-Customize_entry_types=Tùy_chỉnh_các_kiểu_mục
+Customize\ entry\ types=Tùy chỉnh các kiểu mục
 
-Customize_key_bindings=Tùy_chỉnh_tổ_hợp_phím
+Customize\ key\ bindings=Tùy chỉnh tổ hợp phím
 
 Cut=Cắt
 
-cut_entries=cắt_các_mục
+cut\ entries=cắt các mục
 
-cut_entry=cắt_mục
+cut\ entry=cắt mục
 
 
-Library_encoding=Mã_hóa_CSDL
+Library\ encoding=Mã hóa CSDL
 
-Library_properties=Tính_chất_của_CSDL
+Library\ properties=Tính chất của CSDL
 
-Library_type=Dạng_CSDL
+Library\ type=Dạng CSDL
 
-Date_format=Định_dạng_ngày
+Date\ format=Định dạng ngày
 
-Default=Mặc_định
+Default=Mặc định
 
-Default_encoding=Mã_hóa_mặc_định
+Default\ encoding=Mã hóa mặc định
 
-Default_grouping_field=Dữ_liệu_gộp_nhóm_mặc_định
+Default\ grouping\ field=Dữ liệu gộp nhóm mặc định
 
-Default_look_and_feel=Diện_mạo_mặc_định
+Default\ look\ and\ feel=Diện mạo mặc định
 
-Default_pattern=Kiểu_mặc_định
+Default\ pattern=Kiểu mặc định
 
-Default_sort_criteria=Các_tiêu_chuẩn_phân_loại_mặc_định
-Define_'%0'=Định_nghĩa_'%0'
+Default\ sort\ criteria=Các tiêu chuẩn phân loại mặc định
+Define\ '%0'=Định nghĩa '%0'
 
 Delete=Xóa
 
-Delete_custom_format=Xóa_định_dạng_tùy_chọn
+Delete\ custom\ format=Xóa định dạng tùy chọn
 
-delete_entries=xóa_các_mục
+delete\ entries=xóa các mục
 
-Delete_entry=Xóa_mục
+Delete\ entry=Xóa mục
 
-delete_entry=xóa_mục
+delete\ entry=xóa mục
 
-Delete_multiple_entries=Xóa_nhiều_mục
+Delete\ multiple\ entries=Xóa nhiều mục
 
-Delete_rows=Xóa_hàng
+Delete\ rows=Xóa hàng
 
-Delete_strings=Xóa_chuỗi
+Delete\ strings=Xóa chuỗi
 
-Deleted=Bị_xóa
+Deleted=Bị xóa
 
-Permanently_delete_local_file=Xóa_bỏ_tập_tin_cục_bộ
+Permanently\ delete\ local\ file=Xóa bỏ tập tin cục bộ
 
-Delimit_fields_with_semicolon,_ex.=Phân_cách_các_dữ_liệu_bằng,_ví_dụ_như,_dấu_chấm_phẩy.
+Delimit\ fields\ with\ semicolon,\ ex.=Phân cách các dữ liệu bằng, ví dụ như, dấu chấm phẩy.
 
-Descending=Giảm_dần
+Descending=Giảm dần
 
-Description=Mô_tả
+Description=Mô tả
 
-Deselect_all=Khử_chọn_tất_cả
-Deselect_all_duplicates=Khử_chọn_tất_cả_các_mục_lặp
+Deselect\ all=Khử chọn tất cả
+Deselect\ all\ duplicates=Khử chọn tất cả các mục lặp
 
-Disable_this_confirmation_dialog=Tắt_hộp_thoại_xác_nhận_này
+Disable\ this\ confirmation\ dialog=Tắt hộp thoại xác nhận này
 
-Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.=Trình_bày_tất_cả_các_mục_thuộc_về_một_hoặc_nhiều_nhóm_được_chọn.
+Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups.=Trình bày tất cả các mục thuộc về một hoặc nhiều nhóm được chọn.
 
-Display_all_error_messages=Trình_bày_tất_cả_thông_báo_lỗi
+Display\ all\ error\ messages=Trình bày tất cả thông báo lỗi
 
-Display_help_on_command_line_options=Trình_bày_trợ_giúp_ở_các_tùy_chọn_dòng_lệnh
+Display\ help\ on\ command\ line\ options=Trình bày trợ giúp ở các tùy chọn dòng lệnh
 
-Display_only_entries_belonging_to_all_selected_groups.=Chỉ_trình_bày_các_mục_thuộc_về_tất_cả_các_nhóm_được_chọn.
-Display_version=Trình_bày_phiên_bản
+Display\ only\ entries\ belonging\ to\ all\ selected\ groups.=Chỉ trình bày các mục thuộc về tất cả các nhóm được chọn.
+Display\ version=Trình bày phiên bản
 
-Do_not_abbreviate_names=Không_viết_tắt_tên
+Do\ not\ abbreviate\ names=Không viết tắt tên
 
-Do_not_automatically_set=Không_thiết_lập_tự_động
+Do\ not\ automatically\ set=Không thiết lập tự động
 
-Do_not_import_entry=Không_nhập_mục
+Do\ not\ import\ entry=Không nhập mục
 
-Do_not_open_any_files_at_startup=Không_mở_tập_tin_nào_lúc_khởi_động
+Do\ not\ open\ any\ files\ at\ startup=Không mở tập tin nào lúc khởi động
 
-Do_not_overwrite_existing_keys=Không_ghi_đè_các_khóa_hiện_có
-Do_not_show_these_options_in_the_future=Không_hiển_thị_những_tùy_chọn_này_trong_tương_lai
+Do\ not\ overwrite\ existing\ keys=Không ghi đè các khóa hiện có
+Do\ not\ show\ these\ options\ in\ the\ future=Không hiển thị những tùy chọn này trong tương lai
 
-Do_not_wrap_the_following_fields_when_saving=Không_'bọc'_những_dữ_liệu_dưới_đây_khi_lưu
-Do_not_write_the_following_fields_to_XMP_Metadata\:=Không_ghi_những_dữ_liệu_dưới_đây_vào_đặc_tả_dữ_liệu_XMP\:
+Do\ not\ wrap\ the\ following\ fields\ when\ saving=Không 'bọc' những dữ liệu dưới đây khi lưu
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Không ghi những dữ liệu dưới đây vào đặc tả dữ liệu XMP:
 
-Do_you_want_JabRef_to_do_the_following_operations?=Bạn_có_muốn_JabRef_thực_hiện_những_lệnh_sau?
+Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Bạn có muốn JabRef thực hiện những lệnh sau?
 
-Donate_to_JabRef=Hỗ_trợ_cho_JabRef
+Donate\ to\ JabRef=Hỗ trợ cho JabRef
 
 Down=Xuống
 
-Download_file=Tải_xuống_tập_tin
+Download\ file=Tải xuống tập tin
 
-Downloading...=Đang_tải...
+Downloading...=Đang tải...
 
-Drop_%0=Thả_%0
+Drop\ %0=Thả %0
 
-duplicate_removal=loại_bỏ_trùng
+duplicate\ removal=loại bỏ trùng
 
-Duplicate_string_name=Trùng_tên_chuỗi
+Duplicate\ string\ name=Trùng tên chuỗi
 
-Duplicates_found=Tìm_thấy_các_mục_trùng
+Duplicates\ found=Tìm thấy các mục trùng
 
-Dynamic_groups=Các_nhóm_động
+Dynamic\ groups=Các nhóm động
 
-Dynamically_group_entries_by_a_free-form_search_expression=Gộp_nhóm_động_các_mục_bằng_biểu_thức_tìm_kiếm_dạng_tự_do
+Dynamically\ group\ entries\ by\ a\ free-form\ search\ expression=Gộp nhóm động các mục bằng biểu thức tìm kiếm dạng tự do
 
-Dynamically_group_entries_by_searching_a_field_for_a_keyword=Gộp_nhóm_động_các_mục_bằng_cách_tìm_dữ_liệu_hoặc_từ_khóa
+Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=Gộp nhóm động các mục bằng cách tìm dữ liệu hoặc từ khóa
 
-Each_line_must_be_on_the_following_form=Mỗi_dòng_phải_có_dạng_sau
+Each\ line\ must\ be\ on\ the\ following\ form=Mỗi dòng phải có dạng sau
 
-Edit=Chỉnh_sửa
+Edit=Chỉnh sửa
 
-Edit_custom_export=Chỉnh_sửa_việc_xuất_tùy_chọn
-Edit_entry=Chỉnh_sửa_mục
-Save_file=Chỉnh_sửa_liên_kết_tập_tin
-Edit_file_type=Chỉnh_sửa_kiểu_tập_tin
+Edit\ custom\ export=Chỉnh sửa việc xuất tùy chọn
+Edit\ entry=Chỉnh sửa mục
+Save\ file=Chỉnh sửa liên kết tập tin
+Edit\ file\ type=Chỉnh sửa kiểu tập tin
 
-Edit_group=Chỉnh_sửa_nhóm
+Edit\ group=Chỉnh sửa nhóm
 
 
-Edit_preamble=Chỉnh_sửa_phần_mở_đầu
-Edit_strings=Chỉnh_sửa_các_chuỗi
-Editor_options=Các_tùy_chọn_trình_chỉnh_sửa
+Edit\ preamble=Chỉnh sửa phần mở đầu
+Edit\ strings=Chỉnh sửa các chuỗi
+Editor\ options=Các tùy chọn trình chỉnh sửa
 
-Empty_BibTeX_key=Khóa_BibTeX_rỗng
+Empty\ BibTeX\ key=Khóa BibTeX rỗng
 
-Grouping_may_not_work_for_this_entry.=Việc_gộp_nhóm_có_thể_không_làm_được_với_mục_này.
+Grouping\ may\ not\ work\ for\ this\ entry.=Việc gộp nhóm có thể không làm được với mục này.
 
-empty_library=CSDL_rỗng
-Enable_word/name_autocompletion=Bật_chức_năng_tự_hoàn_tất_từ/tên
+empty\ library=CSDL rỗng
+Enable\ word/name\ autocompletion=Bật chức năng tự hoàn tất từ/tên
 
-Enter_URL=Nhập_URL
+Enter\ URL=Nhập URL
 
-Enter_URL_to_download=Nhập_URL_để_tải_về
+Enter\ URL\ to\ download=Nhập URL để tải về
 
-entries=các_mục
+entries=các mục
 
-Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.=Không_thể_gán_thủ_công_hay_loại_bỏ_các_mục_khỏi_nhóm_này.
+Entries\ cannot\ be\ manually\ assigned\ to\ or\ removed\ from\ this\ group.=Không thể gán thủ công hay loại bỏ các mục khỏi nhóm này.
 
-Entries_exported_to_clipboard=Các_mục_được_xuất_ra_bộ_nhớ_tạm
+Entries\ exported\ to\ clipboard=Các mục được xuất ra bộ nhớ tạm
 
 
 entry=mục
 
-Entry_editor=Trình_chỉnh_sửa_mục
+Entry\ editor=Trình chỉnh sửa mục
 
-Entry_preview=Xem_trước_mục
+Entry\ preview=Xem trước mục
 
-Entry_table=Bảng_nhập_vào
+Entry\ table=Bảng nhập vào
 
-Entry_table_columns=Các_cột_của_bảng_nhập_vào
+Entry\ table\ columns=Các cột của bảng nhập vào
 
-Entry_type=Kiểu_của_mục
+Entry\ type=Kiểu của mục
 
-Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Kiểu_của_mục_không_được_phép_chứa_khoảng_trắng_hoặc_các_ký_tự_sau
+Entry\ type\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Kiểu của mục không được phép chứa khoảng trắng hoặc các ký tự sau
 
-Entry_types=Các_kiểu_của_mục
+Entry\ types=Các kiểu của mục
 
 Error=Lỗi
-Error_exporting_to_clipboard=Lỗi_xuất_ra_bộ_nhớ_tạm
+Error\ exporting\ to\ clipboard=Lỗi xuất ra bộ nhớ tạm
 
-Error_occurred_when_parsing_entry=Lỗi_xảy_ra_khi_đang_phân_tách_mục
+Error\ occurred\ when\ parsing\ entry=Lỗi xảy ra khi đang phân tách mục
 
-Error_opening_file=Lỗi_khi_đang_mở_tập_tin
+Error\ opening\ file=Lỗi khi đang mở tập tin
 
-Error_setting_field=Lỗi_thiết_lập_dữ_liệu
+Error\ setting\ field=Lỗi thiết lập dữ liệu
 
-Error_while_writing=Lỗi_khi_đang_ghi
-Error_writing_to_%0_file(s).=Lỗi_khi_đang_ghi_vào_tập_tin_%0.
+Error\ while\ writing=Lỗi khi đang ghi
+Error\ writing\ to\ %0\ file(s).=Lỗi khi đang ghi vào tập tin %0.
 
 
 
-'%0'_exists._Overwrite_file?='%0'_đã_có._Ghi_đè_tập_tin_không?
-Overwrite_file?=Ghi_đè_tập_tin_không?
+'%0'\ exists.\ Overwrite\ file?='%0' đã có. Ghi đè tập tin không?
+Overwrite\ file?=Ghi đè tập tin không?
 
 Export=Xuất
 
-Export_name=Xuất_tên
+Export\ name=Xuất tên
 
-Export_preferences=Xuất_các_tùy_thích
+Export\ preferences=Xuất các tùy thích
 
-Export_preferences_to_file=Xuất_các_tùy_thích_ra_tập_tin
+Export\ preferences\ to\ file=Xuất các tùy thích ra tập tin
 
-Export_properties=Các_tính_chất_xuất
+Export\ properties=Các tính chất xuất
 
-Export_to_clipboard=Xuất_ra_bộ_nhớ_tạm
+Export\ to\ clipboard=Xuất ra bộ nhớ tạm
 
-Exporting=Đang_xuất
-Extension=Đuôi_mở_rộng
+Exporting=Đang xuất
+Extension=Đuôi mở rộng
 
-External_changes=Các_thay_đổi_ngoài
+External\ changes=Các thay đổi ngoài
 
-External_file_links=Các_liên_kết_tập_tin_ngoài
+External\ file\ links=Các liên kết tập tin ngoài
 
-External_programs=Các_chương_trình_ngoài
+External\ programs=Các chương trình ngoài
 
-External_viewer_called=Trình_xem_ngoài_được_gọi
+External\ viewer\ called=Trình xem ngoài được gọi
 
-Fetch=Lấy_về
+Fetch=Lấy về
 
-Field=Dữ_liệu
+Field=Dữ liệu
 
-field=dữ_liệu
+field=dữ liệu
 
-Field_name=Tên_dữ_liệu
-Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters=Tên_dữ_liệu_không_được_phép_chứa_khoảng_trắng_hoặc_các_ký_tự_sau
+Field\ name=Tên dữ liệu
+Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=Tên dữ liệu không được phép chứa khoảng trắng hoặc các ký tự sau
 
-Field_to_filter=Dữ_liệu_cần_lọc
+Field\ to\ filter=Dữ liệu cần lọc
 
-Field_to_group_by=Dữ_liệu_gộp_nhóm_theo
+Field\ to\ group\ by=Dữ liệu gộp nhóm theo
 
-File=Tập_tin
+File=Tập tin
 
-file=tập_tin
-File_'%0'_is_already_open.=Tập_tin_'%0'_đã_mở.
+file=tập tin
+File\ '%0'\ is\ already\ open.=Tập tin '%0' đã mở.
 
-File_changed=Tập_tin_bị_thay_đổi
-File_directory_is_'%0'\:=Thư_mục_tập_tin_là_'%0'\:
+File\ changed=Tập tin bị thay đổi
+File\ directory\ is\ '%0'\:=Thư mục tập tin là '%0':
 
-File_directory_is_not_set_or_does_not_exist\!=Thư_mục_tập_tin_không_được_thiết_lập_hoặc_không_tồn_tại\!
+File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=Thư mục tập tin không được thiết lập hoặc không tồn tại!
 
-File_exists=Tập_tin_đã_có
+File\ exists=Tập tin đã có
 
-File_has_been_updated_externally._What_do_you_want_to_do?=Tập_tin_đã_được_cập_nhật_ở_ngoài_chương_trình._Bạn_muốn_làm_gì?
+File\ has\ been\ updated\ externally.\ What\ do\ you\ want\ to\ do?=Tập tin đã được cập nhật ở ngoài chương trình. Bạn muốn làm gì?
 
-File_not_found=Không_thấy_tập_tin
-File_type=Kiểu_tập_tin
+File\ not\ found=Không thấy tập tin
+File\ type=Kiểu tập tin
 
-File_updated_externally=Tập_tin_được_cập_nhật_ngoài_chương_trình
+File\ updated\ externally=Tập tin được cập nhật ngoài chương trình
 
-filename=tên_tập_tin
+filename=tên tập tin
 
 Filename=
 
-Files_opened=Các_tập_tin_đã_mở
+Files\ opened=Các tập tin đã mở
 
 Filter=Lọc
 
-Filter_All=
+Filter\ All=
 
-Filter_None=
+Filter\ None=
 
-Finished_automatically_setting_external_links.=Thiết_lập_tự_động_các_liên_kết_ngoài_hoàn_tất.
+Finished\ automatically\ setting\ external\ links.=Thiết lập tự động các liên kết ngoài hoàn tất.
 
-Finished_synchronizing_file_links._Entries_changed\:_%0.=Đồng_bộ_hóa_tập_tin_liên_kết_hoàn_tất._Các_mục_thay_đổi\:_%0.
-Finished_writing_XMP-metadata._Wrote_to_%0_file(s).=Ghi_đặc_tả_dữ_liệu_XMP_hoàn_tất._Đã_ghi_vào_%0_tập_tin.
-Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).=Kết_thúc_ghi_XMP_cho_%0_tập_tin_(bỏ_qua_%1,_%2_lỗi).
+Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Đồng bộ hóa tập tin liên kết hoàn tất. Các mục thay đổi: %0.
+Finished\ writing\ XMP-metadata.\ Wrote\ to\ %0\ file(s).=Ghi đặc tả dữ liệu XMP hoàn tất. Đã ghi vào %0 tập tin.
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Kết thúc ghi XMP cho %0 tập tin (bỏ qua %1, %2 lỗi).
 
-First_select_the_entries_you_want_keys_to_be_generated_for.=Trước_tiên_hãy_chọn_các_mục_mà_bạn_muốn_tạo_khóa.
+First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Trước tiên hãy chọn các mục mà bạn muốn tạo khóa.
 
-Fit_table_horizontally_on_screen=Làm_cho_bảng_khít_chiều_ngang_màn_hình
+Fit\ table\ horizontally\ on\ screen=Làm cho bảng khít chiều ngang màn hình
 
 Float=Float
-Float_marked_entries=Các_mục_được_đánh_dấu_là_Float
+Float\ marked\ entries=Các mục được đánh dấu là Float
 
-Font_family=Họ_phông_chữ
+Font\ family=Họ phông chữ
 
-Font_preview=Xem_trước_phông_chữ
+Font\ preview=Xem trước phông chữ
 
-Font_size=Cỡ_phông_chữ
+Font\ size=Cỡ phông chữ
 
-Font_style=Kiểu_phông_chữ
+Font\ style=Kiểu phông chữ
 
-Font_selection=Trình_chọn_phông_chữ
+Font\ selection=Trình chọn phông chữ
 
-for=dùng_cho
+for=dùng cho
 
-Format_of_author_and_editor_names=Định_dạng_tên_tác_giả_và_người_biên_tập
-Format_string=Định_dạng_chuỗi
+Format\ of\ author\ and\ editor\ names=Định dạng tên tác giả và người biên tập
+Format\ string=Định dạng chuỗi
 
-Format_used=Định_dạng_được_dùng
-Formatter_name=Tên_trình_định_dạng
+Format\ used=Định dạng được dùng
+Formatter\ name=Tên trình định dạng
 
-found_in_AUX_file=tìm_thấy_trong_tập_tin_AUX
+found\ in\ AUX\ file=tìm thấy trong tập tin AUX
 
-Full_name=Tên_đầy_đủ
+Full\ name=Tên đầy đủ
 
-General=Tổng_quát
+General=Tổng quát
 
-General_fields=Các_dữ_liệu_tổng_quát
+General\ fields=Các dữ liệu tổng quát
 
 Generate=Tạo
 
-Generate_BibTeX_key=Tạo_khóa_BibTeX
+Generate\ BibTeX\ key=Tạo khóa BibTeX
 
-Generate_keys=Tạo_các_khóa
+Generate\ keys=Tạo các khóa
 
-Generate_keys_before_saving_(for_entries_without_a_key)=Tạo_các_khóa_trước_khi_lưu_(cho_các_mục_không_có_khóa)
-Generate_keys_for_imported_entries=Tạo_khóa_cho_các_mục_được_nhập_vào
+Generate\ keys\ before\ saving\ (for\ entries\ without\ a\ key)=Tạo các khóa trước khi lưu (cho các mục không có khóa)
+Generate\ keys\ for\ imported\ entries=Tạo khóa cho các mục được nhập vào
 
-Generate_now=Tạo_bây_giờ
+Generate\ now=Tạo bây giờ
 
-Generated_BibTeX_key_for=Khóa_BibTeX_được_tạo_ra_cho
+Generated\ BibTeX\ key\ for=Khóa BibTeX được tạo ra cho
 
-Generating_BibTeX_key_for=Đang_tạo_khóa_BibTeX_cho
-Get_fulltext=Nhập_toàn_văn_bản
+Generating\ BibTeX\ key\ for=Đang tạo khóa BibTeX cho
+Get\ fulltext=Nhập toàn văn bản
 
-Gray_out_non-hits=Tô_xám_các_mục_không_gặp
+Gray\ out\ non-hits=Tô xám các mục không gặp
 
-Groups=Các_nhóm
+Groups=Các nhóm
 
-Have_you_chosen_the_correct_package_path?=Bạn_đã_chọn_đường_dẫn_gói_đúng_chưa?
+Have\ you\ chosen\ the\ correct\ package\ path?=Bạn đã chọn đường dẫn gói đúng chưa?
 
-Help=Trợ_giúp
+Help=Trợ giúp
 
-Help_on_key_patterns=Trợ_giúp_về_các_kiểu_khóa
-Help_on_regular_expression_search=Trợ_giúp_về_tìm_kiếm_bằng_biểu_thức_chính_tắc
+Help\ on\ key\ patterns=Trợ giúp về các kiểu khóa
+Help\ on\ regular\ expression\ search=Trợ giúp về tìm kiếm bằng biểu thức chính tắc
 
-Hide_non-hits=Ẩn_các_mục_không_gặp
+Hide\ non-hits=Ẩn các mục không gặp
 
-Hierarchical_context=Ngữ_cảnh_có_cấp_bậc
+Hierarchical\ context=Ngữ cảnh có cấp bậc
 
-Highlight=Tô_sáng
+Highlight=Tô sáng
 Marking=
 Underline=
-Empty_Highlight=
-Empty_Marking=
-Empty_Underline=
-The_marked_area_does_not_contain_any_legible_text!=
+Empty\ Highlight=
+Empty\ Marking=
+Empty\ Underline=
+The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=
 
-Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>=Gợi_ý\:_Để_chỉ_tìm_kiếm_các_dữ_liệu_đặc_thù,_nhập,_ví_dụ_như\:<p><tt>author\=smith_and_title\=electrical</tt>
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Gợi ý: Để chỉ tìm kiếm các dữ liệu đặc thù, nhập, ví dụ như:<p><tt>author=smith and title=electrical</tt>
 
-HTML_table=Bảng_HTML
-HTML_table_(with_Abstract_&_BibTeX)=Bảng_HTML_(với_Tóm_tắt_&_BibTeX)
-Icon=Biểu_tượng
+HTML\ table=Bảng HTML
+HTML\ table\ (with\ Abstract\ &\ BibTeX)=Bảng HTML (với Tóm tắt & BibTeX)
+Icon=Biểu tượng
 
-Ignore=Bỏ_qua
+Ignore=Bỏ qua
 
 Import=Nhập
 
-Import_and_keep_old_entry=Nhập_và_giữ_mục_cũ
+Import\ and\ keep\ old\ entry=Nhập và giữ mục cũ
 
-Import_and_remove_old_entry=Nhập_và_loại_bỏ_mục_cũ
+Import\ and\ remove\ old\ entry=Nhập và loại bỏ mục cũ
 
-Import_entries=Nhập_các_mục
+Import\ entries=Nhập các mục
 
-Import_failed=Việc_nhập_thất_bại
+Import\ failed=Việc nhập thất bại
 
-Import_file=Nhập_tập_tin
+Import\ file=Nhập tập tin
 
-Import_group_definitions=Nhập_các_định_nghĩa_nhóm
+Import\ group\ definitions=Nhập các định nghĩa nhóm
 
-Import_name=Nhập_tên
+Import\ name=Nhập tên
 
-Import_preferences=Nhập_các_tùy_thích
+Import\ preferences=Nhập các tùy thích
 
-Import_preferences_from_file=Nhập_các_tùy_thích_từ_tập_tin
+Import\ preferences\ from\ file=Nhập các tùy thích từ tập tin
 
-Import_strings=Nhập_các_chuỗi
+Import\ strings=Nhập các chuỗi
 
-Import_to_open_tab=Nhập_vào_thẻ_đang_mở
+Import\ to\ open\ tab=Nhập vào thẻ đang mở
 
-Import_word_selector_definitions=Nhập_các_định_nghĩa_trình_chọn_từ
+Import\ word\ selector\ definitions=Nhập các định nghĩa trình chọn từ
 
-Imported_entries=Các_mục_được_nhập
+Imported\ entries=Các mục được nhập
 
-Imported_from_library=được_nhập_từ_CSDL
+Imported\ from\ library=được nhập từ CSDL
 
-Importer_class=Lớp_ĐịnhdạngNhập
+Importer\ class=Lớp ĐịnhdạngNhập
 
-Importing=Đang_nhập
+Importing=Đang nhập
 
-Importing_in_unknown_format=Nhập_vào_thành_định_dạng_không_rõ
+Importing\ in\ unknown\ format=Nhập vào thành định dạng không rõ
 
-Include_abstracts=Đưa_vào_cả_phần_tóm_tắt
-Include_entries=Đưa_vào_các_mục
+Include\ abstracts=Đưa vào cả phần tóm tắt
+Include\ entries=Đưa vào các mục
 
-Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups=Đưa_vào_các_nhóm_con\:_Khi_được_chọn,_xem_các_mục_chứa_trong_nhóm_này_hoặc_các_nhóm_phụ_của_nó
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=Đưa vào các nhóm con: Khi được chọn, xem các mục chứa trong nhóm này hoặc các nhóm phụ của nó
 
-Independent_group\:_When_selected,_view_only_this_group's_entries=Nhóm_độc_lập\:_Khi_được_chọn,_chỉ_xem_các_mục_của_nhóm_này
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=Nhóm độc lập: Khi được chọn, chỉ xem các mục của nhóm này
 
-Work_options=Các_tùy_chọn_làm_việc
+Work\ options=Các tùy chọn làm việc
 
 Insert=Chèn
 
-Insert_rows=Chèn_hàng
+Insert\ rows=Chèn hàng
 
-Intersection=Giao_nhau
+Intersection=Giao nhau
 
-Invalid_BibTeX_key=Khóa_BibTeX_không_hợp_lệ
+Invalid\ BibTeX\ key=Khóa BibTeX không hợp lệ
 
-Invalid_date_format=Định_dạng_ngày_không_hợp_lệ
+Invalid\ date\ format=Định dạng ngày không hợp lệ
 
-Invalid_URL=URL_không_hợp_lệ
+Invalid\ URL=URL không hợp lệ
 
-Online_help=Trợ_giúp_trực_tuyến
+Online\ help=Trợ giúp trực tuyến
 
-JabRef_preferences=Các_tùy_thích_JabRef
+JabRef\ preferences=Các tùy thích JabRef
 
 Join=
 
-Joins_selected_keywords_and_deletes_selected_keywords.=
+Joins\ selected\ keywords\ and\ deletes\ selected\ keywords.=
 
-Journal_abbreviations=Các_viết_tắt_tên_tạp_chí
+Journal\ abbreviations=Các viết tắt tên tạp chí
 
 Keep=Giữ
 
-Keep_both=Giữ_cả
+Keep\ both=Giữ cả
 
-Key_bindings=Các_tổ_hợp_phím
+Key\ bindings=Các tổ hợp phím
 
-Key_bindings_changed=Các_tổ_hợp_phím_thay_đổi
+Key\ bindings\ changed=Các tổ hợp phím thay đổi
 
-Key_generator_settings=Các_thiết_lập_trình_tạo_khóa
+Key\ generator\ settings=Các thiết lập trình tạo khóa
 
-Key_pattern=Kiểu_mẫu_khóa
+Key\ pattern=Kiểu mẫu khóa
 
-keys_in_library=các_khóa_trong_CSDL
+keys\ in\ library=các khóa trong CSDL
 
-Keyword=Từ_khóa
+Keyword=Từ khóa
 
 Label=Nhãn
 
-Language=Ngôn_ngữ
+Language=Ngôn ngữ
 
-Last_modified=Thay_đổi_lần_sau_cùng
+Last\ modified=Thay đổi lần sau cùng
 
-LaTeX_AUX_file=Tập_tin_LaTeX_AUX
-Leave_file_in_its_current_directory=Giữ_tập_tin_trong_thư_mục_hiện_tại_của_nó
+LaTeX\ AUX\ file=Tập tin LaTeX AUX
+Leave\ file\ in\ its\ current\ directory=Giữ tập tin trong thư mục hiện tại của nó
 
 Left=Trái
-Level=Mức_độ
+Level=Mức độ
 
-Limit_to_fields=Giới_hạn_cho_các_dữ_liệu
+Limit\ to\ fields=Giới hạn cho các dữ liệu
 
-Limit_to_selected_entries=Giới_hạn_theo_các_mục_được_chọn
+Limit\ to\ selected\ entries=Giới hạn theo các mục được chọn
 
-Link=Liên_kết
-Link_local_file=Liên_kết_tập_tin_cục_bộ
-Link_to_file_%0=Liên_kết_đến_tập_tin_%0
+Link=Liên kết
+Link\ local\ file=Liên kết tập tin cục bộ
+Link\ to\ file\ %0=Liên kết đến tập tin %0
 
-Listen_for_remote_operation_on_port=Lắng_nghe_lệnh_chạy_từ_xa_tại_cổng
-Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)=Nạp_và_lưu_các_tùy_thích_từ/đến_tập_tin_jabref.xml_khi_khởi_động_(chế_độ_thẻ_nhớ)
+Listen\ for\ remote\ operation\ on\ port=Lắng nghe lệnh chạy từ xa tại cổng
+Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=Nạp và lưu các tùy thích từ/đến tập tin jabref.xml khi khởi động (chế độ thẻ nhớ)
 
-Look_and_feel=Hình_thức
-Main_file_directory=Thư_mục_tập_tin_chính
+Look\ and\ feel=Hình thức
+Main\ file\ directory=Thư mục tập tin chính
 
-Main_layout_file=Tập_tin_trình_bày_chính
+Main\ layout\ file=Tập tin trình bày chính
 
-Manage_custom_exports=Quản_lý_các_phép_xuất_tùy_chọn
+Manage\ custom\ exports=Quản lý các phép xuất tùy chọn
 
-Manage_custom_imports=Quản_lý_các_phép_nhập_tùy_chọn
-Manage_external_file_types=Quản_lý_các_kiểu_tập_tin_ngoài
+Manage\ custom\ imports=Quản lý các phép nhập tùy chọn
+Manage\ external\ file\ types=Quản lý các kiểu tập tin ngoài
 
-Mark_entries=Đánh_dấu_các_mục
+Mark\ entries=Đánh dấu các mục
 
-Mark_entry=Đánh_dấu_mục
+Mark\ entry=Đánh dấu mục
 
-Mark_new_entries_with_addition_date=Đánh_dấu_các_mục_mới_với_ngày_được_thêm_vào
+Mark\ new\ entries\ with\ addition\ date=Đánh dấu các mục mới với ngày được thêm vào
 
-Mark_new_entries_with_owner_name=Đánh_dấu_các_mục_mới_cùng_với_tên_người_sở_hữu
+Mark\ new\ entries\ with\ owner\ name=Đánh dấu các mục mới cùng với tên người sở hữu
 
-Memory_stick_mode=Chế_độ_thẻ_nhớ
+Memory\ stick\ mode=Chế độ thẻ nhớ
 
-Menu_and_label_font_size=Cỡ_phông_chữ_trình_đơn_và_nhãn
+Menu\ and\ label\ font\ size=Cỡ phông chữ trình đơn và nhãn
 
-Merged_external_changes=Các_thay_đổi_ngoài_được_gộp_lại
+Merged\ external\ changes=Các thay đổi ngoài được gộp lại
 
-Messages=Các_thông_báo
+Messages=Các thông báo
 
-Modification_of_field=Sự_điều_chỉnh_của_dữ_liệu
+Modification\ of\ field=Sự điều chỉnh của dữ liệu
 
-Modified_group_"%0".=Nhóm_"%0"_được_điều_chỉnh.
+Modified\ group\ "%0".=Nhóm "%0" được điều chỉnh.
 
-Modified_groups=Các_nhóm_được_điều_chỉnh
+Modified\ groups=Các nhóm được điều chỉnh
 
-Modified_string=Chuỗi_được_điều_chỉnh
+Modified\ string=Chuỗi được điều chỉnh
 
-Modify=Điều_chỉnh
+Modify=Điều chỉnh
 
-modify_group=điều_chỉnh_nhóm
+modify\ group=điều chỉnh nhóm
 
-Move_down=Chuyển_xuống
+Move\ down=Chuyển xuống
 
-Move_external_links_to_'file'_field=Chuyển_các_liên_kết_ngoài_vào_dữ_liệu_'file'
+Move\ external\ links\ to\ 'file'\ field=Chuyển các liên kết ngoài vào dữ liệu 'file'
 
-move_group=chuyển_nhóm
+move\ group=chuyển nhóm
 
-Move_up=Chuyển_lên
+Move\ up=Chuyển lên
 
-Moved_group_"%0".=Đã_chuyển_nhóm_"%0".
+Moved\ group\ "%0".=Đã chuyển nhóm "%0".
 
 Name=Tên
-Name_formatter=Trình_định_dạng_tên
+Name\ formatter=Trình định dạng tên
 
-Natbib_style=Kiểu_Natbib
+Natbib\ style=Kiểu Natbib
 
-nested_AUX_files=các_tập_tin_AUX_lồng_nhau
+nested\ AUX\ files=các tập tin AUX lồng nhau
 
 New=Mới
 
 new=mới
 
-New_BibTeX_entry=Mục_BibTeX_mới
+New\ BibTeX\ entry=Mục BibTeX mới
 
-New_BibTeX_sublibrary=CSDL_con_BibTeX_mới
+New\ BibTeX\ sublibrary=CSDL con BibTeX mới
 
-New_content=Nội_dung_mới
+New\ content=Nội dung mới
 
-New_library_created.=CSDL_mới_được_tao_ra.
-New_%0_library=CSDL_%0_mới
-New_field_value=Giá_trị_dữ_liệu_mới
+New\ library\ created.=CSDL mới được tao ra.
+New\ %0\ library=CSDL %0 mới
+New\ field\ value=Giá trị dữ liệu mới
 
-New_group=Nhóm_mới
+New\ group=Nhóm mới
 
-New_string=Chuỗi_mới
+New\ string=Chuỗi mới
 
-Next_entry=Mục_tiếp
+Next\ entry=Mục tiếp
 
-No_actual_changes_found.=Không_thấy_thay_đổi_thực_sự_nào.
+No\ actual\ changes\ found.=Không thấy thay đổi thực sự nào.
 
-no_base-BibTeX-file_specified=tập_tin_kiểu-BibTeX_không_được_chỉ_định
+no\ base-BibTeX-file\ specified=tập tin kiểu-BibTeX không được chỉ định
 
-no_library_generated=Không_có_CSDL_nào_được_tạo_ra
+no\ library\ generated=Không có CSDL nào được tạo ra
 
-No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.=Không_tìm_thấy_mục_nào._Hãy_đảm_bảo_rằng_bạn_đang_dùng_bộ_lọc_nhập_đúng.
+No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=Không tìm thấy mục nào. Hãy đảm bảo rằng bạn đang dùng bộ lọc nhập đúng.
 
 
-No_entries_found_for_the_search_string_'%0'=Không_tìm_thấy_mục_nào_với_chuỗi_tìm_kiếm_'%0'
+No\ entries\ found\ for\ the\ search\ string\ '%0'=Không tìm thấy mục nào với chuỗi tìm kiếm '%0'
 
-No_entries_imported.=Không_mục_nào_được_nhập.
+No\ entries\ imported.=Không mục nào được nhập.
 
-No_files_found.=Không_tìm_thấy_tập_tin_nào.
+No\ files\ found.=Không tìm thấy tập tin nào.
 
-No_GUI._Only_process_command_line_options.=Không_có_GDĐH._Chỉ_xử_lý_các_tùy_chọn_dòng_lệnh.
+No\ GUI.\ Only\ process\ command\ line\ options.=Không có GDĐH. Chỉ xử lý các tùy chọn dòng lệnh.
 
-No_journal_names_could_be_abbreviated.=Không_có_tên_tạp_chí_nào_có_thể_viết_tắt.
+No\ journal\ names\ could\ be\ abbreviated.=Không có tên tạp chí nào có thể viết tắt.
 
-No_journal_names_could_be_unabbreviated.=Không_có_tên_tạp_chí_nào_có_thể_viết_đầy_đủ.
-No_PDF_linked=Không_có_tập_tin_PDF_nào_được_liên_kết
+No\ journal\ names\ could\ be\ unabbreviated.=Không có tên tạp chí nào có thể viết đầy đủ.
+No\ PDF\ linked=Không có tập tin PDF nào được liên kết
 
-Open_PDF=
+Open\ PDF=
 
-No_URL_defined=Không_có_url_nào_được_định_nghĩa
+No\ URL\ defined=Không có url nào được định nghĩa
 not=không
 
-not_found=không_tìm_thấy
+not\ found=không tìm thấy
 
-Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,=Lưu_ý_rằng_bạn_phải_chỉ_định_tên_lớp_đủ_điều_kiện_dùng_cho_diện_mạo,
+Note\ that\ you\ must\ specify\ the\ fully\ qualified\ class\ name\ for\ the\ look\ and\ feel,=Lưu ý rằng bạn phải chỉ định tên lớp đủ điều kiện dùng cho diện mạo,
 
-Nothing_to_redo=Không_có_lệnh_nào_để_lặp_lại
+Nothing\ to\ redo=Không có lệnh nào để lặp lại
 
-Nothing_to_undo=Không_có_lệnh_nào_để_quay_ngược_lại
+Nothing\ to\ undo=Không có lệnh nào để quay ngược lại
 
-occurrences=các_lần_xuất_hiện
+occurrences=các lần xuất hiện
 
-OK=Đồng_ý
-One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Một_hoặc_nhiều_liên_kết_thuộc_kiểu_'%0',_tức_là_loại_không_xác_định._Bạn_muốn_làm_gì?
+OK=Đồng ý
+One\ or\ more\ file\ links\ are\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Một hoặc nhiều liên kết thuộc kiểu '%0', tức là loại không xác định. Bạn muốn làm gì?
 
-One_or_more_keys_will_be_overwritten._Continue?=Một_hoặc_nhiều_khóa_sẽ_bị_ghi_đè._Có_tiếp_tục_không?
+One\ or\ more\ keys\ will\ be\ overwritten.\ Continue?=Một hoặc nhiều khóa sẽ bị ghi đè. Có tiếp tục không?
 
 
 Open=Mở
 
-Open_BibTeX_library=Mở_CSDL_BibTeX
+Open\ BibTeX\ library=Mở CSDL BibTeX
 
-Open_library=Mở_CSDL
+Open\ library=Mở CSDL
 
-Open_editor_when_a_new_entry_is_created=Mở_trình_biên_tập_khi_một_mục_mới_được_tao
+Open\ editor\ when\ a\ new\ entry\ is\ created=Mở trình biên tập khi một mục mới được tao
 
-Open_file=Mở_tập_tin
+Open\ file=Mở tập tin
 
-Open_last_edited_libraries_at_startup=Mở_CSDL_chỉnh_sửa_lần_cuối_khi_khởi_động
+Open\ last\ edited\ libraries\ at\ startup=Mở CSDL chỉnh sửa lần cuối khi khởi động
 
-Connect_to_shared_database=Mở_CSDL_chia_sẻ
+Connect\ to\ shared\ database=Mở CSDL chia sẻ
 
-Open_terminal_here=Mở_terminal_ở_đây
+Open\ terminal\ here=Mở terminal ở đây
 
-Open_URL_or_DOI=Mở_URL_hoặc_DOI
+Open\ URL\ or\ DOI=Mở URL hoặc DOI
 
-Opened_library=CSDL_được_mở
+Opened\ library=CSDL được mở
 
-Opening=Đang_mỏ
+Opening=Đang mỏ
 
-Opening_preferences...=Đang_mở_các_tùy_thích...
+Opening\ preferences...=Đang mở các tùy thích...
 
-Operation_canceled.=Lệnh_bị_hủy.
-Operation_not_supported=Lệnh_không_được_hỗ_trợ
+Operation\ canceled.=Lệnh bị hủy.
+Operation\ not\ supported=Lệnh không được hỗ trợ
 
-Optional_fields=Các_dữ_liệu_tùy_chọn
+Optional\ fields=Các dữ liệu tùy chọn
 
-Options=Tùy_chọn
+Options=Tùy chọn
 
 or=hoặc
 
-Output_or_export_file=Đầu_ra_hoặc_tập_tin_xuất
+Output\ or\ export\ file=Đầu ra hoặc tập tin xuất
 
-Override=Ghi_đè
+Override=Ghi đè
 
-Override_default_file_directories=Ghi_đè_các_thư_mục_tập_tin_mặc_định
+Override\ default\ file\ directories=Ghi đè các thư mục tập tin mặc định
 
-Override_default_font_settings=Ghi_đè_các_thiết_lập_phông_chữ_mặc_định
+Override\ default\ font\ settings=Ghi đè các thiết lập phông chữ mặc định
 
-Override_the_BibTeX_field_by_the_selected_text=Ghi_đè_khóa_BibTeX_bằng_chữ_được_chọn
+Override\ the\ BibTeX\ field\ by\ the\ selected\ text=Ghi đè khóa BibTeX bằng chữ được chọn
 
 
-Overwrite=Ghi_đè
-Overwrite_existing_field_values=Ghi_đè_các_giá_trị_dữ_liệu_hiện_có
+Overwrite=Ghi đè
+Overwrite\ existing\ field\ values=Ghi đè các giá trị dữ liệu hiện có
 
-Overwrite_keys=Ghi_đè_các_khóa
+Overwrite\ keys=Ghi đè các khóa
 
-pairs_processed=các_cặp_được_xử_lý
-Password=Mật_mã
+pairs\ processed=các cặp được xử lý
+Password=Mật mã
 
 Paste=Dán
 
-paste_entries=dán_các_mục
+paste\ entries=dán các mục
 
-paste_entry=dán_mục
-Paste_from_clipboard=Dán_từ_bộ_nhớ_tạm
+paste\ entry=dán mục
+Paste\ from\ clipboard=Dán từ bộ nhớ tạm
 
-Pasted=Được_dán
+Pasted=Được dán
 
-Path_to_%0_not_defined=Đường_dẫn_đến_%0_không_được_định_nghĩa
+Path\ to\ %0\ not\ defined=Đường dẫn đến %0 không được định nghĩa
 
-Path_to_LyX_pipe=Đường_dẫn_đến_ống_dẫn_LyX
+Path\ to\ LyX\ pipe=Đường dẫn đến ống dẫn LyX
 
-PDF_does_not_exist=PDF_không_tồn_tại
+PDF\ does\ not\ exist=PDF không tồn tại
 
-File_has_no_attached_annotations=
+File\ has\ no\ attached\ annotations=
 
-Plain_text_import=Nhập_văn_bản_trơn
+Plain\ text\ import=Nhập văn bản trơn
 
-Please_enter_a_name_for_the_group.=Vui_lòng_nhập_tên_cho_nhóm.
+Please\ enter\ a\ name\ for\ the\ group.=Vui lòng nhập tên cho nhóm.
 
-Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>=Vui_lòng_nhập_một_thuật_ngữ_tìm_kiếm._Ví_dụ,_để_tìm_từ_<b>Smith</b>_trong_tất_cả_các_dữ_liệu,_nhập\:<p><tt>smith</tt><p>._Để_tìm_từ_<b>Smith</b>_trong_dữ_liệu_<b>Author</b>_và_từ_<b>electrical</b>_trong_dữ_liệu_<b>Title</b>,_nhập\:<p><tt>author\=smith_và_title\=electrical</tt>
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Vui lòng nhập một thuật ngữ tìm kiếm. Ví dụ, để tìm từ <b>Smith</b> trong tất cả các dữ liệu, nhập:<p><tt>smith</tt><p>. Để tìm từ <b>Smith</b> trong dữ liệu <b>Author</b> và từ <b>electrical</b> trong dữ liệu <b>Title</b>, nhập:<p><tt>author=smith và title=electrical</tt>
 
-Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=Vui_lòng_nhập_dữ_liệu_cần_tìm_(ví_dụ\:_<b>từ_khoá</b>)_và_từ_khóa_cần_tìm_kiếm_trong_dữ_liệu_đó_(ví_dụ\:_<b>electrical</b>).
+Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=Vui lòng nhập dữ liệu cần tìm (ví dụ: <b>từ khoá</b>) và từ khóa cần tìm kiếm trong dữ liệu đó (ví dụ: <b>electrical</b>).
 
-Please_enter_the_string's_label=Vui_lòng_nhập_nhãn_của_chuỗi
+Please\ enter\ the\ string's\ label=Vui lòng nhập nhãn của chuỗi
 
-Please_select_an_importer.=Vui_lòng_chọn_một_trình_nhập.
+Please\ select\ an\ importer.=Vui lòng chọn một trình nhập.
 
-Possible_duplicate_entries=Các_mục_có_thể_bị_trùng
+Possible\ duplicate\ entries=Các mục có thể bị trùng
 
-Possible_duplicate_of_existing_entry._Click_to_resolve.=Có_thể_mục_hiện_có_bị_trùng._Nhắp_chuột_để_giải.
+Possible\ duplicate\ of\ existing\ entry.\ Click\ to\ resolve.=Có thể mục hiện có bị trùng. Nhắp chuột để giải.
 
-Preamble=Phần_mở_đầu
+Preamble=Phần mở đầu
 
-Preferences=Các_tùy_thích
+Preferences=Các tùy thích
 
-Preferences_recorded.=Các_tùy_thích_được_ghi_lại.
+Preferences\ recorded.=Các tùy thích được ghi lại.
 
-Preview=Xem_trước
-Citation_Style=Kiểu_trích_dẫn
-Current_Preview=Xem_trước_hiện_tại
-Cannot_generate_preview_based_on_selected_citation_style.=Không_thể_tạo_ra_xem_trước_dựa_trên_kiểu_trích_dẫn_đã_chọn.
-Bad_character_inside_entry=Kí_tự_xấu_trong_mục
-Error_while_generating_citation_style=Lỗi_trong_khi_tạo_ra_kiểu_trích_dẫn
-Preview_style_changed_to\:_%0=Thay_đổi_kiểu_xem_trước_theo\:_%0
-Next_preview_layout=Xem_trước_bố_trí_tiếp_theo
-Previous_preview_layout=Xem_trước_bố_trí_trước_đó
+Preview=Xem trước
+Citation\ Style=Kiểu trích dẫn
+Current\ Preview=Xem trước hiện tại
+Cannot\ generate\ preview\ based\ on\ selected\ citation\ style.=Không thể tạo ra xem trước dựa trên kiểu trích dẫn đã chọn.
+Bad\ character\ inside\ entry=Kí tự xấu trong mục
+Error\ while\ generating\ citation\ style=Lỗi trong khi tạo ra kiểu trích dẫn
+Preview\ style\ changed\ to\:\ %0=Thay đổi kiểu xem trước theo: %0
+Next\ preview\ layout=Xem trước bố trí tiếp theo
+Previous\ preview\ layout=Xem trước bố trí trước đó
 
-Previous_entry=Mục_trước_đó
+Previous\ entry=Mục trước đó
 
-Primary_sort_criterion=Tiêu_chuẩn_xếp_thứ_tự_chính
-Problem_with_parsing_entry=Trục_trặc_khi_phân_tách_mục
-Processing_%0=Đang_xử_lý_%0
-Pull_changes_from_shared_database=Kéo_thay_đổi_từ_CSDL_chia_sẻ
+Primary\ sort\ criterion=Tiêu chuẩn xếp thứ tự chính
+Problem\ with\ parsing\ entry=Trục trặc khi phân tách mục
+Processing\ %0=Đang xử lý %0
+Pull\ changes\ from\ shared\ database=Kéo thay đổi từ CSDL chia sẻ
 
-Pushed_citations_to_%0=Các_trích_dẫn_đã_được_đưa_qua_%0
+Pushed\ citations\ to\ %0=Các trích dẫn đã được đưa qua %0
 
-Quit_JabRef=Thoát_JabRef
+Quit\ JabRef=Thoát JabRef
 
-Quit_synchronization=Thôi_đồng_bộ_hóa
+Quit\ synchronization=Thôi đồng bộ hóa
 
-Raw_source=Nguồn_thô
+Raw\ source=Nguồn thô
 
-Rearrange_tabs_alphabetically_by_title=Xếp_lại_các_thẻ_theo_thứ_tự_ABC_theo_tiêu_đề
+Rearrange\ tabs\ alphabetically\ by\ title=Xếp lại các thẻ theo thứ tự ABC theo tiêu đề
 
-Redo=Lặp_lại_lệnh
+Redo=Lặp lại lệnh
 
-Reference_library=CSDL_tham_khảo
+Reference\ library=CSDL tham khảo
 
-%0_references_found._Number_of_references_to_fetch?=Các_tài_liệu_tham_khảo_được_tìm_thấy\:_%0._Số_lượng_tài_liệu_tham_khảo_cần_lấy_về?
+%0\ references\ found.\ Number\ of\ references\ to\ fetch?=Các tài liệu tham khảo được tìm thấy: %0. Số lượng tài liệu tham khảo cần lấy về?
 
-Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=Tinh_chỉnh_nhóm_lớn\:_Khi_được_chọn,_xem_các_mục_chứa_các_trong_nhóm_này_và_nhóm_lớn_của_nó
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=Tinh chỉnh nhóm lớn: Khi được chọn, xem các mục chứa các trong nhóm này và nhóm lớn của nó
 
-regular_expression=Biểu_thức_chính_tắc
+regular\ expression=Biểu thức chính tắc
 
-Related_articles=
+Related\ articles=
 
-Remote_operation=Lệnh_từ_xa
+Remote\ operation=Lệnh từ xa
 
-Remote_server_port=Cổng_máy_chủ_từ_xa
+Remote\ server\ port=Cổng máy chủ từ xa
 
-Remove=Loại_bỏ
+Remove=Loại bỏ
 
-Remove_subgroups=Loại_bỏ_tất_cả_các_nhóm_con
+Remove\ subgroups=Loại bỏ tất cả các nhóm con
 
-Remove_all_subgroups_of_"%0"?=Loại_bỏ_tất_cả_các_nhóm_con_của_"%0"?
+Remove\ all\ subgroups\ of\ "%0"?=Loại bỏ tất cả các nhóm con của "%0"?
 
-Remove_entry_from_import=Loại_bỏ_mục_khỏi_lệnh_nhập
+Remove\ entry\ from\ import=Loại bỏ mục khỏi lệnh nhập
 
-Remove_selected_entries_from_this_group=
+Remove\ selected\ entries\ from\ this\ group=
 
-Remove_entry_type=Loại_bỏ_kiểu_mục
+Remove\ entry\ type=Loại bỏ kiểu mục
 
-Remove_from_group=Loại_bỏ_khỏi_nhóm
+Remove\ from\ group=Loại bỏ khỏi nhóm
 
-Remove_group=Loại_bỏ_nhóm
+Remove\ group=Loại bỏ nhóm
 
-Remove_group,_keep_subgroups=Loại_bỏ_nhóm,_giữ_lại_các_nhóm_con
+Remove\ group,\ keep\ subgroups=Loại bỏ nhóm, giữ lại các nhóm con
 
-Remove_group_"%0"?=Loại_bỏ_nhóm_"%0"?
+Remove\ group\ "%0"?=Loại bỏ nhóm "%0"?
 
-Remove_group_"%0"_and_its_subgroups?=Loại_bỏ_nhóm_"%0"_và_các_nhóm_con_của_nó?
+Remove\ group\ "%0"\ and\ its\ subgroups?=Loại bỏ nhóm "%0" và các nhóm con của nó?
 
-remove_group_(keep_subgroups)=loại_bỏ_nhóm_(giữ_các_nhóm_con)
+remove\ group\ (keep\ subgroups)=loại bỏ nhóm (giữ các nhóm con)
 
-remove_group_and_subgroups=loại_bỏ_nhóm_và_các_nhóm_con
+remove\ group\ and\ subgroups=loại bỏ nhóm và các nhóm con
 
-Remove_group_and_subgroups=Loại_bỏ_nhóm_và_các_nhóm_con
+Remove\ group\ and\ subgroups=Loại bỏ nhóm và các nhóm con
 
-Remove_link=Loại_bỏ_liên_kết
+Remove\ link=Loại bỏ liên kết
 
-Remove_old_entry=Loại_bỏ_mục_cũ
+Remove\ old\ entry=Loại bỏ mục cũ
 
-Remove_selected_strings=Loại_bỏ_các_chuỗi_được_chọn
+Remove\ selected\ strings=Loại bỏ các chuỗi được chọn
 
-Removed_group_"%0".=Đã_loại_bỏ_nhóm_"%0".
+Removed\ group\ "%0".=Đã loại bỏ nhóm "%0".
 
-Removed_group_"%0"_and_its_subgroups.=Đã_loại_bỏ_nhóm_"%0"_và_các_nhóm_con_của_nó.
+Removed\ group\ "%0"\ and\ its\ subgroups.=Đã loại bỏ nhóm "%0" và các nhóm con của nó.
 
-Removed_string=Đã_loại_bỏ_chuỗi
+Removed\ string=Đã loại bỏ chuỗi
 
-Renamed_string=Chuỗi_được_đặt_tên_lại
+Renamed\ string=Chuỗi được đặt tên lại
 
 Replace=
 
-Replace_(regular_expression)=Thay_thế_(biểu_thức_chính_tắc)
+Replace\ (regular\ expression)=Thay thế (biểu thức chính tắc)
 
-Replace_string=Thay_thế_chuỗi
+Replace\ string=Thay thế chuỗi
 
-Replace_with=Thay_thế_bởi
+Replace\ with=Thay thế bởi
 
-Replaced=Bị_thay_thế
+Replaced=Bị thay thế
 
-Required_fields=Các_dữ_liệu_cần_có
+Required\ fields=Các dữ liệu cần có
 
-Reset_all=Thiết_lập_lại_tất_cả
+Reset\ all=Thiết lập lại tất cả
 
-Resolve_strings_for_all_fields_except=Giải_các_chuỗi_cho_tất_cả_các_dữ_liệu_ngoại_trừ
-Resolve_strings_for_standard_BibTeX_fields_only=Chỉ_giải_các_chuỗi_cho_các_dữ_liệu_BibTeX
+Resolve\ strings\ for\ all\ fields\ except=Giải các chuỗi cho tất cả các dữ liệu ngoại trừ
+Resolve\ strings\ for\ standard\ BibTeX\ fields\ only=Chỉ giải các chuỗi cho các dữ liệu BibTeX
 
-resolved=được_giải
+resolved=được giải
 
-Review=Xem_xét_lại
+Review=Xem xét lại
 
-Review_changes=Xem_xét_lại_các_thay_đổi
+Review\ changes=Xem xét lại các thay đổi
 
 Right=Phải
 
 Save=Lưu
-Save_all_finished.=Lưu_tất_cả_đã_hoàn_tất.
+Save\ all\ finished.=Lưu tất cả đã hoàn tất.
 
-Save_all_open_libraries=Lưu_tất_cả_các_CSDL_đang_mở
+Save\ all\ open\ libraries=Lưu tất cả các CSDL đang mở
 
-Save_before_closing=Lưu_trước_khi_đóng
+Save\ before\ closing=Lưu trước khi đóng
 
-Save_library=Lưu_CSDL
-Save_library_as...=Lưu_CSDL_thành_...
+Save\ library=Lưu CSDL
+Save\ library\ as...=Lưu CSDL thành ...
 
-Save_entries_in_their_original_order=Lưu_các_mục_theo_thứ_tự_gốc_của_chúng
+Save\ entries\ in\ their\ original\ order=Lưu các mục theo thứ tự gốc của chúng
 
-Save_failed=Việc_lưu_thất_bại
+Save\ failed=Việc lưu thất bại
 
-Save_failed_during_backup_creation=Việc_lưu_thất_bại_khi_đang_tạo_bản_sao_lưu
+Save\ failed\ during\ backup\ creation=Việc lưu thất bại khi đang tạo bản sao lưu
 
-Save_selected_as...=Lưu_phần_chọn_thành_...
+Save\ selected\ as...=Lưu phần chọn thành ...
 
-Saved_library=Đã_lưu_CSDL
+Saved\ library=Đã lưu CSDL
 
-Saved_selected_to_'%0'.=Đã_lưu_phần_chọn_vào_'%0'.
+Saved\ selected\ to\ '%0'.=Đã lưu phần chọn vào '%0'.
 
-Saving=Đang_lưu
-Saving_all_libraries...=Đang_lưu_tất_cả_CSDL...
+Saving=Đang lưu
+Saving\ all\ libraries...=Đang lưu tất cả CSDL...
 
-Saving_library=Đang_lưu_CSDL
+Saving\ library=Đang lưu CSDL
 
 Search=Tìm
 
-Search_expression=Biểu_thức_tìm_kiếm
+Search\ expression=Biểu thức tìm kiếm
 
-Search_for=Tìm
+Search\ for=Tìm
 
-Searching_for_duplicates...=Đang_tìm_các_mục_bị_lặp...
+Searching\ for\ duplicates...=Đang tìm các mục bị lặp...
 
-Searching_for_files=Đang_tìm_các_tập_tin
+Searching\ for\ files=Đang tìm các tập tin
 
-Secondary_sort_criterion=Tiêu_chuẩn_phân_loại_thứ_cấp
+Secondary\ sort\ criterion=Tiêu chuẩn phân loại thứ cấp
 
-Select_all=Chọn_tất_cả
+Select\ all=Chọn tất cả
 
-Select_encoding=Chọn_bộ_mã_hóa
+Select\ encoding=Chọn bộ mã hóa
 
-Select_entry_type=Chọn_kiểu_mục
-Select_external_application=Chọn_ứng_dụng_ngoài
+Select\ entry\ type=Chọn kiểu mục
+Select\ external\ application=Chọn ứng dụng ngoài
 
-Select_file_from_ZIP-archive=Chọn_tập_tin_từ_tập_tin_ZIP
+Select\ file\ from\ ZIP-archive=Chọn tập tin từ tập tin ZIP
 
-Select_the_tree_nodes_to_view_and_accept_or_reject_changes=Chọn_các_nốt_trên_sơ_đồ_hình_cây_để_xem_và_chấp_nhận_hoặc_từ_chối_thay_đổi
-Selected_entries=Các_mục_được_chọn
-Set_field=Thiết_lập_dữ_liệu
-Set_fields=Thiết_lập_các_dữ_liệu
+Select\ the\ tree\ nodes\ to\ view\ and\ accept\ or\ reject\ changes=Chọn các nốt trên sơ đồ hình cây để xem và chấp nhận hoặc từ chối thay đổi
+Selected\ entries=Các mục được chọn
+Set\ field=Thiết lập dữ liệu
+Set\ fields=Thiết lập các dữ liệu
 
-Set_general_fields=Thiết_lập_các_dữ_liệu_tổng_quát
-Set_main_external_file_directory=Thiết_lập_thư_mục_tập_tin_ngoài_chính
+Set\ general\ fields=Thiết lập các dữ liệu tổng quát
+Set\ main\ external\ file\ directory=Thiết lập thư mục tập tin ngoài chính
 
-Set_table_font=Chọn_bảng_phông_chữ
+Set\ table\ font=Chọn bảng phông chữ
 
-Settings=Các_thiết_lập
+Settings=Các thiết lập
 
-Shortcut=Phím_tắt
+Shortcut=Phím tắt
 
-Show/edit_%0_source=Hiển_thị/Chỉnh_sửa_nguồn_%0
+Show/edit\ %0\ source=Hiển thị/Chỉnh sửa nguồn %0
 
-Show_'Firstname_Lastname'=Hiển_thị_Tên_Họ
+Show\ 'Firstname\ Lastname'=Hiển thị Tên Họ
 
-Show_'Lastname,_Firstname'=Hiển_thị_Họ,_Tên
+Show\ 'Lastname,\ Firstname'=Hiển thị Họ, Tên
 
-Show_BibTeX_source_by_default=Hiển_thị_nguồn_BibTeX_theo_mặc_định
+Show\ BibTeX\ source\ by\ default=Hiển thị nguồn BibTeX theo mặc định
 
-Show_confirmation_dialog_when_deleting_entries=Hiển_thị_hộp_thoại_xác_nhận_khi_xóa_các_mục
+Show\ confirmation\ dialog\ when\ deleting\ entries=Hiển thị hộp thoại xác nhận khi xóa các mục
 
-Show_description=Hiển_thị_mô_tả
+Show\ description=Hiển thị mô tả
 
-Show_file_column=Hiển_thị_cột_tập_tin
+Show\ file\ column=Hiển thị cột tập tin
 
-Show_last_names_only=Chỉ_hiển_thị_Họ
+Show\ last\ names\ only=Chỉ hiển thị Họ
 
-Show_names_unchanged=Hiển_thị_các_tên_không_bị_thay_đổi
+Show\ names\ unchanged=Hiển thị các tên không bị thay đổi
 
-Show_optional_fields=Hiển_thị_các_dữ_liệu_tùy_chọn
+Show\ optional\ fields=Hiển thị các dữ liệu tùy chọn
 
-Show_required_fields=Hiển_thị_các_dữ_liệu_cần_có
+Show\ required\ fields=Hiển thị các dữ liệu cần có
 
-Show_URL/DOI_column=Hiển_thị_cột_URL/DOI
+Show\ URL/DOI\ column=Hiển thị cột URL/DOI
 
-Simple_HTML=HTML_dạng_đơn_giản
+Simple\ HTML=HTML dạng đơn giản
 
-Size=Kích_thước
+Size=Kích thước
 
-Skipped_-_No_PDF_linked=Bị_bỏ_qua_-_Không_có_tập_tin_PDF_được_liên_kết
-Skipped_-_PDF_does_not_exist=Bỏ_qua_-_tập_tin_PDF_không_tồn_tại
+Skipped\ -\ No\ PDF\ linked=Bị bỏ qua - Không có tập tin PDF được liên kết
+Skipped\ -\ PDF\ does\ not\ exist=Bỏ qua - tập tin PDF không tồn tại
 
-Skipped_entry.=Mục_bị_bỏ_qua.
+Skipped\ entry.=Mục bị bỏ qua.
 
-Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.=
+Some\ appearance\ settings\ you\ changed\ require\ to\ restart\ JabRef\ to\ come\ into\ effect.=
 
-source_edit=chỉnh_sửa_nguồn
-Special_name_formatters=Các_trình_định_dạng_tên_đặc_biệt
+source\ edit=chỉnh sửa nguồn
+Special\ name\ formatters=Các trình định dạng tên đặc biệt
 
-Special_table_columns=Các_cột_bảng_đặc_biệt
+Special\ table\ columns=Các cột bảng đặc biệt
 
-Starting_import=Đang_bắt_đầu_nhập
+Starting\ import=Đang bắt đầu nhập
 
-Statically_group_entries_by_manual_assignment=Gộp_nhóm_các_mục_theo_cách_tĩnh_bằng_phép_gán_thủ_công
+Statically\ group\ entries\ by\ manual\ assignment=Gộp nhóm các mục theo cách tĩnh bằng phép gán thủ công
 
-Status=Trạng_thái
+Status=Trạng thái
 
 Stop=Dừng
 
-Strings=Các_chuỗi
+Strings=Các chuỗi
 
-Strings_for_library=Các_chuỗi_dùng_cho_CSDL
+Strings\ for\ library=Các chuỗi dùng cho CSDL
 
-Sublibrary_from_AUX=CSDL_con_từ_AUX
+Sublibrary\ from\ AUX=CSDL con từ AUX
 
-Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.=Chuyển_đổi_giữa_tên_đầy_đủ_và_tên_viết_tắt_tạp_chí_nếu_biết_tên_tạp_chí_đó.
+Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=Chuyển đổi giữa tên đầy đủ và tên viết tắt tạp chí nếu biết tên tạp chí đó.
 
-Synchronize_file_links=Đồng_bộ_hóa_các_liên_kết_tập_tin
+Synchronize\ file\ links=Đồng bộ hóa các liên kết tập tin
 
-Synchronizing_file_links...=Đang_đồng_bộ_hóa_tập_tin_liên_kết...
+Synchronizing\ file\ links...=Đang đồng bộ hóa tập tin liên kết...
 
-Table_appearance=Diện_mạo_của_bảng
+Table\ appearance=Diện mạo của bảng
 
-Table_background_color=Màu_nền_của_bảng
+Table\ background\ color=Màu nền của bảng
 
-Table_grid_color=Màu_lưới_của_bảng
+Table\ grid\ color=Màu lưới của bảng
 
-Table_text_color=Màu_chữ_của_bảng
+Table\ text\ color=Màu chữ của bảng
 
-Tabname=Tên_bảng
-Target_file_cannot_be_a_directory.=Tập_tin_đích_không_được_phép_là_một_thư_mục.
+Tabname=Tên bảng
+Target\ file\ cannot\ be\ a\ directory.=Tập tin đích không được phép là một thư mục.
 
-Tertiary_sort_criterion=Tiêu_chuẩn_phân_loại_cấp_ba
+Tertiary\ sort\ criterion=Tiêu chuẩn phân loại cấp ba
 
-Test=Kiểm_tra
+Test=Kiểm tra
 
-paste_text_here=Vùng_nhập_chữ
+paste\ text\ here=Vùng nhập chữ
 
-The_chosen_date_format_for_new_entries_is_not_valid=Định_dạng_ngày_được_chọn_cho_các_mục_mới_không_hợp_lệ
+The\ chosen\ date\ format\ for\ new\ entries\ is\ not\ valid=Định dạng ngày được chọn cho các mục mới không hợp lệ
 
-The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:=Mã_hóa_đã_chọn_'%0'_không_thể_mã_hóa_được_các_ký_tự_sau\:
+The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=Mã hóa đã chọn '%0' không thể mã hóa được các ký tự sau:
 
 
-the_field_<b>%0</b>=dữ_liệu_<b>%0</b>
+the\ field\ <b>%0</b>=dữ liệu <b>%0</b>
 
-The_file<BR>'%0'<BR>has_been_modified<BR>externally\!=Tập_tin<BR>'%0'<BR>đã_bị_thay_đổi<BR>ngoài_chương_trình\!
+The\ file<BR>'%0'<BR>has\ been\ modified<BR>externally\!=Tập tin<BR>'%0'<BR>đã bị thay đổi<BR>ngoài chương trình!
 
-The_group_"%0"_already_contains_the_selection.=Nhóm_"%0"_đã_chứa_phép_chọn.
+The\ group\ "%0"\ already\ contains\ the\ selection.=Nhóm "%0" đã chứa phép chọn.
 
-The_label_of_the_string_cannot_be_a_number.=Nhãn_của_chuỗi_không_được_là_một_con_số.
+The\ label\ of\ the\ string\ cannot\ be\ a\ number.=Nhãn của chuỗi không được là một con số.
 
-The_label_of_the_string_cannot_contain_spaces.=Nhãn_của_chuỗi_không_được_chứa_khoảng_trắng.
+The\ label\ of\ the\ string\ cannot\ contain\ spaces.=Nhãn của chuỗi không được chứa khoảng trắng.
 
-The_label_of_the_string_cannot_contain_the_'\#'_character.=Nhãn_của_chuỗi_không_được_chứa_ký_tự_'\#'.
+The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=Nhãn của chuỗi không được chứa ký tự '#'.
 
-The_output_option_depends_on_a_valid_import_option.=Tùy_chọn_đầu_ra_phụ_thuộc_vào_một_tùy_chọn_nhập_hợp_lệ.
-The_PDF_contains_one_or_several_BibTeX-records.=Tập_tin_PDF_chứa_một_hoặc_nhiều_bản_ghi_BibTeX.
-Do_you_want_to_import_these_as_new_entries_into_the_current_library?=Bạn_có_muốn_nhập_chúng_vào_thành_các_mục_mới_trong_CSDL_hiện_tại?
+The\ output\ option\ depends\ on\ a\ valid\ import\ option.=Tùy chọn đầu ra phụ thuộc vào một tùy chọn nhập hợp lệ.
+The\ PDF\ contains\ one\ or\ several\ BibTeX-records.=Tập tin PDF chứa một hoặc nhiều bản ghi BibTeX.
+Do\ you\ want\ to\ import\ these\ as\ new\ entries\ into\ the\ current\ library?=Bạn có muốn nhập chúng vào thành các mục mới trong CSDL hiện tại?
 
-The_regular_expression_<b>%0</b>_is_invalid\:=Biểu_thức_chính_tắc_<b>%0</b>_không_hợp_lệ\:
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=Biểu thức chính tắc <b>%0</b> không hợp lệ:
 
-The_search_is_case_insensitive.=Phép_tìm_không_phân_biệt_chữ_hoa/thường
+The\ search\ is\ case\ insensitive.=Phép tìm không phân biệt chữ hoa/thường
 
-The_search_is_case_sensitive.=Phép_tìm_có_phân_biệt_chữ_hoa/thường.
+The\ search\ is\ case\ sensitive.=Phép tìm có phân biệt chữ hoa/thường.
 
-The_string_has_been_removed_locally=Chuỗi_này_đã_bị_loại_bỏ_cục_bộ
+The\ string\ has\ been\ removed\ locally=Chuỗi này đã bị loại bỏ cục bộ
 
-There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?=Có_thể_có_các_mục_bị_trùng_(được_đánh_dấu_bằng_biểu_tượng)_chưa_được_giải_quyết._Có_tiếp_tục_không?
+There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=Có thể có các mục bị trùng (được đánh dấu bằng biểu tượng) chưa được giải quyết. Có tiếp tục không?
 
-This_entry_has_no_BibTeX_key._Generate_key_now?=Mục_này_không_có_khóa_BibTeX._Tạo_khóa_bây_giờ?
+This\ entry\ has\ no\ BibTeX\ key.\ Generate\ key\ now?=Mục này không có khóa BibTeX. Tạo khóa bây giờ?
 
-This_entry_is_incomplete=Mục_này_chưa_đầy_đủ
+This\ entry\ is\ incomplete=Mục này chưa đầy đủ
 
-This_entry_type_cannot_be_removed.=Không_thể_loại_bỏ_kiểu_mục_này.
+This\ entry\ type\ cannot\ be\ removed.=Không thể loại bỏ kiểu mục này.
 
-This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=Liên_kết_ngoài_có_kiểu_'%0',_thuộc_loại_không_được_định_nghĩa._Bạn_muốn_làm_gì?
+This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=Liên kết ngoài có kiểu '%0', thuộc loại không được định nghĩa. Bạn muốn làm gì?
 
-This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.=Nhóm_này_chứa_các_mục_căn_cứ_trên_phép_gán_thủ_công._Các_mục_có_thể_được_gán_vào_nhóm_này_bằng_cách_chọn_chúng_rồi_dùng_cách_kéo_thả_hoặc_trình_đơn_ngữ_cảnh._Các_mục_có_thể_bị_loại_bỏ_khỏi_nhóm_này_bằng_cách_chọn_chúng_rồi_dùng_trình_đơn_ngữ_cảnh.
+This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=Nhóm này chứa các mục căn cứ trên phép gán thủ công. Các mục có thể được gán vào nhóm này bằng cách chọn chúng rồi dùng cách kéo thả hoặc trình đơn ngữ cảnh. Các mục có thể bị loại bỏ khỏi nhóm này bằng cách chọn chúng rồi dùng trình đơn ngữ cảnh.
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>=Nhóm_này_chứa_các_mục_có_dữ_liệu_<b>%0</b>_chứa_từ_khóa_<b>%1</b>_
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=Nhóm này chứa các mục có dữ liệu <b>%0</b> chứa từ khóa <b>%1</b> 
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>=Nhóm_này_chứa_các_mục_có_dữ_liệu_<b>%0</b>_chứa_biểu_thức_chính_tắc_<b>%1</b>_
-This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.=Điều_này_khiến_cho_JabRef_tìm_từng_liên_kết_trong_tổng_số_tập_tin_và_kiểm_tra_xem_tập_tin_có_tồn_tại_không._Nếu_không_bạn_sẽ_được_cung_cấp_các_tùy_chọn<BR>để_giải_quyết_trục_trặc.
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=Nhóm này chứa các mục có dữ liệu <b>%0</b> chứa biểu thức chính tắc <b>%1</b> 
+This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=Điều này khiến cho JabRef tìm từng liên kết trong tổng số tập tin và kiểm tra xem tập tin có tồn tại không. Nếu không bạn sẽ được cung cấp các tùy chọn<BR>để giải quyết trục trặc.
 
-This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.=Lệnh_này_yêu_cầu_tất_cả_các_mục_được_chọn_phải_có_khóa_BibTeX.
+This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=Lệnh này yêu cầu tất cả các mục được chọn phải có khóa BibTeX.
 
-This_operation_requires_one_or_more_entries_to_be_selected.=Lệnh_này_yêu_cầu_phải_chọn_trước_một_hoặc_nhiều_mục.
+This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=Lệnh này yêu cầu phải chọn trước một hoặc nhiều mục.
 
-Toggle_entry_preview=Bật/tắt_xem_trước_mục
-Toggle_groups_interface=Bật/tắt_giao_diện_nhóm
-Try_different_encoding=Thử_mã_hóa_khác
+Toggle\ entry\ preview=Bật/tắt xem trước mục
+Toggle\ groups\ interface=Bật/tắt giao diện nhóm
+Try\ different\ encoding=Thử mã hóa khác
 
-Unabbreviate_journal_names_of_the_selected_entries=Bỏ_viết_tắt_tên_các_tạp_chí_của_những_mục_được_chọn
-Unabbreviated_%0_journal_names.=%0_tên_tạp_chí_được_bỏ_viết_tắt.
+Unabbreviate\ journal\ names\ of\ the\ selected\ entries=Bỏ viết tắt tên các tạp chí của những mục được chọn
+Unabbreviated\ %0\ journal\ names.=%0 tên tạp chí được bỏ viết tắt.
 
-Unable_to_open_file.=Không_thể_mở_tập_tin.
-Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.=Không_thể_mở_liên_kết._Không_thể_gọi_ứng_dụng_'%0'_liên_quan_đến_kiểu_tập_tin_'%1'.
-unable_to_write_to=Không_thể_ghi_vào
-Undefined_file_type=Kiểu_tập_tin_không_được_định_nghĩa
+Unable\ to\ open\ file.=Không thể mở tập tin.
+Unable\ to\ open\ link.\ The\ application\ '%0'\ associated\ with\ the\ file\ type\ '%1'\ could\ not\ be\ called.=Không thể mở liên kết. Không thể gọi ứng dụng '%0' liên quan đến kiểu tập tin '%1'.
+unable\ to\ write\ to=Không thể ghi vào
+Undefined\ file\ type=Kiểu tập tin không được định nghĩa
 
-Undo=Quay_ngược_lệnh
+Undo=Quay ngược lệnh
 
-Union=Hợp_nhất
+Union=Hợp nhất
 
-Unknown_BibTeX_entries=Các_mục_BibTeX_không_rõ
+Unknown\ BibTeX\ entries=Các mục BibTeX không rõ
 
-unknown_edit=kiểu_chỉnh_sửa_không_biết
+unknown\ edit=kiểu chỉnh sửa không biết
 
-Unknown_export_format=Định_dạng_xuất_không_biết
+Unknown\ export\ format=Định dạng xuất không biết
 
-Unmark_all=Khử_đánh_dấu_tất_cả
+Unmark\ all=Khử đánh dấu tất cả
 
-Unmark_entries=Khử_đánh_dấu_các_mục
+Unmark\ entries=Khử đánh dấu các mục
 
-Unmark_entry=Khử_đánh_dấu_mục
+Unmark\ entry=Khử đánh dấu mục
 
-untitled=không_tiêu_đề
+untitled=không tiêu đề
 
 Up=Lên
 
-Update_to_current_column_widths=Cập_nhật_chiều_rộng_cột_hiện_tại
+Update\ to\ current\ column\ widths=Cập nhật chiều rộng cột hiện tại
 
-Updated_group_selection=Phép_chọn_nhóm_đã_được_cập_nhật
-Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.=Nâng_cấp_các_liên_kết_ngoài_PDF/PS_để_sử_dụng_dữ_liệu_'%0'.
-Upgrade_file=Nâng_cấp_tập_tin
-Upgrade_old_external_file_links_to_use_the_new_feature=Nâng_cấp_các_liên_kết_tập_tin_ngoài_để_sử_dụng_tính_chất_mới
+Updated\ group\ selection=Phép chọn nhóm đã được cập nhật
+Upgrade\ external\ PDF/PS\ links\ to\ use\ the\ '%0'\ field.=Nâng cấp các liên kết ngoài PDF/PS để sử dụng dữ liệu '%0'.
+Upgrade\ file=Nâng cấp tập tin
+Upgrade\ old\ external\ file\ links\ to\ use\ the\ new\ feature=Nâng cấp các liên kết tập tin ngoài để sử dụng tính chất mới
 
-usage=cách_dùng
-Use_autocompletion_for_the_following_fields=Dùng_tính_chất_tự_điền_đầy_đủ_cho_các_dữ_liệu_sau
+usage=cách dùng
+Use\ autocompletion\ for\ the\ following\ fields=Dùng tính chất tự điền đầy đủ cho các dữ liệu sau
 
-Use_other_look_and_feel=Dùng_diện_mạo_khác
-Tweak_font_rendering_for_entry_editor_on_Linux=
-Use_regular_expression_search=Dùng_phép_tìm_bằng_biểu_thức_chính_tắc
+Use\ other\ look\ and\ feel=Dùng diện mạo khác
+Tweak\ font\ rendering\ for\ entry\ editor\ on\ Linux=
+Use\ regular\ expression\ search=Dùng phép tìm bằng biểu thức chính tắc
 
-Username=Tên_người_dùng
+Username=Tên người dùng
 
-Value_cleared_externally=Giá_trị_bị_xóa_ngoài_chương_trình
+Value\ cleared\ externally=Giá trị bị xóa ngoài chương trình
 
-Value_set_externally=Giá_trị_được_thiết_lập_ngoài_chương_trình
+Value\ set\ externally=Giá trị được thiết lập ngoài chương trình
 
-verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid=kiểm_tra_xem_LyX_có_chạy_và_lyxpipe_có_hợp_lệ_không
+verify\ that\ LyX\ is\ running\ and\ that\ the\ lyxpipe\ is\ valid=kiểm tra xem LyX có chạy và lyxpipe có hợp lệ không
 
 View=Xem
-Vim_server_name=Tên_Server_Vim
+Vim\ server\ name=Tên Server Vim
 
-Waiting_for_ArXiv...=Đang_chờ_ArXiv...
+Waiting\ for\ ArXiv...=Đang chờ ArXiv...
 
-Warn_about_unresolved_duplicates_when_closing_inspection_window=Cảnh_báo_về_các_mục_trùng_chưa_được_giải_quyết_khi_đóng_cửa_sổ_kiểm_tra
+Warn\ about\ unresolved\ duplicates\ when\ closing\ inspection\ window=Cảnh báo về các mục trùng chưa được giải quyết khi đóng cửa sổ kiểm tra
 
-Warn_before_overwriting_existing_keys=Cảnh_báo_trước_khi_ghi_đè_các_khóa_hiện_có
+Warn\ before\ overwriting\ existing\ keys=Cảnh báo trước khi ghi đè các khóa hiện có
 
-Warning=Cảnh_báo
+Warning=Cảnh báo
 
-Warnings=Các_cảnh_báo
+Warnings=Các cảnh báo
 
-web_link=liên_kết_web
+web\ link=liên kết web
 
-What_do_you_want_to_do?=Bạn_muốn_làm_gì?
+What\ do\ you\ want\ to\ do?=Bạn muốn làm gì?
 
-When_adding/removing_keywords,_separate_them_by=Khi_thêm/loại_bỏ_các_từ_khóa,_cách_biệt_chúng_ra_bằng
-Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.=Sẽ_ghi_đặc_tả_dữ_liệu_XMP_vào_các_PDF_được_liên_kết_từ_các_mục_đã_chọn.
+When\ adding/removing\ keywords,\ separate\ them\ by=Khi thêm/loại bỏ các từ khóa, cách biệt chúng ra bằng
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Sẽ ghi đặc tả dữ liệu XMP vào các PDF được liên kết từ các mục đã chọn.
 
 with=với
 
-Write_BibTeXEntry_as_XMP-metadata_to_PDF.=Ghi_mục_BibTeX_dưới_dạng_đặc_tả_dữ_liệu_XMP_vào_PDF.
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Ghi mục BibTeX dưới dạng đặc tả dữ liệu XMP vào PDF.
 
-Write_XMP=Ghi_XMP
-Write_XMP-metadata=Ghi_đặc_tả_dữ_liệu_XMP
-Write_XMP-metadata_for_all_PDFs_in_current_library?=Ghi_đặc_tả_dữ_liệu_XMP_cho_tất_cả_các_PDF_trong_CSDL_hiện_tại?
-Writing_XMP-metadata...=Đang_ghi_đặc_tả_dữ_liệu_XMP...
-Writing_XMP-metadata_for_selected_entries...=Đang_ghi_đặc_tả_dữ_liệu_XMP_cho_các_mục_được_chọn...
+Write\ XMP=Ghi XMP
+Write\ XMP-metadata=Ghi đặc tả dữ liệu XMP
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Ghi đặc tả dữ liệu XMP cho tất cả các PDF trong CSDL hiện tại?
+Writing\ XMP-metadata...=Đang ghi đặc tả dữ liệu XMP...
+Writing\ XMP-metadata\ for\ selected\ entries...=Đang ghi đặc tả dữ liệu XMP cho các mục được chọn...
 
-Wrote_XMP-metadata=Đã_ghi_đặc_tả_dữ_liệu_XMP
+Wrote\ XMP-metadata=Đã ghi đặc tả dữ liệu XMP
 
-XMP-annotated_PDF=PDF_có_chú_giải_XMP
-XMP_export_privacy_settings=Các_thiết_lập_riêng_về_Xuất_XMP
-XMP-metadata=Đặc_tả_dữ_liệu_XMP
-XMP-metadata_found_in_PDF\:_%0=Đặc_tả_dữ_liệu_XMP_có_trong_PDF\:_%0
-You_must_restart_JabRef_for_this_to_come_into_effect.=Bạn_phải_khởi_động_lại_JabRef_để_thay_đổi_có_hiệu_lực.
-You_have_changed_the_language_setting.=Bạn_đã_thay_đổi_thiết_lập_ngôn_ngữ.
-You_have_entered_an_invalid_search_'%0'.=Bạn_đã_nhập_một_phép_tìm_không_hợp_lệ_'%0'.
+XMP-annotated\ PDF=PDF có chú giải XMP
+XMP\ export\ privacy\ settings=Các thiết lập riêng về Xuất XMP
+XMP-metadata=Đặc tả dữ liệu XMP
+XMP-metadata\ found\ in\ PDF\:\ %0=Đặc tả dữ liệu XMP có trong PDF: %0
+You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Bạn phải khởi động lại JabRef để thay đổi có hiệu lực.
+You\ have\ changed\ the\ language\ setting.=Bạn đã thay đổi thiết lập ngôn ngữ.
+You\ have\ entered\ an\ invalid\ search\ '%0'.=Bạn đã nhập một phép tìm không hợp lệ '%0'.
 
-You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.=Bạn_phải_khởi_động_lại_JabRef_để_các_tổ_hợp_phím_mới_hoạt_động_được.
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=Bạn phải khởi động lại JabRef để các tổ hợp phím mới hoạt động được.
 
-Your_new_key_bindings_have_been_stored.=Tổ_hợp_phím_tắt_mới_của_bạn_đã_được_lưu_trữ.
+Your\ new\ key\ bindings\ have\ been\ stored.=Tổ hợp phím tắt mới của bạn đã được lưu trữ.
 
-The_following_fetchers_are_available\:=Các_trình_lấy_về_sau_có_thể_dùng_được\:
-Could_not_find_fetcher_'%0'=Không_thể_tìm_thấy_trình_lầy_về_'%0'
-Running_query_'%0'_with_fetcher_'%1'.=Đang_chạy_truy_vấn_'%0'_với_trình_lấy_về_'%1'.
-Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.=Phép_truy_vấn_'%0'_bằng_trình_lấy_về_'%1'_không_trả_lại_kết_quả_nào.
+The\ following\ fetchers\ are\ available\:=Các trình lấy về sau có thể dùng được:
+Could\ not\ find\ fetcher\ '%0'=Không thể tìm thấy trình lầy về '%0'
+Running\ query\ '%0'\ with\ fetcher\ '%1'.=Đang chạy truy vấn '%0' với trình lấy về '%1'.
+Query\ '%0'\ with\ fetcher\ '%1'\ did\ not\ return\ any\ results.=Phép truy vấn '%0' bằng trình lấy về '%1' không trả lại kết quả nào.
 
-Move_file=Chuyển_tin
-Rename_file=Đặt_lại_tên_tập_tin
+Move\ file=Chuyển tin
+Rename\ file=Đặt lại tên tập tin
 
-Move_file_failed=Việc_chuyển_tập_tin_thất_bại
-Could_not_move_file_'%0'.=Không_thể_chuyển_tập_tin_'%0'.
-Could_not_find_file_'%0'.=Không_tìm_thấy_tập_tin_'%0'.
-Number_of_entries_successfully_imported=Số_mục_được_nhập_vào_thành_công
-Import_canceled_by_user=Việc_nhập_bị_người_dùng_hủy
-Progress\:_%0_of_%1=Tiến_trình\:_%0_of_%1
-Error_while_fetching_from_%0=Lỗi_khi_lấy_về_từ_%0
+Move\ file\ failed=Việc chuyển tập tin thất bại
+Could\ not\ move\ file\ '%0'.=Không thể chuyển tập tin '%0'.
+Could\ not\ find\ file\ '%0'.=Không tìm thấy tập tin '%0'.
+Number\ of\ entries\ successfully\ imported=Số mục được nhập vào thành công
+Import\ canceled\ by\ user=Việc nhập bị người dùng hủy
+Progress\:\ %0\ of\ %1=Tiến trình: %0 of %1
+Error\ while\ fetching\ from\ %0=Lỗi khi lấy về từ %0
 
-Please_enter_a_valid_number=Vui_lòng_nhập_một_con_số_hợp_lệ
-Show_search_results_in_a_window=Hiển_thị_kết_quả_tìm_trong_một_cửa_sổ
-Show_global_search_results_in_a_window=
-Search_in_all_open_libraries=Tìm_kiếm_trong_tất_cả_CSDL_đang_mở
-Move_file_to_file_directory?=Di_chuyển_tập_tin_vào_thư_mục_tập_tin?
+Please\ enter\ a\ valid\ number=Vui lòng nhập một con số hợp lệ
+Show\ search\ results\ in\ a\ window=Hiển thị kết quả tìm trong một cửa sổ
+Show\ global\ search\ results\ in\ a\ window=
+Search\ in\ all\ open\ libraries=Tìm kiếm trong tất cả CSDL đang mở
+Move\ file\ to\ file\ directory?=Di chuyển tập tin vào thư mục tập tin?
 
-Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.=CSDL_được_bảo_vệ._Không_thể_lưu_cho_đến_khi_những_thay_đổi_ngoài_được_xem_xét.
-Protected_library=CSDL_được_bảo_vệ
-Refuse_to_save_the_library_before_external_changes_have_been_reviewed.=Từ_chối_lưu_CSDL_trước_khi_những_thay_đổi_ngoài_được_xem_xét.
-Library_protection=Bảo_vệ_CSDL
-Unable_to_save_library=Không_thể_lưu_CSDL
+Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=CSDL được bảo vệ. Không thể lưu cho đến khi những thay đổi ngoài được xem xét.
+Protected\ library=CSDL được bảo vệ
+Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=Từ chối lưu CSDL trước khi những thay đổi ngoài được xem xét.
+Library\ protection=Bảo vệ CSDL
+Unable\ to\ save\ library=Không thể lưu CSDL
 
-BibTeX_key_generator=Trình_tạo_khóa_BibTeX
-Unable_to_open_link.=Không_thể_mở_liên_kết.
-Move_the_keyboard_focus_to_the_entry_table=Chuyển_trọng_tâm_bàn_phím_sang_bảng_chứa_mục
-MIME_type=Kiểu_MIME
+BibTeX\ key\ generator=Trình tạo khóa BibTeX
+Unable\ to\ open\ link.=Không thể mở liên kết.
+Move\ the\ keyboard\ focus\ to\ the\ entry\ table=Chuyển trọng tâm bàn phím sang bảng chứa mục
+MIME\ type=Kiểu MIME
 
-This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.=Tính_chất_này_cho_phép_các_tập_tin_mới_có_thể_được_mở_hoặc_nhập_vào_một_phiên_JabRef_đang_chạy<BR>thay_vì_phải_mở_một_phiên_làm_việc_mới._Điều_này_có_ích,_ví_dụ_như_khi_bạn_mở_một_tập_tin_trong_JabRef<br>từ_trình_duyệt_web_của_mình.<BR>Lưu_ý_rằng_điều_này_sẽ_không_cho_phép_bạn_chạy_nhiều_hơn_một_phiên_làm_việc_của_JabRef_cùng_lúc.
-Run_fetcher,_e.g._"--fetch\=Medline\:cancer"=Run_fetcher,_e.g._"--fetch=Medline\:cancer"
+This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef<BR>instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef<br>from\ your\ web\ browser.<BR>Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=Tính chất này cho phép các tập tin mới có thể được mở hoặc nhập vào một phiên JabRef đang chạy<BR>thay vì phải mở một phiên làm việc mới. Điều này có ích, ví dụ như khi bạn mở một tập tin trong JabRef<br>từ trình duyệt web của mình.<BR>Lưu ý rằng điều này sẽ không cho phép bạn chạy nhiều hơn một phiên làm việc của JabRef cùng lúc.
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=Run fetcher, e.g. "--fetch=Medline:cancer"
 
-The_ACM_Digital_Library=Thư_viện_số_ACM
-Reset=Thiết_lập_lại
+The\ ACM\ Digital\ Library=Thư viện số ACM
+Reset=Thiết lập lại
 
-Use_IEEE_LaTeX_abbreviations=Dùng_các_chữ_viết_tắt_kiểu_IEEE_LaTeX
-The_Guide_to_Computing_Literature=Hướng_dẫn_về_tài_liệu_máy_tính
+Use\ IEEE\ LaTeX\ abbreviations=Dùng các chữ viết tắt kiểu IEEE LaTeX
+The\ Guide\ to\ Computing\ Literature=Hướng dẫn về tài liệu máy tính
 
-When_opening_file_link,_search_for_matching_file_if_no_link_is_defined=Khi_mở_liên_kết_tập_tin,_tìm_tập_tin_khớp_nếu_liên_kết_không_được_định_nghĩa
-Settings_for_%0=Các_thiết_lập_dùng_cho_%0
-Mark_entries_imported_into_an_existing_library=Đánh_dấu_các_mục_được_nhập_vào_CSDL_hiện_có
-Unmark_all_entries_before_importing_new_entries_into_an_existing_library=Khử_đánh_dấu_tất_cả_các_mục_trước_khi_nhập_các_mục_mới_vào_CSDL_hiện_có
+When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=Khi mở liên kết tập tin, tìm tập tin khớp nếu liên kết không được định nghĩa
+Settings\ for\ %0=Các thiết lập dùng cho %0
+Mark\ entries\ imported\ into\ an\ existing\ library=Đánh dấu các mục được nhập vào CSDL hiện có
+Unmark\ all\ entries\ before\ importing\ new\ entries\ into\ an\ existing\ library=Khử đánh dấu tất cả các mục trước khi nhập các mục mới vào CSDL hiện có
 
 Forward=Tới
 Back=Lui
-Sort_the_following_fields_as_numeric_fields=Xếp_thứ_tự_các_dữ_liệu_sau_như_thể_chúng_là_các_dữ_liệu_kiểu_số
-Line_%0\:_Found_corrupted_BibTeX_key.=Dòng_%0\:_Tìm_thấy_khóa-BibTeX_bị_lỗi.
-Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).=Dòng_%0\:_Tìm_thấy_khóa-BibTeX_bị_lỗi_(chứa_khoảng_trắng).
-Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).=Dòng_%0\:_Tìm_thấy_khóa-BibTeX_bị_lỗi_(thiếu_dấu_phẩy).
-Full_text_document_download_failed=Việc_tải_về_bài_viết_đầy_đủ_thất_bại
-Update_to_current_column_order=Cập_nhật_theo_thứ_tự_cột_hiện_tại
-Download_from_URL=Kéo_từ_URL
-Rename_field=Đổi_tên_dữ_liệu
-Set/clear/append/rename_fields=Thiết_lập/xóa/đổi_tên_dữ_liệu
-Append_field=
-Append_to_fields=
-Rename_field_to=Đổi_tên_dữ_liệu_thành
-Move_contents_of_a_field_into_a_field_with_a_different_name=Di_chuyển_nội_dung_của_một_dữ_liệu_sang_một_dữ_liệu_có_tên_khác
-You_can_only_rename_one_field_at_a_time=Bạn_chỉ_có_thể_đổi_tên_một_dữ_liệu_một_lần
+Sort\ the\ following\ fields\ as\ numeric\ fields=Xếp thứ tự các dữ liệu sau như thể chúng là các dữ liệu kiểu số
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=Dòng %0: Tìm thấy khóa-BibTeX bị lỗi.
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=Dòng %0: Tìm thấy khóa-BibTeX bị lỗi (chứa khoảng trắng).
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=Dòng %0: Tìm thấy khóa-BibTeX bị lỗi (thiếu dấu phẩy).
+Full\ text\ document\ download\ failed=Việc tải về bài viết đầy đủ thất bại
+Update\ to\ current\ column\ order=Cập nhật theo thứ tự cột hiện tại
+Download\ from\ URL=Kéo từ URL
+Rename\ field=Đổi tên dữ liệu
+Set/clear/append/rename\ fields=Thiết lập/xóa/đổi tên dữ liệu
+Append\ field=
+Append\ to\ fields=
+Rename\ field\ to=Đổi tên dữ liệu thành
+Move\ contents\ of\ a\ field\ into\ a\ field\ with\ a\ different\ name=Di chuyển nội dung của một dữ liệu sang một dữ liệu có tên khác
+You\ can\ only\ rename\ one\ field\ at\ a\ time=Bạn chỉ có thể đổi tên một dữ liệu một lần
 
-Remove_all_broken_links=Loại_bỏ_tất_cả_các_liên_kết_bị_đứt
+Remove\ all\ broken\ links=Loại bỏ tất cả các liên kết bị đứt
 
-Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.=Không_thể_dùng_cổng_%0_cho_lệnh_chạy_từ_xa;_một_ứng_dụng_khác_có_thể_đang_dùng_nó._Hãy_thử_chỉ_định_một_cổng_khác.
+Cannot\ use\ port\ %0\ for\ remote\ operation;\ another\ application\ may\ be\ using\ it.\ Try\ specifying\ another\ port.=Không thể dùng cổng %0 cho lệnh chạy từ xa; một ứng dụng khác có thể đang dùng nó. Hãy thử chỉ định một cổng khác.
 
-Looking_for_full_text_document...=Đang_tìm_tài_liệu_đầy_đủ...
-Autosave=Lưu_tự_động
-A_local_copy_will_be_opened.=Bản_sao_cục_bộ_sẽ_được_mở.
-Autosave_local_libraries=Tự_động_lưu_CSDL_cục_bộ
-Automatically_save_the_library_to=
-Please_enter_a_valid_file_path.=
+Looking\ for\ full\ text\ document...=Đang tìm tài liệu đầy đủ...
+Autosave=Lưu tự động
+A\ local\ copy\ will\ be\ opened.=Bản sao cục bộ sẽ được mở.
+Autosave\ local\ libraries=Tự động lưu CSDL cục bộ
+Automatically\ save\ the\ library\ to=
+Please\ enter\ a\ valid\ file\ path.=
 
 
-Export_in_current_table_sort_order=Xuất_ra_theo_trình_tự_xếp_thứ_tự_của_bảng_hiện_tại
-Export_entries_in_their_original_order=Xuất_ra_các_mục_theo_thứ_tự_gốc_của_chúng
-Error_opening_file_'%0'.=Lỗi_mở_tập_tin_'%0'.
+Export\ in\ current\ table\ sort\ order=Xuất ra theo trình tự xếp thứ tự của bảng hiện tại
+Export\ entries\ in\ their\ original\ order=Xuất ra các mục theo thứ tự gốc của chúng
+Error\ opening\ file\ '%0'.=Lỗi mở tập tin '%0'.
 
-Formatter_not_found\:_%0=Không_tìm_thấy_trình_định_dạng\:_%0
-Clear_inputarea=Xóa_trong_vùng_nhập_liệu
+Formatter\ not\ found\:\ %0=Không tìm thấy trình định dạng: %0
+Clear\ inputarea=Xóa trong vùng nhập liệu
 
-Automatically_set_file_links_for_this_entry=Tự_động_thiết_lập_các_liên_kết_tập_tin_cho_mục_này
-Could_not_save,_file_locked_by_another_JabRef_instance.=Không_thể_lưu,_tập_tin_bị_khóa_bởi_một_phiên_làm_việc_khác_của_JabRef_đang_chạy.
-File_is_locked_by_another_JabRef_instance.=Tập_tin_bị_khóa_bởi_một_phiên_làm_việc_khác_của_JabRef.
-Do_you_want_to_override_the_file_lock?=Bạn_có_muốn_bỏ_qua_khóa_tập_tin?
-File_locked=Tập_tin_bị_khóa
-Current_tmp_value=Giá_trị_tmp_hiện_tại
-Metadata_change=Thay_đổi_đặc_tả_dữ_liệu
-Changes_have_been_made_to_the_following_metadata_elements=Các_thay_đổi_đã_được_thực_hiện_cho_những_thành_phần_đặc_tả_CSDL_sau
+Automatically\ set\ file\ links\ for\ this\ entry=Tự động thiết lập các liên kết tập tin cho mục này
+Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=Không thể lưu, tập tin bị khóa bởi một phiên làm việc khác của JabRef đang chạy.
+File\ is\ locked\ by\ another\ JabRef\ instance.=Tập tin bị khóa bởi một phiên làm việc khác của JabRef.
+Do\ you\ want\ to\ override\ the\ file\ lock?=Bạn có muốn bỏ qua khóa tập tin?
+File\ locked=Tập tin bị khóa
+Current\ tmp\ value=Giá trị tmp hiện tại
+Metadata\ change=Thay đổi đặc tả dữ liệu
+Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=Các thay đổi đã được thực hiện cho những thành phần đặc tả CSDL sau
 
-Generate_groups_for_author_last_names=Tạo_các_nhóm_cho_họ_của_tác_giả
-Generate_groups_from_keywords_in_a_BibTeX_field=Tạo_các_nhóm_theo_từ_khóa_trong_một_dữ_liệu_BibTeX
-Enforce_legal_characters_in_BibTeX_keys=Buộc_phải_dùng_những_ký_tự_hợp_lệ_trong_khóa_BibTeX
+Generate\ groups\ for\ author\ last\ names=Tạo các nhóm cho họ của tác giả
+Generate\ groups\ from\ keywords\ in\ a\ BibTeX\ field=Tạo các nhóm theo từ khóa trong một dữ liệu BibTeX
+Enforce\ legal\ characters\ in\ BibTeX\ keys=Buộc phải dùng những ký tự hợp lệ trong khóa BibTeX
 
-Save_without_backup?=Lưu_không_có_bản_dự_phòng?
-Unable_to_create_backup=Không_thể_tạo_bản_dự_phòng
-Move_file_to_file_directory=Di_chuyển_tập_tin_vào_thư_mục_tập_tin
-Rename_file_to=Đổi_tên_tập_tin_thành
-<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)=<b>Tất_cả_các_mục</b>_(không_thể_chỉnh_sửa_hoặc_loại_bỏ_nhóm_này)
-static_group=nhóm_tĩnh
-dynamic_group=nhóm_động
-refines_supergroup=tinh_chỉnh_lại_nhóm_lớn
-includes_subgroups=kể_cả_các_nhóm_con
+Save\ without\ backup?=Lưu không có bản dự phòng?
+Unable\ to\ create\ backup=Không thể tạo bản dự phòng
+Move\ file\ to\ file\ directory=Di chuyển tập tin vào thư mục tập tin
+Rename\ file\ to=Đổi tên tập tin thành
+<b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=<b>Tất cả các mục</b> (không thể chỉnh sửa hoặc loại bỏ nhóm này)
+static\ group=nhóm tĩnh
+dynamic\ group=nhóm động
+refines\ supergroup=tinh chỉnh lại nhóm lớn
+includes\ subgroups=kể cả các nhóm con
 contains=chứa
-search_expression=biểu_thức_tìm
+search\ expression=biểu thức tìm
 
-Optional_fields_2=Các_dữ_liệu_tùy_chọn_2
-Waiting_for_save_operation_to_finish=Chờ_thao_tác_lưu_kết_thúc
-Resolving_duplicate_BibTeX_keys...=Giải_quyết_những_khóa_BibTeX_bị_lặp_lại...
-Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.=Giải_quyết_những_khóa_BibTeX_bị_lặp_lại_đã_được_kết_thúc._Mục_%0_đã_được_sửa.
-This_library_contains_one_or_more_duplicated_BibTeX_keys.=CSDL_này_có_một_hoặc_nhiều_khóa_BibTeX_bị_lặp_lại.
-Do_you_want_to_resolve_duplicate_keys_now?=Bạn_có_muốn_giải_quyết_những_khóa_lặp_bây_giờ_không?
+Optional\ fields\ 2=Các dữ liệu tùy chọn 2
+Waiting\ for\ save\ operation\ to\ finish=Chờ thao tác lưu kết thúc
+Resolving\ duplicate\ BibTeX\ keys...=Giải quyết những khóa BibTeX bị lặp lại...
+Finished\ resolving\ duplicate\ BibTeX\ keys.\ %0\ entries\ modified.=Giải quyết những khóa BibTeX bị lặp lại đã được kết thúc. Mục %0 đã được sửa.
+This\ library\ contains\ one\ or\ more\ duplicated\ BibTeX\ keys.=CSDL này có một hoặc nhiều khóa BibTeX bị lặp lại.
+Do\ you\ want\ to\ resolve\ duplicate\ keys\ now?=Bạn có muốn giải quyết những khóa lặp bây giờ không?
 
-Find_and_remove_duplicate_BibTeX_keys=Tìm_và_xóa_bỏ_những_khóa_BibTeX_bị_lặp_lại
-Expected_syntax_for_--fetch\='<name_of_fetcher>\:<query>'=Cú_pháp_mong_đợi_cho--fetch\='<Tên_của_fetcher>\:<query>'
-Duplicate_BibTeX_key=Lặp_lại_khóa_BibTeX
-Import_marking_color=Nhập_màu_đánh_dấu
-Always_add_letter_(a,_b,_...)_to_generated_keys=Luôn_thêm_mẫu_tự_(a,_b,_...)_để_tạo_ra_các_khóa
+Find\ and\ remove\ duplicate\ BibTeX\ keys=Tìm và xóa bỏ những khóa BibTeX bị lặp lại
+Expected\ syntax\ for\ --fetch\='<name\ of\ fetcher>\:<query>'=Cú pháp mong đợi cho--fetch='<Tên của fetcher>:<query>'
+Duplicate\ BibTeX\ key=Lặp lại khóa BibTeX
+Import\ marking\ color=Nhập màu đánh dấu
+Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=Luôn thêm mẫu tự (a, b, ...) để tạo ra các khóa
 
-Ensure_unique_keys_using_letters_(a,_b,_...)=Đảm_bảo_các_khóa_duy_nhất_bằng_sử_dụng_mẫu_tự_(a,_b,_...)
-Ensure_unique_keys_using_letters_(b,_c,_...)=Đảm_bảo_các_khóa_duy_nhất_bằng_sử_dụng_mẫu_tự_(b,_c,_...)
-Entry_editor_active_background_color=Trình_soạn_màu_nền_của_thảo_mục_đã_kích_hoạt
-Entry_editor_background_color=Trình_soạn_màu_nền_của_thảo_mục
-Entry_editor_font_color=Trình_soạn_màu_phông_của_thảo_mục
-Entry_editor_invalid_field_color=Trình_soạn_màu_các_dữ_liệu_không_hợp_lệ_của_thảo_mục
+Ensure\ unique\ keys\ using\ letters\ (a,\ b,\ ...)=Đảm bảo các khóa duy nhất bằng sử dụng mẫu tự (a, b, ...)
+Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=Đảm bảo các khóa duy nhất bằng sử dụng mẫu tự (b, c, ...)
+Entry\ editor\ active\ background\ color=Trình soạn màu nền của thảo mục đã kích hoạt
+Entry\ editor\ background\ color=Trình soạn màu nền của thảo mục
+Entry\ editor\ font\ color=Trình soạn màu phông của thảo mục
+Entry\ editor\ invalid\ field\ color=Trình soạn màu các dữ liệu không hợp lệ của thảo mục
 
-Table_and_entry_editor_colors=Bảng_và_trình_soạn_thảo_màu_của_mục
+Table\ and\ entry\ editor\ colors=Bảng và trình soạn thảo màu của mục
 
-General_file_directory=Tổng_quát_thư_mục_tập_tin
-User-specific_file_directory=Thư_mục_tập_tin_của_người_sử_dụng_cụ_thể
-Search_failed\:_illegal_search_expression=Tìm_kiếm_thất_bại\:_biểu_thức_tìm_kiếm_bất_hợp_lệ
-Show_ArXiv_column=Hiển_thị_cột_ArXiv
+General\ file\ directory=Tổng quát thư mục tập tin
+User-specific\ file\ directory=Thư mục tập tin của người sử dụng cụ thể
+Search\ failed\:\ illegal\ search\ expression=Tìm kiếm thất bại: biểu thức tìm kiếm bất hợp lệ
+Show\ ArXiv\ column=Hiển thị cột ArXiv
 
-You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for=Bạn_phải_nhập_giá_trị_nằm_trong_khoảng_cách_1025-65535_trong_các_dữ_liệu_văn_bản_cho
-Automatically_open_browse_dialog_when_creating_new_file_link=Mở_tự_động_hộp_thoại_khi_tạo_ra_đường_dẫn_tập_tin_mới
-Import_metadata_from\:=Nhập_siêu_dữ_liệu_vào_từ
-Choose_the_source_for_the_metadata_import=Chọn_nguồn_để_nhập_vào_siêu_dữ_liệu
-Create_entry_based_on_XMP-metadata=Tạo_ra_mục_dựa_trên_dữ_liệu_XMP
-Create_blank_entry_linking_the_PDF=Tạo_ra_mục_trống_thuộc_về_PDF
-Only_attach_PDF=Chỉ_kèm_PDF
-Title=Danh_hiệu
-Create_new_entry=Tạo_mục_mới
-Update_existing_entry=Cập_nhật_mục_có_sẵn
-Autocomplete_names_in_'Firstname_Lastname'_format_only=
-Autocomplete_names_in_'Lastname,_Firstname'_format_only=
-Autocomplete_names_in_both_formats=
-Marking_color_%0=
-The_name_'comment'_cannot_be_used_as_an_entry_type_name.=
-You_must_enter_an_integer_value_in_the_text_field_for=
-Send_as_email=Gửi_bằng_email
+You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=Bạn phải nhập giá trị nằm trong khoảng cách 1025-65535 trong các dữ liệu văn bản cho
+Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Mở tự động hộp thoại khi tạo ra đường dẫn tập tin mới
+Import\ metadata\ from\:=Nhập siêu dữ liệu vào từ
+Choose\ the\ source\ for\ the\ metadata\ import=Chọn nguồn để nhập vào siêu dữ liệu
+Create\ entry\ based\ on\ XMP-metadata=Tạo ra mục dựa trên dữ liệu XMP
+Create\ blank\ entry\ linking\ the\ PDF=Tạo ra mục trống thuộc về PDF
+Only\ attach\ PDF=Chỉ kèm PDF
+Title=Danh hiệu
+Create\ new\ entry=Tạo mục mới
+Update\ existing\ entry=Cập nhật mục có sẵn
+Autocomplete\ names\ in\ 'Firstname\ Lastname'\ format\ only=
+Autocomplete\ names\ in\ 'Lastname,\ Firstname'\ format\ only=
+Autocomplete\ names\ in\ both\ formats=
+Marking\ color\ %0=
+The\ name\ 'comment'\ cannot\ be\ used\ as\ an\ entry\ type\ name.=
+You\ must\ enter\ an\ integer\ value\ in\ the\ text\ field\ for=
+Send\ as\ email=Gửi bằng email
 References=
-Sending_of_emails=
-Subject_for_sending_an_email_with_references=
-Automatically_open_folders_of_attached_files=
-Create_entry_based_on_content=
-Do_not_show_this_box_again_for_this_import=
-Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)=
-Error_creating_email=
-Entries_added_to_an_email=
+Sending\ of\ emails=
+Subject\ for\ sending\ an\ email\ with\ references=
+Automatically\ open\ folders\ of\ attached\ files=
+Create\ entry\ based\ on\ content=
+Do\ not\ show\ this\ box\ again\ for\ this\ import=
+Always\ use\ this\ PDF\ import\ style\ (and\ do\ not\ ask\ for\ each\ import)=
+Error\ creating\ email=
+Entries\ added\ to\ an\ email=
 exportFormat=
-Output_file_missing=
-No_search_matches.=
-The_output_option_depends_on_a_valid_input_option.=
-Default_import_style_for_drag_and_drop_of_PDFs=
-Default_PDF_file_link_action=
-Filename_format_pattern=
-Additional_parameters=
-Cite_selected_entries_between_parenthesis=
-Cite_selected_entries_with_in-text_citation=
-Cite_special=
-Extra_information_(e.g._page_number)=
-Manage_citations=
-Problem_modifying_citation=
+Output\ file\ missing=
+No\ search\ matches.=
+The\ output\ option\ depends\ on\ a\ valid\ input\ option.=
+Default\ import\ style\ for\ drag\ and\ drop\ of\ PDFs=
+Default\ PDF\ file\ link\ action=
+Filename\ format\ pattern=
+Additional\ parameters=
+Cite\ selected\ entries\ between\ parenthesis=
+Cite\ selected\ entries\ with\ in-text\ citation=
+Cite\ special=
+Extra\ information\ (e.g.\ page\ number)=
+Manage\ citations=
+Problem\ modifying\ citation=
 Citation=
-Extra_information=
-Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.=
-Select_style=
+Extra\ information=
+Could\ not\ resolve\ BibTeX\ entry\ for\ citation\ marker\ '%0'.=
+Select\ style=
 Journals=
 Cite=
-Cite_in-text=
-Insert_empty_citation=
-Merge_citations=
-Manual_connect=
-Select_Writer_document=
-Sync_OpenOffice/LibreOffice_bibliography=
-Select_which_open_Writer_document_to_work_on=
-Connected_to_document=
-Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)=
-Cite_selected_entries_with_extra_information=
-Ensure_that_the_bibliography_is_up-to-date=
-Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.=
-Unable_to_synchronize_bibliography=
-Combine_pairs_of_citations_that_are_separated_by_spaces_only=
-Autodetection_failed=
+Cite\ in-text=
+Insert\ empty\ citation=
+Merge\ citations=
+Manual\ connect=
+Select\ Writer\ document=
+Sync\ OpenOffice/LibreOffice\ bibliography=
+Select\ which\ open\ Writer\ document\ to\ work\ on=
+Connected\ to\ document=
+Insert\ a\ citation\ without\ text\ (the\ entry\ will\ appear\ in\ the\ reference\ list)=
+Cite\ selected\ entries\ with\ extra\ information=
+Ensure\ that\ the\ bibliography\ is\ up-to-date=
+Your\ OpenOffice/LibreOffice\ document\ references\ the\ BibTeX\ key\ '%0',\ which\ could\ not\ be\ found\ in\ your\ current\ library.=
+Unable\ to\ synchronize\ bibliography=
+Combine\ pairs\ of\ citations\ that\ are\ separated\ by\ spaces\ only=
+Autodetection\ failed=
 Connecting=
-Please_wait...=Vui_lòng_chờ...
-Set_connection_parameters=
-Path_to_OpenOffice/LibreOffice_directory=
-Path_to_OpenOffice/LibreOffice_executable=
-Path_to_OpenOffice/LibreOffice_library_dir=
-Connection_lost=
-The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.=
-The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.=
-Automatically_sync_bibliography_when_inserting_citations=
-Look_up_BibTeX_entries_in_the_active_tab_only=
-Look_up_BibTeX_entries_in_all_open_libraries=
-Autodetecting_paths...=
-Could_not_find_OpenOffice/LibreOffice_installation=
-Found_more_than_one_OpenOffice/LibreOffice_executable.=
-Please_choose_which_one_to_connect_to\:=
-Choose_OpenOffice/LibreOffice_executable=
-Select_document=
-HTML_list=
-If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting=
-Could_not_open_%0=
-Unknown_import_format=
-Web_search=Tìm_kiếm_trên_web
-Style_selection=
-No_valid_style_file_defined=
-Choose_pattern=
-Use_the_BIB_file_location_as_primary_file_directory=
-Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.=
-OpenOffice/LibreOffice_connection=Nối_với_OpenOffice/LibreOffice
-You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.=
+Please\ wait...=Vui lòng chờ...
+Set\ connection\ parameters=
+Path\ to\ OpenOffice/LibreOffice\ directory=
+Path\ to\ OpenOffice/LibreOffice\ executable=
+Path\ to\ OpenOffice/LibreOffice\ library\ dir=
+Connection\ lost=
+The\ paragraph\ format\ is\ controlled\ by\ the\ property\ 'ReferenceParagraphFormat'\ or\ 'ReferenceHeaderParagraphFormat'\ in\ the\ style\ file.=
+The\ character\ format\ is\ controlled\ by\ the\ citation\ property\ 'CitationCharacterFormat'\ in\ the\ style\ file.=
+Automatically\ sync\ bibliography\ when\ inserting\ citations=
+Look\ up\ BibTeX\ entries\ in\ the\ active\ tab\ only=
+Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=
+Autodetecting\ paths...=
+Could\ not\ find\ OpenOffice/LibreOffice\ installation=
+Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=
+Please\ choose\ which\ one\ to\ connect\ to\:=
+Choose\ OpenOffice/LibreOffice\ executable=
+Select\ document=
+HTML\ list=
+If\ possible,\ normalize\ this\ list\ of\ names\ to\ conform\ to\ standard\ BibTeX\ name\ formatting=
+Could\ not\ open\ %0=
+Unknown\ import\ format=
+Web\ search=Tìm kiếm trên web
+Style\ selection=
+No\ valid\ style\ file\ defined=
+Choose\ pattern=
+Use\ the\ BIB\ file\ location\ as\ primary\ file\ directory=
+Could\ not\ run\ the\ gnuclient/emacsclient\ program.\ Make\ sure\ you\ have\ the\ emacsclient/gnuclient\ program\ installed\ and\ available\ in\ the\ PATH.=
+OpenOffice/LibreOffice\ connection=Nối với OpenOffice/LibreOffice
+You\ must\ select\ either\ a\ valid\ style\ file,\ or\ use\ one\ of\ the\ default\ styles.=
 
-This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.=
-This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.=
-You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.=
+This\ is\ a\ simple\ copy\ and\ paste\ dialog.\ First\ load\ or\ paste\ some\ text\ into\ the\ text\ input\ area.<br>After\ that,\ you\ can\ mark\ text\ and\ assign\ it\ to\ a\ BibTeX\ field.=
+This\ feature\ generates\ a\ new\ library\ based\ on\ which\ entries\ are\ needed\ in\ an\ existing\ LaTeX\ document.=
+You\ need\ to\ select\ one\ of\ your\ open\ libraries\ from\ which\ to\ choose\ entries,\ as\ well\ as\ the\ AUX\ file\ produced\ by\ LaTeX\ when\ compiling\ your\ document.=
 
-First_select_entries_to_clean_up.=
-Cleanup_entry=
-Autogenerate_PDF_Names=
-Auto-generating_PDF-Names_does_not_support_undo._Continue?=
+First\ select\ entries\ to\ clean\ up.=
+Cleanup\ entry=
+Autogenerate\ PDF\ Names=
+Auto-generating\ PDF-Names\ does\ not\ support\ undo.\ Continue?=
 
-Use_full_firstname_whenever_possible=
-Use_abbreviated_firstname_whenever_possible=
-Use_abbreviated_and_full_firstname=
-Autocompletion_options=
-Name_format_used_for_autocompletion=
-Treatment_of_first_names=
-Cleanup_entries=
-Automatically_assign_new_entry_to_selected_groups=
-%0_mode=
-Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix=
-Make_paths_of_linked_files_relative_(if_possible)=
-Rename_PDFs_to_given_filename_format_pattern=
-Rename_only_PDFs_having_a_relative_path=
-What_would_you_like_to_clean_up?=
-Doing_a_cleanup_for_%0_entries...=
-No_entry_needed_a_clean_up=
-One_entry_needed_a_clean_up=
-%0_entries_needed_a_clean_up=
+Use\ full\ firstname\ whenever\ possible=
+Use\ abbreviated\ firstname\ whenever\ possible=
+Use\ abbreviated\ and\ full\ firstname=
+Autocompletion\ options=
+Name\ format\ used\ for\ autocompletion=
+Treatment\ of\ first\ names=
+Cleanup\ entries=
+Automatically\ assign\ new\ entry\ to\ selected\ groups=
+%0\ mode=
+Move\ DOIs\ from\ note\ and\ URL\ field\ to\ DOI\ field\ and\ remove\ http\ prefix=
+Make\ paths\ of\ linked\ files\ relative\ (if\ possible)=
+Rename\ PDFs\ to\ given\ filename\ format\ pattern=
+Rename\ only\ PDFs\ having\ a\ relative\ path=
+What\ would\ you\ like\ to\ clean\ up?=
+Doing\ a\ cleanup\ for\ %0\ entries...=
+No\ entry\ needed\ a\ clean\ up=
+One\ entry\ needed\ a\ clean\ up=
+%0\ entries\ needed\ a\ clean\ up=
 
-Remove_selected=
+Remove\ selected=
 
-Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.=
-Attach_file=
-Setting_all_preferences_to_default_values.=
-Resetting_preference_key_'%0'=
-Unknown_preference_key_'%0'=
-Unable_to_clear_preferences.=
+Group\ tree\ could\ not\ be\ parsed.\ If\ you\ save\ the\ BibTeX\ library,\ all\ groups\ will\ be\ lost.=
+Attach\ file=
+Setting\ all\ preferences\ to\ default\ values.=
+Resetting\ preference\ key\ '%0'=
+Unknown\ preference\ key\ '%0'=
+Unable\ to\ clear\ preferences.=
 
-Reset_preferences_(key1,key2,..._or_'all')=
-Find_unlinked_files=
-Unselect_all=
-Expand_all=
-Collapse_all=
-Opens_the_file_browser.=
-Scan_directory=
-Searches_the_selected_directory_for_unlinked_files.=
-Starts_the_import_of_BibTeX_entries.=
-Leave_this_dialog.=
-Create_directory_based_keywords=
-Creates_keywords_in_created_entrys_with_directory_pathnames=
-Select_a_directory_where_the_search_shall_start.=
-Select_file_type\:=
-These_files_are_not_linked_in_the_active_library.=
-Entry_type_to_be_created\:=
-Searching_file_system...=
-Importing_into_Library...=
-Select_directory=
-Select_files=
-BibTeX_entry_creation=
-<No_selection>=
-Unable_to_connect_to_FreeCite_online_service.=
-Parse_with_FreeCite=
-The_current_BibTeX_key_will_be_overwritten._Continue?=
-Overwrite_key=
-Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator=
-How_would_you_like_to_link_to_'%0'?=
-BibTeX_key_patterns=
-Changed_special_field_settings=
-Clear_priority=
-Clear_rank=Xóa_bỏ_hạng
-Enable_special_fields=
-One_star=
-Two_stars=
-Three_stars=
-Four_stars=
-Five_stars=
-Help_on_special_fields=
-Keywords_of_selected_entries=
-Manage_content_selectors=
-Manage_keywords=
-No_priority_information=
-No_rank_information=
+Reset\ preferences\ (key1,key2,...\ or\ 'all')=
+Find\ unlinked\ files=
+Unselect\ all=
+Expand\ all=
+Collapse\ all=
+Opens\ the\ file\ browser.=
+Scan\ directory=
+Searches\ the\ selected\ directory\ for\ unlinked\ files.=
+Starts\ the\ import\ of\ BibTeX\ entries.=
+Leave\ this\ dialog.=
+Create\ directory\ based\ keywords=
+Creates\ keywords\ in\ created\ entrys\ with\ directory\ pathnames=
+Select\ a\ directory\ where\ the\ search\ shall\ start.=
+Select\ file\ type\:=
+These\ files\ are\ not\ linked\ in\ the\ active\ library.=
+Entry\ type\ to\ be\ created\:=
+Searching\ file\ system...=
+Importing\ into\ Library...=
+Select\ directory=
+Select\ files=
+BibTeX\ entry\ creation=
+<No\ selection>=
+Unable\ to\ connect\ to\ FreeCite\ online\ service.=
+Parse\ with\ FreeCite=
+The\ current\ BibTeX\ key\ will\ be\ overwritten.\ Continue?=
+Overwrite\ key=
+Not\ overwriting\ existing\ key.\ To\ change\ this\ setting,\ open\ Options\ ->\ Prefererences\ ->\ BibTeX\ key\ generator=
+How\ would\ you\ like\ to\ link\ to\ '%0'?=
+BibTeX\ key\ patterns=
+Changed\ special\ field\ settings=
+Clear\ priority=
+Clear\ rank=Xóa bỏ hạng
+Enable\ special\ fields=
+One\ star=
+Two\ stars=
+Three\ stars=
+Four\ stars=
+Five\ stars=
+Help\ on\ special\ fields=
+Keywords\ of\ selected\ entries=
+Manage\ content\ selectors=
+Manage\ keywords=
+No\ priority\ information=
+No\ rank\ information=
 Priority=
-Priority_high=
-Priority_low=
-Priority_medium=
+Priority\ high=
+Priority\ low=
+Priority\ medium=
 Quality=
-Rank=Xếp_hạng
+Rank=Xếp hạng
 Relevance=
-Set_priority_to_high=
-Set_priority_to_low=
-Set_priority_to_medium=
-Show_priority=
-Show_quality=
-Show_rank=
-Show_relevance=
-Synchronize_with_keywords=
-Synchronized_special_fields_based_on_keywords=
-Toggle_relevance=
-Toggle_quality_assured=
-Toggle_print_status=
-Update_keywords=
-Write_values_of_special_fields_as_separate_fields_to_BibTeX=
-You_have_changed_settings_for_special_fields.=
-%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.=
-A_string_with_that_label_already_exists=Một_chuỗi_với_nhãn_đó_đã_có
-Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.=
-JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.=
-Correct_the_entry,_and_reopen_editor_to_display/edit_source.=
-Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').=
-Could_not_connect_to_running_OpenOffice/LibreOffice.=
-Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.=
-If_connecting_manually,_please_verify_program_and_library_paths.=
-Error_message\:=
-If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.=
-Import_metadata_from_PDF=
-Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.=
-Removed_all_subgroups_of_group_"%0".=
-To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.=
-Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.=
-Use_the_following_delimiter_character(s)\:=
-When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above=
-Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=
-Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=
+Set\ priority\ to\ high=
+Set\ priority\ to\ low=
+Set\ priority\ to\ medium=
+Show\ priority=
+Show\ quality=
+Show\ rank=
+Show\ relevance=
+Synchronize\ with\ keywords=
+Synchronized\ special\ fields\ based\ on\ keywords=
+Toggle\ relevance=
+Toggle\ quality\ assured=
+Toggle\ print\ status=
+Update\ keywords=
+Write\ values\ of\ special\ fields\ as\ separate\ fields\ to\ BibTeX=
+You\ have\ changed\ settings\ for\ special\ fields.=
+%0\ entries\ found.\ To\ reduce\ server\ load,\ only\ %1\ will\ be\ downloaded.=
+A\ string\ with\ that\ label\ already\ exists=Một chuỗi với nhãn đó đã có
+Connection\ to\ OpenOffice/LibreOffice\ has\ been\ lost.\ Please\ make\ sure\ OpenOffice/LibreOffice\ is\ running,\ and\ try\ to\ reconnect.=
+JabRef\ will\ send\ at\ least\ one\ request\ per\ entry\ to\ a\ publisher.=
+Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=
+Could\ not\ connect\ to\ a\ running\ gnuserv\ process.\ Make\ sure\ that\ Emacs\ or\ XEmacs\ is\ running,<BR>and\ that\ the\ server\ has\ been\ started\ (by\ running\ the\ command\ 'server-start'/'gnuserv-start').=
+Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=
+Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=
+If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=
+Error\ message\:=
+If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=
+Import\ metadata\ from\ PDF=
+Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=
+Removed\ all\ subgroups\ of\ group\ "%0".=
+To\ disable\ the\ memory\ stick\ mode\ rename\ or\ remove\ the\ jabref.xml\ file\ in\ the\ same\ folder\ as\ JabRef.=
+Unable\ to\ connect.\ One\ possible\ reason\ is\ that\ JabRef\ and\ OpenOffice/LibreOffice\ are\ not\ both\ running\ in\ either\ 32\ bit\ mode\ or\ 64\ bit\ mode.=
+Use\ the\ following\ delimiter\ character(s)\:=
+When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\ prefer\ the\ BIB\ file\ location\ rather\ than\ the\ file\ directory\ set\ above=
+Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=
+Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=
 
 Searching...=
-You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?=
-Confirm_selection=
-Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case=
-Import_conversions=
-Please_enter_a_search_string=
-Please_open_or_start_a_new_library_before_searching=
+You\ have\ selected\ more\ than\ %0\ entries\ for\ download.\ Some\ web\ sites\ might\ block\ you\ if\ you\ make\ too\ many\ rapid\ downloads.\ Do\ you\ want\ to\ continue?=
+Confirm\ selection=
+Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=
+Import\ conversions=
+Please\ enter\ a\ search\ string=
+Please\ open\ or\ start\ a\ new\ library\ before\ searching=
 
-Canceled_merging_entries=
+Canceled\ merging\ entries=
 
-Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search=
-Merge_entries=Phối_các_mục
-Merged_entries=
-Merged_entry=
-None=Không_có
+Format\ units\ by\ adding\ non-breaking\ separators\ and\ keeping\ the\ correct\ case\ on\ search=
+Merge\ entries=Phối các mục
+Merged\ entries=
+Merged\ entry=
+None=Không có
 Parse=
 Result=
-Show_DOI_first=
-Show_URL_first=
-Use_Emacs_key_bindings=
-You_have_to_choose_exactly_two_entries_to_merge.=
+Show\ DOI\ first=
+Show\ URL\ first=
+Use\ Emacs\ key\ bindings=
+You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=
 
-Update_timestamp_on_modification=
-All_key_bindings_will_be_reset_to_their_defaults.=
+Update\ timestamp\ on\ modification=
+All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=
 
-Automatically_set_file_links=Tự_động_tạo_liên_kết_cho_tập_tin
-Resetting_all_key_bindings=
+Automatically\ set\ file\ links=Tự động tạo liên kết cho tập tin
+Resetting\ all\ key\ bindings=
 Hostname=
-Invalid_setting=
+Invalid\ setting=
 Network=
-Please_specify_both_hostname_and_port=
-Please_specify_both_username_and_password=
+Please\ specify\ both\ hostname\ and\ port=
+Please\ specify\ both\ username\ and\ password=
 
-Use_custom_proxy_configuration=
-Proxy_requires_authentication=
-Attention\:_Password_is_stored_in_plain_text\!=
-Clear_connection_settings=
-Cleared_connection_settings.=
+Use\ custom\ proxy\ configuration=
+Proxy\ requires\ authentication=
+Attention\:\ Password\ is\ stored\ in\ plain\ text\!=
+Clear\ connection\ settings=
+Cleared\ connection\ settings.=
 
-Rebind_C-a,_too=
-Rebind_C-f,_too=
+Rebind\ C-a,\ too=
+Rebind\ C-f,\ too=
 
-Open_folder=
-Searches_for_unlinked_PDF_files_on_the_file_system=
-Export_entries_ordered_as_specified=
-Export_sort_order=
-Export_sorting=
-Newline_separator=
+Open\ folder=
+Searches\ for\ unlinked\ PDF\ files\ on\ the\ file\ system=
+Export\ entries\ ordered\ as\ specified=
+Export\ sort\ order=
+Export\ sorting=
+Newline\ separator=
 
-Save_entries_ordered_as_specified=
-Save_sort_order=
-Show_extra_columns=
-Parsing_error=
-illegal_backslash_expression=
+Save\ entries\ ordered\ as\ specified=
+Save\ sort\ order=
+Show\ extra\ columns=
+Parsing\ error=
+illegal\ backslash\ expression=
 
-Move_to_group=Di_chuyển_vào_nhóm
+Move\ to\ group=Di chuyển vào nhóm
 
-Clear_read_status=
-Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')=
-Could_not_apply_changes.=
-Deprecated_fields=Các_dữ_liệu_không_tán_thành
-Hide/show_toolbar=
-No_read_status_information=
+Clear\ read\ status=
+Convert\ to\ biblatex\ format\ (for\ example,\ move\ the\ value\ of\ the\ 'journal'\ field\ to\ 'journaltitle')=
+Could\ not\ apply\ changes.=
+Deprecated\ fields=Các dữ liệu không tán thành
+Hide/show\ toolbar=
+No\ read\ status\ information=
 Printed=
-Read_status=
-Read_status_read=
-Read_status_skimmed=
-Save_selected_as_plain_BibTeX...=
-Set_read_status_to_read=
-Set_read_status_to_skimmed=
-Show_deprecated_BibTeX_fields=Hiển_thị_các_dữ_liệu_BibTex_không_tán_thành
+Read\ status=
+Read\ status\ read=
+Read\ status\ skimmed=
+Save\ selected\ as\ plain\ BibTeX...=
+Set\ read\ status\ to\ read=
+Set\ read\ status\ to\ skimmed=
+Show\ deprecated\ BibTeX\ fields=Hiển thị các dữ liệu BibTex không tán thành
 
-Show_gridlines=
-Show_printed_status=
-Show_read_status=
-Table_row_height_padding=
+Show\ gridlines=
+Show\ printed\ status=
+Show\ read\ status=
+Table\ row\ height\ padding=
 
-Marked_selected_entry=
-Marked_all_%0_selected_entries=
-Unmarked_selected_entry=
-Unmarked_all_%0_selected_entries=
+Marked\ selected\ entry=
+Marked\ all\ %0\ selected\ entries=
+Unmarked\ selected\ entry=
+Unmarked\ all\ %0\ selected\ entries=
 
 
-Unmarked_all_entries=
+Unmarked\ all\ entries=
 
-Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.=
+Unable\ to\ find\ the\ requested\ look\ and\ feel\ and\ thus\ the\ default\ one\ is\ used.=
 
-Opens_JabRef's_GitHub_page=
-Could_not_open_browser.=
-Please_open_%0_manually.=
-The_link_has_been_copied_to_the_clipboard.=
+Opens\ JabRef's\ GitHub\ page=
+Could\ not\ open\ browser.=
+Please\ open\ %0\ manually.=
+The\ link\ has\ been\ copied\ to\ the\ clipboard.=
 
-Open_%0_file=
+Open\ %0\ file=
 
-Cannot_delete_file=
-File_permission_error=
-Push_to_%0=
-Path_to_%0=Đường_dẫn_đến_%0
+Cannot\ delete\ file=
+File\ permission\ error=
+Push\ to\ %0=
+Path\ to\ %0=Đường dẫn đến %0
 Convert=
-Normalize_to_BibTeX_name_format=
-Help_on_Name_Formatting=
+Normalize\ to\ BibTeX\ name\ format=
+Help\ on\ Name\ Formatting=
 
-Add_new_file_type=
+Add\ new\ file\ type=
 
-Left_entry=
-Right_entry=
+Left\ entry=
+Right\ entry=
 Use=
-Original_entry=
-Replace_original_entry=
-No_information_added=
-Select_at_least_one_entry_to_manage_keywords.=
-OpenDocument_text=
-OpenDocument_spreadsheet=
-OpenDocument_presentation=
-%0_image=
-Added_entry=
-Modified_entry=
-Deleted_entry=
-Modified_groups_tree=
-Removed_all_groups=
-Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.=
-Select_export_format=
-Return_to_JabRef=
-Please_move_the_file_manually_and_link_in_place.=
-Could_not_connect_to_%0=Không_thể_kết_nối_đến_%0
-Warning\:_%0_out_of_%1_entries_have_undefined_title.=
-Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.=
+Original\ entry=
+Replace\ original\ entry=
+No\ information\ added=
+Select\ at\ least\ one\ entry\ to\ manage\ keywords.=
+OpenDocument\ text=
+OpenDocument\ spreadsheet=
+OpenDocument\ presentation=
+%0\ image=
+Added\ entry=
+Modified\ entry=
+Deleted\ entry=
+Modified\ groups\ tree=
+Removed\ all\ groups=
+Accepting\ the\ change\ replaces\ the\ complete\ groups\ tree\ with\ the\ externally\ modified\ groups\ tree.=
+Select\ export\ format=
+Return\ to\ JabRef=
+Please\ move\ the\ file\ manually\ and\ link\ in\ place.=
+Could\ not\ connect\ to\ %0=Không thể kết nối đến %0
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ title.=
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ BibTeX\ key.=
 occurrence=
-Added_new_'%0'_entry.=
-Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?=
-Changed_type_to_'%0'_for=Kiểu_được_đổi_thành_'%0'_dùng_cho
-Really_delete_the_selected_entry?=
-Really_delete_the_%0_selected_entries?=
-Keep_merged_entry_only=
-Keep_left=
-Keep_right=
-Old_entry=
-From_import=
-No_problems_found.=
-%0_problem(s)_found=
-Save_changes=
-Discard_changes=
-Library_'%0'_has_changed.=
-Print_entry_preview=
-Copy_title=
-Copy_\\cite{BibTeX_key}=Chép\\trích_dẫn{khóa_BibTeX}
-Copy_BibTeX_key_and_title=
-File_rename_failed_for_%0_entries.=
-Merged_BibTeX_source_code=
-Invalid_DOI\:_'%0'.=DOI_không_hợp_lệ\:_'%0'.
-should_start_with_a_name=
-should_end_with_a_name=
-unexpected_closing_curly_bracket=
-unexpected_opening_curly_bracket=
-capital_letters_are_not_masked_using_curly_brackets_{}=
-should_contain_a_four_digit_number=
-should_contain_a_valid_page_number_range=
+Added\ new\ '%0'\ entry.=
+Multiple\ entries\ selected.\ Do\ you\ want\ to\ change\ the\ type\ of\ all\ these\ to\ '%0'?=
+Changed\ type\ to\ '%0'\ for=Kiểu được đổi thành '%0' dùng cho
+Really\ delete\ the\ selected\ entry?=
+Really\ delete\ the\ %0\ selected\ entries?=
+Keep\ merged\ entry\ only=
+Keep\ left=
+Keep\ right=
+Old\ entry=
+From\ import=
+No\ problems\ found.=
+%0\ problem(s)\ found=
+Save\ changes=
+Discard\ changes=
+Library\ '%0'\ has\ changed.=
+Print\ entry\ preview=
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=Chép\\trích dẫn{khóa BibTeX}
+Copy\ BibTeX\ key\ and\ title=
+File\ rename\ failed\ for\ %0\ entries.=
+Merged\ BibTeX\ source\ code=
+Invalid\ DOI\:\ '%0'.=DOI không hợp lệ: '%0'.
+should\ start\ with\ a\ name=
+should\ end\ with\ a\ name=
+unexpected\ closing\ curly\ bracket=
+unexpected\ opening\ curly\ bracket=
+capital\ letters\ are\ not\ masked\ using\ curly\ brackets\ {}=
+should\ contain\ a\ four\ digit\ number=
+should\ contain\ a\ valid\ page\ number\ range=
 Filled=
-Field_is_missing=
-Search_%0=Tìm_trên_%0
+Field\ is\ missing=
+Search\ %0=Tìm trên %0
 
-Search_results_in_all_libraries_for_%0=
-Search_results_in_library_%0_for_%1=
-Search_globally=
-No_results_found.=
-Found_%0_results.=
-plain_text=
-This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>=
-This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>=
-This_search_contains_entries_in_which=
+Search\ results\ in\ all\ libraries\ for\ %0=
+Search\ results\ in\ library\ %0\ for\ %1=
+Search\ globally=
+No\ results\ found.=
+Found\ %0\ results.=
+plain\ text=
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ regular\ expression\ <b>%0</b>=
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ term\ <b>%0</b>=
+This\ search\ contains\ entries\ in\ which=
 
-Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.=
-JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>=
-This_library_uses_outdated_file_links.=
+Unable\ to\ autodetect\ OpenOffice/LibreOffice\ installation.\ Please\ choose\ the\ installation\ directory\ manually.=
+JabRef\ no\ longer\ supports\ 'ps'\ or\ 'pdf'\ fields.<br>File\ links\ are\ now\ stored\ in\ the\ 'file'\ field\ and\ files\ are\ stored\ in\ an\ external\ file\ directory.<br>To\ make\ use\ of\ this\ feature,\ JabRef\ needs\ to\ upgrade\ file\ links.<br><br>=
+This\ library\ uses\ outdated\ file\ links.=
 
-Clear_search=
-Close_library=Đóng_CSDL
-Close_entry_editor=
-Decrease_table_font_size=
-Entry_editor,_next_entry=
-Entry_editor,_next_panel=
-Entry_editor,_next_panel_2=
-Entry_editor,_previous_entry=
-Entry_editor,_previous_panel=
-Entry_editor,_previous_panel_2=
-File_list_editor,_move_entry_down=
-File_list_editor,_move_entry_up=
-Focus_entry_table=
-Import_into_current_library=
-Import_into_new_library=
-Increase_table_font_size=
-New_article=Bài_viết_mới
-New_book=
-New_entry=
-New_from_plain_text=
-New_inbook=
-New_mastersthesis=
-New_phdthesis=
-New_proceedings=
-New_unpublished=
-Next_tab=
-Preamble_editor,_store_changes=
-Previous_tab=
-Push_to_application=
-Refresh_OpenOffice/LibreOffice=
-Resolve_duplicate_BibTeX_keys=
-Save_all=
-String_dialog,_add_string=
-String_dialog,_remove_string=
-Synchronize_files=
+Clear\ search=
+Close\ library=Đóng CSDL
+Close\ entry\ editor=
+Decrease\ table\ font\ size=
+Entry\ editor,\ next\ entry=
+Entry\ editor,\ next\ panel=
+Entry\ editor,\ next\ panel\ 2=
+Entry\ editor,\ previous\ entry=
+Entry\ editor,\ previous\ panel=
+Entry\ editor,\ previous\ panel\ 2=
+File\ list\ editor,\ move\ entry\ down=
+File\ list\ editor,\ move\ entry\ up=
+Focus\ entry\ table=
+Import\ into\ current\ library=
+Import\ into\ new\ library=
+Increase\ table\ font\ size=
+New\ article=Bài viết mới
+New\ book=
+New\ entry=
+New\ from\ plain\ text=
+New\ inbook=
+New\ mastersthesis=
+New\ phdthesis=
+New\ proceedings=
+New\ unpublished=
+Next\ tab=
+Preamble\ editor,\ store\ changes=
+Previous\ tab=
+Push\ to\ application=
+Refresh\ OpenOffice/LibreOffice=
+Resolve\ duplicate\ BibTeX\ keys=
+Save\ all=
+String\ dialog,\ add\ string=
+String\ dialog,\ remove\ string=
+Synchronize\ files=
 Unabbreviate=
-should_contain_a_protocol=
-Copy_preview=
-Automatically_setting_file_links=Tự_động_thiết_lập_liên_kết_với_tập_tin
-Regenerating_BibTeX_keys_according_to_metadata=
-No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys=
-Regenerate_all_keys_for_the_entries_in_a_BibTeX_file=
-Show_debug_level_messages=
-Default_bibliography_mode=
-New_%0_library_created.=
-Show_only_preferences_deviating_from_their_default_value=
+should\ contain\ a\ protocol=
+Copy\ preview=
+Automatically\ setting\ file\ links=Tự động thiết lập liên kết với tập tin
+Regenerating\ BibTeX\ keys\ according\ to\ metadata=
+No\ meta\ data\ present\ in\ BIB\ file.\ Cannot\ regenerate\ BibTeX\ keys=
+Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=
+Show\ debug\ level\ messages=
+Default\ bibliography\ mode=
+New\ %0\ library\ created.=
+Show\ only\ preferences\ deviating\ from\ their\ default\ value=
 default=
 key=
 type=
 value=
-Show_preferences=
-Save_actions=
-Enable_save_actions=
+Show\ preferences=
+Save\ actions=
+Enable\ save\ actions=
 
-Other_fields=Các_dữ_liệu_khác
-Show_remaining_fields=Hiển_thị_dữ_liệu_duy_trì
+Other\ fields=Các dữ liệu khác
+Show\ remaining\ fields=Hiển thị dữ liệu duy trì
 
-link_should_refer_to_a_correct_file_path=
-abbreviation_detected=
-wrong_entry_type_as_proceedings_has_page_numbers=
-Abbreviate_journal_names=
+link\ should\ refer\ to\ a\ correct\ file\ path=
+abbreviation\ detected=
+wrong\ entry\ type\ as\ proceedings\ has\ page\ numbers=
+Abbreviate\ journal\ names=
 Abbreviating...=
-Abbreviation_%s_for_journal_%s_already_defined.=
-Abbreviation_cannot_be_empty=
-Duplicated_Journal_Abbreviation=
-Duplicated_Journal_File=
-Error_Occurred=
-Journal_file_%s_already_added=
-Name_cannot_be_empty=
+Abbreviation\ %s\ for\ journal\ %s\ already\ defined.=
+Abbreviation\ cannot\ be\ empty=
+Duplicated\ Journal\ Abbreviation=
+Duplicated\ Journal\ File=
+Error\ Occurred=
+Journal\ file\ %s\ already\ added=
+Name\ cannot\ be\ empty=
 
-Adding_fetched_entries=
-Display_keywords_appearing_in_ALL_entries=
-Display_keywords_appearing_in_ANY_entry=
-Fetching_entries_from_Inspire=
-None_of_the_selected_entries_have_titles.=
-None_of_the_selected_entries_have_BibTeX_keys.=
-Unabbreviate_journal_names=
+Adding\ fetched\ entries=
+Display\ keywords\ appearing\ in\ ALL\ entries=
+Display\ keywords\ appearing\ in\ ANY\ entry=
+Fetching\ entries\ from\ Inspire=
+None\ of\ the\ selected\ entries\ have\ titles.=
+None\ of\ the\ selected\ entries\ have\ BibTeX\ keys.=
+Unabbreviate\ journal\ names=
 Unabbreviating...=
 Usage=
 
 
-Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.=
-Are_you_sure_you_want_to_reset_all_settings_to_default_values?=
-Reset_preferences=
-Ill-formed_entrytype_comment_in_BIB_file=
+Adds\ {}\ brackets\ around\ acronyms,\ month\ names\ and\ countries\ to\ preserve\ their\ case.=
+Are\ you\ sure\ you\ want\ to\ reset\ all\ settings\ to\ default\ values?=
+Reset\ preferences=
+Ill-formed\ entrytype\ comment\ in\ BIB\ file=
 
-Move_linked_files_to_default_file_directory_%0=
+Move\ linked\ files\ to\ default\ file\ directory\ %0=
 
 Clipboard=
-Could_not_paste_entry_as_text\:=
-Do_you_still_want_to_continue?=
-This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:=
-This_could_cause_undesired_changes_to_your_entries.=
-Run_field_formatter\:=
-Table_font_size_is_%0=
-%0_import_canceled=Vi\u1ec7c_nh\u1eadp_t\u1eeb_%0_b\u1ecb_h\u1ee7y
-Internal_style=
-Add_style_file=
-Are_you_sure_you_want_to_remove_the_style?=
-Current_style_is_'%0'=
-Remove_style=
-Select_one_of_the_available_styles_or_add_a_style_file_from_disk.=
-You_must_select_a_valid_style_file.=
+Could\ not\ paste\ entry\ as\ text\:=
+Do\ you\ still\ want\ to\ continue?=
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=
+This\ could\ cause\ undesired\ changes\ to\ your\ entries.=
+Run\ field\ formatter\:=
+Table\ font\ size\ is\ %0=
+%0\ import\ canceled=Vi\u1ec7c nh\u1eadp t\u1eeb %0 b\u1ecb h\u1ee7y
+Internal\ style=
+Add\ style\ file=
+Are\ you\ sure\ you\ want\ to\ remove\ the\ style?=
+Current\ style\ is\ '%0'=
+Remove\ style=
+Select\ one\ of\ the\ available\ styles\ or\ add\ a\ style\ file\ from\ disk.=
+You\ must\ select\ a\ valid\ style\ file.=
 Reload=
 
 Capitalize=
-Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.=
-Capitalize_the_first_word,_changes_other_words_to_lower_case.=
-Changes_all_letters_to_lower_case.=
-Changes_all_letters_to_upper_case.=
-Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.=
-Cleans_up_LaTeX_code.=
-Converts_HTML_code_to_LaTeX_code.=
-Converts_HTML_code_to_Unicode.=
-Converts_LaTeX_encoding_to_Unicode_characters.=
-Converts_Unicode_characters_to_LaTeX_encoding.=
-Converts_ordinals_to_LaTeX_superscripts.=
-Converts_units_to_LaTeX_formatting.=
-HTML_to_LaTeX=
-LaTeX_cleanup=
-LaTeX_to_Unicode=
-Lower_case=
-Minify_list_of_person_names=
-Normalize_date=
-Normalize_month=
-Normalize_month_to_BibTeX_standard_abbreviation.=
-Normalize_names_of_persons=
-Normalize_page_numbers=
-Normalize_pages_to_BibTeX_standard.=
-Normalizes_lists_of_persons_to_the_BibTeX_standard.=
-Normalizes_the_date_to_ISO_date_format.=
-Ordinals_to_LaTeX_superscript=
-Protect_terms=
-Remove_enclosing_braces=
-Removes_braces_encapsulating_the_complete_field_content.=
-Sentence_case=
-Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".=
-Title_case=
-Unicode_to_LaTeX=
-Units_to_LaTeX=
-Upper_case=
-Does_nothing.=
+Capitalize\ all\ words,\ but\ converts\ articles,\ prepositions,\ and\ conjunctions\ to\ lower\ case.=
+Capitalize\ the\ first\ word,\ changes\ other\ words\ to\ lower\ case.=
+Changes\ all\ letters\ to\ lower\ case.=
+Changes\ all\ letters\ to\ upper\ case.=
+Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=
+Cleans\ up\ LaTeX\ code.=
+Converts\ HTML\ code\ to\ LaTeX\ code.=
+Converts\ HTML\ code\ to\ Unicode.=
+Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=
+Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=
+Converts\ ordinals\ to\ LaTeX\ superscripts.=
+Converts\ units\ to\ LaTeX\ formatting.=
+HTML\ to\ LaTeX=
+LaTeX\ cleanup=
+LaTeX\ to\ Unicode=
+Lower\ case=
+Minify\ list\ of\ person\ names=
+Normalize\ date=
+Normalize\ month=
+Normalize\ month\ to\ BibTeX\ standard\ abbreviation.=
+Normalize\ names\ of\ persons=
+Normalize\ page\ numbers=
+Normalize\ pages\ to\ BibTeX\ standard.=
+Normalizes\ lists\ of\ persons\ to\ the\ BibTeX\ standard.=
+Normalizes\ the\ date\ to\ ISO\ date\ format.=
+Ordinals\ to\ LaTeX\ superscript=
+Protect\ terms=
+Remove\ enclosing\ braces=
+Removes\ braces\ encapsulating\ the\ complete\ field\ content.=
+Sentence\ case=
+Shortens\ lists\ of\ persons\ if\ there\ are\ more\ than\ 2\ persons\ to\ "et\ al.".=
+Title\ case=
+Unicode\ to\ LaTeX=
+Units\ to\ LaTeX=
+Upper\ case=
+Does\ nothing.=
 Identity=
-Clears_the_field_completely.=
-Directory_not_found=
-Main_file_directory_not_set\!=
-This_operation_requires_exactly_one_item_to_be_selected.=
-Importing_in_%0_format=
-Female_name=
-Female_names=
-Male_name=
-Male_names=
-Mixed_names=
-Neuter_name=
-Neuter_names=
+Clears\ the\ field\ completely.=
+Directory\ not\ found=
+Main\ file\ directory\ not\ set\!=
+This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=
+Importing\ in\ %0\ format=
+Female\ name=
+Female\ names=
+Male\ name=
+Male\ names=
+Mixed\ names=
+Neuter\ name=
+Neuter\ names=
 
-Determined_%0_for_%1_entries=
-Look_up_%0=
-Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3=
+Determined\ %0\ for\ %1\ entries=
+Look\ up\ %0=
+Looking\ up\ %0...\ -\ entry\ %1\ out\ of\ %2\ -\ found\ %3=
 
-Audio_CD=Đĩa_âm_thanh
-British_patent=Sáng_chế_của_Anh
-British_patent_request=Yêu_cầu_sáng_chế_của_Anh
-Candidate_thesis=Bài_luận_văn_ứng_viên
+Audio\ CD=Đĩa âm thanh
+British\ patent=Sáng chế của Anh
+British\ patent\ request=Yêu cầu sáng chế của Anh
+Candidate\ thesis=Bài luận văn ứng viên
 Collaborator=
 Column=
 Compiler=
 Continuator=
-Data_CD=Đĩa_dữ_liệu
+Data\ CD=Đĩa dữ liệu
 Editor=
-European_patent=Sáng_chế_của_Châu_Âu
-European_patent_request=Yêu_cầu_sáng_chế_của_Châu_Âu
+European\ patent=Sáng chế của Châu Âu
+European\ patent\ request=Yêu cầu sáng chế của Châu Âu
 Founder=
-French_patent=Sáng_chế_của_Pháp
-French_patent_request=Yêu_cầu_sáng_chế_của_Pháp
-German_patent=Sáng_chế_của_Đức
-German_patent_request=Yêu_cầu_sáng_chế_của_Đức
+French\ patent=Sáng chế của Pháp
+French\ patent\ request=Yêu cầu sáng chế của Pháp
+German\ patent=Sáng chế của Đức
+German\ patent\ request=Yêu cầu sáng chế của Đức
 Line=
-Master's_thesis=Bài_luận_văn_chính
+Master's\ thesis=Bài luận văn chính
 Page=
 Paragraph=
-Patent=Sáng_chế
-Patent_request=Yêu_cầu_sáng_chế
-PhD_thesis=Bài_luận_văn_PhD
+Patent=Sáng chế
+Patent\ request=Yêu cầu sáng chế
+PhD\ thesis=Bài luận văn PhD
 Redactor=
-Research_report=Bảng_báo_cáo_nghiên_cứu
+Research\ report=Bảng báo cáo nghiên cứu
 Reviser=
 Section=
-Software=Phần_mềm
-Technical_report=Bảng_báo_cáo_kỹ_thuật
-U.S._patent=Sáng_chế_của_Mỹ
-U.S._patent_request=Yêu_cầu_sáng_chế_của_Mỹ
+Software=Phần mềm
+Technical\ report=Bảng báo cáo kỹ thuật
+U.S.\ patent=Sáng chế của Mỹ
+U.S.\ patent\ request=Yêu cầu sáng chế của Mỹ
 Verse=
 
-change_entries_of_group=
-odd_number_of_unescaped_'\#'=
+change\ entries\ of\ group=
+odd\ number\ of\ unescaped\ '\#'=
 
-Plain_text=
-Show_diff=
+Plain\ text=
+Show\ diff=
 character=
 word=
-Show_symmetric_diff=
-Copy_Version=
+Show\ symmetric\ diff=
+Copy\ Version=
 Developers=
 Authors=
 License=
 
-HTML_encoded_character_found=
-booktitle_ends_with_'conference_on'=
+HTML\ encoded\ character\ found=
+booktitle\ ends\ with\ 'conference\ on'=
 
-All_external_files=
+All\ external\ files=
 
-OpenOffice/LibreOffice_integration=
+OpenOffice/LibreOffice\ integration=
 
-incorrect_control_digit=
-incorrect_format=
-Copied_version_to_clipboard=
+incorrect\ control\ digit=
+incorrect\ format=
+Copied\ version\ to\ clipboard=
 
-BibTeX_key=
+BibTeX\ key=
 Message=
 
 
-MathSciNet_Review=
-Reset_Bindings=
+MathSciNet\ Review=
+Reset\ Bindings=
 
-Decryption_not_supported.=
+Decryption\ not\ supported.=
 
-Cleared_'%0'_for_%1_entries=
-Set_'%0'_to_'%1'_for_%2_entries=
-Toggled_'%0'_for_%1_entries=
+Cleared\ '%0'\ for\ %1\ entries=
+Set\ '%0'\ to\ '%1'\ for\ %2\ entries=
+Toggled\ '%0'\ for\ %1\ entries=
 
-Check_for_updates=Kiểm_tra_cập_nhật
-Download_update=
-New_version_available=
-Installed_version=
-Remind_me_later=
-Ignore_this_update=
-Could_not_connect_to_the_update_server.=
-Please_try_again_later_and/or_check_your_network_connection.=
-To_see_what_is_new_view_the_changelog.=
-A_new_version_of_JabRef_has_been_released.=
-JabRef_is_up-to-date.=Phiên_bản_JabRef_là_mới_nhất.
-Latest_version=
-Online_help_forum=
+Check\ for\ updates=Kiểm tra cập nhật
+Download\ update=
+New\ version\ available=
+Installed\ version=
+Remind\ me\ later=
+Ignore\ this\ update=
+Could\ not\ connect\ to\ the\ update\ server.=
+Please\ try\ again\ later\ and/or\ check\ your\ network\ connection.=
+To\ see\ what\ is\ new\ view\ the\ changelog.=
+A\ new\ version\ of\ JabRef\ has\ been\ released.=
+JabRef\ is\ up-to-date.=Phiên bản JabRef là mới nhất.
+Latest\ version=
+Online\ help\ forum=
 Custom=
 
-Export_cited=
-Unable_to_generate_new_library=
+Export\ cited=
+Unable\ to\ generate\ new\ library=
 
-Open_console=
-Use_default_terminal_emulator=
-Execute_command=
-Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.=
-Executing_command_\"%0\"...=
-Error_occured_while_executing_the_command_\"%0\".=
-Reformat_ISSN=
+Open\ console=
+Use\ default\ terminal\ emulator=
+Execute\ command=
+Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=
+Executing\ command\ \"%0\"...=
+Error\ occured\ while\ executing\ the\ command\ \"%0\".=
+Reformat\ ISSN=
 
-Countries_and_territories_in_English=
-Electrical_engineering_terms=
+Countries\ and\ territories\ in\ English=
+Electrical\ engineering\ terms=
 Enabled=
-Internal_list=
-Manage_protected_terms_files=
-Months_and_weekdays_in_English=
-The_text_after_the_last_line_starting_with_\#_will_be_used=
-Add_protected_terms_file=
-Are_you_sure_you_want_to_remove_the_protected_terms_file?=
-Remove_protected_terms_file=
-Add_selected_text_to_list=
-Add_{}_around_selected_text=
-Format_field=
-New_protected_terms_file=
-change_field_%0_of_entry_%1_from_%2_to_%3=
-change_key_from_%0_to_%1=
-change_string_content_%0_to_%1=
-change_string_name_%0_to_%1=
-change_type_of_entry_%0_from_%1_to_%2=
-insert_entry_%0=
-insert_string_%0=
-remove_entry_%0=
-remove_string_%0=
+Internal\ list=
+Manage\ protected\ terms\ files=
+Months\ and\ weekdays\ in\ English=
+The\ text\ after\ the\ last\ line\ starting\ with\ \#\ will\ be\ used=
+Add\ protected\ terms\ file=
+Are\ you\ sure\ you\ want\ to\ remove\ the\ protected\ terms\ file?=
+Remove\ protected\ terms\ file=
+Add\ selected\ text\ to\ list=
+Add\ {}\ around\ selected\ text=
+Format\ field=
+New\ protected\ terms\ file=
+change\ field\ %0\ of\ entry\ %1\ from\ %2\ to\ %3=
+change\ key\ from\ %0\ to\ %1=
+change\ string\ content\ %0\ to\ %1=
+change\ string\ name\ %0\ to\ %1=
+change\ type\ of\ entry\ %0\ from\ %1\ to\ %2=
+insert\ entry\ %0=
+insert\ string\ %0=
+remove\ entry\ %0=
+remove\ string\ %0=
 undefined=
-Cannot_get_info_based_on_given_%0\:_%1=
-Get_BibTeX_data_from_%0=Nhập_dữ_liệu_BibTex_từ_%0
-No_%0_found=
-Entry_from_%0=
-Merge_entry_with_%0_information=
-Updated_entry_with_info_from_%0=
+Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=
+Get\ BibTeX\ data\ from\ %0=Nhập dữ liệu BibTex từ %0
+No\ %0\ found=
+Entry\ from\ %0=
+Merge\ entry\ with\ %0\ information=
+Updated\ entry\ with\ info\ from\ %0=
 
-Add_existing_file=
-Create_new_list=
-Remove_list=
-Full_journal_name=
-Abbreviation_name=
+Add\ existing\ file=
+Create\ new\ list=
+Remove\ list=
+Full\ journal\ name=
+Abbreviation\ name=
 
-No_abbreviation_files_loaded=
+No\ abbreviation\ files\ loaded=
 
-Loading_built_in_lists=
+Loading\ built\ in\ lists=
 
-JabRef_built_in_list=
-IEEE_built_in_list=
+JabRef\ built\ in\ list=
+IEEE\ built\ in\ list=
 
-Event_log=
-We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.=
-Log_copied_to_clipboard.=
-Copy_Log=
-Clear_Log=
-Report_Issue=
-Issue_on_GitHub_successfully_reported.=
-Issue_report_successful=
-Your_issue_was_reported_in_your_browser.=
-The_log_and_exception_information_was_copied_to_your_clipboard.=
-Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.=
+Event\ log=
+We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef\'s\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=
+Log\ copied\ to\ clipboard.=
+Copy\ Log=
+Clear\ Log=
+Report\ Issue=
+Issue\ on\ GitHub\ successfully\ reported.=
+Issue\ report\ successful=
+Your\ issue\ was\ reported\ in\ your\ browser.=
+The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=
+Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=
 
-Connection=Sự_kết_nối
-Connecting...=Đang_kết_nối...
-Host=Máy_chủ
+Connection=Sự kết nối
+Connecting...=Đang kết nối...
+Host=Máy chủ
 Port=Cổng
 Library=CSDL
-User=Người_sử_dụng
-Connect=Kết_nối
-Connection_error=Kết_nối_bị_lỗi
-Connection_to_%0_server_established.=Tạo_kết_nối_với_máy_chủ_%0.
-Required_field_"%0"_is_empty.=Dữ_liệu_cần_có_"%0"_đang_trống.
-%0_driver_not_available.=Trình_điều_khiển_%0_hiện_không_có.
-The_connection_to_the_server_has_been_terminated.=Kết_nối_đến_máy_chủ_đã_được_kết_thúc.
-Connection_lost.=Mất_kết_nối.
-Reconnect=Kết_nối_lại.
-Work_offline=Làm_việc_ẩn
-Working_offline.=Đang_làm_việc_ẩn.
-Update_refused.=Cập_nhật_bị_từ_chối.
-Update_refused=Cập_nhật_bị_từ_chối
-Local_entry=Mục_cục_bộ
-Shared_entry=Mục_chia_sẻ_
-Update_could_not_be_performed_due_to_existing_change_conflicts.=Cập_nhật_không_thể_được_thực_hiện_vì_hiện_đang_có_thay_đổi_xung_đột.
-You_are_not_working_on_the_newest_version_of_BibEntry.=Bạn_không_làm_việc_trên_phiên_bản_mới_nhất_của_BibEntry.
-Local_version\:_%0=Phiên_bản_cục_bộ\:_%0
-Shared_version\:_%0=Phiên_bản_chia_sẻ\:_%0
-Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.=Xin_vui_lòng_phối_mục_chia_sẻ_với_mục_của_bạn_và_nhấn_"Phối_các_mục"_để_giải_quyết_lỗi_này.
-Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?=Huỷ_bỏ_thao_tác_này_bạn_sẽ_rời_khỏi_thay_đổi_không_đồng_bộ_hóa_của_bạn._Bạn_vẫn_muốn_hủy?
-Shared_entry_is_no_longer_present=Mục_chia_sẻ_hiện_không_còn_nữa
-The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.=BibEntry_bạn_hiện_giờ_đang_làm_việc_đã_bị_xoá_bên_chia_sẻ.
-You_can_restore_the_entry_using_the_"Undo"_operation.=Bạn_có_thể_phục_hồi_mục_bằng_cách_sử_dụng_thao_tác_"Hoàn_tác".
-Remember_password?=Lưu_mật_mã?
-You_are_already_connected_to_a_database_using_entered_connection_details.=Bạn_đã_được_kết_nối_với_CSDL_bằng_sử_dụng_cách_nhập_chi_tiết_kết_nối.
+User=Người sử dụng
+Connect=Kết nối
+Connection\ error=Kết nối bị lỗi
+Connection\ to\ %0\ server\ established.=Tạo kết nối với máy chủ %0.
+Required\ field\ "%0"\ is\ empty.=Dữ liệu cần có "%0" đang trống.
+%0\ driver\ not\ available.=Trình điều khiển %0 hiện không có.
+The\ connection\ to\ the\ server\ has\ been\ terminated.=Kết nối đến máy chủ đã được kết thúc.
+Connection\ lost.=Mất kết nối.
+Reconnect=Kết nối lại.
+Work\ offline=Làm việc ẩn
+Working\ offline.=Đang làm việc ẩn.
+Update\ refused.=Cập nhật bị từ chối.
+Update\ refused=Cập nhật bị từ chối
+Local\ entry=Mục cục bộ
+Shared\ entry=Mục chia sẻ 
+Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=Cập nhật không thể được thực hiện vì hiện đang có thay đổi xung đột.
+You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=Bạn không làm việc trên phiên bản mới nhất của BibEntry.
+Local\ version\:\ %0=Phiên bản cục bộ: %0
+Shared\ version\:\ %0=Phiên bản chia sẻ: %0
+Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=Xin vui lòng phối mục chia sẻ với mục của bạn và nhấn "Phối các mục" để giải quyết lỗi này.
+Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=Huỷ bỏ thao tác này bạn sẽ rời khỏi thay đổi không đồng bộ hóa của bạn. Bạn vẫn muốn hủy?
+Shared\ entry\ is\ no\ longer\ present=Mục chia sẻ hiện không còn nữa
+The\ BibEntry\ you\ currently\ work\ on\ has\ been\ deleted\ on\ the\ shared\ side.=BibEntry bạn hiện giờ đang làm việc đã bị xoá bên chia sẻ.
+You\ can\ restore\ the\ entry\ using\ the\ "Undo"\ operation.=Bạn có thể phục hồi mục bằng cách sử dụng thao tác "Hoàn tác".
+Remember\ password?=Lưu mật mã?
+You\ are\ already\ connected\ to\ a\ database\ using\ entered\ connection\ details.=Bạn đã được kết nối với CSDL bằng sử dụng cách nhập chi tiết kết nối.
 
-Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?=
-New_technical_report=
+Cannot\ cite\ entries\ without\ BibTeX\ keys.\ Generate\ keys\ now?=
+New\ technical\ report=
 
-%0_file=
-Custom_layout_file=
-Protected_terms_file=
-Style_file=
+%0\ file=
+Custom\ layout\ file=
+Protected\ terms\ file=
+Style\ file=
 
-Open_OpenOffice/LibreOffice_connection=
-You_must_enter_at_least_one_field_name=
-Non-ASCII_encoded_character_found=
-Toggle_web_search_interface=
-Background_color_for_resolved_fields=
-Color_code_for_resolved_fields=
-%0_files_found=
-%0_of_%1=
-One_file_found=
-The_import_finished_with_warnings\:=
-There_was_one_file_that_could_not_be_imported.=
-There_were_%0_files_which_could_not_be_imported.=
+Open\ OpenOffice/LibreOffice\ connection=
+You\ must\ enter\ at\ least\ one\ field\ name=
+Non-ASCII\ encoded\ character\ found=
+Toggle\ web\ search\ interface=
+Background\ color\ for\ resolved\ fields=
+Color\ code\ for\ resolved\ fields=
+%0\ files\ found=
+%0\ of\ %1=
+One\ file\ found=
+The\ import\ finished\ with\ warnings\:=
+There\ was\ one\ file\ that\ could\ not\ be\ imported.=
+There\ were\ %0\ files\ which\ could\ not\ be\ imported.=
 
-Migration_help_information=Thông_tin_trợ_giúp_dời_chuyển
-Entered_database_has_obsolete_structure_and_is_no_longer_supported.=
-However,_a_new_database_was_created_alongside_the_pre-3.6_one.=Tuy_nhiên,_CSDL_mới_đã_được_tạo_lập_theo_CSDL_trước_3.6.
-Click_here_to_learn_about_the_migration_of_pre-3.6_databases.=Nhấp_vào_đây_để_biết_về_dời_chuyển_của_các_CSDL_trước_3.6.
-Opens_JabRef's_Facebook_page=
-Opens_JabRef's_blog=
-Opens_JabRef's_website=
-Opens_a_link_where_the_current_development_version_can_be_downloaded=
-See_what_has_been_changed_in_the_JabRef_versions=
-Referenced_BibTeX_key_does_not_exist=
-Finished_downloading_full_text_document_for_entry_%0.=
-Full_text_document_download_failed_for_entry_%0.=
-Look_up_full_text_documents=
-You_are_about_to_look_up_full_text_documents_for_%0_entries.=
-last_four_nonpunctuation_characters_should_be_numerals=
+Migration\ help\ information=Thông tin trợ giúp dời chuyển
+Entered\ database\ has\ obsolete\ structure\ and\ is\ no\ longer\ supported.=
+However,\ a\ new\ database\ was\ created\ alongside\ the\ pre-3.6\ one.=Tuy nhiên, CSDL mới đã được tạo lập theo CSDL trước 3.6.
+Click\ here\ to\ learn\ about\ the\ migration\ of\ pre-3.6\ databases.=Nhấp vào đây để biết về dời chuyển của các CSDL trước 3.6.
+Opens\ JabRef's\ Facebook\ page=
+Opens\ JabRef's\ blog=
+Opens\ JabRef's\ website=
+Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=
+See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=
+Referenced\ BibTeX\ key\ does\ not\ exist=
+Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=
+Full\ text\ document\ download\ failed\ for\ entry\ %0.=
+Look\ up\ full\ text\ documents=
+You\ are\ about\ to\ look\ up\ full\ text\ documents\ for\ %0\ entries.=
+last\ four\ nonpunctuation\ characters\ should\ be\ numerals=
 
 Author=
 Date=
-File_annotations=
-Show_file_annotations=
-Adobe_Acrobat_Reader=
-Sumatra_Reader=
+File\ annotations=
+Show\ file\ annotations=
+Adobe\ Acrobat\ Reader=
+Sumatra\ Reader=
 shared=
-should_contain_an_integer_or_a_literal=
-should_have_the_first_letter_capitalized=
+should\ contain\ an\ integer\ or\ a\ literal=
+should\ have\ the\ first\ letter\ capitalized=
 Tools=
-What\'s_new_in_this_version?=
-Want_to_help?=
-Make_a_donation=
-get_involved=
-Used_libraries=
-Existing_file=
+What\'s\ new\ in\ this\ version?=
+Want\ to\ help?=
+Make\ a\ donation=
+get\ involved=
+Used\ libraries=
+Existing\ file=
 
-ID=Mã_nhận_diện
-ID_type=Loại_mã_nhận_diện
-ID-based_entry_generator=
-Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+ID=Mã nhận diện
+ID\ type=Loại mã nhận diện
+ID-based\ entry\ generator=
+Fetcher\ '%0'\ did\ not\ find\ an\ entry\ for\ id\ '%1'.=
 
-Select_first_entry=
-Select_last_entry=
+Select\ first\ entry=
+Select\ last\ entry=
 
-Invalid_ISBN\:_'%0'.=
-should_be_an_integer_or_normalized=
-should_be_normalized=
+Invalid\ ISBN\:\ '%0'.=
+should\ be\ an\ integer\ or\ normalized=
+should\ be\ normalized=
 
-Empty_search_ID=
-The_given_search_ID_was_empty.=
-Copy_BibTeX_key_and_link=
-empty_BibTeX_key=
-biblatex_field_only=
+Empty\ search\ ID=
+The\ given\ search\ ID\ was\ empty.=
+Copy\ BibTeX\ key\ and\ link=
+empty\ BibTeX\ key=
+biblatex\ field\ only=
 
-Error_while_generating_fetch_URL=
-Error_while_parsing_ID_list=
-Unable_to_get_PubMed_IDs=
-Backup_found=Tìm_bản_sao_dự_phòng
-A_backup_file_for_'%0'_was_found.=Bản_sao_lưu_dự_phòng_cho_'%0'_đã_tìm_thấy.
-This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.=Điều_này_cho_thấy_là_JabRef_không_được_kết_thúc_hoàn_chỉnh_khi_sử_dụng_tập_tin_lần_cuối.
-Do_you_want_to_recover_the_library_from_the_backup_file?=Bạn_có_muốn_phục_hồi_cơ_sở_dữ_liệu_từ_tập_tin_lưu_dự_phòng_không?
-Firstname_Lastname=Họ_Tên
+Error\ while\ generating\ fetch\ URL=
+Error\ while\ parsing\ ID\ list=
+Unable\ to\ get\ PubMed\ IDs=
+Backup\ found=Tìm bản sao dự phòng
+A\ backup\ file\ for\ '%0'\ was\ found.=Bản sao lưu dự phòng cho '%0' đã tìm thấy.
+This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Điều này cho thấy là JabRef không được kết thúc hoàn chỉnh khi sử dụng tập tin lần cuối.
+Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Bạn có muốn phục hồi cơ sở dữ liệu từ tập tin lưu dự phòng không?
+Firstname\ Lastname=Họ Tên
 
-Recommended_for_%0=
-Show_'Related_Articles'_tab=
-This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
+Recommended\ for\ %0=
+Show\ 'Related\ Articles'\ tab=
+This\ might\ be\ caused\ by\ reaching\ the\ traffic\ limitation\ of\ Google\ Scholar\ (see\ 'Help'\ for\ details).=
 
-Could_not_open_website.=
-Problem_downloading_from_%1=
+Could\ not\ open\ website.=
+Problem\ downloading\ from\ %1=
 
-File_directory_pattern=
-Update_with_bibliographic_information_from_the_web=
+File\ directory\ pattern=
+Update\ with\ bibliographic\ information\ from\ the\ web=
 
-Could_not_find_any_bibliographic_information.=
-BibTeX_key_deviates_from_generated_key=
-DOI_%0_is_invalid=
+Could\ not\ find\ any\ bibliographic\ information.=
+BibTeX\ key\ deviates\ from\ generated\ key=
+DOI\ %0\ is\ invalid=
 
-Select_all_customized_types_to_be_stored_in_local_preferences=
-Currently_unknown=
-Different_customization,_current_settings_will_be_overwritten=
+Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences=
+Currently\ unknown=
+Different\ customization,\ current\ settings\ will\ be\ overwritten=
 
-Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX=
-Jump_to_entry=
+Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=
+Jump\ to\ entry=
 
-Copied_%0_citations.=
+Copied\ %0\ citations.=
 Copying...=
 
-journal_not_found_in_abbreviation_list=
-Unhandled_exception_occurred.=
+journal\ not\ found\ in\ abbreviation\ list=
+Unhandled\ exception\ occurred.=
 
-strings_included=
-Color_for_disabled_icons=
-Color_for_enabled_icons=
-Size_of_large_icons=
-Size_of_small_icons=
-Default_table_font_size=
-Escape_underscores=
+strings\ included=
+Color\ for\ disabled\ icons=
+Color\ for\ enabled\ icons=
+Size\ of\ large\ icons=
+Size\ of\ small\ icons=
+Default\ table\ font\ size=
+Escape\ underscores=
 Color=
-Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=
-Fit_width=
-Fit_a_single_page=
-Zoom_in=
-Zoom_out=
-Previous_page=
-Next_page=
-Document_viewer=
+Please\ also\ add\ all\ steps\ to\ reproduce\ this\ issue,\ if\ possible.=
+Fit\ width=
+Fit\ a\ single\ page=
+Zoom\ in=
+Zoom\ out=
+Previous\ page=
+Next\ page=
+Document\ viewer=
 Live=
 Locked=
-Show_document_viewer=
-Show_the_document_of_the_currently_selected_entry.=
-Show_this_document_until_unlocked.=
-Set_current_user_name_as_owner.=
+Show\ document\ viewer=
+Show\ the\ document\ of\ the\ currently\ selected\ entry.=
+Show\ this\ document\ until\ unlocked.=
+Set\ current\ user\ name\ as\ owner.=
 
-Sort_all_subgroups_(recursively)=
-Collect_and_share_telemetry_data_to_help_improve_JabRef.=
-Don't_share=
-Share_anonymous_statistics=
-Telemetry\:_Help_make_JabRef_better=
-To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.=
-This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?=
-Names_are_not_in_the_standard_%0_format.=
+Sort\ all\ subgroups\ (recursively)=
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=
+Don't\ share=
+Share\ anonymous\ statistics=
+Telemetry\:\ Help\ make\ JabRef\ better=
+To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ statistics\ on\ the\ features\ you\ use.\ We\ will\ only\ record\ what\ features\ you\ access\ and\ how\ often\ you\ do\ it.\ We\ will\ neither\ collect\ any\ personal\ data\ nor\ the\ content\ of\ bibliographic\ items.\ If\ you\ choose\ to\ allow\ data\ collection,\ you\ can\ later\ disable\ it\ via\ Options\ ->\ Preferences\ ->\ General.=
+This\ file\ was\ found\ automatically.\ Do\ you\ want\ to\ link\ it\ to\ this\ entry?=
+Names\ are\ not\ in\ the\ standard\ %0\ format.=
 
-Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.=
-Delete_'%0'=
-Delete_from_disk=
-Remove_from_entry=
-The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.=
-There_exists_already_a_group_with_the_same_name.=
+Delete\ the\ selected\ file\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ file\ permanently\ from\ disk.=
+Delete\ '%0'=
+Delete\ from\ disk=
+Remove\ from\ entry=
+The\ group\ name\ contains\ the\ keyword\ separator\ "%0"\ and\ thus\ probably\ does\ not\ work\ as\ expected.=
+There\ exists\ already\ a\ group\ with\ the\ same\ name.=
 
-Copy_linked_files_to_folder...=
-Copied_file_successfully=
-Copying_files...=
-Copying_file_%0_of_entry_%1=
-Finished_copying=
-Could_not_copy_file=
-Copied_%0_files_of_%1_sucessfully_to_%2=
-Rename_failed=
-JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.=
-Show_console_output_(only_necessary_when_the_launcher_is_used)=
+Copy\ linked\ files\ to\ folder...=
+Copied\ file\ successfully=
+Copying\ files...=
+Copying\ file\ %0\ of\ entry\ %1=
+Finished\ copying=
+Could\ not\ copy\ file=
+Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=
+Rename\ failed=
+JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=
+Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=
 
-Remove_line_breaks=
-Removes_all_line_breaks_in_the_field_content.=
-Checking_integrity...=
+Remove\ line\ breaks=
+Removes\ all\ line\ breaks\ in\ the\ field\ content.=
+Checking\ integrity...=
 
-Remove_hyphenated_line_breaks=
-Removes_all_hyphenated_line_breaks_in_the_field_content.=
-Note_that_currently,_JabRef_does_not_run_with_Java_9.=
-Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.=
+Remove\ hyphenated\ line\ breaks=
+Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=
+Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=
+Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -1206,9 +1206,9 @@ This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\
 
 This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=这个分组包含手动分配的记录, 你可以使用"选中-拖曳"或者右键菜单选中记录分配到该分组, 也可以使用右键菜单移除这些记录.
 
-This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=此分组中记录的 <b>%0</b> 域包含关键词 <b>%1</b> 
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=此分组中记录的 <b>%0</b> 域包含关键词 <b>%1</b>
 
-This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=此分组中记录的 <b>%0</b> 域包含正则表达式 <b>%1</b> 
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=此分组中记录的 <b>%0</b> 域包含正则表达式 <b>%1</b>
 This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=该选项使 JabRef 遍历所有文件链接，检查链接文件是否存在。如果不存在，您将会得到一个选项来处理这个问题。
 
 This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=此操作要求所有选中记录的 BibTeX 键值不为空。

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -1,8 +1,3 @@
-
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 %0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 包含正则表达式 <b>%1</b>
 
 %0\ contains\ the\ term\ <b>%1</b>=%0 包含词组 <b>%1</b>

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -3,156 +3,156 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-%0_contains_the_regular_expression_<b>%1</b>=%0_包含正则表达式_<b>%1</b>
+%0\ contains\ the\ regular\ expression\ <b>%1</b>=%0 包含正则表达式 <b>%1</b>
 
-%0_contains_the_term_<b>%1</b>=%0_包含词组_<b>%1</b>
+%0\ contains\ the\ term\ <b>%1</b>=%0 包含词组 <b>%1</b>
 
-%0_doesn't_contain_the_regular_expression_<b>%1</b>=%0_不包含正则表达式_<b>%1</b>
+%0\ doesn't\ contain\ the\ regular\ expression\ <b>%1</b>=%0 不包含正则表达式 <b>%1</b>
 
-%0_doesn't_contain_the_term_<b>%1</b>=%0_不包含词组_<b>%1</b>
+%0\ doesn't\ contain\ the\ term\ <b>%1</b>=%0 不包含词组 <b>%1</b>
 
-%0_export_successful=%0_导出成功
+%0\ export\ successful=%0 导出成功
 
-%0_matches_the_regular_expression_<b>%1</b>=%0_匹配正则表达式_<b>%1</b>
+%0\ matches\ the\ regular\ expression\ <b>%1</b>=%0 匹配正则表达式 <b>%1</b>
 
-%0_matches_the_term_<b>%1</b>=%0_匹配词组_<b>%1</b>
+%0\ matches\ the\ term\ <b>%1</b>=%0 匹配词组 <b>%1</b>
 
-<field_name>=<域名称>
-<HTML>Could_not_find_file_'%0'<BR>linked_from_entry_'%1'</HTML>=<HTML>无法找到记录'%1'链接的文件'%0'</HTML>
+<field\ name>=<域名称>
+<HTML>Could\ not\ find\ file\ '%0'<BR>linked\ from\ entry\ '%1'</HTML>=<HTML>无法找到记录'%1'链接的文件'%0'</HTML>
 
 <select>=<选择>
 
-<select_word>=<下拉菜单项>
-Abbreviate_journal_names_of_the_selected_entries_(ISO_abbreviation)=缩写选中记录的期刊名_(ISO_格式缩写)
-Abbreviate_journal_names_of_the_selected_entries_(MEDLINE_abbreviation)=缩写选中记录的期刊名_(MEDLINE_格式缩写)
+<select\ word>=<下拉菜单项>
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (ISO\ abbreviation)=缩写选中记录的期刊名 (ISO 格式缩写)
+Abbreviate\ journal\ names\ of\ the\ selected\ entries\ (MEDLINE\ abbreviation)=缩写选中记录的期刊名 (MEDLINE 格式缩写)
 
-Abbreviate_names=缩写名
-Abbreviated_%0_journal_names.=缩写的_%0_期刊名称。
+Abbreviate\ names=缩写名
+Abbreviated\ %0\ journal\ names.=缩写的 %0 期刊名称。
 
 Abbreviation=缩写
 
-About_JabRef=关于_JabRef
+About\ JabRef=关于 JabRef
 
 Abstract=摘要
 
 Accept=接受
 
-Accept_change=接受修改
+Accept\ change=接受修改
 
 Action=动作
 
-What_is_Mr._DLib?=
+What\ is\ Mr.\ DLib?=
 
 Add=添加
 
-Add_a_(compiled)_custom_Importer_class_from_a_class_path.=从一个_class_path_添加(编译好的)自定义导入类。
-The_path_need_not_be_on_the_classpath_of_JabRef.=该路径不需要在_JabRef_的_classpath_下。
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ class\ path.=从一个 class path 添加(编译好的)自定义导入类。
+The\ path\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=该路径不需要在 JabRef 的 classpath 下。
 
-Add_a_(compiled)_custom_Importer_class_from_a_ZIP-archive.=从一个_ZIP_压缩包中添加(编译好的)自定义导入类。
-The_ZIP-archive_need_not_be_on_the_classpath_of_JabRef.=该_ZIP_压缩包不需要在_JabRef_的_classpath_下。
+Add\ a\ (compiled)\ custom\ Importer\ class\ from\ a\ ZIP-archive.=从一个 ZIP 压缩包中添加(编译好的)自定义导入类。
+The\ ZIP-archive\ need\ not\ be\ on\ the\ classpath\ of\ JabRef.=该 ZIP 压缩包不需要在 JabRef 的 classpath 下。
 
-Add_a_regular_expression_for_the_key_pattern.=
+Add\ a\ regular\ expression\ for\ the\ key\ pattern.=
 
-Add_selected_entries_to_this_group=添加选定记录到该组
+Add\ selected\ entries\ to\ this\ group=添加选定记录到该组
 
-Add_from_folder=从文件夹中添加
+Add\ from\ folder=从文件夹中添加
 
-Add_from_JAR=从_JAR_中添加
+Add\ from\ JAR=从 JAR 中添加
 
-add_group=添加分组
+add\ group=添加分组
 
-Add_new=新建
+Add\ new=新建
 
-Add_subgroup=添加子分组
+Add\ subgroup=添加子分组
 
-Add_to_group=添加到分组
+Add\ to\ group=添加到分组
 
-Added_group_"%0".=已添加分组_"%0"。
+Added\ group\ "%0".=已添加分组 "%0"。
 
-Added_missing_braces.=
+Added\ missing\ braces.=
 
-Added_new=已添加
+Added\ new=已添加
 
-Added_string=已添加简写字串
+Added\ string=已添加简写字串
 
-Additionally,_entries_whose_<b>%0</b>_field_does_not_contain_<b>%1</b>_can_be_assigned_manually_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._This_process_adds_the_term_<b>%1</b>_to_each_entry's_<b>%0</b>_field._Entries_can_be_removed_manually_from_this_group_by_selecting_them_then_using_the_context_menu._This_process_removes_the_term_<b>%1</b>_from_each_entry's_<b>%0</b>_field.=此外，那些“<b>%0</b>”域里不包含“<b>%1</b>”的记录可以被手动添加到此分组（使用拖放或者右键菜单）——这个操作将会把词组“<b>%1</b>”添加到每条记录的“<b>%0</b>”域中。选中记录后用右键菜单可以将该记录从此分组中移除——这个操作将会把“<b>%1</b>”从被移除记录的“<b>%0</b>”域中去除。
+Additionally,\ entries\ whose\ <b>%0</b>\ field\ does\ not\ contain\ <b>%1</b>\ can\ be\ assigned\ manually\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ This\ process\ adds\ the\ term\ <b>%1</b>\ to\ each\ entry's\ <b>%0</b>\ field.\ Entries\ can\ be\ removed\ manually\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.\ This\ process\ removes\ the\ term\ <b>%1</b>\ from\ each\ entry's\ <b>%0</b>\ field.=此外，那些“<b>%0</b>”域里不包含“<b>%1</b>”的记录可以被手动添加到此分组（使用拖放或者右键菜单）——这个操作将会把词组“<b>%1</b>”添加到每条记录的“<b>%0</b>”域中。选中记录后用右键菜单可以将该记录从此分组中移除——这个操作将会把“<b>%1</b>”从被移除记录的“<b>%0</b>”域中去除。
 
 Advanced=高级
-All_entries=所有记录
-All_entries_of_this_type_will_be_declared_typeless._Continue?=所有此类型记录将被标记为无类型记录，是否继续？
+All\ entries=所有记录
+All\ entries\ of\ this\ type\ will\ be\ declared\ typeless.\ Continue?=所有此类型记录将被标记为无类型记录，是否继续？
 
-All_fields=所有域
+All\ fields=所有域
 
-Always_reformat_BIB_file_on_save_and_export=当保存和导出时重新格式化_BIB_文件
+Always\ reformat\ BIB\ file\ on\ save\ and\ export=当保存和导出时重新格式化 BIB 文件
 
-A_SAX_exception_occurred_while_parsing_'%0'\:=当解析'%0'时发生了一个_SAXException\:
+A\ SAX\ exception\ occurred\ while\ parsing\ '%0'\:=当解析'%0'时发生了一个 SAXException:
 
 and=和
-and_the_class_must_be_available_in_your_classpath_next_time_you_start_JabRef.=并且下次您启动_JabRef_的时候，请确保该类在您的_classpath_中。
+and\ the\ class\ must\ be\ available\ in\ your\ classpath\ next\ time\ you\ start\ JabRef.=并且下次您启动 JabRef 的时候，请确保该类在您的 classpath 中。
 
-any_field_that_matches_the_regular_expression_<b>%0</b>=匹配正则表达式_<b>%0</b>_的任何域
+any\ field\ that\ matches\ the\ regular\ expression\ <b>%0</b>=匹配正则表达式 <b>%0</b> 的任何域
 
 Appearance=外观
 
 Append=追加
-Append_contents_from_a_BibTeX_library_into_the_currently_viewed_library=从一个_BibTeX_文献库追加内容到当前查看的文献库
+Append\ contents\ from\ a\ BibTeX\ library\ into\ the\ currently\ viewed\ library=从一个 BibTeX 文献库追加内容到当前查看的文献库
 
-Append_library=追加文献库
+Append\ library=追加文献库
 
-Append_the_selected_text_to_BibTeX_field=追加选中的文本到_BibTeX_键值
+Append\ the\ selected\ text\ to\ BibTeX\ field=追加选中的文本到 BibTeX 键值
 Application=应用程序
 
 Apply=应用
 
-Arguments_passed_on_to_running_JabRef_instance._Shutting_down.=参数传递给了正在执行的_JabRef_实例，关闭自身程序。
+Arguments\ passed\ on\ to\ running\ JabRef\ instance.\ Shutting\ down.=参数传递给了正在执行的 JabRef 实例，关闭自身程序。
 
-Assign_new_file=分配新文件
+Assign\ new\ file=分配新文件
 
-Assign_the_original_group's_entries_to_this_group?=将原分组中的记录分配到此分组？
+Assign\ the\ original\ group's\ entries\ to\ this\ group?=将原分组中的记录分配到此分组？
 
-Assigned_%0_entries_to_group_"%1".=分配了_%0_条记录到分组_"%1".
+Assigned\ %0\ entries\ to\ group\ "%1".=分配了 %0 条记录到分组 "%1".
 
-Assigned_1_entry_to_group_"%0".=分配了_1_条记录到分组_"%0".
+Assigned\ 1\ entry\ to\ group\ "%0".=分配了 1 条记录到分组 "%0".
 
-Attach_URL=附加_URL
+Attach\ URL=附加 URL
 
-Attempt_to_automatically_set_file_links_for_your_entries._Automatically_setting_works_if_a_file_in_your_file_directory<BR>or_a_subdirectory_is_named_identically_to_an_entry's_BibTeX_key,_plus_extension.=尝试为您的记录自动设置_文件_链接，该操作要求和记录_BibTeX_键同名的_文件存在于您的_文件_目录或者子目录中。
+Attempt\ to\ automatically\ set\ file\ links\ for\ your\ entries.\ Automatically\ setting\ works\ if\ a\ file\ in\ your\ file\ directory<BR>or\ a\ subdirectory\ is\ named\ identically\ to\ an\ entry's\ BibTeX\ key,\ plus\ extension.=尝试为您的记录自动设置 文件 链接，该操作要求和记录 BibTeX 键同名的 文件存在于您的 文件 目录或者子目录中。
 
-Autodetect_format=自动检测格式
+Autodetect\ format=自动检测格式
 
-Autogenerate_BibTeX_keys=自动生成_BibTeX_键
+Autogenerate\ BibTeX\ keys=自动生成 BibTeX 键
 
-Autolink_files_with_names_starting_with_the_BibTeX_key=自动链接文件名以_BibTeX_键开头的文件
+Autolink\ files\ with\ names\ starting\ with\ the\ BibTeX\ key=自动链接文件名以 BibTeX 键开头的文件
 
-Autolink_only_files_that_match_the_BibTeX_key=自动链接文件名匹配_BibTeX_键的文件
+Autolink\ only\ files\ that\ match\ the\ BibTeX\ key=自动链接文件名匹配 BibTeX 键的文件
 
-Automatically_create_groups=自动创建分组
+Automatically\ create\ groups=自动创建分组
 
-Automatically_remove_exact_duplicates=自动移除完全重复的项
+Automatically\ remove\ exact\ duplicates=自动移除完全重复的项
 
-Allow_overwriting_existing_links.=允许覆盖已有的链接。
+Allow\ overwriting\ existing\ links.=允许覆盖已有的链接。
 
-Do_not_overwrite_existing_links.=不要覆盖已有的链接。
+Do\ not\ overwrite\ existing\ links.=不要覆盖已有的链接。
 
-AUX_file_import=AUX_文件导入
+AUX\ file\ import=AUX 文件导入
 
-Available_export_formats=可用的导出格式
+Available\ export\ formats=可用的导出格式
 
-Available_BibTeX_fields=可用的_BibTeX_域
+Available\ BibTeX\ fields=可用的 BibTeX 域
 
-Available_import_formats=可用的导入格式
+Available\ import\ formats=可用的导入格式
 
-Background_color_for_optional_fields=可选域的背景颜色
+Background\ color\ for\ optional\ fields=可选域的背景颜色
 
-Background_color_for_required_fields=必选域的背景颜色
+Background\ color\ for\ required\ fields=必选域的背景颜色
 
-Backup_old_file_when_saving=保存数据库时保留备份
+Backup\ old\ file\ when\ saving=保存数据库时保留备份
 
-BibTeX_key_is_unique.=BibTeX_键值是唯一的。
+BibTeX\ key\ is\ unique.=BibTeX 键值是唯一的。
 
-%0_source=%0_源代码
+%0\ source=%0 源代码
 
-Broken_link=失效链接
+Broken\ link=失效链接
 
 Browse=浏览...
 
@@ -160,321 +160,321 @@ by=为
 
 Cancel=取消
 
-Cannot_add_entries_to_group_without_generating_keys._Generate_keys_now?=不生成_BibTeX_键就无法添加记录到分组，现在生成键值？
+Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now?=不生成 BibTeX 键就无法添加记录到分组，现在生成键值？
 
-Cannot_merge_this_change=无法合并该更改
+Cannot\ merge\ this\ change=无法合并该更改
 
-case_insensitive=忽略大小写
+case\ insensitive=忽略大小写
 
-case_sensitive=区分大小写
+case\ sensitive=区分大小写
 
-Case_sensitive=区分大小写
+Case\ sensitive=区分大小写
 
-change_assignment_of_entries=修改记录的组分配
+change\ assignment\ of\ entries=修改记录的组分配
 
-Change_case=修改大小写
+Change\ case=修改大小写
 
-Change_entry_type=更改记录类型
-Change_file_type=更改文件类型
+Change\ entry\ type=更改记录类型
+Change\ file\ type=更改文件类型
 
 
-Change_of_Grouping_Method=分组方法改变
+Change\ of\ Grouping\ Method=分组方法改变
 
-change_preamble=修改导言区_(preamble)
+change\ preamble=修改导言区 (preamble)
 
-Change_table_column_and_General_fields_settings_to_use_the_new_feature=修改列外观和_General_域设置以使用新特性
+Change\ table\ column\ and\ General\ fields\ settings\ to\ use\ the\ new\ feature=修改列外观和 General 域设置以使用新特性
 
-Changed_language_settings=已修改语言设置
+Changed\ language\ settings=已修改语言设置
 
-Changed_preamble=已修改导言区_(preamble)
+Changed\ preamble=已修改导言区 (preamble)
 
-Check_existing_file_links=检查存在的文件链接
+Check\ existing\ file\ links=检查存在的文件链接
 
-Check_links=核对链接
+Check\ links=核对链接
 
-Cite_command=引用命令
+Cite\ command=引用命令
 
-Class_name=类名
+Class\ name=类名
 
 Clear=清除
 
-Clear_fields=清除域内容
+Clear\ fields=清除域内容
 
 Close=关闭
-Close_others=关闭其它
-Close_all=关闭所有
+Close\ others=关闭其它
+Close\ all=关闭所有
 
-Close_dialog=关闭对话框
+Close\ dialog=关闭对话框
 
-Close_the_current_library=关闭当前文献库
+Close\ the\ current\ library=关闭当前文献库
 
-Close_window=关闭窗口
+Close\ window=关闭窗口
 
-Closed_library=关闭文献库
+Closed\ library=关闭文献库
 
-Color_codes_for_required_and_optional_fields=列表记录项的可选域和必选域用不同颜色显示
+Color\ codes\ for\ required\ and\ optional\ fields=列表记录项的可选域和必选域用不同颜色显示
 
-Color_for_marking_incomplete_entries=标记不完整记录的颜色
+Color\ for\ marking\ incomplete\ entries=标记不完整记录的颜色
 
-Column_width=列宽
+Column\ width=列宽
 
-Command_line_id=命令行_id
+Command\ line\ id=命令行 id
 
 
-Contained_in=包含在
+Contained\ in=包含在
 
 Content=内容
 
 Copied=已复制
 
-Copied_cell_contents=已拷贝单元格内容
+Copied\ cell\ contents=已拷贝单元格内容
 
-Copied_title=已拷贝标题
+Copied\ title=已拷贝标题
 
-Copied_key=已复制_BibTeX_键
+Copied\ key=已复制 BibTeX 键
 
-Copied_titles=已拷贝标题
+Copied\ titles=已拷贝标题
 
-Copied_keys=已复制_BibTeX_键
+Copied\ keys=已复制 BibTeX 键
 
 Copy=复制
 
-Copy_BibTeX_key=复制_BibTeX_键
-Copy_file_to_file_directory=拷贝文件到文件目录。
+Copy\ BibTeX\ key=复制 BibTeX 键
+Copy\ file\ to\ file\ directory=拷贝文件到文件目录。
 
-Copy_to_clipboard=复制到剪贴板
+Copy\ to\ clipboard=复制到剪贴板
 
-Could_not_call_executable=无法调用可执行文件
-Could_not_connect_to_Vim_server._Make_sure_that_Vim_is_running<BR>with_correct_server_name.=无法连接到_Vim_服务器，请检查_Vim_是否以正确的_Vim_服务器名选项启动。
+Could\ not\ call\ executable=无法调用可执行文件
+Could\ not\ connect\ to\ Vim\ server.\ Make\ sure\ that\ Vim\ is\ running<BR>with\ correct\ server\ name.=无法连接到 Vim 服务器，请检查 Vim 是否以正确的 Vim 服务器名选项启动。
 
-Could_not_export_file=无法导出文件
+Could\ not\ export\ file=无法导出文件
 
-Could_not_export_preferences=无法导出首选项
+Could\ not\ export\ preferences=无法导出首选项
 
-Could_not_find_a_suitable_import_format.=无法找到符合的导入格式.
-Could_not_import_preferences=无法导入首选项
+Could\ not\ find\ a\ suitable\ import\ format.=无法找到符合的导入格式.
+Could\ not\ import\ preferences=无法导入首选项
 
-Could_not_instantiate_%0=无法例示_%0
-Could_not_instantiate_%0_%1=无法例示_%0_%1
-Could_not_instantiate_%0._Have_you_chosen_the_correct_package_path?=无法例示_%0，您选择了正确的包路径吗？
-Could_not_open_link=无法打开链接
+Could\ not\ instantiate\ %0=无法例示 %0
+Could\ not\ instantiate\ %0\ %1=无法例示 %0 %1
+Could\ not\ instantiate\ %0.\ Have\ you\ chosen\ the\ correct\ package\ path?=无法例示 %0，您选择了正确的包路径吗？
+Could\ not\ open\ link=无法打开链接
 
-Could_not_print_preview=无法打印预览
+Could\ not\ print\ preview=无法打印预览
 
-Could_not_run_the_'vim'_program.=无法运行_'vim'_程序。
+Could\ not\ run\ the\ 'vim'\ program.=无法运行 'vim' 程序。
 
-Could_not_save_file.=无法保存文件
-Character_encoding_'%0'_is_not_supported.=，不支持编码_'%0'。
+Could\ not\ save\ file.=无法保存文件
+Character\ encoding\ '%0'\ is\ not\ supported.=，不支持编码 '%0'。
 
-crossreferenced_entries_included=包含交叉引用的记录
+crossreferenced\ entries\ included=包含交叉引用的记录
 
-Current_content=当前内容
+Current\ content=当前内容
 
-Current_value=当前值
+Current\ value=当前值
 
-Custom_entry_types=自定义的记录类型
+Custom\ entry\ types=自定义的记录类型
 
-Custom_entry_types_found_in_file=文件中包含自定义的记录类型
+Custom\ entry\ types\ found\ in\ file=文件中包含自定义的记录类型
 
-Customize_entry_types=自定义记录类型
+Customize\ entry\ types=自定义记录类型
 
-Customize_key_bindings=自定义热键
+Customize\ key\ bindings=自定义热键
 
 Cut=剪切
 
-cut_entries=剪切记录
+cut\ entries=剪切记录
 
-cut_entry=剪切该记录
+cut\ entry=剪切该记录
 
 
-Library_encoding=文献库编码
+Library\ encoding=文献库编码
 
-Library_properties=文献库属性
+Library\ properties=文献库属性
 
-Library_type=文献库类型
+Library\ type=文献库类型
 
-Date_format=日期格式
+Date\ format=日期格式
 
 Default=默认
 
-Default_encoding=默认编码
+Default\ encoding=默认编码
 
-Default_grouping_field=默认分组依据域
+Default\ grouping\ field=默认分组依据域
 
-Default_look_and_feel=默认显示效果_(look_and_feel)
+Default\ look\ and\ feel=默认显示效果 (look and feel)
 
-Default_pattern=默认模式
+Default\ pattern=默认模式
 
-Default_sort_criteria=默认排序规则
-Define_'%0'=定义_'%0'
+Default\ sort\ criteria=默认排序规则
+Define\ '%0'=定义 '%0'
 
 Delete=删除
 
-Delete_custom_format=删除自定义格式
+Delete\ custom\ format=删除自定义格式
 
-delete_entries=删除记录
+delete\ entries=删除记录
 
-Delete_entry=删除该记录
+Delete\ entry=删除该记录
 
-delete_entry=删除该记录
+delete\ entry=删除该记录
 
-Delete_multiple_entries=删除多条记录
+Delete\ multiple\ entries=删除多条记录
 
-Delete_rows=删除行
+Delete\ rows=删除行
 
-Delete_strings=删除简写字串
+Delete\ strings=删除简写字串
 
 Deleted=已删除
 
-Permanently_delete_local_file=删除本地文件
+Permanently\ delete\ local\ file=删除本地文件
 
-Delimit_fields_with_semicolon,_ex.=使用分号分隔域，例如
+Delimit\ fields\ with\ semicolon,\ ex.=使用分号分隔域，例如
 
 Descending=降序
 
 Description=描述
 
-Deselect_all=取消所有选定
-Deselect_all_duplicates=检测所有重复项
+Deselect\ all=取消所有选定
+Deselect\ all\ duplicates=检测所有重复项
 
-Disable_this_confirmation_dialog=不再显示这个确认对话框
+Disable\ this\ confirmation\ dialog=不再显示这个确认对话框
 
-Display_all_entries_belonging_to_one_or_more_of_the_selected_groups.=显示属于选中任一分组的记录，即显示选中分组的并集。
+Display\ all\ entries\ belonging\ to\ one\ or\ more\ of\ the\ selected\ groups.=显示属于选中任一分组的记录，即显示选中分组的并集。
 
-Display_all_error_messages=显示所有错误消息
+Display\ all\ error\ messages=显示所有错误消息
 
-Display_help_on_command_line_options=用命令行选项显示帮助
+Display\ help\ on\ command\ line\ options=用命令行选项显示帮助
 
-Display_only_entries_belonging_to_all_selected_groups.=只显示属于所有选中分组的记录，即显示选中分组的交集。
-Display_version=显示版本
+Display\ only\ entries\ belonging\ to\ all\ selected\ groups.=只显示属于所有选中分组的记录，即显示选中分组的交集。
+Display\ version=显示版本
 
-Do_not_abbreviate_names=不要缩写姓名
+Do\ not\ abbreviate\ names=不要缩写姓名
 
-Do_not_automatically_set=不要自动设置
+Do\ not\ automatically\ set=不要自动设置
 
-Do_not_import_entry=不导入记录
+Do\ not\ import\ entry=不导入记录
 
-Do_not_open_any_files_at_startup=启动时不打开任何文件
+Do\ not\ open\ any\ files\ at\ startup=启动时不打开任何文件
 
-Do_not_overwrite_existing_keys=不覆盖已存在的_BibTeX_键
-Do_not_show_these_options_in_the_future=以后不要再显示这些选项
+Do\ not\ overwrite\ existing\ keys=不覆盖已存在的 BibTeX 键
+Do\ not\ show\ these\ options\ in\ the\ future=以后不要再显示这些选项
 
-Do_not_wrap_the_following_fields_when_saving=保存时不要对下列域添加换行符
-Do_not_write_the_following_fields_to_XMP_Metadata\:=不要将以下域写入_XMP_元数据\:
+Do\ not\ wrap\ the\ following\ fields\ when\ saving=保存时不要对下列域添加换行符
+Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=不要将以下域写入 XMP 元数据:
 
-Do_you_want_JabRef_to_do_the_following_operations?=您希望_JabRef_做以下操作吗？
+Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=您希望 JabRef 做以下操作吗？
 
-Donate_to_JabRef=捐款给_JabRef
+Donate\ to\ JabRef=捐款给 JabRef
 
 Down=下
 
-Download_file=下载文件
+Download\ file=下载文件
 
 Downloading...=下载中...
 
-Drop_%0=释放_%0
+Drop\ %0=释放 %0
 
-duplicate_removal=移除重复
+duplicate\ removal=移除重复
 
-Duplicate_string_name=重复的简写字串名称
+Duplicate\ string\ name=重复的简写字串名称
 
-Duplicates_found=发现重复项
+Duplicates\ found=发现重复项
 
-Dynamic_groups=动态分组
+Dynamic\ groups=动态分组
 
-Dynamically_group_entries_by_a_free-form_search_expression=使用自定义的搜索表达式创建动态分组
+Dynamically\ group\ entries\ by\ a\ free-form\ search\ expression=使用自定义的搜索表达式创建动态分组
 
-Dynamically_group_entries_by_searching_a_field_for_a_keyword=使用关键词搜索某域创建动态分组
+Dynamically\ group\ entries\ by\ searching\ a\ field\ for\ a\ keyword=使用关键词搜索某域创建动态分组
 
-Each_line_must_be_on_the_following_form=每一行必须使用以下形式
+Each\ line\ must\ be\ on\ the\ following\ form=每一行必须使用以下形式
 
 Edit=编辑
 
-Edit_custom_export=编辑自定义导出
-Edit_entry=编辑记录
-Save_file=编辑文件链接
-Edit_file_type=编辑文件类型
+Edit\ custom\ export=编辑自定义导出
+Edit\ entry=编辑记录
+Save\ file=编辑文件链接
+Edit\ file\ type=编辑文件类型
 
-Edit_group=编辑分组
+Edit\ group=编辑分组
 
 
-Edit_preamble=编辑导言区_(preamble)
-Edit_strings=编辑简写字串
-Editor_options=编辑器选项
+Edit\ preamble=编辑导言区 (preamble)
+Edit\ strings=编辑简写字串
+Editor\ options=编辑器选项
 
-Empty_BibTeX_key=空_BibTeX_键
+Empty\ BibTeX\ key=空 BibTeX 键
 
-Grouping_may_not_work_for_this_entry.=，该记录可能无法被分组。
+Grouping\ may\ not\ work\ for\ this\ entry.=，该记录可能无法被分组。
 
-empty_library=空文献库
-Enable_word/name_autocompletion=启用词组/姓名自动补全
+empty\ library=空文献库
+Enable\ word/name\ autocompletion=启用词组/姓名自动补全
 
-Enter_URL=输入_URL
+Enter\ URL=输入 URL
 
-Enter_URL_to_download=输入要下载的_URL
+Enter\ URL\ to\ download=输入要下载的 URL
 
 entries=记录
 
-Entries_cannot_be_manually_assigned_to_or_removed_from_this_group.=此分组中的记录无法进行手动分配。
+Entries\ cannot\ be\ manually\ assigned\ to\ or\ removed\ from\ this\ group.=此分组中的记录无法进行手动分配。
 
-Entries_exported_to_clipboard=记录被导出到剪贴板
+Entries\ exported\ to\ clipboard=记录被导出到剪贴板
 
 
 entry=记录
 
-Entry_editor=记录编辑器
+Entry\ editor=记录编辑器
 
-Entry_preview=预览记录
+Entry\ preview=预览记录
 
-Entry_table=记录列表
+Entry\ table=记录列表
 
-Entry_table_columns=记录列
+Entry\ table\ columns=记录列
 
-Entry_type=记录类型
+Entry\ type=记录类型
 
-Entry_type_names_are_not_allowed_to_contain_white_space_or_the_following_characters=记录类型名中不允许使用空格或者下列字符
+Entry\ type\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=记录类型名中不允许使用空格或者下列字符
 
-Entry_types=记录类型
+Entry\ types=记录类型
 
 Error=错误
-Error_exporting_to_clipboard=导出到剪贴板错误
+Error\ exporting\ to\ clipboard=导出到剪贴板错误
 
-Error_occurred_when_parsing_entry=分析记录时发生错误
+Error\ occurred\ when\ parsing\ entry=分析记录时发生错误
 
-Error_opening_file=打开文件错误
+Error\ opening\ file=打开文件错误
 
-Error_setting_field=设置域错误
+Error\ setting\ field=设置域错误
 
-Error_while_writing=写入错误
-Error_writing_to_%0_file(s).=写入到_%0_文件错误。
+Error\ while\ writing=写入错误
+Error\ writing\ to\ %0\ file(s).=写入到 %0 文件错误。
 
 
 
-'%0'_exists._Overwrite_file?='%0'_已存在，覆盖文件？
-Overwrite_file?=覆盖文件？
+'%0'\ exists.\ Overwrite\ file?='%0' 已存在，覆盖文件？
+Overwrite\ file?=覆盖文件？
 
 Export=导出
 
-Export_name=导出名称
+Export\ name=导出名称
 
-Export_preferences=导出首选项设置
+Export\ preferences=导出首选项设置
 
-Export_preferences_to_file=导出首选项设置到文件
+Export\ preferences\ to\ file=导出首选项设置到文件
 
-Export_properties=导出属性
+Export\ properties=导出属性
 
-Export_to_clipboard=导出到剪贴板
+Export\ to\ clipboard=导出到剪贴板
 
 Exporting=正在导出
 Extension=扩展名
 
-External_changes=外部修改
+External\ changes=外部修改
 
-External_file_links=外部文件链接
+External\ file\ links=外部文件链接
 
-External_programs=外部程序
+External\ programs=外部程序
 
-External_viewer_called=成功调用外部查看器
+External\ viewer\ called=成功调用外部查看器
 
 Fetch=抓取
 
@@ -482,210 +482,210 @@ Field=域
 
 field=域
 
-Field_name=域名称
-Field_names_are_not_allowed_to_contain_white_space_or_the_following_characters=域名中不可含有空格或以下字符
+Field\ name=域名称
+Field\ names\ are\ not\ allowed\ to\ contain\ white\ space\ or\ the\ following\ characters=域名中不可含有空格或以下字符
 
-Field_to_filter=要过滤的域
+Field\ to\ filter=要过滤的域
 
-Field_to_group_by=用来分组的域
+Field\ to\ group\ by=用来分组的域
 
 File=文件
 
 file=文件
-File_'%0'_is_already_open.=文件_'%0'_已经被打开。
+File\ '%0'\ is\ already\ open.=文件 '%0' 已经被打开。
 
-File_changed=文件已改变
-File_directory_is_'%0'\:=文件目录是_'%0'\:
+File\ changed=文件已改变
+File\ directory\ is\ '%0'\:=文件目录是 '%0':
 
-File_directory_is_not_set_or_does_not_exist\!=文件目录未设置或该目录不存在！
+File\ directory\ is\ not\ set\ or\ does\ not\ exist\!=文件目录未设置或该目录不存在！
 
-File_exists=文件已存在
+File\ exists=文件已存在
 
-File_has_been_updated_externally._What_do_you_want_to_do?=文件被外部程序修改，您要怎么做？
+File\ has\ been\ updated\ externally.\ What\ do\ you\ want\ to\ do?=文件被外部程序修改，您要怎么做？
 
-File_not_found=无法找到文件
-File_type=文件类型
+File\ not\ found=无法找到文件
+File\ type=文件类型
 
-File_updated_externally=文件被外部程序修改
+File\ updated\ externally=文件被外部程序修改
 
 filename=文件名
 
 Filename=文件名
 
-Files_opened=已打开文件
+Files\ opened=已打开文件
 
 Filter=过滤
 
-Filter_All=
+Filter\ All=
 
-Filter_None=
+Filter\ None=
 
-Finished_automatically_setting_external_links.=完成自动设置外部链接。
+Finished\ automatically\ setting\ external\ links.=完成自动设置外部链接。
 
-Finished_synchronizing_file_links._Entries_changed\:_%0.=完成同步文件条链接，记录改变\:_%0.
-Finished_writing_XMP-metadata._Wrote_to_%0_file(s).=完成写入_XMP-元数据，写入_%0_文件。
-Finished_writing_XMP_for_%0_file_(%1_skipped,_%2_errors).=完成写入_XMP-元数据到_%0_文件_(跳过_%1_条，%2_条错误).
+Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=完成同步文件条链接，记录改变: %0.
+Finished\ writing\ XMP-metadata.\ Wrote\ to\ %0\ file(s).=完成写入 XMP-元数据，写入 %0 文件。
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=完成写入 XMP-元数据到 %0 文件 (跳过 %1 条，%2 条错误).
 
-First_select_the_entries_you_want_keys_to_be_generated_for.=首先选中您要生成_BibTeX_键的记录。
+First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=首先选中您要生成 BibTeX 键的记录。
 
-Fit_table_horizontally_on_screen=列表宽度填满屏幕宽度
+Fit\ table\ horizontally\ on\ screen=列表宽度填满屏幕宽度
 
-Float=浮动_(结果上浮到最前)
-Float_marked_entries=浮动高亮显示的记录_(上浮到列表最前)
+Float=浮动 (结果上浮到最前)
+Float\ marked\ entries=浮动高亮显示的记录 (上浮到列表最前)
 
-Font_family=字体
+Font\ family=字体
 
-Font_preview=预览字体
+Font\ preview=预览字体
 
-Font_size=字号
+Font\ size=字号
 
-Font_style=字体
+Font\ style=字体
 
-Font_selection=字体下拉菜单项
+Font\ selection=字体下拉菜单项
 
 for=为
 
-Format_of_author_and_editor_names=作者和编者的姓名格式
-Format_string=格式化简写字串
+Format\ of\ author\ and\ editor\ names=作者和编者的姓名格式
+Format\ string=格式化简写字串
 
-Format_used=使用的格式
-Formatter_name=格式化器名称
+Format\ used=使用的格式
+Formatter\ name=格式化器名称
 
-found_in_AUX_file=在_AUX_发现
+found\ in\ AUX\ file=在 AUX 发现
 
-Full_name=全称
+Full\ name=全称
 
 General=基本设置
 
-General_fields=General_域
+General\ fields=General 域
 
 Generate=生成
 
-Generate_BibTeX_key=生成_BibTeX_键
+Generate\ BibTeX\ key=生成 BibTeX 键
 
-Generate_keys=生成键
+Generate\ keys=生成键
 
-Generate_keys_before_saving_(for_entries_without_a_key)=保存数据库前为缺失键值的记录自动生成_BibTeX_键
-Generate_keys_for_imported_entries=为导入的记录重新生成_BibTeX_键
+Generate\ keys\ before\ saving\ (for\ entries\ without\ a\ key)=保存数据库前为缺失键值的记录自动生成 BibTeX 键
+Generate\ keys\ for\ imported\ entries=为导入的记录重新生成 BibTeX 键
 
-Generate_now=现在生成
+Generate\ now=现在生成
 
-Generated_BibTeX_key_for=已生成_BibTeX_键——为
+Generated\ BibTeX\ key\ for=已生成 BibTeX 键——为
 
-Generating_BibTeX_key_for=正在生成_BibTeX_键——为
-Get_fulltext=获取全文
+Generating\ BibTeX\ key\ for=正在生成 BibTeX 键——为
+Get\ fulltext=获取全文
 
-Gray_out_non-hits=置灰未选中
+Gray\ out\ non-hits=置灰未选中
 
 Groups=分组
 
-Have_you_chosen_the_correct_package_path?=您选择了正确的包路径吗？
+Have\ you\ chosen\ the\ correct\ package\ path?=您选择了正确的包路径吗？
 
 Help=帮助
 
-Help_on_key_patterns=键表达式帮助
-Help_on_regular_expression_search=正则表达式搜索帮助
+Help\ on\ key\ patterns=键表达式帮助
+Help\ on\ regular\ expression\ search=正则表达式搜索帮助
 
-Hide_non-hits=隐藏未选中
+Hide\ non-hits=隐藏未选中
 
-Hierarchical_context=分级上下文
+Hierarchical\ context=分级上下文
 
 Highlight=高亮
 Marking=标记
 Underline=下划线
-Empty_Highlight=清除高亮
-Empty_Marking=清除标记
-Empty_Underline=清除下划线
-The_marked_area_does_not_contain_any_legible_text!=
+Empty\ Highlight=清除高亮
+Empty\ Marking=清除标记
+Empty\ Underline=清除下划线
+The\ marked\ area\ does\ not\ contain\ any\ legible\ text!=
 
-Hint\:_To_search_specific_fields_only,_enter_for_example\:<p><tt>author\=smith_and_title\=electrical</tt>=提示\:_若想只搜索特定域的话，可以像这样写\:<p><tt>author\=smith_and_title\=electrical</tt>
+Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=提示: 若想只搜索特定域的话，可以像这样写:<p><tt>author=smith and title=electrical</tt>
 
-HTML_table=HTML_表
-HTML_table_(with_Abstract_&_BibTeX)=HTML_表(包含摘要和_BibTeX)
+HTML\ table=HTML 表
+HTML\ table\ (with\ Abstract\ &\ BibTeX)=HTML 表(包含摘要和 BibTeX)
 Icon=图标
 
 Ignore=忽略
 
 Import=导入
 
-Import_and_keep_old_entry=导入且保存旧记录
+Import\ and\ keep\ old\ entry=导入且保存旧记录
 
-Import_and_remove_old_entry=导入且移除旧记录
+Import\ and\ remove\ old\ entry=导入且移除旧记录
 
-Import_entries=导入记录
+Import\ entries=导入记录
 
-Import_failed=导入失败
+Import\ failed=导入失败
 
-Import_file=导入文件
+Import\ file=导入文件
 
-Import_group_definitions=导入分组配置
+Import\ group\ definitions=导入分组配置
 
-Import_name=导入名称
+Import\ name=导入名称
 
-Import_preferences=导入首选项设置
+Import\ preferences=导入首选项设置
 
-Import_preferences_from_file=从文件中导入首选项设置
+Import\ preferences\ from\ file=从文件中导入首选项设置
 
-Import_strings=导入简写字串
+Import\ strings=导入简写字串
 
-Import_to_open_tab=导入到打开标签页
+Import\ to\ open\ tab=导入到打开标签页
 
-Import_word_selector_definitions=导入词组下拉菜单项
+Import\ word\ selector\ definitions=导入词组下拉菜单项
 
-Imported_entries=已导入记录
+Imported\ entries=已导入记录
 
-Imported_from_library=已从文献库导入
+Imported\ from\ library=已从文献库导入
 
-Importer_class=Importer_类
+Importer\ class=Importer 类
 
 Importing=正在导入
 
-Importing_in_unknown_format=以未知格式导入
+Importing\ in\ unknown\ format=以未知格式导入
 
-Include_abstracts=包含摘要
-Include_entries=包括的记录
+Include\ abstracts=包含摘要
+Include\ entries=包括的记录
 
-Include_subgroups\:_When_selected,_view_entries_contained_in_this_group_or_its_subgroups=包含子分组：当分组被选中时，显示所有它和它的子分组中的记录
+Include\ subgroups\:\ When\ selected,\ view\ entries\ contained\ in\ this\ group\ or\ its\ subgroups=包含子分组：当分组被选中时，显示所有它和它的子分组中的记录
 
-Independent_group\:_When_selected,_view_only_this_group's_entries=独立分组：当分组被选中时，只显示属于此分组的记录
+Independent\ group\:\ When\ selected,\ view\ only\ this\ group's\ entries=独立分组：当分组被选中时，只显示属于此分组的记录
 
-Work_options=工作选项
+Work\ options=工作选项
 
 Insert=插入
 
-Insert_rows=插入行
+Insert\ rows=插入行
 
 Intersection=交集
 
-Invalid_BibTeX_key=非法的_BibTeX_键值
+Invalid\ BibTeX\ key=非法的 BibTeX 键值
 
-Invalid_date_format=非法的日期格式
+Invalid\ date\ format=非法的日期格式
 
-Invalid_URL=非法的_URL
+Invalid\ URL=非法的 URL
 
-Online_help=在线帮助
+Online\ help=在线帮助
 
-JabRef_preferences=JabRef_首选项
+JabRef\ preferences=JabRef 首选项
 
 Join=
 
-Joins_selected_keywords_and_deletes_selected_keywords.=
+Joins\ selected\ keywords\ and\ deletes\ selected\ keywords.=
 
-Journal_abbreviations=期刊缩写名
+Journal\ abbreviations=期刊缩写名
 
 Keep=保留
 
-Keep_both=保留全部
+Keep\ both=保留全部
 
-Key_bindings=热键绑定
+Key\ bindings=热键绑定
 
-Key_bindings_changed=热键绑定已修改
+Key\ bindings\ changed=热键绑定已修改
 
-Key_generator_settings=键值生成器设置
+Key\ generator\ settings=键值生成器设置
 
-Key_pattern=键值表达式
+Key\ pattern=键值表达式
 
-keys_in_library=文献库中的键值
+keys\ in\ library=文献库中的键值
 
 Keyword=关键字
 
@@ -693,449 +693,449 @@ Label=标签
 
 Language=语言
 
-Last_modified=上次修改的
+Last\ modified=上次修改的
 
-LaTeX_AUX_file=LaTeX_AUX_文件
-Leave_file_in_its_current_directory=保留文件的当前位置不改变。
+LaTeX\ AUX\ file=LaTeX AUX 文件
+Leave\ file\ in\ its\ current\ directory=保留文件的当前位置不改变。
 
 Left=Left
 Level=级别
 
-Limit_to_fields=限制范围到域
+Limit\ to\ fields=限制范围到域
 
-Limit_to_selected_entries=限制范围为选中的记录
+Limit\ to\ selected\ entries=限制范围为选中的记录
 
 Link=链接
-Link_local_file=链接本地文件
-Link_to_file_%0=到文件_%0_的链接
+Link\ local\ file=链接本地文件
+Link\ to\ file\ %0=到文件 %0 的链接
 
-Listen_for_remote_operation_on_port=监听端口
-Load_and_Save_preferences_from/to_jabref.xml_on_start-up_(memory_stick_mode)=加载/保存首选项设置从/到_jabref.xml_文件(记忆棒模式)
+Listen\ for\ remote\ operation\ on\ port=监听端口
+Load\ and\ Save\ preferences\ from/to\ jabref.xml\ on\ start-up\ (memory\ stick\ mode)=加载/保存首选项设置从/到 jabref.xml 文件(记忆棒模式)
 
-Look_and_feel=显示效果_(look_and_feel)
-Main_file_directory=文件主目录
+Look\ and\ feel=显示效果 (look and feel)
+Main\ file\ directory=文件主目录
 
-Main_layout_file=主_layout_文件
+Main\ layout\ file=主 layout 文件
 
-Manage_custom_exports=管理自定义导出器
+Manage\ custom\ exports=管理自定义导出器
 
-Manage_custom_imports=管理自定义导入器
-Manage_external_file_types=管理外部文件类型
+Manage\ custom\ imports=管理自定义导入器
+Manage\ external\ file\ types=管理外部文件类型
 
-Mark_entries=高亮标记多条记录
+Mark\ entries=高亮标记多条记录
 
-Mark_entry=高亮标记该记录
+Mark\ entry=高亮标记该记录
 
-Mark_new_entries_with_addition_date=建立新记录时标记时间
+Mark\ new\ entries\ with\ addition\ date=建立新记录时标记时间
 
-Mark_new_entries_with_owner_name=建立新记录时标记所有者为
+Mark\ new\ entries\ with\ owner\ name=建立新记录时标记所有者为
 
-Memory_stick_mode=记忆棒模式
+Memory\ stick\ mode=记忆棒模式
 
-Menu_and_label_font_size=菜单和标签字号
+Menu\ and\ label\ font\ size=菜单和标签字号
 
-Merged_external_changes=合并外部修改
+Merged\ external\ changes=合并外部修改
 
 Messages=消息
 
-Modification_of_field=域的修改
+Modification\ of\ field=域的修改
 
-Modified_group_"%0".=已修改分组_"%0".
+Modified\ group\ "%0".=已修改分组 "%0".
 
-Modified_groups=已修改分组
+Modified\ groups=已修改分组
 
-Modified_string=已修改简写字串
+Modified\ string=已修改简写字串
 
 Modify=修改
 
-modify_group=修改分组
+modify\ group=修改分组
 
-Move_down=下移
+Move\ down=下移
 
-Move_external_links_to_'file'_field=移动外部链接到_'file'_域
+Move\ external\ links\ to\ 'file'\ field=移动外部链接到 'file' 域
 
-move_group=移动分组
+move\ group=移动分组
 
-Move_up=上移
+Move\ up=上移
 
-Moved_group_"%0".=移动了分组_"%0"。
+Moved\ group\ "%0".=移动了分组 "%0"。
 
 Name=名字
-Name_formatter=姓名格式化器
+Name\ formatter=姓名格式化器
 
-Natbib_style=Natbib_格式
+Natbib\ style=Natbib 格式
 
-nested_AUX_files=nested_AUX_文件
+nested\ AUX\ files=nested AUX 文件
 
 New=新建
 
 new=新建
 
-New_BibTeX_entry=新建_BibTeX_记录
+New\ BibTeX\ entry=新建 BibTeX 记录
 
-New_BibTeX_sublibrary=新建_BibTeX_子文献库
+New\ BibTeX\ sublibrary=新建 BibTeX 子文献库
 
-New_content=新内容
+New\ content=新内容
 
-New_library_created.=创建了新文献库。
-New_%0_library=新建_%0_文献库
-New_field_value=新的域内容
+New\ library\ created.=创建了新文献库。
+New\ %0\ library=新建 %0 文献库
+New\ field\ value=新的域内容
 
-New_group=新建分组
+New\ group=新建分组
 
-New_string=新建简写字串
+New\ string=新建简写字串
 
-Next_entry=下一条
+Next\ entry=下一条
 
-No_actual_changes_found.=没有实际的修改。
+No\ actual\ changes\ found.=没有实际的修改。
 
-no_base-BibTeX-file_specified=没有指定_base-BibTeX-文件
+no\ base-BibTeX-file\ specified=没有指定 base-BibTeX-文件
 
-no_library_generated=没有生成文献库
+no\ library\ generated=没有生成文献库
 
-No_entries_found._Please_make_sure_you_are_using_the_correct_import_filter.=没有找到记录，请检查是否使用了正确的导入过滤器。
+No\ entries\ found.\ Please\ make\ sure\ you\ are\ using\ the\ correct\ import\ filter.=没有找到记录，请检查是否使用了正确的导入过滤器。
 
 
-No_entries_found_for_the_search_string_'%0'=没有找到符合查询字符串_'%0'_的记录
+No\ entries\ found\ for\ the\ search\ string\ '%0'=没有找到符合查询字符串 '%0' 的记录
 
-No_entries_imported.=没有导入记录。
+No\ entries\ imported.=没有导入记录。
 
-No_files_found.=没有找到文件。
+No\ files\ found.=没有找到文件。
 
-No_GUI._Only_process_command_line_options.=没有_GUI，只处理命令行选项。
+No\ GUI.\ Only\ process\ command\ line\ options.=没有 GUI，只处理命令行选项。
 
-No_journal_names_could_be_abbreviated.=没有可供缩写的期刊全称。
+No\ journal\ names\ could\ be\ abbreviated.=没有可供缩写的期刊全称。
 
-No_journal_names_could_be_unabbreviated.=没有可供展开的期刊名缩写。
-No_PDF_linked=没有_PDF_链接
+No\ journal\ names\ could\ be\ unabbreviated.=没有可供展开的期刊名缩写。
+No\ PDF\ linked=没有 PDF 链接
 
-Open_PDF=打开_PDF
+Open\ PDF=打开 PDF
 
-No_URL_defined=没有定义_url
+No\ URL\ defined=没有定义 url
 not=非
 
-not_found=无法找到
+not\ found=无法找到
 
-Note_that_you_must_specify_the_fully_qualified_class_name_for_the_look_and_feel,=注意：您必须为显示效果_(look_and_feel)_明确指定完整的经过验证的类名称，
+Note\ that\ you\ must\ specify\ the\ fully\ qualified\ class\ name\ for\ the\ look\ and\ feel,=注意：您必须为显示效果 (look and feel) 明确指定完整的经过验证的类名称，
 
-Nothing_to_redo=无可重做
+Nothing\ to\ redo=无可重做
 
-Nothing_to_undo=无可撤销
+Nothing\ to\ undo=无可撤销
 
 occurrences=次
 
 OK=确定
-One_or_more_file_links_are_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=一个或多个文件链接是未定义的文件类型_'%0'，您希望怎么做？
+One\ or\ more\ file\ links\ are\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=一个或多个文件链接是未定义的文件类型 '%0'，您希望怎么做？
 
-One_or_more_keys_will_be_overwritten._Continue?=一个或多个_BibTeX_键将会被覆盖，是否继续？
+One\ or\ more\ keys\ will\ be\ overwritten.\ Continue?=一个或多个 BibTeX 键将会被覆盖，是否继续？
 
 
 Open=打开
 
-Open_BibTeX_library=打开_BibTeX_文献库
+Open\ BibTeX\ library=打开 BibTeX 文献库
 
-Open_library=打开文献库
+Open\ library=打开文献库
 
-Open_editor_when_a_new_entry_is_created=创建新记录时打开记录编辑器
+Open\ editor\ when\ a\ new\ entry\ is\ created=创建新记录时打开记录编辑器
 
-Open_file=打开文件
+Open\ file=打开文件
 
-Open_last_edited_libraries_at_startup=启动_JabRef_时打开上次使用的数据库
+Open\ last\ edited\ libraries\ at\ startup=启动 JabRef 时打开上次使用的数据库
 
-Connect_to_shared_database=连接到共享数据库
+Connect\ to\ shared\ database=连接到共享数据库
 
-Open_terminal_here=在此处打开终端
+Open\ terminal\ here=在此处打开终端
 
-Open_URL_or_DOI=打开_URL_或_DOI
+Open\ URL\ or\ DOI=打开 URL 或 DOI
 
-Opened_library=已打开文献库
+Opened\ library=已打开文献库
 
 Opening=正在打开
 
-Opening_preferences...=正在打开首选项...
+Opening\ preferences...=正在打开首选项...
 
-Operation_canceled.=操作被取消
-Operation_not_supported=不支持的操作
+Operation\ canceled.=操作被取消
+Operation\ not\ supported=不支持的操作
 
-Optional_fields=可选域
+Optional\ fields=可选域
 
 Options=选项
 
 or=或
 
-Output_or_export_file=输出或导出文件
+Output\ or\ export\ file=输出或导出文件
 
 Override=跳过
 
-Override_default_file_directories=跳过默认文件目录
+Override\ default\ file\ directories=跳过默认文件目录
 
-Override_default_font_settings=跳过默认字体设置
+Override\ default\ font\ settings=跳过默认字体设置
 
-Override_the_BibTeX_field_by_the_selected_text=使用选中文字覆盖_BibTeX_键值
+Override\ the\ BibTeX\ field\ by\ the\ selected\ text=使用选中文字覆盖 BibTeX 键值
 
 
 Overwrite=覆盖
-Overwrite_existing_field_values=覆盖原有域内容
+Overwrite\ existing\ field\ values=覆盖原有域内容
 
-Overwrite_keys=覆盖键值
+Overwrite\ keys=覆盖键值
 
-pairs_processed=已处理记录对
+pairs\ processed=已处理记录对
 Password=口令
 
 Paste=粘贴
 
-paste_entries=粘贴多条记录
+paste\ entries=粘贴多条记录
 
-paste_entry=粘贴记录
-Paste_from_clipboard=从剪贴板粘贴
+paste\ entry=粘贴记录
+Paste\ from\ clipboard=从剪贴板粘贴
 
 Pasted=完成粘贴
 
-Path_to_%0_not_defined=到_%0_的路径未定义
+Path\ to\ %0\ not\ defined=到 %0 的路径未定义
 
-Path_to_LyX_pipe=到_LyX_管道的路径
+Path\ to\ LyX\ pipe=到 LyX 管道的路径
 
-PDF_does_not_exist=PDF_不存在
+PDF\ does\ not\ exist=PDF 不存在
 
-File_has_no_attached_annotations=
+File\ has\ no\ attached\ annotations=
 
-Plain_text_import=纯文本导入
+Plain\ text\ import=纯文本导入
 
-Please_enter_a_name_for_the_group.=请为该分组输入一个名字
+Please\ enter\ a\ name\ for\ the\ group.=请为该分组输入一个名字
 
-Please_enter_a_search_term._For_example,_to_search_all_fields_for_<b>Smith</b>,_enter\:<p><tt>smith</tt><p>To_search_the_field_<b>Author</b>_for_<b>Smith</b>_and_the_field_<b>Title</b>_for_<b>electrical</b>,_enter\:<p><tt>author\=smith_and_title\=electrical</tt>=请输入一个搜索词组。例如，要在所有域中搜索_<b>Smith</b>，就输入\:<p><tt>smith</tt><p>要在_<b>Author</b>_域中搜索_<b>Smith</b>_并且_<b>Title</b>_域中搜索_<b>electrical</b>,_输入\:<p><tt>author\=smith_and_title\=electrical</tt>
+Please\ enter\ a\ search\ term.\ For\ example,\ to\ search\ all\ fields\ for\ <b>Smith</b>,\ enter\:<p><tt>smith</tt><p>To\ search\ the\ field\ <b>Author</b>\ for\ <b>Smith</b>\ and\ the\ field\ <b>Title</b>\ for\ <b>electrical</b>,\ enter\:<p><tt>author\=smith\ and\ title\=electrical</tt>=请输入一个搜索词组。例如，要在所有域中搜索 <b>Smith</b>，就输入:<p><tt>smith</tt><p>要在 <b>Author</b> 域中搜索 <b>Smith</b> 并且 <b>Title</b> 域中搜索 <b>electrical</b>, 输入:<p><tt>author=smith and title=electrical</tt>
 
-Please_enter_the_field_to_search_(e.g._<b>keywords</b>)_and_the_keyword_to_search_it_for_(e.g._<b>electrical</b>).=请输入要搜索的域(例如：_<b>keywords</b>)和要搜索的关键词(例如：_<b>electrical</b>)。
+Please\ enter\ the\ field\ to\ search\ (e.g.\ <b>keywords</b>)\ and\ the\ keyword\ to\ search\ it\ for\ (e.g.\ <b>electrical</b>).=请输入要搜索的域(例如： <b>keywords</b>)和要搜索的关键词(例如： <b>electrical</b>)。
 
-Please_enter_the_string's_label=请输入简写字串的标签
+Please\ enter\ the\ string's\ label=请输入简写字串的标签
 
-Please_select_an_importer.=请选择一个导入器。
+Please\ select\ an\ importer.=请选择一个导入器。
 
-Possible_duplicate_entries=可能的重复记录
+Possible\ duplicate\ entries=可能的重复记录
 
-Possible_duplicate_of_existing_entry._Click_to_resolve.=可能与已存在记录重复，点击以解决此问题。
+Possible\ duplicate\ of\ existing\ entry.\ Click\ to\ resolve.=可能与已存在记录重复，点击以解决此问题。
 
-Preamble=导言区_(Preamble)
+Preamble=导言区 (Preamble)
 
 Preferences=首选项
 
-Preferences_recorded.=首选项被记录。
+Preferences\ recorded.=首选项被记录。
 
 Preview=预览
-Citation_Style=引用样式
-Current_Preview=当前预览
-Cannot_generate_preview_based_on_selected_citation_style.=无法为选中的引用样式生成预览.
-Bad_character_inside_entry=记录是包含非法字符
-Error_while_generating_citation_style=生成引用样式时出错
-Preview_style_changed_to\:_%0=预览样式更改为\:_%0
-Next_preview_layout=下一条预览布局
-Previous_preview_layout=上一条预览布局
+Citation\ Style=引用样式
+Current\ Preview=当前预览
+Cannot\ generate\ preview\ based\ on\ selected\ citation\ style.=无法为选中的引用样式生成预览.
+Bad\ character\ inside\ entry=记录是包含非法字符
+Error\ while\ generating\ citation\ style=生成引用样式时出错
+Preview\ style\ changed\ to\:\ %0=预览样式更改为: %0
+Next\ preview\ layout=下一条预览布局
+Previous\ preview\ layout=上一条预览布局
 
-Previous_entry=上一条
+Previous\ entry=上一条
 
-Primary_sort_criterion=排序依据
-Problem_with_parsing_entry=解析记录时的问题
-Processing_%0=正在处理_%0
-Pull_changes_from_shared_database=从共享数据库中更新
+Primary\ sort\ criterion=排序依据
+Problem\ with\ parsing\ entry=解析记录时的问题
+Processing\ %0=正在处理 %0
+Pull\ changes\ from\ shared\ database=从共享数据库中更新
 
-Pushed_citations_to_%0=已推送文献引用到_%0
+Pushed\ citations\ to\ %0=已推送文献引用到 %0
 
-Quit_JabRef=退出_JabRef
+Quit\ JabRef=退出 JabRef
 
-Quit_synchronization=退出同步
+Quit\ synchronization=退出同步
 
-Raw_source=原始源数据
+Raw\ source=原始源数据
 
-Rearrange_tabs_alphabetically_by_title=对标签页以标题按字母表排序
+Rearrange\ tabs\ alphabetically\ by\ title=对标签页以标题按字母表排序
 
 Redo=重做
 
-Reference_library=参考文献文献库
+Reference\ library=参考文献文献库
 
-%0_references_found._Number_of_references_to_fetch?=找到参考文献\:_%0。_要抓取的引用数？
+%0\ references\ found.\ Number\ of\ references\ to\ fetch?=找到参考文献: %0。 要抓取的引用数？
 
-Refine_supergroup\:_When_selected,_view_entries_contained_in_both_this_group_and_its_supergroup=提炼父分组：当分组被选中时，显示同时包含在该分组和它父分组中的记录
+Refine\ supergroup\:\ When\ selected,\ view\ entries\ contained\ in\ both\ this\ group\ and\ its\ supergroup=提炼父分组：当分组被选中时，显示同时包含在该分组和它父分组中的记录
 
-regular_expression=正则表达式
+regular\ expression=正则表达式
 
-Related_articles=相关文章
+Related\ articles=相关文章
 
-Remote_operation=远程操作
+Remote\ operation=远程操作
 
-Remote_server_port=远程服务器端口
+Remote\ server\ port=远程服务器端口
 
 Remove=移除
 
-Remove_subgroups=移除子分组
+Remove\ subgroups=移除子分组
 
-Remove_all_subgroups_of_"%0"?=移除_"%0"_的所有子分组？
+Remove\ all\ subgroups\ of\ "%0"?=移除 "%0" 的所有子分组？
 
-Remove_entry_from_import=从导入中移除记录
+Remove\ entry\ from\ import=从导入中移除记录
 
-Remove_selected_entries_from_this_group=从这个组里移除选定记录
+Remove\ selected\ entries\ from\ this\ group=从这个组里移除选定记录
 
-Remove_entry_type=移除记录类型
+Remove\ entry\ type=移除记录类型
 
-Remove_from_group=从分组中移除
+Remove\ from\ group=从分组中移除
 
-Remove_group=移除分组
+Remove\ group=移除分组
 
-Remove_group,_keep_subgroups=移除分组，保留子分组
+Remove\ group,\ keep\ subgroups=移除分组，保留子分组
 
-Remove_group_"%0"?=移除分组_"%0"?
+Remove\ group\ "%0"?=移除分组 "%0"?
 
-Remove_group_"%0"_and_its_subgroups?=移除分组_"%0"_和它的子分组？
+Remove\ group\ "%0"\ and\ its\ subgroups?=移除分组 "%0" 和它的子分组？
 
-remove_group_(keep_subgroups)=移除分组(保留子分组)
+remove\ group\ (keep\ subgroups)=移除分组(保留子分组)
 
-remove_group_and_subgroups=移除分组和子分组
+remove\ group\ and\ subgroups=移除分组和子分组
 
-Remove_group_and_subgroups=移除分组和子分组
+Remove\ group\ and\ subgroups=移除分组和子分组
 
-Remove_link=移除链接
+Remove\ link=移除链接
 
-Remove_old_entry=移除旧记录
+Remove\ old\ entry=移除旧记录
 
-Remove_selected_strings=移除选中的简写字串
+Remove\ selected\ strings=移除选中的简写字串
 
-Removed_group_"%0".=已移除分组_"%0"。
+Removed\ group\ "%0".=已移除分组 "%0"。
 
-Removed_group_"%0"_and_its_subgroups.=已移除分组_"%0"_和它的子分组。
+Removed\ group\ "%0"\ and\ its\ subgroups.=已移除分组 "%0" 和它的子分组。
 
-Removed_string=已移除简写字串
+Removed\ string=已移除简写字串
 
-Renamed_string=重命名简写字串
+Renamed\ string=重命名简写字串
 
 Replace=
 
-Replace_(regular_expression)=替换_(正则表达式)
+Replace\ (regular\ expression)=替换 (正则表达式)
 
-Replace_string=替换字符串
+Replace\ string=替换字符串
 
-Replace_with=替换为
+Replace\ with=替换为
 
 Replaced=被替换
 
-Required_fields=必选域
+Required\ fields=必选域
 
-Reset_all=重置所有
+Reset\ all=重置所有
 
-Resolve_strings_for_all_fields_except=处理所有域的简写字串，除了
-Resolve_strings_for_standard_BibTeX_fields_only=只处理标准_BibTeX_域的简写字串
+Resolve\ strings\ for\ all\ fields\ except=处理所有域的简写字串，除了
+Resolve\ strings\ for\ standard\ BibTeX\ fields\ only=只处理标准 BibTeX 域的简写字串
 
 resolved=已解决
 
 Review=评论
 
-Review_changes=复查修改
+Review\ changes=复查修改
 
 Right=右
 
 Save=保存
-Save_all_finished.=完成保存全部。
+Save\ all\ finished.=完成保存全部。
 
-Save_all_open_libraries=保存所有打开的数据库
+Save\ all\ open\ libraries=保存所有打开的数据库
 
-Save_before_closing=关闭前保存
+Save\ before\ closing=关闭前保存
 
-Save_library=保存文献库
-Save_library_as...=保存文献库为_...
+Save\ library=保存文献库
+Save\ library\ as...=保存文献库为 ...
 
-Save_entries_in_their_original_order=以原始顺序保存记录
+Save\ entries\ in\ their\ original\ order=以原始顺序保存记录
 
-Save_failed=保存失败
+Save\ failed=保存失败
 
-Save_failed_during_backup_creation=保存失败，无法创建备份
+Save\ failed\ during\ backup\ creation=保存失败，无法创建备份
 
-Save_selected_as...=选中记录另存为...
+Save\ selected\ as...=选中记录另存为...
 
-Saved_library=已保存文献库
+Saved\ library=已保存文献库
 
-Saved_selected_to_'%0'.=保存选中到_'%0'.
+Saved\ selected\ to\ '%0'.=保存选中到 '%0'.
 
 Saving=保存中
-Saving_all_libraries...=正在保存所有数据库...
+Saving\ all\ libraries...=正在保存所有数据库...
 
-Saving_library=正在保存文献库
+Saving\ library=正在保存文献库
 
 Search=查找
 
-Search_expression=查找表达式
+Search\ expression=查找表达式
 
-Search_for=查找
+Search\ for=查找
 
-Searching_for_duplicates...=正在查找重复记录...
+Searching\ for\ duplicates...=正在查找重复记录...
 
-Searching_for_files=正在查找文件
+Searching\ for\ files=正在查找文件
 
-Secondary_sort_criterion=次要依据
+Secondary\ sort\ criterion=次要依据
 
-Select_all=全选
+Select\ all=全选
 
-Select_encoding=选择编码
+Select\ encoding=选择编码
 
-Select_entry_type=选择记录类型
-Select_external_application=选择外部程序
+Select\ entry\ type=选择记录类型
+Select\ external\ application=选择外部程序
 
-Select_file_from_ZIP-archive=从_ZIP-压缩包中选择文件
+Select\ file\ from\ ZIP-archive=从 ZIP-压缩包中选择文件
 
-Select_the_tree_nodes_to_view_and_accept_or_reject_changes=选择树节点查看和接受/拒绝修改
-Selected_entries=选中的记录
-Set_field=设置域内容
-Set_fields=设置域内容
+Select\ the\ tree\ nodes\ to\ view\ and\ accept\ or\ reject\ changes=选择树节点查看和接受/拒绝修改
+Selected\ entries=选中的记录
+Set\ field=设置域内容
+Set\ fields=设置域内容
 
-Set_general_fields=设置_general_域
-Set_main_external_file_directory=设置外部文件的主目录
+Set\ general\ fields=设置 general 域
+Set\ main\ external\ file\ directory=设置外部文件的主目录
 
-Set_table_font=设置表格字体
+Set\ table\ font=设置表格字体
 
 Settings=设置
 
 Shortcut=快捷键
 
-Show/edit_%0_source=显示/编辑_%0_源代码
+Show/edit\ %0\ source=显示/编辑 %0 源代码
 
-Show_'Firstname_Lastname'=显示_'名_(Firstname)_姓_(Lastname)'
+Show\ 'Firstname\ Lastname'=显示 '名 (Firstname) 姓 (Lastname)'
 
-Show_'Lastname,_Firstname'=显示_'姓_(Lastname),_名_(Firstname)'
+Show\ 'Lastname,\ Firstname'=显示 '姓 (Lastname), 名 (Firstname)'
 
-Show_BibTeX_source_by_default=缺省显示_BibTeX_源代码
+Show\ BibTeX\ source\ by\ default=缺省显示 BibTeX 源代码
 
-Show_confirmation_dialog_when_deleting_entries=删除多条记录时发出警告
+Show\ confirmation\ dialog\ when\ deleting\ entries=删除多条记录时发出警告
 
-Show_description=显示描述
+Show\ description=显示描述
 
-Show_file_column=显示“文件”列
+Show\ file\ column=显示“文件”列
 
-Show_last_names_only=只显示“姓_(Lastname)”
+Show\ last\ names\ only=只显示“姓 (Lastname)”
 
-Show_names_unchanged=显示原始姓名字串
+Show\ names\ unchanged=显示原始姓名字串
 
-Show_optional_fields=显示可选域
+Show\ optional\ fields=显示可选域
 
-Show_required_fields=显示必选域
+Show\ required\ fields=显示必选域
 
-Show_URL/DOI_column=显示_URL/DOI_列
+Show\ URL/DOI\ column=显示 URL/DOI 列
 
-Simple_HTML=简单_HTML
+Simple\ HTML=简单 HTML
 
 Size=大小
 
-Skipped_-_No_PDF_linked=跳过-没有_PDF_链接
-Skipped_-_PDF_does_not_exist=跳过-PDF_不存在
+Skipped\ -\ No\ PDF\ linked=跳过-没有 PDF 链接
+Skipped\ -\ PDF\ does\ not\ exist=跳过-PDF 不存在
 
-Skipped_entry.=已跳过记录
+Skipped\ entry.=已跳过记录
 
-Some_appearance_settings_you_changed_require_to_restart_JabRef_to_come_into_effect.=
+Some\ appearance\ settings\ you\ changed\ require\ to\ restart\ JabRef\ to\ come\ into\ effect.=
 
-source_edit=源代码编辑
-Special_name_formatters=特殊的姓名格式化器
+source\ edit=源代码编辑
+Special\ name\ formatters=特殊的姓名格式化器
 
-Special_table_columns=特殊列
+Special\ table\ columns=特殊列
 
-Starting_import=开始导入
+Starting\ import=开始导入
 
-Statically_group_entries_by_manual_assignment=手动创建静态分组
+Statically\ group\ entries\ by\ manual\ assignment=手动创建静态分组
 
 Status=状态
 
@@ -1143,1019 +1143,1019 @@ Stop=停止
 
 Strings=简写字串
 
-Strings_for_library=简写字串列表——文献库
+Strings\ for\ library=简写字串列表——文献库
 
-Sublibrary_from_AUX=从_AUX_文件生成的子文献库
+Sublibrary\ from\ AUX=从 AUX 文件生成的子文献库
 
-Switches_between_full_and_abbreviated_journal_name_if_the_journal_name_is_known.=在已知的期刊名简写和全称之间切换。
+Switches\ between\ full\ and\ abbreviated\ journal\ name\ if\ the\ journal\ name\ is\ known.=在已知的期刊名简写和全称之间切换。
 
-Synchronize_file_links=同步文件链接
+Synchronize\ file\ links=同步文件链接
 
-Synchronizing_file_links...=正在同步文件链接...
+Synchronizing\ file\ links...=正在同步文件链接...
 
-Table_appearance=列表外观
+Table\ appearance=列表外观
 
-Table_background_color=列表背景颜色
+Table\ background\ color=列表背景颜色
 
-Table_grid_color=列表网格颜色
+Table\ grid\ color=列表网格颜色
 
-Table_text_color=列表文字颜色
+Table\ text\ color=列表文字颜色
 
 Tabname=标签页名
-Target_file_cannot_be_a_directory.=目标文件不可为目录。
+Target\ file\ cannot\ be\ a\ directory.=目标文件不可为目录。
 
-Tertiary_sort_criterion=次要依据
+Tertiary\ sort\ criterion=次要依据
 
 Test=测试
 
-paste_text_here=此处编辑文本
+paste\ text\ here=此处编辑文本
 
-The_chosen_date_format_for_new_entries_is_not_valid=为新记录选择的日期格式非法
+The\ chosen\ date\ format\ for\ new\ entries\ is\ not\ valid=为新记录选择的日期格式非法
 
-The_chosen_encoding_'%0'_could_not_encode_the_following_characters\:=选择的编码_'%0'_无法支持下列字符\:
+The\ chosen\ encoding\ '%0'\ could\ not\ encode\ the\ following\ characters\:=选择的编码 '%0' 无法支持下列字符:
 
 
-the_field_<b>%0</b>=域_<b>%0</b>
+the\ field\ <b>%0</b>=域 <b>%0</b>
 
-The_file<BR>'%0'<BR>has_been_modified<BR>externally\!=文件<BR>'%0'<BR>已经被外部程序修改！
+The\ file<BR>'%0'<BR>has\ been\ modified<BR>externally\!=文件<BR>'%0'<BR>已经被外部程序修改！
 
-The_group_"%0"_already_contains_the_selection.=分组_"%0"_中已经包含选中的项。
+The\ group\ "%0"\ already\ contains\ the\ selection.=分组 "%0" 中已经包含选中的项。
 
-The_label_of_the_string_cannot_be_a_number.=该简写字串的_label_不可以为数字。
+The\ label\ of\ the\ string\ cannot\ be\ a\ number.=该简写字串的 label 不可以为数字。
 
-The_label_of_the_string_cannot_contain_spaces.=该简写字串的_label_不可以包含空格。
+The\ label\ of\ the\ string\ cannot\ contain\ spaces.=该简写字串的 label 不可以包含空格。
 
-The_label_of_the_string_cannot_contain_the_'\#'_character.=该简写字串的_label_不可以包含_'\#'_字符。
+The\ label\ of\ the\ string\ cannot\ contain\ the\ '\#'\ character.=该简写字串的 label 不可以包含 '#' 字符。
 
-The_output_option_depends_on_a_valid_import_option.=输出选项依赖于一个合法的导入选项。
-The_PDF_contains_one_or_several_BibTeX-records.=该_PDF_包含一个或多个_BibTeX_记录，
-Do_you_want_to_import_these_as_new_entries_into_the_current_library?=您希望导入这些记录到当前文献库中吗？
+The\ output\ option\ depends\ on\ a\ valid\ import\ option.=输出选项依赖于一个合法的导入选项。
+The\ PDF\ contains\ one\ or\ several\ BibTeX-records.=该 PDF 包含一个或多个 BibTeX 记录，
+Do\ you\ want\ to\ import\ these\ as\ new\ entries\ into\ the\ current\ library?=您希望导入这些记录到当前文献库中吗？
 
-The_regular_expression_<b>%0</b>_is_invalid\:=正则表达式_<b>%0</b>_是非法的\:
+The\ regular\ expression\ <b>%0</b>\ is\ invalid\:=正则表达式 <b>%0</b> 是非法的:
 
-The_search_is_case_insensitive.=该查询是不区分大小写的。
+The\ search\ is\ case\ insensitive.=该查询是不区分大小写的。
 
-The_search_is_case_sensitive.=该查询是区分大小写的。
+The\ search\ is\ case\ sensitive.=该查询是区分大小写的。
 
-The_string_has_been_removed_locally=简写字串被本地移除
+The\ string\ has\ been\ removed\ locally=简写字串被本地移除
 
-There_are_possible_duplicates_(marked_with_an_icon)_that_haven't_been_resolved._Continue?=存在可能仍未解决的重复项(以'D'图标标记)，是否继续？
+There\ are\ possible\ duplicates\ (marked\ with\ an\ icon)\ that\ haven't\ been\ resolved.\ Continue?=存在可能仍未解决的重复项(以'D'图标标记)，是否继续？
 
-This_entry_has_no_BibTeX_key._Generate_key_now?=此记录没有_BibTeX_键，现在生成它？
+This\ entry\ has\ no\ BibTeX\ key.\ Generate\ key\ now?=此记录没有 BibTeX 键，现在生成它？
 
-This_entry_is_incomplete=该记录是不完整的
+This\ entry\ is\ incomplete=该记录是不完整的
 
-This_entry_type_cannot_be_removed.=该记录类型无法被移除。
+This\ entry\ type\ cannot\ be\ removed.=该记录类型无法被移除。
 
-This_external_link_is_of_the_type_'%0',_which_is_undefined._What_do_you_want_to_do?=此外部链接类型_'%0'_未定义，您想怎么办？
+This\ external\ link\ is\ of\ the\ type\ '%0',\ which\ is\ undefined.\ What\ do\ you\ want\ to\ do?=此外部链接类型 '%0' 未定义，您想怎么办？
 
-This_group_contains_entries_based_on_manual_assignment._Entries_can_be_assigned_to_this_group_by_selecting_them_then_using_either_drag_and_drop_or_the_context_menu._Entries_can_be_removed_from_this_group_by_selecting_them_then_using_the_context_menu.=这个分组包含手动分配的记录,_你可以使用"选中-拖曳"或者右键菜单选中记录分配到该分组,_也可以使用右键菜单移除这些记录.
+This\ group\ contains\ entries\ based\ on\ manual\ assignment.\ Entries\ can\ be\ assigned\ to\ this\ group\ by\ selecting\ them\ then\ using\ either\ drag\ and\ drop\ or\ the\ context\ menu.\ Entries\ can\ be\ removed\ from\ this\ group\ by\ selecting\ them\ then\ using\ the\ context\ menu.=这个分组包含手动分配的记录, 你可以使用"选中-拖曳"或者右键菜单选中记录分配到该分组, 也可以使用右键菜单移除这些记录.
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_keyword_<b>%1</b>=此分组中记录的_<b>%0</b>_域包含关键词_<b>%1</b>_
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ keyword\ <b>%1</b>=此分组中记录的 <b>%0</b> 域包含关键词 <b>%1</b> 
 
-This_group_contains_entries_whose_<b>%0</b>_field_contains_the_regular_expression_<b>%1</b>=此分组中记录的_<b>%0</b>_域包含正则表达式_<b>%1</b>_
-This_makes_JabRef_look_up_each_file_link_and_check_if_the_file_exists._If_not,_you_will_be_given_options<BR>to_resolve_the_problem.=该选项使_JabRef_遍历所有文件链接，检查链接文件是否存在。如果不存在，您将会得到一个选项来处理这个问题。
+This\ group\ contains\ entries\ whose\ <b>%0</b>\ field\ contains\ the\ regular\ expression\ <b>%1</b>=此分组中记录的 <b>%0</b> 域包含正则表达式 <b>%1</b> 
+This\ makes\ JabRef\ look\ up\ each\ file\ link\ and\ check\ if\ the\ file\ exists.\ If\ not,\ you\ will\ be\ given\ options<BR>to\ resolve\ the\ problem.=该选项使 JabRef 遍历所有文件链接，检查链接文件是否存在。如果不存在，您将会得到一个选项来处理这个问题。
 
-This_operation_requires_all_selected_entries_to_have_BibTeX_keys_defined.=此操作要求所有选中记录的_BibTeX_键值不为空。
+This\ operation\ requires\ all\ selected\ entries\ to\ have\ BibTeX\ keys\ defined.=此操作要求所有选中记录的 BibTeX 键值不为空。
 
-This_operation_requires_one_or_more_entries_to_be_selected.=这个操作要求选中一条或多条记录。
+This\ operation\ requires\ one\ or\ more\ entries\ to\ be\ selected.=这个操作要求选中一条或多条记录。
 
-Toggle_entry_preview=打开/关闭记录预览
-Toggle_groups_interface=打开/关闭组界面
-Try_different_encoding=尝试其它编码
+Toggle\ entry\ preview=打开/关闭记录预览
+Toggle\ groups\ interface=打开/关闭组界面
+Try\ different\ encoding=尝试其它编码
 
-Unabbreviate_journal_names_of_the_selected_entries=展开选中记录的缩写期刊名称
-Unabbreviated_%0_journal_names.=展开_%0_期刊名称。
+Unabbreviate\ journal\ names\ of\ the\ selected\ entries=展开选中记录的缩写期刊名称
+Unabbreviated\ %0\ journal\ names.=展开 %0 期刊名称。
 
-Unable_to_open_file.=无法打开文件.
-Unable_to_open_link._The_application_'%0'_associated_with_the_file_type_'%1'_could_not_be_called.=无法打开链接。无法调用与文件类型_'%1'_关联的应用程序_'%0'_。
-unable_to_write_to=无法写入
-Undefined_file_type=未定义的文件类型
+Unable\ to\ open\ file.=无法打开文件.
+Unable\ to\ open\ link.\ The\ application\ '%0'\ associated\ with\ the\ file\ type\ '%1'\ could\ not\ be\ called.=无法打开链接。无法调用与文件类型 '%1' 关联的应用程序 '%0' 。
+unable\ to\ write\ to=无法写入
+Undefined\ file\ type=未定义的文件类型
 
 Undo=撤销
 
 Union=并集
 
-Unknown_BibTeX_entries=未知的_BibTeX_记录
+Unknown\ BibTeX\ entries=未知的 BibTeX 记录
 
-unknown_edit=未知修改
+unknown\ edit=未知修改
 
-Unknown_export_format=未知的导出格式
+Unknown\ export\ format=未知的导出格式
 
-Unmark_all=撤销所有高亮标记
+Unmark\ all=撤销所有高亮标记
 
-Unmark_entries=撤销选中高亮标记
+Unmark\ entries=撤销选中高亮标记
 
-Unmark_entry=撤销记录高亮标记
+Unmark\ entry=撤销记录高亮标记
 
 untitled=未命名
 
 Up=上
 
-Update_to_current_column_widths=使用当前视图中的列宽
+Update\ to\ current\ column\ widths=使用当前视图中的列宽
 
-Updated_group_selection=更新分组选择
-Upgrade_external_PDF/PS_links_to_use_the_'%0'_field.=升级外部_PDF/PS_链接以使用_'%0'_域。
-Upgrade_file=升级文件
-Upgrade_old_external_file_links_to_use_the_new_feature=升级旧外部文件链接以使用新特性
+Updated\ group\ selection=更新分组选择
+Upgrade\ external\ PDF/PS\ links\ to\ use\ the\ '%0'\ field.=升级外部 PDF/PS 链接以使用 '%0' 域。
+Upgrade\ file=升级文件
+Upgrade\ old\ external\ file\ links\ to\ use\ the\ new\ feature=升级旧外部文件链接以使用新特性
 
 usage=用法
-Use_autocompletion_for_the_following_fields=为以下域开启自动补全功能
+Use\ autocompletion\ for\ the\ following\ fields=为以下域开启自动补全功能
 
-Use_other_look_and_feel=使用其它显示效果类_(look_and_feel)
-Tweak_font_rendering_for_entry_editor_on_Linux=
-Use_regular_expression_search=使用正则表达式搜索
+Use\ other\ look\ and\ feel=使用其它显示效果类 (look and feel)
+Tweak\ font\ rendering\ for\ entry\ editor\ on\ Linux=
+Use\ regular\ expression\ search=使用正则表达式搜索
 
 Username=用户名
 
-Value_cleared_externally=内容从外部被清除
+Value\ cleared\ externally=内容从外部被清除
 
-Value_set_externally=内容从外部被设置
+Value\ set\ externally=内容从外部被设置
 
-verify_that_LyX_is_running_and_that_the_lyxpipe_is_valid=检查_LyX_是否在运行以及_lyx_管道是否可用
+verify\ that\ LyX\ is\ running\ and\ that\ the\ lyxpipe\ is\ valid=检查 LyX 是否在运行以及 lyx 管道是否可用
 
 View=视图
-Vim_server_name=Vim_服务器名
+Vim\ server\ name=Vim 服务器名
 
-Waiting_for_ArXiv...=等待_ArXiv...
+Waiting\ for\ ArXiv...=等待 ArXiv...
 
-Warn_about_unresolved_duplicates_when_closing_inspection_window=关闭检视窗口时警告未处理的_BibTeX_键重复情况
+Warn\ about\ unresolved\ duplicates\ when\ closing\ inspection\ window=关闭检视窗口时警告未处理的 BibTeX 键重复情况
 
-Warn_before_overwriting_existing_keys=覆盖已存在的_BibTeX_键之前发出警告
+Warn\ before\ overwriting\ existing\ keys=覆盖已存在的 BibTeX 键之前发出警告
 
 Warning=警告
 
 Warnings=警告
 
-web_link=web_链接
+web\ link=web 链接
 
-What_do_you_want_to_do?=您希望做什么?
+What\ do\ you\ want\ to\ do?=您希望做什么?
 
-When_adding/removing_keywords,_separate_them_by=当增加/移除关键字时，使用分隔符
-Will_write_XMP-metadata_to_the_PDFs_linked_from_selected_entries.=将写入_XMP_元数据到选中记录链接的_PDF_文件。
+When\ adding/removing\ keywords,\ separate\ them\ by=当增加/移除关键字时，使用分隔符
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=将写入 XMP 元数据到选中记录链接的 PDF 文件。
 
 with=以
 
-Write_BibTeXEntry_as_XMP-metadata_to_PDF.=将_BibTeX_记录作为_XMP_源数据写入到_PDF_中。
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=将 BibTeX 记录作为 XMP 源数据写入到 PDF 中。
 
-Write_XMP=写入_XMP
-Write_XMP-metadata=写入_XMP_元数据
-Write_XMP-metadata_for_all_PDFs_in_current_library?=将_XMP_元数据写入到当前文献库中所有_PDF_文件?
-Writing_XMP-metadata...=正在写入_XMP_元数据...
-Writing_XMP-metadata_for_selected_entries...=正在为选中记录写入_XMP_元数据...
+Write\ XMP=写入 XMP
+Write\ XMP-metadata=写入 XMP 元数据
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=将 XMP 元数据写入到当前文献库中所有 PDF 文件?
+Writing\ XMP-metadata...=正在写入 XMP 元数据...
+Writing\ XMP-metadata\ for\ selected\ entries...=正在为选中记录写入 XMP 元数据...
 
-Wrote_XMP-metadata=写入_XMP-元数据
+Wrote\ XMP-metadata=写入 XMP-元数据
 
-XMP-annotated_PDF=XMP-annotated_PDF
-XMP_export_privacy_settings=XMP_导出隐私设置
-XMP-metadata=XMP_元数据
-XMP-metadata_found_in_PDF\:_%0=PDF_中的_XMP_元数据\:_%0
-You_must_restart_JabRef_for_this_to_come_into_effect.=为使这项更改生效，您必须重启_JabRef。
-You_have_changed_the_language_setting.=您已经修改了语言设置。
-You_have_entered_an_invalid_search_'%0'.=您输入了一个非法的查询_'%0'.
+XMP-annotated\ PDF=XMP-annotated PDF
+XMP\ export\ privacy\ settings=XMP 导出隐私设置
+XMP-metadata=XMP 元数据
+XMP-metadata\ found\ in\ PDF\:\ %0=PDF 中的 XMP 元数据: %0
+You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=为使这项更改生效，您必须重启 JabRef。
+You\ have\ changed\ the\ language\ setting.=您已经修改了语言设置。
+You\ have\ entered\ an\ invalid\ search\ '%0'.=您输入了一个非法的查询 '%0'.
 
-You_must_restart_JabRef_for_the_new_key_bindings_to_work_properly.=为使热键绑定生效，您必须重启_JabRef。
+You\ must\ restart\ JabRef\ for\ the\ new\ key\ bindings\ to\ work\ properly.=为使热键绑定生效，您必须重启 JabRef。
 
-Your_new_key_bindings_have_been_stored.=您的热键绑定已经被存储。
+Your\ new\ key\ bindings\ have\ been\ stored.=您的热键绑定已经被存储。
 
-The_following_fetchers_are_available\:=下面列出的是可用的抓取器\:
-Could_not_find_fetcher_'%0'=无法找到抓取器_'%0'
-Running_query_'%0'_with_fetcher_'%1'.=使用抓取器'%1'执行请求'%0'
-Query_'%0'_with_fetcher_'%1'_did_not_return_any_results.=使用抓取器'%1'请求'%0'未返回任何结果。
+The\ following\ fetchers\ are\ available\:=下面列出的是可用的抓取器:
+Could\ not\ find\ fetcher\ '%0'=无法找到抓取器 '%0'
+Running\ query\ '%0'\ with\ fetcher\ '%1'.=使用抓取器'%1'执行请求'%0'
+Query\ '%0'\ with\ fetcher\ '%1'\ did\ not\ return\ any\ results.=使用抓取器'%1'请求'%0'未返回任何结果。
 
-Move_file=移动_文件
-Rename_file=重命名_文件
+Move\ file=移动 文件
+Rename\ file=重命名 文件
 
-Move_file_failed=移动文件失败
-Could_not_move_file_'%0'.=无法移动文件_'%0'
-Could_not_find_file_'%0'.=无法找到文件_'%0'。
-Number_of_entries_successfully_imported=成功导入的记录数
-Import_canceled_by_user=导入操作被用户取消
-Progress\:_%0_of_%1=进度\:_%0_of_%1
-Error_while_fetching_from_%0=从_%0_抓取发生错误
+Move\ file\ failed=移动文件失败
+Could\ not\ move\ file\ '%0'.=无法移动文件 '%0'
+Could\ not\ find\ file\ '%0'.=无法找到文件 '%0'。
+Number\ of\ entries\ successfully\ imported=成功导入的记录数
+Import\ canceled\ by\ user=导入操作被用户取消
+Progress\:\ %0\ of\ %1=进度: %0 of %1
+Error\ while\ fetching\ from\ %0=从 %0 抓取发生错误
 
-Please_enter_a_valid_number=请输入一个合法的数字
-Show_search_results_in_a_window=在新窗口中显示查询结果
-Show_global_search_results_in_a_window=在窗口中显示全局搜索结果
-Search_in_all_open_libraries=在所有打开的数据库中搜索
-Move_file_to_file_directory?=移动文件到文件目录?
+Please\ enter\ a\ valid\ number=请输入一个合法的数字
+Show\ search\ results\ in\ a\ window=在新窗口中显示查询结果
+Show\ global\ search\ results\ in\ a\ window=在窗口中显示全局搜索结果
+Search\ in\ all\ open\ libraries=在所有打开的数据库中搜索
+Move\ file\ to\ file\ directory?=移动文件到文件目录?
 
-Library_is_protected._Cannot_save_until_external_changes_have_been_reviewed.=文献库受保护中，在外部修改未被复查前无法执行保存操作。
-Protected_library=受保护的文献库
-Refuse_to_save_the_library_before_external_changes_have_been_reviewed.=在外部修改未被复查之前拒绝保存文献库。
-Library_protection=文献库保护
-Unable_to_save_library=无法保存文献库
+Library\ is\ protected.\ Cannot\ save\ until\ external\ changes\ have\ been\ reviewed.=文献库受保护中，在外部修改未被复查前无法执行保存操作。
+Protected\ library=受保护的文献库
+Refuse\ to\ save\ the\ library\ before\ external\ changes\ have\ been\ reviewed.=在外部修改未被复查之前拒绝保存文献库。
+Library\ protection=文献库保护
+Unable\ to\ save\ library=无法保存文献库
 
-BibTeX_key_generator=BibTeX_键生成器
-Unable_to_open_link.=无法打开链接。
-Move_the_keyboard_focus_to_the_entry_table=将键盘焦点移动到记录列表
-MIME_type=MIME_类型
+BibTeX\ key\ generator=BibTeX 键生成器
+Unable\ to\ open\ link.=无法打开链接。
+Move\ the\ keyboard\ focus\ to\ the\ entry\ table=将键盘焦点移动到记录列表
+MIME\ type=MIME 类型
 
-This_feature_lets_new_files_be_opened_or_imported_into_an_already_running_instance_of_JabRef<BR>instead_of_opening_a_new_instance._For_instance,_this_is_useful_when_you_open_a_file_in_JabRef<br>from_your_web_browser.<BR>Note_that_this_will_prevent_you_from_running_more_than_one_instance_of_JabRef_at_a_time.=该选项使得打开或者导入新文件的操作在已经运行的_JabRef_中进行，而不是新建另一个_JabRef_窗口<BR>来进行这些操作。例如，当您从浏览器中调用_JabRef_打开一个文件时，这个选项将比较有用。<BR>注意：它将阻止您同时运行多个_JabRef_实例。
-Run_fetcher,_e.g._"--fetch\=Medline\:cancer"=运行抓取器，例如_"--fetch\=Medline\:cancer"
+This\ feature\ lets\ new\ files\ be\ opened\ or\ imported\ into\ an\ already\ running\ instance\ of\ JabRef<BR>instead\ of\ opening\ a\ new\ instance.\ For\ instance,\ this\ is\ useful\ when\ you\ open\ a\ file\ in\ JabRef<br>from\ your\ web\ browser.<BR>Note\ that\ this\ will\ prevent\ you\ from\ running\ more\ than\ one\ instance\ of\ JabRef\ at\ a\ time.=该选项使得打开或者导入新文件的操作在已经运行的 JabRef 中进行，而不是新建另一个 JabRef 窗口<BR>来进行这些操作。例如，当您从浏览器中调用 JabRef 打开一个文件时，这个选项将比较有用。<BR>注意：它将阻止您同时运行多个 JabRef 实例。
+Run\ fetcher,\ e.g.\ "--fetch\=Medline\:cancer"=运行抓取器，例如 "--fetch=Medline:cancer"
 
-The_ACM_Digital_Library=ACM_数字图书馆
+The\ ACM\ Digital\ Library=ACM 数字图书馆
 Reset=重置
 
-Use_IEEE_LaTeX_abbreviations=使用_IEEE_LaTeX_缩写
-The_Guide_to_Computing_Literature=The_Guide_to_Computing_Literature
+Use\ IEEE\ LaTeX\ abbreviations=使用 IEEE LaTeX 缩写
+The\ Guide\ to\ Computing\ Literature=The Guide to Computing Literature
 
-When_opening_file_link,_search_for_matching_file_if_no_link_is_defined=打开文件时，如果文件链接未定义，则自动寻找匹配的文件。
-Settings_for_%0=%0_的设置
-Mark_entries_imported_into_an_existing_library=标记导入到已有文献库的新记录
-Unmark_all_entries_before_importing_new_entries_into_an_existing_library=导入新记录到文献库之前移除所有新记录的标记
+When\ opening\ file\ link,\ search\ for\ matching\ file\ if\ no\ link\ is\ defined=打开文件时，如果文件链接未定义，则自动寻找匹配的文件。
+Settings\ for\ %0=%0 的设置
+Mark\ entries\ imported\ into\ an\ existing\ library=标记导入到已有文献库的新记录
+Unmark\ all\ entries\ before\ importing\ new\ entries\ into\ an\ existing\ library=导入新记录到文献库之前移除所有新记录的标记
 
 Forward=前进
 Back=后退
-Sort_the_following_fields_as_numeric_fields=以数值方式排序下列域
-Line_%0\:_Found_corrupted_BibTeX_key.=第_%0_行\:_发现错误的_BibTeX_键。
-Line_%0\:_Found_corrupted_BibTeX_key_(contains_whitespaces).=第_%0_行\:_发现错误的_BibTeX_键(包含空格)。
-Line_%0\:_Found_corrupted_BibTeX_key_(comma_missing).=第_%0_行\:_发现错误的_BibTeX_键(逗号丢失)。
-Full_text_document_download_failed=下载全文失败
-Update_to_current_column_order=使用当前视图中的列顺序
-Download_from_URL=从_URL_下载
-Rename_field=重命名域
-Set/clear/append/rename_fields=设置/清除/重命名域
-Append_field=
-Append_to_fields=
-Rename_field_to=重命名该域为
-Move_contents_of_a_field_into_a_field_with_a_different_name=将一个域中的内容移动到另一个域中
-You_can_only_rename_one_field_at_a_time=一次只能重命名一个域
+Sort\ the\ following\ fields\ as\ numeric\ fields=以数值方式排序下列域
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key.=第 %0 行: 发现错误的 BibTeX 键。
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (contains\ whitespaces).=第 %0 行: 发现错误的 BibTeX 键(包含空格)。
+Line\ %0\:\ Found\ corrupted\ BibTeX\ key\ (comma\ missing).=第 %0 行: 发现错误的 BibTeX 键(逗号丢失)。
+Full\ text\ document\ download\ failed=下载全文失败
+Update\ to\ current\ column\ order=使用当前视图中的列顺序
+Download\ from\ URL=从 URL 下载
+Rename\ field=重命名域
+Set/clear/append/rename\ fields=设置/清除/重命名域
+Append\ field=
+Append\ to\ fields=
+Rename\ field\ to=重命名该域为
+Move\ contents\ of\ a\ field\ into\ a\ field\ with\ a\ different\ name=将一个域中的内容移动到另一个域中
+You\ can\ only\ rename\ one\ field\ at\ a\ time=一次只能重命名一个域
 
-Remove_all_broken_links=移除所有失效链接
+Remove\ all\ broken\ links=移除所有失效链接
 
-Cannot_use_port_%0_for_remote_operation;_another_application_may_be_using_it._Try_specifying_another_port.=无法使用端口_%0_进行远程操作;该端口可能被其它应用程序占用，请使用其它端口。
+Cannot\ use\ port\ %0\ for\ remote\ operation;\ another\ application\ may\ be\ using\ it.\ Try\ specifying\ another\ port.=无法使用端口 %0 进行远程操作;该端口可能被其它应用程序占用，请使用其它端口。
 
-Looking_for_full_text_document...=查找文章全文文档
+Looking\ for\ full\ text\ document...=查找文章全文文档
 Autosave=自动保存
-A_local_copy_will_be_opened.=将打开一个本地拷贝.
-Autosave_local_libraries=自动保存本地数据库
-Automatically_save_the_library_to=自动将文献库保存到
-Please_enter_a_valid_file_path.=请输入一个合法的文件路径.
+A\ local\ copy\ will\ be\ opened.=将打开一个本地拷贝.
+Autosave\ local\ libraries=自动保存本地数据库
+Automatically\ save\ the\ library\ to=自动将文献库保存到
+Please\ enter\ a\ valid\ file\ path.=请输入一个合法的文件路径.
 
 
-Export_in_current_table_sort_order=按照当前表格排序导出
-Export_entries_in_their_original_order=按照原始顺序导出记录
-Error_opening_file_'%0'.=打开文件_"%0"_时发生错误
+Export\ in\ current\ table\ sort\ order=按照当前表格排序导出
+Export\ entries\ in\ their\ original\ order=按照原始顺序导出记录
+Error\ opening\ file\ '%0'.=打开文件 "%0" 时发生错误
 
-Formatter_not_found\:_%0=无法找到的格式化器：_%0
-Clear_inputarea=清空输入框
+Formatter\ not\ found\:\ %0=无法找到的格式化器： %0
+Clear\ inputarea=清空输入框
 
-Automatically_set_file_links_for_this_entry=自动为此记录设置文件链接
-Could_not_save,_file_locked_by_another_JabRef_instance.=无法保存，文件被另一个_JabRef_实例锁定。
-File_is_locked_by_another_JabRef_instance.=文件被另一个_JabRef_实例锁定。
-Do_you_want_to_override_the_file_lock?=您是否希望覆盖文件锁？
-File_locked=文件被锁定
-Current_tmp_value=当前临时值
-Metadata_change=元数据改变
-Changes_have_been_made_to_the_following_metadata_elements=下列元数据元素被改变
+Automatically\ set\ file\ links\ for\ this\ entry=自动为此记录设置文件链接
+Could\ not\ save,\ file\ locked\ by\ another\ JabRef\ instance.=无法保存，文件被另一个 JabRef 实例锁定。
+File\ is\ locked\ by\ another\ JabRef\ instance.=文件被另一个 JabRef 实例锁定。
+Do\ you\ want\ to\ override\ the\ file\ lock?=您是否希望覆盖文件锁？
+File\ locked=文件被锁定
+Current\ tmp\ value=当前临时值
+Metadata\ change=元数据改变
+Changes\ have\ been\ made\ to\ the\ following\ metadata\ elements=下列元数据元素被改变
 
-Generate_groups_for_author_last_names=用作者的姓_(last_name)_创建分组
-Generate_groups_from_keywords_in_a_BibTeX_field=用_BibTeX_域中的关键词创建分组
-Enforce_legal_characters_in_BibTeX_keys=强制在_BibTeX_键值中使用合法字符
+Generate\ groups\ for\ author\ last\ names=用作者的姓 (last name) 创建分组
+Generate\ groups\ from\ keywords\ in\ a\ BibTeX\ field=用 BibTeX 域中的关键词创建分组
+Enforce\ legal\ characters\ in\ BibTeX\ keys=强制在 BibTeX 键值中使用合法字符
 
-Save_without_backup?=保存但不备份？
-Unable_to_create_backup=无法创建备份
-Move_file_to_file_directory=移动文件到文件目录。
-Rename_file_to=将文件更名为
-<b>All_Entries</b>_(this_group_cannot_be_edited_or_removed)=<b>所有记录</b>（此分组无法被编辑或者删除）
-static_group=静态分组
-dynamic_group=动态分组
-refines_supergroup=refines_supergroup_(翻译时没找到出处)
-includes_subgroups=包含子分组
+Save\ without\ backup?=保存但不备份？
+Unable\ to\ create\ backup=无法创建备份
+Move\ file\ to\ file\ directory=移动文件到文件目录。
+Rename\ file\ to=将文件更名为
+<b>All\ Entries</b>\ (this\ group\ cannot\ be\ edited\ or\ removed)=<b>所有记录</b>（此分组无法被编辑或者删除）
+static\ group=静态分组
+dynamic\ group=动态分组
+refines\ supergroup=refines supergroup (翻译时没找到出处)
+includes\ subgroups=包含子分组
 contains=包含
-search_expression=查询表达式\:
+search\ expression=查询表达式:
 
-Optional_fields_2=可选域_2
-Waiting_for_save_operation_to_finish=正在等待保存操作完成
-Resolving_duplicate_BibTeX_keys...=处理重复的_BibTeX
-Finished_resolving_duplicate_BibTeX_keys._%0_entries_modified.=完成处理重复_BibTeX_键值，修改了_%0_条记录。
-This_library_contains_one_or_more_duplicated_BibTeX_keys.=当前文献库包含一个或多个重复的_BibTeX_键值。
-Do_you_want_to_resolve_duplicate_keys_now?=您希望马上处理重复的键值吗？
+Optional\ fields\ 2=可选域 2
+Waiting\ for\ save\ operation\ to\ finish=正在等待保存操作完成
+Resolving\ duplicate\ BibTeX\ keys...=处理重复的 BibTeX
+Finished\ resolving\ duplicate\ BibTeX\ keys.\ %0\ entries\ modified.=完成处理重复 BibTeX 键值，修改了 %0 条记录。
+This\ library\ contains\ one\ or\ more\ duplicated\ BibTeX\ keys.=当前文献库包含一个或多个重复的 BibTeX 键值。
+Do\ you\ want\ to\ resolve\ duplicate\ keys\ now?=您希望马上处理重复的键值吗？
 
-Find_and_remove_duplicate_BibTeX_keys=查找并移除重复的_BibTeX_键值
-Expected_syntax_for_--fetch\='<name_of_fetcher>\:<query>'=期望的语法_--fetch='<name_of_fetcher>\:<query>'
-Duplicate_BibTeX_key=重复的_BibTeX_键值
-Import_marking_color=标记导入记录的颜色
-Always_add_letter_(a,_b,_...)_to_generated_keys=在生成键值时总是添加字母_(a,_b,_...)
+Find\ and\ remove\ duplicate\ BibTeX\ keys=查找并移除重复的 BibTeX 键值
+Expected\ syntax\ for\ --fetch\='<name\ of\ fetcher>\:<query>'=期望的语法 --fetch='<name of fetcher>:<query>'
+Duplicate\ BibTeX\ key=重复的 BibTeX 键值
+Import\ marking\ color=标记导入记录的颜色
+Always\ add\ letter\ (a,\ b,\ ...)\ to\ generated\ keys=在生成键值时总是添加字母 (a, b, ...)
 
-Ensure_unique_keys_using_letters_(a,_b,_...)=使用字母_(a,_b,_...)_保证键值唯一
-Ensure_unique_keys_using_letters_(b,_c,_...)=使用字母_(b,_c,_...)_保证键值唯一
-Entry_editor_active_background_color=记录编辑器活动的背景颜色
-Entry_editor_background_color=记录编辑器背景颜色
-Entry_editor_font_color=记录编辑器字体颜色
-Entry_editor_invalid_field_color=记录编辑器错误域颜色
+Ensure\ unique\ keys\ using\ letters\ (a,\ b,\ ...)=使用字母 (a, b, ...) 保证键值唯一
+Ensure\ unique\ keys\ using\ letters\ (b,\ c,\ ...)=使用字母 (b, c, ...) 保证键值唯一
+Entry\ editor\ active\ background\ color=记录编辑器活动的背景颜色
+Entry\ editor\ background\ color=记录编辑器背景颜色
+Entry\ editor\ font\ color=记录编辑器字体颜色
+Entry\ editor\ invalid\ field\ color=记录编辑器错误域颜色
 
-Table_and_entry_editor_colors=表格和记录编辑器颜色
+Table\ and\ entry\ editor\ colors=表格和记录编辑器颜色
 
-General_file_directory=生成文件目录
-User-specific_file_directory=用户指定的文件目录
-Search_failed\:_illegal_search_expression=搜索失败\:_不合法的搜索表达式
-Show_ArXiv_column=显示_ArXiv_列
+General\ file\ directory=生成文件目录
+User-specific\ file\ directory=用户指定的文件目录
+Search\ failed\:\ illegal\ search\ expression=搜索失败: 不合法的搜索表达式
+Show\ ArXiv\ column=显示 ArXiv 列
 
-You_must_enter_an_integer_value_in_the_interval_1025-65535_in_the_text_field_for=请输入_1025-65535_之间的整数值。设置项：
-Automatically_open_browse_dialog_when_creating_new_file_link=创建新的文件链接时自动打开文件浏览对话框
-Import_metadata_from\:=导入_metadata，来自：
-Choose_the_source_for_the_metadata_import=选择导入_metadata_的来源
-Create_entry_based_on_XMP-metadata=基于_XMP_数据新建一条记录
-Create_blank_entry_linking_the_PDF=为_PDF_新建一条空白记录
-Only_attach_PDF=只附加_PDF_到记录
+You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ text\ field\ for=请输入 1025-65535 之间的整数值。设置项：
+Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=创建新的文件链接时自动打开文件浏览对话框
+Import\ metadata\ from\:=导入 metadata，来自：
+Choose\ the\ source\ for\ the\ metadata\ import=选择导入 metadata 的来源
+Create\ entry\ based\ on\ XMP-metadata=基于 XMP 数据新建一条记录
+Create\ blank\ entry\ linking\ the\ PDF=为 PDF 新建一条空白记录
+Only\ attach\ PDF=只附加 PDF 到记录
 Title=标题
-Create_new_entry=创建新记录
-Update_existing_entry=更新已有记录
-Autocomplete_names_in_'Firstname_Lastname'_format_only=仅自动补全形如_'Firstname_Lastname'_格式的姓名
-Autocomplete_names_in_'Lastname,_Firstname'_format_only=仅自动补全形如_'Lastname,_Firstname'_格式的姓名
-Autocomplete_names_in_both_formats=自动补全两种格式的姓名
-Marking_color_%0=标记颜色_%0
-The_name_'comment'_cannot_be_used_as_an_entry_type_name.='comment'_不能用作记录类型名
-You_must_enter_an_integer_value_in_the_text_field_for=您必须输入一个整数值到文本框
-Send_as_email=以邮件形式发送
+Create\ new\ entry=创建新记录
+Update\ existing\ entry=更新已有记录
+Autocomplete\ names\ in\ 'Firstname\ Lastname'\ format\ only=仅自动补全形如 'Firstname Lastname' 格式的姓名
+Autocomplete\ names\ in\ 'Lastname,\ Firstname'\ format\ only=仅自动补全形如 'Lastname, Firstname' 格式的姓名
+Autocomplete\ names\ in\ both\ formats=自动补全两种格式的姓名
+Marking\ color\ %0=标记颜色 %0
+The\ name\ 'comment'\ cannot\ be\ used\ as\ an\ entry\ type\ name.='comment' 不能用作记录类型名
+You\ must\ enter\ an\ integer\ value\ in\ the\ text\ field\ for=您必须输入一个整数值到文本框
+Send\ as\ email=以邮件形式发送
 References=引用
-Sending_of_emails=邮件发送选项
-Subject_for_sending_an_email_with_references=发送带参考的邮件时的主题
-Automatically_open_folders_of_attached_files=自动打开附件所在的文件夹
-Create_entry_based_on_content=基于内容新建一条记录
-Do_not_show_this_box_again_for_this_import=本次导入中不再显示此对话框
-Always_use_this_PDF_import_style_(and_do_not_ask_for_each_import)=默认使用这个_PDF_导入策略(不需要每次导入都询问)
-Error_creating_email=创建邮件失败
-Entries_added_to_an_email=记录已添加到邮件中
+Sending\ of\ emails=邮件发送选项
+Subject\ for\ sending\ an\ email\ with\ references=发送带参考的邮件时的主题
+Automatically\ open\ folders\ of\ attached\ files=自动打开附件所在的文件夹
+Create\ entry\ based\ on\ content=基于内容新建一条记录
+Do\ not\ show\ this\ box\ again\ for\ this\ import=本次导入中不再显示此对话框
+Always\ use\ this\ PDF\ import\ style\ (and\ do\ not\ ask\ for\ each\ import)=默认使用这个 PDF 导入策略(不需要每次导入都询问)
+Error\ creating\ email=创建邮件失败
+Entries\ added\ to\ an\ email=记录已添加到邮件中
 exportFormat=导出格式
-Output_file_missing=没有输出文件
-No_search_matches.=没有匹配的搜索结果
-The_output_option_depends_on_a_valid_input_option.=输出选项依赖于合法的输入选项。
-Default_import_style_for_drag_and_drop_of_PDFs=拖入_PDF_的默认导入策略
-Default_PDF_file_link_action=默认_PDF_文件链接操作
-Filename_format_pattern=文件名格式化表达式
-Additional_parameters=额外的参数
-Cite_selected_entries_between_parenthesis=
-Cite_selected_entries_with_in-text_citation=
-Cite_special=
-Extra_information_(e.g._page_number)=额外信息（例如：页码）
-Manage_citations=管理文献引用
-Problem_modifying_citation=修改文献引用存在问题
+Output\ file\ missing=没有输出文件
+No\ search\ matches.=没有匹配的搜索结果
+The\ output\ option\ depends\ on\ a\ valid\ input\ option.=输出选项依赖于合法的输入选项。
+Default\ import\ style\ for\ drag\ and\ drop\ of\ PDFs=拖入 PDF 的默认导入策略
+Default\ PDF\ file\ link\ action=默认 PDF 文件链接操作
+Filename\ format\ pattern=文件名格式化表达式
+Additional\ parameters=额外的参数
+Cite\ selected\ entries\ between\ parenthesis=
+Cite\ selected\ entries\ with\ in-text\ citation=
+Cite\ special=
+Extra\ information\ (e.g.\ page\ number)=额外信息（例如：页码）
+Manage\ citations=管理文献引用
+Problem\ modifying\ citation=修改文献引用存在问题
 Citation=文献引用
-Extra_information=额外信息
-Could_not_resolve_BibTeX_entry_for_citation_marker_'%0'.=文献引用标记_"%0"_无法解析到_BibTeX_记录
-Select_style=选择引用样式
+Extra\ information=额外信息
+Could\ not\ resolve\ BibTeX\ entry\ for\ citation\ marker\ '%0'.=文献引用标记 "%0" 无法解析到 BibTeX 记录
+Select\ style=选择引用样式
 Journals=期刊
 Cite=引用
-Cite_in-text=
-Insert_empty_citation=插入空文献引用
-Merge_citations=合并文献引用
-Manual_connect=手动连接
-Select_Writer_document=选择_Writer_文档
-Sync_OpenOffice/LibreOffice_bibliography=同步_OpenOffice/LibreOffice_参考文献
-Select_which_open_Writer_document_to_work_on=选择使用哪个打开的_Writer_文档
-Connected_to_document=连接到文档
-Insert_a_citation_without_text_(the_entry_will_appear_in_the_reference_list)=插入一条没有内容的引用（这条记录将会出现在引用列表中）
-Cite_selected_entries_with_extra_information=引用包含额外信息的选中记录
-Ensure_that_the_bibliography_is_up-to-date=保证参考文献是最新的
-Your_OpenOffice/LibreOffice_document_references_the_BibTeX_key_'%0',_which_could_not_be_found_in_your_current_library.=您的_OpenOffice/LibreOffice_文档引用了一个当前文献库中不存在的_BibTeX_键值_”%0”。
-Unable_to_synchronize_bibliography=无法同步参考文献
-Combine_pairs_of_citations_that_are_separated_by_spaces_only=
-Autodetection_failed=自动检测失败
+Cite\ in-text=
+Insert\ empty\ citation=插入空文献引用
+Merge\ citations=合并文献引用
+Manual\ connect=手动连接
+Select\ Writer\ document=选择 Writer 文档
+Sync\ OpenOffice/LibreOffice\ bibliography=同步 OpenOffice/LibreOffice 参考文献
+Select\ which\ open\ Writer\ document\ to\ work\ on=选择使用哪个打开的 Writer 文档
+Connected\ to\ document=连接到文档
+Insert\ a\ citation\ without\ text\ (the\ entry\ will\ appear\ in\ the\ reference\ list)=插入一条没有内容的引用（这条记录将会出现在引用列表中）
+Cite\ selected\ entries\ with\ extra\ information=引用包含额外信息的选中记录
+Ensure\ that\ the\ bibliography\ is\ up-to-date=保证参考文献是最新的
+Your\ OpenOffice/LibreOffice\ document\ references\ the\ BibTeX\ key\ '%0',\ which\ could\ not\ be\ found\ in\ your\ current\ library.=您的 OpenOffice/LibreOffice 文档引用了一个当前文献库中不存在的 BibTeX 键值 ”%0”。
+Unable\ to\ synchronize\ bibliography=无法同步参考文献
+Combine\ pairs\ of\ citations\ that\ are\ separated\ by\ spaces\ only=
+Autodetection\ failed=自动检测失败
 Connecting=正在连接
-Please_wait...=请稍候...
-Set_connection_parameters=设置连接参数
-Path_to_OpenOffice/LibreOffice_directory=到_OpenOffice/LibreOffice_安装位置的路径
-Path_to_OpenOffice/LibreOffice_executable=OpenOffice/LibreOffice_可执行文件路径
-Path_to_OpenOffice/LibreOffice_library_dir=OpenOffice/LibreOffice_library_目录
-Connection_lost=连接丢失
-The_paragraph_format_is_controlled_by_the_property_'ReferenceParagraphFormat'_or_'ReferenceHeaderParagraphFormat'_in_the_style_file.=
-The_character_format_is_controlled_by_the_citation_property_'CitationCharacterFormat'_in_the_style_file.=
-Automatically_sync_bibliography_when_inserting_citations=当插入文献引用时自动同步参考文献
-Look_up_BibTeX_entries_in_the_active_tab_only=在当前标签查找_BibTeX_记录
-Look_up_BibTeX_entries_in_all_open_libraries=在所有打开的数据库中查找_BibTeX_记录
-Autodetecting_paths...=自动检测路径...
-Could_not_find_OpenOffice/LibreOffice_installation=无法找到_OpenOffice/LibreOffice_安装路径
-Found_more_than_one_OpenOffice/LibreOffice_executable.=找到多于一个_OpenOffice/LibreOffice_可执行文件。
-Please_choose_which_one_to_connect_to\:=请选择连接到哪个：
-Choose_OpenOffice/LibreOffice_executable=选择_OpenOffice/LibreOffice_可执行文件
-Select_document=选择文件
-HTML_list=HTML_列表
-If_possible,_normalize_this_list_of_names_to_conform_to_standard_BibTeX_name_formatting=尽可能使用标准_BibTeX_名字格式规范化此列表中的名字
-Could_not_open_%0=无法打开_%0
-Unknown_import_format=未知的导入格式
-Web_search=网页搜索
-Style_selection=引用样式选择
-No_valid_style_file_defined=没有找到合法的_style_文件
-Choose_pattern=选择表达式
-Use_the_BIB_file_location_as_primary_file_directory=将_BIB_文件所在位置作为文件主目录
-Could_not_run_the_gnuclient/emacsclient_program._Make_sure_you_have_the_emacsclient/gnuclient_program_installed_and_available_in_the_PATH.=无法执行_gnuclient/emacsclient_程序，确认您已经安装_gnuclient/emacsclient_，并且在_PATH_中。
-OpenOffice/LibreOffice_connection=OpenOffice/LibreOffice_连接
-You_must_select_either_a_valid_style_file,_or_use_one_of_the_default_styles.=您要么选择一个可用的风格文件，要么使用一种默认风格。
+Please\ wait...=请稍候...
+Set\ connection\ parameters=设置连接参数
+Path\ to\ OpenOffice/LibreOffice\ directory=到 OpenOffice/LibreOffice 安装位置的路径
+Path\ to\ OpenOffice/LibreOffice\ executable=OpenOffice/LibreOffice 可执行文件路径
+Path\ to\ OpenOffice/LibreOffice\ library\ dir=OpenOffice/LibreOffice library 目录
+Connection\ lost=连接丢失
+The\ paragraph\ format\ is\ controlled\ by\ the\ property\ 'ReferenceParagraphFormat'\ or\ 'ReferenceHeaderParagraphFormat'\ in\ the\ style\ file.=
+The\ character\ format\ is\ controlled\ by\ the\ citation\ property\ 'CitationCharacterFormat'\ in\ the\ style\ file.=
+Automatically\ sync\ bibliography\ when\ inserting\ citations=当插入文献引用时自动同步参考文献
+Look\ up\ BibTeX\ entries\ in\ the\ active\ tab\ only=在当前标签查找 BibTeX 记录
+Look\ up\ BibTeX\ entries\ in\ all\ open\ libraries=在所有打开的数据库中查找 BibTeX 记录
+Autodetecting\ paths...=自动检测路径...
+Could\ not\ find\ OpenOffice/LibreOffice\ installation=无法找到 OpenOffice/LibreOffice 安装路径
+Found\ more\ than\ one\ OpenOffice/LibreOffice\ executable.=找到多于一个 OpenOffice/LibreOffice 可执行文件。
+Please\ choose\ which\ one\ to\ connect\ to\:=请选择连接到哪个：
+Choose\ OpenOffice/LibreOffice\ executable=选择 OpenOffice/LibreOffice 可执行文件
+Select\ document=选择文件
+HTML\ list=HTML 列表
+If\ possible,\ normalize\ this\ list\ of\ names\ to\ conform\ to\ standard\ BibTeX\ name\ formatting=尽可能使用标准 BibTeX 名字格式规范化此列表中的名字
+Could\ not\ open\ %0=无法打开 %0
+Unknown\ import\ format=未知的导入格式
+Web\ search=网页搜索
+Style\ selection=引用样式选择
+No\ valid\ style\ file\ defined=没有找到合法的 style 文件
+Choose\ pattern=选择表达式
+Use\ the\ BIB\ file\ location\ as\ primary\ file\ directory=将 BIB 文件所在位置作为文件主目录
+Could\ not\ run\ the\ gnuclient/emacsclient\ program.\ Make\ sure\ you\ have\ the\ emacsclient/gnuclient\ program\ installed\ and\ available\ in\ the\ PATH.=无法执行 gnuclient/emacsclient 程序，确认您已经安装 gnuclient/emacsclient ，并且在 PATH 中。
+OpenOffice/LibreOffice\ connection=OpenOffice/LibreOffice 连接
+You\ must\ select\ either\ a\ valid\ style\ file,\ or\ use\ one\ of\ the\ default\ styles.=您要么选择一个可用的风格文件，要么使用一种默认风格。
 
-This_is_a_simple_copy_and_paste_dialog._First_load_or_paste_some_text_into_the_text_input_area.<br>After_that,_you_can_mark_text_and_assign_it_to_a_BibTeX_field.=这是一个简单的拷贝粘贴对话框。首先加载或者粘贴一些文本内容到文本框中，<br>然后你可以选中文本分配到一个_BibTeX_域中。
-This_feature_generates_a_new_library_based_on_which_entries_are_needed_in_an_existing_LaTeX_document.=此功能根据一个_LeTeX_文档，将它使用到的记录生成为一个新的文献库。
-You_need_to_select_one_of_your_open_libraries_from_which_to_choose_entries,_as_well_as_the_AUX_file_produced_by_LaTeX_when_compiling_your_document.=
+This\ is\ a\ simple\ copy\ and\ paste\ dialog.\ First\ load\ or\ paste\ some\ text\ into\ the\ text\ input\ area.<br>After\ that,\ you\ can\ mark\ text\ and\ assign\ it\ to\ a\ BibTeX\ field.=这是一个简单的拷贝粘贴对话框。首先加载或者粘贴一些文本内容到文本框中，<br>然后你可以选中文本分配到一个 BibTeX 域中。
+This\ feature\ generates\ a\ new\ library\ based\ on\ which\ entries\ are\ needed\ in\ an\ existing\ LaTeX\ document.=此功能根据一个 LeTeX 文档，将它使用到的记录生成为一个新的文献库。
+You\ need\ to\ select\ one\ of\ your\ open\ libraries\ from\ which\ to\ choose\ entries,\ as\ well\ as\ the\ AUX\ file\ produced\ by\ LaTeX\ when\ compiling\ your\ document.=
 
-First_select_entries_to_clean_up.=首先选择要清理的记录。
-Cleanup_entry=清理记录
-Autogenerate_PDF_Names=自动生成_PDF_名
-Auto-generating_PDF-Names_does_not_support_undo._Continue?=自动生成_PDF_名操作不可撤销，是否继续？
+First\ select\ entries\ to\ clean\ up.=首先选择要清理的记录。
+Cleanup\ entry=清理记录
+Autogenerate\ PDF\ Names=自动生成 PDF 名
+Auto-generating\ PDF-Names\ does\ not\ support\ undo.\ Continue?=自动生成 PDF 名操作不可撤销，是否继续？
 
-Use_full_firstname_whenever_possible=尽可能使用完整的_Firstname
-Use_abbreviated_firstname_whenever_possible=尽可能使用缩写的_Firstname
-Use_abbreviated_and_full_firstname=混杂使用缩写和完整的_Firstname
-Autocompletion_options=自动补全选项
-Name_format_used_for_autocompletion=自动补全的姓名格式
-Treatment_of_first_names=Firstname_的处理
-Cleanup_entries=清理选中记录
-Automatically_assign_new_entry_to_selected_groups=新增记录分配到选中分组
-%0_mode=%0_模式
-Move_DOIs_from_note_and_URL_field_to_DOI_field_and_remove_http_prefix=
-Make_paths_of_linked_files_relative_(if_possible)=
-Rename_PDFs_to_given_filename_format_pattern=
-Rename_only_PDFs_having_a_relative_path=
-What_would_you_like_to_clean_up?=
-Doing_a_cleanup_for_%0_entries...=
-No_entry_needed_a_clean_up=
-One_entry_needed_a_clean_up=
-%0_entries_needed_a_clean_up=
+Use\ full\ firstname\ whenever\ possible=尽可能使用完整的 Firstname
+Use\ abbreviated\ firstname\ whenever\ possible=尽可能使用缩写的 Firstname
+Use\ abbreviated\ and\ full\ firstname=混杂使用缩写和完整的 Firstname
+Autocompletion\ options=自动补全选项
+Name\ format\ used\ for\ autocompletion=自动补全的姓名格式
+Treatment\ of\ first\ names=Firstname 的处理
+Cleanup\ entries=清理选中记录
+Automatically\ assign\ new\ entry\ to\ selected\ groups=新增记录分配到选中分组
+%0\ mode=%0 模式
+Move\ DOIs\ from\ note\ and\ URL\ field\ to\ DOI\ field\ and\ remove\ http\ prefix=
+Make\ paths\ of\ linked\ files\ relative\ (if\ possible)=
+Rename\ PDFs\ to\ given\ filename\ format\ pattern=
+Rename\ only\ PDFs\ having\ a\ relative\ path=
+What\ would\ you\ like\ to\ clean\ up?=
+Doing\ a\ cleanup\ for\ %0\ entries...=
+No\ entry\ needed\ a\ clean\ up=
+One\ entry\ needed\ a\ clean\ up=
+%0\ entries\ needed\ a\ clean\ up=
 
-Remove_selected=移除选中的
+Remove\ selected=移除选中的
 
-Group_tree_could_not_be_parsed._If_you_save_the_BibTeX_library,_all_groups_will_be_lost.=
-Attach_file=附加文件
-Setting_all_preferences_to_default_values.=重置所有首选项到默认值.
-Resetting_preference_key_'%0'=重置首选项_'%0'
-Unknown_preference_key_'%0'=位置的首选项_'%0'
-Unable_to_clear_preferences.=无法清除所有选项.
+Group\ tree\ could\ not\ be\ parsed.\ If\ you\ save\ the\ BibTeX\ library,\ all\ groups\ will\ be\ lost.=
+Attach\ file=附加文件
+Setting\ all\ preferences\ to\ default\ values.=重置所有首选项到默认值.
+Resetting\ preference\ key\ '%0'=重置首选项 '%0'
+Unknown\ preference\ key\ '%0'=位置的首选项 '%0'
+Unable\ to\ clear\ preferences.=无法清除所有选项.
 
-Reset_preferences_(key1,key2,..._or_'all')=
-Find_unlinked_files=查找未链入的文件
-Unselect_all=取消全选
-Expand_all=展开全部
-Collapse_all=折叠全部
-Opens_the_file_browser.=打开文件浏览器.
-Scan_directory=扫描目录
-Searches_the_selected_directory_for_unlinked_files.=
-Starts_the_import_of_BibTeX_entries.=
-Leave_this_dialog.=离开对话框.
-Create_directory_based_keywords=
-Creates_keywords_in_created_entrys_with_directory_pathnames=
-Select_a_directory_where_the_search_shall_start.=
-Select_file_type\:=选择文件类型\:
-These_files_are_not_linked_in_the_active_library.=
-Entry_type_to_be_created\:=
-Searching_file_system...=正在搜索文件系统...
-Importing_into_Library...=正在导入到文献库...
-Select_directory=选择目录
-Select_files=选择文件
-BibTeX_entry_creation=
-<No_selection>=
-Unable_to_connect_to_FreeCite_online_service.=
-Parse_with_FreeCite=
-The_current_BibTeX_key_will_be_overwritten._Continue?=当前的_BibTeX_键值将会被覆盖,_是否继续?
-Overwrite_key=覆盖_key
-Not_overwriting_existing_key._To_change_this_setting,_open_Options_->_Prefererences_->_BibTeX_key_generator=无法覆盖已经存在的键._若要修改此设置,_请打开_选项_->_首选项_->_BibTeX_键生成器
-How_would_you_like_to_link_to_'%0'?=
-BibTeX_key_patterns=BibTeX_键特征
-Changed_special_field_settings=已修改特殊字段设置
-Clear_priority=清除优先级
-Clear_rank=清除评分
-Enable_special_fields=启用特殊域
-One_star=一星
-Two_stars=二星
-Three_stars=三星
-Four_stars=四星
-Five_stars=五星
-Help_on_special_fields=特殊字段帮助
-Keywords_of_selected_entries=选中记录的关键词
-Manage_content_selectors=
-Manage_keywords=管理关键词
-No_priority_information=没有优先级信息
-No_rank_information=没有评分信息
+Reset\ preferences\ (key1,key2,...\ or\ 'all')=
+Find\ unlinked\ files=查找未链入的文件
+Unselect\ all=取消全选
+Expand\ all=展开全部
+Collapse\ all=折叠全部
+Opens\ the\ file\ browser.=打开文件浏览器.
+Scan\ directory=扫描目录
+Searches\ the\ selected\ directory\ for\ unlinked\ files.=
+Starts\ the\ import\ of\ BibTeX\ entries.=
+Leave\ this\ dialog.=离开对话框.
+Create\ directory\ based\ keywords=
+Creates\ keywords\ in\ created\ entrys\ with\ directory\ pathnames=
+Select\ a\ directory\ where\ the\ search\ shall\ start.=
+Select\ file\ type\:=选择文件类型:
+These\ files\ are\ not\ linked\ in\ the\ active\ library.=
+Entry\ type\ to\ be\ created\:=
+Searching\ file\ system...=正在搜索文件系统...
+Importing\ into\ Library...=正在导入到文献库...
+Select\ directory=选择目录
+Select\ files=选择文件
+BibTeX\ entry\ creation=
+<No\ selection>=
+Unable\ to\ connect\ to\ FreeCite\ online\ service.=
+Parse\ with\ FreeCite=
+The\ current\ BibTeX\ key\ will\ be\ overwritten.\ Continue?=当前的 BibTeX 键值将会被覆盖, 是否继续?
+Overwrite\ key=覆盖 key
+Not\ overwriting\ existing\ key.\ To\ change\ this\ setting,\ open\ Options\ ->\ Prefererences\ ->\ BibTeX\ key\ generator=无法覆盖已经存在的键. 若要修改此设置, 请打开 选项 -> 首选项 -> BibTeX 键生成器
+How\ would\ you\ like\ to\ link\ to\ '%0'?=
+BibTeX\ key\ patterns=BibTeX 键特征
+Changed\ special\ field\ settings=已修改特殊字段设置
+Clear\ priority=清除优先级
+Clear\ rank=清除评分
+Enable\ special\ fields=启用特殊域
+One\ star=一星
+Two\ stars=二星
+Three\ stars=三星
+Four\ stars=四星
+Five\ stars=五星
+Help\ on\ special\ fields=特殊字段帮助
+Keywords\ of\ selected\ entries=选中记录的关键词
+Manage\ content\ selectors=
+Manage\ keywords=管理关键词
+No\ priority\ information=没有优先级信息
+No\ rank\ information=没有评分信息
 Priority=优先级
-Priority_high=高优先级
-Priority_low=低优先级
-Priority_medium=中优先级
+Priority\ high=高优先级
+Priority\ low=低优先级
+Priority\ medium=中优先级
 Quality=质量
 Rank=评分
 Relevance=相关性
-Set_priority_to_high=设置优先级为高
-Set_priority_to_low=设置优先级为低
-Set_priority_to_medium=设置优先级为中
-Show_priority=显示优先级
-Show_quality=显示质量
-Show_rank=显示评分
-Show_relevance=显示相关性
-Synchronize_with_keywords=与关键词同步
-Synchronized_special_fields_based_on_keywords=基于关键词同步特殊字段
-Toggle_relevance=标记为相关
-Toggle_quality_assured=标记为质量已确认
-Toggle_print_status=标记打印状态
-Update_keywords=更新关键词
-Write_values_of_special_fields_as_separate_fields_to_BibTeX=将特殊字段的值以独立字段形式写入_BibTeX
-You_have_changed_settings_for_special_fields.=您已经修改了特殊字段的设置.
-%0_entries_found._To_reduce_server_load,_only_%1_will_be_downloaded.=
-A_string_with_that_label_already_exists=该标签对应的简写字串已存在
-Connection_to_OpenOffice/LibreOffice_has_been_lost._Please_make_sure_OpenOffice/LibreOffice_is_running,_and_try_to_reconnect.=
-JabRef_will_send_at_least_one_request_per_entry_to_a_publisher.=
-Correct_the_entry,_and_reopen_editor_to_display/edit_source.=
-Could_not_connect_to_a_running_gnuserv_process._Make_sure_that_Emacs_or_XEmacs_is_running,<BR>and_that_the_server_has_been_started_(by_running_the_command_'server-start'/'gnuserv-start').=
-Could_not_connect_to_running_OpenOffice/LibreOffice.=
-Make_sure_you_have_installed_OpenOffice/LibreOffice_with_Java_support.=
-If_connecting_manually,_please_verify_program_and_library_paths.=
-Error_message\:=错误信息\:
-If_a_pasted_or_imported_entry_already_has_the_field_set,_overwrite.=
-Import_metadata_from_PDF=从_PDF_中导入_metadata
-Not_connected_to_any_Writer_document._Please_make_sure_a_document_is_open,_and_use_the_'Select_Writer_document'_button_to_connect_to_it.=
-Removed_all_subgroups_of_group_"%0".=
-To_disable_the_memory_stick_mode_rename_or_remove_the_jabref.xml_file_in_the_same_folder_as_JabRef.=
-Unable_to_connect._One_possible_reason_is_that_JabRef_and_OpenOffice/LibreOffice_are_not_both_running_in_either_32_bit_mode_or_64_bit_mode.=
-Use_the_following_delimiter_character(s)\:=
-When_downloading_files,_or_moving_linked_files_to_the_file_directory,_prefer_the_BIB_file_location_rather_than_the_file_directory_set_above=
-Your_style_file_specifies_the_character_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=
-Your_style_file_specifies_the_paragraph_format_'%0',_which_is_undefined_in_your_current_OpenOffice/LibreOffice_document.=
+Set\ priority\ to\ high=设置优先级为高
+Set\ priority\ to\ low=设置优先级为低
+Set\ priority\ to\ medium=设置优先级为中
+Show\ priority=显示优先级
+Show\ quality=显示质量
+Show\ rank=显示评分
+Show\ relevance=显示相关性
+Synchronize\ with\ keywords=与关键词同步
+Synchronized\ special\ fields\ based\ on\ keywords=基于关键词同步特殊字段
+Toggle\ relevance=标记为相关
+Toggle\ quality\ assured=标记为质量已确认
+Toggle\ print\ status=标记打印状态
+Update\ keywords=更新关键词
+Write\ values\ of\ special\ fields\ as\ separate\ fields\ to\ BibTeX=将特殊字段的值以独立字段形式写入 BibTeX
+You\ have\ changed\ settings\ for\ special\ fields.=您已经修改了特殊字段的设置.
+%0\ entries\ found.\ To\ reduce\ server\ load,\ only\ %1\ will\ be\ downloaded.=
+A\ string\ with\ that\ label\ already\ exists=该标签对应的简写字串已存在
+Connection\ to\ OpenOffice/LibreOffice\ has\ been\ lost.\ Please\ make\ sure\ OpenOffice/LibreOffice\ is\ running,\ and\ try\ to\ reconnect.=
+JabRef\ will\ send\ at\ least\ one\ request\ per\ entry\ to\ a\ publisher.=
+Correct\ the\ entry,\ and\ reopen\ editor\ to\ display/edit\ source.=
+Could\ not\ connect\ to\ a\ running\ gnuserv\ process.\ Make\ sure\ that\ Emacs\ or\ XEmacs\ is\ running,<BR>and\ that\ the\ server\ has\ been\ started\ (by\ running\ the\ command\ 'server-start'/'gnuserv-start').=
+Could\ not\ connect\ to\ running\ OpenOffice/LibreOffice.=
+Make\ sure\ you\ have\ installed\ OpenOffice/LibreOffice\ with\ Java\ support.=
+If\ connecting\ manually,\ please\ verify\ program\ and\ library\ paths.=
+Error\ message\:=错误信息:
+If\ a\ pasted\ or\ imported\ entry\ already\ has\ the\ field\ set,\ overwrite.=
+Import\ metadata\ from\ PDF=从 PDF 中导入 metadata
+Not\ connected\ to\ any\ Writer\ document.\ Please\ make\ sure\ a\ document\ is\ open,\ and\ use\ the\ 'Select\ Writer\ document'\ button\ to\ connect\ to\ it.=
+Removed\ all\ subgroups\ of\ group\ "%0".=
+To\ disable\ the\ memory\ stick\ mode\ rename\ or\ remove\ the\ jabref.xml\ file\ in\ the\ same\ folder\ as\ JabRef.=
+Unable\ to\ connect.\ One\ possible\ reason\ is\ that\ JabRef\ and\ OpenOffice/LibreOffice\ are\ not\ both\ running\ in\ either\ 32\ bit\ mode\ or\ 64\ bit\ mode.=
+Use\ the\ following\ delimiter\ character(s)\:=
+When\ downloading\ files,\ or\ moving\ linked\ files\ to\ the\ file\ directory,\ prefer\ the\ BIB\ file\ location\ rather\ than\ the\ file\ directory\ set\ above=
+Your\ style\ file\ specifies\ the\ character\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=
+Your\ style\ file\ specifies\ the\ paragraph\ format\ '%0',\ which\ is\ undefined\ in\ your\ current\ OpenOffice/LibreOffice\ document.=
 
 Searching...=正在搜索...
-You_have_selected_more_than_%0_entries_for_download._Some_web_sites_might_block_you_if_you_make_too_many_rapid_downloads._Do_you_want_to_continue?=
-Confirm_selection=确认选择
-Add_{}_to_specified_title_words_on_search_to_keep_the_correct_case=搜索时为特殊的标题单词添加_{}_以保证大小写正确
-Import_conversions=导入约定
-Please_enter_a_search_string=请输入一个搜索字符串
-Please_open_or_start_a_new_library_before_searching=
+You\ have\ selected\ more\ than\ %0\ entries\ for\ download.\ Some\ web\ sites\ might\ block\ you\ if\ you\ make\ too\ many\ rapid\ downloads.\ Do\ you\ want\ to\ continue?=
+Confirm\ selection=确认选择
+Add\ {}\ to\ specified\ title\ words\ on\ search\ to\ keep\ the\ correct\ case=搜索时为特殊的标题单词添加 {} 以保证大小写正确
+Import\ conversions=导入约定
+Please\ enter\ a\ search\ string=请输入一个搜索字符串
+Please\ open\ or\ start\ a\ new\ library\ before\ searching=
 
-Canceled_merging_entries=已取消记录合并
+Canceled\ merging\ entries=已取消记录合并
 
-Format_units_by_adding_non-breaking_separators_and_keeping_the_correct_case_on_search=对单元格式化时添加非打断分隔符并在搜索时保留正确的大小写
-Merge_entries=合并选中记录
-Merged_entries=已合并选中记录
-Merged_entry=已合并的记录
+Format\ units\ by\ adding\ non-breaking\ separators\ and\ keeping\ the\ correct\ case\ on\ search=对单元格式化时添加非打断分隔符并在搜索时保留正确的大小写
+Merge\ entries=合并选中记录
+Merged\ entries=已合并选中记录
+Merged\ entry=已合并的记录
 None=空
 Parse=解析
 Result=结果
-Show_DOI_first=优先显示_DOI
-Show_URL_first=优先显示_URL
-Use_Emacs_key_bindings=使用_Emacs_快捷键映射
-You_have_to_choose_exactly_two_entries_to_merge.=
+Show\ DOI\ first=优先显示 DOI
+Show\ URL\ first=优先显示 URL
+Use\ Emacs\ key\ bindings=使用 Emacs 快捷键映射
+You\ have\ to\ choose\ exactly\ two\ entries\ to\ merge.=
 
-Update_timestamp_on_modification=修改记录时更新时间戳
-All_key_bindings_will_be_reset_to_their_defaults.=
+Update\ timestamp\ on\ modification=修改记录时更新时间戳
+All\ key\ bindings\ will\ be\ reset\ to\ their\ defaults.=
 
-Automatically_set_file_links=自动设置文件链接
-Resetting_all_key_bindings=
+Automatically\ set\ file\ links=自动设置文件链接
+Resetting\ all\ key\ bindings=
 Hostname=主机名
-Invalid_setting=非法的设置
+Invalid\ setting=非法的设置
 Network=网络
-Please_specify_both_hostname_and_port=
-Please_specify_both_username_and_password=请完整填写用户名和密码
+Please\ specify\ both\ hostname\ and\ port=
+Please\ specify\ both\ username\ and\ password=请完整填写用户名和密码
 
-Use_custom_proxy_configuration=使用自定义_HTTP_代理
-Proxy_requires_authentication=HTTP_代理要求认证
-Attention\:_Password_is_stored_in_plain_text\!=注意\:_密码以明文形式保存\!
-Clear_connection_settings=
-Cleared_connection_settings.=
+Use\ custom\ proxy\ configuration=使用自定义 HTTP 代理
+Proxy\ requires\ authentication=HTTP 代理要求认证
+Attention\:\ Password\ is\ stored\ in\ plain\ text\!=注意: 密码以明文形式保存!
+Clear\ connection\ settings=
+Cleared\ connection\ settings.=
 
-Rebind_C-a,_too=
-Rebind_C-f,_too=
+Rebind\ C-a,\ too=
+Rebind\ C-f,\ too=
 
-Open_folder=打开文件夹
-Searches_for_unlinked_PDF_files_on_the_file_system=
-Export_entries_ordered_as_specified=按照下述顺序导出记录
-Export_sort_order=导出顺序
-Export_sorting=导出排序
-Newline_separator=换行符
+Open\ folder=打开文件夹
+Searches\ for\ unlinked\ PDF\ files\ on\ the\ file\ system=
+Export\ entries\ ordered\ as\ specified=按照下述顺序导出记录
+Export\ sort\ order=导出顺序
+Export\ sorting=导出排序
+Newline\ separator=换行符
 
-Save_entries_ordered_as_specified=以下述顺序保存记录
-Save_sort_order=记录保存顺序
-Show_extra_columns=显示额外的列
-Parsing_error=解析错误
-illegal_backslash_expression=
+Save\ entries\ ordered\ as\ specified=以下述顺序保存记录
+Save\ sort\ order=记录保存顺序
+Show\ extra\ columns=显示额外的列
+Parsing\ error=解析错误
+illegal\ backslash\ expression=
 
-Move_to_group=移动到分组
+Move\ to\ group=移动到分组
 
-Clear_read_status=清除已读状态
-Convert_to_biblatex_format_(for_example,_move_the_value_of_the_'journal'_field_to_'journaltitle')=
-Could_not_apply_changes.=
-Deprecated_fields=废弃的字段
-Hide/show_toolbar=隐藏/显示工具栏
-No_read_status_information=
+Clear\ read\ status=清除已读状态
+Convert\ to\ biblatex\ format\ (for\ example,\ move\ the\ value\ of\ the\ 'journal'\ field\ to\ 'journaltitle')=
+Could\ not\ apply\ changes.=
+Deprecated\ fields=废弃的字段
+Hide/show\ toolbar=隐藏/显示工具栏
+No\ read\ status\ information=
 Printed=已打印
-Read_status=已读状态
-Read_status_read=
-Read_status_skimmed=
-Save_selected_as_plain_BibTeX...=选择记录另存为_BibTeX_纯文本...
-Set_read_status_to_read=
-Set_read_status_to_skimmed=
-Show_deprecated_BibTeX_fields=
+Read\ status=已读状态
+Read\ status\ read=
+Read\ status\ skimmed=
+Save\ selected\ as\ plain\ BibTeX...=选择记录另存为 BibTeX 纯文本...
+Set\ read\ status\ to\ read=
+Set\ read\ status\ to\ skimmed=
+Show\ deprecated\ BibTeX\ fields=
 
-Show_gridlines=显示边框
-Show_printed_status=显示打印状态
-Show_read_status=显示已读状态
-Table_row_height_padding=表格行高
+Show\ gridlines=显示边框
+Show\ printed\ status=显示打印状态
+Show\ read\ status=显示已读状态
+Table\ row\ height\ padding=表格行高
 
-Marked_selected_entry=标记选中的记录
-Marked_all_%0_selected_entries=标记共_%0_条选中的记录
-Unmarked_selected_entry=已取消标记选中的记录
-Unmarked_all_%0_selected_entries=已取消标记共_%0_条选中的记录
+Marked\ selected\ entry=标记选中的记录
+Marked\ all\ %0\ selected\ entries=标记共 %0 条选中的记录
+Unmarked\ selected\ entry=已取消标记选中的记录
+Unmarked\ all\ %0\ selected\ entries=已取消标记共 %0 条选中的记录
 
 
-Unmarked_all_entries=已取消标记所有记录
+Unmarked\ all\ entries=已取消标记所有记录
 
-Unable_to_find_the_requested_look_and_feel_and_thus_the_default_one_is_used.=无法找到要求的显示效果类，使用默认显示效果。
+Unable\ to\ find\ the\ requested\ look\ and\ feel\ and\ thus\ the\ default\ one\ is\ used.=无法找到要求的显示效果类，使用默认显示效果。
 
-Opens_JabRef's_GitHub_page=打开_JabRef_的_GitHub_主页
-Could_not_open_browser.=无法打开浏览器。
-Please_open_%0_manually.=
-The_link_has_been_copied_to_the_clipboard.=
+Opens\ JabRef's\ GitHub\ page=打开 JabRef 的 GitHub 主页
+Could\ not\ open\ browser.=无法打开浏览器。
+Please\ open\ %0\ manually.=
+The\ link\ has\ been\ copied\ to\ the\ clipboard.=
 
-Open_%0_file=打开文件_%0
+Open\ %0\ file=打开文件 %0
 
-Cannot_delete_file=无法删除文件
-File_permission_error=
-Push_to_%0=推送到_%0
-Path_to_%0=到_%0_管道的路径
+Cannot\ delete\ file=无法删除文件
+File\ permission\ error=
+Push\ to\ %0=推送到 %0
+Path\ to\ %0=到 %0 管道的路径
 Convert=转换
-Normalize_to_BibTeX_name_format=
-Help_on_Name_Formatting=
+Normalize\ to\ BibTeX\ name\ format=
+Help\ on\ Name\ Formatting=
 
-Add_new_file_type=
+Add\ new\ file\ type=
 
-Left_entry=
-Right_entry=
+Left\ entry=
+Right\ entry=
 Use=使用
-Original_entry=
-Replace_original_entry=
-No_information_added=
-Select_at_least_one_entry_to_manage_keywords.=选中至少一条记录来管理关键字.
-OpenDocument_text=OpenDocument_text
-OpenDocument_spreadsheet=OpenDocument_spreadsheet
-OpenDocument_presentation=OpenDocument_presentation
-%0_image=
-Added_entry=已添加记录
-Modified_entry=已修改记录
-Deleted_entry=已删除记录
-Modified_groups_tree=已修改分组树
-Removed_all_groups=已移除所有分组
-Accepting_the_change_replaces_the_complete_groups_tree_with_the_externally_modified_groups_tree.=
-Select_export_format=选择导出格式
-Return_to_JabRef=返回_JabRef
-Please_move_the_file_manually_and_link_in_place.=
-Could_not_connect_to_%0=无法连接到_%0
-Warning\:_%0_out_of_%1_entries_have_undefined_title.=
-Warning\:_%0_out_of_%1_entries_have_undefined_BibTeX_key.=警告：_%1_条记录中有_%0_条包含未定义的_BibTeX_键值。
+Original\ entry=
+Replace\ original\ entry=
+No\ information\ added=
+Select\ at\ least\ one\ entry\ to\ manage\ keywords.=选中至少一条记录来管理关键字.
+OpenDocument\ text=OpenDocument text
+OpenDocument\ spreadsheet=OpenDocument spreadsheet
+OpenDocument\ presentation=OpenDocument presentation
+%0\ image=
+Added\ entry=已添加记录
+Modified\ entry=已修改记录
+Deleted\ entry=已删除记录
+Modified\ groups\ tree=已修改分组树
+Removed\ all\ groups=已移除所有分组
+Accepting\ the\ change\ replaces\ the\ complete\ groups\ tree\ with\ the\ externally\ modified\ groups\ tree.=
+Select\ export\ format=选择导出格式
+Return\ to\ JabRef=返回 JabRef
+Please\ move\ the\ file\ manually\ and\ link\ in\ place.=
+Could\ not\ connect\ to\ %0=无法连接到 %0
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ title.=
+Warning\:\ %0\ out\ of\ %1\ entries\ have\ undefined\ BibTeX\ key.=警告： %1 条记录中有 %0 条包含未定义的 BibTeX 键值。
 occurrence=
-Added_new_'%0'_entry.=已添加新_'%0'_记录。
-Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?=已选中多条记录，您希望将所有选中记录都修改为_%0_类型？
-Changed_type_to_'%0'_for=
-Really_delete_the_selected_entry?=确定删除选中的记录？
-Really_delete_the_%0_selected_entries?=确定删除选中的_%0_条记录？
-Keep_merged_entry_only=只保留合并后的记录
-Keep_left=保留左侧
-Keep_right=保留右侧
-Old_entry=
-From_import=
-No_problems_found.=没有发现问题。
-%0_problem(s)_found=
-Save_changes=保存修改
-Discard_changes=放弃修改
-Library_'%0'_has_changed.=文献库_'%0'_已修改。
-Print_entry_preview=打印记录预览
-Copy_title=
-Copy_\\cite{BibTeX_key}=复制_\\cite{BibTeX_键值}
-Copy_BibTeX_key_and_title=复制_BibTeX_键值和标题
-File_rename_failed_for_%0_entries.=
-Merged_BibTeX_source_code=已合并_BibTeX_源代码
-Invalid_DOI\:_'%0'.=不合法的_DOI\:
-should_start_with_a_name=
-should_end_with_a_name=
-unexpected_closing_curly_bracket=
-unexpected_opening_curly_bracket=
-capital_letters_are_not_masked_using_curly_brackets_{}=大写字符没有使用花括号_{}_括起来
-should_contain_a_four_digit_number=应该包含一个_4_位数字
-should_contain_a_valid_page_number_range=应该包含一个合法的页码范围
+Added\ new\ '%0'\ entry.=已添加新 '%0' 记录。
+Multiple\ entries\ selected.\ Do\ you\ want\ to\ change\ the\ type\ of\ all\ these\ to\ '%0'?=已选中多条记录，您希望将所有选中记录都修改为 %0 类型？
+Changed\ type\ to\ '%0'\ for=
+Really\ delete\ the\ selected\ entry?=确定删除选中的记录？
+Really\ delete\ the\ %0\ selected\ entries?=确定删除选中的 %0 条记录？
+Keep\ merged\ entry\ only=只保留合并后的记录
+Keep\ left=保留左侧
+Keep\ right=保留右侧
+Old\ entry=
+From\ import=
+No\ problems\ found.=没有发现问题。
+%0\ problem(s)\ found=
+Save\ changes=保存修改
+Discard\ changes=放弃修改
+Library\ '%0'\ has\ changed.=文献库 '%0' 已修改。
+Print\ entry\ preview=打印记录预览
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=复制 \\cite{BibTeX 键值}
+Copy\ BibTeX\ key\ and\ title=复制 BibTeX 键值和标题
+File\ rename\ failed\ for\ %0\ entries.=
+Merged\ BibTeX\ source\ code=已合并 BibTeX 源代码
+Invalid\ DOI\:\ '%0'.=不合法的 DOI:
+should\ start\ with\ a\ name=
+should\ end\ with\ a\ name=
+unexpected\ closing\ curly\ bracket=
+unexpected\ opening\ curly\ bracket=
+capital\ letters\ are\ not\ masked\ using\ curly\ brackets\ {}=大写字符没有使用花括号 {} 括起来
+should\ contain\ a\ four\ digit\ number=应该包含一个 4 位数字
+should\ contain\ a\ valid\ page\ number\ range=应该包含一个合法的页码范围
 Filled=
-Field_is_missing=
-Search_%0=搜索_%0
+Field\ is\ missing=
+Search\ %0=搜索 %0
 
-Search_results_in_all_libraries_for_%0=在所有数据库中搜索_%0_的结果
-Search_results_in_library_%0_for_%1=在文献库_%0_中搜索_%1_的结果
-Search_globally=全局搜索
-No_results_found.=没有找到结果.
-Found_%0_results.=找到_%0_条结果.
-plain_text=纯文本
-This_search_contains_entries_in_which_any_field_contains_the_regular_expression_<b>%0</b>=这次搜索的结果记录符合条件：记录的任意域包含正则表达式_<b>%0</b>
-This_search_contains_entries_in_which_any_field_contains_the_term_<b>%0</b>=这次搜索的结果记录符合条件：记录的任意域包含词组_<b>%0</b>
-This_search_contains_entries_in_which=这次搜索的结果记录符合条件：
+Search\ results\ in\ all\ libraries\ for\ %0=在所有数据库中搜索 %0 的结果
+Search\ results\ in\ library\ %0\ for\ %1=在文献库 %0 中搜索 %1 的结果
+Search\ globally=全局搜索
+No\ results\ found.=没有找到结果.
+Found\ %0\ results.=找到 %0 条结果.
+plain\ text=纯文本
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ regular\ expression\ <b>%0</b>=这次搜索的结果记录符合条件：记录的任意域包含正则表达式 <b>%0</b>
+This\ search\ contains\ entries\ in\ which\ any\ field\ contains\ the\ term\ <b>%0</b>=这次搜索的结果记录符合条件：记录的任意域包含词组 <b>%0</b>
+This\ search\ contains\ entries\ in\ which=这次搜索的结果记录符合条件：
 
-Unable_to_autodetect_OpenOffice/LibreOffice_installation._Please_choose_the_installation_directory_manually.=自动检测_OpenOffice/LibreOffice_安装位置失败，请手动指定安装目录。
-JabRef_no_longer_supports_'ps'_or_'pdf'_fields.<br>File_links_are_now_stored_in_the_'file'_field_and_files_are_stored_in_an_external_file_directory.<br>To_make_use_of_this_feature,_JabRef_needs_to_upgrade_file_links.<br><br>=JabRef_不再支持_"ps"_或_"pdf"_域。<br>新版本将文件链接保存在_"file"_域中，文件保存在外部文件目录中。<br>为了启用新的特性，JabRef_需要升级文件链接。<br><br>
-This_library_uses_outdated_file_links.=这个文献库使用了过期的文件链接。
+Unable\ to\ autodetect\ OpenOffice/LibreOffice\ installation.\ Please\ choose\ the\ installation\ directory\ manually.=自动检测 OpenOffice/LibreOffice 安装位置失败，请手动指定安装目录。
+JabRef\ no\ longer\ supports\ 'ps'\ or\ 'pdf'\ fields.<br>File\ links\ are\ now\ stored\ in\ the\ 'file'\ field\ and\ files\ are\ stored\ in\ an\ external\ file\ directory.<br>To\ make\ use\ of\ this\ feature,\ JabRef\ needs\ to\ upgrade\ file\ links.<br><br>=JabRef 不再支持 "ps" 或 "pdf" 域。<br>新版本将文件链接保存在 "file" 域中，文件保存在外部文件目录中。<br>为了启用新的特性，JabRef 需要升级文件链接。<br><br>
+This\ library\ uses\ outdated\ file\ links.=这个文献库使用了过期的文件链接。
 
-Clear_search=清除搜索
-Close_library=关闭文献库
-Close_entry_editor=关闭记录编辑器
-Decrease_table_font_size=减小表格字号
-Entry_editor,_next_entry=记录编辑器，下一条记录
-Entry_editor,_next_panel=记录编辑器，下一个面板
-Entry_editor,_next_panel_2=记录编辑器，下一个面板_2
-Entry_editor,_previous_entry=记录编辑器，上一条记录
-Entry_editor,_previous_panel=记录编辑器，上一个面板
-Entry_editor,_previous_panel_2=记录编辑器，上一个面板_2
-File_list_editor,_move_entry_down=文件列表编辑器，下移记录
-File_list_editor,_move_entry_up=文件列表编辑器，上移记录
-Focus_entry_table=激活记录列表
-Import_into_current_library=导入当前文献库
-Import_into_new_library=导入新建文献库
-Increase_table_font_size=增大表格字号
-New_article=新建_article
-New_book=新建_book
-New_entry=新建记录
-New_from_plain_text=从纯文本新建
-New_inbook=新建_inbook
-New_mastersthesis=新建_mastersthesis
-New_phdthesis=新建_phdthesis
-New_proceedings=新建_proceedings
-New_unpublished=新建_unpublished
-Next_tab=下个标签
-Preamble_editor,_store_changes=导言编辑器，保存修改
-Previous_tab=上一标签
-Push_to_application=推送到应用
-Refresh_OpenOffice/LibreOffice=刷新_penOffice/LibreOffice
-Resolve_duplicate_BibTeX_keys=处理重复的_BibTeX_键值
-Save_all=保存所有
-String_dialog,_add_string=简写字串对话框，添加简写字串
-String_dialog,_remove_string=简写字串对话框，删除简写字串
-Synchronize_files=同步文件
+Clear\ search=清除搜索
+Close\ library=关闭文献库
+Close\ entry\ editor=关闭记录编辑器
+Decrease\ table\ font\ size=减小表格字号
+Entry\ editor,\ next\ entry=记录编辑器，下一条记录
+Entry\ editor,\ next\ panel=记录编辑器，下一个面板
+Entry\ editor,\ next\ panel\ 2=记录编辑器，下一个面板 2
+Entry\ editor,\ previous\ entry=记录编辑器，上一条记录
+Entry\ editor,\ previous\ panel=记录编辑器，上一个面板
+Entry\ editor,\ previous\ panel\ 2=记录编辑器，上一个面板 2
+File\ list\ editor,\ move\ entry\ down=文件列表编辑器，下移记录
+File\ list\ editor,\ move\ entry\ up=文件列表编辑器，上移记录
+Focus\ entry\ table=激活记录列表
+Import\ into\ current\ library=导入当前文献库
+Import\ into\ new\ library=导入新建文献库
+Increase\ table\ font\ size=增大表格字号
+New\ article=新建 article
+New\ book=新建 book
+New\ entry=新建记录
+New\ from\ plain\ text=从纯文本新建
+New\ inbook=新建 inbook
+New\ mastersthesis=新建 mastersthesis
+New\ phdthesis=新建 phdthesis
+New\ proceedings=新建 proceedings
+New\ unpublished=新建 unpublished
+Next\ tab=下个标签
+Preamble\ editor,\ store\ changes=导言编辑器，保存修改
+Previous\ tab=上一标签
+Push\ to\ application=推送到应用
+Refresh\ OpenOffice/LibreOffice=刷新 penOffice/LibreOffice
+Resolve\ duplicate\ BibTeX\ keys=处理重复的 BibTeX 键值
+Save\ all=保存所有
+String\ dialog,\ add\ string=简写字串对话框，添加简写字串
+String\ dialog,\ remove\ string=简写字串对话框，删除简写字串
+Synchronize\ files=同步文件
 Unabbreviate=展开缩写
-should_contain_a_protocol=
-Copy_preview=拷贝预览
-Automatically_setting_file_links=自动设置文件链接
-Regenerating_BibTeX_keys_according_to_metadata=基于_metadata_重新生成_BibTeX_键值
-No_meta_data_present_in_BIB_file._Cannot_regenerate_BibTeX_keys=在_BIB_file_中没有找到_meta_data，无法重建_BibTeX_key
-Regenerate_all_keys_for_the_entries_in_a_BibTeX_file=重新生成_BibTeX_文件中所有记录的键值
-Show_debug_level_messages=显示调试级别消息
-Default_bibliography_mode=默认的参考文献模式
-New_%0_library_created.=成功新建文献库_%0.
-Show_only_preferences_deviating_from_their_default_value=只显示与默认值不同的首选项
+should\ contain\ a\ protocol=
+Copy\ preview=拷贝预览
+Automatically\ setting\ file\ links=自动设置文件链接
+Regenerating\ BibTeX\ keys\ according\ to\ metadata=基于 metadata 重新生成 BibTeX 键值
+No\ meta\ data\ present\ in\ BIB\ file.\ Cannot\ regenerate\ BibTeX\ keys=在 BIB file 中没有找到 meta data，无法重建 BibTeX key
+Regenerate\ all\ keys\ for\ the\ entries\ in\ a\ BibTeX\ file=重新生成 BibTeX 文件中所有记录的键值
+Show\ debug\ level\ messages=显示调试级别消息
+Default\ bibliography\ mode=默认的参考文献模式
+New\ %0\ library\ created.=成功新建文献库 %0.
+Show\ only\ preferences\ deviating\ from\ their\ default\ value=只显示与默认值不同的首选项
 default=默认
 key=键值
 type=类型
 value=值
-Show_preferences=列表显示首选项
-Save_actions=保存时附加操作
-Enable_save_actions=启用保存附加操作
+Show\ preferences=列表显示首选项
+Save\ actions=保存时附加操作
+Enable\ save\ actions=启用保存附加操作
 
-Other_fields=其它域
-Show_remaining_fields=显示其它的域
+Other\ fields=其它域
+Show\ remaining\ fields=显示其它的域
 
-link_should_refer_to_a_correct_file_path=链接应该指向一个正确的文件路径
-abbreviation_detected=检测到缩写
-wrong_entry_type_as_proceedings_has_page_numbers=
-Abbreviate_journal_names=缩写期刊名
+link\ should\ refer\ to\ a\ correct\ file\ path=链接应该指向一个正确的文件路径
+abbreviation\ detected=检测到缩写
+wrong\ entry\ type\ as\ proceedings\ has\ page\ numbers=
+Abbreviate\ journal\ names=缩写期刊名
 Abbreviating...=正在缩写...
-Abbreviation_%s_for_journal_%s_already_defined.=
-Abbreviation_cannot_be_empty=
-Duplicated_Journal_Abbreviation=
-Duplicated_Journal_File=
-Error_Occurred=
-Journal_file_%s_already_added=
-Name_cannot_be_empty=
+Abbreviation\ %s\ for\ journal\ %s\ already\ defined.=
+Abbreviation\ cannot\ be\ empty=
+Duplicated\ Journal\ Abbreviation=
+Duplicated\ Journal\ File=
+Error\ Occurred=
+Journal\ file\ %s\ already\ added=
+Name\ cannot\ be\ empty=
 
-Adding_fetched_entries=正在添加抓取的记录
-Display_keywords_appearing_in_ALL_entries=
-Display_keywords_appearing_in_ANY_entry=
-Fetching_entries_from_Inspire=从_Inspire_抓取记录
-None_of_the_selected_entries_have_titles.=
-None_of_the_selected_entries_have_BibTeX_keys.=选中的记录都不包含_BibTeX_键值。
-Unabbreviate_journal_names=展开期刊名缩写
+Adding\ fetched\ entries=正在添加抓取的记录
+Display\ keywords\ appearing\ in\ ALL\ entries=
+Display\ keywords\ appearing\ in\ ANY\ entry=
+Fetching\ entries\ from\ Inspire=从 Inspire 抓取记录
+None\ of\ the\ selected\ entries\ have\ titles.=
+None\ of\ the\ selected\ entries\ have\ BibTeX\ keys.=选中的记录都不包含 BibTeX 键值。
+Unabbreviate\ journal\ names=展开期刊名缩写
 Unabbreviating...=正在展开缩写...
 Usage=用法
 
 
-Adds_{}_brackets_around_acronyms,_month_names_and_countries_to_preserve_their_case.=为_%s_里的缩略语、月份和国家添加花括号_{}_以保持大小写不变。
-Are_you_sure_you_want_to_reset_all_settings_to_default_values?=您确认希望将所有设置重置为默认值吗？
-Reset_preferences=重置所有首选项
-Ill-formed_entrytype_comment_in_BIB_file=
+Adds\ {}\ brackets\ around\ acronyms,\ month\ names\ and\ countries\ to\ preserve\ their\ case.=为 %s 里的缩略语、月份和国家添加花括号 {} 以保持大小写不变。
+Are\ you\ sure\ you\ want\ to\ reset\ all\ settings\ to\ default\ values?=您确认希望将所有设置重置为默认值吗？
+Reset\ preferences=重置所有首选项
+Ill-formed\ entrytype\ comment\ in\ BIB\ file=
 
-Move_linked_files_to_default_file_directory_%0=移动链接的文件到默认文件目录_%0
+Move\ linked\ files\ to\ default\ file\ directory\ %0=移动链接的文件到默认文件目录 %0
 
 Clipboard=剪贴板
-Could_not_paste_entry_as_text\:=
-Do_you_still_want_to_continue?=是否继续？
-This_action_will_modify_the_following_field(s)_in_at_least_one_entry_each\:=
-This_could_cause_undesired_changes_to_your_entries.=
-Run_field_formatter\:=
-Table_font_size_is_%0=表格字号是_%0
-%0_import_canceled=%0_导入被取消
-Internal_style=内部样式
-Add_style_file=添加样式文件
-Are_you_sure_you_want_to_remove_the_style?=
-Current_style_is_'%0'=
-Remove_style=移除样式
-Select_one_of_the_available_styles_or_add_a_style_file_from_disk.=
-You_must_select_a_valid_style_file.=
+Could\ not\ paste\ entry\ as\ text\:=
+Do\ you\ still\ want\ to\ continue?=是否继续？
+This\ action\ will\ modify\ the\ following\ field(s)\ in\ at\ least\ one\ entry\ each\:=
+This\ could\ cause\ undesired\ changes\ to\ your\ entries.=
+Run\ field\ formatter\:=
+Table\ font\ size\ is\ %0=表格字号是 %0
+%0\ import\ canceled=%0 导入被取消
+Internal\ style=内部样式
+Add\ style\ file=添加样式文件
+Are\ you\ sure\ you\ want\ to\ remove\ the\ style?=
+Current\ style\ is\ '%0'=
+Remove\ style=移除样式
+Select\ one\ of\ the\ available\ styles\ or\ add\ a\ style\ file\ from\ disk.=
+You\ must\ select\ a\ valid\ style\ file.=
 Reload=刷新
 
 Capitalize=
-Capitalize_all_words,_but_converts_articles,_prepositions,_and_conjunctions_to_lower_case.=将所有单词大写，不过将_articles,_prepositions_和_conjunctions_转为小写。
-Capitalize_the_first_word,_changes_other_words_to_lower_case.=将每句话第一个字母大写,_其余单词改为小写.
-Changes_all_letters_to_lower_case.=将所有字母改为小写.
-Changes_all_letters_to_upper_case.=将所有字母改为大写.
-Changes_the_first_letter_of_all_words_to_capital_case_and_the_remaining_letters_to_lower_case.=将每个单词的第一个字母改为大写,_其它字母改为小写.
-Cleans_up_LaTeX_code.=清理_LaTeX_代码
-Converts_HTML_code_to_LaTeX_code.=将_HTML_代码转换为_LaTeX_代码。
-Converts_HTML_code_to_Unicode.=
-Converts_LaTeX_encoding_to_Unicode_characters.=将_LaTeX_编码转换为_Unicode_字符。
-Converts_Unicode_characters_to_LaTeX_encoding.=将_Unicode_字符转换为_LaTeX_编码
-Converts_ordinals_to_LaTeX_superscripts.=将序号转换成_LaTeX_上标。
-Converts_units_to_LaTeX_formatting.=
-HTML_to_LaTeX=HTML_转_LaTeX
-LaTeX_cleanup=清理_LaTeX
-LaTeX_to_Unicode=LaTeX_转_Unicode
-Lower_case=改为小写
-Minify_list_of_person_names=
-Normalize_date=规范化日期格式
-Normalize_month=规范化月份格式
-Normalize_month_to_BibTeX_standard_abbreviation.=规范化月份为_BibTeX_标准缩写.
-Normalize_names_of_persons=规范化人名格式
-Normalize_page_numbers=规范化页码格式
-Normalize_pages_to_BibTeX_standard.=规范化_pages_为_BibTeX_标准.
-Normalizes_lists_of_persons_to_the_BibTeX_standard.=规范化人名列表为_BibTeX_标准.
-Normalizes_the_date_to_ISO_date_format.=规范化日期为_ISO_日期格式.
-Ordinals_to_LaTeX_superscript=序号转为_LaTeX_上标
-Protect_terms=保护专有名词
-Remove_enclosing_braces=移除外围花括号
-Removes_braces_encapsulating_the_complete_field_content.=移除包含整个字段内容的括号。
-Sentence_case=句首大写
-Shortens_lists_of_persons_if_there_are_more_than_2_persons_to_"et_al.".=将多于_2_人的人名列表简化为_"et_al."。
-Title_case=首字母大写
-Unicode_to_LaTeX=
-Units_to_LaTeX=
-Upper_case=改为大写
-Does_nothing.=什么都没干。
+Capitalize\ all\ words,\ but\ converts\ articles,\ prepositions,\ and\ conjunctions\ to\ lower\ case.=将所有单词大写，不过将 articles, prepositions 和 conjunctions 转为小写。
+Capitalize\ the\ first\ word,\ changes\ other\ words\ to\ lower\ case.=将每句话第一个字母大写, 其余单词改为小写.
+Changes\ all\ letters\ to\ lower\ case.=将所有字母改为小写.
+Changes\ all\ letters\ to\ upper\ case.=将所有字母改为大写.
+Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=将每个单词的第一个字母改为大写, 其它字母改为小写.
+Cleans\ up\ LaTeX\ code.=清理 LaTeX 代码
+Converts\ HTML\ code\ to\ LaTeX\ code.=将 HTML 代码转换为 LaTeX 代码。
+Converts\ HTML\ code\ to\ Unicode.=
+Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=将 LaTeX 编码转换为 Unicode 字符。
+Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=将 Unicode 字符转换为 LaTeX 编码
+Converts\ ordinals\ to\ LaTeX\ superscripts.=将序号转换成 LaTeX 上标。
+Converts\ units\ to\ LaTeX\ formatting.=
+HTML\ to\ LaTeX=HTML 转 LaTeX
+LaTeX\ cleanup=清理 LaTeX
+LaTeX\ to\ Unicode=LaTeX 转 Unicode
+Lower\ case=改为小写
+Minify\ list\ of\ person\ names=
+Normalize\ date=规范化日期格式
+Normalize\ month=规范化月份格式
+Normalize\ month\ to\ BibTeX\ standard\ abbreviation.=规范化月份为 BibTeX 标准缩写.
+Normalize\ names\ of\ persons=规范化人名格式
+Normalize\ page\ numbers=规范化页码格式
+Normalize\ pages\ to\ BibTeX\ standard.=规范化 pages 为 BibTeX 标准.
+Normalizes\ lists\ of\ persons\ to\ the\ BibTeX\ standard.=规范化人名列表为 BibTeX 标准.
+Normalizes\ the\ date\ to\ ISO\ date\ format.=规范化日期为 ISO 日期格式.
+Ordinals\ to\ LaTeX\ superscript=序号转为 LaTeX 上标
+Protect\ terms=保护专有名词
+Remove\ enclosing\ braces=移除外围花括号
+Removes\ braces\ encapsulating\ the\ complete\ field\ content.=移除包含整个字段内容的括号。
+Sentence\ case=句首大写
+Shortens\ lists\ of\ persons\ if\ there\ are\ more\ than\ 2\ persons\ to\ "et\ al.".=将多于 2 人的人名列表简化为 "et al."。
+Title\ case=首字母大写
+Unicode\ to\ LaTeX=
+Units\ to\ LaTeX=
+Upper\ case=改为大写
+Does\ nothing.=什么都没干。
 Identity=
-Clears_the_field_completely.=完全清除这个字段。
-Directory_not_found=目录未找到
-Main_file_directory_not_set\!=未设置主文件目录\!
-This_operation_requires_exactly_one_item_to_be_selected.=这个操作仅限对选中的一条记录进行。
-Importing_in_%0_format=正在以_%0_格式导入
-Female_name=
-Female_names=
-Male_name=
-Male_names=
-Mixed_names=
-Neuter_name=
-Neuter_names=
+Clears\ the\ field\ completely.=完全清除这个字段。
+Directory\ not\ found=目录未找到
+Main\ file\ directory\ not\ set\!=未设置主文件目录!
+This\ operation\ requires\ exactly\ one\ item\ to\ be\ selected.=这个操作仅限对选中的一条记录进行。
+Importing\ in\ %0\ format=正在以 %0 格式导入
+Female\ name=
+Female\ names=
+Male\ name=
+Male\ names=
+Mixed\ names=
+Neuter\ name=
+Neuter\ names=
 
-Determined_%0_for_%1_entries=
-Look_up_%0=
-Looking_up_%0..._-_entry_%1_out_of_%2_-_found_%3=
+Determined\ %0\ for\ %1\ entries=
+Look\ up\ %0=
+Looking\ up\ %0...\ -\ entry\ %1\ out\ of\ %2\ -\ found\ %3=
 
-Audio_CD=
-British_patent=
-British_patent_request=
-Candidate_thesis=
+Audio\ CD=
+British\ patent=
+British\ patent\ request=
+Candidate\ thesis=
 Collaborator=
 Column=
 Compiler=
 Continuator=
-Data_CD=
+Data\ CD=
 Editor=
-European_patent=
-European_patent_request=
+European\ patent=
+European\ patent\ request=
 Founder=
-French_patent=
-French_patent_request=
-German_patent=
-German_patent_request=
+French\ patent=
+French\ patent\ request=
+German\ patent=
+German\ patent\ request=
 Line=
-Master's_thesis=
+Master's\ thesis=
 Page=页面
 Paragraph=
 Patent=
-Patent_request=
-PhD_thesis=
+Patent\ request=
+PhD\ thesis=
 Redactor=
-Research_report=
+Research\ report=
 Reviser=
 Section=
 Software=
-Technical_report=
-U.S._patent=
-U.S._patent_request=
+Technical\ report=
+U.S.\ patent=
+U.S.\ patent\ request=
 Verse=
 
-change_entries_of_group=
-odd_number_of_unescaped_'\#'=
+change\ entries\ of\ group=
+odd\ number\ of\ unescaped\ '\#'=
 
-Plain_text=
-Show_diff=
+Plain\ text=
+Show\ diff=
 character=
 word=
-Show_symmetric_diff=
-Copy_Version=
+Show\ symmetric\ diff=
+Copy\ Version=
 Developers=
 Authors=作者
 License=
 
-HTML_encoded_character_found=
-booktitle_ends_with_'conference_on'=
+HTML\ encoded\ character\ found=
+booktitle\ ends\ with\ 'conference\ on'=
 
-All_external_files=
+All\ external\ files=
 
-OpenOffice/LibreOffice_integration=
+OpenOffice/LibreOffice\ integration=
 
-incorrect_control_digit=
-incorrect_format=
-Copied_version_to_clipboard=
+incorrect\ control\ digit=
+incorrect\ format=
+Copied\ version\ to\ clipboard=
 
-BibTeX_key=BibTeX_键
+BibTeX\ key=BibTeX 键
 Message=消息
 
 
-MathSciNet_Review=
-Reset_Bindings=
+MathSciNet\ Review=
+Reset\ Bindings=
 
-Decryption_not_supported.=
+Decryption\ not\ supported.=
 
-Cleared_'%0'_for_%1_entries=
-Set_'%0'_to_'%1'_for_%2_entries=
-Toggled_'%0'_for_%1_entries=
+Cleared\ '%0'\ for\ %1\ entries=
+Set\ '%0'\ to\ '%1'\ for\ %2\ entries=
+Toggled\ '%0'\ for\ %1\ entries=
 
-Check_for_updates=检查更新
-Download_update=下载更新
-New_version_available=发现新版本
-Installed_version=当前版本
-Remind_me_later=稍后提醒我
-Ignore_this_update=跳过这次更新
-Could_not_connect_to_the_update_server.=无法连接到更新服务器.
-Please_try_again_later_and/or_check_your_network_connection.=请重试并检查你的互联网连接.
-To_see_what_is_new_view_the_changelog.=查看更新内容.
-A_new_version_of_JabRef_has_been_released.=发现新版本_JabRef.
-JabRef_is_up-to-date.=JabRef_是最新版本.
-Latest_version=最新版本
-Online_help_forum=在线讨论区
+Check\ for\ updates=检查更新
+Download\ update=下载更新
+New\ version\ available=发现新版本
+Installed\ version=当前版本
+Remind\ me\ later=稍后提醒我
+Ignore\ this\ update=跳过这次更新
+Could\ not\ connect\ to\ the\ update\ server.=无法连接到更新服务器.
+Please\ try\ again\ later\ and/or\ check\ your\ network\ connection.=请重试并检查你的互联网连接.
+To\ see\ what\ is\ new\ view\ the\ changelog.=查看更新内容.
+A\ new\ version\ of\ JabRef\ has\ been\ released.=发现新版本 JabRef.
+JabRef\ is\ up-to-date.=JabRef 是最新版本.
+Latest\ version=最新版本
+Online\ help\ forum=在线讨论区
 Custom=
 
-Export_cited=
-Unable_to_generate_new_library=
+Export\ cited=
+Unable\ to\ generate\ new\ library=
 
-Open_console=打开终端程序
-Use_default_terminal_emulator=使用默认的模拟终端
-Execute_command=执行命令
-Note\:_Use_the_placeholder_%0_for_the_location_of_the_opened_library_file.=注意\:_使用_%0_占位符来表示当前打开的文献库文件位置.
-Executing_command_\"%0\"...=
-Error_occured_while_executing_the_command_\"%0\".=
-Reformat_ISSN=
+Open\ console=打开终端程序
+Use\ default\ terminal\ emulator=使用默认的模拟终端
+Execute\ command=执行命令
+Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=注意: 使用 %0 占位符来表示当前打开的文献库文件位置.
+Executing\ command\ \"%0\"...=
+Error\ occured\ while\ executing\ the\ command\ \"%0\".=
+Reformat\ ISSN=
 
-Countries_and_territories_in_English=
-Electrical_engineering_terms=
+Countries\ and\ territories\ in\ English=
+Electrical\ engineering\ terms=
 Enabled=
-Internal_list=
-Manage_protected_terms_files=
-Months_and_weekdays_in_English=
-The_text_after_the_last_line_starting_with_\#_will_be_used=
-Add_protected_terms_file=
-Are_you_sure_you_want_to_remove_the_protected_terms_file?=
-Remove_protected_terms_file=
-Add_selected_text_to_list=
-Add_{}_around_selected_text=
-Format_field=
-New_protected_terms_file=
-change_field_%0_of_entry_%1_from_%2_to_%3=
-change_key_from_%0_to_%1=
-change_string_content_%0_to_%1=
-change_string_name_%0_to_%1=
-change_type_of_entry_%0_from_%1_to_%2=
-insert_entry_%0=
-insert_string_%0=
-remove_entry_%0=
-remove_string_%0=
+Internal\ list=
+Manage\ protected\ terms\ files=
+Months\ and\ weekdays\ in\ English=
+The\ text\ after\ the\ last\ line\ starting\ with\ \#\ will\ be\ used=
+Add\ protected\ terms\ file=
+Are\ you\ sure\ you\ want\ to\ remove\ the\ protected\ terms\ file?=
+Remove\ protected\ terms\ file=
+Add\ selected\ text\ to\ list=
+Add\ {}\ around\ selected\ text=
+Format\ field=
+New\ protected\ terms\ file=
+change\ field\ %0\ of\ entry\ %1\ from\ %2\ to\ %3=
+change\ key\ from\ %0\ to\ %1=
+change\ string\ content\ %0\ to\ %1=
+change\ string\ name\ %0\ to\ %1=
+change\ type\ of\ entry\ %0\ from\ %1\ to\ %2=
+insert\ entry\ %0=
+insert\ string\ %0=
+remove\ entry\ %0=
+remove\ string\ %0=
 undefined=
-Cannot_get_info_based_on_given_%0\:_%1=
-Get_BibTeX_data_from_%0=从_%0_中获取_BibTeX_数据
-No_%0_found=
-Entry_from_%0=
-Merge_entry_with_%0_information=
-Updated_entry_with_info_from_%0=已根据_%0_更新记录
+Cannot\ get\ info\ based\ on\ given\ %0\:\ %1=
+Get\ BibTeX\ data\ from\ %0=从 %0 中获取 BibTeX 数据
+No\ %0\ found=
+Entry\ from\ %0=
+Merge\ entry\ with\ %0\ information=
+Updated\ entry\ with\ info\ from\ %0=已根据 %0 更新记录
 
-Add_existing_file=
-Create_new_list=
-Remove_list=
-Full_journal_name=
-Abbreviation_name=
+Add\ existing\ file=
+Create\ new\ list=
+Remove\ list=
+Full\ journal\ name=
+Abbreviation\ name=
 
-No_abbreviation_files_loaded=
+No\ abbreviation\ files\ loaded=
 
-Loading_built_in_lists=
+Loading\ built\ in\ lists=
 
-JabRef_built_in_list=
-IEEE_built_in_list=
+JabRef\ built\ in\ list=
+IEEE\ built\ in\ list=
 
-Event_log=
-We_now_give_you_insight_into_the_inner_workings_of_JabRef\'s_internals._This_information_might_be_helpful_to_diagnose_the_root_cause_of_a_problem._Please_feel_free_to_inform_the_developers_about_an_issue.=
-Log_copied_to_clipboard.=
-Copy_Log=
-Clear_Log=
-Report_Issue=
-Issue_on_GitHub_successfully_reported.=
-Issue_report_successful=
-Your_issue_was_reported_in_your_browser.=
-The_log_and_exception_information_was_copied_to_your_clipboard.=
-Please_paste_this_information_(with_Ctrl+V)_in_the_issue_description.=
+Event\ log=
+We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef\'s\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=
+Log\ copied\ to\ clipboard.=
+Copy\ Log=
+Clear\ Log=
+Report\ Issue=
+Issue\ on\ GitHub\ successfully\ reported.=
+Issue\ report\ successful=
+Your\ issue\ was\ reported\ in\ your\ browser.=
+The\ log\ and\ exception\ information\ was\ copied\ to\ your\ clipboard.=
+Please\ paste\ this\ information\ (with\ Ctrl+V)\ in\ the\ issue\ description.=
 
 Connection=
 Connecting...=
@@ -2164,194 +2164,194 @@ Port=端口
 Library=
 User=
 Connect=连接
-Connection_error=
-Connection_to_%0_server_established.=
-Required_field_"%0"_is_empty.=
-%0_driver_not_available.=
-The_connection_to_the_server_has_been_terminated.=
-Connection_lost.=
+Connection\ error=
+Connection\ to\ %0\ server\ established.=
+Required\ field\ "%0"\ is\ empty.=
+%0\ driver\ not\ available.=
+The\ connection\ to\ the\ server\ has\ been\ terminated.=
+Connection\ lost.=
 Reconnect=
-Work_offline=
-Working_offline.=
-Update_refused.=
-Update_refused=
-Local_entry=
-Shared_entry=
-Update_could_not_be_performed_due_to_existing_change_conflicts.=
-You_are_not_working_on_the_newest_version_of_BibEntry.=
-Local_version\:_%0=
-Shared_version\:_%0=
-Please_merge_the_shared_entry_with_yours_and_press_"Merge_entries"_to_resolve_this_problem.=
-Canceling_this_operation_will_leave_your_changes_unsynchronized._Cancel_anyway?=
-Shared_entry_is_no_longer_present=
-The_BibEntry_you_currently_work_on_has_been_deleted_on_the_shared_side.=
-You_can_restore_the_entry_using_the_"Undo"_operation.=
-Remember_password?=
-You_are_already_connected_to_a_database_using_entered_connection_details.=
+Work\ offline=
+Working\ offline.=
+Update\ refused.=
+Update\ refused=
+Local\ entry=
+Shared\ entry=
+Update\ could\ not\ be\ performed\ due\ to\ existing\ change\ conflicts.=
+You\ are\ not\ working\ on\ the\ newest\ version\ of\ BibEntry.=
+Local\ version\:\ %0=
+Shared\ version\:\ %0=
+Please\ merge\ the\ shared\ entry\ with\ yours\ and\ press\ "Merge\ entries"\ to\ resolve\ this\ problem.=
+Canceling\ this\ operation\ will\ leave\ your\ changes\ unsynchronized.\ Cancel\ anyway?=
+Shared\ entry\ is\ no\ longer\ present=
+The\ BibEntry\ you\ currently\ work\ on\ has\ been\ deleted\ on\ the\ shared\ side.=
+You\ can\ restore\ the\ entry\ using\ the\ "Undo"\ operation.=
+Remember\ password?=
+You\ are\ already\ connected\ to\ a\ database\ using\ entered\ connection\ details.=
 
-Cannot_cite_entries_without_BibTeX_keys._Generate_keys_now?=无法引用_BibTeX_键为空的记录,_现在生成键值?
-New_technical_report=
+Cannot\ cite\ entries\ without\ BibTeX\ keys.\ Generate\ keys\ now?=无法引用 BibTeX 键为空的记录, 现在生成键值?
+New\ technical\ report=
 
-%0_file=
-Custom_layout_file=
-Protected_terms_file=
-Style_file=
+%0\ file=
+Custom\ layout\ file=
+Protected\ terms\ file=
+Style\ file=
 
-Open_OpenOffice/LibreOffice_connection=
-You_must_enter_at_least_one_field_name=
-Non-ASCII_encoded_character_found=
-Toggle_web_search_interface=切换网页搜索面板
-Background_color_for_resolved_fields=resolved_域背景颜色
-Color_code_for_resolved_fields=使用颜色区分_resolved_域
-%0_files_found=找到_%0_个文件
-%0_of_%1=%1_中的_%0
-One_file_found=找到一个文件
-The_import_finished_with_warnings\:=
-There_was_one_file_that_could_not_be_imported.=
-There_were_%0_files_which_could_not_be_imported.=
+Open\ OpenOffice/LibreOffice\ connection=
+You\ must\ enter\ at\ least\ one\ field\ name=
+Non-ASCII\ encoded\ character\ found=
+Toggle\ web\ search\ interface=切换网页搜索面板
+Background\ color\ for\ resolved\ fields=resolved 域背景颜色
+Color\ code\ for\ resolved\ fields=使用颜色区分 resolved 域
+%0\ files\ found=找到 %0 个文件
+%0\ of\ %1=%1 中的 %0
+One\ file\ found=找到一个文件
+The\ import\ finished\ with\ warnings\:=
+There\ was\ one\ file\ that\ could\ not\ be\ imported.=
+There\ were\ %0\ files\ which\ could\ not\ be\ imported.=
 
-Migration_help_information=
-Entered_database_has_obsolete_structure_and_is_no_longer_supported.=
-However,_a_new_database_was_created_alongside_the_pre-3.6_one.=
-Click_here_to_learn_about_the_migration_of_pre-3.6_databases.=
-Opens_JabRef's_Facebook_page=打开_JabRef_的_Facebook_主页
-Opens_JabRef's_blog=打开_JabRef_的博客
-Opens_JabRef's_website=打开_JabRef_的主页
-Opens_a_link_where_the_current_development_version_can_be_downloaded=
-See_what_has_been_changed_in_the_JabRef_versions=
-Referenced_BibTeX_key_does_not_exist=引用的_BibTeX_键不存在
-Finished_downloading_full_text_document_for_entry_%0.=
-Full_text_document_download_failed_for_entry_%0.=
-Look_up_full_text_documents=
-You_are_about_to_look_up_full_text_documents_for_%0_entries.=
-last_four_nonpunctuation_characters_should_be_numerals=
+Migration\ help\ information=
+Entered\ database\ has\ obsolete\ structure\ and\ is\ no\ longer\ supported.=
+However,\ a\ new\ database\ was\ created\ alongside\ the\ pre-3.6\ one.=
+Click\ here\ to\ learn\ about\ the\ migration\ of\ pre-3.6\ databases.=
+Opens\ JabRef's\ Facebook\ page=打开 JabRef 的 Facebook 主页
+Opens\ JabRef's\ blog=打开 JabRef 的博客
+Opens\ JabRef's\ website=打开 JabRef 的主页
+Opens\ a\ link\ where\ the\ current\ development\ version\ can\ be\ downloaded=
+See\ what\ has\ been\ changed\ in\ the\ JabRef\ versions=
+Referenced\ BibTeX\ key\ does\ not\ exist=引用的 BibTeX 键不存在
+Finished\ downloading\ full\ text\ document\ for\ entry\ %0.=
+Full\ text\ document\ download\ failed\ for\ entry\ %0.=
+Look\ up\ full\ text\ documents=
+You\ are\ about\ to\ look\ up\ full\ text\ documents\ for\ %0\ entries.=
+last\ four\ nonpunctuation\ characters\ should\ be\ numerals=
 
 Author=作者
 Date=日期
-File_annotations=
-Show_file_annotations=
-Adobe_Acrobat_Reader=
-Sumatra_Reader=
+File\ annotations=
+Show\ file\ annotations=
+Adobe\ Acrobat\ Reader=
+Sumatra\ Reader=
 shared=
-should_contain_an_integer_or_a_literal=
-should_have_the_first_letter_capitalized=
+should\ contain\ an\ integer\ or\ a\ literal=
+should\ have\ the\ first\ letter\ capitalized=
 Tools=
-What\'s_new_in_this_version?=
-Want_to_help?=
-Make_a_donation=
-get_involved=
-Used_libraries=
-Existing_file=已有文件
+What\'s\ new\ in\ this\ version?=
+Want\ to\ help?=
+Make\ a\ donation=
+get\ involved=
+Used\ libraries=
+Existing\ file=已有文件
 
 ID=ID
-ID_type=ID_类型
-ID-based_entry_generator=
-Fetcher_'%0'_did_not_find_an_entry_for_id_'%1'.=
+ID\ type=ID 类型
+ID-based\ entry\ generator=
+Fetcher\ '%0'\ did\ not\ find\ an\ entry\ for\ id\ '%1'.=
 
-Select_first_entry=
-Select_last_entry=
+Select\ first\ entry=
+Select\ last\ entry=
 
-Invalid_ISBN\:_'%0'.=
-should_be_an_integer_or_normalized=
-should_be_normalized=
+Invalid\ ISBN\:\ '%0'.=
+should\ be\ an\ integer\ or\ normalized=
+should\ be\ normalized=
 
-Empty_search_ID=
-The_given_search_ID_was_empty.=
-Copy_BibTeX_key_and_link=拷贝_BibTeX_键和链接
-empty_BibTeX_key=空_BibTeX_键
-biblatex_field_only=
+Empty\ search\ ID=
+The\ given\ search\ ID\ was\ empty.=
+Copy\ BibTeX\ key\ and\ link=拷贝 BibTeX 键和链接
+empty\ BibTeX\ key=空 BibTeX 键
+biblatex\ field\ only=
 
-Error_while_generating_fetch_URL=
-Error_while_parsing_ID_list=
-Unable_to_get_PubMed_IDs=
-Backup_found=
-A_backup_file_for_'%0'_was_found.=
-This_could_indicate_that_JabRef_did_not_shut_down_cleanly_last_time_the_file_was_used.=
-Do_you_want_to_recover_the_library_from_the_backup_file?=
-Firstname_Lastname=
+Error\ while\ generating\ fetch\ URL=
+Error\ while\ parsing\ ID\ list=
+Unable\ to\ get\ PubMed\ IDs=
+Backup\ found=
+A\ backup\ file\ for\ '%0'\ was\ found.=
+This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=
+Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=
+Firstname\ Lastname=
 
-Recommended_for_%0=
-Show_'Related_Articles'_tab=
-This_might_be_caused_by_reaching_the_traffic_limitation_of_Google_Scholar_(see_'Help'_for_details).=
+Recommended\ for\ %0=
+Show\ 'Related\ Articles'\ tab=
+This\ might\ be\ caused\ by\ reaching\ the\ traffic\ limitation\ of\ Google\ Scholar\ (see\ 'Help'\ for\ details).=
 
-Could_not_open_website.=
-Problem_downloading_from_%1=
+Could\ not\ open\ website.=
+Problem\ downloading\ from\ %1=
 
-File_directory_pattern=
-Update_with_bibliographic_information_from_the_web=
+File\ directory\ pattern=
+Update\ with\ bibliographic\ information\ from\ the\ web=
 
-Could_not_find_any_bibliographic_information.=
-BibTeX_key_deviates_from_generated_key=BibTeX_键派生于自动生成的键
-DOI_%0_is_invalid=
+Could\ not\ find\ any\ bibliographic\ information.=
+BibTeX\ key\ deviates\ from\ generated\ key=BibTeX 键派生于自动生成的键
+DOI\ %0\ is\ invalid=
 
-Select_all_customized_types_to_be_stored_in_local_preferences=
-Currently_unknown=
-Different_customization,_current_settings_will_be_overwritten=
+Select\ all\ customized\ types\ to\ be\ stored\ in\ local\ preferences=
+Currently\ unknown=
+Different\ customization,\ current\ settings\ will\ be\ overwritten=
 
-Entry_type_%0_is_only_defined_for_Biblatex_but_not_for_BibTeX=
-Jump_to_entry=
+Entry\ type\ %0\ is\ only\ defined\ for\ Biblatex\ but\ not\ for\ BibTeX=
+Jump\ to\ entry=
 
-Copied_%0_citations.=
+Copied\ %0\ citations.=
 Copying...=
 
-journal_not_found_in_abbreviation_list=在缩写列表中未能找到期刊名
-Unhandled_exception_occurred.=
+journal\ not\ found\ in\ abbreviation\ list=在缩写列表中未能找到期刊名
+Unhandled\ exception\ occurred.=
 
-strings_included=
-Color_for_disabled_icons=
-Color_for_enabled_icons=
-Size_of_large_icons=
-Size_of_small_icons=
-Default_table_font_size=
-Escape_underscores=
+strings\ included=
+Color\ for\ disabled\ icons=
+Color\ for\ enabled\ icons=
+Size\ of\ large\ icons=
+Size\ of\ small\ icons=
+Default\ table\ font\ size=
+Escape\ underscores=
 Color=
-Please_also_add_all_steps_to_reproduce_this_issue,_if_possible.=
-Fit_width=
-Fit_a_single_page=
-Zoom_in=
-Zoom_out=
-Previous_page=
-Next_page=
-Document_viewer=
+Please\ also\ add\ all\ steps\ to\ reproduce\ this\ issue,\ if\ possible.=
+Fit\ width=
+Fit\ a\ single\ page=
+Zoom\ in=
+Zoom\ out=
+Previous\ page=
+Next\ page=
+Document\ viewer=
 Live=
 Locked=
-Show_document_viewer=
-Show_the_document_of_the_currently_selected_entry.=
-Show_this_document_until_unlocked.=
-Set_current_user_name_as_owner.=
+Show\ document\ viewer=
+Show\ the\ document\ of\ the\ currently\ selected\ entry.=
+Show\ this\ document\ until\ unlocked.=
+Set\ current\ user\ name\ as\ owner.=
 
-Sort_all_subgroups_(recursively)=
-Collect_and_share_telemetry_data_to_help_improve_JabRef.=
-Don't_share=
-Share_anonymous_statistics=
-Telemetry\:_Help_make_JabRef_better=
-To_improve_the_user_experience,_we_would_like_to_collect_anonymous_statistics_on_the_features_you_use._We_will_only_record_what_features_you_access_and_how_often_you_do_it._We_will_neither_collect_any_personal_data_nor_the_content_of_bibliographic_items._If_you_choose_to_allow_data_collection,_you_can_later_disable_it_via_Options_->_Preferences_->_General.=
-This_file_was_found_automatically._Do_you_want_to_link_it_to_this_entry?=
-Names_are_not_in_the_standard_%0_format.=
+Sort\ all\ subgroups\ (recursively)=
+Collect\ and\ share\ telemetry\ data\ to\ help\ improve\ JabRef.=
+Don't\ share=
+Share\ anonymous\ statistics=
+Telemetry\:\ Help\ make\ JabRef\ better=
+To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ statistics\ on\ the\ features\ you\ use.\ We\ will\ only\ record\ what\ features\ you\ access\ and\ how\ often\ you\ do\ it.\ We\ will\ neither\ collect\ any\ personal\ data\ nor\ the\ content\ of\ bibliographic\ items.\ If\ you\ choose\ to\ allow\ data\ collection,\ you\ can\ later\ disable\ it\ via\ Options\ ->\ Preferences\ ->\ General.=
+This\ file\ was\ found\ automatically.\ Do\ you\ want\ to\ link\ it\ to\ this\ entry?=
+Names\ are\ not\ in\ the\ standard\ %0\ format.=
 
-Delete_the_selected_file_permanently_from_disk,_or_just_remove_the_file_from_the_entry?_Pressing_Delete_will_delete_the_file_permanently_from_disk.=
-Delete_'%0'=
-Delete_from_disk=
-Remove_from_entry=
-The_group_name_contains_the_keyword_separator_"%0"_and_thus_probably_does_not_work_as_expected.=
-There_exists_already_a_group_with_the_same_name.=
+Delete\ the\ selected\ file\ permanently\ from\ disk,\ or\ just\ remove\ the\ file\ from\ the\ entry?\ Pressing\ Delete\ will\ delete\ the\ file\ permanently\ from\ disk.=
+Delete\ '%0'=
+Delete\ from\ disk=
+Remove\ from\ entry=
+The\ group\ name\ contains\ the\ keyword\ separator\ "%0"\ and\ thus\ probably\ does\ not\ work\ as\ expected.=
+There\ exists\ already\ a\ group\ with\ the\ same\ name.=
 
-Copy_linked_files_to_folder...=
-Copied_file_successfully=
-Copying_files...=
-Copying_file_%0_of_entry_%1=
-Finished_copying=
-Could_not_copy_file=
-Copied_%0_files_of_%1_sucessfully_to_%2=
-Rename_failed=
-JabRef_cannot_access_the_file_because_it_is_being_used_by_another_process.=
-Show_console_output_(only_necessary_when_the_launcher_is_used)=
+Copy\ linked\ files\ to\ folder...=
+Copied\ file\ successfully=
+Copying\ files...=
+Copying\ file\ %0\ of\ entry\ %1=
+Finished\ copying=
+Could\ not\ copy\ file=
+Copied\ %0\ files\ of\ %1\ sucessfully\ to\ %2=
+Rename\ failed=
+JabRef\ cannot\ access\ the\ file\ because\ it\ is\ being\ used\ by\ another\ process.=
+Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=
 
-Remove_line_breaks=
-Removes_all_line_breaks_in_the_field_content.=
-Checking_integrity...=
+Remove\ line\ breaks=
+Removes\ all\ line\ breaks\ in\ the\ field\ content.=
+Checking\ integrity...=
 
-Remove_hyphenated_line_breaks=
-Removes_all_hyphenated_line_breaks_in_the_field_content.=
-Note_that_currently,_JabRef_does_not_run_with_Java_9.=
-Your_current_Java_version_(%0)_is_not_supported._Please_install_version_%1_or_higher.=
+Remove\ hyphenated\ line\ breaks=
+Removes\ all\ hyphenated\ line\ breaks\ in\ the\ field\ content.=
+Note\ that\ currently,\ JabRef\ does\ not\ run\ with\ Java\ 9.=
+Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=

--- a/src/main/resources/l10n/Menu_da.properties
+++ b/src/main/resources/l10n/Menu_da.properties
@@ -1,7 +1,3 @@
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 Abbreviate\ journal\ names\ (ISO)=Forkort tidsskriftsnavn (ISO)
 Abbreviate\ journal\ names\ (MEDLINE)=Forkort tidsskriftsnavn (MEDLINE)
 About\ JabRef=Om &JabRef

--- a/src/main/resources/l10n/Menu_da.properties
+++ b/src/main/resources/l10n/Menu_da.properties
@@ -2,139 +2,139 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-Abbreviate_journal_names_(ISO)=Forkort_tidsskriftsnavn_(ISO)
-Abbreviate_journal_names_(MEDLINE)=Forkort_tidsskriftsnavn_(MEDLINE)
-About_JabRef=Om_&JabRef
-Append_library=Tilføj_ind&hold_fra_library
-Autogenerate_BibTeX_keys=&Autogenerer_BibTeX-nøgler
-Close_library=L&uk_library
+Abbreviate\ journal\ names\ (ISO)=Forkort tidsskriftsnavn (ISO)
+Abbreviate\ journal\ names\ (MEDLINE)=Forkort tidsskriftsnavn (MEDLINE)
+About\ JabRef=Om &JabRef
+Append\ library=Tilføj ind&hold fra library
+Autogenerate\ BibTeX\ keys=&Autogenerer BibTeX-nøgler
+Close\ library=L&uk library
 Copy=K&opier
-Copy_title=
-Copy_\\cite{BibTeX_key}=Kopier_\\cite{&BibTeX-nøgler}
-Copy_BibTeX_key=Kopier_&BibTeX-nøgler
-Customize_entry_types=&Tilpas_posttyper
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=Kopier \\cite{&BibTeX-nøgler}
+Copy\ BibTeX\ key=Kopier &BibTeX-nøgler
+Customize\ entry\ types=&Tilpas posttyper
 Cut=&Klip
-Library_properties=Egenskaber_for_library
+Library\ properties=Egenskaber for library
 Edit=&Rediger
 # Bibtex
-Edit_entry=&Rediger_post
-Edit_preamble=Rediger_præ&ambel
-Edit_strings=Rediger_&strenge
+Edit\ entry=&Rediger post
+Edit\ preamble=Rediger præ&ambel
+Edit\ strings=Rediger &strenge
 Export=&Eksporter
-Export_selected_entries_to_clipboard=Eksporter_valgte_poster_til_udklipsholderen
+Export\ selected\ entries\ to\ clipboard=Eksporter valgte poster til udklipsholderen
 
 # Menu names
 File=&Fil
-Find_duplicates=Søg_efter_&dubletter
+Find\ duplicates=Søg efter &dubletter
 Help=&Hjælp
 
 # Help
-Online_help=
-Donate_to_JabRef=Doner_til_JabRef
-Manage_content_selectors=Opsæt_ordlister
-Manage_custom_exports=Administrer_eksterne_&eksportfiltre
-Manage_custom_imports=Administrer_eksterne_i&mportfiltre
-Manage_journal_abbreviations=&Administrer_tidsskriftsforkortelser
-Mark_entries=&Mærk_poster
+Online\ help=
+Donate\ to\ JabRef=Doner til JabRef
+Manage\ content\ selectors=Opsæt ordlister
+Manage\ custom\ exports=Administrer eksterne &eksportfiltre
+Manage\ custom\ imports=Administrer eksterne i&mportfiltre
+Manage\ journal\ abbreviations=&Administrer tidsskriftsforkortelser
+Mark\ entries=&Mærk poster
 # File menu
-New_%0_library=Ny_%0-library
+New\ %0\ library=Ny %0-library
 # Menu BibTeX (BibTeX)
-New_entry=N&y_post
-New_entry_by_type...=&Ny_post...
-New_entry_from_plain_text=Ny_&post_fra_ren_tekst
-New_sublibrary_based_on_AUX_file=Ny_dellibrary_baseret_på_AU&X-fil
+New\ entry=N&y post
+New\ entry\ by\ type...=&Ny post...
+New\ entry\ from\ plain\ text=Ny &post fra ren tekst
+New\ sublibrary\ based\ on\ AUX\ file=Ny dellibrary baseret på AU&X-fil
 # View
-Next_tab=&Næste_faneblad
-Open_library=&Åbn_library
-Open_URL_or_DOI=Åbn_&URL_eller_DOI
-Connect_to_shared_database=
-Open_terminal_here=Åben_terminal_her
+Next\ tab=&Næste faneblad
+Open\ library=&Åbn library
+Open\ URL\ or\ DOI=Åbn &URL eller DOI
+Connect\ to\ shared\ database=
+Open\ terminal\ here=Åben terminal her
 Options=&Opsætning
 Paste=&Indsæt
 # Options
 Preferences=&Indstillinger
-Previous_tab=&Forrige_faneblad
+Previous\ tab=&Forrige faneblad
 Quit=&Afslut
-Recent_libraries=&Seneste_filer
+Recent\ libraries=&Seneste filer
 Redo=&Gentag
-Replace_string=&Erstat_streng
-Save_library=&Gem_library
-Save_library_as...=Ge&m_library_som_...
-Save_selected_as...=Gem_&valgte_poster_som_...
+Replace\ string=&Erstat streng
+Save\ library=&Gem library
+Save\ library\ as...=Ge&m library som ...
+Save\ selected\ as...=Gem &valgte poster som ...
 # Tools
 Search=&Søg
-Select_all=&Vælg_alle
-Set_up_general_fields=Administrer_&generelle_felter
-View_event_log=
-Sort_tabs=Sorter_faneblade
-Next_preview_layout=
-Previous_preview_layout=
+Select\ all=&Vælg alle
+Set\ up\ general\ fields=Administrer &generelle felter
+View\ event\ log=
+Sort\ tabs=Sorter faneblade
+Next\ preview\ layout=
+Previous\ preview\ layout=
 # Export menu
-Toggle_entry_preview=&Vis/skjul_forhåndsvisning
-Toggle_groups_interface=Vis/skjul_&grupperingspanel
+Toggle\ entry\ preview=&Vis/skjul forhåndsvisning
+Toggle\ groups\ interface=Vis/skjul &grupperingspanel
 Tools=F&unktioner
-Unabbreviate_journal_names=Ekspander_tidsskriftsnavn
+Unabbreviate\ journal\ names=Ekspander tidsskriftsnavn
 # Edit
 Undo=&Fortryd
-Mark_specific_color=M&ærk_med_specifik_farve
-Unmark_all=Fjern_mærkning_fra_&alle
-Unmark_entries=F&jern_mærkning
+Mark\ specific\ color=M&ærk med specifik farve
+Unmark\ all=Fjern mærkning fra &alle
+Unmark\ entries=F&jern mærkning
 View=&Vis
-Import_into_new_library=Importer_til_ny_library
-Import_into_current_library=Importer_til_den_aktive_library
+Import\ into\ new\ library=Importer til ny library
+Import\ into\ current\ library=Importer til den aktive library
 
-Switch_to_%0_mode=Skift_til_%0-mode
-Push_entries_to_external_application_(%0)=Send_poster_til_ekstern_applikation_(%0)
-Pull_changes_from_shared_database=
-Write_XMP-metadata_to_PDFs=Skriv_XMP-metadata_til_PDF-filer
+Switch\ to\ %0\ mode=Skift til %0-mode
+Push\ entries\ to\ external\ application\ (%0)=Send poster til ekstern applikation (%0)
+Pull\ changes\ from\ shared\ database=
+Write\ XMP-metadata\ to\ PDFs=Skriv XMP-metadata til PDF-filer
 
-Export_selected_entries=Eksporter_valgte_poster
+Export\ selected\ entries=Eksporter valgte poster
 
-Save_all=Gem_alle
+Save\ all=Gem alle
 
-Manage_external_file_types=Administrer_eksterne_&filtyper
+Manage\ external\ file\ types=Administrer eksterne &filtyper
 
-Open_file=Åbn_fil
+Open\ file=Åbn fil
 
-Focus_entry_table=Fokus_på_hovedtabel
+Focus\ entry\ table=Fokus på hovedtabel
 
-Increase_table_font_size=For&øg_fontstørrelse_i_hovedtabel
-Decrease_table_font_size=For&mindsk_fontstørrelse_i_hovedtabel
+Increase\ table\ font\ size=For&øg fontstørrelse i hovedtabel
+Decrease\ table\ font\ size=For&mindsk fontstørrelse i hovedtabel
 Forward=Frem
 Back=Tilbage
 
-Look_up_document_identifier...=
-Look_up_full_text_documents=
-Set/clear/append/rename_fields=Udfyld/ryd/omdøb_felter
+Look\ up\ document\ identifier...=
+Look\ up\ full\ text\ documents=
+Set/clear/append/rename\ fields=Udfyld/ryd/omdøb felter
 
-Resolve_duplicate_BibTeX_keys=Udred_dublerede_BibTeX-nøgler
-Copy_BibTeX_key_and_title=Kopier_BibTeX-nøgle_og_titel
+Resolve\ duplicate\ BibTeX\ keys=Udred dublerede BibTeX-nøgler
+Copy\ BibTeX\ key\ and\ title=Kopier BibTeX-nøgle og titel
 
-Cleanup_entries=Ryd_op_i_indgange
-Manage_keywords=Håndter_nøgleord
-Merge_entries=Flet_indgange
-Open_folder=Åben_mappe
-Find_unlinked_files...=Find_ulinkede_filer...
-Hide/show_toolbar=Gem/vis_værktøjslinje
+Cleanup\ entries=Ryd op i indgange
+Manage\ keywords=Håndter nøgleord
+Merge\ entries=Flet indgange
+Open\ folder=Åben mappe
+Find\ unlinked\ files...=Find ulinkede filer...
+Hide/show\ toolbar=Gem/vis værktøjslinje
 
-Fork_me_on_GitHub=Fork_mig_på_GitHub
-Save_selected_as_plain_BibTeX...=Gem_det_markerede_som_rå_BibTeX...
+Fork\ me\ on\ GitHub=Fork mig på GitHub
+Save\ selected\ as\ plain\ BibTeX...=Gem det markerede som rå BibTeX...
 
 Groups=Gruppering
-Delete_entry=Slet_post
-Check_integrity=Tjek_integritet
+Delete\ entry=Slet post
+Check\ integrity=Tjek integritet
 
 Quality=Kvalitet
-Online_help_forum=
-Manage_protected_terms=
+Online\ help\ forum=
+Manage\ protected\ terms=
 Website=
 Blog=
-JabRef_resources=
-Development_version=
-View_change_log=
-Copy_BibTeX_key_and_link=
-Copy_DOI_url=
+JabRef\ resources=
+Development\ version=
+View\ change\ log=
+Copy\ BibTeX\ key\ and\ link=
+Copy\ DOI\ url=
 
-Copy_citation=
-Default_table_font_size=
-Show_document_viewer=
+Copy\ citation=
+Default\ table\ font\ size=
+Show\ document\ viewer=

--- a/src/main/resources/l10n/Menu_de.properties
+++ b/src/main/resources/l10n/Menu_de.properties
@@ -2,139 +2,139 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-Abbreviate_journal_names_(ISO)=Zeitschriftentitel_abkürzen_(&ISO)
-Abbreviate_journal_names_(MEDLINE)=Zeitschriftentitel_abkürzen_(&MEDLINE)
-About_JabRef=Über_&JabRef
-Append_library=Bibliothek_&anhängen
-Autogenerate_BibTeX_keys=&BibTeX-Keys_automatisch_generieren
-Close_library=Bibliothek_s&chließen
+Abbreviate\ journal\ names\ (ISO)=Zeitschriftentitel abkürzen (&ISO)
+Abbreviate\ journal\ names\ (MEDLINE)=Zeitschriftentitel abkürzen (&MEDLINE)
+About\ JabRef=Über &JabRef
+Append\ library=Bibliothek &anhängen
+Autogenerate\ BibTeX\ keys=&BibTeX-Keys automatisch generieren
+Close\ library=Bibliothek s&chließen
 Copy=&Kopieren
-Copy_title=Kopiere_Titel
-Copy_\\cite{BibTeX_key}=\\&cite{BibTeX_key}_kopieren
-Copy_BibTeX_key=&BibTeX_key_kopieren
-Customize_entry_types=Eintragstypen_&anpassen
+Copy\ title=Kopiere Titel
+Copy\ \\cite{BibTeX\ key}=\\&cite{BibTeX key} kopieren
+Copy\ BibTeX\ key=&BibTeX key kopieren
+Customize\ entry\ types=Eintragstypen &anpassen
 Cut=Aus&schneiden
-Library_properties=Ei&genschaften_der_Bibliothek
+Library\ properties=Ei&genschaften der Bibliothek
 Edit=&Bearbeiten
 # Bibtex
-Edit_entry=Eintrag_&bearbeiten
-Edit_preamble=&Prämbel_bearbeiten
-Edit_strings=&Strings_bearbeiten
+Edit\ entry=Eintrag &bearbeiten
+Edit\ preamble=&Prämbel bearbeiten
+Edit\ strings=&Strings bearbeiten
 Export=&Exportieren
-Export_selected_entries_to_clipboard=&Ausgwählte_Einträge_in_die_Zwischenablage_kopieren
+Export\ selected\ entries\ to\ clipboard=&Ausgwählte Einträge in die Zwischenablage kopieren
 
 # Menu names
 File=&Datei
-Find_duplicates=Nach_&doppelten_Einträgen_suchen
+Find\ duplicates=Nach &doppelten Einträgen suchen
 Help=&Hilfe
 
 # Help
-Online_help=Online_Hilfe
-Donate_to_JabRef=An_JabRef_spenden
-Manage_content_selectors=W&ortauswahl_verwalten
-Manage_custom_exports=Externe_Exportfilter_&verwalten
-Manage_custom_imports=Externe_&Importfilter_verwalten
-Manage_journal_abbreviations=&Abkürzungen_der_Zeitschriften_verwalten
-Mark_entries=Einträge_&markieren
+Online\ help=Online Hilfe
+Donate\ to\ JabRef=An JabRef spenden
+Manage\ content\ selectors=W&ortauswahl verwalten
+Manage\ custom\ exports=Externe Exportfilter &verwalten
+Manage\ custom\ imports=Externe &Importfilter verwalten
+Manage\ journal\ abbreviations=&Abkürzungen der Zeitschriften verwalten
+Mark\ entries=Einträge &markieren
 # File menu
-New_%0_library=Neue_%0_Bibliothek
+New\ %0\ library=Neue %0 Bibliothek
 # Menu BibTeX (BibTeX)
-New_entry=&Neuer_Eintrag
-New_entry_by_type...=Neuer_&Eintrag...
-New_entry_from_plain_text=Neuer_Eintrag_aus_&Klartext
-New_sublibrary_based_on_AUX_file=&Neue_Teilbibliothek_aus_AUX-Datei
+New\ entry=&Neuer Eintrag
+New\ entry\ by\ type...=Neuer &Eintrag...
+New\ entry\ from\ plain\ text=Neuer Eintrag aus &Klartext
+New\ sublibrary\ based\ on\ AUX\ file=&Neue Teilbibliothek aus AUX-Datei
 # View
-Next_tab=&Nächster_Tab
-Open_library=Bibliothek_öffnen
-Open_URL_or_DOI=&URL_oder_DOI_öffnen
-Connect_to_shared_database=Geteilte_Datenbak_öffnen
-Open_terminal_here=Konsole_hier_öffnen
+Next\ tab=&Nächster Tab
+Open\ library=Bibliothek öffnen
+Open\ URL\ or\ DOI=&URL oder DOI öffnen
+Connect\ to\ shared\ database=Geteilte Datenbak öffnen
+Open\ terminal\ here=Konsole hier öffnen
 Options=&Optionen
 Paste=&Einfügen
 # Options
 Preferences=&Einstellungen
-Previous_tab=&Vorheriger_Tab
+Previous\ tab=&Vorheriger Tab
 Quit=&Beenden
-Recent_libraries=&Zuletzt_geöffnete_Bibliotheken
+Recent\ libraries=&Zuletzt geöffnete Bibliotheken
 Redo=&Wiederholen
-Replace_string=E&rsetzen
-Save_library=Bibliothek_&speichern
-Save_library_as...=Bibliothek_speichern_&unter_...
-Save_selected_as...=Aus&wahl_speichern_unter_...
+Replace\ string=E&rsetzen
+Save\ library=Bibliothek &speichern
+Save\ library\ as...=Bibliothek speichern &unter ...
+Save\ selected\ as...=Aus&wahl speichern unter ...
 # Tools
 Search=&Suchen
-Select_all=&Alle_auswählen
-Set_up_general_fields=Allgemeine_&Felder_festlegen
-View_event_log=Ereignisprotokoll_anzeigen
-Sort_tabs=Tabs_&sortieren
-Next_preview_layout=Nächstes_Vorschaulayout
-Previous_preview_layout=Vorheriges_Vorschaulayout
+Select\ all=&Alle auswählen
+Set\ up\ general\ fields=Allgemeine &Felder festlegen
+View\ event\ log=Ereignisprotokoll anzeigen
+Sort\ tabs=Tabs &sortieren
+Next\ preview\ layout=Nächstes Vorschaulayout
+Previous\ preview\ layout=Vorheriges Vorschaulayout
 # Export menu
-Toggle_entry_preview=&Eintragsvorschau_ein-/ausblenden
-Toggle_groups_interface=&Gruppenansicht_ein-/ausblenden
+Toggle\ entry\ preview=&Eintragsvorschau ein-/ausblenden
+Toggle\ groups\ interface=&Gruppenansicht ein-/ausblenden
 Tools=&Extras
-Unabbreviate_journal_names=&Abkürzung_der_Zeitschriften_aufheben
+Unabbreviate\ journal\ names=&Abkürzung der Zeitschriften aufheben
 # Edit
 Undo=&Rückgängig
-Mark_specific_color=Mit_bestimmter_&Farbe_markieren
-Unmark_all=Säm&tliche_Markierungen_aufheben
-Unmark_entries=Markierung_a&ufheben
+Mark\ specific\ color=Mit bestimmter &Farbe markieren
+Unmark\ all=Säm&tliche Markierungen aufheben
+Unmark\ entries=Markierung a&ufheben
 View=&Ansicht
-Import_into_new_library=&Importieren_in_neue_Bibliothek
-Import_into_current_library=Importieren_in_aktuelle_&Bibliothek
+Import\ into\ new\ library=&Importieren in neue Bibliothek
+Import\ into\ current\ library=Importieren in aktuelle &Bibliothek
 
-Switch_to_%0_mode=In_den_%0-Modus_wechseln
-Push_entries_to_external_application_(%0)=&Einträge_in_externe_Anwendung_einfügen_(%0)
-Pull_changes_from_shared_database=Änderungen_der_geteilten_Datenbank_beziehen
-Write_XMP-metadata_to_PDFs=&XMP-Metadaten_in_PDFs_schreiben
+Switch\ to\ %0\ mode=In den %0-Modus wechseln
+Push\ entries\ to\ external\ application\ (%0)=&Einträge in externe Anwendung einfügen (%0)
+Pull\ changes\ from\ shared\ database=Änderungen der geteilten Datenbank beziehen
+Write\ XMP-metadata\ to\ PDFs=&XMP-Metadaten in PDFs schreiben
 
-Export_selected_entries=Ausgewählte_Einträge_exportieren
+Export\ selected\ entries=Ausgewählte Einträge exportieren
 
-Save_all=A&lle_speichern
+Save\ all=A&lle speichern
 
-Manage_external_file_types=Externe_Dateitypen_verwalten
+Manage\ external\ file\ types=Externe Dateitypen verwalten
 
-Open_file=Datei_öffnen
+Open\ file=Datei öffnen
 
-Focus_entry_table=Fokus_auf_Tabelle_setzen
+Focus\ entry\ table=Fokus auf Tabelle setzen
 
-Increase_table_font_size=Schriftgröße_in_der_&Tabelle_vergrößern
-Decrease_table_font_size=Schriftgröße_in_der_Tabelle_verkleinern
+Increase\ table\ font\ size=Schriftgröße in der &Tabelle vergrößern
+Decrease\ table\ font\ size=Schriftgröße in der Tabelle verkleinern
 Forward=Vor
 Back=Zurück
 
-Look_up_document_identifier...=Schlage_Dokument-ID_nach...
-Look_up_full_text_documents=Volltext-Dokumente_suchen
-Set/clear/append/rename_fields=Felder_setzen/löschen/umbenennen
+Look\ up\ document\ identifier...=Schlage Dokument-ID nach...
+Look\ up\ full\ text\ documents=Volltext-Dokumente suchen
+Set/clear/append/rename\ fields=Felder setzen/löschen/umbenennen
 
-Resolve_duplicate_BibTeX_keys=Doppelte_BibTeX-Keys_beseitigen
-Copy_BibTeX_key_and_title=BibTeX-Key_und_Titel_kopieren
+Resolve\ duplicate\ BibTeX\ keys=Doppelte BibTeX-Keys beseitigen
+Copy\ BibTeX\ key\ and\ title=BibTeX-Key und Titel kopieren
 
-Cleanup_entries=Einträge_bereinigen
-Manage_keywords=Stichworte_verwalten
-Merge_entries=Einträge_zusammenführen
-Open_folder=Ordner_öffnen
-Find_unlinked_files...=Nicht_verlinkte_Dateien_finden...
-Hide/show_toolbar=Toolbar_zeigen/verbergen
+Cleanup\ entries=Einträge bereinigen
+Manage\ keywords=Stichworte verwalten
+Merge\ entries=Einträge zusammenführen
+Open\ folder=Ordner öffnen
+Find\ unlinked\ files...=Nicht verlinkte Dateien finden...
+Hide/show\ toolbar=Toolbar zeigen/verbergen
 
-Fork_me_on_GitHub=Forke_mich_auf_GitHub
-Save_selected_as_plain_BibTeX...=Ausgewählte_Einträge_als_reines_BibTeX_speichern...
+Fork\ me\ on\ GitHub=Forke mich auf GitHub
+Save\ selected\ as\ plain\ BibTeX...=Ausgewählte Einträge als reines BibTeX speichern...
 
 Groups=Gruppen
-Delete_entry=Eintrag_löschen
-Check_integrity=Integrität_prüfen
+Delete\ entry=Eintrag löschen
+Check\ integrity=Integrität prüfen
 
 Quality=Qualität
-Online_help_forum=Online-Hilfeforum
-Manage_protected_terms=Geschützte_Terme_verwalten
+Online\ help\ forum=Online-Hilfeforum
+Manage\ protected\ terms=Geschützte Terme verwalten
 Website=Webseite
 Blog=Blog
-JabRef_resources=Mehr_zu_JabRef
-Development_version=Entwicklungsversion
-View_change_log=Changelog_öffnen
-Copy_BibTeX_key_and_link=BibTeX-Key_und_Link_kopieren
-Copy_DOI_url=DOI-URL_kopieren
+JabRef\ resources=Mehr zu JabRef
+Development\ version=Entwicklungsversion
+View\ change\ log=Changelog öffnen
+Copy\ BibTeX\ key\ and\ link=BibTeX-Key und Link kopieren
+Copy\ DOI\ url=DOI-URL kopieren
 
-Copy_citation=Kopiere_Zitation
-Default_table_font_size=Standard_Tabellenschriftgröße
-Show_document_viewer=Zeige_Dokumentenbetrachter
+Copy\ citation=Kopiere Zitation
+Default\ table\ font\ size=Standard Tabellenschriftgröße
+Show\ document\ viewer=Zeige Dokumentenbetrachter

--- a/src/main/resources/l10n/Menu_de.properties
+++ b/src/main/resources/l10n/Menu_de.properties
@@ -1,7 +1,3 @@
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 Abbreviate\ journal\ names\ (ISO)=Zeitschriftentitel abkürzen (&ISO)
 Abbreviate\ journal\ names\ (MEDLINE)=Zeitschriftentitel abkürzen (&MEDLINE)
 About\ JabRef=Über &JabRef

--- a/src/main/resources/l10n/Menu_el.properties
+++ b/src/main/resources/l10n/Menu_el.properties
@@ -2,139 +2,139 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-Abbreviate_journal_names_(ISO)=Συντομογραφίες_ονομάτων_περιοδικών_(ISO)
-Abbreviate_journal_names_(MEDLINE)=Συντομογραφίες_ονομάτων_περιοδικών_(MEDLINE)
-About_JabRef=&Σχετικά_με_το_JabRef
-Append_library=
-Autogenerate_BibTeX_keys=
-Close_library=
+Abbreviate\ journal\ names\ (ISO)=Συντομογραφίες ονομάτων περιοδικών (ISO)
+Abbreviate\ journal\ names\ (MEDLINE)=Συντομογραφίες ονομάτων περιοδικών (MEDLINE)
+About\ JabRef=&Σχετικά με το JabRef
+Append\ library=
+Autogenerate\ BibTeX\ keys=
+Close\ library=
 Copy=Αντιγραφή
-Copy_title=
-Copy_\\cite{BibTeX_key}=Αντιγραφή_\\c&ite{BibTeX_key}
-Copy_BibTeX_key=Αντιγραφή&BibTeX_key
-Customize_entry_types=&Προσαρμογή_τύπου_καταχώρησης
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=Αντιγραφή \\c&ite{BibTeX key}
+Copy\ BibTeX\ key=Αντιγραφή&BibTeX key
+Customize\ entry\ types=&Προσαρμογή τύπου καταχώρησης
 Cut=&Αποκοπή
-Library_properties=
+Library\ properties=
 Edit=&Επεξεργασία
 # Bibtex
-Edit_entry=&Επεξεργασία_καταχώρησης
-Edit_preamble=Επεξεργασία_&preamble
-Edit_strings=Επεξεργασία_&strings
+Edit\ entry=&Επεξεργασία καταχώρησης
+Edit\ preamble=Επεξεργασία &preamble
+Edit\ strings=Επεξεργασία &strings
 Export=&Εξαγωγή
-Export_selected_entries_to_clipboard=&Εξαγωγή_επιλεγμένων_καταχωρήσεων_στο_clipboard
+Export\ selected\ entries\ to\ clipboard=&Εξαγωγή επιλεγμένων καταχωρήσεων στο clipboard
 
 # Menu names
 File=&Φάκελος
-Find_duplicates=&Εύρεση_διπλότυπων
+Find\ duplicates=&Εύρεση διπλότυπων
 Help=&Βοήθεια
 
 # Help
-Online_help=Online_βοήθεια
-Donate_to_JabRef=Δωρεά_στο_JabRef
-Manage_content_selectors=Διαχείριση&Επιλογείς_Περιεχομένου
-Manage_custom_exports=&Διαχείριση_Εξαγωγής_Προτιμήσεων
-Manage_custom_imports=Διαχείριση_Προτιμήσεων_&Εισαγωγών
-Manage_journal_abbreviations=Διαχείριση_&συντομογραφιών_περιοδικών
-Mark_entries=&Επισύμανση_καταχωρήσεων
+Online\ help=Online βοήθεια
+Donate\ to\ JabRef=Δωρεά στο JabRef
+Manage\ content\ selectors=Διαχείριση&Επιλογείς Περιεχομένου
+Manage\ custom\ exports=&Διαχείριση Εξαγωγής Προτιμήσεων
+Manage\ custom\ imports=Διαχείριση Προτιμήσεων &Εισαγωγών
+Manage\ journal\ abbreviations=Διαχείριση &συντομογραφιών περιοδικών
+Mark\ entries=&Επισύμανση καταχωρήσεων
 # File menu
-New_%0_library=
+New\ %0\ library=
 # Menu BibTeX (BibTeX)
-New_entry=&Νέα_καταχώρηση
-New_entry_by_type...=&Νέα_καταχώρηση_ανα_τύπο...
-New_entry_from_plain_text=&Νέα_καταχώρηση_από_plain_κείμενο
-New_sublibrary_based_on_AUX_file=
+New\ entry=&Νέα καταχώρηση
+New\ entry\ by\ type...=&Νέα καταχώρηση ανα τύπο...
+New\ entry\ from\ plain\ text=&Νέα καταχώρηση από plain κείμενο
+New\ sublibrary\ based\ on\ AUX\ file=
 # View
-Next_tab=&Επόμενη_καρτέλα
-Open_library=
-Open_URL_or_DOI=Άνοιγμα_&URL_ή_DOI
-Connect_to_shared_database=
-Open_terminal_here=
+Next\ tab=&Επόμενη καρτέλα
+Open\ library=
+Open\ URL\ or\ DOI=Άνοιγμα &URL ή DOI
+Connect\ to\ shared\ database=
+Open\ terminal\ here=
 Options=&Επιλογές
 Paste=&Επικόλληση
 # Options
 Preferences=&Προτιμήσεις
-Previous_tab=&Προηγούμενη_καρτέλα
+Previous\ tab=&Προηγούμενη καρτέλα
 Quit=&Έξοδος
-Recent_libraries=
+Recent\ libraries=
 Redo=&Επαναφορά
-Replace_string=&Αντικατάσταση_string
-Save_library=
-Save_library_as...=
-Save_selected_as...=Αποθήκεση_επιλεγμένου_ως...
+Replace\ string=&Αντικατάσταση string
+Save\ library=
+Save\ library\ as...=
+Save\ selected\ as...=Αποθήκεση επιλεγμένου ως...
 # Tools
 Search=&Αναζήτηση
-Select_all=Επιλογή_&όλων
-Set_up_general_fields=Ρύθμιση&γενικών_πεδίων
-View_event_log=
-Sort_tabs=&Σύντομες_καρτέλες
-Next_preview_layout=
-Previous_preview_layout=
+Select\ all=Επιλογή &όλων
+Set\ up\ general\ fields=Ρύθμιση&γενικών πεδίων
+View\ event\ log=
+Sort\ tabs=&Σύντομες καρτέλες
+Next\ preview\ layout=
+Previous\ preview\ layout=
 # Export menu
-Toggle_entry_preview=
-Toggle_groups_interface=
+Toggle\ entry\ preview=
+Toggle\ groups\ interface=
 Tools=&Εργαλεία
-Unabbreviate_journal_names=Ονόματα_περιοδικών_χωρίς_συντομογραφία
+Unabbreviate\ journal\ names=Ονόματα περιοδικών χωρίς συντομογραφία
 # Edit
 Undo=&Αναίρεση
-Mark_specific_color=Επισύμανση_συγκεκριμένου_χρώματος
-Unmark_all=Απεπιλογή_όλων
-Unmark_entries=Απεπιλογή_καταχωρήσεων
+Mark\ specific\ color=Επισύμανση συγκεκριμένου χρώματος
+Unmark\ all=Απεπιλογή όλων
+Unmark\ entries=Απεπιλογή καταχωρήσεων
 View=&Προβολή
-Import_into_new_library=
-Import_into_current_library=
+Import\ into\ new\ library=
+Import\ into\ current\ library=
 
-Switch_to_%0_mode=Αλλαγή_%0_κατάστασης
-Push_entries_to_external_application_(%0)=
-Pull_changes_from_shared_database=
-Write_XMP-metadata_to_PDFs=Εγγραφή_XMP-μεταδεδομένων_σε_PDF
+Switch\ to\ %0\ mode=Αλλαγή %0 κατάστασης
+Push\ entries\ to\ external\ application\ (%0)=
+Pull\ changes\ from\ shared\ database=
+Write\ XMP-metadata\ to\ PDFs=Εγγραφή XMP-μεταδεδομένων σε PDF
 
-Export_selected_entries=Εξαγωγή_επιλεγμένων_καταχωρήσεων
+Export\ selected\ entries=Εξαγωγή επιλεγμένων καταχωρήσεων
 
-Save_all=Αποθήκευση_όλων
+Save\ all=Αποθήκευση όλων
 
-Manage_external_file_types=Διαχείριση_εξωτερικού_τυπου_αρχείων
+Manage\ external\ file\ types=Διαχείριση εξωτερικού τυπου αρχείων
 
-Open_file=Άνοιγμα_αρχείου
+Open\ file=Άνοιγμα αρχείου
 
-Focus_entry_table=Επικεντρωμένη_εισαγωγή_πίνακα
+Focus\ entry\ table=Επικεντρωμένη εισαγωγή πίνακα
 
-Increase_table_font_size=&Μεγένθυση_γραμματοσειράς_πίνακα
-Decrease_table_font_size=&Σμίκρυνση_γραμματοσειράς_πίνακα
+Increase\ table\ font\ size=&Μεγένθυση γραμματοσειράς πίνακα
+Decrease\ table\ font\ size=&Σμίκρυνση γραμματοσειράς πίνακα
 Forward=Επόμενο
 Back=Πίσω
 
-Look_up_document_identifier...=
-Look_up_full_text_documents=
-Set/clear/append/rename_fields=Ρύθμιση/καθαρισμός/μετονομασία_πεδίων
+Look\ up\ document\ identifier...=
+Look\ up\ full\ text\ documents=
+Set/clear/append/rename\ fields=Ρύθμιση/καθαρισμός/μετονομασία πεδίων
 
-Resolve_duplicate_BibTeX_keys=Resolve_διπλότυπων_BibTeX_keys
-Copy_BibTeX_key_and_title=Αντιγραφή_BibTeX_και_τίτλου
+Resolve\ duplicate\ BibTeX\ keys=Resolve διπλότυπων BibTeX keys
+Copy\ BibTeX\ key\ and\ title=Αντιγραφή BibTeX και τίτλου
 
-Cleanup_entries=Καθαρισμός_καταχωρήσεων
-Manage_keywords=Διαχείριση_λέξεων_κλειδιών
-Merge_entries=Συγχώνευση_καταχωρήσεων
-Open_folder=Άνοιγμα_φακέλου
-Find_unlinked_files...=Εύρεση_αποσυνδεμένων_αρχείων...
-Hide/show_toolbar=Απόκρυψη/προβολή_εργαλειοθήκης
+Cleanup\ entries=Καθαρισμός καταχωρήσεων
+Manage\ keywords=Διαχείριση λέξεων κλειδιών
+Merge\ entries=Συγχώνευση καταχωρήσεων
+Open\ folder=Άνοιγμα φακέλου
+Find\ unlinked\ files...=Εύρεση αποσυνδεμένων αρχείων...
+Hide/show\ toolbar=Απόκρυψη/προβολή εργαλειοθήκης
 
-Fork_me_on_GitHub=Fork_me_on_GitHub
-Save_selected_as_plain_BibTeX...=Αποθήκευση_επιλεγμένου_ως_plain_BibTeX...
+Fork\ me\ on\ GitHub=Fork me on GitHub
+Save\ selected\ as\ plain\ BibTeX...=Αποθήκευση επιλεγμένου ως plain BibTeX...
 
 Groups=Ομάδες
-Delete_entry=Διαγραφή_καταχώρησης
-Check_integrity=Έλεγχος_συνοχής
+Delete\ entry=Διαγραφή καταχώρησης
+Check\ integrity=Έλεγχος συνοχής
 
 Quality=Ποιότητα
-Online_help_forum=Online_forum_βοήθειας
-Manage_protected_terms=
+Online\ help\ forum=Online forum βοήθειας
+Manage\ protected\ terms=
 Website=
 Blog=
-JabRef_resources=
-Development_version=
-View_change_log=
-Copy_BibTeX_key_and_link=
-Copy_DOI_url=
+JabRef\ resources=
+Development\ version=
+View\ change\ log=
+Copy\ BibTeX\ key\ and\ link=
+Copy\ DOI\ url=
 
-Copy_citation=
-Default_table_font_size=
-Show_document_viewer=
+Copy\ citation=
+Default\ table\ font\ size=
+Show\ document\ viewer=

--- a/src/main/resources/l10n/Menu_el.properties
+++ b/src/main/resources/l10n/Menu_el.properties
@@ -1,7 +1,3 @@
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 Abbreviate\ journal\ names\ (ISO)=Συντομογραφίες ονομάτων περιοδικών (ISO)
 Abbreviate\ journal\ names\ (MEDLINE)=Συντομογραφίες ονομάτων περιοδικών (MEDLINE)
 About\ JabRef=&Σχετικά με το JabRef

--- a/src/main/resources/l10n/Menu_en.properties
+++ b/src/main/resources/l10n/Menu_en.properties
@@ -1,7 +1,3 @@
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 Abbreviate\ journal\ names\ (ISO)=Abbreviate journal names (ISO)
 Abbreviate\ journal\ names\ (MEDLINE)=Abbreviate journal names (MEDLINE)
 About\ JabRef=&About JabRef

--- a/src/main/resources/l10n/Menu_en.properties
+++ b/src/main/resources/l10n/Menu_en.properties
@@ -2,139 +2,139 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-Abbreviate_journal_names_(ISO)=Abbreviate_journal_names_(ISO)
-Abbreviate_journal_names_(MEDLINE)=Abbreviate_journal_names_(MEDLINE)
-About_JabRef=&About_JabRef
-Append_library=&Append_library
-Autogenerate_BibTeX_keys=&Autogenerate_BibTeX_keys
-Close_library=&Close_library
+Abbreviate\ journal\ names\ (ISO)=Abbreviate journal names (ISO)
+Abbreviate\ journal\ names\ (MEDLINE)=Abbreviate journal names (MEDLINE)
+About\ JabRef=&About JabRef
+Append\ library=&Append library
+Autogenerate\ BibTeX\ keys=&Autogenerate BibTeX keys
+Close\ library=&Close library
 Copy=C&opy
-Copy_title=&Copy_title
-Copy_\\cite{BibTeX_key}=Copy_\\c&ite{BibTeX_key}
-Copy_BibTeX_key=Copy_&BibTeX_key
-Customize_entry_types=&Customize_entry_types
+Copy\ title=&Copy title
+Copy\ \\cite{BibTeX\ key}=Copy \\c&ite{BibTeX key}
+Copy\ BibTeX\ key=Copy &BibTeX key
+Customize\ entry\ types=&Customize entry types
 Cut=&Cut
-Library_properties=Library_&properties
+Library\ properties=Library &properties
 Edit=&Edit
 # Bibtex
-Edit_entry=&Edit_entry
-Edit_preamble=Edit_&preamble
-Edit_strings=Edit_&strings
+Edit\ entry=&Edit entry
+Edit\ preamble=Edit &preamble
+Edit\ strings=Edit &strings
 Export=&Export
-Export_selected_entries_to_clipboard=&Export_selected_entries_to_clipboard
+Export\ selected\ entries\ to\ clipboard=&Export selected entries to clipboard
 
 # Menu names
 File=&File
-Find_duplicates=&Find_duplicates
+Find\ duplicates=&Find duplicates
 Help=&Help
 
 # Help
-Online_help=Online_help
-Donate_to_JabRef=Donate_to_JabRef
-Manage_content_selectors=Manage_&content_selectors
-Manage_custom_exports=&Manage_custom_exports
-Manage_custom_imports=Manage_custom_&imports
-Manage_journal_abbreviations=Manage_&journal_abbreviations
-Mark_entries=&Mark_entries
+Online\ help=Online help
+Donate\ to\ JabRef=Donate to JabRef
+Manage\ content\ selectors=Manage &content selectors
+Manage\ custom\ exports=&Manage custom exports
+Manage\ custom\ imports=Manage custom &imports
+Manage\ journal\ abbreviations=Manage &journal abbreviations
+Mark\ entries=&Mark entries
 # File menu
-New_%0_library=&New_%0_library
+New\ %0\ library=&New %0 library
 # Menu BibTeX (BibTeX)
-New_entry=N&ew_entry
-New_entry_by_type...=&New_entry_by_type...
-New_entry_from_plain_text=Ne&w_entry_from_plain_text
-New_sublibrary_based_on_AUX_file=New_sublibrary_based_on_AU&X_file
+New\ entry=N&ew entry
+New\ entry\ by\ type...=&New entry by type...
+New\ entry\ from\ plain\ text=Ne&w entry from plain text
+New\ sublibrary\ based\ on\ AUX\ file=New sublibrary based on AU&X file
 # View
-Next_tab=&Next_tab
-Open_library=&Open_library
-Open_URL_or_DOI=Open_&URL_or_DOI
-Connect_to_shared_database=Connect_to_shared_database
-Open_terminal_here=Open_terminal_here
+Next\ tab=&Next tab
+Open\ library=&Open library
+Open\ URL\ or\ DOI=Open &URL or DOI
+Connect\ to\ shared\ database=Connect to shared database
+Open\ terminal\ here=Open terminal here
 Options=&Options
 Paste=&Paste
 # Options
 Preferences=&Preferences
-Previous_tab=&Previous_tab
+Previous\ tab=&Previous tab
 Quit=&Quit
-Recent_libraries=&Recent_libraries
+Recent\ libraries=&Recent libraries
 Redo=&Redo
-Replace_string=&Replace_string
-Save_library=&Save_library
-Save_library_as...=S&ave_library_as...
-Save_selected_as...=Save_se&lected_as...
+Replace\ string=&Replace string
+Save\ library=&Save library
+Save\ library\ as...=S&ave library as...
+Save\ selected\ as...=Save se&lected as...
 # Tools
 Search=&Search
-Select_all=Select_&all
-Set_up_general_fields=Set_up_&general_fields
-View_event_log=View_event_log
-Sort_tabs=&Sort_tabs
-Next_preview_layout=&Next_preview_layout
-Previous_preview_layout=&Previous_preview_layout
+Select\ all=Select &all
+Set\ up\ general\ fields=Set up &general fields
+View\ event\ log=View event log
+Sort\ tabs=&Sort tabs
+Next\ preview\ layout=&Next preview layout
+Previous\ preview\ layout=&Previous preview layout
 # Export menu
-Toggle_entry_preview=&Toggle_entry_preview
-Toggle_groups_interface=Toggle_&groups_interface
+Toggle\ entry\ preview=&Toggle entry preview
+Toggle\ groups\ interface=Toggle &groups interface
 Tools=&Tools
-Unabbreviate_journal_names=Unabbreviate_journal_names
+Unabbreviate\ journal\ names=Unabbreviate journal names
 # Edit
 Undo=&Undo
-Mark_specific_color=M&ark_specific_color
-Unmark_all=Unmark_a&ll
-Unmark_entries=U&nmark_entries
+Mark\ specific\ color=M&ark specific color
+Unmark\ all=Unmark a&ll
+Unmark\ entries=U&nmark entries
 View=&View
-Import_into_new_library=Import_into_new_library
-Import_into_current_library=Import_into_current_library
+Import\ into\ new\ library=Import into new library
+Import\ into\ current\ library=Import into current library
 
-Switch_to_%0_mode=Switch_to_%0_mode
-Push_entries_to_external_application_(%0)=Push_entries_to_external_application_(%0)
-Pull_changes_from_shared_database=Pull_changes_from_shared_database
-Write_XMP-metadata_to_PDFs=Write_XMP-metadata_to_PDFs
+Switch\ to\ %0\ mode=Switch to %0 mode
+Push\ entries\ to\ external\ application\ (%0)=Push entries to external application (%0)
+Pull\ changes\ from\ shared\ database=Pull changes from shared database
+Write\ XMP-metadata\ to\ PDFs=Write XMP-metadata to PDFs
 
-Export_selected_entries=Export_selected_entries
+Export\ selected\ entries=Export selected entries
 
-Save_all=Save_all
+Save\ all=Save all
 
-Manage_external_file_types=Manage_external_file_types
+Manage\ external\ file\ types=Manage external file types
 
-Open_file=Open_file
+Open\ file=Open file
 
-Focus_entry_table=Focus_entry_table
+Focus\ entry\ table=Focus entry table
 
-Increase_table_font_size=&Increase_table_font_size
-Decrease_table_font_size=&Decrease_table_font_size
+Increase\ table\ font\ size=&Increase table font size
+Decrease\ table\ font\ size=&Decrease table font size
 Forward=Forward
 Back=Back
 
-Look_up_document_identifier...=Look_up_document_identifier...
-Look_up_full_text_documents=Look_up_full_text_documents
-Set/clear/append/rename_fields=Set/clear/append/rename_fields
+Look\ up\ document\ identifier...=Look up document identifier...
+Look\ up\ full\ text\ documents=Look up full text documents
+Set/clear/append/rename\ fields=Set/clear/append/rename fields
 
-Resolve_duplicate_BibTeX_keys=Resolve_duplicate_BibTeX_keys
-Copy_BibTeX_key_and_title=Copy_BibTeX_key_and_title
+Resolve\ duplicate\ BibTeX\ keys=Resolve duplicate BibTeX keys
+Copy\ BibTeX\ key\ and\ title=Copy BibTeX key and title
 
-Cleanup_entries=Cleanup_entries
-Manage_keywords=Manage_keywords
-Merge_entries=Merge_entries
-Open_folder=Open_folder
-Find_unlinked_files...=Find_unlinked_files...
-Hide/show_toolbar=Hide/show_toolbar
+Cleanup\ entries=Cleanup entries
+Manage\ keywords=Manage keywords
+Merge\ entries=Merge entries
+Open\ folder=Open folder
+Find\ unlinked\ files...=Find unlinked files...
+Hide/show\ toolbar=Hide/show toolbar
 
-Fork_me_on_GitHub=Fork_me_on_GitHub
-Save_selected_as_plain_BibTeX...=Save_selected_as_plain_BibTeX...
+Fork\ me\ on\ GitHub=Fork me on GitHub
+Save\ selected\ as\ plain\ BibTeX...=Save selected as plain BibTeX...
 
 Groups=&Groups
-Delete_entry=Delete_entry
-Check_integrity=Check_integrity
+Delete\ entry=Delete entry
+Check\ integrity=Check integrity
 
 Quality=&Quality
-Online_help_forum=Online_help_forum
-Manage_protected_terms=Manage_protected_terms
+Online\ help\ forum=Online help forum
+Manage\ protected\ terms=Manage protected terms
 Website=Website
 Blog=Blog
-JabRef_resources=JabRef_resources
-Development_version=Development_version
-View_change_log=View_change_log
-Copy_BibTeX_key_and_link=Copy_BibTeX_key_and_link
-Copy_DOI_url=Copy_DOI_url
+JabRef\ resources=JabRef resources
+Development\ version=Development version
+View\ change\ log=View change log
+Copy\ BibTeX\ key\ and\ link=Copy BibTeX key and link
+Copy\ DOI\ url=Copy DOI url
 
-Copy_citation=Copy_citation
-Default_table_font_size=Default_table_font_size
-Show_document_viewer=Show_document_viewer
+Copy\ citation=Copy citation
+Default\ table\ font\ size=Default table font size
+Show\ document\ viewer=Show document viewer

--- a/src/main/resources/l10n/Menu_es.properties
+++ b/src/main/resources/l10n/Menu_es.properties
@@ -1,7 +1,3 @@
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 Abbreviate\ journal\ names\ (ISO)=Abreviar nombres de revistas (ISO)
 Abbreviate\ journal\ names\ (MEDLINE)=Abreviar nombres de revista (MEDLINE)
 About\ JabRef=&Acerca de JabRef

--- a/src/main/resources/l10n/Menu_es.properties
+++ b/src/main/resources/l10n/Menu_es.properties
@@ -2,139 +2,139 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-Abbreviate_journal_names_(ISO)=Abreviar_nombres_de_revistas_(ISO)
-Abbreviate_journal_names_(MEDLINE)=Abreviar_nombres_de_revista_(MEDLINE)
-About_JabRef=&Acerca_de_JabRef
-Append_library=&A\u00f1adir_biblioteca
-Autogenerate_BibTeX_keys=&Autogenerar_claves_de_BibTeX
-Close_library=&Cerrar_biblioteca
+Abbreviate\ journal\ names\ (ISO)=Abreviar nombres de revistas (ISO)
+Abbreviate\ journal\ names\ (MEDLINE)=Abreviar nombres de revista (MEDLINE)
+About\ JabRef=&Acerca de JabRef
+Append\ library=&A\u00f1adir biblioteca
+Autogenerate\ BibTeX\ keys=&Autogenerar claves de BibTeX
+Close\ library=&Cerrar biblioteca
 Copy=C&opiar
-Copy_title=Copiar_título
-Copy_\\cite{BibTeX_key}=Copiar_\\c&ite{clave_BibTeX}
-Copy_BibTeX_key=Copiar_clave_&BibTeX
-Customize_entry_types=&Personalizar_tipos_de_entrada
+Copy\ title=Copiar título
+Copy\ \\cite{BibTeX\ key}=Copiar \\c&ite{clave BibTeX}
+Copy\ BibTeX\ key=Copiar clave &BibTeX
+Customize\ entry\ types=&Personalizar tipos de entrada
 Cut=&Cortar
-Library_properties=&Propiedades_de_la_biblioteca
+Library\ properties=&Propiedades de la biblioteca
 Edit=&Editar
 # Bibtex
-Edit_entry=&Editar_registro
-Edit_preamble=Editar_&preámbulo
-Edit_strings=Editar_&cadenas
+Edit\ entry=&Editar registro
+Edit\ preamble=Editar &preámbulo
+Edit\ strings=Editar &cadenas
 Export=&Exportar
-Export_selected_entries_to_clipboard=&Exportar_registros_seleccionados_al_portapapeles
+Export\ selected\ entries\ to\ clipboard=&Exportar registros seleccionados al portapapeles
 
 # Menu names
 File=&Archivo
-Find_duplicates=&Buscar_duplicados
+Find\ duplicates=&Buscar duplicados
 Help=&Ayuda
 
 # Help
-Online_help=Ayuda_online
-Donate_to_JabRef=Donar_a_JabRef
-Manage_content_selectors=Administrar_selectores_de_&contenido
-Manage_custom_exports=Administrar_&exportaciones_personalizadas
-Manage_custom_imports=Administrar_&importaciones_personalizadas
-Manage_journal_abbreviations=Administrar_abreviaturas_de_publicaciones
-Mark_entries=&Marcar_registros
+Online\ help=Ayuda online
+Donate\ to\ JabRef=Donar a JabRef
+Manage\ content\ selectors=Administrar selectores de &contenido
+Manage\ custom\ exports=Administrar &exportaciones personalizadas
+Manage\ custom\ imports=Administrar &importaciones personalizadas
+Manage\ journal\ abbreviations=Administrar abreviaturas de publicaciones
+Mark\ entries=&Marcar registros
 # File menu
-New_%0_library=Nueva_biblioteca_%0
+New\ %0\ library=Nueva biblioteca %0
 # Menu BibTeX (BibTeX)
-New_entry=Nu&evo_registro
-New_entry_by_type...=&Nuevo_registro...
-New_entry_from_plain_text=Nue&vo_registro_desde_texto_sin_formato
-New_sublibrary_based_on_AUX_file=Nueva_sub-biblioteca_a_partir_de_archivo_AU&X
+New\ entry=Nu&evo registro
+New\ entry\ by\ type...=&Nuevo registro...
+New\ entry\ from\ plain\ text=Nue&vo registro desde texto sin formato
+New\ sublibrary\ based\ on\ AUX\ file=Nueva sub-biblioteca a partir de archivo AU&X
 # View
-Next_tab=Pestaña_&siguiente
-Open_library=&Abrir_biblioteca
-Open_URL_or_DOI=Abrir_&URL_o_DOI
-Connect_to_shared_database=Conectar_a_biblioteca_compartida
-Open_terminal_here=Abrir_terminal_aquí
+Next\ tab=Pestaña &siguiente
+Open\ library=&Abrir biblioteca
+Open\ URL\ or\ DOI=Abrir &URL o DOI
+Connect\ to\ shared\ database=Conectar a biblioteca compartida
+Open\ terminal\ here=Abrir terminal aquí
 Options=&Opciones
 Paste=&Pegar
 # Options
 Preferences=&Preferencias
-Previous_tab=&Pestaña_anterior
+Previous\ tab=&Pestaña anterior
 Quit=&Salir
-Recent_libraries=bibliotecas_&recientes
+Recent\ libraries=bibliotecas &recientes
 Redo=&Rehacer
-Replace_string=&Reemplazar_cadena
-Save_library=&Guardar_biblioteca
-Save_library_as...=Gu&ardar_biblioteca_como...
-Save_selected_as...=Guardar_se&leccionados_como...
+Replace\ string=&Reemplazar cadena
+Save\ library=&Guardar biblioteca
+Save\ library\ as...=Gu&ardar biblioteca como...
+Save\ selected\ as...=Guardar se&leccionados como...
 # Tools
 Search=&Buscar
-Select_all=Seleccionar_&todos
-Set_up_general_fields=Establecer_&campos_generales
-View_event_log=Ver_visor_de_eventos
-Sort_tabs=&Ordenar_pestañas
-Next_preview_layout=Plantilla_de_previsualización_siguiente
-Previous_preview_layout=Plantilla_de_previsualización_previa
+Select\ all=Seleccionar &todos
+Set\ up\ general\ fields=Establecer &campos generales
+View\ event\ log=Ver visor de eventos
+Sort\ tabs=&Ordenar pestañas
+Next\ preview\ layout=Plantilla de previsualización siguiente
+Previous\ preview\ layout=Plantilla de previsualización previa
 # Export menu
-Toggle_entry_preview=A&ctivar/Desactivar_previsualización_de_registro
-Toggle_groups_interface=Activar/Desactivar_ventana_de_&grupos
+Toggle\ entry\ preview=A&ctivar/Desactivar previsualización de registro
+Toggle\ groups\ interface=Activar/Desactivar ventana de &grupos
 Tools=&Herramientas
-Unabbreviate_journal_names=Quitar_abreviatción_de_nombres_de_journal
+Unabbreviate\ journal\ names=Quitar abreviatción de nombres de journal
 # Edit
 Undo=&Deshacer
-Mark_specific_color=Color_espec\u00edfico_de_la_marca
-Unmark_all=Anular_selección_de_todos_los_registros
-Unmark_entries=Anular_selecció&n__de_registros
+Mark\ specific\ color=Color espec\u00edfico de la marca
+Unmark\ all=Anular selección de todos los registros
+Unmark\ entries=Anular selecció&n  de registros
 View=&Ver
-Import_into_new_library=Importar_a_una_nueva_biblioteca
-Import_into_current_library=Importar_a_la_biblioteca_actual
+Import\ into\ new\ library=Importar a una nueva biblioteca
+Import\ into\ current\ library=Importar a la biblioteca actual
 
-Switch_to_%0_mode=Cambiar_a_modo_%0
-Push_entries_to_external_application_(%0)=Agregar_registros_a_aplicación_externa_(%0)
-Pull_changes_from_shared_database=Recuperar_cambios_desde_biblioteca_compartida
-Write_XMP-metadata_to_PDFs=Escribir_metadatos_XMP_a_PDF
+Switch\ to\ %0\ mode=Cambiar a modo %0
+Push\ entries\ to\ external\ application\ (%0)=Agregar registros a aplicación externa (%0)
+Pull\ changes\ from\ shared\ database=Recuperar cambios desde biblioteca compartida
+Write\ XMP-metadata\ to\ PDFs=Escribir metadatos XMP a PDF
 
-Export_selected_entries=Exportar_registros_seleccionados
+Export\ selected\ entries=Exportar registros seleccionados
 
-Save_all=Guardar_todo
+Save\ all=Guardar todo
 
-Manage_external_file_types=Administrar_tipos_de_archivo_externos
+Manage\ external\ file\ types=Administrar tipos de archivo externos
 
-Open_file=Abrir_archivo
+Open\ file=Abrir archivo
 
-Focus_entry_table=Foco_sobre_tabla_de_entradas
+Focus\ entry\ table=Foco sobre tabla de entradas
 
-Increase_table_font_size=&Incrementar_tama\u00f1o_de_fuente_en_tabla
-Decrease_table_font_size=&Disminuir_tama\u00f1o_de_fuente_en_tabla
+Increase\ table\ font\ size=&Incrementar tama\u00f1o de fuente en tabla
+Decrease\ table\ font\ size=&Disminuir tama\u00f1o de fuente en tabla
 Forward=Avanzar
 Back=Retroceder
 
-Look_up_document_identifier...=Bloquear_identificador_de_documento
-Look_up_full_text_documents=Bloquear_documentos_con_texto_completo
-Set/clear/append/rename_fields=Establecer/limpiar/renombrar_campos
+Look\ up\ document\ identifier...=Bloquear identificador de documento
+Look\ up\ full\ text\ documents=Bloquear documentos con texto completo
+Set/clear/append/rename\ fields=Establecer/limpiar/renombrar campos
 
-Resolve_duplicate_BibTeX_keys=Resolver_claves_BibTeX_duplicadas
-Copy_BibTeX_key_and_title=Copiar_clave_y_t\u00edtulo_BibTeX
+Resolve\ duplicate\ BibTeX\ keys=Resolver claves BibTeX duplicadas
+Copy\ BibTeX\ key\ and\ title=Copiar clave y t\u00edtulo BibTeX
 
-Cleanup_entries=Limpiar_entradas
-Manage_keywords=Administrar_palabras_clave
-Merge_entries=Fusionar_entradas
-Open_folder=Abrir_pasta
-Find_unlinked_files...=Buscar_archivos_desenlazados...
-Hide/show_toolbar=Mostrar/ocultar_barra_de_herramientas
+Cleanup\ entries=Limpiar entradas
+Manage\ keywords=Administrar palabras clave
+Merge\ entries=Fusionar entradas
+Open\ folder=Abrir pasta
+Find\ unlinked\ files...=Buscar archivos desenlazados...
+Hide/show\ toolbar=Mostrar/ocultar barra de herramientas
 
-Fork_me_on_GitHub=Fork_en_GitHub
-Save_selected_as_plain_BibTeX...=Guardar_seleccionados_como_BibTeX_plano...
+Fork\ me\ on\ GitHub=Fork en GitHub
+Save\ selected\ as\ plain\ BibTeX...=Guardar seleccionados como BibTeX plano...
 
 Groups=Grupos
-Delete_entry=Borrar_entrada
-Check_integrity=Verificar_Integridad
+Delete\ entry=Borrar entrada
+Check\ integrity=Verificar Integridad
 
 Quality=Calidad
-Online_help_forum=Foro_de_ayuda_en_línea
-Manage_protected_terms=gestionar_términos_protegidos
-Website=Sitio_web
+Online\ help\ forum=Foro de ayuda en línea
+Manage\ protected\ terms=gestionar términos protegidos
+Website=Sitio web
 Blog=Blog
-JabRef_resources=Recursos_sobre_JabRef
-Development_version=Versión_de_desarrollo
-View_change_log=Ver_registro_de_cambios
-Copy_BibTeX_key_and_link=Copiar_clave_BibTeX_y_enlace
-Copy_DOI_url=Copiar_la_url_del_DOI
+JabRef\ resources=Recursos sobre JabRef
+Development\ version=Versión de desarrollo
+View\ change\ log=Ver registro de cambios
+Copy\ BibTeX\ key\ and\ link=Copiar clave BibTeX y enlace
+Copy\ DOI\ url=Copiar la url del DOI
 
-Copy_citation=Copiar_cita
-Default_table_font_size=Tamaño_de_fuente_por_defecto_para_tabla
-Show_document_viewer=Mostrar_visor_de_documentos
+Copy\ citation=Copiar cita
+Default\ table\ font\ size=Tamaño de fuente por defecto para tabla
+Show\ document\ viewer=Mostrar visor de documentos

--- a/src/main/resources/l10n/Menu_fa.properties
+++ b/src/main/resources/l10n/Menu_fa.properties
@@ -1,7 +1,3 @@
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 Abbreviate\ journal\ names\ (ISO)=مخفف‌سازی نام ژورنال‌ها
 Abbreviate\ journal\ names\ (MEDLINE)=خلاصه نام ژورنال‌ها (MEDLINE)
 About\ JabRef=درباره‌ی JabRef

--- a/src/main/resources/l10n/Menu_fa.properties
+++ b/src/main/resources/l10n/Menu_fa.properties
@@ -2,139 +2,139 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-Abbreviate_journal_names_(ISO)=مخفف‌سازی_نام_ژورنال‌ها
-Abbreviate_journal_names_(MEDLINE)=خلاصه_نام_ژورنال‌ها_(MEDLINE)
-About_JabRef=درباره‌ی_JabRef
-Append_library=افزودن_پایگاه_داده
-Autogenerate_BibTeX_keys=تولید_خودکار_کلید_BibTeX
-Close_library=بستن_پایگاه_داده
+Abbreviate\ journal\ names\ (ISO)=مخفف‌سازی نام ژورنال‌ها
+Abbreviate\ journal\ names\ (MEDLINE)=خلاصه نام ژورنال‌ها (MEDLINE)
+About\ JabRef=درباره‌ی JabRef
+Append\ library=افزودن پایگاه داده
+Autogenerate\ BibTeX\ keys=تولید خودکار کلید BibTeX
+Close\ library=بستن پایگاه داده
 Copy=رونوشت
-Copy_title=
-Copy_\\cite{BibTeX_key}=رونوشت_\\cite{key_BibTeX}
-Copy_BibTeX_key=رونوشت_از_کلید_BibTeX
-Customize_entry_types=سفارشی_کردن_نوع_ورودی
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=رونوشت \\cite{key BibTeX}
+Copy\ BibTeX\ key=رونوشت از کلید BibTeX
+Customize\ entry\ types=سفارشی کردن نوع ورودی
 Cut=برش
-Library_properties=خصوصیات_پایگاه_داده
+Library\ properties=خصوصیات پایگاه داده
 Edit=ویرایش
 # Bibtex
-Edit_entry=ویرایش_ورودی
-Edit_preamble=ویرایش_مقدمه
-Edit_strings=ویرایش_رشته
+Edit\ entry=ویرایش ورودی
+Edit\ preamble=ویرایش مقدمه
+Edit\ strings=ویرایش رشته
 Export=فرستادن
-Export_selected_entries_to_clipboard=فرستادن_موارد_منتخب_به_بریده‌دان
+Export\ selected\ entries\ to\ clipboard=فرستادن موارد منتخب به بریده‌دان
 
 # Menu names
 File=پرونده
-Find_duplicates=یافتن_تکراری‌ها
+Find\ duplicates=یافتن تکراری‌ها
 Help=راهنما
 
 # Help
-Online_help=
-Donate_to_JabRef=هدیه_دادن_به_JabRef
-Manage_content_selectors=مدیریت_انتخاب‌گران_مضمون
-Manage_custom_exports=مدیریت_فرستادن_سفارشی
-Manage_custom_imports=مدیریت_واردکنندگان_سفارشی
-Manage_journal_abbreviations=مدیریت_مخفف_ژورنال‌ها
-Mark_entries=نشان_گذاری_ورودی‌ها
+Online\ help=
+Donate\ to\ JabRef=هدیه دادن به JabRef
+Manage\ content\ selectors=مدیریت انتخاب‌گران مضمون
+Manage\ custom\ exports=مدیریت فرستادن سفارشی
+Manage\ custom\ imports=مدیریت واردکنندگان سفارشی
+Manage\ journal\ abbreviations=مدیریت مخفف ژورنال‌ها
+Mark\ entries=نشان گذاری ورودی‌ها
 # File menu
-New_%0_library=پایگاه‌داده‌ی_%0_جدید
+New\ %0\ library=پایگاه‌داده‌ی %0 جدید
 # Menu BibTeX (BibTeX)
-New_entry=ورودی_جدید
-New_entry_by_type...=ورودی_جدید...
-New_entry_from_plain_text=ورودی_جدید_از_نوشته_ساده
-New_sublibrary_based_on_AUX_file=پایگاه_داده_جدید_براساس_پرونده_AUX
+New\ entry=ورودی جدید
+New\ entry\ by\ type...=ورودی جدید...
+New\ entry\ from\ plain\ text=ورودی جدید از نوشته ساده
+New\ sublibrary\ based\ on\ AUX\ file=پایگاه داده جدید براساس پرونده AUX
 # View
-Next_tab=سربرگ_جدید
-Open_library=بازکردن_پایگاه_داده
-Open_URL_or_DOI=بازکردن_URL_یا_DOI
-Connect_to_shared_database=
-Open_terminal_here=در_اینجا_پایانه_را_باز_کن
+Next\ tab=سربرگ جدید
+Open\ library=بازکردن پایگاه داده
+Open\ URL\ or\ DOI=بازکردن URL یا DOI
+Connect\ to\ shared\ database=
+Open\ terminal\ here=در اینجا پایانه را باز کن
 Options=تنظیمات
 Paste=چسباندن
 # Options
 Preferences=پیکربندی
-Previous_tab=سربرگ_قبلی
+Previous\ tab=سربرگ قبلی
 Quit=خروج
-Recent_libraries=پرونده‌های_اخیر
-Redo=دوباره_انجام_دادن
-Replace_string=تعویض_رشته
-Save_library=ذخیره‌ی_پایگاه_داده
-Save_library_as...=ذخیره‌ی_پایگاه_داده_در
-Save_selected_as...=ذخیره‌ی_انتخاب_شده_در
+Recent\ libraries=پرونده‌های اخیر
+Redo=دوباره انجام دادن
+Replace\ string=تعویض رشته
+Save\ library=ذخیره‌ی پایگاه داده
+Save\ library\ as...=ذخیره‌ی پایگاه داده در
+Save\ selected\ as...=ذخیره‌ی انتخاب شده در
 # Tools
 Search=جستجو
-Select_all=انتخاب_همه
-Set_up_general_fields=نصب_کردن_حوزه‌های_کلی
-View_event_log=
-Sort_tabs=دسته‌بندی_کردن_سربرگ‌ها
-Next_preview_layout=
-Previous_preview_layout=
+Select\ all=انتخاب همه
+Set\ up\ general\ fields=نصب کردن حوزه‌های کلی
+View\ event\ log=
+Sort\ tabs=دسته‌بندی کردن سربرگ‌ها
+Next\ preview\ layout=
+Previous\ preview\ layout=
 # Export menu
-Toggle_entry_preview=انتصاب_پیش‌نمایش_ورودی‌ها
-Toggle_groups_interface=انتصاب_واسط_گروه‌ها
+Toggle\ entry\ preview=انتصاب پیش‌نمایش ورودی‌ها
+Toggle\ groups\ interface=انتصاب واسط گروه‌ها
 Tools=ابزارها
-Unabbreviate_journal_names=برداشتن_مخفف_نام_ژورنال‌ها
+Unabbreviate\ journal\ names=برداشتن مخفف نام ژورنال‌ها
 # Edit
-Undo=خنثی_کردن
-Mark_specific_color=نشان‌گذاری_رنگ_ویژه
-Unmark_all=بی‌نشان_کردن_همه
-Unmark_entries=بی‌نشان_کردن_ورودی‌ها
+Undo=خنثی کردن
+Mark\ specific\ color=نشان‌گذاری رنگ ویژه
+Unmark\ all=بی‌نشان کردن همه
+Unmark\ entries=بی‌نشان کردن ورودی‌ها
 View=نمایش
-Import_into_new_library=وارد_کردن_به_پایگاه_داده‌ی_جدید
-Import_into_current_library=وارد_کردن_به_پایگاه_داده‌ی_فعلی
+Import\ into\ new\ library=وارد کردن به پایگاه داده‌ی جدید
+Import\ into\ current\ library=وارد کردن به پایگاه داده‌ی فعلی
 
-Switch_to_%0_mode=تعویض_به_حالت_%0
-Push_entries_to_external_application_(%0)=(نشاندن_ورودی‌ها_به_برنامه‌ی_خارجی_(%0
-Pull_changes_from_shared_database=
-Write_XMP-metadata_to_PDFs=نوشتن_XMP-metadata_در_PDFها
+Switch\ to\ %0\ mode=تعویض به حالت %0
+Push\ entries\ to\ external\ application\ (%0)=(نشاندن ورودی‌ها به برنامه‌ی خارجی (%0
+Pull\ changes\ from\ shared\ database=
+Write\ XMP-metadata\ to\ PDFs=نوشتن XMP-metadata در PDFها
 
-Export_selected_entries=فرستادن_موارد_منتخب
+Export\ selected\ entries=فرستادن موارد منتخب
 
-Save_all=ذخیره‌ی_همه
+Save\ all=ذخیره‌ی همه
 
-Manage_external_file_types=مدیریت_نوع_پرونده‌های_خارجی
+Manage\ external\ file\ types=مدیریت نوع پرونده‌های خارجی
 
-Open_file=بازکردن_پرونده
+Open\ file=بازکردن پرونده
 
-Focus_entry_table=تمرکز_بر_جدول_ورودی
+Focus\ entry\ table=تمرکز بر جدول ورودی
 
-Increase_table_font_size=افزایش_اندازه‌ی_قلم_جدول
-Decrease_table_font_size=کاهش_اندازه‌ی_قلم_جدول
+Increase\ table\ font\ size=افزایش اندازه‌ی قلم جدول
+Decrease\ table\ font\ size=کاهش اندازه‌ی قلم جدول
 Forward=بعد
 Back=قبل
 
-Look_up_document_identifier...=
-Look_up_full_text_documents=
-Set/clear/append/rename_fields=تنظیم/حذف/تغییرنام_حوزه‌ها
+Look\ up\ document\ identifier...=
+Look\ up\ full\ text\ documents=
+Set/clear/append/rename\ fields=تنظیم/حذف/تغییرنام حوزه‌ها
 
-Resolve_duplicate_BibTeX_keys=حل_کلیدهای_تکراری_BibTeX
-Copy_BibTeX_key_and_title=رونوشت_کلید_BibTeX_و_عنوان
+Resolve\ duplicate\ BibTeX\ keys=حل کلیدهای تکراری BibTeX
+Copy\ BibTeX\ key\ and\ title=رونوشت کلید BibTeX و عنوان
 
-Cleanup_entries=تمیز_کردن_ورودی‌ها
-Manage_keywords=مدیریت_کلیدواژه‌ها
-Merge_entries=ترکیب_کردن_ورودی‌ها
-Open_folder=بازکردن_پوشه
-Find_unlinked_files...=یافتن_پرونده‌های_جدا_شده
-Hide/show_toolbar=مخفی‌کردن/نمایش_نوار_ابزار
+Cleanup\ entries=تمیز کردن ورودی‌ها
+Manage\ keywords=مدیریت کلیدواژه‌ها
+Merge\ entries=ترکیب کردن ورودی‌ها
+Open\ folder=بازکردن پوشه
+Find\ unlinked\ files...=یافتن پرونده‌های جدا شده
+Hide/show\ toolbar=مخفی‌کردن/نمایش نوار ابزار
 
-Fork_me_on_GitHub=مرا_در_GitHub_منشعب_کن
-Save_selected_as_plain_BibTeX...=.=منتخب‌شده_را_به_صورت_متن_خام_BibTeX_ذخیره_کن
+Fork\ me\ on\ GitHub=مرا در GitHub منشعب کن
+Save\ selected\ as\ plain\ BibTeX...=.=منتخب‌شده را به صورت متن خام BibTeX ذخیره کن
 
 Groups=گروه‌ها
-Delete_entry=حذف_مدخل
-Check_integrity=بررسی_بی‌نقصی
+Delete\ entry=حذف مدخل
+Check\ integrity=بررسی بی‌نقصی
 
 Quality=کیفیت
-Online_help_forum=
-Manage_protected_terms=
+Online\ help\ forum=
+Manage\ protected\ terms=
 Website=
 Blog=
-JabRef_resources=
-Development_version=
-View_change_log=
-Copy_BibTeX_key_and_link=
-Copy_DOI_url=
+JabRef\ resources=
+Development\ version=
+View\ change\ log=
+Copy\ BibTeX\ key\ and\ link=
+Copy\ DOI\ url=
 
-Copy_citation=
-Default_table_font_size=
-Show_document_viewer=
+Copy\ citation=
+Default\ table\ font\ size=
+Show\ document\ viewer=

--- a/src/main/resources/l10n/Menu_fr.properties
+++ b/src/main/resources/l10n/Menu_fr.properties
@@ -2,139 +2,139 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-Abbreviate_journal_names_(ISO)=Abréger_les_noms_de_journaux_(IS&O)
-Abbreviate_journal_names_(MEDLINE)=Abréger_les_noms_de_journaux_(MEDLI&NE)
-About_JabRef=A_&propos_de_JabRef
-Append_library=&Joindre_au_fichier
-Autogenerate_BibTeX_keys=Création_&automatique_des_clés_BibTeX
-Close_library=&Fermer_le_fichier
+Abbreviate\ journal\ names\ (ISO)=Abréger les noms de journaux (IS&O)
+Abbreviate\ journal\ names\ (MEDLINE)=Abréger les noms de journaux (MEDLI&NE)
+About\ JabRef=A &propos de JabRef
+Append\ library=&Joindre au fichier
+Autogenerate\ BibTeX\ keys=Création &automatique des clés BibTeX
+Close\ library=&Fermer le fichier
 Copy=Co&pier
-Copy_title=Copier_le_titre
-Copy_\\cite{BibTeX_key}=Copier_\\c&ite{clé_BibTeX}
-Copy_BibTeX_key=Copier_la_clé_&BibTeX
-Customize_entry_types=Personnaliser_les_&types_d'entrées
+Copy\ title=Copier le titre
+Copy\ \\cite{BibTeX\ key}=Copier \\c&ite{clé BibTeX}
+Copy\ BibTeX\ key=Copier la clé &BibTeX
+Customize\ entry\ types=Personnaliser les &types d'entrées
 Cut=&Couper
-Library_properties=&Propriétés_du_fichier
+Library\ properties=&Propriétés du fichier
 Edit=&Edition
 # Bibtex
-Edit_entry=&Editer_l'entrée
-Edit_preamble=Editer_le_&préambule
-Edit_strings=Editer_les_c&haînes
+Edit\ entry=&Editer l'entrée
+Edit\ preamble=Editer le &préambule
+Edit\ strings=Editer les c&haînes
 Export=&Exporter
-Export_selected_entries_to_clipboard=Exporter_les_entrées_sélectionnées_vers_le_presse-papiers
+Export\ selected\ entries\ to\ clipboard=Exporter les entrées sélectionnées vers le presse-papiers
 
 # Menu names
 File=&Fichier
-Find_duplicates=Chercher_les_&doublons
+Find\ duplicates=Chercher les &doublons
 Help=Ai&de
 
 # Help
-Online_help=Aide_en_ligne
-Donate_to_JabRef=Faire_un_don_à_JabRef
-Manage_content_selectors=&G\u00e9rer_les_s\u00e9lecteurs_de_contenu
-Manage_custom_exports=&Gérer_les_exportations_personnalisées
-Manage_custom_imports=Gérer_les_&importations_personnalisées
-Manage_journal_abbreviations=Gérer_les_abréviations_de_&journaux
-Mark_entries=Etiqueter_des_&entrées
+Online\ help=Aide en ligne
+Donate\ to\ JabRef=Faire un don à JabRef
+Manage\ content\ selectors=&G\u00e9rer les s\u00e9lecteurs de contenu
+Manage\ custom\ exports=&Gérer les exportations personnalisées
+Manage\ custom\ imports=Gérer les &importations personnalisées
+Manage\ journal\ abbreviations=Gérer les abréviations de &journaux
+Mark\ entries=Etiqueter des &entrées
 # File menu
-New_%0_library=Nouveau_fichier_%0
+New\ %0\ library=Nouveau fichier %0
 # Menu BibTeX (BibTeX)
-New_entry=N&ouvelle_entrée
-New_entry_by_type...=&Nouvelle_entrée...
-New_entry_from_plain_text=Nouvelle_entrée_depuis_&texte_brut
-New_sublibrary_based_on_AUX_file=Nouveau_sous-fichier_BibTeX_depuis_fichier_AU&X
+New\ entry=N&ouvelle entrée
+New\ entry\ by\ type...=&Nouvelle entrée...
+New\ entry\ from\ plain\ text=Nouvelle entrée depuis &texte brut
+New\ sublibrary\ based\ on\ AUX\ file=Nouveau sous-fichier BibTeX depuis fichier AU&X
 # View
-Next_tab=Onglet_&suivant
-Open_library=&Ouvrir_fichier
-Open_URL_or_DOI=Ouvrir_&URL_ou_DOI
-Connect_to_shared_database=Ouvrir_base_partagée
-Open_terminal_here=Ouvrir_un_terminal_ici
+Next\ tab=Onglet &suivant
+Open\ library=&Ouvrir fichier
+Open\ URL\ or\ DOI=Ouvrir &URL ou DOI
+Connect\ to\ shared\ database=Ouvrir base partagée
+Open\ terminal\ here=Ouvrir un terminal ici
 Options=Opt&ions
 Paste=C&oller
 # Options
 Preferences=&Préférences
-Previous_tab=Onglet_&précédent
+Previous\ tab=Onglet &précédent
 Quit=&Quitter
-Recent_libraries=Fichiers_&récents
+Recent\ libraries=Fichiers &récents
 Redo=&Répéter
-Replace_string=Remplacer_la_c&haîne
-Save_library=Enregistrer_le_fichier
-Save_library_as...=Enregistrer_le_fichier_sous_...
-Save_selected_as...=Enregistrer_la_sé&lection_sous_...
+Replace\ string=Remplacer la c&haîne
+Save\ library=Enregistrer le fichier
+Save\ library\ as...=Enregistrer le fichier sous ...
+Save\ selected\ as...=Enregistrer la sé&lection sous ...
 # Tools
 Search=&Recherche
-Select_all=&Tout_sélectionner
-Set_up_general_fields=Configurer_les_champs_&généraux
-View_event_log=Afficher_le_journal_des_évènements
-Sort_tabs=Trier_les_onglets
-Next_preview_layout=Mode_d'aperçu_suivant
-Previous_preview_layout=Mode_d'aperçu_précédent
+Select\ all=&Tout sélectionner
+Set\ up\ general\ fields=Configurer les champs &généraux
+View\ event\ log=Afficher le journal des évènements
+Sort\ tabs=Trier les onglets
+Next\ preview\ layout=Mode d'aperçu suivant
+Previous\ preview\ layout=Mode d'aperçu précédent
 # Export menu
-Toggle_entry_preview=&Afficher/masquer_l'aperçu
-Toggle_groups_interface=Afficher/masquer_l'interface_des_&groupes
+Toggle\ entry\ preview=&Afficher/masquer l'aperçu
+Toggle\ groups\ interface=Afficher/masquer l'interface des &groupes
 Tools=&Outils
-Unabbreviate_journal_names=Dé&velopper_les_noms_de_journaux
+Unabbreviate\ journal\ names=Dé&velopper les noms de journaux
 # Edit
 Undo=&Annuler
-Mark_specific_color=Marquer_d'une_couleur_spécifique
-Unmark_all=To&ut_désétiqueter
-Unmark_entries=&Désétiqueter_des_entrées
+Mark\ specific\ color=Marquer d'une couleur spécifique
+Unmark\ all=To&ut désétiqueter
+Unmark\ entries=&Désétiqueter des entrées
 View=&Affichage
-Import_into_new_library=Importer_dans_un_nouveau_fichier
-Import_into_current_library=Importer_dans_le_fichier_courant
+Import\ into\ new\ library=Importer dans un nouveau fichier
+Import\ into\ current\ library=Importer dans le fichier courant
 
-Switch_to_%0_mode=Basculer_dans_le_mode_%0
-Push_entries_to_external_application_(%0)=Envoyer_l'entrée_vers_l'application_externe_(%0)
-Pull_changes_from_shared_database=Récupérer_les_modif._depuis_la_base_partagée
-Write_XMP-metadata_to_PDFs=Ecrire_les_métadonnées_XMP_dans_les_PDFs
+Switch\ to\ %0\ mode=Basculer dans le mode %0
+Push\ entries\ to\ external\ application\ (%0)=Envoyer l'entrée vers l'application externe (%0)
+Pull\ changes\ from\ shared\ database=Récupérer les modif. depuis la base partagée
+Write\ XMP-metadata\ to\ PDFs=Ecrire les métadonnées XMP dans les PDFs
 
-Export_selected_entries=Exporter_les_entrées_sélectionnées
+Export\ selected\ entries=Exporter les entrées sélectionnées
 
-Save_all=Enregistrer_tout
+Save\ all=Enregistrer tout
 
-Manage_external_file_types=Gérer_les_types_de_fichiers_externes
+Manage\ external\ file\ types=Gérer les types de fichiers externes
 
-Open_file=Ouvrir_un_fichier
+Open\ file=Ouvrir un fichier
 
-Focus_entry_table=Curseur_dans_la_table_des_entrées
+Focus\ entry\ table=Curseur dans la table des entrées
 
-Increase_table_font_size=&Augmenter_la_taille_de_police_de_la_table
-Decrease_table_font_size=&Diminuer_la_taille_de_police_de_la_table
+Increase\ table\ font\ size=&Augmenter la taille de police de la table
+Decrease\ table\ font\ size=&Diminuer la taille de police de la table
 Forward=Suivant
 Back=Précédent
 
-Look_up_document_identifier...=Chercher_l'identifiant_du_document...
-Look_up_full_text_documents=Télécharger_les_documents_cité
-Set/clear/append/rename_fields=Configurer/vider/renommer_des_champs
+Look\ up\ document\ identifier...=Chercher l'identifiant du document...
+Look\ up\ full\ text\ documents=Télécharger les documents cité
+Set/clear/append/rename\ fields=Configurer/vider/renommer des champs
 
-Resolve_duplicate_BibTeX_keys=Traitement_des_clefs_BibTeX_dupliquées
-Copy_BibTeX_key_and_title=Copier_la_clef_BibTeX_et_le_titre
+Resolve\ duplicate\ BibTeX\ keys=Traitement des clefs BibTeX dupliquées
+Copy\ BibTeX\ key\ and\ title=Copier la clef BibTeX et le titre
 
-Cleanup_entries=Nettoyage_des_entrées
-Manage_keywords=Gérer_les_mots-clefs
-Merge_entries=Fusionner_les_entrées
-Open_folder=Ouvrir_le_répertoire
-Find_unlinked_files...=Trouver_les_fichiers_non_liés...
-Hide/show_toolbar=Afficher/masquer_la_barre_d'outils
+Cleanup\ entries=Nettoyage des entrées
+Manage\ keywords=Gérer les mots-clefs
+Merge\ entries=Fusionner les entrées
+Open\ folder=Ouvrir le répertoire
+Find\ unlinked\ files...=Trouver les fichiers non liés...
+Hide/show\ toolbar=Afficher/masquer la barre d'outils
 
-Fork_me_on_GitHub=Forkez-moi_sur_GitHub
-Save_selected_as_plain_BibTeX...=Enregistrer_la_sélection_en_BibTeX_basique...
+Fork\ me\ on\ GitHub=Forkez-moi sur GitHub
+Save\ selected\ as\ plain\ BibTeX...=Enregistrer la sélection en BibTeX basique...
 
 Groups=Groupes
-Delete_entry=Supprimer_l'entrée
-Check_integrity=Vérifier_l'intégrité
+Delete\ entry=Supprimer l'entrée
+Check\ integrity=Vérifier l'intégrité
 
 Quality=Qualité
-Online_help_forum=Forum_d'aide_en_ligne
-Manage_protected_terms=Gérer_les_termes_protégés
-Website=Site_Internet
+Online\ help\ forum=Forum d'aide en ligne
+Manage\ protected\ terms=Gérer les termes protégés
+Website=Site Internet
 Blog=Blog
-JabRef_resources=Plus_sur_JabRef
-Development_version=Version_en_développement
-View_change_log=Afficher_le_fichier_des_changements
-Copy_BibTeX_key_and_link=Copier_la_clef_BibTeX_et_le_lien
-Copy_DOI_url=Copier_l'URL_du_DOI
+JabRef\ resources=Plus sur JabRef
+Development\ version=Version en développement
+View\ change\ log=Afficher le fichier des changements
+Copy\ BibTeX\ key\ and\ link=Copier la clef BibTeX et le lien
+Copy\ DOI\ url=Copier l'URL du DOI
 
-Copy_citation=Copier_la_citation
-Default_table_font_size=Taille_de_police_par_défaut
-Show_document_viewer=Ouvrir_l'afficheur_de_document
+Copy\ citation=Copier la citation
+Default\ table\ font\ size=Taille de police par défaut
+Show\ document\ viewer=Ouvrir l'afficheur de document

--- a/src/main/resources/l10n/Menu_fr.properties
+++ b/src/main/resources/l10n/Menu_fr.properties
@@ -1,7 +1,3 @@
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 Abbreviate\ journal\ names\ (ISO)=Abréger les noms de journaux (IS&O)
 Abbreviate\ journal\ names\ (MEDLINE)=Abréger les noms de journaux (MEDLI&NE)
 About\ JabRef=A &propos de JabRef

--- a/src/main/resources/l10n/Menu_in.properties
+++ b/src/main/resources/l10n/Menu_in.properties
@@ -1,7 +1,3 @@
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 Abbreviate\ journal\ names\ (ISO)=Singkatan nama jurnal (ISO)
 Abbreviate\ journal\ names\ (MEDLINE)=Singkatan nama jurnal (MEDLINE)
 About\ JabRef=Tentang JabRef

--- a/src/main/resources/l10n/Menu_in.properties
+++ b/src/main/resources/l10n/Menu_in.properties
@@ -2,139 +2,139 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-Abbreviate_journal_names_(ISO)=Singkatan_nama_jurnal_(ISO)
-Abbreviate_journal_names_(MEDLINE)=Singkatan_nama_jurnal_(MEDLINE)
-About_JabRef=Tentang_JabRef
-Append_library=Tambah_basisdata
-Autogenerate_BibTeX_keys=Otomatis_kunci_BibTeX
-Close_library=Tutup_library
+Abbreviate\ journal\ names\ (ISO)=Singkatan nama jurnal (ISO)
+Abbreviate\ journal\ names\ (MEDLINE)=Singkatan nama jurnal (MEDLINE)
+About\ JabRef=Tentang JabRef
+Append\ library=Tambah basisdata
+Autogenerate\ BibTeX\ keys=Otomatis kunci BibTeX
+Close\ library=Tutup library
 Copy=Salin
-Copy_title=
-Copy_\\cite{BibTeX_key}=Salin_\\cite{kunci_BibTeX}
-Copy_BibTeX_key=Salin_kunci_BibTeX
-Customize_entry_types=Tipe_entri_atursendiri
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=Salin \\cite{kunci BibTeX}
+Copy\ BibTeX\ key=Salin kunci BibTeX
+Customize\ entry\ types=Tipe entri atursendiri
 Cut=Potong
-Library_properties=Properti_basisdata
+Library\ properties=Properti basisdata
 Edit=&Sunting
 # Bibtex
-Edit_entry=Sunting_entri
-Edit_preamble=Sunting_preamble
-Edit_strings=Sunting_string
+Edit\ entry=Sunting entri
+Edit\ preamble=Sunting preamble
+Edit\ strings=Sunting string
 Export=Ekspor
-Export_selected_entries_to_clipboard=Ekspor_entri_pilihan_ke_papanklip
+Export\ selected\ entries\ to\ clipboard=Ekspor entri pilihan ke papanklip
 
 # Menu names
 File=&Berkas
-Find_duplicates=Temukan_data_yg_sama
+Find\ duplicates=Temukan data yg sama
 Help=Bant&uan
 
 # Help
-Online_help=
-Donate_to_JabRef=Sumbang_ke_JabRef
-Manage_content_selectors=Pengaturan_pengisian_kata
-Manage_custom_exports=Pengaturan_ekspor_atursendiri
-Manage_custom_imports=Pengaturan_impor_atursendiri
-Manage_journal_abbreviations=Pengaturan_singkatan_jurnal
-Mark_entries=Tandai_entri
+Online\ help=
+Donate\ to\ JabRef=Sumbang ke JabRef
+Manage\ content\ selectors=Pengaturan pengisian kata
+Manage\ custom\ exports=Pengaturan ekspor atursendiri
+Manage\ custom\ imports=Pengaturan impor atursendiri
+Manage\ journal\ abbreviations=Pengaturan singkatan jurnal
+Mark\ entries=Tandai entri
 # File menu
-New_%0_library=Basisdata_%0_baru
+New\ %0\ library=Basisdata %0 baru
 # Menu BibTeX (BibTeX)
-New_entry=Entri_baru
-New_entry_by_type...=Entri_baru...
-New_entry_from_plain_text=Entri_baru_dari_teks_biasa
-New_sublibrary_based_on_AUX_file=Anak_basisdata_baru_dari_berkas_AUX
+New\ entry=Entri baru
+New\ entry\ by\ type...=Entri baru...
+New\ entry\ from\ plain\ text=Entri baru dari teks biasa
+New\ sublibrary\ based\ on\ AUX\ file=Anak basisdata baru dari berkas AUX
 # View
-Next_tab=Tab_berikutnya
-Open_library=Buka_basisdata
-Open_URL_or_DOI=Buka_URL_atau_DOI
-Connect_to_shared_database=
-Open_terminal_here=Buka_terminal_di_sini
+Next\ tab=Tab berikutnya
+Open\ library=Buka basisdata
+Open\ URL\ or\ DOI=Buka URL atau DOI
+Connect\ to\ shared\ database=
+Open\ terminal\ here=Buka terminal di sini
 Options=Pen&gaturan
 Paste=Tempelkan
 # Options
 Preferences=Preferensi
-Previous_tab=Tab_sebelumnya
+Previous\ tab=Tab sebelumnya
 Quit=Keluar
-Recent_libraries=Berkas_terkini
-Redo=Jadi_lagi
-Replace_string=Ganti_string
-Save_library=Simpan_basisdata
-Save_library_as...=Simpan_basis_data_sebagai...
-Save_selected_as...=Simpan_pilihan_sebagai...
+Recent\ libraries=Berkas terkini
+Redo=Jadi lagi
+Replace\ string=Ganti string
+Save\ library=Simpan basisdata
+Save\ library\ as...=Simpan basis data sebagai...
+Save\ selected\ as...=Simpan pilihan sebagai...
 # Tools
 Search=Cari
-Select_all=Pilih_semua
-Set_up_general_fields=Penetapan_bidang_umum
-View_event_log=
-Sort_tabs=Urutkan_tab
-Next_preview_layout=
-Previous_preview_layout=
+Select\ all=Pilih semua
+Set\ up\ general\ fields=Penetapan bidang umum
+View\ event\ log=
+Sort\ tabs=Urutkan tab
+Next\ preview\ layout=
+Previous\ preview\ layout=
 # Export menu
-Toggle_entry_preview=Tampilkan_entri
-Toggle_groups_interface=Aktifkan_antarmuka_grup
+Toggle\ entry\ preview=Tampilkan entri
+Toggle\ groups\ interface=Aktifkan antarmuka grup
 Tools=&AlatBantuan
-Unabbreviate_journal_names=Nama_jurnal_tidak_disingkat
+Unabbreviate\ journal\ names=Nama jurnal tidak disingkat
 # Edit
-Undo=Tidak_jadi
-Mark_specific_color=Tandai_dengan_warna
-Unmark_all=Lepas_tanda_semua
-Unmark_entries=Lepas_tanda_entri
+Undo=Tidak jadi
+Mark\ specific\ color=Tandai dengan warna
+Unmark\ all=Lepas tanda semua
+Unmark\ entries=Lepas tanda entri
 View=&Tampilan
-Import_into_new_library=Impor_ke_basisdata_baru
-Import_into_current_library=Impor_ke_basisdata_sekarang
+Import\ into\ new\ library=Impor ke basisdata baru
+Import\ into\ current\ library=Impor ke basisdata sekarang
 
-Switch_to_%0_mode=Ubah_ke_mode_%0
-Push_entries_to_external_application_(%0)=Kirim_entri_ke_program_eksternal_(%0)
-Pull_changes_from_shared_database=
-Write_XMP-metadata_to_PDFs=Tulis_metadata_XMP_ke_PSF
+Switch\ to\ %0\ mode=Ubah ke mode %0
+Push\ entries\ to\ external\ application\ (%0)=Kirim entri ke program eksternal (%0)
+Pull\ changes\ from\ shared\ database=
+Write\ XMP-metadata\ to\ PDFs=Tulis metadata XMP ke PSF
 
-Export_selected_entries=Ekspor_entri_pilihan
+Export\ selected\ entries=Ekspor entri pilihan
 
-Save_all=Simpan_semua
+Save\ all=Simpan semua
 
-Manage_external_file_types=Pengaturan_tipe_berkas_eksternal
+Manage\ external\ file\ types=Pengaturan tipe berkas eksternal
 
-Open_file=Buka_berkas
+Open\ file=Buka berkas
 
-Focus_entry_table=Fokus_tabel_entri
+Focus\ entry\ table=Fokus tabel entri
 
-Increase_table_font_size=Besarkan_ukuran_huruf_tabel
-Decrease_table_font_size=Kecilkan_ukuran_huruf_tabel
+Increase\ table\ font\ size=Besarkan ukuran huruf tabel
+Decrease\ table\ font\ size=Kecilkan ukuran huruf tabel
 Forward=Maju
 Back=Mundur
 
-Look_up_document_identifier...=
-Look_up_full_text_documents=
-Set/clear/append/rename_fields=Tetapkan/bersihkan/namai_bidang
+Look\ up\ document\ identifier...=
+Look\ up\ full\ text\ documents=
+Set/clear/append/rename\ fields=Tetapkan/bersihkan/namai bidang
 
-Resolve_duplicate_BibTeX_keys=Menyelesaikan_kesamaan_kunci_BibTeX
-Copy_BibTeX_key_and_title=Salin_kunci_BibTeX_dan_judul
+Resolve\ duplicate\ BibTeX\ keys=Menyelesaikan kesamaan kunci BibTeX
+Copy\ BibTeX\ key\ and\ title=Salin kunci BibTeX dan judul
 
-Cleanup_entries=Bersihkan_entri
-Manage_keywords=Atur_katakunci
-Merge_entries=Gabung_entri
-Open_folder=Buka_direktori
-Find_unlinked_files...=Temukan_berkas_yang_tidak_bertautan
-Hide/show_toolbar=Sembunyikan/tunjukkan_toolbar
+Cleanup\ entries=Bersihkan entri
+Manage\ keywords=Atur katakunci
+Merge\ entries=Gabung entri
+Open\ folder=Buka direktori
+Find\ unlinked\ files...=Temukan berkas yang tidak bertautan
+Hide/show\ toolbar=Sembunyikan/tunjukkan toolbar
 
-Fork_me_on_GitHub=Fork_JabRef_di_GitHub
-Save_selected_as_plain_BibTeX...=Simpan_seleksi_sebagai_BibTeX_teks_biasa
+Fork\ me\ on\ GitHub=Fork JabRef di GitHub
+Save\ selected\ as\ plain\ BibTeX...=Simpan seleksi sebagai BibTeX teks biasa
 
 Groups=Grup
-Delete_entry=Hapus_entri
-Check_integrity=Periksa_Integritas
+Delete\ entry=Hapus entri
+Check\ integrity=Periksa Integritas
 
 Quality=Kualitas
-Online_help_forum=
-Manage_protected_terms=
+Online\ help\ forum=
+Manage\ protected\ terms=
 Website=
 Blog=
-JabRef_resources=
-Development_version=
-View_change_log=
-Copy_BibTeX_key_and_link=
-Copy_DOI_url=
+JabRef\ resources=
+Development\ version=
+View\ change\ log=
+Copy\ BibTeX\ key\ and\ link=
+Copy\ DOI\ url=
 
-Copy_citation=
-Default_table_font_size=
-Show_document_viewer=
+Copy\ citation=
+Default\ table\ font\ size=
+Show\ document\ viewer=

--- a/src/main/resources/l10n/Menu_it.properties
+++ b/src/main/resources/l10n/Menu_it.properties
@@ -2,139 +2,139 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-Abbreviate_journal_names_(ISO)=Abbrevia_nomi_delle_riviste_(ISO)
-Abbreviate_journal_names_(MEDLINE)=Abbrevia_nomi_delle_riviste_(MEDLINE)
-About_JabRef=&Informazioni_su_JabRef
-Append_library=A&ggiungi_alla_libreria
-Autogenerate_BibTeX_keys=Genera_&automaticamente_le_chiavi_BibTeX
-Close_library=C&hiudi_la_libreria
+Abbreviate\ journal\ names\ (ISO)=Abbrevia nomi delle riviste (ISO)
+Abbreviate\ journal\ names\ (MEDLINE)=Abbrevia nomi delle riviste (MEDLINE)
+About\ JabRef=&Informazioni su JabRef
+Append\ library=A&ggiungi alla libreria
+Autogenerate\ BibTeX\ keys=Genera &automaticamente le chiavi BibTeX
+Close\ library=C&hiudi la libreria
 Copy=&Copia
-Copy_title=Copia_il_titolo
-Copy_\\cite{BibTeX_key}=Co&pia_\\cite{chiave_BibTeX}
-Copy_BibTeX_key=C&opia_chiave
-Customize_entry_types=Personalizza_i_&tipi_di_voci
+Copy\ title=Copia il titolo
+Copy\ \\cite{BibTeX\ key}=Co&pia \\cite{chiave BibTeX}
+Copy\ BibTeX\ key=C&opia chiave
+Customize\ entry\ types=Personalizza i &tipi di voci
 Cut=&Taglia
-Library_properties=P&roprietà_della_libreria
+Library\ properties=P&roprietà della libreria
 Edit=&Modifica
 # Bibtex
-Edit_entry=&Modifica_voce
-Edit_preamble=Modifica_&preambolo
-Edit_strings=Modifica_&stringhe
+Edit\ entry=&Modifica voce
+Edit\ preamble=Modifica &preambolo
+Edit\ strings=Modifica &stringhe
 Export=&Esporta
-Export_selected_entries_to_clipboard=Esporta_le_voci_selezionate_negli_appunti
+Export\ selected\ entries\ to\ clipboard=Esporta le voci selezionate negli appunti
 
 # Menu names
 File=&File
-Find_duplicates=Ricerca_&duplicati
+Find\ duplicates=Ricerca &duplicati
 Help=&Aiuto
 
 # Help
-Online_help=Aiuto_online
-Donate_to_JabRef=Fai_una_donazione_a_JabRef
-Manage_content_selectors=&Gestione_dei_selettori_di_contenuti
-Manage_custom_exports=&Gestione_delle_esportazioni_personalizzate
-Manage_custom_imports=Gestione_delle_&importazioni_personalizzate
-Manage_journal_abbreviations=Gestione_delle_&abbreviazioni_delle_riviste
-Mark_entries=E&videnzia
+Online\ help=Aiuto online
+Donate\ to\ JabRef=Fai una donazione a JabRef
+Manage\ content\ selectors=&Gestione dei selettori di contenuti
+Manage\ custom\ exports=&Gestione delle esportazioni personalizzate
+Manage\ custom\ imports=Gestione delle &importazioni personalizzate
+Manage\ journal\ abbreviations=Gestione delle &abbreviazioni delle riviste
+Mark\ entries=E&videnzia
 # File menu
-New_%0_library=Nuova_libreria_%0
+New\ %0\ library=Nuova libreria %0
 # Menu BibTeX (BibTeX)
-New_entry=&Nuova_voce
-New_entry_by_type...=N&uova_voce...
-New_entry_from_plain_text=Nuova_voce_da_&testo
-New_sublibrary_based_on_AUX_file=Nuovo_sottolibreria_da_file_AU&X
+New\ entry=&Nuova voce
+New\ entry\ by\ type...=N&uova voce...
+New\ entry\ from\ plain\ text=Nuova voce da &testo
+New\ sublibrary\ based\ on\ AUX\ file=Nuovo sottolibreria da file AU&X
 # View
-Next_tab=&Scheda_successiva
-Open_library=&Apri_libreria
-Open_URL_or_DOI=Apri_&URL_o_DOI
-Connect_to_shared_database=Apri_libreria_condivisa
-Open_terminal_here=Apri_un_terminale_qui
+Next\ tab=&Scheda successiva
+Open\ library=&Apri libreria
+Open\ URL\ or\ DOI=Apri &URL o DOI
+Connect\ to\ shared\ database=Apri libreria condivisa
+Open\ terminal\ here=Apri un terminale qui
 Options=&Opzioni
 Paste=&Incolla
 # Options
 Preferences=&Preferenze
-Previous_tab=Scheda_&precedente
+Previous\ tab=Scheda &precedente
 Quit=&Uscita
-Recent_libraries=File_recen&ti
+Recent\ libraries=File recen&ti
 Redo=&Ripeti
-Replace_string=&Sostituisci_stringa
-Save_library=&Salva_libreria
-Save_library_as...=Sa&lva_libreria_come_...
-Save_selected_as...=Sal&va_la_selezione_come_...
+Replace\ string=&Sostituisci stringa
+Save\ library=&Salva libreria
+Save\ library\ as...=Sa&lva libreria come ...
+Save\ selected\ as...=Sal&va la selezione come ...
 # Tools
 Search=&Ricerca
-Select_all=Sele&ziona_tutto
-Set_up_general_fields=Configura_i_campi_generali
-View_event_log=Visualizza_il_log_degli_eventi
-Sort_tabs=Ordina_le_schede
-Next_preview_layout=Layout_di_anteprima_successivo
-Previous_preview_layout=Layout_di_anteprima_precedente
+Select\ all=Sele&ziona tutto
+Set\ up\ general\ fields=Configura i campi generali
+View\ event\ log=Visualizza il log degli eventi
+Sort\ tabs=Ordina le schede
+Next\ preview\ layout=Layout di anteprima successivo
+Previous\ preview\ layout=Layout di anteprima precedente
 # Export menu
-Toggle_entry_preview=&Visualizza/nascondi_anteprima
-Toggle_groups_interface=V&isualizza/nascondi_l'interfaccia_dei_gruppi
+Toggle\ entry\ preview=&Visualizza/nascondi anteprima
+Toggle\ groups\ interface=V&isualizza/nascondi l'interfaccia dei gruppi
 Tools=&Strumenti
-Unabbreviate_journal_names=Espandi_nomi_delle_riviste_(MEDLINE)
+Unabbreviate\ journal\ names=Espandi nomi delle riviste (MEDLINE)
 # Edit
 Undo=&Annulla
-Mark_specific_color=E&videnzia_con_un_colore_specifico
-Unmark_all=Rim&uovi_tutte_le_evidenziazioni
-Unmark_entries=&Rimuovi_evidenziazione
+Mark\ specific\ color=E&videnzia con un colore specifico
+Unmark\ all=Rim&uovi tutte le evidenziazioni
+Unmark\ entries=&Rimuovi evidenziazione
 View=&Visualizza
-Import_into_new_library=Importa_in_una_nuo&va_libreria
-Import_into_current_library=Importa_nella_libreria_&corrente
+Import\ into\ new\ library=Importa in una nuo&va libreria
+Import\ into\ current\ library=Importa nella libreria &corrente
 
-Switch_to_%0_mode=Passa_in_modalità_%0
-Push_entries_to_external_application_(%0)=Invia_le_voci_all'applicazione_esterna_(%0)
-Pull_changes_from_shared_database=Recupera_le_modifiche_dalla_libreria_condivisa.
-Write_XMP-metadata_to_PDFs=Inserisci_metadati_XMP_nei_file_PDF
+Switch\ to\ %0\ mode=Passa in modalità %0
+Push\ entries\ to\ external\ application\ (%0)=Invia le voci all'applicazione esterna (%0)
+Pull\ changes\ from\ shared\ database=Recupera le modifiche dalla libreria condivisa.
+Write\ XMP-metadata\ to\ PDFs=Inserisci metadati XMP nei file PDF
 
-Export_selected_entries=Esporta_le_voci_selezionate
+Export\ selected\ entries=Esporta le voci selezionate
 
-Save_all=Salva_tutti
+Save\ all=Salva tutti
 
-Manage_external_file_types=Gestione_dei_tipi_di_file_esterni
+Manage\ external\ file\ types=Gestione dei tipi di file esterni
 
-Open_file=Apri_file
+Open\ file=Apri file
 
-Focus_entry_table=Cursore_nella_tavola_delle_voci
+Focus\ entry\ table=Cursore nella tavola delle voci
 
-Increase_table_font_size=&Aumenta_la_dimensione_dei_caratteri_della_tabella
-Decrease_table_font_size=&Diminuisci_la_dimensione_dei_caratteri_della_tabella
+Increase\ table\ font\ size=&Aumenta la dimensione dei caratteri della tabella
+Decrease\ table\ font\ size=&Diminuisci la dimensione dei caratteri della tabella
 Forward=Seguente
 Back=Precedente
 
-Look_up_document_identifier...=Cerca_l'identificatore_del_documento...
-Look_up_full_text_documents=Cerca_nel_testo_completo_dei_documenti
-Set/clear/append/rename_fields=Imposta_/_svuota_/_rinomina_i_campi
+Look\ up\ document\ identifier...=Cerca l'identificatore del documento...
+Look\ up\ full\ text\ documents=Cerca nel testo completo dei documenti
+Set/clear/append/rename\ fields=Imposta / svuota / rinomina i campi
 
-Resolve_duplicate_BibTeX_keys=Risolvi_le_chiavi_BibTeX_duplicate
-Copy_BibTeX_key_and_title=Copia_la_chiave_BibTeX_ed_il_titolo
+Resolve\ duplicate\ BibTeX\ keys=Risolvi le chiavi BibTeX duplicate
+Copy\ BibTeX\ key\ and\ title=Copia la chiave BibTeX ed il titolo
 
-Cleanup_entries=Pulizia_voci
-Manage_keywords=Gestione_delle_parole_chiave
-Merge_entries=Unisci_voci
-Open_folder=Apri_cartella
-Find_unlinked_files...=Trovati_file_non_collegati...
-Hide/show_toolbar=Mostra/Nascondi_la_barra_degli_strumenti
+Cleanup\ entries=Pulizia voci
+Manage\ keywords=Gestione delle parole chiave
+Merge\ entries=Unisci voci
+Open\ folder=Apri cartella
+Find\ unlinked\ files...=Trovati file non collegati...
+Hide/show\ toolbar=Mostra/Nascondi la barra degli strumenti
 
-Fork_me_on_GitHub=Fork_me_on_GitHub
-Save_selected_as_plain_BibTeX...=Salva_la_selezione_in_formato_BibTeX_base...
+Fork\ me\ on\ GitHub=Fork me on GitHub
+Save\ selected\ as\ plain\ BibTeX...=Salva la selezione in formato BibTeX base...
 
 Groups=Gruppi
-Delete_entry=Cancella_la_voce
-Check_integrity=Verifica_di_integrità
+Delete\ entry=Cancella la voce
+Check\ integrity=Verifica di integrità
 
 Quality=Qualità
-Online_help_forum=Forum_di_aiuto_online
-Manage_protected_terms=Gestione_dei_termini_protetti
-Website=Sito_web
+Online\ help\ forum=Forum di aiuto online
+Manage\ protected\ terms=Gestione dei termini protetti
+Website=Sito web
 Blog=Blog
-JabRef_resources=Risorse_per_JabRef
-Development_version=Versione_di_sviluppo
-View_change_log=Visualizza_la_lista_delle_modifiche
-Copy_BibTeX_key_and_link=Copia_la_chiave_e_il_link_BibTeX
-Copy_DOI_url=Copia_l'url_del_DOI
+JabRef\ resources=Risorse per JabRef
+Development\ version=Versione di sviluppo
+View\ change\ log=Visualizza la lista delle modifiche
+Copy\ BibTeX\ key\ and\ link=Copia la chiave e il link BibTeX
+Copy\ DOI\ url=Copia l'url del DOI
 
-Copy_citation=Copia_la_citazione
-Default_table_font_size=Font_predefinito_per_le_tabelle
-Show_document_viewer=Mostra_il_visualizzatore_dei_documenti
+Copy\ citation=Copia la citazione
+Default\ table\ font\ size=Font predefinito per le tabelle
+Show\ document\ viewer=Mostra il visualizzatore dei documenti

--- a/src/main/resources/l10n/Menu_it.properties
+++ b/src/main/resources/l10n/Menu_it.properties
@@ -1,7 +1,3 @@
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 Abbreviate\ journal\ names\ (ISO)=Abbrevia nomi delle riviste (ISO)
 Abbreviate\ journal\ names\ (MEDLINE)=Abbrevia nomi delle riviste (MEDLINE)
 About\ JabRef=&Informazioni su JabRef

--- a/src/main/resources/l10n/Menu_ja.properties
+++ b/src/main/resources/l10n/Menu_ja.properties
@@ -1,7 +1,3 @@
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 Abbreviate\ journal\ names\ (ISO)=学術誌名を短縮形に（ISO）
 Abbreviate\ journal\ names\ (MEDLINE)=学術誌名を短縮形に（MEDLINE）
 About\ JabRef=JabRefについて(&A)

--- a/src/main/resources/l10n/Menu_ja.properties
+++ b/src/main/resources/l10n/Menu_ja.properties
@@ -2,139 +2,139 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-Abbreviate_journal_names_(ISO)=学術誌名を短縮形に（ISO）
-Abbreviate_journal_names_(MEDLINE)=学術誌名を短縮形に（MEDLINE）
-About_JabRef=JabRefについて(&A)
-Append_library=データベースを追加(&A)
-Autogenerate_BibTeX_keys=BibTeX鍵を自動生成(&A)
-Close_library=データベースを閉じる(&C)
+Abbreviate\ journal\ names\ (ISO)=学術誌名を短縮形に（ISO）
+Abbreviate\ journal\ names\ (MEDLINE)=学術誌名を短縮形に（MEDLINE）
+About\ JabRef=JabRefについて(&A)
+Append\ library=データベースを追加(&A)
+Autogenerate\ BibTeX\ keys=BibTeX鍵を自動生成(&A)
+Close\ library=データベースを閉じる(&C)
 Copy=コピー(&O)
-Copy_title=タイトルをコピー
-Copy_\\cite{BibTeX_key}=\\c&ite{BibTeX鍵}をコピー
-Copy_BibTeX_key=&BibTeX鍵をコピー
-Customize_entry_types=項目型の調整(&C)
+Copy\ title=タイトルをコピー
+Copy\ \\cite{BibTeX\ key}=\\c&ite{BibTeX鍵}をコピー
+Copy\ BibTeX\ key=&BibTeX鍵をコピー
+Customize\ entry\ types=項目型の調整(&C)
 Cut=切り取り(&C)
-Library_properties=データベース特性(&P)
+Library\ properties=データベース特性(&P)
 Edit=編集(&E)
 # Bibtex
-Edit_entry=項目を編集(&E)
-Edit_preamble=プリアンブルを編集(&P)
-Edit_strings=文字列を編集(&S)
+Edit\ entry=項目を編集(&E)
+Edit\ preamble=プリアンブルを編集(&P)
+Edit\ strings=文字列を編集(&S)
 Export=書き出す(&E)
-Export_selected_entries_to_clipboard=選択した項目をクリップボードに書き出す(&E)
+Export\ selected\ entries\ to\ clipboard=選択した項目をクリップボードに書き出す(&E)
 
 # Menu names
 File=ファイル(&F)
-Find_duplicates=重複を検索(&F)
+Find\ duplicates=重複を検索(&F)
 Help=ヘルプ(&H)
 
 # Help
-Online_help=オンラインヘルプ
-Donate_to_JabRef=JabRefに寄付
-Manage_content_selectors=内容選択メニューの管理(&C)
-Manage_custom_exports=ユーザー書出の管理(&M)
-Manage_custom_imports=ユーザー読込の管理(&I)
-Manage_journal_abbreviations=誌名短縮形の管理(&J)
-Mark_entries=項目に標識を付ける(&M)
+Online\ help=オンラインヘルプ
+Donate\ to\ JabRef=JabRefに寄付
+Manage\ content\ selectors=内容選択メニューの管理(&C)
+Manage\ custom\ exports=ユーザー書出の管理(&M)
+Manage\ custom\ imports=ユーザー読込の管理(&I)
+Manage\ journal\ abbreviations=誌名短縮形の管理(&J)
+Mark\ entries=項目に標識を付ける(&M)
 # File menu
-New_%0_library=新しい%0データベース
+New\ %0\ library=新しい%0データベース
 # Menu BibTeX (BibTeX)
-New_entry=新規項目(&E)
-New_entry_by_type...=新規項目(&N)…
-New_entry_from_plain_text=平文から新規項目(&W)
-New_sublibrary_based_on_AUX_file=AU&Xファイルからの新規部分データベース
+New\ entry=新規項目(&E)
+New\ entry\ by\ type...=新規項目(&N)…
+New\ entry\ from\ plain\ text=平文から新規項目(&W)
+New\ sublibrary\ based\ on\ AUX\ file=AU&Xファイルからの新規部分データベース
 # View
-Next_tab=次のタブ(&N)
-Open_library=データベースを開く(&O)
-Open_URL_or_DOI=&URLまたはDOIを開く
-Connect_to_shared_database=共有データベースを開く
-Open_terminal_here=ここに_ターミナルを選択（開封）する
+Next\ tab=次のタブ(&N)
+Open\ library=データベースを開く(&O)
+Open\ URL\ or\ DOI=&URLまたはDOIを開く
+Connect\ to\ shared\ database=共有データベースを開く
+Open\ terminal\ here=ここに ターミナルを選択（開封）する
 Options=オプション(&O)
 Paste=貼付け(&P)
 # Options
 Preferences=設定(&P)
-Previous_tab=前のタブ(&P)
+Previous\ tab=前のタブ(&P)
 Quit=終了(&Q)
-Recent_libraries=最近開いたファイル(&R)
+Recent\ libraries=最近開いたファイル(&R)
 Redo=再実行(&R)
-Replace_string=文字列の置換(&R)
-Save_library=データベースを保存(&S)
-Save_library_as...=データベースに名前を付けて保存(&A)…
-Save_selected_as...=選択部に名前を付けて保存(&L)…
+Replace\ string=文字列の置換(&R)
+Save\ library=データベースを保存(&S)
+Save\ library\ as...=データベースに名前を付けて保存(&A)…
+Save\ selected\ as...=選択部に名前を付けて保存(&L)…
 # Tools
 Search=検索(&S)
-Select_all=全て選択(&A)
-Set_up_general_fields=汎用フィールドを設定(&G)
-View_event_log=イベントログを表示
-Sort_tabs=タブを整序(&S)
-Next_preview_layout=次のプレビューレイアウト(&N)
-Previous_preview_layout=前のプレビューレイアウト(&P)
+Select\ all=全て選択(&A)
+Set\ up\ general\ fields=汎用フィールドを設定(&G)
+View\ event\ log=イベントログを表示
+Sort\ tabs=タブを整序(&S)
+Next\ preview\ layout=次のプレビューレイアウト(&N)
+Previous\ preview\ layout=前のプレビューレイアウト(&P)
 # Export menu
-Toggle_entry_preview=項目プレビューを入切(&T)
-Toggle_groups_interface=グループ操作面を入切(&G)
+Toggle\ entry\ preview=項目プレビューを入切(&T)
+Toggle\ groups\ interface=グループ操作面を入切(&G)
 Tools=ツール(&T)
-Unabbreviate_journal_names=学術誌名を非短縮形に
+Unabbreviate\ journal\ names=学術誌名を非短縮形に
 # Edit
 Undo=取り消し(&U)
-Mark_specific_color=特定色で標識を付ける(&A)
-Unmark_all=標識をすべて外す(&L)
-Unmark_entries=項目の標識を外す(&N)
+Mark\ specific\ color=特定色で標識を付ける(&A)
+Unmark\ all=標識をすべて外す(&L)
+Unmark\ entries=項目の標識を外す(&N)
 View=表示(&V)
-Import_into_new_library=新規データベースとして読み込む
-Import_into_current_library=現在のデータベースに読み込む
+Import\ into\ new\ library=新規データベースとして読み込む
+Import\ into\ current\ library=現在のデータベースに読み込む
 
-Switch_to_%0_mode=%0モードに切換
-Push_entries_to_external_application_(%0)=項目を外部アプリケーション（%0）に転送
-Pull_changes_from_shared_database=共有データベースから変更点を持ってくる
-Write_XMP-metadata_to_PDFs=XMPメタデータをPDFに書き出す
+Switch\ to\ %0\ mode=%0モードに切換
+Push\ entries\ to\ external\ application\ (%0)=項目を外部アプリケーション（%0）に転送
+Pull\ changes\ from\ shared\ database=共有データベースから変更点を持ってくる
+Write\ XMP-metadata\ to\ PDFs=XMPメタデータをPDFに書き出す
 
-Export_selected_entries=選択した項目を書き出す
+Export\ selected\ entries=選択した項目を書き出す
 
-Save_all=すべて保存
+Save\ all=すべて保存
 
-Manage_external_file_types=外部ファイル型の管理
+Manage\ external\ file\ types=外部ファイル型の管理
 
-Open_file=ファイルを開く
+Open\ file=ファイルを開く
 
-Focus_entry_table=項目表にフォーカス
+Focus\ entry\ table=項目表にフォーカス
 
-Increase_table_font_size=表フォントを拡大(&I)
-Decrease_table_font_size=表フォントを縮小(&D)
+Increase\ table\ font\ size=表フォントを拡大(&I)
+Decrease\ table\ font\ size=表フォントを縮小(&D)
 Forward=進む
 Back=戻る
 
-Look_up_document_identifier...=文書IDを検索...
-Look_up_full_text_documents=文書全文を検索
-Set/clear/append/rename_fields=フィールドを設定/クリア/名称変更
+Look\ up\ document\ identifier...=文書IDを検索...
+Look\ up\ full\ text\ documents=文書全文を検索
+Set/clear/append/rename\ fields=フィールドを設定/クリア/名称変更
 
-Resolve_duplicate_BibTeX_keys=重複したBibTeX鍵を解消する
-Copy_BibTeX_key_and_title=BibTeX鍵とタイトルをコピー
+Resolve\ duplicate\ BibTeX\ keys=重複したBibTeX鍵を解消する
+Copy\ BibTeX\ key\ and\ title=BibTeX鍵とタイトルをコピー
 
-Cleanup_entries=項目の剪定
-Manage_keywords=キーワードを管理
-Merge_entries=項目の統合
-Open_folder=フォルダを開く
-Find_unlinked_files...=リンクされていないファイルを検索...
-Hide/show_toolbar=ツールバーを表示/非表示
+Cleanup\ entries=項目の剪定
+Manage\ keywords=キーワードを管理
+Merge\ entries=項目の統合
+Open\ folder=フォルダを開く
+Find\ unlinked\ files...=リンクされていないファイルを検索...
+Hide/show\ toolbar=ツールバーを表示/非表示
 
-Fork_me_on_GitHub=私をGitHubにフォークして
-Save_selected_as_plain_BibTeX...=選択部をplain_BibTeXとして保存...
+Fork\ me\ on\ GitHub=私をGitHubにフォークして
+Save\ selected\ as\ plain\ BibTeX...=選択部をplain BibTeXとして保存...
 
 Groups=グループ
-Delete_entry=項目を削除
-Check_integrity=整合性検査
+Delete\ entry=項目を削除
+Check\ integrity=整合性検査
 
 Quality=品質
-Online_help_forum=オンラインヘルプ_フォーラム
-Manage_protected_terms=予約語の管理
+Online\ help\ forum=オンラインヘルプ フォーラム
+Manage\ protected\ terms=予約語の管理
 Website=ウェブサイト
 Blog=ブログ
-JabRef_resources=JabRefリソース
-Development_version=開発版
-View_change_log=変更履歴を閲覧
-Copy_BibTeX_key_and_link=BibTeX鍵とリンクをコピー
-Copy_DOI_url=DOIのURLをコピー
+JabRef\ resources=JabRefリソース
+Development\ version=開発版
+View\ change\ log=変更履歴を閲覧
+Copy\ BibTeX\ key\ and\ link=BibTeX鍵とリンクをコピー
+Copy\ DOI\ url=DOIのURLをコピー
 
-Copy_citation=引用をコピー
-Default_table_font_size=表の既定フォント寸法
-Show_document_viewer=文書ビューアを表示
+Copy\ citation=引用をコピー
+Default\ table\ font\ size=表の既定フォント寸法
+Show\ document\ viewer=文書ビューアを表示

--- a/src/main/resources/l10n/Menu_nl.properties
+++ b/src/main/resources/l10n/Menu_nl.properties
@@ -1,7 +1,3 @@
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 Abbreviate\ journal\ names\ (ISO)=Kort namen van tijdschriften af (ISO)
 Abbreviate\ journal\ names\ (MEDLINE)=Kort namen van tijdschriften af (MEDLINE)
 About\ JabRef=Over JabRef

--- a/src/main/resources/l10n/Menu_nl.properties
+++ b/src/main/resources/l10n/Menu_nl.properties
@@ -2,139 +2,139 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-Abbreviate_journal_names_(ISO)=Kort_namen_van_tijdschriften_af_(ISO)
-Abbreviate_journal_names_(MEDLINE)=Kort_namen_van_tijdschriften_af_(MEDLINE)
-About_JabRef=Over_JabRef
-Append_library=Library_bijvoegen
-Autogenerate_BibTeX_keys=Genereer_BibTeX-sleutels_automatisch
-Close_library=Sluit_library
+Abbreviate\ journal\ names\ (ISO)=Kort namen van tijdschriften af (ISO)
+Abbreviate\ journal\ names\ (MEDLINE)=Kort namen van tijdschriften af (MEDLINE)
+About\ JabRef=Over JabRef
+Append\ library=Library bijvoegen
+Autogenerate\ BibTeX\ keys=Genereer BibTeX-sleutels automatisch
+Close\ library=Sluit library
 Copy=Kopi\u00ebren
-Copy_title=
-Copy_\\cite{BibTeX_key}=Kopieer_\\cite{BibTeX-sleutel}
-Copy_BibTeX_key=Kopieer_BibTeX-sleutel
-Customize_entry_types=Pas_entry_types_aan
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=Kopieer \\cite{BibTeX-sleutel}
+Copy\ BibTeX\ key=Kopieer BibTeX-sleutel
+Customize\ entry\ types=Pas entry types aan
 Cut=Knippen
-Library_properties=Library_eigenschappen
+Library\ properties=Library eigenschappen
 Edit=Bewerken
 # Bibtex
-Edit_entry=Bewerk_entry
-Edit_preamble=Bewerk_inleiding
-Edit_strings=Bewerk_constanten
+Edit\ entry=Bewerk entry
+Edit\ preamble=Bewerk inleiding
+Edit\ strings=Bewerk constanten
 Export=Exporteren
-Export_selected_entries_to_clipboard=Exporteer_geselecteerde_entries_naar_het_klembord
+Export\ selected\ entries\ to\ clipboard=Exporteer geselecteerde entries naar het klembord
 
 # Menu names
 File=Bestand
-Find_duplicates=Zoek_dubbels
+Find\ duplicates=Zoek dubbels
 Help=Help
 
 # Help
-Online_help=
-Donate_to_JabRef=Doneer_aan_JabRef
-Manage_content_selectors=Beheer_inhoud_selectors
-Manage_custom_exports=Beheer_externe_exportfilters
-Manage_custom_imports=Beheer_externe_importfilters
-Manage_journal_abbreviations=Beheer_tijdschrift_afkortingen
-Mark_entries=Markeer_entries
+Online\ help=
+Donate\ to\ JabRef=Doneer aan JabRef
+Manage\ content\ selectors=Beheer inhoud selectors
+Manage\ custom\ exports=Beheer externe exportfilters
+Manage\ custom\ imports=Beheer externe importfilters
+Manage\ journal\ abbreviations=Beheer tijdschrift afkortingen
+Mark\ entries=Markeer entries
 # File menu
-New_%0_library=Nieuwe_%0_library
+New\ %0\ library=Nieuwe %0 library
 # Menu BibTeX (BibTeX)
-New_entry=Nieuwe_entry
-New_entry_by_type...=Nieuwe_entry...
-New_entry_from_plain_text=Nieuwe_entry_van_onopgemaakte_tekst
-New_sublibrary_based_on_AUX_file=Nieuwe_sublibrary_gebaseerd_op_AUX_bestand
+New\ entry=Nieuwe entry
+New\ entry\ by\ type...=Nieuwe entry...
+New\ entry\ from\ plain\ text=Nieuwe entry van onopgemaakte tekst
+New\ sublibrary\ based\ on\ AUX\ file=Nieuwe sublibrary gebaseerd op AUX bestand
 # View
-Next_tab=Volgende_tabblad
-Open_library=Open_library
-Open_URL_or_DOI=Open_URL_of_DOI
-Connect_to_shared_database=
-Open_terminal_here=Open_nieuwe_command_prompt_hier
+Next\ tab=Volgende tabblad
+Open\ library=Open library
+Open\ URL\ or\ DOI=Open URL of DOI
+Connect\ to\ shared\ database=
+Open\ terminal\ here=Open nieuwe command prompt hier
 Options=Opties
 Paste=Plakken
 # Options
 Preferences=Instellingen
-Previous_tab=Vorige_tabblad
+Previous\ tab=Vorige tabblad
 Quit=Afsluiten
-Recent_libraries=Recente_bestanden
+Recent\ libraries=Recente bestanden
 Redo=Herstellen
-Replace_string=Tekst_vervangen
-Save_library=Library_opslaan
-Save_library_as...=Library_opslaan_als_...
-Save_selected_as...=Geselecteerde_opslaan_als_...
+Replace\ string=Tekst vervangen
+Save\ library=Library opslaan
+Save\ library\ as...=Library opslaan als ...
+Save\ selected\ as...=Geselecteerde opslaan als ...
 # Tools
 Search=Zoeken
-Select_all=Selecteer_alles
-Set_up_general_fields=Stel_algemene_velden_in
-View_event_log=
-Sort_tabs=Tabbladen_sorteren
-Next_preview_layout=
-Previous_preview_layout=
+Select\ all=Selecteer alles
+Set\ up\ general\ fields=Stel algemene velden in
+View\ event\ log=
+Sort\ tabs=Tabbladen sorteren
+Next\ preview\ layout=
+Previous\ preview\ layout=
 # Export menu
-Toggle_entry_preview=Toon_entry_voorbeeld
-Toggle_groups_interface=Toon_groepenvenster
+Toggle\ entry\ preview=Toon entry voorbeeld
+Toggle\ groups\ interface=Toon groepenvenster
 Tools=Extra's
-Unabbreviate_journal_names=Maak_afkorting_van_tijdschriftnamen_ongedaan
+Unabbreviate\ journal\ names=Maak afkorting van tijdschriftnamen ongedaan
 # Edit
-Undo=Ongedaan_maken
-Mark_specific_color=Markeer_specifieke_kleur
-Unmark_all=Maak_alle_markeringen_ongedaan
-Unmark_entries=Maak_markeringen_van_entries_ongedaan
+Undo=Ongedaan maken
+Mark\ specific\ color=Markeer specifieke kleur
+Unmark\ all=Maak alle markeringen ongedaan
+Unmark\ entries=Maak markeringen van entries ongedaan
 View=Beeld
-Import_into_new_library=Importeer_in_nieuwe_library
-Import_into_current_library=Importeer_in_huidige_library
+Import\ into\ new\ library=Importeer in nieuwe library
+Import\ into\ current\ library=Importeer in huidige library
 
-Switch_to_%0_mode=Switch_naar_%0_modus
-Push_entries_to_external_application_(%0)=Stuur_entries_naar_externe_applicatie
-Pull_changes_from_shared_database=
-Write_XMP-metadata_to_PDFs=Schrijf_XMP_metadata_naar_PDFs
+Switch\ to\ %0\ mode=Switch naar %0 modus
+Push\ entries\ to\ external\ application\ (%0)=Stuur entries naar externe applicatie
+Pull\ changes\ from\ shared\ database=
+Write\ XMP-metadata\ to\ PDFs=Schrijf XMP metadata naar PDFs
 
-Export_selected_entries=Exporteer_geseleteerde_records
+Export\ selected\ entries=Exporteer geseleteerde records
 
-Save_all=Bewaar_alles
+Save\ all=Bewaar alles
 
-Manage_external_file_types=Beheer_externe_bestandstypen
+Manage\ external\ file\ types=Beheer externe bestandstypen
 
-Open_file=Open_bestand
+Open\ file=Open bestand
 
-Focus_entry_table=Focus_op_invoertabel
+Focus\ entry\ table=Focus op invoertabel
 
-Increase_table_font_size=Tabel_font_groter_maken
-Decrease_table_font_size=Tabel_font_kleiner_maken
+Increase\ table\ font\ size=Tabel font groter maken
+Decrease\ table\ font\ size=Tabel font kleiner maken
 Forward=Verder
 Back=Terug
 
-Look_up_document_identifier...=
-Look_up_full_text_documents=
-Set/clear/append/rename_fields=Instellen/wissen/hernoemen_van_velden
+Look\ up\ document\ identifier...=
+Look\ up\ full\ text\ documents=
+Set/clear/append/rename\ fields=Instellen/wissen/hernoemen van velden
 
-Resolve_duplicate_BibTeX_keys=Dubbele_BibTeX_steutels_aanpakken
-Copy_BibTeX_key_and_title=Kopieer_BibTeX_sleutel_en_titel
+Resolve\ duplicate\ BibTeX\ keys=Dubbele BibTeX steutels aanpakken
+Copy\ BibTeX\ key\ and\ title=Kopieer BibTeX sleutel en titel
 
-Cleanup_entries=Entries_schoonmaken
-Manage_keywords=Beheer_sleutelwoorden
-Merge_entries=Voeg_entries_samen
-Open_folder=Open_folder
-Find_unlinked_files...=Vind_bestanden_zonder_verwijzingen...
-Hide/show_toolbar=Verberg/toon_toolbar
+Cleanup\ entries=Entries schoonmaken
+Manage\ keywords=Beheer sleutelwoorden
+Merge\ entries=Voeg entries samen
+Open\ folder=Open folder
+Find\ unlinked\ files...=Vind bestanden zonder verwijzingen...
+Hide/show\ toolbar=Verberg/toon toolbar
 
-Fork_me_on_GitHub=Forken_op_GitHub
-Save_selected_as_plain_BibTeX...=Sla_selectie_op_als_platte_BibTex...
+Fork\ me\ on\ GitHub=Forken op GitHub
+Save\ selected\ as\ plain\ BibTeX...=Sla selectie op als platte BibTex...
 
 Groups=Groepen
-Delete_entry=Verwijder_entry
-Check_integrity=Integriteitscontrole
+Delete\ entry=Verwijder entry
+Check\ integrity=Integriteitscontrole
 
 Quality=Kwaliteit
-Online_help_forum=
-Manage_protected_terms=
+Online\ help\ forum=
+Manage\ protected\ terms=
 Website=
 Blog=
-JabRef_resources=
-Development_version=
-View_change_log=
-Copy_BibTeX_key_and_link=
-Copy_DOI_url=
+JabRef\ resources=
+Development\ version=
+View\ change\ log=
+Copy\ BibTeX\ key\ and\ link=
+Copy\ DOI\ url=
 
-Copy_citation=
-Default_table_font_size=
-Show_document_viewer=
+Copy\ citation=
+Default\ table\ font\ size=
+Show\ document\ viewer=

--- a/src/main/resources/l10n/Menu_no.properties
+++ b/src/main/resources/l10n/Menu_no.properties
@@ -1,7 +1,3 @@
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 Abbreviate\ journal\ names\ (ISO)=Forkort journalnavn (ISO)
 Abbreviate\ journal\ names\ (MEDLINE)=Forkort journalnavn (MEDLINE)
 About\ JabRef=Om &JabRef

--- a/src/main/resources/l10n/Menu_no.properties
+++ b/src/main/resources/l10n/Menu_no.properties
@@ -2,139 +2,139 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-Abbreviate_journal_names_(ISO)=Forkort_journalnavn_(ISO)
-Abbreviate_journal_names_(MEDLINE)=Forkort_journalnavn_(MEDLINE)
-About_JabRef=Om_&JabRef
-Append_library=Legg_til_inn&hold_fra_library
-Autogenerate_BibTeX_keys=&Autogenerer_BibTeX-nøkler
-Close_library=L&ukk_library
+Abbreviate\ journal\ names\ (ISO)=Forkort journalnavn (ISO)
+Abbreviate\ journal\ names\ (MEDLINE)=Forkort journalnavn (MEDLINE)
+About\ JabRef=Om &JabRef
+Append\ library=Legg til inn&hold fra library
+Autogenerate\ BibTeX\ keys=&Autogenerer BibTeX-nøkler
+Close\ library=L&ukk library
 Copy=K&opier
-Copy_title=
-Copy_\\cite{BibTeX_key}=Kopier_\\c&ite{BibTeX-nøkkel}
-Copy_BibTeX_key=Kopier_&BibTeX-nøkkel
-Customize_entry_types=&Tilpass_oppføringstyper
-Cut=&Klipp_up
-Library_properties=Egenskaper_for_library
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=Kopier \\c&ite{BibTeX-nøkkel}
+Copy\ BibTeX\ key=Kopier &BibTeX-nøkkel
+Customize\ entry\ types=&Tilpass oppføringstyper
+Cut=&Klipp up
+Library\ properties=Egenskaper for library
 Edit=&Rediger
 # Bibtex
-Edit_entry=&Rediger_oppføring
-Edit_preamble=Rediger_'&preamble'
-Edit_strings=Rediger_&strenger
+Edit\ entry=&Rediger oppføring
+Edit\ preamble=Rediger '&preamble'
+Edit\ strings=Rediger &strenger
 Export=&Eksporter
-Export_selected_entries_to_clipboard=Eksporter_valgte_oppføringer_til_utklippstavlen
+Export\ selected\ entries\ to\ clipboard=Eksporter valgte oppføringer til utklippstavlen
 
 # Menu names
 File=&Fil
-Find_duplicates=Søk_etter_&duplikater
+Find\ duplicates=Søk etter &duplikater
 Help=&Hjelp
 
 # Help
-Online_help=Online_hjelp
-Donate_to_JabRef=Doner_til_JabRef
-Manage_content_selectors=Sett_opp_&ordvelgere
-Manage_custom_exports=&Sett_opp_eksterne_eksportfiltre
-Manage_custom_imports=Sett_opp_eksterne_&importfiltre
-Manage_journal_abbreviations=Sett_opp_&journalforkortelser
-Mark_entries=&Merk_oppføringer
+Online\ help=Online hjelp
+Donate\ to\ JabRef=Doner til JabRef
+Manage\ content\ selectors=Sett opp &ordvelgere
+Manage\ custom\ exports=&Sett opp eksterne eksportfiltre
+Manage\ custom\ imports=Sett opp eksterne &importfiltre
+Manage\ journal\ abbreviations=Sett opp &journalforkortelser
+Mark\ entries=&Merk oppføringer
 # File menu
-New_%0_library=Ny_%0-library
+New\ %0\ library=Ny %0-library
 # Menu BibTeX (BibTeX)
-New_entry=N&y_oppføring
-New_entry_by_type...=&Ny_oppføring...
-New_entry_from_plain_text=Ny_&oppføring_fra_ren_tekst
-New_sublibrary_based_on_AUX_file=Ny_dellibrary_basert_på_AU&X-fil
+New\ entry=N&y oppføring
+New\ entry\ by\ type...=&Ny oppføring...
+New\ entry\ from\ plain\ text=Ny &oppføring fra ren tekst
+New\ sublibrary\ based\ on\ AUX\ file=Ny dellibrary basert på AU&X-fil
 # View
-Next_tab=&Neste_tab
-Open_library=&Åpne_library
-Open_URL_or_DOI=Åpne_&URL_eller_DOI
-Connect_to_shared_database=Åpne_felles_library
-Open_terminal_here=Åpne_terminal_her
+Next\ tab=&Neste tab
+Open\ library=&Åpne library
+Open\ URL\ or\ DOI=Åpne &URL eller DOI
+Connect\ to\ shared\ database=Åpne felles library
+Open\ terminal\ here=Åpne terminal her
 Options=V&alg
-Paste=&Lim_inn
+Paste=&Lim inn
 # Options
 Preferences=&Oppsett
-Previous_tab=&Forrige_tab
+Previous\ tab=&Forrige tab
 Quit=&Avslutt
-Recent_libraries=&Siste_filer
+Recent\ libraries=&Siste filer
 Redo=&Gjenta
-Replace_string=&Erstatt_streng
-Save_library=&Lagre_library
-Save_library_as...=L&agre_library_som_...
-Save_selected_as...=Lagre_&valgte_oppføringer_som_...
+Replace\ string=&Erstatt streng
+Save\ library=&Lagre library
+Save\ library\ as...=L&agre library som ...
+Save\ selected\ as...=Lagre &valgte oppføringer som ...
 # Tools
 Search=&Søk
-Select_all=&Velg_alle
-Set_up_general_fields=Sett_opp_&generelle_felter
-View_event_log=
-Sort_tabs=Sorter_tabs
-Next_preview_layout=
-Previous_preview_layout=
+Select\ all=&Velg alle
+Set\ up\ general\ fields=Sett opp &generelle felter
+View\ event\ log=
+Sort\ tabs=Sorter tabs
+Next\ preview\ layout=
+Previous\ preview\ layout=
 # Export menu
-Toggle_entry_preview=&Vis/skjul_forhåndsvisning
-Toggle_groups_interface=Vis/skjul_&grupperingskontroll
+Toggle\ entry\ preview=&Vis/skjul forhåndsvisning
+Toggle\ groups\ interface=Vis/skjul &grupperingskontroll
 Tools=V&erktøy
-Unabbreviate_journal_names=Ekspander_journalnavn
+Unabbreviate\ journal\ names=Ekspander journalnavn
 # Edit
 Undo=&Angre
-Mark_specific_color=M&erk_med_spesifikk_farge
-Unmark_all=F&jern_merking_fra_alle
-Unmark_entries=&Fjern_merking
+Mark\ specific\ color=M&erk med spesifikk farge
+Unmark\ all=F&jern merking fra alle
+Unmark\ entries=&Fjern merking
 View=&Vis
-Import_into_new_library=Importer_til_ny_library
-Import_into_current_library=Importer_til_den_aktive_libraryn
+Import\ into\ new\ library=Importer til ny library
+Import\ into\ current\ library=Importer til den aktive libraryn
 
-Switch_to_%0_mode=Bytt_til_%0-modus
-Push_entries_to_external_application_(%0)=Send_oppføringer_til_ekstern_applikasjon_(%0)
-Pull_changes_from_shared_database=
-Write_XMP-metadata_to_PDFs=Skriv_XMP-metadata_til_PDF-filer
+Switch\ to\ %0\ mode=Bytt til %0-modus
+Push\ entries\ to\ external\ application\ (%0)=Send oppføringer til ekstern applikasjon (%0)
+Pull\ changes\ from\ shared\ database=
+Write\ XMP-metadata\ to\ PDFs=Skriv XMP-metadata til PDF-filer
 
-Export_selected_entries=Eksporter_valgte_oppføringer
+Export\ selected\ entries=Eksporter valgte oppføringer
 
-Save_all=Lagre_alle
+Save\ all=Lagre alle
 
-Manage_external_file_types=Sett_opp_eksterne_&filtyper
+Manage\ external\ file\ types=Sett opp eksterne &filtyper
 
-Open_file=Åpne_fil
+Open\ file=Åpne fil
 
-Focus_entry_table=Flytt_fokus_til_hovedtabell
+Focus\ entry\ table=Flytt fokus til hovedtabell
 
-Increase_table_font_size=Øk_størrelse_på_tabellfont
-Decrease_table_font_size=Reduser_størrelse_på_tabellfont
+Increase\ table\ font\ size=Øk størrelse på tabellfont
+Decrease\ table\ font\ size=Reduser størrelse på tabellfont
 Forward=Fram
 Back=Tilbake
 
-Look_up_document_identifier...=
-Look_up_full_text_documents=
-Set/clear/append/rename_fields=Sett/slett/endre_navn_på_felter
+Look\ up\ document\ identifier...=
+Look\ up\ full\ text\ documents=
+Set/clear/append/rename\ fields=Sett/slett/endre navn på felter
 
-Resolve_duplicate_BibTeX_keys=Søk_etter_dupliserte_BibTeX-nøkler
-Copy_BibTeX_key_and_title=Kopier_BibTeX-nøkkel_og_tittel
+Resolve\ duplicate\ BibTeX\ keys=Søk etter dupliserte BibTeX-nøkler
+Copy\ BibTeX\ key\ and\ title=Kopier BibTeX-nøkkel og tittel
 
-Cleanup_entries=Rydd_oppføringer
-Manage_keywords=Administrer_nøkkelord
-Merge_entries=Slå_sammen_oppføringer
-Open_folder=Åpne_mapp
-Find_unlinked_files...=Finn_filer_som_ikke_er_lenket...
-Hide/show_toolbar=Gjem/vis_verktøylinje
+Cleanup\ entries=Rydd oppføringer
+Manage\ keywords=Administrer nøkkelord
+Merge\ entries=Slå sammen oppføringer
+Open\ folder=Åpne mapp
+Find\ unlinked\ files...=Finn filer som ikke er lenket...
+Hide/show\ toolbar=Gjem/vis verktøylinje
 
-Fork_me_on_GitHub=Fork_på_GitHub
-Save_selected_as_plain_BibTeX...=Lagre_valgte_som_BibTeX
+Fork\ me\ on\ GitHub=Fork på GitHub
+Save\ selected\ as\ plain\ BibTeX...=Lagre valgte som BibTeX
 
 Groups=Gruppering
-Delete_entry=Slett_oppføring
-Check_integrity=Sjekk_integritet
+Delete\ entry=Slett oppføring
+Check\ integrity=Sjekk integritet
 
 Quality=Kvalitet
-Online_help_forum=Online_hjelpforum
-Manage_protected_terms=Administrere_beskyttet_ord
+Online\ help\ forum=Online hjelpforum
+Manage\ protected\ terms=Administrere beskyttet ord
 Website=Nettsted
 Blog=Blogg
-JabRef_resources=JabRef-ressurser
-Development_version=Utviklingsversjon
-View_change_log=Vis_endringslogg
-Copy_BibTeX_key_and_link=
-Copy_DOI_url=
+JabRef\ resources=JabRef-ressurser
+Development\ version=Utviklingsversjon
+View\ change\ log=Vis endringslogg
+Copy\ BibTeX\ key\ and\ link=
+Copy\ DOI\ url=
 
-Copy_citation=
-Default_table_font_size=
-Show_document_viewer=
+Copy\ citation=
+Default\ table\ font\ size=
+Show\ document\ viewer=

--- a/src/main/resources/l10n/Menu_pt_BR.properties
+++ b/src/main/resources/l10n/Menu_pt_BR.properties
@@ -1,7 +1,3 @@
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 Abbreviate\ journal\ names\ (ISO)=Abreviar nomes de periódico(ISO)
 Abbreviate\ journal\ names\ (MEDLINE)=Abreviar nomes de periódico(MEDLINE)
 About\ JabRef=Sobre &JabRef

--- a/src/main/resources/l10n/Menu_pt_BR.properties
+++ b/src/main/resources/l10n/Menu_pt_BR.properties
@@ -2,139 +2,139 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-Abbreviate_journal_names_(ISO)=Abreviar_nomes_de_periódico(ISO)
-Abbreviate_journal_names_(MEDLINE)=Abreviar_nomes_de_periódico(MEDLINE)
-About_JabRef=Sobre_&JabRef
-Append_library=&Anexar_base_de_dados
-Autogenerate_BibTeX_keys=Gerar_chaves_BibTeX_&automaticamente
-Close_library=Fe&char_base_de_dados
+Abbreviate\ journal\ names\ (ISO)=Abreviar nomes de periódico(ISO)
+Abbreviate\ journal\ names\ (MEDLINE)=Abreviar nomes de periódico(MEDLINE)
+About\ JabRef=Sobre &JabRef
+Append\ library=&Anexar base de dados
+Autogenerate\ BibTeX\ keys=Gerar chaves BibTeX &automaticamente
+Close\ library=Fe&char base de dados
 Copy=&Copiar
-Copy_title=
-Copy_\\cite{BibTeX_key}=Copiar_como_\\c&ite{chave_BibTeX}
-Copy_BibTeX_key=C&opiar_chave_BibTeX
-Customize_entry_types=&Personalizar_tipos_de_referências
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=Copiar como \\c&ite{chave BibTeX}
+Copy\ BibTeX\ key=C&opiar chave BibTeX
+Customize\ entry\ types=&Personalizar tipos de referências
 Cut=&Recortar
-Library_properties=&Propriedades_da_base_de_dados
+Library\ properties=&Propriedades da base de dados
 Edit=&Editar
 # Bibtex
-Edit_entry=&Editar_referência
-Edit_preamble=&Editar_preâmbulo
-Edit_strings=Editar_s&trings
+Edit\ entry=&Editar referência
+Edit\ preamble=&Editar preâmbulo
+Edit\ strings=Editar s&trings
 Export=&Exportar
-Export_selected_entries_to_clipboard=&Exportar_referências_selecionadas_para_a_área_de_transferência
+Export\ selected\ entries\ to\ clipboard=&Exportar referências selecionadas para a área de transferência
 
 # Menu names
 File=&Arquivo
-Find_duplicates=&Encontrar_duplicatas
+Find\ duplicates=&Encontrar duplicatas
 Help=&Ajuda
 
 # Help
-Online_help=
-Donate_to_JabRef=Doar_para_JabRef
-Manage_content_selectors=Gerenciar_seletores_de_&conteúdo
-Manage_custom_exports=Gerenciar_&exportadores_personalizados
-Manage_custom_imports=Gerenciar_&importadores_personalizados
-Manage_journal_abbreviations=Gerenciar_&abreviações_de_periódicos
-Mark_entries=&Marcar_referências
+Online\ help=
+Donate\ to\ JabRef=Doar para JabRef
+Manage\ content\ selectors=Gerenciar seletores de &conteúdo
+Manage\ custom\ exports=Gerenciar &exportadores personalizados
+Manage\ custom\ imports=Gerenciar &importadores personalizados
+Manage\ journal\ abbreviations=Gerenciar &abreviações de periódicos
+Mark\ entries=&Marcar referências
 # File menu
-New_%0_library=%0_novas_bases_de_dados
+New\ %0\ library=%0 novas bases de dados
 # Menu BibTeX (BibTeX)
-New_entry=No&va_referência
-New_entry_by_type...=N&ova_referência...
-New_entry_from_plain_text=Nova_referência_a_partir_de_texto_&puro
-New_sublibrary_based_on_AUX_file=Nova_base_de_dados_a_partir_de_um_arquivo_AU&X
+New\ entry=No&va referência
+New\ entry\ by\ type...=N&ova referência...
+New\ entry\ from\ plain\ text=Nova referência a partir de texto &puro
+New\ sublibrary\ based\ on\ AUX\ file=Nova base de dados a partir de um arquivo AU&X
 # View
-Next_tab=Próxima_a&ba
-Open_library=&Abrir_base_de_dados
-Open_URL_or_DOI=Abrir_&URL_ou_DOI
-Connect_to_shared_database=
-Open_terminal_here=Abrir_terminal_aqui
+Next\ tab=Próxima a&ba
+Open\ library=&Abrir base de dados
+Open\ URL\ or\ DOI=Abrir &URL ou DOI
+Connect\ to\ shared\ database=
+Open\ terminal\ here=Abrir terminal aqui
 Options=&Opções
 Paste=&Colar
 # Options
 Preferences=&Preferências
-Previous_tab=A&ba_anterior
+Previous\ tab=A&ba anterior
 Quit=&Sair
-Recent_libraries=Arquivos_&recentes
+Recent\ libraries=Arquivos &recentes
 Redo=&Refazer
-Replace_string=&Substituir_string
-Save_library=&Salvar_base_de_dados
-Save_library_as...=S&alvar_base_de_dados_como...
-Save_selected_as...=Salvar_os_se&lecionados_como...
+Replace\ string=&Substituir string
+Save\ library=&Salvar base de dados
+Save\ library\ as...=S&alvar base de dados como...
+Save\ selected\ as...=Salvar os se&lecionados como...
 # Tools
 Search=&Pesquisar
-Select_all=Selecionar_&tudo
-Set_up_general_fields=Configurar_&campos_gerais
-View_event_log=
-Sort_tabs=&Ordenar_abas
-Next_preview_layout=
-Previous_preview_layout=
+Select\ all=Selecionar &tudo
+Set\ up\ general\ fields=Configurar &campos gerais
+View\ event\ log=
+Sort\ tabs=&Ordenar abas
+Next\ preview\ layout=
+Previous\ preview\ layout=
 # Export menu
-Toggle_entry_preview=&Mostrar/Esconder_previsualização_de_referências
-Toggle_groups_interface=Mostrar/Esconder_interface_de_&grupos
+Toggle\ entry\ preview=&Mostrar/Esconder previsualização de referências
+Toggle\ groups\ interface=Mostrar/Esconder interface de &grupos
 Tools=&Ferramentas
-Unabbreviate_journal_names=Reverter_abreviações_de_nomes_de_periódicos
+Unabbreviate\ journal\ names=Reverter abreviações de nomes de periódicos
 # Edit
 Undo=&Desfazer
-Mark_specific_color=Marcar_cor_específica
-Unmark_all=&Desmarcar_todos
-Unmark_entries=Desmarcar_&referências
+Mark\ specific\ color=Marcar cor específica
+Unmark\ all=&Desmarcar todos
+Unmark\ entries=Desmarcar &referências
 View=&Visualizar
-Import_into_new_library=Importar_para_no&va_base_de_dados
-Import_into_current_library=Importar_para_base_de_dados_atual
+Import\ into\ new\ library=Importar para no&va base de dados
+Import\ into\ current\ library=Importar para base de dados atual
 
-Switch_to_%0_mode=Trocar_para_modo_%0
-Push_entries_to_external_application_(%0)=Enviar_referências_para_um_aplicativo_externo_(%0)
-Pull_changes_from_shared_database=
-Write_XMP-metadata_to_PDFs=Escrever_metadados_XMP_para_PDFs
+Switch\ to\ %0\ mode=Trocar para modo %0
+Push\ entries\ to\ external\ application\ (%0)=Enviar referências para um aplicativo externo (%0)
+Pull\ changes\ from\ shared\ database=
+Write\ XMP-metadata\ to\ PDFs=Escrever metadados XMP para PDFs
 
-Export_selected_entries=Exportar_referências_selecionadas
+Export\ selected\ entries=Exportar referências selecionadas
 
-Save_all=Salvar_tudo
+Save\ all=Salvar tudo
 
-Manage_external_file_types=Gerenciar_tipos_de_arquivos_externos
+Manage\ external\ file\ types=Gerenciar tipos de arquivos externos
 
-Open_file=Abrir_arquivo
+Open\ file=Abrir arquivo
 
-Focus_entry_table=Foco_na_tabela_de_referências
+Focus\ entry\ table=Foco na tabela de referências
 
-Increase_table_font_size=&Aumentar_tamanho_da_fonte_da_tabela
-Decrease_table_font_size=&Diminuir_tamanho_da_fonte_da_tabela
+Increase\ table\ font\ size=&Aumentar tamanho da fonte da tabela
+Decrease\ table\ font\ size=&Diminuir tamanho da fonte da tabela
 Forward=Avançar
 Back=Voltar
 
-Look_up_document_identifier...=
-Look_up_full_text_documents=
-Set/clear/append/rename_fields=Definir/Limpar/Renomear_campos
+Look\ up\ document\ identifier...=
+Look\ up\ full\ text\ documents=
+Set/clear/append/rename\ fields=Definir/Limpar/Renomear campos
 
-Resolve_duplicate_BibTeX_keys=Resolver_chaves_BibTeX_duplicadas
-Copy_BibTeX_key_and_title=Copiar_chave_BibTeX_e_título
+Resolve\ duplicate\ BibTeX\ keys=Resolver chaves BibTeX duplicadas
+Copy\ BibTeX\ key\ and\ title=Copiar chave BibTeX e título
 
-Cleanup_entries=Limpar_entradas
-Manage_keywords=Gerenciar_palavras-chave
-Merge_entries=Unir_entradas
-Open_folder=Abrir_diretório
-Find_unlinked_files...=Encontrar_arquivos_não_referenciados
-Hide/show_toolbar=Mostrar/esconder_barra_de_ferramentas
+Cleanup\ entries=Limpar entradas
+Manage\ keywords=Gerenciar palavras-chave
+Merge\ entries=Unir entradas
+Open\ folder=Abrir diretório
+Find\ unlinked\ files...=Encontrar arquivos não referenciados
+Hide/show\ toolbar=Mostrar/esconder barra de ferramentas
 
-Fork_me_on_GitHub=Criar_um_fork_no_GitHub
-Save_selected_as_plain_BibTeX...=Salvar_selecionado_como_BibTeX_simples
+Fork\ me\ on\ GitHub=Criar um fork no GitHub
+Save\ selected\ as\ plain\ BibTeX...=Salvar selecionado como BibTeX simples
 
 Groups=Grupos
-Delete_entry=Remover_referência
-Check_integrity=Verificação_de_integridade
+Delete\ entry=Remover referência
+Check\ integrity=Verificação de integridade
 
 Quality=Qualidade
-Online_help_forum=Forum_de_ajuda_online
-Manage_protected_terms=Gerenciar_palavras_reservadas
+Online\ help\ forum=Forum de ajuda online
+Manage\ protected\ terms=Gerenciar palavras reservadas
 Website=Website
 Blog=Blog
-JabRef_resources=Recursos_do_JabRef
-Development_version=Versão_de_desenvolvimento
-View_change_log=Ver_changelog
-Copy_BibTeX_key_and_link=Copiar_chave_do_BibTex_e_link
-Copy_DOI_url=Copiar_URL_do_DOI
+JabRef\ resources=Recursos do JabRef
+Development\ version=Versão de desenvolvimento
+View\ change\ log=Ver changelog
+Copy\ BibTeX\ key\ and\ link=Copiar chave do BibTex e link
+Copy\ DOI\ url=Copiar URL do DOI
 
-Copy_citation=Copiar_citação
-Default_table_font_size=Tamanho_padrão_da_fonte_da_tabela
-Show_document_viewer=Mostrar_visualizador_de_documentos
+Copy\ citation=Copiar citação
+Default\ table\ font\ size=Tamanho padrão da fonte da tabela
+Show\ document\ viewer=Mostrar visualizador de documentos

--- a/src/main/resources/l10n/Menu_ru.properties
+++ b/src/main/resources/l10n/Menu_ru.properties
@@ -1,7 +1,3 @@
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 Abbreviate\ journal\ names\ (ISO)=Сокращения названий журналов (ISO)
 Abbreviate\ journal\ names\ (MEDLINE)=Сокращения названий журналов (MEDLINE)
 About\ JabRef=О программе JabRef

--- a/src/main/resources/l10n/Menu_ru.properties
+++ b/src/main/resources/l10n/Menu_ru.properties
@@ -2,139 +2,139 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-Abbreviate_journal_names_(ISO)=Сокращения_названий_журналов_(ISO)
-Abbreviate_journal_names_(MEDLINE)=Сокращения_названий_журналов_(MEDLINE)
-About_JabRef=О_программе_JabRef
-Append_library=Добавить_БД
-Autogenerate_BibTeX_keys=Автосоздание_ключей_BibTeX
-Close_library=Закрыть_БД
+Abbreviate\ journal\ names\ (ISO)=Сокращения названий журналов (ISO)
+Abbreviate\ journal\ names\ (MEDLINE)=Сокращения названий журналов (MEDLINE)
+About\ JabRef=О программе JabRef
+Append\ library=Добавить БД
+Autogenerate\ BibTeX\ keys=Автосоздание ключей BibTeX
+Close\ library=Закрыть БД
 Copy=Копировать
-Copy_title=
-Copy_\\cite{BibTeX_key}=Копировать_\\цитировать{ключ_BibTeX}
-Copy_BibTeX_key=Копировать_ключ_BibTeX
-Customize_entry_types=Настроить_типы_записи
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=Копировать \\цитировать{ключ BibTeX}
+Copy\ BibTeX\ key=Копировать ключ BibTeX
+Customize\ entry\ types=Настроить типы записи
 Cut=Вырезать
-Library_properties=Свойства_БД
+Library\ properties=Свойства БД
 Edit=Правка
 # Bibtex
-Edit_entry=Изменить_запись
-Edit_preamble=Изменить_преамбулу
-Edit_strings=Изменить_строки
+Edit\ entry=Изменить запись
+Edit\ preamble=Изменить преамбулу
+Edit\ strings=Изменить строки
 Export=Экспорт
-Export_selected_entries_to_clipboard=Экспорт_выбранных_записей_в_буфер_обмена
+Export\ selected\ entries\ to\ clipboard=Экспорт выбранных записей в буфер обмена
 
 # Menu names
 File=Файл
-Find_duplicates=Найти_дубликаты
+Find\ duplicates=Найти дубликаты
 Help=Справка
 
 # Help
-Online_help=Онлайн-справка
-Donate_to_JabRef=Поддержать_JabRef
-Manage_content_selectors=Управление_выбором_содержимого
-Manage_custom_exports=Управление_пользовательским_экспортом
-Manage_custom_imports=Управление_пользовательским_импортом
-Manage_journal_abbreviations=Управление_сокращениями_для_журналов
-Mark_entries=Метки_записей
+Online\ help=Онлайн-справка
+Donate\ to\ JabRef=Поддержать JabRef
+Manage\ content\ selectors=Управление выбором содержимого
+Manage\ custom\ exports=Управление пользовательским экспортом
+Manage\ custom\ imports=Управление пользовательским импортом
+Manage\ journal\ abbreviations=Управление сокращениями для журналов
+Mark\ entries=Метки записей
 # File menu
-New_%0_library=Новая_база_данных_%0
+New\ %0\ library=Новая база данных %0
 # Menu BibTeX (BibTeX)
-New_entry=Создать_запись
-New_entry_by_type...=Создать_запись...
-New_entry_from_plain_text=Создать_запись_из_неформатированного_текста
-New_sublibrary_based_on_AUX_file=Создать_подчиненную_БД_на_основе_AUX-файла
+New\ entry=Создать запись
+New\ entry\ by\ type...=Создать запись...
+New\ entry\ from\ plain\ text=Создать запись из неформатированного текста
+New\ sublibrary\ based\ on\ AUX\ file=Создать подчиненную БД на основе AUX-файла
 # View
-Next_tab=Следующая_вкладка
-Open_library=Открыть_БД
-Open_URL_or_DOI=Открыть_URL-адрес_или_DOI
-Connect_to_shared_database=
-Open_terminal_here=Открыть_терминал_в_текущей_директории
+Next\ tab=Следующая вкладка
+Open\ library=Открыть БД
+Open\ URL\ or\ DOI=Открыть URL-адрес или DOI
+Connect\ to\ shared\ database=
+Open\ terminal\ here=Открыть терминал в текущей директории
 Options=Параметры
 Paste=Вставить
 # Options
-Preferences=Пользовательские_настройки
-Previous_tab=Предыдущая_вкладка
+Preferences=Пользовательские настройки
+Previous\ tab=Предыдущая вкладка
 Quit=Выход
-Recent_libraries=Недавно_открытые_файлы
+Recent\ libraries=Недавно открытые файлы
 Redo=Отмена
-Replace_string=Заменить_строку
-Save_library=Сохранить_БД
-Save_library_as...=Сохранить_БД_как...
-Save_selected_as...=Сохранить_выбранное_как...
+Replace\ string=Заменить строку
+Save\ library=Сохранить БД
+Save\ library\ as...=Сохранить БД как...
+Save\ selected\ as...=Сохранить выбранное как...
 # Tools
 Search=Поиск
-Select_all=Выбрать_все
-Set_up_general_fields=Настройка_общих_полей
-View_event_log=
-Sort_tabs=Сортировать_вкладки
-Next_preview_layout=
-Previous_preview_layout=
+Select\ all=Выбрать все
+Set\ up\ general\ fields=Настройка общих полей
+View\ event\ log=
+Sort\ tabs=Сортировать вкладки
+Next\ preview\ layout=
+Previous\ preview\ layout=
 # Export menu
-Toggle_entry_preview=Показать/скрыть_просмотр_записи
-Toggle_groups_interface=Показать/скрыть_интерфейс_групп
+Toggle\ entry\ preview=Показать/скрыть просмотр записи
+Toggle\ groups\ interface=Показать/скрыть интерфейс групп
 Tools=Инструменты
-Unabbreviate_journal_names=Полные_названия_журналов
+Unabbreviate\ journal\ names=Полные названия журналов
 # Edit
 Undo=Отмена
-Mark_specific_color=Метка_определенным_цветом
-Unmark_all=Снять_все_метки
-Unmark_entries=Снять_метки_записей
+Mark\ specific\ color=Метка определенным цветом
+Unmark\ all=Снять все метки
+Unmark\ entries=Снять метки записей
 View=Вид
-Import_into_new_library=Импорт_в_новую_БД
-Import_into_current_library=Импорт_в_текущую_БД
+Import\ into\ new\ library=Импорт в новую БД
+Import\ into\ current\ library=Импорт в текущую БД
 
-Switch_to_%0_mode=Переключиться_в_режим_%0
-Push_entries_to_external_application_(%0)=Передать_записи_во_внешнее_приложение_(%0)
-Pull_changes_from_shared_database=Загрузить_изменения_из_БД_с_общим_доступом
-Write_XMP-metadata_to_PDFs=Запись_метаданных_XMP_в_PDF-файл
+Switch\ to\ %0\ mode=Переключиться в режим %0
+Push\ entries\ to\ external\ application\ (%0)=Передать записи во внешнее приложение (%0)
+Pull\ changes\ from\ shared\ database=Загрузить изменения из БД с общим доступом
+Write\ XMP-metadata\ to\ PDFs=Запись метаданных XMP в PDF-файл
 
-Export_selected_entries=Экспорт_выбранных_записей
+Export\ selected\ entries=Экспорт выбранных записей
 
-Save_all=Сохранить_все
+Save\ all=Сохранить все
 
-Manage_external_file_types=Управление_внешними_типами_файлов
+Manage\ external\ file\ types=Управление внешними типами файлов
 
-Open_file=Открыть_файл
+Open\ file=Открыть файл
 
-Focus_entry_table=Поместить_курсор_в_таблицу_записей
+Focus\ entry\ table=Поместить курсор в таблицу записей
 
-Increase_table_font_size=Увеличить_шрифт_в_таблице
-Decrease_table_font_size=Уменьшить_шрифт_в_таблице
+Increase\ table\ font\ size=Увеличить шрифт в таблице
+Decrease\ table\ font\ size=Уменьшить шрифт в таблице
 Forward=Вперед
 Back=Назад
 
-Look_up_document_identifier...=
-Look_up_full_text_documents=Поиск_цитируемых_документов
-Set/clear/append/rename_fields=Задать/очистить/переименовать_поля
+Look\ up\ document\ identifier...=
+Look\ up\ full\ text\ documents=Поиск цитируемых документов
+Set/clear/append/rename\ fields=Задать/очистить/переименовать поля
 
-Resolve_duplicate_BibTeX_keys=Разрешение_дубликатов_ключей_BibTeX
-Copy_BibTeX_key_and_title=Копировать_ключ_и_заголовок_BibTeX
+Resolve\ duplicate\ BibTeX\ keys=Разрешение дубликатов ключей BibTeX
+Copy\ BibTeX\ key\ and\ title=Копировать ключ и заголовок BibTeX
 
-Cleanup_entries=Очистить_записи
-Manage_keywords=Управление_ключевыми_словами
-Merge_entries=Объединение_записей
-Open_folder=Открыть_папку
-Find_unlinked_files...=Найти_несвязанные_файлы...
-Hide/show_toolbar=Показать/скрыть_панель_инструментов
+Cleanup\ entries=Очистить записи
+Manage\ keywords=Управление ключевыми словами
+Merge\ entries=Объединение записей
+Open\ folder=Открыть папку
+Find\ unlinked\ files...=Найти несвязанные файлы...
+Hide/show\ toolbar=Показать/скрыть панель инструментов
 
-Fork_me_on_GitHub=Моя_ветка_на_GitHub
-Save_selected_as_plain_BibTeX...=Сохранить_выбранное_как_неформатированный_BibTeX...
+Fork\ me\ on\ GitHub=Моя ветка на GitHub
+Save\ selected\ as\ plain\ BibTeX...=Сохранить выбранное как неформатированный BibTeX...
 
 Groups=Группы
-Delete_entry=Удалить_запись
-Check_integrity=Проверка_целостности
+Delete\ entry=Удалить запись
+Check\ integrity=Проверка целостности
 
-Quality=Контроль_качества
-Online_help_forum=Форум_онлайн-поддержки
-Manage_protected_terms=Управление_защищенными_терминами
+Quality=Контроль качества
+Online\ help\ forum=Форум онлайн-поддержки
+Manage\ protected\ terms=Управление защищенными терминами
 Website=Веб-сайт
 Blog=Блог
-JabRef_resources=Ресурсы_JabRef
-Development_version=Версия_для_разработчиков
-View_change_log=Просмотр_журнала_изменений
-Copy_BibTeX_key_and_link=Копировать_ключ_BibTeX_и_ссылку
-Copy_DOI_url=Копировать_URL-адрес_DOI
+JabRef\ resources=Ресурсы JabRef
+Development\ version=Версия для разработчиков
+View\ change\ log=Просмотр журнала изменений
+Copy\ BibTeX\ key\ and\ link=Копировать ключ BibTeX и ссылку
+Copy\ DOI\ url=Копировать URL-адрес DOI
 
-Copy_citation=Копировать_цитату
-Default_table_font_size=
-Show_document_viewer=
+Copy\ citation=Копировать цитату
+Default\ table\ font\ size=
+Show\ document\ viewer=

--- a/src/main/resources/l10n/Menu_sv.properties
+++ b/src/main/resources/l10n/Menu_sv.properties
@@ -1,7 +1,3 @@
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 Abbreviate\ journal\ names\ (ISO)=Förkorta tidskriftsnamn (ISO)
 Abbreviate\ journal\ names\ (MEDLINE)=Förkorta tidskriftsnamn (MEDLINE)
 About\ JabRef=&Om JabRef

--- a/src/main/resources/l10n/Menu_sv.properties
+++ b/src/main/resources/l10n/Menu_sv.properties
@@ -2,139 +2,139 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-Abbreviate_journal_names_(ISO)=Förkorta_tidskriftsnamn_(ISO)
-Abbreviate_journal_names_(MEDLINE)=Förkorta_tidskriftsnamn_(MEDLINE)
-About_JabRef=&Om_JabRef
-Append_library=&Lägg_till_databas
-Autogenerate_BibTeX_keys=Automatgenerera_BibTeX-nycklar
-Close_library=Stäng_databas
+Abbreviate\ journal\ names\ (ISO)=Förkorta tidskriftsnamn (ISO)
+Abbreviate\ journal\ names\ (MEDLINE)=Förkorta tidskriftsnamn (MEDLINE)
+About\ JabRef=&Om JabRef
+Append\ library=&Lägg till databas
+Autogenerate\ BibTeX\ keys=Automatgenerera BibTeX-nycklar
+Close\ library=Stäng databas
 Copy=Kopiera
-Copy_title=
-Copy_\\cite{BibTeX_key}=Kopiera_\\cite{BibTeX-nyckel}
-Copy_BibTeX_key=Kopiera_BibTeX-nyckel
-Customize_entry_types=Anpassa_posttyper
-Cut=Klipp_ut
-Library_properties=Librarygenskaper
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=Kopiera \\cite{BibTeX-nyckel}
+Copy\ BibTeX\ key=Kopiera BibTeX-nyckel
+Customize\ entry\ types=Anpassa posttyper
+Cut=Klipp ut
+Library\ properties=Librarygenskaper
 Edit=&Editera
 # Bibtex
-Edit_entry=&Editera_post
-Edit_preamble=Editera_&preamble
-Edit_strings=Editera_&strängar
+Edit\ entry=&Editera post
+Edit\ preamble=Editera &preamble
+Edit\ strings=Editera &strängar
 Export=&Exportera
-Export_selected_entries_to_clipboard=Exportera_valda_poster_till_&urklipp
+Export\ selected\ entries\ to\ clipboard=Exportera valda poster till &urklipp
 
 # Menu names
 File=&Fil
-Find_duplicates=Hitta_dubletter
+Find\ duplicates=Hitta dubletter
 Help=&Hjälp
 
 # Help
-Online_help=Online&hjälp
-Donate_to_JabRef=Donera_till_JabRef
-Manage_content_selectors=Hantera_innehållsväljare
-Manage_custom_exports=Hantera_egna_exporterare
-Manage_custom_imports=Hantera_egna_importerare
-Manage_journal_abbreviations=Hantera_tidskriftsförkortningar
-Mark_entries=&Markera_poster
+Online\ help=Online&hjälp
+Donate\ to\ JabRef=Donera till JabRef
+Manage\ content\ selectors=Hantera innehållsväljare
+Manage\ custom\ exports=Hantera egna exporterare
+Manage\ custom\ imports=Hantera egna importerare
+Manage\ journal\ abbreviations=Hantera tidskriftsförkortningar
+Mark\ entries=&Markera poster
 # File menu
-New_%0_library=Ny_%0-databas
+New\ %0\ library=Ny %0-databas
 # Menu BibTeX (BibTeX)
-New_entry=&Ny_post
-New_entry_by_type...=Ny_post_med_&typ...
-New_entry_from_plain_text=Ny_post_från_&klartext
-New_sublibrary_based_on_AUX_file=&Ny_databas_baserad_på_AUX-fil
+New\ entry=&Ny post
+New\ entry\ by\ type...=Ny post med &typ...
+New\ entry\ from\ plain\ text=Ny post från &klartext
+New\ sublibrary\ based\ on\ AUX\ file=&Ny databas baserad på AUX-fil
 # View
-Next_tab=&Nästa_flik
-Open_library=&Öppna_databas
-Open_URL_or_DOI=Öppna_&URL_eller_DOI
-Connect_to_shared_database=Öppna_delad_databas
-Open_terminal_here=Öppna_&skalfönster_här
+Next\ tab=&Nästa flik
+Open\ library=&Öppna databas
+Open\ URL\ or\ DOI=Öppna &URL eller DOI
+Connect\ to\ shared\ database=Öppna delad databas
+Open\ terminal\ here=Öppna &skalfönster här
 Options=&Alternativ
-Paste=Klistra_in
+Paste=Klistra in
 # Options
 Preferences=&Inställningar
-Previous_tab=Fö&regående_flik
+Previous\ tab=Fö&regående flik
 Quit=&Avsluta
-Recent_libraries=Senaste_&filer
-Redo=&Gör_igen
-Replace_string=Ersätt_sträng
-Save_library=&Spara_databas
-Save_library_as...=Spara_&databas_som...
-Save_selected_as...=Spara_&valda_som...
+Recent\ libraries=Senaste &filer
+Redo=&Gör igen
+Replace\ string=Ersätt sträng
+Save\ library=&Spara databas
+Save\ library\ as...=Spara &databas som...
+Save\ selected\ as...=Spara &valda som...
 # Tools
 Search=&Sök
-Select_all=Välj_&alla
-Set_up_general_fields=Hantera_generella_fält
-View_event_log=
-Sort_tabs=Sortera_flikar
-Next_preview_layout=
-Previous_preview_layout=
+Select\ all=Välj &alla
+Set\ up\ general\ fields=Hantera generella fält
+View\ event\ log=
+Sort\ tabs=Sortera flikar
+Next\ preview\ layout=
+Previous\ preview\ layout=
 # Export menu
-Toggle_entry_preview=Växla_&postvisning
-Toggle_groups_interface=Växla_&grupphantering
+Toggle\ entry\ preview=Växla &postvisning
+Toggle\ groups\ interface=Växla &grupphantering
 Tools=Verkt&yg
-Unabbreviate_journal_names=E&xpandera_förkortade_tidskriftsnamn
+Unabbreviate\ journal\ names=E&xpandera förkortade tidskriftsnamn
 # Edit
 Undo=&Ångra
-Mark_specific_color=Markera_med_&färg
-Unmark_all=&Avmarkera_alla
-Unmark_entries=Avmarkera_&poster
+Mark\ specific\ color=Markera med &färg
+Unmark\ all=&Avmarkera alla
+Unmark\ entries=Avmarkera &poster
 View=&Visa
-Import_into_new_library=Importera_till_ny_databas
-Import_into_current_library=Importera_till_aktuell_databas
+Import\ into\ new\ library=Importera till ny databas
+Import\ into\ current\ library=Importera till aktuell databas
 
-Switch_to_%0_mode=Byt_till_%0-läge
-Push_entries_to_external_application_(%0)=Infoga_&citeringar_i_externt_program_(%0)
-Pull_changes_from_shared_database=Hämta_ändringar_från_delad_databas
-Write_XMP-metadata_to_PDFs=Skriv_XMP-metadata_till_PDFer
+Switch\ to\ %0\ mode=Byt till %0-läge
+Push\ entries\ to\ external\ application\ (%0)=Infoga &citeringar i externt program (%0)
+Pull\ changes\ from\ shared\ database=Hämta ändringar från delad databas
+Write\ XMP-metadata\ to\ PDFs=Skriv XMP-metadata till PDFer
 
-Export_selected_entries=E&xportera_valda_poster
+Export\ selected\ entries=E&xportera valda poster
 
-Save_all=S&para_alla
+Save\ all=S&para alla
 
-Manage_external_file_types=Hantera_externa_filtyper
+Manage\ external\ file\ types=Hantera externa filtyper
 
-Open_file=&Öppna_fil
+Open\ file=&Öppna fil
 
-Focus_entry_table=Fokusera_&tabellen
+Focus\ entry\ table=Fokusera &tabellen
 
-Increase_table_font_size=&Öka_typsnittsstorlek_i_tabellen
-Decrease_table_font_size=&Minska_typsnittsstorlek_i_tabellen
+Increase\ table\ font\ size=&Öka typsnittsstorlek i tabellen
+Decrease\ table\ font\ size=&Minska typsnittsstorlek i tabellen
 Forward=&Framåt
 Back=&Bakåt
 
-Look_up_document_identifier...=
-Look_up_full_text_documents=
-Set/clear/append/rename_fields=Sätt/rensa/byt_namn_på_fält
+Look\ up\ document\ identifier...=
+Look\ up\ full\ text\ documents=
+Set/clear/append/rename\ fields=Sätt/rensa/byt namn på fält
 
-Resolve_duplicate_BibTeX_keys=Hantera_BibTeX-nyckeldubbletter
-Copy_BibTeX_key_and_title=Kopiera_BibTeX-nyckel_och_titel
+Resolve\ duplicate\ BibTeX\ keys=Hantera BibTeX-nyckeldubbletter
+Copy\ BibTeX\ key\ and\ title=Kopiera BibTeX-nyckel och titel
 
-Cleanup_entries=Städa_upp_poster
-Manage_keywords=Hantera_nyckelord
-Merge_entries=Slå_samman_poster
-Open_folder=Öppna_&mapp
-Find_unlinked_files...=Hitta_olänkade_filer...
-Hide/show_toolbar=Dölj/visa_verktygslist
+Cleanup\ entries=Städa upp poster
+Manage\ keywords=Hantera nyckelord
+Merge\ entries=Slå samman poster
+Open\ folder=Öppna &mapp
+Find\ unlinked\ files...=Hitta olänkade filer...
+Hide/show\ toolbar=Dölj/visa verktygslist
 
-Fork_me_on_GitHub=Skapa_kopia_av_källkoden_på_GitHub
-Save_selected_as_plain_BibTeX...=Spara_valda_som_enkel_&BibTeX...
+Fork\ me\ on\ GitHub=Skapa kopia av källkoden på GitHub
+Save\ selected\ as\ plain\ BibTeX...=Spara valda som enkel &BibTeX...
 
 Groups=&Grupper
-Delete_entry=Radera_post
-Check_integrity=Testa_&integriteten
+Delete\ entry=Radera post
+Check\ integrity=Testa &integriteten
 
 Quality=&Kvalitet
-Online_help_forum=Onlineforum
-Manage_protected_terms=Hantera_skyddade_ord
+Online\ help\ forum=Onlineforum
+Manage\ protected\ terms=Hantera skyddade ord
 Website=Hemsida
 Blog=Blogg
-JabRef_resources=JabRef-resurser
-Development_version=Utvecklingsversion
-View_change_log=Visa_ändringar
-Copy_BibTeX_key_and_link=
-Copy_DOI_url=
+JabRef\ resources=JabRef-resurser
+Development\ version=Utvecklingsversion
+View\ change\ log=Visa ändringar
+Copy\ BibTeX\ key\ and\ link=
+Copy\ DOI\ url=
 
-Copy_citation=
-Default_table_font_size=
-Show_document_viewer=
+Copy\ citation=
+Default\ table\ font\ size=
+Show\ document\ viewer=

--- a/src/main/resources/l10n/Menu_tr.properties
+++ b/src/main/resources/l10n/Menu_tr.properties
@@ -1,7 +1,3 @@
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 Abbreviate\ journal\ names\ (ISO)=Dergi adlarını kısalt (ISO)
 Abbreviate\ journal\ names\ (MEDLINE)=Dergi adlarını kısalt (MEDLINE)
 About\ JabRef=JabRef H&akkında

--- a/src/main/resources/l10n/Menu_tr.properties
+++ b/src/main/resources/l10n/Menu_tr.properties
@@ -2,139 +2,139 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-Abbreviate_journal_names_(ISO)=Dergi_adlarını_kısalt_(ISO)
-Abbreviate_journal_names_(MEDLINE)=Dergi_adlarını_kısalt_(MEDLINE)
-About_JabRef=JabRef_H&akkında
-Append_library=Veri_tabanını_son&a_ekle
-Autogenerate_BibTeX_keys=BibTeX_&anahtarlarını_otomatik_oluştur
-Close_library=Veritabanını_&kapat
+Abbreviate\ journal\ names\ (ISO)=Dergi adlarını kısalt (ISO)
+Abbreviate\ journal\ names\ (MEDLINE)=Dergi adlarını kısalt (MEDLINE)
+About\ JabRef=JabRef H&akkında
+Append\ library=Veri tabanını son&a ekle
+Autogenerate\ BibTeX\ keys=BibTeX &anahtarlarını otomatik oluştur
+Close\ library=Veritabanını &kapat
 Copy=K&opyala
-Copy_title=Başlığı_kopyala
-Copy_\\cite{BibTeX_key}=\\c&ite{BibTeX_anahtarı}'nı_kopyala
-Copy_BibTeX_key=&BibTeX_anahtarını_kopyala
-Customize_entry_types=Girdi_türlerini_&özelleştir
+Copy\ title=Başlığı kopyala
+Copy\ \\cite{BibTeX\ key}=\\c&ite{BibTeX anahtarı}'nı kopyala
+Copy\ BibTeX\ key=&BibTeX anahtarını kopyala
+Customize\ entry\ types=Girdi türlerini &özelleştir
 Cut=Ke&s
-Library_properties=Veritabanı_ö&zellikleri
+Library\ properties=Veritabanı ö&zellikleri
 Edit=Düz&enle
 # Bibtex
-Edit_entry=Girdiyi_düz&enle
-Edit_preamble=&Öncülü_düzenle
-Edit_strings=Diz&geleri_düzenle
-Export=Dı&şa_aktarım
-Export_selected_entries_to_clipboard=S&eçili_girdileri_panoya_aktar
+Edit\ entry=Girdiyi düz&enle
+Edit\ preamble=&Öncülü düzenle
+Edit\ strings=Diz&geleri düzenle
+Export=Dı&şa aktarım
+Export\ selected\ entries\ to\ clipboard=S&eçili girdileri panoya aktar
 
 # Menu names
 File=&Dosya
-Find_duplicates=Çift_nüshaları_&bul
+Find\ duplicates=Çift nüshaları &bul
 Help=&Yardım
 
 # Help
-Online_help=Çevrimiçi_yardım
-Donate_to_JabRef=JabRef'e_bağış_yap
-Manage_content_selectors=İçe&rik_seçicileri_yönet
-Manage_custom_exports=Özel_dışa_aktarı&mları_yönet
-Manage_custom_imports=Özel_&içe_aktarımları_yönet
-Manage_journal_abbreviations=Der&gi_kısaltmalarını_yönet
-Mark_entries=Girdileri_iş&aretle
+Online\ help=Çevrimiçi yardım
+Donate\ to\ JabRef=JabRef'e bağış yap
+Manage\ content\ selectors=İçe&rik seçicileri yönet
+Manage\ custom\ exports=Özel dışa aktarı&mları yönet
+Manage\ custom\ imports=Özel &içe aktarımları yönet
+Manage\ journal\ abbreviations=Der&gi kısaltmalarını yönet
+Mark\ entries=Girdileri iş&aretle
 # File menu
-New_%0_library=Yeni_%0_veri_tabanı
+New\ %0\ library=Yeni %0 veri tabanı
 # Menu BibTeX (BibTeX)
-New_entry=Y&eni_girdi
-New_entry_by_type...=Ye&ni_girdi...
-New_entry_from_plain_text=Düz_metinden_&yeni_girdi
-New_sublibrary_based_on_AUX_file=AU&X_dosyası_tabanlı_yeni_altveritabanı
+New\ entry=Y&eni girdi
+New\ entry\ by\ type...=Ye&ni girdi...
+New\ entry\ from\ plain\ text=Düz metinden &yeni girdi
+New\ sublibrary\ based\ on\ AUX\ file=AU&X dosyası tabanlı yeni altveritabanı
 # View
-Next_tab=So&nraki_sekme
-Open_library=Veritabanı_&Aç
-Open_URL_or_DOI=&URL_ya_da_DOI_aç
-Connect_to_shared_database=Paylaşılmış_veritabanını_aç
-Open_terminal_here=Terminali_burada_aç
+Next\ tab=So&nraki sekme
+Open\ library=Veritabanı &Aç
+Open\ URL\ or\ DOI=&URL ya da DOI aç
+Connect\ to\ shared\ database=Paylaşılmış veritabanını aç
+Open\ terminal\ here=Terminali burada aç
 Options=Se&çenekler
 Paste=Ya&pıştır
 # Options
 Preferences=&Tercihler
-Previous_tab=Ön&ceki_sekme
+Previous\ tab=Ön&ceki sekme
 Quit=&Kapat
-Recent_libraries=Son_kullanılan_dosyala&r
+Recent\ libraries=Son kullanılan dosyala&r
 Redo=Y&inele
-Replace_string=Dizgenin_ye&rine_koy
-Save_library=Veritabanını_&kaydet
-Save_library_as...=Varit&abanını_farklı_kaydet...
-Save_selected_as...=Seçimi_fark&lı_kaydet...
+Replace\ string=Dizgenin ye&rine koy
+Save\ library=Veritabanını &kaydet
+Save\ library\ as...=Varit&abanını farklı kaydet...
+Save\ selected\ as...=Seçimi fark&lı kaydet...
 # Tools
 Search=A&ra
-Select_all=T&ümünü_seç
-Set_up_general_fields=&Genel_alanları_ayarla
-View_event_log=Olay_kayıt_dosyasını_göster
-Sort_tabs=&Sekmeleri_sırala
-Next_preview_layout=Sonraki_önizleme_düzeni
-Previous_preview_layout=Önceki_önzileme_düzeni
+Select\ all=T&ümünü seç
+Set\ up\ general\ fields=&Genel alanları ayarla
+View\ event\ log=Olay kayıt dosyasını göster
+Sort\ tabs=&Sekmeleri sırala
+Next\ preview\ layout=Sonraki önizleme düzeni
+Previous\ preview\ layout=Önceki önzileme düzeni
 # Export menu
-Toggle_entry_preview=Girdi_önzilemesini_aç/kapa&t
-Toggle_groups_interface=&Grup_arayüzünü_aç/kapat
+Toggle\ entry\ preview=Girdi önzilemesini aç/kapa&t
+Toggle\ groups\ interface=&Grup arayüzünü aç/kapat
 Tools=Ara&çlar
-Unabbreviate_journal_names=Kısaltma_dergi_adlarını_aç
+Unabbreviate\ journal\ names=Kısaltma dergi adlarını aç
 # Edit
-Undo=&Geri_al
-Mark_specific_color=Özel_işaretleme_rengi
-Unmark_all=Tümünün_işaretini_ka&ldır
-Unmark_entries=Girdilerin_işareti&ni_kaldır
+Undo=&Geri al
+Mark\ specific\ color=Özel işaretleme rengi
+Unmark\ all=Tümünün işaretini ka&ldır
+Unmark\ entries=Girdilerin işareti&ni kaldır
 View=&Görüntüle
-Import_into_new_library=Yeni_veritabanına_aktar
-Import_into_current_library=Mevcut_veritabanına_aktar
+Import\ into\ new\ library=Yeni veritabanına aktar
+Import\ into\ current\ library=Mevcut veritabanına aktar
 
-Switch_to_%0_mode=%0_kipine_geç
-Push_entries_to_external_application_(%0)=Girdileri_harici_uygulamaya_itele_(%0)
-Pull_changes_from_shared_database=Paylaşılmış_veritabaınından_değişiklikleri_çek
-Write_XMP-metadata_to_PDFs=XMP-metaverisini_PDF'ye_yaz
+Switch\ to\ %0\ mode=%0 kipine geç
+Push\ entries\ to\ external\ application\ (%0)=Girdileri harici uygulamaya itele (%0)
+Pull\ changes\ from\ shared\ database=Paylaşılmış veritabaınından değişiklikleri çek
+Write\ XMP-metadata\ to\ PDFs=XMP-metaverisini PDF'ye yaz
 
-Export_selected_entries=Seçili_girdileri_dışa_aktar
+Export\ selected\ entries=Seçili girdileri dışa aktar
 
-Save_all=Tümünü_kaydet
+Save\ all=Tümünü kaydet
 
-Manage_external_file_types=Harici_dosya_türlerini_yönet
+Manage\ external\ file\ types=Harici dosya türlerini yönet
 
-Open_file=Dosya_aç
+Open\ file=Dosya aç
 
-Focus_entry_table=Girdi_tablosuna_odaklan
+Focus\ entry\ table=Girdi tablosuna odaklan
 
-Increase_table_font_size=Tablo_yazıtipi_boyutunu_arttır
-Decrease_table_font_size=Tablo_yazıtipi_boyutunu_azalt
+Increase\ table\ font\ size=Tablo yazıtipi boyutunu arttır
+Decrease\ table\ font\ size=Tablo yazıtipi boyutunu azalt
 Forward=İleri
 Back=Geri
 
-Look_up_document_identifier...=Belge_tanımlayıcıyı_ara
-Look_up_full_text_documents=Tam_metin_belgelerini_ara
-Set/clear/append/rename_fields=Alanları_ata/sil/yeniden_adlandır
+Look\ up\ document\ identifier...=Belge tanımlayıcıyı ara
+Look\ up\ full\ text\ documents=Tam metin belgelerini ara
+Set/clear/append/rename\ fields=Alanları ata/sil/yeniden adlandır
 
-Resolve_duplicate_BibTeX_keys=Çifte_BibTeX_anahtarlarını_çözümle
-Copy_BibTeX_key_and_title=BibTeX_anahtarı_ve_başlığını_kopyala
+Resolve\ duplicate\ BibTeX\ keys=Çifte BibTeX anahtarlarını çözümle
+Copy\ BibTeX\ key\ and\ title=BibTeX anahtarı ve başlığını kopyala
 
-Cleanup_entries=Girdileri_temizle
-Manage_keywords=Anahtar_sözcükleri_yönet
-Merge_entries=Girdileri_birleştir
-Open_folder=Klasörü_aç
-Find_unlinked_files...=Bağlantılanmamış_dosyaları_bul...
-Hide/show_toolbar=Araç_çubuğunu_gizle/göster
+Cleanup\ entries=Girdileri temizle
+Manage\ keywords=Anahtar sözcükleri yönet
+Merge\ entries=Girdileri birleştir
+Open\ folder=Klasörü aç
+Find\ unlinked\ files...=Bağlantılanmamış dosyaları bul...
+Hide/show\ toolbar=Araç çubuğunu gizle/göster
 
-Fork_me_on_GitHub=Beni_GitHub'da_çatalla
-Save_selected_as_plain_BibTeX...=Seçimi_salt_BibTeX_olarak_kaydet_...
+Fork\ me\ on\ GitHub=Beni GitHub'da çatalla
+Save\ selected\ as\ plain\ BibTeX...=Seçimi salt BibTeX olarak kaydet ...
 
 Groups=Gruplar
-Delete_entry=Girdiyi_sil
-Check_integrity=Bütünlük_kontrolü
+Delete\ entry=Girdiyi sil
+Check\ integrity=Bütünlük kontrolü
 
 Quality=Kalite
-Online_help_forum=Çevrimiçi_yardım_forumu
-Manage_protected_terms=Korunmuş_terimleri_yönet
-Website=Web_sitesi
-Blog=Ağ_güncesi
-JabRef_resources=JabRef_kaynakları
-Development_version=Geliştirme_sürümü
-View_change_log=Değişiklik_kütüğünü_göster
-Copy_BibTeX_key_and_link=BibTeX_anahtarı_ve_bağlantısını_kopyala
-Copy_DOI_url=DOI_url'sini_kopyala
+Online\ help\ forum=Çevrimiçi yardım forumu
+Manage\ protected\ terms=Korunmuş terimleri yönet
+Website=Web sitesi
+Blog=Ağ güncesi
+JabRef\ resources=JabRef kaynakları
+Development\ version=Geliştirme sürümü
+View\ change\ log=Değişiklik kütüğünü göster
+Copy\ BibTeX\ key\ and\ link=BibTeX anahtarı ve bağlantısını kopyala
+Copy\ DOI\ url=DOI url'sini kopyala
 
-Copy_citation=Atıf'ı_kopyala
-Default_table_font_size=Öntanımlı_tablo_yazıtipi_boyutu
-Show_document_viewer=Belge_görüntüleyiciyi_göster
+Copy\ citation=Atıf'ı kopyala
+Default\ table\ font\ size=Öntanımlı tablo yazıtipi boyutu
+Show\ document\ viewer=Belge görüntüleyiciyi göster

--- a/src/main/resources/l10n/Menu_vi.properties
+++ b/src/main/resources/l10n/Menu_vi.properties
@@ -1,7 +1,3 @@
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 Abbreviate\ journal\ names\ (ISO)=Viết tắt tên các tạp chí (ISO)
 Abbreviate\ journal\ names\ (MEDLINE)=Viết tắt tên các tạp chí (MEDLINE)
 About\ JabRef=Nói về JabRef

--- a/src/main/resources/l10n/Menu_vi.properties
+++ b/src/main/resources/l10n/Menu_vi.properties
@@ -2,139 +2,139 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-Abbreviate_journal_names_(ISO)=Viết_tắt_tên_các_tạp_chí_(ISO)
-Abbreviate_journal_names_(MEDLINE)=Viết_tắt_tên_các_tạp_chí_(MEDLINE)
-About_JabRef=Nói_về_JabRef
-Append_library=Nối_CSDL
-Autogenerate_BibTeX_keys=Tự_động_tạo_khóa_BibTeX
-Close_library=Đóng_CSDL
-Copy=Sao_chép
-Copy_title=
-Copy_\\cite{BibTeX_key}=Sao_chép\\trích_dẫn{khóa_BibTeX}
-Copy_BibTeX_key=Sao_chép_khóa_BibTeX
-Customize_entry_types=Tùy_biến_kiểu_các_mục
+Abbreviate\ journal\ names\ (ISO)=Viết tắt tên các tạp chí (ISO)
+Abbreviate\ journal\ names\ (MEDLINE)=Viết tắt tên các tạp chí (MEDLINE)
+About\ JabRef=Nói về JabRef
+Append\ library=Nối CSDL
+Autogenerate\ BibTeX\ keys=Tự động tạo khóa BibTeX
+Close\ library=Đóng CSDL
+Copy=Sao chép
+Copy\ title=
+Copy\ \\cite{BibTeX\ key}=Sao chép\\trích dẫn{khóa BibTeX}
+Copy\ BibTeX\ key=Sao chép khóa BibTeX
+Customize\ entry\ types=Tùy biến kiểu các mục
 Cut=Cắt
-Library_properties=Thuộc_tính_CSDL
-Edit=Chỉnh_sửa
+Library\ properties=Thuộc tính CSDL
+Edit=Chỉnh sửa
 # Bibtex
-Edit_entry=Chỉnh_sửa_mục
-Edit_preamble=Chỉnh_sửa_phần_mở_đầu
-Edit_strings=Chỉnh_sửa_chuỗi
+Edit\ entry=Chỉnh sửa mục
+Edit\ preamble=Chỉnh sửa phần mở đầu
+Edit\ strings=Chỉnh sửa chuỗi
 Export=Xuất
-Export_selected_entries_to_clipboard=Xuất_các_mục_đã_chọn_ra_từ_bộ_nhớ_tạm_thời
+Export\ selected\ entries\ to\ clipboard=Xuất các mục đã chọn ra từ bộ nhớ tạm thời
 
 # Menu names
-File=Tập_tin
-Find_duplicates=Tìm_các_mục_trùng
-Help=Trợ_giúp
+File=Tập tin
+Find\ duplicates=Tìm các mục trùng
+Help=Trợ giúp
 
 # Help
-Online_help=Trợ_giúp_trực_tuyến
-Donate_to_JabRef=Hỗ_trợ_cho_JabRef
-Manage_content_selectors=&Quản_lý_các_trình_chọn_nội_dung
-Manage_custom_exports=Quản_lý_xuất_theo_tùy_chọn
-Manage_custom_imports=Quản_lý_nhập_theo_tùy_chọn
-Manage_journal_abbreviations=Quản_lý_viết_tắt_tên_tạp_chí
-Mark_entries=Đánh_dấu_các_mục
+Online\ help=Trợ giúp trực tuyến
+Donate\ to\ JabRef=Hỗ trợ cho JabRef
+Manage\ content\ selectors=&Quản lý các trình chọn nội dung
+Manage\ custom\ exports=Quản lý xuất theo tùy chọn
+Manage\ custom\ imports=Quản lý nhập theo tùy chọn
+Manage\ journal\ abbreviations=Quản lý viết tắt tên tạp chí
+Mark\ entries=Đánh dấu các mục
 # File menu
-New_%0_library=Mở_dữ_liệu_%0_mới
+New\ %0\ library=Mở dữ liệu %0 mới
 # Menu BibTeX (BibTeX)
-New_entry=Mục_mới
-New_entry_by_type...=Mục_mới...
-New_entry_from_plain_text=Mục_mới_từ_văn_bản_trơn
-New_sublibrary_based_on_AUX_file=Cơ_sở_dữ_liệu_con_mới_dựa_trên_tập_tin_AUX
+New\ entry=Mục mới
+New\ entry\ by\ type...=Mục mới...
+New\ entry\ from\ plain\ text=Mục mới từ văn bản trơn
+New\ sublibrary\ based\ on\ AUX\ file=Cơ sở dữ liệu con mới dựa trên tập tin AUX
 # View
-Next_tab=Thẻ_tiếp_theo
-Open_library=Mở_CSDL
-Open_URL_or_DOI=Mở_URL_hoặc_DOI
-Connect_to_shared_database=Mở_CSDL_chia_sẻ
-Open_terminal_here=Mở_thiết_bị_đầu_cuối_ở_đây
-Options=Tùy_chọn
-Paste=Nhập_vào
+Next\ tab=Thẻ tiếp theo
+Open\ library=Mở CSDL
+Open\ URL\ or\ DOI=Mở URL hoặc DOI
+Connect\ to\ shared\ database=Mở CSDL chia sẻ
+Open\ terminal\ here=Mở thiết bị đầu cuối ở đây
+Options=Tùy chọn
+Paste=Nhập vào
 # Options
-Preferences=Tùy_thích
-Previous_tab=Thẻ_trước
+Preferences=Tùy thích
+Previous\ tab=Thẻ trước
 Quit=Thoát
-Recent_libraries=Các_tập_tin_gần_đây
-Redo=Làm_lại
-Replace_string=Thay_chuỗi
-Save_library=Lưu_CSDL
-Save_library_as...=Lưu_CSDL_thành_...
-Save_selected_as...=Lưu_phần_chọn_thành_...
+Recent\ libraries=Các tập tin gần đây
+Redo=Làm lại
+Replace\ string=Thay chuỗi
+Save\ library=Lưu CSDL
+Save\ library\ as...=Lưu CSDL thành ...
+Save\ selected\ as...=Lưu phần chọn thành ...
 # Tools
 Search=Tìm
-Select_all=Chọn_tất_cả
-Set_up_general_fields=Thiết_lập_các_trường_tổng_quát
-View_event_log=
-Sort_tabs=Phân_loại_thẻ
-Next_preview_layout=Xem_trước_bố_trí_tiếp_theo
-Previous_preview_layout=Xem_trước_bố_trí_trước_đó
+Select\ all=Chọn tất cả
+Set\ up\ general\ fields=Thiết lập các trường tổng quát
+View\ event\ log=
+Sort\ tabs=Phân loại thẻ
+Next\ preview\ layout=Xem trước bố trí tiếp theo
+Previous\ preview\ layout=Xem trước bố trí trước đó
 # Export menu
-Toggle_entry_preview=Bật/tắt_xem_trước_mục
-Toggle_groups_interface=Bật/tắt_giao_diện_nhóm
-Tools=Công_cụ
-Unabbreviate_journal_names=Không_viết_tắt_tên_các_tạp_chí
+Toggle\ entry\ preview=Bật/tắt xem trước mục
+Toggle\ groups\ interface=Bật/tắt giao diện nhóm
+Tools=Công cụ
+Unabbreviate\ journal\ names=Không viết tắt tên các tạp chí
 # Edit
-Undo=Quay_ngược_lệnh
-Mark_specific_color=Đánh_dấu_bằng_màu_cụ_thể
-Unmark_all=Xóa_bỏ_đánh_dấu_tất_cả
-Unmark_entries=Xóa_bỏ_đánh_dấu_các_mục
+Undo=Quay ngược lệnh
+Mark\ specific\ color=Đánh dấu bằng màu cụ thể
+Unmark\ all=Xóa bỏ đánh dấu tất cả
+Unmark\ entries=Xóa bỏ đánh dấu các mục
 View=Xem
-Import_into_new_library=Nhập_vào_thành_CSDL_mới
-Import_into_current_library=Nhập_vào_CSDL_hiện_tại
+Import\ into\ new\ library=Nhập vào thành CSDL mới
+Import\ into\ current\ library=Nhập vào CSDL hiện tại
 
-Switch_to_%0_mode=Chuyển_sang_hệ_%0
-Push_entries_to_external_application_(%0)=Đưa_các_mục_ra_ứng_dụng_ngoài_(%0)
-Pull_changes_from_shared_database=Cập_nhập_thông_tin_từ_CSDL_chia_sẻ
-Write_XMP-metadata_to_PDFs=Ghi_XMP-metadata_thành_các_PDF
+Switch\ to\ %0\ mode=Chuyển sang hệ %0
+Push\ entries\ to\ external\ application\ (%0)=Đưa các mục ra ứng dụng ngoài (%0)
+Pull\ changes\ from\ shared\ database=Cập nhập thông tin từ CSDL chia sẻ
+Write\ XMP-metadata\ to\ PDFs=Ghi XMP-metadata thành các PDF
 
-Export_selected_entries=Xuất_các_mục_được_chọn
+Export\ selected\ entries=Xuất các mục được chọn
 
-Save_all=Lưu_tất_cả
+Save\ all=Lưu tất cả
 
-Manage_external_file_types=Quản_lý_các_kiểu_tập_tin_ngoài
+Manage\ external\ file\ types=Quản lý các kiểu tập tin ngoài
 
-Open_file=Mở_tập_tin
+Open\ file=Mở tập tin
 
-Focus_entry_table=Tập_trung_vào_bảng_chứa_mục
+Focus\ entry\ table=Tập trung vào bảng chứa mục
 
-Increase_table_font_size=Tăng_kích_thước_phông_của_bảng
-Decrease_table_font_size=Giảm_kích_thước_phông_của_bảng
+Increase\ table\ font\ size=Tăng kích thước phông của bảng
+Decrease\ table\ font\ size=Giảm kích thước phông của bảng
 Forward=Tới
 Back=Lui
 
-Look_up_document_identifier...=
-Look_up_full_text_documents=
-Set/clear/append/rename_fields=Thiết_lập/Xóa/Đổi_tên_trường
+Look\ up\ document\ identifier...=
+Look\ up\ full\ text\ documents=
+Set/clear/append/rename\ fields=Thiết lập/Xóa/Đổi tên trường
 
-Resolve_duplicate_BibTeX_keys=Giải_quyết_khóa_Bibtex_bị_lặp_lại
-Copy_BibTeX_key_and_title=Sao_chép_khóa_Bibtex_và_danh_hiệu
+Resolve\ duplicate\ BibTeX\ keys=Giải quyết khóa Bibtex bị lặp lại
+Copy\ BibTeX\ key\ and\ title=Sao chép khóa Bibtex và danh hiệu
 
-Cleanup_entries=Dọn_dẹp_các_mục
-Manage_keywords=Quản_lý_các_từ_khóa
-Merge_entries=Phối_các_mục_vào
-Open_folder=Mở_thư_mục
-Find_unlinked_files...=Tìm_các_tập_tin_bị_ngắt_liên_kết...
-Hide/show_toolbar=Tắt/Bật_toolbar
+Cleanup\ entries=Dọn dẹp các mục
+Manage\ keywords=Quản lý các từ khóa
+Merge\ entries=Phối các mục vào
+Open\ folder=Mở thư mục
+Find\ unlinked\ files...=Tìm các tập tin bị ngắt liên kết...
+Hide/show\ toolbar=Tắt/Bật toolbar
 
-Fork_me_on_GitHub=Nhánh_rẽ_từ_GitHub
-Save_selected_as_plain_BibTeX...=Lưu_phần_chọn_thành_plain_Bibtex...
+Fork\ me\ on\ GitHub=Nhánh rẽ từ GitHub
+Save\ selected\ as\ plain\ BibTeX...=Lưu phần chọn thành plain Bibtex...
 
-Groups=Các_nhóm
-Delete_entry=Xóa_mục
-Check_integrity=Kiểm_tra_tính_nguyên_vẹn
+Groups=Các nhóm
+Delete\ entry=Xóa mục
+Check\ integrity=Kiểm tra tính nguyên vẹn
 
-Quality=Chất_Lượng
-Online_help_forum=Diễn_đàn_trợ_giúp_trực_tuyến
-Manage_protected_terms=Quản_lý_bảo_vệ_thuật_ngữ
-Website=Trang_web
+Quality=Chất Lượng
+Online\ help\ forum=Diễn đàn trợ giúp trực tuyến
+Manage\ protected\ terms=Quản lý bảo vệ thuật ngữ
+Website=Trang web
 Blog=Blog
-JabRef_resources=Nguồn_của_JabRef
-Development_version=Phiên_bản_phát_triển
-View_change_log=Xem_nhật_kí_thay_đổi
-Copy_BibTeX_key_and_link=Sao_chép_khóa_BibTex_và_đường_liên_kết
-Copy_DOI_url=Sao_chép_DOI_url
+JabRef\ resources=Nguồn của JabRef
+Development\ version=Phiên bản phát triển
+View\ change\ log=Xem nhật kí thay đổi
+Copy\ BibTeX\ key\ and\ link=Sao chép khóa BibTex và đường liên kết
+Copy\ DOI\ url=Sao chép DOI url
 
-Copy_citation=
-Default_table_font_size=
-Show_document_viewer=
+Copy\ citation=
+Default\ table\ font\ size=
+Show\ document\ viewer=

--- a/src/main/resources/l10n/Menu_zh.properties
+++ b/src/main/resources/l10n/Menu_zh.properties
@@ -2,139 +2,139 @@
 #! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
 #! encoding:UTF-8
 
-Abbreviate_journal_names_(ISO)=缩写期刊名称_(ISO)
-Abbreviate_journal_names_(MEDLINE)=缩写期刊名称_(MEDLINE)
-About_JabRef=关于_JabRef_(&A)
-Append_library=追加文献库_(&A)
-Autogenerate_BibTeX_keys=自动生成_BibTeX_键(&A)
-Close_library=关闭当前文献库_(&C)
+Abbreviate\ journal\ names\ (ISO)=缩写期刊名称 (ISO)
+Abbreviate\ journal\ names\ (MEDLINE)=缩写期刊名称 (MEDLINE)
+About\ JabRef=关于 JabRef (&A)
+Append\ library=追加文献库 (&A)
+Autogenerate\ BibTeX\ keys=自动生成 BibTeX 键(&A)
+Close\ library=关闭当前文献库 (&C)
 Copy=复制(&o)
-Copy_title=复制标题
-Copy_\\cite{BibTeX_key}=复制_\\c&ite{BibTeX_键值}
-Copy_BibTeX_key=复制_&BibTeX_键值
-Customize_entry_types=自定义记录类别_(&C)
-Cut=剪切_(&C)
-Library_properties=文献库属性_(&p)
-Edit=编辑_(&E)
+Copy\ title=复制标题
+Copy\ \\cite{BibTeX\ key}=复制 \\c&ite{BibTeX 键值}
+Copy\ BibTeX\ key=复制 &BibTeX 键值
+Customize\ entry\ types=自定义记录类别 (&C)
+Cut=剪切 (&C)
+Library\ properties=文献库属性 (&p)
+Edit=编辑 (&E)
 # Bibtex
-Edit_entry=编辑记录_(&E)
-Edit_preamble=编辑导言区_(&preamble)
-Edit_strings=编辑简写字串_(&s)
-Export=导出_(&E)
-Export_selected_entries_to_clipboard=导出选中记录到剪贴板_(&E)
+Edit\ entry=编辑记录 (&E)
+Edit\ preamble=编辑导言区 (&preamble)
+Edit\ strings=编辑简写字串 (&s)
+Export=导出 (&E)
+Export\ selected\ entries\ to\ clipboard=导出选中记录到剪贴板 (&E)
 
 # Menu names
-File=文件_(&F)
-Find_duplicates=查找重复记录_(&F)
-Help=帮助_(&H)
+File=文件 (&F)
+Find\ duplicates=查找重复记录 (&F)
+Help=帮助 (&H)
 
 # Help
-Online_help=在线帮助
-Donate_to_JabRef=捐款给_JabRef
-Manage_content_selectors=管理内容下拉菜单_(&C)
-Manage_custom_exports=管理自定义导出器_(&M)
-Manage_custom_imports=管理自定义导入器_(&I)
-Manage_journal_abbreviations=管理期刊名缩写规则_(&J)
-Mark_entries=高亮标记选中记录_(&M)
+Online\ help=在线帮助
+Donate\ to\ JabRef=捐款给 JabRef
+Manage\ content\ selectors=管理内容下拉菜单 (&C)
+Manage\ custom\ exports=管理自定义导出器 (&M)
+Manage\ custom\ imports=管理自定义导入器 (&I)
+Manage\ journal\ abbreviations=管理期刊名缩写规则 (&J)
+Mark\ entries=高亮标记选中记录 (&M)
 # File menu
-New_%0_library=新建_%0_文献库
+New\ %0\ library=新建 %0 文献库
 # Menu BibTeX (BibTeX)
-New_entry=新建记录向导_(&e)
-New_entry_by_type...=新建记录_(&N)...
-New_entry_from_plain_text=以纯文本新建记录_(&W)
-New_sublibrary_based_on_AUX_file=根据_AU&X_文件新建子文献库
+New\ entry=新建记录向导 (&e)
+New\ entry\ by\ type...=新建记录 (&N)...
+New\ entry\ from\ plain\ text=以纯文本新建记录 (&W)
+New\ sublibrary\ based\ on\ AUX\ file=根据 AU&X 文件新建子文献库
 # View
-Next_tab=下一标签页_(&N)
-Open_library=打开文献库_(&O)
-Open_URL_or_DOI=打开_&URL_或_DOI
-Connect_to_shared_database=连接到共享数据库
-Open_terminal_here=在此处打开终端
-Options=选项_(&O)
-Paste=粘贴_(&P)
+Next\ tab=下一标签页 (&N)
+Open\ library=打开文献库 (&O)
+Open\ URL\ or\ DOI=打开 &URL 或 DOI
+Connect\ to\ shared\ database=连接到共享数据库
+Open\ terminal\ here=在此处打开终端
+Options=选项 (&O)
+Paste=粘贴 (&P)
 # Options
-Preferences=首选项_(&P)
-Previous_tab=上一标签页_(&P)
-Quit=退出_(&Q)
-Recent_libraries=最近打开的文件_(&R)
-Redo=重做_(&R)
-Replace_string=替换字符串_(&R)
-Save_library=保存文献库_(&S)
-Save_library_as...=文献库另存为_(&A)...
-Save_selected_as...=选中记录另存为_(&L)...
+Preferences=首选项 (&P)
+Previous\ tab=上一标签页 (&P)
+Quit=退出 (&Q)
+Recent\ libraries=最近打开的文件 (&R)
+Redo=重做 (&R)
+Replace\ string=替换字符串 (&R)
+Save\ library=保存文献库 (&S)
+Save\ library\ as...=文献库另存为 (&A)...
+Save\ selected\ as...=选中记录另存为 (&L)...
 # Tools
-Search=查找_(&S)
-Select_all=全选_(&A)
-Set_up_general_fields=配置_&general_域
-View_event_log=查看事件日志
-Sort_tabs=标签页排序_(&S)
-Next_preview_layout=下一个预览布局
-Previous_preview_layout=上一个预览布局
+Search=查找 (&S)
+Select\ all=全选 (&A)
+Set\ up\ general\ fields=配置 &general 域
+View\ event\ log=查看事件日志
+Sort\ tabs=标签页排序 (&S)
+Next\ preview\ layout=下一个预览布局
+Previous\ preview\ layout=上一个预览布局
 # Export menu
-Toggle_entry_preview=显示/隐藏预览窗格_(&T)
-Toggle_groups_interface=显示/隐藏分组窗格_(&G)
-Tools=工具_(&T)
-Unabbreviate_journal_names=展开期刊名称
+Toggle\ entry\ preview=显示/隐藏预览窗格 (&T)
+Toggle\ groups\ interface=显示/隐藏分组窗格 (&G)
+Tools=工具 (&T)
+Unabbreviate\ journal\ names=展开期刊名称
 # Edit
-Undo=撤销_(&U)
-Mark_specific_color=用指定颜色标记_(&a)
-Unmark_all=撤销所有高亮标记_(&L)
-Unmark_entries=撤销选中高亮标记_(&N)
-View=视图_(&V)
-Import_into_new_library=导入到新文献库
-Import_into_current_library=导入到当前文献库
+Undo=撤销 (&U)
+Mark\ specific\ color=用指定颜色标记 (&a)
+Unmark\ all=撤销所有高亮标记 (&L)
+Unmark\ entries=撤销选中高亮标记 (&N)
+View=视图 (&V)
+Import\ into\ new\ library=导入到新文献库
+Import\ into\ current\ library=导入到当前文献库
 
-Switch_to_%0_mode=切换到_%0_模式
-Push_entries_to_external_application_(%0)=推送选中记录到外部程序_(%0)
-Pull_changes_from_shared_database=从共享数据库更新数据
-Write_XMP-metadata_to_PDFs=将_XMP_元数据写入到_PDF_中
+Switch\ to\ %0\ mode=切换到 %0 模式
+Push\ entries\ to\ external\ application\ (%0)=推送选中记录到外部程序 (%0)
+Pull\ changes\ from\ shared\ database=从共享数据库更新数据
+Write\ XMP-metadata\ to\ PDFs=将 XMP 元数据写入到 PDF 中
 
-Export_selected_entries=导出选中记录
+Export\ selected\ entries=导出选中记录
 
-Save_all=保存全部
+Save\ all=保存全部
 
-Manage_external_file_types=管理外部文件类型关联
+Manage\ external\ file\ types=管理外部文件类型关联
 
-Open_file=打开文件
+Open\ file=打开文件
 
-Focus_entry_table=激活记录列表
+Focus\ entry\ table=激活记录列表
 
-Increase_table_font_size=放大列表字体_(&I)
-Decrease_table_font_size=缩小列表字体_(&D)
+Increase\ table\ font\ size=放大列表字体 (&I)
+Decrease\ table\ font\ size=缩小列表字体 (&D)
 Forward=前进
 Back=后退
 
-Look_up_document_identifier...=查找文档_ID
-Look_up_full_text_documents=查找文档全文
-Set/clear/append/rename_fields=设置/清除/重命名_域
+Look\ up\ document\ identifier...=查找文档 ID
+Look\ up\ full\ text\ documents=查找文档全文
+Set/clear/append/rename\ fields=设置/清除/重命名 域
 
-Resolve_duplicate_BibTeX_keys=处理重复的_BibTeX_键值
-Copy_BibTeX_key_and_title=复制_BibTeX_键值和标题
+Resolve\ duplicate\ BibTeX\ keys=处理重复的 BibTeX 键值
+Copy\ BibTeX\ key\ and\ title=复制 BibTeX 键值和标题
 
-Cleanup_entries=清理记录
-Manage_keywords=管理关键词
-Merge_entries=合并记录
-Open_folder=打开文件夹
-Find_unlinked_files...=查询未被(记录)链接的文件
-Hide/show_toolbar=隐藏/显示工具栏
+Cleanup\ entries=清理记录
+Manage\ keywords=管理关键词
+Merge\ entries=合并记录
+Open\ folder=打开文件夹
+Find\ unlinked\ files...=查询未被(记录)链接的文件
+Hide/show\ toolbar=隐藏/显示工具栏
 
-Fork_me_on_GitHub=去_GitHub_Fork_JabRef
-Save_selected_as_plain_BibTeX...=选择记录另存为_BibTeX_纯文本...
+Fork\ me\ on\ GitHub=去 GitHub Fork JabRef
+Save\ selected\ as\ plain\ BibTeX...=选择记录另存为 BibTeX 纯文本...
 
 Groups=分组
-Delete_entry=删除该记录
-Check_integrity=完整性检查
+Delete\ entry=删除该记录
+Check\ integrity=完整性检查
 
 Quality=质量
-Online_help_forum=在线讨论区
-Manage_protected_terms=管理受保护的术语
+Online\ help\ forum=在线讨论区
+Manage\ protected\ terms=管理受保护的术语
 Website=网站
 Blog=博客
-JabRef_resources=JabRef_资源
-Development_version=开发中版本
-View_change_log=查看变更记录
-Copy_BibTeX_key_and_link=拷贝_BibTeX_key_和链接
-Copy_DOI_url=拷贝_DOI_URL
+JabRef\ resources=JabRef 资源
+Development\ version=开发中版本
+View\ change\ log=查看变更记录
+Copy\ BibTeX\ key\ and\ link=拷贝 BibTeX key 和链接
+Copy\ DOI\ url=拷贝 DOI URL
 
-Copy_citation=复制_Citation
-Default_table_font_size=默认表格字号
-Show_document_viewer=打开文档查看器
+Copy\ citation=复制 Citation
+Default\ table\ font\ size=默认表格字号
+Show\ document\ viewer=打开文档查看器

--- a/src/main/resources/l10n/Menu_zh.properties
+++ b/src/main/resources/l10n/Menu_zh.properties
@@ -1,7 +1,3 @@
-#!
-#! created/edited by Popeye version 0.55 (github.com/JabRef/popeye)
-#! encoding:UTF-8
-
 Abbreviate\ journal\ names\ (ISO)=缩写期刊名称 (ISO)
 Abbreviate\ journal\ names\ (MEDLINE)=缩写期刊名称 (MEDLINE)
 About\ JabRef=关于 JabRef (&A)

--- a/src/test/java/org/jabref/logic/l10n/LocalizationConsistencyTest.java
+++ b/src/test/java/org/jabref/logic/l10n/LocalizationConsistencyTest.java
@@ -142,7 +142,7 @@ public class LocalizationConsistencyTest {
                         "1. PASTE THESE INTO THE ENGLISH LANGUAGE FILE\n" +
                         "2. EXECUTE: gradlew localizationUpdate\n" +
                         missingKeys.parallelStream()
-                                .map(key -> String.format("\n%s=%s\n", key.getKey(), key.getKey()))
+                                .map(key -> String.format("\n%s=%s\n", key.getKey(), key.getKey().replaceAll("\\\\ ", " ")))
                                 .collect(Collectors.toList()),
                 Collections.<LocalizationEntry>emptyList(), missingKeys);
     }

--- a/src/test/java/org/jabref/logic/l10n/LocalizationConsistencyTest.java
+++ b/src/test/java/org/jabref/logic/l10n/LocalizationConsistencyTest.java
@@ -24,7 +24,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class LocalizationConsistencyTest {
@@ -199,23 +198,6 @@ public class LocalizationConsistencyTest {
         for (LocalizationEntry e : keys) {
             assertTrue("Illegal localization parameter found. Must include a String with potential concatenation or replacement parameters. Illegal parameter: Localization.lang(" + e.getKey(),
                     e.getKey().startsWith("\"") || e.getKey().endsWith("\""));
-        }
-    }
-
-    @Test
-    public void localizationTestForInvalidStrings() {
-        for (String bundle : Arrays.asList("JabRef", "Menu")) {
-            for (String lang : Languages.LANGUAGES.values()) {
-                String propertyFilePath = String.format("/l10n/%s_%s.properties", bundle, lang);
-
-                // find any spaces
-                for (Map.Entry<Object, Object> entry : LocalizationParser.getProperties(propertyFilePath).entrySet()) {
-                    assertFalse("Found an invalid character in the '" + lang + "' localization of '" + bundle +
-                            "': The key of " + entry.getKey().toString() + "=" + entry.getValue() + " contains a space!", entry.getKey().toString().contains(" "));
-                    assertFalse("Found an invalid character in the '" + lang + "' localization of '" + bundle +
-                            "': The value of " + entry.getKey().toString() + "=" + entry.getValue() + " contains a space!", entry.getValue().toString().contains(" "));
-                }
-            }
         }
     }
 

--- a/src/test/java/org/jabref/logic/l10n/LocalizationKeyParamsTest.java
+++ b/src/test/java/org/jabref/logic/l10n/LocalizationKeyParamsTest.java
@@ -11,7 +11,8 @@ public class LocalizationKeyParamsTest {
         assertEquals("biblatex mode", new LocalizationKeyParams("biblatex mode").replacePlaceholders());
         assertEquals("biblatex mode", new LocalizationKeyParams("%0 mode", "biblatex").replacePlaceholders());
         assertEquals("C:\\bla mode", new LocalizationKeyParams("%0 mode", "C:\\bla").replacePlaceholders());
-        assertEquals("What \n : %e %c a b", new LocalizationKeyParams("What \n : %e %c_%0 %1", "a", "b").replacePlaceholders());
+        assertEquals("What \n : %e %c a b", new LocalizationKeyParams("What \n : %e %c %0 %1", "a", "b").replacePlaceholders());
+        assertEquals("What \n : %e %c_a b", new LocalizationKeyParams("What \n : %e %c_%0 %1", "a", "b").replacePlaceholders());
     }
 
     @Test(expected = IllegalStateException.class)

--- a/src/test/java/org/jabref/logic/l10n/LocalizationKeyTest.java
+++ b/src/test/java/org/jabref/logic/l10n/LocalizationKeyTest.java
@@ -9,9 +9,15 @@ public class LocalizationKeyTest {
     @Test
     public void testConversionToPropertiesKey() {
         LocalizationKey localizationKey = new LocalizationKey("#test! : =");
-        assertEquals("\\#test\\!_\\:_\\=", localizationKey.getPropertiesKey());
-        assertEquals("#test!_:_=", localizationKey.getPropertiesKeyUnescaped());
+        assertEquals("\\#test\\!\\ \\:\\ \\=", localizationKey.getPropertiesKey());
+        assertEquals("#test! : =", localizationKey.getPropertiesKeyUnescaped());
         assertEquals("#test! : =", localizationKey.getTranslationValue());
+    }
+
+    @Test
+    public void underscoreIsPreserved() {
+        LocalizationKey localizationKey = new LocalizationKey("test_with_underscore");
+        assertEquals("test_with_underscore", localizationKey.getPropertiesKey());
     }
 
 }

--- a/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
+++ b/src/test/java/org/jabref/logic/l10n/LocalizationParser.java
@@ -257,7 +257,7 @@ public class LocalizationParser {
                 // escape chars which are not allowed in property file keys
                 String languagePropertyKey = new LocalizationKey(languageKey).getPropertiesKey();
 
-                if (languagePropertyKey.endsWith("_")) {
+                if (languagePropertyKey.endsWith(" ")) {
                     throw new RuntimeException(languageKey + " ends with a space. As this is a localization key, this is illegal!");
                 }
 

--- a/src/test/java/org/jabref/logic/l10n/LocalizationParserTest.java
+++ b/src/test/java/org/jabref/logic/l10n/LocalizationParserTest.java
@@ -12,17 +12,17 @@ public class LocalizationParserTest {
 
     @Test
     public void testKeyParsingCode() {
-        assertLocalizationKeyParsing("Localization.lang(\"one per line\")", "one_per_line");
-        assertLocalizationKeyParsing("Localization.lang(\n            \"Copy \\\\cite{BibTeX key}\")", "Copy_\\cite{BibTeX_key}");
-        assertLocalizationKeyParsing("Localization.lang(\"two per line\") Localization.lang(\"two per line\")", Arrays.asList("two_per_line", "two_per_line"));
-        assertLocalizationKeyParsing("Localization.lang(\"multi \" + \n\"line\")", "multi_line");
-        assertLocalizationKeyParsing("Localization.lang(\"one per line with var\", var)", "one_per_line_with_var");
-        assertLocalizationKeyParsing("Localization.lang(\"Search %0\", \"Springer\")", "Search_%0");
-        assertLocalizationKeyParsing("Localization.lang(\"Reset preferences (key1,key2,... or 'all')\")", "Reset_preferences_(key1,key2,..._or_'all')");
+        assertLocalizationKeyParsing("Localization.lang(\"one per line\")", "one\\ per\\ line");
+        assertLocalizationKeyParsing("Localization.lang(\n            \"Copy \\\\cite{BibTeX key}\")", "Copy\\ \\cite{BibTeX\\ key}");
+        assertLocalizationKeyParsing("Localization.lang(\"two per line\") Localization.lang(\"two per line\")", Arrays.asList("two\\ per\\ line", "two\\ per\\ line"));
+        assertLocalizationKeyParsing("Localization.lang(\"multi \" + \n\"line\")", "multi\\ line");
+        assertLocalizationKeyParsing("Localization.lang(\"one per line with var\", var)", "one\\ per\\ line\\ with\\ var");
+        assertLocalizationKeyParsing("Localization.lang(\"Search %0\", \"Springer\")", "Search\\ %0");
+        assertLocalizationKeyParsing("Localization.lang(\"Reset preferences (key1,key2,... or 'all')\")", "Reset\\ preferences\\ (key1,key2,...\\ or\\ 'all')");
         assertLocalizationKeyParsing("Localization.lang(\"Multiple entries selected. Do you want to change the type of all these to '%0'?\")",
-                "Multiple_entries_selected._Do_you_want_to_change_the_type_of_all_these_to_'%0'?");
+                "Multiple\\ entries\\ selected.\\ Do\\ you\\ want\\ to\\ change\\ the\\ type\\ of\\ all\\ these\\ to\\ '%0'?");
         assertLocalizationKeyParsing("Localization.lang(\"Run fetcher, e.g. \\\"--fetch=Medline:cancer\\\"\");",
-                "Run_fetcher,_e.g._\"--fetch\\=Medline\\:cancer\"");
+                "Run\\ fetcher,\\ e.g.\\ \"--fetch\\=Medline\\:cancer\"");
     }
 
     @Test


### PR DESCRIPTION
This PR prepares the usage of crowdin: No more strange `_` in our translation files. With this PR we are not bound to crowdin; we can still use our current GitHub worfklow. Furthermore, crowdin pushes new translations using pull requests.

A detailed discussion of crowdin can be found at https://github.com/JabRef/jabref/pull/3470.

![grafik](https://user-images.githubusercontent.com/1366654/33515091-bc56bfe0-d75e-11e7-8f7a-e560fcf14886.png)
