### PR TITLE
method to convert german months (fix for issue 3536)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The new default removes the linked file from the entry instead of deleting the f
 - The group editing window can now also be called by double-clicking the group to be edited. [koppor#277](https://github.com/koppor/jabref/issues/277)
 - The magnifier icon at the search shows the [search mode](https://help.jabref.org/en/Search#search-modes) again. [#3535](https://github.com/JabRef/jabref/issues/3535)
 - We added a new cleanup operation that replaces ligatures with their expanded form. [#3613](https://github.com/JabRef/jabref/issues/3613)
+- Added a new method that can convert from a german month to the corresponding english month. [#3536](https://github.com/JabRef/jabref/pull/3536)
 
 ### Fixed
 - We fixed several performance problems with the management of journal abbreviations [#3323](https://github.com/JabRef/jabref/issues/3323)

--- a/src/main/java/org/jabref/model/entry/Month.java
+++ b/src/main/java/org/jabref/model/entry/Month.java
@@ -22,6 +22,7 @@ public enum Month {
     NOVEMBER("November", "nov", 11),
     DECEMBER("December", "dec", 12);
 
+
     private final String fullName;
     private final String shortName;
     private final String twoDigitNumber;
@@ -128,7 +129,7 @@ public enum Month {
     }
 
     /**
-     * Returns the name of the long in unabbreviated english.
+   forking a repositroy  * Returns the name of the long in unabbreviated english.
      * @return Month
      */
     public String getFullName() {
@@ -141,5 +142,34 @@ public enum Month {
      */
     public String getTwoDigitNumber() {
         return twoDigitNumber;
+    }
+    /**
+    *converts a german month to an english month. Accepts either the short form such as "jan" or the long form such as "januar". 
+    *accepts both lower and upper case
+    *@return the correct month in english short name, if a german month was entered correctly, returns empty if no german month was entered
+    */
+    private static Optional<Month> convertGermanMonth(String name) {
+        
+        if ("jan".equalsIgnoreCase(name)||"januar".equalsIgnoreCase(name)) {
+            return getMonthByShortName("jan");
+        } else if ("feb".equalsIgnoreCase(name)||"februar".equalsIgnoreCase(name)) {
+            return getMonthByShortName("feb");
+        } else if ("mae".equalsIgnoreCase(name)||"mär".equalsIgnoreCase(name)||"märz".equalsIgnoreCase(name)||"maerz".equalsIgnoreCase(name)){
+            return getMonthByShortName("mar");
+        } else if ("apr".equalsIgnoreCase(name)||"april".equalsIgnoreCase(name)) {
+            return getMonthByShortName("apr");
+        } else if ("mai".equalsIgnoreCase(name)) {
+            return getMonthByShortName("may");
+        } else if ("jun".equalsIgnoreCase(name)||"juni".equalsIgnoreCase(name)) {
+            return getMonthByShortName("jun");
+        } else if ("jul".equalsIgnoreCase(name)||"juli".equalsIgnoreCase(name)) {
+            return getMonthByShortName("jul");
+        } else if ("okt".equalsIgnoreCase(name)||"oktober".equalsIgnoreCase(name)) {
+            return getMonthByShortName("oct");
+        } else if ("dez".equalsIgnoreCase(name)||"dezember".equalsIgnoreCase(name)) {
+            return getMonthByShortName("dec");
+        } else {
+            return Optional.empty();
+        }
     }
 }

--- a/src/main/java/org/jabref/model/entry/Month.java
+++ b/src/main/java/org/jabref/model/entry/Month.java
@@ -147,6 +147,7 @@ public enum Month {
     *converts a german month to an english month. Accepts either the short form such as "jan" or the long form such as "januar". 
     *accepts both lower and upper case
     *@return the correct month in english short name, if a german month was entered correctly, returns empty if no german month was entered
+    *@author schmidja
     */
     private static Optional<Month> convertGermanMonth(String name) {
         


### PR DESCRIPTION
I added a method that can convert a german month to an english one by entering either the short or long form (lower and upper case both work).
This was an attempt to solve issue #3536.


----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [ ] Manually tested changed features in running JabRef
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
