### PR TITLE
Shortittle bibtexkeypattern now also discards small words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ### Changed
 - We added a text file export for 'Find Unlinked Files'. [#3341](https://github.com/JabRef/jabref/issues/3341)
 - We added a fetcher based on RFC-IDs. [#3971](https://github.com/JabRef/jabref/issues/3971)
+- We changed the implementation of the `[shorttitle]` key pattern. It now removes small words like `a`, `an`, `on`, `the` etc. Refer to the help page for a complete overview. [Feature request in the forum](http://discourse.jabref.org/t/jabref-differences-in-shorttitle-between-versions-3-8-1-and-4-not-discounting-the-a-an-of-in-titles/1147)
 
 ### Fixed
 We fixed an issue where the export to clipboard functionality could not be invoked. [#3994](https://github.com/JabRef/jabref/issues/3994)

--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BracketedPattern.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BracketedPattern.java
@@ -294,7 +294,8 @@ public class BracketedPattern {
             } else if ("fulltitle".equals(val)) {
                 return entry.getResolvedFieldOrAlias(FieldName.TITLE, database).orElse("");
             } else if ("shorttitle".equals(val)) {
-                return getTitleWords(3, entry.getResolvedFieldOrAlias(FieldName.TITLE, database).orElse(""));
+                return getTitleWords(3,
+                        removeSmallWords(entry.getResolvedFieldOrAlias(FieldName.TITLE, database).orElse("")));
             } else if ("shorttitleINI".equals(val)) {
                 return keepLettersAndDigitsOnly(
                         applyModifiers(getTitleWordsWithSpaces(3, entry.getResolvedFieldOrAlias(FieldName.TITLE, database).orElse("")),

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGeneratorTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyGeneratorTest.java
@@ -767,23 +767,30 @@ public class BibtexKeyGeneratorTest {
      */
     @Test
     public void shortTitle() {
-        // shortTitle is getTitleWords with "3" as count
+        // shortTitle is getTitleWords with "3" as count and removed small words
         int count = 3;
         assertEquals("application migration effort",
-                BibtexKeyGenerator.getTitleWords(count, TITLE_STRING_ALL_LOWER_FOUR_SMALL_WORDS_ONE_EN_DASH));
-        assertEquals("BPEL conformance in", BibtexKeyGenerator.getTitleWords(count,
-                TITLE_STRING_ALL_LOWER_FIRST_WORD_IN_BRACKETS_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON));
-        assertEquals("Process Viewing Patterns", BibtexKeyGenerator.getTitleWords(count, TITLE_STRING_CASED));
-        assertEquals("BPMN Conformance in",
-                BibtexKeyGenerator.getTitleWords(count, TITLE_STRING_CASED_ONE_UPPER_WORD_ONE_SMALL_WORD));
-        assertEquals("The Difference Between", BibtexKeyGenerator.getTitleWords(count,
-                TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AT_THE_BEGINNING));
-        assertEquals("Cloud Computing: The",
-                BibtexKeyGenerator.getTitleWords(count, TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON));
+                BibtexKeyGenerator.getTitleWords(count,
+                        BibtexKeyGenerator.removeSmallWords(TITLE_STRING_ALL_LOWER_FOUR_SMALL_WORDS_ONE_EN_DASH)));
+        assertEquals("BPEL conformance open",
+                BibtexKeyGenerator.getTitleWords(count,
+                        BibtexKeyGenerator.removeSmallWords(TITLE_STRING_ALL_LOWER_FIRST_WORD_IN_BRACKETS_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON)));
+        assertEquals("Process Viewing Patterns",
+                BibtexKeyGenerator.getTitleWords(count,
+                        BibtexKeyGenerator.removeSmallWords(TITLE_STRING_CASED)));
+        assertEquals("BPMN Conformance Open",
+                BibtexKeyGenerator.getTitleWords(count,
+                        BibtexKeyGenerator.removeSmallWords(TITLE_STRING_CASED_ONE_UPPER_WORD_ONE_SMALL_WORD)));
+        assertEquals("Difference Graph Based",
+                BibtexKeyGenerator.getTitleWords(count,
+                        BibtexKeyGenerator.removeSmallWords(TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AT_THE_BEGINNING)));
+        assertEquals("Cloud Computing: Next",
+                BibtexKeyGenerator.getTitleWords(count,
+                        BibtexKeyGenerator.removeSmallWords(TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON)));
         assertEquals("Towards Choreography based",
-                BibtexKeyGenerator.getTitleWords(count, TITLE_STRING_CASED_TWO_SMALL_WORDS_ONE_CONNECTED_WORD));
-        assertEquals("On the Measurement",
-                BibtexKeyGenerator.getTitleWords(count, TITLE_STRING_CASED_FOUR_SMALL_WORDS_TWO_CONNECTED_WORDS));
+                BibtexKeyGenerator.getTitleWords(count, BibtexKeyGenerator.removeSmallWords(TITLE_STRING_CASED_TWO_SMALL_WORDS_ONE_CONNECTED_WORD)));
+        assertEquals("Measurement Design Time",
+                BibtexKeyGenerator.getTitleWords(count, BibtexKeyGenerator.removeSmallWords(TITLE_STRING_CASED_FOUR_SMALL_WORDS_TWO_CONNECTED_WORDS)));
     }
 
     /**
@@ -935,7 +942,7 @@ public class BibtexKeyGeneratorTest {
         BibEntry entry = new BibEntry();
         entry.setField("title", "Green Scheduling of Whatever");
         assertEquals("GSo", BibtexKeyGenerator.generateKey(entry, "shorttitleINI"));
-        assertEquals("GreenSchedulingof", BibtexKeyGenerator.generateKey(entry, "shorttitle",
+        assertEquals("GreenSchedulingWhatever", BibtexKeyGenerator.generateKey(entry, "shorttitle",
                 new BibDatabase()));
     }
 
@@ -950,7 +957,7 @@ public class BibtexKeyGeneratorTest {
         database.insertEntry(entry1);
         entry2.setField("title", "Green Scheduling of Whatever");
 
-        assertEquals("GreenSchedulingof", BibtexKeyGenerator.generateKey(entry1, "shorttitle",
+        assertEquals("GreenSchedulingWhatever", BibtexKeyGenerator.generateKey(entry1, "shorttitle",
                 database));
     }
 

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/MakeLabelWithDatabaseTest.java
@@ -231,7 +231,7 @@ public class MakeLabelWithDatabaseTest {
     public void generateKeyShorttitle() {
         bibtexKeyPattern.setDefaultValue("[shorttitle]");
         new BibtexKeyGenerator(bibtexKeyPattern, database, preferences).generateAndSetKey(entry);
-        assertEquals(Optional.of("Anawesomepaper"), entry.getCiteKeyOptional());
+        assertEquals(Optional.of("awesomepaperJabRef"), entry.getCiteKeyOptional());
     }
 
     @Test
@@ -239,7 +239,7 @@ public class MakeLabelWithDatabaseTest {
         bibtexKeyPattern.setDefaultValue("[shorttitle:lower]");
         entry.setField("title", "An aweSOme Paper on JabRef");
         new BibtexKeyGenerator(bibtexKeyPattern, database, preferences).generateAndSetKey(entry);
-        assertEquals(Optional.of("anawesomepaper"), entry.getCiteKeyOptional());
+        assertEquals(Optional.of("awesomepaperjabref"), entry.getCiteKeyOptional());
     }
 
     @Test
@@ -247,7 +247,7 @@ public class MakeLabelWithDatabaseTest {
         bibtexKeyPattern.setDefaultValue("[shorttitle:upper]");
         entry.setField("title", "An aweSOme Paper on JabRef");
         new BibtexKeyGenerator(bibtexKeyPattern, database, preferences).generateAndSetKey(entry);
-        assertEquals(Optional.of("ANAWESOMEPAPER"), entry.getCiteKeyOptional());
+        assertEquals(Optional.of("AWESOMEPAPERJABREF"), entry.getCiteKeyOptional());
     }
 
     @Test
@@ -255,7 +255,7 @@ public class MakeLabelWithDatabaseTest {
         bibtexKeyPattern.setDefaultValue("[shorttitle:title_case]");
         entry.setField("title", "An aweSOme Paper on JabRef");
         new BibtexKeyGenerator(bibtexKeyPattern, database, preferences).generateAndSetKey(entry);
-        assertEquals(Optional.of("AnAwesomePaper"), entry.getCiteKeyOptional());
+        assertEquals(Optional.of("AwesomePaperJabref"), entry.getCiteKeyOptional());
     }
 
     @Test
@@ -263,7 +263,7 @@ public class MakeLabelWithDatabaseTest {
         bibtexKeyPattern.setDefaultValue("[shorttitle:sentence_case]");
         entry.setField("title", "An aweSOme Paper on JabRef");
         new BibtexKeyGenerator(bibtexKeyPattern, database, preferences).generateAndSetKey(entry);
-        assertEquals(Optional.of("Anawesomepaper"), entry.getCiteKeyOptional());
+        assertEquals(Optional.of("Awesomepaperjabref"), entry.getCiteKeyOptional());
     }
 
     @Test
@@ -271,7 +271,7 @@ public class MakeLabelWithDatabaseTest {
         bibtexKeyPattern.setDefaultValue("[shorttitle:capitalize]");
         entry.setField("title", "An aweSOme Paper on JabRef");
         new BibtexKeyGenerator(bibtexKeyPattern, database, preferences).generateAndSetKey(entry);
-        assertEquals(Optional.of("AnAwesomePaper"), entry.getCiteKeyOptional());
+        assertEquals(Optional.of("AwesomePaperJabref"), entry.getCiteKeyOptional());
     }
 
     @Test


### PR DESCRIPTION
Feature Request in the forum:
http://discourse.jabref.org/t/jabref-differences-in-shorttitle-between-versions-3-8-1-and-4-not-discounting-the-a-an-of-in-titles/1147

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [x] Change in CHANGELOG.md described
- [x] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [x] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
