### PR TITLE
Add required lib for junit5 in eclipse

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,6 +147,7 @@ dependencies {
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.2'
     testCompile 'org.junit.jupiter:junit-jupiter-params:5.0.2'
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.2'
+    testCompile 'org.junit.platform:junit-platform-launcher:1.0.2'
     testRuntime 'org.junit.vintage:junit-vintage-engine:4.12.1'
     testRuntime 'org.apache.logging.log4j:log4j-core:2.9.1'
     testRuntime 'org.apache.logging.log4j:log4j-jul:2.9.1'


### PR DESCRIPTION
This enables working junit5 with eclipse Oxygen 
https://marketplace.eclipse.org/content/junit-5-support-oxygen

<!-- describe the changes you have made here: what, why, ... -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
