### PR TITLE
Group XMP-related translations together

### DIFF
--- a/src/main/resources/l10n/JabRef_da.properties
+++ b/src/main/resources/l10n/JabRef_da.properties
@@ -340,6 +340,20 @@ Do\ not\ overwrite\ existing\ keys=Overskriv ikke eksisterende nøgler
 Do\ not\ show\ these\ options\ in\ the\ future=Vis ikke disse valg igen
 
 Do\ not\ wrap\ the\ following\ fields\ when\ saving=Introducer ikke linjeskift i følgende felter ved gemning
+
+# all XMP related translations
+XMP-annotated\ PDF=XMP-annoteret PDF
+XMP-metadata\ found\ in\ PDF\:\ %0=XMP-metadata fundet i PDF\: %0
+Create\ entry\ based\ on\ XMP-metadata=Opret post baseret på XMP-data
+Write\ XMP=Skriv XMP
+Write\ XMP-metadata=Skriv XMP-metadata
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Skriv XMP-metadata for alle PDFer i denne library?
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Skriv BibTeX-posten som XMP-metadata til PDF.
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Skriver XMP-metadata til PDF-filerne linket fra de valgte poster.
+Writing\ XMP-metadata...=Skriver XMP-metadata...
+Writing\ XMP-metadata\ for\ selected\ entries...=Skriver XMP-metadata for de valgte poster...
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Fuldførte skrivning af XMP for %0-fil (sprang over %1, %2 fejl).
+XMP\ export\ privacy\ settings=Indstillinger for XMP-eksport
 Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Skriv ikke følgende felter til XMP-metadata\:
 
 Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Skal JabRef udføre de følgende operationer?
@@ -490,7 +504,6 @@ Files\ opened=Filer åbnet
 Finished\ automatically\ setting\ external\ links.=Fuldførte automatisk udfyldning af eksterne links.
 
 Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Fuldførte synkronisering af fil-links. Poster ændret\: %0.
-Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Fuldførte skrivning af XMP for %0-fil (sprang over %1, %2 fejl).
 
 First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Vælg først hvilke poster du vil generere nøgler for.
 
@@ -1220,21 +1233,9 @@ web\ link=link
 What\ do\ you\ want\ to\ do?=Hvad vil du gøre?
 
 When\ adding/removing\ keywords,\ separate\ them\ by=Når nøgleord tilføjes eller fjernes, adskil dem med
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Skriver XMP-metadata til PDF-filerne linket fra de valgte poster.
 
 with=med
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Skriv BibTeX-posten som XMP-metadata til PDF.
-
-Write\ XMP=Skriv XMP
-Write\ XMP-metadata=Skriv XMP-metadata
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Skriv XMP-metadata for alle PDFer i denne library?
-Writing\ XMP-metadata...=Skriver XMP-metadata...
-Writing\ XMP-metadata\ for\ selected\ entries...=Skriver XMP-metadata for de valgte poster...
-
-XMP-annotated\ PDF=XMP-annoteret PDF
-XMP\ export\ privacy\ settings=Indstillinger for XMP-eksport
-XMP-metadata\ found\ in\ PDF\:\ %0=XMP-metadata fundet i PDF\: %0
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Du skal genstarte JabRef for, at dette skal træde i kraft.
 You\ have\ changed\ the\ language\ setting.=Du har valgt et nyt sprog.
 You\ have\ entered\ an\ invalid\ search\ '%0'.=Ugyldigt søgeudtryk '%0'.
@@ -1371,7 +1372,6 @@ You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ te
 Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Åbn automatisk fildialog når nyt link oprettes
 Import\ metadata\ from\:=Importer metadata fra\:
 Choose\ the\ source\ for\ the\ metadata\ import=Vælg kilde for import af metadata
-Create\ entry\ based\ on\ XMP-metadata=Opret post baseret på XMP-data
 Create\ blank\ entry\ linking\ the\ PDF=Opret tom post med link til PDF-filen
 Only\ attach\ PDF=Tilføj kun PDF
 Title=Titel
@@ -1557,7 +1557,6 @@ Connect=Tilslut
 
 
 Existing\ file=Eksisterende fil
-
 
 
 

--- a/src/main/resources/l10n/JabRef_de.properties
+++ b/src/main/resources/l10n/JabRef_de.properties
@@ -351,6 +351,22 @@ Do\ not\ overwrite\ existing\ keys=Existierende Keys nicht überschreiben
 Do\ not\ show\ these\ options\ in\ the\ future=Diese Optionen in Zukunft nicht anzeigen
 
 Do\ not\ wrap\ the\ following\ fields\ when\ saving=Beim Speichern keinen Zeilenumbruch in den folgenden Feldern einfügen
+
+# all XMP related translations
+XMP-metadata=XMP-Metadaten
+XMP-annotated\ PDF=PDF mit XMP-Anmerkungen
+XMP-metadata\ found\ in\ PDF\:\ %0=XMP-Metadaten gefunden im PDF\: %0
+Create\ entry\ based\ on\ XMP-metadata=Eintrag aus XMP-Daten erstellen
+Write\ XMP=XMP schreiben
+Write\ XMP-metadata=Schreibe XMP-Metadaten
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=XMP-Metadaten für alle PDFs der aktuellen Bibliothek schreiben?
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=BibTeX-Eintrag als XMP-Metadaten ins PDF schreiben.
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Schreibe XMP-Metadaten in die PDFs, die mit den ausgewählten Einträgen verlinkt sind.
+Writing\ XMP-metadata...=XMP-Metadaten werden geschrieben...
+Writing\ XMP-metadata\ for\ selected\ entries...=XMP-Metadaten für ausgewählte Einträge werden geschrieben...
+Finished\ writing\ XMP-metadata.=XMP-Metadaten schreiben abgeschlossen.
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Schreiben der XMP-Metadaten für Datei %0 beendet (%1 übersprungen, %2 Fehler).
+XMP\ export\ privacy\ settings=Sicherheitseinstellungen für den XMP-Export
 Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Folgende Felder nicht in die XMP-Metadaten schreiben\:
 
 Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Soll JabRef die folgenden Vorgänge durchführen?
@@ -506,7 +522,6 @@ Filter\ None=Filter aufheben
 Finished\ automatically\ setting\ external\ links.=Automatische Einstellung externer Links abgeschlossen.
 
 Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Synchronisierung von Datei Links abgeschlossen. Geänderte Einträge\: %0.
-Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Schreiben der XMP-Metadaten für Datei %0 beendet (%1 übersprungen, %2 Fehler).
 
 First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Wählen Sie zuerst die Einträge aus, für die Keys erstellt werden sollen.
 
@@ -579,7 +594,6 @@ Underline=Unterstreichung
 Empty\ Highlight=Leere Hervorhebung
 Empty\ Marking=Leere Markierung
 Empty\ Underline=Leere Unterstreichung
-The\ marked\ area\ does\ not\ contain\ any\ legible\ text\!=Der markierte Bereich enthält keinen lesbaren Text\!
 
 Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Hinweis\: Um ausschließlich bestimmte Felder zu durchsuchen, geben Sie z.B. ein\:<p><tt>author\=smith and title\=electrical</tt>
 
@@ -1279,22 +1293,9 @@ web\ link=Web-Link
 What\ do\ you\ want\ to\ do?=Was möchten Sie tun?
 
 When\ adding/removing\ keywords,\ separate\ them\ by=Trennzeichen zwischen Stichwörtern im Gruppierungs-Feld
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Schreibe XMP-Metadaten in die PDFs, die mit den ausgewählten Einträgen verlinkt sind.
 
 with=mit
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=BibTeX-Eintrag als XMP-Metadaten ins PDF schreiben.
-
-Write\ XMP=XMP schreiben
-Write\ XMP-metadata=Schreibe XMP-Metadaten
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=XMP-Metadaten für alle PDFs der aktuellen Bibliothek schreiben?
-Writing\ XMP-metadata...=XMP-Metadaten werden geschrieben...
-Writing\ XMP-metadata\ for\ selected\ entries...=XMP-Metadaten für ausgewählte Einträge werden geschrieben...
-
-XMP-annotated\ PDF=PDF mit XMP-Anmerkungen
-XMP\ export\ privacy\ settings=Sicherheitseinstellungen für den XMP-Export
-XMP-metadata=XMP-Metadaten
-XMP-metadata\ found\ in\ PDF\:\ %0=XMP-Metadaten gefunden im PDF\: %0
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Sie müssen JabRef neu starten, damit diese Änderungen in Kraft treten.
 You\ have\ changed\ the\ language\ setting.=Sie haben die Spracheinstellung geändert.
 You\ have\ entered\ an\ invalid\ search\ '%0'.=Sie haben eine ungültige Suche '%0' eingegeben.
@@ -1441,7 +1442,6 @@ You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ te
 Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Beim Erstellen eines neuen Datei-Links den Durchsuchen-Dialog automatisch öffnen
 Import\ metadata\ from\:=Metadaten importieren von\:
 Choose\ the\ source\ for\ the\ metadata\ import=Quelle zum Import von Metadaten wählen
-Create\ entry\ based\ on\ XMP-metadata=Eintrag aus XMP-Daten erstellen
 Create\ blank\ entry\ linking\ the\ PDF=Leeren Eintrag erstellen mit Link zum PDF
 Only\ attach\ PDF=Nur PDF anhängen
 Title=Titel
@@ -2083,8 +2083,6 @@ Open\ console=Terminal öffnen
 Use\ default\ terminal\ emulator=Standard Terminal-Emulator verwenden
 Execute\ command=Befehl ausführen
 Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=Hinweis\: %0 als Platzhalter für den Speicherort der Bibliothek benutzen.
-Executing\ command\ "%0"...=Ausführung des Kommandos "%0"...
-Error\ occured\ while\ executing\ the\ command\ "%0".=Während der Ausführung des Befehls "%0" ist ein Fehler aufgetreten.
 Reformat\ ISSN=Formatiere ISSN
 
 Countries\ and\ territories\ in\ English=Länder und Territorien in Englisch
@@ -2132,7 +2130,6 @@ JabRef\ built\ in\ list=Integrierte JabRef-Liste
 IEEE\ built\ in\ list=Integrierte IEEE-Liste
 
 Event\ log=Ereignisprotokoll
-We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef's\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=Sie erhalten nun Einsicht in die Interna von JabRef. Diese Informationen kann dabei helfen die eigentliche Ursache eines Problems zu ergründen.
 Log\ copied\ to\ clipboard.=In die Zwischenablage kopiert
 Copy\ Log=Log kopieren
 Clear\ Log=Log löschen
@@ -2219,7 +2216,6 @@ shared=geteilt
 should\ contain\ an\ integer\ or\ a\ literal=Sollte einen Integer oder einen Literal enthalten
 should\ have\ the\ first\ letter\ capitalized=Sollte den ersten Buchstaben großgeschrieben haben
 Tools=Werkzeuge
-What's\ new\ in\ this\ version?=Neuerungen in dieser Version
 Want\ to\ help?=Wollen Sie helfen?
 Make\ a\ donation=Spenden
 get\ involved=Engagieren Sie sich
@@ -2342,7 +2338,6 @@ Could\ not\ retrieve\ entry\ data\ from\ '%0'.=Konnte Daten von '%0' nicht abruf
 Entry\ from\ %0\ could\ not\ be\ parsed.=Eintrag von %0 konnte nicht analysiert werden.
 Invalid\ identifier\:\ '%0'.=Ungültige Kennung\: "%0".
 This\ paper\ has\ been\ withdrawn.=Dieses Paper wurde zurückgezogen.
-Finished\ writing\ XMP-metadata.=XMP-Metadaten schreiben abgeschlossen.
 empty\ BibTeX\ key=Leerer BibTeX-Key
 Your\ Java\ Runtime\ Environment\ is\ located\ at\ %0.=Ihre Java Laufzeitumgebung befindet sich in %0.
 Aux\ file=Aux-Datei
@@ -2351,4 +2346,3 @@ Group\ containing\ entries\ cited\ in\ a\ given\ TeX\ file=Gruppe mit Einträgen
 Any\ file=Beliebige Datei
 
 No\ linked\ files\ found\ for\ export.=Keine verknüpften Dateien für den Export gefunden.
-

