### PR TITLE
Fix SPDX license ID for external libraries

### DIFF
--- a/external-libraries.txt
+++ b/external-libraries.txt
@@ -33,7 +33,7 @@ Note:    It is important to include v1.5.54 or later as v1.5.54 is the first ver
 Id:      com.airhacks:afterburner.fx
 Project: afterburner.fx
 URL:     https://github.com/AdamBien/afterburner.fx
-License: Apache 2.0
+License: Apache-2.0
 
 Id:      com.apple:AppleJavaExtensions
 Project: AppleJavaExtensions
@@ -48,22 +48,22 @@ License: Apache-2.0
 Id:      com.github.tomtung
 Project: latex2unicode
 URL:     https://github.com/tomtung/latex2unicode
-License: Apache 2.0
+License: Apache-2.0
 
 Id:      com.impossibl.pgjdbc-ng:pgjdbc-ng
 Project: pgjdbc-ng
 URL:     http://impossibl.github.io/pgjdbc-ng
-License: BSD
+License: BSD-3-Clause
 
 Id:      com.jgoodies:jgoodies-common
 Project: JGoodies Common
 URL:     http://www.jgoodies.com/downloads/libraries/
-License: BSD
+License: BSD-3-Clause
 
 Id:      com.jgoodies:jgoodies-forms
 Project: JGoodies Forms
 URL:     http://www.jgoodies.com/downloads/libraries/
-License: BSD
+License: BSD-3-Clause
 
 Id:      com.mashape.unirest
 Project: Unirest for Java
@@ -127,13 +127,13 @@ License: LGPL-2.1 (not explicitly, but no comments in the source header) and MPL
 
 Id:      org.antlr:antlr
 Project: ANTLR 3
-URL:     http://www.antlr.org/
-License: BSD
+URL:     http://www.antlr3.org/
+License: BSD-3-Clause
 
 Id:      org.antlr:antlr4
 Project: ANTLR 4
 URL:     http://www.antlr.org/
-License: BSD
+License: BSD-3-Clause
 
 Id:      org.apache.commons:commons-lang3
 Project: Apache Commons Lang
@@ -223,12 +223,12 @@ License: Apache-2.0
 Id:      org.xmlunit:xmlunit-core
 Project: XMLUnit
 URL:     http://www.xmlunit.org/
-License: Apache 2.0
+License: Apache-2.0
 
 Id:      org.xmlunit:xmlunit-matchers
 Project: XMLUnit
 URL:     http://www.xmlunit.org/
-License: Apache 2.0
+License: Apache-2.0
 
 Id:      spin
 Path:    lib/spin.jar


### PR DESCRIPTION
This fixes [#3897](https://github.com/JabRef/jabref/issues/3897).

So I went through the BSD ones and ensure their license info is correct now. Two points worth mentioning:

- jgoodies form 1.9.0 is no longer downloadable. Most recent available version is 1.8.0, so I checked its license and assume it did not change.
- antlr v3 has an alternative website now, so I changed its URL too.

Also fixed the ID "Apache 2.0" to "Apache-2.0". Didn't really look into each project with non-BSD license though.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
