### PR TITLE
Code cleanup AbbreviateAction.java

### DIFF
--- a/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
+++ b/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
@@ -1,6 +1,5 @@
 package org.jabref.gui.journals;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -14,70 +13,65 @@ import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.InternalBibtexFields;
 
 /**
- * Converts journal full names to either iso or medline abbreviations for all selected entries.
+ * Converts journal full names to either iso or medline abbreviations for all
+ * selected entries.
  */
 public class AbbreviateAction extends AbstractWorker {
 
-    private final BasePanel panel;
-    private String message = "";
-    private final boolean iso;
+	private final BasePanel panel;
+	private String message = "";
+	private final boolean iso;
 
+	public AbbreviateAction(BasePanel panel, boolean iso) {
+		this.panel = panel;
+		this.iso = iso;
+	}
 
-    public AbbreviateAction(BasePanel panel, boolean iso) {
-        this.panel = panel;
-        this.iso = iso;
-    }
+	@Override
+	public void init() {
+		panel.output(Localization.lang("Abbreviating..."));
+	}
 
-    @Override
-    public void init() {
-        panel.output(Localization.lang("Abbreviating..."));
-    }
+	@Override
+	public void run() {
+		List<BibEntry> entries = panel.getSelectedEntries();
 
-    @Override
-    public void run() {
-        List<BibEntry> entries = panel.getSelectedEntries();
-        if (entries == null) {
-            return;
-        }
+		UndoableAbbreviator undoableAbbreviator = new UndoableAbbreviator(
+				Globals.journalAbbreviationLoader.getRepository(Globals.prefs.getJournalAbbreviationPreferences()),
+				iso);
 
-        UndoableAbbreviator undoableAbbreviator = new UndoableAbbreviator(Globals.journalAbbreviationLoader
-                .getRepository(Globals.prefs.getJournalAbbreviationPreferences()), iso);
+		NamedCompound ce = new NamedCompound(Localization.lang("Abbreviate journal names"));
+		int count = 0;
 
-        NamedCompound ce = new NamedCompound(Localization.lang("Abbreviate journal names"));
-        int count = 0;
+		for (BibEntry entry : entries) {
+			Callable<Boolean> callable = () -> {
+				for (String journalField : InternalBibtexFields.getJournalNameFields()) {
+					if (undoableAbbreviator.abbreviate(panel.getDatabase(), entry, journalField, ce)) {
+						return true;
+					}
+				}
 
-        List<Boolean> futures = new ArrayList<>();
-        for (BibEntry entry : entries) {
-            Callable<Boolean> callable = () -> {
-                for (String journalField : InternalBibtexFields.getJournalNameFields()) {
-                    if (undoableAbbreviator.abbreviate(panel.getDatabase(), entry, journalField, ce)) {
-                        return true;
-                    }
-                }
+				return false;
+			};
 
-                return false;
-            };
-            JabRefExecutorService.INSTANCE.executeAndWait(callable);
-            futures.add(JabRefExecutorService.INSTANCE.executeAndWait(callable));
-        }
+			boolean result = JabRefExecutorService.INSTANCE.executeAndWait(callable);
+			if (result) {
+				count++;
+			}
+		}
 
-        for (Boolean future : futures) {
-            if (future)
-                count++;
-        }
+		if (count > 0) {
+			ce.end();
+			panel.getUndoManager().addEdit(ce);
+			panel.markBaseChanged();
+			message = Localization.lang("Abbreviated %0 journal names.", String.valueOf(count));
+		} else {
+			message = Localization.lang("No journal names could be abbreviated.");
+		}
+	}
 
-        if (count > 0) {
-            ce.end();
-            panel.getUndoManager().addEdit(ce);
-            panel.markBaseChanged();
-            message = Localization.lang("Abbreviated %0 journal names.", String.valueOf(count));
-        } else {
-            message = Localization.lang("No journal names could be abbreviated.");
-        }
-    }
-
-    @Override
-    public void update() {
-        panel.output(message);
-    }
+	@Override
+	public void update() {
+		panel.output(message);
+	}
 }

