### PR TITLE
Export no empty lines in RIS format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We changed one default of [Cleanup entries dialog](http://help.jabref.org/en/CleanupEntries): Per default, the PDF are not moved to the default file directory anymore. [#3619](https://github.com/JabRef/jabref/issues/3619)
 - We added the export of the `translator` field to the according MS-Office XML field. [#1750, comment](https://github.com/JabRef/jabref/issues/1750#issuecomment-357350986)
 - We changed the import of the MS-Office XML fields `bookauthor` and `translator`. Both are now imported to their corresponding bibtex/biblatex fields.
-- We improved the export of the `address` and `location` field to the MS-Office XML fields. If the address field does not contain a comma, it is treated as single value and exported to the field `city`. [#1750, comment](https://github.com/JabRef/jabref/issues/1750#issuecomment-357539167) 
+- We improved the export of the `address` and `location` field to the MS-Office XML fields. If the address field does not contain a comma, it is treated as single value and exported to the field `city`. [#1750, comment](https://github.com/JabRef/jabref/issues/1750#issuecomment-357539167)
 For more details refer to the [field mapping help page](http://help.jabref.org/en/MsOfficeBibFieldMapping)
 - We added Facebook and Twitter icons in the toolbar to link to our [Facebook](https://www.facebook.com/JabRef/) and [Twitter](https://twitter.com/jabref_org) pages.
+- We now longer print empty lines when exporting an entry in RIS format [#3634](https://github.com/JabRef/jabref/issues/3634)
 
 ### Fixed
 - We fixed the missing dot in the name of an exported file. [#3576](https://github.com/JabRef/jabref/issues/3576)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,10 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We changed one default of [Cleanup entries dialog](http://help.jabref.org/en/CleanupEntries): Per default, the PDF are not moved to the default file directory anymore. [#3619](https://github.com/JabRef/jabref/issues/3619)
 - We added the export of the `translator` field to the according MS-Office XML field. [#1750, comment](https://github.com/JabRef/jabref/issues/1750#issuecomment-357350986)
 - We changed the import of the MS-Office XML fields `bookauthor` and `translator`. Both are now imported to their corresponding bibtex/biblatex fields.
-- We improved the export of the `address` and `location` field to the MS-Office XML fields. If the address field does not contain a comma, it is treated as single value and exported to the field `city`. [#1750, comment](https://github.com/JabRef/jabref/issues/1750#issuecomment-357539167)
+- We improved the export of the `address` and `location` field to the MS-Office XML fields. If the address field does not contain a comma, it is treated as single value and exported to the field `city`. [#1750, comment](https://github.com/JabRef/jabref/issues/1750#issuecomment-357539167) 
 For more details refer to the [field mapping help page](http://help.jabref.org/en/MsOfficeBibFieldMapping)
 - We added Facebook and Twitter icons in the toolbar to link to our [Facebook](https://www.facebook.com/JabRef/) and [Twitter](https://twitter.com/jabref_org) pages.
-- We now longer print empty lines when exporting an entry in RIS format [#3634](https://github.com/JabRef/jabref/issues/3634)
+- We no longer print empty lines when exporting an entry in RIS format [#3634](https://github.com/JabRef/jabref/issues/3634)
 
 ### Fixed
 - We fixed the missing dot in the name of an exported file. [#3576](https://github.com/JabRef/jabref/issues/3576)

--- a/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
+++ b/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
@@ -47,7 +47,7 @@ public class ExporterFactory {
         exporters.add(new TemplateExporter("iso690txt", "iso690", "iso690txt", FileType.ISO_690_TXT, layoutPreferences, savePreferences));
         exporters.add(new TemplateExporter("endnote", "EndNote", "endnote", FileType.ENDNOTE_TXT, layoutPreferences, savePreferences));
         exporters.add(new TemplateExporter("oocsv", "openoffice-csv", "openoffice", FileType.OO_LO, layoutPreferences, savePreferences));
-        exporters.add(new TemplateExporter("ris", "ris", "ris", FileType.RIS, layoutPreferences, savePreferences).withEncoding(StandardCharsets.UTF_8));
+        exporters.add(new TemplateExporter("ris", "ris", "ris", FileType.RIS, layoutPreferences, savePreferences, true).withEncoding(StandardCharsets.UTF_8));
         exporters.add(new TemplateExporter("misq", "misq", "misq", FileType.MIS_QUARTERLY, layoutPreferences, savePreferences));
         exporters.add(new BibTeXMLExporter());
         exporters.add(new OpenOfficeDocumentCreator());

--- a/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 import org.jabref.JabRefMain;
 import org.jabref.logic.layout.Layout;
@@ -41,6 +42,14 @@ public class TemplateExporter extends Exporter {
     private Charset encoding; // If this value is set, it will be used to override the default encoding for the getCurrentBasePanel.
     private boolean customExport;
     private boolean deleteBlankLines;
+    
+    /**
+     * A regular expression that matches blank lines
+     *
+     * ?m activates "multimode", which makes ^ match line starts/ends.
+     * \\s simply marks any whitespace character
+     */
+    private Pattern  blankLineMatcher = Pattern.compile("(?m)^\\s");
 
     /**
      * Initialize another export format based on templates stored in dir with
@@ -278,7 +287,8 @@ public class TemplateExporter extends Exporter {
                 // Write the entry
                 if (layout != null) {
                     if (deleteBlankLines) {
-                        ps.write(layout.doLayout(entry, databaseContext.getDatabase()).replaceAll("(?m)^\\s", ""));
+                        String withoutBlankLines = blankLineMatcher.matcher(layout.doLayout(entry, databaseContext.getDatabase())).replaceAll("");
+                        ps.write(withoutBlankLines);
                     } else {
                         ps.write(layout.doLayout(entry, databaseContext.getDatabase()));
                     }

--- a/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
@@ -40,6 +40,7 @@ public class TemplateExporter extends Exporter {
     private final SavePreferences savePreferences;
     private Charset encoding; // If this value is set, it will be used to override the default encoding for the getCurrentBasePanel.
     private boolean customExport;
+    private boolean deleteBlankLines;
 
     /**
      * Initialize another export format based on templates stored in dir with
@@ -91,6 +92,25 @@ public class TemplateExporter extends Exporter {
      */
     public TemplateExporter(String consoleName, String lfFileName, String directory, FileType extension, LayoutFormatterPreferences layoutPreferences, SavePreferences savePreferences) {
         this(extension.getDescription(), consoleName, lfFileName, directory, extension, layoutPreferences, savePreferences);
+    }
+
+    /**
+     * Initialize another export format based on templates stored in dir with
+     * layoutFile lfFilename.
+     * The display name is automatically derived from the FileType
+     *
+     *
+     * @param consoleName Name to call this format in the console.
+     * @param lfFileName  Name of the main layout file.
+     * @param directory   Directory in which to find the layout file.
+     * @param extension   Should contain the . (for instance .txt).
+     * @param layoutPreferences Preferences for layout
+     * @param savePreferences Preferences for saving
+     * @param deleteBlankLines If blank lines should be remove (default: false)
+     */
+    public TemplateExporter(String consoleName, String lfFileName, String directory, FileType extension, LayoutFormatterPreferences layoutPreferences, SavePreferences savePreferences, boolean deleteBlankLines) {
+        this(extension.getDescription(), consoleName, lfFileName, directory, extension, layoutPreferences, savePreferences);
+        this.deleteBlankLines = deleteBlankLines;
     }
 
     /**
@@ -257,7 +277,11 @@ public class TemplateExporter extends Exporter {
 
                 // Write the entry
                 if (layout != null) {
-                    ps.write(layout.doLayout(entry, databaseContext.getDatabase()));
+                    if (deleteBlankLines) {
+                        ps.write(layout.doLayout(entry, databaseContext.getDatabase()).replaceAll("(?m)^\\s", ""));
+                    } else {
+                        ps.write(layout.doLayout(entry, databaseContext.getDatabase()));
+                    }
                 }
             }
 

--- a/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/TemplateExporter.java
@@ -34,7 +34,16 @@ public class TemplateExporter extends Exporter {
 
     private static final String LAYOUT_PREFIX = "/resource/layout/";
 
+    /**
+     * A regular expression that matches blank lines
+     *
+     * ?m activates "multimode", which makes ^ match line starts/ends.
+     * \\s simply marks any whitespace character
+     */
+    private static final Pattern BLANK_LINE_MATCHER = Pattern.compile("(?m)^\\s");
+
     private static final Logger LOGGER = LoggerFactory.getLogger(TemplateExporter.class);
+    
     private final String lfFileName;
     private final String directory;
     private final LayoutFormatterPreferences layoutPreferences;
@@ -42,14 +51,6 @@ public class TemplateExporter extends Exporter {
     private Charset encoding; // If this value is set, it will be used to override the default encoding for the getCurrentBasePanel.
     private boolean customExport;
     private boolean deleteBlankLines;
-    
-    /**
-     * A regular expression that matches blank lines
-     *
-     * ?m activates "multimode", which makes ^ match line starts/ends.
-     * \\s simply marks any whitespace character
-     */
-    private Pattern  blankLineMatcher = Pattern.compile("(?m)^\\s");
 
     /**
      * Initialize another export format based on templates stored in dir with
@@ -287,7 +288,7 @@ public class TemplateExporter extends Exporter {
                 // Write the entry
                 if (layout != null) {
                     if (deleteBlankLines) {
-                        String withoutBlankLines = blankLineMatcher.matcher(layout.doLayout(entry, databaseContext.getDatabase())).replaceAll("");
+                        String withoutBlankLines = BLANK_LINE_MATCHER.matcher(layout.doLayout(entry, databaseContext.getDatabase())).replaceAll("");
                         ps.write(withoutBlankLines);
                     } else {
                         ps.write(layout.doLayout(entry, databaseContext.getDatabase()));

--- a/src/main/java/org/jabref/logic/layout/Layout.java
+++ b/src/main/java/org/jabref/logic/layout/Layout.java
@@ -90,23 +90,21 @@ public class Layout {
      * recursive string references are resolved.
      */
     public String doLayout(BibEntry bibtex, BibDatabase database) {
-        StringBuilder sb = new StringBuilder(100);
+        StringBuilder builder = new StringBuilder(100);
 
         for (LayoutEntry layoutEntry : layoutEntries) {
             String fieldText = layoutEntry.doLayout(bibtex, database);
 
-            // 2005.05.05 M. Alver
             // The following change means we treat null fields as "". This is to fix the
-            // problem of whitespace disappearing after missing fields. Hoping there are
-            // no side effects.
+            // problem of whitespace disappearing after missing fields.
             if (fieldText == null) {
                 fieldText = "";
             }
 
-            sb.append(fieldText);
+            builder.append(fieldText);
         }
 
-        return sb.toString();
+        return builder.toString();
     }
 
     /**


### PR DESCRIPTION
This fixes the remaining part of #3634

I had a closer look at the export / layout logic and wow, this is arcane! The code is more than 12 years old and almost as bad as the bibtex parser used to be.

This PR is based on two decisions:
 - I do not want to change the old layouting code. If I do, I am almost guaranteed to break it in many ways.
- I do not know if the removal of empty lines in exported text is really desirable in all cases. Maybe users wrote their custom formatters to explicitly include empty lines? I cannot tell.

We now have one case (RIS export) where empty lines are not desired. So, I implemented a solution that only changes the behavior of the RIS export, but leaves all others untouched. Nonetheless, it is very easy (single constructor parameter) to let other formats use empty line elimination as well. 

The empty line elimination is done using a hardly understandable, but fully functional regex.


----

- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
