### PR TITLE
[WIP] implement journal abbrev formatter

### DIFF
--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/JournalMedlineAbbreviator.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/JournalMedlineAbbreviator.java
@@ -1,0 +1,54 @@
+package org.jabref.logic.formatter.bibtexfields;
+
+import java.util.Objects;
+
+import org.jabref.logic.journals.JournalAbbreviationLoader;
+import org.jabref.logic.journals.JournalAbbreviationPreferences;
+import org.jabref.model.cleanup.Formatter;
+
+public class JournalMedlineAbbreviator implements Formatter {
+
+    //TODO: How do I pass the prefs at best?
+    public JournalMedlineAbbreviator(JournalAbbreviationLoader repostioryLoader,
+            JournalAbbreviationPreferences journalAbbreviationPreferences) {
+        this.repostioryLoader = Objects.requireNonNull(repostioryLoader);
+        this.journalAbbreviationPreferences = Objects.requireNonNull(journalAbbreviationPreferences);
+    }
+
+    @Override
+    public String getName() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public String getKey() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    private final JournalAbbreviationLoader repostioryLoader;
+    private final JournalAbbreviationPreferences journalAbbreviationPreferences;
+
+
+
+    @Override
+    public String format(String fieldText) {
+        return repostioryLoader.getRepository(journalAbbreviationPreferences)
+                .getIsoAbbreviation(fieldText)
+                .orElse(fieldText);
+    }
+
+    @Override
+    public String getDescription() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public String getExampleInput() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+}

--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/JournalMedlineAbbreviator.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/JournalMedlineAbbreviator.java
@@ -8,6 +8,9 @@ import org.jabref.model.cleanup.Formatter;
 
 public class JournalMedlineAbbreviator implements Formatter {
 
+    private final JournalAbbreviationLoader repostioryLoader;
+    private final JournalAbbreviationPreferences journalAbbreviationPreferences;
+
     //TODO: How do I pass the prefs at best?
     public JournalMedlineAbbreviator(JournalAbbreviationLoader repostioryLoader,
             JournalAbbreviationPreferences journalAbbreviationPreferences) {
@@ -26,11 +29,6 @@ public class JournalMedlineAbbreviator implements Formatter {
         // TODO Auto-generated method stub
         return null;
     }
-
-    private final JournalAbbreviationLoader repostioryLoader;
-    private final JournalAbbreviationPreferences journalAbbreviationPreferences;
-
-
 
     @Override
     public String format(String fieldText) {


### PR DESCRIPTION
I tried to implement a formatter for Journal Abbrev which can be used in the bibtexkeypattern as requested.

http://discourse.jabref.org/t/support-of-import-pattern-for-abbreviated-journal-names/1097
However, I now have a problem I am unsure how to solve.
How do I pass the JournalPrefs and the AbbrevLoader to that logic class? 
Sure, I could call 
`Globals.journalAbbreviationLoader `but that should only be acessed from the gui
@tobiasdiez @lenhard  Any idea?

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
