### PR TITLE
Allow side pane to be completely hidden

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -589,9 +589,19 @@ public class JabRefFrame extends BorderPane implements OutputPrinter {
             @Override
             public void changed(ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean showing) {
                 if (showing) {
-                    splitPane.setDividerPositions(prefs.getDouble(JabRefPreferences.SIDE_PANE_WIDTH));
-                    EasyBind.subscribe(splitPane.getDividers().get(0).positionProperty(),
-                            position -> prefs.putDouble(JabRefPreferences.SIDE_PANE_WIDTH, position.doubleValue()));
+                    setDividerPosition();
+
+                    EasyBind.subscribe(sidePane.visibleProperty(), visible -> {
+                        if (visible) {
+                            if (!splitPane.getItems().contains(sidePane)) {
+                                splitPane.getItems().add(0, sidePane);
+                                setDividerPosition();
+                            }
+                        } else {
+                            splitPane.getItems().remove(sidePane);
+                        }
+                    });
+
                     mainStage.showingProperty().removeListener(this);
                     observable.removeListener(this);
                 }
@@ -627,6 +637,14 @@ public class JabRefFrame extends BorderPane implements OutputPrinter {
         statusLabel.setForeground(GUIGlobals.ENTRY_EDITOR_LABEL_COLOR.darker());
     }
 
+    private void setDividerPosition() {
+        splitPane.setDividerPositions(prefs.getDouble(JabRefPreferences.SIDE_PANE_WIDTH));
+        if (!splitPane.getDividers().isEmpty()) {
+            EasyBind.subscribe(splitPane.getDividers().get(0).positionProperty(),
+                    position -> prefs.putDouble(JabRefPreferences.SIDE_PANE_WIDTH, position.doubleValue()));
+        }
+    }
+
     private Node createToolbar() {
         Pane leftSpacer = new Pane();
         HBox.setHgrow(leftSpacer, Priority.SOMETIMES);
@@ -648,7 +666,7 @@ public class JabRefFrame extends BorderPane implements OutputPrinter {
                 factory.createIconButton(StandardActions.SAVE_LIBRARY, new OldDatabaseCommandWrapper(Actions.SAVE, this, Globals.stateManager)),
 
                 leftSpacer);
-        leftSide.minWidthProperty().bind(sidePane.widthProperty());
+        leftSide.setMinWidth(100);
         leftSide.prefWidthProperty().bind(sidePane.widthProperty());
         leftSide.maxWidthProperty().bind(sidePane.widthProperty());
 


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

Fixes points 3. and 4. of https://github.com/JabRef/jabref/pull/3621#issuecomment-368821666
> Another issue is that the search-bar is connected to the splitter between main-table and the left side bar. When I resize the main-table, it is possible to move the search-bar over the toolbar icons:

> When closing the sidebar, the main-table is not maximized anymore. As can be seen in the image above, we end up with a gray area where the side-bar was.


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
