### PR TITLE
Use streams in group matcher

### DIFF
--- a/src/main/java/org/jabref/model/search/matchers/AndMatcher.java
+++ b/src/main/java/org/jabref/model/search/matchers/AndMatcher.java
@@ -1,26 +1,15 @@
 package org.jabref.model.search.matchers;
 
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.search.SearchMatcher;
 
 /**
- * Subclass of MatcherSet that ANDs or ORs between its rules, returning 0 or
- * 1.
+ * A set of matchers that returns true if all matcher match the given entry.
  */
 public class AndMatcher extends MatcherSet {
 
     @Override
-    public boolean isMatch(BibEntry bibEntry) {
-        int score = 0;
-
-        // We let each rule add a maximum of 1 to the score.
-        for (SearchMatcher rule : matchers) {
-            if (rule.isMatch(bibEntry)) {
-                score++;
-            }
-        }
-
-        // Then an AND rule demands that score == number of rules
-        return score == matchers.size();
+    public boolean isMatch(BibEntry entry) {
+        return matchers.stream()
+                       .allMatch(rule -> rule.isMatch(entry));
     }
 }

--- a/src/main/java/org/jabref/model/search/matchers/OrMatcher.java
+++ b/src/main/java/org/jabref/model/search/matchers/OrMatcher.java
@@ -1,26 +1,15 @@
 package org.jabref.model.search.matchers;
 
 import org.jabref.model.entry.BibEntry;
-import org.jabref.model.search.SearchMatcher;
 
 /**
- * Subclass of MatcherSet that ANDs or ORs between its rules, returning 0 or
- * 1.
+ * A set of matchers that returns true if any matcher matches the given entry.
  */
 public class OrMatcher extends MatcherSet {
 
     @Override
-    public boolean isMatch(BibEntry bibEntry) {
-        int score = 0;
-
-        // We let each rule add a maximum of 1 to the score.
-        for (SearchMatcher rule : matchers) {
-            if (rule.isMatch(bibEntry)) {
-                score++;
-            }
-        }
-
-        // OR rule demands score > 0.
-        return score > 0;
+    public boolean isMatch(BibEntry entry) {
+        return matchers.stream()
+                       .anyMatch(rule -> rule.isMatch(entry));
     }
 }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
Just a small change in the groups matcher code to use streams instead of old-style for-loops.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
