### PR TITLE
Fix JabRef leaks open threads after exit

### DIFF
--- a/src/main/java/org/jabref/JabRefMain.java
+++ b/src/main/java/org/jabref/JabRefMain.java
@@ -150,8 +150,10 @@ public class JabRefMain extends Application {
 
     private static void shutdownCurrentInstance() {
         Globals.shutdownThreadPools();
+        Globals.REMOTE_LISTENER.stop();
         // needed to tell JavaFx to stop
         Platform.exit();
+        System.exit(0);
     }
 
     private static void applyPreferences(JabRefPreferences preferences) {
@@ -185,5 +187,14 @@ public class JabRefMain extends Application {
         if (proxyPreferences.isUseProxy() && proxyPreferences.isUseAuthentication()) {
             Authenticator.setDefault(new ProxyAuthenticator());
         }
+    }
+
+    @Override
+    public void stop() {
+        Globals.shutdownThreadPools();
+        Globals.stopBackgroundTasks();
+        Globals.REMOTE_LISTENER.stop();
+        Platform.exit();
+        System.exit(0);
     }
 }


### PR DESCRIPTION
I noticed that whenver I run JabRef in Eclipse that after the exit of JabRef still some threads were open and not stopping. I have no idea why and where they are coming from. 

<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
