### PR TITLE
Fix IEEE preview does not display month 

### DIFF
--- a/src/main/java/org/jabref/logic/bibtex/LatexFieldFormatter.java
+++ b/src/main/java/org/jabref/logic/bibtex/LatexFieldFormatter.java
@@ -270,8 +270,8 @@ public class LatexFieldFormatter {
 
     private void writeStringLabel(String text, int startPos, int endPos,
                                   boolean first, boolean last) {
-        putIn((first ? "{" : " # ") + text.substring(startPos, endPos)
-                + (last ? "}" : " # "));
+        putIn((first ? "" : " # ") + text.substring(startPos, endPos)
+                + (last ? "" : " # "));
     }
 
     private void putIn(String s) {

--- a/src/main/java/org/jabref/logic/bibtex/LatexFieldFormatter.java
+++ b/src/main/java/org/jabref/logic/bibtex/LatexFieldFormatter.java
@@ -270,8 +270,8 @@ public class LatexFieldFormatter {
 
     private void writeStringLabel(String text, int startPos, int endPos,
                                   boolean first, boolean last) {
-        putIn((first ? "" : " # ") + text.substring(startPos, endPos)
-                + (last ? "" : " # "));
+        putIn((first ? "{" : " # ") + text.substring(startPos, endPos)
+                + (last ? "}" : " # "));
     }
 
     private void putIn(String s) {

--- a/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -16,7 +16,6 @@ import de.undercouch.citeproc.ItemDataProvider;
 import de.undercouch.citeproc.bibtex.BibTeXConverter;
 import de.undercouch.citeproc.csl.CSLItemData;
 import de.undercouch.citeproc.output.Bibliography;
-
 import org.jbibtex.BibTeXEntry;
 import org.jbibtex.DigitStringValue;
 import org.jbibtex.Key;

--- a/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -84,14 +84,10 @@ public class CSLAdapter {
         /**
          * Converts the {@link BibEntry} into {@link CSLItemData}.
          *
-         * Clone bibEntry to make a save changes,
          * Change month field from JabRefFormat <code>#mon#</> to ShortName <code>mon</code>
          * because CSL does not support JabRefFormat.
          */
         private static CSLItemData bibEntryToCSLItemData(BibEntry bibEntry) {
-
-            bibEntry = (BibEntry) bibEntry.clone();
-
             String citeKey = bibEntry.getCiteKeyOptional().orElse("");
             BibTeXEntry bibTeXEntry = new BibTeXEntry(new Key(bibEntry.getType()), new Key(citeKey));
 
@@ -99,14 +95,15 @@ public class CSLAdapter {
             HTMLChars latexToHtmlConverter = new HTMLChars();
             RemoveNewlinesFormatter removeNewlinesFormatter = new RemoveNewlinesFormatter();
             for (String key : bibEntry.getFieldMap().keySet()) {
-                if (FieldName.MONTH.equals(key)) {
-                    bibEntry.getFieldMap().put(FieldName.MONTH, bibEntry.getMonth().get().getShortName());
-                }
-
                 bibEntry.getField(key)
                         .map(removeNewlinesFormatter::format)
                         .map(latexToHtmlConverter::format)
-                        .ifPresent(value -> bibTeXEntry.addField(new Key(key), new DigitStringValue(value)));
+                        .ifPresent(value -> {
+                            if((FieldName.MONTH.equals(key))){
+                                value = bibEntry.getMonth().get().getShortName();
+                            }
+                            bibTeXEntry.addField(new Key(key), new DigitStringValue(value));
+                        });
             }
             return BIBTEX_CONVERTER.toItemData(bibTeXEntry);
         }

--- a/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -9,13 +9,14 @@ import java.util.Objects;
 import org.jabref.logic.formatter.bibtexfields.RemoveNewlinesFormatter;
 import org.jabref.logic.layout.format.HTMLChars;
 import org.jabref.model.entry.BibEntry;
+import org.jabref.model.entry.FieldName;
 
 import de.undercouch.citeproc.CSL;
 import de.undercouch.citeproc.ItemDataProvider;
 import de.undercouch.citeproc.bibtex.BibTeXConverter;
 import de.undercouch.citeproc.csl.CSLItemData;
 import de.undercouch.citeproc.output.Bibliography;
-import org.jabref.model.entry.FieldName;
+
 import org.jbibtex.BibTeXEntry;
 import org.jbibtex.DigitStringValue;
 import org.jbibtex.Key;

--- a/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -88,10 +88,6 @@ public class CSLAdapter {
 
             // create a copy of bibEntry
             bibEntry = (BibEntry) bibEntry.clone();
-            // change month field from "#mon#" to "mon"
-            if((bibEntry.getFieldMap().get(FieldName.MONTH) != null) && !bibEntry.getFieldMap().get(FieldName.MONTH).isEmpty()){
-                bibEntry.getFieldMap().put(FieldName.MONTH, bibEntry.getMonth().get().getShortName());
-            }
 
             String citeKey = bibEntry.getCiteKeyOptional().orElse("");
             BibTeXEntry bibTeXEntry = new BibTeXEntry(new Key(bibEntry.getType()), new Key(citeKey));
@@ -100,6 +96,11 @@ public class CSLAdapter {
             HTMLChars latexToHtmlConverter = new HTMLChars();
             RemoveNewlinesFormatter removeNewlinesFormatter = new RemoveNewlinesFormatter();
             for (String key : bibEntry.getFieldMap().keySet()) {
+                if (FieldName.MONTH.equals(key)) {
+                    // change month field value from "#mon#" to "mon"
+                    bibEntry.getFieldMap().put(FieldName.MONTH, bibEntry.getMonth().get().getShortName());
+                }
+
                 bibEntry.getField(key)
                         .map(removeNewlinesFormatter::format)
                         .map(latexToHtmlConverter::format)

--- a/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -99,7 +99,7 @@ public class CSLAdapter {
                         .map(removeNewlinesFormatter::format)
                         .map(latexToHtmlConverter::format)
                         .ifPresent(value -> {
-                            if((FieldName.MONTH.equals(key))){
+                            if (FieldName.MONTH.equals(key)) {
                                 value = bibEntry.getMonth().get().getShortName();
                             }
                             bibTeXEntry.addField(new Key(key), new DigitStringValue(value));

--- a/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -83,10 +83,13 @@ public class CSLAdapter {
 
         /**
          * Converts the {@link BibEntry} into {@link CSLItemData}.
+         *
+         * Clone bibEntry to make a save changes,
+         * Change month field from JabRefFormat <code>#mon#</> to ShortName <code>mon</code>
+         * because CSL does not support JabRefFormat.
          */
         private static CSLItemData bibEntryToCSLItemData(BibEntry bibEntry) {
 
-            // create a copy of bibEntry
             bibEntry = (BibEntry) bibEntry.clone();
 
             String citeKey = bibEntry.getCiteKeyOptional().orElse("");
@@ -97,7 +100,6 @@ public class CSLAdapter {
             RemoveNewlinesFormatter removeNewlinesFormatter = new RemoveNewlinesFormatter();
             for (String key : bibEntry.getFieldMap().keySet()) {
                 if (FieldName.MONTH.equals(key)) {
-                    // change month field value from "#mon#" to "mon"
                     bibEntry.getFieldMap().put(FieldName.MONTH, bibEntry.getMonth().get().getShortName());
                 }
 

--- a/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -15,6 +15,7 @@ import de.undercouch.citeproc.ItemDataProvider;
 import de.undercouch.citeproc.bibtex.BibTeXConverter;
 import de.undercouch.citeproc.csl.CSLItemData;
 import de.undercouch.citeproc.output.Bibliography;
+import org.jabref.model.entry.FieldName;
 import org.jbibtex.BibTeXEntry;
 import org.jbibtex.DigitStringValue;
 import org.jbibtex.Key;
@@ -84,6 +85,14 @@ public class CSLAdapter {
          * Converts the {@link BibEntry} into {@link CSLItemData}.
          */
         private static CSLItemData bibEntryToCSLItemData(BibEntry bibEntry) {
+
+            // create a copy of bibEntry
+            bibEntry = (BibEntry) bibEntry.clone();
+            // change month field from "#mon#" to "mon"
+            if((bibEntry.getFieldMap().get(FieldName.MONTH) != null) && !bibEntry.getFieldMap().get(FieldName.MONTH).isEmpty()){
+                bibEntry.getFieldMap().put(FieldName.MONTH, bibEntry.getMonth().get().getShortName());
+            }
+
             String citeKey = bibEntry.getCiteKeyOptional().orElse("");
             BibTeXEntry bibTeXEntry = new BibTeXEntry(new Key(bibEntry.getType()), new Key(citeKey));
 

--- a/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -10,6 +10,7 @@ import org.jabref.logic.formatter.bibtexfields.RemoveNewlinesFormatter;
 import org.jabref.logic.layout.format.HTMLChars;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.entry.FieldName;
+import org.jabref.model.entry.Month;
 
 import de.undercouch.citeproc.CSL;
 import de.undercouch.citeproc.ItemDataProvider;
@@ -100,7 +101,7 @@ public class CSLAdapter {
                         .map(latexToHtmlConverter::format)
                         .ifPresent(value -> {
                             if (FieldName.MONTH.equals(key)) {
-                                value = bibEntry.getMonth().get().getShortName();
+                                value = bibEntry.getMonth().map(Month::getShortName).orElse(value);
                             }
                             bibTeXEntry.addField(new Key(key), new DigitStringValue(value));
                         });


### PR DESCRIPTION
Fix issue [#3239](https://github.com/JabRef/jabref/issues/3239) on [maintable-beta](https://github.com/JabRef/jabref/tree/maintable-beta) branch

On month change from comboBox on OptionalFieldsTab, Month was not appear on IEEE style.
The issue get fixed.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
