### PR TITLE
[WIP] Add support for German months at the normalizer functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We now show a small notification icon in the entry editor when we detect data inconsistency or other problems. [#3145](https://github.com/JabRef/jabref/issues/3145)
 - We added [oaDOI](https://oadoi.org/) as a fulltext provider, so that JabRef is now able to provide fulltexts for more than 90 million open-access articles.
 - We changed one default of [Cleanup entries dialog](http://help.jabref.org/en/CleanupEntries): Per default, the PDF are not moved to the default file directory anymore. [#3619](https://github.com/JabRef/jabref/issues/3619)
+- We enhanced the cleanup functionality to normalize month names in other languages such as German, too.
 - We added the export of the the `translator` field to the according MS-Office XML field. [#1750, comment](https://github.com/JabRef/jabref/issues/1750#issuecomment-357350986)
 - We changed the import of the MS-Office XML fields `bookauthor` and `translator`. Both are now imported to their corresponding bibtex/biblatex fields.
 - We improved the export of the `address` and `location` field to the MS-Office XML fields. If the address field does not contain a comma, it is treated as single value and exported to the field `city`. [#1750, comment](https://github.com/JabRef/jabref/issues/1750#issuecomment-357539167) 

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/NormalizeMonthFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/NormalizeMonthFormatterTest.java
@@ -21,4 +21,24 @@ public class NormalizeMonthFormatterTest {
         Assert.assertEquals("#dec#", formatter.format(formatter.getExampleInput()));
     }
 
+    @Test
+    public void formatGermanMarch() {
+        Assert.assertEquals("#mar#", formatter.format("Maerz"));
+    }
+
+    @Test
+    public void formatGermanMarchInUtf8() {
+        Assert.assertEquals("#mar#", formatter.format("März"));
+    }
+
+    @Test
+    public void formatGermanMarchInLaTeX() {
+        Assert.assertEquals("#mar#", formatter.format("M\\\"arz"));
+    }
+
+    @Test
+    public void formatGermanMarchInLaTeXWithBraces() {
+        Assert.assertEquals("#mar#", formatter.format("M{\\\"a}rz"));
+    }
+
 }


### PR DESCRIPTION
My library exports BibTeX in a strange format (http://www2.informatik.uni-stuttgart.de/zdi/buecherei/NCSTRL_listings/privat/Kopp_Oliver.bibtex.html). I cannot get this fixed, so JabRef has to.

----

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] <s>Screenshots added (for bigger UI changes)</s>
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
