### PR TITLE
[WIP] File link deletion dialog improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ For more details refer to the [field mapping help page](http://help.jabref.org/e
 - We added Facebook and Twitter icons in the toolbar to link to our [Facebook](https://www.facebook.com/JabRef/) and [Twitter](https://twitter.com/jabref_org) pages.
 - We no longer print empty lines when exporting an entry in RIS format [#3634](https://github.com/JabRef/jabref/issues/3634)
 - We improved file saving so that hard links are now preserved when a save is performed [#2633](https://github.com/JabRef/jabref/issues/2633)
+- We changed the default dialog option when removing a [file link](http://help.jabref.org/en/FileLinks#adding-external-links-to-an-entry) from an entry.
+The new default removes the linked file from the entry instead of deleting the file from disk. [#3679](https://github.com/JabRef/jabref/issues/3679)
 
 ### Fixed
 - We fixed the missing dot in the name of an exported file. [#3576](https://github.com/JabRef/jabref/issues/3576)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The new default removes the linked file from the entry instead of deleting the f
 - We fixed and extended the RIS import functionality to cover more fields. [#3634](https://github.com/JabRef/jabref/issues/3634) [#2607](https://github.com/JabRef/jabref/issues/2607)
 - Chaining modifiers in BibTeX key pattern now works as described in the documentation. [#3648](https://github.com/JabRef/jabref/issues/3648)
 - We fixed an issue where not all bibtex/biblatex fields would be exported as latex-free to MS-Office XML [koppor#284](https://github.com/koppor/jabref/issues/284)
+- We fixed an issue where linked files would be deleted from bibliography entries despite choosing the "Cancel" option in the dialog menu.
 
 ### Removed
 - We removed the [Look and Feels from JGoodies](http://www.jgoodies.com/freeware/libraries/looks/), because the open source version is not compatible with Java 9.

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -281,7 +281,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
             Optional<ButtonType> buttonType = dialogService.showCustomButtonDialogAndWait(AlertType.INFORMATION,
                     Localization.lang("Delete '%0'", file.get().toString()),
                     Localization.lang("Delete the selected file permanently from disk, or just remove the file from the entry? Pressing Delete will delete the file permanently from disk."),
-                    deleteFromEntry, removeFromEntry, ButtonType.CANCEL);
+                    removeFromEntry, deleteFromEntry, ButtonType.CANCEL);
 
             if (buttonType.isPresent()) {
                 if (buttonType.get().equals(removeFromEntry)) {

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -304,7 +304,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
         } else {
             LOGGER.warn("Could not find file " + linkedFile.getLink());
         }
-        return true;
+        return false;
     }
 
     public void edit() {

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -44,6 +44,8 @@ import de.jensd.fx.glyphs.materialdesignicons.MaterialDesignIcon;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static javafx.scene.control.ButtonBar.ButtonData;
+
 public class LinkedFileViewModel extends AbstractViewModel {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LinkedFileViewModel.class);
@@ -274,7 +276,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
 
     public boolean delete() {
         Optional<Path> file = linkedFile.findIn(databaseContext, Globals.prefs.getFileDirectoryPreferences());
-        ButtonType removeFromEntry = new ButtonType(Localization.lang("Remove from entry"));
+        ButtonType removeFromEntry = new ButtonType(Localization.lang("Remove from entry"), ButtonData.YES);
 
         if (file.isPresent()) {
             ButtonType deleteFromEntry = new ButtonType(Localization.lang("Delete from disk"));

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -56,15 +56,21 @@ public class LinkedFileViewModel extends AbstractViewModel {
     private final BooleanProperty downloadOngoing = new SimpleBooleanProperty(false);
     private final BooleanProperty isAutomaticallyFound = new SimpleBooleanProperty(false);
     private final BooleanProperty canWriteXMPMetadata = new SimpleBooleanProperty(false);
-    private final DialogService dialogService = new FXDialogService();
+    private final DialogService dialogService;
     private final BibEntry entry;
     private final TaskExecutor taskExecutor;
 
     public LinkedFileViewModel(LinkedFile linkedFile, BibEntry entry, BibDatabaseContext databaseContext, TaskExecutor taskExecutor) {
+        this(linkedFile, entry, databaseContext, taskExecutor, new FXDialogService());
+    }
+
+    protected LinkedFileViewModel(LinkedFile linkedFile, BibEntry entry, BibDatabaseContext databaseContext,
+                                  TaskExecutor taskExecutor, DialogService dialogService) {
         this.linkedFile = linkedFile;
         this.databaseContext = databaseContext;
         this.entry = entry;
         this.taskExecutor = taskExecutor;
+        this.dialogService = dialogService;
 
         downloadOngoing.bind(downloadProgress.greaterThanOrEqualTo(0).and(downloadProgress.lessThan(100)));
         canWriteXMPMetadata.setValue(!linkedFile.isOnlineLink() && linkedFile.getFileType().equalsIgnoreCase("pdf"));

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -48,16 +48,12 @@ public class LinkedFileViewModelTest {
     }
 
     @Test
-    public void deleteFilePathNotPresent() {
+    public void deleteWhenFilePathNotPresentReturnsFalse() {
         // Making this a spy, so we can inject an empty optional without digging into the implementation
-        linkedFile = spy(new LinkedFile("", "", ""));
-        doReturn(Optional.empty()).when(linkedFile).findIn(
-                any(BibDatabaseContext.class), any(FileDirectoryPreferences.class)
-        );
+        linkedFile = spy(new LinkedFile("", "nonexistent file", ""));
+        doReturn(Optional.empty()).when(linkedFile).findIn(any(BibDatabaseContext.class), any(FileDirectoryPreferences.class));
 
-        LinkedFileViewModel viewModel = new LinkedFileViewModel(
-                linkedFile, entry, databaseContext, taskExecutor, dialogService
-        );
+        LinkedFileViewModel viewModel = new LinkedFileViewModel(linkedFile, entry, databaseContext, taskExecutor, dialogService);
         boolean removed = viewModel.delete();
 
         assertFalse(removed);
@@ -65,7 +61,7 @@ public class LinkedFileViewModelTest {
     }
 
     @Test
-    public void deleteDialogRemoveFromEntry() throws IOException {
+    public void deleteWhenRemoveChosenReturnsTrue() throws IOException {
         File tempFile = tempFolder.newFile();
         linkedFile = new LinkedFile("", tempFile.getAbsolutePath(), "");
         when(dialogService.showCustomButtonDialogAndWait(
@@ -77,9 +73,7 @@ public class LinkedFileViewModelTest {
                 any(ButtonType.class)
         )).thenAnswer(invocation -> Optional.of(invocation.getArgument(3))); // first vararg - remove button
 
-        LinkedFileViewModel viewModel = new LinkedFileViewModel(
-                linkedFile, entry, databaseContext, taskExecutor, dialogService
-        );
+        LinkedFileViewModel viewModel = new LinkedFileViewModel(linkedFile, entry, databaseContext, taskExecutor, dialogService);
         boolean removed = viewModel.delete();
 
         assertTrue(removed);
@@ -87,7 +81,7 @@ public class LinkedFileViewModelTest {
     }
 
     @Test
-    public void deleteDialogDeleteFromEntry() throws IOException {
+    public void deleteWhenDeleteChosenReturnsTrueAndDeletesFile() throws IOException {
         File tempFile = tempFolder.newFile();
         linkedFile = new LinkedFile("", tempFile.getAbsolutePath(), "");
         when(dialogService.showCustomButtonDialogAndWait(
@@ -99,9 +93,7 @@ public class LinkedFileViewModelTest {
                 any(ButtonType.class)
         )).thenAnswer(invocation -> Optional.of(invocation.getArgument(4))); // second vararg - delete button
 
-        LinkedFileViewModel viewModel = new LinkedFileViewModel(
-                linkedFile, entry, databaseContext, taskExecutor, dialogService
-        );
+        LinkedFileViewModel viewModel = new LinkedFileViewModel(linkedFile, entry, databaseContext, taskExecutor, dialogService);
         boolean removed = viewModel.delete();
 
         assertTrue(removed);
@@ -110,7 +102,7 @@ public class LinkedFileViewModelTest {
 
 
     @Test
-    public void deleteDialogDeleteFromEntryException() throws IOException {
+    public void deleteWhenDeleteChosenAndFileMissingReturnsFalse() throws IOException {
         linkedFile = new LinkedFile("", "!!nonexistent file!!", "");
         when(dialogService.showCustomButtonDialogAndWait(
                 any(AlertType.class),
@@ -121,9 +113,7 @@ public class LinkedFileViewModelTest {
                 any(ButtonType.class)
         )).thenAnswer(invocation -> Optional.of(invocation.getArgument(4))); // second vararg - delete button
 
-        LinkedFileViewModel viewModel = new LinkedFileViewModel(
-                linkedFile, entry, databaseContext, taskExecutor, dialogService
-        );
+        LinkedFileViewModel viewModel = new LinkedFileViewModel(linkedFile, entry, databaseContext, taskExecutor, dialogService);
         boolean removed = viewModel.delete();
 
         verify(dialogService).showErrorDialogAndWait(anyString(), anyString());
@@ -131,7 +121,7 @@ public class LinkedFileViewModelTest {
     }
 
     @Test
-    public void deleteDialogCanceled() throws IOException {
+    public void deleteWhenDialogCancelledReturnsFalse() throws IOException {
         File tempFile = tempFolder.newFile();
         linkedFile = new LinkedFile("desc", tempFile.getAbsolutePath(), "pdf");
         when(dialogService.showCustomButtonDialogAndWait(
@@ -143,9 +133,7 @@ public class LinkedFileViewModelTest {
                 any(ButtonType.class)
         )).thenAnswer(invocation -> Optional.of(invocation.getArgument(5))); // third vararg - cancel button
 
-        LinkedFileViewModel viewModel = new LinkedFileViewModel(
-                linkedFile, entry, databaseContext, taskExecutor, dialogService
-        );
+        LinkedFileViewModel viewModel = new LinkedFileViewModel(linkedFile, entry, databaseContext, taskExecutor, dialogService);
         boolean removed = viewModel.delete();
 
         assertFalse(removed);

--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -1,0 +1,154 @@
+package org.jabref.gui.fieldeditors;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+
+import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.ButtonType;
+
+import org.jabref.gui.DialogService;
+import org.jabref.gui.util.TaskExecutor;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.LinkedFile;
+import org.jabref.model.metadata.FileDirectoryPreferences;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class LinkedFileViewModelTest {
+
+    @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+    private LinkedFile linkedFile;
+    private BibEntry entry;
+    private BibDatabaseContext databaseContext;
+    private TaskExecutor taskExecutor;
+    private DialogService dialogService;
+
+    @Before
+    public void setUp() {
+        entry = new BibEntry();
+        databaseContext = new BibDatabaseContext();
+        taskExecutor = mock(TaskExecutor.class);
+        dialogService = mock(DialogService.class);
+    }
+
+    @Test
+    public void deleteFilePathNotPresent() {
+        // Making this a spy, so we can inject an empty optional without digging into the implementation
+        linkedFile = spy(new LinkedFile("", "", ""));
+        doReturn(Optional.empty()).when(linkedFile).findIn(
+                any(BibDatabaseContext.class), any(FileDirectoryPreferences.class)
+        );
+
+        LinkedFileViewModel viewModel = new LinkedFileViewModel(
+                linkedFile, entry, databaseContext, taskExecutor, dialogService
+        );
+        boolean removed = viewModel.delete();
+
+        assertFalse(removed);
+        verifyZeroInteractions(dialogService); // dialog was never shown
+    }
+
+    @Test
+    public void deleteDialogRemoveFromEntry() throws IOException {
+        File tempFile = tempFolder.newFile();
+        linkedFile = new LinkedFile("", tempFile.getAbsolutePath(), "");
+        when(dialogService.showCustomButtonDialogAndWait(
+                any(AlertType.class),
+                anyString(),
+                anyString(),
+                any(ButtonType.class),
+                any(ButtonType.class),
+                any(ButtonType.class)
+        )).thenAnswer(invocation -> Optional.of(invocation.getArgument(3))); // first vararg - remove button
+
+        LinkedFileViewModel viewModel = new LinkedFileViewModel(
+                linkedFile, entry, databaseContext, taskExecutor, dialogService
+        );
+        boolean removed = viewModel.delete();
+
+        assertTrue(removed);
+        assertTrue(tempFile.exists());
+    }
+
+    @Test
+    public void deleteDialogDeleteFromEntry() throws IOException {
+        File tempFile = tempFolder.newFile();
+        linkedFile = new LinkedFile("", tempFile.getAbsolutePath(), "");
+        when(dialogService.showCustomButtonDialogAndWait(
+                any(AlertType.class),
+                anyString(),
+                anyString(),
+                any(ButtonType.class),
+                any(ButtonType.class),
+                any(ButtonType.class)
+        )).thenAnswer(invocation -> Optional.of(invocation.getArgument(4))); // second vararg - delete button
+
+        LinkedFileViewModel viewModel = new LinkedFileViewModel(
+                linkedFile, entry, databaseContext, taskExecutor, dialogService
+        );
+        boolean removed = viewModel.delete();
+
+        assertTrue(removed);
+        assertFalse(tempFile.exists());
+    }
+
+
+    @Test
+    public void deleteDialogDeleteFromEntryException() throws IOException {
+        linkedFile = new LinkedFile("", "!!nonexistent file!!", "");
+        when(dialogService.showCustomButtonDialogAndWait(
+                any(AlertType.class),
+                anyString(),
+                anyString(),
+                any(ButtonType.class),
+                any(ButtonType.class),
+                any(ButtonType.class)
+        )).thenAnswer(invocation -> Optional.of(invocation.getArgument(4))); // second vararg - delete button
+
+        LinkedFileViewModel viewModel = new LinkedFileViewModel(
+                linkedFile, entry, databaseContext, taskExecutor, dialogService
+        );
+        boolean removed = viewModel.delete();
+
+        verify(dialogService).showErrorDialogAndWait(anyString(), anyString());
+        assertFalse(removed);
+    }
+
+    @Test
+    public void deleteDialogCanceled() throws IOException {
+        File tempFile = tempFolder.newFile();
+        linkedFile = new LinkedFile("desc", tempFile.getAbsolutePath(), "pdf");
+        when(dialogService.showCustomButtonDialogAndWait(
+                any(AlertType.class),
+                anyString(),
+                anyString(),
+                any(ButtonType.class),
+                any(ButtonType.class),
+                any(ButtonType.class)
+        )).thenAnswer(invocation -> Optional.of(invocation.getArgument(5))); // third vararg - cancel button
+
+        LinkedFileViewModel viewModel = new LinkedFileViewModel(
+                linkedFile, entry, databaseContext, taskExecutor, dialogService
+        );
+        boolean removed = viewModel.delete();
+
+        assertFalse(removed);
+        assertTrue(tempFile.exists());
+    }
+}


### PR DESCRIPTION
This pull request fixes the following issues:

* When a file link in a bibliography entry is deleted by the user, a dialog is displayed. Previously, the default (first) dialog option deleted the linked file from disk. The default behaviour has been changed to just removing the file link from the entry.

  This is a fix to issue #3679 
Fixes #3679 

* When clicking the "Cancel" button in the file link deletion dialog, the file  was being deleted from the list. This behaviour has been fixed by changing the return value of the `delete()` method when the "Cancel" button is chosen.

## Example screenshot:

![2018-02-04-001057_477x142_scrot](https://user-images.githubusercontent.com/20418176/35773368-0191977e-0950-11e8-90cb-ba778105f3e3.png)

## Checklist:

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Screenshots added
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)

---

I am unsure whether the remaining checklist items are applicable to this pull request.
I would be willing to provide tests for the `delete()` method; however, the `DialogService` member cannot be stubbed-in/mocked as it is (as it is marked `final`), and therefore I can't control the returned chosen option from inside the unit test.

I would appreciate any pointers and suggestions.