### PR TITLE
Activate context menu on key press

### DIFF
--- a/src/main/java/org/jabref/gui/util/ViewModelTableRowFactory.java
+++ b/src/main/java/org/jabref/gui/util/ViewModelTableRowFactory.java
@@ -3,11 +3,15 @@ package org.jabref.gui.util;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
+import javafx.geometry.Bounds;
+import javafx.geometry.Point2D;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TreeTableCell;
 import javafx.scene.input.DragEvent;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseDragEvent;
 import javafx.scene.input.MouseEvent;
 import javafx.util.Callback;
@@ -100,6 +104,23 @@ public class ViewModelTableRowFactory<S> implements Callback<TableView<S>, Table
                     row.getContextMenu().show(row, event.getScreenX(), event.getScreenY());
                 }
                 event.consume();
+            });
+
+            // Activate context menu if user presses the "context menu" key
+            tableView.addEventHandler(KeyEvent.KEY_RELEASED, event -> {
+                boolean rowFocused = !row.isEmpty() && tableView.getFocusModel().getFocusedIndex() == row.getIndex();
+                if (event.getCode() == KeyCode.CONTEXT_MENU && rowFocused) {
+                    // Get center of focused cell
+                    Bounds anchorBounds = row.getBoundsInParent();
+                    double x = anchorBounds.getMinX() + anchorBounds.getWidth() / 2;
+                    double y = anchorBounds.getMinY() + anchorBounds.getHeight() / 2;
+                    Point2D screenPosition = row.getParent().localToScreen(x, y);
+
+                    if (row.getContextMenu() == null) {
+                        row.setContextMenu(contextMenuFactory.apply(row.getItem()));
+                    }
+                    row.getContextMenu().show(row, screenPosition.getX(), screenPosition.getY());
+                }
             });
         }
 


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

As wished in the [forum](http://discourse.jabref.org/t/how-to-enable-keyboard-context-key-windows), pressing the "context menu" button on the keyboard should show the context menu.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
