### PR TITLE
Fixes #3648: Chained modifiers work again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For more details refer to the [field mapping help page](http://help.jabref.org/e
 - We fixed the missing dot in the name of an exported file. [#3576](https://github.com/JabRef/jabref/issues/3576)
 - Autocompletion in the search bar can now be disabled via the preferences. [#3598](https://github.com/JabRef/jabref/issues/3598)
 - We fixed and extended the RIS import functionality to cover more fields. [#3634](https://github.com/JabRef/jabref/issues/3634) [#2607](https://github.com/JabRef/jabref/issues/2607)
+- Chaining modifiers in BibTeX key pattern now works as described in the documentation. [#3648](https://github.com/JabRef/jabref/issues/3648)
 
 ### Removed
 - We removed the [Look and Feels from JGoodies](http://www.jgoodies.com/freeware/libraries/looks/), because the open source version is not compatible with Java 9.

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGenerator.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGenerator.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.jabref.logic.util.BracketedPattern;
 import org.jabref.model.FieldChange;
 import org.jabref.model.bibtexkeypattern.AbstractBibtexKeyPattern;
 import org.jabref.model.bibtexkeypattern.GlobalBibtexKeyPattern;
@@ -46,13 +45,13 @@ public class BibtexKeyGenerator extends BracketedPattern {
         this.bibtexKeyPatternPreferences = Objects.requireNonNull(bibtexKeyPatternPreferences);
     }
 
-    static String generateKey(BibEntry entry, String value) {
-        return generateKey(entry, value, new BibDatabase());
+    static String generateKey(BibEntry entry, String pattern) {
+        return generateKey(entry, pattern, new BibDatabase());
     }
 
-    static String generateKey(BibEntry entry, String value, BibDatabase database) {
+    static String generateKey(BibEntry entry, String pattern, BibDatabase database) {
         GlobalBibtexKeyPattern keyPattern = new GlobalBibtexKeyPattern(Collections.emptyList());
-        keyPattern.setDefaultValue("[" + value + "]");
+        keyPattern.setDefaultValue("[" + pattern + "]");
         return new BibtexKeyGenerator(keyPattern, database, new BibtexKeyPatternPreferences("", "", false, true, true, keyPattern, ','))
                 .generateKey(entry);
     }

--- a/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -21,10 +21,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.jabref.logic.bibtexkeypattern.BracketedPattern;
 import org.jabref.logic.layout.Layout;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.layout.LayoutHelper;
-import org.jabref.logic.util.BracketedPattern;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.util.OptionalUtil;

--- a/src/main/java/org/jabref/logic/util/io/RegExpBasedFileFinder.java
+++ b/src/main/java/org/jabref/logic/util/io/RegExpBasedFileFinder.java
@@ -17,7 +17,7 @@ import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.jabref.logic.util.BracketedPattern;
+import org.jabref.logic.bibtexkeypattern.BracketedPattern;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.strings.StringUtil;

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGeneratorTest.java
@@ -987,4 +987,18 @@ public class BibtexKeyGeneratorTest {
         entry.setField("title", "Green Scheduling of `Whatever`");
         assertEquals("GreenSchedulingofWhatever", BibtexKeyGenerator.generateKey(entry, "title"));
     }
+
+    @Test
+    public void generateKeyWithOneModifier() throws Exception {
+        BibEntry entry = new BibEntry();
+        entry.setField("title", "The Interesting Title");
+        assertEquals("theinterestingtitle", BibtexKeyGenerator.generateKey(entry, "title:lower"));
+    }
+
+    @Test
+    public void generateKeyWithTwoModifiers() throws Exception {
+        BibEntry entry = new BibEntry();
+        entry.setField("title", "The Interesting Title");
+        assertEquals("theinterestingtitle", BibtexKeyGenerator.generateKey(entry, "title:lower:(_)"));
+    }
 }

--- a/src/test/java/org/jabref/logic/util/BracketedPatternTest.java
+++ b/src/test/java/org/jabref/logic/util/BracketedPatternTest.java
@@ -1,5 +1,6 @@
 package org.jabref.logic.util;
 
+import org.jabref.logic.bibtexkeypattern.BracketedPattern;
 import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.BibtexEntryTypes;
@@ -9,7 +10,8 @@ import org.jabref.model.entry.FieldName;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class BracketedPatternTest {
     private BibEntry bibentry;


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

Fixes #3648. 

The problem was that `resultingLabel = formatter.get().format(label);` always used the original input and not the result of the previous modifier.

----

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
