### PR TITLE
Improve performance for managing journal abbreviations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The new default removes the linked file from the entry instead of deleting the f
 - We added a new cleanup operation that replaces ligatures with their expanded form. [#3613](https://github.com/JabRef/jabref/issues/3613)
 
 ### Fixed
+- We fixed several performance problems with the management of journal abbreviations [#3323](https://github.com/JabRef/jabref/issues/3323)
 - We fixed an issue where changing the type of an entry did not update the label in the tool bar of the entry editor and the contents of the currently visible entry editor tab
 - We fixed an issue where pressing space caused the cursor to jump to the start of the text field. [#3471](https://github.com/JabRef/jabref/issues/3471)
 - We fixed the missing dot in the name of an exported file. [#3576](https://github.com/JabRef/jabref/issues/3576)

--- a/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviationsViewModel.java
+++ b/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviationsViewModel.java
@@ -350,8 +350,9 @@ public class ManageJournalAbbreviationsViewModel extends AbstractViewModel {
      * {@link JournalAbbreviationLoader#update(JournalAbbreviationPreferences)}.
      */
     public void saveEverythingAndUpdateAutoCompleter() {
+        saveExternalFilesList();
+
         if (shouldWriteLists) {
-            saveExternalFilesList();
             saveJournalAbbreviationFiles();
             shouldWriteLists = false;
         }

--- a/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviationsViewModel.java
+++ b/src/main/java/org/jabref/gui/journals/ManageJournalAbbreviationsViewModel.java
@@ -54,6 +54,7 @@ public class ManageJournalAbbreviationsViewModel extends AbstractViewModel {
     private final TaskExecutor taskExecutor;
     private final JournalAbbreviationPreferences abbreviationsPreferences;
     private final JournalAbbreviationLoader journalAbbreviationLoader;
+    private boolean shouldWriteLists = false;
 
     public ManageJournalAbbreviationsViewModel(PreferencesService preferences, DialogService dialogService, TaskExecutor taskExecutor, JournalAbbreviationLoader journalAbbreviationLoader) {
         this.preferences = Objects.requireNonNull(preferences);
@@ -234,6 +235,7 @@ public class ManageJournalAbbreviationsViewModel extends AbstractViewModel {
         } else {
             abbreviations.add(abbreviationViewModel);
             currentAbbreviation.set(abbreviationViewModel);
+            shouldWriteLists = true;
         }
     }
 
@@ -274,6 +276,7 @@ public class ManageJournalAbbreviationsViewModel extends AbstractViewModel {
         }
         currentAbbreviation.get().setName(name);
         currentAbbreviation.get().setAbbreviation(abbreviation);
+        shouldWriteLists = true;
     }
 
     /**
@@ -294,6 +297,7 @@ public class ManageJournalAbbreviationsViewModel extends AbstractViewModel {
                     currentAbbreviation.set(null);
                 }
                 abbreviations.remove(index);
+                shouldWriteLists = true;
             }
         }
     }
@@ -346,8 +350,11 @@ public class ManageJournalAbbreviationsViewModel extends AbstractViewModel {
      * {@link JournalAbbreviationLoader#update(JournalAbbreviationPreferences)}.
      */
     public void saveEverythingAndUpdateAutoCompleter() {
-        saveExternalFilesList();
-        saveJournalAbbreviationFiles();
+        if (shouldWriteLists) {
+            saveExternalFilesList();
+            saveJournalAbbreviationFiles();
+            shouldWriteLists = false;
+        }
 
         // Update journal abbreviation loader
         journalAbbreviationLoader.update(abbreviationsPreferences);

--- a/src/main/java/org/jabref/logic/journals/JournalAbbreviationRepository.java
+++ b/src/main/java/org/jabref/logic/journals/JournalAbbreviationRepository.java
@@ -60,11 +60,11 @@ public class JournalAbbreviationRepository {
     public void addEntry(Abbreviation abbreviation) {
         Objects.requireNonNull(abbreviation);
 
+        // Abbreviation equality is tested on name only, so we might have to remove an old abbreviation
         if (abbreviations.contains(abbreviation)) {
-            Abbreviation previous = getAbbreviation(abbreviation.getName()).get();
-            abbreviations.remove(previous);
+            abbreviations.remove(abbreviation);
             LOGGER.info("Duplicate journal abbreviation - old one will be overwritten by new one\nOLD: "
-                    + previous + "\nNEW: " + abbreviation);
+                    + abbreviation + "\nNEW: " + abbreviation);
         }
 
         abbreviations.add(abbreviation);

--- a/src/main/java/org/jabref/logic/journals/JournalAbbreviationRepository.java
+++ b/src/main/java/org/jabref/logic/journals/JournalAbbreviationRepository.java
@@ -63,8 +63,6 @@ public class JournalAbbreviationRepository {
         // Abbreviation equality is tested on name only, so we might have to remove an old abbreviation
         if (abbreviations.contains(abbreviation)) {
             abbreviations.remove(abbreviation);
-            LOGGER.info("Duplicate journal abbreviation - old one will be overwritten by new one\nOLD: "
-                    + abbreviation + "\nNEW: " + abbreviation);
         }
 
         abbreviations.add(abbreviation);


### PR DESCRIPTION
Fixes #3323

I was actually surprised to find that no one attacked the issue so far. These were really just a few minor changes. Ultimately, the `Abbreviation` class is still flawed, because it violates the equals contract and we use it in a `Set`. That's why the code might look strange. Nevertheless, it is the fix suggested in the issue. 

----

- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
