### PR TITLE
Automate Gradle dependency Update checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,7 @@ env:
     - TEST_SUITE=guiTest
     - TEST_SUITE=checkstyle
     - TEST_SUITE=codecov
-    - if type == cron
-      notifications:
-        email:
-        - linus@lynyus.de
+
 
 matrix:
     fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,10 @@ env:
     - TEST_SUITE=guiTest
     - TEST_SUITE=checkstyle
     - TEST_SUITE=codecov
-    include:
-      if: type == cron
-        notifications:
-          email:
-          - linus@lynyus.de
+    if: type == cron
+      notifications:
+        email:
+        - linus@lynyus.de
 
 matrix:
     fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - TEST_SUITE=guiTest
     - TEST_SUITE=checkstyle
     - TEST_SUITE=codecov
-
+    - DEPENDENCY_UPDATE=yes
 
 matrix:
     fast_finish: true
@@ -47,7 +47,7 @@ script:
   - if [ "$TEST_SUITE" == "checkstyle" ]; then ./gradlew checkstyleMain checkstyleTest checkstyleJmh; fi
   - if [ "$TEST_SUITE" == "guiTest" ]; then ./buildres/gui-tests.sh; fi
   - if [ "$TEST_SUITE" == "codecov" ]; then ./gradlew jacocoJunit5TestReport; bash <(curl -s https://codecov.io/bash); fi
-  - if type == cron; then ./gradlew depencencyUpdate; fi
+  - if [ "$DEPENDENCY_UPDATE" == "yes" ] then ./gradlew depencencyUpdate; fi
 
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
   - if [ "$TEST_SUITE" == "checkstyle" ]; then ./gradlew checkstyleMain checkstyleTest checkstyleJmh; fi
   - if [ "$TEST_SUITE" == "guiTest" ]; then ./buildres/gui-tests.sh; fi
   - if [ "$TEST_SUITE" == "codecov" ]; then ./gradlew jacocoJunit5TestReport; bash <(curl -s https://codecov.io/bash); fi
-  - if [ "$DEPENDENCY_UPDATE" == "yes" ]; then ./gradlew depencencyUpdate; fi
+  - if [ "$DEPENDENCY_UPDATE" == "yes" ]; then ./gradlew depencencyUpdates; fi
 
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,20 @@ script:
   - if [ "$TEST_SUITE" == "guiTest" ]; then ./buildres/gui-tests.sh; fi
   - if [ "$TEST_SUITE" == "codecov" ]; then ./gradlew jacocoJunit5TestReport; bash <(curl -s https://codecov.io/bash); fi
 
+jobs:
+  include:
+  - if: type == "cron"
+  - ./gradlew depencencyUpdate
+  notifications:
+    email:
+      - linus@lynyus.de
+
 after_failure:
   # show test results if build fails
   - $TRAVIS_BUILD_DIR/scripts/after-failure.sh
 
 branches:
-  only: 
+  only:
     - master
 
 # cache gradle dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - TEST_SUITE=guiTest
     - TEST_SUITE=checkstyle
     - TEST_SUITE=codecov
-    if: type == cron
+    - if type == cron
       notifications:
         email:
         - linus@lynyus.de

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,11 @@ env:
     - TEST_SUITE=guiTest
     - TEST_SUITE=checkstyle
     - TEST_SUITE=codecov
+    include:
+      if: type == cron
+        notifications:
+          email:
+          - linus@lynyus.de
 
 matrix:
     fast_finish: true
@@ -46,14 +51,8 @@ script:
   - if [ "$TEST_SUITE" == "checkstyle" ]; then ./gradlew checkstyleMain checkstyleTest checkstyleJmh; fi
   - if [ "$TEST_SUITE" == "guiTest" ]; then ./buildres/gui-tests.sh; fi
   - if [ "$TEST_SUITE" == "codecov" ]; then ./gradlew jacocoJunit5TestReport; bash <(curl -s https://codecov.io/bash); fi
+  - if type == cron; then ./gradlew depencencyUpdate; fi
 
-jobs:
-  include:
-  - if: type == "cron"
-  - ./gradlew depencencyUpdate
-  notifications:
-    email:
-      - linus@lynyus.de
 
 after_failure:
   # show test results if build fails

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,7 @@ script:
   - if [ "$TEST_SUITE" == "checkstyle" ]; then ./gradlew checkstyleMain checkstyleTest checkstyleJmh; fi
   - if [ "$TEST_SUITE" == "guiTest" ]; then ./buildres/gui-tests.sh; fi
   - if [ "$TEST_SUITE" == "codecov" ]; then ./gradlew jacocoJunit5TestReport; bash <(curl -s https://codecov.io/bash); fi
-  - if [ "$DEPENDENCY_UPDATE" == "yes" ]; then ./gradlew dependencyUpdates; fi
-
+  - if [ "$DEPENDENCY_UPDATE" == "yes" ]; then ./gradlew checkOutdatedDependencies; fi
 
 after_failure:
   # show test results if build fails

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
   - if [ "$TEST_SUITE" == "checkstyle" ]; then ./gradlew checkstyleMain checkstyleTest checkstyleJmh; fi
   - if [ "$TEST_SUITE" == "guiTest" ]; then ./buildres/gui-tests.sh; fi
   - if [ "$TEST_SUITE" == "codecov" ]; then ./gradlew jacocoJunit5TestReport; bash <(curl -s https://codecov.io/bash); fi
-  - if [ "$DEPENDENCY_UPDATE" == "yes" ]; then ./gradlew depencencyUpdates; fi
+  - if [ "$DEPENDENCY_UPDATE" == "yes" ]; then ./gradlew dependencyUpdates; fi
 
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
   - if [ "$TEST_SUITE" == "checkstyle" ]; then ./gradlew checkstyleMain checkstyleTest checkstyleJmh; fi
   - if [ "$TEST_SUITE" == "guiTest" ]; then ./buildres/gui-tests.sh; fi
   - if [ "$TEST_SUITE" == "codecov" ]; then ./gradlew jacocoJunit5TestReport; bash <(curl -s https://codecov.io/bash); fi
-  - if [ "$DEPENDENCY_UPDATE" == "yes" ] then ./gradlew depencencyUpdate; fi
+  - if [ "$DEPENDENCY_UPDATE" == "yes" ]; then ./gradlew depencencyUpdate; fi
 
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,14 @@ env:
     - TEST_SUITE=guiTest
     - TEST_SUITE=checkstyle
     - TEST_SUITE=codecov
-    - DEPENDENCY_UPDATE=yes
+    - DEPENDENCY_UPDATES=check
 
 matrix:
     fast_finish: true
     allow_failures:
       - env: TEST_SUITE=fetcherTest
       - env: TEST_SUITE=codecov
+      - env: DEPENDENCY_UPDATES=check
 
 # JavaFX localization tests need a running X environment
 before_install:
@@ -47,7 +48,7 @@ script:
   - if [ "$TEST_SUITE" == "checkstyle" ]; then ./gradlew checkstyleMain checkstyleTest checkstyleJmh; fi
   - if [ "$TEST_SUITE" == "guiTest" ]; then ./buildres/gui-tests.sh; fi
   - if [ "$TEST_SUITE" == "codecov" ]; then ./gradlew jacocoJunit5TestReport; bash <(curl -s https://codecov.io/bash); fi
-  - if [ "$DEPENDENCY_UPDATE" == "yes" ]; then ./gradlew checkOutdatedDependencies; fi
+  - if [ "$DEPENDENCY_UPDATES" == "check" ]; then ./gradlew -q checkOutdatedDependencies; fi
 
 after_failure:
   # show test results if build fails

--- a/build.gradle
+++ b/build.gradle
@@ -214,9 +214,12 @@ dependencyUpdates.resolutionStrategy = {
         }
     }
 }
-task checkOutdatedDependencies(dependsOn: "dependencyUpdates") {
-    def dependencyReport = new JsonSlurper().parseText(new File("build/dependencyUpdates/report.json").text)
-    assert dependencyReport.outdated.count == 0: "There are outdated dependencies in build.gradle!\n Run ./gradlew dependencyUpdates to see which"
+
+task checkOutdatedDependencies(dependsOn: dependencyUpdates) {
+    doLast {
+        def dependencyReport = new JsonSlurper().parseText(new File("build/dependencyUpdates/report.json").text)
+        assert dependencyReport.outdated.count == 0: "There are outdated dependencies in build.gradle!\n Run ./gradlew dependencyUpdates to see which"
+    }
 }
 
 clean {
@@ -309,6 +312,7 @@ javadoc {
     }
 }
 
+// Test tasks
 junitPlatform {
     filters {
         tags {
@@ -337,6 +341,7 @@ task guiTest(type: Test) {
     }
 }
 
+// Test result tasks
 task copyTestResources(type: Copy) {
     from "${projectDir}/src/test/resources"
     into "${buildDir}/classes/test"
@@ -387,6 +392,8 @@ afterEvaluate {
     }
 }
 
+
+// Code quality tasks
 checkstyle {
     // do not use other packages for checkstyle, excluding gen(erated) sources
     checkstyleMain.source = "src/main/java"
@@ -402,6 +409,7 @@ modernizer {
     failOnViolations = false
 }
 
+// Release tasks
 shadowJar {
     classifier 'fat'
 }
@@ -494,8 +502,3 @@ jmh {
     iterations = 10
     fork = 2
 }
-
-
-
-
-

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+import groovy.json.JsonSlurper
 import org.gradle.internal.os.OperatingSystem
 
 // to update the gradle wrapper, execute ./gradlew wrapper --gradle-version 4.0
@@ -57,8 +58,16 @@ mainClassName = "org.jabref.JabRefMain"
 ext.minRequiredJavaVersion = "1.8.0_144"
 ext.allowJava9 = false
 
-install4j {
-    installDir = file(project.ext.install4jDir)
+sourceSets {
+    main {
+        java {
+            srcDirs = ["src/main/java", "src/main/gen"]
+        }
+
+        resources {
+            srcDirs = ["src/main/java", "src/main/resources"]
+        }
+    }
 }
 
 repositories {
@@ -105,7 +114,6 @@ dependencies {
     antlr4 'org.antlr:antlr4:4.7.1'
     compile 'org.antlr:antlr4-runtime:4.7.1'
 
-    // VersionEye states that 6.0.5 is the most recent version, but http://dev.mysql.com/downloads/connector/j/ shows that as "Development Release"
     compile 'mysql:mysql-connector-java:5.1.44'
 
     compile 'com.impossibl.pgjdbc-ng:pgjdbc-ng:0.7.1'
@@ -162,16 +170,57 @@ dependencies {
     testCompile 'org.slf4j:slf4j-jcl:1.7.25' // required by ArchUnit to enable logging over jcl
 }
 
-sourceSets {
-    main {
-        java {
-            srcDirs = ["src/main/java", "src/main/gen"]
-        }
+dependencyUpdates {
+    outputFormatter = "json"
+}
 
-        resources {
-            srcDirs = ["src/main/java", "src/main/resources"]
+// We have some dependencies which cannot be updated due to various reasons.
+dependencyUpdates.resolutionStrategy = {
+    componentSelection {
+        withModule("org.controlsfx:controlsfx") { ComponentSelection selection ->
+            if (selection.candidate.version ==~ /9.*/) { // Reject version 9 or higher
+                selection.reject("Cannot be updated to 9.*.* until Jabref works with Java 9")
+            }
+        }
+        withModule("com.microsoft.azure:applicationinsights-core") { ComponentSelection selection ->
+            if (selection.candidate.version.equals("1.0.10")) {
+                selection.reject("Version 1.0.10 is broken... waiting for 1.0.11")
+            }
+        }
+        withModule("com.microsoft.azure:applicationinsights-logging-log4j2") { ComponentSelection selection ->
+            if (selection.candidate.version.equals("1.0.10")) {
+                selection.reject("Version 1.0.10 is broken... waiting for 1.0.11")
+            }
+        }
+        withModule("de.jensd:fontawesomefx-materialdesignfont") { ComponentSelection selection ->
+            if (selection.candidate.version ==~ /2.*/) {
+                selection.reject("Cannot be upgraded to version 2")
+            }
+        }
+        withModule("org.apache.pdfbox:fontbox") { ComponentSelection selection ->
+            if (selection.candidate.version ==~ /2.*/) {
+                selection.reject("update to 2.0.x is not possible - see https://github.com/JabRef/jabref/pull/1096#issuecomment-208857517")
+            }
+        }
+        withModule("org.apache.pdfbox:pdfbox") { ComponentSelection selection ->
+            if (selection.candidate.version ==~ /2.*/) {
+                selection.reject("update to 2.0.x is not possible - see https://github.com/JabRef/jabref/pull/1096#issuecomment-208857517")
+            }
+        }
+        withModule("mysql:mysql-connector-java") { ComponentSelection selection ->
+            if (selection.candidate.version ==~ /[6-9].*/) {
+                selection.reject("http://dev.mysql.com/downloads/connector/j/ lists the version 5.* as last stable version.")
+            }
         }
     }
+}
+task checkOutdatedDependencies(dependsOn: "dependencyUpdates") {
+    def dependencyReport = new JsonSlurper().parseText(new File("build/dependencyUpdates/report.json").text)
+    assert dependencyReport.outdated.count == 0: "There are outdated dependencies in build.gradle!\n Run ./gradlew dependencyUpdates to see which"
+}
+
+clean {
+    delete "src/main/gen"
 }
 
 processResources {
@@ -195,9 +244,6 @@ processResources {
     }
 }
 
-clean {
-    delete "src/main/gen"
-}
 
 task generateSource(dependsOn: ["generateBstGrammarSource", "generateSearchGrammarSource"]) {
     group = 'JabRef'
@@ -341,6 +387,21 @@ afterEvaluate {
     }
 }
 
+checkstyle {
+    // do not use other packages for checkstyle, excluding gen(erated) sources
+    checkstyleMain.source = "src/main/java"
+    toolVersion = '8.3'
+}
+
+checkstyleMain.shouldRunAfter test
+checkstyleTest.shouldRunAfter test
+
+modernizer {
+    // We have more than 20 issues, which are not fixed yet. Nevertheless, we produce the modernizer output.
+    // See https://github.com/andrewgaul/modernizer-maven-plugin for more information on modernizer
+    failOnViolations = false
+}
+
 shadowJar {
     classifier 'fat'
 }
@@ -378,6 +439,10 @@ if (hasProperty('dev')) {
     project.version += "--snapshot--" + infoString
 }
 
+install4j {
+    installDir = file(project.ext.install4jDir)
+}
+
 // has to be defined AFTER 'dev' things to have the correct project.version
 task media(type: com.install4j.gradle.Install4jTask, dependsOn: "releaseJar") {
     projectFile = file('jabref.install4j')
@@ -398,14 +463,6 @@ task media(type: com.install4j.gradle.Install4jTask, dependsOn: "releaseJar") {
     }
 }
 
-checkstyle {
-    // do not use other packages for checkstyle, excluding gen(erated) sources
-    checkstyleMain.source = "src/main/java"
-    toolVersion = '8.3'
-}
-
-checkstyleMain.shouldRunAfter test
-checkstyleTest.shouldRunAfter test
 
 task release(dependsOn: ["media", "releaseJar"]) {
     group = 'JabRef - Release'
@@ -438,8 +495,7 @@ jmh {
     fork = 2
 }
 
-modernizer {
-    // We have more than 20 issues, which are not fixed yet. Nevertheless, we produce the modernizer output.
-    // See https://github.com/andrewgaul/modernizer-maven-plugin for more information on modernizer
-    failOnViolations = false
-}
+
+
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -169,6 +169,8 @@ dependencies {
     testCompile 'org.xmlunit:xmlunit-matchers:2.5.1'
     testCompile 'com.tngtech.archunit:archunit-junit:0.5.0'
     testCompile 'org.slf4j:slf4j-jcl:1.7.25' // required by ArchUnit to enable logging over jcl
+
+    checkstyle 'com.puppycrawl.tools:checkstyle:8.5'
 }
 
 dependencyUpdates {
@@ -398,7 +400,7 @@ afterEvaluate {
 checkstyle {
     // do not use other packages for checkstyle, excluding gen(erated) sources
     checkstyleMain.source = "src/main/java"
-    toolVersion = '8.3'
+    toolVersion = '8.5'
 }
 
 checkstyleMain.shouldRunAfter test

--- a/xjc.gradle
+++ b/xjc.gradle
@@ -3,6 +3,7 @@ configurations {
 }
 
 dependencies {
+    // Cannot be updated.
     xjc 'com.sun.xml.bind:jaxb-xjc:2.2.4-1'
 }
 


### PR DESCRIPTION
I have created a new build job on Travis, that automatically checks if there are zero out-of date dependencies.
Features:
- [x] set up specific build job
- [x] It is checked on PR, but as an allowed failure. Otherwise it might be annoying in WIP Pull requests.

As soon as anybody sees that a dependency is out-of-date, on travis, we can update it automatically.

Furthermore, I regrouped the gradle tasks that belong together.