### PR TITLE
Quickfix to get build running on all platforms

### DIFF
--- a/src/main/java/org/jabref/gui/util/IconValidationDecorator.java
+++ b/src/main/java/org/jabref/gui/util/IconValidationDecorator.java
@@ -39,7 +39,7 @@ public class IconValidationDecorator extends GraphicValidationDecoration {
         return IconTheme.JabRefIcon.WARNING.getGraphicNode();
     }
 
-    private Node createDecorationNode(ValidationMessage message) {
+    public Node createDecorationNode(ValidationMessage message) {
         Node graphic = Severity.ERROR == message.getSeverity() ? createErrorNode() : createWarningNode();
         graphic.getStyleClass().add(Severity.ERROR == message.getSeverity() ? "error-icon" : "warning-icon");
         Label label = new Label();


### PR DESCRIPTION
The current version does not compile on my computer locally. This PR fixes it. It was already discussed with @halirutan on gitter.

```
/Users/dietzl/git/jabref/src/main/java/org/jabref/gui/util/IconValidationDecorator.java:42: error: createDecorationNode(ValidationMessage) in IconValidationDecorator cannot override createDecorationNode(ValidationMessage) in GraphicValidationDecoration
private Node createDecorationNode(ValidationMessage message) {
^
attempting to assign weaker access privileges; was protected
```