### PR TITLE
Fix IEEE Fetcher by enabling cookie support

### DIFF
--- a/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
@@ -52,7 +52,9 @@ public class IEEE implements FulltextFetcher {
             if (doi.isPresent() && doi.get().getDOI().startsWith(IEEE_DOI) && doi.get().getExternalURI().isPresent()) {
                 // Download the HTML page from IEEE
                 URLDownload dl = new URLDownload(doi.get().getExternalURI().get().toURL());
+                //We don't need to modify the cookies, but we need support for them
                 dl.getCookieFromUrl();
+
                 String resolvedDOIPage = dl.asString();
                 // Try to find the link
                 Matcher matcher = STAMP_PATTERN.matcher(resolvedDOIPage);
@@ -70,7 +72,9 @@ public class IEEE implements FulltextFetcher {
 
         // Download the HTML page containing a frame with the PDF
         URLDownload dl = new URLDownload(BASE_URL + stampString);
-        dl.getCookieFromUrl(); //We don't need to modify the cookies, but we need support for them
+        //We don't need to modify the cookies, but we need support for them
+        dl.getCookieFromUrl();
+
         String framePage = dl.asString();
         // Try to find the direct PDF link
         Matcher matcher = PDF_PATTERN.matcher(framePage);

--- a/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
@@ -51,11 +51,11 @@ public class IEEE implements FulltextFetcher {
             Optional<DOI> doi = entry.getField(FieldName.DOI).flatMap(DOI::parse);
             if (doi.isPresent() && doi.get().getDOI().startsWith(IEEE_DOI) && doi.get().getExternalURI().isPresent()) {
                 // Download the HTML page from IEEE
-                URLDownload dl = new URLDownload(doi.get().getExternalURI().get().toURL());
+                URLDownload urlDownload = new URLDownload(doi.get().getExternalURI().get().toURL());
                 //We don't need to modify the cookies, but we need support for them
-                dl.getCookieFromUrl();
+                urlDownload.getCookieFromUrl();
 
-                String resolvedDOIPage = dl.asString();
+                String resolvedDOIPage = urlDownload.asString();
                 // Try to find the link
                 Matcher matcher = STAMP_PATTERN.matcher(resolvedDOIPage);
                 if (matcher.find()) {
@@ -71,11 +71,11 @@ public class IEEE implements FulltextFetcher {
         }
 
         // Download the HTML page containing a frame with the PDF
-        URLDownload dl = new URLDownload(BASE_URL + stampString);
+        URLDownload urlDownload = new URLDownload(BASE_URL + stampString);
         //We don't need to modify the cookies, but we need support for them
-        dl.getCookieFromUrl();
+        urlDownload.getCookieFromUrl();
 
-        String framePage = dl.asString();
+        String framePage = urlDownload.asString();
         // Try to find the direct PDF link
         Matcher matcher = PDF_PATTERN.matcher(framePage);
         if (matcher.find()) {

--- a/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
+++ b/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
@@ -46,8 +46,6 @@ public class IEEE implements FulltextFetcher {
             }
         }
 
-        //        12:50:19.221 GEThttps://ieeexplore.ieee.org/ielx7/6287639/7419931/07421926.pdf[HTTP/1.1 200 OK 8421ms]
-
         // If not, try DOI
         if (stampString.isEmpty()) {
             Optional<DOI> doi = entry.getField(FieldName.DOI).flatMap(DOI::parse);


### PR DESCRIPTION
Fixes #3966 

Apparently when in VPN network of University IEEE fulltext fetcher needs cookie support enabled

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