--- a/src/main/resources/l10n/JabRef_el.properties
+++ b/src/main/resources/l10n/JabRef_el.properties
@@ -155,7 +155,7 @@ Cannot\ add\ entries\ to\ group\ without\ generating\ keys.\ Generate\ keys\ now
 
 Cannot\ merge\ this\ change=Δεν είναι δυνατό να συγχωνευτεί αυτή η αλλαγή
 
-case\ insensitive=Χωρίς διάκριση πεζών - κεφαλαίων γραμμάτων 
+case\ insensitive=Χωρίς διάκριση πεζών - κεφαλαίων γραμμάτων
 
 case\ sensitive=διαφοροποίηση πεζών-κεφαλαίων
 
@@ -287,6 +287,8 @@ Description=Περιγραφή
 
 
 
+
+# all XMP related translations
 
 
 Donate\ to\ JabRef=Δωρεά στο JabRef
@@ -747,8 +749,6 @@ Pull\ changes\ from\ shared\ database=Τραβήξτε αλλαγές από τ�
 
 
 
-
-
 Forward=Επόμενο
 Back=Πίσω
 Set/clear/append/rename\ fields=Ρύθμιση/καθαρισμός/μετονομασία πεδίων
@@ -867,7 +867,6 @@ Copy\ BibTeX\ key\ and\ link=Αντιγραφή BibTeX και συνδέσμου
 
 Default\ table\ font\ size=Προεπιλεγμένη γραμματοσειρά πίνακα
 Show\ document\ viewer=Εμφάνιση προβολέα εγγράφου
-
 
 
 

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -350,6 +350,22 @@ Do\ not\ overwrite\ existing\ keys=Do not overwrite existing keys
 Do\ not\ show\ these\ options\ in\ the\ future=Do not show these options in the future
 
 Do\ not\ wrap\ the\ following\ fields\ when\ saving=Do not wrap the following fields when saving
+
+# all XMP related translations
+XMP-metadata=XMP-metadata
+XMP-annotated\ PDF=XMP-annotated PDF
+XMP-metadata\ found\ in\ PDF\:\ %0=XMP-metadata found in PDF: %0
+Create\ entry\ based\ on\ XMP-metadata=Create entry based on XMP-metadata
+Write\ XMP=Write XMP
+Write\ XMP-metadata=Write XMP-metadata
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Write XMP-metadata for all PDFs in current library?
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Write BibTeXEntry as XMP-metadata to PDF.
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Will write XMP-metadata to the PDFs linked from selected entries.
+Writing\ XMP-metadata...=Writing XMP-metadata...
+Writing\ XMP-metadata\ for\ selected\ entries...=Writing XMP-metadata for selected entries...
+Finished\ writing\ XMP-metadata.=Finished writing XMP-metadata.
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Finished writing XMP for %0 file (%1 skipped, %2 errors).
+XMP\ export\ privacy\ settings=XMP export privacy settings
 Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Do not write the following fields to XMP Metadata:
 
 Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Do you want JabRef to do the following operations?
@@ -505,7 +521,6 @@ Filter\ None=Filter None
 Finished\ automatically\ setting\ external\ links.=Finished automatically setting external links.
 
 Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Finished synchronizing file links. Entries changed: %0.
-Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Finished writing XMP for %0 file (%1 skipped, %2 errors).
 
 First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=First select the entries you want keys to be generated for.
 
@@ -1278,22 +1293,9 @@ web\ link=web link
 What\ do\ you\ want\ to\ do?=What do you want to do?
 
 When\ adding/removing\ keywords,\ separate\ them\ by=When adding/removing keywords, separate them by
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Will write XMP-metadata to the PDFs linked from selected entries.
 
 with=with
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Write BibTeXEntry as XMP-metadata to PDF.
-
-Write\ XMP=Write XMP
-Write\ XMP-metadata=Write XMP-metadata
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Write XMP-metadata for all PDFs in current library?
-Writing\ XMP-metadata...=Writing XMP-metadata...
-Writing\ XMP-metadata\ for\ selected\ entries...=Writing XMP-metadata for selected entries...
-
-XMP-annotated\ PDF=XMP-annotated PDF
-XMP\ export\ privacy\ settings=XMP export privacy settings
-XMP-metadata=XMP-metadata
-XMP-metadata\ found\ in\ PDF\:\ %0=XMP-metadata found in PDF: %0
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=You must restart JabRef for this to come into effect.
 You\ have\ changed\ the\ language\ setting.=You have changed the language setting.
 You\ have\ entered\ an\ invalid\ search\ '%0'.=You have entered an invalid search '%0'.
@@ -1440,7 +1442,6 @@ You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ te
 Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Automatically open browse dialog when creating new file link
 Import\ metadata\ from\:=Import metadata from:
 Choose\ the\ source\ for\ the\ metadata\ import=Choose the source for the metadata import
-Create\ entry\ based\ on\ XMP-metadata=Create entry based on XMP-metadata
 Create\ blank\ entry\ linking\ the\ PDF=Create blank entry linking the PDF
 Only\ attach\ PDF=Only attach PDF
 Title=Title
@@ -2341,7 +2342,6 @@ Could\ not\ retrieve\ entry\ data\ from\ '%0'.=Could not retrieve entry data fro
 Entry\ from\ %0\ could\ not\ be\ parsed.=Entry from %0 could not be parsed.
 Invalid\ identifier\:\ '%0'.=Invalid identifier: '%0'.
 This\ paper\ has\ been\ withdrawn.=This paper has been withdrawn.
-Finished\ writing\ XMP-metadata.=Finished writing XMP-metadata.
 empty\ BibTeX\ key=empty BibTeX key
 Your\ Java\ Runtime\ Environment\ is\ located\ at\ %0.=Your Java Runtime Environment is located at %0.
 Aux\ file=Aux file

--- a/src/main/resources/l10n/JabRef_es.properties
+++ b/src/main/resources/l10n/JabRef_es.properties
@@ -349,6 +349,21 @@ Do\ not\ overwrite\ existing\ keys=No sobreescribir claves existentes
 Do\ not\ show\ these\ options\ in\ the\ future=No mostrar estas ospciones en el futuro
 
 Do\ not\ wrap\ the\ following\ fields\ when\ saving=No envolver los siguientes campos al guardar
+
+# all XMP related translations
+XMP-metadata=Metadatos XMP
+XMP-annotated\ PDF=PDF con anotaciones XMP
+XMP-metadata\ found\ in\ PDF\:\ %0=Metadatos XMP encontrados en PDF\: '%0'
+Create\ entry\ based\ on\ XMP-metadata=Crear entradas a partir de datos XMP
+Write\ XMP=Escribir XMP
+Write\ XMP-metadata=Escribir metadatos XMP
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=¿Escribir metadatos XMP para todos los PDF en la biblioteca actual?
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Escribir entrada BibTeX como metadatos XMP al PDF.
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Escribirá metadatos XMP a los PDF's enlazados desde las entradas seleccionadas.
+Writing\ XMP-metadata...=Escribiendo metadatos XMP
+Writing\ XMP-metadata\ for\ selected\ entries...=Escribiendo metadatos XMP para las entradas seleccionadas...
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Se finalizó la escritura XMP en archivo %0 (%1 evitados, %2 errores).
+XMP\ export\ privacy\ settings=Ajustes de privacidad en exportación XMP
 Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=No escribir los campos a continuación a los metadatos XMP
 
 Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=¿Quiere que JabRef efectúe las siguientes operaciones?
@@ -503,7 +518,6 @@ Filter\ All=Filtrar todos
 Finished\ automatically\ setting\ external\ links.=Se ha finalizado la configuración automática de enlaces esternos.
 
 Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Se ha finalizado la sincronización de archivo enlaces. Se cambiaron \: %0 entradas.
-Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Se finalizó la escritura XMP en archivo %0 (%1 evitados, %2 errores).
 
 First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=En primer lugar, seleccione las entradas para las que desea generar claves
 
@@ -575,7 +589,6 @@ Underline=Subrayado
 Empty\ Highlight=Resaltado vacío
 Empty\ Marking=Marcado vacío
 Empty\ Underline=Subrayado vacío
-The\ marked\ area\ does\ not\ contain\ any\ legible\ text\!=¡El área marcada no contiente ningún texto legible\!
 
 Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Pista \: Para buscar sólo campos específicos, introduzca, por ejemplo, \: <p><tt>author\=smith and title\=electrical</tt>
 
@@ -1267,22 +1280,9 @@ web\ link=enlace a web
 What\ do\ you\ want\ to\ do?=¿Qué desea hacer?
 
 When\ adding/removing\ keywords,\ separate\ them\ by=Cuando se eliminen/añadan palabras clave, separar por
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Escribirá metadatos XMP a los PDF's enlazados desde las entradas seleccionadas.
 
 with=con
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Escribir entrada BibTeX como metadatos XMP al PDF.
-
-Write\ XMP=Escribir XMP
-Write\ XMP-metadata=Escribir metadatos XMP
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=¿Escribir metadatos XMP para todos los PDF en la biblioteca actual?
-Writing\ XMP-metadata...=Escribiendo metadatos XMP
-Writing\ XMP-metadata\ for\ selected\ entries...=Escribiendo metadatos XMP para las entradas seleccionadas...
-
-XMP-annotated\ PDF=PDF con anotaciones XMP
-XMP\ export\ privacy\ settings=Ajustes de privacidad en exportación XMP
-XMP-metadata=Metadatos XMP
-XMP-metadata\ found\ in\ PDF\:\ %0=Metadatos XMP encontrados en PDF\: '%0'
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Debe reiniciar JabRef para que los cambios surtan efecto.
 You\ have\ changed\ the\ language\ setting.=Ha cambiado el ajuste de lenguaje.
 You\ have\ entered\ an\ invalid\ search\ '%0'.=Ha introducido una búsqueda inválida '%0'
@@ -1428,7 +1428,6 @@ You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ te
 Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Abrir automáticamente el diálogo de exploración al crear nuevo enlace a archivo
 Import\ metadata\ from\:=Importar metadatos desde\:
 Choose\ the\ source\ for\ the\ metadata\ import=Escoger fuente para importar metadatos
-Create\ entry\ based\ on\ XMP-metadata=Crear entradas a partir de datos XMP
 Create\ blank\ entry\ linking\ the\ PDF=Crear entrada en blanco enlazando el PDF
 Only\ attach\ PDF=Sólo adjnntar PDF
 Title=Título
@@ -2067,8 +2066,6 @@ Open\ console=Abrir consola
 Use\ default\ terminal\ emulator=Usar emulador de consola por defecto
 Execute\ command=Ejecutar comando
 Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=Nota\:usar el marcador %0 para la ubicación de la biblioteca abierta
-Executing\ command\ "%0"...=Ejecutando el comando "%0"...
-Error\ occured\ while\ executing\ the\ command\ "%0".=Error durante la ejecución del comando "%0".
 Reformat\ ISSN=Reformatear ISSN
 
 Countries\ and\ territories\ in\ English=Países y territorios en inglés.
@@ -2116,7 +2113,6 @@ JabRef\ built\ in\ list=Lista preinstalada de JabRef
 IEEE\ built\ in\ list=Lista preinstalada de IEEE
 
 Event\ log=Registro de eventos
-We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef's\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=Esta es una visión de las interioridades de JabRef. Esta información puede ser útil para diagnosticar la causa principal del problema. Puede informar a los desarrolladores acerca del problema si lo desea.
 Log\ copied\ to\ clipboard.=Registro copiado al portapapeles
 Copy\ Log=Copiar registro
 Clear\ Log=Limpiar registro
@@ -2201,7 +2197,6 @@ shared=compartido
 should\ contain\ an\ integer\ or\ a\ literal=debería contener un entero o un literal
 should\ have\ the\ first\ letter\ capitalized=debería tener la primera letra mayúscula
 Tools=Herramientas
-What's\ new\ in\ this\ version?=¿Qué hay de nuevo en esta versión?
 Want\ to\ help?=¿Desea ayudar?
 Make\ a\ donation=Haga una donación
 get\ involved=participe
@@ -2295,6 +2290,5 @@ To\ improve\ the\ user\ experience,\ we\ would\ like\ to\ collect\ anonymous\ st
 Your\ current\ Java\ version\ (%0)\ is\ not\ supported.\ Please\ install\ version\ %1\ or\ higher.=No se admite la versión actual de Java (%0). Por favor, instale la versión %1 o superior.
 
 empty\ BibTeX\ key=vaciar clave BibTeX
