### PR TITLE
Watch main css file for change and reapply automatically

### DIFF
--- a/src/main/java/org/jabref/Globals.java
+++ b/src/main/java/org/jabref/Globals.java
@@ -12,6 +12,7 @@ import org.jabref.gui.keyboard.KeyBindingRepository;
 import org.jabref.gui.util.DefaultFileUpdateMonitor;
 import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.gui.util.TaskExecutor;
+import org.jabref.gui.util.ThemeLoader;
 import org.jabref.logic.exporter.ExporterFactory;
 import org.jabref.logic.importer.ImportFormatReader;
 import org.jabref.logic.journals.JournalAbbreviationLoader;
@@ -61,6 +62,7 @@ public class Globals {
     // Background tasks
     private static GlobalFocusListener focusListener;
     private static DefaultFileUpdateMonitor fileUpdateMonitor;
+    private static ThemeLoader themeLoader;
     private static TelemetryClient telemetryClient;
 
     private Globals() {
@@ -80,6 +82,8 @@ public class Globals {
 
         Globals.fileUpdateMonitor = new DefaultFileUpdateMonitor();
         JabRefExecutorService.INSTANCE.executeInterruptableTask(Globals.fileUpdateMonitor, "FileUpdateMonitor");
+
+        themeLoader = new ThemeLoader(fileUpdateMonitor);
 
         if (Globals.prefs.shouldCollectTelemetry() && !GraphicsEnvironment.isHeadless()) {
             startTelemetryClient();
@@ -129,5 +133,9 @@ public class Globals {
 
     public static Optional<TelemetryClient> getTelemetryClient() {
         return Optional.ofNullable(telemetryClient);
+    }
+
+    public static ThemeLoader getThemeLoader() {
+        return themeLoader;
     }
 }

--- a/src/main/java/org/jabref/JabRefGUI.java
+++ b/src/main/java/org/jabref/JabRefGUI.java
@@ -18,7 +18,6 @@ import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
-import org.jabref.gui.AbstractView;
 import org.jabref.gui.BasePanel;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.FXDialogService;
@@ -150,7 +149,7 @@ public class JabRefGUI {
         }
 
         Scene scene = new Scene(JabRefGUI.mainFrame, 800, 800);
-        scene.getStylesheets().add(AbstractView.class.getResource("Main.css").toExternalForm());
+        Globals.getThemeLoader().installBaseCss(scene);
         mainStage.setTitle(JabRefFrame.FRAME_TITLE);
         mainStage.getIcons().addAll(IconTheme.getLogoSetFX());
         mainStage.setScene(scene);

--- a/src/main/java/org/jabref/gui/AbstractView.java
+++ b/src/main/java/org/jabref/gui/AbstractView.java
@@ -6,6 +6,7 @@ import java.util.function.Function;
 import javafx.scene.Parent;
 import javafx.stage.Stage;
 
+import org.jabref.Globals;
 import org.jabref.logic.l10n.Localization;
 
 import com.airhacks.afterburner.views.FXMLView;
@@ -28,7 +29,7 @@ public class AbstractView extends FXMLView {
         Parent view = super.getView();
 
         // Add our base css file
-        view.getStylesheets().add(0, AbstractDialogView.class.getResource("Main.css").toExternalForm());
+        Globals.getThemeLoader().installBaseCss(view);
 
         // Notify controller about the stage, where it is displayed
         view.sceneProperty().addListener((observable, oldValue, newValue) -> {

--- a/src/main/java/org/jabref/gui/customjfx/CustomJFXPanel.java
+++ b/src/main/java/org/jabref/gui/customjfx/CustomJFXPanel.java
@@ -3,7 +3,7 @@ package org.jabref.gui.customjfx;
 import javafx.embed.swing.JFXPanel;
 import javafx.scene.Scene;
 
-import org.jabref.gui.AbstractView;
+import org.jabref.Globals;
 import org.jabref.gui.util.DefaultTaskExecutor;
 
 /**
@@ -13,7 +13,7 @@ public class CustomJFXPanel {
 
     public static JFXPanel wrap(Scene scene) {
         JFXPanel container = new JFXPanel();
-        scene.getStylesheets().add(AbstractView.class.getResource("Main.css").toExternalForm());
+        Globals.getThemeLoader().installBaseCss(scene);
         DefaultTaskExecutor.runInJavaFXThread(() -> container.setScene(scene));
         return container;
     }

--- a/src/main/java/org/jabref/gui/util/ControlHelper.java
+++ b/src/main/java/org/jabref/gui/util/ControlHelper.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 
-import org.jabref.gui.AbstractView;
+import org.jabref.Globals;
 import org.jabref.logic.l10n.Localization;
 
 import org.slf4j.Logger;
@@ -29,9 +29,7 @@ public class ControlHelper {
             fxmlLoader.load();
 
             // Add our base css file
-            control.getStylesheets().add(0, AbstractView.class.getResource("Main.css").toExternalForm());
-
-            // Add language resource
+            Globals.getThemeLoader().installBaseCss(control);
 
         } catch (IOException exception) {
             LOGGER.error("Problem loading fxml for control", exception);

--- a/src/main/java/org/jabref/gui/util/ThemeLoader.java
+++ b/src/main/java/org/jabref/gui/util/ThemeLoader.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 public class ThemeLoader {
 
     private static final String pathDefaultMainCss = AbstractView.class.getResource("Main.css").toExternalForm();
-    Logger LOGGER = LoggerFactory.getLogger(ThemeLoader.class);
+    private Logger LOGGER = LoggerFactory.getLogger(ThemeLoader.class);
     private final FileUpdateMonitor fileUpdateMonitor;
 
     public ThemeLoader(FileUpdateMonitor fileUpdateMonitor) {

--- a/src/main/java/org/jabref/gui/util/ThemeLoader.java
+++ b/src/main/java/org/jabref/gui/util/ThemeLoader.java
@@ -3,6 +3,7 @@ package org.jabref.gui.util;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
@@ -16,9 +17,21 @@ import org.jabref.model.util.FileUpdateMonitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Installs the Main.css style file and provides live reloading. The live reloading has to be turned on by setting
+ * the <code>-Djabref.main.css</code> property. There two possible modes: (1) When only <code>-Djabref.main.css</code>
+ * is specified, then the standard <code>Main.css</code> that is found will be watched and on changes in that file,
+ * the style-sheet will be reloaded and changes are immediately visible.
+ * <p>
+ * When working from an IDE, this usually means that the <code>Main.css</code> is located in the build folder. To use
+ * the css-file that is located in the sources directly, the full path can be given as value:
+ * <p>
+ * <code>-Djabref.main.css="/path/to/src/Main.css"</code>
+ */
 public class ThemeLoader {
 
     private static final String pathDefaultMainCss = AbstractView.class.getResource("Main.css").toExternalForm();
+    private static final String cssSystemProperty = System.getProperty("jabref.main.css");
     private static final Logger LOGGER = LoggerFactory.getLogger(ThemeLoader.class);
     private final FileUpdateMonitor fileUpdateMonitor;
 
@@ -31,15 +44,24 @@ public class ThemeLoader {
      * Changes in the css file lead to a redraw of the scene using the new css file.
      */
     public void installBaseCss(Scene scene) {
-        installCss(scene, pathDefaultMainCss);
+        String pathToMainCss = pathDefaultMainCss;
+        if (cssSystemProperty != null) {
+            final Path path = Paths.get(cssSystemProperty);
+            if ("Main.css".matches(path.getFileName().toString()) && Files.isReadable(path)) {
+                pathToMainCss = path.toUri().toString();
+            }
+        }
+        installCss(scene, pathToMainCss);
     }
 
     private void installCss(Scene scene, String cssUrl) {
         scene.getStylesheets().add(0, cssUrl);
         try {
-            // If the resources are part of a .jar bundle, then we don't want to watch it for changes
-            if (!cssUrl.startsWith("jar:")) {
+            // If -Djabref.main.css is defined and the resources are not part of a .jar bundle,
+            // we watch the file for changes and turn on live reloading
+            if (!cssUrl.startsWith("jar:") && cssSystemProperty != null) {
                 Path cssFile = Paths.get(new URL(cssUrl).toURI());
+                LOGGER.info("Enabling live reloading of " + cssFile);
                 fileUpdateMonitor.addListenerForFile(cssFile, () -> {
                     LOGGER.info("Reload css file " + cssFile);
 

--- a/src/main/java/org/jabref/gui/util/ThemeLoader.java
+++ b/src/main/java/org/jabref/gui/util/ThemeLoader.java
@@ -48,7 +48,8 @@ public class ThemeLoader {
                 );
             });
         } catch (URISyntaxException | IOException e) {
-            LOGGER.error("Could not watch css file for changes " + cssUrl, e);
+            // If the resources are part of a .jar bundle, then we cannot get the path (as a path in the file system) in the way above; so just ignore the exception
+            LOGGER.debug("Could not watch css file for changes " + cssUrl, e);
         }
     }
 

--- a/src/main/java/org/jabref/gui/util/ThemeLoader.java
+++ b/src/main/java/org/jabref/gui/util/ThemeLoader.java
@@ -1,0 +1,62 @@
+package org.jabref.gui.util;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+
+import org.jabref.gui.AbstractView;
+import org.jabref.model.util.FileUpdateMonitor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ThemeLoader {
+
+    private static final String pathDefaultMainCss = AbstractView.class.getResource("Main.css").toExternalForm();
+    Logger LOGGER = LoggerFactory.getLogger(ThemeLoader.class);
+    private final FileUpdateMonitor fileUpdateMonitor;
+
+    public ThemeLoader(FileUpdateMonitor fileUpdateMonitor) {
+        this.fileUpdateMonitor = Objects.requireNonNull(fileUpdateMonitor);
+    }
+
+    /**
+     * Installs the base css file as a stylesheet in the given scene.
+     * Changes in the css file lead to a redraw of the scene using the new css file.
+     */
+    public void installBaseCss(Scene scene) {
+        installCss(scene, pathDefaultMainCss);
+    }
+
+    private void installCss(Scene scene, String cssUrl) {
+        scene.getStylesheets().add(0, cssUrl);
+        try {
+            Path cssFile = Paths.get(new URL(cssUrl).toURI());
+            fileUpdateMonitor.addListenerForFile(cssFile, () -> {
+                LOGGER.info("Reload css file " + cssFile);
+
+                DefaultTaskExecutor.runInJavaFXThread(() -> {
+                            scene.getStylesheets().remove(cssUrl);
+                            scene.getStylesheets().add(0, cssUrl);
+                        }
+                );
+            });
+        } catch (URISyntaxException | IOException e) {
+            LOGGER.error("Could not watch css file for changes " + cssUrl, e);
+        }
+    }
+
+    /**
+     * @deprecated you should never need to add css to a control, add it to the scene containing the control
+     */
+    @Deprecated
+    public void installBaseCss(Parent control) {
+        control.getStylesheets().add(0, pathDefaultMainCss);
+    }
+}

--- a/src/main/java/org/jabref/gui/util/ThemeLoader.java
+++ b/src/main/java/org/jabref/gui/util/ThemeLoader.java
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory;
 public class ThemeLoader {
 
     private static final String pathDefaultMainCss = AbstractView.class.getResource("Main.css").toExternalForm();
-    private Logger LOGGER = LoggerFactory.getLogger(ThemeLoader.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ThemeLoader.class);
     private final FileUpdateMonitor fileUpdateMonitor;
 
     public ThemeLoader(FileUpdateMonitor fileUpdateMonitor) {

--- a/src/main/java/org/jabref/gui/util/ThemeLoader.java
+++ b/src/main/java/org/jabref/gui/util/ThemeLoader.java
@@ -30,8 +30,8 @@ import org.slf4j.LoggerFactory;
  */
 public class ThemeLoader {
 
-    private static final String pathDefaultMainCss = AbstractView.class.getResource("Main.css").toExternalForm();
-    private static final String cssSystemProperty = System.getProperty("jabref.main.css");
+    private static final String DEFAULT_PATH_MAIN_CSS = AbstractView.class.getResource("Main.css").toExternalForm();
+    private static final String CSS_SYSTEM_PROPERTY = System.getProperty("jabref.main.css");
     private static final Logger LOGGER = LoggerFactory.getLogger(ThemeLoader.class);
     private final FileUpdateMonitor fileUpdateMonitor;
 
@@ -44,9 +44,9 @@ public class ThemeLoader {
      * Changes in the css file lead to a redraw of the scene using the new css file.
      */
     public void installBaseCss(Scene scene) {
-        String pathToMainCss = pathDefaultMainCss;
-        if (cssSystemProperty != null) {
-            final Path path = Paths.get(cssSystemProperty);
+        String pathToMainCss = DEFAULT_PATH_MAIN_CSS;
+        if (CSS_SYSTEM_PROPERTY != null) {
+            final Path path = Paths.get(CSS_SYSTEM_PROPERTY);
             if ("Main.css".matches(path.getFileName().toString()) && Files.isReadable(path)) {
                 pathToMainCss = path.toUri().toString();
             }
@@ -59,7 +59,7 @@ public class ThemeLoader {
         try {
             // If -Djabref.main.css is defined and the resources are not part of a .jar bundle,
             // we watch the file for changes and turn on live reloading
-            if (!cssUrl.startsWith("jar:") && cssSystemProperty != null) {
+            if (!cssUrl.startsWith("jar:") && CSS_SYSTEM_PROPERTY != null) {
                 Path cssFile = Paths.get(new URL(cssUrl).toURI());
                 LOGGER.info("Enabling live reloading of " + cssFile);
                 fileUpdateMonitor.addListenerForFile(cssFile, () -> {
@@ -82,6 +82,6 @@ public class ThemeLoader {
      */
     @Deprecated
     public void installBaseCss(Parent control) {
-        control.getStylesheets().add(0, pathDefaultMainCss);
+        control.getStylesheets().add(0, DEFAULT_PATH_MAIN_CSS);
     }
 }

--- a/src/main/java/org/jabref/gui/util/ThemeLoader.java
+++ b/src/main/java/org/jabref/gui/util/ThemeLoader.java
@@ -37,19 +37,21 @@ public class ThemeLoader {
     private void installCss(Scene scene, String cssUrl) {
         scene.getStylesheets().add(0, cssUrl);
         try {
-            Path cssFile = Paths.get(new URL(cssUrl).toURI());
-            fileUpdateMonitor.addListenerForFile(cssFile, () -> {
-                LOGGER.info("Reload css file " + cssFile);
+            // If the resources are part of a .jar bundle, then we don't want to watch it for changes
+            if (!cssUrl.startsWith("jar:")) {
+                Path cssFile = Paths.get(new URL(cssUrl).toURI());
+                fileUpdateMonitor.addListenerForFile(cssFile, () -> {
+                    LOGGER.info("Reload css file " + cssFile);
 
-                DefaultTaskExecutor.runInJavaFXThread(() -> {
-                            scene.getStylesheets().remove(cssUrl);
-                            scene.getStylesheets().add(0, cssUrl);
-                        }
-                );
-            });
+                    DefaultTaskExecutor.runInJavaFXThread(() -> {
+                                scene.getStylesheets().remove(cssUrl);
+                                scene.getStylesheets().add(0, cssUrl);
+                            }
+                    );
+                });
+            }
         } catch (URISyntaxException | IOException e) {
-            // If the resources are part of a .jar bundle, then we cannot get the path (as a path in the file system) in the way above; so just ignore the exception
-            LOGGER.debug("Could not watch css file for changes " + cssUrl, e);
+            LOGGER.error("Could not watch css file for changes " + cssUrl, e);
         }
     }
 


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

With this PR, working on styling and css files should be easier. Css files are now watched for changes and automatically reloaded. Thus JabRef does not have to be restarted in order to apply a new design. In IntellJ you can now start debugging, edit the css and apply the changes by `Build > Build project` or `Run > Reload Changed Classes`. 

The idea of the `ThemeLoader` class is to support external css files (next to the jar file) in the future so that users could change the theme on their own.

I'll add a short note documenting this feature to the wiki after this PR gets merged.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
