### PR TITLE
Remove all @author comments and empty method/class comments

### DIFF
--- a/src/main/java/org/jabref/gui/DragDropPane.java
+++ b/src/main/java/org/jabref/gui/DragDropPane.java
@@ -20,8 +20,6 @@ import org.jabref.gui.icon.JabRefIcon;
 
 /**
  * Extends the JTabbedPane class to support Drag&Drop of Tabs.
- *
- * @author kleinms, strassfn
  */
 class DragDropPane extends JTabbedPane {
 

--- a/src/main/java/org/jabref/gui/FindUnlinkedFilesDialog.java
+++ b/src/main/java/org/jabref/gui/FindUnlinkedFilesDialog.java
@@ -1008,10 +1008,6 @@ public class FindUnlinkedFilesDialog extends JabRefDialog {
 
     /**
      * Wrapper for displaying the Type {@link BibtexEntryType} in a Combobox.
-     *
-     * @author Nosh&Dan
-     * @version 12.11.2008 | 01:02:30
-     *
      */
     private static class BibtexEntryTypeWrapper {
 

--- a/src/main/java/org/jabref/gui/MergeDialog.java
+++ b/src/main/java/org/jabref/gui/MergeDialog.java
@@ -21,12 +21,8 @@ import org.jabref.gui.keyboard.KeyBinding;
 import org.jabref.logic.l10n.Localization;
 
 /**
- * <p>Title: MergeDialog</p>
- * <p>Description: Asks for details about merge database operation.</p>
- * <p>Copyright: Copyright (c) 2003</p>
- * @author Morten O. Alver
+ * Asks for details about merge database operation.
  */
-
 public class MergeDialog extends JabRefDialog {
 
     private final JPanel panel1 = new JPanel();

--- a/src/main/java/org/jabref/gui/customentrytypes/EntryTypeList.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/EntryTypeList.java
@@ -23,7 +23,6 @@ import org.jabref.preferences.JabRefPreferences;
 /**
  * This class extends FieldSetComponent to provide some required functionality for the
  * list of entry types in EntryCustomizationDialog.
- * @author alver
  */
 public class EntryTypeList extends FieldSetComponent implements ListSelectionListener {
 

--- a/src/main/java/org/jabref/gui/customentrytypes/FieldSetComponent.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/FieldSetComponent.java
@@ -38,9 +38,6 @@ import org.jabref.logic.bibtexkeypattern.BibtexKeyGenerator;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.preferences.JabRefPreferences;
 
-/**
- * @author alver
- */
 class FieldSetComponent extends JPanel {
 
     protected final JList<String> list;

--- a/src/main/java/org/jabref/gui/exporter/ExportCustomizationDialog.java
+++ b/src/main/java/org/jabref/gui/exporter/ExportCustomizationDialog.java
@@ -35,15 +35,6 @@ import ca.odell.glazedlists.gui.TableFormat;
 import ca.odell.glazedlists.swing.DefaultEventTableModel;
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 
-/**
- * <p>Title: </p>
- * <p>Description: </p>
- * <p>Copyright: Copyright (c) 2003</p>
- * <p>Company: </p>
- * @author not attributable
- * @version 1.0
- */
-
 public class ExportCustomizationDialog extends JabRefDialog {
 
     // Column widths for export customization dialog table:

--- a/src/main/java/org/jabref/gui/groups/GroupTreeCellRenderer.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeCellRenderer.java
@@ -16,8 +16,6 @@ import org.jabref.model.groups.GroupTreeNode;
 
 /**
  * Renders a GroupTreeNode using its group's getName() method, rather that its toString() method.
- *
- * @author jzieren
  */
 public class GroupTreeCellRenderer extends DefaultTreeCellRenderer {
 

--- a/src/main/java/org/jabref/gui/importer/EntryFromFileCreator.java
+++ b/src/main/java/org/jabref/gui/importer/EntryFromFileCreator.java
@@ -23,10 +23,6 @@ import org.jabref.model.entry.FieldName;
  * other hand it provides the functionality to create a Bibtex entry out of a
  * file. The interface extends the java.io.FileFilter to inherit a common way of
  * defining file sets.
- *
- * @author Dan&Nosh
- * @version 25.11.2008 | 23:39:03
- *
  */
 public abstract class EntryFromFileCreator implements FileFilter {
 

--- a/src/main/java/org/jabref/gui/importer/EntryFromFileCreatorManager.java
+++ b/src/main/java/org/jabref/gui/importer/EntryFromFileCreatorManager.java
@@ -28,7 +28,6 @@ import org.jabref.model.entry.IdGenerator;
  * Given a file, the manager can then provide a creator, which is able to create a Bibtex entry for his file.
  * Knowing all implementations of the interface, the manager also knows the set of all files, of which Bibtex entries can be created.
  * The GUI uses this capability for offering the user only such files, of which entries could actually be created.
- * @author Dan&Nosh
  *
  */
 public final class EntryFromFileCreatorManager {

--- a/src/main/java/org/jabref/gui/importer/EntryFromPDFCreator.java
+++ b/src/main/java/org/jabref/gui/importer/EntryFromPDFCreator.java
@@ -17,9 +17,6 @@ import org.jabref.pdfimport.PdfImporter.ImportPdfFilesResult;
  * Uses XMPUtils to get one BibEntry for a PDF-File.
  * Also imports the non-XMP Data (PDDocument-Information) using XMPUtil.getBibtexEntryFromDocumentInformation.
  * If data from more than one entry is read by XMPUtil then this entys are merged into one.
- * @author Dan
- * @version 12.11.2008 | 22:12:48
- *
  */
 public class EntryFromPDFCreator extends EntryFromFileCreator {
 

--- a/src/main/java/org/jabref/gui/importer/UnlinkedPDFFileFilter.java
+++ b/src/main/java/org/jabref/gui/importer/UnlinkedPDFFileFilter.java
@@ -17,10 +17,6 @@ import org.jabref.model.entry.BibEntry;
  * This {@link FileFilter} sits on top of another {@link FileFilter}
  * -implementation, which it first consults. Only if this major filefilter
  * has accepted a file, this implementation will verify on that file.
- *
- * @author Nosh&Dan
- * @version 12.11.2008 | 02:00:15
- *
  */
 public class UnlinkedPDFFileFilter implements FileFilter {
 

--- a/src/main/java/org/jabref/gui/importer/fetcher/INSPIREFetcher.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/INSPIREFetcher.java
@@ -30,12 +30,6 @@ import org.slf4j.LoggerFactory;
  * This class allows to access the Slac INSPIRE database. It is just a port of the original SPIRES Fetcher.
  *
  * It can either be a GeneralFetcher to pose requests to the database or fetch individual entries.
- *
- * @author Fedor Bezrukov
- * @author Sheer El-Showk
- *
- * @version $Id$
- *
  */
 public class INSPIREFetcher implements EntryFetcher {
 

--- a/src/main/java/org/jabref/gui/importer/fetcher/OAI2Fetcher.java
+++ b/src/main/java/org/jabref/gui/importer/fetcher/OAI2Fetcher.java
@@ -36,8 +36,6 @@ import org.xml.sax.helpers.DefaultHandler;
  * This class can be used to access any archive offering an OAI2 interface. By
  * default it will access ArXiv.org
  *
- * @author Ulrich St&auml;rk
- * @author Christian Kopf
  * @see <a href="http://arxiv.org/help/oa/index"></a>
  */
 public class OAI2Fetcher implements EntryFetcher {

--- a/src/main/java/org/jabref/gui/mergeentries/MergeEntries.java
+++ b/src/main/java/org/jabref/gui/mergeentries/MergeEntries.java
@@ -52,12 +52,6 @@ import com.jgoodies.forms.layout.RowSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * @author Oscar Gustafsson
- *
- *         Class for dealing with merging entries
- */
-
 public class MergeEntries {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MergeEntries.class);

--- a/src/main/java/org/jabref/gui/mergeentries/MergeEntriesDialog.java
+++ b/src/main/java/org/jabref/gui/mergeentries/MergeEntriesDialog.java
@@ -23,11 +23,6 @@ import com.jgoodies.forms.layout.ColumnSpec;
 import com.jgoodies.forms.layout.FormLayout;
 import com.jgoodies.forms.layout.RowSpec;
 
-/**
- * @author Oscar
- *
- *         Dialog for merging two Bibtex entries
- */
 public class MergeEntriesDialog extends JabRefDialog {
 
     private static final String MERGE_ENTRIES = Localization.lang("Merge entries");

--- a/src/main/java/org/jabref/logic/exporter/OOCalcDatabase.java
+++ b/src/main/java/org/jabref/logic/exporter/OOCalcDatabase.java
@@ -22,11 +22,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Text;
 
-/**
- * @author Morten O. Alver.
- * Based on net.sf.jabref.MODSDatabase by Michael Wrighton
- *
- */
 class OOCalcDatabase {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OOCalcDatabase.class);

--- a/src/main/java/org/jabref/logic/exporter/OpenDocumentRepresentation.java
+++ b/src/main/java/org/jabref/logic/exporter/OpenDocumentRepresentation.java
@@ -22,11 +22,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Text;
 
-/**
- * @author Morten O. Alver.
- * Based on net.sf.jabref.MODSDatabase by Michael Wrighton
- *
- */
 class OpenDocumentRepresentation {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenDocumentRepresentation.class);

--- a/src/main/java/org/jabref/logic/exporter/OpenDocumentSpreadsheetCreator.java
+++ b/src/main/java/org/jabref/logic/exporter/OpenDocumentSpreadsheetCreator.java
@@ -35,9 +35,6 @@ import org.jabref.model.entry.BibEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * @author alver
- */
 public class OpenDocumentSpreadsheetCreator extends Exporter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenDocumentSpreadsheetCreator.class);

--- a/src/main/java/org/jabref/logic/exporter/OpenOfficeDocumentCreator.java
+++ b/src/main/java/org/jabref/logic/exporter/OpenOfficeDocumentCreator.java
@@ -34,9 +34,6 @@ import org.jabref.model.entry.BibEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * @author alver
- */
 public class OpenOfficeDocumentCreator extends Exporter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenOfficeDocumentCreator.class);

--- a/src/main/java/org/jabref/logic/importer/fileformat/MedlinePlainImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/MedlinePlainImporter.java
@@ -23,8 +23,6 @@ import org.jabref.model.entry.FieldName;
  *
  * check here for details on the format
  * http://www.nlm.nih.gov/bsd/mms/medlineelements.html
- *
- * @author vegeziel
  */
 public class MedlinePlainImporter extends Importer {
 

--- a/src/main/java/org/jabref/logic/importer/fileformat/RepecNepImporter.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/RepecNepImporter.java
@@ -135,9 +135,6 @@ import org.slf4j.LoggerFactory;
  *       '\n-----------------------------'
  * </pre>
  * </p>
- *
- * @author andreas_sf at rudert-home dot de
- * @see <a href="http://nep.repec.org">NEP</a>
  */
 public class RepecNepImporter extends Importer {
 

--- a/src/main/java/org/jabref/logic/importer/util/INSPIREBibtexFilterReader.java
+++ b/src/main/java/org/jabref/logic/importer/util/INSPIREBibtexFilterReader.java
@@ -12,12 +12,7 @@ import java.util.regex.Pattern;
  *
  * Note: this is just a quick port of the original SPIRESBibtexFilterReader.
  *
- * @author Fedor Bezrukov
- * @author Sheer El-Showk
- *
- * @version $Id$
- *
- * TODO: Fix grammar in bibtex entries -- it ma return invalid bibkeys (with space)
+ * TODO: Fix grammar in bibtex entries -- it may return invalid bibkeys (with space)
  *
  */
 public class INSPIREBibtexFilterReader extends FilterReader {

--- a/src/main/java/org/jabref/logic/importer/util/OAI2Handler.java
+++ b/src/main/java/org/jabref/logic/importer/util/OAI2Handler.java
@@ -11,10 +11,6 @@ import org.xml.sax.helpers.DefaultHandler;
 
 /**
  * SAX-Handler to parse OAI2-xml files.
- *
- * @author Ulrich St&auml;rk
- * @author Christian Kopf
- * @author Christopher Oezbek
  */
 public class OAI2Handler extends DefaultHandler {
 

--- a/src/main/java/org/jabref/logic/layout/StringInt.java
+++ b/src/main/java/org/jabref/logic/layout/StringInt.java
@@ -2,8 +2,6 @@ package org.jabref.logic.layout;
 
 /**
  * String and integer value.
- *
- * @author     wegnerj
  */
 public class StringInt implements java.io.Serializable {
 

--- a/src/main/java/org/jabref/logic/layout/format/AuthorAbbreviator.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorAbbreviator.java
@@ -7,8 +7,6 @@ import org.jabref.model.entry.AuthorList;
  * Duplicate of AuthorLastFirstAbbreviator.
  *
  * @see AuthorLastFirstAbbreviator
- *
- * @author Carlos Silla
  */
 public class AuthorAbbreviator implements LayoutFormatter {
 

--- a/src/main/java/org/jabref/logic/layout/format/AuthorAndsCommaReplacer.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorAndsCommaReplacer.java
@@ -5,8 +5,6 @@ import org.jabref.logic.layout.LayoutFormatter;
 /**
  * Replaces and's for & (in case of two authors) and , (in case
  * of more than two authors).
- *
- * @author Carlos Silla
  */
 public class AuthorAndsCommaReplacer implements LayoutFormatter {
 

--- a/src/main/java/org/jabref/logic/layout/format/AuthorAndsReplacer.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorAndsReplacer.java
@@ -5,8 +5,6 @@ import org.jabref.logic.layout.LayoutFormatter;
 /**
  * Replaces and's for & (in case of two authors) and ; (in case
  * of more than two authors).
- *
- * @author Carlos Silla
  */
 public class AuthorAndsReplacer implements LayoutFormatter {
 

--- a/src/main/java/org/jabref/logic/layout/format/AuthorFirstAbbrLastCommas.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorFirstAbbrLastCommas.java
@@ -10,8 +10,6 @@ import org.jabref.model.entry.AuthorList;
  * <li>Individual authors separated by comma.</li>
  * <li>There is no command in front the and of a list of three or more authors.</li>
  * </ul>
- *
- * @author Christopher Oezbek <oezi@oezi.de>
  */
 public class AuthorFirstAbbrLastCommas implements LayoutFormatter {
 

--- a/src/main/java/org/jabref/logic/layout/format/AuthorFirstAbbrLastOxfordCommas.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorFirstAbbrLastOxfordCommas.java
@@ -11,10 +11,6 @@ import org.jabref.model.entry.AuthorList;
  * <li>The and of a list of three or more authors is preceeded by a comma
  * (Oxford comma)</li>
  * </ul>
- *
- * @author mkovtun
- * @author Christopher Oezbek <oezi@oezi.de>
- *
  */
 public class AuthorFirstAbbrLastOxfordCommas implements LayoutFormatter {
 

--- a/src/main/java/org/jabref/logic/layout/format/AuthorFirstFirstCommas.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorFirstFirstCommas.java
@@ -10,9 +10,6 @@ import org.jabref.model.entry.AuthorList;
  * <li>Individual authors are separated by commas.</li>
  * <li>There is no comma before the 'and' at the end of a list of three or more authors</li>
  * </ul>
- *
- * @author Morten O. Alver / Christopher Oezbek <oezi@oezi.de>
- *
  */
 public class AuthorFirstFirstCommas implements LayoutFormatter {
 

--- a/src/main/java/org/jabref/logic/layout/format/AuthorFirstLastCommas.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorFirstLastCommas.java
@@ -10,10 +10,6 @@ import org.jabref.model.entry.AuthorList;
  * <li>Individual authors separated by comma.</li>
  * <li>There is no comma before the and of a list of three or more authors.</li>
  * </ul>
- *
- * @author mkovtun
- * @author Christopher Oezbek <oezi@oezi.de>
- *
  */
 public class AuthorFirstLastCommas implements LayoutFormatter {
 

--- a/src/main/java/org/jabref/logic/layout/format/AuthorFirstLastOxfordCommas.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorFirstLastOxfordCommas.java
@@ -10,10 +10,6 @@ import org.jabref.model.entry.AuthorList;
  * <li>The and of a list of three or more authors is preceeded by a comma
  * (Oxford comma)</li>
  * </ul>
- *
- * @author mkovtun
- * @author Christopher Oezbek <oezi@oezi.de>
- *
  */
 public class AuthorFirstLastOxfordCommas implements LayoutFormatter {
 

--- a/src/main/java/org/jabref/logic/layout/format/AuthorLastFirstAbbrCommas.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorLastFirstAbbrCommas.java
@@ -10,10 +10,6 @@ import org.jabref.model.entry.AuthorList;
  * <li>Individual authors are separated by commas.</li>
  * <li>There is no comma before the 'and' at the end of a list of three or more authors</li>
  * </ul>
- *
- * @author mkovtun
- * @author Christopher Oezbek <oezi@oezi.de>
- *
  */
 public class AuthorLastFirstAbbrCommas implements LayoutFormatter {
 

--- a/src/main/java/org/jabref/logic/layout/format/AuthorLastFirstAbbrOxfordCommas.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorLastFirstAbbrOxfordCommas.java
@@ -11,10 +11,6 @@ import org.jabref.model.entry.AuthorList;
  * <li>The 'and' of a list of three or more authors is preceeded by a comma
  * (Oxford comma)</li>
  * </ul>
- *
- * @author mkovtun
- * @author Christopher Oezbek <oezi@oezi.de>
- *
  */
 public class AuthorLastFirstAbbrOxfordCommas implements LayoutFormatter {
 

--- a/src/main/java/org/jabref/logic/layout/format/AuthorLastFirstCommas.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorLastFirstCommas.java
@@ -10,10 +10,6 @@ import org.jabref.model.entry.AuthorList;
  * <li>Individual authors are separated by commas.</li>
  * <li>There is no comma before the 'and' at the end of a list of three or more authors</li>
  * </ul>
- *
- * @author mkovtun
- * @author Christopher Oezbek <oezi@oezi.de>
- *
  */
 public class AuthorLastFirstCommas implements LayoutFormatter {
 

--- a/src/main/java/org/jabref/logic/layout/format/AuthorLastFirstOxfordCommas.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorLastFirstOxfordCommas.java
@@ -10,10 +10,6 @@ import org.jabref.model.entry.AuthorList;
  * <li>Individual authors are separated by commas.</li>
  * <li>The 'and' of a list of three or more authors is preceeded by a comma
  * (Oxford comma)</li>
- *
- * @author mkovtun
- * @author Christopher Oezbek <oezi@oezi.de>
- *
  */
 public class AuthorLastFirstOxfordCommas implements LayoutFormatter {
 

--- a/src/main/java/org/jabref/logic/layout/format/AuthorNatBib.java
+++ b/src/main/java/org/jabref/logic/layout/format/AuthorNatBib.java
@@ -6,8 +6,6 @@ import org.jabref.model.entry.AuthorList;
 /**
  * Natbib style: Last names only. Two authors are separated by "and",
  * three or more authors are given as "Smith et al."
- *
- * @author Morten O. Alver
  */
 public class AuthorNatBib implements LayoutFormatter {
 

--- a/src/main/java/org/jabref/logic/layout/format/CreateBibORDFAuthors.java
+++ b/src/main/java/org/jabref/logic/layout/format/CreateBibORDFAuthors.java
@@ -2,13 +2,7 @@ package org.jabref.logic.layout.format;
 
 import org.jabref.logic.layout.LayoutFormatter;
 
-/**
- * @author $author$
- * @version $Revision: 2268 $
- */
 public class CreateBibORDFAuthors implements LayoutFormatter {
-
-    //~ Methods ////////////////////////////////////////////////////////////////
 
     @Override
     public String format(String fieldText) {
@@ -39,11 +33,6 @@ public class CreateBibORDFAuthors implements LayoutFormatter {
         return sb.toString();
     }
 
-    /**
-     * @param sb
-     * @param author
-     * @param position
-     */
     private static void singleAuthor(StringBuilder sb, String author, int position) {
         sb.append("<bibo:contribution>\n");
         sb.append("  <bibo:Contribution>\n");

--- a/src/main/java/org/jabref/logic/layout/format/CurrentDate.java
+++ b/src/main/java/org/jabref/logic/layout/format/CurrentDate.java
@@ -17,7 +17,6 @@ public class CurrentDate implements LayoutFormatter {
     // default time stamp follows ISO-8601. Reason: https://xkcd.com/1179/
     private static final String DEFAULT_FORMAT = "yyyy-MM-dd hh:mm:ss z";
 
-
     @Override
     public String format(String fieldText) {
         String format = CurrentDate.DEFAULT_FORMAT;

--- a/src/main/java/org/jabref/logic/layout/format/CurrentDate.java
+++ b/src/main/java/org/jabref/logic/layout/format/CurrentDate.java
@@ -11,8 +11,6 @@ import org.jabref.logic.layout.LayoutFormatter;
  * <p>If a fieldText is given, it must be a valid {@link DateTimeFormatter} pattern.
  * If none is given, the format pattern will be <code>yyyy-MM-dd hh:mm:ss z</code>.
  * This follows ISO-8601. Reason: <a href="https://xkcd.com/1179/">https://xkcd.com/1179/</a>.</p>
- *
- * @author andreas_sf at rudert-home dot de
  */
 public class CurrentDate implements LayoutFormatter {
 
@@ -20,10 +18,6 @@ public class CurrentDate implements LayoutFormatter {
     private static final String DEFAULT_FORMAT = "yyyy-MM-dd hh:mm:ss z";
 
 
-    /*
-     *  (non-Javadoc)
-     * @see org.jabref.export.layout.LayoutFormatter#format(java.lang.String)
-     */
     @Override
     public String format(String fieldText) {
         String format = CurrentDate.DEFAULT_FORMAT;

--- a/src/main/java/org/jabref/logic/layout/format/GetOpenOfficeType.java
+++ b/src/main/java/org/jabref/logic/layout/format/GetOpenOfficeType.java
@@ -4,10 +4,6 @@ import org.jabref.logic.layout.LayoutFormatter;
 
 /**
  * Change type of record to match the one used by OpenOffice formatter.
- *
- * Based on the RemoveBrackets.java class (Revision 1.2) by mortenalver
- * @author $author$
- * @version $Revision$
  */
 public class GetOpenOfficeType implements LayoutFormatter {
 

--- a/src/main/java/org/jabref/logic/layout/format/IfPlural.java
+++ b/src/main/java/org/jabref/logic/layout/format/IfPlural.java
@@ -5,8 +5,6 @@ import java.util.List;
 import org.jabref.logic.layout.AbstractParamLayoutFormatter;
 
 /**
- * @author ralmond
- *
  * This formatter takes two arguments and examines the field text.
  * If the field text represents multiple individuals, that is it contains the string "and"
  * then the field text is replaced with the first argument, otherwise it is replaced with the second.
@@ -15,7 +13,6 @@ import org.jabref.logic.layout.AbstractParamLayoutFormatter;
  * \format[IfPlural(Eds.,Ed.)]{\editor}
  *
  * Should expand to 'Eds.' if the document has more than one editor and 'Ed.' if it only has one.
- *
  *
  */
 public class IfPlural extends AbstractParamLayoutFormatter {

--- a/src/main/java/org/jabref/logic/layout/format/Iso690FormatDate.java
+++ b/src/main/java/org/jabref/logic/layout/format/Iso690FormatDate.java
@@ -2,10 +2,6 @@ package org.jabref.logic.layout.format;
 
 import org.jabref.logic.layout.LayoutFormatter;
 
-/**
- *
- * @author Usuario
- */
 public class Iso690FormatDate implements LayoutFormatter {
 
     @Override

--- a/src/main/java/org/jabref/logic/layout/format/Iso690NamesAuthors.java
+++ b/src/main/java/org/jabref/logic/layout/format/Iso690NamesAuthors.java
@@ -4,10 +4,6 @@ import java.util.Locale;
 
 import org.jabref.logic.layout.LayoutFormatter;
 
-/**
- *
- * @author Usuario
- */
 public class Iso690NamesAuthors implements LayoutFormatter {
 
     @Override

--- a/src/main/java/org/jabref/logic/layout/format/JournalAbbreviator.java
+++ b/src/main/java/org/jabref/logic/layout/format/JournalAbbreviator.java
@@ -18,8 +18,6 @@ import org.jabref.logic.layout.LayoutFormatter;
  * Example result:
  *    "Phys. Rev. Lett." instead of "Physical Review Letters"
  *
- * @author  Meigel
- *
  */
 public class JournalAbbreviator implements LayoutFormatter {
 

--- a/src/main/java/org/jabref/logic/search/DatabaseSearcher.java
+++ b/src/main/java/org/jabref/logic/search/DatabaseSearcher.java
@@ -12,9 +12,6 @@ import org.jabref.model.entry.BibEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * @author Silberer, Zirn
- */
 public class DatabaseSearcher {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseSearcher.class);

--- a/src/main/java/org/jabref/logic/search/SearchQueryHighlightListener.java
+++ b/src/main/java/org/jabref/logic/search/SearchQueryHighlightListener.java
@@ -8,17 +8,12 @@ import com.google.common.eventbus.Subscribe;
 /**
  * Every Listener that wants to receive events from a search needs to
  * implement this interface
- *
- * @author Ben
- *
  */
 @FunctionalInterface
 public interface SearchQueryHighlightListener {
 
     /**
      * Pattern with which one can determine what to highlight
-     *
-     * @param words null if nothing is searched for
      */
     @Subscribe
     void highlightPattern(Optional<Pattern> highlightPattern);

--- a/src/test/java/org/jabref/gui/importer/fetcher/OAI2HandlerFetcherTest.java
+++ b/src/test/java/org/jabref/gui/importer/fetcher/OAI2HandlerFetcherTest.java
@@ -22,12 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test for OAI2-Handler and Fetcher.
- *
- * @author Ulrich St&auml;rk
- * @author Christian Kopf
- * @author Christopher Oezbek
  */
-
 @FetcherTest
 public class OAI2HandlerFetcherTest {
 

--- a/src/test/java/org/jabref/gui/util/TooltipTextUtilTest.java
+++ b/src/test/java/org/jabref/gui/util/TooltipTextUtilTest.java
@@ -12,10 +12,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * @author jpf
- * @created 11/21/17
- */
 public class TooltipTextUtilTest {
 
     @Test

--- a/src/test/java/org/jabref/logic/importer/DatabaseFileLookupTest.java
+++ b/src/test/java/org/jabref/logic/importer/DatabaseFileLookupTest.java
@@ -18,10 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
-/**
- * @author Nosh&Dan
- * @version 09.11.2008 | 21:06:17
- */
 public class DatabaseFileLookupTest {
 
     private BibDatabase database;

--- a/src/test/java/org/jabref/logic/importer/ImportDataTest.java
+++ b/src/test/java/org/jabref/logic/importer/ImportDataTest.java
@@ -8,10 +8,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * @author Nosh&Dan
- * @version 09.11.2008 | 19:41:40
- */
 public class ImportDataTest {
 
     public static final File FILE_IN_DATABASE = Paths

--- a/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -1101,12 +1101,6 @@ public class BibtexParserTest {
         assertEquals(Optional.of("a b"), parsedEntry.getField("c"));
     }
 
-    /**
-     * Test for [2022983]
-     *
-     * @author Uwe Kuehn
-     * @author Andrei Haralevich
-     */
     @Test
     public void parsePreservesMultipleSpacesInNonWrappableField() throws IOException {
         when(importFormatPreferences.getFieldContentParserPreferences().getNonWrappableFields())

--- a/src/test/java/org/jabref/logic/layout/LayoutEntryTest.java
+++ b/src/test/java/org/jabref/logic/layout/LayoutEntryTest.java
@@ -26,8 +26,6 @@ import static org.mockito.Mockito.mock;
  * - There are two words which will be highlighted ignoring case sensitivity.
  * - There is one word which will be highlighted case sensitivity.
  * - There are more words which will be highlighted case sensitivity.
- *
- * @author Arne
  */
 
 public class LayoutEntryTest {
@@ -35,14 +33,8 @@ public class LayoutEntryTest {
     private BibEntry mBTE;
 
 
-    /**
-     * Initialize Preferences.
-     */
     @BeforeEach
     public void setUp() {
-
-        // create Bibtext Entry
-
         mBTE = new BibEntry();
         mBTE.setField("abstract", "In this paper, we initiate a formal study of security on Android: Google's new open-source platform for mobile devices. Tags: Paper android google Open-Source Devices");
         //  Specifically, we present a core typed language to describe Android applications, and to reason about their data-flow security properties. Our operational semantics and type system provide some necessary foundations to help both users and developers of Android applications deal with their security concerns.
@@ -68,18 +60,12 @@ public class LayoutEntryTest {
         mBTE.setField("doi", "10.1145/1554339.1554341");
     }
 
-    // helper Methods
-
     public String layout(String layoutFile, BibEntry entry) throws IOException {
         StringReader sr = new StringReader(layoutFile.replace("__NEWLINE__", "\n"));
         Layout layout = new LayoutHelper(sr, mock(LayoutFormatterPreferences.class)).getLayoutFromText();
 
         return layout.doLayout(entry, null);
     }
-
-    /*************************/
-    /****** tests Cases ******/
-    /*************************/
 
     @Test
     public void testParseMethodCalls() {

--- a/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstAbbreviatorTester.java
+++ b/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstAbbreviatorTester.java
@@ -6,9 +6,6 @@ import org.junit.jupiter.api.Test;
 /**
  * Test case  that verifies the functionalities of the
  * formater AuthorLastFirstAbbreviator.
- *
- * @author Carlos Silla
- * @author Christopher Oezbek <oezi@oezi.de>
  */
 public class AuthorLastFirstAbbreviatorTester {
 


### PR DESCRIPTION
This removes all `@author` patterns as we do not track author ship by these annotations, but with the version control system git.

Some other obsolete headers were also removed (e.g., `$Id`).