### PR TITLE
Fix select entries my holding mouse

### DIFF
--- a/src/main/java/org/jabref/gui/util/ViewModelTableRowFactory.java
+++ b/src/main/java/org/jabref/gui/util/ViewModelTableRowFactory.java
@@ -7,8 +7,12 @@ import javafx.scene.control.ContextMenu;
 import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TreeTableCell;
+import javafx.scene.input.DragEvent;
+import javafx.scene.input.MouseDragEvent;
 import javafx.scene.input.MouseEvent;
 import javafx.util.Callback;
+
+import org.reactfx.util.TriConsumer;
 
 /**
  * Constructs a {@link TreeTableCell} based on the view model of the row and a bunch of specified converter methods.
@@ -19,6 +23,12 @@ public class ViewModelTableRowFactory<S> implements Callback<TableView<S>, Table
 
     private BiConsumer<S, ? super MouseEvent> onMouseClickedEvent;
     private Function<S, ContextMenu> contextMenuFactory;
+    private TriConsumer<TableRow<S>, S, ? super MouseEvent> toOnDragDetected;
+    private BiConsumer<S, ? super DragEvent> toOnDragDropped;
+    private BiConsumer<S, ? super DragEvent> toOnDragEntered;
+    private BiConsumer<S, ? super DragEvent> toOnDragExited;
+    private BiConsumer<S, ? super DragEvent> toOnDragOver;
+    private TriConsumer<TableRow<S>, S, ? super MouseDragEvent> toOnMouseDragEntered;
 
     public ViewModelTableRowFactory<S> withOnMouseClickedEvent(BiConsumer<S, ? super MouseEvent> onMouseClickedEvent) {
         this.onMouseClickedEvent = onMouseClickedEvent;
@@ -27,6 +37,46 @@ public class ViewModelTableRowFactory<S> implements Callback<TableView<S>, Table
 
     public ViewModelTableRowFactory<S> withContextMenu(Function<S, ContextMenu> contextMenuFactory) {
         this.contextMenuFactory = contextMenuFactory;
+        return this;
+    }
+
+    public ViewModelTableRowFactory<S> setOnDragDetected(TriConsumer<TableRow<S>, S, ? super MouseEvent> toOnDragDetected) {
+        this.toOnDragDetected = toOnDragDetected;
+        return this;
+    }
+
+    public ViewModelTableRowFactory<S> setOnDragDetected(BiConsumer<S, ? super MouseEvent> toOnDragDetected) {
+        this.toOnDragDetected = (row, viewModel, event) -> toOnDragDetected.accept(viewModel, event);
+        return this;
+    }
+
+    public ViewModelTableRowFactory<S> setOnDragDropped(BiConsumer<S, ? super DragEvent> toOnDragDropped) {
+        this.toOnDragDropped = toOnDragDropped;
+        return this;
+    }
+
+    public ViewModelTableRowFactory<S> setOnDragEntered(BiConsumer<S, ? super DragEvent> toOnDragEntered) {
+        this.toOnDragEntered = toOnDragEntered;
+        return this;
+    }
+
+    public ViewModelTableRowFactory<S> setOnMouseDragEntered(BiConsumer<S, ? super MouseDragEvent> toOnDragEntered) {
+        this.toOnMouseDragEntered = (row, viewModel, event) -> toOnDragEntered.accept(viewModel, event);
+        return this;
+    }
+
+    public ViewModelTableRowFactory<S> setOnMouseDragEntered(TriConsumer<TableRow<S>, S, ? super MouseDragEvent> toOnDragEntered) {
+        this.toOnMouseDragEntered = toOnDragEntered;
+        return this;
+    }
+
+    public ViewModelTableRowFactory<S> setOnDragExited(BiConsumer<S, ? super DragEvent> toOnDragExited) {
+        this.toOnDragExited = toOnDragExited;
+        return this;
+    }
+
+    public ViewModelTableRowFactory<S> setOnDragOver(BiConsumer<S, ? super DragEvent> toOnDragOver) {
+        this.toOnDragOver = toOnDragOver;
         return this;
     }
 
@@ -53,6 +103,53 @@ public class ViewModelTableRowFactory<S> implements Callback<TableView<S>, Table
             });
         }
 
+        if (toOnDragDetected != null) {
+            row.setOnDragDetected(event -> {
+                if (!row.isEmpty()) {
+                    toOnDragDetected.accept(row, row.getItem(), event);
+                }
+            });
+        }
+        if (toOnDragDropped != null) {
+            row.setOnDragDropped(event -> {
+                if (!row.isEmpty()) {
+                    toOnDragDropped.accept(row.getItem(), event);
+                }
+            });
+        }
+        if (toOnDragEntered != null) {
+            row.setOnDragEntered(event -> {
+                if (!row.isEmpty()) {
+                    toOnDragEntered.accept(row.getItem(), event);
+                }
+            });
+        }
+        if (toOnDragExited != null) {
+            row.setOnDragExited(event -> {
+                if (!row.isEmpty()) {
+                    toOnDragExited.accept(row.getItem(), event);
+                }
+            });
+        }
+        if (toOnDragOver != null) {
+            row.setOnDragOver(event -> {
+                if (!row.isEmpty()) {
+                    toOnDragOver.accept(row.getItem(), event);
+                }
+            });
+        }
+
+        if (toOnMouseDragEntered != null) {
+            row.setOnMouseDragEntered(event -> {
+                if (!row.isEmpty()) {
+                    toOnMouseDragEntered.accept(row, row.getItem(), event);
+                }
+            });
+        }
         return row;
+    }
+
+    public void install(TableView<S> table) {
+        table.setRowFactory(this);
     }
 }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->

With this PR the new maintable support again the following gesture to select entries: click on one row and hold mouse button, then move over other rows to also select them.

The view does not scroll when you move the curser to the border and thus currently it is only possible to select rows in the current view using the method described above. To enable scrolling needs further research on my part and thus is something for a new PR.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
