### PR TITLE
Formatter refactoring

### DIFF
--- a/src/main/java/org/jabref/logic/formatter/Formatters.java
+++ b/src/main/java/org/jabref/logic/formatter/Formatters.java
@@ -80,22 +80,18 @@ public class Formatters {
     public static Optional<Formatter> getFormatterForModifier(String modifier) {
         Objects.requireNonNull(modifier);
 
-        if (modifier.startsWith(RegexFormatter.KEY)) {
-            String regex = modifier.substring(RegexFormatter.KEY.length());
-            return Optional.of(new RegexFormatter(regex));
-        } else {
-            Optional<Formatter> formatter = getAll().stream().filter(f -> f.getKey().equals(modifier)).findAny();
-            if (formatter.isPresent()) {
-                return formatter;
-            }
-        }
         switch (modifier) {
             case "lower":
                 return Optional.of(new LowerCaseFormatter());
             case "upper":
                 return Optional.of(new UpperCaseFormatter());
-            default:
-                return Optional.empty();
+        }
+
+        if (modifier.startsWith(RegexFormatter.KEY)) {
+            String regex = modifier.substring(RegexFormatter.KEY.length());
+            return Optional.of(new RegexFormatter(regex));
+        } else {
+            return getAll().stream().filter(f -> f.getKey().equals(modifier)).findAny();
         }
     }
 

--- a/src/main/java/org/jabref/logic/formatter/Formatters.java
+++ b/src/main/java/org/jabref/logic/formatter/Formatters.java
@@ -31,83 +31,63 @@ import org.jabref.model.cleanup.Formatter;
 
 public class Formatters {
 
-    private static final List<Formatter> CONVERTERS = Arrays.asList(
-            new HtmlToLatexFormatter(),
-            new HtmlToUnicodeFormatter(),
-            new LatexToUnicodeFormatter(),
-            new UnicodeToLatexFormatter()
-    );
-
-    private static final List<Formatter> CASE_CHANGERS = Arrays.asList(
-            new CapitalizeFormatter(),
-            new LowerCaseFormatter(),
-            new SentenceCaseFormatter(),
-            new TitleCaseFormatter(),
-            new UpperCaseFormatter()
-    );
-
-    private static final List<Formatter> OTHERS = Arrays.asList(
-            new ClearFormatter(),
-            new LatexCleanupFormatter(),
-            new MinifyNameListFormatter(),
-            new NormalizeDateFormatter(),
-            new NormalizeMonthFormatter(),
-            new NormalizeNamesFormatter(),
-            new NormalizePagesFormatter(),
-            new OrdinalsToSuperscriptFormatter(),
-            new RegexFormatter(),
-            new RemoveBracesFormatter(),
-            new UnitsToLatexFormatter(),
-            new EscapeUnderscoresFormatter()
-    );
-
-    private static final String REGEX = "regex";
-
-    private static final int LENGTH_OF_REGEX_PREFIX = REGEX.length();
-
     private Formatters() {
     }
 
-    public static final List<Formatter> getConverters() {
-        List<Formatter> converters = new ArrayList<>();
-        converters.addAll(CONVERTERS);
-        return converters;
+    public static List<Formatter> getConverters() {
+        return Arrays.asList(
+                new HtmlToLatexFormatter(),
+                new HtmlToUnicodeFormatter(),
+                new LatexToUnicodeFormatter(),
+                new UnicodeToLatexFormatter()
+        );
     }
 
-    public static final List<Formatter> getCaseChangers() {
-        List<Formatter> caseChangers = new ArrayList<>();
-        caseChangers.addAll(CASE_CHANGERS);
-        return caseChangers;
+    public static List<Formatter> getCaseChangers() {
+        return Arrays.asList(
+                new CapitalizeFormatter(),
+                new LowerCaseFormatter(),
+                new SentenceCaseFormatter(),
+                new TitleCaseFormatter(),
+                new UpperCaseFormatter()
+        );
     }
 
-    public static final List<Formatter> getOthers() {
-        List<Formatter> others = new ArrayList<>();
-        others.addAll(OTHERS);
-        return others;
+    public static List<Formatter> getOthers() {
+        return Arrays.asList(
+                new ClearFormatter(),
+                new LatexCleanupFormatter(),
+                new MinifyNameListFormatter(),
+                new NormalizeDateFormatter(),
+                new NormalizeMonthFormatter(),
+                new NormalizeNamesFormatter(),
+                new NormalizePagesFormatter(),
+                new OrdinalsToSuperscriptFormatter(),
+                new RemoveBracesFormatter(),
+                new UnitsToLatexFormatter(),
+                new EscapeUnderscoresFormatter()
+        );
     }
 
-    public static final List<Formatter> getAll() {
+    public static List<Formatter> getAll() {
         List<Formatter> all = new ArrayList<>();
-        all.addAll(CONVERTERS);
-        all.addAll(CASE_CHANGERS);
-        all.addAll(OTHERS);
+        all.addAll(getConverters());
+        all.addAll(getCaseChangers());
+        all.addAll(getOthers());
         return all;
     }
 
     public static Optional<Formatter> getFormatterForModifier(String modifier) {
         Objects.requireNonNull(modifier);
-        Optional<Formatter> formatter;
-        List<Formatter> all = getAll();
 
-        if (modifier.matches("regex.*")) {
-            String regex = modifier.substring(LENGTH_OF_REGEX_PREFIX);
-            RegexFormatter.setRegex(regex);
-            formatter = all.stream().filter(f -> f.getKey().equals("regex")).findAny();
+        if (modifier.startsWith(RegexFormatter.KEY)) {
+            String regex = modifier.substring(RegexFormatter.KEY.length());
+            return Optional.of(new RegexFormatter(regex));
         } else {
-            formatter = all.stream().filter(f -> f.getKey().equals(modifier)).findAny();
-        }
-        if (formatter.isPresent()) {
-            return formatter;
+            Optional<Formatter> formatter = getAll().stream().filter(f -> f.getKey().equals(modifier)).findAny();
+            if (formatter.isPresent()) {
+                return formatter;
+            }
         }
         switch (modifier) {
             case "lower":

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
@@ -34,9 +34,23 @@ public class RegexFormatter implements Formatter {
     private static final String CLOSING_BRACE_AND_QUOTE = ")\"";
 
     private static final int LENGTH_OF_CLOSING_BRACE_AND_QUOTE = CLOSING_BRACE_AND_QUOTE.length();
+    public static final String KEY = "regex";
 
-    // stores the regex set by setRegex
-    private static String[] regex;
+    private String regex;
+    private String replacement;
+
+    /**
+     * Constructs a new regular expression-based formatter with the given RegEx.
+     *
+     * @param input the regular expressions for matching and replacing given in the form {@code (<regex>, <replace>)}.
+     */
+    public RegexFormatter(String input) {
+        // formatting is like ("exp1","exp2"), we want to first remove (" and ")
+        String rexToSet = input.substring(LENGTH_OF_QUOTE_AND_OPENING_BRACE, input.length() - LENGTH_OF_CLOSING_BRACE_AND_QUOTE);
+        String[] parts = rexToSet.split("\",\"");
+        regex = parts[0];
+        replacement = parts[1];
+    }
 
     @Override
     public String getName() {
@@ -45,7 +59,7 @@ public class RegexFormatter implements Formatter {
 
     @Override
     public String getKey() {
-        return "regex";
+        return KEY;
     }
 
     private String replaceHonoringProtectedGroups(final String input) {
@@ -56,7 +70,7 @@ public class RegexFormatter implements Formatter {
             replaced.add(matcher.group(1));
         }
         String workingString = matcher.replaceAll(PLACEHOLDER_FOR_PROTECTED_GROUP);
-        workingString = workingString.replaceAll(RegexFormatter.regex[0], RegexFormatter.regex[1]);
+        workingString = workingString.replaceAll(regex, replacement);
 
         for (String r : replaced) {
             workingString = workingString.replaceFirst(PLACEHOLDER_FOR_PROTECTED_GROUP, r);
@@ -93,13 +107,4 @@ public class RegexFormatter implements Formatter {
     public String getExampleInput() {
         return "Please replace the spaces";
     }
-
-    public static void setRegex(String rex) {
-        // formatting is like ("exp1","exp2"), we want to remove (" and ")
-        String rexToSet = rex;
-        rexToSet = rexToSet.substring(LENGTH_OF_QUOTE_AND_OPENING_BRACE, rexToSet.length() - LENGTH_OF_CLOSING_BRACE_AND_QUOTE);
-        String[] parts = rexToSet.split("\",\"");
-        regex = parts;
-    }
-
 }

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/RegexFormatter.java
@@ -11,31 +11,21 @@ import org.jabref.model.cleanup.Formatter;
 
 public class RegexFormatter implements Formatter {
 
+    public static final String KEY = "regex";
     private static final Pattern PATTERN_ESCAPED_OPENING_CURLY_BRACE = Pattern.compile("\\\\\\{");
-
     private static final Pattern PATTERN_ESCAPED_CLOSING_CURLY_BRACE = Pattern.compile("\\\\\\}");
-
     // RegEx to match {...}
     // \\ is required to have the { interpreted as character
     // ? is required to disable the aggressive match
     private static final Pattern PATTERN_ENCLOSED_IN_CURLY_BRACES = Pattern.compile("(\\{.*?})");
-
     // Magic arbitrary unicode char, which will never appear in bibtex files
     private static final String PLACEHOLDER_FOR_PROTECTED_GROUP = Character.toString('\u0A14');
-
     private static final String PLACEHOLDER_FOR_OPENING_CURLY_BRACE = Character.toString('\u0A15');
-
     private static final String PLACEHOLDER_FOR_CLOSING_CURLY_BRACE = Character.toString('\u0A16');
-
     private static final String QUOTE_AND_OPENING_BRACE = "\"(";
-
     private static final int LENGTH_OF_QUOTE_AND_OPENING_BRACE = QUOTE_AND_OPENING_BRACE.length();
-
     private static final String CLOSING_BRACE_AND_QUOTE = ")\"";
-
     private static final int LENGTH_OF_CLOSING_BRACE_AND_QUOTE = CLOSING_BRACE_AND_QUOTE.length();
-    public static final String KEY = "regex";
-
     private String regex;
     private String replacement;
 

--- a/src/test/java/org/jabref/logic/formatter/FormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/FormatterTest.java
@@ -54,8 +54,7 @@ class FormatterTest {
         // all classes implementing {@link net.sf.jabref.model.cleanup.Formatter}
         // sorted alphabetically
         // Alternative: Use reflection - https://github.com/ronmamo/reflections
-        // @formatter:off
-       return Stream.of(
+        return Stream.of(
                 new CapitalizeFormatter(),
                 new ClearFormatter(),
                 new HtmlToLatexFormatter(),
@@ -71,15 +70,14 @@ class FormatterTest {
                 new NormalizePagesFormatter(),
                 new OrdinalsToSuperscriptFormatter(),
                 new ProtectTermsFormatter(protectedTermsLoader),
-               new RegexFormatter("(\" \",\"-\")"),
+                new RegexFormatter("(\" \",\"-\")"),
                 new RemoveBracesFormatter(),
                 new SentenceCaseFormatter(),
                 new TitleCaseFormatter(),
                 new UnicodeToLatexFormatter(),
                 new UnitsToLatexFormatter(),
-                new UpperCaseFormatter());
-
-        // @formatter:on
+                new UpperCaseFormatter()
+        );
     }
 
     @ParameterizedTest

--- a/src/test/java/org/jabref/logic/formatter/FormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/FormatterTest.java
@@ -38,74 +38,19 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class FormatterTest {
+class FormatterTest {
 
     private static ProtectedTermsLoader protectedTermsLoader;
 
     @BeforeAll
-    public static void setUp() {
+    static void setUp() {
         protectedTermsLoader = new ProtectedTermsLoader(
                 new ProtectedTermsPreferences(ProtectedTermsLoader.getInternalLists(), Collections.emptyList(),
                         Collections.emptyList(), Collections.emptyList()));
 
-
     }
 
-    @ParameterizedTest
-    @MethodSource("getFormatters")
-    public void getNameReturnsNotNull(Formatter formatter) {
-        assertNotNull(formatter.getName());
-    }
-
-    @ParameterizedTest
-    @MethodSource("getFormatters")
-    public void getNameReturnsNotEmpty(Formatter formatter) {
-        assertNotEquals("", formatter.getName());
-    }
-
-    @ParameterizedTest
-    @MethodSource("getFormatters")
-    public void getKeyReturnsNotNull(Formatter formatter) {
-        assertNotNull(formatter.getKey());
-    }
-
-    @ParameterizedTest
-    @MethodSource("getFormatters")
-    public void getKeyReturnsNotEmpty(Formatter formatter) {
-        assertNotEquals("", formatter.getKey());
-    }
-
-    @ParameterizedTest
-    @MethodSource("getFormatters")
-    public void formatOfNullThrowsException(Formatter formatter) {
-        assertThrows(NullPointerException.class, () -> formatter.format(null));
-    }
-
-    @ParameterizedTest
-    @MethodSource("getFormatters")
-    public void formatOfEmptyStringReturnsEmpty(Formatter formatter) {
-        assertEquals("", formatter.format(""));
-    }
-
-    @ParameterizedTest
-    @MethodSource("getFormatters")
-    public void formatNotReturnsNull(Formatter formatter) {
-        assertNotNull(formatter.format("string"));
-    }
-
-    @ParameterizedTest
-    @MethodSource("getFormatters")
-    public void getDescriptionAlwaysNonEmpty(Formatter formatter) {
-        assertFalse(formatter.getDescription().isEmpty());
-    }
-
-    @ParameterizedTest
-    @MethodSource("getFormatters")
-    public void getExampleInputAlwaysNonEmpty(Formatter formatter) {
-        assertFalse(formatter.getExampleInput().isEmpty());
-    }
-
-    public static Stream<Formatter> getFormatters() {
+    private static Stream<Formatter> getFormatters() {
         // all classes implementing {@link net.sf.jabref.model.cleanup.Formatter}
         // sorted alphabetically
         // Alternative: Use reflection - https://github.com/ronmamo/reflections
@@ -126,7 +71,7 @@ public class FormatterTest {
                 new NormalizePagesFormatter(),
                 new OrdinalsToSuperscriptFormatter(),
                 new ProtectTermsFormatter(protectedTermsLoader),
-                new RegexFormatter(),
+               new RegexFormatter("(\" \",\"-\")"),
                 new RemoveBracesFormatter(),
                 new SentenceCaseFormatter(),
                 new TitleCaseFormatter(),
@@ -135,5 +80,59 @@ public class FormatterTest {
                 new UpperCaseFormatter());
 
         // @formatter:on
+    }
+
+    @ParameterizedTest
+    @MethodSource("getFormatters")
+    void getNameReturnsNotNull(Formatter formatter) {
+        assertNotNull(formatter.getName());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getFormatters")
+    void getNameReturnsNotEmpty(Formatter formatter) {
+        assertNotEquals("", formatter.getName());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getFormatters")
+    void getKeyReturnsNotNull(Formatter formatter) {
+        assertNotNull(formatter.getKey());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getFormatters")
+    void getKeyReturnsNotEmpty(Formatter formatter) {
+        assertNotEquals("", formatter.getKey());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getFormatters")
+    void formatOfNullThrowsException(Formatter formatter) {
+        assertThrows(NullPointerException.class, () -> formatter.format(null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getFormatters")
+    void formatOfEmptyStringReturnsEmpty(Formatter formatter) {
+        assertEquals("", formatter.format(""));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getFormatters")
+    void formatNotReturnsNull(Formatter formatter) {
+        assertNotNull(formatter.format("string"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getFormatters")
+    void getDescriptionAlwaysNonEmpty(Formatter formatter) {
+        assertFalse(formatter.getDescription().isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("getFormatters")
+    void getExampleInputAlwaysNonEmpty(Formatter formatter) {
+        assertFalse(formatter.getExampleInput().isEmpty());
     }
 }

--- a/src/test/java/org/jabref/logic/formatter/bibtexfields/RegexFormatterTest.java
+++ b/src/test/java/org/jabref/logic/formatter/bibtexfields/RegexFormatterTest.java
@@ -1,6 +1,5 @@
 package org.jabref.logic.formatter.bibtexfields;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -8,57 +7,49 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Tests in addition to the general tests from {@link org.jabref.logic.formatter.FormatterTest}
  */
-public class RegexFormatterTest {
+class RegexFormatterTest {
 
     private RegexFormatter formatter;
 
-    @BeforeEach
-    public void setUp() {
-        formatter = new RegexFormatter();
-    }
-
     @Test
-    public void spacesReplacedCorrectly() {
-        String regexInput = "(\" \",\"-\")";
-        RegexFormatter.setRegex(regexInput);
+    void spacesReplacedCorrectly() {
+        formatter = new RegexFormatter("(\" \",\"-\")");
         assertEquals("replace-all-spaces", formatter.format("replace all spaces"));
     }
 
     @Test
-    public void protectedSpacesNotReplacedInSingleProtectedBlock() {
-        String regexInput = "(\" \",\"-\")";
-        RegexFormatter.setRegex(regexInput);
+    void protectedSpacesNotReplacedInSingleProtectedBlock() {
+        formatter = new RegexFormatter("(\" \",\"-\")");
         assertEquals("replace-spaces-{not these ones}", formatter.format("replace spaces {not these ones}"));
     }
 
     @Test
-    public void protectedSpacesNotReplacedInTwoProtectedBlocks() {
-        String regexInput = "(\" \",\"-\")";
-        RegexFormatter.setRegex(regexInput);
+    void protectedSpacesNotReplacedInTwoProtectedBlocks() {
+        formatter = new RegexFormatter("(\" \",\"-\")");
         assertEquals("replace-spaces-{not these ones}-{or these ones}-but-these-ones", formatter.format("replace spaces {not these ones} {or these ones} but these ones"));
     }
 
     @Test
-    public void escapedBracesAreNotReplaced() {
-        String regexInput = "(\" \",\"-\")";
-        RegexFormatter.setRegex(regexInput);
+    void escapedBracesAreNotReplaced() {
+        formatter = new RegexFormatter("(\" \",\"-\")");
         assertEquals("replace-spaces-\\{-these-ones\\}-and-these-ones", formatter.format("replace spaces \\{ these ones\\} and these ones"));
     }
 
     @Test
-    public void escapedBracesAreNotReplacedInTwoCases() {
-        String regexInput = "(\" \",\"-\")";
-        RegexFormatter.setRegex(regexInput);
+    void escapedBracesAreNotReplacedInTwoCases() {
+        formatter = new RegexFormatter("(\" \",\"-\")");
         assertEquals("replace-spaces-\\{-these-ones\\},-these-ones,-and-\\{-these-ones\\}", formatter.format("replace spaces \\{ these ones\\}, these ones, and \\{ these ones\\}"));
     }
 
     @Test
-    public void escapedBracesAreNotReplacedAndProtectionStillWorks() {
+    void escapedBracesAreNotReplacedAndProtectionStillWorks() {
+        formatter = new RegexFormatter("(\" \",\"-\")");
         assertEquals("replace-spaces-{not these ones},-these-ones,-and-\\{-these-ones\\}", formatter.format("replace spaces {not these ones}, these ones, and \\{ these ones\\}"));
     }
 
     @Test
-    public void formatExample() {
+    void formatExample() {
+        formatter = new RegexFormatter("(\" \",\"-\")");
         assertEquals("Please-replace-the-spaces", formatter.format(formatter.getExampleInput()));
     }
 }


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

Refactor the regular expression-based formatter. Previously, the regex was sent through a static `setRegex` method, now it gets passed as a normal constructor argument.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
