### PR TITLE
[WIP] Adapt log4j configuration for junit tests

### DIFF
--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,2 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration />
+<Configuration status="INFO" packages="org.jabref">
+    <Appenders>
+        <Console name="CONSOLE" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="OFF">
+            <AppenderRef ref="CONSOLE"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,13 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="INFO" packages="org.jabref">
-    <Appenders>
-        <Console name="CONSOLE" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
-        </Console>
-    </Appenders>
-    <Loggers>
-        <Root level="INFO">
-            <AppenderRef ref="CONSOLE"/>
-        </Root>
-    </Loggers>
-</Configuration>
+<configuration />


### PR DESCRIPTION
Fixes #3510 

After searching and reading around I now set the log level to off. 
Failures are still reported, but the travis output is no longer cluttered

<!-- describe the changes you have made here: what, why, ... -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
