### PR TITLE
Add \textquotesingle to the html conversion table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - In the preference, all installed java Look and Feels are now listed and selectable
 
 ### Fixed
- - We fixed the translation of \textendash in the entry preview [#3307](https://github.com/JabRef/jabref/issues/3307)
+ - We fixed the translation of \textendash and \textquotesingle in the entry preview [#3307](https://github.com/JabRef/jabref/issues/3307)
  - We fixed an issue where JabRef would not terminated after asking to collect anonymous statistics [#2955 comment](https://github.com/JabRef/jabref/issues/2955#issuecomment-334591123)
  - We fixed an issue where JabRef would not shut down when started with the '-n' (No GUI) option. [#3247](https://github.com/JabRef/jabref/issues/3247)
  - We improved the way metadata is updated in remote databases. [#3235](https://github.com/JabRef/jabref/issues/3235)

--- a/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
+++ b/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
@@ -474,7 +474,7 @@ public class HTMLUnicodeConversionMaps {
             {"35", "", "\\#"}, // Hash
             {"36", "dollar", "\\$"}, // Dollar
             {"37", "#37", "\\%"}, // Percent (&percnt; is not displayed correctly in the entry preview)
-            {"39", "apos", "'"}, // Apostrophe                        
+            {"39", "apos", "'"}, // Apostrophe
             {"40", "lpar", "("}, // Left bracket
             {"41", "rpar", ")"}, // Right bracket
             {"42", "", "*"}, // Asterisk

--- a/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
+++ b/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
@@ -474,8 +474,7 @@ public class HTMLUnicodeConversionMaps {
             {"35", "", "\\#"}, // Hash
             {"36", "dollar", "\\$"}, // Dollar
             {"37", "#37", "\\%"}, // Percent (&percnt; is not displayed correctly in the entry preview)
-            {"39", "apos", "'"}, // Apostrophe
-            {"39", "apos", "{\\textquotesingle}"}, // Apostrophe                                                          
+            {"39", "apos", "'"}, // Apostrophe                        
             {"40", "lpar", "("}, // Left bracket
             {"41", "rpar", ")"}, // Right bracket
             {"42", "", "*"}, // Asterisk
@@ -896,7 +895,10 @@ public class HTMLUnicodeConversionMaps {
         // Support relax to the extent that it is simply removed
         LATEX_HTML_CONVERSION_MAP.put("relax", "");
         LATEX_UNICODE_CONVERSION_MAP.put("relax", "");
-
+        // Support a special version of apostrophe
+        LATEX_HTML_CONVERSION_MAP.put("{\\textquotesingle}", "&apos;");
+        LATEX_UNICODE_CONVERSION_MAP.put("{\\textquotesingle}", "'"); // apostrophe, U+00027
+        
     }
 
     private HTMLUnicodeConversionMaps() {

--- a/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
+++ b/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
@@ -475,6 +475,7 @@ public class HTMLUnicodeConversionMaps {
             {"36", "dollar", "\\$"}, // Dollar
             {"37", "#37", "\\%"}, // Percent (&percnt; is not displayed correctly in the entry preview)
             {"39", "apos", "'"}, // Apostrophe
+            {"39", "apos", "{\\textquotesingle}"}, // Apostrophe                                                          
             {"40", "lpar", "("}, // Left bracket
             {"41", "rpar", ")"}, // Right bracket
             {"42", "", "*"}, // Asterisk


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
`LaTex` use various escape strings to denote certain symbols. Here I add {\textquotesingle} to the html conversion table, which represents apostrophe (').

----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