--- a/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
+++ b/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
@@ -18,60 +18,60 @@ import org.jabref.model.entry.InternalBibtexFields;
  */
 public class AbbreviateAction extends AbstractWorker {
 
-	private final BasePanel panel;
-	private String message = "";
-	private final boolean iso;
+    private final BasePanel panel;
+    private String message = "";
+    private final boolean iso;
 
-	public AbbreviateAction(BasePanel panel, boolean iso) {
-		this.panel = panel;
-		this.iso = iso;
-	}
+    public AbbreviateAction(BasePanel panel, boolean iso) {
+	this.panel = panel;
+	this.iso = iso;
+    }
 
-	@Override
-	public void init() {
-		panel.output(Localization.lang("Abbreviating..."));
-	}
+    @Override
+    public void init() {
+	panel.output(Localization.lang("Abbreviating..."));
+    }
 
-	@Override
-	public void run() {
-		List<BibEntry> entries = panel.getSelectedEntries();
+    @Override
+    public void run() {
+	List<BibEntry> entries = panel.getSelectedEntries();
 
-		UndoableAbbreviator undoableAbbreviator = new UndoableAbbreviator(
-				Globals.journalAbbreviationLoader.getRepository(Globals.prefs.getJournalAbbreviationPreferences()),
-				iso);
+	UndoableAbbreviator undoableAbbreviator = new UndoableAbbreviator(
+		Globals.journalAbbreviationLoader.getRepository(Globals.prefs.getJournalAbbreviationPreferences()),
+		iso);
 
-		NamedCompound ce = new NamedCompound(Localization.lang("Abbreviate journal names"));
-		int count = 0;
+	NamedCompound ce = new NamedCompound(Localization.lang("Abbreviate journal names"));
+	int count = 0;
 
-		for (BibEntry entry : entries) {
-			Callable<Boolean> callable = () -> {
-				for (String journalField : InternalBibtexFields.getJournalNameFields()) {
-					if (undoableAbbreviator.abbreviate(panel.getDatabase(), entry, journalField, ce)) {
-						return true;
-					}
-				}
-
-				return false;
-			};
-
-			boolean result = JabRefExecutorService.INSTANCE.executeAndWait(callable);
-			if (result) {
-				count++;
-			}
+	for (BibEntry entry : entries) {
+	    Callable<Boolean> callable = () -> {
+		for (String journalField : InternalBibtexFields.getJournalNameFields()) {
+		    if (undoableAbbreviator.abbreviate(panel.getDatabase(), entry, journalField, ce)) {
+			return true;
+		    }
 		}
 
-		if (count > 0) {
-			ce.end();
-			panel.getUndoManager().addEdit(ce);
-			panel.markBaseChanged();
-			message = Localization.lang("Abbreviated %0 journal names.", String.valueOf(count));
-		} else {
-			message = Localization.lang("No journal names could be abbreviated.");
-		}
+		return false;
+	    };
+
+	    boolean result = JabRefExecutorService.INSTANCE.executeAndWait(callable);
+	    if (result) {
+		count++;
+	    }
 	}
 
-	@Override
-	public void update() {
-		panel.output(message);
+	if (count > 0) {
+	    ce.end();
+	    panel.getUndoManager().addEdit(ce);
+	    panel.markBaseChanged();
+	    message = Localization.lang("Abbreviated %0 journal names.", String.valueOf(count));
+	} else {
+	    message = Localization.lang("No journal names could be abbreviated.");
 	}
+    }
+
+    @Override
+    public void update() {
+	panel.output(message);
+    }
 }

--- a/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
+++ b/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
@@ -23,55 +23,55 @@ public class AbbreviateAction extends AbstractWorker {
     private final boolean iso;
 
     public AbbreviateAction(BasePanel panel, boolean iso) {
-	this.panel = panel;
-	this.iso = iso;
+        this.panel = panel;
+        this.iso = iso;
     }
 
     @Override
     public void init() {
-	panel.output(Localization.lang("Abbreviating..."));
+        panel.output(Localization.lang("Abbreviating..."));
     }
 
     @Override
     public void run() {
-	List<BibEntry> entries = panel.getSelectedEntries();
+        List<BibEntry> entries = panel.getSelectedEntries();
 
-	UndoableAbbreviator undoableAbbreviator = new UndoableAbbreviator(
-		Globals.journalAbbreviationLoader.getRepository(Globals.prefs.getJournalAbbreviationPreferences()),
-		iso);
+        UndoableAbbreviator undoableAbbreviator = new UndoableAbbreviator(
+                Globals.journalAbbreviationLoader.getRepository(Globals.prefs.getJournalAbbreviationPreferences()),
+                iso);
 
-	NamedCompound ce = new NamedCompound(Localization.lang("Abbreviate journal names"));
-	int count = 0;
+        NamedCompound ce = new NamedCompound(Localization.lang("Abbreviate journal names"));
+        int count = 0;
 
-	for (BibEntry entry : entries) {
-	    Callable<Boolean> callable = () -> {
-		for (String journalField : InternalBibtexFields.getJournalNameFields()) {
-		    if (undoableAbbreviator.abbreviate(panel.getDatabase(), entry, journalField, ce)) {
-			return true;
-		    }
-		}
+        for (BibEntry entry : entries) {
+            Callable<Boolean> callable = () -> {
+                for (String journalField : InternalBibtexFields.getJournalNameFields()) {
+                    if (undoableAbbreviator.abbreviate(panel.getDatabase(), entry, journalField, ce)) {
+                        return true;
+                    }
+                }
 
-		return false;
-	    };
+                return false;
+            };
 
-	    boolean result = JabRefExecutorService.INSTANCE.executeAndWait(callable);
-	    if (result) {
-		count++;
-	    }
-	}
+            boolean result = JabRefExecutorService.INSTANCE.executeAndWait(callable);
+            if (result) {
+                count++;
+            }
+        }
 
-	if (count > 0) {
-	    ce.end();
-	    panel.getUndoManager().addEdit(ce);
-	    panel.markBaseChanged();
-	    message = Localization.lang("Abbreviated %0 journal names.", String.valueOf(count));
-	} else {
-	    message = Localization.lang("No journal names could be abbreviated.");
-	}
+        if (count > 0) {
+            ce.end();
+            panel.getUndoManager().addEdit(ce);
+            panel.markBaseChanged();
+            message = Localization.lang("Abbreviated %0 journal names.", String.valueOf(count));
+        } else {
+            message = Localization.lang("No journal names could be abbreviated.");
+        }
     }
 
     @Override
     public void update() {
-	panel.output(message);
+        panel.output(message);
     }
 }


### PR DESCRIPTION
Removed redundant code in line 60 and 61 (callable was executed twice without using the return value of the first execution).
Also removed the ArrayList which was used to count the number of abbreviations made. Instead the number will be incremented within the for-loop now.

Removed the null check of the _entries_ variable, because JavaDoc comment of _panel.getSelectedEntries()_ clearly says it never returns _null_.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
