### PR TITLE
add exception for junit-pioneer in version rejection of snapshots

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,13 +188,18 @@ dependencyUpdates.revision = 'integration'
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->
         rules.all { ComponentSelection selection ->
-            if ( selection.candidate.module != "junit-pioneer" && selection.candidate.version ==~ /[0-9].*SNAPSHOT/ ) {
+            if ( selection.candidate.module != "junit-pioneer" && selection.candidate.module!="javax.inject"  && selection.candidate.version ==~ /[0-9].*SNAPSHOT/ ) {
                 selection.reject("Ignore SNAPSHOT releases")
             }
         }
         rules.withModule("org.controlsfx:controlsfx") { ComponentSelection selection ->
             if (selection.candidate.version ==~ /9.*/) { // Reject version 9 or higher
                  selection.reject("Cannot be updated to 9.*.* until Jabref works with Java 9")
+            }
+        }
+		rules.withModule("com.github.tomtung:latex2unicode_2.12") { ComponentSelection selection ->
+            if (selection.candidate.version ==~ /0.2.2/) { // Reject version higher than 2.0.2
+                 selection.reject("Cannot be updated to 0.2.4 until JabRef is prepared for it")
             }
         }
         rules.withModule("de.jensd:fontawesomefx-materialdesignfont") { ComponentSelection selection ->
@@ -207,6 +212,7 @@ dependencyUpdates.resolutionStrategy = {
                 selection.reject("http://dev.mysql.com/downloads/connector/j/ lists the version 5.* as last stable version.")
             }
         }
+		
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -188,7 +188,7 @@ dependencyUpdates.revision = 'integration'
 dependencyUpdates.resolutionStrategy = {
     componentSelection { rules ->
         rules.all { ComponentSelection selection ->
-            if (selection.candidate.version ==~ /[0-9].*SNAPSHOT/) {
+            if ( selection.candidate.module != "junit-pioneer" && selection.candidate.version ==~ /[0-9].*SNAPSHOT/ ) {
                 selection.reject("Ignore SNAPSHOT releases")
             }
         }


### PR DESCRIPTION
I now added an exception for junit-pioneer  version checker. All other snapshots are rejected.


<!-- describe the changes you have made here: what, why, ... 
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333) or [koppor#49](https://github.com/koppor/jabref/issues/47).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->


----

- [ ] Change in CHANGELOG.md described
- [ ] Tests created for changes
- [ ] Manually tested changed features in running JabRef
- [ ] Screenshots added in PR description (for bigger UI changes)
- [ ] Ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
