### PR TITLE
Fixed saving of entry preview preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The new default removes the linked file from the entry instead of deleting the f
 - We fixed an issue where the "Copy linked files" dialog produced an error when the entry had no file [#3818](https://github.com/JabRef/jabref/issues/3818)
 - We fixed the coloring of the search box icon in case a user switches to advanced search mode [#3870](https://github.com/JabRef/jabref/issues/3870)
 - We fixed an issue where pressing <kbd>del</kbd> in the `file` field would trigger the delete dialog a second file, if the first file is deleted [#3926](https://github.com/JabRef/jabref/issues/3926)
+- We fixed the saving of entry preview preferences [#3845](https://github.com/JabRef/jabref/issues/3845)
 
 ### Removed
 - We removed the [Look and Feels from JGoodies](http://www.jgoodies.com/freeware/libraries/looks/), because the open source version is not compatible with Java 9.

--- a/src/main/java/org/jabref/gui/preftabs/PreviewPrefsTab.java
+++ b/src/main/java/org/jabref/gui/preftabs/PreviewPrefsTab.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
 import javax.swing.BoxLayout;
@@ -176,8 +177,9 @@ public class PreviewPrefsTab extends JPanel implements PrefsTab {
         chosenModel.clear();
         boolean isPreviewChosen = false;
         for (String style : previewPreferences.getPreviewCycle()) {
-            if (CitationStyle.isCitationStyleFile(style)) {
-                chosenModel.addElement(CitationStyle.createCitationStyleFromFile(style));
+            Optional<CitationStyle> citationStyle = CitationStyle.createCitationStyleFromFile(style);
+            if (citationStyle.isPresent()) {
+                chosenModel.addElement(citationStyle.get());
             } else {
                 if (isPreviewChosen) {
                     LOGGER.error("Preview is already in the list, something went wrong");

--- a/src/main/java/org/jabref/gui/preftabs/PreviewPrefsTab.java
+++ b/src/main/java/org/jabref/gui/preftabs/PreviewPrefsTab.java
@@ -177,6 +177,7 @@ public class PreviewPrefsTab extends JPanel implements PrefsTab {
         chosenModel.clear();
         boolean isPreviewChosen = false;
         for (String style : previewPreferences.getPreviewCycle()) {
+            // in case the style is not a valid citation style file, an empty Optional is returned
             Optional<CitationStyle> citationStyle = CitationStyle.createCitationStyleFromFile(style);
             if (citationStyle.isPresent()) {
                 chosenModel.addElement(citationStyle.get());


### PR DESCRIPTION
Fixed saving entry preview preferences.

Stored preview citation styles were loaded in a wrapping Optional before.

Fixes #3845 

----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
