### PR TITLE
Set minimum java to 171

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 ## [Unreleased]
 
 ### Changed
+- We changed the minimum required version of Java to 1.8.0_171, as this is the latest release for which the automatic Java update works.  [4093](https://github.com/JabRef/jabref/issues/4093)
 - The special fields like `Printed` and `Read status` now show gray icons when the row is hovered.
 - We added a button in the tab header which allows you to close the database with one click. https://github.com/JabRef/jabref/issues/494
 - Sorting in the main table now takes information from cross-referenced entries into account. https://github.com/JabRef/jabref/issues/2808

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ targetCompatibility = 1.8
 mainClassName = "org.jabref.JabRefMain"
 
 // These are the Java version requirements we will check on each start of JabRef
-ext.minRequiredJavaVersion = "1.8.0_172"
+ext.minRequiredJavaVersion = "1.8.0_171"
 ext.allowJava9 = false
 
 sourceSets {


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

Fixes #4093. Since Java does not automatically update to 171, users have to manually install the 172 update. This is very convenient. 

I actually propose to cherry-pick this PR to 4.x and immediately release 4.3.1.

----

- [x] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