-
 
 

--- a/src/main/resources/l10n/JabRef_fa.properties
+++ b/src/main/resources/l10n/JabRef_fa.properties
@@ -164,6 +164,8 @@ Delete\ entry=حذف مدخل
 
 
 
+# all XMP related translations
+
 
 Donate\ to\ JabRef=هدیه دادن به JabRef
 
@@ -603,8 +605,6 @@ Open\ terminal\ here=در اینجا پایانه را باز کن
 
 
 
-
-
 Forward=بعد
 Back=قبل
 Set/clear/append/rename\ fields=تنظیم/حذف/تغییرنام حوزه‌ها
@@ -670,7 +670,6 @@ Save\ all=ذخیره‌ی همه
 
 
 Unabbreviate\ journal\ names=برداشتن مخفف نام ژورنال‌ها
-
 
 
 

--- a/src/main/resources/l10n/JabRef_fr.properties
+++ b/src/main/resources/l10n/JabRef_fr.properties
@@ -351,6 +351,22 @@ Do\ not\ overwrite\ existing\ keys=Ne pas écraser de clefs existantes
 Do\ not\ show\ these\ options\ in\ the\ future=Ne pas afficher ces options à l'avenir
 
 Do\ not\ wrap\ the\ following\ fields\ when\ saving=Ne pas renvoyer à la ligne les champs suivants lors de l'enregistrement
+
+# all XMP related translations
+XMP-metadata=Métadonnées XMP
+XMP-annotated\ PDF=PDF avec annotations XMP
+XMP-metadata\ found\ in\ PDF\:\ %0=Métadonnées XMP trouvées dans le PDF \: %0
+Create\ entry\ based\ on\ XMP-metadata=Créer une entrée basée sur les données XMP
+Write\ XMP=Ecrire XMP
+Write\ XMP-metadata=Ecrire les métadonnées XMP
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Ecrire les métadonnées XMP pour tous les PDFs dans le fichier courant ?
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Ecrire l'entrée BibTeX comme des métadonnées XMP dans un PDF
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Ecrit les métadonnées XMP dans les PDFs liés aux entrées sélectionnées
+Writing\ XMP-metadata...=Ecriture des métadonnées XMP
+Writing\ XMP-metadata\ for\ selected\ entries...=Ecriture des métadonnées XMP pour les entrées sélectionnées
+Finished\ writing\ XMP-metadata.=Écriture des métadonnées XMP terminée.
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Fin de l'écriture des XMP pour %0 fichiers (%1 passés, %2 erreurs).
+XMP\ export\ privacy\ settings=Paramètres de confidentialité pour l'exportation XMP
 Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Ne pas écrire les champs suivants dans les métadonnées XMP \:
 
 Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Voulez-vous que JabRef fasse les opérations suivantes ?
@@ -506,7 +522,6 @@ Filter\ None=Aucun filtre
 Finished\ automatically\ setting\ external\ links.=La définition automatique des liens externes est terminée.
 
 Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Synchronisation des liens fichier terminée. Entrées modifiées \: %0.
-Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Fin de l'écriture des XMP pour %0 fichiers (%1 passés, %2 erreurs).
 
 First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Commencez par sélectionner les entrées pour lesquelles vous voulez que des clefs soient générées.
 
@@ -579,7 +594,6 @@ Underline=Souligner
 Empty\ Highlight=Annuler le surlignement
 Empty\ Marking=Annuler l'étiquetage
 Empty\ Underline=Annuler le soulignement
-The\ marked\ area\ does\ not\ contain\ any\ legible\ text\!=La zone marquée ne contient aucun texte lisible \!
 
 Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Astuce \: Pour chercher uniquement dans des champs spécifiques, entrez par exemple \:<p><tt>author\=smith and title\=électrique</tt>
 
@@ -1279,22 +1293,9 @@ web\ link=Lien internet
 What\ do\ you\ want\ to\ do?=Que voulez-vous faire ?
 
 When\ adding/removing\ keywords,\ separate\ them\ by=Lors de l'ajout/suppression de mots-clefs, les séparer avec
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Ecrit les métadonnées XMP dans les PDFs liés aux entrées sélectionnées
 
 with=avec
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Ecrire l'entrée BibTeX comme des métadonnées XMP dans un PDF
-
-Write\ XMP=Ecrire XMP
-Write\ XMP-metadata=Ecrire les métadonnées XMP
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Ecrire les métadonnées XMP pour tous les PDFs dans le fichier courant ?
-Writing\ XMP-metadata...=Ecriture des métadonnées XMP
-Writing\ XMP-metadata\ for\ selected\ entries...=Ecriture des métadonnées XMP pour les entrées sélectionnées
-
-XMP-annotated\ PDF=PDF avec annotations XMP
-XMP\ export\ privacy\ settings=Paramètres de confidentialité pour l'exportation XMP
-XMP-metadata=Métadonnées XMP
-XMP-metadata\ found\ in\ PDF\:\ %0=Métadonnées XMP trouvées dans le PDF \: %0
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Vous devez redémarrer JabRef pour que ce changement prenne effet.
 You\ have\ changed\ the\ language\ setting.=Vous avez modifié la langue.
 You\ have\ entered\ an\ invalid\ search\ '%0'.=Vous avez entré une recherche invalide '%0'.
@@ -1441,7 +1442,6 @@ You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ te
 Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Ouvrir automatiquement la fenêtre de navigation lors de la création d'un nouveau lien de fichier
 Import\ metadata\ from\:=Importer les métadonnées depuis \:
 Choose\ the\ source\ for\ the\ metadata\ import=Choisir la source pour l'importation des métadonnées
-Create\ entry\ based\ on\ XMP-metadata=Créer une entrée basée sur les données XMP
 Create\ blank\ entry\ linking\ the\ PDF=Créer une entrée vide liée au PDF
 Only\ attach\ PDF=Lier uniquement le PDF
 Title=Titre
@@ -2083,8 +2083,6 @@ Open\ console=Ouvrir la console
 Use\ default\ terminal\ emulator=Utilise l'émulateur de terminal par défaut
 Execute\ command=Lance une commande
 Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=Note \: Utiliser le paramètre %0 comme localisation du fichier ouverte.
-Executing\ command\ "%0"...=Exécution de la commande "%0"...
-Error\ occured\ while\ executing\ the\ command\ "%0".=Une erreur est survenue lors de l'exécution de la commande "%0".
 Reformat\ ISSN=Reformater l'ISSN
 
 Countries\ and\ territories\ in\ English=Pays et territoires en anglais
@@ -2132,7 +2130,6 @@ JabRef\ built\ in\ list=Liste interne de JabRef
 IEEE\ built\ in\ list=List interne de IEEE
 
 Event\ log=Journal des évènements
-We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef's\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=Nous vous donnons à présent un aperçu du fonctionnemment interne de JabRef. Cette information pourrait être utile pour diagnostiquer la cause du problème. S'il vous plaît, informez les développeurs des anomalies rencontrées.
 Log\ copied\ to\ clipboard.=Journal copié dans le presse-papiers.
 Copy\ Log=Copier le journal
 Clear\ Log=Vider le journal
@@ -2219,7 +2216,6 @@ shared=partagé
 should\ contain\ an\ integer\ or\ a\ literal=doit contenir un nombre entier ou en toutes lettres
 should\ have\ the\ first\ letter\ capitalized=doit avoir une première lettre en majuscule
 Tools=Outils
-What's\ new\ in\ this\ version?=Quoi de neuf dans cette version ?
 Want\ to\ help?=Vous voulez aider ?
 Make\ a\ donation=Faire un don
 get\ involved=S'impliquer
@@ -2342,7 +2338,6 @@ Could\ not\ retrieve\ entry\ data\ from\ '%0'.=Impossible de récupérer les don
 Entry\ from\ %0\ could\ not\ be\ parsed.=Entrée de %0 n’a pas pu être analysée.
 Invalid\ identifier\:\ '%0'.=Identifiant non valide \: « %0 ».
 This\ paper\ has\ been\ withdrawn.=Cet article a été retiré.
-Finished\ writing\ XMP-metadata.=Écriture des métadonnées XMP terminée.
 empty\ BibTeX\ key=Clef BibTeX vide
 Your\ Java\ Runtime\ Environment\ is\ located\ at\ %0.=Votre environnement d’exécution Java se trouve à %0.
 Aux\ file=Fichier aux
@@ -2351,4 +2346,3 @@ Group\ containing\ entries\ cited\ in\ a\ given\ TeX\ file=Groupe contenant les 
 Any\ file=N’importe quel fichier
 
 No\ linked\ files\ found\ for\ export.=Aucun fichier lié trouvé pour l'exportation.
-

--- a/src/main/resources/l10n/JabRef_in.properties
+++ b/src/main/resources/l10n/JabRef_in.properties
@@ -349,6 +349,21 @@ Do\ not\ overwrite\ existing\ keys=Jangan menindih kunci yang ada
 Do\ not\ show\ these\ options\ in\ the\ future=Untuk selanjutnya jangan tampilkan ini lagi
 
 Do\ not\ wrap\ the\ following\ fields\ when\ saving=Jangan lipat bidang berikut ketika menyimpan
+
+# all XMP related translations
+XMP-metadata=Metadata XMP
+XMP-annotated\ PDF=Anotasi XMP PDF
+XMP-metadata\ found\ in\ PDF\:\ %0=XMP metadata ditemukan di PDF\: %0
+Create\ entry\ based\ on\ XMP-metadata=Membuat entri berasal data XMP
+Write\ XMP=Menulis XMP
+Write\ XMP-metadata=Menulis XMP-metadata
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Menulis XMP-metadata untuk semua PDF di basisdata sekarang?
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Menulis BibTeXEntry sebagai XMP-metadata ke PDF.
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Akan menulis metadata XMP ke tautan PDF dari entri pilihan.
+Writing\ XMP-metadata...=Sedang menulis XMP metadata...
+Writing\ XMP-metadata\ for\ selected\ entries...=Sedang menulis XMP metadata untuk entri pilihan...
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Selesai menulis XMP untuk berkas %0 (%1 dilewati, %2 kesalahan).
+XMP\ export\ privacy\ settings=Pengaturan Info Ekspor XMP
 Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Jangan menulis bidang dibawah pada Metadata XMP\:
 
 Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Apakah anda ingin JabRef melakukan proses berikut?
@@ -503,7 +518,6 @@ Filter\ None=Filter tidak ada
 Finished\ automatically\ setting\ external\ links.=Selesai pengaturan otomatis tautan eksternal.
 
 Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Selesai menyelaraskan berkas tautan. Entri diubah\: %0.
-Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Selesai menulis XMP untuk berkas %0 (%1 dilewati, %2 kesalahan).
 
 First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Pertama pilih entri yang anda kehendaki untuk dibuat kunci.
 
@@ -575,7 +589,6 @@ Underline=Garis bawah
 Empty\ Highlight=Sorot kosong
 Empty\ Marking=Tanda Kosong
 Empty\ Underline=Garis Bawah Kosong
-The\ marked\ area\ does\ not\ contain\ any\ legible\ text\!=Area yang ditandai tidak berisi teks yang dapat dibaca\!
 
 Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Sarant\: untuk mencari hanya bidang tertentu, misal tulis\:<p><tt>author\=smith dan title\=electrical</tt>
 
@@ -1269,22 +1282,9 @@ web\ link=tautan web
 What\ do\ you\ want\ to\ do?=Apa yang anda inginkan?
 
 When\ adding/removing\ keywords,\ separate\ them\ by=Ketika menambah/menghapus katakunci, pisahkan dengan tanda
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Akan menulis metadata XMP ke tautan PDF dari entri pilihan.
 
 with=dan
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Menulis BibTeXEntry sebagai XMP-metadata ke PDF.
-
-Write\ XMP=Menulis XMP
-Write\ XMP-metadata=Menulis XMP-metadata
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Menulis XMP-metadata untuk semua PDF di basisdata sekarang?
-Writing\ XMP-metadata...=Sedang menulis XMP metadata...
-Writing\ XMP-metadata\ for\ selected\ entries...=Sedang menulis XMP metadata untuk entri pilihan...
-
-XMP-annotated\ PDF=Anotasi XMP PDF
-XMP\ export\ privacy\ settings=Pengaturan Info Ekspor XMP
-XMP-metadata=Metadata XMP
-XMP-metadata\ found\ in\ PDF\:\ %0=XMP metadata ditemukan di PDF\: %0
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Anda harus menjalankan ulang JabRef agar berfungsi.
 You\ have\ changed\ the\ language\ setting.=Anda telah mengganti pengaturan bahasa.
 You\ have\ entered\ an\ invalid\ search\ '%0'.=Anda telah menulis pencarian yang salah '%0'.
