### PR TITLE
Add GenerateKey Button to Entry Editor Toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The new default removes the linked file from the entry instead of deleting the f
 - We added another CLI functionality for reading and writing metadata to pdfs. (see https://github.com/JabRef/jabref/pull/3756 and see http://help.jabref.org/en/CommandLine)
 - We no longer print errors in field values during autosave into the log [#3811](https://github.com/JabRef/jabref/issues/3811)
 - We improved the search performance by adding a short delay before starting to display search results [Bug report in the forum](http://discourse.jabref.org/t/poor-performance-of-jabref-4/1110/2)
+- We re-added the Generate BibTeX Key button to the EntryEditor toolbar on the left
 
 ### Fixed
 - We fixed several performance problems with the management of journal abbreviations [#3323](https://github.com/JabRef/jabref/issues/3323)

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.fxml
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.fxml
@@ -39,6 +39,14 @@
                     <Tooltip text="%Change entry type"/>
                 </tooltip>
             </Button>
+            <Button fx:id="generateKeyButton" styleClass="flatButton,narrow">
+                <graphic>
+                    <MaterialDesignIconView glyphName="KEY_VARIANT"/>
+                </graphic>
+                <tooltip>
+                    <Tooltip text="%Generate BibTeX key"/>
+                </tooltip>
+            </Button>
             <Button fx:id="fetcherButton" styleClass="flatButton,narrow">
                 <graphic>
                     <MaterialDesignIconView glyphName="REFRESH"/>

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.fxml
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.fxml
@@ -39,7 +39,7 @@
                     <Tooltip text="%Change entry type"/>
                 </tooltip>
             </Button>
-            <Button fx:id="generateKeyButton" styleClass="flatButton,narrow">
+            <Button styleClass="flatButton,narrow" onAction="#generateKey">
                 <graphic>
                     <MaterialDesignIconView glyphName="KEY_VARIANT"/>
                 </graphic>

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -26,9 +26,11 @@ import org.jabref.gui.keyboard.KeyBinding;
 import org.jabref.gui.menus.ChangeEntryTypeMenu;
 import org.jabref.gui.mergeentries.EntryFetchAndMergeWorker;
 import org.jabref.gui.undo.CountingUndoManager;
+import org.jabref.gui.undo.UndoableKeyChange;
 import org.jabref.gui.util.ControlHelper;
 import org.jabref.gui.util.DefaultTaskExecutor;
 import org.jabref.logic.TypedBibEntry;
+import org.jabref.logic.bibtexkeypattern.BibtexKeyGenerator;
 import org.jabref.logic.help.HelpFile;
 import org.jabref.logic.importer.EntryBasedFetcher;
 import org.jabref.logic.importer.WebFetchers;
@@ -62,11 +64,17 @@ public class EntryEditor extends BorderPane {
      * A reference to the entry this editor works on.
      */
     private BibEntry entry;
-    @FXML private TabPane tabbed;
-    @FXML private Button typeChangeButton;
-    @FXML private Button fetcherButton;
+    @FXML
+    private TabPane tabbed;
+    @FXML
+    private Button typeChangeButton;
+    @FXML
+    private Button generateKeyButton;
+    @FXML
+    private Button fetcherButton;
     private SourceTab sourceTab;
-    @FXML private Label typeLabel;
+    @FXML
+    private Label typeLabel;
 
     public EntryEditor(BasePanel panel) {
         this.panel = panel;
@@ -253,7 +261,9 @@ public class EntryEditor extends BorderPane {
         ContextMenu typeMenu = new ChangeEntryTypeMenu().getChangeEntryTypePopupMenu(entry, bibDatabaseContext, undoManager);
         typeLabel.setOnMouseClicked(event -> typeMenu.show(typeLabel, Side.RIGHT, 0, 0));
         typeChangeButton.setOnMouseClicked(event -> typeMenu.show(typeChangeButton, Side.RIGHT, 0, 0));
-
+        generateKeyButton.setOnMouseClicked(event -> new BibtexKeyGenerator(bibDatabaseContext, Globals.prefs.getBibtexKeyPatternPreferences())
+                .generateAndSetKey(entry)
+                .ifPresent(change -> undoManager.addEdit(new UndoableKeyChange(change))));
         // Add menu for fetching bibliographic information
         ContextMenu fetcherMenu = new ContextMenu();
         for (EntryBasedFetcher fetcher : WebFetchers
@@ -282,5 +292,4 @@ public class EntryEditor extends BorderPane {
             }
         });
     }
-
 }

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -64,17 +64,13 @@ public class EntryEditor extends BorderPane {
      * A reference to the entry this editor works on.
      */
     private BibEntry entry;
-    @FXML
-    private TabPane tabbed;
-    @FXML
-    private Button typeChangeButton;
-    @FXML
-    private Button generateKeyButton;
-    @FXML
-    private Button fetcherButton;
     private SourceTab sourceTab;
-    @FXML
-    private Label typeLabel;
+
+    @FXML private TabPane tabbed;
+    @FXML private Button typeChangeButton;
+    @FXML private Button generateKeyButton;
+    @FXML private Button fetcherButton;
+    @FXML private Label typeLabel;
 
     public EntryEditor(BasePanel panel) {
         this.panel = panel;

--- a/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
+++ b/src/main/java/org/jabref/gui/entryeditor/EntryEditor.java
@@ -68,7 +68,6 @@ public class EntryEditor extends BorderPane {
 
     @FXML private TabPane tabbed;
     @FXML private Button typeChangeButton;
-    @FXML private Button generateKeyButton;
     @FXML private Button fetcherButton;
     @FXML private Label typeLabel;
 
@@ -130,6 +129,13 @@ public class EntryEditor extends BorderPane {
     @FXML
     public void close() {
         panel.entryEditorClosing(EntryEditor.this);
+    }
+
+    @FXML
+    public void generateKey() {
+        new BibtexKeyGenerator(bibDatabaseContext, Globals.prefs.getBibtexKeyPatternPreferences())
+                .generateAndSetKey(entry)
+                .ifPresent(change -> undoManager.addEdit(new UndoableKeyChange(change)));
     }
 
     @FXML
@@ -257,9 +263,6 @@ public class EntryEditor extends BorderPane {
         ContextMenu typeMenu = new ChangeEntryTypeMenu().getChangeEntryTypePopupMenu(entry, bibDatabaseContext, undoManager);
         typeLabel.setOnMouseClicked(event -> typeMenu.show(typeLabel, Side.RIGHT, 0, 0));
         typeChangeButton.setOnMouseClicked(event -> typeMenu.show(typeChangeButton, Side.RIGHT, 0, 0));
-        generateKeyButton.setOnMouseClicked(event -> new BibtexKeyGenerator(bibDatabaseContext, Globals.prefs.getBibtexKeyPatternPreferences())
-                .generateAndSetKey(entry)
-                .ifPresent(change -> undoManager.addEdit(new UndoableKeyChange(change))));
         // Add menu for fetching bibliographic information
         ContextMenu fetcherMenu = new ContextMenu();
         for (EntryBasedFetcher fetcher : WebFetchers


### PR DESCRIPTION
When re-designing the Entry Editor, the Generate BibTeX Button moved to the left on the Required Fields tab. Now I'm re-adding it to the toolbar on the left, because I think it should be accessible from all tabs. See screenshot

<img width="1145" alt="screen shot 2018-04-24 at 22 23 44" src="https://user-images.githubusercontent.com/1254003/39212166-33781de2-480e-11e8-9d82-bbf327a831a2.png">



- [X] Change in CHANGELOG.md described
- [X] Manually tested changed features in running JabRef
