### PR TITLE
[WIP] Added Select all and Deselect all buttons to the "Review changes" dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For more details refer to the [field mapping help page](http://help.jabref.org/e
 - We improved file saving so that hard links are now preserved when a save is performed [#2633](https://github.com/JabRef/jabref/issues/2633)
 - We changed the default dialog option when removing a [file link](http://help.jabref.org/en/FileLinks#adding-external-links-to-an-entry) from an entry.
 The new default removes the linked file from the entry instead of deleting the file from disk. [#3679](https://github.com/JabRef/jabref/issues/3679)
+- Added a "Select all" [#280](https://github.com/koppor/jabref/issues/280) and "Deselect all" button in the "Review changes" dialog.
 
 ### Fixed
 - We fixed an issue where pressing space caused the cursor to jump to the start of the text field. [#3471](https://github.com/JabRef/jabref/issues/3471)

--- a/src/main/java/org/jabref/gui/collab/ChangeDisplayDialog.java
+++ b/src/main/java/org/jabref/gui/collab/ChangeDisplayDialog.java
@@ -1,7 +1,10 @@
 package org.jabref.gui.collab;
 
 import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
 import java.awt.Insets;
+import java.awt.event.ActionListener;
 import java.util.Collections;
 import java.util.Enumeration;
 
@@ -50,8 +53,36 @@ class ChangeDisplayDialog extends JabRefDialog implements TreeSelectionListener 
         tree = new JTree(root);
         tree.addTreeSelectionListener(this);
 
+        //start fix issue 280
+        this.setMinimumSize(new Dimension(400, 400));
+        JPanel treePanel = new JPanel(new BorderLayout());
+        JPanel buttonAlignment = new JPanel(new FlowLayout(FlowLayout.LEADING));
+        treePanel.add(tree, BorderLayout.CENTER);
+        JButton selectAll = new JButton(Localization.lang("Select all"));
+        JButton deselectAll = new JButton(Localization.lang("Deselect all"));
+        ActionListener selectEvent = (event) -> {
+            boolean accept = event.getSource() == selectAll;
+            Enumeration<? extends Object> nodes = root.preorderEnumeration();
+            while (nodes.hasMoreElements()) {
+                Object o = nodes.nextElement();
+                if ((o instanceof ChangeViewModel) && (o != root)) {
+                    ((ChangeViewModel) o).setAccepted(accept);
+                }
+            }
+            cb.setSelected(accept);
+            if (selected != null) {
+                cb.setEnabled(selected.isAcceptable());
+            }
+        };
+        selectAll.addActionListener(selectEvent);
+        deselectAll.addActionListener(selectEvent);
+        buttonAlignment.add(selectAll);
+        buttonAlignment.add(deselectAll);
+        treePanel.add(buttonAlignment, BorderLayout.SOUTH);
+        //end fix issue 280
+
         JSplitPane pane = new JSplitPane();
-        pane.setLeftComponent(new JScrollPane(tree));
+        pane.setLeftComponent(new JScrollPane(treePanel)); //fix issue 280 change: tree -> treePanel
         JPanel infoBorder = new JPanel();
         pane.setRightComponent(infoBorder);
 


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
Added "Select all" and "Deselect all" buttons to the "Review changes" dialog. The "Select all" button is the fix for https://github.com/koppor/jabref/issues/280 made by janek greif. The "Deselect all" button is an addition to that issue.

----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