@@ -1431,7 +1431,6 @@ You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ te
 Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Otomatis membuka dialog jelajah ketika membuat tautan berkas baru
 Import\ metadata\ from\:=Impor Metadata dari\:
 Choose\ the\ source\ for\ the\ metadata\ import=Pilih sumber untuk impor metadata
-Create\ entry\ based\ on\ XMP-metadata=Membuat entri berasal data XMP
 Create\ blank\ entry\ linking\ the\ PDF=Membuat entri kosong tautan PDF
 Only\ attach\ PDF=Hanya lampirkan PDF
 Title=Judul
@@ -2070,8 +2069,6 @@ Open\ console=Buka konsol
 Use\ default\ terminal\ emulator=Gunakan emulator terminal standar
 Execute\ command=Jalankan perintah
 Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=Catatan\: Gunakan placeholder% 0 untuk lokasi file library yang dibuka.
-Executing\ command\ "%0"...=Perintah pelaksana "%0"...
-Error\ occured\ while\ executing\ the\ command\ "%0".=Terjadi kesalahan saat menjalankan perintah "%0".
 Reformat\ ISSN=Reformat ISSN
 
 Countries\ and\ territories\ in\ English=Negara dan wilayah dalam bahasa Inggris
@@ -2119,7 +2116,6 @@ JabRef\ built\ in\ list=JabRef masuk daftar
 IEEE\ built\ in\ list=Daftar built in IEEE
 
 Event\ log=Log peristiwa
-We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef's\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=Kami sekarang memberi Anda wawasan tentang cara kerja internal JabRef. Informasi ini mungkin bisa membantu mendiagnosis akar permasalahan. Jangan ragu untuk memberi tahu pengembang tentang sebuah masalah.
 Log\ copied\ to\ clipboard.=Log disalin ke clipboard.
 Copy\ Log=Salin Log
 Clear\ Log=Hapus Log
@@ -2206,7 +2202,6 @@ shared=bersama
 should\ contain\ an\ integer\ or\ a\ literal=harus mengandung bilangan bulat atau literal
 should\ have\ the\ first\ letter\ capitalized=harus memiliki huruf pertama yang dikapitalisasi
 Tools=Alat
-What's\ new\ in\ this\ version?=Apa yang baru di versi ini?
 Want\ to\ help?=Want to help?
 Make\ a\ donation=Berikan sumbangan
 get\ involved=terlibat
@@ -2330,6 +2325,5 @@ Entry\ from\ %0\ could\ not\ be\ parsed.=Entri dari % 0 tidak dapat diuraikan.
 Invalid\ identifier\:\ '%0'.=Pengenal tidak valid\: ' % 0 '.
 This\ paper\ has\ been\ withdrawn.=Makalah ini telah ditarik.
 empty\ BibTeX\ key=kosongkan tombol BibTeX
-
 
 

--- a/src/main/resources/l10n/JabRef_it.properties
+++ b/src/main/resources/l10n/JabRef_it.properties
@@ -349,6 +349,21 @@ Do\ not\ overwrite\ existing\ keys=Non sovrascrivere chiavi esistenti
 Do\ not\ show\ these\ options\ in\ the\ future=Non mostrare queste opzioni in futuro
 
 Do\ not\ wrap\ the\ following\ fields\ when\ saving=Non mandare a capo i campi seguenti salvando il file
+
+# all XMP related translations
+XMP-metadata=Metadati XMP
+XMP-annotated\ PDF=PDF con annotazioni XMP
+XMP-metadata\ found\ in\ PDF\:\ %0=Metadati XMP trovati nel file PDF\: %0
+Create\ entry\ based\ on\ XMP-metadata=Crea una nuova voce in base ai dati XMP
+Write\ XMP=Scrivi XMP
+Write\ XMP-metadata=Scrivi i metadati XMP
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Scrivere i metadati XMP per tutti i file PDF della libreria corrente?
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Scrivi voce BibTeX come metadati XMP in un file PDF.
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Scrive i metadati XMP nei file PDF collegati alle voci selezionate
+Writing\ XMP-metadata...=Scrittura dei metadati XMP...
+Writing\ XMP-metadata\ for\ selected\ entries...=Scrittura dei metadati XMP per le voci selezionate
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Terminata la scrittura di metadati XMP per %0 file (%1 saltati, %2 errori).
+XMP\ export\ privacy\ settings=Impostazioni per la riservatezza dei dati XMP esportati
 Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Non scrivere i dati dei campi seguenti nei metadati XMP\:
 
 Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Vuoi che JabRef esegua le operazioni seguenti?
@@ -504,7 +519,6 @@ Filter\ None=Filtra nulla
 Finished\ automatically\ setting\ external\ links.=Impostazione automatica dei collegamenti esterni terminata.
 
 Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Sincronizzazione di collegamenti a file\: Voci cambiate\: %0.
-Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Terminata la scrittura di metadati XMP per %0 file (%1 saltati, %2 errori).
 
 First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Selezionare dapprima le voci per le quali si vogliono generare le chiavi.
 
@@ -576,7 +590,6 @@ Underline=Sottolinea
 Empty\ Highlight=Evidenziazione vuota
 Empty\ Marking=Contrassegno vuoto
 Empty\ Underline=Sottolineatura vuota
-The\ marked\ area\ does\ not\ contain\ any\ legible\ text\!=L'area marcata non contiene alcun testo leggibile\!
 
 Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Suggerimento\: Per ricercare in un campo specifico digitare, per esempio\:<p><tt>author\=smith and title\=electrical</tt>
 
@@ -1267,22 +1280,9 @@ web\ link=collegamenti Internet
 What\ do\ you\ want\ to\ do?=Cosa vuoi fare?
 
 When\ adding/removing\ keywords,\ separate\ them\ by=All'aggiunta/rimozione di keyword separarle con
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Scrive i metadati XMP nei file PDF collegati alle voci selezionate
 
 with=con
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Scrivi voce BibTeX come metadati XMP in un file PDF.
-
-Write\ XMP=Scrivi XMP
-Write\ XMP-metadata=Scrivi i metadati XMP
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Scrivere i metadati XMP per tutti i file PDF della libreria corrente?
-Writing\ XMP-metadata...=Scrittura dei metadati XMP...
-Writing\ XMP-metadata\ for\ selected\ entries...=Scrittura dei metadati XMP per le voci selezionate
-
-XMP-annotated\ PDF=PDF con annotazioni XMP
-XMP\ export\ privacy\ settings=Impostazioni per la riservatezza dei dati XMP esportati
-XMP-metadata=Metadati XMP
-XMP-metadata\ found\ in\ PDF\:\ %0=Metadati XMP trovati nel file PDF\: %0
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Riavviare JabRef per rendere effettiva la modifica.
 You\ have\ changed\ the\ language\ setting.=La lingua è stata modificata.
 You\ have\ entered\ an\ invalid\ search\ '%0'.=È stata inserita una ricerca non valida '%0'.
@@ -1426,7 +1426,6 @@ You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ te
 Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Apri automaticamente la finestra di dialogo "Sfoglia" quando viene creato un nuovo collegamento ad un file
 Import\ metadata\ from\:=Importa i Metadati da\:
 Choose\ the\ source\ for\ the\ metadata\ import=Scegli la sorgente dei metadati da importare
-Create\ entry\ based\ on\ XMP-metadata=Crea una nuova voce in base ai dati XMP
 Create\ blank\ entry\ linking\ the\ PDF=Crea una voce vuota collegata al file PDF
 Only\ attach\ PDF=Allega solo il file PDF
 Title=Titolo
@@ -2065,8 +2064,6 @@ Open\ console=Apri la console
 Use\ default\ terminal\ emulator=Usa l'emulatore di terminale predefinito
 Execute\ command=Esegui il comando
 Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=Nota\: Usa il segnaposto %0 come posizione nel file di libreria aperto.
-Executing\ command\ "%0"...=Esegui il comando "%0"
-Error\ occured\ while\ executing\ the\ command\ "%0".=È avvenuto un errore eseguendo il comando "%0".
 Reformat\ ISSN=Riformatta ISSN
 
 Countries\ and\ territories\ in\ English=Paesi e territori in inglese
@@ -2114,7 +2111,6 @@ JabRef\ built\ in\ list=Liste predefinite di JabRef
 IEEE\ built\ in\ list=Liste predefinite di IEEE
 
 Event\ log=Log degli eventi
-We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef's\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=Ora ti daremo un'idea del funzionamento interno di JabRef. Questa informazione potrà essere utile per diagnosticare la causa originale del problema. Per favore, sentitevi liberi di informare gli sviluppatori di qualsiasi problema.
 Log\ copied\ to\ clipboard.=Log copiato negli appunti.
 Copy\ Log=Copia il log
 Clear\ Log=Cancello il log
@@ -2198,7 +2194,6 @@ shared=condiviso
 should\ contain\ an\ integer\ or\ a\ literal=deve contenere almeno un intero o una lettera
 should\ have\ the\ first\ letter\ capitalized=la prima lettera deve essere maiuscola
 Tools=Strumenti
-What's\ new\ in\ this\ version?=Cosa c'è di nuovo in questa versione?
 Want\ to\ help?=Ti serve aiuto?
 Make\ a\ donation=Fai una donazione
 get\ involved=collabora con noi
@@ -2306,4 +2301,3 @@ Aux\ file=File aux
 Any\ file=Qualsiasi file
 
 No\ linked\ files\ found\ for\ export.=Nessun file collegati trovati per esportazione.
-

--- a/src/main/resources/l10n/JabRef_ja.properties
+++ b/src/main/resources/l10n/JabRef_ja.properties
@@ -351,6 +351,22 @@ Do\ not\ overwrite\ existing\ keys=既存の鍵は上書きしない
 Do\ not\ show\ these\ options\ in\ the\ future=これらのオプションはもう表示しない
 
 Do\ not\ wrap\ the\ following\ fields\ when\ saving=以下のフィールドは保存時に改行しない
+
+# all XMP related translations
+XMP-metadata=XMPメタデータ
+XMP-annotated\ PDF=XMP注釈付きPDF
+XMP-metadata\ found\ in\ PDF\:\ %0=PDF中にXMPメタデータを検出しました：%0
+Create\ entry\ based\ on\ XMP-metadata=XMPデータに基づいて項目を生成
+Write\ XMP=XMPを書き込む
+Write\ XMP-metadata=XMPメタデータを書き込む
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=現データベースの全PDFにXMPメタデータを書き込みますか？
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=PDFにBibTeX項目をXMPメタデータとして書き込む．
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=選択した項目からリンクされているPDFにXMPメタデータを書き込みます．
+Writing\ XMP-metadata...=XMPメタデータを書き込んでいます...
+Writing\ XMP-metadata\ for\ selected\ entries...=選択した項目にXMPメタデータを書き込んでいます...
+Finished\ writing\ XMP-metadata.=XMPメタデータを書き終えました．
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=XMPを%0ファイルに書き込み終わりました（%1スキップ・%2エラー）．
+XMP\ export\ privacy\ settings=XMP書き出しのプライバシー設定
 Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=以下のフィールドはXMPメタデータに書き込まない：
 
 Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=JabRefに以下の操作をさせますか？
@@ -506,7 +522,6 @@ Filter\ None=フィルタを外す
 Finished\ automatically\ setting\ external\ links.=外部リンクの自動設定が終了しました
 
 Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=ファイルリンクの同期し終えました．変更された項目：%0．
-Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=XMPを%0ファイルに書き込み終わりました（%1スキップ・%2エラー）．
 
 First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=鍵を生成させたい項目をまず選択してください．
 
@@ -579,7 +594,6 @@ Underline=下線
 Empty\ Highlight=着色を取り除く
 Empty\ Marking=標識を取り除く
 Empty\ Underline=下線を取り除く
-The\ marked\ area\ does\ not\ contain\ any\ legible\ text\!=標識した領域に文が含まれていません！
 
 Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=ヒント：特定のフィールドのみを検索するには，たとえば：<p><tt>author\=smith and title\=electrical</tt>と入力してください
 
