### PR TITLE
Add gradle task downloadDependencies and use it at CircleCI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -486,3 +486,19 @@ jmh {
     iterations = 10
     fork = 2
 }
+
+// Source: https://stackoverflow.com/a/44168582/873282
+task downloadDependencies {
+  description "Pre-downloads *most* dependencies"
+  doLast {
+    configurations.getAsMap().each { name, config ->
+      println "Retrieving dependencies for $name"
+      try {
+        config.files
+      } catch (e) {
+        // some cannot be resolved, just log them
+        project.logger.info e.message
+      }
+    }
+  }
+}

--- a/circle.yml
+++ b/circle.yml
@@ -13,19 +13,14 @@ dependencies:
     - install4j7/bin/install4jc --verbose --license=$INSTALL4J_KEY 
     #--win-keystore-password $CERTIFICATE_PW --mac-keystore-password $CERTIFICATE_PW
   override:
-    # We do this to decrease build time by using CircleCI's cache. See https://discuss.circleci.com/t/effective-caching-for-gradle/540 for a longer motivation.
-    - ./gradlew compileJava
+    - ./gradlew downloadDependencies
   cache_directories:
     - "~/.install4j7"
     - "~/downloads"
 
 test:
   override:
-    - ./gradlew -Pdev=true -Pinstall4jDir="install4j7" release --stacktrace
-  post:
-    # save test reports as build artifacts
-    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
-    - find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+    - "true"
 
 deployment:
   release:
@@ -34,17 +29,18 @@ deployment:
    commands:
       # we have to do a clean build as changing gradle's "project.version" does not lead to a rebuild of resources (mirroring project.version)
       - ./gradlew -Pinstall4jDir="install4j7" clean release --stacktrace
-      # upload at all circumstances
-      - scripts/upload-to-builds.jabref.org.sh
+      # if upload fails, it is accepted; CircleCI provides deep links to the binaries as fallback.
+      - timeout 580 scripts/upload-to-builds.jabref.org.sh || exit 0
+      # generate dependency information. This is not published on our buid server, but can be collected as logged in user at CircleCI
       - ./gradlew dependencyUpdates -Drevision=release -DoutputFormatter=json -DoutputDir=build/releases
   development:
      # match all branches; this is executed, if "release" is not matched - see https://circleci.com/docs/configuration/
     branch: /.*/
     commands:
+      # generate binaries
+      - ./gradlew -Pdev=true -Pinstall4jDir="install4j7" release --stacktrace
       # if upload fails, it is accepted; CircleCI provides deep links to the binaries as fallback
       - timeout 580 scripts/upload-to-builds.jabref.org.sh || exit 0
-
-
 
 general:
   artifacts:


### PR DESCRIPTION
I discovered a gradle task fetching all dependencies without building. I added that and adapted the CircleCI script accordingly.

I also made some cleanups, which should ease the migration from CircleCI 1.0 to CircleCi 2.0.