### PR TITLE
Fix IEEE preview does not display month

### DIFF
--- a/src/main/java/org/jabref/logic/bibtex/LatexFieldFormatter.java
+++ b/src/main/java/org/jabref/logic/bibtex/LatexFieldFormatter.java
@@ -270,8 +270,8 @@ public class LatexFieldFormatter {
 
     private void writeStringLabel(String text, int startPos, int endPos,
                                   boolean first, boolean last) {
-        putIn((first ? "" : " # ") + text.substring(startPos, endPos)
-                + (last ? "" : " # "));
+        putIn((first ? "{" : " # ") + text.substring(startPos, endPos)
+                + (last ? "}" : " # "));
     }
 
     private void putIn(String s) {

--- a/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
+++ b/src/main/java/org/jabref/logic/citationstyle/CSLAdapter.java
@@ -15,6 +15,7 @@ import de.undercouch.citeproc.ItemDataProvider;
 import de.undercouch.citeproc.bibtex.BibTeXConverter;
 import de.undercouch.citeproc.csl.CSLItemData;
 import de.undercouch.citeproc.output.Bibliography;
+import org.jabref.model.entry.FieldName;
 import org.jbibtex.BibTeXEntry;
 import org.jbibtex.DigitStringValue;
 import org.jbibtex.Key;
@@ -84,6 +85,14 @@ public class CSLAdapter {
          * Converts the {@link BibEntry} into {@link CSLItemData}.
          */
         private static CSLItemData bibEntryToCSLItemData(BibEntry bibEntry) {
+
+            // create a copy of bibEntry
+            bibEntry = (BibEntry) bibEntry.clone();
+            // change month field from "#mon#" to "mon"
+            if((bibEntry.getFieldMap().get(FieldName.MONTH) != null) && !bibEntry.getFieldMap().get(FieldName.MONTH).isEmpty()){
+                bibEntry.getFieldMap().put(FieldName.MONTH, bibEntry.getMonth().get().getShortName());
+            }
+
             String citeKey = bibEntry.getCiteKeyOptional().orElse("");
             BibTeXEntry bibTeXEntry = new BibTeXEntry(new Key(bibEntry.getType()), new Key(citeKey));
 


### PR DESCRIPTION
Fix issue [#3239](https://github.com/JabRef/jabref/issues/3239) on [master](https://github.com/JabRef/jabref/tree/master) branch

On month change from comboBox on OptionalFieldsTab:
1. Month was not appear on IEEE style.
2. Month was not written correctly on SourceTab.
both issues get fixed.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
