### PR TITLE
Do no longer log InvalidFieldValueExceptions during autosave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The new default removes the linked file from the entry instead of deleting the f
 - Pressing <kbd>ESC</kbd> while searching will clear the search field and select the first entry, if available, in the table. [koppor#293](https://github.com/koppor/jabref/issues/293)
 - We changed the metadata reading and writing. DublinCore is now the only metadata format, JabRef supports. (https://github.com/JabRef/jabref/pull/3710)
 - We added another CLI functionality for reading and writing metadata to pdfs. (see https://github.com/JabRef/jabref/pull/3756 and see http://help.jabref.org/en/CommandLine)
+- We no longer print errors in field values during autosave into the log [#3811](https://github.com/JabRef/jabref/issues/3811)
 
 ### Fixed
 - We fixed several performance problems with the management of journal abbreviations [#3323](https://github.com/JabRef/jabref/issues/3323)

--- a/src/main/java/org/jabref/logic/bibtex/BibEntryWriter.java
+++ b/src/main/java/org/jabref/logic/bibtex/BibEntryWriter.java
@@ -153,7 +153,7 @@ public class BibEntryWriter {
                 out.write(fieldFormatter.format(field.get(), name));
                 out.write(',' + OS.NEWLINE);
             } catch (InvalidFieldValueException ex) {
-                throw new IOException("Error in field '" + name + "': " + ex.getMessage());
+                throw new IOException("Error in field '" + name + "': " + ex.getMessage(), ex);
             }
         }
     }


### PR DESCRIPTION
Fixes  #3811

InvalidFieldValueExceptions are no longer printed into the log when they occur during autosave. Fields in the entry editor still have the warning sign next to them.

The normal save operation (CTRL+S) still triggers a warning dialog, saying that the file could not be saved.

----

- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [X] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
