### PR TITLE
Add new authors to mailMap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -90,9 +90,9 @@ Ulrik Stervbo <ulriks@users.sourceforge.net>
 Stefano Gariazzo <steog88@gmail.com>
 Lee Patton <lpatton@users.sourceforge.net>
 Jörg Lenhard <joerg.lenhard@kau.se>
-Jörg Lenhard <joerg@lenhard.info>
-Jörg Lenhard <lenhard@users.noreply.github.com>
-Jörg Lenhard <joerg.lenhard@uni-bamberg.de>
+<joerg.lenhard@kau.se> <joerg@lenhard.info>
+<joerg.lenhard@kau.se> <lenhard@users.noreply.github.com>
+Jörg Lenhard <joerg.lenhard@kau.se> <joerg.lenhard@uni-bamberg.de>
 Matthias Geiger <matthias.geiger@uni-bamberg.de>
 Christoph Braun <braunch.dev@gmail.com>
 Felix Wilke <horstilaemmer@yahoo.com>

--- a/.mailmap
+++ b/.mailmap
@@ -90,9 +90,9 @@ Ulrik Stervbo <ulriks@users.sourceforge.net>
 Stefano Gariazzo <steog88@gmail.com>
 Lee Patton <lpatton@users.sourceforge.net>
 Jörg Lenhard <joerg.lenhard@kau.se>
-<joerg.lenhard@kau.se> <joerg@lenhard.info>
-<joerg.lenhard@kau.se> <lenhard@users.noreply.github.com>
-Jörg Lenhard <joerg.lenhard@kau.se> <joerg.lenhard@uni-bamberg.de>
+Jörg Lenhard <joerg@lenhard.info>
+Jörg Lenhard <lenhard@users.noreply.github.com>
+Jörg Lenhard <joerg.lenhard@uni-bamberg.de>
 Matthias Geiger <matthias.geiger@uni-bamberg.de>
 Christoph Braun <braunch.dev@gmail.com>
 Felix Wilke <horstilaemmer@yahoo.com>
@@ -132,3 +132,5 @@ Abhishek Rai <abhisheksavitarai@gmail.com>
 Abhishek Rai <betheunique@users.noreply.github.com>
 Stéphane Curet <stephane.curet@orange.fr>
 Erdem Derebasoglu <erdemderebasoglu@hotmail.com>
+Domenico Cufalo <cufalo@gmail.com>
+Tobias Bouschen <tobias.bouschen@googlemail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -136,3 +136,4 @@ Domenico Cufalo <cufalo@gmail.com>
 Tobias Bouschen <tobias.bouschen@googlemail.com>
 József Pallagi <pallagijoe@gmail.com>
 Mattia Bunel <MBunel@users.noreply.github.com>
+Waida Fan <31742543+weidafan@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -135,3 +135,4 @@ Erdem Derebasoglu <erdemderebasoglu@hotmail.com>
 Domenico Cufalo <cufalo@gmail.com>
 Tobias Bouschen <tobias.bouschen@googlemail.com>
 József Pallagi <pallagijoe@gmail.com>
+Mattia Bunel <MBunel@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -134,3 +134,4 @@ Stéphane Curet <stephane.curet@orange.fr>
 Erdem Derebasoglu <erdemderebasoglu@hotmail.com>
 Domenico Cufalo <cufalo@gmail.com>
 Tobias Bouschen <tobias.bouschen@googlemail.com>
+József Pallagi <pallagijoe@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -95,6 +95,7 @@ Jong-Ho Shinn
 Jorge Tornero
 Joshua Ramon Enslin
 Julian Pfeifer
+József Pallagi
 Jörg Lenhard
 Jörg Wegner
 Jörg Zieren

--- a/AUTHORS
+++ b/AUTHORS
@@ -123,8 +123,8 @@ Martin Kähmer
 Martin Stolle
 Mathias Walter
 Matthias Geiger
+Mattia Bunel
 Mattias Ulbrich
-MBunel
 mcmoody
 Meltem Demirköprü
 Michael

--- a/AUTHORS
+++ b/AUTHORS
@@ -204,9 +204,9 @@ Ulrich Stärk
 Ulrik Stervbo
 Uwe Kuehn
 Vincent W. Yang
+Waida Fan
 Waluyo Adi Siswanto
 Ward Poelmans
-weidafan
 Wenbo Yang
 wuw
 Yang Zongze

--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Anh Nghia Tran
 Anita Armbruster
 Antonio Ribeiro
 Arno Blouin
+Bartosz J. Kaczkowski
 Behrouz Javanmardi
 Benjamin Köhler
 Berk Gureken
@@ -44,6 +45,7 @@ Daniel Svärd
 David Gleich
 David Weitzman
 Dennis Tschechlov
+Domenico Cufalo
 Dominik Waßenhoven
 Douglas Nassif Roma Junior
 Eduard Braun
@@ -51,8 +53,10 @@ Eduardo Greco
 Egon Willighagen
 Ellen Reitmayr
 Erdem Derebasoglu
+Erdem Derebaşoğlu
 Erik Putrycz
 Ervin Kolenovic
+Ethan Harris
 Fabian Bauer
 Fabian Bieker
 Fabrice Dessaint
@@ -90,6 +94,7 @@ Jonathan Powell
 Jong-Ho Shinn
 Jorge Tornero
 Joshua Ramon Enslin
+Julian Pfeifer
 Jörg Lenhard
 Jörg Wegner
 Jörg Zieren
@@ -118,11 +123,13 @@ Martin Stolle
 Mathias Walter
 Matthias Geiger
 Mattias Ulbrich
+MBunel
 mcmoody
 Meltem Demirköprü
 Michael
 Michael Beckmann
 Michael Falkenthal
+Michael Lass
 Michael Spiegel
 Michael Wrighton
 Michel Baylac
@@ -143,6 +150,7 @@ Oliver Beckmann
 Oliver Kopp
 Oscar Gustafsson
 Owen Huang
+Patrick Scheibe
 Paul Martin
 payload
 Peter Ansell
@@ -184,6 +192,7 @@ Thorsten Dahlheimer
 Tim van Rossum
 Tim Würtele
 Tobias Boceck
+Tobias Bouschen
 Tobias Denkinger
 Tobias Diez
 tokkot
@@ -196,9 +205,11 @@ Uwe Kuehn
 Vincent W. Yang
 Waluyo Adi Siswanto
 Ward Poelmans
+weidafan
 Wenbo Yang
 wuw
 Yang Zongze
 Yara Grassi Gouffon
 Yifan Peng
 zacmks
+Zhang Liang


### PR DESCRIPTION
These are the new authors of Jabref. :tada: 

 I have contacted @MBunel  and @weidafan, whether they can provide us their full names, so let's wait until the release before we merge this.