### PR TITLE
Update Architecture Tests to catch static imports

### DIFF
--- a/src/test/java/org/jabref/architecture/MainArchitectureTests.java
+++ b/src/test/java/org/jabref/architecture/MainArchitectureTests.java
@@ -14,11 +14,12 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MainArchitectureTests {
 
@@ -105,7 +106,7 @@ public class MainArchitectureTests {
                     })
                     .collect(Collectors.toList());
 
-            Assertions.assertEquals(Collections.emptyList(), files, "The following classes are not allowed to depend on " + secondPackage);
+            assertEquals(Collections.emptyList(), files, "The following classes are not allowed to depend on " + secondPackage);
         }
     }
 }

--- a/src/test/java/org/jabref/architecture/MainArchitectureTests.java
+++ b/src/test/java/org/jabref/architecture/MainArchitectureTests.java
@@ -14,7 +14,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -78,7 +78,8 @@ public class MainArchitectureTests {
     @ParameterizedTest(name = "{index} -- is {0} independent of {1}?")
     @MethodSource("getPackages")
     public void firstPackageIsIndependentOfSecondPackage(String firstPackage, String secondPackage) throws IOException {
-        Predicate<String> isExceptionPackage = (s) -> s.startsWith("import " + secondPackage)
+        Predicate<String> isExceptionPackage = (s) -> (s.startsWith("import " + secondPackage)
+                || s.startsWith("import static " + secondPackage))
                 && exceptions.getOrDefault(firstPackage, Collections.emptyList())
                         .stream()
                         .noneMatch(exception -> s.startsWith("import " + exception));
@@ -104,8 +105,7 @@ public class MainArchitectureTests {
                     })
                     .collect(Collectors.toList());
 
-            Assert.assertEquals("The following classes are not allowed to depend on " + secondPackage,
-                    Collections.emptyList(), files);
+            Assertions.assertEquals(Collections.emptyList(), files, "The following classes are not allowed to depend on " + secondPackage);
         }
     }
 }


### PR DESCRIPTION
Fixes a part of #2617

Updates the architecture tests to JUnit5 and also catches violations in static imports now. I tested this by adding a static import and checking that the build breaks. It does, but of course I had to remove the cause again.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
