### PR TITLE
single line text fields

### DIFF
--- a/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/EditorTextArea.java
@@ -8,6 +8,7 @@ import java.util.function.Supplier;
 import javafx.fxml.Initializable;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.TextFormatter;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 
@@ -16,10 +17,14 @@ import com.sun.javafx.scene.control.skin.TextAreaSkin;
 public class EditorTextArea extends javafx.scene.control.TextArea implements Initializable {
 
     public EditorTextArea() {
-        this("");
+        this("", false);
     }
 
-    public EditorTextArea(String text) {
+    public EditorTextArea(final boolean hasSingleLine) {
+        this("", hasSingleLine);
+    }
+
+    public EditorTextArea(final String text, final boolean hasSingleLine) {
         super(text);
 
         setMinHeight(1);
@@ -46,6 +51,19 @@ public class EditorTextArea extends javafx.scene.control.TextArea implements Ini
                 }
                 event.consume();
             }
+        });
+
+        if (hasSingleLine) {
+            setTextFormatter(createSingleLineTextFormatter());
+        }
+    }
+
+    private static <T> TextFormatter<T> createSingleLineTextFormatter() {
+        return new TextFormatter<>(change -> {
+            if (change.isAdded()) {
+                change.setText(change.getText().replaceAll("\\s+", " "));
+            }
+            return change;
         });
     }
 

--- a/src/main/java/org/jabref/gui/fieldeditors/FieldEditors.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/FieldEditors.java
@@ -30,7 +30,8 @@ public class FieldEditors {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FieldEditors.class);
 
-    private static final ImmutableSet<String> SINGLE_LINE_FIELDS = ImmutableSet.of("title", "author", "year");
+    private static final ImmutableSet<String> SINGLE_LINE_FIELDS = ImmutableSet.of(
+            "title", "author", "year", "institution");
 
     public static FieldEditorFX getForField(final String fieldName,
                                             final TaskExecutor taskExecutor,

--- a/src/main/java/org/jabref/gui/fieldeditors/PersonsEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/PersonsEditor.java
@@ -18,10 +18,14 @@ public class PersonsEditor extends HBox implements FieldEditorFX {
 
     private EditorTextArea textArea;
 
-    public PersonsEditor(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, JabRefPreferences preferences, FieldCheckers fieldCheckers) {
+    public PersonsEditor(final String fieldName,
+                         final AutoCompleteSuggestionProvider<?> suggestionProvider,
+                         final JabRefPreferences preferences,
+                         final FieldCheckers fieldCheckers,
+                         final boolean hasSingleLine) {
         this.viewModel = new PersonsEditorViewModel(fieldName, suggestionProvider, preferences.getAutoCompletePreferences(), fieldCheckers);
 
-        textArea = new EditorTextArea();
+        textArea = new EditorTextArea(hasSingleLine);
         HBox.setHgrow(textArea, Priority.ALWAYS);
         textArea.textProperty().bindBidirectional(viewModel.textProperty());
         textArea.addToContextMenu(EditorMenus.getNameMenu(textArea));

--- a/src/main/java/org/jabref/gui/fieldeditors/SimpleEditor.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/SimpleEditor.java
@@ -17,10 +17,14 @@ public class SimpleEditor extends HBox implements FieldEditorFX {
 
     @FXML private final SimpleEditorViewModel viewModel;
 
-    public SimpleEditor(String fieldName, AutoCompleteSuggestionProvider<?> suggestionProvider, FieldCheckers fieldCheckers, JabRefPreferences preferences) {
+    public SimpleEditor(final String fieldName,
+                        final AutoCompleteSuggestionProvider<?> suggestionProvider,
+                        final FieldCheckers fieldCheckers,
+                        final JabRefPreferences preferences,
+                        final boolean hasSingleLine) {
         this.viewModel = new SimpleEditorViewModel(fieldName, suggestionProvider, fieldCheckers);
 
-        EditorTextArea textArea = new EditorTextArea();
+        EditorTextArea textArea = new EditorTextArea(hasSingleLine);
         HBox.setHgrow(textArea, Priority.ALWAYS);
         textArea.textProperty().bindBidirectional(viewModel.textProperty());
         textArea.addToContextMenu(EditorMenus.getDefaultMenu(textArea));
@@ -33,6 +37,14 @@ public class SimpleEditor extends HBox implements FieldEditorFX {
         }
 
         new EditorValidator(preferences).configureValidation(viewModel.getFieldValidator().getValidationStatus(), textArea);
+    }
+
+
+    public SimpleEditor(final String fieldName,
+                        final AutoCompleteSuggestionProvider<?> suggestionProvider,
+                        final FieldCheckers fieldCheckers,
+                        final JabRefPreferences preferences) {
+        this(fieldName, suggestionProvider, fieldCheckers, preferences, false);
     }
 
     @Override


### PR DESCRIPTION
Solution for [#4126](https://github.com/JabRef/jabref/issues/4126). I've used text formatter to force single line behavior. Hope it's enough :) Particular fields, that should contain only one line, are stored in immutable set.