### PR TITLE
Fix delete action and convert confirmation dialog to JavaFX

### DIFF
--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -1562,12 +1562,17 @@ public class BasePanel extends StackPane implements ClipboardOwner {
         if (Globals.prefs.getBoolean(JabRefPreferences.CONFIRM_DELETE)) {
             String title = Localization.lang("Delete entry");
             String message = Localization.lang("Really delete the selected entry?");
+            String okButton = Localization.lang("Delete entry");
+            String cancelButton = Localization.lang("Keep entry");
             if (numberOfEntries > 1) {
                 title = Localization.lang("Delete multiple entries");
                 message = Localization.lang("Really delete the %0 selected entries?", Integer.toString(numberOfEntries));
+                okButton = Localization.lang("Delete entries");
+                cancelButton = Localization.lang("Keep entries");
             }
 
             return dialogService.showConfirmationDialogWithOptOutAndWait(title, message,
+                    okButton, cancelButton,
                     Localization.lang("Disable this confirmation dialog"),
                     optOut -> Globals.prefs.putBoolean(JabRefPreferences.CONFIRM_DELETE, !optOut));
         } else {

--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -349,8 +349,6 @@ public class BasePanel extends StackPane implements ClipboardOwner {
 
         actions.put(Actions.CUT, (BaseAction) mainTable::cut);
 
-        //when you modify this action be sure to adjust Actions.CUT,
-        //they are the same except of the Localization, delete confirmation and Actions.COPY call
         actions.put(Actions.DELETE, (BaseAction) () -> delete(false));
 
         // The action for pasting entries or cell contents.
@@ -1562,22 +1560,16 @@ public class BasePanel extends StackPane implements ClipboardOwner {
 
     public boolean showDeleteConfirmationDialog(int numberOfEntries) {
         if (Globals.prefs.getBoolean(JabRefPreferences.CONFIRM_DELETE)) {
-            String msg;
-            msg = Localization.lang("Really delete the selected entry?");
             String title = Localization.lang("Delete entry");
+            String message = Localization.lang("Really delete the selected entry?");
             if (numberOfEntries > 1) {
-                msg = Localization.lang("Really delete the %0 selected entries?", Integer.toString(numberOfEntries));
                 title = Localization.lang("Delete multiple entries");
+                message = Localization.lang("Really delete the %0 selected entries?", Integer.toString(numberOfEntries));
             }
 
-            CheckBoxMessage cb = new CheckBoxMessage(msg, Localization.lang("Disable this confirmation dialog"), false);
-
-            int answer = JOptionPane.showConfirmDialog(null, cb, title, JOptionPane.YES_NO_OPTION,
-                    JOptionPane.QUESTION_MESSAGE);
-            if (cb.isSelected()) {
-                Globals.prefs.putBoolean(JabRefPreferences.CONFIRM_DELETE, false);
-            }
-            return answer == JOptionPane.YES_OPTION;
+            return dialogService.showConfirmationDialogWithOptOutAndWait(title, message,
+                    Localization.lang("Disable this confirmation dialog"),
+                    optOut -> Globals.prefs.putBoolean(JabRefPreferences.CONFIRM_DELETE, !optOut));
         } else {
             return true;
         }

--- a/src/main/java/org/jabref/gui/DialogService.java
+++ b/src/main/java/org/jabref/gui/DialogService.java
@@ -122,6 +122,19 @@ public interface DialogService {
                                                     String optOutMessage, Consumer<Boolean> optOutAction);
 
     /**
+     * Create and display a new confirmation dialog.
+     * It will include a blue question icon on the left and
+     * a YES (with given label) and Cancel (also with given label) button. To create a confirmation dialog with custom
+     * buttons see also {@link #showCustomButtonDialogAndWait(Alert.AlertType, String, String, ButtonType...)}.
+     * Moreover, the dialog contains a opt-out checkbox with the given text to support "Do not ask again"-behaviour.
+     *
+     * @return true if the use clicked "YES" otherwise false
+     */
+    boolean showConfirmationDialogWithOptOutAndWait(String title, String content,
+                                                    String okButtonLabel, String cancelButtonLabel,
+                                                    String optOutMessage, Consumer<Boolean> optOutAction);
+
+    /**
      * This will create and display a new dialog of the specified
      * {@link Alert.AlertType} but with user defined buttons as optional
      * {@link ButtonType}s.

--- a/src/main/java/org/jabref/gui/DialogService.java
+++ b/src/main/java/org/jabref/gui/DialogService.java
@@ -3,6 +3,7 @@ package org.jabref.gui;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import javafx.concurrent.Task;
 import javafx.print.PrinterJob;
@@ -92,7 +93,7 @@ public interface DialogService {
      * Create and display a new confirmation dialog.
      * It will include a blue question icon on the left and
      * a OK (with given label) and Cancel button. To create a confirmation dialog with custom
-     * buttons see also {@link #showCustomButtonDialogAndWait(Alert.AlertType, String, String, ButtonType...)}
+     * buttons see also {@link #showCustomButtonDialogAndWait(Alert.AlertType, String, String, ButtonType...)}.
      *
      * @return true if the use clicked "OK" otherwise false
      */
@@ -102,11 +103,23 @@ public interface DialogService {
      * Create and display a new confirmation dialog.
      * It will include a blue question icon on the left and
      * a OK (with given label) and Cancel (also with given label) button. To create a confirmation dialog with custom
-     * buttons see also {@link #showCustomButtonDialogAndWait(Alert.AlertType, String, String, ButtonType...)}
+     * buttons see also {@link #showCustomButtonDialogAndWait(Alert.AlertType, String, String, ButtonType...)}.
      *
      * @return true if the use clicked "OK" otherwise false
      */
     boolean showConfirmationDialogAndWait(String title, String content, String okButtonLabel, String cancelButtonLabel);
+
+    /**
+     * Create and display a new confirmation dialog.
+     * It will include a blue question icon on the left and
+     * a YES (with given label) and Cancel (also with given label) button. To create a confirmation dialog with custom
+     * buttons see also {@link #showCustomButtonDialogAndWait(Alert.AlertType, String, String, ButtonType...)}.
+     * Moreover, the dialog contains a opt-out checkbox with the given text to support "Do not ask again"-behaviour.
+     *
+     * @return true if the use clicked "YES" otherwise false
+     */
+    boolean showConfirmationDialogWithOptOutAndWait(String title, String content,
+                                                    String optOutMessage, Consumer<Boolean> optOutAction);
 
     /**
      * This will create and display a new dialog of the specified

--- a/src/main/java/org/jabref/gui/FXDialog.java
+++ b/src/main/java/org/jabref/gui/FXDialog.java
@@ -1,10 +1,5 @@
 package org.jabref.gui;
 
-import java.awt.Window;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
-
-import javafx.application.Platform;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Dialog;
@@ -19,11 +14,7 @@ import org.jabref.gui.keyboard.KeyBindingRepository;
 
 /**
  * This class provides a super class for all dialogs implemented in JavaFX.
- * It mimics the behavior of a Swing JDialog which means once a object of this class
- * is shown all Swing windows will be blocked and stay in the background. Since this
- * class extends from a JavaFX {@link Alert} it behaves as a normal dialog towards all
- * windows in the JavaFX thread.
- * <p>
+ *
  * To create a custom JavaFX dialog one should create an instance of this class and set a dialog
  * pane through the inherited {@link Dialog#setDialogPane(DialogPane)} method.
  * The dialog can be shown via {@link Dialog#show()} or {@link Dialog#showAndWait()}.
@@ -32,33 +23,6 @@ import org.jabref.gui.keyboard.KeyBindingRepository;
  * {@link FXMLLoader}.
  */
 public class FXDialog extends Alert {
-
-    /**
-     * The WindowAdapter will be added to all Swing windows once an instance
-     * of this class is shown and redirects the focus towards this instance.
-     * The WindowAdapter will be removed once the instance of this class gets hidden.
-     *
-     */
-    private final WindowAdapter fxOverSwingHelper = new WindowAdapter() {
-
-        @Override
-        public void windowActivated(WindowEvent e) {
-            Platform.runLater(() -> {
-                Stage fxDialogWindow = getDialogWindow();
-                fxDialogWindow.toFront();
-                fxDialogWindow.requestFocus();
-            });
-        }
-
-        @Override
-        public void windowGainedFocus(WindowEvent e) {
-            Platform.runLater(() -> {
-                Stage fxDialogWindow = getDialogWindow();
-                fxDialogWindow.toFront();
-                fxDialogWindow.requestFocus();
-            });
-        }
-    };
 
     public FXDialog(AlertType type, String title, Image image, boolean isModal) {
         this(type, title, isModal);
@@ -92,13 +56,6 @@ public class FXDialog extends Alert {
         } else {
             initModality(Modality.NONE);
         }
-        dialogWindow.setOnShown(evt -> {
-            setSwingWindowsEnabledAndFocusable(!isModal);
-            setLocationRelativeToMainWindow();
-        });
-        dialogWindow.setOnHiding(evt -> setSwingWindowsEnabledAndFocusable(true));
-
-        dialogWindow.setOnCloseRequest(evt -> this.close());
 
         dialogWindow.getScene().setOnKeyPressed(event -> {
             KeyBindingRepository keyBindingRepository = Globals.getKeyPrefs();
@@ -112,36 +69,13 @@ public class FXDialog extends Alert {
         this(type, true);
     }
 
-    public void setDialogIcon(Image image) {
+    private void setDialogIcon(Image image) {
         Stage fxDialogWindow = getDialogWindow();
         fxDialogWindow.getIcons().add(image);
     }
 
     private Stage getDialogWindow() {
         return (Stage) getDialogPane().getScene().getWindow();
-    }
-
-    private void setSwingWindowsEnabledAndFocusable(boolean enabled) {
-        for (Window swingWindow : Window.getWindows()) {
-            swingWindow.setEnabled(enabled);
-            if (!enabled) {
-                swingWindow.addWindowListener(fxOverSwingHelper);
-            } else {
-                swingWindow.removeWindowListener(fxOverSwingHelper);
-            }
-        }
-    }
-
-    private void setLocationRelativeToMainWindow() {
-        /*
-        double mainWindowX = JabRefGUI.getMainFrame().getLocationOnScreen().getX();
-        double mainWindowY = JabRefGUI.getMainFrame().getLocationOnScreen().getY();
-        double mainWindowWidth = JabRefGUI.getMainFrame().getSize().getWidth();
-        double mainWindowHeight = JabRefGUI.getMainFrame().getSize().getHeight();
-
-        setX((mainWindowX + (mainWindowWidth / 2)) - (getWidth() / 2));
-        setY((mainWindowY + (mainWindowHeight / 2)) - (getHeight() / 2));
-        */
     }
 
 }

--- a/src/main/java/org/jabref/gui/FXDialogService.java
+++ b/src/main/java/org/jabref/gui/FXDialogService.java
@@ -5,14 +5,18 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javafx.concurrent.Task;
 import javafx.print.PrinterJob;
+import javafx.scene.Group;
+import javafx.scene.Node;
 import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonType;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.DialogPane;
 import javafx.scene.control.TextInputDialog;
 import javafx.scene.layout.Region;
@@ -47,6 +51,38 @@ public class FXDialogService implements DialogService {
 
     private static FXDialog createDialog(AlertType type, String title, String content) {
         FXDialog alert = new FXDialog(type, title, true);
+        alert.setHeaderText(null);
+        alert.setContentText(content);
+        alert.getDialogPane().setMinHeight(Region.USE_PREF_SIZE);
+        return alert;
+    }
+
+    private static FXDialog createDialogWithOptOut(AlertType type, String title, String content,
+                                                   String optOutMessage, Consumer<Boolean> optOutAction) {
+        FXDialog alert = new FXDialog(type, title, true);
+        // Need to force the alert to layout in order to grab the graphic as we are replacing the dialog pane with a custom pane
+        alert.getDialogPane().applyCss();
+        Node graphic = alert.getDialogPane().getGraphic();
+
+        // Create a new dialog pane that has a checkbox instead of the hide/show details button
+        // Use the supplied callback for the action of the checkbox
+        alert.setDialogPane(new DialogPane() {
+            @Override
+            protected Node createDetailsButton() {
+                CheckBox optOut = new CheckBox();
+                optOut.setText(optOutMessage);
+                optOut.setOnAction(e -> optOutAction.accept(optOut.isSelected()));
+                return optOut;
+            }
+        });
+
+        // Fool the dialog into thinking there is some expandable content; a group won't take up any space if it has no children
+        alert.getDialogPane().setExpandableContent(new Group());
+        alert.getDialogPane().setExpanded(true);
+
+        // Reset the dialog graphic using the default style
+        alert.getDialogPane().setGraphic(graphic);
+
         alert.setHeaderText(null);
         alert.setContentText(content);
         alert.getDialogPane().setMinHeight(Region.USE_PREF_SIZE);
@@ -123,6 +159,15 @@ public class FXDialogService implements DialogService {
         alert.getButtonTypes().setAll(okButtonType, cancelButtonType);
         return alert.showAndWait().filter(buttonType -> buttonType == okButtonType).isPresent();
     }
+
+    @Override
+    public boolean showConfirmationDialogWithOptOutAndWait(String title, String content,
+                                                           String optOutMessage, Consumer<Boolean> optOutAction) {
+        FXDialog alert = createDialogWithOptOut(AlertType.CONFIRMATION, title, content, optOutMessage, optOutAction);
+        alert.getButtonTypes().setAll(ButtonType.YES, ButtonType.NO);
+        return alert.showAndWait().filter(buttonType -> buttonType == ButtonType.YES).isPresent();
+    }
+
 
     @Override
     public Optional<ButtonType> showCustomButtonDialogAndWait(AlertType type, String title, String content,

--- a/src/main/java/org/jabref/gui/FXDialogService.java
+++ b/src/main/java/org/jabref/gui/FXDialogService.java
@@ -151,8 +151,8 @@ public class FXDialogService implements DialogService {
     }
 
     @Override
-    public boolean showConfirmationDialogAndWait(String title, String content, String okButtonLabel,
-            String cancelButtonLabel) {
+    public boolean showConfirmationDialogAndWait(String title, String content,
+                                                 String okButtonLabel, String cancelButtonLabel) {
         FXDialog alert = createDialog(AlertType.CONFIRMATION, title, content);
         ButtonType okButtonType = new ButtonType(okButtonLabel, ButtonBar.ButtonData.OK_DONE);
         ButtonType cancelButtonType = new ButtonType(cancelButtonLabel, ButtonBar.ButtonData.NO);
@@ -168,6 +168,16 @@ public class FXDialogService implements DialogService {
         return alert.showAndWait().filter(buttonType -> buttonType == ButtonType.YES).isPresent();
     }
 
+    @Override
+    public boolean showConfirmationDialogWithOptOutAndWait(String title, String content,
+                                                           String okButtonLabel, String cancelButtonLabel,
+                                                           String optOutMessage, Consumer<Boolean> optOutAction) {
+        FXDialog alert = createDialogWithOptOut(AlertType.CONFIRMATION, title, content, optOutMessage, optOutAction);
+        ButtonType okButtonType = new ButtonType(okButtonLabel, ButtonBar.ButtonData.YES);
+        ButtonType cancelButtonType = new ButtonType(cancelButtonLabel, ButtonBar.ButtonData.NO);
+        alert.getButtonTypes().setAll(okButtonType, cancelButtonType);
+        return alert.showAndWait().filter(buttonType -> buttonType == okButtonType).isPresent();
+    }
 
     @Override
     public Optional<ButtonType> showCustomButtonDialogAndWait(AlertType type, String title, String content,

--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -873,7 +873,7 @@ public class JabRefFrame extends BorderPane implements OutputPrinter {
 
                 new SeparatorMenuItem(),
 
-                factory.createMenuItem(StandardActions.DELETE_ENTRY, new EditAction(Actions.DELETE)),
+                factory.createMenuItem(StandardActions.DELETE_ENTRY, new OldDatabaseCommandWrapper(Actions.DELETE, this, Globals.stateManager)),
 
                 new SeparatorMenuItem(),
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2333,3 +2333,6 @@ Look\ up\ document\ identifier=Look up document identifier
 Next\ library=Next library
 Previous\ library=Previous library
 add\ group=add group
+Delete\ entries=Delete entries
+Keep\ entries=Keep entries
+Keep\ entry=Keep entry


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

Fixes the delete action in the maintable branch and the "do you really want to delete the entry"-dialog is converted to JavaFX. Moreover, a few lines of JavaFX-Swing-interaction code in `FXDialog` are deleted since it is no longer needed.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
