### PR TITLE
A first solution for the cli problem #4038

### DIFF
--- a/src/main/java/org/jabref/JabRefMain.java
+++ b/src/main/java/org/jabref/JabRefMain.java
@@ -108,9 +108,6 @@ public class JabRefMain extends Application {
         PreferencesMigrations.addCrossRefRelatedFieldsForAutoComplete();
         PreferencesMigrations.upgradeObsoleteLookAndFeels();
 
-        // Process arguments
-        ArgumentProcessor argumentProcessor = new ArgumentProcessor(args, ArgumentProcessor.Mode.INITIAL_START);
-
         FallbackExceptionHandler.installExceptionHandler();
 
         ensureCorrectJavaVersion();
@@ -140,6 +137,9 @@ public class JabRefMain extends Application {
         EntryTypes.loadCustomEntryTypes(preferences.loadCustomEntryTypes(BibDatabaseMode.BIBTEX),
                 preferences.loadCustomEntryTypes(BibDatabaseMode.BIBLATEX));
         Globals.exportFactory = Globals.prefs.getExporterFactory(Globals.journalAbbreviationLoader);
+
+        // Process arguments
+        ArgumentProcessor argumentProcessor = new ArgumentProcessor(args, ArgumentProcessor.Mode.INITIAL_START);
 
         // Initialize protected terms loader
         Globals.protectedTermsLoader = new ProtectedTermsLoader(Globals.prefs.getProtectedTermsPreferences());

--- a/src/main/java/org/jabref/cli/JabRefCLI.java
+++ b/src/main/java/org/jabref/cli/JabRefCLI.java
@@ -1,11 +1,8 @@
 package org.jabref.cli;
 
-import java.util.HashMap;
 import java.util.List;
 
 import org.jabref.Globals;
-import org.jabref.logic.exporter.ExporterFactory;
-import org.jabref.logic.exporter.TemplateExporter;
 import org.jabref.logic.l10n.Localization;
 
 import org.apache.commons.cli.CommandLine;
@@ -262,8 +259,7 @@ public class JabRefCLI {
         String importFormats = Globals.IMPORT_FORMAT_READER.getImportFormatList();
         String importFormatsList = String.format("%s:%n%s%n", Localization.lang("Available import formats"), importFormats);
 
-        ExporterFactory exportFactory = ExporterFactory.create(new HashMap<String, TemplateExporter>(), null, null, null);
-        String outFormats = exportFactory.getExportersAsString(70, 20, "");
+        String outFormats = Globals.exportFactory.getExportersAsString(70, 20, "");
         String outFormatsList = String.format("%s: %s%n", Localization.lang("Available export formats"), outFormats);
 
         String footer = '\n' + importFormatsList + outFormatsList + "\nPlease report issues at https://github.com/JabRef/jabref/issues.";

--- a/src/main/java/org/jabref/cli/JabRefCLI.java
+++ b/src/main/java/org/jabref/cli/JabRefCLI.java
@@ -1,8 +1,11 @@
 package org.jabref.cli;
 
+import java.util.HashMap;
 import java.util.List;
 
 import org.jabref.Globals;
+import org.jabref.logic.exporter.ExporterFactory;
+import org.jabref.logic.exporter.TemplateExporter;
 import org.jabref.logic.l10n.Localization;
 
 import org.apache.commons.cli.CommandLine;
@@ -259,7 +262,8 @@ public class JabRefCLI {
         String importFormats = Globals.IMPORT_FORMAT_READER.getImportFormatList();
         String importFormatsList = String.format("%s:%n%s%n", Localization.lang("Available import formats"), importFormats);
 
-        String outFormats = Globals.exportFactory.getExportersAsString(70, 20, "");
+        ExporterFactory exportFactory = ExporterFactory.create(new HashMap<String, TemplateExporter>(), null, null, null);
+        String outFormats = exportFactory.getExportersAsString(70, 20, "");
         String outFormatsList = String.format("%s: %s%n", Localization.lang("Available export formats"), outFormats);
 
         String footer = '\n' + importFormatsList + outFormatsList + "\nPlease report issues at https://github.com/JabRef/jabref/issues.";


### PR DESCRIPTION
ExportFactory is not initialized at this execution point...
The printUsage method is used twice. The JabRefCLI prints the usage, if an error occurs during argument parsing and the ArgumentProcessor prints the usage, when --help option is chosen. 

I made two solutions for this problem:
 - Commit 1: Some sort of a hack to only get the names of the exporters without altering the processing in the main method. 
![image](https://user-images.githubusercontent.com/30231151/40351621-2505b92c-5dad-11e8-9c3c-c780ae48f514.png) 

 - Commit 2: Changed the order of execution in the main method. The argument processor needs the export factory. I don't know, if the processing of the preferences will influence the cli functionality?

Fixes #4038 

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [X] Manually tested changed features in running JabRef
