### PR TITLE
[WIP] Django style unchained.

### DIFF
--- a/config/IntelliJ Code Style.xml
+++ b/config/IntelliJ Code Style.xml
@@ -31,6 +31,7 @@
     <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
     <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+    <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
     <arrangement>
       <rules>
         <section>


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

Code examples are better than words. So, let them speak. Instead of the current
````java
super.getFoo()
        .foo()
        .getBar()
        .bar();
````
we now get the nicely aligned
````java
super.getFoo()
     .foo()
     .getBar()
     .bar();
````

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
