### PR TITLE
 Fix #4033: order of fields in customized entry types is saved correctly 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ We refer to [GitHub issues](https://github.com/JabRef/jabref/issues) by using `#
 - We fixed an issue where the custom file column were sorted incorrectly. https://github.com/JabRef/jabref/issues/3119
 - We fixed an issues where the entry losses focus when a field is edited and at the same time used for sorting. https://github.com/JabRef/jabref/issues/3373
 - We fixed an issue where the menu on Mac OS was not displayed in the usual Mac-specific way. https://github.com/JabRef/jabref/issues/3146
+- We fixed an issue where the order of fields in customized entry types was not saved correctly. [#4033](http://github.com/JabRef/jabref/issues/4033)
 - We fixed an issue where the groups tree of the last database was still shown even after the database was already closed.
 - We fixed an issue where the "Open file dialog" may disappear behind other windows. https://github.com/JabRef/jabref/issues/3410
 - We fixed an issue where the default icon of a group was not colored correctly.

--- a/src/main/java/org/jabref/gui/actions/CustomizeEntryAction.java
+++ b/src/main/java/org/jabref/gui/actions/CustomizeEntryAction.java
@@ -3,7 +3,7 @@ package org.jabref.gui.actions;
 import javax.swing.JDialog;
 
 import org.jabref.gui.JabRefFrame;
-import org.jabref.gui.customentrytypes.EntryCustomizationDialog;
+import org.jabref.gui.customentrytypes.EntryTypeCustomizationDialog;
 
 public class CustomizeEntryAction extends SimpleCommand {
 
@@ -12,10 +12,10 @@ public class CustomizeEntryAction extends SimpleCommand {
     public CustomizeEntryAction(JabRefFrame frame) {
         this.frame = frame;
     }
-    
+
     @Override
     public void execute() {
-        JDialog dialog = new EntryCustomizationDialog(frame);
+        JDialog dialog = new EntryTypeCustomizationDialog(frame);
         dialog.setVisible(true);
     }
 }

--- a/src/main/java/org/jabref/gui/customentrytypes/EntryTypeCustomizationDialog.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/EntryTypeCustomizationDialog.java
@@ -8,6 +8,7 @@ import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -276,11 +277,13 @@ public class EntryTypeCustomizationDialog extends JabRefDialog implements ListSe
                 if (biblatexMode) {
                     Set<String> oldPrimaryOptionalFieldsLists = oldType.get().getPrimaryOptionalFields();
                     Set<String> oldSecondaryOptionalFieldsList = oldType.get().getSecondaryOptionalFields();
-                    if (oldRequiredFieldsList.equals(requiredFieldsList) && oldPrimaryOptionalFieldsLists.equals(optionalFieldsList) &&
-                            oldSecondaryOptionalFieldsList.equals(secondaryOptionalFieldsLists)) {
+                    if (Arrays.equals(oldRequiredFieldsList.toArray(), requiredFieldsList.toArray())
+                            && Arrays.equals(oldPrimaryOptionalFieldsLists.toArray(), optionalFieldsList.toArray())
+                            && Arrays.equals(oldSecondaryOptionalFieldsList.toArray(), secondaryOptionalFieldsLists.toArray())) {
                         changesMade = false;
                     }
-                } else if (oldRequiredFieldsList.equals(requiredFieldsList) && oldOptionalFieldsList.equals(optionalFieldsList)) {
+                } else if (Arrays.equals(oldRequiredFieldsList.toArray(), requiredFieldsList.toArray())
+                        && Arrays.equals(oldOptionalFieldsList.toArray(), optionalFieldsList.toArray())) {
                     changesMade = false;
                 }
             }

--- a/src/main/java/org/jabref/gui/customentrytypes/EntryTypeCustomizationDialog.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/EntryTypeCustomizationDialog.java
@@ -49,7 +49,7 @@ import org.jabref.model.strings.StringUtil;
 
 import com.jgoodies.forms.builder.ButtonBarBuilder;
 
-public class EntryCustomizationDialog extends JabRefDialog implements ListSelectionListener {
+public class EntryTypeCustomizationDialog extends JabRefDialog implements ListSelectionListener {
 
     protected GridBagLayout gbl = new GridBagLayout();
     protected GridBagConstraints con = new GridBagConstraints();
@@ -71,10 +71,10 @@ public class EntryCustomizationDialog extends JabRefDialog implements ListSelect
     private BibDatabaseMode bibDatabaseMode;
 
     /**
-     * Creates a new instance of EntryCustomizationDialog
+     * Creates a new instance of EntryTypeCustomizationDialog
      */
-    public EntryCustomizationDialog(JabRefFrame frame) {
-        super((JFrame) null, Localization.lang("Customize entry types"), false, EntryCustomizationDialog.class);
+    public EntryTypeCustomizationDialog(JabRefFrame frame) {
+        super((JFrame) null, Localization.lang("Customize entry types"), false, EntryTypeCustomizationDialog.class);
 
         this.frame = frame;
         initGui();

--- a/src/main/java/org/jabref/gui/customentrytypes/EntryTypeList.java
+++ b/src/main/java/org/jabref/gui/customentrytypes/EntryTypeList.java
@@ -22,7 +22,7 @@ import org.jabref.preferences.JabRefPreferences;
 
 /**
  * This class extends FieldSetComponent to provide some required functionality for the
- * list of entry types in EntryCustomizationDialog.
+ * list of entry types in EntryTypeCustomizationDialog.
  */
 public class EntryTypeList extends FieldSetComponent implements ListSelectionListener {
 


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
