### PR TITLE
[WIP] Delete from group

### DIFF
--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -795,37 +795,17 @@ public class BasePanel extends JPanel implements ClipboardOwner {
         
     	//get list of all groups
         Optional<GroupTreeNode> groups = bibDatabaseContext.getMetaData().getGroups();
-
-        if (groups.get().getName().contentEquals(groups.get().getName())) { //checks if is selected any group
-        	//TODO define dialog not to offer "remove from group"
-        }
-
         
         if(!cut) { // dialog only for delete
         	DeleteDialog diag = new DeleteDialog(Globals.stateManager.getSelectedGroup(bibDatabaseContext), allEnriesGroups);
         	diag.setVisible(true);
 
         	DeleteResult resultDialog = diag.getResult();
-        	System.out.println(resultDialog);
-
-        	//		Object[] options = {Localization.lang("Delete_from_database"),
-        	//			Localization.lang("Remove_from_group") + " \"" + selectedGroup + "\"",
-        	//			Localization.lang("Cancel")};
-        	//		int n = JOptionPane.showOptionDialog(frame,
-        	//				Localization.lang("The_entry_is_the_member_of_groups") + entries.get(0).getField("groups"),
-        	//				Localization.lang("Delete_remove_entry"),
-        	//				JOptionPane.YES_NO_CANCEL_OPTION,
-        	//				JOptionPane.QUESTION_MESSAGE,
-        	//				null,
-        	//				options,
-        	//				options[2]);
 
         	if (resultDialog == DeleteResult.DELETE_FROM_DATABASE) { // Delete
         		delete = true;
         	} else if (resultDialog == DeleteResult.REMOVE_FROM_GROUPS) { //Remove from selected groups 
         		for(GroupTreeNode node: Globals.stateManager.getSelectedGroup(bibDatabaseContext)){
-        			//GroupTreeNode node = Globals.stateManager.getSelectedGroup(bibDatabaseContext).get(0);
-        			//changesRemove = node.removeEntriesFromGroup(entries);
         			changesRemove = node.removeEntriesFromGroup(entries);
 
         			// Remember undo information

--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -769,7 +769,6 @@ public class BasePanel extends JPanel implements ClipboardOwner {
      *            "deleted". If true the action will be localized as "cut"
      */
     private void delete(boolean cut) {
-    	boolean delete = false;
     	List<FieldChange> changesRemove = new ArrayList<>();
     	
     	List<BibEntry> entries = mainTable.getSelectedEntries();
@@ -777,35 +776,32 @@ public class BasePanel extends JPanel implements ClipboardOwner {
             return;
         }
     	
-        
         //create list of all groups of selected entries
-        Set<String> allEnriesGroups = new HashSet<String>(); {
-		};
-		for(BibEntry entrie : entries){
-			if(entrie.getField("groups").isPresent()){
-				System.out.println(entrie.getField("groups"));
-				String[] groups = entrie.getField("groups").get().split(",");
-				for(String group : groups){
-					allEnriesGroups.add(group);
-				}
-			}
-		}
+        Set<String> allEnriesGroups = new HashSet<String>(); 
+
+        for (BibEntry entrie : entries) {
+        	if (entrie.getField("groups").isPresent()) {
+        		System.out.println(entrie.getField("groups"));
+        		String[] groups = entrie.getField("groups").get().split(",");
+        		for(String group : groups){
+        			allEnriesGroups.add(group);
+        		}
+        	}
+        }
         System.out.println(allEnriesGroups);
         
         
     	//get list of all groups
-        Optional<GroupTreeNode> groups = bibDatabaseContext.getMetaData().getGroups();
+        //Optional<GroupTreeNode> groups = bibDatabaseContext.getMetaData().getGroups();
         
-        if(!cut) { // dialog only for delete
+        if (!cut) { // dialog only for delete
         	DeleteDialog diag = new DeleteDialog(Globals.stateManager.getSelectedGroup(bibDatabaseContext), allEnriesGroups);
         	diag.setVisible(true);
 
         	DeleteResult resultDialog = diag.getResult();
 
-        	if (resultDialog == DeleteResult.DELETE_FROM_DATABASE) { // Delete
-        		delete = true;
-        	} else if (resultDialog == DeleteResult.REMOVE_FROM_GROUPS) { //Remove from selected groups 
-        		for(GroupTreeNode node: Globals.stateManager.getSelectedGroup(bibDatabaseContext)){
+        	if (resultDialog == DeleteResult.REMOVE_FROM_GROUPS) { //Remove from selected groups 
+        		for (GroupTreeNode node: Globals.stateManager.getSelectedGroup(bibDatabaseContext)) {
         			changesRemove = node.removeEntriesFromGroup(entries);
 
         			// Remember undo information
@@ -820,7 +816,7 @@ public class BasePanel extends JPanel implements ClipboardOwner {
         		return;
         	} else if (resultDialog == DeleteResult.CANCEL) { //Cancel
         		return;
-        	}
+        	} 
         }
 
 

--- a/src/main/java/org/jabref/gui/DeleteDialog.java
+++ b/src/main/java/org/jabref/gui/DeleteDialog.java
@@ -1,0 +1,114 @@
+package org.jabref.gui;
+
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JPanel;
+
+import org.jabref.model.groups.GroupTreeNode;
+
+import javafx.collections.ObservableList;
+
+import javax.swing.BoxLayout;
+import javax.swing.JLabel;
+import javax.swing.JCheckBox;
+import java.awt.event.ActionListener;
+import java.util.Iterator;
+import java.util.Set;
+import java.awt.event.ActionEvent;
+
+public class DeleteDialog extends JDialog {
+
+	public enum DeleteResult {
+		DELETE_FROM_DATABASE,
+		REMOVE_FROM_GROUPS,
+		CANCEL
+	}
+
+	protected DeleteResult result = DeleteResult.CANCEL;
+
+
+	/**
+	 * Create the dialog.
+	 * @param selectedGroups 
+	 * @param allEnriesGroups 
+	 */
+	public DeleteDialog(ObservableList<GroupTreeNode> selectedGroups, Set<String> allEnriesGroups) {
+		setTitle("Delete");
+		setModal(true);
+		setBounds(100, 100, 423, 231);
+		getContentPane().setLayout(new BoxLayout(getContentPane(), BoxLayout.Y_AXIS));
+
+		JPanel panel = new JPanel();
+		getContentPane().add(panel);
+
+		String message = "";
+		if (selectedGroups.size() > 0) {
+			message += "Currently there are selected group(s): <br/><ul>";
+			for(int i = 0; i < selectedGroups.size(); i++){
+				message += "<li>"+selectedGroups.get(i).getName() + "</li>"; 
+			}
+			message += "</ul>If you would like to remove selected entities from selected groups <br/>press button \"Remove from groups\" <br>";
+		}
+		
+		if (!allEnriesGroups.isEmpty()) {
+			message += "Selected entries belongs to group(s): <br/><ul>";
+			Iterator<String> iterator = allEnriesGroups.iterator();
+			while(iterator.hasNext()){
+				message += "<li>"+iterator.next()+ "</li>"; 
+			}
+			message += "</ul>If you delete articles it will be removed from all groups <br>";
+		}
+
+		JLabel lblThisEntitiesAre = new JLabel("<html> "+ message + " </html>");
+		panel.add(lblThisEntitiesAre);
+
+
+		JPanel buttonPane = new JPanel();
+		getContentPane().add(buttonPane);
+		buttonPane.setLayout(new BoxLayout(buttonPane, BoxLayout.X_AXIS));
+
+		JButton btnDeleteFromDatabase = new JButton("Delete from database");
+		btnDeleteFromDatabase.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				result = DeleteResult.DELETE_FROM_DATABASE;
+				dispose();
+			}
+		});
+		buttonPane.add(btnDeleteFromDatabase);
+
+		if (selectedGroups.size() > 0) {
+			JButton btnRemoveFromAll = new JButton("Remove from groups");
+			btnRemoveFromAll.addActionListener(new ActionListener() {
+				public void actionPerformed(ActionEvent e) {
+					result = DeleteResult.REMOVE_FROM_GROUPS;
+					dispose();
+				}
+			});
+			buttonPane.add(btnRemoveFromAll);
+		}
+
+		JButton cancelButton = new JButton("Cancel");
+		cancelButton.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent arg0) {
+				result = DeleteResult.CANCEL;
+				dispose();
+			}
+		});
+		cancelButton.setActionCommand("Cancel");
+		buttonPane.add(cancelButton);
+		
+
+		JPanel panel2 = new JPanel();
+		getContentPane().add(panel2);
+		panel2.setLayout(new BoxLayout(panel2, 0));
+		{
+			JCheckBox chckbxRememberChoice = new JCheckBox("Remember choice");
+			panel2.add(chckbxRememberChoice);
+		}
+	}
+
+	DeleteResult getResult(){
+		return result;
+	}
+
+}

--- a/src/main/java/org/jabref/gui/DeleteDialog.java
+++ b/src/main/java/org/jabref/gui/DeleteDialog.java
@@ -3,15 +3,18 @@ package org.jabref.gui;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
+import javax.swing.KeyStroke;
 
 import org.jabref.model.groups.GroupTreeNode;
-
 import javafx.collections.ObservableList;
 
 import javax.swing.BoxLayout;
 import javax.swing.JLabel;
 import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+
 import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
 import java.util.Iterator;
 import java.util.Set;
 import java.awt.event.ActionEvent;
@@ -35,7 +38,6 @@ public class DeleteDialog extends JDialog {
 	public DeleteDialog(ObservableList<GroupTreeNode> selectedGroups, Set<String> allEnriesGroups) {
 		setTitle("Delete");
 		setModal(true);
-		setBounds(100, 100, 423, 231);
 		getContentPane().setLayout(new BoxLayout(getContentPane(), BoxLayout.Y_AXIS));
 
 		JPanel panel = new JPanel();
@@ -47,7 +49,7 @@ public class DeleteDialog extends JDialog {
 			for(int i = 0; i < selectedGroups.size(); i++){
 				message += "<li>"+selectedGroups.get(i).getName() + "</li>"; 
 			}
-			message += "</ul>If you would like to remove selected entities from selected groups <br/>press button \"Remove from groups\" <br>";
+			message += "</ul>If you would like to remove selected entities from selected groups <br/>press button \"Remove from groups\" <br/><br/>";
 		}
 		
 		if (!allEnriesGroups.isEmpty()) {
@@ -56,12 +58,11 @@ public class DeleteDialog extends JDialog {
 			while(iterator.hasNext()){
 				message += "<li>"+iterator.next()+ "</li>"; 
 			}
-			message += "</ul>If you delete articles it will be removed from all groups <br>";
+			message += "</ul>If you delete articles it will be removed from all listed groups <br>";
 		}
 
 		JLabel lblThisEntitiesAre = new JLabel("<html> "+ message + " </html>");
 		panel.add(lblThisEntitiesAre);
-
 
 		JPanel buttonPane = new JPanel();
 		getContentPane().add(buttonPane);
@@ -105,6 +106,18 @@ public class DeleteDialog extends JDialog {
 			JCheckBox chckbxRememberChoice = new JCheckBox("Remember choice");
 			panel2.add(chckbxRememberChoice);
 		}
+		
+		
+		// set size
+		pack();
+		
+		// center of screen
+		this.setLocationRelativeTo(null);
+		
+		// dispose on ESC
+		getRootPane().registerKeyboardAction(e -> {
+		    this.dispose();
+		}, KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), JComponent.WHEN_IN_FOCUSED_WINDOW);
 	}
 
 	DeleteResult getResult(){

--- a/src/main/java/org/jabref/gui/DeleteDialog.java
+++ b/src/main/java/org/jabref/gui/DeleteDialog.java
@@ -11,7 +11,6 @@ import javafx.collections.ObservableList;
 
 import javax.swing.BoxLayout;
 import javax.swing.JLabel;
-import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 
 import java.awt.event.ActionListener;
@@ -49,16 +48,19 @@ public class DeleteDialog extends JDialog {
 			for(int i = 0; i < selectedGroups.size(); i++){
 				message += "<li>"+selectedGroups.get(i).getName() + "</li>"; 
 			}
-			message += "</ul>" + Localization.lang("If_you_would_like_to_remove_selected_entities_from_selected_groups_<br/>press_button_")+"\""+Localization.lang("Remove_from_groups")+"\"<br/><br/>";
+			message += "</ul>" + Localization.lang("If_you_would_like_to_remove_selected_entities_from_selected_groups_<br/>press_button") 
+			+ "\" " 
+			+ Localization.lang("Remove_from_groups") 
+			+ "\"<br/><br/>";
 		}
 		
 		if (!allEnriesGroups.isEmpty()) {
-			message += Localization.lang("Selected_entries_belongs_to_group(s)")+": <br/><ul>";
+			message += Localization.lang("Selected_entries_belongs_to_group(s)") + ": <br/><ul>";
 			Iterator<String> iterator = allEnriesGroups.iterator();
-			while(iterator.hasNext()){
-				message += "<li>"+iterator.next()+ "</li>"; 
+			while (iterator.hasNext()) {
+				message += "<li>" + iterator.next() + "</li>"; 
 			}
-			message += "</ul>"+ Localization.lang("If_you_delete_articles_it_will_be_removed_from_all_listed_groups") +"<br>";
+			message += "</ul>" + Localization.lang("If_you_delete_articles_it_will_be_removed_from_all_listed_groups") + "<br>";
 		}
 
 		JLabel lblThisEntitiesAre = new JLabel("<html> "+ message + " </html>");

--- a/src/main/java/org/jabref/gui/DeleteDialog.java
+++ b/src/main/java/org/jabref/gui/DeleteDialog.java
@@ -5,6 +5,7 @@ import javax.swing.JDialog;
 import javax.swing.JPanel;
 import javax.swing.KeyStroke;
 
+import org.jabref.logic.l10n.Localization;
 import org.jabref.model.groups.GroupTreeNode;
 import javafx.collections.ObservableList;
 
@@ -29,7 +30,6 @@ public class DeleteDialog extends JDialog {
 
 	protected DeleteResult result = DeleteResult.CANCEL;
 
-
 	/**
 	 * Create the dialog.
 	 * @param selectedGroups 
@@ -45,20 +45,20 @@ public class DeleteDialog extends JDialog {
 
 		String message = "";
 		if (selectedGroups.size() > 0) {
-			message += "Currently there are selected group(s): <br/><ul>";
+			message += Localization.lang("Currently_there_are_selected_group(s)")+": <br/><ul>";
 			for(int i = 0; i < selectedGroups.size(); i++){
 				message += "<li>"+selectedGroups.get(i).getName() + "</li>"; 
 			}
-			message += "</ul>If you would like to remove selected entities from selected groups <br/>press button \"Remove from groups\" <br/><br/>";
+			message += "</ul>" + Localization.lang("If_you_would_like_to_remove_selected_entities_from_selected_groups_<br/>press_button_")+"\""+Localization.lang("Remove_from_groups")+"\"<br/><br/>";
 		}
 		
 		if (!allEnriesGroups.isEmpty()) {
-			message += "Selected entries belongs to group(s): <br/><ul>";
+			message += Localization.lang("Selected_entries_belongs_to_group(s)")+": <br/><ul>";
 			Iterator<String> iterator = allEnriesGroups.iterator();
 			while(iterator.hasNext()){
 				message += "<li>"+iterator.next()+ "</li>"; 
 			}
-			message += "</ul>If you delete articles it will be removed from all listed groups <br>";
+			message += "</ul>"+ Localization.lang("If_you_delete_articles_it_will_be_removed_from_all_listed_groups") +"<br>";
 		}
 
 		JLabel lblThisEntitiesAre = new JLabel("<html> "+ message + " </html>");
@@ -68,7 +68,7 @@ public class DeleteDialog extends JDialog {
 		getContentPane().add(buttonPane);
 		buttonPane.setLayout(new BoxLayout(buttonPane, BoxLayout.X_AXIS));
 
-		JButton btnDeleteFromDatabase = new JButton("Delete from database");
+		JButton btnDeleteFromDatabase = new JButton(Localization.lang("Delete_from_database"));
 		btnDeleteFromDatabase.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				result = DeleteResult.DELETE_FROM_DATABASE;
@@ -78,7 +78,7 @@ public class DeleteDialog extends JDialog {
 		buttonPane.add(btnDeleteFromDatabase);
 
 		if (selectedGroups.size() > 0) {
-			JButton btnRemoveFromAll = new JButton("Remove from groups");
+			JButton btnRemoveFromAll = new JButton(Localization.lang("Remove_from_group(s)"));
 			btnRemoveFromAll.addActionListener(new ActionListener() {
 				public void actionPerformed(ActionEvent e) {
 					result = DeleteResult.REMOVE_FROM_GROUPS;
@@ -88,7 +88,7 @@ public class DeleteDialog extends JDialog {
 			buttonPane.add(btnRemoveFromAll);
 		}
 
-		JButton cancelButton = new JButton("Cancel");
+		JButton cancelButton = new JButton(Localization.lang("Cancel"));
 		cancelButton.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent arg0) {
 				result = DeleteResult.CANCEL;
@@ -99,13 +99,13 @@ public class DeleteDialog extends JDialog {
 		buttonPane.add(cancelButton);
 		
 
-		JPanel panel2 = new JPanel();
-		getContentPane().add(panel2);
-		panel2.setLayout(new BoxLayout(panel2, 0));
-		{
-			JCheckBox chckbxRememberChoice = new JCheckBox("Remember choice");
-			panel2.add(chckbxRememberChoice);
-		}
+//		JPanel panel2 = new JPanel();
+//		getContentPane().add(panel2);
+//		panel2.setLayout(new BoxLayout(panel2, 0));
+//		{
+//			JCheckBox chckbxRememberChoice = new JCheckBox(Localization.lang("Remember_choice"));
+//			panel2.add(chckbxRememberChoice);
+//		}
 		
 		
 		// set size

--- a/src/main/java/org/jabref/gui/groups/DeleteDialog.java
+++ b/src/main/java/org/jabref/gui/groups/DeleteDialog.java
@@ -1,4 +1,4 @@
-package org.jabref.gui;
+package org.jabref.gui.groups;
 
 import javax.swing.JButton;
 import javax.swing.JDialog;
@@ -44,9 +44,9 @@ public class DeleteDialog extends JDialog {
 
 		String message = "";
 		if (selectedGroups.size() > 0) {
-			message += Localization.lang("Currently_there_are_selected_group(s)")+": <br/><ul>";
-			for(int i = 0; i < selectedGroups.size(); i++){
-				message += "<li>"+selectedGroups.get(i).getName() + "</li>"; 
+			message += Localization.lang("There_are_group(s)_selected") + ": <br/><ul>";
+			for (int i = 0; i < selectedGroups.size(); i++) {
+				message += "<li>" + selectedGroups.get(i).getName() + "</li>"; 
 			}
 			message += "</ul>" + Localization.lang("If_you_would_like_to_remove_selected_entities_from_selected_groups_<br/>press_button") 
 			+ "\" " 
@@ -55,29 +55,29 @@ public class DeleteDialog extends JDialog {
 		}
 		
 		if (!allEnriesGroups.isEmpty()) {
-			message += Localization.lang("Selected_entries_belongs_to_group(s)") + ": <br/><ul>";
+			message += Localization.lang("Selected_entries_belong_to_group(s)") + ": <br/><ul>";
 			Iterator<String> iterator = allEnriesGroups.iterator();
 			while (iterator.hasNext()) {
 				message += "<li>" + iterator.next() + "</li>"; 
 			}
-			message += "</ul>" + Localization.lang("If_you_delete_articles_it_will_be_removed_from_all_listed_groups") + "<br>";
+			message += "</ul>" + Localization.lang("If_you_delete_the_entries_they_will_be_removed_from_all_listed_groups") + "<br>";
 		}
 
-		JLabel lblThisEntitiesAre = new JLabel("<html> "+ message + " </html>");
-		panel.add(lblThisEntitiesAre);
+		JLabel centralLabel = new JLabel("<html> " + message + " </html>");
+		panel.add(centralLabel);
 
 		JPanel buttonPane = new JPanel();
 		getContentPane().add(buttonPane);
 		buttonPane.setLayout(new BoxLayout(buttonPane, BoxLayout.X_AXIS));
 
-		JButton btnDeleteFromDatabase = new JButton(Localization.lang("Delete_from_database"));
-		btnDeleteFromDatabase.addActionListener(new ActionListener() {
+		JButton deleteFromDatabase = new JButton(Localization.lang("Delete_from_database"));
+		deleteFromDatabase.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				result = DeleteResult.DELETE_FROM_DATABASE;
 				dispose();
 			}
 		});
-		buttonPane.add(btnDeleteFromDatabase);
+		buttonPane.add(deleteFromDatabase);
 
 		if (selectedGroups.size() > 0) {
 			JButton btnRemoveFromAll = new JButton(Localization.lang("Remove_from_group(s)"));
@@ -110,19 +110,15 @@ public class DeleteDialog extends JDialog {
 //		}
 		
 		
-		// set size
 		pack();
-		
-		// center of screen
 		this.setLocationRelativeTo(null);
 		
-		// dispose on ESC
 		getRootPane().registerKeyboardAction(e -> {
 		    this.dispose();
 		}, KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), JComponent.WHEN_IN_FOCUSED_WINDOW);
 	}
 
-	DeleteResult getResult(){
+	public DeleteResult getResult() {
 		return result;
 	}
 


### PR DESCRIPTION
This pull request is continuation of #3071

The default dialog for confirmation of delete entries is changed so the user have option to choose if he wants to delete entry, or to just remove entry from active group. I have few times deleted articles from database not being aware that article belongs to other groups. 
New dialog should make clear to user what is happening when he press "Delete" and offer to just remove from selected groups.

At this phase I need help with defining text in dialog, so any advice is welcome.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
