### PR TITLE
[WIP] Add Accept All Changes to External Changes Dialog 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The new default removes the linked file from the entry instead of deleting the f
 - The group editing window can now also be called by double-clicking the group to be edited. [koppor#277](https://github.com/koppor/jabref/issues/277)
 - The magnifier icon at the search shows the [search mode](https://help.jabref.org/en/Search#search-modes) again. [#3535](https://github.com/JabRef/jabref/issues/3535)
 - We added a new cleanup operation that replaces ligatures with their expanded form. [#3613](https://github.com/JabRef/jabref/issues/3613)
++- Added a "Select all" [#280](https://github.com/koppor/jabref/issues/280) in the"Review changes" dialog.
 
 ### Fixed
 - We fixed an issue where pressing space caused the cursor to jump to the start of the text field. [#3471](https://github.com/JabRef/jabref/issues/3471)

--- a/src/main/java/org/jabref/gui/collab/ChangeDisplayDialog.java
+++ b/src/main/java/org/jabref/gui/collab/ChangeDisplayDialog.java
@@ -30,6 +30,7 @@ class ChangeDisplayDialog extends JabRefDialog implements TreeSelectionListener 
     private final JTree tree;
     private final JPanel infoPanel = new JPanel();
     private final JCheckBox cb = new JCheckBox(Localization.lang("Accept change"));
+    private final JCheckBox cb2 = new JCheckBox(Localization.lang("Accept all change"));
     private final JLabel rootInfo = new JLabel(Localization.lang("Select the tree nodes to view and accept or reject changes") + '.');
     private ChangeViewModel selected;
     private JComponent infoShown;
@@ -57,12 +58,14 @@ class ChangeDisplayDialog extends JabRefDialog implements TreeSelectionListener 
 
         cb.setMargin(new Insets(2, 2, 2, 2));
         cb.setEnabled(false);
+        cb2.setMargin(new Insets(4, 4, 4, 4));
+        cb2.setEnabled(false);
         infoPanel.setLayout(new BorderLayout());
         infoBorder.setLayout(new BorderLayout());
         infoBorder.setBorder(BorderFactory.createEtchedBorder());
         infoBorder.add(infoPanel, BorderLayout.CENTER);
         setInfo(rootInfo);
-        infoPanel.add(cb, BorderLayout.SOUTH);
+        infoPanel.add(cb, cb2, BorderLayout.SOUTH);
 
         JButton ok = new JButton(Localization.lang("OK"));
         JPanel buttonPanel = new JPanel();
@@ -78,6 +81,12 @@ class ChangeDisplayDialog extends JabRefDialog implements TreeSelectionListener 
                 selected.setAccepted(cb.isSelected());
             }
         });
+        cb2.addChangeListener(e -> {
+        	if ( selected != null) {
+        		selected.setAccepted(cb2.isSelected());
+        		cb.setEnabled(true);
+        	}
+        })
 
         cancel.addActionListener(e -> dispose());
 

--- a/src/main/java/org/jabref/gui/collab/ChangeDisplayDialog.java
+++ b/src/main/java/org/jabref/gui/collab/ChangeDisplayDialog.java
@@ -30,7 +30,7 @@ class ChangeDisplayDialog extends JabRefDialog implements TreeSelectionListener 
     private final JTree tree;
     private final JPanel infoPanel = new JPanel();
     private final JCheckBox cb = new JCheckBox(Localization.lang("Accept change"));
-    private final JCheckBox cb2 = new JCheckBox(Localization.lang("Accept all change"));
+    private final JCheckBox cb2 = new JCheckBox(Localization.lang("Accept all changes"));
     private final JLabel rootInfo = new JLabel(Localization.lang("Select the tree nodes to view and accept or reject changes") + '.');
     private ChangeViewModel selected;
     private JComponent infoShown;


### PR DESCRIPTION
 Fix for issue https://github.com/koppor/jabref/issues/280

Added a new ChoiceBox "Accept all changes" to the JabRefChangeDisplay that allows to select all the change and modify the status of the ChoiceBox from false to true so that all the cb now are selected when the computation is completed.

<!-- describe the changes you have made here: what, why, ... -->


----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
