### PR TITLE
Describe new workflow with Crowdin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,10 +82,9 @@ because <additional rationale>.
 
 ### When adding a new Localization.lang entry
 Add new `Localization.lang("KEY")` to Java file.
-Tests fail. In the test output a snippet is generated which must be added to the English translation file. There is also a snippet generated for the non-English files, but this is irrelevant.
-Add snippet to English translation file located at `src/main/resources/l10n/JabRef_en.properties`
-With `gradlew localizationUpdate` the "KEY" is added to the other translation files as well.
-Tests are green again.
+Tests fail. In the test output a snippet is generated which must be added to the English translation file.
+Add snippet to English translation file located at `src/main/resources/l10n/JabRef_en.properties`.
+[Crowdin](http://translate.jabref.org/) will automatically pick up the new string and add it to the other translations.
 
 You can also directly run the specific test in your IDE. The test "LocalizationConsistencyTest" is placed under `src/test/java/net.sf.jabref.logic.l10n/LocalizationConsistencyTest.java`
 Find more information in the [JabRef Wiki](https://github.com/JabRef/jabref/wiki/Code-Howtos#using-localization-correctly).

--- a/src/test/java/org/jabref/logic/l10n/LocalizationConsistencyTest.java
+++ b/src/test/java/org/jabref/logic/l10n/LocalizationConsistencyTest.java
@@ -48,7 +48,7 @@ public class LocalizationConsistencyTest {
     }
 
     @Test
-    public void allFilesMustHaveSameKeys() {
+    public void nonEnglishFilesMustHaveSubsetOfKeys() {
         for (String bundle : Arrays.asList("JabRef", "Menu")) {
             Set<String> englishKeys = LocalizationParser
                     .getKeysInPropertiesFile(String.format("/l10n/%s_%s.properties", bundle, "en"));
@@ -59,12 +59,11 @@ public class LocalizationConsistencyTest {
                 Set<String> nonEnglishKeys = LocalizationParser
                         .getKeysInPropertiesFile(String.format("/l10n/%s_%s.properties", bundle, lang));
 
-                List<String> missing = new ArrayList<>(englishKeys);
-                missing.removeAll(nonEnglishKeys);
+                // we do not check for missing keys as Crowdin adds them automatically
+
                 List<String> obsolete = new ArrayList<>(nonEnglishKeys);
                 obsolete.removeAll(englishKeys);
 
-                assertEquals("Missing keys of " + lang, Collections.emptyList(), missing);
                 assertEquals("Obsolete keys of " + lang, Collections.emptyList(), obsolete);
             }
         }


### PR DESCRIPTION
[Crowdin](http://translate.jabref.org/) automatically adds missing translations to the other languages.

With our `localizationUpdate` task, we also do that. This leads to conflicts at the Crowdin synchronizations.

This PR proposes to 

1. update the description of how to add new strings
2. update the tests to enable the translations being a subset of the existing translations.

After each sync, the translation will reappear. So we have a short time window where the translations are missing and that translators using GitHub do not see these new translations. I would accept that.

News: We have 17 new Indonesian translations, because a guy just translated some strings there at Crowdin. 🎉 