### PR TITLE
Partial revert of #3715 since double click on group should expand/collapse it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@ For more details refer to the [field mapping help page](http://help.jabref.org/e
 - We improved file saving so that hard links are now preserved when a save is performed [#2633](https://github.com/JabRef/jabref/issues/2633)
 - We changed the default dialog option when removing a [file link](http://help.jabref.org/en/FileLinks#adding-external-links-to-an-entry) from an entry.
 The new default removes the linked file from the entry instead of deleting the file from disk. [#3679](https://github.com/JabRef/jabref/issues/3679)
-- The group editing window can now also be called by double-clicking the group to be edited. [koppor#277](https://github.com/koppor/jabref/issues/277)
 - The magnifier icon at the search shows the [search mode](https://help.jabref.org/en/Search#search-modes) again. [#3535](https://github.com/JabRef/jabref/issues/3535)
 - We added a new cleanup operation that replaces ligatures with their expanded form. [#3613](https://github.com/JabRef/jabref/issues/3613)
 - We added the function to parse German month names. [#3536](https://github.com/JabRef/jabref/pull/3536)

--- a/src/main/java/org/jabref/gui/groups/GroupTreeController.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeController.java
@@ -28,7 +28,6 @@ import javafx.scene.control.TreeTableView;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.input.DragEvent;
 import javafx.scene.input.Dragboard;
-import javafx.scene.input.MouseButton;
 import javafx.scene.input.TransferMode;
 import javafx.scene.layout.StackPane;
 import javafx.scene.text.Text;
@@ -173,18 +172,7 @@ public class GroupTreeController extends AbstractController<GroupTreeViewModel> 
             // Simply setting to null is not enough since it would be replaced by the default node on every change
             row.setDisclosureNode(null);
             row.disclosureNodeProperty().addListener((observable, oldValue, newValue) -> row.setDisclosureNode(null));
-
-            // Opens the group's edit window when the group gets double clicked
-            row.setOnMouseClicked((mouseClickedEvent) -> {
-                if (mouseClickedEvent.getButton().equals(MouseButton.PRIMARY)
-                        && (mouseClickedEvent.getClickCount() == 2)) {
-                    GroupNodeViewModel groupToEdit = row.itemProperty().getValue();
-                    if (groupToEdit != null) {
-                        viewModel.editGroup(groupToEdit);
-                    }
-                }
-            });
-
+            
             // Add context menu (only for non-null items)
             row.contextMenuProperty().bind(
                     EasyBind.monadic(row.itemProperty())


### PR DESCRIPTION
This PR reverts the part of #3715, which introduced that a double click on a group opens the edit window. However, the default behavior is that double click expands or collapse the subtree and users probably profit from the default behavior more than from the easier way to edit a group.

Fixes (or better closes) https://github.com/koppor/jabref/issues/277.

----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
