### PR TITLE
[WIP] Fix for issue 2831

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ## [Unreleased]
 
 ### Changed
+- Abbreviate journal names functionality is now running parallel, increasing performance significantly. [#2831] (https://github.com/JabRef/jabref/issues/2831)
 - Changed ID-based entry generator to store the last used fetcher. [#2796] (https://github.com/JabRef/jabref/issues/2796)
 - Reorganised annotation information on the right side of the "File annotations" tab. [#3109](https://github.com/JabRef/jabref/issues/3109)
 - We now show a small notification icon in the entry editor when we detect data inconsistency or other problems. [#3145](https://github.com/JabRef/jabref/issues/3145)

--- a/scripts/bib-file-generator.py
+++ b/scripts/bib-file-generator.py
@@ -1,5 +1,4 @@
 number_of_entries = 100000
-
 file = open("generatedDatabase.bib", 'w')
 
 for i in range(number_of_entries):
@@ -12,6 +11,5 @@ for i in range(number_of_entries):
     pages   = {%i},
  }""" % (i, i, i, i, i, i, i)
     file.write(entry)
-    
 file.flush()
 file.close()

--- a/scripts/bib-file-generator.py
+++ b/scripts/bib-file-generator.py
@@ -1,0 +1,17 @@
+number_of_entries = 100000
+
+file = open("generatedDatabase.bib", 'w')
+
+for i in range(number_of_entries):
+    entry = """@article{%i,
+    author  = {%i},
+    title   = {%i},
+    journal = {%i},
+    volume  = {%i},
+    year    = {%i},
+    pages   = {%i},
+ }""" % (i, i, i, i, i, i, i)
+    file.write(entry)
+    
+file.flush()
+file.close()

--- a/src/main/java/org/jabref/JabRefExecutorService.java
+++ b/src/main/java/org/jabref/JabRefExecutorService.java
@@ -89,19 +89,16 @@ public class JabRefExecutorService implements Executor {
      */
     public <T> Future<T> executeAndReturn(Callable<T> command) {
         Objects.requireNonNull(command);
-
         return executorService.submit(command);
     }
     
     public <T> List<Future<T>> executeAll(Collection<Callable<T>> tasks) throws InterruptedException {
         Objects.requireNonNull(tasks);
-        
         List<Future<T>> futures = null; 
-        
         try {
             futures =  executorService.invokeAll(tasks);
         } catch (InterruptedException e) {
-            LOGGER.debug("Invokation has been interrupted during execution.");
+            LOGGER.info("Invokation has been interrupted during execution.");
         }
         Objects.requireNonNull(futures);
         return futures;

--- a/src/main/java/org/jabref/JabRefExecutorService.java
+++ b/src/main/java/org/jabref/JabRefExecutorService.java
@@ -2,6 +2,7 @@ package org.jabref;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Timer;
@@ -80,7 +81,7 @@ public class JabRefExecutorService implements Executor {
     }
 
     /**
-     * This method allows to execute a callable task that provides a return value after the calculation is done.
+     * Executes a callable task that provides a return value after the calculation is done.
      * 
      * @param command The task to execute.
      * @return A Future object that provides the returning value.
@@ -90,13 +91,20 @@ public class JabRefExecutorService implements Executor {
         return executorService.submit(command);
     }
 
+    /**
+     * Executes a collection of callable tasks and returns a List of the resulting Future objects after the calculation is done. 
+     * 
+     * @param tasks The tasks to execute
+     * @return A List of Future objects that provide the returning values.
+     */
     public <T> List<Future<T>> executeAll(Collection<Callable<T>> tasks) {
         Objects.requireNonNull(tasks);
         List<Future<T>> futures = new ArrayList<>();
         try {
             futures = executorService.invokeAll(tasks);
         } catch (InterruptedException exception) {
-            LOGGER.error("Unble to execute tasks", exception);
+            LOGGER.error("Unable to execute tasks", exception);
+            return Collections.emptyList();
         }
         return futures;
     }

--- a/src/main/java/org/jabref/JabRefExecutorService.java
+++ b/src/main/java/org/jabref/JabRefExecutorService.java
@@ -110,10 +110,7 @@ public class JabRefExecutorService implements Executor {
     }
 
     public void executeInterruptableTaskAndWait(Runnable runnable) {
-        if (runnable == null) {
-            LOGGER.debug("Received null as command for execution");
-            return;
-        }
+        Objects.requireNonNull(runnable);
 
         Future<?> future = lowPriorityExecutorService.submit(runnable);
         while (true) {

--- a/src/main/java/org/jabref/JabRefExecutorService.java
+++ b/src/main/java/org/jabref/JabRefExecutorService.java
@@ -1,5 +1,7 @@
 package org.jabref;
 
+import java.util.Collection;
+import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.Callable;
@@ -40,19 +42,13 @@ public class JabRefExecutorService implements Executor {
 
     @Override
     public void execute(Runnable command) {
-        if (command == null) {
-            LOGGER.debug("Received null as command for execution");
-            return;
-        }
-
+        Objects.requireNonNull(command);
+        
         executorService.execute(command);
     }
 
     public void executeAndWait(Runnable command) {
-        if (command == null) {
-            LOGGER.debug("Received null as command for execution");
-            return;
-        }
+        Objects.requireNonNull(command);
 
         Future<?> future = executorService.submit(command);
         while (true) {
@@ -67,12 +63,9 @@ public class JabRefExecutorService implements Executor {
         }
     }
 
-    public boolean executeAndWait(Callable command) {
-        if (command == null) {
-            LOGGER.debug("Received null as command for execution");
-            return false;
-        }
-
+    public boolean executeAndWait(Callable<?> command) {
+        Objects.requireNonNull(command);
+        
         Future<?> future = executorService.submit(command);
         while (true) {
             try {
@@ -89,16 +82,25 @@ public class JabRefExecutorService implements Executor {
 
     /**
      * This method allows to execute a callable task that provides a return value after the calculation is done.
+     * 
      * @param command The task to execute.
      * @return A Future object that provides the returning value.
      */
     public <T> Future<T> executeAndReturn(Callable<T> command) {
-        if (command == null) {
-            LOGGER.debug("Received null as command for execution");
-            return null;
-        }
+        Objects.requireNonNull(command);
 
         return executorService.submit(command);
+    }
+    
+    public void executeAll(Collection<? extends Callable<?>> tasks) {
+        Objects.requireNonNull(tasks);
+        
+        
+        try {
+            executorService.invokeAll(tasks);
+        } catch (InterruptedException e) {
+            LOGGER.debug("Invokation has been interrupted during execution.");
+        }
     }
 
     public void executeInterruptableTask(final Runnable runnable) {

--- a/src/main/java/org/jabref/JabRefExecutorService.java
+++ b/src/main/java/org/jabref/JabRefExecutorService.java
@@ -89,14 +89,14 @@ public class JabRefExecutorService implements Executor {
         Objects.requireNonNull(command);
         return executorService.submit(command);
     }
-    
+
     public <T> List<Future<T>> executeAll(Collection<Callable<T>> tasks) {
         Objects.requireNonNull(tasks);
-        List<Future<T>> futures = new ArrayList<>(); 
+        List<Future<T>> futures = new ArrayList<>();
         try {
-            futures =  executorService.invokeAll(tasks);
-        } catch (InterruptedException e) {
-            LOGGER.info("Invokation has been interrupted during execution.");
+            futures = executorService.invokeAll(tasks);
+        } catch (InterruptedException exception) {
+            LOGGER.error("Unble to execute tasks", exception);
         }
         return futures;
     }

--- a/src/main/java/org/jabref/JabRefExecutorService.java
+++ b/src/main/java/org/jabref/JabRefExecutorService.java
@@ -1,5 +1,6 @@
 package org.jabref;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -91,13 +92,12 @@ public class JabRefExecutorService implements Executor {
     
     public <T> List<Future<T>> executeAll(Collection<Callable<T>> tasks) {
         Objects.requireNonNull(tasks);
-        List<Future<T>> futures = null; 
+        List<Future<T>> futures = new ArrayList<>(); 
         try {
             futures =  executorService.invokeAll(tasks);
         } catch (InterruptedException e) {
             LOGGER.info("Invokation has been interrupted during execution.");
         }
-        Objects.requireNonNull(futures);
         return futures;
     }
 

--- a/src/main/java/org/jabref/JabRefExecutorService.java
+++ b/src/main/java/org/jabref/JabRefExecutorService.java
@@ -12,7 +12,6 @@ import java.util.concurrent.Future;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * Responsible for managing of all threads (except Swing threads) in JabRef
  */
@@ -36,7 +35,8 @@ public class JabRefExecutorService implements Executor {
     private final Timer timer = new Timer("timer", true);
     private Thread remoteThread;
 
-    private JabRefExecutorService() { }
+    private JabRefExecutorService() {
+    }
 
     @Override
     public void execute(Runnable command) {
@@ -85,6 +85,20 @@ public class JabRefExecutorService implements Executor {
                 return false;
             }
         }
+    }
+
+    /**
+     * This method allows to execute a callable task that provides a return value after the calculation is done.
+     * @param command The task to execute.
+     * @return A Future object that provides the returning value.
+     */
+    public <T> Future<T> executeAndReturn(Callable<T> command) {
+        if (command == null) {
+            LOGGER.debug("Received null as command for execution");
+            return null;
+        }
+
+        return executorService.submit(command);
     }
 
     public void executeInterruptableTask(final Runnable runnable) {

--- a/src/main/java/org/jabref/JabRefExecutorService.java
+++ b/src/main/java/org/jabref/JabRefExecutorService.java
@@ -1,6 +1,7 @@
 package org.jabref;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -92,15 +93,18 @@ public class JabRefExecutorService implements Executor {
         return executorService.submit(command);
     }
     
-    public void executeAll(Collection<? extends Callable<?>> tasks) {
+    public <T> List<Future<T>> executeAll(Collection<Callable<T>> tasks) throws InterruptedException {
         Objects.requireNonNull(tasks);
         
+        List<Future<T>> futures = null; 
         
         try {
-            executorService.invokeAll(tasks);
+            futures =  executorService.invokeAll(tasks);
         } catch (InterruptedException e) {
             LOGGER.debug("Invokation has been interrupted during execution.");
         }
+        Objects.requireNonNull(futures);
+        return futures;
     }
 
     public void executeInterruptableTask(final Runnable runnable) {

--- a/src/main/java/org/jabref/JabRefExecutorService.java
+++ b/src/main/java/org/jabref/JabRefExecutorService.java
@@ -86,7 +86,7 @@ public class JabRefExecutorService implements Executor {
      * @param command The task to execute.
      * @return A Future object that provides the returning value.
      */
-    public <T> Future<T> executeAndReturn(Callable<T> command) {
+    public <T> Future<T> execute(Callable<T> command) {
         Objects.requireNonNull(command);
         return executorService.submit(command);
     }

--- a/src/main/java/org/jabref/JabRefExecutorService.java
+++ b/src/main/java/org/jabref/JabRefExecutorService.java
@@ -44,13 +44,11 @@ public class JabRefExecutorService implements Executor {
     @Override
     public void execute(Runnable command) {
         Objects.requireNonNull(command);
-        
         executorService.execute(command);
     }
 
     public void executeAndWait(Runnable command) {
         Objects.requireNonNull(command);
-
         Future<?> future = executorService.submit(command);
         while (true) {
             try {
@@ -66,7 +64,6 @@ public class JabRefExecutorService implements Executor {
 
     public boolean executeAndWait(Callable<?> command) {
         Objects.requireNonNull(command);
-        
         Future<?> future = executorService.submit(command);
         while (true) {
             try {

--- a/src/main/java/org/jabref/JabRefExecutorService.java
+++ b/src/main/java/org/jabref/JabRefExecutorService.java
@@ -89,7 +89,7 @@ public class JabRefExecutorService implements Executor {
         return executorService.submit(command);
     }
     
-    public <T> List<Future<T>> executeAll(Collection<Callable<T>> tasks) throws InterruptedException {
+    public <T> List<Future<T>> executeAll(Collection<Callable<T>> tasks) {
         Objects.requireNonNull(tasks);
         List<Future<T>> futures = null; 
         try {

--- a/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
+++ b/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
@@ -49,9 +49,8 @@ public class AbbreviateAction extends AbstractWorker {
                 iso);
 
         NamedCompound ce = new NamedCompound(Localization.lang("Abbreviate journal names"));
-        int count = 0;
         Set<Callable<Boolean>> tasks = new HashSet<>();
-        
+
         // Collect all callables to execute in one collection.
         for (BibEntry entry : entries) {
             Callable<Boolean> callable = () -> {
@@ -70,15 +69,17 @@ public class AbbreviateAction extends AbstractWorker {
         List<Future<Boolean>> futures = JabRefExecutorService.INSTANCE.executeAll(tasks);
 
         // Evaluate the results of the callables.
-        for (Future<Boolean> future : futures) {
+        long count = futures.stream().filter(f -> {
+            boolean result;
             try {
-                if (future.get()) {
-                    count++;
-                }
+                result = f.get();
             } catch (InterruptedException | ExecutionException e) {
-                LOGGER.debug("Unable to retrieve return value.");
+                LOGGER.debug("Invokation has been interrupted during execution.");
+            } finally {
+                result = false;
             }
-        }
+            return result;
+        }).count();
 
         if (count > 0) {
             ce.end();

--- a/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
+++ b/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
@@ -15,6 +15,7 @@ import org.jabref.gui.worker.AbstractWorker;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.InternalBibtexFields;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
+++ b/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
@@ -69,16 +69,13 @@ public class AbbreviateAction extends AbstractWorker {
         List<Future<Boolean>> futures = JabRefExecutorService.INSTANCE.executeAll(tasks);
 
         // Evaluate the results of the callables.
-        long count = futures.stream().filter(f -> {
-            boolean result;
+        long count = futures.stream().filter(future -> {
             try {
-                result = f.get();
-            } catch (InterruptedException | ExecutionException e) {
-                LOGGER.debug("Invokation has been interrupted during execution.");
-            } finally {
-                result = false;
+                return future.get();
+            } catch (InterruptedException | ExecutionException exception) {
+                LOGGER.error("Unable to retrieve value.", exception);
+                return false;
             }
-            return result;
         }).count();
 
         if (count > 0) {

--- a/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
+++ b/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
@@ -15,6 +15,8 @@ import org.jabref.gui.worker.AbstractWorker;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.InternalBibtexFields;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Converts journal full names to either iso or medline abbreviations for all
@@ -25,6 +27,8 @@ public class AbbreviateAction extends AbstractWorker {
     private final BasePanel panel;
     private String message = "";
     private final boolean iso;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbbreviateAction.class);
 
     public AbbreviateAction(BasePanel panel, boolean iso) {
         this.panel = panel;
@@ -57,18 +61,18 @@ public class AbbreviateAction extends AbstractWorker {
 
                 return false;
             };
-            
+
             Future<Boolean> result = JabRefExecutorService.INSTANCE.executeAndReturn(callable);
             futures.add(result);
         }
-        
+
         for (Future<Boolean> future : futures) {
             try {
-                if(future.get()) {
+                if (future.get()) {
                     count++;
                 }
             } catch (InterruptedException | ExecutionException e) {
-                // Do nothing.
+                LOGGER.debug("Unable to retrieve return value.");
             }
         }
 

--- a/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
+++ b/src/main/java/org/jabref/gui/journals/AbbreviateAction.java
@@ -24,11 +24,10 @@ import org.slf4j.LoggerFactory;
  */
 public class AbbreviateAction extends AbstractWorker {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbbreviateAction.class);
     private final BasePanel panel;
     private String message = "";
     private final boolean iso;
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbbreviateAction.class);
 
     public AbbreviateAction(BasePanel panel, boolean iso) {
         this.panel = panel;
@@ -43,7 +42,6 @@ public class AbbreviateAction extends AbstractWorker {
     @Override
     public void run() {
         List<BibEntry> entries = panel.getSelectedEntries();
-
         UndoableAbbreviator undoableAbbreviator = new UndoableAbbreviator(
                 Globals.journalAbbreviationLoader.getRepository(Globals.prefs.getJournalAbbreviationPreferences()),
                 iso);
@@ -59,7 +57,6 @@ public class AbbreviateAction extends AbstractWorker {
                         return true;
                     }
                 }
-
                 return false;
             };
             tasks.add(callable);


### PR DESCRIPTION
Fixes #2831 

Added new method _executeAndReturn_ to the JabRefExecutorService that allows to run callables that return a value when the computation is completed. Using this method the abbreviations in _AbbreviateAction.java_ should run parallel now.

----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
