### PR TITLE
Add dependency checker plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ plugins {
     id "com.simonharrer.modernizer" version '1.5.0-1'
     id 'me.champeau.gradle.jmh' version '0.4.3'
     id 'net.ltgt.errorprone' version '0.0.13'
+    id 'com.github.ben-manes.versions' version '0.17.0'
 }
 
 // use the gradle build scan feature: https://scans.gradle.com/get-started

--- a/circle.yml
+++ b/circle.yml
@@ -35,6 +35,7 @@ deployment:
       - ./gradlew -Pinstall4jDir="install4j7" clean release --stacktrace
       # upload at all circumstances
       - scripts/upload-to-builds.jabref.org.sh
+      - ./gradlew dependencyUpdates -Drevision=release -DoutputFormatter=json -DoutputDir=build/releases
   development:
      # match all branches; this is executed, if "release" is not matched - see https://circleci.com/docs/configuration/
     branch: /.*/


### PR DESCRIPTION
As VersionEye is no longer working, I searched for an alternative and found this nice plugin:
https://github.com/ben-manes/gradle-versions-plugin
Run `gradlew dependencyUpdates` to show the dependencies and avaiable updates.

Supports different output formats to log stuff.

Example:
```
The following dependencies have later milestone versions:
 - com.microsoft.azure:applicationinsights-core [1.0.9 -> 1.0.10]
 - com.microsoft.azure:applicationinsights-logging-log4j2 [1.0.9 -> 1.0.10]
 - com.tngtech.archunit:archunit-junit [0.4.0 -> 0.5.0]
 - com.gradle:build-scan-plugin [1.9 -> 1.10.3]
 - org.controlsfx:controlsfx [8.40.14 -> 9.0.0]
 - de.jensd:fontawesomefx-materialdesignfont [1.7.22-4 -> 2.0.26-9.1.2]
 - org.apache.pdfbox:fontbox [1.8.13 -> 2.0.8]
 - gradle.plugin.install4j.install4j:gradle_plugin [6.1.5 -> 7.0.3]
 - com.google.guava:guava [23.4-jre -> 23.5-jre]
 - info.debatty:java-string-similarity [1.0.0 -> 1.0.1]
 - com.sun.xml.bind:jaxb-xjc [2.2.4-1 -> 2.3.0]
 - org.jsoup:jsoup [1.10.3 -> 1.11.2]
 - org.junit.jupiter:junit-jupiter-api [5.0.2 -> 5.1.0-M1]
 - org.junit.jupiter:junit-jupiter-engine [5.0.2 -> 5.1.0-M1]
 - org.junit.jupiter:junit-jupiter-params [5.0.2 -> 5.1.0-M1]
 - org.junit.platform:junit-platform-gradle-plugin [1.0.2 -> 1.1.0-M1]
 - org.junit.vintage:junit-vintage-engine [4.12.1 -> 5.1.0-M1]
 - org.apache.logging.log4j:log4j-api [2.9.1 -> 2.10.0]
 - org.apache.logging.log4j:log4j-core [2.9.1 -> 2.10.0]
 - org.apache.logging.log4j:log4j-jcl [2.9.1 -> 2.10.0]
 - org.apache.logging.log4j:log4j-jul [2.9.1 -> 2.10.0]
 - mysql:mysql-connector-java [5.1.44 -> 8.0.8-dmr]
 - org.apache.pdfbox:pdfbox [1.8.13 -> 2.0.8]
 - com.github.tomakehurst:wiremock [2.11.0 -> 2.12.0]
 - org.xmlunit:xmlunit-core [2.5.0 -> 2.5.1]
 - org.xmlunit:xmlunit-matchers [2.5.0 -> 2.5.1]

```


<!-- describe the changes you have made here: what, why, ... -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
