### PR TITLE
 Export translator field to msoffice 2007 xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Changed
 - We added [oaDOI](https://oadoi.org/) as a fulltext provider, so that JabRef is now able to provide fulltexts for more than 90 million open-access articles.
 - We changed one default of [Cleanup entries dialog](http://help.jabref.org/en/CleanupEntries): Per default, the PDF are not moved to the default file directory anymore. [#3619](https://github.com/JabRef/jabref/issues/3619)
-
+- We added the export of the the `translator` field to the according MS-Office XML field. [#1750, comment](https://github.com/JabRef/jabref/issues/1750#issuecomment-357350986)
+- We changed the import of the MS-Office XML fields `bookauthor` and `translator`. Both are now imported to their corresponding bibtex/biblatex fields.
 
 ### Fixed
 - We fixed the missing dot in the name of an exported file. [#3576](https://github.com/JabRef/jabref/issues/3576)

--- a/src/main/java/org/jabref/gui/importer/ImportFormats.java
+++ b/src/main/java/org/jabref/gui/importer/ImportFormats.java
@@ -75,7 +75,6 @@ public class ImportFormats {
                 FileDialogConfiguration fileDialogConfiguration = new FileDialogConfiguration.Builder()
                         .addExtensionFilter(allImports)
                         .addExtensionFilters(extensions)
-                        .withDefaultExtension(allImports)
                         .withInitialDirectory(Globals.prefs.get(JabRefPreferences.IMPORT_WORKING_DIRECTORY))
                         .build();
                 DialogService dialogService = new FXDialogService();

--- a/src/main/java/org/jabref/gui/util/FileFilterConverter.java
+++ b/src/main/java/org/jabref/gui/util/FileFilterConverter.java
@@ -37,7 +37,7 @@ public class FileFilterConverter {
     }
 
     public static Optional<Importer> getImporter(FileChooser.ExtensionFilter extensionFilter, Collection<Importer> importers) {
-        return importers.stream().filter(importer -> importer.getDescription().equals(extensionFilter.getDescription())).findFirst();
+        return importers.stream().filter(importer -> importer.getFileType().getDescription().equals(extensionFilter.getDescription())).findFirst();
     }
 
     public static Optional<Exporter> getExporter(FileChooser.ExtensionFilter extensionFilter, Collection<Exporter> exporters) {

--- a/src/main/java/org/jabref/logic/msbib/BibTeXConverter.java
+++ b/src/main/java/org/jabref/logic/msbib/BibTeXConverter.java
@@ -48,9 +48,9 @@ public class BibTeXConverter {
         }
 
         addAuthor(fieldValues, FieldName.AUTHOR, entry.authors);
-        addAuthor(fieldValues, MSBIB_PREFIX + FieldName.BOOKAUTHOR, entry.bookAuthors);
+        addAuthor(fieldValues, FieldName.BOOKAUTHOR, entry.bookAuthors);
         addAuthor(fieldValues, FieldName.EDITOR, entry.editors);
-        addAuthor(fieldValues, MSBIB_PREFIX + FieldName.TRANSLATOR, entry.translators);
+        addAuthor(fieldValues, FieldName.TRANSLATOR, entry.translators);
         addAuthor(fieldValues, MSBIB_PREFIX + "producername", entry.producerNames);
         addAuthor(fieldValues, MSBIB_PREFIX + "composer", entry.composers);
         addAuthor(fieldValues, MSBIB_PREFIX + "conductor", entry.conductors);

--- a/src/main/java/org/jabref/logic/msbib/MSBibConverter.java
+++ b/src/main/java/org/jabref/logic/msbib/MSBibConverter.java
@@ -108,6 +108,7 @@ public class MSBibConverter {
 
         entry.getField(FieldName.AUTHOR).ifPresent(authors -> result.authors = getAuthors(authors));
         entry.getField(FieldName.EDITOR).ifPresent(editors -> result.editors = getAuthors(editors));
+        entry.getField(FieldName.TRANSLATOR).ifPresent(translator -> result.translators = getAuthors(translator));
 
         return result;
     }

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -2334,4 +2334,5 @@ Invalid\ identifier\:\ '%0'.=Identifiant non valide \: « %0 ».
 This\ paper\ has\ been\ withdrawn.=Cet article a été retiré.
 Finished\ writing\ XMP-metadata.=Écriture des métadonnées XMP terminée.
 empty\ BibTeX\ key=Clef BibTeX vide
+Your\ Java\ Runtime\ Environment\ is\ located\ at\ %0.=Votre environnement d’exécution Java se trouve à %0.
 

--- a/src/test/java/org/jabref/logic/importer/fileformat/MsBibImporterTestFiles.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/MsBibImporterTestFiles.java
@@ -25,14 +25,14 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class MsBibImporterTestFiles {
 
-    @Parameter
-    public String fileName;
+    @Parameter public String fileName;
     public Path resourceDir;
-
+    private MsBibImporter testImporter;
 
     @Before
     public void setUp() throws Exception {
         resourceDir = Paths.get(MsBibImporterTestFiles.class.getResource("").toURI());
+        testImporter = new MsBibImporter();
     }
 
     @Parameters(name = "{0}")
@@ -45,9 +45,7 @@ public class MsBibImporterTestFiles {
 
     @Test
     public final void testIsRecognizedFormat() throws Exception {
-        MsBibImporter testImporter = new MsBibImporter();
         Path xmlFile = resourceDir.resolve(fileName);
-
         Assert.assertTrue(testImporter.isRecognizedFormat(xmlFile, StandardCharsets.UTF_8));
     }
 
@@ -55,8 +53,6 @@ public class MsBibImporterTestFiles {
     public void testImportEntries() throws Exception {
 
         String bibFileName = fileName.replace(".xml", ".bib");
-        MsBibImporter testImporter = new MsBibImporter();
-
         Path xmlFile = resourceDir.resolve(fileName);
 
         List<BibEntry> result = testImporter.importDatabase(xmlFile, StandardCharsets.UTF_8).getDatabase().getEntries();

--- a/src/test/resources/org/jabref/logic/importer/fileformat/MsBibImporterTestTranslator.bib
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/MsBibImporterTestTranslator.bib
@@ -1,0 +1,15 @@
+% Encoding: UTF-8
+
+@Misc{2016,
+  title          = {MeinArtikel},
+  year           = {2016},
+  month          = jul,
+  journal        = {MeineZeitung},
+  msbib-accessed = {2018-07-01},
+  msbib-day      = {1},
+  pages          = {17},
+  timestamp      = {2018-01-12},
+  translator     = {TestÜbersetzer},
+}
+
+@Comment{jabref-meta: databaseType:biblatex;}

--- a/src/test/resources/org/jabref/logic/importer/fileformat/MsBibImporterTestTranslator.xml
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/MsBibImporterTestTranslator.xml
@@ -1,33 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <b:Sources xmlns:b="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" xmlns="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" SelectedStyle="">
-<b:Source>
-<b:Volume>130</b:Volume>
-<b:BIBTEX_Entry>article</b:BIBTEX_Entry>
-<b:SourceType>JournalArticle</b:SourceType>
-<b:Title>La doctrine médicale des Indo-Européens</b:Title>
-<b:Tag>benv-doct</b:Tag>
-<b:BIBTEX_KeyWords>medicine, agni and soma</b:BIBTEX_KeyWords>
-<b:Author>
-<b:Author>
-<b:NameList>
-<b:Person>
-<b:Last>Benveniste</b:Last>
-<b:First>{\'E}mile</b:First>
-</b:Person>
-</b:NameList>
-</b:Author>
-<b:Translator>
-<b:NameList>
-<b:Person>
-<b:Last>Übersetzer</b:Last>
-<b:Middle>Test</b:Middle>
-<b:First>Mein</b:First>
-</b:Person>
-</b:NameList>
-</b:Translator>
-</b:Author>
-<b:Pages>5-12</b:Pages>
-<b:Year>1945</b:Year>
-<b:JournalName>Revue de l'Histoire des Religions</b:JournalName>
-</b:Source>
+   <b:Source>
+      <b:Tag>Nac16</b:Tag>
+      <b:SourceType>Misc</b:SourceType>
+      <b:Guid>{BD524449-102F-470B-951F-CFE852BA526D}</b:Guid>
+      <b:Title>MeinArtikel</b:Title>
+      <b:Year>2016</b:Year>
+      <b:Pages>17</b:Pages>
+      <b:JournalName>MeineZeitung</b:JournalName>
+      <b:Author>
+         <b:Author>
+            <b:Corporate>Nachname, Vorname MIddleName; Nachname2, Vorname2 MiddleName21</b:Corporate>
+         </b:Author>
+         <b:Translator>
+            <b:NameList>
+               <b:Person>
+                  <b:Last>TestÜbersetzer</b:Last>
+               </b:Person>
+            </b:NameList>
+         </b:Translator>
+      </b:Author>
+      <b:RefOrder>1</b:RefOrder>
+      <b:Month>07</b:Month>
+      <b:Day>1</b:Day>
+      <b:YearAccessed>2018</b:YearAccessed>
+      <b:MonthAccessed>07</b:MonthAccessed>
+      <b:DayAccessed>1</b:DayAccessed>
+   </b:Source>
 </b:Sources>

--- a/src/test/resources/org/jabref/logic/importer/fileformat/MsBibImporterTestTranslator.xml
+++ b/src/test/resources/org/jabref/logic/importer/fileformat/MsBibImporterTestTranslator.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<b:Sources xmlns:b="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" xmlns="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" SelectedStyle="">
+<b:Source>
+<b:Volume>130</b:Volume>
+<b:BIBTEX_Entry>article</b:BIBTEX_Entry>
+<b:SourceType>JournalArticle</b:SourceType>
+<b:Title>La doctrine médicale des Indo-Européens</b:Title>
+<b:Tag>benv-doct</b:Tag>
+<b:BIBTEX_KeyWords>medicine, agni and soma</b:BIBTEX_KeyWords>
+<b:Author>
+<b:Author>
+<b:NameList>
+<b:Person>
+<b:Last>Benveniste</b:Last>
+<b:First>{\'E}mile</b:First>
+</b:Person>
+</b:NameList>
+</b:Author>
+<b:Translator>
+<b:NameList>
+<b:Person>
+<b:Last>Übersetzer</b:Last>
+<b:Middle>Test</b:Middle>
+<b:First>Mein</b:First>
+</b:Person>
+</b:NameList>
+</b:Translator>
+</b:Author>
+<b:Pages>5-12</b:Pages>
+<b:Year>1945</b:Year>
+<b:JournalName>Revue de l'Histoire des Religions</b:JournalName>
+</b:Source>
+</b:Sources>


### PR DESCRIPTION
Upcoming issue from #1750
While testing this I noticed that the import was broken (due to the recent export filetype/extension changes), fixed that, too.

Directly use Bookauthors and Translator for import from xml
Add test 

----

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
