### PR TITLE
Add required mock to LinkedfileViewModelTest

### DIFF
--- a/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -2,11 +2,13 @@ package org.jabref.gui.fieldeditors;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.ButtonType;
 
+import org.jabref.Globals;
 import org.jabref.gui.DialogService;
 import org.jabref.gui.util.TaskExecutor;
 import org.jabref.logic.journals.JournalAbbreviationLoader;
@@ -50,7 +52,10 @@ public class LinkedFileViewModelTest {
         databaseContext = new BibDatabaseContext();
         taskExecutor = mock(TaskExecutor.class);
         dialogService = mock(DialogService.class);
-
+        Globals.prefs = mock(JabRefPreferences.class);
+        when(Globals.prefs.getDefaultEncoding()).thenReturn(StandardCharsets.UTF_8);
+        FileDirectoryPreferences fileDirectoryPreferences = mock(FileDirectoryPreferences.class);
+        when(Globals.prefs.getFileDirectoryPreferences()).thenReturn(fileDirectoryPreferences);
     }
 
     @Test


### PR DESCRIPTION
While working on #3704, test were failing in other settings. This is a quick fix to get the tests running.