### PR TITLE
Add missing translation for "HTML to Unicode"

### DIFF
--- a/src/main/java/org/jabref/logic/formatter/bibtexfields/HtmlToUnicodeFormatter.java
+++ b/src/main/java/org/jabref/logic/formatter/bibtexfields/HtmlToUnicodeFormatter.java
@@ -12,7 +12,7 @@ public class HtmlToUnicodeFormatter implements LayoutFormatter, Formatter {
 
     @Override
     public String getName() {
-        return "HTML to Unicode";
+        return Localization.lang("HTML to Unicode");
     }
 
     @Override

--- a/src/main/resources/l10n/JabRef_en.properties
+++ b/src/main/resources/l10n/JabRef_en.properties
@@ -1945,6 +1945,7 @@ Changes\ all\ letters\ to\ upper\ case.=Changes all letters to upper case.
 Changes\ the\ first\ letter\ of\ all\ words\ to\ capital\ case\ and\ the\ remaining\ letters\ to\ lower\ case.=Changes the first letter of all words to capital case and the remaining letters to lower case.
 Cleans\ up\ LaTeX\ code.=Cleans up LaTeX code.
 Converts\ HTML\ code\ to\ LaTeX\ code.=Converts HTML code to LaTeX code.
+HTML\ to\ Unicode=HTML to Unicode
 Converts\ HTML\ code\ to\ Unicode.=Converts HTML code to Unicode.
 Converts\ LaTeX\ encoding\ to\ Unicode\ characters.=Converts LaTeX encoding to Unicode characters.
 Converts\ Unicode\ characters\ to\ LaTeX\ encoding.=Converts Unicode characters to LaTeX encoding.


### PR DESCRIPTION
All formatters return a localized `getName`. The only exception is the `HtmlToUnicodeFormatter`. This PR fixes this.