### PR TITLE
Set git clone depth to 1 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ language: java
 dist: trusty
 sudo: required
 
+git:
+  depth: false
+
 services:
   - postgresql
   - mysql
@@ -52,7 +55,7 @@ after_failure:
   - $TRAVIS_BUILD_DIR/scripts/after-failure.sh
 
 branches:
-  only: 
+  only:
     - master
 
 # cache gradle dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ dist: trusty
 sudo: required
 
 git:
-  depth: false
+  depth: 1
 
 services:
   - postgresql


### PR DESCRIPTION
Per default, travis pulls the last 50 commits.

This sets the depth to one, which is all we need. It's a small optimization.