### PR TITLE
Do not run checkstyle as part of the gradle check task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ env:
   global:
     - GRADLE_OPTS=-Dorg.gradle.daemon=false
   matrix:
-    - TEST_SUITE=checkstyle
     - TEST_SUITE=check OPTIONS=modernizer
+    - TEST_SUITE=checkstyle
     - TEST_SUITE=fetcherTest
     - TEST_SUITE=databaseTest
     - TEST_SUITE=guiTest

--- a/build.gradle
+++ b/build.gradle
@@ -395,10 +395,10 @@ checkstyle {
     // do not use other packages for checkstyle, excluding gen(erated) sources
     checkstyleMain.source = "src/main/java"
     toolVersion = '8.5'
+    
+    // do not perform checkstyle checks by default
+    sourceSets = []
 }
-
-checkstyleMain.shouldRunAfter test
-checkstyleTest.shouldRunAfter test
 
 modernizer {
     // We have more than 20 issues, which are not fixed yet. Nevertheless, we produce the modernizer output.


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

With these changes, the `checkstyle` task is no longer invoked as part of the `build` or `check` task. The `checkstyleMain` task and its variations are kept. 

Reason: The build fails as soon as the checkstyle task fails, possibly hiding more important build or test failures (recent [example](https://travis-ci.org/JabRef/jabref/builds/371621951?utm_source=github_status&utm_medium=notification)). Moreover, the checkstyle task is invoked as a separate build command on travis anyway. 

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
