### PR TITLE
Add link to contribute.jabref.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ An explanation of donation possibilities and usage of donations is available at 
 [![Join the chat at https://gitter.im/JabRef/jabref](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/JabRef/jabref?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![OpenHub](https://www.openhub.net/p/jabref/widgets/project_thin_badge.gif)](https://www.openhub.net/p/jabref)
 
-> Not a programmer? [We also need help at other things](http://contribute.jabref.org).
+> Not a programmer? [Learn how to help.](http://contribute.jabref.org)
 
 Want to be part of a free and open-source project that tens of thousands scientist use every day?
 Check out our [issue tracker](https://github.com/JabRef/jabref/issues) to find something to work on.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ An explanation of donation possibilities and usage of donations is available at 
 [![Join the chat at https://gitter.im/JabRef/jabref](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/JabRef/jabref?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![OpenHub](https://www.openhub.net/p/jabref/widgets/project_thin_badge.gif)](https://www.openhub.net/p/jabref)
 
+> Not a programmer? Check other ways of contributing at <http://contribute.jabref.org>
+
 Want to be part of a free and open-source project that tens of thousands scientist use every day?
 Check out our [issue tracker](https://github.com/JabRef/jabref/issues) to find something to work on.
 You are also welcome to contribute new features.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ An explanation of donation possibilities and usage of donations is available at 
 [![Join the chat at https://gitter.im/JabRef/jabref](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/JabRef/jabref?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![OpenHub](https://www.openhub.net/p/jabref/widgets/project_thin_badge.gif)](https://www.openhub.net/p/jabref)
 
-> Not a programmer? Check other ways of contributing at <http://contribute.jabref.org>
+> Not a programmer? [We also need help at other things](http://contribute.jabref.org).
 
 Want to be part of a free and open-source project that tens of thousands scientist use every day?
 Check out our [issue tracker](https://github.com/JabRef/jabref/issues) to find something to work on.


### PR DESCRIPTION
I am not sure about a good way to link http://contribute.jabref.org. WDYT?