### PR TITLE
Remove reflection hack to set WM_CLASS

### DIFF
--- a/src/main/java/org/jabref/gui/GUIGlobals.java
+++ b/src/main/java/org/jabref/gui/GUIGlobals.java
@@ -2,12 +2,10 @@ package org.jabref.gui;
 
 import java.awt.Color;
 import java.awt.Font;
-import java.awt.Toolkit;
 
 import org.jabref.Globals;
 import org.jabref.gui.keyboard.EmacsKeyBindings;
 import org.jabref.logic.l10n.Localization;
-import org.jabref.logic.util.OS;
 import org.jabref.preferences.JabRefPreferences;
 
 import org.slf4j.Logger;
@@ -61,19 +59,6 @@ public class GUIGlobals {
 
         GUIGlobals.currentFont = new Font(Globals.prefs.get(JabRefPreferences.FONT_FAMILY),
                 Globals.prefs.getInt(JabRefPreferences.FONT_STYLE), Globals.prefs.getInt(JabRefPreferences.FONT_SIZE));
-
-        // Set WM_CLASS using reflection for certain Un*x window managers
-        if (!OS.WINDOWS && !OS.OS_X) {
-            try {
-                Toolkit xToolkit = Toolkit.getDefaultToolkit();
-                java.lang.reflect.Field awtAppClassNameField = xToolkit.getClass().getDeclaredField("awtAppClassName");
-                awtAppClassNameField.setAccessible(true);
-                awtAppClassNameField.set(xToolkit, "org-jabref-JabRefMain");
-            } catch (Exception e) {
-                // ignore any error since this code only works for certain toolkits
-            }
-        }
-
     }
 
     public static void setFont(int size) {


### PR DESCRIPTION
The WM_CLASS attribute of X11 is set by JavaFX automatically (https://bugs.openjdk.java.net/browse/JDK-8097949).

This PR is part of #3421 

Tested with OpenJDK 1.8.0_172 and Oracle JDK 1.8.0_162
 
----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