@@ -1279,22 +1293,9 @@ web\ link=ウェブリンク
 What\ do\ you\ want\ to\ do?=どうしますか？
 
 When\ adding/removing\ keywords,\ separate\ them\ by=キーワードを追加・削除する際，それらを以下の文字で区切る
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=選択した項目からリンクされているPDFにXMPメタデータを書き込みます．
 
 with=と
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=PDFにBibTeX項目をXMPメタデータとして書き込む．
-
-Write\ XMP=XMPを書き込む
-Write\ XMP-metadata=XMPメタデータを書き込む
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=現データベースの全PDFにXMPメタデータを書き込みますか？
-Writing\ XMP-metadata...=XMPメタデータを書き込んでいます...
-Writing\ XMP-metadata\ for\ selected\ entries...=選択した項目にXMPメタデータを書き込んでいます...
-
-XMP-annotated\ PDF=XMP注釈付きPDF
-XMP\ export\ privacy\ settings=XMP書き出しのプライバシー設定
-XMP-metadata=XMPメタデータ
-XMP-metadata\ found\ in\ PDF\:\ %0=PDF中にXMPメタデータを検出しました：%0
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=これを有効にするためにはJabRefを再起動する必要があります．
 You\ have\ changed\ the\ language\ setting.=言語設定が変更されました．
 You\ have\ entered\ an\ invalid\ search\ '%0'.=無効な検索「%0」を入力しました．
@@ -1441,7 +1442,6 @@ You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ te
 Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=新しくファイルリンクを作成する際，自動的にブラウズダイアログを開く
 Import\ metadata\ from\:=右記からメタデータを読み込み：
 Choose\ the\ source\ for\ the\ metadata\ import=メタデータを読み込むソースを選んでください
-Create\ entry\ based\ on\ XMP-metadata=XMPデータに基づいて項目を生成
 Create\ blank\ entry\ linking\ the\ PDF=PDFにリンクした空の項目を生成
 Only\ attach\ PDF=PDFを添付してください
 Title=タイトル
@@ -2083,8 +2083,6 @@ Open\ console=コンソールを開く
 Use\ default\ terminal\ emulator=既定の擬似端末を使用する
 Execute\ command=コマンドを実行
 Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=【註】開かれたデータベースの場所のプレイスホルダーに%0を使用します．
-Executing\ command\ "%0"...=コマンド「%0」を実行…
-Error\ occured\ while\ executing\ the\ command\ "%0".=コマンド「%0」を実行中にエラーが発生しました
 Reformat\ ISSN=ISSNを再構成
 
 Countries\ and\ territories\ in\ English=英語での国名・地域名
@@ -2132,7 +2130,6 @@ JabRef\ built\ in\ list=JabRef組込リスト
 IEEE\ built\ in\ list=IEEE組込リスト
 
 Event\ log=イベントログ
-We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef's\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=これからJabRef内部の内部動作についての情報を提供します．この情報は，問題の根本原因を診断するために役立つことがあります．お気軽に問題を開発者に相談してください．
 Log\ copied\ to\ clipboard.=ログがクリップボードにコピーされました．
 Copy\ Log=ログをコピー
 Clear\ Log=ログを消去
@@ -2219,7 +2216,6 @@ shared=共有中
 should\ contain\ an\ integer\ or\ a\ literal=整数または文字を含んでいなくてはなりません
 should\ have\ the\ first\ letter\ capitalized=最初の文字を大文字にしなくてはなりません
 Tools=ツール
-What's\ new\ in\ this\ version?=このバージョンの新しいところは？
 Want\ to\ help?=手助けが必要ですか？
 Make\ a\ donation=寄付をするには
 get\ involved=参加するには
@@ -2342,7 +2338,6 @@ Could\ not\ retrieve\ entry\ data\ from\ '%0'.='%0' から項目データを取�
 Entry\ from\ %0\ could\ not\ be\ parsed.=%0 からの項目を解析することができませんでした．
 Invalid\ identifier\:\ '%0'.=「%0」は識別子として無効です．
 This\ paper\ has\ been\ withdrawn.=この論文は撤回されました．
-Finished\ writing\ XMP-metadata.=XMPメタデータを書き終えました．
 empty\ BibTeX\ key=空のBibTeX鍵
 Your\ Java\ Runtime\ Environment\ is\ located\ at\ %0.=お使いのJava Runtime Environmentは%0にあります．
 Aux\ file=auxファイル
@@ -2351,4 +2346,3 @@ Group\ containing\ entries\ cited\ in\ a\ given\ TeX\ file=特定のTeXファイ
 Any\ file=任意のファイル
 
 No\ linked\ files\ found\ for\ export.=エクスポートしようとしましたが，リンク先のファイルが見つかりません．
-

--- a/src/main/resources/l10n/JabRef_nl.properties
+++ b/src/main/resources/l10n/JabRef_nl.properties
@@ -321,6 +321,16 @@ Do\ not\ overwrite\ existing\ keys=Bestaande BibTeX-sleutels niet overschrijven
 
 Do\ not\ wrap\ the\ following\ fields\ when\ saving=De volgende velden niet bij het opslaan afbreken
 
+# all XMP related translations
+XMP-metadata=XMP metadata
+XMP-annotated\ PDF=XMP geannoteerde PDF
+Write\ XMP=Schrijf XMP
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Schrijf BibTeX-entry als XMP-metadata naar PDF.
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Zal XMP metadata naar de PDFs gelinkt vanuit geselecteerde entries schrijven.
+Writing\ XMP-metadata...=XMP metadata aan het schrijven...
+Writing\ XMP-metadata\ for\ selected\ entries...=XMP metadata voor geselecteerde entries aan het schrijven...
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=XMP schrijven voor %0 bestand voltooid (%1 overgeslagen, %2 fouten).
+
 
 Donate\ to\ JabRef=Doneer aan JabRef
 
@@ -447,7 +457,6 @@ Files\ opened=Bestanden geopend
 
 
 Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Synchroniseren van bestand snelkoppelingen voltooid. Aantal veranderde entries\: %0.
-Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=XMP schrijven voor %0 bestand voltooid (%1 overgeslagen, %2 fouten).
 
 First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Selecteer eerst de entries waarvoor u sleutels wilt genereren.
 
@@ -1123,18 +1132,9 @@ web\ link=web-link
 What\ do\ you\ want\ to\ do?=Wat wilt u doen?
 
 When\ adding/removing\ keywords,\ separate\ them\ by=Wanneer u sleutelwoorden toevoegt/verwijdert, scheid ze dan door
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Zal XMP metadata naar de PDFs gelinkt vanuit geselecteerde entries schrijven.
 
 with=met
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Schrijf BibTeX-entry als XMP-metadata naar PDF.
-
-Write\ XMP=Schrijf XMP
-Writing\ XMP-metadata...=XMP metadata aan het schrijven...
-Writing\ XMP-metadata\ for\ selected\ entries...=XMP metadata voor geselecteerde entries aan het schrijven...
-
-XMP-annotated\ PDF=XMP geannoteerde PDF
-XMP-metadata=XMP metadata
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=U moet JabRef herstarten om dit toe te passen.
 You\ have\ changed\ the\ language\ setting.=U heeft de taalinstelling veranderd.
 
@@ -1252,7 +1252,6 @@ Unabbreviate\ journal\ names=Maak afkorting van tijdschriftnamen ongedaan
 
 Port=Poort
 Connect=Verbinden
-
 
 
 

--- a/src/main/resources/l10n/JabRef_no.properties
+++ b/src/main/resources/l10n/JabRef_no.properties
@@ -337,6 +337,20 @@ Do\ not\ overwrite\ existing\ keys=Ikke skriv over eksisterende nøkler
 Do\ not\ show\ these\ options\ in\ the\ future=Ikke vis disse valgene igjen
 
 Do\ not\ wrap\ the\ following\ fields\ when\ saving=Ikke introduser linjeskift i følgende felter ved lagring
+
+# all XMP related translations
+XMP-annotated\ PDF=XMP-annotert PDF
+XMP-metadata\ found\ in\ PDF\:\ %0=XMP-metadata funnet i PDF\: %0
+Create\ entry\ based\ on\ XMP-metadata=Lag enhet basert på XMP-data
+Write\ XMP=Skriv XMP
+Write\ XMP-metadata=Skriv XMP-metadata
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Skriv XMP-metadata for alle PDFer i denne libraryn?
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Skriv BibTeX-enheten som XMP-metadata til PDF.
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Vil skrive XMP-metadata til PDFene linket fra de valgte enhetene.
+Writing\ XMP-metadata...=Skriver XMP-metadata...
+Writing\ XMP-metadata\ for\ selected\ entries...=Skriver XMP-metadata for de valgte enhetene...
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Fullførte skriving av XMP-data for %0 fil(er) (hoppet over %1, %2 mislyktes).
+XMP\ export\ privacy\ settings=Innstillinger for XMP-eksport
 Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Ikke skriv de følgende feltene til XMP-metadata\:
 
 Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Vil du at JabRef skal gjøre de følgende operasjonene?
@@ -487,7 +501,6 @@ Files\ opened=Filer åpnet
 Finished\ automatically\ setting\ external\ links.=Fullførte automatisk setting av eksterne linker.
 
 Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Fullførte synkronisering av fil-linker. Enheter endret\: %0.
-Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Fullførte skriving av XMP-data for %0 fil(er) (hoppet over %1, %2 mislyktes).
 
 First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Velg først hvilke enheter du vil generere nøkler for.
 
@@ -1216,21 +1229,9 @@ web\ link=link
 What\ do\ you\ want\ to\ do?=Hva vil du gjøre?
 
 When\ adding/removing\ keywords,\ separate\ them\ by=Når nøkkelord legges til eller fjernes skill dem med
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Vil skrive XMP-metadata til PDFene linket fra de valgte enhetene.
 
 with=med
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Skriv BibTeX-enheten som XMP-metadata til PDF.
-
-Write\ XMP=Skriv XMP
-Write\ XMP-metadata=Skriv XMP-metadata
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Skriv XMP-metadata for alle PDFer i denne libraryn?
-Writing\ XMP-metadata...=Skriver XMP-metadata...
-Writing\ XMP-metadata\ for\ selected\ entries...=Skriver XMP-metadata for de valgte enhetene...
-
-XMP-annotated\ PDF=XMP-annotert PDF
-XMP\ export\ privacy\ settings=Innstillinger for XMP-eksport
-XMP-metadata\ found\ in\ PDF\:\ %0=XMP-metadata funnet i PDF\: %0
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Du må starte JabRef på nytt for at dette skal tre i kraft.
 You\ have\ changed\ the\ language\ setting.=Du har valgt et nytt språk.
 You\ have\ entered\ an\ invalid\ search\ '%0'.=Ugyldig søkeuttrykk '%0'.
@@ -1365,7 +1366,6 @@ You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ te
 Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Åpne fildialog automatisk når ny link opprettes
 Import\ metadata\ from\:=Importer metadata fra\:
 Choose\ the\ source\ for\ the\ metadata\ import=Velg kilde for import av metadata
-Create\ entry\ based\ on\ XMP-metadata=Lag enhet basert på XMP-data
 Create\ blank\ entry\ linking\ the\ PDF=Lag blank enhet med lenke til PDF
 Only\ attach\ PDF=Bare lenk til PDF
 Title=Tittel
@@ -1544,7 +1544,6 @@ Online\ help\ forum=Online hjelpforum
 
 
 Connect=Koble til
-
 
 
 

--- a/src/main/resources/l10n/JabRef_pt_BR.properties
+++ b/src/main/resources/l10n/JabRef_pt_BR.properties
@@ -343,6 +343,21 @@ Do\ not\ overwrite\ existing\ keys=Não sobrescrever chaves existentes
 Do\ not\ show\ these\ options\ in\ the\ future=Não exibir estas opções no futuro
 
 Do\ not\ wrap\ the\ following\ fields\ when\ saving=Não agregar os seguintes campos ao salvar
