### PR TITLE
Fix medline and convert some fetchers to junit5 where possible

### DIFF
--- a/src/test/java/org/jabref/logic/importer/FulltextFetchersTest.java
+++ b/src/test/java/org/jabref/logic/importer/FulltextFetchersTest.java
@@ -7,21 +7,21 @@ import java.util.Optional;
 
 import org.jabref.model.entry.BibEntry;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FulltextFetchersTest {
     private BibEntry entry;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         entry = new BibEntry();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         entry = null;
     }

--- a/src/test/java/org/jabref/logic/importer/WebFetchersTest.java
+++ b/src/test/java/org/jabref/logic/importer/WebFetchersTest.java
@@ -9,11 +9,11 @@ import org.jabref.logic.importer.fetcher.IsbnViaChimboriFetcher;
 import org.jabref.logic.importer.fetcher.IsbnViaEbookDeFetcher;
 import org.jabref.logic.importer.fetcher.MrDLibFetcher;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.reflections.Reflections;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 public class WebFetchersTest {
@@ -21,7 +21,7 @@ public class WebFetchersTest {
     Reflections reflections = new Reflections("org.jabref");
     ImportFormatPreferences importFormatPreferences;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         importFormatPreferences = mock(ImportFormatPreferences.class);
     }

--- a/src/test/java/org/jabref/logic/importer/fetcher/AbstractIsbnFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/AbstractIsbnFetcherTest.java
@@ -4,12 +4,14 @@ import java.util.Optional;
 
 import org.jabref.logic.importer.FetcherException;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.testutils.category.FetcherTest;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@FetcherTest
 public abstract class AbstractIsbnFetcherTest {
 
     protected AbstractIsbnFetcher fetcher;

--- a/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/ArXivTest.java
@@ -13,26 +13,22 @@ import org.jabref.model.entry.FieldName;
 import org.jabref.model.entry.identifier.ArXivIdentifier;
 import org.jabref.testutils.category.FetcherTest;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@Category(FetcherTest.class)
+@FetcherTest
 public class ArXivTest {
 
-    @Rule public ExpectedException expectedException = ExpectedException.none();
     private ArXiv finder;
     private BibEntry entry;
     private BibEntry sliceTheoremPaper;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
         when(importFormatPreferences.getKeywordSeparator()).thenReturn(',');
@@ -57,10 +53,10 @@ public class ArXivTest {
         assertEquals(Optional.empty(), finder.findFullText(entry));
     }
 
-    @Test(expected = NullPointerException.class)
     public void findFullTextRejectsNullParameter() throws IOException {
-        finder.findFullText(null);
-        Assert.fail();
+
+        assertThrows(NullPointerException.class, () -> finder.findFullText(null));
+
     }
 
     @Test
@@ -127,7 +123,6 @@ public class ArXivTest {
         entry.setField(FieldName.DOI, "10.1016/0370-2693(77)90015-6");
         entry.setField(FieldName.TITLE, "Superspace formulation of supergravity");
 
-
         assertEquals(Optional.empty(), finder.findFullText(entry));
     }
 
@@ -186,9 +181,7 @@ public class ArXivTest {
 
     @Test
     public void searchWithMalformedIdThrowsException() throws Exception {
-        expectedException.expect(FetcherException.class);
-        expectedException.expectMessage("incorrect id format");
-        finder.performSearchById("123412345");
+        assertThrows(FetcherException.class, () -> finder.performSearchById("123412345"));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystemTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/AstrophysicsDataSystemTest.java
@@ -12,22 +12,21 @@ import org.jabref.model.entry.BibtexEntryTypes;
 import org.jabref.model.entry.FieldName;
 import org.jabref.testutils.category.FetcherTest;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@Category(FetcherTest.class)
+@FetcherTest
 public class AstrophysicsDataSystemTest {
 
     private AstrophysicsDataSystem fetcher;
     private BibEntry diezSliceTheoremEntry, famaeyMcGaughEntry, sunWelchEntry, xiongSunEntry, ingersollPollardEntry, luceyPaulEntry;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
         when(importFormatPreferences.getFieldContentParserPreferences()).thenReturn(

--- a/src/test/java/org/jabref/logic/importer/fetcher/CrossRefTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/CrossRefTest.java
@@ -6,19 +6,18 @@ import java.util.Optional;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.testutils.category.FetcherTest;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Category(FetcherTest.class)
+@FetcherTest
 public class CrossRefTest {
 
     private CrossRef fetcher;
     private BibEntry barrosEntry;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         fetcher = new CrossRef();
 

--- a/src/test/java/org/jabref/logic/importer/fetcher/DBLPFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DBLPFetcherTest.java
@@ -11,21 +11,20 @@ import org.jabref.model.entry.BibtexEntryTypes;
 import org.jabref.model.entry.FieldName;
 import org.jabref.testutils.category.FetcherTest;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@Category(FetcherTest.class)
+@FetcherTest
 public class DBLPFetcherTest {
 
     private DBLPFetcher dblpFetcher;
     private BibEntry entry;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         ImportFormatPreferences importFormatPreferences = mock(ImportFormatPreferences.class);
         when(importFormatPreferences.getFieldContentParserPreferences())
@@ -54,7 +53,7 @@ public class DBLPFetcherTest {
         String query = "Process Engine Benchmarking with Betsy in the Context of {ISO/IEC} Quality Standards";
         List<BibEntry> result = dblpFetcher.performSearch(query);
 
-        Assert.assertEquals(Collections.singletonList(entry), result);
+        assertEquals(Collections.singletonList(entry), result);
     }
 
     @Test
@@ -62,7 +61,7 @@ public class DBLPFetcherTest {
         String query = "geiger harrer betsy$ softw.trends"; //-wirtz Negative operators do no longer work,  see issue https://github.com/JabRef/jabref/issues/2890
         List<BibEntry> result = dblpFetcher.performSearch(query);
 
-        Assert.assertEquals(Collections.singletonList(entry), result);
+        assertEquals(Collections.singletonList(entry), result);
     }
 
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/DiVATest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DiVATest.java
@@ -7,22 +7,21 @@ import org.jabref.logic.importer.ImportFormatPreferences;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.testutils.category.FetcherTest;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-@Category(FetcherTest.class)
+@FetcherTest
 public class DiVATest {
 
     private DiVA fetcher;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         fetcher = new DiVA(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS));
     }

--- a/src/test/java/org/jabref/logic/importer/fetcher/DoiFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/DoiFetcherTest.java
@@ -8,22 +8,21 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BiblatexEntryTypes;
 import org.jabref.testutils.category.FetcherTest;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
-@Category(FetcherTest.class)
+@FetcherTest
 public class DoiFetcherTest {
 
     private DoiFetcher fetcher;
     private BibEntry bibEntryBurd2011, bibEntryDecker2007;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         fetcher = new DoiFetcher(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS));
 
@@ -71,15 +70,12 @@ public class DoiFetcherTest {
         assertEquals(Optional.of(bibEntryDecker2007), fetchedEntry);
     }
 
-    @Test(expected = FetcherException.class)
-    public void testPerformSearchEmptyDOI() throws FetcherException {
-        Optional<BibEntry> fetchedEntry = fetcher.performSearchById("");
-        assertEquals(Optional.empty(), fetchedEntry);
+    public void testPerformSearchEmptyDOI() {
+        assertThrows(FetcherException.class, () -> fetcher.performSearchById(""));
     }
 
-    @Test(expected = FetcherException.class)
-    public void testPerformSearchInvalidDOI() throws FetcherException {
-        fetcher.performSearchById("10.1002/9781118257517F");
-        fail();
+    public void testPerformSearchInvalidDOI() {
+        assertThrows(FetcherException.class, () -> fetcher.performSearchById("10.1002/9781118257517F"));
+
     }
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/GvkFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/GvkFetcherTest.java
@@ -11,21 +11,20 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BiblatexEntryTypes;
 import org.jabref.testutils.category.FetcherTest;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Category(FetcherTest.class)
+@FetcherTest
 public class GvkFetcherTest {
 
     private GvkFetcher fetcher;
     private BibEntry bibEntryPPN591166003;
     private BibEntry bibEntryPPN66391437X;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         fetcher = new GvkFetcher();
 
@@ -68,7 +67,7 @@ public class GvkFetcherTest {
     }
 
     @Test
-    public void simpleSearchQueryStringCorrect() throws FetcherException {
+    public void simpleSearchQueryStringCorrect() {
         String query = "java jdk";
         String result = fetcher.getSearchQueryString(query);
         assertEquals("pica.all=java jdk", result);
@@ -82,7 +81,7 @@ public class GvkFetcherTest {
     }
 
     @Test
-    public void complexSearchQueryStringCorrect() throws FetcherException {
+    public void complexSearchQueryStringCorrect() {
         String query = "kon java tit jdk";
         String result = fetcher.getSearchQueryString(query);
         assertEquals("pica.kon=java and pica.tit=jdk", result);

--- a/src/test/java/org/jabref/logic/importer/fetcher/IacrEprintFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/IacrEprintFetcherTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Answers;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;

--- a/src/test/java/org/jabref/logic/importer/fetcher/IsbnFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/IsbnFetcherTest.java
@@ -31,10 +31,11 @@ public class IsbnFetcherTest {
         bibEntry.setType(BiblatexEntryTypes.BOOK);
         bibEntry.setField("bibtexkey", "9780134685991");
         bibEntry.setField("title", "Effective Java");
-        bibEntry.setField("publisher", "Addison Wesley");
+        bibEntry.setField("publisher", "ADDISON WESLEY PUB CO INC");
+        bibEntry.setField("pagetotal", "416");
         bibEntry.setField("year", "2018");
         bibEntry.setField("author", "Bloch, Joshua");
-        bibEntry.setField("date", "2018-01-11");
+        bibEntry.setField("date", "2018-01-06");
         bibEntry.setField("ean", "9780134685991");
         bibEntry.setField("isbn", "0134685997");
         bibEntry.setField("url", "http://www.ebook.de/de/product/28983211/joshua_bloch_effective_java.html");

--- a/src/test/java/org/jabref/logic/importer/fetcher/IsbnViaEbookDeFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/IsbnViaEbookDeFetcherTest.java
@@ -24,10 +24,11 @@ public class IsbnViaEbookDeFetcherTest extends AbstractIsbnFetcherTest {
         bibEntry.setType(BiblatexEntryTypes.BOOK);
         bibEntry.setField("bibtexkey", "9780134685991");
         bibEntry.setField("title", "Effective Java");
-        bibEntry.setField("publisher", "Addison Wesley");
+        bibEntry.setField("publisher", "ADDISON WESLEY PUB CO INC");
+        bibEntry.setField("pagetotal", "416");
         bibEntry.setField("year", "2018");
         bibEntry.setField("author", "Bloch, Joshua");
-        bibEntry.setField("date", "2018-01-11");
+        bibEntry.setField("date", "2018-01-06");
         bibEntry.setField("ean", "9780134685991");
         bibEntry.setField("isbn", "0134685997");
         bibEntry.setField("url", "http://www.ebook.de/de/product/28983211/joshua_bloch_effective_java.html");

--- a/src/test/java/org/jabref/logic/importer/fetcher/LibraryOfCongressTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/LibraryOfCongressTest.java
@@ -5,15 +5,14 @@ import java.util.Optional;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.testutils.category.FetcherTest;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Category(FetcherTest.class)
+@FetcherTest
 public class LibraryOfCongressTest {
 
-    private LibraryOfCongress fetcher = new LibraryOfCongress();
+    private final LibraryOfCongress fetcher = new LibraryOfCongress();
 
     @Test
     public void performSearchById() throws Exception {

--- a/src/test/java/org/jabref/logic/importer/fetcher/MedlineFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/MedlineFetcherTest.java
@@ -170,6 +170,7 @@ public class MedlineFetcherTest {
         assertTrue(entryList.contains(bibEntrySari));
     }
 
+    @Test
     public void testInvalidSearchTermCauseIndexOutOfBoundsException() throws Exception {
         assertThrows(FetcherException.class, () -> fetcher.performSearchById("this.is.a.invalid.search.term.for.the.medline.fetcher"));
     }

--- a/src/test/java/org/jabref/logic/importer/fetcher/MedlineFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/MedlineFetcherTest.java
@@ -10,27 +10,26 @@ import org.jabref.model.entry.BiblatexEntryTypes;
 import org.jabref.model.entry.FieldName;
 import org.jabref.testutils.category.FetcherTest;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Category(FetcherTest.class)
+@FetcherTest
 public class MedlineFetcherTest {
 
     private MedlineFetcher fetcher;
     private BibEntry entryWijedasa, entryEndharti, bibEntryIchikawa, bibEntrySari;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         fetcher = new MedlineFetcher();
 
         entryWijedasa = new BibEntry();
         entryWijedasa.setType(BiblatexEntryTypes.ARTICLE);
-        entryWijedasa.setField("author","Wijedasa, Lahiru S and Jauhiainen, Jyrki and Könönen, Mari and Lampela, Maija and Vasander, Harri and Leblanc, Marie-Claire and Evers, Stephanie and Smith, Thomas E L and Yule, Catherine M and Varkkey, Helena and Lupascu, Massimo and Parish, Faizal and Singleton, Ian and Clements, Gopalasamy R and Aziz, Sheema Abdul and Harrison, Mark E and Cheyne, Susan and Anshari, Gusti Z and Meijaard, Erik and Goldstein, Jenny E and Waldron, Susan and Hergoualc'h, Kristell and Dommain, Rene and Frolking, Steve and Evans, Christopher D and Posa, Mary Rose C and Glaser, Paul H and Suryadiputra, Nyoman and Lubis, Reza and Santika, Truly and Padfield, Rory and Kurnianto, Sofyan and Hadisiswoyo, Panut and Lim, Teck Wyn and Page, Susan E and Gauci, Vincent and Van Der Meer, Peter J and Buckland, Helen and Garnier, Fabien and Samuel, Marshall K and Choo, Liza Nuriati Lim Kim and O'Reilly, Patrick and Warren, Matthew and Suksuwan, Surin and Sumarga, Elham and Jain, Anuj and Laurance, William F and Couwenberg, John and Joosten, Hans and Vernimmen, Ronald and Hooijer, Aljosja and Malins, Chris and Cochrane, Mark A and Perumal, Balu and Siegert, Florian and Peh, Kelvin S-H and Comeau, Louis-Pierre and Verchot, Louis and Harvey, Charles F and Cobb, Alex and Jaafar, Zeehan and Wösten, Henk and Manuri, Solichin and Müller, Moritz and Giesen, Wim and Phelps, Jacob and Yong, Ding Li and Silvius, Marcel and Wedeux, Béatrice M M and Hoyt, Alison and Osaki, Mitsuru and Hirano, Takashi and Takahashi, Hidenori and Kohyama, Takashi S and Haraguchi, Akira and Nugroho, Nunung P and Coomes, David A and Quoi, Le Phat and Dohong, Alue and Gunawan, Haris and Gaveau, David L A and Langner, Andreas and Lim, Felix K S and Edwards, David P and Giam, Xingli and Van Der Werf, Guido and Carmenta, Rachel and Verwer, Caspar C and Gibson, Luke and Gandois, Laure and Graham, Laura Linda Bozena and Regalino, Jhanson and Wich, Serge A and Rieley, Jack and Kettridge, Nicholas and Brown, Chloe and Pirard, Romain and Moore, Sam and Capilla, B Ripoll and Ballhorn, Uwe and Ho, Hua Chew and Hoscilo, Agata and Lohberger, Sandra and Evans, Theodore A and Yulianti, Nina and Blackham, Grace and Onrizal and Husson, Simon and Murdiyarso, Daniel and Pangala, Sunita and Cole, Lydia E S and Tacconi, Luca and Segah, Hendrik and Tonoto, Prayoto and Lee, Janice S H and Schmilewski, Gerald and Wulffraat, Stephan and Putra, Erianto Indra and Cattau, Megan E and Clymo, R S and Morrison, Ross and Mujahid, Aazani and Miettinen, Jukka and Liew, Soo Chin and Valpola, Samu and Wilson, David and D'Arcy, Laura and Gerding, Michiel and Sundari, Siti and Thornton, Sara A and Kalisz, Barbara and Chapman, Stephen J and Su, Ahmad Suhaizi Mat and Basuki, Imam and Itoh, Masayuki and Traeholt, Carl and Sloan, Sean and Sayok, Alexander K and Andersen, Roxane");
+        entryWijedasa.setField("author", "Wijedasa, Lahiru S and Jauhiainen, Jyrki and Könönen, Mari and Lampela, Maija and Vasander, Harri and Leblanc, Marie-Claire and Evers, Stephanie and Smith, Thomas E L and Yule, Catherine M and Varkkey, Helena and Lupascu, Massimo and Parish, Faizal and Singleton, Ian and Clements, Gopalasamy R and Aziz, Sheema Abdul and Harrison, Mark E and Cheyne, Susan and Anshari, Gusti Z and Meijaard, Erik and Goldstein, Jenny E and Waldron, Susan and Hergoualc'h, Kristell and Dommain, Rene and Frolking, Steve and Evans, Christopher D and Posa, Mary Rose C and Glaser, Paul H and Suryadiputra, Nyoman and Lubis, Reza and Santika, Truly and Padfield, Rory and Kurnianto, Sofyan and Hadisiswoyo, Panut and Lim, Teck Wyn and Page, Susan E and Gauci, Vincent and Van Der Meer, Peter J and Buckland, Helen and Garnier, Fabien and Samuel, Marshall K and Choo, Liza Nuriati Lim Kim and O'Reilly, Patrick and Warren, Matthew and Suksuwan, Surin and Sumarga, Elham and Jain, Anuj and Laurance, William F and Couwenberg, John and Joosten, Hans and Vernimmen, Ronald and Hooijer, Aljosja and Malins, Chris and Cochrane, Mark A and Perumal, Balu and Siegert, Florian and Peh, Kelvin S-H and Comeau, Louis-Pierre and Verchot, Louis and Harvey, Charles F and Cobb, Alex and Jaafar, Zeehan and Wösten, Henk and Manuri, Solichin and Müller, Moritz and Giesen, Wim and Phelps, Jacob and Yong, Ding Li and Silvius, Marcel and Wedeux, Béatrice M M and Hoyt, Alison and Osaki, Mitsuru and Hirano, Takashi and Takahashi, Hidenori and Kohyama, Takashi S and Haraguchi, Akira and Nugroho, Nunung P and Coomes, David A and Quoi, Le Phat and Dohong, Alue and Gunawan, Haris and Gaveau, David L A and Langner, Andreas and Lim, Felix K S and Edwards, David P and Giam, Xingli and Van Der Werf, Guido and Carmenta, Rachel and Verwer, Caspar C and Gibson, Luke and Gandois, Laure and Graham, Laura Linda Bozena and Regalino, Jhanson and Wich, Serge A and Rieley, Jack and Kettridge, Nicholas and Brown, Chloe and Pirard, Romain and Moore, Sam and Capilla, B Ripoll and Ballhorn, Uwe and Ho, Hua Chew and Hoscilo, Agata and Lohberger, Sandra and Evans, Theodore A and Yulianti, Nina and Blackham, Grace and Onrizal and Husson, Simon and Murdiyarso, Daniel and Pangala, Sunita and Cole, Lydia E S and Tacconi, Luca and Segah, Hendrik and Tonoto, Prayoto and Lee, Janice S H and Schmilewski, Gerald and Wulffraat, Stephan and Putra, Erianto Indra and Cattau, Megan E and Clymo, R S and Morrison, Ross and Mujahid, Aazani and Miettinen, Jukka and Liew, Soo Chin and Valpola, Samu and Wilson, David and D'Arcy, Laura and Gerding, Michiel and Sundari, Siti and Thornton, Sara A and Kalisz, Barbara and Chapman, Stephen J and Su, Ahmad Suhaizi Mat and Basuki, Imam and Itoh, Masayuki and Traeholt, Carl and Sloan, Sean and Sayok, Alexander K and Andersen, Roxane");
         entryWijedasa.setField("country", "England");
         entryWijedasa.setField("doi", "10.1111/gcb.13516");
         entryWijedasa.setField("issn", "1365-2486");
@@ -44,7 +43,7 @@ public class MedlineFetcherTest {
         entryWijedasa.setField("pmid", "27670948");
         entryWijedasa.setField("pubmodel", "Print-Electronic");
         entryWijedasa.setField("pubstatus", "ppublish");
-        entryWijedasa.setField("revised", "2017-02-17");
+        entryWijedasa.setField("revised", "2018-01-23");
         entryWijedasa.setField("title", "Denial of long-term issues with agriculture on tropical peatlands will have devastating consequences.");
         entryWijedasa.setField("volume", "23");
         entryWijedasa.setField("year", "2017");
@@ -171,10 +170,8 @@ public class MedlineFetcherTest {
         assertTrue(entryList.contains(bibEntrySari));
     }
 
-    @Test(expected = FetcherException.class)//caused by Optional.of(entry.get(0))
     public void testInvalidSearchTermCauseIndexOutOfBoundsException() throws Exception {
-        fetcher.performSearchById("this.is.a.invalid.search.term.for.the.medline.fetcher");
-        fail();
+        assertThrows(FetcherException.class, () -> fetcher.performSearchById("this.is.a.invalid.search.term.for.the.medline.fetcher"));
     }
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/fetcher/MrDLibFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/MrDLibFetcherTest.java
@@ -7,27 +7,25 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.FieldName;
 import org.jabref.testutils.category.FetcherTest;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
-@Category(FetcherTest.class)
+@FetcherTest
 public class MrDLibFetcherTest {
 
     private MrDLibFetcher fetcher;
-    private BibEntry bibEntry;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         fetcher = new MrDLibFetcher("", "");
     }
 
     @Test
     public void testPerformSearch() throws FetcherException {
-        bibEntry = new BibEntry();
+        BibEntry bibEntry = new BibEntry();
         bibEntry.setField(FieldName.TITLE, "lernen");
         List<BibEntry> bibEntrys = fetcher.performSearch(bibEntry);
         assertFalse(bibEntrys.isEmpty());

--- a/src/test/java/org/jabref/logic/importer/fetcher/SpringerLinkTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/SpringerLinkTest.java
@@ -7,48 +7,46 @@ import java.util.Optional;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.testutils.category.FetcherTest;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@Category(FetcherTest.class)
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@FetcherTest
 public class SpringerLinkTest {
 
     private SpringerLink finder;
     private BibEntry entry;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         finder = new SpringerLink();
         entry = new BibEntry();
     }
 
-    @Test(expected = NullPointerException.class)
-    public void rejectNullParameter() throws IOException {
-        finder.findFullText(null);
-        Assert.fail();
+    @Test
+    public void rejectNullParameter() {
+        assertThrows(NullPointerException.class, () -> finder.findFullText(null));
     }
 
     @Test
     public void doiNotPresent() throws IOException {
-        Assert.assertEquals(Optional.empty(), finder.findFullText(entry));
+        assertEquals(Optional.empty(), finder.findFullText(entry));
     }
 
     @Test
     public void findByDOI() throws IOException {
         entry.setField("doi", "10.1186/s13677-015-0042-8");
-
-        Assert.assertEquals(
+        assertEquals(
                 Optional.of(new URL("http://link.springer.com/content/pdf/10.1186/s13677-015-0042-8.pdf")),
-                finder.findFullText(entry)
-        );
+                finder.findFullText(entry));
     }
 
     @Test
     public void notFoundByDOI() throws IOException {
         entry.setField("doi", "10.1186/unknown-doi");
 
-        Assert.assertEquals(Optional.empty(), finder.findFullText(entry));
+        assertEquals(Optional.empty(), finder.findFullText(entry));
     }
 }

--- a/src/test/java/org/jabref/logic/importer/fetcher/TitleFetcherTest.java
+++ b/src/test/java/org/jabref/logic/importer/fetcher/TitleFetcherTest.java
@@ -8,21 +8,20 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BiblatexEntryTypes;
 import org.jabref.testutils.category.FetcherTest;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
-@Category(FetcherTest.class)
+@FetcherTest
 public class TitleFetcherTest {
 
     private TitleFetcher fetcher;
     private BibEntry bibEntryBischof2009;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         fetcher = new TitleFetcher(mock(ImportFormatPreferences.class, Answers.RETURNS_DEEP_STUBS));
 


### PR DESCRIPTION
I converted only some, because others rely on Mockito and there is not yet an offical Mockito-Extension for junit5

See https://github.com/mockito/mockito/issues/445 and https://github.com/mockito/mockito/pull/1221 for details.  Then we can consider the others.


<!-- describe the changes you have made here: what, why, ... -->


----

- [ ] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
