### PR TITLE
Group interface: Usability tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For more details refer to the [field mapping help page](http://help.jabref.org/e
 - We improved file saving so that hard links are now preserved when a save is performed [#2633](https://github.com/JabRef/jabref/issues/2633)
 - We changed the default dialog option when removing a [file link](http://help.jabref.org/en/FileLinks#adding-external-links-to-an-entry) from an entry.
 The new default removes the linked file from the entry instead of deleting the file from disk. [#3679](https://github.com/JabRef/jabref/issues/3679)
+- The group editing window can now also be called by double-clicking the group to be edited. [koppor#277](https://github.com/koppor/jabref/issues/277)
 
 ### Fixed
 - We fixed an issue where pressing space caused the cursor to jump to the start of the text field. [#3471](https://github.com/JabRef/jabref/issues/3471)
@@ -37,6 +38,7 @@ The new default removes the linked file from the entry instead of deleting the f
 - Chaining modifiers in BibTeX key pattern now works as described in the documentation. [#3648](https://github.com/JabRef/jabref/issues/3648)
 - We fixed an issue where not all bibtex/biblatex fields would be exported as latex-free to MS-Office XML [koppor#284](https://github.com/koppor/jabref/issues/284)
 - We fixed an issue where linked files would be deleted from bibliography entries despite choosing the "Cancel" option in the dialog menu.
+- We fixed the name of the group editing window to "Add group" instead of "Edit Group" when adding a new group. [koppor#277](https://github.com/koppor/jabref/issues/277)
 
 ### Removed
 - We removed the [Look and Feels from JGoodies](http://www.jgoodies.com/freeware/libraries/looks/), because the open source version is not compatible with Java 9.

--- a/src/main/java/org/jabref/gui/groups/GroupDialog.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialog.java
@@ -148,7 +148,8 @@ class GroupDialog extends JabRefDialog implements Dialog<AbstractGroup> {
      *                    created.
      */
     public GroupDialog(JabRefFrame jabrefFrame, AbstractGroup editedGroup) {
-        super(jabrefFrame, Localization.lang("Edit group"), true, GroupDialog.class);
+        super(jabrefFrame, (editedGroup == null) ? Localization.lang("Add group") : Localization.lang("Edit group"),
+                true, GroupDialog.class);
 
         // set default values (overwritten if editedGroup != null)
         keywordGroupSearchField.setText(jabrefFrame.prefs().get(JabRefPreferences.GROUPS_DEFAULT_FIELD));

--- a/src/main/java/org/jabref/gui/groups/GroupTreeController.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeController.java
@@ -178,7 +178,7 @@ public class GroupTreeController extends AbstractController<GroupTreeViewModel> 
             row.setOnMouseClicked((mouseClickedEvent) -> {
                 if (mouseClickedEvent.getButton().equals(MouseButton.PRIMARY)
                         && (mouseClickedEvent.getClickCount() == 2)) {
-                    GroupNodeViewModel groupToEdit = EasyBind.monadic(row.itemProperty()).getValue();
+                    GroupNodeViewModel groupToEdit = row.itemProperty().getValue();
                     if (groupToEdit != null) {
                         viewModel.editGroup(groupToEdit);
                     }

--- a/src/main/java/org/jabref/gui/groups/GroupTreeController.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeController.java
@@ -28,6 +28,7 @@ import javafx.scene.control.TreeTableView;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.input.DragEvent;
 import javafx.scene.input.Dragboard;
+import javafx.scene.input.MouseButton;
 import javafx.scene.input.TransferMode;
 import javafx.scene.layout.StackPane;
 import javafx.scene.text.Text;
@@ -172,6 +173,17 @@ public class GroupTreeController extends AbstractController<GroupTreeViewModel> 
             // Simply setting to null is not enough since it would be replaced by the default node on every change
             row.setDisclosureNode(null);
             row.disclosureNodeProperty().addListener((observable, oldValue, newValue) -> row.setDisclosureNode(null));
+
+            // Opens the group's edit window when the group gets double clicked
+            row.setOnMouseClicked((mouseClickedEvent) -> {
+                if (mouseClickedEvent.getButton().equals(MouseButton.PRIMARY)
+                        && (mouseClickedEvent.getClickCount() == 2)) {
+                    GroupNodeViewModel groupToEdit = EasyBind.monadic(row.itemProperty()).getValue();
+                    if (groupToEdit != null) {
+                        viewModel.editGroup(groupToEdit);
+                    }
+                }
+            });
 
             // Add context menu (only for non-null items)
             row.contextMenuProperty().bind(

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -386,6 +386,7 @@ Edit\ entry=Edit entry
 Save\ file=Save file
 Edit\ file\ type=Edit file type
 
+Add\ group=Add group
 Edit\ group=Edit group
 
 


### PR DESCRIPTION
Fixes [koppor#277](https://github.com/koppor/jabref/issues/277)

This fixes the name of the group editing window to "Add group" instead of "Edit Group" when adding a new group.
The group editing window can now also be called by double-clicking the group to be edited.

----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)

----

_Credit (for an exercise):
Rico Haas
David Zeck_