### PR TITLE
DOI encoded with % supported

### DIFF
--- a/src/main/java/org/jabref/model/entry/identifier/DOI.java
+++ b/src/main/java/org/jabref/model/entry/identifier/DOI.java
@@ -30,7 +30,7 @@ public class DOI implements Identifier {
             + "("                               // begin group \1
             + "10"                              // directory indicator
             + "(?:\\.[0-9]+)+"                  // registrant codes
-            + "[/:]"                            // divider
+            + "[/:%]" // divider
             + "(?:.+)"                          // suffix alphanumeric string
             + ")";                              // end group \1
     private static final String FIND_DOI_EXP = ""

--- a/src/test/java/org/jabref/model/entry/identifier/DOITest.java
+++ b/src/test/java/org/jabref/model/entry/identifier/DOITest.java
@@ -64,6 +64,8 @@ public class DOITest {
         Assert.assertEquals("10.1006/jmbi.1998.2354", new DOI("http://doi.org/10.1006/jmbi.1998.2354").getDOI());
         // https
         Assert.assertEquals("10.1006/jmbi.1998.2354", new DOI("https://doi.org/10.1006/jmbi.1998.2354").getDOI());
+        // https with % divider
+        Assert.assertEquals("10.2307/1990888", new DOI("https://dx.doi.org/10.2307%2F1990888").getDOI());
         // other domains
         Assert.assertEquals("10.1145/1294928.1294933", new DOI("http://doi.acm.org/10.1145/1294928.1294933").getDOI());
         Assert.assertEquals("10.1145/1294928.1294933", new DOI("http://doi.acm.net/10.1145/1294928.1294933").getDOI());


### PR DESCRIPTION
Fix koppor issues https://github.com/koppor/jabref/issues/3 "DOI: encoded URLs should be supported". New divider within the DOI % is supported.

<!-- describe the changes you have made here: what, why, ... -->


----

- [ ] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
