### PR TITLE
Groups right click

### DIFF
--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -28,6 +28,8 @@ import javafx.scene.control.TreeTableView;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.input.DragEvent;
 import javafx.scene.input.Dragboard;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.input.TransferMode;
 import javafx.scene.layout.StackPane;
 import javafx.scene.text.Text;
@@ -178,6 +180,12 @@ public class GroupTreeView {
                     EasyBind.monadic(row.itemProperty())
                             .map(this::createContextMenuForGroup)
                             .orElse((ContextMenu) null));
+            row.addEventFilter(MouseEvent.MOUSE_PRESSED, event -> {
+                if (event.getButton() == MouseButton.SECONDARY) {
+                    // Prevent right-click to select group
+                    event.consume();
+                }
+            });
 
             // Drag and drop support
             row.setOnDragDetected(event -> {

--- a/src/main/java/org/jabref/gui/groups/GroupTreeView.java
+++ b/src/main/java/org/jabref/gui/groups/GroupTreeView.java
@@ -150,7 +150,10 @@ public class GroupTreeView {
                     disclosureNode.getChildren().add(disclosureNodeArrow);
                     return disclosureNode;
                 })
-                .withOnMouseClickedEvent(group -> event -> group.toggleExpansion()));
+                .withOnMouseClickedEvent(group -> event -> {
+                    group.toggleExpansion();
+                    event.consume();
+                }));
 
         // Set pseudo-classes to indicate if row is root or sub-item ( > 1 deep)
         PseudoClass rootPseudoClass = PseudoClass.getPseudoClass("root");


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

(Partly) fixes https://github.com/JabRef/jabref/issues/4025. Right-click on a group no longer focuses that group. It's not perfect since there is no longer feedback on which group the user clicked and the context menu belongs to.  

Clicking the disclosure node (the small arrow) still leads to an immediate selection of the group. The selection happens before any events are triggered on the row and thus I'm not able to intercept the selection.

----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
