### PR TITLE
Enable travis build for maintable-beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ after_failure:
 branches:
   only:
     - master
+    - maintable-beta
 
 # cache gradle dependencies
 # https://docs.travis-ci.com/user/languages/java#Caching


### PR DESCRIPTION
I think it would be nice to have travis build for maintable-beta. 
That would show us some potential errornous tests or

Edit// Maybe first it is useful to update the localization files to be consistent 

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
