### PR TITLE
Fix mapping of textquotesingle

### DIFF
--- a/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
+++ b/src/main/java/org/jabref/logic/util/strings/HTMLUnicodeConversionMaps.java
@@ -896,9 +896,8 @@ public class HTMLUnicodeConversionMaps {
         LATEX_HTML_CONVERSION_MAP.put("relax", "");
         LATEX_UNICODE_CONVERSION_MAP.put("relax", "");
         // Support a special version of apostrophe
-        LATEX_HTML_CONVERSION_MAP.put("{\\textquotesingle}", "&apos;");
-        LATEX_UNICODE_CONVERSION_MAP.put("{\\textquotesingle}", "'"); // apostrophe, U+00027
-        
+        LATEX_HTML_CONVERSION_MAP.put("textquotesingle", "&apos;");
+        LATEX_UNICODE_CONVERSION_MAP.put("textquotesingle", "'"); // apostrophe, U+00027
     }
 
     private HTMLUnicodeConversionMaps() {

--- a/src/test/java/org/jabref/logic/layout/format/HTMLCharsTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/HTMLCharsTest.java
@@ -85,6 +85,11 @@ public class HTMLCharsTest {
      */
 
     @Test
+    public void testQuoteSingle() {
+        assertEquals("&apos;", layout.format("{\\textquotesingle}"));
+    }
+
+    @Test
     public void unknownCommandIsKept() {
         assertEquals("aaaa", layout.format("\\aaaa"));
     }


### PR DESCRIPTION
Follow-up to #3487 Actually, the mapping in that PR has not been correct syntactically.


----

- [ ] Change in CHANGELOG.md described
- [X] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
