### PR TITLE
Concurrent fetchers

### DIFF
--- a/src/main/java/org/jabref/gui/externalfiles/DownloadExternalFile.java
+++ b/src/main/java/org/jabref/gui/externalfiles/DownloadExternalFile.java
@@ -155,16 +155,9 @@ public class DownloadExternalFile {
 
         URLDownload udl = new URLDownload(url);
 
-        try {
-            // TODO: what if this takes long time?
-            // TODO: stop editor dialog if this results in an error:
-            mimeType = udl.getMimeType(); // Read MIME type
-        } catch (IOException ex) {
-            JOptionPane.showMessageDialog(frame, Localization.lang("Invalid URL") + ": " + ex.getMessage(),
-                    Localization.lang("Download file"), JOptionPane.ERROR_MESSAGE);
-            LOGGER.info("Error while downloading " + "'" + res + "'", ex);
-            return;
-        }
+        // TODO: what if this takes long time?
+        // TODO: stop editor dialog if this results in an error:
+        mimeType = udl.getMimeType(); // Read MIME type
         final URL urlF = url;
         final URLDownload udlF = udl;
 

--- a/src/main/java/org/jabref/gui/externalfiles/FindFullTextAction.java
+++ b/src/main/java/org/jabref/gui/externalfiles/FindFullTextAction.java
@@ -71,8 +71,8 @@ public class FindFullTextAction extends AbstractWorker {
             }
         }
         for (BibEntry entry : basePanel.getSelectedEntries()) {
-            FulltextFetchers fft = new FulltextFetchers(Globals.prefs.getImportFormatPreferences());
-            downloads.put(fft.findFullTextPDF(entry), entry);
+            FulltextFetchers fetchers = new FulltextFetchers(Globals.prefs.getImportFormatPreferences());
+            downloads.put(fetchers.findFullTextPDF(entry), entry);
         }
     }
 

--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -421,17 +421,12 @@ public class LinkedFileViewModel extends AbstractViewModel {
     }
 
     private Optional<ExternalFileType> inferFileTypeFromMimeType(URLDownload urlDownload) {
-        try {
-            // TODO: what if this takes long time?
-            String mimeType = urlDownload.getMimeType(); // Read MIME type
-            if (mimeType != null) {
-                LOGGER.debug("MIME Type suggested: " + mimeType);
-                return ExternalFileTypes.getInstance().getExternalFileTypeByMimeType(mimeType);
-            } else {
-                return Optional.empty();
-            }
-        } catch (IOException ex) {
-            LOGGER.debug("Error while inferring MIME type for URL " + urlDownload.getSource(), ex);
+        // TODO: what if this takes long time?
+        String mimeType = urlDownload.getMimeType(); // Read MIME type
+        if (mimeType != null) {
+            LOGGER.debug("MIME Type suggested: " + mimeType);
+            return ExternalFileTypes.getInstance().getExternalFileTypeByMimeType(mimeType);
+        } else {
             return Optional.empty();
         }
     }

--- a/src/main/java/org/jabref/logic/importer/FulltextFetchers.java
+++ b/src/main/java/org/jabref/logic/importer/FulltextFetchers.java
@@ -3,9 +3,20 @@ package org.jabref.logic.importer;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
+import org.jabref.logic.importer.fetcher.DoiResolution;
 import org.jabref.logic.net.URLDownload;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.FieldName;
@@ -45,17 +56,95 @@ public class FulltextFetchers {
             }
         }
 