+
+# all XMP related translations
+XMP-metadata=Metaddos XMP
+XMP-annotated\ PDF=PDF com anotações XMP
+XMP-metadata\ found\ in\ PDF\:\ %0=Metadados XMP encontrados no PDF\: %0
+Create\ entry\ based\ on\ XMP-metadata=Criar referência baseada em dados XMP
+Write\ XMP=Escrever XMP
+Write\ XMP-metadata=Escrever metadados XMP
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Escrever metadados XMP para todos os PDF's no banco de dados atual?
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Escrever BibTeXEntry como um metadado XMP para o PDF.
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Irá escrever todos os metadados XMP para os PDF linkados a partir das referências selecionadas.
+Writing\ XMP-metadata...=Escrevendo metadados XMP...
+Writing\ XMP-metadata\ for\ selected\ entries...=Escrevendo metadados XMP para as referências selecionadas...
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=A escrita de metadados XMP para o arquivo %0 terminou (%1 ignorado, %2 erros).
+XMP\ export\ privacy\ settings=Configurações de privacidade para a exportação XMP
 Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Não escrever os seguintes campos para metadados XMP\:
 
 Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Você deseja que o JabRef realize as seguintes operações?
@@ -494,7 +509,6 @@ Filter=Filtro
 Finished\ automatically\ setting\ external\ links.=A definição automática de links externos foi finalizada.
 
 Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=A sincronização de arquivo links foi finalizada. Referências modificadas\: %0.
-Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=A escrita de metadados XMP para o arquivo %0 terminou (%1 ignorado, %2 erros).
 
 First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Primeiro selecione as referências para as quais você deseja ter chaves geradas.
 
@@ -1229,22 +1243,9 @@ web\ link=link web
 What\ do\ you\ want\ to\ do?=O que você deseja fazer?
 
 When\ adding/removing\ keywords,\ separate\ them\ by=Ao adicionar/remover palavras-cave, separá-las por
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Irá escrever todos os metadados XMP para os PDF linkados a partir das referências selecionadas.
 
 with=com
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Escrever BibTeXEntry como um metadado XMP para o PDF.
-
-Write\ XMP=Escrever XMP
-Write\ XMP-metadata=Escrever metadados XMP
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Escrever metadados XMP para todos os PDF's no banco de dados atual?
-Writing\ XMP-metadata...=Escrevendo metadados XMP...
-Writing\ XMP-metadata\ for\ selected\ entries...=Escrevendo metadados XMP para as referências selecionadas...
-
-XMP-annotated\ PDF=PDF com anotações XMP
-XMP\ export\ privacy\ settings=Configurações de privacidade para a exportação XMP
-XMP-metadata=Metaddos XMP
-XMP-metadata\ found\ in\ PDF\:\ %0=Metadados XMP encontrados no PDF\: %0
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Você deve reiniciar o JabRef para a alteração tenha efeito.
 You\ have\ changed\ the\ language\ setting.=Você configurou a configuração de idioma.
 You\ have\ entered\ an\ invalid\ search\ '%0'.=Você digitou um termo de busca inválido '%0'.
@@ -1385,7 +1386,6 @@ You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ te
 Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Abrir janela de diálogo automaticamente ao criar um novo link de arquivo
 Import\ metadata\ from\:=Importar metadados a partir de\:
 Choose\ the\ source\ for\ the\ metadata\ import=Escolher a fonte para a importação de metadados
-Create\ entry\ based\ on\ XMP-metadata=Criar referência baseada em dados XMP
 Create\ blank\ entry\ linking\ the\ PDF=Criar referência em branco linkando o PDF
 Only\ attach\ PDF=Anexar apenas PDF
 Title=Título
@@ -1843,7 +1843,6 @@ Copy\ BibTeX\ key\ and\ link=Copiar chave do BibTex e link
 
 Default\ table\ font\ size=Tamanho padrão da fonte da tabela
 Show\ document\ viewer=Mostrar visualizador de documentos
-
 
 
 

--- a/src/main/resources/l10n/JabRef_ru.properties
+++ b/src/main/resources/l10n/JabRef_ru.properties
@@ -344,6 +344,21 @@ Do\ not\ overwrite\ existing\ keys=Не перезаписывать сущес�
 Do\ not\ show\ these\ options\ in\ the\ future=Не показывать эти параметры в дальнейшем
 
 Do\ not\ wrap\ the\ following\ fields\ when\ saving=Не сворачивать следующие поля при сохранении
+
+# all XMP related translations
+XMP-metadata=Метаданные XMP
+XMP-annotated\ PDF=PDF с аннотациями XMP
+XMP-metadata\ found\ in\ PDF\:\ %0=Найдены метаданные XMP в PDF\: %0
+Create\ entry\ based\ on\ XMP-metadata=Создание записи на основе данных XMP
+Write\ XMP=Запись XMP
+Write\ XMP-metadata=Запись метаданных XMP
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Выполнить запись метаданных XMP для всех PDF текущей БД?
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Запись значения записи BibTeX как метаданных XMP в PDF.
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Будет выполнена запись метаданных XMP в PDF со ссылками из выбранных записей.
+Writing\ XMP-metadata...=Выполняется запись метаданных XMP...
+Writing\ XMP-metadata\ for\ selected\ entries...=Выполняется запись метаданных XMPдля выбранных записей...
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Запись XMP в %0 файл(ов) выполнена (пропущено\: %1 ,с ошибками\: %2).
+XMP\ export\ privacy\ settings=Настройки защиты экспорта XMP
 Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Не записывать следующие поля в метаданные XMP\:
 
 Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Приложение JabRef выполнит следующие операции. Продолжить?
@@ -495,7 +510,6 @@ Filter=Фильтр
 Finished\ automatically\ setting\ external\ links.=Автоопределение внешних ссылок выполнено.
 
 Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Синхронизация ссылок файл выполнена. Записей с изменениями\: %0.
-Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Запись XMP в %0 файл(ов) выполнена (пропущено\: %1 ,с ошибками\: %2).
 
 First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Сначала выберите записи, для которых следует создать ключи.
 
@@ -1237,22 +1251,9 @@ web\ link=веб-ссылки
 What\ do\ you\ want\ to\ do?=Выберите действие для продолжения.
 
 When\ adding/removing\ keywords,\ separate\ them\ by=При добавлении/удалении ключевых слов разделять их с помощью
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Будет выполнена запись метаданных XMP в PDF со ссылками из выбранных записей.
 
 with=с
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Запись значения записи BibTeX как метаданных XMP в PDF.
-
-Write\ XMP=Запись XMP
-Write\ XMP-metadata=Запись метаданных XMP
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Выполнить запись метаданных XMP для всех PDF текущей БД?
-Writing\ XMP-metadata...=Выполняется запись метаданных XMP...
-Writing\ XMP-metadata\ for\ selected\ entries...=Выполняется запись метаданных XMPдля выбранных записей...
-
-XMP-annotated\ PDF=PDF с аннотациями XMP
-XMP\ export\ privacy\ settings=Настройки защиты экспорта XMP
-XMP-metadata=Метаданные XMP
-XMP-metadata\ found\ in\ PDF\:\ %0=Найдены метаданные XMP в PDF\: %0
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Для применения изменений необходимо перезапустить JabRef.
 You\ have\ changed\ the\ language\ setting.=Настройки языка изменены пользователем.
 You\ have\ entered\ an\ invalid\ search\ '%0'.=Указано недопустимое значение для поиска '%0'.
@@ -1392,7 +1393,6 @@ You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ te
 Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Автоматически открывать диалоговое окно обзора при создании новой ссылки на файл
 Import\ metadata\ from\:=Импорт метаданных из\:
 Choose\ the\ source\ for\ the\ metadata\ import=Выбрать источник для импорта метаданных
-Create\ entry\ based\ on\ XMP-metadata=Создание записи на основе данных XMP
 Create\ blank\ entry\ linking\ the\ PDF=Создание пустой записи со ссылкой на PDF
 Only\ attach\ PDF=Приложить только PDF
 Title=Заглавие
@@ -2009,8 +2009,6 @@ Open\ console=Открыть консоль
 Use\ default\ terminal\ emulator=Использовать эмуляцию терминала по умолчанию
 Execute\ command=Выполнить команду
 Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=Примечание. Используйте подстановочный знак %0 для указания расположения открытой БД.
-Executing\ command\ "%0"...=Выполнение команды "%0"...
-Error\ occured\ while\ executing\ the\ command\ "%0".=Ошибка при выполнении команды "%0".
 Reformat\ ISSN=Переформатировать ISSN
 
 Countries\ and\ territories\ in\ English=Страны и территории на английском
@@ -2115,7 +2113,6 @@ Copy\ BibTeX\ key\ and\ link=Копировать ключ BibTeX и ссылк�
 
 Default\ table\ font\ size=Размер шрифта в таблице по умолчанию
 Show\ document\ viewer=Показать программу просмотра документов
-
 
 
 

--- a/src/main/resources/l10n/JabRef_sv.properties
+++ b/src/main/resources/l10n/JabRef_sv.properties
@@ -336,6 +336,17 @@ Do\ not\ overwrite\ existing\ keys=Skriv inte över befintliga nycklar
 Do\ not\ show\ these\ options\ in\ the\ future=Visa inte dessa alternativ igen
 
 Do\ not\ wrap\ the\ following\ fields\ when\ saving=Radbryt inte följande fält vid sparning
+
+# all XMP related translations
+XMP-metadata\ found\ in\ PDF\:\ %0=XMP-metadata funnen i PDF\: %0
+Create\ entry\ based\ on\ XMP-metadata=Skapa post baserat på XMP-data
+Write\ XMP=Skriv XMP
+Write\ XMP-metadata=Skriv XMP-metadata
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Skriv XMP-metadata för alla PDFer i aktuell databas?
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Skriv BibTeX-posten som XMP-metadata i PDF.
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Kommer skriva XMP-metadata till PDFer länkade från valda poster.
+Writing\ XMP-metadata...=Skriver XMP-metadata...
+Writing\ XMP-metadata\ for\ selected\ entries...=Skriver XMP-metadata för valda poster...
 Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Vill du skriva följande fält till XMP-metadata?
 
 Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Vill du att JabRef ska göra följande?
@@ -1184,19 +1195,9 @@ web\ link=weblänk
 What\ do\ you\ want\ to\ do?=Vad vill du göra?
 
 When\ adding/removing\ keywords,\ separate\ them\ by=När nyckelord läggs till/tas bort, separera dem med
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Kommer skriva XMP-metadata till PDFer länkade från valda poster.
 
 with=med
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Skriv BibTeX-posten som XMP-metadata i PDF.
-
-Write\ XMP=Skriv XMP
-Write\ XMP-metadata=Skriv XMP-metadata
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Skriv XMP-metadata för alla PDFer i aktuell databas?
-Writing\ XMP-metadata...=Skriver XMP-metadata...
-Writing\ XMP-metadata\ for\ selected\ entries...=Skriver XMP-metadata för valda poster...
-
-XMP-metadata\ found\ in\ PDF\:\ %0=XMP-metadata funnen i PDF\: %0
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Du måste starta om JabRef för att ändringen ska slå igenom.
 You\ have\ changed\ the\ language\ setting.=Du har ändrat språkinställningarna.
 You\ have\ entered\ an\ invalid\ search\ '%0'.=Du har angett en ogiltig sökning '%0'.
@@ -1322,7 +1323,6 @@ You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ te
 Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Öppna fildialog automatiskt när ny fillänk skapas
 Import\ metadata\ from\:=Importera metadata från\:
 Choose\ the\ source\ for\ the\ metadata\ import=Välj källa för metadata-import
-Create\ entry\ based\ on\ XMP-metadata=Skapa post baserat på XMP-data
 Create\ blank\ entry\ linking\ the\ PDF=Skapa tom post som länkar till PDF\:en
 Only\ attach\ PDF=Lägg bara till PDF
 Title=Titel
@@ -1886,8 +1886,6 @@ Open\ console=Öppna konsoll
 Use\ default\ terminal\ emulator=Använd standardterminalen
 Execute\ command=Kör kommando
 Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=Använd %0 för att infoga mappen för databasfilen.
-Executing\ command\ "%0"...=Kör kommandot "%0"...
-Error\ occured\ while\ executing\ the\ command\ "%0".=Fel när kommandot "%0" kördes.
 Reformat\ ISSN=Formattera om ISSN
 
 Countries\ and\ territories\ in\ English=Länder och territorier på engelska
@@ -1996,7 +1994,6 @@ Existing\ file=Existerande fil
 
 strings\ included=innehåller strings
 Escape\ underscores=Maskera understreck
-
 
 
 

