### PR TITLE
[WIP] Fix author parsing with ands 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Brian Quistorff
 Brian Van Essen
 captain123
 Carlos Silla
+cerrisantos
 Christian Bartsch
 Christian Kopf
 Christoph Braun
@@ -89,6 +90,7 @@ Jeff Kerr
 Jeff Miller
 Jeffrey Kuhn
 Jens Döcke
+Joerg Lenhard
 Johannes Manner
 John David
 John Relph
@@ -138,6 +140,7 @@ Michael Spiegel
 Michael Wrighton
 Michel Baylac
 Mike Smoot
+Mohamad Altaweel
 Moritz Ringler
 Morten Alver
 Mélanie Tremblay
@@ -163,6 +166,7 @@ Predrag Milanovic
 Raik Nagel
 Renato Massao
 Richard Schneeman
+Robert
 Robert Jäschke
 Rolf Starre
 Rudolf Seemann
@@ -190,6 +194,7 @@ Stephan Lau
 Stephan Rave
 Stéphane Curet
 Sven Jäger
+Tarix
 The Gitter Badger
 Thiago Toledo
 Thomas Arildsen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ## [Unreleased]
 
 ### Changed
-- Changed Authorlist Format method to a new Method Last,First and Last,First. [#294]
- (https://github.com/koppor/jabref/issues/294)
 - Changed ID-based entry generator to store the last used fetcher. [#2796] (https://github.com/JabRef/jabref/issues/2796)
 - Reorganised annotation information on the right side of the "File annotations" tab. [#3109](https://github.com/JabRef/jabref/issues/3109)
 - We now show a small notification icon in the entry editor when we detect data inconsistency or other problems. [#3145](https://github.com/JabRef/jabref/issues/3145)
@@ -31,6 +29,8 @@ For more details refer to the [field mapping help page](http://help.jabref.org/e
 The new default removes the linked file from the entry instead of deleting the file from disk. [#3679](https://github.com/JabRef/jabref/issues/3679)
 
 ### Fixed
+- Fixed three commans and one and issue [#294]
+ (https://github.com/koppor/jabref/issues/294)
 - We fixed an issue where pressing space caused the cursor to jump to the start of the text field. [#3471](https://github.com/JabRef/jabref/issues/3471)
 - We fixed the missing dot in the name of an exported file. [#3576](https://github.com/JabRef/jabref/issues/3576)
 - Autocompletion in the search bar can now be disabled via the preferences. [#3598](https://github.com/JabRef/jabref/issues/3598)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ## [Unreleased]
 
 ### Changed
+- Changed Authorlist Format method to a new Method Last,First and Last,First. [#294]
+ (https://github.com/koppor/jabref/issues/294)
 - Changed ID-based entry generator to store the last used fetcher. [#2796] (https://github.com/JabRef/jabref/issues/2796)
 - Reorganised annotation information on the right side of the "File annotations" tab. [#3109](https://github.com/JabRef/jabref/issues/3109)
 - We now show a small notification icon in the entry editor when we detect data inconsistency or other problems. [#3145](https://github.com/JabRef/jabref/issues/3145)

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatter.java
@@ -24,7 +24,7 @@ public class NormalizeNamesFormatter implements Formatter {
     @Override
     public String format(String nameList) {
         Objects.requireNonNull(nameList);
-        nameList.replaceAll(" and", ",");
+        nameList = nameList.replaceAll(" and", ",");
         AuthorList authorList = AuthorList.parse(nameList);
         return authorList.getAsLastFirstNamesWithAnd(false);
     }

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatter.java
@@ -24,7 +24,7 @@ public class NormalizeNamesFormatter implements Formatter {
     @Override
     public String format(String nameList) {
         Objects.requireNonNull(nameList);
-        nameList = nameList.replaceAll(" and", ",");
+
         AuthorList authorList = AuthorList.parse(nameList);
         return authorList.getAsLastFirstNamesWithAnd(false);
     }

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/NormalizeNamesFormatter.java
@@ -24,6 +24,7 @@ public class NormalizeNamesFormatter implements Formatter {
     @Override
     public String format(String nameList) {
         Objects.requireNonNull(nameList);
+        nameList.replaceAll(" and", ",");
         AuthorList authorList = AuthorList.parse(nameList);
         return authorList.getAsLastFirstNamesWithAnd(false);
     }

--- a/src/main/java/org/jabref/logic/layout/format/AuthorAbbreviator.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorAbbreviator.java
@@ -20,6 +20,6 @@ public class AuthorAbbreviator implements LayoutFormatter {
     @Override
     public String format(String fieldText) {
         AuthorList list = AuthorList.parse(fieldText);
-        return list.getAsLastFirstNamesWithAnd(true);
+        return list.getAsLastFirstLastFirstWithAnd(true);
     }
 }

--- a/src/main/java/org/jabref/logic/layout/format/AuthorAbbreviator.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorAbbreviator.java
@@ -20,6 +20,6 @@ public class AuthorAbbreviator implements LayoutFormatter {
     @Override
     public String format(String fieldText) {
         AuthorList list = AuthorList.parse(fieldText);
-        return list.getAsLastFirstLastFirstWithAnd(true);
+        return list.getAsLastFirstNamesWithAnd(true);
     }
 }

--- a/src/main/java/org/jabref/model/entry/AuthorList.java
+++ b/src/main/java/org/jabref/model/entry/AuthorList.java
@@ -166,7 +166,7 @@ public class AuthorList {
      */
     public static AuthorList parse(String authors) {
         Objects.requireNonNull(authors);
-
+        authors = authors.replaceAll(" and", ",");
         // Handle case names in order lastname, firstname and separated by ","
         // E.g., Ali Babar, M., Dingsøyr, T., Lago, P., van der Vliet, H.
         final boolean authorsContainAND = authors.toUpperCase(Locale.ENGLISH).contains(" AND ");

--- a/src/main/java/org/jabref/model/entry/AuthorList.java
+++ b/src/main/java/org/jabref/model/entry/AuthorList.java
@@ -129,7 +129,7 @@ public class AuthorList {
     private final String[] authorLastFirstAnds = new String[2];
     private final String[] authorsLastFirst = new String[4];
     private final String[] authorsLastFirstFirstLast = new String[2];
-    private final String[] authorsLastFirstLastFirst = new String[2];
+
 
     // Variables for storing computed strings, so they only need to be created once:
     private String authorsNatbib;
@@ -538,44 +538,10 @@ public class AuthorList {
             }
         }
 
-        authorsLastFirstLastFirst[abbrInt] = result.toString();
-        return authorsLastFirstLastFirst[abbrInt];
+        authorsLastFirstFirstLast[abbrInt] = result.toString();
+        return authorsLastFirstFirstLast[abbrInt];
     }
 
-    /**
-     * Returns the list of authors separated by commas with last names before
-     * first name; first names are abbreviated or not depending on parameter. If
-     * the list consists of three or more authors, "and" is inserted before the
-     * first author's name.
-     * <p>
-     * <ul>
-     * <li>"John Smith , Peter Black brown" ==> "Smith,John and  Black
-     * Brown,Peter"</li>
-     * </ul>
-     *
-     * @param abbreviate first names
-     * @return formatted list of authors.
-     */
-    public String getAsLastFirstLastFirstWithAnd(boolean abbreviate) {
-        int abbrInt = abbreviate ? 0 : 1;
-        // Check if we've computed this before:
-        if (authorsLastFirstLastFirst[abbrInt] != null) {
-            return authorsLastFirstLastFirst[abbrInt];
-        }
-
-        StringBuilder result = new StringBuilder();
-        if (!isEmpty()) {
-            result.append(getAuthor(0).getLastFirst(abbreviate));
-            for (int i = 1; i < getNumberOfAuthors(); i++) {
-                result.append(" and ");
-                result.append(getAuthor(i).getLastFirst(abbreviate));
-            }
-        }
-
-        authorsLastFirstLastFirst[abbrInt] = result.toString();
-        return authorsLastFirstLastFirst[abbrInt];
-
-    }
 
     /**
      * Returns the list of authors separated by commas with first names before

--- a/src/main/java/org/jabref/model/entry/AuthorList.java
+++ b/src/main/java/org/jabref/model/entry/AuthorList.java
@@ -128,7 +128,9 @@ public class AuthorList {
     private final String[] authorsLastOnly = new String[2];
     private final String[] authorLastFirstAnds = new String[2];
     private final String[] authorsLastFirst = new String[4];
-    private final String[] authorsLastFirstFirstLast = new String[2];
+    private final String[] authorsLastFirstLastFirst = new String[2];
+    private final String[] authorsLastFirstLastFirst = new String[2];
+
     // Variables for storing computed strings, so they only need to be created once:
     private String authorsNatbib;
     private String authorsFirstFirstAnds;
@@ -523,8 +525,8 @@ public class AuthorList {
     public String getAsLastFirstFirstLastNamesWithAnd(boolean abbreviate) {
         int abbrInt = abbreviate ? 0 : 1;
         // Check if we've computed this before:
-        if (authorsLastFirstFirstLast[abbrInt] != null) {
-            return authorsLastFirstFirstLast[abbrInt];
+        if (authorsLastFirstLastFirst[abbrInt] != null) {
+            return authorsLastFirstLastFirst[abbrInt];
         }
 
         StringBuilder result = new StringBuilder();
@@ -536,8 +538,43 @@ public class AuthorList {
             }
         }
 
-        authorsLastFirstFirstLast[abbrInt] = result.toString();
-        return authorsLastFirstFirstLast[abbrInt];
+        authorsLastFirstLastFirst[abbrInt] = result.toString();
+        return authorsLastFirstLastFirst[abbrInt];
+    }
+
+    /**
+     * Returns the list of authors separated by commas with last names before
+     * first name; first names are abbreviated or not depending on parameter. If
+     * the list consists of three or more authors, "and" is inserted before the
+     * first author's name.
+     * <p>
+     * <ul>
+     * <li>"John Smith , Peter Black brown" ==> "Smith,John and  Black
+     * Brown,Peter"</li>
+     * </ul>
+     *
+     * @param abbreviate first names
+     * @return formatted list of authors.
+     */
+    public String getAsLastFirstLastFirstWithAnd(boolean abbreviate) {
+        int abbrInt = abbreviate ? 0 : 1;
+        // Check if we've computed this before:
+        if (authorsLastFirstLastFirst[abbrInt] != null) {
+            return authorsLastFirstLastFirst[abbrInt];
+        }
+
+        StringBuilder result = new StringBuilder();
+        if (!isEmpty()) {
+            result.append(getAuthor(0).getLastFirst(abbreviate));
+            for (int i = 1; i < getNumberOfAuthors(); i++) {
+                result.append(" and ");
+                result.append(getAuthor(i).getLastFirst(abbreviate));
+            }
+        }
+
+        authorsLastFirstLastFirst[abbrInt] = result.toString();
+        return authorsLastFirstLastFirst[abbrInt];
+
     }
 
     /**

--- a/src/main/java/org/jabref/model/entry/AuthorList.java
+++ b/src/main/java/org/jabref/model/entry/AuthorList.java
@@ -128,7 +128,7 @@ public class AuthorList {
     private final String[] authorsLastOnly = new String[2];
     private final String[] authorLastFirstAnds = new String[2];
     private final String[] authorsLastFirst = new String[4];
-    private final String[] authorsLastFirstLastFirst = new String[2];
+    private final String[] authorsLastFirstFirstLast = new String[2];
     private final String[] authorsLastFirstLastFirst = new String[2];
 
     // Variables for storing computed strings, so they only need to be created once:
@@ -525,8 +525,8 @@ public class AuthorList {
     public String getAsLastFirstFirstLastNamesWithAnd(boolean abbreviate) {
         int abbrInt = abbreviate ? 0 : 1;
         // Check if we've computed this before:
-        if (authorsLastFirstLastFirst[abbrInt] != null) {
-            return authorsLastFirstLastFirst[abbrInt];
+        if (authorsLastFirstFirstLast[abbrInt] != null) {
+            return authorsLastFirstFirstLast[abbrInt];
         }
 
         StringBuilder result = new StringBuilder();

--- a/src/test/java/org/jabref/logic/layout/format/AuthorAbbreviatorTest.java
+++ b/src/test/java/org/jabref/logic/layout/format/AuthorAbbreviatorTest.java
@@ -21,6 +21,11 @@ public class AuthorAbbreviatorTest {
         assertEquals(b.format("Smith, John"), a.format("Smith, John"));
         assertEquals(b.format("von Neumann, John and Smith, John and Black Brown, Peter"), a
                 .format("von Neumann, John and Smith, John and Black Brown, Peter"));
+        assertEquals(b.format("Maier, Florian and Wohlfrom,"
+                + " Andreas and Koetter, Falko and Merkel-Malkowskiy, "
+                + "Sabrina and Zech, Daniel"), a.format(
+                        "Maier, Florian and Wohlfrom, Andreas and Koetter, "
+                                + "Falko and Merkel-Malkowskiy, Sabrina and Zech, Daniel"));
 
     }
 


### PR DESCRIPTION

Fixes https://github.com/koppor/jabref/issues/294
<!-- describe the changes you have made here: what, why, ... -->
I think that the issue is not with the junior suffix. 
first I tried to implement a new method but it didn't make any sense
I have tested inputs examples in the form fName lName,fName lName,fName lName,fName lName.....
so the problem is always with the "and" that comes before the Last author's name
before normalizing i added replaceAll method that replaces all and sepertaing between two names with a comma to get to my tested case and then normalizing it...

----

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [x] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
