### PR TITLE
Add XMP Exporter

### DIFF
--- a/src/main/java/org/jabref/cli/ArgumentProcessor.java
+++ b/src/main/java/org/jabref/cli/ArgumentProcessor.java
@@ -41,6 +41,7 @@ import org.jabref.logic.search.DatabaseSearcher;
 import org.jabref.logic.search.SearchQuery;
 import org.jabref.logic.shared.prefs.SharedDatabasePreferences;
 import org.jabref.logic.util.OS;
+import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.Defaults;
 import org.jabref.model.EntryTypes;
 import org.jabref.model.database.BibDatabase;
@@ -471,7 +472,8 @@ public class ArgumentProcessor {
             LayoutFormatterPreferences layoutPreferences = Globals.prefs
                     .getLayoutFormatterPreferences(Globals.journalAbbreviationLoader);
             SavePreferences savePreferences = SavePreferences.loadForExportFromPreferences(Globals.prefs);
-            Globals.exportFactory = ExporterFactory.create(customExporters, layoutPreferences, savePreferences);
+            XmpPreferences xmpPreferences = Globals.prefs.getXMPPreferences();
+            Globals.exportFactory = ExporterFactory.create(customExporters, layoutPreferences, savePreferences, xmpPreferences);
         } catch (JabRefException ex) {
             LOGGER.error("Cannot import preferences", ex);
         }

--- a/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
+++ b/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
@@ -8,10 +8,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.jabref.Globals;
 import org.jabref.logic.journals.JournalAbbreviationLoader;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.util.FileType;
