### PR TITLE
Try to change color of magnifier icon

### DIFF
--- a/src/main/java/org/jabref/gui/IconTheme.java
+++ b/src/main/java/org/jabref/gui/IconTheme.java
@@ -198,6 +198,7 @@ public class IconTheme {
         REFRESH(MaterialDesignIcon.REFRESH),
         DELETE_ENTRY(MaterialDesignIcon.DELETE),
         SEARCH(MaterialDesignIcon.MAGNIFY),
+        ADVANCED_SEARCH(Color.ORANGE, MaterialDesignIcon.MAGNIFY),
         PREFERENCES(MaterialDesignIcon.SETTINGS),
         HELP(MaterialDesignIcon.HELP_CIRCLE),
         UP(MaterialDesignIcon.CHEVRON_UP),

--- a/src/main/java/org/jabref/gui/IconTheme.java
+++ b/src/main/java/org/jabref/gui/IconTheme.java
@@ -198,7 +198,7 @@ public class IconTheme {
         REFRESH(MaterialDesignIcon.REFRESH),
         DELETE_ENTRY(MaterialDesignIcon.DELETE),
         SEARCH(MaterialDesignIcon.MAGNIFY),
-        ADVANCED_SEARCH(Color.ORANGE, MaterialDesignIcon.MAGNIFY),
+        ADVANCED_SEARCH(Color.CYAN, MaterialDesignIcon.MAGNIFY),
         PREFERENCES(MaterialDesignIcon.SETTINGS),
         HELP(MaterialDesignIcon.HELP_CIRCLE),
         UP(MaterialDesignIcon.CHEVRON_UP),

--- a/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
@@ -391,6 +391,7 @@ public class GlobalSearchBar extends JPanel {
             currentResults.setText(Localization.lang("Found %0 results.", String.valueOf(matched)));
             searchField.pseudoClassStateChanged(CLASS_RESULTS_FOUND, true);
         }
+        SearchTextField.switchSearchColor(searchField, grammarBasedSearch);
         Tooltip tooltip = new Tooltip();
         tooltip.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
         tooltip.setGraphic(description);

--- a/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
@@ -22,7 +22,6 @@ import javax.swing.SwingUtilities;
 
 import javafx.css.PseudoClass;
 import javafx.embed.swing.JFXPanel;
-import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.ContentDisplay;
 import javafx.scene.control.TextField;

--- a/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
@@ -22,6 +22,7 @@ import javax.swing.SwingUtilities;
 
 import javafx.css.PseudoClass;
 import javafx.embed.swing.JFXPanel;
+import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.ContentDisplay;
 import javafx.scene.control.TextField;
@@ -77,6 +78,8 @@ public class GlobalSearchBar extends JPanel {
     private SearchResultFrame searchResultFrame;
 
     private SearchDisplayMode searchDisplayMode;
+
+    private JLabel searchIcon = new JLabel(IconTheme.JabRefIcon.SEARCH.getIcon());
 
     /**
      * if this flag is set the searchbar won't be selected after the next search
@@ -195,6 +198,7 @@ public class GlobalSearchBar extends JPanel {
         setLayout(new FlowLayout(FlowLayout.RIGHT));
         JToolBar toolBar = new OSXCompatibleToolbar();
         toolBar.setFloatable(false);
+        toolBar.add(searchIcon);
         toolBar.add(container);
         toolBar.add(openCurrentResultsInDialog);
         toolBar.addSeparator();
@@ -391,7 +395,11 @@ public class GlobalSearchBar extends JPanel {
             currentResults.setText(Localization.lang("Found %0 results.", String.valueOf(matched)));
             searchField.pseudoClassStateChanged(CLASS_RESULTS_FOUND, true);
         }
-        SearchTextField.switchSearchColor(searchField, grammarBasedSearch);
+        if (grammarBasedSearch) {
+           searchIcon.setIcon(IconTheme.JabRefIcon.ADVANCED_SEARCH.getIcon());
+        } else {
+            searchIcon.setIcon(IconTheme.JabRefIcon.SEARCH.getIcon());
+        }
         Tooltip tooltip = new Tooltip();
         tooltip.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
         tooltip.setGraphic(description);

--- a/src/main/java/org/jabref/gui/search/SearchTextField.java
+++ b/src/main/java/org/jabref/gui/search/SearchTextField.java
@@ -1,8 +1,10 @@
 package org.jabref.gui.search;
 
+import javafx.scene.Node;
 import javafx.scene.control.TextField;
 
 import org.jabref.gui.IconTheme;
+import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.logic.l10n.Localization;
 
 import org.controlsfx.control.textfield.CustomTextField;
@@ -13,7 +15,21 @@ public class SearchTextField {
     public static TextField create() {
         CustomTextField textField = (CustomTextField) TextFields.createClearableTextField();
         textField.setPromptText(Localization.lang("Search") + "...");
-        textField.setLeft(IconTheme.JabRefIcon.SEARCH.getGraphicNode());
+        Node node = IconTheme.JabRefIcon.SEARCH.getGraphicNode();
+        node.setStyle("-fx-text-fill: #00ffff");
+        textField.setLeft(node);
         return textField;
     }
+
+    public static void switchSearchColor(TextField textField, boolean grammarBasedSearch) {
+        if (grammarBasedSearch) {
+            DefaultTaskExecutor.runInJavaFXThread(() ->
+                    ((CustomTextField) textField).setLeft(IconTheme.JabRefIcon.ADVANCED_SEARCH.getGraphicNode()));
+        } else {
+            DefaultTaskExecutor.runInJavaFXThread(() ->
+                    ((CustomTextField) textField).setLeft(IconTheme.JabRefIcon.SEARCH.getGraphicNode()));
+        }
+    }
+
+
 }

--- a/src/main/java/org/jabref/gui/search/SearchTextField.java
+++ b/src/main/java/org/jabref/gui/search/SearchTextField.java
@@ -1,10 +1,7 @@
 package org.jabref.gui.search;
 
-import javafx.scene.Node;
 import javafx.scene.control.TextField;
 
-import org.jabref.gui.IconTheme;
-import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.logic.l10n.Localization;
 
 import org.controlsfx.control.textfield.CustomTextField;
@@ -15,21 +12,7 @@ public class SearchTextField {
     public static TextField create() {
         CustomTextField textField = (CustomTextField) TextFields.createClearableTextField();
         textField.setPromptText(Localization.lang("Search") + "...");
-        Node node = IconTheme.JabRefIcon.SEARCH.getGraphicNode();
-        node.setStyle("-fx-text-fill: #00ffff");
-        textField.setLeft(node);
         return textField;
     }
-
-    public static void switchSearchColor(TextField textField, boolean grammarBasedSearch) {
-        if (grammarBasedSearch) {
-            DefaultTaskExecutor.runInJavaFXThread(() ->
-                    ((CustomTextField) textField).setLeft(IconTheme.JabRefIcon.ADVANCED_SEARCH.getGraphicNode()));
-        } else {
-            DefaultTaskExecutor.runInJavaFXThread(() ->
-                    ((CustomTextField) textField).setLeft(IconTheme.JabRefIcon.SEARCH.getGraphicNode()));
-        }
-    }
-
 
 }


### PR DESCRIPTION
I am trying to change the color of the magnifier icon as requested here: #3535

However, the icon refuses a color change. It even opts out of the color scheme of JabRef, since it is black instead of purple (despite the fact that the icon is configured as purple in the code).

@tobiasdiez How can I change the color of this icon? Any change will do, really. For reasons unknown to me the icon straight-out refuses the change. 


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
