### PR TITLE
Extend toolbar with more icons and add tool tips

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -655,10 +655,9 @@ public class JabRefFrame extends BorderPane implements OutputPrinter {
         HBox rightSide = new HBox (
                 factory.createIconButton(StandardActions.NEW_ENTRY, new NewEntryAction(this, BiblatexEntryTypes.ARTICLE)),
                 factory.createIconButton(StandardActions.DELETE_ENTRY, new EditAction(Actions.DELETE)),
-
-                // TODO: Undo does not work currently, so there is not much point in adding these buttons
-                //factory.createIconButton(StandardActions.UNDO, new OldDatabaseCommandWrapper(Actions.UNDO, this, Globals.stateManager)),
-                //factory.createIconButton(StandardActions.REDO, new OldDatabaseCommandWrapper(Actions.REDO, this, Globals.stateManager)),
+                
+                factory.createIconButton(StandardActions.UNDO, new OldDatabaseCommandWrapper(Actions.UNDO, this, Globals.stateManager)),
+                factory.createIconButton(StandardActions.REDO, new OldDatabaseCommandWrapper(Actions.REDO, this, Globals.stateManager)),
                 factory.createIconButton(StandardActions.CUT, new EditAction(Actions.CUT)),
                 factory.createIconButton(StandardActions.COPY, new EditAction(Actions.COPY)),
                 factory.createIconButton(StandardActions.PASTE, new EditAction(Actions.PASTE)),

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -646,19 +646,42 @@ public class JabRefFrame extends BorderPane implements OutputPrinter {
                 newLibrary,
                 factory.createIconButton(StandardActions.OPEN_LIBRARY, new OpenDatabaseAction(this)),
                 factory.createIconButton(StandardActions.SAVE_LIBRARY, new OldDatabaseCommandWrapper(Actions.SAVE, this, Globals.stateManager)),
-
                 leftSpacer);
         leftSide.minWidthProperty().bind(sidePane.widthProperty());
         leftSide.prefWidthProperty().bind(sidePane.widthProperty());
         leftSide.maxWidthProperty().bind(sidePane.widthProperty());
+
+        PushToApplicationButton pushToExternal = new PushToApplicationButton(this, pushApplications.getApplications());
+        HBox rightSide = new HBox (
+                factory.createIconButton(StandardActions.NEW_ENTRY, new NewEntryAction(this, BiblatexEntryTypes.ARTICLE)),
+                factory.createIconButton(StandardActions.DELETE_ENTRY, new EditAction(Actions.DELETE)),
+
+                // TODO: Undo does not work currently, so there is not much point in adding these buttons
+                //factory.createIconButton(StandardActions.UNDO, new OldDatabaseCommandWrapper(Actions.UNDO, this, Globals.stateManager)),
+                //factory.createIconButton(StandardActions.REDO, new OldDatabaseCommandWrapper(Actions.REDO, this, Globals.stateManager)),
+                factory.createIconButton(StandardActions.CUT, new EditAction(Actions.CUT)),
+                factory.createIconButton(StandardActions.COPY, new EditAction(Actions.COPY)),
+                factory.createIconButton(StandardActions.PASTE, new EditAction(Actions.PASTE)),
+
+                factory.createIconButton(StandardActions.CLEANUP_ENTRIES, new OldDatabaseCommandWrapper(Actions.CLEANUP, this, Globals.stateManager)),
+                factory.createIconButton(pushToExternal.getMenuAction(), pushToExternal),
+
+                factory.createIconButton(StandardActions.FORK_ME, new OpenBrowserAction("https://github.com/JabRef/jabref")),
+                factory.createIconButton(StandardActions.OPEN_FACEBOOK, new OpenBrowserAction("https://www.facebook.com/JabRef/")),
+                factory.createIconButton(StandardActions.OPEN_TWITTER, new OpenBrowserAction("https://twitter.com/jabref_org"))
+
+                );
+        rightSide.minWidthProperty().bind(sidePane.widthProperty());
+        rightSide.prefWidthProperty().bind(sidePane.widthProperty());
+        rightSide.maxWidthProperty().bind(sidePane.widthProperty());
 
         ToolBar toolBar = new ToolBar(
                 leftSide,
 
                 globalSearchBar,
 
-                rightSpacer,
-                factory.createIconButton(StandardActions.NEW_ENTRY, new NewEntryAction(this, BiblatexEntryTypes.ARTICLE)));
+                rightSide
+                );
         toolBar.getStyleClass().add("mainToolbar");
 
         return toolBar;

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -670,15 +670,13 @@ public class JabRefFrame extends BorderPane implements OutputPrinter {
                 factory.createIconButton(StandardActions.OPEN_TWITTER, new OpenBrowserAction("https://twitter.com/jabref_org"))
 
                 );
-        rightSide.minWidthProperty().bind(sidePane.widthProperty());
-        rightSide.prefWidthProperty().bind(sidePane.widthProperty());
-        rightSide.maxWidthProperty().bind(sidePane.widthProperty());
 
         ToolBar toolBar = new ToolBar(
                 leftSide,
 
                 globalSearchBar,
 
+                rightSpacer,
                 rightSide
                 );
         toolBar.getStyleClass().add("mainToolbar");

--- a/src/main/java/org/jabref/gui/actions/ActionFactory.java
+++ b/src/main/java/org/jabref/gui/actions/ActionFactory.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import javafx.scene.control.Button;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.Tooltip;
 
 import org.jabref.gui.keyboard.KeyBindingRepository;
 
@@ -58,6 +59,8 @@ public class ActionFactory {
     public Button createIconButton(Action action, Command command) {
         Button button = ActionUtils.createButton(new JabRefAction(action, command, keyBindingRepository), ActionUtils.ActionTextBehavior.HIDE);
         button.getStyleClass().add("flatButton");
+        Tooltip toolTip = new Tooltip(action.getText());
+        Tooltip.install(button, toolTip);
 
         // For some reason the graphic is not set correctly, so let's fix this
         button.graphicProperty().unbind();

--- a/src/main/java/org/jabref/gui/actions/ActionFactory.java
+++ b/src/main/java/org/jabref/gui/actions/ActionFactory.java
@@ -59,9 +59,8 @@ public class ActionFactory {
     public Button createIconButton(Action action, Command command) {
         Button button = ActionUtils.createButton(new JabRefAction(action, command, keyBindingRepository), ActionUtils.ActionTextBehavior.HIDE);
         button.getStyleClass().add("flatButton");
-        Tooltip toolTip = new Tooltip(action.getText());
-        Tooltip.install(button, toolTip);
-
+        button.setTooltip(new Tooltip(action.getDescription()));
+        
         // For some reason the graphic is not set correctly, so let's fix this
         button.graphicProperty().unbind();
         action.getIcon().ifPresent(icon -> button.setGraphic(icon.getGraphicNode()));


### PR DESCRIPTION
I know this is a controversial topic in the maintable-beta right now, but to get the discussion going a little more and taking inspiration from #3678, I took the liberty to extend the toolbar with more buttons here.

This is really not meant as a final say, it just moves the code in place for some buttons that seem of some value for me. They can be removed again, resorted, and the layout is probably also not perfect.

Here's a screenshot:
![toolbar](https://user-images.githubusercontent.com/1515701/36594431-5af45894-189e-11e8-8b36-53408dee2328.png)

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [X] Manually tested changed features in running JabRef
- [X] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)

