### PR TITLE
Remove erroneous escape character

### DIFF
--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -2349,6 +2349,6 @@ Your\ Java\ Runtime\ Environment\ is\ located\ at\ %0.=Your Java Runtime Environ
 Aux\ file=Aux file
 Group\ containing\ entries\ cited\ in\ a\ given\ TeX\ file=Group containing entries cited in a given TeX file
 
-Any\ file=Any\ file
+Any\ file=Any file
 
 No\ linked\ files\ found\ for\ export.=No linked files found for export.


### PR DESCRIPTION
This seems to be an escape character that slipped into the localized text. Presumably a copy-and-paste error?
