### PR TITLE
Add gitter badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Take a look at GitHub's excellent [help documentation] for a detailed explanatio
 We also have [code howtos](https://github.com/JabRef/jabref/wiki/Code-Howtos) and [guidelines for setting up a local workspace](https://github.com/JabRef/jabref/wiki/Guidelines-for-setting-up-a-local-workspace).
 
 In case you have any question, do not hesitate to write one of our [JabRef developers](https://github.com/orgs/JabRef/teams/developers) an email.
+We should also be online at [gitter](https://gitter.im/JabRef/jabref).
 
 
 ## Formal requirements for a pull request

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![codecov.io](https://codecov.io/github/JabRef/jabref/coverage.svg?branch=master)](https://codecov.io/github/JabRef/jabref?branch=master)
 [![Donation](https://img.shields.io/badge/donate%20to-jabref-orange.svg)](https://donations.jabref.org)
 [![Help Contribute to Open Source](https://www.codetriage.com/jabref/jabref/badges/users.svg)](https://www.codetriage.com/jabref/jabref)
+[![Join the chat at https://gitter.im/JabRef/jabref](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/JabRef/jabref?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 This version is a development version. Features may not work as expected.
 


### PR DESCRIPTION
This addresses https://github.com/JabRef/jabref/issues/3586

In the DevCall, we decided, that we will try to use Gitter and see how it goes.

The main arguments were:
- easy to join for new users
- offer help for new developers since the burden of initial JabRef development is high for newcomers - even if we have https://github.com/JabRef/jabref/wiki/High-Level-Documentation and https://github.com/JabRef/jabref/wiki/Code-Howtos
- Nearly none of the developers uses Slack
- does not clutter the Skype chat of the developers
- developers can use [pinned tabs](https://support.mozilla.org/en-US/kb/pinned-tabs-keep-favorite-websites-open) to keep gitter always opened

We will shutdown gitter in case there won't be much support from @JabRef/developers there (because lack of time). Nevertheless, we give it a chance. 😇 