-        for (FulltextFetcher finder : finders) {
-            try {
-                Optional<URL> result = finder.findFullText(clonedEntry);
+        ExecutorService executor = Executors.newCachedThreadPool();
+        try {
+            // First try publisher access
+            FulltextFetcher authority = new DoiResolution();
 
-                if (result.isPresent() && new URLDownload(result.get().toString()).isPdf()) {
-                    return result;
-                }
-            } catch (IOException | FetcherException e) {
-                LOGGER.debug("Failed to find fulltext PDF at given URL", e);
+            Optional<URL> pdfUrl = findFirst(executor, Arrays.asList(getCallable(clonedEntry, authority)));
+            if (pdfUrl.isPresent()) {
+                return pdfUrl;
             }
+            // All other available fetchers
+            pdfUrl = findFirst(executor, getCallables(clonedEntry, finders));
+            if (pdfUrl.isPresent()) {
+                return pdfUrl;
+            }
+        } finally {
+            shutdownAndAwaitTermination(executor);
         }
         return Optional.empty();
+    }
+
+    private Callable<Optional<URL>> getCallable(BibEntry entry, FulltextFetcher fetcher) {
+            return () -> {
+                try {
+                    Optional<URL> result = fetcher.findFullText(entry);
+
+                    if (result.isPresent() && new URLDownload(result.get().toString()).isPdf()) {
+                        return result;
+                    }
+                } catch (IOException | FetcherException e) {
+                    LOGGER.debug("Failed to find fulltext PDF at given URL", e);
+                }
+                return Optional.empty();
+            };
+    }
+
+    private List<Callable<Optional<URL>>> getCallables(BibEntry entry, List<FulltextFetcher> fetchers) {
+        return fetchers.stream()
+                .map(f -> getCallable(entry, f))
+                .collect(Collectors.toList());
+    }
+
+    private Optional<URL> findFirst(ExecutorService executor, List<Callable<Optional<URL>>> solvers) {
+        CompletionService<Optional<URL>> service = new ExecutorCompletionService<>(executor);
+        List<Future<Optional<URL>>> futures = solvers.stream()
+                .map(callable -> service.submit(callable))
+                .collect(Collectors.toList());
+
+        Optional<URL> result = Optional.empty();
+        try {
+            // check all fetcher results
+            for (int i = 0; i < futures.size(); i++) {
+                try {
+                    Optional<URL> link = service.take().get();
+
+                    if (link.isPresent()) {
+                        result = link;
+                        break;
+                    }
+                } catch (InterruptedException ignore) {
+
+                } catch (ExecutionException e) {
+                    LOGGER.warn("Error during fetcher execution: " + e.getMessage());
+                }
+            }
+        } finally {
+            futures.stream().forEach(f -> f.cancel(true));
+        }
+
+        return result;
+    }
+
+    private void shutdownAndAwaitTermination(ExecutorService pool) {
+        // Disable new tasks from being submitted
+        pool.shutdown();
+        try {
+            // Wait a while for existing tasks to terminate
+            if (!pool.awaitTermination(5, TimeUnit.SECONDS)) {
+                // Cancel currently executing tasks
+                pool.shutdownNow();
+                // Wait a while for tasks to respond to being cancelled
+                if (!pool.awaitTermination(5, TimeUnit.SECONDS)) {
+                    LOGGER.warn("Pool did not terminate");
+                }
+            }
+        } catch (InterruptedException ie) {
+            // (Re-)Cancel if current thread also interrupted
+            pool.shutdownNow();
+            // Preserve interrupt status
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/src/main/java/org/jabref/logic/importer/WebFetchers.java
+++ b/src/main/java/org/jabref/logic/importer/WebFetchers.java
@@ -122,10 +122,7 @@ public class WebFetchers {
 
     public static List<FulltextFetcher> getFullTextFetchers(ImportFormatPreferences importFormatPreferences) {
         List<FulltextFetcher> fetchers = new ArrayList<>();
-
-        // Ordering is important, authorities first!
-        // Publisher
-        fetchers.add(new DoiResolution());
+        // Publishers
         fetchers.add(new ScienceDirect());
         fetchers.add(new SpringerLink());
         fetchers.add(new ACS());

--- a/src/main/java/org/jabref/logic/importer/fetcher/DoiResolution.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DoiResolution.java
@@ -48,7 +48,7 @@ public class DoiResolution implements FulltextFetcher {
                     connection.followRedirects(true);
                     connection.ignoreHttpErrors(true);
                     // some publishers are quite slow (default is 3s)
-                    connection.timeout(5000);
+                    connection.timeout(10000);
 
                     Document html = connection.get();
                     // scan for PDF

--- a/src/main/java/org/jabref/logic/importer/fetcher/DoiResolution.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/DoiResolution.java
@@ -16,6 +16,7 @@ import org.jabref.model.entry.identifier.DOI;
 
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
+import org.jsoup.UnsupportedMimeTypeException;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -51,6 +52,7 @@ public class DoiResolution implements FulltextFetcher {
                     connection.timeout(10000);
 
                     Document html = connection.get();
+
                     // scan for PDF
                     Elements elements = html.body().select("a[href]");
                     List<Optional<URL>> links = new ArrayList<>();
@@ -69,6 +71,11 @@ public class DoiResolution implements FulltextFetcher {
                     if (links.size() == 1) {
                         LOGGER.info("Fulltext PDF found @ " + sciLink);
                         pdfLink = links.get(0);
+                    }
+                } catch (UnsupportedMimeTypeException type) {
+                    // this might be the PDF already as we follow redirects
+                    if (type.getMimeType().startsWith("application/pdf")) {
+                        return Optional.of(new URL(type.getUrl()));
                     }
                 } catch (IOException e) {
                     LOGGER.warn("DoiResolution fetcher failed: ", e);

--- a/src/main/java/org/jabref/logic/net/URLDownload.java
+++ b/src/main/java/org/jabref/logic/net/URLDownload.java
@@ -123,7 +123,7 @@ public class URLDownload {
         return source;
     }
 
-    public String getMimeType() throws IOException {
+    public String getMimeType() {
         Unirest.setDefaultHeader("User-Agent", "Mozilla/5.0 (Windows; U; WindowsNT 5.1; en-US; rv1.8.1.6) Gecko/20070725 Firefox/2.0.0.6");
 
         String contentType;
@@ -162,7 +162,7 @@ public class URLDownload {
         return "";
     }
 
-    public boolean isMimeType(String type) throws IOException {
+    public boolean isMimeType(String type) {
         String mime = getMimeType();
 
         if (mime.isEmpty()) {
@@ -172,7 +172,7 @@ public class URLDownload {
         return mime.startsWith(type);
     }
 
-    public boolean isPdf() throws IOException {
+    public boolean isPdf() {
         return isMimeType("application/pdf");
     }
 


### PR DESCRIPTION
Trying to improve the speed of the fulltext fetcher:

- First the authoritative publisher is queried for the PDF (if user has access)
- Afterwards we query all remaining sources and take the first result

@JabRef/developers  WDYT?
