### PR TITLE
Fix freezing by replacing codeArea with TextArea

### DIFF
--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -1086,7 +1086,8 @@ public class BasePanel extends JPanel implements ClipboardOwner {
     }
 
     private boolean saveDatabase(File file, boolean selectedOnly, Charset enc,
-            SavePreferences.DatabaseSaveType saveType) throws SaveException {
+                                 SavePreferences.DatabaseSaveType saveType)
+            throws SaveException {
         SaveSession session;
         frame.block();
         final String SAVE_DATABASE = Localization.lang("Save library");
@@ -1500,20 +1501,21 @@ public class BasePanel extends JPanel implements ClipboardOwner {
      * @param entry The entry to edit.
      */
     public void showAndEdit(BibEntry entry) {
-        DefaultTaskExecutor.runInJavaFXThread(() -> {
-            if (mode == BasePanelMode.SHOWING_EDITOR) {
-                Globals.prefs.putInt(JabRefPreferences.ENTRY_EDITOR_HEIGHT, splitPane.getHeight() - splitPane.getDividerLocation());
-            }
-            mode = BasePanelMode.SHOWING_EDITOR;
-            splitPane.setBottomComponent(entryEditorContainer);
 
+        if (mode == BasePanelMode.SHOWING_EDITOR) {
+            Globals.prefs.putInt(JabRefPreferences.ENTRY_EDITOR_HEIGHT, splitPane.getHeight() - splitPane.getDividerLocation());
+        }
+        mode = BasePanelMode.SHOWING_EDITOR;
+        splitPane.setBottomComponent(entryEditorContainer);
+        DefaultTaskExecutor.runInJavaFXThread(() -> {
             if (entry != getShowing()) {
                 entryEditor.setEntry(entry);
                 newEntryShowing(entry);
             }
             entryEditor.requestFocus();
-            adjustSplitter();
+
         });
+        adjustSplitter();
     }
 
     /**

--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -1510,7 +1510,7 @@ public class BasePanel extends JPanel implements ClipboardOwner {
             entryEditor.setEntry(entry);
             newEntryShowing(entry);
         }
-        DefaultTaskExecutor.runInJavaFXThread(() -> entryEditor.requestFocus());
+        entryEditor.requestFocus();
         adjustSplitter();
     }
 

--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -585,7 +585,8 @@ public class BasePanel extends JPanel implements ClipboardOwner {
                 .openConsole(frame.getCurrentBasePanel().getBibDatabaseContext().getDatabaseFile().orElse(null)));
 
         actions.put(Actions.PULL_CHANGES_FROM_SHARED_DATABASE, (BaseAction) () -> {
-            DatabaseSynchronizer dbmsSynchronizer = frame.getCurrentBasePanel().getBibDatabaseContext()
+            DatabaseSynchronizer dbmsSynchronizer = frame.getCurrentBasePanel()
+                    .getBibDatabaseContext()
                     .getDBMSSynchronizer();
             dbmsSynchronizer.pullChanges();
         });
@@ -1092,7 +1093,8 @@ public class BasePanel extends JPanel implements ClipboardOwner {
         frame.block();
         final String SAVE_DATABASE = Localization.lang("Save library");
         try {
-            SavePreferences prefs = SavePreferences.loadForSaveFromPreferences(Globals.prefs).withEncoding(enc)
+            SavePreferences prefs = SavePreferences.loadForSaveFromPreferences(Globals.prefs)
+                    .withEncoding(enc)
                     .withSaveType(saveType);
             BibtexDatabaseWriter<SaveSession> databaseWriter = new BibtexDatabaseWriter<>(
                     FileSaveSession::new);
@@ -1500,18 +1502,20 @@ public class BasePanel extends JPanel implements ClipboardOwner {
      * @param entry The entry to edit.
      */
     public void showAndEdit(BibEntry entry) {
-        if (mode == BasePanelMode.SHOWING_EDITOR) {
-            Globals.prefs.putInt(JabRefPreferences.ENTRY_EDITOR_HEIGHT, splitPane.getHeight() - splitPane.getDividerLocation());
-        }
-        mode = BasePanelMode.SHOWING_EDITOR;
-        splitPane.setBottomComponent(entryEditorContainer);
+        DefaultTaskExecutor.runInJavaFXThread(() -> {
+            if (mode == BasePanelMode.SHOWING_EDITOR) {
+                Globals.prefs.putInt(JabRefPreferences.ENTRY_EDITOR_HEIGHT, splitPane.getHeight() - splitPane.getDividerLocation());
+            }
+            mode = BasePanelMode.SHOWING_EDITOR;
+            splitPane.setBottomComponent(entryEditorContainer);
 
-        if (entry != getShowing()) {
-            entryEditor.setEntry(entry);
-            newEntryShowing(entry);
-        }
-        entryEditor.requestFocus();
-        adjustSplitter();
+            if (entry != getShowing()) {
+                entryEditor.setEntry(entry);
+                newEntryShowing(entry);
+            }
+            entryEditor.requestFocus();
+            adjustSplitter();
+        });
     }
 
     /**
@@ -2013,7 +2017,7 @@ public class BasePanel extends JPanel implements ClipboardOwner {
             // Run the search operation:
             FileFinder fileFinder = FileFinders.constructFromConfiguration(Globals.prefs.getAutoLinkPreferences());
             try {
-            List<Path> files = fileFinder.findAssociatedFiles(entry, dirs, extensions);
+                List<Path> files = fileFinder.findAssociatedFiles(entry, dirs, extensions);
                 if (!files.isEmpty()) {
                     Path file = files.get(0);
                     Optional<ExternalFileType> type = ExternalFileTypes.getInstance().getExternalFileTypeByFile(file);
@@ -2223,7 +2227,8 @@ public class BasePanel extends JPanel implements ClipboardOwner {
             FileDialogConfiguration fileDialogConfiguration = new FileDialogConfiguration.Builder()
                     .withDefaultExtension(FileType.BIBTEX_DB)
                     .addExtensionFilter(FileType.BIBTEX_DB)
-                    .withInitialDirectory(Globals.prefs.get(JabRefPreferences.WORKING_DIRECTORY)).build();
+                    .withInitialDirectory(Globals.prefs.get(JabRefPreferences.WORKING_DIRECTORY))
+                    .build();
 
             DialogService ds = new FXDialogService();
 

--- a/src/main/java/org/jabref/gui/BasePanel.java
+++ b/src/main/java/org/jabref/gui/BasePanel.java
@@ -585,9 +585,7 @@ public class BasePanel extends JPanel implements ClipboardOwner {
                 .openConsole(frame.getCurrentBasePanel().getBibDatabaseContext().getDatabaseFile().orElse(null)));
 
         actions.put(Actions.PULL_CHANGES_FROM_SHARED_DATABASE, (BaseAction) () -> {
-            DatabaseSynchronizer dbmsSynchronizer = frame.getCurrentBasePanel()
-                    .getBibDatabaseContext()
-                    .getDBMSSynchronizer();
+            DatabaseSynchronizer dbmsSynchronizer = frame.getCurrentBasePanel().getBibDatabaseContext().getDBMSSynchronizer();
             dbmsSynchronizer.pullChanges();
         });
 

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.css
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.css
@@ -1,11 +1,4 @@
-.text-area {
-    -fx-text-fill: text-area-foreground;
-    -fx-control-inner-background: text-area-background;
-}
 
-.text-area *.text {
-    -fx-alignment: center-left;
-}
 
 .editorPane {
     -fx-hgap: 10;

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -13,6 +13,7 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ListChangeListener;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.Tooltip;
+
 import org.jabref.gui.IconTheme;
 import org.jabref.gui.undo.CountingUndoManager;
 import org.jabref.gui.undo.NamedCompound;

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -13,8 +13,6 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ListChangeListener;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.Tooltip;
-import javafx.scene.layout.Region;
-
 import org.jabref.gui.IconTheme;
 import org.jabref.gui.undo.CountingUndoManager;
 import org.jabref.gui.undo.NamedCompound;
@@ -82,12 +80,10 @@ public class SourceTab extends EntryEditorTab {
     @Override
     protected void bindToEntry(BibEntry entry) {
         TextArea codeArea = new TextArea();
-        codeArea.setPrefHeight(300);
-        codeArea.setMaxHeight(Region.USE_PREF_SIZE);
+
 
         javafx.scene.control.ScrollPane scrollPane = new javafx.scene.control.ScrollPane(codeArea);
         NotificationPane notificationPane = new NotificationPane(scrollPane);
-        scrollPane.setMaxHeight(codeArea.getMaxHeight());
 
         notificationPane.setShowFromTop(false);
         sourceValidator.getValidationStatus().getMessages().addListener((ListChangeListener<ValidationMessage>) c -> {

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -81,8 +81,9 @@ public class SourceTab extends EntryEditorTab {
     @Override
     protected void bindToEntry(BibEntry entry) {
         TextArea codeArea = new TextArea();
+        codeArea.setPrefHeight(100);
         javafx.scene.control.ScrollPane scrollPane = new javafx.scene.control.ScrollPane(codeArea);
-        scrollPane.autosize();
+
         NotificationPane notificationPane = new NotificationPane(scrollPane);
 
         notificationPane.setShowFromTop(false);

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -53,8 +53,6 @@ public class SourceTab extends EntryEditorTab {
     private final ObjectProperty<ValidationMessage> sourceIsValid = new SimpleObjectProperty<>();
     private final ObservableRuleBasedValidator sourceValidator = new ObservableRuleBasedValidator(sourceIsValid);
     private final FileUpdateMonitor fileMonitor;
-    private final Pane pane = new Pane();
-    private final TextArea codeArea = new TextArea();
 
     public SourceTab(BibDatabaseContext bibDatabaseContext, CountingUndoManager undoManager, LatexFieldFormatterPreferences fieldFormatterPreferences, JabRefPreferences preferences, FileUpdateMonitor fileMonitor) {
         this.mode = bibDatabaseContext.getMode();
@@ -66,7 +64,6 @@ public class SourceTab extends EntryEditorTab {
         this.preferences = preferences;
         this.fileMonitor = fileMonitor;
 
-        pane.getChildren().add(codeArea);
     }
 
     private static String getSourceString(BibEntry entry, BibDatabaseMode type, LatexFieldFormatterPreferences fieldFormatterPreferences) throws IOException {
@@ -84,7 +81,9 @@ public class SourceTab extends EntryEditorTab {
 
     @Override
     protected void bindToEntry(BibEntry entry) {
-
+        Pane pane = new Pane();
+        TextArea codeArea = new TextArea();
+        pane.getChildren().add(codeArea);
         NotificationPane notificationPane = new NotificationPane(pane);
         notificationPane.setShowFromTop(false);
         sourceValidator.getValidationStatus().getMessages().addListener((ListChangeListener<ValidationMessage>) c -> {
@@ -99,7 +98,7 @@ public class SourceTab extends EntryEditorTab {
         // Store source for every change in the source code
         // and update source code for every change of entry field values
         BindingsHelper.bindContentBidirectional(entry.getFieldsObservable(), codeArea.textProperty(), this::storeSource, fields -> {
-            DefaultTaskExecutor.runAndWaitInJavaFXThread(() -> {
+            DefaultTaskExecutor.runInJavaFXThread(() -> {
                 codeArea.clear();
                 try {
                     codeArea.appendText(getSourceString(entry, mode, fieldFormatterPreferences));

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -13,6 +13,7 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ListChangeListener;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.Tooltip;
+import javafx.scene.layout.Region;
 
 import org.jabref.gui.IconTheme;
 import org.jabref.gui.undo.CountingUndoManager;
@@ -81,9 +82,10 @@ public class SourceTab extends EntryEditorTab {
     @Override
     protected void bindToEntry(BibEntry entry) {
         TextArea codeArea = new TextArea();
-        codeArea.setPrefHeight(100);
-        javafx.scene.control.ScrollPane scrollPane = new javafx.scene.control.ScrollPane(codeArea);
+        codeArea.setPrefHeight(300);
+        codeArea.setMaxHeight(Region.USE_PREF_SIZE);
 
+        javafx.scene.control.ScrollPane scrollPane = new javafx.scene.control.ScrollPane(codeArea);
         NotificationPane notificationPane = new NotificationPane(scrollPane);
 
         notificationPane.setShowFromTop(false);

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -87,6 +87,7 @@ public class SourceTab extends EntryEditorTab {
 
         javafx.scene.control.ScrollPane scrollPane = new javafx.scene.control.ScrollPane(codeArea);
         NotificationPane notificationPane = new NotificationPane(scrollPane);
+        scrollPane.setMaxHeight(codeArea.getMaxHeight());
 
         notificationPane.setShowFromTop(false);
         sourceValidator.getValidationStatus().getMessages().addListener((ListChangeListener<ValidationMessage>) c -> {

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -11,6 +11,7 @@ import javax.swing.undo.UndoManager;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ListChangeListener;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.Tooltip;
 
@@ -81,9 +82,7 @@ public class SourceTab extends EntryEditorTab {
     @Override
     protected void bindToEntry(BibEntry entry) {
         TextArea codeArea = new TextArea();
-
-
-        javafx.scene.control.ScrollPane scrollPane = new javafx.scene.control.ScrollPane(codeArea);
+        ScrollPane scrollPane = new ScrollPane(codeArea);
         NotificationPane notificationPane = new NotificationPane(scrollPane);
 
         notificationPane.setShowFromTop(false);

--- a/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/SourceTab.java
@@ -13,7 +13,6 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ListChangeListener;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.Tooltip;
-import javafx.scene.layout.Pane;
 
 import org.jabref.gui.IconTheme;
 import org.jabref.gui.undo.CountingUndoManager;
@@ -81,10 +80,11 @@ public class SourceTab extends EntryEditorTab {
 
     @Override
     protected void bindToEntry(BibEntry entry) {
-        Pane pane = new Pane();
         TextArea codeArea = new TextArea();
-        pane.getChildren().add(codeArea);
-        NotificationPane notificationPane = new NotificationPane(pane);
+        javafx.scene.control.ScrollPane scrollPane = new javafx.scene.control.ScrollPane(codeArea);
+        scrollPane.autosize();
+        NotificationPane notificationPane = new NotificationPane(scrollPane);
+
         notificationPane.setShowFromTop(false);
         sourceValidator.getValidationStatus().getMessages().addListener((ListChangeListener<ValidationMessage>) c -> {
             if (sourceValidator.getValidationStatus().isValid()) {
@@ -98,10 +98,10 @@ public class SourceTab extends EntryEditorTab {
         // Store source for every change in the source code
         // and update source code for every change of entry field values
         BindingsHelper.bindContentBidirectional(entry.getFieldsObservable(), codeArea.textProperty(), this::storeSource, fields -> {
-            DefaultTaskExecutor.runInJavaFXThread(() -> {
+            DefaultTaskExecutor.runAndWaitInJavaFXThread(() -> {
                 codeArea.clear();
                 try {
-                    codeArea.appendText(getSourceString(entry, mode, fieldFormatterPreferences));
+                    codeArea.setText(getSourceString(entry, mode, fieldFormatterPreferences));
                 } catch (IOException ex) {
                     codeArea.setEditable(false);
                     codeArea.appendText(ex.getMessage() + "\n\n" +


### PR DESCRIPTION
I looked a bit more at the freezing problem and could nail it down to the CodeArea.
I replaced the CodeArea with a simple TextArea and now I don't get any freezes anylonger 

We don't use any extensive features of the TextArea, except for some styling.

We should adapt this for the 4.2 release as a workaround. As we don't have those freezes in the maintable-beta, I am in strong favor of using this.

I did some heavy clicking and scrolling and did not receive any freezes.


<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
