### PR TITLE
Remove Dependency for JUnit4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,6 @@ dependencies {
     compile group: 'com.microsoft.azure', name: 'applicationinsights-core', version: '1.0.9'
     compile group: 'com.microsoft.azure', name: 'applicationinsights-logging-log4j2', version: '1.0.9'
 
-    testCompile 'junit:junit:4.12'
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.1.0-M1'
     testCompile 'org.junit.jupiter:junit-jupiter-params:5.1.0-M1'
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.1.0-M1'


### PR DESCRIPTION
The JUnit4 tests are handled by the `junit-vintage-engine`, so we don't need the old dependency anymore. 🎉 