### PR TITLE
fix #3693

### DIFF
--- a/src/main/java/org/jabref/gui/exporter/ExportAction.java
+++ b/src/main/java/org/jabref/gui/exporter/ExportAction.java
@@ -1,7 +1,6 @@
 package org.jabref.gui.exporter;
 
 import java.awt.event.ActionEvent;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -81,14 +80,6 @@ public class ExportAction {
                     FileUtil.addExtension(file, selectedExtension);
                     }
 
-                if (Files.exists(file)) {
-                        // Warn that the file exists:
-                        if (JOptionPane.showConfirmDialog(frame,
-                                Localization.lang("'%0' exists. Overwrite file?", file.getFileName().toString()),
-                                Localization.lang("Export"), JOptionPane.OK_CANCEL_OPTION) != JOptionPane.OK_OPTION) {
-                            return;
-                        }
-                    }
                 final Exporter format = FileFilterConverter.getExporter(selectedExtensionFilter, exporters).orElseThrow(() -> new IllegalStateException("User didn't selected a file type for the extension"));
                     List<BibEntry> entries;
                     if (selectedOnly) {


### PR DESCRIPTION
Duplicated functionality, if file already exists. Previous implementation asks twice, if a file should be overriden.

<!-- describe the changes you have made here: what, why, ... -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