--- a/src/main/resources/l10n/JabRef_tl.properties
+++ b/src/main/resources/l10n/JabRef_tl.properties
@@ -350,6 +350,22 @@ Do\ not\ overwrite\ existing\ keys=Huwag i-overwrite ang umiiral na keys
 Do\ not\ show\ these\ options\ in\ the\ future=Huwag ipakita ang mga opsyon sa hinaharap
 
 Do\ not\ wrap\ the\ following\ fields\ when\ saving=Huwat balutin ang mga sumusunod na patlang habang nagse-save
+
+# all XMP related translations
+XMP-metadata=Ang XMP-metadata
+XMP-annotated\ PDF=Ang XMP-ay nalagyan ng anotasyon sa PDF
+XMP-metadata\ found\ in\ PDF\:\ %0=Ang XMP-metadata ay nakita sa PDF\: %0
+Create\ entry\ based\ on\ XMP-metadata=Lumikha ng entry batay sa XMP-metadata
+Write\ XMP=Isulat ang XMP
+Write\ XMP-metadata=Isulat ang XMP-metadata
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Isulat ang XMP-medata para sa lahat na PDF sa kasalukuyang library?
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Isulat ang BibTeXEntry bilang XMP-metadata sa PDF.
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Ay magsusulat ng XMP-metadata para sa PDFs na linked mula sa napiling mga entries.
+Writing\ XMP-metadata...=Nagsusulat ng XMP-metadata...
+Writing\ XMP-metadata\ for\ selected\ entries...=Nagsusulat ng XMP-medata para sa mga napiling entries...
+Finished\ writing\ XMP-metadata.=Tapos na pagsulat ng XMP-metadata.
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Tapusin ang pagsusulat ng XMP para sa %0 file (%1 nilaktawan, %2 may mga mali).
+XMP\ export\ privacy\ settings=Ang XMP ay nagpalabas ng mga settings na privacy
 Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Huwag isulat ang mga sumusunod na patlang sa XMP Metadata\:
 
 Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Gusto mo ba na ang JabRef ay sundin ang mga operasyon?
@@ -504,7 +520,6 @@ Filter\ None=Walang na sala
 Finished\ automatically\ setting\ external\ links.=Tapusing awtomatiko ang pagtatakda ng panlabas na links.
 
 Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Tapusin ang pag-synchronize ng mga file links. Nabago ang entries\: %0.
-Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Tapusin ang pagsusulat ng XMP para sa %0 file (%1 nilaktawan, %2 may mga mali).
 
 First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Unahin sa pagpili ang entries na gusto mo para ma buo sa.
 
@@ -577,7 +592,6 @@ Underline=Salungguhitan
 Empty\ Highlight=Walang laman na highlight
 Empty\ Marking=Walang laman na marka
 Empty\ Underline=Walang laman na salungguhit
-The\ marked\ area\ does\ not\ contain\ any\ legible\ text\!=Ang may marka na lugar ay hindi naglalaman ng kahit anong tunay na teksto\!
 
 Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=Pagiwatig\: Sa paghahanap ng tiyak na patlang lamang, ilagay ang halimbawa\:<p><tt>akda\=smith at pamagat\=elektrikal </tt>
 
@@ -1271,22 +1285,9 @@ web\ link=ang link ng web
 What\ do\ you\ want\ to\ do?=Ano ang gusto mong gawin?
 
 When\ adding/removing\ keywords,\ separate\ them\ by=Kapag nagdagdag/nagtanggal ng keywords, ihiwalay ito sa
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Ay magsusulat ng XMP-metadata para sa PDFs na linked mula sa napiling mga entries.
 
 with=may
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Isulat ang BibTeXEntry bilang XMP-metadata sa PDF.
-
-Write\ XMP=Isulat ang XMP
-Write\ XMP-metadata=Isulat ang XMP-metadata
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Isulat ang XMP-medata para sa lahat na PDF sa kasalukuyang library?
-Writing\ XMP-metadata...=Nagsusulat ng XMP-metadata...
-Writing\ XMP-metadata\ for\ selected\ entries...=Nagsusulat ng XMP-medata para sa mga napiling entries...
-
-XMP-annotated\ PDF=Ang XMP-ay nalagyan ng anotasyon sa PDF
-XMP\ export\ privacy\ settings=Ang XMP ay nagpalabas ng mga settings na privacy
-XMP-metadata=Ang XMP-metadata
-XMP-metadata\ found\ in\ PDF\:\ %0=Ang XMP-metadata ay nakita sa PDF\: %0
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Dapat mong i-restart ang JabRef para gumana ito.
 You\ have\ changed\ the\ language\ setting.=Pinalitan mo ang wika ng setting.
 You\ have\ entered\ an\ invalid\ search\ '%0'.=Naipasok mo ang isang hindi balidong paghahanap '%0'.
@@ -1430,7 +1431,6 @@ You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ te
 Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Awtomatikong buksan ang pag-browse ng dialog kapag lumilikha ng bagong fine na link
 Import\ metadata\ from\:=Mag-import ng metadata mula sa\:
 Choose\ the\ source\ for\ the\ metadata\ import=Piliin ang pinagmulan para sa pag-import ng metadata
-Create\ entry\ based\ on\ XMP-metadata=Lumikha ng entry batay sa XMP-metadata
 Create\ blank\ entry\ linking\ the\ PDF=Gumawa ng blangko na entry na nagli-link sa PDF
 Only\ attach\ PDF=Maglakip lamang ng PDF
 Title=Pamagat
@@ -1996,12 +1996,10 @@ Could\ not\ retrieve\ entry\ data\ from\ '%0'.=Hindi makuha ang data mula sa ent
 Entry\ from\ %0\ could\ not\ be\ parsed.=Ang entry mula sa %0 ay hindi ma-parse.
 Invalid\ identifier\:\ '%0'.=Di-wastong identifier\: '%0'.
 This\ paper\ has\ been\ withdrawn.=Ang papel na ito ay na-withdraw.
-Finished\ writing\ XMP-metadata.=Tapos na pagsulat ng XMP-metadata.
 empty\ BibTeX\ key=walang laman na BibTeX key
 Your\ Java\ Runtime\ Environment\ is\ located\ at\ %0.=Ang iyong Java Runtime Environment ay matatagpuan sa %0.
 Aux\ file=Aux file
 Group\ containing\ entries\ cited\ in\ a\ given\ TeX\ file=Grupo na naglalaman ng mga entry na binanggit sa isang ibinigay na file ng TeX
 
 Any\ file=Anumang file
-
 

--- a/src/main/resources/l10n/JabRef_tr.properties
+++ b/src/main/resources/l10n/JabRef_tr.properties
@@ -350,6 +350,21 @@ Do\ not\ overwrite\ existing\ keys=Mevcut anahtarların üzerine yazma
 Do\ not\ show\ these\ options\ in\ the\ future=Gelecekte bu seçenekleri gösterme
 
 Do\ not\ wrap\ the\ following\ fields\ when\ saving=Kaydederken aşağıdaki alanları sarmalama
+
+# all XMP related translations
+XMP-metadata=XMP metaverisi
+XMP-annotated\ PDF=XMP-ek notlu PDF
+XMP-metadata\ found\ in\ PDF\:\ %0=PDF'de XMP metaverisi bulundu\: %0
+Create\ entry\ based\ on\ XMP-metadata=XMP verisine dayanarak girdi oluştur
+Write\ XMP=XMP'yi yaz
+Write\ XMP-metadata=XMP-metaverisini yaz
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Mevcut veritabanındaki tüm PFDlere XMP-metaverisi yazılsın mı?
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=BibTeXGirdisi'ni PDF'ye XMP-metaverisi olarak yaz.
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Seçili girdilerle bağlantılı PDFlere XMP metaverisi yazılacak.
+Writing\ XMP-metadata...=XMP metaverisi yazılıyor...
+Writing\ XMP-metadata\ for\ selected\ entries...=Seçili girdiler için XMP metaverisi yazılıyor...
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=%0 dosya için XMP yazımı bitti (%1 atlandı, %2 hata).
+XMP\ export\ privacy\ settings=Gizlilik Ayarlarını XMP Dışa Aktar
 Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Aşağıdaki alanları XMP Metadata'ya yazma\:
 
 Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=JabRef'in aşağıdaki işlemleri yapmasını ister misiniz?
@@ -504,7 +519,6 @@ Filter\ None=Hiçbirine Süzgeç Uygulama
 Finished\ automatically\ setting\ external\ links.=Harici linklerin otokurulması bitti.
 
 Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Dosya linkin eşzamanlaması bitti. Değişen girdiler\: %0.
-Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=%0 dosya için XMP yazımı bitti (%1 atlandı, %2 hata).
 
 First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Önce anahtar oluşturulmasını istediğiniz girdileri seçiniz.
 
@@ -576,7 +590,6 @@ Underline=Altını çiz
 Empty\ Highlight=Boş vurgulama
 Empty\ Marking=Boş işaretleme
 Empty\ Underline=Boş altını çizme
-The\ marked\ area\ does\ not\ contain\ any\ legible\ text\!=İşaretlenmiş alan herhangi bir okunabilir metin içermiyor\!
 
 Hint\:\ To\ search\ specific\ fields\ only,\ enter\ for\ example\:<p><tt>author\=smith\ and\ title\=electrical</tt>=İpucu\: Yalnızca belirli alanları aramak için, örneğin şunu giriniz\:<p><tt>author\=smith and title\=electrical</tt>
 
@@ -1268,22 +1281,9 @@ web\ link=sanaldoku linki
 What\ do\ you\ want\ to\ do?=Ne yapmak istersiniz?
 
 When\ adding/removing\ keywords,\ separate\ them\ by=Anahtar sözcük ekler/çıkarırken, onları şöyle ayırın
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Seçili girdilerle bağlantılı PDFlere XMP metaverisi yazılacak.
 
 with=ile
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=BibTeXGirdisi'ni PDF'ye XMP-metaverisi olarak yaz.
-
-Write\ XMP=XMP'yi yaz
-Write\ XMP-metadata=XMP-metaverisini yaz
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Mevcut veritabanındaki tüm PFDlere XMP-metaverisi yazılsın mı?
-Writing\ XMP-metadata...=XMP metaverisi yazılıyor...
-Writing\ XMP-metadata\ for\ selected\ entries...=Seçili girdiler için XMP metaverisi yazılıyor...
-
-XMP-annotated\ PDF=XMP-ek notlu PDF
-XMP\ export\ privacy\ settings=Gizlilik Ayarlarını XMP Dışa Aktar
-XMP-metadata=XMP metaverisi
-XMP-metadata\ found\ in\ PDF\:\ %0=PDF'de XMP metaverisi bulundu\: %0
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Bunun etkinleşmesi için JabRefi yeniden başlatmalısınız.
 You\ have\ changed\ the\ language\ setting.=Dil ayarını değiştirdiniz.
 You\ have\ entered\ an\ invalid\ search\ '%0'.=Geçersiz bir arama girdiniz '%0'.
@@ -1428,7 +1428,6 @@ You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ te
 Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Yeni dosya bağlantısını oluştururken gözatma iletişim kutusunu otomatikman aç
 Import\ metadata\ from\:=Metaverisini Şuradan İçe Aktar\:
 Choose\ the\ source\ for\ the\ metadata\ import=Metaverisini içe aktarmak için kaynağı seçin
-Create\ entry\ based\ on\ XMP-metadata=XMP verisine dayanarak girdi oluştur
 Create\ blank\ entry\ linking\ the\ PDF=PDF'yle bağlantılı olarak boş girdi oluştur
 Only\ attach\ PDF=Yalnızca PDF'yi ekle
 Title=Başlık
@@ -2066,8 +2065,6 @@ Open\ console=Konsolu aç
 Use\ default\ terminal\ emulator=Öntanımlı uçbirim öykünücüsünü kullan
 Execute\ command=Komutu çalıştır
 Note\:\ Use\ the\ placeholder\ %0\ for\ the\ location\ of\ the\ opened\ library\ file.=Not\:Açık veritabanının konumu için %0 yer tutucusunu kullan.
-Executing\ command\ "%0"...="%0" komutu çalıştırılıyor...
-Error\ occured\ while\ executing\ the\ command\ "%0".="%0" komutu çalıştırılırken hata oluştu.
 Reformat\ ISSN=ISSN'i yeniden biçimlendir
 
 Countries\ and\ territories\ in\ English=Ülke ve bölgeler İngilizce
