### PR TITLE
Update documentation to new workflow using Crowdin

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,4 +8,3 @@
 - [ ] Screenshots added (for bigger UI changes)
 - [ ] Manually tested changed features in running JabRef
 - [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
-- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,10 +84,24 @@ because <additional rationale>.
 ### When adding a new Localization.lang entry
 Add new `Localization.lang("KEY")` to Java file.
 Tests fail. In the test output a snippet is generated which must be added to the English translation file.
+
+Example:
+
+```
+java.lang.AssertionError: DETECTED LANGUAGE KEYS WHICH ARE NOT IN THE ENGLISH LANGUAGE FILE
+PASTE THESE INTO THE ENGLISH LANGUAGE FILE
+[
+Opens\ JabRef's\ Twitter\ page=Opens JabRef's Twitter page
+]
+Expected :[]
+Actual   :[Opens\ JabRef's\ Twitter\ page (src\main\java\org\jabref\gui\JabRefFrame.java LANG)]
+```
+
 Add snippet to English translation file located at `src/main/resources/l10n/JabRef_en.properties`.
 [Crowdin](http://translate.jabref.org/) will automatically pick up the new string and add it to the other translations.
 
-You can also directly run the specific test in your IDE. The test "LocalizationConsistencyTest" is placed under `src/test/java/net.sf.jabref.logic.l10n/LocalizationConsistencyTest.java`
+You can also directly run the specific test in your IDE.
+The test "LocalizationConsistencyTest" is placed under `src/test/java/net.sf.jabref.logic.l10n/LocalizationConsistencyTest.java`
 Find more information in the [JabRef Wiki](https://github.com/JabRef/jabref/wiki/Code-Howtos#using-localization-correctly).
 
 

--- a/scripts/syncLang.py
+++ b/scripts/syncLang.py
@@ -314,7 +314,9 @@ class SyncLang:
             for line in main_lines:
                 key = main_keys.key_from_line(line)
                 if key is not None:
-                    other_lines_to_write.append(u"{key}={value}\n".format(key=key, value=keys[key]))
+                    # Do not write empty keys
+                    if keys[key] !=  "":
+                        other_lines_to_write.append(u"{key}={value}\n".format(key=key, value=keys[key]))
                 else:
                     other_lines_to_write.append(line)
 

--- a/src/test/java/org/jabref/logic/l10n/LocalizationConsistencyTest.java
+++ b/src/test/java/org/jabref/logic/l10n/LocalizationConsistencyTest.java
@@ -48,28 +48,6 @@ public class LocalizationConsistencyTest {
     }
 
     @Test
-    public void nonEnglishFilesMustHaveSubsetOfKeys() {
-        for (String bundle : Arrays.asList("JabRef", "Menu")) {
-            Set<String> englishKeys = LocalizationParser
-                    .getKeysInPropertiesFile(String.format("/l10n/%s_%s.properties", bundle, "en"));
-
-            List<String> nonEnglishLanguages = Languages.LANGUAGES.values().stream().filter(l -> !"en".equals(l))
-                    .collect(Collectors.toList());
-            for (String lang : nonEnglishLanguages) {
-                Set<String> nonEnglishKeys = LocalizationParser
-                        .getKeysInPropertiesFile(String.format("/l10n/%s_%s.properties", bundle, lang));
-
-                // we do not check for missing keys as Crowdin adds them automatically
-
-                List<String> obsolete = new ArrayList<>(nonEnglishKeys);
-                obsolete.removeAll(englishKeys);
-
-                assertEquals("Obsolete keys of " + lang, Collections.emptyList(), obsolete);
-            }
-        }
-    }
-
-    @Test
     public void ensureNoDuplicates() {
         for (String bundle : Arrays.asList("JabRef", "Menu")) {
             for (String lang : Languages.LANGUAGES.values()) {
@@ -138,8 +116,7 @@ public class LocalizationConsistencyTest {
                 .distinct().collect(Collectors.toList());
 
         assertEquals("DETECTED LANGUAGE KEYS WHICH ARE NOT IN THE ENGLISH LANGUAGE FILE\n" +
-                        "1. PASTE THESE INTO THE ENGLISH LANGUAGE FILE\n" +
-                        "2. EXECUTE: gradlew localizationUpdate\n" +
+                        "PASTE THESE INTO THE ENGLISH LANGUAGE FILE\n" +
                         missingKeys.parallelStream()
                                 .map(key -> String.format("\n%s=%s\n", key.getKey(), key.getKey().replaceAll("\\\\ ", " ")))
                                 .collect(Collectors.toList()),
@@ -151,8 +128,7 @@ public class LocalizationConsistencyTest {
         Set<LocalizationEntry> missingKeys = LocalizationParser.find(LocalizationBundleForTest.MENU);
 
         assertEquals("DETECTED LANGUAGE KEYS WHICH ARE NOT IN THE ENGLISH MENU FILE\n" +
-                        "1. PASTE THESE INTO THE ENGLISH MENU FILE\n" +
-                        "2. EXECUTE: gradlew localizationUpdate\n" +
+                        "PASTE THESE INTO THE ENGLISH MENU FILE\n" +
                         missingKeys.parallelStream()
                                 .map(key -> String.format("%s=%s", key.getKey(), key.getKey()))
                                 .collect(Collectors.toList()),
@@ -165,8 +141,7 @@ public class LocalizationConsistencyTest {
 
         assertEquals("Obsolete keys found in language properties file: " + obsoleteKeys + "\n" +
                         "1. CHECK IF THE KEY IS REALLY NOT USED ANYMORE\n" +
-                        "2. REMOVE THESE FROM THE ENGLISH LANGUAGE FILE\n" +
-                        "3. EXECUTE: gradlew localizationUpdate\n",
+                        "2. REMOVE THESE FROM THE ENGLISH LANGUAGE FILE\n",
                 Collections.<String>emptySet(), obsoleteKeys);
     }
 
@@ -176,8 +151,7 @@ public class LocalizationConsistencyTest {
 
         assertEquals("Obsolete keys found in the menu properties file: " + obsoleteKeys + "\n" +
                         "1. CHECK IF THE KEY IS REALLY NOT USED ANYMORE\n" +
-                        "2. REMOVE THESE FROM THE ENGLISH MENU FILE\n" +
-                        "3. EXECUTE: gradlew localizationUpdate\n",
+                        "2. REMOVE THESE FROM THE ENGLISH MENU FILE\n",
                 Collections.<String>emptySet(), obsoleteKeys);
     }
 


### PR DESCRIPTION
Thanks to Crowdin, the workflow to add new keys is simpler.

This addresses https://github.com/JabRef/jabref/issues/3573, but not completely fixes it. More work is required at `syncLang.py`. That script, however, is not absolutely required any more. Crowdin de facto replaced it.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [x] <s>If you changed the localization: Did you run `gradle localizationUpdate`?</s>
