### PR TITLE
The textarea in the PersonsEditor is focused when the field is focused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the groups tree of the last database was still shown even after the database was already closed.
 - We fixed an issue where the "Open file dialog" may disappear behind other windows. https://github.com/JabRef/jabref/issues/3410
 - We fixed an issue where the default icon of a group was not colored correctly.
-- We fixed an issue where the first field in entry editor was not focused when adding a new entry.
+- We fixed an issue where the first field in entry editor was not focused when adding a new entry. [#4024](https://github.com/JabRef/jabref/issues/4024)
 - We reworked the "Edit file" dialog to make it resizeable and improved the workflow for adding and editing files https://github.com/JabRef/jabref/issues/2970
 - We fixed an issue where the month was not shown in the preview https://github.com/JabRef/jabref/issues/3239.
 - Rewritten logic to detect a second jabref instance. [#4023](https://github.com/JabRef/jabref/issues/4023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the groups tree of the last database was still shown even after the database was already closed.
 - We fixed an issue where the "Open file dialog" may disappear behind other windows. https://github.com/JabRef/jabref/issues/3410
 - We fixed an issue where the default icon of a group was not colored correctly.
+- We fixed an issue where the first field in entry editor was not focused when adding a new entry.
 - We reworked the "Edit file" dialog to make it resizeable and improved the workflow for adding and editing files https://github.com/JabRef/jabref/issues/2970
 - We fixed an issue where the month was not shown in the preview https://github.com/JabRef/jabref/issues/3239.
 - Rewritten logic to detect a second jabref instance. [#4023](https://github.com/JabRef/jabref/issues/4023)

--- a/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
+++ b/src/main/java/org/jabref/gui/entryeditor/FieldsEditorTab.java
@@ -80,6 +80,7 @@ abstract class FieldsEditorTab extends EntryEditorTab {
         fields = determineFieldsToShow(entry, entryType);
 
         List<Label> labels = new ArrayList<>();
+        boolean isFirstField = true;
         for (String fieldName : fields) {
             FieldEditorFX fieldEditor = FieldEditors.getForField(fieldName, Globals.TASK_EXECUTOR, dialogService,
                     Globals.journalAbbreviationLoader, Globals.prefs.getJournalAbbreviationPreferences(), Globals.prefs,
@@ -88,12 +89,10 @@ abstract class FieldsEditorTab extends EntryEditorTab {
             fieldEditor.bindToEntry(entry);
 
             editors.put(fieldName, fieldEditor);
-            /*
-            // TODO: Reenable this
-            if (i == 0) {
+            if (isFirstField) {
                 activeField = fieldEditor;
+                isFirstField = false;
             }
-            */
 
             labels.add(new FieldNameLabel(fieldName));
         }

--- a/src/main/java/org/jabref/gui/fieldeditors/PersonsEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/PersonsEditor.java
@@ -16,10 +16,12 @@ public class PersonsEditor extends HBox implements FieldEditorFX {
 
     @FXML private final PersonsEditorViewModel viewModel;
 
+    private EditorTextArea textArea;
+
     public PersonsEditor(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, JabRefPreferences preferences, FieldCheckers fieldCheckers) {
         this.viewModel = new PersonsEditorViewModel(fieldName, suggestionProvider, preferences.getAutoCompletePreferences(), fieldCheckers);
 
-        EditorTextArea textArea = new EditorTextArea();
+        textArea = new EditorTextArea();
         HBox.setHgrow(textArea, Priority.ALWAYS);
         textArea.textProperty().bindBidirectional(viewModel.textProperty());
         textArea.addToContextMenu(EditorMenus.getNameMenu(textArea));
@@ -39,4 +41,10 @@ public class PersonsEditor extends HBox implements FieldEditorFX {
     public Parent getNode() {
         return this;
     }
+
+    @Override
+    public void requestFocus() {
+        textArea.requestFocus();
+    }
+
 }


### PR DESCRIPTION
The first field of the FieldsEditorTab.java is selected on creating for focus, and the textarea inside the PersonsEditor is focused when the field is focused.

fixes [#4024](https://github.com/JabRef/jabref/issues/4024)

----

- [X] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [X] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [X] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
