### PR TITLE
 Use JavaFX-native SVGPath for logo in About dialog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,6 @@ dependencies {
     compile 'com.google.guava:guava:25.0-jre'
 
     // JavaFX stuff
-    compile 'de.codecentric.centerdevice:javafxsvg:1.3.0'
     compile 'de.jensd:fontawesomefx-materialdesignfont:1.7.22-4'
     compile 'de.saxsys:mvvmfx-validation:1.7.0'
     compile 'de.saxsys:mvvmfx:1.7.0'
@@ -314,7 +313,7 @@ test {
     useJUnitPlatform {
         excludeTags 'DatabaseTest', 'FetcherTest', 'GUITest', 'org.jabref.testutils.category.FetcherTest', 'org.jabref.testutils.category.GUITest'
     }
-    
+
     testLogging {
         // set options for log level LIFECYCLE
         events "failed"
@@ -375,7 +374,7 @@ checkstyle {
     // do not use other packages for checkstyle, excluding gen(erated) sources
     checkstyleMain.source = "src/main/java"
     toolVersion = '8.5'
-    
+
     // do not perform checkstyle checks by default
     sourceSets = []
 }

--- a/src/main/java/org/jabref/gui/help/AboutDialog.css
+++ b/src/main/java/org/jabref/gui/help/AboutDialog.css
@@ -44,3 +44,11 @@
 	-fx-max-height: 0;
 	-fx-pref-height: 0;
 }
+
+.logo-pane {
+    fx-fill: transparent;
+}
+
+.logo-pane SVGPath {
+    -fx-fill: #4f5f8f;
+}

--- a/src/main/java/org/jabref/gui/help/AboutDialog.fxml
+++ b/src/main/java/org/jabref/gui/help/AboutDialog.fxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.scene.Cursor?>
 <?import javafx.scene.control.ButtonType?>
 <?import javafx.scene.control.DialogPane?>
 <?import javafx.scene.control.Hyperlink?>
@@ -7,62 +8,74 @@
 <?import javafx.scene.control.ScrollPane?>
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.control.Tooltip?>
-<?import javafx.scene.Cursor?>
 <?import javafx.scene.effect.Reflection?>
-<?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Pane?>
+<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-<DialogPane xmlns:fx="http://javafx.com/fxml/1" prefHeight="600.0" prefWidth="600.0"
-            xmlns="http://javafx.com/javafx/8.0.65" fx:controller="org.jabref.gui.help.AboutDialogView">
+<?import javafx.scene.shape.SVGPath?>
+
+<DialogPane prefHeight="600.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.jabref.gui.help.AboutDialogView">
     <content>
         <VBox alignment="CENTER_LEFT" BorderPane.alignment="CENTER">
             <HBox alignment="CENTER_LEFT">
                 <VBox alignment="CENTER_LEFT" spacing="1.0" styleClass="about-top" HBox.hgrow="NEVER">
-                    <Label alignment="CENTER" contentDisplay="CENTER"
-                           onMouseClicked="#copyVersionToClipboard" styleClass="about-heading"
-                           text="${controller.viewModel.heading}" textFill="#2c3e50"
-                           wrapText="true">
+                    <Label alignment="CENTER" contentDisplay="CENTER" onMouseClicked="#copyVersionToClipboard" styleClass="about-heading" text="${controller.viewModel.heading}" textFill="#2c3e50" wrapText="true">
                         <cursor>
-                            <Cursor fx:constant="HAND"/>
+                            <Cursor fx:constant="HAND" />
                         </cursor>
                         <tooltip>
-                            <Tooltip text="%Copy Version"/>
+                            <Tooltip text="%Copy Version" />
                         </tooltip>
                     </Label>
-                    <Label styleClass="dev-heading" fx:id="devVersionLabel"
-                           visible="${controller.viewModel.isDevelopmentVersion}"
-                           managed="${controller.viewModel.isDevelopmentVersion}"
-                           text="${controller.viewModel.developmentVersion}"/>
-                    <Hyperlink styleClass="top-padding" onAction="#openChangeLog"
-                               text="%What's new in this version?"/>
-                    <Label styleClass="filler"/>
+                    <Label fx:id="devVersionLabel" managed="${controller.viewModel.isDevelopmentVersion}" styleClass="dev-heading" text="${controller.viewModel.developmentVersion}" visible="${controller.viewModel.isDevelopmentVersion}" />
+                    <Hyperlink onAction="#openChangeLog" styleClass="top-padding" text="%What's new in this version?" />
+                    <Label styleClass="filler" />
                     <HBox alignment="CENTER_LEFT">
-                        <Label styleClass="space-after" text="${controller.viewModel.license}"
-                               wrapText="true"/>
-                        <Hyperlink onAction="#openLicense" text="MIT"/>
+                        <Label styleClass="space-after" text="${controller.viewModel.license}" wrapText="true" />
+                        <Hyperlink onAction="#openLicense" text="MIT" />
                     </HBox>
-                    <Hyperlink onAction="#openExternalLibrariesWebsite" text="%Used libraries"/>
+                    <Hyperlink onAction="#openExternalLibrariesWebsite" text="%Used libraries" />
                     <HBox alignment="CENTER_LEFT">
-                        <Label styleClass="space-after" text="%Want to help?" wrapText="true"/>
-                        <Hyperlink onAction="#openDonation" text="%Make a donation"/>
-                        <Label styleClass="space" text="%or" wrapText="true"/>
-                        <Hyperlink onAction="#openGithub" text="%get involved"/>
-                        <Label text="."/>
+                        <Label styleClass="space-after" text="%Want to help?" wrapText="true" />
+                        <Hyperlink onAction="#openDonation" text="%Make a donation" />
+                        <Label styleClass="space" text="%or" wrapText="true" />
+                        <Hyperlink onAction="#openGithub" text="%get involved" />
+                        <Label text="." />
                     </HBox>
                 </VBox>
                 <BorderPane BorderPane.alignment="CENTER" HBox.hgrow="ALWAYS">
                     <center>
-                        <ImageView fx:id="iconImage" fitHeight="140.0" fitWidth="140.0"
-                                   onMouseClicked="#openJabrefWebsite" pickOnBounds="true"
-                                   preserveRatio="true" BorderPane.alignment="CENTER">
+                        <StackPane onMouseClicked="#openJabrefWebsite" scaleX="0.6" scaleY="0.6" prefWidth="140" prefHeight="140" BorderPane.alignment="CENTER">
+                            <!-- SVGPaths need to be wrapped in a Pane to get them to the same size -->
+                            <Pane prefHeight="350" prefWidth="350" styleClass="logo-pane">
+                                <SVGPath content="M97.2 87.1C93.2 33.8 18.4 14.6 18.2 15.6c-0.1 6.7-0.3 13.3-0.4 20 17.8 3.6 61.7 20.1 79.4 51.5" />
+                            </Pane>
+                            <Pane prefHeight="350" prefWidth="350" styleClass="logo-pane">
+                                <SVGPath content="M96.2 61.2C92.8 19.2 35.1 0.4 35 1c0 3.5-0.1 7-0.1 10.6 18.1 7.5 47.7 24.7 61.3 49.6" />
+                            </Pane>
+                            <Pane prefHeight="350" prefWidth="350" styleClass="logo-pane">
+                                <SVGPath content="M67.1 65.2c-25.9-17.6-58.5-22.1-58.6-21.4-0.3 12.4-0.6 24.8-0.9 37.2 37.9 2.2 40.2 25.7 37.9 40.8l-39.1 12.6-1.9 69.5 68.7-26.6c8-3.3 16-6.4 24.1-9.3v-47.9c0-21.4-10.9-41.8-30.1-54.9" />
+                            </Pane>
+
+                            <Pane prefHeight="350" prefWidth="350" styleClass="logo-pane">
+                                <SVGPath content="M107.8 87.1c3.9-53.2 78.8-72.5 78.9-71.5 0.1 6.7 0.3 13.3 0.4 20-17.8 3.6-61.7 20.1-79.4 51.5" />
+                            </Pane>
+                            <Pane prefHeight="350" prefWidth="350" styleClass="logo-pane">
+                                <SVGPath content="M108.8 61.2c3.4-42.1 61.1-60.8 61.2-60.2 0 3.5 0.1 7 0.1 10.6-18.1 7.5-47.7 24.7-61.3 49.6" />
+                            </Pane>
+                            <Pane prefHeight="350" prefWidth="350" styleClass="logo-pane">
+                                <SVGPath content="M137.9 65.2c25.9-17.6 58.5-22.1 58.6-21.4 0.3 12.4 0.6 24.8 0.9 37.2-37.9 2.2-40.2 25.7-37.9 40.8l39.1 12.6 1.9 69.5-68.7-26.6c-8-3.3-16-6.4-24.1-9.3v-47.9c0-21.4 10.9-41.8 30.1-54.9" />
+                            </Pane>
+
                             <cursor>
-                                <Cursor fx:constant="HAND"/>
+                                <Cursor fx:constant="HAND" />
                             </cursor>
                             <effect>
-                                <Reflection fraction="0.15"/>
+                                <Reflection fraction="0.15" />
                             </effect>
-                        </ImageView>
+                        </StackPane>
                     </center>
                     <bottom>
                     </bottom>
@@ -70,22 +83,19 @@
             </HBox>
             <Label styleClass="sub-heading" text="%Developers">
             </Label>
-            <Label alignment="CENTER" styleClass="info-sections" text="${controller.viewModel.developers}"
-                   textAlignment="JUSTIFY" wrapText="true"/>
+            <Label alignment="CENTER" styleClass="info-sections" text="${controller.viewModel.developers}" textAlignment="JUSTIFY" wrapText="true" />
             <Label styleClass="sub-heading" text="%Authors">
             </Label>
             <HBox alignment="CENTER" VBox.vgrow="ALWAYS">
                 <ScrollPane fitToWidth="true">
-                    <Label styleClass="info-sections" text="${controller.viewModel.authors}"
-                           textAlignment="JUSTIFY" wrapText="true" BorderPane.alignment="CENTER"/>
+                    <Label styleClass="info-sections" text="${controller.viewModel.authors}" textAlignment="JUSTIFY" wrapText="true" BorderPane.alignment="CENTER" />
                 </ScrollPane>
             </HBox>
-            <TextArea fx:id="textAreaVersions" styleClass="info-sections" editable="false"
-                      prefHeight="100.0" prefWidth="200.0"/>
+            <TextArea fx:id="textAreaVersions" editable="false" prefHeight="100.0" prefWidth="200.0" styleClass="info-sections" />
         </VBox>
     </content>
     <header>
     </header>
-    <ButtonType fx:id="copyVersionButton" text="%Copy Version"/>
-    <ButtonType fx:constant="CLOSE"/>
+    <ButtonType fx:id="copyVersionButton" text="%Copy Version" />
+    <ButtonType fx:constant="CLOSE" />
 </DialogPane>

--- a/src/main/java/org/jabref/gui/help/AboutDialogView.java
+++ b/src/main/java/org/jabref/gui/help/AboutDialogView.java
@@ -5,8 +5,6 @@ import javax.inject.Inject;
 import javafx.fxml.FXML;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.TextArea;
-import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
 
 import org.jabref.gui.ClipBoardManager;
 import org.jabref.gui.DialogService;
@@ -16,13 +14,11 @@ import org.jabref.logic.l10n.Localization;
 import org.jabref.logic.util.BuildInfo;
 
 import com.airhacks.afterburner.views.ViewLoader;
-import de.codecentric.centerdevice.javafxsvg.SvgImageLoaderFactory;
 
 public class AboutDialogView extends BaseDialog<Void> {
 
     @FXML private ButtonType copyVersionButton;
     @FXML private TextArea textAreaVersions;
-    @FXML private ImageView iconImage;
 
     @Inject private DialogService dialogService;
     @Inject private ClipBoardManager clipBoardManager;
@@ -44,9 +40,6 @@ public class AboutDialogView extends BaseDialog<Void> {
     private void initialize() {
         viewModel = new AboutDialogViewModel(dialogService, clipBoardManager, buildInfo);
 
-        SvgImageLoaderFactory.install();
-        Image icon = new Image(this.getClass().getResourceAsStream("/icons/jabref.svg"));
-        iconImage.setImage(icon);
         textAreaVersions.setText(viewModel.getVersionInfo());
     }
 

--- a/src/main/java/org/jabref/logic/util/io/FileUtil.java
+++ b/src/main/java/org/jabref/logic/util/io/FileUtil.java
@@ -26,7 +26,6 @@ import org.jabref.model.database.BibDatabase;
 import org.jabref.model.entry.BibEntry;
 import org.jabref.model.util.OptionalUtil;
 
-import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +65,7 @@ public class FileUtil {
      * Returns the name part of a file name (i.e., everything in front of last ".").
      */
     public static String getBaseName(String fileNameWithExtension) {
-        return FilenameUtils.getBaseName(fileNameWithExtension);
+        return com.google.common.io.Files.getNameWithoutExtension(fileNameWithExtension);
     }
 
     /**


### PR DESCRIPTION
Instead of requiring an additional library for rendering one SVG image, the JavaFX-native [SVGPath](https://docs.oracle.com/javase/8/javafx/api/javafx/scene/shape/SVGPath.html) should be used.

Removing the dependency `de.codecentric.centerdevice:javafxsvg:1.3.0` also removed the transitive dependency on Apache Commons IO, so its usages had to be removed.

This is part of #3421 

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
