### PR TITLE
Fixes #3505: Another try to fix the NPE in the search bar

### DIFF
--- a/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
@@ -29,6 +29,7 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.text.TextFlow;
 
 import org.jabref.Globals;
+import org.jabref.gui.AbstractView;
 import org.jabref.gui.BasePanel;
 import org.jabref.gui.GUIGlobals;
 import org.jabref.gui.IconTheme;
@@ -187,7 +188,7 @@ public class GlobalSearchBar extends JPanel {
         container = OS.LINUX ? new CustomJFXPanel() : new JFXPanel();
         DefaultTaskExecutor.runInJavaFXThread(() -> {
             Scene scene = new Scene(searchField);
-            scene.getStylesheets().add(GlobalSearchBar.class.getResource("../Main.css").toExternalForm());
+            scene.getStylesheets().add(AbstractView.class.getResource("Main.css").toExternalForm());
             container.setScene(scene);
             container.addKeyListener(new SearchKeyAdapter());
         });


### PR DESCRIPTION
Fiexes #3505

<!-- describe the changes you have made here: what, why, ... -->

I think, I managed to locate the problem of the NPE and the missing search bar. Apparently, in some conditions the syntax `../` to access the parent in a path does not work for resources. Thus the css file is not found, resulting in a NPE.

----

- [ ] Change in CHANGELOG.md described (bug introduced in 4.1dev)
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
