### PR TITLE
Show empty group pane if no database is open

### DIFF
--- a/src/main/java/org/jabref/gui/JabRefFrame.java
+++ b/src/main/java/org/jabref/gui/JabRefFrame.java
@@ -278,6 +278,7 @@ public class JabRefFrame extends BorderPane implements OutputPrinter {
          */
         EasyBind.subscribe(tabbedPane.getSelectionModel().selectedItemProperty(), e -> {
             if (e == null) {
+                Globals.stateManager.activeDatabaseProperty().setValue(Optional.empty());
                 return;
             }
 

--- a/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeViewModel.java
@@ -33,6 +33,8 @@ import org.jabref.model.groups.ExplicitGroup;
 import org.jabref.model.groups.GroupTreeNode;
 import org.jabref.model.metadata.MetaData;
 
+import org.fxmisc.easybind.EasyBind;
+
 public class GroupTreeViewModel extends AbstractViewModel {
 
     private final ObjectProperty<GroupNodeViewModel> rootGroup = new SimpleObjectProperty<>();
@@ -53,9 +55,8 @@ public class GroupTreeViewModel extends AbstractViewModel {
         this.taskExecutor = Objects.requireNonNull(taskExecutor);
 
         // Register listener
-        stateManager.activeDatabaseProperty()
-                .addListener((observable, oldValue, newValue) -> onActiveDatabaseChanged(newValue));
-        selectedGroups.addListener((observable, oldValue, newValue) -> onSelectedGroupChanged(newValue));
+        EasyBind.subscribe(stateManager.activeDatabaseProperty(), this::onActiveDatabaseChanged);
+        EasyBind.subscribe(selectedGroups, this::onSelectedGroupChanged);
 
         // Set-up bindings
         filterPredicate
@@ -122,8 +123,10 @@ public class GroupTreeViewModel extends AbstractViewModel {
             rootGroup.setValue(newRoot);
             this.selectedGroups.setAll(
                     stateManager.getSelectedGroup(newDatabase.get()).stream()
-                            .map(selectedGroup -> new GroupNodeViewModel(newDatabase.get(), stateManager, taskExecutor, selectedGroup))
-                            .collect(Collectors.toList()));
+                                .map(selectedGroup -> new GroupNodeViewModel(newDatabase.get(), stateManager, taskExecutor, selectedGroup))
+                                .collect(Collectors.toList()));
+        } else {
+            rootGroup.setValue(GroupNodeViewModel.getAllEntriesGroup(new BibDatabaseContext(), stateManager, taskExecutor));
         }
 
         currentDatabase = newDatabase;


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

Fixes an issue where the group tree of the last database is still shown even after the database was closed.
Reported in https://github.com/JabRef/jabref/pull/3621#issuecomment-368821666

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
