### PR TITLE
Update internal state of DatabaseChangeMonitor when external changes …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
  - We fixed an issue where double clicking on an entry in the integrity check dialog resulted in an exception [#3485](https://github.com/JabRef/jabref/issues/3485)
  - We fixed an issue where the entry type could sometimes not be changed when the entry editor was open [#3435](https://github.com/JabRef/jabref/issues/3435)
  - We fixed an issue where dropping a pdf on the entry table and renaming it triggered an exception [#3490](https://github.com/JabRef/jabref/issues/3490)
+ - We fixed an issue where integrating external changes to a bib file caused instability [#3498](https://github.com/JabRef/jabref/issues/3498)
 
  ### Removed
 

--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -1984,7 +1984,7 @@ public class BasePanel extends JPanel implements ClipboardOwner {
     }
 
     public void updateTimeStamp() {
-        changeMonitor.ifPresent(DatabaseChangeMonitor::updateTimestampAndFileSize);
+        changeMonitor.ifPresent(DatabaseChangeMonitor::markAsSaved);
     }
 
     public Path getTempFile() {

--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -1984,7 +1984,7 @@ public class BasePanel extends JPanel implements ClipboardOwner {
     }
 
     public void updateTimeStamp() {
-        changeMonitor.ifPresent(DatabaseChangeMonitor::markAsSaved);
+        changeMonitor.ifPresent(DatabaseChangeMonitor::updateTimestampAndFileSize);
     }
 
     public Path getTempFile() {

--- a/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
+++ b/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
@@ -136,9 +136,10 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
 
     public void markExternalChangesAsResolved() {
         updatedExternally = false;
+        updateTimestampAndFileSize();
     }
 
-    public void markAsSaved() {
+    public void updateTimestampAndFileSize() {
         database.getDatabasePath().ifPresent(file -> {
             try {
                 timeStamp = Files.getLastModifiedTime(file).toMillis();

--- a/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
+++ b/src/main/java/org/jabref/gui/collab/DatabaseChangeMonitor.java
@@ -136,10 +136,10 @@ public class DatabaseChangeMonitor implements FileUpdateListener {
 
     public void markExternalChangesAsResolved() {
         updatedExternally = false;
-        updateTimestampAndFileSize();
+        markAsSaved();
     }
 
-    public void updateTimestampAndFileSize() {
+    public void markAsSaved() {
         database.getDatabasePath().ifPresent(file -> {
             try {
                 timeStamp = Files.getLastModifiedTime(file).toMillis();


### PR DESCRIPTION
…are resolved

Attempts to fix #3498

It seems that the internal state of DatabaseChangeMonitor was not updated correctly when external changes were marked as resolved, causing the monitor to misbehave when you tried to save afterwards. I am not sure how this bug came into being and what caused the update to get lost. Adding an additional update step seems to resolve the problem, but I would really appreciate some more testing of this branch by other people.

----

- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
