### PR TITLE
Fix #4041 to make Push to Application work again on OSX.

### DIFF
--- a/src/main/java/org/jabref/gui/push/AbstractPushToApplication.java
+++ b/src/main/java/org/jabref/gui/push/AbstractPushToApplication.java
@@ -71,7 +71,19 @@ public abstract class AbstractPushToApplication implements PushToApplication {
         try {
             if (OS.OS_X) {
                 String[] commands = getCommandLine(keyString);
-                ProcessBuilder processBuilder = new ProcessBuilder("open -a " + commands[0] + " -n --args " + commands[1] + " " + commands[2]);
+                if (commands.length < 3) {
+                    LOGGER.error("Commandline does not contain enough parameters to \"push to application\"");
+                    return;
+                }
+                ProcessBuilder processBuilder = new ProcessBuilder(
+                        "open",
+                        "-a",
+                        commands[0],
+                        "-n",
+                        "--args",
+                        commands[1],
+                        commands[2]
+                );
                 processBuilder.start();
             } else {
                 ProcessBuilder processBuilder = new ProcessBuilder(getCommandLine(keyString));


### PR DESCRIPTION
For unknown reasons, it seems no longer possible to give the command
as one single string. I created a test class and not even simple commands
can be executed. I'm not sure when this changed but giving the command
as a list of arguments works as expected.

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [x] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [x] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
