### PR TITLE
Library properties: no change but.. (issue #3562)

### DIFF
--- a/src/main/java/org/jabref/gui/dbproperties/DatabasePropertiesDialog.java
+++ b/src/main/java/org/jabref/gui/dbproperties/DatabasePropertiesDialog.java
@@ -167,11 +167,40 @@ public class DatabasePropertiesDialog extends JabRefDialog {
         am.put("close", closeAction);
 
         ok.addActionListener(e -> {
-            storeSettings();
+            if (propertiesChanged()) {
+                storeSettings();
+            }
             dispose();
         });
 
         cancel.addActionListener(e -> dispose());
+    }
+
+    private boolean propertiesChanged() {
+        Charset oldEncoding = panel.getBibDatabaseContext().getMetaData().getEncoding()
+                .orElse(Globals.prefs.getDefaultEncoding());
+        Charset newEncoding = (Charset) encoding.getSelectedItem();
+        boolean saveActionsChanged = fieldFormatterCleanupsPanel.hasChanged();
+        boolean saveOrderConfigChanged = newAndOldOrderCinfigIsSame(getNewSaveOrderConfig(), oldSaveOrderConfig);
+        boolean changed = saveOrderConfigChanged || !newEncoding.equals(oldEncoding)
+                || !oldFileVal.equals(fileDir.getText()) || !oldFileIndvVal.equals(fileDirIndv.getText())
+                || (oldProtectVal != protect.isSelected()) || saveActionsChanged;
+        return changed;
+    }
+
+    private boolean newAndOldOrderCinfigIsSame(SaveOrderConfig newSaveOrderConfig, SaveOrderConfig oldSaveOrderConfig) {
+        return newSaveOrderConfig.equals(oldSaveOrderConfig) ? false : true;
+    }
+
+    private SaveOrderConfig getNewSaveOrderConfig() {
+        SaveOrderConfig saveOrderConfig = null;
+        if (saveInOriginalOrder.isSelected()) {
+            saveOrderConfig = SaveOrderConfig.getDefaultSaveOrder();
+        } else {
+            saveOrderConfig = saveOrderPanel.getSaveOrderConfig();
+            saveOrderConfig.setSaveInSpecifiedOrder();
+        }
+        return saveOrderConfig;
     }
 
     private void setupSortOrderConfiguration() {
@@ -270,21 +299,10 @@ public class DatabasePropertiesDialog extends JabRefDialog {
             metaData.markAsNotProtected();
         }
 
-        SaveOrderConfig newSaveOrderConfig;
-        if (saveInOriginalOrder.isSelected()) {
-            newSaveOrderConfig = SaveOrderConfig.getDefaultSaveOrder();
-        } else {
-            newSaveOrderConfig = saveOrderPanel.getSaveOrderConfig();
-            newSaveOrderConfig.setSaveInSpecifiedOrder();
-        }
+        SaveOrderConfig newSaveOrderConfig = getNewSaveOrderConfig();
 
         // See if any of the values have been modified:
-        boolean saveOrderConfigChanged;
-        if (newSaveOrderConfig.equals(oldSaveOrderConfig)) {
-            saveOrderConfigChanged = false;
-        } else {
-            saveOrderConfigChanged = true;
-        }
+        boolean saveOrderConfigChanged = newAndOldOrderCinfigIsSame(getNewSaveOrderConfig(), oldSaveOrderConfig);
 
         if (saveOrderConfigChanged) {
             if (newSaveOrderConfig.equals(SaveOrderConfig.getDefaultSaveOrder())) {

--- a/src/main/java/org/jabref/gui/dbproperties/DatabasePropertiesDialog.java
+++ b/src/main/java/org/jabref/gui/dbproperties/DatabasePropertiesDialog.java
@@ -188,7 +188,6 @@ public class DatabasePropertiesDialog extends JabRefDialog {
         return changed;
     }
 
-
     private SaveOrderConfig getNewSaveOrderConfig() {
         SaveOrderConfig saveOrderConfig = null;
         if (saveInOriginalOrder.isSelected()) {
@@ -270,7 +269,6 @@ public class DatabasePropertiesDialog extends JabRefDialog {
     }
 
     private void storeSettings() {
-
         Charset oldEncoding = panel.getBibDatabaseContext().getMetaData().getEncoding()
                 .orElse(Globals.prefs.getDefaultEncoding());
         Charset newEncoding = (Charset) encoding.getSelectedItem();

--- a/src/main/java/org/jabref/gui/dbproperties/DatabasePropertiesDialog.java
+++ b/src/main/java/org/jabref/gui/dbproperties/DatabasePropertiesDialog.java
@@ -181,16 +181,13 @@ public class DatabasePropertiesDialog extends JabRefDialog {
                 .orElse(Globals.prefs.getDefaultEncoding());
         Charset newEncoding = (Charset) encoding.getSelectedItem();
         boolean saveActionsChanged = fieldFormatterCleanupsPanel.hasChanged();
-        boolean saveOrderConfigChanged = newAndOldOrderConfigIsSame(getNewSaveOrderConfig(), oldSaveOrderConfig);
+        boolean saveOrderConfigChanged = !getNewSaveOrderConfig().equals(oldSaveOrderConfig);
         boolean changed = saveOrderConfigChanged || !newEncoding.equals(oldEncoding)
                 || !oldFileVal.equals(fileDir.getText()) || !oldFileIndvVal.equals(fileDirIndv.getText())
                 || (oldProtectVal != protect.isSelected()) || saveActionsChanged;
         return changed;
     }
 
-    private boolean newAndOldOrderConfigIsSame(SaveOrderConfig newSaveOrderConfig, SaveOrderConfig oldSaveOrderConfig) {
-        return !newSaveOrderConfig.equals(oldSaveOrderConfig);
-    }
 
     private SaveOrderConfig getNewSaveOrderConfig() {
         SaveOrderConfig saveOrderConfig = null;
@@ -302,7 +299,7 @@ public class DatabasePropertiesDialog extends JabRefDialog {
         SaveOrderConfig newSaveOrderConfig = getNewSaveOrderConfig();
 
         // See if any of the values have been modified:
-        boolean saveOrderConfigChanged = newAndOldOrderConfigIsSame(getNewSaveOrderConfig(), oldSaveOrderConfig);
+        boolean saveOrderConfigChanged = !getNewSaveOrderConfig().equals(oldSaveOrderConfig);;
 
         if (saveOrderConfigChanged) {
             if (newSaveOrderConfig.equals(SaveOrderConfig.getDefaultSaveOrder())) {

--- a/src/main/java/org/jabref/gui/dbproperties/DatabasePropertiesDialog.java
+++ b/src/main/java/org/jabref/gui/dbproperties/DatabasePropertiesDialog.java
@@ -298,9 +298,9 @@ public class DatabasePropertiesDialog extends JabRefDialog {
 
         SaveOrderConfig newSaveOrderConfig = getNewSaveOrderConfig();
 
-        // See if any of the values have been modified:
-        boolean saveOrderConfigChanged = !getNewSaveOrderConfig().equals(oldSaveOrderConfig);;
+        boolean saveOrderConfigChanged = !getNewSaveOrderConfig().equals(oldSaveOrderConfig);
 
+        // See if any of the values have been modified:
         if (saveOrderConfigChanged) {
             if (newSaveOrderConfig.equals(SaveOrderConfig.getDefaultSaveOrder())) {
                 metaData.clearSaveOrderConfig();

--- a/src/main/java/org/jabref/gui/dbproperties/DatabasePropertiesDialog.java
+++ b/src/main/java/org/jabref/gui/dbproperties/DatabasePropertiesDialog.java
@@ -189,7 +189,7 @@ public class DatabasePropertiesDialog extends JabRefDialog {
     }
 
     private boolean newAndOldOrderConfigIsSame(SaveOrderConfig newSaveOrderConfig, SaveOrderConfig oldSaveOrderConfig) {
-        return newSaveOrderConfig.equals(oldSaveOrderConfig) ? false : true;
+        return !newSaveOrderConfig.equals(oldSaveOrderConfig);
     }
 
     private SaveOrderConfig getNewSaveOrderConfig() {

--- a/src/main/java/org/jabref/gui/dbproperties/DatabasePropertiesDialog.java
+++ b/src/main/java/org/jabref/gui/dbproperties/DatabasePropertiesDialog.java
@@ -181,14 +181,14 @@ public class DatabasePropertiesDialog extends JabRefDialog {
                 .orElse(Globals.prefs.getDefaultEncoding());
         Charset newEncoding = (Charset) encoding.getSelectedItem();
         boolean saveActionsChanged = fieldFormatterCleanupsPanel.hasChanged();
-        boolean saveOrderConfigChanged = newAndOldOrderCinfigIsSame(getNewSaveOrderConfig(), oldSaveOrderConfig);
+        boolean saveOrderConfigChanged = newAndOldOrderConfigIsSame(getNewSaveOrderConfig(), oldSaveOrderConfig);
         boolean changed = saveOrderConfigChanged || !newEncoding.equals(oldEncoding)
                 || !oldFileVal.equals(fileDir.getText()) || !oldFileIndvVal.equals(fileDirIndv.getText())
                 || (oldProtectVal != protect.isSelected()) || saveActionsChanged;
         return changed;
     }
 
-    private boolean newAndOldOrderCinfigIsSame(SaveOrderConfig newSaveOrderConfig, SaveOrderConfig oldSaveOrderConfig) {
+    private boolean newAndOldOrderConfigIsSame(SaveOrderConfig newSaveOrderConfig, SaveOrderConfig oldSaveOrderConfig) {
         return newSaveOrderConfig.equals(oldSaveOrderConfig) ? false : true;
     }
 
@@ -302,7 +302,7 @@ public class DatabasePropertiesDialog extends JabRefDialog {
         SaveOrderConfig newSaveOrderConfig = getNewSaveOrderConfig();
 
         // See if any of the values have been modified:
-        boolean saveOrderConfigChanged = newAndOldOrderCinfigIsSame(getNewSaveOrderConfig(), oldSaveOrderConfig);
+        boolean saveOrderConfigChanged = newAndOldOrderConfigIsSame(getNewSaveOrderConfig(), oldSaveOrderConfig);
 
         if (saveOrderConfigChanged) {
             if (newSaveOrderConfig.equals(SaveOrderConfig.getDefaultSaveOrder())) {


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
When user wanted to lead default Library properties, after clicking OK button even though there was no modification in Library property the bibTeX tab marked as modified. I fixed this bug so no need to  worry about this anymore.  

Fixes #3562 

----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