+import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.preferences.JabRefPreferences;
 
 public class ExporterFactory {
@@ -30,7 +30,7 @@ public class ExporterFactory {
     }
 
     public static ExporterFactory create(Map<String, TemplateExporter> customFormats,
-            LayoutFormatterPreferences layoutPreferences, SavePreferences savePreferences) {
+            LayoutFormatterPreferences layoutPreferences, SavePreferences savePreferences, XmpPreferences xmpPreferences) {
 
         List<Exporter> exporters = new ArrayList<>();
 
@@ -55,7 +55,7 @@ public class ExporterFactory {
         exporters.add(new OpenDocumentSpreadsheetCreator());
         exporters.add(new MSBibExporter());
         exporters.add(new ModsExporter());
-        exporters.add(new XmpExporter(Globals.prefs.getXMPPreferences()));
+        exporters.add(new XmpExporter(xmpPreferences));
 
         // Now add custom export formats
         exporters.addAll(customFormats.values());
@@ -67,7 +67,8 @@ public class ExporterFactory {
         Map<String, TemplateExporter> customFormats = preferences.customExports.getCustomExportFormats(preferences, abbreviationLoader);
         LayoutFormatterPreferences layoutPreferences = preferences.getLayoutFormatterPreferences(abbreviationLoader);
         SavePreferences savePreferences = SavePreferences.loadForExportFromPreferences(preferences);
-        return create(customFormats, layoutPreferences, savePreferences);
+        XmpPreferences xmpPreferences = preferences.getXMPPreferences();
+        return create(customFormats, layoutPreferences, savePreferences, xmpPreferences);
     }
 
     /**

--- a/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
+++ b/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
@@ -54,6 +54,7 @@ public class ExporterFactory {
         exporters.add(new OpenDocumentSpreadsheetCreator());
         exporters.add(new MSBibExporter());
         exporters.add(new ModsExporter());
+        exporters.add(new XmpExporter());
 
         // Now add custom export formats
         exporters.addAll(customFormats.values());

--- a/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
+++ b/src/main/java/org/jabref/logic/exporter/ExporterFactory.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.jabref.Globals;
 import org.jabref.logic.journals.JournalAbbreviationLoader;
 import org.jabref.logic.layout.LayoutFormatterPreferences;
 import org.jabref.logic.util.FileType;
@@ -54,7 +55,7 @@ public class ExporterFactory {
         exporters.add(new OpenDocumentSpreadsheetCreator());
         exporters.add(new MSBibExporter());
         exporters.add(new ModsExporter());
-        exporters.add(new XmpExporter());
+        exporters.add(new XmpExporter(Globals.prefs.getXMPPreferences()));
 
         // Now add custom export formats
         exporters.addAll(customFormats.values());

--- a/src/main/java/org/jabref/logic/exporter/XmpExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/XmpExporter.java
@@ -8,8 +8,8 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 
-import org.jabref.Globals;
 import org.jabref.logic.util.FileType;
+import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.logic.xmp.XmpUtilWriter;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
@@ -21,8 +21,11 @@ import org.jabref.model.entry.BibEntry;
  */
 public class XmpExporter extends Exporter {
 
-    public XmpExporter() {
-        super("XmpBib", FileType.ENDNOTE_XMP.getDescription(), FileType.ENDNOTE_XMP);
+    private final XmpPreferences xmpPreferences;
+
+    public XmpExporter(XmpPreferences xmpPreferences) {
+        super("xmp", FileType.PLAIN_XMP.getDescription(), FileType.PLAIN_XMP);
+        this.xmpPreferences = xmpPreferences;
     }
 
     @Override
@@ -35,7 +38,7 @@ public class XmpExporter extends Exporter {
         }
 
         try (BufferedWriter writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
-            writer.write(XmpUtilWriter.generateXmpString(entries, Globals.prefs.getXMPPreferences()));
+            writer.write(XmpUtilWriter.generateXmpString(entries, this.xmpPreferences));
             writer.flush();
         }
     }

--- a/src/main/java/org/jabref/logic/exporter/XmpExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/XmpExporter.java
@@ -3,7 +3,6 @@ package org.jabref.logic.exporter;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -46,19 +45,26 @@ public class XmpExporter extends Exporter {
         // This is a distinction between writing all entries from the supplied list to a single .xmp file,
         // or write every entry to a separate file.
         if (file.getFileName().toString().trim().equals(XMP_SPLIT_PATTERN)) {
+
             for (BibEntry entry : entries) {
                 // Avoid situations, where two cite keys are null
-                Path entryFile = Paths.get(entry.getId() + "_" + entry.getCiteKey() + ".xmp");
+                Path entryFile;
+                String suffix = entry.getId() + "_" + entry.getCiteKey() + ".xmp";
+                if (file.getParent() == null) {
+                    entryFile = Paths.get(suffix);
+                } else {
+                    entryFile = Paths.get(file.getParent().toString() + "/" + suffix);
+                }
 
-                this.writeBibToXmp(entryFile, Arrays.asList(entry));
+                this.writeBibToXmp(entryFile, Arrays.asList(entry), encoding);
             }
         } else {
-            this.writeBibToXmp(file, entries);
+            this.writeBibToXmp(file, entries, encoding);
         }
     }
 
-    private void writeBibToXmp(Path file, List<BibEntry> entries) throws IOException {
-        try (BufferedWriter writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
+    private void writeBibToXmp(Path file, List<BibEntry> entries, Charset encoding) throws IOException {
+        try (BufferedWriter writer = Files.newBufferedWriter(file, encoding)) {
             writer.write(XmpUtilWriter.generateXmpString(entries, this.xmpPreferences));
             writer.flush();
         }

--- a/src/main/java/org/jabref/logic/exporter/XmpExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/XmpExporter.java
@@ -1,0 +1,40 @@
+package org.jabref.logic.exporter;
+
+import java.io.BufferedWriter;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+import org.jabref.logic.util.FileType;
+import org.jabref.logic.xmp.XmpUtilWriter;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+
+/**
+ *
+ */
+public class XmpExporter extends Exporter {
+
+    public XmpExporter() {
+        super("XmpBib", FileType.ENDNOTE_XMP.getDescription(), FileType.ENDNOTE_XMP);
+    }
+
+    @Override
+    public void export(BibDatabaseContext databaseContext, Path file, Charset encoding, List<BibEntry> entries) throws Exception {
+        Objects.requireNonNull(databaseContext);
+        Objects.requireNonNull(entries);
+
+        if (entries.isEmpty()) {
+            return;
+        }
+
+        try (BufferedWriter writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
+            writer.write(XmpUtilWriter.generateXmpString(entries));
+            writer.flush();
+        }
+    }
+
+}

--- a/src/main/java/org/jabref/logic/exporter/XmpExporter.java
+++ b/src/main/java/org/jabref/logic/exporter/XmpExporter.java
@@ -8,13 +8,16 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
 
+import org.jabref.Globals;
 import org.jabref.logic.util.FileType;
 import org.jabref.logic.xmp.XmpUtilWriter;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 
 /**
- *
+ * A custom exporter to write bib entries to a .xmp file for further processing
+ * in other scenarios and applications. The xmp metadata are written in dublin
+ * core format.
  */
 public class XmpExporter extends Exporter {
 
@@ -32,7 +35,7 @@ public class XmpExporter extends Exporter {
         }
 
         try (BufferedWriter writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
-            writer.write(XmpUtilWriter.generateXmpString(entries));
+            writer.write(XmpUtilWriter.generateXmpString(entries, Globals.prefs.getXMPPreferences()));
             writer.flush();
         }
     }

--- a/src/main/java/org/jabref/logic/util/FileType.java
+++ b/src/main/java/org/jabref/logic/util/FileType.java
@@ -26,6 +26,7 @@ public enum FileType {
     DIN_1505(Localization.lang("%0 file", "DIN 1505"), "rtf"),
     ENDNOTE(Localization.lang("%0 file", "EndNote/Refer"), "ref", "enw"),
     ENDNOTE_XML(Localization.lang("%0 file", "EndNote XML"), "xml"),
+    ENDNOTE_XMP(Localization.lang("%0 file", "EndNote Xmp"), "xmp"),
     ENDNOTE_TXT(Localization.lang("%0 file", "EndNote"), "txt"), //for export
     FREECITE(Localization.lang("%0 file", "FreeCite"), "txt", "xml"),
     HARVARD_RTF(Localization.lang("%0 file", "Harvard"), "rtf"),

--- a/src/main/java/org/jabref/logic/util/FileType.java
+++ b/src/main/java/org/jabref/logic/util/FileType.java
@@ -26,7 +26,6 @@ public enum FileType {
     DIN_1505(Localization.lang("%0 file", "DIN 1505"), "rtf"),
     ENDNOTE(Localization.lang("%0 file", "EndNote/Refer"), "ref", "enw"),
     ENDNOTE_XML(Localization.lang("%0 file", "EndNote XML"), "xml"),
-    ENDNOTE_XMP(Localization.lang("%0 file", "Xmp"), "xmp"),
     ENDNOTE_TXT(Localization.lang("%0 file", "EndNote"), "txt"), //for export
     FREECITE(Localization.lang("%0 file", "FreeCite"), "txt", "xml"),
     HARVARD_RTF(Localization.lang("%0 file", "Harvard"), "rtf"),
@@ -51,6 +50,7 @@ public enum FileType {
     SILVER_PLATTER(Localization.lang("%0 file", "SilverPlatter"), "dat", "txt"),
     SIMPLE_HTML(Localization.lang("%0 file", Localization.lang("Simple HTML")), "html"),
     XMP(Localization.lang("XMP-annotated PDF"), "pdf"),
+    PLAIN_XMP(Localization.lang("%0 file", "Xmp"), "xmp"),
 
     AUX(Localization.lang("%0 file", "AUX"), "aux"),
     JSTYLE(Localization.lang("Style file"), "jstyle"),

--- a/src/main/java/org/jabref/logic/util/FileType.java
+++ b/src/main/java/org/jabref/logic/util/FileType.java
@@ -50,7 +50,7 @@ public enum FileType {
     SILVER_PLATTER(Localization.lang("%0 file", "SilverPlatter"), "dat", "txt"),
     SIMPLE_HTML(Localization.lang("%0 file", Localization.lang("Simple HTML")), "html"),
     XMP(Localization.lang("XMP-annotated PDF"), "pdf"),
-    PLAIN_XMP(Localization.lang("%0 file", "Xmp"), "xmp"),
+    PLAIN_XMP(Localization.lang("%0 file", "XMP"), "xmp"),
 
     AUX(Localization.lang("%0 file", "AUX"), "aux"),
     JSTYLE(Localization.lang("Style file"), "jstyle"),

--- a/src/main/java/org/jabref/logic/util/FileType.java
+++ b/src/main/java/org/jabref/logic/util/FileType.java
@@ -26,7 +26,7 @@ public enum FileType {
     DIN_1505(Localization.lang("%0 file", "DIN 1505"), "rtf"),
     ENDNOTE(Localization.lang("%0 file", "EndNote/Refer"), "ref", "enw"),
     ENDNOTE_XML(Localization.lang("%0 file", "EndNote XML"), "xml"),
-    ENDNOTE_XMP(Localization.lang("%0 file", "EndNote Xmp"), "xmp"),
+    ENDNOTE_XMP(Localization.lang("%0 file", "Xmp"), "xmp"),
     ENDNOTE_TXT(Localization.lang("%0 file", "EndNote"), "txt"), //for export
     FREECITE(Localization.lang("%0 file", "FreeCite"), "txt", "xml"),
     HARVARD_RTF(Localization.lang("%0 file", "Harvard"), "rtf"),

--- a/src/main/java/org/jabref/logic/xmp/XmpUtilWriter.java
+++ b/src/main/java/org/jabref/logic/xmp/XmpUtilWriter.java
@@ -99,7 +99,21 @@ public class XmpUtilWriter {
 
         BibEntry resolvedEntry = XmpUtilWriter.getDefaultOrDatabaseEntry(entry, database);
 
-        DublinCoreExtractor dcExtractor = new DublinCoreExtractor(dcSchema, xmpPreferences, resolvedEntry);
+        writeToDCSchema(dcSchema, resolvedEntry, xmpPreferences);
+    }
+
+    /**
+     * Writes the information of the bib entry to the dublin core schema using
+     * a custom extractor.
+     *
+     * @param dcSchema  Dublin core schema, which is filled with the bib entry.
+     * @param entry     The entry, which is added to the dublin core metadata.
+     * @param xmpPreferences    The user's xmp preferences.
+     */
+    private static void writeToDCSchema(DublinCoreSchema dcSchema, BibEntry entry,
+            XmpPreferences xmpPreferences) {
+
+        DublinCoreExtractor dcExtractor = new DublinCoreExtractor(dcSchema, xmpPreferences, entry);
         dcExtractor.fillDublinCoreSchema();
     }
 
@@ -184,20 +198,20 @@ public class XmpUtilWriter {
         XMPMetadata meta = XMPMetadata.createXMPMetadata();
         for (BibEntry entry : entries) {
             DublinCoreSchema dcSchema = meta.createAndAddDublinCoreSchema();
-            XmpUtilWriter.writeToDCSchema(dcSchema, entry, null, xmpPreferences);
+            XmpUtilWriter.writeToDCSchema(dcSchema, entry, xmpPreferences);
         }
         try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
             XmpSerializer serializer = new XmpSerializer();
             serializer.serialize(meta, os, true);
             return os.toString(StandardCharsets.UTF_8.name());
         } catch (TransformerException e) {
-            LOGGER.warn("Tranformation into xmp not possible: " + e.getMessage());
+            LOGGER.warn("Tranformation into xmp not possible: " + e.getMessage(), e);
             return "";
         } catch (UnsupportedEncodingException e) {
-            LOGGER.warn("Unsupported encoding to UTF-8 of bib entries in xmp metadata.");
+            LOGGER.warn("Unsupported encoding to UTF-8 of bib entries in xmp metadata.", e);
             return "";
         } catch (IOException e) {
-            LOGGER.warn("IO Exception thrown by closing the output stream.");
+            LOGGER.warn("IO Exception thrown by closing the output stream.", e);
             return "";
         }
     }

--- a/src/test/java/org/jabref/logic/exporter/CsvExportFormatTest.java
+++ b/src/test/java/org/jabref/logic/exporter/CsvExportFormatTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.jabref.logic.layout.LayoutFormatterPreferences;
+import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 
@@ -36,7 +37,8 @@ public class CsvExportFormatTest {
         Map<String, TemplateExporter> customFormats = new HashMap<>();
         LayoutFormatterPreferences layoutPreferences = mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS);
         SavePreferences savePreferences = mock(SavePreferences.class);
-        ExporterFactory exporterFactory = ExporterFactory.create(customFormats, layoutPreferences, savePreferences);
+        XmpPreferences xmpPreferences = mock(XmpPreferences.class);
+        ExporterFactory exporterFactory = ExporterFactory.create(customFormats, layoutPreferences, savePreferences, xmpPreferences);
 
         exportFormat = exporterFactory.getExporterByName("oocsv").get();
 

--- a/src/test/java/org/jabref/logic/exporter/ExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/ExporterTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.jabref.logic.layout.LayoutFormatterPreferences;
+import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 
@@ -57,7 +58,8 @@ public class ExporterTest {
         Map<String, TemplateExporter> customFormats = new HashMap<>();
         LayoutFormatterPreferences layoutPreferences = mock(LayoutFormatterPreferences.class);
         SavePreferences savePreferences = mock(SavePreferences.class);
-        ExporterFactory exporterFactory = ExporterFactory.create(customFormats, layoutPreferences, savePreferences);
+        XmpPreferences xmpPreferences = mock(XmpPreferences.class);
+        ExporterFactory exporterFactory = ExporterFactory.create(customFormats, layoutPreferences, savePreferences, xmpPreferences);
 
         for (Exporter format : exporterFactory.getExporters()) {
             result.add(new Object[]{format, format.getDisplayName()});

--- a/src/test/java/org/jabref/logic/exporter/HtmlExportFormatTest.java
+++ b/src/test/java/org/jabref/logic/exporter/HtmlExportFormatTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.jabref.logic.layout.LayoutFormatterPreferences;
+import org.jabref.logic.xmp.XmpPreferences;
 import org.jabref.model.database.BibDatabaseContext;
 import org.jabref.model.entry.BibEntry;
 
@@ -37,7 +38,8 @@ public class HtmlExportFormatTest {
         Map<String, TemplateExporter> customFormats = new HashMap<>();
         LayoutFormatterPreferences layoutPreferences = mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS);
         SavePreferences savePreferences = mock(SavePreferences.class);
-        ExporterFactory exporterFactory = ExporterFactory.create(customFormats, layoutPreferences, savePreferences);
+        XmpPreferences xmpPreferences = mock(XmpPreferences.class);
+        ExporterFactory exporterFactory = ExporterFactory.create(customFormats, layoutPreferences, savePreferences, xmpPreferences);
 
         exportFormat = exporterFactory.getExporterByName("html").get();
 

--- a/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
+++ b/src/test/java/org/jabref/logic/exporter/XmpExporterTest.java
@@ -1,0 +1,112 @@
+package org.jabref.logic.exporter;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jabref.logic.layout.LayoutFormatterPreferences;
+import org.jabref.logic.xmp.XmpPreferences;
+import org.jabref.model.database.BibDatabaseContext;
+import org.jabref.model.entry.BibEntry;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Answers;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class XmpExporterTest {
+
+    private Exporter exporter;
+    private BibDatabaseContext databaseContext;
+    private Charset encoding;
+
+    @Rule public TemporaryFolder testFolder = new TemporaryFolder();
+
+    @Before
+    public void setUp() {
+        Map<String, TemplateExporter> customFormats = new HashMap<>();
+        LayoutFormatterPreferences layoutPreferences = mock(LayoutFormatterPreferences.class, Answers.RETURNS_DEEP_STUBS);
+        SavePreferences savePreferences = mock(SavePreferences.class);
+        XmpPreferences xmpPreferences = mock(XmpPreferences.class);
+        ExporterFactory exporterFactory = ExporterFactory.create(customFormats, layoutPreferences, savePreferences, xmpPreferences);
+
+        exporter = exporterFactory.getExporterByName("xmp").get();
+
+        databaseContext = new BibDatabaseContext();
+        encoding = StandardCharsets.UTF_8;
+    }
+
+    @Test
+    public void exportSingleEntry() throws Exception {
+
+        Path file = testFolder.newFile().toPath();
+
+        BibEntry entry = new BibEntry();
+        entry.setField("author", "Alan Turing");
+
+        exporter.export(databaseContext, file, encoding, Arrays.asList(entry));
+
+        List<String> lines = Files.readAllLines(file);
+        assertTrue(lines.size() == 21);
+        assertEquals("<rdf:li>Alan Turing</rdf:li>", lines.get(7).trim());
+    }
+
+    @Test
+    public void writeMutlipleEntriesInASingleFile() throws Exception {
+
+        Path file = testFolder.newFile().toPath();
+
+        BibEntry entryTuring = new BibEntry();
+        entryTuring.setField("author", "Alan Turing");
+
+        BibEntry entryArmbrust = new BibEntry();
+        entryArmbrust.setField("author", "Michael Armbrust");
+        entryArmbrust.setCiteKey("Armbrust2010");
+
+        exporter.export(databaseContext, file, encoding, Arrays.asList(entryTuring, entryArmbrust));
+
+        List<String> lines = Files.readAllLines(file);
+        assertTrue(lines.size() == 39);
+        assertEquals("<rdf:li>Alan Turing</rdf:li>", lines.get(7).trim());
+        assertEquals("<rdf:li>Michael Armbrust</rdf:li>", lines.get(20).trim());
+    }
+
+    @Test
+    public void writeMultipleEntriesInDifferentFiles() throws Exception {
+
+        Path file = testFolder.newFile("split").toPath();
+
+        BibEntry entryTuring = new BibEntry();
+        entryTuring.setField("author", "Alan Turing");
+
+        BibEntry entryArmbrust = new BibEntry();
+        entryArmbrust.setField("author", "Michael Armbrust");
+        entryArmbrust.setCiteKey("Armbrust2010");
+
+        exporter.export(databaseContext, file, encoding, Arrays.asList(entryTuring, entryArmbrust));
+
+        List<String> lines = Files.readAllLines(file);
+        assertTrue(lines.size() == 0);
+
+        Path fileTuring = Paths.get(file.getParent().toString() + "/" + entryTuring.getId() + "_null.xmp");
+        List<String> linesTuring = Files.readAllLines(fileTuring);
+        assertTrue(linesTuring.size() == 21);
+        assertEquals("<rdf:li>Alan Turing</rdf:li>", linesTuring.get(7).trim());
+
+        Path fileArmbrust = Paths.get(file.getParent().toString() + "/" + entryArmbrust.getId() + "_Armbrust2010.xmp");
+        List<String> linesArmbrust = Files.readAllLines(fileArmbrust);
+        assertTrue(linesArmbrust.size() == 26);
+        assertEquals("<rdf:li>Michael Armbrust</rdf:li>", linesArmbrust.get(7).trim());
+    }
+}


### PR DESCRIPTION
Refs [koppor#319](https://github.com/koppor/jabref/issues/319).

Adds the first functionality to export the bib entries in a single .xmp file. 
@koppor For a first review: Please check the output format of the new .xmp file.
There is also a <?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?> tag included. Should I remove this tag?

The cli support is planned for the next days :)
----

- [ ] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?) Updated the help page within the already opened pull request.
