### PR TITLE
Reenable closing of entry preview by pressing Esc

### DIFF
--- a/src/main/java/org/jabref/gui/EntryTypeDialog.java
+++ b/src/main/java/org/jabref/gui/EntryTypeDialog.java
@@ -116,7 +116,7 @@ public class EntryTypeDialog extends JabRefDialog implements ActionListener {
         cancel.addActionListener(this);
 
         // Make ESC close dialog, equivalent to clicking Cancel.
-        cancel.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        cancel.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         cancel.getActionMap().put("close", cancelAction);
 
         JPanel buttons = new JPanel();

--- a/src/main/java/org/jabref/gui/FXDialog.java
+++ b/src/main/java/org/jabref/gui/FXDialog.java
@@ -59,7 +59,7 @@ public class FXDialog extends Alert {
 
         dialogWindow.getScene().setOnKeyPressed(event -> {
             KeyBindingRepository keyBindingRepository = Globals.getKeyPrefs();
-            if (keyBindingRepository.checkKeyCombinationEquality(KeyBinding.CLOSE_DIALOG, event)) {
+            if (keyBindingRepository.checkKeyCombinationEquality(KeyBinding.CLOSE, event)) {
                 dialogWindow.close();
             }
         });

--- a/src/main/java/org/jabref/gui/GenFieldsCustomizer.java
+++ b/src/main/java/org/jabref/gui/GenFieldsCustomizer.java
@@ -97,7 +97,7 @@ public class GenFieldsCustomizer extends JabRefDialog {
         // Key bindings:
         ActionMap am = buttons.getActionMap();
         InputMap im = buttons.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", new AbstractAction() {
 
             @Override

--- a/src/main/java/org/jabref/gui/MergeDialog.java
+++ b/src/main/java/org/jabref/gui/MergeDialog.java
@@ -91,7 +91,7 @@ public class MergeDialog extends JabRefDialog {
         // Key bindings:
         ActionMap am = jPanel1.getActionMap();
         InputMap im = jPanel1.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", new AbstractAction() {
 
             @Override

--- a/src/main/java/org/jabref/gui/PreviewPanel.java
+++ b/src/main/java/org/jabref/gui/PreviewPanel.java
@@ -112,7 +112,7 @@ public class PreviewPanel extends ScrollPane implements SearchQueryHighlightList
                         copyPreviewToClipBoard();
                         event.consume();
                         break;
-                    case CLOSE_DIALOG:
+                    case CLOSE:
                         close();
                         event.consume();
                         break;

--- a/src/main/java/org/jabref/gui/ReplaceStringDialog.java
+++ b/src/main/java/org/jabref/gui/ReplaceStringDialog.java
@@ -81,7 +81,7 @@ class ReplaceStringDialog extends JabRefDialog {
         JPanel settings = new JPanel();
         ActionMap am = settings.getActionMap();
         InputMap im = settings.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", cancelAction);
 
         // Layout starts here.

--- a/src/main/java/org/jabref/gui/StringDialog.java
+++ b/src/main/java/org/jabref/gui/StringDialog.java
@@ -119,7 +119,7 @@ class StringDialog extends JabRefDialog {
         am.put("remove", removeStringAction);
         im.put(Globals.getKeyPrefs().getKey(KeyBinding.SAVE_DATABASE), "save");
         am.put("save", saveAction);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", closeAction);
         im.put(Globals.getKeyPrefs().getKey(KeyBinding.HELP), "help");
         am.put("help", helpAction);
@@ -217,7 +217,7 @@ class StringDialog extends JabRefDialog {
             TableColumnModel cm = getColumnModel();
             cm.getColumn(0).setPreferredWidth(800);
             cm.getColumn(1).setPreferredWidth(2000);
-            getInputMap().put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+            getInputMap().put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
             getActionMap().put("close", closeAction);
             getInputMap().put(Globals.getKeyPrefs().getKey(KeyBinding.HELP), "help");
             getActionMap().put("help", helpAction);

--- a/src/main/java/org/jabref/gui/actions/ManageKeywordsAction.java
+++ b/src/main/java/org/jabref/gui/actions/ManageKeywordsAction.java
@@ -197,7 +197,7 @@ public class ManageKeywordsAction extends SimpleCommand {
         // Key bindings:
         ActionMap am = builder.getPanel().getActionMap();
         InputMap im = builder.getPanel().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", cancelAction);
 
         diag.getContentPane().add(builder.getPanel(), BorderLayout.CENTER);

--- a/src/main/java/org/jabref/gui/actions/MassSetFieldAction.java
+++ b/src/main/java/org/jabref/gui/actions/MassSetFieldAction.java
@@ -189,7 +189,7 @@ public class MassSetFieldAction extends SimpleCommand {
         // Key bindings:
         ActionMap am = builder.getPanel().getActionMap();
         InputMap im = builder.getPanel().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", cancelAction);
     }
 

--- a/src/main/java/org/jabref/gui/auximport/FromAuxDialog.java
+++ b/src/main/java/org/jabref/gui/auximport/FromAuxDialog.java
@@ -132,7 +132,7 @@ public class FromAuxDialog extends JabRefDialog {
         // Key bindings:
         ActionMap am = statusPanel.getActionMap();
         InputMap im = statusPanel.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", new AbstractAction() {
 
             @Override

--- a/src/main/java/org/jabref/gui/bibtexkeypattern/ResolveDuplicateLabelDialog.java
+++ b/src/main/java/org/jabref/gui/bibtexkeypattern/ResolveDuplicateLabelDialog.java
@@ -104,7 +104,7 @@ class ResolveDuplicateLabelDialog {
 
         ActionMap am = b.getPanel().getActionMap();
         InputMap im = b.getPanel().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", closeAction);
     }
 

--- a/src/main/java/org/jabref/gui/customentrytypes/EntryCustomizationDialog.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/EntryCustomizationDialog.java
@@ -156,7 +156,7 @@ public class EntryCustomizationDialog extends JabRefDialog implements ListSelect
         };
         ActionMap am = main.getActionMap();
         InputMap im = main.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", closeAction);
 
         //con.fill = GridBagConstraints.BOTH;

--- a/src/main/java/org/jabref/gui/dbproperties/DatabasePropertiesDialog.java
+++ b/src/main/java/org/jabref/gui/dbproperties/DatabasePropertiesDialog.java
@@ -163,7 +163,7 @@ public class DatabasePropertiesDialog extends JabRefDialog {
         };
         ActionMap am = builder.getPanel().getActionMap();
         InputMap im = builder.getPanel().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", closeAction);
 
         ok.addActionListener(e -> {

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -125,7 +125,7 @@ public class EntryEditor extends BorderPane {
                         HelpAction.openHelpPage(HelpFile.ENTRY_EDITOR);
                         event.consume();
                         break;
-                    case CLOSE_ENTRY_EDITOR:
+                    case CLOSE:
                         close();
                         event.consume();
                         break;

--- a/src/main/java/org/jabref/gui/exporter/CustomExportDialog.java
+++ b/src/main/java/org/jabref/gui/exporter/CustomExportDialog.java
@@ -112,7 +112,7 @@ class CustomExportDialog extends JabRefDialog {
         JPanel main = new JPanel();
         ActionMap am = main.getActionMap();
         InputMap im = main.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", cancelAction);
 
         // Layout starts here.

--- a/src/main/java/org/jabref/gui/exporter/ExportCustomizationDialog.java
+++ b/src/main/java/org/jabref/gui/exporter/ExportCustomizationDialog.java
@@ -136,7 +136,7 @@ public class ExportCustomizationDialog extends JabRefDialog {
         JPanel main = new JPanel();
         ActionMap am = main.getActionMap();
         InputMap im = main.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", closeAction);
         main.setLayout(new BorderLayout());
         main.add(sp, BorderLayout.CENTER);

--- a/src/main/java/org/jabref/gui/externalfiles/WriteXMPActionWorker.java
+++ b/src/main/java/org/jabref/gui/externalfiles/WriteXMPActionWorker.java
@@ -205,7 +205,7 @@ public class WriteXMPActionWorker extends AbstractWorker {
 
             InputMap im = cancelButton.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
             ActionMap am = cancelButton.getActionMap();
-            im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+            im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
             am.put("close", cancel);
 
             progressArea = new JTextArea(15, 60);

--- a/src/main/java/org/jabref/gui/externalfiletype/ExternalFileTypeEditor.java
+++ b/src/main/java/org/jabref/gui/externalfiletype/ExternalFileTypeEditor.java
@@ -194,11 +194,11 @@ public class ExternalFileTypeEditor extends JabRefDialog {
         // Key bindings:
         ActionMap am = upper.getActionMap();
         InputMap im = upper.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", cancelAction);
         am = bb.getPanel().getActionMap();
         im = bb.getPanel().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", cancelAction);
 
         if (frame == null) {

--- a/src/main/java/org/jabref/gui/filelist/FileListEntryEditor.java
+++ b/src/main/java/org/jabref/gui/filelist/FileListEntryEditor.java
@@ -206,7 +206,7 @@ public class FileListEntryEditor {
         // Key bindings:
         ActionMap am = builder.getPanel().getActionMap();
         InputMap im = builder.getPanel().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", cancelAction);
 
         link.getDocument().addDocumentListener(new DocumentListener() {

--- a/src/main/java/org/jabref/gui/groups/GroupAddRemoveDialog.java
+++ b/src/main/java/org/jabref/gui/groups/GroupAddRemoveDialog.java
@@ -109,7 +109,7 @@ public class GroupAddRemoveDialog implements BaseAction {
         // Key bindings:
         ActionMap am = sp.getActionMap();
         InputMap im = sp.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", new AbstractAction() {
 
             @Override

--- a/src/main/java/org/jabref/gui/groups/GroupDialog.java
+++ b/src/main/java/org/jabref/gui/groups/GroupDialog.java
@@ -348,7 +348,7 @@ class GroupDialog extends JabRefDialog implements Dialog<AbstractGroup> {
         };
         mCancel.addActionListener(cancelAction);
         builderAll.getPanel().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-                .put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+                  .put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         builderAll.getPanel().getActionMap().put("close", cancelAction);
 
         okButton.addActionListener(e -> {

--- a/src/main/java/org/jabref/gui/importer/FetcherPreviewDialog.java
+++ b/src/main/java/org/jabref/gui/importer/FetcherPreviewDialog.java
@@ -113,7 +113,7 @@ public class FetcherPreviewDialog extends JabRefDialog implements OutputPrinter 
         };
         ActionMap am = centerPan.getActionMap();
         InputMap im = centerPan.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", closeAction);
 
         pack();

--- a/src/main/java/org/jabref/gui/importer/ImportCustomizationDialog.java
+++ b/src/main/java/org/jabref/gui/importer/ImportCustomizationDialog.java
@@ -193,7 +193,7 @@ public class ImportCustomizationDialog extends JabRefDialog {
         JPanel mainPanel = new JPanel();
         ActionMap am = mainPanel.getActionMap();
         InputMap im = mainPanel.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", closeAction);
         mainPanel.setLayout(new BorderLayout());
         mainPanel.add(sp, BorderLayout.CENTER);

--- a/src/main/java/org/jabref/gui/importer/ImportInspectionDialog.java
+++ b/src/main/java/org/jabref/gui/importer/ImportInspectionDialog.java
@@ -340,7 +340,7 @@ public class ImportInspectionDialog extends JabRefDialog implements ImportInspec
         };
         ActionMap am = contentPane.getActionMap();
         InputMap im = contentPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", closeAction);
 
     }

--- a/src/main/java/org/jabref/gui/keyboard/KeyBinder.java
+++ b/src/main/java/org/jabref/gui/keyboard/KeyBinder.java
@@ -22,7 +22,7 @@ public class KeyBinder {
     public static void bindCloseDialogKeyToCancelAction(JRootPane rootPane, Action cancelAction) {
         InputMap im = rootPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
         ActionMap am = rootPane.getActionMap();
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", cancelAction);
     }
 

--- a/src/main/java/org/jabref/gui/keyboard/KeyBinding.java
+++ b/src/main/java/org/jabref/gui/keyboard/KeyBinding.java
@@ -11,8 +11,7 @@ public enum KeyBinding {
     CHECK_INTEGRITY("Check integrity", Localization.menuTitle("Check integrity"), "ctrl+F8", KeyBindingCategory.QUALITY),
     CLEANUP("Cleanup", Localization.lang("Cleanup entries"), "alt+F8", KeyBindingCategory.QUALITY),
     CLOSE_DATABASE("Close library", Localization.lang("Close library"), "ctrl+W", KeyBindingCategory.FILE),
-    CLOSE_DIALOG("Close dialog", Localization.lang("Close dialog"), "ESCAPE", KeyBindingCategory.FILE),
-    CLOSE_ENTRY_EDITOR("Close entry editor", Localization.lang("Close entry editor"), "Esc", KeyBindingCategory.VIEW),
+    CLOSE("Close dialog", Localization.lang("Close dialog"), "Esc", KeyBindingCategory.VIEW),
     COPY("Copy", Localization.lang("Copy"), "ctrl+C", KeyBindingCategory.EDIT),
     COPY_TITLE("Copy title", Localization.lang("Copy title"), "ctrl+shift+alt+T", KeyBindingCategory.EDIT),
     COPY_CITE_BIBTEX_KEY("Copy \\cite{BibTeX key}", Localization.lang("Copy \\cite{BibTeX key}"), "ctrl+K", KeyBindingCategory.EDIT),
@@ -87,8 +86,7 @@ public enum KeyBinding {
     UNABBREVIATE("Unabbreviate", Localization.lang("Unabbreviate"), "ctrl+alt+shift+A", KeyBindingCategory.TOOLS),
     UNDO("Undo", Localization.lang("Undo"), "ctrl+Z", KeyBindingCategory.EDIT),
     WEB_SEARCH("Web search", Localization.lang("Web search"), "alt+4", KeyBindingCategory.SEARCH),
-    WRITE_XMP("Write XMP", Localization.lang("Write XMP"), "F6", KeyBindingCategory.TOOLS),
-    CLEAR_SEARCH("Clear search", Localization.lang("Clear search"), "ESC", KeyBindingCategory.SEARCH);
+    WRITE_XMP("Write XMP", Localization.lang("Write XMP"), "F6", KeyBindingCategory.TOOLS);
 
     private final String constant;
     private final String localization;

--- a/src/main/java/org/jabref/gui/openoffice/AdvancedCiteDialog.java
+++ b/src/main/java/org/jabref/gui/openoffice/AdvancedCiteDialog.java
@@ -89,7 +89,7 @@ class AdvancedCiteDialog {
         };
         cancel.addActionListener(cancelAction);
         builder.getPanel().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-                .put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+               .put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         builder.getPanel().getActionMap().put("close", cancelAction);
 
     }

--- a/src/main/java/org/jabref/gui/openoffice/CitationManager.java
+++ b/src/main/java/org/jabref/gui/openoffice/CitationManager.java
@@ -110,7 +110,7 @@ class CitationManager {
         cancel.addActionListener(cancelAction);
 
         bb.getPanel().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put
-                (Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+                (Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         bb.getPanel().getActionMap().put("close", cancelAction);
 
         table.getColumnModel().getColumn(0).setPreferredWidth(580);
@@ -225,7 +225,7 @@ class CitationManager {
             cancelButton.addActionListener(cancelAction);
 
             builder.getPanel().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put
-                    (Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+                    (Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
             builder.getPanel().getActionMap().put("close", cancelAction);
 
         }

--- a/src/main/java/org/jabref/gui/openoffice/StyleSelectDialog.java
+++ b/src/main/java/org/jabref/gui/openoffice/StyleSelectDialog.java
@@ -193,7 +193,7 @@ class StyleSelectDialog {
 
         ActionMap am = bb.getPanel().getActionMap();
         InputMap im = bb.getPanel().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", cancelListener);
         im.put(KeyStroke.getKeyStroke("ENTER"), "enterOk");
         am.put("enterOk", okListener);
@@ -517,8 +517,8 @@ class StyleSelectDialog {
 
             // Key bindings:
             bb.getPanel()
-                    .getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-                    .put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+              .getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+              .put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
             bb.getPanel().getActionMap().put("close", cancelAction);
             pack();
             setLocationRelativeTo(diag);

--- a/src/main/java/org/jabref/gui/plaintextimport/TextInputDialog.java
+++ b/src/main/java/org/jabref/gui/plaintextimport/TextInputDialog.java
@@ -174,7 +174,7 @@ public class TextInputDialog extends JabRefDialog {
         // Key bindings:
         ActionMap am = buttons.getActionMap();
         InputMap im = buttons.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", new AbstractAction() {
 
             @Override

--- a/src/main/java/org/jabref/gui/protectedterms/NewProtectedTermsFileDialog.java
+++ b/src/main/java/org/jabref/gui/protectedterms/NewProtectedTermsFileDialog.java
@@ -111,7 +111,7 @@ public class NewProtectedTermsFileDialog extends JabRefDialog {
 
         // Key bindings:
         bb.getPanel().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-                .put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+          .put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         bb.getPanel().getActionMap().put("close", cancelAction);
         pack();
     }

--- a/src/main/java/org/jabref/gui/protectedterms/ProtectedTermsDialog.java
+++ b/src/main/java/org/jabref/gui/protectedterms/ProtectedTermsDialog.java
@@ -166,7 +166,7 @@ public class ProtectedTermsDialog {
 
         ActionMap am = bb.getPanel().getActionMap();
         InputMap im = bb.getPanel().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", cancelListener);
         im.put(KeyStroke.getKeyStroke("ENTER"), "enterOk");
         am.put("enterOk", okListener);
@@ -477,7 +477,7 @@ public class ProtectedTermsDialog {
 
             // Key bindings:
             bb.getPanel().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-                    .put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+              .put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
             bb.getPanel().getActionMap().put("close", cancelAction);
             pack();
             setLocationRelativeTo(diag);

--- a/src/main/java/org/jabref/gui/push/PushToApplicationSettingsDialog.java
+++ b/src/main/java/org/jabref/gui/push/PushToApplicationSettingsDialog.java
@@ -43,7 +43,7 @@ public class PushToApplicationSettingsDialog {
         // Key bindings:
         ActionMap am = bb.getPanel().getActionMap();
         InputMap im = bb.getPanel().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        im.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         am.put("close", new AbstractAction() {
 
             @Override

--- a/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
+++ b/src/main/java/org/jabref/gui/search/GlobalSearchBar.java
@@ -143,7 +143,7 @@ public class GlobalSearchBar extends HBox {
                     updateOpenCurrentResultsTooltip(globalSearch.isSelected());
                     focus();
                     event.consume();
-                } else if (keyBinding.get().equals(KeyBinding.CLEAR_SEARCH)) {
+                } else if (keyBinding.get().equals(KeyBinding.CLOSE)) {
                     // Clear search and select first entry, if available
                     clearSearch();
                     frame.getCurrentBasePanel().getMainTable().getSelectionModel().selectFirst();

--- a/src/main/java/org/jabref/gui/search/SearchResultFrame.java
+++ b/src/main/java/org/jabref/gui/search/SearchResultFrame.java
@@ -164,7 +164,7 @@ public class SearchResultFrame {
 
         ActionMap actionMap = contentPane.getActionMap();
         InputMap inputMap = contentPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
-        inputMap.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DIALOG), "close");
+        inputMap.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE), "close");
         inputMap.put(Globals.getKeyPrefs().getKey(KeyBinding.CLOSE_DATABASE), "close");
         actionMap.put("close", closeAction);
 

--- a/src/main/java/org/jabref/gui/util/BaseDialog.java
+++ b/src/main/java/org/jabref/gui/util/BaseDialog.java
@@ -14,7 +14,7 @@ public class BaseDialog<T> extends Dialog<T> {
     protected BaseDialog() {
         getDialogPane().getScene().setOnKeyPressed(event -> {
             KeyBindingRepository keyBindingRepository = Globals.getKeyPrefs();
-            if (keyBindingRepository.checkKeyCombinationEquality(KeyBinding.CLOSE_DIALOG, event)) {
+            if (keyBindingRepository.checkKeyCombinationEquality(KeyBinding.CLOSE, event)) {
                 close();
             }
         });

--- a/src/test/java/org/jabref/gui/keyboard/KeyBindingsDialogViewModelTest.java
+++ b/src/test/java/org/jabref/gui/keyboard/KeyBindingsDialogViewModelTest.java
@@ -145,16 +145,16 @@ public class KeyBindingsDialogViewModelTest {
 
     @Test
     public void testCloseEntryEditorCloseEntryKeybinding() {
-        KeyBindingViewModel viewModel = setKeyBindingViewModel(KeyBinding.CLOSE_ENTRY_EDITOR);
+        KeyBindingViewModel viewModel = setKeyBindingViewModel(KeyBinding.CLOSE);
         model.selectedKeyBindingProperty().set(viewModel);
         KeyEvent closeEditorEvent = new KeyEvent(KeyEvent.KEY_PRESSED, "", "", KeyCode.ESCAPE, false, false, false, false);
 
-        assertEquals(KeyBinding.CLOSE_ENTRY_EDITOR.getDefaultKeyBinding(), KeyCode.ESCAPE.getName());
+        assertEquals(KeyBinding.CLOSE.getDefaultKeyBinding(), KeyCode.ESCAPE.getName());
 
-        KeyCombination combi = KeyCombination.valueOf(KeyBinding.CLOSE_ENTRY_EDITOR.getDefaultKeyBinding());
+        KeyCombination combi = KeyCombination.valueOf(KeyBinding.CLOSE.getDefaultKeyBinding());
 
         assertTrue(combi.match(closeEditorEvent));
-        assertTrue(keyBindingRepository.checkKeyCombinationEquality(KeyBinding.CLOSE_ENTRY_EDITOR, closeEditorEvent));
+        assertTrue(keyBindingRepository.checkKeyCombinationEquality(KeyBinding.CLOSE, closeEditorEvent));
     }
 
     @Test


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

Problem was that we had a few key-bindings that were bound to `Esc`, but only the first binding was returned (e.g. user pressed `Esc`, was recognized as `DialogClose` but preview only reacted on `EntryPreviewClose`). 

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