@@ -2115,7 +2112,6 @@ JabRef\ built\ in\ list=JabRef yerleşik listesi
 IEEE\ built\ in\ list=IEEE yerleşik listesi
 
 Event\ log=Olay kayıt dosyası
-We\ now\ give\ you\ insight\ into\ the\ inner\ workings\ of\ JabRef's\ internals.\ This\ information\ might\ be\ helpful\ to\ diagnose\ the\ root\ cause\ of\ a\ problem.\ Please\ feel\ free\ to\ inform\ the\ developers\ about\ an\ issue.=Biz şimdi size JabRef'in iç çalışma düzeneği hakkında içgörü veriyoruz. Bu bilgi bir sorunun temel nedenini tanımada yararlı olabilir. Lütfen bir sorun hakkında geliştiricileri bilgilendirmekten çekinmeyin.
 Log\ copied\ to\ clipboard.=Kayıt dosyası panoya kopyalandı.
 Copy\ Log=Kayıt Dosyasını Kopyala
 Clear\ Log=Kayıt Dosyasını Temizle
@@ -2202,7 +2198,6 @@ shared=paylaşıldı
 should\ contain\ an\ integer\ or\ a\ literal=bir tamsayı ya da harf içermelidir
 should\ have\ the\ first\ letter\ capitalized=İlk harf büyük olmalıdır
 Tools=Araçlar
-What's\ new\ in\ this\ version?=Bu sürümde neler yeni?
 Want\ to\ help?=Yardım etmek ister misiniz?
 Make\ a\ donation=Bağışta bulun
 get\ involved=katkıda bulun
@@ -2308,6 +2303,5 @@ Show\ console\ output\ (only\ necessary\ when\ the\ launcher\ is\ used)=Consol �
 
 
 empty\ BibTeX\ key=boş BibTeX anahtarı
-
 
 

--- a/src/main/resources/l10n/JabRef_vi.properties
+++ b/src/main/resources/l10n/JabRef_vi.properties
@@ -343,6 +343,21 @@ Do\ not\ overwrite\ existing\ keys=Không ghi đè các khóa hiện có
 Do\ not\ show\ these\ options\ in\ the\ future=Không hiển thị những tùy chọn này trong tương lai
 
 Do\ not\ wrap\ the\ following\ fields\ when\ saving=Không 'bọc' những dữ liệu dưới đây khi lưu
+
+# all XMP related translations
+XMP-metadata=Đặc tả dữ liệu XMP
+XMP-annotated\ PDF=PDF có chú giải XMP
+XMP-metadata\ found\ in\ PDF\:\ %0=Đặc tả dữ liệu XMP có trong PDF\: %0
+Create\ entry\ based\ on\ XMP-metadata=Tạo ra mục dựa trên dữ liệu XMP
+Write\ XMP=Ghi XMP
+Write\ XMP-metadata=Ghi đặc tả dữ liệu XMP
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Ghi đặc tả dữ liệu XMP cho tất cả các PDF trong CSDL hiện tại?
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Ghi mục BibTeX dưới dạng đặc tả dữ liệu XMP vào PDF.
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Sẽ ghi đặc tả dữ liệu XMP vào các PDF được liên kết từ các mục đã chọn.
+Writing\ XMP-metadata...=Đang ghi đặc tả dữ liệu XMP...
+Writing\ XMP-metadata\ for\ selected\ entries...=Đang ghi đặc tả dữ liệu XMP cho các mục được chọn...
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Kết thúc ghi XMP cho %0 tập tin (bỏ qua %1, %2 lỗi).
+XMP\ export\ privacy\ settings=Các thiết lập riêng về Xuất XMP
 Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=Không ghi những dữ liệu dưới đây vào đặc tả dữ liệu XMP\:
 
 Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=Bạn có muốn JabRef thực hiện những lệnh sau?
@@ -494,7 +509,6 @@ Filter=Lọc
 Finished\ automatically\ setting\ external\ links.=Thiết lập tự động các liên kết ngoài hoàn tất.
 
 Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=Đồng bộ hóa tập tin liên kết hoàn tất. Các mục thay đổi\: %0.
-Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=Kết thúc ghi XMP cho %0 tập tin (bỏ qua %1, %2 lỗi).
 
 First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=Trước tiên hãy chọn các mục mà bạn muốn tạo khóa.
 
@@ -1244,22 +1258,9 @@ web\ link=liên kết web
 What\ do\ you\ want\ to\ do?=Bạn muốn làm gì?
 
 When\ adding/removing\ keywords,\ separate\ them\ by=Khi thêm/loại bỏ các từ khóa, cách biệt chúng ra bằng
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=Sẽ ghi đặc tả dữ liệu XMP vào các PDF được liên kết từ các mục đã chọn.
 
 with=với
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=Ghi mục BibTeX dưới dạng đặc tả dữ liệu XMP vào PDF.
-
-Write\ XMP=Ghi XMP
-Write\ XMP-metadata=Ghi đặc tả dữ liệu XMP
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=Ghi đặc tả dữ liệu XMP cho tất cả các PDF trong CSDL hiện tại?
-Writing\ XMP-metadata...=Đang ghi đặc tả dữ liệu XMP...
-Writing\ XMP-metadata\ for\ selected\ entries...=Đang ghi đặc tả dữ liệu XMP cho các mục được chọn...
-
-XMP-annotated\ PDF=PDF có chú giải XMP
-XMP\ export\ privacy\ settings=Các thiết lập riêng về Xuất XMP
-XMP-metadata=Đặc tả dữ liệu XMP
-XMP-metadata\ found\ in\ PDF\:\ %0=Đặc tả dữ liệu XMP có trong PDF\: %0
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=Bạn phải khởi động lại JabRef để thay đổi có hiệu lực.
 You\ have\ changed\ the\ language\ setting.=Bạn đã thay đổi thiết lập ngôn ngữ.
 You\ have\ entered\ an\ invalid\ search\ '%0'.=Bạn đã nhập một phép tìm không hợp lệ '%0'.
@@ -1400,7 +1401,6 @@ You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ te
 Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=Mở tự động hộp thoại khi tạo ra đường dẫn tập tin mới
 Import\ metadata\ from\:=Nhập siêu dữ liệu vào từ
 Choose\ the\ source\ for\ the\ metadata\ import=Chọn nguồn để nhập vào siêu dữ liệu
-Create\ entry\ based\ on\ XMP-metadata=Tạo ra mục dựa trên dữ liệu XMP
 Create\ blank\ entry\ linking\ the\ PDF=Tạo ra mục trống thuộc về PDF
 Only\ attach\ PDF=Chỉ kèm PDF
 Title=Danh hiệu
@@ -1581,7 +1581,6 @@ A\ backup\ file\ for\ '%0'\ was\ found.=Bản sao lưu dự phòng cho '%0' đã
 This\ could\ indicate\ that\ JabRef\ did\ not\ shut\ down\ cleanly\ last\ time\ the\ file\ was\ used.=Điều này cho thấy là JabRef không được kết thúc hoàn chỉnh khi sử dụng tập tin lần cuối.
 Do\ you\ want\ to\ recover\ the\ library\ from\ the\ backup\ file?=Bạn có muốn phục hồi cơ sở dữ liệu từ tập tin lưu dự phòng không?
 Firstname\ Lastname=Họ Tên
-
 
 
 

--- a/src/main/resources/l10n/JabRef_zh.properties
+++ b/src/main/resources/l10n/JabRef_zh.properties
@@ -349,6 +349,20 @@ Do\ not\ overwrite\ existing\ keys=不覆盖已存在的 BibTeX 键
 Do\ not\ show\ these\ options\ in\ the\ future=以后不要再显示这些选项
 
 Do\ not\ wrap\ the\ following\ fields\ when\ saving=保存时不要对下列域添加换行符
+
+# all XMP related translations
+XMP-metadata=XMP 元数据
+XMP-metadata\ found\ in\ PDF\:\ %0=PDF 中的 XMP 元数据\: %0
+Create\ entry\ based\ on\ XMP-metadata=基于 XMP 数据新建一条记录
+Write\ XMP=写入 XMP
+Write\ XMP-metadata=写入 XMP 元数据
+Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=将 XMP 元数据写入到当前文献库中所有 PDF 文件?
+Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=将 BibTeX 记录作为 XMP 源数据写入到 PDF 中。
+Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=将写入 XMP 元数据到选中记录链接的 PDF 文件。
+Writing\ XMP-metadata...=正在写入 XMP 元数据...
+Writing\ XMP-metadata\ for\ selected\ entries...=正在为选中记录写入 XMP 元数据...
+Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=完成写入 XMP-元数据到 %0 文件 (跳过 %1 条，%2 条错误).
+XMP\ export\ privacy\ settings=XMP 导出隐私设置
 Do\ not\ write\ the\ following\ fields\ to\ XMP\ Metadata\:=不要将以下域写入 XMP 元数据\:
 
 Do\ you\ want\ JabRef\ to\ do\ the\ following\ operations?=您希望 JabRef 做以下操作吗？
@@ -503,7 +517,6 @@ Filter\ All=筛选所有
 Finished\ automatically\ setting\ external\ links.=完成自动设置外部链接。
 
 Finished\ synchronizing\ file\ links.\ Entries\ changed\:\ %0.=完成同步文件条链接，记录改变\: %0.
-Finished\ writing\ XMP\ for\ %0\ file\ (%1\ skipped,\ %2\ errors).=完成写入 XMP-元数据到 %0 文件 (跳过 %1 条，%2 条错误).
 
 First\ select\ the\ entries\ you\ want\ keys\ to\ be\ generated\ for.=首先选中您要生成 BibTeX 键的记录。
 
@@ -1264,21 +1277,9 @@ web\ link=web 链接
 What\ do\ you\ want\ to\ do?=您希望做什么?
 
 When\ adding/removing\ keywords,\ separate\ them\ by=当增加/移除关键字时，使用分隔符
-Will\ write\ XMP-metadata\ to\ the\ PDFs\ linked\ from\ selected\ entries.=将写入 XMP 元数据到选中记录链接的 PDF 文件。
 
 with=以
 
-Write\ BibTeXEntry\ as\ XMP-metadata\ to\ PDF.=将 BibTeX 记录作为 XMP 源数据写入到 PDF 中。
-
-Write\ XMP=写入 XMP
-Write\ XMP-metadata=写入 XMP 元数据
-Write\ XMP-metadata\ for\ all\ PDFs\ in\ current\ library?=将 XMP 元数据写入到当前文献库中所有 PDF 文件?
-Writing\ XMP-metadata...=正在写入 XMP 元数据...
-Writing\ XMP-metadata\ for\ selected\ entries...=正在为选中记录写入 XMP 元数据...
-
-XMP\ export\ privacy\ settings=XMP 导出隐私设置
-XMP-metadata=XMP 元数据
-XMP-metadata\ found\ in\ PDF\:\ %0=PDF 中的 XMP 元数据\: %0
 You\ must\ restart\ JabRef\ for\ this\ to\ come\ into\ effect.=为使这项更改生效，您必须重启 JabRef。
 You\ have\ changed\ the\ language\ setting.=您已经修改了语言设置。
 You\ have\ entered\ an\ invalid\ search\ '%0'.=您输入了一个非法的查询 '%0'.
@@ -1422,7 +1423,6 @@ You\ must\ enter\ an\ integer\ value\ in\ the\ interval\ 1025-65535\ in\ the\ te
 Automatically\ open\ browse\ dialog\ when\ creating\ new\ file\ link=创建新的文件链接时自动打开文件浏览对话框
 Import\ metadata\ from\:=导入 metadata，来自：
 Choose\ the\ source\ for\ the\ metadata\ import=选择导入 metadata 的来源
-Create\ entry\ based\ on\ XMP-metadata=基于 XMP 数据新建一条记录
 Create\ blank\ entry\ linking\ the\ PDF=为 PDF 新建一条空白记录
 Only\ attach\ PDF=只附加 PDF 到记录
 Title=标题
@@ -2032,6 +2032,5 @@ Show\ document\ viewer=打开文档查看器
 
 
 empty\ BibTeX\ key=空 BibTeX 键
-
 
 


### PR DESCRIPTION
Example how grouping in language files could look like. Example taken: [XMP related functionality](http://help.jabref.org/en/XMP).

Refs discussion at #3873.