### PR TITLE
Add null checks in GroupChangeViewModel

### DIFF
--- a/src/main/java/org/jabref/gui/collab/GroupChangeViewModel.java
+++ b/src/main/java/org/jabref/gui/collab/GroupChangeViewModel.java
@@ -28,7 +28,11 @@ class GroupChangeViewModel extends ChangeViewModel {
 
     @Override
     public boolean makeChange(BasePanel panel, BibDatabase secondary, NamedCompound undoEdit) {
-        final GroupTreeNode root = panel.getBibDatabaseContext().getMetaData().getGroups().orElse(null);
+        GroupTreeNode root = panel.getBibDatabaseContext().getMetaData().getGroups().orElse(null);
+        if(root == null) {
+            root = new GroupTreeNode(DefaultGroupsFactory.getAllEntriesGroup());
+            panel.getBibDatabaseContext().getMetaData().setGroups(root);
+        }
         final UndoableModifySubtree undo = new UndoableModifySubtree(
                 new GroupTreeNodeViewModel(panel.getBibDatabaseContext().getMetaData().getGroups().orElse(null)),
                 new GroupTreeNodeViewModel(root), Localization.lang("Modified groups"));
@@ -47,14 +51,17 @@ class GroupChangeViewModel extends ChangeViewModel {
         undoEdit.addEdit(undo);
 
         // Update tmp database:
-        tmpGroupRoot.removeAllChildren();
-        if (changedGroups != null) {
-            GroupTreeNode copied = changedGroups.copySubtree();
-            tmpGroupRoot.setGroup(copied.getGroup());
-            for (GroupTreeNode child : copied.getChildren()) {
-                child.copySubtree().moveTo(tmpGroupRoot);
+        if (tmpGroupRoot != null) {
+            tmpGroupRoot.removeAllChildren();
+            if (changedGroups != null) {
+                GroupTreeNode copied = changedGroups.copySubtree();
+                tmpGroupRoot.setGroup(copied.getGroup());
+                for (GroupTreeNode child : copied.getChildren()) {
+                    child.copySubtree().moveTo(tmpGroupRoot);
+                }
             }
         }
+
         return true;
     }
 

--- a/src/main/java/org/jabref/gui/collab/GroupChangeViewModel.java
+++ b/src/main/java/org/jabref/gui/collab/GroupChangeViewModel.java
@@ -29,7 +29,7 @@ class GroupChangeViewModel extends ChangeViewModel {
     @Override
     public boolean makeChange(BasePanel panel, BibDatabase secondary, NamedCompound undoEdit) {
         GroupTreeNode root = panel.getBibDatabaseContext().getMetaData().getGroups().orElse(null);
-        if(root == null) {
+        if (root == null) {
             root = new GroupTreeNode(DefaultGroupsFactory.getAllEntriesGroup());
             panel.getBibDatabaseContext().getMetaData().setGroups(root);
         }


### PR DESCRIPTION
This avoids the NPEs in #3526. However, I can't get the groups side pane to repaint and depict the modified groups tree. I've tried different ways via calling the `GroupsSidePane` or setting selected groups in the `StateManager`, but no success.

@tobiasdiez How do I force the `GroupSidePane` to display a changed group tree?


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
